### PR TITLE
bugfix(protocol,codex): normalize codex payload for anthropic dispatch

### DIFF
--- a/Taskfile.curl.yml
+++ b/Taskfile.curl.yml
@@ -269,6 +269,33 @@ tasks:
           "input": [{"role": "user", "content": "Hello!"}],
           "stream": true
         }'
+        
+  anthropic2codex:
+    cmds:
+      - |
+        curl -v -X POST -k http://localhost:12580/tingly/anthropic/v1/messages \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer {{.TINGLY_BOX_KEY}}" \
+        -d '{
+          "model": "tingly-codex",
+          "messages": [{"role": "user", "content": "who are you"}],
+          "stream": true,
+          "max_tokens": 10000
+        }'
+        
+  codex-responses2:
+    cmds:
+      - |
+        curl -X POST -k http://localhost:12580/tingly/codex/v1/responses \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer {{.TINGLY_BOX_KEY}}" \
+        -d '{
+          "stream": true,
+          "model": "tingly-codex",
+          "previous_response_id": "resp_05317e38712808d20169ec0e08f7648191a5014bffc2566dd7",
+          "input": [{"role": "user", "content": "what can you do?"}],
+          "store": true
+        }'
   
   openai-stream:
     cmds:

--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const reasoningMarker = "reasoning.encrypted_content"
+
 // codexRoundTripper wraps an http.RoundTripper to transform ChatGPT backend API
 // responses to OpenAI Responses API format. The ChatGPT backend API returns a custom format
 // that differs from the standard OpenAI Responses API spec.
@@ -96,51 +98,69 @@ func filterCodexRequestJSON(data []byte) ([]byte, bool) {
 		return data, false // Return original if parsing fails
 	}
 
-	isStreaming := false
-	if stream, ok := req["stream"]; ok {
-		isStreaming, ok = stream.(bool)
-	}
+	// stream is always true: codex-rs hardcodes true, and our SSE layer only handles streaming
+	isStreaming := true
 
-	// required
 	req["store"] = false
-	req["include"] = []string{}
 
-	if ins, ok := req["instructions"]; ok {
-		if insStr, ok := ins.(string); ok {
-			req["instructions"] = "You are a helpful AI assistant."
-			if input, ok := req["input"].([]any); ok {
-				tmp := []any{
-					map[string]any{
-						"content": []map[string]any{
-							{
-								"text": insStr,
-								"type": "input_text",
-							},
-						},
-						"role": "user", "type": "message"},
-				}
-				if len(input) > 0 {
-					tmp = append(tmp, input...)
-				}
-				req["input"] = tmp
-			}
+	// Force stream=true — override even if client sent false
+	req["stream"] = isStreaming
+
+	// Merge "reasoning.encrypted_content" into existing include array (preserve client-provided values)
+	includes := []interface{}{}
+	if existing, ok := req["include"].([]interface{}); ok {
+		includes = existing
+	}
+	hasMarker := false
+	for _, v := range includes {
+		if s, ok := v.(string); ok && s == reasoningMarker {
+			hasMarker = true
+			break
 		}
+	}
+	if !hasMarker {
+		includes = append(includes, reasoningMarker)
+	}
+	req["include"] = includes
+
+	if _, ok := req["instructions"]; ok {
+		//if insStr, ok := ins.(string); ok {
+		//	req["instructions"] = "You are a helpful AI assistant."
+		//	if input, ok := req["input"].([]any); ok {
+		//		tmp := []any{
+		//			map[string]any{
+		//				"content": []map[string]any{
+		//					{
+		//						"text": insStr,
+		//						"type": "input_text",
+		//					},
+		//				},
+		//				"role": "user", "type": "message"},
+		//		}
+		//		if len(input) > 0 {
+		//			tmp = append(tmp, input...)
+		//		}
+		//		req["input"] = tmp
+		//	}
+		//}
 	} else {
 		req["instructions"] = "You are a helpful AI assistant."
 	}
-	//delete(req, "tools")
-	//delete(req, "input")
 
-	// Filter out unsupported parameters
-	// These parameters are NOT supported by ChatGPT backend API
+	// Insert defaults only if client did not provide them
+	if _, ok := req["tools"]; !ok {
+		req["tools"] = []interface{}{}
+	}
+	if _, ok := req["parallel_tool_calls"]; !ok {
+		req["parallel_tool_calls"] = false
+	}
+
+	// Remove unsupported parameters
 	delete(req, "max_tokens")
 	delete(req, "max_completion_tokens")
 	delete(req, "max_output_tokens")
 	delete(req, "temperature")
 	delete(req, "top_p")
-
-	// max_output_tokens IS supported, so we keep it
-	// Other supported parameters: instructions, input, tools, tool_choice, stream, store, include, etc.
 
 	result, err := json.Marshal(req)
 	if err != nil {

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -136,8 +136,8 @@ func (s *Server) handleAnthropicStreamResponseV1Beta(c *gin.Context, req *anthro
 	s.trackUsageWithTokenUsage(c, usageStat, err)
 }
 
-// handleAnthropicV1BetaViaResponsesAPINonStreaming handles non-streaming Responses API request
-func (s *Server) handleAnthropicV1BetaViaResponsesAPINonStreaming(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
+// nonstreamResponsesToAnthropicBeta handles non-streaming Responses API request
+func (s *Server) nonstreamResponsesToAnthropicBeta(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
 	// Get scenario recorder if exists
 	var recorder *ScenarioRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {
@@ -195,8 +195,8 @@ func (s *Server) handleAnthropicV1BetaViaResponsesAPINonStreaming(c *gin.Context
 
 }
 
-// handleAnthropicV1BetaViaResponsesAPIStreaming handles streaming Responses API request
-func (s *Server) handleAnthropicV1BetaViaResponsesAPIStreaming(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
+// streamResponsesToAnthropicBeta handles streaming Responses API request
+func (s *Server) streamResponsesToAnthropicBeta(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
 	// Get scenario recorder and set up stream recorder
 	var recorder *ProtocolRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {
@@ -248,8 +248,8 @@ func (s *Server) handleAnthropicV1BetaViaResponsesAPIStreaming(c *gin.Context, p
 	// Note: The handler tracks usage when response.completed event is received
 }
 
-// handleAnthropicV1BetaViaResponsesAPIStreaming handles streaming Responses API request
-func (s *Server) handleAnthropicV1BetaViaResponsesAPIAssembly(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
+// streamResponsesToAnthropicBeta handles streaming Responses API request
+func (s *Server) assembleResponsesToAnthropicBeta(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
 	// Get scenario recorder and set up stream recorder
 	var recorder *ProtocolRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -90,9 +90,9 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	s.dispatchChainResult(c, reqCtx, rule, provider, isStreaming, recorder)
 }
 
-// handleAnthropicV1ViaResponsesAPINonStreaming handles non-streaming Responses API request for v1
+// nonstreamResponsesToAnthropic handles non-streaming Responses API request for v1
 // This converts Anthropic v1 request directly to Responses API format, calls the API, and converts back to v1
-func (s *Server) handleAnthropicV1ViaResponsesAPINonStreaming(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
+func (s *Server) nonstreamResponsesToAnthropic(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
 	// Get scenario recorder if exists
 	var recorder *ScenarioRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {
@@ -151,9 +151,9 @@ func (s *Server) handleAnthropicV1ViaResponsesAPINonStreaming(c *gin.Context, pr
 	c.JSON(http.StatusOK, anthropicResp)
 }
 
-// handleAnthropicV1ViaResponsesAPIStreaming handles streaming Responses API request for v1
+// streamResponsesToAnthropic handles streaming Responses API request for v1
 // This converts Anthropic v1 request directly to Responses API format, calls the API, and streams back in v1 format
-func (s *Server) handleAnthropicV1ViaResponsesAPIStreaming(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
+func (s *Server) streamResponsesToAnthropic(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
 	// Get scenario recorder and set up stream recorder
 	var recorder *ProtocolRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {
@@ -205,8 +205,8 @@ func (s *Server) handleAnthropicV1ViaResponsesAPIStreaming(c *gin.Context, proxy
 	// Note: The handler tracks usage when response.completed event is received
 }
 
-// handleAnthropicV1ViaResponsesAPIStreaming handles streaming Responses API request
-func (s *Server) handleAnthropicV1ViaResponsesAPIAssembly(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
+// streamResponsesToAnthropic handles streaming Responses API request
+func (s *Server) assembleResponsesToAnthropic(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
 	// Get scenario recorder and set up stream recorder
 	var recorder *ProtocolRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -686,19 +686,23 @@ func (s *Server) dispatchChainFromResponses(
 		logrus.Debugf("[AnthropicV1] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
 			s.streamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
-		} else if provider.APIBase == protocol.CodexAPIBase {
-			s.assembleResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
 		} else {
-			s.nonstreamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
+			if provider.APIBase == protocol.CodexAPIBase {
+				s.assembleResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
+			} else {
+				s.nonstreamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
+			}
 		}
 	case protocol.TypeAnthropicBeta:
 		logrus.Debugf("[Anthropic Beta] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
 			s.streamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
-		} else if provider.APIBase == protocol.CodexAPIBase {
-			s.assembleResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
 		} else {
-			s.nonstreamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
+			if provider.APIBase == protocol.CodexAPIBase {
+				s.assembleResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
+			} else {
+				s.nonstreamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
+			}
 		}
 	case protocol.TypeOpenAIChat:
 		// Client sent Responses API, but provider needs Chat format

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -685,20 +685,20 @@ func (s *Server) dispatchChainFromResponses(
 	case protocol.TypeAnthropicV1:
 		logrus.Debugf("[AnthropicV1] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
-			s.streamAnthropicV1ToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+			s.streamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
 		} else if provider.APIBase == protocol.CodexAPIBase {
-			s.handleAnthropicV1ViaResponsesAPIAssembly(c, responseModel, actualModel, provider, *req)
+			s.assembleResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
 		} else {
-			s.nonstreamAnthropicV1ToResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+			s.nonstreamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
 		}
 	case protocol.TypeAnthropicBeta:
 		logrus.Debugf("[Anthropic Beta] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
-			s.handleAnthropicV1BetaViaResponsesAPIStreaming(c, responseModel, actualModel, provider, *req)
+			s.streamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
 		} else if provider.APIBase == protocol.CodexAPIBase {
-			s.handleAnthropicV1BetaViaResponsesAPIAssembly(c, responseModel, actualModel, provider, *req)
+			s.assembleResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
 		} else {
-			s.handleAnthropicV1BetaViaResponsesAPINonStreaming(c, responseModel, actualModel, provider, *req)
+			s.nonstreamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
 		}
 	case protocol.TypeOpenAIChat:
 		// Client sent Responses API, but provider needs Chat format


### PR DESCRIPTION
## Summary

Codex-originated requests still included fields unsupported by Anthropic handlers, and protocol dispatch failed to reliably propagate result payloads into Anthropic logic paths. 

This caused incompatible request shapes and inconsistent response handling in mixed-provider workflows.

## Major

- Ensures protocol dispatch forwards response result data into Anthropic processing paths, so downstream behavior is consistent.
- Normalizes Codex request payloads by removing unsupported fields before forwarding, reducing provider compatibility failures.
- Aligns Anthropic v1/beta server handling with the updated dispatch and payload normalization path, improving cross-protocol reliability.

## Minor

- Adds curl task coverage in `Taskfile.curl.yml` to make validation of these protocol paths easier and repeatable.
- Includes cleanup and refinement in dispatch and provider glue code to keep request/response transformation boundaries clearer.