### PR TITLE
minor: add a model list for providers.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import System from './pages/System';
 import UseOpenAIPage from './pages/UseOpenAIPage';
 import UseAnthropicPage from './pages/UseAnthropicPage';
 import UseClaudeCodePage from './pages/UseClaudeCodePage';
+import ModelTestPage from './pages/ModelTestPage';
 import theme from './theme';
 
 function App() {
@@ -39,6 +40,7 @@ function App() {
                                             <Route path="/api-keys" element={<ApiKeyPage />} />
                                             <Route path="/oauth" element={<OAuthPage />} />
                                             <Route path="/system" element={<System />} />
+                                            <Route path="/model-test/:providerUuid" element={<ModelTestPage />} />
                                         </Routes>
                                     </Layout>
                                 </ProtectedRoute>

--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -1,4 +1,4 @@
-import { Cancel, CheckCircle, ContentCopy, Delete, Edit, Visibility } from '@mui/icons-material';
+import { Cancel, CheckCircle, ContentCopy, Delete, Edit, ListAlt, Visibility } from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -21,6 +21,7 @@ import { useState } from 'react';
 import api from '../services/api';
 import type { Provider } from '../types/provider';
 import { ApiStyleBadge } from '@/components/ApiStyleBadge.tsx';
+import ModelListDialog from '@/components/ModelListDialog';
 
 interface ApiKeyTableProps {
     providers: Provider[];
@@ -42,6 +43,11 @@ interface DeleteModalState {
     providerName: string;
 }
 
+interface ModelListDialogState {
+    open: boolean;
+    provider: Provider | null;
+}
+
 const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete }: ApiKeyTableProps) => {
     const [tokenModal, setTokenModal] = useState<TokenModalState>({
         open: false,
@@ -53,6 +59,10 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete }: ApiKeyTableProps
         open: false,
         providerUuid: '',
         providerName: '',
+    });
+    const [modelListDialog, setModelListDialog] = useState<ModelListDialogState>({
+        open: false,
+        provider: null,
     });
 
     const fetchFullToken = async (providerUuid: string): Promise<string> => {
@@ -130,6 +140,17 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete }: ApiKeyTableProps
         return `${prefix}${'*'.repeat(4)}${suffix}`;
     };
 
+    const handleModelListClick = (providerUuid: string) => {
+        const provider = providers.find((p) => p.uuid === providerUuid);
+        if (provider) {
+            setModelListDialog({ open: true, provider });
+        }
+    };
+
+    const handleCloseModelListDialog = () => {
+        setModelListDialog({ open: false, provider: null });
+    };
+
     return (
         <TableContainer component={Paper} elevation={0} sx={{ border: 1, borderColor: 'divider' }}>
             <Table>
@@ -140,6 +161,7 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete }: ApiKeyTableProps
                         <TableCell sx={{ fontWeight: 600, minWidth: 200 }}>API Base</TableCell>
                         <TableCell sx={{ fontWeight: 600, minWidth: 120 }}>API Style</TableCell>
                         <TableCell sx={{ fontWeight: 600, minWidth: 120 }}>Actions</TableCell>
+                        <TableCell sx={{ fontWeight: 600, minWidth: 120 }}>Model List</TableCell>
                         <TableCell sx={{ fontWeight: 600, minWidth: 120 }}>Status</TableCell>
                     </TableRow>
                 </TableHead>
@@ -205,6 +227,22 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete }: ApiKeyTableProps
                                         </Tooltip>
                                     )}
                                 </Stack>
+                            </TableCell>
+                            <TableCell>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    startIcon={<ListAlt />}
+                                    onClick={() => handleModelListClick(provider.uuid)}
+                                    disabled={!provider.enabled}
+                                    sx={{
+                                        textTransform: 'none',
+                                        borderRadius: 1.5,
+                                        fontSize: '0.8rem',
+                                    }}
+                                >
+                                    Models
+                                </Button>
                             </TableCell>
                             <TableCell>
                                 <Stack direction="row" alignItems="center" spacing={1}>
@@ -326,6 +364,13 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete }: ApiKeyTableProps
                     </Stack>
                 </Box>
             </Modal>
+
+            {/* Model List Dialog */}
+            <ModelListDialog
+                open={modelListDialog.open}
+                onClose={handleCloseModelListDialog}
+                provider={modelListDialog.provider}
+            />
         </TableContainer>
     );
 };

--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -120,6 +120,14 @@ func (s *Server) HandleProbeModel(c *gin.Context) {
 
 	startTime := time.Now()
 
+	// Generate curl command for this provider/model
+	curlCommand := GenerateCurlCommand(
+		provider.APIBase,
+		string(provider.APIStyle),
+		provider.Token,
+		model,
+	)
+
 	// Create the mock request data that would be sent to the API
 	mockRequest := NewMockRequest(provider.Name, req.Model)
 
@@ -154,15 +162,10 @@ func (s *Server) HandleProbeModel(c *gin.Context) {
 			Success: false,
 			Error:   &errorResp,
 			Data: &ProbeResponseData{
-				Request: mockRequest,
-				Response: ProbeResponseDetail{
-					Content:      "",
-					Model:        model,
-					Provider:     provider.Name,
-					FinishReason: "error",
-					Error:        errorMessage,
-				},
-				Usage: ProbeUsage{},
+				Request:     mockRequest,
+				Response:    ProbeResponseDetail{Content: "", Model: model, Provider: provider.Name, FinishReason: "error", Error: errorMessage},
+				Usage:       ProbeUsage{},
+				CurlCommand: curlCommand,
 			},
 		})
 		return
@@ -177,12 +180,10 @@ func (s *Server) HandleProbeModel(c *gin.Context) {
 	c.JSON(http.StatusOK, ProbeResponse{
 		Success: true,
 		Data: &ProbeResponseData{
-			Request: mockRequest,
-			Response: ProbeResponseDetail{
-				Content:      responseContent,
-				FinishReason: finishReason,
-			},
-			Usage: usage,
+			Request:     mockRequest,
+			Response:    ProbeResponseDetail{Content: responseContent, FinishReason: finishReason},
+			Usage:       usage,
+			CurlCommand: curlCommand,
 		},
 	})
 }


### PR DESCRIPTION
##   Add "Models" button to API Keys page for viewing and testing provider models.

  - Add "Models" button to API Keys table that opens a model selection dialog
  - Dialog reuses existing ModelSelectTab component in single-provider mode
  - Add model testing with "Test" button and result dialog showing curl command
  - Backend generates curl command in probe response using actual provider config and shows on test tab
