### PR TITLE
feat: add configurable HTTP transport connection pooling

### DIFF
--- a/internal/client/transport_pool.go
+++ b/internal/client/transport_pool.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,23 +15,65 @@ import (
 	"github.com/tingly-dev/tingly-box/pkg/oauth"
 )
 
+// TransportConfig holds the configuration for HTTP transport connection pooling
+// All fields are pointers so that zero-value (nil) means "use Go default"
+type TransportConfig struct {
+	MaxIdleConns        *int  // nil = use Go default (100)
+	MaxIdleConnsPerHost *int  // nil = use Go default (2)
+	MaxConnsPerHost     *int  // nil = use Go default (0, no limit)
+	DisableKeepAlives   *bool // nil = use Go default (false)
+}
+
+// Go defaults for reference (not used directly, only for documentation)
+const (
+	DefaultMaxIdleConns        = 100
+	DefaultMaxIdleConnsPerHost = 2
+)
+
 // TransportPool manages shared HTTP transports for clients
 // Transports are keyed by: apiBaseURL + proxyURL + oauthType
 // This allows multiple clients to share the same connection pool
 // when they connect to the same API endpoint through the same proxy.
 type TransportPool struct {
 	transports map[string]*http.Transport
+	config     *TransportConfig // nil = use Go defaults
 	mutex      sync.RWMutex
 }
 
 // Global singleton transport pool
 var globalTransportPool = &TransportPool{
 	transports: make(map[string]*http.Transport),
+	config:     nil, // nil = use Go defaults (backward compatible with TB)
 }
 
 // GetGlobalTransportPool returns the global transport pool singleton
 func GetGlobalTransportPool() *TransportPool {
 	return globalTransportPool
+}
+
+// SetTransportConfig updates the transport pool configuration
+// Pass nil to reset to Go defaults (backward compatible)
+// This affects newly created transports only, existing transports are not modified
+func SetTransportConfig(config *TransportConfig) {
+	globalTransportPool.mutex.Lock()
+	defer globalTransportPool.mutex.Unlock()
+
+	globalTransportPool.config = config
+
+	if config == nil {
+		logrus.Info("Transport pool config reset to Go defaults")
+	} else {
+		maxIdle := "default"
+		maxIdlePerHost := "default"
+		if config.MaxIdleConns != nil {
+			maxIdle = fmt.Sprintf("%d", *config.MaxIdleConns)
+		}
+		if config.MaxIdleConnsPerHost != nil {
+			maxIdlePerHost = fmt.Sprintf("%d", *config.MaxIdleConnsPerHost)
+		}
+		logrus.Infof("Transport pool config updated: MaxIdleConns=%s, MaxIdleConnsPerHost=%s",
+			maxIdle, maxIdlePerHost)
+	}
 }
 
 // GetTransport returns or creates a shared HTTP transport for the given configuration
@@ -88,7 +131,9 @@ func (tp *TransportPool) generateTransportKey(apiBase, proxyURL string, oauthTyp
 func (tp *TransportPool) createTransport(proxyURL string) *http.Transport {
 	if proxyURL == "" {
 		// Return a copy of default transport to avoid mutation issues
-		return http.DefaultTransport.(*http.Transport).Clone()
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		tp.applyConfig(transport)
+		return transport
 	}
 
 	// Parse the proxy URL
@@ -124,7 +169,30 @@ func (tp *TransportPool) createTransport(proxyURL string) *http.Transport {
 		return http.DefaultTransport.(*http.Transport).Clone()
 	}
 
+	tp.applyConfig(transport)
 	return transport
+}
+
+// applyConfig applies custom configuration to transport if set
+// TB (tingly-box) will have tp.config == nil, so this is a no-op
+func (tp *TransportPool) applyConfig(transport *http.Transport) {
+	if tp.config == nil {
+		return
+	}
+	if tp.config.MaxIdleConns != nil {
+		transport.MaxIdleConns = *tp.config.MaxIdleConns
+	}
+	if tp.config.MaxIdleConnsPerHost != nil {
+		transport.MaxIdleConnsPerHost = *tp.config.MaxIdleConnsPerHost
+	}
+	if tp.config.MaxConnsPerHost != nil {
+		transport.MaxConnsPerHost = *tp.config.MaxConnsPerHost
+	}
+	if tp.config.DisableKeepAlives != nil {
+		transport.DisableKeepAlives = *tp.config.DisableKeepAlives
+	}
+	logrus.Debugf("Applied custom transport config: MaxIdleConns=%d, MaxIdleConnsPerHost=%d",
+		transport.MaxIdleConns, transport.MaxIdleConnsPerHost)
 }
 
 // Stats returns statistics about the transport pool

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -77,6 +77,9 @@ type Config struct {
 	// Enterprise context JWT validation settings for TBE->TB proxy calls.
 	EnterpriseContextJWT EnterpriseContextJWTConfig `json:"enterprise_context_jwt,omitempty" yaml:"enterprise_context_jwt,omitempty"`
 
+	// HTTP Transport settings for upstream API connections
+	HTTPTransport HTTPTransportConfig `json:"http_transport,omitempty" yaml:"http_transport,omitempty"`
+
 	ConfigFile string `yaml:"-" json:"-"` // Not serialized to YAML (exported to preserve field)
 	ConfigDir  string `yaml:"-" json:"-"`
 
@@ -122,6 +125,31 @@ type EnterpriseContextJWTConfig struct {
 	PublicKeys        []EnterpriseContextPublicKey `json:"public_keys,omitempty" yaml:"public_keys,omitempty"`
 	ClockSkewSeconds  int                          `json:"clock_skew_seconds,omitempty" yaml:"clock_skew_seconds,omitempty"`
 	RequireJTI        bool                         `json:"require_jti" yaml:"require_jti"`
+}
+
+// HTTPTransportConfig holds HTTP transport connection pool settings
+// These settings control the connection pooling behavior for upstream API requests
+// All fields use pointers so that omitting them means "use Go default" (backward compatible)
+type HTTPTransportConfig struct {
+	// MaxIdleConns is the maximum number of idle connections across all hosts
+	// Default (nil): 100 (Go stdlib default)
+	// Recommended for 200 concurrent users: 200-300
+	MaxIdleConns *int `json:"max_idle_conns,omitempty" yaml:"max_idle_conns,omitempty"`
+
+	// MaxIdleConnsPerHost is the maximum number of idle connections per host
+	// Default (nil): 2 (Go stdlib default)
+	// Recommended for 200 concurrent users: 20-50
+	MaxIdleConnsPerHost *int `json:"max_idle_conns_per_host,omitempty" yaml:"max_idle_conns_per_host,omitempty"`
+
+	// MaxConnsPerHost limits the total number of connections per host (active + idle)
+	// Default (nil): 0 (no limit)
+	// Set to control maximum concurrent connections to a single upstream host
+	MaxConnsPerHost *int `json:"max_conns_per_host,omitempty" yaml:"max_conns_per_host,omitempty"`
+
+	// DisableKeepAlives disables HTTP/1.1 keep-alive connections
+	// Default (nil): false
+	// WARNING: Setting this to true will significantly impact performance
+	DisableKeepAlives *bool `json:"disable_keep_alives,omitempty" yaml:"disable_keep_alives,omitempty"`
 }
 
 func enterpriseContextKeyPaths(configDir string) (string, string) {
@@ -2284,4 +2312,27 @@ func (c *Config) GetSmartGuideRule() *typ.Rule {
 		}
 	}
 	return nil
+}
+
+// ApplyHTTPTransportConfig applies the HTTP transport configuration to the global transport pool
+// This is called by TBE during initialization to configure connection pooling
+// For TB (tingly-box), this is a no-op since HTTPTransport will be empty (zero values)
+func (c *Config) ApplyHTTPTransportConfig() {
+	if c.HTTPTransport.MaxIdleConns == nil &&
+		c.HTTPTransport.MaxIdleConnsPerHost == nil &&
+		c.HTTPTransport.MaxConnsPerHost == nil &&
+		c.HTTPTransport.DisableKeepAlives == nil {
+		// No custom transport config, use Go defaults (backward compatible with TB)
+		return
+	}
+
+	// Import client package to set transport config
+	// We need to do this here to avoid circular dependency
+	config := &client.TransportConfig{
+		MaxIdleConns:        c.HTTPTransport.MaxIdleConns,
+		MaxIdleConnsPerHost: c.HTTPTransport.MaxIdleConnsPerHost,
+		MaxConnsPerHost:     c.HTTPTransport.MaxConnsPerHost,
+		DisableKeepAlives:   c.HTTPTransport.DisableKeepAlives,
+	}
+	client.SetTransportConfig(config)
 }


### PR DESCRIPTION
## Summary
- Add `HTTPTransportConfig` to Config struct for transport pool settings
- Use pointer fields to distinguish unset from zero values (backward compatible)
- TB (tingly-box) with no config: uses Go defaults (MaxIdleConns=100, MaxIdleConnsPerHost=2)
- TBE can configure via config.json for 200 concurrent users

## Configuration Example
```json
{
  "http_transport": {
    "max_idle_conns": 200,
    "max_idle_conns_per_host": 50
  }
}
```

## Test plan
- [x] Build passes
- [x] TB behavior unchanged when config not set (backward compatible)
- [x] TBE can configure transport pool via config.json