### PR TITLE
feat(harness): add matrix filtering, server modes, and batch testing

### DIFF
--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
@@ -15,6 +16,7 @@ type matrixOptions struct {
 	nonStream  bool
 	jsonOutput bool
 	verbose    int
+	recordDir  string // Directory for recording requests/responses
 }
 
 // newMatrixCommand creates the matrix test subcommand.
@@ -62,6 +64,7 @@ Use flags to filter specific combinations.`,
 	cmd.Flags().BoolVar(&opts.nonStream, "non-streaming", false, "Run only non-streaming tests")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().CountVarP(&opts.verbose, "verbose", "v", "Verbose output (can repeat for more detail)")
+	cmd.Flags().StringVar(&opts.recordDir, "record-dir", os.Getenv("HARNESS_RECORD_DIR"), "Directory for recording requests/responses (default: disabled)")
 
 	return cmd
 }
@@ -73,6 +76,11 @@ func runMatrix(opts *matrixOptions) error {
 
 	if len(opts.scenarios) > 0 {
 		matrix = matrix.OnlyScenarios(opts.scenarios...)
+	}
+
+	// Set record directory if provided
+	if opts.recordDir != "" {
+		matrix = matrix.WithRecordDir(opts.recordDir)
 	}
 
 	// Resolve streaming filter

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -92,8 +92,21 @@ func runMatrix(opts *matrixOptions) error {
 	// Build matrix with filters
 	matrix := protocol_validate.DefaultMatrix()
 
+	// Apply filters to limit execution (not just display)
 	if len(opts.scenarios) > 0 {
 		matrix = matrix.OnlyScenarios(opts.scenarios...)
+	}
+	if len(opts.sources) > 0 {
+		matrix = matrix.OnlySources(opts.sources...)
+	}
+	if len(opts.targets) > 0 {
+		matrix = matrix.OnlyTargets(opts.targets...)
+	}
+	if opts.streaming {
+		matrix = matrix.OnlyStreaming(true)
+	}
+	if opts.nonStream {
+		matrix = matrix.OnlyStreaming(false)
 	}
 
 	// Set record directory if provided
@@ -111,15 +124,17 @@ func runMatrix(opts *matrixOptions) error {
 		matrix = matrix.WithBatchCount(opts.batchCount)
 	}
 
-	// Resolve streaming filter
+	// Resolve streaming filter conflict
 	if opts.streaming && opts.nonStream {
 		return fmt.Errorf("cannot specify both --streaming and --non-streaming")
 	}
 
-	// Execute all tests
+	// Execute tests (only filtered combinations)
 	results := matrix.ExecuteAll()
 
-	// Filter results by options
+	// Note: No need to filter results here since we filtered before execution
+	// But keep filterResults for backward compatibility in case results contain
+	// additional entries from skipPairs or skipSourceScenarios
 	results = filterResults(results, opts)
 
 	// Output results

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -18,6 +18,8 @@ type matrixOptions struct {
 	jsonOutput bool
 	verbose    int
 	recordDir  string // Directory for recording requests/responses
+	serverMode string // Server reuse mode: auto (per-scenario), all, pair
+	batchCount int    // Number of times to run each test (for batch testing)
 }
 
 // newMatrixCommand creates the matrix test subcommand.
@@ -66,6 +68,8 @@ Use flags to filter specific combinations.`,
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().CountVarP(&opts.verbose, "verbose", "v", "Verbose output (can repeat for more detail)")
 	cmd.Flags().StringVar(&opts.recordDir, "record-dir", os.Getenv("HARNESS_RECORD_DIR"), "Directory for recording requests/responses (default: disabled)")
+	cmd.Flags().StringVar(&opts.serverMode, "server-mode", "auto", "Server reuse mode: auto (per-scenario), all (single server), pair (per source-target)")
+	cmd.Flags().IntVar(&opts.batchCount, "batch", 1, "Number of times to run each test (for stability/performance testing)")
 
 	return cmd
 }
@@ -95,6 +99,16 @@ func runMatrix(opts *matrixOptions) error {
 	// Set record directory if provided
 	if opts.recordDir != "" {
 		matrix = matrix.WithRecordDir(opts.recordDir)
+	}
+
+	// Set server mode
+	if opts.serverMode != "" && opts.serverMode != "auto" {
+		matrix = matrix.WithServerMode(opts.serverMode)
+	}
+
+	// Set batch count
+	if opts.batchCount > 1 {
+		matrix = matrix.WithBatchCount(opts.batchCount)
 	}
 
 	// Resolve streaming filter

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
 )
@@ -71,6 +72,19 @@ Use flags to filter specific combinations.`,
 
 // runMatrix executes the matrix tests with the given options.
 func runMatrix(opts *matrixOptions) error {
+	// Set log level based on verbose flag
+	// Default (v=0): Warn level - minimal output
+	// v=1: Info level - normal output
+	// v=2+: Debug level - detailed output
+	switch opts.verbose {
+	case 0:
+		logrus.SetLevel(logrus.WarnLevel)
+	case 1:
+		logrus.SetLevel(logrus.InfoLevel)
+	default:
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	// Build matrix with filters
 	matrix := protocol_validate.DefaultMatrix()
 

--- a/cli/harness/output.go
+++ b/cli/harness/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -18,8 +19,15 @@ func printTable(results []protocol_validate.TestResult, verbose int) {
 	// Summary
 	pass, fail, skip := countResults(results)
 	fmt.Printf("\n📊 Matrix Test Results\n")
-	fmt.Printf("Total: %d | ✓ Pass: %d | ✗ Fail: %d | ⊘ Skip: %d\n\n",
+	fmt.Printf("Total: %d | ✓ Pass: %d | ✗ Fail: %d | ⊘ Skip: %d\n",
 		len(results), pass, fail, skip)
+
+	// Device info
+	fmt.Printf("Host: %s/%s | CPUs: %d | Go: %s | Time: %s\n\n",
+		runtime.GOOS, runtime.GOARCH,
+		runtime.NumCPU(),
+		runtime.Version(),
+		time.Now().Format("2006-01-02 15:04:05"))
 
 	// Table header
 	fmt.Fprintln(w, "Scenario\tSource\tTarget\tStreaming\tStatus\tDuration")

--- a/cli/harness/output.go
+++ b/cli/harness/output.go
@@ -29,16 +29,28 @@ func printTable(results []protocol_validate.TestResult, verbose int) {
 		runtime.Version(),
 		time.Now().Format("2006-01-02 15:04:05"))
 
-	// Table header
-	fmt.Fprintln(w, "Scenario\tSource\tTarget\tStreaming\tStatus\tDuration")
-	fmt.Fprintln(w, "--------\t------\t------\t---------\t------\t--------")
+	// Table header - always show Duration (ms) for consistency
+	fmt.Fprintln(w, "Scenario\tSource\tTarget\tStreaming\tStatus\tDuration (ms)")
+	fmt.Fprintln(w, "--------\t------\t------\t---------\t------\t-------------")
 
 	for _, r := range results {
-		status := "✓ PASS"
+		// Unified status format: always show N/M
+		batchCount := r.BatchCount
+		if batchCount == 0 {
+			batchCount = 1
+		}
+		batchPassed := r.BatchPassed
+		if batchPassed == 0 && r.Passed {
+			batchPassed = batchCount
+		}
+
+		var status string
 		if r.Skipped {
 			status = fmt.Sprintf("⊘ SKIP: %s", truncateString(r.SkipReason, 30))
-		} else if !r.Passed {
-			status = "✗ FAIL"
+		} else if r.Passed {
+			status = fmt.Sprintf("✓ PASS %d/%d", batchPassed, batchCount)
+		} else {
+			status = fmt.Sprintf("✗ FAIL %d/%d", batchPassed, batchCount)
 		}
 
 		streaming := "no"
@@ -46,13 +58,27 @@ func printTable(results []protocol_validate.TestResult, verbose int) {
 			streaming = "yes"
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Scenario,
-			r.Source,
-			r.Target,
-			streaming,
-			status,
-			r.Duration.Round(time.Millisecond))
+		if batchCount > 1 {
+			// Batch mode: show min/avg/max
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\tmin:%s avg:%s max:%s\n",
+				r.Scenario,
+				r.Source,
+				r.Target,
+				streaming,
+				status,
+				r.BatchMinDur.Round(time.Millisecond),
+				r.BatchAvgDur.Round(time.Millisecond),
+				r.BatchMaxDur.Round(time.Millisecond))
+		} else {
+			// Single mode (batch=1): show just the duration
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				r.Scenario,
+				r.Source,
+				r.Target,
+				streaming,
+				status,
+				r.Duration.Round(time.Millisecond))
+		}
 	}
 
 	w.Flush()

--- a/internal/obs/sink.go
+++ b/internal/obs/sink.go
@@ -116,6 +116,11 @@ func NewSink(baseDir string, mode RecordMode) *Sink {
 	case RecordModeAll, RecordModeScenario,
 		RecordModeRequest, RecordModeResponse, RecordModeV2RequestResponse:
 
+		// Empty baseDir means recording is disabled
+		if baseDir == "" {
+			return nil
+		}
+
 		// Ensure base directory exists
 		if err := os.MkdirAll(baseDir, 0755); err != nil {
 			logrus.Errorf("Failed to create record directory %s: %v", baseDir, err)

--- a/internal/protocol_validate/agent_scenario.go
+++ b/internal/protocol_validate/agent_scenario.go
@@ -1,7 +1,6 @@
 package protocol_validate
 
 import (
-	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/server_validate"
 )
 
@@ -16,7 +15,7 @@ type AgentScenario struct {
 	Description string
 
 	// MockResponses are the mock responses keyed by API style
-	MockResponses map[server_validate.APIStyle]server_validate.MockResponseBuilder
+	MockResponses map[server_validate.ResponseFormat]server_validate.MockResponseBuilder
 }
 
 // AgentScenarios returns all built-in profile test scenarios
@@ -33,8 +32,8 @@ func AgentTextScenario() AgentScenario {
 	return AgentScenario{
 		Name:        "text",
 		Description: "Basic text message request and response",
-		MockResponses: map[server_validate.APIStyle]server_validate.MockResponseBuilder{
-			protocol.APIStyleAnthropic: {
+		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
+			server_validate.FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello, world!"}],"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":5}}`)
 				},
@@ -64,7 +63,7 @@ func AgentTextScenario() AgentScenario {
 					}
 				},
 			},
-			protocol.APIStyleOpenAI: {
+			server_validate.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello, world!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
 				},
@@ -96,8 +95,8 @@ func AgentToolUseScenario() AgentScenario {
 	return AgentScenario{
 		Name:        "tool_use",
 		Description: "Tool use request and response",
-		MockResponses: map[server_validate.APIStyle]server_validate.MockResponseBuilder{
-			protocol.APIStyleAnthropic: {
+		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
+			server_validate.FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg_456","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_123","name":"bash","input":{"command":"echo 'hello'"}}],"model":"claude-3-5-sonnet-20241022","stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":20}}`)
 				},
@@ -127,7 +126,7 @@ func AgentToolUseScenario() AgentScenario {
 					}
 				},
 			},
-			protocol.APIStyleOpenAI: {
+			server_validate.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-456","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_123","type":"function","function":{"name":"bash","arguments":"{\"command\":\"echo 'hello'\"}"}}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
 				},

--- a/internal/protocol_validate/matrix.go
+++ b/internal/protocol_validate/matrix.go
@@ -12,12 +12,21 @@ import (
 // Matrix defines the cross-product of source protocols, target protocols,
 // scenarios, and streaming modes to validate.
 type Matrix struct {
-	Sources   []protocol.APIType
-	Targets   []protocol.APIType
-	Scenarios []Scenario
-	Streaming []bool
-	RecordDir string // Optional directory for recording requests/responses
+	Sources    []protocol.APIType
+	Targets    []protocol.APIType
+	Scenarios  []Scenario
+	Streaming  []bool
+	RecordDir  string // Optional directory for recording requests/responses
+	ServerMode string // Server reuse mode: auto, all, pair
+	BatchCount int    // Number of times to run each test
 }
+
+// ServerMode constants
+const (
+	ServerModeAuto = "auto" // Per-scenario (default)
+	ServerModeAll  = "all"  // Single server for all tests
+	ServerModePair = "pair" // Per source-target pair
+)
 
 // DefaultMatrix returns the full validation matrix covering all supported
 // protocol combinations, all built-in scenarios, and both streaming modes.
@@ -56,11 +65,13 @@ func (m *Matrix) OnlyScenarios(names ...string) *Matrix {
 	}
 
 	return &Matrix{
-		Sources:   m.Sources,
-		Targets:   m.Targets,
-		Scenarios: filtered,
-		Streaming: m.Streaming,
-		RecordDir: m.RecordDir,
+		Sources:    m.Sources,
+		Targets:    m.Targets,
+		Scenarios:  filtered,
+		Streaming:  m.Streaming,
+		RecordDir:  m.RecordDir,
+		ServerMode: m.ServerMode,
+		BatchCount: m.BatchCount,
 	}
 }
 
@@ -68,11 +79,39 @@ func (m *Matrix) OnlyScenarios(names ...string) *Matrix {
 // If recordDir is empty, recording is disabled.
 func (m *Matrix) WithRecordDir(recordDir string) *Matrix {
 	return &Matrix{
-		Sources:   m.Sources,
-		Targets:   m.Targets,
-		Scenarios: m.Scenarios,
-		Streaming: m.Streaming,
-		RecordDir: recordDir,
+		Sources:    m.Sources,
+		Targets:    m.Targets,
+		Scenarios:  m.Scenarios,
+		Streaming:  m.Streaming,
+		RecordDir:  m.RecordDir,
+		ServerMode: m.ServerMode,
+		BatchCount: m.BatchCount,
+	}
+}
+
+// WithServerMode returns a copy of the Matrix with the server reuse mode set.
+func (m *Matrix) WithServerMode(mode string) *Matrix {
+	return &Matrix{
+		Sources:    m.Sources,
+		Targets:    m.Targets,
+		Scenarios:  m.Scenarios,
+		Streaming:  m.Streaming,
+		RecordDir:  m.RecordDir,
+		ServerMode: mode,
+		BatchCount: m.BatchCount,
+	}
+}
+
+// WithBatchCount returns a copy of the Matrix with the batch count set.
+func (m *Matrix) WithBatchCount(count int) *Matrix {
+	return &Matrix{
+		Sources:    m.Sources,
+		Targets:    m.Targets,
+		Scenarios:  m.Scenarios,
+		Streaming:  m.Streaming,
+		RecordDir:  m.RecordDir,
+		ServerMode: m.ServerMode,
+		BatchCount: count,
 	}
 }
 
@@ -191,9 +230,27 @@ func truncate(s string, max int) string {
 // This is a pure function that can be called from both tests and CLI.
 // It does not use testing.T, making it suitable for standalone execution.
 //
-// Optimization: Reuses TestEnv per scenario to reduce server startup overhead.
-// Each scenario creates one TestEnv that is reused for all its combinations.
+// Server reuse strategies based on ServerMode:
+// - auto (default): Reuses TestEnv per scenario
+// - all: Uses a single TestEnv for all tests (fastest, potential for interference)
+// - pair: Reuses TestEnv per source-target pair (balanced approach)
 func (m *Matrix) ExecuteAll() []TestResult {
+	var results []TestResult
+
+	switch m.ServerMode {
+	case ServerModeAll:
+		results = m.executeAllWithSingleServer()
+	case ServerModePair:
+		results = m.executeAllWithPairServer()
+	default: // ServerModeAuto
+		results = m.executeAllWithScenarioServer()
+	}
+
+	return results
+}
+
+// executeAllWithScenarioServer executes tests with per-scenario server reuse (default).
+func (m *Matrix) executeAllWithScenarioServer() []TestResult {
 	var results []TestResult
 
 	// For each scenario, create one TestEnv and reuse it for all combinations
@@ -224,74 +281,15 @@ func (m *Matrix) ExecuteAll() []TestResult {
 			}
 			continue
 		}
+		defer env.Close()
 
 		// Run all combinations for this scenario
 		for _, source := range m.Sources {
-			source := source
 			for _, target := range m.Targets {
-				target := target
 				for _, streaming := range m.Streaming {
-					streaming := streaming
-
-					// Check skip conditions first
-					pairKey := fmt.Sprintf("%s|%s", source, target)
-					if reason, skip := skipPairs[pairKey]; skip {
-						results = append(results, TestResult{
-							Name:       m.buildTestName(scenario.Name, source, target, streaming),
-							Scenario:   scenario.Name,
-							Source:     source,
-							Target:     target,
-							Streaming:  streaming,
-							Skipped:    true,
-							SkipReason: reason,
-						})
-						continue
+					if result := m.executeTest(env, scenario, source, target, streaming); result != nil {
+						results = append(results, *result)
 					}
-
-					srcScenarioKey := fmt.Sprintf("%s|%s", source, scenario.Name)
-					if reason, skip := skipSourceScenarios[srcScenarioKey]; skip {
-						results = append(results, TestResult{
-							Name:       m.buildTestName(scenario.Name, source, target, streaming),
-							Scenario:   scenario.Name,
-							Source:     source,
-							Target:     target,
-							Streaming:  streaming,
-							Skipped:    true,
-							SkipReason: reason,
-						})
-						continue
-					}
-
-					// Check streaming compatibility
-					if streaming && !scenarioSupportsStreaming(scenario) {
-						results = append(results, TestResult{
-							Name:       m.buildTestName(scenario.Name, source, target, streaming),
-							Scenario:   scenario.Name,
-							Source:     source,
-							Target:     target,
-							Streaming:  streaming,
-							Skipped:    true,
-							SkipReason: "scenario does not support streaming",
-						})
-						continue
-					}
-
-					if !streaming && scenarioRequiresStreaming(scenario) {
-						results = append(results, TestResult{
-							Name:       m.buildTestName(scenario.Name, source, target, streaming),
-							Scenario:   scenario.Name,
-							Source:     source,
-							Target:     target,
-							Streaming:  streaming,
-							Skipped:    true,
-							SkipReason: "scenario requires streaming mode",
-						})
-						continue
-					}
-
-					// Execute test with shared env
-					result := m.executeOneWithEnv(env, scenario, source, target, streaming)
-					results = append(results, result)
 				}
 			}
 		}
@@ -300,6 +298,192 @@ func (m *Matrix) ExecuteAll() []TestResult {
 		env.Close()
 	}
 
+	return results
+}
+
+// executeAllWithSingleServer executes all tests with a single server.
+func (m *Matrix) executeAllWithSingleServer() []TestResult {
+	var results []TestResult
+
+	// Create a single TestEnv for all tests
+	env, err := NewTestEnvForCLI(NewTestEnvOptionWithRecordDir(m.RecordDir))
+	if err != nil {
+		// All tests fail with setup error
+		return m.allSetupError(err)
+	}
+	defer env.Close()
+
+	// Run all combinations
+	for _, scenario := range m.Scenarios {
+		for _, source := range m.Sources {
+			for _, target := range m.Targets {
+				for _, streaming := range m.Streaming {
+					if result := m.executeTest(env, scenario, source, target, streaming); result != nil {
+						results = append(results, *result)
+					}
+				}
+			}
+		}
+	}
+
+	return results
+}
+
+// executeAllWithPairServer executes tests with per source-target pair server reuse.
+func (m *Matrix) executeAllWithPairServer() []TestResult {
+	var results []TestResult
+
+	// For each source-target pair, create one TestEnv
+	for _, source := range m.Sources {
+		for _, target := range m.Targets {
+			pairKey := fmt.Sprintf("%s|%s", source, target)
+
+			// Check if this pair is skipped
+			if reason, skip := skipPairs[pairKey]; skip {
+				// All scenarios for this pair are skipped
+				for _, scenario := range m.Scenarios {
+					for _, streaming := range m.Streaming {
+						results = append(results, TestResult{
+							Name:       m.buildTestName(scenario.Name, source, target, streaming),
+							Scenario:   scenario.Name,
+							Source:     source,
+							Target:     target,
+							Streaming:  streaming,
+							Skipped:    true,
+							SkipReason: reason,
+						})
+					}
+				}
+				continue
+			}
+
+			// Create TestEnv for this pair
+			env, err := NewTestEnvForCLI(NewTestEnvOptionWithRecordDir(m.RecordDir))
+			if err != nil {
+				// All tests for this pair fail with setup error
+				for _, scenario := range m.Scenarios {
+					for _, streaming := range m.Streaming {
+						results = append(results, TestResult{
+							Name:      m.buildTestName(scenario.Name, source, target, streaming),
+							Scenario:  scenario.Name,
+							Source:    source,
+							Target:    target,
+							Streaming: streaming,
+							Passed:    false,
+							Errors: []AssertionError{{
+								Assertion: "setup",
+								Error:     fmt.Sprintf("failed to create test env: %v", err),
+							}},
+						})
+					}
+				}
+				continue
+			}
+			defer env.Close()
+
+			// Run all scenarios for this pair
+			for _, scenario := range m.Scenarios {
+				for _, streaming := range m.Streaming {
+					if result := m.executeTest(env, scenario, source, target, streaming); result != nil {
+						results = append(results, *result)
+					}
+				}
+			}
+
+			env.Close()
+		}
+	}
+
+	return results
+}
+
+// executeTest executes a single test with the given environment.
+// Returns nil if the test should be skipped.
+func (m *Matrix) executeTest(env *TestEnv, scenario Scenario, source, target protocol.APIType, streaming bool) *TestResult {
+	// Check skip conditions first
+	pairKey := fmt.Sprintf("%s|%s", source, target)
+	if reason, skip := skipPairs[pairKey]; skip {
+		return &TestResult{
+			Name:       m.buildTestName(scenario.Name, source, target, streaming),
+			Scenario:   scenario.Name,
+			Source:     source,
+			Target:     target,
+			Streaming:  streaming,
+			Skipped:    true,
+			SkipReason: reason,
+		}
+	}
+
+	srcScenarioKey := fmt.Sprintf("%s|%s", source, scenario.Name)
+	if reason, skip := skipSourceScenarios[srcScenarioKey]; skip {
+		return &TestResult{
+			Name:       m.buildTestName(scenario.Name, source, target, streaming),
+			Scenario:   scenario.Name,
+			Source:     source,
+			Target:     target,
+			Streaming:  streaming,
+			Skipped:    true,
+			SkipReason: reason,
+		}
+	}
+
+	// Check streaming compatibility
+	if streaming && !scenarioSupportsStreaming(scenario) {
+		return &TestResult{
+			Name:       m.buildTestName(scenario.Name, source, target, streaming),
+			Scenario:   scenario.Name,
+			Source:     source,
+			Target:     target,
+			Streaming:  streaming,
+			Skipped:    true,
+			SkipReason: "scenario does not support streaming",
+		}
+	}
+
+	if !streaming && scenarioRequiresStreaming(scenario) {
+		return &TestResult{
+			Name:       m.buildTestName(scenario.Name, source, target, streaming),
+			Scenario:   scenario.Name,
+			Source:     source,
+			Target:     target,
+			Streaming:  streaming,
+			Skipped:    true,
+			SkipReason: "scenario requires streaming mode",
+		}
+	}
+
+	// Execute test (with batch if requested)
+	if m.BatchCount > 1 {
+		return m.executeBatch(env, scenario, source, target, streaming)
+	}
+
+	result := m.executeOneWithEnv(env, scenario, source, target, streaming)
+	return &result
+}
+
+// allSetupError returns results all marked as setup errors.
+func (m *Matrix) allSetupError(err error) []TestResult {
+	var results []TestResult
+	for _, scenario := range m.Scenarios {
+		for _, source := range m.Sources {
+			for _, target := range m.Targets {
+				for _, streaming := range m.Streaming {
+					results = append(results, TestResult{
+						Name:      m.buildTestName(scenario.Name, source, target, streaming),
+						Scenario:  scenario.Name,
+						Source:    source,
+						Target:    target,
+						Streaming: streaming,
+						Passed:    false,
+						Errors: []AssertionError{{
+							Assertion: "setup",
+							Error:     fmt.Sprintf("failed to create test env: %v", err),
+						}},
+					})
+				}
+			}
+		}
+	}
 	return results
 }
 
@@ -430,4 +614,71 @@ func (m *Matrix) buildTestName(scenario string, source, target protocol.APIType,
 		mode = "stream"
 	}
 	return fmt.Sprintf("%s/%s/%s/%s", scenario, source, target, mode)
+}
+
+// executeBatch runs a test multiple times and aggregates the results.
+func (m *Matrix) executeBatch(env *TestEnv, scenario Scenario, source, target protocol.APIType, streaming bool) *TestResult {
+	name := m.buildTestName(scenario.Name, source, target, streaming)
+
+	var results []TestResult
+	var totalDur time.Duration
+	var minDur, maxDur time.Duration
+	passedCount := 0
+	uniqueErrors := make(map[string]bool)
+
+	// Run the test N times
+	for i := 0; i < m.BatchCount; i++ {
+		result := m.executeOneWithEnv(env, scenario, source, target, streaming)
+		results = append(results, result)
+
+		totalDur += result.Duration
+		if i == 0 || result.Duration < minDur {
+			minDur = result.Duration
+		}
+		if i == 0 || result.Duration > maxDur {
+			maxDur = result.Duration
+		}
+
+		if result.Passed {
+			passedCount++
+		} else {
+			for _, e := range result.Errors {
+				uniqueErrors[e.Error] = true
+			}
+		}
+	}
+
+	// Build aggregated result
+	var errorList []string
+	for err := range uniqueErrors {
+		errorList = append(errorList, err)
+	}
+
+	avgDur := totalDur / time.Duration(m.BatchCount)
+	allPassed := passedCount == m.BatchCount
+
+	// Use the last result's response for debugging (or first if preferred)
+	var response *RoundTripResult
+	if len(results) > 0 {
+		response = results[len(results)-1].Response
+	}
+
+	return &TestResult{
+		Name:        name,
+		Scenario:    scenario.Name,
+		Source:      source,
+		Target:      target,
+		Streaming:   streaming,
+		Passed:      allPassed,
+		Skipped:     false,
+		Duration:    avgDur, // Use average for primary duration
+		BatchCount:  m.BatchCount,
+		BatchPassed: passedCount,
+		BatchMinDur: minDur,
+		BatchAvgDur: avgDur,
+		BatchMaxDur: maxDur,
+		BatchErrors: errorList,
+		HTTPStatus:  0, // Not meaningful for batch
+		Response:    response,
+	}
 }

--- a/internal/protocol_validate/matrix.go
+++ b/internal/protocol_validate/matrix.go
@@ -16,6 +16,7 @@ type Matrix struct {
 	Targets   []protocol.APIType
 	Scenarios []Scenario
 	Streaming []bool
+	RecordDir string // Optional directory for recording requests/responses
 }
 
 // DefaultMatrix returns the full validation matrix covering all supported
@@ -59,6 +60,19 @@ func (m *Matrix) OnlyScenarios(names ...string) *Matrix {
 		Targets:   m.Targets,
 		Scenarios: filtered,
 		Streaming: m.Streaming,
+		RecordDir: m.RecordDir,
+	}
+}
+
+// WithRecordDir returns a copy of the Matrix with the record directory set.
+// If recordDir is empty, recording is disabled.
+func (m *Matrix) WithRecordDir(recordDir string) *Matrix {
+	return &Matrix{
+		Sources:   m.Sources,
+		Targets:   m.Targets,
+		Scenarios: m.Scenarios,
+		Streaming: m.Streaming,
+		RecordDir: recordDir,
 	}
 }
 
@@ -187,7 +201,7 @@ func (m *Matrix) ExecuteAll() []TestResult {
 		scenario := scenario
 
 		// Create TestEnv for this scenario
-		env, err := NewTestEnvForCLI()
+		env, err := NewTestEnvForCLI(NewTestEnvOptionWithRecordDir(m.RecordDir))
 		if err != nil {
 			// All tests for this scenario fail with setup error
 			for _, source := range m.Sources {

--- a/internal/protocol_validate/matrix.go
+++ b/internal/protocol_validate/matrix.go
@@ -75,6 +75,71 @@ func (m *Matrix) OnlyScenarios(names ...string) *Matrix {
 	}
 }
 
+// OnlySources returns a copy of the Matrix filtered to only the specified source protocols.
+func (m *Matrix) OnlySources(sources ...string) *Matrix {
+	sourceSet := make(map[protocol.APIType]bool, len(sources))
+	for _, s := range sources {
+		sourceSet[protocol.APIType(s)] = true
+	}
+
+	filtered := make([]protocol.APIType, 0, len(sources))
+	for _, s := range m.Sources {
+		if sourceSet[s] {
+			filtered = append(filtered, s)
+		}
+	}
+
+	return &Matrix{
+		Sources:    filtered,
+		Targets:    m.Targets,
+		Scenarios:  m.Scenarios,
+		Streaming:  m.Streaming,
+		RecordDir:  m.RecordDir,
+		ServerMode: m.ServerMode,
+		BatchCount: m.BatchCount,
+	}
+}
+
+// OnlyTargets returns a copy of the Matrix filtered to only the specified target protocols.
+func (m *Matrix) OnlyTargets(targets ...string) *Matrix {
+	targetSet := make(map[protocol.APIType]bool, len(targets))
+	for _, t := range targets {
+		targetSet[protocol.APIType(t)] = true
+	}
+
+	filtered := make([]protocol.APIType, 0, len(targets))
+	for _, t := range m.Targets {
+		if targetSet[t] {
+			filtered = append(filtered, t)
+		}
+	}
+
+	return &Matrix{
+		Sources:    m.Sources,
+		Targets:    filtered,
+		Scenarios:  m.Scenarios,
+		Streaming:  m.Streaming,
+		RecordDir:  m.RecordDir,
+		ServerMode: m.ServerMode,
+		BatchCount: m.BatchCount,
+	}
+}
+
+// OnlyStreaming returns a copy of the Matrix filtered to only streaming or non-streaming tests.
+// If streaming is true, only streaming tests are included. If false, only non-streaming tests.
+func (m *Matrix) OnlyStreaming(streaming bool) *Matrix {
+	filtered := []bool{streaming}
+	return &Matrix{
+		Sources:    m.Sources,
+		Targets:    m.Targets,
+		Scenarios:  m.Scenarios,
+		Streaming:  filtered,
+		RecordDir:  m.RecordDir,
+		ServerMode: m.ServerMode,
+		BatchCount: m.BatchCount,
+	}
+}
+
 // WithRecordDir returns a copy of the Matrix with the record directory set.
 // If recordDir is empty, recording is disabled.
 func (m *Matrix) WithRecordDir(recordDir string) *Matrix {
@@ -181,7 +246,7 @@ func (m *Matrix) Run(t *testing.T) {
 
 									env.SetupRoute(source, target, scenario)
 
-									result := env.SendAs(t, source, scenario, streaming)
+									result := env.SendAs(t, source, target, scenario, streaming)
 
 									for _, a := range scenario.Assertions {
 										if err := a.Check(result); err != nil {
@@ -511,7 +576,7 @@ func (m *Matrix) executeOne(s Scenario, source, target protocol.APIType, streami
 	defer env.Close()
 
 	env.SetupRoute(source, target, s)
-	result, err := env.SendAsCLI(source, s, streaming)
+	result, err := env.SendAsCLI(source, target, s, streaming)
 	if err != nil {
 		return TestResult{
 			Name:      m.buildTestName(s.Name, source, target, streaming),
@@ -562,7 +627,7 @@ func (m *Matrix) executeOneWithEnv(env *TestEnv, s Scenario, source, target prot
 	start := time.Now()
 
 	env.SetupRoute(source, target, s)
-	result, err := env.SendAsCLI(source, s, streaming)
+	result, err := env.SendAsCLI(source, target, s, streaming)
 	if err != nil {
 		return TestResult{
 			Name:      m.buildTestName(s.Name, source, target, streaming),

--- a/internal/protocol_validate/roundtrip_test.go
+++ b/internal/protocol_validate/roundtrip_test.go
@@ -19,7 +19,7 @@ func TestRoundTrip_AnthropicV1_To_OpenAIChat_Text(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.TextScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.TextScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.TextScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.Equal(t, "assistant", result.Role)
@@ -35,7 +35,7 @@ func TestRoundTrip_AnthropicBeta_To_OpenAIResponses_Text(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.TextScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicBeta, pt.TextScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.TextScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.Equal(t, "assistant", result.Role)
@@ -48,7 +48,7 @@ func TestRoundTrip_OpenAIChat_To_AnthropicV1_Text(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeOpenAIChat, protocol.TypeAnthropicV1, pt.TextScenario())
 
-	result := env.SendAs(t, protocol.TypeOpenAIChat, pt.TextScenario(), false)
+	result := env.SendAs(t, protocol.TypeOpenAIChat, protocol.TypeAnthropicV1, pt.TextScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.Equal(t, "assistant", result.Role)
@@ -62,7 +62,7 @@ func TestRoundTrip_AnthropicV1_To_OpenAIChat_ToolUse(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.ToolUseScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.ToolUseScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.ToolUseScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	require.Len(t, result.ToolCalls, 1)
@@ -77,7 +77,7 @@ func TestRoundTrip_AnthropicBeta_To_OpenAIChat_ToolUse(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicBeta, protocol.TypeOpenAIChat, pt.ToolUseScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicBeta, pt.ToolUseScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeOpenAIChat, pt.ToolUseScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	require.Len(t, result.ToolCalls, 1)
@@ -90,7 +90,7 @@ func TestRoundTrip_AnthropicV1_To_AnthropicV1_Thinking(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, pt.ThinkingScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.ThinkingScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, pt.ThinkingScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.NotEmpty(t, result.ThinkingContent)
@@ -103,7 +103,7 @@ func TestRoundTrip_AnthropicV1_To_OpenAIChat_Thinking(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.ThinkingScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.ThinkingScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.ThinkingScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.NotEmpty(t, result.Content)
@@ -115,7 +115,7 @@ func TestRoundTrip_AnthropicV1_To_OpenAIChat_MultiTurn(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.MultiTurnScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.MultiTurnScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.MultiTurnScenario(), false)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.Equal(t, "assistant", result.Role)
@@ -128,7 +128,7 @@ func TestRoundTrip_AnthropicV1_To_OpenAIChat_Streaming(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.StreamingTextScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.StreamingTextScenario(), true)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.StreamingTextScenario(), true)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.NotEmpty(t, result.StreamEvents)
@@ -141,7 +141,7 @@ func TestRoundTrip_AnthropicBeta_To_OpenAIChat_StreamingToolUse(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicBeta, protocol.TypeOpenAIChat, pt.StreamingToolUseScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicBeta, pt.StreamingToolUseScenario(), true)
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeOpenAIChat, pt.StreamingToolUseScenario(), true)
 
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.NotEmpty(t, result.StreamEvents)
@@ -155,7 +155,7 @@ func TestRoundTrip_ErrorPassthrough(t *testing.T) {
 
 	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.ErrorScenario())
 
-	result := env.SendAs(t, protocol.TypeAnthropicV1, pt.ErrorScenario(), false)
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, pt.ErrorScenario(), false)
 
 	assert.NotEqual(t, 200, result.HTTPStatus)
 }
@@ -177,7 +177,7 @@ func TestRoundTrip_AllSources_TextScenario_NonStreaming(t *testing.T) {
 
 			env.SetupRoute(src, protocol.TypeOpenAIChat, pt.TextScenario())
 
-			result := env.SendAs(t, src, pt.TextScenario(), false)
+			result := env.SendAs(t, src, protocol.TypeOpenAIChat, pt.TextScenario(), false)
 			require.Equal(t, 200, result.HTTPStatus)
 			assert.NotEmpty(t, result.Content)
 		})

--- a/internal/protocol_validate/scenarios.go
+++ b/internal/protocol_validate/scenarios.go
@@ -12,15 +12,15 @@ import (
 type MockResponseBuilder = server_validate.MockResponseBuilder
 
 // Scenario is a named test scenario describing:
-//   - What the mock provider should return (MockResponses per APIStyle)
+//   - What the mock provider should return (MockResponses per ResponseFormat)
 //   - What assertions to run on the round-trip result
 type Scenario struct {
 	Name        string
 	Description string
 	Tags        []string
 
-	// MockResponses keyed by provider APIStyle ("openai", "anthropic", "google").
-	MockResponses map[server_validate.APIStyle]MockResponseBuilder
+	// MockResponses keyed by response format (openai_chat, openai_responses, anthropic, google).
+	MockResponses map[server_validate.ResponseFormat]MockResponseBuilder
 
 	// Assertions run after every round-trip for this scenario.
 	Assertions []Assertion
@@ -58,10 +58,11 @@ func TextScenario() Scenario {
 		Name:        "text",
 		Description: "Basic text completion: user asks a question, assistant answers",
 		Tags:        []string{"text"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAITextResponse(),
-			server_validate.StyleAnthropic: anthropicTextResponse(),
-			server_validate.StyleGoogle:    googleTextResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAITextResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
+			server_validate.FormatAnthropic:       anthropicTextResponse(),
+			server_validate.FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -155,10 +156,11 @@ func ToolUseScenario() Scenario {
 		Name:        "tool_use",
 		Description: "Single tool call: assistant calls get_weather with location arg",
 		Tags:        []string{"tool_use"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAIToolUseResponse(),
-			server_validate.StyleAnthropic: anthropicToolUseResponse(),
-			server_validate.StyleGoogle:    googleToolUseResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAIToolUseResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesToolUseResponse(),
+			server_validate.FormatAnthropic:       anthropicToolUseResponse(),
+			server_validate.FormatGoogle:          googleToolUseResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -272,10 +274,11 @@ func ToolResultScenario() Scenario {
 		Name:        "tool_result",
 		Description: "Multi-turn with tool result: user→assistant(tool_use)→user(tool_result)→assistant",
 		Tags:        []string{"tool_use", "multi_turn"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAITextResponse(),
-			server_validate.StyleAnthropic: anthropicTextResponse(),
-			server_validate.StyleGoogle:    googleTextResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAITextResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
+			server_validate.FormatAnthropic:       anthropicTextResponse(),
+			server_validate.FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -293,10 +296,11 @@ func ThinkingScenario() Scenario {
 		Name:        "thinking",
 		Description: "Extended thinking: response contains a thinking block before text",
 		Tags:        []string{"thinking"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleAnthropic: anthropicThinkingResponse(),
-			server_validate.StyleOpenAI:    openAITextResponse(),
-			server_validate.StyleGoogle:    googleTextResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatAnthropic:       anthropicThinkingResponse(),
+			server_validate.FormatOpenAIChat:      openAITextResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
+			server_validate.FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -341,10 +345,11 @@ func MultiTurnScenario() Scenario {
 		Name:        "multi_turn",
 		Description: "Multi-turn conversation: system + user/assistant history + final user message",
 		Tags:        []string{"multi_turn"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAITextResponse(),
-			server_validate.StyleAnthropic: anthropicTextResponse(),
-			server_validate.StyleGoogle:    googleTextResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAITextResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
+			server_validate.FormatAnthropic:       anthropicTextResponse(),
+			server_validate.FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -362,10 +367,11 @@ func StreamingTextScenario() Scenario {
 		Name:        "streaming_text",
 		Description: "Streaming text: SSE chunks assembling to a complete text response",
 		Tags:        []string{"text", "streaming"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAITextResponse(),
-			server_validate.StyleAnthropic: anthropicTextResponse(),
-			server_validate.StyleGoogle:    googleTextResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAITextResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
+			server_validate.FormatAnthropic:       anthropicTextResponse(),
+			server_validate.FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -383,10 +389,11 @@ func StreamingToolUseScenario() Scenario {
 		Name:        "streaming_tool_use",
 		Description: "Streaming tool use: SSE chunks with tool call deltas",
 		Tags:        []string{"tool_use", "streaming"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAIToolUseResponse(),
-			server_validate.StyleAnthropic: anthropicToolUseResponse(),
-			server_validate.StyleGoogle:    googleToolUseResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAIToolUseResponse(),
+			server_validate.FormatOpenAIResponses: openAIResponsesToolUseResponse(),
+			server_validate.FormatAnthropic:       anthropicToolUseResponse(),
+			server_validate.FormatGoogle:          googleToolUseResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -403,10 +410,11 @@ func ErrorScenario() Scenario {
 		Name:        "error",
 		Description: "Provider rate limit error (429) propagated to client",
 		Tags:        []string{"error"},
-		MockResponses: map[server_validate.APIStyle]MockResponseBuilder{
-			server_validate.StyleOpenAI:    openAIErrorResponse(),
-			server_validate.StyleAnthropic: anthropicErrorResponse(),
-			server_validate.StyleGoogle:    googleErrorResponse(),
+		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
+			server_validate.FormatOpenAIChat:      openAIErrorResponse(),
+			server_validate.FormatOpenAIResponses: openAIErrorResponse(),
+			server_validate.FormatAnthropic:       anthropicErrorResponse(),
+			server_validate.FormatGoogle:          googleErrorResponse(),
 		},
 		Assertions: []Assertion{},
 	}
@@ -455,6 +463,86 @@ func googleErrorResponse() MockResponseBuilder {
 	return MockResponseBuilder{
 		NonStream: func() (int, []byte) { return 429, mustMarshal(body) },
 		Stream:    func() []string { return []string{`data: {"error":{"code":429,"message":"Rate limit exceeded"}}`} },
+	}
+}
+
+// ─── OpenAI Responses API mock builders ───────────────────────────────────────
+
+func openAIResponsesTextResponse() MockResponseBuilder {
+	body := map[string]interface{}{
+		"id":     "resp-validate-text",
+		"object": "realtime.response",
+		"model":  "gpt-4o",
+		"status": "completed",
+		"output": []map[string]interface{}{
+			{
+				"id":     "item-validate-text",
+				"type":   "message",
+				"role":   "assistant",
+				"status": "completed",
+				"content": []map[string]interface{}{
+					{"type": "output_text", "text": "The capital of France is Paris."},
+				},
+			},
+		},
+		"usage": map[string]interface{}{
+			"input_tokens":  10,
+			"output_tokens": 8,
+			"total_tokens":  18,
+		},
+	}
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+		Stream:    openAIResponsesTextSSE,
+	}
+}
+
+func openAIResponsesToolUseResponse() MockResponseBuilder {
+	body := map[string]interface{}{
+		"id":     "resp-validate-tool",
+		"object": "realtime.response",
+		"model":  "gpt-4o",
+		"status": "completed",
+		"output": []map[string]interface{}{
+			{
+				"id":        "call-validate-weather",
+				"type":      "function_call",
+				"call_id":   "call_validate_weather_1",
+				"name":      "get_weather",
+				"arguments": `{"location":"Paris","unit":"celsius"}`,
+			},
+		},
+		"usage": map[string]interface{}{
+			"input_tokens":  15,
+			"output_tokens": 20,
+			"total_tokens":  35,
+		},
+	}
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+		Stream:    openAIResponsesToolUseSSE,
+	}
+}
+
+func openAIResponsesTextSSE() []string {
+	return []string{
+		`data: {"type":"response.created","response":{"id":"resp-validate-text","object":"realtime.response","model":"gpt-4o","status":"in_progress","output":[]}}`,
+		`data: {"type":"response.output_item.added","response_id":"resp-validate-text","item":{"id":"item-validate-text","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
+		`data: {"type":"response.output_text.delta","response_id":"resp-validate-text","item_id":"item-validate-text","output_index":0,"content_index":0,"delta":"The capital of France is Paris."}`,
+		`data: {"type":"response.output_text.done","response_id":"resp-validate-text","item_id":"item-validate-text","output_index":0,"content_index":0,"text":"The capital of France is Paris."}`,
+		`data: {"type":"response.completed","response":{"id":"resp-validate-text","object":"realtime.response","model":"gpt-4o","status":"completed","output":[{"id":"item-validate-text","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"The capital of France is Paris."}]}],"usage":{"input_tokens":10,"output_tokens":8,"total_tokens":18}}}`,
+		`data: [DONE]`,
+	}
+}
+
+func openAIResponsesToolUseSSE() []string {
+	return []string{
+		`data: {"type":"response.created","response":{"id":"resp-validate-tool","object":"realtime.response","model":"gpt-4o","status":"in_progress","output":[]}}`,
+		`data: {"type":"response.output_item.added","response_id":"resp-validate-tool","item":{"id":"call-validate-weather","type":"function_call","call_id":"call_validate_weather_1","name":"get_weather","status":"in_progress"}}`,
+		`data: {"type":"response.function_call_arguments.delta","response_id":"resp-validate-tool","item_id":"call-validate-weather","output_index":0,"delta":"{\"location\":\"Paris\",\"unit\":\"celsius\"}"}`,
+		`data: {"type":"response.function_call_arguments.done","response_id":"resp-validate-tool","item_id":"call-validate-weather","output_index":0,"arguments":"{\"location\":\"Paris\",\"unit\":\"celsius\"}"}`,
+		`data: {"type":"response.completed","response":{"id":"resp-validate-tool","object":"realtime.response","model":"gpt-4o","status":"completed","output":[{"id":"call-validate-weather","type":"function_call","call_id":"call_validate_weather_1","name":"get_weather","arguments":"{\"location\":\"Paris\",\"unit\":\"celsius\"}"}],"usage":{"input_tokens":15,"output_tokens":20,"total_tokens":35}}}`,
+		`data: [DONE]`,
 	}
 }
 

--- a/internal/protocol_validate/testenv.go
+++ b/internal/protocol_validate/testenv.go
@@ -21,8 +21,19 @@ import (
 )
 
 // TestEnv wires a real gateway Server (with the full transform pipeline) to a
-// VirtualServer. It manages config, routing rules, and provides SendAs() for
-// full round-trip testing.
+// VirtualServer (mock provider). It manages config, routing rules, and provides
+// SendAs() for full round-trip testing.
+//
+// **Routing Architecture**:
+//
+//	Client Request → Gateway (/tingly/{scenario}/v1/...)
+//	              → Protocol Transform
+//	              → Provider Request (virtual-server-url/v1/...)
+//	              → VirtualServer (mock provider response)
+//
+// The gateway handles /tingly/{scenario}/v1/... routes, transforms the request
+// to provider format, and forwards to the virtual server which speaks provider
+// native APIs (/v1/chat/completions, /v1/messages, etc.).
 type TestEnv struct {
 	appConfig *config.AppConfig
 	ginEngine interface {
@@ -34,6 +45,7 @@ type TestEnv struct {
 
 	mu          sync.Mutex
 	routeModels map[string]string // key → requestModel
+	setupRoutes map[string]bool   // track which routes have been set up
 	configDir   string            // config directory for cleanup (CLI mode only)
 }
 
@@ -80,6 +92,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		virtual:       server_validate.NewVirtualServer(t),
 		modelToken:    appConfig.GetGlobalConfig().GetModelToken(),
 		routeModels:   make(map[string]string),
+		setupRoutes:   make(map[string]bool),
 	}
 }
 
@@ -144,6 +157,7 @@ func NewTestEnvForCLI(opts ...TestEnvOption) (*TestEnv, error) {
 		virtual:       virtual,
 		modelToken:    appConfig.GetGlobalConfig().GetModelToken(),
 		routeModels:   make(map[string]string),
+		setupRoutes:   make(map[string]bool),
 		configDir:     configDir, // Store for cleanup
 	}, nil
 }
@@ -158,12 +172,35 @@ func (env *TestEnv) VirtualCallCount() int { return env.virtual.CallCount() }
 // to the virtual server acting as a target protocol provider.
 //
 // The virtual server is pre-registered with the scenario's mock responses.
+// If the route has already been set up, this is a no-op (idempotent).
+//
+// **Routing Flow**:
+// 1. Client sends request to gateway: POST /tingly/{scenario}/v1/chat/completions
+// 2. Gateway transforms request to provider format based on source protocol
+// 3. Gateway forwards to provider: POST {virtualURL}/v1/chat/completions
+// 4. VirtualServer (provider mock) returns pre-configured scenario response
+//
+// The provider's APIBase includes the /v1 suffix for OpenAI-style providers
+// to match actual provider API structure.
 func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
+	key := routeKey(source, target, s.Name)
+
+	env.mu.Lock()
+	if env.setupRoutes[key] {
+		env.mu.Unlock()
+		return
+	}
+	env.setupRoutes[key] = true
+	env.mu.Unlock()
+
 	env.virtual.RegisterScenario(s.toVirtualServerScenario())
 
 	virtualURL := env.virtual.URL()
-	providerName := fmt.Sprintf("virtual-%s-%s", target, s.Name)
-	providerModel := fmt.Sprintf("virtual-model-%s", s.Name)
+
+	// Make provider UUID unique per source+target+scenario to avoid conflicts
+	providerUUID := fmt.Sprintf("virtual-%s-%s-%s", source, target, s.Name)
+	providerName := providerUUID // Use UUID as name for uniqueness
+	providerModel := fmt.Sprintf("virtual-model-%s-%s", target, s.Name)
 	requestModel := fmt.Sprintf("pv-%s-to-%s-%s", source, target, s.Name)
 
 	apiStyle := targetToAPIStyle(target)
@@ -208,7 +245,6 @@ func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
 	}
 	_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
 
-	key := routeKey(source, target, s.Name)
 	env.mu.Lock()
 	env.routeModels[key] = requestModel
 	env.mu.Unlock()
@@ -405,6 +441,8 @@ func targetToAPIStyle(target protocol.APIType) protocol.APIStyle {
 		return protocol.APIStyleAnthropic
 	case protocol.TypeGoogle:
 		return protocol.APIStyleGoogle
+	case protocol.TypeOpenAIResponses:
+		return protocol.APIStyleOpenAI // Responses API uses OpenAI style
 	default:
 		return protocol.APIStyleOpenAI
 	}
@@ -423,6 +461,8 @@ func sourceToStyle(source protocol.APIType) protocol.APIStyle {
 	switch source {
 	case protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta:
 		return protocol.APIStyleAnthropic
+	case protocol.TypeOpenAIResponses:
+		return protocol.APIStyleOpenAI // Responses API uses OpenAI style
 	default:
 		return protocol.APIStyleOpenAI
 	}
@@ -436,6 +476,7 @@ func parseFromJSON(raw []byte, style protocol.APIStyle) sse.ParsedResult {
 	var r *sse.ParsedResult
 	switch style {
 	case protocol.APIStyleOpenAI:
+		// Check if this is a Responses API response by looking for "output" field
 		if _, hasOutput := m["output"]; hasOutput {
 			r = sse.ParseOpenAIResponsesResult(m)
 		} else {
@@ -456,7 +497,12 @@ func assembleFromEvents(events []string, style protocol.APIStyle) sse.ParsedResu
 	var r *sse.ParsedResult
 	switch style {
 	case protocol.APIStyleOpenAI:
-		r = sse.AssembleOpenAIStream(events)
+		// Try to assemble as Responses API first
+		r = sse.AssembleOpenAIResponsesStream(events)
+		// If that failed, try Chat Completions
+		if r == nil || len(r.Content) == 0 {
+			r = sse.AssembleOpenAIStream(events)
+		}
 	case protocol.APIStyleAnthropic:
 		r = sse.AssembleAnthropicStream(events)
 	case protocol.APIStyleGoogle:

--- a/internal/protocol_validate/testenv.go
+++ b/internal/protocol_validate/testenv.go
@@ -220,12 +220,12 @@ func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
 // Streaming requests use the real httptest.Server (env.gatewayServer) because
 // httptest.ResponseRecorder does not support Gin's streaming/SSE machinery.
 // Non-streaming requests use the recorder for simplicity.
-func (env *TestEnv) SendAs(t *testing.T, source protocol.APIType, s Scenario, streaming bool) *RoundTripResult {
+func (env *TestEnv) SendAs(t *testing.T, source, target protocol.APIType, s Scenario, streaming bool) *RoundTripResult {
 	t.Helper()
 
-	requestModel := env.findRouteModel(source, s.Name)
+	requestModel := env.findRouteModel(source, target, s.Name)
 	if requestModel == "" {
-		t.Fatalf("no route configured for source=%s scenario=%s — call SetupRoute first", source, s.Name)
+		t.Fatalf("no route configured for source=%s target=%s scenario=%s — call SetupRoute first", source, target, s.Name)
 	}
 
 	path, body := buildRequest(source, requestModel, streaming)
@@ -283,10 +283,10 @@ func (env *TestEnv) SendAs(t *testing.T, source protocol.APIType, s Scenario, st
 // Streaming requests use the real httptest.Server (env.gatewayServer) because
 // httptest.ResponseRecorder does not support Gin's streaming/SSE machinery.
 // Non-streaming requests use the recorder for simplicity.
-func (env *TestEnv) SendAsCLI(source protocol.APIType, s Scenario, streaming bool) (*RoundTripResult, error) {
-	requestModel := env.findRouteModel(source, s.Name)
+func (env *TestEnv) SendAsCLI(source, target protocol.APIType, s Scenario, streaming bool) (*RoundTripResult, error) {
+	requestModel := env.findRouteModel(source, target, s.Name)
 	if requestModel == "" {
-		return nil, fmt.Errorf("no route configured for source=%s scenario=%s — call SetupRoute first", source, s.Name)
+		return nil, fmt.Errorf("no route configured for source=%s target=%s scenario=%s — call SetupRoute first", source, target, s.Name)
 	}
 
 	path, body := buildRequest(source, requestModel, streaming)
@@ -343,18 +343,11 @@ func routeKey(source, target protocol.APIType, scenario string) string {
 	return fmt.Sprintf("%s|%s|%s", source, target, scenario)
 }
 
-func (env *TestEnv) findRouteModel(source protocol.APIType, scenarioName string) string {
+func (env *TestEnv) findRouteModel(source, target protocol.APIType, scenarioName string) string {
 	env.mu.Lock()
 	defer env.mu.Unlock()
-	prefix := fmt.Sprintf("%s|", source)
-	suffix := fmt.Sprintf("|%s", scenarioName)
-	for k, v := range env.routeModels {
-		if len(k) >= len(prefix) && k[:len(prefix)] == prefix &&
-			len(k) >= len(suffix) && k[len(k)-len(suffix):] == suffix {
-			return v
-		}
-	}
-	return ""
+	key := routeKey(source, target, scenarioName)
+	return env.routeModels[key]
 }
 
 func buildRequest(source protocol.APIType, model string, streaming bool) (path string, body []byte) {

--- a/internal/protocol_validate/testenv.go
+++ b/internal/protocol_validate/testenv.go
@@ -37,6 +37,21 @@ type TestEnv struct {
 	configDir   string            // config directory for cleanup (CLI mode only)
 }
 
+// TestEnvOption is a functional option for configuring TestEnv.
+type TestEnvOption func(*testEnvConfig)
+
+type testEnvConfig struct {
+	recordDir string
+}
+
+// NewTestEnvOptionWithRecordDir creates an option to set the record directory.
+// If empty, recording is disabled.
+func NewTestEnvOptionWithRecordDir(dir string) TestEnvOption {
+	return func(cfg *testEnvConfig) {
+		cfg.recordDir = dir
+	}
+}
+
 // NewTestEnv creates a TestEnv with a fresh gateway config and a new VirtualServer.
 // All resources are cleaned up via t.Cleanup.
 func NewTestEnv(t *testing.T) *TestEnv {
@@ -87,7 +102,13 @@ func (env *TestEnv) Close() {
 
 // NewTestEnvForCLI creates a TestEnv for CLI use (without testing.T).
 // Resources must be cleaned up via explicit Close() call.
-func NewTestEnvForCLI() (*TestEnv, error) {
+func NewTestEnvForCLI(opts ...TestEnvOption) (*TestEnv, error) {
+	// Apply options
+	cfg := &testEnvConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	configDir, err := os.MkdirTemp("", "pv-cli-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temp config dir: %w", err)
@@ -99,7 +120,13 @@ func NewTestEnvForCLI() (*TestEnv, error) {
 		return nil, fmt.Errorf("create app config: %w", err)
 	}
 
-	gatewayServer := server.NewServer(appConfig.GetGlobalConfig(), server.WithAdaptor(false))
+	// Build server options
+	serverOpts := []server.ServerOption{server.WithAdaptor(false)}
+	if cfg.recordDir != "" {
+		serverOpts = append(serverOpts, server.WithRecordDir(cfg.recordDir))
+	}
+
+	gatewayServer := server.NewServer(appConfig.GetGlobalConfig(), serverOpts...)
 	router := gatewayServer.GetRouter()
 	ts := httptest.NewServer(router)
 

--- a/internal/protocol_validate/types.go
+++ b/internal/protocol_validate/types.go
@@ -76,8 +76,8 @@ type Assertion struct {
 // This is returned by Matrix.ExecuteAll() for CLI and other non-testing contexts.
 type TestResult struct {
 	// Test identification
-	Name      string        // Full test name: "scenario/source/target/mode"
-	Scenario  string        // Scenario name: "text", "tool_use", etc.
+	Name      string // Full test name: "scenario/source/target/mode"
+	Scenario  string // Scenario name: "text", "tool_use", etc.
 	Source    protocol.APIType
 	Target    protocol.APIType
 	Streaming bool
@@ -91,9 +91,17 @@ type TestResult struct {
 	Errors   []AssertionError // list of assertion failures
 	Duration time.Duration    // test execution time
 
+	// Batch statistics (populated when BatchCount > 1)
+	BatchCount  int           // number of times the test was executed
+	BatchPassed int           // number of executions that passed
+	BatchMinDur time.Duration // minimum duration across executions
+	BatchAvgDur time.Duration // average duration across executions
+	BatchMaxDur time.Duration // maximum duration across executions
+	BatchErrors []string      // unique error messages from failed executions
+
 	// Response details (for debugging/verbose output)
 	HTTPStatus int              // HTTP status code
-	Response   *RoundTripResult // full round-trip result
+	Response   *RoundTripResult // full round-trip result (from first or last execution)
 }
 
 // AssertionError represents a single assertion failure.

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -583,11 +583,20 @@ func (c *Config) UpdateRule(uid string, rule typ.Rule) error {
 	return nil
 }
 
-// AddRequestConfig adds a new Rule
+// AddRequestConfig adds a new Rule. If a rule with the same UUID already exists,
+// it is rejected instead of adding a duplicate.
 func (c *Config) AddRequestConfig(reqConfig typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// Check if rule with same UUID already exists
+	for _, rule := range c.Rules {
+		if rule.UUID == reqConfig.UUID {
+			return nil
+		}
+	}
+
+	// No existing rule, append new one
 	c.Rules = append(c.Rules, reqConfig)
 	return c.Save()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -427,7 +427,9 @@ func (s *Server) GetOrCreateScenarioSink(scenario typ.RuleScenario) *obs.Sink {
 	// Create new sink for this scenario
 	sink := obs.NewSink(s.recordDir, obs.RecordModeScenario)
 	if sink == nil {
-		logrus.Warnf("Failed to create scenario recording sink for %s", scenario)
+		// Sink creation failed or recording is disabled (empty recordDir)
+		// This is expected when no record directory is configured
+		logrus.Debugf("Failed to create scenario recording sink for %s", scenario)
 		return nil
 	}
 

--- a/internal/server_validate/client.go
+++ b/internal/server_validate/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
 )
 
@@ -62,7 +63,7 @@ func (vc *VirtualClient) SendOpenAIChat(t *testing.T, s Scenario, streaming bool
 		"messages": []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":   streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/chat/completions", body, streaming, StyleOpenAI)
+	return vc.doRequest(t, "POST", vc.baseURL+"/v1/chat/completions", body, streaming, protocol.APIStyleOpenAI)
 }
 
 // SendOpenAIResponses sends a request to the OpenAI Responses API endpoint.
@@ -74,7 +75,7 @@ func (vc *VirtualClient) SendOpenAIResponses(t *testing.T, s Scenario, streaming
 		"input":  "What is the capital of France?",
 		"stream": streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/responses", body, streaming, StyleOpenAI)
+	return vc.doRequest(t, "POST", vc.baseURL+"/v1/responses", body, streaming, protocol.APIStyleOpenAI)
 }
 
 // SendAnthropicV1 sends a request to the Anthropic Messages endpoint.
@@ -87,7 +88,7 @@ func (vc *VirtualClient) SendAnthropicV1(t *testing.T, s Scenario, streaming boo
 		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":     streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages", body, streaming, StyleAnthropic)
+	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages", body, streaming, protocol.APIStyleAnthropic)
 }
 
 // SendGoogle sends a request to the Google GenerateContent endpoint.
@@ -103,7 +104,7 @@ func (vc *VirtualClient) SendGoogle(t *testing.T, s Scenario, streaming bool) *P
 	if streaming {
 		suffix = "streamGenerateContent"
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1beta/models/gemini-2.0-flash/"+suffix, body, streaming, StyleGoogle)
+	return vc.doRequest(t, "POST", vc.baseURL+"/v1beta/models/gemini-2.0-flash/"+suffix, body, streaming, protocol.APIStyleGoogle)
 }
 
 // ─── Model-parameterized send helpers ─────────────────────────────────────────
@@ -117,7 +118,7 @@ func (vc *VirtualClient) SendOpenAIChatModel(t *testing.T, modelID string, strea
 		"messages": []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":   streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/chat/completions", body, streaming, StyleOpenAI)
+	return vc.doRequest(t, "POST", vc.baseURL+"/v1/chat/completions", body, streaming, protocol.APIStyleOpenAI)
 }
 
 // SendAnthropicV1Model sends a request to the Anthropic Messages endpoint
@@ -130,7 +131,7 @@ func (vc *VirtualClient) SendAnthropicV1Model(t *testing.T, modelID string, stre
 		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":     streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages", body, streaming, StyleAnthropic)
+	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages", body, streaming, protocol.APIStyleAnthropic)
 }
 
 // ─── Internals ─────────────────────────────────────────────────────────────────
@@ -143,7 +144,7 @@ func (vc *VirtualClient) maybeRegister(s Scenario) {
 }
 
 // doRequest sends an HTTP request and returns a ParsedResponse.
-func (vc *VirtualClient) doRequest(t *testing.T, method, url string, body interface{}, streaming bool, style APIStyle) *ParsedResponse {
+func (vc *VirtualClient) doRequest(t *testing.T, method, url string, body interface{}, streaming bool, style protocol.APIStyle) *ParsedResponse {
 	t.Helper()
 
 	reqBody, err := json.Marshal(body)
@@ -179,22 +180,22 @@ func (vc *VirtualClient) doRequest(t *testing.T, method, url string, body interf
 	return result
 }
 
-func parsedResultFromJSON(raw []byte, style APIStyle) sse.ParsedResult {
+func parsedResultFromJSON(raw []byte, style protocol.APIStyle) sse.ParsedResult {
 	var m map[string]interface{}
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return sse.ParsedResult{}
 	}
 	var r *sse.ParsedResult
 	switch style {
-	case StyleOpenAI:
+	case protocol.APIStyleOpenAI:
 		if _, hasOutput := m["output"]; hasOutput {
 			r = sse.ParseOpenAIResponsesResult(m)
 		} else {
 			r = sse.ParseOpenAIChatResult(m)
 		}
-	case StyleAnthropic:
+	case protocol.APIStyleAnthropic:
 		r = sse.ParseAnthropicResult(m)
-	case StyleGoogle:
+	case protocol.APIStyleGoogle:
 		r = sse.ParseGoogleResult(m)
 	default:
 		return sse.ParsedResult{}
@@ -205,14 +206,14 @@ func parsedResultFromJSON(raw []byte, style APIStyle) sse.ParsedResult {
 	return *r
 }
 
-func parsedResultFromStream(events []string, style APIStyle) sse.ParsedResult {
+func parsedResultFromStream(events []string, style protocol.APIStyle) sse.ParsedResult {
 	var r *sse.ParsedResult
 	switch style {
-	case StyleOpenAI:
+	case protocol.APIStyleOpenAI:
 		r = sse.AssembleOpenAIStream(events)
-	case StyleAnthropic:
+	case protocol.APIStyleAnthropic:
 		r = sse.AssembleAnthropicStream(events)
-	case StyleGoogle:
+	case protocol.APIStyleGoogle:
 		r = sse.AssembleGoogleStream(events)
 	default:
 		return sse.ParsedResult{}

--- a/internal/server_validate/server.go
+++ b/internal/server_validate/server.go
@@ -135,7 +135,7 @@ func (vs *VirtualServer) handleOpenAIChat(w http.ResponseWriter, r *http.Request
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	streaming := vs.parseStreamFlagFromBytes(bodyBytes)
-	scenario := vs.detectScenario(r)
+	scenario := vs.detectScenario(bodyBytes)
 
 	resp, ok := vs.scenarios[scenario]
 	if !ok {
@@ -219,7 +219,7 @@ func (vs *VirtualServer) handleAnthropicMessages(w http.ResponseWriter, r *http.
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	streaming := vs.parseStreamFlagFromBytes(bodyBytes)
-	scenario := vs.detectScenario(r)
+	scenario := vs.detectScenario(bodyBytes)
 
 	resp, ok := vs.scenarios[scenario]
 	if !ok {
@@ -247,8 +247,11 @@ func (vs *VirtualServer) handleGoogle(w http.ResponseWriter, r *http.Request) {
 	vs.callCount++
 	vs.mu.Unlock()
 
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
 	streaming := strings.Contains(r.URL.Path, "streamGenerateContent")
-	scenario := vs.detectScenario(r)
+	scenario := vs.detectScenarioFromURLOrBody(r.URL.Path, bodyBytes)
 
 	resp, ok := vs.scenarios[scenario]
 	if !ok {
@@ -282,7 +285,51 @@ func (vs *VirtualServer) parseStreamFlagFromBytes(body []byte) bool {
 	return flag
 }
 
-func (vs *VirtualServer) detectScenario(_ *http.Request) string {
+// detectScenarioFromURLOrBody extracts scenario from Google-style URL path or falls back to body.
+// Google requests encode the model in the URL: /v1beta/models/{model}/generateContent
+func (vs *VirtualServer) detectScenarioFromURLOrBody(urlPath string, body []byte) string {
+	const prefix = "virtual-model-"
+	// Try URL path first: extract model segment
+	parts := strings.Split(urlPath, "/")
+	for _, part := range parts {
+		if strings.HasPrefix(part, prefix) {
+			name := part[len(prefix):]
+			// Strip trailing action suffix if any (e.g. ":generateContent" edge case)
+			if idx := strings.IndexByte(name, ':'); idx >= 0 {
+				name = name[:idx]
+			}
+			vs.mu.RLock()
+			_, exists := vs.scenarios[name]
+			vs.mu.RUnlock()
+			if exists {
+				return name
+			}
+		}
+	}
+	// Fallback to body parsing
+	return vs.detectScenario(body)
+}
+
+// detectScenario extracts the scenario name from the request body's model field.
+// The model field is expected to be "virtual-model-{scenario}" (set by SetupRoute).
+// Falls back to the first registered scenario if extraction fails.
+func (vs *VirtualServer) detectScenario(body []byte) string {
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err == nil {
+		if model, ok := m["model"].(string); ok {
+			const prefix = "virtual-model-"
+			if strings.HasPrefix(model, prefix) {
+				name := model[len(prefix):]
+				vs.mu.RLock()
+				_, exists := vs.scenarios[name]
+				vs.mu.RUnlock()
+				if exists {
+					return name
+				}
+			}
+		}
+	}
+	// Fallback: return first registered scenario name
 	vs.mu.RLock()
 	defer vs.mu.RUnlock()
 	for name := range vs.scenarios {

--- a/internal/server_validate/server.go
+++ b/internal/server_validate/server.go
@@ -1,12 +1,20 @@
 // Package server_validate provides a mock HTTP provider server that speaks
 // OpenAI, Anthropic, and Google response formats for testing purposes.
 //
+// **Architecture Note**: VirtualServer is a **provider mock**, not a gateway mock.
+// It speaks provider-native formats (OpenAI/Anthropic/Google APIs) at provider-native
+// routes (/v1/chat/completions, /v1/messages, /v1beta/models/...).
+//
+// The test harness routing flow is:
+//
+//	Client → Gateway (/tingly/{scenario}/v1/...) → Protocol Transform → Virtual Server (/v1/...)
+//
 // A VirtualServer acts as a deterministic "virtual model" — scenario responses
 // are pre-configured and returned without any real model calls. It is used by
-// the virtualmodel test framework to exercise the gateway's protocol transform
+// the protocol_validate test framework to exercise the gateway's protocol transform
 // pipeline end-to-end.
 //
-// Use VirtualClient (client.go) to send requests to the server and inspect
+// Use VirtualClient (client.go) to send requests directly to the server and inspect
 // parsed responses. A bound client is obtained via vs.Client().
 package server_validate
 
@@ -20,20 +28,20 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
 )
 
-// APIStyle aliases protocol.APIStyle for scenario keying.
-type APIStyle = protocol.APIStyle
+// ResponseFormat represents the format of the mock response for different endpoints.
+type ResponseFormat string
 
 const (
-	StyleOpenAI    = protocol.APIStyleOpenAI
-	StyleAnthropic = protocol.APIStyleAnthropic
-	StyleGoogle    = protocol.APIStyleGoogle
+	FormatOpenAIChat      ResponseFormat = "openai_chat"      // /v1/chat/completions
+	FormatOpenAIResponses ResponseFormat = "openai_responses" // /v1/responses
+	FormatAnthropic       ResponseFormat = "anthropic"        // /v1/messages
+	FormatGoogle          ResponseFormat = "google"           // /v1beta/models/.../generateContent
 )
 
-// MockResponseBuilder defines how a virtual server should respond for one provider style.
+// MockResponseBuilder defines how a virtual server should respond for one response format.
 type MockResponseBuilder struct {
 	// NonStream returns the HTTP status code and response body bytes.
 	NonStream func() (statusCode int, body []byte)
@@ -47,13 +55,19 @@ type Scenario struct {
 	Description string
 	Tags        []string
 
-	// MockResponses keyed by provider APIStyle ("openai", "anthropic", "google").
-	MockResponses map[APIStyle]MockResponseBuilder
+	// MockResponses keyed by response format (openai_chat, openai_responses, anthropic, google).
+	// Each endpoint (/v1/chat/completions, /v1/responses, /v1/messages, /v1beta/models/.../generateContent)
+	// returns the corresponding format.
+	MockResponses map[ResponseFormat]MockResponseBuilder
 }
 
 // VirtualServer is a mock provider server backed by httptest.Server.
 // It speaks OpenAI, Anthropic, and Google response formats and returns
 // pre-configured scenario responses.
+//
+// **Provider Routes**: This server handles provider-native routes (/v1/chat/completions,
+// /v1/messages, /v1beta/models/...), NOT gateway routes (/tingly/{scenario}/v1/...).
+// The gateway transforms requests to provider format before forwarding to this server.
 type VirtualServer struct {
 	server    *httptest.Server
 	scenarios map[string]Scenario // keyed by scenario name
@@ -82,19 +96,26 @@ func NewVirtualServer(t *testing.T) *VirtualServer {
 
 // NewVirtualServerForCLI creates a new VirtualServer for CLI use (without testing.T).
 // The caller must call Close() to clean up resources.
+//
+// **Provider Mock**: This is a provider mock, not a gateway. Routes are /v1/...
+// (provider-native), not /tingly/... (gateway). The gateway transforms /tingly/{scenario}/v1/...
+// requests to provider format before forwarding to this server.
 func NewVirtualServerForCLI() *VirtualServer {
 	vs := &VirtualServer{
 		scenarios: make(map[string]Scenario),
 	}
 
 	mux := http.NewServeMux()
+
+	// Provider-native routes (matching actual provider APIs)
+	// Most providers require /v1/ prefix, but we register both for flexibility
 	mux.HandleFunc("/v1/chat/completions", vs.handleOpenAIChat)
-	mux.HandleFunc("/chat/completions", vs.handleOpenAIChat)
 	mux.HandleFunc("/v1/responses", vs.handleOpenAIResponses)
-	mux.HandleFunc("/responses", vs.handleOpenAIResponses)
 	mux.HandleFunc("/v1/messages", vs.handleAnthropicMessages)
-	mux.HandleFunc("/messages", vs.handleAnthropicMessages)
-	mux.HandleFunc("/", vs.handleGoogle) // catches /v1beta/models/*/generateContent
+
+	// Google API route pattern: /v1beta/models/{model}/generateContent
+	// Using catch-all handler since model name is dynamic in the path
+	mux.HandleFunc("/v1beta/models/", vs.handleGoogle)
 
 	vs.server = httptest.NewServer(mux)
 	return vs
@@ -142,9 +163,9 @@ func (vs *VirtualServer) handleOpenAIChat(w http.ResponseWriter, r *http.Request
 		resp = vs.firstScenario()
 	}
 
-	builder, ok := resp.MockResponses[StyleOpenAI]
+	builder, ok := resp.MockResponses[FormatOpenAIChat]
 	if !ok {
-		http.Error(w, "no openai mock response for scenario "+scenario, http.StatusInternalServerError)
+		http.Error(w, "no openai_chat mock response for scenario "+scenario, http.StatusInternalServerError)
 		return
 	}
 
@@ -167,46 +188,30 @@ func (vs *VirtualServer) handleOpenAIResponses(w http.ResponseWriter, r *http.Re
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	streaming := vs.parseStreamFlagFromBytes(bodyBytes)
+	scenario := vs.detectScenario(bodyBytes)
+
+	resp, ok := vs.scenarios[scenario]
+	if !ok {
+		resp = vs.firstScenario()
+	}
+
+	builder, ok := resp.MockResponses[FormatOpenAIResponses]
+	if !ok {
+		// Fallback to FormatOpenAIChat for Responses API when not explicitly defined
+		builder, ok = resp.MockResponses[FormatOpenAIChat]
+		if !ok {
+			http.Error(w, "no openai_responses or openai_chat mock response for scenario "+scenario, http.StatusInternalServerError)
+			return
+		}
+	}
 
 	if streaming {
-		// Return Responses API SSE streaming format
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.WriteHeader(http.StatusOK)
-		flusher, _ := w.(http.Flusher)
-
-		lines := []string{
-			`data: {"type":"response.created","response":{"id":"resp_vs_001","object":"realtime.response","model":"virtual","status":"in_progress","output":[],"usage":null}}`,
-			``,
-			`data: {"type":"response.output_item.added","response_id":"resp_vs_001","item":{"id":"item_vs_001","type":"message","status":"in_progress","role":"assistant","content":[]}}`,
-			``,
-			`data: {"type":"response.content_part.added","response_id":"resp_vs_001","item_id":"item_vs_001","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`,
-			``,
-			`data: {"type":"response.output_text.delta","response_id":"resp_vs_001","item_id":"item_vs_001","output_index":0,"content_index":0,"delta":"Hello, world!"}`,
-			``,
-			`data: {"type":"response.output_text.done","response_id":"resp_vs_001","item_id":"item_vs_001","output_index":0,"content_index":0,"text":"Hello, world!"}`,
-			``,
-			`data: {"type":"response.content_part.done","response_id":"resp_vs_001","item_id":"item_vs_001","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello, world!"}}`,
-			``,
-			`data: {"type":"response.output_item.done","response_id":"resp_vs_001","item":{"id":"item_vs_001","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, world!"}]}}`,
-			``,
-			`data: {"type":"response.completed","response":{"id":"resp_vs_001","object":"realtime.response","model":"virtual","status":"completed","output":[{"id":"item_vs_001","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, world!"}]}],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}`,
-			``,
-			`data: [DONE]`,
-			``,
-		}
-		for _, line := range lines {
-			w.Write([]byte(line + "\n"))
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
+		sse.WriteSSEResponse(w, builder.Stream())
 	} else {
-		// Return Responses API non-streaming format
+		status, body := builder.NonStream()
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"id":"resp_vs_001","object":"realtime.response","model":"virtual","status":"completed","output":[{"id":"item_vs_001","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, world!"}]}],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}`))
+		w.WriteHeader(status)
+		w.Write(body)
 	}
 }
 
@@ -226,7 +231,7 @@ func (vs *VirtualServer) handleAnthropicMessages(w http.ResponseWriter, r *http.
 		resp = vs.firstScenario()
 	}
 
-	builder, ok := resp.MockResponses[StyleAnthropic]
+	builder, ok := resp.MockResponses[FormatAnthropic]
 	if !ok {
 		http.Error(w, "no anthropic mock response for scenario "+scenario, http.StatusInternalServerError)
 		return
@@ -258,7 +263,7 @@ func (vs *VirtualServer) handleGoogle(w http.ResponseWriter, r *http.Request) {
 		resp = vs.firstScenario()
 	}
 
-	builder, ok := resp.MockResponses[StyleGoogle]
+	builder, ok := resp.MockResponses[FormatGoogle]
 	if !ok {
 		http.Error(w, "no google mock response for scenario "+scenario, http.StatusInternalServerError)
 		return
@@ -293,7 +298,15 @@ func (vs *VirtualServer) detectScenarioFromURLOrBody(urlPath string, body []byte
 	parts := strings.Split(urlPath, "/")
 	for _, part := range parts {
 		if strings.HasPrefix(part, prefix) {
-			name := part[len(prefix):]
+			remaining := part[len(prefix):] // "{target}-{scenario}"
+			// Find the last "-" to separate target from scenario
+			lastDash := strings.LastIndex(remaining, "-")
+			var name string
+			if lastDash > 0 {
+				name = remaining[lastDash+1:]
+			} else {
+				name = remaining
+			}
 			// Strip trailing action suffix if any (e.g. ":generateContent" edge case)
 			if idx := strings.IndexByte(name, ':'); idx >= 0 {
 				name = name[:idx]
@@ -311,7 +324,8 @@ func (vs *VirtualServer) detectScenarioFromURLOrBody(urlPath string, body []byte
 }
 
 // detectScenario extracts the scenario name from the request body's model field.
-// The model field is expected to be "virtual-model-{scenario}" (set by SetupRoute).
+// The model field is expected to be "virtual-model-{target}-{scenario}" (set by SetupRoute).
+// We extract just the scenario name for lookup.
 // Falls back to the first registered scenario if extraction fails.
 func (vs *VirtualServer) detectScenario(body []byte) string {
 	var m map[string]interface{}
@@ -319,12 +333,19 @@ func (vs *VirtualServer) detectScenario(body []byte) string {
 		if model, ok := m["model"].(string); ok {
 			const prefix = "virtual-model-"
 			if strings.HasPrefix(model, prefix) {
-				name := model[len(prefix):]
-				vs.mu.RLock()
-				_, exists := vs.scenarios[name]
-				vs.mu.RUnlock()
-				if exists {
-					return name
+				// Format: virtual-model-{target}-{scenario}
+				// We need to extract the scenario name after the target
+				remaining := model[len(prefix):] // "{target}-{scenario}"
+				// Find the last "-" to separate target from scenario
+				lastDash := strings.LastIndex(remaining, "-")
+				if lastDash > 0 {
+					name := remaining[lastDash+1:]
+					vs.mu.RLock()
+					_, exists := vs.scenarios[name]
+					vs.mu.RUnlock()
+					if exists {
+						return name
+					}
 				}
 			}
 		}

--- a/internal/server_validate/server_test.go
+++ b/internal/server_validate/server_test.go
@@ -13,8 +13,8 @@ import (
 func newTextScenario() server_validate.Scenario {
 	return server_validate.Scenario{
 		Name: "text",
-		MockResponses: map[server_validate.APIStyle]server_validate.MockResponseBuilder{
-			server_validate.StyleOpenAI: {
+		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
+			server_validate.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-test","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"The capital of France is Paris."},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":8,"total_tokens":18}}`)
 				},
@@ -27,7 +27,7 @@ func newTextScenario() server_validate.Scenario {
 					}
 				},
 			},
-			server_validate.StyleAnthropic: {
+			server_validate.FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg-test","type":"message","role":"assistant","content":[{"type":"text","text":"The capital of France is Paris."}],"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":8}}`)
 				},
@@ -42,7 +42,7 @@ func newTextScenario() server_validate.Scenario {
 					}
 				},
 			},
-			server_validate.StyleGoogle: {
+			server_validate.FormatGoogle: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"The capital of France is Paris."}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":8}}`)
 				},
@@ -59,18 +59,18 @@ func newTextScenario() server_validate.Scenario {
 func newToolUseScenario() server_validate.Scenario {
 	return server_validate.Scenario{
 		Name: "tool_use",
-		MockResponses: map[server_validate.APIStyle]server_validate.MockResponseBuilder{
-			server_validate.StyleOpenAI: {
+		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
+			server_validate.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-tool","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":20}}`)
 				},
 			},
-			server_validate.StyleAnthropic: {
+			server_validate.FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg-tool","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"location":"Paris"}}],"model":"claude-3-5-sonnet-20241022","stop_reason":"tool_use","usage":{"input_tokens":15,"output_tokens":20}}`)
 				},
 			},
-			server_validate.StyleGoogle: {
+			server_validate.FormatGoogle: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"location":"Paris"}}}]},"finishReason":"STOP"}]}`)
 				},
@@ -82,8 +82,8 @@ func newToolUseScenario() server_validate.Scenario {
 func newErrorScenario() server_validate.Scenario {
 	return server_validate.Scenario{
 		Name: "error",
-		MockResponses: map[server_validate.APIStyle]server_validate.MockResponseBuilder{
-			server_validate.StyleOpenAI: {
+		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
+			server_validate.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 429, []byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}`)
 				},


### PR DESCRIPTION
## Summary

The harness test framework previously lacked execution-level filtering, reusable server strategies, and performance testing capabilities. 

Tests always ran the full matrix with per-scenario servers, making the process slow and inflexible for targeted testing.

## Major

- **Source/Target Filtering**: Added `--sources` and `--targets` flags to run only specific protocol combinations (e.g., `--sources anthropic_v1 --targets openai_chat`).
- **Server Reuse Modes**: Introduced the `--server-mode` flag with three strategies:
  - `auto` (default): Per-scenario server reuse (existing behavior)
  - `all`: Single server for all tests (fastest, but may cause interference)
  - `pair`: Per source-target pair server reuse (balanced)
- **Batch Testing**: Added the `--batch` flag to run each test N times for stability and performance testing, with aggregated min/avg/max duration statistics.
- **Request Recording**: Added `--record-dir` flag to record all HTTP requests and responses for debugging (also configurable via the `HARNESS_RECORD_DIR` environment variable).

## Minor

- **API Style Declaration Fix**: Mock responses are now keyed by `ResponseFormat` (`openai_chat`, `openai_responses`, `anthropic`, `google`) instead of `APIStyle`, separating endpoint format from protocol style.
- **OpenAI Responses API Support**: Added proper mock responses for the `/v1/responses` endpoint (text and `tool_use` scenarios).
- **Verbose Logging**: The `--verbose` flag now controls the logrus output level (`warn`/`info`/`debug`) and includes runtime metadata in the output (host, CPUs, Go version, timestamp).
- **TestEnv Improvements**: Route setup is now idempotent, and provider UUIDs are made unique per source+target+scenario to avoid conflicts.
- **Output Enhancements**: Batch results now show N/M pass counts, duration columns are standardized, and min/avg/max values are displayed for batch runs.