### PR TITLE
feat(imbot, harness, remote): create mock agent for testing message interactions

### DIFF
--- a/agentboot/mockagent/agent.go
+++ b/agentboot/mockagent/agent.go
@@ -2,8 +2,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -13,7 +11,7 @@ import (
 	"github.com/tingly-dev/tingly-box/agentboot"
 )
 
-// mockToolNames are the tool names used in mock permission requests
+// mockToolNames are the tool names used by the linear default script.
 var mockToolNames = []string{
 	"mock_tool_read",
 	"mock_tool_write",
@@ -22,8 +20,13 @@ var mockToolNames = []string{
 	"mock_tool_analyze",
 }
 
-// Agent implements the agentboot.Agent interface for testing purposes.
-// It simulates agent behavior by repeatedly requesting user permission confirmations.
+// Agent is a scriptable mock agentboot.Agent for tests.
+//
+// Two ways to drive it:
+//
+//   - Pass Config{Script: ...} to declare an explicit event sequence.
+//   - Pass legacy Config{MaxIterations, AskUserQuestionFrequency, ...} to
+//     fall back to the linear default script.
 type Agent struct {
 	config        Config
 	abConfig      agentboot.Config
@@ -31,7 +34,7 @@ type Agent struct {
 	mu            sync.RWMutex
 }
 
-// NewAgent creates a new mock agent with the given configuration
+// NewAgent creates a new mock agent with the given configuration.
 func NewAgent(config Config) *Agent {
 	config = config.Merge(DefaultConfig())
 	return &Agent{
@@ -40,351 +43,204 @@ func NewAgent(config Config) *Agent {
 	}
 }
 
-// NewAgentWithConfig creates a new mock agent with both mock and agentboot configs
+// NewAgentWithConfig creates a new mock agent with both mock and agentboot configs.
 func NewAgentWithConfig(mockConfig Config, abConfig agentboot.Config) *Agent {
-	agent := NewAgent(mockConfig)
-	agent.abConfig = abConfig
-	return agent
+	a := NewAgent(mockConfig)
+	a.abConfig = abConfig
+	return a
 }
 
-// Execute runs the mock agent, simulating permission request cycles
+// Execute plays the agent's script (explicit or linear-default) and returns
+// the captured event stream.
 func (a *Agent) Execute(ctx context.Context, prompt string, opts agentboot.ExecutionOptions) (*agentboot.Result, error) {
 	startTime := time.Now()
 	logrus.Infof("[MockAgent] Starting execution with prompt: %s", truncatePrompt(prompt))
 
-	var events []agentboot.Event
+	a.mu.RLock()
+	cfg := a.config
+	a.mu.RUnlock()
+
 	sessionID := opts.SessionID
 	if sessionID == "" {
 		sessionID = uuid.NewString()[:8]
 	}
 
-	// Generate session init event
-	initMsg := agentboot.NewInitMessage(agentboot.AgentTypeMockAgent, sessionID, a.config.MaxIterations)
-	events = append(events, initMsg.ToEvent())
-
-	// Send via handler if available
-	if opts.Handler != nil {
-		if err := opts.Handler.OnMessage(initMsg); err != nil {
-			opts.Handler.OnError(err)
-		}
+	script := cfg.Script
+	if len(script) == 0 {
+		script = defaultLinearScript(cfg)
 	}
 
-	// Process through iterations
-	for step := 1; step <= a.config.MaxIterations; step++ {
+	var events []agentboot.Event
+	state := &runState{
+		agentType:  agentboot.AgentTypeMockAgent,
+		sessionID:  sessionID,
+		prompt:     prompt,
+		handler:    opts.Handler,
+		opts:       opts,
+		cfg:        cfg,
+		events:     &events,
+		totalSteps: cfg.MaxIterations,
+	}
+
+	if err := state.emit(agentboot.NewInitMessage(state.agentType, sessionID, cfg.MaxIterations)); err != nil {
+		logrus.WithError(err).Warn("[MockAgent] init handler error")
+	}
+
+	for i, step := range script {
 		select {
 		case <-ctx.Done():
-			logrus.Infof("[MockAgent] Context cancelled at step %d", step)
-			resultMsg := agentboot.NewResultMessage(agentboot.AgentTypeMockAgent, sessionID, "cancelled", "Context cancelled by user")
-			events = append(events, resultMsg.ToEvent())
-
-			if opts.Handler != nil {
-				opts.Handler.OnComplete(&agentboot.CompletionResult{
-					Success:    false,
-					DurationMS: time.Since(startTime).Milliseconds(),
-					SessionID:  sessionID,
-					Error:      "Context cancelled",
-				})
-			}
-
-			return a.buildResult(events, startTime, sessionID), ctx.Err()
+			return a.finishCancelled(state, startTime, ctx.Err()), ctx.Err()
 		default:
 		}
-
-		// Generate tool name for this step
-		toolName := mockToolNames[(step-1)%len(mockToolNames)]
-
-		// Check if this should be an AskUserQuestion request
-		var isAskUserQuestion bool
-		var askInput map[string]interface{}
-
-		if a.config.AskUserQuestionFrequency > 0 && step%a.config.AskUserQuestionFrequency == 0 {
-			isAskUserQuestion = true
-			askInput = map[string]interface{}{
-				"questions": []map[string]interface{}{
-					{
-						"question": fmt.Sprintf("Mock question %d of %d", step, a.config.MaxIterations),
-						"header":   "Mock",
-						"options": []map[string]interface{}{
-							{
-								"label":       "Option A",
-								"description": "First option",
-							},
-							{
-								"label":       "Option B",
-								"description": "Second option",
-							},
-							{
-								"label":       "Option C",
-								"description": "Third option",
-							},
-						},
-					},
-				},
-			}
+		state.stepIdx = i + 1
+		if err := step.play(ctx, state); err != nil {
+			return a.finishWithError(state, startTime, err), err
 		}
-
-		var approved bool
-
-		if isAskUserQuestion {
-			// Handle AskUserQuestion
-			req := agentboot.AskRequest{
-				ID:        uuid.NewString()[:8],
-				Type:      "tool_use",
-				AgentType: agentboot.AgentTypeMockAgent,
-				Platform:  opts.Platform,
-				ChatID:    opts.ChatID,
-				SessionID: sessionID,
-				ToolName:  "AskUserQuestion",
-				Input:     askInput,
-			}
-
-			// Create unified permission request message
-			permReqMsg := agentboot.NewPermissionRequestMessage(
-				agentboot.AgentTypeMockAgent, sessionID, req.ID, req.ToolName, req.Input, "Mock AskUserQuestion",
-			)
-			permReqMsg.Step = step
-			permReqMsg.Total = a.config.MaxIterations
-			events = append(events, permReqMsg.ToEvent())
-
-			// Send via handler if available
-			if opts.Handler != nil {
-				if err := opts.Handler.OnMessage(permReqMsg); err != nil {
-					opts.Handler.OnError(err)
-				}
-			}
-
-			// Get decision
-			if a.config.AutoApprove {
-				approved = true
-			} else if opts.Handler != nil {
-				result, e := opts.Handler.OnAsk(ctx, req)
-				if e != nil {
-					logrus.Errorf("[MockAgent] Ask handler error: %v", e)
-					approved = false
-				} else {
-					approved = result.Approved
-				}
-			} else {
-				approved = true // Default to approved if no handler
-			}
-
-			// Create permission result message
-			if approved {
-				permResultMsg := agentboot.NewPermissionResultMessage(
-					agentboot.AgentTypeMockAgent, sessionID, req.ID, true, "Approved",
-				)
-				events = append(events, permResultMsg.ToEvent())
-			} else {
-				permResultMsg := agentboot.NewPermissionResultMessage(
-					agentboot.AgentTypeMockAgent, sessionID, req.ID, false, "Denied",
-				)
-				events = append(events, permResultMsg.ToEvent())
-
-				resultMsg := agentboot.NewResultMessage(
-					agentboot.AgentTypeMockAgent, sessionID, "ask_denied",
-					fmt.Sprintf("AskUserQuestion denied at step %d", step),
-				)
-				events = append(events, resultMsg.ToEvent())
-
-				if opts.Handler != nil {
-					opts.Handler.OnComplete(&agentboot.CompletionResult{
-						Success:    false,
-						DurationMS: time.Since(startTime).Milliseconds(),
-						SessionID:  sessionID,
-						Error:      "AskUserQuestion denied",
-					})
-				}
-
-				return a.buildResult(events, startTime, sessionID), nil
-			}
-		} else {
-			// Regular permission request
-			req := agentboot.PermissionRequest{
-				RequestID: uuid.NewString()[:8],
-				AgentType: agentboot.AgentTypeMockAgent,
-				ToolName:  toolName,
-				Input: map[string]interface{}{
-					"step":      step,
-					"total":     a.config.MaxIterations,
-					"prompt":    truncatePrompt(prompt),
-					"command":   fmt.Sprintf("mock_command --step %d --input %q", step, truncatePrompt(prompt)),
-					"_chat_id":  opts.ChatID,
-					"_platform": opts.Platform,
-				},
-				Reason:    fmt.Sprintf("Mock permission request %d of %d", step, a.config.MaxIterations),
-				Timestamp: time.Now(),
-				SessionID: sessionID,
-			}
-
-			// Create unified permission request message
-			permReqMsg := agentboot.NewPermissionRequestMessage(
-				agentboot.AgentTypeMockAgent, sessionID, req.RequestID, req.ToolName, req.Input, req.Reason,
-			)
-			permReqMsg.Step = step
-			permReqMsg.Total = a.config.MaxIterations
-			events = append(events, permReqMsg.ToEvent())
-
-			// Send via handler if available
-			if opts.Handler != nil {
-				if err := opts.Handler.OnMessage(permReqMsg); err != nil {
-					opts.Handler.OnError(err)
-				}
-			}
-
-			// Get permission decision using the new OnApproval method
-			if a.config.AutoApprove {
-				approved = true
-			} else if opts.Handler != nil {
-				result, e := opts.Handler.OnApproval(ctx, req)
-				if e != nil {
-					logrus.Errorf("[MockAgent] Permission handler error: %v", e)
-					approved = false
-				} else {
-					approved = result.Approved
-				}
-			} else {
-				approved = true // Default to approved if no handler
-			}
-
-			// Handle permission response
-			if !approved {
-				logrus.Infof("[MockAgent] Permission denied at step %d", step)
-
-				// Create unified permission result message (denied)
-				permResultMsg := agentboot.NewPermissionResultMessage(
-					agentboot.AgentTypeMockAgent, sessionID, req.RequestID, false, "Denied",
-				)
-				events = append(events, permResultMsg.ToEvent())
-
-				// Send result event
-				resultMsg := agentboot.NewResultMessage(
-					agentboot.AgentTypeMockAgent, sessionID, "permission_denied",
-					fmt.Sprintf("Permission denied at step %d", step),
-				)
-				events = append(events, resultMsg.ToEvent())
-
-				if opts.Handler != nil {
-					opts.Handler.OnComplete(&agentboot.CompletionResult{
-						Success:    false,
-						DurationMS: time.Since(startTime).Milliseconds(),
-						SessionID:  sessionID,
-						Error:      "Permission denied",
-					})
-				}
-
-				return a.buildResult(events, startTime, sessionID), nil
-			}
-
-			// Permission approved - create unified result message
-			permResultMsg := agentboot.NewPermissionResultMessage(
-				agentboot.AgentTypeMockAgent, sessionID, req.RequestID, true, "Approved",
-			)
-			events = append(events, permResultMsg.ToEvent())
+		if state.halt {
+			break
 		}
-
-		// Generate assistant response
-		responseText := a.formatResponse(step, prompt)
-		assistantMsg := agentboot.NewAssistantMessage(agentboot.AgentTypeMockAgent, sessionID, responseText)
-		events = append(events, assistantMsg.ToEvent())
-
-		// Send via handler if available
-		if opts.Handler != nil {
-			if err := opts.Handler.OnMessage(assistantMsg); err != nil {
-				opts.Handler.OnError(err)
-			}
-		}
-
-		// Add delay between steps (except for the last step)
-		if step < a.config.MaxIterations {
+		if cfg.StepDelay > 0 && i < len(script)-1 {
 			select {
-			case <-time.After(a.config.StepDelay):
-				// Continue to next step
+			case <-time.After(cfg.StepDelay):
 			case <-ctx.Done():
-				logrus.Infof("[MockAgent] Context cancelled during delay at step %d", step)
-
-				if opts.Handler != nil {
-					opts.Handler.OnComplete(&agentboot.CompletionResult{
-						Success:    false,
-						DurationMS: time.Since(startTime).Milliseconds(),
-						SessionID:  sessionID,
-						Error:      "Context cancelled",
-					})
-				}
-
-				return a.buildResult(events, startTime, sessionID), ctx.Err()
+				return a.finishCancelled(state, startTime, ctx.Err()), ctx.Err()
 			}
 		}
 	}
 
-	// All iterations completed successfully
-	resultMsg := agentboot.NewResultMessage(
-		agentboot.AgentTypeMockAgent, sessionID, "success", "Mock agent completed all iterations",
-	)
-	events = append(events, resultMsg.ToEvent())
+	if !hasFinalResult(events) {
+		_ = state.emit(agentboot.NewResultMessage(
+			state.agentType, sessionID, "success", "Mock agent completed all iterations",
+		))
+	}
 
-	// Notify handler of completion
-	if opts.Handler != nil {
-		opts.Handler.OnComplete(&agentboot.CompletionResult{
-			Success:    true,
+	if state.handler != nil {
+		successTerm := isSuccessTerminal(events)
+		completion := &agentboot.CompletionResult{
+			Success:    successTerm && len(state.mismatches) == 0,
 			DurationMS: time.Since(startTime).Milliseconds(),
 			SessionID:  sessionID,
-		})
+		}
+		if !successTerm {
+			completion.Error = lastResultMessage(events)
+		} else if len(state.mismatches) > 0 {
+			completion.Error = state.mismatches[0]
+		}
+		state.handler.OnComplete(completion)
 	}
 
-	return a.buildResult(events, startTime, sessionID), nil
+	return a.buildResult(events, startTime, sessionID, state.mismatches), nil
 }
 
-// formatResponse generates a mock response text
-func (a *Agent) formatResponse(step int, prompt string) string {
-	text := a.config.ResponseTemplate
-	text = strings.ReplaceAll(text, "{step}", fmt.Sprintf("%d", step))
-	text = strings.ReplaceAll(text, "{total}", fmt.Sprintf("%d", a.config.MaxIterations))
-	text = strings.ReplaceAll(text, "{prompt}", truncatePrompt(prompt))
-	return text
+func (a *Agent) finishCancelled(state *runState, startTime time.Time, err error) *agentboot.Result {
+	if !hasFinalResult(*state.events) {
+		_ = state.emit(agentboot.NewResultMessage(
+			state.agentType, state.sessionID, "cancelled", "Context cancelled by user",
+		))
+	}
+	if state.handler != nil {
+		state.handler.OnComplete(&agentboot.CompletionResult{
+			Success:    false,
+			DurationMS: time.Since(startTime).Milliseconds(),
+			SessionID:  state.sessionID,
+			Error:      err.Error(),
+		})
+	}
+	return a.buildResult(*state.events, startTime, state.sessionID, state.mismatches)
 }
 
-// buildResult constructs the final result
-func (a *Agent) buildResult(events []agentboot.Event, startTime time.Time, sessionID string) *agentboot.Result {
-	return &agentboot.Result{
-		Output:   "", // Text output is empty for stream-json mode
+func (a *Agent) finishWithError(state *runState, startTime time.Time, err error) *agentboot.Result {
+	if !hasFinalResult(*state.events) {
+		_ = state.emit(agentboot.NewResultMessage(
+			state.agentType, state.sessionID, "error", err.Error(),
+		))
+	}
+	if state.handler != nil {
+		state.handler.OnComplete(&agentboot.CompletionResult{
+			Success:    false,
+			DurationMS: time.Since(startTime).Milliseconds(),
+			SessionID:  state.sessionID,
+			Error:      err.Error(),
+		})
+	}
+	return a.buildResult(*state.events, startTime, state.sessionID, state.mismatches)
+}
+
+func (a *Agent) buildResult(events []agentboot.Event, startTime time.Time, sessionID string, mismatches []string) *agentboot.Result {
+	res := &agentboot.Result{
+		Output:   "",
 		ExitCode: 0,
-		Error:    "",
 		Duration: time.Since(startTime),
 		Format:   a.defaultFormat,
 		Events:   events,
 		Metadata: map[string]interface{}{
-			"session_id":     sessionID,
-			"agent_type":     "mock",
-			"max_iterations": a.config.MaxIterations,
+			"session_id": sessionID,
+			"agent_type": "mock",
 		},
 	}
+	if len(mismatches) > 0 {
+		res.Error = mismatches[0]
+		res.Metadata["expectation_failures"] = mismatches
+	}
+	return res
 }
 
-// IsAvailable always returns true for mock agent
-func (a *Agent) IsAvailable() bool {
-	return true
+func hasFinalResult(events []agentboot.Event) bool {
+	for _, e := range events {
+		if e.Type == agentboot.EventTypeResult {
+			return true
+		}
+	}
+	return false
 }
 
-// Type returns the mock agent type
-func (a *Agent) Type() agentboot.AgentType {
-	return agentboot.AgentTypeMockAgent
+func isSuccessTerminal(events []agentboot.Event) bool {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Type == agentboot.EventTypeResult {
+			if status, _ := events[i].Data["status"].(string); status == "success" {
+				return true
+			}
+			return false
+		}
+	}
+	return false
 }
 
-// SetDefaultFormat sets the default output format
+func lastResultMessage(events []agentboot.Event) string {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Type == agentboot.EventTypeResult {
+			if msg, _ := events[i].Data["message"].(string); msg != "" {
+				return msg
+			}
+			if st, _ := events[i].Data["status"].(string); st != "" {
+				return st
+			}
+		}
+	}
+	return ""
+}
+
+// IsAvailable always returns true for the mock agent.
+func (a *Agent) IsAvailable() bool { return true }
+
+// Type returns the mock agent type.
+func (a *Agent) Type() agentboot.AgentType { return agentboot.AgentTypeMockAgent }
+
+// SetDefaultFormat sets the default output format.
 func (a *Agent) SetDefaultFormat(format agentboot.OutputFormat) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.defaultFormat = format
 }
 
-// GetDefaultFormat returns the current default format
+// GetDefaultFormat returns the current default format.
 func (a *Agent) GetDefaultFormat() agentboot.OutputFormat {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.defaultFormat
 }
 
-// SetMaxIterations configures the maximum number of iterations
+// SetMaxIterations updates the linear-default iteration count.
 func (a *Agent) SetMaxIterations(max int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -393,7 +249,7 @@ func (a *Agent) SetMaxIterations(max int) {
 	}
 }
 
-// SetStepDelay configures the delay between steps
+// SetStepDelay updates the inter-step delay.
 func (a *Agent) SetStepDelay(delay time.Duration) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -402,14 +258,15 @@ func (a *Agent) SetStepDelay(delay time.Duration) {
 	}
 }
 
-// SetAutoApprove configures auto-approval mode
+// SetAutoApprove toggles auto-approval mode.
 func (a *Agent) SetAutoApprove(autoApprove bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.config.AutoApprove = autoApprove
 }
 
-// SetAskUserQuestionFrequency configures how often to send AskUserQuestion requests
+// SetAskUserQuestionFrequency configures how often the linear-default script
+// emits AskUserQuestion (every N steps).
 func (a *Agent) SetAskUserQuestionFrequency(freq int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -418,7 +275,15 @@ func (a *Agent) SetAskUserQuestionFrequency(freq int) {
 	}
 }
 
-// truncatePrompt truncates a prompt for display purposes
+// SetScript replaces the agent's script with the provided steps. Pass nil or
+// an empty slice to revert to the linear default.
+func (a *Agent) SetScript(steps []Step) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.config.Script = steps
+}
+
+// truncatePrompt truncates a prompt for display purposes.
 func truncatePrompt(prompt string) string {
 	const maxLen = 50
 	if len(prompt) <= maxLen {

--- a/agentboot/mockagent/config.go
+++ b/agentboot/mockagent/config.go
@@ -6,41 +6,53 @@ import (
 	"github.com/tingly-dev/tingly-box/agentboot"
 )
 
-// Config holds the mock agent configuration
+// Config holds the mock agent configuration.
+//
+// Two execution modes:
+//
+//   - If Script is non-empty, the agent plays it step by step.
+//   - Otherwise, the agent generates a linear default script from
+//     MaxIterations / AskUserQuestionFrequency / ResponseTemplate.
 type Config struct {
-	// MaxIterations is the maximum number of permission cycles (default: 5)
+	// Script declares an explicit event sequence. When set, MaxIterations,
+	// AskUserQuestionFrequency and ResponseTemplate are ignored.
+	Script []Step `json:"-"`
+
+	// MaxIterations is the legacy linear-default iteration count.
 	MaxIterations int `json:"max_iterations"`
 
-	// StepDelay is the delay between steps (default: 1s)
+	// StepDelay is the inter-step delay (default: 1s).
 	StepDelay time.Duration `json:"step_delay"`
 
-	// AutoApprove if true, auto-approves permissions without user interaction (default: false)
+	// AutoApprove short-circuits PermissionStep / AskStep without invoking
+	// the handler.
 	AutoApprove bool `json:"auto_approve"`
 
-	// ResponseTemplate is the template for mock responses
-	// Supports placeholders: {step}, {total}, {prompt}
+	// ResponseTemplate is the template for legacy linear-default assistant
+	// messages. Supports placeholders: {step}, {total}, {prompt}.
 	ResponseTemplate string `json:"response_template"`
 
-	// PermissionMode sets how permissions are handled
+	// PermissionMode is informational; the scriptable engine routes through
+	// the handler regardless.
 	PermissionMode agentboot.PermissionMode `json:"permission_mode"`
 
-	// AskUserQuestionFrequency controls how often to send AskUserQuestion requests
-	// 0 = never send AskUserQuestion, 1 = every step, 2 = every 2 steps, etc.
+	// AskUserQuestionFrequency configures the linear-default script to emit
+	// an AskUserQuestion every N steps (0 = never).
 	AskUserQuestionFrequency int `json:"ask_user_question_frequency"`
 }
 
-// DefaultConfig returns the default mock agent configuration
+// DefaultConfig returns the default mock agent configuration.
 func DefaultConfig() Config {
 	return Config{
 		MaxIterations:    5,
-		StepDelay:        1 * time.Second,
+		StepDelay:        0,
 		AutoApprove:      false,
 		ResponseTemplate: "[Mock Step {step}/{total}] Processing: {prompt}",
 		PermissionMode:   agentboot.PermissionModeManual,
 	}
 }
 
-// Merge merges the given config with defaults
+// Merge merges the given config with defaults.
 func (c Config) Merge(defaults Config) Config {
 	result := defaults
 	if c.MaxIterations > 0 {
@@ -54,6 +66,12 @@ func (c Config) Merge(defaults Config) Config {
 	}
 	if c.PermissionMode != "" {
 		result.PermissionMode = c.PermissionMode
+	}
+	if c.AskUserQuestionFrequency > 0 {
+		result.AskUserQuestionFrequency = c.AskUserQuestionFrequency
+	}
+	if len(c.Script) > 0 {
+		result.Script = c.Script
 	}
 	result.AutoApprove = c.AutoApprove
 	return result

--- a/agentboot/mockagent/mockagent_test.go
+++ b/agentboot/mockagent/mockagent_test.go
@@ -2,7 +2,9 @@ package mock
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/agentboot"
@@ -98,6 +100,192 @@ func Example_mockAgentWithAskUserQuestion() {
 	// Completed: true
 	// Events: 14
 }
+
+// Test_ScriptedMockAgent_PlaybackOrder verifies that explicit script playback
+// emits init / per-step / result events in declared order.
+func Test_ScriptedMockAgent_PlaybackOrder(t *testing.T) {
+	ag := NewAgent(Config{
+		AutoApprove: true,
+		Script: NewScript().
+			Assistant("hello").
+			Permission("Read", map[string]any{"path": "/tmp/x"}).
+			ToolResult("hello\n").
+			Assistant("done").
+			Success("ok").
+			Build(),
+	})
+
+	result, err := ag.Execute(context.Background(), "go", agentboot.ExecutionOptions{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	wantTypes := []string{
+		agentboot.EventTypeInit,
+		agentboot.EventTypeAssistant,
+		agentboot.EventTypePermissionRequest,
+		agentboot.EventTypePermissionResult,
+		agentboot.EventTypeToolResult,
+		agentboot.EventTypeAssistant,
+		agentboot.EventTypeResult,
+	}
+	if len(result.Events) != len(wantTypes) {
+		t.Fatalf("expected %d events, got %d (%v)", len(wantTypes), len(result.Events), eventTypes(result.Events))
+	}
+	for i, want := range wantTypes {
+		if result.Events[i].Type != want {
+			t.Errorf("event %d: want %q got %q", i, want, result.Events[i].Type)
+		}
+	}
+	if result.Error != "" {
+		t.Errorf("expected no Result.Error, got %q", result.Error)
+	}
+}
+
+// Test_ScriptedMockAgent_DenyHalts verifies that PermissionStep with
+// OnDenyTerminate (the default) terminates with permission_denied.
+func Test_ScriptedMockAgent_DenyHalts(t *testing.T) {
+	ag := NewAgent(Config{
+		Script: NewScript().
+			Permission("Bash", map[string]any{"cmd": "rm -rf /"}).
+			Assistant("never reached").
+			Success("never").
+			Build(),
+	})
+
+	handler := agentboot.NewCompositeHandler().SetApprovalHandler(denyHandler{})
+	result, err := ag.Execute(context.Background(), "go", agentboot.ExecutionOptions{Handler: handler})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	last := result.Events[len(result.Events)-1]
+	if last.Type != agentboot.EventTypeResult {
+		t.Fatalf("expected last event %q, got %q", agentboot.EventTypeResult, last.Type)
+	}
+	if status, _ := last.Data["status"].(string); status != "permission_denied" {
+		t.Fatalf("expected status permission_denied, got %q", status)
+	}
+	for _, e := range result.Events {
+		if e.Type == agentboot.EventTypeAssistant {
+			if msg, _ := e.Data["message"].(string); msg == "never reached" {
+				t.Fatalf("script kept running past denial")
+			}
+		}
+	}
+}
+
+// Test_ScriptedMockAgent_ExpectMismatch verifies that ExpectApproved mismatch
+// surfaces via Result.Error and a handler.OnError call.
+func Test_ScriptedMockAgent_ExpectMismatch(t *testing.T) {
+	ag := NewAgent(Config{
+		Script: NewScript().
+			Permission("Bash", nil, WithExpectApproved(true)).
+			Build(),
+	})
+
+	rec := &errorRecorder{}
+	handler := agentboot.NewCompositeHandler().
+		SetStreamer(rec).
+		SetApprovalHandler(denyHandler{})
+
+	result, err := ag.Execute(context.Background(), "go", agentboot.ExecutionOptions{Handler: handler})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Error == "" {
+		t.Fatalf("expected Result.Error from mismatch, got empty")
+	}
+	if len(rec.errs) == 0 {
+		t.Fatalf("expected handler.OnError to be called for mismatch")
+	}
+}
+
+// Test_ScriptedMockAgent_ErrorStep verifies that an ErrorStep delivers via
+// handler.OnError and is surfaced in Result.Events.
+func Test_ScriptedMockAgent_ErrorStep(t *testing.T) {
+	ag := NewAgent(Config{
+		Script: NewScript().
+			Assistant("trying").
+			FailWith(errors.New("boom")).
+			Build(),
+	})
+
+	rec := &errorRecorder{}
+	handler := agentboot.NewCompositeHandler().SetStreamer(rec)
+	_, err := ag.Execute(context.Background(), "go", agentboot.ExecutionOptions{Handler: handler})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if len(rec.errs) != 1 || rec.errs[0].Error() != "boom" {
+		t.Fatalf("expected exactly one OnError(\"boom\"), got %v", rec.errs)
+	}
+}
+
+// Test_ScriptedMockAgent_AskAnswers verifies that AskStep records expected
+// answer mismatches via Result.Error.
+func Test_ScriptedMockAgent_AskAnswers(t *testing.T) {
+	questions := []AskQuestion{
+		{
+			Question: "color?",
+			Options: []AskOption{
+				{Label: "red"},
+				{Label: "green"},
+			},
+		},
+	}
+	ag := NewAgent(Config{
+		Script: NewScript().
+			Ask(questions, WithAskExpectAnswers(map[int]int{0: 1})). // expect "green"
+			Build(),
+	})
+
+	// autoAskHandler always picks Option A → label "red" for the legacy script
+	// paths; here it returns "Option A" which doesn't match either label, so
+	// we wire a handler that explicitly returns "red".
+	handler := agentboot.NewCompositeHandler().SetAskHandler(fixedAskHandler{label: "red"})
+
+	result, err := ag.Execute(context.Background(), "go", agentboot.ExecutionOptions{Handler: handler})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Error == "" {
+		t.Fatalf("expected mismatch on ask answer, got no Result.Error")
+	}
+}
+
+func eventTypes(evs []agentboot.Event) []string {
+	out := make([]string, len(evs))
+	for i, e := range evs {
+		out[i] = e.Type
+	}
+	return out
+}
+
+type denyHandler struct{}
+
+func (denyHandler) OnApproval(_ context.Context, req agentboot.PermissionRequest) (agentboot.PermissionResult, error) {
+	return agentboot.PermissionResult{Approved: false, Reason: "test denial"}, nil
+}
+
+type fixedAskHandler struct{ label string }
+
+func (h fixedAskHandler) OnAsk(_ context.Context, req agentboot.AskRequest) (agentboot.AskResult, error) {
+	answers := map[string]interface{}{"0": h.label}
+	updated := map[string]interface{}{}
+	for k, v := range req.Input {
+		updated[k] = v
+	}
+	updated["answers"] = answers
+	return agentboot.AskResult{ID: req.ID, Approved: true, UpdatedInput: updated}, nil
+}
+
+type errorRecorder struct {
+	errs []error
+}
+
+func (r *errorRecorder) OnMessage(interface{}) error { return nil }
+func (r *errorRecorder) OnError(err error)           { r.errs = append(r.errs, err) }
 
 // autoApprovalHandler is a simple handler that auto-approves all permissions
 type autoApprovalHandler struct{}

--- a/agentboot/mockagent/script.go
+++ b/agentboot/mockagent/script.go
@@ -1,0 +1,607 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+)
+
+// Step is one entry in a mock-agent script. Implementations describe how to
+// emit events and (optionally) interact with the configured handler.
+type Step interface {
+	play(ctx context.Context, st *runState) error
+}
+
+// runState carries shared state across script playback.
+type runState struct {
+	agentType  agentboot.AgentType
+	sessionID  string
+	prompt     string
+	handler    agentboot.MessageHandler
+	opts       agentboot.ExecutionOptions
+	cfg        Config
+	events     *[]agentboot.Event
+	stepIdx    int
+	totalSteps int
+
+	// mismatches collects expectation failures (PermissionStep / AskStep
+	// asserts).
+	mismatches []string
+
+	// halt stops further script playback once set.
+	halt bool
+}
+
+func (s *runState) emit(msg agentboot.AgentMessage) error {
+	*s.events = append(*s.events, msg.ToEvent())
+	if s.handler != nil {
+		if err := s.handler.OnMessage(msg); err != nil {
+			s.handler.OnError(err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *runState) emitEvent(ev agentboot.Event) {
+	*s.events = append(*s.events, ev)
+	if s.handler != nil {
+		if msg := agentboot.MessageFromEvent(ev, s.agentType); msg != nil {
+			_ = s.handler.OnMessage(msg)
+		}
+	}
+}
+
+func (s *runState) recordMismatch(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	s.mismatches = append(s.mismatches, msg)
+	if s.handler != nil {
+		s.handler.OnError(fmt.Errorf("mockagent: %s", msg))
+	}
+}
+
+// AssistantStep emits an assistant text message.
+type AssistantStep struct {
+	Text string
+}
+
+func (s *AssistantStep) play(_ context.Context, st *runState) error {
+	return st.emit(agentboot.NewAssistantMessage(st.agentType, st.sessionID, s.Text))
+}
+
+// StreamDeltaStep emits a stream_delta event. Note: in the production
+// streaming handler, deltas are silently logged and not surfaced to chat.
+type StreamDeltaStep struct {
+	Delta string
+}
+
+func (s *StreamDeltaStep) play(_ context.Context, st *runState) error {
+	return st.emit(agentboot.NewStreamDeltaMessage(st.agentType, st.sessionID, s.Delta))
+}
+
+// ToolUseStep emits a tool_use ContentBlock attached to an assistant message.
+type ToolUseStep struct {
+	ToolID   string
+	ToolName string
+	Input    map[string]any
+}
+
+func (s *ToolUseStep) play(_ context.Context, st *runState) error {
+	if s.ToolID == "" {
+		s.ToolID = "tool_" + uuid.NewString()[:6]
+	}
+	msg := agentboot.NewAssistantMessage(st.agentType, st.sessionID, "")
+	msg.Content = []agentboot.ContentBlock{{
+		Type:     "tool_use",
+		ToolID:   s.ToolID,
+		ToolName: s.ToolName,
+		Input:    s.Input,
+	}}
+	return st.emit(msg)
+}
+
+// ToolResultStep emits a tool_result event referencing a prior ToolUseStep.
+type ToolResultStep struct {
+	ToolID  string
+	Output  any
+	IsError bool
+}
+
+func (s *ToolResultStep) play(_ context.Context, st *runState) error {
+	ev := agentboot.Event{
+		Type:      agentboot.EventTypeToolResult,
+		Timestamp: time.Now(),
+		Data: map[string]interface{}{
+			"agent_type":  string(st.agentType),
+			"session_id":  st.sessionID,
+			"tool_use_id": s.ToolID,
+			"is_error":    s.IsError,
+		},
+	}
+	if s.Output != nil {
+		ev.Data["content"] = s.Output
+	}
+	st.emitEvent(ev)
+	return nil
+}
+
+// PermissionStep performs a permission round-trip with the handler.
+//
+// If ExpectApproved is non-nil and the handler returns a different value, the
+// mismatch is recorded (surfaced via OnError and Result.Error).
+//
+// If the request is denied and OnDenyTerminate is true, the script halts and
+// a "permission_denied" ResultMessage is emitted.
+type PermissionStep struct {
+	ToolName        string
+	Input           map[string]any
+	Reason          string
+	RequestID       string // optional override; auto-generated otherwise
+	ExpectApproved  *bool
+	OnDenyTerminate bool
+}
+
+func (s *PermissionStep) play(ctx context.Context, st *runState) error {
+	if s.RequestID == "" {
+		s.RequestID = uuid.NewString()[:8]
+	}
+
+	permReq := agentboot.NewPermissionRequestMessage(
+		st.agentType, st.sessionID, s.RequestID, s.ToolName, s.Input, s.Reason,
+	)
+	permReq.Step = st.stepIdx
+	permReq.Total = st.totalSteps
+	if err := st.emit(permReq); err != nil {
+		return err
+	}
+
+	approved, result := s.invoke(ctx, st)
+
+	reasonText := result.Reason
+	if reasonText == "" {
+		if approved {
+			reasonText = "Approved"
+		} else {
+			reasonText = "Denied"
+		}
+	}
+	if err := st.emit(agentboot.NewPermissionResultMessage(
+		st.agentType, st.sessionID, s.RequestID, approved, reasonText,
+	)); err != nil {
+		return err
+	}
+
+	if s.ExpectApproved != nil && *s.ExpectApproved != approved {
+		st.recordMismatch("step %d: permission expected approved=%v got %v",
+			st.stepIdx, *s.ExpectApproved, approved)
+	}
+
+	if !approved && s.OnDenyTerminate {
+		st.halt = true
+		return st.emit(agentboot.NewResultMessage(
+			st.agentType, st.sessionID, "permission_denied",
+			fmt.Sprintf("Permission denied at step %d", st.stepIdx),
+		))
+	}
+	return nil
+}
+
+func (s *PermissionStep) invoke(ctx context.Context, st *runState) (bool, agentboot.PermissionResult) {
+	if st.cfg.AutoApprove {
+		return true, agentboot.PermissionResult{Approved: true, UpdatedInput: s.Input}
+	}
+	if st.handler == nil {
+		return true, agentboot.PermissionResult{Approved: true, UpdatedInput: s.Input}
+	}
+	req := agentboot.PermissionRequest{
+		RequestID: s.RequestID,
+		AgentType: st.agentType,
+		ToolName:  s.ToolName,
+		Input:     s.Input,
+		Reason:    s.Reason,
+		Timestamp: time.Now(),
+		SessionID: st.sessionID,
+		BotUUID:   st.opts.BotUUID,
+		ChatID:    st.opts.ChatID,
+		Platform:  st.opts.Platform,
+	}
+	r, err := st.handler.OnApproval(ctx, req)
+	if err != nil {
+		return false, agentboot.PermissionResult{Approved: false, Reason: err.Error()}
+	}
+	return r.Approved, r
+}
+
+// AskQuestion is one question in an AskStep.
+type AskQuestion struct {
+	Question string
+	Header   string
+	Options  []AskOption
+}
+
+// AskOption is one selectable option for an AskQuestion.
+type AskOption struct {
+	Label       string
+	Description string
+}
+
+// AskStep performs an AskUserQuestion round-trip.
+//
+// ExpectAnswers asserts that the handler returned a specific option index for
+// each question (qIdx -> optIdx).
+type AskStep struct {
+	Questions       []AskQuestion
+	RequestID       string
+	ExpectApproved  *bool
+	ExpectAnswers   map[int]int
+	OnDenyTerminate bool
+}
+
+func (s *AskStep) play(ctx context.Context, st *runState) error {
+	if s.RequestID == "" {
+		s.RequestID = uuid.NewString()[:8]
+	}
+
+	input := s.buildInput()
+	permReq := agentboot.NewPermissionRequestMessage(
+		st.agentType, st.sessionID, s.RequestID, "AskUserQuestion", input, "Mock AskUserQuestion",
+	)
+	permReq.Step = st.stepIdx
+	permReq.Total = st.totalSteps
+	if err := st.emit(permReq); err != nil {
+		return err
+	}
+
+	approved, result := s.invoke(ctx, st, input)
+
+	if err := st.emit(agentboot.NewPermissionResultMessage(
+		st.agentType, st.sessionID, s.RequestID, approved, result.Reason,
+	)); err != nil {
+		return err
+	}
+
+	if s.ExpectApproved != nil && *s.ExpectApproved != approved {
+		st.recordMismatch("step %d: ask expected approved=%v got %v",
+			st.stepIdx, *s.ExpectApproved, approved)
+	}
+
+	if approved {
+		s.checkAnswers(st, result)
+	}
+
+	if !approved && s.OnDenyTerminate {
+		st.halt = true
+		return st.emit(agentboot.NewResultMessage(
+			st.agentType, st.sessionID, "ask_denied",
+			fmt.Sprintf("AskUserQuestion denied at step %d", st.stepIdx),
+		))
+	}
+	return nil
+}
+
+func (s *AskStep) buildInput() map[string]interface{} {
+	// IMPrompter consumes "questions" as []interface{}; serialize accordingly.
+	qs := make([]interface{}, 0, len(s.Questions))
+	for _, q := range s.Questions {
+		opts := make([]interface{}, 0, len(q.Options))
+		for _, o := range q.Options {
+			opts = append(opts, map[string]interface{}{
+				"label":       o.Label,
+				"description": o.Description,
+			})
+		}
+		qs = append(qs, map[string]interface{}{
+			"question": q.Question,
+			"header":   q.Header,
+			"options":  opts,
+		})
+	}
+	return map[string]interface{}{"questions": qs}
+}
+
+func (s *AskStep) invoke(ctx context.Context, st *runState, input map[string]interface{}) (bool, agentboot.AskResult) {
+	if st.cfg.AutoApprove {
+		return true, agentboot.AskResult{ID: s.RequestID, Approved: true, UpdatedInput: input}
+	}
+	if st.handler == nil {
+		return true, agentboot.AskResult{ID: s.RequestID, Approved: true, UpdatedInput: input}
+	}
+	req := agentboot.AskRequest{
+		ID:        s.RequestID,
+		Type:      "tool_use",
+		AgentType: st.agentType,
+		Platform:  st.opts.Platform,
+		ChatID:    st.opts.ChatID,
+		BotUUID:   st.opts.BotUUID,
+		SessionID: st.sessionID,
+		ToolName:  "AskUserQuestion",
+		Input:     input,
+	}
+	r, err := st.handler.OnAsk(ctx, req)
+	if err != nil {
+		return false, agentboot.AskResult{ID: s.RequestID, Approved: false, Reason: err.Error()}
+	}
+	return r.Approved, r
+}
+
+func (s *AskStep) checkAnswers(st *runState, result agentboot.AskResult) {
+	if len(s.ExpectAnswers) == 0 {
+		return
+	}
+	answers := pickAnswers(result)
+	for qIdx, optIdx := range s.ExpectAnswers {
+		if qIdx < 0 || qIdx >= len(s.Questions) {
+			continue
+		}
+		if optIdx < 0 || optIdx >= len(s.Questions[qIdx].Options) {
+			continue
+		}
+		want := s.Questions[qIdx].Options[optIdx].Label
+		got := lookupAnswer(answers, qIdx, s.Questions[qIdx].Question)
+		if got != want {
+			st.recordMismatch("step %d: ask q[%d] expected %q got %q",
+				st.stepIdx, qIdx, want, got)
+		}
+	}
+}
+
+func pickAnswers(r agentboot.AskResult) map[string]interface{} {
+	if r.UpdatedInput != nil {
+		if m, ok := r.UpdatedInput["answers"].(map[string]interface{}); ok {
+			return m
+		}
+	}
+	return r.Selection
+}
+
+func lookupAnswer(m map[string]interface{}, qIdx int, qText string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[fmt.Sprintf("%d", qIdx)]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	if qText != "" {
+		if v, ok := m[qText]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// ResultStep emits a final ResultMessage and halts further playback.
+type ResultStep struct {
+	Status  string
+	Message string
+	CostUSD float64
+	Steps   int
+}
+
+func (s *ResultStep) play(_ context.Context, st *runState) error {
+	status := s.Status
+	if status == "" {
+		status = "success"
+	}
+	msg := agentboot.NewResultMessage(st.agentType, st.sessionID, status, s.Message)
+	msg.CostUSD = s.CostUSD
+	msg.Steps = s.Steps
+	st.halt = true
+	return st.emit(msg)
+}
+
+// ErrorStep dispatches an error to the handler. Set Halt=true to stop the
+// script after the error is delivered.
+type ErrorStep struct {
+	Err  error
+	Halt bool
+}
+
+func (s *ErrorStep) play(_ context.Context, st *runState) error {
+	if st.handler != nil && s.Err != nil {
+		st.handler.OnError(s.Err)
+	}
+	if s.Halt {
+		st.halt = true
+	}
+	return nil
+}
+
+// ExpectApprove is a convenience for ExpectApproved=true.
+func ExpectApprove() *bool { v := true; return &v }
+
+// ExpectDeny is a convenience for ExpectApproved=false.
+func ExpectDeny() *bool { v := false; return &v }
+
+// ScriptBuilder constructs a Step slice with a fluent API.
+type ScriptBuilder struct {
+	steps []Step
+}
+
+// NewScript returns a fresh ScriptBuilder.
+func NewScript() *ScriptBuilder { return &ScriptBuilder{} }
+
+// Build returns the accumulated step list.
+func (b *ScriptBuilder) Build() []Step { return b.steps }
+
+// Add appends arbitrary steps.
+func (b *ScriptBuilder) Add(steps ...Step) *ScriptBuilder {
+	b.steps = append(b.steps, steps...)
+	return b
+}
+
+// Assistant appends an AssistantStep.
+func (b *ScriptBuilder) Assistant(text string) *ScriptBuilder {
+	return b.Add(&AssistantStep{Text: text})
+}
+
+// Stream appends a StreamDeltaStep.
+func (b *ScriptBuilder) Stream(delta string) *ScriptBuilder {
+	return b.Add(&StreamDeltaStep{Delta: delta})
+}
+
+// Tool appends a ToolUseStep.
+func (b *ScriptBuilder) Tool(name string, input map[string]any) *ScriptBuilder {
+	return b.Add(&ToolUseStep{ToolName: name, Input: input})
+}
+
+// ToolResult appends a ToolResultStep referencing the most recent ToolUseStep.
+func (b *ScriptBuilder) ToolResult(output any) *ScriptBuilder {
+	var toolID string
+	for i := len(b.steps) - 1; i >= 0; i-- {
+		if tu, ok := b.steps[i].(*ToolUseStep); ok {
+			if tu.ToolID == "" {
+				tu.ToolID = "tool_" + uuid.NewString()[:6]
+			}
+			toolID = tu.ToolID
+			break
+		}
+	}
+	return b.Add(&ToolResultStep{ToolID: toolID, Output: output})
+}
+
+// PermissionOpt is a functional option for ScriptBuilder.Permission.
+type PermissionOpt func(*PermissionStep)
+
+// WithReason sets the permission request reason.
+func WithReason(r string) PermissionOpt {
+	return func(p *PermissionStep) { p.Reason = r }
+}
+
+// WithExpectApproved asserts the user's approval value.
+func WithExpectApproved(approved bool) PermissionOpt {
+	v := approved
+	return func(p *PermissionStep) { p.ExpectApproved = &v }
+}
+
+// WithDenyHalts overrides OnDenyTerminate (default: true).
+func WithDenyHalts(halt bool) PermissionOpt {
+	return func(p *PermissionStep) { p.OnDenyTerminate = halt }
+}
+
+// Permission appends a PermissionStep with OnDenyTerminate=true by default.
+func (b *ScriptBuilder) Permission(toolName string, input map[string]any, opts ...PermissionOpt) *ScriptBuilder {
+	p := &PermissionStep{
+		ToolName:        toolName,
+		Input:           input,
+		OnDenyTerminate: true,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return b.Add(p)
+}
+
+// AskOpt is a functional option for ScriptBuilder.Ask.
+type AskOpt func(*AskStep)
+
+// WithAskExpectAnswers asserts the handler picked specific options per question.
+func WithAskExpectAnswers(answers map[int]int) AskOpt {
+	return func(a *AskStep) { a.ExpectAnswers = answers }
+}
+
+// WithAskExpectApproved asserts the handler approved or denied the ask.
+func WithAskExpectApproved(approved bool) AskOpt {
+	v := approved
+	return func(a *AskStep) { a.ExpectApproved = &v }
+}
+
+// WithAskDenyHalts overrides OnDenyTerminate (default: true).
+func WithAskDenyHalts(halt bool) AskOpt {
+	return func(a *AskStep) { a.OnDenyTerminate = halt }
+}
+
+// Ask appends an AskStep with the given questions.
+func (b *ScriptBuilder) Ask(questions []AskQuestion, opts ...AskOpt) *ScriptBuilder {
+	a := &AskStep{Questions: questions, OnDenyTerminate: true}
+	for _, o := range opts {
+		o(a)
+	}
+	return b.Add(a)
+}
+
+// Success appends a success ResultStep.
+func (b *ScriptBuilder) Success(message string) *ScriptBuilder {
+	return b.Add(&ResultStep{Status: "success", Message: message})
+}
+
+// Result appends an arbitrary ResultStep.
+func (b *ScriptBuilder) Result(status, message string) *ScriptBuilder {
+	return b.Add(&ResultStep{Status: status, Message: message})
+}
+
+// Error appends an ErrorStep that does not halt.
+func (b *ScriptBuilder) Error(err error) *ScriptBuilder {
+	return b.Add(&ErrorStep{Err: err})
+}
+
+// FailWith appends an ErrorStep followed by an "error" ResultStep.
+func (b *ScriptBuilder) FailWith(err error) *ScriptBuilder {
+	return b.Add(&ErrorStep{Err: err}, &ResultStep{Status: "error", Message: err.Error()})
+}
+
+// defaultLinearScript replicates the legacy fixed-loop behavior for callers
+// that don't supply a Script.
+func defaultLinearScript(cfg Config) []Step {
+	n := cfg.MaxIterations
+	if n <= 0 {
+		n = DefaultConfig().MaxIterations
+	}
+	out := make([]Step, 0, n*2+1)
+	for step := 1; step <= n; step++ {
+		if cfg.AskUserQuestionFrequency > 0 && step%cfg.AskUserQuestionFrequency == 0 {
+			out = append(out, &AskStep{
+				Questions: []AskQuestion{
+					{
+						Question: fmt.Sprintf("Mock question %d of %d", step, n),
+						Header:   "Mock",
+						Options: []AskOption{
+							{Label: "Option A", Description: "First option"},
+							{Label: "Option B", Description: "Second option"},
+							{Label: "Option C", Description: "Third option"},
+						},
+					},
+				},
+				OnDenyTerminate: true,
+			})
+		} else {
+			tool := mockToolNames[(step-1)%len(mockToolNames)]
+			out = append(out, &PermissionStep{
+				ToolName: tool,
+				Input: map[string]interface{}{
+					"step":  step,
+					"total": n,
+				},
+				Reason:          fmt.Sprintf("Mock permission request %d of %d", step, n),
+				OnDenyTerminate: true,
+			})
+		}
+		out = append(out, &linearAssistantStep{tpl: cfg.ResponseTemplate, step: step, total: n})
+	}
+	out = append(out, &ResultStep{Status: "success", Message: "Mock agent completed all iterations"})
+	return out
+}
+
+// linearAssistantStep formats and emits an assistant message using the legacy
+// ResponseTemplate placeholders (used by defaultLinearScript only).
+type linearAssistantStep struct {
+	tpl   string
+	step  int
+	total int
+}
+
+func (s *linearAssistantStep) play(_ context.Context, st *runState) error {
+	text := s.tpl
+	text = strings.ReplaceAll(text, "{step}", fmt.Sprintf("%d", s.step))
+	text = strings.ReplaceAll(text, "{total}", fmt.Sprintf("%d", s.total))
+	text = strings.ReplaceAll(text, "{prompt}", truncatePrompt(st.prompt))
+	return st.emit(agentboot.NewAssistantMessage(st.agentType, st.sessionID, text))
+}

--- a/imbot/platform/tingly/testenv/prompt.go
+++ b/imbot/platform/tingly/testenv/prompt.go
@@ -1,0 +1,145 @@
+package testenv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/imbot"
+)
+
+// ApprovalPrompt is a strongly-typed view of an outbound permission prompt
+// (Approve / Deny / Always Allow keyboard). Tests use it to click a specific
+// option without remembering the button label or callback wire format.
+type ApprovalPrompt struct {
+	Event     *OutEvent
+	RequestID string
+}
+
+// Approve clicks the configured "approve" button (default: "✅ Allow"). Fails
+// the test if the button is missing.
+func (p *ApprovalPrompt) Approve() { p.clickAction("allow") }
+
+// Deny clicks the configured "deny" button. Fails the test if missing.
+func (p *ApprovalPrompt) Deny() { p.clickAction("deny") }
+
+// AlwaysAllow clicks the configured "always" button. Fails the test if
+// missing.
+func (p *ApprovalPrompt) AlwaysAllow() { p.clickAction("always") }
+
+// Text returns the prompt's body text (passthrough convenience).
+func (p *ApprovalPrompt) Text() string { return p.Event.Text }
+
+func (p *ApprovalPrompt) clickAction(action string) {
+	t := p.Event.chat.env.t
+	t.Helper()
+
+	want := imbot.FormatCallbackData("perm", action, p.RequestID)
+	if btn, ok := findButtonByCallback(p.Event, want); ok {
+		btn.Click()
+		return
+	}
+	t.Fatalf("ApprovalPrompt: no button for action %q (callback=%q); have %s",
+		action, want, formatButtons(p.Event.Buttons))
+}
+
+// AskPrompt is a strongly-typed view of an outbound AskUserQuestion prompt.
+type AskPrompt struct {
+	Event     *OutEvent
+	RequestID string
+}
+
+// SelectOption clicks the (qIdx, optIdx) button. Fails the test if missing.
+func (p *AskPrompt) SelectOption(qIdx, optIdx int) {
+	t := p.Event.chat.env.t
+	t.Helper()
+	want := imbot.FormatCallbackData("perm", "option", p.RequestID,
+		fmt.Sprintf("%d", qIdx), fmt.Sprintf("%d", optIdx))
+	if btn, ok := findButtonByCallback(p.Event, want); ok {
+		btn.Click()
+		return
+	}
+	t.Fatalf("AskPrompt: no option button q=%d opt=%d (callback=%q); have %s",
+		qIdx, optIdx, want, formatButtons(p.Event.Buttons))
+}
+
+// Cancel clicks the AskUserQuestion cancel button.
+func (p *AskPrompt) Cancel() {
+	t := p.Event.chat.env.t
+	t.Helper()
+	want := imbot.FormatCallbackData("perm", "deny", p.RequestID)
+	if btn, ok := findButtonByCallback(p.Event, want); ok {
+		btn.Click()
+		return
+	}
+	if btn, ok := p.Event.ButtonByLabel("❌ Cancel"); ok {
+		btn.Click()
+		return
+	}
+	t.Fatalf("AskPrompt: no cancel button (callback=%q); have %s",
+		want, formatButtons(p.Event.Buttons))
+}
+
+// Text returns the prompt's body text (passthrough convenience).
+func (p *AskPrompt) Text() string { return p.Event.Text }
+
+// WaitApprovalPrompt blocks until the next outbound message in this chat is a
+// permission keyboard (perm:allow / perm:deny / perm:always callback buttons).
+// Fails the test on timeout or if a non-prompt message arrives first.
+func (c *Chat) WaitApprovalPrompt(d time.Duration) *ApprovalPrompt {
+	t := c.env.t
+	t.Helper()
+	evt := c.WaitText(d)
+	id, ok := extractPermRequestID(evt, "allow", "deny", "always")
+	if !ok {
+		t.Fatalf("WaitApprovalPrompt: message does not look like a permission prompt: text=%q buttons=%s",
+			evt.Text, formatButtons(evt.Buttons))
+	}
+	return &ApprovalPrompt{Event: evt, RequestID: id}
+}
+
+// WaitAskQuestionPrompt blocks until the next outbound message carries an
+// AskUserQuestion keyboard (perm:option callback buttons). Fails the test on
+// timeout or non-prompt arrival.
+func (c *Chat) WaitAskQuestionPrompt(d time.Duration) *AskPrompt {
+	t := c.env.t
+	t.Helper()
+	evt := c.WaitText(d)
+	id, ok := extractPermRequestID(evt, "option")
+	if !ok {
+		t.Fatalf("WaitAskQuestionPrompt: message does not look like an ask prompt: text=%q buttons=%s",
+			evt.Text, formatButtons(evt.Buttons))
+	}
+	return &AskPrompt{Event: evt, RequestID: id}
+}
+
+func findButtonByCallback(e *OutEvent, want string) (*Button, bool) {
+	for i := range e.Buttons {
+		for j := range e.Buttons[i] {
+			if e.Buttons[i][j].CallbackData == want {
+				return &e.Buttons[i][j], true
+			}
+		}
+	}
+	return nil, false
+}
+
+func extractPermRequestID(e *OutEvent, actions ...string) (string, bool) {
+	want := make(map[string]struct{}, len(actions))
+	for _, a := range actions {
+		want[a] = struct{}{}
+	}
+	for i := range e.Buttons {
+		for j := range e.Buttons[i] {
+			parts := strings.Split(e.Buttons[i][j].CallbackData, ":")
+			if len(parts) < 3 || parts[0] != "perm" {
+				continue
+			}
+			if _, ok := want[parts[1]]; !ok {
+				continue
+			}
+			return parts[2], true
+		}
+	}
+	return "", false
+}

--- a/internal/remote_control/bot/tingly_agent_test.go
+++ b/internal/remote_control/bot/tingly_agent_test.go
@@ -1,0 +1,209 @@
+package bot_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+	mockagent "github.com/tingly-dev/tingly-box/agentboot/mockagent"
+	"github.com/tingly-dev/tingly-box/imbot/platform/tingly/testenv"
+	"github.com/tingly-dev/tingly-box/internal/remote_control/bot"
+)
+
+// agentBoot returns a bootHelper variant that registers a custom mock agent
+// for the chat. The returned chat is already routed to the mock agent.
+func agentBoot(t *testing.T, script []mockagent.Step) (*testenv.TestEnv, *bot.TestHarness, *testenv.Chat) {
+	t.Helper()
+
+	env, harness, alice := bootHelper(t, false)
+	chat := alice.OpenDM(harness.Setting.UUID)
+
+	customMock := mockagent.NewAgent(mockagent.Config{Script: script})
+	harness.AgentBoot.RegisterAgent(agentboot.AgentTypeMockAgent, customMock)
+	harness.SetCurrentAgent(chat.ChatID, "mock")
+
+	return env, harness, chat
+}
+
+// drainProcessingPreface reads the leading "🧪 Mock: Processing..." reply that
+// MockAgentExecutor sends before invoking the agent. Tests use this to focus
+// assertions on script-driven events.
+func drainProcessingPreface(t *testing.T, chat *testenv.Chat) {
+	t.Helper()
+	evt := chat.WaitText(3 * time.Second)
+	if !strings.Contains(evt.Text, "Mock: Processing") {
+		t.Fatalf("expected 'Mock: Processing...' preface, got %q", evt.Text)
+	}
+}
+
+// waitTextContaining scans up to maxScan outbound text messages for the first
+// containing substr. Fails the test if not found in time.
+func waitTextContaining(t *testing.T, chat *testenv.Chat, substr string, maxScan int, perWait time.Duration) *testenv.OutEvent {
+	t.Helper()
+	for i := 0; i < maxScan; i++ {
+		evt := chat.WaitText(perWait)
+		if strings.Contains(evt.Text, substr) {
+			return evt
+		}
+	}
+	t.Fatalf("did not see text containing %q within %d messages", substr, maxScan)
+	return nil
+}
+
+// Test_AgentE2E_AssistantText drives the bot through a script that emits a
+// single assistant text and a success result. Verifies the assistant text
+// reaches chat at least once.
+func Test_AgentE2E_AssistantText(t *testing.T) {
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Assistant("hello from mock").
+		Success("done").
+		Build())
+
+	chat.SendText("hi")
+	drainProcessingPreface(t, chat)
+
+	waitTextContaining(t, chat, "hello from mock", 4, 3*time.Second)
+}
+
+// Test_AgentE2E_PermissionApprove verifies the full permission round-trip:
+// the bot surfaces a permission prompt, the user approves, and the agent
+// continues to emit further events.
+func Test_AgentE2E_PermissionApprove(t *testing.T) {
+	approved := true
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Permission("Bash", map[string]any{"command": "pwd"},
+			mockagent.WithExpectApproved(approved),
+			mockagent.WithDenyHalts(false)).
+		Assistant("after approve").
+		Success("ok").
+		Build())
+
+	chat.SendText("run pwd")
+	drainProcessingPreface(t, chat)
+
+	prompt := chat.WaitApprovalPrompt(3 * time.Second)
+	require.NotEmpty(t, prompt.RequestID, "permission prompt should carry a request id")
+	prompt.Approve()
+
+	waitTextContaining(t, chat, "after approve", 4, 3*time.Second)
+}
+
+// Test_AgentE2E_PermissionDeny verifies that clicking Deny halts the script
+// and the bot surfaces a denial confirmation.
+func Test_AgentE2E_PermissionDeny(t *testing.T) {
+	denied := false
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Permission("Bash", map[string]any{"command": "rm -rf /"},
+			mockagent.WithExpectApproved(denied)).
+		Assistant("never reached").
+		Build())
+
+	chat.SendText("dangerous")
+	drainProcessingPreface(t, chat)
+
+	prompt := chat.WaitApprovalPrompt(3 * time.Second)
+	prompt.Deny()
+
+	// The denial confirmation lands within a few messages: either the
+	// "❌ Deny for tool: ..." callback ack or the prompter's edited prompt
+	// carrying "Denied".
+	for i := 0; i < 4; i++ {
+		evt := chat.WaitText(3 * time.Second)
+		if strings.Contains(evt.Text, "Deny") || strings.Contains(evt.Text, "❌") || strings.Contains(evt.Text, "Denied") {
+			return
+		}
+	}
+	t.Fatalf("expected a denial-related reply after clicking Deny")
+}
+
+// Test_AgentE2E_AskQuestion drives the bot through an AskUserQuestion script
+// step and verifies the option keyboard works end-to-end.
+func Test_AgentE2E_AskQuestion(t *testing.T) {
+	questions := []mockagent.AskQuestion{
+		{
+			Question: "pick a fruit",
+			Options: []mockagent.AskOption{
+				{Label: "apple"},
+				{Label: "banana"},
+				{Label: "cherry"},
+			},
+		},
+	}
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Ask(questions, mockagent.WithAskExpectAnswers(map[int]int{0: 1})).
+		Assistant("got it").
+		Success("ok").
+		Build())
+
+	chat.SendText("ask me")
+	drainProcessingPreface(t, chat)
+
+	prompt := chat.WaitAskQuestionPrompt(3 * time.Second)
+	require.NotEmpty(t, prompt.RequestID)
+	prompt.SelectOption(0, 1) // banana
+
+	waitTextContaining(t, chat, "got it", 6, 3*time.Second)
+}
+
+// Test_AgentE2E_ScriptError verifies that an ErrorStep reaches the chat as an
+// "[ERROR] ..." message via the streaming handler's OnError path.
+func Test_AgentE2E_ScriptError(t *testing.T) {
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Assistant("trying").
+		Error(errors.New("boom")).
+		Success("done").
+		Build())
+
+	chat.SendText("trigger error")
+	drainProcessingPreface(t, chat)
+
+	// We expect "trying" then an "[ERROR] boom" line — not necessarily in a
+	// fixed order, since OnMessage and OnError can interleave on the bot
+	// goroutine. Scan up to four messages for both.
+	sawTrying, sawErr := false, false
+	for i := 0; i < 6 && (!sawTrying || !sawErr); i++ {
+		evt := chat.WaitText(3 * time.Second)
+		if strings.Contains(evt.Text, "trying") {
+			sawTrying = true
+		}
+		if strings.Contains(evt.Text, "boom") {
+			sawErr = true
+		}
+	}
+	if !sawTrying {
+		t.Fatalf("did not see 'trying' assistant text")
+	}
+	if !sawErr {
+		t.Fatalf("did not see 'boom' error text")
+	}
+}
+
+// Test_AgentE2E_PermissionExpectMismatch verifies that scripts with
+// ExpectApproved mismatches surface via the streaming handler's OnError path
+// (rendered as "[ERROR] mockagent: ...").
+func Test_AgentE2E_PermissionExpectMismatch(t *testing.T) {
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Permission("Bash", nil,
+			mockagent.WithExpectApproved(true),
+			mockagent.WithDenyHalts(true)).
+		Build())
+
+	chat.SendText("trigger")
+	drainProcessingPreface(t, chat)
+
+	prompt := chat.WaitApprovalPrompt(3 * time.Second)
+	prompt.Deny() // user denies, but the script expected approval → mismatch
+
+	// Scan up to six replies for the "expected approved=true" mismatch.
+	for i := 0; i < 6; i++ {
+		evt := chat.WaitText(3 * time.Second)
+		if strings.Contains(evt.Text, "expected approved=true") {
+			return
+		}
+	}
+	t.Fatalf("did not see expectation-mismatch error in chat")
+}


### PR DESCRIPTION
Rewrite agentboot/mockagent's fixed-loop engine as a script player so tests can declare exact event sequences (assistant/permission/ask/result/error). The legacy Config{MaxIterations,...} path is preserved by generating an equivalent linear default script, so existing callers (BootForTest, agent_mock.go) keep working unchanged.

Add testenv prompt helpers (WaitApprovalPrompt, WaitAskQuestionPrompt) so tests can semantically click Approve/Deny/Always or SelectOption(q,o) without hardcoding callback wire formats.

Add tingly_agent_test.go covering happy-path assistant text, permission approve/deny, ask-question multi-option select, mid-flow script error, and permission-expectation mismatch — exercising the full imbot+tingly+ remote-control routing through the mock agent for the first time.