### PR TITLE
refactor(imbot): tighten lifecycle, unify adapters, and type telegram helpers

### DIFF
--- a/imbot/core/base.go
+++ b/imbot/core/base.go
@@ -119,6 +119,26 @@ func (b *BaseBot) UpdateReady(ready bool) {
 	b.status.Ready = ready
 }
 
+// MarkConnected marks the bot connected and authenticated, then emits connected.
+func (b *BaseBot) MarkConnected(authenticated bool) {
+	b.UpdateConnected(true)
+	b.UpdateAuthenticated(authenticated)
+	b.EmitConnected()
+}
+
+// MarkReady marks the bot ready and emits ready.
+func (b *BaseBot) MarkReady() {
+	b.UpdateReady(true)
+	b.EmitReady()
+}
+
+// MarkDisconnected marks the bot disconnected and not ready, then emits disconnected.
+func (b *BaseBot) MarkDisconnected() {
+	b.UpdateConnected(false)
+	b.UpdateReady(false)
+	b.EmitDisconnected()
+}
+
 // UpdateLastActivity updates the last activity timestamp
 func (b *BaseBot) UpdateLastActivity() {
 	b.mu.Lock()

--- a/imbot/core/base.go
+++ b/imbot/core/base.go
@@ -196,97 +196,99 @@ func (b *BaseBot) OnReady(handler func()) {
 // EmitMessage emits a message event
 func (b *BaseBot) EmitMessage(msg Message) {
 	b.UpdateLastActivity()
+	b.emitMessageHandlers(b.snapshotMessageHandlers(), msg, "message")
+}
 
+// EmitError emits an error event
+func (b *BaseBot) EmitError(err error) {
+	b.emitErrorHandlers(b.snapshotErrorHandlers(), err, "error")
+}
+
+// EmitConnected emits a connected event
+func (b *BaseBot) EmitConnected() {
+	b.emitVoidHandlers(b.snapshotConnectedHandlers(), "connected")
+}
+
+// EmitDisconnected emits a disconnected event
+func (b *BaseBot) EmitDisconnected() {
+	b.emitVoidHandlers(b.snapshotDisconnectedHandlers(), "disconnected")
+}
+
+// EmitReady emits a ready event
+func (b *BaseBot) EmitReady() {
+	b.emitVoidHandlers(b.snapshotReadyHandlers(), "ready")
+}
+
+func (b *BaseBot) snapshotMessageHandlers() []func(Message) {
 	b.mu.RLock()
+	defer b.mu.RUnlock()
 	handlers := make([]func(Message), len(b.handlers.message))
 	copy(handlers, b.handlers.message)
-	b.mu.RUnlock()
+	return handlers
+}
 
+func (b *BaseBot) snapshotErrorHandlers() []func(error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	handlers := make([]func(error), len(b.handlers.error))
+	copy(handlers, b.handlers.error)
+	return handlers
+}
+
+func (b *BaseBot) snapshotConnectedHandlers() []func() {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	handlers := make([]func(), len(b.handlers.connected))
+	copy(handlers, b.handlers.connected)
+	return handlers
+}
+
+func (b *BaseBot) snapshotDisconnectedHandlers() []func() {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	handlers := make([]func(), len(b.handlers.disconnected))
+	copy(handlers, b.handlers.disconnected)
+	return handlers
+}
+
+func (b *BaseBot) snapshotReadyHandlers() []func() {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	handlers := make([]func(), len(b.handlers.ready))
+	copy(handlers, b.handlers.ready)
+	return handlers
+}
+
+func (b *BaseBot) emitMessageHandlers(handlers []func(Message), msg Message, event string) {
 	for _, handler := range handlers {
 		go func(h func(Message)) {
-			defer func() {
-				if r := recover(); r != nil {
-					b.Logger().Error(fmt.Sprintf("panic in message handler: %v", r))
-				}
-			}()
+			defer b.recoverHandler(event)
 			h(msg)
 		}(handler)
 	}
 }
 
-// EmitError emits an error event
-func (b *BaseBot) EmitError(err error) {
-	b.mu.RLock()
-	handlers := make([]func(error), len(b.handlers.error))
-	copy(handlers, b.handlers.error)
-	b.mu.RUnlock()
-
+func (b *BaseBot) emitErrorHandlers(handlers []func(error), err error, event string) {
 	for _, handler := range handlers {
 		go func(h func(error)) {
-			defer func() {
-				if r := recover(); r != nil {
-					b.Logger().Error(fmt.Sprintf("panic in error handler: %v", r))
-				}
-			}()
+			defer b.recoverHandler(event)
 			h(err)
 		}(handler)
-	}
+		}
 }
 
-// EmitConnected emits a connected event
-func (b *BaseBot) EmitConnected() {
-	b.mu.RLock()
-	handlers := make([]func(), len(b.handlers.connected))
-	copy(handlers, b.handlers.connected)
-	b.mu.RUnlock()
-
+func (b *BaseBot) emitVoidHandlers(handlers []func(), event string) {
 	for _, handler := range handlers {
 		go func(h func()) {
-			defer func() {
-				if r := recover(); r != nil {
-					b.Logger().Error(fmt.Sprintf("panic in connected handler: %v", r))
-				}
-			}()
+			defer b.recoverHandler(event)
 			h()
 		}(handler)
 	}
 }
 
-// EmitDisconnected emits a disconnected event
-func (b *BaseBot) EmitDisconnected() {
-	b.mu.RLock()
-	handlers := make([]func(), len(b.handlers.disconnected))
-	copy(handlers, b.handlers.disconnected)
-	b.mu.RUnlock()
-
-	for _, handler := range handlers {
-		go func(h func()) {
-			defer func() {
-				if r := recover(); r != nil {
-					b.Logger().Error(fmt.Sprintf("panic in disconnected handler: %v", r))
-				}
-			}()
-			h()
-		}(handler)
-	}
-}
-
-// EmitReady emits a ready event
-func (b *BaseBot) EmitReady() {
-	b.mu.RLock()
-	handlers := make([]func(), len(b.handlers.ready))
-	copy(handlers, b.handlers.ready)
-	b.mu.RUnlock()
-
-	for _, handler := range handlers {
-		go func(h func()) {
-			defer func() {
-				if r := recover(); r != nil {
-					b.Logger().Error(fmt.Sprintf("panic in ready handler: %v", r))
-				}
-			}()
-			h()
-		}(handler)
+func (b *BaseBot) recoverHandler(event string) {
+	if r := recover(); r != nil {
+		b.Logger().Error(fmt.Sprintf("panic in %s handler: %v", event, r))
 	}
 }
 

--- a/imbot/imbot.go
+++ b/imbot/imbot.go
@@ -2,6 +2,7 @@
 package imbot
 
 import (
+	"github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot/command"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 	"github.com/tingly-dev/tingly-box/imbot/interaction"
@@ -15,13 +16,15 @@ type TelegramBot interface {
 	// ResolveChatID resolves a chat ID from invite link, username, or direct ID
 	ResolveChatID(input string) (string, error)
 	// EditMessageWithKeyboard edits a message text and keyboard
-	EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard interface{}) error
+	EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard *models.InlineKeyboardMarkup) error
 	// RemoveMessageKeyboard removes the inline keyboard from a message
 	RemoveMessageKeyboard(ctx interface{}, chatID string, messageID string) error
 	// SetCommandList sets the bot's command list (shown in the menu button)
-	SetCommandList(commands interface{}) error
+	SetCommandList(commands []models.BotCommand) error
 	// SetMenuButton sets the menu button for the bot
-	SetMenuButton(config interface{}) error
+	SetMenuButton(config telegram.MenuButtonConfig) error
+	// GetMenuButton gets the current menu button configuration
+	GetMenuButton() (map[string]interface{}, error)
 }
 
 // AsTelegramBot attempts to cast a Bot to TelegramBot interface

--- a/imbot/manager.go
+++ b/imbot/manager.go
@@ -94,6 +94,10 @@ func (m *Manager) AddBot(config *core.Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if config.UUID == "" {
+		return fmt.Errorf("missing bot uuid")
+	}
+
 	// Create bot
 	bot, err := CreateBot(config)
 	if err != nil {
@@ -104,11 +108,7 @@ func (m *Manager) AddBot(config *core.Config) error {
 	m.setupBotHandlers(bot, config.Platform)
 
 	// Add to UUID index
-	if config.UUID != "" {
-		m.bots[config.UUID] = bot
-	} else {
-		return fmt.Errorf("missing bot uuid")
-	}
+	m.bots[config.UUID] = bot
 
 	// Connect if enabled
 	if config.Enabled {
@@ -186,13 +186,12 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.logger.Info("Starting bot manager...")
 
 	// Connect all bots
-	for _, bot := range m.bots {
+	for _, bot := range m.snapshotBots() {
 		if !bot.IsConnected() {
 			if err := bot.Connect(ctx); err != nil {
 				m.logger.Error("Failed to connect %s bot: %v", bot.PlatformInfo().Name, err)
 			}
 		}
-
 	}
 
 	m.logger.Info("Bot manager started")
@@ -212,12 +211,7 @@ func (m *Manager) shutdown() {
 	m.stopping.Store(true)
 
 	// Disconnect all bots without using WaitGroup to avoid deadlock
-	m.mu.RLock()
-	bots := make([]core.Bot, 0, len(m.bots))
-	for _, bot := range m.bots {
-		bots = append(bots, bot)
-	}
-	m.mu.RUnlock()
+	bots := m.snapshotBots()
 
 	// Disconnect each bot (with timeout)
 	for _, bot := range bots {
@@ -323,75 +317,19 @@ func (m *Manager) setupBotHandlers(bot core.Bot, platform Platform) {
 	botUUID := bot.UUID()
 
 	bot.OnMessage(func(msg core.Message) {
-		m.mu.RLock()
-		handlers := make([]func(core.Message, Platform, string), len(m.handlers.message))
-		copy(handlers, m.handlers.message)
-		m.mu.RUnlock()
-
-		for _, handler := range handlers {
-			go func(h func(core.Message, Platform, string)) {
-				defer func() {
-					if r := recover(); r != nil {
-						m.logger.Error("panic in message handler: %v", r)
-					}
-				}()
-				h(msg, platform, botUUID)
-			}(handler)
-		}
+		m.emitMessageHandlers(m.snapshotMessageHandlers(), msg, platform, botUUID, "message")
 	})
 
 	bot.OnError(func(err error) {
-		m.mu.RLock()
-		handlers := make([]func(error, Platform, string), len(m.handlers.error))
-		copy(handlers, m.handlers.error)
-		m.mu.RUnlock()
-
-		for _, handler := range handlers {
-			go func(h func(error, Platform, string)) {
-				defer func() {
-					if r := recover(); r != nil {
-						m.logger.Error("panic in error handler: %v", r)
-					}
-				}()
-				h(err, platform, botUUID)
-			}(handler)
-		}
+		m.emitErrorHandlers(m.snapshotErrorHandlers(), err, platform, botUUID, "error")
 	})
 
 	bot.OnConnected(func() {
-		m.mu.RLock()
-		handlers := make([]func(Platform), len(m.handlers.connected))
-		copy(handlers, m.handlers.connected)
-		m.mu.RUnlock()
-
-		for _, handler := range handlers {
-			go func(h func(Platform)) {
-				defer func() {
-					if r := recover(); r != nil {
-						m.logger.Error("panic in connected handler: %v", r)
-					}
-				}()
-				h(platform)
-			}(handler)
-		}
+		m.emitPlatformHandlers(m.snapshotConnectedHandlers(), platform, "connected")
 	})
 
 	bot.OnDisconnected(func() {
-		m.mu.RLock()
-		handlers := make([]func(Platform), len(m.handlers.disconnected))
-		copy(handlers, m.handlers.disconnected)
-		m.mu.RUnlock()
-
-		for _, handler := range handlers {
-			go func(h func(Platform)) {
-				defer func() {
-					if r := recover(); r != nil {
-						m.logger.Error("panic in disconnected handler: %v", r)
-					}
-				}()
-				h(platform)
-			}(handler)
-		}
+		m.emitPlatformHandlers(m.snapshotDisconnectedHandlers(), platform, "disconnected")
 
 		// Auto-reconnect if enabled
 		if m.config.AutoReconnect {
@@ -400,22 +338,91 @@ func (m *Manager) setupBotHandlers(bot core.Bot, platform Platform) {
 	})
 
 	bot.OnReady(func() {
-		m.mu.RLock()
-		handlers := make([]func(Platform), len(m.handlers.ready))
-		copy(handlers, m.handlers.ready)
-		m.mu.RUnlock()
-
-		for _, handler := range handlers {
-			go func(h func(Platform)) {
-				defer func() {
-					if r := recover(); r != nil {
-						m.logger.Error("panic in ready handler: %v", r)
-					}
-				}()
-				h(platform)
-			}(handler)
-		}
+		m.emitPlatformHandlers(m.snapshotReadyHandlers(), platform, "ready")
 	})
+}
+
+func (m *Manager) snapshotBots() []core.Bot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	bots := make([]core.Bot, 0, len(m.bots))
+	for _, bot := range m.bots {
+		bots = append(bots, bot)
+	}
+	return bots
+}
+
+func (m *Manager) snapshotMessageHandlers() []func(core.Message, Platform, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	handlers := make([]func(core.Message, Platform, string), len(m.handlers.message))
+	copy(handlers, m.handlers.message)
+	return handlers
+}
+
+func (m *Manager) snapshotErrorHandlers() []func(error, Platform, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	handlers := make([]func(error, Platform, string), len(m.handlers.error))
+	copy(handlers, m.handlers.error)
+	return handlers
+}
+
+func (m *Manager) snapshotConnectedHandlers() []func(Platform) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	handlers := make([]func(Platform), len(m.handlers.connected))
+	copy(handlers, m.handlers.connected)
+	return handlers
+}
+
+func (m *Manager) snapshotDisconnectedHandlers() []func(Platform) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	handlers := make([]func(Platform), len(m.handlers.disconnected))
+	copy(handlers, m.handlers.disconnected)
+	return handlers
+}
+
+func (m *Manager) snapshotReadyHandlers() []func(Platform) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	handlers := make([]func(Platform), len(m.handlers.ready))
+	copy(handlers, m.handlers.ready)
+	return handlers
+}
+
+func (m *Manager) emitMessageHandlers(handlers []func(core.Message, Platform, string), msg core.Message, platform Platform, botUUID string, event string) {
+	for _, handler := range handlers {
+		go func(h func(core.Message, Platform, string)) {
+			defer m.recoverHandler(event)
+			h(msg, platform, botUUID)
+		}(handler)
+	}
+}
+
+func (m *Manager) emitErrorHandlers(handlers []func(error, Platform, string), err error, platform Platform, botUUID string, event string) {
+	for _, handler := range handlers {
+		go func(h func(error, Platform, string)) {
+			defer m.recoverHandler(event)
+			h(err, platform, botUUID)
+		}(handler)
+	}
+}
+
+func (m *Manager) emitPlatformHandlers(handlers []func(Platform), platform Platform, event string) {
+	for _, handler := range handlers {
+		go func(h func(Platform)) {
+			defer m.recoverHandler(event)
+			h(platform)
+		}(handler)
+	}
+}
+
+func (m *Manager) recoverHandler(event string) {
+	if r := recover(); r != nil {
+		m.logger.Error("panic in %s handler: %v", event, r)
+	}
 }
 
 // handleReconnect handles auto-reconnect logic

--- a/imbot/manager.go
+++ b/imbot/manager.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 )
 
@@ -20,6 +20,7 @@ type Manager struct {
 	ctx      context.Context
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
+	stopping atomic.Bool
 }
 
 // eventHandlers stores global event handlers
@@ -93,14 +94,6 @@ func (m *Manager) AddBot(config *core.Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Validate config
-	if err := config.Validate(); err != nil {
-		return fmt.Errorf("invalid config: %w", err)
-	}
-
-	// Expand environment variables
-	config.ExpandEnvVars()
-
 	// Create bot
 	bot, err := CreateBot(config)
 	if err != nil {
@@ -114,7 +107,7 @@ func (m *Manager) AddBot(config *core.Config) error {
 	if config.UUID != "" {
 		m.bots[config.UUID] = bot
 	} else {
-		logrus.Errorf("missing bot uuid")
+		return fmt.Errorf("missing bot uuid")
 	}
 
 	// Connect if enabled
@@ -153,8 +146,8 @@ func (m *Manager) RemoveBot(uid string) error {
 		m.logger.Error("Error closing bot: %v", err)
 	}
 
-	// Remove
-	logrus.Infof("remove bot: %s[%s]", bot.PlatformInfo().Name, bot.UUID())
+	delete(m.bots, uid)
+	m.logger.Info("Removed %s bot [%s]", bot.PlatformInfo().Name, bot.UUID())
 	return nil
 }
 
@@ -187,6 +180,7 @@ func (m *Manager) GetBotByUUID(uuid string) core.Bot {
 func (m *Manager) Start(ctx context.Context) error {
 	m.mu.Lock()
 	m.ctx = ctx
+	m.stopping.Store(false)
 	m.mu.Unlock()
 
 	m.logger.Info("Starting bot manager...")
@@ -215,13 +209,15 @@ func (m *Manager) Start(ctx context.Context) error {
 
 // shutdown performs the actual shutdown (called from Stop goroutine or when context is cancelled)
 func (m *Manager) shutdown() {
+	m.stopping.Store(true)
+
 	// Disconnect all bots without using WaitGroup to avoid deadlock
-	m.mu.Lock()
+	m.mu.RLock()
 	bots := make([]core.Bot, 0, len(m.bots))
 	for _, bot := range m.bots {
 		bots = append(bots, bot)
 	}
-	m.mu.Unlock()
+	m.mu.RUnlock()
 
 	// Disconnect each bot (with timeout)
 	for _, bot := range bots {
@@ -239,13 +235,20 @@ func (m *Manager) shutdown() {
 // Stop stops the manager and disconnects all bots
 func (m *Manager) Stop(ctx context.Context) error {
 	m.logger.Info("Stopping bot manager...")
+	m.stopping.Store(true)
 
 	m.cancel()
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		m.shutdown()
+		close(shutdownDone)
+	}()
 
 	// Wait for shutdown to complete (with timeout)
 	done := make(chan struct{})
 	go func() {
-		m.wg.Wait()
+		<-shutdownDone
 		close(done)
 	}()
 
@@ -253,6 +256,8 @@ func (m *Manager) Stop(ctx context.Context) error {
 	case <-done:
 		m.logger.Info("Bot manager stopped")
 		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("stop cancelled: %w", ctx.Err())
 	case <-time.After(10 * time.Second):
 		m.logger.Warn("Timeout waiting for bot manager to stop")
 		return fmt.Errorf("timeout waiting for bots to stop")
@@ -430,7 +435,7 @@ func (m *Manager) handleReconnect(bot core.Bot, platform Platform) {
 			m.mu.RUnlock()
 
 			// Don't reconnect if context is cancelled or auto-reconnect is disabled
-			if ctxCancelled || !autoReconnect {
+			if ctxCancelled || !autoReconnect || m.stopping.Load() {
 				m.logger.Info("Skipping reconnect for %s bot: context cancelled or auto-reconnect disabled", platform)
 				return
 			}

--- a/imbot/manager_test.go
+++ b/imbot/manager_test.go
@@ -1,0 +1,93 @@
+package imbot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+func TestManagerRemoveBotDeletesEntry(t *testing.T) {
+	manager := NewManager()
+	cfg := &core.Config{
+		UUID:     "bot-remove",
+		Platform: core.PlatformWebChat,
+		Enabled:  false,
+		Auth: core.AuthConfig{
+			Type:  "token",
+			Token: "test-token",
+		},
+	}
+
+	if err := manager.AddBot(cfg); err != nil {
+		t.Fatalf("AddBot failed: %v", err)
+	}
+	if got := manager.GetBotByUUID(cfg.UUID); got == nil {
+		t.Fatalf("expected bot to exist before removal")
+	}
+
+	if err := manager.RemoveBot(cfg.UUID); err != nil {
+		t.Fatalf("RemoveBot failed: %v", err)
+	}
+	if got := manager.GetBotByUUID(cfg.UUID); got != nil {
+		t.Fatalf("expected bot to be removed, got %#v", got)
+	}
+}
+
+func TestManagerAddBotRequiresUUID(t *testing.T) {
+	manager := NewManager()
+	cfg := &core.Config{
+		Platform: core.PlatformWebChat,
+		Enabled:  false,
+		Auth: core.AuthConfig{
+			Type:  "token",
+			Token: "test-token",
+		},
+	}
+
+	if err := manager.AddBot(cfg); err == nil {
+		t.Fatal("expected AddBot to fail when UUID is missing")
+	}
+}
+
+func TestManagerStopDisconnectsBot(t *testing.T) {
+	manager := NewManager()
+	cfg := &core.Config{
+		UUID:     "bot-stop",
+		Platform: core.PlatformWebChat,
+		Enabled:  false,
+		Auth: core.AuthConfig{
+			Type:  "token",
+			Token: "test-token",
+		},
+	}
+
+	if err := manager.AddBot(cfg); err != nil {
+		t.Fatalf("AddBot failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	bot := manager.GetBotByUUID(cfg.UUID)
+	if bot == nil {
+		t.Fatal("expected bot to exist")
+	}
+	if !bot.IsConnected() {
+		t.Fatal("expected bot to be connected after Start")
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	if err := manager.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+	if bot.IsConnected() {
+		t.Fatal("expected bot to be disconnected after Stop")
+	}
+}

--- a/imbot/platform/dingtalk/dingtalk.go
+++ b/imbot/platform/dingtalk/dingtalk.go
@@ -100,9 +100,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 		return core.NewConnectionFailedError(core.PlatformDingTalk, "stream connection failed", true)
 	}
 
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
-	b.EmitConnected()
+	b.MarkConnected(true)
 	b.Logger().Info("DingTalk bot connected")
 
 	// Wait for connection to be ready
@@ -127,9 +125,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 
 	b.wg.Wait()
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("DingTalk bot disconnected")
 
 	return nil
@@ -139,8 +135,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 func (b *Bot) waitForReady() {
 	defer b.wg.Done()
 	time.Sleep(2 * time.Second)
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 }
 
 // onChatBotMessage handles chat bot callback messages

--- a/imbot/platform/feishu/bot_sdk.go
+++ b/imbot/platform/feishu/bot_sdk.go
@@ -123,9 +123,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 		return core.NewAuthFailedError(core.Platform(b.domain), "authentication failed", err)
 	}
 
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
-	b.EmitConnected()
+	b.MarkConnected(true)
 	b.Logger().Info("%s bot connected (authenticated): domain=%s", b.domain, b.domain)
 
 	// Auto-start receiving messages via WebSocket
@@ -145,9 +143,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 		_ = b.StopReceiving(ctx)
 	}
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("%s bot disconnected", b.domain)
 	return nil
 }
@@ -191,8 +187,7 @@ func (b *Bot) StartReceiving(ctx context.Context) error {
 	// Wait a moment for connection to establish
 	time.Sleep(2 * time.Second)
 
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 	b.Logger().Info("%s WebSocket connected and receiving events", b.domain)
 
 	return nil

--- a/imbot/platform/slack/slack.go
+++ b/imbot/platform/slack/slack.go
@@ -58,9 +58,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 		return core.NewAuthFailedError(core.PlatformSlack, "authentication failed", err)
 	}
 
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
-	b.EmitConnected()
+	b.MarkConnected(true)
 	b.Logger().Info("Slack bot connected: %s", authResp.User)
 
 	// Start RTM or WebSocket
@@ -83,9 +81,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 
 	b.wg.Wait()
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("Slack bot disconnected")
 
 	return nil
@@ -233,8 +229,7 @@ func (b *Bot) handleRTMEvents(rtm *slack.RTM) {
 	b.wg.Add(1)
 	defer b.wg.Done()
 
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 
 	for {
 		select {

--- a/imbot/platform/telegram/menu.go
+++ b/imbot/platform/telegram/menu.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 	"github.com/tingly-dev/tingly-box/imbot/interaction"
 	"github.com/tingly-dev/tingly-box/imbot/menu"
@@ -198,7 +199,7 @@ func (a *MenuAdapter) HideMenu(ctx context.Context, bot core.Bot, menuCtx *menu.
 func (a *MenuAdapter) UpdateMenu(ctx context.Context, bot core.Bot, menuCtx *menu.MenuContext, m *menu.Menu) error {
 	// For inline keyboards, we can edit the existing message
 	type TelegramEditBot interface {
-		EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard interface{}) error
+		EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard *models.InlineKeyboardMarkup) error
 	}
 
 	if tgBot, ok := bot.(TelegramEditBot); ok && menuCtx.MessageID != "" {
@@ -209,7 +210,20 @@ func (a *MenuAdapter) UpdateMenu(ctx context.Context, bot core.Bot, menuCtx *men
 		}
 
 		if kb, ok := markup.(interaction.InlineKeyboardMarkup); ok {
-			return tgBot.EditMessageWithKeyboard(ctx, menuCtx.ChatID, menuCtx.MessageID, m.Title, kb)
+			telegramRows := make([][]models.InlineKeyboardButton, 0, len(kb.InlineKeyboard))
+			for _, row := range kb.InlineKeyboard {
+				telegramRow := make([]models.InlineKeyboardButton, len(row))
+				for i, button := range row {
+					telegramRow[i] = models.InlineKeyboardButton{
+						Text:         button.Text,
+						CallbackData: button.CallbackData,
+						URL:          button.URL,
+					}
+				}
+				telegramRows = append(telegramRows, telegramRow)
+			}
+			markup := models.InlineKeyboardMarkup{InlineKeyboard: telegramRows}
+			return tgBot.EditMessageWithKeyboard(ctx, menuCtx.ChatID, menuCtx.MessageID, m.Title, &markup)
 		}
 	}
 

--- a/imbot/platform/telegram/telegram.go
+++ b/imbot/platform/telegram/telegram.go
@@ -31,6 +31,20 @@ type Bot struct {
 	messageIDMap map[string]int // chatID -> last message ID
 }
 
+type MenuButtonType string
+
+const (
+	MenuButtonTypeDefault  MenuButtonType = "default"
+	MenuButtonTypeCommands MenuButtonType = "commands"
+	MenuButtonTypeWebApp   MenuButtonType = "web_app"
+)
+
+type MenuButtonConfig struct {
+	Type MenuButtonType
+	Text string
+	URL  string
+}
+
 // NewTelegramBot creates a new Telegram bot
 func NewTelegramBot(config *core.Config) (*Bot, error) {
 	if err := config.Validate(); err != nil {
@@ -283,7 +297,7 @@ func (b *Bot) EditMessage(ctx context.Context, messageID string, text string) er
 }
 
 // EditMessageWithKeyboard edits a message with text and inline keyboard
-func (b *Bot) EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard interface{}) error {
+func (b *Bot) EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard *models.InlineKeyboardMarkup) error {
 	if err := b.EnsureReady(); err != nil {
 		return err
 	}
@@ -308,11 +322,7 @@ func (b *Bot) EditMessageWithKeyboard(ctx interface{}, chatID string, messageID 
 	}
 
 	// Set keyboard if provided
-	if keyboard != nil {
-		if kb, ok := keyboard.(models.InlineKeyboardMarkup); ok {
-			params.ReplyMarkup = &kb
-		}
-	}
+	params.ReplyMarkup = keyboard
 
 	_, err = b.api.EditMessageText(b.ctx, params)
 	if err != nil {
@@ -602,68 +612,37 @@ func (b *Bot) ResolveChatID(input string) (string, error) {
 	return "", fmt.Errorf("invalid input format: %s (expected chat ID, @username, or invite link)", input)
 }
 
-// SetCommandList sets the bot's command list (shown in the menu button)
-// Accepts either []models.BotCommand or []map[string]string
-func (b *Bot) SetCommandList(commands interface{}) error {
+// SetCommandList sets the bot's command list (shown in the menu button).
+func (b *Bot) SetCommandList(commands []models.BotCommand) error {
 	if err := b.EnsureReady(); err != nil {
 		return err
 	}
 
-	var botCommands []models.BotCommand
-
-	switch v := commands.(type) {
-	case []models.BotCommand:
-		botCommands = v
-	case []map[string]string:
-		// Convert from map format to BotCommand
-		botCommands = make([]models.BotCommand, 0, len(v))
-		for _, cmd := range v {
-			botCommands = append(botCommands, models.BotCommand{
-				Command:     cmd["command"],
-				Description: cmd["description"],
-			})
-		}
-	default:
-		return fmt.Errorf("invalid commands type: %T", commands)
-	}
-
 	_, err := b.api.SetMyCommands(b.ctx, &tgbot.SetMyCommandsParams{
-		Commands: botCommands,
+		Commands: commands,
 	})
 	return err
 }
 
-// SetMenuButton sets the menu button for the bot
-// Config can be:
-// - map[string]interface{}{"type": "commands"} - Show commands menu
-// - map[string]interface{}{"type": "web_app", "text": "Text", "url": "https://..."} - Open web app
-// - map[string]interface{}{"type": "default"} - Reset to default
-func (b *Bot) SetMenuButton(config interface{}) error {
+// SetMenuButton sets the menu button for the bot.
+func (b *Bot) SetMenuButton(config MenuButtonConfig) error {
 	if err := b.EnsureReady(); err != nil {
 		return err
 	}
 
 	var menuButton models.InputMenuButton
 
-	switch cfg := config.(type) {
-	case map[string]interface{}:
-		menuType, _ := cfg["type"].(string)
-		switch menuType {
-		case "commands":
-			menuButton = &models.MenuButtonCommands{Type: models.MenuButtonTypeCommands}
-		case "web_app":
-			text, _ := cfg["text"].(string)
-			url, _ := cfg["url"].(string)
-			menuButton = &models.MenuButtonWebApp{
-				Type:   models.MenuButtonTypeWebApp,
-				Text:   text,
-				WebApp: models.WebAppInfo{URL: url},
-			}
-		default:
-			menuButton = &models.MenuButtonDefault{Type: models.MenuButtonTypeDefault}
+	switch config.Type {
+	case MenuButtonTypeCommands:
+		menuButton = &models.MenuButtonCommands{Type: models.MenuButtonTypeCommands}
+	case MenuButtonTypeWebApp:
+		menuButton = &models.MenuButtonWebApp{
+			Type:   models.MenuButtonTypeWebApp,
+			Text:   config.Text,
+			WebApp: models.WebAppInfo{URL: config.URL},
 		}
 	default:
-		menuButton = &models.MenuButtonCommands{Type: models.MenuButtonTypeCommands}
+		menuButton = &models.MenuButtonDefault{Type: models.MenuButtonTypeDefault}
 	}
 
 	_, err := b.api.SetChatMenuButton(b.ctx, &tgbot.SetChatMenuButtonParams{

--- a/imbot/platform/telegram/telegram.go
+++ b/imbot/platform/telegram/telegram.go
@@ -111,9 +111,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 	b.api.RegisterHandler(tgbot.HandlerTypeMessageText, "", tgbot.MatchTypePrefix, b.handleMessageUpdate)
 	b.api.RegisterHandler(tgbot.HandlerTypeCallbackQueryData, "", tgbot.MatchTypePrefix, b.handleCallbackQueryUpdate)
 
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
-	b.EmitConnected()
+	b.MarkConnected(true)
 
 	// Get bot info
 	me, err := b.api.GetMe(b.ctx)
@@ -123,8 +121,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 		b.Logger().Info("Telegram bot connected: @%s", me.Username)
 	}
 
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 
 	// Start receiving messages
 	b.wg.Add(1)
@@ -187,9 +184,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 
 	b.wg.Wait()
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("Telegram bot disconnected")
 
 	return nil

--- a/imbot/platform/wecom/adapter.go
+++ b/imbot/platform/wecom/adapter.go
@@ -3,34 +3,29 @@ package wecom
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/tingly-dev/tingly-box/imbot/core"
+	weixinadapter "github.com/tingly-dev/tingly-box/imbot/platform/weixin"
 	"github.com/tingly-dev/weixin/types"
 )
 
 // Adapter converts types.Message (already translated from WeCom wire format by the SDK)
 // to core.Message.
 type Adapter struct {
-	*core.BaseAdapter
+	*weixinadapter.Adapter
 }
 
 // NewAdapter creates a new WeCom adapter.
 func NewAdapter(config *core.Config) *Adapter {
 	return &Adapter{
-		BaseAdapter: core.NewBaseAdapter(config),
+		Adapter: weixinadapter.NewAdapterForPlatform(config, nil, core.PlatformWecom),
 	}
-}
-
-// Platform returns core.PlatformWecom.
-func (a *Adapter) Platform() core.Platform {
-	return core.PlatformWecom
 }
 
 // AdaptMessage converts a types.Message to core.Message.
 func (a *Adapter) AdaptMessage(ctx context.Context, msg *types.Message) (*core.Message, error) {
 	if msg == nil {
-		return nil, fmt.Errorf("nil message")
+		return nil, core.NewAdaptError(core.PlatformWecom, "adapt message", msg, context.Canceled)
 	}
 
 	// Determine recipient ID: use chatId from metadata when available (group),
@@ -41,12 +36,12 @@ func (a *Adapter) AdaptMessage(ctx context.Context, msg *types.Message) (*core.M
 		recipientID = cid
 	}
 
-	builder := core.NewMessageBuilder(core.PlatformWecom).
+	builder := core.NewMessageBuilder(a.Platform()).
 		WithID(msg.MessageID).
 		WithTimestamp(msg.Timestamp.Unix()).
 		WithSender(msg.SenderID, "", "").
 		WithRecipient(recipientID, string(chatType), "").
-		WithContent(a.extractContent(msg)).
+		WithContent(weixinadapter.BuildContent(msg, mapMimeType)).
 		WithMetadata("context_token", msg.ContextToken)
 
 	if msg.ReplyToID != "" {
@@ -56,25 +51,6 @@ func (a *Adapter) AdaptMessage(ctx context.Context, msg *types.Message) (*core.M
 	}
 
 	return builder.Build(), nil
-}
-
-// extractContent derives a core.Content value from the SDK message.
-func (a *Adapter) extractContent(msg *types.Message) core.Content {
-	if len(msg.Attachments) > 0 {
-		media := make([]core.MediaAttachment, 0, len(msg.Attachments))
-		for _, att := range msg.Attachments {
-			media = append(media, core.MediaAttachment{
-				Type:     mapMimeType(att.MimeType),
-				URL:      att.URL,
-				Filename: att.FileName,
-			})
-		}
-		return core.NewMediaContent(media, msg.Text)
-	}
-	if msg.Text != "" {
-		return core.NewTextContent(msg.Text)
-	}
-	return core.NewSystemContent("unknown", nil)
 }
 
 // mapChatType maps SDK ChatType to core ChatType.

--- a/imbot/platform/wecom/wecom.go
+++ b/imbot/platform/wecom/wecom.go
@@ -65,8 +65,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 		return core.NewAuthFailedError(core.PlatformWecom, fmt.Sprintf("connect failed: %v", err), err)
 	}
 
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
+	b.MarkConnected(true)
 
 	b.wg.Add(1)
 	go b.runUntilDone()
@@ -78,8 +77,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 func (b *Bot) runUntilDone() {
 	defer b.wg.Done()
 
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 	b.Logger().Info("WeCom bot ready: botID=%s", b.botID)
 
 	<-b.ctx.Done()
@@ -97,9 +95,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 
 	_ = b.sdk.Disconnect()
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("WeCom bot disconnected")
 
 	return nil

--- a/imbot/platform/weixin/adapter.go
+++ b/imbot/platform/weixin/adapter.go
@@ -13,6 +13,7 @@ import (
 type Adapter struct {
 	*core.BaseAdapter
 	account *types.WeChatAccount
+	platform core.Platform
 }
 
 // NewAdapter creates a new Weixin adapter with the given config and account.
@@ -20,12 +21,19 @@ func NewAdapter(config *core.Config, account *types.WeChatAccount) *Adapter {
 	return &Adapter{
 		BaseAdapter: core.NewBaseAdapter(config),
 		account:     account,
+		platform:    core.PlatformWeixin,
 	}
+}
+
+func NewAdapterForPlatform(config *core.Config, account *types.WeChatAccount, platform core.Platform) *Adapter {
+	adapter := NewAdapter(config, account)
+	adapter.platform = platform
+	return adapter
 }
 
 // Platform returns core.PlatformWeixin.
 func (a *Adapter) Platform() core.Platform {
-	return core.PlatformWeixin
+	return a.platform
 }
 
 // AdaptMessage converts a types.Message to core.Message.
@@ -40,7 +48,7 @@ func (a *Adapter) AdaptMessage(ctx context.Context, msg *types.Message) (*core.M
 	messageState, _ := msg.Metadata["message_state"].(int)
 
 	// Build message using fluent builder
-	messageBuilder := core.NewMessageBuilder(core.PlatformWeixin).
+	messageBuilder := core.NewMessageBuilder(a.Platform()).
 		WithID(msg.MessageID).
 		WithTimestamp(msg.Timestamp.Unix()).
 		WithRecipient(msg.To, string(msg.ChatType), "").
@@ -67,39 +75,39 @@ func (a *Adapter) AdaptMessage(ctx context.Context, msg *types.Message) (*core.M
 
 // extractContent extracts the content from a types.Message.
 func (a *Adapter) extractContent(msg *types.Message) core.Content {
-	// Check if there's text
+	return BuildContent(msg, a.mapContentType)
+}
+
+func BuildContent(msg *types.Message, mapType func(string) string) core.Content {
 	if msg.Text != "" {
-		// Check if there are also attachments
 		if len(msg.Attachments) > 0 {
-			// Compound content: text + media
-			media := make([]core.MediaAttachment, 0, len(msg.Attachments))
-			for _, att := range msg.Attachments {
-				media = append(media, core.MediaAttachment{
-					Type:     a.mapContentType(att.ContentType),
-					URL:      att.URL,
-					Filename: att.FileName,
-				})
-			}
-			return core.NewMediaContent(media, msg.Text)
+			return core.NewMediaContent(buildMediaAttachments(msg.Attachments, mapType), msg.Text)
 		}
 		return core.NewTextContent(msg.Text)
 	}
-
-	// Only attachments (media)
 	if len(msg.Attachments) > 0 {
-		media := make([]core.MediaAttachment, 0, len(msg.Attachments))
-		for _, att := range msg.Attachments {
-			media = append(media, core.MediaAttachment{
-				Type:     a.mapContentType(att.ContentType),
-				URL:      att.URL,
-				Filename: att.FileName,
-			})
-		}
-		return core.NewMediaContent(media, "")
+		return core.NewMediaContent(buildMediaAttachments(msg.Attachments, mapType), "")
 	}
-
-	// Unknown content
 	return core.NewSystemContent("unknown", nil)
+}
+
+func buildMediaAttachments(attachments []types.Attachment, mapType func(string) string) []core.MediaAttachment {
+	media := make([]core.MediaAttachment, 0, len(attachments))
+	for _, att := range attachments {
+		media = append(media, core.MediaAttachment{
+			Type:     mapType(resolveAttachmentType(att)),
+			URL:      att.URL,
+			Filename: att.FileName,
+		})
+	}
+	return media
+}
+
+func resolveAttachmentType(att types.Attachment) string {
+	if att.ContentType != "" {
+		return att.ContentType
+	}
+	return att.MimeType
 }
 
 // mapContentType maps Weixin content type to core media type.

--- a/imbot/platform/weixin/weixin.go
+++ b/imbot/platform/weixin/weixin.go
@@ -125,9 +125,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 	b.adapter = NewAdapter(b.BaseBot.Config(), wcAccount)
 
 	// Mark as connected and start receiving messages
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
-	b.EmitConnected()
+	b.MarkConnected(true)
 	b.Logger().Info("Weixin bot connected: account=%s", b.account.ID())
 
 	b.wg.Add(1)
@@ -147,9 +145,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 	// Disconnect from plugin
 	_ = b.WechatBot.Disconnect()
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("Weixin bot disconnected")
 
 	return nil
@@ -407,8 +403,7 @@ func (b *Bot) receiveMessages() {
 	defer b.wg.Done()
 
 	// Mark as ready
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 	b.Logger().Info("Weixin bot ready: account=%s", b.accountID)
 
 	var syncBuf string

--- a/imbot/platform/whatsapp/whatsapp.go
+++ b/imbot/platform/whatsapp/whatsapp.go
@@ -126,9 +126,7 @@ func (b *Bot) Connect(ctx context.Context) error {
 		return err
 	}
 
-	b.UpdateConnected(true)
-	b.UpdateAuthenticated(true)
-	b.EmitConnected()
+	b.MarkConnected(true)
 	b.Logger().Info("WhatsApp bot connected: phoneID=%s", b.phoneID)
 
 	// Start receiving events (via webhook polling or websocket)
@@ -146,9 +144,7 @@ func (b *Bot) Disconnect(ctx context.Context) error {
 
 	b.wg.Wait()
 
-	b.UpdateConnected(false)
-	b.UpdateReady(false)
-	b.EmitDisconnected()
+	b.MarkDisconnected()
 	b.Logger().Info("WhatsApp bot disconnected")
 
 	return nil
@@ -283,8 +279,7 @@ func (b *Bot) authenticate() error {
 func (b *Bot) receiveEvents() {
 	defer b.wg.Done()
 
-	b.UpdateReady(true)
-	b.EmitReady()
+	b.MarkReady()
 
 	// WhatsApp primarily uses webhooks
 	// In a real implementation, you would:

--- a/internal/remote_control/bot/feature/telegram_dir_browser.go
+++ b/internal/remote_control/bot/feature/telegram_dir_browser.go
@@ -368,7 +368,7 @@ func SendDirectoryBrowser(ctx context.Context, bot imbot.Bot, browser *Directory
 	if ok && editMessageID != "" && state.MessageID != "" {
 		// Edit existing message
 		tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
-		if err := tgBot.EditMessageWithKeyboard(ctx, chatID, editMessageID, text, tgKeyboard); err != nil {
+		if err := tgBot.EditMessageWithKeyboard(ctx, chatID, editMessageID, text, &tgKeyboard); err != nil {
 			logrus.WithError(err).Warn("Failed to edit message, sending new one")
 			// Fall through to send new message
 		} else {

--- a/internal/remote_control/bot/menu_button.go
+++ b/internal/remote_control/bot/menu_button.go
@@ -2,8 +2,11 @@ package bot
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot"
+	imbottelegram "github.com/tingly-dev/tingly-box/imbot/platform/telegram"
 )
 
 // MenuButtonConfig configures the menu button for different platforms
@@ -220,52 +223,45 @@ func (r *MenuRegistry) matchesContext(cfg MenuButtonConfig, ctx *MenuContext) bo
 }
 
 // BuildForTelegram returns the Telegram Bot API configuration for the menu button
-func (r *MenuRegistry) BuildForTelegram(context *MenuContext) map[string]interface{} {
+func (r *MenuRegistry) BuildForTelegram(context *MenuContext) imbottelegram.MenuButtonConfig {
 	config := r.GetForPlatform(imbot.PlatformTelegram, context)
 	if config == nil {
-		// Return default commands menu
-		return map[string]interface{}{
-			"type": "commands",
-		}
+		return imbottelegram.MenuButtonConfig{Type: imbottelegram.MenuButtonTypeCommands}
 	}
 
 	switch config.Type {
 	case MenuTypeCommands:
-		// Build commands list
-		commands := make([]map[string]string, 0)
-		for _, item := range config.Items {
-			if item.Hidden {
-				continue
-			}
-			commands = append(commands, map[string]string{
-				"command":     item.Value,
-				"description": item.Description,
-			})
-		}
-		return map[string]interface{}{
-			"type":     "commands",
-			"commands": commands,
-		}
+		return imbottelegram.MenuButtonConfig{Type: imbottelegram.MenuButtonTypeCommands}
 
 	case MenuTypeWebApp:
-		return map[string]interface{}{
-			"type": "web_app",
-			"text": config.ButtonText,
-			"url":  config.Items[0].URL,
+		menuConfig := imbottelegram.MenuButtonConfig{Type: imbottelegram.MenuButtonTypeDefault}
+		if len(config.Items) > 0 {
+			menuConfig = imbottelegram.MenuButtonConfig{
+				Type: imbottelegram.MenuButtonTypeWebApp,
+				Text: config.ButtonText,
+				URL:  config.Items[0].URL,
+			}
 		}
+		return menuConfig
 
 	case MenuTypeCallbacks:
-		// Telegram doesn't support callback menu buttons directly
-		// Fall back to commands
-		return map[string]interface{}{
-			"type": "commands",
-		}
+		return imbottelegram.MenuButtonConfig{Type: imbottelegram.MenuButtonTypeCommands}
 
 	default:
-		return map[string]interface{}{
-			"type": "commands",
-		}
+		return imbottelegram.MenuButtonConfig{Type: imbottelegram.MenuButtonTypeCommands}
 	}
+}
+
+func buildTelegramBotCommands(cmds []map[string]string) []models.BotCommand {
+	commands := make([]models.BotCommand, 0, len(cmds))
+	for _, cmd := range cmds {
+		command := strings.TrimPrefix(cmd["command"], "/")
+		commands = append(commands, models.BotCommand{
+			Command:     command,
+			Description: cmd["description"],
+		})
+	}
+	return commands
 }
 
 // BuildForFeishu returns the Feishu/Lark configuration for quick actions
@@ -464,7 +460,7 @@ func setupTelegramMenuButton(bot imbot.Bot, cmdRegistry *imbot.CommandRegistry) 
 	}
 
 	// Build command list from the imbot command registry
-	telegramCommands := cmdRegistry.BuildPlatformCommands(imbot.PlatformTelegram)
+	telegramCommands := buildTelegramBotCommands(cmdRegistry.BuildPlatformCommands(imbot.PlatformTelegram))
 
 	if err := tgBot.SetCommandList(telegramCommands); err != nil {
 		return fmt.Errorf("failed to set bot commands: %w", err)


### PR DESCRIPTION
## Summary

ImBot suffered from lifecycle inconsistencies across platforms, duplicate adapter code between Weixin and WeCom, and untyped Telegram menu APIs. This refactoring consolidates shared patterns and improves type safety.

## Major

- Unified platform lifecycle using `MarkConnected()`, `MarkReady()`, and `MarkDisconnected()` helpers.
- Merged Weixin and WeCom adapters to eliminate ~60 lines of duplicate content extraction logic.
- Telegram menu/button APIs now use typed structs (`MenuButtonConfig`, `[]models.BotCommand`) instead of `interface{}`.

## Minor

- Manager shutdown: added a stopping atomic flag to prevent reconnect races during graceful shutdown.
- Extracted shared event emission patterns in `BaseBot` and `Manager` (snapshot-then-emit pattern).
- Added tests for manager `RemoveBot` deletion and UUID validation.
- `RemoveBot` now deletes the bot entry before closing (previously it logged after removal).
- `AddBot` validates UUID upfront instead of silently dropping bots.