### PR TITLE
bugfix(server): exclude profile rules from non-profile scenario model list

### DIFF
--- a/internal/server/model_list_scope.go
+++ b/internal/server/model_list_scope.go
@@ -16,9 +16,24 @@ func scenarioSupportsTransport(scenario typ.RuleScenario, transport typ.Scenario
 }
 
 func shouldIncludeRuleInModelList(requestedScenario typ.RuleScenario, ruleScenario typ.RuleScenario) bool {
+	// If requested scenario is a profile (e.g., "claude_code:p1"), only include exact matches.
+	// Profiles are isolated scopes and should not fallback to transport-based reachability.
+	if typ.IsProfiledScenario(requestedScenario) {
+		return requestedScenario == ruleScenario
+	}
+
+	// If the rule belongs to a profiled scenario, it must not be visible to non-profile requests.
+	// Profile rules are exclusively scoped to their own profile.
+	if typ.IsProfiledScenario(ruleScenario) {
+		return false
+	}
+
+	// For non-profile scenarios, check exact match first
 	if requestedScenario == ruleScenario {
 		return true
 	}
+
+	// Then check transport reachability for non-profile scenarios
 	requestedDescriptor, ok := typ.GetScenarioDescriptor(requestedScenario)
 	if !ok {
 		return false

--- a/internal/server/model_list_scope_test.go
+++ b/internal/server/model_list_scope_test.go
@@ -66,3 +66,72 @@ func TestShouldIncludeRuleInModelList_CustomScenarioWithBothTransports(t *testin
 		t.Fatalf("expected custom scenario to include anthropic transport scenario")
 	}
 }
+
+func TestShouldIncludeRuleInModelList_ProfileOnlyIncludesExactMatch(t *testing.T) {
+	// Test that profile scenarios only include exact matches, not transport-reachable scenarios
+	profiledScenario := typ.RuleScenario("claude_code:p1")
+	baseScenario := typ.RuleScenario("claude_code")
+
+	// Profile should include exact match
+	if !shouldIncludeRuleInModelList(profiledScenario, profiledScenario) {
+		t.Fatalf("expected profile to include exact match rule")
+	}
+
+	// Profile should NOT include base scenario rules (even though they share transport)
+	if shouldIncludeRuleInModelList(profiledScenario, baseScenario) {
+		t.Fatalf("expected profile to exclude base scenario rules")
+	}
+
+	// Profile should NOT include other scenarios with compatible transport
+	if shouldIncludeRuleInModelList(profiledScenario, typ.ScenarioAnthropic) {
+		t.Fatalf("expected profile to exclude other anthropic transport scenarios")
+	}
+
+	// Base scenario should still include transport-reachable scenarios
+	if !shouldIncludeRuleInModelList(baseScenario, typ.ScenarioAnthropic) {
+		t.Fatalf("expected base scenario to include transport-reachable scenarios")
+	}
+}
+
+func TestShouldIncludeRuleInModelList_BaseScenarioExcludesProfileRules(t *testing.T) {
+	baseScenario := typ.RuleScenario("claude_code")
+	profiledScenario := typ.RuleScenario("claude_code:p1")
+
+	// Base scenario should NOT include profile rules (profiles are exclusively scoped)
+	if shouldIncludeRuleInModelList(baseScenario, profiledScenario) {
+		t.Fatalf("expected base scenario to exclude profiled scenario rules")
+	}
+
+	// Base scenario should still include its own rules
+	if !shouldIncludeRuleInModelList(baseScenario, baseScenario) {
+		t.Fatalf("expected base scenario to include its own rules")
+	}
+
+	// Base scenario should still include transport-reachable non-profile scenarios
+	if !shouldIncludeRuleInModelList(baseScenario, typ.ScenarioAnthropic) {
+		t.Fatalf("expected base scenario to include transport-reachable scenarios")
+	}
+}
+
+func TestShouldIncludeRuleInModelList_DifferentProfilesAreIsolated(t *testing.T) {
+	profile1 := typ.RuleScenario("claude_code:p1")
+	profile2 := typ.RuleScenario("claude_code:p2")
+
+	// Profile 1 should not include Profile 2's rules
+	if shouldIncludeRuleInModelList(profile1, profile2) {
+		t.Fatalf("expected profile p1 to exclude profile p2 rules")
+	}
+
+	// Profile 2 should not include Profile 1's rules
+	if shouldIncludeRuleInModelList(profile2, profile1) {
+		t.Fatalf("expected profile p2 to exclude profile p1 rules")
+	}
+
+	// Each profile should only include its own rules
+	if !shouldIncludeRuleInModelList(profile1, profile1) {
+		t.Fatalf("expected profile p1 to include its own rules")
+	}
+	if !shouldIncludeRuleInModelList(profile2, profile2) {
+		t.Fatalf("expected profile p2 to include its own rules")
+	}
+}


### PR DESCRIPTION
When a non-profiled scenario (e.g. claude_code) requests the model list, profile rules (e.g. claude_code:p1) were incorrectly included via transport reachability. Profiles are exclusively scoped and must only appear in their own profile's model list.