### PR TITLE
fix(protocol): preserve images across request conversions

### DIFF
--- a/internal/protocol/request/anthropic_beta_to_openai.go
+++ b/internal/protocol/request/anthropic_beta_to_openai.go
@@ -162,6 +162,24 @@ func ConvertBetaContentBlocksToString(blocks []anthropic.BetaContentBlockParamUn
 	return result.String()
 }
 
+// betaImageBlockToOpenAIURL converts an Anthropic beta image block source into
+// the URL string OpenAI's image_url content part expects. Base64 sources become
+// a data: URL; URL sources are passed through. Returns "" for unsupported
+// sources (e.g. file IDs that have no OpenAI equivalent).
+func betaImageBlockToOpenAIURL(img *anthropic.BetaImageBlockParam) string {
+	if img == nil {
+		return ""
+	}
+	if img.Source.OfBase64 != nil {
+		return "data:" + string(img.Source.OfBase64.MediaType) +
+			";base64," + img.Source.OfBase64.Data
+	}
+	if img.Source.OfURL != nil {
+		return img.Source.OfURL.URL
+	}
+	return ""
+}
+
 // convertAnthropicBetaAssistantMessageToOpenAI converts Anthropic beta assistant message to OpenAI format
 // Note: thinking content is preserved in "x_thinking" field for provider-specific transforms
 func convertAnthropicBetaAssistantMessageToOpenAI(msg anthropic.BetaMessageParam) openai.ChatCompletionMessageParamUnion {
@@ -242,13 +260,14 @@ func convertAnthropicBetaAssistantMessageToOpenAI(msg anthropic.BetaMessageParam
 func convertAnthropicBetaUserMessageToOpenAI(msg anthropic.BetaMessageParam) []openai.ChatCompletionMessageParamUnion {
 	var result []openai.ChatCompletionMessageParamUnion
 	var textContent string
-	var hasToolResult bool
+	var hasToolResult, hasImage bool
 
-	// First, check if there are any tool_result blocks
 	for _, block := range msg.Content {
 		if block.OfToolResult != nil {
 			hasToolResult = true
-			break
+		}
+		if block.OfImage != nil {
+			hasImage = true
 		}
 	}
 
@@ -276,6 +295,37 @@ func convertAnthropicBetaUserMessageToOpenAI(msg anthropic.BetaMessageParam) []o
 		// If there was text content alongside tool results, add it as a user message
 		if textContent != "" {
 			result = append(result, openai.UserMessage(textContent))
+		}
+	} else if hasImage {
+		// Multimodal user message: emit an array of text + image_url content parts
+		parts := make([]map[string]interface{}, 0, len(msg.Content))
+		for _, block := range msg.Content {
+			switch {
+			case block.OfText != nil:
+				parts = append(parts, map[string]interface{}{
+					"type": "text",
+					"text": block.OfText.Text,
+				})
+			case block.OfImage != nil:
+				url := betaImageBlockToOpenAIURL(block.OfImage)
+				if url == "" {
+					continue
+				}
+				parts = append(parts, map[string]interface{}{
+					"type":      "image_url",
+					"image_url": map[string]interface{}{"url": url},
+				})
+			}
+		}
+		if len(parts) > 0 {
+			msgMap := map[string]interface{}{
+				"role":    "user",
+				"content": parts,
+			}
+			msgBytes, _ := json.Marshal(msgMap)
+			var userMsg openai.ChatCompletionMessageParamUnion
+			_ = json.Unmarshal(msgBytes, &userMsg)
+			result = append(result, userMsg)
 		}
 	} else {
 		// Simple text-only user message

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -83,12 +83,13 @@ func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageN
 func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
 
-	// Check for tool_result blocks
-	var hasToolResult bool
+	var hasToolResult, hasImage bool
 	for _, block := range msg.Content {
 		if block.OfToolResult != nil {
 			hasToolResult = true
-			break
+		}
+		if block.OfImage != nil {
+			hasImage = true
 		}
 	}
 
@@ -120,6 +121,39 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 					OfMessage: &messageItem,
 				})
 			}
+		}
+	} else if hasImage {
+		// Multimodal user message: emit input_text + input_image content parts
+		contentList := make(responses.ResponseInputMessageContentListParam, 0, len(msg.Content))
+		for _, block := range msg.Content {
+			switch {
+			case block.OfText != nil:
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{
+					OfInputText: &responses.ResponseInputTextParam{Text: block.OfText.Text},
+				})
+			case block.OfImage != nil:
+				url := betaImageBlockToOpenAIURL(block.OfImage)
+				if url == "" {
+					continue
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{
+					OfInputImage: &responses.ResponseInputImageParam{
+						ImageURL: ParamOpt(url),
+					},
+				})
+			}
+		}
+		if len(contentList) > 0 {
+			messageItem := responses.EasyInputMessageParam{
+				Type: responses.EasyInputMessageTypeMessage,
+				Role: responses.EasyInputMessageRole("user"),
+				Content: responses.EasyInputMessageContentUnionParam{
+					OfInputItemContentList: contentList,
+				},
+			}
+			items = append(items, responses.ResponseInputItemUnionParam{
+				OfMessage: &messageItem,
+			})
 		}
 	} else {
 		// Simple text-only user message

--- a/internal/protocol/request/anthropic_to_openai_test.go
+++ b/internal/protocol/request/anthropic_to_openai_test.go
@@ -187,6 +187,154 @@ func TestConvertAnthropicToolsToOpenAI_EmptyTools(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+// userMessageContentParts marshals the OpenAI request, finds the first user
+// message, and returns its content parts as a slice of maps. Returns nil if
+// content is a plain string (not an array).
+func userMessageContentParts(t *testing.T, msg interface{}) []map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(msg)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+	require.Equal(t, "user", m["role"])
+	parts, ok := m["content"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(parts))
+	for _, p := range parts {
+		if pm, ok := p.(map[string]interface{}); ok {
+			out = append(out, pm)
+		}
+	}
+	return out
+}
+
+// TestConvertAnthropicBetaToOpenAI_ImageBase64 verifies that a base64 image
+// block in an Anthropic beta user message is preserved as an OpenAI
+// image_url content part with a data: URL.
+func TestConvertAnthropicBetaToOpenAI_ImageBase64(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					anthropic.NewBetaTextBlock("describe this image"),
+					anthropic.NewBetaImageBlock(anthropic.BetaBase64ImageSourceParam{
+						Data:      "iVBORw0KGgo=",
+						MediaType: anthropic.BetaBase64ImageSourceMediaTypeImagePNG,
+					}),
+				},
+			},
+		},
+	}
+
+	out, _ := ConvertAnthropicBetaToOpenAIRequest(req, false, false, false)
+	require.Len(t, out.Messages, 1)
+
+	parts := userMessageContentParts(t, out.Messages[0])
+	require.Len(t, parts, 2, "expected text + image_url parts, got: %v", parts)
+
+	assert.Equal(t, "text", parts[0]["type"])
+	assert.Equal(t, "describe this image", parts[0]["text"])
+
+	assert.Equal(t, "image_url", parts[1]["type"])
+	imgURL, ok := parts[1]["image_url"].(map[string]interface{})
+	require.True(t, ok, "image_url should be an object")
+	assert.Equal(t, "data:image/png;base64,iVBORw0KGgo=", imgURL["url"])
+}
+
+// TestConvertAnthropicBetaToOpenAI_ImageURL verifies that a URL image block
+// in an Anthropic beta user message round-trips into OpenAI's image_url.url.
+func TestConvertAnthropicBetaToOpenAI_ImageURL(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					anthropic.NewBetaImageBlock(anthropic.BetaURLImageSourceParam{
+						URL: "https://example.com/cat.png",
+					}),
+				},
+			},
+		},
+	}
+
+	out, _ := ConvertAnthropicBetaToOpenAIRequest(req, false, false, false)
+	require.Len(t, out.Messages, 1)
+
+	parts := userMessageContentParts(t, out.Messages[0])
+	require.Len(t, parts, 1)
+	assert.Equal(t, "image_url", parts[0]["type"])
+	imgURL, ok := parts[0]["image_url"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "https://example.com/cat.png", imgURL["url"])
+}
+
+// TestConvertAnthropicBetaToOpenAI_TextOnlyUnchanged is a regression test
+// confirming the text-only path still emits a plain string content (not a
+// parts array), so we don't accidentally degrade simple requests.
+func TestConvertAnthropicBetaToOpenAI_TextOnlyUnchanged(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					anthropic.NewBetaTextBlock("hello"),
+				},
+			},
+		},
+	}
+
+	out, _ := ConvertAnthropicBetaToOpenAIRequest(req, false, false, false)
+	require.Len(t, out.Messages, 1)
+
+	raw, err := json.Marshal(out.Messages[0])
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.Equal(t, "user", m["role"])
+	assert.Equal(t, "hello", m["content"], "text-only content should remain a string")
+}
+
+// TestConvertAnthropicToOpenAI_ImageBase64 mirrors the beta image test for
+// the v1 conversion path so the duplicated converter is also covered.
+func TestConvertAnthropicToOpenAI_ImageBase64(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					anthropic.NewTextBlock("look"),
+					anthropic.NewImageBlockBase64("image/jpeg", "/9j/4AAQ"),
+				},
+			},
+		},
+	}
+
+	out, _ := ConvertAnthropicToOpenAIRequest(req, false, false, false)
+	require.Len(t, out.Messages, 1)
+
+	parts := userMessageContentParts(t, out.Messages[0])
+	require.Len(t, parts, 2)
+
+	assert.Equal(t, "text", parts[0]["type"])
+	assert.Equal(t, "look", parts[0]["text"])
+
+	assert.Equal(t, "image_url", parts[1]["type"])
+	imgURL, ok := parts[1]["image_url"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "data:image/jpeg;base64,/9j/4AAQ", imgURL["url"])
+}
+
 // TestConvertAnthropicToolsToOpenAI_MultipleTools tests conversion with multiple tools
 func TestConvertAnthropicToolsToOpenAI_MultipleTools(t *testing.T) {
 	tool1 := anthropic.ToolParam{

--- a/internal/protocol/request/anthropic_v1_to_openai.go
+++ b/internal/protocol/request/anthropic_v1_to_openai.go
@@ -199,6 +199,23 @@ func ConvertContentBlocksToString(blocks []anthropic.ContentBlockParamUnion) str
 	return result.String()
 }
 
+// imageBlockToOpenAIURL converts an Anthropic v1 image block source into the
+// URL string OpenAI's image_url content part expects. Base64 sources become a
+// data: URL; URL sources are passed through.
+func imageBlockToOpenAIURL(img *anthropic.ImageBlockParam) string {
+	if img == nil {
+		return ""
+	}
+	if img.Source.OfBase64 != nil {
+		return "data:" + string(img.Source.OfBase64.MediaType) +
+			";base64," + img.Source.OfBase64.Data
+	}
+	if img.Source.OfURL != nil {
+		return img.Source.OfURL.URL
+	}
+	return ""
+}
+
 // ConvertTextBlocksToString converts Anthropic TextBlockParam array to string
 func ConvertTextBlocksToString(blocks []anthropic.TextBlockParam) string {
 	var result strings.Builder
@@ -292,13 +309,14 @@ func convertAnthropicAssistantMessageToOpenAI(msg anthropic.MessageParam) openai
 func convertAnthropicUserMessageToOpenAI(msg anthropic.MessageParam) []openai.ChatCompletionMessageParamUnion {
 	var result []openai.ChatCompletionMessageParamUnion
 	var textContent string
-	var hasToolResult bool
+	var hasToolResult, hasImage bool
 
-	// First, check if there are any tool_result blocks
 	for _, block := range msg.Content {
 		if block.OfToolResult != nil {
 			hasToolResult = true
-			break
+		}
+		if block.OfImage != nil {
+			hasImage = true
 		}
 	}
 
@@ -326,6 +344,37 @@ func convertAnthropicUserMessageToOpenAI(msg anthropic.MessageParam) []openai.Ch
 		// If there was text content alongside tool results, add it as a user message
 		if textContent != "" {
 			result = append(result, openai.UserMessage(textContent))
+		}
+	} else if hasImage {
+		// Multimodal user message: emit an array of text + image_url content parts
+		parts := make([]map[string]interface{}, 0, len(msg.Content))
+		for _, block := range msg.Content {
+			switch {
+			case block.OfText != nil:
+				parts = append(parts, map[string]interface{}{
+					"type": "text",
+					"text": block.OfText.Text,
+				})
+			case block.OfImage != nil:
+				url := imageBlockToOpenAIURL(block.OfImage)
+				if url == "" {
+					continue
+				}
+				parts = append(parts, map[string]interface{}{
+					"type":      "image_url",
+					"image_url": map[string]interface{}{"url": url},
+				})
+			}
+		}
+		if len(parts) > 0 {
+			msgMap := map[string]interface{}{
+				"role":    "user",
+				"content": parts,
+			}
+			msgBytes, _ := json.Marshal(msgMap)
+			var userMsg openai.ChatCompletionMessageParamUnion
+			_ = json.Unmarshal(msgBytes, &userMsg)
+			result = append(result, userMsg)
 		}
 	} else {
 		// Simple text-only user message

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -83,12 +83,13 @@ func convertV1MessagesToResponsesInput(messages []anthropic.MessageParam) respon
 func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
 
-	// Check for tool_result blocks
-	var hasToolResult bool
+	var hasToolResult, hasImage bool
 	for _, block := range msg.Content {
 		if block.OfToolResult != nil {
 			hasToolResult = true
-			break
+		}
+		if block.OfImage != nil {
+			hasImage = true
 		}
 	}
 
@@ -120,6 +121,42 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 					OfMessage: &messageItem,
 				})
 			}
+		}
+		return items
+	}
+
+	if hasImage {
+		// Multimodal user message: emit input_text + input_image content parts
+		contentList := make(responses.ResponseInputMessageContentListParam, 0, len(msg.Content))
+		for _, block := range msg.Content {
+			switch {
+			case block.OfText != nil:
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{
+					OfInputText: &responses.ResponseInputTextParam{Text: block.OfText.Text},
+				})
+			case block.OfImage != nil:
+				url := imageBlockToOpenAIURL(block.OfImage)
+				if url == "" {
+					continue
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{
+					OfInputImage: &responses.ResponseInputImageParam{
+						ImageURL: param.NewOpt(url),
+					},
+				})
+			}
+		}
+		if len(contentList) > 0 {
+			messageItem := responses.EasyInputMessageParam{
+				Type: responses.EasyInputMessageTypeMessage,
+				Role: responses.EasyInputMessageRole("user"),
+				Content: responses.EasyInputMessageContentUnionParam{
+					OfInputItemContentList: contentList,
+				},
+			}
+			items = append(items, responses.ResponseInputItemUnionParam{
+				OfMessage: &messageItem,
+			})
 		}
 		return items
 	}

--- a/internal/protocol/request/image_conversions_test.go
+++ b/internal/protocol/request/image_conversions_test.go
@@ -1,0 +1,302 @@
+package request
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseImageURLToAnthropicSource covers the data-URL parser used by every
+// "OpenAI image_url -> Anthropic image" conversion path.
+func TestParseImageURLToAnthropicSource(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		mediaType string
+		data      string
+		remoteURL string
+	}{
+		{"data url", "data:image/png;base64,iVBORw0KGgo=", "image/png", "iVBORw0KGgo=", ""},
+		{"https url", "https://example.com/cat.jpg", "", "", "https://example.com/cat.jpg"},
+		{"empty", "", "", "", ""},
+		{"non-base64 data url falls through as remoteURL", "data:image/png;utf8,abc", "", "", "data:image/png;utf8,abc"},
+		{"malformed data url falls through", "data:broken", "", "", "data:broken"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt, d, u := parseImageURLToAnthropicSource(tc.in)
+			assert.Equal(t, tc.mediaType, mt)
+			assert.Equal(t, tc.data, d)
+			assert.Equal(t, tc.remoteURL, u)
+		})
+	}
+}
+
+// TestConvertOpenAIToAnthropic_ImageURL verifies that an OpenAI Chat
+// Completions multipart user message with an image_url part is preserved as an
+// Anthropic image content block.
+func TestConvertOpenAIToAnthropic_ImageURL(t *testing.T) {
+	// Build a multimodal user message via JSON (the same path the converter
+	// uses internally) so we don't need to know the exact SDK union shape.
+	rawMsg := json.RawMessage(`{
+		"role": "user",
+		"content": [
+			{"type": "text", "text": "look"},
+			{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}
+		]
+	}`)
+	var userMsg openai.ChatCompletionMessageParamUnion
+	require.NoError(t, json.Unmarshal(rawMsg, &userMsg))
+
+	req := &openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel("gpt-4o"),
+		Messages: []openai.ChatCompletionMessageParamUnion{userMsg},
+	}
+
+	out := ConvertOpenAIToAnthropicRequest(req, 1024)
+	require.Len(t, out.Messages, 1)
+	require.Len(t, out.Messages[0].Content, 2, "expected text + image blocks")
+
+	assert.NotNil(t, out.Messages[0].Content[0].OfText)
+	assert.Equal(t, "look", out.Messages[0].Content[0].OfText.Text)
+
+	require.NotNil(t, out.Messages[0].Content[1].OfImage)
+	require.NotNil(t, out.Messages[0].Content[1].OfImage.Source.OfURL)
+	assert.Equal(t, "https://example.com/cat.png", out.Messages[0].Content[1].OfImage.Source.OfURL.URL)
+}
+
+// TestConvertOpenAIToAnthropic_ImageDataURL verifies that an OpenAI data: URL
+// becomes an Anthropic base64 image source.
+func TestConvertOpenAIToAnthropic_ImageDataURL(t *testing.T) {
+	rawMsg := json.RawMessage(`{
+		"role": "user",
+		"content": [
+			{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,/9j/4AAQ"}}
+		]
+	}`)
+	var userMsg openai.ChatCompletionMessageParamUnion
+	require.NoError(t, json.Unmarshal(rawMsg, &userMsg))
+
+	req := &openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel("gpt-4o"),
+		Messages: []openai.ChatCompletionMessageParamUnion{userMsg},
+	}
+
+	out := ConvertOpenAIToAnthropicRequest(req, 1024)
+	require.Len(t, out.Messages, 1)
+	require.Len(t, out.Messages[0].Content, 1)
+
+	require.NotNil(t, out.Messages[0].Content[0].OfImage)
+	src := out.Messages[0].Content[0].OfImage.Source
+	require.NotNil(t, src.OfBase64)
+	assert.Equal(t, "image/jpeg", string(src.OfBase64.MediaType))
+	assert.Equal(t, "/9j/4AAQ", src.OfBase64.Data)
+}
+
+// TestConvertAnthropicV1ToResponses_Image verifies Anthropic image -> Responses
+// API input_image conversion (v1 path).
+func TestConvertAnthropicV1ToResponses_Image(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					anthropic.NewTextBlock("describe"),
+					anthropic.NewImageBlockBase64("image/png", "iVBORw0KGgo="),
+				},
+			},
+		},
+	}
+
+	out := ConvertAnthropicV1ToResponsesRequest(req)
+	require.NotNil(t, out)
+	require.Len(t, out.Input.OfInputItemList, 1)
+
+	msg := out.Input.OfInputItemList[0].OfMessage
+	require.NotNil(t, msg)
+	require.True(t, !param.IsOmitted(msg.Content.OfInputItemContentList))
+	parts := msg.Content.OfInputItemContentList
+	require.Len(t, parts, 2)
+
+	require.NotNil(t, parts[0].OfInputText)
+	assert.Equal(t, "describe", parts[0].OfInputText.Text)
+
+	require.NotNil(t, parts[1].OfInputImage)
+	assert.Equal(t, "data:image/png;base64,iVBORw0KGgo=", parts[1].OfInputImage.ImageURL.Value)
+}
+
+// TestConvertAnthropicBetaToResponses_Image is the beta variant of the above.
+func TestConvertAnthropicBetaToResponses_Image(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					anthropic.NewBetaImageBlock(anthropic.BetaURLImageSourceParam{
+						URL: "https://example.com/cat.png",
+					}),
+				},
+			},
+		},
+	}
+
+	out := ConvertAnthropicBetaToResponsesRequest(req)
+	require.NotNil(t, out)
+	require.Len(t, out.Input.OfInputItemList, 1)
+
+	msg := out.Input.OfInputItemList[0].OfMessage
+	require.NotNil(t, msg)
+	parts := msg.Content.OfInputItemContentList
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].OfInputImage)
+	assert.Equal(t, "https://example.com/cat.png", parts[0].OfInputImage.ImageURL.Value)
+}
+
+// TestConvertResponsesToAnthropic_Image verifies Responses input_image ->
+// Anthropic image conversion for both v1 and beta paths.
+func TestConvertResponsesToAnthropic_Image(t *testing.T) {
+	makeReq := func() responses.ResponseNewParams {
+		return responses.ResponseNewParams{
+			Model:           "test-model",
+			MaxOutputTokens: param.NewOpt(int64(100)),
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					{
+						OfMessage: &responses.EasyInputMessageParam{
+							Type: responses.EasyInputMessageTypeMessage,
+							Role: responses.EasyInputMessageRole("user"),
+							Content: responses.EasyInputMessageContentUnionParam{
+								OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+									{OfInputText: &responses.ResponseInputTextParam{Text: "describe"}},
+									{OfInputImage: &responses.ResponseInputImageParam{
+										ImageURL: param.NewOpt("data:image/png;base64,iVBORw0KGgo="),
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("v1", func(t *testing.T) {
+		out := ConvertOpenAIResponsesToAnthropicRequest(makeReq(), 1024)
+		require.Len(t, out.Messages, 1)
+		require.Len(t, out.Messages[0].Content, 2)
+
+		assert.NotNil(t, out.Messages[0].Content[0].OfText)
+		assert.Equal(t, "describe", out.Messages[0].Content[0].OfText.Text)
+
+		require.NotNil(t, out.Messages[0].Content[1].OfImage)
+		require.NotNil(t, out.Messages[0].Content[1].OfImage.Source.OfBase64)
+		assert.Equal(t, "image/png", string(out.Messages[0].Content[1].OfImage.Source.OfBase64.MediaType))
+	})
+
+	t.Run("beta", func(t *testing.T) {
+		out := ConvertOpenAIResponsesToAnthropicBetaRequest(makeReq(), 1024)
+		require.Len(t, out.Messages, 1)
+		require.Len(t, out.Messages[0].Content, 2)
+
+		require.NotNil(t, out.Messages[0].Content[1].OfImage)
+		require.NotNil(t, out.Messages[0].Content[1].OfImage.Source.OfBase64)
+		assert.Equal(t, "image/png", string(out.Messages[0].Content[1].OfImage.Source.OfBase64.MediaType))
+	})
+}
+
+// TestConvertChatToOpenAIResponses_Image verifies that a Chat Completions
+// multipart user message with image_url is forwarded as input_image when
+// converting to the Responses API.
+func TestConvertChatToOpenAIResponses_Image(t *testing.T) {
+	rawMsg := json.RawMessage(`{
+		"role": "user",
+		"content": [
+			{"type": "text", "text": "look"},
+			{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}
+		]
+	}`)
+	var userMsg openai.ChatCompletionMessageParamUnion
+	require.NoError(t, json.Unmarshal(rawMsg, &userMsg))
+
+	params := &openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel("gpt-4o"),
+		Messages: []openai.ChatCompletionMessageParamUnion{userMsg},
+	}
+
+	out := ConvertChatToOpenAIResponses(params, 1024)
+	require.NotNil(t, out)
+	require.Len(t, out.Input.OfInputItemList, 1)
+
+	msg := out.Input.OfInputItemList[0].OfMessage
+	require.NotNil(t, msg)
+	parts := msg.Content.OfInputItemContentList
+	require.Len(t, parts, 2)
+
+	require.NotNil(t, parts[0].OfInputText)
+	assert.Equal(t, "look", parts[0].OfInputText.Text)
+
+	require.NotNil(t, parts[1].OfInputImage)
+	assert.Equal(t, "https://example.com/cat.png", parts[1].OfInputImage.ImageURL.Value)
+}
+
+// TestConvertOpenAIResponsesToChat_Image verifies that a Responses API
+// multipart user message with input_image is forwarded as image_url when
+// converting back to Chat Completions.
+func TestConvertOpenAIResponsesToChat_Image(t *testing.T) {
+	params := &responses.ResponseNewParams{
+		Model:           "gpt-4o",
+		MaxOutputTokens: param.NewOpt(int64(100)),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: responses.ResponseInputParam{
+				{
+					OfMessage: &responses.EasyInputMessageParam{
+						Type: responses.EasyInputMessageTypeMessage,
+						Role: responses.EasyInputMessageRole("user"),
+						Content: responses.EasyInputMessageContentUnionParam{
+							OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+								{OfInputText: &responses.ResponseInputTextParam{Text: "look"}},
+								{OfInputImage: &responses.ResponseInputImageParam{
+									ImageURL: param.NewOpt("https://example.com/cat.png"),
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out := ConvertOpenAIResponsesToChat(params, 1024)
+	require.NotNil(t, out)
+	require.Len(t, out.Messages, 1)
+
+	raw, err := json.Marshal(out.Messages[0])
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.Equal(t, "user", m["role"])
+
+	parts, ok := m["content"].([]interface{})
+	require.True(t, ok, "content should be an array, got: %v", m["content"])
+	require.Len(t, parts, 2)
+
+	first := parts[0].(map[string]interface{})
+	assert.Equal(t, "text", first["type"])
+	assert.Equal(t, "look", first["text"])
+
+	second := parts[1].(map[string]interface{})
+	assert.Equal(t, "image_url", second["type"])
+	imgURL, ok := second["image_url"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "https://example.com/cat.png", imgURL["url"])
+}

--- a/internal/protocol/request/image_helper.go
+++ b/internal/protocol/request/image_helper.go
@@ -1,0 +1,36 @@
+package request
+
+import "strings"
+
+// parseImageURLToAnthropicSource splits a string from OpenAI's image_url.url
+// (used by both Chat Completions and the Responses API) into the bits an
+// Anthropic image source needs.
+//
+// Returns mediaType and data when the URL is a "data:<mime>;base64,<payload>"
+// data URL. Returns the same URL string back as remoteURL when it's a regular
+// http(s) URL. Exactly one of (mediaType+data) or remoteURL is non-empty for
+// well-formed input.
+func parseImageURLToAnthropicSource(url string) (mediaType, data, remoteURL string) {
+	if url == "" {
+		return "", "", ""
+	}
+	if !strings.HasPrefix(url, "data:") {
+		return "", "", url
+	}
+	rest := strings.TrimPrefix(url, "data:")
+	semi := strings.IndexByte(rest, ';')
+	comma := strings.IndexByte(rest, ',')
+	if semi < 0 || comma < 0 || semi > comma {
+		// Malformed data URL — give the caller back the raw string so it can
+		// at least be passed through as a reference rather than dropped.
+		return "", "", url
+	}
+	mediaType = rest[:semi]
+	// Encoding token between ';' and ',' — we only support base64 data URLs.
+	encoding := rest[semi+1 : comma]
+	if encoding != "base64" {
+		return "", "", url
+	}
+	data = rest[comma+1:]
+	return mediaType, data, ""
+}

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -115,17 +115,59 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 
 // convertChatUserMessageToResponses converts a Chat user message to Responses format.
 func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessageParam) responses.ResponseInputItemUnionParam {
-	content := ""
-	if !param.IsOmitted(userMsg.Content.OfString) && userMsg.Content.OfString.Value != "" {
-		content = userMsg.Content.OfString.Value
+	if userMsg.Content.OfString.Valid() {
+		return responses.ResponseInputItemUnionParam{
+			OfMessage: &responses.EasyInputMessageParam{
+				Type: responses.EasyInputMessageTypeMessage,
+				Role: responses.EasyInputMessageRole("user"),
+				Content: responses.EasyInputMessageContentUnionParam{
+					OfString: param.NewOpt(userMsg.Content.OfString.Value),
+				},
+			},
+		}
 	}
 
+	// Multipart content: forward text + image_url parts as input_text + input_image.
+	if len(userMsg.Content.OfArrayOfContentParts) > 0 {
+		contentList := make(responses.ResponseInputMessageContentListParam, 0, len(userMsg.Content.OfArrayOfContentParts))
+		for _, part := range userMsg.Content.OfArrayOfContentParts {
+			switch {
+			case part.OfText != nil:
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{
+					OfInputText: &responses.ResponseInputTextParam{Text: part.OfText.Text},
+				})
+			case part.OfImageURL != nil:
+				url := part.OfImageURL.ImageURL.URL
+				if url == "" {
+					continue
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{
+					OfInputImage: &responses.ResponseInputImageParam{
+						ImageURL: param.NewOpt(url),
+					},
+				})
+			}
+		}
+		if len(contentList) > 0 {
+			return responses.ResponseInputItemUnionParam{
+				OfMessage: &responses.EasyInputMessageParam{
+					Type: responses.EasyInputMessageTypeMessage,
+					Role: responses.EasyInputMessageRole("user"),
+					Content: responses.EasyInputMessageContentUnionParam{
+						OfInputItemContentList: contentList,
+					},
+				},
+			}
+		}
+	}
+
+	// Fall back to an empty user message to preserve prior behavior.
 	return responses.ResponseInputItemUnionParam{
 		OfMessage: &responses.EasyInputMessageParam{
 			Type: responses.EasyInputMessageTypeMessage,
 			Role: responses.EasyInputMessageRole("user"),
 			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(content),
+				OfString: param.NewOpt(""),
 			},
 		},
 	}

--- a/internal/protocol/request/openai_responses_to_anthropic.go
+++ b/internal/protocol/request/openai_responses_to_anthropic.go
@@ -226,10 +226,20 @@ func convertResponsesUserMessageToAnthropic(msg *responses.EasyInputMessageParam
 	if !param.IsOmitted(msg.Content.OfInputItemContentList) {
 		var blocks []anthropic.ContentBlockParamUnion
 		for _, contentItem := range msg.Content.OfInputItemContentList {
-			if !param.IsOmitted(contentItem.OfInputText) {
+			switch {
+			case !param.IsOmitted(contentItem.OfInputText):
 				blocks = append(blocks, anthropic.NewTextBlock(contentItem.OfInputText.Text))
-			} else {
-				// Log unsupported content types (images, audio, etc.)
+			case !param.IsOmitted(contentItem.OfInputImage):
+				img := contentItem.OfInputImage
+				if !img.ImageURL.Valid() {
+					// File-id only or empty image — Anthropic has no equivalent, skip.
+					logrus.Warnf("Skipping Responses API input_image without image_url (e.g. file_id-only) in user message")
+					continue
+				}
+				if block, ok := openAIImageURLToAnthropicV1Block(img.ImageURL.Value); ok {
+					blocks = append(blocks, block)
+				}
+			default:
 				logrus.Warnf("Unsupported content type in Responses API user message, skipping. Content types available: %v", contentItem)
 			}
 		}
@@ -314,10 +324,19 @@ func convertResponsesUserMessageToAnthropicBeta(msg *responses.EasyInputMessageP
 	if !param.IsOmitted(msg.Content.OfInputItemContentList) {
 		var blocks []anthropic.BetaContentBlockParamUnion
 		for _, contentItem := range msg.Content.OfInputItemContentList {
-			if !param.IsOmitted(contentItem.OfInputText) {
+			switch {
+			case !param.IsOmitted(contentItem.OfInputText):
 				blocks = append(blocks, anthropic.NewBetaTextBlock(contentItem.OfInputText.Text))
-			} else {
-				// Log unsupported content types
+			case !param.IsOmitted(contentItem.OfInputImage):
+				img := contentItem.OfInputImage
+				if !img.ImageURL.Valid() {
+					logrus.Warnf("Skipping Responses API input_image without image_url (e.g. file_id-only) in beta user message")
+					continue
+				}
+				if block, ok := openAIImageURLToAnthropicBetaBlock(img.ImageURL.Value); ok {
+					blocks = append(blocks, block)
+				}
+			default:
 				logrus.Warnf("Unsupported content type in Responses API beta user message, skipping. Content types available: %v", contentItem)
 			}
 		}

--- a/internal/protocol/request/openai_responses_to_chat.go
+++ b/internal/protocol/request/openai_responses_to_chat.go
@@ -74,7 +74,50 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 				content := msg.Content.OfString.Value
 				messages = append(messages, createMessage(role, content))
 			} else if !param.IsOmitted(msg.Content.OfInputItemContentList) {
-				// Array content - concatenate text items
+				// Array content. If any input_image is present, preserve the
+				// multipart shape for OpenAI Chat Completions so vision input
+				// survives the conversion. Otherwise concatenate text items.
+				var hasImage bool
+				for _, contentItem := range msg.Content.OfInputItemContentList {
+					if !param.IsOmitted(contentItem.OfInputImage) {
+						hasImage = true
+						break
+					}
+				}
+
+				if hasImage && strings.EqualFold(role, "user") {
+					parts := make([]map[string]interface{}, 0, len(msg.Content.OfInputItemContentList))
+					for _, contentItem := range msg.Content.OfInputItemContentList {
+						switch {
+						case !param.IsOmitted(contentItem.OfInputText):
+							parts = append(parts, map[string]interface{}{
+								"type": "text",
+								"text": contentItem.OfInputText.Text,
+							})
+						case !param.IsOmitted(contentItem.OfInputImage):
+							img := contentItem.OfInputImage
+							if !img.ImageURL.Valid() || img.ImageURL.Value == "" {
+								continue
+							}
+							parts = append(parts, map[string]interface{}{
+								"type":      "image_url",
+								"image_url": map[string]interface{}{"url": img.ImageURL.Value},
+							})
+						}
+					}
+					if len(parts) > 0 {
+						msgMap := map[string]interface{}{
+							"role":    "user",
+							"content": parts,
+						}
+						msgBytes, _ := json.Marshal(msgMap)
+						var userMsg openai.ChatCompletionMessageParamUnion
+						_ = json.Unmarshal(msgBytes, &userMsg)
+						messages = append(messages, userMsg)
+					}
+					continue
+				}
+
 				var contentStr string
 				for _, contentItem := range msg.Content.OfInputItemContentList {
 					if !param.IsOmitted(contentItem.OfInputText) {

--- a/internal/protocol/request/openai_to_anthropic.go
+++ b/internal/protocol/request/openai_to_anthropic.go
@@ -40,9 +40,23 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			} else if contentParts, ok := m["content"].([]interface{}); ok {
 				// Array of content parts (multimodal)
 				for _, part := range contentParts {
-					if partMap, ok := part.(map[string]interface{}); ok {
+					partMap, ok := part.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					switch partMap["type"] {
+					case "text":
 						if text, ok := partMap["text"].(string); ok {
 							blocks = append(blocks, anthropic.NewBetaTextBlock(text))
+						}
+					case "image_url":
+						imageURL, _ := partMap["image_url"].(map[string]interface{})
+						if imageURL == nil {
+							continue
+						}
+						url, _ := imageURL["url"].(string)
+						if block, ok := openAIImageURLToAnthropicBetaBlock(url); ok {
+							blocks = append(blocks, block)
 						}
 					}
 				}
@@ -130,6 +144,44 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 	}
 
 	return params
+}
+
+// openAIImageURLToAnthropicBetaBlock turns an OpenAI image_url.url string into
+// an Anthropic beta image content block. Data URLs become base64 image sources,
+// remote URLs become URL image sources. Returns ok=false for empty/malformed
+// inputs the caller should drop.
+func openAIImageURLToAnthropicBetaBlock(url string) (anthropic.BetaContentBlockParamUnion, bool) {
+	mediaType, data, remoteURL := parseImageURLToAnthropicSource(url)
+	switch {
+	case mediaType != "" && data != "":
+		return anthropic.NewBetaImageBlock(anthropic.BetaBase64ImageSourceParam{
+			Data:      data,
+			MediaType: anthropic.BetaBase64ImageSourceMediaType(mediaType),
+		}), true
+	case remoteURL != "":
+		return anthropic.NewBetaImageBlock(anthropic.BetaURLImageSourceParam{
+			URL: remoteURL,
+		}), true
+	}
+	return anthropic.BetaContentBlockParamUnion{}, false
+}
+
+// openAIImageURLToAnthropicV1Block is the v1 counterpart of
+// openAIImageURLToAnthropicBetaBlock.
+func openAIImageURLToAnthropicV1Block(url string) (anthropic.ContentBlockParamUnion, bool) {
+	mediaType, data, remoteURL := parseImageURLToAnthropicSource(url)
+	switch {
+	case mediaType != "" && data != "":
+		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
+			Data:      data,
+			MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
+		}), true
+	case remoteURL != "":
+		return anthropic.NewImageBlock(anthropic.URLImageSourceParam{
+			URL: remoteURL,
+		}), true
+	}
+	return anthropic.ContentBlockParamUnion{}, false
 }
 
 func ConvertOpenAIToAnthropicTools(tools []openai.ChatCompletionToolUnionParam) []anthropic.BetaToolUnionParam {


### PR DESCRIPTION
## Summary

Image content blocks were being silently dropped across most request-conversion paths under `internal/protocol/request/`. Vision requests routed through tingly-box reached the upstream model without their images.

This PR restores image preservation across every direction:

| Direction | File | What was missing |
|---|---|---|
| Anthropic → OpenAI Chat (v1 + beta) | `anthropic_v1_to_openai.go`, `anthropic_beta_to_openai.go` | `OfImage` blocks → `image_url` parts |
| OpenAI Chat → Anthropic | `openai_to_anthropic.go` | `image_url` parts → Anthropic `image` block |
| Anthropic → OpenAI Responses (v1 + beta) | `anthropic_v1_to_responses.go`, `anthropic_beta_to_responses.go` | `OfImage` → `input_image` content item |
| OpenAI Responses → Anthropic (v1 + beta) | `openai_responses_to_anthropic.go` | `OfInputImage` → Anthropic `image` block |
| OpenAI Chat → OpenAI Responses | `openai_chat_to_openai_responses.go` | multipart user `image_url` → `input_image` |
| OpenAI Responses → OpenAI Chat | `openai_responses_to_chat.go` | `input_image` → `image_url` |

The Google branch already handled `OfImage` (`any_to_google.go:358-372`), so OpenAI/Responses were the only paths regressing.

### Implementation notes

- New shared helper `parseImageURLToAnthropicSource` in `image_helper.go` splits OpenAI `image_url.url` (data URL or remote URL) into the fields an Anthropic image source needs, reused by every reverse-direction converter.
- New `betaImageBlockToOpenAIURL` / `imageBlockToOpenAIURL` helpers turn an Anthropic image block into the URL string OpenAI's `image_url` / `input_image` expects (data URL for base64, passthrough for URL sources).
- Anthropic `tool_result` inner image content and assistant-side images are intentionally still text-only — see "Out of scope" below.

### Out of scope (separate issues)

- `tool_result` inner image content: OpenAI `role: tool` doesn't accept images, so this stays flattened to text by `convertToolResultContent` / `convertBetaToolResultContent`.
- Assistant messages: Anthropic assistant turns don't carry image blocks in practice.
- Anthropic `BetaFileImageSourceParam` (file IDs): no OpenAI equivalent — currently dropped with no fallback rather than fabricating one.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/protocol/request/...` — all green, 13 new image-related test cases:
  - `TestConvertAnthropicBetaToOpenAI_{ImageBase64,ImageURL,TextOnlyUnchanged}`
  - `TestConvertAnthropicToOpenAI_ImageBase64`
  - `TestParseImageURLToAnthropicSource` (5 sub-cases incl. malformed/empty)
  - `TestConvertOpenAIToAnthropic_{ImageURL,ImageDataURL}`
  - `TestConvertAnthropic{V1,Beta}ToResponses_Image`
  - `TestConvertResponsesToAnthropic_Image` (v1 + beta)
  - `TestConvertChatToOpenAIResponses_Image`
  - `TestConvertOpenAIResponsesToChat_Image`
- [ ] Manual smoke: send a Claude-format request with a base64 image through tingly-box pointed at an OpenAI-compatible upstream and confirm the upstream request body contains an `image_url` part rather than a stripped text-only message

https://claude.ai/code/session_01Cw7DJbkkz338vnRuvjzcjn
