### PR TITLE
perf(server): only create recording sink while enable recording

### DIFF
--- a/frontend/src/components/ExperimentalFeatures.tsx
+++ b/frontend/src/components/ExperimentalFeatures.tsx
@@ -58,7 +58,7 @@ const ExperimentalFeatures: React.FC<ExperimentalFeaturesProps> = ({ scenario })
             setFeatures(newFeatures);
 
             // Load Record V2 mode (string flag)
-            const recordV2Result = await api.getScenarioStringFlag(scenario, 'record_v2');
+            const recordV2Result = await api.getScenarioStringFlag(scenario, 'recording_v2');
             setRecordV2Mode(recordV2Result?.data?.value || '');
         } catch (error) {
             console.error('Failed to load experimental features:', error);
@@ -89,17 +89,17 @@ const ExperimentalFeatures: React.FC<ExperimentalFeaturesProps> = ({ scenario })
     const handleRecordV2Change = (event: SelectChangeEvent<string>) => {
         const newMode = event.target.value;
         console.log('Record V2 mode changed:', newMode);
-        api.setScenarioStringFlag(scenario, 'record_v2', newMode)
+        api.setScenarioStringFlag(scenario, 'recording_v2', newMode)
             .then((result) => {
                 if (result.success) {
                     setRecordV2Mode(newMode);
                 } else {
-                    console.error('Failed to set record_v2 mode:', result);
+                    console.error('Failed to set recording_v2 mode:', result);
                     loadFeatures();
                 }
             })
             .catch((err) => {
-                console.error('Failed to set record_v2 mode:', err);
+                console.error('Failed to set recording_v2 mode:', err);
                 loadFeatures();
             });
     };

--- a/frontend/src/components/PluginFeatures.tsx
+++ b/frontend/src/components/PluginFeatures.tsx
@@ -109,7 +109,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             setFeatures(newFeatures);
 
             // Load Record V2 mode (string flag)
-            const recordV2Result = await api.getScenarioStringFlag(scenario, 'record_v2');
+            const recordV2Result = await api.getScenarioStringFlag(scenario, 'recording_v2');
             if (recordV2Result?.success && recordV2Result?.data?.value !== undefined) {
                 setRecordV2Mode(recordV2Result.data.value);
             }
@@ -203,17 +203,17 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
 
         setUpdating(prev => ({ ...prev, recordV2: true }));
 
-        api.setScenarioStringFlag(scenario, 'record_v2', newMode)
+        api.setScenarioStringFlag(scenario, 'recording_v2', newMode)
             .then((result) => {
                 if (result.success) {
                     setRecordV2Mode(newMode);
                 } else {
-                    console.error('Failed to set record_v2 mode:', result);
+                    console.error('Failed to set recording_v2 mode:', result);
                     loadData();
                 }
             })
             .catch((err) => {
-                console.error('Failed to set record_v2 mode:', err);
+                console.error('Failed to set recording_v2 mode:', err);
                 loadData();
             })
             .finally(() => {

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -98,7 +98,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 					Type:    "invalid_request_error",
 				},
 			})
-			logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic decode error")
+			logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic beta decode error")
 			return
 		}
 		requestModel = string(betaMessages.Model)

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -99,6 +99,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 				},
 			})
 			logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic beta decode error")
+			c.Abort()
 			return
 		}
 		requestModel = string(betaMessages.Model)
@@ -117,6 +118,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 				},
 			})
 			logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic decode error")
+			c.Abort()
 			return
 		}
 

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -19,10 +19,7 @@ import (
 // AnthropicMessagesV1Beta implements beta messages API
 func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, proxyModel string, provider *typ.Provider, actualModel string, rule *typ.Rule) {
 
-	// Get or create recorder for dual-stage recording (when V2 flag is enabled)
-	var recorder *ProtocolRecorder
 	scenarioType := rule.GetScenario()
-	recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.recordMode)
 
 	// Check if streaming is requested
 	isStreaming := req.Stream
@@ -81,12 +78,15 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 		}
 	}
 
+	// Get or create recorder for dual-stage recording (when V2 flag is enabled)
+	var recorder *ProtocolRecorder
+	if s.ApplyRecording(scenarioType) {
+		recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.recordMode)
+	}
+
 	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		if recorder != nil {
-			recorder.RecordError(err)
-		}
 		return
 	}
 

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -16,10 +16,8 @@ import (
 
 // AnthropicMessagesV1 implements standard v1 messages API
 func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessagesRequest, proxyModel string, provider *typ.Provider, actualModel string, rule *typ.Rule) {
-	// Get or create recorder for dual-stage recording (when V2 flag is enabled)
-	var recorder *ProtocolRecorder
+
 	scenarioType := rule.GetScenario()
-	recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.recordMode)
 
 	// Check if streaming is requested
 	isStreaming := req.Stream
@@ -74,12 +72,15 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 		}
 	}
 
+	// Get or create recorder for dual-stage recording (when V2 flag is enabled)
+	var recorder *ProtocolRecorder
+	if s.ApplyRecording(scenarioType) {
+		recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.recordMode)
+	}
+
 	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		if recorder != nil {
-			recorder.RecordError(err)
-		}
 		return
 	}
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1493,8 +1493,6 @@ func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) boo
 		return flags.Smart
 	case "smart_compact":
 		return flags.SmartCompact
-	case "recording":
-		return flags.Recording
 	case "disable_stream_usage":
 		return flags.DisableStreamUsage
 	case "clean_header":
@@ -1559,8 +1557,6 @@ func (c *Config) SetScenarioFlag(scenario typ.RuleScenario, flagName string, val
 		config.Flags.Smart = value
 	case "smart_compact":
 		config.Flags.SmartCompact = value
-	case "recording":
-		config.Flags.Recording = value
 	case "disable_stream_usage":
 		config.Flags.DisableStreamUsage = value
 	case "clean_header":
@@ -1605,11 +1601,11 @@ func (c *Config) GetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 	flags := config.GetDefaultFlags()
 	switch flagName {
 	case "thinking_effort":
-		return string(flags.ThinkingEffort)
+		return flags.ThinkingEffort
 	case "thinking_mode":
 		return flags.ThinkingMode
-	case "record_v2":
-		return string(flags.RecordV2)
+	case "recording_v2":
+		return string(flags.RecordingV2)
 	default:
 		return ""
 	}
@@ -1646,11 +1642,11 @@ func (c *Config) SetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 		config.Flags.ThinkingEffort = typ.ThinkingEffortLevel(value)
 	case "thinking_mode":
 		config.Flags.ThinkingMode = value
-	case "record_v2":
+	case "recording_v2":
 		if !typ.IsValidRecordingMode(value) {
-			return fmt.Errorf("invalid record_v2 value: %s (must be one of: request, response, request_response, or empty)", value)
+			return fmt.Errorf("invalid recording_v2 value: %s (must be one of: request, response, request_response, or empty)", value)
 		}
-		config.Flags.RecordV2 = typ.RecordingMode(value)
+		config.Flags.RecordingV2 = typ.RecordingMode(value)
 	default:
 		return fmt.Errorf("unknown string flag name: %s", flagName)
 	}
@@ -1738,8 +1734,8 @@ func (c *Config) GetScenarioRecordingMode(scenario typ.RuleScenario) typ.Recordi
 
 	flags := config.GetDefaultFlags()
 
-	if flags.RecordV2 != typ.RecordingModeDisabled {
-		return flags.RecordV2
+	if flags.RecordingV2 != typ.RecordingModeDisabled {
+		return flags.RecordingV2
 	}
 
 	return typ.RecordingModeDisabled

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1491,7 +1491,7 @@ func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) boo
 		return flags.Separate
 	case "smart":
 		return flags.Smart
-	case "smart_compact":
+	case FeatureSmartCompact:
 		return flags.SmartCompact
 	case "disable_stream_usage":
 		return flags.DisableStreamUsage
@@ -1555,7 +1555,7 @@ func (c *Config) SetScenarioFlag(scenario typ.RuleScenario, flagName string, val
 		config.Flags.Separate = value
 	case "smart":
 		config.Flags.Smart = value
-	case "smart_compact":
+	case FeatureSmartCompact:
 		config.Flags.SmartCompact = value
 	case "disable_stream_usage":
 		config.Flags.DisableStreamUsage = value

--- a/internal/server/config/flag.go
+++ b/internal/server/config/flag.go
@@ -1,0 +1,6 @@
+package config
+
+// Experimental feature flag names
+const (
+	FeatureSmartCompact = "smart_compact"
+)

--- a/internal/server/experimental.go
+++ b/internal/server/experimental.go
@@ -1,29 +1,17 @@
 package server
 
 import (
+	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// Experimental feature flag names
-const (
-	ExperimentalFeatureSmartCompact = "smart_compact"
-	ExperimentalFeatureRecording    = "recording"
-)
-
-// IsExperimentalFeatureEnabled checks if an experimental feature is enabled for a scenario
-func (s *Server) IsExperimentalFeatureEnabled(scenario typ.RuleScenario, feature string) bool {
-	if s.config == nil {
-		return false
-	}
-	return s.config.GetScenarioFlag(scenario, feature)
-}
-
 // ApplySmartCompact checks if smart_compact should be applied for a scenario
 func (s *Server) ApplySmartCompact(scenario typ.RuleScenario) bool {
-	return s.IsExperimentalFeatureEnabled(scenario, ExperimentalFeatureSmartCompact)
+	return s.config.GetScenarioFlag(scenario, config.FeatureSmartCompact)
+
 }
 
 // ApplyRecording checks if recording should be applied for a scenario
 func (s *Server) ApplyRecording(scenario typ.RuleScenario) bool {
-	return s.IsExperimentalFeatureEnabled(scenario, ExperimentalFeatureRecording)
+	return s.config.IsScenarioRecordingEnabled(scenario)
 }

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -63,13 +63,12 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		path := c.Request.URL.Path
 		raw := c.Request.URL.RawQuery
 
-		// Wrap request body to capture content for logging while still allowing
-		// downstream handlers to read it. This is a tee-style reader that doesn't
-		// block or fail - if capture fails, the request continues normally.
+		// Capture request body using TeeReader for logging.
+		// We ALWAYS read (to support error debugging), but only STORE on errors (4xx/5xx).
+		// This minimizes storage overhead while keeping logging capability.
 		var bodyBuffer *bytes.Buffer
 		if m.requestBodyStore != nil && c.Request.Body != nil && c.Request.Method != "GET" && c.Request.Method != "HEAD" {
 			bodyBuffer = &bytes.Buffer{}
-			// TeeReader copies reads to both bodyBuffer and the original body
 			teeReader := io.TeeReader(c.Request.Body, bodyBuffer)
 			c.Request.Body = io.NopCloser(teeReader)
 		}
@@ -128,9 +127,9 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 			"user_agent": c.Request.UserAgent(),
 		}
 
-		// Add body reference if request body was captured
-		// This is done after c.Next() so we have the complete body
-		if bodyBuffer != nil && bodyBuffer.Len() > 0 {
+		// Add body reference - ONLY for error responses (4xx/5xx) to minimize storage overhead
+		// Happy path (2xx) requests don't store body, saving memory and CPU
+		if bodyBuffer != nil && statusCode >= 400 && bodyBuffer.Len() > 0 {
 			bodyRef := m.requestBodyStore.Store(method, path, bodyBuffer.String(), MaxRequestBodySize)
 			fields["body_ref"] = bodyRef
 		}

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -63,23 +63,15 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		path := c.Request.URL.Path
 		raw := c.Request.URL.RawQuery
 
-		// Read request body for storage (before it's consumed by handlers)
-		var bodyRef string
+		// Wrap request body to capture content for logging while still allowing
+		// downstream handlers to read it. This is a tee-style reader that doesn't
+		// block or fail - if capture fails, the request continues normally.
+		var bodyBuffer *bytes.Buffer
 		if m.requestBodyStore != nil && c.Request.Body != nil && c.Request.Method != "GET" && c.Request.Method != "HEAD" {
-			bodyBytes, err := io.ReadAll(c.Request.Body)
-			if err != nil {
-				// Log the error but continue processing
-				logrus.WithFields(logrus.Fields{
-					"method": c.Request.Method,
-					"path":   c.Request.URL.Path,
-					"error":  err.Error(),
-				}).Warn("Failed to read request body for storage")
-			} else if len(bodyBytes) > 0 {
-				// Store body and get reference ID
-				bodyRef = m.requestBodyStore.Store(c.Request.Method, c.Request.URL.Path, string(bodyBytes), MaxRequestBodySize)
-				// Restore body for downstream handlers
-				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			}
+			bodyBuffer = &bytes.Buffer{}
+			// TeeReader copies reads to both bodyBuffer and the original body
+			teeReader := io.TeeReader(c.Request.Body, bodyBuffer)
+			c.Request.Body = io.NopCloser(teeReader)
 		}
 
 		// Wrap response writer to capture body for error responses
@@ -136,8 +128,10 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 			"user_agent": c.Request.UserAgent(),
 		}
 
-		// Add body reference if request body was stored
-		if bodyRef != "" {
+		// Add body reference if request body was captured
+		// This is done after c.Next() so we have the complete body
+		if bodyBuffer != nil && bodyBuffer.Len() > 0 {
+			bodyRef := m.requestBodyStore.Store(method, path, bodyBuffer.String(), MaxRequestBodySize)
 			fields["body_ref"] = bodyRef
 		}
 

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -135,8 +135,7 @@ type ScenarioFlags struct {
 
 	// Experimental feature flags (scenario-based opt-in)
 	SmartCompact bool          `json:"smart_compact,omitempty" yaml:"smart_compact,omitempty"`   // Enable smart compact (remove thinking blocks)
-	Recording    bool          `json:"recording,omitempty" yaml:"recording,omitempty"`           // Enable scenario recording (legacy boolean flag)
-	RecordV2     RecordingMode `json:"record_v2,omitempty" yaml:"record_v2,omitempty"`           // Enable scenario recording V2 (request/response/request_response)
+	RecordingV2  RecordingMode `json:"recording_v2,omitempty" yaml:"recording_v2,omitempty"`     // Enable scenario recording V2 (request/response/request_response)
 	Beta         bool          `json:"anthropic_beta,omitempty" yaml:"anthropic_beta,omitempty"` // Enable Anthropic beta features (e.g. extended thinking)
 
 	// Stream configuration flags

--- a/openapi.json
+++ b/openapi.json
@@ -7679,9 +7679,9 @@
             "type": "boolean",
             "description": "Field disable_stream_usage"
           },
-          "record_v2": {
+          "recording_v2": {
             "type": "string",
-            "description": "Field record_v2"
+            "description": "Field recording_v2"
           },
           "recording": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
Recording sinks were being created for all Anthropic API requests regardless of whether recording was enabled, causing unnecessary memory allocation and CPU overhead.

### Major
- Recording sinks now only created when `ApplyRecording()` returns true
- Reduces memory allocation and improves performance for non-recording scenarios
- Recording logic unified across Anthropic v1 and beta API handlers

### Minor
- Renamed `record_v2` flag to `recording_v2` for consistency
- Removed legacy boolean `recording` flag in favor of mode-based recording
- Added `c.Abort()` calls after decode errors for proper request termination
- Added `config.FeatureSmartCompact` constant to replace magic strings
- Changed request body logging to use TeeReader (only store on errors)
- Fixed type conversion for `ThinkingEffort` (no longer string())