### PR TITLE
Change to use https to clone submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "libs/openai-go"]
 	path = libs/openai-go
-	url = git@github.com:tingly-dev/openai-go.git
+	url = https://github.com/tingly-dev/openai-go.git
 	branch = "tingly-dev"
 [submodule "libs/anthropic-sdk-go"]
 	path = libs/anthropic-sdk-go
-	url = git@github.com:tingly-dev/anthropic-sdk-go.git
+	url = https://github.com/tingly-dev/anthropic-sdk-go.git
 	branch = "fork"
 [submodule "libs/go-genai"]
 	path = libs/go-genai
-	url = git@github.com:tingly-dev/go-genai.git
+	url = https://github.com/tingly-dev/go-genai.git


### PR DESCRIPTION
# Major changes

Use https instead of ssh to clone submodules, need to run `git submodule sync --recursive` first to clear git cache. Then, `git submodule update --init --recursive` will use https.