### PR TITLE
[Bugfix] Make guardrails opt-in and create default config

### DIFF
--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -64,10 +64,13 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 		req.BetaMessageNewParams.Tools = toolinterceptor.StripSearchFetchToolsAnthropicBeta(req.BetaMessageNewParams.Tools)
 	}
 
-	s.applyGuardrailsToToolResultV1Beta(c, &req.BetaMessageNewParams, actualModel, provider)
-	// Apply alias masking after terminal tool_result filtering so the decision
-	// engine sees original tool output and the upstream model sees aliases.
-	s.applyGuardrailsCredentialMasksV1Beta(c, &req.BetaMessageNewParams, actualModel, provider)
+	session := s.guardrailsSessionFromContext(c, actualModel, provider)
+	if s.guardrailsEnabledForSession(session) {
+		s.applyGuardrailsToToolResultV1Beta(c, &req.BetaMessageNewParams, session)
+		// Apply alias masking after terminal tool_result filtering so the decision
+		// engine sees original tool output and the upstream model sees aliases.
+		s.applyGuardrailsCredentialMasksV1BetaWithSession(c, &req.BetaMessageNewParams, session)
+	}
 
 	// Check provider's API style to decide which path to take
 	apiStyle := provider.APIStyle

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -61,11 +61,14 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 		req.MessageNewParams.Tools = toolinterceptor.StripSearchFetchToolsAnthropic(req.MessageNewParams.Tools)
 	}
 
-	s.applyGuardrailsToToolResultV1(c, &req.MessageNewParams, actualModel, provider)
-	// Run credential masking after terminal tool_result filtering so block/review
-	// decisions still inspect the original tool output while the upstream model
-	// only receives alias tokens.
-	s.applyGuardrailsCredentialMasksV1(c, &req.MessageNewParams, actualModel, provider)
+	session := s.guardrailsSessionFromContext(c, actualModel, provider)
+	if s.guardrailsEnabledForSession(session) {
+		s.applyGuardrailsToToolResultV1(c, &req.MessageNewParams, session)
+		// Run credential masking after terminal tool_result filtering so block/review
+		// decisions still inspect the original tool output while the upstream model
+		// only receives alias tokens.
+		s.applyGuardrailsCredentialMasksV1WithSession(c, &req.MessageNewParams, session)
+	}
 
 	// Check provider's API style to decide which path to take
 	apiStyle := provider.APIStyle

--- a/internal/server/config/guardrails_config.go
+++ b/internal/server/config/guardrails_config.go
@@ -2,7 +2,10 @@ package config
 
 import "github.com/tingly-dev/tingly-box/internal/typ"
 
-// applyGuardrailsDefaults enables guardrails by default for testing when not set.
+// applyGuardrailsDefaults ensures the global scenario has an extensions map so
+// guardrails can be toggled explicitly later. Guardrails themselves stay opt-in:
+// a missing flag should behave as disabled rather than forcing runtime startup
+// before a guardrails config exists.
 func (c *Config) applyGuardrailsDefaults() bool {
 	updated := false
 	cfg := c.GetScenarioConfig(typ.ScenarioGlobal)
@@ -17,11 +20,6 @@ func (c *Config) applyGuardrailsDefaults() bool {
 
 	if cfg.Extensions == nil {
 		cfg.Extensions = make(map[string]interface{})
-		updated = true
-	}
-
-	if _, exists := cfg.Extensions["guardrails"]; !exists {
-		cfg.Extensions["guardrails"] = true
 		updated = true
 	}
 

--- a/internal/server/guardrails_credentials_cache.go
+++ b/internal/server/guardrails_credentials_cache.go
@@ -87,7 +87,32 @@ func (s *Server) refreshGuardrailsCredentialCacheOrWarn(context string) {
 	}
 }
 
+func (s *Server) refreshGuardrailsActivationState() {
+	s.guardrailsHasActivePolicies = false
+	if s.config == nil || s.config.ConfigDir == "" {
+		return
+	}
+
+	cfgPath, err := serverguardrails.FindGuardrailsConfig(s.config.ConfigDir)
+	if err != nil {
+		return
+	}
+
+	cfg, err := guardrails.LoadConfig(cfgPath)
+	if err != nil {
+		logrus.WithError(err).Debug("Guardrails activation state: failed to load config")
+		return
+	}
+
+	s.guardrailsHasActivePolicies = hasActiveGuardrailsPolicies(cfg)
+}
+
 func (s *Server) setGuardrailsEngine(engine guardrails.Guardrails, context string) {
 	s.guardrailsEngine = engine
+	if engine == nil {
+		s.guardrailsHasActivePolicies = false
+	} else {
+		s.refreshGuardrailsActivationState()
+	}
 	s.refreshGuardrailsCredentialCacheOrWarn(context)
 }

--- a/internal/server/guardrails_credentials_runtime.go
+++ b/internal/server/guardrails_credentials_runtime.go
@@ -27,11 +27,25 @@ func (s *Server) applyGuardrailsCredentialMasksV1(c *gin.Context, req *anthropic
 	s.applyGuardrailsCredentialMasksToV1Request(c, session, req)
 }
 
+func (s *Server) applyGuardrailsCredentialMasksV1WithSession(c *gin.Context, req *anthropic.MessageNewParams, session guardrailsSession) {
+	if req == nil {
+		return
+	}
+	s.applyGuardrailsCredentialMasksToV1Request(c, session, req)
+}
+
 func (s *Server) applyGuardrailsCredentialMasksV1Beta(c *gin.Context, req *anthropic.BetaMessageNewParams, actualModel string, provider *typ.Provider) {
 	if req == nil {
 		return
 	}
 	session := s.guardrailsSessionFromContext(c, actualModel, provider)
+	s.applyGuardrailsCredentialMasksToV1BetaRequest(c, session, req)
+}
+
+func (s *Server) applyGuardrailsCredentialMasksV1BetaWithSession(c *gin.Context, req *anthropic.BetaMessageNewParams, session guardrailsSession) {
+	if req == nil {
+		return
+	}
 	s.applyGuardrailsCredentialMasksToV1BetaRequest(c, session, req)
 }
 

--- a/internal/server/guardrails_request.go
+++ b/internal/server/guardrails_request.go
@@ -9,16 +9,10 @@ import (
 
 	"github.com/tingly-dev/tingly-box/internal/guardrails"
 	serverguardrails "github.com/tingly-dev/tingly-box/internal/server/guardrails"
-	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // applyGuardrailsToToolResultV1 evaluates tool_result content and replaces it when blocked.
-func (s *Server) applyGuardrailsToToolResultV1(c *gin.Context, req *anthropic.MessageNewParams, actualModel string, provider *typ.Provider) {
-	session := s.guardrailsSessionFromContext(c, actualModel, provider)
-	if !s.guardrailsEnabledForSession(session) {
-		return
-	}
-
+func (s *Server) applyGuardrailsToToolResultV1(c *gin.Context, req *anthropic.MessageNewParams, session guardrailsSession) {
 	toolResultText, toolResultBlocks, toolResultParts := serverguardrails.ExtractToolResultTextV1(req.Messages)
 	logrus.Debugf("Guardrails: tool_result detected (v1) blocks=%d parts=%d len=%d", toolResultBlocks, toolResultParts, len(toolResultText))
 	if toolResultText == "" {
@@ -48,12 +42,7 @@ func (s *Server) applyGuardrailsToToolResultV1(c *gin.Context, req *anthropic.Me
 }
 
 // applyGuardrailsToToolResultV1Beta evaluates tool_result content and replaces it when blocked.
-func (s *Server) applyGuardrailsToToolResultV1Beta(c *gin.Context, req *anthropic.BetaMessageNewParams, actualModel string, provider *typ.Provider) {
-	session := s.guardrailsSessionFromContext(c, actualModel, provider)
-	if !s.guardrailsEnabledForSession(session) {
-		return
-	}
-
+func (s *Server) applyGuardrailsToToolResultV1Beta(c *gin.Context, req *anthropic.BetaMessageNewParams, session guardrailsSession) {
 	toolResultText, toolResultBlocks, toolResultParts := serverguardrails.ExtractToolResultTextV1Beta(req.Messages)
 	logrus.Debugf("Guardrails: tool_result detected (v1beta) blocks=%d parts=%d len=%d", toolResultBlocks, toolResultParts, len(toolResultText))
 	if toolResultText == "" {

--- a/internal/server/guardrails_runtime.go
+++ b/internal/server/guardrails_runtime.go
@@ -43,7 +43,7 @@ func (s *Server) guardrailsSessionFromContext(c *gin.Context, actualModel string
 // guardrailsEnabledForSession centralizes feature-flag checks so protocol handlers
 // do not repeat scenario/global guardrails gating logic.
 func (s *Server) guardrailsEnabledForSession(session guardrailsSession) bool {
-	if s.guardrailsEngine == nil || s.config == nil {
+	if s.guardrailsEngine == nil || s.config == nil || !s.guardrailsHasActivePolicies {
 		return false
 	}
 	if !s.guardrailsSupportsScenario(session.Scenario) {
@@ -51,6 +51,35 @@ func (s *Server) guardrailsEnabledForSession(session guardrailsSession) bool {
 	}
 	return s.config.GetScenarioFlag(typ.RuleScenario(session.Scenario), "guardrails") ||
 		s.config.GetScenarioFlag(typ.ScenarioGlobal, "guardrails")
+}
+
+func hasActiveGuardrailsPolicies(cfg guardrails.Config) bool {
+	if len(cfg.Policies) == 0 || len(cfg.Groups) == 0 {
+		return false
+	}
+
+	enabledGroups := make(map[string]struct{}, len(cfg.Groups))
+	for _, group := range cfg.Groups {
+		if group.Enabled != nil && !*group.Enabled {
+			continue
+		}
+		enabledGroups[group.ID] = struct{}{}
+	}
+	if len(enabledGroups) == 0 {
+		return false
+	}
+
+	for _, policy := range cfg.Policies {
+		if policy.Enabled != nil && !*policy.Enabled {
+			continue
+		}
+		for _, groupID := range policy.Groups {
+			if _, ok := enabledGroups[groupID]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s *Server) guardrailsSupportsScenario(scenario string) bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -186,8 +186,15 @@ func (s *Server) initGuardrailsEngine() {
 
 	cfgPath, err := serverguardrails.FindGuardrailsConfig(s.config.ConfigDir)
 	if err != nil {
-		logrus.WithError(err).Warn("Guardrails config not found; guardrails disabled")
-		return
+		if !strings.Contains(err.Error(), "no guardrails config") {
+			logrus.WithError(err).Warn("Failed to locate guardrails config")
+			return
+		}
+		cfgPath, err = s.ensureDefaultGuardrailsConfig()
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to create default guardrails config")
+			return
+		}
 	}
 
 	cfg, err := guardrails.LoadConfig(cfgPath)
@@ -204,6 +211,35 @@ func (s *Server) initGuardrailsEngine() {
 
 	s.setGuardrailsEngine(engine, "guardrails init")
 	logrus.Infof("Guardrails enabled with config: %s", cfgPath)
+}
+
+func (s *Server) ensureDefaultGuardrailsConfig() (string, error) {
+	if s == nil || s.config == nil || s.config.ConfigDir == "" {
+		return "", fmt.Errorf("config directory not set")
+	}
+
+	path := serverguardrails.GetGuardrailsConfigPath(s.config.ConfigDir)
+	enabled := true
+	cfg := guardrails.Config{
+		Groups: []guardrails.PolicyGroup{
+			{
+				ID:      guardrails.DefaultPolicyGroupID,
+				Name:    "Default",
+				Enabled: &enabled,
+			},
+		},
+	}
+
+	data, err := marshalGuardrailsConfig(cfg)
+	if err != nil {
+		return "", err
+	}
+	if err := writeFileAtomic(path, data); err != nil {
+		return "", err
+	}
+
+	logrus.Infof("Created default guardrails config: %s", path)
+	return path, nil
 }
 
 func (s *Server) guardrailsEnabled() bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,8 +94,9 @@ type Server struct {
 	toolInterceptor *toolinterceptor.Interceptor
 
 	// guardrails engine (optional)
-	guardrailsEngine  guardrails.Guardrails
-	guardrailsHistory *serverguardrails.HistoryStore
+	guardrailsEngine            guardrails.Guardrails
+	guardrailsHasActivePolicies bool
+	guardrailsHistory           *serverguardrails.HistoryStore
 
 	// Protected credential aliasing needs a fast request-path lookup from
 	// scenario -> active mask credentials, plus ID -> credential metadata.


### PR DESCRIPTION
Don't enable guardrails by default; ensure the global scenario has an extensions map so guardrails can be toggled explicitly later (internal/server/config/guardrails_config.go).

In server initialization, treat a missing guardrails config specially: attempt to create a default guardrails config instead of silently disabling guardrails. Add ensureDefaultGuardrailsConfig to generate and atomically write a minimal config with the default policy group enabled, and improve logging for lookup/creation failures (internal/server/server.go). Also reorganized imports accordingly.

clean pr for #603 