### PR TITLE
Fix scenario V2 recording activation and add three recording modes

### DIFF
--- a/frontend/src/components/ExperimentalFeatures.tsx
+++ b/frontend/src/components/ExperimentalFeatures.tsx
@@ -32,9 +32,9 @@ const FEATURES: FeatureConfig[] = [
 // Record V2 modes
 const RECORD_V2_MODES = [
     { value: '', label: 'Off', description: 'Recording disabled' },
-    { value: 'request', label: 'Request', description: 'Record request only' },
-    { value: 'response', label: 'Response', description: 'Record response only' },
-    { value: 'request_response', label: 'Both', description: 'Record both request and response' },
+    { value: 'request', label: 'Request Only', description: 'Record the final outbound request only' },
+    { value: 'request_response', label: 'Request + Response', description: 'Record the final outbound request and final response' },
+    { value: 'staged_request_response', label: 'Request + Transform + Response', description: 'Record original request, transformed request, and final response' },
 ] as const;
 
 const ExperimentalFeatures: React.FC<ExperimentalFeaturesProps> = ({ scenario }) => {

--- a/frontend/src/components/PluginFeatures.tsx
+++ b/frontend/src/components/PluginFeatures.tsx
@@ -58,9 +58,9 @@ const THINKING_MODES = [
 // Record V2 modes
 const RECORD_V2_MODES = [
     { value: '', label: 'Off', description: 'Recording disabled' },
-    { value: 'request', label: 'Request', description: 'Record request only' },
-    { value: 'response', label: 'Response', description: 'Record response only' },
-    { value: 'request_response', label: 'Both', description: 'Record both request and response' },
+    { value: 'request', label: 'Request Only', description: 'Record the final outbound request only' },
+    { value: 'request_response', label: 'Request + Response', description: 'Record the final outbound request and final response' },
+    { value: 'staged_request_response', label: 'Request + Transform + Response', description: 'Record original request, transformed request, and final response' },
 ] as const;
 
 const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {

--- a/internal/client/record_roundtripper.go
+++ b/internal/client/record_roundtripper.go
@@ -47,6 +47,13 @@ func NewRecordRoundTripper(transport http.RoundTripper, recordSink *obs.Sink, pr
 
 // RoundTrip executes a single HTTP transaction and records request/response
 func (r *RecordRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.recordSink != nil {
+		mode := r.recordSink.GetMode()
+		if mode == obs.RecordModeRequestOnly || mode == obs.RecordModeRequestResponse || mode == obs.RecordModeStagedRequestResponse {
+			return r.transport.RoundTrip(req)
+		}
+	}
+
 	startTime := time.Now()
 
 	// Mark advisor loopback requests with depth header to prevent recursive MCP tool injection

--- a/internal/obs/sink.go
+++ b/internal/obs/sink.go
@@ -21,9 +21,9 @@ const (
 	RecordModeScenario RecordMode = "scenario"
 	RecordModeSlim     RecordMode = "slim" // TODO: Not implemented yet
 
-	RecordModeRequest           RecordMode = "request"          // Record only requests (original + transformed)
-	RecordModeResponse          RecordMode = "response"         // Record only response
-	RecordModeV2RequestResponse RecordMode = "request_response" // Record both requests and responses
+	RecordModeRequestOnly           RecordMode = "request"                 // Record transformed request only
+	RecordModeRequestResponse       RecordMode = "request_response"        // Record transformed request + final response
+	RecordModeStagedRequestResponse RecordMode = "staged_request_response" // Record original request + transformed request + final response
 )
 
 // RecordEntry represents a single recorded request/response pair
@@ -93,6 +93,13 @@ type Sink struct {
 	mutex   sync.RWMutex
 }
 
+func (r *Sink) GetMode() RecordMode {
+	if r == nil {
+		return ""
+	}
+	return r.mode
+}
+
 // recordFile holds a file handle and its writer
 type recordFile struct {
 	file        *os.File
@@ -115,7 +122,7 @@ func NewSink(baseDir string, mode RecordMode) *Sink {
 		return nil
 
 	case RecordModeAll, RecordModeScenario,
-		RecordModeRequest, RecordModeResponse, RecordModeV2RequestResponse:
+		RecordModeRequestOnly, RecordModeRequestResponse, RecordModeStagedRequestResponse:
 
 		// Empty baseDir means recording is disabled
 		if baseDir == "" {
@@ -201,6 +208,7 @@ func (r *Sink) RecordWithScenario(provider, model, scenario string, req *RecordR
 	if r.mode == "" {
 		return
 	}
+
 
 	entry := &RecordEntry{
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
@@ -371,6 +379,7 @@ func (r *Sink) RecordEntryV2(entry *RecordEntryV2) {
 	if r == nil || r.mode == "" {
 		return
 	}
+
 
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/internal/protocol/openai.go
+++ b/internal/protocol/openai.go
@@ -114,10 +114,17 @@ func PreprocessInputData(data []byte) ([]byte, error) {
 			continue
 		}
 
-		// Step 1: Add "type": "message" if missing and role exists
+		// Step 1: Infer missing union discriminator for input items.
+		// Some clients replay prior Responses history without `type`, but the SDK
+		// needs it to deserialize union items and preserve function arguments.
 		if _, hasType := itemObj["type"]; !hasType {
-			if _, hasRole := itemObj["role"]; hasRole {
+			switch {
+			case hasKey(itemObj, "role"):
 				itemObj["type"] = "message"
+			case hasKey(itemObj, "call_id") && hasKey(itemObj, "arguments"):
+				itemObj["type"] = "function_call"
+			case hasKey(itemObj, "call_id") && hasKey(itemObj, "output"):
+				itemObj["type"] = "function_call_output"
 			}
 		}
 
@@ -186,6 +193,11 @@ func asSlice(v any) ([]any, bool) {
 		return items, true
 	}
 	return nil, false
+}
+
+func hasKey(m map[string]any, key string) bool {
+	_, ok := m[key]
+	return ok
 }
 
 // =============================================

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -62,9 +62,11 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	//	return
 	//}
 
+	c.Set("server_instance", s)
+
 	// Start scenario-level recording (client -> tingly-box traffic) only if enabled
 	var recorder *ProtocolRecorder
-	if s.ApplyRecording(scenarioType) {
+	if s.GetScenarioRecordMode(scenarioType) != "" {
 		recorder = s.RecordScenarioRequest(c, scenario)
 		if recorder != nil {
 			// Store recorder in context for use in handlers

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -85,7 +85,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	// Get or create recorder for dual-stage recording (when V2 flag is enabled)
 	var recorder *ProtocolRecorder
 	if s.ApplyRecording(scenarioType) {
-		recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.recordMode)
+		recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
 	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType)
@@ -142,10 +142,10 @@ func (s *Server) handleAnthropicStreamResponseV1Beta(c *gin.Context, req *anthro
 
 // nonstreamResponsesToAnthropicBeta handles non-streaming Responses API request
 func (s *Server) nonstreamResponsesToAnthropicBeta(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
-	// Get scenario recorder if exists
-	var recorder *ScenarioRecorder
+	// Get protocol recorder if exists
+	var recorder *ProtocolRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {
-		recorder = r.(*ScenarioRecorder)
+		recorder = r.(*ProtocolRecorder)
 	}
 
 	// Get rule from context for affinity

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -79,7 +79,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	// Get or create recorder for dual-stage recording (when V2 flag is enabled)
 	var recorder *ProtocolRecorder
 	if s.ApplyRecording(scenarioType) {
-		recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.recordMode)
+		recorder = s.GetOrCreateScenarioRecorderV2(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
 	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType)
@@ -97,10 +97,10 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 // nonstreamResponsesToAnthropic handles non-streaming Responses API request for v1
 // This converts Anthropic v1 request directly to Responses API format, calls the API, and converts back to v1
 func (s *Server) nonstreamResponsesToAnthropic(c *gin.Context, proxyModel string, actualModel string, provider *typ.Provider, responsesReq responses.ResponseNewParams) {
-	// Get scenario recorder if exists
-	var recorder *ScenarioRecorder
+	// Get protocol recorder if exists
+	var recorder *ProtocolRecorder
 	if r, exists := c.Get("scenario_recorder"); exists {
-		recorder = r.(*ScenarioRecorder)
+		recorder = r.(*ProtocolRecorder)
 	}
 
 	var response *responses.Response

--- a/internal/server/chain_builder.go
+++ b/internal/server/chain_builder.go
@@ -11,19 +11,25 @@ import (
 
 // ShouldRecording determines if recording should be used
 func (s *Server) ShouldRecording(recorder *ProtocolRecorder) bool {
-	return s.enableRecording && recorder != nil
+	return recorder != nil
 }
 
 // BuildTransformChain builds the appropriate transform chain based on recording configuration
-func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioFlags *typ.ScenarioFlags, recorder *ProtocolRecorder) (*transform.TransformChain, error) {
+func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioType typ.RuleScenario, scenarioFlags *typ.ScenarioFlags, recorder *ProtocolRecorder) (*transform.TransformChain, error) {
 
-	recordMode := s.recordMode
+	recordMode := s.GetScenarioRecordMode(scenarioType)
 	shouldRecord := s.ShouldRecording(recorder)
 
 	var transforms []transform.Transform
 
+	requestRecordingEnabled := recordMode == obs.RecordModeAll ||
+		recordMode == obs.RecordModeScenario ||
+		recordMode == obs.RecordModeRequestOnly ||
+		recordMode == obs.RecordModeRequestResponse ||
+		recordMode == obs.RecordModeStagedRequestResponse
+
 	// 1. Pre-transform recording (if request recording is enabled)
-	if shouldRecord && (recordMode == obs.RecordModeAll || recordMode == obs.RecordModeScenario) {
+	if shouldRecord && requestRecordingEnabled {
 		transforms = append(transforms, NewPreTransformRecorder(c, recorder))
 	}
 
@@ -36,7 +42,7 @@ func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType
 	transforms = append(transforms, transform.NewVendorTransform(providerURL))
 
 	// 3. Post-transform recording (if request recording is enabled)
-	if shouldRecord && (recordMode == obs.RecordModeAll || recordMode == obs.RecordModeScenario) {
+	if shouldRecord && requestRecordingEnabled {
 		transforms = append(transforms, NewPostTransformRecorder(recorder, c))
 	}
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1705,7 +1705,7 @@ func (c *Config) SetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 		config.Flags.ThinkingMode = value
 	case "recording_v2":
 		if !typ.IsValidRecordingMode(value) {
-			return fmt.Errorf("invalid recording_v2 value: %s (must be one of: request, response, request_response, or empty)", value)
+			return fmt.Errorf("invalid recording_v2 value: %s (must be one of: request, request_response, staged_request_response, or empty)", value)
 		}
 		config.Flags.RecordingV2 = typ.RecordingMode(value)
 	default:

--- a/internal/server/openai_responses_test.go
+++ b/internal/server/openai_responses_test.go
@@ -96,6 +96,47 @@ func TestResponseCreateRequest_UnmarshalJSON_ArrayInput(t *testing.T) {
 	}
 }
 
+func TestResponseCreateRequest_UnmarshalJSON_TypelessFunctionCallInput(t *testing.T) {
+	jsonString := `{
+		"model": "gpt-4o",
+		"input": [
+			{
+				"call_id": "call_123",
+				"name": "Write",
+				"arguments": "{\"file_path\":\"c:/Users/nil/workspace/mario-game.html\",\"content\":\"hello\"}"
+			}
+		]
+	}`
+
+	var req protocol.ResponseCreateRequest
+	if err := json.Unmarshal([]byte(jsonString), &req); err != nil {
+		t.Fatalf("Failed to deserialize typeless function_call input: %v", err)
+	}
+
+	if param.IsOmitted(req.Input.OfInputItemList) {
+		t.Fatal("Expected input item list")
+	}
+	items := req.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("Expected 1 input item, got %d", len(items))
+	}
+	if param.IsOmitted(items[0].OfFunctionCall) {
+		t.Fatal("Expected function_call item to be preserved")
+	}
+	if items[0].OfFunctionCall.Name != "Write" {
+		t.Fatalf("Expected function name Write, got %q", items[0].OfFunctionCall.Name)
+	}
+	if items[0].OfFunctionCall.Arguments == "" {
+		t.Fatal("Expected function call arguments to be preserved")
+	}
+	if items[0].OfFunctionCall.Arguments != `{"file_path":"c:/Users/nil/workspace/mario-game.html","content":"hello"}` {
+		t.Fatalf("Unexpected function call arguments: %s", items[0].OfFunctionCall.Arguments)
+	}
+	if items[0].OfFunctionCall.CallID != "call_123" {
+		t.Fatalf("Expected call_id call_123, got %q", items[0].OfFunctionCall.CallID)
+	}
+}
+
 // TestResponseCreateRequest_UnmarshalJSON_WithExtraFields tests unmarshaling with extra fields
 func TestResponseCreateRequest_UnmarshalJSON_WithExtraFields(t *testing.T) {
 	jsonString := `{

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -91,6 +92,64 @@ func (sr *ProtocolRecorder) SetTransformSteps(steps []string) {
 	sr.transformSteps = steps
 }
 
+// SetAssembledResponse stores the final assembled response for V2 recording.
+// This mirrors ScenarioRecorder behavior but routes the final serialized body
+// into ProtocolRecorder so RecordResponse() can emit RecordEntryV2.
+func (sr *ProtocolRecorder) SetAssembledResponse(response any) {
+	if sr == nil {
+		return
+	}
+
+	var responseMap map[string]interface{}
+	switch v := response.(type) {
+	case map[string]interface{}:
+		responseMap = v
+	case []byte:
+		if err := json.Unmarshal(v, &responseMap); err != nil {
+			logrus.Debugf("ProtocolRecorder: failed to unmarshal response bytes: %v", err)
+			return
+		}
+	default:
+		data, err := json.Marshal(response)
+		if err != nil {
+			logrus.Debugf("ProtocolRecorder: failed to marshal response: %v", err)
+			return
+		}
+		if err := json.Unmarshal(data, &responseMap); err != nil {
+			logrus.Debugf("ProtocolRecorder: failed to unmarshal marshaled response: %v", err)
+			return
+		}
+	}
+
+	statusCode := 200
+	headers := map[string]string{}
+	if sr.c != nil {
+		statusCode = sr.c.Writer.Status()
+		headers = headerToMap(sr.c.Writer.Header())
+	}
+
+	sr.SetFinalResponse(&obs.RecordResponse{
+		StatusCode: statusCode,
+		Headers:    headers,
+		Body:       responseMap,
+	})
+}
+
+// RecordResponse records a V2 protocol entry instead of falling back to the
+// embedded ScenarioRecorder's old-format RecordWithScenario path.
+func (sr *ProtocolRecorder) RecordResponse(provider *typ.Provider, model string) {
+	if sr == nil {
+		return
+	}
+	if provider != nil {
+		sr.providerName = provider.Name
+	}
+	if model != "" {
+		sr.model = model
+	}
+	sr.Record()
+}
+
 // Record writes the V2 record entry to the sink
 func (sr *ProtocolRecorder) Record() {
 	if sr == nil || sr.sink == nil || sr.mode == "" {
@@ -123,9 +182,14 @@ func (sr *ProtocolRecorder) Record() {
 		entry.TransformedRequest = sr.transformedRequest
 		entry.ProviderResponse = sr.providerResponse
 		entry.FinalResponse = sr.finalResponse
-	case obs.RecordModeResponse:
-		// Only record responses
-		entry.ProviderResponse = sr.providerResponse
+	case obs.RecordModeRequestOnly:
+		entry.TransformedRequest = sr.transformedRequest
+	case obs.RecordModeRequestResponse:
+		entry.TransformedRequest = sr.transformedRequest
+		entry.FinalResponse = sr.finalResponse
+	case obs.RecordModeStagedRequestResponse:
+		entry.OriginalRequest = sr.originalRequest
+		entry.TransformedRequest = sr.transformedRequest
 		entry.FinalResponse = sr.finalResponse
 	case obs.RecordModeScenario:
 		// For scenario mode, record everything
@@ -164,12 +228,18 @@ func (sr *ProtocolRecorder) RecordError(err error) {
 
 	// Filter based on existing record mode
 	switch sr.mode {
-	case obs.RecordModeAll, obs.RecordModeScenario:
+	case obs.RecordModeAll, obs.RecordModeScenario, obs.RecordModeStagedRequestResponse:
 		entry.OriginalRequest = sr.originalRequest
 		entry.TransformedRequest = sr.transformedRequest
-	case obs.RecordModeResponse:
-		entry.ProviderResponse = sr.providerResponse
 		entry.FinalResponse = sr.finalResponse
+		if sr.mode == obs.RecordModeAll || sr.mode == obs.RecordModeScenario {
+			entry.ProviderResponse = sr.providerResponse
+		}
+	case obs.RecordModeRequestOnly, obs.RecordModeRequestResponse:
+		entry.TransformedRequest = sr.transformedRequest
+		if sr.mode == obs.RecordModeRequestResponse {
+			entry.FinalResponse = sr.finalResponse
+		}
 	}
 
 	sr.sink.RecordEntryV2(entry)

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -11,7 +11,7 @@ import (
 func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, nil, protocolRecorder)
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 
 func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, nil, protocolRecorder)
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 
 func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, nil, protocolRecorder)
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 
 func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, nil, protocolRecorder)
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -442,8 +442,15 @@ func (s *Server) GetOrCreateScenarioSink(scenario typ.RuleScenario) *obs.Sink {
 		return sink
 	}
 
-	// Create new sink for this scenario
-	sink := obs.NewSink(s.recordDir, obs.RecordModeScenario)
+	mode := s.GetScenarioRecordMode(scenario)
+	if mode == "" {
+		return nil
+	}
+
+	// Create new sink for this scenario using the scenario-effective recording mode.
+	// This allows `recording_v2` on individual scenarios such as `claude_code`
+	// even when global CLI record mode is unset.
+	sink := obs.NewSink(s.recordDir, mode)
 	if sink == nil {
 		// Sink creation failed or recording is disabled (empty recordDir)
 		// This is expected when no record directory is configured
@@ -452,8 +459,20 @@ func (s *Server) GetOrCreateScenarioSink(scenario typ.RuleScenario) *obs.Sink {
 	}
 
 	s.scenarioRecordSinks[scenario] = sink
-	logrus.Debugf("Created scenario recording sink for %s, directory: %s", scenario, s.recordDir)
+	logrus.Debugf("Created scenario recording sink for %s, mode: %s, directory: %s", scenario, mode, s.recordDir)
 	return sink
+}
+
+func (s *Server) GetScenarioRecordMode(scenario typ.RuleScenario) obs.RecordMode {
+	if s == nil || s.config == nil {
+		return s.recordMode
+	}
+
+	if mode := s.config.GetScenarioRecordingMode(scenario); mode != typ.RecordingModeDisabled {
+		return obs.RecordMode(mode)
+	}
+
+	return s.recordMode
 }
 
 // NewServer creates a new HTTP server instance with functional options
@@ -559,11 +578,11 @@ func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
 	switch server.recordMode {
 	case "":
 		// Recording disabled
-	case obs.RecordModeResponse, obs.RecordModeAll:
+	case obs.RecordModeAll:
 		recordSink := obs.NewSink(server.recordDir, server.recordMode)
 		server.clientPool.SetRecordSink(recordSink)
 		logrus.Debugf("Request recording enabled, mode: %s, directory: %s", server.recordMode, server.recordDir)
-	case obs.RecordModeScenario:
+	case obs.RecordModeScenario, obs.RecordModeRequestOnly, obs.RecordModeRequestResponse, obs.RecordModeStagedRequestResponse:
 		// Scenario recording is now on-demand, created when scenario flag is enabled
 		logrus.Debugf("Scenario recording mode enabled, sinks will be created on-demand per scenario")
 	default:

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -112,16 +112,16 @@ const (
 type RecordingMode string
 
 const (
-	RecordingModeDisabled        RecordingMode = ""                 // Recording disabled (default)
-	RecordingModeRequest         RecordingMode = "request"          // Record request only
-	RecordingModeResponse        RecordingMode = "response"         // Record response only
-	RecordingModeRequestResponse RecordingMode = "request_response" // Record both request and response
+	RecordingModeDisabled               RecordingMode = ""                         // Recording disabled (default)
+	RecordingModeRequestOnly            RecordingMode = "request"                  // Record transformed request only
+	RecordingModeRequestResponse        RecordingMode = "request_response"         // Record transformed request + final response
+	RecordingModeStagedRequestResponse  RecordingMode = "staged_request_response"  // Record original request + transformed request + final response
 )
 
 // IsValidRecordingMode checks if the given string is a valid recording mode
 func IsValidRecordingMode(mode string) bool {
 	switch RecordingMode(mode) {
-	case RecordingModeDisabled, RecordingModeRequest, RecordingModeResponse, RecordingModeRequestResponse:
+	case RecordingModeDisabled, RecordingModeRequestOnly, RecordingModeRequestResponse, RecordingModeStagedRequestResponse:
 		return true
 	default:
 		return false
@@ -136,7 +136,7 @@ type ScenarioFlags struct {
 
 	// Experimental feature flags (scenario-based opt-in)
 	SmartCompact bool          `json:"smart_compact,omitempty" yaml:"smart_compact,omitempty"`   // Enable smart compact (remove thinking blocks)
-	RecordingV2  RecordingMode `json:"recording_v2,omitempty" yaml:"recording_v2,omitempty"`     // Enable scenario recording V2 (request/response/request_response)
+	RecordingV2  RecordingMode `json:"recording_v2,omitempty" yaml:"recording_v2,omitempty"`     // Enable scenario recording V2 (request/request_response/staged_request_response)
 	Beta         bool          `json:"anthropic_beta,omitempty" yaml:"anthropic_beta,omitempty"` // Enable Anthropic beta features (e.g. extended thinking)
 
 	// Stream configuration flags


### PR DESCRIPTION
## Summary
- make scenario-level `recording_v2` actually activate V2 staged recording for flows such as `claude_code`
- route staged request/response capture through `ProtocolRecorder` consistently, instead of falling back to legacy scenario recording in some Anthropic paths
- avoid mixing legacy roundtrip JSONL output into V2 scenario recording modes
- replace the old `request/response/both` shape with three recording modes: `request`, `request_response`, and `staged_request_response`
- update the frontend mode selector to reflect the new recording semantics

## Problem
Scenario config already supported `recording_v2`, but `claude_code` requests still did not emit true staged V2 entries (`original_request`, `transformed_request`, `final_response`). In practice this made it hard to determine whether malformed tool calls came from the upstream client/LLM or from tingly-box transforms.

## Root Cause
There were multiple gaps in the recording path:
- scenario sinks were still created with legacy `scenario` mode instead of the scenario’s effective `recording_v2` mode
- several Anthropic handlers still passed global `s.recordMode` instead of the scenario-effective mode
- transform pre/post recorders were gated behind a stale global `enableRecording` path that was not what scenario `recording_v2` actually used
- client roundtrip recording could still write old-format JSONL alongside V2 staged entries, making inspection noisy
- the old recording mode model did not clearly separate final-request recording from staged request/transform recording

## Fix
- compute recording mode from the scenario via `GetScenarioRecordMode(...)`
- create scenario sinks with that effective mode
- pass the scenario-effective mode into V2 recorder setup and transform-chain recording decisions
- keep non-stream Responses→Anthropic paths on `ProtocolRecorder`
- skip legacy roundtrip recording when V2 scenario recording is active
- redefine scenario `recording_v2` into three modes:
  - `request`: final outbound request only
  - `request_response`: final outbound request + final response
  - `staged_request_response`: original request + transformed request + final response
- update frontend scenario controls to use the new three-mode semantics

## Validation
- rebased onto `origin/main`
- `task cli:build` passes in the isolated worktree
- verified on a worktree build running on port `12580`
- switched `claude_code.recording_v2` through `request`, `request_response`, and `staged_request_response`
- sent real `claude_code` requests against the patched server
- confirmed the appended JSONL entries under `~/.tingly-box-daily/record/claude_code` match the expected field sets for each mode
