### PR TITLE
server: include transport-reachable scenarios in model list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ dist-ssr
 
 # Go workspace file
 go.work
+go.work.sum
 
 # End of https://www.toptal.com/developers/gitignore/api/go
 /openspec/

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -211,7 +211,7 @@ func (s *Server) anthropicListModelsWithScenario(c *gin.Context, scenario *typ.R
 		if !rule.Active {
 			continue
 		}
-		if scenario != nil && rule.GetScenario() != *scenario {
+		if scenario != nil && !shouldIncludeRuleInModelList(*scenario, rule.GetScenario()) {
 			continue
 		}
 

--- a/internal/server/model_list_scope.go
+++ b/internal/server/model_list_scope.go
@@ -19,13 +19,14 @@ func shouldIncludeRuleInModelList(requestedScenario typ.RuleScenario, ruleScenar
 	if requestedScenario == ruleScenario {
 		return true
 	}
-
-	switch requestedScenario {
-	case typ.ScenarioOpenAI:
-		return scenarioSupportsTransport(ruleScenario, typ.TransportOpenAI)
-	case typ.ScenarioAnthropic:
-		return scenarioSupportsTransport(ruleScenario, typ.TransportAnthropic)
-	default:
+	requestedDescriptor, ok := typ.GetScenarioDescriptor(requestedScenario)
+	if !ok {
 		return false
 	}
+	for _, transport := range requestedDescriptor.SupportedTransport {
+		if scenarioSupportsTransport(ruleScenario, transport) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/model_list_scope.go
+++ b/internal/server/model_list_scope.go
@@ -1,0 +1,31 @@
+package server
+
+import "github.com/tingly-dev/tingly-box/internal/typ"
+
+func scenarioSupportsTransport(scenario typ.RuleScenario, transport typ.ScenarioTransport) bool {
+	descriptor, ok := typ.GetScenarioDescriptor(scenario)
+	if !ok {
+		return false
+	}
+	for _, supported := range descriptor.SupportedTransport {
+		if supported == transport {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldIncludeRuleInModelList(requestedScenario typ.RuleScenario, ruleScenario typ.RuleScenario) bool {
+	if requestedScenario == ruleScenario {
+		return true
+	}
+
+	switch requestedScenario {
+	case typ.ScenarioOpenAI:
+		return scenarioSupportsTransport(ruleScenario, typ.TransportOpenAI)
+	case typ.ScenarioAnthropic:
+		return scenarioSupportsTransport(ruleScenario, typ.TransportAnthropic)
+	default:
+		return false
+	}
+}

--- a/internal/server/model_list_scope_test.go
+++ b/internal/server/model_list_scope_test.go
@@ -6,12 +6,15 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func TestShouldIncludeRuleInModelList_StrictForCustomScenario(t *testing.T) {
+func TestShouldIncludeRuleInModelList_TransportReachabilityForOpenAI(t *testing.T) {
 	if !shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioOpenCode) {
 		t.Fatalf("expected exact scenario match to be included")
 	}
-	if shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioCodex) {
-		t.Fatalf("expected non-matching custom scenario to be excluded")
+	if !shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioCodex) {
+		t.Fatalf("expected openai-transport scenario to include transport-reachable scenario")
+	}
+	if shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioAnthropic) {
+		t.Fatalf("expected openai-transport scenario to exclude anthropic-only scenario")
 	}
 }
 
@@ -32,5 +35,34 @@ func TestShouldIncludeRuleInModelList_TransportReachabilityForAnthropic(t *testi
 	}
 	if shouldIncludeRuleInModelList(typ.ScenarioOpenAI, customScenario) {
 		t.Fatalf("expected openai model list to exclude anthropic-only custom scenario")
+	}
+}
+
+func TestShouldIncludeRuleInModelList_ClaudeCodeUsesAnthropicTransport(t *testing.T) {
+	if !shouldIncludeRuleInModelList(typ.ScenarioClaudeCode, typ.ScenarioAnthropic) {
+		t.Fatalf("expected claude_code model list to include anthropic-transport scenario")
+	}
+	if shouldIncludeRuleInModelList(typ.ScenarioClaudeCode, typ.ScenarioOpenAI) {
+		t.Fatalf("expected claude_code model list to exclude openai-only scenario")
+	}
+}
+
+func TestShouldIncludeRuleInModelList_CustomScenarioWithBothTransports(t *testing.T) {
+	customScenario := typ.RuleScenario("general_test_transport_both")
+	err := typ.RegisterScenario(typ.ScenarioDescriptor{
+		ID:                 customScenario,
+		SupportedTransport: []typ.ScenarioTransport{typ.TransportOpenAI, typ.TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	})
+	if err != nil {
+		t.Fatalf("register custom scenario: %v", err)
+	}
+
+	if !shouldIncludeRuleInModelList(customScenario, typ.ScenarioOpenAI) {
+		t.Fatalf("expected custom scenario to include openai transport scenario")
+	}
+	if !shouldIncludeRuleInModelList(customScenario, typ.ScenarioAnthropic) {
+		t.Fatalf("expected custom scenario to include anthropic transport scenario")
 	}
 }

--- a/internal/server/model_list_scope_test.go
+++ b/internal/server/model_list_scope_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestShouldIncludeRuleInModelList_StrictForCustomScenario(t *testing.T) {
+	if !shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioOpenCode) {
+		t.Fatalf("expected exact scenario match to be included")
+	}
+	if shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioCodex) {
+		t.Fatalf("expected non-matching custom scenario to be excluded")
+	}
+}
+
+func TestShouldIncludeRuleInModelList_TransportReachabilityForAnthropic(t *testing.T) {
+	customScenario := typ.RuleScenario("general_test_transport_anthropic")
+	err := typ.RegisterScenario(typ.ScenarioDescriptor{
+		ID:                 customScenario,
+		SupportedTransport: []typ.ScenarioTransport{typ.TransportAnthropic},
+		AllowRuleBinding:   true,
+		AllowDirectPathUse: true,
+	})
+	if err != nil {
+		t.Fatalf("register custom scenario: %v", err)
+	}
+
+	if !shouldIncludeRuleInModelList(typ.ScenarioAnthropic, customScenario) {
+		t.Fatalf("expected anthropic model list to include transport-reachable custom scenario")
+	}
+	if shouldIncludeRuleInModelList(typ.ScenarioOpenAI, customScenario) {
+		t.Fatalf("expected openai model list to exclude anthropic-only custom scenario")
+	}
+}

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -48,7 +48,7 @@ func (s *Server) openAIListModelsWithScenario(c *gin.Context, scenario *typ.Rule
 		if !rule.Active {
 			continue
 		}
-		if scenario != nil && rule.GetScenario() != *scenario {
+		if scenario != nil && !shouldIncludeRuleInModelList(*scenario, rule.GetScenario()) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- include transport-reachable scenarios in OpenAI/Anthropic model listing
- keep strict behavior for non-transport list contexts via shared scope helper
- add unit tests for model-list scope behavior
- ignore go.work.sum in .gitignore

## Why
- custom scenarios (e.g. general-like) with anthropic/openai transport should be visible on corresponding model list endpoints
- avoid accidental local noise from go.work.sum

## Testing
- go test ./internal/server -run TestShouldIncludeRuleInModelList -count=1