### PR TITLE
feat: enable local search and webfetch with soft-open mode by default

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -63,6 +63,10 @@ type Config struct {
 	// Value is the JSON-encoded config for that tool type
 	ToolConfigs map[string]json.RawMessage `json:"tool_configs,omitempty"`
 
+	// ToolInterceptorConfig is a shortcut for tool_interceptor config at top level
+	// This allows using "tool_interceptor" directly in config file
+	ToolInterceptorConfig *typ.ToolInterceptorConfig `json:"tool_interceptor,omitempty"`
+
 	// Error log settings
 	ErrorLogFilterExpression string `json:"error_log_filter_expression"` // Expression for filtering error log entries (default: "StatusCode >= 400 && (Path matches '^/api/' || Path matches '^/tbe/')")
 
@@ -1087,6 +1091,12 @@ func (c *Config) GetToolInterceptorConfig() *typ.ToolInterceptorConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	// First check the top-level tool_interceptor field
+	if c.ToolInterceptorConfig != nil {
+		return c.ToolInterceptorConfig
+	}
+
+	// Then check the tool_configs map
 	var config typ.ToolInterceptorConfig
 	if c.ToolConfigs != nil {
 		if data, ok := c.ToolConfigs[db.ToolTypeInterceptor]; ok {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -443,6 +443,33 @@ func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
 		return cfg.GetToolInterceptorConfigForProvider(providerUUID)
 	})
 
+	// Set global config for soft/hard open mode
+	// If no config is set, use default config to enable tool interception by default
+	globalConfig := cfg.GetToolInterceptorConfig()
+	if globalConfig == nil {
+		// Enable tool interceptor by default with soft-open mode
+		logrus.Infof("No tool_interceptor config found, using default config (enabled, soft-open mode)")
+		globalConfig = &typ.ToolInterceptorConfig{
+			PreferLocalSearch: false, // soft open by default
+			SearchAPI:         "duckduckgo",
+			ProxyURL:          "",
+			MaxResults:        5,
+			MaxFetchSize:      1 * 1024 * 1024,
+			FetchTimeout:      30,
+			MaxURLLength:      2000,
+		}
+		typ.ApplyToolInterceptorDefaults(globalConfig)
+
+		// Write default config to config file
+		cfg.ToolInterceptorConfig = globalConfig
+		if err := cfg.Save(); err != nil {
+			logrus.Warnf("Failed to save default tool_interceptor config: %v", err)
+		} else {
+			logrus.Infof("Default tool_interceptor config written to config file")
+		}
+	}
+	server.toolInterceptor.SetGlobalConfig(globalConfig)
+
 	// Initialize probe cache with 24-hour TTL
 	server.probeCache = NewProbeCache(24 * time.Hour)
 	// Start background cleanup task for expired cache entries

--- a/internal/server/tool_interceptor_logic.go
+++ b/internal/server/tool_interceptor_logic.go
@@ -8,8 +8,14 @@ import (
 
 // resolveToolInterceptor determines interception and tool stripping behavior for a provider.
 func (s *Server) resolveToolInterceptor(provider *typ.Provider, hasBuiltInWebSearch bool) (shouldIntercept bool, shouldStripTools bool, interceptorConfig *typ.ToolInterceptorConfig) {
+	// First check provider-specific config
 	if s.toolInterceptor != nil {
 		interceptorConfig = s.toolInterceptor.GetConfigForProvider(provider)
+	}
+
+	// If no provider-specific config, use global config
+	if interceptorConfig == nil && s.toolInterceptor != nil {
+		interceptorConfig = s.toolInterceptor.GetGlobalConfig()
 	}
 
 	shouldIntercept = interceptorConfig != nil && (bool(interceptorConfig.PreferLocalSearch) || !hasBuiltInWebSearch)

--- a/internal/toolinterceptor/alias.go
+++ b/internal/toolinterceptor/alias.go
@@ -12,16 +12,42 @@ const (
 // toolAliases maps various tool names to internal handler types
 var toolAliases = map[string]HandlerType{
 	// Search aliases
-	"web_search":    HandlerTypeSearch,
-	"Google Search": HandlerTypeSearch,
-	"search":        HandlerTypeSearch,
-	"bing_search":   HandlerTypeSearch,
+	"web_search":       HandlerTypeSearch,
+	"Google Search":    HandlerTypeSearch,
+	"search":           HandlerTypeSearch,
+	"bing_search":      HandlerTypeSearch,
+	"google_search":    HandlerTypeSearch,
+	"duckduckgo":       HandlerTypeSearch,
+	"ddg_search":       HandlerTypeSearch,
 
 	// Fetch aliases
 	"web_fetch":        HandlerTypeFetch,
 	"browse":           HandlerTypeFetch,
 	"read_url":         HandlerTypeFetch,
 	"get_page_content": HandlerTypeFetch,
+	"url_fetch":        HandlerTypeFetch,
+	"fetch_url":        HandlerTypeFetch,
+}
+
+// nativeSearchTools lists tool names that indicate the model has native search capability
+var nativeSearchTools = map[string]bool{
+	"web_search":    true,
+	"Google Search": true,
+	"google_search": true,
+	"bing_search":   true,
+	"duckduckgo":    true,
+	"ddg_search":    true,
+	"search":        true,
+}
+
+// nativeFetchTools lists tool names that indicate the model has native fetch capability
+var nativeFetchTools = map[string]bool{
+	"web_fetch":        true,
+	"browse":           true,
+	"read_url":         true,
+	"get_page_content": true,
+	"url_fetch":        true,
+	"fetch_url":        true,
 }
 
 // MatchToolAlias checks if a tool name matches any known alias and returns the handler type
@@ -46,4 +72,48 @@ func IsFetchTool(toolName string) bool {
 func ShouldInterceptTool(toolName string) bool {
 	_, matched := MatchToolAlias(toolName)
 	return matched
+}
+
+// HasNativeSearchTool checks if the model has a native search tool
+func HasNativeSearchTool(toolNames []string) bool {
+	for _, name := range toolNames {
+		if nativeSearchTools[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// HasNativeFetchTool checks if the model has a native fetch tool
+func HasNativeFetchTool(toolNames []string) bool {
+	for _, name := range toolNames {
+		if nativeFetchTools[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldInterceptSearch determines if search should be intercepted based on mode and native tools
+// preferLocal: true = hard open (always intercept), false = soft open (skip if model has native)
+// returns true if should intercept
+func ShouldInterceptSearch(preferLocal bool, modelToolNames []string) bool {
+	if preferLocal {
+		// Hard open: always intercept
+		return true
+	}
+	// Soft open: only intercept if model doesn't have native search
+	return !HasNativeSearchTool(modelToolNames)
+}
+
+// ShouldInterceptFetch determines if fetch should be intercepted based on mode and native tools
+// preferLocal: true = hard open (always intercept), false = soft open (skip if model has native)
+// returns true if should intercept
+func ShouldInterceptFetch(preferLocal bool, modelToolNames []string) bool {
+	if preferLocal {
+		// Hard open: always intercept
+		return true
+	}
+	// Soft open: only intercept if model doesn't have native fetch
+	return !HasNativeFetchTool(modelToolNames)
 }

--- a/internal/toolinterceptor/fetch.go
+++ b/internal/toolinterceptor/fetch.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-shiori/go-readability"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -77,11 +78,25 @@ func NewFetchHandlerWithConfig(cache *Cache, config *Config) *FetchHandler {
 		timeout = time.Duration(config.FetchTimeout) * time.Second
 	}
 
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	// Configure proxy if specified (like SearchHandler does)
+	if config.ProxyURL != "" {
+		proxyURL, err := url.Parse(config.ProxyURL)
+		if err != nil {
+			logrus.Warnf("Failed to parse proxy URL %s: %v", config.ProxyURL, err)
+		} else {
+			client.Transport = &http.Transport{
+				Proxy: http.ProxyURL(proxyURL),
+			}
+		}
+	}
+
 	return &FetchHandler{
-		cache: cache,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		cache:  cache,
+		client: client,
 		config: config,
 	}
 }

--- a/internal/toolinterceptor/interceptor.go
+++ b/internal/toolinterceptor/interceptor.go
@@ -67,6 +67,16 @@ func (i *Interceptor) GetConfigForProvider(provider *typ.Provider) *typ.ToolInte
 	return config
 }
 
+// SetGlobalConfig sets the global tool interceptor config
+func (i *Interceptor) SetGlobalConfig(config *typ.ToolInterceptorConfig) {
+	i.globalConfig = config
+}
+
+// GetGlobalConfig returns the global tool interceptor config
+func (i *Interceptor) GetGlobalConfig() *typ.ToolInterceptorConfig {
+	return i.globalConfig
+}
+
 // InterceptOpenAIRequest intercepts tool calls in an OpenAI request
 // Returns:
 // - intercepted: true if any tools were intercepted
@@ -76,6 +86,17 @@ func (i *Interceptor) InterceptOpenAIRequest(provider *typ.Provider, req *openai
 	// Check if enabled for this provider
 	if !i.IsEnabledForProvider(provider) || len(req.Tools) == 0 {
 		return false, nil, req.Tools
+	}
+
+	// Get global config for soft/hard open mode (default: soft open)
+	preferLocal := i.globalConfig != nil && bool(i.globalConfig.PreferLocalSearch)
+
+	// Extract model's native tool names for soft open check
+	modelToolNames := make([]string, 0, len(req.Tools))
+	for _, toolUnion := range req.Tools {
+		if fn := toolUnion.GetFunction(); fn != nil {
+			modelToolNames = append(modelToolNames, fn.Name)
+		}
 	}
 
 	results = []ToolResult{}
@@ -91,7 +112,7 @@ func (i *Interceptor) InterceptOpenAIRequest(provider *typ.Provider, req *openai
 		}
 
 		// Check if this tool should be intercepted
-		if !ShouldInterceptTool(fn.Name) {
+		if !i.shouldInterceptToolWithMode(fn.Name, preferLocal, modelToolNames) {
 			toolsToForward = append(toolsToForward, toolUnion)
 			continue
 		}
@@ -133,7 +154,7 @@ func (i *Interceptor) InterceptOpenAIRequest(provider *typ.Provider, req *openai
 			arguments, _ := fnMap["arguments"].(string)
 
 			// Check if this tool should be intercepted
-			if !ShouldInterceptTool(name) {
+			if !i.shouldInterceptToolWithMode(name, preferLocal, modelToolNames) {
 				continue
 			}
 
@@ -160,6 +181,17 @@ func (i *Interceptor) InterceptAnthropicRequest(provider *typ.Provider, req *ant
 		return false, nil, req.Tools
 	}
 
+	// Get global config for soft/hard open mode (default: soft open)
+	preferLocal := i.globalConfig != nil && bool(i.globalConfig.PreferLocalSearch)
+
+	// Extract model's native tool names for soft open check
+	modelToolNames := make([]string, 0, len(req.Tools))
+	for _, toolUnion := range req.Tools {
+		if tool := toolUnion.OfTool; tool != nil {
+			modelToolNames = append(modelToolNames, tool.Name)
+		}
+	}
+
 	results = []ToolResult{}
 	toolsToForward := []anthropic.ToolUnionParam{}
 
@@ -172,7 +204,7 @@ func (i *Interceptor) InterceptAnthropicRequest(provider *typ.Provider, req *ant
 		}
 
 		// Check if this tool should be intercepted
-		if !ShouldInterceptTool(tool.Name) {
+		if !i.shouldInterceptToolWithMode(tool.Name, preferLocal, modelToolNames) {
 			toolsToForward = append(toolsToForward, toolUnion)
 			continue
 		}
@@ -219,7 +251,7 @@ func (i *Interceptor) InterceptAnthropicRequest(provider *typ.Provider, req *ant
 			}
 
 			// Check if this tool should be intercepted
-			if !ShouldInterceptTool(name) {
+			if !i.shouldInterceptToolWithMode(name, preferLocal, modelToolNames) {
 				continue
 			}
 
@@ -246,6 +278,17 @@ func (i *Interceptor) InterceptAnthropicBetaRequest(provider *typ.Provider, req 
 		return false, nil, req.Tools
 	}
 
+	// Get global config for soft/hard open mode (default: soft open)
+	preferLocal := i.globalConfig != nil && bool(i.globalConfig.PreferLocalSearch)
+
+	// Extract model's native tool names for soft open check
+	modelToolNames := make([]string, 0, len(req.Tools))
+	for _, toolUnion := range req.Tools {
+		if tool := toolUnion.OfTool; tool != nil {
+			modelToolNames = append(modelToolNames, tool.Name)
+		}
+	}
+
 	results = []ToolResult{}
 	toolsToForward := []anthropic.BetaToolUnionParam{}
 
@@ -258,7 +301,7 @@ func (i *Interceptor) InterceptAnthropicBetaRequest(provider *typ.Provider, req 
 		}
 
 		// Check if this tool should be intercepted
-		if !ShouldInterceptTool(tool.Name) {
+		if !i.shouldInterceptToolWithMode(tool.Name, preferLocal, modelToolNames) {
 			toolsToForward = append(toolsToForward, toolUnion)
 			continue
 		}
@@ -277,7 +320,7 @@ func (i *Interceptor) InterceptAnthropicBetaRequest(provider *typ.Provider, req 
 			}
 
 			name := block.OfToolUse.Name
-			if !ShouldInterceptTool(name) {
+			if !i.shouldInterceptToolWithMode(name, preferLocal, modelToolNames) {
 				continue
 			}
 
@@ -342,9 +385,9 @@ func (i *Interceptor) PrepareOpenAIRequest(provider *typ.Provider, originalReq *
 	}
 
 	// Strip tool_choice if all tools were intercepted
-	if len(modifiedTools) == 0 && ShouldStripToolChoice(originalReq) {
-		// Reset tool_choice to default (empty/zero value)
-		// The empty ToolChoice will default to "auto" behavior
+	if len(modifiedTools) == 0 {
+		// Clear tool_choice when all tools are intercepted to prevent provider errors
+		// e.g., qwen returns "When using `tool_choice`, `tools` must be set"
 		modifiedReq.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{}
 	}
 
@@ -424,6 +467,30 @@ func (i *Interceptor) PrepareAnthropicBetaRequest(provider *typ.Provider, origin
 	return modifiedReq, false
 }
 
+// shouldInterceptToolWithMode determines if a tool should be intercepted based on mode and native tools
+// preferLocal: true = hard open (always intercept), false = soft open (skip if model has native)
+func (i *Interceptor) shouldInterceptToolWithMode(toolName string, preferLocal bool, modelToolNames []string) bool {
+	handlerType, matched := MatchToolAlias(toolName)
+	if !matched {
+		return false
+	}
+
+	if preferLocal {
+		// Hard open: always intercept
+		return true
+	}
+
+	// Soft open: check if model has native tool
+	switch handlerType {
+	case HandlerTypeSearch:
+		return !HasNativeSearchTool(modelToolNames)
+	case HandlerTypeFetch:
+		return !HasNativeFetchTool(modelToolNames)
+	default:
+		return false
+	}
+}
+
 // executeTool executes a tool by name with JSON arguments
 func (i *Interceptor) executeTool(provider *typ.Provider, toolName string, argsJSON string) ToolResult {
 	// Determine handler type based on tool name
@@ -465,12 +532,16 @@ func previewString(s string, max int) string {
 
 // executeSearch executes a search tool
 func (i *Interceptor) executeSearch(provider *typ.Provider, argsJSON string) ToolResult {
-	// Get provider-specific config
+	// Get provider-specific config first, then fall back to global config
 	providerConfig := i.GetConfigForProvider(provider)
+	if providerConfig == nil {
+		// Use global config as fallback
+		providerConfig = i.globalConfig
+	}
 	if providerConfig == nil {
 		return ToolResult{
 			Content: "",
-			Error:   "Search is not enabled for this provider",
+			Error:   "Search is not configured for this provider",
 			IsError: true,
 		}
 	}
@@ -521,6 +592,12 @@ func (i *Interceptor) executeSearch(provider *typ.Provider, argsJSON string) Too
 
 // executeFetch executes a fetch tool
 func (i *Interceptor) executeFetch(provider *typ.Provider, argsJSON string) ToolResult {
+	// Get provider-specific config first, then fall back to global config
+	providerConfig := i.GetConfigForProvider(provider)
+	if providerConfig == nil {
+		providerConfig = i.globalConfig
+	}
+
 	// Parse fetch arguments
 	var fetchReq FetchRequest
 	if err := json.Unmarshal([]byte(argsJSON), &fetchReq); err != nil {
@@ -539,8 +616,22 @@ func (i *Interceptor) executeFetch(provider *typ.Provider, argsJSON string) Tool
 		}
 	}
 
-	// Execute fetch
-	content, err := i.fetchHandler.FetchAndExtract(fetchReq.URL)
+	// Execute fetch with correct config (for proxy support)
+	var content string
+	var err error
+
+	// If we have a config with proxy, create a new handler with that config
+	if providerConfig != nil && providerConfig.ProxyURL != "" {
+		tempHandler := NewFetchHandlerWithConfig(i.cache, &Config{
+			ProxyURL:     providerConfig.ProxyURL,
+			MaxFetchSize: providerConfig.MaxFetchSize,
+			FetchTimeout: providerConfig.FetchTimeout,
+			MaxURLLength: providerConfig.MaxURLLength,
+		})
+		content, err = tempHandler.FetchAndExtract(fetchReq.URL)
+	} else {
+		content, err = i.fetchHandler.FetchAndExtract(fetchReq.URL)
+	}
 	if err != nil {
 		return ToolResult{
 			Content: "",
@@ -687,7 +778,7 @@ func StripSearchFetchToolsOpenAI(req *openai.ChatCompletionNewParams) *openai.Ch
 	}
 
 	req.Tools = filtered
-	if len(filtered) == 0 && ShouldStripToolChoice(req) {
+	if len(filtered) == 0 {
 		req.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{}
 	}
 

--- a/internal/toolinterceptor/search.go
+++ b/internal/toolinterceptor/search.go
@@ -87,6 +87,27 @@ func (h *SearchHandler) SearchWithConfig(query string, count int, config *Config
 		count = config.MaxResults
 	}
 
+	// Create HTTP client with proxy if specified in config
+	client := h.client
+	if config.ProxyURL != "" {
+		logrus.Infof("Using proxy for search: %s", config.ProxyURL)
+		proxyURL, err := url.Parse(config.ProxyURL)
+		if err != nil {
+			logrus.Warnf("Failed to parse proxy URL %s: %v", config.ProxyURL, err)
+		} else {
+			client = &http.Client{
+				Timeout: ddgTimeout,
+				Transport: &http.Transport{
+					Proxy: http.ProxyURL(proxyURL),
+					TLSClientConfig: nil, // Use default TLS config
+				},
+			}
+			logrus.Infof("Created HTTP client with proxy transport")
+		}
+	} else {
+		logrus.Infof("No proxy configured, using default client")
+	}
+
 	// Execute search based on configured API
 	var results []SearchResult
 	var err error
@@ -97,7 +118,7 @@ func (h *SearchHandler) SearchWithConfig(query string, count int, config *Config
 	case "google":
 		results, err = h.searchGoogleWithConfig(query, count, config)
 	case "duckduckgo", "ddg":
-		results, err = h.searchDuckDuckGo(query, count)
+		results, err = h.searchDuckDuckGoWithClient(query, count, client)
 	default:
 		err = fmt.Errorf("unsupported search API: %s (supported: brave, google, duckduckgo)", config.SearchAPI)
 	}
@@ -152,8 +173,8 @@ func (h *SearchHandler) searchBraveWithConfig(query string, count int, config *C
 	}
 	defer resp.Body.Close()
 
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
+	// Check status code - DuckDuckGo may return 200 OK or 202 Accepted
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != 202 {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("search API returned status %d: %s", resp.StatusCode, string(body))
 	}
@@ -220,6 +241,11 @@ type DuckDuckGoInstantAnswerAPIResponse struct {
 
 // searchDuckDuckGo executes a search using DuckDuckGo Instant Answer API (no API key required)
 func (h *SearchHandler) searchDuckDuckGo(query string, count int) ([]SearchResult, error) {
+	return h.searchDuckDuckGoWithClient(query, count, h.client)
+}
+
+// searchDuckDuckGoWithClient executes a search using DuckDuckGo with a custom HTTP client
+func (h *SearchHandler) searchDuckDuckGoWithClient(query string, count int, client *http.Client) ([]SearchResult, error) {
 	// Apply count limits
 	if count <= 0 || count > 20 {
 		count = 10
@@ -245,15 +271,17 @@ func (h *SearchHandler) searchDuckDuckGo(query string, count int) ([]SearchResul
 	// Set headers
 	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; TinglyBox/1.0)")
 
-	// Execute request using the handler's client (which may have proxy configured)
-	resp, err := h.client.Do(req)
+	// Execute request using the provided client (which has proxy configured)
+	logrus.Infof("Executing DuckDuckGo search request to: %s", apiURL.String())
+	resp, err := client.Do(req)
 	if err != nil {
+		logrus.Warnf("DuckDuckGo request failed: %v", err)
 		return nil, h.enrichSearchError(fmt.Errorf("search request failed: %w", err))
 	}
 	defer resp.Body.Close()
 
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
+	// Check status code - DuckDuckGo may return 200 OK or 202 Accepted
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != 202 {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("search returned status %d: %s", resp.StatusCode, string(body))
 	}
@@ -264,7 +292,7 @@ func (h *SearchHandler) searchDuckDuckGo(query string, count int) ([]SearchResul
 		// JSON parsing failed - DuckDuckGo might have changed format or returned error
 		// Fall back to HTML parsing
 		logrus.Debugf("DuckDuckGo JSON parsing failed: %v, falling back to HTML", err)
-		return h.searchDuckDuckGoHTML(query, count)
+		return h.searchDuckDuckGoHTMLWithClient(query, count, client)
 	}
 
 	// Convert to search results
@@ -319,7 +347,7 @@ func (h *SearchHandler) searchDuckDuckGo(query string, count int) ([]SearchResul
 
 	// If no results found, try HTML fallback
 	if len(results) == 0 {
-		return h.searchDuckDuckGoHTML(query, count)
+		return h.searchDuckDuckGoHTMLWithClient(query, count, client)
 	}
 
 	if len(results) == 0 {
@@ -331,6 +359,11 @@ func (h *SearchHandler) searchDuckDuckGo(query string, count int) ([]SearchResul
 
 // searchDuckDuckGoHTML executes a search using DuckDuckGo HTML (fallback)
 func (h *SearchHandler) searchDuckDuckGoHTML(query string, count int) ([]SearchResult, error) {
+	return h.searchDuckDuckGoHTMLWithClient(query, count, h.client)
+}
+
+// searchDuckDuckGoHTMLWithClient executes a search using DuckDuckGo HTML with a custom HTTP client
+func (h *SearchHandler) searchDuckDuckGoHTMLWithClient(query string, count int, client *http.Client) ([]SearchResult, error) {
 	// Apply count limits (DDG typically returns good results)
 	if count <= 0 || count > 20 {
 		count = 10
@@ -356,15 +389,15 @@ func (h *SearchHandler) searchDuckDuckGoHTML(query string, count int) ([]SearchR
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml")
 
-	// Execute request using the handler's client (which may have proxy configured)
-	resp, err := h.client.Do(req)
+	// Execute request using the provided client (which has proxy configured)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, h.enrichSearchError(fmt.Errorf("search request failed: %w", err))
 	}
 	defer resp.Body.Close()
 
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
+	// Check status code - DuckDuckGo may return 200 OK or 202 Accepted
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != 202 {
 		return nil, fmt.Errorf("search returned status %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
## Summary

- Enable local search (DuckDuckGo) and webfetch by default
- Implement soft-open mode: uses local tools only when model has no native search
- Add proxy support for search and fetch operations
- Auto-generate default config on first run

## Changes

- **config.go**: Add `ToolInterceptorConfig` field to read top-level config
- **server.go**: Auto-generate and save default tool_interceptor config
- **search.go**: Use proxy from config, accept 202 status code from DuckDuckGo
- **fetch.go**: Use proxy from config  
- **interceptor.go**: Fall back to global config when provider config is nil
- **alias.go**: Add native tool detection for soft-open mode logic

## Test plan

- [x] Test local search with qwen-plus through gateway
- [x] Test webfetch through gateway
- [x] Verify proxy is used for search requests
- [x] Verify default config is written to config file

## Test Commands

### Test 1: Direct Qwen API (no search)
```bash
curl -s https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions \
  -H "Authorization: Bearer <QWEN_API_KEY>" \
  -H "Content-Type: application/json" \
  -d '{"model": "qwen-plus", "messages": [{"role": "user", "content": "Who won the 2024 Nobel Prize in Physics?"}]}'
```

### Test 2: Gateway with web_search
```bash
curl -s "http://127.0.0.1:12580/tingly/openai/v1/chat/completions" \
  -H "Authorization: Bearer <TB_API_KEY>" \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen-plus","messages":[{"role":"system","content":"You are a helpful assistant. Use web_search tool when you need current information."},{"role":"user","content":"Who won the 2024 Nobel Prize in Physics?"}],"tools":[{"type":"function","function":{"name":"web_search","description":"Search the web for current information","parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}}],"tool_choice":"auto"}'
```

### Test 3: Direct Qwen API with web_fetch
```bash
curl -s https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions \
  -H "Authorization: Bearer <QWEN_API_KEY>" \
  -H "Content-Type: application/json" \
  -d '{"model": "qwen-plus", "messages": [{"role": "user", "content": "Fetch and summarize https://www.nobelprize.org/prizes/physics/2024/summary/"}]}'
```

### Test 4: Gateway with web_fetch
```bash
curl -s "http://127.0.0.1:12580/tingly/openai/v1/chat/completions" \
  -H "Authorization: Bearer <TB_API_KEY>" \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen-plus","messages":[{"role":"system","content":"You are a helpful assistant. Use web_fetch tool when you need to read webpage content."},{"role":"user","content":"Fetch and summarize https://www.nobelprize.org/prizes/physics/2024/summary/"}],"tools":[{"type":"function","function":{"name":"web_fetch","description":"Fetch content from a URL","parameters":{"type":"object","properties":{"url":{"type":"string"}},"required":["url"]}}],"tool_choice":"auto"}'
```

## Config example

```json
{
  "tool_interceptor": {
    "enabled": true,
    "prefer_local_search": false,
    "search_api": "duckduckgo",
    "proxy_url": "http://127.0.0.1:7897",
    "max_results": 5
  }
}
```