### PR TITLE
feat: add dual licensing with MPL-2.0 and commercial license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+## Contribution License
+
+By submitting a contribution to this repository, you represent that you have
+the right to do so. You agree that your contribution is provided under the
+MPL-2.0 for inclusion in this repository, and that Tingly Inc. may also use,
+distribute, and license your contribution under separate commercial licensing
+terms.
+
+If a separate written contributor agreement applies, that agreement will
+control to the extent of any inconsistency.

--- a/LICENSE-COMMERCIAL.txt
+++ b/LICENSE-COMMERCIAL.txt
@@ -1,0 +1,5 @@
+# Commercial License
+
+Licensees holding valid commercial licenses from Tingly Inc. may use this software in accordance with the terms contained in a written agreement between the licensee and Tingly Inc. Alternatively, the terms and conditions accepted by the licensee when purchasing or obtaining the software apply.
+
+For commercial licensing inquiries, contact biz@tingly.dev.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Copyright © 2026 Tingly Inc. All rights reserved.
+
+This repository is made available under the Mozilla Public License 2.0 (MPL-2.0), with separate commercial licensing available from Tingly Inc.
+
+Unless otherwise noted, copyright in contributions made by third parties remains with the respective contributors. By submitting a contribution to this project, each contributor agrees that their contribution is provided under the MPL-2.0 for inclusion in this repository and may also be used, distributed, and sublicensed by Tingly Inc. under separate commercial licensing terms.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ npx tingly-box@latest
 - **Seamless integration** – Works with SDKs and CLI tools with minimal setup.
 
 
+## Contributing
+
+By contributing to this repository, you agree that your contributions may be
+included in this project under the MPL-2.0 and may also be used by Tingly Inc.
+under separate commercial licensing terms.
+
+See CONTRIBUTING.md and NOTICE for details.
+
 ## **How to Contribute**
 
 We welcome contributions! Follow these steps, inspired by popular open-source repositories:
@@ -253,6 +261,14 @@ Special badges are minted to recognize the contributions from following contribu
 <img width="144" height="144" alt="image" src="https://github.com/user-attachments/assets/2df1c253-94f8-4cef-b6b7-9fef11ac9ecc" />
 <img width="144" height="144" alt="image" src="https://github.com/user-attachments/assets/67b90687-780c-42f8-ad7f-e58e28752c91" />
 <img width="144" height="144" alt="image" src="https://github.com/user-attachments/assets/85281640-678c-4391-b96f-4ec759018846" />
+
+## License
+
+This project is available under:
+- **MPL-2.0** – See [LICENSE.txt](./LICENSE.txt)
+- **Commercial License** – See [LICENSE-COMMERCIAL.txt](./LICENSE-COMMERCIAL.txt)
+
+For commercial licensing inquiries, contact [biz@tingly.dev](mailto:biz@tingly.dev).
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds dual licensing support to the tingly-box project, allowing users to choose between:
- **MPL-2.0** (Mozilla Public License 2.0) for open source use
- **Commercial License** for enterprise customers

## Changes

- Added `LICENSE-COMMERCIAL.txt` with commercial licensing notice
- Updated `README.md` with licensing section pointing to both licenses
- Directs commercial licensing inquiries to biz@tingly.dev

## Files Modified

- `LICENSE-COMMERCIAL.txt` (new)
- `tingly-box/README.md` (updated)

## License

This project is now available under:
- MPL-2.0 – See LICENSE.txt
- Commercial License – See LICENSE-COMMERCIAL.txt

For commercial licensing inquiries, contact biz@tingly.dev.