### PR TITLE
feat: Service Health Check for Load Balancing 

### DIFF
--- a/internal/loadbalance/health_monitor.go
+++ b/internal/loadbalance/health_monitor.go
@@ -1,0 +1,305 @@
+package loadbalance
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// HealthStatus represents the health state of a service
+type HealthStatus int
+
+const (
+	HealthHealthy HealthStatus = iota // Service is healthy and available
+	HealthUnhealthy                    // Service is unhealthy (rate limited, failing)
+)
+
+// String returns the string representation of HealthStatus
+func (h HealthStatus) String() string {
+	switch h {
+	case HealthHealthy:
+		return "healthy"
+	case HealthUnhealthy:
+		return "unhealthy"
+	default:
+		return "unknown"
+	}
+}
+
+// ServiceHealth tracks health information for a single service
+type ServiceHealth struct {
+	ServiceID         string        // Unique service identifier (provider:model)
+	Status            HealthStatus  // Current health status
+	LastError         error         // Last error that caused unhealthy state
+	LastErrorTime     time.Time     // When the error occurred
+	ConsecutiveErrors int           // Count of consecutive errors
+	RateLimited       bool          // True if last error was 429
+	AuthError         bool          // True if last error was 401/403
+	LastHealthCheck   time.Time     // Last time health was checked
+	RecoveryTimeout   time.Duration // Time before auto-recovery
+	mutex             sync.RWMutex  // Thread safety
+}
+
+// HealthProbeFunc is the function type for probing service health
+// Returns true if service is healthy, false otherwise
+type HealthProbeFunc func(serviceID string) bool
+
+// HealthMonitorConfig holds configuration for health monitoring
+type HealthMonitorConfig struct {
+	// ConsecutiveErrorThreshold is the number of consecutive errors before marking unhealthy
+	ConsecutiveErrorThreshold int `json:"consecutive_error_threshold" yaml:"consecutive_error_threshold"`
+	// RecoveryTimeoutSeconds is the time in seconds before auto-recovery
+	RecoveryTimeoutSeconds int `json:"recovery_timeout_seconds" yaml:"recovery_timeout_seconds"`
+	// ProbeEnabled enables health check probing before marking service healthy
+	ProbeEnabled bool `json:"probe_enabled" yaml:"probe_enabled"`
+}
+
+// DefaultHealthMonitorConfig returns default configuration
+func DefaultHealthMonitorConfig() HealthMonitorConfig {
+	return HealthMonitorConfig{
+		ConsecutiveErrorThreshold: 3,
+		RecoveryTimeoutSeconds:    300, // 5 minutes
+		ProbeEnabled:              true,
+	}
+}
+
+// HealthMonitor manages health status for all services
+type HealthMonitor struct {
+	services                  map[string]*ServiceHealth // serviceID -> health
+	mutex                     sync.RWMutex
+	config                    HealthMonitorConfig
+	defaultRecoveryTimeout    time.Duration
+	consecutiveErrorThreshold int
+	probeFunc                 HealthProbeFunc // Optional probe function for recovery checking
+}
+
+// NewHealthMonitor creates a new health monitor with the given configuration
+func NewHealthMonitor(config HealthMonitorConfig) *HealthMonitor {
+	return &HealthMonitor{
+		services:                  make(map[string]*ServiceHealth),
+		config:                    config,
+		defaultRecoveryTimeout:    time.Duration(config.RecoveryTimeoutSeconds) * time.Second,
+		consecutiveErrorThreshold: config.ConsecutiveErrorThreshold,
+		probeFunc:                 nil, // Can be set via SetProbeFunc
+	}
+}
+
+// SetProbeFunc sets the probe function for health checking during recovery
+func (hm *HealthMonitor) SetProbeFunc(fn HealthProbeFunc) {
+	hm.mutex.Lock()
+	defer hm.mutex.Unlock()
+	hm.probeFunc = fn
+}
+
+// getOrCreateHealth gets or creates a health record for a service
+func (hm *HealthMonitor) getOrCreateHealth(serviceID string) *ServiceHealth {
+	hm.mutex.Lock()
+	defer hm.mutex.Unlock()
+
+	if health, exists := hm.services[serviceID]; exists {
+		return health
+	}
+
+	health := &ServiceHealth{
+		ServiceID:       serviceID,
+		Status:          HealthHealthy,
+		RecoveryTimeout: hm.defaultRecoveryTimeout,
+	}
+	hm.services[serviceID] = health
+	return health
+}
+
+// getHealth gets a health record for a service (returns nil if not found)
+func (hm *HealthMonitor) getHealth(serviceID string) *ServiceHealth {
+	hm.mutex.RLock()
+	defer hm.mutex.RUnlock()
+
+	return hm.services[serviceID]
+}
+
+// IsHealthy checks if a service is healthy (with time-based recovery and probing)
+func (hm *HealthMonitor) IsHealthy(serviceID string) bool {
+	health := hm.getHealth(serviceID)
+	if health == nil {
+		// No health record means healthy by default
+		return true
+	}
+
+	health.mutex.RLock()
+	status := health.Status
+	lastErrorTime := health.LastErrorTime
+	recoveryTimeout := health.RecoveryTimeout
+	health.mutex.RUnlock()
+
+	if status == HealthHealthy {
+		return true
+	}
+
+	// Check if recovery timeout has elapsed
+	if time.Since(lastErrorTime) > recoveryTimeout {
+		// Probe before auto-recover (if probing is enabled and probe func is set)
+		if hm.config.ProbeEnabled && hm.probeFunc != nil {
+			if hm.probeFunc(serviceID) {
+				// Probe succeeded, recover the service
+				hm.recoverService(serviceID)
+				return true
+			}
+			// Probe failed, extend the timeout
+			hm.extendRecoveryTimeout(serviceID)
+			return false
+		}
+
+		// No probe function set or probing disabled, auto-recover
+		hm.recoverService(serviceID)
+		return true
+	}
+
+	return false
+}
+
+// recoverService recovers a service to healthy state
+func (hm *HealthMonitor) recoverService(serviceID string) {
+	hm.mutex.RLock()
+	health, exists := hm.services[serviceID]
+	hm.mutex.RUnlock()
+
+	if !exists {
+		return
+	}
+
+	health.mutex.Lock()
+	defer health.mutex.Unlock()
+
+	if health.Status == HealthUnhealthy {
+		health.Status = HealthHealthy
+		health.RateLimited = false
+		health.AuthError = false
+		health.ConsecutiveErrors = 0
+		health.LastError = nil
+	}
+}
+
+// extendRecoveryTimeout extends the recovery timeout after a failed probe
+func (hm *HealthMonitor) extendRecoveryTimeout(serviceID string) {
+	hm.mutex.RLock()
+	health, exists := hm.services[serviceID]
+	hm.mutex.RUnlock()
+
+	if !exists {
+		return
+	}
+
+	health.mutex.Lock()
+	defer health.mutex.Unlock()
+
+	// Extend timeout by another recovery period (exponential backoff could be added here)
+	health.LastErrorTime = time.Now()
+}
+
+// ReportRateLimit reports a 429 rate limit error for a service
+func (hm *HealthMonitor) ReportRateLimit(serviceID string) {
+	health := hm.getOrCreateHealth(serviceID)
+	health.mutex.Lock()
+	defer health.mutex.Unlock()
+
+	health.Status = HealthUnhealthy
+	health.RateLimited = true
+	health.LastErrorTime = time.Now()
+	health.ConsecutiveErrors = 0 // Reset consecutive errors on 429
+	health.LastHealthCheck = time.Now()
+}
+
+// ReportAuthError reports a 401/403 auth error for a service
+func (hm *HealthMonitor) ReportAuthError(serviceID string, statusCode int) {
+	health := hm.getOrCreateHealth(serviceID)
+	health.mutex.Lock()
+	defer health.mutex.Unlock()
+
+	// Auth errors immediately mark unhealthy (no threshold)
+	health.Status = HealthUnhealthy
+	health.AuthError = true
+	health.LastError = errors.New("auth error")
+	health.LastErrorTime = time.Now()
+	health.LastHealthCheck = time.Now()
+}
+
+// ReportError reports a retryable error for a service
+func (hm *HealthMonitor) ReportError(serviceID string, err error) {
+	health := hm.getOrCreateHealth(serviceID)
+	health.mutex.Lock()
+	defer health.mutex.Unlock()
+
+	health.ConsecutiveErrors++
+	health.LastError = err
+	health.LastErrorTime = time.Now()
+	health.LastHealthCheck = time.Now()
+
+	// Only mark unhealthy after threshold
+	if health.ConsecutiveErrors >= hm.consecutiveErrorThreshold {
+		health.Status = HealthUnhealthy
+	}
+}
+
+// ReportSuccess reports a successful request for a service
+func (hm *HealthMonitor) ReportSuccess(serviceID string) {
+	health := hm.getHealth(serviceID)
+	if health == nil {
+		return
+	}
+
+	health.mutex.Lock()
+	defer health.mutex.Unlock()
+
+	// Any success immediately recovers
+	if health.Status == HealthUnhealthy {
+		health.Status = HealthHealthy
+		health.RateLimited = false
+		health.AuthError = false
+		health.ConsecutiveErrors = 0
+		health.LastError = nil
+	} else {
+		// Reset consecutive errors even if already healthy
+		health.ConsecutiveErrors = 0
+	}
+	health.LastHealthCheck = time.Now()
+}
+
+// GetHealth returns the health status for a service
+func (hm *HealthMonitor) GetHealth(serviceID string) *ServiceHealth {
+	return hm.getOrCreateHealth(serviceID)
+}
+
+// GetAllHealth returns health status for all services
+func (hm *HealthMonitor) GetAllHealth() map[string]*ServiceHealth {
+	hm.mutex.RLock()
+	defer hm.mutex.RUnlock()
+
+	result := make(map[string]*ServiceHealth, len(hm.services))
+	for k, v := range hm.services {
+		result[k] = v
+	}
+	return result
+}
+
+// ResetHealth manually resets a service's health to healthy
+func (hm *HealthMonitor) ResetHealth(serviceID string) {
+	hm.recoverService(serviceID)
+}
+
+// RemoveHealth removes a service's health record
+func (hm *HealthMonitor) RemoveHealth(serviceID string) {
+	hm.mutex.Lock()
+	defer hm.mutex.Unlock()
+
+	delete(hm.services, serviceID)
+}
+
+// UpdateConfig updates the health monitor configuration
+func (hm *HealthMonitor) UpdateConfig(config HealthMonitorConfig) {
+	hm.mutex.Lock()
+	defer hm.mutex.Unlock()
+
+	hm.config = config
+	hm.defaultRecoveryTimeout = time.Duration(config.RecoveryTimeoutSeconds) * time.Second
+	hm.consecutiveErrorThreshold = config.ConsecutiveErrorThreshold
+}

--- a/internal/loadbalance/health_monitor_test.go
+++ b/internal/loadbalance/health_monitor_test.go
@@ -1,0 +1,420 @@
+package loadbalance
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHealthMonitor(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	assert.NotNil(t, hm)
+	assert.NotNil(t, hm.services)
+	assert.Equal(t, 3, hm.consecutiveErrorThreshold)
+	assert.Equal(t, 5*time.Minute, hm.defaultRecoveryTimeout)
+}
+
+func TestHealthMonitor_IsHealthy_Default(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	// Service with no health record should be healthy by default
+	assert.True(t, hm.IsHealthy("provider:model"))
+}
+
+func TestHealthMonitor_ReportRateLimit(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Initially healthy
+	assert.True(t, hm.IsHealthy(serviceID))
+
+	// Report rate limit
+	hm.ReportRateLimit(serviceID)
+
+	// Should be unhealthy
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Check health record
+	health := hm.GetHealth(serviceID)
+	assert.Equal(t, HealthUnhealthy, health.Status)
+	assert.True(t, health.RateLimited)
+	assert.False(t, health.AuthError)
+	assert.Equal(t, 0, health.ConsecutiveErrors)
+}
+
+func TestHealthMonitor_ReportAuthError(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Initially healthy
+	assert.True(t, hm.IsHealthy(serviceID))
+
+	// Report auth error (401)
+	hm.ReportAuthError(serviceID, 401)
+
+	// Should be unhealthy immediately
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Check health record
+	health := hm.GetHealth(serviceID)
+	assert.Equal(t, HealthUnhealthy, health.Status)
+	assert.False(t, health.RateLimited)
+	assert.True(t, health.AuthError)
+
+	// Reset and test 403
+	hm.ResetHealth(serviceID)
+	hm.ReportAuthError(serviceID, 403)
+	assert.False(t, hm.IsHealthy(serviceID))
+}
+
+func TestHealthMonitor_ReportError_ConsecutiveThreshold(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	config.ConsecutiveErrorThreshold = 3
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+	testErr := errors.New("connection timeout")
+
+	// Initially healthy
+	assert.True(t, hm.IsHealthy(serviceID))
+
+	// Report 1 error - should still be healthy
+	hm.ReportError(serviceID, testErr)
+	assert.True(t, hm.IsHealthy(serviceID))
+
+	// Report 2nd error - should still be healthy
+	hm.ReportError(serviceID, testErr)
+	assert.True(t, hm.IsHealthy(serviceID))
+
+	// Report 3rd error - should now be unhealthy
+	hm.ReportError(serviceID, testErr)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Check health record
+	health := hm.GetHealth(serviceID)
+	assert.Equal(t, 3, health.ConsecutiveErrors)
+}
+
+func TestHealthMonitor_ReportSuccess_ImmediateRecovery(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Report success
+	hm.ReportSuccess(serviceID)
+
+	// Should be healthy again
+	assert.True(t, hm.IsHealthy(serviceID))
+
+	// Check health record
+	health := hm.GetHealth(serviceID)
+	assert.Equal(t, HealthHealthy, health.Status)
+	assert.False(t, health.RateLimited)
+	assert.False(t, health.AuthError)
+	assert.Equal(t, 0, health.ConsecutiveErrors)
+}
+
+func TestHealthMonitor_ReportSuccess_ResetsConsecutiveErrors(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	config.ConsecutiveErrorThreshold = 3
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+	testErr := errors.New("connection timeout")
+
+	// Report 2 errors
+	hm.ReportError(serviceID, testErr)
+	hm.ReportError(serviceID, testErr)
+
+	health := hm.GetHealth(serviceID)
+	assert.Equal(t, 2, health.ConsecutiveErrors)
+
+	// Report success
+	hm.ReportSuccess(serviceID)
+
+	// Consecutive errors should be reset
+	health = hm.GetHealth(serviceID)
+	assert.Equal(t, 0, health.ConsecutiveErrors)
+	assert.True(t, hm.IsHealthy(serviceID))
+}
+
+func TestHealthMonitor_TimeBasedRecovery(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	config.RecoveryTimeoutSeconds = 1 // 1 second for testing
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Wait for recovery timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should be healthy again due to time-based recovery
+	assert.True(t, hm.IsHealthy(serviceID))
+}
+
+func TestHealthMonitor_ResetHealth(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Manual reset
+	hm.ResetHealth(serviceID)
+
+	// Should be healthy
+	assert.True(t, hm.IsHealthy(serviceID))
+}
+
+func TestHealthMonitor_RemoveHealth(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Remove health record
+	hm.RemoveHealth(serviceID)
+
+	// Should be healthy (no record = default healthy)
+	assert.True(t, hm.IsHealthy(serviceID))
+}
+
+func TestHealthMonitor_ConcurrentAccess(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+	var wg sync.WaitGroup
+
+	// Concurrent error reporting
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			hm.ReportError(serviceID, errors.New("test error"))
+		}()
+	}
+
+	// Concurrent success reporting
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			hm.ReportSuccess(serviceID)
+		}()
+	}
+
+	// Concurrent health checks
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = hm.IsHealthy(serviceID)
+		}()
+	}
+
+	wg.Wait()
+
+	// Should not panic and should have valid state
+	health := hm.GetHealth(serviceID)
+	assert.NotNil(t, health)
+	// After concurrent success reports, it should be healthy
+	assert.True(t, hm.IsHealthy(serviceID))
+}
+
+func TestHealthMonitor_GetAllHealth(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	// Create health records for multiple services
+	hm.ReportRateLimit("provider-a:gpt-4o")
+	hm.ReportRateLimit("provider-b:gpt-4o")
+	hm.ReportSuccess("provider-a:gpt-4o") // Make this one healthy
+
+	allHealth := hm.GetAllHealth()
+
+	assert.Len(t, allHealth, 2)
+	assert.Contains(t, allHealth, "provider-a:gpt-4o")
+	assert.Contains(t, allHealth, "provider-b:gpt-4o")
+}
+
+func TestHealthMonitor_UpdateConfig(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	assert.Equal(t, 3, hm.consecutiveErrorThreshold)
+	assert.Equal(t, 5*time.Minute, hm.defaultRecoveryTimeout)
+
+	newConfig := HealthMonitorConfig{
+		ConsecutiveErrorThreshold: 5,
+		RecoveryTimeoutSeconds:    600,
+	}
+	hm.UpdateConfig(newConfig)
+
+	assert.Equal(t, 5, hm.consecutiveErrorThreshold)
+	assert.Equal(t, 10*time.Minute, hm.defaultRecoveryTimeout)
+}
+
+func TestHealthStatus_String(t *testing.T) {
+	assert.Equal(t, "healthy", HealthHealthy.String())
+	assert.Equal(t, "unhealthy", HealthUnhealthy.String())
+	assert.Equal(t, "unknown", HealthStatus(999).String())
+}
+
+func TestHealthMonitor_ReportError_WhileUnhealthy(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+	testErr := errors.New("connection timeout")
+
+	// Make service unhealthy via rate limit
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Consecutive errors should be 0 after rate limit
+	health := hm.GetHealth(serviceID)
+	assert.Equal(t, 0, health.ConsecutiveErrors)
+
+	// Report error while unhealthy
+	hm.ReportError(serviceID, testErr)
+
+	// Should increment consecutive errors even while unhealthy
+	health = hm.GetHealth(serviceID)
+	assert.Equal(t, 1, health.ConsecutiveErrors)
+	assert.False(t, hm.IsHealthy(serviceID))
+}
+
+// Test probe function that returns true (healthy) by default
+var testProbeResult = true
+
+func TestHealthMonitor_ProbeBeforeRecovery(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	config.ProbeEnabled = true
+	config.RecoveryTimeoutSeconds = 1 // 1 second for testing
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Set probe function that checks testProbeResult
+	hm.SetProbeFunc(func(sid string) bool {
+		return testProbeResult
+	})
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Set probe to fail (service still unhealthy)
+	testProbeResult = false
+
+	// Wait for recovery timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should still be unhealthy because probe failed (and timeout extended)
+	assert.False(t, hm.IsHealthy(serviceID), "Service should remain unhealthy when probe fails")
+
+	// Set probe to succeed
+	testProbeResult = true
+
+	// Wait for recovery timeout again (since it was extended)
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should now be healthy because probe succeeded
+	assert.True(t, hm.IsHealthy(serviceID), "Service should become healthy when probe succeeds")
+}
+
+func TestHealthMonitor_ProbeDisabled(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	config.ProbeEnabled = false // Probing disabled
+	config.RecoveryTimeoutSeconds = 1
+	hm := NewHealthMonitor(config)
+
+	// Set probe function that returns false - but it shouldn't be called
+	hm.SetProbeFunc(func(sid string) bool {
+		return false
+	})
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Wait for recovery timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should auto-recover because probing is disabled
+	assert.True(t, hm.IsHealthy(serviceID), "Service should auto-recover when probing is disabled")
+}
+
+func TestHealthMonitor_ProbeExtendsTimeout(t *testing.T) {
+	config := DefaultHealthMonitorConfig()
+	config.ProbeEnabled = true
+	config.RecoveryTimeoutSeconds = 1
+	hm := NewHealthMonitor(config)
+
+	serviceID := "provider-a:gpt-4o"
+
+	// Set probe function
+	hm.SetProbeFunc(func(sid string) bool {
+		return testProbeResult
+	})
+
+	// Make service unhealthy
+	hm.ReportRateLimit(serviceID)
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Set probe to fail
+	testProbeResult = false
+
+	// Wait for initial recovery timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Probe fails, timeout should be extended
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Wait another second for the extended timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Probe still fails, should extend timeout again
+	assert.False(t, hm.IsHealthy(serviceID))
+
+	// Wait another second and now make probe succeed
+	time.Sleep(1100 * time.Millisecond)
+
+	// Now make probe succeed
+	testProbeResult = true
+
+	// Wait for timeout and probe to succeed
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should now recover
+	assert.True(t, hm.IsHealthy(serviceID))
+}

--- a/internal/loadbalance/load_balancing_test.go
+++ b/internal/loadbalance/load_balancing_test.go
@@ -140,7 +140,7 @@ func TestParseTacticType(t *testing.T) {
 		{"round_robin", TacticRoundRobin},
 		{"token_based", TacticTokenBased},
 		{"hybrid", TacticHybrid},
-		{"random", loadbalance.TacticRandom},
+		{"random", TacticRandom},
 		{"invalid", TacticRoundRobin}, // Default fallback
 		{"", TacticRoundRobin},        // Empty string fallback
 	}
@@ -153,12 +153,12 @@ func TestParseTacticType(t *testing.T) {
 }
 
 func TestTacticType_String(t *testing.T) {
-	tests := map[loadbalance.TacticType]string{
-		loadbalance.TacticRoundRobin: "round_robin",
-		loadbalance.TacticTokenBased: "token_based",
-		loadbalance.TacticHybrid:     "hybrid",
-		loadbalance.TacticRandom:     "random",
-		loadbalance.TacticType(999):  "unknown", // Invalid type
+	tests := map[TacticType]string{
+		TacticRoundRobin: "round_robin",
+		TacticTokenBased: "token_based",
+		TacticHybrid:     "hybrid",
+		TacticRandom:     "random",
+		TacticType(999):  "unknown", // Invalid type
 	}
 
 	for tacticType, expected := range tests {

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -53,6 +53,9 @@ type Config struct {
 	// Error log settings
 	ErrorLogFilterExpression string `json:"error_log_filter_expression"` // Expression for filtering error log entries (default: "StatusCode >= 400 && Path matches '^/api/'")
 
+	// Health monitor settings
+	HealthMonitor loadbalance.HealthMonitorConfig `json:"health_monitor,omitempty" yaml:"health_monitor,omitempty"`
+
 	ConfigFile string `yaml:"-" json:"-"` // Not serialized to YAML (exported to preserve field)
 	ConfigDir  string `yaml:"-" json:"-"`
 

--- a/internal/server/tests/health_check_integration_test.go
+++ b/internal/server/tests/health_check_integration_test.go
@@ -1,0 +1,452 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/server"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestHealthCheck_Lifecycle tests the full health check lifecycle:
+// 1. Service returns normal (200)
+// 2. Service returns 429 (rate limited) - should be marked unhealthy
+// 3. Service recovers after timeout - should be marked healthy again
+func TestHealthCheck_Lifecycle(t *testing.T) {
+	// Create mock provider server
+	mockProvider := NewMockProviderServer()
+	defer mockProvider.Close()
+
+	// Create temp config directory
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	// Configure health monitor with short recovery timeout for testing
+	healthConfig := loadbalance.HealthMonitorConfig{
+		ConsecutiveErrorThreshold: 3,
+		RecoveryTimeoutSeconds:    2, // 2 seconds for testing
+	}
+	appConfig.GetGlobalConfig().HealthMonitor = healthConfig
+
+	// Create health monitor and filter
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	// Create server components
+	loadBalancer := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer loadBalancer.Stop()
+
+	// Create provider pointing to mock server
+	provider := &typ.Provider{
+		UUID:     "test-provider-uuid",
+		Name:     "test-mock-provider",
+		APIBase:  mockProvider.GetURL(),
+		APIStyle: "openai",
+		Enabled:  true,
+	}
+
+	// Create rule with single service
+	rule := &typ.Rule{
+		UUID:         uuid.New().String(),
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   provider.UUID,
+				Model:      "gpt-test",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	serviceID := rule.Services[0].ServiceID()
+
+	// === Phase 1: Normal Operation ===
+	t.Log("Phase 1: Testing normal operation (200 OK)")
+	mockProvider.SetResponse("/v1/chat/completions", MockResponse{
+		StatusCode: 200,
+		Body:       CreateMockChatCompletionResponse("test-1", "gpt-test", "Hello from mock"),
+	})
+
+	// Verify service is healthy initially
+	assert.True(t, healthMonitor.IsHealthy(serviceID), "Service should be healthy initially")
+
+	// Make a request
+	selectedService, err := loadBalancer.SelectService(rule)
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-test", selectedService.Model)
+
+	// Report success to health monitor
+	healthMonitor.ReportSuccess(serviceID)
+	assert.True(t, healthMonitor.IsHealthy(serviceID), "Service should still be healthy after success")
+
+	// === Phase 2: Rate Limit (429) ===
+	t.Log("Phase 2: Testing rate limit (429)")
+	mockProvider.SetResponse("/v1/chat/completions", MockResponse{
+		StatusCode: 429,
+		Error:      "rate limit exceeded",
+	})
+
+	// Simulate receiving a 429 error
+	healthMonitor.ReportRateLimit(serviceID)
+
+	// Verify service is now unhealthy
+	assert.False(t, healthMonitor.IsHealthy(serviceID), "Service should be unhealthy after 429")
+
+	// Try to select service - should fail with "no healthy services"
+	_, err = loadBalancer.SelectService(rule)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no healthy services", "Should return error when service is unhealthy")
+
+	// === Phase 3: Recovery After Timeout ===
+	t.Log("Phase 3: Testing recovery after timeout")
+
+	// Wait for recovery timeout
+	time.Sleep(2500 * time.Millisecond)
+
+	// Service should be healthy again due to time-based recovery
+	assert.True(t, healthMonitor.IsHealthy(serviceID), "Service should be healthy after recovery timeout")
+
+	// Set mock to return success again
+	mockProvider.SetResponse("/v1/chat/completions", MockResponse{
+		StatusCode: 200,
+		Body:       CreateMockChatCompletionResponse("test-2", "gpt-test", "Recovered!"),
+	})
+
+	// Should be able to select service again
+	selectedService, err = loadBalancer.SelectService(rule)
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-test", selectedService.Model)
+
+	t.Log("Health check lifecycle test completed successfully!")
+}
+
+// TestHealthCheck_ConsecutiveErrorsThenRecovery tests that a service:
+// 1. Starts healthy
+// 2. Gets consecutive errors and becomes unhealthy
+// 3. Recovers immediately on success
+func TestHealthCheck_ConsecutiveErrorsThenRecovery(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	// Configure with low threshold
+	healthConfig := loadbalance.HealthMonitorConfig{
+		ConsecutiveErrorThreshold: 3,
+		RecoveryTimeoutSeconds:    300,
+	}
+	appConfig.GetGlobalConfig().HealthMonitor = healthConfig
+
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	loadBalancer := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer loadBalancer.Stop()
+
+	provider := &typ.Provider{
+		UUID:     "test-provider-uuid",
+		Name:     "test-provider",
+		APIBase:  "http://localhost:9999",
+		APIStyle: "openai",
+		Enabled:  true,
+	}
+
+	rule := &typ.Rule{
+		UUID:         uuid.New().String(),
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   provider.UUID,
+				Model:      "gpt-test",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	serviceID := rule.Services[0].ServiceID()
+
+	// Initially healthy
+	assert.True(t, healthMonitor.IsHealthy(serviceID))
+
+	// First error - still healthy
+	healthMonitor.ReportError(serviceID, fmt.Errorf("connection timeout"))
+	assert.True(t, healthMonitor.IsHealthy(serviceID), "Should be healthy after 1 error")
+
+	// Second error - still healthy
+	healthMonitor.ReportError(serviceID, fmt.Errorf("connection timeout"))
+	assert.True(t, healthMonitor.IsHealthy(serviceID), "Should be healthy after 2 errors")
+
+	// Third error - now unhealthy
+	healthMonitor.ReportError(serviceID, fmt.Errorf("connection timeout"))
+	assert.False(t, healthMonitor.IsHealthy(serviceID), "Should be unhealthy after 3 errors")
+
+	// Try to select - should fail
+	_, err = loadBalancer.SelectService(rule)
+	assert.Error(t, err)
+
+	// Report success - should immediately recover
+	healthMonitor.ReportSuccess(serviceID)
+	assert.True(t, healthMonitor.IsHealthy(serviceID), "Should be healthy after success")
+
+	// Should be able to select again
+	selectedService, err := loadBalancer.SelectService(rule)
+	require.NoError(t, err)
+	assert.NotNil(t, selectedService)
+}
+
+// TestHealthCheck_APIEndpoint tests the health check API endpoints
+func TestHealthCheck_APIEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	healthConfig := loadbalance.DefaultHealthMonitorConfig()
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	loadBalancer := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer loadBalancer.Stop()
+
+	loadBalancerAPI := server.NewLoadBalancerAPI(loadBalancer, appConfig.GetGlobalConfig())
+
+	// Create router
+	router := gin.New()
+	api := router.Group("/api/v1/loadbalancer")
+	loadBalancerAPI.RegisterRoutes(api)
+
+	// Create a rule with services
+	rule := &typ.Rule{
+		UUID:         uuid.New().String(),
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-health-api",
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider-healthy",
+				Model:      "model-1",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+			{
+				Provider:   "provider-unhealthy",
+				Model:      "model-2",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	// Add rule to config
+	err = appConfig.GetGlobalConfig().AddOrUpdateRequestConfigByRequestModel(*rule)
+	require.NoError(t, err)
+
+	// Mark one service as unhealthy
+	healthMonitor.ReportRateLimit(rule.Services[1].ServiceID())
+
+	// Test GET /rules/{ruleId}/health
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/loadbalancer/rules/%s/health", rule.UUID), nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	var healthResp map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &healthResp)
+	require.NoError(t, err)
+
+	// Verify response structure
+	health, ok := healthResp["health"].(map[string]interface{})
+	require.True(t, ok, "Response should have health field")
+
+	// Check healthy service
+	healthyService, ok := health["provider-healthy:model-1"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, healthyService["healthy"])
+	assert.Equal(t, "healthy", healthyService["status"])
+
+	// Check unhealthy service
+	unhealthyService, ok := health["provider-unhealthy:model-2"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, unhealthyService["healthy"])
+	assert.Equal(t, "unhealthy", unhealthyService["status"])
+	assert.Equal(t, true, unhealthyService["rate_limited"])
+
+	// Test POST /services/{serviceId}/health/reset
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/loadbalancer/services/provider-unhealthy:model-2/health/reset", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	// Verify service is now healthy
+	assert.True(t, healthMonitor.IsHealthy(rule.Services[1].ServiceID()))
+}
+
+// TestHealthCheck_MultipleServicesWithOneUnhealthy tests load balancing
+// when one of multiple services becomes unhealthy
+func TestHealthCheck_MultipleServicesWithOneUnhealthy(t *testing.T) {
+	mockProvider1 := NewMockProviderServer()
+	defer mockProvider1.Close()
+
+	mockProvider2 := NewMockProviderServer()
+	defer mockProvider2.Close()
+
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	healthConfig := loadbalance.DefaultHealthMonitorConfig()
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	loadBalancer := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer loadBalancer.Stop()
+
+	// Set both providers to return success
+	mockProvider1.SetResponse("/v1/chat/completions", MockResponse{
+		StatusCode: 200,
+		Body:       CreateMockChatCompletionResponse("test", "model1", "Response from provider 1"),
+	})
+	mockProvider2.SetResponse("/v1/chat/completions", MockResponse{
+		StatusCode: 200,
+		Body:       CreateMockChatCompletionResponse("test", "model2", "Response from provider 2"),
+	})
+
+	provider1 := &typ.Provider{
+		UUID:     "provider-1-uuid",
+		Name:     "provider-1",
+		APIBase:  mockProvider1.GetURL(),
+		APIStyle: "openai",
+		Enabled:  true,
+	}
+	provider2 := &typ.Provider{
+		UUID:     "provider-2-uuid",
+		Name:     "provider-2",
+		APIBase:  mockProvider2.GetURL(),
+		APIStyle: "openai",
+		Enabled:  true,
+	}
+
+	// Create rule with two services
+	rule := &typ.Rule{
+		UUID:         uuid.New().String(),
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: &typ.RoundRobinParams{RequestThreshold: 1}, // Switch after each request
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   provider1.UUID,
+				Model:      "gpt-model",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+			{
+				Provider:   provider2.UUID,
+				Model:      "gpt-model",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	serviceID1 := rule.Services[0].ServiceID()
+	serviceID2 := rule.Services[1].ServiceID()
+
+	// Initially both healthy - both should be selectable
+	// Test that we can select from both providers
+	selectedProviders := map[string]bool{}
+	for i := 0; i < 10; i++ {
+		svc, err := loadBalancer.SelectService(rule)
+		require.NoError(t, err)
+		selectedProviders[svc.Provider] = true
+	}
+
+	// Should have selected from both providers at some point
+	assert.True(t, selectedProviders["provider-1-uuid"], "Should select from provider 1")
+	assert.True(t, selectedProviders["provider-2-uuid"], "Should select from provider 2")
+
+	// Mark provider 1 as unhealthy (rate limited)
+	healthMonitor.ReportRateLimit(serviceID1)
+	assert.False(t, healthMonitor.IsHealthy(serviceID1))
+	assert.True(t, healthMonitor.IsHealthy(serviceID2))
+
+	// Now all selections should go to provider 2
+	selections := map[string]int{}
+	for i := 0; i < 10; i++ {
+		svc, err := loadBalancer.SelectService(rule)
+		require.NoError(t, err)
+		selections[svc.Provider]++
+	}
+
+	assert.Equal(t, 0, selections["provider-1-uuid"], "Should not select from unhealthy provider 1")
+	assert.Equal(t, 10, selections["provider-2-uuid"], "Should select only from healthy provider 2")
+
+	// Mark provider 2 as unhealthy too
+	healthMonitor.ReportRateLimit(serviceID2)
+
+	// Now should get error
+	_, err = loadBalancer.SelectService(rule)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no healthy services")
+
+	t.Log("Multiple services health check test passed!")
+}
+
+// Helper function to create a chat completion request body
+func createChatCompletionRequest(model string) map[string]interface{} {
+	return map[string]interface{}{
+		"model": model,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "Hello"},
+		},
+	}
+}
+
+// Helper function to send a request to the server
+func sendChatRequest(t *testing.T, router http.Handler, model string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(createChatCompletionRequest(model))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/tingly/openai/v1/chat/completions", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-token")
+	router.ServeHTTP(w, req)
+	return w
+}

--- a/internal/server/tests/health_filter_test.go
+++ b/internal/server/tests/health_filter_test.go
@@ -1,0 +1,323 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/server"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestHealthFilter_BasicFiltering tests that unhealthy services are filtered out
+func TestHealthFilter_BasicFiltering(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	// Create health monitor with default config
+	healthConfig := loadbalance.DefaultHealthMonitorConfig()
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	// Create load balancer with health filter
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer lb.Stop()
+
+	// Create test rule with two services
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		UUID:         uuid.New().String(),
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider-healthy",
+				Model:      "model1",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+			{
+				Provider:   "provider-unhealthy",
+				Model:      "model2",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	// Mark one service as unhealthy (rate limited)
+	healthMonitor.ReportRateLimit(rule.Services[1].ServiceID())
+
+	// Select service multiple times
+	selections := make(map[string]int)
+	for i := 0; i < 10; i++ {
+		service, err := lb.SelectService(rule)
+		require.NoError(t, err)
+		require.NotNil(t, service)
+		selections[service.Provider]++
+	}
+
+	// All selections should be the healthy provider
+	assert.Equal(t, 10, selections["provider-healthy"], "All requests should go to healthy provider")
+	assert.Equal(t, 0, selections["provider-unhealthy"], "No requests should go to unhealthy provider")
+}
+
+// TestHealthFilter_AllUnhealthy tests behavior when all services are unhealthy
+func TestHealthFilter_AllUnhealthy(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	healthConfig := loadbalance.DefaultHealthMonitorConfig()
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer lb.Stop()
+
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		UUID:         uuid.New().String(),
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider1",
+				Model:      "model1",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+			{
+				Provider:   "provider2",
+				Model:      "model2",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	// Mark all services as unhealthy
+	healthMonitor.ReportRateLimit(rule.Services[0].ServiceID())
+	healthMonitor.ReportRateLimit(rule.Services[1].ServiceID())
+
+	// SelectService should return error when no healthy services
+	_, err = lb.SelectService(rule)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no healthy services")
+}
+
+// TestHealthFilter_Recovery tests that services recover after time-based timeout
+func TestHealthFilter_Recovery(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	// Use short recovery timeout for testing
+	healthConfig := loadbalance.HealthMonitorConfig{
+		ConsecutiveErrorThreshold: 3,
+		RecoveryTimeoutSeconds:    1, // 1 second for testing
+	}
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer lb.Stop()
+
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		UUID:         uuid.New().String(),
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider1",
+				Model:      "model1",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	// Mark service as unhealthy
+	serviceID := rule.Services[0].ServiceID()
+	healthMonitor.ReportRateLimit(serviceID)
+
+	// Should get error immediately
+	_, err = lb.SelectService(rule)
+	assert.Error(t, err)
+
+	// Wait for recovery timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Service should be healthy again
+	service, err := lb.SelectService(rule)
+	assert.NoError(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "provider1", service.Provider)
+}
+
+// TestHealthFilter_SuccessRecovery tests that services recover immediately on success
+func TestHealthFilter_SuccessRecovery(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	healthConfig := loadbalance.DefaultHealthMonitorConfig()
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer lb.Stop()
+
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		UUID:         uuid.New().String(),
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider1",
+				Model:      "model1",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	serviceID := rule.Services[0].ServiceID()
+
+	// Mark service as unhealthy
+	healthMonitor.ReportRateLimit(serviceID)
+	assert.False(t, healthMonitor.IsHealthy(serviceID))
+
+	// Report success - should recover immediately
+	healthMonitor.ReportSuccess(serviceID)
+	assert.True(t, healthMonitor.IsHealthy(serviceID))
+
+	// Should be able to select service
+	service, err := lb.SelectService(rule)
+	assert.NoError(t, err)
+	assert.NotNil(t, service)
+}
+
+// TestHealthFilter_ConsecutiveErrors tests that consecutive errors mark service unhealthy
+func TestHealthFilter_ConsecutiveErrors(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	// Set low threshold for testing
+	healthConfig := loadbalance.HealthMonitorConfig{
+		ConsecutiveErrorThreshold: 2,
+		RecoveryTimeoutSeconds:    300,
+	}
+	healthMonitor := loadbalance.NewHealthMonitor(healthConfig)
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer lb.Stop()
+
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		UUID:         uuid.New().String(),
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider1",
+				Model:      "model1",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	serviceID := rule.Services[0].ServiceID()
+
+	// First error - should still be healthy
+	healthMonitor.ReportError(serviceID, assert.AnError)
+	assert.True(t, healthMonitor.IsHealthy(serviceID))
+
+	// Second error - should now be unhealthy (threshold = 2)
+	healthMonitor.ReportError(serviceID, assert.AnError)
+	assert.False(t, healthMonitor.IsHealthy(serviceID))
+
+	// Should get error
+	_, err = lb.SelectService(rule)
+	assert.Error(t, err)
+}
+
+// TestHealthFilter_InactiveServices tests that inactive services are not selected
+func TestHealthFilter_InactiveServices(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+
+	healthMonitor := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
+	defer lb.Stop()
+
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "test-model",
+		UUID:         uuid.New().String(),
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticRoundRobin,
+			Params: typ.DefaultRoundRobinParams(),
+		},
+		Services: []*loadbalance.Service{
+			{
+				Provider:   "provider-inactive",
+				Model:      "model1",
+				Weight:     1,
+				Active:     false, // Inactive
+				TimeWindow: 300,
+			},
+			{
+				Provider:   "provider-active",
+				Model:      "model2",
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			},
+		},
+		Active: true,
+	}
+
+	// Select service multiple times
+	for i := 0; i < 5; i++ {
+		service, err := lb.SelectService(rule)
+		require.NoError(t, err)
+		require.NotNil(t, service)
+		assert.Equal(t, "provider-active", service.Provider)
+	}
+}

--- a/internal/server/tests/load_balancing_test.go
+++ b/internal/server/tests/load_balancing_test.go
@@ -30,8 +30,11 @@ func TestLoadBalancer_RoundRobin(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Create test rule with multiple services using new LBTactic format
@@ -124,8 +127,11 @@ func TestLoadBalancer_EnabledFilter(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Create test rule with mixed enabled/disabled services
@@ -190,8 +196,11 @@ func TestLoadBalancer_RecordUsage(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Create a test service
@@ -228,8 +237,11 @@ func TestLoadBalancer_ValidateRule(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Test valid rule
@@ -291,8 +303,11 @@ func TestLoadBalancer_GetRuleSummary(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Create test rule
@@ -813,8 +828,11 @@ func TestLoadBalancer_WeightedRandom(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer - it already has all default tactics
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Create test rule with weighted services using new LBTactic format
@@ -930,8 +948,11 @@ func TestLoadBalancer_WithMockProvider(t *testing.T) {
 		t.Fatalf("Failed to add rule: %v", err)
 	}
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(ts.appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(ts.appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Test service selection
@@ -966,8 +987,11 @@ func TestLoadBalancer_RoundRobinThreshold2(t *testing.T) {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
 	require.NoError(t, err)
 
+	// Create health filter (nil for tests - all services healthy)
+	healthFilter := typ.NewHealthFilter(nil)
+
 	// Create load balancer
-	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig())
+	lb := server.NewLoadBalancer(appConfig.GetGlobalConfig(), healthFilter)
 	defer lb.Stop()
 
 	// Create test rule with 3 services to make the rotation more interesting

--- a/internal/typ/health_filter.go
+++ b/internal/typ/health_filter.go
@@ -1,0 +1,61 @@
+package typ
+
+import (
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// HealthFilter filters services based on their health status
+type HealthFilter struct {
+	monitor *loadbalance.HealthMonitor
+}
+
+// NewHealthFilter creates a new health filter with the given health monitor
+func NewHealthFilter(monitor *loadbalance.HealthMonitor) *HealthFilter {
+	return &HealthFilter{
+		monitor: monitor,
+	}
+}
+
+// Filter filters out unhealthy services from the given list
+// Returns only healthy services. If no healthy services are found,
+// returns an empty slice (not nil).
+func (hf *HealthFilter) Filter(services []*loadbalance.Service) []*loadbalance.Service {
+	if hf.monitor == nil {
+		// If no health monitor is configured, treat all services as healthy
+		return services
+	}
+
+	var healthy []*loadbalance.Service
+	for _, svc := range services {
+		if svc != nil && hf.monitor.IsHealthy(svc.ServiceID()) {
+			healthy = append(healthy, svc)
+		}
+	}
+	return healthy
+}
+
+// FilterWithFallback filters services and returns healthy ones.
+// If no healthy services are found, returns all services as a fallback.
+// This is useful when you want to avoid complete failure even if all
+// services are marked unhealthy.
+func (hf *HealthFilter) FilterWithFallback(services []*loadbalance.Service) []*loadbalance.Service {
+	healthy := hf.Filter(services)
+	if len(healthy) == 0 && len(services) > 0 {
+		// Fallback: return all services if none are healthy
+		return services
+	}
+	return healthy
+}
+
+// IsHealthy checks if a specific service is healthy
+func (hf *HealthFilter) IsHealthy(serviceID string) bool {
+	if hf.monitor == nil {
+		return true
+	}
+	return hf.monitor.IsHealthy(serviceID)
+}
+
+// GetHealthMonitor returns the underlying health monitor
+func (hf *HealthFilter) GetHealthMonitor() *loadbalance.HealthMonitor {
+	return hf.monitor
+}

--- a/internal/typ/health_filter_test.go
+++ b/internal/typ/health_filter_test.go
@@ -1,0 +1,170 @@
+package typ
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func TestNewHealthFilter(t *testing.T) {
+	// Test with nil monitor
+	hf := NewHealthFilter(nil)
+	assert.NotNil(t, hf)
+	assert.Nil(t, hf.monitor)
+}
+
+func TestHealthFilter_Filter_WithNilMonitor(t *testing.T) {
+	hf := NewHealthFilter(nil)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	// With nil monitor, all services should be returned
+	filtered := hf.Filter(services)
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, services, filtered)
+}
+
+func TestHealthFilter_Filter_AllHealthy(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	// All services should be healthy by default
+	filtered := hf.Filter(services)
+	assert.Len(t, filtered, 2)
+}
+
+func TestHealthFilter_Filter_WithUnhealthy(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	// Mark one service as unhealthy
+	monitor.ReportRateLimit("p1:m1")
+
+	filtered := hf.Filter(services)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "p2", filtered[0].Provider)
+}
+
+func TestHealthFilter_Filter_AllUnhealthy(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	// Mark all services as unhealthy
+	monitor.ReportRateLimit("p1:m1")
+	monitor.ReportRateLimit("p2:m2")
+
+	filtered := hf.Filter(services)
+	assert.Len(t, filtered, 0)
+}
+
+func TestHealthFilter_Filter_EmptyInput(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	filtered := hf.Filter([]*loadbalance.Service{})
+	assert.Len(t, filtered, 0)
+}
+
+func TestHealthFilter_Filter_WithNilService(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		nil,
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	filtered := hf.Filter(services)
+	assert.Len(t, filtered, 2)
+}
+
+func TestHealthFilter_FilterWithFallback(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	// Mark all services as unhealthy
+	monitor.ReportRateLimit("p1:m1")
+	monitor.ReportRateLimit("p2:m2")
+
+	// FilterWithFallback should return all services when none are healthy
+	filtered := hf.FilterWithFallback(services)
+	assert.Len(t, filtered, 2)
+}
+
+func TestHealthFilter_FilterWithFallback_HealthyExist(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	services := []*loadbalance.Service{
+		{Provider: "p1", Model: "m1", Active: true},
+		{Provider: "p2", Model: "m2", Active: true},
+	}
+
+	// Mark only one service as unhealthy
+	monitor.ReportRateLimit("p1:m1")
+
+	// FilterWithFallback should return only healthy services
+	filtered := hf.FilterWithFallback(services)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "p2", filtered[0].Provider)
+}
+
+func TestHealthFilter_IsHealthy(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	// Mark service as unhealthy
+	monitor.ReportRateLimit("p1:m1")
+
+	assert.False(t, hf.IsHealthy("p1:m1"))
+	assert.True(t, hf.IsHealthy("p2:m2"))
+}
+
+func TestHealthFilter_IsHealthy_NilMonitor(t *testing.T) {
+	hf := NewHealthFilter(nil)
+
+	// With nil monitor, everything is healthy
+	assert.True(t, hf.IsHealthy("p1:m1"))
+	assert.True(t, hf.IsHealthy("p2:m2"))
+}
+
+func TestHealthFilter_GetHealthMonitor(t *testing.T) {
+	config := loadbalance.DefaultHealthMonitorConfig()
+	monitor := loadbalance.NewHealthMonitor(config)
+	hf := NewHealthFilter(monitor)
+
+	assert.Equal(t, monitor, hf.GetHealthMonitor())
+}


### PR DESCRIPTION
### Service Health Check for Load Balancing

**Problem:**
When services, such as providers, are rate-limited (HTTP 429) or experience other errors (e.g., 401/403), the current round-robin load balancing mechanism may continue sending requests to them, leading to user-facing failures. There was no mechanism in place to detect unhealthy services and temporarily exclude them from the load balancing pool.

**Solution:**
This PR introduces a service health monitoring system, leveraging an efficient Filter + Picker architecture, which ensures that unhealthy services are excluded from the load balancing pool until they are deemed healthy again.

Key changes include:

1. **Health Monitor**: Tracks and updates the health status of services automatically based on various failure conditions.
2. **Health Filter**: Filters out unhealthy services before they are selected for load balancing.
3. **Probe-based Recovery**: Reuses the existing probe infrastructure to verify service health before marking a service as healthy again after recovery.

**How It Works:**

1. Requests are first passed through a **Health Filter** that checks the health of services.
2. The **Load Balancer Tactic** selects the next healthy service.
3. The **Health Monitor** reports on service health by tracking HTTP errors and using probes for recovery.

**Health State Transitions:**

| **Event**                        | **Action**                                 |
|----------------------------------|--------------------------------------------|
| 429 Rate Limit                   | Mark unhealthy immediately                 |
| 401/403 Auth Error               | Mark unhealthy immediately                 |
| 3 Consecutive Errors             | Mark unhealthy                             |
| Any Success                      | Mark healthy immediately                   |
| Recovery Timeout + Probe Success | Mark healthy                               |
| Recovery Timeout + Probe Fail    | Extend timeout                             |

**Key Features:**

- **Implicit Detection**: Health issues are detected through HTTP responses without requiring any special quota configuration.
- **Probe-based Recovery**: Services are probed before being marked as healthy again after a timeout, ensuring that recovery is validated.
- **Reuses Existing Infrastructure**: Utilizes the `AdaptiveProbe` system for health checks, ensuring consistent behavior across different service endpoints.
- **Configurable**: The health monitor is highly configurable with options for the recovery timeout, consecutive error thresholds, and enabling/disabling probes.

**Configuration:**
The following is set as default setting of health_monitor:
```yaml
health_monitor:
  consecutive_error_threshold: 3    # Mark service as unhealthy after N errors
  recovery_timeout_seconds: 300     # Auto-recovery timeout (5 minutes)
  probe_enabled: true               # Enable probe checks before recovery
```