### PR TITLE
feat(bot): support multi-question AskUserQuestion via inline keyboard and many bugfix

### DIFF
--- a/agentboot/ask/tool_handlers.go
+++ b/agentboot/ask/tool_handlers.go
@@ -109,10 +109,11 @@ func (h *AskUserQuestionHandler) ParseResponse(req Request, response Response) (
 		}, nil
 	}
 
-	// Try to match against first question (most common case)
+	// Try to match against first question (most common case for stdin single-line input)
 	if len(questions) > 0 {
 		question, ok := questions[0].(map[string]interface{})
 		if ok {
+			questionText, _ := question["question"].(string)
 			options, ok := question["options"].([]interface{})
 			if ok {
 				selectedIndex, selectedLabel := h.parseSelection(selection, options)
@@ -121,12 +122,12 @@ func (h *AskUserQuestionHandler) ParseResponse(req Request, response Response) (
 					// Store the selected option label as the answer
 					if opt, ok := options[selectedIndex].(map[string]interface{}); ok {
 						if label, ok := opt["label"].(string); ok {
-							answers["0"] = label
+							answers[questionText] = label
 						}
 					}
 				} else if selectedLabel != "" {
 					// User typed the label directly
-					answers["0"] = selectedLabel
+					answers[questionText] = selectedLabel
 				}
 			}
 		}

--- a/agentboot/claude/launcher.go
+++ b/agentboot/claude/launcher.go
@@ -69,14 +69,11 @@ func (l *Launcher) GetDiscovery() *CLIDiscovery {
 func (l *Launcher) Execute(ctx context.Context, prompt string, opts agentboot.ExecutionOptions) (*agentboot.Result, error) {
 	timeout := opts.Timeout
 	if timeout == 0 {
-		// Use configured default timeout
+		// Use configured default timeout (0 means no timeout)
 		l.mu.RLock()
 		timeout = l.config.DefaultExecutionTimeout
 		l.mu.RUnlock()
-		// Fallback to 5 minutes if not configured
-		if timeout == 0 {
-			timeout = 5 * time.Minute
-		}
+		// timeout == 0 means no timeout (context cancellation is used instead)
 	}
 	logrus.Infof("launching claude code...: %s", prompt)
 	// If handler is provided in options, use ExecuteWithHandler directly

--- a/agentboot/config.go
+++ b/agentboot/config.go
@@ -11,7 +11,7 @@ func DefaultConfig() Config {
 		DefaultFormat:           OutputFormatStreamJSON,
 		EnableStreamJSON:        true,
 		StreamBufferSize:        100,
-		DefaultExecutionTimeout: 5 * time.Minute,
+		DefaultExecutionTimeout: 0, // no timeout
 	}
 }
 

--- a/internal/remote_control/bot/agent_executor.go
+++ b/internal/remote_control/bot/agent_executor.go
@@ -111,7 +111,7 @@ func (d *ExecutorDependencies) ResolveDefaultProjectPath() string {
 func (d *ExecutorDependencies) resolveSession(chatID string, agentType string, projectPath string) (string, bool, string) {
 	sess := d.SessionMgr.FindBy(chatID, agentType, projectPath)
 
-	if sess == nil || sess.Status == session.StatusExpired || sess.Status == session.StatusClosed || sess.Status == session.StatusPending {
+	if sess == nil || sess.Status == session.StatusExpired || sess.Status == session.StatusClosed {
 		sess = d.SessionMgr.CreateWith(chatID, agentType, projectPath)
 		d.SessionMgr.Update(sess.ID, func(s *session.Session) {
 			s.ExpiresAt = time.Time{}

--- a/internal/remote_control/bot/bot_handler.go
+++ b/internal/remote_control/bot/bot_handler.go
@@ -804,6 +804,11 @@ func (h *BotHandler) completeBind(hCtx HandlerContext, projectPath string) {
 		return
 	}
 
+	// Also update bash cwd to match the new project path
+	if err := h.chatStore.SetBashCwd(hCtx.ChatID, expandedPath); err != nil {
+		logrus.WithError(err).Warn("Failed to update bash cwd after project bind")
+	}
+
 	// With new design, sessions are created on-demand when agent processes a message
 	// No need to create session here
 

--- a/internal/remote_control/bot/bot_handler.go
+++ b/internal/remote_control/bot/bot_handler.go
@@ -247,8 +247,8 @@ func (h *BotHandler) SetVerbose(chatID string, verbose bool) {
 
 	// Also update in-memory default (fallback)
 	h.verboseMu.Lock()
-	h.verboseMu.Unlock()
 	h.verbose = verbose
+	h.verboseMu.Unlock()
 }
 
 // HandleMessage is the main entry point for handling bot messages

--- a/internal/remote_control/bot/bot_prompter.go
+++ b/internal/remote_control/bot/bot_prompter.go
@@ -42,11 +42,13 @@ type IMPrompter struct {
 
 // pendingIMRequest stores a pending request with its context
 type pendingIMRequest struct {
-	request   ask.Request
-	chatID    string
-	platform  imbot.Platform
-	messageID string
-	createdAt time.Time
+	request        ask.Request
+	chatID         string
+	platform       imbot.Platform
+	messageID      string
+	createdAt      time.Time
+	partialAnswers map[string]string // question text -> selected label (for multi-question AskUserQuestion)
+	totalQuestions int               // total number of questions (set when request is created)
 }
 
 // NewIMPrompter creates a new IM-based prompter
@@ -122,12 +124,22 @@ func (p *IMPrompter) Prompt(ctx context.Context, req ask.Request) (ask.Result, e
 	// Create response channel
 	responseChan := make(chan ask.Result, 1)
 
+	// Count questions for AskUserQuestion requests
+	totalQuestions := 0
+	if req.ToolName == "AskUserQuestion" {
+		if questions, ok := req.Input["questions"].([]interface{}); ok {
+			totalQuestions = len(questions)
+		}
+	}
+
 	p.mu.Lock()
 	p.pendingRequests[req.ID] = &pendingIMRequest{
-		request:   req,
-		chatID:    chatID,
-		platform:  platform,
-		createdAt: time.Now(),
+		request:        req,
+		chatID:         chatID,
+		platform:       platform,
+		createdAt:      time.Now(),
+		partialAnswers: make(map[string]string),
+		totalQuestions: totalQuestions,
 	}
 	p.responseChannels[req.ID] = responseChan
 	timeout := p.defaultTimeout
@@ -325,6 +337,48 @@ func (p *IMPrompter) SubmitUserResponse(requestID string, response ask.Response)
 	return p.SubmitResult(requestID, result)
 }
 
+// SubmitPartialAnswer records the answer for one question of an AskUserQuestion request.
+// Returns (true, nil) when all questions are answered and the result has been submitted.
+// Returns (false, nil) when more questions remain.
+func (p *IMPrompter) SubmitPartialAnswer(requestID, questionText, label string) (bool, error) {
+	p.mu.Lock()
+	pending, exists := p.pendingRequests[requestID]
+	if !exists {
+		p.mu.Unlock()
+		return false, fmt.Errorf("request not found or expired: %s", requestID)
+	}
+
+	pending.partialAnswers[questionText] = label
+	answered := len(pending.partialAnswers)
+	total := pending.totalQuestions
+
+	if answered < total {
+		p.mu.Unlock()
+		return false, nil
+	}
+
+	// All questions answered — build final result
+	answers := make(map[string]interface{}, len(pending.partialAnswers))
+	for k, v := range pending.partialAnswers {
+		answers[k] = v
+	}
+	updatedInput := make(map[string]interface{})
+	for k, v := range pending.request.Input {
+		updatedInput[k] = v
+	}
+	updatedInput["answers"] = answers
+
+	result := ask.Result{
+		ID:           requestID,
+		Approved:     true,
+		UpdatedInput: updatedInput,
+		Reason:       "User selected options",
+	}
+	p.mu.Unlock()
+
+	return true, p.SubmitResult(requestID, result)
+}
+
 // GetPendingRequest returns a pending request by ID
 func (p *IMPrompter) GetPendingRequest(requestID string) (*ask.Request, bool) {
 	p.mu.RLock()
@@ -393,6 +447,7 @@ func (p *IMPrompter) buildDefaultKeyboard(requestID string) imbot.InlineKeyboard
 }
 
 // buildAskUserQuestionKeyboard builds a keyboard with options for AskUserQuestion
+// Supports multiple questions: callback data includes question index and option index.
 func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineKeyboardMarkup {
 	kb := imbot.NewKeyboardBuilder()
 
@@ -401,19 +456,28 @@ func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineK
 		return p.buildDefaultKeyboard(req.ID)
 	}
 
-	// Build buttons for each option in the first question
-	if question, ok := questions[0].(map[string]interface{}); ok {
-		if options, ok := question["options"].([]interface{}); ok {
-			for i, opt := range options {
-				if option, ok := opt.(map[string]interface{}); ok {
-					label, _ := option["label"].(string)
-					if label != "" {
-						// Use simple button text with just the number
-						buttonText := fmt.Sprintf("Option %d", i+1)
-						// Use only the index in callback data to keep it short
-						callbackData := imbot.FormatCallbackData("perm", "option", req.ID, fmt.Sprintf("%d", i))
-						kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
-					}
+	// Build buttons for each question and its options
+	for qIdx, q := range questions {
+		question, ok := q.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		options, ok := question["options"].([]interface{})
+		if !ok || len(options) == 0 {
+			continue
+		}
+		// Add a label row for the question if there are multiple questions
+		if len(questions) > 1 {
+			questionText, _ := question["question"].(string)
+			kb.AddRow(imbot.CallbackButton(fmt.Sprintf("Q%d: %s", qIdx+1, questionText), imbot.FormatCallbackData("perm", "noop", req.ID)))
+		}
+		for optIdx, opt := range options {
+			if option, ok := opt.(map[string]interface{}); ok {
+				label, _ := option["label"].(string)
+				if label != "" {
+					buttonText := fmt.Sprintf("%d. %s", optIdx+1, label)
+					callbackData := imbot.FormatCallbackData("perm", "option", req.ID, fmt.Sprintf("%d", qIdx), fmt.Sprintf("%d", optIdx))
+					kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
 				}
 			}
 		}
@@ -429,32 +493,47 @@ func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineK
 func (p *IMPrompter) buildTextSelectionInstructions(req ask.Request) string {
 	var text strings.Builder
 
-	text.WriteString("*To select an option, reply with the number:*\n\n")
-
 	questions, ok := req.Input["questions"].([]interface{})
 	if !ok || len(questions) == 0 {
 		// Fallback: use permission instructions from shared config
 		return ask.FormatPermissionInstructions()
 	}
 
-	// For AskUserQuestion - list the options
-	if question, ok := questions[0].(map[string]interface{}); ok {
-		if options, ok := question["options"].([]interface{}); ok {
-			for i, opt := range options {
-				if option, ok := opt.(map[string]interface{}); ok {
-					label, _ := option["label"].(string)
-					desc, hasDesc := option["description"].(string)
-					if hasDesc && desc != "" {
-						text.WriteString(fmt.Sprintf("• `%d` - %s - %s\n", i+1, label, desc))
-					} else {
-						text.WriteString(fmt.Sprintf("• `%d` - %s\n", i+1, label))
-					}
+	// For AskUserQuestion - list all questions and options
+	for qIdx, q := range questions {
+		question, ok := q.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		questionText, _ := question["question"].(string)
+		options, ok := question["options"].([]interface{})
+		if !ok {
+			continue
+		}
+		if len(questions) > 1 {
+			text.WriteString(fmt.Sprintf("*Q%d: %s*\n", qIdx+1, questionText))
+		} else {
+			text.WriteString("*To select an option, reply with the number:*\n\n")
+		}
+		for i, opt := range options {
+			if option, ok := opt.(map[string]interface{}); ok {
+				label, _ := option["label"].(string)
+				desc, hasDesc := option["description"].(string)
+				if hasDesc && desc != "" {
+					text.WriteString(fmt.Sprintf("• `%d` - %s - %s\n", i+1, label, desc))
+				} else {
+					text.WriteString(fmt.Sprintf("• `%d` - %s\n", i+1, label))
 				}
 			}
 		}
+		text.WriteString("\n")
 	}
 
-	text.WriteString("\n_Just type the number to reply_")
+	if len(questions) > 1 {
+		text.WriteString("_Reply with answers in order, e.g. `1 2 1` for Q1=opt1, Q2=opt2, Q3=opt1_")
+	} else {
+		text.WriteString("_Just type the number to reply_")
+	}
 
 	return text.String()
 }

--- a/internal/remote_control/bot/bot_prompter.go
+++ b/internal/remote_control/bot/bot_prompter.go
@@ -195,6 +195,13 @@ func (p *IMPrompter) Prompt(ctx context.Context, req ask.Request) (ask.Result, e
 	case <-time.After(timeout):
 		p.cleanup(req.ID)
 		p.editPromptToTimeout(bot, chatID, msg.MessageID, req)
+
+		// For AskUserQuestion: auto-select first option (recommended strategy)
+		// For permission/approval requests: deny on timeout
+		if req.ToolName == "AskUserQuestion" {
+			result := p.buildTimeoutQuestionResult(req)
+			return result, nil
+		}
 		return ask.Result{
 			ID:       req.ID,
 			Approved: false,
@@ -204,6 +211,54 @@ func (p *IMPrompter) Prompt(ctx context.Context, req ask.Request) (ask.Result, e
 	case <-ctx.Done():
 		p.cleanup(req.ID)
 		return ask.Result{ID: req.ID, Approved: false}, ctx.Err()
+	}
+}
+
+// buildTimeoutQuestionResult builds a result that auto-selects the first (recommended) option
+// for AskUserQuestion when it times out.
+func (p *IMPrompter) buildTimeoutQuestionResult(req ask.Request) ask.Result {
+	questions, ok := req.Input["questions"].([]interface{})
+	if !ok || len(questions) == 0 {
+		return ask.Result{
+			ID:       req.ID,
+			Approved: false,
+			Reason:   "request timed out",
+		}
+	}
+
+	// For each question, select its first option as the recommended default
+	answers := make(map[string]interface{})
+	for _, q := range questions {
+		question, ok := q.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		questionText, ok := question["question"].(string)
+		if !ok {
+			continue
+		}
+		options, ok := question["options"].([]interface{})
+		if !ok || len(options) == 0 {
+			continue
+		}
+		if opt, ok := options[0].(map[string]interface{}); ok {
+			if label, ok := opt["label"].(string); ok {
+				answers[questionText] = label
+			}
+		}
+	}
+
+	updatedInput := make(map[string]interface{})
+	for k, v := range req.Input {
+		updatedInput[k] = v
+	}
+	updatedInput["answers"] = answers
+
+	return ask.Result{
+		ID:           req.ID,
+		Approved:     true,
+		UpdatedInput: updatedInput,
+		Reason:       "timed out - auto-selected recommended option",
 	}
 }
 

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -216,11 +216,22 @@ func (h *streamingMessageHandler) handleClaudeMessage(claudeMsg claude.Message) 
 	logrus.Infof("[bot] Raw: %s", d)
 	logrus.Infof("[bot] Formatted: %s", formatted)
 
-	if strings.TrimSpace(formatted) != "" {
-		h.sendMessage(formatted)
-	} else {
+	if strings.TrimSpace(formatted) == "" {
 		logrus.WithField("msgType", claudeMsg.GetType()).Debug("Skipping empty formatted message")
+		return nil
 	}
+
+	// In non-verbose mode, only show the final result (assistant turn end), not tool use / intermediate
+	if !h.verbose {
+		msgType := claudeMsg.GetType()
+		// Only forward "result" type messages in quiet mode; skip tool use, system etc.
+		if msgType != "result" && msgType != "assistant" {
+			logrus.WithField("msgType", msgType).Debug("Quiet mode: suppressing non-result message")
+			return nil
+		}
+	}
+
+	h.sendMessage(formatted)
 	return nil
 }
 

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -295,7 +295,7 @@ func newStatusCommand(adapter BotHandlerAdapter) imbot.Command {
 			}
 
 			var parts []string
-			parts = append(parts, fmt.Sprintf("Agent: %s", agentType))
+			parts = append(parts, fmt.Sprintf("Agent: %s", GetAgentDisplayName(agentType)))
 			parts = append(parts, fmt.Sprintf("Session: %s", sess.ID))
 			parts = append(parts, fmt.Sprintf("Status: %s", sess.Status))
 

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -200,7 +200,8 @@ func newInterruptCommand(adapter BotHandlerAdapter) imbot.Command {
 			}
 			return adapter.SendText(ctx.ChatID, "No running task to stop.")
 		}).
-		Hidden().
+		WithCategory("session").
+		WithPriority(70).
 		MustBuild()
 }
 

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -257,48 +257,64 @@ func (h *BotHandler) handlePermissionCallback(hCtx HandlerContext, parts []strin
 	var resultText string
 
 	switch subAction {
+	case "noop":
+		// Label-only button (e.g., question header), do nothing
+		return
+
 	case "option":
 		// Handle multi-option selection (e.g., AskUserQuestion)
-		if len(parts) < 4 {
+		// Callback data format: perm:option:reqID:qIdx:optIdx
+		if len(parts) < 5 {
 			logrus.WithField("parts", parts).Warn("Invalid option callback data")
 			return
 		}
-		optionIndex := parts[3]
+		qIdxStr := parts[3]
+		optIdxStr := parts[4]
 
-		// Convert index to label from the pending request
-		optionLabel := optionIndex
-		if questions, ok := pendingReq.Input["questions"].([]interface{}); ok && len(questions) > 0 {
-			if question, ok := questions[0].(map[string]interface{}); ok {
-				if options, ok := question["options"].([]interface{}); ok {
-					// Parse index
-					var idx int
-					if _, err := fmt.Sscanf(optionIndex, "%d", &idx); err == nil && idx >= 0 && idx < len(options) {
-						if option, ok := options[idx].(map[string]interface{}); ok {
-							if label, ok := option["label"].(string); ok {
-								optionLabel = label
+		// Resolve question text and option label from the pending request
+		var questionText, optionLabel string
+		if questions, ok := pendingReq.Input["questions"].([]interface{}); ok {
+			var qIdx int
+			if _, err := fmt.Sscanf(qIdxStr, "%d", &qIdx); err == nil && qIdx >= 0 && qIdx < len(questions) {
+				if question, ok := questions[qIdx].(map[string]interface{}); ok {
+					questionText, _ = question["question"].(string)
+					if options, ok := question["options"].([]interface{}); ok {
+						var optIdx int
+						if _, err := fmt.Sscanf(optIdxStr, "%d", &optIdx); err == nil && optIdx >= 0 && optIdx < len(options) {
+							if option, ok := options[optIdx].(map[string]interface{}); ok {
+								optionLabel, _ = option["label"].(string)
 							}
 						}
 					}
 				}
 			}
 		}
+		if questionText == "" || optionLabel == "" {
+			logrus.WithField("parts", parts).Warn("Could not resolve question or option from callback data")
+			h.SendText(hCtx, "⚠️ Failed to process selection.")
+			return
+		}
 
-		// Submit as a structured response with the label
-		if err := h.imPrompter.SubmitUserResponse(requestID, ask.Response{
-			Type: "selection",
-			Data: optionLabel,
-		}); err != nil {
-			logrus.WithError(err).WithField("request_id", requestID).Error("Failed to submit option selection")
+		done, err := h.imPrompter.SubmitPartialAnswer(requestID, questionText, optionLabel)
+		if err != nil {
+			logrus.WithError(err).WithField("request_id", requestID).Error("Failed to submit partial answer")
 			h.SendText(hCtx, fmt.Sprintf("Failed to process option selection: %v", err))
 			return
 		}
-		resultText = fmt.Sprintf("✅ Selected: %s", optionLabel)
+
+		if done {
+			resultText = fmt.Sprintf("✅ All answered")
+		} else {
+			h.SendText(hCtx, fmt.Sprintf("✅ Q: %s → %s", questionText, optionLabel))
+			return
+		}
+
 		logrus.WithFields(logrus.Fields{
-			"request_id":   requestID,
-			"tool_name":    pendingReq.ToolName,
-			"option_index": optionIndex,
-			"option_label": optionLabel,
-			"user_id":      hCtx.SenderID,
+			"request_id":    requestID,
+			"tool_name":     pendingReq.ToolName,
+			"question":      questionText,
+			"option_label":  optionLabel,
+			"user_id":       hCtx.SenderID,
 		}).Info("User selected option")
 
 	default:

--- a/internal/remote_control/smart_guide/prompts/default_system_prompt.v4.txt
+++ b/internal/remote_control/smart_guide/prompts/default_system_prompt.v4.txt
@@ -1,6 +1,6 @@
 You are Claude Code, Anthropic's official CLI for Claude.
 
-Now You are @tb (Tingly-Box Smart Guide), an intelligent navigation and coordination assistant.
+Now You are @tb (Smart Guide), an intelligent navigation and coordination assistant.
 
 ## Your Role
 


### PR DESCRIPTION
## Summary  
The Telegram bot previously supported only single-question `AskUserQuestion` prompts, causing workflows to break when Claude asked multiple questions simultaneously. This PR introduces robust multi-question support, featuring inline keyboard buttons for each question and partial-answer accumulation until all questions are resolved.

### Major Improvements  
- **Multi-question rendering**: All questions in an `AskUserQuestion` prompt are now displayed with labeled inline keyboard buttons—each clearly tied to its corresponding question.  
- **Partial answer collection**: Answers are collected per question; the complete `answers` map is submitted only after *all* questions have been answered—ensuring Claude receives a fully populated, correctly keyed result.  
- **Semantic answer keys**: Keys in the `answers` map now use the exact question text (e.g., `"What’s your preferred timezone?"`) instead of positional indices like `"0"`, aligning precisely with the expectations of the Claude Code harness.  
- **Graceful timeout handling**: On timeout, the bot auto-selects the first (recommended) option for *each* unanswered question—preventing agent stalls without compromising correctness.  
- **True `/quiet` mode**: Tool-use notifications and intermediate messages are now fully suppressed; only final `result` and `assistant` messages are forwarded to the user.

### Minor Improvements  
- **Session deduplication**: Sessions are no longer re-created when status is `pending`, eliminating duplicate pending sessions.  
- **Consistent working directory**: The `/cd` (bind) command now synchronizes the bash CWD with the newly bound project path.  
- **Flexible execution timeout**: Default timeout changed from 5 minutes to `0` (infinite), delegating lifecycle control to context cancellation instead.  
- **Mutex fix**: Fixed incorrect unlock order in `SetVerbose`—now properly unlocks *after* the write operation.  
- **Command visibility**: `/interrupt` is now visible in the session category with priority `70`.  
- **Clearer status reporting**: `/status` displays the agent’s human-readable display name (e.g., `Smart Guide`) instead of its internal type string.  
- **Refined system identity**: Updated system prompt so the agent self-identifies as `@tb (Smart Guide)`—cleaner and more consistent than the previous `@tb (Tingly-Box Smart Guide)`.