### PR TITLE
refactor(server): migrate openai responses to chain dispatch

### DIFF
--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -1,21 +1,15 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
-	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
-	"github.com/sirupsen/logrus"
-	. "github.com/tingly-dev/tingly-box/internal/protocol/stream"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -190,6 +184,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	s.dispatchChainFromResponses(c, reqCtx, rule, provider, isStreaming, nil)
 }
 
+// buildResponsesPayloadFromChat converts a Chat completion response to Responses API format
 func buildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, actualModel string) map[string]any {
 	model := responseModel
 	if model == "" {
@@ -224,6 +219,7 @@ func buildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, a
 	}
 }
 
+// buildResponsesPayloadFromAnthropic converts an Anthropic message response to Responses API format
 func buildResponsesPayloadFromAnthropic(resp *anthropic.Message, responseModel, actualModel string) map[string]any {
 	model := responseModel
 	if model == "" {
@@ -274,266 +270,6 @@ func buildResponsesPayloadFromAnthropic(resp *anthropic.Message, responseModel, 
 			"total_tokens":  resp.Usage.InputTokens + resp.Usage.OutputTokens,
 		},
 	}
-}
-
-// handleResponsesNonStreamingRequest handles non-streaming Responses API requests
-func (s *Server) handleResponsesNonStreamingRequest(c *gin.Context, provider *typ.Provider, params responses.ResponseNewParams, responseModel, actualModel string) {
-	// Forward request to provider
-	var response *responses.Response
-	var err error
-	var cancel context.CancelFunc
-
-	wrapper := s.clientPool.GetOpenAIClient(provider, string(params.Model))
-	fc := NewForwardContext(nil, provider)
-	response, cancel, err = ForwardOpenAIResponses(fc, wrapper, params)
-	if cancel != nil {
-		defer cancel()
-	}
-
-	if err != nil {
-		// Track error with no usage
-		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Error: ErrorDetail{
-				Message: "Failed to forward request: " + err.Error(),
-				Type:    "api_error",
-			},
-		})
-		return
-	}
-
-	// Extract usage from response
-	inputTokens := int64(response.Usage.InputTokens)
-	outputTokens := int64(response.Usage.OutputTokens)
-	cacheTokens := int64(response.Usage.InputTokensDetails.CachedTokens)
-
-	// Track usage
-	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil)
-
-	// Override model in response if needed
-	if responseModel != actualModel {
-		// Create a copy of the response with updated model
-		responseJSON, _ := json.Marshal(response)
-		var responseMap map[string]any
-		if err := json.Unmarshal(responseJSON, &responseMap); err == nil {
-			responseMap["model"] = responseModel
-			c.JSON(http.StatusOK, responseMap)
-			return
-		}
-	}
-
-	// Return response as-is
-	c.JSON(http.StatusOK, response)
-}
-
-// handleResponsesStreamingRequest handles streaming Responses API requests
-func (s *Server) handleResponsesStreamingRequest(c *gin.Context, provider *typ.Provider, params responses.ResponseNewParams, responseModel, actualModel string) {
-	// Create streaming request with request context for proper cancellation
-	wrapper := s.clientPool.GetOpenAIClient(provider, params.Model)
-	fc := NewForwardContext(c.Request.Context(), provider)
-	stream, cancel, err := ForwardOpenAIResponsesStream(fc, wrapper, params)
-	if cancel != nil {
-		defer cancel()
-	}
-	if err != nil {
-		// Track error with no usage
-		s.trackUsageFromContext(c, 0, 0, err)
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Error: ErrorDetail{
-				Message: "Failed to create streaming request: " + err.Error(),
-				Type:    "api_error",
-			},
-		})
-		return
-	}
-
-	// Handle the streaming response
-	hc := protocol.NewHandleContext(c, responseModel)
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
-	usage, err := HandleOpenAIResponsesStream(hc, stream, responseModel)
-
-	// Track usage from stream handler
-	s.trackUsageWithTokenUsage(c, usage, err)
-}
-
-// handleResponsesStreamResponse processes the streaming response and sends it to the client
-func (s *Server) handleResponsesStreamResponse(c *gin.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion], responseModel, actualModel string) {
-	// Accumulate usage from stream chunks
-	var inputTokens, outputTokens int64
-	var hasUsage bool
-
-	defer func() {
-		if r := recover(); r != nil {
-			logrus.Errorf("Panic in streaming handler: %v", r)
-			if hasUsage {
-				s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), 0), fmt.Errorf("panic: %v", r))
-			}
-			if c.Writer != nil {
-				c.Writer.WriteHeader(http.StatusInternalServerError)
-				c.Writer.Write([]byte("data: {\"error\":{\"message\":\"Internal streaming error\",\"type\":\"internal_error\"}}\n\n"))
-				if flusher, ok := c.Writer.(http.Flusher); ok {
-					flusher.Flush()
-				}
-			}
-		}
-		if stream != nil {
-			if err := stream.Close(); err != nil {
-				logrus.Errorf("Error closing stream: %v", err)
-			}
-		}
-	}()
-
-	// Set SSE headers
-	c.Header("Content-Type", "text/event-stream")
-	c.Header("Cache-Control", "no-cache")
-	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Headers", "Cache-Control")
-
-	flusher, ok := c.Writer.(http.Flusher)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Error: ErrorDetail{
-				Message: "Streaming not supported by this connection",
-				Type:    "api_error",
-				Code:    "streaming_unsupported",
-			},
-		})
-		return
-	}
-
-	// Process the stream with context cancellation checking
-	c.Stream(func(w io.Writer) bool {
-		// Check context cancellation first
-		select {
-		case <-c.Request.Context().Done():
-			logrus.Debug("Client disconnected, stopping Responses stream")
-			return false
-		default:
-		}
-
-		// Try to get next event
-		if !stream.Next() {
-			// Stream ended
-			return false
-		}
-
-		event := stream.Current()
-
-		// Accumulate usage from completed events
-		if event.Response.Usage.InputTokens > 0 {
-			inputTokens = event.Response.Usage.InputTokens
-			hasUsage = true
-		}
-		if event.Response.Usage.OutputTokens > 0 {
-			outputTokens = event.Response.Usage.OutputTokens
-		}
-
-		// Use the event type as the SSE event type (e.g., "response.created", "response.output_text.delta")
-		SSEventOpenAI(c, event.Type, event, responseModel)
-		flusher.Flush()
-		return true
-	})
-
-	// Check for stream errors
-	if err := stream.Err(); err != nil {
-		// Check if it was a client cancellation
-		if errors.Is(err, context.Canceled) {
-			logrus.Debug("Responses stream canceled by client")
-			if hasUsage {
-				s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), 0), err)
-			}
-			return
-		}
-
-		logrus.Errorf("Stream error: %v", err)
-		if hasUsage {
-			s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), 0), err)
-		}
-
-		errorChunk := map[string]any{
-			"error": map[string]any{
-				"message": err.Error(),
-				"type":    "stream_error",
-				"code":    "stream_failed",
-			},
-		}
-
-		errorJSON, marshalErr := json.Marshal(errorChunk)
-		if marshalErr != nil {
-			logrus.Errorf("Failed to marshal error chunk: %v", marshalErr)
-			c.Writer.Write([]byte("data: {\"error\":{\"message\":\"Failed to marshal error\",\"type\":\"internal_error\"}}\n\n"))
-		} else {
-			c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", string(errorJSON))))
-		}
-		flusher.Flush()
-		return
-	}
-
-	// Track successful streaming completion
-	if hasUsage {
-		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), 0), nil)
-	}
-
-	// Send the final [DONE] message
-	c.Writer.Write([]byte("data: [DONE]\n\n"))
-	flusher.Flush()
-}
-
-// SSEventOpenAI sends an SSE event with the given data
-// If the data is a ResponseStreamEventUnion, it uses the raw JSON to avoid
-// serializing empty fields from the union type
-// If modelOverride is provided and the event contains a response object with a model field,
-// it will be overridden in the JSON output
-func SSEventOpenAI(c *gin.Context, t string, data any, modelOverride ...string) error {
-	var jsonBytes []byte
-
-	// For ResponseStreamEventUnion, use RawJSON() to avoid serializing all empty union fields
-	if event, ok := data.(responses.ResponseStreamEventUnion); ok {
-		rawJSON := event.RawJSON()
-		if rawJSON != "" {
-			jsonBytes = []byte(rawJSON)
-			// Apply model override if provided
-			if len(modelOverride) > 0 && modelOverride[0] != "" {
-				var parsed map[string]any
-				if err := json.Unmarshal(jsonBytes, &parsed); err == nil {
-					// Check if this event has a response field with a model
-					if response, ok := parsed["response"].(map[string]any); ok {
-						if model, ok := response["model"].(string); ok && model != "" {
-							response["model"] = modelOverride[0]
-							modified, err := json.Marshal(parsed)
-							if err == nil {
-								jsonBytes = modified
-							}
-						}
-					}
-				}
-			}
-		} else {
-			// Fallback to regular marshaling if RawJSON is empty
-			var err error
-			jsonBytes, err = json.Marshal(event)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		var err error
-		jsonBytes, err = json.Marshal(data)
-		if err != nil {
-			return err
-		}
-	}
-
-	c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", jsonBytes))
-	return nil
 }
 
 // convertToResponsesParams converts raw JSON to OpenAI SDK params format

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -136,10 +136,10 @@ func (s *Server) HandleResponsesCreate(c *gin.Context) {
 	req.ResponseNewParams = params
 	// req.Model is replaced with actualModel (resolved backend model) from this point on
 	req.Model = actualModel
-	s.ResponsesCreate(c, scenarioType, provider, req, rule.RequestModel, maxAllowed)
+	s.ResponsesCreate(c, scenarioType, provider, rule, req, rule.RequestModel, maxAllowed)
 }
 
-func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, provider *typ.Provider, req protocol.ResponseCreateRequest, responseModel string, maxAllowed int) {
+func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, provider *typ.Provider, rule *typ.Rule, req protocol.ResponseCreateRequest, responseModel string, maxAllowed int) {
 	actualModel := req.Model
 	isStreaming := req.Stream
 
@@ -186,100 +186,8 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 		return
 	}
 
-	// Dispatch based on target
-	switch target {
-	case protocol.TypeOpenAIResponses:
-		params := reqCtx.Request.(*responses.ResponseNewParams)
-		if isStreaming {
-			s.handleResponsesStreamingRequest(c, provider, *params, responseModel, actualModel)
-		} else {
-			s.handleResponsesNonStreamingRequest(c, provider, *params, responseModel, actualModel)
-		}
-
-	case protocol.TypeOpenAIChat:
-		chatReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
-		if isStreaming {
-			wrapper := s.clientPool.GetOpenAIClient(provider, string(chatReq.Model))
-			fc := NewForwardContext(c.Request.Context(), provider)
-			chatStream, cancel, err := ForwardOpenAIChatStream(fc, wrapper, chatReq)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{Message: "Failed to create streaming request: " + err.Error(), Type: "api_error"},
-				})
-				return
-			}
-			usage, err := HandleOpenAIChatToResponsesStream(c, chatStream, responseModel)
-			s.trackUsageWithTokenUsage(c, usage, err)
-		} else {
-			wrapper := s.clientPool.GetOpenAIClient(provider, string(chatReq.Model))
-			fc := NewForwardContext(nil, provider)
-			chatResp, _, err := ForwardOpenAIChat(fc, wrapper, chatReq)
-			if err != nil {
-				s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{Message: "Failed to forward request: " + err.Error(), Type: "api_error"},
-				})
-				return
-			}
-			inputTokens := chatResp.Usage.PromptTokens
-			outputTokens := chatResp.Usage.CompletionTokens
-			cacheTokens := chatResp.Usage.PromptTokensDetails.CachedTokens
-			s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil)
-			c.JSON(http.StatusOK, buildResponsesPayloadFromChat(chatResp, responseModel, actualModel))
-		}
-
-	case protocol.TypeAnthropicV1:
-		anthropicReq := reqCtx.Request.(*anthropic.MessageNewParams)
-		if isStreaming {
-			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
-			fc := NewForwardContext(c.Request.Context(), provider)
-			anthropicStream, cancel, err := ForwardAnthropicV1Stream(fc, wrapper, anthropicReq)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{Message: "Failed to create streaming request: " + err.Error(), Type: "api_error"},
-				})
-				return
-			}
-
-			hc := protocol.NewHandleContext(c, responseModel)
-			firstTokenRecorded := false
-			hc.WithOnStreamEvent(func(_ interface{}) error {
-				if !firstTokenRecorded {
-					SetFirstTokenTime(c)
-					firstTokenRecorded = true
-				}
-				return nil
-			})
-			usage, err := HandleAnthropicToOpenAIResponsesStream(hc, anthropicStream, responseModel)
-			s.trackUsageWithTokenUsage(c, usage, err)
-		} else {
-			wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
-			fc := NewForwardContext(nil, provider)
-			anthropicResp, cancel, err := ForwardAnthropicV1(fc, wrapper, anthropicReq)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-				c.JSON(http.StatusInternalServerError, ErrorResponse{
-					Error: ErrorDetail{Message: "Failed to forward request: " + err.Error(), Type: "api_error"},
-				})
-				return
-			}
-
-			cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens)
-			s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(anthropicResp.Usage.InputTokens), int(anthropicResp.Usage.OutputTokens), cacheTokens), nil)
-			c.JSON(http.StatusOK, buildResponsesPayloadFromAnthropic(anthropicResp, responseModel, actualModel))
-		}
-	}
+	// Use unified dispatch
+	s.dispatchChainFromResponses(c, reqCtx, rule, provider, isStreaming, nil)
 }
 
 func buildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, actualModel string) map[string]any {

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -50,6 +52,12 @@ func (s *Server) dispatchChainFromAnthropicV1(
 	isStreaming bool, recorder *ProtocolRecorder,
 ) {
 	switch reqCtx.SourceAPI {
+	case protocol.TypeOpenAIResponses:
+		if isStreaming {
+			s.streamAnthropicV1ToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+		} else {
+			s.nonstreamAnthropicV1ToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+		}
 	default:
 		s.dispatchAnthropicToAnthropicV1(c, reqCtx, rule, provider, isStreaming, recorder)
 	}
@@ -158,7 +166,7 @@ func (s *Server) dispatchAnthropicToAnthropicV1(
 
 		if recorder != nil {
 			recorder.SetAssembledResponse(anthropicResp)
-			recorder.RecordResponse(provider, actualModel)
+			recorder.RecordResponse(provider, reqCtx.RequestModel)
 		}
 		c.JSON(http.StatusOK, anthropicResp)
 	}
@@ -275,7 +283,7 @@ func (s *Server) dispatchOpenAIChatFromAnthropicBeta(
 
 		if recorder != nil {
 			recorder.SetAssembledResponse(anthropicResp)
-			recorder.RecordResponse(provider, actualModel)
+			recorder.RecordResponse(provider, reqCtx.RequestModel)
 		}
 		c.JSON(http.StatusOK, openaiResp)
 	}
@@ -344,7 +352,7 @@ func (s *Server) dispatchChainFromAnthropicBeta(
 
 			if recorder != nil {
 				recorder.SetAssembledResponse(anthropicResp)
-				recorder.RecordResponse(provider, actualModel)
+				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
 			c.JSON(http.StatusOK, anthropicResp)
 		}
@@ -430,7 +438,7 @@ func (s *Server) dispatchChainFromGoogle(
 			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
 			if recorder != nil {
 				recorder.SetAssembledResponse(anthropicResp)
-				recorder.RecordResponse(provider, actualModel)
+				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
 			c.JSON(http.StatusOK, anthropicResp)
 		case protocol.TypeAnthropicBeta:
@@ -438,7 +446,7 @@ func (s *Server) dispatchChainFromGoogle(
 			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
 			if recorder != nil {
 				recorder.SetAssembledResponse(anthropicResp)
-				recorder.RecordResponse(provider, actualModel)
+				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
 			c.JSON(http.StatusOK, anthropicResp)
 		}
@@ -474,11 +482,11 @@ func (s *Server) dispatchChainFromResponses(
 	case protocol.TypeAnthropicV1:
 		logrus.Debugf("[AnthropicV1] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
-			s.handleAnthropicV1ViaResponsesAPIStreaming(c, responseModel, actualModel, provider, *req)
+			s.streamAnthropicV1ToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
 		} else if provider.APIBase == protocol.CodexAPIBase {
 			s.handleAnthropicV1ViaResponsesAPIAssembly(c, responseModel, actualModel, provider, *req)
 		} else {
-			s.handleAnthropicV1ViaResponsesAPINonStreaming(c, responseModel, actualModel, provider, *req)
+			s.nonstreamAnthropicV1ToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
 		}
 	case protocol.TypeAnthropicBeta:
 		logrus.Debugf("[Anthropic Beta] Using Transform Chain for Responses API for model=%s", actualModel)
@@ -493,6 +501,13 @@ func (s *Server) dispatchChainFromResponses(
 		// Client sent Responses API, but provider needs Chat format
 		// Forward as Chat, then convert response back to Responses format
 		s.dispatchOpenAIChatFromResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+	case protocol.TypeOpenAIResponses:
+		// Responses API passthrough
+		if isStreaming {
+			s.streamOpenAIResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+		} else {
+			s.nonstreamOpenAIResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+		}
 	}
 }
 
@@ -590,6 +605,8 @@ func (s *Server) dispatchChainFromOpenAIChat(
 			}
 
 			s.handleOpenAIChatStreamingRequest(c, provider, req, responseModel, shouldIntercept, shouldStripTools, disableStreamUsage)
+		case protocol.TypeOpenAIResponses:
+			s.streamOpenAIChatToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
 		}
 	} else {
 		switch reqCtx.SourceAPI {
@@ -603,6 +620,9 @@ func (s *Server) dispatchChainFromOpenAIChat(
 			}
 
 			s.handleNonStreamingRequest(c, provider, req, responseModel, shouldIntercept, shouldStripTools, stripUsage)
+			return
+		case protocol.TypeOpenAIResponses:
+			s.nonstreamOpenAIChatToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
 			return
 		default:
 			// Forward request to provider for format conversion
@@ -639,7 +659,7 @@ func (s *Server) dispatchChainFromOpenAIChat(
 			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
 			if recorder != nil {
 				recorder.SetAssembledResponse(anthropicResp)
-				recorder.RecordResponse(provider, actualModel)
+				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
 			c.JSON(http.StatusOK, anthropicResp)
 		case protocol.TypeAnthropicBeta:
@@ -647,7 +667,7 @@ func (s *Server) dispatchChainFromOpenAIChat(
 			s.updateAffinityMessageID(c, rule, anthropicResp.ID)
 			if recorder != nil {
 				recorder.SetAssembledResponse(anthropicResp)
-				recorder.RecordResponse(provider, actualModel)
+				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
 			c.JSON(http.StatusOK, anthropicResp)
 		}
@@ -698,7 +718,7 @@ func (s *Server) dispatchOpenAIChatFromResponses(
 		usage, err := stream.HandleResponsesToOpenAIChatStream(hc, responsesStream, responseModel)
 		s.trackUsageWithTokenUsage(c, usage, err)
 		if recorder != nil {
-			recorder.RecordResponse(provider, actualModel)
+			recorder.RecordResponse(provider, reqCtx.RequestModel)
 		}
 	} else {
 		responsesResp, cancel, err := ForwardOpenAIResponses(fc, wrapper, *req)
@@ -728,8 +748,259 @@ func (s *Server) dispatchOpenAIChatFromResponses(
 		chatResp := nonstream.OpenAIResponsesToChat(responsesResp, responseModel)
 		if recorder != nil {
 			recorder.SetAssembledResponse(chatResp)
-			recorder.RecordResponse(provider, actualModel)
+			recorder.RecordResponse(provider, reqCtx.RequestModel)
 		}
 		c.JSON(http.StatusOK, chatResp)
 	}
+}
+
+// ── OpenAI Responses Handlers ─────────────────────────────────────────────
+
+// nonstreamOpenAIResponses handles Responses API passthrough (non-streaming)
+// Moved from openai_responses.go:371-419
+func (s *Server) nonstreamOpenAIResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	responseModel := reqCtx.ResponseModel
+	params := reqCtx.Request.(*responses.ResponseNewParams)
+
+	// Forward request to provider
+	var response *responses.Response
+	var err error
+	var cancel context.CancelFunc
+
+	wrapper := s.clientPool.GetOpenAIClient(provider, string(params.Model))
+	fc := NewForwardContext(nil, provider)
+	response, cancel, err = ForwardOpenAIResponses(fc, wrapper, *params)
+	if cancel != nil {
+		defer cancel()
+	}
+
+	if err != nil {
+		// Track error with no usage
+		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Failed to forward request: " + err.Error(),
+				Type:    "api_error",
+			},
+		})
+		if recorder != nil {
+			recorder.RecordError(err)
+		}
+		return
+	}
+
+	// Extract usage from response
+	inputTokens := int64(response.Usage.InputTokens)
+	outputTokens := int64(response.Usage.OutputTokens)
+	cacheTokens := int64(response.Usage.InputTokensDetails.CachedTokens)
+
+	// Track usage
+	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil)
+
+	// Override model in response if needed
+	if responseModel != reqCtx.RequestModel {
+		// Create a copy of the response with updated model
+		responseJSON, _ := json.Marshal(response)
+		var responseMap map[string]any
+		if err := json.Unmarshal(responseJSON, &responseMap); err == nil {
+			responseMap["model"] = responseModel
+			if recorder != nil {
+				recorder.SetAssembledResponse(response)
+				recorder.RecordResponse(provider, reqCtx.RequestModel)
+			}
+			c.JSON(http.StatusOK, responseMap)
+			return
+		}
+	}
+
+	if recorder != nil {
+		recorder.SetAssembledResponse(response)
+		recorder.RecordResponse(provider, reqCtx.RequestModel)
+	}
+	// Return response as-is
+	c.JSON(http.StatusOK, response)
+}
+
+// streamOpenAIResponses handles Responses API passthrough (streaming)
+// Moved from openai_responses.go:421-456
+func (s *Server) streamOpenAIResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	responseModel := reqCtx.ResponseModel
+	params := reqCtx.Request.(*responses.ResponseNewParams)
+
+	// Create streaming request with request context for proper cancellation
+	wrapper := s.clientPool.GetOpenAIClient(provider, params.Model)
+	fc := NewForwardContext(c.Request.Context(), provider)
+	respStream, cancel, err := ForwardOpenAIResponsesStream(fc, wrapper, *params)
+	if cancel != nil {
+		defer cancel()
+	}
+	if err != nil {
+		// Track error with no usage
+		s.trackUsageFromContext(c, 0, 0, err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Failed to create streaming request: " + err.Error(),
+				Type:    "api_error",
+			},
+		})
+		if recorder != nil {
+			recorder.RecordError(err)
+		}
+		return
+	}
+
+	// Handle the streaming response
+	hc := protocol.NewHandleContext(c, responseModel)
+	firstTokenRecorded := false
+	hc.WithOnStreamEvent(func(_ interface{}) error {
+		if !firstTokenRecorded {
+			SetFirstTokenTime(c)
+			firstTokenRecorded = true
+		}
+		return nil
+	})
+	usage, err := stream.HandleOpenAIResponsesStream(hc, respStream, responseModel)
+
+	// Track usage from stream handler
+	s.trackUsageWithTokenUsage(c, usage, err)
+}
+
+// nonstreamOpenAIChatToResponses handles Chat → Responses conversion (non-streaming)
+// Extracted from openai_responses.go:218-233
+func (s *Server) nonstreamOpenAIChatToResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	responseModel := reqCtx.ResponseModel
+	chatReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
+
+	wrapper := s.clientPool.GetOpenAIClient(provider, string(chatReq.Model))
+	fc := NewForwardContext(nil, provider)
+	chatResp, _, err := ForwardOpenAIChat(fc, wrapper, chatReq)
+	if err != nil {
+		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{Message: "Failed to forward request: " + err.Error(), Type: "api_error"},
+		})
+		if recorder != nil {
+			recorder.RecordError(err)
+		}
+		return
+	}
+	inputTokens := chatResp.Usage.PromptTokens
+	outputTokens := chatResp.Usage.CompletionTokens
+	cacheTokens := chatResp.Usage.PromptTokensDetails.CachedTokens
+	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil)
+	c.JSON(http.StatusOK, buildResponsesPayloadFromChat(chatResp, responseModel, reqCtx.RequestModel))
+}
+
+// streamOpenAIChatToResponses handles Chat → Responses conversion (streaming)
+// Extracted from openai_responses.go:202-216
+func (s *Server) streamOpenAIChatToResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	responseModel := reqCtx.ResponseModel
+	chatReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
+
+	wrapper := s.clientPool.GetOpenAIClient(provider, string(chatReq.Model))
+	fc := NewForwardContext(c.Request.Context(), provider)
+	chatStream, cancel, err := ForwardOpenAIChatStream(fc, wrapper, chatReq)
+	if cancel != nil {
+		defer cancel()
+	}
+	if err != nil {
+		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{Message: "Failed to create streaming request: " + err.Error(), Type: "api_error"},
+		})
+		if recorder != nil {
+			recorder.RecordError(err)
+		}
+		return
+	}
+	usage, err := stream.HandleOpenAIChatToResponsesStream(c, chatStream, responseModel)
+	s.trackUsageWithTokenUsage(c, usage, err)
+}
+
+// nonstreamAnthropicV1ToResponses handles Anthropic v1 → Responses (non-streaming)
+// Extracted from openai_responses.go:265-280
+func (s *Server) nonstreamAnthropicV1ToResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	responseModel := reqCtx.ResponseModel
+	anthropicReq := reqCtx.Request.(*anthropic.MessageNewParams)
+
+	wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
+	fc := NewForwardContext(nil, provider)
+	anthropicResp, cancel, err := ForwardAnthropicV1(fc, wrapper, anthropicReq)
+	if cancel != nil {
+		defer cancel()
+	}
+	if err != nil {
+		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{Message: "Failed to forward request: " + err.Error(), Type: "api_error"},
+		})
+		if recorder != nil {
+			recorder.RecordError(err)
+		}
+		return
+	}
+
+	cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens)
+	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(anthropicResp.Usage.InputTokens), int(anthropicResp.Usage.OutputTokens), cacheTokens), nil)
+	c.JSON(http.StatusOK, buildResponsesPayloadFromAnthropic(anthropicResp, responseModel, reqCtx.RequestModel))
+}
+
+// streamAnthropicV1ToResponses handles Anthropic v1 → Responses (streaming)
+// Extracted from openai_responses.go:238-262
+func (s *Server) streamAnthropicV1ToResponses(
+	c *gin.Context, reqCtx *transform.TransformContext,
+	rule *typ.Rule, provider *typ.Provider,
+	isStreaming bool, recorder *ProtocolRecorder,
+) {
+	responseModel := reqCtx.ResponseModel
+	anthropicReq := reqCtx.Request.(*anthropic.MessageNewParams)
+
+	wrapper := s.clientPool.GetAnthropicClient(provider, string(anthropicReq.Model))
+	fc := NewForwardContext(c.Request.Context(), provider)
+	anthropicStream, cancel, err := ForwardAnthropicV1Stream(fc, wrapper, anthropicReq)
+	if cancel != nil {
+		defer cancel()
+	}
+	if err != nil {
+		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{Message: "Failed to create streaming request: " + err.Error(), Type: "api_error"},
+		})
+		if recorder != nil {
+			recorder.RecordError(err)
+		}
+		return
+	}
+
+	hc := protocol.NewHandleContext(c, responseModel)
+	firstTokenRecorded := false
+	hc.WithOnStreamEvent(func(_ interface{}) error {
+		if !firstTokenRecorded {
+			SetFirstTokenTime(c)
+			firstTokenRecorded = true
+		}
+		return nil
+	})
+	usage, err := stream.HandleAnthropicToOpenAIResponsesStream(hc, anthropicStream, responseModel)
+	s.trackUsageWithTokenUsage(c, usage, err)
 }

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -1,3 +1,5 @@
+// Package server
+// since we do refactoring and migrating step by step, some api names are not unified, this will be updated in future
 package server
 
 import (


### PR DESCRIPTION
## Summary
After code review identified issues with the chain dispatch refactor, this PR completes the migration of OpenAI Responses API handlers to use the unified dispatch pattern, eliminating 360+ lines of duplicate protocol conversion code.

### Major

- **Migrated Responses API to chain dispatch**: `openai_responses.go` now delegates to `protocol_dispatch.go` handlers instead of implementing direct request forwarding
- **Added streaming/non-streaming handlers**: New `streamOpenAIResponses()` and `nonstreamOpenAIResponses()` in `protocol_dispatch.go` handle Responses API passthrough
- **Fixed model tracking bug**: Changed `recorder.RecordResponse(provider, actualModel)` to `recorder.RecordResponse(provider, reqCtx.RequestModel)` for consistent tracking

### Architecture Changes

**Before** (`openai_responses.go`):
```go
// Direct dispatch with duplicated forwarding logic
switch target {
case protocol.TypeOpenAIResponses:
s.handleResponsesStreamingRequest(...)
case protocol.TypeOpenAIChat:
// Inline Chat→Responses conversion (100+ lines)
case protocol.TypeAnthropicV1:
// Inline Anthropic→Responses conversion (80+ lines)
...
}

After (protocol_dispatch.go):
// Chain dispatch via unified handlers
func (s *Server) dispatchChainFromResponses(...) {
switch target {
case protocol.TypeAnthropicV1:
s.streamAnthropicV1ToResponses(...)
case protocol.TypeOpenAIChat:
s.dispatchOpenAIChatFromResponses(...)
case protocol.TypeOpenAIResponses:
s.streamOpenAIResponses(...) // New passthrough handler
}
}
```

### Minor

- Code cleanup: removed unused imports from openai_responses.go
- Chore commit: minor formatting/organization