### PR TITLE
Fix bot model switching sync issue

### DIFF
--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -14,6 +14,50 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 )
 
+// botLifecycle is the subset of BotManager that UpdateSettings needs to
+// react to SmartGuide config changes. Defining it here lets us swap a fake
+// in tests without depending on the full BotManager construction.
+type botLifecycle interface {
+	IsRunning(uuid string) bool
+	StopBot(uuid string) error
+	StartBot(ctx context.Context, uuid string) error
+}
+
+// shouldRestartForSmartGuideChange reports whether a running bot must be
+// restarted because its SmartGuide config (or the name embedded in the
+// _internal_smart_guide_{uuid} rule description) changed.
+//
+// Callers must pass enabledToggled=true when the same request also flipped
+// Enabled — that case is handled by the enabled-toggle branch and must not
+// be double-handled here.
+func shouldRestartForSmartGuideChange(before, after db.Settings, enabledToggled bool) bool {
+	if enabledToggled {
+		return false
+	}
+	if !after.Enabled {
+		return false
+	}
+	return before.SmartGuideProvider != after.SmartGuideProvider ||
+		before.SmartGuideModel != after.SmartGuideModel ||
+		before.Name != after.Name
+}
+
+// restartBotForSmartGuideChange stops and re-starts a running bot so it
+// picks up the new SmartGuide config. No-op when mgr is nil or the bot
+// isn't currently running. Stop / start failures are logged but do not
+// surface to the API caller, matching the enabled-toggle branch.
+func restartBotForSmartGuideChange(ctx context.Context, mgr botLifecycle, uuid string) {
+	if mgr == nil || !mgr.IsRunning(uuid) {
+		return
+	}
+	if err := mgr.StopBot(uuid); err != nil {
+		logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to stop bot for SmartGuide config refresh")
+	}
+	if err := mgr.StartBot(ctx, uuid); err != nil {
+		logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to restart bot after SmartGuide config change")
+	}
+}
+
 // Handler handles ImBot settings HTTP requests
 type Handler struct {
 	config         *config.Config
@@ -324,17 +368,8 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	// _internal_smart_guide_{uuid} rule pick up the new provider/model.
 	// Skipped when enabled was toggled in the same request — that branch above
 	// already starts/stops the bot.
-	smartGuideChanged := currentSettings.SmartGuideProvider != settings.SmartGuideProvider ||
-		currentSettings.SmartGuideModel != settings.SmartGuideModel ||
-		currentSettings.Name != settings.Name
-	if smartGuideChanged && !enabledToggled && settings.Enabled && h.botMgr != nil && h.botMgr.IsRunning(uuid) {
-		ctx := context.Background()
-		if err := h.botMgr.StopBot(uuid); err != nil {
-			logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to stop bot for SmartGuide config refresh")
-		}
-		if err := h.botMgr.StartBot(ctx, uuid); err != nil {
-			logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to restart bot after SmartGuide config change")
-		}
+	if shouldRestartForSmartGuideChange(currentSettings, settings, enabledToggled) {
+		restartBotForSmartGuideChange(context.Background(), h.botMgr, uuid)
 	}
 
 	// Fetch updated settings

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -242,6 +242,8 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	// Only set fields if they are provided in the request
 	if req.Name != "" {
 		settings.Name = strings.TrimSpace(req.Name)
+	} else {
+		settings.Name = currentSettings.Name
 	}
 
 	settings.Platform = platform
@@ -299,7 +301,8 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	logrus.WithField("uuid", uuid).Info("ImBot settings updated")
 
 	// Handle bot lifecycle if enabled status changed
-	if currentSettings.Enabled != settings.Enabled {
+	enabledToggled := currentSettings.Enabled != settings.Enabled
+	if enabledToggled {
 		if h.botMgr != nil {
 			ctx := context.Background()
 			if settings.Enabled {
@@ -313,6 +316,24 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 					logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to stop bot after update")
 				}
 			}
+		}
+	}
+
+	// Restart a running bot when SmartGuide config (or the name embedded in the
+	// rule description) changes, so the running BotSetting and the
+	// _internal_smart_guide_{uuid} rule pick up the new provider/model.
+	// Skipped when enabled was toggled in the same request — that branch above
+	// already starts/stops the bot.
+	smartGuideChanged := currentSettings.SmartGuideProvider != settings.SmartGuideProvider ||
+		currentSettings.SmartGuideModel != settings.SmartGuideModel ||
+		currentSettings.Name != settings.Name
+	if smartGuideChanged && !enabledToggled && settings.Enabled && h.botMgr != nil && h.botMgr.IsRunning(uuid) {
+		ctx := context.Background()
+		if err := h.botMgr.StopBot(uuid); err != nil {
+			logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to stop bot for SmartGuide config refresh")
+		}
+		if err := h.botMgr.StartBot(ctx, uuid); err != nil {
+			logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to restart bot after SmartGuide config change")
 		}
 	}
 

--- a/internal/server/module/imbot/handler_test.go
+++ b/internal/server/module/imbot/handler_test.go
@@ -1,6 +1,8 @@
 package imbot
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -426,6 +428,152 @@ func TestPlatformConfigStructure(t *testing.T) {
 		t.Errorf("expected 1 field, got %d", len(config.Fields))
 	}
 }
+
+// fakeBotLifecycle is a minimal botLifecycle stand-in that records every
+// call so the tests can assert order and arguments.
+type fakeBotLifecycle struct {
+	running    bool
+	stopCalls  []string
+	startCalls []string
+	calls      []string // ordered log of "stop"/"start"
+	stopErr    error
+	startErr   error
+}
+
+func (f *fakeBotLifecycle) IsRunning(uuid string) bool { return f.running }
+
+func (f *fakeBotLifecycle) StopBot(uuid string) error {
+	f.stopCalls = append(f.stopCalls, uuid)
+	f.calls = append(f.calls, "stop")
+	return f.stopErr
+}
+
+func (f *fakeBotLifecycle) StartBot(ctx context.Context, uuid string) error {
+	f.startCalls = append(f.startCalls, uuid)
+	f.calls = append(f.calls, "start")
+	return f.startErr
+}
+
+func TestShouldRestartForSmartGuideChange(t *testing.T) {
+	base := db.Settings{
+		Name:               "Bot A",
+		Enabled:            true,
+		SmartGuideProvider: "prov-old",
+		SmartGuideModel:    "model-old",
+	}
+
+	cases := []struct {
+		name           string
+		before         db.Settings
+		after          db.Settings
+		enabledToggled bool
+		want           bool
+	}{
+		{
+			name:   "provider changed -> restart",
+			before: base,
+			after: db.Settings{
+				Name: "Bot A", Enabled: true,
+				SmartGuideProvider: "prov-new", SmartGuideModel: "model-old",
+			},
+			want: true,
+		},
+		{
+			name:   "model changed -> restart",
+			before: base,
+			after: db.Settings{
+				Name: "Bot A", Enabled: true,
+				SmartGuideProvider: "prov-old", SmartGuideModel: "model-new",
+			},
+			want: true,
+		},
+		{
+			name:   "name changed -> restart (rule description embeds the name)",
+			before: base,
+			after: db.Settings{
+				Name: "Bot B", Enabled: true,
+				SmartGuideProvider: "prov-old", SmartGuideModel: "model-old",
+			},
+			want: true,
+		},
+		{
+			name:   "no relevant change -> no restart",
+			before: base,
+			after:  base,
+			want:   false,
+		},
+		{
+			name:   "unrelated field changed only -> no restart",
+			before: base,
+			after: db.Settings{
+				Name: "Bot A", Enabled: true,
+				SmartGuideProvider: "prov-old", SmartGuideModel: "model-old",
+				ProxyURL: "http://proxy",
+			},
+			want: false,
+		},
+		{
+			name:   "disabled bot -> no restart even if model changed",
+			before: db.Settings{Name: "Bot A", Enabled: false, SmartGuideProvider: "prov-old", SmartGuideModel: "model-old"},
+			after:  db.Settings{Name: "Bot A", Enabled: false, SmartGuideProvider: "prov-new", SmartGuideModel: "model-old"},
+			want:   false,
+		},
+		{
+			name:           "enabled toggled in same request -> defer to enabled-toggle branch",
+			before:         db.Settings{Name: "Bot A", Enabled: false, SmartGuideProvider: "prov-old", SmartGuideModel: "model-old"},
+			after:          db.Settings{Name: "Bot A", Enabled: true, SmartGuideProvider: "prov-new", SmartGuideModel: "model-old"},
+			enabledToggled: true,
+			want:           false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldRestartForSmartGuideChange(tc.before, tc.after, tc.enabledToggled)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRestartBotForSmartGuideChange_Running_StopsThenStarts(t *testing.T) {
+	mgr := &fakeBotLifecycle{running: true}
+
+	restartBotForSmartGuideChange(context.Background(), mgr, "uuid-1")
+
+	assert.Equal(t, []string{"stop", "start"}, mgr.calls,
+		"stop must happen before start so the new BotSetting is read fresh")
+	assert.Equal(t, []string{"uuid-1"}, mgr.stopCalls)
+	assert.Equal(t, []string{"uuid-1"}, mgr.startCalls)
+}
+
+func TestRestartBotForSmartGuideChange_NotRunning_NoOp(t *testing.T) {
+	mgr := &fakeBotLifecycle{running: false}
+
+	restartBotForSmartGuideChange(context.Background(), mgr, "uuid-1")
+
+	assert.Empty(t, mgr.calls, "must not touch a bot that isn't running")
+}
+
+func TestRestartBotForSmartGuideChange_NilManager_NoPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		restartBotForSmartGuideChange(context.Background(), nil, "uuid-1")
+	})
+}
+
+func TestRestartBotForSmartGuideChange_StopFails_StillStarts(t *testing.T) {
+	// If Stop fails (e.g. timeout), we still attempt Start so a transient
+	// stop failure doesn't leave the bot running with stale config.
+	mgr := &fakeBotLifecycle{running: true, stopErr: errors.New("boom")}
+
+	restartBotForSmartGuideChange(context.Background(), mgr, "uuid-1")
+
+	assert.Equal(t, []string{"stop", "start"}, mgr.calls)
+}
+
+// Ensure the production type satisfies the interface used by the helper.
+// This is a compile-time assertion: if BotManager's signatures drift the
+// build breaks here, not in production at request time.
+var _ botLifecycle = (*BotManager)(nil)
 
 func TestDeleteResponseStructure(t *testing.T) {
 	response := DeleteResponse{


### PR DESCRIPTION
…anges

UpdateSettings only restarted bots on enabled toggle, so changing smartguide_provider/smartguide_model from the frontend left the running bot using its cached BotSetting and the stale _internal_smart_guide_{uuid} rule. New branch restarts a running, still-enabled bot when SmartGuide config (or the name embedded in the rule description) changes; the restart re-reads settings and re-runs EnsureSmartGuideRuleForBot, syncing both the in-memory BotSetting and the routing rule.

https://claude.ai/code/session_015QMDXxGof6AHQycedS7jzJ