### PR TITLE
feat(ui): add npm mirror command support for agent setup

### DIFF
--- a/frontend/src/components/AgentSetupCard.tsx
+++ b/frontend/src/components/AgentSetupCard.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import UnifiedCard from '@/components/UnifiedCard';
 import { api } from '@/services/api';
+import { copyableTextStyle } from '@/styles/textStyles';
 
 export interface AgentApplyResult {
     success: boolean;
@@ -30,6 +31,7 @@ export interface AgentSetupCardProps {
     agentKey: string;
     agentName: string;
     installCommand: string;
+    installMirrorCommand?: string;
     onApply: () => Promise<AgentApplyResult>;
     onApplyWithStatusLine?: () => Promise<AgentApplyResult>;
     isApplyLoading?: boolean;
@@ -50,6 +52,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     agentKey,
     agentName,
     installCommand,
+    installMirrorCommand,
     onApply,
     onApplyWithStatusLine,
     isApplyLoading = false,
@@ -69,6 +72,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     const [providerLoading, setProviderLoading] = useState(true);
     const [applyResult, setApplyResult] = useState<AgentApplyResult | null>(null);
     const [copied, setCopied] = useState(false);
+    const [copiedMirror, setCopiedMirror] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
@@ -109,6 +113,13 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         await navigator.clipboard.writeText(installCommand);
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
+    };
+
+    const handleCopyMirror = async () => {
+        if (!installMirrorCommand) return;
+        await navigator.clipboard.writeText(installMirrorCommand);
+        setCopiedMirror(true);
+        setTimeout(() => setCopiedMirror(false), 1500);
     };
 
     const handleApply = async () => {
@@ -204,32 +215,77 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                             <Typography variant="body2" fontWeight={500} color={step2Done ? 'text.primary' : 'primary.main'}>
                                 Step 2 — Install {agentName}
                             </Typography>
-                            <Box
-                                sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 1,
-                                    mt: 0.75,
-                                    px: 1.5,
-                                    py: 0.75,
-                                    bgcolor: 'background.default',
-                                    borderRadius: 1,
-                                    border: '1px solid',
-                                    borderColor: 'divider',
-                                }}
-                            >
-                                <Typography
-                                    variant="body2"
-                                    sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', fontSize: '0.8rem' }}
-                                >
-                                    {installCommand}
+
+                            {/* npm official */}
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}>
+                                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>
+                                    npm official
                                 </Typography>
-                                <Tooltip title={copied ? 'Copied!' : 'Copy'}>
-                                    <IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0 }}>
-                                        <ContentCopyIcon sx={{ fontSize: 16 }} />
-                                    </IconButton>
-                                </Tooltip>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}>
+                                    <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+                                        <IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0, p: 0.25 }}>
+                                            <ContentCopyIcon sx={{ fontSize: 14 }} />
+                                        </IconButton>
+                                    </Tooltip>
+                                    <Typography
+                                        variant="body2"
+                                        onClick={handleCopy}
+                                        sx={{
+                                            fontFamily: 'monospace',
+                                            flex: 1,
+                                            fontSize: '0.8rem',
+                                            color: 'text.primary',
+                                            cursor: 'pointer',
+                                            '&:hover': {
+                                                color: 'primary.main',
+                                            },
+                                            overflow: 'hidden',
+                                            textOverflow: 'ellipsis',
+                                            whiteSpace: 'nowrap',
+                                        }}
+                                        title={installCommand}
+                                    >
+                                        {installCommand}
+                                    </Typography>
+                                </Box>
                             </Box>
+
+                            {/* npm mirror */}
+                            {installMirrorCommand && (
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800, mt: 0.75 }}>
+                                    <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>
+                                        npm mirror
+                                    </Typography>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}>
+                                        <Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}>
+                                            <IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}>
+                                                <ContentCopyIcon sx={{ fontSize: 14 }} />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Typography
+                                            variant="body2"
+                                            onClick={handleCopyMirror}
+                                            sx={{
+                                                fontFamily: 'monospace',
+                                                flex: 1,
+                                                fontSize: '0.8rem',
+                                                color: 'text.primary',
+                                                cursor: 'pointer',
+                                                '&:hover': {
+                                                    color: 'primary.main',
+                                                },
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                            title={installMirrorCommand}
+                                        >
+                                            {installMirrorCommand}
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                            )}
+
                             {!step2Done && (
                                 <Button
                                     size="small"

--- a/frontend/src/components/AgentSetupCard.tsx
+++ b/frontend/src/components/AgentSetupCard.tsx
@@ -68,7 +68,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         () => localStorage.getItem(STEP3_KEY(agentKey)) === 'true'
     );
     const [hasProvider, setHasProvider] = useState(false);
-    const [providerName, setProviderName] = useState('');
+    const [providerCount, setProviderCount] = useState(0);
     const [providerLoading, setProviderLoading] = useState(true);
     const [applyResult, setApplyResult] = useState<AgentApplyResult | null>(null);
     const [copied, setCopied] = useState(false);
@@ -81,7 +81,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
             const providers = Array.isArray(result?.data) ? result.data : [];
             const enabled = providers.filter((p: any) => p.enabled);
             setHasProvider(enabled.length > 0);
-            setProviderName(enabled[0]?.name ?? '');
+            setProviderCount(enabled.length);
             setProviderLoading(false);
         }).catch(() => {
             if (!cancelled) setProviderLoading(false);
@@ -187,7 +187,9 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                             </Typography>
                             {step1Done ? (
                                 <Typography variant="caption" color="text.secondary">
-                                    {providerName} is ready
+                                    {providerCount === 1
+                                        ? `${providerCount} provider ready`
+                                        : `${providerCount} providers ready`}
                                 </Typography>
                             ) : (
                                 <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -247,6 +247,7 @@ const UseClaudeCodePageContent: React.FC = () => {
                     agentKey={SCENARIO}
                     agentName="Claude Code"
                     installCommand="npm install -g @anthropic-ai/claude-code"
+                    installMirrorCommand="npm install -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com"
                     onApply={handleApply}
                     onApplyWithStatusLine={handleApplyWithStatusLine}
                     isApplyLoading={isApplyLoading}

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -73,6 +73,7 @@ const UseCodexPageContent: React.FC = () => {
                     agentKey={scenario}
                     agentName="Codex"
                     installCommand="npm install -g @openai/codex"
+                    installMirrorCommand="npm install -g @openai/codex --registry=https://registry.npmmirror.com"
                     onApply={handleApply}
                     onViewConfig={() => setConfigModalOpen(true)}
                 />

--- a/frontend/src/pages/scenario/UseOpenCodePage.tsx
+++ b/frontend/src/pages/scenario/UseOpenCodePage.tsx
@@ -121,6 +121,7 @@ const UseOpenCodePageContent: React.FC = () => {
                     agentKey={scenario}
                     agentName="OpenCode"
                     installCommand="npm install -g opencode-ai"
+                    installMirrorCommand="npm install -g opencode-ai --registry=https://registry.npmmirror.com"
                     onApply={handleApply}
                     isApplyLoading={isApplyLoading}
                     onViewConfig={handleOpenConfigModal}


### PR DESCRIPTION
## Summary
Users in regions with limited npm registry access (e.g., China) struggle to install agent packages using the default npm command.
This change provides both official and mirror npm registry commands side-by-side in the setup card, allowing users to choose the fastest option for their
network.

### Major
- Added `installMirrorCommand` prop to `AgentSetupCard` component
- Displays two command rows with labels ("npm official" / "npm mirror")
- Each command has independent copy button and hover feedback
- Applied to ClaudeCode, Codex, and OpenCode agent setup pages

### Minor
- Replaced single provider name display with count-based message ("N providers ready")
- Improved command text overflow handling with ellipsis
- Single-row layout with inline copy buttons for compact design