### PR TITLE
Fix streamed OpenAI cancellations being recorded as successful usage

### DIFF
--- a/internal/protocol/stream/anthropic_to_openai_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_test.go
@@ -116,7 +116,7 @@ func TestSendOpenAIStreamChunk(t *testing.T) {
 		},
 	}
 
-	sendOpenAIStreamChunk(c, chunk)
+	sendOpenAIStreamChunkForce(c, chunk)
 
 	body := w.Body.String()
 	assert.Contains(t, body, "data: ")

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -338,6 +338,9 @@ func HandleOpenAIToAnthropicStreamResponse(c *gin.Context, req *openai.ChatCompl
 		sendAnthropicStreamEvent(c, "error", errorEvent, flusher)
 		return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), err
 	}
+	if errors.Is(c.Request.Context().Err(), context.Canceled) {
+		return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), context.Canceled
+	}
 	return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), nil
 }
 

--- a/internal/protocol/stream/openai_to_anthropic_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
@@ -11,9 +12,27 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	openaiOption "github.com/openai/openai-go/v3/option"
+	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeOpenAIDecoder struct{}
+
+func (f *fakeOpenAIDecoder) Event() openaistream.Event { return openaistream.Event{} }
+func (f *fakeOpenAIDecoder) Next() bool                { return false }
+func (f *fakeOpenAIDecoder) Close() error              { return nil }
+func (f *fakeOpenAIDecoder) Err() error                { return nil }
+
+type closeNotifyRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (r *closeNotifyRecorder) CloseNotify() <-chan bool {
+	ch := make(chan bool)
+	close(ch)
+	return ch
+}
 
 // TestHandleOpenAIToAnthropicStreamResponse tests the OpenAI to Anthropic stream conversion
 func TestHandleOpenAIToAnthropicStreamResponse(t *testing.T) {
@@ -246,6 +265,25 @@ func TestHandleOpenAIToAnthropicStreamResponseWithThinking(t *testing.T) {
 
 	// Verify SSE headers
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+}
+
+func TestHandleOpenAIToAnthropicStreamResponse_ClientCanceled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	c.Request = req.WithContext(ctx)
+
+	stream := openaistream.NewStream[openai.ChatCompletionChunk](&fakeOpenAIDecoder{}, nil)
+
+	usage, err := HandleOpenAIToAnthropicStreamResponse(c, nil, stream, "test-model")
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, usage)
+	assert.Equal(t, 0, usage.InputTokens)
+	assert.Equal(t, 0, usage.OutputTokens)
 }
 
 // parseSSEEvents parses SSE response body into a map of events


### PR DESCRIPTION
## Summary
- treat client-canceled OpenAI->Anthropic streaming requests as canceled instead of successful usage
- add a regression test for canceled stream handling
- update the existing stream test helper call so the package test suite compiles cleanly

## Why
Some streamed OpenAI-compatible requests were being recorded as  even when the client disconnected early. In that path, input tokens were already estimated, while output tokens stayed at zero. That polluted usage data with abnormally large successful input counts.

## What changed
- return  from the OpenAI->Anthropic stream bridge when the client request context is canceled
- keep the partial usage object so upstream can classify the request correctly
- add a focused test that asserts canceled client streams do not return success

## Validation
- ok  	github.com/tingly-dev/tingly-box/internal/protocol/stream	(cached)
- ok  	github.com/tingly-dev/tingly-box/internal/server	(cached)
