### PR TITLE
Fix OAuth callback retries and Codex reasoning input IDs

### DIFF
--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
+
+var codexInputIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 const reasoningMarker = "reasoning.encrypted_content"
 
@@ -162,11 +165,52 @@ func filterCodexRequestJSON(data []byte) ([]byte, bool) {
 	delete(req, "temperature")
 	delete(req, "top_p")
 
+	// ChatGPT Codex rejects empty/invalid item ids in input[].
+	// These ids are optional for request items, so strip malformed values.
+	sanitizeCodexInputIDs(req)
+
+	// max_output_tokens IS supported, so we keep it
+	// Other supported parameters: instructions, input, tools, tool_choice, stream, store, include, etc.
+
 	result, err := json.Marshal(req)
 	if err != nil {
 		return data, isStreaming // Return original if marshaling fails
 	}
 	return result, isStreaming
+}
+
+func sanitizeCodexInputIDs(req map[string]interface{}) {
+	input, ok := req["input"]
+	if !ok {
+		return
+	}
+	model, _ := req["model"].(string)
+	req["input"] = sanitizeCodexValue(input, "input", model)
+}
+
+func sanitizeCodexValue(v interface{}, path, model string) interface{} {
+	switch item := v.(type) {
+	case []interface{}:
+		for i := range item {
+			item[i] = sanitizeCodexValue(item[i], fmt.Sprintf("%s[%d]", path, i), model)
+		}
+		return item
+	case map[string]interface{}:
+		for key, value := range item {
+			item[key] = sanitizeCodexValue(value, path+"."+key, model)
+		}
+		if rawID, ok := item["id"].(string); ok {
+			rawID = strings.TrimSpace(rawID)
+			if rawID == "" || !codexInputIDPattern.MatchString(rawID) {
+				delete(item, "id")
+			} else {
+				item["id"] = rawID
+			}
+		}
+		return item
+	default:
+		return v
+	}
 }
 
 func rewriteCodexPath(path string) string {

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -309,6 +309,8 @@ func (h *Handler) AuthorizeOAuth(c *gin.Context) {
 		}
 		h.oauthManager.SetProxyURL(parsedURL)
 		log.Printf("[OAuth] Proxy URL configured: %s", proxyURL)
+	} else {
+		h.oauthManager.ResetProxyURL()
 	}
 
 	// Generate session ID for this OAuth flow

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -820,6 +820,28 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		return fmt.Errorf("callback server already exists for session %s", sessionID)
 	}
 
+	// Providers with fixed callback ports (for example Codex/OpenAI on 1455)
+	// can only have one active browser flow at a time. If a previous attempt
+	// is still waiting or failed before cleanup, replace it so retrying OAuth
+	// does not require waiting for the five minute timeout.
+	if port > 0 {
+		for existingSessionID, existingServer := range s.callbackServers {
+			if existingServer.GetPort() != port {
+				continue
+			}
+
+			_ = s.oauthManager.UpdateSessionStatus(existingSessionID, pkgoauth.SessionStatusFailed, "", "Superseded by a new OAuth authorization attempt")
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := existingServer.Stop(ctx); err != nil {
+				cancel()
+				return fmt.Errorf("failed to stop existing callback server on port %d: %w", port, err)
+			}
+			cancel()
+			delete(s.callbackServers, existingSessionID)
+			logrus.Debugf("[OAuth] Replaced existing dynamic callback server on port %d for session %s", port, existingSessionID)
+		}
+	}
+
 	// Create an http.HandlerFunc that properly handles the OAuth callback
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		// Ignore favicon requests
@@ -836,6 +858,10 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		token, err := s.oauthManager.HandleCallback(r.Context(), r)
 		if err != nil {
 			logrus.Debugf("[OAuth] Callback error: %v", err)
+			if sessionID != "" {
+				_ = s.oauthManager.UpdateSessionStatus(sessionID, pkgoauth.SessionStatusFailed, "", err.Error())
+				s.stopDynamicCallbackServerAfterResponse(sessionID)
+			}
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, "<html><body><h1>OAuth Error</h1><p>%s</p></body></html>", err.Error())
@@ -846,6 +872,14 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		providerUUID, err := s.oauthHandler.CreateProviderFromToken(token, token.Provider, "", token.SessionID)
 		if err != nil {
 			logrus.Debugf("[OAuth] Failed to create provider: %v", err)
+			failedSessionID := token.SessionID
+			if failedSessionID == "" {
+				failedSessionID = sessionID
+			}
+			if failedSessionID != "" {
+				_ = s.oauthManager.UpdateSessionStatus(failedSessionID, pkgoauth.SessionStatusFailed, "", err.Error())
+			}
+			s.stopDynamicCallbackServerAfterResponse(sessionID)
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "<html><body><h1>OAuth Error</h1><p>Failed to create provider: %v</p></body></html>", err)
@@ -860,10 +894,7 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 		logrus.Debugf("[OAuth] Callback successful for provider %s, created provider %s", token.Provider, providerUUID)
 
 		// Stop the dynamic callback server after successful callback
-		go func() {
-			time.Sleep(1 * time.Second) // Give time for the response to be sent
-			s.stopDynamicCallbackServer(sessionID)
-		}()
+		s.stopDynamicCallbackServerAfterResponse(sessionID)
 
 		// Return success HTML page
 		w.Header().Set("Content-Type", "text/html")
@@ -908,6 +939,13 @@ func (s *Server) startDynamicCallbackServer(sessionID string, port int) error {
 	}()
 
 	return nil
+}
+
+func (s *Server) stopDynamicCallbackServerAfterResponse(sessionID string) {
+	go func() {
+		time.Sleep(1 * time.Second) // Give time for the response to be sent
+		s.stopDynamicCallbackServer(sessionID)
+	}()
 }
 
 // stopDynamicCallbackServer stops and removes a dynamic callback server


### PR DESCRIPTION
**Summary**

This PR fixes issues:

1. Repeated OAuth attempts could fail if a stale callback server was still holding the fixed callback port.
2. Codex Responses forwarding could send malformed empty `input[].id` fields to the ChatGPT Codex backend and trigger request validation failures.

**Root Causes**

- OAuth retries could reuse a stale callback server that was still bound to the fixed local callback port after an earlier failed attempt.
- On the Codex Responses path, a `reasoning` input item could arrive without an `id`, then be converted through proxy-side OpenAI SDK request types where the reasoning item `id` is represented as a required string. That normalization step turned a missing `id` into `id: ""`, and the downstream ChatGPT Codex backend rejected the request.

**Changes**

### OAuth callback handling
- Reset proxy URL when no proxy is provided.
- Replace stale fixed-port callback servers instead of waiting for them to time out.
- Mark superseded OAuth sessions as failed.
- Ensure callback/session status is updated when callback handling or provider creation fails.
- Centralize callback server shutdown after sending the OAuth response.

### Codex request sanitization
- Sanitize outbound Codex Responses requests before forwarding to `chatgpt.com/backend-api/codex/responses`.
- Remove empty or invalid optional `input` item `id` fields.
- Preserve valid `call_id` values and the rest of the request structure.
- Prevent backend validation failures such as `Invalid 'input[*].id': ''`.
- Handle reasoning items whose missing `id` becomes `id: ""` during proxy-side request normalization.