### PR TITLE
fix: preserve Claude Code Write tool arguments in replayed responses

### DIFF
--- a/internal/protocol/openai.go
+++ b/internal/protocol/openai.go
@@ -114,10 +114,17 @@ func PreprocessInputData(data []byte) ([]byte, error) {
 			continue
 		}
 
-		// Step 1: Add "type": "message" if missing and role exists
+		// Step 1: Infer missing union discriminator for input items.
+		// Some clients replay prior Responses history without `type`, but the SDK
+		// needs it to deserialize union items and preserve function arguments.
 		if _, hasType := itemObj["type"]; !hasType {
-			if _, hasRole := itemObj["role"]; hasRole {
+			switch {
+			case hasKey(itemObj, "role"):
 				itemObj["type"] = "message"
+			case hasKey(itemObj, "call_id") && hasKey(itemObj, "arguments"):
+				itemObj["type"] = "function_call"
+			case hasKey(itemObj, "call_id") && hasKey(itemObj, "output"):
+				itemObj["type"] = "function_call_output"
 			}
 		}
 
@@ -186,6 +193,11 @@ func asSlice(v any) ([]any, bool) {
 		return items, true
 	}
 	return nil, false
+}
+
+func hasKey(m map[string]any, key string) bool {
+	_, ok := m[key]
+	return ok
 }
 
 // =============================================

--- a/internal/server/openai_responses_test.go
+++ b/internal/server/openai_responses_test.go
@@ -96,6 +96,47 @@ func TestResponseCreateRequest_UnmarshalJSON_ArrayInput(t *testing.T) {
 	}
 }
 
+func TestResponseCreateRequest_UnmarshalJSON_TypelessFunctionCallInput(t *testing.T) {
+	jsonString := `{
+		"model": "gpt-4o",
+		"input": [
+			{
+				"call_id": "call_123",
+				"name": "Write",
+				"arguments": "{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}"
+			}
+		]
+	}`
+
+	var req protocol.ResponseCreateRequest
+	if err := json.Unmarshal([]byte(jsonString), &req); err != nil {
+		t.Fatalf("Failed to deserialize typeless function_call input: %v", err)
+	}
+
+	if param.IsOmitted(req.Input.OfInputItemList) {
+		t.Fatal("Expected input item list")
+	}
+	items := req.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("Expected 1 input item, got %d", len(items))
+	}
+	if param.IsOmitted(items[0].OfFunctionCall) {
+		t.Fatal("Expected function_call item to be preserved")
+	}
+	if items[0].OfFunctionCall.Name != "Write" {
+		t.Fatalf("Expected function name Write, got %q", items[0].OfFunctionCall.Name)
+	}
+	if items[0].OfFunctionCall.Arguments == "" {
+		t.Fatal("Expected function call arguments to be preserved")
+	}
+	if items[0].OfFunctionCall.Arguments != `{"file_path":"c:/Users/nil/workspace/mario-game.html","content":"hello"}` {
+		t.Fatalf("Unexpected function call arguments: %s", items[0].OfFunctionCall.Arguments)
+	}
+	if items[0].OfFunctionCall.CallID != "call_123" {
+		t.Fatalf("Expected call_id call_123, got %q", items[0].OfFunctionCall.CallID)
+	}
+}
+
 // TestResponseCreateRequest_UnmarshalJSON_WithExtraFields tests unmarshaling with extra fields
 func TestResponseCreateRequest_UnmarshalJSON_WithExtraFields(t *testing.T) {
 	jsonString := `{


### PR DESCRIPTION
## 1. Problem
A Claude Code session replayed a previous `Write` tool call, but the replayed tool input reached Anthropic as `{}` instead of the original arguments. This caused the tool to fail with missing required parameters (`file_path` and `content`).

## 2. Evidence
According to recording file, two concrete tool-use entries from the same recorded request body show the issue clearly.

Earlier in the conversation, a `Read` tool call is present with a valid absolute path:
- Recorded block excerpt:
  - `{"id":"call_00_9X0bU1jDttp9Yn1AkBpWZkxH","input":{"file_path":"c:/Users/nil/workspace/mario-game.html"},"name":"Read","type":"tool_use"}`

Later, the same replayed history contains a `Write` tool call block with empty input:
- Recorded block excerpt:
  - `{"id":"call_00_00KI7hjAuTnuIALFyhFWoZKG","input":{},"name":"Write","type":"tool_use"}`

The immediately following recorded `tool_result` reports missing required parameters for `Write`:
- missing `file_path`
- missing `content`

This shows the failure is not a local filesystem/write permission problem. The tool call had already lost its arguments before execution.

## 3. Root Cause
The recording proves that the execution layer received an empty `Write` input, but by itself it does not prove whether the model emitted `{}` or whether the proxy lost arguments during request normalization.

The proxy, however, had a concrete lossy path in Responses input preprocessing:
- before this change, typeless input items were only normalized as `message` when they had `role`
- replayed tool calls can arrive as typeless `function_call` items
- without an explicit discriminator, the OpenAI Go SDK can drop those items during union deserialization

This is related to the upstream `openai-go` issue about typeless Responses input items being lost during unmarshal:
- [openai-go #465](https://github.com/openai/openai-go/issues/465)

The reproduction below is adapted from that issue, but uses a typeless `function_call` instead of a typeless `message` to match the Claude Code replay failure mode observed here.

A standalone reproduction script demonstrates that exact SDK behavior:

```go
package main

import (
	"encoding/json"
	"fmt"

	"github.com/openai/openai-go/v3/responses"
)

func main() {
	withoutType := `{"model":"gpt-4o","input":[{"call_id":"call_123","name":"Write","arguments":"{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}"}]}`
	fmt.Printf("Input:  %s\n", withoutType)
	test(withoutType)

	fmt.Println()

	withType := `{"model":"gpt-4o","input":[{"type":"function_call","call_id":"call_123","name":"Write","arguments":"{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}"}]}`
	fmt.Printf("Input:  %s\n", withType)
	test(withType)
}

func test(jsonInput string) {
	var req responses.ResponseNewParams
	if err := json.Unmarshal([]byte(jsonInput), &req); err != nil {
		fmt.Printf("Unmarshal error: %v\n", err)
		return
	}

	marshaled, err := json.Marshal(req)
	if err != nil {
		fmt.Printf("Marshal error: %v\n", err)
		return
	}
	fmt.Printf("Output: %s\n", string(marshaled))
}
```

Run command:
- `go run ./scripts/repro_responses_typeless_function_call.go`

Observed output:

```text
Input:  {"model":"gpt-4o","input":[{"call_id":"call_123","name":"Write","arguments":"{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}"}]}
Output: {"model":"gpt-4o"}

Input:  {"model":"gpt-4o","input":[{"type":"function_call","call_id":"call_123","name":"Write","arguments":"{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}"}]}
Output: {"input":[{"arguments":"{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}","call_id":"call_123","name":"Write","type":"function_call"}],"model":"gpt-4o"}
```

This shows that a typeless replayed `function_call` can be dropped by SDK unmarshal/marshal, while the same payload is preserved once `type: "function_call"` is present. That makes proxy-side argument loss during request normalization the most likely explanation for the recorded `Write` failure.

## 4. Fix
Extend Responses input preprocessing to infer missing union discriminators for replayed non-message items too:
- `role` -> `message`
- `call_id + arguments` -> `function_call`
- `call_id + output` -> `function_call_output`

Also add a regression test covering typeless replayed `function_call` input so a `Write` tool call keeps its serialized arguments intact.

## Verification
- `task cli:build`
