### PR TITLE
fix: enable ConsistencyTransform, align tool messages, cap thinking budget

### DIFF
--- a/internal/protocol/transform/consistency.go
+++ b/internal/protocol/transform/consistency.go
@@ -245,25 +245,29 @@ func AlignToolMessagesForOpenAI(req *openai.ChatCompletionNewParams) {
 	// Convert orphaned tool messages to user messages
 	for i := range req.Messages {
 		if req.Messages[i].OfTool != nil {
-			if msgBytes, err := json.Marshal(req.Messages[i]); err == nil {
-				var toolMsg map[string]interface{}
-				if err := json.Unmarshal(msgBytes, &toolMsg); err == nil {
-					if toolCallID, ok := toolMsg["tool_call_id"].(string); ok {
-						if !validToolCallIDs[toolCallID] {
-							// Orphaned tool message, convert to user message
-							toolMsg["role"] = "user"
-							delete(toolMsg, "tool_call_id")
-
-							if newBytes, err := json.Marshal(toolMsg); err == nil {
-								var updatedMsg openai.ChatCompletionMessageParamUnion
-								if err := json.Unmarshal(newBytes, &updatedMsg); err == nil {
-									req.Messages[i] = updatedMsg
-								}
-							}
-						}
-					}
-				}
+			toolMsg := req.Messages[i].OfTool
+			toolCallID := toolMsg.ToolCallID
+			if toolCallID == "" || validToolCallIDs[toolCallID] {
+				continue
 			}
+
+			// Orphaned tool message, convert to user message.
+			// Tool content supports string or text parts; map both to user content.
+			if toolMsg.Content.OfString.Valid() {
+				req.Messages[i] = openai.UserMessage(toolMsg.Content.OfString.Value)
+				continue
+			}
+
+			if len(toolMsg.Content.OfArrayOfContentParts) > 0 {
+				parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(toolMsg.Content.OfArrayOfContentParts))
+				for _, part := range toolMsg.Content.OfArrayOfContentParts {
+					parts = append(parts, openai.TextContentPart(part.Text))
+				}
+				req.Messages[i] = openai.UserMessage(parts)
+				continue
+			}
+
+			req.Messages[i] = openai.UserMessage("")
 		}
 	}
 }

--- a/internal/protocol/transform/consistency.go
+++ b/internal/protocol/transform/consistency.go
@@ -162,6 +162,9 @@ func (t *ConsistencyTransform) normalizeMessages(req *openai.ChatCompletionNewPa
 		return
 	}
 
+	// First, align tool messages to ensure they follow assistant messages with tool_calls
+	t.alignToolMessages(req)
+
 	for i := range req.Messages {
 		// Check if this is a tool message
 		if req.Messages[i].OfTool != nil {
@@ -216,6 +219,69 @@ func (t *ConsistencyTransform) normalizeMessages(req *openai.ChatCompletionNewPa
 			}
 		}
 	}
+}
+
+// AlignToolMessagesForOpenAI converts orphaned tool messages (those without a
+// matching tool_call_id) to user messages. This prevents "role 'tool' must be a
+// response to preceding message with 'tool_calls'" errors.
+func AlignToolMessagesForOpenAI(req *openai.ChatCompletionNewParams) {
+	if len(req.Messages) == 0 {
+		return
+	}
+
+	// Collect all valid tool_call_ids from assistant messages
+	validToolCallIDs := make(map[string]bool)
+	for _, msg := range req.Messages {
+		if msg.OfAssistant != nil {
+			if msgBytes, err := json.Marshal(msg); err == nil {
+				var assistantMsg map[string]interface{}
+				if err := json.Unmarshal(msgBytes, &assistantMsg); err == nil {
+					if toolCalls, ok := assistantMsg["tool_calls"].([]interface{}); ok {
+						for _, tc := range toolCalls {
+							if tcMap, ok := tc.(map[string]interface{}); ok {
+								if id, ok := tcMap["id"].(string); ok {
+									validToolCallIDs[id] = true
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Convert orphaned tool messages to user messages
+	for i := range req.Messages {
+		if req.Messages[i].OfTool != nil {
+			if msgBytes, err := json.Marshal(req.Messages[i]); err == nil {
+				var toolMsg map[string]interface{}
+				if err := json.Unmarshal(msgBytes, &toolMsg); err == nil {
+					if toolCallID, ok := toolMsg["tool_call_id"].(string); ok {
+						if !validToolCallIDs[toolCallID] {
+							// Orphaned tool message, convert to user message
+							toolMsg["role"] = "user"
+							delete(toolMsg, "tool_call_id")
+
+							if newBytes, err := json.Marshal(toolMsg); err == nil {
+								var updatedMsg openai.ChatCompletionMessageParamUnion
+								if err := json.Unmarshal(newBytes, &updatedMsg); err == nil {
+									req.Messages[i] = updatedMsg
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// alignToolMessages ensures tool messages follow assistant messages with tool_calls.
+// OpenAI API requires that messages with role "tool" must be a response to a preceding
+// message with "tool_calls". This function converts orphaned tool messages to user messages.
+func (t *ConsistencyTransform) alignToolMessages(req *openai.ChatCompletionNewParams) {
+	// Delegate to the public function
+	AlignToolMessagesForOpenAI(req)
 }
 
 // validateChatCompletion validates request parameters against OpenAI API constraints.

--- a/internal/protocol/transform/consistency.go
+++ b/internal/protocol/transform/consistency.go
@@ -232,20 +232,12 @@ func AlignToolMessagesForOpenAI(req *openai.ChatCompletionNewParams) {
 	// Collect all valid tool_call_ids from assistant messages
 	validToolCallIDs := make(map[string]bool)
 	for _, msg := range req.Messages {
-		if msg.OfAssistant != nil {
-			if msgBytes, err := json.Marshal(msg); err == nil {
-				var assistantMsg map[string]interface{}
-				if err := json.Unmarshal(msgBytes, &assistantMsg); err == nil {
-					if toolCalls, ok := assistantMsg["tool_calls"].([]interface{}); ok {
-						for _, tc := range toolCalls {
-							if tcMap, ok := tc.(map[string]interface{}); ok {
-								if id, ok := tcMap["id"].(string); ok {
-									validToolCallIDs[id] = true
-								}
-							}
-						}
-					}
-				}
+		if msg.OfAssistant == nil {
+			continue
+		}
+		for _, tc := range msg.OfAssistant.ToolCalls {
+			if id := tc.GetID(); id != nil && *id != "" {
+				validToolCallIDs[*id] = true
 			}
 		}
 	}

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -92,18 +92,17 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	}
 
 	// Ensure max_tokens is set (Anthropic API requires this)
-	// and cap it at the model's maximum allowed value
-	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil {
-		// for thinking, max tokens should be larger than thinking budget
-	} else {
-		if req.MaxTokens == 0 {
-			req.MaxTokens = int64(s.config.GetDefaultMaxTokens())
-		}
-		// Cap max_tokens at the model's maximum to prevent API errors
-		maxAllowed := s.templateManager.GetMaxTokensForModel(provider.Name, actualModel)
-		if req.MaxTokens > int64(maxAllowed) {
-			req.MaxTokens = int64(maxAllowed)
-		}
+	// and cap it at the model's maximum allowed value.
+	if req.MaxTokens == 0 {
+		req.MaxTokens = int64(s.config.GetDefaultMaxTokens())
+	}
+	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
+	if req.MaxTokens > int64(maxAllowed) {
+		req.MaxTokens = int64(maxAllowed)
+	}
+	// If thinking carries budget_tokens beyond model max, shrink budget to max_allowed/10.
+	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil && *thinkBudget > int64(maxAllowed) {
+		req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(int64(maxAllowed / 10))
 	}
 
 	// Set provider UUID in context (Service.Provider uses UUID, not name)

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -92,18 +92,17 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	}
 
 	// Ensure max_tokens is set (Anthropic API requires this)
-	// and cap it at the model's maximum allowed value
-	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil {
-		// for thinking, max tokens should be larger than thinking budget
-	} else {
-		if req.MaxTokens == 0 {
-			req.MaxTokens = int64(s.config.GetDefaultMaxTokens())
-		}
-		// Cap max_tokens at the model's maximum to prevent API errors
-		maxAllowed := s.templateManager.GetMaxTokensForModel(provider.Name, actualModel)
-		if req.MaxTokens > int64(maxAllowed) {
-			req.MaxTokens = int64(maxAllowed)
-		}
+	// and cap it at the model's maximum allowed value.
+	if req.MaxTokens == 0 {
+		req.MaxTokens = int64(s.config.GetDefaultMaxTokens())
+	}
+	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
+	if req.MaxTokens > int64(maxAllowed) {
+		req.MaxTokens = int64(maxAllowed)
+	}
+	// If thinking carries budget_tokens beyond model max, shrink budget to max_allowed/10.
+	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil && *thinkBudget > int64(maxAllowed) {
+		req.Thinking = anthropic.ThinkingConfigParamOfEnabled(int64(maxAllowed / 10))
 	}
 
 	// Set provider UUID in context (Service.Provider uses UUID, not name)

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -230,6 +230,10 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 			ops.ApplyCursorCompatContentNormalization(&req.ChatCompletionNewParams)
 		}
 
+		// Align tool messages to ensure valid message sequence for OpenAI API compatibility
+		// This prevents "role 'tool' must be a response to preceding message with 'tool_calls'" errors
+		transform.AlignToolMessagesForOpenAI(&req.ChatCompletionNewParams)
+
 		anthropicReq := request.ConvertOpenAIToAnthropicRequest(&req.ChatCompletionNewParams, int64(maxAllowed))
 		if isStreaming {
 			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))


### PR DESCRIPTION
## Summary

PR2 adds ConsistencyTransform alignment and thinking budget fixes on top of PR1.

### Changes
- **consistency.go**: Add `AlignToolMessagesForOpenAI` and `alignToolMessages` for orphan tool message conversion (prevents "role 'tool' must be response to preceding tool_calls" errors)
- **openai.go**: Call `AlignToolMessagesForOpenAI` in Anthropic path after cursor_compat normalization
- **anthropic_v1.go & anthropic_beta.go**: Fix thinking budget capping — always cap max_tokens at maxAllowed, shrink thinking budget to maxAllowed/10 if it exceeds maxAllowed

### Depends on
This PR builds on PR1 (cursor compatibility mode). Merge PR1 first, or merge both together.

## Test plan
- [ ] Verify tool messages without tool_calls don't cause "role 'tool'" errors
- [ ] Verify thinking budget capped correctly for models with strict limits
- [ ] Verify max_tokens capping works for providers like DeepSeek