### PR TITLE
fix: max tokens overflow from the models' actual upper limits.

### DIFF
--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -159,6 +159,8 @@ func (s *Server) ChatCompletions(c *gin.Context) {
 	}
 
 	actualModel := selectedService.Model
+	maxAllowed := s.templateManager.GetMaxTokensForModel(provider.Name, actualModel)
+
 	// FIXME: response as proxy / request
 	responseModel := proxyModel
 	req.Model = actualModel
@@ -184,7 +186,7 @@ func (s *Server) ChatCompletions(c *gin.Context) {
 			return
 		}
 
-		anthropicReq := adaptor.ConvertOpenAIToAnthropicRequest(&req, int64(s.config.GetDefaultMaxTokens()))
+		anthropicReq := adaptor.ConvertOpenAIToAnthropicRequest(&req, int64(maxAllowed))
 
 		// 🔥 REQUIRED: forward tool_choice
 		if req.ToolChoice.OfAuto.Value != "" || req.ToolChoice.OfAllowedTools != nil || req.ToolChoice.OfFunctionToolChoice != nil || req.ToolChoice.OfCustomToolChoice != nil {


### PR DESCRIPTION
The error is caused by bug of our max_token logic, which missed the upper limit checking
> 
<img width="1844" height="81" alt="image" src="https://github.com/user-attachments/assets/a038258b-8f4e-40b4-94ba-33e2151748ed" />
