### PR TITLE
Fix OAuth callback retries, empty scenario rules requests, Credential rerender churn, and Codex reasoning input IDs

### DIFF
--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -28,6 +28,23 @@ import { api } from '../services/api';
 import { OpenAI, Anthropic } from './BrandIcons';
 import ProviderIcon from './ProviderIcon';
 
+const protocolsEqual = (
+    left?: ('openai' | 'anthropic')[],
+    right?: ('openai' | 'anthropic')[],
+) => {
+    const a = left || [];
+    const b = right || [];
+    return a.length === b.length && a.every((value, index) => value === b[index]);
+};
+
+const providerBaseUrlsEqual = (
+    left?: { openai?: string; anthropic?: string },
+    right?: { openai?: string; anthropic?: string },
+) => {
+    return (left?.openai || '') === (right?.openai || '') &&
+        (left?.anthropic || '') === (right?.anthropic || '');
+};
+
 export interface EnhancedProviderFormData {
     uuid?: string;
     name: string;
@@ -186,26 +203,39 @@ const ProviderFormDialog = ({
         const protocols: ('openai' | 'anthropic')[] = [];
         if (protocolOpenAI) protocols.push('openai');
         if (protocolAnthropic) protocols.push('anthropic');
-        onChange('protocols', protocols);
+        if (!protocolsEqual(data.protocols, protocols)) {
+            onChange('protocols', protocols);
+        }
 
+        const nextApiStyle = protocols.length > 0 ? protocols[0] : undefined;
+        if (data.apiStyle !== nextApiStyle) {
+            onChange('apiStyle', nextApiStyle);
+        }
+
+        let nextProviderBaseUrls: { openai?: string; anthropic?: string } | undefined;
         if (protocols.length > 0) {
-            onChange('apiStyle', protocols[0]);
-        } else {
-            onChange('apiStyle', undefined);
+            nextProviderBaseUrls = selectedProvider ? {
+                openai: selectedProvider.baseUrlOpenAI,
+                anthropic: selectedProvider.baseUrlAnthropic,
+            } : undefined;
+        }
+
+        if (!providerBaseUrlsEqual(data.providerBaseUrls, nextProviderBaseUrls)) {
+            onChange('providerBaseUrls', nextProviderBaseUrls);
         }
 
         if (selectedProvider) {
-            onChange('providerBaseUrls', {
-                openai: selectedProvider.baseUrlOpenAI,
-                anthropic: selectedProvider.baseUrlAnthropic,
-            });
             if (protocolOpenAI && selectedProvider.baseUrlOpenAI) {
-                onChange('apiBase', selectedProvider.baseUrlOpenAI);
+                if (data.apiBase !== selectedProvider.baseUrlOpenAI) {
+                    onChange('apiBase', selectedProvider.baseUrlOpenAI);
+                }
             } else if (protocolAnthropic && selectedProvider.baseUrlAnthropic) {
-                onChange('apiBase', selectedProvider.baseUrlAnthropic);
+                if (data.apiBase !== selectedProvider.baseUrlAnthropic) {
+                    onChange('apiBase', selectedProvider.baseUrlAnthropic);
+                }
             }
         }
-    }, [protocolOpenAI, protocolAnthropic, selectedProvider, onChange]);
+    }, [protocolOpenAI, protocolAnthropic, selectedProvider, onChange, data.protocols, data.apiStyle, data.providerBaseUrls, data.apiBase]);
 
     const handleProviderSelect = (newValue: string | UniqueProvider | null) => {
         setVerificationResult(null);

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -9,7 +9,7 @@ import {
     Stack,
     Typography,
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import { PageLayout } from '@/components/PageLayout';
 import ProviderFormDialog from '@/components/ProviderFormDialog.tsx';
@@ -111,6 +111,34 @@ const CredentialPage = () => {
     const showNotification = (message: string, severity: 'success' | 'error') => {
         setSnackbar({ open: true, message, severity });
     };
+
+    const handleProviderFormChange = useCallback((field: keyof EnhancedProviderFormData, value: any) => {
+        setProviderFormData((prev) => {
+            if (field === 'protocols') {
+                const prevProtocols = (prev.protocols || []) as string[];
+                const nextProtocols = (value || []) as string[];
+                if (
+                    prevProtocols.length === nextProtocols.length &&
+                    prevProtocols.every((item, index) => item === nextProtocols[index])
+                ) {
+                    return prev;
+                }
+            } else if (field === 'providerBaseUrls') {
+                const prevUrls = prev.providerBaseUrls || {};
+                const nextUrls = value || {};
+                if (
+                    prevUrls.openai === nextUrls.openai &&
+                    prevUrls.anthropic === nextUrls.anthropic
+                ) {
+                    return prev;
+                }
+            } else if (prev[field] === value) {
+                return prev;
+            }
+
+            return { ...prev, [field]: value };
+        });
+    }, []);
 
     const handleAddApiKey = () => {
         setApiKeyDialogMode('add');
@@ -528,7 +556,7 @@ const CredentialPage = () => {
                 onSubmit={handleProviderSubmit}
                 onForceAdd={handleProviderForceAdd}
                 data={providerFormData}
-                onChange={(field, value) => setProviderFormData(prev => ({ ...prev, [field]: value }))}
+                onChange={handleProviderFormChange}
                 mode={apiKeyDialogMode}
             />
 

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -39,7 +39,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
     // Determine which mode we're in
     // If `rules` is provided, use external mode (legacy)
     // If only `scenario` is provided, use internal mode (recommended)
-    const isInternalMode = !props.rules && props.scenario;
+    const isInternalMode = !props.rules && Boolean(props.scenario);
 
     // Internal mode: fetch all data internally (excluding modal - that's from context)
     const internalData = useScenarioPageInternal(

--- a/frontend/src/pages/scenario/hooks/useRuleManagement.ts
+++ b/frontend/src/pages/scenario/hooks/useRuleManagement.ts
@@ -24,6 +24,12 @@ export const useRuleManagement = () => {
     }, [rules.length]);
 
     const loadRules = useCallback(async (scenario: string) => {
+        if (!scenario.trim()) {
+            setRules([]);
+            setLoadingRule(false);
+            return;
+        }
+
         const result = await api.getRules(scenario);
         if (result && result.success) {
             // Ensure data is an array to prevent crashes

--- a/frontend/src/pages/scenario/hooks/useScenarioPageInternal.ts
+++ b/frontend/src/pages/scenario/hooks/useScenarioPageInternal.ts
@@ -66,6 +66,7 @@ export const useScenarioPageInternal = (scenario: string) => {
 
     // Load rules for the specified scenario
     useEffect(() => {
+        if (!scenario.trim()) return;
         ruleManagement.loadRules(scenario);
     }, [scenario, ruleManagement.loadRules]);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -394,6 +394,10 @@ export const api = {
 
     // Rules API
     getRules: async (scenario: string): Promise<any> => {
+        if (!scenario.trim()) {
+            return {success: false, error: 'Scenario is required', data: []};
+        }
+
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();

--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
+
+var codexInputIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // codexRoundTripper wraps an http.RoundTripper to transform ChatGPT backend API
 // responses to OpenAI Responses API format. The ChatGPT backend API returns a custom format
@@ -139,6 +142,10 @@ func filterCodexRequestJSON(data []byte) ([]byte, bool) {
 	delete(req, "temperature")
 	delete(req, "top_p")
 
+	// ChatGPT Codex rejects empty/invalid item ids in input[].
+	// These ids are optional for request items, so strip malformed values.
+	sanitizeCodexInputIDs(req)
+
 	// max_output_tokens IS supported, so we keep it
 	// Other supported parameters: instructions, input, tools, tool_choice, stream, store, include, etc.
 
@@ -147,6 +154,40 @@ func filterCodexRequestJSON(data []byte) ([]byte, bool) {
 		return data, isStreaming // Return original if marshaling fails
 	}
 	return result, isStreaming
+}
+
+func sanitizeCodexInputIDs(req map[string]interface{}) {
+	input, ok := req["input"]
+	if !ok {
+		return
+	}
+	model, _ := req["model"].(string)
+	req["input"] = sanitizeCodexValue(input, "input", model)
+}
+
+func sanitizeCodexValue(v interface{}, path, model string) interface{} {
+	switch item := v.(type) {
+	case []interface{}:
+		for i := range item {
+			item[i] = sanitizeCodexValue(item[i], fmt.Sprintf("%s[%d]", path, i), model)
+		}
+		return item
+	case map[string]interface{}:
+		for key, value := range item {
+			item[key] = sanitizeCodexValue(value, path+"."+key, model)
+		}
+		if rawID, ok := item["id"].(string); ok {
+			rawID = strings.TrimSpace(rawID)
+			if rawID == "" || !codexInputIDPattern.MatchString(rawID) {
+				delete(item, "id")
+			} else {
+				item["id"] = rawID
+			}
+		}
+		return item
+	default:
+		return v
+	}
 }
 
 func rewriteCodexPath(path string) string {

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -309,6 +309,8 @@ func (h *Handler) AuthorizeOAuth(c *gin.Context) {
 		}
 		h.oauthManager.SetProxyURL(parsedURL)
 		log.Printf("[OAuth] Proxy URL configured: %s", proxyURL)
+	} else {
+		h.oauthManager.ResetProxyURL()
 	}
 
 	// Generate session ID for this OAuth flow

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -820,6 +820,28 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		return fmt.Errorf("callback server already exists for session %s", sessionID)
 	}
 
+	// Providers with fixed callback ports (for example Codex/OpenAI on 1455)
+	// can only have one active browser flow at a time. If a previous attempt
+	// is still waiting or failed before cleanup, replace it so retrying OAuth
+	// does not require waiting for the five minute timeout.
+	if port > 0 {
+		for existingSessionID, existingServer := range s.callbackServers {
+			if existingServer.GetPort() != port {
+				continue
+			}
+
+			_ = s.oauthManager.UpdateSessionStatus(existingSessionID, pkgoauth.SessionStatusFailed, "", "Superseded by a new OAuth authorization attempt")
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := existingServer.Stop(ctx); err != nil {
+				cancel()
+				return fmt.Errorf("failed to stop existing callback server on port %d: %w", port, err)
+			}
+			cancel()
+			delete(s.callbackServers, existingSessionID)
+			logrus.Debugf("[OAuth] Replaced existing dynamic callback server on port %d for session %s", port, existingSessionID)
+		}
+	}
+
 	// Create an http.HandlerFunc that properly handles the OAuth callback
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		// Ignore favicon requests
@@ -836,6 +858,10 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		token, err := s.oauthManager.HandleCallback(r.Context(), r)
 		if err != nil {
 			logrus.Debugf("[OAuth] Callback error: %v", err)
+			if sessionID != "" {
+				_ = s.oauthManager.UpdateSessionStatus(sessionID, pkgoauth.SessionStatusFailed, "", err.Error())
+				s.stopDynamicCallbackServerAfterResponse(sessionID)
+			}
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, "<html><body><h1>OAuth Error</h1><p>%s</p></body></html>", err.Error())
@@ -846,6 +872,14 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		providerUUID, err := s.oauthHandler.CreateProviderFromToken(token, token.Provider, "", token.SessionID)
 		if err != nil {
 			logrus.Debugf("[OAuth] Failed to create provider: %v", err)
+			failedSessionID := token.SessionID
+			if failedSessionID == "" {
+				failedSessionID = sessionID
+			}
+			if failedSessionID != "" {
+				_ = s.oauthManager.UpdateSessionStatus(failedSessionID, pkgoauth.SessionStatusFailed, "", err.Error())
+			}
+			s.stopDynamicCallbackServerAfterResponse(sessionID)
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "<html><body><h1>OAuth Error</h1><p>Failed to create provider: %v</p></body></html>", err)
@@ -860,10 +894,7 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		logrus.Debugf("[OAuth] Callback successful for provider %s, created provider %s", token.Provider, providerUUID)
 
 		// Stop the dynamic callback server after successful callback
-		go func() {
-			time.Sleep(1 * time.Second) // Give time for the response to be sent
-			s.stopDynamicCallbackServer(sessionID)
-		}()
+		s.stopDynamicCallbackServerAfterResponse(sessionID)
 
 		// Return success HTML page
 		w.Header().Set("Content-Type", "text/html")
@@ -908,6 +939,13 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 	}()
 
 	return nil
+}
+
+func (s *Server) stopDynamicCallbackServerAfterResponse(sessionID string) {
+	go func() {
+		time.Sleep(1 * time.Second) // Give time for the response to be sent
+		s.stopDynamicCallbackServer(sessionID)
+	}()
 }
 
 // stopDynamicCallbackServer stops and removes a dynamic callback server


### PR DESCRIPTION
**Summary**

This PR fixes four issues:

1. Repeated OAuth attempts could fail if a stale callback server was still holding the fixed callback port.
2. Scenario pages could issue rules requests with an empty scenario value.
3. The Credential page could repeatedly sync unchanged provider form state and trigger unnecessary rerenders.
4. Codex Responses forwarding could send malformed empty `input[].id` fields to the ChatGPT Codex backend and trigger request validation failures.

**Root Causes**

- OAuth retries could reuse a stale callback server that was still bound to the fixed local callback port after an earlier failed attempt.
- Scenario rule fetching did not consistently reject blank scenario values before issuing frontend and API requests.
- `CredentialPage` kept `ProviderFormDialog` mounted even when closed, and the dialog synced derived values back to the parent through an unstable callback and redundant state writes, causing a render loop.
- On the Codex Responses path, a `reasoning` input item could arrive without an `id`, then be converted through proxy-side OpenAI SDK request types where the reasoning item `id` is represented as a required string. That normalization step turned a missing `id` into `id: ""`, and the downstream ChatGPT Codex backend rejected the request.

**Changes**

### OAuth callback handling
- Reset proxy URL when no proxy is provided.
- Replace stale fixed-port callback servers instead of waiting for them to time out.
- Mark superseded OAuth sessions as failed.
- Ensure callback/session status is updated when callback handling or provider creation fails.
- Centralize callback server shutdown after sending the OAuth response.

### Empty scenario protection
- Treat blank or whitespace-only scenario values as invalid.
- Skip rules fetching when scenario is empty.
- Clear local rules/loading state on early return.
- Add API-side validation for blank scenario requests.

### Credential page state stabilization
- Memoize the parent `onChange` handler passed into `ProviderFormDialog`.
- Add equality checks before syncing derived provider form fields.
- Skip parent state updates when `protocols` or `providerBaseUrls` have not actually changed.
- Avoid unnecessary `apiStyle` / `apiBase` writebacks.

### Codex request sanitization
- Sanitize outbound Codex Responses requests before forwarding to `chatgpt.com/backend-api/codex/responses`.
- Remove empty or invalid optional `input` item `id` fields.
- Preserve valid `call_id` values and the rest of the request structure.
- Prevent backend validation failures such as `Invalid 'input[*].id': ''`.
- Handle reasoning items whose missing `id` becomes `id: ""` during proxy-side request normalization.