### PR TITLE
feat(config): add global proxy configuration setting

### DIFF
--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -746,23 +746,6 @@ const OAuthDialog = ({open, onClose, onSuccess}: OAuthDialogProps) => {
 
                     {/* Proxy URL input */}
                     <Box sx={{mb: 3}}>
-                        {globalProxyUrl && (
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        size="small"
-                                        checked={useGlobalProxy}
-                                        onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
-                                    />
-                                }
-                                label={
-                                    <Typography variant="body2">
-                                        {`Use global proxy (${globalProxyUrl})`}
-                                    </Typography>
-                                }
-                                sx={{mb: 1}}
-                            />
-                        )}
                         <TextField
                             fullWidth
                             label="HTTP/SOCKS Proxy URL (Optional)"
@@ -778,6 +761,26 @@ const OAuthDialog = ({open, onClose, onSuccess}: OAuthDialogProps) => {
                             color={autoDetectedProxy ? "success" : "primary"}
                             focused={autoDetectedProxy ? true : undefined}
                         />
+                        <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: 0.5, pr: 2}}>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        size="small"
+                                        checked={useGlobalProxy}
+                                        disabled={!globalProxyUrl}
+                                        onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
+                                    />
+                                }
+                                label={
+                                    <Typography variant="body2" color={globalProxyUrl ? 'text.secondary' : 'text.disabled'}>
+                                        {globalProxyUrl
+                                            ? `Use global proxy (${globalProxyUrl})`
+                                            : 'Use global proxy (not configured)'}
+                                    </Typography>
+                                }
+                                labelPlacement="start"
+                            />
+                        </Box>
                         {autoDetectedProxy && (
                             <Alert severity="success" sx={{mt: 1}} icon={<Launch fontSize="small"/>}>
                                 <Typography variant="caption">

--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -5,10 +5,12 @@ import {
     Button,
     Card,
     CardContent,
+    Checkbox,
     CircularProgress,
     Dialog,
     DialogContent,
     DialogTitle,
+    FormControlLabel,
     IconButton,
     Stack,
     TextField,
@@ -541,19 +543,43 @@ const OAuthDialog = ({open, onClose, onSuccess}: OAuthDialogProps) => {
     const [proxyUrl, setProxyUrl] = useState('');
     const [autoDetectedProxy, setAutoDetectedProxy] = useState('');
     const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+    const [useGlobalProxy, setUseGlobalProxy] = useState(false);
+    const [globalProxyUrl, setGlobalProxyUrl] = useState('');
 
-    // Load saved proxy URL from localStorage on mount
+    // Load saved proxy URL and global proxy setting from localStorage/config on mount
     useEffect(() => {
         const savedProxy = localStorage.getItem('oauth_proxy_url');
         if (savedProxy) {
             setProxyUrl(savedProxy);
         }
+        const savedUseGlobal = localStorage.getItem('oauth_use_global_proxy') === 'true';
+        setUseGlobalProxy(savedUseGlobal);
+        // Fetch global proxy URL from config
+        api.getConfig().then((result) => {
+            const gp = result?.data?.http_transport?.global_proxy_url ?? '';
+            setGlobalProxyUrl(gp);
+            if (savedUseGlobal && gp && !savedProxy) {
+                setProxyUrl(gp);
+            }
+        });
     }, []);
 
     // Save proxy URL to localStorage when it changes
     const handleProxyUrlChange = (value: string) => {
         setProxyUrl(value);
         localStorage.setItem('oauth_proxy_url', value);
+    };
+
+    const handleUseGlobalProxyChange = (checked: boolean) => {
+        setUseGlobalProxy(checked);
+        localStorage.setItem('oauth_use_global_proxy', String(checked));
+        if (checked && globalProxyUrl) {
+            setProxyUrl(globalProxyUrl);
+            localStorage.setItem('oauth_proxy_url', globalProxyUrl);
+        } else if (!checked) {
+            setProxyUrl('');
+            localStorage.setItem('oauth_proxy_url', '');
+        }
     };
 
     // Fetch existing providers to detect proxy URLs when dialog opens
@@ -720,6 +746,23 @@ const OAuthDialog = ({open, onClose, onSuccess}: OAuthDialogProps) => {
 
                     {/* Proxy URL input */}
                     <Box sx={{mb: 3}}>
+                        {globalProxyUrl && (
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        size="small"
+                                        checked={useGlobalProxy}
+                                        onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
+                                    />
+                                }
+                                label={
+                                    <Typography variant="body2">
+                                        {`Use global proxy (${globalProxyUrl})`}
+                                    </Typography>
+                                }
+                                sx={{mb: 1}}
+                            />
+                        )}
                         <TextField
                             fullWidth
                             label="HTTP/SOCKS Proxy URL (Optional)"

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -750,40 +750,44 @@ const ProviderFormDialog = ({
                             placeholder={t('providerDialog.keyName.placeholder')}
                         />
 
-                        {mode === 'add' && (
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        size="small"
-                                        checked={useGlobalProxy}
-                                        disabled={!globalProxyUrl}
-                                        onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
-                                    />
-                                }
-                                label={
-                                    <Typography variant="body2" color={globalProxyUrl ? 'text.primary' : 'text.disabled'}>
-                                        {globalProxyUrl
-                                            ? t('providerDialog.advanced.proxyUrl.useGlobal', {url: globalProxyUrl})
-                                            : t('providerDialog.advanced.proxyUrl.useGlobalNotSet')}
-                                    </Typography>
-                                }
+                        <Box>
+                            <TextField
+                                size="small"
+                                fullWidth
+                                label={t('providerDialog.advanced.proxyUrl.label')}
+                                placeholder={t('providerDialog.advanced.proxyUrl.placeholder')}
+                                value={data.proxyUrl || ''}
+                                onChange={(e) => {
+                                    onChange('proxyUrl', e.target.value);
+                                    if (useGlobalProxy && e.target.value !== globalProxyUrl) {
+                                        setUseGlobalProxy(false);
+                                        localStorage.setItem('provider_use_global_proxy', 'false');
+                                    }
+                                }}
                             />
-                        )}
-
-                        <TextField
-                            size="small"
-                            fullWidth
-                            label={t('providerDialog.advanced.proxyUrl.label')}
-                            placeholder={t('providerDialog.advanced.proxyUrl.placeholder')}
-                            value={data.proxyUrl || ''}
-                            onChange={(e) => {
-                                onChange('proxyUrl', e.target.value);
-                                if (useGlobalProxy && e.target.value !== globalProxyUrl) {
-                                    setUseGlobalProxy(false);
-                                    localStorage.setItem('provider_use_global_proxy', 'false');
-                                }
-                            }}
-                        />
+                            {mode === 'add' && (
+                                <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: 0.5, pr: 2}}>
+                                    <FormControlLabel
+                                        control={
+                                            <Checkbox
+                                                size="small"
+                                                checked={useGlobalProxy}
+                                                disabled={!globalProxyUrl}
+                                                onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
+                                            />
+                                        }
+                                        label={
+                                            <Typography variant="body2" color={globalProxyUrl ? 'text.secondary' : 'text.disabled'}>
+                                                {globalProxyUrl
+                                                    ? t('providerDialog.advanced.proxyUrl.useGlobal', {url: globalProxyUrl})
+                                                    : t('providerDialog.advanced.proxyUrl.useGlobalNotSet')}
+                                            </Typography>
+                                        }
+                                        labelPlacement="start"
+                                    />
+                                </Box>
+                            )}
+                        </Box>
 
                         {mode === 'edit' && (
                             <FormControlLabel

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -750,18 +750,21 @@ const ProviderFormDialog = ({
                             placeholder={t('providerDialog.keyName.placeholder')}
                         />
 
-                        {globalProxyUrl && mode === 'add' && (
+                        {mode === 'add' && (
                             <FormControlLabel
                                 control={
                                     <Checkbox
                                         size="small"
                                         checked={useGlobalProxy}
+                                        disabled={!globalProxyUrl}
                                         onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
                                     />
                                 }
                                 label={
-                                    <Typography variant="body2">
-                                        {t('providerDialog.advanced.proxyUrl.useGlobal', {url: globalProxyUrl})}
+                                    <Typography variant="body2" color={globalProxyUrl ? 'text.primary' : 'text.disabled'}>
+                                        {globalProxyUrl
+                                            ? t('providerDialog.advanced.proxyUrl.useGlobal', {url: globalProxyUrl})
+                                            : t('providerDialog.advanced.proxyUrl.useGlobalNotSet')}
                                     </Typography>
                                 }
                             />

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -109,6 +109,8 @@ const ProviderFormDialog = ({
     const [protocolAnthropic, setProtocolAnthropic] = useState(false);
     const [nameIsAutoFilled, setNameIsAutoFilled] = useState(true);
     const [providerInputValue, setProviderInputValue] = useState('');
+    const [useGlobalProxy, setUseGlobalProxy] = useState(false);
+    const [globalProxyUrl, setGlobalProxyUrl] = useState('');
 
     const allProviders = useProviderTemplates();
 
@@ -173,6 +175,14 @@ const ProviderFormDialog = ({
         setNoApiKey(data.noKeyRequired || false);
     }, [data.noKeyRequired]);
 
+    // Fetch global proxy URL once on mount
+    useEffect(() => {
+        api.getConfig().then((result) => {
+            const gp = result?.data?.http_transport?.global_proxy_url ?? '';
+            setGlobalProxyUrl(gp);
+        });
+    }, []);
+
     // Reset / initialise local state when the dialog opens.
     // Only runs on the open transition — never during typing.
     useEffect(() => {
@@ -200,6 +210,17 @@ const ProviderFormDialog = ({
             }
             setSelectedProvider(null);
             setProviderInputValue('');
+        }
+
+        // Restore "use global proxy" checkbox state from localStorage (add mode only)
+        if (mode === 'add') {
+            const savedUseGlobal = localStorage.getItem('provider_use_global_proxy') === 'true';
+            setUseGlobalProxy(savedUseGlobal);
+            if (savedUseGlobal && globalProxyUrl && !data.proxyUrl) {
+                onChangeRef.current('proxyUrl', globalProxyUrl);
+            }
+        } else {
+            setUseGlobalProxy(false);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open]);
@@ -234,6 +255,16 @@ const ProviderFormDialog = ({
         },
         []
     );
+
+    const handleUseGlobalProxyChange = (checked: boolean) => {
+        setUseGlobalProxy(checked);
+        localStorage.setItem('provider_use_global_proxy', String(checked));
+        if (checked && globalProxyUrl) {
+            onChange('proxyUrl', globalProxyUrl);
+        } else if (!checked) {
+            onChange('proxyUrl', '');
+        }
+    };
 
     const toggleOpenAIProtocol = () => {
         if (mode === 'edit') return;
@@ -719,13 +750,36 @@ const ProviderFormDialog = ({
                             placeholder={t('providerDialog.keyName.placeholder')}
                         />
 
+                        {globalProxyUrl && mode === 'add' && (
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        size="small"
+                                        checked={useGlobalProxy}
+                                        onChange={(e) => handleUseGlobalProxyChange(e.target.checked)}
+                                    />
+                                }
+                                label={
+                                    <Typography variant="body2">
+                                        {t('providerDialog.advanced.proxyUrl.useGlobal', {url: globalProxyUrl})}
+                                    </Typography>
+                                }
+                            />
+                        )}
+
                         <TextField
                             size="small"
                             fullWidth
                             label={t('providerDialog.advanced.proxyUrl.label')}
                             placeholder={t('providerDialog.advanced.proxyUrl.placeholder')}
                             value={data.proxyUrl || ''}
-                            onChange={(e) => onChange('proxyUrl', e.target.value)}
+                            onChange={(e) => {
+                                onChange('proxyUrl', e.target.value);
+                                if (useGlobalProxy && e.target.value !== globalProxyUrl) {
+                                    setUseGlobalProxy(false);
+                                    localStorage.setItem('provider_use_global_proxy', 'false');
+                                }
+                            }}
                         />
 
                         {mode === 'edit' && (

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -238,7 +238,8 @@ export default {
       "proxyUrl": {
         "label": "HTTP/SOCKS Proxy URL (Optional)",
         "placeholder": "http://127.0.0.1:7890 or socks5://127.0.0.1:7890",
-        "helper": "Optional: Use a proxy to bypass region restrictions. Saved for future use."
+        "helper": "Optional: Use a proxy to bypass region restrictions. Saved for future use.",
+        "useGlobal": "Use global proxy ({{url}})"
       }
     },
     "verification": {
@@ -403,6 +404,12 @@ export default {
       "respectEnvProxy": {
         "label": "Respect Environment Proxy",
         "helper": "When enabled, providers without explicit proxy configuration will use system proxy settings (HTTP_PROXY, HTTPS_PROXY, macOS system proxy, Clash, etc.)"
+      },
+      "globalProxyUrl": {
+        "label": "Global Proxy",
+        "helper": "Fallback proxy for all providers and OAuth. Per-provider proxy takes priority.",
+        "saveSuccess": "Global proxy URL saved",
+        "saveFailed": "Failed to save global proxy URL"
       },
       "notifications": {
         "updateSuccess": "Proxy settings updated successfully",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -239,7 +239,8 @@ export default {
         "label": "HTTP/SOCKS Proxy URL (Optional)",
         "placeholder": "http://127.0.0.1:7890 or socks5://127.0.0.1:7890",
         "helper": "Optional: Use a proxy to bypass region restrictions. Saved for future use.",
-        "useGlobal": "Use global proxy ({{url}})"
+        "useGlobal": "Use global proxy ({{url}})",
+        "useGlobalNotSet": "Use global proxy (not configured — set in System Settings)"
       }
     },
     "verification": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -239,7 +239,8 @@ export default {
         "label": "HTTP/SOCKS 代理 URL（可选）",
         "placeholder": "http://127.0.0.1:7890 或 socks5://127.0.0.1:7890",
         "helper": "可选：使用代理绕过区域限制。将保存以供将来使用。",
-        "useGlobal": "使用全局代理（{{url}}）"
+        "useGlobal": "使用全局代理（{{url}}）",
+        "useGlobalNotSet": "使用全局代理（未配置 — 请在系统设置中配置）"
       }
     },
     "verification": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -238,7 +238,8 @@ export default {
       "proxyUrl": {
         "label": "HTTP/SOCKS 代理 URL（可选）",
         "placeholder": "http://127.0.0.1:7890 或 socks5://127.0.0.1:7890",
-        "helper": "可选：使用代理绕过区域限制。将保存以供将来使用。"
+        "helper": "可选：使用代理绕过区域限制。将保存以供将来使用。",
+        "useGlobal": "使用全局代理（{{url}}）"
       }
     },
     "verification": {
@@ -403,6 +404,12 @@ export default {
       "respectEnvProxy": {
         "label": "遵循环境代理",
         "helper": "启用后，没有显式代理配置的提供商将使用系统代理设置（HTTP_PROXY、HTTPS_PROXY、macOS 系统代理、Clash 等）"
+      },
+      "globalProxyUrl": {
+        "label": "全局代理",
+        "helper": "所有提供商和 OAuth 的兜底代理，每个提供商的专属代理优先级更高。",
+        "saveSuccess": "全局代理 URL 已保存",
+        "saveFailed": "保存全局代理 URL 失败"
       },
       "notifications": {
         "updateSuccess": "代理设置更新成功",

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -240,7 +240,7 @@ const System = () => {
                                         {t('system.proxy.globalProxyUrl.label')}
                                     </Typography>
                                 </Box>
-                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flex: 1 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, maxWidth: 380 }}>
                                     <TextField
                                         size="small"
                                         value={globalProxyInput}

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -5,7 +5,7 @@ import UnifiedCard from '@/components/UnifiedCard';
 import { Logout } from '@mui/icons-material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
 import { IconCircleCheck, IconCircleX, IconInfoCircle, IconKey, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage } from '@tabler/icons-react';
-import { Box, CircularProgress, IconButton, Link, Stack, Tooltip, Typography, Chip } from '@mui/material';
+import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHealth } from '@/contexts/HealthContext';
@@ -22,6 +22,9 @@ const System = () => {
     const [notification, setNotification] = useState<{ open: boolean; message?: string; severity?: 'success' | 'error' | 'info' | 'warning' }>({ open: false });
     const [loading, setLoading] = useState(true);
     const [respectEnvProxy, setRespectEnvProxy] = useState<boolean | null>(null);
+    const [globalProxyUrl, setGlobalProxyUrl] = useState('');
+    const [globalProxyInput, setGlobalProxyInput] = useState('');
+    const [proxyUrlSaving, setProxyUrlSaving] = useState(false);
 
     const handleForceLogout = () => {
         authLogout();
@@ -68,7 +71,24 @@ const System = () => {
         if (result.success && result.data) {
             const value = result.data.http_transport?.respect_env_proxy;
             setRespectEnvProxy(value === null ? false : value);
+            const gpUrl = result.data.http_transport?.global_proxy_url ?? '';
+            setGlobalProxyUrl(gpUrl);
+            setGlobalProxyInput(gpUrl);
         }
+    };
+
+    const saveGlobalProxyUrl = async () => {
+        setProxyUrlSaving(true);
+        const result = await api.updateConfig({
+            http_transport: { global_proxy_url: globalProxyInput },
+        });
+        if (result.success) {
+            setGlobalProxyUrl(globalProxyInput);
+            setNotification({ open: true, message: t('system.proxy.globalProxyUrl.saveSuccess'), severity: 'success' });
+        } else {
+            setNotification({ open: true, message: t('system.proxy.globalProxyUrl.saveFailed'), severity: 'error' });
+        }
+        setProxyUrlSaving(false);
     };
 
     const loadServerStatus = async () => {
@@ -209,6 +229,42 @@ const System = () => {
                                             />
                                         </Tooltip>
                                     )}
+                                </Box>
+                            </Box>
+
+                            {/* Global Proxy URL */}
+                            <Box sx={{ display: 'flex', alignItems: 'flex-start', py: 0.5, gap: 3 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100, pt: 1 }}>
+                                    <IconLock size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                        {t('system.proxy.globalProxyUrl.label')}
+                                    </Typography>
+                                </Box>
+                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flex: 1 }}>
+                                    <TextField
+                                        size="small"
+                                        value={globalProxyInput}
+                                        onChange={(e) => setGlobalProxyInput(e.target.value)}
+                                        placeholder="http://127.0.0.1:7890"
+                                        helperText={t('system.proxy.globalProxyUrl.helper')}
+                                        sx={{ flex: 1 }}
+                                        InputProps={globalProxyUrl && globalProxyInput === globalProxyUrl ? {
+                                            endAdornment: (
+                                                <InputAdornment position="end">
+                                                    <IconLock size={14} style={{ color: 'var(--mui-palette-success-main)' }} />
+                                                </InputAdornment>
+                                            )
+                                        } : undefined}
+                                    />
+                                    <Button
+                                        size="small"
+                                        variant="outlined"
+                                        onClick={saveGlobalProxyUrl}
+                                        disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
+                                        sx={{ mt: 0.5, whiteSpace: 'nowrap' }}
+                                    >
+                                        {t('common.save')}
+                                    </Button>
                                 </Box>
                             </Box>
                         </Stack>

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -44,8 +44,9 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 	}
 
 	// Create HTTP client with session-bound transport
+	effectiveProxy := resolveProxyURL(provider.ProxyURL)
 	var transport http.RoundTripper
-	if provider.AuthType == typ.AuthTypeOAuth || provider.ProxyURL != "" {
+	if provider.AuthType == typ.AuthTypeOAuth || effectiveProxy != "" {
 		// Use createSessionBoundTransport which applies OAuth hooks and uses shared transport
 		transport = createSessionBoundTransport(provider, sessionID)
 
@@ -53,8 +54,8 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 			logrus.Infof("Using session-bound transport for OAuth provider type: %s, session: %s",
 				provider.OAuthDetail.ProviderType, sessionID.Value)
 		}
-		if provider.ProxyURL != "" {
-			logrus.Infof("Using proxy for Anthropic client: %s", provider.ProxyURL)
+		if effectiveProxy != "" {
+			logrus.Infof("Using proxy for Anthropic client: %s", effectiveProxy)
 		}
 	} else {
 		transport = http.DefaultTransport
@@ -64,7 +65,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 		Transport: transport,
 	}
 
-	if provider.ProxyURL != "" || provider.AuthType == typ.AuthTypeOAuth {
+	if effectiveProxy != "" || provider.AuthType == typ.AuthTypeOAuth {
 		options = append(options, anthropicOption.WithHTTPClient(httpClient))
 	}
 

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -44,9 +44,8 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 	}
 
 	// Create HTTP client with session-bound transport
-	effectiveProxy := resolveProxyURL(provider.ProxyURL)
 	var transport http.RoundTripper
-	if provider.AuthType == typ.AuthTypeOAuth || effectiveProxy != "" {
+	if provider.AuthType == typ.AuthTypeOAuth || provider.ProxyURL != "" {
 		// Use createSessionBoundTransport which applies OAuth hooks and uses shared transport
 		transport = createSessionBoundTransport(provider, sessionID)
 
@@ -54,8 +53,8 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 			logrus.Infof("Using session-bound transport for OAuth provider type: %s, session: %s",
 				provider.OAuthDetail.ProviderType, sessionID.Value)
 		}
-		if effectiveProxy != "" {
-			logrus.Infof("Using proxy for Anthropic client: %s", effectiveProxy)
+		if provider.ProxyURL != "" {
+			logrus.Infof("Using proxy for Anthropic client: %s", provider.ProxyURL)
 		}
 	} else {
 		transport = http.DefaultTransport
@@ -65,7 +64,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 		Transport: transport,
 	}
 
-	if effectiveProxy != "" || provider.AuthType == typ.AuthTypeOAuth {
+	if provider.ProxyURL != "" || provider.AuthType == typ.AuthTypeOAuth {
 		options = append(options, anthropicOption.WithHTTPClient(httpClient))
 	}
 

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -469,7 +469,7 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 	baseTransport := &SessionBoundTransport{
 		transportPool: GetGlobalTransportPool(),
 		providerUUID:  provider.UUID,
-		proxyURL:      resolveProxyURL(provider.ProxyURL),
+		proxyURL:      provider.ProxyURL,
 		oauthType:     oauthType,
 		sessionID:     sessionID,
 	}
@@ -500,7 +500,7 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 				RoundTripper: baseTransport,
 				project:      project,
 				model:        model,
-				proxyURL:     resolveProxyURL(provider.ProxyURL),
+				proxyURL:     provider.ProxyURL,
 			}
 		default:
 			// Generic OAuth with hooks (if any are defined)
@@ -533,7 +533,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 
 	// Get shared transport from transport pool (keyed by providerUUID + sessionID for OAuth)
 	// proxyURL is used to configure the transport but is NOT part of the key
-	transport := GetGlobalTransportPool().GetTransport(provider.UUID, model, resolveProxyURL(provider.ProxyURL), providerType, sessionID)
+	transport := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, providerType, sessionID)
 
 	client := &http.Client{
 		Transport: transport,
@@ -554,7 +554,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			}
 			// Create a separate transport with proxy for Antigravity
 			var antigravityTransport http.RoundTripper = transport
-			effectiveProxy := resolveProxyURL(provider.ProxyURL)
+			effectiveProxy := provider.ProxyURL
 			if effectiveProxy != "" {
 				// Use CreateHTTPClientWithProxy to create a transport with proxy
 				proxyClient := CreateHTTPClientWithProxy(effectiveProxy)
@@ -574,7 +574,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 		case oauth.ProviderClaudeCode:
 			// For Claude Code OAuth, use claudeRoundTripper for request/response transformations
 			var claudeTransport http.RoundTripper = transport
-			if ep := resolveProxyURL(provider.ProxyURL); ep != "" {
+			if ep := provider.ProxyURL; ep != "" {
 				proxyClient := CreateHTTPClientWithProxy(ep)
 				if proxyClient.Transport != nil {
 					claudeTransport = proxyClient.Transport
@@ -584,11 +584,11 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			client.Transport = &claudeRoundTripper{
 				RoundTripper: claudeTransport,
 			}
-			logrus.Infof("Created Claude Code RoundTripper with proxy=%s", resolveProxyURL(provider.ProxyURL))
+			logrus.Infof("Created Claude Code RoundTripper with proxy=%s", provider.ProxyURL)
 		case oauth.ProviderCodex:
 			// Create base transport with proxy support if needed
 			var baseTransport http.RoundTripper = transport
-			if ep := resolveProxyURL(provider.ProxyURL); ep != "" {
+			if ep := provider.ProxyURL; ep != "" {
 				// Explicitly create transport with proxy for this provider
 				proxyClient := CreateHTTPClientWithProxy(ep)
 				if proxyClient.Transport != nil {
@@ -602,7 +602,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			baseTransport = &codexRoundTripper{
 				RoundTripper: baseTransport,
 			}
-			logrus.Infof("Created ChatGPT backend response transformer RoundTripper with proxy=%s", resolveProxyURL(provider.ProxyURL))
+			logrus.Infof("Created ChatGPT backend response transformer RoundTripper with proxy=%s", provider.ProxyURL)
 
 			client.Transport = baseTransport
 		default:
@@ -611,7 +611,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			if ok {
 				// Create base transport with proxy support if needed
 				var baseTransport http.RoundTripper = transport
-				if ep := resolveProxyURL(provider.ProxyURL); ep != "" {
+				if ep := provider.ProxyURL; ep != "" {
 					// Explicitly create transport with proxy for this provider
 					proxyClient := CreateHTTPClientWithProxy(ep)
 					if proxyClient.Transport != nil {

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -469,7 +469,7 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 	baseTransport := &SessionBoundTransport{
 		transportPool: GetGlobalTransportPool(),
 		providerUUID:  provider.UUID,
-		proxyURL:      provider.ProxyURL,
+		proxyURL:      resolveProxyURL(provider.ProxyURL),
 		oauthType:     oauthType,
 		sessionID:     sessionID,
 	}
@@ -500,7 +500,7 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 				RoundTripper: baseTransport,
 				project:      project,
 				model:        model,
-				proxyURL:     provider.ProxyURL,
+				proxyURL:     resolveProxyURL(provider.ProxyURL),
 			}
 		default:
 			// Generic OAuth with hooks (if any are defined)
@@ -533,7 +533,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 
 	// Get shared transport from transport pool (keyed by providerUUID + sessionID for OAuth)
 	// proxyURL is used to configure the transport but is NOT part of the key
-	transport := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, providerType, sessionID)
+	transport := GetGlobalTransportPool().GetTransport(provider.UUID, model, resolveProxyURL(provider.ProxyURL), providerType, sessionID)
 
 	client := &http.Client{
 		Transport: transport,
@@ -554,9 +554,10 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			}
 			// Create a separate transport with proxy for Antigravity
 			var antigravityTransport http.RoundTripper = transport
-			if provider.ProxyURL != "" {
+			effectiveProxy := resolveProxyURL(provider.ProxyURL)
+			if effectiveProxy != "" {
 				// Use CreateHTTPClientWithProxy to create a transport with proxy
-				proxyClient := CreateHTTPClientWithProxy(provider.ProxyURL)
+				proxyClient := CreateHTTPClientWithProxy(effectiveProxy)
 				if proxyClient.Transport != nil {
 					antigravityTransport = proxyClient.Transport
 				}
@@ -567,14 +568,14 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 				RoundTripper: antigravityTransport,
 				project:      project,
 				model:        model,
-				proxyURL:     provider.ProxyURL,
+				proxyURL:     effectiveProxy,
 			}
-			logrus.Infof("Created Antigravity RoundTripper with project=%s, model=%s, proxy=%s", project, model, provider.ProxyURL)
+			logrus.Infof("Created Antigravity RoundTripper with project=%s, model=%s, proxy=%s", project, model, effectiveProxy)
 		case oauth.ProviderClaudeCode:
 			// For Claude Code OAuth, use claudeRoundTripper for request/response transformations
 			var claudeTransport http.RoundTripper = transport
-			if provider.ProxyURL != "" {
-				proxyClient := CreateHTTPClientWithProxy(provider.ProxyURL)
+			if ep := resolveProxyURL(provider.ProxyURL); ep != "" {
+				proxyClient := CreateHTTPClientWithProxy(ep)
 				if proxyClient.Transport != nil {
 					claudeTransport = proxyClient.Transport
 				}
@@ -583,16 +584,16 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			client.Transport = &claudeRoundTripper{
 				RoundTripper: claudeTransport,
 			}
-			logrus.Infof("Created Claude Code RoundTripper with proxy=%s", provider.ProxyURL)
+			logrus.Infof("Created Claude Code RoundTripper with proxy=%s", resolveProxyURL(provider.ProxyURL))
 		case oauth.ProviderCodex:
 			// Create base transport with proxy support if needed
 			var baseTransport http.RoundTripper = transport
-			if provider.ProxyURL != "" {
+			if ep := resolveProxyURL(provider.ProxyURL); ep != "" {
 				// Explicitly create transport with proxy for this provider
-				proxyClient := CreateHTTPClientWithProxy(provider.ProxyURL)
+				proxyClient := CreateHTTPClientWithProxy(ep)
 				if proxyClient.Transport != nil {
 					baseTransport = proxyClient.Transport
-					logrus.Infof("Created proxy transport for %s: %s", providerType, provider.ProxyURL)
+					logrus.Infof("Created proxy transport for %s: %s", providerType, ep)
 				}
 			}
 
@@ -601,7 +602,7 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			baseTransport = &codexRoundTripper{
 				RoundTripper: baseTransport,
 			}
-			logrus.Infof("Created ChatGPT backend response transformer RoundTripper with proxy=%s", provider.ProxyURL)
+			logrus.Infof("Created ChatGPT backend response transformer RoundTripper with proxy=%s", resolveProxyURL(provider.ProxyURL))
 
 			client.Transport = baseTransport
 		default:
@@ -610,12 +611,12 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 			if ok {
 				// Create base transport with proxy support if needed
 				var baseTransport http.RoundTripper = transport
-				if provider.ProxyURL != "" {
+				if ep := resolveProxyURL(provider.ProxyURL); ep != "" {
 					// Explicitly create transport with proxy for this provider
-					proxyClient := CreateHTTPClientWithProxy(provider.ProxyURL)
+					proxyClient := CreateHTTPClientWithProxy(ep)
 					if proxyClient.Transport != nil {
 						baseTransport = proxyClient.Transport
-						logrus.Infof("Created proxy transport for %s: %s", providerType, provider.ProxyURL)
+						logrus.Infof("Created proxy transport for %s: %s", providerType, ep)
 					}
 				}
 

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -50,8 +50,9 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	}
 
 	// Create HTTP client with session-bound transport
+	effectiveProxy := resolveProxyURL(provider.ProxyURL)
 	var transport http.RoundTripper
-	if provider.AuthType == typ.AuthTypeOAuth || provider.ProxyURL != "" {
+	if provider.AuthType == typ.AuthTypeOAuth || effectiveProxy != "" {
 		// Use createSessionBoundTransport which applies OAuth hooks and uses shared transport
 		transport = createSessionBoundTransport(provider, sessionID)
 		providerType := ""
@@ -62,6 +63,8 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 			logrus.Infof("[Codex] Using session-bound transport for ChatGPT backend API path rewriting, session: %s", sessionID.Value)
 		} else if providerType != "" {
 			logrus.Infof("Using session-bound transport for OAuth provider type: %s, session: %s", providerType, sessionID.Value)
+		} else if effectiveProxy != "" {
+			logrus.Infof("Using proxy for OpenAI client: %s", effectiveProxy)
 		}
 	} else {
 		// For non-OAuth providers without proxy, use default transport

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -50,9 +50,8 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	}
 
 	// Create HTTP client with session-bound transport
-	effectiveProxy := resolveProxyURL(provider.ProxyURL)
 	var transport http.RoundTripper
-	if provider.AuthType == typ.AuthTypeOAuth || effectiveProxy != "" {
+	if provider.AuthType == typ.AuthTypeOAuth || provider.ProxyURL != "" {
 		// Use createSessionBoundTransport which applies OAuth hooks and uses shared transport
 		transport = createSessionBoundTransport(provider, sessionID)
 		providerType := ""
@@ -63,8 +62,8 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 			logrus.Infof("[Codex] Using session-bound transport for ChatGPT backend API path rewriting, session: %s", sessionID.Value)
 		} else if providerType != "" {
 			logrus.Infof("Using session-bound transport for OAuth provider type: %s, session: %s", providerType, sessionID.Value)
-		} else if effectiveProxy != "" {
-			logrus.Infof("Using proxy for OpenAI client: %s", effectiveProxy)
+		} else if provider.ProxyURL != "" {
+			logrus.Infof("Using proxy for OpenAI client: %s", provider.ProxyURL)
 		}
 	} else {
 		// For non-OAuth providers without proxy, use default transport

--- a/internal/client/transport_pool.go
+++ b/internal/client/transport_pool.go
@@ -35,9 +35,6 @@ type TransportConfig struct {
 	// Set to true: providers without proxy_url will use system/environment proxy
 	RespectEnvProxy *bool // nil = use default (false)
 
-	// GlobalProxyURL is a fallback proxy URL for providers that have no per-provider proxy_url set.
-	// Per-provider proxy_url always takes priority. Supports http://, https://, socks5://.
-	GlobalProxyURL string
 }
 
 // Go defaults for reference (not used directly, only for documentation)
@@ -115,34 +112,6 @@ func GetGlobalTransportPool() *TransportPool {
 	return globalTransportPool
 }
 
-// globalProxyURL holds the fallback proxy URL for providers without an explicit per-provider proxy.
-var (
-	globalProxyURLMu  sync.RWMutex
-	globalProxyURLVal string
-)
-
-// SetGlobalProxyURL sets the global fallback proxy URL (thread-safe).
-func SetGlobalProxyURL(u string) {
-	globalProxyURLMu.Lock()
-	defer globalProxyURLMu.Unlock()
-	globalProxyURLVal = u
-}
-
-// GetGlobalProxyURL returns the current global fallback proxy URL (thread-safe).
-func GetGlobalProxyURL() string {
-	globalProxyURLMu.RLock()
-	defer globalProxyURLMu.RUnlock()
-	return globalProxyURLVal
-}
-
-// resolveProxyURL returns providerProxy if non-empty, otherwise falls back to the global proxy URL.
-func resolveProxyURL(providerProxy string) string {
-	if providerProxy != "" {
-		return providerProxy
-	}
-	return GetGlobalProxyURL()
-}
-
 // SetTransportConfig updates the transport pool configuration
 // Pass nil to reset to Go defaults (backward compatible)
 // This affects newly created transports only, existing transports are not modified
@@ -153,10 +122,8 @@ func SetTransportConfig(config *TransportConfig) {
 	globalTransportPool.config = config
 
 	if config == nil {
-		SetGlobalProxyURL("")
 		logrus.Info("Transport pool config reset to Go defaults")
 	} else {
-		SetGlobalProxyURL(config.GlobalProxyURL)
 		maxIdle := "default"
 		maxIdlePerHost := "default"
 		if config.MaxIdleConns != nil {
@@ -165,8 +132,8 @@ func SetTransportConfig(config *TransportConfig) {
 		if config.MaxIdleConnsPerHost != nil {
 			maxIdlePerHost = fmt.Sprintf("%d", *config.MaxIdleConnsPerHost)
 		}
-		logrus.Infof("Transport pool config updated: MaxIdleConns=%s, MaxIdleConnsPerHost=%s, GlobalProxyURL=%s",
-			maxIdle, maxIdlePerHost, config.GlobalProxyURL)
+		logrus.Infof("Transport pool config updated: MaxIdleConns=%s, MaxIdleConnsPerHost=%s",
+			maxIdle, maxIdlePerHost)
 	}
 }
 
@@ -284,10 +251,6 @@ func (tp *TransportPool) respectEnvProxy() bool {
 
 // createTransport creates a new HTTP transport with proxy support
 func (tp *TransportPool) createTransport(proxyURL string) *http.Transport {
-	// Use global proxy as fallback when no provider-specific proxy is set
-	if proxyURL == "" && tp.config != nil && tp.config.GlobalProxyURL != "" {
-		proxyURL = tp.config.GlobalProxyURL
-	}
 	if proxyURL == "" {
 		// Clone default transport for connection pool settings, then clear proxy
 		// unless the user has explicitly opted into env proxy via RespectEnvProxy.

--- a/internal/client/transport_pool.go
+++ b/internal/client/transport_pool.go
@@ -34,6 +34,10 @@ type TransportConfig struct {
 	// Default (nil): false - providers without proxy_url connect directly
 	// Set to true: providers without proxy_url will use system/environment proxy
 	RespectEnvProxy *bool // nil = use default (false)
+
+	// GlobalProxyURL is a fallback proxy URL for providers that have no per-provider proxy_url set.
+	// Per-provider proxy_url always takes priority. Supports http://, https://, socks5://.
+	GlobalProxyURL string
 }
 
 // Go defaults for reference (not used directly, only for documentation)
@@ -111,6 +115,34 @@ func GetGlobalTransportPool() *TransportPool {
 	return globalTransportPool
 }
 
+// globalProxyURL holds the fallback proxy URL for providers without an explicit per-provider proxy.
+var (
+	globalProxyURLMu  sync.RWMutex
+	globalProxyURLVal string
+)
+
+// SetGlobalProxyURL sets the global fallback proxy URL (thread-safe).
+func SetGlobalProxyURL(u string) {
+	globalProxyURLMu.Lock()
+	defer globalProxyURLMu.Unlock()
+	globalProxyURLVal = u
+}
+
+// GetGlobalProxyURL returns the current global fallback proxy URL (thread-safe).
+func GetGlobalProxyURL() string {
+	globalProxyURLMu.RLock()
+	defer globalProxyURLMu.RUnlock()
+	return globalProxyURLVal
+}
+
+// resolveProxyURL returns providerProxy if non-empty, otherwise falls back to the global proxy URL.
+func resolveProxyURL(providerProxy string) string {
+	if providerProxy != "" {
+		return providerProxy
+	}
+	return GetGlobalProxyURL()
+}
+
 // SetTransportConfig updates the transport pool configuration
 // Pass nil to reset to Go defaults (backward compatible)
 // This affects newly created transports only, existing transports are not modified
@@ -121,8 +153,10 @@ func SetTransportConfig(config *TransportConfig) {
 	globalTransportPool.config = config
 
 	if config == nil {
+		SetGlobalProxyURL("")
 		logrus.Info("Transport pool config reset to Go defaults")
 	} else {
+		SetGlobalProxyURL(config.GlobalProxyURL)
 		maxIdle := "default"
 		maxIdlePerHost := "default"
 		if config.MaxIdleConns != nil {
@@ -131,8 +165,8 @@ func SetTransportConfig(config *TransportConfig) {
 		if config.MaxIdleConnsPerHost != nil {
 			maxIdlePerHost = fmt.Sprintf("%d", *config.MaxIdleConnsPerHost)
 		}
-		logrus.Infof("Transport pool config updated: MaxIdleConns=%s, MaxIdleConnsPerHost=%s",
-			maxIdle, maxIdlePerHost)
+		logrus.Infof("Transport pool config updated: MaxIdleConns=%s, MaxIdleConnsPerHost=%s, GlobalProxyURL=%s",
+			maxIdle, maxIdlePerHost, config.GlobalProxyURL)
 	}
 }
 
@@ -250,6 +284,10 @@ func (tp *TransportPool) respectEnvProxy() bool {
 
 // createTransport creates a new HTTP transport with proxy support
 func (tp *TransportPool) createTransport(proxyURL string) *http.Transport {
+	// Use global proxy as fallback when no provider-specific proxy is set
+	if proxyURL == "" && tp.config != nil && tp.config.GlobalProxyURL != "" {
+		proxyURL = tp.config.GlobalProxyURL
+	}
 	if proxyURL == "" {
 		// Clone default transport for connection pool settings, then clear proxy
 		// unless the user has explicitly opted into env proxy via RespectEnvProxy.

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -144,6 +144,11 @@ type HTTPTransportConfig struct {
 	// Default (nil): false - providers without proxy_url connect directly
 	// Set to true: providers without proxy_url will use system/environment proxy
 	RespectEnvProxy *bool `json:"respect_env_proxy,omitempty" yaml:"respect_env_proxy,omitempty"`
+
+	// GlobalProxyURL is a global fallback proxy URL for all providers that have no per-provider proxy_url.
+	// Per-provider proxy_url always takes priority. Supports http://, https://, socks5://.
+	// Example: "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
+	GlobalProxyURL string `json:"global_proxy_url,omitempty" yaml:"global_proxy_url,omitempty"`
 }
 
 // MultiTenantConfig holds settings for multi-tenant API token authentication
@@ -2036,7 +2041,8 @@ func (c *Config) ApplyHTTPTransportConfig() {
 		c.HTTPTransport.MaxIdleConnsPerHost == nil &&
 		c.HTTPTransport.MaxConnsPerHost == nil &&
 		c.HTTPTransport.DisableKeepAlives == nil &&
-		c.HTTPTransport.RespectEnvProxy == nil {
+		c.HTTPTransport.RespectEnvProxy == nil &&
+		c.HTTPTransport.GlobalProxyURL == "" {
 		// No custom transport config, use Go defaults (backward compatible with TB)
 		return
 	}
@@ -2049,6 +2055,7 @@ func (c *Config) ApplyHTTPTransportConfig() {
 		MaxConnsPerHost:     c.HTTPTransport.MaxConnsPerHost,
 		DisableKeepAlives:   c.HTTPTransport.DisableKeepAlives,
 		RespectEnvProxy:     c.HTTPTransport.RespectEnvProxy,
+		GlobalProxyURL:      c.HTTPTransport.GlobalProxyURL,
 	}
 	client.SetTransportConfig(config)
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -145,9 +145,8 @@ type HTTPTransportConfig struct {
 	// Set to true: providers without proxy_url will use system/environment proxy
 	RespectEnvProxy *bool `json:"respect_env_proxy,omitempty" yaml:"respect_env_proxy,omitempty"`
 
-	// GlobalProxyURL is a global fallback proxy URL for all providers that have no per-provider proxy_url.
-	// Per-provider proxy_url always takes priority. Supports http://, https://, socks5://.
-	// Example: "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
+	// GlobalProxyURL stores a shared proxy URL offered as a UI convenience default.
+	// The backend does NOT apply it automatically; users must explicitly opt in per-provider/OAuth.
 	GlobalProxyURL string `json:"global_proxy_url,omitempty" yaml:"global_proxy_url,omitempty"`
 }
 
@@ -2041,8 +2040,7 @@ func (c *Config) ApplyHTTPTransportConfig() {
 		c.HTTPTransport.MaxIdleConnsPerHost == nil &&
 		c.HTTPTransport.MaxConnsPerHost == nil &&
 		c.HTTPTransport.DisableKeepAlives == nil &&
-		c.HTTPTransport.RespectEnvProxy == nil &&
-		c.HTTPTransport.GlobalProxyURL == "" {
+		c.HTTPTransport.RespectEnvProxy == nil {
 		// No custom transport config, use Go defaults (backward compatible with TB)
 		return
 	}
@@ -2055,7 +2053,6 @@ func (c *Config) ApplyHTTPTransportConfig() {
 		MaxConnsPerHost:     c.HTTPTransport.MaxConnsPerHost,
 		DisableKeepAlives:   c.HTTPTransport.DisableKeepAlives,
 		RespectEnvProxy:     c.HTTPTransport.RespectEnvProxy,
-		GlobalProxyURL:      c.HTTPTransport.GlobalProxyURL,
 	}
 	client.SetTransportConfig(config)
 }

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -55,7 +55,8 @@ func NewHandler(cfg *config.Config, host string) *Handler {
 
 // HTTPTransportConfigUpdate represents the update request for HTTP transport settings
 type HTTPTransportConfigUpdate struct {
-	RespectEnvProxy *bool `json:"respect_env_proxy"` // nil = no change
+	RespectEnvProxy *bool   `json:"respect_env_proxy"` // nil = no change
+	GlobalProxyURL  *string `json:"global_proxy_url"`  // nil = no change; "" = clear
 }
 
 // GetConfig returns the current system configuration
@@ -75,6 +76,7 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		"data": gin.H{
 			"http_transport": gin.H{
 				"respect_env_proxy": cfg.HTTPTransport.RespectEnvProxy,
+				"global_proxy_url":  cfg.HTTPTransport.GlobalProxyURL,
 			},
 		},
 	}
@@ -110,6 +112,11 @@ func (h *Handler) UpdateConfig(c *gin.Context) {
 		cfg.HTTPTransport.RespectEnvProxy = req.HTTPTransport.RespectEnvProxy
 	}
 
+	// Update global_proxy_url if provided (pointer allows distinguishing "not sent" from "clear")
+	if req.HTTPTransport.GlobalProxyURL != nil {
+		cfg.HTTPTransport.GlobalProxyURL = *req.HTTPTransport.GlobalProxyURL
+	}
+
 	// Save the configuration
 	if err := cfg.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -127,6 +134,7 @@ func (h *Handler) UpdateConfig(c *gin.Context) {
 		"data": gin.H{
 			"http_transport": gin.H{
 				"respect_env_proxy": cfg.HTTPTransport.RespectEnvProxy,
+				"global_proxy_url":  cfg.HTTPTransport.GlobalProxyURL,
 			},
 		},
 	})


### PR DESCRIPTION
## What

Adds a global proxy URL setting so users don't need to retype the same proxy address every time they add a new provider or start an OAuth flow.

The global URL is stored in system config and exposed via the existing `/api/v1/config` endpoint. It is **not** applied automatically — users must explicitly opt in per provider or per OAuth session via a checkbox.

## Changes

### Backend
- `internal/server/config/config.go` — adds `GlobalProxyURL` field to `HTTPTransportConfig` (JSON: `global_proxy_url`)
- `internal/server/module/configapply/handler.go` — exposes `global_proxy_url` in GET/PUT `/api/v1/config`; no automatic transport-layer fallback

### Frontend
- **System Settings** — new "Global Proxy URL" text field with Save button; width capped so it doesn't stretch the full card
- **Add Provider dialog** — "Use global proxy" checkbox below the Proxy URL field (right-aligned, mirrors the "No API Key Required" pattern); always visible in add mode, disabled with a hint when no global URL is configured
- **OAuth dialog** — same checkbox pattern below the proxy URL field
- Checkbox state is persisted to `localStorage` per dialog so the choice carries over to the next session

## Behaviour

| Scenario | Result |
|---|---|
| Global URL set, checkbox unchecked | Provider saved without proxy |
| Global URL set, checkbox checked | Global URL copied into provider's `proxy_url` on submit |
| Per-provider `proxy_url` already set | Used as-is; global URL is irrelevant |
| No global URL configured | Checkbox shown but disabled; tooltip guides user to System Settings |

## Not changed
- Transport pool and HTTP client logic — no silent fallback; `proxy_url` on the provider record is the single source of truth

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtByG24z1DAty1WWqEZ2gx)_