### PR TITLE
fix: prevent MIME-type issues by 404ing missing static assets

### DIFF
--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -978,6 +978,12 @@ func (s *Server) useWebStaticEndpoints(engine *gin.Engine) {
 	engine.NoRoute(func(c *gin.Context) {
 		// Don't serve index.html for API routes - let them return 404s
 		path := c.Request.URL.Path
+		// Don't serve index.html for static assets - missing assets should 404 (prevents MIME-type issues).
+		if path == "" || strings.HasPrefix(path, "/assets/") || path == "/assets" {
+			c.Status(http.StatusNotFound)
+			c.Abort()
+			return
+		}
 		// Check if this looks like an API route
 		if path == "" || strings.HasPrefix(path, "/api/v") || strings.HasPrefix(path, "/v") || strings.HasPrefix(path, "/openai") || strings.HasPrefix(path, "/anthropic") || strings.HasPrefix(path, "/tingly") {
 			// This looks like an API route, return 404


### PR DESCRIPTION
## Summary

When a static asset (e.g., `/assets/file.js`) is not found, the current behavior is to fall through and serve `index.html`. This causes MIME-type mismatches where JavaScript is served as HTML, leading to browser errors like "Uncaught SyntaxError: Unexpected token '<'".

## Changes

- Add early check for asset paths in `NoRoute` handler
- Return 404 immediately when static asset is not found
- Prevents incorrect MIME-type responses

## Test Plan

- [x] Build succeeds
- [x] Missing assets return 404 with correct MIME-type
- [x] Existing routes continue to work correctly