### PR TITLE
cli: new cli module via `github.com/alecthomas/kong` with backword support via go tag.

### DIFF
--- a/cli/harness/commands_kong.go
+++ b/cli/harness/commands_kong.go
@@ -1,0 +1,146 @@
+//go:build kong
+
+package main
+
+import "fmt"
+
+// MatrixKong runs protocol validation matrix tests
+type MatrixKong struct {
+	Scenarios  []string `kong:"flag,name='scenario',short='s',help='Test scenarios'"`
+	Sources    []string `kong:"flag,name='source',help='Source protocols'"`
+	Targets    []string `kong:"flag,name='target',help='Target protocols'"`
+	Streaming  bool     `kong:"flag,name='streaming',help='Run only streaming tests'"`
+	NonStream  bool     `kong:"flag,name='non-stream',help='Run only non-streaming tests'"`
+	JsonOutput bool     `kong:"flag,name='json',help='JSON output'"`
+	Verbose    []bool   `kong:"flag,name='verbose',short='v',help='Verbose level'"`
+	RecordDir  string   `kong:"flag,name='record-dir',help='Recording directory'"`
+	ServerMode string   `kong:"flag,name='server-mode',help='Server reuse mode'"`
+	BatchCount int      `kong:"flag,name='batch',help='Batch count'"`
+}
+
+func (m *MatrixKong) Run() error {
+	cmd := newMatrixCommand()
+	args := buildArgsFromMatrix(m)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func buildArgsFromMatrix(m *MatrixKong) []string {
+	args := []string{}
+	for _, s := range m.Scenarios {
+		args = append(args, "--scenario", s)
+	}
+	for _, s := range m.Sources {
+		args = append(args, "--source", s)
+	}
+	for _, t := range m.Targets {
+		args = append(args, "--target", t)
+	}
+	if m.Streaming {
+		args = append(args, "--streaming")
+	}
+	if m.NonStream {
+		args = append(args, "--non-stream")
+	}
+	if m.JsonOutput {
+		args = append(args, "--json")
+	}
+	for i := 0; i < len(m.Verbose); i++ {
+		args = append(args, "-v")
+	}
+	if m.RecordDir != "" {
+		args = append(args, "--record-dir", m.RecordDir)
+	}
+	if m.ServerMode != "" {
+		args = append(args, "--server-mode", m.ServerMode)
+	}
+	if m.BatchCount > 0 {
+		args = append(args, "--batch", fmt.Sprintf("%d", m.BatchCount))
+	}
+	return args
+}
+
+// AgentKong runs agent e2e tests
+type AgentKong struct {
+	Mock      bool   `kong:"flag,name='mock',help='Use virtual upstream provider'"`
+	Config    string `kong:"flag,name='config',help='Config file for real providers'"`
+	Timeout   int    `kong:"flag,name='timeout',short='t',help='Timeout in seconds'"`
+	AgentType string `kong:"arg,optional,help='Agent type (claude, codex, opencode, batch)'"`
+}
+
+func (a *AgentKong) Run() error {
+	cmd := newAgentCommand()
+	args := []string{}
+	if a.AgentType != "" {
+		args = append(args, a.AgentType)
+	}
+	if a.Mock {
+		args = append(args, "--mock")
+	}
+	if a.Config != "" {
+		args = append(args, "--config", a.Config)
+	}
+	if a.Timeout > 0 {
+		args = append(args, "--timeout", fmt.Sprintf("%d", a.Timeout))
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// ProviderKong runs real provider API tests
+type ProviderKong struct {
+	Test ProviderTestKong `kong:"cmd,help='Run provider tests'"`
+	List ProviderListKong `kong:"cmd,help='List providers'"`
+}
+
+func (p *ProviderKong) Run() error {
+	return p.List.Run()
+}
+
+// ProviderTestKong runs provider tests
+type ProviderTestKong struct {
+	Provider  string   `kong:"arg,optional,help='Provider name or UUID'"`
+	Scenarios []string `kong:"flag,name='scenario',help='Test scenarios'"`
+}
+
+func (p *ProviderTestKong) Run() error {
+	cmd := newProviderCommand()
+	args := []string{"test"}
+	if p.Provider != "" {
+		args = append(args, p.Provider)
+	}
+	for _, s := range p.Scenarios {
+		args = append(args, "--scenario", s)
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// ProviderListKong lists providers
+type ProviderListKong struct{}
+
+func (p *ProviderListKong) Run() error {
+	cmd := newProviderCommand()
+	cmd.SetArgs([]string{"list"})
+	return cmd.Execute()
+}
+
+// InitConfigKong creates config file template
+type InitConfigKong struct {
+	Output string `kong:"flag,name='output',short='o',help='Output file path'"`
+}
+
+func (i *InitConfigKong) Run() error {
+	return runInitConfig(i.Output)
+}
+
+// VersionKong shows version
+type VersionKong struct{}
+
+func (v *VersionKong) Run() error {
+	fmt.Printf("Tingly-Box Protocol Validation Harness\n")
+	fmt.Printf("Version:   %s\n", version)
+	fmt.Printf("Commit:    %s\n", gitCommit)
+	fmt.Printf("Built:     %s\n", buildTime)
+	return nil
+}

--- a/cli/harness/main.go
+++ b/cli/harness/main.go
@@ -1,3 +1,6 @@
+//go:build !kong
+//go:build !kong
+
 // Package main provides the CLI harness for protocol validation testing.
 //
 // The harness provides three testing modes:
@@ -55,3 +58,5 @@ func init() {
 	rootCmd.AddCommand(newProviderCommand())
 	rootCmd.AddCommand(newInitConfigCommand())
 }
+
+// Original cobra version - only built when kong tag is NOT set

--- a/cli/harness/main_kong.go
+++ b/cli/harness/main_kong.go
@@ -1,0 +1,43 @@
+//go:build kong
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/kong"
+)
+
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
+// CLI is the main Kong CLI structure for harness
+type CLI struct {
+	Version VersionKong `kong:"cmd,help='Show version'"`
+
+	// Subcommands
+	Matrix     MatrixKong     `kong:"cmd,help='Run protocol validation matrix tests'"`
+	Agent      AgentKong      `kong:"cmd,help='Run agent e2e tests'"`
+	Provider   ProviderKong   `kong:"cmd,help='Run real provider API tests'"`
+	InitConfig InitConfigKong `kong:"cmd,help='Create config file template'"`
+}
+
+func main() {
+	var cli CLI
+
+	ctx := kong.Parse(&cli, kong.Vars{
+		"version":   version,
+		"gitCommit": gitCommit,
+		"buildTime": buildTime,
+	})
+
+	// Run the selected command
+	if err := ctx.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cli/tingly-box/cli.go
+++ b/cli/tingly-box/cli.go
@@ -1,3 +1,5 @@
+//go:build !kong
+
 package main
 
 import (

--- a/cli/tingly-box/main_kong.go
+++ b/cli/tingly-box/main_kong.go
@@ -1,0 +1,116 @@
+//go:build kong
+
+// Kong version of main - for testing migration
+// Build with: go build -tags kong ./cli/tingly-box
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/kong"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/command"
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/pkg/fs"
+)
+
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+	goVersion = "unknown"
+	platform  = "unknown"
+)
+
+// CLI is the main Kong CLI structure
+type CLI struct {
+	ConfigDir string `kong:"flag,name='config-dir',help='Configuration directory'"`
+	Verbose   bool   `kong:"flag,name='verbose',short='v',help='Verbose output'"`
+
+	// Server commands
+	Start   command.StartCmdKong   `kong:"cmd,help='Start the server'"`
+	Stop    command.StopCmdKong    `kong:"cmd,help='Stop the server'"`
+	Status  command.StatusCmdKong  `kong:"cmd,help='Show status'"`
+	Restart command.RestartCmdKong `kong:"cmd,help='Restart the server'"`
+	Open    command.OpenCmdKong    `kong:"cmd,help='Open web UI'"`
+
+	// Provider commands
+	Provider command.ProviderCmdKong `kong:"cmd,help='Manage providers'"`
+
+	// Agent commands
+	Agent command.AgentCmdKong `kong:"cmd,help='Agent configuration'"`
+
+	// OAuth
+	OAuth command.OAuthCmdKong `kong:"cmd,help='OAuth authentication'"`
+
+	// Import/Export
+	Export command.ExportCmdKong `kong:"cmd,help='Export configuration'"`
+	Import command.ImportCmdKong `kong:"cmd,help='Import configuration'"`
+
+	// Claude Code
+	CC command.CCmdKong `kong:"cmd,help='Launch Claude Code',passthrough"`
+
+	// Other commands
+	Swagger    command.SwaggerCmdKong    `kong:"cmd,help='Generate OpenAPI schema'"`
+	Quota      command.QuotaCmdKong      `kong:"cmd,help='Quota information'"`
+	Remote     command.RemoteCmdKong     `kong:"cmd,help='Remote control'"`
+	Quickstart command.QuickstartCmdKong `kong:"cmd,help='Guided setup'"`
+	MCP        command.MCPCmdKong        `kong:"cmd,help='MCP builtin server'"`
+
+	// Version
+	Version command.VersionCmdKong `kong:"cmd,help='Show version'"`
+}
+
+func main() {
+	var cli CLI
+
+	// Parse CLI
+	ctx := kong.Parse(&cli, kong.Vars{
+		"version":   version,
+		"gitCommit": gitCommit,
+		"buildTime": buildTime,
+		"goVersion": goVersion,
+		"platform":  platform,
+	})
+
+	// Setup verbose logging
+	if cli.Verbose {
+		logrus.SetLevel(logrus.TraceLevel)
+	}
+
+	// Initialize config
+	var appConfig *config.AppConfig
+	var err error
+
+	configDir := cli.ConfigDir
+	if configDir != "" {
+		expandedDir, expandErr := fs.ExpandConfigDir(configDir)
+		if expandErr == nil {
+			appConfig, err = config.NewAppConfig(config.WithConfigDir(expandedDir))
+		} else {
+			err = expandErr
+		}
+	}
+	if appConfig == nil && err == nil {
+		appConfig, err = config.NewAppConfig()
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to initialize config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if appConfig != nil {
+		appConfig.SetVersion(version)
+	}
+
+	appManager := command.NewAppManagerWithConfig(appConfig)
+
+	// Run the selected command
+	if err := ctx.Run(appManager); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	cloud.google.com/go/auth v0.18.2 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
+	github.com/alecthomas/kong v1.15.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bwmarrin/discordgo v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2 h1:/yrfI55LRt1M7H1vkaw+NaH1+L1CDxrqDltwm5euVuE=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2/go.mod h1:jA4OqHKTQ4AFBdwrSnwnskUIIS3HYzlJSgdzCKqfavo=
+github.com/alecthomas/kong v1.15.0 h1:BVJstKbpO73zKpmIu+m/aLRrNmWwxXPIGTNin9VmLVI=
+github.com/alecthomas/kong v1.15.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/command/agent_kong.go
+++ b/internal/command/agent_kong.go
@@ -1,0 +1,78 @@
+//go:build kong
+
+package command
+
+import ()
+
+// AgentCmdKong is the Kong version of agent command
+type AgentCmdKong struct {
+	Apply AgentApplyCmdKong `kong:"cmd,help='Apply agent configuration'"`
+	List  AgentListCmdKong  `kong:"cmd,help='List configured agents'"`
+	Show  AgentShowCmdKong  `kong:"cmd,help='Show agent configuration details'"`
+}
+
+func (a *AgentCmdKong) Run(appManager *AppManager) error {
+	// For now, call the existing cobra command
+	cmd := AgentCommand(appManager)
+	cmd.SetArgs([]string{})
+	return cmd.Execute()
+}
+
+// AgentApplyCmdKong applies an agent configuration
+type AgentApplyCmdKong struct {
+	AgentType string `kong:"arg,optional,help='Agent type (claude-code, opencode, codex)'"`
+	Provider  string `kong:"flag,name='provider',help='Provider UUID'"`
+	Model     string `kong:"flag,name='model',help='Model name'"`
+	Unified   bool   `kong:"flag,name='unified',default='true',help='Unified mode'"`
+	Force     bool   `kong:"flag,name='force',help='Skip confirmation'"`
+	Preview   bool   `kong:"flag,name='preview',help='Preview without applying'"`
+}
+
+func (a *AgentApplyCmdKong) Run(appManager *AppManager) error {
+	cmd := AgentCommand(appManager)
+	args := []string{"apply"}
+	if a.AgentType != "" {
+		args = append(args, a.AgentType)
+	}
+	if a.Provider != "" {
+		args = append(args, "--provider", a.Provider)
+	}
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	if a.Unified {
+		args = append(args, "--unified=true")
+	}
+	if a.Force {
+		args = append(args, "--force")
+	}
+	if a.Preview {
+		args = append(args, "--preview")
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// AgentListCmdKong lists configured agents
+type AgentListCmdKong struct{}
+
+func (a *AgentListCmdKong) Run(appManager *AppManager) error {
+	cmd := AgentCommand(appManager)
+	cmd.SetArgs([]string{"list"})
+	return cmd.Execute()
+}
+
+// AgentShowCmdKong shows agent configuration details
+type AgentShowCmdKong struct {
+	AgentType string `kong:"arg,optional,help='Agent type to show'"`
+}
+
+func (a *AgentShowCmdKong) Run(appManager *AppManager) error {
+	cmd := AgentCommand(appManager)
+	args := []string{"show"}
+	if a.AgentType != "" {
+		args = append(args, a.AgentType)
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}

--- a/internal/command/cc_kong.go
+++ b/internal/command/cc_kong.go
@@ -1,0 +1,17 @@
+//go:build kong
+
+package command
+
+// CCmdKong launches Claude Code with passthrough mode
+// Kong's passthrough mode requires at least one positional arg
+type CCmdKong struct {
+	Args []string `kong:"arg,optional,passthrough"`
+}
+
+func (c *CCmdKong) Run(appManager *AppManager) error {
+	profile, claudeArgs, err := parseCCFlags(c.Args)
+	if err != nil {
+		return err
+	}
+	return runCC(appManager, profile, claudeArgs)
+}

--- a/internal/command/export_kong.go
+++ b/internal/command/export_kong.go
@@ -1,0 +1,35 @@
+//go:build kong
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ExportCmdKong exports routing rules
+type ExportCmdKong struct {
+	RequestModel string `kong:"flag,name='request-model',required,help='Request model name'"`
+	Scenario     string `kong:"flag,name='scenario',required,help='Rule scenario'"`
+	Format       string `kong:"flag,name='format',default='jsonl',help='Export format (jsonl, base64)'"`
+	Output       string `kong:"flag,name='output',short='o',help='Output file path'"`
+}
+
+func (e *ExportCmdKong) Run(appManager *AppManager) error {
+	// Create a mock cobra command for the existing runExport function
+	mockCmd := &cobra.Command{}
+	if err := mockCmd.Flags().Set("request-model", e.RequestModel); err != nil {
+		return err
+	}
+	if err := mockCmd.Flags().Set("scenario", e.Scenario); err != nil {
+		return err
+	}
+	if err := mockCmd.Flags().Set("format", e.Format); err != nil {
+		return err
+	}
+	if e.Output != "" {
+		if err := mockCmd.Flags().Set("output", e.Output); err != nil {
+			return err
+		}
+	}
+	return runExport(appManager, mockCmd)
+}

--- a/internal/command/import_kong.go
+++ b/internal/command/import_kong.go
@@ -1,0 +1,13 @@
+//go:build kong
+
+package command
+
+// ImportCmdKong imports routing rules
+type ImportCmdKong struct {
+	File   string `kong:"arg,optional,help='Import file path (default: stdin)'"`
+	Format string `kong:"flag,name='format',default='auto',help='Import format (auto, jsonl, base64)'"`
+}
+
+func (i *ImportCmdKong) Run(appManager *AppManager) error {
+	return runImport(appManager, i.Format, []string{i.File})
+}

--- a/internal/command/mcp_kong.go
+++ b/internal/command/mcp_kong.go
@@ -1,0 +1,16 @@
+//go:build kong
+
+package command
+
+// MCPCmdKong manages MCP builtin server
+type MCPCmdKong struct {
+	Builtin MCPBuiltinCmdKong `kong:"cmd,help='MCP builtin server'"`
+}
+
+// MCPBuiltinCmdKong runs MCP builtin server
+type MCPBuiltinCmdKong struct{}
+
+func (m *MCPBuiltinCmdKong) Run(appManager *AppManager) error {
+	cmd := MCPBuiltinCommand()
+	return cmd.Execute()
+}

--- a/internal/command/oauth_kong.go
+++ b/internal/command/oauth_kong.go
@@ -1,0 +1,18 @@
+//go:build kong
+
+package command
+
+// OAuthCmdKong handles OAuth authentication
+type OAuthCmdKong struct {
+	// Positional argument (optional)
+	Provider string `kong:"arg,optional,help='Provider type (e.g., claude_code, qwen_code, codex)'"`
+
+	// Flags
+	Name     string `kong:"flag,name='name',short='n',help='Custom name for the provider'"`
+	Port     int    `kong:"flag,name='port',short='p',help='Callback server port'"`
+	ProxyURL string `kong:"flag,name='proxy',short='x',help='Proxy URL for OAuth requests'"`
+}
+
+func (o *OAuthCmdKong) Run(appManager *AppManager) error {
+	return runOAuthFlow(appManager.AppConfig(), o.Provider, o.Name, o.Port, o.ProxyURL)
+}

--- a/internal/command/open_kong.go
+++ b/internal/command/open_kong.go
@@ -1,0 +1,83 @@
+//go:build kong
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/tingly-dev/tingly-box/internal/command/options"
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/feature"
+	"github.com/tingly-dev/tingly-box/pkg/lock"
+	"github.com/tingly-dev/tingly-box/pkg/network"
+)
+
+// OpenCmdKong opens the web UI
+type OpenCmdKong struct {
+	// Embed StartCmdKong to share server flags
+	StartCmdKong
+}
+
+func (o *OpenCmdKong) Run(appManager *AppManager) error {
+	opts := resolveStartCmdKongOptions(&o.StartCmdKong, appManager.AppConfig())
+	appConfig := appManager.AppConfig()
+	fileLock := lock.NewFileLock(appConfig.ConfigDir())
+
+	if fileLock.IsLocked() {
+		port := appConfig.GetServerPort()
+		globalConfig := appManager.GetGlobalConfig()
+
+		host := opts.Host
+		if host == "" {
+			host = "localhost"
+		}
+		resolvedHost := network.ResolveHost(host)
+
+		webUIURL := fmt.Sprintf("http://%s:%d/", resolvedHost, port)
+		if globalConfig.HasUserToken() {
+			webUIURL = fmt.Sprintf("http://%s:%d/login/%s", resolvedHost, port, globalConfig.GetUserToken())
+		}
+
+		fmt.Printf("Opening web UI: %s\n", webUIURL)
+		return openBrowserURL(webUIURL)
+	}
+
+	fmt.Println("Server is not running, starting it...")
+	return startServer(appManager, opts)
+}
+
+// resolveStartCmdKongOptions converts StartCmdKong to StartServerOptions
+func resolveStartCmdKongOptions(start *StartCmdKong, appConfig *config.AppConfig) options.StartServerOptions {
+	resolvedDebug := start.EnableDebug
+	if !start.EnableDebug {
+		resolvedDebug = appConfig.GetDebug()
+	}
+
+	resolvedPort := start.Port
+	if resolvedPort == 0 {
+		resolvedPort = appConfig.GetServerPort()
+	} else {
+		appConfig.SetServerPort(start.Port)
+	}
+
+	resolvedRecordDir := start.RecordDir
+	if resolvedRecordDir == "" {
+		resolvedRecordDir = appConfig.ConfigDir() + "/record"
+	}
+
+	experimentalFeatures := feature.ParseFeatures(start.Expr)
+
+	return options.StartServerOptions{
+		Host:                 start.Host,
+		Port:                 resolvedPort,
+		EnableUI:             start.EnableUI,
+		EnableDebug:          resolvedDebug,
+		EnableOpenBrowser:    start.EnableOpenBrowser,
+		Daemon:               start.Daemon,
+		LogFile:              start.LogFile,
+		PromptRestart:        start.PromptRestart,
+		RecordMode:           start.RecordMode,
+		RecordDir:            resolvedRecordDir,
+		ExperimentalFeatures: experimentalFeatures,
+	}
+}

--- a/internal/command/provider_kong.go
+++ b/internal/command/provider_kong.go
@@ -1,0 +1,45 @@
+//go:build kong
+
+package command
+
+// ProviderCmdKong is the Kong version of provider command
+type ProviderCmdKong struct {
+	Add  ProviderAddCmdKong  `kong:"cmd,help='Add a new provider'"`
+	List ProviderListCmdKong `kong:"cmd,help='List all providers'"`
+}
+
+func (p *ProviderCmdKong) Run(appManager *AppManager) error {
+	return runProviderInteractiveMode(appManager)
+}
+
+// ProviderAddCmdKong adds a new provider
+type ProviderAddCmdKong struct {
+	Name     string `kong:"arg,optional,help='Provider name'"`
+	BaseURL  string `kong:"arg,optional,help='API base URL'"`
+	Token    string `kong:"arg,optional,help='API token'"`
+	APIStyle string `kong:"arg,optional,help='API style (openai, anthropic)'"`
+}
+
+func (p *ProviderAddCmdKong) Run(appManager *AppManager) error {
+	args := []string{}
+	if p.Name != "" {
+		args = append(args, p.Name)
+	}
+	if p.BaseURL != "" {
+		args = append(args, p.BaseURL)
+	}
+	if p.Token != "" {
+		args = append(args, p.Token)
+	}
+	if p.APIStyle != "" {
+		args = append(args, p.APIStyle)
+	}
+	return runAdd(appManager, args)
+}
+
+// ProviderListCmdKong lists all providers
+type ProviderListCmdKong struct{}
+
+func (p *ProviderListCmdKong) Run(appManager *AppManager) error {
+	return runProviderList(appManager)
+}

--- a/internal/command/quickstart_kong.go
+++ b/internal/command/quickstart_kong.go
@@ -1,0 +1,12 @@
+//go:build kong
+
+package command
+
+// QuickstartCmdKong runs the guided setup wizard
+type QuickstartCmdKong struct {
+	UseTUI bool `kong:"flag,name='tui',short='t',default='true',help='Use interactive TUI mode'"`
+}
+
+func (q *QuickstartCmdKong) Run(appManager *AppManager) error {
+	return runQuickstart(appManager)
+}

--- a/internal/command/quota_kong.go
+++ b/internal/command/quota_kong.go
@@ -1,0 +1,59 @@
+//go:build kong
+
+package command
+
+// QuotaCmdKong is the Kong version of quota command
+type QuotaCmdKong struct {
+	List    QuotaListCmdKong    `kong:"cmd,help='List all provider quotas'"`
+	Get     QuotaGetCmdKong     `kong:"cmd,help='Get provider quota details'"`
+	Refresh QuotaRefreshCmdKong `kong:"cmd,help='Refresh provider quota data'"`
+	Summary QuotaSummaryCmdKong `kong:"cmd,help='Show quota summary'"`
+}
+
+func (q *QuotaCmdKong) Run(appManager *AppManager) error {
+	return runQuotaList(appManager)
+}
+
+// QuotaListCmdKong lists quotas
+type QuotaListCmdKong struct {
+	Refresh bool `kong:"flag,name='refresh',short='r',help='Refresh before listing'"`
+}
+
+func (q *QuotaListCmdKong) Run(appManager *AppManager) error {
+	if q.Refresh {
+		return runQuotaRefresh(appManager)
+	}
+	return runQuotaList(appManager)
+}
+
+// QuotaGetCmdKong gets quota details
+type QuotaGetCmdKong struct {
+	Provider string `kong:"arg,optional,help='Provider name or UUID'"`
+	Refresh  bool   `kong:"flag,name='refresh',short='r',help='Refresh before displaying'"`
+}
+
+func (q *QuotaGetCmdKong) Run(appManager *AppManager) error {
+	if q.Provider == "" {
+		return runQuotaGetInteractive(appManager)
+	}
+	return runQuotaGet(appManager, q.Provider, q.Refresh)
+}
+
+// QuotaRefreshCmdKong refreshes quota data
+type QuotaRefreshCmdKong struct {
+	Provider string `kong:"arg,optional,help='Provider name or UUID'"`
+}
+
+func (q *QuotaRefreshCmdKong) Run(appManager *AppManager) error {
+	if q.Provider == "" {
+		return runQuotaRefresh(appManager)
+	}
+	return runQuotaRefreshProvider(appManager, q.Provider)
+}
+
+// QuotaSummaryCmdKong shows quota summary
+type QuotaSummaryCmdKong struct{}
+
+func (q *QuotaSummaryCmdKong) Run(appManager *AppManager) error {
+	return runQuotaSummary(appManager)
+}

--- a/internal/command/remote_kong.go
+++ b/internal/command/remote_kong.go
@@ -1,0 +1,49 @@
+//go:build kong
+
+package command
+
+// RemoteCmdKong manages remote control
+type RemoteCmdKong struct {
+	List   RemoteListCmdKong   `kong:"cmd,help='List remote sessions'"`
+	Start  RemoteStartCmdKong  `kong:"cmd,help='Start a remote session'"`
+	Config RemoteConfigCmdKong `kong:"cmd,help='Configure remote settings'"`
+}
+
+func (r *RemoteCmdKong) Run(appManager *AppManager) error {
+	cmd := RemoteCommand(appManager)
+	cmd.SetArgs([]string{"list"})
+	return cmd.Execute()
+}
+
+// RemoteListCmdKong lists remote sessions
+type RemoteListCmdKong struct{}
+
+func (r *RemoteListCmdKong) Run(appManager *AppManager) error {
+	cmd := RemoteCommand(appManager)
+	cmd.SetArgs([]string{"list"})
+	return cmd.Execute()
+}
+
+// RemoteStartCmdKong starts a remote session
+type RemoteStartCmdKong struct {
+	Name string `kong:"arg,optional,help='Session name'"`
+}
+
+func (r *RemoteStartCmdKong) Run(appManager *AppManager) error {
+	cmd := RemoteCommand(appManager)
+	args := []string{"start"}
+	if r.Name != "" {
+		args = append(args, r.Name)
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// RemoteConfigCmdKong configures remote settings
+type RemoteConfigCmdKong struct{}
+
+func (r *RemoteConfigCmdKong) Run(appManager *AppManager) error {
+	cmd := RemoteCommand(appManager)
+	cmd.SetArgs([]string{"config"})
+	return cmd.Execute()
+}

--- a/internal/command/server_kong.go
+++ b/internal/command/server_kong.go
@@ -1,0 +1,184 @@
+//go:build kong
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tingly-dev/tingly-box/internal/command/options"
+	"github.com/tingly-dev/tingly-box/pkg/lock"
+)
+
+// StartCmdKong is the Kong version of start command
+type StartCmdKong struct {
+	Port                 int    `kong:"flag,name='port',short='p',help='Server port'"`
+	Host                 string `kong:"flag,name='host',help='Server host'"`
+	EnableUI             bool   `kong:"flag,name='ui',short='u',default='true',help='Enable web UI'"`
+	EnableDebug          bool   `kong:"flag,name='debug',help='Enable debug mode'"`
+	EnableOpenBrowser    bool   `kong:"flag,name='browser',default='true',help='Auto-open browser'"`
+	EnableStyleTransform bool   `kong:"flag,name='adapter',default='true',help='Enable API style transform'"`
+	Daemon               bool   `kong:"flag,name='daemon',help='Run as daemon'"`
+	LogFile              string `kong:"flag,name='log-file',help='Log file path'"`
+	PromptRestart        bool   `kong:"flag,name='prompt-restart',help='Prompt to restart if running'"`
+	RecordMode           string `kong:"flag,name='record-mode',help='Record mode'"`
+	RecordDir            string `kong:"flag,name='record-dir',help='Record directory'"`
+	Expr                 string `kong:"flag,name='expr',help='Experimental features'"`
+}
+
+func (s *StartCmdKong) Run(appManager *AppManager) error {
+	flags := options.StartFlags{
+		Port:                 s.Port,
+		Host:                 s.Host,
+		EnableUI:             s.EnableUI,
+		EnableDebug:          s.EnableDebug,
+		EnableOpenBrowser:    s.EnableOpenBrowser,
+		EnableStyleTransform: s.EnableStyleTransform,
+		Daemon:               s.Daemon,
+		LogFile:              s.LogFile,
+		PromptRestart:        s.PromptRestart,
+		RecordMode:           s.RecordMode,
+		RecordDir:            s.RecordDir,
+		Expr:                 s.Expr,
+	}
+	mockCmd := &cobra.Command{}
+	if s.EnableDebug {
+		mockCmd.Flags().Set("debug", "true")
+	}
+	if s.Port != 0 {
+		mockCmd.Flags().Set("port", fmt.Sprintf("%d", s.Port))
+	}
+	opts := options.ResolveStartOptions(mockCmd, flags, appManager.AppConfig())
+	return startServer(appManager, opts)
+}
+
+// StopCmdKong is the Kong version of stop command
+type StopCmdKong struct{}
+
+func (s *StopCmdKong) Run(appManager *AppManager) error {
+	return doStopServer(appManager)
+}
+
+// StatusCmdKong is the Kong version of status command
+type StatusCmdKong struct{}
+
+func (s *StatusCmdKong) Run(appManager *AppManager) error {
+	return runStatusCmd(appManager)
+}
+
+// RestartCmdKong is the Kong version of restart command
+type RestartCmdKong struct {
+	StartCmdKong
+}
+
+func (r *RestartCmdKong) Run(appManager *AppManager) error {
+	appConfig := appManager.AppConfig()
+	fileLock := lock.NewFileLock(appConfig.ConfigDir())
+	wasRunning := fileLock.IsLocked()
+
+	if wasRunning {
+		fmt.Println("Stopping current server...")
+		if err := stopServerWithFileLock(fileLock); err != nil {
+			return fmt.Errorf("failed to stop server: %w", err)
+		}
+		fmt.Println("Server stopped successfully")
+	} else {
+		fmt.Println("Server was not running, starting it...")
+	}
+
+	flags := options.StartFlags{
+		Port:                 r.Port,
+		Host:                 r.Host,
+		EnableUI:             r.EnableUI,
+		EnableDebug:          r.EnableDebug,
+		EnableOpenBrowser:    r.EnableOpenBrowser,
+		EnableStyleTransform: r.EnableStyleTransform,
+		Daemon:               r.Daemon,
+		LogFile:              r.LogFile,
+		PromptRestart:        r.PromptRestart,
+		RecordMode:           r.RecordMode,
+		RecordDir:            r.RecordDir,
+		Expr:                 r.Expr,
+	}
+	mockCmd := &cobra.Command{}
+	if r.EnableDebug {
+		mockCmd.Flags().Set("debug", "true")
+	}
+	if r.Port != 0 {
+		mockCmd.Flags().Set("port", fmt.Sprintf("%d", r.Port))
+	}
+	opts := options.ResolveStartOptions(mockCmd, flags, appManager.AppConfig())
+	return startServer(appManager, opts)
+}
+
+// VersionCmdKong is the Kong version of version command
+type VersionCmdKong struct{}
+
+func (v *VersionCmdKong) Run(appManager *AppManager) error {
+	appConfig := appManager.AppConfig()
+	fmt.Printf("Tingly Box CLI\n")
+	fmt.Printf("Version:    %s\n", appConfig.GetVersion())
+	return nil
+}
+
+// runStatusCmd extracts status logic
+func runStatusCmd(appManager *AppManager) error {
+	providers := appManager.ListProviders()
+	appConfig := appManager.AppConfig()
+	fileLock := lock.NewFileLock(appConfig.ConfigDir())
+	serverRunning := fileLock.IsLocked()
+	globalConfig := appManager.GetGlobalConfig()
+
+	fmt.Println("=== Tingly Box Status ===")
+	fmt.Printf("Server Status: ")
+	if serverRunning {
+		fmt.Printf("Running\n")
+		port := appConfig.GetServerPort()
+		fmt.Printf("Port: %d\n", port)
+		fmt.Printf("OpenAI Style API Endpoint: http://localhost:%d/tingly/openai/v1/chat/completions\n", port)
+		fmt.Printf("Anthropic Style API Endpoint: http://localhost:%d/tingly/anthropic/v1/messages\n", port)
+		if globalConfig.HasUserToken() {
+			fmt.Printf("Web UI: http://localhost:%d/login/%s\n", port, globalConfig.GetUserToken())
+		} else {
+			fmt.Printf("Web UI: http://localhost:%d/\n", port)
+		}
+	} else {
+		fmt.Printf("Stopped\n")
+	}
+
+	fmt.Printf("\nAuthentication:\n")
+	if globalConfig.HasModelToken() {
+		fmt.Printf("  Model API Key: Configured (sk-tingly- format)\n")
+	} else {
+		fmt.Printf("  Model API Key: Not configured (will auto-generate on start)\n")
+	}
+
+	fmt.Printf("\nConfigured Providers: %d\n", len(providers))
+	if len(providers) > 0 {
+		fmt.Println("Providers:")
+		for _, provider := range providers {
+			status := "Disabled"
+			if provider.Enabled {
+				status = "Enabled"
+			}
+			fmt.Printf("  - %s (%s) [%s]: %s\n", provider.Name, provider.APIBase, provider.APIStyle, status)
+		}
+	}
+
+	cfg := appConfig.GetGlobalConfig()
+	rules := cfg.Rules
+	fmt.Printf("\nConfigured Rules: %d\n", len(rules))
+	if len(rules) > 0 {
+		fmt.Println("Rules:")
+		for _, rule := range rules {
+			status := "Inactive"
+			if rule.Active {
+				status = "Active"
+			}
+			serviceCount := len(rule.GetServices())
+			fmt.Printf("  - %s -> %s: %s (%d services)\n", rule.RequestModel, rule.ResponseModel, status, serviceCount)
+		}
+	}
+
+	return nil
+}

--- a/internal/command/swagger_kong.go
+++ b/internal/command/swagger_kong.go
@@ -1,0 +1,56 @@
+//go:build kong
+
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/tingly-dev/tingly-box/internal/server"
+)
+
+// SwaggerCmdKong generates OpenAPI schema
+type SwaggerCmdKong struct {
+	Output string `kong:"flag,name='output',short='o',help='Output file path'"`
+	Stdout bool   `kong:"flag,name='stdout',help='Write to stdout'"`
+}
+
+func (s *SwaggerCmdKong) Run(appManager *AppManager) error {
+	mockCmd := &cobra.Command{}
+	if s.Output != "" {
+		mockCmd.Flags().Set("output", s.Output)
+	}
+	if s.Stdout {
+		mockCmd.Flags().Set("stdout", "true")
+	}
+	// For now, just call the existing command's RunE logic
+	return runSwagger(appManager, s.Output, s.Stdout)
+}
+
+// runSwagger extracts swagger logic from SwaggerCommand
+func runSwagger(appManager *AppManager, output string, stdout bool) error {
+	cfg := appManager.GetGlobalConfig()
+	if cfg == nil {
+		return fmt.Errorf("config not available")
+	}
+
+	json, err := server.GenerateOpenAPI(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to generate OpenAPI schema: %w", err)
+	}
+
+	if stdout {
+		fmt.Println(json)
+	} else {
+		if output == "" {
+			output = "openapi.json"
+		}
+		if err := os.WriteFile(output, []byte(json), 0644); err != nil {
+			return fmt.Errorf("failed to write to file %s: %w", output, err)
+		}
+		fmt.Fprintf(os.Stderr, "OpenAPI schema written to: %s\n", output)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary 
Introduces a new CLI implementation using `github.com/alecthomas/kong` alongside the existing Cobra-based CLI, enabling gradual migration and evaluation of alternative CLI frameworks. 

The implementation uses Go build tags to allow both versions to coexist without conflicts.

## Preview

```
Usage: tingly-box <command> [flags]

Flags:
  -h, --help                 Show context-sensitive help.
      --config-dir=STRING    Configuration directory
  -v, --verbose              Verbose output

Commands:
  start [flags]
    Start the server

  stop [flags]
    Stop the server

  status [flags]
    Show status

  restart [flags]
    Restart the server

  open [flags]
    Open web UI

  provider add [<name> [<base-url> [<token> [<api-style>]]]]
    Add a new provider

  provider list
    List all providers

  agent apply [<agent-type>] [flags]
    Apply agent configuration

  agent list
    List configured agents

  agent show [<agent-type>]
    Show agent configuration details

  o-auth [<provider>] [flags]
    OAuth authentication

  export --request-model=STRING --scenario=STRING [flags]
    Export configuration

  import [<file>] [flags]
    Import configuration

  cc [<args> ...] [flags]
    Launch Claude Code

  swagger [flags]
    Generate OpenAPI schema

  quota list [flags]
    List all provider quotas

  quota get [<provider>] [flags]
    Get provider quota details

  quota refresh [<provider>]
    Refresh provider quota data

  quota summary
    Show quota summary

  remote list
    List remote sessions

  remote start [<name>]
    Start a remote session

  remote config
    Configure remote settings

  quickstart [flags]
    Guided setup

  mcp builtin
    MCP builtin server

  version [flags]
    Show version

Run "tingly-box <command> --help" for more information on a command.
```