### PR TITLE
feat(cli, tui): add `token` command and optional model-token reveal in quickstart

### DIFF
--- a/cli/tingly-box/main.go
+++ b/cli/tingly-box/main.go
@@ -43,6 +43,9 @@ type CLI struct {
 	// OAuth
 	OAuth command.OAuthCmdKong `kong:"cmd,name='oauth',help='OAuth authentication'"`
 
+	// Tingly-box token management (auth + model, view / refresh)
+	Token command.TokenCmdKong `kong:"cmd,name='token',help='View or refresh tingly-box auth/model tokens'"`
+
 	// Claude Code
 	CC command.CCmdKong `kong:"cmd,help='Launch Claude Code',passthrough"`
 

--- a/internal/command/token.go
+++ b/internal/command/token.go
@@ -1,0 +1,290 @@
+package command
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
+)
+
+// TokenKind identifies which tingly-box token a sub-command operates on.
+// "auth" is the UserToken (control panel + control API). "model" is the
+// ModelToken (used by AI clients hitting the box's OpenAI/Anthropic
+// endpoints). Both are managed independently from upstream provider creds.
+type TokenKind string
+
+const (
+	tokenKindAuth  TokenKind = "auth"
+	tokenKindModel TokenKind = "model"
+)
+
+// ============== Kong Command Structures ==============
+
+// TokenCmdKong manages tingly-box's own auth and model tokens.
+// Upstream provider credentials are not handled here — those live under
+// the `provider` and `oauth` commands.
+type TokenCmdKong struct {
+	List    TokenListCmdKong    `kong:"cmd,name='list',default='1',hidden,help='List tingly-box tokens (default)'"`
+	View    TokenViewCmdKong    `kong:"cmd,help='View a tingly-box token (auth or model)'"`
+	Refresh TokenRefreshCmdKong `kong:"cmd,help='Refresh (rotate) a tingly-box token (auth or model)'"`
+}
+
+// TokenListCmdKong prints both tokens with masked previews.
+type TokenListCmdKong struct{}
+
+func (t *TokenListCmdKong) Run(appManager *AppManager) error {
+	return runBoxTokenList(appManager)
+}
+
+// TokenViewCmdKong shows a single tingly-box token. When kind is omitted,
+// the user is prompted interactively.
+type TokenViewCmdKong struct {
+	Kind string `kong:"arg,optional,help='Which token to view: auth or model'"`
+	Reveal bool   `kong:"flag,name='reveal',short='r',help='Print the full token instead of a masked preview'"`
+}
+
+func (t *TokenViewCmdKong) Run(appManager *AppManager) error {
+	kind, err := resolveTokenKind(t.Kind)
+	if err != nil {
+		return err
+	}
+	return runBoxTokenView(appManager, kind, t.Reveal)
+}
+
+// TokenRefreshCmdKong rotates a tingly-box token (auth or model) and
+// persists the new value. Existing clients using the old token will need
+// to be updated.
+type TokenRefreshCmdKong struct {
+	Kind string `kong:"arg,optional,help='Which token to refresh: auth or model'"`
+	Reveal bool   `kong:"flag,name='reveal',short='r',help='Print the full rotated token after success'"`
+	Yes    bool   `kong:"flag,name='yes',short='y',help='Skip the rotation confirmation prompt'"`
+}
+
+func (t *TokenRefreshCmdKong) Run(appManager *AppManager) error {
+	kind, err := resolveTokenKind(t.Kind)
+	if err != nil {
+		return err
+	}
+	return runBoxTokenRefresh(appManager, kind, t.Reveal, t.Yes)
+}
+
+// ============== Business Logic Functions ==============
+
+// resolveTokenKind validates an argument value and prompts the user when
+// the argument was omitted on the command line.
+func resolveTokenKind(arg string) (TokenKind, error) {
+	switch strings.ToLower(strings.TrimSpace(arg)) {
+	case "auth", "user":
+		return tokenKindAuth, nil
+	case "model":
+		return tokenKindModel, nil
+	case "":
+		// fall through to interactive
+	default:
+		return "", fmt.Errorf("unknown token kind %q (expected 'auth' or 'model')", arg)
+	}
+
+	fmt.Println("Which tingly-box token?")
+	fmt.Println("  [1] auth   — control panel & control API (UserToken)")
+	fmt.Println("  [2] model  — model API for AI clients (ModelToken)")
+	fmt.Print("Enter choice: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(input)) {
+	case "1", "auth", "user":
+		return tokenKindAuth, nil
+	case "2", "model":
+		return tokenKindModel, nil
+	}
+	return "", fmt.Errorf("invalid selection")
+}
+
+// runBoxTokenList prints both tingly-box tokens (masked) along with the
+// endpoint each one is used for.
+func runBoxTokenList(appManager *AppManager) error {
+	cfg, err := globalConfigOrErr(appManager)
+	if err != nil {
+		return err
+	}
+	port := cfg.ServerPort
+	if port == 0 {
+		port = 12580
+	}
+
+	fmt.Println()
+	fmt.Println("Tingly Box Tokens")
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Printf("  auth   %s\n", maskTokenPreview(cfg.GetUserToken()))
+	fmt.Printf("         used at  http://localhost:%d/login/<token>\n", port)
+	fmt.Printf("  model  %s\n", maskTokenPreview(cfg.GetModelToken()))
+	fmt.Printf("         used at  http://localhost:%d (OpenAI/Anthropic API)\n", port)
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println("Tip: 'tingly-box token view <auth|model> --reveal' to copy.")
+	return nil
+}
+
+// runBoxTokenView prints a single tingly-box token, masked unless --reveal.
+func runBoxTokenView(appManager *AppManager, kind TokenKind, reveal bool) error {
+	cfg, err := globalConfigOrErr(appManager)
+	if err != nil {
+		return err
+	}
+	value := readBoxToken(cfg, kind)
+	if value == "" {
+		return fmt.Errorf("%s token is not set; run 'tingly-box token refresh %s' to generate one", kind, kind)
+	}
+	port := cfg.ServerPort
+	if port == 0 {
+		port = 12580
+	}
+
+	fmt.Println()
+	fmt.Println("Tingly Box Token")
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Printf("Kind:     %s\n", kind)
+	fmt.Printf("Purpose:  %s\n", boxTokenPurpose(kind))
+	fmt.Printf("Endpoint: %s\n", boxTokenEndpoint(kind, port, value, reveal))
+	if reveal {
+		fmt.Printf("Token:    %s\n", value)
+	} else {
+		fmt.Printf("Token:    %s   (use --reveal to copy full token)\n", maskTokenPreview(value))
+	}
+	fmt.Println(strings.Repeat("=", 60))
+	if reveal {
+		fmt.Println("Note: token printed in full above — handle with care.")
+	}
+	return nil
+}
+
+// runBoxTokenRefresh rotates the chosen token, persists the change, and
+// prints the new value. Prompts for confirmation unless --yes is set
+// because rotation invalidates any clients still using the old token.
+func runBoxTokenRefresh(appManager *AppManager, kind TokenKind, reveal, yes bool) error {
+	cfg, err := globalConfigOrErr(appManager)
+	if err != nil {
+		return err
+	}
+
+	if !yes {
+		fmt.Printf("Rotate the %s token now? Existing clients using the current token will stop working until updated. [y/N]: ", kind)
+		reader := bufio.NewReader(os.Stdin)
+		input, _ := reader.ReadString('\n')
+		switch strings.ToLower(strings.TrimSpace(input)) {
+		case "y", "yes":
+		default:
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	newToken, err := generateBoxToken(kind)
+	if err != nil {
+		return fmt.Errorf("failed to generate %s token: %w", kind, err)
+	}
+	if err := writeBoxToken(cfg, kind, newToken); err != nil {
+		return fmt.Errorf("failed to persist %s token: %w", kind, err)
+	}
+
+	port := cfg.ServerPort
+	if port == 0 {
+		port = 12580
+	}
+	fmt.Println()
+	fmt.Printf("Rotated %s token successfully.\n", kind)
+	fmt.Printf("Endpoint: %s\n", boxTokenEndpoint(kind, port, newToken, reveal))
+	if reveal {
+		fmt.Printf("Token:    %s\n", newToken)
+	} else {
+		fmt.Printf("Token:    %s   (use --reveal to copy full token)\n", maskTokenPreview(newToken))
+	}
+	fmt.Println("Restart any clients (web UI, AI tools) with the new value.")
+	return nil
+}
+
+// ============== Helpers ==============
+
+func globalConfigOrErr(appManager *AppManager) (*serverconfig.Config, error) {
+	if appManager == nil || appManager.AppConfig() == nil {
+		return nil, fmt.Errorf("application config not initialised")
+	}
+	cfg := appManager.AppConfig().GetGlobalConfig()
+	if cfg == nil {
+		return nil, fmt.Errorf("global config not available")
+	}
+	return cfg, nil
+}
+
+func readBoxToken(cfg *serverconfig.Config, kind TokenKind) string {
+	switch kind {
+	case tokenKindAuth:
+		return cfg.GetUserToken()
+	case tokenKindModel:
+		return cfg.GetModelToken()
+	}
+	return ""
+}
+
+func writeBoxToken(cfg *serverconfig.Config, kind TokenKind, value string) error {
+	switch kind {
+	case tokenKindAuth:
+		return cfg.SetUserToken(value)
+	case tokenKindModel:
+		return cfg.SetModelToken(value)
+	}
+	return fmt.Errorf("unknown token kind: %s", kind)
+}
+
+func generateBoxToken(kind TokenKind) (string, error) {
+	switch kind {
+	case tokenKindAuth:
+		return serverconfig.GenerateUserToken()
+	case tokenKindModel:
+		return serverconfig.GenerateModelToken()
+	}
+	return "", fmt.Errorf("unknown token kind: %s", kind)
+}
+
+func boxTokenPurpose(kind TokenKind) string {
+	switch kind {
+	case tokenKindAuth:
+		return "control panel & control API authentication"
+	case tokenKindModel:
+		return "model API authentication for AI clients"
+	}
+	return ""
+}
+
+// boxTokenEndpoint formats the endpoint hint for the given token. For the
+// auth token the URL embeds the value when the user opted into --reveal;
+// otherwise a placeholder is shown so logs don't leak the secret.
+func boxTokenEndpoint(kind TokenKind, port int, value string, reveal bool) string {
+	switch kind {
+	case tokenKindAuth:
+		if reveal && value != "" {
+			return fmt.Sprintf("http://localhost:%d/login/%s", port, value)
+		}
+		return fmt.Sprintf("http://localhost:%d/login/<token>", port)
+	case tokenKindModel:
+		return fmt.Sprintf("http://localhost:%d", port)
+	}
+	return ""
+}
+
+// maskTokenPreview returns a redacted preview of a token suitable for
+// display, e.g. "tb-mod…wxyz". Tokens shorter than 12 chars are fully
+// masked.
+func maskTokenPreview(t string) string {
+	if t == "" {
+		return "<empty>"
+	}
+	if len(t) <= 12 {
+		return strings.Repeat("•", len(t))
+	}
+	return t[:6] + "…" + t[len(t)-4:]
+}

--- a/internal/command/tui/quickstart.go
+++ b/internal/command/tui/quickstart.go
@@ -63,6 +63,7 @@ func RunQuickstart(mgr QuickstartManager) error {
 		{Name: "Details", Execute: qsDetails, Skip: qsUsingExisting},
 		{Name: "Model", Execute: qsModel},
 		{Name: "Rules", Execute: qsRules},
+		{Name: "Token", Execute: qsShowToken},
 		{Name: "Agent", Execute: qsAgent},
 		{Name: "Done", Execute: qsDone},
 	}
@@ -570,6 +571,54 @@ func qsRules(ctx StepContext, s quickstartState) (quickstartState, StepResult, e
 		configured++
 	}
 	fmt.Println(descStyle.Render(fmt.Sprintf("\n%d rules configured.\n", configured)))
+	return s, StepContinue, nil
+}
+
+// qsShowToken offers an optional preview of the tingly-box model token —
+// the credential AI clients send to this box's OpenAI/Anthropic-compatible
+// endpoints. Skipped by default; answering "no" advances without printing
+// the secret. This is independent of upstream provider tokens.
+func qsShowToken(ctx StepContext, s quickstartState) (quickstartState, StepResult, error) {
+	cfg := s.mgr.GetGlobalConfig()
+	if cfg == nil {
+		return s, StepContinue, nil
+	}
+	modelToken := cfg.ModelToken
+	if modelToken == "" {
+		// Token is generated lazily at server start; nothing to show yet.
+		return s, StepContinue, nil
+	}
+
+	r, err := Confirm("Reveal tingly box model token now?", ConfirmOptions{
+		Header:      ctx.Header,
+		DefaultYes:  false,
+		CanGoBack:   true,
+		Description: "Prints this box's model token (clients use it to call the box) — only reveal on a trusted screen.",
+	})
+	if err != nil {
+		return s, StepCancel, err
+	}
+	switch {
+	case r.IsBack():
+		return s, StepBack, nil
+	case r.IsCancel():
+		return s, StepCancel, nil
+	}
+	if !r.Value {
+		return s, StepContinue, nil
+	}
+
+	port := s.mgr.GetServerPort()
+	if port == 0 {
+		port = 12580
+	}
+
+	fmt.Println()
+	fmt.Println(promptStyle.Render("Tingly Box model token (copy into your AI client):"))
+	fmt.Println(descStyle.Render("  Endpoint ") + valueStyle.Render(fmt.Sprintf("http://localhost:%d", port)))
+	fmt.Println(descStyle.Render("  Token    ") + valueStyle.Render(modelToken))
+	fmt.Println(descStyle.Render("  Tip: 'tingly-box token view model --reveal' to copy later, 'token refresh model' to rotate."))
+	fmt.Println()
 	return s, StepContinue, nil
 }
 


### PR DESCRIPTION
## Summary

Add a new `token` command group that manages tingly-box's **own** credentials — `UserToken` (auth) and `ModelToken` (model API) — and surface the model token through an optional reveal step in the quickstart TUI so users can copy it straight into their AI client during setup.

This is distinct from upstream **provider** credentials, which remain the responsibility of the existing `provider` and `oauth` commands.

## Changes

### `tingly-box token` (new) — `internal/command/token.go`, `cli/tingly-box/main.go`

| Command | Behavior |
| --- | --- |
| `token` (default `list`) | Print both tokens with masked previews (e.g. `tb-user…wxyz`) and the endpoint each is used for. |
| `token view <auth\|model> [--reveal]` | Show one token. `--reveal` prints the full secret and embeds it into the corresponding login/API URL. |
| `token refresh <auth\|model> [--reveal] [--yes]` | Rotate via `GenerateUserToken` / `GenerateModelToken`, persist via `SetUserToken` / `SetModelToken`. Prompts for confirmation unless `--yes` is passed because rotation invalidates clients still on the old token. |

- Kind argument is interactive (numbered menu) when omitted on the command line.
- Tokens shorter than 12 characters are fully masked in previews; longer ones show first-6 and last-4.

### Quickstart TUI step — `internal/command/tui/quickstart.go`

- New optional step inserted after **Rules**: `Reveal tingly box model token now?` (defaults to **No**).
- When confirmed, prints the model token plus the local endpoint URL so users can paste it into Claude Code, Codex, etc.
- Auto-skipped if `ModelToken` has not been generated yet (e.g. first run before server start).
- Tip line points at the new `tingly-box token view model --reveal` and `token refresh model` commands for follow-up.

## Notes

- No changes to provider/OAuth credential paths — those still flow through `provider` and `oauth`.
- `token refresh` preserves the configured port in printed endpoint URLs and falls back to `12580`.

## Test plan

- [ ] `go build ./...`
- [ ] `tingly-box token --help`, `token view --help`, `token refresh --help` render the new commands and flags
- [ ] `tingly-box token` lists both tokens masked
- [ ] `tingly-box token view model --reveal` prints the full token + `http://localhost:<port>` endpoint
- [ ] `tingly-box token view auth --reveal` prints the full token + `/login/<token>` URL
- [ ] `tingly-box token refresh model` (interactive y/N) rotates and persists the model token
- [ ] `tingly-box token refresh auth --yes` rotates without prompting and persists
- [ ] `tingly-box tui` reaches the new "Token" step; **No** advances silently, **Yes** prints the model token and endpoint
- [ ] Running quickstart on a fresh config (no ModelToken yet) silently skips the new step

https://claude.ai/code/session_01CBc3ZnucMczxNsgd65TrTp