### PR TITLE
bugfix(remote): should update bot setting dynamically; can not use "*" as remote control rule (use bot uuid instead)

### DIFF
--- a/internal/command/remote_control_command.go
+++ b/internal/command/remote_control_command.go
@@ -668,7 +668,8 @@ func runBotWithSettingsInternal(ctx context.Context, appManager *AppManager, set
 	pairing := bot.NewPairingManager(auditLog)
 
 	// Register unified message handler
-	handler := bot.NewBotHandler(ctx, setting, chatStore, sessionMgr, agentBoot, directoryBrowser, manager, tbClient, pairing, auditLog)
+	// Pass nil as SettingsStore - standalone bots don't have dynamic config updates
+	handler := bot.NewBotHandler(ctx, setting, chatStore, sessionMgr, agentBoot, directoryBrowser, manager, tbClient, pairing, auditLog, nil)
 	manager.OnMessage(handler.HandleMessage)
 
 	if err := manager.Start(ctx); err != nil {

--- a/internal/remote_control/bot/agent_executor.go
+++ b/internal/remote_control/bot/agent_executor.go
@@ -57,7 +57,11 @@ type ExecutionResult struct {
 
 // ExecutorDependencies holds shared dependencies for agent executors and router.
 type ExecutorDependencies struct {
-	BotSetting                 BotSetting
+	// GetBotSetting dynamically retrieves the current bot settings from the store.
+	// This ensures that any configuration changes (provider, model, etc.) are reflected
+	// immediately without requiring a bot restart.
+	GetBotSetting func() (BotSetting, error)
+
 	ChatStore                  ChatStoreInterface
 	SessionMgr                 *SessionManager
 	AgentBoot                  *agentboot.AgentBoot
@@ -78,6 +82,15 @@ type ExecutorDependencies struct {
 	NewStreamingMessageHandler func(hCtx HandlerContext, meta *ResponseMeta) *streamingMessageHandler
 }
 
+// GetBotSettingOrCache returns the current bot setting.
+// If dynamic lookup fails, returns an empty setting.
+func (d *ExecutorDependencies) GetBotSettingOrCache() BotSetting {
+	if setting, err := d.GetBotSetting(); err == nil {
+		return setting
+	}
+	return BotSetting{}
+}
+
 // resolveProjectPath resolves project path: override > ChatStore > default.
 func (d *ExecutorDependencies) resolveProjectPath(chatID string, override string) string {
 	if override != "" {
@@ -89,14 +102,14 @@ func (d *ExecutorDependencies) resolveProjectPath(chatID string, override string
 	return d.ResolveDefaultProjectPath()
 }
 
-// ResolveDefaultProjectPath returns the default project path.
-// Priority: 1. DefaultCwd from bot setting, 2. Current working directory, 3. User home directory
+// ResolveDefaultProjectPath returns the default project path from bot settings.
 func (d *ExecutorDependencies) ResolveDefaultProjectPath() string {
-	if d.BotSetting.DefaultCwd != "" {
-		if expanded, err := ExpandPath(d.BotSetting.DefaultCwd); err == nil {
+	setting := d.GetBotSettingOrCache()
+	if setting.DefaultCwd != "" {
+		if expanded, err := ExpandPath(setting.DefaultCwd); err == nil {
 			return expanded
 		}
-		logrus.WithField("path", d.BotSetting.DefaultCwd).Warn("Failed to expand DefaultCwd")
+		logrus.WithField("path", setting.DefaultCwd).Warn("Failed to expand DefaultCwd")
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		return cwd

--- a/internal/remote_control/bot/agent_smart_guide.go
+++ b/internal/remote_control/bot/agent_smart_guide.go
@@ -105,8 +105,7 @@ func (e *SmartGuideExecutor) Execute(ctx context.Context, req PreparedRequest) (
 		SmartGuideConfig: smart_guide.LoadSmartGuideConfig(),
 		BaseURL:          baseURL,
 		APIKey:           apiKey,
-		Provider:         botSetting.SmartGuideProvider,
-		Model:            botSetting.SmartGuideModel,
+		Model:            botSetting.UUID, // use bot uuid as model (rule)
 		Handler:          agentboot.NewCompositeHandler().SetApprovalHandler(e.deps.IMPrompter),
 		ChatID:           hCtx.ChatID,
 		Platform:         string(hCtx.Platform),

--- a/internal/remote_control/bot/agent_smart_guide.go
+++ b/internal/remote_control/bot/agent_smart_guide.go
@@ -34,6 +34,9 @@ func (e *SmartGuideExecutor) Execute(ctx context.Context, req PreparedRequest) (
 	projectPath := req.ProjectPath
 	meta := req.Meta
 
+	// Get current bot settings (dynamic lookup for latest config)
+	botSetting := e.deps.GetBotSettingOrCache()
+
 	// 1. Load messages from session store
 	var messages []*message.Msg
 	if e.deps.TBSessionStore != nil {
@@ -86,7 +89,7 @@ func (e *SmartGuideExecutor) Execute(ctx context.Context, req PreparedRequest) (
 				},
 				Reason:    prompt,
 				SessionID: hCtx.ChatID,
-				BotUUID:   e.deps.BotSetting.UUID,
+				BotUUID:   botSetting.UUID,
 				ChatID:    hCtx.ChatID,
 				Platform:  string(hCtx.Platform),
 			}
@@ -102,12 +105,12 @@ func (e *SmartGuideExecutor) Execute(ctx context.Context, req PreparedRequest) (
 		SmartGuideConfig: smart_guide.LoadSmartGuideConfig(),
 		BaseURL:          baseURL,
 		APIKey:           apiKey,
-		Provider:         e.deps.BotSetting.SmartGuideProvider,
-		Model:            e.deps.BotSetting.SmartGuideModel,
+		Provider:         botSetting.SmartGuideProvider,
+		Model:            botSetting.SmartGuideModel,
 		Handler:          agentboot.NewCompositeHandler().SetApprovalHandler(e.deps.IMPrompter),
 		ChatID:           hCtx.ChatID,
 		Platform:         string(hCtx.Platform),
-		BotUUID:          e.deps.BotSetting.UUID,
+		BotUUID:          botSetting.UUID,
 		ToolCtx:          toolCtx,
 		GetStatusFunc: func(chatID string) (*smart_guide.StatusInfo, error) {
 			projectPath, _, _ := e.deps.ChatStore.GetProjectPath(chatID)
@@ -184,7 +187,7 @@ func (e *SmartGuideExecutor) Execute(ctx context.Context, req PreparedRequest) (
 		agent:          agent,
 		projectPath:    projectPath,
 		meta:           meta,
-		behavior:       e.deps.BotSetting.GetOutputBehavior(),
+		behavior:       botSetting.GetOutputBehavior(),
 		formatResponse: e.deps.FormatResponse,
 		sendText:       e.deps.SendText,
 		messagesSent:   0,

--- a/internal/remote_control/bot/handler_constructor.go
+++ b/internal/remote_control/bot/handler_constructor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/agentboot"
 	"github.com/tingly-dev/tingly-box/imbot"
+	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/remote_control/audit"
 	"github.com/tingly-dev/tingly-box/internal/remote_control/bot/feature"
 	"github.com/tingly-dev/tingly-box/internal/remote_control/session"
@@ -25,6 +26,7 @@ func NewBotHandler(
 	tbClient tbclient.TBClient,
 	pairing *PairingManager,
 	auditLog *audit.Logger,
+	store SettingsStore,
 ) *BotHandler {
 	// Create IM prompter for permission requests
 	imPrompter := NewIMPrompter(manager)
@@ -109,7 +111,6 @@ func NewBotHandler(
 
 	// Initialize AgentRouter with dependencies
 	deps := &ExecutorDependencies{
-		BotSetting:                 botSetting,
 		ChatStore:                  chatStore,
 		SessionMgr:                 sessionMgr,
 		AgentBoot:                  agentBoot,
@@ -130,6 +131,36 @@ func NewBotHandler(
 			return handler.SendFile(context.Background(), hCtx, filePath, caption)
 		},
 		NewStreamingMessageHandler: handler.newStreamingMessageHandler,
+		// GetBotSetting dynamically fetches the current bot settings from the store
+		GetBotSetting: func() (BotSetting, error) {
+			if store == nil {
+				return botSetting, nil
+			}
+			settingsAny, err := store.GetSettingsByUUIDInterface(botSetting.UUID)
+			if err != nil {
+				return botSetting, err
+			}
+			// Handle both bot.Settings and db.Settings types
+			if record, ok := settingsAny.(db.Settings); ok {
+				return BotSetting{
+					UUID:               record.UUID,
+					Name:               record.Name,
+					Token:              record.Auth["token"],
+					Platform:           record.Platform,
+					AuthType:           record.AuthType,
+					Auth:               record.Auth,
+					ProxyURL:           record.ProxyURL,
+					ChatIDLock:         record.ChatIDLock,
+					BashAllowlist:      record.BashAllowlist,
+					DefaultCwd:         record.DefaultCwd,
+					Enabled:            record.Enabled,
+					SmartGuideProvider: record.SmartGuideProvider,
+					SmartGuideModel:    record.SmartGuideModel,
+					RequirePairing:     record.RequirePairing,
+				}, nil
+			}
+			return botSetting, nil
+		},
 	}
 	handler.agentRouter = NewAgentRouter(deps)
 	handler.InitCommandRegistry()

--- a/internal/remote_control/bot/manager.go
+++ b/internal/remote_control/bot/manager.go
@@ -337,7 +337,26 @@ func (m *Manager) Start(parentCtx context.Context, uuid string) error {
 	tbClient := m.tbClient
 	dataPath := m.dataPath
 
-	if s.SmartGuideProvider == "" || s.SmartGuideModel == "" {
+	// Update SmartGuide routing rule when bot starts
+	// This ensures the route rule is always in sync with the current settings
+	if s.SmartGuideProvider != "" && s.SmartGuideModel != "" && tbClient != nil {
+		if err := tbClient.EnsureSmartGuideRuleForBot(parentCtx, s.UUID, s.Name, s.SmartGuideProvider, s.SmartGuideModel); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"uuid":     uuid,
+				"name":     name,
+				"provider": s.SmartGuideProvider,
+				"model":    s.SmartGuideModel,
+			}).Error("Failed to update SmartGuide routing rule during bot start")
+			// Don't fail startup, SmartGuide will use fallback or error at execution time
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"uuid":     uuid,
+				"name":     name,
+				"provider": s.SmartGuideProvider,
+				"model":    s.SmartGuideModel,
+			}).Info("SmartGuide routing rule updated during bot start")
+		}
+	} else if s.SmartGuideProvider == "" || s.SmartGuideModel == "" {
 		logrus.WithFields(logrus.Fields{
 			"uuid":     uuid,
 			"name":     name,
@@ -384,6 +403,15 @@ func (m *Manager) Stop(uuid string) {
 		logrus.WithField("uuid", uuid).Info("Stopping bot")
 		rb.stopped = true // Mark as stopping
 		rb.cancel()
+
+		// Clean up SmartGuide routing rule when bot stops
+		if m.tbClient != nil {
+			if err := m.tbClient.DeleteSmartGuideRuleForBot(context.Background(), uuid); err != nil {
+				logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to delete SmartGuide routing rule")
+			} else {
+				logrus.WithField("uuid", uuid).Info("SmartGuide routing rule deleted")
+			}
+		}
 		// Don't delete from map yet - let the goroutine clean up
 	}
 }

--- a/internal/remote_control/bot/manager.go
+++ b/internal/remote_control/bot/manager.go
@@ -21,7 +21,7 @@ import (
 )
 
 // runBotWithSettings starts a bot using JSON file storage for chat state
-func runBotWithSettings(ctx context.Context, setting BotSetting, dataPath string, sessionMgr *session.Manager, agentBoot *agentboot.AgentBoot, tbClient tbclient.TBClient, pairing *PairingManager, auditLog *audit.Logger) error {
+func runBotWithSettings(ctx context.Context, setting BotSetting, dataPath string, sessionMgr *session.Manager, agentBoot *agentboot.AgentBoot, tbClient tbclient.TBClient, pairing *PairingManager, auditLog *audit.Logger, store SettingsStore) error {
 	// Create a JSON-based chat store
 	chatStore, err := NewChatStoreJSON(dataPath)
 	if err != nil {
@@ -73,7 +73,7 @@ func runBotWithSettings(ctx context.Context, setting BotSetting, dataPath string
 	}
 
 	// Register unified message handler with platform parameter
-	handler := NewBotHandler(ctx, setting, chatStore, sessionMgr, agentBoot, directoryBrowser, manager, tbClient, pairing, auditLog)
+	handler := NewBotHandler(ctx, setting, chatStore, sessionMgr, agentBoot, directoryBrowser, manager, tbClient, pairing, auditLog, store)
 	manager.OnMessage(handler.HandleMessage)
 
 	if err := manager.Start(ctx); err != nil {
@@ -359,9 +359,10 @@ func (m *Manager) Start(parentCtx context.Context, uuid string) error {
 	// Start bot in goroutine (dataPath and tbClient already captured above)
 	pairing := m.pairing
 	auditLog := m.audit
+	store := m.store
 	go func() {
 		defer close(doneChan) // Signal that goroutine is done
-		if err := runBotWithSettings(ctx, s, dataPath, m.sessionMgr, m.agentBoot, tbClient, pairing, auditLog); err != nil {
+		if err := runBotWithSettings(ctx, s, dataPath, m.sessionMgr, m.agentBoot, tbClient, pairing, auditLog, store); err != nil {
 			logrus.WithError(err).WithField("uuid", uuid).Warn("Bot stopped with error")
 		}
 

--- a/internal/remote_control/bot/type.go
+++ b/internal/remote_control/bot/type.go
@@ -53,6 +53,6 @@ type Lifecycle interface {
 // runningBot tracks a running bot instance
 type runningBot struct {
 	cancel   context.CancelFunc
-	stopped  bool          // marker to indicate if bot is being stopped
-	doneChan chan struct{} // closed when goroutine finishes
+	stopped  bool          // marker to indicate if the bot is being stopped
+	doneChan chan struct{} // closed when the goroutine finishes
 }

--- a/internal/remote_control/smart_guide/agent.go
+++ b/internal/remote_control/smart_guide/agent.go
@@ -54,13 +54,13 @@ type TinglyBoxAgent struct {
 // AgentConfig holds the configuration for creating a TinglyBoxAgent
 type AgentConfig struct {
 	SmartGuideConfig *SmartGuideConfig
+	ToolExecutor     *ToolExecutor
+
 	// HTTP endpoint configuration (resolved from TBClient by caller)
-	BaseURL      string // e.g., "http://localhost:12580/tingly/_smart_guide"
-	APIKey       string // Tingly-box authentication token
-	ToolExecutor *ToolExecutor
-	// SmartGuide model configuration (required from bot setting)
-	Provider string // Provider UUID
-	Model    string // Model identifier
+	BaseURL string // e.g., "http://localhost:12580/tingly/_smart_guide"
+	APIKey  string // Tingly-box authentication token
+	Model   string // Model identifier
+
 	// Callback functions for internal tools
 	GetStatusFunc     func(chatID string) (*StatusInfo, error)
 	GetProjectFunc    func(chatID string) (string, bool, error)
@@ -96,7 +96,7 @@ func NewTinglyBoxAgent(config *AgentConfig) (*TinglyBoxAgent, error) {
 	var modelConfig *anthropic.Config
 
 	// Validate that SmartGuide config is provided
-	if config.Provider == "" || config.Model == "" {
+	if config.Model == "" {
 		return nil, fmt.Errorf("smartguide_provider and smartguide_model are required in bot setting")
 	}
 
@@ -112,7 +112,6 @@ func NewTinglyBoxAgent(config *AgentConfig) (*TinglyBoxAgent, error) {
 		BaseURL: config.BaseURL,
 	}
 	logrus.WithFields(logrus.Fields{
-		"provider": config.Provider,
 		"model":    config.Model,
 		"endpoint": config.BaseURL,
 	}).Info("Using HTTP endpoint for smartguide agent")
@@ -322,43 +321,6 @@ func (a *TinglyBoxAgent) IsEnabled() bool {
 // GetConfig returns the agent's configuration
 func (a *TinglyBoxAgent) GetConfig() *SmartGuideConfig {
 	return a.config
-}
-
-// AgentFactory creates TinglyBoxAgent instances
-type AgentFactory struct {
-	config             *SmartGuideConfig
-	baseURL            string // HTTP endpoint URL
-	apiKey             string // Authentication token
-	smartGuideProvider string // Provider UUID
-	smartGuideModel    string // Model identifier
-}
-
-// NewAgentFactory creates a new agent factory
-func NewAgentFactory(config *SmartGuideConfig, baseURL, apiKey string, smartGuideProvider, smartGuideModel string) *AgentFactory {
-	return &AgentFactory{
-		config:             config,
-		baseURL:            baseURL,
-		apiKey:             apiKey,
-		smartGuideProvider: smartGuideProvider,
-		smartGuideModel:    smartGuideModel,
-	}
-}
-
-// CreateAgent creates a new TinglyBoxAgent with the given callbacks
-func (f *AgentFactory) CreateAgent(getStatusFunc func(chatID string) (*StatusInfo, error),
-	getProjectFunc func(chatID string) (string, bool, error),
-	updateProjectFunc func(chatID string, projectPath string) error) (*TinglyBoxAgent, error) {
-
-	return NewTinglyBoxAgent(&AgentConfig{
-		SmartGuideConfig:  f.config,
-		BaseURL:           f.baseURL,
-		APIKey:            f.apiKey,
-		Provider:          f.smartGuideProvider,
-		Model:             f.smartGuideModel,
-		GetStatusFunc:     getStatusFunc,
-		GetProjectFunc:    getProjectFunc,
-		UpdateProjectFunc: updateProjectFunc,
-	})
 }
 
 // CanCreateAgent checks if a SmartGuide agent can be created with the given configuration

--- a/internal/remote_control/smart_guide/agent_test.go
+++ b/internal/remote_control/smart_guide/agent_test.go
@@ -56,7 +56,6 @@ func TestNewTinglyBoxAgent_DefaultConfig(t *testing.T) {
 		SmartGuideConfig: DefaultSmartGuideConfig(),
 		BaseURL:          "http://localhost:12580/tingly/_smart_guide",
 		APIKey:           "test-api-key",
-		Provider:         "test-provider",
 		Model:            "claude-sonnet-4-6",
 		GetStatusFunc: func(chatID string) (*StatusInfo, error) {
 			return &StatusInfo{}, nil
@@ -79,7 +78,6 @@ func TestNewTinglyBoxAgent_NoAPIKey(t *testing.T) {
 		SmartGuideConfig: DefaultSmartGuideConfig(),
 		BaseURL:          "http://localhost:12580/tingly/_smart_guide",
 		APIKey:           "", // Empty API key
-		Provider:         "test-provider",
 		Model:            "claude-sonnet-4-6",
 	}
 	agent, err := NewTinglyBoxAgent(cfg)
@@ -93,7 +91,6 @@ func TestNewTinglyBoxAgent_NoBaseURL(t *testing.T) {
 		SmartGuideConfig: DefaultSmartGuideConfig(),
 		BaseURL:          "", // Empty BaseURL
 		APIKey:           "test-api-key",
-		Provider:         "test-provider",
 		Model:            "claude-sonnet-4-6",
 	}
 	agent, err := NewTinglyBoxAgent(cfg)
@@ -108,7 +105,6 @@ func TestNewTinglyBoxAgent_CustomToolExecutor(t *testing.T) {
 		SmartGuideConfig: DefaultSmartGuideConfig(),
 		BaseURL:          "http://localhost:12580/tingly/_smart_guide",
 		APIKey:           "test-api-key",
-		Provider:         "test-provider",
 		Model:            "claude-sonnet-4-6",
 		ToolExecutor:     customExecutor,
 	}
@@ -203,32 +199,6 @@ func TestTinglyBoxAgent_GetConfig(t *testing.T) {
 	cfg := DefaultSmartGuideConfig()
 	agent := &TinglyBoxAgent{config: cfg}
 	assert.Same(t, cfg, agent.GetConfig())
-}
-
-func TestNewAgentFactory(t *testing.T) {
-	cfg := DefaultSmartGuideConfig()
-	factory := NewAgentFactory(cfg, "http://localhost:12580/tingly/_smart_guide", "test-api-key", "test-provider", "test-model")
-	assert.NotNil(t, factory)
-	assert.Same(t, cfg, factory.config)
-	assert.Equal(t, "http://localhost:12580/tingly/_smart_guide", factory.baseURL)
-	assert.Equal(t, "test-api-key", factory.apiKey)
-}
-
-func TestAgentFactory_CreateAgent(t *testing.T) {
-	cfg := DefaultSmartGuideConfig()
-	factory := NewAgentFactory(cfg, "http://localhost:12580/tingly/_smart_guide", "test-api-key", "test-provider", "test-model")
-
-	getStatus := func(chatID string) (*StatusInfo, error) { return &StatusInfo{}, nil }
-	getProject := func(chatID string) (string, bool, error) { return "", false, nil }
-	updateProject := func(chatID string, projectPath string) error { return nil }
-
-	testAgent, err := factory.CreateAgent(getStatus, getProject, updateProject)
-	assert.NoError(t, err)
-	assert.NotNil(t, testAgent)
-	assert.NotNil(t, testAgent.ReActAgent)
-	assert.NotNil(t, testAgent.config)
-	assert.NotNil(t, testAgent.executor)
-	assert.NotNil(t, testAgent.toolkit)
 }
 
 func TestToolExecutor_SetWorkingDirectory(t *testing.T) {

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -36,6 +37,7 @@ func Migrate(c *Config) error {
 	migrate20260306(c)
 	migrate20260416(c) // Enable multi-tenant by default
 	migrate20260421(c) // Migrate profile unified model from "*" to "cc"
+	migrate20260502(c) // Remove wildcard (*) rules for smart_guide scenario
 	return nil
 }
 
@@ -401,5 +403,34 @@ func migrate20260421(c *Config) {
 
 	if needsSave {
 		_ = c.Save()
+	}
+}
+
+// migrate20260502 removes wildcard (*) rules for smart_guide scenario
+// This cleans up legacy wildcard rules that are no longer needed
+// as SmartGuide now uses bot-specific rules with UUID pattern: _internal_smart_guide_{botUUID}
+func migrate20260502(c *Config) {
+	needsSave := false
+
+	// Filter out smart_guide rules with wildcard RequestModel
+	var filteredRules []typ.Rule
+	for _, rule := range c.Rules {
+		// Skip smart_guide rules with wildcard RequestModel
+		if rule.Scenario == typ.ScenarioSmartGuide && rule.RequestModel == "*" {
+			logrus.WithFields(logrus.Fields{
+				"rule_uuid":      rule.UUID,
+				"request_model":  rule.RequestModel,
+				"response_model": rule.ResponseModel,
+			}).Info("Removing smart_guide wildcard rule")
+			needsSave = true
+			continue
+		}
+		filteredRules = append(filteredRules, rule)
+	}
+
+	if needsSave {
+		c.Rules = filteredRules
+		_ = c.Save()
+		logrus.Info("Migration 2026-05-02 completed: removed smart_guide wildcard rules")
 	}
 }

--- a/internal/server/config/rule.go
+++ b/internal/server/config/rule.go
@@ -69,7 +69,7 @@ func (c *Config) EnsureSmartGuideRuleForBot(botUUID, botName, providerUUID, mode
 		newRule := typ.Rule{
 			UUID:          ruleUUID,
 			Scenario:      typ.ScenarioSmartGuide,
-			RequestModel:  WildcardRuleName,
+			RequestModel:  botUUID, // Use actual bot UUID instead of wildcard
 			ResponseModel: modelID,
 			Description:   fmt.Sprintf("Auto-generated rule for SmartGuide bot '%s' (DO NOT EDIT)", displayName),
 			Services: []*loadbalance.Service{

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -298,20 +298,25 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 
 	logrus.WithField("uuid", uuid).Info("ImBot settings updated")
 
-	// Handle bot lifecycle if enabled status changed
+	// Handle enabled status changes only
+	// Config changes (provider, model, etc.) take effect automatically via dynamic lookup
 	if currentSettings.Enabled != settings.Enabled {
 		if h.botMgr != nil {
 			ctx := context.Background()
 			if settings.Enabled {
-				// Enable -> start the bot
-				if err := h.botMgr.StartBot(ctx, uuid); err != nil {
-					logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to start bot after update")
-				}
+				// Disabled -> Enabled: start the bot
+				go func() {
+					if err := h.botMgr.StartBot(ctx, uuid); err != nil {
+						logrus.WithError(err).WithField("uuid", uuid).Error("Failed to start bot after enabling")
+					}
+				}()
 			} else {
-				// Disable -> stop the bot
-				if err := h.botMgr.StopBot(uuid); err != nil {
-					logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to stop bot after update")
-				}
+				// Enabled -> Disabled: stop the bot
+				go func() {
+					if err := h.botMgr.StopBot(uuid); err != nil {
+						logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to stop bot after disabling")
+					}
+				}()
 			}
 		}
 	}

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -298,6 +298,24 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 
 	logrus.WithField("uuid", uuid).Info("ImBot settings updated")
 
+	// Update SmartGuide routing rule if provider/model configured
+	// This ensures the routing rule stays in sync with the configuration
+	if settings.SmartGuideProvider != "" && settings.SmartGuideModel != "" {
+		if err := h.config.EnsureSmartGuideRuleForBot(uuid, settings.Name, settings.SmartGuideProvider, settings.SmartGuideModel); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"uuid":     uuid,
+				"provider": settings.SmartGuideProvider,
+				"model":    settings.SmartGuideModel,
+			}).Error("Failed to update SmartGuide routing rule")
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"uuid":     uuid,
+				"provider": settings.SmartGuideProvider,
+				"model":    settings.SmartGuideModel,
+			}).Info("SmartGuide routing rule updated")
+		}
+	}
+
 	// Handle enabled status changes only
 	// Config changes (provider, model, etc.) take effect automatically via dynamic lookup
 	if currentSettings.Enabled != settings.Enabled {

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -10,6 +10,12 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// SmartGuideRuleUUID generates the rule UUID for a specific bot
+// Uses the bot UUID directly as the rule UUID for consistency
+func SmartGuideRuleUUID(botUUID string) string {
+	return botUUID
+}
+
 // TBClient defines the interface for remote control interactions
 type TBClient interface {
 
@@ -38,8 +44,11 @@ type TBClient interface {
 	EnsureSmartGuideRule(ctx context.Context, providerUUID, modelID string) error
 
 	// EnsureSmartGuideRuleForBot ensures the _smart_guide rule exists for a specific bot
-	// Each bot gets its own rule with UUID: _internal_smart_guide_{botUUID}
+	// Each bot gets its own rule with UUID equal to botUUID
 	EnsureSmartGuideRuleForBot(ctx context.Context, botUUID, botName, providerUUID, modelID string) error
+
+	// DeleteSmartGuideRuleForBot removes the _smart_guide rule for a specific bot
+	DeleteSmartGuideRuleForBot(ctx context.Context, botUUID string) error
 
 	// SelectModel returns model configuration for @tb execution
 	SelectModel(ctx context.Context, req ModelSelectionRequest) (*ModelConfig, error)
@@ -261,4 +270,10 @@ func (c *TBClientImpl) EnsureSmartGuideRule(ctx context.Context, providerUUID, m
 // Each bot gets its own rule with UUID: _internal_smart_guide_{botUUID}
 func (c *TBClientImpl) EnsureSmartGuideRuleForBot(ctx context.Context, botUUID, botName, providerUUID, modelID string) error {
 	return c.config.EnsureSmartGuideRuleForBot(botUUID, botName, providerUUID, modelID)
+}
+
+// DeleteSmartGuideRuleForBot removes the _smart_guide rule for a specific bot
+func (c *TBClientImpl) DeleteSmartGuideRuleForBot(ctx context.Context, botUUID string) error {
+	ruleUUID := SmartGuideRuleUUID(botUUID)
+	return c.config.DeleteRule(ruleUUID)
 }


### PR DESCRIPTION
- feat: load bot setting dynamically
- bugfix: can not use "*" as remote control agent rule, and we do migration for new users
- feat: update smart guide routing rule for each time to confirm up-to-date