### PR TITLE
Fix Codex probe requests to use the Responses API and Codex-compatible tool schemas

### DIFF
--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -38,6 +38,8 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
 
     const configToml = `model = "tingly-codex"
 model_provider = "tingly-box"
+model_supports_reasoning_summaries = true
+model_reasoning_summary = "auto"
 
 [model_providers.tingly-box]
 name = "OpenAI using Tingly Box"

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -27,7 +27,7 @@ const UseCodexPageContent: React.FC = () => {
     // Codex has no backend apply — copy config.toml to clipboard as a convenience
     const handleApply = async (): Promise<AgentApplyResult> => {
         const codexBaseUrl = `${baseUrl}/tingly/codex`;
-        const config = `model = "tingly-codex"\nmodel_provider = "tingly-box"\n\n[model_providers.tingly-box]\nname = "OpenAI using Tingly Box"\nbase_url = "${codexBaseUrl}"\npreferred_auth_method = "apikey"\nwire_api = "responses"`;
+        const config = `model = "tingly-codex"\nmodel_provider = "tingly-box"\nmodel_supports_reasoning_summaries = true\nmodel_reasoning_summary = "auto"\n\n[model_providers.tingly-box]\nname = "OpenAI using Tingly Box"\nbase_url = "${codexBaseUrl}"\npreferred_auth_method = "apikey"\nwire_api = "responses"`;
         await navigator.clipboard.writeText(config);
         return {
             success: true,

--- a/internal/server/probe_v2_sdk.go
+++ b/internal/server/probe_v2_sdk.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/client"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -70,6 +73,38 @@ func (b *SDKProbeBuilder) buildOpenAIChatRequest(model, message string, testMode
 	return params
 }
 
+func (b *SDKProbeBuilder) buildOpenAIResponsesRequest(model, message string, testMode ProbeMode) responses.ResponseNewParams {
+	params := responses.ResponseNewParams{
+		Model:        model,
+		Instructions: param.NewOpt("work as `echo` if possible"),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: []responses.ResponseInputItemUnionParam{
+				responses.ResponseInputItemParamOfMessage(
+					responses.ResponseInputMessageContentListParam{
+						responses.ResponseInputContentParamOfInputText(message),
+					},
+					responses.EasyInputMessageRoleUser,
+				),
+			},
+		},
+	}
+
+	if testMode == ProbeV2ModeTool {
+		params.Tools = GetProbeToolsResponses()
+		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
+		}
+	}
+
+	return params
+}
+
+func shouldUseResponsesProbe(provider *typ.Provider) bool {
+	return provider.AuthType == typ.AuthTypeOAuth &&
+		provider.OAuthDetail != nil &&
+		provider.OAuthDetail.GetIssuer() == ai.IssuerCodex
+}
+
 // getClientForProvider gets the appropriate SDK client for a provider
 func (s *Server) getClientForProvider(provider *typ.Provider, model string) (interface{}, error) {
 	switch provider.APIStyle {
@@ -110,6 +145,8 @@ func (s *Server) probeProviderWithSDK(ctx context.Context, provider *typ.Provide
 	url := provider.APIBase
 	if provider.APIStyle == protocol.APIStyleAnthropic {
 		url += "/v1/messages"
+	} else if shouldUseResponsesProbe(provider) {
+		url += "/responses"
 	} else {
 		url += "/chat/completions"
 	}
@@ -132,12 +169,36 @@ func (s *Server) probeProviderWithSDK(ctx context.Context, provider *typ.Provide
 
 	case protocol.APIStyleOpenAI:
 		openaiClient := clientInterface.(*client.OpenAIClient)
+		if shouldUseResponsesProbe(provider) {
+			params := builder.buildOpenAIResponsesRequest(model, message, testMode)
+			stream := openaiClient.ResponsesNewStreaming(ctx, params)
+			defer stream.Close()
+
+			var chunks []interface{}
+			for stream.Next() {
+				chunks = append(chunks, stream.Current())
+			}
+
+			if err := stream.Err(); err != nil {
+				return nil, err
+			}
+
+			respJSON, err := json.Marshal(chunks)
+			if err != nil {
+				return nil, err
+			}
+			return &ProbeV2Data{
+				Content:    string(respJSON),
+				LatencyMs:  time.Since(startTime).Milliseconds(),
+				RequestURL: url,
+			}, nil
+		}
+
 		params := builder.buildOpenAIChatRequest(model, message, testMode)
 		resp, err := openaiClient.ChatCompletionsNew(ctx, params)
 		if err != nil {
 			return nil, err
 		}
-		// Convert response to JSON string as content
 		respJSON, _ := json.Marshal(resp)
 		return &ProbeV2Data{
 			Content:    string(respJSON),
@@ -164,6 +225,8 @@ func (s *Server) probeProviderStream(ctx context.Context, provider *typ.Provider
 	url := provider.APIBase
 	if provider.APIStyle == protocol.APIStyleAnthropic {
 		url += "/v1/messages"
+	} else if shouldUseResponsesProbe(provider) {
+		url += "/responses"
 	} else {
 		url += "/chat/completions"
 	}
@@ -196,6 +259,28 @@ func (s *Server) probeProviderStream(ctx context.Context, provider *typ.Provider
 
 	case protocol.APIStyleOpenAI:
 		openaiClient := clientInterface.(*client.OpenAIClient)
+		if shouldUseResponsesProbe(provider) {
+			params := builder.buildOpenAIResponsesRequest(model, message, testMode)
+			stream := openaiClient.ResponsesNewStreaming(ctx, params)
+			defer stream.Close()
+
+			var chunks []interface{}
+			for stream.Next() {
+				chunks = append(chunks, stream.Current())
+			}
+
+			if err := stream.Err(); err != nil {
+				return nil, err
+			}
+
+			chunksJSON, _ := json.Marshal(chunks)
+			return &ProbeV2Data{
+				Content:    string(chunksJSON),
+				LatencyMs:  time.Since(startTime).Milliseconds(),
+				RequestURL: url,
+			}, nil
+		}
+
 		params := builder.buildOpenAIChatRequest(model, message, testMode)
 		stream := openaiClient.ChatCompletionsNewStreaming(ctx, params)
 		defer stream.Close()
@@ -203,7 +288,6 @@ func (s *Server) probeProviderStream(ctx context.Context, provider *typ.Provider
 		var chunks []interface{}
 		for stream.Next() {
 			chunk := stream.Current()
-			// Collect each chunk as-is
 			chunks = append(chunks, chunk)
 		}
 
@@ -211,7 +295,6 @@ func (s *Server) probeProviderStream(ctx context.Context, provider *typ.Provider
 			return nil, err
 		}
 
-		// Convert chunks to JSON string as content
 		chunksJSON, _ := json.Marshal(chunks)
 		return &ProbeV2Data{
 			Content:    string(chunksJSON),

--- a/internal/server/probe_v2_tools.go
+++ b/internal/server/probe_v2_tools.go
@@ -4,6 +4,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
 )
 
@@ -40,7 +41,8 @@ func GetProbeToolsOpenAI() []openai.ChatCompletionToolUnionParam {
 			Name:        "add_numbers",
 			Description: param.NewOpt("Add two numbers"),
 			Parameters: shared.FunctionParameters{
-				"type": "object",
+				"type":                 "object",
+				"additionalProperties": false,
 				"properties": map[string]interface{}{
 					"a": map[string]interface{}{
 						"type":        "number",
@@ -54,6 +56,31 @@ func GetProbeToolsOpenAI() []openai.ChatCompletionToolUnionParam {
 				"required": []string{"a", "b"},
 			},
 		}),
+	}
+}
+
+// GetProbeToolsResponses returns predefined tools in Responses API format for probe testing.
+func GetProbeToolsResponses() []responses.ToolUnionParam {
+	return []responses.ToolUnionParam{
+		responses.ToolParamOfFunction(
+			"add_numbers",
+			map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"a": map[string]interface{}{
+						"type":        "number",
+						"description": "The first number to add",
+					},
+					"b": map[string]interface{}{
+						"type":        "number",
+						"description": "The second number to add",
+					},
+				},
+				"required": []string{"a", "b"},
+			},
+			true,
+		),
 	}
 }
 


### PR DESCRIPTION
**Summary**

This PR fixes probe failures for Codex-backed providers and rules.

When a probe targeted a provider or rule that ultimately used the ChatGPT Codex backend, the probe flow could still send Chat Completions style requests with `messages`, use non-stream Responses calls against an SSE endpoint, or send tool schemas that were valid for standard OpenAI chat but rejected by the Codex backend. These mismatches caused probe errors even though the underlying provider configuration was otherwise correct.

<img width="1057" height="453" alt="截屏2026-05-07 17 30 06" src="https://github.com/user-attachments/assets/b9c1c8ed-2194-4141-b606-51cb10d0d493" />

**Root Cause**

- Probe V2 SDK paths built `/chat/completions` requests for OpenAI-style targets without accounting for providers that actually route to the ChatGPT Codex backend.
- Codex backend probe requests need to use the Responses API and, in practice, stream mode semantics.
- Codex backend also validates function tool schemas more strictly and requires `additionalProperties: false` in the probe function schema.

**Changes**

### Probe V2 Responses support
- Add Responses API request construction for Probe V2 SDK flows.
- Route Codex-backed OpenAI probes to `/responses` instead of `/chat/completions`.
- Apply the same Codex-aware behavior to simple, streaming, and tool probe modes.

### Streaming handling for Codex probes
- Use `ResponsesNewStreaming()` for Codex-backed simple probes as well as streaming probes.
- Collect streamed events and return them as probe output instead of attempting a non-stream Responses call against an SSE response.

### Codex-compatible tool schemas
- Update probe function tool schemas for OpenAI/Responses probe requests to include:
  - `type: "object"`
  - `additionalProperties: false`
- Keep the existing probe tool shape while making it acceptable to the Codex backend.
