### PR TITLE
perf: better client pool transport ttl control.

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -388,6 +389,21 @@ func CreateHTTPClientWithProxy(proxyURL string) *http.Client {
 // This allows both the real TransportPool and test doubles to be used.
 type TransportPoolInterface interface {
 	GetTransport(providerUUID, model, proxyURL string, oauthType oauth.ProviderType, sessionID typ.SessionID) *http.Transport
+	AcquireTransport(providerUUID, model, proxyURL string, oauthType oauth.ProviderType, sessionID typ.SessionID) (*http.Transport, func())
+}
+
+// refCountedBody wraps an io.ReadCloser and calls onclose exactly once when closed.
+// The sync.Once prevents double-decrement if the body is closed multiple times.
+type refCountedBody struct {
+	io.ReadCloser
+	once    sync.Once
+	onclose func()
+}
+
+func (b *refCountedBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(b.onclose)
+	return err
 }
 
 // SessionBoundTransport is a RoundTripper that binds to a specific session.
@@ -406,21 +422,30 @@ type SessionBoundTransport struct {
 }
 
 // RoundTrip implements http.RoundTripper for SessionBoundTransport.
-// It gets the transport for the stored session from the pool and executes the request.
+// It acquires the transport for the stored session (incrementing refCount),
+// executes the request, and wraps the response body to auto-release on close.
 func (t *SessionBoundTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Get the transport for this session (cached in pool)
-	transport := t.transportPool.GetTransport(
+	transport, release := t.transportPool.AcquireTransport(
 		t.providerUUID,
 		"", // model - not used for transport keying
 		t.proxyURL,
 		t.oauthType,
-		t.sessionID, // Use stored sessionID
+		t.sessionID,
 	)
 
 	// Execute request
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
+		release()
 		return nil, err
+	}
+
+	// Wrap response body to auto-release refCount on close.
+	// This ensures long-running streaming requests keep the transport alive.
+	if resp.Body != nil {
+		resp.Body = &refCountedBody{ReadCloser: resp.Body, onclose: release}
+	} else {
+		release()
 	}
 
 	// Apply response wrapper if needed (e.g., tool prefix stripping)

--- a/internal/client/pool_test.go
+++ b/internal/client/pool_test.go
@@ -2,10 +2,16 @@ package client
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/typ"
+	"github.com/tingly-dev/tingly-box/pkg/oauth"
 )
 
 // TestClientPool_BasicCreation tests basic client creation
@@ -320,4 +326,315 @@ func TestClientPool_ConcurrentAccess(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		<-done
 	}
+}
+
+// --- Transport Pool Reference Counting Tests ---
+
+// newTestTransportPool creates an isolated TransportPool for testing
+// (not the global singleton).
+func newTestTransportPool() *TransportPool {
+	return &TransportPool{
+		transports: make(map[string]*pooledTransport),
+		config:     nil,
+	}
+}
+
+// TestTransportPool_AcquireReleaseRefCount verifies that AcquireTransport increments
+// the refCount and the release callback decrements it.
+func TestTransportPool_AcquireReleaseRefCount(t *testing.T) {
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "refcount-test"}
+	providerUUID := "test-provider-refcount"
+
+	// Acquire transport
+	_, release := pool.AcquireTransport(providerUUID, "", "", oauth.ProviderClaudeCode, sessionID)
+	if release == nil {
+		t.Fatal("Expected non-nil release callback")
+	}
+
+	// Verify refCount == 1
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+	pool.mutex.RLock()
+	pooled, exists := pool.transports[key]
+	pool.mutex.RUnlock()
+	if !exists {
+		t.Fatal("Expected transport to exist in pool")
+	}
+	if pooled.getRefCount() != 1 {
+		t.Errorf("Expected refCount=1, got %d", pooled.getRefCount())
+	}
+
+	// Release
+	release()
+
+	// Verify refCount == 0
+	if pooled.getRefCount() != 0 {
+		t.Errorf("Expected refCount=0 after release, got %d", pooled.getRefCount())
+	}
+}
+
+// TestTransportPool_CleanupSkipsActiveTransports verifies that cleanup does not
+// evict transports that have active in-flight requests (refCount > 0).
+func TestTransportPool_CleanupSkipsActiveTransports(t *testing.T) {
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "cleanup-skip-test"}
+	providerUUID := "test-provider-cleanup-skip"
+
+	// Acquire transport (refCount = 1)
+	_, release := pool.AcquireTransport(providerUUID, "", "", oauth.ProviderClaudeCode, sessionID)
+
+	// Set lastAccess to far in the past so it's "expired"
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+	pool.mutex.RLock()
+	pooled := pool.transports[key]
+	pool.mutex.RUnlock()
+	atomic.StoreInt64(&pooled.lastAccess, time.Now().Add(-30*time.Minute).UnixNano())
+
+	// Run cleanup with short TTL
+	pool.cleanupExpiredTransports(15 * time.Minute)
+
+	// Transport should still be in the map (refCount > 0)
+	pool.mutex.RLock()
+	_, stillExists := pool.transports[key]
+	pool.mutex.RUnlock()
+	if !stillExists {
+		t.Error("Expected transport to still exist after cleanup (refCount > 0)")
+	}
+
+	// Release
+	release()
+}
+
+// TestTransportPool_CleanupEvictsAfterRelease verifies that cleanup evicts
+// a transport once its refCount drops to 0 and TTL has expired.
+func TestTransportPool_CleanupEvictsAfterRelease(t *testing.T) {
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "cleanup-evict-test"}
+	providerUUID := "test-provider-cleanup-evict"
+
+	// Acquire and set lastAccess to far past
+	_, release := pool.AcquireTransport(providerUUID, "", "", oauth.ProviderClaudeCode, sessionID)
+
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+	pool.mutex.RLock()
+	pooled := pool.transports[key]
+	pool.mutex.RUnlock()
+	atomic.StoreInt64(&pooled.lastAccess, time.Now().Add(-30*time.Minute).UnixNano())
+
+	// Cleanup while active — should skip
+	pool.cleanupExpiredTransports(15 * time.Minute)
+
+	// Release (refCount -> 0)
+	release()
+
+	// Set lastAccess to far past again (first cleanup refreshed it when skipping)
+	atomic.StoreInt64(&pooled.lastAccess, time.Now().Add(-30*time.Minute).UnixNano())
+
+	// Cleanup again — should now evict
+	pool.cleanupExpiredTransports(15 * time.Minute)
+
+	pool.mutex.RLock()
+	_, stillExists := pool.transports[key]
+	pool.mutex.RUnlock()
+	if stillExists {
+		t.Error("Expected transport to be removed after release and cleanup")
+	}
+}
+
+// TestTransportPool_InvalidateSessionDefersActive verifies that InvalidateSession
+// defers removal of transports with active requests.
+func TestTransportPool_InvalidateSessionDefersActive(t *testing.T) {
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "invalidate-defer-test"}
+	providerUUID := "test-provider-invalidate-defer"
+
+	// Acquire transport (refCount = 1)
+	_, release := pool.AcquireTransport(providerUUID, "", "", oauth.ProviderClaudeCode, sessionID)
+
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+
+	// Invalidate session while active
+	pool.InvalidateSession(providerUUID, sessionID.Value)
+
+	// Transport should still be in the map (refCount > 0), but marked for removal
+	pool.mutex.RLock()
+	_, stillExists := pool.transports[key]
+	pool.mutex.RUnlock()
+	if !stillExists {
+		t.Error("Expected transport to still exist after invalidation (refCount > 0)")
+	}
+
+	// Verify lastAccess was set to epoch (marked for deferred removal)
+	pool.mutex.RLock()
+	lastAccessNano := atomic.LoadInt64(&pool.transports[key].lastAccess)
+	pool.mutex.RUnlock()
+	if lastAccessNano != 0 {
+		t.Errorf("Expected lastAccess to be zero (epoch), got %d", lastAccessNano)
+	}
+
+	// Release (refCount -> 0)
+	release()
+
+	// Cleanup should now evict it
+	pool.cleanupExpiredTransports(1 * time.Minute)
+
+	pool.mutex.RLock()
+	_, stillExists = pool.transports[key]
+	pool.mutex.RUnlock()
+	if stillExists {
+		t.Error("Expected transport to be removed after release and cleanup")
+	}
+}
+
+// TestTransportPool_AcquireReleaseConcurrentRace tests that concurrent AcquireTransport
+// and release calls do not cause data races (run with -race).
+func TestTransportPool_AcquireReleaseConcurrentRace(t *testing.T) {
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "race-test"}
+	providerUUID := "test-provider-race"
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, release := pool.AcquireTransport(providerUUID, "", "", oauth.ProviderClaudeCode, sessionID)
+			// Simulate some work
+			time.Sleep(time.Microsecond * 10)
+			release()
+		}()
+	}
+
+	wg.Wait()
+
+	// All releases done; refCount should be 0
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+	pool.mutex.RLock()
+	pooled := pool.transports[key]
+	pool.mutex.RUnlock()
+	if pooled.getRefCount() != 0 {
+		t.Errorf("Expected refCount=0 after all releases, got %d", pooled.getRefCount())
+	}
+}
+
+// TestSessionBoundTransport_RefCountedBodyRelease tests that the response body
+// wrapper correctly decrements the refCount when closed.
+func TestSessionBoundTransport_RefCountedBodyRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	// Use a real TransportPool (not test double) to verify ref counting
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "body-release-test"}
+	providerUUID := "test-provider-body-release"
+
+	transport := &SessionBoundTransport{
+		transportPool: pool,
+		providerUUID:  providerUUID,
+		proxyURL:      "",
+		oauthType:     oauth.ProviderClaudeCode,
+		sessionID:     sessionID,
+	}
+
+	client := &http.Client{Transport: transport}
+
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	// During the request, refCount should be 1 (body not yet closed)
+	pool.mutex.RLock()
+	pooled := pool.transports[key]
+	pool.mutex.RUnlock()
+	if pooled.getRefCount() != 1 {
+		t.Errorf("Expected refCount=1 during request, got %d", pooled.getRefCount())
+	}
+
+	// Close the body — should decrement refCount
+	resp.Body.Close()
+
+	if pooled.getRefCount() != 0 {
+		t.Errorf("Expected refCount=0 after body close, got %d", pooled.getRefCount())
+	}
+}
+
+// TestSessionBoundTransport_RefCountedBodyDoubleClose tests that double-closing
+// the response body does not double-decrement (sync.Once protection).
+func TestSessionBoundTransport_RefCountedBodyDoubleClose(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "double-close-test"}
+	providerUUID := "test-provider-double-close"
+
+	sbt := &SessionBoundTransport{
+		transportPool: pool,
+		providerUUID:  providerUUID,
+		proxyURL:      "",
+		oauthType:     oauth.ProviderClaudeCode,
+		sessionID:     sessionID,
+	}
+
+	client := &http.Client{Transport: sbt}
+	key := NewTransportKey(providerUUID, "", oauth.ProviderClaudeCode, sessionID).String()
+
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	// Close body twice
+	resp.Body.Close()
+	resp.Body.Close() // Second close should be safe (sync.Once)
+
+	pool.mutex.RLock()
+	pooled := pool.transports[key]
+	pool.mutex.RUnlock()
+	if pooled.getRefCount() != 0 {
+		t.Errorf("Expected refCount=0 after double close, got %d", pooled.getRefCount())
+	}
+}
+
+// TestTransportPool_LastAccessAtomicRace tests that the lastAccess timestamp
+// is updated atomically without the RUnlock->Lock race (run with -race).
+func TestTransportPool_LastAccessAtomicRace(t *testing.T) {
+	pool := newTestTransportPool()
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "atomic-race-test"}
+	providerUUID := "test-provider-atomic-race"
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pool.GetTransport(providerUUID, "", "", oauth.ProviderClaudeCode, sessionID)
+		}()
+	}
+
+	// Also run cleanup concurrently
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pool.cleanupExpiredTransports(1 * time.Nanosecond) // Very short TTL to trigger cleanup
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/client/transport_pool.go
+++ b/internal/client/transport_pool.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -47,10 +48,38 @@ const (
 	DefaultTransportCleanupInterval = 5 * time.Minute  // Default interval for cleanup task
 )
 
-// pooledTransport wraps a transport with its last access timestamp for TTL tracking
+// pooledTransport wraps a transport with reference counting and last access timestamp for TTL tracking.
+// refCount and lastAccess use atomic operations so they can be updated under RLock without
+// upgrading to a full write lock.
 type pooledTransport struct {
 	transport  *http.Transport
-	lastAccess time.Time
+	refCount   int32 // active in-flight requests (atomic)
+	lastAccess int64 // UnixNano of last access (atomic)
+}
+
+// incrementRefCount atomically increments and returns the new value.
+func (pt *pooledTransport) incrementRefCount() int32 {
+	return atomic.AddInt32(&pt.refCount, 1)
+}
+
+// decrementRefCount atomically decrements and returns the new value.
+func (pt *pooledTransport) decrementRefCount() int32 {
+	return atomic.AddInt32(&pt.refCount, -1)
+}
+
+// getRefCount returns the current reference count.
+func (pt *pooledTransport) getRefCount() int32 {
+	return atomic.LoadInt32(&pt.refCount)
+}
+
+// setLastAccess atomically sets the last access time to now.
+func (pt *pooledTransport) setLastAccess() {
+	atomic.StoreInt64(&pt.lastAccess, time.Now().UnixNano())
+}
+
+// getLastAccess returns the last access time.
+func (pt *pooledTransport) getLastAccess() time.Time {
+	return time.Unix(0, atomic.LoadInt64(&pt.lastAccess))
 }
 
 // TransportPool manages shared HTTP transports for clients
@@ -111,17 +140,17 @@ func SetTransportConfig(config *TransportConfig) {
 // The transport key is based on: providerUUID + sessionID (for OAuth providers).
 // proxyURL is used to configure the transport but is NOT part of the key.
 // sessionID is used to scope transports for OAuth providers that require per-session isolation.
+//
+// Note: For in-flight request tracking (preventing cleanup of active transports),
+// use AcquireTransport instead.
 func (tp *TransportPool) GetTransport(providerUUID, model, proxyURL string, oauthType oauth.ProviderType, sessionID typ.SessionID) *http.Transport {
 	key := NewTransportKey(providerUUID, "", oauthType, sessionID).String()
 
-	// Try to get existing transport with read lock first
+	// Try to get existing transport with read lock
 	tp.mutex.RLock()
 	if pooled, exists := tp.transports[key]; exists {
+		pooled.setLastAccess() // atomic — no need to upgrade to write lock
 		tp.mutex.RUnlock()
-		// Update last access time
-		tp.mutex.Lock()
-		pooled.lastAccess = time.Now()
-		tp.mutex.Unlock()
 		logrus.Debugf("Using cached transport for key: %s", key)
 		return pooled.transport
 	}
@@ -133,7 +162,7 @@ func (tp *TransportPool) GetTransport(providerUUID, model, proxyURL string, oaut
 
 	// Double-check after acquiring write lock to avoid race conditions
 	if pooled, exists := tp.transports[key]; exists {
-		pooled.lastAccess = time.Now()
+		pooled.setLastAccess()
 		logrus.Debugf("Using cached transport for key: %s (double-check)", key)
 		return pooled.transport
 	}
@@ -142,12 +171,53 @@ func (tp *TransportPool) GetTransport(providerUUID, model, proxyURL string, oaut
 	logrus.Infof("Creating new transport for provider: %s, model: %s, proxy: %s, oauth: %s, session: %s",
 		providerUUID, model, proxyURL, oauthType, sessionID.Value)
 	transport := tp.createTransport(proxyURL)
-	tp.transports[key] = &pooledTransport{
-		transport:  transport,
-		lastAccess: time.Now(),
-	}
+	pt := &pooledTransport{transport: transport}
+	pt.setLastAccess()
+	tp.transports[key] = pt
 
 	return transport
+}
+
+// AcquireTransport returns a transport for the given configuration and increments its
+// reference count. The caller MUST call the returned release function exactly once
+// when the request is complete (typically by wrapping the response body).
+// This prevents the cleanup task from evicting a transport that has active in-flight requests.
+func (tp *TransportPool) AcquireTransport(providerUUID, model, proxyURL string, oauthType oauth.ProviderType, sessionID typ.SessionID) (*http.Transport, func()) {
+	key := NewTransportKey(providerUUID, "", oauthType, sessionID).String()
+
+	// Fast path: read lock for cache hit
+	tp.mutex.RLock()
+	if pooled, exists := tp.transports[key]; exists {
+		pooled.incrementRefCount()
+		pooled.setLastAccess()
+		tp.mutex.RUnlock()
+		logrus.Debugf("Acquired cached transport for key: %s", key)
+		return pooled.transport, func() { pooled.decrementRefCount() }
+	}
+	tp.mutex.RUnlock()
+
+	// Slow path: write lock to create
+	tp.mutex.Lock()
+	defer tp.mutex.Unlock()
+
+	// Double-check after acquiring write lock
+	if pooled, exists := tp.transports[key]; exists {
+		pooled.incrementRefCount()
+		pooled.setLastAccess()
+		logrus.Debugf("Acquired cached transport for key: %s (double-check)", key)
+		return pooled.transport, func() { pooled.decrementRefCount() }
+	}
+
+	// Create new transport
+	logrus.Infof("Creating new transport for provider: %s, model: %s, proxy: %s, oauth: %s, session: %s",
+		providerUUID, model, proxyURL, oauthType, sessionID.Value)
+	transport := tp.createTransport(proxyURL)
+	pt := &pooledTransport{transport: transport}
+	pt.setLastAccess()
+	pt.incrementRefCount()
+	tp.transports[key] = pt
+
+	return transport, func() { pt.decrementRefCount() }
 }
 
 // generateTransportKey creates a unique key for transport caching.
@@ -261,21 +331,35 @@ func (tp *TransportPool) Stats() map[string]interface{} {
 	}
 }
 
-// Clear removes all transports from the pool and closes idle connections
+// Clear removes all transports from the pool and closes idle connections.
+// Transports with active in-flight requests (refCount > 0) are marked for deferred
+// removal (lastAccess set to epoch) and will be cleaned up on the next cycle after
+// their requests complete.
 func (tp *TransportPool) Clear() {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()
 
+	removedCount := 0
+	deferredCount := 0
+
 	for key, pooled := range tp.transports {
-		pooled.transport.CloseIdleConnections()
-		logrus.Debugf("Closed idle connections for transport key: %s", key)
+		if pooled.getRefCount() > 0 {
+			pooled.transport.CloseIdleConnections()
+			atomic.StoreInt64(&pooled.lastAccess, 0) // mark for deferred removal
+			deferredCount++
+		} else {
+			pooled.transport.CloseIdleConnections()
+			delete(tp.transports, key)
+			removedCount++
+		}
 	}
-	tp.transports = make(map[string]*pooledTransport)
-	logrus.Info("Transport pool cleared")
+
+	logrus.Infof("Transport pool cleared: %d removed, %d deferred (active requests)", removedCount, deferredCount)
 }
 
 // InvalidateProvider removes all transports associated with a specific provider UUID.
 // This should be called when provider credentials are updated (e.g., OAuth token refresh).
+// Transports with active requests are marked for deferred removal.
 func (tp *TransportPool) InvalidateProvider(providerUUID string) {
 	if providerUUID == "" {
 		return
@@ -285,23 +369,32 @@ func (tp *TransportPool) InvalidateProvider(providerUUID string) {
 	defer tp.mutex.Unlock()
 
 	uuidToken := `"` + providerUUID + `"`
-	count := 0
+	removedCount := 0
+	deferredCount := 0
 
 	for key, pooled := range tp.transports {
 		if strings.Contains(key, uuidToken) {
-			pooled.transport.CloseIdleConnections()
-			delete(tp.transports, key)
-			count++
+			if pooled.getRefCount() > 0 {
+				pooled.transport.CloseIdleConnections()
+				atomic.StoreInt64(&pooled.lastAccess, 0) // mark for deferred removal
+				deferredCount++
+			} else {
+				pooled.transport.CloseIdleConnections()
+				delete(tp.transports, key)
+				removedCount++
+			}
 		}
 	}
 
-	if count > 0 {
-		logrus.Infof("Invalidated %d transport(s) for provider UUID: %s", count, providerUUID)
+	if removedCount > 0 || deferredCount > 0 {
+		logrus.Infof("Invalidated %d transport(s) for provider UUID: %s (%d deferred due to active requests)",
+			removedCount, providerUUID, deferredCount)
 	}
 }
 
 // InvalidateSession removes all transports associated with a specific session for a provider.
 // This should be called when a session ends or its OAuth token is revoked.
+// Transports with active requests are marked for deferred removal.
 func (tp *TransportPool) InvalidateSession(providerUUID, sessionID string) {
 	if sessionID == "" {
 		return
@@ -310,26 +403,34 @@ func (tp *TransportPool) InvalidateSession(providerUUID, sessionID string) {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()
 
-	// Keys are JSON from TransportKey.String(); match both provider_uuid and session_id value fields.
 	uuidToken := `"` + providerUUID + `"`
 	sessionToken := `"` + sessionID + `"`
-	count := 0
+	removedCount := 0
+	deferredCount := 0
 
 	for key, pooled := range tp.transports {
-		// Note: ProxyURL is no longer part of the key, so we don't need to match it
 		if strings.Contains(key, uuidToken) && strings.Contains(key, sessionToken) {
-			pooled.transport.CloseIdleConnections()
-			delete(tp.transports, key)
-			count++
+			if pooled.getRefCount() > 0 {
+				pooled.transport.CloseIdleConnections()
+				atomic.StoreInt64(&pooled.lastAccess, 0) // mark for deferred removal
+				deferredCount++
+			} else {
+				pooled.transport.CloseIdleConnections()
+				delete(tp.transports, key)
+				removedCount++
+			}
 		}
 	}
 
-	if count > 0 {
-		logrus.Infof("Invalidated %d transport(s) for provider UUID: %s session: %s", count, providerUUID, sessionID)
+	if removedCount > 0 || deferredCount > 0 {
+		logrus.Infof("Invalidated %d transport(s) for provider UUID: %s session: %s (%d deferred due to active requests)",
+			removedCount, providerUUID, sessionID, deferredCount)
 	}
 }
 
-// cleanupExpiredTransports removes transports that haven't been accessed within the TTL period
+// cleanupExpiredTransports removes transports that haven't been accessed within the TTL period.
+// Transports with active in-flight requests (refCount > 0) are skipped and their lastAccess
+// is refreshed so they get a fresh TTL window after the active request completes.
 func (tp *TransportPool) cleanupExpiredTransports(ttl time.Duration) {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()
@@ -338,16 +439,24 @@ func (tp *TransportPool) cleanupExpiredTransports(ttl time.Duration) {
 	expirationThreshold := now.Add(-ttl)
 
 	removedCount := 0
+	skippedCount := 0
 	for key, pooled := range tp.transports {
-		if pooled.lastAccess.Before(expirationThreshold) {
+		if pooled.getRefCount() > 0 {
+			// Transport has active requests; refresh lastAccess so it gets a fresh
+			// TTL window once the request completes instead of being immediately evicted.
+			pooled.setLastAccess()
+			skippedCount++
+			continue
+		}
+		if pooled.getLastAccess().Before(expirationThreshold) {
 			pooled.transport.CloseIdleConnections()
 			delete(tp.transports, key)
 			removedCount++
 		}
 	}
 
-	if removedCount > 0 {
-		logrus.Infof("Cleaned up %d expired transports from pool", removedCount)
+	if removedCount > 0 || skippedCount > 0 {
+		logrus.Infof("Cleaned up %d expired transports from pool, skipped %d with active requests", removedCount, skippedCount)
 	}
 }
 

--- a/internal/client/transport_test_helper.go
+++ b/internal/client/transport_test_helper.go
@@ -46,6 +46,13 @@ func (p *TestTransportPool) GetTransport(providerUUID, model, proxyURL string, o
 	return transport
 }
 
+// AcquireTransport returns a transport for the given configuration.
+// The release function is a no-op for tests (no reference counting).
+func (p *TestTransportPool) AcquireTransport(providerUUID, model, proxyURL string, oauthType oauth.ProviderType, sessionID typ.SessionID) (*http.Transport, func()) {
+	transport := p.GetTransport(providerUUID, model, proxyURL, oauthType, sessionID)
+	return transport, func() {} // no-op for tests
+}
+
 // Keys returns all transport keys that were requested.
 func (p *TestTransportPool) Keys() []string {
 	p.mutex.Lock()


### PR DESCRIPTION
# Summary
This PR introduces better performance and stability by updating the client pool count and cleanup logic.
- no race condition
- guard transport in better solution - even for the edge case
- less unnecessary lock, use atomic instead

# Example
```
T=0min   : Request starts, refCount=1, lastAccess=now
T=5min   : Cleanup runs — refCount>0, skip, refresh lastAccess
T=10min  : Request still going, refCount=1
T=15min  : Cleanup runs — refCount>0, skip, refresh lastAccess
T=20min  : Stream ends, body.Close(), refCount=0
T=25min  : Cleanup runs — refCount=0, lastAccess=10min ago < TTL=15min → KEEP
T=30min  : Cleanup runs — refCount=0, lastAccess=20min ago > TTL=15min → EVICT
```

# Details
[2026-04-21-transport-pool-refcount-explanation.md](https://github.com/user-attachments/files/26920701/2026-04-21-transport-pool-refcount-explanation.md)
