### PR TITLE
fix: user get client timeout exceeded while awaiting headers problem.

### DIFF
--- a/internal/constant/constant.go
+++ b/internal/constant/constant.go
@@ -20,6 +20,8 @@ const (
 	DefaultRequestTimeout = 1800
 	// DefaultMaxTimeout in seconds
 	DefaultMaxTimeout = 30 * 60
+	// ModelFetchTimeout is the timeout for fetching models from provider API in seconds
+	ModelFetchTimeout = 30
 
 	// DefaultMaxTokens is the default max_tokens value for API requests
 	DefaultMaxTokens = 8192

--- a/internal/helper/provider_model.go
+++ b/internal/helper/provider_model.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"tingly-box/internal/constant"
 	"tingly-box/internal/llmclient/httpclient"
 	"tingly-box/internal/typ"
 	"tingly-box/pkg/oauth"
@@ -68,7 +69,8 @@ func GetProviderModelsFromAPI(provider *typ.Provider) ([]string, error) {
 	} else {
 		httpClient = httpclient.CreateHTTPClientWithProxy(provider.ProxyURL)
 	}
-	httpClient.Timeout = 30 * time.Second
+	// Use constant timeout for model fetching (30s is sufficient)
+	httpClient.Timeout = time.Duration(constant.ModelFetchTimeout) * time.Second
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -362,8 +362,12 @@ func (s *Server) forwardOpenAIRequest(provider *typ.Provider, req *openai.ChatCo
 	// Get or create OpenAI client wrapper from pool
 	wrapper := s.clientPool.GetOpenAIClient(provider, req.Model)
 
-	// Make the request using wrapper method
-	chatCompletion, err := wrapper.ChatCompletionsNew(context.Background(), *req)
+	// Make the request using wrapper method with provider timeout
+	timeout := time.Duration(provider.Timeout) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	chatCompletion, err := wrapper.ChatCompletionsNew(ctx, *req)
 	if err != nil {
 		logrus.Error(err)
 		return nil, fmt.Errorf("failed to create chat completion: %w", err)
@@ -383,8 +387,12 @@ func (s *Server) forwardOpenAIStreamRequest(provider *typ.Provider, req *openai.
 	// Get or create OpenAI client wrapper from pool
 	wrapper := s.clientPool.GetOpenAIClient(provider, "")
 
-	// Make the streaming request using wrapper method
-	stream := wrapper.ChatCompletionsNewStreaming(context.Background(), *req)
+	// Make the streaming request using wrapper method with provider timeout
+	timeout := time.Duration(provider.Timeout) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	stream := wrapper.ChatCompletionsNewStreaming(ctx, *req)
 
 	return stream, nil
 }

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -332,7 +333,11 @@ func (s *Server) forwardResponsesRequest(provider *typ.Provider, params response
 	wrapper := s.clientPool.GetOpenAIClient(provider, "")
 	logrus.Infof("provider: %s (responses)", provider.Name)
 
-	ctx := context.Background()
+	// Make the request using wrapper method with provider timeout
+	timeout := time.Duration(provider.Timeout) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	resp, err := wrapper.Client().Responses.New(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create response: %w", err)
@@ -346,7 +351,11 @@ func (s *Server) forwardResponsesStreamRequest(provider *typ.Provider, params re
 	wrapper := s.clientPool.GetOpenAIClient(provider, "")
 	logrus.Infof("provider: %s (responses streaming)", provider.Name)
 
-	ctx := context.Background()
+	// Make the request using wrapper method with provider timeout
+	timeout := time.Duration(provider.Timeout) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	stream := wrapper.Client().Responses.NewStreaming(ctx, params)
 
 	return stream, nil


### PR DESCRIPTION
User reports frequent timeouts when using the Ark platform with a customized model:

<img width="2870" height="230" alt="Screenshot showing timeout error on Ark platform" src="https://github.com/user-attachments/assets/b6d27e96-395e-4d91-83d5-0a0d0e45dbd7" />