### PR TITLE
feat(imbot,bot): add emoji reactions for message received and agent done

### DIFF
--- a/imbot/core/types.go
+++ b/imbot/core/types.go
@@ -254,3 +254,87 @@ func GetPlatformCapabilities(platform Platform) *PlatformCapabilities {
 		Features:  []string{},
 	}
 }
+
+// ReactionToken represents a platform-agnostic semantic reaction token.
+// Use these constants instead of raw emoji or platform-specific keys.
+type ReactionToken string
+
+const (
+	ReactionReceived  ReactionToken = "received" // 👀 / Get / eyes — message received, processing
+	ReactionDone      ReactionToken = "done"     // ✅ / DONE / CheckMark — task completed successfully
+	ReactionError     ReactionToken = "error"    // ❌ / CrossMark — task failed
+	ReactionLike      ReactionToken = "like"     // 👍 / THUMBSUP — general approval
+	ReactionLove      ReactionToken = "love"     // ❤️ / HEART — love / great
+	ReactionLaugh     ReactionToken = "laugh"    // 😂 / LOL — funny
+)
+
+// reactionMap maps semantic ReactionToken to platform-specific emoji/key strings.
+var reactionMap = map[Platform]map[ReactionToken]string{
+	PlatformTelegram: {
+		ReactionReceived: "👀",
+		ReactionDone:     "✅",
+		ReactionError:    "❌",
+		ReactionLike:     "👍",
+		ReactionLove:     "❤️",
+		ReactionLaugh:    "😂",
+	},
+	PlatformDiscord: {
+		ReactionReceived: "👀",
+		ReactionDone:     "✅",
+		ReactionError:    "❌",
+		ReactionLike:     "👍",
+		ReactionLove:     "❤️",
+		ReactionLaugh:    "😂",
+	},
+	PlatformSlack: {
+		ReactionReceived: "eyes",
+		ReactionDone:     "white_check_mark",
+		ReactionError:    "x",
+		ReactionLike:     "thumbsup",
+		ReactionLove:     "heart",
+		ReactionLaugh:    "joy",
+	},
+	PlatformWhatsApp: {
+		ReactionReceived: "👀",
+		ReactionDone:     "✅",
+		ReactionError:    "❌",
+		ReactionLike:     "👍",
+		ReactionLove:     "❤️",
+		ReactionLaugh:    "😂",
+	},
+	PlatformFeishu: {
+		ReactionReceived: "Get",
+		ReactionDone:     "DONE",
+		ReactionError:    "CrossMark",
+		ReactionLike:     "THUMBSUP",
+		ReactionLove:     "HEART",
+		ReactionLaugh:    "LOL",
+	},
+	PlatformLark: {
+		ReactionReceived: "Get",
+		ReactionDone:     "DONE",
+		ReactionError:    "CrossMark",
+		ReactionLike:     "THUMBSUP",
+		ReactionLove:     "HEART",
+		ReactionLaugh:    "LOL",
+	},
+	PlatformDingTalk: {
+		ReactionReceived: "👀",
+		ReactionDone:     "✅",
+		ReactionError:    "❌",
+		ReactionLike:     "👍",
+		ReactionLove:     "❤️",
+		ReactionLaugh:    "😂",
+	},
+}
+
+// ResolveReaction returns the platform-specific emoji/key for a semantic reaction token.
+// Falls back to the reaction token itself if no mapping is found.
+func ResolveReaction(platform Platform, r ReactionToken) string {
+	if m, ok := reactionMap[platform]; ok {
+		if v, ok := m[r]; ok {
+			return v
+		}
+	}
+	return string(r)
+}

--- a/imbot/imbot.go
+++ b/imbot/imbot.go
@@ -90,6 +90,7 @@ type (
 	Poll              = core.Poll
 	PollOption        = core.PollOption
 	Reaction          = core.Reaction
+	ReactionToken     = core.ReactionToken
 	ThreadContext     = core.ThreadContext
 	Entity            = core.Entity
 	ConnectionDetails = core.ConnectionDetails
@@ -144,8 +145,15 @@ const (
 	ErrPlatformError     = core.ErrPlatformError
 	ErrTimeout           = core.ErrTimeout
 	ErrUnknown           = core.ErrUnknown
-)
 
+	// Semantic reaction tokens
+	ReactionReceived = core.ReactionReceived
+	ReactionDone     = core.ReactionDone
+	ReactionError    = core.ReactionError
+	ReactionLike     = core.ReactionLike
+	ReactionLove     = core.ReactionLove
+	ReactionLaugh    = core.ReactionLaugh
+)
 // Version is the imbot package version
 const Version = "0.1.0"
 
@@ -169,6 +177,11 @@ func NewPollContent(poll core.Poll) *core.PollContent {
 // NewReactionContent creates a new reaction content
 func NewReactionContent(reaction core.Reaction) *core.ReactionContent {
 	return core.NewReactionContent(reaction)
+}
+
+// ResolveReaction returns the platform-specific emoji/key for a semantic reaction token.
+func ResolveReaction(platform Platform, r ReactionToken) string {
+	return core.ResolveReaction(platform, r)
 }
 
 // NewSystemContent creates a new system content

--- a/imbot/platform/dingtalk/dingtalk.go
+++ b/imbot/platform/dingtalk/dingtalk.go
@@ -1,8 +1,12 @@
 package dingtalk
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"sync"
 	"time"
 
@@ -27,6 +31,11 @@ type Bot struct {
 	wg         sync.WaitGroup
 	mu         sync.RWMutex
 	webhookMap map[string]string // conversationID -> webhook URL
+
+	// access token cache for REST API calls (e.g. reactions)
+	tokenMu      sync.Mutex
+	cachedToken  string
+	tokenExpiry  time.Time
 }
 
 // NewDingTalkBot creates a new DingTalk bot
@@ -190,9 +199,80 @@ func (b *Bot) SendMedia(ctx context.Context, target string, media []core.MediaAt
 	})
 }
 
-// React reacts to a message (not supported in current implementation)
+// React adds an emoji reaction to a message via DingTalk REST API.
+// messageID must be the DingTalk msgId (from incoming message data.MsgId).
 func (b *Bot) React(ctx context.Context, messageID string, emoji string) error {
-	return core.NewBotError(core.ErrPlatformError, "react not yet implemented for DingTalk", false)
+	token, err := b.getAccessToken(ctx)
+	if err != nil {
+		return fmt.Errorf("dingtalk react: get token: %w", err)
+	}
+
+	url := "https://api.dingtalk.com/v1.0/im/messages/" + messageID + "/reactions"
+	body, _ := json.Marshal(map[string]interface{}{
+		"reactionType": map[string]string{"emojiCode": emoji},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("dingtalk react: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("dingtalk react: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("dingtalk react: status %d: %s", resp.StatusCode, string(data))
+	}
+	return nil
+}
+
+// getAccessToken returns a cached or fresh DingTalk access token.
+func (b *Bot) getAccessToken(ctx context.Context) (string, error) {
+	b.tokenMu.Lock()
+	defer b.tokenMu.Unlock()
+
+	if b.cachedToken != "" && time.Now().Before(b.tokenExpiry) {
+		return b.cachedToken, nil
+	}
+
+	clientID := b.Config().Auth.ClientID
+	clientSecret := b.Config().Auth.ClientSecret
+
+	url := fmt.Sprintf("https://oapi.dingtalk.com/gettoken?appkey=%s&appsecret=%s", clientID, clientSecret)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("get token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		Errcode     int    `json:"errcode"`
+		Errmsg      string `json:"errmsg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if result.Errcode != 0 {
+		return "", fmt.Errorf("dingtalk gettoken error %d: %s", result.Errcode, result.Errmsg)
+	}
+
+	b.cachedToken = result.AccessToken
+	// Expire 5 minutes early to avoid edge cases
+	b.tokenExpiry = time.Now().Add(time.Duration(result.ExpiresIn-300) * time.Second)
+	return b.cachedToken, nil
 }
 
 // EditMessage edits a message (not supported)

--- a/imbot/platform/feishu/bot_sdk.go
+++ b/imbot/platform/feishu/bot_sdk.go
@@ -654,9 +654,29 @@ func (b *Bot) SendMedia(ctx context.Context, target string, media []core.MediaAt
 	return b.SendMessage(ctx, target, &core.SendMessageOptions{Media: media})
 }
 
-// React reacts to a message
+// React reacts to a message using Feishu SDK MessageReaction API.
+// emoji should be a platform-specific key (e.g. "THUMBSUP") or a core.Reaction
+// resolved via core.ResolveReaction before calling.
 func (b *Bot) React(ctx context.Context, messageID string, emoji string) error {
-	return fmt.Errorf("reaction not implemented")
+	if b.client == nil {
+		return fmt.Errorf("feishu client not initialized")
+	}
+
+	req := larkim.NewCreateMessageReactionReqBuilder().
+		MessageId(messageID).
+		Body(larkim.NewCreateMessageReactionReqBodyBuilder().
+			ReactionType(larkim.NewEmojiBuilder().EmojiType(emoji).Build()).
+			Build()).
+		Build()
+
+	resp, err := b.client.Im.MessageReaction.Create(ctx, req)
+	if err != nil {
+		return fmt.Errorf("feishu react: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("feishu react failed: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
 }
 
 // EditMessage edits a message

--- a/internal/remote_control/bot/bot_agent.go
+++ b/internal/remote_control/bot/bot_agent.go
@@ -37,7 +37,7 @@ func (c *CompletionCallback) OnComplete(result *agentboot.CompletionResult) {
 	kb := BuildActionKeyboard()
 	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
 
-	doneText := IconDone + " " + MsgTaskDone + ". \n" + MsgContinueOrHelp + BuildFooter(c.meta.AgentType, c.meta.ProjectPath)
+	doneText := IconDone + " " + MsgTaskDone + ". " + MsgContinueOrHelp + BuildFooter(c.meta.AgentType, c.meta.ProjectPath)
 	_, err := c.hCtx.Bot.SendMessage(context.Background(), c.hCtx.ChatID, &imbot.SendMessageOptions{
 		Text: doneText,
 		Metadata: map[string]interface{}{
@@ -217,7 +217,7 @@ func (c *SmartGuideCompletionCallback) OnComplete(result *agentboot.CompletionRe
 		}
 	}
 
-	sgDoneText := IconDone + " " + MsgTaskDone + ". \n" + MsgContinueOrHelp + BuildFooter(c.meta.AgentType, c.meta.ProjectPath)
+	sgDoneText := IconDone + " " + MsgTaskDone + ". " + MsgContinueOrHelp + BuildFooter(c.meta.AgentType, c.meta.ProjectPath)
 	_, err := c.hCtx.Bot.SendMessage(context.Background(), c.hCtx.ChatID, &imbot.SendMessageOptions{
 		Text:     sgDoneText,
 		Metadata: metadata,
@@ -255,7 +255,9 @@ func (h *BotHandler) handleAgentMessage(hCtx HandlerContext, agent agentboot.Age
 	if err != nil {
 		logrus.WithError(err).Error("Agent execution failed via router")
 		h.SendText(hCtx, fmt.Sprintf("Agent execution failed: %v", err))
+		return
 	}
+	h.reactDone(hCtx)
 }
 
 // getCurrentAgent retrieves the current agent for a chat

--- a/internal/remote_control/bot/bot_handler.go
+++ b/internal/remote_control/bot/bot_handler.go
@@ -318,6 +318,7 @@ func (h *BotHandler) HandleMessage(msg imbot.Message, platform imbot.Platform, b
 	if msg.IsMediaContent() {
 		media := msg.GetMedia()
 		if len(media) > 0 {
+			h.reactReceived(hCtx)
 			h.handleMediaMessage(hCtx, media)
 		} else {
 			h.SendText(hCtx, fmt.Sprintf("Empty media from %s %s.", msg.ChatType, chatID))
@@ -348,6 +349,9 @@ func (h *BotHandler) HandleMessage(msg imbot.Message, platform imbot.Platform, b
 		return
 	}
 
+	// React to indicate the message is being processed (after stop check, before all other handling)
+	h.reactReceived(hCtx)
+
 	// Handle commands
 	if strings.HasPrefix(hCtx.Text(), "/") {
 		h.handleSlashCommands(hCtx)
@@ -364,6 +368,7 @@ func (h *BotHandler) HandleMessage(msg imbot.Message, platform imbot.Platform, b
 	if h.handlePermissionTextResponse(hCtx) {
 		return
 	}
+
 
 	// NEW: Route all messages through agent router
 	// The router now defaults to @tb (Smart Guide) for new users
@@ -885,6 +890,30 @@ func (h *BotHandler) handleCustomPathInput(hCtx HandlerContext) {
 // BuildBindConfirmPrompt returns the text for bind confirmation prompt
 func BuildBindConfirmPrompt(proposedPath string) string {
 	return fmt.Sprintf("📁 *No project bound.*\n\nBind to current directory?\n\n`%s`", proposedPath)
+}
+
+// reactReceived sends a "received" reaction on the user's message to indicate it is being processed.
+// Errors are silently ignored — platforms that don't support reactions degrade gracefully.
+func (h *BotHandler) reactReceived(hCtx HandlerContext) {
+	if hCtx.MessageID == "" {
+		return
+	}
+	emoji := imbot.ResolveReaction(hCtx.Platform, imbot.ReactionToken(imbot.ReactionReceived))
+	if err := hCtx.Bot.React(context.Background(), hCtx.MessageID, emoji); err != nil {
+		logrus.WithError(err).WithField("messageID", hCtx.MessageID).Warn("React received failed")
+	}
+}
+
+// reactDone sends a "done" reaction on the user's message to indicate processing is complete.
+// Errors are silently ignored — platforms that don't support reactions degrade gracefully.
+func (h *BotHandler) reactDone(hCtx HandlerContext) {
+	if hCtx.MessageID == "" {
+		return
+	}
+	emoji := imbot.ResolveReaction(hCtx.Platform, imbot.ReactionToken(imbot.ReactionDone))
+	if err := hCtx.Bot.React(context.Background(), hCtx.MessageID, emoji); err != nil {
+		logrus.WithError(err).WithField("messageID", hCtx.MessageID).Warn("React done failed")
+	}
 }
 
 // BuildCustomPathPrompt returns the text for custom path input prompt

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -115,9 +115,9 @@ func (f *streamingMessageHandler) OnComplete(result *agentboot.CompletionResult)
 	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
 
 	// Prepare completion message based on verbose mode
-	completionText := IconDone + " " + MsgTaskDone + ". \n" + MsgContinueOrHelp + BuildFooter(f.meta.AgentType, f.meta.ProjectPath)
+	completionText := IconDone + " " + MsgTaskDone + ". " + MsgContinueOrHelp + BuildFooter(f.meta.AgentType, f.meta.ProjectPath)
 	if !f.verbose {
-		completionText = IconDone + " " + MsgTaskDone + ". (Quiet mode: /verbose to show details)\n" + MsgContinueOrHelp + BuildFooter(f.meta.AgentType, f.meta.ProjectPath)
+		completionText = IconDone + " " + MsgTaskDone + ". (Quiet mode: /verbose to show details) " + MsgContinueOrHelp + BuildFooter(f.meta.AgentType, f.meta.ProjectPath)
 	}
 
 	_, err := f.bot.SendMessage(context.Background(), f.chatID, &imbot.SendMessageOptions{


### PR DESCRIPTION
## Summary
Users had no visual feedback indicating whether the bot had received their message or finished processing it. This adds emoji reactions (👀 on receive, ✅ on done) that appear immediately on the user's message, giving clear status
signals without extra chat noise.

<img width="1168" height="320" alt="image" src="https://github.com/user-attachments/assets/f90c957c-4ee5-48d9-9c52-d444ab49e7fd" />

### Major
- Bot reacts with 👀 ("received") when a message or media is accepted and processing begins
- Bot reacts with ✅ ("done") when the agent finishes successfully
- Feishu and DingTalk `React()` APIs implemented (were stubs returning errors before)
- DingTalk reaction uses REST API with cached access token to avoid repeated token fetches
- Added semantic `ReactionToken` abstraction (`received`, `done`, `error`, `like`, `love`, `laugh`) with per-platform emoji/key mappings — callers use tokens, not raw strings

### Minor
- Fixed extra `\n` in completion messages (all three completion paths: callback, smart guide, stream)
- Fixed missing `return` after agent error that caused `reactDone` to fire on failure
- Exported `ReactionToken` and reaction constants through `imbot` package top-level