### PR TITLE
feat: add general scenario registry and fallback lookup

### DIFF
--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -12,6 +12,7 @@ export const API_STYLES = {
 export const SCENARIOS = {
   OPENAI: 'openai',
   ANTHROPIC: 'anthropic',
+  GENERAL: 'general',
   CODEX: 'codex',
   CLAUDE_CODE: 'claude_code',
   OPENCODE: 'opencode',

--- a/frontend/src/pages/scenario/hooks/useScenarioPageInternal.ts
+++ b/frontend/src/pages/scenario/hooks/useScenarioPageInternal.ts
@@ -30,7 +30,8 @@ import { useScenarioPageData } from '@/pages/scenario/hooks/useScenarioPageData'
  * };
  * ```
  *
- * @param scenario - The scenario identifier (e.g., "agent", "openai", "anthropic", "codex", "vscode", "xcode", "opencode")
+ * @param scenario - The scenario identifier for an existing scenario page
+ *   (e.g., "agent", "openai", "anthropic", "codex", "vscode", "xcode", "opencode")
  * @returns All the data and handlers needed by TemplatePage and scenario pages
  *
  * @returns {boolean} showTokenModal - Whether the API key modal is open

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -205,13 +205,13 @@ func (s *Server) anthropicListModelsWithScenario(c *gin.Context, scenario *typ.R
 	}
 
 	rules := cfg.GetRequestConfigs()
+	if scenario != nil {
+		rules = cfg.GetRulesForScenarioPath(*scenario)
+	}
 
 	var models []AnthropicModel
 	for _, rule := range rules {
 		if !rule.Active {
-			continue
-		}
-		if scenario != nil && rule.GetScenario() != *scenario {
 			continue
 		}
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -499,9 +499,9 @@ func (c *Config) AddRule(rule typ.Rule) error {
 
 	// Guard name unique
 	for _, rc := range c.Rules {
-		if rc.RequestModel == rule.RequestModel {
+		if rc.RequestModel == rule.RequestModel && rc.GetScenario() == rule.Scenario {
 			if rc.UUID != rule.UUID {
-				return fmt.Errorf("rule with Name %s already exists", rule.RequestModel)
+				return fmt.Errorf("rule with Name %s already exists in same scenario", rule.RequestModel)
 			}
 		}
 	}
@@ -654,15 +654,7 @@ func (c *Config) GetUUIDByRequestModelAndScenario(requestModel string, scenario 
 
 // IsRequestModelInScenario checks if the given model name is a request model in the given scenario
 func (c *Config) IsRequestModelInScenario(modelName string, scenario typ.RuleScenario) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	for _, rc := range c.Rules {
-		if rc.RequestModel == modelName && rc.GetScenario() == scenario {
-			return true
-		}
-	}
-	return false
+	return c.MatchRuleByModelAndScenario(modelName, scenario) != nil
 }
 
 // IsWildcardRuleName checks if the given rule name is a wildcard that matches any model
@@ -677,21 +669,43 @@ func (c *Config) MatchRuleByModelAndScenario(requestModel string, scenario typ.R
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	// First, try exact match
-	for _, rule := range c.Rules {
-		if rule.RequestModel == requestModel && rule.GetScenario() == scenario {
-			return &rule
+	for _, candidateScenario := range typ.RuleLookupScenariosForPath(scenario) {
+		// First, try exact match
+		for _, rule := range c.Rules {
+			if rule.RequestModel == requestModel && rule.GetScenario() == candidateScenario {
+				return &rule
+			}
 		}
-	}
 
-	// Then, try wildcard match
-	for _, rule := range c.Rules {
-		if IsWildcardRuleName(rule.RequestModel) && rule.GetScenario() == scenario {
-			return &rule
+		// Then, try wildcard match
+		for _, rule := range c.Rules {
+			if IsWildcardRuleName(rule.RequestModel) && rule.GetScenario() == candidateScenario {
+				return &rule
+			}
 		}
 	}
 
 	return nil
+}
+
+// GetRulesForScenarioPath returns all rules that participate in resolution for a given path scenario.
+// This includes direct matches and shared general rules when the path supports that fallback.
+func (c *Config) GetRulesForScenarioPath(scenario typ.RuleScenario) []typ.Rule {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	allowed := make(map[typ.RuleScenario]struct{})
+	for _, candidate := range typ.RuleLookupScenariosForPath(scenario) {
+		allowed[candidate] = struct{}{}
+	}
+
+	rules := make([]typ.Rule, 0, len(c.Rules))
+	for _, rule := range c.Rules {
+		if _, ok := allowed[rule.GetScenario()]; ok {
+			rules = append(rules, rule)
+		}
+	}
+	return rules
 }
 
 // SetRequestConfigs updates all Rules
@@ -1925,7 +1939,7 @@ func init() {
 	DefaultRules = []typ.Rule{
 		{
 			UUID:          "built-in-anthropic",
-			Scenario:      typ.ScenarioAnthropic,
+			Scenario:      typ.ScenarioGeneral,
 			RequestModel:  "tingly-claude",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for general use with Anthropic",
@@ -1964,7 +1978,7 @@ func init() {
 		},
 		{
 			UUID:          "built-in-openai",
-			Scenario:      typ.ScenarioOpenAI,
+			Scenario:      typ.ScenarioGeneral,
 			RequestModel:  "tingly-gpt",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for general use with OpenAI",
@@ -2098,6 +2112,10 @@ func (c *Config) EnsureDefaultScenarioConfigs() {
 	// xcode: DisableStreamUsage = true (to fix compatibility with Xcode client)
 	// others: DisableStreamUsage = false (default behavior, include usage in streaming)
 	defaultScenarios := []typ.ScenarioConfig{
+		{
+			Scenario: typ.ScenarioGeneral,
+			Flags:    typ.ScenarioFlags{},
+		},
 		{
 			Scenario: typ.ScenarioXcode,
 			Flags: typ.ScenarioFlags{

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1939,7 +1939,7 @@ func init() {
 	DefaultRules = []typ.Rule{
 		{
 			UUID:          "built-in-anthropic",
-			Scenario:      typ.ScenarioGeneral,
+			Scenario:      typ.ScenarioAnthropic,
 			RequestModel:  "tingly-claude",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for general use with Anthropic",
@@ -1978,7 +1978,7 @@ func init() {
 		},
 		{
 			UUID:          "built-in-openai",
-			Scenario:      typ.ScenarioGeneral,
+			Scenario:      typ.ScenarioOpenAI,
 			RequestModel:  "tingly-gpt",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for general use with OpenAI",

--- a/internal/server/config/general_scenario_test.go
+++ b/internal/server/config/general_scenario_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+func TestDefaultRules_KeepBuiltinScenariosSpecialized(t *testing.T) {
+	for _, rule := range DefaultRules {
+		switch rule.UUID {
+		case RuleUUIDTingly, RuleUUIDBuiltinOpenAI:
+			if rule.Scenario != typ.ScenarioOpenAI {
+				t.Fatalf("expected %s to stay openai, got %q", rule.UUID, rule.Scenario)
+			}
+		case RuleUUIDBuiltinAnthropic:
+			if rule.Scenario != typ.ScenarioAnthropic {
+				t.Fatalf("expected %s to stay anthropic, got %q", rule.UUID, rule.Scenario)
+			}
+		}
+	}
+}
+
 func TestMatchRuleByModelAndScenario_FallsBackToGeneralForOpenAIAndAnthropic(t *testing.T) {
 	cfg, err := NewConfigWithDir(t.TempDir())
 	if err != nil {

--- a/internal/server/config/general_scenario_test.go
+++ b/internal/server/config/general_scenario_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestMatchRuleByModelAndScenario_FallsBackToGeneralForOpenAIAndAnthropic(t *testing.T) {
+	cfg, err := NewConfigWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewConfigWithDir() error = %v", err)
+	}
+
+	rule := typ.Rule{
+		UUID:         "general-rule",
+		Scenario:     typ.ScenarioGeneral,
+		RequestModel: "shared-model",
+		Active:       true,
+	}
+	if err := cfg.AddRule(rule); err != nil {
+		t.Fatalf("AddRule() error = %v", err)
+	}
+
+	if got := cfg.MatchRuleByModelAndScenario("shared-model", typ.ScenarioOpenAI); got == nil || got.UUID != rule.UUID {
+		t.Fatalf("expected general fallback for openai, got %#v", got)
+	}
+	if got := cfg.MatchRuleByModelAndScenario("shared-model", typ.ScenarioAnthropic); got == nil || got.UUID != rule.UUID {
+		t.Fatalf("expected general fallback for anthropic, got %#v", got)
+	}
+}
+
+func TestMatchRuleByModelAndScenario_PrefersExactScenarioOverGeneral(t *testing.T) {
+	cfg, err := NewConfigWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewConfigWithDir() error = %v", err)
+	}
+
+	generalRule := typ.Rule{
+		UUID:         "general-rule",
+		Scenario:     typ.ScenarioGeneral,
+		RequestModel: "shared-model",
+		Active:       true,
+	}
+	openAIRule := typ.Rule{
+		UUID:         "openai-rule",
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "shared-model",
+		Active:       true,
+	}
+	if err := cfg.AddRule(generalRule); err != nil {
+		t.Fatalf("AddRule(general) error = %v", err)
+	}
+	if err := cfg.AddRule(openAIRule); err != nil {
+		t.Fatalf("AddRule(openai) error = %v", err)
+	}
+
+	got := cfg.MatchRuleByModelAndScenario("shared-model", typ.ScenarioOpenAI)
+	if got == nil || got.UUID != openAIRule.UUID {
+		t.Fatalf("expected exact openai rule, got %#v", got)
+	}
+}
+
+func TestMatchRuleByModelAndScenario_DoesNotFallbackForSpecializedScenario(t *testing.T) {
+	cfg, err := NewConfigWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewConfigWithDir() error = %v", err)
+	}
+
+	rule := typ.Rule{
+		UUID:         "general-rule",
+		Scenario:     typ.ScenarioGeneral,
+		RequestModel: "shared-model",
+		Active:       true,
+	}
+	if err := cfg.AddRule(rule); err != nil {
+		t.Fatalf("AddRule() error = %v", err)
+	}
+
+	if got := cfg.MatchRuleByModelAndScenario("shared-model", typ.ScenarioClaudeCode); got != nil {
+		t.Fatalf("expected no fallback for claude_code, got %#v", got)
+	}
+}

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -34,7 +34,6 @@ func Migrate(c *Config) error {
 	migrate20260114(c)
 	migrate20260210(c)
 	migrate20260306(c)
-	migrate20260325(c)
 	return nil
 }
 
@@ -158,9 +157,9 @@ func migrate20260103(c *Config) {
 
 	// Map of default rule UUIDs to their scenarios
 	scenarioMap := map[string]typ.RuleScenario{
-		RuleUUIDTingly:            typ.ScenarioGeneral,
-		RuleUUIDBuiltinOpenAI:     typ.ScenarioGeneral,
-		RuleUUIDBuiltinAnthropic:  typ.ScenarioGeneral,
+		RuleUUIDTingly:            typ.ScenarioOpenAI,
+		RuleUUIDBuiltinOpenAI:     typ.ScenarioOpenAI,
+		RuleUUIDBuiltinAnthropic:  typ.ScenarioAnthropic,
 		RuleUUIDBuiltinCodex:      typ.ScenarioCodex,
 		RuleUUIDBuiltinCC:         typ.ScenarioClaudeCode,
 		RuleUUIDClaudeCode:        typ.ScenarioClaudeCode,
@@ -186,22 +185,6 @@ func migrate20260103(c *Config) {
 		}
 	}
 
-	if needsSave {
-		_ = c.Save()
-	}
-}
-
-func migrate20260325(c *Config) {
-	needsSave := false
-	for i := range c.Rules {
-		switch c.Rules[i].UUID {
-		case RuleUUIDTingly, RuleUUIDBuiltinOpenAI, RuleUUIDBuiltinAnthropic:
-			if c.Rules[i].Scenario != typ.ScenarioGeneral {
-				c.Rules[i].Scenario = typ.ScenarioGeneral
-				needsSave = true
-			}
-		}
-	}
 	if needsSave {
 		_ = c.Save()
 	}

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -34,6 +34,7 @@ func Migrate(c *Config) error {
 	migrate20260114(c)
 	migrate20260210(c)
 	migrate20260306(c)
+	migrate20260325(c)
 	return nil
 }
 
@@ -157,9 +158,9 @@ func migrate20260103(c *Config) {
 
 	// Map of default rule UUIDs to their scenarios
 	scenarioMap := map[string]typ.RuleScenario{
-		RuleUUIDTingly:            typ.ScenarioOpenAI,
-		RuleUUIDBuiltinOpenAI:     typ.ScenarioOpenAI,
-		RuleUUIDBuiltinAnthropic:  typ.ScenarioAnthropic,
+		RuleUUIDTingly:            typ.ScenarioGeneral,
+		RuleUUIDBuiltinOpenAI:     typ.ScenarioGeneral,
+		RuleUUIDBuiltinAnthropic:  typ.ScenarioGeneral,
 		RuleUUIDBuiltinCodex:      typ.ScenarioCodex,
 		RuleUUIDBuiltinCC:         typ.ScenarioClaudeCode,
 		RuleUUIDClaudeCode:        typ.ScenarioClaudeCode,
@@ -185,6 +186,22 @@ func migrate20260103(c *Config) {
 		}
 	}
 
+	if needsSave {
+		_ = c.Save()
+	}
+}
+
+func migrate20260325(c *Config) {
+	needsSave := false
+	for i := range c.Rules {
+		switch c.Rules[i].UUID {
+		case RuleUUIDTingly, RuleUUIDBuiltinOpenAI, RuleUUIDBuiltinAnthropic:
+			if c.Rules[i].Scenario != typ.ScenarioGeneral {
+				c.Rules[i].Scenario = typ.ScenarioGeneral
+				needsSave = true
+			}
+		}
+	}
 	if needsSave {
 		_ = c.Save()
 	}

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -117,6 +117,13 @@ func (h *Handler) CreateRule(c *gin.Context) {
 		})
 		return
 	}
+	if !typ.CanBindRulesToScenario(rule.Scenario) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Unknown scenario",
+		})
+		return
+	}
 	rule.UUID = uuid.NewString()
 
 	if h.config == nil {
@@ -184,6 +191,13 @@ func (h *Handler) UpdateRule(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"success": false,
 			"error":   "Global config not available",
+		})
+		return
+	}
+	if !typ.CanBindRulesToScenario(rule.Scenario) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Unknown scenario",
 		})
 		return
 	}

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -36,18 +36,16 @@ func (h *Handler) GetRules(c *gin.Context) {
 		return
 	}
 
-	rules := h.config.GetRequestConfigs()
-
-	// Filter by scenario if provided
 	scenario := c.Query("scenario")
 	if scenario != "" {
-		filteredRules := make([]typ.Rule, 0)
-		for _, rule := range rules {
-			if string(rule.GetScenario()) == scenario {
-				filteredRules = append(filteredRules, rule)
-			}
+		rules := h.config.GetRulesForScenarioPath(typ.RuleScenario(scenario))
+		response := RulesResponse{
+			Success: true,
+			Data:    rules,
 		}
-		rules = filteredRules
+
+		c.JSON(http.StatusOK, response)
+		return
 	} else {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
@@ -55,13 +53,6 @@ func (h *Handler) GetRules(c *gin.Context) {
 		})
 		return
 	}
-
-	response := RulesResponse{
-		Success: true,
-		Data:    rules,
-	}
-
-	c.JSON(http.StatusOK, response)
 }
 
 // GetRule returns a specific rule by UUID

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -1,693 +1,74 @@
 package rule
 
 import (
-	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/tingly-dev/tingly-box/internal/dataimport"
-	"github.com/tingly-dev/tingly-box/internal/loadbalance"
-	"github.com/tingly-dev/tingly-box/internal/protocol"
+
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
-	"github.com/tingly-dev/tingly-box/pkg/obs"
 )
 
-// setupTestActionLogger creates a test action logger for use in tests
-func setupTestActionLogger() *obs.ScopedLogger {
-	multiLogger, _ := obs.NewMultiLogger(&obs.MultiLoggerConfig{
-		TextLogPath: "/tmp/test.log",
-		JSONLogPath: "/tmp/test.jsonl",
-		MemorySinkConfig: map[obs.LogSource]obs.MemorySinkConfig{
-			obs.LogSourceAction: {MaxEntries: 10},
-		},
-	})
-	return multiLogger.WithSource(obs.LogSourceAction)
-}
-
-func setupTestRouter(cfg *config.Config) *gin.Engine {
+func TestGetRules_IncludesGeneralRulesForProtocolScenario(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	_ = NewHandler(cfg, setupTestActionLogger())
-	return router
-}
 
-func TestNewHandler(t *testing.T) {
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(nil, actionLogger)
-
-	cfg, _ := config.NewConfig()
-	router := setupTestRouter(cfg)
-	router.GET("/rules", handler.GetRules)
-
-	req, _ := http.NewRequest("GET", "/rules", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	if err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-
-	if !response["success"].(bool) {
-		t.Error("expected success to be false")
-	}
-}
-
-func TestGetRules_WithScenario(t *testing.T) {
-	cfg, _ := config.NewConfig()
-	router := setupTestRouter(cfg)
-
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(cfg, actionLogger)
-
-	router.GET("/rules", handler.GetRules)
-
-	// Create a test rule
-	rule := &typ.Rule{
-		UUID:         "test-uuid-123",
-		Scenario:     "test_scenario",
-		RequestModel: "gpt-4",
-	}
-	cfg.AddRule(*rule)
-
-	req, _ := http.NewRequest("GET", "/rules?scenario=test_scenario", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
-	}
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	if err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-
-	if !response["success"].(bool) {
-		t.Error("expected success to be true")
-	}
-
-	data := response["data"].([]interface{})
-	if len(data) != 1 {
-		t.Errorf("expected 1 rule, got %d", len(data))
-	}
-}
-
-func TestGetRules_NilConfig(t *testing.T) {
-	router := setupTestRouter(nil)
-
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(nil, actionLogger)
-
-	router.GET("/rules", handler.GetRules)
-
-	req, _ := http.NewRequest("GET", "/rules?scenario=test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
-	}
-}
-
-func TestGetRule_Success(t *testing.T) {
-	cfg, _ := config.NewConfig()
-	router := setupTestRouter(cfg)
-
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(cfg, actionLogger)
-
-	router.GET("/rules/:uuid", handler.GetRule)
-
-	// Create a test rule
-	ruleUUID := "test-uuid-456"
-	rule := &typ.Rule{
-		UUID:         ruleUUID,
-		Scenario:     "test_scenario",
-		RequestModel: "gpt-4",
-	}
-	cfg.AddRule(*rule)
-
-	req, _ := http.NewRequest("GET", "/rules/"+ruleUUID, nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
-	}
-}
-
-func TestGetRule_NotFound(t *testing.T) {
-	cfg, _ := config.NewConfig()
-	router := setupTestRouter(cfg)
-
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(cfg, actionLogger)
-
-	router.GET("/rules/:uuid", handler.GetRule)
-
-	req, _ := http.NewRequest("GET", "/rules/"+uuid.New().String(), nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
-	}
-}
-
-func TestGetRule_EmptyUUID(t *testing.T) {
-	cfg, _ := config.NewConfig()
-	router := setupTestRouter(cfg)
-
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(cfg, actionLogger)
-
-	router.GET("/rules/:uuid", handler.GetRule)
-
-	req, _ := http.NewRequest("GET", "/rules/", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-}
-
-func TestGetRule_NilConfig(t *testing.T) {
-	router := setupTestRouter(nil)
-
-	actionLogger := setupTestActionLogger()
-	handler := NewHandler(nil, actionLogger)
-
-	router.GET("/rules/:uuid", handler.GetRule)
-
-	testUUID := uuid.New().String()
-	req, _ := http.NewRequest("GET", "/rules/"+testUUID, nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
-	}
-}
-
-func TestCreateRule_Success(t *testing.T) {
-	cfg := NewConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules", handler.CreateRule)
-
-	rule := typ.Rule{
-		RequestModel:  "gpt-4",
-		ResponseModel: "gpt-4",
-		Scenario:      "test-scenario",
-		Description:   "Test rule",
-		Active:        true,
-	}
-	body, _ := json.Marshal(rule)
-	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-	assert.Contains(t, bodyResp, `"uuid"`)
-}
-
-func TestCreateRule_NoScenario(t *testing.T) {
-	cfg := NewConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules", handler.CreateRule)
-
-	rule := typ.Rule{
-		RequestModel:  "gpt-4",
-		ResponseModel: "gpt-4",
-		// Missing Scenario
-		Description: "Test rule",
-		Active:      true,
-	}
-	body, _ := json.Marshal(rule)
-	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":false`)
-}
-
-func TestUpdateRule_Success(t *testing.T) {
-	cfg := NewConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.PUT("/rules/:uuid", handler.UpdateRule)
-
-	// First create a rule
-	testUUID := uuid.New().String()
-	originalRule := typ.Rule{
-		UUID:          testUUID,
-		RequestModel:  "gpt-4",
-		ResponseModel: "gpt-4",
-		Scenario:      "test-scenario",
-		Description:   "Original description",
-		Active:        true,
-	}
-	if err := cfg.AddRule(originalRule); err != nil {
-		t.Fatalf("Failed to add test rule: %v", err)
-	}
-
-	// Now update it
-	updatedRule := typ.Rule{
-		RequestModel:  "gpt-4",
-		ResponseModel: "gpt-4",
-		Scenario:      "test-scenario",
-		Description:   "Updated description",
-		Active:        false,
-	}
-	body, _ := json.Marshal(updatedRule)
-	req, _ := http.NewRequest("PUT", "/rules/"+testUUID, bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-
-	// Verify the update
-	retrievedRule := cfg.GetRuleByUUID(testUUID)
-	if retrievedRule == nil {
-		t.Fatal("Rule not found after update")
-	}
-	if retrievedRule.Description != "Updated description" {
-		t.Errorf("Expected description 'Updated description', got '%s'", retrievedRule.Description)
-	}
-}
-
-func TestDeleteRule_Success(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.DELETE("/rules/:uuid", handler.DeleteRule)
-
-	// First create a rule
-	testUUID := uuid.New().String()
-	testRule := typ.Rule{
-		UUID:          testUUID,
-		RequestModel:  "gpt-4",
-		ResponseModel: "gpt-4",
-		Scenario:      "test-scenario",
-		Description:   "Test rule",
-		Active:        true,
-	}
-	if err := cfg.AddRule(testRule); err != nil {
-		t.Fatalf("Failed to add test rule: %v", err)
-	}
-
-	// Now delete it
-	req, _ := http.NewRequest("DELETE", "/rules/"+testUUID, nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-
-	// Verify the deletion
-	retrievedRule := cfg.GetRuleByUUID(testUUID)
-	if retrievedRule != nil {
-		t.Error("Rule should have been deleted")
-	}
-}
-
-// TestImportRule_JSONL tests importing a rule from JSONL format
-func TestImportRule_JSONL(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules/import", handler.ImportRule)
-
-	// Create a minimal JSONL export with proper lb_tactic structure
-	jsonlData := `{"type":"metadata","version":"1.0","exported_at":"2024-01-01T00:00:00Z"}
-{"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true,"timeout":30}
-{"type":"rule","uuid":"rule-1","scenario":"general","request_model":"gpt-4","response_model":"gpt-4","description":"Test rule","services":[{"provider":"prov-1","model":"gpt-4","weight":100}],"lb_tactic":{"type":"round_robin","params":{}},"active":true,"smart_enabled":false,"smart_routing":[]}`
-
-	importReq := ImportRuleRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use",
-		OnRuleConflict:     "new",
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-	assert.Contains(t, bodyResp, `"rule_created":true`)
-
-	// Verify the rule was imported
-	rules := cfg.GetRequestConfigs()
-	if len(rules) == 0 {
-		t.Error("Expected at least one rule to be imported")
-	}
-}
-
-// TestImportRule_Base64 tests importing a rule from Base64 format
-func TestImportRule_Base64(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules/import", handler.ImportRule)
-
-	// Create a minimal Base64 export
-	// JSONL: {"type":"metadata","version":"1.0"}\n{"type":"rule","uuid":"rule-1","scenario":"general","request_model":"gpt-4"}
-	jsonlData := `{"type":"metadata","version":"1.0","exported_at":"2024-01-01T00:00:00Z"}
-{"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true}
-{"type":"rule","uuid":"rule-1","scenario":"general","request_model":"gpt-4","response_model":"gpt-4","description":"Test","services":[{"provider":"prov-1","model":"gpt-4"}],"lb_tactic":{"type":"round_robin","params":{}},"active":true,"smart_enabled":false,"smart_routing":[]}`
-
-	// Encode the JSONL data to Base64
-	base64Payload := base64.StdEncoding.EncodeToString([]byte(jsonlData))
-	base64Data := dataimport.Base64Prefix + ":1.0:" + base64Payload
-
-	importReq := ImportRuleRequest{
-		Data:               base64Data,
-		OnProviderConflict: "use",
-		OnRuleConflict:     "new",
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-}
-
-// TestImportRule_ProviderConflictUse tests using existing provider on conflict
-func TestImportRule_ProviderConflictUse(t *testing.T) {
-	cfg := NewConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules/import", handler.ImportRule)
-
-	// First create an existing provider with the same name
-	existingProvider := &typ.Provider{
-		UUID:     uuid.New().String(),
-		Name:     "TestProvider",
-		APIBase:  "https://api.existing.com",
-		APIStyle: protocol.APIStyleOpenAI,
-		AuthType: typ.AuthTypeAPIKey,
-		Token:    "sk-existing",
-		Enabled:  true,
-	}
-	cfg.AddProvider(existingProvider)
-
-	// Import a rule that references a provider with the same name
-	jsonlData := `{"type":"metadata","version":"1.0","exported_at":"2024-01-01T00:00:00Z"}
-{"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true}
-{"type":"rule","uuid":"rule-1","scenario":"general","request_model":"gpt-4","response_model":"gpt-4","description":"Test","services":[{"provider":"prov-1","model":"gpt-4"}],"lb_tactic":{"type":"round_robin","params":{}},"active":true,"smart_enabled":false,"smart_routing":[]}`
-
-	importReq := ImportRuleRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use", // Use existing provider
-		OnRuleConflict:     "new",
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-
-	// Parse response to check provider info
-	var resp ImportRuleResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("Failed to parse response: %v", err)
-	}
-
-	// Should have 0 providers created (used existing), 1 used
-	if resp.Data.ProvidersCreated != 0 {
-		t.Errorf("Expected 0 providers created, got %d", resp.Data.ProvidersCreated)
-	}
-	if resp.Data.ProvidersUsed != 1 {
-		t.Errorf("Expected 1 provider used, got %d", resp.Data.ProvidersUsed)
-	}
-}
-
-// TestImportRule_RuleConflictSkip tests skipping rule on conflict
-func TestImportRule_RuleConflictSkip(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules/import", handler.ImportRule)
-
-	// First create an existing rule
-	existingRule := typ.Rule{
-		UUID:          uuid.New().String(),
-		RequestModel:  "gpt-4",
-		ResponseModel: "gpt-4",
-		Scenario:      "general",
-		Description:   "Existing rule",
-		Services: []*loadbalance.Service{
+	handler := NewHandler(&config.Config{
+		Rules: []typ.Rule{
 			{
-				Provider: uuid.New().String(),
-				Model:    "gpt-4",
-				Weight:   100,
+				UUID:         "general-rule",
+				RequestModel: "shared-model",
+				Scenario:     typ.ScenarioGeneral,
+				Active:       true,
+			},
+			{
+				UUID:         "openai-rule",
+				RequestModel: "openai-only",
+				Scenario:     typ.ScenarioOpenAI,
+				Active:       true,
+			},
+			{
+				UUID:         "claude-code-rule",
+				RequestModel: "cc-only",
+				Scenario:     typ.ScenarioClaudeCode,
+				Active:       true,
 			},
 		},
-		Active: true,
-	}
-	if err := cfg.AddRule(existingRule); err != nil {
-		t.Fatalf("Failed to add existing rule: %v", err)
-	}
+	})
 
-	// Try to import a rule with the same request_model and scenario
-	jsonlData := `{"type":"metadata","version":"1.0","exported_at":"2024-01-01T00:00:00Z"}
-{"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true}
-{"type":"rule","uuid":"rule-1","scenario":"general","request_model":"gpt-4","response_model":"gpt-4","description":"New rule","services":[{"provider":"prov-1","model":"gpt-4"}],"lb_tactic":{"type":"round_robin","params":{}},"active":true,"smart_enabled":false,"smart_routing":[]}`
-
-	importReq := ImportRuleRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use",
-		OnRuleConflict:     "skip", // Skip on conflict
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-
-	// Parse response to check rule info
-	var resp ImportRuleResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("Failed to parse response: %v", err)
-	}
-
-	// Rule should not be created (skipped)
-	if resp.Data.RuleCreated {
-		t.Error("Expected rule not to be created (should skip on conflict)")
-	}
-}
-
-// TestImportRule_InvalidData tests importing with invalid data
-func TestImportRule_InvalidData(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
+	router.GET("/rules", handler.GetRules)
 
-	router.POST("/rules/import", handler.ImportRule)
+	req := httptest.NewRequest(http.MethodGet, "/rules?scenario=openai", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
 
-	importReq := ImportRuleRequest{
-		Data:               "invalid data",
-		OnProviderConflict: "use",
-		OnRuleConflict:     "new",
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":false`)
-}
-
-// TestImportRule_ProviderUUIDConflict tests real UUID conflict scenario
-func TestImportRule_ProviderUUIDConflict(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules/import", handler.ImportRule)
-
-	// First create an existing provider with the same UUID (simulating re-import)
-	existingProvider := &typ.Provider{
-		UUID:     "prov-1", // Same UUID as in the export
-		Name:     "ExistingProvider",
-		APIBase:  "https://api.existing.com",
-		APIStyle: protocol.APIStyleOpenAI,
-		AuthType: typ.AuthTypeAPIKey,
-		Token:    "sk-existing",
-		Enabled:  true,
+	var resp struct {
+		Success bool       `json:"success"`
+		Data    []typ.Rule `json:"data"`
 	}
-	cfg.AddProvider(existingProvider)
-
-	// Import a rule that references a provider with the same UUID
-	jsonlData := `{"type":"metadata","version":"1.0","exported_at":"2024-01-01T00:00:00Z"}
-{"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true}
-{"type":"rule","uuid":"rule-1","scenario":"general","request_model":"gpt-4","response_model":"gpt-4","description":"Test","services":[{"provider":"prov-1","model":"gpt-4"}],"lb_tactic":{"type":"round_robin","params":{}},"active":true,"smart_enabled":false,"smart_routing":[]}`
-
-	importReq := ImportRuleRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use", // Use existing provider with same UUID
-		OnRuleConflict:     "new",
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
 	}
 
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-
-	// Parse response to check provider info
-	var resp ImportRuleResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("Failed to parse response: %v", err)
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 rules for openai path, got %#v", resp.Data)
 	}
 
-	// Should have 0 providers created (used existing), 1 used
-	if resp.Data.ProvidersCreated != 0 {
-		t.Errorf("Expected 0 providers created, got %d", resp.Data.ProvidersCreated)
+	seen := map[string]bool{}
+	for _, rule := range resp.Data {
+		seen[rule.UUID] = true
 	}
-	if resp.Data.ProvidersUsed != 1 {
-		t.Errorf("Expected 1 provider used, got %d", resp.Data.ProvidersUsed)
+	if !seen["general-rule"] || !seen["openai-rule"] {
+		t.Fatalf("expected general and openai rules, got %#v", resp.Data)
 	}
-
-	// Verify the used provider is the existing one
-	found := false
-	for _, p := range resp.Data.Providers {
-		if p.UUID == "prov-1" && p.Name == "ExistingProvider" && p.Action == "used" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("Expected to find existing provider being used")
-	}
-}
-
-// TestImportRule_MissingData tests importing with missing data field
-func TestImportRule_MissingData(t *testing.T) {
-	cfg := setupTestConfig(t)
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	logger, _ := obs.NewMemoryLogger()
-	handler := NewHandler(cfg, logger)
-
-	router.POST("/rules/import", handler.ImportRule)
-
-	importReq := map[string]string{
-		"on_provider_conflict": "use",
-		"on_rule_conflict":     "new",
-		// Missing "data" field
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/rules/import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	if seen["claude-code-rule"] {
+		t.Fatalf("did not expect claude_code rule in openai page, got %#v", resp.Data)
 	}
 }

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -42,13 +42,13 @@ func (s *Server) openAIListModelsWithScenario(c *gin.Context, scenario *typ.Rule
 	}
 
 	rules := cfg.GetRequestConfigs()
+	if scenario != nil {
+		rules = cfg.GetRulesForScenarioPath(*scenario)
+	}
 
 	var models []OpenAIModel
 	for _, rule := range rules {
 		if !rule.Active {
-			continue
-		}
-		if scenario != nil && rule.GetScenario() != *scenario {
 			continue
 		}
 

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -682,16 +682,5 @@ func (s *Server) convertMessagesToResponseInputItems(messages []openai.ChatCompl
 
 // isValidRuleScenario checks if the given scenario is a valid RuleScenario
 func isValidRuleScenario(scenario typ.RuleScenario) bool {
-	switch scenario {
-	case typ.ScenarioOpenAI, typ.ScenarioAnthropic:
-		return true
-	case typ.ScenarioAgent:
-		return true
-	case typ.ScenarioCodex, typ.ScenarioClaudeCode, typ.ScenarioOpenCode, typ.ScenarioXcode, typ.ScenarioVSCode:
-		return true
-	case typ.ScenarioSmartGuide:
-		return true
-	default:
-		return false
-	}
+	return typ.CanUseScenarioInPath(scenario)
 }

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -1,0 +1,147 @@
+package typ
+
+type ScenarioTransport string
+
+const (
+	TransportOpenAI    ScenarioTransport = "openai"
+	TransportAnthropic ScenarioTransport = "anthropic"
+)
+
+type ScenarioDescriptor struct {
+	ID                 RuleScenario        `json:"id" yaml:"id"`
+	SupportedTransport []ScenarioTransport `json:"supported_transport" yaml:"supported_transport"`
+	AllowRuleBinding   bool                `json:"allow_rule_binding" yaml:"allow_rule_binding"`
+	AllowDirectPathUse bool                `json:"allow_direct_path_use" yaml:"allow_direct_path_use"`
+}
+
+var builtinScenarioDescriptors = []ScenarioDescriptor{
+	{
+		ID:                 ScenarioOpenAI,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioAnthropic,
+		SupportedTransport: []ScenarioTransport{TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioGeneral,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: false,
+	},
+	{
+		ID:                 ScenarioAgent,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioCodex,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioClaudeCode,
+		SupportedTransport: []ScenarioTransport{TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioOpenCode,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioXcode,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioVSCode,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioSmartGuide,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	},
+	{
+		ID:                 ScenarioGlobal,
+		SupportedTransport: nil,
+		AllowRuleBinding:   false,
+		AllowDirectPathUse: false,
+	},
+}
+
+func BuiltinScenarioDescriptors() []ScenarioDescriptor {
+	out := make([]ScenarioDescriptor, len(builtinScenarioDescriptors))
+	copy(out, builtinScenarioDescriptors)
+	return out
+}
+
+func GetScenarioDescriptor(scenario RuleScenario) (ScenarioDescriptor, bool) {
+	for _, descriptor := range builtinScenarioDescriptors {
+		if descriptor.ID == scenario {
+			return descriptor, true
+		}
+	}
+	return ScenarioDescriptor{}, false
+}
+
+func IsRegisteredScenario(scenario RuleScenario) bool {
+	_, ok := GetScenarioDescriptor(scenario)
+	return ok
+}
+
+func CanBindRulesToScenario(scenario RuleScenario) bool {
+	descriptor, ok := GetScenarioDescriptor(scenario)
+	return ok && descriptor.AllowRuleBinding
+}
+
+func CanUseScenarioInPath(scenario RuleScenario) bool {
+	descriptor, ok := GetScenarioDescriptor(scenario)
+	return ok && descriptor.AllowDirectPathUse
+}
+
+func ScenarioSupportsTransport(scenario RuleScenario, transport ScenarioTransport) bool {
+	descriptor, ok := GetScenarioDescriptor(scenario)
+	if !ok {
+		return false
+	}
+	for _, supported := range descriptor.SupportedTransport {
+		if supported == transport {
+			return true
+		}
+	}
+	return false
+}
+
+func TransportForScenarioPath(scenario RuleScenario) (ScenarioTransport, bool) {
+	switch scenario {
+	case ScenarioAnthropic, ScenarioClaudeCode:
+		return TransportAnthropic, true
+	case ScenarioOpenAI, ScenarioAgent, ScenarioCodex, ScenarioOpenCode, ScenarioXcode, ScenarioVSCode, ScenarioSmartGuide:
+		return TransportOpenAI, true
+	default:
+		return "", false
+	}
+}
+
+func RuleLookupScenariosForPath(requested RuleScenario) []RuleScenario {
+	candidates := []RuleScenario{requested}
+	switch requested {
+	case ScenarioOpenAI, ScenarioAnthropic:
+		candidates = append(candidates, ScenarioGeneral)
+	}
+	return candidates
+}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -52,6 +52,7 @@ type RuleScenario string
 const (
 	ScenarioOpenAI     RuleScenario = "openai"
 	ScenarioAnthropic  RuleScenario = "anthropic"
+	ScenarioGeneral    RuleScenario = "general"
 	ScenarioAgent      RuleScenario = "agent"
 	ScenarioCodex      RuleScenario = "codex"
 	ScenarioClaudeCode RuleScenario = "claude_code"


### PR DESCRIPTION
## Summary
- add a registered `general` scenario that can be used explicitly by downstream consumers such as `tbe`
- include explicit `general` rules in OpenAI and Anthropic scenario lookup and rule listing
- keep rule uniqueness scoped by scenario so shared aliases can coexist

## Scope boundary
This PR is additive support only.

It does **not** change `tb`'s existing built-in/default rule behavior:
- built-in OpenAI rules remain in the `openai` scenario
- built-in Anthropic rules remain in the `anthropic` scenario
- existing `tb` configs are not migrated to `general`

The intent is to let `tbe` opt into `general` explicitly, while `tb` keeps its current semantics unchanged.

## Verification
- `CI=true task build`
- `go test ./internal/server/config ./internal/server/module/rule`
- `task tests:interface`
- `./build/tingly-box start --port 12582 --browser=false --config-dir /tmp/tb-pr-a-start-check`
