### PR TITLE
refactor(server): migrate openai chat to use transform chain dispatch

### DIFF
--- a/internal/protocol/nonstream/openai_reponses_to_chat.go
+++ b/internal/protocol/nonstream/openai_reponses_to_chat.go
@@ -1,0 +1,47 @@
+package nonstream
+
+import "github.com/openai/openai-go/v3/responses"
+
+// OpenAIResponsesToChat converts a Responses API response to Chat Completions format.
+// This is used when the client expects Chat format but the provider uses Responses API.
+func OpenAIResponsesToChat(resp *responses.Response, responseModel string) map[string]any {
+	// Extract text content from output
+	// Response output can have various types: "message", "function_call", etc.
+	content := ""
+	for _, output := range resp.Output {
+		if output.Type == "message" {
+			// For message type, extract text from content array
+			for _, contentItem := range output.Content {
+				// ContentItemUnion has a Type field to distinguish variants
+				if contentItem.Type == "output_text" || contentItem.Type == "text" {
+					content += contentItem.Text
+				}
+			}
+		}
+	}
+
+	// Build Chat Completion response structure
+	choices := []map[string]any{
+		{
+			"index": 0,
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": content,
+			},
+			"finish_reason": "stop",
+		},
+	}
+
+	return map[string]any{
+		"id":      resp.ID,
+		"object":  "chat.completion",
+		"created": int64(resp.CreatedAt),
+		"model":   responseModel,
+		"choices": choices,
+		"usage": map[string]any{
+			"prompt_tokens":     resp.Usage.InputTokens,
+			"completion_tokens": resp.Usage.OutputTokens,
+			"total_tokens":      resp.Usage.InputTokens + resp.Usage.OutputTokens,
+		},
+	}
+}

--- a/internal/protocol/stream/responses_to_openai_chat.go
+++ b/internal/protocol/stream/responses_to_openai_chat.go
@@ -1,0 +1,232 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	responsesstream "github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// responsesToChatState tracks the streaming conversion state from Responses API to Chat Completions
+type responsesToChatState struct {
+	chatID         string
+	createdAt      int64
+	accumulated    string
+	inputTokens    int64
+	outputTokens   int64
+	cacheTokens    int64
+	hasSentCreated bool
+}
+
+// HandleResponsesToOpenAIChatStream converts Responses API streaming to Chat Completions format.
+// Returns TokenUsage containing token usage information for tracking.
+func HandleResponsesToOpenAIChatStream(
+	hc *protocol.HandleContext,
+	stream *responsesstream.Stream[responses.ResponseStreamEventUnion],
+	responseModel string,
+) (*protocol.TokenUsage, error) {
+	c := hc.GinContext
+	logrus.Debug("Starting Responses to Chat streaming conversion handler")
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.Errorf("Panic in Responses to Chat streaming handler: %v", r)
+			if c.Writer != nil {
+				c.Writer.WriteHeader(http.StatusInternalServerError)
+				c.Writer.Write([]byte("data: {\"error\":{\"message\":\"Internal streaming error\",\"type\":\"internal_error\"}}\n\n"))
+				if flusher, ok := c.Writer.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+		}
+		if stream != nil {
+			if err := stream.Close(); err != nil {
+				logrus.Errorf("Error closing Responses stream: %v", err)
+			}
+		}
+		logrus.Info("Finished Responses to Chat streaming conversion handler")
+	}()
+
+	// Set SSE headers for Chat Completions
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.Header("Access-Control-Allow-Headers", "Cache-Control")
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return protocol.ZeroTokenUsage(), errors.New("streaming not supported by this connection")
+	}
+
+	state := &responsesToChatState{
+		createdAt: time.Now().Unix(),
+	}
+
+	// Trigger stream event hook
+	for _, hook := range hc.OnStreamEventHooks {
+		if err := hook(nil); err != nil {
+			logrus.Errorf("Stream event hook error: %v", err)
+		}
+	}
+
+	// Process the stream
+	c.Stream(func(w io.Writer) bool {
+		select {
+		case <-c.Request.Context().Done():
+			logrus.Debug("Client disconnected, stopping Responses to Chat stream")
+			return false
+		default:
+		}
+
+		if !stream.Next() {
+			return false
+		}
+
+		evt := stream.Current()
+
+		switch evt.Type {
+		case "response.created":
+			// Extract response ID and timestamp
+			state.chatID = evt.Response.ID
+			if !state.hasSentCreated {
+				// Send initial chat.chunk with created event
+				chunk := map[string]interface{}{
+					"id":      state.chatID,
+					"object":  "chat.completion.chunk",
+					"created": state.createdAt,
+					"model":   responseModel,
+					"choices": []map[string]interface{}{
+						{
+							"index": 0,
+							"delta": map[string]interface{}{
+								"role": "assistant",
+							},
+							"finish_reason": nil,
+						},
+					},
+				}
+				writeSSEChunk(c, flusher, chunk)
+				state.hasSentCreated = true
+			}
+
+		case "response.output_text.delta":
+			// Text delta - send as chat chunk
+			state.accumulated += evt.Text
+			chunk := map[string]interface{}{
+				"id":      state.chatID,
+				"object":  "chat.completion.chunk",
+				"created": state.createdAt,
+				"model":   responseModel,
+				"choices": []map[string]interface{}{
+					{
+						"index": 0,
+						"delta": map[string]interface{}{
+							"content": evt.Text,
+						},
+						"finish_reason": nil,
+					},
+				},
+			}
+			writeSSEChunk(c, flusher, chunk)
+
+		case "response.output_text.done":
+			// Text output is complete - handled in response.completed
+
+		case "response.completed":
+			// Response is complete, send final chunk with usage
+			state.inputTokens = int64(evt.Response.Usage.InputTokens)
+			state.outputTokens = int64(evt.Response.Usage.OutputTokens)
+
+			// Check for cache tokens in raw JSON
+			var evtParsed map[string]interface{}
+			if err := json.Unmarshal([]byte(evt.RawJSON()), &evtParsed); err == nil {
+				if response, ok := evtParsed["response"].(map[string]interface{}); ok {
+					if usage, ok := response["usage"].(map[string]interface{}); ok {
+						if details, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
+							if cached, ok := details["cached_tokens"].(float64); ok {
+								state.cacheTokens = int64(cached)
+							}
+						}
+					}
+				}
+			}
+
+			// Send final chunk with finish_reason and usage
+			finalChunk := map[string]interface{}{
+				"id":      state.chatID,
+				"object":  "chat.completion.chunk",
+				"created": state.createdAt,
+				"model":   responseModel,
+				"choices": []map[string]interface{}{
+					{
+						"index":         0,
+						"delta":         map[string]interface{}{},
+						"finish_reason": "stop",
+					},
+				},
+			}
+			// Only include usage if not disabled
+			if !hc.DisableStreamUsage {
+				finalChunk["usage"] = map[string]interface{}{
+					"prompt_tokens":     state.inputTokens,
+					"completion_tokens": state.outputTokens,
+					"total_tokens":      state.inputTokens + state.outputTokens,
+				}
+			}
+			writeSSEChunk(c, flusher, finalChunk)
+
+		case "error":
+			// Handle error event
+			errorChunk := map[string]interface{}{
+				"error": map[string]interface{}{
+					"message": evt.Message,
+					"type":    "error",
+					"code":    evt.Param,
+				},
+			}
+			errorJSON, _ := json.Marshal(errorChunk)
+			c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", string(errorJSON))))
+			flusher.Flush()
+			return false
+		}
+
+		return true
+	})
+
+	// Check for stream errors
+	if err := stream.Err(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			logrus.Debug("Responses to Chat stream canceled by client")
+			return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), err
+		}
+		logrus.Errorf("Responses to Chat stream error: %v", err)
+		return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), err
+	}
+
+	// Send final [DONE] message
+	c.Writer.Write([]byte("data: [DONE]\n\n"))
+	flusher.Flush()
+
+	return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), nil
+}
+
+// writeSSEChunk writes a single SSE chunk
+func writeSSEChunk(c *gin.Context, flusher http.Flusher, chunk map[string]interface{}) {
+	jsonBytes, err := json.Marshal(chunk)
+	if err != nil {
+		logrus.Errorf("Failed to marshal chunk: %v", err)
+		return
+	}
+	c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", string(jsonBytes))))
+	flusher.Flush()
+}

--- a/internal/protocol/stream/responses_to_openai_chat.go
+++ b/internal/protocol/stream/responses_to_openai_chat.go
@@ -144,22 +144,9 @@ func HandleResponsesToOpenAIChatStream(
 
 		case "response.completed":
 			// Response is complete, send final chunk with usage
-			state.inputTokens = int64(evt.Response.Usage.InputTokens)
-			state.outputTokens = int64(evt.Response.Usage.OutputTokens)
-
-			// Check for cache tokens in raw JSON
-			var evtParsed map[string]interface{}
-			if err := json.Unmarshal([]byte(evt.RawJSON()), &evtParsed); err == nil {
-				if response, ok := evtParsed["response"].(map[string]interface{}); ok {
-					if usage, ok := response["usage"].(map[string]interface{}); ok {
-						if details, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
-							if cached, ok := details["cached_tokens"].(float64); ok {
-								state.cacheTokens = int64(cached)
-							}
-						}
-					}
-				}
-			}
+			state.inputTokens = evt.Response.Usage.InputTokens
+			state.outputTokens = evt.Response.Usage.OutputTokens
+			state.cacheTokens = evt.Response.Usage.InputTokensDetails.CachedTokens
 
 			// Send final chunk with finish_reason and usage
 			finalChunk := map[string]interface{}{

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -7,14 +7,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-
-	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -265,122 +260,8 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	reqCtx.Extra["should_intercept"] = shouldIntercept
 	reqCtx.Extra["should_strip_tools"] = shouldStripTools
 
-	// === Dispatch based on target ===
-	switch target {
-	case protocol.TypeAnthropicBeta:
-		anthropicReq := reqCtx.Request.(*anthropic.BetaMessageNewParams)
-		if isStreaming {
-			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
-			fc := NewForwardContext(c.Request.Context(), provider)
-			streamResp, cancel, err := ForwardAnthropicV1BetaStream(fc, wrapper, anthropicReq)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				// Track error with no usage
-				s.trackUsageFromContext(c, 0, 0, err)
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{
-						Message: "Failed to create streaming request: " + err.Error(),
-						Type:    "api_error",
-					},
-				})
-				return
-			}
-
-			// Get scenario config for DisableStreamUsage flag
-			disableStreamUsage := cursorCompat
-			if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
-				disableStreamUsage = disableStreamUsage || scenarioConfig.Flags.DisableStreamUsage
-			}
-
-			inputTokens, outputTokens, err := stream.AnthropicToOpenAIStream(c, anthropicReq, streamResp, responseModel, disableStreamUsage)
-			if err != nil {
-				// Track usage with error status
-				if inputTokens > 0 || outputTokens > 0 {
-					tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
-					s.trackUsageWithTokenUsage(c, tokenUsage, err)
-				}
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{
-						Message: "Failed to create streaming request: " + err.Error(),
-						Type:    "api_error",
-					},
-				})
-				return
-			}
-
-			// Track successful streaming completion
-			if inputTokens > 0 || outputTokens > 0 {
-				tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
-				s.trackUsageWithTokenUsage(c, tokenUsage, nil)
-			}
-			return
-		} else {
-			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
-			fc := NewForwardContext(nil, provider)
-			anthropicResp, cancel, err := ForwardAnthropicV1Beta(fc, wrapper, anthropicReq)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				// Track error with no usage
-				s.trackUsageFromContext(c, 0, 0, err)
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{
-						Message: "Failed to forward Anthropic request: " + err.Error(),
-						Type:    "api_error",
-					},
-				})
-				return
-			}
-
-			// Track usage from response
-			inputTokens := int(anthropicResp.Usage.InputTokens)
-			outputTokens := int(anthropicResp.Usage.OutputTokens)
-			cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens + anthropicResp.Usage.CacheCreationInputTokens)
-			tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
-			s.trackUsageWithTokenUsage(c, tokenUsage, nil)
-
-			// Use provider-aware conversion for provider-specific handling
-			openaiResp := ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp, responseModel, provider, actualModel)
-			if ShouldRoundtripResponse(c, "anthropic") {
-				roundtripped, err := RoundtripOpenAIMapViaAnthropic(openaiResp, responseModel, provider, actualModel)
-				if err != nil {
-					c.JSON(http.StatusInternalServerError, ErrorResponse{
-						Error: ErrorDetail{
-							Message: "Failed to roundtrip response: " + err.Error(),
-							Type:    "api_error",
-						},
-					})
-					return
-				}
-				openaiResp = roundtripped
-			}
-			if cursorCompat {
-				delete(openaiResp, "usage")
-			}
-			c.JSON(http.StatusOK, openaiResp)
-			return
-		}
-	case protocol.TypeOpenAIChat:
-		transformedReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
-		if isStreaming {
-			disableStreamUsage := cursorCompat
-			if scenarioConfig := s.config.GetScenarioConfig(scenarioType); scenarioConfig != nil {
-				disableStreamUsage = disableStreamUsage || scenarioConfig.Flags.DisableStreamUsage
-			}
-
-			s.handleOpenAIChatStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools, disableStreamUsage)
-		} else {
-			s.handleNonStreamingRequest(c, provider, transformedReq, responseModel, shouldIntercept, shouldStripTools, cursorCompat)
-		}
-	case protocol.TypeOpenAIResponses:
-		responsesReq := reqCtx.Request.(*responses.ResponseNewParams)
-		if isStreaming {
-			s.handleResponsesStreamingRequest(c, provider, *responsesReq, responseModel, actualModel)
-		} else {
-			s.handleResponsesNonStreamingRequest(c, provider, *responsesReq, responseModel, actualModel)
-		}
-	}
+	// === Dispatch via transform chain ===
+	reqCtx.RequestModel = actualModel
+	reqCtx.ResponseModel = responseModel
+	s.dispatchChainResult(c, reqCtx, rule, provider, isStreaming, nil)
 }

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -267,7 +267,6 @@ func (s *Server) handleOpenAIChatStreamingRequest(c *gin.Context, provider *typ.
 	s.trackUsageWithTokenUsage(c, usage, err)
 }
 
-// ListModelsByScenario handles the /v1/models endpoint for scenario-based routing
 func (s *Server) handleOpenAIStreamResponse(c *gin.Context, streamResp *ssestream.Stream[openai.ChatCompletionChunk], req *openai.ChatCompletionNewParams, responseModel string, disableStreamUsage bool) {
 	// Accumulate usage from stream chunks
 	var inputTokens, outputTokens int

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -16,15 +16,15 @@ import (
 	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/toolinterceptor"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
-	"github.com/tingly-dev/tingly-box/internal/toolinterceptor"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// handleNonStreamingRequest handles non-streaming chat completion requests
+// handleNonStreamingRequest handles non-streaming chat completion requests with tool interceptor support
 func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provider, originalReq *openai.ChatCompletionNewParams, responseModel string, shouldIntercept, shouldStripTools bool, stripUsage bool) {
 	// === PRE-REQUEST INTERCEPTION: Strip tools before sending to provider ===
 	req := originalReq
@@ -217,7 +217,7 @@ func (s *Server) handleInterceptedToolCalls(provider *typ.Provider, originalReq 
 	return finalResponse, nil
 }
 
-// handleOpenAIChatStreamingRequest handles streaming chat completion requests
+// handleOpenAIChatStreamingRequest handles streaming chat completion requests with tool interceptor support
 func (s *Server) handleOpenAIChatStreamingRequest(c *gin.Context, provider *typ.Provider, originalReq *openai.ChatCompletionNewParams, responseModel string, shouldIntercept, shouldStripTools bool, disableStreamUsage bool) {
 	// === PRE-REQUEST INTERCEPTION: Strip tools before sending to provider ===
 	req := originalReq
@@ -267,7 +267,7 @@ func (s *Server) handleOpenAIChatStreamingRequest(c *gin.Context, provider *typ.
 	s.trackUsageWithTokenUsage(c, usage, err)
 }
 
-// handleOpenAIStreamResponse processes the streaming response and sends it to the client
+// ListModelsByScenario handles the /v1/models endpoint for scenario-based routing
 func (s *Server) handleOpenAIStreamResponse(c *gin.Context, streamResp *ssestream.Stream[openai.ChatCompletionChunk], req *openai.ChatCompletionNewParams, responseModel string, disableStreamUsage bool) {
 	// Accumulate usage from stream chunks
 	var inputTokens, outputTokens int

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -49,6 +49,18 @@ func (s *Server) dispatchChainFromAnthropicV1(
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
 ) {
+	switch reqCtx.SourceAPI {
+	default:
+		s.dispatchAnthropicToAnthropicV1(c, reqCtx, rule, provider, isStreaming, recorder)
+	}
+}
+
+// dispatchAnthropicToAnthropicV1 handles Anthropic→Anthropic v1 passthrough (original behavior)
+func (s *Server) dispatchAnthropicToAnthropicV1(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 	req := reqCtx.Request.(*anthropic.MessageNewParams)
 
@@ -127,7 +139,7 @@ func (s *Server) dispatchChainFromAnthropicV1(
 		// FIXME: now we use req model as resp model
 		anthropicResp.Model = anthropic.Model(responseModel)
 
-		// TODO: anthropic <-> anthropic beta
+		// TODO: disable this round trip until we support anthropic <-> anthropic beta
 		//if ShouldRoundtripResponse(c, "openai") {
 		//	roundtripped, err := RoundtripAnthropicBetaResponseViaOpenAI(anthropicResp, responseModel, provider, actualModel)
 		//	if err != nil {
@@ -152,7 +164,9 @@ func (s *Server) dispatchChainFromAnthropicV1(
 	}
 }
 
-func (s *Server) dispatchChainFromAnthropicBeta(
+// dispatchOpenAIChatFromAnthropicV1 handles OpenAI→Anthropic v1 conversion.
+// The client expects OpenAI format, so responses are converted back.
+func (s *Server) dispatchOpenAIChatFromAnthropicBeta(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
@@ -170,13 +184,48 @@ func (s *Server) dispatchChainFromAnthropicBeta(
 		}
 		if err != nil {
 			s.trackUsageFromContext(c, 0, 0, err)
-			stream.SendStreamingError(c, err)
+			c.JSON(http.StatusInternalServerError, ErrorResponse{
+				Error: ErrorDetail{
+					Message: "Failed to create streaming request: " + err.Error(),
+					Type:    "api_error",
+				},
+			})
 			if recorder != nil {
 				recorder.RecordError(err)
 			}
 			return
 		}
-		s.handleAnthropicStreamResponseV1Beta(c, req, streamResp, responseModel, provider, recorder)
+
+		disableStreamUsage := false
+		if v, ok := reqCtx.Extra["cursor_compat"]; ok {
+			disableStreamUsage = v.(bool)
+		}
+		if reqCtx.ScenarioFlags != nil {
+			disableStreamUsage = disableStreamUsage || reqCtx.ScenarioFlags.DisableStreamUsage
+		}
+
+		inputTokens, outputTokens, err := stream.AnthropicToOpenAIStream(c, req, streamResp, responseModel, disableStreamUsage)
+		if err != nil {
+			if inputTokens > 0 || outputTokens > 0 {
+				tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
+				s.trackUsageWithTokenUsage(c, tokenUsage, err)
+			}
+			c.JSON(http.StatusInternalServerError, ErrorResponse{
+				Error: ErrorDetail{
+					Message: "Failed to create streaming request: " + err.Error(),
+					Type:    "api_error",
+				},
+			})
+			if recorder != nil {
+				recorder.RecordError(err)
+			}
+			return
+		}
+
+		if inputTokens > 0 || outputTokens > 0 {
+			tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
+			s.trackUsageWithTokenUsage(c, tokenUsage, nil)
+		}
 	} else {
 		anthropicResp, cancel, err := ForwardAnthropicV1Beta(fc, wrapper, req)
 		if cancel != nil {
@@ -184,7 +233,12 @@ func (s *Server) dispatchChainFromAnthropicBeta(
 		}
 		if err != nil {
 			s.trackUsageFromContext(c, 0, 0, err)
-			stream.SendForwardingError(c, err)
+			c.JSON(http.StatusInternalServerError, ErrorResponse{
+				Error: ErrorDetail{
+					Message: "Failed to forward Anthropic request: " + err.Error(),
+					Type:    "api_error",
+				},
+			})
 			if recorder != nil {
 				recorder.RecordError(err)
 			}
@@ -193,27 +247,107 @@ func (s *Server) dispatchChainFromAnthropicBeta(
 
 		inputTokens := int(anthropicResp.Usage.InputTokens)
 		outputTokens := int(anthropicResp.Usage.OutputTokens)
-		cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens)
-		usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
-		s.trackUsageWithTokenUsage(c, usage, nil)
+		cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens + anthropicResp.Usage.CacheCreationInputTokens)
+		tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
+		s.trackUsageWithTokenUsage(c, tokenUsage, nil)
 
-		s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
-
-		// FIXME: now we use req model as resp model
-		anthropicResp.Model = anthropic.Model(responseModel)
-
-		session := s.guardrailsSessionFromContext(c, actualModel, provider)
-		messageHistory := serverguardrails.MessagesFromAnthropicV1Beta(req.System, req.Messages)
-		blocked := s.applyGuardrailsToAnthropicV1BetaNonStreamResponse(c, session, messageHistory, anthropicResp)
-		if !blocked {
-			s.restoreGuardrailsCredentialAliasesV1BetaResponse(c, anthropicResp)
+		openaiResp := ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp, responseModel, provider, actualModel)
+		if ShouldRoundtripResponse(c, "anthropic") {
+			roundtripped, err := RoundtripOpenAIMapViaAnthropic(openaiResp, responseModel, provider, actualModel)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, ErrorResponse{
+					Error: ErrorDetail{
+						Message: "Failed to roundtrip response: " + err.Error(),
+						Type:    "api_error",
+					},
+				})
+				return
+			}
+			openaiResp = roundtripped
+		}
+		cursorCompat := false
+		if v, ok := reqCtx.Extra["cursor_compat"]; ok {
+			cursorCompat = v.(bool)
+		}
+		if cursorCompat {
+			delete(openaiResp, "usage")
 		}
 
 		if recorder != nil {
 			recorder.SetAssembledResponse(anthropicResp)
 			recorder.RecordResponse(provider, actualModel)
 		}
-		c.JSON(http.StatusOK, anthropicResp)
+		c.JSON(http.StatusOK, openaiResp)
+	}
+}
+
+func (s *Server) dispatchChainFromAnthropicBeta(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	switch reqCtx.SourceAPI {
+	case protocol.TypeOpenAIChat:
+		s.dispatchOpenAIChatFromAnthropicBeta(c, reqCtx, rule, provider, isStreaming, recorder)
+	default:
+		actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
+		req := reqCtx.Request.(*anthropic.BetaMessageNewParams)
+
+		wrapper := s.clientPool.GetAnthropicClient(provider, actualModel)
+		fc := NewForwardContext(c.Request.Context(), provider)
+
+		if isStreaming {
+			streamResp, cancel, err := ForwardAnthropicV1BetaStream(fc, wrapper, req)
+			if cancel != nil {
+				defer cancel()
+			}
+			if err != nil {
+				s.trackUsageFromContext(c, 0, 0, err)
+				stream.SendStreamingError(c, err)
+				if recorder != nil {
+					recorder.RecordError(err)
+				}
+				return
+			}
+			s.handleAnthropicStreamResponseV1Beta(c, req, streamResp, responseModel, provider, recorder)
+		} else {
+			anthropicResp, cancel, err := ForwardAnthropicV1Beta(fc, wrapper, req)
+			if cancel != nil {
+				defer cancel()
+			}
+			if err != nil {
+				s.trackUsageFromContext(c, 0, 0, err)
+				stream.SendForwardingError(c, err)
+				if recorder != nil {
+					recorder.RecordError(err)
+				}
+				return
+			}
+
+			inputTokens := int(anthropicResp.Usage.InputTokens)
+			outputTokens := int(anthropicResp.Usage.OutputTokens)
+			cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens)
+			usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
+			s.trackUsageWithTokenUsage(c, usage, nil)
+
+			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
+
+			// FIXME: now we use req model as resp model
+			anthropicResp.Model = anthropic.Model(responseModel)
+
+			session := s.guardrailsSessionFromContext(c, actualModel, provider)
+			messageHistory := serverguardrails.MessagesFromAnthropicV1Beta(req.System, req.Messages)
+			blocked := s.applyGuardrailsToAnthropicV1BetaNonStreamResponse(c, session, messageHistory, anthropicResp)
+			if !blocked {
+				s.restoreGuardrailsCredentialAliasesV1BetaResponse(c, anthropicResp)
+			}
+
+			if recorder != nil {
+				recorder.SetAssembledResponse(anthropicResp)
+				recorder.RecordResponse(provider, actualModel)
+			}
+			c.JSON(http.StatusOK, anthropicResp)
+		}
 	}
 }
 
@@ -355,6 +489,10 @@ func (s *Server) dispatchChainFromResponses(
 		} else {
 			s.handleAnthropicV1BetaViaResponsesAPINonStreaming(c, responseModel, actualModel, provider, *req)
 		}
+	case protocol.TypeOpenAIChat:
+		// Client sent Responses API, but provider needs Chat format
+		// Forward as Chat, then convert response back to Responses format
+		s.dispatchOpenAIChatFromResponses(c, reqCtx, rule, provider, isStreaming, recorder)
 	}
 }
 
@@ -438,8 +576,38 @@ func (s *Server) dispatchChainFromOpenAIChat(
 				streamRec.Finish(responseModel, usage.InputTokens, usage.OutputTokens)
 				streamRec.RecordResponse(provider, actualModel)
 			}
+		case protocol.TypeOpenAIChat:
+			// OpenAI passthrough: source and target are both OpenAI Chat format
+			shouldIntercept, _ := reqCtx.Extra["should_intercept"].(bool)
+			shouldStripTools, _ := reqCtx.Extra["should_strip_tools"].(bool)
+
+			disableStreamUsage := false
+			if v, ok := reqCtx.Extra["cursor_compat"]; ok {
+				disableStreamUsage = v.(bool)
+			}
+			if reqCtx.ScenarioFlags != nil {
+				disableStreamUsage = disableStreamUsage || reqCtx.ScenarioFlags.DisableStreamUsage
+			}
+
+			s.handleOpenAIChatStreamingRequest(c, provider, req, responseModel, shouldIntercept, shouldStripTools, disableStreamUsage)
 		}
 	} else {
+		switch reqCtx.SourceAPI {
+		case protocol.TypeOpenAIChat:
+			// OpenAI passthrough: delegate to handleNonStreamingRequest for tool interceptor support
+			shouldIntercept, _ := reqCtx.Extra["should_intercept"].(bool)
+			shouldStripTools, _ := reqCtx.Extra["should_strip_tools"].(bool)
+			stripUsage := false
+			if v, ok := reqCtx.Extra["cursor_compat"]; ok {
+				stripUsage = v.(bool)
+			}
+
+			s.handleNonStreamingRequest(c, provider, req, responseModel, shouldIntercept, shouldStripTools, stripUsage)
+			return
+		default:
+			// Forward request to provider for format conversion
+		}
+
 		wrapper := s.clientPool.GetOpenAIClient(provider, req.Model)
 		fc := NewForwardContext(nil, provider)
 		resp, _, err := ForwardOpenAIChat(fc, wrapper, req)
@@ -483,5 +651,85 @@ func (s *Server) dispatchChainFromOpenAIChat(
 			}
 			c.JSON(http.StatusOK, anthropicResp)
 		}
+	}
+}
+
+// dispatchOpenAIChatFromResponses handles Chat→Responses→Chat conversion.
+// Client expects Chat format, provider uses Responses format.
+func (s *Server) dispatchOpenAIChatFromResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
+	req := reqCtx.Request.(*responses.ResponseNewParams)
+
+	wrapper := s.clientPool.GetOpenAIClient(provider, actualModel)
+	fc := NewForwardContext(c.Request.Context(), provider)
+
+	if isStreaming {
+		responsesStream, cancel, err := ForwardOpenAIResponsesStream(fc, wrapper, *req)
+		if cancel != nil {
+			defer cancel()
+		}
+		if err != nil {
+			s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+			c.JSON(http.StatusInternalServerError, ErrorResponse{
+				Error: ErrorDetail{
+					Message: "Failed to create streaming request: " + err.Error(),
+					Type:    "api_error",
+				},
+			})
+			if recorder != nil {
+				recorder.RecordError(err)
+			}
+			return
+		}
+
+		hc := protocol.NewHandleContext(c, responseModel)
+		firstTokenRecorded := false
+		hc.WithOnStreamEvent(func(_ interface{}) error {
+			if !firstTokenRecorded {
+				SetFirstTokenTime(c)
+				firstTokenRecorded = true
+			}
+			return nil
+		})
+		usage, err := stream.HandleResponsesToOpenAIChatStream(hc, responsesStream, responseModel)
+		s.trackUsageWithTokenUsage(c, usage, err)
+		if recorder != nil {
+			recorder.RecordResponse(provider, actualModel)
+		}
+	} else {
+		responsesResp, cancel, err := ForwardOpenAIResponses(fc, wrapper, *req)
+		if cancel != nil {
+			defer cancel()
+		}
+		if err != nil {
+			s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+			c.JSON(http.StatusInternalServerError, ErrorResponse{
+				Error: ErrorDetail{
+					Message: "Failed to forward request: " + err.Error(),
+					Type:    "api_error",
+				},
+			})
+			if recorder != nil {
+				recorder.RecordError(err)
+			}
+			return
+		}
+
+		inputTokens := int(responsesResp.Usage.InputTokens)
+		outputTokens := int(responsesResp.Usage.OutputTokens)
+		cacheTokens := int(responsesResp.Usage.InputTokensDetails.CachedTokens)
+		tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
+		s.trackUsageWithTokenUsage(c, tokenUsage, nil)
+
+		chatResp := nonstream.OpenAIResponsesToChat(responsesResp, responseModel)
+		if recorder != nil {
+			recorder.SetAssembledResponse(chatResp)
+			recorder.RecordResponse(provider, actualModel)
+		}
+		c.JSON(http.StatusOK, chatResp)
 	}
 }


### PR DESCRIPTION
## Summary
OpenAI Chat Completions was using a separate code path instead of the unified transform chain dispatch. This created inconsistency and made it harder to support cross-protocol conversions like Chat→Responses.

part of #500 

### Major
- OpenAI Chat now uses the same dispatch chain as other protocols
- Added Responses→Chat conversion for providers using Responses API with Chat clients
- Chat→Responses→Chat conversion path is now possible (an error converson before)

### Minor
- Added `stream.HandleResponsesToOpenAIChatStream()` for streaming Responses→Chat conversion
- Added `nonstream.OpenAIResponsesToChat()` for non-streaming conversion
- Reduced `openai.go` by ~120 lines through dispatch consolidation
- Added `dispatchOpenAIChatFromResponses()` handler in `protocol_dispatch.go`