### PR TITLE
refactor(server): extract forwarding layer into dedicated package [1/5]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # doc
 docs
 script
+.worktrees
 
 # codegen
 internal/web/dist
@@ -110,3 +111,4 @@ wheels/
 MANIFEST
 /tests/test_results/
 go.work.sum
+/docs/plans/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -87,11 +87,14 @@ tasks:
           BINARY_EXT=".exe"
         fi
 
+        # Set CGO_ENABLED: 1 for all platform
         CGO_ENABLED=1
-        
+
+
         # Build with ldflags
         mkdir -p build
         LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -X main.platform=${PLATFORM}"
+        GOOS={{.OS}} GOARCH={{.ARCH}} go build -ldflags="${LDFLAGS}" -o ./build/{{.BIN_NAME}} ./cli/tingly-box
         CGO_ENABLED=${CGO_ENABLED} GOOS={{.OS}} GOARCH={{.ARCH}} go build -ldflags="${LDFLAGS}" -o ./build/{{.BIN_NAME}}${BINARY_EXT} ./cli/tingly-box
 
   go:test:

--- a/internal/client/record_roundtripper.go
+++ b/internal/client/record_roundtripper.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -18,6 +20,9 @@ import (
 type contextKey string
 
 const ScenarioContextKey contextKey = "scenario"
+
+// Header to mark advisor loopback requests with depth (must match server check)
+const advisorDepthHeader = "X-Tingly-Advisor-Depth"
 
 // RecordRoundTripper is an http.RoundTripper that records requests and responses
 type RecordRoundTripper struct {
@@ -43,6 +48,16 @@ func NewRecordRoundTripper(transport http.RoundTripper, recordSink *obs.Sink, pr
 // RoundTrip executes a single HTTP transaction and records request/response
 func (r *RecordRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
+
+	// Mark advisor loopback requests with depth header to prevent recursive MCP tool injection
+	if r.provider != nil && r.provider.Name == "advisor" {
+		logrus.Debug("[RECORD-TRIPPER] Setting X-Tingly-Advisor-Depth header for advisor provider")
+		req.Header.Set(advisorDepthHeader, "1")
+	} else if r.provider != nil {
+		logrus.Debugf("[RECORD-TRIPPER] Provider name: %s (not advisor)", r.provider.Name)
+	} else {
+		logrus.Debug("[RECORD-TRIPPER] Provider is nil")
+	}
 
 	// Extract scenario from request context
 	scenario := ""

--- a/internal/server/forwarding/anthropic.go
+++ b/internal/server/forwarding/anthropic.go
@@ -1,0 +1,73 @@
+package forwarding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/client"
+)
+
+// ForwardAnthropicV1 sends a non-streaming Anthropic v1 message request.
+func ForwardAnthropicV1(fc *ForwardContext, wrapper *client.AnthropicClient, req *anthropic.MessageNewParams) (*anthropic.Message, context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get Anthropic client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(req)
+	message, err := wrapper.MessagesNew(ctx, req)
+	fc.Complete(ctx, message, err)
+
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	return message, cancel, nil
+}
+
+// ForwardAnthropicV1Stream sends a streaming Anthropic v1 message request.
+// Note: Set BaseCtx via WithBaseCtx() to support client cancellation.
+func ForwardAnthropicV1Stream(fc *ForwardContext, wrapper *client.AnthropicClient, req *anthropic.MessageNewParams) (*anthropicstream.Stream[anthropic.MessageStreamEventUnion], context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get Anthropic client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(req)
+	logrus.Debugln("Creating Anthropic v1 streaming request")
+	stream := wrapper.MessagesNewStreaming(ctx, req)
+	return stream, cancel, nil
+}
+
+// ForwardAnthropicV1Beta sends a non-streaming Anthropic v1 beta message request.
+func ForwardAnthropicV1Beta(fc *ForwardContext, wrapper *client.AnthropicClient, req *anthropic.BetaMessageNewParams) (*anthropic.BetaMessage, context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get Anthropic client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(req)
+	message, err := wrapper.BetaMessagesNew(ctx, req)
+	fc.Complete(ctx, message, err)
+
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	return message, cancel, nil
+}
+
+// ForwardAnthropicV1BetaStream sends a streaming Anthropic v1 beta message request.
+// Note: Set BaseCtx via WithBaseCtx() to support client cancellation.
+func ForwardAnthropicV1BetaStream(fc *ForwardContext, wrapper *client.AnthropicClient, req *anthropic.BetaMessageNewParams) (*anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get Anthropic client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(req)
+	logrus.Debugln("Creating Anthropic v1 beta streaming request")
+	stream := wrapper.BetaMessagesNewStreaming(ctx, req)
+	return stream, cancel, nil
+}

--- a/internal/server/forwarding/context.go
+++ b/internal/server/forwarding/context.go
@@ -1,0 +1,106 @@
+package forwarding
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// ForwardContext provides dependencies for forward functions.
+// It uses the builder pattern for optional configuration and hooks.
+type ForwardContext struct {
+	// Required dependencies
+	Provider *typ.Provider
+	BaseCtx  context.Context // Base context (e.g., request context for cancellation support)
+
+	// Optional configuration
+	Timeout time.Duration
+
+	// Hooks (chainable - multiple hooks can be added)
+	BeforeRequestHooks []func(ctx context.Context, req interface{}) (context.Context, error)
+	AfterRequestHooks  []func(ctx context.Context, resp interface{}, err error)
+}
+
+// NewForwardContext creates a new ForwardContext with required dependencies.
+// The timeout is set to the provider's default timeout.
+// baseCtx is the base context for the request:
+//   - Use context.Background() for non-streaming requests
+//   - Use c.Request.Context() for streaming requests to support client cancellation
+func NewForwardContext(baseCtx context.Context, provider *typ.Provider) *ForwardContext {
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	timeout := time.Duration(provider.Timeout) * time.Second
+	if timeout <= 0 {
+		timeout = time.Duration(constant.DefaultRequestTimeout) * time.Second
+	}
+	return &ForwardContext{
+		Provider: provider,
+		BaseCtx:  baseCtx,
+		Timeout:  timeout,
+	}
+}
+
+// WithTimeout sets the timeout for the request.
+// If not set, the provider's default timeout is used.
+func (fc *ForwardContext) WithTimeout(timeout time.Duration) *ForwardContext {
+	fc.Timeout = timeout
+	return fc
+}
+
+// WithBeforeRequest adds a hook that is called before the request is sent.
+// Multiple hooks can be added and will be called in order.
+// Each hook can modify the context and return an error to abort the request.
+func (fc *ForwardContext) WithBeforeRequest(hook func(context.Context, interface{}) (context.Context, error)) *ForwardContext {
+	fc.BeforeRequestHooks = append(fc.BeforeRequestHooks, hook)
+	return fc
+}
+
+// WithAfterRequest adds a hook that is called after the request completes.
+// Multiple hooks can be added and will be called in order.
+// Each hook receives the response and any error that occurred.
+func (fc *ForwardContext) WithAfterRequest(hook func(context.Context, interface{}, error)) *ForwardContext {
+	fc.AfterRequestHooks = append(fc.AfterRequestHooks, hook)
+	if fc.Timeout <= 0 {
+		fc.Timeout = time.Duration(constant.DefaultRequestTimeout) * time.Second
+	}
+	return fc
+}
+
+// PrepareContext prepares the final context for the request.
+// It applies the BeforeRequest hooks and adds the scenario to the context.
+// It also sets up the timeout and returns a cancel function.
+// If BaseCtx is not set, it uses context.Background() as the base.
+//
+// The order of operations matches the original implementation:
+// 1. Apply BeforeRequest hooks
+// 2. Add timeout
+func (fc *ForwardContext) PrepareContext(req interface{}) (context.Context, context.CancelFunc) {
+	ctx := fc.BaseCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Apply BeforeRequest hooks in order
+	for _, hook := range fc.BeforeRequestHooks {
+		var err error
+		ctx, err = hook(ctx, req)
+		if err != nil {
+			logrus.Errorf("Request hook error: %s", err)
+		}
+	}
+
+	return context.WithTimeout(ctx, fc.Timeout)
+}
+
+// Complete calls all AfterRequest hooks (if set) with the response and error.
+// Hooks are called in the order they were added.
+// This should be called after the request completes, regardless of success or failure.
+func (fc *ForwardContext) Complete(ctx context.Context, resp interface{}, err error) {
+	for _, hook := range fc.AfterRequestHooks {
+		hook(ctx, resp, err)
+	}
+}

--- a/internal/server/forwarding/google.go
+++ b/internal/server/forwarding/google.go
@@ -1,0 +1,36 @@
+package forwarding
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"google.golang.org/genai"
+)
+
+// ForwardGoogle sends a non-streaming Google Generative AI request.
+func ForwardGoogle(fc *ForwardContext, wrapper *client.GoogleClient, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get Google client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(nil)
+	resp, err := wrapper.GenerateContent(ctx, model, contents, config)
+	fc.Complete(ctx, resp, err)
+	return resp, cancel, err
+}
+
+// ForwardGoogleStream sends a streaming Google Generative AI request.
+// Note: Pass request context (c.Request.Context()) as baseCtx in NewForwardContext for client cancellation support.
+func ForwardGoogleStream(fc *ForwardContext, wrapper *client.GoogleClient, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (iter.Seq2[*genai.GenerateContentResponse, error], context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get Google client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(nil)
+	logrus.Debugln("Creating Google streaming request")
+	stream := wrapper.GenerateContentStream(ctx, model, contents, config)
+	return stream, cancel, nil
+}

--- a/internal/server/forwarding/openai.go
+++ b/internal/server/forwarding/openai.go
@@ -1,0 +1,75 @@
+package forwarding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/client"
+)
+
+// ForwardOpenAIChat sends a non-streaming OpenAI chat completion request.
+// IMPORTANT: All transformations (protocol conversion + vendor-specific) should
+// be applied by the transform chain BEFORE calling this function.
+func ForwardOpenAIChat(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.ChatCompletionNewParams) (*openai.ChatCompletion, context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(req)
+
+	// Clear empty tools array
+	if len(req.Tools) == 0 {
+		req.Tools = nil
+	}
+
+	logrus.Infof("provider: %s, model: %s", fc.Provider.Name, req.Model)
+
+	resp, err := wrapper.ChatCompletionsNew(ctx, *req)
+	fc.Complete(ctx, resp, err)
+
+	return resp, cancel, err
+}
+
+// ForwardOpenAIChatStream sends a streaming OpenAI chat completion request.
+// IMPORTANT: All transformations (protocol conversion + vendor-specific) should
+// be applied by the transform chain BEFORE calling this function.
+// Note: Pass request context (c.Request.Context()) as baseCtx in NewForwardContext for client cancellation support.
+func ForwardOpenAIChatStream(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.ChatCompletionNewParams) (*openaistream.Stream[openai.ChatCompletionChunk], context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
+	}
+	logrus.Debugf("provider: %s (streaming)", fc.Provider.Name)
+
+	ctx, cancel := fc.PrepareContext(req)
+
+	stream := wrapper.ChatCompletionsNewStreaming(ctx, *req)
+	return stream, cancel, nil
+}
+
+// ForwardOpenAIResponses sends a non-streaming OpenAI Responses API request.
+func ForwardOpenAIResponses(fc *ForwardContext, wrapper *client.OpenAIClient, params responses.ResponseNewParams) (*responses.Response, context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(params)
+	resp, err := wrapper.ResponsesNew(ctx, params)
+	fc.Complete(ctx, resp, err)
+	return resp, cancel, err
+}
+
+// ForwardOpenAIResponsesStream sends a streaming OpenAI Responses API request.
+// Note: Pass request context (c.Request.Context()) as baseCtx in NewForwardContext for client cancellation support.
+func ForwardOpenAIResponsesStream(fc *ForwardContext, wrapper *client.OpenAIClient, params responses.ResponseNewParams) (*openaistream.Stream[responses.ResponseStreamEventUnion], context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(params)
+	stream := wrapper.ResponsesNewStreaming(ctx, params)
+	return stream, cancel, nil
+}


### PR DESCRIPTION
## Summary

Part 1 of 5 — see #739 for full context.

- Extract protocol forwarding logic from `internal/server` into `internal/server/forwarding/` (separate files per provider: anthropic, openai, google)
- Add `ForwardContext` for per-request metadata propagation
- Add `record_roundtripper.go` for request recording support
- Minor Taskfile and .gitignore updates

## Depends on
None — safe to merge to main independently.

## Review chain
- **[1/5] This PR** — forwarding layer extraction
- [2/5] split/02-mcp-runtime — MCP runtime (advisor, virtual registry, session store)
- [3/5] split/03-generic-mcp-core — Generic MCP architecture (FormatAdapter, GenericLoopProcessor)
- [4/5] split/04-protocol-dispatch — Protocol dispatch wiring
- [5/5] split/05-frontend-misc — Frontend + config