### PR TITLE
feat(frontend,server): display provider quota inline in credential table

### DIFF
--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -2,6 +2,7 @@ import { ApiStyleBadge } from '@/components/ApiStyleBadge.tsx';
 import ModelListDialog from '@/components/ModelListDialog';
 import ProviderExportMenu from '@/components/ProviderExportMenu';
 import { exportProvider, exportProviderAsBase64ToClipboard, exportProviderAsJsonlToClipboard } from '@/components/rule-card/utils';
+import { ProviderQuotaDetailRow } from '@/components/credential/ProviderQuotaDetailRow';
 import { Cancel, ContentCopy, Delete, Edit, ListAlt, Route, Visibility } from '@mui/icons-material';
 import {
     Box,
@@ -23,7 +24,8 @@ import {
     Typography,
 } from '@mui/material';
 import type { ExportFormat } from '@/components/rule-card/utils';
-import {useCallback, useState} from 'react';
+import type { ProviderQuota } from '@/types/quota';
+import React, {useCallback, useState} from 'react';
 import api from '../services/api';
 import type { Provider } from '../types/provider';
 
@@ -33,6 +35,9 @@ interface ApiKeyTableProps {
     onToggle?: (providerUuid: string) => void;
     onDelete?: (providerUuid: string) => void;
     onNotification?: (message: string, severity: 'success' | 'error') => void;
+    providerQuotas?: { [uuid: string]: ProviderQuota };
+    refreshingQuotas?: Set<string>;
+    onQuotaRefresh?: (providerUuid: string) => void;
 }
 
 interface TokenModalState {
@@ -53,7 +58,7 @@ interface ModelListDialogState {
     provider: Provider | null;
 }
 
-const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification }: ApiKeyTableProps) => {
+const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, providerQuotas, refreshingQuotas, onQuotaRefresh }: ApiKeyTableProps) => {
     const [tokenModal, setTokenModal] = useState<TokenModalState>({
         open: false,
         providerName: '',
@@ -190,7 +195,9 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification }: 
                 </TableHead>
                 <TableBody>
                     {providers.map((provider) => (
-                        <TableRow key={provider.uuid}>
+                        <React.Fragment key={provider.uuid}>
+                            {/* Main provider row */}
+                            <TableRow>
                             {/* Status */}
                             <TableCell>
                                 <Stack direction="row" alignItems="center" spacing={1}>
@@ -329,7 +336,18 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification }: 
                                 </Box>
                             </TableCell>
                         </TableRow>
-                    ))}
+
+                    {/* Quota detail row */}
+                    {providerQuotas && onQuotaRefresh && (
+                        <ProviderQuotaDetailRow
+                            provider={provider}
+                            quota={providerQuotas[provider.uuid]}
+                            isRefreshing={refreshingQuotas?.has(provider.uuid) || false}
+                            onRefresh={onQuotaRefresh}
+                        />
+                    )}
+                </React.Fragment>
+                ))}
                 </TableBody>
             </Table>
 

--- a/frontend/src/components/OAuthTable.tsx
+++ b/frontend/src/components/OAuthTable.tsx
@@ -2,6 +2,7 @@ import { ApiStyleBadge } from '@/components/ApiStyleBadge.tsx';
 import ModelListDialog from '@/components/ModelListDialog';
 import ProviderExportMenu from '@/components/ProviderExportMenu';
 import { exportProvider, exportProviderAsBase64ToClipboard, exportProviderAsJsonlToClipboard } from '@/components/rule-card/utils';
+import { ProviderQuotaDetailRow } from '@/components/credential/ProviderQuotaDetailRow';
 import { Delete, Edit, ListAlt, Refresh as RefreshIcon, Route, Schedule, VpnKey } from '@mui/icons-material';
 import {
     Box,
@@ -24,7 +25,8 @@ import {
     Typography,
 } from '@mui/material';
 import type { ExportFormat } from '@/components/rule-card/utils';
-import {useCallback, useState} from 'react';
+import type { ProviderQuota } from '@/types/quota';
+import React, {useCallback, useState} from 'react';
 import type { Provider } from '../types/provider';
 
 interface OAuthTableProps {
@@ -35,6 +37,9 @@ interface OAuthTableProps {
     onReauthorize?: (providerUuid: string) => void;
     onRefreshToken?: (providerUuid: string) => Promise<void>;
     onNotification?: (message: string, severity: 'success' | 'error') => void;
+    providerQuotas?: { [uuid: string]: ProviderQuota };
+    refreshingQuotas?: Set<string>;
+    onQuotaRefresh?: (providerUuid: string) => void;
 }
 
 interface DeleteModalState {
@@ -54,7 +59,7 @@ interface ModelListDialogState {
     provider: Provider | null;
 }
 
-const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRefreshToken, onNotification }: OAuthTableProps) => {
+const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRefreshToken, onNotification, providerQuotas, refreshingQuotas, onQuotaRefresh }: OAuthTableProps) => {
     const [deleteModal, setDeleteModal] = useState<DeleteModalState>({
         open: false,
         providerUuid: '',
@@ -207,7 +212,9 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                         const isExpired = expiresAt ? new Date(expiresAt) < new Date() : false;
 
                         return (
-                            <TableRow key={provider.uuid}>
+                            <React.Fragment key={provider.uuid}>
+                                {/* Main provider row */}
+                                <TableRow>
                                 {/* Status */}
                                 <TableCell>
                                     <Stack direction="row" alignItems="center" spacing={1}>
@@ -350,7 +357,18 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                                     </Box>
                                 </TableCell>
                             </TableRow>
-                        );
+
+                    {/* Quota detail row */}
+                    {providerQuotas && onQuotaRefresh && (
+                        <ProviderQuotaDetailRow
+                            provider={provider}
+                            quota={providerQuotas[provider.uuid]}
+                            isRefreshing={refreshingQuotas?.has(provider.uuid) || false}
+                            onRefresh={onQuotaRefresh}
+                        />
+                    )}
+                </React.Fragment>
+                );
                     })}
                 </TableBody>
             </Table>

--- a/frontend/src/components/credential/ProviderQuotaDetailRow.tsx
+++ b/frontend/src/components/credential/ProviderQuotaDetailRow.tsx
@@ -1,0 +1,55 @@
+import { TableCell, TableRow } from '@mui/material';
+import type { Provider } from '@/types/provider';
+import type { ProviderQuota } from '@/types/quota';
+import { QuotaInlineDisplay } from './QuotaInlineDisplay';
+
+interface ProviderQuotaDetailRowProps {
+  provider: Provider;
+  quota: ProviderQuota | undefined;
+  isRefreshing: boolean;
+  onRefresh: (providerUuid: string) => void;
+}
+
+/**
+ * Detail row component for displaying provider quota information.
+ * Renders as a table row with colspan spanning all columns.
+ * Only renders if quota data is available.
+ */
+export function ProviderQuotaDetailRow({
+  provider,
+  quota,
+  isRefreshing,
+  onRefresh,
+}: ProviderQuotaDetailRowProps) {
+  // Debug logging
+  console.log('[ProviderQuotaDetailRow] Rendering for provider:', provider.name, 'uuid:', provider.uuid);
+  console.log('[ProviderQuotaDetailRow] quota:', quota);
+  console.log('[ProviderQuotaDetailRow] quota exists?', !!quota);
+  console.log('[ProviderQuotaDetailRow] quota.primary?', quota?.primary);
+
+  // Don't render the row if no quota data
+  if (!quota) {
+    console.log('[ProviderQuotaDetailRow] Skipping render - no quota data');
+    return null;
+  }
+
+  console.log('[ProviderQuotaDetailRow] Rendering row with quota');
+
+  return (
+    <TableRow>
+      <TableCell
+        colSpan={7}
+        sx={{
+          p: 0,
+          borderTop: 'none',
+        }}
+      >
+        <QuotaInlineDisplay
+          quota={quota}
+          isRefreshing={isRefreshing}
+          onRefresh={() => onRefresh(provider.uuid)}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -1,0 +1,197 @@
+import { Box, Stack, Tooltip, Typography, tooltipClasses } from '@mui/material';
+import type { UsageWindow } from '@/types/quota';
+import { QUOTA_COLORS } from '../dashboard/chartStyles';
+
+interface QuotaBarItemProps {
+  window: UsageWindow;
+  /**
+   * Whether to show detailed info (used/limit, reset time)
+   * If false, only shows label, bar, and percent
+   * @default false
+   */
+  showDetails?: boolean;
+}
+
+/**
+ * Compact inline display of a single quota window.
+ * Shows: Label + Bar + Percent, with details in tooltip.
+ */
+export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps) {
+  const getColor = (percent: number) => {
+    if (percent >= 80) return QUOTA_COLORS.error;
+    if (percent >= 50) return QUOTA_COLORS.warning;
+    return QUOTA_COLORS.success;
+  };
+
+  const barColor = getColor(window.used_percent);
+
+  // Format usage display
+  const formatUsageDisplay = () => {
+    // For percentage-only quotas
+    if (window.used === 0 && window.limit === 0 && window.unit === 'percent') {
+      return `${window.used_percent.toFixed(0)}%`;
+    }
+    return `${window.used_percent.toFixed(0)}%`;
+  };
+
+  // Format detailed info for tooltip
+  const formatDetailedInfo = () => {
+    if (window.used === 0 && window.limit === 0 && window.unit === 'percent') {
+      return `${window.used_percent.toFixed(0)}%`;
+    }
+
+    const formatNumber = (num: number) => {
+      if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
+      if (num >= 1000) return `${(num / 1000).toFixed(0)}K`;
+      return num.toString();
+    };
+
+    return `${formatNumber(window.used)} / ${formatNumber(window.limit)} ${window.unit}`;
+  };
+
+  // Format reset time
+  const formatResetTime = () => {
+    if (!window.resets_at) return null;
+
+    const resetDate = new Date(window.resets_at);
+    const now = new Date();
+    const diffMs = resetDate.getTime() - now.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMs < 0) return 'Expired';
+    if (diffMins < 60) return `in ${diffMins} min`;
+    if (diffHours < 24) return `in ${diffHours}h`;
+    if (diffDays < 7) return `in ${diffDays} days`;
+    return resetDate.toLocaleDateString();
+  };
+
+  const resetTime = formatResetTime();
+  const detailedInfo = formatDetailedInfo();
+
+  const tooltipContent = (
+    <Box
+      sx={{
+        backgroundColor: 'background.paper',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 1.5,
+                        maxWidth: 250,
+      }}
+    >
+      <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+        {window.label}
+      </Typography>
+      <Typography variant="body2" sx={{ display: 'block', mb: 0.5 }}>
+        {detailedInfo}
+      </Typography>
+      {resetTime && (
+        <Typography variant="caption" color="text.secondary">
+          Resets: {resetTime}
+        </Typography>
+      )}
+      {window.description && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          {window.description}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  return (
+    <Tooltip
+      title={tooltipContent}
+      arrow
+      disableInteractive
+      componentsProps={{
+        tooltip: {
+          sx: {
+            backgroundColor: 'transparent',
+            boxShadow: 'none',
+            padding: 0,
+            [`& .${tooltipClasses.arrow}`]: {
+              color: 'divider',
+            },
+          },
+        },
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          flexShrink: 0,
+        }}
+      >
+        {/* Label */}
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ minWidth: 45 }}
+        >
+          {window.label}:
+        </Typography>
+
+        {/* Bar */}
+        <Box
+          sx={{
+            position: 'relative',
+            width: 60,
+            height: 8,
+            cursor: 'pointer',
+          }}
+        >
+          {/* Background */}
+          <Box
+            sx={{
+              height: '100%',
+              bgcolor: QUOTA_COLORS.background,
+              borderRadius: 1,
+              position: 'relative',
+              overflow: 'hidden',
+            }}
+          >
+            {/* Fill bar */}
+            <Box
+              sx={{
+                height: '100%',
+                width: `${Math.min(window.used_percent, 100)}%`,
+                bgcolor: barColor,
+                borderRadius: 1,
+                transition: 'width 0.3s ease',
+              }}
+            />
+          </Box>
+        </Box>
+
+        {/* Percent */}
+        <Typography
+          variant="body2"
+          sx={{
+            color: barColor,
+            minWidth: 35,
+          }}
+        >
+          {formatUsageDisplay()}
+        </Typography>
+
+        {/* Optional details inline */}
+        {showDetails && (
+          <>
+            <Typography variant="caption" color="text.secondary">
+              {detailedInfo}
+            </Typography>
+            {resetTime && (
+              <Typography variant="caption" color="text.secondary">
+                ({resetTime})
+              </Typography>
+            )}
+          </>
+        )}
+      </Stack>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -1,0 +1,185 @@
+import { Box, Stack, IconButton, Typography, CircularProgress, Tooltip } from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import InfoIcon from '@mui/icons-material/Info';
+import { QuotaBarItem } from './QuotaBarItem';
+import type { ProviderQuota } from '@/types/quota';
+
+interface QuotaInlineDisplayProps {
+  quota: ProviderQuota | undefined;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+  /**
+   * Maximum number of quota items to display inline
+   * Additional items are available via info tooltip
+   * @default 3
+   */
+  maxInlineItems?: number;
+}
+
+/**
+ * Horizontal inline display of quota information.
+ * Shows quota items side by side with refresh button.
+ * Hidden items accessible via info icon tooltip.
+ */
+export function QuotaInlineDisplay({
+  quota,
+  isRefreshing,
+  onRefresh,
+  maxInlineItems = 3,
+}: QuotaInlineDisplayProps) {
+  // Debug logging at component entry
+  console.log('[QuotaInlineDisplay] Component rendered, quota:', quota);
+
+  // Collect all available windows
+  const windows: Array<{ key: string; window: any; label: string }> = [];
+
+  console.log('[QuotaInlineDisplay] Checking quota.primary:', quota?.primary);
+
+  if (quota?.primary) {
+    console.log('[QuotaInlineDisplay] Found primary window:', quota.primary);
+    windows.push({ key: 'primary', window: quota.primary, label: quota.primary.label });
+  }
+  if (quota?.secondary) {
+    windows.push({ key: 'secondary', window: quota.secondary, label: quota.secondary.label });
+  }
+  if (quota?.tertiary) {
+    windows.push({ key: 'tertiary', window: quota.tertiary, label: quota.tertiary.label });
+  }
+
+  const hasQuota = windows.length > 0;
+  const hasHiddenItems = windows.length > maxInlineItems;
+  const visibleWindows = windows.slice(0, maxInlineItems);
+  const hiddenWindows = windows.slice(maxInlineItems);
+
+  console.log('[QuotaInlineDisplay] windows collected:', windows);
+  console.log('[QuotaInlineDisplay] hasQuota:', hasQuota);
+
+  // No quota available - don't show anything
+  if (!hasQuota) {
+    return null;
+  }
+
+  // Build hidden items tooltip content
+  const hiddenItemsTooltip = hasHiddenItems ? (
+    <Box
+      sx={{
+        backgroundColor: 'background.paper',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 1.5,
+        maxWidth: 300,
+      }}
+    >
+      <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
+        Additional Quota Information
+      </Typography>
+      {hiddenWindows.map(({ key, window, label }) => (
+        <Box key={key} sx={{ mb: 1 }}>
+          <Typography variant="caption" sx={{ fontWeight: 500, display: 'block' }}>
+            {label}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {window.used === 0 && window.limit === 0 && window.unit === 'percent'
+              ? `${window.used_percent.toFixed(0)}%`
+              : `${window.used} / ${window.limit} ${window.unit} (${window.used_percent.toFixed(0)}%)`
+            }
+          </Typography>
+          {window.resets_at && (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+              Resets: {new Date(window.resets_at).toLocaleString()}
+            </Typography>
+          )}
+        </Box>
+      ))}
+      {quota.cost && (
+        <Box sx={{ mt: 1.5, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+          <Typography variant="caption" sx={{ fontWeight: 500, display: 'block' }}>
+            Cost
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {quota.cost.currency_code || '$'}{quota.cost.used.toFixed(2)} / {quota.cost.currency_code || '$'}{quota.cost.limit.toFixed(2)}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  ) : null;
+
+  return (
+    <Box
+      sx={{
+        px: 2,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        gap: 2,
+      }}
+    >
+      {/* Quota items */}
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{
+          overflowX: 'auto',
+          // Hide scrollbar but keep functionality
+          '&::-webkit-scrollbar': {
+            display: 'none',
+          },
+          msOverflowStyle: 'none',
+          scrollbarWidth: 'none',
+        }}
+      >
+        {visibleWindows.map(({ key, window }) => (
+          <QuotaBarItem key={key} window={window} />
+        ))}
+      </Stack>
+
+      {/* Actions */}
+      <Stack direction="row" spacing={1} alignItems="center">
+        {/* Info icon for hidden items */}
+        {hasHiddenItems && (
+          <Tooltip title={hiddenItemsTooltip} arrow disableInteractive>
+            <IconButton
+              size="small"
+              sx={{
+                p: 0.5,
+                color: 'text.secondary',
+                '&:hover': {
+                  bgcolor: 'action.hover',
+                },
+              }}
+            >
+              <InfoIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {/* Refresh button */}
+        <Tooltip title="Refresh quota" arrow>
+          <IconButton
+            size="small"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            sx={{
+              p: 0.5,
+              color: 'text.secondary',
+              '&:hover': {
+                bgcolor: 'action.hover',
+              },
+              '&:disabled': {
+                color: 'text.disabled',
+              },
+            }}
+          >
+            {isRefreshing ? (
+              <CircularProgress size={16} />
+            ) : (
+              <RefreshIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/hooks/useProviderQuota.ts
+++ b/frontend/src/hooks/useProviderQuota.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ProviderQuota } from '@/types/quota';
+
+interface ProviderQuotaData {
+  [providerUuid: string]: ProviderQuota;
+}
+
+interface UseProviderQuotaOptions {
+  /**
+   * Whether to fetch quota on mount
+   * @default true
+   */
+  fetchOnMount?: boolean;
+}
+
+/**
+ * Helper function to fetch from API
+ */
+async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> {
+  const basePath = window.location.origin;
+  const fullUrl = `${basePath}/api/v1${url}`;
+
+  const token = localStorage.getItem('user_auth_token');
+
+  const response = await fetch(fullUrl, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token && { Authorization: `Bearer ${token}` }),
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Hook for fetching and managing provider quota data.
+ *
+ * Uses batch API to fetch quota for multiple providers efficiently.
+ */
+export function useProviderQuota(providers: Array<{ uuid: string }>, options: UseProviderQuotaOptions = {}) {
+  const { fetchOnMount = true } = options;
+
+  const [quotaData, setQuotaData] = useState<ProviderQuotaData>({});
+  const [refreshing, setRefreshing] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Map<string, string>>(new Map());
+
+  // Batch fetch quota for multiple providers
+  const batchFetchQuota = useCallback(async (providerUuids: string[]): Promise<void> => {
+    if (providerUuids.length === 0) {
+      return;
+    }
+
+    setLoading(true);
+    try {
+      console.log('[useProviderQuota] Batch fetching quota for providers:', providerUuids);
+      const response = await fetchUIAPI('/provider-quota/batch', {
+        method: 'POST',
+        body: JSON.stringify({ provider_uuids: providerUuids }),
+      });
+
+      console.log('[useProviderQuota] Batch response:', response);
+
+      if (response.data) {
+        setQuotaData(prev => ({ ...prev, ...response.data }));
+        // Clear any previous errors for these providers
+        setErrors(prev => {
+          const next = new Map(prev);
+          for (const uuid of providerUuids) {
+            next.delete(uuid);
+          }
+          return next;
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error('[useProviderQuota] Batch fetch failed:', error);
+      // Set error for all providers in the batch
+      setErrors(prev => {
+        const next = new Map(prev);
+        for (const uuid of providerUuids) {
+          next.set(uuid, errorMessage);
+        }
+        return next;
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Fetch quota for a single provider
+  const fetchQuota = useCallback(async (providerUuid: string): Promise<ProviderQuota | null> => {
+    try {
+      console.log(`[useProviderQuota] Fetching quota for ${providerUuid}`);
+      const response = await fetchUIAPI(`/provider-quota/${providerUuid}`);
+
+      console.log(`[useProviderQuota] Response for ${providerUuid}:`, response);
+
+      if (response && response.provider_uuid) {
+        setQuotaData(prev => ({ ...prev, [providerUuid]: response }));
+        // Clear any previous error for this provider
+        setErrors(prev => {
+          const next = new Map(prev);
+          next.delete(providerUuid);
+          return next;
+        });
+        return response;
+      }
+
+      return null;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[useProviderQuota] Failed to fetch quota for ${providerUuid}:`, error);
+      setErrors(prev => new Map(prev).set(providerUuid, errorMessage));
+      return null;
+    }
+  }, []);
+
+  // Refresh quota for a single provider
+  const refreshQuota = useCallback(async (providerUuid: string): Promise<void> => {
+    setRefreshing(prev => new Set(prev).add(providerUuid));
+    try {
+      await fetchUIAPI(`/provider-quota/${providerUuid}/refresh`, {
+        method: 'POST',
+      });
+      await fetchQuota(providerUuid);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[useProviderQuota] Failed to refresh quota for ${providerUuid}:`, error);
+      setErrors(prev => new Map(prev).set(providerUuid, errorMessage));
+    } finally {
+      setRefreshing(prev => {
+        const next = new Set(prev);
+        next.delete(providerUuid);
+        return next;
+      });
+    }
+  }, [fetchQuota]);
+
+  // Fetch all quotas
+  const fetchAllQuotas = useCallback(async () => {
+    const uuids = providers.map(p => p.uuid);
+    await batchFetchQuota(uuids);
+  }, [providers, batchFetchQuota]);
+
+  // Lazy load: fetch quotas when hook is initialized with providers
+  useEffect(() => {
+    if (!fetchOnMount || providers.length === 0) return;
+
+    const providerUuids = providers.map(p => p.uuid);
+    batchFetchQuota(providerUuids);
+  }, [providers.length, fetchOnMount, batchFetchQuota]);
+
+  return {
+    quotaData,
+    refreshing,
+    loading,
+    errors,
+    fetchQuota,
+    refreshQuota,
+    fetchAllQuotas,
+    batchFetchQuota,
+  };
+}

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -22,6 +22,7 @@ import OAuthTable from '@/components/OAuthTable.tsx';
 import EmptyStateGuide from '@/components/EmptyStateGuide';
 import OAuthDialog from '@/components/OAuthDialog.tsx';
 import OAuthDetailDialog from '@/components/OAuthDetailDialog.tsx';
+import { useProviderQuota } from '@/hooks/useProviderQuota';
 
 type ProviderFormData = EnhancedProviderFormData;
 
@@ -99,6 +100,19 @@ const CredentialPage = () => {
     useEffect(() => {
         loadProviders();
     }, []);
+
+    // Quota data fetching
+    const {
+        quotaData,
+        refreshing,
+        refreshQuota,
+    } = useProviderQuota(providers, { fetchOnMount: true });
+
+    // Debug logging
+    useEffect(() => {
+        console.log('[CredentialPage] quotaData updated:', quotaData);
+        console.log('[CredentialPage] providers:', providers);
+    }, [quotaData, providers]);
 
     const showNotification = (message: string, severity: 'success' | 'error') => {
         setSnackbar({ open: true, message, severity });
@@ -446,6 +460,9 @@ const CredentialPage = () => {
                             onNotification={(message, severity) => {
                                 setSnackbar({ open: true, message, severity });
                             }}
+                            providerQuotas={quotaData}
+                            refreshingQuotas={refreshing}
+                            onQuotaRefresh={refreshQuota}
                         />
                     ) : (
                         <EmptyStateGuide
@@ -484,6 +501,9 @@ const CredentialPage = () => {
                             onNotification={(message, severity) => {
                                 setSnackbar({ open: true, message, severity });
                             }}
+                            providerQuotas={quotaData}
+                            refreshingQuotas={refreshing}
+                            onQuotaRefresh={refreshQuota}
                         />
                     ) : (
                         <EmptyStateGuide

--- a/internal/server/module/provider_quota/handler.go
+++ b/internal/server/module/provider_quota/handler.go
@@ -3,6 +3,7 @@ package provider_quota
 import (
 	"context"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -50,6 +51,7 @@ func (h *Handler) RegisterRoutes(r *gin.RouterGroup) {
 	quota := r.Group("/provider-quota")
 	{
 		quota.GET("", h.ListQuota)
+		quota.POST("/batch", h.BatchGetQuota) // 批量获取指定 providers 的 quota
 		quota.GET("/:uuid", h.GetQuota)
 		quota.POST("/refresh", h.RefreshAll)
 		quota.POST("/:uuid/refresh", h.RefreshProvider)
@@ -186,4 +188,84 @@ func (h *Handler) Summary(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, summary)
+}
+
+// BatchGetQuotaRequest 批量获取配额请求
+type BatchGetQuotaRequest struct {
+	// ProviderUUIDs 需要获取配额的供应商 UUID 列表
+	ProviderUUIDs []string `json:"provider_uuids" binding:"required"`
+}
+
+// BatchGetQuotaResponse 批量获取配额响应
+type BatchGetQuotaResponse struct {
+	Data map[string]*quota.ProviderUsage `json:"data"` // key: provider_uuid, value: quota data
+}
+
+// BatchGetQuota 批量获取指定供应商的配额
+// POST /api/v1/provider-quota/batch
+// Body: { "provider_uuids": ["uuid1", "uuid2", "uuid3"] }
+func (h *Handler) BatchGetQuota(c *gin.Context) {
+	var req BatchGetQuotaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if len(req.ProviderUUIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "provider_uuids cannot be empty",
+		})
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	// 并发获取多个 provider 的 quota
+	result := make(map[string]*quota.ProviderUsage)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(req.ProviderUUIDs))
+
+	for _, uuid := range req.ProviderUUIDs {
+		wg.Add(1)
+		go func(providerUUID string) {
+			defer wg.Done()
+			usage, err := h.manager.GetQuota(ctx, providerUUID)
+			if err != nil {
+				// 如果某个 provider 没有 quota 数据，不返回错误，只是跳过
+				if err != quota.ErrUsageNotFound {
+					h.logger.WithError(err).WithField("provider_uuid", providerUUID).Warn("failed to get quota for provider")
+					errChan <- err
+				}
+				return
+			}
+			mu.Lock()
+			result[providerUUID] = usage
+			mu.Unlock()
+		}(uuid)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// 收集错误（如果有）
+	var errors []error
+	for err := range errChan {
+		errors = append(errors, err)
+	}
+
+	// 如果全部失败，返回错误
+	if len(result) == 0 && len(errors) > 0 {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to get quota for any provider",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, BatchGetQuotaResponse{
+		Data: result,
+	})
 }


### PR DESCRIPTION
## Summary
There was no way to view quota usage (rate limits, token budgets) for individual
providers without navigating away from the credential page. This adds an inline
quota display row beneath each provider entry so operators can monitor usage at
a glance.

### Major
- Each provider row in the API Key and OAuth tables now shows a collapsible quota
  detail row with visual bar indicators for primary/secondary/tertiary usage windows
- Color-coded bars (green/yellow/red) reflect utilization thresholds; hover tooltip
  shows exact used/limit values and reset time
- Per-provider refresh button allows manual quota re-fetch without reloading the page
- Batch API endpoint (`POST /api/v1/provider-quota/batch`) fetches quota for all
  visible providers in a single request on page load, reducing N individual calls
  to one

### Minor
- Added `useProviderQuota` hook encapsulating batch fetch, single fetch, and
  per-provider refresh with loading/error state tracking
- `QuotaBarItem` and `QuotaInlineDisplay` components handle rendering and overflow
  (items beyond 3 are accessible via info icon tooltip)
- Backend batch handler runs concurrent goroutines per provider and gracefully
  skips providers with no quota data