### PR TITLE
fix(server): enforce minimum 1024 budget_tokens for thinking

### DIFF
--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -102,7 +102,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	}
 	// If thinking carries budget_tokens beyond model max, shrink budget to max_allowed/10.
 	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil && *thinkBudget > int64(maxAllowed) {
-		req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(int64(maxAllowed / 10))
+		req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(max(1024, int64(maxAllowed / 10)))
 	}
 
 	// Set provider UUID in context (Service.Provider uses UUID, not name)

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -100,9 +100,9 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	if req.MaxTokens > int64(maxAllowed) {
 		req.MaxTokens = int64(maxAllowed)
 	}
-	// If thinking carries budget_tokens beyond model max, shrink budget to max_allowed/10.
+	// If thinking carries budget_tokens beyond model max, shrink budget to max_allowed/10, but at leas 1024
 	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil && *thinkBudget > int64(maxAllowed) {
-		req.Thinking = anthropic.ThinkingConfigParamOfEnabled(int64(maxAllowed / 10))
+		req.Thinking = anthropic.ThinkingConfigParamOfEnabled(max(1024, int64(maxAllowed / 10)))
 	}
 
 	// Set provider UUID in context (Service.Provider uses UUID, not name)


### PR DESCRIPTION
## Summary

- Enforce a minimum floor of 1024 tokens for `budget_tokens` when adjusting thinking configuration for downstream providers
- Fix 400 Bad Request error when downstream providers require minimum 1024 budget_tokens

## Problem

When the thinking budget is adjusted based on model's max tokens (`maxAllowed / 10`), it can fall below 1024 tokens. However, many downstream providers (e.g., third-party Anthropic-compatible APIs) enforce a minimum of 1024 tokens for `budget_tokens`, causing requests to fail with:

```
400 Bad Request
{
  "error": {
    "message": "***.enabled.budget_tokens: Input should be greater than or equal to 1024",
    "type": "error"
  }
}
```

## Solution

Use `max(1024, maxAllowed / 10)` instead of just `maxAllowed / 10` when shrinking the thinking budget, ensuring the value never falls below 1024 tokens.

### Changed Files

- `internal/server/anthropic_beta.go`: Added `max(1024, ...)` floor for beta API thinking budget
- `internal/server/anthropic_v1.go`: Added `max(1024, ...)` floor for v1 API thinking budget

## Test Plan

- [x] Code builds successfully
- [ ] Test with downstream provider that enforces minimum 1024 budget_tokens