### PR TITLE
config: add OpenCode Go to provider list

### DIFF
--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -1258,6 +1258,27 @@
       "models": [],
       "supports_models_endpoint": true,
       "icon": "opencode"
+    },
+    "opencode-go": {
+      "id": "opencode-go",
+      "name": "OpenCode Go",
+      "status": "active",
+      "valid": true,
+      "canonical_domain": "opencode.ai",
+      "vendor_family": "opencode",
+      "region": "global",
+      "plan": "standard",
+      "website": "https://opencode.ai",
+      "description": "OpenCode Go - low-cost code templates for everyone",
+      "type": "reseller",
+      "api_doc": "https://opencode.ai/docs/providers/",
+      "model_doc": "https://opencode.ai/docs/providers/",
+      "pricing_doc": "https://opencode.ai/docs/providers/",
+      "base_url_openai": "https://opencode.ai/zen/go/v1",
+      "base_url_anthropic": null,
+      "models": [],
+      "supports_models_endpoint": true,
+      "icon": "opencode"
     }
   }
 }


### PR DESCRIPTION
OpenCode Go uses different base url from Zen, so added a new entry for OpenCode Go.