### PR TITLE
feat(ui): remember agent page selection across sessions, and fix api missing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -295,8 +295,13 @@ function AppContent() {
                         </ProtectedRoute>
                     }
                 >
-                    {/* Default redirect */}
-                    <Route index element={<Navigate to="/dashboard/7d" replace />} />
+                    {/* Default redirect - use layout memory (localStorage), fallback to agent page */}
+                    <Route index element={<Navigate to={
+                        (() => {
+                            const activeActivity = localStorage.getItem('layout.activeActivity') || 'scenario';
+                            return localStorage.getItem(`layout.activityPath.${activeActivity}`) || '/agent/claude_code';
+                        })()
+                    } replace />} />
                     {/* Function panel routes */}
                     <Route path="/agent/openai" element={<UseOpenAIPage />} />
                     <Route path="/agent/anthropic" element={<UseAnthropicPage />} />
@@ -387,7 +392,7 @@ function AppContent() {
                     {/* Legacy zen redirects */}
                     <Route path="/zen/claude-code" element={<Navigate to="/zen/claude_code" replace />} />
                     {/* Catch-all redirect for unknown routes */}
-                    <Route path="*" element={<Navigate to="/dashboard/7d" replace />} />
+                    <Route path="*" element={<Navigate to="/agent/claude_code" replace />} />
                 </Route>
             </Routes>
     )

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -51,15 +51,15 @@ const Layout = ({ children }: LayoutProps) => {
     const isChildActive = (children?: ActivityItem['children']) =>
         children?.some(item => item.type !== 'divider' && isActive(item.path)) ?? false;
 
-    // Determine active activity from current path, falling back to sessionStorage
+    // Determine active activity from current path, falling back to localStorage
     const activeActivity = useMemo(() => {
         for (const item of activityItems) {
             if (item.path && isActive(item.path)) return item.key;
             if (item.children && isChildActive(item.children)) return item.key;
         }
-        const saved = sessionStorage.getItem('layout.activeActivity');
+        const saved = sessionStorage.getItem('layout.activeActivity') || localStorage.getItem('layout.activeActivity');
         if (saved && activityItems.some(item => item.key === saved)) return saved;
-        return 'dashboard';
+        return 'scenario';
     }, [activityItems, location.pathname]);
 
     // In zen mode, active activity is based on current zen path
@@ -72,10 +72,12 @@ const Layout = ({ children }: LayoutProps) => {
         return activeActivity;
     }, [effectiveZenEnabled, location.pathname, activeActivity]);
 
-    // Persist active activity + last visited path
+    // Persist active activity + last visited path (localStorage for cross-session memory)
     useEffect(() => {
         sessionStorage.setItem('layout.activeActivity', activeActivity);
         sessionStorage.setItem(`layout.activityPath.${activeActivity}`, location.pathname);
+        localStorage.setItem('layout.activeActivity', activeActivity);
+        localStorage.setItem(`layout.activityPath.${activeActivity}`, location.pathname);
     }, [activeActivity, location.pathname]);
 
     // When navigating to a zen path, clear zenMoreActivity

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1366,6 +1366,30 @@ export const api = {
 
     // ========== ImBot Settings API ==========
 
+    // Get ImBot platform configurations
+    getImBotPlatforms: async (): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.GET('/api/v1/imbot-platforms', {headers});
+            return response.data;
+        } catch (error: any) {
+            return {success: false, error: error.message};
+        }
+    },
+
+    // List all ImBot settings
+    getImBotSettingsList: async (): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.GET('/api/v1/imbot-settings', {headers});
+            return response.data;
+        } catch (error: any) {
+            return {success: false, error: error.message};
+        }
+    },
+
     // List all ImBot settings
     listImbotSettings: async (): Promise<any> => {
         try {
@@ -1458,6 +1482,112 @@ export const api = {
             const client = await getClient();
             const headers = await getAuthHeaders();
             const response = await client.DELETE('/api/v1/imbot-settings/{uuid}', {
+                headers,
+                params: {path: {uuid}}
+            });
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 404) {
+                return {success: false, error: 'ImBot setting not found'};
+            }
+            return {success: false, error: error.message};
+        }
+    },
+
+    // Aliases using getImBot* naming convention (used by BotPage and PlatformBotPage)
+    getImBotSetting: async (uuid: string): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.GET('/api/v1/imbot-settings/{uuid}', {
+                headers,
+                params: {path: {uuid}}
+            });
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 404) {
+                return {success: false, error: 'ImBot setting not found'};
+            }
+            return {success: false, error: error.message};
+        }
+    },
+
+    createImBotSetting: async (data: {
+        name?: string;
+        platform: string;
+        auth_type: string;
+        auth?: Record<string, string>;
+        proxy_url?: string;
+        chat_id?: string;
+        bash_allowlist?: string[];
+        default_agent?: string;
+        agent_type?: string;
+        default_cwd?: string;
+        enabled?: boolean;
+    }): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.POST('/api/v1/imbot-settings', {
+                headers,
+                body: data as any
+            });
+            return response.data;
+        } catch (error: any) {
+            return {success: false, error: error.message};
+        }
+    },
+
+    updateImBotSetting: async (uuid: string, data: {
+        name?: string;
+        auth_type?: string;
+        auth?: Record<string, string>;
+        proxy_url?: string;
+        chat_id?: string;
+        bash_allowlist?: string[];
+        enabled?: boolean;
+        default_agent?: string;
+        default_cwd?: string;
+    }): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.PUT('/api/v1/imbot-settings/{uuid}', {
+                headers,
+                params: {path: {uuid}},
+                body: data
+            });
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 404) {
+                return {success: false, error: 'ImBot setting not found'};
+            }
+            return {success: false, error: error.message};
+        }
+    },
+
+    deleteImBotSetting: async (uuid: string): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.DELETE('/api/v1/imbot-settings/{uuid}', {
+                headers,
+                params: {path: {uuid}}
+            });
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 404) {
+                return {success: false, error: 'ImBot setting not found'};
+            }
+            return {success: false, error: error.message};
+        }
+    },
+
+    toggleImBotSetting: async (uuid: string): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.POST('/api/v1/imbot-settings/{uuid}/toggle', {
                 headers,
                 params: {path: {uuid}}
             });


### PR DESCRIPTION
## Summary
The app was losing user's navigation context on page load - always redirecting to dashboard regardless of where the user left off. 

Now remembers the last visited page and restores it automatically.

### Major
- App now remembers the last visited agent/page across browser sessions using localStorage
- Users land on their preferred starting page instead of being forced to dashboard
- Redirects to agent page (`/agent/claude_code`) as default fallback instead of dashboard

### Minor
- Added missing ImBot API methods (`getImBotSetting`, `createImBotSetting`, `updateImBotSetting`, `deleteImBotSetting`, `toggleImBotSetting`)
- Added `getImBotPlatforms` and `getImBotSettingsList` API methods for BotPage