### PR TITLE
feat: use request URL instead of startup host for OpenCode config generation

### DIFF
--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -13,6 +13,32 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// getBaseURLFromRequest constructs the base URL from the incoming HTTP request
+// This ensures users get the URL they actually used to access the server
+func getBaseURLFromRequest(c *gin.Context, defaultPort int) string {
+	// Get the host from the request (includes port if non-standard)
+	host := c.Request.Host
+
+	// Get the scheme from X-Forwarded-Proto header (set by reverse proxies)
+	// or detect from the request
+	scheme := c.GetHeader("X-Forwarded-Proto")
+	if scheme == "" {
+		// Fall back to detecting from the request
+		if c.Request.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	// If host doesn't include port, add the default port
+	if !strings.Contains(host, ":") {
+		host = fmt.Sprintf("%s:%d", host, defaultPort)
+	}
+
+	return fmt.Sprintf("%s://%s", scheme, host)
+}
+
 // Handler handles config apply HTTP requests
 type Handler struct {
 	config *config.Config
@@ -164,16 +190,20 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 		return
 	}
 
-	// Get base URL from server config or use default
+	// Get base URL from the user's request (respects reverse proxy headers)
 	port := h.config.ServerPort
 	if port == 0 {
 		port = 12580
 	}
-	baseURL := fmt.Sprintf("http://%s:%d", h.host, port)
+	baseURL := getBaseURLFromRequest(c, port)
+	configBaseURL := baseURL + "/tingly/claude_code"
+
+	// Use the model token from config (tingly-box- prefixed JWT)
+	apiKey := h.config.GetModelToken()
 
 	// Generate env vars based on mode
 	unified := req.Mode != "separate"
-	env := agent.GenerateClaudeCodeEnv(baseURL, h.config.GetModelToken(), unified)
+	env := agent.GenerateClaudeCodeEnv(configBaseURL, apiKey, unified)
 
 	// Install status line script if requested (before applying settings)
 	var statusLineInstalled bool
@@ -321,12 +351,12 @@ func (h *Handler) ApplyOpenCodeConfigFromState(c *gin.Context) {
 		return
 	}
 
-	// Get base URL from server config or use default
+	// Get base URL from the user's request (respects reverse proxy headers)
 	port := h.config.ServerPort
 	if port == 0 {
 		port = 12580
 	}
-	baseURL := fmt.Sprintf("http://%s:%d", h.host, port)
+	baseURL := getBaseURLFromRequest(c, port)
 	configBaseURL := baseURL + "/tingly/opencode"
 
 	// Use the model token from config (tingly-box- prefixed JWT)
@@ -414,12 +444,12 @@ func (h *Handler) GetOpenCodeConfigPreview(c *gin.Context) {
 		return
 	}
 
-	// Get base URL from server config or use default
+	// Get base URL from the user's request (respects reverse proxy headers)
 	port := h.config.ServerPort
 	if port == 0 {
 		port = 12580
 	}
-	baseURL := fmt.Sprintf("http://%s:%d", h.host, port)
+	baseURL := getBaseURLFromRequest(c, port)
 	configBaseURL := baseURL + "/tingly/opencode"
 
 	// Use the model token from config (tingly-box- prefixed JWT)


### PR DESCRIPTION
## Summary

- Add `getBaseURLFromRequest` function to get base URL from HTTP request instead of using startup host parameter
- This ensures users get the URL they actually used to access the server
- Supports X-Forwarded-Proto header for reverse proxy scenarios

## Changes

- Modified: `internal/server/module/configapply/handler.go`
  - Add `getBaseURLFromRequest` helper function
  - Update `ApplyClaudeConfig`, `ApplyOpenCodeConfigFromState`, `GetOpenCodeConfigPreview` to use request URL
- Affects: configuration JSON and scripts for Windows/Linux/macOS