### PR TITLE
optimize: guard against empty scenario in rules flow

### DIFF
--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -39,7 +39,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
     // Determine which mode we're in
     // If `rules` is provided, use external mode (legacy)
     // If only `scenario` is provided, use internal mode (recommended)
-    const isInternalMode = !props.rules && props.scenario;
+    const isInternalMode = !props.rules && Boolean(props.scenario);
 
     // Internal mode: fetch all data internally (excluding modal - that's from context)
     const internalData = useScenarioPageInternal(

--- a/frontend/src/pages/scenario/hooks/useRuleManagement.ts
+++ b/frontend/src/pages/scenario/hooks/useRuleManagement.ts
@@ -24,6 +24,12 @@ export const useRuleManagement = () => {
     }, [rules.length]);
 
     const loadRules = useCallback(async (scenario: string) => {
+        if (!scenario.trim()) {
+            setRules([]);
+            setLoadingRule(false);
+            return;
+        }
+
         const result = await api.getRules(scenario);
         if (result && result.success) {
             // Ensure data is an array to prevent crashes

--- a/frontend/src/pages/scenario/hooks/useScenarioPageInternal.ts
+++ b/frontend/src/pages/scenario/hooks/useScenarioPageInternal.ts
@@ -66,6 +66,7 @@ export const useScenarioPageInternal = (scenario: string) => {
 
     // Load rules for the specified scenario
     useEffect(() => {
+        if (!scenario.trim()) return;
         ruleManagement.loadRules(scenario);
     }, [scenario, ruleManagement.loadRules]);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -394,6 +394,10 @@ export const api = {
 
     // Rules API
     getRules: async (scenario: string): Promise<any> => {
+        if (!scenario.trim()) {
+            return {success: false, error: 'Scenario is required', data: []};
+        }
+
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();


### PR DESCRIPTION
Treat whitespace/empty scenario strings as invalid and avoid calling rules API for them. Convert scenario check to Boolean in TemplatePage, add early-return logic in useRuleManagement (clear rules and loading state) and useScenarioPageInternal (skip effect), and add an API-level validation in getRules to return an error for blank scenarios. These changes prevent unnecessary API calls and potential crashes when scenarios are empty.