### PR TITLE
feat(scenario): add embed API support to routing gateway

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import UseAgentPage from './pages/scenario/UseAgentPage';
 import UseOpenCodePage from './pages/scenario/UseOpenCodePage';
 import UseXcodePage from './pages/scenario/UseXcodePage';
 import UseVSCodePage from './pages/scenario/UseVSCodePage';
+import UseEmbedPage from './pages/scenario/UseEmbedPage';
 import CredentialPage from './pages/CredentialPage';
 import ProviderListPage from './pages/ProviderListPage';
 import System from './pages/System';
@@ -350,6 +351,7 @@ function AppContent() {
                     <Route path="/agent/opencode" element={<UseOpenCodePage />} />
                     <Route path="/agent/xcode" element={<UseXcodePage />} />
                     <Route path="/agent/vscode" element={<UseVSCodePage />} />
+                    <Route path="/agent/embed" element={<UseEmbedPage />} />
                     {/* Legacy redirects */}
                     <Route path="/use-openai" element={<Navigate to="/agent/openai" replace />} />
                     <Route path="/use-anthropic" element={<Navigate to="/agent/anthropic" replace />} />

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -16,6 +16,7 @@ export const SCENARIOS = {
   CLAUDE_CODE: 'claude_code',
   OPENCODE: 'opencode',
   VSCODE: 'vscode',
+  EMBED: 'embed', // Embedding application scenario
   GLOBAL: '_global', // Global flags that apply to all scenarios
 } as const;
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -43,6 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
+      "useEmbed": "Embed",
       "apiKeys": "API Keys",
       "oauth": "OAuth",
       "credential": "Credential",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -43,6 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
+      "useEmbed": "Embed 嵌入",
       "apiKeys": "API 密钥",
       "oauth": "OAuth 凭证",
       "credential": "凭证",

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -19,6 +19,7 @@ import {
     IconShield,
     IconLock,
     IconMessageCircle,
+    IconVector,
 } from '@tabler/icons-react';
 import { OpenAI, Anthropic, Claude, OpenCode, Xcode, VSCode, Telegram, Feishu, Lark, DingTalk, Weixin, WeCom, Codex, OpenClaw } from '../components/BrandIcons';
 import { SettingsApplications } from '@mui/icons-material';
@@ -101,6 +102,7 @@ export function useActivityItems(): ActivityItem[] {
                     { type: 'divider' },
                     { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> },
                     { path: '/agent/anthropic', label: t('layout.nav.useAnthropic', { defaultValue: 'Anthropic' }), icon: <Anthropic size={20} /> },
+                    { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embed' }), icon: <IconVector size={20} /> },
                     { type: 'divider' },
                     { path: '/agent/agent', label: t('common.openClaw', { defaultValue: 'OpenClaw' }), icon: <OpenClaw size={20} /> },
                 ],

--- a/frontend/src/pages/scenario/UseEmbedPage.tsx
+++ b/frontend/src/pages/scenario/UseEmbedPage.tsx
@@ -1,0 +1,57 @@
+import CardGrid from "@/components/CardGrid.tsx";
+import UnifiedCard from "@/components/UnifiedCard.tsx";
+import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
+import { Box } from '@mui/material';
+import PageLayout from '@/components/PageLayout';
+import TemplatePage from './components/TemplatePage.tsx';
+import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
+import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
+
+const scenario = "embed";
+
+const UseEmbedPageContent: React.FC = () => {
+    const {
+        isLoading,
+        notification,
+        copyToClipboard,
+        baseUrl,
+    } = useScenarioPageInternal(scenario);
+
+    return (
+        <PageLayout loading={isLoading} notification={notification}>
+            <CardGrid>
+                <UnifiedCard
+                    title={
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <span>Embed API Configuration</span>
+                        </Box>
+                    }
+                    size="full"
+                >
+                    <ProviderConfigCard
+                        title="Embed API Configuration"
+                        baseUrlPath="/tingly/embed"
+                        baseUrl={baseUrl}
+                        onCopy={copyToClipboard}
+                    />
+                </UnifiedCard>
+                <TemplatePage
+                    scenario={scenario}
+                    title="Embedding Models and Forwarding Rules"
+                    collapsible={true}
+                    allowDeleteRule={true}
+                />
+            </CardGrid>
+        </PageLayout>
+    );
+};
+
+const UseEmbedPage: React.FC = () => {
+    return (
+        <ScenarioPageModalProvider>
+            <UseEmbedPageContent />
+        </ScenarioPageModalProvider>
+    );
+};
+
+export default UseEmbedPage;

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -119,6 +119,11 @@ func (c *OpenAIClient) ChatCompletionsNewStreaming(ctx context.Context, req open
 	return c.client.Chat.Completions.NewStreaming(ctx, req)
 }
 
+// EmbeddingsNew creates a new embeddings request
+func (c *OpenAIClient) EmbeddingsNew(ctx context.Context, req openai.EmbeddingNewParams) (*openai.CreateEmbeddingResponse, error) {
+	return c.client.Embeddings.New(ctx, req)
+}
+
 // ResponsesNew creates a new Responses API request
 func (c *OpenAIClient) ResponsesNew(ctx context.Context, req responses.ResponseNewParams) (*responses.Response, error) {
 	return c.client.Responses.New(ctx, req)

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -52,6 +52,16 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 		return
 	}
 
+	if !typ.ScenarioSupportsTransport(scenarioType, typ.TransportAnthropic) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: fmt.Sprintf("scenario %s does not support Anthropic messages", scenario),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
 	// Start scenario-level recording (client -> tingly-box traffic) only if enabled
 	var recorder *ProtocolRecorder
 	if s.ApplyRecording(scenarioType) {

--- a/internal/server/forwarding/openai.go
+++ b/internal/server/forwarding/openai.go
@@ -34,6 +34,23 @@ func ForwardOpenAIChat(fc *ForwardContext, wrapper *client.OpenAIClient, req *op
 	return resp, cancel, err
 }
 
+// ForwardOpenAIEmbeddings sends an OpenAI embeddings request.
+// Embeddings have no streaming and skip the chat transform chain.
+func ForwardOpenAIEmbeddings(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.EmbeddingNewParams) (*openai.CreateEmbeddingResponse, context.CancelFunc, error) {
+	if wrapper == nil {
+		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
+	}
+
+	ctx, cancel := fc.PrepareContext(req)
+
+	logrus.Infof("provider: %s, model: %s (embeddings)", fc.Provider.Name, req.Model)
+
+	resp, err := wrapper.EmbeddingsNew(ctx, *req)
+	fc.Complete(ctx, resp, err)
+
+	return resp, cancel, err
+}
+
 // ForwardOpenAIChatStream sends a streaming OpenAI chat completion request.
 // IMPORTANT: All transformations (protocol conversion + vendor-specific) should
 // be applied by the transform chain BEFORE calling this function.

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -165,6 +165,16 @@ func (s *Server) HandleOpenAIChatCompletions(c *gin.Context) {
 		return
 	}
 
+	if !typ.ScenarioSupportsTransport(scenarioType, typ.TransportOpenAI) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: fmt.Sprintf("scenario %s does not support OpenAI chat completions", scenario),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
 	// Check if this is the request model name first
 	rule, err = s.determineRuleWithScenario(c, scenarioType, req.Model)
 	if err != nil {

--- a/internal/server/openai_embeddings.go
+++ b/internal/server/openai_embeddings.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/server/forwarding"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// HandleOpenAIEmbeddings serves OpenAI-compatible embedding requests.
+//
+// The endpoint is exposed via the mixin route group, so any scenario whose
+// descriptor declares TransportOpenAI or TransportEmbed can reach it. The
+// canonical home is the dedicated `embed` scenario; `openai` scenario also
+// works because its descriptor is extended with TransportEmbed.
+func (s *Server) HandleOpenAIEmbeddings(c *gin.Context) {
+	scenario := c.Param("scenario")
+	scenarioType := typ.RuleScenario(scenario)
+
+	if !isValidRuleScenario(scenarioType) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: fmt.Sprintf("invalid scenario: %s", scenario),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	if !typ.ScenarioSupportsTransport(scenarioType, typ.TransportOpenAI) &&
+		!typ.ScenarioSupportsTransport(scenarioType, typ.TransportEmbed) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: fmt.Sprintf("scenario %s does not support embeddings", scenario),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	bodyBytes, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Failed to read request body: " + err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	var req openai.EmbeddingNewParams
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Invalid request body: " + err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	if string(req.Model) == "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Model is required",
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	if isEmbeddingInputEmpty(req.Input) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Input is required",
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	requestModel := string(req.Model)
+	responseModel := requestModel
+
+	rule, err := s.determineRuleWithScenario(c, scenarioType, requestModel)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	provider, selectedService, err := s.routingSelector.SelectServiceForEmbeddings(c, scenarioType, rule)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	if provider.APIStyle != protocol.APIStyleOpenAI {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: fmt.Sprintf("unsupported provider api style for embeddings: %s", provider.APIStyle),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	actualModel := selectedService.Model
+	req.Model = openai.EmbeddingModel(actualModel)
+
+	sessionID := resolveSessionID(c, &req)
+	c.Request = c.Request.WithContext(typ.WithSessionID(c.Request.Context(), sessionID))
+
+	SetTrackingContext(c, rule, provider, actualModel, responseModel, false)
+
+	wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, actualModel)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
+
+	resp, cancel, err := forwarding.ForwardOpenAIEmbeddings(fc, wrapper, &req)
+	if cancel != nil {
+		defer cancel()
+	}
+	if err != nil {
+		usage := protocol.NewTokenUsageWithCache(0, 0, 0)
+		s.trackUsageWithTokenUsage(c, usage, err)
+		logrus.Errorf("Failed to forward embeddings request: %v", err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Failed to forward request: " + err.Error(),
+				Type:    "api_error",
+			},
+		})
+		return
+	}
+
+	usage := protocol.NewTokenUsageWithCache(int(resp.Usage.PromptTokens), 0, 0)
+	s.trackUsageWithTokenUsage(c, usage, nil)
+
+	responseJSON, err := json.Marshal(resp)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Failed to marshal response: " + err.Error(),
+				Type:    "api_error",
+			},
+		})
+		return
+	}
+
+	var responseMap map[string]interface{}
+	if err := json.Unmarshal(responseJSON, &responseMap); err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "Failed to process response: " + err.Error(),
+				Type:    "api_error",
+			},
+		})
+		return
+	}
+
+	responseMap["model"] = responseModel
+	c.JSON(http.StatusOK, responseMap)
+}
+
+// isEmbeddingInputEmpty returns true if no variant of the union input is set.
+func isEmbeddingInputEmpty(input openai.EmbeddingNewParamsInputUnion) bool {
+	if !param.IsOmitted(input.OfString) && input.OfString.Value != "" {
+		return false
+	}
+	if len(input.OfArrayOfStrings) > 0 {
+		return false
+	}
+	if len(input.OfArrayOfTokens) > 0 {
+		return false
+	}
+	if len(input.OfArrayOfTokenArrays) > 0 {
+		return false
+	}
+	return true
+}

--- a/internal/server/openai_embeddings_test.go
+++ b/internal/server/openai_embeddings_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+func TestIsEmbeddingInputEmpty(t *testing.T) {
+	cases := []struct {
+		name  string
+		input openai.EmbeddingNewParamsInputUnion
+		want  bool
+	}{
+		{
+			name:  "empty union",
+			input: openai.EmbeddingNewParamsInputUnion{},
+			want:  true,
+		},
+		{
+			name:  "empty string",
+			input: openai.EmbeddingNewParamsInputUnion{OfString: param.NewOpt("")},
+			want:  true,
+		},
+		{
+			name:  "non-empty string",
+			input: openai.EmbeddingNewParamsInputUnion{OfString: param.NewOpt("hello")},
+			want:  false,
+		},
+		{
+			name:  "non-empty string array",
+			input: openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: []string{"a", "b"}},
+			want:  false,
+		},
+		{
+			name:  "non-empty token array",
+			input: openai.EmbeddingNewParamsInputUnion{OfArrayOfTokens: []int64{1, 2, 3}},
+			want:  false,
+		},
+		{
+			name:  "non-empty token array of arrays",
+			input: openai.EmbeddingNewParamsInputUnion{OfArrayOfTokenArrays: [][]int64{{1}, {2}}},
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmbeddingInputEmpty(tc.input); got != tc.want {
+				t.Fatalf("isEmbeddingInputEmpty(%+v) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -85,6 +85,16 @@ func (s *Server) HandleResponsesCreate(c *gin.Context) {
 		return
 	}
 
+	if !typ.ScenarioSupportsTransport(scenarioType, typ.TransportOpenAI) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: fmt.Sprintf("scenario %s does not support OpenAI responses", scenario),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
 	// Check if this is the request model name first
 	rule, err = s.determineRuleWithScenario(c, scenarioType, req.Model)
 	if err != nil {

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -79,3 +79,14 @@ func (s *SimpleSelector) SelectService(
 
 	return result.Provider, result.Service, nil
 }
+
+// SelectServiceForEmbeddings is a variant of SelectService for embedding requests.
+// Embedding requests don't carry chat-style context, so content-based smart routing
+// is skipped (load balancing, affinity, and health filters still apply).
+func (s *SimpleSelector) SelectServiceForEmbeddings(
+	c *gin.Context,
+	scenario typ.RuleScenario,
+	rule *typ.Rule,
+) (*typ.Provider, *loadbalance.Service, error) {
+	return s.SelectService(c, scenario, rule, nil)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1131,6 +1131,9 @@ func (s *Server) SetupMixinEndpoints(group *gin.RouterGroup) {
 	// Count tokens endpoint (Anthropic compatible)
 	group.POST("/messages/count_tokens", s.getModelAuthMiddleware(), s.AnthropicCountTokens)
 
+	// Embeddings endpoint (OpenAI compatible)
+	group.POST("/embeddings", s.getModelAuthMiddleware(), s.HandleOpenAIEmbeddings)
+
 	// Models endpoint (routed by scenario: openai -> OpenAIListModels, anthropic/claude_code -> AnthropicListModels)
 	group.GET("/models", s.getModelAuthMiddleware(), s.ListModelsByScenario)
 }
@@ -1305,6 +1308,7 @@ func (s *Server) Start(port int) error {
 	if !s.enableUI {
 		fmt.Printf("OpenAI v1 Chat API endpoint: %s://%s:%d/openai/v1/chat/completions\n", scheme, resolvedHost, port)
 		fmt.Printf("Anthropic v1 Message API endpoint: %s://%s:%d/anthropic/v1/messages\n", scheme, resolvedHost, port)
+		fmt.Printf("Embeddings API endpoint: %s://%s:%d/tingly/embed/v1/embeddings\n", scheme, resolvedHost, port)
 		fmt.Printf("Virtual Model API endpoint: %s://%s:%d/virtual/v1/chat/completions\n", scheme, resolvedHost, port)
 		fmt.Printf("Mode name: %s\n", constant.DefaultModeName)
 		fmt.Printf("Model API key: %s\n", s.config.GetModelToken())

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -12,6 +12,7 @@ type ScenarioTransport string
 const (
 	TransportOpenAI    ScenarioTransport = "openai"
 	TransportAnthropic ScenarioTransport = "anthropic"
+	TransportEmbed     ScenarioTransport = "embed"
 )
 
 type ScenarioDescriptor struct {
@@ -49,7 +50,14 @@ func builtinScenarioDescriptorFor(scenario RuleScenario) ScenarioDescriptor {
 	case ScenarioOpenAI:
 		return ScenarioDescriptor{
 			ID:                 scenario,
-			SupportedTransport: []ScenarioTransport{TransportOpenAI},
+			SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportEmbed},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
+	case ScenarioEmbed:
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportEmbed},
 			AllowRuleBinding:   true,
 			AllowDirectPathUse: true,
 		}
@@ -160,6 +168,16 @@ func CanBindRulesToScenario(scenario RuleScenario) bool {
 func CanUseScenarioInPath(scenario RuleScenario) bool {
 	descriptor, ok := GetScenarioDescriptor(scenario)
 	return ok && descriptor.AllowDirectPathUse
+}
+
+// ScenarioSupportsTransport reports whether the given scenario's descriptor
+// declares support for the specified transport.
+func ScenarioSupportsTransport(scenario RuleScenario, transport ScenarioTransport) bool {
+	descriptor, ok := GetScenarioDescriptor(scenario)
+	if !ok {
+		return false
+	}
+	return slices.Contains(descriptor.SupportedTransport, transport)
 }
 
 // ProfileSeparator is used to split "scenario:profile_id" strings.

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -39,6 +39,40 @@ func TestRegisterScenario_IsIdempotentForSameDescriptor(t *testing.T) {
 	}
 }
 
+func TestEmbedScenarioDescriptor(t *testing.T) {
+	d, ok := GetScenarioDescriptor(ScenarioEmbed)
+	if !ok {
+		t.Fatalf("expected %q descriptor to be registered", ScenarioEmbed)
+	}
+	if !d.AllowRuleBinding || !d.AllowDirectPathUse {
+		t.Fatalf("expected embed descriptor to allow rule binding and path use, got %+v", d)
+	}
+	if !ScenarioSupportsTransport(ScenarioEmbed, TransportEmbed) {
+		t.Fatalf("expected embed scenario to support TransportEmbed")
+	}
+	if ScenarioSupportsTransport(ScenarioEmbed, TransportOpenAI) {
+		t.Fatalf("embed scenario must NOT support TransportOpenAI (chat must be rejected)")
+	}
+	if ScenarioSupportsTransport(ScenarioEmbed, TransportAnthropic) {
+		t.Fatalf("embed scenario must NOT support TransportAnthropic")
+	}
+}
+
+func TestOpenAIScenarioSupportsBothTransports(t *testing.T) {
+	if !ScenarioSupportsTransport(ScenarioOpenAI, TransportOpenAI) {
+		t.Fatalf("openai scenario should support TransportOpenAI")
+	}
+	if !ScenarioSupportsTransport(ScenarioOpenAI, TransportEmbed) {
+		t.Fatalf("openai scenario should also support TransportEmbed (mixin extension)")
+	}
+}
+
+func TestScenarioSupportsTransport_UnknownScenario(t *testing.T) {
+	if ScenarioSupportsTransport(RuleScenario("does_not_exist"), TransportOpenAI) {
+		t.Fatalf("unknown scenario must not report transport support")
+	}
+}
+
 func TestRegisterScenario_RejectsConflictingDescriptor(t *testing.T) {
 	scenario := RuleScenario("test_registry_conflict")
 

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -59,6 +59,7 @@ const (
 	ScenarioVSCode     RuleScenario = "vscode"
 	ScenarioSmartGuide RuleScenario = "_smart_guide"
 	ScenarioGlobal     RuleScenario = "_global" // Global flags that apply to all scenarios
+	ScenarioEmbed      RuleScenario = "embed"   // Embedding application scenario; only serves /embeddings
 )
 
 func BuiltinScenarios() []RuleScenario {
@@ -73,6 +74,7 @@ func BuiltinScenarios() []RuleScenario {
 		ScenarioVSCode,
 		ScenarioSmartGuide,
 		ScenarioGlobal,
+		ScenarioEmbed,
 	}
 }
 


### PR DESCRIPTION
Introduce a dedicated `embed` scenario that serves OpenAI-compatible `/v1/embeddings` requests, alongside extending the existing OpenAI mixin so any OpenAI-transport scenario (e.g. `openai`) can also reach the new endpoint. The `embed` scenario is purpose-built for embedding applications (RAG, semantic search) and explicitly rejects chat / messages / responses traffic via a new transport gate.

Backend:
- new ScenarioEmbed + TransportEmbed, registered with descriptor
- ScenarioSupportsTransport helper + transport gates in chat, responses, and messages handlers
- HandleOpenAIEmbeddings + ForwardOpenAIEmbeddings reusing rule matching, load balancer, affinity, client pool, and usage tracking
- SelectServiceForEmbeddings short-circuits content-based smart routing (embeddings carry no chat context)
- /embeddings route added to SetupMixinEndpoints

Frontend:
- new UseEmbedPage reusing TemplatePage / useScenarioPageInternal
- /agent/embed route, sidebar entry, SCENARIOS.EMBED constant, i18n

https://claude.ai/code/session_01WBmBVb7r1FVk8imk4BaUkn