### PR TITLE
minor: sqlite init with timeouts

### DIFF
--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -135,6 +135,15 @@ func verifyEnterpriseContextJWT(cfg *config.Config, rawToken string) (*enterpris
 			}
 			return []byte(secret), nil
 		case "RS256":
+			// If no public keys were provided, fall back to RS256PublicKeyRef.
+			if len(jwtCfg.PublicKeys) == 0 && strings.TrimSpace(jwtCfg.RS256PublicKeyRef) != "" {
+				ref, refErr := resolveSecretRef(jwtCfg.RS256PublicKeyRef)
+				if refErr == nil && strings.TrimSpace(ref) != "" {
+					if pub, parseErr := parseRSAPublicKeyFromPEM(ref); parseErr == nil {
+						return pub, nil
+					}
+				}
+			}
 			kid, _ := token.Header["kid"].(string)
 			kid = strings.TrimSpace(kid)
 			for _, item := range jwtCfg.PublicKeys {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -900,8 +900,12 @@ func (s *Server) Start(port int) error {
 
 	addr := fmt.Sprintf("%s:%d", s.host, port)
 	s.httpServer = &http.Server{
-		Addr:    addr,
-		Handler: s.engine,
+		Addr:              addr,
+		Handler:           s.engine,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      10 * time.Minute,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	resolvedHost := network.ResolveHost(s.host)


### PR DESCRIPTION
## Summary

- Align enterprise context JWT verification to use rs256_public_key_ref.
- Add HTTP server timeouts to harden request handling.

## Changes

- internal/server/middleware/auth.go: Read rs256_public_key_ref when validating enterprise context JWT.
- internal/server/server.go: Configure HTTP server timeouts.

