### PR TITLE
refactor(typ): migrate provider types to public packages

### DIFF
--- a/common/provider/types.go
+++ b/common/provider/types.go
@@ -1,0 +1,106 @@
+// Package provider provides types for AI provider configuration and authentication.
+// These types are used across multiple components and are part of the public API.
+package provider
+
+import (
+	"time"
+
+	"github.com/tingly-dev/tingly-box/protocol"
+)
+
+// AuthType represents the authentication type for a provider
+type AuthType string
+
+const (
+	AuthTypeAPIKey AuthType = "api_key"
+	AuthTypeOAuth  AuthType = "oauth"
+)
+
+// OAuthDetail contains OAuth-specific authentication information
+type OAuthDetail struct {
+	AccessToken  string                 `json:"access_token"`  // OAuth access token
+	ProviderType string                 `json:"provider_type"` // anthropic, google, etc. for token manager lookup
+	UserID       string                 `json:"user_id"`       // OAuth user identifier
+	RefreshToken string                 `json:"refresh_token"` // Token for refreshing access token
+	ExpiresAt    string                 `json:"expires_at"`    // Token expiration time (RFC3339)
+	ExtraFields  map[string]interface{} `json:"extra_fields"`  // Any extra field for some special clients
+}
+
+// IsExpired checks if the OAuth token is expired
+func (o *OAuthDetail) IsExpired() bool {
+	if o == nil || o.ExpiresAt == "" {
+		return false
+	}
+	// Parse RFC3339 timestamp and check if expired
+	expiryTime, err := time.Parse(time.RFC3339, o.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return time.Now().Add(5 * time.Minute).After(expiryTime) // Consider expired if within 5 minutes
+}
+
+// Provider represents an AI model api key and provider configuration
+type Provider struct {
+	UUID          string            `json:"uuid"`
+	Name          string            `json:"name"`
+	APIBase       string            `json:"api_base"`
+	APIStyle      protocol.APIStyle `json:"api_style"` // "openai" or "anthropic", defaults to "openai"
+	Token         string            `json:"token"`     // API key for api_key auth type
+	NoKeyRequired bool              `json:"no_key_required"`
+	Enabled       bool              `json:"enabled"`
+	ProxyURL      string            `json:"proxy_url"`              // HTTP or SOCKS proxy URL (e.g., "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080")
+	Timeout       int64             `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
+	Tags          []string          `json:"tags,omitempty"`         // Provider tags for categorization
+	Models        []string          `json:"models,omitempty"`       // Available models for this provider (cached)
+	LastUpdated   string            `json:"last_updated,omitempty"` // Last update timestamp
+
+	// Auth configuration
+	AuthType    AuthType     `json:"auth_type"`              // api_key or oauth
+	OAuthDetail *OAuthDetail `json:"oauth_detail,omitempty"` // OAuth credentials (only for oauth auth type)
+}
+
+// GetAccessToken returns the access token based on auth type
+func (p *Provider) GetAccessToken() string {
+	switch p.AuthType {
+	case AuthTypeOAuth:
+		if p.OAuthDetail != nil {
+			return p.OAuthDetail.AccessToken
+		}
+	case AuthTypeAPIKey, "":
+		// Default to api_key for backward compatibility
+		return p.Token
+	}
+	return ""
+}
+
+// IsOAuthExpired checks if the OAuth token is expired (only valid for oauth auth type)
+func (p *Provider) IsOAuthExpired() bool {
+	if p.AuthType == AuthTypeOAuth && p.OAuthDetail != nil {
+		return p.OAuthDetail.IsExpired()
+	}
+	return false
+}
+
+// IsOAuthToken checks if the current access token is an OAuth token
+// by detecting the sk-ant-oat prefix. This provides runtime detection
+// independent of the AuthType field.
+func (p *Provider) IsOAuthToken() bool {
+	token := p.GetAccessToken()
+	if token == "" {
+		return false
+	}
+	// Claude OAuth tokens start with sk-ant-oat
+	const oAuthPrefix = "sk-ant-oat"
+	if len(token) >= len(oAuthPrefix) {
+		return token[:len(oAuthPrefix)] == oAuthPrefix
+	}
+	return false
+}
+
+// IsClaudeCodeProvider checks if this provider is using Claude Code OAuth
+func (p *Provider) IsClaudeCodeProvider() bool {
+	if p.AuthType == AuthTypeOAuth && p.OAuthDetail != nil {
+		return p.OAuthDetail.ProviderType == "claude_code"
+	}
+	return false
+}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -2,11 +2,11 @@ package typ
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
-	"github.com/tingly-dev/tingly-box/internal/protocol"
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+
+	"github.com/tingly-dev/tingly-box/common/provider"
 )
 
 // FlexibleBool is a boolean type that can unmarshal from both bool and int (0/1)
@@ -186,22 +186,18 @@ func (sc *ScenarioConfig) GetDefaultFlags() ScenarioFlags {
 }
 
 // AuthType represents the authentication type for a provider
-type AuthType string
+// Type alias for backward compatibility with common/provider
+type AuthType = provider.AuthType
 
+// AuthType constants - re-exported for backward compatibility
 const (
-	AuthTypeAPIKey AuthType = "api_key"
-	AuthTypeOAuth  AuthType = "oauth"
+	AuthTypeAPIKey = provider.AuthTypeAPIKey
+	AuthTypeOAuth  = provider.AuthTypeOAuth
 )
 
 // OAuthDetail contains OAuth-specific authentication information
-type OAuthDetail struct {
-	AccessToken  string                 `json:"access_token"`  // OAuth access token
-	ProviderType string                 `json:"provider_type"` // anthropic, google, etc. for token manager lookup
-	UserID       string                 `json:"user_id"`       // OAuth user identifier
-	RefreshToken string                 `json:"refresh_token"` // Token for refreshing access token
-	ExpiresAt    string                 `json:"expires_at"`    // Token expiration time (RFC3339)
-	ExtraFields  map[string]interface{} `json:"extra_fields"`  // Any extra field for some special clients
-}
+// Type alias for backward compatibility with common/provider
+type OAuthDetail = provider.OAuthDetail
 
 // MCPMode defines MCP runtime mode
 type MCPMode string
@@ -357,84 +353,9 @@ func IsMCPSourceEnabled(source MCPSourceConfig) bool {
 	return source.Enabled == nil || *source.Enabled
 }
 
-// IsExpired checks if the OAuth token is expired
-func (o *OAuthDetail) IsExpired() bool {
-	if o == nil || o.ExpiresAt == "" {
-		return false
-	}
-	// Parse RFC3339 timestamp and check if expired
-	expiryTime, err := time.Parse(time.RFC3339, o.ExpiresAt)
-	if err != nil {
-		return false
-	}
-	return time.Now().Add(5 * time.Minute).After(expiryTime) // Consider expired if within 5 minutes
-}
-
 // Provider represents an AI model api key and provider configuration
-type Provider struct {
-	UUID          string            `json:"uuid"`
-	Name          string            `json:"name"`
-	APIBase       string            `json:"api_base"`
-	APIStyle      protocol.APIStyle `json:"api_style"` // "openai" or "anthropic", defaults to "openai"
-	Token         string            `json:"token"`     // API key for api_key auth type
-	NoKeyRequired bool              `json:"no_key_required"`
-	Enabled       bool              `json:"enabled"`
-	ProxyURL      string            `json:"proxy_url"`              // HTTP or SOCKS proxy URL (e.g., "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080")
-	Timeout       int64             `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
-	Tags          []string          `json:"tags,omitempty"`         // Provider tags for categorization
-	Models        []string          `json:"models,omitempty"`       // Available models for this provider (cached)
-	LastUpdated   string            `json:"last_updated,omitempty"` // Last update timestamp
-
-	// Auth configuration
-	AuthType    AuthType     `json:"auth_type"`              // api_key or oauth
-	OAuthDetail *OAuthDetail `json:"oauth_detail,omitempty"` // OAuth credentials (only for oauth auth type)
-}
-
-// GetAccessToken returns the access token based on auth type
-func (p *Provider) GetAccessToken() string {
-	switch p.AuthType {
-	case AuthTypeOAuth:
-		if p.OAuthDetail != nil {
-			return p.OAuthDetail.AccessToken
-		}
-	case AuthTypeAPIKey, "":
-		// Default to api_key for backward compatibility
-		return p.Token
-	}
-	return ""
-}
-
-// IsOAuthExpired checks if the OAuth token is expired (only valid for oauth auth type)
-func (p *Provider) IsOAuthExpired() bool {
-	if p.AuthType == AuthTypeOAuth && p.OAuthDetail != nil {
-		return p.OAuthDetail.IsExpired()
-	}
-	return false
-}
-
-// IsOAuthToken checks if the current access token is an OAuth token
-// by detecting the sk-ant-oat prefix. This provides runtime detection
-// independent of the AuthType field.
-func (p *Provider) IsOAuthToken() bool {
-	token := p.GetAccessToken()
-	if token == "" {
-		return false
-	}
-	// Claude OAuth tokens start with sk-ant-oat
-	const oAuthPrefix = "sk-ant-oat"
-	if len(token) >= len(oAuthPrefix) {
-		return token[:len(oAuthPrefix)] == oAuthPrefix
-	}
-	return false
-}
-
-// IsClaudeCodeProvider checks if this provider is using Claude Code OAuth
-func (p *Provider) IsClaudeCodeProvider() bool {
-	if p.AuthType == AuthTypeOAuth && p.OAuthDetail != nil {
-		return p.OAuthDetail.ProviderType == "claude_code"
-	}
-	return false
-}
+// Type alias for backward compatibility with common/provider
+type Provider = provider.Provider
 
 // Rule represents a request/response configuration with load balancing support
 type Rule struct {

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -1,0 +1,38 @@
+// Package protocol provides public API aliases to internal protocol types.
+// This package enables external consumers to use protocol types without
+// depending on internal packages.
+//
+// For future migrations: add new type aliases here as types are promoted
+// to public API.
+package protocol
+
+import internalprotocol "github.com/tingly-dev/tingly-box/internal/protocol"
+
+// Type aliases to internal protocol types
+type APIStyle = internalprotocol.APIStyle
+type APIType = internalprotocol.APIType
+type Client = internalprotocol.Client
+type TokenUsage = internalprotocol.TokenUsage
+type OpenAIConfig = internalprotocol.OpenAIConfig
+
+// Re-export constants
+const (
+	APIStyleOpenAI    APIStyle = internalprotocol.APIStyleOpenAI
+	APIStyleAnthropic APIStyle = internalprotocol.APIStyleAnthropic
+	APIStyleGoogle    APIStyle = internalprotocol.APIStyleGoogle
+
+	TypeOpenAIChat      APIType = internalprotocol.TypeOpenAIChat
+	TypeOpenAIResponses APIType = internalprotocol.TypeOpenAIResponses
+	TypeAnthropicV1     APIType = internalprotocol.TypeAnthropicV1
+	TypeAnthropicBeta   APIType = internalprotocol.TypeAnthropicBeta
+	TypeGoogle          APIType = internalprotocol.TypeGoogle
+
+	CodexAPIBase = internalprotocol.CodexAPIBase
+)
+
+// Re-export functions
+var (
+	NewTokenUsage          = internalprotocol.NewTokenUsage
+	NewTokenUsageWithCache = internalprotocol.NewTokenUsageWithCache
+	ZeroTokenUsage         = internalprotocol.ZeroTokenUsage
+)


### PR DESCRIPTION
Migrate Provider, AuthType, and OAuthDetail types from internal/typ to public packages following the new migration pattern:

- Create protocol/ package with aliases to internal/protocol types
- Create common/provider/ package for provider-related types
- Update internal/typ/type.go to use aliases for backward compatibility

This establishes a pattern for future migrations of internal types to public API while maintaining zero breaking changes through type aliases.