### PR TITLE
refactor(ui): refactor activity bar layout and move status indicators

### DIFF
--- a/frontend/src/components/AgentSetupCard.tsx
+++ b/frontend/src/components/AgentSetupCard.tsx
@@ -42,8 +42,10 @@ export interface AgentSetupCardProps {
 }
 
 const COLLAPSED_KEY = (agentKey: string) => `setup-card-collapsed-${agentKey}`;
-const STEP2_KEY = (agentKey: string) => `setup-card-step2-done-${agentKey}`;
-const STEP3_KEY = (agentKey: string) => `setup-card-step3-done-${agentKey}`;
+// Storage key names retain their `step2`/`step3` suffixes for backward compat
+// even though those steps moved to positions 3 and 4 in the UI.
+const INSTALL_DONE_KEY = (agentKey: string) => `setup-card-step2-done-${agentKey}`;
+const APPLY_DONE_KEY = (agentKey: string) => `setup-card-step3-done-${agentKey}`;
 const TOTAL_STEPS = 4;
 
 /** True iff at least one rule has a service with both a non-empty provider and model. */
@@ -81,11 +83,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     // effect below can distinguish "user has not chosen" from "user chose expanded".
     const initialCollapsedPref = useRef<string | null>(localStorage.getItem(COLLAPSED_KEY(agentKey)));
     const [collapsed, setCollapsed] = useState(initialCollapsedPref.current === 'true');
-    const [step2Done, setStep2Done] = useState(
-        () => localStorage.getItem(STEP2_KEY(agentKey)) === 'true'
+    const [installDone, setInstallDone] = useState(
+        () => localStorage.getItem(INSTALL_DONE_KEY(agentKey)) === 'true'
     );
-    const [step3Done, setStep3Done] = useState(
-        () => localStorage.getItem(STEP3_KEY(agentKey)) === 'true'
+    const [applyDone, setApplyDone] = useState(
+        () => localStorage.getItem(APPLY_DONE_KEY(agentKey)) === 'true'
     );
     const [hasProvider, setHasProvider] = useState(false);
     const [providerCount, setProviderCount] = useState(0);
@@ -109,10 +111,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         return () => { cancelled = true; };
     }, []);
 
-    const step1Done = hasProvider;
-    const step4Done = hasModelSelected;
-    const allDone = step1Done && step2Done && step3Done && step4Done;
-    const doneCount = [step1Done, step2Done, step3Done, step4Done].filter(Boolean).length;
+    // Step order: 1) Provider, 2) Model, 3) Install, 4) Apply
+    const providerDone = hasProvider;
+    const modelDone = hasModelSelected;
+    const allDone = providerDone && modelDone && installDone && applyDone;
+    const doneCount = [providerDone, modelDone, installDone, applyDone].filter(Boolean).length;
 
     // Auto-collapse on first visit when every step is already complete, but only
     // when the user hasn't expressed a preference. We wait for providerLoading
@@ -135,14 +138,14 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setCollapsed(next);
     };
 
-    const handleStep2Done = () => {
-        localStorage.setItem(STEP2_KEY(agentKey), 'true');
-        setStep2Done(true);
+    const handleInstallDone = () => {
+        localStorage.setItem(INSTALL_DONE_KEY(agentKey), 'true');
+        setInstallDone(true);
     };
 
-    const handleStep3Done = () => {
-        localStorage.setItem(STEP3_KEY(agentKey), 'true');
-        setStep3Done(true);
+    const handleApplyDone = () => {
+        localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
+        setApplyDone(true);
     };
 
     const handleCopy = async () => {
@@ -162,7 +165,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         const result = await onApply();
         setApplyResult(result);
         if (result.success) {
-            handleStep3Done();
+            handleApplyDone();
         }
     };
 
@@ -171,20 +174,20 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         const result = await onApplyWithStatusLine();
         setApplyResult(result);
         if (result.success) {
-            handleStep3Done();
+            handleApplyDone();
         }
     };
 
     const progressLabel = allDone ? 'Done' : `${doneCount}/${TOTAL_STEPS}`;
     const progressColor = allDone ? 'success' : 'default';
 
-    const collapsedHint = !step1Done
+    const collapsedHint = !providerDone
         ? 'Add a provider to get started'
-        : !step2Done
-            ? `Install ${agentName}`
-            : !step3Done
-                ? 'Apply config'
-                : 'Pick a model to finish';
+        : !modelDone
+            ? 'Pick a model'
+            : !installDone
+                ? `Install ${agentName}`
+                : 'Apply config to finish';
 
     return (
         <UnifiedCard
@@ -221,13 +224,13 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                     <Stack direction="row" spacing={1.5} alignItems="flex-start">
                         {providerLoading
                             ? <CircularProgress size={20} sx={{ mt: 0.2, flexShrink: 0 }} />
-                            : <StepIcon done={step1Done} active={!step1Done} />
+                            : <StepIcon done={providerDone} active={!providerDone} />
                         }
                         <Box sx={{ flex: 1 }}>
-                            <Typography variant="body2" fontWeight={500} color={step1Done ? 'text.primary' : 'primary.main'}>
+                            <Typography variant="body2" fontWeight={500} color={providerDone ? 'text.primary' : 'primary.main'}>
                                 Step 1 — Add a Provider
                             </Typography>
-                            {step1Done ? (
+                            {providerDone ? (
                                 <Typography variant="caption" color="text.secondary">
                                     {providerCount === 1
                                         ? `${providerCount} provider ready`
@@ -252,12 +255,52 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                         </Box>
                     </Stack>
 
-                    {/* Step 2: Install */}
+                    {/* Step 2: Select a Model */}
                     <Stack direction="row" spacing={1.5} alignItems="flex-start">
-                        <StepIcon done={step2Done} active={!step2Done} />
+                        <StepIcon done={modelDone} active={providerDone && !modelDone} />
                         <Box sx={{ flex: 1 }}>
-                            <Typography variant="body2" fontWeight={500} color={step2Done ? 'text.primary' : 'primary.main'}>
-                                Step 2 — Install {agentName}
+                            <Typography
+                                variant="body2"
+                                fontWeight={500}
+                                color={!providerDone ? 'text.disabled' : modelDone ? 'text.primary' : 'primary.main'}
+                            >
+                                Step 2 — Select a Model
+                            </Typography>
+                            {modelDone ? (
+                                <Typography variant="caption" color="text.secondary">
+                                    Model selected — you're ready to go.
+                                </Typography>
+                            ) : (
+                                <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }} flexWrap="wrap" gap={1}>
+                                    <Typography variant="caption" color="text.secondary">
+                                        Pick a model in <em>Models and Forwarding Rules</em> to start routing requests.
+                                    </Typography>
+                                    {onSelectModel && (
+                                        <Button
+                                            size="small"
+                                            variant="outlined"
+                                            disabled={!providerDone}
+                                            onClick={onSelectModel}
+                                            sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem' }}
+                                        >
+                                            Choose Model
+                                        </Button>
+                                    )}
+                                </Stack>
+                            )}
+                        </Box>
+                    </Stack>
+
+                    {/* Step 3: Install */}
+                    <Stack direction="row" spacing={1.5} alignItems="flex-start">
+                        <StepIcon done={installDone} active={modelDone && !installDone} />
+                        <Box sx={{ flex: 1 }}>
+                            <Typography
+                                variant="body2"
+                                fontWeight={500}
+                                color={!modelDone ? 'text.disabled' : installDone ? 'text.primary' : 'primary.main'}
+                            >
+                                Step 3 — Install {agentName}
                             </Typography>
 
                             {/* npm official */}
@@ -330,11 +373,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 </Box>
                             )}
 
-                            {!step2Done && (
+                            {!installDone && (
                                 <Button
                                     size="small"
                                     variant="text"
-                                    onClick={handleStep2Done}
+                                    onClick={handleInstallDone}
                                     sx={{ mt: 0.5, fontSize: '0.75rem', px: 0 }}
                                 >
                                     ✓ Already installed / Done
@@ -343,27 +386,27 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                         </Box>
                     </Stack>
 
-                    {/* Step 3: Apply Config */}
+                    {/* Step 4: Apply Config */}
                     <Stack direction="row" spacing={1.5} alignItems="flex-start">
-                        <StepIcon done={step3Done} active={step2Done && !step3Done} />
+                        <StepIcon done={applyDone} active={installDone && !applyDone} />
                         <Box sx={{ flex: 1 }}>
                             <Typography
                                 variant="body2"
                                 fontWeight={500}
-                                color={!step2Done ? 'text.disabled' : step3Done ? 'text.primary' : 'primary.main'}
+                                color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}
                             >
-                                Step 3 — Apply Config
+                                Step 4 — Apply Config
                             </Typography>
                             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
                                 Write the proxy configuration to {agentName}'s settings file.
                             </Typography>
 
-                            <Collapse in={!step3Done}>
+                            <Collapse in={!applyDone}>
                                 <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
                                     <Button
                                         variant="contained"
                                         size="small"
-                                        disabled={!step2Done || isApplyLoading}
+                                        disabled={!installDone || isApplyLoading}
                                         onClick={handleApply}
                                         startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}
                                     >
@@ -373,7 +416,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                         <Button
                                             variant="outlined"
                                             size="small"
-                                            disabled={!step2Done || isApplyLoading}
+                                            disabled={!installDone || isApplyLoading}
                                             onClick={handleApplyWithStatusLine}
                                         >
                                             Apply + Status Line
@@ -391,8 +434,8 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                     <Button
                                         variant="text"
                                         size="small"
-                                        disabled={!step2Done}
-                                        onClick={handleStep3Done}
+                                        disabled={!installDone}
+                                        onClick={handleApplyDone}
                                         sx={{ fontSize: '0.75rem' }}
                                     >
                                         ✓ Already configured / Done
@@ -418,42 +461,6 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                         <Typography variant="caption">{applyResult.error ?? 'Apply failed'}</Typography>
                                     )}
                                 </Alert>
-                            )}
-                        </Box>
-                    </Stack>
-
-                    {/* Step 4: Select a Model */}
-                    <Stack direction="row" spacing={1.5} alignItems="flex-start">
-                        <StepIcon done={step4Done} active={step3Done && !step4Done} />
-                        <Box sx={{ flex: 1 }}>
-                            <Typography
-                                variant="body2"
-                                fontWeight={500}
-                                color={!step3Done ? 'text.disabled' : step4Done ? 'text.primary' : 'primary.main'}
-                            >
-                                Step 4 — Select a Model
-                            </Typography>
-                            {step4Done ? (
-                                <Typography variant="caption" color="text.secondary">
-                                    Model selected — you're ready to go.
-                                </Typography>
-                            ) : (
-                                <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }} flexWrap="wrap" gap={1}>
-                                    <Typography variant="caption" color="text.secondary">
-                                        Pick a model in <em>Models and Forwarding Rules</em> to start routing requests.
-                                    </Typography>
-                                    {onSelectModel && (
-                                        <Button
-                                            size="small"
-                                            variant="outlined"
-                                            disabled={!step3Done}
-                                            onClick={onSelectModel}
-                                            sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem' }}
-                                        >
-                                            Choose Model
-                                        </Button>
-                                    )}
-                                </Stack>
                             )}
                         </Box>
                     </Stack>

--- a/frontend/src/components/FloatingStatusIndicators.tsx
+++ b/frontend/src/components/FloatingStatusIndicators.tsx
@@ -1,0 +1,94 @@
+import { Box, IconButton, Tooltip } from '@mui/material';
+import { IconAlertCircle, IconStar } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+import { useHealth } from '../contexts/HealthContext';
+import { useVersion as useAppVersion } from '../contexts/VersionContext';
+import { Z_INDEX } from '../constants/zIndex';
+
+export const FloatingStatusIndicators = () => {
+    const { t } = useTranslation();
+    const { hasUpdate, showUpdateDialog } = useAppVersion();
+    const { isHealthy, showDisconnectDialog } = useHealth();
+
+    const showError = !isHealthy || import.meta.env.DEV;
+    const showUpdate = hasUpdate || import.meta.env.DEV;
+
+    if (!showError && !showUpdate) return null;
+
+    return (
+        <Box
+            sx={{
+                position: 'fixed',
+                bottom: 16,
+                right: 16,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1,
+                zIndex: Z_INDEX.popover,
+            }}
+        >
+            {showError && (
+                <Tooltip
+                    title={
+                        import.meta.env.DEV && isHealthy
+                            ? t('layout.activityBar.disconnectedDebug')
+                            : t('layout.activityBar.disconnected')
+                    }
+                    placement="left"
+                    arrow
+                >
+                    <IconButton
+                        onClick={showDisconnectDialog}
+                        size="small"
+                        sx={{
+                            width: 40,
+                            height: 40,
+                            bgcolor: 'background.paper',
+                            color: 'error.main',
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            boxShadow: 2,
+                            '&:hover': {
+                                bgcolor: 'action.hover',
+                                color: 'error.dark',
+                            },
+                        }}
+                    >
+                        <IconAlertCircle size={20} />
+                    </IconButton>
+                </Tooltip>
+            )}
+
+            {showUpdate && (
+                <Tooltip
+                    title={
+                        import.meta.env.DEV && !hasUpdate
+                            ? t('layout.activityBar.devMode')
+                            : t('layout.activityBar.newVersionAvailable')
+                    }
+                    placement="left"
+                    arrow
+                >
+                    <IconButton
+                        onClick={showUpdateDialog}
+                        size="small"
+                        sx={{
+                            width: 40,
+                            height: 40,
+                            bgcolor: 'background.paper',
+                            color: import.meta.env.DEV && !hasUpdate ? 'success.main' : 'info.main',
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            boxShadow: 2,
+                            '&:hover': {
+                                bgcolor: 'action.hover',
+                            },
+                        }}
+                    >
+                        <IconStar size={20} />
+                    </IconButton>
+                </Tooltip>
+            )}
+        </Box>
+    );
+};

--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -774,8 +774,8 @@ const OAuthDialog = ({open, onClose, onSuccess}: OAuthDialogProps) => {
                                 label={
                                     <Typography variant="body2" color={globalProxyUrl ? 'text.secondary' : 'text.disabled'}>
                                         {globalProxyUrl
-                                            ? `Use global proxy (${globalProxyUrl})`
-                                            : 'Use global proxy (not configured)'}
+                                            ? `Use quick proxy (${globalProxyUrl})`
+                                            : 'Use quick proxy (not configured)'}
                                     </Typography>
                                 }
                                 labelPlacement="start"

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -110,6 +110,7 @@ export default {
     "accessControl": "Access Control",
     "status": "Status",
     "system": "System",
+    "general": "General",
     "experimental": "Experimental",
     "logs": "Logs",
     "userRequest": "User Request",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -247,8 +247,8 @@ export default {
         "label": "HTTP/SOCKS Proxy URL (Optional)",
         "placeholder": "http://127.0.0.1:7890 or socks5://127.0.0.1:7890",
         "helper": "Optional: Use a proxy to bypass region restrictions. Saved for future use.",
-        "useGlobal": "Use global proxy ({{url}})",
-        "useGlobalNotSet": "Use global proxy (not configured — set in System Settings)"
+        "useGlobal": "Use quick proxy ({{url}})",
+        "useGlobalNotSet": "Use quick proxy (not configured — set in System Settings)"
       }
     },
     "verification": {
@@ -415,10 +415,11 @@ export default {
         "helper": "When enabled, providers without explicit proxy configuration will use system proxy settings (HTTP_PROXY, HTTPS_PROXY, macOS system proxy, Clash, etc.)"
       },
       "globalProxyUrl": {
-        "label": "Global Proxy",
-        "helper": "Fallback proxy for all providers and OAuth. Per-provider proxy takes priority.",
-        "saveSuccess": "Global proxy URL saved",
-        "saveFailed": "Failed to save global proxy URL"
+        "label": "Quick Proxy",
+        "description": "Save a proxy you reuse often so providers and OAuth can pick it up with one click — per-provider proxy still wins if set.",
+        "helper": "Reusable across providers and OAuth. Per-provider proxy takes priority.",
+        "saveSuccess": "Quick proxy saved",
+        "saveFailed": "Failed to save quick proxy"
       },
       "notifications": {
         "updateSuccess": "Proxy settings updated successfully",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -110,6 +110,7 @@ export default {
     "accessControl": "访问控制",
     "status": "状态",
     "system": "系统",
+    "general": "通用",
     "experimental": "实验功能",
     "logs": "日志",
     "userRequest": "用户请求",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -247,8 +247,8 @@ export default {
         "label": "HTTP/SOCKS 代理 URL（可选）",
         "placeholder": "http://127.0.0.1:7890 或 socks5://127.0.0.1:7890",
         "helper": "可选：使用代理绕过区域限制。将保存以供将来使用。",
-        "useGlobal": "使用全局代理（{{url}}）",
-        "useGlobalNotSet": "使用全局代理（未配置 — 请在系统设置中配置）"
+        "useGlobal": "使用常用代理（{{url}}）",
+        "useGlobalNotSet": "使用常用代理（未配置 — 请在系统设置中配置）"
       }
     },
     "verification": {
@@ -415,10 +415,11 @@ export default {
         "helper": "启用后，没有显式代理配置的提供商将使用系统代理设置（HTTP_PROXY、HTTPS_PROXY、macOS 系统代理、Clash 等）"
       },
       "globalProxyUrl": {
-        "label": "全局代理",
-        "helper": "所有提供商和 OAuth 的兜底代理，每个提供商的专属代理优先级更高。",
-        "saveSuccess": "全局代理 URL 已保存",
-        "saveFailed": "保存全局代理 URL 失败"
+        "label": "常用代理",
+        "description": "保存一个常用的代理，配置 Provider 或 OAuth 时可一键复用；如果 Provider 单独设置了代理，会以 Provider 的为准。",
+        "helper": "可在 Provider 和 OAuth 中一键复用，Provider 单独设置的代理优先级更高。",
+        "saveSuccess": "常用代理已保存",
+        "saveFailed": "保存常用代理失败"
       },
       "notifications": {
         "updateSuccess": "代理设置更新成功",

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -14,6 +14,7 @@ import { useZenMode } from '../hooks/useZenMode';
 import { useProfileContext } from '../contexts/ProfileContext';
 import type { ActivityItem, LayoutProps } from './types';
 import { Claude, Codex, OpenCode, Xcode, VSCode, OpenAI, Anthropic, OpenClaw } from '../components/BrandIcons';
+import { FloatingStatusIndicators } from '../components/FloatingStatusIndicators';
 import { IconPlus } from '@tabler/icons-react';
 
 const Layout = ({ children }: LayoutProps) => {
@@ -292,6 +293,7 @@ const Layout = ({ children }: LayoutProps) => {
 
     return (
         <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden', position: 'relative', zIndex: Z_INDEX.main }}>
+            <FloatingStatusIndicators />
             {/* Zen Mode Layout */}
             {effectiveZenEnabled && !zenLoading && zenAgent ? (
                 <>

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -1,6 +1,4 @@
 import {
-    IconAlertCircle,
-    IconStar,
     IconUser,
     IconYinYang,
     IconDots,
@@ -11,7 +9,6 @@ import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Ty
 import React, { useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useHealth } from '../contexts/HealthContext';
 import { useVersion as useAppVersion } from '../contexts/VersionContext';
 import { Claude, Codex, OpenCode, Xcode, VSCode, OpenAI, Anthropic, OpenClaw } from '@/components/BrandIcons';
 import {
@@ -46,8 +43,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
 }) => {
     const { t, i18n } = useTranslation();
     const { currentVersion } = useAppVersion();
-    const { hasUpdate, showUpdateDialog } = useAppVersion();
-    const { isHealthy, showDisconnectDialog } = useHealth();
     const [zenMenuAnchorEl, setZenMenuAnchorEl] = useState<HTMLElement | null>(null);
     const [languageMenuAnchorEl, setLanguageMenuAnchorEl] = useState<HTMLElement | null>(null);
 
@@ -191,51 +186,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                 })}
 
                 <Divider sx={{ mx: 2, my: 1 }} />
-
-                {/* Disconnected indicator */}
-                {(!isHealthy || import.meta.env.DEV) && (
-                    <Tooltip
-                        title={import.meta.env.DEV && isHealthy ? t('layout.activityBar.disconnectedDebug') : t('layout.activityBar.disconnected')}
-                        placement="right"
-                        arrow
-                    >
-                        <ListItemButton
-                            onClick={showDisconnectDialog}
-                            sx={activityItemSx({ color: 'error.main', '&:hover': { bgcolor: 'action.hover' } })}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <IconAlertCircle size={22} />
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
-                                {t('layout.activityBar.error')}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-                )}
-
-                {/* Update indicator */}
-                {(hasUpdate || import.meta.env.DEV) && (
-                    <Tooltip
-                        title={import.meta.env.DEV && !hasUpdate ? t('layout.activityBar.devMode') : t('layout.activityBar.newVersionAvailable')}
-                        placement="right"
-                        arrow
-                    >
-                        <ListItemButton
-                            onClick={showUpdateDialog}
-                            sx={activityItemSx({
-                                color: import.meta.env.DEV && !hasUpdate ? 'success.main' : 'info.main',
-                                '&:hover': { bgcolor: 'action.hover' },
-                            })}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <IconStar size={22} />
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
-                                {import.meta.env.DEV && !hasUpdate ? t('layout.activityBar.devMode') : t('layout.activityBar.newVersionAvailable')}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-                )}
 
                 {/* Language menu - only show in normal mode */}
                 {!zenEnabled && (

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -1,11 +1,6 @@
 import {
     IconAlertCircle,
-    IconBrush,
-    IconMoon,
-    IconSparkles,
     IconStar,
-    IconSun,
-    IconSunHigh,
     IconUser,
     IconYinYang,
     IconDots,
@@ -18,7 +13,6 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useHealth } from '../contexts/HealthContext';
 import { useVersion as useAppVersion } from '../contexts/VersionContext';
-import { useThemeMode } from '../contexts/ThemeContext';
 import { Claude, Codex, OpenCode, Xcode, VSCode, OpenAI, Anthropic, OpenClaw } from '@/components/BrandIcons';
 import {
     activityBarWidth,
@@ -54,18 +48,8 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
     const { currentVersion } = useAppVersion();
     const { hasUpdate, showUpdateDialog } = useAppVersion();
     const { isHealthy, showDisconnectDialog } = useHealth();
-    const { mode, setTheme } = useThemeMode();
-    const [themeMenuAnchorEl, setThemeMenuAnchorEl] = useState<HTMLElement | null>(null);
     const [zenMenuAnchorEl, setZenMenuAnchorEl] = useState<HTMLElement | null>(null);
     const [languageMenuAnchorEl, setLanguageMenuAnchorEl] = useState<HTMLElement | null>(null);
-
-    const handleThemeMenuClick = (event: React.MouseEvent<HTMLElement>) => {
-        setThemeMenuAnchorEl(event.currentTarget);
-    };
-
-    const handleThemeMenuClose = () => {
-        setThemeMenuAnchorEl(null);
-    };
 
     const handleLanguageMenuClick = (event: React.MouseEvent<HTMLElement>) => {
         setLanguageMenuAnchorEl(event.currentTarget);
@@ -253,59 +237,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                     </Tooltip>
                 )}
 
-                {/* Theme menu - only show in normal mode */}
-                {!zenEnabled && (
-                    <Menu
-                        anchorEl={themeMenuAnchorEl}
-                        open={Boolean(themeMenuAnchorEl)}
-                        onClose={handleThemeMenuClose}
-                        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-                        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                        slotProps={{
-                            paper: {
-                                sx: {
-                                    minWidth: 160,
-                                    mt: 1,
-                                },
-                            },
-                        }}
-                    >
-                        <MenuItem
-                            selected={mode === 'light'}
-                            onClick={() => {
-                                setTheme('light');
-                                handleThemeMenuClose();
-                            }}
-                            sx={{ gap: 1.5 }}
-                        >
-                            <IconSun size={18} />
-                            <Typography>{t('layout.activityBar.light')}</Typography>
-                        </MenuItem>
-                        <MenuItem
-                            selected={mode === 'dark'}
-                            onClick={() => {
-                                setTheme('dark');
-                                handleThemeMenuClose();
-                            }}
-                            sx={{ gap: 1.5 }}
-                        >
-                            <IconMoon size={18} />
-                            <Typography>{t('layout.activityBar.dark')}</Typography>
-                        </MenuItem>
-                        <MenuItem
-                            selected={mode === 'sunlit'}
-                            onClick={() => {
-                                setTheme('sunlit');
-                                handleThemeMenuClose();
-                            }}
-                            sx={{ gap: 1.5 }}
-                        >
-                            <IconSunHigh size={18} />
-                            <Typography>{t('layout.activityBar.sunlit')}</Typography>
-                        </MenuItem>
-                    </Menu>
-                )}
-
                 {/* Language menu - only show in normal mode */}
                 {!zenEnabled && (
                     <Menu
@@ -475,7 +406,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                 )}
             </Box>
 
-            {/* Theme & Language buttons - bottom-left, above user icon */}
+            {/* Language button - bottom-left, above user icon */}
             {!zenEnabled && (
                 <Box
                     sx={{
@@ -487,34 +418,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                         flexShrink: 0,
                     }}
                 >
-                    <Tooltip title={t('layout.activityBar.theme')} placement="right" arrow>
-                        <ListItemButton
-                            onClick={handleThemeMenuClick}
-                            sx={{
-                                minHeight: 48,
-                                mx: 0.5,
-                                px: activityItemPaddingX,
-                                py: 0.75,
-                                flexDirection: 'column',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                gap: 0.25,
-                                position: 'relative',
-                                color: 'text.secondary',
-                                borderRadius: activityItemRadius,
-                                cursor: 'pointer',
-                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
-                            }}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <IconBrush size={22} />
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.6rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
-                                {t('common.theme')}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-
                     <Tooltip title={t('system.language.title')} placement="right" arrow>
                         <ListItemButton
                             onClick={handleLanguageMenuClick}

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -253,44 +253,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                     </Tooltip>
                 )}
 
-                {/* Theme toggle button - only show in normal mode */}
-                {!zenEnabled && (
-                    <Tooltip title={t('layout.activityBar.theme')} placement="right" arrow>
-                        <ListItemButton
-                            onClick={handleThemeMenuClick}
-                            sx={activityItemSx({
-                                '&:hover': { bgcolor: 'action.hover' },
-                            })}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <IconBrush size={22} />
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
-                                {t('common.theme')}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-                )}
-
-                {/* Language toggle button - only show in normal mode */}
-                {!zenEnabled && (
-                    <Tooltip title={t('system.language.title')} placement="right" arrow>
-                        <ListItemButton
-                            onClick={handleLanguageMenuClick}
-                            sx={activityItemSx({
-                                '&:hover': { bgcolor: 'action.hover' },
-                            })}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <IconLanguage size={22} />
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
-                                {i18n.language === 'zh' ? '中文' : 'EN'}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-                )}
-
                 {/* Theme menu - only show in normal mode */}
                 {!zenEnabled && (
                     <Menu
@@ -376,6 +338,26 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <Typography>{t('system.language.zh')}</Typography>
                         </MenuItem>
                     </Menu>
+                )}
+
+                {/* Onboarding Quick Add Button - above Zen */}
+                {!zenEnabled && (
+                    <Tooltip title={t('layout.onboarding', { defaultValue: 'Quick Add Provider' })} placement="right" arrow>
+                        <ListItemButton
+                            component={RouterLink}
+                            to="/onboarding"
+                            sx={activityItemSx({
+                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                            })}
+                        >
+                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                                <IconWand size={22} />
+                            </ListItemIcon>
+                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
+                                {t('layout.onboardingShort', { defaultValue: 'Onboard' })}
+                            </Typography>
+                        </ListItemButton>
+                    </Tooltip>
                 )}
 
                 {/* Zen mode toggle button - only show in normal mode */}
@@ -493,46 +475,75 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                 )}
             </Box>
 
-            {/* Onboarding Quick Add Button - above user icon */}
-            <Box
-                sx={{
-                    py: 0.5,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    flexShrink: 0,
-                }}
-            >
-                <Tooltip title={t('layout.onboarding', { defaultValue: 'Quick Add Provider' })} placement="right" arrow>
-                    <ListItemButton
-                        component={RouterLink}
-                        to="/onboarding"
-                        sx={{
-                            minHeight: 48,
-                            mx: 0.5,
-                            px: activityItemPaddingX,
-                            py: 0.75,
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            gap: 0.25,
-                            position: 'relative',
-                            color: 'text.secondary',
-                            borderRadius: activityItemRadius,
-                            cursor: 'pointer',
-                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
-                        }}
-                    >
-                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                            <IconWand size={22} />
-                        </ListItemIcon>
-                        <Typography variant="caption" sx={{ fontSize: '0.6rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
-                            {t('layout.onboardingShort', { defaultValue: 'Onboard' })}
-                        </Typography>
-                    </ListItemButton>
-                </Tooltip>
-            </Box>
+            {/* Theme & Language buttons - bottom-left, above user icon */}
+            {!zenEnabled && (
+                <Box
+                    sx={{
+                        py: 0.5,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                    }}
+                >
+                    <Tooltip title={t('layout.activityBar.theme')} placement="right" arrow>
+                        <ListItemButton
+                            onClick={handleThemeMenuClick}
+                            sx={{
+                                minHeight: 48,
+                                mx: 0.5,
+                                px: activityItemPaddingX,
+                                py: 0.75,
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: 0.25,
+                                position: 'relative',
+                                color: 'text.secondary',
+                                borderRadius: activityItemRadius,
+                                cursor: 'pointer',
+                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                            }}
+                        >
+                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                                <IconBrush size={22} />
+                            </ListItemIcon>
+                            <Typography variant="caption" sx={{ fontSize: '0.6rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
+                                {t('common.theme')}
+                            </Typography>
+                        </ListItemButton>
+                    </Tooltip>
+
+                    <Tooltip title={t('system.language.title')} placement="right" arrow>
+                        <ListItemButton
+                            onClick={handleLanguageMenuClick}
+                            sx={{
+                                minHeight: 48,
+                                mx: 0.5,
+                                px: activityItemPaddingX,
+                                py: 0.75,
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: 0.25,
+                                position: 'relative',
+                                color: 'text.secondary',
+                                borderRadius: activityItemRadius,
+                                cursor: 'pointer',
+                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                            }}
+                        >
+                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                                <IconLanguage size={22} />
+                            </ListItemIcon>
+                            <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
+                                {i18n.language === 'zh' ? '中文' : 'EN'}
+                            </Typography>
+                        </ListItemButton>
+                    </Tooltip>
+                </Box>
+            )}
 
             {/* Bottom: User icon */}
             <Box

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -171,11 +171,11 @@ export function useActivityItems(): ActivityItem[] {
             {
                 key: 'system',
                 icon: <IconSettings size={22} />,
-                label: t('layout.settings'),
+                label: t('layout.system'),
                 defaultPath: '/system',
                 children: [
+                    { path: '/system', label: t('layout.general'), icon: <IconSettings size={20} /> },
                     { path: '/access-control', label: t('layout.accessControl'), icon: <IconShield size={20} /> },
-                    { path: '/system', label: t('layout.system'), icon: <IconSettings size={20} /> },
                     { path: '/system/experimental', label: t('layout.experimental'), icon: <IconFlask size={20} /> },
                     { path: '/system/logs', label: t('layout.logs'), icon: <IconFileText size={20} /> },
                 ],

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -3,7 +3,7 @@ import { PageLayout } from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import { Logout } from '@mui/icons-material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
-import { IconCircleCheck, IconCircleX, IconInfoCircle, IconKey, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconSun, IconMoon, IconSunHigh } from '@tabler/icons-react';
+import { IconCircleCheck, IconCircleX, IconInfoCircle, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconSun, IconMoon, IconSunHigh, IconWorld, IconCheck } from '@tabler/icons-react';
 import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -168,21 +168,6 @@ const System = () => {
                                 </Box>
                             </Box>
 
-                            {/* Keys */}
-                            <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                    <IconKey size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('system.status.keys')}
-                                    </Typography>
-                                </Box>
-                                <Box sx={{ flex: 1 }}>
-                                    <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                                        {serverStatus.providers_enabled} / {serverStatus.providers_total}
-                                    </Typography>
-                                </Box>
-                            </Box>
-
                             {/* Uptime */}
                             {serverStatus.uptime && (
                                 <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
@@ -230,42 +215,6 @@ const System = () => {
                                             />
                                         </Tooltip>
                                     )}
-                                </Box>
-                            </Box>
-
-                            {/* Global Proxy URL */}
-                            <Box sx={{ display: 'flex', alignItems: 'flex-start', py: 0.5, gap: 3 }}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100, pt: 1 }}>
-                                    <IconLock size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('system.proxy.globalProxyUrl.label')}
-                                    </Typography>
-                                </Box>
-                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, maxWidth: 380 }}>
-                                    <TextField
-                                        size="small"
-                                        value={globalProxyInput}
-                                        onChange={(e) => setGlobalProxyInput(e.target.value)}
-                                        placeholder="http://127.0.0.1:7890"
-                                        helperText={t('system.proxy.globalProxyUrl.helper')}
-                                        sx={{ flex: 1 }}
-                                        InputProps={globalProxyUrl && globalProxyInput === globalProxyUrl ? {
-                                            endAdornment: (
-                                                <InputAdornment position="end">
-                                                    <IconLock size={14} style={{ color: 'var(--mui-palette-success-main)' }} />
-                                                </InputAdornment>
-                                            )
-                                        } : undefined}
-                                    />
-                                    <Button
-                                        size="small"
-                                        variant="outlined"
-                                        onClick={saveGlobalProxyUrl}
-                                        disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
-                                        sx={{ mt: 0.5, whiteSpace: 'nowrap' }}
-                                    >
-                                        {t('common.save')}
-                                    </Button>
                                 </Box>
                             </Box>
 
@@ -353,6 +302,54 @@ const System = () => {
                                         );
                                     })}
                                 </Box>
+                            </Box>
+
+                            {/* Global Proxy URL — moved to the bottom of the card */}
+                            <Box
+                                sx={{
+                                    mt: 1,
+                                    pt: 2,
+                                    borderTop: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                                    <IconWorld size={16} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                                    <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 500 }}>
+                                        {t('system.proxy.globalProxyUrl.label')}
+                                    </Typography>
+                                </Box>
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                    <TextField
+                                        size="small"
+                                        fullWidth
+                                        value={globalProxyInput}
+                                        onChange={(e) => setGlobalProxyInput(e.target.value)}
+                                        placeholder="http://127.0.0.1:7890"
+                                        sx={{ maxWidth: 480 }}
+                                        InputProps={globalProxyUrl && globalProxyInput === globalProxyUrl ? {
+                                            endAdornment: (
+                                                <InputAdornment position="end">
+                                                    <Tooltip title={t('common.saved', { defaultValue: 'Saved' })} arrow>
+                                                        <IconCheck size={16} style={{ color: 'var(--mui-palette-success-main)' }} />
+                                                    </Tooltip>
+                                                </InputAdornment>
+                                            )
+                                        } : undefined}
+                                    />
+                                    <Button
+                                        size="small"
+                                        variant="contained"
+                                        onClick={saveGlobalProxyUrl}
+                                        disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
+                                        sx={{ whiteSpace: 'nowrap', minWidth: 72 }}
+                                    >
+                                        {proxyUrlSaving ? <CircularProgress size={14} color="inherit" /> : t('common.save')}
+                                    </Button>
+                                </Stack>
+                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
+                                    {t('system.proxy.globalProxyUrl.helper')}
+                                </Typography>
                             </Box>
                         </Stack>
                     ) : (

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -3,13 +3,14 @@ import { PageLayout } from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import { Logout } from '@mui/icons-material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
-import { IconCircleCheck, IconCircleX, IconInfoCircle, IconKey, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage } from '@tabler/icons-react';
+import { IconCircleCheck, IconCircleX, IconInfoCircle, IconKey, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconSun, IconMoon, IconSunHigh } from '@tabler/icons-react';
 import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHealth } from '@/contexts/HealthContext';
 import { useVersion } from '@/contexts/VersionContext';
 import { useAuth } from '@/contexts/AuthContext';
+import { useThemeMode } from '@/contexts/ThemeContext';
 import { api } from '@/services/api';
 
 const System = () => {
@@ -17,6 +18,7 @@ const System = () => {
     const { currentVersion, hasUpdate, latestVersion, showUpdateDialog } = useVersion();
     const { isHealthy, checking, checkHealth } = useHealth();
     const { logout: authLogout } = useAuth();
+    const { mode: themeMode, setTheme } = useThemeMode();
     const [serverStatus, setServerStatus] = useState<any>(null);
     const [notification, setNotification] = useState<{ open: boolean; message?: string; severity?: 'success' | 'error' | 'info' | 'warning' }>({ open: false });
     const [loading, setLoading] = useState(true);
@@ -308,6 +310,48 @@ const System = () => {
                                             },
                                         }}
                                     />
+                                </Box>
+                            </Box>
+
+                            {/* Theme — moved from the activity bar */}
+                            <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                    <IconBrush size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                        {t('common.theme')}
+                                    </Typography>
+                                </Box>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
+                                    {([
+                                        { value: 'light', label: t('layout.activityBar.light'), Icon: IconSun },
+                                        { value: 'dark', label: t('layout.activityBar.dark'), Icon: IconMoon },
+                                        { value: 'sunlit', label: t('layout.activityBar.sunlit'), Icon: IconSunHigh },
+                                    ] as const).map(({ value, label, Icon }) => {
+                                        const selected = themeMode === value;
+                                        return (
+                                            <Chip
+                                                key={value}
+                                                icon={<Icon size={14} />}
+                                                label={label}
+                                                onClick={() => setTheme(value)}
+                                                size="small"
+                                                sx={{
+                                                    bgcolor: selected ? 'primary.main' : 'action.hover',
+                                                    color: selected ? 'primary.contrastText' : 'text.primary',
+                                                    fontWeight: selected ? 600 : 400,
+                                                    border: selected ? 'none' : '1px solid',
+                                                    borderColor: 'divider',
+                                                    cursor: 'pointer',
+                                                    '& .MuiChip-icon': {
+                                                        color: 'inherit',
+                                                    },
+                                                    '&:hover': {
+                                                        bgcolor: selected ? 'primary.dark' : 'action.selected',
+                                                    },
+                                                }}
+                                            />
+                                        );
+                                    })}
                                 </Box>
                             </Box>
                         </Stack>

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -303,58 +303,57 @@ const System = () => {
                                     })}
                                 </Box>
                             </Box>
-
-                            {/* Global Proxy URL — moved to the bottom of the card */}
-                            <Box
-                                sx={{
-                                    mt: 1,
-                                    pt: 2,
-                                    borderTop: '1px solid',
-                                    borderColor: 'divider',
-                                }}
-                            >
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                                    <IconWorld size={16} style={{ color: 'var(--mui-palette-text-secondary)' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 500 }}>
-                                        {t('system.proxy.globalProxyUrl.label')}
-                                    </Typography>
-                                </Box>
-                                <Stack direction="row" spacing={1} alignItems="center">
-                                    <TextField
-                                        size="small"
-                                        fullWidth
-                                        value={globalProxyInput}
-                                        onChange={(e) => setGlobalProxyInput(e.target.value)}
-                                        placeholder="http://127.0.0.1:7890"
-                                        sx={{ maxWidth: 480 }}
-                                        InputProps={globalProxyUrl && globalProxyInput === globalProxyUrl ? {
-                                            endAdornment: (
-                                                <InputAdornment position="end">
-                                                    <Tooltip title={t('common.saved', { defaultValue: 'Saved' })} arrow>
-                                                        <IconCheck size={16} style={{ color: 'var(--mui-palette-success-main)' }} />
-                                                    </Tooltip>
-                                                </InputAdornment>
-                                            )
-                                        } : undefined}
-                                    />
-                                    <Button
-                                        size="small"
-                                        variant="contained"
-                                        onClick={saveGlobalProxyUrl}
-                                        disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
-                                        sx={{ whiteSpace: 'nowrap', minWidth: 72 }}
-                                    >
-                                        {proxyUrlSaving ? <CircularProgress size={14} color="inherit" /> : t('common.save')}
-                                    </Button>
-                                </Stack>
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
-                                    {t('system.proxy.globalProxyUrl.helper')}
-                                </Typography>
-                            </Box>
                         </Stack>
                     ) : (
                         <Typography color="text.secondary">{t('system.status.loading')}</Typography>
                     )}
+                </UnifiedCard>
+
+                {/* Quick Proxy — dedicated card for the reusable proxy preset */}
+                <UnifiedCard
+                    title={
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                            <IconWorld size={18} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                            <Typography variant="subtitle1" fontWeight={600}>
+                                {t('system.proxy.globalProxyUrl.label')}
+                            </Typography>
+                        </Stack>
+                    }
+                    size="full"
+                >
+                    <Stack spacing={1.5}>
+                        <Typography variant="body2" color="text.secondary">
+                            {t('system.proxy.globalProxyUrl.description', { defaultValue: t('system.proxy.globalProxyUrl.helper') })}
+                        </Typography>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                            <TextField
+                                size="small"
+                                fullWidth
+                                value={globalProxyInput}
+                                onChange={(e) => setGlobalProxyInput(e.target.value)}
+                                placeholder="http://127.0.0.1:7890"
+                                sx={{ maxWidth: 480 }}
+                                InputProps={globalProxyUrl && globalProxyInput === globalProxyUrl ? {
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip title={t('common.saved', { defaultValue: 'Saved' })} arrow>
+                                                <IconCheck size={16} style={{ color: 'var(--mui-palette-success-main)' }} />
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    )
+                                } : undefined}
+                            />
+                            <Button
+                                size="small"
+                                variant="contained"
+                                onClick={saveGlobalProxyUrl}
+                                disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
+                                sx={{ whiteSpace: 'nowrap', minWidth: 72 }}
+                            >
+                                {proxyUrlSaving ? <CircularProgress size={14} color="inherit" /> : t('common.save')}
+                            </Button>
+                        </Stack>
+                    </Stack>
                 </UnifiedCard>
 
                 {/* About - Simplified one-line-per-status design */}


### PR DESCRIPTION
## Summary

A pass over the global navigation and System settings to reduce clutter and make a few features easier to find. No backend or behavior changes — UI/UX only.

## Activity bar
- Onboard button moves up next to the Zen toggle so it sits with the other primary actions instead of the footer.
- Language switcher moves to the bottom-left, above the user icon.
- Theme switcher leaves the activity bar entirely (now lives in System → General).
- Disconnected and Dev/Update indicators leave the activity bar and become a floating overlay in the bottom-right (`FloatingStatusIndicators`), so the bar stays focused on navigation.
- Top-level entry renamed **Settings → System**; child page `System` renamed to **General** and moved above **Access Control**.

## System → General page
- Drops the redundant providers/keys count row from Server Status.
- Adds a Theme row (Light / Dark / Sunlit chips with icons) next to Language.
- Pulls the proxy preset out of the Server Status card.

## Quick Proxy (formerly Global Proxy)
- Promoted to its own dedicated card on the General page.
- Renamed everywhere it surfaces — System card, provider form, OAuth dialog — to **Quick Proxy / 常用代理**, with copy that frames it as a reusable preset rather than something that overrides everything.
- Cleaner card layout: titled header with `IconWorld`, short description, fullWidth input capped at 480px, inline saved-state ✓, contained Save button with in-button spinner.

## Quick Setup (Agent page)
- Step order changed from `Provider → Install → Apply → Model` to **`Provider → Model → Install → Apply`**, so users pick a target model before touching local tooling.
- Step gating updates accordingly (Model active once Provider is set, Install active once Model is picked, Apply active once Install is done).
- Internal state renamed to `providerDone / modelDone / installDone / applyDone`. Storage keys keep their `step2-done` / `step3-done` suffixes so existing user progress carries over.

## i18n
- New keys: `layout.general`, `system.proxy.globalProxyUrl.description`.
- Updated copy for `system.proxy.globalProxyUrl.*` and `providerDialog.advanced.proxyUrl.useGlobal*` to match the Quick Proxy naming, in both `en` and `zh`.

## Test plan
- [ ] Activity bar: Onboard, Language, Zen toggle, user icon all reachable; theme button is gone.
- [ ] Bottom-right overlay shows the disconnected and update icons (in dev both should be visible) and the existing dialogs still open from them.
- [ ] System → General: server status, language, theme rows render; no Keys row; Quick Proxy is a separate card below.
- [ ] Quick Proxy: save, edit, saved-state ✓, disabled-while-saving spinner all work; the same preset shows up as "Use quick proxy" in provider form and OAuth dialog.
- [ ] Agent Quick Setup: order is Provider → Model → Install → Apply; previously stored install/apply progress is preserved.
- [ ] Sidebar under System: General is the first item, then Access Control, Experimental, Logs.

https://claude.ai/code/session_01TcsEUKEgLaDRwFLZoFx5Ld

<img width="2038" height="1628" alt="image" src="https://github.com/user-attachments/assets/be2d42ea-3d0e-48f0-b812-1683338c1692" />
