### PR TITLE
feat(ui): add agent overview page with scenario visibility management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import UseCodexPage from './pages/scenario/UseCodexPage';
 import UseClaudeCodePage from './pages/scenario/UseClaudeCodePage';
 import ClaudeCodeProfilePage from './pages/scenario/ClaudeCodeProfilePage';
 import UseAgentPage from './pages/scenario/UseAgentPage';
+import AgentOverviewPage from './pages/scenario/AgentOverviewPage';
 import UseOpenCodePage from './pages/scenario/UseOpenCodePage';
 import UseXcodePage from './pages/scenario/UseXcodePage';
 import UseVSCodePage from './pages/scenario/UseVSCodePage';
@@ -275,10 +276,9 @@ const AppDialogs = () => {
 
 // OnboardingGate decides where a freshly-authenticated user lands. Brand-new
 // installs (no provider configured) get sent to /onboarding; everyone else
-// always lands in the scenario activity, restoring the previously selected
-// agent sub-page if one was remembered, or /agent/claude_code by default.
-// We hit /api/v2/providers once on mount; while in flight we render nothing
-// to avoid a flash of the default agent page.
+// lands on the agent overview at /agent. We hit /api/v2/providers once on
+// mount; while in flight we render nothing to avoid a flash of the default
+// agent page.
 const OnboardingGate: React.FC = () => {
     const [target, setTarget] = useState<string | null>(null);
 
@@ -298,8 +298,7 @@ const OnboardingGate: React.FC = () => {
                 // Swallow the error and fall through to the default agent —
                 // failing the gate should never lock the user out of the app.
             }
-            const fallback = localStorage.getItem('layout.activityPath.scenario') || '/agent/claude_code';
-            if (!cancelled) setTarget(fallback);
+            if (!cancelled) setTarget('/agent');
         })();
         return () => { cancelled = true; };
     }, []);
@@ -341,6 +340,7 @@ function AppContent() {
                     {/* Onboarding for new installs */}
                     <Route path="/onboarding" element={<Onboarding />} />
                     {/* Function panel routes */}
+                    <Route path="/agent" element={<AgentOverviewPage />} />
                     <Route path="/agent/openai" element={<UseOpenAIPage />} />
                     <Route path="/agent/anthropic" element={<UseAnthropicPage />} />
                     <Route path="/agent/codex" element={<UseCodexPage />} />
@@ -434,7 +434,7 @@ function AppContent() {
                     {/* Legacy zen redirects */}
                     <Route path="/zen/claude-code" element={<Navigate to="/zen/claude_code" replace />} />
                     {/* Catch-all redirect for unknown routes */}
-                    <Route path="*" element={<Navigate to="/agent/claude_code" replace />} />
+                    <Route path="*" element={<Navigate to="/agent" replace />} />
                 </Route>
             </Routes>
     )

--- a/frontend/src/components/BrandIcons.tsx
+++ b/frontend/src/components/BrandIcons.tsx
@@ -87,8 +87,14 @@ const createBrandIcon = (src: string, alt: string, defaultGrayscale = false, mon
                             width: '100%',
                             height: '100%',
                             backgroundColor: 'currentColor',
-                            mask: `url(${src}) center / contain no-repeat`,
-                            WebkitMask: `url(${src}) center / contain no-repeat`,
+                            maskImage: `url(${src})`,
+                            maskRepeat: 'no-repeat',
+                            maskPosition: 'center',
+                            maskSize: 'contain',
+                            WebkitMaskImage: `url(${src})`,
+                            WebkitMaskRepeat: 'no-repeat',
+                            WebkitMaskPosition: 'center',
+                            WebkitMaskSize: 'contain',
                         }}
                     />
                 </Box>

--- a/frontend/src/components/BrandIcons.tsx
+++ b/frontend/src/components/BrandIcons.tsx
@@ -1,5 +1,5 @@
 import type {SxProps, Theme} from '@mui/material';
-import {Box} from '@mui/material';
+import {Box, useTheme} from '@mui/material';
 
 // Import SVG files as URLs
 import AnthropicSvg from '@lobehub/icons-static-svg/icons/anthropic.svg?url';
@@ -59,47 +59,24 @@ interface BrandIconProps {
     grayscale?: boolean;
 }
 
-// Box 作为容器控制大小。
-// monochrome=true：SVG 用 fill="currentColor"，通过 mask-image 渲染并以 currentColor 上色，
-// 这样图标在亮/暗主题及高亮态下都会自动跟随父级文字颜色，避免暗色背景下黑图不可见。
-// monochrome=false：保留原 <img> 渲染，保留品牌色或 grayscale 处理。
+// Lobehub 的品牌 SVG 用 fill="currentColor" 是单色设计，但 <img> 加载是独立文档，
+// currentColor 没有外部颜色继承，会落到默认黑色，导致暗色主题下黑图不可见。
+// 解决：暗色主题下对单色图标加 invert(1)（黑→白），亮色主题保持原样。
+// 高亮态由 Sidebar 处理（白底 + 强制清零 filter，保持黑图在白底上的效果）。
 const createBrandIcon = (src: string, alt: string, defaultGrayscale = false, monochrome = false) => {
     return ({size = 24, sx, style, grayscale = defaultGrayscale}: BrandIconProps) => {
-        if (monochrome) {
-            return (
-                <Box
-                    sx={{
-                        width: size,
-                        height: size,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexShrink: 0,
-                        color: 'inherit',
-                        ...sx,
-                    }}
-                    style={style}
-                >
-                    <Box
-                        role="img"
-                        aria-label={alt}
-                        sx={{
-                            width: '100%',
-                            height: '100%',
-                            backgroundColor: 'currentColor',
-                            maskImage: `url(${src})`,
-                            maskRepeat: 'no-repeat',
-                            maskPosition: 'center',
-                            maskSize: 'contain',
-                            WebkitMaskImage: `url(${src})`,
-                            WebkitMaskRepeat: 'no-repeat',
-                            WebkitMaskPosition: 'center',
-                            WebkitMaskSize: 'contain',
-                        }}
-                    />
-                </Box>
-            );
+        const theme = useTheme();
+        const isDark = theme.palette.mode === 'dark';
+
+        let filter = 'none';
+        if (grayscale) {
+            filter = isDark
+                ? 'grayscale(100%) brightness(1.6)'
+                : 'grayscale(100%) brightness(1.15) contrast(1.1)';
+        } else if (monochrome && isDark) {
+            filter = 'invert(1)';
         }
+
         return (
             <Box
                 sx={{
@@ -122,7 +99,7 @@ const createBrandIcon = (src: string, alt: string, defaultGrayscale = false, mon
                         width: '100%',
                         height: '100%',
                         objectFit: 'contain',
-                        filter: grayscale ? 'grayscale(100%) brightness(1.15) contrast(1.1)' : 'none',
+                        filter,
                         transition: 'filter 0.2s',
                     }}
                 />

--- a/frontend/src/components/BrandIcons.tsx
+++ b/frontend/src/components/BrandIcons.tsx
@@ -59,55 +59,89 @@ interface BrandIconProps {
     grayscale?: boolean;
 }
 
-// Box 作为容器控制大小，img 填充整个 Box
-const createBrandIcon = (src: string, alt: string, defaultGrayscale = false) => {
-    return ({size = 24, sx, style, grayscale = defaultGrayscale}: BrandIconProps) => (
-        <Box
-            sx={{
-                width: size,
-                height: size,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-                ...sx,
-            }}
-            style={style}
-        >
+// Box 作为容器控制大小。
+// monochrome=true：SVG 用 fill="currentColor"，通过 mask-image 渲染并以 currentColor 上色，
+// 这样图标在亮/暗主题及高亮态下都会自动跟随父级文字颜色，避免暗色背景下黑图不可见。
+// monochrome=false：保留原 <img> 渲染，保留品牌色或 grayscale 处理。
+const createBrandIcon = (src: string, alt: string, defaultGrayscale = false, monochrome = false) => {
+    return ({size = 24, sx, style, grayscale = defaultGrayscale}: BrandIconProps) => {
+        if (monochrome) {
+            return (
+                <Box
+                    sx={{
+                        width: size,
+                        height: size,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                        color: 'inherit',
+                        ...sx,
+                    }}
+                    style={style}
+                >
+                    <Box
+                        role="img"
+                        aria-label={alt}
+                        sx={{
+                            width: '100%',
+                            height: '100%',
+                            backgroundColor: 'currentColor',
+                            mask: `url(${src}) center / contain no-repeat`,
+                            WebkitMask: `url(${src}) center / contain no-repeat`,
+                        }}
+                    />
+                </Box>
+            );
+        }
+        return (
             <Box
-                component="img"
-                src={src}
-                alt={alt}
                 sx={{
-                    display: 'block',
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'contain',
-                    filter: grayscale ? 'grayscale(100%) brightness(1.15) contrast(1.1)' : 'none',
-                    transition: 'filter 0.2s',
+                    width: size,
+                    height: size,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                    ...sx,
                 }}
-            />
-        </Box>
-    );
+                style={style}
+            >
+                <Box
+                    component="img"
+                    src={src}
+                    alt={alt}
+                    sx={{
+                        display: 'block',
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'contain',
+                        filter: grayscale ? 'grayscale(100%) brightness(1.15) contrast(1.1)' : 'none',
+                        transition: 'filter 0.2s',
+                    }}
+                />
+            </Box>
+        );
+    };
 };
 
-export const OpenAI = createBrandIcon(OpenAISvg, 'OpenAI');
-export const Anthropic = createBrandIcon(AnthropicSvg, 'Anthropic');
-export const Claude = createBrandIcon(ClaudeSvg, 'Claude');
-export const ClaudeCode = createBrandIcon(ClaudeCodeSvg, 'Claude Code');
-export const Codex = createBrandIcon(CodexSvg, 'Codex');
-export const Gemini = createBrandIcon(GeminiSvg, 'Gemini');
-export const Google = createBrandIcon(GoogleSvg, 'Google');
-export const Kimi = createBrandIcon(KimiSvg, 'Kimi');
-export const OpenClaw = createBrandIcon(OpenClawSvg, 'OpenClaw');
-export const Qwen = createBrandIcon(QwenSvg, 'Qwen');
-export const OpenCode = createBrandIcon(OpenCodeSvg, 'OpenCode');
-export const DeepSeek = createBrandIcon(DeepSeekSvg, 'DeepSeek');
-export const Minimax = createBrandIcon(MinimaxSvg, 'Minimax');
-export const Zhipu = createBrandIcon(ZhipuSvg, 'Zhipu');
-export const XAI = createBrandIcon(XAISvg, 'xAI');
-export const Mistral = createBrandIcon(MistralSvg, 'Mistral');
-export const OpenRouter = createBrandIcon(OpenRouterSvg, 'OpenRouter');
+export const OpenAI = createBrandIcon(OpenAISvg, 'OpenAI', false, true);
+export const Anthropic = createBrandIcon(AnthropicSvg, 'Anthropic', false, true);
+export const Claude = createBrandIcon(ClaudeSvg, 'Claude', false, true);
+export const ClaudeCode = createBrandIcon(ClaudeCodeSvg, 'Claude Code', false, true);
+export const Codex = createBrandIcon(CodexSvg, 'Codex', false, true);
+export const Gemini = createBrandIcon(GeminiSvg, 'Gemini', false, true);
+export const Google = createBrandIcon(GoogleSvg, 'Google', false, true);
+export const Kimi = createBrandIcon(KimiSvg, 'Kimi', false, true);
+export const OpenClaw = createBrandIcon(OpenClawSvg, 'OpenClaw', false, true);
+export const Qwen = createBrandIcon(QwenSvg, 'Qwen', false, true);
+export const OpenCode = createBrandIcon(OpenCodeSvg, 'OpenCode', false, true);
+export const DeepSeek = createBrandIcon(DeepSeekSvg, 'DeepSeek', false, true);
+export const Minimax = createBrandIcon(MinimaxSvg, 'Minimax', false, true);
+export const Zhipu = createBrandIcon(ZhipuSvg, 'Zhipu', false, true);
+export const XAI = createBrandIcon(XAISvg, 'xAI', false, true);
+export const Mistral = createBrandIcon(MistralSvg, 'Mistral', false, true);
+export const OpenRouter = createBrandIcon(OpenRouterSvg, 'OpenRouter', false, true);
 export const Xcode = createBrandIcon(XcodeSvg, 'Xcode', true);
 export const VSCode = createBrandIcon(VSCodeSvg, 'VS Code', true);
 
@@ -122,23 +156,26 @@ export const Discord = createBrandIcon(DiscordSvg, 'Discord', true);
 export const Slack = createBrandIcon(SlackSvg, 'Slack', true);
 
 // New provider icons
-export const Groq = createBrandIcon(GroqSvg, 'Groq');
+// Together / Baidu / Yi import the brand-color variants and stay <img>; the
+// rest use lobehub's `fill="currentColor"` monochrome SVGs and need mask
+// rendering so they follow text color in dark/light themes.
+export const Groq = createBrandIcon(GroqSvg, 'Groq', false, true);
 export const Together = createBrandIcon(TogetherSvg, 'Together');
-export const Fireworks = createBrandIcon(FireworksSvg, 'Fireworks');
-export const Cerebras = createBrandIcon(CerebrasSvg, 'Cerebras');
-export const Perplexity = createBrandIcon(PerplexitySvg, 'Perplexity');
-export const Cohere = createBrandIcon(CohereSvg, 'Cohere');
-export const Nvidia = createBrandIcon(NvidiaSvg, 'NVIDIA');
-export const Novita = createBrandIcon(NovitaSvg, 'Novita');
-export const DeepInfra = createBrandIcon(DeepInfraSvg, 'DeepInfra');
-export const Hyperbolic = createBrandIcon(HyperbolicSvg, 'Hyperbolic');
-export const ModelScope = createBrandIcon(ModelScopeSvg, 'ModelScope');
-export const SiliconFlow = createBrandIcon(SiliconFlowSvg, 'SiliconFlow');
-export const Stepfun = createBrandIcon(StepfunSvg, 'Stepfun');
-export const Xiaomimimo = createBrandIcon(XiaomimimoSvg, 'Xiaomi Mimo');
+export const Fireworks = createBrandIcon(FireworksSvg, 'Fireworks', false, true);
+export const Cerebras = createBrandIcon(CerebrasSvg, 'Cerebras', false, true);
+export const Perplexity = createBrandIcon(PerplexitySvg, 'Perplexity', false, true);
+export const Cohere = createBrandIcon(CohereSvg, 'Cohere', false, true);
+export const Nvidia = createBrandIcon(NvidiaSvg, 'NVIDIA', false, true);
+export const Novita = createBrandIcon(NovitaSvg, 'Novita', false, true);
+export const DeepInfra = createBrandIcon(DeepInfraSvg, 'DeepInfra', false, true);
+export const Hyperbolic = createBrandIcon(HyperbolicSvg, 'Hyperbolic', false, true);
+export const ModelScope = createBrandIcon(ModelScopeSvg, 'ModelScope', false, true);
+export const SiliconFlow = createBrandIcon(SiliconFlowSvg, 'SiliconFlow', false, true);
+export const Stepfun = createBrandIcon(StepfunSvg, 'Stepfun', false, true);
+export const Xiaomimimo = createBrandIcon(XiaomimimoSvg, 'Xiaomi Mimo', false, true);
 export const Baidu = createBrandIcon(BaiduSvg, 'Baidu');
-export const Tencent = createBrandIcon(TencentSvg, 'Tencent');
-export const IflytekCloud = createBrandIcon(IflytekCloudSvg, 'iFlytek');
-export const Baichuan = createBrandIcon(BaichuanSvg, 'Baichuan');
+export const Tencent = createBrandIcon(TencentSvg, 'Tencent', false, true);
+export const IflytekCloud = createBrandIcon(IflytekCloudSvg, 'iFlytek', false, true);
+export const Baichuan = createBrandIcon(BaichuanSvg, 'Baichuan', false, true);
 export const Yi = createBrandIcon(YiSvg, 'Lingyi Wanwu');
-export const Doubao = createBrandIcon(DoubaoSvg, 'Doubao');
+export const Doubao = createBrandIcon(DoubaoSvg, 'Doubao', false, true);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -852,5 +852,24 @@ export default {
     "quickLinks": "Quick Links",
     "goToDashboard": "Dashboard",
     "goToHelp": "Help & Docs"
+  },
+  "scenarioOverview": {
+    "title": "Agents",
+    "subtitle": "Pick a scenario to configure. Hide the ones you don't use to keep the sidebar tidy.",
+    "showInSidebar": "Show in sidebar",
+    "hidden": "Hidden",
+    "editTooltip": "Manage visible agents",
+    "descriptions": {
+      "claude_code": "Route Claude Code with custom profiles and per-task models.",
+      "codex": "Configure Codex CLI through your provider keys.",
+      "opencode": "Open-source coding agent powered by your provider.",
+      "xcode": "Bring your model into Xcode's coding intelligence.",
+      "vscode": "Power VS Code Copilot Chat through Tingly Box.",
+      "openai": "Drop-in OpenAI-compatible SDK endpoint.",
+      "anthropic": "Drop-in Anthropic-compatible SDK endpoint.",
+      "embed": "Route embedding requests to your provider.",
+      "imagegen": "Route image generation through Tingly Box.",
+      "agent": "OpenClaw — universal agent runner."
+    }
   }
 };

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -852,5 +852,24 @@ export default {
     "quickLinks": "快速链接",
     "goToDashboard": "控制台",
     "goToHelp": "帮助与文档"
+  },
+  "scenarioOverview": {
+    "title": "智能应用",
+    "subtitle": "选择要配置的场景，未使用的可以隐藏以保持侧边栏整洁。",
+    "showInSidebar": "在侧边栏显示",
+    "hidden": "已隐藏",
+    "editTooltip": "管理可见的智能应用",
+    "descriptions": {
+      "claude_code": "为 Claude Code 配置自定义路由、配置文件与按任务的模型。",
+      "codex": "用你的提供商凭证配置 Codex CLI。",
+      "opencode": "使用你的提供商驱动的开源代码 Agent。",
+      "xcode": "将你的模型接入 Xcode 编码智能。",
+      "vscode": "通过 Tingly Box 驱动 VS Code Copilot Chat。",
+      "openai": "兼容 OpenAI 的 SDK 直连端点。",
+      "anthropic": "兼容 Anthropic 的 SDK 直连端点。",
+      "embed": "将 Embedding 请求路由到你的提供商。",
+      "imagegen": "通过 Tingly Box 路由图像生成。",
+      "agent": "OpenClaw — 通用 Agent 运行器。"
+    }
   }
 };

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -1,5 +1,5 @@
-import { Box, Drawer, IconButton, Popover, Typography, Menu, MenuItem } from '@mui/material';
-import { IconMenu, IconDots, IconYinYang, IconSun, IconMoon, IconSunHigh } from '@tabler/icons-react';
+import { Box, Drawer, IconButton, Popover, Tooltip, Typography, Menu, MenuItem } from '@mui/material';
+import { IconMenu, IconDots, IconYinYang, IconSun, IconMoon, IconSunHigh, IconPencil } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -77,16 +77,11 @@ const Layout = ({ children }: LayoutProps) => {
         return activeActivity;
     }, [effectiveZenEnabled, location.pathname, activeActivity]);
 
-    // Persist the active activity for cross-session boot. Per-activity path
-    // memory is intentionally scoped to the scenario (agent) activity only —
-    // every other activity opens at its defaultPath when re-clicked.
+    // Persist the active activity for cross-session boot. Each activity
+    // re-opens at its defaultPath (the scenario activity opens its overview).
     useEffect(() => {
         sessionStorage.setItem('layout.activeActivity', activeActivity);
         localStorage.setItem('layout.activeActivity', activeActivity);
-        if (activeActivity === 'scenario') {
-            sessionStorage.setItem(`layout.activityPath.${activeActivity}`, location.pathname);
-            localStorage.setItem(`layout.activityPath.${activeActivity}`, location.pathname);
-        }
     }, [activeActivity, location.pathname]);
 
     // When navigating to a zen path, clear zenMoreActivity
@@ -192,22 +187,11 @@ const Layout = ({ children }: LayoutProps) => {
 
         sessionStorage.setItem('layout.activeActivity', item.key);
 
-        // Only the scenario activity restores its previously visited sub-page —
-        // every other activity always opens at its defaultPath, so users never
-        // get a stale "last viewed" view they don't expect.
+        // Every activity opens at its defaultPath when clicked. The scenario
+        // activity points at /agent (the overview) so users always land there
+        // before drilling into a specific scenario.
         const firstNavChild = item.children?.find(c => c.type !== 'divider');
-        let targetPath: string | undefined;
-
-        if (item.key === 'scenario') {
-            const savedPath = sessionStorage.getItem(`layout.activityPath.${item.key}`) || localStorage.getItem(`layout.activityPath.${item.key}`);
-            if (savedPath && item.children?.some(c => c.type !== 'divider' && c.path === savedPath)) {
-                targetPath = savedPath;
-            }
-        }
-
-        if (!targetPath) {
-            targetPath = item.defaultPath || item.path || firstNavChild?.path;
-        }
+        let targetPath = item.defaultPath || item.path || firstNavChild?.path;
 
         // Ultimate fallback to prevent navigation to invalid paths
         if (!targetPath && firstNavChild) {
@@ -242,6 +226,21 @@ const Layout = ({ children }: LayoutProps) => {
 
     const zenActivityItems = getZenActivityItems();
 
+    const sidebarHeaderAction = activeActivity === 'scenario' ? (
+        <Tooltip title={t('scenarioOverview.editTooltip', { defaultValue: 'Manage visible agents' })} arrow placement="right">
+            <IconButton
+                size="small"
+                onClick={() => navigate('/agent')}
+                sx={{
+                    color: location.pathname === '/agent' ? 'primary.main' : 'text.secondary',
+                    '&:hover': { color: 'primary.main' },
+                }}
+            >
+                <IconPencil size={16} />
+            </IconButton>
+        </Tooltip>
+    ) : undefined;
+
     const navigationContent = (
         <Box sx={{ display: 'flex', height: '100%' }}>
             <ZenActivityBar
@@ -261,6 +260,7 @@ const Layout = ({ children }: LayoutProps) => {
                     sidebarItems={sidebarItems}
                     activeActivityLabel={activeActivityLabel}
                     onClose={() => setMobileOpen(false)}
+                    headerAction={sidebarHeaderAction}
                 />
             )}
         </Box>

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -148,7 +148,11 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                                         backgroundColor: 'primary.main',
                                         color: 'primary.contrastText',
                                         '& img': { filter: 'none !important' },
-                                        '& .MuiListItemIcon-root > div': {
+                                        // White plate is only useful for the colored <img> icons
+                                        // (Xcode/VSCode/social platforms). Monochrome mask icons
+                                        // already follow currentColor and look correct on the
+                                        // primary background, so don't add a plate behind them.
+                                        '& .MuiListItemIcon-root > div:has(img)': {
                                             bgcolor: 'white',
                                             borderRadius: 0.5,
                                             p: 0.25,

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -28,9 +28,10 @@ interface SidebarProps {
     sidebarItems: NavItem[];
     activeActivityLabel: string;
     onClose: () => void;
+    headerAction?: React.ReactNode;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLabel, onClose }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLabel, onClose, headerAction }) => {
     const { t } = useTranslation();
     const location = useLocation();
     const { refresh } = useProfileContext();
@@ -94,6 +95,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                     px: 2,
                     display: 'flex',
                     alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 1,
                     borderBottom: '1px solid',
                     borderColor: 'divider',
                 }}
@@ -101,6 +104,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                 <Typography variant="subtitle2" sx={{ color: 'text.primary', fontWeight: 600, fontSize: '0.875rem' }}>
                     {activeActivityLabel}
                 </Typography>
+                {headerAction}
             </Box>
 
             {/* Nav Items */}

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -148,11 +148,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                                         backgroundColor: 'primary.main',
                                         color: 'primary.contrastText',
                                         '& img': { filter: 'none !important' },
-                                        // White plate is only useful for the colored <img> icons
-                                        // (Xcode/VSCode/social platforms). Monochrome mask icons
-                                        // already follow currentColor and look correct on the
-                                        // primary background, so don't add a plate behind them.
-                                        '& .MuiListItemIcon-root > div:has(img)': {
+                                        '& .MuiListItemIcon-root > div': {
                                             bgcolor: 'white',
                                             borderRadius: 0.5,
                                             p: 0.25,

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getHiddenScenarios } from '@/pages/scenario/AgentOverviewPage';
 import {
     IconChartBar,
     IconGridDots,
@@ -36,6 +37,17 @@ export function useActivityItems(): ActivityItem[] {
     const { skillUser, skillIde, enableGuardrails, enableMCP } = useFeatureFlags();
     const { profiles } = useProfileContext();
     const botSummary = useBotPlatformSummary(isFullEdition);
+
+    const [hiddenScenarios, setHiddenScenarios] = useState<Set<string>>(() => getHiddenScenarios());
+    useEffect(() => {
+        const sync = () => setHiddenScenarios(getHiddenScenarios());
+        window.addEventListener('scenario-visibility-change', sync);
+        window.addEventListener('storage', sync);
+        return () => {
+            window.removeEventListener('scenario-visibility-change', sync);
+            window.removeEventListener('storage', sync);
+        };
+    }, []);
     const platformSubtitle = (id: string): string | undefined => {
         const s = botSummary[id];
         return s && s.total > 0 ? `active ${s.active} / ${s.total}` : undefined;
@@ -69,34 +81,47 @@ export function useActivityItems(): ActivityItem[] {
             icon: <Claude size={20} />,
         }));
 
+        type HideableScenario = { id: string; nav: NavItem };
+        const visible = (group: HideableScenario[]): NavItem[] =>
+            group.filter(s => !hiddenScenarios.has(s.id)).map(s => s.nav);
+
+        const codingTools = visible([
+            { id: 'codex', nav: { path: '/agent/codex', label: t('layout.nav.useCodex', { defaultValue: 'Codex' }), icon: <Codex size={20} /> } },
+            { id: 'opencode', nav: { path: '/agent/opencode', label: t('layout.nav.useOpenCode', { defaultValue: 'OpenCode' }), icon: <OpenCode size={20} /> } },
+            { id: 'xcode', nav: { path: '/agent/xcode', label: t('layout.nav.useXcode', { defaultValue: 'Xcode' }), icon: <Xcode size={20} /> } },
+            { id: 'vscode', nav: { path: '/agent/vscode', label: t('layout.nav.useVSCode', { defaultValue: 'VS Code' }), icon: <VSCode size={20} /> } },
+        ]);
+        const sdkTools = visible([
+            { id: 'openai', nav: { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> } },
+            { id: 'anthropic', nav: { path: '/agent/anthropic', label: t('layout.nav.useAnthropic', { defaultValue: 'Anthropic' }), icon: <Anthropic size={20} /> } },
+            { id: 'embed', nav: { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embed' }), icon: <IconVector size={20} /> } },
+            { id: 'imagegen', nav: { path: '/agent/imagegen', label: t('layout.nav.useImageGen', { defaultValue: 'Image Gen' }), icon: <IconPhoto size={20} /> } },
+        ]);
+        const agentTools = visible([
+            { id: 'agent', nav: { path: '/agent/agent', label: t('common.openClaw', { defaultValue: 'OpenClaw' }), icon: <OpenClaw size={20} /> } },
+        ]);
+
+        const scenarioChildren: NavItem[] = [
+            {
+                path: '/agent/claude_code',
+                subtitle: t('layout.default'),
+                label: t('layout.nav.useClaudeCode', { defaultValue: 'Claude Code' }),
+                icon: <Claude size={20} />,
+            },
+            ...profileNavItems,
+            { path: '#add-profile', label: t('layout.addProfile'), icon: <IconPlus size={20} /> },
+        ];
+        if (codingTools.length > 0) scenarioChildren.push({ type: 'divider' }, ...codingTools);
+        if (sdkTools.length > 0) scenarioChildren.push({ type: 'divider' }, ...sdkTools);
+        if (agentTools.length > 0) scenarioChildren.push({ type: 'divider' }, ...agentTools);
+
         const items: ActivityItem[] = [
             {
                 key: 'scenario',
                 icon: <IconAiAgents size={22} />,
                 label: t('layout.nav.home'),
-                defaultPath: '/agent/claude_code',
-                children: [
-                    {
-                        path: '/agent/claude_code',
-                        subtitle: t('layout.default'),
-                        label: t('layout.nav.useClaudeCode', { defaultValue: 'Claude Code' }),
-                        icon: <Claude size={20} />,
-                    },
-                    ...profileNavItems,
-                    { path: '#add-profile', label: t('layout.addProfile'), icon: <IconPlus size={20} /> },
-                    { type: 'divider' },
-                    { path: '/agent/codex', label: t('layout.nav.useCodex', { defaultValue: 'Codex' }), icon: <Codex size={20} /> },
-                    { path: '/agent/opencode', label: t('layout.nav.useOpenCode', { defaultValue: 'OpenCode' }), icon: <OpenCode size={20} /> },
-                    { path: '/agent/xcode', label: t('layout.nav.useXcode', { defaultValue: 'Xcode' }), icon: <Xcode size={20} /> },
-                    { path: '/agent/vscode', label: t('layout.nav.useVSCode', { defaultValue: 'VS Code' }), icon: <VSCode size={20} /> },
-                    { type: 'divider' },
-                    { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> },
-                    { path: '/agent/anthropic', label: t('layout.nav.useAnthropic', { defaultValue: 'Anthropic' }), icon: <Anthropic size={20} /> },
-                    { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embed' }), icon: <IconVector size={20} /> },
-                    { path: '/agent/imagegen', label: t('layout.nav.useImageGen', { defaultValue: 'Image Gen' }), icon: <IconPhoto size={20} /> },
-                    { type: 'divider' },
-                    { path: '/agent/agent', label: t('common.openClaw', { defaultValue: 'OpenClaw' }), icon: <OpenClaw size={20} /> },
-                ],
+                defaultPath: '/agent',
+                children: scenarioChildren,
             },
             {
                 key: 'dashboard',
@@ -185,5 +210,5 @@ export function useActivityItems(): ActivityItem[] {
         ];
 
         return items;
-    }, [t, promptMenuItems, enableGuardrails, enableMCP, profiles, botSummary]);
+    }, [t, promptMenuItems, enableGuardrails, enableMCP, profiles, botSummary, hiddenScenarios]);
 }

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -101,19 +101,27 @@ export function useActivityItems(): ActivityItem[] {
             { id: 'agent', nav: { path: '/agent/agent', label: t('common.openClaw', { defaultValue: 'OpenClaw' }), icon: <OpenClaw size={20} /> } },
         ]);
 
-        const scenarioChildren: NavItem[] = [
-            {
-                path: '/agent/claude_code',
-                subtitle: t('layout.default'),
-                label: t('layout.nav.useClaudeCode', { defaultValue: 'Claude Code' }),
-                icon: <Claude size={20} />,
-            },
-            ...profileNavItems,
-            { path: '#add-profile', label: t('layout.addProfile'), icon: <IconPlus size={20} /> },
-        ];
-        if (codingTools.length > 0) scenarioChildren.push({ type: 'divider' }, ...codingTools);
-        if (sdkTools.length > 0) scenarioChildren.push({ type: 'divider' }, ...sdkTools);
-        if (agentTools.length > 0) scenarioChildren.push({ type: 'divider' }, ...agentTools);
+        const scenarioChildren: NavItem[] = [];
+        if (!hiddenScenarios.has('claude_code')) {
+            scenarioChildren.push(
+                {
+                    path: '/agent/claude_code',
+                    subtitle: t('layout.default'),
+                    label: t('layout.nav.useClaudeCode', { defaultValue: 'Claude Code' }),
+                    icon: <Claude size={20} />,
+                },
+                ...profileNavItems,
+                { path: '#add-profile', label: t('layout.addProfile'), icon: <IconPlus size={20} /> },
+            );
+        }
+        const pushGroup = (group: NavItem[]) => {
+            if (group.length === 0) return;
+            if (scenarioChildren.length > 0) scenarioChildren.push({ type: 'divider' });
+            scenarioChildren.push(...group);
+        };
+        pushGroup(codingTools);
+        pushGroup(sdkTools);
+        pushGroup(agentTools);
 
         const items: ActivityItem[] = [
             {

--- a/frontend/src/pages/scenario/AgentOverviewPage.tsx
+++ b/frontend/src/pages/scenario/AgentOverviewPage.tsx
@@ -1,0 +1,279 @@
+import {
+    Box,
+    Card,
+    CardActionArea,
+    Chip,
+    Grid,
+    Stack,
+    Switch,
+    Typography,
+} from '@mui/material';
+import {
+    IconAiAgents,
+    IconPhoto,
+    IconVector,
+} from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import {
+    Anthropic,
+    Claude,
+    Codex,
+    OpenAI,
+    OpenClaw,
+    OpenCode,
+    VSCode,
+    Xcode,
+} from '@/components/BrandIcons';
+import PageLayout from '@/components/PageLayout';
+
+export interface ScenarioDescriptor {
+    id: string;
+    labelKey: string;
+    descKey: string;
+    path: string;
+    icon: React.ReactNode;
+    /** Hideable from the sidebar. Claude Code is always shown (anchors profiles). */
+    hideable: boolean;
+}
+
+const scenarioIconSize = 32;
+
+export const SCENARIOS: ScenarioDescriptor[] = [
+    {
+        id: 'claude_code',
+        labelKey: 'layout.nav.useClaudeCode',
+        descKey: 'scenarioOverview.descriptions.claude_code',
+        path: '/agent/claude_code',
+        icon: <Claude size={scenarioIconSize} />,
+        hideable: false,
+    },
+    {
+        id: 'codex',
+        labelKey: 'layout.nav.useCodex',
+        descKey: 'scenarioOverview.descriptions.codex',
+        path: '/agent/codex',
+        icon: <Codex size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'opencode',
+        labelKey: 'layout.nav.useOpenCode',
+        descKey: 'scenarioOverview.descriptions.opencode',
+        path: '/agent/opencode',
+        icon: <OpenCode size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'xcode',
+        labelKey: 'layout.nav.useXcode',
+        descKey: 'scenarioOverview.descriptions.xcode',
+        path: '/agent/xcode',
+        icon: <Xcode size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'vscode',
+        labelKey: 'layout.nav.useVSCode',
+        descKey: 'scenarioOverview.descriptions.vscode',
+        path: '/agent/vscode',
+        icon: <VSCode size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'openai',
+        labelKey: 'layout.nav.useOpenAI',
+        descKey: 'scenarioOverview.descriptions.openai',
+        path: '/agent/openai',
+        icon: <OpenAI size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'anthropic',
+        labelKey: 'layout.nav.useAnthropic',
+        descKey: 'scenarioOverview.descriptions.anthropic',
+        path: '/agent/anthropic',
+        icon: <Anthropic size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'embed',
+        labelKey: 'layout.nav.useEmbed',
+        descKey: 'scenarioOverview.descriptions.embed',
+        path: '/agent/embed',
+        icon: <IconVector size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'imagegen',
+        labelKey: 'layout.nav.useImageGen',
+        descKey: 'scenarioOverview.descriptions.imagegen',
+        path: '/agent/imagegen',
+        icon: <IconPhoto size={scenarioIconSize} />,
+        hideable: true,
+    },
+    {
+        id: 'agent',
+        labelKey: 'common.openClaw',
+        descKey: 'scenarioOverview.descriptions.agent',
+        path: '/agent/agent',
+        icon: <OpenClaw size={scenarioIconSize} />,
+        hideable: true,
+    },
+];
+
+const STORAGE_KEY = 'scenario.hiddenScenarios';
+const VISIBILITY_EVENT = 'scenario-visibility-change';
+
+const readHidden = (): string[] => {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+    } catch {
+        return [];
+    }
+};
+
+const writeHidden = (ids: string[]) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    window.dispatchEvent(new Event(VISIBILITY_EVENT));
+};
+
+export const getHiddenScenarios = (): Set<string> => new Set(readHidden());
+
+export const useHiddenScenarios = () => {
+    const [hidden, setHidden] = useState<Set<string>>(() => new Set(readHidden()));
+
+    useEffect(() => {
+        const sync = () => setHidden(new Set(readHidden()));
+        window.addEventListener(VISIBILITY_EVENT, sync);
+        window.addEventListener('storage', sync);
+        return () => {
+            window.removeEventListener(VISIBILITY_EVENT, sync);
+            window.removeEventListener('storage', sync);
+        };
+    }, []);
+
+    const isHidden = useCallback((id: string) => hidden.has(id), [hidden]);
+
+    const toggleHidden = useCallback((id: string) => {
+        const next = new Set(readHidden());
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        writeHidden([...next]);
+        setHidden(next);
+    }, []);
+
+    return { hidden, isHidden, toggleHidden };
+};
+
+const AgentOverviewPage: React.FC = () => {
+    const { t } = useTranslation();
+    const navigate = useNavigate();
+    const { isHidden, toggleHidden } = useHiddenScenarios();
+
+    const scenarios = useMemo(() => SCENARIOS, []);
+
+    return (
+        <PageLayout loading={false}>
+            <Box sx={{ maxWidth: 1280, mx: 'auto' }}>
+                <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1 }}>
+                    <IconAiAgents size={28} />
+                    <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                        {t('scenarioOverview.title')}
+                    </Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                    {t('scenarioOverview.subtitle')}
+                </Typography>
+
+                <Grid container spacing={2}>
+                    {scenarios.map((s) => {
+                        const hidden = s.hideable && isHidden(s.id);
+                        return (
+                            <Grid key={s.id} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                                <Card
+                                    variant="outlined"
+                                    sx={{
+                                        opacity: hidden ? 0.55 : 1,
+                                        transition: 'opacity 0.15s, box-shadow 0.15s, transform 0.15s',
+                                        '&:hover': {
+                                            boxShadow: 3,
+                                            transform: 'translateY(-1px)',
+                                        },
+                                    }}
+                                >
+                                    <CardActionArea
+                                        onClick={() => navigate(s.path)}
+                                        sx={{ p: 2 }}
+                                    >
+                                        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1 }}>
+                                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 40, height: 40 }}>
+                                                {s.icon}
+                                            </Box>
+                                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                                                <Stack direction="row" spacing={1} alignItems="center">
+                                                    <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+                                                        {t(s.labelKey)}
+                                                    </Typography>
+                                                    {hidden && (
+                                                        <Chip
+                                                            size="small"
+                                                            label={t('scenarioOverview.hidden')}
+                                                            sx={{ height: 18, fontSize: '0.6875rem' }}
+                                                        />
+                                                    )}
+                                                </Stack>
+                                            </Box>
+                                        </Stack>
+                                        <Typography
+                                            variant="body2"
+                                            color="text.secondary"
+                                            sx={{
+                                                minHeight: 40,
+                                                display: '-webkit-box',
+                                                WebkitLineClamp: 2,
+                                                WebkitBoxOrient: 'vertical',
+                                                overflow: 'hidden',
+                                            }}
+                                        >
+                                            {t(s.descKey)}
+                                        </Typography>
+                                    </CardActionArea>
+                                    <Box
+                                        sx={{
+                                            px: 2,
+                                            py: 1,
+                                            borderTop: '1px solid',
+                                            borderColor: 'divider',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'space-between',
+                                            visibility: s.hideable ? 'visible' : 'hidden',
+                                        }}
+                                    >
+                                        <Typography variant="caption" color="text.secondary">
+                                            {t('scenarioOverview.showInSidebar')}
+                                        </Typography>
+                                        <Switch
+                                            size="small"
+                                            checked={!hidden}
+                                            disabled={!s.hideable}
+                                            onChange={() => toggleHidden(s.id)}
+                                            onClick={(e) => e.stopPropagation()}
+                                        />
+                                    </Box>
+                                </Card>
+                            </Grid>
+                        );
+                    })}
+                </Grid>
+            </Box>
+        </PageLayout>
+    );
+};
+
+export default AgentOverviewPage;

--- a/frontend/src/pages/scenario/AgentOverviewPage.tsx
+++ b/frontend/src/pages/scenario/AgentOverviewPage.tsx
@@ -47,7 +47,7 @@ export const SCENARIOS: ScenarioDescriptor[] = [
         descKey: 'scenarioOverview.descriptions.claude_code',
         path: '/agent/claude_code',
         icon: <Claude size={scenarioIconSize} />,
-        hideable: false,
+        hideable: true,
     },
     {
         id: 'codex',


### PR DESCRIPTION
## Summary
This PR introduces a new Agent Overview page that allows users to browse all available scenarios (agents) and control which ones appear in the sidebar. It includes persistent visibility preferences stored in localStorage and synced across browser tabs.

## Key Changes

- **New AgentOverviewPage component** (`frontend/src/pages/scenario/AgentOverviewPage.tsx`):
  - Displays all 10 scenarios in a responsive grid layout with icons, titles, and descriptions
  - Provides toggle switches to show/hide scenarios from the sidebar
  - Implements `useHiddenScenarios()` hook for managing visibility state with localStorage persistence
  - Exports `ScenarioDescriptor` interface and `SCENARIOS` array for reuse across the app

- **Updated brand icon rendering** (`frontend/src/components/BrandIcons.tsx`):
  - Added theme-aware dark mode support for monochrome SVG icons
  - Monochrome icons now invert in dark mode for proper visibility
  - Added `monochrome` parameter to `createBrandIcon()` factory function
  - Updated all provider icons to use the new monochrome flag

- **Integrated visibility state into sidebar navigation** (`frontend/src/layout/useActivityItems.tsx`):
  - Sidebar now respects hidden scenario preferences
  - Dynamically filters scenario items based on visibility state
  - Listens to visibility change events for real-time updates across tabs

- **Updated Layout and Sidebar components** (`frontend/src/layout/Layout.tsx`, `frontend/src/layout/Sidebar.tsx`):
  - Changed default scenario path from `/agent/claude_code` to `/agent` (the overview page)
  - Added edit button in sidebar header to navigate to overview when in scenario activity
  - Removed per-activity path memory for scenario activity (always opens at overview)
  - Added `headerAction` prop to Sidebar for the edit button

- **Added i18n translations** (`frontend/src/i18n/locales/en.ts`, `frontend/src/i18n/locales/zh.ts`):
  - New `scenarioOverview` namespace with title, subtitle, and descriptions for all 10 scenarios
  - Translations in English and Chinese

- **Updated routing** (`frontend/src/App.tsx`):
  - Added `/agent` route pointing to the new AgentOverviewPage
  - Updated onboarding flow to land on overview instead of claude_code

## Implementation Details

- **Visibility persistence**: Uses localStorage with a custom event system (`scenario-visibility-change`) to sync state across browser tabs and windows
- **Responsive design**: Grid layout adapts from 1 column (mobile) to 4 columns (desktop)
- **Graceful degradation**: Hidden scenarios show reduced opacity and a "Hidden" chip badge
- **Non-destructive**: Hiding a scenario doesn't affect its configuration, only its sidebar visibility

https://claude.ai/code/session_01Xw6WKgdhv6BVqEn5ywKweg

<img width="3024" height="1654" alt="image" src="https://github.com/user-attachments/assets/4b8ed5ad-6782-455e-a67b-d97b1b494a05" />
