### PR TITLE
fix: remove openai/anthropic client retry when failed

### DIFF
--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -40,6 +40,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 	options := []anthropicOption.RequestOption{
 		anthropicOption.WithAPIKey(provider.GetAccessToken()),
 		anthropicOption.WithBaseURL(apiBase),
+		anthropicOption.WithMaxRetries(0), // Disable automatic retries for 429 errors in test environments
 	}
 
 	// Create HTTP client with session-bound transport

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -37,6 +37,7 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	options := []option.RequestOption{
 		option.WithAPIKey(provider.GetAccessToken()),
 		option.WithBaseURL(provider.APIBase),
+		option.WithMaxRetries(0), // Disable automatic retries for 429 errors in test environments
 	}
 
 	// Add X-ChatGPT-Account-ID header if available from OAuth metadata


### PR DESCRIPTION
## Summary
- Disable automatic retries for OpenAI and Anthropic clients to prevent masking 429 rate limit errors during testing

## Details
The OpenAI and Anthropic SDK clients have built-in retry mechanisms that automatically retry failed requests, including 429 rate limit errors. While this is useful in production, it can mask rate limiting issues during testing and development.

This change:
- Sets `WithMaxRetries(0)` for both OpenAI and Anthropic clients to disable automatic retries

## Test plan
- [x] Run `go run ./cli/harness/*.go matrix` to verify client behavior
- [x] Verified that rate limit errors (429) are now immediately propagated without retry delays

