### PR TITLE
feat(ux): design landing page for LLM provider setup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -286,8 +286,11 @@ const OnboardingGate: React.FC = () => {
                 const result = await api.getProviders();
                 if (cancelled) return;
                 const providers = Array.isArray(result?.data) ? result.data : [];
+                // No providers? Force onboarding, regardless of previous activity
                 if (providers.length === 0) {
                     setTarget('/onboarding');
+                    // Clear the previous activity path to avoid redirect loops
+                    localStorage.removeItem('layout.activeActivity');
                     return;
                 }
             } catch {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { ContentCopy, Error as ErrorIcon, GitHub, AppRegistration as NPM, Refres
 import { Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Divider, IconButton, Paper, Stack, Typography } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -19,6 +19,8 @@ import createAppTheme from './theme';
 
 import Login from './pages/Login';
 import Guiding from './pages/Guiding';
+import Onboarding from './pages/Onboarding';
+import { api } from './services/api';
 import APITokensPage from './pages/APITokensPage';
 import UseOpenAIPage from './pages/scenario/UseOpenAIPage';
 import UseAnthropicPage from './pages/scenario/UseAnthropicPage';
@@ -269,6 +271,40 @@ const AppDialogs = () => {
     );
 };
 
+// OnboardingGate decides where a freshly-authenticated user lands. Brand-new
+// installs (no provider configured) get sent to /onboarding; everyone else
+// returns to the last visited activity, with the existing /agent/claude_code
+// fallback. We hit /api/v2/providers once on mount; while in flight we render
+// nothing to avoid a flash of the default agent page.
+const OnboardingGate: React.FC = () => {
+    const [target, setTarget] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const result = await api.getProviders();
+                if (cancelled) return;
+                const providers = Array.isArray(result?.data) ? result.data : [];
+                if (providers.length === 0) {
+                    setTarget('/onboarding');
+                    return;
+                }
+            } catch {
+                // Swallow the error and fall through to the default activity —
+                // failing the gate should never lock the user out of the app.
+            }
+            const activeActivity = localStorage.getItem('layout.activeActivity') || 'scenario';
+            const fallback = localStorage.getItem(`layout.activityPath.${activeActivity}`) || '/agent/claude_code';
+            if (!cancelled) setTarget(fallback);
+        })();
+        return () => { cancelled = true; };
+    }, []);
+
+    if (target === null) return null;
+    return <Navigate to={target} replace />;
+};
+
 function AppContent() {
     const navigate = useNavigate();
 
@@ -296,13 +332,11 @@ function AppContent() {
                         </ProtectedRoute>
                     }
                 >
-                    {/* Default redirect - use layout memory (localStorage), fallback to agent page */}
-                    <Route index element={<Navigate to={
-                        (() => {
-                            const activeActivity = localStorage.getItem('layout.activeActivity') || 'scenario';
-                            return localStorage.getItem(`layout.activityPath.${activeActivity}`) || '/agent/claude_code';
-                        })()
-                    } replace />} />
+                    {/* Default landing: send first-time users (no providers) to onboarding,
+                        everyone else to their last-active activity. */}
+                    <Route index element={<OnboardingGate />} />
+                    {/* Onboarding for new installs */}
+                    <Route path="/onboarding" element={<Onboarding />} />
                     {/* Function panel routes */}
                     <Route path="/agent/openai" element={<UseOpenAIPage />} />
                     <Route path="/agent/anthropic" element={<UseAnthropicPage />} />

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -126,11 +126,14 @@ const ProviderFormDialog = ({
         [selectedProvider]
     );
 
-    // Find the matching template only when the dialog opens in edit mode.
-    // Depend on `open` (a stable boolean transition) rather than `data.apiBase`
-    // so that typing in the field doesn't recompute this and re-trigger init.
+    // Find the matching template only when the dialog opens. Depend on
+    // `open` (a stable boolean transition) rather than `data.apiBase` so that
+    // typing in the field doesn't recompute this and re-trigger init.
+    // We resolve in both modes so prefilled add-mode data (e.g. picked from
+    // onboarding) shows the provider in the Autocomplete instead of blank.
     const matchingProvider = useMemo(() => {
-        if (!open || mode !== 'edit') return null;
+        if (!open) return null;
+        if (!data.apiBase) return null;
         return (
             allProviders.find(
                 p =>
@@ -139,7 +142,7 @@ const ProviderFormDialog = ({
             ) || null
         );
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [open, mode, allProviders]);
+    }, [open, allProviders]);
 
     const ProtocolBaseUrlDisplay: React.FC<{ url: string }> = ({url}) => {
         if (!url) return null;
@@ -208,8 +211,15 @@ const ProviderFormDialog = ({
                 setProtocolOpenAI(false);
                 setProtocolAnthropic(false);
             }
-            setSelectedProvider(null);
-            setProviderInputValue('');
+            // If the parent prefilled apiBase to a known provider (onboarding
+            // browse / paste-detect), seed the Autocomplete with it so users
+            // see the picked provider rather than a blank field.
+            setSelectedProvider(matchingProvider);
+            setProviderInputValue(
+                matchingProvider
+                    ? matchingProvider.alias || matchingProvider.name
+                    : data.apiBase || ''
+            );
         }
 
         // Restore "use global proxy" checkbox state from localStorage (add mode only)

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -134,11 +134,10 @@ const ProviderFormDialog = ({
     const matchingProvider = useMemo(() => {
         if (!open) return null;
         if (!data.apiBase) return null;
+        // Match by apiBase alone - this handles onboarding prefills where apiStyle is undefined
         return (
             allProviders.find(
-                p =>
-                    (p.baseUrlOpenAI === data.apiBase && data.apiStyle === 'openai') ||
-                    (p.baseUrlAnthropic === data.apiBase && data.apiStyle === 'anthropic')
+                p => p.baseUrlOpenAI === data.apiBase || p.baseUrlAnthropic === data.apiBase
             ) || null
         );
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -207,6 +206,11 @@ const ProviderFormDialog = ({
             } else if (data.apiStyle) {
                 setProtocolOpenAI(data.apiStyle === 'openai');
                 setProtocolAnthropic(data.apiStyle === 'anthropic');
+            } else if (matchingProvider) {
+                // When apiBase matches a known provider (e.g., from onboarding),
+                // auto-select the provider's supported protocols
+                setProtocolOpenAI(!!matchingProvider.baseUrlOpenAI);
+                setProtocolAnthropic(!!matchingProvider.baseUrlAnthropic);
             } else {
                 setProtocolOpenAI(false);
                 setProtocolAnthropic(false);

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -871,8 +871,16 @@ const ProviderFormDialog = ({
                         variant="outlined"
                         color="warning"
                         size="small"
-                        disabled={!hasAnyProtocol}
-                        onClick={() => onForceAdd?.()}
+                        disabled={!hasAnyProtocol || verifying}
+                        onClick={async () => {
+                            // Make sure any free-form text in the provider input is committed
+                            if (!selectedProvider && data.apiBase !== providerInputValue) {
+                                onChangeRef.current('apiBase', providerInputValue);
+                                onChangeRef.current('providerBaseUrls', undefined);
+                            }
+                            onClose();
+                            await onForceAdd?.();
+                        }}
                         title="Skip connectivity check and save anyway. The provider may not work correctly if the connection fails."
                         sx={{
                             '&.Mui-disabled': {

--- a/frontend/src/components/UnifiedCard.tsx
+++ b/frontend/src/components/UnifiedCard.tsx
@@ -161,7 +161,19 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
               </Box>
             </Box>
             {subtitle && (
-              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: 'text.secondary',
+                  maxWidth: '800px',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  lineHeight: 1.5,
+                }}
+              >
                 {subtitle}
               </Typography>
             )}

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -1,0 +1,162 @@
+import {useMemo, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {
+    Box,
+    Card,
+    CardActionArea,
+    Chip,
+    InputAdornment,
+    Stack,
+    TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+    Typography,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ProviderIcon from '@/components/ProviderIcon';
+import {useProviderTemplates, type UniqueProvider} from '@/services/serviceProviders';
+import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
+
+type ProtocolFilter = 'all' | 'openai' | 'anthropic' | 'both';
+
+interface BrowseProvidersProps {
+    onPick: (prefill: EnhancedProviderFormData) => void;
+}
+
+const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
+    const {t} = useTranslation();
+    const providers = useProviderTemplates();
+    const [search, setSearch] = useState('');
+    const [protocolFilter, setProtocolFilter] = useState<ProtocolFilter>('all');
+
+    const filtered = useMemo(() => {
+        const term = search.trim().toLowerCase();
+        return providers.filter(p => {
+            if (term) {
+                const haystack = `${p.name} ${p.alias || ''}`.toLowerCase();
+                if (!haystack.includes(term)) return false;
+            }
+            switch (protocolFilter) {
+                case 'openai':
+                    return p.supportsOpenAI && !p.supportsAnthropic;
+                case 'anthropic':
+                    return p.supportsAnthropic && !p.supportsOpenAI;
+                case 'both':
+                    return p.supportsOpenAI && p.supportsAnthropic;
+                default:
+                    return true;
+            }
+        });
+    }, [providers, search, protocolFilter]);
+
+    const handlePick = (p: UniqueProvider) => {
+        const apiStyle: 'openai' | 'anthropic' = p.supportsOpenAI ? 'openai' : 'anthropic';
+        const apiBase = apiStyle === 'openai' ? p.baseUrlOpenAI || p.baseUrlAnthropic || '' : p.baseUrlAnthropic || p.baseUrlOpenAI || '';
+        const protocols: ('openai' | 'anthropic')[] = [];
+        if (p.supportsOpenAI) protocols.push('openai');
+        if (p.supportsAnthropic) protocols.push('anthropic');
+        onPick({
+            name: p.alias || p.name,
+            apiBase,
+            apiStyle,
+            token: '',
+            enabled: true,
+            protocols,
+            providerBaseUrls: {
+                openai: p.baseUrlOpenAI,
+                anthropic: p.baseUrlAnthropic,
+            },
+        });
+    };
+
+    return (
+        <Box>
+            <Stack direction={{xs: 'column', sm: 'row'}} spacing={2} sx={{mb: 2}}>
+                <TextField
+                    size="small"
+                    fullWidth
+                    placeholder={t('onboarding.browse.searchPlaceholder', {defaultValue: 'Search providers'})}
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    InputProps={{
+                        startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon fontSize="small"/>
+                            </InputAdornment>
+                        ),
+                    }}
+                />
+                <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={protocolFilter}
+                    onChange={(_, v) => v && setProtocolFilter(v)}
+                >
+                    <ToggleButton value="all">{t('onboarding.browse.all', {defaultValue: 'All'})}</ToggleButton>
+                    <ToggleButton value="openai">OpenAI</ToggleButton>
+                    <ToggleButton value="anthropic">Anthropic</ToggleButton>
+                    <ToggleButton value="both">{t('onboarding.browse.both', {defaultValue: 'Both'})}</ToggleButton>
+                </ToggleButtonGroup>
+            </Stack>
+
+            {filtered.length === 0 ? (
+                <Box sx={{py: 6, textAlign: 'center'}}>
+                    <Typography variant="body2" color="text.secondary">
+                        {t('onboarding.browse.empty', {defaultValue: 'No providers match your filters.'})}
+                    </Typography>
+                </Box>
+            ) : (
+                <Box
+                    sx={{
+                        display: 'grid',
+                        gap: 1.5,
+                        gridTemplateColumns: {
+                            xs: '1fr',
+                            sm: 'repeat(2, 1fr)',
+                            md: 'repeat(3, 1fr)',
+                            lg: 'repeat(4, 1fr)',
+                        },
+                    }}
+                >
+                    {filtered.map(p => (
+                        <Card key={p.id} variant="outlined" sx={{borderRadius: 2}}>
+                            <CardActionArea onClick={() => handlePick(p)} sx={{p: 1.5, height: '100%'}}>
+                                <Stack direction="row" spacing={1.5} alignItems="center">
+                                    <ProviderIcon identifier={p.icon || p.id} size={28}/>
+                                    <Box sx={{minWidth: 0}}>
+                                        <Typography
+                                            variant="subtitle2"
+                                            fontWeight={600}
+                                            noWrap
+                                            title={p.alias || p.name}
+                                        >
+                                            {p.alias || p.name}
+                                        </Typography>
+                                        <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
+                                            {p.supportsOpenAI && (
+                                                <Chip
+                                                    label="OpenAI"
+                                                    size="small"
+                                                    sx={{height: 18, fontSize: '0.65rem'}}
+                                                />
+                                            )}
+                                            {p.supportsAnthropic && (
+                                                <Chip
+                                                    label="Anthropic"
+                                                    size="small"
+                                                    sx={{height: 18, fontSize: '0.65rem'}}
+                                                />
+                                            )}
+                                        </Stack>
+                                    </Box>
+                                </Stack>
+                            </CardActionArea>
+                        </Card>
+                    ))}
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default BrowseProviders;

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -90,7 +90,7 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                             xs: '1fr',
                             sm: 'repeat(2, 1fr)',
                             md: 'repeat(3, 1fr)',
-                            lg: 'repeat(4, 1fr)',
+                            xl: 'repeat(4, 1fr)',
                         },
                     }}
                 >

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -100,11 +100,18 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                                 <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between" width="100%">
                                     <Stack direction="row" spacing={1.5} alignItems="center">
                                         <ProviderIcon identifier={p.icon || p.id} size={32}/>
-                                        <Box>
+                                        <Box sx={{minWidth: 0, flex: 1}}>
                                             <Typography
                                                 variant="subtitle2"
                                                 fontWeight={600}
-                                                noWrap
+                                                sx={{
+                                                    overflow: 'hidden',
+                                                    textOverflow: 'ellipsis',
+                                                    display: '-webkit-box',
+                                                    WebkitLineClamp: 2,
+                                                    WebkitBoxOrient: 'vertical',
+                                                    lineHeight: 1.3,
+                                                }}
                                                 title={p.alias || p.name}
                                             >
                                                 {p.alias || p.name}

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -8,16 +8,12 @@ import {
     InputAdornment,
     Stack,
     TextField,
-    ToggleButton,
-    ToggleButtonGroup,
     Typography,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ProviderIcon from '@/components/ProviderIcon';
 import {useProviderTemplates, type UniqueProvider} from '@/services/serviceProviders';
 import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
-
-type ProtocolFilter = 'all' | 'openai' | 'anthropic' | 'both';
 
 interface BrowseProvidersProps {
     onPick: (prefill: EnhancedProviderFormData) => void;
@@ -27,27 +23,15 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
     const {t} = useTranslation();
     const providers = useProviderTemplates();
     const [search, setSearch] = useState('');
-    const [protocolFilter, setProtocolFilter] = useState<ProtocolFilter>('all');
 
     const filtered = useMemo(() => {
         const term = search.trim().toLowerCase();
+        if (!term) return providers;
         return providers.filter(p => {
-            if (term) {
-                const haystack = `${p.name} ${p.alias || ''}`.toLowerCase();
-                if (!haystack.includes(term)) return false;
-            }
-            switch (protocolFilter) {
-                case 'openai':
-                    return p.supportsOpenAI && !p.supportsAnthropic;
-                case 'anthropic':
-                    return p.supportsAnthropic && !p.supportsOpenAI;
-                case 'both':
-                    return p.supportsOpenAI && p.supportsAnthropic;
-                default:
-                    return true;
-            }
+            const haystack = `${p.name} ${p.alias || ''}`.toLowerCase();
+            return haystack.includes(term);
         });
-    }, [providers, search, protocolFilter]);
+    }, [providers, search]);
 
     const handlePick = (p: UniqueProvider) => {
         const apiStyle: 'openai' | 'anthropic' = p.supportsOpenAI ? 'openai' : 'anthropic';
@@ -71,7 +55,7 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
 
     return (
         <Box>
-            <Stack direction={{xs: 'column', sm: 'row'}} spacing={2} sx={{mb: 2}}>
+            <Box sx={{mb: 2}}>
                 <TextField
                     size="small"
                     fullWidth
@@ -86,18 +70,7 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                         ),
                     }}
                 />
-                <ToggleButtonGroup
-                    size="small"
-                    exclusive
-                    value={protocolFilter}
-                    onChange={(_, v) => v && setProtocolFilter(v)}
-                >
-                    <ToggleButton value="all">{t('onboarding.browse.all', {defaultValue: 'All'})}</ToggleButton>
-                    <ToggleButton value="openai">OpenAI</ToggleButton>
-                    <ToggleButton value="anthropic">Anthropic</ToggleButton>
-                    <ToggleButton value="both">{t('onboarding.browse.both', {defaultValue: 'Both'})}</ToggleButton>
-                </ToggleButtonGroup>
-            </Stack>
+            </Box>
 
             {filtered.length === 0 ? (
                 <Box sx={{py: 6, textAlign: 'center'}}>

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -5,12 +5,15 @@ import {
     Card,
     CardActionArea,
     Chip,
+    IconButton,
     InputAdornment,
     Stack,
     TextField,
     Typography,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
+import LanguageIcon from '@mui/icons-material/Language';
+import DescriptionIcon from '@mui/icons-material/Description';
 import ProviderIcon from '@/components/ProviderIcon';
 import {useProviderTemplates, type UniqueProvider} from '@/services/serviceProviders';
 import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
@@ -93,35 +96,63 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                 >
                     {filtered.map(p => (
                         <Card key={p.id} variant="outlined" sx={{borderRadius: 2}}>
-                            <CardActionArea onClick={() => handlePick(p)} sx={{p: 1.5, height: '100%'}}>
-                                <Stack direction="row" spacing={1.5} alignItems="center">
-                                    <ProviderIcon identifier={p.icon || p.id} size={28}/>
-                                    <Box sx={{minWidth: 0}}>
-                                        <Typography
-                                            variant="subtitle2"
-                                            fontWeight={600}
-                                            noWrap
-                                            title={p.alias || p.name}
-                                        >
-                                            {p.alias || p.name}
-                                        </Typography>
-                                        <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
-                                            {p.supportsOpenAI && (
-                                                <Chip
-                                                    label="OpenAI"
-                                                    size="small"
-                                                    sx={{height: 18, fontSize: '0.65rem'}}
-                                                />
-                                            )}
-                                            {p.supportsAnthropic && (
-                                                <Chip
-                                                    label="Anthropic"
-                                                    size="small"
-                                                    sx={{height: 18, fontSize: '0.65rem'}}
-                                                />
-                                            )}
-                                        </Stack>
-                                    </Box>
+                            <CardActionArea onClick={() => handlePick(p)} sx={{p: 1.5}}>
+                                <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between" width="100%">
+                                    <Stack direction="row" spacing={1.5} alignItems="center">
+                                        <ProviderIcon identifier={p.icon || p.id} size={32}/>
+                                        <Box>
+                                            <Typography
+                                                variant="subtitle2"
+                                                fontWeight={600}
+                                                noWrap
+                                                title={p.alias || p.name}
+                                            >
+                                                {p.alias || p.name}
+                                            </Typography>
+                                            <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
+                                                {p.supportsOpenAI && (
+                                                    <Chip
+                                                        label="OpenAI"
+                                                        size="small"
+                                                        sx={{height: 18, fontSize: '0.65rem'}}
+                                                    />
+                                                )}
+                                                {p.supportsAnthropic && (
+                                                    <Chip
+                                                        label="Anthropic"
+                                                        size="small"
+                                                        sx={{height: 18, fontSize: '0.65rem'}}
+                                                    />
+                                                )}
+                                            </Stack>
+                                        </Box>
+                                    </Stack>
+                                    <Stack direction="row" spacing={0.3}>
+                                        {p.website && (
+                                            <IconButton
+                                                size="small"
+                                                href={p.website}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                title="Official Website"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <LanguageIcon fontSize="small" />
+                                            </IconButton>
+                                        )}
+                                        {p.apiDoc && (
+                                            <IconButton
+                                                size="small"
+                                                href={p.apiDoc}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                title="API Documentation"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <DescriptionIcon fontSize="small" />
+                                            </IconButton>
+                                        )}
+                                    </Stack>
                                 </Stack>
                             </CardActionArea>
                         </Card>

--- a/frontend/src/components/onboarding/PasteAndDetect.tsx
+++ b/frontend/src/components/onboarding/PasteAndDetect.tsx
@@ -1,0 +1,204 @@
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import ProviderIcon from '@/components/ProviderIcon';
+import {extractOnboardingCandidates, type OnboardingCandidate} from '@/services/onboardingExtract';
+import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
+
+interface PasteAndDetectProps {
+    onPick: (prefill: EnhancedProviderFormData) => void;
+    onManualFill: () => void;
+}
+
+const PLACEHOLDER = `# .env
+OPENAI_API_KEY=sk-proj-...
+OPENAI_BASE_URL=https://api.openai.com/v1
+
+# or paste a curl snippet
+curl https://api.anthropic.com/v1/messages \\
+  -H "x-api-key: sk-ant-..."
+`;
+
+const maskToken = (raw?: string) => {
+    if (!raw) return '';
+    if (raw.length <= 8) return '•'.repeat(raw.length);
+    return raw.slice(0, 4) + '…' + raw.slice(-4);
+};
+
+const confidenceLabel = (c: number) => {
+    if (c >= 0.8) return 'high';
+    if (c >= 0.5) return 'medium';
+    return 'low';
+};
+
+const confidenceColor = (c: number): 'success' | 'warning' | 'default' => {
+    if (c >= 0.8) return 'success';
+    if (c >= 0.5) return 'warning';
+    return 'default';
+};
+
+const PasteAndDetect: React.FC<PasteAndDetectProps> = ({onPick, onManualFill}) => {
+    const {t} = useTranslation();
+    const [input, setInput] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [candidates, setCandidates] = useState<OnboardingCandidate[] | null>(null);
+    const [warnings, setWarnings] = useState<string[]>([]);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleDetect = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await extractOnboardingCandidates(input);
+            if (!res.success) {
+                setError(res.error || 'Extraction failed');
+                setCandidates([]);
+                setWarnings([]);
+                return;
+            }
+            setCandidates(res.candidates);
+            setWarnings(res.warnings);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleUse = (c: OnboardingCandidate) => {
+        const apiStyle = (c.api_style === 'anthropic' ? 'anthropic' : 'openai') as 'openai' | 'anthropic';
+        const protocols: ('openai' | 'anthropic')[] = (c.protocols || []).filter(
+            (p): p is 'openai' | 'anthropic' => p === 'openai' || p === 'anthropic',
+        );
+        onPick({
+            name: c.name,
+            apiBase: c.base_url || '',
+            apiStyle,
+            token: c.token || '',
+            enabled: true,
+            protocols: protocols.length ? protocols : [apiStyle],
+        });
+    };
+
+    return (
+        <Box>
+            <TextField
+                fullWidth
+                multiline
+                minRows={6}
+                maxRows={14}
+                value={input}
+                onChange={e => setInput(e.target.value)}
+                placeholder={PLACEHOLDER}
+                spellCheck={false}
+                inputProps={{style: {fontFamily: 'monospace', fontSize: 13}}}
+            />
+
+            <Stack direction="row" spacing={1.5} sx={{mt: 1.5}}>
+                <Button
+                    variant="contained"
+                    startIcon={loading ? <CircularProgress size={16} color="inherit"/> : <AutoFixHighIcon/>}
+                    onClick={handleDetect}
+                    disabled={loading || !input.trim()}
+                >
+                    {t('onboarding.paste.detectButton', {defaultValue: 'Detect'})}
+                </Button>
+                <Button variant="text" onClick={onManualFill}>
+                    {t('onboarding.paste.manualFill', {defaultValue: 'Fill in manually'})}
+                </Button>
+            </Stack>
+
+            {error && (
+                <Alert severity="error" sx={{mt: 2}}>
+                    {error}
+                </Alert>
+            )}
+
+            {warnings.map((w, i) => (
+                <Alert key={i} severity="warning" sx={{mt: 2}}>
+                    {w}
+                </Alert>
+            ))}
+
+            {candidates !== null && (
+                <Box sx={{mt: 2}}>
+                    {candidates.length === 0 ? (
+                        <Alert severity="info">
+                            {t('onboarding.paste.noMatch', {
+                                defaultValue: 'Could not detect a known provider. You can fill in the form manually.',
+                            })}
+                        </Alert>
+                    ) : (
+                        <Stack spacing={1.5}>
+                            {candidates.map(c => (
+                                <Card key={c.provider_id} variant="outlined">
+                                    <CardContent sx={{py: 1.5, '&:last-child': {pb: 1.5}}}>
+                                        <Stack direction="row" spacing={2} alignItems="center">
+                                            <ProviderIcon identifier={c.icon || c.provider_id} size={32}/>
+                                            <Box sx={{flex: 1, minWidth: 0}}>
+                                                <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 0.5}}>
+                                                    <Typography variant="subtitle2" fontWeight={600}>
+                                                        {c.name}
+                                                    </Typography>
+                                                    <Chip
+                                                        size="small"
+                                                        label={`${confidenceLabel(c.confidence)} · ${Math.round(c.confidence * 100)}%`}
+                                                        color={confidenceColor(c.confidence)}
+                                                        sx={{height: 18, fontSize: '0.65rem'}}
+                                                    />
+                                                    {c.api_style && (
+                                                        <Chip
+                                                            size="small"
+                                                            label={c.api_style}
+                                                            variant="outlined"
+                                                            sx={{height: 18, fontSize: '0.65rem'}}
+                                                        />
+                                                    )}
+                                                </Stack>
+                                                <Typography
+                                                    variant="caption"
+                                                    color="text.secondary"
+                                                    sx={{display: 'block', wordBreak: 'break-all'}}
+                                                >
+                                                    {c.base_url || '—'}
+                                                    {c.token ? ` · key: ${maskToken(c.token)}` : ''}
+                                                </Typography>
+                                                {c.match_reasons && c.match_reasons.length > 0 && (
+                                                    <Stack direction="row" spacing={0.5} sx={{mt: 0.5, flexWrap: 'wrap', gap: 0.5}}>
+                                                        {c.match_reasons.map((r, i) => (
+                                                            <Chip
+                                                                key={i}
+                                                                label={r}
+                                                                size="small"
+                                                                sx={{height: 16, fontSize: '0.6rem'}}
+                                                            />
+                                                        ))}
+                                                    </Stack>
+                                                )}
+                                            </Box>
+                                            <Button variant="contained" size="small" onClick={() => handleUse(c)}>
+                                                {t('onboarding.candidate.useThis', {defaultValue: 'Use this'})}
+                                            </Button>
+                                        </Stack>
+                                    </CardContent>
+                                </Card>
+                            ))}
+                        </Stack>
+                    )}
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default PasteAndDetect;

--- a/frontend/src/components/onboarding/PasteAndDetect.tsx
+++ b/frontend/src/components/onboarding/PasteAndDetect.tsx
@@ -4,17 +4,20 @@ import {
     Alert,
     Box,
     Button,
-    Card,
-    CardContent,
     Chip,
     CircularProgress,
+    List,
+    ListItemButton,
+    ListItemText,
+    Paper,
     Stack,
     TextField,
     Typography,
 } from '@mui/material';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import ProviderIcon from '@/components/ProviderIcon';
-import {extractOnboardingCandidates, type OnboardingCandidate} from '@/services/onboardingExtract';
+import LinkIcon from '@mui/icons-material/Link';
+import VpnKeyIcon from '@mui/icons-material/VpnKey';
+import {extractOnboardingCandidates, type OnboardingTokenCandidate} from '@/services/onboardingExtract';
 import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
 
 interface PasteAndDetectProps {
@@ -22,40 +25,25 @@ interface PasteAndDetectProps {
     onManualFill: () => void;
 }
 
-const PLACEHOLDER = `# .env
+const PLACEHOLDER = `Paste anything: a .env snippet, a curl command, a JSON config…
+
+# .env
 OPENAI_API_KEY=sk-proj-...
 OPENAI_BASE_URL=https://api.openai.com/v1
 
-# or paste a curl snippet
 curl https://api.anthropic.com/v1/messages \\
   -H "x-api-key: sk-ant-..."
 `;
-
-const maskToken = (raw?: string) => {
-    if (!raw) return '';
-    if (raw.length <= 8) return '•'.repeat(raw.length);
-    return raw.slice(0, 4) + '…' + raw.slice(-4);
-};
-
-const confidenceLabel = (c: number) => {
-    if (c >= 0.8) return 'high';
-    if (c >= 0.5) return 'medium';
-    return 'low';
-};
-
-const confidenceColor = (c: number): 'success' | 'warning' | 'default' => {
-    if (c >= 0.8) return 'success';
-    if (c >= 0.5) return 'warning';
-    return 'default';
-};
 
 const PasteAndDetect: React.FC<PasteAndDetectProps> = ({onPick, onManualFill}) => {
     const {t} = useTranslation();
     const [input, setInput] = useState('');
     const [loading, setLoading] = useState(false);
-    const [candidates, setCandidates] = useState<OnboardingCandidate[] | null>(null);
-    const [warnings, setWarnings] = useState<string[]>([]);
     const [error, setError] = useState<string | null>(null);
+    const [urls, setUrls] = useState<string[] | null>(null);
+    const [tokens, setTokens] = useState<OnboardingTokenCandidate[] | null>(null);
+    const [selectedURL, setSelectedURL] = useState<string | null>(null);
+    const [selectedToken, setSelectedToken] = useState<string | null>(null);
 
     const handleDetect = async () => {
         setLoading(true);
@@ -64,31 +52,38 @@ const PasteAndDetect: React.FC<PasteAndDetectProps> = ({onPick, onManualFill}) =
             const res = await extractOnboardingCandidates(input);
             if (!res.success) {
                 setError(res.error || 'Extraction failed');
-                setCandidates([]);
-                setWarnings([]);
+                setUrls([]);
+                setTokens([]);
+                setSelectedURL(null);
+                setSelectedToken(null);
                 return;
             }
-            setCandidates(res.candidates);
-            setWarnings(res.warnings);
+            setUrls(res.urls);
+            setTokens(res.tokens);
+            // Sensible default: pre-select if there's exactly one of each.
+            setSelectedURL(res.urls.length === 1 ? res.urls[0] : null);
+            setSelectedToken(res.tokens.length === 1 ? res.tokens[0].value : null);
         } finally {
             setLoading(false);
         }
     };
 
-    const handleUse = (c: OnboardingCandidate) => {
-        const apiStyle = (c.api_style === 'anthropic' ? 'anthropic' : 'openai') as 'openai' | 'anthropic';
-        const protocols: ('openai' | 'anthropic')[] = (c.protocols || []).filter(
-            (p): p is 'openai' | 'anthropic' => p === 'openai' || p === 'anthropic',
-        );
+    const handleUseSelected = () => {
+        // Vendor-agnostic: just hand the chosen URL+token to the dialog.
+        // ProviderFormDialog already matches a known provider against
+        // apiBase, fills the rest of the form, and lets the user override
+        // anything before saving.
         onPick({
-            name: c.name,
-            apiBase: c.base_url || '',
-            apiStyle,
-            token: c.token || '',
+            name: '',
+            apiBase: selectedURL || '',
+            apiStyle: undefined,
+            token: selectedToken || '',
             enabled: true,
-            protocols: protocols.length ? protocols : [apiStyle],
         });
     };
+
+    const canUse = !!selectedURL || !!selectedToken;
+    const hasResults = urls !== null;
 
     return (
         <Box>
@@ -124,76 +119,124 @@ const PasteAndDetect: React.FC<PasteAndDetectProps> = ({onPick, onManualFill}) =
                 </Alert>
             )}
 
-            {warnings.map((w, i) => (
-                <Alert key={i} severity="warning" sx={{mt: 2}}>
-                    {w}
-                </Alert>
-            ))}
-
-            {candidates !== null && (
+            {hasResults && (
                 <Box sx={{mt: 2}}>
-                    {candidates.length === 0 ? (
+                    {urls!.length === 0 && tokens!.length === 0 ? (
                         <Alert severity="info">
                             {t('onboarding.paste.noMatch', {
-                                defaultValue: 'Could not detect a known provider. You can fill in the form manually.',
+                                defaultValue: 'No URL or API key detected. You can fill in the form manually.',
                             })}
                         </Alert>
                     ) : (
-                        <Stack spacing={1.5}>
-                            {candidates.map(c => (
-                                <Card key={c.provider_id} variant="outlined">
-                                    <CardContent sx={{py: 1.5, '&:last-child': {pb: 1.5}}}>
-                                        <Stack direction="row" spacing={2} alignItems="center">
-                                            <ProviderIcon identifier={c.icon || c.provider_id} size={32}/>
-                                            <Box sx={{flex: 1, minWidth: 0}}>
-                                                <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 0.5}}>
-                                                    <Typography variant="subtitle2" fontWeight={600}>
-                                                        {c.name}
-                                                    </Typography>
-                                                    <Chip
-                                                        size="small"
-                                                        label={`${confidenceLabel(c.confidence)} · ${Math.round(c.confidence * 100)}%`}
-                                                        color={confidenceColor(c.confidence)}
-                                                        sx={{height: 18, fontSize: '0.65rem'}}
-                                                    />
-                                                    {c.api_style && (
-                                                        <Chip
-                                                            size="small"
-                                                            label={c.api_style}
-                                                            variant="outlined"
-                                                            sx={{height: 18, fontSize: '0.65rem'}}
-                                                        />
-                                                    )}
-                                                </Stack>
-                                                <Typography
-                                                    variant="caption"
-                                                    color="text.secondary"
-                                                    sx={{display: 'block', wordBreak: 'break-all'}}
+                        <>
+                            <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 1.5}}>
+                                {t('onboarding.paste.pickHint', {
+                                    defaultValue: 'Pick the URL and the token you want to use, then click "Use selected".',
+                                })}
+                            </Typography>
+
+                            <Stack direction={{xs: 'column', md: 'row'}} spacing={2}>
+                                <Paper variant="outlined" sx={{flex: 1, p: 1.5, minWidth: 0}}>
+                                    <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+                                        <LinkIcon fontSize="small" color="action"/>
+                                        <Typography variant="subtitle2" fontWeight={600}>
+                                            {t('onboarding.paste.urlsTitle', {defaultValue: 'Detected URLs'})}
+                                        </Typography>
+                                        <Chip label={urls!.length} size="small" sx={{height: 18, fontSize: '0.65rem'}}/>
+                                    </Stack>
+                                    {urls!.length === 0 ? (
+                                        <Typography variant="caption" color="text.secondary">
+                                            {t('onboarding.paste.noURL', {defaultValue: 'No URLs detected.'})}
+                                        </Typography>
+                                    ) : (
+                                        <List dense disablePadding>
+                                            {urls!.map(u => (
+                                                <ListItemButton
+                                                    key={u}
+                                                    selected={selectedURL === u}
+                                                    onClick={() => setSelectedURL(prev => prev === u ? null : u)}
+                                                    sx={{borderRadius: 1, mb: 0.5}}
                                                 >
-                                                    {c.base_url || '—'}
-                                                    {c.token ? ` · key: ${maskToken(c.token)}` : ''}
-                                                </Typography>
-                                                {c.match_reasons && c.match_reasons.length > 0 && (
-                                                    <Stack direction="row" spacing={0.5} sx={{mt: 0.5, flexWrap: 'wrap', gap: 0.5}}>
-                                                        {c.match_reasons.map((r, i) => (
-                                                            <Chip
-                                                                key={i}
-                                                                label={r}
-                                                                size="small"
-                                                                sx={{height: 16, fontSize: '0.6rem'}}
-                                                            />
-                                                        ))}
-                                                    </Stack>
-                                                )}
-                                            </Box>
-                                            <Button variant="contained" size="small" onClick={() => handleUse(c)}>
-                                                {t('onboarding.candidate.useThis', {defaultValue: 'Use this'})}
-                                            </Button>
-                                        </Stack>
-                                    </CardContent>
-                                </Card>
-                            ))}
-                        </Stack>
+                                                    <ListItemText
+                                                        primary={
+                                                            <Typography
+                                                                variant="body2"
+                                                                sx={{fontFamily: 'monospace', wordBreak: 'break-all'}}
+                                                            >
+                                                                {u}
+                                                            </Typography>
+                                                        }
+                                                    />
+                                                </ListItemButton>
+                                            ))}
+                                        </List>
+                                    )}
+                                </Paper>
+
+                                <Paper variant="outlined" sx={{flex: 1, p: 1.5, minWidth: 0}}>
+                                    <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+                                        <VpnKeyIcon fontSize="small" color="action"/>
+                                        <Typography variant="subtitle2" fontWeight={600}>
+                                            {t('onboarding.paste.tokensTitle', {defaultValue: 'Detected tokens'})}
+                                        </Typography>
+                                        <Chip label={tokens!.length} size="small" sx={{height: 18, fontSize: '0.65rem'}}/>
+                                    </Stack>
+                                    {tokens!.length === 0 ? (
+                                        <Typography variant="caption" color="text.secondary">
+                                            {t('onboarding.paste.noToken', {defaultValue: 'No tokens detected.'})}
+                                        </Typography>
+                                    ) : (
+                                        <List dense disablePadding>
+                                            {tokens!.map(tok => (
+                                                <ListItemButton
+                                                    key={tok.value}
+                                                    selected={selectedToken === tok.value}
+                                                    onClick={() => setSelectedToken(prev => prev === tok.value ? null : tok.value)}
+                                                    sx={{borderRadius: 1, mb: 0.5}}
+                                                >
+                                                    <ListItemText
+                                                        primary={
+                                                            <Typography
+                                                                variant="body2"
+                                                                sx={{fontFamily: 'monospace'}}
+                                                            >
+                                                                {tok.preview}
+                                                            </Typography>
+                                                        }
+                                                        secondary={
+                                                            <Typography variant="caption" color="text.secondary">
+                                                                {tok.source}
+                                                            </Typography>
+                                                        }
+                                                    />
+                                                </ListItemButton>
+                                            ))}
+                                        </List>
+                                    )}
+                                </Paper>
+                            </Stack>
+
+                            <Stack direction="row" spacing={1.5} sx={{mt: 2}}>
+                                <Button
+                                    variant="contained"
+                                    onClick={handleUseSelected}
+                                    disabled={!canUse}
+                                >
+                                    {t('onboarding.paste.useSelected', {defaultValue: 'Use selected'})}
+                                </Button>
+                                {(selectedURL || selectedToken) && (
+                                    <Button
+                                        variant="text"
+                                        onClick={() => {
+                                            setSelectedURL(null);
+                                            setSelectedToken(null);
+                                        }}
+                                    >
+                                        {t('common.clear', {defaultValue: 'Clear selection'})}
+                                    </Button>
+                                )}
+                            </Stack>
+                        </>
                     )}
                 </Box>
             )}

--- a/frontend/src/components/onboarding/PasteAndDetect.tsx
+++ b/frontend/src/components/onboarding/PasteAndDetect.tsx
@@ -198,9 +198,9 @@ const PasteAndDetect: React.FC<PasteAndDetectProps> = ({onPick, onManualFill}) =
                                                         primary={
                                                             <Typography
                                                                 variant="body2"
-                                                                sx={{fontFamily: 'monospace'}}
+                                                                sx={{fontFamily: 'monospace', wordBreak: 'break-all'}}
                                                             >
-                                                                {tok.preview}
+                                                                {tok.value}
                                                             </Typography>
                                                         }
                                                         secondary={

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -828,10 +828,13 @@ export default {
     "paste": {
       "detectButton": "Detect",
       "manualFill": "Fill in manually",
-      "noMatch": "Could not detect a known provider. You can fill in the form manually."
-    },
-    "candidate": {
-      "useThis": "Use this"
+      "noMatch": "No URL or API key detected. You can fill in the form manually.",
+      "pickHint": "Pick the URL and the token you want to use, then click \"Use selected\".",
+      "urlsTitle": "Detected URLs",
+      "tokensTitle": "Detected tokens",
+      "noURL": "No URLs detected.",
+      "noToken": "No tokens detected.",
+      "useSelected": "Use selected"
     }
   }
 };

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -821,9 +821,7 @@ export default {
     },
     "browse": {
       "searchPlaceholder": "Search providers",
-      "all": "All",
-      "both": "Both",
-      "empty": "No providers match your filters."
+      "empty": "No providers match your search."
     },
     "paste": {
       "detectButton": "Detect",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -110,7 +110,10 @@ export default {
     "userRequest": "User Request",
     "skills": "Skills",
     "addProfile": "Add Profile",
-    "default": "default"
+    "default": "default",
+    "onboarding": "Quick Add Provider",
+    "onboardingHint": "Browse or paste config",
+    "onboardingShort": "Onboard"
   },
   "health": {
     "connected": "Connected",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -810,5 +810,28 @@ export default {
       "savedError": "Failed to save MCP configuration"
     },
     "currentConfig": "Current Configuration"
+  },
+  "onboarding": {
+    "title": "Welcome to Tingly Box",
+    "subtitle": "Add your first AI provider to get started. Browse the catalog or paste a config snippet — we’ll figure out the rest.",
+    "hint": "Detection runs locally in the box; pasted text is not sent to any third party.",
+    "tab": {
+      "browse": "Browse providers",
+      "paste": "Paste & detect"
+    },
+    "browse": {
+      "searchPlaceholder": "Search providers",
+      "all": "All",
+      "both": "Both",
+      "empty": "No providers match your filters."
+    },
+    "paste": {
+      "detectButton": "Detect",
+      "manualFill": "Fill in manually",
+      "noMatch": "Could not detect a known provider. You can fill in the form manually."
+    },
+    "candidate": {
+      "useThis": "Use this"
+    }
   }
 };

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -824,7 +824,8 @@ export default {
     },
     "browse": {
       "searchPlaceholder": "Search providers",
-      "empty": "No providers match your search."
+      "empty": "No providers match your search.",
+      "selectProvider": "Select this provider"
     },
     "paste": {
       "detectButton": "Detect",
@@ -836,6 +837,9 @@ export default {
       "noURL": "No URLs detected.",
       "noToken": "No tokens detected.",
       "useSelected": "Use selected"
-    }
+    },
+    "quickLinks": "Quick Links",
+    "goToDashboard": "Dashboard",
+    "goToHelp": "Help & Docs"
   }
 };

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -821,8 +821,6 @@ export default {
     },
     "browse": {
       "searchPlaceholder": "搜索提供商",
-      "all": "全部",
-      "both": "双协议",
       "empty": "没有匹配的提供商。"
     },
     "paste": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -810,5 +810,28 @@ export default {
       "savedError": "保存 MCP 配置失败"
     },
     "currentConfig": "当前配置"
+  },
+  "onboarding": {
+    "title": "欢迎使用 Tingly Box",
+    "subtitle": "添加你的第一个 AI 提供商。可以从清单里挑一个，也可以粘贴一段配置文本让系统自动识别。",
+    "hint": "识别完全在本地完成，粘贴的内容不会发送到任何第三方。",
+    "tab": {
+      "browse": "浏览提供商",
+      "paste": "粘贴并识别"
+    },
+    "browse": {
+      "searchPlaceholder": "搜索提供商",
+      "all": "全部",
+      "both": "双协议",
+      "empty": "没有匹配的提供商。"
+    },
+    "paste": {
+      "detectButton": "识别",
+      "manualFill": "手动填写",
+      "noMatch": "未识别到已知的提供商，可以手动填写表单。"
+    },
+    "candidate": {
+      "useThis": "使用此候选"
+    }
   }
 };

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -824,7 +824,8 @@ export default {
     },
     "browse": {
       "searchPlaceholder": "搜索提供商",
-      "empty": "没有匹配的提供商。"
+      "empty": "没有匹配的提供商。",
+      "selectProvider": "选择此提供商"
     },
     "paste": {
       "detectButton": "识别",
@@ -836,6 +837,9 @@ export default {
       "noURL": "未识别到 URL。",
       "noToken": "未识别到 Token。",
       "useSelected": "使用所选"
-    }
+    },
+    "quickLinks": "快速链接",
+    "goToDashboard": "控制台",
+    "goToHelp": "帮助与文档"
   }
 };

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -110,7 +110,10 @@ export default {
     "userRequest": "用户请求",
     "skills": "技能",
     "addProfile": "添加配置文件",
-    "default": "默认"
+    "default": "默认",
+    "onboarding": "快速添加提供商",
+    "onboardingHint": "浏览或粘贴配置",
+    "onboardingShort": "入门"
   },
   "health": {
     "connected": "已连接",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -828,10 +828,13 @@ export default {
     "paste": {
       "detectButton": "识别",
       "manualFill": "手动填写",
-      "noMatch": "未识别到已知的提供商，可以手动填写表单。"
-    },
-    "candidate": {
-      "useThis": "使用此候选"
+      "noMatch": "没有识别到 URL 或 API Key，可以手动填写。",
+      "pickHint": "选择想用的 URL 和 Token，然后点击「使用所选」。",
+      "urlsTitle": "识别到的 URL",
+      "tokensTitle": "识别到的 Token",
+      "noURL": "未识别到 URL。",
+      "noToken": "未识别到 Token。",
+      "useSelected": "使用所选"
     }
   }
 };

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -59,8 +59,10 @@ const Layout = ({ children }: LayoutProps) => {
             if (item.path && isActive(item.path)) return item.key;
             if (item.children && isChildActive(item.children)) return item.key;
         }
+        // Check if saved activity is still valid
         const saved = sessionStorage.getItem('layout.activeActivity') || localStorage.getItem('layout.activeActivity');
         if (saved && activityItems.some(item => item.key === saved)) return saved;
+        // Fallback to 'scenario' (which is valid - it's the agent activity)
         return 'scenario';
     }, [activityItems, location.pathname]);
 
@@ -186,13 +188,29 @@ const Layout = ({ children }: LayoutProps) => {
         sessionStorage.setItem('layout.activeActivity', item.key);
 
         // Priority: saved path > defaultPath > item.path > first non-divider child
-        const savedPath = sessionStorage.getItem(`layout.activityPath.${item.key}`);
+        // But validate that saved path is still valid (exists in current item's children)
+        const savedPath = sessionStorage.getItem(`layout.activityPath.${item.key}`) || localStorage.getItem(`layout.activityPath.${item.key}`);
         const firstNavChild = item.children?.find(c => c.type !== 'divider');
-        const targetPath =
-            savedPath ||
-            item.defaultPath ||
-            item.path ||
-            firstNavChild?.path;
+
+        // Validate saved path - check if it still exists in this activity's children
+        let targetPath: string | undefined;
+        if (savedPath && item.children) {
+            const isValidPath = item.children.some(c => c.type !== 'divider' && c.path === savedPath);
+            if (isValidPath) {
+                targetPath = savedPath;
+            }
+        }
+
+        // Fall back to default options if saved path is invalid
+        if (!targetPath) {
+            targetPath = item.defaultPath || item.path || firstNavChild?.path;
+        }
+
+        // Ultimate fallback to prevent navigation to invalid paths
+        if (!targetPath && firstNavChild) {
+            targetPath = firstNavChild.path;
+        }
+
         if (targetPath) navigate(targetPath);
     };
 

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -10,6 +10,7 @@ import {
     IconYinYang,
     IconDots,
     IconLanguage,
+    IconWand,
 } from '@tabler/icons-react';
 import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import React, { useState } from 'react';
@@ -490,6 +491,47 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                         </ListItemButton>
                     </Tooltip>
                 )}
+            </Box>
+
+            {/* Onboarding Quick Add Button - above user icon */}
+            <Box
+                sx={{
+                    py: 0.5,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                }}
+            >
+                <Tooltip title={t('layout.onboarding', { defaultValue: 'Quick Add Provider' })} placement="right" arrow>
+                    <ListItemButton
+                        component={RouterLink}
+                        to="/onboarding"
+                        sx={{
+                            minHeight: 48,
+                            mx: 0.5,
+                            px: activityItemPaddingX,
+                            py: 0.75,
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: 0.25,
+                            position: 'relative',
+                            color: 'text.secondary',
+                            borderRadius: activityItemRadius,
+                            cursor: 'pointer',
+                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                        }}
+                    >
+                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                            <IconWand size={22} />
+                        </ListItemIcon>
+                        <Typography variant="caption" sx={{ fontSize: '0.6rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
+                            {t('layout.onboardingShort', { defaultValue: 'Onboard' })}
+                        </Typography>
+                    </ListItemButton>
+                </Tooltip>
             </Box>
 
             {/* Bottom: User icon */}

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -18,7 +18,6 @@ import {
     IconKey,
     IconShield,
     IconLock,
-    IconSparkles,
     IconMessageCircle,
     IconList,
 } from '@tabler/icons-react';

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -19,7 +19,6 @@ import {
     IconShield,
     IconLock,
     IconMessageCircle,
-    IconList,
 } from '@tabler/icons-react';
 import { OpenAI, Anthropic, Claude, OpenCode, Xcode, VSCode, Telegram, Feishu, Lark, DingTalk, Weixin, WeCom, Codex, OpenClaw } from '../components/BrandIcons';
 import { SettingsApplications } from '@mui/icons-material';
@@ -155,7 +154,6 @@ export function useActivityItems(): ActivityItem[] {
                 defaultPath: '/credentials',
                 children: [
                     { path: '/credentials', label: t('layout.modelKey'), icon: <IconLock size={20} /> },
-                    { path: '/credentials/providers', label: t('layout.providerList', { defaultValue: 'Provider List' }), icon: <IconList size={20} /> },
                     { path: '/tingly-box-token', label: t('layout.tinglyBox'), icon: <IconKey size={20} /> },
                 ],
             },

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -1,4 +1,14 @@
-import { Add, Upload, VpnKey, ListAlt } from '@mui/icons-material';
+import ApiKeyTable from '@/components/ApiKeyTable.tsx';
+import EmptyStateGuide from '@/components/EmptyStateGuide';
+import ImportModal from '@/components/ImportModal';
+import OAuthDetailDialog from '@/components/OAuthDetailDialog.tsx';
+import OAuthDialog from '@/components/OAuthDialog.tsx';
+import OAuthTable from '@/components/OAuthTable.tsx';
+import { PageLayout } from '@/components/PageLayout';
+import ProviderFormDialog, { type EnhancedProviderFormData } from '@/components/ProviderFormDialog.tsx';
+import UnifiedCard from '@/components/UnifiedCard';
+import { useProviderQuota } from '@/hooks/useProviderQuota';
+import { Add, ListAlt, Upload, VpnKey } from '@mui/icons-material';
 import {
     Alert,
     Box,
@@ -10,19 +20,8 @@ import {
     Typography,
 } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
-import { PageLayout } from '@/components/PageLayout';
-import ProviderFormDialog from '@/components/ProviderFormDialog.tsx';
-import { type EnhancedProviderFormData } from '@/components/ProviderFormDialog.tsx';
-import UnifiedCard from '@/components/UnifiedCard';
-import ImportModal from '@/components/ImportModal';
+import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../services/api';
-import ApiKeyTable from '@/components/ApiKeyTable.tsx';
-import OAuthTable from '@/components/OAuthTable.tsx';
-import EmptyStateGuide from '@/components/EmptyStateGuide';
-import OAuthDialog from '@/components/OAuthDialog.tsx';
-import OAuthDetailDialog from '@/components/OAuthDetailDialog.tsx';
-import { useProviderQuota } from '@/hooks/useProviderQuota';
 
 type ProviderFormData = EnhancedProviderFormData;
 
@@ -405,13 +404,13 @@ const CredentialPage = () => {
                     <Stack direction="row" spacing={1}>
                         <Button
                             component={Link}
-                            to="/credentials/providers"
+                            to="/onboarding"
                             variant="outlined"
                             startIcon={<ListAlt />}
                             size="small"
                             sx={{ minWidth: 130 }}
                         >
-                            Browse Providers
+                            Providers
                         </Button>
                         <Button
                             variant="outlined"

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Alert, Box, Button, Container, Paper, Snackbar, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Container, Paper, TextField, Typography } from '@mui/material';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -12,7 +12,6 @@ const Login: React.FC = () => {
     const [token, setToken] = useState('');
     const [error, setError] = useState('');
     const [loading, setLoading] = useState(false);
-    const [showSuccess, setShowSuccess] = useState(false);
     const { login } = useAuth();
 
     // Get the redirect path from router state or sessionStorage, default to '/'
@@ -34,11 +33,10 @@ const Login: React.FC = () => {
 
             if (response.ok) {
                 await login(urlToken);
-                setShowSuccess(true);
                 sessionStorage.removeItem('redirectAfterLogin');
-                setTimeout(() => {
-                    navigate(from, { replace: true });
-                }, 500);
+                // Use window.location.href to trigger a full page reload
+                // This ensures all contexts and states are properly initialized
+                window.location.href = from;
             } else {
                 setError(t('login.errors.invalidToken'));
                 setLoading(false);
@@ -77,13 +75,11 @@ const Login: React.FC = () => {
 
             if (response.ok) {
                 await login(token);
-                setShowSuccess(true);
                 // Clear the saved redirect path
                 sessionStorage.removeItem('redirectAfterLogin');
-                // Navigate to the original path after successful login
-                setTimeout(() => {
-                    navigate(from, { replace: true });
-                }, 500);
+                // Use window.location.href to trigger a full page reload
+                // This ensures all contexts and states are properly initialized
+                window.location.href = from;
             } else {
                 setError(t('login.errors.invalidToken'));
             }
@@ -146,16 +142,6 @@ const Login: React.FC = () => {
                     </Box>
                 </Paper>
             </Box>
-
-            <Snackbar
-                open={showSuccess}
-                autoHideDuration={2000}
-                onClose={() => setShowSuccess(false)}
-            >
-                <Alert onClose={() => setShowSuccess(false)} severity="success">
-                    {t('login.success.loginSuccess')}
-                </Alert>
-            </Snackbar>
         </Container>
     );
 };

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,14 +1,22 @@
 import {useState} from 'react';
-import {useNavigate} from 'react-router-dom';
+import {Link, useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
 import {
     Alert,
     Box,
+    Button,
+    Card,
+    CardContent,
+    Stack,
     Snackbar,
     Tab,
     Tabs,
     Typography,
 } from '@mui/material';
+import {
+    Home as HomeIcon,
+    Help as HelpIcon,
+} from '@mui/icons-material';
 import PageLayout from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import ProviderFormDialog, {type EnhancedProviderFormData} from '@/components/ProviderFormDialog';

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,0 +1,161 @@
+import {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useTranslation} from 'react-i18next';
+import {
+    Alert,
+    Box,
+    Snackbar,
+    Tab,
+    Tabs,
+    Typography,
+} from '@mui/material';
+import PageLayout from '@/components/PageLayout';
+import UnifiedCard from '@/components/UnifiedCard';
+import ProviderFormDialog, {type EnhancedProviderFormData} from '@/components/ProviderFormDialog';
+import BrowseProviders from '@/components/onboarding/BrowseProviders';
+import PasteAndDetect from '@/components/onboarding/PasteAndDetect';
+import {api} from '@/services/api';
+
+type OnboardingTab = 'browse' | 'paste';
+
+const emptyForm = (): EnhancedProviderFormData => ({
+    name: '',
+    apiBase: '',
+    apiStyle: undefined,
+    token: '',
+    enabled: true,
+    noKeyRequired: false,
+    proxyUrl: '',
+});
+
+const Onboarding: React.FC = () => {
+    const {t} = useTranslation();
+    const navigate = useNavigate();
+    const [tab, setTab] = useState<OnboardingTab>('browse');
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [formData, setFormData] = useState<EnhancedProviderFormData>(emptyForm());
+    const [snackbar, setSnackbar] = useState<{open: boolean; message: string; severity: 'success' | 'error' | 'info'}>({
+        open: false,
+        message: '',
+        severity: 'info',
+    });
+
+    const showMessage = (message: string, severity: 'success' | 'error' | 'info' = 'info') => {
+        setSnackbar({open: true, message, severity});
+    };
+
+    const openDialogWith = (prefill: EnhancedProviderFormData) => {
+        setFormData({
+            ...emptyForm(),
+            ...prefill,
+        });
+        setDialogOpen(true);
+    };
+
+    const handleFieldChange = (field: keyof EnhancedProviderFormData, value: any) => {
+        setFormData(prev => ({...prev, [field]: value}));
+    };
+
+    const submitProvider = async (force: boolean) => {
+        const payload = {
+            name: formData.name,
+            api_base: formData.apiBase,
+            api_style: formData.apiStyle,
+            token: formData.token,
+            no_key_required: formData.noKeyRequired,
+            proxy_url: formData.proxyUrl,
+        };
+        const result = await api.addProvider(payload, force);
+        if (result?.success) {
+            showMessage('Provider added', 'success');
+            setDialogOpen(false);
+            const target = formData.apiStyle === 'anthropic' ? '/agent/anthropic' : '/agent/openai';
+            navigate(target, {replace: true});
+        } else {
+            showMessage(`Failed to add provider: ${result?.error || 'unknown error'}`, 'error');
+        }
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        await submitProvider(false);
+    };
+
+    const handleForceAdd = async () => {
+        await submitProvider(true);
+    };
+
+    return (
+        <PageLayout loading={false}>
+            <Box sx={{py: 3, px: {xs: 2, md: 3}}}>
+                <UnifiedCard
+                    size="full"
+                    title={t('onboarding.title', {defaultValue: 'Welcome to Tingly Box'})}
+                    subtitle={t('onboarding.subtitle', {
+                        defaultValue: 'Add your first AI provider to get started. Browse the catalog or paste a config snippet — we’ll figure out the rest.',
+                    })}
+                >
+                    <Tabs
+                        value={tab}
+                        onChange={(_, v) => setTab(v as OnboardingTab)}
+                        sx={{mb: 2, borderBottom: 1, borderColor: 'divider'}}
+                    >
+                        <Tab
+                            value="browse"
+                            label={t('onboarding.tab.browse', {defaultValue: 'Browse providers'})}
+                        />
+                        <Tab
+                            value="paste"
+                            label={t('onboarding.tab.paste', {defaultValue: 'Paste & detect'})}
+                        />
+                    </Tabs>
+
+                    {tab === 'browse' && (
+                        <BrowseProviders onPick={openDialogWith}/>
+                    )}
+                    {tab === 'paste' && (
+                        <PasteAndDetect
+                            onPick={openDialogWith}
+                            onManualFill={() => openDialogWith(emptyForm())}
+                        />
+                    )}
+
+                    <Box sx={{mt: 3}}>
+                        <Typography variant="caption" color="text.secondary">
+                            {t('onboarding.hint', {
+                                defaultValue: 'Detection runs locally in the box; pasted text is not sent to any third party.',
+                            })}
+                        </Typography>
+                    </Box>
+                </UnifiedCard>
+            </Box>
+
+            <ProviderFormDialog
+                open={dialogOpen}
+                onClose={() => setDialogOpen(false)}
+                onSubmit={handleSubmit}
+                onForceAdd={handleForceAdd}
+                data={formData}
+                onChange={handleFieldChange}
+                mode="add"
+                isFirstProvider
+            />
+
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={4000}
+                onClose={() => setSnackbar(prev => ({...prev, open: false}))}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+            >
+                <Alert
+                    severity={snackbar.severity}
+                    onClose={() => setSnackbar(prev => ({...prev, open: false}))}
+                >
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
+        </PageLayout>
+    );
+};
+
+export default Onboarding;

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -7,6 +7,11 @@ import {
     Button,
     Card,
     CardContent,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
     Stack,
     Snackbar,
     Tab,
@@ -47,6 +52,7 @@ const Onboarding: React.FC = () => {
         message: '',
         severity: 'info',
     });
+    const [successDialogOpen, setSuccessDialogOpen] = useState(false);
 
     const showMessage = (message: string, severity: 'success' | 'error' | 'info' = 'info') => {
         setSnackbar({open: true, message, severity});
@@ -75,10 +81,8 @@ const Onboarding: React.FC = () => {
         };
         const result = await api.addProvider(payload, force);
         if (result?.success) {
-            showMessage('Provider added', 'success');
             setDialogOpen(false);
-            const target = formData.apiStyle === 'anthropic' ? '/agent/anthropic' : '/agent/openai';
-            navigate(target, {replace: true});
+            setSuccessDialogOpen(true);
         } else {
             showMessage(`Failed to add provider: ${result?.error || 'unknown error'}`, 'error');
         }
@@ -91,6 +95,16 @@ const Onboarding: React.FC = () => {
 
     const handleForceAdd = async () => {
         await submitProvider(true);
+    };
+
+    const handleGoToAgents = () => {
+        setSuccessDialogOpen(false);
+        navigate('/agent');
+    };
+
+    const handleStayOnOnboarding = () => {
+        setSuccessDialogOpen(false);
+        showMessage(t('onboarding.success', {defaultValue: 'Provider added successfully! You can now create scenarios.'}), 'success');
     };
 
     return (
@@ -148,6 +162,30 @@ const Onboarding: React.FC = () => {
                 mode="add"
                 isFirstProvider
             />
+
+            <Dialog
+                open={successDialogOpen}
+                onClose={() => setSuccessDialogOpen(false)}
+                aria-labelledby="success-dialog-title"
+                aria-describedby="success-dialog-description"
+            >
+                <DialogTitle id="success-dialog-title">
+                    {t('onboarding.dialog.title', {defaultValue: 'Provider Added'})}
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="success-dialog-description">
+                        {t('onboarding.dialog.message', {defaultValue: 'Your AI provider has been added successfully. Would you like to go to the agents page to start using it?'})}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleStayOnOnboarding}>
+                        {t('onboarding.dialog.stay', {defaultValue: 'Stay Here'})}
+                    </Button>
+                    <Button onClick={handleGoToAgents} variant="contained" autoFocus>
+                        {t('onboarding.dialog.goToAgents', {defaultValue: 'Go to Agents'})}
+                    </Button>
+                </DialogActions>
+            </Dialog>
 
             <Snackbar
                 open={snackbar.open}

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -299,12 +299,17 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
             return null;
         }
 
+        // First-run path: send users to the onboarding flow rather than the
+        // bare provider dialog — they get to browse the catalog or paste a
+        // config snippet for auto-detection.
         return (
             <UnifiedCard size="full" title={title}>
                 <EmptyStateGuide
                     title={"No Providers Configured"}
                     description={"Add an API key provider to start routing requests"}
-                    onAddApiKeyClick={onAddApiKeyClick || handleAddApiKeyClick}
+                    primaryButtonLabel={"Get started"}
+                    showOAuthButton={false}
+                    onAddApiKeyClick={onAddApiKeyClick || (() => navigate('/onboarding'))}
                 />
             </UnifiedCard>
         );

--- a/frontend/src/services/onboardingExtract.ts
+++ b/frontend/src/services/onboardingExtract.ts
@@ -1,21 +1,15 @@
 import TinglyService from "@/bindings";
 
-export interface OnboardingCandidate {
-    provider_id: string;
-    name: string;
-    icon?: string;
-    base_url?: string;
-    api_style?: 'openai' | 'anthropic' | string;
-    token?: string;
-    confidence: number;
-    match_reasons?: string[];
-    protocols?: string[];
+export interface OnboardingTokenCandidate {
+    value: string;
+    preview: string;
+    source: string; // bearer | x-api-key | env:NAME | json:api_key | key_prefix
 }
 
 export interface OnboardingExtractResult {
     success: boolean;
-    candidates: OnboardingCandidate[];
-    warnings: string[];
+    urls: string[];
+    tokens: OnboardingTokenCandidate[];
     error?: string;
 }
 
@@ -56,21 +50,21 @@ export async function extractOnboardingCandidates(input: string): Promise<Onboar
         if (!body?.success) {
             return {
                 success: false,
-                candidates: [],
-                warnings: [],
+                urls: [],
+                tokens: [],
                 error: body?.error?.message || 'Extraction failed',
             };
         }
         return {
             success: true,
-            candidates: body?.data?.candidates ?? [],
-            warnings: body?.data?.warnings ?? [],
+            urls: body?.data?.urls ?? [],
+            tokens: body?.data?.tokens ?? [],
         };
     } catch (err) {
         return {
             success: false,
-            candidates: [],
-            warnings: [],
+            urls: [],
+            tokens: [],
             error: (err as Error).message,
         };
     }

--- a/frontend/src/services/onboardingExtract.ts
+++ b/frontend/src/services/onboardingExtract.ts
@@ -1,0 +1,77 @@
+import TinglyService from "@/bindings";
+
+export interface OnboardingCandidate {
+    provider_id: string;
+    name: string;
+    icon?: string;
+    base_url?: string;
+    api_style?: 'openai' | 'anthropic' | string;
+    token?: string;
+    confidence: number;
+    match_reasons?: string[];
+    protocols?: string[];
+}
+
+export interface OnboardingExtractResult {
+    success: boolean;
+    candidates: OnboardingCandidate[];
+    warnings: string[];
+    error?: string;
+}
+
+const getUserAuthToken = (): string | null => {
+    return localStorage.getItem('user_auth_token');
+};
+
+const getAuthBearer = async (): Promise<string | null> => {
+    let token = getUserAuthToken();
+    if (!token && import.meta.env.VITE_PKG_MODE === "gui") {
+        const svc = TinglyService;
+        if (svc) {
+            try {
+                const guiToken = await svc.GetUserAuthToken();
+                if (guiToken) token = guiToken;
+            } catch (err) {
+                console.error('Failed to get GUI token for onboarding extract:', err);
+            }
+        }
+    }
+    return token;
+};
+
+export async function extractOnboardingCandidates(input: string): Promise<OnboardingExtractResult> {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+    };
+    const token = await getAuthBearer();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+
+    try {
+        const resp = await fetch('/api/v1/onboarding/extract', {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({input}),
+        });
+        const body = await resp.json();
+        if (!body?.success) {
+            return {
+                success: false,
+                candidates: [],
+                warnings: [],
+                error: body?.error?.message || 'Extraction failed',
+            };
+        }
+        return {
+            success: true,
+            candidates: body?.data?.candidates ?? [],
+            warnings: body?.data?.warnings ?? [],
+        };
+    } catch (err) {
+        return {
+            success: false,
+            candidates: [],
+            warnings: [],
+            error: (err as Error).message,
+        };
+    }
+}

--- a/frontend/src/services/serviceProviders.ts
+++ b/frontend/src/services/serviceProviders.ts
@@ -158,6 +158,7 @@ export interface UniqueProvider {
     supportsAnthropic: boolean;
     baseUrlOpenAI?: string;
     baseUrlAnthropic?: string;
+    website?: string;
     apiDoc?: string;
     icon?: string; // Icon identifier for Lobe Icons
 }
@@ -183,6 +184,7 @@ export function getAllUniqueProviders(): UniqueProvider[] {
             supportsAnthropic: !!sp.base_url_anthropic,
             baseUrlOpenAI: sp.base_url_openai,
             baseUrlAnthropic: sp.base_url_anthropic,
+            website: sp.website,
             apiDoc: sp.api_doc,
             icon: sp.icon,
         });

--- a/internal/server/module/onboarding/extractor.go
+++ b/internal/server/module/onboarding/extractor.go
@@ -4,453 +4,161 @@ import (
 	"context"
 	"net/url"
 	"regexp"
-	"sort"
 	"strings"
-
-	"github.com/tingly-dev/tingly-box/internal/data"
 )
 
 // Extractor is the contract handlers depend on. v1 ships a pure rule-based
-// implementation; future variants (LLM-assisted, model-based) can satisfy the
-// same contract without changing the handler or wire format.
+// implementation; future variants (LLM-assisted, model-based) can satisfy
+// the same contract without changing the handler or wire format.
 type Extractor interface {
-	Extract(ctx context.Context, input string) (candidates []Candidate, warnings []string, err error)
-}
-
-// vendor → known API key prefixes. Embedded here (not in providers.json) so
-// the onboarding hint table stays an internal concern of the extractor.
-var keyPrefixVendorMap = map[string]string{
-	"sk-ant-":  "anthropic",
-	"sk-or-":   "openrouter",
-	"sk-proj-": "openai",
-	"gsk_":     "groq",
-	"xai-":     "xai",
-	"AIza":     "google",
-	"ds-":      "deepseek",
-}
-
-// vendor signal from environment variable names.
-var envVarVendorMap = map[string]string{
-	"ANTHROPIC_API_KEY":    "anthropic",
-	"ANTHROPIC_BASE_URL":   "anthropic",
-	"ANTHROPIC_AUTH_TOKEN": "anthropic",
-	"OPENAI_API_KEY":       "openai",
-	"OPENAI_BASE_URL":      "openai",
-	"OPENAI_API_BASE":      "openai",
-	"GROQ_API_KEY":         "groq",
-	"DEEPSEEK_API_KEY":     "deepseek",
-	"DEEPSEEK_BASE_URL":    "deepseek",
-	"XAI_API_KEY":          "xai",
-	"GEMINI_API_KEY":       "google",
-	"GOOGLE_API_KEY":       "google",
-	"OPENROUTER_API_KEY":   "openrouter",
-	"OPENROUTER_BASE_URL":  "openrouter",
-	"MISTRAL_API_KEY":      "mistral",
-	"PERPLEXITY_API_KEY":   "perplexity",
-	"COHERE_API_KEY":       "cohere",
-	"TOGETHER_API_KEY":     "together",
-	"FIREWORKS_API_KEY":    "fireworks",
-	"CEREBRAS_API_KEY":     "cerebras",
-	"DASHSCOPE_API_KEY":    "alibaba",
-	"MOONSHOT_API_KEY":     "moonshot",
-	"KIMI_API_KEY":         "moonshot",
-	"ZHIPU_API_KEY":        "zhipu",
-	"ZAI_API_KEY":          "zhipu",
-	"SILICONFLOW_API_KEY":  "siliconflow",
-	"MODELSCOPE_API_KEY":   "modelscope",
-	"NOVITA_API_KEY":       "novita",
-	"DEEPINFRA_API_KEY":    "deepinfra",
-	"HYPERBOLIC_API_KEY":   "hyperbolic",
-	"NVIDIA_API_KEY":       "nvidia",
-	"BAIDU_API_KEY":        "baidu",
-	"TENCENT_API_KEY":      "tencent",
-	"DOUBAO_API_KEY":       "doubao",
+	Extract(ctx context.Context, input string) (data ExtractData, err error)
 }
 
 var (
 	urlRegex      = regexp.MustCompile(`https?://[^\s'"\x60<>]+`)
 	envVarRegex   = regexp.MustCompile(`\b([A-Z][A-Z0-9_]{3,})\s*[:=]\s*['"]?([^\s'"\x60]+)`)
-	bearerRegex   = regexp.MustCompile(`(?i)Bearer\s+([A-Za-z0-9_\-\.]{8,})`)
-	xApiKeyRegex  = regexp.MustCompile(`(?i)x-api-key\s*[:=]\s*['"]?([A-Za-z0-9_\-\.]{8,})`)
+	bearerRegex   = regexp.MustCompile(`(?i)Bearer\s+([A-Za-z0-9_\-\.]{12,})`)
+	xApiKeyRegex  = regexp.MustCompile(`(?i)x-api-key\s*[:=]\s*['"]?([A-Za-z0-9_\-\.]{12,})`)
 	keyPrefixRe   = regexp.MustCompile(`\b(sk-ant-[A-Za-z0-9_\-]+|sk-or-[A-Za-z0-9_\-]+|sk-proj-[A-Za-z0-9_\-]+|sk-[A-Za-z0-9_\-]{16,}|gsk_[A-Za-z0-9_\-]+|xai-[A-Za-z0-9_\-]+|AIza[A-Za-z0-9_\-]{30,}|ds-[A-Za-z0-9_\-]{16,})\b`)
 	jsonAPIKeyRe  = regexp.MustCompile(`(?i)"api[_-]?key"\s*:\s*"([^"]+)"`)
 	jsonBaseURLRe = regexp.MustCompile(`(?i)"base[_-]?url"\s*:\s*"([^"]+)"`)
 )
 
-// templateProvider is the minimal subset of data.ProviderTemplate the
-// extractor needs. Decoupling from the full struct makes the extractor easy
-// to fake in tests without spinning up a TemplateManager.
-type templateProvider struct {
-	ID               string
-	Name             string
-	Alias            string
-	Icon             string
-	VendorFamily     string
-	CanonicalDomain  string
-	BaseURLOpenAI    string
-	BaseURLAnthropic string
-	AuthType         string
+// Heuristic minimum length for env-var values to qualify as token candidates.
+// Below this, values like `LANG=en_US` would be reported as tokens.
+const envValueMinLen = 12
+
+// Names of env vars whose values are URLs, not tokens. Anything else gets
+// treated as a possible token if its value is long enough.
+var urlEnvVarNames = map[string]bool{
+	"OPENAI_BASE_URL":     true,
+	"OPENAI_API_BASE":     true,
+	"ANTHROPIC_BASE_URL":  true,
+	"DEEPSEEK_BASE_URL":   true,
+	"OPENROUTER_BASE_URL": true,
+	"BASE_URL":            true,
+	"API_BASE":            true,
+	"API_BASE_URL":        true,
+	"HTTPS_PROXY":         true,
+	"HTTP_PROXY":          true,
+	"NO_PROXY":            true,
 }
 
-// RuleExtractor implements Extractor with pure regex + registry matching.
-// No LLM, no network calls.
-type RuleExtractor struct {
-	templates []*templateProvider
+// RuleExtractor implements Extractor with pure regex matching.
+// No LLM, no network calls, no vendor-specific assumptions.
+type RuleExtractor struct{}
+
+// NewRuleExtractor builds a new RuleExtractor. The signature accepts a
+// dependency placeholder (any) for future-proofing — the v1 implementation
+// has no dependencies.
+func NewRuleExtractor() *RuleExtractor {
+	return &RuleExtractor{}
 }
 
-// NewRuleExtractor builds an extractor from a TemplateManager. OAuth-only
-// providers are excluded — onboarding's paste/browse flow targets API key
-// providers; OAuth has its own dedicated flow.
-func NewRuleExtractor(tm *data.TemplateManager) *RuleExtractor {
-	var providers []*templateProvider
-	if tm != nil {
-		for _, t := range tm.GetAllTemplates() {
-			if t == nil {
-				continue
-			}
-			if t.AuthType == "oauth" {
-				continue
-			}
-			providers = append(providers, &templateProvider{
-				ID:               t.ID,
-				Name:             t.Name,
-				Alias:            t.Alias,
-				Icon:             t.Icon,
-				VendorFamily:     t.VendorFamily,
-				CanonicalDomain:  t.CanonicalDomain,
-				BaseURLOpenAI:    t.BaseURLOpenAI,
-				BaseURLAnthropic: t.BaseURLAnthropic,
-				AuthType:         t.AuthType,
-			})
-		}
-	}
-	return &RuleExtractor{templates: providers}
-}
-
-// candidateBuilder accumulates evidence for a single provider during
-// extraction, then renders to Candidate at the end.
-type candidateBuilder struct {
-	tmpl         *templateProvider
-	score        float64
-	matchReasons []string
-	baseURL      string
-	apiStyle     string
-	token        string
-}
-
-func (b *candidateBuilder) addReason(weight float64, reason string) {
-	b.score += weight
-	b.matchReasons = append(b.matchReasons, reason)
-}
-
-// Extract scans the input text for URLs, env vars, bearer tokens, x-api-key
-// headers, JSON fields, and known key prefixes. It cross-references each
-// signal against the provider registry and returns up to 3 candidates ranked
-// by confidence. A non-nil warning is added when URL host disagrees with the
-// vendor implied by the API key prefix.
-func (e *RuleExtractor) Extract(_ context.Context, input string) ([]Candidate, []string, error) {
+// Extract scans the input text for URLs and possible API tokens. It is
+// deliberately vendor-agnostic: no scoring, no provider matching, no
+// warnings. The caller decides what to do with the raw signals.
+func (e *RuleExtractor) Extract(_ context.Context, input string) (ExtractData, error) {
 	if strings.TrimSpace(input) == "" {
-		return nil, nil, nil
+		return ExtractData{URLs: []string{}, Tokens: []TokenCandidate{}}, nil
 	}
 
-	urls := urlRegex.FindAllString(input, -1)
-	envVars := envVarRegex.FindAllStringSubmatch(input, -1)
-	bearers := bearerRegex.FindAllStringSubmatch(input, -1)
-	xKeys := xApiKeyRegex.FindAllStringSubmatch(input, -1)
-	keyMatches := keyPrefixRe.FindAllString(input, -1)
-	jsonKeys := jsonAPIKeyRe.FindAllStringSubmatch(input, -1)
-	jsonURLs := jsonBaseURLRe.FindAllStringSubmatch(input, -1)
-
-	// Collect all candidate tokens we saw, in the order encountered.
-	var tokens []string
-	for _, m := range bearers {
+	// --- URLs ---
+	var urls []string
+	for _, raw := range urlRegex.FindAllString(input, -1) {
+		urls = append(urls, cleanURL(raw))
+	}
+	for _, m := range jsonBaseURLRe.FindAllStringSubmatch(input, -1) {
 		if len(m) >= 2 {
-			tokens = append(tokens, m[1])
+			urls = append(urls, cleanURL(m[1]))
 		}
 	}
-	for _, m := range xKeys {
-		if len(m) >= 2 {
-			tokens = append(tokens, m[1])
-		}
-	}
-	for _, m := range jsonKeys {
-		if len(m) >= 2 {
-			tokens = append(tokens, m[1])
-		}
-	}
-	tokens = append(tokens, keyMatches...)
-	// env var values that look key-like (skip URL-valued env vars).
-	for _, m := range envVars {
+	for _, m := range envVarRegex.FindAllStringSubmatch(input, -1) {
 		if len(m) < 3 {
 			continue
 		}
 		val := m[2]
-		if strings.HasPrefix(strings.ToLower(val), "http://") || strings.HasPrefix(strings.ToLower(val), "https://") {
-			continue
-		}
-		tokens = append(tokens, val)
-	}
-	tokens = dedupeStrings(tokens)
-
-	// Determine vendor signals from key prefixes and env var names.
-	var keyVendor string
-	pickedToken := firstNonEmpty(keyMatches...)
-	for prefix, vendor := range keyPrefixVendorMap {
-		if pickedToken != "" && strings.HasPrefix(pickedToken, prefix) {
-			keyVendor = vendor
-			break
+		if isURLString(val) {
+			urls = append(urls, cleanURL(val))
 		}
 	}
-	if pickedToken == "" {
-		// Fall back: pick the longest token-like string we have.
-		pickedToken = longestString(tokens)
-	}
+	urls = dedupeStrings(urls)
 
-	envVendor := ""
-	for _, m := range envVars {
+	// --- Tokens ---
+	var tokens []TokenCandidate
+	for _, m := range bearerRegex.FindAllStringSubmatch(input, -1) {
+		if len(m) >= 2 {
+			tokens = append(tokens, TokenCandidate{Value: m[1], Source: "bearer"})
+		}
+	}
+	for _, m := range xApiKeyRegex.FindAllStringSubmatch(input, -1) {
+		if len(m) >= 2 {
+			tokens = append(tokens, TokenCandidate{Value: m[1], Source: "x-api-key"})
+		}
+	}
+	for _, m := range jsonAPIKeyRe.FindAllStringSubmatch(input, -1) {
+		if len(m) >= 2 {
+			tokens = append(tokens, TokenCandidate{Value: m[1], Source: "json:api_key"})
+		}
+	}
+	for _, k := range keyPrefixRe.FindAllString(input, -1) {
+		tokens = append(tokens, TokenCandidate{Value: k, Source: "key_prefix"})
+	}
+	for _, m := range envVarRegex.FindAllStringSubmatch(input, -1) {
 		if len(m) < 3 {
 			continue
 		}
 		name := strings.ToUpper(m[1])
-		if v, ok := envVarVendorMap[name]; ok {
-			envVendor = v
-			break
-		}
-	}
-
-	// Compute base URLs from explicit signals.
-	allURLs := append([]string{}, urls...)
-	for _, m := range jsonURLs {
-		if len(m) >= 2 {
-			allURLs = append(allURLs, m[1])
-		}
-	}
-	for _, m := range envVars {
-		if len(m) < 3 {
-			continue
-		}
 		val := m[2]
-		if strings.HasPrefix(strings.ToLower(val), "http://") || strings.HasPrefix(strings.ToLower(val), "https://") {
-			allURLs = append(allURLs, val)
-		}
-	}
-	allURLs = dedupeStrings(allURLs)
-
-	builders := make(map[string]*candidateBuilder)
-
-	// Signal 1: URL host → canonical_domain match.
-	urlVendors := make(map[string]bool)
-	for _, raw := range allURLs {
-		host := hostOf(raw)
-		if host == "" {
+		if isURLString(val) {
 			continue
 		}
-		for _, t := range e.templates {
-			if t.CanonicalDomain == "" {
-				continue
-			}
-			if !hostMatchesDomain(host, t.CanonicalDomain) {
-				continue
-			}
-			b := getOrInit(builders, t)
-			b.addReason(0.45, "domain:"+host)
-			b.baseURL = canonicalBaseURL(raw, t)
-			b.apiStyle = inferAPIStyle(raw, t, b.apiStyle)
-			if t.VendorFamily != "" {
-				urlVendors[t.VendorFamily] = true
-			}
+		if urlEnvVarNames[name] {
+			continue
 		}
+		if len(val) < envValueMinLen {
+			continue
+		}
+		tokens = append(tokens, TokenCandidate{Value: val, Source: "env:" + name})
+	}
+	tokens = dedupeTokens(tokens)
+	for i := range tokens {
+		tokens[i].Preview = maskToken(tokens[i].Value)
 	}
 
-	// Signal 2: env var vendor.
-	if envVendor != "" {
-		for _, t := range e.templates {
-			if t.VendorFamily == envVendor {
-				b := getOrInit(builders, t)
-				b.addReason(0.25, "env:"+envVendor)
-			}
-		}
+	if urls == nil {
+		urls = []string{}
 	}
-
-	// Signal 3: key prefix vendor.
-	if keyVendor != "" {
-		for _, t := range e.templates {
-			if t.VendorFamily == keyVendor {
-				b := getOrInit(builders, t)
-				b.addReason(0.30, "key_prefix:"+keyVendor)
-			}
-		}
+	if tokens == nil {
+		tokens = []TokenCandidate{}
 	}
-
-	// Attach token and fill in defaults for builders.
-	for _, b := range builders {
-		if b.baseURL == "" {
-			b.baseURL = preferredBaseURL(b.tmpl, b.apiStyle)
-		}
-		if b.apiStyle == "" {
-			b.apiStyle = preferredAPIStyle(b.tmpl)
-		}
-		// Prefer the token whose prefix matches this provider's vendor.
-		b.token = pickTokenForVendor(tokens, b.tmpl.VendorFamily)
-		if b.token == "" {
-			b.token = pickedToken
-		}
-	}
-
-	var warnings []string
-	if keyVendor != "" && len(urlVendors) > 0 && !urlVendors[keyVendor] {
-		warnings = append(warnings, "URL and API key prefix indicate different vendors; please double-check before saving.")
-	}
-
-	// Render and rank.
-	var out []Candidate
-	for _, b := range builders {
-		conf := b.score
-		// Cap confidence to 0.5 if URL/key disagreement was flagged AND this
-		// candidate is one of the disagreeing parties.
-		if len(warnings) > 0 && b.tmpl.VendorFamily != "" {
-			if (keyVendor != "" && b.tmpl.VendorFamily == keyVendor) || urlVendors[b.tmpl.VendorFamily] {
-				if conf > 0.5 {
-					conf = 0.5
-				}
-			}
-		}
-		if conf > 1 {
-			conf = 1
-		}
-		out = append(out, Candidate{
-			ProviderID:   b.tmpl.ID,
-			Name:         displayName(b.tmpl),
-			Icon:         b.tmpl.Icon,
-			BaseURL:      b.baseURL,
-			APIStyle:     b.apiStyle,
-			Token:        b.token,
-			Confidence:   roundTo(conf, 2),
-			MatchReasons: b.matchReasons,
-			Protocols:    protocolsFor(b.tmpl),
-		})
-	}
-
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Confidence > out[j].Confidence
-	})
-	if len(out) > 3 {
-		out = out[:3]
-	}
-	return out, warnings, nil
+	return ExtractData{URLs: urls, Tokens: tokens}, nil
 }
 
 // --- helpers ---
 
-func getOrInit(m map[string]*candidateBuilder, t *templateProvider) *candidateBuilder {
-	if b, ok := m[t.ID]; ok {
-		return b
-	}
-	b := &candidateBuilder{tmpl: t}
-	m[t.ID] = b
-	return b
+func isURLString(s string) bool {
+	low := strings.ToLower(s)
+	return strings.HasPrefix(low, "http://") || strings.HasPrefix(low, "https://")
 }
 
-func hostOf(raw string) string {
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u == nil {
-		return ""
-	}
-	return strings.ToLower(u.Host)
-}
-
-// hostMatchesDomain returns true when host equals domain or is a subdomain of
-// it. Avoid plain substring matching to prevent foo-anthropic.com from
-// matching anthropic.com.
-func hostMatchesDomain(host, domain string) bool {
-	host = strings.ToLower(strings.TrimSpace(host))
-	domain = strings.ToLower(strings.TrimSpace(domain))
-	if host == "" || domain == "" {
-		return false
-	}
-	if host == domain {
-		return true
-	}
-	return strings.HasSuffix(host, "."+domain)
-}
-
-// canonicalBaseURL returns the template-preferred base URL when the input
-// URL matches the template's canonical domain. Otherwise it falls back to
-// either base URL the template advertises.
-func canonicalBaseURL(rawURL string, t *templateProvider) string {
-	if t.BaseURLOpenAI != "" && strings.Contains(rawURL, hostOf(t.BaseURLOpenAI)) {
-		return t.BaseURLOpenAI
-	}
-	if t.BaseURLAnthropic != "" && strings.Contains(rawURL, hostOf(t.BaseURLAnthropic)) {
-		return t.BaseURLAnthropic
-	}
-	if t.BaseURLOpenAI != "" {
-		return t.BaseURLOpenAI
-	}
-	return t.BaseURLAnthropic
-}
-
-func inferAPIStyle(rawURL string, t *templateProvider, prev string) string {
-	low := strings.ToLower(rawURL)
-	switch {
-	case strings.Contains(low, "/v1/messages"), strings.Contains(low, "anthropic"):
-		return "anthropic"
-	case strings.Contains(low, "/chat/completions"), strings.Contains(low, "/responses"), strings.Contains(low, "/v1/models"):
-		return "openai"
-	}
-	if prev != "" {
-		return prev
-	}
-	return preferredAPIStyle(t)
-}
-
-func preferredAPIStyle(t *templateProvider) string {
-	if t.BaseURLOpenAI != "" && t.BaseURLAnthropic == "" {
-		return "openai"
-	}
-	if t.BaseURLAnthropic != "" && t.BaseURLOpenAI == "" {
-		return "anthropic"
-	}
-	if t.BaseURLOpenAI != "" {
-		return "openai"
-	}
-	if t.BaseURLAnthropic != "" {
-		return "anthropic"
-	}
-	return ""
-}
-
-func preferredBaseURL(t *templateProvider, style string) string {
-	switch style {
-	case "anthropic":
-		if t.BaseURLAnthropic != "" {
-			return t.BaseURLAnthropic
+// cleanURL trims trailing punctuation that often follows URLs in prose
+// ("see https://api.anthropic.com.") and surrounding quotes from JSON.
+func cleanURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.Trim(s, `"'`+"`")
+	for len(s) > 0 {
+		last := s[len(s)-1]
+		if last == '.' || last == ',' || last == ';' || last == ')' || last == ']' || last == '}' {
+			s = s[:len(s)-1]
+			continue
 		}
-		return t.BaseURLOpenAI
-	default:
-		if t.BaseURLOpenAI != "" {
-			return t.BaseURLOpenAI
-		}
-		return t.BaseURLAnthropic
+		break
 	}
-}
-
-func protocolsFor(t *templateProvider) []string {
-	var out []string
-	if t.BaseURLOpenAI != "" {
-		out = append(out, "openai")
+	if u, err := url.Parse(s); err == nil && u.Host != "" {
+		return s
 	}
-	if t.BaseURLAnthropic != "" {
-		out = append(out, "anthropic")
-	}
-	return out
-}
-
-func displayName(t *templateProvider) string {
-	if t.Alias != "" {
-		return t.Alias
-	}
-	return t.Name
+	return s
 }
 
 func dedupeStrings(in []string) []string {
@@ -466,45 +174,52 @@ func dedupeStrings(in []string) []string {
 	return out
 }
 
-func longestString(in []string) string {
-	var best string
-	for _, s := range in {
-		if len(s) > len(best) {
-			best = s
+// dedupeTokens dedupes by token value. When the same value appears under
+// multiple sources we keep the more informative source — Bearer / x-api-key
+// / env-var-name beat the generic key_prefix detector.
+func dedupeTokens(in []TokenCandidate) []TokenCandidate {
+	idx := make(map[string]int, len(in))
+	out := make([]TokenCandidate, 0, len(in))
+	for _, t := range in {
+		if t.Value == "" {
+			continue
 		}
+		if i, ok := idx[t.Value]; ok {
+			if sourcePriority(t.Source) > sourcePriority(out[i].Source) {
+				out[i].Source = t.Source
+			}
+			continue
+		}
+		idx[t.Value] = len(out)
+		out = append(out, t)
 	}
-	return best
+	return out
 }
 
-func firstNonEmpty(in ...string) string {
-	for _, s := range in {
-		if s != "" {
-			return s
-		}
+func sourcePriority(src string) int {
+	switch {
+	case strings.HasPrefix(src, "env:"):
+		return 4
+	case src == "x-api-key":
+		return 3
+	case src == "bearer":
+		return 3
+	case src == "json:api_key":
+		return 2
+	case src == "key_prefix":
+		return 1
 	}
-	return ""
+	return 0
 }
 
-// pickTokenForVendor returns the first token whose known prefix maps to the
-// given vendor, or empty if no such token is present.
-func pickTokenForVendor(tokens []string, vendor string) string {
-	if vendor == "" {
+// maskToken returns a redacted preview safe for display. Short tokens get
+// fully bulleted; longer tokens show their first 4 and last 4 characters.
+func maskToken(raw string) string {
+	if len(raw) == 0 {
 		return ""
 	}
-	for _, tok := range tokens {
-		for prefix, v := range keyPrefixVendorMap {
-			if v == vendor && strings.HasPrefix(tok, prefix) {
-				return tok
-			}
-		}
+	if len(raw) <= 8 {
+		return strings.Repeat("•", len(raw))
 	}
-	return ""
-}
-
-func roundTo(v float64, places int) float64 {
-	mult := 1.0
-	for i := 0; i < places; i++ {
-		mult *= 10
-	}
-	return float64(int(v*mult+0.5)) / mult
+	return raw[:4] + "…" + raw[len(raw)-4:]
 }

--- a/internal/server/module/onboarding/extractor.go
+++ b/internal/server/module/onboarding/extractor.go
@@ -19,9 +19,10 @@ var (
 	envVarRegex   = regexp.MustCompile(`\b([A-Z][A-Z0-9_]{3,})\s*[:=]\s*['"]?([^\s'"\x60]+)`)
 	bearerRegex   = regexp.MustCompile(`(?i)Bearer\s+([A-Za-z0-9_\-\.]{12,})`)
 	xApiKeyRegex  = regexp.MustCompile(`(?i)x-api-key\s*[:=]\s*['"]?([A-Za-z0-9_\-\.]{12,})`)
-	keyPrefixRe   = regexp.MustCompile(`\b(sk-ant-[A-Za-z0-9_\-]+|sk-or-[A-Za-z0-9_\-]+|sk-proj-[A-Za-z0-9_\-]+|sk-[A-Za-z0-9_\-]{16,}|gsk_[A-Za-z0-9_\-]+|xai-[A-Za-z0-9_\-]+|AIza[A-Za-z0-9_\-]{30,}|ds-[A-Za-z0-9_\-]{16,})\b`)
 	jsonAPIKeyRe  = regexp.MustCompile(`(?i)"api[_-]?key"\s*:\s*"([^"]+)"`)
 	jsonBaseURLRe = regexp.MustCompile(`(?i)"base[_-]?url"\s*:\s*"([^"]+)"`)
+	// Catch-all: alphanumeric strings 12+ chars that look like API tokens
+	tokenLikeRegex = regexp.MustCompile(`\b[A-Za-z0-9_\-\.]{12,}\b`)
 )
 
 // Heuristic minimum length for env-var values to qualify as token candidates.
@@ -101,8 +102,14 @@ func (e *RuleExtractor) Extract(_ context.Context, input string) (ExtractData, e
 			tokens = append(tokens, TokenCandidate{Value: m[1], Source: "json:api_key"})
 		}
 	}
-	for _, k := range keyPrefixRe.FindAllString(input, -1) {
-		tokens = append(tokens, TokenCandidate{Value: k, Source: "key_prefix"})
+	for _, tok := range tokenLikeRegex.FindAllString(input, -1) {
+		if isURLString(tok) {
+			continue
+		}
+		if isLowEntropy(tok) {
+			continue
+		}
+		tokens = append(tokens, TokenCandidate{Value: tok, Source: "token_like"})
 	}
 	for _, m := range envVarRegex.FindAllStringSubmatch(input, -1) {
 		if len(m) < 3 {
@@ -140,6 +147,61 @@ func (e *RuleExtractor) Extract(_ context.Context, input string) (ExtractData, e
 func isURLString(s string) bool {
 	low := strings.ToLower(s)
 	return strings.HasPrefix(low, "http://") || strings.HasPrefix(low, "https://")
+}
+
+// isLowEntropy filters out strings that definitely aren't API tokens.
+// Since users can pick from candidates, we only filter obvious garbage.
+func isLowEntropy(s string) bool {
+	if len(s) == 0 {
+		return true
+	}
+
+	// Skip all-digit strings (timestamps, simple IDs)
+	allDigits := true
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		return true
+	}
+
+	// Skip strings with < 2 unique characters (obvious repetition like "aaaaa...")
+	unique := make(map[rune]bool, len(s))
+	for _, c := range s {
+		unique[c] = true
+	}
+	if len(unique) < 2 {
+		return true
+	}
+
+	// Skip things that look like domain names (contain dots but no other token-like chars)
+	if strings.Contains(s, ".") && !strings.ContainsAny(s, "_-") {
+		// Check if it looks like a domain
+		parts := strings.Split(s, ".")
+		if len(parts) >= 2 {
+			allAlpha := true
+			for _, part := range parts {
+				if len(part) == 0 {
+					allAlpha = false
+					break
+				}
+				for _, c := range part {
+					if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+						allAlpha = false
+						break
+					}
+				}
+			}
+			if allAlpha {
+				return true // looks like a domain name
+			}
+		}
+	}
+
+	return false
 }
 
 // cleanURL trims trailing punctuation that often follows URLs in prose
@@ -206,7 +268,7 @@ func sourcePriority(src string) int {
 		return 3
 	case src == "json:api_key":
 		return 2
-	case src == "key_prefix":
+	case src == "token_like":
 		return 1
 	}
 	return 0

--- a/internal/server/module/onboarding/extractor.go
+++ b/internal/server/module/onboarding/extractor.go
@@ -1,0 +1,510 @@
+package onboarding
+
+import (
+	"context"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/tingly-dev/tingly-box/internal/data"
+)
+
+// Extractor is the contract handlers depend on. v1 ships a pure rule-based
+// implementation; future variants (LLM-assisted, model-based) can satisfy the
+// same contract without changing the handler or wire format.
+type Extractor interface {
+	Extract(ctx context.Context, input string) (candidates []Candidate, warnings []string, err error)
+}
+
+// vendor → known API key prefixes. Embedded here (not in providers.json) so
+// the onboarding hint table stays an internal concern of the extractor.
+var keyPrefixVendorMap = map[string]string{
+	"sk-ant-":  "anthropic",
+	"sk-or-":   "openrouter",
+	"sk-proj-": "openai",
+	"gsk_":     "groq",
+	"xai-":     "xai",
+	"AIza":     "google",
+	"ds-":      "deepseek",
+}
+
+// vendor signal from environment variable names.
+var envVarVendorMap = map[string]string{
+	"ANTHROPIC_API_KEY":    "anthropic",
+	"ANTHROPIC_BASE_URL":   "anthropic",
+	"ANTHROPIC_AUTH_TOKEN": "anthropic",
+	"OPENAI_API_KEY":       "openai",
+	"OPENAI_BASE_URL":      "openai",
+	"OPENAI_API_BASE":      "openai",
+	"GROQ_API_KEY":         "groq",
+	"DEEPSEEK_API_KEY":     "deepseek",
+	"DEEPSEEK_BASE_URL":    "deepseek",
+	"XAI_API_KEY":          "xai",
+	"GEMINI_API_KEY":       "google",
+	"GOOGLE_API_KEY":       "google",
+	"OPENROUTER_API_KEY":   "openrouter",
+	"OPENROUTER_BASE_URL":  "openrouter",
+	"MISTRAL_API_KEY":      "mistral",
+	"PERPLEXITY_API_KEY":   "perplexity",
+	"COHERE_API_KEY":       "cohere",
+	"TOGETHER_API_KEY":     "together",
+	"FIREWORKS_API_KEY":    "fireworks",
+	"CEREBRAS_API_KEY":     "cerebras",
+	"DASHSCOPE_API_KEY":    "alibaba",
+	"MOONSHOT_API_KEY":     "moonshot",
+	"KIMI_API_KEY":         "moonshot",
+	"ZHIPU_API_KEY":        "zhipu",
+	"ZAI_API_KEY":          "zhipu",
+	"SILICONFLOW_API_KEY":  "siliconflow",
+	"MODELSCOPE_API_KEY":   "modelscope",
+	"NOVITA_API_KEY":       "novita",
+	"DEEPINFRA_API_KEY":    "deepinfra",
+	"HYPERBOLIC_API_KEY":   "hyperbolic",
+	"NVIDIA_API_KEY":       "nvidia",
+	"BAIDU_API_KEY":        "baidu",
+	"TENCENT_API_KEY":      "tencent",
+	"DOUBAO_API_KEY":       "doubao",
+}
+
+var (
+	urlRegex      = regexp.MustCompile(`https?://[^\s'"\x60<>]+`)
+	envVarRegex   = regexp.MustCompile(`\b([A-Z][A-Z0-9_]{3,})\s*[:=]\s*['"]?([^\s'"\x60]+)`)
+	bearerRegex   = regexp.MustCompile(`(?i)Bearer\s+([A-Za-z0-9_\-\.]{8,})`)
+	xApiKeyRegex  = regexp.MustCompile(`(?i)x-api-key\s*[:=]\s*['"]?([A-Za-z0-9_\-\.]{8,})`)
+	keyPrefixRe   = regexp.MustCompile(`\b(sk-ant-[A-Za-z0-9_\-]+|sk-or-[A-Za-z0-9_\-]+|sk-proj-[A-Za-z0-9_\-]+|sk-[A-Za-z0-9_\-]{16,}|gsk_[A-Za-z0-9_\-]+|xai-[A-Za-z0-9_\-]+|AIza[A-Za-z0-9_\-]{30,}|ds-[A-Za-z0-9_\-]{16,})\b`)
+	jsonAPIKeyRe  = regexp.MustCompile(`(?i)"api[_-]?key"\s*:\s*"([^"]+)"`)
+	jsonBaseURLRe = regexp.MustCompile(`(?i)"base[_-]?url"\s*:\s*"([^"]+)"`)
+)
+
+// templateProvider is the minimal subset of data.ProviderTemplate the
+// extractor needs. Decoupling from the full struct makes the extractor easy
+// to fake in tests without spinning up a TemplateManager.
+type templateProvider struct {
+	ID               string
+	Name             string
+	Alias            string
+	Icon             string
+	VendorFamily     string
+	CanonicalDomain  string
+	BaseURLOpenAI    string
+	BaseURLAnthropic string
+	AuthType         string
+}
+
+// RuleExtractor implements Extractor with pure regex + registry matching.
+// No LLM, no network calls.
+type RuleExtractor struct {
+	templates []*templateProvider
+}
+
+// NewRuleExtractor builds an extractor from a TemplateManager. OAuth-only
+// providers are excluded — onboarding's paste/browse flow targets API key
+// providers; OAuth has its own dedicated flow.
+func NewRuleExtractor(tm *data.TemplateManager) *RuleExtractor {
+	var providers []*templateProvider
+	if tm != nil {
+		for _, t := range tm.GetAllTemplates() {
+			if t == nil {
+				continue
+			}
+			if t.AuthType == "oauth" {
+				continue
+			}
+			providers = append(providers, &templateProvider{
+				ID:               t.ID,
+				Name:             t.Name,
+				Alias:            t.Alias,
+				Icon:             t.Icon,
+				VendorFamily:     t.VendorFamily,
+				CanonicalDomain:  t.CanonicalDomain,
+				BaseURLOpenAI:    t.BaseURLOpenAI,
+				BaseURLAnthropic: t.BaseURLAnthropic,
+				AuthType:         t.AuthType,
+			})
+		}
+	}
+	return &RuleExtractor{templates: providers}
+}
+
+// candidateBuilder accumulates evidence for a single provider during
+// extraction, then renders to Candidate at the end.
+type candidateBuilder struct {
+	tmpl         *templateProvider
+	score        float64
+	matchReasons []string
+	baseURL      string
+	apiStyle     string
+	token        string
+}
+
+func (b *candidateBuilder) addReason(weight float64, reason string) {
+	b.score += weight
+	b.matchReasons = append(b.matchReasons, reason)
+}
+
+// Extract scans the input text for URLs, env vars, bearer tokens, x-api-key
+// headers, JSON fields, and known key prefixes. It cross-references each
+// signal against the provider registry and returns up to 3 candidates ranked
+// by confidence. A non-nil warning is added when URL host disagrees with the
+// vendor implied by the API key prefix.
+func (e *RuleExtractor) Extract(_ context.Context, input string) ([]Candidate, []string, error) {
+	if strings.TrimSpace(input) == "" {
+		return nil, nil, nil
+	}
+
+	urls := urlRegex.FindAllString(input, -1)
+	envVars := envVarRegex.FindAllStringSubmatch(input, -1)
+	bearers := bearerRegex.FindAllStringSubmatch(input, -1)
+	xKeys := xApiKeyRegex.FindAllStringSubmatch(input, -1)
+	keyMatches := keyPrefixRe.FindAllString(input, -1)
+	jsonKeys := jsonAPIKeyRe.FindAllStringSubmatch(input, -1)
+	jsonURLs := jsonBaseURLRe.FindAllStringSubmatch(input, -1)
+
+	// Collect all candidate tokens we saw, in the order encountered.
+	var tokens []string
+	for _, m := range bearers {
+		if len(m) >= 2 {
+			tokens = append(tokens, m[1])
+		}
+	}
+	for _, m := range xKeys {
+		if len(m) >= 2 {
+			tokens = append(tokens, m[1])
+		}
+	}
+	for _, m := range jsonKeys {
+		if len(m) >= 2 {
+			tokens = append(tokens, m[1])
+		}
+	}
+	tokens = append(tokens, keyMatches...)
+	// env var values that look key-like (skip URL-valued env vars).
+	for _, m := range envVars {
+		if len(m) < 3 {
+			continue
+		}
+		val := m[2]
+		if strings.HasPrefix(strings.ToLower(val), "http://") || strings.HasPrefix(strings.ToLower(val), "https://") {
+			continue
+		}
+		tokens = append(tokens, val)
+	}
+	tokens = dedupeStrings(tokens)
+
+	// Determine vendor signals from key prefixes and env var names.
+	var keyVendor string
+	pickedToken := firstNonEmpty(keyMatches...)
+	for prefix, vendor := range keyPrefixVendorMap {
+		if pickedToken != "" && strings.HasPrefix(pickedToken, prefix) {
+			keyVendor = vendor
+			break
+		}
+	}
+	if pickedToken == "" {
+		// Fall back: pick the longest token-like string we have.
+		pickedToken = longestString(tokens)
+	}
+
+	envVendor := ""
+	for _, m := range envVars {
+		if len(m) < 3 {
+			continue
+		}
+		name := strings.ToUpper(m[1])
+		if v, ok := envVarVendorMap[name]; ok {
+			envVendor = v
+			break
+		}
+	}
+
+	// Compute base URLs from explicit signals.
+	allURLs := append([]string{}, urls...)
+	for _, m := range jsonURLs {
+		if len(m) >= 2 {
+			allURLs = append(allURLs, m[1])
+		}
+	}
+	for _, m := range envVars {
+		if len(m) < 3 {
+			continue
+		}
+		val := m[2]
+		if strings.HasPrefix(strings.ToLower(val), "http://") || strings.HasPrefix(strings.ToLower(val), "https://") {
+			allURLs = append(allURLs, val)
+		}
+	}
+	allURLs = dedupeStrings(allURLs)
+
+	builders := make(map[string]*candidateBuilder)
+
+	// Signal 1: URL host → canonical_domain match.
+	urlVendors := make(map[string]bool)
+	for _, raw := range allURLs {
+		host := hostOf(raw)
+		if host == "" {
+			continue
+		}
+		for _, t := range e.templates {
+			if t.CanonicalDomain == "" {
+				continue
+			}
+			if !hostMatchesDomain(host, t.CanonicalDomain) {
+				continue
+			}
+			b := getOrInit(builders, t)
+			b.addReason(0.45, "domain:"+host)
+			b.baseURL = canonicalBaseURL(raw, t)
+			b.apiStyle = inferAPIStyle(raw, t, b.apiStyle)
+			if t.VendorFamily != "" {
+				urlVendors[t.VendorFamily] = true
+			}
+		}
+	}
+
+	// Signal 2: env var vendor.
+	if envVendor != "" {
+		for _, t := range e.templates {
+			if t.VendorFamily == envVendor {
+				b := getOrInit(builders, t)
+				b.addReason(0.25, "env:"+envVendor)
+			}
+		}
+	}
+
+	// Signal 3: key prefix vendor.
+	if keyVendor != "" {
+		for _, t := range e.templates {
+			if t.VendorFamily == keyVendor {
+				b := getOrInit(builders, t)
+				b.addReason(0.30, "key_prefix:"+keyVendor)
+			}
+		}
+	}
+
+	// Attach token and fill in defaults for builders.
+	for _, b := range builders {
+		if b.baseURL == "" {
+			b.baseURL = preferredBaseURL(b.tmpl, b.apiStyle)
+		}
+		if b.apiStyle == "" {
+			b.apiStyle = preferredAPIStyle(b.tmpl)
+		}
+		// Prefer the token whose prefix matches this provider's vendor.
+		b.token = pickTokenForVendor(tokens, b.tmpl.VendorFamily)
+		if b.token == "" {
+			b.token = pickedToken
+		}
+	}
+
+	var warnings []string
+	if keyVendor != "" && len(urlVendors) > 0 && !urlVendors[keyVendor] {
+		warnings = append(warnings, "URL and API key prefix indicate different vendors; please double-check before saving.")
+	}
+
+	// Render and rank.
+	var out []Candidate
+	for _, b := range builders {
+		conf := b.score
+		// Cap confidence to 0.5 if URL/key disagreement was flagged AND this
+		// candidate is one of the disagreeing parties.
+		if len(warnings) > 0 && b.tmpl.VendorFamily != "" {
+			if (keyVendor != "" && b.tmpl.VendorFamily == keyVendor) || urlVendors[b.tmpl.VendorFamily] {
+				if conf > 0.5 {
+					conf = 0.5
+				}
+			}
+		}
+		if conf > 1 {
+			conf = 1
+		}
+		out = append(out, Candidate{
+			ProviderID:   b.tmpl.ID,
+			Name:         displayName(b.tmpl),
+			Icon:         b.tmpl.Icon,
+			BaseURL:      b.baseURL,
+			APIStyle:     b.apiStyle,
+			Token:        b.token,
+			Confidence:   roundTo(conf, 2),
+			MatchReasons: b.matchReasons,
+			Protocols:    protocolsFor(b.tmpl),
+		})
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Confidence > out[j].Confidence
+	})
+	if len(out) > 3 {
+		out = out[:3]
+	}
+	return out, warnings, nil
+}
+
+// --- helpers ---
+
+func getOrInit(m map[string]*candidateBuilder, t *templateProvider) *candidateBuilder {
+	if b, ok := m[t.ID]; ok {
+		return b
+	}
+	b := &candidateBuilder{tmpl: t}
+	m[t.ID] = b
+	return b
+}
+
+func hostOf(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u == nil {
+		return ""
+	}
+	return strings.ToLower(u.Host)
+}
+
+// hostMatchesDomain returns true when host equals domain or is a subdomain of
+// it. Avoid plain substring matching to prevent foo-anthropic.com from
+// matching anthropic.com.
+func hostMatchesDomain(host, domain string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if host == "" || domain == "" {
+		return false
+	}
+	if host == domain {
+		return true
+	}
+	return strings.HasSuffix(host, "."+domain)
+}
+
+// canonicalBaseURL returns the template-preferred base URL when the input
+// URL matches the template's canonical domain. Otherwise it falls back to
+// either base URL the template advertises.
+func canonicalBaseURL(rawURL string, t *templateProvider) string {
+	if t.BaseURLOpenAI != "" && strings.Contains(rawURL, hostOf(t.BaseURLOpenAI)) {
+		return t.BaseURLOpenAI
+	}
+	if t.BaseURLAnthropic != "" && strings.Contains(rawURL, hostOf(t.BaseURLAnthropic)) {
+		return t.BaseURLAnthropic
+	}
+	if t.BaseURLOpenAI != "" {
+		return t.BaseURLOpenAI
+	}
+	return t.BaseURLAnthropic
+}
+
+func inferAPIStyle(rawURL string, t *templateProvider, prev string) string {
+	low := strings.ToLower(rawURL)
+	switch {
+	case strings.Contains(low, "/v1/messages"), strings.Contains(low, "anthropic"):
+		return "anthropic"
+	case strings.Contains(low, "/chat/completions"), strings.Contains(low, "/responses"), strings.Contains(low, "/v1/models"):
+		return "openai"
+	}
+	if prev != "" {
+		return prev
+	}
+	return preferredAPIStyle(t)
+}
+
+func preferredAPIStyle(t *templateProvider) string {
+	if t.BaseURLOpenAI != "" && t.BaseURLAnthropic == "" {
+		return "openai"
+	}
+	if t.BaseURLAnthropic != "" && t.BaseURLOpenAI == "" {
+		return "anthropic"
+	}
+	if t.BaseURLOpenAI != "" {
+		return "openai"
+	}
+	if t.BaseURLAnthropic != "" {
+		return "anthropic"
+	}
+	return ""
+}
+
+func preferredBaseURL(t *templateProvider, style string) string {
+	switch style {
+	case "anthropic":
+		if t.BaseURLAnthropic != "" {
+			return t.BaseURLAnthropic
+		}
+		return t.BaseURLOpenAI
+	default:
+		if t.BaseURLOpenAI != "" {
+			return t.BaseURLOpenAI
+		}
+		return t.BaseURLAnthropic
+	}
+}
+
+func protocolsFor(t *templateProvider) []string {
+	var out []string
+	if t.BaseURLOpenAI != "" {
+		out = append(out, "openai")
+	}
+	if t.BaseURLAnthropic != "" {
+		out = append(out, "anthropic")
+	}
+	return out
+}
+
+func displayName(t *templateProvider) string {
+	if t.Alias != "" {
+		return t.Alias
+	}
+	return t.Name
+}
+
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := in[:0]
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+func longestString(in []string) string {
+	var best string
+	for _, s := range in {
+		if len(s) > len(best) {
+			best = s
+		}
+	}
+	return best
+}
+
+func firstNonEmpty(in ...string) string {
+	for _, s := range in {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// pickTokenForVendor returns the first token whose known prefix maps to the
+// given vendor, or empty if no such token is present.
+func pickTokenForVendor(tokens []string, vendor string) string {
+	if vendor == "" {
+		return ""
+	}
+	for _, tok := range tokens {
+		for prefix, v := range keyPrefixVendorMap {
+			if v == vendor && strings.HasPrefix(tok, prefix) {
+				return tok
+			}
+		}
+	}
+	return ""
+}
+
+func roundTo(v float64, places int) float64 {
+	mult := 1.0
+	for i := 0; i < places; i++ {
+		mult *= 10
+	}
+	return float64(int(v*mult+0.5)) / mult
+}

--- a/internal/server/module/onboarding/extractor_test.go
+++ b/internal/server/module/onboarding/extractor_test.go
@@ -100,8 +100,9 @@ func TestExtractor_PlainKey(t *testing.T) {
 	if len(d.Tokens) == 0 {
 		t.Fatalf("expected at least one token, got none")
 	}
-	if d.Tokens[0].Source != "key_prefix" {
-		t.Fatalf("expected key_prefix source, got %q", d.Tokens[0].Source)
+	// source is now "token_like" after simplification
+	if !strings.HasPrefix(d.Tokens[0].Source, "token") {
+		t.Fatalf("expected token_like source, got %q", d.Tokens[0].Source)
 	}
 	if !strings.HasPrefix(d.Tokens[0].Preview, "sk-a") {
 		t.Fatalf("expected masked preview, got %q", d.Tokens[0].Preview)
@@ -208,5 +209,96 @@ OPENAI_API_KEY=sk-proj-abcdef1234567890abcdef`
 	// And the real key still made it through.
 	if !contains(tokenValues(d.Tokens), "sk-proj-abcdef1234567890abcdef") {
 		t.Fatalf("expected OPENAI_API_KEY value in tokens, got %v", tokenValues(d.Tokens))
+	}
+}
+
+func TestExtractor_UUIDToken(t *testing.T) {
+	// Test UUID not in env var (env has higher priority, so it would override source)
+	input := `Here is my token: 550e8400-e29b-41d4-a716-446655440000`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(tokenValues(d.Tokens), "550e8400-e29b-41d4-a716-446655440000") {
+		t.Fatalf("expected UUID token, got %v", tokenValues(d.Tokens))
+	}
+	// source is now "token_like" after simplification
+	found := false
+	for _, tok := range d.Tokens {
+		if tok.Value == "550e8400-e29b-41d4-a716-446655440000" && tok.Source == "token_like" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected source=token_like for UUID token, got %v", d.Tokens)
+	}
+}
+
+func TestExtractor_UUIDInEnvVar(t *testing.T) {
+	// When UUID is in env var, env source takes priority (higher priority)
+	input := `API_TOKEN=550e8400-e29b-41d4-a716-446655440000`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(tokenValues(d.Tokens), "550e8400-e29b-41d4-a716-446655440000") {
+		t.Fatalf("expected UUID token, got %v", tokenValues(d.Tokens))
+	}
+	// Should have env:API_TOKEN source (higher priority than uuid)
+	found := false
+	for _, tok := range d.Tokens {
+		if tok.Value == "550e8400-e29b-41d4-a716-446655440000" && tok.Source == "env:API_TOKEN" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected source=env:API_TOKEN for UUID in env var, got %v", d.Tokens)
+	}
+}
+
+func TestExtractor_UUIDNoHyphen(t *testing.T) {
+	// UUID without hyphens: 32 hex chars
+	input := `token: 550e8400e29b41d4a716446655440000`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(tokenValues(d.Tokens), "550e8400e29b41d4a716446655440000") {
+		t.Fatalf("expected UUID without hyphens, got %v", tokenValues(d.Tokens))
+	}
+}
+
+func TestExtractor_GenericLongToken(t *testing.T) {
+	// Generic long alphanumeric token that doesn't match specific patterns
+	input := `Authorization: abc123XYZdef456GHI789jklMNO012`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should be caught by bearer regex first
+	if !contains(tokenValues(d.Tokens), "abc123XYZdef456GHI789jklMNO012") {
+		t.Fatalf("expected generic token, got %v", tokenValues(d.Tokens))
+	}
+}
+
+func TestExtractor_ShortPrefixToken(t *testing.T) {
+	// Short vendor prefix tokens like 火山 engine's ant-6e2a70f0
+	input := `{"token":"ant-6e2a70f0"}`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(tokenValues(d.Tokens), "ant-6e2a70f0") {
+		t.Fatalf("expected short_prefix token, got %v", tokenValues(d.Tokens))
+	}
+	// source is now "token_like" after simplification
+	found := false
+	for _, tok := range d.Tokens {
+		if tok.Value == "ant-6e2a70f0" && tok.Source == "token_like" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected source=token_like, got %v", d.Tokens)
 	}
 }

--- a/internal/server/module/onboarding/extractor_test.go
+++ b/internal/server/module/onboarding/extractor_test.go
@@ -1,0 +1,240 @@
+package onboarding
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// newTestExtractor builds a RuleExtractor with a small fixed registry covering
+// the providers exercised by the test cases below. Keeping the fixture local
+// avoids coupling the test suite to the live providers.json.
+func newTestExtractor() *RuleExtractor {
+	return &RuleExtractor{templates: []*templateProvider{
+		{
+			ID:              "openai-com",
+			Name:            "OpenAI",
+			Icon:            "openai",
+			VendorFamily:    "openai",
+			CanonicalDomain: "api.openai.com",
+			BaseURLOpenAI:   "https://api.openai.com/v1",
+		},
+		{
+			ID:               "anthropic-com",
+			Name:             "Anthropic",
+			Icon:             "anthropic",
+			VendorFamily:     "anthropic",
+			CanonicalDomain:  "api.anthropic.com",
+			BaseURLAnthropic: "https://api.anthropic.com",
+		},
+		{
+			ID:              "openrouter-ai",
+			Name:            "OpenRouter",
+			Icon:            "openrouter",
+			VendorFamily:    "openrouter",
+			CanonicalDomain: "openrouter.ai",
+			BaseURLOpenAI:   "https://openrouter.ai/api/v1",
+		},
+		{
+			ID:              "deepseek-com",
+			Name:            "DeepSeek",
+			Icon:            "deepseek",
+			VendorFamily:    "deepseek",
+			CanonicalDomain: "api.deepseek.com",
+			BaseURLOpenAI:   "https://api.deepseek.com",
+		},
+		{
+			ID:              "groq-com",
+			Name:            "Groq",
+			Icon:            "groq",
+			VendorFamily:    "groq",
+			CanonicalDomain: "api.groq.com",
+			BaseURLOpenAI:   "https://api.groq.com/openai/v1",
+		},
+	}}
+}
+
+func mustTopCandidate(t *testing.T, cands []Candidate) Candidate {
+	t.Helper()
+	if len(cands) == 0 {
+		t.Fatalf("expected at least one candidate, got 0")
+	}
+	return cands[0]
+}
+
+func TestExtractor_EnvFile(t *testing.T) {
+	ext := newTestExtractor()
+	input := `# .env
+OPENAI_API_KEY=sk-proj-abcdef1234567890abcdef
+OPENAI_BASE_URL=https://api.openai.com/v1
+`
+	cands, warnings, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("did not expect warnings, got %v", warnings)
+	}
+	top := mustTopCandidate(t, cands)
+	if top.ProviderID != "openai-com" {
+		t.Fatalf("expected top=openai-com, got %s", top.ProviderID)
+	}
+	if top.APIStyle != "openai" {
+		t.Fatalf("expected api_style=openai, got %s", top.APIStyle)
+	}
+	if !strings.HasPrefix(top.Token, "sk-proj-") {
+		t.Fatalf("expected sk-proj token, got %q", top.Token)
+	}
+	if top.Confidence < 0.9 {
+		t.Fatalf("expected high confidence (>=0.9), got %v", top.Confidence)
+	}
+}
+
+func TestExtractor_AnthropicCurl(t *testing.T) {
+	ext := newTestExtractor()
+	input := `curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: sk-ant-api03-XYZxyz0123456789ABCDEF" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-3-5-sonnet-latest","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}'`
+	cands, warnings, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("did not expect warnings, got %v", warnings)
+	}
+	top := mustTopCandidate(t, cands)
+	if top.ProviderID != "anthropic-com" {
+		t.Fatalf("expected top=anthropic-com, got %s", top.ProviderID)
+	}
+	if top.APIStyle != "anthropic" {
+		t.Fatalf("expected api_style=anthropic, got %s", top.APIStyle)
+	}
+	if !strings.HasPrefix(top.Token, "sk-ant-") {
+		t.Fatalf("expected sk-ant token, got %q", top.Token)
+	}
+	if top.Confidence < 0.7 {
+		t.Fatalf("expected confidence >=0.7, got %v", top.Confidence)
+	}
+}
+
+func TestExtractor_OpenAIDocSnippet(t *testing.T) {
+	ext := newTestExtractor()
+	input := `from openai import OpenAI
+client = OpenAI(api_key="sk-proj-abcdefghijklmnopqrstuvwx")
+resp = client.chat.completions.create(model="gpt-4o", messages=[{"role":"user","content":"hi"}])
+`
+	cands, _, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	top := mustTopCandidate(t, cands)
+	if top.ProviderID != "openai-com" {
+		t.Fatalf("expected top=openai-com, got %s", top.ProviderID)
+	}
+	if !strings.HasPrefix(top.Token, "sk-proj-") {
+		t.Fatalf("expected sk-proj token, got %q", top.Token)
+	}
+}
+
+func TestExtractor_OpenRouterDoc(t *testing.T) {
+	ext := newTestExtractor()
+	input := `curl https://openrouter.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer sk-or-v1-abcdef0123456789abcdef" \
+  -H "Content-Type: application/json"`
+	cands, warnings, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("did not expect warnings, got %v", warnings)
+	}
+	top := mustTopCandidate(t, cands)
+	if top.ProviderID != "openrouter-ai" {
+		t.Fatalf("expected top=openrouter-ai, got %s", top.ProviderID)
+	}
+	if top.APIStyle != "openai" {
+		t.Fatalf("expected openai-style for openrouter, got %s", top.APIStyle)
+	}
+	if !strings.HasPrefix(top.Token, "sk-or-") {
+		t.Fatalf("expected sk-or token, got %q", top.Token)
+	}
+}
+
+func TestExtractor_ConflictingURLAndKey(t *testing.T) {
+	ext := newTestExtractor()
+	// URL points to anthropic, but key prefix says openrouter — should warn.
+	input := `https://api.anthropic.com/v1/messages
+sk-or-v1-someopenrouterkey0123456789`
+	_, warnings, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected a warning for url/key disagreement, got none")
+	}
+}
+
+func TestExtractor_BareKey(t *testing.T) {
+	ext := newTestExtractor()
+	input := `sk-ant-api03-justakeynothingelse123456`
+	cands, _, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	top := mustTopCandidate(t, cands)
+	if top.ProviderID != "anthropic-com" {
+		t.Fatalf("expected anthropic-com from bare key, got %s", top.ProviderID)
+	}
+	if top.BaseURL == "" {
+		t.Fatalf("expected base URL filled in from template, got empty")
+	}
+	if top.Confidence > 0.5 {
+		t.Fatalf("expected lower confidence with single signal, got %v", top.Confidence)
+	}
+}
+
+func TestExtractor_BareURL(t *testing.T) {
+	ext := newTestExtractor()
+	input := `Try https://api.deepseek.com/v1/chat/completions in your client.`
+	cands, _, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	top := mustTopCandidate(t, cands)
+	if top.ProviderID != "deepseek-com" {
+		t.Fatalf("expected deepseek-com from URL, got %s", top.ProviderID)
+	}
+	if top.Token != "" {
+		t.Fatalf("expected empty token (none in input), got %q", top.Token)
+	}
+}
+
+func TestExtractor_EmptyInput(t *testing.T) {
+	ext := newTestExtractor()
+	cands, warnings, err := ext.Extract(context.Background(), "   ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cands) != 0 || len(warnings) != 0 {
+		t.Fatalf("expected empty result for whitespace input, got cands=%v warnings=%v", cands, warnings)
+	}
+}
+
+func TestExtractor_LimitsToThreeCandidates(t *testing.T) {
+	ext := newTestExtractor()
+	// Multiple URLs, each matching a different vendor.
+	input := `https://api.openai.com
+https://api.anthropic.com
+https://openrouter.ai
+https://api.deepseek.com
+https://api.groq.com`
+	cands, _, err := ext.Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cands) > 3 {
+		t.Fatalf("expected at most 3 candidates, got %d", len(cands))
+	}
+}

--- a/internal/server/module/onboarding/extractor_test.go
+++ b/internal/server/module/onboarding/extractor_test.go
@@ -6,235 +6,207 @@ import (
 	"testing"
 )
 
-// newTestExtractor builds a RuleExtractor with a small fixed registry covering
-// the providers exercised by the test cases below. Keeping the fixture local
-// avoids coupling the test suite to the live providers.json.
-func newTestExtractor() *RuleExtractor {
-	return &RuleExtractor{templates: []*templateProvider{
-		{
-			ID:              "openai-com",
-			Name:            "OpenAI",
-			Icon:            "openai",
-			VendorFamily:    "openai",
-			CanonicalDomain: "api.openai.com",
-			BaseURLOpenAI:   "https://api.openai.com/v1",
-		},
-		{
-			ID:               "anthropic-com",
-			Name:             "Anthropic",
-			Icon:             "anthropic",
-			VendorFamily:     "anthropic",
-			CanonicalDomain:  "api.anthropic.com",
-			BaseURLAnthropic: "https://api.anthropic.com",
-		},
-		{
-			ID:              "openrouter-ai",
-			Name:            "OpenRouter",
-			Icon:            "openrouter",
-			VendorFamily:    "openrouter",
-			CanonicalDomain: "openrouter.ai",
-			BaseURLOpenAI:   "https://openrouter.ai/api/v1",
-		},
-		{
-			ID:              "deepseek-com",
-			Name:            "DeepSeek",
-			Icon:            "deepseek",
-			VendorFamily:    "deepseek",
-			CanonicalDomain: "api.deepseek.com",
-			BaseURLOpenAI:   "https://api.deepseek.com",
-		},
-		{
-			ID:              "groq-com",
-			Name:            "Groq",
-			Icon:            "groq",
-			VendorFamily:    "groq",
-			CanonicalDomain: "api.groq.com",
-			BaseURLOpenAI:   "https://api.groq.com/openai/v1",
-		},
-	}}
+func newExt() *RuleExtractor { return NewRuleExtractor() }
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }
 
-func mustTopCandidate(t *testing.T, cands []Candidate) Candidate {
-	t.Helper()
-	if len(cands) == 0 {
-		t.Fatalf("expected at least one candidate, got 0")
+func tokenValues(in []TokenCandidate) []string {
+	out := make([]string, len(in))
+	for i, t := range in {
+		out[i] = t.Value
 	}
-	return cands[0]
+	return out
 }
 
 func TestExtractor_EnvFile(t *testing.T) {
-	ext := newTestExtractor()
 	input := `# .env
 OPENAI_API_KEY=sk-proj-abcdef1234567890abcdef
 OPENAI_BASE_URL=https://api.openai.com/v1
 `
-	cands, warnings, err := ext.Extract(context.Background(), input)
+	d, err := newExt().Extract(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("did not expect warnings, got %v", warnings)
+	if !contains(d.URLs, "https://api.openai.com/v1") {
+		t.Fatalf("expected URL https://api.openai.com/v1, got %v", d.URLs)
 	}
-	top := mustTopCandidate(t, cands)
-	if top.ProviderID != "openai-com" {
-		t.Fatalf("expected top=openai-com, got %s", top.ProviderID)
+	if !contains(tokenValues(d.Tokens), "sk-proj-abcdef1234567890abcdef") {
+		t.Fatalf("expected sk-proj token in %v", tokenValues(d.Tokens))
 	}
-	if top.APIStyle != "openai" {
-		t.Fatalf("expected api_style=openai, got %s", top.APIStyle)
-	}
-	if !strings.HasPrefix(top.Token, "sk-proj-") {
-		t.Fatalf("expected sk-proj token, got %q", top.Token)
-	}
-	if top.Confidence < 0.9 {
-		t.Fatalf("expected high confidence (>=0.9), got %v", top.Confidence)
+	// OPENAI_BASE_URL should not show up as a token.
+	for _, tok := range d.Tokens {
+		if tok.Source == "env:OPENAI_BASE_URL" {
+			t.Fatalf("OPENAI_BASE_URL leaked into tokens: %v", tok)
+		}
 	}
 }
 
 func TestExtractor_AnthropicCurl(t *testing.T) {
-	ext := newTestExtractor()
 	input := `curl https://api.anthropic.com/v1/messages \
   -H "x-api-key: sk-ant-api03-XYZxyz0123456789ABCDEF" \
   -H "anthropic-version: 2023-06-01" \
-  -H "content-type: application/json" \
-  -d '{"model":"claude-3-5-sonnet-latest","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}'`
-	cands, warnings, err := ext.Extract(context.Background(), input)
+  -H "content-type: application/json"`
+	d, err := newExt().Extract(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("did not expect warnings, got %v", warnings)
+	if !contains(d.URLs, "https://api.anthropic.com/v1/messages") {
+		t.Fatalf("expected anthropic URL, got %v", d.URLs)
 	}
-	top := mustTopCandidate(t, cands)
-	if top.ProviderID != "anthropic-com" {
-		t.Fatalf("expected top=anthropic-com, got %s", top.ProviderID)
+	found := false
+	for _, tok := range d.Tokens {
+		if tok.Value == "sk-ant-api03-XYZxyz0123456789ABCDEF" && tok.Source == "x-api-key" {
+			found = true
+		}
 	}
-	if top.APIStyle != "anthropic" {
-		t.Fatalf("expected api_style=anthropic, got %s", top.APIStyle)
-	}
-	if !strings.HasPrefix(top.Token, "sk-ant-") {
-		t.Fatalf("expected sk-ant token, got %q", top.Token)
-	}
-	if top.Confidence < 0.7 {
-		t.Fatalf("expected confidence >=0.7, got %v", top.Confidence)
+	if !found {
+		t.Fatalf("expected x-api-key token, got %v", d.Tokens)
 	}
 }
 
-func TestExtractor_OpenAIDocSnippet(t *testing.T) {
-	ext := newTestExtractor()
-	input := `from openai import OpenAI
-client = OpenAI(api_key="sk-proj-abcdefghijklmnopqrstuvwx")
-resp = client.chat.completions.create(model="gpt-4o", messages=[{"role":"user","content":"hi"}])
-`
-	cands, _, err := ext.Extract(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	top := mustTopCandidate(t, cands)
-	if top.ProviderID != "openai-com" {
-		t.Fatalf("expected top=openai-com, got %s", top.ProviderID)
-	}
-	if !strings.HasPrefix(top.Token, "sk-proj-") {
-		t.Fatalf("expected sk-proj token, got %q", top.Token)
-	}
-}
-
-func TestExtractor_OpenRouterDoc(t *testing.T) {
-	ext := newTestExtractor()
+func TestExtractor_BearerHeader(t *testing.T) {
 	input := `curl https://openrouter.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer sk-or-v1-abcdef0123456789abcdef" \
-  -H "Content-Type: application/json"`
-	cands, warnings, err := ext.Extract(context.Background(), input)
+  -H "Authorization: Bearer sk-or-v1-abcdef0123456789abcdef"`
+	d, err := newExt().Extract(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("did not expect warnings, got %v", warnings)
+	var bearerSrc string
+	for _, tok := range d.Tokens {
+		if tok.Value == "sk-or-v1-abcdef0123456789abcdef" {
+			bearerSrc = tok.Source
+		}
 	}
-	top := mustTopCandidate(t, cands)
-	if top.ProviderID != "openrouter-ai" {
-		t.Fatalf("expected top=openrouter-ai, got %s", top.ProviderID)
-	}
-	if top.APIStyle != "openai" {
-		t.Fatalf("expected openai-style for openrouter, got %s", top.APIStyle)
-	}
-	if !strings.HasPrefix(top.Token, "sk-or-") {
-		t.Fatalf("expected sk-or token, got %q", top.Token)
+	// The same value is matched by both bearer and key_prefix; we keep the
+	// more informative source.
+	if bearerSrc != "bearer" {
+		t.Fatalf("expected source=bearer, got %q (tokens=%v)", bearerSrc, d.Tokens)
 	}
 }
 
-func TestExtractor_ConflictingURLAndKey(t *testing.T) {
-	ext := newTestExtractor()
-	// URL points to anthropic, but key prefix says openrouter — should warn.
-	input := `https://api.anthropic.com/v1/messages
-sk-or-v1-someopenrouterkey0123456789`
-	_, warnings, err := ext.Extract(context.Background(), input)
+func TestExtractor_PlainKey(t *testing.T) {
+	input := `here is my key: sk-ant-api03-justakeynothingelse123456`
+	d, err := newExt().Extract(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(warnings) == 0 {
-		t.Fatalf("expected a warning for url/key disagreement, got none")
+	if len(d.Tokens) == 0 {
+		t.Fatalf("expected at least one token, got none")
+	}
+	if d.Tokens[0].Source != "key_prefix" {
+		t.Fatalf("expected key_prefix source, got %q", d.Tokens[0].Source)
+	}
+	if !strings.HasPrefix(d.Tokens[0].Preview, "sk-a") {
+		t.Fatalf("expected masked preview, got %q", d.Tokens[0].Preview)
 	}
 }
 
-func TestExtractor_BareKey(t *testing.T) {
-	ext := newTestExtractor()
-	input := `sk-ant-api03-justakeynothingelse123456`
-	cands, _, err := ext.Extract(context.Background(), input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	top := mustTopCandidate(t, cands)
-	if top.ProviderID != "anthropic-com" {
-		t.Fatalf("expected anthropic-com from bare key, got %s", top.ProviderID)
-	}
-	if top.BaseURL == "" {
-		t.Fatalf("expected base URL filled in from template, got empty")
-	}
-	if top.Confidence > 0.5 {
-		t.Fatalf("expected lower confidence with single signal, got %v", top.Confidence)
-	}
-}
-
-func TestExtractor_BareURL(t *testing.T) {
-	ext := newTestExtractor()
+func TestExtractor_OnlyURL(t *testing.T) {
 	input := `Try https://api.deepseek.com/v1/chat/completions in your client.`
-	cands, _, err := ext.Extract(context.Background(), input)
+	d, err := newExt().Extract(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	top := mustTopCandidate(t, cands)
-	if top.ProviderID != "deepseek-com" {
-		t.Fatalf("expected deepseek-com from URL, got %s", top.ProviderID)
+	if !contains(d.URLs, "https://api.deepseek.com/v1/chat/completions") {
+		t.Fatalf("expected deepseek URL, got %v", d.URLs)
 	}
-	if top.Token != "" {
-		t.Fatalf("expected empty token (none in input), got %q", top.Token)
+	if len(d.Tokens) != 0 {
+		t.Fatalf("expected no tokens, got %v", d.Tokens)
+	}
+}
+
+func TestExtractor_JSONFields(t *testing.T) {
+	input := `{
+  "api_key": "sk-someservice-abcdef1234567890",
+  "base_url": "https://example.com/api/v1"
+}`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(d.URLs, "https://example.com/api/v1") {
+		t.Fatalf("expected base_url, got %v", d.URLs)
+	}
+	if !contains(tokenValues(d.Tokens), "sk-someservice-abcdef1234567890") {
+		t.Fatalf("expected api_key token, got %v", tokenValues(d.Tokens))
+	}
+}
+
+func TestExtractor_MultipleURLsAndTokensDeduped(t *testing.T) {
+	input := `https://api.openai.com/v1
+https://api.openai.com/v1
+sk-proj-abcdef1234567890ABCDEF
+sk-proj-abcdef1234567890ABCDEF`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	urlCount := 0
+	for _, u := range d.URLs {
+		if u == "https://api.openai.com/v1" {
+			urlCount++
+		}
+	}
+	if urlCount != 1 {
+		t.Fatalf("expected URL deduped to 1, got %d (%v)", urlCount, d.URLs)
+	}
+	tokCount := 0
+	for _, tok := range d.Tokens {
+		if tok.Value == "sk-proj-abcdef1234567890ABCDEF" {
+			tokCount++
+		}
+	}
+	if tokCount != 1 {
+		t.Fatalf("expected token deduped to 1, got %d (%v)", tokCount, d.Tokens)
+	}
+}
+
+func TestExtractor_PreservesURLPath(t *testing.T) {
+	input := `Endpoint: https://example.com/foo/bar?x=1.`
+	d, err := newExt().Extract(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://example.com/foo/bar?x=1"
+	if !contains(d.URLs, want) {
+		t.Fatalf("expected %q (trailing punct stripped), got %v", want, d.URLs)
 	}
 }
 
 func TestExtractor_EmptyInput(t *testing.T) {
-	ext := newTestExtractor()
-	cands, warnings, err := ext.Extract(context.Background(), "   ")
+	d, err := newExt().Extract(context.Background(), "   ")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(cands) != 0 || len(warnings) != 0 {
-		t.Fatalf("expected empty result for whitespace input, got cands=%v warnings=%v", cands, warnings)
+	if len(d.URLs) != 0 || len(d.Tokens) != 0 {
+		t.Fatalf("expected empty result, got %+v", d)
 	}
 }
 
-func TestExtractor_LimitsToThreeCandidates(t *testing.T) {
-	ext := newTestExtractor()
-	// Multiple URLs, each matching a different vendor.
-	input := `https://api.openai.com
-https://api.anthropic.com
-https://openrouter.ai
-https://api.deepseek.com
-https://api.groq.com`
-	cands, _, err := ext.Extract(context.Background(), input)
+func TestExtractor_IgnoresShortEnvValues(t *testing.T) {
+	input := `LANG=en_US.UTF-8
+HOME=/root
+PATH=/usr/bin
+OPENAI_API_KEY=sk-proj-abcdef1234567890abcdef`
+	d, err := newExt().Extract(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(cands) > 3 {
-		t.Fatalf("expected at most 3 candidates, got %d", len(cands))
+	for _, tok := range d.Tokens {
+		switch tok.Source {
+		case "env:LANG", "env:HOME", "env:PATH":
+			t.Fatalf("unrelated env var leaked in as token: %v", tok)
+		}
+	}
+	// And the real key still made it through.
+	if !contains(tokenValues(d.Tokens), "sk-proj-abcdef1234567890abcdef") {
+		t.Fatalf("expected OPENAI_API_KEY value in tokens, got %v", tokenValues(d.Tokens))
 	}
 }

--- a/internal/server/module/onboarding/handler.go
+++ b/internal/server/module/onboarding/handler.go
@@ -4,23 +4,27 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
-	"github.com/tingly-dev/tingly-box/internal/data"
 )
 
 // Handler serves the onboarding extraction endpoint.
 type Handler struct {
-	templateManager *data.TemplateManager
+	extractor Extractor
 }
 
-// NewHandler creates a new onboarding handler.
-func NewHandler(tm *data.TemplateManager) *Handler {
-	return &Handler{templateManager: tm}
+// NewHandler creates a new onboarding handler. The extractor is injected so
+// tests and future variants (LLM-assisted, model-based) can swap in a
+// different implementation without touching the route.
+func NewHandler(extractor Extractor) *Handler {
+	if extractor == nil {
+		extractor = NewRuleExtractor()
+	}
+	return &Handler{extractor: extractor}
 }
 
 // Extract parses an arbitrary text blob (env file, curl, snippet from docs,
-// etc.) and returns ranked provider candidates. v1 uses a pure rule-based
-// extractor — no LLM calls, no network.
+// etc.) and returns the URLs and possible API tokens it finds. The
+// extraction is vendor-agnostic; the user picks which URL and which token to
+// use in the dialog.
 func (h *Handler) Extract(c *gin.Context) {
 	var req ExtractRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -34,8 +38,7 @@ func (h *Handler) Extract(c *gin.Context) {
 		return
 	}
 
-	extractor := NewRuleExtractor(h.templateManager)
-	candidates, warnings, err := extractor.Extract(c.Request.Context(), req.Input)
+	data, err := h.extractor.Extract(c.Request.Context(), req.Input)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ExtractResponse{
 			Success: false,
@@ -47,15 +50,8 @@ func (h *Handler) Extract(c *gin.Context) {
 		return
 	}
 
-	if candidates == nil {
-		candidates = []Candidate{}
-	}
-
 	c.JSON(http.StatusOK, ExtractResponse{
 		Success: true,
-		Data: &ExtractData{
-			Candidates: candidates,
-			Warnings:   warnings,
-		},
+		Data:    &data,
 	})
 }

--- a/internal/server/module/onboarding/handler.go
+++ b/internal/server/module/onboarding/handler.go
@@ -1,0 +1,61 @@
+package onboarding
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/data"
+)
+
+// Handler serves the onboarding extraction endpoint.
+type Handler struct {
+	templateManager *data.TemplateManager
+}
+
+// NewHandler creates a new onboarding handler.
+func NewHandler(tm *data.TemplateManager) *Handler {
+	return &Handler{templateManager: tm}
+}
+
+// Extract parses an arbitrary text blob (env file, curl, snippet from docs,
+// etc.) and returns ranked provider candidates. v1 uses a pure rule-based
+// extractor — no LLM calls, no network.
+func (h *Handler) Extract(c *gin.Context) {
+	var req ExtractRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ExtractResponse{
+			Success: false,
+			Error: &ErrorDetail{
+				Message: "Invalid request body: " + err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	extractor := NewRuleExtractor(h.templateManager)
+	candidates, warnings, err := extractor.Extract(c.Request.Context(), req.Input)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ExtractResponse{
+			Success: false,
+			Error: &ErrorDetail{
+				Message: err.Error(),
+				Type:    "extraction_error",
+			},
+		})
+		return
+	}
+
+	if candidates == nil {
+		candidates = []Candidate{}
+	}
+
+	c.JSON(http.StatusOK, ExtractResponse{
+		Success: true,
+		Data: &ExtractData{
+			Candidates: candidates,
+			Warnings:   warnings,
+		},
+	})
+}

--- a/internal/server/module/onboarding/routes.go
+++ b/internal/server/module/onboarding/routes.go
@@ -1,0 +1,14 @@
+package onboarding
+
+import "github.com/tingly-dev/tingly-box/pkg/swagger"
+
+// RegisterRoutes wires the onboarding endpoints onto a swagger route group.
+// The route group is expected to already carry the user auth middleware.
+func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
+	router.POST("/onboarding/extract", handler.Extract,
+		swagger.WithDescription("Extract provider candidates from arbitrary text input"),
+		swagger.WithTags("onboarding"),
+		swagger.WithRequestModel(ExtractRequest{}),
+		swagger.WithResponseModel(ExtractResponse{}),
+	)
+}

--- a/internal/server/module/onboarding/types.go
+++ b/internal/server/module/onboarding/types.go
@@ -1,0 +1,42 @@
+package onboarding
+
+// Candidate is a provider configuration candidate returned by the extractor.
+// It is the wire format the frontend consumes to pre-fill the provider
+// creation dialog.
+type Candidate struct {
+	ProviderID   string   `json:"provider_id"`
+	Name         string   `json:"name"`
+	Icon         string   `json:"icon,omitempty"`
+	BaseURL      string   `json:"base_url,omitempty"`
+	APIStyle     string   `json:"api_style,omitempty"`
+	Token        string   `json:"token,omitempty"`
+	Confidence   float64  `json:"confidence"`
+	MatchReasons []string `json:"match_reasons,omitempty"`
+	Protocols    []string `json:"protocols,omitempty"`
+}
+
+// ExtractRequest is the body for POST /api/v1/onboarding/extract.
+type ExtractRequest struct {
+	Input string `json:"input"`
+}
+
+// ExtractData is the inner payload returned by the extractor.
+type ExtractData struct {
+	Candidates []Candidate `json:"candidates"`
+	Warnings   []string    `json:"warnings,omitempty"`
+}
+
+// ExtractResponse mirrors the rest of the v1 envelope shape used elsewhere in
+// the API.
+type ExtractResponse struct {
+	Success bool         `json:"success"`
+	Data    *ExtractData `json:"data,omitempty"`
+	Error   *ErrorDetail `json:"error,omitempty"`
+}
+
+// ErrorDetail is a minimal error envelope. Kept local to the module so the
+// onboarding API does not depend on internal server types.
+type ErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type,omitempty"`
+}

--- a/internal/server/module/onboarding/types.go
+++ b/internal/server/module/onboarding/types.go
@@ -1,18 +1,12 @@
 package onboarding
 
-// Candidate is a provider configuration candidate returned by the extractor.
-// It is the wire format the frontend consumes to pre-fill the provider
-// creation dialog.
-type Candidate struct {
-	ProviderID   string   `json:"provider_id"`
-	Name         string   `json:"name"`
-	Icon         string   `json:"icon,omitempty"`
-	BaseURL      string   `json:"base_url,omitempty"`
-	APIStyle     string   `json:"api_style,omitempty"`
-	Token        string   `json:"token,omitempty"`
-	Confidence   float64  `json:"confidence"`
-	MatchReasons []string `json:"match_reasons,omitempty"`
-	Protocols    []string `json:"protocols,omitempty"`
+// TokenCandidate is a possible API token found in the input. The extractor
+// stays vendor-agnostic — it just reports what it saw and where it came
+// from. The user picks which one (if any) to use.
+type TokenCandidate struct {
+	Value   string `json:"value"`
+	Preview string `json:"preview"`
+	Source  string `json:"source"` // bearer | x-api-key | env:NAME | json:api_key | key_prefix
 }
 
 // ExtractRequest is the body for POST /api/v1/onboarding/extract.
@@ -20,14 +14,15 @@ type ExtractRequest struct {
 	Input string `json:"input"`
 }
 
-// ExtractData is the inner payload returned by the extractor.
+// ExtractData is the inner payload returned by the extractor. It is a flat
+// list of detected URLs and tokens — provider matching, if any, is done on
+// the client side after the user picks values.
 type ExtractData struct {
-	Candidates []Candidate `json:"candidates"`
-	Warnings   []string    `json:"warnings,omitempty"`
+	URLs   []string         `json:"urls"`
+	Tokens []TokenCandidate `json:"tokens"`
 }
 
-// ExtractResponse mirrors the rest of the v1 envelope shape used elsewhere in
-// the API.
+// ExtractResponse mirrors the rest of the v1 envelope shape used elsewhere.
 type ExtractResponse struct {
 	Success bool         `json:"success"`
 	Data    *ExtractData `json:"data,omitempty"`

--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -26,6 +26,7 @@ import (
 	mcpmodule "github.com/tingly-dev/tingly-box/internal/server/module/mcp"
 	notifymodule "github.com/tingly-dev/tingly-box/internal/server/module/notify"
 	oauthmodule "github.com/tingly-dev/tingly-box/internal/server/module/oauth"
+	"github.com/tingly-dev/tingly-box/internal/server/module/onboarding"
 	providerQuotaModule "github.com/tingly-dev/tingly-box/internal/server/module/provider_quota"
 	"github.com/tingly-dev/tingly-box/internal/server/module/providertemplate"
 	rulemodule "github.com/tingly-dev/tingly-box/internal/server/module/rule"
@@ -912,6 +913,11 @@ func (s *Server) useWebAPIEndpoints(manager *swagger.RouteManager) {
 		swagger.WithRequestModel(ProbeRequest{}),
 		swagger.WithResponseModel(ProbeResponse{}),
 	)
+
+	// Onboarding: extract provider candidates from arbitrary pasted text.
+	// Pure rule-based; no LLM calls. Used by /onboarding "Paste & detect" path.
+	onboardingHandler := onboarding.NewHandler(s.templateManager)
+	onboarding.RegisterRoutes(apiV1, onboardingHandler)
 
 	apiV1.POST("/probe/provider", s.HandleProbeProvider,
 		swagger.WithDescription("Test api key for the provider"),

--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -914,9 +914,9 @@ func (s *Server) useWebAPIEndpoints(manager *swagger.RouteManager) {
 		swagger.WithResponseModel(ProbeResponse{}),
 	)
 
-	// Onboarding: extract provider candidates from arbitrary pasted text.
-	// Pure rule-based; no LLM calls. Used by /onboarding "Paste & detect" path.
-	onboardingHandler := onboarding.NewHandler(s.templateManager)
+	// Onboarding: extract URLs and possible API tokens from arbitrary pasted
+	// text. Vendor-agnostic — the user picks which URL/token to use.
+	onboardingHandler := onboarding.NewHandler(onboarding.NewRuleExtractor())
 	onboarding.RegisterRoutes(apiV1, onboardingHandler)
 
 	apiV1.POST("/probe/provider", s.HandleProbeProvider,


### PR DESCRIPTION
First-run users now land on /onboarding instead of an empty agent page. The onboarding page offers two paths to add the first provider:

- Browse: visual grid of catalog providers (reuses provider templates), click to pre-fill the existing ProviderFormDialog.
- Paste & detect: paste any text (env file, curl snippet, doc fragment) and have the box extract candidate providers via a pure rule-based extractor on the server (no LLM, no network calls).

Backend exposes POST /api/v1/onboarding/extract via a new internal/server/module/onboarding module. The Extractor interface keeps the rule engine swappable so future LLM-assisted variants can plug in without changing the handler or wire format.

https://claude.ai/code/session_013VyeaZvovR3m6bofgsEumL

<img width="2980" height="1636" alt="image" src="https://github.com/user-attachments/assets/1f9f439d-1e4f-486d-9d36-662ee0a931f4" />
