### PR TITLE
feat(config): implement agent config rotation and restore

### DIFF
--- a/internal/agent/apply.go
+++ b/internal/agent/apply.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
@@ -295,6 +297,103 @@ func (aa *AgentApply) collectBackupPaths(results ...*serverconfig.ApplyResult) [
 		}
 	}
 	return paths
+}
+
+// RestoreAgent restores all config files for the given agent type from their
+// most recent backup. Each file is handled independently — a missing backup
+// for one file does not abort the others; per-file outcomes are summarised in
+// the returned RestoreAgentResult.
+//
+// Routing rules and other in-process state are NOT touched: backups only cover
+// the on-disk config files. Re-run `agent apply` afterward to bring rules back
+// in sync if needed.
+func (aa *AgentApply) RestoreAgent(req *RestoreAgentRequest) (*RestoreAgentResult, error) {
+	if !req.AgentType.IsValid() {
+		return nil, fmt.Errorf("unknown agent type: %s", req.AgentType)
+	}
+
+	info, ok := GetAgentInfo(req.AgentType)
+	if !ok {
+		return nil, fmt.Errorf("no info registered for agent type: %s", req.AgentType)
+	}
+
+	result := &RestoreAgentResult{AgentType: req.AgentType}
+
+	for _, displayPath := range info.ConfigFiles {
+		realPath, err := expandUser(displayPath)
+		if err != nil {
+			result.Failures = append(result.Failures,
+				fmt.Sprintf("%s: %v", displayPath, err))
+			continue
+		}
+		r, err := serverconfig.RestoreLatestBackup(realPath)
+		if err != nil {
+			msg := fmt.Sprintf("%s: %v", displayPath, err)
+			if r != nil && r.Message != "" {
+				msg = fmt.Sprintf("%s: %s", displayPath, r.Message)
+			}
+			result.Failures = append(result.Failures, msg)
+			continue
+		}
+		result.RestoredFiles = append(result.RestoredFiles,
+			fmt.Sprintf("%s <- %s", displayPath, r.RestoredFrom))
+		if r.PreRestoreBackup != "" {
+			result.PreRestoreBackups = append(result.PreRestoreBackups, r.PreRestoreBackup)
+		}
+	}
+
+	result.Success = len(result.RestoredFiles) > 0 && len(result.Failures) == 0
+	result.Message = aa.buildRestoreMessage(result)
+	return result, nil
+}
+
+// expandUser resolves a leading "~" or "~/" in p against the current user's
+// home directory. Other paths are returned unchanged.
+func expandUser(p string) (string, error) {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		if p == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, p[2:]), nil
+	}
+	return p, nil
+}
+
+// buildRestoreMessage formats a human-readable summary of a restore run.
+func (aa *AgentApply) buildRestoreMessage(result *RestoreAgentResult) string {
+	var sb strings.Builder
+	if result.Success {
+		sb.WriteString(fmt.Sprintf("Restored configuration for %s\n", result.AgentType))
+	} else if len(result.RestoredFiles) > 0 {
+		sb.WriteString(fmt.Sprintf("Partial restore for %s\n", result.AgentType))
+	} else {
+		sb.WriteString(fmt.Sprintf("Restore failed for %s\n", result.AgentType))
+	}
+
+	if len(result.RestoredFiles) > 0 {
+		sb.WriteString("\nRestored files:\n")
+		for _, f := range result.RestoredFiles {
+			sb.WriteString(fmt.Sprintf("  - %s\n", f))
+		}
+	}
+	if len(result.PreRestoreBackups) > 0 {
+		sb.WriteString("\nPre-restore safety backups (used to roll back this restore):\n")
+		for _, p := range result.PreRestoreBackups {
+			sb.WriteString(fmt.Sprintf("  - %s\n", p))
+		}
+	}
+	if len(result.Failures) > 0 {
+		sb.WriteString("\nFailures:\n")
+		for _, m := range result.Failures {
+			sb.WriteString(fmt.Sprintf("  - %s\n", m))
+		}
+	}
+	sb.WriteString("\nNote: routing rules are not part of the backup. Run `agent apply` to resync them if needed.\n")
+	return sb.String()
 }
 
 // buildResultMessage builds a human-readable result message

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -85,6 +85,41 @@ type ApplyAgentResult struct {
 	Message string
 }
 
+// RestoreAgentRequest represents a request to restore agent configuration
+// from the most recent on-disk backup.
+type RestoreAgentRequest struct {
+	// AgentType is the type of agent to restore (required)
+	AgentType AgentType
+
+	// Force skips confirmation prompts (CLI use)
+	Force bool
+}
+
+// RestoreAgentResult represents the result of restoring agent configuration.
+type RestoreAgentResult struct {
+	// Success is true only when every relevant config file was restored
+	// without error.
+	Success bool
+
+	// AgentType is the type of agent that was restored.
+	AgentType AgentType
+
+	// RestoredFiles lists "<original> <- <backup>" entries for files that
+	// were successfully restored.
+	RestoredFiles []string
+
+	// PreRestoreBackups lists the safety snapshots taken of each live file
+	// before the restore overwrote it.
+	PreRestoreBackups []string
+
+	// Failures lists per-file error messages, e.g. "no backup found".
+	// Non-empty Failures with empty RestoredFiles means Success == false.
+	Failures []string
+
+	// Message is a human-readable summary suitable for CLI output.
+	Message string
+}
+
 // AgentInfo provides information about an agent type
 type AgentInfo struct {
 	// Type is the agent type

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -28,8 +28,96 @@ config files and to TinglyBox routing rules.`,
 	cmd.AddCommand(agentApplyCommand(appManager))
 	cmd.AddCommand(agentListCommand(appManager))
 	cmd.AddCommand(agentShowCommand(appManager))
+	cmd.AddCommand(agentRestoreCommand(appManager))
 
 	return cmd
+}
+
+// agentRestoreCommand creates the restore subcommand. It rolls back an agent's
+// on-disk config files to their most recent backup, taking a "pre-restore"
+// safety snapshot of each live file first.
+func agentRestoreCommand(appManager *AppManager) *cobra.Command {
+	var req agent.RestoreAgentRequest
+
+	cmd := &cobra.Command{
+		Use:   "restore [agent-type]",
+		Short: "Restore agent configuration from the most recent backup",
+		Long: `Restore an agent's config files from the most recent backup created by
+'agent apply'. A pre-restore safety snapshot is taken of each live file
+before the restore overwrites it, so you can roll the restore back if
+something looks wrong.
+
+Routing rules are not part of the backup. After a restore, run 'agent apply'
+to bring routing rules back in sync if needed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(os.Stdin)
+
+			if len(args) == 0 {
+				agentType, err := promptForAgentTypeChoice(reader)
+				if err != nil {
+					return err
+				}
+				req.AgentType = agentType
+			} else {
+				req.AgentType = agent.AgentType(args[0])
+				if !req.AgentType.IsValid() {
+					fmt.Fprintf(os.Stderr, "Unknown agent type: %s\n\n", args[0])
+					return cmd.Usage()
+				}
+			}
+
+			info, ok := agent.GetAgentInfo(req.AgentType)
+			if !ok {
+				return fmt.Errorf("no info registered for agent type: %s", req.AgentType)
+			}
+
+			if !req.Force {
+				fmt.Println("\nFiles that will be restored from their most recent backup:")
+				for _, f := range info.ConfigFiles {
+					fmt.Printf("  - %s\n", f)
+				}
+				fmt.Print("\nProceed? [y/N]: ")
+				input, err := reader.ReadString('\n')
+				if err != nil {
+					return err
+				}
+				input = strings.TrimSpace(strings.ToLower(input))
+				if input != "y" && input != "yes" {
+					return fmt.Errorf("cancelled by user")
+				}
+			}
+
+			return executeAgentRestore(appManager, &req)
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			types := []string{string(agent.AgentTypeClaudeCode), string(agent.AgentTypeOpenCode)}
+			return types, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+
+	cmd.Flags().BoolVar(&req.Force, "force", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+// executeAgentRestore performs the agent restore and prints the result.
+func executeAgentRestore(appManager *AppManager, req *agent.RestoreAgentRequest) error {
+	globalConfig := appManager.GetGlobalConfig()
+	host := "127.0.0.1"
+
+	agentApply := agent.NewAgentApply(globalConfig, host)
+	result, err := agentApply.RestoreAgent(req)
+	if err != nil {
+		return fmt.Errorf("failed to restore configuration: %w", err)
+	}
+
+	fmt.Println("\n" + result.Message)
+
+	if !result.Success {
+		return fmt.Errorf("restore did not complete successfully")
+	}
+	return nil
 }
 
 // agentApplyCommand creates the apply subcommand

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -6,10 +6,21 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/internal"
 )
+
+// defaultBackupRetention is the default number of backup files to keep per
+// original config file. Older backups beyond this count are removed by
+// rotateBackups after each new backup is created.
+const defaultBackupRetention = 3
+
+// backupTimestampLayout matches the timestamp format embedded in backup
+// filenames produced by generateBackupPath.
+const backupTimestampLayout = "20060102-150405"
 
 // ApplyResult contains the result of applying a configuration
 type ApplyResult struct {
@@ -52,9 +63,17 @@ func generateBackupPath(originalPath string) string {
 	return filepath.Join(backupDir, fmt.Sprintf("%s.bak-%s%s", base, timestamp, ext))
 }
 
-// backupFile creates a backup of the existing file
+// backupFile creates a backup of the existing file and rotates older backups
+// matching the same originalPath, keeping at most defaultBackupRetention copies.
+// Rotation failures are logged but do not fail the backup itself, since the
+// fresh backup has already been written successfully.
 func backupFile(path string) (string, error) {
-	// Read the original file
+	return backupFileWithRetention(path, defaultBackupRetention)
+}
+
+// backupFileWithRetention is like backupFile but allows overriding the
+// retention count. retention <= 0 falls back to defaultBackupRetention.
+func backupFileWithRetention(path string, retention int) (string, error) {
 	src, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to open original file: %w", err)
@@ -63,7 +82,6 @@ func backupFile(path string) (string, error) {
 
 	backupPath := generateBackupPath(path)
 
-	// Ensure backup directory exists
 	if err := os.MkdirAll(filepath.Dir(backupPath), 0755); err != nil {
 		return "", fmt.Errorf("failed to create backup directory: %w", err)
 	}
@@ -78,7 +96,167 @@ func backupFile(path string) (string, error) {
 		return "", fmt.Errorf("failed to copy to backup: %w", err)
 	}
 
+	if retention <= 0 {
+		retention = defaultBackupRetention
+	}
+	// Best-effort rotation: a failure here must not invalidate the
+	// freshly-written backup that the caller now depends on.
+	_ = rotateBackups(path, retention)
+
 	return backupPath, nil
+}
+
+// BackupInfo describes a single backup file for an original config path.
+type BackupInfo struct {
+	Path      string    `json:"path"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ListBackups returns all backup files for originalPath in <dir>/backup/,
+// ordered newest-first. Files that do not match the
+// "<base>.bak-<timestamp><ext>" pattern are ignored.
+func ListBackups(originalPath string) ([]BackupInfo, error) {
+	dir := filepath.Dir(originalPath)
+	base := filepath.Base(originalPath)
+	ext := filepath.Ext(originalPath)
+	backupDir := filepath.Join(dir, "backup")
+	prefix := base + ".bak-"
+
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	var backups []BackupInfo
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ext) {
+			continue
+		}
+		stamp := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ext)
+		ts, err := time.ParseInLocation(backupTimestampLayout, stamp, time.Local)
+		if err != nil {
+			continue
+		}
+		backups = append(backups, BackupInfo{
+			Path:      filepath.Join(backupDir, name),
+			Timestamp: ts,
+		})
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Timestamp.After(backups[j].Timestamp)
+	})
+	return backups, nil
+}
+
+// rotateBackups deletes older backups for originalPath, keeping at most the
+// `keep` most recent ones. keep <= 0 falls back to defaultBackupRetention.
+func rotateBackups(originalPath string, keep int) error {
+	if keep <= 0 {
+		keep = defaultBackupRetention
+	}
+	backups, err := ListBackups(originalPath)
+	if err != nil {
+		return err
+	}
+	if len(backups) <= keep {
+		return nil
+	}
+	var firstErr error
+	for _, b := range backups[keep:] {
+		if err := os.Remove(b.Path); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// RestoreResult describes the outcome of restoring a single config file.
+type RestoreResult struct {
+	Success          bool   `json:"success"`
+	OriginalPath     string `json:"originalPath"`
+	RestoredFrom     string `json:"restoredFrom,omitempty"`
+	PreRestoreBackup string `json:"preRestoreBackup,omitempty"`
+	Message          string `json:"message"`
+}
+
+// RestoreLatestBackup restores originalPath from its most recent backup.
+// If originalPath currently exists, a "pre-restore" backup of the live file
+// is created first (and is itself subject to rotation) so the restore is
+// reversible.
+func RestoreLatestBackup(originalPath string) (*RestoreResult, error) {
+	result := &RestoreResult{OriginalPath: originalPath}
+
+	backups, err := ListBackups(originalPath)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to list backups: %v", err)
+		return result, err
+	}
+	if len(backups) == 0 {
+		result.Message = fmt.Sprintf("No backup found for %s", originalPath)
+		return result, fmt.Errorf("no backup found for %s", originalPath)
+	}
+
+	latest := backups[0]
+	result.RestoredFrom = latest.Path
+
+	if _, err := os.Stat(originalPath); err == nil {
+		preBackup, err := backupFile(originalPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create pre-restore backup: %v", err)
+			return result, err
+		}
+		result.PreRestoreBackup = preBackup
+	} else if !os.IsNotExist(err) {
+		result.Message = fmt.Sprintf("Failed to stat original file: %v", err)
+		return result, err
+	}
+
+	if err := ensureDir(originalPath); err != nil {
+		result.Message = fmt.Sprintf("Failed to ensure target directory: %v", err)
+		return result, err
+	}
+
+	if err := copyFile(latest.Path, originalPath); err != nil {
+		result.Message = fmt.Sprintf("Failed to restore from backup: %v", err)
+		return result, err
+	}
+
+	result.Success = true
+	if result.PreRestoreBackup != "" {
+		result.Message = fmt.Sprintf("Restored %s from %s (pre-restore backup: %s)",
+			originalPath, latest.Path, result.PreRestoreBackup)
+	} else {
+		result.Message = fmt.Sprintf("Restored %s from %s", originalPath, latest.Path)
+	}
+	return result, nil
+}
+
+// copyFile copies src to dst, truncating dst if it exists.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ensureDir ensures the directory for the given path exists
@@ -91,8 +269,9 @@ func ensureDir(path string) error {
 type ApplyOption func(*applyOptions)
 
 type applyOptions struct {
-	backup bool
-	extras map[string]any
+	backup    bool
+	retention int
+	extras    map[string]any
 }
 
 // WithBackup enables or disables backup when applying settings.
@@ -100,6 +279,14 @@ type applyOptions struct {
 func WithBackup(enable bool) ApplyOption {
 	return func(opts *applyOptions) {
 		opts.backup = enable
+	}
+}
+
+// WithBackupRetention overrides the default number of backups to keep
+// after rotation. n <= 0 means use the package default.
+func WithBackupRetention(n int) ApplyOption {
+	return func(opts *applyOptions) {
+		opts.retention = n
 	}
 }
 
@@ -155,7 +342,7 @@ func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, opts ..
 
 		// Only create backup if enabled
 		if applyOpts.backup {
-			backupPath, err := backupFile(targetPath)
+			backupPath, err := backupFileWithRetention(targetPath, applyOpts.retention)
 			if err != nil {
 				result.Message = fmt.Sprintf("Failed to create backup: %v", err)
 				return result, nil

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -589,6 +590,198 @@ func TestApplyClaudeSettingsToPath_MultipleWithExtra(t *testing.T) {
 
 	if sl["command"] != "/path/to/script.sh" {
 		t.Errorf("Expected statusLine command to be '/path/to/script.sh', got: %v", sl["command"])
+	}
+}
+
+// writeFakeBackup synthesizes a backup file at <dir>/backup/ with a controlled
+// timestamp embedded in its filename. Used by rotation tests to avoid the
+// 1-second granularity of the real timestamping path.
+func writeFakeBackup(t *testing.T, originalPath string, ts time.Time, content string) string {
+	t.Helper()
+	dir := filepath.Dir(originalPath)
+	base := filepath.Base(originalPath)
+	ext := filepath.Ext(originalPath)
+	backupDir := filepath.Join(dir, "backup")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		t.Fatalf("mkdir backup: %v", err)
+	}
+	name := fmt.Sprintf("%s.bak-%s%s", base, ts.Format(backupTimestampLayout), ext)
+	path := filepath.Join(backupDir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write fake backup: %v", err)
+	}
+	return path
+}
+
+func TestBackupRotation_KeepsLatestN(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	targetPath := filepath.Join(tempDir, "settings.json")
+	if err := os.WriteFile(targetPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Synthesize 6 backups spaced 10 seconds apart.
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.Local)
+	var paths []string
+	for i := 0; i < 6; i++ {
+		paths = append(paths, writeFakeBackup(t, targetPath, base.Add(time.Duration(i)*10*time.Second), fmt.Sprintf("v%d", i)))
+	}
+
+	if err := rotateBackups(targetPath, 3); err != nil {
+		t.Fatalf("rotateBackups: %v", err)
+	}
+
+	backups, err := ListBackups(targetPath)
+	if err != nil {
+		t.Fatalf("ListBackups: %v", err)
+	}
+	if len(backups) != 3 {
+		t.Fatalf("Expected 3 backups after rotation, got %d", len(backups))
+	}
+	// The 3 newest must be the last 3 we created.
+	expected := map[string]bool{paths[3]: true, paths[4]: true, paths[5]: true}
+	for _, b := range backups {
+		if !expected[b.Path] {
+			t.Errorf("Unexpected backup retained: %s", b.Path)
+		}
+	}
+	// Order is newest-first.
+	for i := 1; i < len(backups); i++ {
+		if !backups[i-1].Timestamp.After(backups[i].Timestamp) {
+			t.Errorf("Backups not in descending order")
+		}
+	}
+}
+
+func TestBackupRotation_DoesNotTouchOtherBaseFiles(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	settings := filepath.Join(tempDir, "settings.json")
+	other := filepath.Join(tempDir, "other.json")
+	if err := os.WriteFile(settings, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+	if err := os.WriteFile(other, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("seed other: %v", err)
+	}
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.Local)
+	otherBackup := writeFakeBackup(t, other, base, "x")
+	for i := 0; i < 5; i++ {
+		writeFakeBackup(t, settings, base.Add(time.Duration(i)*10*time.Second), fmt.Sprintf("s%d", i))
+	}
+
+	if err := rotateBackups(settings, defaultBackupRetention); err != nil {
+		t.Fatalf("rotateBackups: %v", err)
+	}
+
+	if _, err := os.Stat(otherBackup); err != nil {
+		t.Errorf("Rotation of settings.json removed unrelated backup %s: %v", otherBackup, err)
+	}
+
+	settingsBackups, err := ListBackups(settings)
+	if err != nil {
+		t.Fatalf("ListBackups(settings): %v", err)
+	}
+	if len(settingsBackups) != defaultBackupRetention {
+		t.Errorf("Expected %d settings backups, got %d", defaultBackupRetention, len(settingsBackups))
+	}
+}
+
+func TestRestoreLatestBackup_RoundTrip(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	targetPath := filepath.Join(tempDir, "settings.json")
+	original := []byte(`{"version":"original"}`)
+	mutated := []byte(`{"version":"mutated"}`)
+
+	// Seed a synthetic backup that holds the "original" content.
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.Local)
+	backupPath := writeFakeBackup(t, targetPath, base, string(original))
+
+	// Live file holds the mutated state we want to undo.
+	if err := os.WriteFile(targetPath, mutated, 0644); err != nil {
+		t.Fatalf("seed live: %v", err)
+	}
+
+	result, err := RestoreLatestBackup(targetPath)
+	if err != nil {
+		t.Fatalf("RestoreLatestBackup: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Restore not successful: %s", result.Message)
+	}
+	if result.RestoredFrom != backupPath {
+		t.Errorf("Restored from %q, want %q", result.RestoredFrom, backupPath)
+	}
+	if result.PreRestoreBackup == "" {
+		t.Errorf("Expected a pre-restore backup to be created")
+	}
+
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("Restored content mismatch: got %s, want %s", got, original)
+	}
+
+	preData, err := os.ReadFile(result.PreRestoreBackup)
+	if err != nil {
+		t.Fatalf("read pre-restore backup: %v", err)
+	}
+	if string(preData) != string(mutated) {
+		t.Errorf("Pre-restore backup mismatch: got %s, want %s", preData, mutated)
+	}
+}
+
+func TestRestoreLatestBackup_NoBackup(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	targetPath := filepath.Join(tempDir, "settings.json")
+	if err := os.WriteFile(targetPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	result, err := RestoreLatestBackup(targetPath)
+	if err == nil {
+		t.Fatalf("Expected error when no backup exists, got nil")
+	}
+	if result == nil || result.Success {
+		t.Errorf("Expected unsuccessful result, got %+v", result)
+	}
+}
+
+func TestListBackups_MissingDir(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "tingly-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	backups, err := ListBackups(filepath.Join(tempDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("ListBackups should not error on missing backup dir: %v", err)
+	}
+	if len(backups) != 0 {
+		t.Errorf("Expected no backups, got %d", len(backups))
 	}
 }
 

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -394,6 +394,65 @@ func (h *Handler) ApplyOpenCodeConfigFromState(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+// RestoreClaudeConfig rolls back Claude Code config files to their most
+// recent backup. Mirrors the CLI 'agent restore claude-code' flow.
+func (h *Handler) RestoreClaudeConfig(c *gin.Context) {
+	h.restoreAgent(c, agent.AgentTypeClaudeCode)
+}
+
+// RestoreOpenCodeConfig rolls back OpenCode config files to their most
+// recent backup. Mirrors the CLI 'agent restore opencode' flow.
+func (h *Handler) RestoreOpenCodeConfig(c *gin.Context) {
+	h.restoreAgent(c, agent.AgentTypeOpenCode)
+}
+
+// restoreAgent runs the shared restore flow for the given agent type and
+// writes the appropriate JSON response.
+func (h *Handler) restoreAgent(c *gin.Context, agentType agent.AgentType) {
+	if h.config == nil {
+		c.JSON(http.StatusInternalServerError, RestoreConfigResponse{
+			Success: false,
+			Message: "Global config not available",
+		})
+		return
+	}
+
+	host := h.host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	apply := agent.NewAgentApply(h.config, host)
+
+	result, err := apply.RestoreAgent(&agent.RestoreAgentRequest{
+		AgentType: agentType,
+		Force:     true,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, RestoreConfigResponse{
+			Success:   false,
+			AgentType: string(agentType),
+			Message:   "Restore failed: " + err.Error(),
+		})
+		return
+	}
+
+	resp := RestoreConfigResponse{
+		Success:           result.Success,
+		AgentType:         string(result.AgentType),
+		RestoredFiles:     result.RestoredFiles,
+		PreRestoreBackups: result.PreRestoreBackups,
+		Failures:          result.Failures,
+		Message:           result.Message,
+	}
+	if !result.Success {
+		// Still return 200 so the structured payload reaches the client; the
+		// "success" field and Failures already convey the error state.
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
 // GetOpenCodeConfigPreview generates OpenCode configuration preview from system state
 // This endpoint returns the config JSON for display purposes without applying it
 func (h *Handler) GetOpenCodeConfigPreview(c *gin.Context) {

--- a/internal/server/module/configapply/routes.go
+++ b/internal/server/module/configapply/routes.go
@@ -36,4 +36,17 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithTags("config"),
 		swagger.WithResponseModel(OpenCodeConfigPreviewResponse{}),
 	)
+
+	// Config restore endpoints - roll back to the most recent on-disk backup.
+	router.POST("/config/restore/claude", handler.RestoreClaudeConfig,
+		swagger.WithDescription("Restore Claude Code configuration from the most recent backup"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(RestoreConfigResponse{}),
+	)
+
+	router.POST("/config/restore/opencode", handler.RestoreOpenCodeConfig,
+		swagger.WithDescription("Restore OpenCode configuration from the most recent backup"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(RestoreConfigResponse{}),
+	)
 }

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -27,3 +27,15 @@ type OpenCodeConfigPreviewResponse struct {
 	ScriptUnix string `json:"scriptUnix"`
 	Message    string `json:"message,omitempty"`
 }
+
+// RestoreConfigResponse is the response for the restore endpoints. It mirrors
+// the agent.RestoreAgentResult so callers can drive UI from the same data
+// the CLI prints.
+type RestoreConfigResponse struct {
+	Success           bool     `json:"success"`
+	AgentType         string   `json:"agentType"`
+	RestoredFiles     []string `json:"restoredFiles"`
+	PreRestoreBackups []string `json:"preRestoreBackups"`
+	Failures          []string `json:"failures,omitempty"`
+	Message           string   `json:"message"`
+}


### PR DESCRIPTION
Agent quick-config "apply" used to leave backups untouched, so ~/.claude/backup/ and ~/.config/opencode/backup/ accumulated indefinitely with no way to roll back. 

Now each backup write rotates older copies down to the 3 most recent (configurable via WithBackupRetention), and a new restore flow brings the live config back from the latest backup, taking a pre-restore safety snapshot first so the operation is itself reversible.

Surface area:
- internal/server/config: rotateBackups + ListBackups + RestoreLatestBackup
- internal/agent: RestoreAgent orchestrates per-agent file restore
- internal/command: `tingly-box agent restore <agent-type>`
- internal/server/module/configapply: POST /config/restore/{claude,opencode}