### PR TITLE
fix: set UserID in recordDetailedUsageWithTokenUsage

### DIFF
--- a/internal/server/usage_tracking.go
+++ b/internal/server/usage_tracking.go
@@ -322,6 +322,7 @@ func (s *Server) recordDetailedUsageWithTokenUsage(c *gin.Context, rule *typ.Rul
 		Model:            model,
 		Scenario:         scenario,
 		RequestModel:     requestModel,
+		UserID:           c.GetString("enterprise_user_id"),
 		InputTokens:      usage.InputTokens,
 		OutputTokens:     usage.OutputTokens,
 		CacheInputTokens: usage.CacheInputTokens,


### PR DESCRIPTION
Add missing UserID field in recordDetailedUsageWithTokenUsage function.

This ensures user_id is populated for token-based usage tracking, matching the behavior of recordUsageFromContext.