### PR TITLE
fix: convert toolCall.Function.Arguments string to map[string]interface{} for NewToolUseBlock

### DIFF
--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -58,7 +58,11 @@ func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model s
 		// Convert tool_calls to tool_use blocks
 		if len(choice.Message.ToolCalls) > 0 {
 			for _, toolCall := range choice.Message.ToolCalls {
-				contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(toolCall.ID, toolCall.Function.Arguments, toolCall.Function.Name))
+				var input map[string]interface{}
+				if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
+					input = make(map[string]interface{})
+				}
+				contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
 			}
 
 			// If there were tool calls, set stop_reason to tool_use
@@ -127,7 +131,11 @@ func ConvertOpenAIToAnthropicBetaResponse(openaiResp *openai.ChatCompletion, mod
 		// Convert tool_calls to tool_use blocks
 		if len(choice.Message.ToolCalls) > 0 {
 			for _, toolCall := range choice.Message.ToolCalls {
-				contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(toolCall.ID, toolCall.Function.Arguments, toolCall.Function.Name))
+				var input map[string]interface{}
+				if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
+					input = make(map[string]interface{})
+				}
+				contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
 			}
 
 			// If there were tool calls, set stop_reason to tool_use


### PR DESCRIPTION
Fix type conversion in ConvertOpenAIToAnthropicResponse and ConvertOpenAIToAnthropicBetaResponse functions. The input field of tool_use block requires map[string]interface{} instead of string.