### PR TITLE
feat(smart_routing): add service TTFT and capacity utilization routing ops

### DIFF
--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -14,7 +14,7 @@ export interface ConfigProvider {
 
 export interface SmartOp {
     uuid: string;
-    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'tool_use' | 'token';
+    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'tool_use' | 'token' | 'service_ttft' | 'service_capacity';
     operation: string;
     value: string;
     meta?: {

--- a/frontend/src/components/SmartRuleEditDialog.tsx
+++ b/frontend/src/components/SmartRuleEditDialog.tsx
@@ -30,6 +30,8 @@ const POSITION_OPTIONS = [
     // { value: 'tool_use', label: 'Tool Name', description: 'Tool name' },
     { value: 'thinking', label: 'Thinking', description: 'Thinking mode enabled / disable' },
     { value: 'token', label: 'Token Count', description: 'Token count' },
+    { value: 'service_ttft', label: 'Service TTFT', description: 'Time to first token across services (ms)' },
+    { value: 'service_capacity', label: 'Service Capacity', description: 'Seat utilization across services (%)' },
 ] as const;
 
 // Operation options grouped by position
@@ -63,6 +65,18 @@ const OPERATION_OPTIONS: Record<string, Array<{ value: string; label: string; de
         // { value: 'gt', label: 'Greater Than', description: 'Token count > value', valueType: 'int' },
         { value: 'le', label: 'Less or Equal', description: 'Token count <= value', valueType: 'int' },
         // { value: 'lt', label: 'Less Than', description: 'Token count < value', valueType: 'int' },
+    ],
+    service_ttft: [
+        { value: 'avg_le', label: 'Avg ≤', description: 'Best service avg TTFT <= value (ms)', valueType: 'int' },
+        { value: 'avg_ge', label: 'Avg ≥', description: 'Mean avg TTFT across services >= value (ms)', valueType: 'int' },
+        { value: 'max_le', label: 'P99 ≤', description: 'Best service P99 TTFT <= value (ms)', valueType: 'int' },
+        { value: 'max_ge', label: 'P99 ≥', description: 'Mean P99 TTFT across services >= value (ms)', valueType: 'int' },
+    ],
+    service_capacity: [
+        { value: 'util_le', label: 'Utilization ≤', description: 'Avg seat utilization across services <= value (%)', valueType: 'int' },
+        { value: 'util_ge', label: 'Utilization ≥', description: 'Avg seat utilization across services >= value (%)', valueType: 'int' },
+        { value: 'util_lt', label: 'Utilization <', description: 'Avg seat utilization across services < value (%)', valueType: 'int' },
+        { value: 'util_gt', label: 'Utilization >', description: 'Avg seat utilization across services > value (%)', valueType: 'int' },
     ],
 };
 
@@ -333,6 +347,8 @@ const SmartRuleEditDialog: React.FC<SmartRuleEditDialogProps> = ({
                                                 value={getDisplayValue(op)}
                                                 onChange={(e) => handleValueChange(op.uuid, e.target.value)}
                                                 placeholder={
+                                                    op.position === 'service_capacity' ? '0–100' :
+                                                    op.position === 'service_ttft' ? 'ms' :
                                                     op.meta?.type === 'int' ? '1,234' :
                                                     'enter value'
                                                 }

--- a/internal/server/affinity.go
+++ b/internal/server/affinity.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultAffinityTTL = 2 * time.Hour
+	defaultAffinityTTL = 1 * time.Hour
 	gcInterval         = 30 * time.Minute
 )
 
@@ -108,6 +108,26 @@ func (s *AffinityStore) GC() {
 			delete(s.entries, key)
 		}
 	}
+}
+
+const capacityActiveWindow = 30 * time.Minute
+
+// CountByService returns the number of sessions locked to the given serviceID
+// that were created within the capacity active window (last 30 minutes).
+// This provides a "recently active users" count for seat utilization calculation.
+func (s *AffinityStore) CountByService(serviceID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cutoff := time.Now().Add(-capacityActiveWindow)
+	count := 0
+	for _, entry := range s.entries {
+		if entry.LockedAt.After(cutoff) && entry.Service != nil &&
+			entry.Service.ServiceID() == serviceID {
+			count++
+		}
+	}
+	return count
 }
 
 // StartGC starts a background goroutine that periodically cleans up expired entries

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -27,6 +27,7 @@ type LoadBalancer interface {
 type AffinityStore interface {
 	Get(ruleUUID, sessionID string) (*AffinityEntry, bool)
 	Set(ruleUUID, sessionID string, entry *AffinityEntry)
+	CountByService(serviceID string) int // count active sessions locked to this service
 }
 
 // AffinityEntry represents a locked service for a session
@@ -94,18 +95,18 @@ func NewServiceSelector(
 
 	// Pre-build all pipeline variants
 	s.pipelines[pipelineModeNoAffinity] = []SelectionStage{
-		NewSmartRoutingStage(lb),
+		NewSmartRoutingStage(lb, affinity),
 		NewLoadBalancerStage(lb),
 	}
 	s.pipelines[pipelineModeGlobalAffinity] = []SelectionStage{
 		NewAffinityStage(affinity, "global"),
-		NewSmartRoutingStage(lb),
+		NewSmartRoutingStage(lb, affinity),
 		NewLoadBalancerStage(lb),
 	}
 	s.pipelines[pipelineModeSmartAffinity] = []SelectionStage{
 		NewHealthStage(healthFilter),
 		NewAffinityStage(affinity, "smart_rule"),
-		NewSmartRoutingStage(lb),
+		NewSmartRoutingStage(lb, affinity),
 		NewLoadBalancerStage(lb),
 	}
 

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -11,13 +11,15 @@ import (
 // SmartRoutingStage evaluates smart routing rules and returns matched services.
 // If multiple services match, applies load balancing within the matched set.
 type SmartRoutingStage struct {
-	loadBalancer LoadBalancer
+	loadBalancer  LoadBalancer
+	affinityStore AffinityStore
 }
 
 // NewSmartRoutingStage creates a new smart routing stage
-func NewSmartRoutingStage(lb LoadBalancer) *SmartRoutingStage {
+func NewSmartRoutingStage(lb LoadBalancer, affinity AffinityStore) *SmartRoutingStage {
 	return &SmartRoutingStage{
-		loadBalancer: lb,
+		loadBalancer:  lb,
+		affinityStore: affinity,
 	}
 }
 
@@ -43,6 +45,10 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		logrus.Debugf("[smart_routing] failed to extract context: %v", err)
 		return nil, false
 	}
+
+	// Pre-collect capacity info for all services across all smart routing rules.
+	// evaluateRule will filter this down to per-rule services when evaluating.
+	reqCtx.ServiceCapacity = s.collectAllCapacityInfo(rule.SmartRouting)
 
 	// Create router and evaluate
 	router, err := smartrouting.NewRouter(rule.SmartRouting)
@@ -116,4 +122,37 @@ func (s *SmartRoutingStage) selectFromServices(services []*loadbalance.Service, 
 		return nil
 	}
 	return service
+}
+
+// collectAllCapacityInfo collects seat-capacity info for all services across all smart routing rules.
+// Deduplicates by serviceID. evaluateRule will filter down to per-rule services.
+func (s *SmartRoutingStage) collectAllCapacityInfo(rules []smartrouting.SmartRouting) []smartrouting.ServiceCapacityInfo {
+	seen := make(map[string]struct{})
+	var result []smartrouting.ServiceCapacityInfo
+	for _, r := range rules {
+		for _, svc := range r.Services {
+			id := svc.ServiceID()
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+
+			cap := 0
+			if svc.ModelCapacity != nil {
+				cap = *svc.ModelCapacity
+			}
+
+			active := 0
+			if s.affinityStore != nil {
+				active = s.affinityStore.CountByService(id)
+			}
+
+			result = append(result, smartrouting.ServiceCapacityInfo{
+				ServiceID:   id,
+				Capacity:    cap,
+				ActiveCount: active,
+			})
+		}
+	}
+	return result
 }

--- a/internal/server/routing/stage_smart_routing_test.go
+++ b/internal/server/routing/stage_smart_routing_test.go
@@ -17,7 +17,7 @@ func TestSmartRouting_RuleMatch(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.True(t, handled)
 	require.NotNil(t, result)
@@ -34,7 +34,7 @@ func TestSmartRouting_NoMatch(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled, "should pass when rule doesn't match")
 }
@@ -44,7 +44,7 @@ func TestSmartRouting_Disabled(t *testing.T) {
 	rule := testRule("rule-1", "gpt-4", nil)
 	// SmartEnabled is false by default
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	ctx := testContext(rule, "")
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled)
@@ -56,7 +56,7 @@ func TestSmartRouting_EmptyRules(t *testing.T) {
 	rule.SmartEnabled = true
 	rule.SmartRouting = []smartrouting.SmartRouting{} // empty
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4")
 
@@ -69,7 +69,7 @@ func TestSmartRouting_NilRequest(t *testing.T) {
 	rule := testRule("rule-1", "gpt-4", nil)
 	rule.SmartEnabled = true
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	ctx := testContext(rule, "")
 	ctx.Request = nil
 
@@ -85,7 +85,7 @@ func TestSmartRouting_InactiveServiceFiltered(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled, "should pass when matched service is inactive")
 }
@@ -98,7 +98,7 @@ func TestSmartRouting_SingleService(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.True(t, handled)
 	require.Equal(t, "provider-a", result.Service.Provider)
@@ -115,7 +115,7 @@ func TestSmartRouting_MultipleServices_LB(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.True(t, handled)
 	require.Equal(t, "provider-b", result.Service.Provider, "should use LB-selected service")
@@ -138,7 +138,7 @@ func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb)
+	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.True(t, handled)
 	require.Equal(t, "provider-b", result.Service.Provider)
@@ -146,6 +146,6 @@ func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
 }
 
 func TestSmartRouting_Name(t *testing.T) {
-	stage := NewSmartRoutingStage(&mockLoadBalancer{})
+	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
 	require.Equal(t, "smart_routing", stage.Name())
 }

--- a/internal/server/routing/test_helpers.go
+++ b/internal/server/routing/test_helpers.go
@@ -123,6 +123,18 @@ func (m *mockAffinityStore) Set(ruleUUID, sessionID string, entry *AffinityEntry
 	m.sets = append(m.sets, setCall{ruleUUID: ruleUUID, sessionID: sessionID})
 }
 
+func (m *mockAffinityStore) CountByService(serviceID string) int {
+	cutoff := time.Now().Add(-30 * time.Minute)
+	count := 0
+	for _, entry := range m.entries {
+		if entry.LockedAt.After(cutoff) && entry.Service != nil &&
+			entry.Service.ServiceID() == serviceID {
+			count++
+		}
+	}
+	return count
+}
+
 // mockConfig implements ProviderResolver for ServiceSelector tests.
 type mockConfig struct {
 	providers map[string]*typ.Provider

--- a/internal/smart_routing/context.go
+++ b/internal/smart_routing/context.go
@@ -5,7 +5,18 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
+
+// ServiceCapacityInfo holds seat-capacity info for a single service.
+// Capacity is ModelCapacity (configured seat limit); 0 means unlimited.
+// ActiveCount is the number of active affinity sessions currently locked to this service.
+type ServiceCapacityInfo struct {
+	ServiceID   string
+	Capacity    int // seat limit (ModelCapacity); 0 = unlimited
+	ActiveCount int // active affinity sessions
+}
 
 // RequestContext holds extracted request data for evaluation
 type RequestContext struct {
@@ -17,6 +28,11 @@ type RequestContext struct {
 	LatestRole        string // Latest message role (user, assistant, tool, function, etc.)
 	LatestContentType string
 	EstimatedTokens   int
+
+	// Service runtime characteristics — populated by SmartRoutingStage before router evaluation.
+	// These fields are set per-rule inside evaluateRule to avoid cross-rule contamination.
+	ServiceStats    []loadbalance.ServiceStats // TTFT / latency snapshots
+	ServiceCapacity []ServiceCapacityInfo      // seat utilization info
 }
 
 // GetLatestUserMessage returns the latest user message

--- a/internal/smart_routing/op.go
+++ b/internal/smart_routing/op.go
@@ -154,16 +154,86 @@ var Operations = []SmartOp{
 			Type:        ValueTypeInt,
 		},
 	},
+
+	// Service TTFT operations
+	{
+		Position:  PositionServiceTTFT,
+		Operation: OpServiceTTFTAvgLe,
+		Meta: SmartOpMeta{
+			Description: "Min avg TTFT across services <= value (ms)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceTTFT,
+		Operation: OpServiceTTFTAvgGe,
+		Meta: SmartOpMeta{
+			Description: "Avg TTFT mean across services >= value (ms)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceTTFT,
+		Operation: OpServiceTTFTMaxLe,
+		Meta: SmartOpMeta{
+			Description: "Min P99 TTFT across services <= value (ms)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceTTFT,
+		Operation: OpServiceTTFTMaxGe,
+		Meta: SmartOpMeta{
+			Description: "Avg P99 TTFT across services >= value (ms)",
+			Type:        ValueTypeInt,
+		},
+	},
+
+	// Service capacity operations (seat utilization %)
+	{
+		Position:  PositionServiceCapacity,
+		Operation: OpServiceCapacityUtilLe,
+		Meta: SmartOpMeta{
+			Description: "Avg seat utilization across services <= value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceCapacity,
+		Operation: OpServiceCapacityUtilGe,
+		Meta: SmartOpMeta{
+			Description: "Avg seat utilization across services >= value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceCapacity,
+		Operation: OpServiceCapacityUtilLt,
+		Meta: SmartOpMeta{
+			Description: "Avg seat utilization across services < value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceCapacity,
+		Operation: OpServiceCapacityUtilGt,
+		Meta: SmartOpMeta{
+			Description: "Avg seat utilization across services > value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
 }
 
 const (
-	PositionModel         SmartOpPosition = "model"          // Request model name
-	PositionThinking      SmartOpPosition = "thinking"       // Thinking mode enabled
-	PositionContextSystem SmartOpPosition = "context_system" // System message content in context
-	PositionContextUser   SmartOpPosition = "context_user"   // User message content in context
-	PositionLatestUser    SmartOpPosition = "latest_user"    // Latest user message
-	PositionToolUse       SmartOpPosition = "tool_use"       // Tool use/name
-	PositionToken         SmartOpPosition = "token"          // Token count
+	PositionModel           SmartOpPosition = "model"            // Request model name
+	PositionThinking        SmartOpPosition = "thinking"         // Thinking mode enabled
+	PositionContextSystem   SmartOpPosition = "context_system"   // System message content in context
+	PositionContextUser     SmartOpPosition = "context_user"     // User message content in context
+	PositionLatestUser      SmartOpPosition = "latest_user"      // Latest user message
+	PositionToolUse         SmartOpPosition = "tool_use"         // Tool use/name
+	PositionToken           SmartOpPosition = "token"            // Token count
+	PositionServiceTTFT     SmartOpPosition = "service_ttft"     // Service TTFT characteristics
+	PositionServiceCapacity SmartOpPosition = "service_capacity" // Service seat capacity (affinity utilization)
 )
 
 const (
@@ -197,4 +267,16 @@ const (
 	OpTokenGt SmartOpOperation = "gt" // Token count greater than value
 	OpTokenLe SmartOpOperation = "le" // Token count less than or equal to value
 	OpTokenLt SmartOpOperation = "lt" // Token count less than value
+
+	// Service TTFT operations
+	OpServiceTTFTAvgLe SmartOpOperation = "avg_le" // Min avg TTFT across services <= value (ms)
+	OpServiceTTFTAvgGe SmartOpOperation = "avg_ge" // Avg TTFT mean across services >= value (ms)
+	OpServiceTTFTMaxLe SmartOpOperation = "max_le" // Min P99 TTFT across services <= value (ms)
+	OpServiceTTFTMaxGe SmartOpOperation = "max_ge" // Avg P99 TTFT across services >= value (ms)
+
+	// Service capacity operations (seat utilization %)
+	OpServiceCapacityUtilLe SmartOpOperation = "util_le" // Avg seat utilization <= value (%)
+	OpServiceCapacityUtilGe SmartOpOperation = "util_ge" // Avg seat utilization >= value (%)
+	OpServiceCapacityUtilLt SmartOpOperation = "util_lt" // Avg seat utilization < value (%)
+	OpServiceCapacityUtilGt SmartOpOperation = "util_gt" // Avg seat utilization > value (%)
 )

--- a/internal/smart_routing/routing.go
+++ b/internal/smart_routing/routing.go
@@ -53,6 +53,16 @@ func (r *Router) EvaluateRequestWithIndex(ctx *RequestContext) ([]*loadbalance.S
 
 // evaluateRule evaluates if a context matches a single rule
 func (r *Router) evaluateRule(ctx *RequestContext, rule *SmartRouting) bool {
+	// Inject per-rule service data to avoid cross-rule contamination
+	origStats := ctx.ServiceStats
+	origCap := ctx.ServiceCapacity
+	ctx.ServiceStats = collectRuleStats(rule.Services)
+	ctx.ServiceCapacity = filterCapacityForRule(ctx.ServiceCapacity, rule.Services)
+	defer func() {
+		ctx.ServiceStats = origStats
+		ctx.ServiceCapacity = origCap
+	}()
+
 	// All operations must match (AND logic)
 	for _, op := range rule.Ops {
 		if !r.evaluateOp(ctx, &op) {
@@ -79,6 +89,10 @@ func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) bool {
 		return r.evaluateToolUseOp(ctx, op)
 	case PositionToken:
 		return r.evaluateTokenOp(ctx, op)
+	case PositionServiceTTFT:
+		return r.evaluateServiceTTFTOp(ctx, op)
+	case PositionServiceCapacity:
+		return r.evaluateServiceCapacityOp(ctx, op)
 	default:
 		return false
 	}
@@ -387,4 +401,139 @@ func EstimateTokens(text string) int {
 // GetRules returns the router's rules
 func (r *Router) GetRules() []SmartRouting {
 	return r.rules
+}
+
+// evaluateServiceTTFTOp evaluates operations on service TTFT characteristics.
+// Operates on ctx.ServiceStats, which is pre-filtered per-rule by evaluateRule.
+// Returns true (pass) when there is no data (cold-start friendliness).
+func (r *Router) evaluateServiceTTFTOp(ctx *RequestContext, op *SmartOp) bool {
+	if len(ctx.ServiceStats) == 0 {
+		return true
+	}
+
+	threshold, err := op.Int()
+	if err != nil {
+		log.Printf("[smart_routing] invalid service_ttft value '%s': %v", op.Value, err)
+		return false
+	}
+
+	var values []float64
+	for _, s := range ctx.ServiceStats {
+		switch op.Operation {
+		case OpServiceTTFTAvgLe, OpServiceTTFTAvgGe:
+			if s.AvgTTFTMs > 0 {
+				values = append(values, s.AvgTTFTMs)
+			}
+		case OpServiceTTFTMaxLe, OpServiceTTFTMaxGe:
+			if s.P99TTFTMs > 0 {
+				values = append(values, s.P99TTFTMs)
+			}
+		}
+	}
+
+	if len(values) == 0 {
+		return true // no samples yet — do not block
+	}
+
+	thresholdF := float64(threshold)
+	switch op.Operation {
+	case OpServiceTTFTAvgLe:
+		return minFloat(values) <= thresholdF
+	case OpServiceTTFTAvgGe:
+		return avgFloat(values) >= thresholdF
+	case OpServiceTTFTMaxLe:
+		return minFloat(values) <= thresholdF
+	case OpServiceTTFTMaxGe:
+		return avgFloat(values) >= thresholdF
+	}
+	return false
+}
+
+// evaluateServiceCapacityOp evaluates seat-utilization operations.
+// Utilization = activeCount / capacity * 100 per service; averaged across services that have a capacity set.
+// Services with no ModelCapacity (capacity == 0) are treated as unlimited and skipped.
+// Returns true (pass) when no service has a capacity configured.
+func (r *Router) evaluateServiceCapacityOp(ctx *RequestContext, op *SmartOp) bool {
+	if len(ctx.ServiceCapacity) == 0 {
+		return true
+	}
+
+	threshold, err := op.Int()
+	if err != nil {
+		log.Printf("[smart_routing] invalid service_capacity value '%s': %v", op.Value, err)
+		return false
+	}
+
+	var utilValues []float64
+	for _, c := range ctx.ServiceCapacity {
+		if c.Capacity <= 0 {
+			continue // unlimited — skip
+		}
+		util := float64(c.ActiveCount) / float64(c.Capacity) * 100
+		utilValues = append(utilValues, util)
+	}
+
+	if len(utilValues) == 0 {
+		return true // no capacity-configured services — do not block
+	}
+
+	avg := avgFloat(utilValues)
+	thresholdF := float64(threshold)
+
+	switch op.Operation {
+	case OpServiceCapacityUtilLe:
+		return avg <= thresholdF
+	case OpServiceCapacityUtilGe:
+		return avg >= thresholdF
+	case OpServiceCapacityUtilLt:
+		return avg < thresholdF
+	case OpServiceCapacityUtilGt:
+		return avg > thresholdF
+	}
+	return false
+}
+
+// collectRuleStats returns a snapshot of ServiceStats for each service in the rule.
+func collectRuleStats(services []*loadbalance.Service) []loadbalance.ServiceStats {
+	result := make([]loadbalance.ServiceStats, 0, len(services))
+	for _, svc := range services {
+		result = append(result, svc.Stats.GetStats())
+	}
+	return result
+}
+
+// filterCapacityForRule filters all capacity info down to services belonging to this rule.
+func filterCapacityForRule(all []ServiceCapacityInfo, services []*loadbalance.Service) []ServiceCapacityInfo {
+	if len(all) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(services))
+	for _, svc := range services {
+		ids[svc.ServiceID()] = struct{}{}
+	}
+	var result []ServiceCapacityInfo
+	for _, c := range all {
+		if _, ok := ids[c.ServiceID]; ok {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+func minFloat(vals []float64) float64 {
+	m := vals[0]
+	for _, v := range vals[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+func avgFloat(vals []float64) float64 {
+	var sum float64
+	for _, v := range vals {
+		sum += v
+	}
+	return sum / float64(len(vals))
 }

--- a/internal/smart_routing/type.go
+++ b/internal/smart_routing/type.go
@@ -72,7 +72,8 @@ type SmartRouting struct {
 // IsValid checks if the position is valid
 func (p SmartOpPosition) IsValid() bool {
 	switch p {
-	case PositionModel, PositionThinking, PositionContextSystem, PositionContextUser, PositionLatestUser, PositionToolUse, PositionToken:
+	case PositionModel, PositionThinking, PositionContextSystem, PositionContextUser, PositionLatestUser, PositionToolUse, PositionToken,
+		PositionServiceTTFT, PositionServiceCapacity:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
Smart routing rules could only match on request-side signals (model name, token count,
thinking mode, etc.) — there was no way to route based on how services were actually
performing at runtime. This adds two new rule dimensions — service TTFT and seat
utilization — enabling load-aware and capacity-aware routing decisions.

### Major
- New `service_ttft` position: route based on real-time TTFT stats (avg / P99) across
  services in the rule group
- New `service_capacity` position: route based on average seat utilization (%) using
  affinity session counts as the active-user proxy
- Capacity data comes from `AffinityStore.CountByService()`, counting sessions locked
  within the last 30 minutes
- Both positions are cold-start-safe: rules pass when no data is available yet
- Per-rule data isolation in `evaluateRule` prevents cross-rule contamination
- UI: `SmartRuleEditDialog` exposes both positions with operation labels and placeholder
  hints (`ms` / `0–100`)

### Minor
- Reduced default affinity TTL from 2 h to 1 h for more accurate capacity counts
- `SmartRoutingStage` now accepts `AffinityStore` for active session counting
- Added `ServiceCapacityInfo` struct; extended `RequestContext` with `ServiceStats` /
  `ServiceCapacity` fields