### PR TITLE
fix(deepseek): always populate reasoning_content for DeepSeek thinking mode

### DIFF
--- a/internal/mcp/runtime/advisor_call.go
+++ b/internal/mcp/runtime/advisor_call.go
@@ -63,17 +63,36 @@ func callOpenAI(ctx context.Context, cfg typ.AdvisorConfig, cp *client.ClientPoo
 	for _, m := range actx.Messages {
 		role, _ := m["role"].(string)
 		content := extractMessageText(m["content"])
-		if content == "" {
+		reasoning := extractMessageThinking(m["content"])
+		if content == "" && reasoning == "" {
 			continue
 		}
 		switch role {
 		case "user":
+			if content == "" {
+				continue
+			}
 			messages = append(messages, openai.UserMessage(content))
 		case "assistant":
-			messages = append(messages, openai.AssistantMessage(content))
+			msg := openai.AssistantMessage(content)
+			if reasoning != "" && msg.OfAssistant != nil {
+				extra := msg.OfAssistant.ExtraFields()
+				if extra == nil {
+					extra = map[string]any{}
+				}
+				extra["reasoning_content"] = reasoning
+				msg.OfAssistant.SetExtraFields(extra)
+			}
+			messages = append(messages, msg)
 		case "system":
+			if content == "" {
+				continue
+			}
 			messages = append(messages, openai.SystemMessage(content))
 		case "tool":
+			if content == "" {
+				continue
+			}
 			messages = append(messages, openai.UserMessage("[tool result]: "+content))
 		default:
 			logrus.WithField("role", role).Warn("advisor: dropping unknown message role")
@@ -296,6 +315,35 @@ func extractMessageText(content any) string {
 	default:
 		return ""
 	}
+}
+
+// extractMessageThinking extracts Anthropic-style thinking text from content parts.
+// This is mapped to OpenAI-compatible reasoning_content for providers like DeepSeek.
+func extractMessageThinking(content any) string {
+	parts, ok := content.([]any)
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		p, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		t, _ := p["type"].(string)
+		if t != "thinking" {
+			continue
+		}
+		txt, _ := p["thinking"].(string)
+		if txt == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(txt)
+	}
+	return b.String()
 }
 
 const advisorCallTimeout = 60 * time.Second

--- a/internal/protocol/transform/ops/request_openai_deepseek.go
+++ b/internal/protocol/transform/ops/request_openai_deepseek.go
@@ -1,9 +1,6 @@
 package ops
 
 import (
-	"encoding/json"
-	"strings"
-
 	"github.com/openai/openai-go/v3"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
@@ -13,114 +10,38 @@ import (
 // The base conversion preserves thinking content in "x_thinking" field
 func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
 	if config.CursorCompat {
-		normalizeDeepSeekCursorContent(req)
+		normalizeCursorContent(req)
 	}
 	// if has thinking, we should confirm each assistant contains `reasoning_content`
-	if config.HasThinking {
-		for i := range req.Messages {
-			if req.Messages[i].OfAssistant != nil {
-				// Convert the message to map to check/modify fields
-				msgMap := req.Messages[i].ExtraFields()
-				if msgMap == nil {
-					msgMap = map[string]any{}
-				}
-
-				// Extract x_thinking and convert to reasoning_content
-				if thinking, hasThinking := msgMap["x_thinking"]; hasThinking {
-					// Convert x_thinking to reasoning_content
-					if thinkingStr, ok := thinking.(string); ok {
-						msgMap["reasoning_content"] = thinkingStr
-					}
-					// Remove x_thinking field
-					delete(msgMap, "x_thinking")
-				} else {
-					// Ensure reasoning_content field exists even if no thinking content
-					// Use a placeholder (empty pointer) instead of empty string to ensure it's included in JSON
-					var emptyStr string
-					msgMap["reasoning_content"] = &emptyStr
-				}
-
-				// Convert back to message param
-				req.Messages[i].SetExtraFields(msgMap)
-			}
-		}
-	}
-	return req
-}
-
-func normalizeDeepSeekCursorContent(req *openai.ChatCompletionNewParams) {
+	// deepseek do not regard to config's has thinking field.
+	//if config.HasThinking {
 	for i := range req.Messages {
-		msgMap, err := MessageToMap(req.Messages[i])
-		if err != nil {
-			continue
-		}
-		content, ok := msgMap["content"]
-		if !ok {
-			continue
-		}
-		contentParts, ok := content.([]interface{})
-		if !ok {
-			continue
-		}
-		flattened, _ := flattenRichContent(contentParts)
-		msgMap["content"] = flattened
-
-		updatedBytes, err := json.Marshal(msgMap)
-		if err != nil {
-			continue
-		}
-		var updated openai.ChatCompletionMessageParamUnion
-		if err := json.Unmarshal(updatedBytes, &updated); err != nil {
-			continue
-		}
-		req.Messages[i] = updated
-	}
-}
-
-func flattenRichContent(parts []interface{}) (string, bool) {
-	var segments []string
-	var dropped bool
-	for _, part := range parts {
-		switch value := part.(type) {
-		case string:
-			if strings.TrimSpace(value) != "" {
-				segments = append(segments, value)
+		if req.Messages[i].OfAssistant != nil {
+			// Convert the message to map to check/modify fields
+			msgMap := req.Messages[i].ExtraFields()
+			if msgMap == nil {
+				msgMap = map[string]any{}
 			}
-		case map[string]interface{}:
-			if textValue, ok := value["text"].(string); ok {
-				if strings.TrimSpace(textValue) != "" {
-					segments = append(segments, textValue)
+
+			// Extract x_thinking and convert to reasoning_content
+			if thinking, hasThinking := msgMap["x_thinking"]; hasThinking {
+				// Convert x_thinking to reasoning_content
+				if thinkingStr, ok := thinking.(string); ok {
+					msgMap["reasoning_content"] = thinkingStr
 				}
-			} else if contentValue, ok := value["content"].(string); ok {
-				if strings.TrimSpace(contentValue) != "" {
-					segments = append(segments, contentValue)
-				}
+				// Remove x_thinking field
+				delete(msgMap, "x_thinking")
 			} else {
-				dropped = true
+				// Ensure reasoning_content field exists even if no thinking content
+				// Use a placeholder (empty pointer) instead of empty string to ensure it's included in JSON
+				var emptyStr string
+				msgMap["reasoning_content"] = &emptyStr
 			}
-		default:
-			dropped = true
+
+			// Convert back to message param
+			req.Messages[i].SetExtraFields(msgMap)
 		}
 	}
-	if len(segments) == 0 && dropped {
-		return "[non-text content omitted]", true
-	}
-	if dropped {
-		segments = append(segments, "[non-text content omitted]")
-	}
-	return strings.Join(segments, "\n"), dropped
-}
-
-// MessageToMap converts a ChatCompletionMessageParamUnion to a map for modification
-func MessageToMap(msg openai.ChatCompletionMessageParamUnion) (map[string]interface{}, error) {
-	msgBytes, err := json.Marshal(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	var result map[string]interface{}
-	if err := json.Unmarshal(msgBytes, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
+	//}
+	return req
 }

--- a/internal/protocol/transform/ops/request_openai_extensions.go
+++ b/internal/protocol/transform/ops/request_openai_extensions.go
@@ -138,6 +138,40 @@ func messageToMap(msg openai.ChatCompletionMessageParamUnion) (map[string]interf
 	return result, nil
 }
 
+func flattenRichContent(parts []interface{}) (string, bool) {
+	var segments []string
+	var dropped bool
+	for _, part := range parts {
+		switch value := part.(type) {
+		case string:
+			if strings.TrimSpace(value) != "" {
+				segments = append(segments, value)
+			}
+		case map[string]interface{}:
+			if textValue, ok := value["text"].(string); ok {
+				if strings.TrimSpace(textValue) != "" {
+					segments = append(segments, textValue)
+				}
+			} else if contentValue, ok := value["content"].(string); ok {
+				if strings.TrimSpace(contentValue) != "" {
+					segments = append(segments, contentValue)
+				}
+			} else {
+				dropped = true
+			}
+		default:
+			dropped = true
+		}
+	}
+	if len(segments) == 0 && dropped {
+		return "[non-text content omitted]", true
+	}
+	if dropped {
+		segments = append(segments, "[non-text content omitted]")
+	}
+	return strings.Join(segments, "\n"), dropped
+}
+
 // applyDefaultTransform applies default transformations for OpenAI-compatible requests
 // This handles standard fields like reasoning_effort that are widely supported
 func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {

--- a/internal/server/module/mcp/anthropic_beta_adapter.go
+++ b/internal/server/module/mcp/anthropic_beta_adapter.go
@@ -89,7 +89,7 @@ func (a *AnthropicBetaAdapter) BuildAssistantMessage(response any) (any, error) 
 	if !ok {
 		return nil, fmt.Errorf("expected *anthropic.BetaMessage, got %T", response)
 	}
-	return msg.ToParam(), nil
+	return betaMessageToParamPreservingThinking(msg), nil
 }
 
 func (a *AnthropicBetaAdapter) BuildToolMessage(result ToolExecutionResult) any {
@@ -110,7 +110,7 @@ func (a *AnthropicBetaAdapter) AppendToolResults(req, resp any, results []any) (
 	// Create new request with appended messages
 	newReq := *reqParams
 	newMessages := append([]anthropic.BetaMessageParam{}, reqParams.Messages...)
-	newMessages = append(newMessages, msg.ToParam())
+	newMessages = append(newMessages, betaMessageToParamPreservingThinking(msg))
 
 	// Convert results to tool result blocks
 	resultBlocks := make([]anthropic.BetaContentBlockParamUnion, len(results))
@@ -122,6 +122,23 @@ func (a *AnthropicBetaAdapter) AppendToolResults(req, resp any, results []any) (
 
 	newReq.Messages = newMessages
 	return &newReq, nil
+}
+
+func betaMessageToParamPreservingThinking(msg *anthropic.BetaMessage) anthropic.BetaMessageParam {
+	if msg == nil {
+		return anthropic.BetaMessageParam{}
+	}
+
+	// Preserve original assistant content when building the follow-up request.
+	// Raw JSON round-trip keeps provider-specific fields that ToParam() may omit.
+	if raw := msg.RawJSON(); raw != "" {
+		var param anthropic.BetaMessageParam
+		if err := json.Unmarshal([]byte(raw), &param); err == nil {
+			return param
+		}
+	}
+
+	return msg.ToParam()
 }
 
 func (a *AnthropicBetaAdapter) FilterVirtualTools(response any, externalTools []Tool) (any, error) {

--- a/internal/server/module/mcp/anthropic_v1_adapter.go
+++ b/internal/server/module/mcp/anthropic_v1_adapter.go
@@ -89,7 +89,7 @@ func (a *AnthropicV1Adapter) BuildAssistantMessage(response any) (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("expected *anthropic.Message, got %T", response)
 	}
-	return msg.ToParam(), nil
+	return messageToParamPreservingThinking(msg), nil
 }
 
 func (a *AnthropicV1Adapter) BuildToolMessage(result ToolExecutionResult) any {
@@ -110,7 +110,7 @@ func (a *AnthropicV1Adapter) AppendToolResults(req, resp any, results []any) (an
 	// Create new request with appended messages
 	newReq := *reqParams
 	newMessages := append([]anthropic.MessageParam{}, reqParams.Messages...)
-	newMessages = append(newMessages, msg.ToParam())
+	newMessages = append(newMessages, messageToParamPreservingThinking(msg))
 
 	// Convert results to tool result blocks
 	resultBlocks := make([]anthropic.ContentBlockParamUnion, len(results))
@@ -122,6 +122,23 @@ func (a *AnthropicV1Adapter) AppendToolResults(req, resp any, results []any) (an
 
 	newReq.Messages = newMessages
 	return &newReq, nil
+}
+
+func messageToParamPreservingThinking(msg *anthropic.Message) anthropic.MessageParam {
+	if msg == nil {
+		return anthropic.MessageParam{}
+	}
+
+	// Preserve original assistant content when building the follow-up request.
+	// Raw JSON round-trip keeps provider-specific fields that ToParam() may omit.
+	if raw := msg.RawJSON(); raw != "" {
+		var param anthropic.MessageParam
+		if err := json.Unmarshal([]byte(raw), &param); err == nil {
+			return param
+		}
+	}
+
+	return msg.ToParam()
 }
 
 func (a *AnthropicV1Adapter) FilterVirtualTools(response any, externalTools []Tool) (any, error) {

--- a/internal/server/module/mcp/generic_loop_processor.go
+++ b/internal/server/module/mcp/generic_loop_processor.go
@@ -2,11 +2,8 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/openai/openai-go/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/mcp/runtime"
@@ -16,17 +13,17 @@ import (
 
 // GenericLoopProcessor implements format-agnostic non-streaming MCP tool handling
 type GenericLoopProcessor struct {
-	ctx              context.Context
-	s                ServerOps
-	provider         *typ.Provider
-	hc               *protocol.HandleContext
-	virtualRegistry  *runtime.VirtualToolRegistry
-	recorder         ProtocolRecorder
-	adapter          FormatAdapter
-	forwarder        Forwarder
-	toolExecutor     ToolExecutor
-	pendingManager   PendingResultsManager
-	config           InterceptorConfig
+	ctx             context.Context
+	s               ServerOps
+	provider        *typ.Provider
+	hc              *protocol.HandleContext
+	virtualRegistry *runtime.VirtualToolRegistry
+	recorder        ProtocolRecorder
+	adapter         FormatAdapter
+	forwarder       Forwarder
+	toolExecutor    ToolExecutor
+	pendingManager  PendingResultsManager
+	config          InterceptorConfig
 
 	// Usage tracking
 	totalInputTokens  int64
@@ -242,61 +239,11 @@ func (p *GenericLoopProcessor) executeTool(tool Tool, req any) (ToolExecutionRes
 // Helper methods
 
 func (p *GenericLoopProcessor) extractModel(req any) string {
-	// Extract model from request based on format
-	switch r := req.(type) {
-	case *anthropic.MessageNewParams:
-		return string(r.Model)
-	case *anthropic.BetaMessageNewParams:
-		return string(r.Model)
-	case *openai.ChatCompletionNewParams:
-		return string(r.Model)
-	default:
-		// Fallback to provider name if available
-		if len(p.provider.Models) > 0 {
-			return p.provider.Models[0]
-		}
-		return ""
-	}
+	return extractModelFromRequest(req, p.provider)
 }
 
 func (p *GenericLoopProcessor) extractMessages(req any) []map[string]any {
-	// Extract messages from request for tool execution hooks
-	// Note: Current CallMCPTool implementation does not use messages parameter,
-	// but this is implemented for future compatibility
-	switch r := req.(type) {
-	case *anthropic.MessageNewParams:
-		if len(r.Messages) == 0 {
-			return nil
-		}
-		b, _ := json.Marshal(r.Messages)
-		var out []map[string]any
-		json.Unmarshal(b, &out)
-		return out
-	case *anthropic.BetaMessageNewParams:
-		if len(r.Messages) == 0 {
-			return nil
-		}
-		b, _ := json.Marshal(r.Messages)
-		var out []map[string]any
-		json.Unmarshal(b, &out)
-		return out
-	case *openai.ChatCompletionNewParams:
-		// For OpenAI, convert messages to map format
-		if len(r.Messages) == 0 {
-			return nil
-		}
-		messages := make([]map[string]any, len(r.Messages))
-		for i, msg := range r.Messages {
-			// Convert OpenAI message to map representation
-			msgJSON, _ := msg.MarshalJSON()
-			var msgMap map[string]any
-			json.Unmarshal(msgJSON, &msgMap)
-			messages[i] = msgMap
-		}
-		return messages
-	default:
-		return nil
-	}
+	return extractMessagesForToolCall(req)
 }
 
 func (p *GenericLoopProcessor) resultsToAny(results []ToolExecutionResult) []any {

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -521,21 +521,7 @@ func (i *GenericStreamInterceptor) executeTool(tool Tool, req any) (ToolExecutio
 // Helper methods
 
 func (i *GenericStreamInterceptor) extractModel(req any) string {
-	// Extract model from request based on format
-	switch r := req.(type) {
-	case *anthropic.MessageNewParams:
-		return string(r.Model)
-	case *anthropic.BetaMessageNewParams:
-		return string(r.Model)
-	case *openai.ChatCompletionNewParams:
-		return string(r.Model)
-	default:
-		// Fallback to provider's first model if available
-		if len(i.provider.Models) > 0 {
-			return i.provider.Models[0]
-		}
-		return ""
-	}
+	return extractModelFromRequest(req, i.provider)
 }
 
 func (i *GenericStreamInterceptor) extractEventPayload(event any) ([]byte, error) {
@@ -560,15 +546,7 @@ func (i *GenericStreamInterceptor) extractEventPayload(event any) ([]byte, error
 }
 
 func (i *GenericStreamInterceptor) extractMessages(req any) []map[string]any {
-	switch r := req.(type) {
-	case *anthropic.MessageNewParams:
-		return extractAnthropicV1Messages(r.Messages)
-	case *anthropic.BetaMessageNewParams:
-		return extractAnthropicBetaMessages(r.Messages)
-	case *openai.ChatCompletionNewParams:
-		return extractOpenAIChatMessages(r.Messages)
-	}
-	return nil
+	return extractMessagesForToolCall(req)
 }
 
 func (i *GenericStreamInterceptor) resultsToAny(results []ToolExecutionResult) []any {
@@ -635,53 +613,4 @@ func (i *GenericStreamInterceptor) extractRoundTools(response any) ([]Tool, erro
 		return i.roundTools, nil
 	}
 	return tools, err
-}
-
-// extractAnthropicV1Messages serialises Anthropic v1 messages to []map[string]any for advisor context.
-// JSON round-trip is used because the SDK union types don't expose underlying maps directly.
-func extractAnthropicV1Messages(messages []anthropic.MessageParam) []map[string]any {
-	if len(messages) == 0 {
-		return nil
-	}
-	b, err := json.Marshal(messages)
-	if err != nil {
-		return nil
-	}
-	var out []map[string]any
-	if err := json.Unmarshal(b, &out); err != nil {
-		return nil
-	}
-	return out
-}
-
-// extractAnthropicBetaMessages serialises Anthropic Beta messages to []map[string]any for advisor context.
-func extractAnthropicBetaMessages(messages []anthropic.BetaMessageParam) []map[string]any {
-	if len(messages) == 0 {
-		return nil
-	}
-	b, err := json.Marshal(messages)
-	if err != nil {
-		return nil
-	}
-	var out []map[string]any
-	if err := json.Unmarshal(b, &out); err != nil {
-		return nil
-	}
-	return out
-}
-
-// extractOpenAIChatMessages serialises OpenAI chat messages to []map[string]any for advisor context.
-func extractOpenAIChatMessages(messages []openai.ChatCompletionMessageParamUnion) []map[string]any {
-	if len(messages) == 0 {
-		return nil
-	}
-	b, err := json.Marshal(messages)
-	if err != nil {
-		return nil
-	}
-	var out []map[string]any
-	if err := json.Unmarshal(b, &out); err != nil {
-		return nil
-	}
-	return out
 }

--- a/internal/server/module/mcp/message_extract.go
+++ b/internal/server/module/mcp/message_extract.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func extractMessagesForToolCall(req any) []map[string]any {
+	switch r := req.(type) {
+	case *anthropic.MessageNewParams:
+		return extractMessageMaps(r.Messages)
+	case *anthropic.BetaMessageNewParams:
+		return extractMessageMaps(r.Messages)
+	case *openai.ChatCompletionNewParams:
+		return extractMessageMaps(r.Messages)
+	default:
+		return nil
+	}
+}
+
+func extractMessageMaps[T any](messages []T) []map[string]any {
+	if len(messages) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(messages)
+	if err != nil {
+		return nil
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func extractModelFromRequest(req any, provider *typ.Provider) string {
+	switch r := req.(type) {
+	case *anthropic.MessageNewParams:
+		return string(r.Model)
+	case *anthropic.BetaMessageNewParams:
+		return string(r.Model)
+	case *openai.ChatCompletionNewParams:
+		return string(r.Model)
+	default:
+		if provider != nil && len(provider.Models) > 0 {
+			return provider.Models[0]
+		}
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a 400 error when using DeepSeek with thinking mode enabled through the protocol transform pipeline. The error occurred because `reasoning_content` was not being echoed back in every assistant message turn.

## Root Cause

In `internal/protocol/transform/ops/request_openai_deepseek.go`, the logic that populates `reasoning_content` on assistant messages was gated behind `if config.HasThinking` (line 17-18). However, **DeepSeek requires `reasoning_content` to be present in every round-trip assistant message regardless of the proxy-level config** — when thinking mode is active on the DeepSeek side, the API rejects requests that omit `reasoning_content` on replayed assistant messages with:

```
POST https://api.deepseek.com/v1/chat/completions: 400 Bad Request
"reasoning_content in the thinking mode must be passed back to the API"
```

## Changes

### Core fix (`request_openai_deepseek.go`)
- **Removed the `if config.HasThinking` guard** — `reasoning_content` is now unconditionally populated from `x_thinking` (or set to an empty placeholder) on every assistant message in the DeepSeek transform path.

### MCP tool-loop thinking preservation (`anthropic_v1_adapter.go`, `anthropic_beta_adapter.go`)
- Added `messageToParamPreservingThinking` / `betaMessageToParamPreservingThinking` helpers that use raw JSON round-trip (`RawJSON()` → `json.Unmarshal`) instead of the SDK's `ToParam()`, which drops `x_thinking` extra fields. This ensures thinking content survives the MCP tool execution loop.

### Refactoring (no behavior change)
- Extracted `extractModelFromRequest`, `extractMessagesForToolCall`, and `extractMessageMaps` into shared `message_extract.go` (was duplicated in `generic_loop_processor.go` and `generic_stream_interceptor.go`).
- Moved `flattenRichContent` to `request_openai_extensions.go`.

## Test plan

- [x] Matrix e2e tests pass (212 PASS, 0 FAIL)
- [x] Matrix e2e tests with `--mcp` flag pass (226 PASS, 0 FAIL)