### PR TITLE
swagger: bugfix - missing groups with same prefix; feat - support default tag.

### DIFF
--- a/pkg/swagger/router.go
+++ b/pkg/swagger/router.go
@@ -51,7 +51,7 @@ type RouteGroupOption func(*RouteGroup)
 // RouteManager manages all route groups and swagger generation
 type RouteManager struct {
 	engine      *gin.Engine
-	groups      map[string]*RouteGroup
+	groups      []*RouteGroup
 	globalMW    []gin.HandlerFunc
 	swaggerInfo *SwaggerInfo
 }
@@ -60,7 +60,7 @@ type RouteManager struct {
 func NewRouteManager(engine *gin.Engine) *RouteManager {
 	return &RouteManager{
 		engine: engine,
-		groups: make(map[string]*RouteGroup),
+		groups: make([]*RouteGroup, 0),
 		swaggerInfo: &SwaggerInfo{
 			Title:       "API Documentation",
 			Description: "Generated API documentation",
@@ -108,7 +108,7 @@ func (rm *RouteManager) NewGroup(name, version, prefix string, opts ...RouteGrou
 		opt(group)
 	}
 
-	rm.groups[fullPrefix] = group
+	rm.groups = append(rm.groups, group)
 	return group
 }
 
@@ -309,7 +309,7 @@ func (rg *RouteGroup) authMiddleware() gin.HandlerFunc {
 }
 
 // GetRouteGroups returns all registered route groups
-func (rm *RouteManager) GetRouteGroups() map[string]*RouteGroup {
+func (rm *RouteManager) GetRouteGroups() []*RouteGroup {
 	return rm.groups
 }
 


### PR DESCRIPTION
- bugfix: missing groups with same prefix (now we replace map to array for groups)
- feat: support set default tag for route
- feat: support get engine in swagger wrapper