### PR TITLE
Discuss: try to fix opencode deepseek

### DIFF
--- a/internal/protocol/request/openai_responses_to_chat.go
+++ b/internal/protocol/request/openai_responses_to_chat.go
@@ -61,10 +61,28 @@ func ConvertOpenAIResponsesToChat(params *responses.ResponseNewParams, defaultMa
 // ConvertResponsesInputToMessages converts Responses API input items to Chat Completion messages.
 func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []openai.ChatCompletionMessageParamUnion {
 	var messages []openai.ChatCompletionMessageParamUnion
+	var pendingToolCalls []map[string]interface{}
+
+	flushPendingToolCalls := func() {
+		if len(pendingToolCalls) == 0 {
+			return
+		}
+		msgMap := map[string]interface{}{
+			"role":       "assistant",
+			"content":    "",
+			"tool_calls": pendingToolCalls,
+		}
+		msgBytes, _ := json.Marshal(msgMap)
+		var result openai.ChatCompletionMessageParamUnion
+		_ = json.Unmarshal(msgBytes, &result)
+		messages = append(messages, result)
+		pendingToolCalls = nil
+	}
 
 	for _, item := range items {
 		// Handle message items
 		if !param.IsOmitted(item.OfMessage) {
+			flushPendingToolCalls()
 			msg := item.OfMessage
 			role := string(msg.Role)
 
@@ -135,7 +153,6 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 		if !param.IsOmitted(item.OfFunctionCall) {
 			fnCall := item.OfFunctionCall
 
-			// Create assistant message with tool_calls
 			toolCallMap := map[string]interface{}{
 				"id":   fnCall.CallID,
 				"type": "function",
@@ -145,21 +162,13 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 				},
 			}
 
-			msgMap := map[string]interface{}{
-				"role":       "assistant",
-				"content":    "",
-				"tool_calls": []map[string]interface{}{toolCallMap},
-			}
-
-			msgBytes, _ := json.Marshal(msgMap)
-			var result openai.ChatCompletionMessageParamUnion
-			_ = json.Unmarshal(msgBytes, &result)
-			messages = append(messages, result)
+			pendingToolCalls = append(pendingToolCalls, toolCallMap)
 			continue
 		}
 
 		// Handle function call output items (tool results)
 		if !param.IsOmitted(item.OfFunctionCallOutput) {
+			flushPendingToolCalls()
 			output := item.OfFunctionCallOutput
 
 			// Extract output content
@@ -181,6 +190,8 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 			messages = append(messages, result)
 		}
 	}
+
+	flushPendingToolCalls()
 
 	return messages
 }

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -180,9 +180,9 @@ func handleOpenAIToAnthropicStreamResponse(
 
 		choice := chunk.Choices[0]
 
-		logrus.Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
-			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason)
+		//logrus.Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
+		//	chunkCount, len(chunk.Choices),
+		//	choice.Delta.Content, choice.FinishReason)
 
 		// Log first few chunks in detail for debugging
 		if chunkCount <= 5 || choice.FinishReason != "" {
@@ -581,8 +581,8 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				logrus.Debugf("[Thinking][ResponsesAPI] Initializing thinking block at index %d", state.thinkingBlockIndex)
 				senders.SendContentBlockStart(state.thinkingBlockIndex, blockTypeThinking, map[string]interface{}{"thinking": ""}, flusher)
 			}
-			preview := reasoningDelta.Delta
-			logrus.Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
+			//preview := reasoningDelta.Delta
+			//logrus.Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
 			senders.SendContentBlockDelta(state.thinkingBlockIndex, map[string]interface{}{
 				"type":     deltaTypeThinkingDelta,
 				"thinking": reasoningDelta.Delta,
@@ -658,8 +658,8 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 					logrus.Debugf("[Thinking][ResponsesAPI] Initializing thinking block at index %d", state.thinkingBlockIndex)
 					senders.SendContentBlockStart(state.thinkingBlockIndex, blockTypeThinking, map[string]interface{}{"thinking": ""}, flusher)
 				}
-				preview := reasoningDelta.Delta
-				logrus.Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
+				//preview := reasoningDelta.Delta
+				//logrus.Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
 				senders.SendContentBlockDelta(state.thinkingBlockIndex, map[string]interface{}{
 					"type":     deltaTypeThinkingDelta,
 					"thinking": reasoningDelta.Delta,

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -163,9 +163,9 @@ func handleOpenAIToAnthropicBetaStream(
 
 		choice := chunk.Choices[0]
 
-		logrus.Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
-			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason)
+		//logrus.Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
+		//	chunkCount, len(chunk.Choices),
+		//	choice.Delta.Content, choice.FinishReason)
 
 		delta := choice.Delta
 
@@ -200,8 +200,8 @@ func handleOpenAIToAnthropicBetaStream(
 					// Extract thinking content (handle different types)
 					thinkingText := extractString(v)
 					if thinkingText != "" {
-						preview := thinkingText
-						logrus.Debugf("[Thinking] Sending thinking_delta: len=%d, preview=%q", len(thinkingText), preview)
+						//preview := thinkingText
+						//logrus.Debugf("[Thinking] Sending thinking_delta: len=%d, preview=%q", len(thinkingText), preview)
 						// Send content_block_delta with thinking_delta
 						ensureMessageStart()
 						sendContentBlockDelta(c, state.thinkingBlockIndex, map[string]interface{}{

--- a/internal/protocol/transform/ops/request_openai_deepseek.go
+++ b/internal/protocol/transform/ops/request_openai_deepseek.go
@@ -17,21 +17,33 @@ func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, mo
 	//if config.HasThinking {
 	for i := range req.Messages {
 		if req.Messages[i].OfAssistant != nil {
-			// Convert the message to map to check/modify fields
-			msgMap := req.Messages[i].ExtraFields()
-			if msgMap == nil {
-				msgMap = map[string]any{}
+			// Anthropic -> OpenAI conversion stores x_thinking on the union as
+			// internal metadata, but ChatCompletionMessageParamUnion marshals
+			// only its concrete OfAssistant variant when present.
+			unionExtra := req.Messages[i].ExtraFields()
+			assistantExtra := req.Messages[i].OfAssistant.ExtraFields()
+
+			// Preserve existing assistant-level extras; these are the fields
+			// that actually reach the provider in the final JSON payload.
+			msgMap := map[string]any{}
+			for k, v := range assistantExtra {
+				msgMap[k] = v
+			}
+
+			thinking, hasThinking := unionExtra["x_thinking"]
+			if !hasThinking {
+				thinking, hasThinking = assistantExtra["x_thinking"]
 			}
 
 			// Extract x_thinking and convert to reasoning_content
-			if thinking, hasThinking := msgMap["x_thinking"]; hasThinking {
+			if hasThinking {
 				// Convert x_thinking to reasoning_content
 				if thinkingStr, ok := thinking.(string); ok {
 					msgMap["reasoning_content"] = thinkingStr
 				}
 				// Remove x_thinking field
 				delete(msgMap, "x_thinking")
-			} else {
+			} else if _, hasReasoning := msgMap["reasoning_content"]; !hasReasoning {
 				// Ensure reasoning_content field exists even if no thinking content
 				// Use a placeholder (empty pointer) instead of empty string to ensure it's included in JSON
 				var emptyStr string

--- a/internal/protocol/transform/ops/request_openai_deepseek.go
+++ b/internal/protocol/transform/ops/request_openai_deepseek.go
@@ -38,8 +38,9 @@ func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, mo
 				msgMap["reasoning_content"] = &emptyStr
 			}
 
-			// Convert back to message param
-			req.Messages[i].SetExtraFields(msgMap)
+			// ChatCompletionMessageParamUnion marshals the concrete assistant variant,
+			// so provider-specific extras must live on OfAssistant to reach the wire.
+			req.Messages[i].OfAssistant.SetExtraFields(msgMap)
 		}
 	}
 	//}

--- a/internal/protocol/transform/ops/request_openai_deepseek_test.go
+++ b/internal/protocol/transform/ops/request_openai_deepseek_test.go
@@ -1,0 +1,76 @@
+package ops
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+func TestDeepSeekTransformWritesReasoningContentToAssistantVariant(t *testing.T) {
+	msg := assistantToolCallMessage(t)
+
+	// The SDK marshals the concrete OfAssistant variant, so union-level extras
+	// are ignored when OfAssistant is present.
+	msg.SetExtraFields(map[string]any{"reasoning_content": "ignored"})
+	raw := marshalMessage(t, msg)
+	_, hasReasoning := raw["reasoning_content"]
+	require.False(t, hasReasoning, "union-level reasoning_content should not be serialized")
+
+	// Anthropic -> OpenAI conversion preserves thinking on the union, which the
+	// DeepSeek transform must move to the assistant variant before forwarding.
+	msg.OfAssistant.SetExtraFields(map[string]any{"vendor_marker": "keep"})
+	msg.SetExtraFields(map[string]any{"x_thinking": "tool planning"})
+	req := &openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel("deepseek-v4-flash"),
+		Messages: []openai.ChatCompletionMessageParamUnion{msg},
+	}
+
+	ApplyProviderTransforms(req, "https://opencode.ai/zen/go/v1", string(req.Model), &protocol.OpenAIConfig{})
+
+	raw = marshalMessage(t, req.Messages[0])
+	assert.Equal(t, "tool planning", raw["reasoning_content"])
+	assert.Equal(t, "keep", raw["vendor_marker"])
+	assert.NotContains(t, raw, "x_thinking")
+}
+
+func assistantToolCallMessage(t *testing.T) openai.ChatCompletionMessageParamUnion {
+	t.Helper()
+
+	msgMap := map[string]any{
+		"role":    "assistant",
+		"content": "",
+		"tool_calls": []map[string]any{
+			{
+				"id":   "call_123",
+				"type": "function",
+				"function": map[string]any{
+					"name":      "lookup",
+					"arguments": `{"q":"hello"}`,
+				},
+			},
+		},
+	}
+
+	msgBytes, err := json.Marshal(msgMap)
+	require.NoError(t, err)
+
+	var msg openai.ChatCompletionMessageParamUnion
+	require.NoError(t, json.Unmarshal(msgBytes, &msg))
+	require.NotNil(t, msg.OfAssistant)
+	return msg
+}
+
+func marshalMessage(t *testing.T, msg openai.ChatCompletionMessageParamUnion) map[string]any {
+	t.Helper()
+
+	msgBytes, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(msgBytes, &raw))
+	return raw
+}

--- a/internal/protocol/transform/ops/request_openai_extensions.go
+++ b/internal/protocol/transform/ops/request_openai_extensions.go
@@ -28,6 +28,13 @@ var ProviderConfigs = []providerConfig{
 		Transform:      applyDeepSeekTransform,
 	},
 
+	// OpenCode Go - backed by DeepSeek-compatible reasoning models.
+	{
+		APIBasePattern: "opencode.ai/zen/go",
+		ModelPattern:   "*",
+		Transform:      applyDeepSeekTransform,
+	},
+
 	// Moonshot - official API (CN)
 	// Moonshot requires reasoning_content in assistant messages with tool_calls when thinking is enabled
 	// Similar to DeepSeek, we reuse applyDeepSeekTransform to handle x_thinking -> reasoning_content conversion


### PR DESCRIPTION
**问题 1：DeepSeek thinking mode 要求 `reasoning_content` 回传**

现象：

```text
Error from provider (DeepSeek): The `reasoning_content` in the thinking mode must be passed back to the API.
```

定位到 OpenAI SDK 的序列化行为：`ChatCompletionMessageParamUnion` 有 `OfAssistant` variant 时，只序列化 `OfAssistant`，所以把 extra fields 写在 union 上不会出现在最终 JSON 里。

修复逻辑：

- 在 `tingly-box/internal/protocol/transform/ops/request_openai_extensions.go:31` 增加 `opencode.ai/zen/go` 走 `applyDeepSeekTransform`。
- 在 `tingly-box/internal/protocol/transform/ops/request_openai_deepseek.go:56` 把 `reasoning_content` 写到 `req.Messages[i].OfAssistant.SetExtraFields(...)`，而不是 `req.Messages[i].SetExtraFields(...)`。
- 这样最终 wire JSON 里才会带上 `reasoning_content`。

这个修复没有改大逻辑，也没有动 `consistency.go`；本质是 provider 匹配 + SDK extra fields 写入位置错误。

**问题 2：Responses→Chat 后 tool_calls 顺序非法**

现象：

```text
An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.
```

日志显示问题不是 tool result 丢失，而是 Chat message 结构非法：

```text
index 6 assistant call_00_hCA...
index 7 assistant call_01_tR...
index 8 assistant call_02_VI...
index 8 后面才跟三个 tool result
```

DeepSeek/OpenAI Chat 规则要求：带 `tool_calls` 的 assistant message 后面必须立刻跟对应 `tool` messages。当前结构等价于：

```text
assistant(call A)
assistant(call B)
assistant(call C)
tool(A)
tool(B)
tool(C)
```

这是非法的，因为 `assistant(call A)` 后面不是 `tool(A)`。

修复逻辑：

- 修复点放在 `tingly-box/internal/protocol/request/openai_responses_to_chat.go:64`。
- 遍历 Responses input 时，连续遇到 `function_call` 不立即 append assistant message。
- 先缓存在 `pendingToolCalls`。
- 遇到第一个非 `function_call`，尤其是 `function_call_output`，先 flush 成一个 assistant message，里面包含多个 `tool_calls`。
- 然后正常追加多个 `tool` messages。

修复后的结构是合法的：

```text
assistant(call A, call B, call C)
tool(A)
tool(B)
tool(C)
```

这个也没有动 `consistency.go`，只是修正 Responses API 历史映射到 Chat Completions 历史时的分组方式。