### PR TITLE
feat: add cursor compatibility mode for rule-based configuration

### DIFF
--- a/frontend/src/components/GraphSettingsMenu.tsx
+++ b/frontend/src/components/GraphSettingsMenu.tsx
@@ -5,6 +5,7 @@ import {
     Delete as DeleteIcon,
     Download as ExportIcon,
     Download as DownloadIcon,
+    Edit as EditIcon,
     PlayArrow as ProbeIcon,
     Settings as SettingsIcon,
     UnfoldMore as ExportMenuIcon,
@@ -22,11 +23,16 @@ export interface GraphSettingsMenuProps {
     active: boolean;
     allowToggleRule: boolean;
     saving: boolean;
+    cursorCompatEnabled?: boolean;
+    cursorCompatAutoEnabled?: boolean;
     onExport: (format: ExportFormat) => void;
     onExportAsJsonlToClipboard?: () => void;
     onExportAsBase64ToClipboard?: () => void;
     onDelete: () => void;
     onToggleActive: () => void;
+    onToggleCursorCompat?: () => void;
+    onToggleCursorCompatAuto?: () => void;
+    onEditFlags?: () => void;
     // Probe V2 props
     ruleUuid?: string;
     ruleName?: string;
@@ -39,11 +45,16 @@ export const GraphSettingsMenu = ({
     active,
     allowToggleRule,
     saving,
+    cursorCompatEnabled,
+    cursorCompatAutoEnabled,
     onExport,
     onExportAsJsonlToClipboard,
     onExportAsBase64ToClipboard,
     onDelete,
     onToggleActive,
+    onToggleCursorCompat,
+    onToggleCursorCompatAuto,
+    onEditFlags,
     ruleUuid,
     ruleName,
     scenario,
@@ -108,6 +119,40 @@ export const GraphSettingsMenu = ({
                         </>
                     )}
                 </MenuItem>
+
+                {onToggleCursorCompat && (
+                    <MenuItem onClick={() => { closeMenu(); onToggleCursorCompat(); }}>
+                        {cursorCompatEnabled ? (
+                            <>
+                                <ActiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Compatibility: On
+                            </>
+                        ) : (
+                            <>
+                                <InactiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Compatibility: Off
+                            </>
+                        )}
+                    </MenuItem>
+                )}
+
+                {onToggleCursorCompatAuto && (
+                    <MenuItem onClick={() => { closeMenu(); onToggleCursorCompatAuto(); }}>
+                        {cursorCompatAutoEnabled ? (
+                            <>
+                                <ActiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Auto-Detect: On
+                            </>
+                        ) : (
+                            <>
+                                <InactiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Auto-Detect: Off
+                            </>
+                        )}
+                    </MenuItem>
+                )}
+
+                {onEditFlags && (
+                    <MenuItem onClick={() => { closeMenu(); onEditFlags(); }}>
+                        <EditIcon fontSize="small" sx={{ mr: 1 }} />Edit flag
+                    </MenuItem>
+                )}
 
                 {allowDeleteRule && (
                     <MenuItem onClick={() => { closeMenu(); onDelete(); }} sx={{ color: 'error.main' }}>

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -38,9 +38,15 @@ export interface ConfigRecord {
     active: boolean;
     providers: ConfigProvider[];
     description?: string;
+    flags?: RuleFlags;
     // Smart routing fields
     smartEnabled?: boolean;
     smartRouting?: SmartRouting[];
+}
+
+export interface RuleFlags {
+    cursorCompat?: boolean;
+    cursorCompatAuto?: boolean;
 }
 
 export interface Rule {
@@ -50,6 +56,10 @@ export interface Rule {
     response_model?: string;
     active?: boolean;
     description?: string;
+    flags?: {
+        cursor_compat?: boolean;
+        cursor_compat_auto?: boolean;
+    };
     services?: Array<{
         id?: string;
         uuid?: string;

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -9,11 +9,12 @@ import {
     useRuleExport,
     useSmartRoutingHandlers,
 } from '@/components/rule-card/useRuleCardHooks';
-import { RuleCardDeleteDialog } from '@/components/rule-card/dialogs';
+import { RuleCardDeleteDialog, RuleFlagEditDialog } from '@/components/rule-card/dialogs';
 import RoutingGraph from '@/components/RoutingGraph';
 import SmartRoutingGraph from '@/components/SmartRoutingGraph';
 import SmartRuleEditDialog from '@/components/SmartRuleEditDialog';
 import GraphSettingsMenu from '@/components/GraphSettingsMenu';
+import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
 
 export interface RuleCardProps {
     rule: Rule;
@@ -82,6 +83,9 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 
     // Delete confirmation state
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [flagDialogOpen, setFlagDialogOpen] = useState(false);
+    const [flagInput, setFlagInput] = useState('');
+    const [flagError, setFlagError] = useState<string | undefined>(undefined);
 
     // Handler: Switch routing mode (simple toggle, preserves data)
     const handleRoutingModeSwitch = useCallback(async () => {
@@ -161,9 +165,34 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         }
     }, [rule.uuid, onRuleDelete, showNotification]);
 
-    if (!configRecord) return null;
-
     const isSmartMode = rule.smart_enabled;
+    const cursorCompatEnabled = configRecord?.flags?.cursorCompat || false;
+    const cursorCompatAutoEnabled = configRecord?.flags?.cursorCompatAuto || false;
+
+    const handleOpenFlagEditor = useCallback(() => {
+        if (!configRecord) return;
+        const currentFlags = formatRuleFlags(configRecord.flags);
+        if (!currentFlags && configRecord.requestModel === 'cursor') {
+            setFlagInput('cursor_compat=true');
+        } else {
+            setFlagInput(currentFlags);
+        }
+        setFlagError(undefined);
+        setFlagDialogOpen(true);
+    }, [configRecord]);
+
+    const handleSaveFlags = useCallback(async () => {
+        if (!configRecord) return;
+        const result = parseRuleFlags(flagInput);
+        if (result.error) {
+            setFlagError(result.error);
+            return;
+        }
+        await updateField(configRecord, setConfigRecord, 'flags', result.flags);
+        setFlagDialogOpen(false);
+    }, [configRecord, flagInput, updateField, setConfigRecord]);
+
+    if (!configRecord) return null;
 
     // Extra actions menu - shared between RoutingGraph and SmartRoutingGraph
     const extraActions = (
@@ -172,11 +201,22 @@ export const RuleCard: React.FC<RuleCardProps> = ({
             active={configRecord.active}
             allowToggleRule={allowToggleRule}
             saving={saving}
+            cursorCompatEnabled={cursorCompatEnabled}
+            cursorCompatAutoEnabled={cursorCompatAutoEnabled}
             onExport={handleExport}
             onExportAsJsonlToClipboard={handleExportAsJsonlToClipboard}
             onExportAsBase64ToClipboard={handleExportAsBase64ToClipboard}
             onDelete={handleDeleteButtonClick}
             onToggleActive={() => updateField(configRecord, setConfigRecord, 'active', !configRecord.active)}
+            onToggleCursorCompat={() => updateField(configRecord, setConfigRecord, 'flags', {
+                ...(configRecord.flags || {}),
+                cursorCompat: !cursorCompatEnabled,
+            })}
+            onToggleCursorCompatAuto={() => updateField(configRecord, setConfigRecord, 'flags', {
+                ...(configRecord.flags || {}),
+                cursorCompatAuto: !cursorCompatAutoEnabled,
+            })}
+            onEditFlags={handleOpenFlagEditor}
             ruleUuid={rule.uuid}
             ruleName={rule.request_model || rule.uuid}
             scenario={rule.scenario}
@@ -234,6 +274,19 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 
             {/* Delete Confirmation Dialog */}
             <RuleCardDeleteDialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)} onConfirm={confirmDeleteRule} />
+
+            {/* Flag Edit Dialog */}
+            <RuleFlagEditDialog
+                open={flagDialogOpen}
+                value={flagInput}
+                error={flagError}
+                onChange={(value) => {
+                    setFlagInput(value);
+                    if (flagError) setFlagError(undefined);
+                }}
+                onClose={() => setFlagDialogOpen(false)}
+                onSave={handleSaveFlags}
+            />
 
             {/* Smart Rule Edit Dialog */}
             <SmartRuleEditDialog

--- a/frontend/src/components/rule-card/dialogs.tsx
+++ b/frontend/src/components/rule-card/dialogs.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography } from '@mui/material';
+import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField, Typography } from '@mui/material';
 import type { ProbeResponse } from '@/client';
 import Probe from '@/components/ProbeModal';
 import type { ConfigRecord } from '@/components/RoutingGraphTypes';
@@ -89,6 +89,62 @@ export function RuleCardDeleteDialog({ open, onClose, onConfirm }: RuleCardDelet
                 </Button>
                 <Button onClick={onConfirm} color="error" variant="contained">
                     Delete
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+// ============================================================================
+// Rule Flag Edit Dialog
+// ============================================================================
+
+export interface RuleFlagEditDialogProps {
+    open: boolean;
+    value: string;
+    error?: string;
+    onChange: (value: string) => void;
+    onClose: () => void;
+    onSave: () => void;
+}
+
+export function RuleFlagEditDialog({ open, value, error, onChange, onClose, onSave }: RuleFlagEditDialogProps) {
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>Edit Rule Flags</DialogTitle>
+            <DialogContent>
+                <DialogContentText sx={{ mb: 2 }}>
+                    Use comma-separated key/value pairs. Example: <strong>cursor_compat=true,cursor_compat_auto=false</strong>
+                </DialogContentText>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    label="Flags"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    error={Boolean(error)}
+                    helperText={error || ' '}
+                    variant="standard"
+                    InputProps={{ disableUnderline: true }}
+                    sx={{
+                        '& .MuiInputBase-root': {
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            borderRadius: 2,
+                            padding: '10px 12px',
+                        },
+                        '& .MuiInputBase-input': {
+                            padding: 0,
+                        },
+                    }}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={onSave} color="primary" variant="contained">
+                    Save
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -111,6 +111,10 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                     response_model: newConfigRecord.responseModel,
                     active: newConfigRecord.active,
                     description: newConfigRecord.description,
+                    flags: {
+                        cursor_compat: newConfigRecord.flags?.cursorCompat || false,
+                        cursor_compat_auto: newConfigRecord.flags?.cursorCompatAuto || false,
+                    },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)
                         .map((provider) => ({
@@ -133,6 +137,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         response_model: ruleData.response_model,
                         active: ruleData.active,
                         description: ruleData.description,
+                        flags: ruleData.flags,
                         services: ruleData.services,
                         smart_enabled: ruleData.smart_enabled,
                         smart_routing: ruleData.smart_routing,

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { api } from '@/services/api';
-import type { SmartRouting, ConfigProvider, Rule, ConfigRecord } from '@/components/RoutingGraphTypes';
+import type { SmartRouting, ConfigProvider, Rule, ConfigRecord, RuleFlags } from '@/components/RoutingGraphTypes';
 
 // ============================================================================
 // Helper Functions
@@ -64,6 +64,10 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
         active: rule.active !== undefined ? rule.active : true,
         providers: providersList,
         description: rule.description,
+        flags: {
+            cursorCompat: rule.flags?.cursor_compat || false,
+            cursorCompatAuto: rule.flags?.cursor_compat_auto || false,
+        },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
     };
@@ -147,6 +151,10 @@ interface ExportRule {
     description?: string;
     services: any[];
     active?: boolean;
+    flags?: {
+        cursor_compat?: boolean;
+        cursor_compat_auto?: boolean;
+    };
     smart_enabled?: boolean;
     smart_routing: any[];
 }
@@ -165,6 +173,64 @@ interface ExportProvider {
     timeout?: number;
     tags?: string[];
     models?: any[];
+}
+
+// ============================================================================
+// Rule flag helpers
+// ============================================================================
+
+const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
+const FALSE_VALUES = new Set(['false', '0', 'no', 'off']);
+
+export function formatRuleFlags(flags?: RuleFlags): string {
+    if (!flags) return '';
+    const entries: string[] = [];
+    if (flags.cursorCompat) entries.push('cursor_compat=true');
+    if (flags.cursorCompatAuto) entries.push('cursor_compat_auto=true');
+    return entries.join(',');
+}
+
+export function parseRuleFlags(input: string): { flags: RuleFlags; error?: string } {
+    const flags: RuleFlags = {
+        cursorCompat: false,
+        cursorCompatAuto: false,
+    };
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+        return { flags };
+    }
+
+    const parts = trimmed.split(',').map((part) => part.trim()).filter(Boolean);
+    for (const part of parts) {
+        const [rawKey, rawValue] = part.split('=').map((chunk) => chunk.trim());
+        if (!rawKey || rawValue === undefined || rawValue === '') {
+            return { flags, error: `Invalid flag format: "${part}". Use key=value.` };
+        }
+
+        const valueLower = rawValue.toLowerCase();
+        let parsedValue: boolean;
+        if (TRUE_VALUES.has(valueLower)) {
+            parsedValue = true;
+        } else if (FALSE_VALUES.has(valueLower)) {
+            parsedValue = false;
+        } else {
+            return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use true/false.` };
+        }
+
+        switch (rawKey) {
+            case 'cursor_compat':
+                flags.cursorCompat = parsedValue;
+                break;
+            case 'cursor_compat_auto':
+                flags.cursorCompatAuto = parsedValue;
+                break;
+            default:
+                return { flags, error: `Unknown flag "${rawKey}".` };
+        }
+    }
+
+    return { flags };
 }
 
 // Generic export handler
@@ -365,6 +431,7 @@ function createRuleLine(rule: Rule): string {
         description: rule.description,
         services: rule.services || [],
         active: rule.active,
+        flags: rule.flags,
         smart_enabled: rule.smart_enabled,
         smart_routing: rule.smart_routing || [],
     } as ExportRule);

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -98,7 +98,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 					},
 				},
 			}
-			sendOpenAIStreamChunk(c, chunk)
+			sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
 
 		case "content_block_start":
 			// Content block starting
@@ -136,7 +136,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 						},
 					},
 				}
-				sendOpenAIStreamChunk(c, chunk)
+				sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
 			} else if event.ContentBlock.Type == "thinking" {
 				// Thinking block starting - reset thinking builder
 				thinkingText.Reset()
@@ -165,7 +165,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 						},
 					},
 				}
-				sendOpenAIStreamChunk(c, chunk)
+				sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
 			} else if event.Delta.Type == "input_json_delta" && event.Delta.PartialJSON != "" {
 				// Tool call arguments delta
 				args := event.Delta.PartialJSON
@@ -192,7 +192,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 						},
 					},
 				}
-				sendOpenAIStreamChunk(c, chunk)
+				sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
 			} else if event.Delta.Type == "thinking_delta" && event.Delta.Thinking != "" {
 				// Thinking content delta - convert to OpenAI's reasoning_content format
 				thinking := event.Delta.Thinking
@@ -200,7 +200,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 
 				// Send as reasoning_content - use custom chunk creation since reasoning_content is not a standard field
 				chunk := createReasoningContentChunk(chatID, created, responseModel, thinking)
-				sendOpenAIStreamChunk(c, chunk)
+				sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
 			}
 			// Note: signature_delta is intentionally ignored as OpenAI doesn't have an equivalent
 
@@ -253,7 +253,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 				}
 			}
 
-			sendOpenAIStreamChunk(c, chunk)
+			sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
 			// Send final [DONE] message
 			// MENTION: must keep extra space (matching openai_chat.go:462)
 			c.SSEvent("", " [DONE]")
@@ -289,8 +289,19 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 }
 
 // sendOpenAIStreamChunk sends a ChatCompletionChunk as SSE
-func sendOpenAIStreamChunk(c *gin.Context, chunk openai.ChatCompletionChunk) {
-	chunkJSON, err := json.Marshal(chunk)
+func sendOpenAIStreamChunk(c *gin.Context, chunk openai.ChatCompletionChunk, disableStreamUsage bool) {
+	chunkMap, err := chunkToMap(chunk)
+	if err != nil {
+		logrus.Errorf("Failed to convert chunk to map: %v", err)
+		return
+	}
+
+	// Cursor compatibility path must not expose usage in stream chunks.
+	if disableStreamUsage {
+		delete(chunkMap, "usage")
+	}
+
+	chunkJSON, err := json.Marshal(chunkMap)
 	if err != nil {
 		logrus.Errorf("Failed to marshal chunk: %v", err)
 		return
@@ -300,6 +311,18 @@ func sendOpenAIStreamChunk(c *gin.Context, chunk openai.ChatCompletionChunk) {
 	if flusher, ok := c.Writer.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+func chunkToMap(chunk openai.ChatCompletionChunk) (map[string]interface{}, error) {
+	bytes, err := json.Marshal(chunk)
+	if err != nil {
+		return nil, err
+	}
+	var chunkMap map[string]interface{}
+	if err := json.Unmarshal(bytes, &chunkMap); err != nil {
+		return nil, err
+	}
+	return chunkMap, nil
 }
 
 // sendOpenAIStreamChunk helper function to send a chunk in OpenAI format

--- a/internal/protocol/transform/ops/request_openai_deepseek.go
+++ b/internal/protocol/transform/ops/request_openai_deepseek.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -11,6 +12,9 @@ import (
 // This is required by DeepSeek's and Moonshot's reasoning models
 // The base conversion preserves thinking content in "x_thinking" field
 func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
+	if config.CursorCompat {
+		normalizeDeepSeekCursorContent(req)
+	}
 	// if has thinking, we should confirm each assistant contains `reasoning_content`
 	if config.HasThinking {
 		for i := range req.Messages {
@@ -42,6 +46,69 @@ func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, mo
 		}
 	}
 	return req
+}
+
+func normalizeDeepSeekCursorContent(req *openai.ChatCompletionNewParams) {
+	for i := range req.Messages {
+		msgMap, err := MessageToMap(req.Messages[i])
+		if err != nil {
+			continue
+		}
+		content, ok := msgMap["content"]
+		if !ok {
+			continue
+		}
+		contentParts, ok := content.([]interface{})
+		if !ok {
+			continue
+		}
+		flattened, _ := flattenRichContent(contentParts)
+		msgMap["content"] = flattened
+
+		updatedBytes, err := json.Marshal(msgMap)
+		if err != nil {
+			continue
+		}
+		var updated openai.ChatCompletionMessageParamUnion
+		if err := json.Unmarshal(updatedBytes, &updated); err != nil {
+			continue
+		}
+		req.Messages[i] = updated
+	}
+}
+
+func flattenRichContent(parts []interface{}) (string, bool) {
+	var segments []string
+	var dropped bool
+	for _, part := range parts {
+		switch value := part.(type) {
+		case string:
+			if strings.TrimSpace(value) != "" {
+				segments = append(segments, value)
+			}
+		case map[string]interface{}:
+			if textValue, ok := value["text"].(string); ok {
+				if strings.TrimSpace(textValue) != "" {
+					segments = append(segments, textValue)
+				}
+			} else if contentValue, ok := value["content"].(string); ok {
+				if strings.TrimSpace(contentValue) != "" {
+					segments = append(segments, contentValue)
+				}
+			} else {
+				dropped = true
+			}
+		default:
+			dropped = true
+		}
+	}
+	if len(segments) == 0 && dropped {
+		return "[non-text content omitted]", true
+	}
+	if dropped {
+		segments = append(segments, "[non-text content omitted]")
+	}
+	return strings.Join(segments, "\n"), dropped
 }
 
 // MessageToMap converts a ChatCompletionMessageParamUnion to a map for modification

--- a/internal/protocol/transform/ops/request_openai_extensions.go
+++ b/internal/protocol/transform/ops/request_openai_extensions.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
@@ -85,6 +86,58 @@ func GetProviderTransform(providerURL, model string) ProviderTransform {
 	return nil
 }
 
+// normalizeCursorContent flattens rich content in messages for Cursor compatibility.
+// This should be applied for ALL providers when cursor_compat is enabled.
+func normalizeCursorContent(req *openai.ChatCompletionNewParams) {
+	for i := range req.Messages {
+		msgMap, err := messageToMap(req.Messages[i])
+		if err != nil {
+			continue
+		}
+		content, ok := msgMap["content"]
+		if !ok {
+			continue
+		}
+		contentParts, ok := content.([]interface{})
+		if !ok {
+			continue
+		}
+		flattened, _ := flattenRichContent(contentParts)
+		msgMap["content"] = flattened
+
+		updatedBytes, err := json.Marshal(msgMap)
+		if err != nil {
+			continue
+		}
+		var updated openai.ChatCompletionMessageParamUnion
+		if err := json.Unmarshal(updatedBytes, &updated); err != nil {
+			continue
+		}
+		req.Messages[i] = updated
+	}
+}
+
+// ApplyCursorCompatContentNormalization is the exported version of normalizeCursorContent.
+// It flattens rich content in messages for Cursor compatibility.
+// This should be called for ALL providers when cursor_compat is enabled.
+func ApplyCursorCompatContentNormalization(req *openai.ChatCompletionNewParams) {
+	normalizeCursorContent(req)
+}
+
+// messageToMap converts a ChatCompletionMessageParamUnion to a map for modification
+func messageToMap(msg openai.ChatCompletionMessageParamUnion) (map[string]interface{}, error) {
+	msgBytes, err := json.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(msgBytes, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // applyDefaultTransform applies default transformations for OpenAI-compatible requests
 // This handles standard fields like reasoning_effort that are widely supported
 func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
@@ -113,6 +166,11 @@ func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol
 // ApplyProviderTransforms applies provider-specific transformations
 // Falls back to default handling if no specific transform found
 func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
+	// When cursor_compat is enabled, ALWAYS flatten content regardless of provider
+	// This ensures Cursor compatibility for all providers
+	if config.CursorCompat {
+		normalizeCursorContent(req)
+	}
 	if transform := GetProviderTransform(providerURL, model); transform != nil {
 		return transform(req, providerURL, model, config)
 	}

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -47,6 +47,9 @@ type OpenAIConfig struct {
 	// Defaults to "low" when HasThinking is true
 	ReasoningEffort shared.ReasoningEffort
 
+	// CursorCompat indicates Cursor compatibility handling is enabled for this request.
+	CursorCompat bool
+
 	// Future fields can be added here as needed for provider-specific transformations
 }
 

--- a/internal/server/cursor_compat.go
+++ b/internal/server/cursor_compat.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+const cursorCompatExtraField = "__tb_cursor_compat"
+
+// resolveCursorCompat determines whether Cursor compatibility handling should be enabled.
+// Primary mechanism is rule flags; optional auto-detection is enabled via rule flags.
+func resolveCursorCompat(c *gin.Context, rule *typ.Rule) bool {
+	if rule == nil {
+		return false
+	}
+
+	flags := rule.Flags
+	if flags.CursorCompat {
+		return true
+	}
+	if flags.CursorCompatAuto && isCursorRequest(c) {
+		return true
+	}
+	return false
+}
+
+func isCursorRequest(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	userAgent := strings.ToLower(c.GetHeader("User-Agent"))
+	if strings.Contains(userAgent, "cursor") {
+		return true
+	}
+	clientName := strings.ToLower(c.GetHeader("X-Client-Name"))
+	if clientName == "cursor" {
+		return true
+	}
+	clientApp := strings.ToLower(c.GetHeader("X-Client-App"))
+	if strings.Contains(clientApp, "cursor") {
+		return true
+	}
+	return false
+}
+
+// applyCursorCompatFlag embeds a transient flag in request extra fields for downstream transforms.
+// The flag is stripped before sending to the provider.
+func applyCursorCompatFlag(req *openai.ChatCompletionNewParams, enabled bool) {
+	if req == nil || !enabled {
+		return
+	}
+	extra := req.ExtraFields()
+	if extra == nil {
+		extra = map[string]interface{}{}
+	}
+	extra[cursorCompatExtraField] = true
+	req.SetExtraFields(extra)
+}

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/request"
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -200,6 +201,8 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	isStreaming := req.Stream
 	actualModel := req.Model
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
+	cursorCompat := resolveCursorCompat(c, rule)
+	applyCursorCompatFlag(&req.ChatCompletionNewParams, cursorCompat)
 
 	// Set tracking context with all metadata (eliminates need for explicit parameter passing)
 	SetTrackingContext(c, rule, provider, actualModel, responseModel, isStreaming)
@@ -221,6 +224,12 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 		})
 		return
 	case protocol.APIStyleAnthropic:
+		// Apply cursor_compat content normalization before converting to Anthropic format
+		// This ensures rich content is flattened for all providers when cursor_compat is enabled
+		if cursorCompat {
+			ops.ApplyCursorCompatContentNormalization(&req.ChatCompletionNewParams)
+		}
+
 		anthropicReq := request.ConvertOpenAIToAnthropicRequest(&req.ChatCompletionNewParams, int64(maxAllowed))
 		if isStreaming {
 			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
@@ -242,9 +251,9 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 			}
 
 			// Get scenario config for DisableStreamUsage flag
-			disableStreamUsage := false
+			disableStreamUsage := cursorCompat
 			if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
-				disableStreamUsage = scenarioConfig.Flags.DisableStreamUsage
+				disableStreamUsage = disableStreamUsage || scenarioConfig.Flags.DisableStreamUsage
 			}
 
 			inputTokens, outputTokens, err := stream.HandleAnthropicToOpenAIStreamResponse(c, &anthropicReq, streamResp, responseModel, disableStreamUsage)
@@ -310,6 +319,9 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 				}
 				openaiResp = roundtripped
 			}
+			if cursorCompat {
+				delete(openaiResp, "usage")
+			}
 			c.JSON(http.StatusOK, openaiResp)
 			return
 		}
@@ -324,11 +336,17 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 			return
 		}
 
+		// Cap max_tokens at the model's maximum to prevent API errors
+		// This is critical for providers like DeepSeek which have strict max_tokens limits
+		if req.MaxTokens.Valid() && req.MaxTokens.Value > int64(maxAllowed) {
+			req.MaxTokens.Value = int64(maxAllowed)
+		}
+
 		// Use Transform Chain for request transformation (Consistency + Vendor transforms)
 		// Note: Base transform is not needed since the request is already in OpenAI Chat format
 		// Chain: Consistency Transform → Vendor Transform
 		chain := transform.NewTransformChain([]transform.Transform{
-			//transform.NewConsistencyTransform(transform.TargetAPIStyleOpenAIChat),
+			transform.NewConsistencyTransform(transform.TargetAPIStyleOpenAIChat),
 			transform.NewVendorTransform(provider.APIBase),
 		})
 
@@ -363,14 +381,14 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 
 		if isStreaming {
 			// Get scenario config for DisableStreamUsage flag
-			disableStreamUsage := false
+			disableStreamUsage := cursorCompat
 			if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
-				disableStreamUsage = scenarioConfig.Flags.DisableStreamUsage
+				disableStreamUsage = disableStreamUsage || scenarioConfig.Flags.DisableStreamUsage
 			}
 
 			s.handleOpenAIChatStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools, disableStreamUsage)
 		} else {
-			s.handleNonStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools)
+			s.handleNonStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools, cursorCompat)
 		}
 	}
 }

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -25,7 +25,7 @@ import (
 )
 
 // handleNonStreamingRequest handles non-streaming chat completion requests
-func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provider, originalReq *openai.ChatCompletionNewParams, responseModel string, shouldIntercept, shouldStripTools bool) {
+func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provider, originalReq *openai.ChatCompletionNewParams, responseModel string, shouldIntercept, shouldStripTools bool, stripUsage bool) {
 	// === PRE-REQUEST INTERCEPTION: Strip tools before sending to provider ===
 	req := originalReq
 	if shouldIntercept {
@@ -93,6 +93,9 @@ func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provide
 				var responseMap map[string]interface{}
 				json.Unmarshal(responseJSON, &responseMap)
 				responseMap["model"] = responseModel
+				if stripUsage {
+					delete(responseMap, "usage")
+				}
 				c.JSON(http.StatusOK, responseMap)
 				return
 			}
@@ -133,6 +136,9 @@ func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provide
 
 	// Update response model if configured
 	responseMap["model"] = responseModel
+	if stripUsage {
+		delete(responseMap, "usage")
+	}
 
 	if ShouldRoundtripResponse(c, "anthropic") {
 		roundtripped, err := RoundtripOpenAIResponseViaAnthropic(response, responseModel, provider, req.Model)
@@ -147,6 +153,9 @@ func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provide
 		}
 		responseMap = roundtripped
 		responseMap["model"] = responseModel
+		if stripUsage {
+			delete(responseMap, "usage")
+		}
 	}
 
 	// Return modified response

--- a/internal/server/protocol_forward.go
+++ b/internal/server/protocol_forward.go
@@ -122,6 +122,11 @@ func ForwardOpenAIChatStream(fc *ForwardContext, wrapper *client.OpenAIClient, r
 
 	ctx, cancel := fc.PrepareContext(req)
 
+	// Apply provider-specific transformations
+	config := buildOpenAIConfig(req)
+	transformedReq := ops.ApplyProviderTransforms(req, fc.Provider.APIBase, string(req.Model), config)
+	*req = *transformedReq
+
 	stream := wrapper.ChatCompletionsNewStreaming(ctx, *req)
 	return stream, cancel, nil
 }
@@ -192,6 +197,16 @@ func buildOpenAIConfig(req *openai.ChatCompletionNewParams) *protocol.OpenAIConf
 
 	// Check if request has thinking configuration in extra_fields
 	extraFields := req.ExtraFields()
+	if extraFields == nil {
+		extraFields = map[string]interface{}{}
+	}
+	if cursorCompatRaw, ok := extraFields[cursorCompatExtraField]; ok {
+		if enabled, ok := cursorCompatRaw.(bool); ok && enabled {
+			config.CursorCompat = true
+		}
+		delete(extraFields, cursorCompatExtraField)
+		req.SetExtraFields(extraFields)
+	}
 	if thinking, ok := extraFields["thinking"]; ok {
 		if _, ok := thinking.(map[string]interface{}); ok {
 			config.HasThinking = true

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -112,7 +112,8 @@ func IsValidRecordingMode(mode string) bool {
 	}
 }
 
-// ScenarioFlags represents configuration flags for a scenario
+// ScenarioFlags represents legacy scenario-level feature flags.
+// These are global per scenario and are not a replacement for rule-level flags.
 type ScenarioFlags struct {
 	Unified  bool `json:"unified" yaml:"unified"`   // Single configuration for all models
 	Separate bool `json:"separate" yaml:"separate"` // Separate configuration for each model
@@ -137,8 +138,9 @@ type ScenarioFlags struct {
 	CleanHeader bool `json:"clean_header,omitempty" yaml:"clean_header,omitempty"` // Remove billing header from system messages (Claude Code only)
 }
 
-// RuleFlags represents configuration flags for a specific rule.
-// These flags are applied at rule-match time and are independent of scenario flags.
+// RuleFlags represents per-rule feature flags.
+// For routing behavior that should vary by rule (for example cursor compatibility),
+// add flags here instead of ScenarioFlags.
 type RuleFlags struct {
 	// CursorCompat enables Cursor compatibility handling (rich content normalization, stream usage stripping, tool gating).
 	CursorCompat bool `json:"cursor_compat,omitempty" yaml:"cursor_compat,omitempty"`

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -137,6 +137,16 @@ type ScenarioFlags struct {
 	CleanHeader bool `json:"clean_header,omitempty" yaml:"clean_header,omitempty"` // Remove billing header from system messages (Claude Code only)
 }
 
+// RuleFlags represents configuration flags for a specific rule.
+// These flags are applied at rule-match time and are independent of scenario flags.
+type RuleFlags struct {
+	// CursorCompat enables Cursor compatibility handling (rich content normalization, stream usage stripping, tool gating).
+	CursorCompat bool `json:"cursor_compat,omitempty" yaml:"cursor_compat,omitempty"`
+
+	// CursorCompatAuto enables Cursor auto-detection based on request headers.
+	CursorCompatAuto bool `json:"cursor_compat_auto,omitempty" yaml:"cursor_compat_auto,omitempty"`
+}
+
 // ScenarioConfig represents configuration for a specific scenario
 type ScenarioConfig struct {
 	Scenario   RuleScenario           `json:"scenario" yaml:"scenario"`
@@ -303,6 +313,8 @@ type Rule struct {
 	ResponseModel string                 `json:"response_model" yaml:"response_model"`
 	Description   string                 `json:"description"`
 	Services      []*loadbalance.Service `json:"services" yaml:"services"`
+	// RuleFlags represents configuration flags for a specific rule (e.g., cursor_compat)
+	Flags         RuleFlags `json:"flags,omitempty" yaml:"flags,omitempty"`
 	// CurrentServiceID is persisted to SQLite, not JSON (provider:model format)
 	// This identifies the current service for round-robin load balancing
 	CurrentServiceID string `json:"-" yaml:"-"`

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -112,8 +112,7 @@ func IsValidRecordingMode(mode string) bool {
 	}
 }
 
-// ScenarioFlags represents legacy scenario-level feature flags.
-// These are global per scenario and are not a replacement for rule-level flags.
+// ScenarioFlags represents configuration flags for a scenario
 type ScenarioFlags struct {
 	Unified  bool `json:"unified" yaml:"unified"`   // Single configuration for all models
 	Separate bool `json:"separate" yaml:"separate"` // Separate configuration for each model
@@ -139,8 +138,6 @@ type ScenarioFlags struct {
 }
 
 // RuleFlags represents per-rule feature flags.
-// For routing behavior that should vary by rule (for example cursor compatibility),
-// add flags here instead of ScenarioFlags.
 type RuleFlags struct {
 	// CursorCompat enables Cursor compatibility handling (rich content normalization, stream usage stripping, tool gating).
 	CursorCompat bool `json:"cursor_compat,omitempty" yaml:"cursor_compat,omitempty"`
@@ -315,7 +312,7 @@ type Rule struct {
 	ResponseModel string                 `json:"response_model" yaml:"response_model"`
 	Description   string                 `json:"description"`
 	Services      []*loadbalance.Service `json:"services" yaml:"services"`
-	// RuleFlags represents configuration flags for a specific rule (e.g., cursor_compat)
+	// Per-rule feature flags (e.g. cursor_compat / cursor_compat_auto).
 	Flags         RuleFlags `json:"flags,omitempty" yaml:"flags,omitempty"`
 	// CurrentServiceID is persisted to SQLite, not JSON (provider:model format)
 	// This identifies the current service for round-robin load balancing


### PR DESCRIPTION
## Summary

Adds `cursor_compat` and `cursor_compat_auto` rule flags that enable Cursor-specific request/response handling.

### Backend Changes
- `RuleFlags` struct with `cursor_compat` and `cursor_compat_auto` boolean fields on the `Rule` type
- `resolveCursorCompat()` detects enabled flag or auto-detects via User-Agent/X-Client headers
- `applyCursorCompatFlag()` embeds transient flag in request extra fields for downstream transforms
- `OpenAIConfig.CursorCompat` field propagated to vendor transform pipeline
- `ApplyCursorCompatContentNormalization` flattens rich content blocks for Anthropic requests
- `normalizeCursorContent` for OpenAI/DeepSeek provider transforms
- Usage stripping in non-streaming and streaming responses when enabled

### Frontend Changes
- Toggle `cursor_compat` and `cursor_compat_auto` via GraphSettingsMenu
- `RuleFlagEditDialog` for manual key=value flag editing
- Flags serialized in rule configuration and persisted via auto-save

## Test plan
- [ ] Verify cursor_compat toggle appears in GraphSettingsMenu for active rules
- [ ] Verify flags persist after page reload
- [ ] Verify requests with cursor_compat enabled produce normalized content
- [ ] Verify usage field stripped from non-streaming responses when enabled
- [ ] Verify streaming chunks have no usage data when enabled