### PR TITLE
feat(protocol/assembler): add streamemit decoupling layer for Anthropic streams

### DIFF
--- a/internal/protocol/assembler/streamemit/README.md
+++ b/internal/protocol/assembler/streamemit/README.md
@@ -1,0 +1,325 @@
+# streamemit
+
+Decoupled emission layer on top of the Anthropic stream assemblers in
+`internal/protocol/assembler`.
+
+## Why this package exists
+
+The provider-side stream from Anthropic interleaves several kinds of
+content blocks — `text`, `thinking`, `tool_use`, and various tool-result
+variants — inside one event sequence. Today the passthrough handler in
+`internal/protocol/stream/anthropic_passthrough.go` forwards each event
+to the SSE consumer the moment it arrives:
+
+```
+provider ──► ProcessStream ──► SSEvent ──► consumer
+```
+
+That is fine when the consumer is happy to render partial content as it
+arrives. It breaks down for two real use cases:
+
+1. **Independent visibility into tool vs. message assembly.** Recording,
+   auditing, and routing code want to ask "have I finished the tool
+   call yet?" or "what text has the model produced so far?" without
+   reimplementing the per-block state machine each time.
+2. **Atomic tool-call delivery.** Some downstream consumers cannot act
+   on a half-formed tool call — they need the whole `tool_use` block
+   (id, name, fully-parsed input) before any of it reaches them, while
+   text and thinking continue to stream live in parallel.
+
+The buffer-then-decide pattern that solves (2) already lives in
+`internal/guardrails/mutate/anthropic_stream.go`, but it is wired
+specifically into the guardrails rewrite path. `streamemit` generalizes
+that pattern into a reusable layer so non-guardrails callers can
+compose the same shape, and so guardrails itself can eventually
+collapse onto it.
+
+## Design
+
+### One emitter, two responsibilities
+
+A `StreamEmitter` does two things every time `Feed` is called:
+
+1. **Always feed the inner `*assembler.AnthropicStreamAssembler`** so
+   `MessageAssembler()` and `Finish()` reflect every event the emitter
+   has seen, regardless of any buffering decisions.
+2. **Decide what to release right now.** Per-kind `EmissionPolicy`
+   selects between `EmitImmediate` (1:1 with arrival) and
+   `EmitOnComplete` (buffer the entire content block, flush as one
+   ordered slice on `content_block_stop`).
+
+Both responsibilities are independent: the assembled `*anthropic.Message`
+returned by `Finish` is correct whether or not anything was buffered.
+
+### Routing
+
+```
+                  ┌─────────────────────────────────────────────┐
+                  │                StreamEmitter                │
+                  │                                             │
+ evt ─► Feed ─►   │   ┌─ inner *AnthropicStreamAssembler        │
+                  │   │     (RecordV1Event / RecordV1BetaEvent) │
+                  │   │                                         │
+                  │   ├─ kinds[index]    ── learned at          │
+                  │   │                     content_block_start │
+                  │   │                                         │
+                  │   ├─ toolBufs[index] ── only when policy    │
+                  │   │                     for that kind is    │
+                  │   │                     EmitOnComplete      │
+                  │   │                                         │
+                  │   └─ OnToolBlockComplete hook ── invoked at │
+                  │                                  cb_stop    │
+                  │                                  on flush   │
+                  └─────────────────────────────────────────────┘
+                              │
+                              ▼
+                    []BufferedEvent  (zero, one, or many — caller
+                                      forwards each to the consumer)
+```
+
+`message_start`, `message_delta`, `message_stop` are always immediate.
+`content_block_start` learns the block kind, opens a buffer if needed,
+and either holds or releases the start event. `content_block_delta`
+routes by the previously-recorded kind. `content_block_stop` either
+flushes a buffered block (running the optional decision hook first) or
+passes through.
+
+### Emission timeline
+
+```
+events arriving:   ms_start  cb_start(text)  txt_d  txt_d  cb_stop  cb_start(tool)  json_d  json_d  cb_stop  ms_delta  ms_stop
+                       │           │           │      │       │            │           │       │       │         │         │
+emitter.Feed   ───►   1ev         1ev         1ev    1ev     1ev          0ev         0ev     0ev    ┌─4ev─┐    1ev      1ev
+                       ▼           ▼           ▼      ▼       ▼            ▼           ▼       ▼     ▼     ▼     ▼         ▼
+ SSE wire:           ms_start    cb_start(t)  d      d     cb_stop      ░░░░░░░░░  ░░░░░░  ░░░░░░  cb_start(tool)  ms_delta  ms_stop
+                                                                                                   json_d
+                                                                                                   json_d
+                                                                                                   cb_stop
+                                                                  ▲
+                                                                  │
+                                                          held in toolBufs[1] until
+                                                          cb_stop, then drained as
+                                                          one ordered slice
+```
+
+Text and thinking flow live; the tool block goes silent on the wire and
+re-emerges as a contiguous burst at `content_block_stop`.
+
+### `BufferedEvent` is a type alias
+
+```go
+type BufferedEvent = protocol.GuardrailsBufferedEvent
+```
+
+The alias (not a named type) means the output of `streamemit` and the
+output of the guardrails rewriter are interchangeable. A handler can
+chain them, a slice from one can be appended to a slice from the
+other, and the existing `sendAnthropicStreamEvent` consumes both
+without translation.
+
+### Hook composition
+
+`Config.OnToolBlockComplete` is the integration point for tool-level
+post-processing — credential masking, allow/deny verdicts, content
+rewriting:
+
+```
+            ┌──────────────────────────┐
+            │ OnToolBlockComplete      │
+            │   ├─ allow  → nil        │   (flush buffered as-is)
+            │   ├─ rewrite→ Replace[]  │   (emit replacement instead)
+            │   └─ drop   → Drop:true  │   (emit nothing)
+            └──────────────────────────┘
+```
+
+This is the same decision shape as the guardrails
+`AnthropicToolUseDecision`; an adapter is one screen of code.
+
+### Scope
+
+- **In:** Anthropic v1 (`MessageStreamEventUnion`) and v1beta
+  (`BetaRawMessageStreamEventUnion`).
+- **Out:** OpenAI Chat, OpenAI Responses, Google streams. Those have
+  their own assemblers; analogous emitters can be added later.
+- **One version per emitter.** Mixing v1 and v1beta events on a single
+  emitter returns `ErrMixedVersions`. Use one emitter per request.
+
+## Usage
+
+### Pass-through (default — same behavior as today's handler)
+
+```go
+e := streamemit.New(streamemit.Config{}) // zero value: emit everything immediately
+
+for streamResp.Next() {
+    evt := streamResp.Current()
+    out, err := e.FeedV1(&evt)
+    if err != nil {
+        return err
+    }
+    for _, ev := range out {
+        sendAnthropicStreamEvent(c, ev.EventType, ev.Payload, c.Writer)
+    }
+}
+
+_, msg := e.Finish(model, inputTokens, outputTokens)
+// `msg` is *anthropic.Message reflecting the full stream.
+```
+
+### Hold tool calls until complete
+
+```go
+e := streamemit.New(streamemit.Config{
+    ToolPolicy: streamemit.EmitOnComplete,
+})
+
+for streamResp.Next() {
+    evt := streamResp.Current()
+    out, _ := e.FeedV1(&evt)
+    for _, ev := range out {
+        sendAnthropicStreamEvent(c, ev.EventType, ev.Payload, c.Writer)
+    }
+}
+
+// On error or client disconnect, salvage anything still buffered:
+//   pending := e.Drain()
+//   for _, ev := range pending { ... }
+```
+
+Text and thinking events still reach the consumer the moment they
+arrive. Each tool block is silent on the wire from `content_block_start`
+through every `input_json_delta`, then bursts out as a single ordered
+slice at `content_block_stop`.
+
+### Compose with a verdict hook
+
+```go
+e := streamemit.New(streamemit.Config{
+    ToolPolicy: streamemit.EmitOnComplete,
+    OnToolBlockComplete: func(toolID string, idx int, buffered []streamemit.BufferedEvent) (*streamemit.ToolDecision, error) {
+        verdict, err := guardrails.Inspect(toolID, buffered)
+        if err != nil {
+            return nil, err
+        }
+        switch verdict.Kind {
+        case guardrails.Allow:
+            return nil, nil                              // flush as-is
+        case guardrails.Block:
+            return &streamemit.ToolDecision{Replace: verdict.ErrorEvents}, nil
+        case guardrails.Drop:
+            return &streamemit.ToolDecision{Drop: true}, nil
+        }
+        return nil, nil
+    },
+})
+```
+
+### Inspect each side independently
+
+```go
+// Read-only access to the inner state machine; safe to call at any time.
+asm := e.MessageAssembler()
+_ = asm // e.g. inspect blocks accumulated so far
+
+// Snapshot the events buffered for a specific block index.
+if buf, ok := e.ToolBuffer(1); ok {
+    fmt.Println("tool block 1 has", len(buf), "events buffered so far")
+}
+```
+
+## Public API surface
+
+```go
+// Construction
+func New(cfg Config) *StreamEmitter
+
+// Feeding
+func (e *StreamEmitter) Feed(event interface{}) ([]BufferedEvent, error)
+func (e *StreamEmitter) FeedV1(*anthropic.MessageStreamEventUnion) ([]BufferedEvent, error)
+func (e *StreamEmitter) FeedV1Beta(*anthropic.BetaRawMessageStreamEventUnion) ([]BufferedEvent, error)
+
+// Inspection
+func (e *StreamEmitter) MessageAssembler() *assembler.AnthropicStreamAssembler
+func (e *StreamEmitter) ToolBuffer(index int) ([]BufferedEvent, bool)
+
+// Termination
+func (e *StreamEmitter) Drain() []BufferedEvent
+func (e *StreamEmitter) Finish(model string, inputTokens, outputTokens int) ([]BufferedEvent, *anthropic.Message)
+
+// Sentinels
+var ErrMixedVersions = errors.New(...)
+
+// Config
+type Config struct {
+    TextPolicy          EmissionPolicy
+    ThinkingPolicy      EmissionPolicy
+    ToolPolicy          EmissionPolicy
+    OnToolBlockComplete func(toolID string, index int, buffered []BufferedEvent) (*ToolDecision, error)
+}
+
+type EmissionPolicy int
+const (
+    EmitImmediate EmissionPolicy = iota
+    EmitOnComplete
+)
+
+type ToolDecision struct {
+    Replace []BufferedEvent
+    Drop    bool
+}
+
+type BufferedEvent = protocol.GuardrailsBufferedEvent
+```
+
+## Design notes and caveats
+
+- **The emitter owns the inner assembler.** Callers that today drive
+  their own `AnthropicStreamAssembler` in parallel (e.g.
+  `internal/server/scenario_recording.go`) should pick one or the other
+  to avoid double-feeding. `MessageAssembler()` is the bridge for
+  callers that want the assembled message without a second instance.
+- **`Drain()` does not call `OnToolBlockComplete`.** It is the salvage
+  path for error/cancel handling, not a completion signal. If the hook
+  must run for partial tool blocks too, the caller should invoke it
+  explicitly before calling `Drain`.
+- **`MessageAssembler()` is read-oriented.** Feeding events into the
+  returned assembler directly will desync it from the emitter's
+  routing state. Use `Feed*` only.
+- **`Drop` and `Replace` are independent.** If both are set, `Drop`
+  wins. A nil `*ToolDecision` flushes the buffered events unchanged.
+- **Thinking blocks under `EmitOnComplete`.** Mechanically supported
+  (the same buffer machinery is reused) but no caller exercises this
+  yet. Treat as latent capability.
+
+## Migration plan
+
+This package landed library-only. The handler-side migration happens
+in follow-ups:
+
+1. Swap `anthropic_passthrough.go` to drive a `StreamEmitter` with
+   `Config{}` (byte-identical default behavior).
+2. Move the guardrails rewriter behind `OnToolBlockComplete`; delete
+   `GuardrailsStreamState.AnthropicToolEvents` /
+   `AnthropicToolIDs`.
+3. Expose a per-request opt-in (header or `HandleContext` flag) that
+   flips `ToolPolicy` to `EmitOnComplete` for consumers that prefer
+   atomic tool delivery.
+4. Optionally retire the inline state machine in
+   `internal/protocol/stream/openai_to_anthropic.go::streamState` by
+   having the conversion handler emit Anthropic events into a
+   `StreamEmitter`.
+
+## Tests
+
+`go test ./internal/protocol/assembler/streamemit/...` covers:
+
+- text-only streams (v1 + v1beta) with `EmitImmediate`
+- tool-only streams (v1 + v1beta) with `EmitOnComplete`
+- mixed text + tool with text live, tool buffered
+- ordering invariant: a tool flush returns only the tool's events,
+  even when text deltas on a different block were already emitted
+- `Drain()` flushing an unclosed tool buffer
+- `Finish()` returning pending events plus an assembled message
+- `OnToolBlockComplete` `Replace` / `Drop` / error propagation
+- `ErrMixedVersions` when v1 and v1beta are fed to the same emitter
+- byte-compatibility with `protocol.GuardrailsBufferedEvent`

--- a/internal/protocol/assembler/streamemit/buffered_event.go
+++ b/internal/protocol/assembler/streamemit/buffered_event.go
@@ -1,0 +1,11 @@
+package streamemit
+
+import "github.com/tingly-dev/tingly-box/internal/protocol"
+
+// BufferedEvent is one Anthropic SSE event ready to be sent to the consumer.
+//
+// It is a type alias of protocol.GuardrailsBufferedEvent so the output of
+// this package is byte-compatible with the guardrails rewrite layer's
+// buffered events: callers can append slices from both sources and feed
+// them into the same emitter without conversion.
+type BufferedEvent = protocol.GuardrailsBufferedEvent

--- a/internal/protocol/assembler/streamemit/doc.go
+++ b/internal/protocol/assembler/streamemit/doc.go
@@ -1,0 +1,27 @@
+// Package streamemit provides a decoupled emission layer on top of the
+// Anthropic stream assemblers in internal/protocol/assembler.
+//
+// A StreamEmitter routes incoming Anthropic stream events to per-kind
+// sub-buffers and applies a configurable EmissionPolicy per kind. The
+// supported policies are EmitImmediate (the default — events flow out
+// 1:1 as they arrive) and EmitOnComplete (events for a content block
+// are buffered from content_block_start through content_block_stop and
+// flushed as a single ordered slice on stop).
+//
+// The primary use case is "hold tool_use blocks until the assembler
+// has the complete tool call" while still streaming text and thinking
+// to the consumer live. This mirrors the buffer/decision pattern used
+// by internal/guardrails/mutate for credential masking, but generalizes
+// it so non-guardrails callers can compose the same shape.
+//
+// The emitter owns its inner *assembler.AnthropicStreamAssembler. It
+// always feeds every event to the inner assembler, regardless of any
+// buffering, so MessageAssembler() and Finish() always reflect the
+// full stream so far. Callers that today drive their own assembler
+// in parallel (e.g. internal/server/scenario_recording.go) should
+// pick one or the other to avoid double-feeding.
+//
+// Scope: this package supports Anthropic v1 (MessageStreamEventUnion)
+// and v1beta (BetaRawMessageStreamEventUnion). OpenAI Chat and OpenAI
+// Responses streams are out of scope.
+package streamemit

--- a/internal/protocol/assembler/streamemit/emitter.go
+++ b/internal/protocol/assembler/streamemit/emitter.go
@@ -1,0 +1,183 @@
+package streamemit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/tingly-dev/tingly-box/internal/protocol/assembler"
+)
+
+// ErrMixedVersions is returned by Feed when an emitter that has already
+// processed v1 events receives a v1beta event (or vice versa).
+var ErrMixedVersions = errors.New("streamemit: cannot mix v1 and v1beta events on a single emitter")
+
+// emitterVersion pins an emitter to a single Anthropic event union type
+// after the first Feed call.
+type emitterVersion uint8
+
+const (
+	versionUnset emitterVersion = iota
+	versionV1
+	versionV1Beta
+)
+
+// StreamEmitter routes Anthropic stream events through a configurable
+// emission policy. See package doc for usage.
+type StreamEmitter struct {
+	cfg Config
+
+	// msg is the inner state machine used to produce the final
+	// *anthropic.Message. It is fed every event regardless of buffering.
+	msg *assembler.AnthropicStreamAssembler
+
+	// kinds tracks BlockKind per content block index, learned at
+	// content_block_start, used to route subsequent deltas and stops.
+	kinds map[int]BlockKind
+
+	// toolIDs is the tool_use id per content block index, populated when
+	// a tool_use block opens.
+	toolIDs map[int]string
+
+	// toolBufs holds per-block buffers for tool_use blocks under the
+	// EmitOnComplete policy. A block index has an entry here only while
+	// it is being buffered; the entry is removed on flush/drain.
+	toolBufs map[int]*toolBlockBuffer
+
+	version emitterVersion
+}
+
+// New constructs a StreamEmitter with the given configuration.
+func New(cfg Config) *StreamEmitter {
+	return &StreamEmitter{
+		cfg:      cfg,
+		msg:      assembler.NewAnthropicStreamAssembler(),
+		kinds:    make(map[int]BlockKind),
+		toolIDs:  make(map[int]string),
+		toolBufs: make(map[int]*toolBlockBuffer),
+	}
+}
+
+// MessageAssembler returns the inner *AnthropicStreamAssembler so callers
+// can inspect message-side accumulation independently of tool buffering.
+// Callers should treat it as read-only — feeding events into it directly
+// will desync it from the emitter's routing state.
+func (e *StreamEmitter) MessageAssembler() *assembler.AnthropicStreamAssembler {
+	return e.msg
+}
+
+// ToolBuffer returns a copy of the events currently buffered for the given
+// content block index. The bool is false when no buffer exists for that
+// index (either it was never tool_use, it was emitted immediately, or it
+// has already been flushed).
+func (e *StreamEmitter) ToolBuffer(index int) ([]BufferedEvent, bool) {
+	buf, ok := e.toolBufs[index]
+	if !ok {
+		return nil, false
+	}
+	return buf.snapshot(), true
+}
+
+// Drain flushes every still-open tool buffer, returning the buffered events
+// in ascending block-index order, and clears the buffers. Useful at end of
+// stream or on error when the caller wants whatever has been accumulated.
+//
+// Drain does NOT call OnToolBlockComplete — it is a salvage path, not a
+// completion signal.
+func (e *StreamEmitter) Drain() []BufferedEvent {
+	if len(e.toolBufs) == 0 {
+		return nil
+	}
+	indices := make([]int, 0, len(e.toolBufs))
+	for idx := range e.toolBufs {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	var out []BufferedEvent
+	for _, idx := range indices {
+		out = append(out, e.toolBufs[idx].drain()...)
+		delete(e.toolBufs, idx)
+	}
+	return out
+}
+
+// Finish drains any remaining tool buffers and returns the assembled
+// *anthropic.Message produced by the inner assembler.
+//
+// model, inputTokens, outputTokens are forwarded to
+// AnthropicStreamAssembler.Finish.
+func (e *StreamEmitter) Finish(model string, inputTokens, outputTokens int) ([]BufferedEvent, *anthropic.Message) {
+	pending := e.Drain()
+	return pending, e.msg.Finish(model, inputTokens, outputTokens)
+}
+
+// Feed accepts either a *anthropic.MessageStreamEventUnion (v1) or a
+// *anthropic.BetaRawMessageStreamEventUnion (v1beta) and returns the
+// events the caller should send to the consumer right now.
+//
+// An emitter is pinned to its first version; mixing versions returns
+// ErrMixedVersions.
+func (e *StreamEmitter) Feed(event interface{}) ([]BufferedEvent, error) {
+	switch evt := event.(type) {
+	case *anthropic.MessageStreamEventUnion:
+		return e.FeedV1(evt)
+	case *anthropic.BetaRawMessageStreamEventUnion:
+		return e.FeedV1Beta(evt)
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("streamemit: unsupported event type %T", event)
+	}
+}
+
+// payloadFromRaw unmarshals an Anthropic event's RawJSON into a payload
+// map, ensuring the "type" field is set to eventType. The returned map
+// matches the shape that sendAnthropicStreamEvent already consumes and
+// that GuardrailsBufferedEvent.Payload uses, so emitter output can be
+// passed to either consumer without translation.
+func payloadFromRaw(rawJSON string, eventType string) (map[string]interface{}, error) {
+	payload := map[string]interface{}{}
+	if rawJSON != "" {
+		if err := json.Unmarshal([]byte(rawJSON), &payload); err != nil {
+			return nil, err
+		}
+	}
+	if eventType != "" {
+		payload["type"] = eventType
+	}
+	return payload, nil
+}
+
+// flushToolBuffer drains a tool_use buffer at the given index, runs the
+// OnToolBlockComplete hook if configured, and returns the events that
+// should be released to the caller.
+func (e *StreamEmitter) flushToolBuffer(index int) ([]BufferedEvent, error) {
+	buf, ok := e.toolBufs[index]
+	if !ok {
+		return nil, nil
+	}
+	delete(e.toolBufs, index)
+
+	buffered := buf.drain()
+	if e.cfg.OnToolBlockComplete == nil {
+		return buffered, nil
+	}
+
+	decision, err := e.cfg.OnToolBlockComplete(buf.toolID, buf.index, buffered)
+	if err != nil {
+		return nil, err
+	}
+	if decision == nil {
+		return buffered, nil
+	}
+	if decision.Drop {
+		return nil, nil
+	}
+	if decision.Replace != nil {
+		return decision.Replace, nil
+	}
+	return buffered, nil
+}

--- a/internal/protocol/assembler/streamemit/emitter_test.go
+++ b/internal/protocol/assembler/streamemit/emitter_test.go
@@ -1,0 +1,374 @@
+package streamemit
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// feedV1Raw is a small helper that unmarshals a raw v1 event JSON and
+// feeds it into the emitter, returning the released events.
+func feedV1Raw(t *testing.T, e *StreamEmitter, raw string) []BufferedEvent {
+	t.Helper()
+	out, err := e.FeedV1(v1Event(t, raw))
+	require.NoError(t, err)
+	return out
+}
+
+func feedV1BetaRaw(t *testing.T, e *StreamEmitter, raw string) []BufferedEvent {
+	t.Helper()
+	out, err := e.FeedV1Beta(betaEvent(t, raw))
+	require.NoError(t, err)
+	return out
+}
+
+func TestStreamEmitter_TextOnly_EmitImmediate_v1(t *testing.T) {
+	e := New(Config{})
+
+	got := feedV1Raw(t, e, fxMessageStart("msg_1"))
+	require.Len(t, got, 1)
+	assert.Equal(t, "message_start", got[0].EventType)
+
+	got = feedV1Raw(t, e, fxTextBlockStart(0))
+	require.Len(t, got, 1)
+	assert.Equal(t, "content_block_start", got[0].EventType)
+
+	got = feedV1Raw(t, e, fxTextDelta(0, "He"))
+	require.Len(t, got, 1)
+	assert.Equal(t, "content_block_delta", got[0].EventType)
+
+	got = feedV1Raw(t, e, fxTextDelta(0, "llo"))
+	require.Len(t, got, 1)
+
+	got = feedV1Raw(t, e, fxBlockStop(0))
+	require.Len(t, got, 1)
+	assert.Equal(t, "content_block_stop", got[0].EventType)
+
+	got = feedV1Raw(t, e, fxMessageDelta("end_turn", 5))
+	require.Len(t, got, 1)
+	got = feedV1Raw(t, e, fxMessageStop())
+	require.Len(t, got, 1)
+
+	// No tool buffer was ever opened.
+	_, hasBuf := e.ToolBuffer(0)
+	assert.False(t, hasBuf)
+
+	pending, msg := e.Finish("claude-test", 1, 5)
+	assert.Empty(t, pending)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "text", string(msg.Content[0].Type))
+	assert.Equal(t, "Hello", msg.Content[0].Text)
+}
+
+func TestStreamEmitter_ToolOnly_EmitOnComplete_v1(t *testing.T) {
+	e := New(Config{ToolPolicy: EmitOnComplete})
+
+	got := feedV1Raw(t, e, fxMessageStart("msg_2"))
+	require.Len(t, got, 1)
+
+	// Tool block start: should be buffered.
+	got = feedV1Raw(t, e, fxToolUseBlockStart(0, "toolu_1", "get_weather"))
+	assert.Empty(t, got)
+	snap, ok := e.ToolBuffer(0)
+	require.True(t, ok)
+	require.Len(t, snap, 1)
+
+	// Three input_json_delta events: still buffered.
+	got = feedV1Raw(t, e, fxInputJSONDelta(0, `{"ci`))
+	assert.Empty(t, got)
+	got = feedV1Raw(t, e, fxInputJSONDelta(0, `ty":"S`))
+	assert.Empty(t, got)
+	got = feedV1Raw(t, e, fxInputJSONDelta(0, `F"}`))
+	assert.Empty(t, got)
+
+	// content_block_stop flushes start + 3 deltas + stop in order.
+	got = feedV1Raw(t, e, fxBlockStop(0))
+	require.Len(t, got, 5)
+	assert.Equal(t, "content_block_start", got[0].EventType)
+	assert.Equal(t, "content_block_delta", got[1].EventType)
+	assert.Equal(t, "content_block_delta", got[2].EventType)
+	assert.Equal(t, "content_block_delta", got[3].EventType)
+	assert.Equal(t, "content_block_stop", got[4].EventType)
+
+	// Buffer is gone after flush.
+	_, ok = e.ToolBuffer(0)
+	assert.False(t, ok)
+
+	feedV1Raw(t, e, fxMessageDelta("tool_use", 7))
+	feedV1Raw(t, e, fxMessageStop())
+
+	pending, msg := e.Finish("claude-test", 1, 7)
+	assert.Empty(t, pending)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "tool_use", string(msg.Content[0].Type))
+	assert.Equal(t, "toolu_1", msg.Content[0].ID)
+	assert.Equal(t, "get_weather", msg.Content[0].Name)
+	assert.JSONEq(t, `{"city":"SF"}`, string(msg.Content[0].Input))
+}
+
+func TestStreamEmitter_Mixed_TextLive_ToolBuffered_v1(t *testing.T) {
+	e := New(Config{ToolPolicy: EmitOnComplete})
+
+	feedV1Raw(t, e, fxMessageStart("msg_3"))
+
+	// Block 0: text — flows live.
+	got := feedV1Raw(t, e, fxTextBlockStart(0))
+	require.Len(t, got, 1)
+	got = feedV1Raw(t, e, fxTextDelta(0, "hi"))
+	require.Len(t, got, 1)
+	got = feedV1Raw(t, e, fxBlockStop(0))
+	require.Len(t, got, 1)
+
+	// Block 1: tool_use — buffered.
+	got = feedV1Raw(t, e, fxToolUseBlockStart(1, "toolu_2", "noop"))
+	assert.Empty(t, got)
+	got = feedV1Raw(t, e, fxInputJSONDelta(1, `{`))
+	assert.Empty(t, got)
+	got = feedV1Raw(t, e, fxInputJSONDelta(1, `}`))
+	assert.Empty(t, got)
+	got = feedV1Raw(t, e, fxBlockStop(1))
+	require.Len(t, got, 4) // start + 2 deltas + stop
+	for _, ev := range got {
+		assert.Equal(t, 1.0, ev.Payload["index"])
+	}
+
+	feedV1Raw(t, e, fxMessageDelta("tool_use", 9))
+	feedV1Raw(t, e, fxMessageStop())
+
+	_, msg := e.Finish("claude-test", 1, 9)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Content, 2)
+	assert.Equal(t, "text", string(msg.Content[0].Type))
+	assert.Equal(t, "hi", msg.Content[0].Text)
+	assert.Equal(t, "tool_use", string(msg.Content[1].Type))
+	assert.JSONEq(t, `{}`, string(msg.Content[1].Input))
+}
+
+func TestStreamEmitter_Mixed_PendingTextDeltaThenToolStop_v1(t *testing.T) {
+	// Open text block 0, open tool block 1, more text deltas, then stop tool 1.
+	// Verify the tool flush returns ONLY tool events; none of the text events
+	// already emitted earlier leak into the tool buffer's drain.
+	e := New(Config{ToolPolicy: EmitOnComplete})
+
+	feedV1Raw(t, e, fxMessageStart("msg_4"))
+	feedV1Raw(t, e, fxTextBlockStart(0))
+	feedV1Raw(t, e, fxTextDelta(0, "a"))
+
+	// Tool 1 starts and is buffered.
+	got := feedV1Raw(t, e, fxToolUseBlockStart(1, "toolu_3", "f"))
+	assert.Empty(t, got)
+
+	// More text on block 0 keeps flowing live.
+	got = feedV1Raw(t, e, fxTextDelta(0, "b"))
+	require.Len(t, got, 1)
+	assert.Equal(t, "content_block_delta", got[0].EventType)
+	assert.Equal(t, 0.0, got[0].Payload["index"])
+
+	got = feedV1Raw(t, e, fxInputJSONDelta(1, `{}`))
+	assert.Empty(t, got)
+
+	// Stop tool 1: flush should contain only the tool's events (start, json
+	// delta, stop) — nothing from block 0.
+	got = feedV1Raw(t, e, fxBlockStop(1))
+	require.Len(t, got, 3)
+	for _, ev := range got {
+		assert.Equal(t, 1.0, ev.Payload["index"], "expected only tool block events")
+	}
+}
+
+func TestStreamEmitter_TextOnly_EmitImmediate_v1Beta(t *testing.T) {
+	e := New(Config{})
+	got := feedV1BetaRaw(t, e, fxMessageStart("msg_b1"))
+	require.Len(t, got, 1)
+
+	got = feedV1BetaRaw(t, e, fxTextBlockStart(0))
+	require.Len(t, got, 1)
+	got = feedV1BetaRaw(t, e, fxTextDelta(0, "Hi"))
+	require.Len(t, got, 1)
+	got = feedV1BetaRaw(t, e, fxBlockStop(0))
+	require.Len(t, got, 1)
+	feedV1BetaRaw(t, e, fxMessageDelta("end_turn", 2))
+	feedV1BetaRaw(t, e, fxMessageStop())
+
+	pending, msg := e.Finish("claude-test", 1, 2)
+	assert.Empty(t, pending)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "Hi", msg.Content[0].Text)
+}
+
+func TestStreamEmitter_ToolOnly_EmitOnComplete_v1Beta(t *testing.T) {
+	e := New(Config{ToolPolicy: EmitOnComplete})
+	feedV1BetaRaw(t, e, fxMessageStart("msg_b2"))
+
+	got := feedV1BetaRaw(t, e, fxToolUseBlockStart(0, "toolu_b1", "f"))
+	assert.Empty(t, got)
+	feedV1BetaRaw(t, e, fxInputJSONDelta(0, `{"k":1}`))
+	got = feedV1BetaRaw(t, e, fxBlockStop(0))
+	require.Len(t, got, 3)
+
+	feedV1BetaRaw(t, e, fxMessageDelta("tool_use", 3))
+	feedV1BetaRaw(t, e, fxMessageStop())
+
+	_, msg := e.Finish("claude-test", 1, 3)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "tool_use", string(msg.Content[0].Type))
+	assert.JSONEq(t, `{"k":1}`, string(msg.Content[0].Input))
+}
+
+func TestStreamEmitter_Mixed_v1Beta(t *testing.T) {
+	e := New(Config{ToolPolicy: EmitOnComplete})
+	feedV1BetaRaw(t, e, fxMessageStart("msg_b3"))
+
+	got := feedV1BetaRaw(t, e, fxTextBlockStart(0))
+	require.Len(t, got, 1)
+	feedV1BetaRaw(t, e, fxTextDelta(0, "x"))
+	feedV1BetaRaw(t, e, fxBlockStop(0))
+
+	got = feedV1BetaRaw(t, e, fxToolUseBlockStart(1, "toolu_b2", "g"))
+	assert.Empty(t, got)
+	feedV1BetaRaw(t, e, fxInputJSONDelta(1, `{}`))
+	got = feedV1BetaRaw(t, e, fxBlockStop(1))
+	require.Len(t, got, 3)
+
+	_, msg := e.Finish("claude-test", 1, 4)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Content, 2)
+}
+
+func TestStreamEmitter_Drain_FlushesUnclosedToolBlock(t *testing.T) {
+	e := New(Config{ToolPolicy: EmitOnComplete})
+	feedV1Raw(t, e, fxMessageStart("msg_5"))
+	feedV1Raw(t, e, fxToolUseBlockStart(0, "toolu_x", "f"))
+	feedV1Raw(t, e, fxInputJSONDelta(0, `{`))
+	feedV1Raw(t, e, fxInputJSONDelta(0, `}`))
+
+	pending := e.Drain()
+	require.Len(t, pending, 3) // start + 2 deltas, no stop
+
+	// Buffer is now empty.
+	_, ok := e.ToolBuffer(0)
+	assert.False(t, ok)
+
+	// A second drain returns nothing.
+	assert.Empty(t, e.Drain())
+}
+
+func TestStreamEmitter_Finish_ReturnsPendingAndMessage(t *testing.T) {
+	e := New(Config{ToolPolicy: EmitOnComplete})
+	feedV1Raw(t, e, fxMessageStart("msg_6"))
+	feedV1Raw(t, e, fxToolUseBlockStart(0, "toolu_y", "f"))
+	feedV1Raw(t, e, fxInputJSONDelta(0, `{}`))
+
+	pending, msg := e.Finish("claude-test", 1, 1)
+	require.Len(t, pending, 2) // start + 1 delta, drained by Finish
+	require.NotNil(t, msg)
+	// Inner assembler still produced a tool_use block reflecting what it saw.
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "tool_use", string(msg.Content[0].Type))
+}
+
+func TestStreamEmitter_OnToolBlockComplete_ReplacesBuffered(t *testing.T) {
+	synthetic := []BufferedEvent{
+		{EventType: "content_block_start", Payload: map[string]interface{}{"type": "content_block_start", "index": 0, "content_block": map[string]interface{}{"type": "text", "text": ""}}},
+		{EventType: "content_block_delta", Payload: map[string]interface{}{"type": "content_block_delta", "index": 0, "delta": map[string]interface{}{"type": "text_delta", "text": "blocked"}}},
+		{EventType: "content_block_stop", Payload: map[string]interface{}{"type": "content_block_stop", "index": 0}},
+	}
+
+	var sawID string
+	e := New(Config{
+		ToolPolicy: EmitOnComplete,
+		OnToolBlockComplete: func(toolID string, index int, buffered []BufferedEvent) (*ToolDecision, error) {
+			sawID = toolID
+			return &ToolDecision{Replace: synthetic}, nil
+		},
+	})
+
+	feedV1Raw(t, e, fxMessageStart("msg_7"))
+	feedV1Raw(t, e, fxToolUseBlockStart(0, "toolu_h", "f"))
+	feedV1Raw(t, e, fxInputJSONDelta(0, `{}`))
+	got := feedV1Raw(t, e, fxBlockStop(0))
+
+	assert.Equal(t, "toolu_h", sawID)
+	require.Len(t, got, 3)
+	assert.Equal(t, "content_block_delta", got[1].EventType)
+	delta := got[1].Payload["delta"].(map[string]interface{})
+	assert.Equal(t, "blocked", delta["text"])
+}
+
+func TestStreamEmitter_OnToolBlockComplete_DropDrops(t *testing.T) {
+	e := New(Config{
+		ToolPolicy: EmitOnComplete,
+		OnToolBlockComplete: func(toolID string, index int, buffered []BufferedEvent) (*ToolDecision, error) {
+			return &ToolDecision{Drop: true}, nil
+		},
+	})
+
+	feedV1Raw(t, e, fxMessageStart("msg_8"))
+	feedV1Raw(t, e, fxToolUseBlockStart(0, "toolu_d", "f"))
+	feedV1Raw(t, e, fxInputJSONDelta(0, `{}`))
+	got := feedV1Raw(t, e, fxBlockStop(0))
+	assert.Empty(t, got)
+}
+
+func TestStreamEmitter_OnToolBlockComplete_ErrorPropagates(t *testing.T) {
+	wantErr := errors.New("boom")
+	e := New(Config{
+		ToolPolicy: EmitOnComplete,
+		OnToolBlockComplete: func(toolID string, index int, buffered []BufferedEvent) (*ToolDecision, error) {
+			return nil, wantErr
+		},
+	})
+
+	_, err := e.FeedV1(v1Event(t, fxMessageStart("msg_e")))
+	require.NoError(t, err)
+	_, err = e.FeedV1(v1Event(t, fxToolUseBlockStart(0, "t", "f")))
+	require.NoError(t, err)
+	_, err = e.FeedV1(v1Event(t, fxBlockStop(0)))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestStreamEmitter_RejectsMixedVersions(t *testing.T) {
+	e := New(Config{})
+	_, err := e.FeedV1(v1Event(t, fxMessageStart("msg_v1")))
+	require.NoError(t, err)
+
+	_, err = e.FeedV1Beta(betaEvent(t, fxMessageStart("msg_beta")))
+	assert.ErrorIs(t, err, ErrMixedVersions)
+}
+
+func TestStreamEmitter_GuardrailsCompatSketch(t *testing.T) {
+	// The output of streamemit is byte-compatible with
+	// protocol.GuardrailsBufferedEvent (it's the same type via alias).
+	// This test demonstrates that the Payload map a guardrails consumer
+	// would build by hand matches what the emitter produces.
+	e := New(Config{ToolPolicy: EmitOnComplete})
+	feedV1Raw(t, e, fxMessageStart("msg_gr"))
+	feedV1Raw(t, e, fxToolUseBlockStart(0, "toolu_gr", "f"))
+	feedV1Raw(t, e, fxInputJSONDelta(0, `{}`))
+	flushed := feedV1Raw(t, e, fxBlockStop(0))
+
+	// Construct an equivalent slice of GuardrailsBufferedEvent from the
+	// same raw JSON payloads — the alias makes assignment trivial.
+	var guardrailsView []protocol.GuardrailsBufferedEvent = flushed
+	require.Len(t, guardrailsView, 3)
+	assert.Equal(t, "content_block_start", guardrailsView[0].EventType)
+
+	// And the Payload round-trips through json.Marshal -> json.Unmarshal,
+	// which is what sendAnthropicStreamEvent does.
+	for _, ev := range guardrailsView {
+		raw, err := json.Marshal(ev.Payload)
+		require.NoError(t, err)
+		var back map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &back))
+		assert.Equal(t, ev.Payload["type"], back["type"])
+	}
+}

--- a/internal/protocol/assembler/streamemit/emitter_v1.go
+++ b/internal/protocol/assembler/streamemit/emitter_v1.go
@@ -1,0 +1,95 @@
+package streamemit
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// FeedV1 routes a v1 Anthropic stream event through the emitter and
+// returns the (possibly empty) events to send to the consumer right now.
+func (e *StreamEmitter) FeedV1(evt *anthropic.MessageStreamEventUnion) ([]BufferedEvent, error) {
+	if evt == nil {
+		return nil, nil
+	}
+	if e.version == versionUnset {
+		e.version = versionV1
+	} else if e.version != versionV1 {
+		return nil, ErrMixedVersions
+	}
+
+	// Always feed the inner assembler so MessageAssembler() and Finish()
+	// stay accurate regardless of buffering decisions.
+	e.msg.RecordV1Event(evt)
+
+	payload, err := payloadFromRaw(evt.RawJSON(), evt.Type)
+	if err != nil {
+		return nil, err
+	}
+	buf := BufferedEvent{EventType: evt.Type, Payload: payload}
+	index := int(evt.Index)
+
+	switch evt.Type {
+	case "message_start", "message_delta", "message_stop":
+		return []BufferedEvent{buf}, nil
+
+	case "content_block_start":
+		kind, toolID := decideBlockKindV1(evt.ContentBlock)
+		e.kinds[index] = kind
+		if kind == BlockKindToolUse {
+			e.toolIDs[index] = toolID
+		}
+		if e.shouldBuffer(kind) {
+			e.openBuffer(index, toolID, buf)
+			return nil, nil
+		}
+		return []BufferedEvent{buf}, nil
+
+	case "content_block_delta":
+		if e.isBuffered(index) {
+			e.toolBufs[index].append(buf)
+			return nil, nil
+		}
+		return []BufferedEvent{buf}, nil
+
+	case "content_block_stop":
+		if e.isBuffered(index) {
+			e.toolBufs[index].append(buf)
+			return e.flushToolBuffer(index)
+		}
+		return []BufferedEvent{buf}, nil
+
+	default:
+		return []BufferedEvent{buf}, nil
+	}
+}
+
+// shouldBuffer reports whether new blocks of the given kind should be
+// held under EmitOnComplete given the emitter's policy.
+func (e *StreamEmitter) shouldBuffer(kind BlockKind) bool {
+	switch kind {
+	case BlockKindText:
+		return e.cfg.TextPolicy == EmitOnComplete
+	case BlockKindThinking:
+		return e.cfg.ThinkingPolicy == EmitOnComplete
+	case BlockKindToolUse:
+		return e.cfg.ToolPolicy == EmitOnComplete
+	default:
+		return false
+	}
+}
+
+// openBuffer creates a new toolBlockBuffer for the given index and seeds
+// it with the start event. We reuse the tool buffer machinery for any
+// kind that is configured to buffer (text/thinking/tool_use).
+func (e *StreamEmitter) openBuffer(index int, toolID string, start BufferedEvent) {
+	buf := newToolBlockBuffer(index, toolID)
+	buf.append(start)
+	e.toolBufs[index] = buf
+}
+
+// isBuffered reports whether the given content block index currently has
+// a live buffer (i.e. its start event was held and the block hasn't been
+// flushed yet).
+func (e *StreamEmitter) isBuffered(index int) bool {
+	_, ok := e.toolBufs[index]
+	return ok
+}

--- a/internal/protocol/assembler/streamemit/emitter_v1beta.go
+++ b/internal/protocol/assembler/streamemit/emitter_v1beta.go
@@ -1,0 +1,61 @@
+package streamemit
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// FeedV1Beta routes a v1beta Anthropic stream event through the emitter
+// and returns the events to send to the consumer right now.
+func (e *StreamEmitter) FeedV1Beta(evt *anthropic.BetaRawMessageStreamEventUnion) ([]BufferedEvent, error) {
+	if evt == nil {
+		return nil, nil
+	}
+	if e.version == versionUnset {
+		e.version = versionV1Beta
+	} else if e.version != versionV1Beta {
+		return nil, ErrMixedVersions
+	}
+
+	e.msg.RecordV1BetaEvent(evt)
+
+	payload, err := payloadFromRaw(evt.RawJSON(), evt.Type)
+	if err != nil {
+		return nil, err
+	}
+	buf := BufferedEvent{EventType: evt.Type, Payload: payload}
+	index := int(evt.Index)
+
+	switch evt.Type {
+	case "message_start", "message_delta", "message_stop":
+		return []BufferedEvent{buf}, nil
+
+	case "content_block_start":
+		kind, toolID := decideBlockKindV1Beta(evt.ContentBlock)
+		e.kinds[index] = kind
+		if kind == BlockKindToolUse {
+			e.toolIDs[index] = toolID
+		}
+		if e.shouldBuffer(kind) {
+			e.openBuffer(index, toolID, buf)
+			return nil, nil
+		}
+		return []BufferedEvent{buf}, nil
+
+	case "content_block_delta":
+		if e.isBuffered(index) {
+			e.toolBufs[index].append(buf)
+			return nil, nil
+		}
+		return []BufferedEvent{buf}, nil
+
+	case "content_block_stop":
+		if e.isBuffered(index) {
+			e.toolBufs[index].append(buf)
+			return e.flushToolBuffer(index)
+		}
+		return []BufferedEvent{buf}, nil
+
+	default:
+		return []BufferedEvent{buf}, nil
+	}
+}

--- a/internal/protocol/assembler/streamemit/kind.go
+++ b/internal/protocol/assembler/streamemit/kind.go
@@ -1,0 +1,67 @@
+package streamemit
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// BlockKind is the assembler-level classification of a content block.
+// We collapse the SDK's many tool-result variants into a single ToolUse
+// kind because the routing decision is the same for all of them: hold
+// until complete, or pass through.
+type BlockKind uint8
+
+const (
+	BlockKindUnknown BlockKind = iota
+	BlockKindText
+	BlockKindThinking
+	BlockKindToolUse
+)
+
+// decideBlockKindV1 inspects a v1 content_block_start payload and returns
+// the BlockKind plus the tool_use id (empty for non-tool blocks).
+func decideBlockKindV1(b anthropic.ContentBlockStartEventContentBlockUnion) (BlockKind, string) {
+	switch b.Type {
+	case "text":
+		return BlockKindText, ""
+	case "thinking", "redacted_thinking":
+		return BlockKindThinking, ""
+	case "tool_use",
+		"server_tool_use",
+		"web_search_tool_result",
+		"web_fetch_tool_result",
+		"code_execution_tool_result",
+		"bash_code_execution_tool_result",
+		"text_editor_code_execution_tool_result",
+		"tool_search_tool_result",
+		"container_upload":
+		return BlockKindToolUse, b.ID
+	default:
+		return BlockKindUnknown, b.ID
+	}
+}
+
+// decideBlockKindV1Beta is the v1beta variant of decideBlockKindV1.
+func decideBlockKindV1Beta(b anthropic.BetaRawContentBlockStartEventContentBlockUnion) (BlockKind, string) {
+	switch b.Type {
+	case "text":
+		return BlockKindText, ""
+	case "thinking", "redacted_thinking":
+		return BlockKindThinking, ""
+	case "tool_use",
+		"server_tool_use",
+		"web_search_tool_result",
+		"web_fetch_tool_result",
+		"advisor_tool_result",
+		"code_execution_tool_result",
+		"bash_code_execution_tool_result",
+		"text_editor_code_execution_tool_result",
+		"tool_search_tool_result",
+		"mcp_tool_use",
+		"mcp_tool_result",
+		"container_upload",
+		"compaction":
+		return BlockKindToolUse, b.ID
+	default:
+		return BlockKindUnknown, b.ID
+	}
+}

--- a/internal/protocol/assembler/streamemit/policy.go
+++ b/internal/protocol/assembler/streamemit/policy.go
@@ -1,0 +1,50 @@
+package streamemit
+
+// EmissionPolicy controls when events for a given block kind are released
+// from the emitter to the caller.
+type EmissionPolicy int
+
+const (
+	// EmitImmediate releases each event as soon as it is fed to the emitter.
+	// This is the zero value and matches today's passthrough behavior.
+	EmitImmediate EmissionPolicy = iota
+
+	// EmitOnComplete buffers all events for a single content block from
+	// content_block_start through content_block_stop, then releases them
+	// as one ordered slice when the stop event arrives.
+	EmitOnComplete
+)
+
+// Config configures a StreamEmitter. The zero value emits everything
+// immediately and installs no hooks.
+type Config struct {
+	// TextPolicy governs "text" content blocks.
+	TextPolicy EmissionPolicy
+
+	// ThinkingPolicy governs "thinking" and "redacted_thinking" content blocks.
+	ThinkingPolicy EmissionPolicy
+
+	// ToolPolicy governs "tool_use" content blocks. Setting this to
+	// EmitOnComplete is the primary use case for this package: tool events
+	// are held until the tool's content_block_stop arrives.
+	ToolPolicy EmissionPolicy
+
+	// OnToolBlockComplete is invoked when a tool_use block has finished
+	// buffering under EmitOnComplete and is about to be released. The hook
+	// receives the tool_use id, the content block index, and the buffered
+	// events in arrival order. It may return a *ToolDecision to replace or
+	// drop the buffered events; returning nil flushes them as-is. An error
+	// short-circuits Feed and is returned to the caller.
+	OnToolBlockComplete func(toolID string, index int, buffered []BufferedEvent) (*ToolDecision, error)
+}
+
+// ToolDecision is the return value of Config.OnToolBlockComplete.
+//
+// If Drop is true the buffered events are suppressed entirely.
+// Otherwise, if Replace is non-nil those events are emitted instead of
+// the buffered ones. A nil ToolDecision (or a zero-value one) means
+// "flush the buffered events unchanged".
+type ToolDecision struct {
+	Replace []BufferedEvent
+	Drop    bool
+}

--- a/internal/protocol/assembler/streamemit/testdata_helpers_test.go
+++ b/internal/protocol/assembler/streamemit/testdata_helpers_test.go
@@ -1,0 +1,108 @@
+package streamemit
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// v1Event JSON-unmarshals a raw Anthropic v1 stream event into a typed
+// MessageStreamEventUnion. Failing here indicates a malformed fixture.
+func v1Event(t *testing.T, raw string) *anthropic.MessageStreamEventUnion {
+	t.Helper()
+	var evt anthropic.MessageStreamEventUnion
+	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+		t.Fatalf("v1Event unmarshal failed: %v\nraw: %s", err, raw)
+	}
+	return &evt
+}
+
+// betaEvent JSON-unmarshals a raw Anthropic v1beta stream event into a
+// typed BetaRawMessageStreamEventUnion.
+func betaEvent(t *testing.T, raw string) *anthropic.BetaRawMessageStreamEventUnion {
+	t.Helper()
+	var evt anthropic.BetaRawMessageStreamEventUnion
+	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+		t.Fatalf("betaEvent unmarshal failed: %v\nraw: %s", err, raw)
+	}
+	return &evt
+}
+
+// Fixture builders. Each returns a JSON string that can be passed to
+// v1Event or betaEvent.
+
+func fxMessageStart(id string) string {
+	return fmt.Sprintf(`{
+		"type": "message_start",
+		"message": {
+			"id": %q,
+			"type": "message",
+			"role": "assistant",
+			"content": [],
+			"model": "claude-test",
+			"stop_reason": null,
+			"stop_sequence": null,
+			"usage": {"input_tokens": 1, "output_tokens": 0}
+		}
+	}`, id)
+}
+
+func fxMessageDelta(stopReason string, outTokens int) string {
+	return fmt.Sprintf(`{
+		"type": "message_delta",
+		"delta": {"stop_reason": %q, "stop_sequence": null},
+		"usage": {"input_tokens": 0, "output_tokens": %d}
+	}`, stopReason, outTokens)
+}
+
+func fxMessageStop() string {
+	return `{"type": "message_stop"}`
+}
+
+func fxTextBlockStart(index int) string {
+	return fmt.Sprintf(`{
+		"type": "content_block_start",
+		"index": %d,
+		"content_block": {"type": "text", "text": ""}
+	}`, index)
+}
+
+func fxThinkingBlockStart(index int) string {
+	return fmt.Sprintf(`{
+		"type": "content_block_start",
+		"index": %d,
+		"content_block": {"type": "thinking", "thinking": "", "signature": ""}
+	}`, index)
+}
+
+func fxToolUseBlockStart(index int, id, name string) string {
+	return fmt.Sprintf(`{
+		"type": "content_block_start",
+		"index": %d,
+		"content_block": {"type": "tool_use", "id": %q, "name": %q, "input": {}}
+	}`, index, id, name)
+}
+
+func fxTextDelta(index int, text string) string {
+	textJSON, _ := json.Marshal(text)
+	return fmt.Sprintf(`{
+		"type": "content_block_delta",
+		"index": %d,
+		"delta": {"type": "text_delta", "text": %s}
+	}`, index, textJSON)
+}
+
+func fxInputJSONDelta(index int, partial string) string {
+	pj, _ := json.Marshal(partial)
+	return fmt.Sprintf(`{
+		"type": "content_block_delta",
+		"index": %d,
+		"delta": {"type": "input_json_delta", "partial_json": %s}
+	}`, index, pj)
+}
+
+func fxBlockStop(index int) string {
+	return fmt.Sprintf(`{"type": "content_block_stop", "index": %d}`, index)
+}

--- a/internal/protocol/assembler/streamemit/tool_buffer.go
+++ b/internal/protocol/assembler/streamemit/tool_buffer.go
@@ -1,0 +1,37 @@
+package streamemit
+
+// toolBlockBuffer accumulates the start, deltas, and stop events for a
+// single tool_use content block while EmitOnComplete is in effect. It is
+// flushed as one ordered slice when the block's content_block_stop event
+// arrives (or when Drain is called).
+type toolBlockBuffer struct {
+	index  int
+	toolID string
+	events []BufferedEvent
+}
+
+func newToolBlockBuffer(index int, toolID string) *toolBlockBuffer {
+	return &toolBlockBuffer{index: index, toolID: toolID}
+}
+
+func (b *toolBlockBuffer) append(evt BufferedEvent) {
+	b.events = append(b.events, evt)
+}
+
+// drain returns all buffered events in arrival order and clears the buffer.
+func (b *toolBlockBuffer) drain() []BufferedEvent {
+	out := b.events
+	b.events = nil
+	return out
+}
+
+// snapshot returns a copy of the buffered events without clearing the buffer.
+// Used by StreamEmitter.ToolBuffer for read-only inspection.
+func (b *toolBlockBuffer) snapshot() []BufferedEvent {
+	if len(b.events) == 0 {
+		return nil
+	}
+	out := make([]BufferedEvent, len(b.events))
+	copy(out, b.events)
+	return out
+}


### PR DESCRIPTION
## Summary

- New package `internal/protocol/assembler/streamemit/` wraps `AnthropicStreamAssembler` so callers can independently observe message and tool assembly, and optionally hold a `tool_use` block's stream events until the block is fully assembled.
- Generalizes the buffer-then-decide pattern that today only lives in `internal/guardrails/mutate/anthropic_stream.go`, so non-guardrails callers can use the same shape and guardrails itself can eventually compose onto it.
- Library-only change. No handler is rewired; `anthropic_passthrough.go`, the existing assemblers, `protocol/context.go`, and the guardrails layer are untouched.

## What it does

`StreamEmitter` routes each Anthropic v1 / v1beta stream event through a per-kind `EmissionPolicy`:

- `EmitImmediate` (zero value) — events flow out 1:1 as they arrive. Byte-identical to today's behavior.
- `EmitOnComplete` — events for one content block (`content_block_start` -> deltas -> `content_block_stop`) are buffered, then released as a single ordered slice on stop. The primary use case is "hold the `tool_use` block until the input JSON is fully parsed" while text and thinking continue to stream live in parallel.

```
events arriving:   ms_start  cb_start(text)  txt_d  cb_stop  cb_start(tool)  json_d  json_d  cb_stop  ms_stop
                       │           │           │       │            │           │       │       │         │
emitter.Feed   ───►   1ev         1ev         1ev     1ev          0ev         0ev     0ev    ┌─4ev─┐    1ev
                       ▼           ▼           ▼       ▼            ▼           ▼       ▼     ▼     ▼     ▼
 SSE wire:           ms_start    cb_start(t)  d     cb_stop      ░░░░░░░  ░░░░░  ░░░░░  cb_start(tool)  ms_stop
                                                                                        json_d
                                                                                        json_d
                                                                                        cb_stop
```

A `Config.OnToolBlockComplete` hook receives the buffered tool events and may `Replace` / `Drop` / pass them through — the same decision shape the guardrails rewriter uses, so a future adapter is one screen of code. `MessageAssembler()`, `ToolBuffer(idx)`, `Drain()`, and `Finish()` give callers independent inspection of each side.

`BufferedEvent` is a type alias of `protocol.GuardrailsBufferedEvent`, so `streamemit` and guardrails outputs are interchangeable without translation.

See `internal/protocol/assembler/streamemit/README.md` for full design, usage, and migration notes.

## What is NOT in this PR

- No edits to `internal/protocol/stream/anthropic_passthrough.go` or any other handler.
- No edits to `internal/protocol/assembler/anthropic_assembler.go`, `anthropic_sdk_assembler.go`, or their tests.
- No edits to `internal/guardrails/mutate/anthropic_stream.go` or `internal/protocol/context.go`.
- OpenAI Chat / OpenAI Responses / Google streams are out of scope this iteration.

Migration of `anthropic_passthrough.go` onto the emitter, and the guardrails-as-`OnToolBlockComplete` adapter, are planned as follow-up PRs (see README "Migration plan").

## Test plan

- [x] `go build ./internal/protocol/assembler/streamemit/...`
- [x] `go test ./internal/protocol/assembler/streamemit/... -count=1 -v` — 14 cases pass
- [x] `go test ./internal/protocol/assembler/... -count=1` — existing assembler tests still green (no regressions)
- [x] `grep -rn "streamemit" internal/protocol/stream internal/server internal/guardrails` returns nothing (confirms library-only)

Coverage:

- text-only streams (v1 + v1beta) with `EmitImmediate`
- tool-only streams (v1 + v1beta) with `EmitOnComplete` — verifies start + deltas + stop release in one ordered slice
- mixed text + tool: text live, tool buffered; ordering invariant (tool flush returns only the tool's events)
- `Drain()` flushing an unclosed tool buffer
- `Finish()` returning pending events plus assembled `*anthropic.Message`
- `OnToolBlockComplete` `Replace` / `Drop` / error propagation
- `ErrMixedVersions` when v1 and v1beta are fed to the same emitter
- byte-compatibility with `protocol.GuardrailsBufferedEvent`

https://claude.ai/code/session_018gBsZfbaxuJ5hvK6jsoWZx
