### PR TITLE
 Fix: Model List Not Refreshing After Directory Missing

### DIFF
--- a/internal/constant/constant.go
+++ b/internal/constant/constant.go
@@ -40,6 +40,8 @@ const ConfigDirName = ".tingly-box"
 
 const ModelsDirName = "models"
 
+const MemoryDirName = "memory"
+
 // GetStateDir returns the directory used for persisted runtime state
 func GetStateDir() string {
 	return filepath.Join(GetTinglyConfDir(), StateDirName)
@@ -58,4 +60,14 @@ func GetTinglyConfDir() string {
 // GetModelsDir returns the models directory path
 func GetModelsDir() string {
 	return filepath.Join(GetTinglyConfDir(), ModelsDirName)
+}
+
+// GetMemoryDir returns the memory directory path
+func GetMemoryDir() string {
+	return filepath.Join(GetTinglyConfDir(), MemoryDirName)
+}
+
+// GetLogDir returns the log directory path
+func GetLogDir() string {
+	return filepath.Join(GetTinglyConfDir(), LogDirName)
 }


### PR DESCRIPTION
![telegram-cloud-photo-size-5-6271402806744911797-y](https://github.com/user-attachments/assets/15e213c4-ff60-4a04-bb74-e8b60f000152)

This PR resolves an issue where deleting ~/.tingly-box/models and then clicking Refresh resulted in an empty model list： https://github.com/tingly-dev/tingly-box/issues/157 . The Server now starts up with a directory existence assuring logic.