### PR TITLE
bugfix(server): prefer responses API based on streaming capability

### DIFF
--- a/internal/server/adaptive_probe.go
+++ b/internal/server/adaptive_probe.go
@@ -47,6 +47,7 @@ func (ap *AdaptiveProbe) ProbeModelEndpoints(ctx context.Context, req ModelProbe
 	if !req.ForceRefresh && ap.server.probeCache != nil {
 		if cached := ap.server.probeCache.Get(req.ProviderUUID, req.ModelID); cached != nil {
 			// Convert cached capability to probe result
+			logrus.Debugf("Prefer cache hit for provider %s, %s", req.ProviderUUID, cached.PreferredEndpoint)
 			return ap.cachedCapabilityToResult(cached), nil
 		}
 	}
@@ -128,15 +129,17 @@ func (ap *AdaptiveProbe) probeChatEndpoint(ctx context.Context, provider *typ.Pr
 	}
 }
 
-// probeOpenAIChatEndpointWithSDK probes OpenAI-style chat completions endpoint using SDK
+// probeOpenAIChatEndpointWithSDK probes OpenAI-style chat completions endpoint using SDK.
+// Tests streaming capability only.
 func (ap *AdaptiveProbe) probeOpenAIChatEndpointWithSDK(ctx context.Context, provider *typ.Provider, modelID string, startTime time.Time) EndpointStatus {
 	// Get OpenAI client from pool
 	wrapper := ap.server.clientPool.GetOpenAIClient(context.Background(), provider, "")
 	if wrapper == nil {
 		return EndpointStatus{
-			Available:    false,
-			ErrorMessage: "Failed to get OpenAI client",
-			LastChecked:  time.Now(),
+			Available:      false,
+			SupportsStream: false,
+			ErrorMessage:   "Failed to get OpenAI client",
+			LastChecked:    time.Now(),
 		}
 	}
 
@@ -144,42 +147,52 @@ func (ap *AdaptiveProbe) probeOpenAIChatEndpointWithSDK(ctx context.Context, pro
 		openai.UserMessage("Hi"),
 	}
 
-	params := openai.ChatCompletionNewParams{
-		Model:    openai.ChatModel(modelID),
-		Messages: messages,
-	}
-
 	// Create a context with timeout for the probe
 	probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
 	defer cancel()
 
-	resp, err := wrapper.Client().Chat.Completions.New(probeCtx, params)
+	// Test streaming capability
+	params := openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel(modelID),
+		Messages: messages,
+	}
+	stream := wrapper.Client().Chat.Completions.NewStreaming(probeCtx, params)
+	defer stream.Close()
+
+	streamWorks := false
+	for stream.Next() {
+		streamWorks = true
+		break // Got at least one chunk, streaming works
+	}
+
 	latency := int(time.Since(startTime).Milliseconds())
 
-	if err != nil {
+	if err := stream.Err(); err != nil {
 		return EndpointStatus{
-			Available:    false,
-			LatencyMs:    latency,
-			ErrorMessage: fmt.Sprintf("Chat request failed: %v", err),
-			LastChecked:  time.Now(),
+			Available:      false,
+			SupportsStream: false,
+			LatencyMs:      latency,
+			ErrorMessage:   fmt.Sprintf("Chat streaming failed: %v", err),
+			LastChecked:    time.Now(),
 		}
 	}
 
-	// Check if response is valid
-	if resp != nil && len(resp.Choices) > 0 {
+	if streamWorks {
 		return EndpointStatus{
-			Available:    true,
-			LatencyMs:    latency,
-			ErrorMessage: "",
-			LastChecked:  time.Now(),
+			Available:      true,
+			SupportsStream: true,
+			LatencyMs:      latency,
+			ErrorMessage:   "",
+			LastChecked:    time.Now(),
 		}
 	}
 
 	return EndpointStatus{
-		Available:    false,
-		LatencyMs:    latency,
-		ErrorMessage: "Chat endpoint returned invalid response",
-		LastChecked:  time.Now(),
+		Available:      false,
+		SupportsStream: false,
+		LatencyMs:      latency,
+		ErrorMessage:   "Chat streaming returned no data",
+		LastChecked:    time.Now(),
 	}
 }
 
@@ -251,7 +264,8 @@ func (ap *AdaptiveProbe) probeAnthropicChatEndpoint(ctx context.Context, provide
 	return ap.probeAnthropicChatEndpointWithSDK(ctx, provider, modelID, startTime)
 }
 
-// probeResponsesEndpoint probes the Responses API endpoint for a model
+// probeResponsesEndpoint probes the Responses API endpoint for a model.
+// Tests streaming capability only.
 func (ap *AdaptiveProbe) probeResponsesEndpoint(ctx context.Context, provider *typ.Provider, modelID string) EndpointStatus {
 	startTime := time.Now()
 
@@ -259,14 +273,14 @@ func (ap *AdaptiveProbe) probeResponsesEndpoint(ctx context.Context, provider *t
 	wrapper := ap.server.clientPool.GetOpenAIClient(context.Background(), provider, modelID)
 	if wrapper == nil {
 		return EndpointStatus{
-			Available:    false,
-			ErrorMessage: "Failed to get OpenAI client",
-			LastChecked:  time.Now(),
+			Available:      false,
+			SupportsStream: false,
+			ErrorMessage:   "Failed to get OpenAI client",
+			LastChecked:    time.Now(),
 		}
 	}
 
-	// Create minimal Responses API request using raw JSON approach
-	// This avoids the complex type issues with the SDK
+	// Create minimal Responses API request
 	params := responses.ResponseNewParams{
 		Model: modelID,
 		Input: responses.ResponseNewParamsInputUnion{
@@ -283,47 +297,60 @@ func (ap *AdaptiveProbe) probeResponsesEndpoint(ctx context.Context, provider *t
 		},
 	}
 
-	// Make the request
-	resp, err := wrapper.Client().Responses.New(ctx, params)
+	// Test streaming capability
+	stream := wrapper.Client().Responses.NewStreaming(ctx, params)
+
+	streamWorks := false
+	for stream.Next() {
+		streamWorks = true
+		break // Got at least one chunk, streaming works
+	}
+
 	latency := int(time.Since(startTime).Milliseconds())
 
-	if err != nil {
+	if err := stream.Err(); err != nil {
 		return EndpointStatus{
-			Available:    false,
-			LatencyMs:    latency,
-			ErrorMessage: fmt.Sprintf("Responses API request failed: %v", err),
-			LastChecked:  time.Now(),
+			Available:      false,
+			SupportsStream: false,
+			LatencyMs:      latency,
+			ErrorMessage:   fmt.Sprintf("Responses streaming failed: %v", err),
+			LastChecked:    time.Now(),
 		}
 	}
 
-	// Check if response is valid
-	if resp != nil && resp.ID != "" {
+	if streamWorks {
 		return EndpointStatus{
-			Available:    true,
-			LatencyMs:    latency,
-			ErrorMessage: "",
-			LastChecked:  time.Now(),
+			Available:      true,
+			SupportsStream: true,
+			LatencyMs:      latency,
+			ErrorMessage:   "",
+			LastChecked:    time.Now(),
 		}
 	}
 
 	return EndpointStatus{
-		Available:    false,
-		LatencyMs:    latency,
-		ErrorMessage: "Responses API returned invalid response",
-		LastChecked:  time.Now(),
+		Available:      false,
+		SupportsStream: false,
+		LatencyMs:      latency,
+		ErrorMessage:   "Responses streaming returned no data",
+		LastChecked:    time.Now(),
 	}
 }
 
-// determinePreferredEndpoint determines which endpoint to prefer based on availability
+// determinePreferredEndpoint determines which endpoint to prefer based on streaming support.
+// Priority: Responses with streaming > Chat with streaming
 func (ap *AdaptiveProbe) determinePreferredEndpoint(chat, responses *EndpointStatus) string {
-	// Responses API is preferred when available
-	if responses.Available {
+	// Priority 1: Responses API with streaming support (preferred)
+	if responses.Available && responses.SupportsStream {
 		return string(db.EndpointTypeResponses)
 	}
-	if chat.Available {
+
+	// Priority 2: Chat API with streaming support
+	if chat.Available && chat.SupportsStream {
 		return string(db.EndpointTypeChat)
 	}
-	return "" // Neither available
+
+	return "" // Neither available with streaming
 }
 
 // persistResult persists probe result to database
@@ -449,10 +476,8 @@ func (ap *AdaptiveProbe) GetPreferredEndpoint(provider *typ.Provider, modelID st
 		return res.PreferredEndpoint
 	}
 
-	if capability.SupportsChat {
-		return string(db.EndpointTypeChat)
-	}
-	return string(db.EndpointTypeResponses)
+	// Return the preferred endpoint that was determined during probing
+	return capability.PreferredEndpoint
 }
 
 // InvalidateProviderCache invalidates all cached capabilities for a provider

--- a/internal/server/adaptive_probe.go
+++ b/internal/server/adaptive_probe.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
@@ -257,7 +256,7 @@ func (ap *AdaptiveProbe) probeResponsesEndpoint(ctx context.Context, provider *t
 	startTime := time.Now()
 
 	// Get OpenAI client from pool
-	wrapper := ap.server.clientPool.GetOpenAIClient(context.Background(), provider, "")
+	wrapper := ap.server.clientPool.GetOpenAIClient(context.Background(), provider, modelID)
 	if wrapper == nil {
 		return EndpointStatus{
 			Available:    false,
@@ -269,45 +268,19 @@ func (ap *AdaptiveProbe) probeResponsesEndpoint(ctx context.Context, provider *t
 	// Create minimal Responses API request using raw JSON approach
 	// This avoids the complex type issues with the SDK
 	params := responses.ResponseNewParams{
-		Input: responses.ResponseNewParamsInputUnion{OfString: param.NewOpt("Hi")},
-	}
-
-	// Set model via raw JSON - marshal to JSON, set model, unmarshal back
-	paramsJSON, err := json.Marshal(params)
-	if err != nil {
-		return EndpointStatus{
-			Available:    false,
-			ErrorMessage: fmt.Sprintf("Failed to marshal params: %v", err),
-			LastChecked:  time.Now(),
-		}
-	}
-
-	var raw map[string]interface{}
-	if err := json.Unmarshal(paramsJSON, &raw); err != nil {
-		return EndpointStatus{
-			Available:    false,
-			ErrorMessage: fmt.Sprintf("Failed to unmarshal params: %v", err),
-			LastChecked:  time.Now(),
-		}
-	}
-
-	raw["model"] = modelID
-
-	modifiedJSON, err := json.Marshal(raw)
-	if err != nil {
-		return EndpointStatus{
-			Available:    false,
-			ErrorMessage: fmt.Sprintf("Failed to marshal modified params: %v", err),
-			LastChecked:  time.Now(),
-		}
-	}
-
-	if err := json.Unmarshal(modifiedJSON, &params); err != nil {
-		return EndpointStatus{
-			Available:    false,
-			ErrorMessage: fmt.Sprintf("Failed to unmarshal modified params: %v", err),
-			LastChecked:  time.Now(),
-		}
+		Model: modelID,
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: responses.ResponseInputParam{
+				{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role: responses.EasyInputMessageRoleUser,
+						Content: responses.EasyInputMessageContentUnionParam{
+							OfString: param.NewOpt("hi"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Make the request
@@ -460,25 +433,26 @@ func (ap *AdaptiveProbe) GetModelCapability(providerUUID, modelID string) (*Mode
 // GetPreferredEndpoint returns the preferred endpoint for a model
 func (ap *AdaptiveProbe) GetPreferredEndpoint(provider *typ.Provider, modelID string) string {
 	capability, err := ap.GetModelCapability(provider.UUID, modelID)
-	if err != nil {
+	if err != nil || capability.PreferredEndpoint == "" {
 		// Trigger async probe refresh
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), DefaultProbeTimeout)
-			defer cancel()
-			ap.ProbeModelEndpoints(ctx, ModelProbeRequest{
-				ProviderUUID: provider.UUID,
-				ModelID:      modelID,
-			})
-		}()
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultProbeTimeout)
+		defer cancel()
+		res, err := ap.ProbeModelEndpoints(ctx, ModelProbeRequest{
+			ProviderUUID: provider.UUID,
+			ModelID:      modelID,
+		})
 
-		// Default to chat for unknown models
+		if err != nil {
+			logrus.Warnf("Failed to get model capability: %v", err)
+			return string(db.EndpointTypeChat)
+		}
+		return res.PreferredEndpoint
+	}
+
+	if capability.SupportsChat {
 		return string(db.EndpointTypeChat)
 	}
-
-	if capability.PreferredEndpoint == string(db.EndpointTypeResponses) {
-		return string(db.EndpointTypeResponses)
-	}
-	return string(db.EndpointTypeChat)
+	return string(db.EndpointTypeResponses)
 }
 
 // InvalidateProviderCache invalidates all cached capabilities for a provider

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -69,7 +69,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 		// Check if model prefers Responses API (for models like Codex)
 		// This is used for ChatGPT backend API which only supports Responses API
 		preferredEndpoint := s.GetPreferredEndpointForModel(provider, actualModel)
-		logrus.Debugf("[AnthropicV1] Probe cache preferred endpoint for model=%s: %s", actualModel, preferredEndpoint)
+		logrus.Debugf("[AnthropicV1] Preferred endpoint for model=%s: %s", actualModel, preferredEndpoint)
 		useResponsesAPI := preferredEndpoint == "responses"
 		if useResponsesAPI {
 			target = protocol.TypeOpenAIResponses

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -63,7 +63,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
 		preferredEndpoint := s.GetPreferredEndpointForModel(provider, actualModel)
-		logrus.Debugf("[AnthropicV1] Probe cache preferred endpoint for model=%s: %s", actualModel, preferredEndpoint)
+		logrus.Debugf("[AnthropicV1] Preferred endpoint for model=%s: %s", actualModel, preferredEndpoint)
 		useResponsesAPI := preferredEndpoint == "responses"
 		if useResponsesAPI {
 			target = protocol.TypeOpenAIResponses

--- a/internal/server/probe_cache.go
+++ b/internal/server/probe_cache.go
@@ -34,10 +34,11 @@ type ModelEndpointCapability struct {
 
 // EndpointStatus represents the status of a single endpoint
 type EndpointStatus struct {
-	Available    bool
-	LatencyMs    int
-	ErrorMessage string
-	LastChecked  time.Time
+	Available      bool
+	LatencyMs      int
+	ErrorMessage   string
+	LastChecked    time.Time
+	SupportsStream bool // True if streaming works for this endpoint
 }
 
 // ProbeResult represents the complete probe result for a model

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1288,10 +1288,11 @@ func (s *Server) GetPreferredEndpointForModel(provider *typ.Provider, modelID st
 	if strings.Contains(strings.ToLower(modelID), "codex") {
 		return string(db.EndpointTypeResponses)
 	}
-	// TODO: we use chat as default unless the model do not support chat, e.g. codex
-	// In the future, we can use adaptiveProbe := NewAdaptiveProbe(s)
-	// return adaptiveProbe.GetPreferredEndpoint(provider, modelID)
-	return "chat"
+	if strings.Contains(strings.ToLower(provider.APIBase), "chatgpt.com") {
+		return string(db.EndpointTypeResponses)
+	}
+	adaptiveProbe := NewAdaptiveProbe(s)
+	return adaptiveProbe.GetPreferredEndpoint(provider, modelID)
 }
 
 // HealthMonitor returns the server's health monitor


### PR DESCRIPTION
## Summary
The probe logic incorrectly prioritized the Chat API over the Responses API for ChatGPT and Codex models. 
The `GetPreferredEndpoint` function disregarded actual probe results and always returned "chat" as the default.

### Major
- Responses API is now correctly preferred when streaming is supported.
- ChatGPT and Codex models automatically use the Responses API endpoint.
- The probe now directly tests streaming capability, not just availability.
- Fixed `GetPreferredEndpoint` to respect cached probe results.

### Minor
- Added `SupportsStream` field to `EndpointStatus` for tracking streaming capability.
- Updated probe functions to test streaming using `NewStreaming()` SDK calls.
- Simplified `determinePreferredEndpoint` to prioritize Responses over Chat when streaming works.
- Added chatgpt.com domain detection for automatic Responses API preference.