### PR TITLE
feat(client, codex): new codex client with sdk type and support image gen via codex.

### DIFF
--- a/Taskfile.curl.yml
+++ b/Taskfile.curl.yml
@@ -28,14 +28,12 @@ tasks:
           -H "Content-Type: application/json" \
           -d '{
             "model": "gpt-image-2",
-            "prompt": "A cute orange cat sitting on a wooden desk, soft natural light",
+            "prompt": "A cute orange cat and dog sitting on a wooden desk, soft natural light",
             "size": "1024x1024",
             "quality": "low"
-          }'
-        
-        # \
-        # | jq -r '.data[0].b64_json' \
-        # | base64 -d > output.png
+          }' \
+        | jq -r '.data[0].b64_json' \
+        | base64 -d > output.png
   
   codex-image-reponses:
     cmds:

--- a/Taskfile.curl.yml
+++ b/Taskfile.curl.yml
@@ -20,6 +20,47 @@ tasks:
       - echo "{{.GREETING}}"
     silent: true
   
+  codex-image-gen:
+    cmds:
+      - |
+        curl -s -X POST "http://localhost:12580/tingly/imagegen/v1/images/generations" \
+          -H "Authorization: Bearer {{.TINGLY_BOX_KEY}}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "model": "gpt-image-2",
+            "prompt": "A cute orange cat sitting on a wooden desk, soft natural light",
+            "size": "1024x1024",
+            "quality": "low"
+          }'
+        
+        # \
+        # | jq -r '.data[0].b64_json' \
+        # | base64 -d > output.png
+  
+  codex-image-reponses:
+    cmds:
+      - |
+        curl -v http://localhost:12580/tingly/imagegen/responses \
+        -H "Authorization: Bearer {{.TINGLY_BOX_KEY}}" \
+        -H "Content-Type: application/json" \
+        -d '{
+          "model": "gpt-5.5",
+          "stream": true,
+          "input": [
+            {
+              "role": "user",
+              "content": "Draw a clean product icon for an AI gateway app."
+            }
+          ],
+          "tools": [
+            {
+              "type": "image_generation",
+              "size": "1024x1024",
+              "output_format": "png"
+            }
+          ]
+        }'
+  
   request-o2a:
     cmds:
       - |

--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
-
-var codexInputIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 const reasoningMarker = "reasoning.encrypted_content"
 const defaultInstructions = "You are a helpful AI assistant."
@@ -70,40 +67,6 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	return resp, nil
-}
-
-func sanitizeCodexInputIDs(req map[string]interface{}) {
-	input, ok := req["input"]
-	if !ok {
-		return
-	}
-	model, _ := req["model"].(string)
-	req["input"] = sanitizeCodexValue(input, "input", model)
-}
-
-func sanitizeCodexValue(v interface{}, path, model string) interface{} {
-	switch item := v.(type) {
-	case []interface{}:
-		for i := range item {
-			item[i] = sanitizeCodexValue(item[i], fmt.Sprintf("%s[%d]", path, i), model)
-		}
-		return item
-	case map[string]interface{}:
-		for key, value := range item {
-			item[key] = sanitizeCodexValue(value, path+"."+key, model)
-		}
-		if rawID, ok := item["id"].(string); ok {
-			rawID = strings.TrimSpace(rawID)
-			if rawID == "" || !codexInputIDPattern.MatchString(rawID) {
-				delete(item, "id")
-			} else {
-				item["id"] = rawID
-			}
-		}
-		return item
-	default:
-		return v
-	}
 }
 
 func rewriteCodexPath(path string) string {

--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +13,7 @@ import (
 var codexInputIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 const reasoningMarker = "reasoning.encrypted_content"
+const defaultInstructions = "You are a helpful AI assistant."
 
 // codexRoundTripper wraps an http.RoundTripper to transform ChatGPT backend API
 // responses to OpenAI Responses API format. The ChatGPT backend API returns a custom format
@@ -51,26 +50,7 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	// Filter out unsupported parameters for ChatGPT backend API
 	// ChatGPT backend API does NOT support: max_tokens, max_completion_tokens, temperature, top_p
 	// It DOES support: max_output_tokens
-	var filtered []byte
-	var isStreaming = false
-	if req.Body != nil && req.Method == "POST" {
-		body, err := io.ReadAll(req.Body)
-		_ = req.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("failed to read request body: %w", err)
-		}
-
-		// Filter the request body to remove unsupported parameters
-		filtered, isStreaming = filterCodexRequestJSON(body)
-		// Trim capacity to length to avoid excessive memory usage
-		filtered = append([]byte(nil), filtered...)
-		// Set GetBody to allow retries and redirects
-		req.Body = io.NopCloser(bytes.NewReader(filtered))
-		req.ContentLength = int64(len(filtered))
-		req.GetBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewReader(filtered)), nil
-		}
-	}
+	var isStreaming = true
 
 	resp, err := t.RoundTripper.RoundTrip(req)
 	if err != nil {
@@ -90,93 +70,6 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	return resp, nil
-}
-
-// filterCodexRequestJSON filters out unsupported parameters for ChatGPT backend API.
-// ChatGPT backend API does NOT support: max_tokens, max_completion_tokens, temperature, top_p
-// It DOES support: max_output_tokens
-func filterCodexRequestJSON(data []byte) ([]byte, bool) {
-	var req map[string]interface{}
-	if err := json.Unmarshal(data, &req); err != nil {
-		return data, false // Return original if parsing fails
-	}
-
-	// stream is always true: codex-rs hardcodes true, and our SSE layer only handles streaming
-	isStreaming := true
-
-	req["store"] = false
-
-	// Force stream=true — override even if client sent false
-	req["stream"] = isStreaming
-
-	// Merge "reasoning.encrypted_content" into existing include array (preserve client-provided values)
-	includes := []interface{}{}
-	if existing, ok := req["include"].([]interface{}); ok {
-		includes = existing
-	}
-	hasMarker := false
-	for _, v := range includes {
-		if s, ok := v.(string); ok && s == reasoningMarker {
-			hasMarker = true
-			break
-		}
-	}
-	if !hasMarker {
-		includes = append(includes, reasoningMarker)
-	}
-	req["include"] = includes
-
-	if _, ok := req["instructions"]; ok {
-		//if insStr, ok := ins.(string); ok {
-		//	req["instructions"] = "You are a helpful AI assistant."
-		//	if input, ok := req["input"].([]any); ok {
-		//		tmp := []any{
-		//			map[string]any{
-		//				"content": []map[string]any{
-		//					{
-		//						"text": insStr,
-		//						"type": "input_text",
-		//					},
-		//				},
-		//				"role": "user", "type": "message"},
-		//		}
-		//		if len(input) > 0 {
-		//			tmp = append(tmp, input...)
-		//		}
-		//		req["input"] = tmp
-		//	}
-		//}
-	} else {
-		req["instructions"] = "You are a helpful AI assistant."
-	}
-
-	// Insert defaults only if client did not provide them
-	if _, ok := req["tools"]; !ok {
-		req["tools"] = []interface{}{}
-	}
-	if _, ok := req["parallel_tool_calls"]; !ok {
-		req["parallel_tool_calls"] = false
-	}
-
-	// Remove unsupported parameters
-	delete(req, "max_tokens")
-	delete(req, "max_completion_tokens")
-	delete(req, "max_output_tokens")
-	delete(req, "temperature")
-	delete(req, "top_p")
-
-	// ChatGPT Codex rejects empty/invalid item ids in input[].
-	// These ids are optional for request items, so strip malformed values.
-	sanitizeCodexInputIDs(req)
-
-	// max_output_tokens IS supported, so we keep it
-	// Other supported parameters: instructions, input, tools, tool_choice, stream, store, include, etc.
-
-	result, err := json.Marshal(req)
-	if err != nil {
-		return data, isStreaming // Return original if marshaling fails
-	}
-	return result, isStreaming
 }
 
 func sanitizeCodexInputIDs(req map[string]interface{}) {

--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -1,12 +1,14 @@
 package client
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/tidwall/sjson"
 )
 
 const reasoningMarker = "reasoning.encrypted_content"
@@ -45,9 +47,31 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	// Filter out unsupported parameters for ChatGPT backend API
-	// ChatGPT backend API does NOT support: max_tokens, max_completion_tokens, temperature, top_p
-	// It DOES support: max_output_tokens
-	var isStreaming = true
+	// ChatGPT backend API does NOT support: max_tokens, max_completion_tokens, temperature, top_p, max_output_tokens
+
+	var filtered []byte
+	var isStreaming = false
+	if req.Body != nil && req.Method == "POST" {
+		body, err := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+
+		filtered, err = t.filterField(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to filter field: %w", err)
+		}
+
+		// Trim capacity to length to avoid excessive memory usage
+		filtered = append([]byte(nil), filtered...)
+		// Set GetBody to allow retries and redirects
+		req.Body = io.NopCloser(bytes.NewReader(filtered))
+		req.ContentLength = int64(len(filtered))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(filtered)), nil
+		}
+	}
 
 	resp, err := t.RoundTripper.RoundTrip(req)
 	if err != nil {
@@ -67,6 +91,22 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	return resp, nil
+}
+
+func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
+	// Filter the request body to remove unsupported parameters using sjson
+	// This is more efficient than unmarshaling to map and marshaling back
+
+	bodyStr := string(body)
+
+	// Remove unsupported parameters (ignore errors if key doesn't exist)
+	bodyStr, _ = sjson.Delete(bodyStr, "max_tokens")
+	bodyStr, _ = sjson.Delete(bodyStr, "max_completion_tokens")
+	bodyStr, _ = sjson.Delete(bodyStr, "max_output_tokens")
+	bodyStr, _ = sjson.Delete(bodyStr, "temperature")
+	bodyStr, _ = sjson.Delete(bodyStr, "top_p")
+
+	return []byte(bodyStr), nil
 }
 
 func rewriteCodexPath(path string) string {

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -3,8 +3,10 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
@@ -91,6 +93,131 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 	return c.parseImageGenerationStream(ctx, stream)
 }
 
+// ResponsesNewStreaming creates a new streaming Responses API request with Codex-specific defaults applied.
+func (c *CodexClient) ResponsesNewStreaming(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
+	// Apply Codex-specific defaults to the request
+	applyCodexDefaultsToParams(&req)
+
+	// Call the base implementation
+	return c.OpenAIClient.ResponsesNewStreaming(ctx, req)
+}
+
+// applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
+func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
+	// Set default instructions if not provided
+	if !req.Instructions.Valid() {
+		req.Instructions = param.NewOpt(defaultInstructions)
+	}
+	// Set store to false for Codex
+	req.Store = param.NewOpt(false)
+	// Insert defaults only if client did not provide them
+	if len(req.Tools) == 0 {
+		req.Tools = []responses.ToolUnionParam{}
+	}
+	if !req.ParallelToolCalls.Valid() {
+		req.ParallelToolCalls = param.NewOpt(false)
+	}
+
+	// Remove unsupported parameters for Codex
+	// ChatGPT backend API does NOT support: temperature, top_p, max_output_tokens
+	// Set them to invalid/zero state so they won't be included in the request
+	req.Temperature = param.Opt[float64]{}
+	req.TopP = param.Opt[float64]{}
+	req.MaxOutputTokens = param.Opt[int64]{}
+
+	// Merge "reasoning.encrypted_content" into existing include array (preserve client-provided values)
+	includes := req.Include
+	hasMarker := false
+	for _, v := range includes {
+		if string(v) == reasoningMarker {
+			hasMarker = true
+			break
+		}
+	}
+	if !hasMarker {
+		includes = append(includes, responses.ResponseIncludable(reasoningMarker))
+	}
+	req.Include = includes
+
+	// Get the current extra fields (call the method)
+	extraFields := map[string]interface{}{}
+	if len(req.ExtraFields()) > 0 {
+		// Copy existing extra fields
+		for k, v := range req.ExtraFields() {
+			extraFields[k] = v
+		}
+	}
+
+	extraFields["stream"] = true
+
+	// ChatGPT Codex rejects empty/invalid item ids in input[].
+	// These ids are optional for request items, so strip malformed values.
+	sanitizeResponseInputIDs(req)
+
+	// Set the modified extra fields back
+	req.SetExtraFields(extraFields)
+}
+
+// sanitizeResponseInputIDs sanitizes item IDs in ResponseNewParams.Input for Codex.
+// ChatGPT Codex rejects empty/invalid item ids, so we strip malformed values.
+func sanitizeResponseInputIDs(req *responses.ResponseNewParams) {
+	// Check if Input is set and is of type OfInputItemList
+	if req.Input.OfInputItemList == nil {
+		return
+	}
+
+	inputItems := req.Input.OfInputItemList
+	for i := range inputItems {
+		item := &inputItems[i]
+		sanitizeInputItemID(item)
+	}
+
+	req.Input.OfInputItemList = inputItems
+}
+
+// sanitizeInputItemID sanitizes the ID field in a ResponseInputItemUnionParam.
+// For most item types, ID is stored in ExtraFields.
+func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) {
+	// Get the extra fields from the item
+	extraFields := item.ExtraFields()
+	if extraFields == nil {
+		return
+	}
+
+	// Check if there's an ID field
+	if idValue, ok := extraFields["id"].(string); ok {
+		// Trim and validate the ID
+		idValue = strings.TrimSpace(idValue)
+		if idValue == "" || !isValidCodexID(idValue) {
+			// Remove invalid ID
+			delete(extraFields, "id")
+			item.SetExtraFields(extraFields)
+		}
+	}
+}
+
+// isValidCodexID checks if a string is a valid Codex ID.
+// Valid IDs contain only alphanumeric characters, underscores, and hyphens.
+func isValidCodexID(id string) bool {
+	if len(id) == 0 {
+		return false
+	}
+	for _, c := range id {
+		if !isAlnumunderscoreHyphen(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// isAlnumunderscoreHyphen checks if a rune is alphanumeric, underscore, or hyphen.
+func isAlnumunderscoreHyphen(c rune) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_' || c == '-'
+}
+
 // ListModels returns the list of available models.
 // For Codex, this returns an error as ChatGPT OAuth tokens cannot access /models endpoint.
 func (c *CodexClient) ListModels(ctx context.Context) ([]string, error) {
@@ -103,6 +230,7 @@ func (c *CodexClient) ListModels(ctx context.Context) ([]string, error) {
 // buildImageGenerationResponsesRequest transforms ImageGenerateParams into
 // a Responses API request with the image_generation tool.
 func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGenerateParams) responses.ResponseNewParams {
+
 	// Build input item from prompt
 	inputItem := map[string]interface{}{
 		"type": "message",
@@ -159,14 +287,35 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 		Model: req.Model,
 	}
 
-	// Use extra fields to set the custom format
-	params.SetExtraFields(map[string]interface{}{
-		"input":   []interface{}{inputItem},
-		"tools":   []interface{}{tool},
-		"stream":  true,
-		"store":   false,
-		"include": []string{"reasoning.encrypted_content"},
-	})
+	// Build the base request map with Codex-specific defaults
+	reqMap := map[string]interface{}{
+		"input": []interface{}{inputItem},
+		"tools": []interface{}{tool},
+	}
+
+	// Apply Codex-specific defaults and filters
+	ApplyCodexExtra(reqMap)
+
+	// Convert back to the format expected by SetExtraFields
+	extraFields := map[string]interface{}{
+		"input":   reqMap["input"],
+		"tools":   reqMap["tools"],
+		"stream":  reqMap["stream"],
+		"store":   reqMap["store"],
+		"include": reqMap["include"],
+	}
+
+	// Add instructions if it was set
+	if instructions, ok := reqMap["instructions"]; ok {
+		extraFields["instructions"] = instructions
+	}
+
+	// Add parallel_tool_calls if it was set
+	if parallel, ok := reqMap["parallel_tool_calls"]; ok {
+		extraFields["parallel_tool_calls"] = parallel
+	}
+
+	params.SetExtraFields(extraFields)
 
 	return params
 }

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -173,28 +173,50 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 
 // parseImageGenerationStream parses the streaming Responses API response
 // and extracts the generated image data from the output array.
+//
+// The image data comes through two event types:
+// 1. response.image_generation_call.partial_image - streaming partial image chunks
+// 2. response.output_item.done - final status of the image generation call
 func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
 	defer stream.Close()
 
 	var b64JSON string
+	var imageCallID string
 
-	// Collect output items from response.output_item.done events
+	// Collect image data from stream events
 	for stream.Next() {
 		event := stream.Current()
 
-		fmt.Printf("[Codex] Receiving event: %v\n", event)
+		switch event.Type {
+		case "response.image_generation_call.partial_image":
+			// Partial image chunks during generation
+			partialEvent := event.AsResponseImageGenerationCallPartialImage()
+			if partialEvent.PartialImageB64 != "" {
+				b64JSON += partialEvent.PartialImageB64
+				imageCallID = partialEvent.ItemID
+				logrus.Debugf("[Codex] Received partial image chunk, item_id: %s, total_size: %d",
+					partialEvent.ItemID, len(b64JSON))
+			}
 
-		// Look for response.output_item.done events
-		if event.Type == "response.output_item.done" {
+		case "response.output_item.done":
+			// Final status of output items
 			doneEvent := event.AsResponseOutputItemDone()
-
-			// Extract image data from output item
 			item := doneEvent.Item
+
 			if item.Type == "image_generation_call" {
 				imageCall := item.AsImageGenerationCall()
-				if imageCall.Status == "completed" && imageCall.Result != "" {
+				// Check for image result in the done event
+				// The status can be "generating", "completed", or other values
+				// If we haven't received partial images, use the Result field
+				if b64JSON == "" && imageCall.Result != "" {
 					b64JSON = imageCall.Result
-					logrus.Debugf("[Codex] Received completed image, id: %s", imageCall.ID)
+					imageCallID = imageCall.ID
+					logrus.Debugf("[Codex] Received image result in done event, id: %s, status: %s",
+						imageCall.ID, imageCall.Status)
+				}
+				// Update imageCallID even if we already have data from partial events
+				if imageCallID == "" {
+					imageCallID = imageCall.ID
 				}
 			}
 		}
@@ -205,8 +227,10 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 	}
 
 	if b64JSON == "" {
-		return nil, fmt.Errorf("no image data in response")
+		return nil, fmt.Errorf("no image data in response (image_call_id: %s)", imageCallID)
 	}
+
+	logrus.Infof("[Codex] Successfully extracted image data, id: %s, size: %d bytes", imageCallID, len(b64JSON))
 
 	// Build standard ImagesResponse from extracted data
 	return &openai.ImagesResponse{

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -133,11 +133,12 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 
 	// Map response_format to output_format
 	// OpenAI: "url", "b64_json" -> Codex: "url", "b64_json"
+	// Codex: supported values are: 'png', 'webp', and 'jpeg'
 	if req.ResponseFormat != "" {
 		tool["output_format"] = string(req.ResponseFormat)
 	} else {
 		// Default to b64_json for Codex
-		tool["output_format"] = "b64_json"
+		tool["output_format"] = "png"
 	}
 
 	// Log warning for unsupported N parameter
@@ -180,6 +181,8 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 	// Collect output items from response.output_item.done events
 	for stream.Next() {
 		event := stream.Current()
+
+		fmt.Printf("[Codex] Receiving event: %v\n", event)
 
 		// Look for response.output_item.done events
 		if event.Type == "response.output_item.done" {

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -87,7 +87,7 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 	responsesReq := c.buildImageGenerationResponsesRequest(req)
 
 	// Call streaming Responses API
-	stream := c.ResponsesNewStreaming(ctx, responsesReq)
+	stream := c.OpenAIClient.ResponsesNewStreaming(ctx, responsesReq)
 
 	// Parse streaming response
 	return c.parseImageGenerationStream(ctx, stream)
@@ -230,44 +230,63 @@ func (c *CodexClient) ListModels(ctx context.Context) ([]string, error) {
 // buildImageGenerationResponsesRequest transforms ImageGenerateParams into
 // a Responses API request with the image_generation tool.
 func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGenerateParams) responses.ResponseNewParams {
+	// Build the Responses API request with Codex-specific defaults
+	params := responses.ResponseNewParams{
+		Model: req.Model,
+	}
 
-	// Build input item from prompt
-	inputItem := map[string]interface{}{
-		"type": "message",
-		"role": "user",
-		"content": []map[string]string{
-			{"type": "input_text", "text": string(req.Prompt)},
+	// Set default values directly on the struct
+	params.Store = param.NewOpt(false)
+	params.Instructions = param.NewOpt(defaultInstructions)
+	params.ParallelToolCalls = param.NewOpt(false)
+	params.Include = []responses.ResponseIncludable{responses.ResponseIncludable(reasoningMarker)}
+
+	// Build input content
+	contentItem := responses.ResponseInputContentParamOfInputText(string(req.Prompt))
+	contentItems := responses.ResponseInputMessageContentListParam{contentItem}
+
+	// Build input message
+	inputItem := responses.ResponseInputItemUnionParam{
+		OfMessage: &responses.EasyInputMessageParam{
+			Type:    responses.EasyInputMessageTypeMessage,
+			Role:    responses.EasyInputMessageRoleUser,
+			Content: responses.EasyInputMessageContentUnionParam{OfInputItemContentList: contentItems},
 		},
 	}
+	inputItems := responses.ResponseInputParam{inputItem}
+	params.Input = responses.ResponseNewParamsInputUnion{OfInputItemList: inputItems}
 
-	// Build image_generation tool with base parameters
-	tool := map[string]interface{}{
-		"type": "image_generation",
-		"size": string(req.Size),
-	}
-
-	// Map quality parameter (if provided)
-	// OpenAI: "standard", "hd" -> Codex: "medium", "high"
+	// Determine quality
+	quality := "auto"
 	if req.Quality != "" {
-		quality := string(req.Quality)
-		if quality == "standard" {
-			tool["quality"] = "medium"
-		} else if quality == "hd" {
-			tool["quality"] = "high"
+		qualityStr := string(req.Quality)
+		if qualityStr == "standard" {
+			quality = "medium"
+		} else if qualityStr == "hd" {
+			quality = "high"
 		} else {
-			tool["quality"] = quality
+			quality = qualityStr
 		}
 	}
 
-	// Map response_format to output_format
-	// OpenAI: "url", "b64_json" -> Codex: "url", "b64_json"
-	// Codex: supported values are: 'png', 'webp', and 'jpeg'
+	// Determine output format
+	outputFormat := "png"
 	if req.ResponseFormat != "" {
-		tool["output_format"] = string(req.ResponseFormat)
-	} else {
-		// Default to b64_json for Codex
-		tool["output_format"] = "png"
+		outputFormat = string(req.ResponseFormat)
 	}
+
+	// Build image_generation tool
+	toolParam := &responses.ToolImageGenerationParam{
+		Type:         "image_generation",
+		Size:         string(req.Size),
+		Quality:      quality,
+		OutputFormat: outputFormat,
+		//Action:       "auto",
+		//Background:   "auto",
+		//Moderation:   "auto",
+	}
+
+	params.Tools = []responses.ToolUnionParam{{OfImageGeneration: toolParam}}
 
 	// Log warning for unsupported N parameter
 	if req.N.Valid() {
@@ -282,39 +301,10 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 		logrus.Warnf("[Codex] Style parameter not supported for image generation")
 	}
 
-	// Build the Responses API request
-	params := responses.ResponseNewParams{
-		Model: req.Model,
-	}
-
-	// Build the base request map with Codex-specific defaults
-	reqMap := map[string]interface{}{
-		"input": []interface{}{inputItem},
-		"tools": []interface{}{tool},
-	}
-
-	// Apply Codex-specific defaults and filters
-	ApplyCodexExtra(reqMap)
-
-	// Convert back to the format expected by SetExtraFields
+	// Set stream=true via ExtraFields
 	extraFields := map[string]interface{}{
-		"input":   reqMap["input"],
-		"tools":   reqMap["tools"],
-		"stream":  reqMap["stream"],
-		"store":   reqMap["store"],
-		"include": reqMap["include"],
+		"stream": true,
 	}
-
-	// Add instructions if it was set
-	if instructions, ok := reqMap["instructions"]; ok {
-		extraFields["instructions"] = instructions
-	}
-
-	// Add parallel_tool_calls if it was set
-	if parallel, ok := reqMap["parallel_tool_calls"]; ok {
-		extraFields["parallel_tool_calls"] = parallel
-	}
-
 	params.SetExtraFields(extraFields)
 
 	return params

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -1,0 +1,226 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// CodexClient wraps OpenAIClient with Codex-specific behaviors.
+// It embeds OpenAIClient to inherit standard OpenAI API functionality,
+// while overriding methods that require special handling for ChatGPT backend API.
+//
+// Codex (ChatGPT OAuth) limitations:
+// - Does NOT support standard Chat Completions API
+// - Does NOT support /models endpoint
+// - Does NOT support /images/generations endpoint
+// - ONLY supports Responses API with special parameters
+type CodexClient struct {
+	*OpenAIClient
+}
+
+// NewCodexClient creates a new Codex client wrapper.
+// The base OpenAIClient is configured with codexRoundTripper for path/header transformation.
+func NewCodexClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*CodexClient, error) {
+	base, err := NewOpenAIClient(provider, model, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base OpenAI client: %w", err)
+	}
+
+	// Set the override function for chat completions (reject with error)
+	base.chatCompletionsHandler = func(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+		return nil, &ErrCodexNotSupported{
+			Operation: "Chat Completions",
+			Reason:    "ChatGPT backend API does not support standard /v1/chat/completions endpoint. Use Responses API instead.",
+		}
+	}
+
+	// Set the override function for streaming chat completions (reject with error)
+	base.chatCompletionsStreamingHandler = func(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
+		logrus.Errorf("[Codex] Chat Completions Streaming not supported, use Responses API instead")
+		return nil
+	}
+
+	// Set the override function for image generation (use Responses API)
+	base.imagesGenerateHandler = func(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
+		return (&CodexClient{OpenAIClient: base}).ImagesGenerate(ctx, req)
+	}
+
+	return &CodexClient{
+		OpenAIClient: base,
+	}, nil
+}
+
+// ChatCompletionsNew creates a new chat completion request.
+// For Codex, this returns an error as ChatGPT backend API does not support standard Chat Completions.
+// Use Responses API instead.
+func (c *CodexClient) ChatCompletionsNew(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+	return nil, &ErrCodexNotSupported{
+		Operation: "Chat Completions",
+		Reason:    "ChatGPT backend API does not support standard /v1/chat/completions endpoint. Use Responses API instead.",
+	}
+}
+
+// ChatCompletionsNewStreaming creates a new streaming chat completion request.
+// For Codex, this returns nil as ChatGPT backend API does not support standard Chat Completions.
+// Use Responses API instead.
+func (c *CodexClient) ChatCompletionsNewStreaming(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
+	logrus.Errorf("[Codex] Chat Completions Streaming not supported, use Responses API instead")
+	return nil
+}
+
+// ImagesGenerate creates a new image generation request.
+// For Codex, this transforms the request to use the Responses API with the image_generation tool,
+// as ChatGPT backend API does not support the standard /images/generations endpoint.
+func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
+	logrus.Debugf("[Codex] Using Responses API for image generation, model: %s", req.Model)
+
+	// Build Responses API request
+	responsesReq := c.buildImageGenerationResponsesRequest(req)
+
+	// Call streaming Responses API
+	stream := c.ResponsesNewStreaming(ctx, responsesReq)
+
+	// Parse streaming response
+	return c.parseImageGenerationStream(ctx, stream)
+}
+
+// ListModels returns the list of available models.
+// For Codex, this returns an error as ChatGPT OAuth tokens cannot access /models endpoint.
+func (c *CodexClient) ListModels(ctx context.Context) ([]string, error) {
+	return nil, &ErrModelsEndpointNotSupported{
+		Provider: c.provider.Name,
+		Reason:   "ChatGPT OAuth token cannot access /models endpoint",
+	}
+}
+
+// buildImageGenerationResponsesRequest transforms ImageGenerateParams into
+// a Responses API request with the image_generation tool.
+func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGenerateParams) responses.ResponseNewParams {
+	// Build input item from prompt
+	inputItem := map[string]interface{}{
+		"type": "message",
+		"role": "user",
+		"content": []map[string]string{
+			{"type": "input_text", "text": string(req.Prompt)},
+		},
+	}
+
+	// Build image_generation tool with base parameters
+	tool := map[string]interface{}{
+		"type": "image_generation",
+		"size": string(req.Size),
+	}
+
+	// Map quality parameter (if provided)
+	// OpenAI: "standard", "hd" -> Codex: "medium", "high"
+	if req.Quality != "" {
+		quality := string(req.Quality)
+		if quality == "standard" {
+			tool["quality"] = "medium"
+		} else if quality == "hd" {
+			tool["quality"] = "high"
+		} else {
+			tool["quality"] = quality
+		}
+	}
+
+	// Map response_format to output_format
+	// OpenAI: "url", "b64_json" -> Codex: "url", "b64_json"
+	if req.ResponseFormat != "" {
+		tool["output_format"] = string(req.ResponseFormat)
+	} else {
+		// Default to b64_json for Codex
+		tool["output_format"] = "b64_json"
+	}
+
+	// Log warning for unsupported N parameter
+	if req.N.Valid() {
+		n := req.N.Value
+		if n > 1 {
+			logrus.Warnf("[Codex] Multiple images (N=%d) not supported, using N=1", n)
+		}
+	}
+
+	// Log warning for unsupported style parameter
+	if req.Style != "" {
+		logrus.Warnf("[Codex] Style parameter not supported for image generation")
+	}
+
+	// Build the Responses API request
+	params := responses.ResponseNewParams{
+		Model: req.Model,
+	}
+
+	// Use extra fields to set the custom format
+	params.SetExtraFields(map[string]interface{}{
+		"input":   []interface{}{inputItem},
+		"tools":   []interface{}{tool},
+		"stream":  true,
+		"store":   false,
+		"include": []string{"reasoning.encrypted_content"},
+	})
+
+	return params
+}
+
+// parseImageGenerationStream parses the streaming Responses API response
+// and extracts the generated image data from the output array.
+func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
+	defer stream.Close()
+
+	var b64JSON string
+
+	// Collect output items from response.output_item.done events
+	for stream.Next() {
+		event := stream.Current()
+
+		// Look for response.output_item.done events
+		if event.Type == "response.output_item.done" {
+			doneEvent := event.AsResponseOutputItemDone()
+
+			// Extract image data from output item
+			item := doneEvent.Item
+			if item.Type == "image_generation_call" {
+				imageCall := item.AsImageGenerationCall()
+				if imageCall.Status == "completed" && imageCall.Result != "" {
+					b64JSON = imageCall.Result
+					logrus.Debugf("[Codex] Received completed image, id: %s", imageCall.ID)
+				}
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, fmt.Errorf("stream error: %w", err)
+	}
+
+	if b64JSON == "" {
+		return nil, fmt.Errorf("no image data in response")
+	}
+
+	// Build standard ImagesResponse from extracted data
+	return &openai.ImagesResponse{
+		Data: []openai.Image{
+			{
+				B64JSON: b64JSON,
+			},
+		},
+	}, nil
+}
+
+// IsCodexProvider returns true for CodexClient instances.
+func (c *CodexClient) IsCodexProvider() bool {
+	return true
+}
+
+// GetProvider returns the provider for this client.
+func (c *CodexClient) GetProvider() *typ.Provider {
+	return c.provider
+}

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -35,35 +36,6 @@ func NewCodexClient(provider *typ.Provider, model string, sessionID typ.SessionI
 		return nil, fmt.Errorf("failed to create base OpenAI client: %w", err)
 	}
 
-	// Set the override function for chat completions (reject with error)
-	base.chatCompletionsHandler = func(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
-		return nil, &ErrCodexNotSupported{
-			Operation: "Chat Completions",
-			Reason:    "ChatGPT backend API does not support standard /v1/chat/completions endpoint. Use Responses API instead.",
-		}
-	}
-
-	// Set the override function for streaming chat completions (reject with error)
-	base.chatCompletionsStreamingHandler = func(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
-		logrus.Errorf("[Codex] Chat Completions Streaming not supported, use Responses API instead")
-		return nil
-	}
-
-	base.responsesNewStreamingHandler = func(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
-		c := &CodexClient{OpenAIClient: base}
-
-		// Apply Codex-specific defaults to the request
-		applyCodexDefaultsToParams(&req)
-
-		// Call the base implementation
-		return c.client.Responses.NewStreaming(ctx, req)
-	}
-
-	// Set the override function for image generation (use Responses API)
-	base.imagesGenerateHandler = func(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
-		return (&CodexClient{OpenAIClient: base}).ImagesGenerate(ctx, req)
-	}
-
 	return &CodexClient{
 		OpenAIClient: base,
 	}, nil
@@ -85,6 +57,14 @@ func (c *CodexClient) ChatCompletionsNew(ctx context.Context, req openai.ChatCom
 func (c *CodexClient) ChatCompletionsNewStreaming(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
 	logrus.Errorf("[Codex] Chat Completions Streaming not supported, use Responses API instead")
 	return nil
+}
+
+// ResponsesNewStreaming creates a new streaming Responses API request with Codex-specific defaults.
+func (c *CodexClient) ResponsesNewStreaming(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
+	// Apply Codex-specific defaults to the request
+	applyCodexDefaultsToParams(&req)
+	// Call the base implementation
+	return c.OpenAIClient.ResponsesNewStreaming(ctx, req)
 }
 
 // ImagesGenerate creates a new image generation request.
@@ -385,12 +365,45 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 	}, nil
 }
 
-// IsCodexProvider returns true for CodexClient instances.
-func (c *CodexClient) IsCodexProvider() bool {
-	return true
+// SetRecordSink sets the record sink for the client.
+// For CodexClient, we delegate to the embedded OpenAIClient.
+func (c *CodexClient) SetRecordSink(sink *obs.Sink) {
+	c.OpenAIClient.SetRecordSink(sink)
 }
 
-// GetProvider returns the provider for this client.
-func (c *CodexClient) GetProvider() *typ.Provider {
-	return c.provider
+// Client returns the underlying OpenAI SDK client.
+// For CodexClient, we delegate to the embedded OpenAIClient.
+func (c *CodexClient) Client() *openai.Client {
+	return c.OpenAIClient.Client()
+}
+
+// ProbeChatEndpoint tests the chat endpoint.
+// For Codex, this delegates to the embedded OpenAIClient's probeResponsesEndpoint.
+func (c *CodexClient) ProbeChatEndpoint(ctx context.Context, model string) ProbeResult {
+	logrus.Errorf("[Codex] Chat Completions Streaming not supported, use Responses API instead")
+	return ProbeResult{
+		Success:          false,
+		Message:          "",
+		Content:          "",
+		LatencyMs:        0,
+		ModelsCount:      0,
+		PromptTokens:     0,
+		CompletionTokens: 0,
+		TotalTokens:      0,
+		ErrorMessage:     "Codex does not support /chat endpoint",
+	}
+}
+
+// ProbeModelsEndpoint tests the models endpoint.
+// For Codex, this returns an error as the endpoint is not supported.
+func (c *CodexClient) ProbeModelsEndpoint(ctx context.Context) ProbeResult {
+	return ProbeResult{
+		Success:      false,
+		ErrorMessage: "Codex does not support /models endpoint",
+	}
+}
+
+// ProbeOptionsEndpoint tests basic connectivity with an OPTIONS request.
+func (c *CodexClient) ProbeOptionsEndpoint(ctx context.Context) ProbeResult {
+	return c.OpenAIClient.ProbeOptionsEndpoint(ctx)
 }

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -49,6 +49,16 @@ func NewCodexClient(provider *typ.Provider, model string, sessionID typ.SessionI
 		return nil
 	}
 
+	base.responsesNewStreamingHandler = func(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
+		c := &CodexClient{OpenAIClient: base}
+
+		// Apply Codex-specific defaults to the request
+		applyCodexDefaultsToParams(&req)
+
+		// Call the base implementation
+		return c.client.Responses.NewStreaming(ctx, req)
+	}
+
 	// Set the override function for image generation (use Responses API)
 	base.imagesGenerateHandler = func(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
 		return (&CodexClient{OpenAIClient: base}).ImagesGenerate(ctx, req)
@@ -93,15 +103,6 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 	return c.parseImageGenerationStream(ctx, stream)
 }
 
-// ResponsesNewStreaming creates a new streaming Responses API request with Codex-specific defaults applied.
-func (c *CodexClient) ResponsesNewStreaming(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
-	// Apply Codex-specific defaults to the request
-	applyCodexDefaultsToParams(&req)
-
-	// Call the base implementation
-	return c.OpenAIClient.ResponsesNewStreaming(ctx, req)
-}
-
 // applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
 func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
 	// Set default instructions if not provided
@@ -121,9 +122,9 @@ func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
 	// Remove unsupported parameters for Codex
 	// ChatGPT backend API does NOT support: temperature, top_p, max_output_tokens
 	// Set them to invalid/zero state so they won't be included in the request
-	req.Temperature = param.Opt[float64]{}
-	req.TopP = param.Opt[float64]{}
-	req.MaxOutputTokens = param.Opt[int64]{}
+	req.Temperature = param.Null[float64]()
+	req.TopP = param.Null[float64]()
+	req.MaxOutputTokens = param.Null[int64]()
 
 	// Merge "reasoning.encrypted_content" into existing include array (preserve client-provided values)
 	includes := req.Include
@@ -144,6 +145,9 @@ func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
 	if len(req.ExtraFields()) > 0 {
 		// Copy existing extra fields
 		for k, v := range req.ExtraFields() {
+			if k == "max_output_tokens" {
+				continue
+			}
 			extraFields[k] = v
 		}
 	}

--- a/internal/client/model_lister.go
+++ b/internal/client/model_lister.go
@@ -15,6 +15,16 @@ func (e *ErrModelsEndpointNotSupported) Error() string {
 	return fmt.Sprintf("models endpoint not supported for provider %s: %s", e.Provider, e.Reason)
 }
 
+// ErrCodexNotSupported is returned when attempting to use an OpenAI API that is not supported by Codex
+type ErrCodexNotSupported struct {
+	Operation string
+	Reason    string
+}
+
+func (e *ErrCodexNotSupported) Error() string {
+	return fmt.Sprintf("Codex does not support %s: %s", e.Operation, e.Reason)
+}
+
 // IsModelsEndpointNotSupported checks if an error is ErrModelsEndpointNotSupported
 func IsModelsEndpointNotSupported(err error) bool {
 	_, ok := err.(*ErrModelsEndpointNotSupported)

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -31,6 +31,11 @@ type OpenAIClient struct {
 	debugMode  bool
 	httpClient *http.Client
 	recordSink *obs.Sink
+
+	// Override functions for Codex-specific behavior
+	imagesGenerateHandler           func(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error)
+	chatCompletionsHandler          func(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
+	chatCompletionsStreamingHandler func(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk]
 }
 
 // NewOpenAIClient creates a new OpenAI client wrapper
@@ -111,11 +116,21 @@ func (c *OpenAIClient) HttpClient() *http.Client {
 
 // ChatCompletionsNew creates a new chat completion request
 func (c *OpenAIClient) ChatCompletionsNew(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+	// Use override function if set (for Codex providers)
+	if c.chatCompletionsHandler != nil {
+		return c.chatCompletionsHandler(ctx, req)
+	}
+	// Use standard OpenAI SDK
 	return c.client.Chat.Completions.New(ctx, req)
 }
 
 // ChatCompletionsNewStreaming creates a new streaming chat completion request
 func (c *OpenAIClient) ChatCompletionsNewStreaming(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
+	// Use override function if set (for Codex providers)
+	if c.chatCompletionsStreamingHandler != nil {
+		return c.chatCompletionsStreamingHandler(ctx, req)
+	}
+	// Use standard OpenAI SDK
 	return c.client.Chat.Completions.NewStreaming(ctx, req)
 }
 
@@ -125,15 +140,12 @@ func (c *OpenAIClient) EmbeddingsNew(ctx context.Context, req openai.EmbeddingNe
 }
 
 // ImagesGenerate creates a new image generation request
-// For Codex OAuth providers, this transforms the request to use the Responses API
-// with the image_generation tool, as Codex does not support /images/generations endpoint.
 func (c *OpenAIClient) ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
-	// Check if this is a Codex OAuth provider
-	// Codex requires using the Responses API with image_generation tool
-	if c.isCodexProvider() {
-		return c.imagesGenerateViaCodex(ctx, req)
+	// Use override function if set (for Codex providers)
+	if c.imagesGenerateHandler != nil {
+		return c.imagesGenerateHandler(ctx, req)
 	}
-	// Use standard path for other providers
+	// Use standard OpenAI SDK
 	return c.client.Images.Generate(ctx, req)
 }
 
@@ -623,136 +635,4 @@ func (c *OpenAIClient) isCodexProvider() bool {
 		return false
 	}
 	return c.provider.OAuthDetail.GetIssuer() == ai.IssuerCodex
-}
-
-// imagesGenerateViaCodex handles image generation for Codex OAuth providers
-// by transforming the request to use the Responses API with image_generation tool
-func (c *OpenAIClient) imagesGenerateViaCodex(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
-	logrus.Debugf("[Codex] Using Responses API for image generation, model: %s", req.Model)
-
-	// Build Responses API request
-	responsesReq := c.buildImageGenerationResponsesRequest(req)
-
-	// Call streaming Responses API
-	stream := c.ResponsesNewStreaming(ctx, responsesReq)
-
-	// Parse streaming response
-	return c.parseImageGenerationStream(ctx, stream)
-}
-
-// buildImageGenerationResponsesRequest transforms ImageGenerateParams into
-// a Responses API request with the image_generation tool
-func (c *OpenAIClient) buildImageGenerationResponsesRequest(req openai.ImageGenerateParams) responses.ResponseNewParams {
-	// Build input item from prompt
-	inputItem := map[string]interface{}{
-		"type": "message",
-		"role": "user",
-		"content": []map[string]string{
-			{"type": "input_text", "text": string(req.Prompt)},
-		},
-	}
-
-	// Build image_generation tool with base parameters
-	tool := map[string]interface{}{
-		"type": "image_generation",
-		"size": string(req.Size),
-	}
-
-	// Map quality parameter (if provided)
-	// OpenAI: "standard", "hd" -> Codex: "medium", "high"
-	if req.Quality != "" {
-		quality := string(req.Quality)
-		if quality == "standard" {
-			tool["quality"] = "medium"
-		} else if quality == "hd" {
-			tool["quality"] = "high"
-		} else {
-			tool["quality"] = quality
-		}
-	}
-
-	// Map response_format to output_format
-	// OpenAI: "url", "b64_json" -> Codex: "url", "b64_json"
-	if req.ResponseFormat != "" {
-		tool["output_format"] = string(req.ResponseFormat)
-	} else {
-		// Default to b64_json for Codex
-		tool["output_format"] = "b64_json"
-	}
-
-	// Log warning for unsupported N parameter
-	if req.N.Valid() {
-		n := req.N.Value
-		if n > 1 {
-			logrus.Warnf("[Codex] Multiple images (N=%d) not supported, using N=1", n)
-		}
-	}
-
-	// Log warning for unsupported style parameter
-	if req.Style != "" {
-		logrus.Warnf("[Codex] Style parameter not supported for image generation")
-	}
-
-	// Build the Responses API request
-	params := responses.ResponseNewParams{
-		Model: req.Model,
-	}
-
-	// Use extra fields to set the custom format
-	params.SetExtraFields(map[string]interface{}{
-		"input":   []interface{}{inputItem},
-		"tools":   []interface{}{tool},
-		"stream":  true,
-		"store":   false,
-		"include": []string{"reasoning.encrypted_content"},
-	})
-
-	return params
-}
-
-// parseImageGenerationStream parses the streaming Responses API response
-// and extracts the generated image data from the output array
-func (c *OpenAIClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
-	defer stream.Close()
-
-	var b64JSON string
-
-	// Collect output items from response.output_item.done events
-	// The final image data will be in the image_generation_call output
-	for stream.Next() {
-		event := stream.Current()
-
-		// Look for response.output_item.done events
-		if event.Type == "response.output_item.done" {
-			doneEvent := event.AsResponseOutputItemDone()
-
-			// Extract image data from output item
-			item := doneEvent.Item
-			if item.Type == "image_generation_call" {
-				imageCall := item.AsImageGenerationCall()
-				if imageCall.Status == "completed" && imageCall.Result != "" {
-					b64JSON = imageCall.Result
-					logrus.Debugf("[Codex] Received completed image, id: %s", imageCall.ID)
-				}
-			}
-		}
-	}
-
-	if err := stream.Err(); err != nil {
-		return nil, fmt.Errorf("stream error: %w", err)
-	}
-
-	if b64JSON == "" {
-		return nil, fmt.Errorf("no image data in response")
-	}
-
-	// Build standard ImagesResponse from extracted data
-	// Note: Token usage is not available in stream events for image generation
-	return &openai.ImagesResponse{
-		Data: []openai.Image{
-			{
-				B64JSON: b64JSON,
-			},
-		},
-	}, nil
 }

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -24,6 +24,33 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// OpenAIClientInterface defines the contract for OpenAI-compatible clients.
+// Both OpenAIClient and CodexClient implement this interface.
+type OpenAIClientInterface interface {
+	// Core API methods
+	ChatCompletionsNew(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
+	ChatCompletionsNewStreaming(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk]
+	ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error)
+	ResponsesNew(ctx context.Context, req responses.ResponseNewParams) (*responses.Response, error)
+	ResponsesNewStreaming(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion]
+	EmbeddingsNew(ctx context.Context, req openai.EmbeddingNewParams) (*openai.CreateEmbeddingResponse, error)
+
+	// Utility methods
+	ListModels(ctx context.Context) ([]string, error)
+	Close() error
+	GetProvider() *typ.Provider
+	APIStyle() protocol.APIStyle
+	SetRecordSink(sink *obs.Sink)
+
+	// Prober interface methods
+	ProbeChatEndpoint(ctx context.Context, model string) ProbeResult
+	ProbeModelsEndpoint(ctx context.Context) ProbeResult
+	ProbeOptionsEndpoint(ctx context.Context) ProbeResult
+
+	// Client returns the underlying OpenAI SDK client (for advanced usage)
+	Client() *openai.Client
+}
+
 // OpenAIClient wraps the OpenAI SDK client
 type OpenAIClient struct {
 	client     openai.Client
@@ -31,12 +58,6 @@ type OpenAIClient struct {
 	debugMode  bool
 	httpClient *http.Client
 	recordSink *obs.Sink
-
-	// Override functions for Codex-specific behavior
-	imagesGenerateHandler           func(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error)
-	chatCompletionsHandler          func(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
-	chatCompletionsStreamingHandler func(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk]
-	responsesNewStreamingHandler    func(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion]
 }
 
 // NewOpenAIClient creates a new OpenAI client wrapper
@@ -117,21 +138,11 @@ func (c *OpenAIClient) HttpClient() *http.Client {
 
 // ChatCompletionsNew creates a new chat completion request
 func (c *OpenAIClient) ChatCompletionsNew(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
-	// Use override function if set (for Codex providers)
-	if c.chatCompletionsHandler != nil {
-		return c.chatCompletionsHandler(ctx, req)
-	}
-	// Use standard OpenAI SDK
 	return c.client.Chat.Completions.New(ctx, req)
 }
 
 // ChatCompletionsNewStreaming creates a new streaming chat completion request
 func (c *OpenAIClient) ChatCompletionsNewStreaming(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
-	// Use override function if set (for Codex providers)
-	if c.chatCompletionsStreamingHandler != nil {
-		return c.chatCompletionsStreamingHandler(ctx, req)
-	}
-	// Use standard OpenAI SDK
 	return c.client.Chat.Completions.NewStreaming(ctx, req)
 }
 
@@ -142,11 +153,6 @@ func (c *OpenAIClient) EmbeddingsNew(ctx context.Context, req openai.EmbeddingNe
 
 // ImagesGenerate creates a new image generation request
 func (c *OpenAIClient) ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
-	// Use override function if set (for Codex providers)
-	if c.imagesGenerateHandler != nil {
-		return c.imagesGenerateHandler(ctx, req)
-	}
-	// Use standard OpenAI SDK
 	return c.client.Images.Generate(ctx, req)
 }
 
@@ -157,11 +163,6 @@ func (c *OpenAIClient) ResponsesNew(ctx context.Context, req responses.ResponseN
 
 // ResponsesNewStreaming creates a new streaming Responses API request
 func (c *OpenAIClient) ResponsesNewStreaming(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
-	// Use override function if set (for Codex providers)
-	if c.responsesNewStreamingHandler != nil {
-		return c.responsesNewStreamingHandler(ctx, req)
-	}
-	// Use standard OpenAI SDK
 	return c.client.Responses.NewStreaming(ctx, req)
 }
 

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -125,7 +125,15 @@ func (c *OpenAIClient) EmbeddingsNew(ctx context.Context, req openai.EmbeddingNe
 }
 
 // ImagesGenerate creates a new image generation request
+// For Codex OAuth providers, this transforms the request to use the Responses API
+// with the image_generation tool, as Codex does not support /images/generations endpoint.
 func (c *OpenAIClient) ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
+	// Check if this is a Codex OAuth provider
+	// Codex requires using the Responses API with image_generation tool
+	if c.isCodexProvider() {
+		return c.imagesGenerateViaCodex(ctx, req)
+	}
+	// Use standard path for other providers
 	return c.client.Images.Generate(ctx, req)
 }
 
@@ -603,4 +611,148 @@ func (c *OpenAIClient) probeResponsesEndpoint(ctx context.Context, model string)
 		CompletionTokens: tokenUsage.CompletionTokens,
 		TotalTokens:      tokenUsage.TotalTokens,
 	}
+}
+
+// isCodexProvider checks if the current provider is a Codex OAuth provider
+// Codex OAuth providers require special handling for image generation
+func (c *OpenAIClient) isCodexProvider() bool {
+	if c.provider.AuthType != typ.AuthTypeOAuth {
+		return false
+	}
+	if c.provider.OAuthDetail == nil {
+		return false
+	}
+	return c.provider.OAuthDetail.GetIssuer() == ai.IssuerCodex
+}
+
+// imagesGenerateViaCodex handles image generation for Codex OAuth providers
+// by transforming the request to use the Responses API with image_generation tool
+func (c *OpenAIClient) imagesGenerateViaCodex(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
+	logrus.Debugf("[Codex] Using Responses API for image generation, model: %s", req.Model)
+
+	// Build Responses API request
+	responsesReq := c.buildImageGenerationResponsesRequest(req)
+
+	// Call streaming Responses API
+	stream := c.ResponsesNewStreaming(ctx, responsesReq)
+
+	// Parse streaming response
+	return c.parseImageGenerationStream(ctx, stream)
+}
+
+// buildImageGenerationResponsesRequest transforms ImageGenerateParams into
+// a Responses API request with the image_generation tool
+func (c *OpenAIClient) buildImageGenerationResponsesRequest(req openai.ImageGenerateParams) responses.ResponseNewParams {
+	// Build input item from prompt
+	inputItem := map[string]interface{}{
+		"type": "message",
+		"role": "user",
+		"content": []map[string]string{
+			{"type": "input_text", "text": string(req.Prompt)},
+		},
+	}
+
+	// Build image_generation tool with base parameters
+	tool := map[string]interface{}{
+		"type": "image_generation",
+		"size": string(req.Size),
+	}
+
+	// Map quality parameter (if provided)
+	// OpenAI: "standard", "hd" -> Codex: "medium", "high"
+	if req.Quality != "" {
+		quality := string(req.Quality)
+		if quality == "standard" {
+			tool["quality"] = "medium"
+		} else if quality == "hd" {
+			tool["quality"] = "high"
+		} else {
+			tool["quality"] = quality
+		}
+	}
+
+	// Map response_format to output_format
+	// OpenAI: "url", "b64_json" -> Codex: "url", "b64_json"
+	if req.ResponseFormat != "" {
+		tool["output_format"] = string(req.ResponseFormat)
+	} else {
+		// Default to b64_json for Codex
+		tool["output_format"] = "b64_json"
+	}
+
+	// Log warning for unsupported N parameter
+	if req.N.Valid() {
+		n := req.N.Value
+		if n > 1 {
+			logrus.Warnf("[Codex] Multiple images (N=%d) not supported, using N=1", n)
+		}
+	}
+
+	// Log warning for unsupported style parameter
+	if req.Style != "" {
+		logrus.Warnf("[Codex] Style parameter not supported for image generation")
+	}
+
+	// Build the Responses API request
+	params := responses.ResponseNewParams{
+		Model: req.Model,
+	}
+
+	// Use extra fields to set the custom format
+	params.SetExtraFields(map[string]interface{}{
+		"input":   []interface{}{inputItem},
+		"tools":   []interface{}{tool},
+		"stream":  true,
+		"store":   false,
+		"include": []string{"reasoning.encrypted_content"},
+	})
+
+	return params
+}
+
+// parseImageGenerationStream parses the streaming Responses API response
+// and extracts the generated image data from the output array
+func (c *OpenAIClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
+	defer stream.Close()
+
+	var b64JSON string
+
+	// Collect output items from response.output_item.done events
+	// The final image data will be in the image_generation_call output
+	for stream.Next() {
+		event := stream.Current()
+
+		// Look for response.output_item.done events
+		if event.Type == "response.output_item.done" {
+			doneEvent := event.AsResponseOutputItemDone()
+
+			// Extract image data from output item
+			item := doneEvent.Item
+			if item.Type == "image_generation_call" {
+				imageCall := item.AsImageGenerationCall()
+				if imageCall.Status == "completed" && imageCall.Result != "" {
+					b64JSON = imageCall.Result
+					logrus.Debugf("[Codex] Received completed image, id: %s", imageCall.ID)
+				}
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, fmt.Errorf("stream error: %w", err)
+	}
+
+	if b64JSON == "" {
+		return nil, fmt.Errorf("no image data in response")
+	}
+
+	// Build standard ImagesResponse from extracted data
+	// Note: Token usage is not available in stream events for image generation
+	return &openai.ImagesResponse{
+		Data: []openai.Image{
+			{
+				B64JSON: b64JSON,
+			},
+		},
+	}, nil
 }

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -36,6 +36,7 @@ type OpenAIClient struct {
 	imagesGenerateHandler           func(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error)
 	chatCompletionsHandler          func(ctx context.Context, req openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
 	chatCompletionsStreamingHandler func(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk]
+	responsesNewStreamingHandler    func(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion]
 }
 
 // NewOpenAIClient creates a new OpenAI client wrapper
@@ -156,6 +157,11 @@ func (c *OpenAIClient) ResponsesNew(ctx context.Context, req responses.ResponseN
 
 // ResponsesNewStreaming creates a new streaming Responses API request
 func (c *OpenAIClient) ResponsesNewStreaming(ctx context.Context, req responses.ResponseNewParams) *ssestream.Stream[responses.ResponseStreamEventUnion] {
+	// Use override function if set (for Codex providers)
+	if c.responsesNewStreamingHandler != nil {
+		return c.responsesNewStreamingHandler(ctx, req)
+	}
+	// Use standard OpenAI SDK
 	return c.client.Responses.NewStreaming(ctx, req)
 }
 

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -57,24 +57,20 @@ func NewClientPool() *ClientPool {
 // GetOpenAIClient returns an OpenAI client wrapper for the specified provider.
 // For Codex OAuth providers, returns a CodexClient with special handling.
 // sessionID is resolved from ctx via typ.GetSessionID; pass context.Background() when no session is available.
-func (p *ClientPool) GetOpenAIClient(ctx context.Context, provider *typ.Provider, model string) *OpenAIClient {
+func (p *ClientPool) GetOpenAIClient(ctx context.Context, provider *typ.Provider, model string) OpenAIClientInterface {
 	sessionID := typ.GetSessionID(ctx)
 	logrus.Debugf("Creating OpenAI client for provider: %s, session: %s", provider.Name, sessionID.Value)
 
-	var client *OpenAIClient
+	var client OpenAIClientInterface
 	var err error
 
 	// Check if this is a Codex OAuth provider
 	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil && provider.OAuthDetail.GetIssuer() == ai.IssuerCodex {
-		codexClient, err := NewCodexClient(provider, model, sessionID)
+		client, err = NewCodexClient(provider, model, sessionID)
 		if err != nil {
 			logrus.Errorf("Failed to create Codex client for provider %s: %v", provider.Name, err)
 			return nil
 		}
-		// Return the embedded OpenAIClient for compatibility
-		// Note: This means callers won't get CodexClient's overridden methods
-		// For full Codex support, the return type should be changed to an interface
-		client = codexClient.OpenAIClient
 	} else {
 		client, err = NewOpenAIClient(provider, model, sessionID)
 		if err != nil {
@@ -83,13 +79,16 @@ func (p *ClientPool) GetOpenAIClient(ctx context.Context, provider *typ.Provider
 		}
 	}
 
+	// Set record sink if enabled (only for OpenAIClient, not CodexClient)
 	if p.recordSink != nil && p.recordSink.IsEnabled() {
-		client.SetRecordSink(p.recordSink)
+		if oc, ok := client.(*OpenAIClient); ok {
+			oc.SetRecordSink(p.recordSink)
+		}
 	}
 
 	// Set finalizer for automatic cleanup when GC collects the client.
 	// This ensures idle connections are closed without requiring explicit Close() calls.
-	runtime.SetFinalizer(client, func(c *OpenAIClient) {
+	runtime.SetFinalizer(client, func(c OpenAIClientInterface) {
 		if c != nil {
 			c.Close()
 			logrus.Debugf("Auto-closed OpenAI client for provider: %s via finalizer", provider.Name)

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -54,15 +55,32 @@ func NewClientPool() *ClientPool {
 }
 
 // GetOpenAIClient returns an OpenAI client wrapper for the specified provider.
+// For Codex OAuth providers, returns a CodexClient with special handling.
 // sessionID is resolved from ctx via typ.GetSessionID; pass context.Background() when no session is available.
 func (p *ClientPool) GetOpenAIClient(ctx context.Context, provider *typ.Provider, model string) *OpenAIClient {
 	sessionID := typ.GetSessionID(ctx)
 	logrus.Debugf("Creating OpenAI client for provider: %s, session: %s", provider.Name, sessionID.Value)
 
-	client, err := NewOpenAIClient(provider, model, sessionID)
-	if err != nil {
-		logrus.Errorf("Failed to create OpenAI client for provider %s: %v", provider.Name, err)
-		return nil
+	var client *OpenAIClient
+	var err error
+
+	// Check if this is a Codex OAuth provider
+	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil && provider.OAuthDetail.GetIssuer() == ai.IssuerCodex {
+		codexClient, err := NewCodexClient(provider, model, sessionID)
+		if err != nil {
+			logrus.Errorf("Failed to create Codex client for provider %s: %v", provider.Name, err)
+			return nil
+		}
+		// Return the embedded OpenAIClient for compatibility
+		// Note: This means callers won't get CodexClient's overridden methods
+		// For full Codex support, the return type should be changed to an interface
+		client = codexClient.OpenAIClient
+	} else {
+		client, err = NewOpenAIClient(provider, model, sessionID)
+		if err != nil {
+			logrus.Errorf("Failed to create OpenAI client for provider %s: %v", provider.Name, err)
+			return nil
+		}
 	}
 
 	if p.recordSink != nil && p.recordSink.IsEnabled() {

--- a/internal/server/forwarding/openai.go
+++ b/internal/server/forwarding/openai.go
@@ -14,7 +14,7 @@ import (
 // ForwardOpenAIChat sends a non-streaming OpenAI chat completion request.
 // IMPORTANT: All transformations (protocol conversion + vendor-specific) should
 // be applied by the transform chain BEFORE calling this function.
-func ForwardOpenAIChat(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.ChatCompletionNewParams) (*openai.ChatCompletion, context.CancelFunc, error) {
+func ForwardOpenAIChat(fc *ForwardContext, wrapper client.OpenAIClientInterface, req *openai.ChatCompletionNewParams) (*openai.ChatCompletion, context.CancelFunc, error) {
 	if wrapper == nil {
 		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
 	}
@@ -36,7 +36,7 @@ func ForwardOpenAIChat(fc *ForwardContext, wrapper *client.OpenAIClient, req *op
 
 // ForwardOpenAIEmbeddings sends an OpenAI embeddings request.
 // Embeddings have no streaming and skip the chat transform chain.
-func ForwardOpenAIEmbeddings(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.EmbeddingNewParams) (*openai.CreateEmbeddingResponse, context.CancelFunc, error) {
+func ForwardOpenAIEmbeddings(fc *ForwardContext, wrapper client.OpenAIClientInterface, req *openai.EmbeddingNewParams) (*openai.CreateEmbeddingResponse, context.CancelFunc, error) {
 	if wrapper == nil {
 		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
 	}
@@ -53,7 +53,7 @@ func ForwardOpenAIEmbeddings(fc *ForwardContext, wrapper *client.OpenAIClient, r
 
 // ForwardOpenAIImageGeneration sends an OpenAI image generation request.
 // Image generation has no streaming and skips the chat transform chain.
-func ForwardOpenAIImageGeneration(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.ImageGenerateParams) (*openai.ImagesResponse, context.CancelFunc, error) {
+func ForwardOpenAIImageGeneration(fc *ForwardContext, wrapper client.OpenAIClientInterface, req *openai.ImageGenerateParams) (*openai.ImagesResponse, context.CancelFunc, error) {
 	if wrapper == nil {
 		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
 	}
@@ -72,7 +72,7 @@ func ForwardOpenAIImageGeneration(fc *ForwardContext, wrapper *client.OpenAIClie
 // IMPORTANT: All transformations (protocol conversion + vendor-specific) should
 // be applied by the transform chain BEFORE calling this function.
 // Note: Pass request context (c.Request.Context()) as baseCtx in NewForwardContext for client cancellation support.
-func ForwardOpenAIChatStream(fc *ForwardContext, wrapper *client.OpenAIClient, req *openai.ChatCompletionNewParams) (*openaistream.Stream[openai.ChatCompletionChunk], context.CancelFunc, error) {
+func ForwardOpenAIChatStream(fc *ForwardContext, wrapper client.OpenAIClientInterface, req *openai.ChatCompletionNewParams) (*openaistream.Stream[openai.ChatCompletionChunk], context.CancelFunc, error) {
 	if wrapper == nil {
 		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
 	}
@@ -85,7 +85,7 @@ func ForwardOpenAIChatStream(fc *ForwardContext, wrapper *client.OpenAIClient, r
 }
 
 // ForwardOpenAIResponses sends a non-streaming OpenAI Responses API request.
-func ForwardOpenAIResponses(fc *ForwardContext, wrapper *client.OpenAIClient, params responses.ResponseNewParams) (*responses.Response, context.CancelFunc, error) {
+func ForwardOpenAIResponses(fc *ForwardContext, wrapper client.OpenAIClientInterface, params responses.ResponseNewParams) (*responses.Response, context.CancelFunc, error) {
 	if wrapper == nil {
 		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
 	}
@@ -98,7 +98,7 @@ func ForwardOpenAIResponses(fc *ForwardContext, wrapper *client.OpenAIClient, pa
 
 // ForwardOpenAIResponsesStream sends a streaming OpenAI Responses API request.
 // Note: Pass request context (c.Request.Context()) as baseCtx in NewForwardContext for client cancellation support.
-func ForwardOpenAIResponsesStream(fc *ForwardContext, wrapper *client.OpenAIClient, params responses.ResponseNewParams) (*openaistream.Stream[responses.ResponseStreamEventUnion], context.CancelFunc, error) {
+func ForwardOpenAIResponsesStream(fc *ForwardContext, wrapper client.OpenAIClientInterface, params responses.ResponseNewParams) (*openaistream.Stream[responses.ResponseStreamEventUnion], context.CancelFunc, error) {
 	if wrapper == nil {
 		return nil, nil, fmt.Errorf("failed to get OpenAI client for provider: %s", fc.Provider.Name)
 	}

--- a/internal/server/module/mcp/forwarder.go
+++ b/internal/server/module/mcp/forwarder.go
@@ -18,7 +18,7 @@ import (
 // ClientPoolGetter matches client.ClientPool interface
 type ClientPoolGetter interface {
 	GetAnthropicClient(ctx context.Context, provider *typ.Provider, model string) *client.AnthropicClient
-	GetOpenAIClient(ctx context.Context, provider *typ.Provider, model string) *client.OpenAIClient
+	GetOpenAIClient(ctx context.Context, provider *typ.Provider, model string) client.OpenAIClientInterface
 }
 
 // ForwardContextGetter provides ForwardContext
@@ -136,7 +136,7 @@ type ForwardResult struct {
 	Message         any
 	Cancel          context.CancelFunc
 	AnthropicClient *client.AnthropicClient
-	OpenAIClient    *client.OpenAIClient
+	OpenAIClient    client.OpenAIClientInterface
 }
 
 // ===================================================================


### PR DESCRIPTION
## Summary

Add Codex-compatible image generation support, enabling Tingly Box to proxy OpenAI image generation and Responses image-generation requests through the Codex backend. 

This also separates Codex client behavior from the standard OpenAI client, preventing Codex-specific request filtering and streaming transforms from leaking into normal OpenAI forwarding.

## Major

- Codex-backed image generation now works through the OpenAI image generation endpoint.
- Responses API requests can stream image generation output from the Codex backend.
- Codex request handling now filters unsupported backend fields before forwarding, avoiding backend rejection due to incompatible parameters.
- Codex client logic is split behind a dedicated client interface, making OpenAI and Codex forwarding behavior easier to maintain independently.

## Minor

- Added curl task examples for Codex image generation and Responses image-generation streaming.
- Reused SDK image generation types for Codex image responses.
- Moved Codex-specific round-tripper behavior into a dedicated client implementation.
- Updated forwarding and MCP paths to use the extracted OpenAI/Codex client interfaces.

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/7a59a8c3-d8c4-4ee3-ba63-0bbc3f8aa128" />
