### PR TITLE
fix(anthropic): return proxy model in stream message_start

### DIFF
--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -38,10 +39,6 @@ func HandleAnthropicV1Stream(hc *protocol.HandleContext, req anthropic.MessageNe
 		},
 		func(event interface{}) error {
 			evt := event.(*anthropic.MessageStreamEventUnion)
-			// Only set model for message_start events, as other events don't have a message field
-			if evt.Type == "message_start" {
-				evt.Message.Model = anthropic.Model(hc.ResponseModel)
-			}
 
 			if evt.Usage.InputTokens > 0 {
 				inputTokens = int(evt.Usage.InputTokens)
@@ -56,8 +53,24 @@ func HandleAnthropicV1Stream(hc *protocol.HandleContext, req anthropic.MessageNe
 				hasUsage = true
 			}
 
-			// Send SSE event using RawJSON to preserve original API response
-			hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+			// For message_start events, modify the model in the raw JSON
+			// to preserve the original API response structure
+			if evt.Type == "message_start" {
+				var eventMap map[string]json.RawMessage
+				if err := json.Unmarshal([]byte(evt.RawJSON()), &eventMap); err == nil {
+					var msgMap map[string]json.RawMessage
+					if err := json.Unmarshal(eventMap["message"], &msgMap); err == nil {
+						msgMap["model"] = json.RawMessage(`"` + hc.ResponseModel + `"`)
+						eventMap["message"], _ = json.Marshal(msgMap)
+					}
+					modified, _ := json.Marshal(eventMap)
+					hc.GinContext.SSEvent(evt.Type, string(modified))
+				} else {
+					hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+				}
+			} else {
+				hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+			}
 			hc.GinContext.Writer.Flush()
 			return nil
 		},
@@ -106,10 +119,6 @@ func HandleAnthropicV1BetaStream(hc *protocol.HandleContext, req anthropic.BetaM
 		},
 		func(event interface{}) error {
 			evt := event.(*anthropic.BetaRawMessageStreamEventUnion)
-			// Only set model for message_start events, as other events don't have a message field
-			if evt.Type == "message_start" {
-				evt.Message.Model = anthropic.Model(hc.ResponseModel)
-			}
 
 			if evt.Usage.InputTokens > 0 {
 				inputTokens = int(evt.Usage.InputTokens)
@@ -124,8 +133,24 @@ func HandleAnthropicV1BetaStream(hc *protocol.HandleContext, req anthropic.BetaM
 				hasUsage = true
 			}
 
-			// MENTION: Send SSE event, should use evt.RawJSON()
-			hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+			// For message_start events, modify the model in the raw JSON
+			// to preserve the original API response structure
+			if evt.Type == "message_start" {
+				var eventMap map[string]json.RawMessage
+				if err := json.Unmarshal([]byte(evt.RawJSON()), &eventMap); err == nil {
+					var msgMap map[string]json.RawMessage
+					if err := json.Unmarshal(eventMap["message"], &msgMap); err == nil {
+						msgMap["model"] = json.RawMessage(`"` + hc.ResponseModel + `"`)
+						eventMap["message"], _ = json.Marshal(msgMap)
+					}
+					modified, _ := json.Marshal(eventMap)
+					hc.GinContext.SSEvent(evt.Type, string(modified))
+				} else {
+					hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+				}
+			} else {
+				hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+			}
 			hc.GinContext.Writer.Flush()
 			return nil
 		},


### PR DESCRIPTION
## Summary
- Ensure Anthropic streaming `message_start` events return the proxy/request model (`hc.ResponseModel`) instead of the upstream provider model.
- Apply the same fix to both v1 stream and v1 beta stream handlers in `internal/protocol/stream/anthropic_passthrough.go`.
- Preserve raw SSE shape by editing only `message.model` in decoded raw event payload before forwarding.

## Before / After Samples
### Before (`stream_response_before_fix.json`)
```text
event:message_start
data:{"type": "message_start", "message": {"id": "msg_2026032715123596c12cbdbf5348a1", "type": "message", "role": "assistant", "model": "glm-4.6", "content": [], "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0}}}


```

### After (`stream_response_after_fix.json`)
```text
event:message_start
data:{"message":{"content":[],"id":"msg_2026032716004387512f9be0444c06","model":"tingly-glm","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"input_tokens":0,"output_tokens":0}},"type":"message_start"}

```

## Test plan
- [x] `task build` in enterprise repo succeeds.
- [x] Manual streaming request validated for `message_start.message.model` using Anthropic endpoint.
- [x] Confirmed non-`message_start` events continue to passthrough via raw JSON path.
