### PR TITLE
Fix guardrails command matching and blocked tool-use stream handling

### DIFF
--- a/internal/guardrails/core/command_shell_test.go
+++ b/internal/guardrails/core/command_shell_test.go
@@ -114,7 +114,7 @@ func TestCommandAttachDerivedFieldsBuildsShellAndNormalizedViews(t *testing.T) {
 	if cmd.Normalized.Kind != "shell" {
 		t.Fatalf("expected shell kind, got %q", cmd.Normalized.Kind)
 	}
-	if !reflect.DeepEqual(cmd.Normalized.Actions, []string{"read"}) {
+	if !reflect.DeepEqual(cmd.Normalized.Actions, []string{"execute", "read"}) {
 		t.Fatalf("unexpected normalized actions: %#v", cmd.Normalized.Actions)
 	}
 	if !reflect.DeepEqual(cmd.Normalized.Resources, []string{"~/.ssh"}) {

--- a/internal/guardrails/evaluate/operation_policy.go
+++ b/internal/guardrails/evaluate/operation_policy.go
@@ -181,5 +181,14 @@ func sliceContainsPattern(values, patterns []string) bool {
 			}
 		}
 	}
+	if len(values) == 0 {
+		return false
+	}
+	joined := strings.ToLower(strings.Join(values, " "))
+	for _, pattern := range patterns {
+		if strings.Contains(joined, strings.ToLower(pattern)) {
+			return true
+		}
+	}
 	return false
 }

--- a/internal/guardrails/evaluate/operation_policy_test.go
+++ b/internal/guardrails/evaluate/operation_policy_test.go
@@ -80,3 +80,36 @@ func TestOperationPolicyDoesNotBlockNonSSHRead(t *testing.T) {
 		t.Fatalf("expected allow, got %s", res.Verdict)
 	}
 }
+
+func TestOperationPolicyBlocksMultiTokenCommandPattern(t *testing.T) {
+	policy, err := NewOperationPolicy(
+		"block-destructive-rm",
+		"Block destructive rm",
+		true,
+		guardrailscore.Scope{},
+		CommandPolicyConfig{
+			Terms:   []string{"rm -rf"},
+			Actions: []string{"execute"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("new policy: %v", err)
+	}
+
+	res, err := policy.Evaluate(context.Background(), guardrailscore.Input{
+		Content: guardrailscore.Content{
+			Command: &guardrailscore.Command{
+				Name: "bash",
+				Arguments: map[string]interface{}{
+					"command": "rm -rf /tmp/demo",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if res.Verdict != guardrailscore.VerdictBlock {
+		t.Fatalf("expected block, got %s", res.Verdict)
+	}
+}

--- a/internal/guardrails/mutate/anthropic_stream.go
+++ b/internal/guardrails/mutate/anthropic_stream.go
@@ -12,6 +12,7 @@ const (
 	anthropicEventTypeContentBlockStart = "content_block_start"
 	anthropicEventTypeContentBlockDelta = "content_block_delta"
 	anthropicEventTypeContentBlockStop  = "content_block_stop"
+	anthropicEventTypeMessageDelta      = "message_delta"
 	anthropicDeltaTypeInputJSONDelta    = "input_json_delta"
 )
 
@@ -96,6 +97,9 @@ func RewriteAnthropicToolUseEvent(
 		if decision.BlockMessage == "" {
 			return true, nil, nil
 		}
+		if streamState != nil {
+			streamState.RewroteBlockedToolUse = true
+		}
 		return true, []AnthropicBufferedEvent{
 			{
 				EventType: anthropicEventTypeContentBlockStart,
@@ -157,6 +161,10 @@ func ShouldRewriteAnthropicEvent(state *protocol.GuardrailsStreamState, eventTyp
 			if hasBuffered {
 				return true
 			}
+		}
+	case anthropicEventTypeMessageDelta:
+		if state != nil && state.RewroteBlockedToolUse {
+			return true
 		}
 	}
 	return false
@@ -229,6 +237,26 @@ func HandleAnthropicToolUseBuffer(credentialMask *guardrailscore.CredentialMaskS
 		return AnthropicToolUseDecision{
 			Kind:        AnthropicToolUseDecisionPassthrough,
 			Passthrough: buffered,
+		}
+	case anthropicEventTypeMessageDelta:
+		if !streamState.RewroteBlockedToolUse {
+			return AnthropicToolUseDecision{}
+		}
+		streamState.RewroteBlockedToolUse = false
+		payload := cloneAnthropicEventPayload(eventMap)
+		delta, _ := payload["delta"].(map[string]interface{})
+		if delta == nil {
+			delta = map[string]interface{}{}
+			payload["delta"] = delta
+		}
+		if stopReason, _ := delta["stop_reason"].(string); stopReason == "tool_use" {
+			delta["stop_reason"] = "end_turn"
+		}
+		return AnthropicToolUseDecision{
+			Kind: AnthropicToolUseDecisionPassthrough,
+			Passthrough: []AnthropicBufferedEvent{
+				{EventType: anthropicEventTypeMessageDelta, Payload: payload},
+			},
 		}
 	}
 	return AnthropicToolUseDecision{}

--- a/internal/guardrails/mutate/anthropic_stream_test.go
+++ b/internal/guardrails/mutate/anthropic_stream_test.go
@@ -1,0 +1,41 @@
+package mutate
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+func TestHandleAnthropicToolUseBuffer_RewritesBlockedMessageDeltaStopReason(t *testing.T) {
+	streamState := &protocol.GuardrailsStreamState{
+		RewroteBlockedToolUse: true,
+	}
+
+	decision := HandleAnthropicToolUseBuffer(
+		nil,
+		streamState,
+		anthropicEventTypeMessageDelta,
+		0,
+		nil,
+		map[string]interface{}{
+			"type": anthropicEventTypeMessageDelta,
+			"delta": map[string]interface{}{
+				"stop_reason": "tool_use",
+			},
+		},
+	)
+
+	if decision.Kind != AnthropicToolUseDecisionPassthrough {
+		t.Fatalf("decision.Kind = %q, want %q", decision.Kind, AnthropicToolUseDecisionPassthrough)
+	}
+	if streamState.RewroteBlockedToolUse {
+		t.Fatalf("streamState.RewroteBlockedToolUse = true, want false")
+	}
+	if len(decision.Passthrough) != 1 {
+		t.Fatalf("len(decision.Passthrough) = %d, want 1", len(decision.Passthrough))
+	}
+	delta, _ := decision.Passthrough[0].Payload["delta"].(map[string]interface{})
+	if got, _ := delta["stop_reason"].(string); got != "end_turn" {
+		t.Fatalf("delta.stop_reason = %q, want %q", got, "end_turn")
+	}
+}

--- a/internal/protocol/context.go
+++ b/internal/protocol/context.go
@@ -53,6 +53,10 @@ type GuardrailsStreamState struct {
 	PendingBlockMessages map[string]string
 	// PendingBlockedIndex tracks which content block index is currently blocked.
 	PendingBlockedIndex map[int]string
+	// RewroteBlockedToolUse is set once the current message's tool_use block has
+	// been replaced by a synthetic guardrails text block. The subsequent
+	// message_delta stop_reason must be rewritten away from tool_use.
+	RewroteBlockedToolUse bool
 	// AnthropicToolEvents buffers one tool_use block from start -> delta -> stop
 	// so the rewrite layer can either flush the original events or replace them.
 	AnthropicToolEvents map[int][]GuardrailsBufferedEvent


### PR DESCRIPTION
**Description**
This PR fixes a few guardrails regressions caused by mismatches between normalized command semantics, stream rewriting, and UI defaults.

Root causes:
- `command_execution` term matching only checked individual normalized terms, so multi-token patterns like `rm -rf` failed once commands were split into separate tokens
- blocked Anthropic `tool_use` streams were rewritten into text blocks, but the trailing `message_delta.stop_reason` still remained `tool_use`, which left the client in an inconsistent state and could trigger duplicate block output or tool-call parse failures
- the UI was implicitly persisting `tool_names: [bash]` for `command_execution` policies even though that filter was no longer clearly exposed in the editor

Changes:
- fix `command_execution` term matching so multi-token patterns match the joined normalized command sequence
- rewrite blocked Anthropic `tool_use` streams so the following `message_delta.stop_reason` becomes `end_turn`
- move the default `command_execution` tool filter to runtime evaluator construction
- update tests to match the current normalized command action model