### PR TITLE
feat: add scenario registration registry

### DIFF
--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -117,6 +117,13 @@ func (h *Handler) CreateRule(c *gin.Context) {
 		})
 		return
 	}
+	if !typ.CanBindRulesToScenario(rule.Scenario) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Unknown scenario",
+		})
+		return
+	}
 	rule.UUID = uuid.NewString()
 
 	if h.config == nil {
@@ -184,6 +191,13 @@ func (h *Handler) UpdateRule(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"success": false,
 			"error":   "Global config not available",
+		})
+		return
+	}
+	if !typ.CanBindRulesToScenario(rule.Scenario) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Unknown scenario",
 		})
 		return
 	}

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -38,6 +38,19 @@ func setupTestRouter(cfg *config.Config) *gin.Engine {
 	return router
 }
 
+func registerTestRuleScenario(t *testing.T, scenario typ.RuleScenario) {
+	t.Helper()
+	err := typ.RegisterScenario(typ.ScenarioDescriptor{
+		ID:                 scenario,
+		SupportedTransport: []typ.ScenarioTransport{typ.TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: false,
+	})
+	if err != nil {
+		t.Fatalf("RegisterScenario(%q) error = %v", scenario, err)
+	}
+}
+
 func TestNewHandler(t *testing.T) {
 	actionLogger := setupTestActionLogger()
 	handler := NewHandler(nil, actionLogger)
@@ -205,6 +218,8 @@ func TestGetRule_NilConfig(t *testing.T) {
 }
 
 func TestCreateRule_Success(t *testing.T) {
+	registerTestRuleScenario(t, typ.RuleScenario("test-scenario"))
+
 	cfg := NewConfig(t)
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -265,6 +280,8 @@ func TestCreateRule_NoScenario(t *testing.T) {
 }
 
 func TestUpdateRule_Success(t *testing.T) {
+	registerTestRuleScenario(t, typ.RuleScenario("test-scenario"))
+
 	cfg := NewConfig(t)
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -682,16 +682,5 @@ func (s *Server) convertMessagesToResponseInputItems(messages []openai.ChatCompl
 
 // isValidRuleScenario checks if the given scenario is a valid RuleScenario
 func isValidRuleScenario(scenario typ.RuleScenario) bool {
-	switch scenario {
-	case typ.ScenarioOpenAI, typ.ScenarioAnthropic:
-		return true
-	case typ.ScenarioAgent:
-		return true
-	case typ.ScenarioCodex, typ.ScenarioClaudeCode, typ.ScenarioOpenCode, typ.ScenarioXcode, typ.ScenarioVSCode:
-		return true
-	case typ.ScenarioSmartGuide:
-		return true
-	default:
-		return false
-	}
+	return typ.CanUseScenarioInPath(scenario)
 }

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -1,0 +1,156 @@
+package typ
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+)
+
+type ScenarioTransport string
+
+const (
+	TransportOpenAI    ScenarioTransport = "openai"
+	TransportAnthropic ScenarioTransport = "anthropic"
+)
+
+type ScenarioDescriptor struct {
+	// ID is the stable scenario identifier stored on rules and scenario configs.
+	ID RuleScenario `json:"id" yaml:"id"`
+	// SupportedTransport declares which protocol surfaces may resolve rules bound to this scenario.
+	SupportedTransport []ScenarioTransport `json:"supported_transport" yaml:"supported_transport"`
+	// AllowRuleBinding controls whether API/CLI callers may create or update rules under this scenario.
+	AllowRuleBinding bool `json:"allow_rule_binding" yaml:"allow_rule_binding"`
+	// AllowDirectPathUse controls whether scenario-scoped HTTP paths like /openai/{scenario}/... are valid.
+	AllowDirectPathUse bool `json:"allow_direct_path_use" yaml:"allow_direct_path_use"`
+}
+
+var (
+	scenarioRegistryMu sync.RWMutex
+	scenarioRegistry   = map[RuleScenario]ScenarioDescriptor{}
+)
+
+func init() {
+	for _, descriptor := range BuiltinScenarioDescriptors() {
+		scenarioRegistry[descriptor.ID] = cloneScenarioDescriptor(descriptor)
+	}
+}
+
+func BuiltinScenarioDescriptors() []ScenarioDescriptor {
+	descriptors := make([]ScenarioDescriptor, 0, len(BuiltinScenarios()))
+	for _, scenario := range BuiltinScenarios() {
+		descriptors = append(descriptors, builtinScenarioDescriptorFor(scenario))
+	}
+	return descriptors
+}
+
+func builtinScenarioDescriptorFor(scenario RuleScenario) ScenarioDescriptor {
+	switch scenario {
+	case ScenarioOpenAI:
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportOpenAI},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
+	case ScenarioAnthropic:
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportAnthropic},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
+	case ScenarioAgent, ScenarioCodex, ScenarioOpenCode, ScenarioXcode, ScenarioVSCode, ScenarioSmartGuide:
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportOpenAI},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
+	case ScenarioClaudeCode:
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportAnthropic},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
+	case ScenarioGlobal:
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: nil,
+			AllowRuleBinding:   false,
+			AllowDirectPathUse: false,
+		}
+	default:
+		return ScenarioDescriptor{ID: scenario}
+	}
+}
+
+func cloneScenarioDescriptor(descriptor ScenarioDescriptor) ScenarioDescriptor {
+	out := descriptor
+	out.SupportedTransport = slices.Clone(descriptor.SupportedTransport)
+	return out
+}
+
+func RegisterScenario(descriptor ScenarioDescriptor) error {
+	if descriptor.ID == "" {
+		return fmt.Errorf("scenario id is required")
+	}
+
+	descriptor = cloneScenarioDescriptor(descriptor)
+
+	scenarioRegistryMu.Lock()
+	defer scenarioRegistryMu.Unlock()
+
+	if existing, ok := scenarioRegistry[descriptor.ID]; ok {
+		if existing.AllowRuleBinding == descriptor.AllowRuleBinding &&
+			existing.AllowDirectPathUse == descriptor.AllowDirectPathUse &&
+			slices.Equal(existing.SupportedTransport, descriptor.SupportedTransport) {
+			return nil
+		}
+		return fmt.Errorf("scenario %s already registered with different descriptor", descriptor.ID)
+	}
+
+	scenarioRegistry[descriptor.ID] = descriptor
+	return nil
+}
+
+func RegisteredScenarioDescriptors() []ScenarioDescriptor {
+	scenarioRegistryMu.RLock()
+	defer scenarioRegistryMu.RUnlock()
+
+	descriptors := make([]ScenarioDescriptor, 0, len(scenarioRegistry))
+	for _, descriptor := range scenarioRegistry {
+		descriptors = append(descriptors, cloneScenarioDescriptor(descriptor))
+	}
+	slices.SortFunc(descriptors, func(a, b ScenarioDescriptor) int {
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	return descriptors
+}
+
+func GetScenarioDescriptor(scenario RuleScenario) (ScenarioDescriptor, bool) {
+	scenarioRegistryMu.RLock()
+	defer scenarioRegistryMu.RUnlock()
+
+	descriptor, ok := scenarioRegistry[scenario]
+	if !ok {
+		return ScenarioDescriptor{}, false
+	}
+	return cloneScenarioDescriptor(descriptor), true
+}
+
+func CanBindRulesToScenario(scenario RuleScenario) bool {
+	descriptor, ok := GetScenarioDescriptor(scenario)
+	return ok && descriptor.AllowRuleBinding
+}
+
+func CanUseScenarioInPath(scenario RuleScenario) bool {
+	descriptor, ok := GetScenarioDescriptor(scenario)
+	return ok && descriptor.AllowDirectPathUse
+}

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -1,0 +1,62 @@
+package typ
+
+import "testing"
+
+func TestRegisterScenario_AllowsRuleBindingWithoutPathUsage(t *testing.T) {
+	scenario := RuleScenario("test_shared_registry")
+
+	if err := RegisterScenario(ScenarioDescriptor{
+		ID:                 scenario,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: false,
+	}); err != nil {
+		t.Fatalf("RegisterScenario() error = %v", err)
+	}
+
+	if !CanBindRulesToScenario(scenario) {
+		t.Fatalf("expected %q to allow rule binding", scenario)
+	}
+	if CanUseScenarioInPath(scenario) {
+		t.Fatalf("expected %q to reject direct path use", scenario)
+	}
+}
+
+func TestRegisterScenario_IsIdempotentForSameDescriptor(t *testing.T) {
+	scenario := RuleScenario("test_registry_idempotent")
+	descriptor := ScenarioDescriptor{
+		ID:                 scenario,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: false,
+	}
+
+	if err := RegisterScenario(descriptor); err != nil {
+		t.Fatalf("RegisterScenario() first call error = %v", err)
+	}
+	if err := RegisterScenario(descriptor); err != nil {
+		t.Fatalf("RegisterScenario() second call error = %v", err)
+	}
+}
+
+func TestRegisterScenario_RejectsConflictingDescriptor(t *testing.T) {
+	scenario := RuleScenario("test_registry_conflict")
+
+	if err := RegisterScenario(ScenarioDescriptor{
+		ID:                 scenario,
+		SupportedTransport: []ScenarioTransport{TransportOpenAI},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: false,
+	}); err != nil {
+		t.Fatalf("RegisterScenario() first call error = %v", err)
+	}
+
+	if err := RegisterScenario(ScenarioDescriptor{
+		ID:                 scenario,
+		SupportedTransport: []ScenarioTransport{TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: false,
+	}); err == nil {
+		t.Fatalf("expected conflicting descriptor registration to fail")
+	}
+}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -62,6 +62,21 @@ const (
 	ScenarioGlobal     RuleScenario = "_global" // Global flags that apply to all scenarios
 )
 
+func BuiltinScenarios() []RuleScenario {
+	return []RuleScenario{
+		ScenarioOpenAI,
+		ScenarioAnthropic,
+		ScenarioAgent,
+		ScenarioCodex,
+		ScenarioClaudeCode,
+		ScenarioOpenCode,
+		ScenarioXcode,
+		ScenarioVSCode,
+		ScenarioSmartGuide,
+		ScenarioGlobal,
+	}
+}
+
 // ThinkingEffortLevel represents the thinking effort level for extended thinking
 type ThinkingEffortLevel = string
 


### PR DESCRIPTION
## Summary
- add a minimal scenario registration registry in `internal/typ`
- allow rule create/update to bind only to registered, bindable scenarios
- keep direct path usage gated separately so enterprise-only scenarios can be registered without changing existing routing semantics

## What This Does Not Change
- no fallback lookup
- no built-in migration
- no scenario uniqueness changes
- no `general` builtin behavior
- no mixed scenario listing behavior

## Verification
- `go test ./internal/typ`
- `go test ./internal/server -run ^$`

## Notes
- `internal/server/module/rule` has pre-existing test-file drift against the current `NewHandler` signature and was not expanded as part of this PR.