### PR TITLE
feat(frontend,server): add unified/separate mode for claude code profiles

### DIFF
--- a/frontend/src/contexts/ProfileContext.tsx
+++ b/frontend/src/contexts/ProfileContext.tsx
@@ -4,6 +4,7 @@ import { api } from '@/services/api';
 export interface ProfileInfo {
     id: string;
     name: string;
+    unified?: boolean;  // true=unified mode, false/undefined=separate mode
 }
 
 interface ScenarioProfiles {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -454,7 +454,14 @@ export default {
       "profileRenamed": "Profile renamed",
       "profileDeleted": "Profile deleted",
       "renameFailed": "Failed to rename profile",
-      "deleteFailed": "Failed to delete profile"
+      "deleteFailed": "Failed to delete profile",
+      "mode": "Mode",
+      "unified": "Unified",
+      "separate": "Separate",
+      "unifiedDescription": "All models use the same routing rule (tingly/cc)",
+      "separateDescription": "Each model uses its own routing rule",
+      "modeUpdated": "Profile mode updated to {{mode}}",
+      "modeUpdateFailed": "Failed to update profile mode"
     }
   },
   "prompt": {

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -9,6 +9,8 @@ import {
     ListItemIcon,
     ListItemText,
     Popover,
+    Stack,
+    Switch,
     TextField,
     Tooltip,
     Typography,
@@ -34,6 +36,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
 
     const [addProfileAnchorEl, setAddProfileAnchorEl] = useState<HTMLElement | null>(null);
     const [newProfileName, setNewProfileName] = useState('');
+    const [newProfileUnified, setNewProfileUnified] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
     const addProfileInputRef = useRef<HTMLInputElement>(null);
 
@@ -42,19 +45,21 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
     const handleAddProfileClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
         setAddProfileAnchorEl(e.currentTarget);
         setNewProfileName('');
+        setNewProfileUnified(false);
         setTimeout(() => addProfileInputRef.current?.focus(), 100);
     }, []);
 
     const handleAddProfileClose = useCallback(() => {
         setAddProfileAnchorEl(null);
         setNewProfileName('');
+        setNewProfileUnified(false);
     }, []);
 
     const handleCreateProfile = useCallback(async () => {
         if (!newProfileName.trim()) return;
         try {
             setIsCreating(true);
-            const result = await api.createProfile('claude_code', newProfileName.trim());
+            const result = await api.createProfile('claude_code', newProfileName.trim(), newProfileUnified);
             if (result.success) {
                 handleAddProfileClose();
                 refresh();
@@ -64,7 +69,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
         } finally {
             setIsCreating(false);
         }
-    }, [newProfileName, refresh, handleAddProfileClose]);
+    }, [newProfileName, newProfileUnified, refresh, handleAddProfileClose]);
 
     return (
         <Box
@@ -204,7 +209,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                 onClose={handleAddProfileClose}
                 anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                slotProps={{ paper: { sx: { p: 2, width: 220, mt: -0.5 } } }}
+                slotProps={{ paper: { sx: { p: 2, width: 280, mt: -0.5 } } }}
             >
                 <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>New Profile</Typography>
                 <TextField
@@ -217,6 +222,24 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                     onKeyDown={(e) => e.key === 'Enter' && handleCreateProfile()}
                     disabled={isCreating}
                 />
+                <Box sx={{ mt: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <Box>
+                        <Typography variant="body2" sx={{ fontWeight: 500 }}>Mode</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            {newProfileUnified ? 'Unified: Single model for all' : 'Separate: Individual models'}
+                        </Typography>
+                    </Box>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography variant="body2" color="text.secondary">Separate</Typography>
+                        <Switch
+                            size="small"
+                            checked={newProfileUnified}
+                            onChange={(e) => setNewProfileUnified(e.target.checked)}
+                            disabled={isCreating}
+                        />
+                        <Typography variant="body2" color="text.secondary">Unified</Typography>
+                    </Stack>
+                </Box>
                 <Box sx={{ mt: 1.5, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
                     <Button size="small" onClick={handleAddProfileClose} disabled={isCreating}>Cancel</Button>
                     <Button size="small" variant="contained" onClick={handleCreateProfile} disabled={!newProfileName.trim() || isCreating}>

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -36,7 +36,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
 
     const [addProfileAnchorEl, setAddProfileAnchorEl] = useState<HTMLElement | null>(null);
     const [newProfileName, setNewProfileName] = useState('');
-    const [newProfileUnified, setNewProfileUnified] = useState(false);
+    const [newProfileUnified, setNewProfileUnified] = useState(true);  // Default to unified
     const [isCreating, setIsCreating] = useState(false);
     const addProfileInputRef = useRef<HTMLInputElement>(null);
 
@@ -45,14 +45,14 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
     const handleAddProfileClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
         setAddProfileAnchorEl(e.currentTarget);
         setNewProfileName('');
-        setNewProfileUnified(false);
+        setNewProfileUnified(true);  // Reset to unified when opening
         setTimeout(() => addProfileInputRef.current?.focus(), 100);
     }, []);
 
     const handleAddProfileClose = useCallback(() => {
         setAddProfileAnchorEl(null);
         setNewProfileName('');
-        setNewProfileUnified(false);
+        setNewProfileUnified(true);  // Reset to unified when closing
     }, []);
 
     const handleCreateProfile = useCallback(async () => {

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -12,6 +12,7 @@ import InfoIcon from '@mui/icons-material/Info';
 import CodeIcon from '@mui/icons-material/Code';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import Chip from '@mui/material/Chip';
+import Switch from '@mui/material/Switch';
 import {
     Box,
     Button,
@@ -26,7 +27,7 @@ import {
     Tooltip,
     Typography
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import TemplatePage from './components/TemplatePage.tsx';
@@ -63,21 +64,27 @@ const ClaudeCodeProfilePage: React.FC = () => {
     const [isProfileMutating, setIsProfileMutating] = useState(false);
     const [npmMode, setNpmMode] = useState(true);
     const [appVersion, setAppVersion] = useState('');
+    const [unifiedMode, setUnifiedMode] = useState(currentProfile?.unified || false);
+    const [isUpdatingMode, setIsUpdatingMode] = useState(false);
+
+    // Update unified mode when profile changes
+    useEffect(() => {
+        setUnifiedMode(currentProfile?.unified || false);
+    }, [currentProfile]);
 
     // Load rules for this profile
-    useEffect(() => {
-        let isMounted = true;
-        const loadData = async () => {
-            setLoadingRule(true);
-            const result = await api.getRules(scenario);
-            if (isMounted) {
-                setRules(result.success ? result.data : []);
-                setLoadingRule(false);
-            }
-        };
-        loadData();
-        return () => { isMounted = false; };
+    const loadRules = useCallback(async () => {
+        setLoadingRule(true);
+        // Profile rules have their own scenario (e.g., claude_code:p1)
+        // Just load all rules for this profile scenario
+        const result = await api.getRules(scenario);
+        setRules(result.success ? result.data : []);
+        setLoadingRule(false);
     }, [scenario]);
+
+    useEffect(() => {
+        loadRules();
+    }, [loadRules]);
 
     // Load app version for npm command
     useEffect(() => {
@@ -125,6 +132,30 @@ const ClaudeCodeProfilePage: React.FC = () => {
         }
     };
 
+    // Handle mode toggle
+    const handleModeToggle = async () => {
+        if (!profileId) return;
+        const newMode = !unifiedMode;
+        try {
+            setIsUpdatingMode(true);
+            // Only pass unified mode, let backend use existing name
+            const result = await api.updateProfile(BASE_SCENARIO, profileId, '', newMode);
+            if (result.success) {
+                setUnifiedMode(newMode);
+                showNotification(t('claudeCode.profile.modeUpdated', { mode: newMode ? t('claudeCode.profile.unified') : t('claudeCode.profile.separate') }), 'success');
+                refreshProfiles();
+                // Reload rules after mode change
+                await loadRules();
+            } else {
+                showNotification(`${t('claudeCode.profile.modeUpdateFailed')}: ${result.error || 'Unknown error'}`, 'error');
+            }
+        } catch {
+            showNotification(t('claudeCode.profile.modeUpdateFailed'), 'error');
+        } finally {
+            setIsUpdatingMode(false);
+        }
+    };
+
     const ccCommand = npmMode && appVersion
         ? `npx -y tingly-box@${appVersion} cc --profile ${profileId}`
         : `tingly-box cc --profile ${profileId}`;
@@ -155,7 +186,15 @@ const ClaudeCodeProfilePage: React.FC = () => {
                         </Box>
                     }
                     rightAction={
-                        <Chip label={currentProfile ? `${profileId} - ${currentProfile.name}` : profileId} size="small" variant="outlined" />
+                        <Stack direction="row" spacing={1} alignItems="center">
+                            <Chip
+                                label={unifiedMode ? t('claudeCode.profile.unified') : t('claudeCode.profile.separate')}
+                                size="small"
+                                variant="outlined"
+                                color={unifiedMode ? "primary" : "default"}
+                            />
+                            <Chip label={currentProfile ? `${profileId} - ${currentProfile.name}` : profileId} size="small" variant="outlined" />
+                        </Stack>
                     }
                 >
                     <Box sx={{ px: 2, pb: 1.5 }}>
@@ -225,6 +264,51 @@ const ClaudeCodeProfilePage: React.FC = () => {
                                 </Tooltip>
                             </Stack>
                         </Box>
+                    </Box>
+                    <Divider sx={{ mx: 2 }} />
+                    {/* Mode Toggle Section */}
+                    <Box sx={{ px: 2, py: 1.5 }}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, maxWidth: 700 }}>
+                            <Typography variant="subtitle2" color="text.secondary" sx={{ minWidth: 190, flexShrink: 0, fontWeight: 500 }}>
+                                {t('claudeCode.profile.mode')}
+                            </Typography>
+                            <Typography variant="subtitle2" color="text.secondary"
+                            sx={{
+                                    fontFamily: 'monospace',
+                                    fontSize: '0.75rem',
+                                    color: 'primary.main',
+                                    flex: 1,
+                                    minWidth: 0,
+                                    cursor: 'pointer',
+                                    '&:hover': {
+                                        textDecoration: 'underline',
+                                        backgroundColor: 'action.hover'
+                                    },
+                                    padding: 1,
+                                    borderRadius: 1,
+                                    transition: 'all 0.2s ease-in-out'
+                                }}
+                            >
+                            {unifiedMode
+                                ? t('claudeCode.profile.unifiedDescription')
+                                : t('claudeCode.profile.separateDescription')}
+                            </Typography>
+                            <Stack direction="row" spacing={1} alignItems="center">
+                                <Typography variant="body2" color="text.secondary">
+                                    {t('claudeCode.profile.separate')}
+                                </Typography>
+                                <Switch
+                                    checked={unifiedMode}
+                                    onChange={handleModeToggle}
+                                    disabled={isUpdatingMode}
+                                    size="small"
+                                />
+                                <Typography variant="body2" color="text.secondary">
+                                    {t('claudeCode.profile.unified')}
+                                </Typography>
+                            </Stack>
+                        </Box>
+
                     </Box>
                     <Divider sx={{ mx: 2 }} />
                     <ProviderConfigCard

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -556,17 +556,24 @@ export const api = {
         return uiAPI(`/scenario/${scenario}/profiles`);
     },
 
-    createProfile: async (scenario: string, name: string): Promise<any> => {
+    createProfile: async (scenario: string, name: string, unified?: boolean): Promise<any> => {
         return uiAPI(`/scenario/${scenario}/profiles`, {
             method: 'POST',
-            body: JSON.stringify({ name }),
+            body: JSON.stringify({ name, unified }),
         });
     },
 
-    updateProfile: async (scenario: string, id: string, name: string): Promise<any> => {
+    updateProfile: async (scenario: string, id: string, name: string, unified?: boolean): Promise<any> => {
+        const body: { name?: string; unified?: boolean } = {};
+        if (name) {
+            body.name = name;
+        }
+        if (unified !== undefined) {
+            body.unified = unified;
+        }
         return uiAPI(`/scenario/${scenario}/profiles/${id}`, {
             method: 'PUT',
-            body: JSON.stringify({ name }),
+            body: JSON.stringify(body),
         });
     },
 

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -28,7 +28,12 @@ func CCCommand(appManager *AppManager) *cobra.Command {
 A temporary settings file is created and passed to Claude Code via --settings,
 so the existing Claude Code configuration is not modified.
 
-Profiles can be used to switch between different rule sets for the same scenario.`,
+Profiles can be used to switch between different rule sets for the same scenario.
+
+Flags:
+  -p, --profile <id>     Profile ID or name (e.g., p1, Premium)
+  -u, --unified          Unified mode (all models use same rule)
+  -s, --no-unified       Separate mode (individual model rules)`,
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,11 +90,11 @@ func parseCCFlags(args []string) (profile string, unified *bool, remaining []str
 			profile = args[i+1]
 			i++ // skip next
 
-		case args[i] == "--unified":
+		case args[i] == "--unified" || args[i] == "-u":
 			v := true
 			unified = &v
 
-		case args[i] == "--no-unified":
+		case args[i] == "--no-unified" || args[i] == "-s":
 			v := false
 			unified = &v
 
@@ -108,12 +113,22 @@ func runCC(appManager *AppManager, profile string, unified bool, claudeArgs []st
 
 	// Resolve profile if specified
 	var profileID string
+	var profileMeta *typ.ProfileMeta
 	if profile != "" {
 		resolved, err := globalConfig.ResolveProfileNameOrID(scenario, profile)
 		if err != nil {
 			return fmt.Errorf("profile error: %w", err)
 		}
 		profileID = resolved
+
+		// Get profile metadata to check Unified setting
+		profiles := globalConfig.GetProfiles(scenario)
+		for i := range profiles {
+			if profiles[i].ID == profileID {
+				profileMeta = &profiles[i]
+				break
+			}
+		}
 	}
 
 	// Build the scenario path (with or without profile)
@@ -130,10 +145,18 @@ func runCC(appManager *AppManager, profile string, unified bool, claudeArgs []st
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	apiKey := globalConfig.GetModelToken()
 
-	// Generate env map (profile always uses separate mode)
+	// Determine unified mode: CLI flag > profile setting > default (false for profiles)
 	envUnified := unified
 	if profileID != "" {
-		envUnified = false
+		if !unified {
+			// No explicit CLI flag, use profile's setting
+			if profileMeta != nil {
+				envUnified = profileMeta.Unified
+			} else {
+				envUnified = false // default to separate for backward compatibility
+			}
+		}
+		// If unified flag was explicitly set, it overrides profile setting
 	}
 	env := generateCCEnv(baseURL, apiKey, scenarioPath, envUnified, profileID != "")
 

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -194,7 +194,10 @@ func runCC(appManager *AppManager, profile string, unified bool, claudeArgs []st
 	execCmd.Stderr = os.Stderr
 	execCmd.Env = os.Environ()
 
-	return execCmd.Run()
+	if err := execCmd.Run(); err != nil {
+		return fmt.Errorf("failed to run claude CLI: %w", err)
+	}
+	return nil
 }
 
 // buildProfileSettings copies the user's ~/.claude/settings.json to

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1200,7 +1200,8 @@ func (c *Config) GetProfile(baseScenario typ.RuleScenario, profileID string) (ty
 }
 
 // CreateProfile adds a new profile to a base scenario. Returns the created ProfileMeta.
-func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string) (typ.ProfileMeta, error) {
+// The unified parameter determines whether to use unified mode (single model) or separate mode (individual models).
+func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unified bool) (typ.ProfileMeta, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -1229,20 +1230,40 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string) (typ.
 	}
 
 	meta := typ.ProfileMeta{
-		ID:   fmt.Sprintf("p%d", nextID),
-		Name: name,
+		ID:      fmt.Sprintf("p%d", nextID),
+		Name:    name,
+		Unified: unified,
 	}
 
 	c.Profiles[base] = append(c.Profiles[base], meta)
 
 	// Clone rules from base scenario to the new profiled scenario.
-	// For claude_code, profiles only support "separate" mode, so skip the unified rule.
+	// For claude_code, mode determines which rules to include:
+	// - unified mode: include built-in-cc rule, skip individual model rules
+	// - separate mode: skip built-in-cc rule, include individual model rules
 	profiledScenario := typ.ProfiledScenarioName(baseScenario, meta.ID)
 	for _, rule := range c.Rules {
 		if rule.Scenario == baseScenario {
-			if baseScenario == typ.ScenarioClaudeCode && rule.UUID == RuleUUIDBuiltinCC {
-				continue // skip unified rule for claude_code profiles
+			// Handle claude_code scenario specially based on mode
+			if baseScenario == typ.ScenarioClaudeCode {
+				if unified {
+					// Unified mode: only include built-in-cc, skip individual model rules
+					if rule.UUID == RuleUUIDBuiltinCC {
+						cloned := rule
+						cloned.UUID = uuid.New().String()
+						cloned.Scenario = profiledScenario
+						c.Rules = append(c.Rules, cloned)
+					}
+					// Skip individual model rules (haiku, sonnet, opus, default, subagent)
+					continue
+				} else {
+					// Separate mode: skip built-in-cc, include individual model rules
+					if rule.UUID == RuleUUIDBuiltinCC {
+						continue
+					}
+				}
 			}
+
 			cloned := rule
 			cloned.UUID = uuid.New().String()
 			cloned.Scenario = profiledScenario
@@ -1250,7 +1271,10 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string) (typ.
 			if strings.HasPrefix(cloned.RequestModel, "tingly/cc-") {
 				cloned.RequestModel = strings.TrimPrefix(cloned.RequestModel, "tingly/cc-")
 			} else if cloned.RequestModel == "tingly/cc" {
-				continue // skip unified model name
+				// Skip unified model name for separate mode
+				if !unified {
+					continue
+				}
 			}
 			c.Rules = append(c.Rules, cloned)
 		}
@@ -1259,8 +1283,9 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string) (typ.
 	return meta, c.Save()
 }
 
-// UpdateProfile updates the name of an existing profile.
-func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, name string) error {
+// UpdateProfile updates the name and/or mode of an existing profile.
+// Pass nil for unified to keep existing mode, or bool pointer to change it.
+func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, name string, unified *bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -1288,7 +1313,58 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 		}
 	}
 
+	oldUnified := profiles[idx].Unified
+
+	// Update fields
 	profiles[idx].Name = name
+	if unified != nil {
+		profiles[idx].Unified = *unified
+	}
+
+	// If mode changed, we need to update the rules
+	if unified != nil && *unified != oldUnified && baseScenario == typ.ScenarioClaudeCode {
+		profiledScenario := typ.ProfiledScenarioName(baseScenario, profileID)
+
+		// Remove existing profile rules
+		c.Rules = slices.DeleteFunc(c.Rules, func(r typ.Rule) bool {
+			return r.Scenario == profiledScenario
+		})
+
+		// Re-clone rules with new mode setting
+		for _, rule := range c.Rules {
+			if rule.Scenario == baseScenario {
+				if *unified {
+					// Unified mode: only include built-in-cc, skip individual model rules
+					if rule.UUID == RuleUUIDBuiltinCC {
+						cloned := rule
+						cloned.UUID = uuid.New().String()
+						cloned.Scenario = profiledScenario
+						c.Rules = append(c.Rules, cloned)
+					}
+					continue
+				} else {
+					// Separate mode: skip built-in-cc, include individual model rules
+					if rule.UUID == RuleUUIDBuiltinCC {
+						continue
+					}
+				}
+
+				cloned := rule
+				cloned.UUID = uuid.New().String()
+				cloned.Scenario = profiledScenario
+				// Strip "tingly/cc-" prefix for profile rules
+				if strings.HasPrefix(cloned.RequestModel, "tingly/cc-") {
+					cloned.RequestModel = strings.TrimPrefix(cloned.RequestModel, "tingly/cc-")
+				} else if cloned.RequestModel == "tingly/cc" {
+					if !*unified {
+						continue
+					}
+				}
+				c.Rules = append(c.Rules, cloned)
+			}
+		}
+	}
+
 	return c.Save()
 }
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1239,7 +1239,7 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 
 	// Clone rules from base scenario to the new profiled scenario.
 	// For claude_code, mode determines which rules to include:
-	// - unified mode: include built-in-cc rule, skip individual model rules
+	// - unified mode: include built-in-cc rule as "*" (wildcard), skip individual model rules
 	// - separate mode: skip built-in-cc rule, include individual model rules
 	profiledScenario := typ.ProfiledScenarioName(baseScenario, meta.ID)
 	for _, rule := range c.Rules {
@@ -1247,11 +1247,12 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 			// Handle claude_code scenario specially based on mode
 			if baseScenario == typ.ScenarioClaudeCode {
 				if unified {
-					// Unified mode: only include built-in-cc, skip individual model rules
+					// Unified mode: only include built-in-cc, rename request model to "*"
 					if rule.UUID == RuleUUIDBuiltinCC {
 						cloned := rule
 						cloned.UUID = uuid.New().String()
 						cloned.Scenario = profiledScenario
+						cloned.RequestModel = "*" // Use "*" as wildcard for all models
 						c.Rules = append(c.Rules, cloned)
 					}
 					// Skip individual model rules (haiku, sonnet, opus, default, subagent)
@@ -1275,6 +1276,8 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 				if !unified {
 					continue
 				}
+				// For unified mode, rename to "*"
+				cloned.RequestModel = "*"
 			}
 			c.Rules = append(c.Rules, cloned)
 		}
@@ -1334,11 +1337,12 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 		for _, rule := range c.Rules {
 			if rule.Scenario == baseScenario {
 				if *unified {
-					// Unified mode: only include built-in-cc, skip individual model rules
+					// Unified mode: only include built-in-cc, rename to "*"
 					if rule.UUID == RuleUUIDBuiltinCC {
 						cloned := rule
 						cloned.UUID = uuid.New().String()
 						cloned.Scenario = profiledScenario
+						cloned.RequestModel = "*" // Use "*" as wildcard for all models
 						c.Rules = append(c.Rules, cloned)
 					}
 					continue
@@ -1359,6 +1363,8 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 					if !*unified {
 						continue
 					}
+					// For unified mode, rename to "*"
+					cloned.RequestModel = "*"
 				}
 				c.Rules = append(c.Rules, cloned)
 			}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -680,7 +680,9 @@ func (c *Config) IsRequestModelInScenario(modelName string, scenario typ.RuleSce
 	return false
 }
 
-// IsWildcardRuleName checks if the given rule name is a wildcard that matches any model
+// IsWildcardRuleName checks if the given rule name is a wildcard that matches any model.
+// This function is thread-safe as it only performs constant string comparisons
+// and does not access any shared state. It can be called without holding Config.mu.
 func IsWildcardRuleName(name string) bool {
 	return name == WildcardRuleName || name == WildcardRuleNameAlt
 }

--- a/internal/server/module/scenario/handler.go
+++ b/internal/server/module/scenario/handler.go
@@ -362,7 +362,7 @@ func (h *Handler) CreateProfile(c *gin.Context) {
 		return
 	}
 
-	meta, err := h.config.CreateProfile(scenario, req.Name)
+	meta, err := h.config.CreateProfile(scenario, req.Name, req.Unified)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
 		return
@@ -371,7 +371,7 @@ func (h *Handler) CreateProfile(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": meta})
 }
 
-// UpdateProfile updates a profile's name
+// UpdateProfile updates a profile's name and/or mode
 func (h *Handler) UpdateProfile(c *gin.Context) {
 	scenario := typ.RuleScenario(c.Param("scenario"))
 	if scenario == "" {
@@ -388,22 +388,43 @@ func (h *Handler) UpdateProfile(c *gin.Context) {
 		return
 	}
 
-	var req ProfileCreateRequest
+	var req ProfileUpdateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
 		return
 	}
+
+	// If name is not provided, fetch existing profile name
 	if req.Name == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "name is required"})
-		return
+		profiles := h.config.GetProfiles(scenario)
+		for _, p := range profiles {
+			if p.ID == profileID {
+				req.Name = p.Name
+				break
+			}
+		}
+		if req.Name == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "profile not found"})
+			return
+		}
 	}
 
-	if err := h.config.UpdateProfile(scenario, profileID, req.Name); err != nil {
+	if err := h.config.UpdateProfile(scenario, profileID, req.Name, req.Unified); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"success": true, "message": "profile updated"})
+	// Fetch updated profile to return in response
+	profiles := h.config.GetProfiles(scenario)
+	var updatedProfile *typ.ProfileMeta
+	for i := range profiles {
+		if profiles[i].ID == profileID {
+			updatedProfile = &profiles[i]
+			break
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "profile updated", "data": updatedProfile})
 }
 
 // DeleteProfile deletes a profile by ID

--- a/internal/server/module/scenario/routes.go
+++ b/internal/server/module/scenario/routes.go
@@ -71,6 +71,13 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithRequestModel(ProfileCreateRequest{}),
 	)
 
+	// PUT /scenario/:scenario/profiles/:id - Update a profile
+	router.PUT("/scenario/:scenario/profiles/:id", handler.UpdateProfile,
+		swagger.WithDescription("Update a profile name or mode"),
+		swagger.WithTags("scenarios"),
+		swagger.WithRequestModel(ProfileUpdateRequest{}),
+	)
+
 	// DELETE /scenario/:scenario/profiles/:id - Delete a profile
 	router.DELETE("/scenario/:scenario/profiles/:id", handler.DeleteProfile,
 		swagger.WithDescription("Delete a profile"),

--- a/internal/server/module/scenario/types.go
+++ b/internal/server/module/scenario/types.go
@@ -20,7 +20,14 @@ type ScenarioUpdateRequest struct {
 
 // ProfileCreateRequest represents the request to create or rename a profile
 type ProfileCreateRequest struct {
-	Name string `json:"name" binding:"required"`
+	Name    string `json:"name" binding:"required"`
+	Unified bool   `json:"unified"` // Optional, defaults to false (separate mode)
+}
+
+// ProfileUpdateRequest represents the request to update a profile
+type ProfileUpdateRequest struct {
+	Name    string `json:"name"`
+	Unified *bool  `json:"unified"` // Pointer to distinguish zero from unset; nil = no change
 }
 
 // ScenariosResponse represents the response for getting all scenarios

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -165,8 +165,9 @@ type RuleFlags struct {
 // Profiles allow multiple Rule + ScenarioFlags configurations per base scenario.
 // A profile is identified by a short service-generated ID (e.g. "p1", "p2").
 type ProfileMeta struct {
-	ID   string `json:"id" yaml:"id"`     // Profile ID (e.g. "p1")
-	Name string `json:"name" yaml:"name"` // Human-readable name (unique within base scenario)
+	ID      string `json:"id" yaml:"id"`           // Profile ID (e.g. "p1")
+	Name    string `json:"name" yaml:"name"`       // Human-readable name (unique within base scenario)
+	Unified bool   `json:"unified" yaml:"unified"` // true=unified mode (single model), false=separate mode (individual models, default)
 }
 
 // ScenarioConfig represents configuration for a specific scenario

--- a/openapi.json
+++ b/openapi.json
@@ -2362,6 +2362,57 @@
       }
     },
     "/api/v1/scenario/{scenario}/profiles/{id}": {
+      "put": {
+        "tags": [
+          "scenarios"
+        ],
+        "summary": "Update a profile name or mode",
+        "description": "Update a profile name or mode",
+        "operationId": "apiV1ScenarioScenarioProfilesIdPut",
+        "parameters": [
+          {
+            "name": "scenario",
+            "in": "path",
+            "description": "Path parameter 'scenario'",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "scenarios"
@@ -6286,10 +6337,32 @@
           "name": {
             "type": "string",
             "description": "Field name"
+          },
+          "unified": {
+            "type": "boolean",
+            "description": "Field unified"
           }
         },
         "required": [
-          "name"
+          "name",
+          "unified"
+        ]
+      },
+      "ProfileUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "unified": {
+            "type": "boolean",
+            "description": "Field unified"
+          }
+        },
+        "required": [
+          "name",
+          "unified"
         ]
       },
       "ProviderModelInfo": {
@@ -8814,40 +8887,16 @@
   },
   "tags": [
     {
-      "name": "history",
-      "description": "Operations related to history"
-    },
-    {
-      "name": "config",
-      "description": "Operations related to config"
-    },
-    {
-      "name": "auth",
-      "description": "Operations related to auth"
-    },
-    {
-      "name": "token",
-      "description": "Operations related to token"
-    },
-    {
-      "name": "imbot-settings",
-      "description": "Operations related to imbot-settings"
-    },
-    {
-      "name": "codex",
-      "description": "Operations related to codex"
-    },
-    {
-      "name": "mcp",
-      "description": "Operations related to mcp"
-    },
-    {
-      "name": "system-logs",
-      "description": "Operations related to system-logs"
+      "name": "actions",
+      "description": "Operations related to actions"
     },
     {
       "name": "server",
       "description": "Operations related to server"
+    },
+    {
+      "name": "scenarios",
+      "description": "Operations related to scenarios"
     },
     {
       "name": "models",
@@ -8862,44 +8911,68 @@
       "description": "Operations related to providers"
     },
     {
-      "name": "weixin",
-      "description": "Operations related to weixin"
+      "name": "oauth",
+      "description": "Operations related to oauth"
+    },
+    {
+      "name": "imbot-settings",
+      "description": "Operations related to imbot-settings"
     },
     {
       "name": "info",
       "description": "Operations related to info"
     },
     {
-      "name": "actions",
-      "description": "Operations related to actions"
+      "name": "history",
+      "description": "Operations related to history"
     },
     {
-      "name": "rules",
-      "description": "Operations related to rules"
-    },
-    {
-      "name": "scenarios",
-      "description": "Operations related to scenarios"
-    },
-    {
-      "name": "guardrails",
-      "description": "Operations related to guardrails"
+      "name": "token",
+      "description": "Operations related to token"
     },
     {
       "name": "skills",
       "description": "Operations related to skills"
     },
     {
-      "name": "oauth",
-      "description": "Operations related to oauth"
+      "name": "config",
+      "description": "Operations related to config"
+    },
+    {
+      "name": "codex",
+      "description": "Operations related to codex"
+    },
+    {
+      "name": "auth",
+      "description": "Operations related to auth"
+    },
+    {
+      "name": "logs",
+      "description": "Operations related to logs"
+    },
+    {
+      "name": "system-logs",
+      "description": "Operations related to system-logs"
+    },
+    {
+      "name": "guardrails",
+      "description": "Operations related to guardrails"
+    },
+    {
+      "name": "rules",
+      "description": "Operations related to rules"
     },
     {
       "name": "usage",
       "description": "Operations related to usage"
     },
     {
-      "name": "logs",
-      "description": "Operations related to logs"
+      "name": "weixin",
+      "description": "Operations related to weixin"
+    },
+    {
+      "name": "mcp",
+      "description": "Operations related to mcp"
     }
   ]
 }

--- a/swagger.json
+++ b/swagger.json
@@ -2409,6 +2409,53 @@
       }
     },
     "/api/v1/scenario/{scenario}/profiles/{id}": {
+      "put": {
+        "tags": [
+          "scenarios"
+        ],
+        "summary": "Update a profile name or mode",
+        "description": "Update a profile name or mode",
+        "operationId": "apiV1ScenarioScenarioProfilesIdPut",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "scenario",
+            "in": "path",
+            "description": "Path parameter 'scenario'",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "Request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProfileUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "type": "object"
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "scenarios"
@@ -6300,10 +6347,32 @@
         "name": {
           "type": "string",
           "description": "Field name"
+        },
+        "unified": {
+          "type": "boolean",
+          "description": "Field unified"
         }
       },
       "required": [
-        "name"
+        "name",
+        "unified"
+      ]
+    },
+    "ProfileUpdateRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Field name"
+        },
+        "unified": {
+          "type": "boolean",
+          "description": "Field unified"
+        }
+      },
+      "required": [
+        "name",
+        "unified"
       ]
     },
     "ProviderModelInfo": {
@@ -8826,48 +8895,12 @@
   },
   "tags": [
     {
-      "name": "system-logs",
-      "description": "Operations related to system-logs"
-    },
-    {
-      "name": "actions",
-      "description": "Operations related to actions"
-    },
-    {
-      "name": "providers",
-      "description": "Operations related to providers"
-    },
-    {
-      "name": "usage",
-      "description": "Operations related to usage"
-    },
-    {
-      "name": "weixin",
-      "description": "Operations related to weixin"
-    },
-    {
-      "name": "mcp",
-      "description": "Operations related to mcp"
-    },
-    {
       "name": "auth",
       "description": "Operations related to auth"
     },
     {
-      "name": "info",
-      "description": "Operations related to info"
-    },
-    {
-      "name": "server",
-      "description": "Operations related to server"
-    },
-    {
-      "name": "imbot-settings",
-      "description": "Operations related to imbot-settings"
-    },
-    {
-      "name": "logs",
-      "description": "Operations related to logs"
+      "name": "system-logs",
+      "description": "Operations related to system-logs"
     },
     {
       "name": "scenarios",
@@ -8878,12 +8911,52 @@
       "description": "Operations related to guardrails"
     },
     {
-      "name": "testing",
-      "description": "Operations related to testing"
-    },
-    {
       "name": "token",
       "description": "Operations related to token"
+    },
+    {
+      "name": "providers",
+      "description": "Operations related to providers"
+    },
+    {
+      "name": "imbot-settings",
+      "description": "Operations related to imbot-settings"
+    },
+    {
+      "name": "weixin",
+      "description": "Operations related to weixin"
+    },
+    {
+      "name": "logs",
+      "description": "Operations related to logs"
+    },
+    {
+      "name": "oauth",
+      "description": "Operations related to oauth"
+    },
+    {
+      "name": "mcp",
+      "description": "Operations related to mcp"
+    },
+    {
+      "name": "info",
+      "description": "Operations related to info"
+    },
+    {
+      "name": "actions",
+      "description": "Operations related to actions"
+    },
+    {
+      "name": "rules",
+      "description": "Operations related to rules"
+    },
+    {
+      "name": "history",
+      "description": "Operations related to history"
+    },
+    {
+      "name": "testing",
+      "description": "Operations related to testing"
     },
     {
       "name": "skills",
@@ -8898,20 +8971,16 @@
       "description": "Operations related to codex"
     },
     {
-      "name": "rules",
-      "description": "Operations related to rules"
-    },
-    {
-      "name": "history",
-      "description": "Operations related to history"
+      "name": "server",
+      "description": "Operations related to server"
     },
     {
       "name": "models",
       "description": "Operations related to models"
     },
     {
-      "name": "oauth",
-      "description": "Operations related to oauth"
+      "name": "usage",
+      "description": "Operations related to usage"
     }
   ]
 }


### PR DESCRIPTION
# Summary

Claude Code profiles previously only supported "separate" mode where each model required its own routing rule. This PR adds "unified" mode support, allowing all models to share a single routing rule (tingly/cc), significantly
simplifying configuration for most users.

# Major

- Users can now choose between unified (single wildcard rule) or separate (per-model rules) mode when creating Claude Code profiles
- Unified mode reduces configuration complexity: one rule "*" instead of individual rules for each model
- Switching between modes dynamically updates the routing rules without manual configuration
- Frontend UI displays current mode and allows switching with a single click
- New profiles default to unified mode for better out-of-box experience

# Minor

- Updated profile creation API to accept unified parameter
- Added profile update endpoint to support mode switching on existing profiles
- Profile metadata now includes unified boolean field
- CLI command extended to support profile mode updates

<img width="3008" height="984" alt="image" src="https://github.com/user-attachments/assets/6e71bf4c-eddb-4b47-a5da-fc5ac1fed53d" />