### PR TITLE
feat(cli): command cc - improve settings file management with backup control and scenario flag support

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -458,7 +458,7 @@ export default {
       "mode": "Mode",
       "unified": "Unified",
       "separate": "Separate",
-      "unifiedDescription": "All models use the same routing rule (tingly/cc)",
+      "unifiedDescription": "All models use the same routing rule",
       "separateDescription": "Each model uses its own routing rule",
       "modeUpdated": "Profile mode updated to {{mode}}",
       "modeUpdateFailed": "Failed to update profile mode"

--- a/internal/agent/apply.go
+++ b/internal/agent/apply.go
@@ -230,7 +230,7 @@ func (aa *AgentApply) generateOpenCodeConfigPayload(configBaseURL, apiKey, _ str
 
 // applyClaudeSettings applies Claude Code settings.json
 func (aa *AgentApply) applyClaudeSettings(env map[string]string, installStatusLine bool) (*serverconfig.ApplyResult, error) {
-	var extras []serverconfig.KV
+	var opts []serverconfig.ApplyOption
 	if installStatusLine {
 		// Install status line script
 		_, _, err := serverconfig.InstallStatusLineScript()
@@ -240,10 +240,10 @@ func (aa *AgentApply) applyClaudeSettings(env map[string]string, installStatusLi
 		baseURL, _ := aa.getBaseURLAndToken()
 		statusLineCmd := fmt.Sprintf("TINGLY_API_URL=%s ~/.claude/tingly-statusline.sh", baseURL)
 		statusLine := map[string]any{"type": "command", "command": statusLineCmd}
-		extras = append(extras, serverconfig.KV{Key: "statusLine", Value: statusLine})
+		opts = append(opts, serverconfig.WithExtra("statusLine", statusLine))
 	}
 
-	return serverconfig.ApplyClaudeSettingsFromEnv(env, extras...)
+	return serverconfig.ApplyClaudeSettingsFromEnv(env, opts...)
 }
 
 // applyClaudeOnboarding applies Claude Code .claude.json

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -274,7 +274,7 @@ func buildProfileSettings(profileID string, env map[string]string, scenarioPath 
 		"type":    "command",
 		"command": wrapperPath,
 	}
-	result, err := config.ApplyClaudeSettingsToPath(destPath, env, config.KV{Key: "statusLine", Value: statusLine})
+	result, err := config.ApplyClaudeSettingsToPath(destPath, env, config.WithBackup(false), config.WithExtra("statusLine", statusLine))
 	if err != nil {
 		return "", fmt.Errorf("failed to apply settings: %w", err)
 	}
@@ -348,7 +348,7 @@ func buildTempSettings(env map[string]string, scenarioPath string) (string, erro
 		"type":    "command",
 		"command": wrapperPath,
 	}
-	result, err := config.ApplyClaudeSettingsToPath(destPath, env, config.KV{Key: "statusLine", Value: statusLine})
+	result, err := config.ApplyClaudeSettingsToPath(destPath, env, config.WithBackup(false), config.WithExtra("statusLine", statusLine))
 	if err != nil {
 		return "", fmt.Errorf("failed to apply settings: %w", err)
 	}

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,8 +24,11 @@ func CCCommand(appManager *AppManager) *cobra.Command {
 		Short: "Launch Claude Code with tingly-box routing",
 		Long: `Launch Claude Code with tingly-box as the API proxy.
 
-A temporary settings file is created and passed to Claude Code via --settings,
-so the existing Claude Code configuration is not modified.
+A settings file is created at ~/.tingly-box/claude/default.json (or per-profile
+for profile mode) and passed to Claude Code via --settings. This file includes:
+- Your existing Claude settings (copied from ~/.claude/settings.json)
+- Tingly-box routing environment variables
+- Status line integration
 
 Profiles can be used to switch between different rule sets for the same scenario.
 If a profile name or ID is not found, an interactive list will be shown.
@@ -143,8 +145,9 @@ func runCC(appManager *AppManager, profile string, claudeArgs []string) error {
 		// then merge the env section with tingly-box routing vars.
 		settingsPath, err = buildProfileSettings(profileID, env, scenarioPath)
 	} else {
-		// Default mode: create a temp settings file with only env vars.
-		settingsPath, err = buildTempSettings(env)
+		// Default mode: same as profile mode but with a predictable file name
+		// and no profile suffix in the scenario path.
+		settingsPath, err = buildTempSettings(env, scenarioPath)
 	}
 	if err != nil {
 		return err
@@ -291,32 +294,59 @@ exec ~/.claude/tingly-statusline.sh "$@"
 	return wrapperPath, nil
 }
 
-// buildTempSettings creates a temporary settings file containing only the env vars.
-func buildTempSettings(env map[string]string) (string, error) {
-	settingsContent, err := json.MarshalIndent(map[string]interface{}{
-		"env": env,
-	}, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("failed to generate settings: %w", err)
-	}
-
-	tmpDir := filepath.Join(os.TempDir(), "tingly-box-cc")
+// buildTempSettings creates a temporary settings file that is equivalent to
+// profile mode: copies user's ~/.claude/settings.json as base, then applies
+// tingly-box env vars and status line config. The file is created in a temp
+// directory with a predictable name so it can be reused across launches.
+func buildTempSettings(env map[string]string, scenarioPath string) (string, error) {
+	tmpDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	tmpFile, err := os.CreateTemp(tmpDir, "settings-*.json")
+	destPath := filepath.Join(tmpDir, "default.json")
+
+	// Copy user's ~/.claude/settings.json as the base (if it exists)
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp settings file: %w", err)
+		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	tmpPath := tmpFile.Name()
-	defer tmpFile.Close()
+	srcPath := filepath.Join(homeDir, ".claude", "settings.json")
 
-	if _, err := tmpFile.Write(settingsContent); err != nil {
-		return "", fmt.Errorf("failed to write settings file: %w", err)
+	if data, err := os.ReadFile(srcPath); err == nil {
+		if err := os.WriteFile(destPath, data, 0644); err != nil {
+			return "", fmt.Errorf("failed to copy user settings: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to read user settings: %w", err)
+	}
+	// If file doesn't exist, destPath may not exist yet — ApplyClaudeSettingsToPath will create it
+
+	// Install the base status line script
+	if _, _, err := config.InstallStatusLineScript(); err != nil {
+		return "", fmt.Errorf("failed to install status line script: %w", err)
 	}
 
-	return tmpPath, nil
+	// Generate a wrapper script that sets TINGLY_SCENARIO
+	wrapperPath, err := buildProfileStatusLineScript(tmpDir, "default", scenarioPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create status line wrapper: %w", err)
+	}
+
+	// Apply tingly-box env vars + statusLine config
+	statusLine := map[string]any{
+		"type":    "command",
+		"command": wrapperPath,
+	}
+	result, err := config.ApplyClaudeSettingsToPath(destPath, env, config.KV{Key: "statusLine", Value: statusLine})
+	if err != nil {
+		return "", fmt.Errorf("failed to apply settings: %w", err)
+	}
+	if !result.Success {
+		return "", fmt.Errorf("failed to apply settings: %s", result.Message)
+	}
+
+	return destPath, nil
 }
 
 // generateCCEnv builds the env vars map for Claude Code settings.

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -40,11 +40,15 @@ Flags:
   -p, --profile <id>     Profile ID or name (e.g., p1, Premium)
 
 Examples:
-  tingly-box cc                                     # launch without profile
+  tingly-box cc                                     # launch without profile (uses scenario flag)
   tingly-box cc -p Premium                          # launch with named profile
   tingly-box cc -p p1 resume                        # pass "resume" to claude
   tingly-box cc -p p1 --print "hello"               # pass --print to claude
-  tingly-box cc --dangerously-skip-permissions       # forwarded to claude`,
+  tingly-box cc --dangerously-skip-permissions       # forwarded to claude
+
+Unified mode:
+  Use "tingly-box scenario set-flag claude-code unified true" to enable unified mode
+  (single model for all requests). Default is separate mode (individual models).`,
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -130,10 +134,16 @@ func runCC(appManager *AppManager, profile string, claudeArgs []string) error {
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	apiKey := globalConfig.GetModelToken()
 
-	// Unified mode comes from profile config only; no CLI override allowed
+	// Unified mode determination:
+	// 1. If profile is used, use profile's unified setting
+	// 2. Otherwise, use scenario flag (defaults to false/separate mode)
 	var envUnified bool
 	if profileMeta != nil {
+		// Profile mode: use profile's unified setting
 		envUnified = profileMeta.Unified
+	} else {
+		// Default mode: use scenario flag
+		envUnified = globalConfig.GetScenarioFlag(scenario, "unified")
 	}
 	env := generateCCEnv(baseURL, apiKey, scenarioPath, envUnified, profileID != "")
 

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -87,18 +87,47 @@ func ensureDir(path string) error {
 	return os.MkdirAll(dir, 0755)
 }
 
-type KV struct {
-	Key   string
-	Value any
+// ApplyOption is a functional option for ApplyClaudeSettingsToPath
+type ApplyOption func(*applyOptions)
+
+type applyOptions struct {
+	backup bool
+	extras map[string]any
+}
+
+// WithBackup enables or disables backup when applying settings.
+// Default is true (create backup).
+func WithBackup(enable bool) ApplyOption {
+	return func(opts *applyOptions) {
+		opts.backup = enable
+	}
+}
+
+// WithExtra sets a single extra key-value pair to merge into the settings.
+func WithExtra(key string, value any) ApplyOption {
+	return func(opts *applyOptions) {
+		if opts.extras == nil {
+			opts.extras = make(map[string]any)
+		}
+		opts.extras[key] = value
+	}
 }
 
 // ApplyClaudeSettingsToPath applies Claude settings env vars to a specific target file.
 // If the file exists, it merges the env section into the existing config (with backup).
 // If not, it creates a new file with only the env section.
-func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, extras ...KV) (*ApplyResult, error) {
+func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, opts ...ApplyOption) (*ApplyResult, error) {
 	result := &ApplyResult{
 		Success: false,
 		Message: "",
+	}
+
+	// Parse options
+	applyOpts := &applyOptions{
+		backup: true, // default: enable backup
+	}
+	for _, opt := range opts {
+		opt(applyOpts)
 	}
 
 	// Ensure directory exists
@@ -124,12 +153,15 @@ func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, extras 
 			return result, nil
 		}
 
-		backupPath, err := backupFile(targetPath)
-		if err != nil {
-			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
-			return result, nil
+		// Only create backup if enabled
+		if applyOpts.backup {
+			backupPath, err := backupFile(targetPath)
+			if err != nil {
+				result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+				return result, nil
+			}
+			result.BackupPath = backupPath
 		}
-		result.BackupPath = backupPath
 		result.Updated = true
 	} else {
 		existingConfig = make(map[string]interface{})
@@ -143,8 +175,9 @@ func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, extras 
 	}
 
 	existingConfig["env"] = envInterface
-	for _, extra := range extras {
-		existingConfig[extra.Key] = extra.Value
+	// Apply extras from options
+	for k, v := range applyOpts.extras {
+		existingConfig[k] = v
 	}
 
 	// Write the merged config
@@ -173,14 +206,14 @@ func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, extras 
 
 // ApplyClaudeSettingsFromEnv applies Claude settings configuration with env vars
 // This is the safe version - env map is controlled by backend
-func ApplyClaudeSettingsFromEnv(env map[string]string, extras ...KV) (*ApplyResult, error) {
+func ApplyClaudeSettingsFromEnv(env map[string]string, opts ...ApplyOption) (*ApplyResult, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 
 	targetPath := filepath.Join(homeDir, ".claude", "settings.json")
-	return ApplyClaudeSettingsToPath(targetPath, env, extras...)
+	return ApplyClaudeSettingsToPath(targetPath, env, opts...)
 }
 
 // InstallStatusLineScript installs the tingly-statusline.sh script to ~/.claude/

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -404,3 +404,229 @@ func TestEnsureDir(t *testing.T) {
 		t.Errorf("Expected directory to be created")
 	}
 }
+
+func TestApplyClaudeSettingsToPath_WithBackupDisabled(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create existing file
+	targetPath := filepath.Join(tempDir, "settings.json")
+	existingConfig := map[string]interface{}{
+		"someKey": "someValue",
+	}
+	existingData, _ := json.MarshalIndent(existingConfig, "", "  ")
+	if err := os.WriteFile(targetPath, existingData, 0644); err != nil {
+		t.Fatalf("Failed to create existing file: %v", err)
+	}
+
+	// Apply with backup disabled
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	}, WithBackup(false))
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got failure: %s", result.Message)
+	}
+
+	// Verify no backup was created
+	if result.BackupPath != "" {
+		t.Errorf("Expected no backup when disabled, got: %s", result.BackupPath)
+	}
+
+	backupDir := filepath.Join(filepath.Dir(targetPath), "backup")
+	entries, _ := os.ReadDir(backupDir)
+	if len(entries) > 0 {
+		t.Errorf("Expected backup directory to be empty, found %d entries", len(entries))
+	}
+}
+
+func TestApplyClaudeSettingsToPath_WithBackupEnabled(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create existing file
+	targetPath := filepath.Join(tempDir, "settings.json")
+	existingConfig := map[string]interface{}{
+		"someKey": "someValue",
+	}
+	existingData, _ := json.MarshalIndent(existingConfig, "", "  ")
+	if err := os.WriteFile(targetPath, existingData, 0644); err != nil {
+		t.Fatalf("Failed to create existing file: %v", err)
+	}
+
+	// Apply with backup enabled (default)
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	}, WithBackup(true))
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got failure: %s", result.Message)
+	}
+
+	// Verify backup was created
+	if result.BackupPath == "" {
+		t.Errorf("Expected backup path when enabled")
+	}
+
+	if _, err := os.Stat(result.BackupPath); os.IsNotExist(err) {
+		t.Errorf("Expected backup file to exist at %s", result.BackupPath)
+	}
+}
+
+func TestApplyClaudeSettingsToPath_WithExtra(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	targetPath := filepath.Join(tempDir, "settings.json")
+
+	// Apply with extra statusLine config
+	statusLine := map[string]any{
+		"type":    "command",
+		"command": "/path/to/script.sh",
+	}
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	}, WithExtra("statusLine", statusLine), WithBackup(false))
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got failure: %s", result.Message)
+	}
+
+	// Verify statusLine was added
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse JSON: %v", err)
+	}
+
+	sl, ok := config["statusLine"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected statusLine section in config")
+	}
+
+	if sl["type"] != "command" {
+		t.Errorf("Expected statusLine type to be 'command', got: %v", sl["type"])
+	}
+
+	if sl["command"] != "/path/to/script.sh" {
+		t.Errorf("Expected statusLine command to be '/path/to/script.sh', got: %v", sl["command"])
+	}
+}
+
+func TestApplyClaudeSettingsToPath_MultipleWithExtra(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	targetPath := filepath.Join(tempDir, "settings.json")
+
+	// Apply with multiple extras using multiple WithExtra calls
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	},
+		WithExtra("key1", "value1"),
+		WithExtra("key2", "value2"),
+		WithExtra("statusLine", map[string]any{
+			"type":    "command",
+			"command": "/path/to/script.sh",
+		}),
+		WithBackup(false),
+	)
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got failure: %s", result.Message)
+	}
+
+	// Verify all extras were added
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse JSON: %v", err)
+	}
+
+	if config["key1"] != "value1" {
+		t.Errorf("Expected key1 to be 'value1', got: %v", config["key1"])
+	}
+	if config["key2"] != "value2" {
+		t.Errorf("Expected key2 to be 'value2', got: %v", config["key2"])
+	}
+
+	sl, ok := config["statusLine"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected statusLine section in config")
+	}
+
+	if sl["command"] != "/path/to/script.sh" {
+		t.Errorf("Expected statusLine command to be '/path/to/script.sh', got: %v", sl["command"])
+	}
+}
+
+func TestApplyClaudeSettingsToPath_DefaultBackupBehavior(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create existing file
+	targetPath := filepath.Join(tempDir, "settings.json")
+	existingConfig := map[string]interface{}{
+		"someKey": "someValue",
+	}
+	existingData, _ := json.MarshalIndent(existingConfig, "", "  ")
+	if err := os.WriteFile(targetPath, existingData, 0644); err != nil {
+		t.Fatalf("Failed to create existing file: %v", err)
+	}
+
+	// Apply without specifying backup option (should default to true)
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	})
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got failure: %s", result.Message)
+	}
+
+	// Verify backup was created by default
+	if result.BackupPath == "" {
+		t.Errorf("Expected backup path by default")
+	}
+
+	if _, err := os.Stat(result.BackupPath); os.IsNotExist(err) {
+		t.Errorf("Expected backup file to exist at %s by default", result.BackupPath)
+	}
+}

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 	var statusLineInstalled bool
 	var statusLinePath string
 
-	var extras = []config.KV{}
+	var opts []config.ApplyOption
 	if req.InstallStatusLine {
 		var scriptCreated bool
 		statusLinePath, scriptCreated, err = config.InstallStatusLineScript()
@@ -194,11 +194,11 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 		_ = scriptCreated // Used for tracking but not needed for response
 		// Add statusLine config to env
 		statusLine := map[string]any{"type": "command", "command": "~/.claude/tingly-statusline.sh"}
-		extras = append(extras, config.KV{Key: "statusLine", Value: statusLine})
+		opts = append(opts, config.WithExtra("statusLine", statusLine))
 	}
 
 	// Apply settings.json (now including statusLine config if requested)
-	settingsResult, err := config.ApplyClaudeSettingsFromEnv(env, extras...)
+	settingsResult, err := config.ApplyClaudeSettingsFromEnv(env, opts...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, config.ApplyResult{
 			Success: false,


### PR DESCRIPTION
## Summary

The `cc` command previously created unpredictable temporary settings files that couldn't be reused across launches and lacked integration with scenario-level configuration. 

This refactoring unifies settings file handling between profile and default modes while adding granular backup control and scenario flag support.

## Major Changes

- Settings file now created at a predictable path (`~/.tingly-box/claude/default.json`) instead of a temp directory, enabling reuse across launches
- Default mode now copies the user's existing `~/.claude/settings.json` as a base (same as profile mode), preserving all Claude Code configuration
- Unified mode now respects the scenario flag (`scenario set-flag claude-code unified true`) when no profile is specified, providing consistent behavior across all usage patterns
- New functional options API (`WithBackup()`, `WithExtra()`) replaces the KV slice pattern for cleaner, more extensible configuration

## Minor Changes

- Backup creation can now be disabled via `WithBackup(false)` option
- Refactored `buildTempSettings()` to match the profile settings workflow: copy user settings → install status line script → apply tingly-box environment variables
- Updated all call sites (`agent/apply.go`, `command/cc_command.go`, `configapply/handler.go`) to use the new options API