### PR TITLE
feat(remote, agent): add tool call rendering for remote control bot

### DIFF
--- a/agentboot/claude/formatter.go
+++ b/agentboot/claude/formatter.go
@@ -19,11 +19,76 @@ type TextFormatter struct {
 	Verbose          bool
 	ShowToolDetails  bool
 	mu               sync.RWMutex
+	// toolNameByID correlates tool_use IDs to tool names so that result
+	// rendering can dispatch to the right per-tool renderer. Entries are
+	// removed once the corresponding result is rendered.
+	toolNameByID map[string]string
+	// seenAssistantToolIDs records IDs of tool_use blocks already rendered
+	// inside an AssistantMessage so the SDK's standalone *ToolUseMessage
+	// duplicate is suppressed (returns "" and is dropped by the caller).
+	seenAssistantToolIDs map[string]struct{}
 }
 
 // NewTextFormatter creates a new text formatter
 func NewTextFormatter() *TextFormatter {
 	return &TextFormatter{}
+}
+
+func (f *TextFormatter) rememberToolName(id, name string) {
+	if id == "" || name == "" {
+		return
+	}
+	f.mu.Lock()
+	if f.toolNameByID == nil {
+		f.toolNameByID = map[string]string{}
+	}
+	f.toolNameByID[id] = name
+	f.mu.Unlock()
+}
+
+func (f *TextFormatter) lookupToolName(id string) string {
+	if id == "" {
+		return ""
+	}
+	f.mu.RLock()
+	name := f.toolNameByID[id]
+	f.mu.RUnlock()
+	return name
+}
+
+func (f *TextFormatter) consumeToolName(id string) string {
+	if id == "" {
+		return ""
+	}
+	f.mu.Lock()
+	name := f.toolNameByID[id]
+	if name != "" {
+		delete(f.toolNameByID, id)
+	}
+	f.mu.Unlock()
+	return name
+}
+
+func (f *TextFormatter) markAssistantToolID(id string) {
+	if id == "" {
+		return
+	}
+	f.mu.Lock()
+	if f.seenAssistantToolIDs == nil {
+		f.seenAssistantToolIDs = map[string]struct{}{}
+	}
+	f.seenAssistantToolIDs[id] = struct{}{}
+	f.mu.Unlock()
+}
+
+func (f *TextFormatter) wasAssistantToolID(id string) bool {
+	if id == "" {
+		return false
+	}
+	f.mu.RLock()
+	_, ok := f.seenAssistantToolIDs[id]
+	f.mu.RUnlock()
+	return ok
 }
 
 // Format formats a message
@@ -118,64 +183,51 @@ func (f *TextFormatter) formatTaskNotification(m *SystemMessage) string {
 }
 
 func (f *TextFormatter) formatAssistant(m *AssistantMessage) string {
-	var b strings.Builder
+	var sections []string
+	var tools []ToolUseRef
 
-	if m.Message.ID != "" {
-		b.WriteString("[ASSISTANT] ")
-		b.WriteString(m.Message.ID)
-		b.WriteString("\n")
-	} else if !m.IsError() {
-		b.WriteString("[ASSISTANT]")
+	flushTools := func() {
+		if len(tools) == 0 {
+			return
+		}
+		if rendered := renderToolUseGroup(tools, f.ShowToolDetails); rendered != "" {
+			sections = append(sections, rendered)
+		}
+		tools = tools[:0]
 	}
 
-	hasContent := false
 	for _, content := range m.Message.Content {
 		switch content.Type {
 		case ContentBlockTypeText:
+			flushTools()
 			if content.Text != "" {
-				hasContent = true
-				b.WriteString(content.Text)
-				b.WriteString("\n")
+				sections = append(sections, strings.TrimRight(content.Text, "\n"))
 			}
 		case ContentBlockTypeToolUse:
-			if f.ShowToolDetails {
-				hasContent = true
-				b.WriteString("[TOOL] ")
-				b.WriteString(content.Name)
-				switch content.Name {
-				case "Bash":
-					b.WriteString("\n")
-					b.WriteString(fmt.Sprintf("%s", content.Input))
-				}
-				b.WriteString("\n")
-			}
+			f.rememberToolName(content.ID, content.Name)
+			f.markAssistantToolID(content.ID)
+			tools = append(tools, ToolUseRef{
+				ID:    content.ID,
+				Name:  content.Name,
+				Input: inputFromRaw(content.Input),
+			})
 		case ContentBlockTypeThinking:
+			flushTools()
 			if f.Verbose && content.Thinking != "" {
-				hasContent = true
-				b.WriteString("[THINKING] ")
-				b.WriteString(content.Thinking)
-				b.WriteString("\n")
-			}
-		case "web_search_tool_result":
-			if f.ShowToolDetails && content.ToolUseID != "" {
-				hasContent = true
-				b.WriteString("[TOOL_RESULT] ")
-				b.WriteString(content.ToolUseID)
-				b.WriteString("\n")
+				sections = append(sections, "[THINKING] "+content.Thinking)
 			}
 		}
 	}
+	flushTools()
 
 	if m.IsError() {
-		hasContent = true
-		b.WriteString(fmt.Sprintf("[ASSISTANT ERROR: %s] ", m.Error))
+		sections = append(sections, fmt.Sprintf("[ASSISTANT ERROR: %s]", m.Error))
 	}
 
-	if hasContent {
-		return strings.TrimRight(b.String(), "\n")
+	if len(sections) == 0 {
+		return ""
 	}
-
-	return ""
+	return strings.Join(sections, "\n")
 }
 
 func (f *TextFormatter) formatUser(m *UserMessage) string {
@@ -195,50 +247,24 @@ func (f *TextFormatter) formatUser(m *UserMessage) string {
 }
 
 func (f *TextFormatter) formatToolUse(m *ToolUseMessage) string {
-	var b strings.Builder
-	b.WriteString("[TOOL_USE] ")
-	b.WriteString(m.ToolUseID)
-	b.WriteString(" (")
-	b.WriteString(m.Name)
-	b.WriteString(")")
-
-	if m.Input != nil && len(m.Input) > 0 {
-		b.WriteString("\nInput: ")
-		for key, value := range m.Input {
-			b.WriteString(key)
-			b.WriteString("=")
-			b.WriteString(fmt.Sprintf("%v", value))
-			b.WriteString(" ")
-		}
+	if m == nil {
+		return ""
 	}
-	return b.String()
+	// Suppress duplicates: if the same tool_use ID was already rendered as
+	// part of an AssistantMessage bundle, drop this standalone event.
+	if f.wasAssistantToolID(m.ToolUseID) {
+		return ""
+	}
+	f.rememberToolName(m.ToolUseID, m.Name)
+	return renderToolUse(m.Name, m.Input, f.ShowToolDetails)
 }
 
 func (f *TextFormatter) formatToolResult(m *ToolResultMessage) string {
-	var b strings.Builder
-	b.WriteString("[TOOL_RESULT] ")
-	b.WriteString(m.ToolUseID)
-	b.WriteString(" [")
-	if m.IsError {
-		b.WriteString("ERROR")
-	} else {
-		b.WriteString("SUCCESS")
+	if m == nil {
+		return ""
 	}
-	b.WriteString("]")
-
-	if m.Output != "" {
-		b.WriteString("\n")
-		b.WriteString(m.Output)
-	} else if m.Content != nil {
-		for _, c := range m.Content {
-			if tr, ok := c.(*ToolResultContentBlock); ok && tr.Content != "" {
-				b.WriteString("\n")
-				b.WriteString(tr.Content)
-				break
-			}
-		}
-	}
-	return b.String()
+	name := f.consumeToolName(m.ToolUseID)
+	return renderToolResult(name, m)
 }
 
 func (f *TextFormatter) formatStreamEvent(m *StreamEventMessage) string {

--- a/agentboot/claude/formatter_test.go
+++ b/agentboot/claude/formatter_test.go
@@ -65,9 +65,6 @@ func TestTextFormatter_FormatAssistantMessage(t *testing.T) {
 		t.Fatal("Expected non-empty output")
 	}
 
-	if !contains(output, "[ASSISTANT]") {
-		t.Errorf("Expected [ASSISTANT] in output: %s", output)
-	}
 	if !contains(output, "Hello, world!") {
 		t.Errorf("Expected text content in output: %s", output)
 	}
@@ -111,14 +108,11 @@ func TestTextFormatter_FormatToolUseMessage(t *testing.T) {
 		t.Fatal("Expected non-empty output")
 	}
 
-	if !contains(output, "[TOOL_USE]") {
-		t.Errorf("Expected [TOOL_USE] in output: %s", output)
+	if !contains(output, "$ ls -la") {
+		t.Errorf("Expected formatted Bash command in output: %s", output)
 	}
-	if !contains(output, "toolu-123") {
-		t.Errorf("Expected tool use ID in output: %s", output)
-	}
-	if !contains(output, "Bash") {
-		t.Errorf("Expected tool name in output: %s", output)
+	if contains(output, "toolu-123") {
+		t.Errorf("Tool use ID should not leak into user-facing output: %s", output)
 	}
 }
 
@@ -137,11 +131,11 @@ func TestTextFormatter_FormatToolResultMessage(t *testing.T) {
 		t.Fatal("Expected non-empty output")
 	}
 
-	if !contains(output, "[TOOL_RESULT]") {
-		t.Errorf("Expected [TOOL_RESULT] in output: %s", output)
+	if !contains(output, "✓") {
+		t.Errorf("Expected ✓ marker in output: %s", output)
 	}
-	if !contains(output, "SUCCESS") {
-		t.Errorf("Expected SUCCESS in output: %s", output)
+	if contains(output, "toolu-123") {
+		t.Errorf("Tool use ID should not leak into user-facing output: %s", output)
 	}
 }
 
@@ -237,11 +231,11 @@ func TestTextFormatter_ShowToolDetails(t *testing.T) {
 
 	output := formatter.Format(msg)
 	t.Logf("Tool use output: %q", output)
-	if !contains(output, "[TOOL]") {
-		t.Errorf("Expected [TOOL] in output when ShowToolDetails: %s", output)
+	if !contains(output, "$") {
+		t.Errorf("Expected Bash $ marker in output when ShowToolDetails: %s", output)
 	}
-	if !contains(output, "Bash") {
-		t.Errorf("Expected tool name in output: %s", output)
+	if contains(output, "toolu-123") {
+		t.Errorf("Tool use ID should not leak: %s", output)
 	}
 }
 
@@ -268,13 +262,12 @@ func TestTextFormatter_ShowToolDetailsWithInput(t *testing.T) {
 
 	output := formatter.Format(msg)
 	t.Logf("Tool use with input output: %q", output)
-	if !contains(output, "[TOOL]") {
-		t.Errorf("Expected [TOOL] in output: %s", output)
+	if !contains(output, "$ ls -la") {
+		t.Errorf("Expected Bash command in output: %s", output)
 	}
-	if !contains(output, "Bash") {
-		t.Errorf("Expected tool name in output: %s", output)
+	if !contains(output, "List files") {
+		t.Errorf("Expected description in detail mode: %s", output)
 	}
-	// Note: Input is not displayed in current template, but we verify tool name is shown
 }
 
 // Test for the new template logic that checks field values instead of Type
@@ -317,11 +310,8 @@ func TestTextFormatter_MultipleContentBlocks(t *testing.T) {
 	if !contains(output, "Let me check.") {
 		t.Errorf("Expected first text: %s", output)
 	}
-	if !contains(output, "[TOOL]") {
-		t.Errorf("Expected [TOOL]: %s", output)
-	}
-	if !contains(output, "Bash") {
-		t.Errorf("Expected tool name: %s", output)
+	if !contains(output, "$") {
+		t.Errorf("Expected Bash $ marker: %s", output)
 	}
 	if !contains(output, "Done!") {
 		t.Errorf("Expected second text: %s", output)
@@ -342,11 +332,8 @@ func TestTextFormatter_ToolUseWithEmptyInput(t *testing.T) {
 	}
 
 	output := formatter.Format(msg)
-	if !contains(output, "[TOOL]") {
-		t.Errorf("Expected [TOOL] even with empty input: %s", output)
-	}
-	if !contains(output, "Bash") {
-		t.Errorf("Expected tool name: %s", output)
+	if !contains(output, "$") {
+		t.Errorf("Expected Bash $ marker even with empty input: %s", output)
 	}
 }
 
@@ -449,19 +436,11 @@ func TestTextFormatter_RealWorldAssistantMessage(t *testing.T) {
 	output := formatter.Format(&msg)
 	t.Logf("Real world assistant output:\n%s", output)
 
-	// Verify key components
-	if !contains(output, "[ASSISTANT]") {
-		t.Errorf("Expected [ASSISTANT] in output: %s", output)
+	if !contains(output, "$ ls -la") {
+		t.Errorf("Expected formatted Bash command in output: %s", output)
 	}
-	if !contains(output, "msg_202602212021386647913f511e4f49") {
-		t.Errorf("Expected message ID in output: %s", output)
-	}
-	// Check tool name is displayed
-	if !contains(output, "[TOOL]") {
-		t.Errorf("Expected [TOOL] in output: %s", output)
-	}
-	if !contains(output, "Bash") {
-		t.Errorf("Expected tool name 'Bash' in output: %s", output)
+	if contains(output, "msg_202602212021386647913f511e4f49") {
+		t.Errorf("Message ID should not leak into user-facing output: %s", output)
 	}
 }
 
@@ -513,14 +492,10 @@ func TestTextFormatter_RealWorldAssistantMessageWithExtraFields(t *testing.T) {
 	output := formatter.Format(&msg)
 	t.Logf("Real world assistant output with extra fields:\n%s", output)
 
-	// Verify key components
-	if !contains(output, "[ASSISTANT]") {
-		t.Errorf("Expected [ASSISTANT] in output: %s", output)
-	}
 	if !contains(output, "git add .") {
 		t.Errorf("Expected text content in output: %s", output)
 	}
-	if !contains(output, "msg_c09a5322-952b-4242-b743-94b1245f15ad") {
-		t.Errorf("Expected message ID in output: %s", output)
+	if contains(output, "msg_c09a5322-952b-4242-b743-94b1245f15ad") {
+		t.Errorf("Message ID should not leak into user-facing output: %s", output)
 	}
 }

--- a/agentboot/claude/tool_renderer.go
+++ b/agentboot/claude/tool_renderer.go
@@ -1,0 +1,635 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ToolRenderer renders a tool_use call to a single (possibly multi-line) string.
+type ToolRenderer func(name string, input map[string]interface{}) string
+
+// ToolResultRenderer renders a tool_result message to a single (possibly
+// multi-line) string. The tool name is looked up via ToolUseID by the formatter.
+type ToolResultRenderer func(name string, m *ToolResultMessage) string
+
+var (
+	toolRenderers       = map[string]ToolRenderer{}
+	toolResultRenderers = map[string]ToolResultRenderer{}
+)
+
+// RegisterToolRenderer registers a renderer for a tool name.
+func RegisterToolRenderer(name string, fn ToolRenderer) { toolRenderers[name] = fn }
+
+// RegisterToolResultRenderer registers a result renderer for a tool name.
+func RegisterToolResultRenderer(name string, fn ToolResultRenderer) {
+	toolResultRenderers[name] = fn
+}
+
+// renderToolUse dispatches to a per-tool renderer or falls back to a generic one.
+// detail toggles slightly more verbose per-tool output (e.g. Edit diff preview).
+func renderToolUse(name string, input map[string]interface{}, detail bool) string {
+	if fn, ok := toolRenderers[name]; ok {
+		out := fn(name, input)
+		if detail {
+			out = appendDetail(name, input, out)
+		}
+		return out
+	}
+	return renderGenericToolUse(name, input)
+}
+
+// renderToolResult dispatches to a per-tool result renderer or falls back.
+func renderToolResult(name string, m *ToolResultMessage) string {
+	if name != "" {
+		if fn, ok := toolResultRenderers[name]; ok {
+			return fn(name, m)
+		}
+	}
+	return renderGenericToolResult(name, m)
+}
+
+// ToolUseRef is a lightweight view of a tool_use block used for grouping.
+type ToolUseRef struct {
+	ID    string
+	Name  string
+	Input map[string]interface{}
+}
+
+// renderToolUseGroup renders a sequence of tool_use blocks, coalescing
+// consecutive blocks of the same groupable tool onto one line.
+func renderToolUseGroup(refs []ToolUseRef, detail bool) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	var lines []string
+	i := 0
+	for i < len(refs) {
+		j := i + 1
+		if isGroupable(refs[i].Name) && !detail {
+			for j < len(refs) && refs[j].Name == refs[i].Name {
+				j++
+			}
+		}
+		if j-i > 1 {
+			lines = append(lines, renderGroup(refs[i:j]))
+		} else {
+			lines = append(lines, renderToolUse(refs[i].Name, refs[i].Input, detail))
+		}
+		i = j
+	}
+	return strings.Join(lines, "\n")
+}
+
+func isGroupable(name string) bool {
+	switch name {
+	case "Read", "Write", "Edit", "WebFetch":
+		return true
+	}
+	return false
+}
+
+// renderGroup renders a coalesced run of same-tool blocks on one line.
+func renderGroup(refs []ToolUseRef) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	name := refs[0].Name
+	parts := make([]string, 0, len(refs))
+	for _, r := range refs {
+		parts = append(parts, "`"+basename(getStr(r.Input, "file_path"))+"`")
+	}
+	switch name {
+	case "Read":
+		return "Read " + strings.Join(parts, ", ")
+	case "Write":
+		return "Write " + strings.Join(parts, ", ")
+	case "Edit":
+		return "Edit " + strings.Join(parts, ", ")
+	case "WebFetch":
+		urls := make([]string, 0, len(refs))
+		for _, r := range refs {
+			urls = append(urls, getStr(r.Input, "url"))
+		}
+		return "Fetch " + strings.Join(urls, ", ")
+	}
+	// Unreachable given isGroupable, but be defensive.
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, renderToolUse(r.Name, r.Input, false))
+	}
+	return strings.Join(out, "\n")
+}
+
+func appendDetail(name string, input map[string]interface{}, base string) string {
+	switch name {
+	case "Edit":
+		oldS := firstLine(getStr(input, "old_string"))
+		newS := firstLine(getStr(input, "new_string"))
+		if oldS == "" && newS == "" {
+			return base
+		}
+		return base + "\n- " + truncate(oldS, 80) + "\n+ " + truncate(newS, 80)
+	case "Bash":
+		desc := getStr(input, "description")
+		if desc != "" {
+			return base + " — " + desc
+		}
+	case "TodoWrite":
+		todos := getSlice(input, "todos")
+		if len(todos) == 0 {
+			return base
+		}
+		var b strings.Builder
+		b.WriteString(base)
+		for i, t := range todos {
+			if i >= 5 {
+				break
+			}
+			tm, _ := t.(map[string]interface{})
+			b.WriteString("\n  - [")
+			b.WriteString(getStr(tm, "status"))
+			b.WriteString("] ")
+			b.WriteString(truncate(getStr(tm, "content"), 80))
+		}
+		return b.String()
+	}
+	return base
+}
+
+// ----- per-tool renderers (tool_use) -----
+
+func init() {
+	RegisterToolRenderer("Read", renderRead)
+	RegisterToolRenderer("Write", renderWrite)
+	RegisterToolRenderer("Edit", renderEdit)
+	RegisterToolRenderer("MultiEdit", renderMultiEdit)
+	RegisterToolRenderer("Bash", renderBash)
+	RegisterToolRenderer("BashOutput", renderBashOutput)
+	RegisterToolRenderer("KillBash", renderKillBash)
+	RegisterToolRenderer("KillShell", renderKillBash)
+	RegisterToolRenderer("Grep", renderGrep)
+	RegisterToolRenderer("Glob", renderGlob)
+	RegisterToolRenderer("LS", renderLS)
+	RegisterToolRenderer("WebFetch", renderWebFetch)
+	RegisterToolRenderer("WebSearch", renderWebSearch)
+	RegisterToolRenderer("Task", renderTask)
+	RegisterToolRenderer("Agent", renderTask)
+	RegisterToolRenderer("TodoWrite", renderTodoWrite)
+	RegisterToolRenderer("NotebookEdit", renderNotebookEdit)
+	RegisterToolRenderer("ExitPlanMode", renderExitPlanMode)
+	RegisterToolRenderer("SlashCommand", renderSlashCommand)
+	RegisterToolRenderer("AskUserQuestion", renderAskUserQuestion)
+
+	RegisterToolResultRenderer("Read", renderReadResult)
+	RegisterToolResultRenderer("Bash", renderBashResult)
+	RegisterToolResultRenderer("TodoWrite", renderTodoWriteResult)
+	RegisterToolResultRenderer("Grep", renderGrepResult)
+	RegisterToolResultRenderer("Glob", renderGlobResult)
+	RegisterToolResultRenderer("WebFetch", renderWebFetchResult)
+	RegisterToolResultRenderer("WebSearch", renderWebSearchResult)
+	RegisterToolResultRenderer("Edit", renderQuietResult)
+	RegisterToolResultRenderer("Write", renderQuietResult)
+	RegisterToolResultRenderer("MultiEdit", renderQuietResult)
+}
+
+func renderRead(_ string, in map[string]interface{}) string {
+	path := getStr(in, "file_path")
+	out := "Read `" + basename(path) + "`"
+	offset := getInt(in, "offset")
+	limit := getInt(in, "limit")
+	if offset > 0 || limit > 0 {
+		end := offset + limit
+		if limit == 0 {
+			end = offset
+		}
+		out += fmt.Sprintf(" L%d-%d", offset, end)
+	}
+	return out
+}
+
+func renderWrite(_ string, in map[string]interface{}) string {
+	path := getStr(in, "file_path")
+	content := getStr(in, "content")
+	lines := 0
+	if content != "" {
+		lines = strings.Count(content, "\n") + 1
+	}
+	if lines > 0 {
+		return fmt.Sprintf("Write `%s` (%d lines)", basename(path), lines)
+	}
+	return "Write `" + basename(path) + "`"
+}
+
+func renderEdit(_ string, in map[string]interface{}) string {
+	path := getStr(in, "file_path")
+	out := "Edit `" + basename(path) + "`"
+	if getBool(in, "replace_all") {
+		out += " (replace_all)"
+	}
+	return out
+}
+
+func renderMultiEdit(_ string, in map[string]interface{}) string {
+	path := getStr(in, "file_path")
+	edits := getSlice(in, "edits")
+	return fmt.Sprintf("MultiEdit `%s` (%d edits)", basename(path), len(edits))
+}
+
+func renderBash(_ string, in map[string]interface{}) string {
+	cmd := singleLine(getStr(in, "command"))
+	return "`$ " + truncate(cmd, 160) + "`"
+}
+
+func renderBashOutput(_ string, in map[string]interface{}) string {
+	id := getStr(in, "bash_id")
+	out := "BashOutput " + id
+	if f := getStr(in, "filter"); f != "" {
+		out += " /" + f + "/"
+	}
+	return out
+}
+
+func renderKillBash(name string, in map[string]interface{}) string {
+	id := getStr(in, "shell_id")
+	if id == "" {
+		id = getStr(in, "bash_id")
+	}
+	return name + " " + id
+}
+
+func renderGrep(_ string, in map[string]interface{}) string {
+	pattern := getStr(in, "pattern")
+	path := getStr(in, "path")
+	if path == "" {
+		path = "."
+	}
+	out := fmt.Sprintf("Grep /%s/ in `%s`", pattern, path)
+	if g := getStr(in, "glob"); g != "" {
+		out += " glob=" + g
+	}
+	if mode := getStr(in, "output_mode"); mode != "" {
+		out += " mode=" + mode
+	}
+	return out
+}
+
+func renderGlob(_ string, in map[string]interface{}) string {
+	pattern := getStr(in, "pattern")
+	out := "Glob " + pattern
+	if path := getStr(in, "path"); path != "" {
+		out += " in `" + path + "`"
+	}
+	return out
+}
+
+func renderLS(_ string, in map[string]interface{}) string {
+	return "LS `" + getStr(in, "path") + "`"
+}
+
+func renderWebFetch(_ string, in map[string]interface{}) string {
+	return "Fetch " + getStr(in, "url")
+}
+
+func renderWebSearch(_ string, in map[string]interface{}) string {
+	return `Search "` + getStr(in, "query") + `"`
+}
+
+func renderTask(_ string, in map[string]interface{}) string {
+	subagent := getStr(in, "subagent_type")
+	desc := truncate(getStr(in, "description"), 80)
+	if subagent == "" {
+		return "Task " + desc
+	}
+	return "Task " + subagent + ": " + desc
+}
+
+func renderTodoWrite(_ string, in map[string]interface{}) string {
+	todos := getSlice(in, "todos")
+	return fmt.Sprintf("Todos: %d items", len(todos))
+}
+
+func renderNotebookEdit(_ string, in map[string]interface{}) string {
+	path := getStr(in, "notebook_path")
+	cell := getStr(in, "cell_id")
+	mode := getStr(in, "edit_mode")
+	out := "NotebookEdit `" + basename(path) + "`"
+	if cell != "" {
+		out += " cell=" + cell
+	}
+	if mode != "" {
+		out += " mode=" + mode
+	}
+	return out
+}
+
+func renderExitPlanMode(_ string, in map[string]interface{}) string {
+	plan := getStr(in, "plan")
+	return fmt.Sprintf("Plan ready (%d chars)", len(plan))
+}
+
+func renderSlashCommand(_ string, in map[string]interface{}) string {
+	cmd := getStr(in, "command")
+	if cmd == "" {
+		return "SlashCommand"
+	}
+	return "/" + strings.TrimPrefix(cmd, "/")
+}
+
+func renderAskUserQuestion(_ string, in map[string]interface{}) string {
+	q := truncate(firstLine(getStr(in, "question")), 100)
+	if q == "" {
+		// Newer schema uses "questions" array.
+		if qs := getSlice(in, "questions"); len(qs) > 0 {
+			if first, ok := qs[0].(map[string]interface{}); ok {
+				q = truncate(firstLine(getStr(first, "question")), 100)
+			}
+		}
+	}
+	if q == "" {
+		return "Ask"
+	}
+	return "Ask: " + q
+}
+
+// renderGenericToolUse formats unknown tools without a JSON dump.
+func renderGenericToolUse(name string, in map[string]interface{}) string {
+	if len(in) == 0 {
+		return name
+	}
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+truncate(stringifyValue(in[k]), 60))
+	}
+	out := name + ": " + strings.Join(parts, " ")
+	return truncate(out, 200)
+}
+
+// ----- per-tool renderers (tool_result) -----
+
+func renderReadResult(_ string, m *ToolResultMessage) string {
+	body := resultBody(m)
+	if m.IsError {
+		return "Read ✗: " + truncate(firstLine(body), 120)
+	}
+	lines := strings.Count(body, "\n") + 1
+	if body == "" {
+		lines = 0
+	}
+	return fmt.Sprintf("Read ✓ (%d lines)", lines)
+}
+
+func renderBashResult(_ string, m *ToolResultMessage) string {
+	body := resultBody(m)
+	mark := "✓"
+	if m.IsError {
+		mark = "✗"
+	}
+	if body == "" {
+		return "Bash " + mark
+	}
+	tail, more := lastNLines(body, 3)
+	out := "Bash " + mark + "\n" + tail
+	if more > 0 {
+		out += fmt.Sprintf("\n… (+%d more lines)", more)
+	}
+	return out
+}
+
+func renderTodoWriteResult(_ string, m *ToolResultMessage) string {
+	if m.IsError {
+		return "Todos ✗: " + truncate(firstLine(resultBody(m)), 120)
+	}
+	return "Todos updated"
+}
+
+func renderGrepResult(_ string, m *ToolResultMessage) string {
+	body := resultBody(m)
+	if m.IsError {
+		return "Grep ✗: " + truncate(firstLine(body), 120)
+	}
+	if body == "" {
+		return "Grep ✓: 0 matches"
+	}
+	lines := strings.Split(body, "\n")
+	n := len(lines)
+	if lines[n-1] == "" {
+		n--
+	}
+	preview, more := firstNLines(body, 3)
+	out := fmt.Sprintf("Grep ✓: %d matches", n)
+	if preview != "" {
+		out += "\n" + preview
+	}
+	if more > 0 {
+		out += fmt.Sprintf("\n… (+%d more)", more)
+	}
+	return out
+}
+
+func renderGlobResult(_ string, m *ToolResultMessage) string {
+	body := resultBody(m)
+	if m.IsError {
+		return "Glob ✗: " + truncate(firstLine(body), 120)
+	}
+	if body == "" {
+		return "Glob ✓: 0 matches"
+	}
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	preview, more := firstNLines(body, 3)
+	out := fmt.Sprintf("Glob ✓: %d matches\n%s", len(lines), preview)
+	if more > 0 {
+		out += fmt.Sprintf("\n… (+%d more)", more)
+	}
+	return out
+}
+
+func renderWebFetchResult(_ string, m *ToolResultMessage) string {
+	if m.IsError {
+		return "Fetch ✗: " + truncate(firstLine(resultBody(m)), 120)
+	}
+	return "Fetch ✓: " + truncate(singleLine(resultBody(m)), 200)
+}
+
+func renderWebSearchResult(_ string, m *ToolResultMessage) string {
+	if m.IsError {
+		return "Search ✗: " + truncate(firstLine(resultBody(m)), 120)
+	}
+	return "Search ✓: " + truncate(firstLine(resultBody(m)), 200)
+}
+
+// renderQuietResult is used by Edit/Write/MultiEdit: only print on error.
+func renderQuietResult(name string, m *ToolResultMessage) string {
+	if m.IsError {
+		return name + " ✗: " + truncate(firstLine(resultBody(m)), 120)
+	}
+	return ""
+}
+
+// renderGenericToolResult is the fallback for tools without a result renderer.
+func renderGenericToolResult(name string, m *ToolResultMessage) string {
+	mark := "✓"
+	if m.IsError {
+		mark = "✗"
+	}
+	prefix := "Result"
+	if name != "" {
+		prefix = name
+	}
+	body := resultBody(m)
+	if body == "" {
+		return prefix + " " + mark
+	}
+	preview, more := firstNLines(body, 5)
+	out := prefix + " " + mark + "\n" + preview
+	if more > 0 {
+		out += fmt.Sprintf("\n… (+%d more lines)", more)
+	}
+	return out
+}
+
+// resultBody returns the textual body of a ToolResultMessage, preferring the
+// explicit Output field but falling back to ToolResultContentBlock content.
+func resultBody(m *ToolResultMessage) string {
+	if m == nil {
+		return ""
+	}
+	if m.Output != "" {
+		return m.Output
+	}
+	for _, c := range m.Content {
+		if tr, ok := c.(*ToolResultContentBlock); ok && tr.Content != "" {
+			return tr.Content
+		}
+	}
+	return ""
+}
+
+// ----- helpers -----
+
+// inputFromRaw converts a json.RawMessage / interface{} input shape (as used
+// by anthropic.ContentBlockUnion) into a map[string]interface{}.
+// Returns nil on any error or non-object payload.
+func inputFromRaw(v any) map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	if m, ok := v.(map[string]interface{}); ok {
+		return m
+	}
+	var data []byte
+	switch x := v.(type) {
+	case json.RawMessage:
+		data = x
+	case []byte:
+		data = x
+	case string:
+		data = []byte(x)
+	default:
+		var err error
+		data, err = json.Marshal(x)
+		if err != nil {
+			return nil
+		}
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// getStr is a thin wrapper around the package-level getString that tolerates a
+// nil map (callers in this file frequently receive nil from inputFromRaw).
+func getStr(m map[string]interface{}, k string) string {
+	if m == nil {
+		return ""
+	}
+	return getString(m, k)
+}
+
+func getSlice(m map[string]interface{}, k string) []interface{} {
+	if m == nil {
+		return nil
+	}
+	if s, ok := m[k].([]interface{}); ok {
+		return s
+	}
+	return nil
+}
+
+func basename(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.Base(p)
+}
+
+func truncate(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func singleLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.TrimSpace(s)
+}
+
+// firstNLines returns the first n lines and the count of remaining lines.
+func firstNLines(s string, n int) (string, int) {
+	if s == "" || n <= 0 {
+		return "", 0
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n"), 0
+	}
+	return strings.Join(lines[:n], "\n"), len(lines) - n
+}
+
+// lastNLines returns the last n lines and the count of preceding (omitted) lines.
+func lastNLines(s string, n int) (string, int) {
+	if s == "" || n <= 0 {
+		return "", 0
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n"), 0
+	}
+	return strings.Join(lines[len(lines)-n:], "\n"), len(lines) - n
+}
+
+func stringifyValue(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}

--- a/agentboot/claude/tool_renderer_test.go
+++ b/agentboot/claude/tool_renderer_test.go
@@ -1,0 +1,535 @@
+package claude
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+func TestRenderToolUse_NativeTools(t *testing.T) {
+	tests := []struct {
+		name            string
+		tool            string
+		input           map[string]interface{}
+		detail          bool
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:         "Read basic",
+			tool:         "Read",
+			input:        map[string]interface{}{"file_path": "/repo/main.go"},
+			wantContains: []string{"Read", "main.go"},
+		},
+		{
+			name:         "Read with offset/limit",
+			tool:         "Read",
+			input:        map[string]interface{}{"file_path": "/repo/main.go", "offset": float64(10), "limit": float64(20)},
+			wantContains: []string{"Read", "main.go", "L10-30"},
+		},
+		{
+			name:         "Write with content",
+			tool:         "Write",
+			input:        map[string]interface{}{"file_path": "/x/y.go", "content": "line1\nline2\nline3"},
+			wantContains: []string{"Write", "y.go", "3 lines"},
+		},
+		{
+			name:         "Edit basic",
+			tool:         "Edit",
+			input:        map[string]interface{}{"file_path": "/x/y.go", "old_string": "a", "new_string": "b"},
+			wantContains: []string{"Edit", "y.go"},
+		},
+		{
+			name:         "Edit replace_all",
+			tool:         "Edit",
+			input:        map[string]interface{}{"file_path": "/x/y.go", "old_string": "a", "new_string": "b", "replace_all": true},
+			wantContains: []string{"Edit", "y.go", "replace_all"},
+		},
+		{
+			name:         "Edit detail mode shows diff preview",
+			tool:         "Edit",
+			input:        map[string]interface{}{"file_path": "/x/y.go", "old_string": "fooLine", "new_string": "barLine"},
+			detail:       true,
+			wantContains: []string{"Edit", "y.go", "- fooLine", "+ barLine"},
+		},
+		{
+			name:         "MultiEdit",
+			tool:         "MultiEdit",
+			input:        map[string]interface{}{"file_path": "/x/y.go", "edits": []interface{}{1, 2, 3}},
+			wantContains: []string{"MultiEdit", "y.go", "3 edits"},
+		},
+		{
+			name:            "Bash short",
+			tool:            "Bash",
+			input:           map[string]interface{}{"command": "ls -la", "description": "List files"},
+			wantContains:    []string{"$ ls -la"},
+			wantNotContains: []string{"List files"}, // description hidden by default
+		},
+		{
+			name:         "Bash detail shows description",
+			tool:         "Bash",
+			input:        map[string]interface{}{"command": "ls -la", "description": "List files"},
+			detail:       true,
+			wantContains: []string{"$ ls -la", "List files"},
+		},
+		{
+			name:         "Bash long command truncated",
+			tool:         "Bash",
+			input:        map[string]interface{}{"command": strings.Repeat("a", 300)},
+			wantContains: []string{"$"},
+		},
+		{
+			name:         "Bash multi-line collapsed",
+			tool:         "Bash",
+			input:        map[string]interface{}{"command": "echo hi\nrm -rf /tmp/foo"},
+			wantContains: []string{"$ echo hi rm -rf /tmp/foo"},
+		},
+		{
+			name:         "BashOutput with filter",
+			tool:         "BashOutput",
+			input:        map[string]interface{}{"bash_id": "shell_1", "filter": "error"},
+			wantContains: []string{"BashOutput", "shell_1", "/error/"},
+		},
+		{
+			name:         "KillBash",
+			tool:         "KillBash",
+			input:        map[string]interface{}{"shell_id": "shell_2"},
+			wantContains: []string{"KillBash", "shell_2"},
+		},
+		{
+			name:         "Grep with all options",
+			tool:         "Grep",
+			input:        map[string]interface{}{"pattern": "func", "path": "src/", "glob": "*.go", "output_mode": "files_with_matches"},
+			wantContains: []string{"Grep", "/func/", "src/", "glob=*.go", "mode=files_with_matches"},
+		},
+		{
+			name:         "Grep default path",
+			tool:         "Grep",
+			input:        map[string]interface{}{"pattern": "todo"},
+			wantContains: []string{"Grep", "/todo/", "."},
+		},
+		{
+			name:         "Glob with path",
+			tool:         "Glob",
+			input:        map[string]interface{}{"pattern": "**/*.go", "path": "internal/"},
+			wantContains: []string{"Glob", "**/*.go", "internal/"},
+		},
+		{
+			name:         "WebFetch",
+			tool:         "WebFetch",
+			input:        map[string]interface{}{"url": "https://example.com"},
+			wantContains: []string{"Fetch", "https://example.com"},
+		},
+		{
+			name:         "WebSearch",
+			tool:         "WebSearch",
+			input:        map[string]interface{}{"query": "golang fmt"},
+			wantContains: []string{`Search "golang fmt"`},
+		},
+		{
+			name:         "Task",
+			tool:         "Task",
+			input:        map[string]interface{}{"subagent_type": "Explore", "description": "Find usages"},
+			wantContains: []string{"Task", "Explore", "Find usages"},
+		},
+		{
+			name:         "TodoWrite count only",
+			tool:         "TodoWrite",
+			input:        map[string]interface{}{"todos": []interface{}{map[string]interface{}{"content": "a", "status": "pending"}, map[string]interface{}{"content": "b", "status": "in_progress"}}},
+			wantContains: []string{"Todos", "2 items"},
+		},
+		{
+			name:   "TodoWrite detail lists items",
+			tool:   "TodoWrite",
+			detail: true,
+			input: map[string]interface{}{
+				"todos": []interface{}{
+					map[string]interface{}{"content": "Task one", "status": "pending"},
+					map[string]interface{}{"content": "Task two", "status": "in_progress"},
+				},
+			},
+			wantContains: []string{"Todos", "2 items", "[pending] Task one", "[in_progress] Task two"},
+		},
+		{
+			name:         "NotebookEdit",
+			tool:         "NotebookEdit",
+			input:        map[string]interface{}{"notebook_path": "/n/foo.ipynb", "cell_id": "c1", "edit_mode": "replace"},
+			wantContains: []string{"NotebookEdit", "foo.ipynb", "cell=c1", "mode=replace"},
+		},
+		{
+			name:         "ExitPlanMode",
+			tool:         "ExitPlanMode",
+			input:        map[string]interface{}{"plan": "step 1\nstep 2"},
+			wantContains: []string{"Plan ready", "13 chars"},
+		},
+		{
+			name:         "SlashCommand without prefix",
+			tool:         "SlashCommand",
+			input:        map[string]interface{}{"command": "review"},
+			wantContains: []string{"/review"},
+		},
+		{
+			name:         "SlashCommand with prefix",
+			tool:         "SlashCommand",
+			input:        map[string]interface{}{"command": "/review"},
+			wantContains: []string{"/review"},
+		},
+		{
+			name:         "AskUserQuestion legacy",
+			tool:         "AskUserQuestion",
+			input:        map[string]interface{}{"question": "Which option?"},
+			wantContains: []string{"Ask", "Which option?"},
+		},
+		{
+			name: "AskUserQuestion array form",
+			tool: "AskUserQuestion",
+			input: map[string]interface{}{
+				"questions": []interface{}{
+					map[string]interface{}{"question": "Pick one"},
+				},
+			},
+			wantContains: []string{"Ask", "Pick one"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderToolUse(tt.tool, tt.input, tt.detail)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected output to contain %q\ngot: %q", want, got)
+				}
+			}
+			for _, no := range tt.wantNotContains {
+				if strings.Contains(got, no) {
+					t.Errorf("expected output to NOT contain %q\ngot: %q", no, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderToolUse_GenericFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		tool         string
+		input        map[string]interface{}
+		wantContains []string
+	}{
+		{
+			name:         "no input",
+			tool:         "MysteryTool",
+			input:        nil,
+			wantContains: []string{"MysteryTool"},
+		},
+		{
+			name:         "with input sorted",
+			tool:         "Custom",
+			input:        map[string]interface{}{"zeta": "z", "alpha": "a"},
+			wantContains: []string{"Custom", "alpha=a", "zeta=z"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderToolUse(tt.tool, tt.input, false)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected %q in %q", want, got)
+				}
+			}
+		})
+	}
+
+	// Sorted ordering check
+	got := renderToolUse("Custom", map[string]interface{}{"zeta": "z", "alpha": "a", "mid": "m"}, false)
+	if i, j, k := strings.Index(got, "alpha"), strings.Index(got, "mid"), strings.Index(got, "zeta"); !(i < j && j < k) {
+		t.Errorf("expected keys in sorted order: %q", got)
+	}
+}
+
+func TestRenderToolUse_MissingFields(t *testing.T) {
+	// Each native tool called with empty input should produce non-empty output
+	// without panicking. We don't assert specific text; just no crash and a name.
+	tools := []string{
+		"Read", "Write", "Edit", "MultiEdit", "Bash", "BashOutput", "KillBash",
+		"Grep", "Glob", "LS", "WebFetch", "WebSearch", "Task", "TodoWrite",
+		"NotebookEdit", "ExitPlanMode", "SlashCommand", "AskUserQuestion",
+	}
+	for _, name := range tools {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic in %s: %v", name, r)
+				}
+			}()
+			out := renderToolUse(name, nil, false)
+			if out == "" {
+				t.Errorf("expected non-empty fallback output for %s", name)
+			}
+		})
+	}
+}
+
+func TestRenderToolUseGroup_GroupsConsecutive(t *testing.T) {
+	refs := []ToolUseRef{
+		{ID: "1", Name: "Read", Input: map[string]interface{}{"file_path": "a.go"}},
+		{ID: "2", Name: "Read", Input: map[string]interface{}{"file_path": "b.go"}},
+		{ID: "3", Name: "Bash", Input: map[string]interface{}{"command": "ls"}},
+		{ID: "4", Name: "Read", Input: map[string]interface{}{"file_path": "c.go"}},
+	}
+	got := renderToolUseGroup(refs, false)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (Read x2, Bash, Read), got %d:\n%s", len(lines), got)
+	}
+	if !strings.Contains(lines[0], "a.go") || !strings.Contains(lines[0], "b.go") {
+		t.Errorf("first line should group reads of a.go and b.go: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "$ ls") {
+		t.Errorf("second line should be Bash: %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "c.go") || strings.Contains(lines[2], "a.go") {
+		t.Errorf("third line should be standalone Read of c.go: %q", lines[2])
+	}
+}
+
+func TestRenderToolUseGroup_DetailDisablesGrouping(t *testing.T) {
+	// In detail mode each Read should be on its own line so the diff/preview
+	// per-call is preserved.
+	refs := []ToolUseRef{
+		{ID: "1", Name: "Read", Input: map[string]interface{}{"file_path": "a.go"}},
+		{ID: "2", Name: "Read", Input: map[string]interface{}{"file_path": "b.go"}},
+	}
+	got := renderToolUseGroup(refs, true)
+	if lines := strings.Split(got, "\n"); len(lines) != 2 {
+		t.Fatalf("expected 2 lines in detail mode, got %d:\n%s", len(lines), got)
+	}
+}
+
+func TestRenderToolResult_PerTool(t *testing.T) {
+	tests := []struct {
+		name         string
+		tool         string
+		msg          *ToolResultMessage
+		wantContains []string
+	}{
+		{
+			name:         "Read success",
+			tool:         "Read",
+			msg:          &ToolResultMessage{Output: "line1\nline2\nline3"},
+			wantContains: []string{"Read ✓", "3 lines"},
+		},
+		{
+			name:         "Read error",
+			tool:         "Read",
+			msg:          &ToolResultMessage{Output: "no such file", IsError: true},
+			wantContains: []string{"Read ✗", "no such file"},
+		},
+		{
+			name:         "Bash success short",
+			tool:         "Bash",
+			msg:          &ToolResultMessage{Output: "hello\nworld"},
+			wantContains: []string{"Bash ✓", "hello", "world"},
+		},
+		{
+			name:         "Bash success long truncated",
+			tool:         "Bash",
+			msg:          &ToolResultMessage{Output: "a\nb\nc\nd\ne\nf\ng"},
+			wantContains: []string{"Bash ✓", "e", "f", "g", "+4 more"},
+		},
+		{
+			name:         "TodoWrite success",
+			tool:         "TodoWrite",
+			msg:          &ToolResultMessage{Output: "ignored noisy json"},
+			wantContains: []string{"Todos updated"},
+		},
+		{
+			name:         "Grep with matches",
+			tool:         "Grep",
+			msg:          &ToolResultMessage{Output: "a.go\nb.go\nc.go\nd.go"},
+			wantContains: []string{"Grep ✓", "4 matches", "a.go", "+1 more"},
+		},
+		{
+			name:         "Edit success silent",
+			tool:         "Edit",
+			msg:          &ToolResultMessage{Output: "File edited"},
+			wantContains: nil, // expects empty output — see direct check below
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderToolResult(tt.tool, tt.msg)
+			if tt.name == "Edit success silent" {
+				if got != "" {
+					t.Errorf("Edit success should be silent, got %q", got)
+				}
+				return
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected %q in %q", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderToolResult_GenericFallback(t *testing.T) {
+	m := &ToolResultMessage{Output: strings.Repeat("line\n", 20)}
+	got := renderToolResult("UnknownTool", m)
+	if !strings.Contains(got, "UnknownTool ✓") {
+		t.Errorf("expected tool name and ✓: %q", got)
+	}
+	if !strings.Contains(got, "+15 more lines") {
+		t.Errorf("expected truncation marker: %q", got)
+	}
+	// Error branch
+	got = renderToolResult("UnknownTool", &ToolResultMessage{Output: "boom", IsError: true})
+	if !strings.Contains(got, "✗") {
+		t.Errorf("expected ✗ marker: %q", got)
+	}
+}
+
+func TestRenderToolResult_NoTrackedNameUsesGeneric(t *testing.T) {
+	got := renderToolResult("", &ToolResultMessage{Output: "ok"})
+	if !strings.Contains(got, "Result") {
+		t.Errorf("expected generic 'Result' prefix when name is empty: %q", got)
+	}
+}
+
+func TestFormatter_AssistantBundlesTextAndTools(t *testing.T) {
+	f := NewTextFormatter()
+	msg := &AssistantMessage{
+		Type: SDKAssistantMessage,
+		Message: anthropic.Message{
+			Content: []anthropic.ContentBlockUnion{
+				{Type: "text", Text: "Reading both files."},
+				{Type: "tool_use", ID: "T1", Name: "Read", Input: []byte(`{"file_path":"/x/a.go"}`)},
+				{Type: "tool_use", ID: "T2", Name: "Read", Input: []byte(`{"file_path":"/x/b.go"}`)},
+			},
+		},
+	}
+	got := f.Format(msg)
+	if !strings.Contains(got, "Reading both files.") {
+		t.Errorf("expected text content: %q", got)
+	}
+	if !strings.Contains(got, "a.go") || !strings.Contains(got, "b.go") {
+		t.Errorf("expected grouped Read line for a.go,b.go: %q", got)
+	}
+	// Text should appear before the tool line.
+	if i, j := strings.Index(got, "Reading both"), strings.Index(got, "a.go"); !(i >= 0 && i < j) {
+		t.Errorf("text should precede tools: %q", got)
+	}
+	// IDs should not be present in user-facing output.
+	if strings.Contains(got, "T1") || strings.Contains(got, "T2") {
+		t.Errorf("tool_use IDs leaked into output: %q", got)
+	}
+}
+
+func TestFormatter_StandaloneToolUseSuppressedAfterAssistant(t *testing.T) {
+	f := NewTextFormatter()
+	asm := &AssistantMessage{
+		Type: SDKAssistantMessage,
+		Message: anthropic.Message{
+			Content: []anthropic.ContentBlockUnion{
+				{Type: "tool_use", ID: "TX", Name: "Read", Input: []byte(`{"file_path":"/x/a.go"}`)},
+			},
+		},
+	}
+	if out := f.Format(asm); out == "" {
+		t.Fatalf("expected non-empty assistant output")
+	}
+	dup := &ToolUseMessage{ToolUseID: "TX", Name: "Read", Input: map[string]interface{}{"file_path": "/x/a.go"}}
+	if out := f.Format(dup); out != "" {
+		t.Errorf("expected duplicate standalone ToolUseMessage to be suppressed, got %q", out)
+	}
+}
+
+func TestFormatter_StandaloneToolUseShownIfNotInAssistant(t *testing.T) {
+	f := NewTextFormatter()
+	msg := &ToolUseMessage{ToolUseID: "T_NEW", Name: "Bash", Input: map[string]interface{}{"command": "echo hi"}}
+	out := f.Format(msg)
+	if !strings.Contains(out, "$ echo hi") {
+		t.Errorf("expected standalone ToolUseMessage to render, got %q", out)
+	}
+}
+
+func TestFormatter_ToolNameCorrelation(t *testing.T) {
+	f := NewTextFormatter()
+	asm := &AssistantMessage{
+		Type: SDKAssistantMessage,
+		Message: anthropic.Message{
+			Content: []anthropic.ContentBlockUnion{
+				{Type: "tool_use", ID: "T1", Name: "Read", Input: []byte(`{"file_path":"/x/a.go"}`)},
+			},
+		},
+	}
+	_ = f.Format(asm)
+
+	res := &ToolResultMessage{ToolUseID: "T1", Output: "line1\nline2"}
+	got := f.Format(res)
+	if !strings.Contains(got, "Read ✓") {
+		t.Errorf("expected Read-specific result rendering, got %q", got)
+	}
+	if !strings.Contains(got, "2 lines") {
+		t.Errorf("expected line count from Read renderer, got %q", got)
+	}
+
+	// Unknown ID falls back to generic.
+	got = f.Format(&ToolResultMessage{ToolUseID: "UNKNOWN", Output: "ok"})
+	if !strings.Contains(got, "Result") {
+		t.Errorf("expected generic fallback for unknown ID, got %q", got)
+	}
+}
+
+func TestFormatter_ConcurrentToolNameMap(t *testing.T) {
+	f := NewTextFormatter()
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := "id" + string(rune('A'+i%26))
+			f.rememberToolName(id, "Read")
+			_ = f.lookupToolName(id)
+			_ = f.consumeToolName(id)
+			f.markAssistantToolID(id)
+			_ = f.wasAssistantToolID(id)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestInputFromRaw(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"raw bytes", []byte(`{"file_path":"/a.go"}`), "/a.go"},
+		{"json.RawMessage", anthropicRawJSON(`{"file_path":"/a.go"}`), "/a.go"},
+		{"string", `{"file_path":"/a.go"}`, "/a.go"},
+		{"already a map", map[string]interface{}{"file_path": "/a.go"}, "/a.go"},
+		{"non-object json", []byte(`"hello"`), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := inputFromRaw(tc.in)
+			if tc.want == "" {
+				if got := getStr(m, "file_path"); got != "" {
+					t.Errorf("expected empty file_path, got %q (m=%v)", got, m)
+				}
+				return
+			}
+			if got := getStr(m, "file_path"); got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// anthropicRawJSON is a tiny helper to avoid importing encoding/json here.
+func anthropicRawJSON(s string) []byte { return []byte(s) }


### PR DESCRIPTION
The remote control bot relied on a generic key=value dump for every tool_use and a raw output dump for every tool_result, producing noisy, opaque messages in Telegram and other IM platforms. Tool calls bundled inside an AssistantMessage were either dropped (ShowToolDetails defaults to false) or duplicated by the SDK's standalone ToolUseMessage events.

This change adds a tool renderer registry in agentboot/claude with curated, one-line formats for the native Claude Code tools (Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch, Task, TodoWrite, NotebookEdit, BashOutput, KillBash, ExitPlanMode, SlashCommand, AskUserQuestion, ...) and a clean generic fallback for unknown tools. The formatter now bundles assistant text and grouped tool-call summaries into a single message, coalesces consecutive same-tool calls (Read a, b, c on one line), and dedups standalone ToolUseMessage events against IDs already rendered in an AssistantMessage. Tool results correlate via ToolUseID -> tool name (small map guarded by the existing formatter mutex) so per-tool result renderers run for Read/Bash/Grep/etc.

Opaque toolu_xxx IDs are no longer surfaced in user-facing output. ShowToolDetails now controls whether per-tool detail (Edit diff preview, Bash description, TodoWrite item list) is appended.

https://claude.ai/code/session_01KgDYijHoZ5TRwDmMmyDoWF

<img width="900" height="1052" alt="image" src="https://github.com/user-attachments/assets/ba1b4edd-a0cf-4720-ae91-c903278b4f41" />