### PR TITLE
feat(agentboot): add process/ and protocol/ packages as testable seams

### DIFF
--- a/agentboot/process/fake.go
+++ b/agentboot/process/fake.go
@@ -1,0 +1,151 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+)
+
+// FakeFactory is the test Factory. It never spawns a real process; instead
+// each call to Start produces a [FakeHandle] whose stdin/stdout are wired to
+// in-memory pipes. Tests script the handle's behavior either via [OnStart]
+// or by calling helpers on the returned FakeHandle directly.
+type FakeFactory struct {
+	// OnStart, if non-nil, is invoked synchronously inside Start with the
+	// freshly-constructed FakeHandle. Use it to install scripted I/O.
+	OnStart func(context.Context, LaunchSpec, *FakeHandle)
+
+	mu      sync.Mutex
+	starts  []LaunchSpec
+	handles []*FakeHandle
+}
+
+// NewFakeFactory returns an empty FakeFactory. Configure OnStart before
+// passing it to a runner.
+func NewFakeFactory() *FakeFactory { return &FakeFactory{} }
+
+// Starts returns the LaunchSpec from every Start call, in order.
+func (f *FakeFactory) Starts() []LaunchSpec {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]LaunchSpec, len(f.starts))
+	copy(out, f.starts)
+	return out
+}
+
+// Handles returns every FakeHandle produced by this factory, in order.
+func (f *FakeFactory) Handles() []*FakeHandle {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*FakeHandle, len(f.handles))
+	copy(out, f.handles)
+	return out
+}
+
+func (f *FakeFactory) Start(ctx context.Context, spec LaunchSpec) (Handle, error) {
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+
+	h := &FakeHandle{
+		StdinR:    stdinR,
+		stdinW:    stdinW,
+		stdoutR:   stdoutR,
+		stdoutW:   stdoutW,
+		done:      make(chan struct{}),
+		exitErr:   nil,
+		spec:      spec,
+	}
+
+	f.mu.Lock()
+	f.starts = append(f.starts, spec)
+	f.handles = append(f.handles, h)
+	onStart := f.OnStart
+	f.mu.Unlock()
+
+	if onStart != nil {
+		onStart(ctx, spec, h)
+	}
+	return h, nil
+}
+
+// FakeHandle is the Handle returned by FakeFactory.
+//
+// Its Stdin and Stdout are connected to in-memory pipes:
+//   - Bytes the system under test writes to Stdin can be read from StdinR.
+//   - Bytes pushed via WriteOutput appear on Stdout.
+//
+// A FakeHandle starts in the running state. Call SignalExit (with optional
+// error) or Kill to transition it to exited.
+type FakeHandle struct {
+	// StdinR exposes the read end of the stdin pipe so tests can observe
+	// what the system under test wrote to the child.
+	StdinR *io.PipeReader
+
+	stdinW  *io.PipeWriter
+	stdoutR *io.PipeReader
+	stdoutW *io.PipeWriter
+
+	mu      sync.Mutex
+	done    chan struct{}
+	exited  bool
+	exitErr error
+
+	closeOutOnce sync.Once
+	killOnce     sync.Once
+
+	spec LaunchSpec
+}
+
+// Spec returns the LaunchSpec used to construct this handle.
+func (h *FakeHandle) Spec() LaunchSpec { return h.spec }
+
+func (h *FakeHandle) Stdin() io.WriteCloser { return h.stdinW }
+func (h *FakeHandle) Stdout() io.ReadCloser { return h.stdoutR }
+func (h *FakeHandle) Done() <-chan struct{} { return h.done }
+
+// WriteOutput pushes bytes to the handle's Stdout. Tests use this to emit
+// scripted events. Safe to call concurrently with reads from Stdout.
+func (h *FakeHandle) WriteOutput(p []byte) (int, error) {
+	return h.stdoutW.Write(p)
+}
+
+// FinishOutput closes the Stdout pipe, signaling EOF to the reader. Idempotent.
+func (h *FakeHandle) FinishOutput() {
+	h.closeOutOnce.Do(func() { _ = h.stdoutW.Close() })
+}
+
+// SignalExit transitions the handle to the exited state with the given error.
+// Subsequent Wait calls return err. Idempotent: only the first call's error is recorded.
+func (h *FakeHandle) SignalExit(err error) {
+	h.mu.Lock()
+	if h.exited {
+		h.mu.Unlock()
+		return
+	}
+	h.exited = true
+	h.exitErr = err
+	h.mu.Unlock()
+	close(h.done)
+}
+
+func (h *FakeHandle) Wait() error {
+	<-h.done
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.exitErr
+}
+
+// Kill closes both pipes and signals exit with a synthetic "killed" error.
+// Idempotent.
+func (h *FakeHandle) Kill() error {
+	h.killOnce.Do(func() {
+		_ = h.stdinW.Close()
+		h.FinishOutput()
+		h.SignalExit(ErrKilled)
+	})
+	return nil
+}
+
+// ErrKilled is the synthetic Wait error reported after Kill.
+var ErrKilled = errors.New("process killed")

--- a/agentboot/process/osexec.go
+++ b/agentboot/process/osexec.go
@@ -1,0 +1,98 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// OSExecFactory is the production Factory backed by os/exec.
+type OSExecFactory struct {
+	// Stderr, if non-nil, receives the child process's stderr stream.
+	// Defaults to os.Stderr.
+	Stderr io.Writer
+}
+
+// NewOSExecFactory returns a Factory wired to os.Stderr.
+func NewOSExecFactory() *OSExecFactory {
+	return &OSExecFactory{Stderr: os.Stderr}
+}
+
+func (f *OSExecFactory) Start(ctx context.Context, spec LaunchSpec) (Handle, error) {
+	cmd := exec.CommandContext(ctx, spec.Path, spec.Args...)
+	if spec.Env != nil {
+		cmd.Env = spec.Env
+	}
+	cmd.Dir = spec.WorkDir
+	cmd.Stderr = f.Stderr
+	if cmd.Stderr == nil {
+		cmd.Stderr = os.Stderr
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("start %q: %w", spec.Path, err)
+	}
+
+	h := &osHandle{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		h.waitErr = cmd.Wait()
+		close(h.done)
+	}()
+	return h, nil
+}
+
+type osHandle struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+
+	done    chan struct{}
+	waitErr error
+
+	killOnce sync.Once
+}
+
+func (h *osHandle) Stdin() io.WriteCloser { return h.stdin }
+func (h *osHandle) Stdout() io.ReadCloser { return h.stdout }
+func (h *osHandle) Done() <-chan struct{} { return h.done }
+
+func (h *osHandle) Wait() error {
+	<-h.done
+	return h.waitErr
+}
+
+func (h *osHandle) Kill() error {
+	var err error
+	h.killOnce.Do(func() {
+		if h.cmd.Process == nil {
+			return
+		}
+		select {
+		case <-h.done:
+			return
+		default:
+		}
+		err = h.cmd.Process.Kill()
+	})
+	return err
+}

--- a/agentboot/process/process.go
+++ b/agentboot/process/process.go
@@ -1,0 +1,44 @@
+// Package process provides the seam between agentboot and the OS process that
+// implements an agent (e.g. the `claude` CLI binary).
+//
+// Production code uses [OSExecFactory], which wraps os/exec. Tests use
+// [FakeFactory] to substitute the binary with a scripted in-memory process,
+// keeping the rest of the agent stack (driver, decoder, runner) on the real
+// code path.
+package process
+
+import (
+	"context"
+	"io"
+)
+
+// LaunchSpec describes how to start an agent process.
+//
+// It intentionally mirrors the subset of os/exec.Cmd that an agent driver
+// needs to populate, so that drivers can be unit-tested against any Factory.
+type LaunchSpec struct {
+	Path    string
+	Args    []string
+	Env     []string
+	WorkDir string
+}
+
+// Handle is a running process with attached stdin/stdout pipes.
+//
+// Lifecycle invariants:
+//   - Stdin and Stdout are valid until Wait returns.
+//   - Done is closed after the process has exited; Wait then returns
+//     immediately with the exit error.
+//   - Kill is idempotent and safe to call concurrently with Wait.
+type Handle interface {
+	Stdin() io.WriteCloser
+	Stdout() io.ReadCloser
+	Wait() error
+	Kill() error
+	Done() <-chan struct{}
+}
+
+// Factory starts agent processes.
+type Factory interface {
+	Start(ctx context.Context, spec LaunchSpec) (Handle, error)
+}

--- a/agentboot/process/process_test.go
+++ b/agentboot/process/process_test.go
@@ -1,0 +1,222 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestOSExecFactory_EchoSucceeds(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only test")
+	}
+	f := NewOSExecFactory()
+	h, err := f.Start(context.Background(), LaunchSpec{
+		Path: "/bin/echo",
+		Args: []string{"hello"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	out, err := io.ReadAll(h.Stdout())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := string(bytes.TrimSpace(out)); got != "hello" {
+		t.Fatalf("stdout = %q, want %q", got, "hello")
+	}
+	if err := h.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	select {
+	case <-h.Done():
+	default:
+		t.Fatalf("Done() not closed after Wait")
+	}
+}
+
+func TestOSExecFactory_KillTerminates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only test")
+	}
+	f := NewOSExecFactory()
+	h, err := f.Start(context.Background(), LaunchSpec{
+		Path: "/bin/sh",
+		Args: []string{"-c", "sleep 60"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := h.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	// Wait must return promptly after Kill.
+	done := make(chan error, 1)
+	go func() { done <- h.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Wait did not return after Kill")
+	}
+}
+
+func TestOSExecFactory_KillIdempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only test")
+	}
+	f := NewOSExecFactory()
+	h, err := f.Start(context.Background(), LaunchSpec{
+		Path: "/bin/echo",
+		Args: []string{"x"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	_ = h.Wait()
+	if err := h.Kill(); err != nil {
+		t.Fatalf("first Kill after exit: %v", err)
+	}
+	if err := h.Kill(); err != nil {
+		t.Fatalf("second Kill: %v", err)
+	}
+}
+
+func TestOSExecFactory_StartMissingBinary(t *testing.T) {
+	f := NewOSExecFactory()
+	_, err := f.Start(context.Background(), LaunchSpec{
+		Path: "/definitely/not/a/binary/here",
+	})
+	if err == nil {
+		t.Fatalf("expected error starting missing binary")
+	}
+}
+
+func TestFakeFactory_RecordsSpec(t *testing.T) {
+	f := NewFakeFactory()
+	spec := LaunchSpec{Path: "claude", Args: []string{"--resume", "abc"}}
+	h, err := f.Start(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer h.Kill()
+
+	starts := f.Starts()
+	if len(starts) != 1 || starts[0].Path != "claude" || len(starts[0].Args) != 2 {
+		t.Fatalf("unexpected Starts: %+v", starts)
+	}
+	if got := h.(*FakeHandle).Spec().Path; got != "claude" {
+		t.Fatalf("Spec().Path = %q", got)
+	}
+}
+
+func TestFakeFactory_ScriptedOutputThenExit(t *testing.T) {
+	f := NewFakeFactory()
+	f.OnStart = func(_ context.Context, _ LaunchSpec, h *FakeHandle) {
+		go func() {
+			_, _ = h.WriteOutput([]byte("event1\n"))
+			_, _ = h.WriteOutput([]byte("event2\n"))
+			h.FinishOutput()
+			h.SignalExit(nil)
+		}()
+	}
+
+	h, err := f.Start(context.Background(), LaunchSpec{Path: "x"})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	got, err := io.ReadAll(h.Stdout())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "event1\nevent2\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if err := h.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+}
+
+func TestFakeFactory_ExitErrPropagated(t *testing.T) {
+	wantErr := errors.New("boom")
+	f := NewFakeFactory()
+	f.OnStart = func(_ context.Context, _ LaunchSpec, h *FakeHandle) {
+		go func() {
+			h.FinishOutput()
+			h.SignalExit(wantErr)
+		}()
+	}
+	h, err := f.Start(context.Background(), LaunchSpec{})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	_, _ = io.ReadAll(h.Stdout())
+	if got := h.Wait(); !errors.Is(got, wantErr) {
+		t.Fatalf("Wait err = %v, want %v", got, wantErr)
+	}
+}
+
+func TestFakeFactory_KillBeforeExitClosesAndSignals(t *testing.T) {
+	f := NewFakeFactory()
+	h, err := f.Start(context.Background(), LaunchSpec{})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(h.Stdout())
+		close(done)
+	}()
+
+	if err := h.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("Stdout did not EOF after Kill")
+	}
+
+	if got := h.Wait(); !errors.Is(got, ErrKilled) {
+		t.Fatalf("Wait after Kill = %v, want ErrKilled", got)
+	}
+	// Idempotent.
+	if err := h.Kill(); err != nil {
+		t.Fatalf("second Kill: %v", err)
+	}
+}
+
+func TestFakeHandle_StdinObservable(t *testing.T) {
+	f := NewFakeFactory()
+	h, err := f.Start(context.Background(), LaunchSpec{})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fh := h.(*FakeHandle)
+	defer fh.Kill()
+
+	var got bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&got, fh.StdinR)
+	}()
+
+	if _, err := fh.Stdin().Write([]byte("hello child\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = fh.Stdin().Close()
+	wg.Wait()
+
+	if s := got.String(); s != "hello child\n" {
+		t.Fatalf("StdinR observed %q", s)
+	}
+}

--- a/agentboot/protocol/decoder.go
+++ b/agentboot/protocol/decoder.go
@@ -1,0 +1,92 @@
+// Package protocol is the pure stream-protocol layer of agentboot. It has no
+// knowledge of how the agent process is started or how its events are routed
+// — it only understands bytes flowing in and out of an io.Reader/io.Writer.
+//
+// This isolation makes the decoder testable against fixed JSON inputs without
+// any process or goroutine plumbing.
+package protocol
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/tingly-dev/tingly-box/agentboot/common"
+)
+
+// Event is the type emitted by Decoder. It aliases common.Event so callers
+// can pass values to the rest of agentboot without conversion.
+type Event = common.Event
+
+// Decoder reads a stream of JSON-encoded values from an io.Reader and emits
+// them as Events on the channel returned by Stream.
+type Decoder struct {
+	src io.Reader
+}
+
+// NewDecoder constructs a Decoder reading from r.
+func NewDecoder(r io.Reader) *Decoder { return &Decoder{src: r} }
+
+// Stream consumes the decoder's input on a goroutine and returns the event
+// channel together with an Err accessor.
+//
+// Channel-close semantics:
+//   - The channel is closed exactly once, when the source reaches EOF, ctx
+//     is canceled, or a non-recoverable decode error occurs.
+//   - Err must only be called after the channel has been observed closed.
+//     The Go memory model guarantees the terminal error is visible to
+//     readers after channel-close synchronization.
+//   - If the source implements io.Closer, it is closed on ctx cancel so
+//     that an in-flight blocking Decode unblocks promptly. Callers that
+//     pass a non-closer reader must close it themselves to abort decoding.
+//
+// If decoding succeeds and the source ends cleanly with EOF, Err returns nil.
+func (d *Decoder) Stream(ctx context.Context) (events <-chan Event, errFn func() error) {
+	out := make(chan Event)
+	var termErr error
+
+	go func() {
+		defer close(out)
+
+		if closer, ok := d.src.(io.Closer); ok {
+			watcherDone := make(chan struct{})
+			defer close(watcherDone)
+			go func() {
+				select {
+				case <-ctx.Done():
+					_ = closer.Close()
+				case <-watcherDone:
+				}
+			}()
+		}
+
+		dec := json.NewDecoder(bufio.NewReader(d.src))
+		for {
+			var raw map[string]any
+			if err := dec.Decode(&raw); err != nil {
+				if ctx.Err() != nil {
+					termErr = ctx.Err()
+					return
+				}
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				termErr = fmt.Errorf("decode: %w", err)
+				return
+			}
+
+			ev := common.NewEventFromMap(raw)
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				termErr = ctx.Err()
+				return
+			}
+		}
+	}()
+
+	return out, func() error { return termErr }
+}

--- a/agentboot/protocol/decoder_test.go
+++ b/agentboot/protocol/decoder_test.go
@@ -1,0 +1,147 @@
+package protocol
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDecoder_GoldenAssistantThenResult(t *testing.T) {
+	f, err := os.Open("testdata/assistant_then_result.jsonl")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	d := NewDecoder(f)
+	ch, errFn := d.Stream(context.Background())
+
+	var types []string
+	for ev := range ch {
+		types = append(types, ev.Type)
+	}
+	if errFn() != nil {
+		t.Fatalf("Err() = %v, want nil", errFn())
+	}
+	want := []string{"system", "assistant", "result"}
+	if len(types) != len(want) {
+		t.Fatalf("got %d events, want %d (%v)", len(types), len(want), types)
+	}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Fatalf("event[%d].Type = %q, want %q", i, types[i], want[i])
+		}
+	}
+}
+
+func TestDecoder_PermissionRequest(t *testing.T) {
+	f, err := os.Open("testdata/permission_request.jsonl")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	d := NewDecoder(f)
+	ch, errFn := d.Stream(context.Background())
+
+	ev, ok := <-ch
+	if !ok {
+		t.Fatalf("channel closed before first event")
+	}
+	if ev.Type != "control_request" {
+		t.Fatalf("Type = %q, want control_request", ev.Type)
+	}
+	req, ok := ev.Data["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request field missing")
+	}
+	if req["subtype"] != "can_use_tool" {
+		t.Fatalf("subtype = %v", req["subtype"])
+	}
+
+	for range ch {
+		// drain
+	}
+	if errFn() != nil {
+		t.Fatalf("Err() = %v, want nil", errFn())
+	}
+}
+
+func TestDecoder_EmptyInputClosesChannel(t *testing.T) {
+	d := NewDecoder(strings.NewReader(""))
+	ch, errFn := d.Stream(context.Background())
+	if _, ok := <-ch; ok {
+		t.Fatalf("expected immediate close on empty input")
+	}
+	if errFn() != nil {
+		t.Fatalf("Err() = %v, want nil", errFn())
+	}
+}
+
+func TestDecoder_MalformedInputReportsError(t *testing.T) {
+	d := NewDecoder(strings.NewReader(`{"type":"ok"} not-json`))
+	ch, errFn := d.Stream(context.Background())
+
+	first, ok := <-ch
+	if !ok || first.Type != "ok" {
+		t.Fatalf("first event = %+v, ok=%v", first, ok)
+	}
+	for range ch {
+		// drain until closure
+	}
+	if errFn() == nil {
+		t.Fatalf("Err() = nil, want decode error")
+	}
+}
+
+func TestDecoder_CtxCancelStopsStream(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d := NewDecoder(pr)
+	ch, errFn := d.Stream(ctx)
+
+	// Push one valid event so the goroutine is past its first select.
+	go func() { _, _ = pw.Write([]byte(`{"type":"x"}` + "\n")) }()
+	if _, ok := <-ch; !ok {
+		t.Fatalf("channel closed before first event")
+	}
+
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			// drain remaining
+			for range ch {
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("channel did not close after ctx cancel")
+	}
+	if !errors.Is(errFn(), context.Canceled) {
+		t.Fatalf("Err() = %v, want context.Canceled", errFn())
+	}
+}
+
+func TestEncoder_WritesNewlineDelimited(t *testing.T) {
+	var buf bytes.Buffer
+	e := NewEncoder(&buf)
+	if err := e.Encode(map[string]any{"a": 1}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := e.Encode(map[string]any{"b": 2}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got := buf.String()
+	want := `{"a":1}` + "\n" + `{"b":2}` + "\n"
+	if got != want {
+		t.Fatalf("encoder output = %q, want %q", got, want)
+	}
+}

--- a/agentboot/protocol/encoder.go
+++ b/agentboot/protocol/encoder.go
@@ -1,0 +1,32 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Encoder writes control responses (and other outbound messages) as
+// newline-delimited JSON to a destination io.Writer. It is safe for
+// concurrent use; concurrent Encode calls are serialized so that no two
+// JSON values interleave on the wire.
+type Encoder struct {
+	mu  sync.Mutex
+	dst io.Writer
+}
+
+// NewEncoder constructs an Encoder targeting w.
+func NewEncoder(w io.Writer) *Encoder { return &Encoder{dst: w} }
+
+// Encode marshals v to JSON and writes it to the destination, terminated
+// by a newline.
+func (e *Encoder) Encode(v any) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	enc := json.NewEncoder(e.dst)
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+	return nil
+}

--- a/agentboot/protocol/testdata/assistant_then_result.jsonl
+++ b/agentboot/protocol/testdata/assistant_then_result.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"sess-abc","cwd":"/tmp"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Hello"}]}}
+{"type":"result","subtype":"success","session_id":"sess-abc","is_error":false}

--- a/agentboot/protocol/testdata/permission_request.jsonl
+++ b/agentboot/protocol/testdata/permission_request.jsonl
@@ -1,0 +1,1 @@
+{"type":"control_request","request_id":"req-1","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{"command":"ls"}}}


### PR DESCRIPTION
## Summary

Phase 1 of the AgentBoot redesign for testability. Two new packages under `agentboot/`, both purely additive — no consumer changes, no behavior changes, no existing tests touched.

The motivation: today `claude/driver.go` → `mitm.Runner` → `cmd.Start` is a hard-wired path. The real `ClaudeCodeExecutor` cannot be e2e-tested without spawning the actual `claude` binary, which is why all current e2e coverage runs through `mockagent` and the real path is untested. These two packages introduce the seams needed to fix that — once the runner is rewritten to take a `process.Factory` injection (later phase), tests can script the claude CLI's stdout without spawning a binary.

## What ships in this PR

### `agentboot/process/`

- `Factory` + `Handle` interfaces abstract OS process management — `Stdin()`, `Stdout()`, `Wait()`, `Kill()`, `Done()`.
- `OSExecFactory` wraps `os/exec` for production use.
- `FakeFactory` + `FakeHandle` script an in-memory event sequence, substituting the binary while keeping the rest of the agent stack on its real code path.

### `agentboot/protocol/`

- `Decoder` reads a JSON-stream from `io.Reader`, emits `common.Event` on a channel; closes on EOF or `ctx` cancel. Closes the source reader when `ctx` cancels so a blocking `Decode` unblocks promptly.
- `Encoder` writes newline-delimited JSON; serializes concurrent calls with an internal mutex.
- Golden testdata in `testdata/*.jsonl` covers the assistant + result flow and the permission_request flow.

## Files changed

```
agentboot/process/fake.go                            +151
agentboot/process/osexec.go                          +98
agentboot/process/process.go                         +44
agentboot/process/process_test.go                    +222
agentboot/protocol/decoder.go                        +92
agentboot/protocol/decoder_test.go                   +147
agentboot/protocol/encoder.go                        +32
agentboot/protocol/testdata/assistant_then_result.jsonl  +3
agentboot/protocol/testdata/permission_request.jsonl +1
9 files changed, +790 / -0
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./agentboot/process/... -race -count=1` — passes
- [x] `go test ./agentboot/protocol/... -race -count=1` — passes
- [x] `go test ./...` — full suite still green (no consumers touched)
- [ ] Reviewer: confirm the new packages have no production callers yet (they don't — wiring happens in a follow-up PR)

## Follow-ups (not in this PR)

- Rewrite `agentboot/runner.go` to take a `process.Factory` injection so the real claude pipeline can be exercised in tests
- Replace `mockagent` with a Claude wire-format fixture driving `process.FakeFactory`
- Move session state transitions into the runner
- Formalize the Prompter contract with a `FakePrompter`

https://claude.ai/code/session_015mmAEE1QbZAYaz5xBCa7zz

---
_Generated by [Claude Code](https://claude.ai/code/session_015mmAEE1QbZAYaz5xBCa7zz)_