### PR TITLE
Fix 404 error fetching Deepseek model list

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -1813,30 +1814,41 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 	// Create appropriate client based on provider API style
 	// Note: For model listing, we use empty SessionID as no user session is involved
 	var lister client.ModelLister
-	switch provider.APIStyle {
-	case protocol.APIStyleAnthropic:
-		aClient, err := client.NewAnthropicClient(provider, "", typ.SessionID{})
-		if err == nil {
-			defer aClient.Close()
-			lister = aClient
-		}
-		apiErr = err
-	case protocol.APIStyleGoogle:
-		gClient, err := client.NewGoogleClient(provider, "", typ.SessionID{})
-		if err == nil {
-			defer gClient.Close()
-			lister = gClient
-		}
-		apiErr = err
-	case protocol.APIStyleOpenAI:
-		fallthrough
-	default:
-		oClient, err := client.NewOpenAIClient(provider, "", typ.SessionID{})
+	if strings.Contains(strings.ToLower(strings.TrimSpace(provider.APIBase)), "api.deepseek.com") {
+		providerForModels := *provider
+		providerForModels.APIBase = "https://api.deepseek.com"
+		oClient, err := client.NewOpenAIClient(&providerForModels, "", typ.SessionID{})
 		if err == nil {
 			defer oClient.Close()
 			lister = oClient
 		}
 		apiErr = err
+	} else {
+		switch provider.APIStyle {
+		case protocol.APIStyleAnthropic:
+			aClient, err := client.NewAnthropicClient(provider, "", typ.SessionID{})
+			if err == nil {
+				defer aClient.Close()
+				lister = aClient
+			}
+			apiErr = err
+		case protocol.APIStyleGoogle:
+			gClient, err := client.NewGoogleClient(provider, "", typ.SessionID{})
+			if err == nil {
+				defer gClient.Close()
+				lister = gClient
+			}
+			apiErr = err
+		case protocol.APIStyleOpenAI:
+			fallthrough
+		default:
+			oClient, err := client.NewOpenAIClient(provider, "", typ.SessionID{})
+			if err == nil {
+				defer oClient.Close()
+				lister = oClient
+			}
+			apiErr = err
+		}
 	}
 
 	// If we have a lister, try to fetch models


### PR DESCRIPTION
According to [https://api-docs.deepseek.com/api/list-models](https://api-docs.deepseek.com/api/list-models), deepseek should use [https://api.deepseek.com/models](https://api.deepseek.com/models) to fetch model list, no need to use anthropic or openai specific. Avoid the following error:

```
INFO[0121] Messages endpoint is accessible               action=fetch_models api_base="https://api.deepseek.com/anthropic" models_count=0 provider=placeholder response_time=747 success=true valid=true
ERRO[0122] Failed to fetch models from API: GET "https://api.deepseek.com/anthropic/v1/models": 404 Not Found
```