### PR TITLE
test(bot,testenv): tighten mock-agent harness — Expect DSL + fix 4 silent bugs

### DIFF
--- a/agentboot/ask/normalize.go
+++ b/agentboot/ask/normalize.go
@@ -1,0 +1,27 @@
+package ask
+
+// NormalizeQuestions coerces the heterogeneous "questions" payload into a
+// canonical []map[string]any. Callers may serialize it as []interface{},
+// []map[string]any, or []any of map[string]any — all should yield identical
+// downstream rendering. Returns nil for any other shape (including nil).
+func NormalizeQuestions(v any) []map[string]any {
+	switch xs := v.(type) {
+	case []map[string]any:
+		return xs
+	case []interface{}:
+		out := make([]map[string]any, 0, len(xs))
+		for _, item := range xs {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			} else if m, ok := item.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// NormalizeOptions is identical to NormalizeQuestions; named separately for
+// readability at call sites where the payload represents per-question options.
+func NormalizeOptions(v any) []map[string]any { return NormalizeQuestions(v) }

--- a/agentboot/ask/stdin_prompter.go
+++ b/agentboot/ask/stdin_prompter.go
@@ -113,8 +113,8 @@ func (p *StdinPrompter) Prompt(ctx context.Context, req Request) (Result, error)
 
 // promptAskUserQuestion handles AskUserQuestion tool with multi-option selection
 func (p *StdinPrompter) promptAskUserQuestion(ctx context.Context, req Request) (Result, error) {
-	questions, ok := req.Input["questions"].([]interface{})
-	if !ok || len(questions) == 0 {
+	questions := NormalizeQuestions(req.Input["questions"])
+	if len(questions) == 0 {
 		return Result{
 			ID:           req.ID,
 			Approved:     true,
@@ -127,12 +127,7 @@ func (p *StdinPrompter) promptAskUserQuestion(ctx context.Context, req Request) 
 
 	answers := make(map[string]interface{})
 
-	for i, q := range questions {
-		question, ok := q.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
+	for i, question := range questions {
 		questionText, _ := question["question"].(string)
 		header, _ := question["header"].(string)
 
@@ -142,17 +137,13 @@ func (p *StdinPrompter) promptAskUserQuestion(ctx context.Context, req Request) 
 		fmt.Printf("%s\n", questionText)
 
 		// Show options
-		options, ok := question["options"].([]interface{})
-		if !ok || len(options) == 0 {
+		options := NormalizeOptions(question["options"])
+		if len(options) == 0 {
 			continue
 		}
 
 		fmt.Printf("\nOptions:\n")
-		for j, opt := range options {
-			option, ok := opt.(map[string]interface{})
-			if !ok {
-				continue
-			}
+		for j, option := range options {
 			label, _ := option["label"].(string)
 			desc, _ := option["description"].(string)
 			if desc != "" {
@@ -202,13 +193,11 @@ func (p *StdinPrompter) promptAskUserQuestion(ctx context.Context, req Request) 
 
 			// If not a valid number, try matching by label
 			if selectedIndex < 0 {
-				for j, opt := range options {
-					if option, ok := opt.(map[string]interface{}); ok {
-						if label, ok := option["label"].(string); ok {
-							if strings.EqualFold(label, r.response) {
-								selectedIndex = j
-								break
-							}
+				for j, option := range options {
+					if label, ok := option["label"].(string); ok {
+						if strings.EqualFold(label, r.response) {
+							selectedIndex = j
+							break
 						}
 					}
 				}
@@ -218,10 +207,8 @@ func (p *StdinPrompter) promptAskUserQuestion(ctx context.Context, req Request) 
 			if selectedIndex < 0 {
 				selectedLabel = r.response
 			} else if selectedIndex >= 0 && selectedIndex < len(options) {
-				if option, ok := options[selectedIndex].(map[string]interface{}); ok {
-					if label, ok := option["label"].(string); ok {
-						selectedLabel = label
-					}
+				if label, ok := options[selectedIndex]["label"].(string); ok {
+					selectedLabel = label
 				}
 			}
 

--- a/agentboot/ask/tool_handlers.go
+++ b/agentboot/ask/tool_handlers.go
@@ -32,22 +32,16 @@ func (h *AskUserQuestionHandler) BuildPrompt(req Request) string {
 
 	text.WriteString("❓ *Question*\n\n")
 
-	questions, ok := req.Input["questions"].([]interface{})
-	if !ok || len(questions) == 0 {
+	questions := NormalizeQuestions(req.Input["questions"])
+	if len(questions) == 0 {
 		text.WriteString("_No questions provided_\n")
 		logrus.WithFields(map[string]interface{}{
-			"has_questions":  ok,
 			"questions_type": fmt.Sprintf("%T", req.Input["questions"]),
 		}).Debug("BuildPrompt: questions parsing result")
 		return text.String()
 	}
 
-	for i, q := range questions {
-		question, ok := q.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
+	for i, question := range questions {
 		questionText, _ := question["question"].(string)
 		header, _ := question["header"].(string)
 
@@ -57,14 +51,10 @@ func (h *AskUserQuestionHandler) BuildPrompt(req Request) string {
 		text.WriteString(fmt.Sprintf("%d. %s\n\n", i+1, questionText))
 
 		// Show options with clear mapping to buttons
-		options, ok := question["options"].([]interface{})
-		if ok && len(options) > 0 {
+		options := NormalizeOptions(question["options"])
+		if len(options) > 0 {
 			text.WriteString("Options:\n")
-			for j, opt := range options {
-				option, ok := opt.(map[string]interface{})
-				if !ok {
-					continue
-				}
+			for j, option := range options {
 				label, _ := option["label"].(string)
 				desc, _ := option["description"].(string)
 				// Format to match button labels (Option 1, Option 2, etc.)
@@ -87,8 +77,8 @@ func (h *AskUserQuestionHandler) BuildPrompt(req Request) string {
 
 // ParseResponse parses the user's selection into the answers format
 func (h *AskUserQuestionHandler) ParseResponse(req Request, response Response) (Result, error) {
-	questions, ok := req.Input["questions"].([]interface{})
-	if !ok || len(questions) == 0 {
+	questions := NormalizeQuestions(req.Input["questions"])
+	if len(questions) == 0 {
 		return Result{
 			ID:       req.ID,
 			Approved: false,
@@ -110,26 +100,19 @@ func (h *AskUserQuestionHandler) ParseResponse(req Request, response Response) (
 	}
 
 	// Try to match against first question (most common case for stdin single-line input)
-	if len(questions) > 0 {
-		question, ok := questions[0].(map[string]interface{})
-		if ok {
-			questionText, _ := question["question"].(string)
-			options, ok := question["options"].([]interface{})
-			if ok {
-				selectedIndex, selectedLabel := h.parseSelection(selection, options)
+	question := questions[0]
+	questionText, _ := question["question"].(string)
+	options := NormalizeOptions(question["options"])
+	if len(options) > 0 {
+		selectedIndex, selectedLabel := h.parseSelection(selection, options)
 
-				if selectedIndex >= 0 && selectedIndex < len(options) {
-					// Store the selected option label as the answer
-					if opt, ok := options[selectedIndex].(map[string]interface{}); ok {
-						if label, ok := opt["label"].(string); ok {
-							answers[questionText] = label
-						}
-					}
-				} else if selectedLabel != "" {
-					// User typed the label directly
-					answers[questionText] = selectedLabel
-				}
+		if selectedIndex >= 0 && selectedIndex < len(options) {
+			if label, ok := options[selectedIndex]["label"].(string); ok {
+				answers[questionText] = label
 			}
+		} else if selectedLabel != "" {
+			// User typed the label directly
+			answers[questionText] = selectedLabel
 		}
 	}
 
@@ -154,7 +137,7 @@ func (h *AskUserQuestionHandler) ParseResponse(req Request, response Response) (
 //   - 1-based number (user types "1" for first option)
 //   - 0-based index from callback (e.g., "0", "1")
 //   - label text (exact or case-insensitive match)
-func (h *AskUserQuestionHandler) parseSelection(selection string, options []interface{}) (int, string) {
+func (h *AskUserQuestionHandler) parseSelection(selection string, options []map[string]any) (int, string) {
 	// Try to parse as number
 	var index int
 	if _, err := fmt.Sscanf(selection, "%d", &index); err == nil {
@@ -172,12 +155,10 @@ func (h *AskUserQuestionHandler) parseSelection(selection string, options []inte
 
 	// Try to match by label (case-insensitive)
 	selectionLower := strings.ToLower(selection)
-	for i, opt := range options {
-		if option, ok := opt.(map[string]interface{}); ok {
-			if label, ok := option["label"].(string); ok {
-				if strings.ToLower(label) == selectionLower {
-					return i, ""
-				}
+	for i, option := range options {
+		if label, ok := option["label"].(string); ok {
+			if strings.ToLower(label) == selectionLower {
+				return i, ""
 			}
 		}
 	}

--- a/imbot/platform/tingly/testenv/expect.go
+++ b/imbot/platform/tingly/testenv/expect.go
@@ -1,0 +1,237 @@
+package testenv
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/imbot/platform/tingly"
+)
+
+// Matcher describes a single expected outbound event. Zero-valued fields are
+// not enforced; only the fields the caller sets are checked.
+//
+// Kind is required. Use the constants from package tingly (EventSend,
+// EventEdit, EventReact, EventDelete, EventMedia).
+type Matcher struct {
+	Kind tingly.EventKind
+
+	// Optional: require the event target a specific message id (mainly
+	// useful for EventEdit / EventReact / EventDelete).
+	MessageID string
+
+	// At most one of TextEquals / TextContains / TextRegexp may be set.
+	TextEquals   string
+	TextContains string
+	TextRegexp   *regexp.Regexp
+
+	// HasButton, if non-empty, requires the event's keyboard contains a
+	// button with this exact label. HasCallback (also optional) requires
+	// the keyboard contains a button whose CallbackData matches.
+	HasButton   string
+	HasCallback string
+
+	// NoKeyboard, if true, fails when the event carries any inline keyboard.
+	NoKeyboard bool
+
+	// Name is shown in failure messages. Falls back to the Matcher's index.
+	Name string
+}
+
+// String returns a short human description of the matcher.
+func (m Matcher) String() string {
+	parts := []string{string(m.Kind)}
+	if m.Name != "" {
+		parts = append([]string{m.Name + ":"}, parts...)
+	}
+	if m.MessageID != "" {
+		parts = append(parts, "msgID="+m.MessageID)
+	}
+	if m.TextEquals != "" {
+		parts = append(parts, fmt.Sprintf("text==%q", m.TextEquals))
+	}
+	if m.TextContains != "" {
+		parts = append(parts, fmt.Sprintf("text~=%q", m.TextContains))
+	}
+	if m.TextRegexp != nil {
+		parts = append(parts, "text=~/"+m.TextRegexp.String()+"/")
+	}
+	if m.HasButton != "" {
+		parts = append(parts, "button="+m.HasButton)
+	}
+	if m.HasCallback != "" {
+		parts = append(parts, "callback="+m.HasCallback)
+	}
+	if m.NoKeyboard {
+		parts = append(parts, "noKeyboard")
+	}
+	return strings.Join(parts, " ")
+}
+
+func (m Matcher) match(e OutEvent) (bool, string) {
+	if e.Kind != m.Kind {
+		return false, fmt.Sprintf("kind=%q want %q", e.Kind, m.Kind)
+	}
+	if m.MessageID != "" && e.MessageID != m.MessageID {
+		return false, fmt.Sprintf("messageID=%q want %q", e.MessageID, m.MessageID)
+	}
+	if m.TextEquals != "" && e.Text != m.TextEquals {
+		return false, fmt.Sprintf("text=%q want exactly %q", e.Text, m.TextEquals)
+	}
+	if m.TextContains != "" && !strings.Contains(e.Text, m.TextContains) {
+		return false, fmt.Sprintf("text=%q does not contain %q", e.Text, m.TextContains)
+	}
+	if m.TextRegexp != nil && !m.TextRegexp.MatchString(e.Text) {
+		return false, fmt.Sprintf("text=%q does not match /%s/", e.Text, m.TextRegexp.String())
+	}
+	if m.HasButton != "" {
+		if _, ok := e.ButtonByLabel(m.HasButton); !ok {
+			return false, fmt.Sprintf("no button %q in %s", m.HasButton, formatButtons(e.Buttons))
+		}
+	}
+	if m.HasCallback != "" {
+		if _, ok := findButtonByCallback(&e, m.HasCallback); !ok {
+			return false, fmt.Sprintf("no callback %q in %s", m.HasCallback, formatButtons(e.Buttons))
+		}
+	}
+	if m.NoKeyboard && len(e.Buttons) > 0 {
+		return false, fmt.Sprintf("expected no keyboard, got %s", formatButtons(e.Buttons))
+	}
+	return true, ""
+}
+
+// Expect consumes the next len(matchers) events from this chat in order.
+// Each event must match the corresponding Matcher exactly. Extra/skipped
+// events between matchers are not allowed — use ExpectInOrderLoose for that.
+//
+// The total wait deadline applies across all matchers (not per-matcher).
+// On failure the test is fatal'd with the full event history dumped.
+func (c *Chat) Expect(d time.Duration, matchers ...Matcher) []OutEvent {
+	c.env.t.Helper()
+	deadline := time.Now().Add(d)
+	got := make([]OutEvent, 0, len(matchers))
+	for i, m := range matchers {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			c.failExpect(matchers, got, i, "deadline reached before matcher", "")
+			return got
+		}
+		// Always advance to the very next event — strict mode.
+		e, ok := c.tryReceive(remaining, func(tingly.Event) bool { return true })
+		if !ok {
+			c.failExpect(matchers, got, i, "no more events", "")
+			return got
+		}
+		out := toOutEvent(c, e)
+		got = append(got, out)
+		if ok, why := m.match(out); !ok {
+			c.failExpect(matchers, got, i, "matcher failed", why)
+			return got
+		}
+	}
+	return got
+}
+
+// ExpectInOrderLoose is like Expect but allows extra events between matchers.
+// Each matcher is satisfied by the next event that matches it; non-matching
+// events are silently consumed.
+//
+// Use this when the surrounding events are flaky in number/order, but the
+// presence and order of the listed matchers still matters.
+func (c *Chat) ExpectInOrderLoose(d time.Duration, matchers ...Matcher) []OutEvent {
+	c.env.t.Helper()
+	deadline := time.Now().Add(d)
+	got := make([]OutEvent, 0, len(matchers))
+	for i, m := range matchers {
+		var matched OutEvent
+		found := false
+		for !found {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				c.failExpect(matchers, got, i, "deadline reached before matcher", "")
+				return got
+			}
+			e, ok := c.tryReceive(remaining, func(tingly.Event) bool { return true })
+			if !ok {
+				c.failExpect(matchers, got, i, "no more events", "")
+				return got
+			}
+			out := toOutEvent(c, e)
+			if ok, _ := m.match(out); ok {
+				matched = out
+				found = true
+			}
+		}
+		got = append(got, matched)
+	}
+	return got
+}
+
+// ExpectIdle fails the test if any outbound event arrives within d.
+// Equivalent to ExpectNoEvent with all kinds.
+func (c *Chat) ExpectIdle(d time.Duration) {
+	c.env.t.Helper()
+	c.ExpectNoEvent(d)
+}
+
+// CountText returns how many recorded events for this chat have a Text field
+// containing the substring substr. Useful for "exactly once" assertions.
+func (c *Chat) CountText(substr string) int {
+	n := 0
+	for _, e := range c.AllEvents() {
+		if strings.Contains(e.Text, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// AssertTextOccurrences fails the test unless exactly want events with
+// substring substr have been observed in this chat so far.
+func (c *Chat) AssertTextOccurrences(substr string, want int) {
+	c.env.t.Helper()
+	got := c.CountText(substr)
+	if got != want {
+		c.env.t.Fatalf("[chat=%s] expected %d events containing %q, got %d; events seen: %s",
+			c.ChatID, want, substr, got, summarize(c.AllEvents()))
+	}
+}
+
+func (c *Chat) failExpect(matchers []Matcher, got []OutEvent, idx int, reason, detail string) {
+	c.env.t.Helper()
+	want := matchers[idx]
+	var msg strings.Builder
+	fmt.Fprintf(&msg, "[chat=%s] Expect: matcher #%d (%s) — %s",
+		c.ChatID, idx, want.String(), reason)
+	if detail != "" {
+		fmt.Fprintf(&msg, ": %s", detail)
+	}
+	msg.WriteString("\n  matched so far:\n")
+	for i := 0; i < idx; i++ {
+		fmt.Fprintf(&msg, "    [%d] %s OK <- %s\n", i, matchers[i].String(), brief(got[i]))
+	}
+	if idx < len(got) {
+		fmt.Fprintf(&msg, "    [%d] %s GOT <- %s\n", idx, want.String(), brief(got[idx]))
+	}
+	msg.WriteString("  full event history (this chat): " + summarize(c.AllEvents()))
+	c.env.t.Fatalf("%s", msg.String())
+}
+
+func brief(e OutEvent) string {
+	text := e.Text
+	if len(text) > 60 {
+		text = text[:60] + "..."
+	}
+	parts := []string{string(e.Kind)}
+	if e.MessageID != "" {
+		parts = append(parts, "msg="+e.MessageID)
+	}
+	if text != "" {
+		parts = append(parts, fmt.Sprintf("%q", text))
+	}
+	if len(e.Buttons) > 0 {
+		parts = append(parts, "kb="+formatButtons(e.Buttons))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/remote_control/bot/agent_mock.go
+++ b/internal/remote_control/bot/agent_mock.go
@@ -75,9 +75,18 @@ func (e *MockAgentExecutor) Execute(ctx context.Context, req PreparedRequest) (*
 	// Create streaming handler (shared meta pointer)
 	streamHandler := e.deps.NewStreamingMessageHandler(req.HCtx, meta)
 
-	// Create composite handler
+	// Create composite handler. The CompletionCallback is what sends the
+	// "Task done" footer + action keyboard at the end of a successful run
+	// and writes the final session status. Mock and Claude Code share the
+	// same callback so both paths look identical to the user.
 	compositeHandler := agentboot.NewCompositeHandler().
 		SetStreamer(streamHandler).
+		SetCompletionCallback(&CompletionCallback{
+			hCtx:       req.HCtx,
+			sessionID:  sessionID,
+			sessionMgr: e.deps.SessionMgr,
+			meta:       meta,
+		}).
 		SetApprovalHandler(e.deps.IMPrompter).
 		SetAskHandler(e.deps.IMPrompter)
 
@@ -133,14 +142,14 @@ func (e *MockAgentExecutor) Execute(ctx context.Context, req PreparedRequest) (*
 		}, err
 	}
 
-	e.deps.SessionMgr.SetCompleted(sessionID, response)
+	// Persist the assistant turn to the session log. CompletionCallback
+	// already handled the "Task done" card and SetCompleted; the response
+	// text was streamed to chat by streamingMessageHandler during execution.
 	e.deps.SessionMgr.AppendMessage(sessionID, session.Message{
 		Role:      "assistant",
 		Content:   response,
 		Timestamp: time.Now(),
 	})
-
-	e.deps.SendTextWithActionKeyboard(req.HCtx, response, req.ReplyTo)
 
 	return &ExecutionResult{
 		SessionID:    sessionID,

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -333,6 +333,9 @@ func (h *streamingMessageHandler) GetOutput() string {
 // sendMessage sends a message to the bot
 // Note: Platform handles chunking internally via BaseBot.ChunkText()
 func (h *streamingMessageHandler) sendMessage(text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
 	_, err := h.bot.SendMessage(context.Background(), h.chatID, &imbot.SendMessageOptions{
 		Text:      text,
 		ParseMode: imbot.ParseModeMarkdown,

--- a/internal/remote_control/bot/handler_send.go
+++ b/internal/remote_control/bot/handler_send.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/imbot"
@@ -81,6 +82,11 @@ func (h *BotHandler) sendTextWithReply(hCtx HandlerContext, text string, replyTo
 // The platform's BaseBot.ChunkText() doesn't support "last chunk only" metadata yet.
 // TODO: Add platform support for metadata that only applies to the last chunk.
 func (h *BotHandler) sendTextWithActionKeyboard(hCtx HandlerContext, text string, replyTo string) {
+	if strings.TrimSpace(text) == "" {
+		// ChunkText("") returns [""] which would otherwise produce an empty
+		// outbound bubble. Drop silently — there's nothing to render.
+		return
+	}
 	kb := feature.BuildActionKeyboard()
 	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
 

--- a/internal/remote_control/bot/tingly_agent_assertions_test.go
+++ b/internal/remote_control/bot/tingly_agent_assertions_test.go
@@ -1,0 +1,122 @@
+package bot_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/imbot/platform/tingly"
+	"github.com/tingly-dev/tingly-box/imbot/platform/tingly/testenv"
+	mockagent "github.com/tingly-dev/tingly-box/agentboot/mockagent"
+	"github.com/tingly-dev/tingly-box/remote/session"
+)
+
+// Test_AgentE2E_AssistantTextSentExactlyOnce asserts the assistant text
+// emitted by the script reaches the chat exactly once, not twice.
+//
+// Background: MockAgentExecutor previously sent the response a second time
+// via SendTextWithActionKeyboard *after* streamingMessageHandler had already
+// streamed it. This test caught that regression.
+func Test_AgentE2E_AssistantTextSentExactlyOnce(t *testing.T) {
+	const phrase = "hello from mock once"
+
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Assistant(phrase).
+		Success("done").
+		Build())
+
+	chat.SendText("hi")
+	drainProcessingPreface(t, chat)
+
+	// Wait for the script to fully play out: streaming text + the
+	// CompletionCallback's "Task done" card.
+	waitTextContaining(t, chat, "Task done", 6, 3*time.Second)
+
+	chat.AssertTextOccurrences(phrase, 1)
+}
+
+// Test_AgentE2E_MockTaskDoneCard asserts the mock executor delivers the
+// CompletionCallback "Task done" footer + action keyboard at the end of a
+// successful run, matching the Claude Code path.
+//
+// Background: MockAgentExecutor never registered SetCompletionCallback, so
+// no "Task done" card was ever sent for mock-routed chats.
+func Test_AgentE2E_MockTaskDoneCard(t *testing.T) {
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
+		Assistant("processing").
+		Success("ok").
+		Build())
+
+	chat.SendText("go")
+	drainProcessingPreface(t, chat)
+
+	// Find the "Task done" message within a small window.
+	var doneEvt *testenv.OutEvent
+	for i := 0; i < 6 && doneEvt == nil; i++ {
+		evt := chat.WaitText(3 * time.Second)
+		if strings.Contains(evt.Text, "Task done") {
+			doneEvt = evt
+		}
+	}
+	require.NotNil(t, doneEvt, "expected a Task done card after script success")
+
+	// Session must be marked completed by the CompletionCallback.
+	// lastMockSession polls until terminal (race-free via GetStatus).
+	require.Equal(t, session.StatusCompleted, lastMockSession(t, harness, chat.ChatID),
+		"CompletionCallback should mark mock session as completed")
+}
+
+// Test_AgentE2E_DenyDoesNotSendEmptyMessage asserts that when a permission
+// is denied and the script halts (no further assistant text), the bot does
+// NOT send an empty message via the action-keyboard path.
+//
+// Background: ChunkText("") returned [""] and SendTextWithActionKeyboard
+// happily sent it. Tests that scanned for "Deny" / "Denied" never noticed
+// the empty bubble that landed in chat.
+func Test_AgentE2E_DenyDoesNotSendEmptyMessage(t *testing.T) {
+	_, _, chat := agentBoot(t, mockagent.NewScript().
+		Permission("Bash", map[string]any{"command": "rm -rf /"},
+			mockagent.WithExpectApproved(false)).
+		Build())
+
+	chat.SendText("dangerous")
+	drainProcessingPreface(t, chat)
+
+	prompt := chat.WaitApprovalPrompt(3 * time.Second)
+	prompt.Deny()
+
+	// Wait long enough for: callback ack → IMPrompter edits prompt to
+	// "❌ Denied" → MockAgentExecutor's post-script SendTextWithActionKeyboard
+	// (which currently sends an empty bubble — what this test catches).
+	time.Sleep(800 * time.Millisecond)
+
+	// Verify no empty Send events ever appeared for this chat.
+	for _, e := range chat.AllEvents() {
+		if e.Kind == tingly.EventSend && strings.TrimSpace(e.Text) == "" && len(e.Media) == 0 {
+			t.Fatalf("found empty outbound text event: %s", brief(e))
+		}
+	}
+
+	// And at least one denial signal must have arrived (either as a Send
+	// containing "Denied"/"❌" or as an Edit on the prompt message).
+	sawDenialConfirm := false
+	for _, e := range chat.AllEvents() {
+		if strings.Contains(e.Text, "Denied") || strings.Contains(e.Text, "❌") {
+			sawDenialConfirm = true
+			break
+		}
+	}
+	require.True(t, sawDenialConfirm, "expected denial confirmation in chat events")
+}
+
+// brief copies testenv.brief for in-test debugging — testenv keeps it
+// unexported, so we build a tiny mirror here.
+func brief(e testenv.OutEvent) string {
+	text := e.Text
+	if len(text) > 60 {
+		text = text[:60] + "..."
+	}
+	return string(e.Kind) + " " + text
+}

--- a/internal/remote_control/bot/tingly_agent_test.go
+++ b/internal/remote_control/bot/tingly_agent_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/tingly-dev/tingly-box/agentboot"
 	mockagent "github.com/tingly-dev/tingly-box/agentboot/mockagent"
+	"github.com/tingly-dev/tingly-box/imbot/platform/tingly"
 	"github.com/tingly-dev/tingly-box/imbot/platform/tingly/testenv"
 	"github.com/tingly-dev/tingly-box/internal/remote_control/bot"
+	"github.com/tingly-dev/tingly-box/remote/session"
 )
 
 // agentBoot returns a bootHelper variant that registers a custom mock agent
@@ -42,6 +44,10 @@ func drainProcessingPreface(t *testing.T, chat *testenv.Chat) {
 
 // waitTextContaining scans up to maxScan outbound text messages for the first
 // containing substr. Fails the test if not found in time.
+//
+// Prefer chat.Expect / chat.ExpectInOrderLoose for new tests — this helper is
+// kept around as an escape hatch where the surrounding event ordering is too
+// flaky to lock down.
 func waitTextContaining(t *testing.T, chat *testenv.Chat, substr string, maxScan int, perWait time.Duration) *testenv.OutEvent {
 	t.Helper()
 	for i := 0; i < maxScan; i++ {
@@ -54,11 +60,49 @@ func waitTextContaining(t *testing.T, chat *testenv.Chat, substr string, maxScan
 	return nil
 }
 
+// lastMockSession finds the most recent mock-agent session for chatID and
+// polls up to 3 s for it to reach a terminal state. Status is read via
+// Manager.GetStatus (which holds the manager lock) so there is no data race
+// with the executor goroutine that writes session.Status concurrently.
+func lastMockSession(t *testing.T, harness *bot.TestHarness, chatID string) session.Status {
+	t.Helper()
+	all := harness.SessionMgr.ListByChat(chatID)
+	var sessID string
+	for _, s := range all {
+		if s.Agent == "mock" {
+			sessID = s.ID // .ID is immutable after creation — safe to read
+		}
+	}
+	if sessID == "" {
+		t.Fatalf("no mock session for chat %s; have %d sessions", chatID, len(all))
+		return ""
+	}
+
+	// Poll until terminal. Reading via GetStatus (holds RLock) is race-free.
+	var last session.Status
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if st, ok := harness.SessionMgr.GetStatus(sessID); ok {
+			switch st {
+			case session.StatusCompleted, session.StatusFailed,
+				session.StatusClosed, session.StatusExpired:
+				return st
+			default:
+				last = st
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %s for chat %s never reached terminal state (last: %s)", sessID, chatID, last)
+	return ""
+}
+
 // Test_AgentE2E_AssistantText drives the bot through a script that emits a
-// single assistant text and a success result. Verifies the assistant text
-// reaches chat at least once.
+// single assistant text and a success result. The assertions verify the
+// strict sequence: assistant text, then the CompletionCallback's "Task done"
+// footer, and finally that the session is marked completed.
 func Test_AgentE2E_AssistantText(t *testing.T) {
-	_, _, chat := agentBoot(t, mockagent.NewScript().
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
 		Assistant("hello from mock").
 		Success("done").
 		Build())
@@ -66,17 +110,25 @@ func Test_AgentE2E_AssistantText(t *testing.T) {
 	chat.SendText("hi")
 	drainProcessingPreface(t, chat)
 
-	waitTextContaining(t, chat, "hello from mock", 4, 3*time.Second)
+	// Loose ordering: the platform interleaves typing-indicator (EventReact)
+	// events around outbound sends. We only care about the relative order
+	// of the script-driven sends, not the ambient noise.
+	chat.ExpectInOrderLoose(3*time.Second,
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "hello from mock", Name: "assistant"},
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "Task done", Name: "completion"},
+	)
+
+	require.Equal(t, session.StatusCompleted, lastMockSession(t, harness, chat.ChatID))
 }
 
 // Test_AgentE2E_PermissionApprove verifies the full permission round-trip:
-// the bot surfaces a permission prompt, the user approves, and the agent
-// continues to emit further events.
+// the bot surfaces a permission prompt, the user approves, the prompt is
+// edited to mark approval, the agent emits its post-approval text, and the
+// session ends in completed.
 func Test_AgentE2E_PermissionApprove(t *testing.T) {
-	approved := true
-	_, _, chat := agentBoot(t, mockagent.NewScript().
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
 		Permission("Bash", map[string]any{"command": "pwd"},
-			mockagent.WithExpectApproved(approved),
+			mockagent.WithExpectApproved(true),
 			mockagent.WithDenyHalts(false)).
 		Assistant("after approve").
 		Success("ok").
@@ -89,16 +141,27 @@ func Test_AgentE2E_PermissionApprove(t *testing.T) {
 	require.NotEmpty(t, prompt.RequestID, "permission prompt should carry a request id")
 	prompt.Approve()
 
-	waitTextContaining(t, chat, "after approve", 4, 3*time.Second)
+	// After approve, the IMPrompter posts an "✅ Allow for tool: ..." ack
+	// (on Telegram it edits the prompt; on the tingly platform it posts a
+	// new send, which is what we observe here). Then the agent emits the
+	// "after approve" assistant text and the CompletionCallback's
+	// Task done card.
+	chat.ExpectInOrderLoose(3*time.Second,
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "Allow for tool", Name: "approve-ack"},
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "after approve", Name: "post-approve-assistant"},
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "Task done", Name: "completion"},
+	)
+
+	require.Equal(t, session.StatusCompleted, lastMockSession(t, harness, chat.ChatID))
 }
 
-// Test_AgentE2E_PermissionDeny verifies that clicking Deny halts the script
-// and the bot surfaces a denial confirmation.
+// Test_AgentE2E_PermissionDeny verifies that clicking Deny halts the script,
+// the prompt is edited to mark denial, no further assistant text appears,
+// and the session is marked failed (the script terminates with permission_denied).
 func Test_AgentE2E_PermissionDeny(t *testing.T) {
-	denied := false
-	_, _, chat := agentBoot(t, mockagent.NewScript().
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
 		Permission("Bash", map[string]any{"command": "rm -rf /"},
-			mockagent.WithExpectApproved(denied)).
+			mockagent.WithExpectApproved(false)).
 		Assistant("never reached").
 		Build())
 
@@ -108,16 +171,23 @@ func Test_AgentE2E_PermissionDeny(t *testing.T) {
 	prompt := chat.WaitApprovalPrompt(3 * time.Second)
 	prompt.Deny()
 
-	// The denial confirmation lands within a few messages: either the
-	// "❌ Deny for tool: ..." callback ack or the prompter's edited prompt
-	// carrying "Denied".
-	for i := 0; i < 4; i++ {
-		evt := chat.WaitText(3 * time.Second)
-		if strings.Contains(evt.Text, "Deny") || strings.Contains(evt.Text, "❌") || strings.Contains(evt.Text, "Denied") {
-			return
+	chat.ExpectInOrderLoose(3*time.Second,
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "Deny for tool", Name: "deny-ack"},
+	)
+
+	// Give the executor a beat to finish its (now empty) post-script work.
+	time.Sleep(500 * time.Millisecond)
+
+	// The "never reached" assistant must never appear — script halted on deny.
+	for _, e := range chat.AllEvents() {
+		if strings.Contains(e.Text, "never reached") {
+			t.Fatalf("script kept running past denial: saw %q", e.Text)
 		}
 	}
-	t.Fatalf("expected a denial-related reply after clicking Deny")
+
+	// Session should be failed (Result with status=permission_denied → SetFailed).
+	require.Equal(t, session.StatusFailed, lastMockSession(t, harness, chat.ChatID),
+		"deny should mark session as failed")
 }
 
 // Test_AgentE2E_AskQuestion drives the bot through an AskUserQuestion script
@@ -133,7 +203,7 @@ func Test_AgentE2E_AskQuestion(t *testing.T) {
 			},
 		},
 	}
-	_, _, chat := agentBoot(t, mockagent.NewScript().
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
 		Ask(questions, mockagent.WithAskExpectAnswers(map[int]int{0: 1})).
 		Assistant("got it").
 		Success("ok").
@@ -144,15 +214,27 @@ func Test_AgentE2E_AskQuestion(t *testing.T) {
 
 	prompt := chat.WaitAskQuestionPrompt(3 * time.Second)
 	require.NotEmpty(t, prompt.RequestID)
+	// The keyboard must contain the option labels — guards against the
+	// IMPrompter type-assertion regression that would have rendered the
+	// default Approve/Deny keyboard instead.
+	require.Contains(t, summarizeButtonLabels(prompt.Event), "apple")
+	require.Contains(t, summarizeButtonLabels(prompt.Event), "banana")
 	prompt.SelectOption(0, 1) // banana
 
-	waitTextContaining(t, chat, "got it", 6, 3*time.Second)
+	chat.ExpectInOrderLoose(3*time.Second,
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "got it", Name: "post-ask-assistant"},
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "Task done", Name: "completion"},
+	)
+
+	require.Equal(t, session.StatusCompleted, lastMockSession(t, harness, chat.ChatID))
 }
 
 // Test_AgentE2E_ScriptError verifies that an ErrorStep reaches the chat as an
-// "[ERROR] ..." message via the streaming handler's OnError path.
+// "[ERROR] ..." message via the streaming handler's OnError path. Both the
+// preceding assistant text and the error must appear; their order on the bot
+// goroutine is non-deterministic, so we only assert that both appeared.
 func Test_AgentE2E_ScriptError(t *testing.T) {
-	_, _, chat := agentBoot(t, mockagent.NewScript().
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
 		Assistant("trying").
 		Error(errors.New("boom")).
 		Success("done").
@@ -161,32 +243,31 @@ func Test_AgentE2E_ScriptError(t *testing.T) {
 	chat.SendText("trigger error")
 	drainProcessingPreface(t, chat)
 
-	// We expect "trying" then an "[ERROR] boom" line — not necessarily in a
-	// fixed order, since OnMessage and OnError can interleave on the bot
-	// goroutine. Scan up to four messages for both.
+	// Wait for the script to fully play out, then scan the recorded events.
+	waitTextContaining(t, chat, "Task done", 8, 3*time.Second)
+
 	sawTrying, sawErr := false, false
-	for i := 0; i < 6 && (!sawTrying || !sawErr); i++ {
-		evt := chat.WaitText(3 * time.Second)
-		if strings.Contains(evt.Text, "trying") {
+	for _, e := range chat.AllEvents() {
+		if e.Kind == tingly.EventSend && strings.Contains(e.Text, "trying") {
 			sawTrying = true
 		}
-		if strings.Contains(evt.Text, "boom") {
+		if e.Kind == tingly.EventSend && strings.Contains(e.Text, "boom") {
 			sawErr = true
 		}
 	}
-	if !sawTrying {
-		t.Fatalf("did not see 'trying' assistant text")
-	}
-	if !sawErr {
-		t.Fatalf("did not see 'boom' error text")
-	}
+	require.True(t, sawTrying, "did not see 'trying' assistant text")
+	require.True(t, sawErr, "did not see 'boom' error text")
+
+	// The script ends with a success Result, so the session is completed
+	// even though OnError fired for the (non-fatal) ErrorStep.
+	require.Equal(t, session.StatusCompleted, lastMockSession(t, harness, chat.ChatID))
 }
 
 // Test_AgentE2E_PermissionExpectMismatch verifies that scripts with
 // ExpectApproved mismatches surface via the streaming handler's OnError path
 // (rendered as "[ERROR] mockagent: ...").
 func Test_AgentE2E_PermissionExpectMismatch(t *testing.T) {
-	_, _, chat := agentBoot(t, mockagent.NewScript().
+	_, harness, chat := agentBoot(t, mockagent.NewScript().
 		Permission("Bash", nil,
 			mockagent.WithExpectApproved(true),
 			mockagent.WithDenyHalts(true)).
@@ -198,12 +279,23 @@ func Test_AgentE2E_PermissionExpectMismatch(t *testing.T) {
 	prompt := chat.WaitApprovalPrompt(3 * time.Second)
 	prompt.Deny() // user denies, but the script expected approval → mismatch
 
-	// Scan up to six replies for the "expected approved=true" mismatch.
-	for i := 0; i < 6; i++ {
-		evt := chat.WaitText(3 * time.Second)
-		if strings.Contains(evt.Text, "expected approved=true") {
-			return
+	chat.ExpectInOrderLoose(3*time.Second,
+		testenv.Matcher{Kind: tingly.EventSend, TextContains: "expected approved=true", Name: "mismatch-error"},
+	)
+
+	// Mismatch + OnDenyTerminate halts the script with permission_denied →
+	// session ends in failed.
+	require.Equal(t, session.StatusFailed, lastMockSession(t, harness, chat.ChatID))
+}
+
+// summarizeButtonLabels returns a flat string of all button labels in the
+// event's keyboard for use in failure messages and Contains assertions.
+func summarizeButtonLabels(e *testenv.OutEvent) string {
+	var labels []string
+	for _, row := range e.Buttons {
+		for _, b := range row {
+			labels = append(labels, b.Label)
 		}
 	}
-	t.Fatalf("did not see expectation-mismatch error in chat")
+	return strings.Join(labels, "|")
 }

--- a/remote/channel/imchannel/imprompter.go
+++ b/remote/channel/imchannel/imprompter.go
@@ -124,12 +124,12 @@ func (p *IMPrompter) Prompt(ctx context.Context, req ask.Request) (ask.Result, e
 	// Create response channel
 	responseChan := make(chan ask.Result, 1)
 
-	// Count questions for AskUserQuestion requests
+	// Count questions for AskUserQuestion requests. The "questions" payload
+	// can arrive as []interface{}, []map[string]any, or []any depending on
+	// the caller — normalize once.
 	totalQuestions := 0
 	if req.ToolName == "AskUserQuestion" {
-		if questions, ok := req.Input["questions"].([]interface{}); ok {
-			totalQuestions = len(questions)
-		}
+		totalQuestions = len(ask.NormalizeQuestions(req.Input["questions"]))
 	}
 
 	p.mu.Lock()
@@ -229,8 +229,8 @@ func (p *IMPrompter) Prompt(ctx context.Context, req ask.Request) (ask.Result, e
 // buildTimeoutQuestionResult builds a result that auto-selects the first (recommended) option
 // for AskUserQuestion when it times out.
 func (p *IMPrompter) buildTimeoutQuestionResult(req ask.Request) ask.Result {
-	questions, ok := req.Input["questions"].([]interface{})
-	if !ok || len(questions) == 0 {
+	questions := ask.NormalizeQuestions(req.Input["questions"])
+	if len(questions) == 0 {
 		return ask.Result{
 			ID:       req.ID,
 			Approved: false,
@@ -240,23 +240,17 @@ func (p *IMPrompter) buildTimeoutQuestionResult(req ask.Request) ask.Result {
 
 	// For each question, select its first option as the recommended default
 	answers := make(map[string]interface{})
-	for _, q := range questions {
-		question, ok := q.(map[string]interface{})
-		if !ok {
-			continue
-		}
+	for _, question := range questions {
 		questionText, ok := question["question"].(string)
 		if !ok {
 			continue
 		}
-		options, ok := question["options"].([]interface{})
-		if !ok || len(options) == 0 {
+		options := ask.NormalizeOptions(question["options"])
+		if len(options) == 0 {
 			continue
 		}
-		if opt, ok := options[0].(map[string]interface{}); ok {
-			if label, ok := opt["label"].(string); ok {
-				answers[questionText] = label
-			}
+		if label, ok := options[0]["label"].(string); ok {
+			answers[questionText] = label
 		}
 	}
 
@@ -451,19 +445,15 @@ func (p *IMPrompter) buildDefaultKeyboard(requestID string) imbot.InlineKeyboard
 func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineKeyboardMarkup {
 	kb := imbot.NewKeyboardBuilder()
 
-	questions, ok := req.Input["questions"].([]interface{})
-	if !ok || len(questions) == 0 {
+	questions := ask.NormalizeQuestions(req.Input["questions"])
+	if len(questions) == 0 {
 		return p.buildDefaultKeyboard(req.ID)
 	}
 
 	// Build buttons for each question and its options
-	for qIdx, q := range questions {
-		question, ok := q.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		options, ok := question["options"].([]interface{})
-		if !ok || len(options) == 0 {
+	for qIdx, question := range questions {
+		options := ask.NormalizeOptions(question["options"])
+		if len(options) == 0 {
 			continue
 		}
 		// Add a label row for the question if there are multiple questions
@@ -471,14 +461,12 @@ func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineK
 			questionText, _ := question["question"].(string)
 			kb.AddRow(imbot.CallbackButton(fmt.Sprintf("Q%d: %s", qIdx+1, questionText), imbot.FormatCallbackData("perm", "noop", req.ID)))
 		}
-		for optIdx, opt := range options {
-			if option, ok := opt.(map[string]interface{}); ok {
-				label, _ := option["label"].(string)
-				if label != "" {
-					buttonText := fmt.Sprintf("%d. %s", optIdx+1, label)
-					callbackData := imbot.FormatCallbackData("perm", "option", req.ID, fmt.Sprintf("%d", qIdx), fmt.Sprintf("%d", optIdx))
-					kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
-				}
+		for optIdx, option := range options {
+			label, _ := option["label"].(string)
+			if label != "" {
+				buttonText := fmt.Sprintf("%d. %s", optIdx+1, label)
+				callbackData := imbot.FormatCallbackData("perm", "option", req.ID, fmt.Sprintf("%d", qIdx), fmt.Sprintf("%d", optIdx))
+				kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
 			}
 		}
 	}
@@ -493,21 +481,17 @@ func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineK
 func (p *IMPrompter) buildTextSelectionInstructions(req ask.Request) string {
 	var text strings.Builder
 
-	questions, ok := req.Input["questions"].([]interface{})
-	if !ok || len(questions) == 0 {
+	questions := ask.NormalizeQuestions(req.Input["questions"])
+	if len(questions) == 0 {
 		// Fallback: use permission instructions from shared config
 		return ask.FormatPermissionInstructions()
 	}
 
 	// For AskUserQuestion - list all questions and options
-	for qIdx, q := range questions {
-		question, ok := q.(map[string]interface{})
-		if !ok {
-			continue
-		}
+	for qIdx, question := range questions {
 		questionText, _ := question["question"].(string)
-		options, ok := question["options"].([]interface{})
-		if !ok {
+		options := ask.NormalizeOptions(question["options"])
+		if len(options) == 0 {
 			continue
 		}
 		if len(questions) > 1 {
@@ -515,15 +499,13 @@ func (p *IMPrompter) buildTextSelectionInstructions(req ask.Request) string {
 		} else {
 			text.WriteString("*To select an option, reply with the number:*\n\n")
 		}
-		for i, opt := range options {
-			if option, ok := opt.(map[string]interface{}); ok {
-				label, _ := option["label"].(string)
-				desc, hasDesc := option["description"].(string)
-				if hasDesc && desc != "" {
-					text.WriteString(fmt.Sprintf("• `%d` - %s - %s\n", i+1, label, desc))
-				} else {
-					text.WriteString(fmt.Sprintf("• `%d` - %s\n", i+1, label))
-				}
+		for i, option := range options {
+			label, _ := option["label"].(string)
+			desc, hasDesc := option["description"].(string)
+			if hasDesc && desc != "" {
+				text.WriteString(fmt.Sprintf("• `%d` - %s - %s\n", i+1, label, desc))
+			} else {
+				text.WriteString(fmt.Sprintf("• `%d` - %s\n", i+1, label))
 			}
 		}
 		text.WriteString("\n")
@@ -636,6 +618,11 @@ func (p *IMPrompter) IsWhitelisted(toolName string) bool {
 
 	return p.whitelist[toolName]
 }
+
+// normalizeQuestionList re-exports ask.NormalizeQuestions for the local tests.
+// The shared implementation lives in agentboot/ask/normalize.go so the same
+// coercion logic is used by every prompter (IM, stdin, tool_handlers).
+func normalizeQuestionList(v any) []map[string]any { return ask.NormalizeQuestions(v) }
 
 // Legacy compatibility methods
 

--- a/remote/channel/imchannel/imprompter_test.go
+++ b/remote/channel/imchannel/imprompter_test.go
@@ -1,0 +1,131 @@
+package imchannel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/agentboot/ask"
+)
+
+// Test_AskUserQuestionKeyboard_AcceptsHeterogeneousShapes verifies that the
+// AskUserQuestion keyboard builder renders option buttons regardless of which
+// concrete slice/map type the caller used for "questions" / "options". The
+// production code path goes through `[]interface{}` and `map[string]interface{}`,
+// but agentboot callers serializing from typed structs may emit
+// `[]map[string]any` instead — IMPrompter must accept both rather than
+// silently degrading to the default Approve/Deny keyboard.
+func Test_AskUserQuestionKeyboard_AcceptsHeterogeneousShapes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input map[string]interface{}
+	}{
+		{
+			name: "interface_slice_with_interface_options",
+			input: map[string]interface{}{
+				"questions": []interface{}{
+					map[string]interface{}{
+						"question": "color?",
+						"options": []interface{}{
+							map[string]interface{}{"label": "red"},
+							map[string]interface{}{"label": "blue"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "typed_slice_of_maps",
+			input: map[string]interface{}{
+				"questions": []map[string]interface{}{
+					{
+						"question": "color?",
+						"options": []map[string]interface{}{
+							{"label": "red"},
+							{"label": "blue"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "typed_slice_of_any",
+			input: map[string]interface{}{
+				"questions": []any{
+					map[string]any{
+						"question": "color?",
+						"options": []any{
+							map[string]any{"label": "red"},
+							map[string]any{"label": "blue"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewIMPrompter(nil)
+			req := ask.Request{
+				ID:       "req-1",
+				ToolName: "AskUserQuestion",
+				Input:    tc.input,
+			}
+
+			kb := p.buildAskUserQuestionKeyboard(req)
+
+			// Walk the rendered buttons and assert two perm:option callbacks
+			// exist, one per declared option.
+			labels := []string{}
+			callbacks := []string{}
+			for _, row := range kb.InlineKeyboard {
+				for _, b := range row {
+					labels = append(labels, b.Text)
+					callbacks = append(callbacks, b.CallbackData)
+				}
+			}
+
+			countOptionCallbacks := 0
+			for _, cb := range callbacks {
+				if strings.HasPrefix(cb, "perm:option:") {
+					countOptionCallbacks++
+				}
+			}
+			if countOptionCallbacks != 2 {
+				t.Fatalf("expected 2 perm:option callbacks, got %d. labels=%v callbacks=%v",
+					countOptionCallbacks, labels, callbacks)
+			}
+
+			// Sanity: the labels must include the option names ("red", "blue").
+			joined := strings.Join(labels, "|")
+			if !strings.Contains(joined, "red") || !strings.Contains(joined, "blue") {
+				t.Fatalf("expected option labels red and blue in keyboard, got %v", labels)
+			}
+		})
+	}
+}
+
+// Test_NormalizeQuestionList_AcceptsHeterogeneousShapes verifies the helper
+// the fix introduces at imprompter.go to normalize the questions slice into
+// `[]map[string]any` regardless of caller-side concrete types.
+func Test_NormalizeQuestionList_AcceptsHeterogeneousShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want int
+	}{
+		{"interface_slice", []interface{}{map[string]any{}, map[string]any{}}, 2},
+		{"map_slice", []map[string]any{{}, {}}, 2},
+		{"any_slice", []any{map[string]any{}}, 1},
+		{"nil", nil, 0},
+		{"wrong_type", "not a slice", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := len(normalizeQuestionList(tc.in))
+			if got != tc.want {
+				t.Fatalf("normalizeQuestionList(%v) = len %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/remote/session/manager.go
+++ b/remote/session/manager.go
@@ -142,6 +142,19 @@ func (m *Manager) Get(id string) (*Session, bool) {
 	return session, exists
 }
 
+// GetStatus returns the current status of a session, read under the manager's
+// own lock. Callers that need a race-free status read should prefer this over
+// dereferencing a *Session pointer returned by Get or ListByChat.
+func (m *Manager) GetStatus(id string) (Status, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	sess, exists := m.sessions[id]
+	if !exists {
+		return "", false
+	}
+	return sess.Status, true
+}
+
 // GetOrLoad retrieves a session by ID, falling back to the store if needed
 func (m *Manager) GetOrLoad(id string) (*Session, bool) {
 	m.mu.RLock()


### PR DESCRIPTION
## Background

The mock agent landed in the previous phase, but the five e2e tests in
`tingly_agent_test.go` asserted with weak `contains` scan-loops (up to 6
messages, no ordering, no count). Four real bugs were silently passing CI
the whole time.

## What changed

### New: strict event-sequence assertion DSL

`imbot/platform/tingly/testenv/expect.go` adds:

- `Matcher` — declares one expected outbound event (kind, text, button, etc.)
- `Chat.Expect` — consume events in strict order, fail on any deviation
- `Chat.ExpectInOrderLoose` — same but skips non-matching events (handles
  platform react/typing noise)
- `Chat.ExpectIdle` — assert silence for a duration
- `Chat.AssertTextOccurrences` — exact count of a substring across all events

### Bug fixes (all were silently green before)

Bug 1+2 — agent_mock.go
Root cause: MockAgentExecutor sent assistant text twice (streamed + re-sent via SendTextWithActionKeyboard); never registered SetCompletionCallback so "Task done" card was never delivered
Fix: Wire SetCompletionCallback matching the Claude Code path; remove the duplicate send

Bug 3 — imprompter.go, tool_handlers.go, stdin_prompter.go
Root cause: Hard []interface{} assertion on questions silently fell back to the default Approve/Deny keyboard when caller passed []map[string]any
Fix: Extract shared NormalizeQuestions/NormalizeOptions helpers (agentboot/ask/normalize.go) used by all three prompter sites

Bug 4 — handler_send.go, bot_stream.go
Root cause: ChunkText("") returns [""]; both send paths happily sent empty messages on deny-halt flows
Fix: Early-return guard strings.TrimSpace(text) == "" in both sites

Bug 5 — session/manager.go, tingly_agent_test.go
Root cause: Test goroutine read sess.Status on a raw *Session pointer after releasing the manager lock, while the executor goroutine wrote sess.Status concurrently — data race flagged by -race
Fix: Add Manager.GetStatus(id) (reads under RLock, returns value not pointer); refactor lastMockSession to poll until terminal state

### Regression tests

- `tingly_agent_assertions_test.go`: `Test_AgentE2E_AssistantTextSentExactlyOnce`, `Test_AgentE2E_MockTaskDoneCard`, `Test_AgentE2E_DenyDoesNotSendEmptyMessage`
- `imprompter_test.go`: `Test_AskUserQuestionKeyboard_AcceptsHeterogeneousShapes`, `Test_NormalizeQuestionList_AcceptsHeterogeneousShapes`

All five existing e2e tests in `tingly_agent_test.go` migrated to `ExpectInOrderLoose` and hardened with session status assertions.

## Verification

```bash
go test ./internal/remote_control/bot/ \
        ./remote/channel/imchannel/ \
        ./agentboot/mockagent/ \
        ./imbot/platform/tingly/testenv/ \
        -count=1 -race -timeout=180s
# all four packages: ok
```

## Out of scope
Bug 5's write-side root cause (executor goroutine outliving the bot after /stop or test teardown) is not fixed here — that requires context-propagation refactoring in the executor layer. Tracked separately.