### PR TITLE
refactor(protocol): unify OpenAI Chat to Anthropic beta transform pipeline (partial)

### DIFF
--- a/internal/protocol/nonstream/anthropic_to_openai.go
+++ b/internal/protocol/nonstream/anthropic_to_openai.go
@@ -8,10 +8,7 @@ import (
 )
 
 // ConvertAnthropicToOpenAIResponse converts an Anthropic response to OpenAI format
-func ConvertAnthropicToOpenAIResponse(
-	anthropicResp *anthropic.Message,
-	responseModel string,
-) map[string]interface{} {
+func ConvertAnthropicToOpenAIResponse(anthropicResp *anthropic.BetaMessage, responseModel string) map[string]interface{} {
 
 	message := make(map[string]interface{})
 	var toolCalls []map[string]interface{}

--- a/internal/protocol/nonstream/google_to.go
+++ b/internal/protocol/nonstream/google_to.go
@@ -118,9 +118,9 @@ func MapGoogleFinishReasonToOpenAI(reason genai.FinishReason) string {
 }
 
 // ConvertGoogleToAnthropicResponse converts Google GenerateContentResponse to Anthropic format
-func ConvertGoogleToAnthropicResponse(googleResp *genai.GenerateContentResponse, responseModel string) anthropic.Message {
+func ConvertGoogleToAnthropicResponse(googleResp *genai.GenerateContentResponse, responseModel string) *anthropic.BetaMessage {
 	if googleResp == nil {
-		return anthropic.Message{}
+		return &anthropic.BetaMessage{}
 	}
 
 	// Build response JSON
@@ -180,10 +180,10 @@ func ConvertGoogleToAnthropicResponse(googleResp *genai.GenerateContentResponse,
 
 	// Marshal and unmarshal to create proper Message struct
 	jsonBytes, _ := json.Marshal(responseJSON)
-	var msg anthropic.Message
+	var msg anthropic.BetaMessage
 	json.Unmarshal(jsonBytes, &msg)
 
-	return msg
+	return &msg
 }
 
 func MapGoogleFinishReasonToAnthropic(reason genai.FinishReason) string {

--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
-func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model string) *anthropic.Message {
+func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model string) *anthropic.BetaMessage {
 	// Create the response as JSON first, then unmarshal into Message
 	// This is a workaround for the complex union types
 	responseJSON := map[string]interface{}{
@@ -73,7 +73,7 @@ func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model s
 
 	// Marshal and unmarshal to create proper Message struct
 	jsonBytes, _ := json.Marshal(responseJSON)
-	var msg anthropic.Message
+	var msg anthropic.BetaMessage
 	json.Unmarshal(jsonBytes, &msg)
 
 	return &msg

--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
-func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model string) anthropic.Message {
+func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model string) *anthropic.Message {
 	// Create the response as JSON first, then unmarshal into Message
 	// This is a workaround for the complex union types
 	responseJSON := map[string]interface{}{
@@ -76,7 +76,7 @@ func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model s
 	var msg anthropic.Message
 	json.Unmarshal(jsonBytes, &msg)
 
-	return msg
+	return &msg
 }
 
 // ConvertOpenAIToAnthropicBetaResponse converts OpenAI response to Anthropic beta format

--- a/internal/protocol/request/openai_to_anthropic.go
+++ b/internal/protocol/request/openai_to_anthropic.go
@@ -8,8 +8,8 @@ import (
 )
 
 // ConvertOpenAIToAnthropicRequest converts OpenAI ChatCompletionNewParams to Anthropic SDK format
-func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaultMaxTokens int64) *anthropic.MessageNewParams {
-	messages := make([]anthropic.MessageParam, 0, len(req.Messages))
+func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaultMaxTokens int64) *anthropic.BetaMessageNewParams {
+	messages := make([]anthropic.BetaMessageParam, 0, len(req.Messages))
 	var systemParts []string
 
 	for _, msg := range req.Messages {
@@ -32,33 +32,33 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 
 		case "user":
 			// User message
-			var blocks []anthropic.ContentBlockParamUnion
+			var blocks []anthropic.BetaContentBlockParamUnion
 
 			if content, ok := m["content"].(string); ok && content != "" {
 				// Simple text content
-				blocks = append(blocks, anthropic.NewTextBlock(content))
+				blocks = append(blocks, anthropic.NewBetaTextBlock(content))
 			} else if contentParts, ok := m["content"].([]interface{}); ok {
 				// Array of content parts (multimodal)
 				for _, part := range contentParts {
 					if partMap, ok := part.(map[string]interface{}); ok {
 						if text, ok := partMap["text"].(string); ok {
-							blocks = append(blocks, anthropic.NewTextBlock(text))
+							blocks = append(blocks, anthropic.NewBetaTextBlock(text))
 						}
 					}
 				}
 			}
 
 			if len(blocks) > 0 {
-				messages = append(messages, anthropic.NewUserMessage(blocks...))
+				messages = append(messages, anthropic.NewBetaUserMessage(blocks...))
 			}
 
 		case "assistant":
 			// Assistant message
-			var blocks []anthropic.ContentBlockParamUnion
+			var blocks []anthropic.BetaContentBlockParamUnion
 
 			// Add text content if present
 			if content, ok := m["content"].(string); ok && content != "" {
-				blocks = append(blocks, anthropic.NewTextBlock(content))
+				blocks = append(blocks, anthropic.NewBetaTextBlock(content))
 			}
 
 			// Convert tool calls to tool_use blocks
@@ -75,7 +75,7 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 							}
 
 							blocks = append(blocks,
-								anthropic.NewToolUseBlock(id, argsInput, name),
+								anthropic.NewBetaToolUseBlock(id, argsInput, name),
 							)
 						}
 					}
@@ -83,7 +83,10 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			}
 
 			if len(blocks) > 0 {
-				messages = append(messages, anthropic.NewAssistantMessage(blocks...))
+				messages = append(messages, anthropic.BetaMessageParam{
+					Content: blocks,
+					Role:    anthropic.BetaMessageParamRoleAssistant,
+				})
 			}
 
 		case "tool":
@@ -91,10 +94,10 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			toolCallID, _ := m["tool_call_id"].(string)
 			content, _ := m["content"].(string)
 
-			blocks := []anthropic.ContentBlockParamUnion{
-				anthropic.NewToolResultBlock(toolCallID, content, false),
+			blocks := []anthropic.BetaContentBlockParamUnion{
+				anthropic.NewBetaToolResultBlock(toolCallID, content, false),
 			}
-			messages = append(messages, anthropic.NewUserMessage(blocks...))
+			messages = append(messages, anthropic.NewBetaUserMessage(blocks...))
 		}
 	}
 
@@ -104,7 +107,7 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 		maxTokens = defaultMaxTokens
 	}
 
-	params := &anthropic.MessageNewParams{
+	params := &anthropic.BetaMessageNewParams{
 		Model:     anthropic.Model(req.Model),
 		Messages:  messages,
 		MaxTokens: maxTokens,
@@ -112,9 +115,9 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 
 	// Add system parts if any
 	if len(systemParts) > 0 {
-		params.System = make([]anthropic.TextBlockParam, len(systemParts))
+		params.System = make([]anthropic.BetaTextBlockParam, len(systemParts))
 		for i, part := range systemParts {
-			params.System[i] = anthropic.TextBlockParam{Text: part}
+			params.System[i] = anthropic.BetaTextBlockParam{Text: part}
 		}
 	}
 
@@ -129,13 +132,13 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 	return params
 }
 
-func ConvertOpenAIToAnthropicTools(tools []openai.ChatCompletionToolUnionParam) []anthropic.ToolUnionParam {
+func ConvertOpenAIToAnthropicTools(tools []openai.ChatCompletionToolUnionParam) []anthropic.BetaToolUnionParam {
 
 	if len(tools) == 0 {
 		return nil
 	}
 
-	out := make([]anthropic.ToolUnionParam, 0, len(tools))
+	out := make([]anthropic.BetaToolUnionParam, 0, len(tools))
 
 	for _, t := range tools {
 		fn := t.GetFunction()
@@ -149,14 +152,14 @@ func ConvertOpenAIToAnthropicTools(tools []openai.ChatCompletionToolUnionParam) 
 			if bytes, err := json.Marshal(fn.Parameters); err == nil {
 				if err := json.Unmarshal(bytes, &inputSchema); err == nil {
 					// Create tool with input schema
-					var tool anthropic.ToolUnionParam
+					var tool anthropic.BetaToolUnionParam
 					if inputSchema != nil {
 						// Convert map[string]interface{} to the proper structure
 						if schemaBytes, err := json.Marshal(inputSchema); err == nil {
-							var schemaParam anthropic.ToolInputSchemaParam
+							var schemaParam anthropic.BetaToolInputSchemaParam
 							if err := json.Unmarshal(schemaBytes, &schemaParam); err == nil {
-								tool = anthropic.ToolUnionParam{
-									OfTool: &anthropic.ToolParam{
+								tool = anthropic.BetaToolUnionParam{
+									OfTool: &anthropic.BetaToolParam{
 										Name:        fn.Name,
 										InputSchema: schemaParam,
 									},
@@ -164,8 +167,8 @@ func ConvertOpenAIToAnthropicTools(tools []openai.ChatCompletionToolUnionParam) 
 							}
 						}
 					} else {
-						tool = anthropic.ToolUnionParam{
-							OfTool: &anthropic.ToolParam{
+						tool = anthropic.BetaToolUnionParam{
+							OfTool: &anthropic.BetaToolParam{
 								Name: fn.Name,
 							},
 						}
@@ -184,39 +187,39 @@ func ConvertOpenAIToAnthropicTools(tools []openai.ChatCompletionToolUnionParam) 
 	return out
 }
 
-func ConvertOpenAIToAnthropicToolChoice(tc *openai.ChatCompletionToolChoiceOptionUnionParam) anthropic.ToolChoiceUnionParam {
+func ConvertOpenAIToAnthropicToolChoice(tc *openai.ChatCompletionToolChoiceOptionUnionParam) anthropic.BetaToolChoiceUnionParam {
 
 	// Check the different variants
 	if auto := tc.OfAuto.Value; auto != "" {
 		if auto == "auto" {
-			return anthropic.ToolChoiceUnionParam{
-				OfAuto: &anthropic.ToolChoiceAutoParam{},
+			return anthropic.BetaToolChoiceUnionParam{
+				OfAuto: &anthropic.BetaToolChoiceAutoParam{},
 			}
 		}
 	}
 
 	if tc.OfAllowedTools != nil {
 		// Default to auto for allowed tools
-		return anthropic.ToolChoiceUnionParam{
-			OfAuto: &anthropic.ToolChoiceAutoParam{},
+		return anthropic.BetaToolChoiceUnionParam{
+			OfAuto: &anthropic.BetaToolChoiceAutoParam{},
 		}
 	}
 
 	if funcChoice := tc.OfFunctionToolChoice; funcChoice != nil {
 		if name := funcChoice.Function.Name; name != "" {
-			return anthropic.ToolChoiceParamOfTool(name)
+			return anthropic.BetaToolChoiceParamOfTool(name)
 		}
 	}
 
 	if tc.OfCustomToolChoice != nil {
 		// Default to auto for custom tool choice
-		return anthropic.ToolChoiceUnionParam{
-			OfAuto: &anthropic.ToolChoiceAutoParam{},
+		return anthropic.BetaToolChoiceUnionParam{
+			OfAuto: &anthropic.BetaToolChoiceAutoParam{},
 		}
 	}
 
 	// Default to auto
-	return anthropic.ToolChoiceUnionParam{
-		OfAuto: &anthropic.ToolChoiceAutoParam{},
+	return anthropic.BetaToolChoiceUnionParam{
+		OfAuto: &anthropic.BetaToolChoiceAutoParam{},
 	}
 }

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -17,9 +17,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// HandleAnthropicToOpenAIStreamResponse processes Anthropic streaming events and converts them to OpenAI format
+// AnthropicToOpenAIStream processes Anthropic streaming events and converts them to OpenAI format
 // Returns inputTokens, outputTokens, and error for usage tracking
-func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.MessageNewParams, stream *anthropicstream.Stream[anthropic.MessageStreamEventUnion], responseModel string, disableStreamUsage bool) (int, int, error) {
+func AnthropicToOpenAIStream(c *gin.Context, req *anthropic.BetaMessageNewParams, stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], responseModel string, disableStreamUsage bool) (int, int, error) {
 	logrus.Info("Starting Anthropic to OpenAI streaming response handler")
 	defer func() {
 		if r := recover(); r != nil {
@@ -51,7 +51,7 @@ func HandleAnthropicToOpenAIStreamResponse(c *gin.Context, req *anthropic.Messag
 		chatID       = fmt.Sprintf("chatcmpl-%d", time.Now().Unix())
 		created      = time.Now().Unix()
 		contentText  = strings.Builder{}
-		usage        *anthropic.MessageDeltaUsage
+		usage        *anthropic.BetaMessageDeltaUsage
 		inputTokens  int
 		outputTokens int
 		finished     bool

--- a/internal/protocol/stream/anthropic_to_openai_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_test.go
@@ -41,11 +41,11 @@ func TestHandleAnthropicToOpenAIStreamResponse(t *testing.T) {
 	}
 
 	// Create a streaming request
-	stream := client.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+	stream := client.Beta.Messages.NewStreaming(context.Background(), anthropic.BetaMessageNewParams{
 		Model:     anthropic.Model(model),
 		MaxTokens: int64(100),
-		Messages: []anthropic.MessageParam{
-			anthropic.NewUserMessage(anthropic.NewTextBlock("What's the weather like in London?")),
+		Messages: []anthropic.BetaMessageParam{
+			anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("What's the weather like in London?")),
 		},
 		Tools: request.ConvertOpenAIToAnthropicTools([]openai.ChatCompletionToolUnionParam{NewExampleTool()}),
 	})
@@ -56,7 +56,7 @@ func TestHandleAnthropicToOpenAIStreamResponse(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 
 	// Run the handler
-	_, _, err := HandleAnthropicToOpenAIStreamResponse(c, nil, stream, model, false)
+	_, _, err := AnthropicToOpenAIStream(c, nil, stream, model, false)
 	require.NoError(t, err)
 
 	// Verify the response

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -144,14 +144,16 @@ func (s *Server) handleAnthropicV1ViaResponsesAPINonStreaming(c *gin.Context, pr
 
 	// Convert Responses API response back to Anthropic v1 format
 	anthropicResp := nonstream.ConvertResponsesToAnthropicV1Response(response, proxyModel)
-	if ShouldRoundtripResponse(c, "openai") {
-		roundtripped, err := RoundtripAnthropicResponseViaOpenAI(&anthropicResp, proxyModel, provider, actualModel)
-		if err != nil {
-			stream.SendInternalError(c, "Failed to roundtrip response: "+err.Error())
-			return
-		}
-		anthropicResp = *roundtripped
-	}
+
+	// TODO: require anthropic <-> anthropic beta
+	//if ShouldRoundtripResponse(c, "openai") {
+	//	roundtripped, err := RoundtripAnthropicBetaResponseViaOpenAI(&anthropicResp, proxyModel, provider, actualModel)
+	//	if err != nil {
+	//		stream.SendInternalError(c, "Failed to roundtrip response: "+err.Error())
+	//		return
+	//	}
+	//	anthropicResp = *roundtripped
+	//}
 
 	// Record response if scenario recording is enabled
 	if recorder != nil {

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -4,15 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/protocol/request"
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
@@ -216,7 +217,29 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	// === Tool Interceptor: Check if enabled and should be used ===
 	shouldIntercept, shouldStripTools, _ := s.resolveToolInterceptor(provider, hasBuiltInWebSearch)
 
+	// === Cursor compat content normalization (before transform) ===
+	if cursorCompat {
+		ops.ApplyCursorCompatContentNormalization(&req.ChatCompletionNewParams)
+	}
+	transform.AlignToolMessagesForOpenAI(&req.ChatCompletionNewParams)
+
+	// === Cap max_tokens at model's maximum ===
+	if req.MaxTokens.Valid() && req.MaxTokens.Value > int64(maxAllowed) {
+		req.MaxTokens.Value = int64(maxAllowed)
+	}
+
+	// === Determine target API type ===
+	apiStyle = provider.APIStyle
+	target := protocol.TypeOpenAIChat
 	switch apiStyle {
+	case protocol.APIStyleAnthropic:
+		target = protocol.TypeAnthropicBeta
+	case protocol.APIStyleGoogle:
+		target = protocol.TypeGoogle
+	case protocol.APIStyleOpenAI:
+		if s.GetPreferredEndpointForModel(provider, actualModel) == "responses" {
+			target = protocol.TypeOpenAIResponses
+		}
 	default:
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
@@ -225,22 +248,31 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 			},
 		})
 		return
-	case protocol.APIStyleAnthropic:
-		// Apply cursor_compat content normalization before converting to Anthropic format
-		// This ensures rich content is flattened for all providers when cursor_compat is enabled
-		if cursorCompat {
-			ops.ApplyCursorCompatContentNormalization(&req.ChatCompletionNewParams)
-		}
+	}
 
-		// Align tool messages to ensure valid message sequence for OpenAI API compatibility
-		// This prevents "role 'tool' must be a response to preceding message with 'tool_calls'" errors
-		transform.AlignToolMessagesForOpenAI(&req.ChatCompletionNewParams)
+	// === Transform via pipeline ===
+	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Transform failed: " + err.Error(),
+				Type:    "api_error",
+			},
+		})
+		return
+	}
+	reqCtx.Extra["cursor_compat"] = cursorCompat
+	reqCtx.Extra["should_intercept"] = shouldIntercept
+	reqCtx.Extra["should_strip_tools"] = shouldStripTools
 
-		anthropicReq := request.ConvertOpenAIToAnthropicRequest(&req.ChatCompletionNewParams, int64(maxAllowed))
+	// === Dispatch based on target ===
+	switch target {
+	case protocol.TypeAnthropicBeta:
+		anthropicReq := reqCtx.Request.(*anthropic.BetaMessageNewParams)
 		if isStreaming {
 			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
 			fc := NewForwardContext(c.Request.Context(), provider)
-			streamResp, cancel, err := ForwardAnthropicV1Stream(fc, wrapper, anthropicReq)
+			streamResp, cancel, err := ForwardAnthropicV1BetaStream(fc, wrapper, anthropicReq)
 			if cancel != nil {
 				defer cancel()
 			}
@@ -262,7 +294,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 				disableStreamUsage = disableStreamUsage || scenarioConfig.Flags.DisableStreamUsage
 			}
 
-			inputTokens, outputTokens, err := stream.HandleAnthropicToOpenAIStreamResponse(c, anthropicReq, streamResp, responseModel, disableStreamUsage)
+			inputTokens, outputTokens, err := stream.AnthropicToOpenAIStream(c, anthropicReq, streamResp, responseModel, disableStreamUsage)
 			if err != nil {
 				// Track usage with error status
 				if inputTokens > 0 || outputTokens > 0 {
@@ -287,7 +319,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 		} else {
 			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
 			fc := NewForwardContext(nil, provider)
-			anthropicResp, cancel, err := ForwardAnthropicV1(fc, wrapper, anthropicReq)
+			anthropicResp, cancel, err := ForwardAnthropicV1Beta(fc, wrapper, anthropicReq)
 			if cancel != nil {
 				defer cancel()
 			}
@@ -331,61 +363,9 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 			c.JSON(http.StatusOK, openaiResp)
 			return
 		}
-	case protocol.APIStyleOpenAI:
-		// Check if model prefers responses endpoint (for models like Codex)
-
-		// For now, all models with "codex" in their name (case insensitive) prefer completions
-		// In the future, this can be extended to support more models or be configured per-model
-		if strings.Contains(strings.ToLower(actualModel), "codex") {
-			// Convert chat request to responses request
-			s.handleResponsesForChatRequest(c, provider, &req, responseModel, actualModel, isStreaming)
-			return
-		}
-
-		// Cap max_tokens at the model's maximum to prevent API errors
-		// This is critical for providers like DeepSeek which have strict max_tokens limits
-		if req.MaxTokens.Valid() && req.MaxTokens.Value > int64(maxAllowed) {
-			req.MaxTokens.Value = int64(maxAllowed)
-		}
-
-		// Use Transform Chain for request transformation (Consistency + Vendor transforms)
-		// Note: Base transform is not needed since the request is already in OpenAI Chat format
-		// Chain: Consistency Transform → Vendor Transform
-		chain := transform.NewTransformChain([]transform.Transform{
-			transform.NewConsistencyTransform(protocol.TypeOpenAIChat),
-			transform.NewVendorTransform(provider.APIBase),
-		})
-
-		// Create transform context
-		var scenarioFlags *typ.ScenarioFlags
-		if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
-			scenarioFlags = &scenarioConfig.Flags
-		}
-
-		transformCtx := transform.NewTransformContext(
-			&req.ChatCompletionNewParams,
-			transform.WithProviderURL(provider.APIBase),
-			transform.WithScenarioFlags(scenarioFlags),
-			transform.WithStreaming(isStreaming),
-		)
-
-		// Execute transform chain
-		finalCtx, err := chain.Execute(transformCtx)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, ErrorResponse{
-				Error: ErrorDetail{
-					Message: "Transform chain failed: " + err.Error(),
-					Type:    "invalid_request_error",
-				},
-			})
-			return
-		}
-
-		// Get final transformed request
-		transformedReq := finalCtx.Request.(*openai.ChatCompletionNewParams)
-
+	case protocol.TypeOpenAIChat:
+		transformedReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
 		if isStreaming {
-			// Get scenario config for DisableStreamUsage flag
 			disableStreamUsage := cursorCompat
 			if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
 				disableStreamUsage = disableStreamUsage || scenarioConfig.Flags.DisableStreamUsage
@@ -394,6 +374,13 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 			s.handleOpenAIChatStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools, disableStreamUsage)
 		} else {
 			s.handleNonStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools, cursorCompat)
+		}
+	case protocol.TypeOpenAIResponses:
+		responsesReq := reqCtx.Request.(*responses.ResponseNewParams)
+		if isStreaming {
+			s.handleResponsesStreamingRequest(c, provider, *responsesReq, responseModel, actualModel)
+		} else {
+			s.handleResponsesNonStreamingRequest(c, provider, *responsesReq, responseModel, actualModel)
 		}
 	}
 }

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -586,19 +586,6 @@ func (s *Server) ListModelsByScenario(c *gin.Context) {
 	}
 }
 
-// handleResponsesForChatRequest handles chat completion requests by converting them to Responses API requests
-// This is used for models that prefer the Responses API over the Chat Completions API
-func (s *Server) handleResponsesForChatRequest(c *gin.Context, provider *typ.Provider, req *protocol.OpenAIChatCompletionRequest, responseModel, actualModel string, isStreaming bool) {
-	// Convert chat completion request to responses request
-	params := s.convertChatCompletionToResponsesParams(req, actualModel)
-
-	if isStreaming {
-		s.handleResponsesStreamingRequest(c, provider, params, responseModel, actualModel)
-	} else {
-		s.handleResponsesNonStreamingRequest(c, provider, params, responseModel, actualModel)
-	}
-}
-
 // convertChatCompletionToResponsesParams converts a chat completion request to responses API params
 func (s *Server) convertChatCompletionToResponsesParams(req *protocol.OpenAIChatCompletionRequest, actualModel string) responses.ResponseNewParams {
 	// Build input items from chat messages

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -25,15 +25,15 @@ func (s *Server) dispatchChainResult(
 ) {
 	switch reqCtx.TargetAPI {
 	case protocol.TypeAnthropicV1:
-		s.dispatchChainResultToAnthropicV1(c, reqCtx, rule, provider, isStreaming, recorder)
+		s.dispatchChainFromAnthropicV1(c, reqCtx, rule, provider, isStreaming, recorder)
 	case protocol.TypeAnthropicBeta:
-		s.dispatchChainResultToAnthropicBeta(c, reqCtx, rule, provider, isStreaming, recorder)
+		s.dispatchChainFromAnthropicBeta(c, reqCtx, rule, provider, isStreaming, recorder)
 	case protocol.TypeGoogle:
-		s.dispatchChainResultToGoogle(c, reqCtx, rule, provider, isStreaming, recorder)
+		s.dispatchChainFromGoogle(c, reqCtx, rule, provider, isStreaming, recorder)
 	case protocol.TypeOpenAIResponses:
-		s.dispatchChainResultToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+		s.dispatchChainFromResponses(c, reqCtx, rule, provider, isStreaming, recorder)
 	case protocol.TypeOpenAIChat:
-		s.dispatchChainResultToOpenAIChat(c, reqCtx, rule, provider, isStreaming, recorder)
+		s.dispatchChainFromOpenAIChat(c, reqCtx, rule, provider, isStreaming, recorder)
 	default:
 		c.JSON(http.StatusBadRequest, "tingly-box: invalid api style")
 		if recorder != nil {
@@ -44,7 +44,7 @@ func (s *Server) dispatchChainResult(
 
 // ── Anthropic direct ────────────────────────────────────────────────────
 
-func (s *Server) dispatchChainResultToAnthropicV1(
+func (s *Server) dispatchChainFromAnthropicV1(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
@@ -151,7 +151,7 @@ func (s *Server) dispatchChainResultToAnthropicV1(
 	}
 }
 
-func (s *Server) dispatchChainResultToAnthropicBeta(
+func (s *Server) dispatchChainFromAnthropicBeta(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
@@ -218,7 +218,7 @@ func (s *Server) dispatchChainResultToAnthropicBeta(
 
 // ── Google ──────────────────────────────────────────────────────────────
 
-func (s *Server) dispatchChainResultToGoogle(
+func (s *Server) dispatchChainFromGoogle(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
@@ -312,7 +312,7 @@ func (s *Server) dispatchChainResultToGoogle(
 
 // ── OpenAI Responses API ────────────────────────────────────────────────
 
-func (s *Server) dispatchChainResultToResponses(
+func (s *Server) dispatchChainFromResponses(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
@@ -359,7 +359,7 @@ func (s *Server) dispatchChainResultToResponses(
 
 // ── OpenAI Chat Completions ─────────────────────────────────────────────
 
-func (s *Server) dispatchChainResultToOpenAIChat(
+func (s *Server) dispatchChainFromOpenAIChat(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -127,14 +127,15 @@ func (s *Server) dispatchChainFromAnthropicV1(
 		// FIXME: now we use req model as resp model
 		anthropicResp.Model = anthropic.Model(responseModel)
 
-		if ShouldRoundtripResponse(c, "openai") {
-			roundtripped, err := RoundtripAnthropicResponseViaOpenAI(anthropicResp, responseModel, provider, actualModel)
-			if err != nil {
-				stream.SendInternalError(c, "Failed to roundtrip response: "+err.Error())
-				return
-			}
-			anthropicResp = roundtripped
-		}
+		// TODO: anthropic <-> anthropic beta
+		//if ShouldRoundtripResponse(c, "openai") {
+		//	roundtripped, err := RoundtripAnthropicBetaResponseViaOpenAI(anthropicResp, responseModel, provider, actualModel)
+		//	if err != nil {
+		//		stream.SendInternalError(c, "Failed to roundtrip response: "+err.Error())
+		//		return
+		//	}
+		//	anthropicResp = roundtripped
+		//}
 
 		session := s.guardrailsSessionFromContext(c, actualModel, provider)
 		messageHistory := serverguardrails.MessagesFromAnthropicV1(req.System, req.Messages)
@@ -285,12 +286,12 @@ func (s *Server) dispatchChainFromGoogle(
 		case protocol.TypeAnthropicV1:
 			anthropicResp := nonstream.ConvertGoogleToAnthropicResponse(resp, responseModel)
 			if ShouldRoundtripResponse(c, "openai") {
-				roundtripped, err := RoundtripAnthropicResponseViaOpenAI(&anthropicResp, responseModel, provider, actualModel)
+				roundtripped, err := RoundtripAnthropicBetaResponseViaOpenAI(anthropicResp, responseModel, provider, actualModel)
 				if err != nil {
 					stream.SendInternalError(c, "Failed to roundtrip resp: "+err.Error())
 					return
 				}
-				anthropicResp = *roundtripped
+				anthropicResp = roundtripped
 			}
 			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
 			if recorder != nil {
@@ -460,12 +461,12 @@ func (s *Server) dispatchChainFromOpenAIChat(
 		case protocol.TypeAnthropicV1:
 			anthropicResp := nonstream.ConvertOpenAIToAnthropicResponse(resp, responseModel)
 			if ShouldRoundtripResponse(c, "openai") {
-				roundtripped, err := RoundtripAnthropicResponseViaOpenAI(&anthropicResp, responseModel, provider, actualModel)
+				roundtripped, err := RoundtripAnthropicBetaResponseViaOpenAI(anthropicResp, responseModel, provider, actualModel)
 				if err != nil {
 					stream.SendInternalError(c, "Failed to roundtrip resp: "+err.Error())
 					return
 				}
-				anthropicResp = *roundtripped
+				anthropicResp = roundtripped
 			}
 			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
 			if recorder != nil {

--- a/internal/server/protocol_roundtrip.go
+++ b/internal/server/protocol_roundtrip.go
@@ -36,7 +36,7 @@ func RoundtripOpenAIMapViaAnthropic(openaiResp map[string]interface{}, responseM
 	return RoundtripOpenAIResponseViaAnthropic(&parsed, responseModel, provider, actualModel)
 }
 
-func RoundtripAnthropicResponseViaOpenAI(anthropicResp *anthropic.BetaMessage, responseModel string, provider *typ.Provider, actualModel string) (*anthropic.BetaMessage, error) {
+func RoundtripAnthropicBetaResponseViaOpenAI(anthropicResp *anthropic.BetaMessage, responseModel string, provider *typ.Provider, actualModel string) (*anthropic.BetaMessage, error) {
 	openaiResp := ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp, responseModel, provider, actualModel)
 	raw, err := json.Marshal(openaiResp)
 	if err != nil {

--- a/internal/server/protocol_roundtrip.go
+++ b/internal/server/protocol_roundtrip.go
@@ -21,7 +21,7 @@ func ShouldRoundtripResponse(c *gin.Context, target string) bool {
 
 func RoundtripOpenAIResponseViaAnthropic(openaiResp *openai.ChatCompletion, responseModel string, provider *typ.Provider, actualModel string) (map[string]interface{}, error) {
 	anthropicResp := nonstream.ConvertOpenAIToAnthropicResponse(openaiResp, responseModel)
-	return ConvertAnthropicToOpenAIResponseWithProvider(&anthropicResp, responseModel, provider, actualModel), nil
+	return ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp, responseModel, provider, actualModel), nil
 }
 
 func RoundtripOpenAIMapViaAnthropic(openaiResp map[string]interface{}, responseModel string, provider *typ.Provider, actualModel string) (map[string]interface{}, error) {
@@ -36,7 +36,7 @@ func RoundtripOpenAIMapViaAnthropic(openaiResp map[string]interface{}, responseM
 	return RoundtripOpenAIResponseViaAnthropic(&parsed, responseModel, provider, actualModel)
 }
 
-func RoundtripAnthropicResponseViaOpenAI(anthropicResp *anthropic.Message, responseModel string, provider *typ.Provider, actualModel string) (*anthropic.Message, error) {
+func RoundtripAnthropicResponseViaOpenAI(anthropicResp *anthropic.BetaMessage, responseModel string, provider *typ.Provider, actualModel string) (*anthropic.BetaMessage, error) {
 	openaiResp := ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp, responseModel, provider, actualModel)
 	raw, err := json.Marshal(openaiResp)
 	if err != nil {
@@ -47,17 +47,12 @@ func RoundtripAnthropicResponseViaOpenAI(anthropicResp *anthropic.Message, respo
 		return nil, err
 	}
 	roundtrip := nonstream.ConvertOpenAIToAnthropicResponse(&parsed, responseModel)
-	return &roundtrip, nil
+	return roundtrip, nil
 }
 
 // ConvertAnthropicToOpenAIResponseWithProvider converts an Anthropic response to OpenAI format
 // and applies provider-specific transformations to the response
-func ConvertAnthropicToOpenAIResponseWithProvider(
-	anthropicResp *anthropic.Message,
-	responseModel string,
-	provider *typ.Provider,
-	model string,
-) map[string]interface{} {
+func ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp *anthropic.BetaMessage, responseModel string, provider *typ.Provider, model string) map[string]interface{} {
 	// Base conversion
 	openaiResp := nonstream.ConvertAnthropicToOpenAIResponse(anthropicResp, responseModel)
 

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -100,3 +100,50 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	}
 	return finalCtx, nil
 }
+
+func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
+	// Build transform chain with recording support
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, nil, protocolRecorder)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create transform context
+	var scenarioFlags *typ.ScenarioFlags
+	if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
+		scenarioFlags = &scenarioConfig.Flags
+	}
+
+	extra := map[string]any{}
+
+	if provider.AuthType == typ.AuthTypeOAuth {
+		extra["user_id"] = provider.OAuthDetail.UserID
+	}
+	extra["device"] = s.config.ClaudeCodeDeviceID
+
+	transformCtx := transform.NewTransformContext(
+		&req.ChatCompletionNewParams,
+		transform.WithProviderURL(provider.APIBase),
+		transform.WithScenarioFlags(scenarioFlags),
+		transform.WithStreaming(isStreaming),
+		transform.WithExtra(extra),
+	)
+	transformCtx.SourceAPI = protocol.TypeOpenAIChat
+	transformCtx.TargetAPI = target
+
+	// Execute transform chain
+	finalCtx, err := chain.Execute(transformCtx)
+	if err != nil {
+		if protocolRecorder != nil {
+			protocolRecorder.SetTransformSteps(finalCtx.TransformSteps)
+			protocolRecorder.RecordError(err)
+		}
+		return nil, err
+	}
+
+	// Store transform steps in V2 recorder
+	if protocolRecorder != nil {
+		protocolRecorder.SetTransformSteps(finalCtx.TransformSteps)
+	}
+	return finalCtx, nil
+}


### PR DESCRIPTION
## Summary
The OpenAI Chat → Anthropic proxy path was using `anthropic.Message` (v1) types throughout the request/response conversion flow, while Anthropic beta types were already used elsewhere. 

This PR migrates the entire conversion pipeline to consistently use `anthropic.BetaMessage` types and unifies the OpenAI Chat handler to route through the shared transform chain, eliminating duplicated dispatch logic.

part of #508 

### Major
- All Anthropic request/response conversions now use `BetaMessage*` types (`BetaMessageNewParams`, `BetaMessageParam`, `BetaContentBlockParamUnion`, etc.)
- OpenAI Chat handler (`OpenAIChatCompletion`) refactored: target API type is determined first, then a single `transformOpenAIChat` call produces a typed `TransformContext`, followed by a clean dispatch switch — replacing the previous per-`APIStyle` code blocks with inline transform+dispatch logic
- New `transformOpenAIChat` helper in `protocol_transform.go` mirrors the existing `transformAnthropicV1` pattern, with recording support, scenario flags, and extra context (user_id, device)

### Minor
- Renamed dispatch functions: `dispatchChainResultTo*` → `dispatchChainFrom*` to reflect source-API semantics
- Renamed stream handler: `HandleAnthropicToOpenAIStreamResponse` → `AnthropicToOpenAIStream`
- Renamed roundtrip: `RoundtripAnthropicResponseViaOpenAI` → `RoundtripAnthropicBetaResponseViaOpenAI`
- Removed `handleResponsesForChatRequest` (merged into dispatch switch)
- Disabled roundtrip in `anthropic_v1.go` and `dispatchChainFromAnthropicV1` with TODO for v1↔beta migration
- Nonstream conversions return `*BetaMessage` (pointer) instead of value copy