### PR TITLE
fix: guard mcp runtime with mcp switch as well as server tool flags

### DIFF
--- a/internal/mcp/local/handler.go
+++ b/internal/mcp/local/handler.go
@@ -117,7 +117,7 @@ func (h *Handler) SetMCPMode(c *gin.Context) {
 	if req.Mode != typ.MCPModeServertool && req.Mode != typ.MCPModeClienttool {
 		c.JSON(http.StatusBadRequest, MCPModeResponse{
 			Success: false,
-			Error:   "Invalid mode. Must be 'intercept' or 'local'",
+			Error:   "Invalid mode. Must be 'servertool' or 'clienttool'",
 		})
 		return
 	}

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -52,8 +52,9 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	// Set provider UUID in context (Service.Provider uses UUID, not name)
 	c.Set("provider", provider.UUID)
 	c.Set("model", actualModel)
-
-	req.BetaMessageNewParams = *s.injectMCPToolsIntoAnthropicBetaRequest(c.Request.Context(), &req.BetaMessageNewParams)
+	if s.mcpEnabled() && s.mcpMode() == typ.MCPModeServertool {
+		req.BetaMessageNewParams = *s.injectMCPToolsIntoAnthropicBetaRequest(c.Request.Context(), &req.BetaMessageNewParams)
+	}
 
 	session := s.guardrailsSessionFromContext(c, actualModel, provider)
 	if s.guardrailsEnabledForSession(session) {

--- a/internal/server/mcp_anthropic_loop.go
+++ b/internal/server/mcp_anthropic_loop.go
@@ -177,8 +177,9 @@ func (s *Server) handleAnthropicBetaMCPToolCalls(
 
 		nextReq := *currentReq
 		nextReq.Messages = append(append([]anthropic.BetaMessageParam{}, currentReq.Messages...), currentResp.ToParam(), anthropic.NewBetaUserMessage(toolResults...))
-		nextReq = *s.injectMCPToolsIntoAnthropicBetaRequest(ctx, &nextReq)
-
+		if s.mcpEnabled() && s.mcpMode() == typ.MCPModeServertool {
+			nextReq = *s.injectMCPToolsIntoAnthropicBetaRequest(ctx, &nextReq)
+		}
 		wrapper := s.clientPool.GetAnthropicClient(ctx, provider, nextReq.Model)
 		fc := NewForwardContext(nil, provider)
 		nextResp, cancel, err := ForwardAnthropicV1Beta(fc, wrapper, &nextReq)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -261,6 +261,21 @@ func (s *Server) mcpEnabled() bool {
 		s.config.GetScenarioFlag(typ.ScenarioClaudeCode, "mcp")
 }
 
+// mcpMode returns the current MCP runtime mode
+func (s *Server) mcpMode() typ.MCPMode {
+	if s.config == nil {
+		return ""
+	}
+	var mcpCfg typ.MCPRuntimeConfig
+	if s.config.GetToolConfig(db.ToolTypeMCPRuntime, &mcpCfg) {
+		if mcpCfg.Mode == "" {
+			return typ.MCPModeClienttool // default mode
+		}
+		return mcpCfg.Mode
+	}
+	return typ.MCPModeClienttool // default mode
+}
+
 func (s *Server) syncGuardrailsFromConfig() {
 	if s.config == nil {
 		return
@@ -609,9 +624,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
 	// Set template manager in config for model fetching fallback
 	server.config.SetTemplateManager(templateManager)
 
-	server.mcpRuntime = mcpruntime.NewRuntime(func() *typ.MCPRuntimeConfig {
-		return cfg.GetMCPRuntimeConfig()
-	})
+	server.mcpRuntime = mcpruntime.NewRuntime(cfg.GetMCPRuntimeConfig)
 	if err := mcpruntime.EnsureBuiltinScripts(cfg.ConfigDir); err != nil {
 		logrus.WithError(err).Warn("mcp: failed to ensure builtin scripts in config dir")
 	}


### PR DESCRIPTION
## Summary
- Fixed MCP tool injection to only occur when both MCP is enabled AND mode is `servertool`
- Fixed error message in SetMCPMode handler (changed "intercept/local" to "servertool/clienttool")
- Added `mcpMode()` method to check current MCP runtime mode
- Simplified `mcpruntime.NewRuntime` call

## Changes
- `internal/server/mcp_anthropic_loop.go`: Added mode check before tool injection in loop
- `internal/server/anthropic_beta.go`: Added mode check before tool injection in main handler
- `internal/server/server.go`: Added `mcpMode()` method
- `internal/mcp/local/handler.go`: Fixed error message typo

## Test plan
- Verify MCP tools are only injected when MCP is enabled AND mode is servertool
- Verify MCP tools are not injected in clienttool mode
- Verify error message shows correct mode names