### PR TITLE
feat: export CleanSystemMessages and CleanBetaSystemMessages

### DIFF
--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -88,7 +88,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 
 	// Clean system messages if clean_header flag is enabled (for Claude Code scenario)
 	if cleanHeader {
-		req.BetaMessageNewParams.System = cleanBetaSystemMessages(req.BetaMessageNewParams.System)
+		req.BetaMessageNewParams.System = CleanBetaSystemMessages(req.BetaMessageNewParams.System)
 	}
 
 	// Ensure max_tokens is set (Anthropic API requires this)

--- a/internal/server/anthropic_plugin.go
+++ b/internal/server/anthropic_plugin.go
@@ -6,9 +6,9 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 )
 
-// cleanSystemMessages removes billing header messages from system blocks
+// CleanSystemMessages removes billing header messages from system blocks
 // This is used for Claude Code scenario to filter out injected billing headers
-func cleanSystemMessages(blocks []anthropic.TextBlockParam) []anthropic.TextBlockParam {
+func CleanSystemMessages(blocks []anthropic.TextBlockParam) []anthropic.TextBlockParam {
 	if len(blocks) == 0 {
 		return blocks
 	}
@@ -23,8 +23,8 @@ func cleanSystemMessages(blocks []anthropic.TextBlockParam) []anthropic.TextBloc
 	return result
 }
 
-// cleanBetaSystemMessages removes billing header messages from beta system blocks
-func cleanBetaSystemMessages(blocks []anthropic.BetaTextBlockParam) []anthropic.BetaTextBlockParam {
+// CleanBetaSystemMessages removes billing header messages from beta system blocks
+func CleanBetaSystemMessages(blocks []anthropic.BetaTextBlockParam) []anthropic.BetaTextBlockParam {
 	if len(blocks) == 0 {
 		return blocks
 	}

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -88,7 +88,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 
 	// Clean system messages if clean_header flag is enabled (for Claude Code scenario)
 	if cleanHeader {
-		req.MessageNewParams.System = cleanSystemMessages(req.MessageNewParams.System)
+		req.MessageNewParams.System = CleanSystemMessages(req.MessageNewParams.System)
 	}
 
 	// Ensure max_tokens is set (Anthropic API requires this)


### PR DESCRIPTION
Export clean header functions to allow TBE to reuse the logic for removing billing headers from system messages.

## Changes
- `cleanSystemMessages` → `CleanSystemMessages` (exported)
- `cleanBetaSystemMessages` → `CleanBetaSystemMessages` (exported)
- Updated callers in `anthropic_v1.go` and `anthropic_beta.go`

## Motivation
TBE needs to clean billing headers from anthropic system messages. By exporting these functions, TBE can reuse the existing logic instead of duplicating code.