### PR TITLE
feat(ui): show MUI tooltip on Base URL / API Key for click-to-copy

### DIFF
--- a/frontend/src/components/CompactConfigCard.tsx
+++ b/frontend/src/components/CompactConfigCard.tsx
@@ -80,14 +80,15 @@ export const CompactConfigCard: React.FC<CompactConfigCardProps> = ({
             key: 'baseUrl',
             label: 'Base URL',
             content: (
-                <Typography
-                    variant="subtitle2"
-                    onClick={() => onCopy(fullUrl, title || baseUrlLabel)}
-                    sx={copyableTextStyle}
-                    title={`Click to copy ${baseUrlLabel}: ${fullUrl}`}
-                >
-                    {fullUrl}
-                </Typography>
+                <Tooltip title={`Click to copy ${baseUrlLabel}`} arrow placement="top">
+                    <Typography
+                        variant="subtitle2"
+                        onClick={() => onCopy(fullUrl, title || baseUrlLabel)}
+                        sx={copyableTextStyle}
+                    >
+                        {fullUrl}
+                    </Typography>
+                </Tooltip>
             ),
             actions: (
                 <EnvironmentModeSwitcher
@@ -101,14 +102,15 @@ export const CompactConfigCard: React.FC<CompactConfigCardProps> = ({
             key: 'apiKey',
             label: 'API Key',
             content: (
-                <Typography
-                    variant="subtitle2"
-                    onClick={() => onCopy(token, apiKeyLabel)}
-                    sx={copyableTextStyle}
-                    title={`Click to copy ${apiKeyLabel}`}
-                >
-                    {maskToken(token)}
-                </Typography>
+                <Tooltip title={`Click to copy ${apiKeyLabel}`} arrow placement="top">
+                    <Typography
+                        variant="subtitle2"
+                        onClick={() => onCopy(token, apiKeyLabel)}
+                        sx={copyableTextStyle}
+                    >
+                        {maskToken(token)}
+                    </Typography>
+                </Tooltip>
             ),
             actions: (
                 <Tooltip title="View Full Token">

--- a/frontend/src/components/ProviderConfigCard.tsx
+++ b/frontend/src/components/ProviderConfigCard.tsx
@@ -141,14 +141,15 @@ export const ProviderConfigCard: React.FC<ProviderConfigCardProps> = ({
                                 key: 'baseUrl',
                                 label: baseUrlLabel,
                                 content: (
-                                    <Typography
-                                        variant="subtitle2"
-                                        onClick={() => onCopy(fullUrl, `${title} ${baseUrlLabel}`)}
-                                        sx={copyableTextStyle}
-                                        title={`Click to copy ${baseUrlLabel}`}
-                                    >
-                                        {fullUrl}
-                                    </Typography>
+                                    <Tooltip title={`Click to copy ${baseUrlLabel}`} arrow placement="top">
+                                        <Typography
+                                            variant="subtitle2"
+                                            onClick={() => onCopy(fullUrl, `${title} ${baseUrlLabel}`)}
+                                            sx={copyableTextStyle}
+                                        >
+                                            {fullUrl}
+                                        </Typography>
+                                    </Tooltip>
                                 ),
                                 actions: (
                                     <EnvironmentModeSwitcher
@@ -173,14 +174,15 @@ export const ProviderConfigCard: React.FC<ProviderConfigCardProps> = ({
                                 key: 'apiKey',
                                 label: 'API Key',
                                 content: (
-                                    <Typography
-                                        variant="subtitle2"
-                                        onClick={() => onCopy(token, 'API Key')}
-                                        sx={copyableTextStyle}
-                                        title="Click to copy API Key"
-                                    >
-                                        {maskToken(token)}
-                                    </Typography>
+                                    <Tooltip title="Click to copy API Key" arrow placement="top">
+                                        <Typography
+                                            variant="subtitle2"
+                                            onClick={() => onCopy(token, 'API Key')}
+                                            sx={copyableTextStyle}
+                                        >
+                                            {maskToken(token)}
+                                        </Typography>
+                                    </Tooltip>
                                 ),
                                 actions: (
                                     <Tooltip title="View Full Token">


### PR DESCRIPTION
## Summary

On every `Use xxx` scenario page, the header renders Base URL / API Key
through the unified `ConfigRow` component (via `ProviderConfigCard` in
standard mode and `CompactConfigCard` in compact mode). The whole text
is already clickable to copy, but the affordance was hidden behind the
native HTML `title` attribute — users frequently did not realize they
could just click to copy.

This PR replaces the native `title` with a MUI `<Tooltip arrow placement="top">`
on both the Base URL and API Key rows in both card variants, so a
clearly-styled "Click to copy …" hint pops up immediately on hover.

## Changes

- `frontend/src/components/ProviderConfigCard.tsx` — wrap Base URL and API Key Typography in MUI `Tooltip`
- `frontend/src/components/CompactConfigCard.tsx` — same change for the compact variant

No behavior change beyond the hover hint; click-to-copy logic is
untouched. Unused components `BaseUrlRow.tsx` / `ApiConfigRow.tsx`
were left alone.

## Test plan

- [ ] Open an Anthropic / OpenAI / Codex / VSCode / ClaudeCode `Use xxx` page
- [ ] Hover over the Base URL — verify the MUI tooltip "Click to copy Base URL" appears immediately with an arrow
- [ ] Click the Base URL — verify it copies and the success snackbar shows
- [ ] Hover over the API Key — verify "Click to copy API Key" tooltip
- [ ] Click the API Key — verify it copies the masked-token value
- [ ] Switch a page that uses compact mode (e.g. ClaudeCodeProfilePage) and repeat the hover/copy checks for both tabs