### PR TITLE
fix: prevent MIME-type issues by 404ing missing static assets

### DIFF
--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -978,6 +978,12 @@ func (s *Server) useWebStaticEndpoints(engine *gin.Engine) {
 	engine.NoRoute(func(c *gin.Context) {
 		// Don't serve index.html for API routes - let them return 404s
 		path := c.Request.URL.Path
+		// Don't serve index.html for static assets - missing assets should 404 (prevents MIME-type issues).
+		if path == "" || strings.HasPrefix(path, "/assets/") || path == "/assets" {
+			c.Status(http.StatusNotFound)
+			c.Abort()
+			return
+		}
 		// Check if this looks like an API route
 		if path == "" || strings.HasPrefix(path, "/api/v") || strings.HasPrefix(path, "/v") || strings.HasPrefix(path, "/openai") || strings.HasPrefix(path, "/anthropic") || strings.HasPrefix(path, "/tingly") {
 			// This looks like an API route, return 404


### PR DESCRIPTION
## Summary

When a static asset (e.g., `/assets/file.js`) is not found, Gin's StaticFS lets the request continue to NoRoute. The original NoRoute handler then serves index.html, causing MIME-type mismatches where JavaScript is served as HTML. This leads to browser errors like "Uncaught SyntaxError: Unexpected token '<'".

## Root Cause Analysis

Gin's StaticFS behavior (verified with test):
- **File exists**: StaticFS returns 200 + file content, NoRoute NOT called
- **File missing**: StaticFS forwards request to NoRoute

## Changes

Add early check in NoRoute for `/assets/` paths. Since StaticFS handles existing files before NoRoute is reached, this only affects missing files.

### Test Results

```bash
# Test 1: Existing file
GET /assets/test.js → StaticFS → 200 + file content

# Test 2: Missing file  
GET /assets/missing.js → StaticFS → NoRoute → 404
```

## Impact

- ✅ Fixes missing assets returning index.html with wrong MIME-type
- ✅ Existing assets continue to work correctly (handled by StaticFS)
- ✅ No breaking changes to API routes or other paths