### PR TITLE
bugfix/server: Add module lifecycle context to Server

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,9 +131,9 @@ type Server struct {
 	remoteCoderCancel context.CancelFunc
 	remoteCoderMu     sync.Mutex
 
-	// module lifecycle management for long-lived background components created during setup
-	moduleCtx    context.Context
-	moduleCancel context.CancelFunc
+	// lifecycle management for long-lived background components created during setup
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	// custom auth middleware (optional, for TBE integration)
 	customUserAuthMiddleware  gin.HandlerFunc // For Web UI routes
@@ -294,16 +294,16 @@ func (s *Server) GetOrCreateScenarioSink(scenario typ.RuleScenario) *obs.Sink {
 
 // NewServer creates a new HTTP server instance with functional options
 func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
-	moduleCtx, moduleCancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
 	// Start with default options
 	allOpts := append([]ServerOption{WithDefault()}, opts...)
 
 	// Default options
 	server := &Server{
-		config:       cfg,
-		moduleCtx:    moduleCtx,
-		moduleCancel: moduleCancel,
+		config: cfg,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 
 	// Apply all options (defaults + provided)
@@ -520,7 +520,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
 	server.setupMiddleware()
 
 	// Setup routes
-	server.setupRoutes(server.moduleCtx)
+	server.setupRoutes(server.ctx)
 
 	// Setup configuration watcher
 	server.setupConfigWatcher()
@@ -1158,10 +1158,10 @@ func (s *Server) SyncRemoteCoderBots(ctx context.Context) error {
 
 // Stop gracefully stops the HTTP server
 func (s *Server) Stop(ctx context.Context) error {
-	if s.moduleCancel != nil {
-		s.moduleCancel()
-		s.moduleCancel = nil
-		s.moduleCtx = nil
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+		s.ctx = nil
 	}
 
 	if s.httpServer == nil {

--- a/internal/server/server_lifecycle_test.go
+++ b/internal/server/server_lifecycle_test.go
@@ -13,21 +13,21 @@ func TestNewServerKeepsModuleContextAlive(t *testing.T) {
 	}
 
 	s := NewServer(cfg, WithOpenBrowser(false))
-	if s.moduleCtx == nil {
-		t.Fatal("expected module context to be initialized")
+	if s.ctx == nil {
+		t.Fatal("expected context to be initialized")
 	}
-	if err := s.moduleCtx.Err(); err != nil {
-		t.Fatalf("expected module context to remain active after NewServer, got %v", err)
+	if err := s.ctx.Err(); err != nil {
+		t.Fatalf("expected context to remain active after NewServer, got %v", err)
 	}
 
-	if s.moduleCancel == nil {
-		t.Fatal("expected module cancel to be initialized")
+	if s.cancel == nil {
+		t.Fatal("expected cancel to be initialized")
 	}
-	s.moduleCancel()
+	s.cancel()
 
 	select {
-	case <-s.moduleCtx.Done():
+	case <-s.ctx.Done():
 	default:
-		t.Fatal("expected module context to be canceled by moduleCancel")
+		t.Fatal("expected context to be canceled by cancel")
 	}
 }


### PR DESCRIPTION
Introduce moduleCtx/moduleCancel fields to Server to manage long-lived background components created during setup. NewServer now initializes and stores the module context (instead of creating a transient ctx that was immediately canceled), passes it to setupRoutes, and Stop will cancel the module context when shutting down. Add server_lifecycle_test.go to verify the module context remains active after NewServer and is canceled by moduleCancel.

Try to fix #570 .