### PR TITLE
minor: add proxy option for providers.

### DIFF
--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -1,4 +1,4 @@
-import { WarningAmber, Close } from '@mui/icons-material';
+import { WarningAmber, Close, Star } from '@mui/icons-material';
 import {
     Alert,
     Autocomplete,
@@ -33,6 +33,7 @@ export interface EnhancedProviderFormData {
     token: string;
     noKeyRequired?: boolean;
     enabled?: boolean;
+    proxyUrl?: string;
 }
 
 interface PresetProviderFormDialogProps {
@@ -372,6 +373,7 @@ const ProviderFormDialog = ({
                                         <TextField
                                             {...params}
                                             label={t('providerDialog.providerOrUrl.label')}
+                                            required
                                             placeholder={t('providerDialog.providerOrUrl.placeholder')}
                                         />
                                     )}
@@ -383,7 +385,7 @@ const ProviderFormDialog = ({
                                     }}
                                 />
 
-                                {/* API Key Field with No Key Required switch */}
+                                {/* API Key Field */}
                                 <TextField
                                     size="small"
                                     fullWidth
@@ -395,11 +397,24 @@ const ProviderFormDialog = ({
                                         // Clear verification result when token changes
                                         setVerificationResult(null);
                                     }}
-                                    required={mode === 'add' && !noApiKey}
+                                    required={!noApiKey}
                                     placeholder={mode === 'add' ? t('providerDialog.apiKey.placeholderAdd') : t('providerDialog.apiKey.placeholderEdit')}
                                     helperText={mode === 'edit' && t('providerDialog.apiKey.helperEdit')}
                                     disabled={noApiKey}
                                 />
+
+                                {/* Proxy URL Field */}
+                                <TextField
+                                    size="small"
+                                    fullWidth
+                                    label={t('providerDialog.advanced.proxyUrl.label')}
+                                    placeholder={t('providerDialog.advanced.proxyUrl.placeholder')}
+                                    value={data.proxyUrl || ''}
+                                    onChange={(e) => onChange('proxyUrl', e.target.value)}
+                                    helperText={t('providerDialog.advanced.proxyUrl.helper')}
+                                />
+
+                                {/* No Key Required switch */}
                                 {isCustomUrl && (
                                     <FormControlLabel
                                         control={

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -30,6 +30,7 @@ export const useProviderDialog = (
         token: '',
         enabled: true,
         noKeyRequired: false,
+        proxyUrl: '',
     });
 
     const handleAddProviderClick = () => {
@@ -40,6 +41,7 @@ export const useProviderDialog = (
             token: '',
             enabled: true,
             noKeyRequired: false,
+            proxyUrl: '',
         });
         setProviderDialogOpen(true);
     };
@@ -53,6 +55,7 @@ export const useProviderDialog = (
             api_style: providerFormData.apiStyle,
             token: providerFormData.token,
             no_key_required: providerFormData.noKeyRequired,
+            proxy_url: providerFormData.proxyUrl,
         };
 
         const result = await api.addProvider(providerData);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -129,6 +129,14 @@ export default {
       "helperEdit": "Leave empty to keep current token"
     },
     "enabled": "Enabled",
+    "advanced": {
+      "title": "Advanced",
+      "proxyUrl": {
+        "label": "Proxy URL",
+        "placeholder": "e.g., http://127.0.0.1:7890 or socks5://127.0.0.1:1080",
+        "helper": "Optional HTTP or SOCKS proxy for API requests"
+      }
+    },
     "verification": {
       "verifying": "Verifying...",
       "verifyButton": "Verify",

--- a/frontend/src/pages/ApiKeyPage.tsx
+++ b/frontend/src/pages/ApiKeyPage.tsx
@@ -47,6 +47,7 @@ const ApiKeyPage = () => {
             token: '',
             enabled: true,
             noKeyRequired: false,
+            proxyUrl: '',
         } as any);
         setDialogOpen(true);
     };
@@ -72,6 +73,7 @@ const ApiKeyPage = () => {
             api_style: providerFormData.apiStyle,
             token: providerFormData.token,
             no_key_required: (providerFormData as any).noKeyRequired || false,
+            ...(dialogMode === 'add' && { proxy_url: (providerFormData as any).proxyUrl || '' }),
             ...(dialogMode === 'edit' && { enabled: providerFormData.enabled }),
         };
 
@@ -84,6 +86,7 @@ const ApiKeyPage = () => {
                 token: providerData.token || undefined,
                 no_key_required: providerData.no_key_required,
                 enabled: providerData.enabled,
+                proxy_url: (providerFormData as any).proxyUrl || undefined,
             });
 
         if (result.success) {
@@ -131,6 +134,7 @@ const ApiKeyPage = () => {
                 token: provider.token || "",
                 enabled: provider.enabled,
                 noKeyRequired: provider.no_key_required || false,
+                proxyUrl: provider.proxy_url || '',
             } as any);
             setDialogOpen(true);
         } else {

--- a/internal/server/provider_handler.go
+++ b/internal/server/provider_handler.go
@@ -20,6 +20,7 @@ func maskProviderForResponse(provider *typ.Provider) ProviderResponse {
 		APIStyle:      string(provider.APIStyle),
 		NoKeyRequired: provider.NoKeyRequired,
 		Enabled:       provider.Enabled,
+		ProxyURL:      provider.ProxyURL,
 		AuthType:      string(provider.AuthType),
 	}
 
@@ -140,6 +141,7 @@ func (s *Server) CreateProvider(c *gin.Context) {
 		Token:         req.Token,
 		NoKeyRequired: req.NoKeyRequired,
 		Enabled:       req.Enabled,
+		ProxyURL:      req.ProxyURL,
 	}
 
 	err = s.config.AddProvider(provider)
@@ -280,6 +282,9 @@ func (s *Server) UpdateProvider(c *gin.Context) {
 	}
 	if req.Enabled != nil {
 		provider.Enabled = *req.Enabled
+	}
+	if req.ProxyURL != nil {
+		provider.ProxyURL = *req.ProxyURL
 	}
 
 	err = s.config.UpdateProvider(uid, provider)

--- a/internal/server/server_models.go
+++ b/internal/server/server_models.go
@@ -192,6 +192,7 @@ type ProviderResponse struct {
 	Token         string           `json:"token" example:"sk-***...***"` // Only populated for api_key auth type
 	NoKeyRequired bool             `json:"no_key_required" example:"false"`
 	Enabled       bool             `json:"enabled" example:"true"`
+	ProxyURL      string           `json:"proxy_url,omitempty" example:"http://127.0.0.1:7890"`
 	AuthType      string           `json:"auth_type,omitempty" example:"api_key"` // api_key or oauth
 	OAuthDetail   *typ.OAuthDetail `json:"oauth_detail,omitempty"`                // OAuth credentials (only for oauth auth type)
 }
@@ -267,6 +268,7 @@ type CreateProviderRequest struct {
 	Token         string `json:"token" description:"API token" example:"sk-..."`
 	NoKeyRequired bool   `json:"no_key_required" description:"Whether provider requires no API key" example:"false"`
 	Enabled       bool   `json:"enabled" description:"Whether provider is enabled" example:"true"`
+	ProxyURL      string `json:"proxy_url,omitempty" description:"HTTP or SOCKS proxy URL (e.g., http://127.0.0.1:7890 or socks5://127.0.0.1:1080)" example:"http://127.0.0.1:7890"`
 }
 
 // CreateProviderResponse represents the response for adding a provider
@@ -284,6 +286,7 @@ type UpdateProviderRequest struct {
 	Token         *string `json:"token,omitempty" description:"New API token"`
 	NoKeyRequired *bool   `json:"no_key_required,omitempty" description:"Whether provider requires no API key"`
 	Enabled       *bool   `json:"enabled,omitempty" description:"New enabled status"`
+	ProxyURL      *string `json:"proxy_url,omitempty" description:"HTTP or SOCKS proxy URL"`
 }
 
 // UpdateProviderResponse represents the response for updating a provider

--- a/swagger.json
+++ b/swagger.json
@@ -1155,6 +1155,11 @@
           "description": "Whether provider requires no API key",
           "example": false
         },
+        "proxy_url": {
+          "type": "string",
+          "description": "HTTP or SOCKS proxy URL (e.g., http://127.0.0.1:7890 or socks5://127.0.0.1:1080)",
+          "example": "http://127.0.0.1:7890"
+        },
         "token": {
           "type": "string",
           "description": "API token",
@@ -2087,6 +2092,11 @@
           "description": "Field oauth_detail",
           "$ref": "#/definitions/OAuthDetail"
         },
+        "proxy_url": {
+          "type": "string",
+          "description": "Field proxy_url",
+          "example": "http://127.0.0.1:7890"
+        },
         "token": {
           "type": "string",
           "description": "Field token",
@@ -2634,6 +2644,10 @@
           "type": "boolean",
           "description": "Whether provider requires no API key"
         },
+        "proxy_url": {
+          "type": "string",
+          "description": "HTTP or SOCKS proxy URL"
+        },
         "token": {
           "type": "string",
           "description": "New API token"
@@ -2826,8 +2840,28 @@
   },
   "tags": [
     {
+      "name": "token",
+      "description": "Operations related to token"
+    },
+    {
+      "name": "oauth",
+      "description": "Operations related to oauth"
+    },
+    {
       "name": "server",
       "description": "Operations related to server"
+    },
+    {
+      "name": "providers",
+      "description": "Operations related to providers"
+    },
+    {
+      "name": "info",
+      "description": "Operations related to info"
+    },
+    {
+      "name": "logs",
+      "description": "Operations related to logs"
     },
     {
       "name": "rules",
@@ -2844,26 +2878,6 @@
     {
       "name": "testing",
       "description": "Operations related to testing"
-    },
-    {
-      "name": "info",
-      "description": "Operations related to info"
-    },
-    {
-      "name": "logs",
-      "description": "Operations related to logs"
-    },
-    {
-      "name": "token",
-      "description": "Operations related to token"
-    },
-    {
-      "name": "providers",
-      "description": "Operations related to providers"
-    },
-    {
-      "name": "oauth",
-      "description": "Operations related to oauth"
     }
   ]
 }


### PR DESCRIPTION
###  add proxy option for providers.
Resolve  https://github.com/tingly-dev/tingly-box/issues/151

Some workflows require routing requests through a network proxy. This PR adds a Proxy URL field to the provider Add/Edit dialog, allowing users to configure a proxy directly within the UI. This improves flexibility and supports environments where direct outbound requests are restricted.

<img width="585" height="438" alt="image" src="https://github.com/user-attachments/assets/067e1a38-b745-4ad4-83f2-3f39e2a46ac0" />