### PR TITLE
perf(client): reduce transport TTL from 120min to 15min

### DIFF
--- a/internal/client/transport_pool.go
+++ b/internal/client/transport_pool.go
@@ -43,8 +43,8 @@ const (
 
 // Constants for transport TTL and cleanup interval
 const (
-	DefaultTransportTTL             = 120 * time.Minute // Default time-to-live for cached transports
-	DefaultTransportCleanupInterval = 60 * time.Minute  // Default interval for cleanup task
+	DefaultTransportTTL             = 15 * time.Minute // Default time-to-live for cached transports (reduced from 120min for better session lifecycle management)
+	DefaultTransportCleanupInterval = 5 * time.Minute  // Default interval for cleanup task
 )
 
 // pooledTransport wraps a transport with its last access timestamp for TTL tracking


### PR DESCRIPTION
The 120-minute TTL for cached transports was too long, causing:
- Stale connections using expired OAuth tokens
- Unnecessary resource retention for idle connections
- Potential session contamination

Reduced to 15 minutes with 5-minute cleanup interval:
- Still allows connection reuse during active sessions
- Better aligned with typical OAuth token lifetimes
- Reduces resource waste from long-lived idle transports
