### PR TITLE
feat(mcp): add advisor virtual tool support

### DIFF
--- a/frontend/src/pages/mcp/types.ts
+++ b/frontend/src/pages/mcp/types.ts
@@ -19,6 +19,13 @@ export interface MCPSourceConfig {
     tools_auto_exec?: string[];
     allowed_extra_headers?: string[];
     auto_registered?: boolean;
+    advisor?: {
+        base_url?: string;
+        model?: string;
+        api_key?: string;
+        max_uses_per_request?: number;
+        max_tokens?: number;
+    };
 }
 
 export interface MCPRuntimeConfig {
@@ -33,7 +40,9 @@ export interface MCPConfigResponse {
     error?: string;
 }
 
-export const BUILTIN_IDS = ['webtools'] as const;
+export const BUILTIN_WEBTOOLS_ID = 'webtools' as const;
+export const BUILTIN_ADVISOR_ID = 'advisor' as const;
+export const BUILTIN_IDS = [BUILTIN_WEBTOOLS_ID, BUILTIN_ADVISOR_ID] as const;
 export type BuiltinId = typeof BUILTIN_IDS[number];
 
 export interface MCPKVPair {
@@ -101,10 +110,20 @@ export const sourceToFormValue = (source?: MCPSourceConfig): MCPSourceFormValue 
         args = [];
     }
 
+    const normalizedTransport = source.transport === 'http' || source.transport === 'sse' || source.transport === 'stdio'
+        ? source.transport
+        : 'stdio';
+
+    // advisor is an in-process backend transport; keep frontend UX on stdio editor.
+    if (source.transport === 'advisor' && !command) {
+        command = 'builtin';
+        args = [];
+    }
+
     return {
         id: source.id || '',
         enabled: source.enabled ?? true,
-        transport: (source.transport as 'http' | 'stdio' | 'sse') || 'stdio',
+        transport: normalizedTransport,
         endpoint: source.endpoint || '',
         command,
         args,

--- a/internal/mcp/runtime/advisor_context.go
+++ b/internal/mcp/runtime/advisor_context.go
@@ -1,0 +1,22 @@
+package runtime
+
+import "context"
+
+type advisorContextKey struct{}
+
+// AdvisorContext holds conversation state for the advisor tool.
+type AdvisorContext struct {
+	Messages      []map[string]any
+	UsesRemaining int
+}
+
+// WithAdvisorContext attaches advisor context to the context.
+func WithAdvisorContext(ctx context.Context, ac *AdvisorContext) context.Context {
+	return context.WithValue(ctx, advisorContextKey{}, ac)
+}
+
+// GetAdvisorContext retrieves advisor context from the context.
+func GetAdvisorContext(ctx context.Context) (*AdvisorContext, bool) {
+	ac, ok := ctx.Value(advisorContextKey{}).(*AdvisorContext)
+	return ac, ok
+}

--- a/internal/mcp/runtime/advisor_context_test.go
+++ b/internal/mcp/runtime/advisor_context_test.go
@@ -1,0 +1,25 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAdvisorContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ac := &AdvisorContext{
+		Messages:      []map[string]any{{"role": "user", "content": "hello"}},
+		UsesRemaining: 2,
+	}
+	ctx = WithAdvisorContext(ctx, ac)
+	got, ok := GetAdvisorContext(ctx)
+	if !ok {
+		t.Fatal("expected advisor context to be present")
+	}
+	if got.UsesRemaining != 2 {
+		t.Fatalf("expected UsesRemaining=2, got %d", got.UsesRemaining)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(got.Messages))
+	}
+}

--- a/internal/mcp/runtime/advisor_virtual.go
+++ b/internal/mcp/runtime/advisor_virtual.go
@@ -1,0 +1,110 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func NewAdvisorVirtualTool(cfg typ.AdvisorConfig, cp *client.ClientPool) VirtualTool {
+	if cfg.MaxUsesPerRequest <= 0 {
+		cfg.MaxUsesPerRequest = 3
+	}
+	if cfg.MaxTokens <= 0 {
+		cfg.MaxTokens = 4096
+	}
+
+	schema := mcp.ToolInputSchema{Type: "object"}
+	props := map[string]any{
+		"reason": map[string]any{
+			"type":        "string",
+			"description": "Why the executor is consulting the advisor.",
+		},
+	}
+	schema.Properties = props
+	schema.Required = []string{"reason"}
+
+	return VirtualTool{
+		Name:         "advisor",
+		Description:  fmt.Sprintf("Consult a more powerful advisor model for strategic guidance. Use when facing architectural decisions, complex debugging, unclear trade-offs, or when stuck. You have %d consultation(s) remaining this request.", cfg.MaxUsesPerRequest),
+		InputSchema:  schema,
+		Handler:      newAdvisorHandler(cfg, cp),
+		IsClientTool: false, // Server tool: not exposed to clients
+	}
+}
+
+func newAdvisorHandler(cfg typ.AdvisorConfig, cp *client.ClientPool) VirtualToolHandler {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Extract arguments
+		args, ok := req.Params.Arguments.(map[string]any)
+		if !ok {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent("invalid arguments")},
+				IsError: true,
+			}, nil
+		}
+
+		reason, _ := args["reason"].(string)
+		if reason == "" {
+			reason = "The executor has requested strategic guidance."
+		}
+
+		// Check depth to prevent recursion.
+		// Depth is incremented by response hook before tool execution, so the first
+		// legitimate advisor call runs at depth=1 and must be allowed.
+		depth := GetAdvisorDepth(ctx)
+		if depth > 1 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent("Advisor recursion limit reached.")},
+				IsError: true,
+			}, nil
+		}
+
+		// Check per-request quota from context
+		actx, ok := GetAdvisorContext(ctx)
+		if !ok || actx.UsesRemaining <= 0 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent("Advisor consultations exhausted for this request.")},
+				IsError: true,
+			}, nil
+		}
+
+		// Execute advisor call
+		logrus.WithFields(logrus.Fields{
+			"reason":         reason,
+			"uses_remaining": actx.UsesRemaining,
+			"depth":          depth,
+			"format":         detectAdvisorFormat(cfg),
+		}).Debug("[MCP-DEBUG] ADVISOR: calling advisor model")
+
+		advisorCtx, cancel := context.WithTimeout(ctx, advisorCallTimeout)
+		defer cancel()
+
+		var result string
+		var err error
+		if detectAdvisorFormat(cfg) == FormatOpenAI {
+			result, err = callOpenAI(advisorCtx, cfg, cp, reason, actx)
+		} else {
+			result, err = callAnthropic(advisorCtx, cfg, cp, reason, actx)
+		}
+
+		if err != nil {
+			logrus.WithError(err).Error("[MCP-DEBUG] ADVISOR: consultation failed")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent(fmt.Sprintf("Advisor error: %v", err))},
+				IsError: true,
+			}, nil
+		}
+
+		// Decrement uses
+		actx.UsesRemaining--
+		logrus.WithField("uses_remaining", actx.UsesRemaining).Debug("[MCP-DEBUG] ADVISOR: consultation completed")
+
+		return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(result)}}, nil
+	}
+}

--- a/internal/mcp/runtime/builtin_registry.go
+++ b/internal/mcp/runtime/builtin_registry.go
@@ -17,14 +17,19 @@ func RegisterBuiltinTools(getConfig func() *typ.MCPRuntimeConfig, setConfig func
 		cfg = &typ.MCPRuntimeConfig{}
 	}
 
-	// Check if webtools already exists
+	// Check if builtins already exist
 	var existingWebtools *typ.MCPSourceConfig
-	var existingIndex = -1
+	var existingAdvisor *typ.MCPSourceConfig
+	webtoolsIndex := -1
+	advisorIndex := -1
 	for i, source := range cfg.Sources {
 		if source.ID == mcptools.BuiltinWebtoolsSourceID {
 			existingWebtools = &cfg.Sources[i]
-			existingIndex = i
-			break
+			webtoolsIndex = i
+		}
+		if source.ID == mcptools.BuiltinAdvisorSourceID {
+			existingAdvisor = &cfg.Sources[i]
+			advisorIndex = i
 		}
 	}
 
@@ -79,14 +84,72 @@ func RegisterBuiltinTools(getConfig func() *typ.MCPRuntimeConfig, setConfig func
 		Env:          preservedEnv, // Preserve user's environment variables
 	}
 
-	// Update or append the configuration
-	if existingIndex >= 0 {
-		cfg.Sources[existingIndex] = builtinWebtools
+	// Update or append webtools configuration
+	if webtoolsIndex >= 0 {
+		cfg.Sources[webtoolsIndex] = builtinWebtools
 		logrus.Info("mcp: updated builtin webtools configuration")
 	} else {
 		cfg.Sources = append(cfg.Sources, builtinWebtools)
 		logrus.Info("mcp: registered builtin webtools configuration")
 	}
+
+	// Create advisor configuration and register as virtual tool.
+	advisorEnabled := typ.BoolPtr(false) // default: disabled
+	advisorIsClientTool := false         // server tool
+	advisorTools := mcptools.DefaultBuiltinAdvisorToolNames()
+	advisorEnv := map[string]string{
+		"ADVISOR_BASE_URL": "${ADVISOR_BASE_URL}",
+		"ADVISOR_MODEL":    "${ADVISOR_MODEL}",
+		"ADVISOR_API_KEY":  "${ADVISOR_API_KEY}",
+	}
+	advisorCfg := &typ.AdvisorConfig{
+		BaseURL:           "${ADVISOR_BASE_URL}",
+		Model:             "${ADVISOR_MODEL}",
+		APIKey:            "${ADVISOR_API_KEY}",
+		MaxUsesPerRequest: 3,
+		MaxTokens:         4096,
+	}
+	if existingAdvisor != nil {
+		if existingAdvisor.Enabled != nil {
+			advisorEnabled = existingAdvisor.Enabled
+		}
+		if existingAdvisor.IsClientTool != nil {
+			advisorIsClientTool = *existingAdvisor.IsClientTool
+		}
+		if len(existingAdvisor.Tools) > 0 {
+			advisorTools = existingAdvisor.Tools
+		}
+		// Preserve user's custom environment variables
+		for k, v := range existingAdvisor.Env {
+			advisorEnv[k] = v
+		}
+		if existingAdvisor.Advisor != nil {
+			copied := *existingAdvisor.Advisor
+			advisorCfg = &copied
+		}
+	}
+	builtinAdvisor := typ.MCPSourceConfig{
+		ID:           mcptools.BuiltinAdvisorSourceID,
+		Name:         mcptools.BuiltinAdvisorSourceName,
+		Enabled:      advisorEnabled,
+		IsClientTool: &advisorIsClientTool,
+		Tools:        advisorTools,
+		Env:          advisorEnv,
+		Advisor:      advisorCfg,
+	}
+
+	// Update or append advisor configuration
+	if advisorIndex >= 0 {
+		cfg.Sources[advisorIndex] = builtinAdvisor
+		logrus.Info("mcp: updated builtin advisor configuration")
+	} else {
+		cfg.Sources = append(cfg.Sources, builtinAdvisor)
+		logrus.Info("mcp: registered builtin advisor configuration")
+	}
+
+	// Note: We no longer create a transport-based MCPSourceConfig for adviser.
+	// Instead, the virtual tool is registered directly into the runtime's VirtualRegistry.
+	// This is done in Runtime initialization, not here.
 
 	if err := setConfig("mcp_runtime", cfg); err != nil {
 		logrus.WithError(err).Error("mcp: failed to save builtin webtools configuration")

--- a/internal/mcp/runtime/virtual_registry.go
+++ b/internal/mcp/runtime/virtual_registry.go
@@ -1,0 +1,71 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// VirtualToolHandler executes an in-process MCP tool.
+type VirtualToolHandler func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error)
+
+// VirtualTool is an in-process MCP tool definition.
+type VirtualTool struct {
+	Name        string
+	Description string
+	InputSchema mcp.ToolInputSchema
+	Handler     VirtualToolHandler
+	// IsClientTool indicates whether this tool should be exposed to client requests.
+	// If false, the tool is only available for internal server-side logic.
+	IsClientTool bool
+}
+
+// VirtualToolRegistry holds registered in-process tools.
+type VirtualToolRegistry struct {
+	mu    sync.RWMutex
+	tools map[string]VirtualTool
+}
+
+func NewVirtualToolRegistry() *VirtualToolRegistry {
+	return &VirtualToolRegistry{tools: make(map[string]VirtualTool)}
+}
+
+func (r *VirtualToolRegistry) Register(tool VirtualTool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tools[tool.Name] = tool
+}
+
+func (r *VirtualToolRegistry) Get(name string) (VirtualTool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+func (r *VirtualToolRegistry) List() []mcp.Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]mcp.Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, mcp.Tool{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+		})
+	}
+	return out
+}
+
+// ListVirtualTools returns the full VirtualTool list with IsClientTool information.
+// This is used by Runtime to filter tools based on client exposure.
+func (r *VirtualToolRegistry) ListVirtualTools() []VirtualTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]VirtualTool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, t)
+	}
+	return out
+}

--- a/internal/mcp/runtime/virtual_registry_test.go
+++ b/internal/mcp/runtime/virtual_registry_test.go
@@ -1,0 +1,80 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestVirtualRegistry_RegisterAndGet(t *testing.T) {
+	reg := NewVirtualToolRegistry()
+	vt := VirtualTool{
+		Name:        "advisor",
+		Description: "strategic guidance",
+		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent("ok")}}, nil
+		},
+		IsClientTool: false, // Server tool
+	}
+	reg.Register(vt)
+
+	got, ok := reg.Get("advisor")
+	if !ok || got.Name != "advisor" {
+		t.Fatal("expected advisor virtual tool")
+	}
+
+	if got.IsClientTool {
+		t.Fatal("expected advisor to be a server tool (IsClientTool=false)")
+	}
+
+	mcpTools := reg.List()
+	if len(mcpTools) != 1 || mcpTools[0].Name != "advisor" {
+		t.Fatalf("expected 1 tool, got %d", len(mcpTools))
+	}
+}
+
+func TestVirtualRegistry_ListVirtualTools(t *testing.T) {
+	reg := NewVirtualToolRegistry()
+
+	// Register server tool (not exposed to clients)
+	serverTool := VirtualTool{
+		Name:        "adviser",
+		Description: "Server-side advisor",
+		Handler:     nil,
+		IsClientTool: false,
+	}
+	reg.Register(serverTool)
+
+	// Register client tool (exposed to clients)
+	clientTool := VirtualTool{
+		Name:        "websearch",
+		Description: "Client-side web search",
+		Handler:     nil,
+		IsClientTool: true,
+	}
+	reg.Register(clientTool)
+
+	virtualTools := reg.ListVirtualTools()
+	if len(virtualTools) != 2 {
+		t.Fatalf("expected 2 virtual tools, got %d", len(virtualTools))
+	}
+
+	// Count client and server tools
+	clientCount := 0
+	serverCount := 0
+	for _, vt := range virtualTools {
+		if vt.IsClientTool {
+			clientCount++
+		} else {
+			serverCount++
+		}
+	}
+
+	if clientCount != 1 {
+		t.Errorf("expected 1 client tool, got %d", clientCount)
+	}
+	if serverCount != 1 {
+		t.Errorf("expected 1 server tool, got %d", serverCount)
+	}
+}

--- a/internal/server/advisor_integration_test.go
+++ b/internal/server/advisor_integration_test.go
@@ -1,0 +1,280 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/mcp/runtime"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestAdvisorToolLoop(t *testing.T) {
+	var receivedRequests []map[string]any
+	var handlerErrors []error
+	var requestPaths []string
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPaths = append(requestPaths, r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErrors = append(handlerErrors, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			handlerErrors = append(handlerErrors, err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		receivedRequests = append(receivedRequests, req)
+
+		resp := map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 1234567890,
+			"model":   "gpt-4",
+			"choices": []map[string]any{
+				{
+					"index": 0,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": `{"assessment":"situation clear","recommendation":"proceed with caution"}`,
+					},
+					"finish_reason": "stop",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	// Set up SessionStore for completeness (even though adviser doesn't use it yet)
+	sessionStore := runtime.NewSessionStore(10 * time.Minute)
+	defer sessionStore.Sweep()
+
+	sessionID := "test-session-123"
+	sessionStore.Put(&runtime.SessionContext{
+		SessionID: sessionID,
+	})
+
+	cp := client.NewClientPool()
+	source, err := runtime.NewAdvisorToolSource(typ.MCPSourceConfig{
+		ID: "test-advisor",
+		Advisor: &typ.AdvisorConfig{
+			BaseURL:           mockServer.URL,
+			Model:             "gpt-4",
+			APIKey:            "test-key",
+			MaxUsesPerRequest: 3,
+		},
+	}, cp)
+	require.NoError(t, err)
+
+	actx := &runtime.AdvisorContext{
+		Messages: []map[string]any{
+			{"role": "system", "content": "You are a helpful assistant."},
+			{"role": "user", "content": "Hello"},
+			{"role": "assistant", "content": "Hi there!"},
+		},
+		UsesRemaining: 3,
+	}
+	ctx := runtime.WithAdvisorContext(context.Background(), actx)
+
+	// First call should succeed and decrement UsesRemaining.
+	result, err := source.CallTool(ctx, "advisor", `{"reason":"Need strategic guidance"}`)
+	require.NoError(t, err)
+	require.Contains(t, result, "situation clear")
+	require.Contains(t, result, "proceed with caution")
+	require.Equal(t, 2, actx.UsesRemaining)
+
+	// Second call.
+	result, err = source.CallTool(ctx, "advisor", `{"reason":"Still unsure"}`)
+	require.NoError(t, err)
+	require.Contains(t, result, "situation clear")
+	require.Equal(t, 1, actx.UsesRemaining)
+
+	// Third call.
+	result, err = source.CallTool(ctx, "advisor", `{"reason":"One more time"}`)
+	require.NoError(t, err)
+	require.Contains(t, result, "situation clear")
+	require.Equal(t, 0, actx.UsesRemaining)
+
+	// Fourth call should return exhaustion message.
+	result, err = source.CallTool(ctx, "advisor", `{"reason":"No uses left"}`)
+	require.NoError(t, err)
+	require.Equal(t, "Advisor consultations exhausted for this request.", result)
+	require.Equal(t, 0, actx.UsesRemaining)
+
+	// Verify handler had no errors and received correct paths.
+	require.Empty(t, handlerErrors, "mock server handler encountered errors")
+	require.Len(t, requestPaths, 3, "expected 3 requests to mock server")
+	for _, path := range requestPaths {
+		require.Equal(t, "/chat/completions", path)
+	}
+
+	// Verify the mock server received the expected messages on each call.
+	require.Len(t, receivedRequests, 3)
+
+	for i, req := range receivedRequests {
+		messages, ok := req["messages"].([]any)
+		require.True(t, ok, "request %d: expected messages array", i)
+
+		// Advisor system prompt + context system message + user + assistant + reason = 5 messages.
+		require.Len(t, messages, 5, "request %d: expected 5 messages", i)
+
+		advisorSysMsg, ok := messages[0].(map[string]any)
+		require.True(t, ok, "request %d: first message should be system", i)
+		require.Equal(t, "system", advisorSysMsg["role"], "request %d", i)
+		require.NotEmpty(t, advisorSysMsg["content"], "request %d: advisor system prompt should not be empty", i)
+
+		ctxSysMsg, ok := messages[1].(map[string]any)
+		require.True(t, ok, "request %d: second message should be system", i)
+		require.Equal(t, "system", ctxSysMsg["role"], "request %d", i)
+		require.Equal(t, "You are a helpful assistant.", ctxSysMsg["content"], "request %d", i)
+
+		userHello, ok := messages[2].(map[string]any)
+		require.True(t, ok, "request %d: third message should be user", i)
+		require.Equal(t, "user", userHello["role"], "request %d", i)
+		require.Equal(t, "Hello", userHello["content"], "request %d", i)
+
+		asstMsg, ok := messages[3].(map[string]any)
+		require.True(t, ok, "request %d: fourth message should be assistant", i)
+		require.Equal(t, "assistant", asstMsg["role"], "request %d", i)
+		require.Equal(t, "Hi there!", asstMsg["content"], "request %d", i)
+
+		reasonMsg, ok := messages[4].(map[string]any)
+		require.True(t, ok, "request %d: fifth message should be user", i)
+		require.Equal(t, "user", reasonMsg["role"], "request %d", i)
+	}
+
+	require.Equal(t, "Need strategic guidance", receivedRequests[0]["messages"].([]any)[4].(map[string]any)["content"])
+	require.Equal(t, "Still unsure", receivedRequests[1]["messages"].([]any)[4].(map[string]any)["content"])
+	require.Equal(t, "One more time", receivedRequests[2]["messages"].([]any)[4].(map[string]any)["content"])
+}
+
+func TestAdvisorToolLoop_Anthropic(t *testing.T) {
+	var receivedRequests []map[string]any
+	var handlerErrors []error
+	var requestPaths []string
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPaths = append(requestPaths, r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErrors = append(handlerErrors, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			handlerErrors = append(handlerErrors, err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		receivedRequests = append(receivedRequests, req)
+
+		resp := map[string]any{
+			"id":      "msg_01Test",
+			"type":    "message",
+			"role":    "assistant",
+			"model":   "claude-opus-4-6",
+			"content": []map[string]any{
+				{"type": "text", "text": `{"assessment":"anthropic clear","recommendation":"proceed carefully"}`},
+			},
+			"stop_reason": "end_turn",
+			"usage": map[string]any{
+				"input_tokens":  10,
+				"output_tokens": 5,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	// Set up SessionStore for completeness (even though adviser doesn't use it yet)
+	sessionStore := runtime.NewSessionStore(10 * time.Minute)
+	defer sessionStore.Sweep()
+
+	sessionID := "test-session-anthropic-456"
+	sessionStore.Put(&runtime.SessionContext{
+		SessionID: sessionID,
+	})
+
+	cp := client.NewClientPool()
+	source, err := runtime.NewAdvisorToolSource(typ.MCPSourceConfig{
+		ID: "test-advisor-anthropic",
+		Advisor: &typ.AdvisorConfig{
+			BaseURL:           mockServer.URL + "/v1",
+			Model:             "claude-opus-4-6",
+			APIKey:            "test-key",
+			MaxUsesPerRequest: 2,
+			MaxTokens:         2048,
+		},
+	}, cp)
+	require.NoError(t, err)
+
+	actx := &runtime.AdvisorContext{
+		Messages: []map[string]any{
+			{"role": "system", "content": "Executor system prompt."},
+			{"role": "user", "content": "Help me"},
+			{"role": "assistant", "content": "Sure!"},
+		},
+		UsesRemaining: 2,
+	}
+	ctx := runtime.WithAdvisorContext(context.Background(), actx)
+
+	result, err := source.CallTool(ctx, "advisor", `{"reason":"Need Anthropic guidance"}`)
+	require.NoError(t, err)
+	require.Contains(t, result, "anthropic clear")
+	require.Equal(t, 1, actx.UsesRemaining)
+
+	result, err = source.CallTool(ctx, "advisor", `{"reason":"Again"}`)
+	require.NoError(t, err)
+	require.Contains(t, result, "anthropic clear")
+	require.Equal(t, 0, actx.UsesRemaining)
+
+	result, err = source.CallTool(ctx, "advisor", `{"reason":"Exhausted"}`)
+	require.NoError(t, err)
+	require.Equal(t, "Advisor consultations exhausted for this request.", result)
+
+	require.Empty(t, handlerErrors)
+	require.Len(t, requestPaths, 2)
+	for _, path := range requestPaths {
+		require.Equal(t, "/v1/messages", path)
+	}
+
+	require.Len(t, receivedRequests, 2)
+	for i, req := range receivedRequests {
+		require.Equal(t, "claude-opus-4-6", req["model"])
+		require.Equal(t, float64(2048), req["max_tokens"])
+
+		systemBlocks, ok := req["system"].([]any)
+		require.True(t, ok, "request %d: expected system array", i)
+		require.Len(t, systemBlocks, 1, "request %d: expected 1 system block", i)
+		sysBlock, ok := systemBlocks[0].(map[string]any)
+		require.True(t, ok, "request %d: expected system block map", i)
+		systemText, ok := sysBlock["text"].(string)
+		require.True(t, ok, "request %d: expected system text", i)
+		require.Contains(t, systemText, "Executor system prompt.")
+		require.Contains(t, systemText, "You are an advisor to a coding agent.")
+
+		messages, ok := req["messages"].([]any)
+		require.True(t, ok, "request %d: expected messages array", i)
+		require.Len(t, messages, 3, "request %d: expected 3 messages", i)
+	}
+}

--- a/internal/server/mcp_anthropic_loop.go
+++ b/internal/server/mcp_anthropic_loop.go
@@ -68,16 +68,25 @@ func (s *Server) handleAnthropicV1MCPToolCalls(
 	for round := 0; round < maxRounds; round++ {
 		toolUses, ok := hasOnlyMCPToolUsesV1(currentResp.Content)
 		if !ok {
+			logrus.Debugf("[MCP-DEBUG] V1 round %d: no MCP tool uses found, exiting loop", round)
 			return currentResp, currentReq, nil
 		}
 
+		// Log all tool uses for debugging
+		toolNames := make([]string, 0, len(toolUses))
+		for _, tu := range toolUses {
+			toolNames = append(toolNames, tu.Name)
+		}
+		logrus.Debugf("[MCP-DEBUG] V1 round %d: executing %d MCP tools: %v", round, len(toolUses), toolNames)
+
 		toolResults := make([]anthropic.ContentBlockParamUnion, 0, len(toolUses))
+		hookMessages := extractAnthropicV1Messages(append(append([]anthropic.MessageParam{}, currentReq.Messages...), currentResp.ToParam()))
 		for _, tu := range toolUses {
 			arguments := string(tu.Input)
 			if arguments == "" {
 				arguments = "{}"
 			}
-			result, err := s.callMCPToolWithGuard(ctx, tu.Name, arguments)
+			result, err := s.callMCPToolWithHooks(ctx, tu.Name, arguments, hookMessages)
 			if err != nil {
 				logrus.WithError(err).Warnf("mcp: tool call failed name=%s arguments=%s", tu.Name, arguments)
 			}
@@ -156,16 +165,25 @@ func (s *Server) handleAnthropicBetaMCPToolCalls(
 	for round := 0; round < maxRounds; round++ {
 		toolUses, ok := hasOnlyMCPToolUsesBeta(currentResp.Content)
 		if !ok {
+			logrus.Debugf("[MCP-DEBUG] Beta round %d: no MCP tool uses found, exiting loop", round)
 			return currentResp, currentReq, nil
 		}
 
+		// Log all tool uses for debugging
+		toolNames := make([]string, 0, len(toolUses))
+		for _, tu := range toolUses {
+			toolNames = append(toolNames, tu.Name)
+		}
+		logrus.Debugf("[MCP-DEBUG] Beta round %d: executing %d MCP tools: %v", round, len(toolUses), toolNames)
+
 		toolResults := make([]anthropic.BetaContentBlockParamUnion, 0, len(toolUses))
+		hookMessages := extractAnthropicBetaMessages(append(append([]anthropic.BetaMessageParam{}, currentReq.Messages...), currentResp.ToParam()))
 		for _, tu := range toolUses {
 			arguments := "{}"
 			if b, err := json.Marshal(tu.Input); err == nil && len(b) > 0 {
 				arguments = string(b)
 			}
-			result, err := s.callMCPToolWithGuard(ctx, tu.Name, arguments)
+			result, err := s.callMCPToolWithHooks(ctx, tu.Name, arguments, hookMessages)
 			if err != nil {
 				logrus.WithError(err).Warnf("mcp: beta tool call failed name=%s arguments=%s", tu.Name, arguments)
 			}
@@ -174,7 +192,6 @@ func (s *Server) handleAnthropicBetaMCPToolCalls(
 
 		nextReq := *currentReq
 		nextReq.Messages = append(append([]anthropic.BetaMessageParam{}, currentReq.Messages...), currentResp.ToParam(), anthropic.NewBetaUserMessage(toolResults...))
-
 		wrapper := s.clientPool.GetAnthropicClient(ctx, provider, nextReq.Model)
 		fc := NewForwardContext(nil, provider)
 		nextResp, cancel, err := ForwardAnthropicV1Beta(fc, wrapper, &nextReq)

--- a/internal/server/mcp_tool_error.go
+++ b/internal/server/mcp_tool_error.go
@@ -4,7 +4,32 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	mcpruntime "github.com/tingly-dev/tingly-box/internal/mcp/runtime"
+	mcptools "github.com/tingly-dev/tingly-box/internal/mcp/tools"
 )
+
+// mcpResponseToolCallHook prepares runtime context for specific MCP servertool calls.
+// Hooks run after worker response arrives and before local tool execution.
+type mcpResponseToolCallHook interface {
+	Match(toolName string) bool
+	PrepareContext(s *Server, ctx context.Context, messages []map[string]any) context.Context
+}
+
+type advisorResponseHook struct{}
+
+func (h advisorResponseHook) Match(toolName string) bool {
+	sourceID, toolNameOnly, ok := mcpruntime.ParseNormalizedToolName(toolName)
+	if !ok {
+		return false
+	}
+	isAdvisorSource := sourceID == mcptools.BuiltinAdvisorSourceID || sourceID == "builtin"
+	return isAdvisorSource && toolNameOnly == mcptools.BuiltinAdvisorToolName
+}
+
+func (h advisorResponseHook) PrepareContext(s *Server, ctx context.Context, messages []map[string]any) context.Context {
+	return s.withAdvisorContext(ctx, messages)
+}
 
 func (s *Server) isEnabledMCPToolName(ctx context.Context, toolName string) bool {
 	if s == nil || s.mcpRuntime == nil {
@@ -28,15 +53,72 @@ func normalizeMCPToolCallError(err error) string {
 	return string(payload)
 }
 
+func remapLegacyAdvisorToolName(toolName string) string {
+	sourceID, toolNameOnly, ok := mcpruntime.ParseNormalizedToolName(toolName)
+	if !ok {
+		return toolName
+	}
+	if sourceID == mcptools.BuiltinAdvisorSourceID && toolNameOnly == mcptools.BuiltinAdvisorToolName {
+		return mcpruntime.NormalizeToolName("builtin", mcptools.BuiltinAdvisorToolName)
+	}
+	return toolName
+}
+
 func (s *Server) callMCPToolWithGuard(ctx context.Context, toolName, arguments string) (string, error) {
-	if !s.isEnabledMCPToolName(ctx, toolName) {
+	resolvedToolName := remapLegacyAdvisorToolName(toolName)
+	if !s.isEnabledMCPToolName(ctx, resolvedToolName) {
 		return disabledMCPToolErrorPayload(toolName), fmt.Errorf("calling disabled tools: %s", toolName)
 	}
 
-	result, err := s.mcpRuntime.CallTool(ctx, toolName, arguments)
+	result, err := s.mcpRuntime.CallTool(ctx, resolvedToolName, arguments)
 	if err != nil {
 		return normalizeMCPToolCallError(err), err
 	}
 
 	return result, nil
+}
+
+func (s *Server) mcpResponseToolCallHooks() []mcpResponseToolCallHook {
+	return []mcpResponseToolCallHook{
+		advisorResponseHook{},
+	}
+}
+
+func (s *Server) withAdvisorContext(ctx context.Context, messages []map[string]any) context.Context {
+	if actx, ok := mcpruntime.GetAdvisorContext(ctx); ok {
+		actx.Messages = messages
+		return mcpruntime.WithAdvisorContext(ctx, actx)
+	}
+
+	maxUses := 0
+	if s != nil && s.mcpRuntime != nil {
+		maxUses = s.mcpRuntime.GetAdvisorMaxUses()
+	}
+	if maxUses <= 0 {
+		maxUses = 3
+	}
+
+	return mcpruntime.WithAdvisorContext(ctx, &mcpruntime.AdvisorContext{
+		Messages:      messages,
+		UsesRemaining: maxUses,
+	})
+}
+
+func (s *Server) applyMCPResponseToolCallHooks(ctx context.Context, toolName string, messages []map[string]any) context.Context {
+	for _, hook := range s.mcpResponseToolCallHooks() {
+		if hook.Match(toolName) {
+			// Increment depth to prevent adviser recursion
+			depth := mcpruntime.GetAdvisorDepth(ctx)
+			ctx = mcpruntime.WithAdvisorDepth(ctx, depth+1)
+			ctx = hook.PrepareContext(s, ctx, messages)
+		}
+	}
+	return ctx
+}
+
+// callMCPToolWithHooks executes response-phase MCP servertool hooks before the runtime call.
+// Hooks run when we consume worker-returned tool calls.
+func (s *Server) callMCPToolWithHooks(ctx context.Context, toolName, arguments string, messages []map[string]any) (string, error) {
+	ctx = s.applyMCPResponseToolCallHooks(ctx, toolName, messages)
+	return s.callMCPToolWithGuard(ctx, toolName, arguments)
 }

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -24,6 +24,16 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+func extractOpenAIMessages(messages []openai.ChatCompletionMessageParamUnion) []map[string]any {
+	if len(messages) == 0 {
+		return nil
+	}
+	b, _ := json.Marshal(messages)
+	var out []map[string]any
+	_ = json.Unmarshal(b, &out)
+	return out
+}
+
 // handleNonStreamingRequest handles non-streaming chat completion requests with MCP runtime support.
 func (s *Server) handleNonStreamingRequest(c *gin.Context, provider *typ.Provider, originalReq *openai.ChatCompletionNewParams, responseModel string, stripUsage bool) {
 	req := originalReq
@@ -170,8 +180,9 @@ func (s *Server) handleMCPToolCalls(ctx context.Context, provider *typ.Provider,
 		}
 
 		newMessages = append(newMessages, resp.Choices[0].Message.ToParam())
+		hookMessages := extractOpenAIMessages(newMessages)
 		for _, tc := range resp.Choices[0].Message.ToolCalls {
-			result, err := s.callMCPToolWithGuard(ctx, tc.Function.Name, tc.Function.Arguments)
+			result, err := s.callMCPToolWithHooks(ctx, tc.Function.Name, tc.Function.Arguments, hookMessages)
 			if err != nil {
 				logrus.WithError(err).Warnf("mcp: openai tool call failed name=%s arguments=%s", tc.Function.Name, tc.Function.Arguments)
 			}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -274,6 +274,17 @@ type MCPSourceConfig struct {
 	ToolsAutoExec       []string          `json:"tools_to_auto_execute,omitempty"` // auto-execute tools (agent mode)
 	IsPingAvailable     *bool             `json:"is_ping_available,omitempty"`     // health check method
 	AutoRegistered      bool              `json:"auto_registered,omitempty"`       // true if auto-registered on first connect
+	Advisor             *AdvisorConfig    `json:"advisor,omitempty" yaml:"advisor,omitempty"`
+}
+
+// AdvisorConfig configures the in-process advisor tool source.
+type AdvisorConfig struct {
+	BaseURL           string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	Model             string `json:"model,omitempty" yaml:"model,omitempty"`
+	APIKey            string `json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	MaxUsesPerRequest int    `json:"max_uses_per_request,omitempty" yaml:"max_uses_per_request,omitempty"`
+	// The max token output by adviser. Too much explodes worker's context. 4k is enough for pure suggestions.
+	MaxTokens int `json:"max_tokens,omitempty" yaml:"max_tokens,omitempty"`
 }
 
 // MCPStdioConfig STDIO connection configuration
@@ -318,6 +329,18 @@ func ApplyMCPRuntimeDefaults(config *MCPRuntimeConfig) {
 	for i := range config.Sources {
 		if config.Sources[i].Enabled == nil {
 			config.Sources[i].Enabled = BoolPtr(true)
+		}
+		// Apply defaults for in-process advisor source.
+		if config.Sources[i].Transport == "advisor" || config.Sources[i].Advisor != nil {
+			if config.Sources[i].Advisor == nil {
+				config.Sources[i].Advisor = &AdvisorConfig{}
+			}
+			if config.Sources[i].Advisor.MaxUsesPerRequest <= 0 {
+				config.Sources[i].Advisor.MaxUsesPerRequest = 3
+			}
+			if config.Sources[i].Advisor.MaxTokens <= 0 {
+				config.Sources[i].Advisor.MaxTokens = 4096
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 概述

此 PR 添加了 advisor 虚拟工具功能，允许 MCP 运行时在工具执行过程中咨询更强大的 advisor 模型以获取战略指导。

## 主要变更

### 核心功能
- **VirtualToolRegistry**: 管理进程内工具的注册表
- **Advisor Context Management**: 管理 advisor 上下文，包含递归深度保护
- **Advisor Virtual Tool**: 将 advisor 实现为虚拟工具，可配置使用限制
- **Response-Phase Hooks**: 为 advisor 工具调用添加响应阶段钩子
- **MCP Integration**: 将 advisor 集成到 MCP 工具执行循环中

### 修改的文件
- `internal/mcp/runtime/`: 添加 advisor 上下文、虚拟工具和内置注册表
- `internal/server/`: 添加 advisor 集成和 MCP 工具钩子
- `internal/typ/`: 添加 AdvisorConfig 类型定义
- `frontend/`: 在 MCP 配置 UI 中添加 advisor 支持

## 技术细节

### Advisor 工作原理
1. Advisor 作为服务器工具运行（不暴露给客户端）
2. 每个请求可配置最大使用次数限制
3. 内置递归深度保护，防止无限递归
4. 支持自定义模型、API 端点和令牌配置

### 安全性
- Advisor 不会被注入到客户端请求中
- 实施深度检查防止递归调用
- 每请求使用配额限制

## 测试
- 添加了 advisor 集成测试
- 添加了虚拟工具注册表测试
- 添加了 advisor 上下文管理测试

此 PR 提供了完整的 advisor 功能，可以安全地在 MCP 工具执行过程中提供战略指导。