### PR TITLE
migrate(cli): Migrate CLI to Kong and cleanup legacy code

### DIFF
--- a/cli/harness/commands_kong.go
+++ b/cli/harness/commands_kong.go
@@ -1,8 +1,11 @@
-//go:build kong
+//go:build !legacy
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // MatrixKong runs protocol validation matrix tests
 type MatrixKong struct {
@@ -10,7 +13,7 @@ type MatrixKong struct {
 	Sources    []string `kong:"flag,name='source',help='Source protocols'"`
 	Targets    []string `kong:"flag,name='target',help='Target protocols'"`
 	Streaming  bool     `kong:"flag,name='streaming',help='Run only streaming tests'"`
-	NonStream  bool     `kong:"flag,name='non-stream',help='Run only non-streaming tests'"`
+	NonStream  bool     `kong:"flag,name='non-streaming',help='Run only non-streaming tests'"`
 	JsonOutput bool     `kong:"flag,name='json',help='JSON output'"`
 	Verbose    []bool   `kong:"flag,name='verbose',short='v',help='Verbose level'"`
 	RecordDir  string   `kong:"flag,name='record-dir',help='Recording directory'"`
@@ -40,7 +43,7 @@ func buildArgsFromMatrix(m *MatrixKong) []string {
 		args = append(args, "--streaming")
 	}
 	if m.NonStream {
-		args = append(args, "--non-stream")
+		args = append(args, "--non-streaming")
 	}
 	if m.JsonOutput {
 		args = append(args, "--json")
@@ -62,10 +65,16 @@ func buildArgsFromMatrix(m *MatrixKong) []string {
 
 // AgentKong runs agent e2e tests
 type AgentKong struct {
-	Mock      bool   `kong:"flag,name='mock',help='Use virtual upstream provider'"`
-	Config    string `kong:"flag,name='config',help='Config file for real providers'"`
-	Timeout   int    `kong:"flag,name='timeout',short='t',help='Timeout in seconds'"`
-	AgentType string `kong:"arg,optional,help='Agent type (claude, codex, opencode, batch)'"`
+	Mock      bool          `kong:"flag,name='mock',help='Use virtual upstream provider'"`
+	Config    string        `kong:"flag,name='config',help='Config file for real providers'"`
+	Prompt    string        `kong:"flag,name='prompt',help='Prompt to send (overrides positional and default)'"`
+	Summary   string        `kong:"flag,name='summary',default='harness-summary.csv',help='Path to CSV summary file'"`
+	OutputDir string        `kong:"flag,name='output-dir',help='Directory for full output files (default: harness-output/)'"`
+	Resume    string        `kong:"flag,name='resume',help='Resume from previous run: skip recorded (agent,entry) pairs'"`
+	Filter    []string      `kong:"flag,name='filter',help='Only run entries whose name matches (real-provider mode)'"`
+	Timeout   time.Duration `kong:"flag,name='timeout',short='t',default='2m',help='Per-entry timeout (e.g. 30s, 2m). 0 disables.'"`
+	AgentType string        `kong:"arg,optional,help='Agent type (claude, codex, opencode, batch)'"`
+	Args      []string      `kong:"arg,optional,help='Optional prompt as positional args'"`
 }
 
 func (a *AgentKong) Run() error {
@@ -74,15 +83,29 @@ func (a *AgentKong) Run() error {
 	if a.AgentType != "" {
 		args = append(args, a.AgentType)
 	}
+	args = append(args, a.Args...)
 	if a.Mock {
 		args = append(args, "--mock")
 	}
 	if a.Config != "" {
 		args = append(args, "--config", a.Config)
 	}
-	if a.Timeout > 0 {
-		args = append(args, "--timeout", fmt.Sprintf("%d", a.Timeout))
+	if a.Prompt != "" {
+		args = append(args, "--prompt", a.Prompt)
 	}
+	if a.Summary != "" {
+		args = append(args, "--summary", a.Summary)
+	}
+	if a.OutputDir != "" {
+		args = append(args, "--output-dir", a.OutputDir)
+	}
+	if a.Resume != "" {
+		args = append(args, "--resume", a.Resume)
+	}
+	for _, f := range a.Filter {
+		args = append(args, "--filter", f)
+	}
+	args = append(args, "--timeout", a.Timeout.String())
 	cmd.SetArgs(args)
 	return cmd.Execute()
 }
@@ -94,7 +117,7 @@ type ProviderKong struct {
 }
 
 func (p *ProviderKong) Run() error {
-	return p.List.Run()
+	return fmt.Errorf("provider tests not yet implemented - see Phase 3 in specification")
 }
 
 // ProviderTestKong runs provider tests

--- a/cli/harness/main.go
+++ b/cli/harness/main.go
@@ -1,4 +1,4 @@
-//go:build !kong
+//go:build legacy
 
 // Package main provides the CLI harness for protocol validation testing.
 //

--- a/cli/harness/main_kong.go
+++ b/cli/harness/main_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package main
 

--- a/cli/harness/main_kong_test.go
+++ b/cli/harness/main_kong_test.go
@@ -1,0 +1,180 @@
+//go:build !legacy
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+)
+
+func newTestParser(t *testing.T) (*CLI, *kong.Kong) {
+	t.Helper()
+	var cli CLI
+	parser, err := kong.New(&cli, kong.Vars{
+		"version":   "test",
+		"gitCommit": "abcdef",
+		"buildTime": "2026-01-01",
+	}, kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatalf("kong.New failed: %v", err)
+	}
+	return &cli, parser
+}
+
+func TestKongCLIDefinitionParses(t *testing.T) {
+	newTestParser(t)
+}
+
+func TestKongAllTopLevelSubcommandsRecognized(t *testing.T) {
+	// For each top-level subcommand, parse with arguments that should succeed
+	// without invoking the handler. We use --help where the command has no
+	// required subcommand; for those that do, we descend to a child.
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"version", []string{"version"}},
+		{"matrix-help", []string{"matrix", "--help"}},
+		{"agent-help", []string{"agent", "--help"}},
+		{"provider-list", []string{"provider", "list"}},
+		{"provider-test", []string{"provider", "test"}},
+		{"init-config-help", []string{"init-config", "--help"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, parser := newTestParser(t)
+			if _, err := parser.Parse(tc.args); err != nil && !isHelpErr(err) {
+				t.Fatalf("args %v failed to parse: %v", tc.args, err)
+			}
+		})
+	}
+}
+
+func TestAgentKongParsesAllFlags(t *testing.T) {
+	cli, parser := newTestParser(t)
+	_, err := parser.Parse([]string{
+		"agent", "claude",
+		"--mock",
+		"--timeout", "30s",
+		"--prompt", "hello",
+		"--summary", "x.csv",
+		"--output-dir", "out",
+		"--resume", "key",
+		"--filter", "a",
+		"--filter", "b",
+	})
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if cli.Agent.AgentType != "claude" {
+		t.Errorf("AgentType: got %q", cli.Agent.AgentType)
+	}
+	if !cli.Agent.Mock {
+		t.Error("Mock not set")
+	}
+	if cli.Agent.Timeout != 30*time.Second {
+		t.Errorf("Timeout: want 30s, got %v", cli.Agent.Timeout)
+	}
+	if cli.Agent.Prompt != "hello" {
+		t.Errorf("Prompt: got %q", cli.Agent.Prompt)
+	}
+	if cli.Agent.Summary != "x.csv" {
+		t.Errorf("Summary: got %q", cli.Agent.Summary)
+	}
+	if cli.Agent.OutputDir != "out" {
+		t.Errorf("OutputDir: got %q", cli.Agent.OutputDir)
+	}
+	if cli.Agent.Resume != "key" {
+		t.Errorf("Resume: got %q", cli.Agent.Resume)
+	}
+	if len(cli.Agent.Filter) != 2 || cli.Agent.Filter[0] != "a" || cli.Agent.Filter[1] != "b" {
+		t.Errorf("Filter: got %v", cli.Agent.Filter)
+	}
+}
+
+func TestAgentKongTimeoutDefaultIs2m(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"agent", "--mock", "claude"}); err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if cli.Agent.Timeout != 2*time.Minute {
+		t.Errorf("default Timeout: want 2m, got %v", cli.Agent.Timeout)
+	}
+}
+
+func TestMatrixKongNonStreamingFlag(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"matrix", "--non-streaming"}); err != nil {
+		t.Fatalf("--non-streaming should parse: %v", err)
+	}
+	if !cli.Matrix.NonStream {
+		t.Error("Matrix.NonStream should be true")
+	}
+}
+
+func TestProviderKongDefaultReturnsNotImplemented(t *testing.T) {
+	var p ProviderKong
+	err := p.Run()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Errorf("expected not-implemented error, got: %v", err)
+	}
+}
+
+func TestVersionKongPrintsAllFields(t *testing.T) {
+	version = "test-version"
+	gitCommit = "test-commit"
+	buildTime = "test-time"
+
+	out := captureStdout(t, func() {
+		v := &VersionKong{}
+		if err := v.Run(); err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"Tingly-Box Protocol Validation Harness",
+		"Version:   test-version",
+		"Commit:    test-commit",
+		"Built:     test-time",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func isHelpErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "help") || strings.Contains(msg, "usage")
+}

--- a/cli/tingly-box/cli.go
+++ b/cli/tingly-box/cli.go
@@ -1,4 +1,4 @@
-//go:build !kong
+//go:build legacy
 
 package main
 

--- a/cli/tingly-box/main_kong.go
+++ b/cli/tingly-box/main_kong.go
@@ -1,7 +1,6 @@
-//go:build kong
+//go:build !legacy
 
-// Kong version of main - for testing migration
-// Build with: go build -tags kong ./cli/tingly-box
+// Default Kong-based CLI. Build the legacy Cobra CLI with: go build -tags legacy ./cli/tingly-box
 
 package main
 
@@ -44,7 +43,7 @@ type CLI struct {
 	Agent command.AgentCmdKong `kong:"cmd,help='Agent configuration'"`
 
 	// OAuth
-	OAuth command.OAuthCmdKong `kong:"cmd,help='OAuth authentication'"`
+	OAuth command.OAuthCmdKong `kong:"cmd,name='oauth',help='OAuth authentication'"`
 
 	// Import/Export
 	Export command.ExportCmdKong `kong:"cmd,help='Export configuration'"`
@@ -58,13 +57,19 @@ type CLI struct {
 	Quota      command.QuotaCmdKong      `kong:"cmd,help='Quota information'"`
 	Remote     command.RemoteCmdKong     `kong:"cmd,help='Remote control'"`
 	Quickstart command.QuickstartCmdKong `kong:"cmd,help='Guided setup'"`
-	MCP        command.MCPCmdKong        `kong:"cmd,help='MCP builtin server'"`
+	MCPBuiltin command.MCPBuiltinCmdKong `kong:"cmd,name='mcp-builtin',hidden,help='Start the builtin MCP server (internal use)'"`
 
 	// Version
 	Version command.VersionCmdKong `kong:"cmd,help='Show version'"`
 }
 
 func main() {
+	command.BuildVersion = version
+	command.BuildGitCommit = gitCommit
+	command.BuildBuildTime = buildTime
+	command.BuildGoVersion = goVersion
+	command.BuildPlatform = platform
+
 	var cli CLI
 
 	// Parse CLI

--- a/cli/tingly-box/main_kong_test.go
+++ b/cli/tingly-box/main_kong_test.go
@@ -113,6 +113,125 @@ func TestProviderHasAllSubcommands(t *testing.T) {
 	}
 }
 
+// TestExportCmdParsesAndForwardsFlags ensures `export` actually accepts its
+// flags and the Kong handler can read them. The previous implementation
+// errored with "no such flag -request-model" because the mock cobra cmd had
+// no flags registered.
+func TestExportCmdParsesAndForwardsFlags(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{
+		"export",
+		"--request-model", "gpt-4",
+		"--scenario", "general",
+		"--format", "base64",
+		"--output", "out.txt",
+	}); err != nil {
+		t.Fatalf("export flags should parse: %v", err)
+	}
+	if cli.Export.RequestModel != "gpt-4" {
+		t.Errorf("RequestModel: %q", cli.Export.RequestModel)
+	}
+	if cli.Export.Scenario != "general" {
+		t.Errorf("Scenario: %q", cli.Export.Scenario)
+	}
+	if cli.Export.Format != "base64" {
+		t.Errorf("Format: %q", cli.Export.Format)
+	}
+	if cli.Export.Output != "out.txt" {
+		t.Errorf("Output: %q", cli.Export.Output)
+	}
+}
+
+// TestStartCmdDebugFlagSet ensures --debug sets EnableDebug. The earlier
+// implementation parsed --debug into EnableDebug, but the unregistered mock
+// cobra command silently dropped it before ResolveStartOptions could see
+// Changed("debug")=true, so config.GetDebug() always won.
+func TestStartCmdDebugFlagSet(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"start", "--debug"}); err != nil {
+		t.Fatalf("start --debug should parse: %v", err)
+	}
+	if !cli.Start.EnableDebug {
+		t.Error("Start.EnableDebug should be true after --debug")
+	}
+}
+
+// TestImportFromStdinWhenNoFile ensures `import` with no positional gets an
+// empty args slice, so runImport reads from stdin instead of trying to open
+// a file named "".
+func TestImportFromStdinWhenNoFile(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"import"}); err != nil {
+		t.Fatalf("import (no file) should parse: %v", err)
+	}
+	if cli.Import.File != "" {
+		t.Errorf("File should be empty, got %q", cli.Import.File)
+	}
+}
+
+// TestQuickstartUseTUIDefault ensures --tui defaults to true (legacy parity:
+// without the flag the TUI wizard runs, not the plain quickstart).
+func TestQuickstartUseTUIDefault(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"quickstart"}); err != nil {
+		t.Fatalf("quickstart should parse: %v", err)
+	}
+	if !cli.Quickstart.UseTUI {
+		t.Error("Quickstart.UseTUI should default to true")
+	}
+}
+
+// TestRemoteAddSubcommandExists ensures `remote add` is reachable (legacy has
+// it, but the original Kong version was missing it entirely).
+func TestRemoteAddSubcommandExists(t *testing.T) {
+	_, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"remote", "add", "--help"}); err != nil && !isHelpErr(err) {
+		t.Fatalf("remote add should parse: %v", err)
+	}
+}
+
+// TestRemoteStartFlagsParse ensures the start subcommand exposes the
+// --data-path/--provider/--model/--force flags that legacy supports.
+func TestRemoteStartFlagsParse(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{
+		"remote", "start", "abc",
+		"--data-path", "/tmp/d",
+		"--provider", "p",
+		"--model", "m",
+		"--force",
+	}); err != nil {
+		t.Fatalf("remote start with all flags should parse: %v", err)
+	}
+	if cli.Remote.Start.UUID != "abc" {
+		t.Errorf("UUID: %q", cli.Remote.Start.UUID)
+	}
+	if cli.Remote.Start.DataPath != "/tmp/d" {
+		t.Errorf("DataPath: %q", cli.Remote.Start.DataPath)
+	}
+	if cli.Remote.Start.Provider != "p" {
+		t.Errorf("Provider: %q", cli.Remote.Start.Provider)
+	}
+	if cli.Remote.Start.Model != "m" {
+		t.Errorf("Model: %q", cli.Remote.Start.Model)
+	}
+	if !cli.Remote.Start.Force {
+		t.Error("Force should be true")
+	}
+}
+
+// TestAgentApplyUnifiedDefaultIsTrue ensures the legacy default (--unified=true)
+// is preserved in Kong.
+func TestAgentApplyUnifiedDefaultIsTrue(t *testing.T) {
+	cli, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"agent", "apply", "claude-code"}); err != nil {
+		t.Fatalf("agent apply should parse: %v", err)
+	}
+	if !cli.Agent.Apply.Unified {
+		t.Error("Apply.Unified should default to true")
+	}
+}
+
 // TestParentCommandDefaultsParse ensures `provider` and `quota` parse with no
 // subcommand (their hidden default subcommands take over).
 func TestParentCommandDefaultsParse(t *testing.T) {

--- a/cli/tingly-box/main_kong_test.go
+++ b/cli/tingly-box/main_kong_test.go
@@ -1,0 +1,181 @@
+//go:build !legacy
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/tingly-dev/tingly-box/internal/command"
+)
+
+func newTestParser(t *testing.T) (*CLI, *kong.Kong) {
+	t.Helper()
+	var cli CLI
+	parser, err := kong.New(&cli, kong.Vars{
+		"version":   "test",
+		"gitCommit": "abcdef",
+		"buildTime": "2026-01-01",
+		"goVersion": "go1.25",
+		"platform":  "linux/amd64",
+	}, kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatalf("kong.New failed: %v", err)
+	}
+	return &cli, parser
+}
+
+func TestKongCLIDefinitionParses(t *testing.T) {
+	newTestParser(t)
+}
+
+func TestKongAllTopLevelSubcommandsRecognized(t *testing.T) {
+	// Each top-level command is exercised with arguments that fully resolve
+	// the command tree without invoking any handler. Commands that have
+	// required subcommands are descended; commands with required flags get
+	// --help.
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"start", []string{"start", "--help"}},
+		{"stop", []string{"stop", "--help"}},
+		{"status", []string{"status", "--help"}},
+		{"restart", []string{"restart", "--help"}},
+		{"open", []string{"open", "--help"}},
+		{"provider-add", []string{"provider", "add", "--help"}},
+		{"provider-list", []string{"provider", "list", "--help"}},
+		{"provider-delete", []string{"provider", "delete", "--help"}},
+		{"provider-update", []string{"provider", "update", "--help"}},
+		{"provider-get", []string{"provider", "get", "--help"}},
+		{"agent-apply", []string{"agent", "apply", "--help"}},
+		{"agent-list", []string{"agent", "list", "--help"}},
+		{"agent-show", []string{"agent", "show", "--help"}},
+		{"oauth", []string{"oauth", "--help"}},
+		{"export", []string{"export", "--request-model", "x", "--scenario", "y", "--help"}},
+		{"import", []string{"import", "--help"}},
+		{"cc", []string{"cc", "--help"}},
+		{"swagger", []string{"swagger", "--help"}},
+		{"quota-list", []string{"quota", "list", "--help"}},
+		{"quota-get", []string{"quota", "get", "--help"}},
+		{"quota-refresh", []string{"quota", "refresh", "--help"}},
+		{"quota-summary", []string{"quota", "summary", "--help"}},
+		{"remote-list", []string{"remote", "list", "--help"}},
+		{"remote-start", []string{"remote", "start", "--help"}},
+		{"remote-config", []string{"remote", "config", "--help"}},
+		{"quickstart", []string{"quickstart", "--help"}},
+		{"mcp-builtin", []string{"mcp-builtin", "--help"}},
+		{"version", []string{"version", "--help"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, parser := newTestParser(t)
+			if _, err := parser.Parse(tc.args); err != nil && !isHelpErr(err) {
+				t.Fatalf("args %v failed to parse: %v", tc.args, err)
+			}
+		})
+	}
+}
+
+// TestOAuthCommandRoutesByName ensures `oauth` is reachable rather than being
+// auto-kebab-cased to `o-auth`.
+func TestOAuthCommandRoutesByName(t *testing.T) {
+	_, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"oauth", "--help"}); err != nil && !isHelpErr(err) {
+		t.Fatalf("oauth should parse: %v", err)
+	}
+}
+
+// TestMCPBuiltinTopLevel ensures the legacy `mcp-builtin` command path is preserved.
+// internal/mcp/runtime/builtin_registry.go invokes the binary with this exact arg.
+func TestMCPBuiltinTopLevel(t *testing.T) {
+	_, parser := newTestParser(t)
+	if _, err := parser.Parse([]string{"mcp-builtin", "--help"}); err != nil && !isHelpErr(err) {
+		t.Fatalf("mcp-builtin should parse: %v", err)
+	}
+}
+
+// TestProviderHasAllSubcommands ensures provider exposes add/list/delete/update/get
+// (legacy parity).
+func TestProviderHasAllSubcommands(t *testing.T) {
+	for _, sub := range []string{"add", "list", "delete", "update", "get"} {
+		t.Run(sub, func(t *testing.T) {
+			_, parser := newTestParser(t)
+			if _, err := parser.Parse([]string{"provider", sub, "--help"}); err != nil && !isHelpErr(err) {
+				t.Fatalf("provider %s should parse: %v", sub, err)
+			}
+		})
+	}
+}
+
+// TestParentCommandDefaultsParse ensures `provider` and `quota` parse with no
+// subcommand (their hidden default subcommands take over).
+func TestParentCommandDefaultsParse(t *testing.T) {
+	for _, name := range []string{"provider", "quota"} {
+		t.Run(name, func(t *testing.T) {
+			_, parser := newTestParser(t)
+			if _, err := parser.Parse([]string{name}); err != nil {
+				t.Fatalf("%s with no subcommand should parse: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestVersionCmdPrintsAllFields(t *testing.T) {
+	command.BuildVersion = "test-version"
+	command.BuildGitCommit = "test-commit"
+	command.BuildBuildTime = "test-time"
+	command.BuildGoVersion = "test-go"
+	command.BuildPlatform = "test-platform"
+
+	out := captureStdout(t, func() {
+		cmd := &command.VersionCmdKong{}
+		if err := cmd.Run(nil); err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"Tingly Box CLI",
+		"Version:    test-version",
+		"Git Commit: test-commit",
+		"Build Time: test-time",
+		"Go Version: test-go",
+		"Platform:   test-platform",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func isHelpErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "help") || strings.Contains(msg, "usage")
+}

--- a/internal/command/agent_kong.go
+++ b/internal/command/agent_kong.go
@@ -40,8 +40,12 @@ func (a *AgentApplyCmdKong) Run(appManager *AppManager) error {
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
+	// Always forward unified explicitly: legacy default is true, so a Kong
+	// user passing --unified=false would otherwise be silently dropped.
 	if a.Unified {
 		args = append(args, "--unified=true")
+	} else {
+		args = append(args, "--unified=false")
 	}
 	if a.Force {
 		args = append(args, "--force")

--- a/internal/command/agent_kong.go
+++ b/internal/command/agent_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/cc_kong.go
+++ b/internal/command/cc_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/export.go
+++ b/internal/command/export.go
@@ -31,7 +31,11 @@ Examples:
   # Export to clipboard-friendly Base64 format
   tingly-box export --request-model gpt-4 --scenario general --format base64`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runExport(appManager, cmd)
+			formatStr, _ := cmd.Flags().GetString("format")
+			outputFile, _ := cmd.Flags().GetString("output")
+			requestModel, _ := cmd.Flags().GetString("request-model")
+			scenarioStr, _ := cmd.Flags().GetString("scenario")
+			return runExport(appManager, requestModel, scenarioStr, formatStr, outputFile)
 		},
 	}
 
@@ -46,14 +50,7 @@ Examples:
 	return cmd
 }
 
-func runExport(appManager *AppManager, cmd *cobra.Command) error {
-	// Get flags
-	formatStr, _ := cmd.Flags().GetString("format")
-	outputFile, _ := cmd.Flags().GetString("output")
-	requestModel, _ := cmd.Flags().GetString("request-model")
-	scenarioStr, _ := cmd.Flags().GetString("scenario")
-
-	// Parse format
+func runExport(appManager *AppManager, requestModel, scenarioStr, formatStr, outputFile string) error {
 	var format dataio.Format
 	switch strings.ToLower(formatStr) {
 	case "jsonl":

--- a/internal/command/export_kong.go
+++ b/internal/command/export_kong.go
@@ -2,10 +2,6 @@
 
 package command
 
-import (
-	"github.com/spf13/cobra"
-)
-
 // ExportCmdKong exports routing rules
 type ExportCmdKong struct {
 	RequestModel string `kong:"flag,name='request-model',required,help='Request model name'"`
@@ -15,21 +11,5 @@ type ExportCmdKong struct {
 }
 
 func (e *ExportCmdKong) Run(appManager *AppManager) error {
-	// Create a mock cobra command for the existing runExport function
-	mockCmd := &cobra.Command{}
-	if err := mockCmd.Flags().Set("request-model", e.RequestModel); err != nil {
-		return err
-	}
-	if err := mockCmd.Flags().Set("scenario", e.Scenario); err != nil {
-		return err
-	}
-	if err := mockCmd.Flags().Set("format", e.Format); err != nil {
-		return err
-	}
-	if e.Output != "" {
-		if err := mockCmd.Flags().Set("output", e.Output); err != nil {
-			return err
-		}
-	}
-	return runExport(appManager, mockCmd)
+	return runExport(appManager, e.RequestModel, e.Scenario, e.Format, e.Output)
 }

--- a/internal/command/export_kong.go
+++ b/internal/command/export_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/import_kong.go
+++ b/internal/command/import_kong.go
@@ -9,5 +9,9 @@ type ImportCmdKong struct {
 }
 
 func (i *ImportCmdKong) Run(appManager *AppManager) error {
-	return runImport(appManager, i.Format, []string{i.File})
+	var args []string
+	if i.File != "" {
+		args = []string{i.File}
+	}
+	return runImport(appManager, i.Format, args)
 }

--- a/internal/command/import_kong.go
+++ b/internal/command/import_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/mcp_kong.go
+++ b/internal/command/mcp_kong.go
@@ -1,13 +1,10 @@
-//go:build kong
+//go:build !legacy
 
 package command
 
-// MCPCmdKong manages MCP builtin server
-type MCPCmdKong struct {
-	Builtin MCPBuiltinCmdKong `kong:"cmd,help='MCP builtin server'"`
-}
-
-// MCPBuiltinCmdKong runs MCP builtin server
+// MCPBuiltinCmdKong starts the builtin MCP server. Registered at the top level
+// as "mcp-builtin" to match the legacy command path, which is consumed by
+// internal/mcp/runtime/builtin_registry.go.
 type MCPBuiltinCmdKong struct{}
 
 func (m *MCPBuiltinCmdKong) Run(appManager *AppManager) error {

--- a/internal/command/oauth_kong.go
+++ b/internal/command/oauth_kong.go
@@ -14,5 +14,9 @@ type OAuthCmdKong struct {
 }
 
 func (o *OAuthCmdKong) Run(appManager *AppManager) error {
-	return runOAuthFlow(appManager.AppConfig(), o.Provider, o.Name, o.Port, o.ProxyURL)
+	appConfig := appManager.AppConfig()
+	if o.Provider == "" {
+		return runInteractiveMode(appConfig, o.Name, o.Port, o.ProxyURL)
+	}
+	return runOAuthFlow(appConfig, o.Provider, o.Name, o.Port, o.ProxyURL)
 }

--- a/internal/command/oauth_kong.go
+++ b/internal/command/oauth_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/open_kong.go
+++ b/internal/command/open_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/provider_kong.go
+++ b/internal/command/provider_kong.go
@@ -1,14 +1,28 @@
-//go:build kong
+//go:build !legacy
 
 package command
 
-// ProviderCmdKong is the Kong version of provider command
+import (
+	"bufio"
+	"os"
+)
+
+// ProviderCmdKong is the Kong version of provider command. The hidden
+// Interactive subcommand is marked default so `tingly-box provider` (no
+// further args) drops into interactive management, matching legacy behavior.
 type ProviderCmdKong struct {
-	Add  ProviderAddCmdKong  `kong:"cmd,help='Add a new provider'"`
-	List ProviderListCmdKong `kong:"cmd,help='List all providers'"`
+	Interactive ProviderInteractiveCmdKong `kong:"cmd,name='interactive',default='1',hidden,help='Interactive provider management'"`
+	Add         ProviderAddCmdKong         `kong:"cmd,help='Add a new provider'"`
+	List        ProviderListCmdKong        `kong:"cmd,help='List all providers'"`
+	Delete      ProviderDeleteCmdKong      `kong:"cmd,help='Delete a provider (interactive)'"`
+	Update      ProviderUpdateCmdKong      `kong:"cmd,help='Update a provider (interactive)'"`
+	Get         ProviderGetCmdKong         `kong:"cmd,help='Get provider details by name'"`
 }
 
-func (p *ProviderCmdKong) Run(appManager *AppManager) error {
+// ProviderInteractiveCmdKong runs the interactive provider menu.
+type ProviderInteractiveCmdKong struct{}
+
+func (p *ProviderInteractiveCmdKong) Run(appManager *AppManager) error {
 	return runProviderInteractiveMode(appManager)
 }
 
@@ -42,4 +56,31 @@ type ProviderListCmdKong struct{}
 
 func (p *ProviderListCmdKong) Run(appManager *AppManager) error {
 	return runProviderList(appManager)
+}
+
+// ProviderDeleteCmdKong deletes a provider in interactive mode.
+type ProviderDeleteCmdKong struct{}
+
+func (p *ProviderDeleteCmdKong) Run(appManager *AppManager) error {
+	return runProviderDeleteInteractive(appManager, bufio.NewReader(os.Stdin))
+}
+
+// ProviderUpdateCmdKong updates a provider in interactive mode.
+type ProviderUpdateCmdKong struct{}
+
+func (p *ProviderUpdateCmdKong) Run(appManager *AppManager) error {
+	return runProviderUpdateInteractive(appManager, bufio.NewReader(os.Stdin))
+}
+
+// ProviderGetCmdKong displays a provider's details. Without a name it drops
+// into interactive selection.
+type ProviderGetCmdKong struct {
+	Name string `kong:"arg,optional,help='Provider name'"`
+}
+
+func (p *ProviderGetCmdKong) Run(appManager *AppManager) error {
+	if p.Name == "" {
+		return runProviderGetInteractive(appManager, bufio.NewReader(os.Stdin))
+	}
+	return runProviderGet(appManager, p.Name)
 }

--- a/internal/command/quickstart_kong.go
+++ b/internal/command/quickstart_kong.go
@@ -2,11 +2,18 @@
 
 package command
 
+import (
+	"github.com/tingly-dev/tingly-box/internal/tui/wizards"
+)
+
 // QuickstartCmdKong runs the guided setup wizard
 type QuickstartCmdKong struct {
 	UseTUI bool `kong:"flag,name='tui',short='t',default='true',help='Use interactive TUI mode'"`
 }
 
 func (q *QuickstartCmdKong) Run(appManager *AppManager) error {
+	if q.UseTUI {
+		return wizards.RunQuickstartWizard(appManager)
+	}
 	return runQuickstart(appManager)
 }

--- a/internal/command/quickstart_kong.go
+++ b/internal/command/quickstart_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/quota_kong.go
+++ b/internal/command/quota_kong.go
@@ -1,16 +1,22 @@
-//go:build kong
+//go:build !legacy
 
 package command
 
-// QuotaCmdKong is the Kong version of quota command
+// QuotaCmdKong is the Kong version of quota command. The hidden Default
+// subcommand is marked default so `tingly-box quota` (no further args)
+// behaves like `quota list`, matching legacy behavior.
 type QuotaCmdKong struct {
+	Default QuotaDefaultCmdKong `kong:"cmd,name='default',default='1',hidden,help='List all provider quotas (default)'"`
 	List    QuotaListCmdKong    `kong:"cmd,help='List all provider quotas'"`
 	Get     QuotaGetCmdKong     `kong:"cmd,help='Get provider quota details'"`
 	Refresh QuotaRefreshCmdKong `kong:"cmd,help='Refresh provider quota data'"`
 	Summary QuotaSummaryCmdKong `kong:"cmd,help='Show quota summary'"`
 }
 
-func (q *QuotaCmdKong) Run(appManager *AppManager) error {
+// QuotaDefaultCmdKong is the no-subcommand default that runs the list view.
+type QuotaDefaultCmdKong struct{}
+
+func (q *QuotaDefaultCmdKong) Run(appManager *AppManager) error {
 	return runQuotaList(appManager)
 }
 

--- a/internal/command/remote_kong.go
+++ b/internal/command/remote_kong.go
@@ -2,17 +2,15 @@
 
 package command
 
-// RemoteCmdKong manages remote control
+// RemoteCmdKong manages remote control. The hidden Default subcommand is
+// marked default so `tingly-box remote` (no further args) lists sessions,
+// matching the legacy behavior of showing help/list.
 type RemoteCmdKong struct {
-	List   RemoteListCmdKong   `kong:"cmd,help='List remote sessions'"`
-	Start  RemoteStartCmdKong  `kong:"cmd,help='Start a remote session'"`
-	Config RemoteConfigCmdKong `kong:"cmd,help='Configure remote settings'"`
-}
-
-func (r *RemoteCmdKong) Run(appManager *AppManager) error {
-	cmd := RemoteCommand(appManager)
-	cmd.SetArgs([]string{"list"})
-	return cmd.Execute()
+	Default RemoteListCmdKong   `kong:"cmd,name='default',default='1',hidden,help='List remote sessions (default)'"`
+	List    RemoteListCmdKong   `kong:"cmd,help='List remote sessions'"`
+	Start   RemoteStartCmdKong  `kong:"cmd,help='Start a remote session'"`
+	Config  RemoteConfigCmdKong `kong:"cmd,help='Configure remote settings'"`
+	Add     RemoteAddCmdKong    `kong:"cmd,help='Add a new bot configuration'"`
 }
 
 // RemoteListCmdKong lists remote sessions
@@ -26,24 +24,67 @@ func (r *RemoteListCmdKong) Run(appManager *AppManager) error {
 
 // RemoteStartCmdKong starts a remote session
 type RemoteStartCmdKong struct {
-	Name string `kong:"arg,optional,help='Session name'"`
+	UUID     string `kong:"arg,optional,help='Bot UUID (interactive selection if omitted)'"`
+	DataPath string `kong:"flag,name='data-path',help='Data directory for bot state'"`
+	Provider string `kong:"flag,name='provider',help='Provider UUID for smartguide'"`
+	Model    string `kong:"flag,name='model',help='Model name for smartguide'"`
+	Force    bool   `kong:"flag,name='force',help='Skip provider validation and force start'"`
 }
 
 func (r *RemoteStartCmdKong) Run(appManager *AppManager) error {
 	cmd := RemoteCommand(appManager)
 	args := []string{"start"}
-	if r.Name != "" {
-		args = append(args, r.Name)
+	if r.UUID != "" {
+		args = append(args, r.UUID)
+	}
+	if r.DataPath != "" {
+		args = append(args, "--data-path", r.DataPath)
+	}
+	if r.Provider != "" {
+		args = append(args, "--provider", r.Provider)
+	}
+	if r.Model != "" {
+		args = append(args, "--model", r.Model)
+	}
+	if r.Force {
+		args = append(args, "--force")
 	}
 	cmd.SetArgs(args)
 	return cmd.Execute()
 }
 
 // RemoteConfigCmdKong configures remote settings
-type RemoteConfigCmdKong struct{}
+type RemoteConfigCmdKong struct {
+	UUID     string `kong:"arg,optional,help='Bot UUID (interactive selection if omitted)'"`
+	Show     bool   `kong:"flag,name='show',help='Show current configuration'"`
+	Provider string `kong:"flag,name='provider',help='Provider UUID for smartguide'"`
+	Model    string `kong:"flag,name='model',help='Model name for smartguide'"`
+}
 
 func (r *RemoteConfigCmdKong) Run(appManager *AppManager) error {
 	cmd := RemoteCommand(appManager)
-	cmd.SetArgs([]string{"config"})
+	args := []string{"config"}
+	if r.UUID != "" {
+		args = append(args, r.UUID)
+	}
+	if r.Show {
+		args = append(args, "--show")
+	}
+	if r.Provider != "" {
+		args = append(args, "--provider", r.Provider)
+	}
+	if r.Model != "" {
+		args = append(args, "--model", r.Model)
+	}
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// RemoteAddCmdKong adds a new bot configuration (interactive).
+type RemoteAddCmdKong struct{}
+
+func (r *RemoteAddCmdKong) Run(appManager *AppManager) error {
+	cmd := RemoteCommand(appManager)
+	cmd.SetArgs([]string{"add"})
 	return cmd.Execute()
 }

--- a/internal/command/remote_kong.go
+++ b/internal/command/remote_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 

--- a/internal/command/server_kong.go
+++ b/internal/command/server_kong.go
@@ -41,14 +41,7 @@ func (s *StartCmdKong) Run(appManager *AppManager) error {
 		RecordDir:            s.RecordDir,
 		Expr:                 s.Expr,
 	}
-	mockCmd := &cobra.Command{}
-	if s.EnableDebug {
-		mockCmd.Flags().Set("debug", "true")
-	}
-	if s.Port != 0 {
-		mockCmd.Flags().Set("port", fmt.Sprintf("%d", s.Port))
-	}
-	opts := options.ResolveStartOptions(mockCmd, flags, appManager.AppConfig())
+	opts := options.ResolveStartOptions(newKongShimCmd(s.EnableDebug), flags, appManager.AppConfig())
 	return startServer(appManager, opts)
 }
 
@@ -100,15 +93,22 @@ func (r *RestartCmdKong) Run(appManager *AppManager) error {
 		RecordDir:            r.RecordDir,
 		Expr:                 r.Expr,
 	}
-	mockCmd := &cobra.Command{}
-	if r.EnableDebug {
-		mockCmd.Flags().Set("debug", "true")
-	}
-	if r.Port != 0 {
-		mockCmd.Flags().Set("port", fmt.Sprintf("%d", r.Port))
-	}
-	opts := options.ResolveStartOptions(mockCmd, flags, appManager.AppConfig())
+	opts := options.ResolveStartOptions(newKongShimCmd(r.EnableDebug), flags, appManager.AppConfig())
 	return startServer(appManager, opts)
+}
+
+// newKongShimCmd builds a cobra.Command whose only purpose is to satisfy
+// options.ResolveStartOptions, which probes cmd.Flags().Changed("debug") to
+// give an explicit --debug priority over the config file value. Kong has
+// already done flag parsing; we register --debug here and Set it iff the
+// caller passed it, so Changed() returns the right answer.
+func newKongShimCmd(debugSet bool) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("debug", false, "")
+	if debugSet {
+		_ = cmd.Flags().Set("debug", "true")
+	}
+	return cmd
 }
 
 // Build information set by cli/tingly-box/main_kong.go at startup.

--- a/internal/command/server_kong.go
+++ b/internal/command/server_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 
@@ -111,13 +111,25 @@ func (r *RestartCmdKong) Run(appManager *AppManager) error {
 	return startServer(appManager, opts)
 }
 
+// Build information set by cli/tingly-box/main_kong.go at startup.
+var (
+	BuildVersion   = "dev"
+	BuildGitCommit = "unknown"
+	BuildBuildTime = "unknown"
+	BuildGoVersion = "unknown"
+	BuildPlatform  = "unknown"
+)
+
 // VersionCmdKong is the Kong version of version command
 type VersionCmdKong struct{}
 
 func (v *VersionCmdKong) Run(appManager *AppManager) error {
-	appConfig := appManager.AppConfig()
 	fmt.Printf("Tingly Box CLI\n")
-	fmt.Printf("Version:    %s\n", appConfig.GetVersion())
+	fmt.Printf("Version:    %s\n", BuildVersion)
+	fmt.Printf("Git Commit: %s\n", BuildGitCommit)
+	fmt.Printf("Build Time: %s\n", BuildBuildTime)
+	fmt.Printf("Go Version: %s\n", BuildGoVersion)
+	fmt.Printf("Platform:   %s\n", BuildPlatform)
 	return nil
 }
 

--- a/internal/command/swagger_kong.go
+++ b/internal/command/swagger_kong.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/tingly-dev/tingly-box/internal/server"
 )
 
@@ -17,14 +16,6 @@ type SwaggerCmdKong struct {
 }
 
 func (s *SwaggerCmdKong) Run(appManager *AppManager) error {
-	mockCmd := &cobra.Command{}
-	if s.Output != "" {
-		mockCmd.Flags().Set("output", s.Output)
-	}
-	if s.Stdout {
-		mockCmd.Flags().Set("stdout", "true")
-	}
-	// For now, just call the existing command's RunE logic
 	return runSwagger(appManager, s.Output, s.Stdout)
 }
 

--- a/internal/command/swagger_kong.go
+++ b/internal/command/swagger_kong.go
@@ -1,4 +1,4 @@
-//go:build kong
+//go:build !legacy
 
 package command
 


### PR DESCRIPTION
The Kong-based CLI was wired up but never built (no `-tags kong` in any Taskfile, Dockerfile, or CI workflow). 
This flips the build tags so Kong becomes the default and the legacy Cobra entry points are reachable only with `-tags legacy`. While doing so, fixes seven parity gaps that would have broken users on the Kong path.

## Build-tag flip

- `//go:build kong` → `//go:build !legacy` on all Kong files (cli/{tingly-box,harness}/main_kong.go, cli/harness/commands_kong.go, internal/command/*_kong.go).
- `//go:build !kong` → `//go:build legacy` on legacy entry points (cli/tingly-box/cli.go, cli/harness/main.go).
- Mutual `legacy` / `!legacy` exclusion preserves the duplicated package-level symbols (main, version, gitCommit, ...) in both trees.

## Kong parity fixes

- `tingly-box version`: now prints Version, Git Commit, Build Time, Go Version, Platform (was only printing Version).
- `harness agent`: added missing flags --prompt, --summary, --output-dir, --resume, --filter; --timeout is now `time.Duration` with a 2m default (was `int` forwarded as nanoseconds, breaking real durations).
- `harness matrix`: --non-stream renamed to --non-streaming so the delegated Cobra command actually receives the flag it defines.
- `harness provider`: parent without subcommand now returns the legacy "not yet implemented - Phase 3" message instead of falling through to list (which itself errored with a misleading message).
- `tingly-box oauth`: added explicit name='oauth' so Kong's auto kebab-case doesn't rewrite it to o-auth (which broke the command).
- `tingly-box mcp-builtin`: restored as a top-level hidden command. internal/mcp/runtime/builtin_registry.go invokes the binary with the literal "mcp-builtin" argument; Kong was exposing it as `mcp builtin`.
- `tingly-box provider/quota`: added hidden default subcommands so `provider` (no args) opens interactive management and `quota` (no args) lists, matching legacy. Also added the missing provider subcommands delete, update, get.

## Tests

Added cli/tingly-box/main_kong_test.go and cli/harness/main_kong_test.go (both `//go:build !legacy`). Coverage: every top-level subcommand parses, plus regression tests for each of the seven fixes above (version output, agent flag set + duration default, matrix --non-streaming, provider not-implemented, oauth routing, mcp-builtin top-level, parent defaults).

## Verification

- `go build ./cli/{tingly-box,harness}` (default = Kong) ✓
- `go build -tags legacy ./cli/{tingly-box,harness}` ✓
- `go test ./internal/command/... ./cli/...` (default + -tags legacy) ✓
- Smoke: tingly-box {version,oauth,mcp-builtin,provider,quota,...} ✓
- Smoke: harness {version,matrix --non-streaming,agent --timeout 30s,...} ✓

https://claude.ai/code/session_017sVGb95bHL2AxFsFCjpZmE