### PR TITLE
bugfix(remote): add per-chat project history and numeric project switching

### DIFF
--- a/internal/remote_control/bot/agent_smart_guide.go
+++ b/internal/remote_control/bot/agent_smart_guide.go
@@ -137,7 +137,7 @@ func (e *SmartGuideExecutor) Execute(ctx context.Context, req PreparedRequest) (
 				"newPath": newProjectPath,
 			}).Info("updateProjectFunc called - persisting to chat store")
 			return e.deps.ChatStore.UpdateChat(chatID, func(chat *Chat) {
-				chat.ProjectPath = newProjectPath
+				pushProjectHistory(chat, newProjectPath)
 				chat.BashCwd = newProjectPath
 			})
 		},

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -180,18 +180,26 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 
 	if len(projectPaths) > 0 {
 		buf.WriteString("Your Projects:\n")
+		for i, path := range projectPaths {
+			marker := ""
+			if path == currentPath {
+				marker = " ✓"
+			}
+			buf.WriteString(fmt.Sprintf("  %d. %s%s\n", i+1, path, marker))
+		}
+		buf.WriteString("\nUse /cd <number> or /cd <path> to switch.")
 	} else {
 		buf.WriteString("No projects found.")
 	}
 
 	var rows [][]imbot.InlineKeyboardButton
-	for _, path := range projectPaths {
+	for i, path := range projectPaths {
 		marker := ""
 		if path == currentPath {
 			marker = " ✓"
 		}
 		btn := imbot.InlineKeyboardButton{
-			Text:         fmt.Sprintf("📁 %s%s", filepath.Base(path), marker),
+			Text:         fmt.Sprintf("%d. 📁 %s%s", i+1, filepath.Base(path), marker),
 			CallbackData: imbot.FormatCallbackData("project", "switch", path),
 		}
 		rows = append(rows, []imbot.InlineKeyboardButton{btn})

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -167,7 +167,6 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 		return
 	}
 
-	platform := string(hCtx.Platform)
 	currentPath, _, _ := h.chatStore.GetProjectPath(hCtx.ChatID)
 
 	var buf strings.Builder
@@ -177,19 +176,7 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 		buf.WriteString("No project bound to this chat.\n\n")
 	}
 
-	var projectPaths []string
-	if hCtx.IsDirect() {
-		chats, err := h.chatStore.ListChatsByOwner(hCtx.SenderID, platform)
-		if err == nil {
-			seen := make(map[string]bool)
-			for _, chat := range chats {
-				if chat.ProjectPath != "" && !seen[chat.ProjectPath] {
-					projectPaths = append(projectPaths, chat.ProjectPath)
-					seen[chat.ProjectPath] = true
-				}
-			}
-		}
-	}
+	projectPaths, _ := h.chatStore.ListChatProjectPaths(hCtx.ChatID)
 
 	if len(projectPaths) > 0 {
 		buf.WriteString("Your Projects:\n")

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -84,7 +84,7 @@ func (h *BotHandler) handleSlashCommands(hCtx HandlerContext) {
 			helpText += "@tb to handoff control to Tingly Box Smart Guide\n"
 
 			helpText += fmt.Sprintf("\nYour ID: %s", hCtx.SenderID)
-			formattedHelp := h.formatHelpWithHeader(hCtx, helpText)
+			formattedHelp := h.formatHelpWithFooter(hCtx, helpText)
 			h.SendText(hCtx, formattedHelp)
 			return
 		}
@@ -228,20 +228,23 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 	}
 }
 
-// formatHelpWithHeader formats help text with meta information
-func (h *BotHandler) formatHelpWithHeader(hCtx HandlerContext, helpText string) string {
+// formatHelpWithFooter formats help text with the standard reply footer
+// (agent + project path) appended at the bottom.
+func (h *BotHandler) formatHelpWithFooter(hCtx HandlerContext, helpText string) string {
 	projectPath, _, _ := h.chatStore.GetProjectPath(hCtx.ChatID)
+	if projectPath == "" {
+		if path, found := getProjectPathForGroup(h.chatStore, hCtx.ChatID, string(hCtx.Platform)); found {
+			projectPath = path
+		}
+	}
 	currentAgent, _ := h.getCurrentAgent(hCtx.ChatID)
 
 	meta := ResponseMeta{
 		ProjectPath: projectPath,
 		AgentType:   string(currentAgent),
-		ChatID:      hCtx.ChatID,
-		UserID:      hCtx.SenderID,
-		SessionID:   hCtx.ChatID,
 	}
 
-	return h.formatResponseWithHeader(meta, helpText, true)
+	return h.formatResponseWithFooter(meta, helpText)
 }
 
 // normalizeAllowlistToMap converts a string slice to a map for O(1) lookups

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -214,9 +214,8 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 	tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
 
 	_, err := hCtx.Bot.SendMessage(context.Background(), hCtx.ChatID, &imbot.SendMessageOptions{
-		Text:      buf.String(),
-		ParseMode: imbot.ParseModeMarkdown,
-		Metadata:  buildTrackedReplyMetadata(tgKeyboard),
+		Text:     buf.String(),
+		Metadata: buildTrackedReplyMetadata(tgKeyboard),
 	})
 	if err != nil {
 		logrus.WithError(err).Error("Failed to send project list")

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -159,25 +159,15 @@ func (h *BotHandler) handleClearCommand(hCtx HandlerContext) {
 	}
 }
 
-// handleBotProjectCommand handles /project - shows current project and list with keyboard.
-// Kept as a direct BotHandler method since it needs inline keyboard + directory browser integration.
-func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
-	if h.chatStore == nil {
-		h.SendText(hCtx, "Store not available")
-		return
-	}
-
-	currentPath, _, _ := h.chatStore.GetProjectPath(hCtx.ChatID)
-
+// buildProjectText builds the plain-text body for /project replies. The same
+// string is used by every platform so the information shown is always identical.
+func buildProjectText(currentPath string, projectPaths []string) string {
 	var buf strings.Builder
 	if currentPath != "" {
 		buf.WriteString(fmt.Sprintf("Current Project:\n📁 %s\n\n", currentPath))
 	} else {
 		buf.WriteString("No project bound to this chat.\n\n")
 	}
-
-	projectPaths, _ := h.chatStore.ListChatProjectPaths(hCtx.ChatID)
-
 	if len(projectPaths) > 0 {
 		buf.WriteString("Your Projects:\n")
 		for i, path := range projectPaths {
@@ -189,32 +179,49 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 		}
 		buf.WriteString("\nUse /cd <number> or /cd <path> to switch.")
 	} else {
-		buf.WriteString("No projects found.")
+		buf.WriteString("Use /cd <path> to bind a project.")
 	}
+	return buf.String()
+}
 
+// buildProjectKeyboard builds the inline keyboard for interactive /project replies.
+// Button labels include the index so they map 1-to-1 to the numbered text list.
+func buildProjectKeyboard(currentPath string, projectPaths []string) imbot.InlineKeyboardMarkup {
 	var rows [][]imbot.InlineKeyboardButton
 	for i, path := range projectPaths {
 		marker := ""
 		if path == currentPath {
 			marker = " ✓"
 		}
-		btn := imbot.InlineKeyboardButton{
+		rows = append(rows, []imbot.InlineKeyboardButton{{
 			Text:         fmt.Sprintf("%d. 📁 %s%s", i+1, filepath.Base(path), marker),
 			CallbackData: imbot.FormatCallbackData("project", "switch", path),
-		}
-		rows = append(rows, []imbot.InlineKeyboardButton{btn})
+		}})
 	}
-
 	rows = append(rows, []imbot.InlineKeyboardButton{{
 		Text:         "📁 Bind New Project",
 		CallbackData: imbot.FormatCallbackData("action", "bind"),
 	}})
+	return imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
+}
 
-	keyboard := imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
+// handleBotProjectCommand handles the inline-keyboard action-menu "project" button.
+// Always runs from a Telegram callback, so always sends with a keyboard.
+func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
+	if h.chatStore == nil {
+		h.SendText(hCtx, "Store not available")
+		return
+	}
+
+	currentPath, _, _ := h.chatStore.GetProjectPath(hCtx.ChatID)
+	projectPaths, _ := h.chatStore.ListChatProjectPaths(hCtx.ChatID)
+
+	text := buildProjectText(currentPath, projectPaths)
+	keyboard := buildProjectKeyboard(currentPath, projectPaths)
 	tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
 
 	_, err := hCtx.Bot.SendMessage(context.Background(), hCtx.ChatID, &imbot.SendMessageOptions{
-		Text:     buf.String(),
+		Text:     text,
 		Metadata: buildTrackedReplyMetadata(tgKeyboard),
 	})
 	if err != nil {

--- a/internal/remote_control/bot/chat_store.go
+++ b/internal/remote_control/bot/chat_store.go
@@ -52,10 +52,11 @@ func (b BotSetting) IsRequirePairing() bool {
 
 // Chat represents all state associated with a chat (direct or group)
 type Chat struct {
-	ChatID      string `json:"chat_id"`
-	Platform    string `json:"platform"`
-	ProjectPath string `json:"project_path,omitempty"`
-	OwnerID     string `json:"owner_id,omitempty"`
+	ChatID         string   `json:"chat_id"`
+	Platform       string   `json:"platform"`
+	ProjectPath    string   `json:"project_path,omitempty"`
+	ProjectHistory []string `json:"project_history,omitempty"` // MRU list of paths this chat has bound to
+	OwnerID        string   `json:"owner_id,omitempty"`
 
 	// Session removed - sessions are now managed by SessionManager with (ChatID, Agent, Project) binding
 
@@ -111,6 +112,9 @@ type ChatStoreInterface interface {
 
 	// ListChatsByOwner lists all chats owned by a user
 	ListChatsByOwner(ownerID, platform string) ([]*Chat, error)
+
+	// ListChatProjectPaths returns the MRU project-path history for a chat.
+	ListChatProjectPaths(chatID string) ([]string, error)
 
 	// AddToWhitelist adds a chat to the whitelist
 	AddToWhitelist(chatID, platform, addedBy string) error
@@ -323,9 +327,63 @@ func (s *ChatStoreJSON) BindProject(chatID, platform, projectPath, ownerID strin
 	}
 
 	chat.Platform = platform
-	chat.ProjectPath = projectPath
 	chat.OwnerID = ownerID
+	pushProjectHistory(chat, projectPath)
 	return s.UpsertChat(chat)
+}
+
+// projectHistoryCap caps the per-chat MRU list to keep storage bounded and
+// the /project list readable.
+const projectHistoryCap = 20
+
+// pushProjectHistory sets chat.ProjectPath and prepends it to ProjectHistory
+// (deduped, capped). When the chat already had a ProjectPath that wasn't in
+// the history yet, it is preserved one slot below so a fresh upgrade keeps
+// the previous binding visible.
+func pushProjectHistory(chat *Chat, path string) {
+	if chat == nil || path == "" {
+		return
+	}
+	prior := chat.ProjectHistory
+	if len(prior) == 0 && chat.ProjectPath != "" && chat.ProjectPath != path {
+		prior = []string{chat.ProjectPath}
+	}
+	chat.ProjectPath = path
+
+	out := make([]string, 0, len(prior)+1)
+	out = append(out, path)
+	for _, p := range prior {
+		if p == "" || p == path {
+			continue
+		}
+		out = append(out, p)
+		if len(out) >= projectHistoryCap {
+			break
+		}
+	}
+	chat.ProjectHistory = out
+}
+
+// ListChatProjectPaths returns the per-chat MRU list of project paths the
+// chat has bound to (newest first). Falls back to [ProjectPath] for legacy
+// chats with no history yet, and an empty slice when nothing has been bound.
+func (s *ChatStoreJSON) ListChatProjectPaths(chatID string) ([]string, error) {
+	if err := s.ensureStore(); err != nil {
+		return nil, err
+	}
+	chat := s.store.Get(chatID)
+	if chat == nil {
+		return nil, nil
+	}
+	if len(chat.ProjectHistory) > 0 {
+		out := make([]string, len(chat.ProjectHistory))
+		copy(out, chat.ProjectHistory)
+		return out, nil
+	}
+	if chat.ProjectPath != "" {
+		return []string{chat.ProjectPath}, nil
+	}
+	return nil, nil
 }
 
 // GetProjectPath retrieves the project path for a chat

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -316,22 +316,35 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 
 			projectPaths, _ := adapter.ListChatProjectPaths(ctx.ChatID)
 
-			// Interactive UI (inline keyboard) only for DMs on platforms that
-			// natively render buttons/cards. Other channels get a numbered text
-			// list — switching is done by /cd <number>.
+			// Body: same numbered list everywhere so the text content of /project
+			// is identical across platforms. Telegram (and other interactive
+			// platforms in DMs) gets an inline keyboard layered on top.
+			if len(projectPaths) > 0 {
+				buf.WriteString("Your Projects:\n")
+				for i, path := range projectPaths {
+					marker := ""
+					if path == currentPath {
+						marker = " ✓"
+					}
+					buf.WriteString(fmt.Sprintf("  %d. %s%s\n", i+1, path, marker))
+				}
+				buf.WriteString("\nUse /cd <number> or /cd <path> to switch.")
+			} else {
+				buf.WriteString("Use /cd <path> to bind a project.")
+			}
+
 			caps := imbot.GetPlatformCapabilities(string(ctx.Platform))
 			interactive := ctx.IsDirectMessage && caps != nil && caps.SupportsInteraction()
 
 			if interactive && len(projectPaths) > 0 {
-				buf.WriteString("Your Projects:\n")
 				var rows [][]imbot.InlineKeyboardButton
-				for _, path := range projectPaths {
+				for i, path := range projectPaths {
 					marker := ""
 					if path == currentPath {
 						marker = " ✓"
 					}
 					btn := imbot.InlineKeyboardButton{
-						Text:         fmt.Sprintf("📁 %s%s", filepath.Base(path), marker),
+						Text:         fmt.Sprintf("%d. 📁 %s%s", i+1, filepath.Base(path), marker),
 						CallbackData: imbot.FormatCallbackData("project", "switch", path),
 					}
 					rows = append(rows, []imbot.InlineKeyboardButton{btn})
@@ -355,19 +368,6 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 				return nil
 			}
 
-			if len(projectPaths) > 0 {
-				buf.WriteString("Your Projects:\n")
-				for i, path := range projectPaths {
-					marker := ""
-					if path == currentPath {
-						marker = " ✓"
-					}
-					buf.WriteString(fmt.Sprintf("  %d. %s%s\n", i+1, path, marker))
-				}
-				buf.WriteString("\nUse /cd <number> or /cd <path> to switch.")
-			} else {
-				buf.WriteString("Use /cd <path> to bind a project.")
-			}
 			return sendCommandText(adapter, ctx, buf.String())
 		}).
 		WithCategory("project").

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -306,60 +306,19 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 	return imbot.NewCommand("cmd-project", "project", "Show and switch between projects").
 		WithAliases("p").
 		WithHandler(func(ctx *imbot.HandlerContext, args []string) error {
-			currentPath, _ := adapter.GetProjectPath(ctx.ChatID)
-
-			var buf strings.Builder
-			if currentPath != "" {
-				buf.WriteString(fmt.Sprintf("Current Project:\n📁 %s\n\n", currentPath))
-			} else {
-				buf.WriteString("No project bound to this chat.\n\n")
-			}
-
+			currentPath := resolveProjectPath(adapter, ctx.ChatID, string(ctx.Platform))
 			projectPaths, _ := adapter.ListChatProjectPaths(ctx.ChatID)
 
-			// Body: same numbered list everywhere so the text content of /project
-			// is identical across platforms. Telegram (and other interactive
-			// platforms in DMs) gets an inline keyboard layered on top.
-			if len(projectPaths) > 0 {
-				buf.WriteString("Your Projects:\n")
-				for i, path := range projectPaths {
-					marker := ""
-					if path == currentPath {
-						marker = " ✓"
-					}
-					buf.WriteString(fmt.Sprintf("  %d. %s%s\n", i+1, path, marker))
-				}
-				buf.WriteString("\nUse /cd <number> or /cd <path> to switch.")
-			} else {
-				buf.WriteString("Use /cd <path> to bind a project.")
-			}
+			text := buildProjectText(currentPath, projectPaths)
 
 			caps := imbot.GetPlatformCapabilities(string(ctx.Platform))
 			interactive := ctx.IsDirectMessage && caps != nil && caps.SupportsInteraction()
 
 			if interactive && len(projectPaths) > 0 {
-				var rows [][]imbot.InlineKeyboardButton
-				for i, path := range projectPaths {
-					marker := ""
-					if path == currentPath {
-						marker = " ✓"
-					}
-					btn := imbot.InlineKeyboardButton{
-						Text:         fmt.Sprintf("%d. 📁 %s%s", i+1, filepath.Base(path), marker),
-						CallbackData: imbot.FormatCallbackData("project", "switch", path),
-					}
-					rows = append(rows, []imbot.InlineKeyboardButton{btn})
-				}
-				rows = append(rows, []imbot.InlineKeyboardButton{{
-					Text:         "📁 Bind New Project",
-					CallbackData: imbot.FormatCallbackData("action", "bind"),
-				}})
-
-				keyboard := imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
+				keyboard := buildProjectKeyboard(currentPath, projectPaths)
 				tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
-
 				_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
-					Text:     buf.String() + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
+					Text:     text + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
 					Metadata: buildTrackedReplyMetadata(tgKeyboard),
 				})
 				if err != nil {
@@ -368,7 +327,7 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 				return nil
 			}
 
-			return sendCommandText(adapter, ctx, buf.String())
+			return sendCommandText(adapter, ctx, text)
 		}).
 		WithCategory("project").
 		WithPriority(60).

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -304,6 +304,7 @@ func newInterruptCommand(adapter BotHandlerAdapter) imbot.Command {
 
 func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 	return imbot.NewCommand("cmd-project", "project", "Show and switch between projects").
+		WithAliases("p").
 		WithHandler(func(ctx *imbot.HandlerContext, args []string) error {
 			currentPath, _ := adapter.GetProjectPath(ctx.ChatID)
 

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -105,6 +105,9 @@ type BotHandlerAdapter interface {
 	// ListProjectPaths lists all project paths for a user
 	ListProjectPaths(ownerID, platform string) ([]string, error)
 
+	// ListChatProjectPaths lists the MRU per-chat project-path history.
+	ListChatProjectPaths(chatID string) ([]string, error)
+
 	// VerifyAndPair verifies a one-time pairing code and, on success, records
 	// the chat as paired with the bot. Implementations should also emit the
 	// matching audit events (success / failure).
@@ -205,14 +208,14 @@ func newBindCommand(adapter BotHandlerAdapter) imbot.Command {
 				return sendCommandText(adapter, ctx, usageBind)
 			}
 
-			// Numeric index → resolve from this user's known projects.
+			// Numeric index → resolve from this chat's project history.
 			if idx, ok := parsePositiveInt(input); ok {
-				paths, err := adapter.ListProjectPaths(ctx.SenderID, string(ctx.Platform))
+				paths, err := adapter.ListChatProjectPaths(ctx.ChatID)
 				if err != nil {
 					return sendCommandTextf(adapter, ctx, "Failed to list projects: %v", err)
 				}
 				if idx < 1 || idx > len(paths) {
-					return sendCommandTextf(adapter, ctx, "Invalid project number: %d (have %d)", idx, len(paths))
+					return sendCommandTextf(adapter, ctx, "Invalid project number: %d (have %d). Use /project to see the list.", idx, len(paths))
 				}
 				selected := paths[idx-1]
 				if err := adapter.SetProjectPath(ctx.ChatID, selected); err != nil {
@@ -311,7 +314,7 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 				buf.WriteString("No project bound to this chat.\n\n")
 			}
 
-			projectPaths, _ := adapter.ListProjectPaths(ctx.SenderID, string(ctx.Platform))
+			projectPaths, _ := adapter.ListChatProjectPaths(ctx.ChatID)
 
 			// Interactive UI (inline keyboard) only for DMs on platforms that
 			// natively render buttons/cards. Other channels get a numbered text

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -109,6 +109,11 @@ type BotHandlerAdapter interface {
 	// the chat as paired with the bot. Implementations should also emit the
 	// matching audit events (success / failure).
 	VerifyAndPair(botUUID, chatID, senderID, platform, code string) error
+
+	// BuildReplyFooter returns a compact footer (agent + project path) that
+	// command replies append for context continuity. Returns an empty string
+	// when neither agent nor project path is resolvable for the chat.
+	BuildReplyFooter(chatID, platform string) string
 }
 
 // SessionInfo holds session information.
@@ -123,7 +128,7 @@ type SessionInfo struct {
 }
 
 const (
-	usageBind     = "Usage: /cd <project_path>"
+	usageBind     = "Usage: /cd <project_path|number>"
 	usageBash     = "Usage: /bash <command>"
 	usageBashCD   = "Usage: /bash cd <path>"
 	usageJoin     = "Usage: /join <group_id|@username|invite_link>"
@@ -132,7 +137,8 @@ const (
 )
 
 func sendCommandText(adapter BotHandlerAdapter, ctx *imbot.HandlerContext, text string) error {
-	return adapter.SendText(ctx.ChatID, text)
+	footer := adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform))
+	return adapter.SendText(ctx.ChatID, text+footer)
 }
 
 func sendCommandTextf(adapter BotHandlerAdapter, ctx *imbot.HandlerContext, format string, args ...interface{}) error {
@@ -194,13 +200,30 @@ func newHelpCommand(adapter BotHandlerAdapter) imbot.Command {
 func newBindCommand(adapter BotHandlerAdapter) imbot.Command {
 	return imbot.NewCommand("cmd-bind", "cd", "Bind and cd into a project directory").
 		WithHandler(func(ctx *imbot.HandlerContext, args []string) error {
-			projectPath, ok := joinedArgs(args)
+			input, ok := joinedArgs(args)
 			if !ok {
 				return sendCommandText(adapter, ctx, usageBind)
 			}
 
-			// Expand and validate path
-			expandedPath, err := ExpandPath(projectPath)
+			// Numeric index → resolve from this user's known projects.
+			if idx, ok := parsePositiveInt(input); ok {
+				paths, err := adapter.ListProjectPaths(ctx.SenderID, string(ctx.Platform))
+				if err != nil {
+					return sendCommandTextf(adapter, ctx, "Failed to list projects: %v", err)
+				}
+				if idx < 1 || idx > len(paths) {
+					return sendCommandTextf(adapter, ctx, "Invalid project number: %d (have %d)", idx, len(paths))
+				}
+				selected := paths[idx-1]
+				if err := adapter.SetProjectPath(ctx.ChatID, selected); err != nil {
+					return sendCommandTextf(adapter, ctx, "Failed to bind project: %v", err)
+				}
+				return sendCommandTextf(adapter, ctx, "✅ Switched to project: %s", ShortenPath(selected))
+			}
+
+			// Path argument: expand relative to the chat's currently-bound project.
+			currentPath, _ := adapter.GetProjectPath(ctx.ChatID)
+			expandedPath, err := ExpandPathFrom(input, currentPath)
 			if err != nil {
 				return sendCommandTextf(adapter, ctx, "Invalid path: %v", err)
 			}
@@ -209,7 +232,6 @@ func newBindCommand(adapter BotHandlerAdapter) imbot.Command {
 				return sendCommandTextf(adapter, ctx, "Path validation failed: %v", err)
 			}
 
-			// Set the project path
 			if err := adapter.SetProjectPath(ctx.ChatID, expandedPath); err != nil {
 				return sendCommandTextf(adapter, ctx, "Failed to bind project: %v", err)
 			}
@@ -219,6 +241,29 @@ func newBindCommand(adapter BotHandlerAdapter) imbot.Command {
 		WithCategory("project").
 		WithPriority(90).
 		MustBuild()
+}
+
+// parsePositiveInt parses a string into a positive integer (>= 1). Returns
+// (0, false) on any non-numeric input or non-positive values.
+func parsePositiveInt(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+		if n > 1<<20 {
+			return 0, false
+		}
+	}
+	if n < 1 {
+		return 0, false
+	}
+	return n, true
 }
 
 func newClearCommand(adapter BotHandlerAdapter) imbot.Command {
@@ -266,46 +311,60 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 				buf.WriteString("No project bound to this chat.\n\n")
 			}
 
-			// Get all projects for user (direct messages only)
-			if ctx.IsDirectMessage {
-				projectPaths, err := adapter.ListProjectPaths(ctx.SenderID, string(ctx.Platform))
-				if err == nil && len(projectPaths) > 0 {
-					buf.WriteString("Your Projects:\n")
-					// Build inline keyboard with projects
-					var rows [][]imbot.InlineKeyboardButton
-					for _, path := range projectPaths {
-						marker := ""
-						if path == currentPath {
-							marker = " ✓"
-						}
-						btn := imbot.InlineKeyboardButton{
-							Text:         fmt.Sprintf("📁 %s%s", filepath.Base(path), marker),
-							CallbackData: imbot.FormatCallbackData("project", "switch", path),
-						}
-						rows = append(rows, []imbot.InlineKeyboardButton{btn})
-					}
-					// Add "Bind New" button
-					rows = append(rows, []imbot.InlineKeyboardButton{{
-						Text:         "📁 Bind New Project",
-						CallbackData: imbot.FormatCallbackData("action", "bind"),
-					}})
+			projectPaths, _ := adapter.ListProjectPaths(ctx.SenderID, string(ctx.Platform))
 
-					keyboard := imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
-					tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
+			// Interactive UI (inline keyboard) only for DMs on platforms that
+			// natively render buttons/cards. Other channels get a numbered text
+			// list — switching is done by /cd <number>.
+			caps := imbot.GetPlatformCapabilities(string(ctx.Platform))
+			interactive := ctx.IsDirectMessage && caps != nil && caps.SupportsInteraction()
 
-					_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
-						Text:      buf.String(),
-						ParseMode: imbot.ParseModeMarkdown,
-						Metadata:  buildTrackedReplyMetadata(tgKeyboard),
-					})
-					if err != nil {
-						logrus.WithError(err).Error("Failed to send project list")
+			if interactive && len(projectPaths) > 0 {
+				buf.WriteString("Your Projects:\n")
+				var rows [][]imbot.InlineKeyboardButton
+				for _, path := range projectPaths {
+					marker := ""
+					if path == currentPath {
+						marker = " ✓"
 					}
-					return nil
+					btn := imbot.InlineKeyboardButton{
+						Text:         fmt.Sprintf("📁 %s%s", filepath.Base(path), marker),
+						CallbackData: imbot.FormatCallbackData("project", "switch", path),
+					}
+					rows = append(rows, []imbot.InlineKeyboardButton{btn})
 				}
+				rows = append(rows, []imbot.InlineKeyboardButton{{
+					Text:         "📁 Bind New Project",
+					CallbackData: imbot.FormatCallbackData("action", "bind"),
+				}})
+
+				keyboard := imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
+				tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
+
+				_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
+					Text:      buf.String() + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
+					ParseMode: imbot.ParseModeMarkdown,
+					Metadata:  buildTrackedReplyMetadata(tgKeyboard),
+				})
+				if err != nil {
+					logrus.WithError(err).Error("Failed to send project list")
+				}
+				return nil
 			}
 
-			buf.WriteString("Use /cd <path> to bind a project.")
+			if len(projectPaths) > 0 {
+				buf.WriteString("Your Projects:\n")
+				for i, path := range projectPaths {
+					marker := ""
+					if path == currentPath {
+						marker = " ✓"
+					}
+					buf.WriteString(fmt.Sprintf("  %d. %s%s\n", i+1, path, marker))
+				}
+				buf.WriteString("\nUse /cd <number> or /cd <path> to switch.")
+			} else {
+				buf.WriteString("Use /cd <path> to bind a project.")
+			}
 			return sendCommandText(adapter, ctx, buf.String())
 		}).
 		WithCategory("project").

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -359,9 +359,8 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 				tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
 
 				_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
-					Text:      buf.String() + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
-					ParseMode: imbot.ParseModeMarkdown,
-					Metadata:  buildTrackedReplyMetadata(tgKeyboard),
+					Text:     buf.String() + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
+					Metadata: buildTrackedReplyMetadata(tgKeyboard),
 				})
 				if err != nil {
 					logrus.WithError(err).Error("Failed to send project list")

--- a/internal/remote_control/bot/command_integration.go
+++ b/internal/remote_control/bot/command_integration.go
@@ -210,22 +210,6 @@ func (a *botHandlerAdapter) ListProjectPaths(ownerID, platform string) ([]string
 	return paths, nil
 }
 
-// SendMessageWithKeyboard sends a text message with an inline keyboard.
-// Note: For commands that need keyboards, use ctx.Bot directly in the handler.
-func (a *botHandlerAdapter) SendMessageWithKeyboard(chatID, text string, keyboard interface{}) error {
-	return fmt.Errorf("SendMessageWithKeyboard requires bot context, use ctx.Bot directly")
-}
-
-// StartInteractiveBind starts an interactive directory browser for project binding.
-func (a *botHandlerAdapter) StartInteractiveBind(chatID string) error {
-	hCtx := HandlerContext{
-		ChatID:   chatID,
-		Platform: imbot.PlatformTelegram,
-	}
-	a.handler.handleBindInteractive(hCtx)
-	return nil
-}
-
 // VerifyAndPair runs pairing-code verification and persists the binding.
 func (a *botHandlerAdapter) VerifyAndPair(botUUID, chatID, senderID, platform, code string) error {
 	return a.handler.VerifyAndPair(botUUID, chatID, senderID, platform, code)

--- a/internal/remote_control/bot/command_integration.go
+++ b/internal/remote_control/bot/command_integration.go
@@ -211,16 +211,6 @@ func (a *botHandlerAdapter) SendMessageWithKeyboard(chatID, text string, keyboar
 	return fmt.Errorf("SendMessageWithKeyboard requires bot context, use ctx.Bot directly")
 }
 
-// FormatHelpWithHeader formats help text with meta information.
-func (a *botHandlerAdapter) FormatHelpWithHeader(chatID, senderID, text string, isDirect bool, platform string) string {
-	hCtx := HandlerContext{
-		ChatID:   chatID,
-		SenderID: senderID,
-		Platform: imbot.Platform(platform),
-	}
-	return a.handler.formatHelpWithHeader(hCtx, text)
-}
-
 // StartInteractiveBind starts an interactive directory browser for project binding.
 func (a *botHandlerAdapter) StartInteractiveBind(chatID string) error {
 	hCtx := HandlerContext{
@@ -234,6 +224,19 @@ func (a *botHandlerAdapter) StartInteractiveBind(chatID string) error {
 // VerifyAndPair runs pairing-code verification and persists the binding.
 func (a *botHandlerAdapter) VerifyAndPair(botUUID, chatID, senderID, platform, code string) error {
 	return a.handler.VerifyAndPair(botUUID, chatID, senderID, platform, code)
+}
+
+// BuildReplyFooter assembles the standard command-reply footer for a chat.
+// Resolves project path with the same group fallback used elsewhere and the
+// current agent for the chat. Returns "" when neither piece is available,
+// so unpaired/unbound chats see no decoration.
+func (a *botHandlerAdapter) BuildReplyFooter(chatID, platform string) string {
+	projectPath := resolveProjectPath(a, chatID, platform)
+	agentType, _ := a.GetCurrentAgent(chatID)
+	if projectPath == "" && agentType == "" {
+		return ""
+	}
+	return BuildFooter(agentType, projectPath)
 }
 
 // InitCommandRegistry initializes the command registry with built-in commands.

--- a/internal/remote_control/bot/command_integration.go
+++ b/internal/remote_control/bot/command_integration.go
@@ -188,6 +188,11 @@ func (a *botHandlerAdapter) GetBashAllowlist() map[string]struct{} {
 	return allowlist
 }
 
+// ListChatProjectPaths returns the MRU project-path history for a chat.
+func (a *botHandlerAdapter) ListChatProjectPaths(chatID string) ([]string, error) {
+	return a.handler.chatStore.ListChatProjectPaths(chatID)
+}
+
 // ListProjectPaths lists all project paths for a user.
 func (a *botHandlerAdapter) ListProjectPaths(ownerID, platform string) ([]string, error) {
 	chats, err := a.handler.chatStore.ListChatsByOwner(ownerID, platform)

--- a/internal/remote_control/bot/feature/telegram_dir_browser.go
+++ b/internal/remote_control/bot/feature/telegram_dir_browser.go
@@ -35,16 +35,32 @@ func NewDirectoryBrowser() *DirectoryBrowser {
 	}
 }
 
-// Start begins a new bind flow for a chat
+// Start begins a new bind flow for a chat, starting at the home directory.
 func (b *DirectoryBrowser) Start(chatID string) (*BindFlowState, error) {
-	homeDir, err := getHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	return b.StartAt(chatID, "")
+}
+
+// StartAt begins a new bind flow for a chat, starting at startPath.
+// If startPath is empty or does not exist, the browser falls back to the
+// home directory so the user always lands somewhere navigable.
+func (b *DirectoryBrowser) StartAt(chatID, startPath string) (*BindFlowState, error) {
+	initialPath := ""
+	if startPath != "" {
+		if info, err := os.Stat(startPath); err == nil && info.IsDir() {
+			initialPath = startPath
+		}
+	}
+	if initialPath == "" {
+		homeDir, err := getHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
+		initialPath = homeDir
 	}
 
 	state := &BindFlowState{
 		ChatID:      chatID,
-		CurrentPath: homeDir,
+		CurrentPath: initialPath,
 		Page:        0,
 		PageSize:    b.pageSize,
 		ExpiresAt:   time.Now().Add(stateExpiry),

--- a/internal/remote_control/bot/handler_bind.go
+++ b/internal/remote_control/bot/handler_bind.go
@@ -25,7 +25,7 @@ func (h *BotHandler) handleBindConfirm(hCtx HandlerContext) {
 	}
 
 	// Bind the project
-	err := h.chatStore.BindProject(hCtx.ChatID, string(hCtx.Platform), hCtx.BotUUID, pending.ProposedPath)
+	err := h.chatStore.BindProject(hCtx.ChatID, string(hCtx.Platform), pending.ProposedPath, hCtx.SenderID)
 	if err != nil {
 		h.SendText(hCtx, fmt.Sprintf("Failed to bind project: %v", err))
 		delete(h.pendingBinds, hCtx.ChatID)
@@ -34,7 +34,7 @@ func (h *BotHandler) handleBindConfirm(hCtx HandlerContext) {
 	}
 
 	// Close the old session for this (chat, agent) combination if exists
-	agentType := "claude"
+	agentType := AgentNameClaude
 	oldSess := h.sessionMgr.FindBy(hCtx.ChatID, agentType, "")
 	if oldSess != nil {
 		h.sessionMgr.Close(oldSess.ID)

--- a/internal/remote_control/bot/handler_bind.go
+++ b/internal/remote_control/bot/handler_bind.go
@@ -97,8 +97,10 @@ func (h *BotHandler) handleProjectSwitch(hCtx HandlerContext, projectPath string
 
 // handleBindInteractive starts an interactive directory browser for binding
 func (h *BotHandler) handleBindInteractive(hCtx HandlerContext) {
-	// Start from home directory
-	_, err := h.directoryBrowser.Start(hCtx.ChatID)
+	// Start from the currently-bound project path so the user lands in a
+	// familiar spot; falls back to home when nothing is bound yet.
+	currentPath, _, _ := h.chatStore.GetProjectPath(hCtx.ChatID)
+	_, err := h.directoryBrowser.StartAt(hCtx.ChatID, currentPath)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to start directory browser")
 		h.SendText(hCtx, fmt.Sprintf("Failed to start directory browser: %v", err))

--- a/internal/remote_control/bot/output.go
+++ b/internal/remote_control/bot/output.go
@@ -1,7 +1,6 @@
 package bot
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -116,14 +115,28 @@ func ShortenID(id string, maxLen int) string {
 	return id[:maxLen]
 }
 
-// BuildFooter creates a compact footer line with agent and path info
-// Format: separator + "📁 path · icon agent"
-// Path is always present (defaults are resolved before calling this)
+// BuildFooter creates a compact footer line with agent and path info.
+// Format: separator + agent line + path line. Either part is omitted when
+// the corresponding value is empty, and an empty footer is returned when
+// both are empty so callers don't print a stray separator.
 func BuildFooter(agentType, projectPath string) string {
-	icon := GetAgentIcon(agentType)
-	agentName := GetAgentDisplayName(agentType)
-	shortPath := ShortenPath(projectPath)
-	return fmt.Sprintf(FormatFooter, SeparatorLine, icon, agentName, shortPath)
+	var b strings.Builder
+	if agentType != "" {
+		b.WriteString("\n")
+		b.WriteString(GetAgentIcon(agentType))
+		b.WriteString(" ")
+		b.WriteString(GetAgentDisplayName(agentType))
+	}
+	if projectPath != "" {
+		b.WriteString("\n")
+		b.WriteString(IconProject)
+		b.WriteString(" ")
+		b.WriteString(ShortenPath(projectPath))
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return "\n" + SeparatorLine + b.String()
 }
 
 // Helper functions for path handling (avoiding filepath import issues)

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -202,9 +202,9 @@ func (h *BotHandler) handleCustomPathPrompt(hCtx HandlerContext) {
 	// Ensure state exists
 	state := h.directoryBrowser.GetState(hCtx.ChatID)
 	if state == nil {
-		// Start a new bind flow if none exists
+		currentPath, _, _ := h.chatStore.GetProjectPath(hCtx.ChatID)
 		var err error
-		state, err = h.directoryBrowser.Start(hCtx.ChatID)
+		state, err = h.directoryBrowser.StartAt(hCtx.ChatID, currentPath)
 		if err != nil {
 			h.SendText(hCtx, fmt.Sprintf("Failed to start bind flow: %v", err))
 			return

--- a/internal/remote_control/bot/util.go
+++ b/internal/remote_control/bot/util.go
@@ -11,12 +11,29 @@ import (
 
 // ExpandPath expands ~ and environment variables in a path
 func ExpandPath(path string) (string, error) {
+	return ExpandPathFrom(path, "")
+}
+
+// ExpandPathFrom expands a user-provided path with the given baseDir as the
+// reference for relative paths. ~/ and absolute paths are handled as in
+// ExpandPath. When path is relative and baseDir is non-empty, it is joined
+// with baseDir; otherwise it falls back to filepath.Abs (process cwd).
+func ExpandPathFrom(path, baseDir string) (string, error) {
+	if path == "~" {
+		return os.UserHomeDir()
+	}
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
 		}
 		return filepath.Join(home, path[2:]), nil
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	if baseDir != "" {
+		return filepath.Clean(filepath.Join(baseDir, path)), nil
 	}
 	return filepath.Abs(path)
 }

--- a/internal/remote_control/bot/util_extra_test.go
+++ b/internal/remote_control/bot/util_extra_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -107,5 +108,102 @@ func TestBuildFooter_OnlyProject(t *testing.T) {
 	}
 	if strings.Contains(got, AgentNameCC) || strings.Contains(got, AgentNameTB) {
 		t.Errorf("agent line should not appear: %q", got)
+	}
+}
+
+func TestPushProjectHistory_PrependsAndDedupes(t *testing.T) {
+	chat := &Chat{}
+	pushProjectHistory(chat, "/a")
+	pushProjectHistory(chat, "/b")
+	pushProjectHistory(chat, "/c")
+	pushProjectHistory(chat, "/a") // dedupe — should move to front, not duplicate
+	want := []string{"/a", "/c", "/b"}
+	if len(chat.ProjectHistory) != len(want) {
+		t.Fatalf("history length %d, want %d (%v)", len(chat.ProjectHistory), len(want), chat.ProjectHistory)
+	}
+	for i, w := range want {
+		if chat.ProjectHistory[i] != w {
+			t.Errorf("history[%d] = %q, want %q (%v)", i, chat.ProjectHistory[i], w, chat.ProjectHistory)
+		}
+	}
+	if chat.ProjectPath != "/a" {
+		t.Errorf("ProjectPath = %q, want /a", chat.ProjectPath)
+	}
+}
+
+func TestPushProjectHistory_SeedsLegacyProjectPath(t *testing.T) {
+	chat := &Chat{ProjectPath: "/legacy"} // pre-existing binding from before history
+	pushProjectHistory(chat, "/new")
+	want := []string{"/new", "/legacy"}
+	if len(chat.ProjectHistory) != 2 || chat.ProjectHistory[0] != want[0] || chat.ProjectHistory[1] != want[1] {
+		t.Errorf("history = %v, want %v", chat.ProjectHistory, want)
+	}
+}
+
+func TestPushProjectHistory_EmptyPathIsNoOp(t *testing.T) {
+	chat := &Chat{ProjectPath: "/x", ProjectHistory: []string{"/x"}}
+	pushProjectHistory(chat, "")
+	if chat.ProjectPath != "/x" || len(chat.ProjectHistory) != 1 {
+		t.Errorf("empty path should not mutate state: path=%q history=%v", chat.ProjectPath, chat.ProjectHistory)
+	}
+}
+
+func TestPushProjectHistory_Caps(t *testing.T) {
+	chat := &Chat{}
+	for i := 0; i < projectHistoryCap+5; i++ {
+		pushProjectHistory(chat, fmt.Sprintf("/p%d", i))
+	}
+	if len(chat.ProjectHistory) != projectHistoryCap {
+		t.Errorf("history not capped: got %d, want %d", len(chat.ProjectHistory), projectHistoryCap)
+	}
+}
+
+func TestListChatProjectPaths_FallbackToProjectPath(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewChatStoreJSON(dir + "/chats.json")
+	if err != nil {
+		t.Fatalf("NewChatStoreJSON: %v", err)
+	}
+	defer store.Close()
+	// Simulate a legacy chat written before ProjectHistory existed.
+	if err := store.UpsertChat(&Chat{
+		ChatID:      "legacy",
+		Platform:    "telegram",
+		ProjectPath: "/legacy/path",
+	}); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	got, err := store.ListChatProjectPaths("legacy")
+	if err != nil {
+		t.Fatalf("ListChatProjectPaths: %v", err)
+	}
+	if len(got) != 1 || got[0] != "/legacy/path" {
+		t.Errorf("got %v, want [/legacy/path]", got)
+	}
+}
+
+func TestBindProject_RecordsHistoryPerChat(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewChatStoreJSON(dir + "/chats.json")
+	if err != nil {
+		t.Fatalf("NewChatStoreJSON: %v", err)
+	}
+	defer store.Close()
+	if err := store.BindProject("c1", "telegram", "/a", "alice"); err != nil {
+		t.Fatalf("BindProject /a: %v", err)
+	}
+	if err := store.BindProject("c1", "telegram", "/b", "alice"); err != nil {
+		t.Fatalf("BindProject /b: %v", err)
+	}
+	if err := store.BindProject("c1", "telegram", "/a", "alice"); err != nil {
+		t.Fatalf("BindProject /a (re-bind): %v", err)
+	}
+	got, err := store.ListChatProjectPaths("c1")
+	if err != nil {
+		t.Fatalf("ListChatProjectPaths: %v", err)
+	}
+	want := []string{"/a", "/b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/internal/remote_control/bot/util_extra_test.go
+++ b/internal/remote_control/bot/util_extra_test.go
@@ -1,0 +1,111 @@
+package bot
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExpandPathFrom_Absolute(t *testing.T) {
+	got, err := ExpandPathFrom("/tmp/foo", "/home/me/proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/tmp/foo" {
+		t.Fatalf("absolute path mutated: %q", got)
+	}
+}
+
+func TestExpandPathFrom_RelativeUsesBaseDir(t *testing.T) {
+	got, err := ExpandPathFrom("src/api", "/home/me/proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Clean("/home/me/proj/src/api")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandPathFrom_RelativeDotDotEscape(t *testing.T) {
+	got, err := ExpandPathFrom("../sibling", "/home/me/proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Clean("/home/me/sibling")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandPathFrom_RelativeWithoutBaseFallsBackToCwd(t *testing.T) {
+	got, err := ExpandPathFrom(".", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("expected absolute fallback, got %q", got)
+	}
+}
+
+func TestExpandPathFrom_HomeAlias(t *testing.T) {
+	got, err := ExpandPathFrom("~/x", "/whatever")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(got, "/x") || strings.HasPrefix(got, "/whatever/") {
+		t.Fatalf("home alias not honored: %q", got)
+	}
+}
+
+func TestParsePositiveInt(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   int
+		wantOk bool
+	}{
+		{"1", 1, true},
+		{"42", 42, true},
+		{"  7  ", 7, true},
+		{"0", 0, false},
+		{"", 0, false},
+		{"-3", 0, false},
+		{"3a", 0, false},
+		{"abc", 0, false},
+	}
+	for _, tt := range tests {
+		got, ok := parsePositiveInt(tt.in)
+		if got != tt.want || ok != tt.wantOk {
+			t.Errorf("parsePositiveInt(%q) = (%d,%v), want (%d,%v)", tt.in, got, ok, tt.want, tt.wantOk)
+		}
+	}
+}
+
+func TestBuildFooter_BothFields(t *testing.T) {
+	got := BuildFooter(AgentNameClaude, "/home/me/proj")
+	if !strings.Contains(got, SeparatorLine) {
+		t.Errorf("missing separator: %q", got)
+	}
+	if !strings.Contains(got, AgentNameCC) {
+		t.Errorf("missing agent name: %q", got)
+	}
+	if !strings.Contains(got, "proj") {
+		t.Errorf("missing project path: %q", got)
+	}
+}
+
+func TestBuildFooter_EmptyReturnsEmpty(t *testing.T) {
+	if got := BuildFooter("", ""); got != "" {
+		t.Errorf("expected empty footer, got %q", got)
+	}
+}
+
+func TestBuildFooter_OnlyProject(t *testing.T) {
+	got := BuildFooter("", "/home/me/proj")
+	if !strings.Contains(got, "proj") {
+		t.Errorf("missing project: %q", got)
+	}
+	if strings.Contains(got, AgentNameCC) || strings.Contains(got, AgentNameTB) {
+		t.Errorf("agent line should not appear: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
This PR enhances project management by introducing a per-chat project history (MRU list) and enabling users to switch between recently-used projects via numeric shortcuts. It also standardizes command reply formatting with a consistent footer showing the current agent and project context.

## Key Changes

- **Per-chat project history**: Added `ProjectHistory` field to `Chat` struct to track the most-recently-used (MRU) projects for each chat, capped at 20 entries. The history is automatically maintained when projects are bound via `pushProjectHistory()`.

- **Numeric project switching**: Extended `/cd` command to accept numeric indices (e.g., `/cd 1`) to quickly switch to a project from the chat's history, in addition to path arguments. Added `parsePositiveInt()` helper to parse and validate numeric input.

- **Unified reply footer**: Introduced `BuildFooter()` function that generates a consistent footer with agent name and project path for command replies. Integrated into `sendCommandText()` so all command responses include context. Footer is omitted when neither agent nor project is available.

- **Project listing improvements**: 
  - Refactored `/project` command to show numbered list of projects from chat history
  - Added `ListChatProjectPaths()` to `ChatStoreInterface` to retrieve per-chat project history
  - Extracted `buildProjectText()` and `buildProjectKeyboard()` helpers for consistent formatting across platforms
  - Added `/p` alias for `/project` command

- **Path expansion enhancement**: Extended `ExpandPath()` with new `ExpandPathFrom()` function that resolves relative paths against a base directory (the chat's current project), enabling relative path navigation within projects.

- **Directory browser enhancement**: Added `StartAt()` method to `DirectoryBrowser` to begin browsing from a specific directory instead of always starting at home.

- **Legacy compatibility**: `ListChatProjectPaths()` falls back to the legacy `ProjectPath` field for chats that haven't yet populated the history, ensuring smooth migration.

## Implementation Details

- Project history is maintained in insertion order (newest first) with automatic deduplication—rebinding an existing project moves it to the front without creating duplicates.
- The `/cd` command now resolves relative paths against the chat's currently-bound project, allowing users to navigate within a project tree.
- Footer formatting is conditional: empty when both agent and project are unavailable, preventing visual clutter in unpaired/unbound chats.
- All existing tests pass; comprehensive test coverage added for new utility functions (`ExpandPathFrom`, `parsePositiveInt`, `BuildFooter`, `pushProjectHistory`).

https://claude.ai/code/session_01DtEwF161DMyeXksbqXG3dk