### PR TITLE
bugfix(cli, cc): fix claude code profile rule initialization and model routing

### DIFF
--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -298,20 +298,20 @@ const ClaudeCodeProfilePage: React.FC = () => {
                                 ? t('claudeCode.profile.unifiedDescription')
                                 : t('claudeCode.profile.separateDescription')}
                             </Typography>
-                            <Stack direction="row" spacing={1} alignItems="center">
-                                <Typography variant="body2" color="text.secondary">
-                                    {t('claudeCode.profile.separate')}
-                                </Typography>
-                                <Switch
-                                    checked={unifiedMode}
-                                    onChange={handleModeToggle}
-                                    disabled={isUpdatingMode}
-                                    size="small"
-                                />
-                                <Typography variant="body2" color="text.secondary">
-                                    {t('claudeCode.profile.unified')}
-                                </Typography>
-                            </Stack>
+                            {/*<Stack direction="row" spacing={1} alignItems="center">*/}
+                            {/*    <Typography variant="body2" color="text.secondary">*/}
+                            {/*        {t('claudeCode.profile.separate')}*/}
+                            {/*    </Typography>*/}
+                            {/*    <Switch*/}
+                            {/*        checked={unifiedMode}*/}
+                            {/*        onChange={handleModeToggle}*/}
+                            {/*        disabled={isUpdatingMode}*/}
+                            {/*        size="small"*/}
+                            {/*    />*/}
+                            {/*    <Typography variant="body2" color="text.secondary">*/}
+                            {/*        {t('claudeCode.profile.unified')}*/}
+                            {/*    </Typography>*/}
+                            {/*</Stack>*/}
                         </Box>
 
                     </Box>

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -372,18 +372,30 @@ func generateCCEnv(baseURL, apiKey, scenarioPath string, unified bool, isProfile
 	}
 
 	if unified {
-		env["ANTHROPIC_MODEL"] = "tingly/cc"
-		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "tingly/cc"
-		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "tingly/cc"
-		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "tingly/cc"
-		env["CLAUDE_CODE_SUBAGENT_MODEL"] = "tingly/cc"
+		if isProfile {
+			// Profile unified mode: use "*" to match the wildcard rule
+			env["ANTHROPIC_MODEL"] = "*"
+			env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "*"
+			env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "*"
+			env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "*"
+			env["CLAUDE_CODE_SUBAGENT_MODEL"] = "*"
+		} else {
+			// Non-profile unified mode: use full model name
+			env["ANTHROPIC_MODEL"] = "tingly/cc"
+			env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "tingly/cc"
+			env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "tingly/cc"
+			env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "tingly/cc"
+			env["CLAUDE_CODE_SUBAGENT_MODEL"] = "tingly/cc"
+		}
 	} else if isProfile {
+		// Profile separate mode: use short names (rules have stripped prefix)
 		env["ANTHROPIC_MODEL"] = "default"
 		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "haiku"
 		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "opus"
 		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "sonnet"
 		env["CLAUDE_CODE_SUBAGENT_MODEL"] = "subagent"
 	} else {
+		// Non-profile separate mode: use full model names
 		env["ANTHROPIC_MODEL"] = "tingly/cc-default"
 		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "tingly/cc-haiku"
 		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "tingly/cc-opus"

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -373,12 +373,12 @@ func generateCCEnv(baseURL, apiKey, scenarioPath string, unified bool, isProfile
 
 	if unified {
 		if isProfile {
-			// Profile unified mode: use "*" to match the wildcard rule
-			env["ANTHROPIC_MODEL"] = "*"
-			env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "*"
-			env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "*"
-			env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "*"
-			env["CLAUDE_CODE_SUBAGENT_MODEL"] = "*"
+			// Profile unified mode: use "cc" to match the profile rule
+			env["ANTHROPIC_MODEL"] = "cc"
+			env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "cc"
+			env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "cc"
+			env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "cc"
+			env["CLAUDE_CODE_SUBAGENT_MODEL"] = "cc"
 		} else {
 			// Non-profile unified mode: use full model name
 			env["ANTHROPIC_MODEL"] = "tingly/cc"

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1349,6 +1349,9 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 						cloned.UUID = uuid.New().String()
 						cloned.Scenario = profiledScenario
 						cloned.RequestModel = "cc" // Use "cc" for unified mode
+						// Clear services - users should configure their own
+						cloned.Services = nil
+						cloned.SmartRouting = nil
 						c.Rules = append(c.Rules, cloned)
 					}
 					// Skip individual model rules (haiku, sonnet, opus, default, subagent)
@@ -1372,9 +1375,12 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 				if !unified {
 					continue
 				}
-				// For unified mode, rename to "*"
-				cloned.RequestModel = "*"
+				// For unified mode, rename to "cc"
+				cloned.RequestModel = "cc"
 			}
+			// Clear services and smart routing - users should configure their own
+			cloned.Services = nil
+			cloned.SmartRouting = nil
 			c.Rules = append(c.Rules, cloned)
 		}
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -1295,6 +1294,38 @@ func (c *Config) GetProfile(baseScenario typ.RuleScenario, profileID string) (ty
 	return typ.ProfileMeta{}, false
 }
 
+// newCCProfileRules builds fresh rules for a claude_code profile.
+// unified=true → one rule "cc"; unified=false → five rules (default/haiku/sonnet/opus/subagent).
+// Rules are empty (no services, no smart routing) for users to configure.
+func newCCProfileRules(profiledScenario typ.RuleScenario, unified bool) []typ.Rule {
+	newRule := func(requestModel, description string) typ.Rule {
+		return typ.Rule{
+			UUID:         uuid.New().String(),
+			Scenario:     profiledScenario,
+			RequestModel: requestModel,
+			Description:  description,
+			LBTactic: typ.Tactic{
+				Type:   loadbalance.TacticAdaptive,
+				Params: typ.DefaultAdaptiveParams(),
+			},
+			Active: true,
+		}
+	}
+
+	if unified {
+		return []typ.Rule{
+			newRule("cc", "Claude Code profile - unified mode"),
+		}
+	}
+	return []typ.Rule{
+		newRule("default", "Claude Code profile - default model"),
+		newRule("haiku", "Claude Code profile - haiku model"),
+		newRule("sonnet", "Claude Code profile - sonnet model"),
+		newRule("opus", "Claude Code profile - opus model"),
+		newRule("subagent", "Claude Code profile - subagent model"),
+	}
+}
+
 // CreateProfile adds a new profile to a base scenario. Returns the created ProfileMeta.
 // The unified parameter determines whether to use unified mode (single model) or separate mode (individual models).
 func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unified bool) (typ.ProfileMeta, error) {
@@ -1333,55 +1364,12 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 
 	c.Profiles[base] = append(c.Profiles[base], meta)
 
-	// Clone rules from base scenario to the new profiled scenario.
-	// For claude_code, mode determines which rules to include:
-	// - unified mode: include built-in-cc rule as "*" (wildcard), skip individual model rules
-	// - separate mode: skip built-in-cc rule, include individual model rules
+	// Create fresh profile rules from DefaultRules templates (not copied from existing rules).
+	// For claude_code: unified mode → one "cc" rule; separate mode → five individual model rules.
+	// All profile rules start with empty Services/SmartRouting for users to configure.
 	profiledScenario := typ.ProfiledScenarioName(baseScenario, meta.ID)
-	for _, rule := range c.Rules {
-		if rule.Scenario == baseScenario {
-			// Handle claude_code scenario specially based on mode
-			if baseScenario == typ.ScenarioClaudeCode {
-				if unified {
-					// Unified mode: only include built-in-cc, rename request model to "cc"
-					if rule.UUID == RuleUUIDBuiltinCC {
-						cloned := rule
-						cloned.UUID = uuid.New().String()
-						cloned.Scenario = profiledScenario
-						cloned.RequestModel = "cc" // Use "cc" for unified mode
-						cloned.Services = nil      // cleared here (not at bottom) because unified path uses continue
-						cloned.SmartRouting = nil
-						c.Rules = append(c.Rules, cloned)
-					}
-					// Skip individual model rules (haiku, sonnet, opus, default, subagent)
-					continue
-				} else {
-					// Separate mode: skip built-in-cc, include individual model rules
-					if rule.UUID == RuleUUIDBuiltinCC {
-						continue
-					}
-				}
-			}
-
-			cloned := rule
-			cloned.UUID = uuid.New().String()
-			cloned.Scenario = profiledScenario
-			// Strip "tingly/cc-" prefix for profile rules (e.g. "tingly/cc-default" -> "default")
-			if strings.HasPrefix(cloned.RequestModel, "tingly/cc-") {
-				cloned.RequestModel = strings.TrimPrefix(cloned.RequestModel, "tingly/cc-")
-			} else if cloned.RequestModel == "tingly/cc" {
-				// Skip unified model name for separate mode
-				if !unified {
-					continue
-				}
-				// For unified mode, rename to "cc"
-				cloned.RequestModel = "cc"
-			}
-			// Clear services and smart routing - users should configure their own
-			cloned.Services = nil
-			cloned.SmartRouting = nil
-			c.Rules = append(c.Rules, cloned)
-		}
+	if baseScenario == typ.ScenarioClaudeCode {
+		c.Rules = append(c.Rules, newCCProfileRules(profiledScenario, unified)...)
 	}
 
 	return meta, c.Save()

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1349,8 +1349,7 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 						cloned.UUID = uuid.New().String()
 						cloned.Scenario = profiledScenario
 						cloned.RequestModel = "cc" // Use "cc" for unified mode
-						// Clear services - users should configure their own
-						cloned.Services = nil
+						cloned.Services = nil      // cleared here (not at bottom) because unified path uses continue
 						cloned.SmartRouting = nil
 						c.Rules = append(c.Rules, cloned)
 					}
@@ -1388,8 +1387,9 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 	return meta, c.Save()
 }
 
-// UpdateProfile updates the name and/or mode of an existing profile.
-// Pass nil for unified to keep existing mode, or bool pointer to change it.
+// UpdateProfile updates the name of an existing profile.
+// The unified parameter is accepted for API compatibility but ignored — mode is
+// fixed at creation time. To switch modes, delete and recreate the profile.
 func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, name string, unified *bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1420,14 +1420,10 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 
 	// Update fields
 	profiles[idx].Name = name
-	if unified != nil {
-		profiles[idx].Unified = *unified
-	}
-
-	// Note: Mode (unified/separate) is determined at profile creation time.
-	// Changing the mode field here only affects display, not the actual rules.
-	// To switch modes, users should delete and recreate the profile.
-	// This prevents confusion and data loss from rule reconstruction.
+	// Note: unified/separate mode is intentionally not updated here.
+	// Mode is fixed at profile creation time; to switch, delete and recreate.
+	// Accepting a unified flag change here would silently diverge the stored
+	// metadata from the actual rules, which are not rebuilt by this function.
 
 	return c.Save()
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1343,12 +1343,12 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 			// Handle claude_code scenario specially based on mode
 			if baseScenario == typ.ScenarioClaudeCode {
 				if unified {
-					// Unified mode: only include built-in-cc, rename request model to "*"
+					// Unified mode: only include built-in-cc, rename request model to "cc"
 					if rule.UUID == RuleUUIDBuiltinCC {
 						cloned := rule
 						cloned.UUID = uuid.New().String()
 						cloned.Scenario = profiledScenario
-						cloned.RequestModel = "*" // Use "*" as wildcard for all models
+						cloned.RequestModel = "cc" // Use "cc" for unified mode
 						c.Rules = append(c.Rules, cloned)
 					}
 					// Skip individual model rules (haiku, sonnet, opus, default, subagent)
@@ -1430,6 +1430,8 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 		})
 
 		// Re-clone rules with new mode setting
+		// IMPORTANT: Collect rules to clone first, then append to avoid modifying slice during iteration
+		var rulesToClone []typ.Rule
 		for _, rule := range c.Rules {
 			if rule.Scenario == baseScenario {
 				if *unified {
@@ -1438,8 +1440,8 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 						cloned := rule
 						cloned.UUID = uuid.New().String()
 						cloned.Scenario = profiledScenario
-						cloned.RequestModel = "*" // Use "*" as wildcard for all models
-						c.Rules = append(c.Rules, cloned)
+						cloned.RequestModel = "cc" // Use "cc" for unified mode
+						rulesToClone = append(rulesToClone, cloned)
 					}
 					continue
 				} else {
@@ -1459,12 +1461,14 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 					if !*unified {
 						continue
 					}
-					// For unified mode, rename to "*"
-					cloned.RequestModel = "*"
+					// For unified mode, rename to "cc"
+					cloned.RequestModel = "cc"
 				}
-				c.Rules = append(c.Rules, cloned)
+				rulesToClone = append(rulesToClone, cloned)
 			}
 		}
+		// Append all cloned rules at once
+		c.Rules = append(c.Rules, rulesToClone...)
 	}
 
 	return c.Save()

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1412,64 +1412,16 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 		}
 	}
 
-	oldUnified := profiles[idx].Unified
-
 	// Update fields
 	profiles[idx].Name = name
 	if unified != nil {
 		profiles[idx].Unified = *unified
 	}
 
-	// If mode changed, we need to update the rules
-	if unified != nil && *unified != oldUnified && baseScenario == typ.ScenarioClaudeCode {
-		profiledScenario := typ.ProfiledScenarioName(baseScenario, profileID)
-
-		// Remove existing profile rules
-		c.Rules = slices.DeleteFunc(c.Rules, func(r typ.Rule) bool {
-			return r.Scenario == profiledScenario
-		})
-
-		// Re-clone rules with new mode setting
-		// IMPORTANT: Collect rules to clone first, then append to avoid modifying slice during iteration
-		var rulesToClone []typ.Rule
-		for _, rule := range c.Rules {
-			if rule.Scenario == baseScenario {
-				if *unified {
-					// Unified mode: only include built-in-cc, rename to "*"
-					if rule.UUID == RuleUUIDBuiltinCC {
-						cloned := rule
-						cloned.UUID = uuid.New().String()
-						cloned.Scenario = profiledScenario
-						cloned.RequestModel = "cc" // Use "cc" for unified mode
-						rulesToClone = append(rulesToClone, cloned)
-					}
-					continue
-				} else {
-					// Separate mode: skip built-in-cc, include individual model rules
-					if rule.UUID == RuleUUIDBuiltinCC {
-						continue
-					}
-				}
-
-				cloned := rule
-				cloned.UUID = uuid.New().String()
-				cloned.Scenario = profiledScenario
-				// Strip "tingly/cc-" prefix for profile rules
-				if strings.HasPrefix(cloned.RequestModel, "tingly/cc-") {
-					cloned.RequestModel = strings.TrimPrefix(cloned.RequestModel, "tingly/cc-")
-				} else if cloned.RequestModel == "tingly/cc" {
-					if !*unified {
-						continue
-					}
-					// For unified mode, rename to "cc"
-					cloned.RequestModel = "cc"
-				}
-				rulesToClone = append(rulesToClone, cloned)
-			}
-		}
-		// Append all cloned rules at once
-		c.Rules = append(c.Rules, rulesToClone...)
-	}
+	// Note: Mode (unified/separate) is determined at profile creation time.
+	// Changing the mode field here only affects display, not the actual rules.
+	// To switch modes, users should delete and recreate the profile.
+	// This prevents confusion and data loss from rule reconstruction.
 
 	return c.Save()
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -35,6 +35,7 @@ func Migrate(c *Config) error {
 	migrate20260210(c)
 	migrate20260306(c)
 	migrate20260416(c) // Enable multi-tenant by default
+	migrate20260421(c) // Migrate profile unified model from "*" to "cc"
 	return nil
 }
 
@@ -368,4 +369,37 @@ func migrate20260416(c *Config) {
 	// Keep global token enabled for backward compatibility
 
 	_ = c.Save()
+}
+
+// migrate20260421 migrates profile unified model name from "*" to "cc"
+// This ensures consistency with the new naming convention where profile
+// rules use simplified names: "cc" (unified), "default", "haiku", etc. (separate)
+// Only applies to claude-code scenario profiles.
+func migrate20260421(c *Config) {
+	needsSave := false
+
+	for i := range c.Rules {
+		rule := &c.Rules[i]
+
+		// Only migrate claude-code profile rules
+		// Profile rules have scenario like "claude-code:profileID"
+		if !typ.IsProfiledScenario(rule.Scenario) {
+			continue
+		}
+		// Check if base scenario is claude-code
+		baseScenario, _ := typ.ParseScenarioProfile(rule.Scenario)
+		if baseScenario != typ.ScenarioClaudeCode {
+			continue
+		}
+
+		// Migrate "*" to "cc" for unified mode
+		if rule.RequestModel == "*" {
+			rule.RequestModel = "cc"
+			needsSave = true
+		}
+	}
+
+	if needsSave {
+		_ = c.Save()
+	}
 }


### PR DESCRIPTION
## Summary
Claude Code profiles were not functioning correctly: rules were initialized by copying and mutating existing base rules (a fragile approach that led to incorrect model names and duplicate services), and the `ANTHROPIC_MODEL` environment variables pointed to the wrong model names when running in profile mode. This PR resolves both issues and locks profile mode to be immutable after creation.

### Major Changes
- Profile rules are now created fresh with explicit names (`cc`, `default`, `haiku`, `sonnet`, `opus`, `subagent`) instead of copying and stripping prefixes from base rules—eliminating the source of model-name mismatches.
- `generateCCEnv` now correctly sets short model names (`cc`, `default`, etc.) for profile mode versus full names (`tingly/cc`, `tingly/cc-default`, etc.) for non-profile mode, ensuring Claude Code routes to the correct rule.
- Profile mode (unified/separate) is now immutable after creation; `UpdateProfile` no longer accepts a mode change, preventing silent divergence between stored metadata and actual rules.
- Migration `migrate20260421` upgrades existing configurations: renames any `"*"` unified rule to `"cc"` to align with the new convention.

### Minor Changes
- Removed the mode-switch toggle from the profile UI (users must delete and recreate a profile to change its mode).
- Removed approximately 60 lines of dead rule-reconstruction logic from `UpdateProfile`.
- Removed `slices` and `strings` imports that are no longer needed in `config.go`.