### PR TITLE
Fix: Support OpenAI Codex models via the Responses API

### DIFF
--- a/internal/loadbalance/load_balancing.go
+++ b/internal/loadbalance/load_balancing.go
@@ -3,6 +3,7 @@ package loadbalance
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -20,6 +21,14 @@ type Service struct {
 // ServiceID returns a unique identifier for the service
 func (s *Service) ServiceID() string {
 	return fmt.Sprintf("%s:%s", s.Provider, s.Model)
+}
+
+// PreferCompletions returns true if the model prefers the /v1/completions endpoint over /v1/chat/completions.
+// This is used for models like Codex that don't support the chat completions endpoint.
+func (s *Service) PreferCompletions() bool {
+	// For now, all models with "codex" in their name (case insensitive) prefer completions
+	// In the future, this can be extended to support more models or be configured per-model
+	return strings.Contains(strings.ToLower(s.Model), "codex")
 }
 
 // InitializeStats initializes the service statistics if they are empty


### PR DESCRIPTION
OpenAI Codex models do not support the /v1/chat/completions endpoint and must be accessed through the /v1/responses API. This PR adds transparent support for Codex models while preserving the existing /chat/completions interface for clients.

##  What changed

- Introduced PreferCompletions() to detect models that should use the Responses API

- Currently applies to models with "codex" in their name

- Updated the chat completions handler to automatically route eligible models to the Responses API

- Added request conversion utilities to translate Chat Completions payloads into Responses format



## Result

Clients can continue using /chat/completions unchanged, while Codex models are automatically routed through the correct /v1/responses API under the hood.