### PR TITLE
bugfix(cli): restore daemon mode functionality for start/restart commands

### DIFF
--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -14,6 +14,7 @@ import {
 import SearchIcon from '@mui/icons-material/Search';
 import LanguageIcon from '@mui/icons-material/Language';
 import DescriptionIcon from '@mui/icons-material/Description';
+import AddIcon from '@mui/icons-material/Add';
 import ProviderIcon from '@/components/ProviderIcon';
 import {useProviderTemplates, type UniqueProvider} from '@/services/serviceProviders';
 import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
@@ -21,6 +22,66 @@ import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
 interface BrowseProvidersProps {
     onPick: (prefill: EnhancedProviderFormData) => void;
 }
+
+// Empty form data for custom provider entry
+const emptyForm = (): EnhancedProviderFormData => ({
+    name: '',
+    apiBase: '',
+    apiStyle: undefined,
+    token: '',
+    enabled: true,
+    noKeyRequired: false,
+    proxyUrl: '',
+});
+
+// Common card styles to ensure consistent dimensions
+const cardSx = {
+    borderRadius: 2,
+    height: 80,
+    display: 'flex',
+    flexDirection: 'column' as const,
+};
+
+const cardActionAreaSx = {
+    height: 80,
+    p: 1.5,
+    display: 'flex',
+    alignItems: 'center',
+};
+
+// Custom provider card component
+const CustomProviderCard: React.FC<{ onPick: () => void }> = ({ onPick }) => {
+    const { t } = useTranslation();
+    return (
+        <Card
+            variant="outlined"
+            sx={{
+                ...cardSx,
+                borderStyle: 'dashed',
+                borderColor: 'primary.main',
+                bgcolor: 'primary.50',
+                transition: 'all 0.2s',
+                '&:hover': {
+                    bgcolor: 'primary.100',
+                    borderColor: 'primary.dark',
+                },
+            }}
+        >
+            <CardActionArea onClick={onPick} sx={cardActionAreaSx}>
+                <Stack direction="row" spacing={1.5} alignItems="center" width="100%">
+                    <AddIcon sx={{ color: 'primary.main', fontSize: 32 }} />
+                    <Typography
+                        variant="subtitle2"
+                        fontWeight={600}
+                        color="primary.main"
+                    >
+                        {t('onboarding.browse.customProvider', { defaultValue: 'Custom Provider' })}
+                    </Typography>
+                </Stack>
+            </CardActionArea>
+        </Card>
+    );
+};
 
 const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
     const {t} = useTranslation();
@@ -75,28 +136,30 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                 />
             </Box>
 
-            {filtered.length === 0 ? (
-                <Box sx={{py: 6, textAlign: 'center'}}>
-                    <Typography variant="body2" color="text.secondary">
-                        {t('onboarding.browse.empty', {defaultValue: 'No providers match your filters.'})}
-                    </Typography>
-                </Box>
-            ) : (
-                <Box
-                    sx={{
-                        display: 'grid',
-                        gap: 1.5,
-                        gridTemplateColumns: {
-                            xs: '1fr',
-                            sm: 'repeat(2, 1fr)',
-                            md: 'repeat(3, 1fr)',
-                            xl: 'repeat(4, 1fr)',
-                        },
-                    }}
-                >
-                    {filtered.map(p => (
-                        <Card key={p.id} variant="outlined" sx={{borderRadius: 2}}>
-                            <CardActionArea onClick={() => handlePick(p)} sx={{p: 1.5}}>
+            <Box
+                sx={{
+                    display: 'grid',
+                    gap: 1.5,
+                    gridTemplateColumns: {
+                        xs: '1fr',
+                        sm: 'repeat(2, 1fr)',
+                        md: 'repeat(3, 1fr)',
+                        xl: 'repeat(4, 1fr)',
+                    },
+                }}
+            >
+                {/* Custom provider card - always visible, even when no providers match search */}
+                <CustomProviderCard onPick={() => onPick(emptyForm())} />
+                {filtered.length === 0 ? (
+                    <Box sx={{py: 6, textAlign: 'center', gridColumn: '1 / -1'}}>
+                        <Typography variant="body2" color="text.secondary">
+                            {t('onboarding.browse.empty', {defaultValue: 'No providers match your filters.'})}
+                        </Typography>
+                    </Box>
+                ) : (
+                    filtered.map(p => (
+                        <Card key={p.id} variant="outlined" sx={cardSx}>
+                            <CardActionArea onClick={() => handlePick(p)} sx={cardActionAreaSx}>
                                 <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between" width="100%">
                                     <Stack direction="row" spacing={1.5} alignItems="center">
                                         <ProviderIcon identifier={p.icon || p.id} size={32}/>
@@ -163,9 +226,9 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                                 </Stack>
                             </CardActionArea>
                         </Card>
-                    ))}
-                </Box>
-            )}
+                    ))
+                )}
+            </Box>
         </Box>
     );
 };

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/server"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/pkg/daemon"
 	"github.com/tingly-dev/tingly-box/pkg/lock"
 	"github.com/tingly-dev/tingly-box/pkg/network"
 )
@@ -535,12 +536,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
-	// Start server in goroutine to keep it non-blocking
-	serverErr := make(chan error, 1)
-	go func() {
-		serverErr <- serverManager.Start()
-	}()
-
+	// Print startup information before daemonizing
 	fmt.Printf("Server starting on port %d...\n", port)
 
 	printBanner(BannerConfig{
@@ -550,6 +546,26 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 		GlobalConfig: appConfig.GetGlobalConfig(),
 		IsDaemon:     false,
 	})
+
+	// Handle daemon mode - fork and detach after all messages are printed
+	if opts.Daemon {
+		if !daemon.IsDaemonProcess() {
+			// Fork and detach - this call exits the parent process
+			if err := daemon.Daemonize(); err != nil {
+				fileLock.Unlock()
+				return fmt.Errorf("failed to daemonize: %w", err)
+			}
+			// Daemonize() calls os.Exit(0), so we never reach here in parent
+		}
+		// Child process continues here
+		fmt.Println("Server running in background (daemon mode)")
+	}
+
+	// Start server in goroutine to keep it non-blocking
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serverManager.Start()
+	}()
 
 	// Wait for either server error, shutdown signal, or web UI stop request
 	select {


### PR DESCRIPTION
## Summary  
Daemon mode was non-functional for the `start` and `restart` commands due to a missing daemonize call after refactoring. As a result, users could not run the server in the background as intended.

### Major  
- Daemon mode now works correctly for the `start` and `restart` commands.  
- The server properly forks and detaches when the `--daemon` flag is used.  
- Startup messages are printed before daemonization to ensure visibility.

### Minor  
- Added a custom provider card in the onboarding UI for manual provider configuration.  
- Improved provider card styling consistency across the grid.