### PR TITLE
refactor(ui): provider browsing UI with regional grouping and improved styling

### DIFF
--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -72,13 +72,15 @@ const gridSx = {
 interface SectionHeaderProps {
     icon: React.ReactNode;
     title: string;
-    count: number;
-    accent: 'global' | 'cn';
+    count?: number;
+    accent: 'global' | 'cn' | 'custom';
 }
 
 const SectionHeader: React.FC<SectionHeaderProps> = ({icon, title, count, accent}) => {
-    const accentColor = accent === 'cn' ? 'error.main' : 'primary.main';
-    const accentBg = accent === 'cn' ? 'error.50' : 'primary.50';
+    const accentColor =
+        accent === 'cn' ? 'error.main' : accent === 'custom' ? 'secondary.main' : 'primary.main';
+    const accentBg =
+        accent === 'cn' ? 'error.50' : accent === 'custom' ? 'secondary.50' : 'primary.50';
     return (
         <Stack
             direction="row"
@@ -109,18 +111,20 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({icon, title, count, accent
             <Typography variant="subtitle1" fontWeight={700} sx={{color: 'text.primary'}}>
                 {title}
             </Typography>
-            <Chip
-                label={count}
-                size="small"
-                sx={{
-                    height: 20,
-                    fontSize: '0.7rem',
-                    fontWeight: 600,
-                    bgcolor: accentBg,
-                    color: accentColor,
-                    border: 'none',
-                }}
-            />
+            {typeof count === 'number' && (
+                <Chip
+                    label={count}
+                    size="small"
+                    sx={{
+                        height: 20,
+                        fontSize: '0.7rem',
+                        fontWeight: 600,
+                        bgcolor: accentBg,
+                        color: accentColor,
+                        border: 'none',
+                    }}
+                />
+            )}
         </Stack>
     );
 };
@@ -287,8 +291,7 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
         });
     };
 
-    const totalMatched = filtered.length;
-    const isEmpty = totalMatched === 0;
+    const isEmpty = filtered.length === 0;
 
     return (
         <Box>
@@ -313,54 +316,54 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                 />
             </Box>
 
-            {isEmpty ? (
-                <Box sx={gridSx}>
-                    <CustomProviderCard onPick={() => onPick(emptyForm())}/>
-                    <Box sx={{py: 6, textAlign: 'center', gridColumn: '1 / -1'}}>
-                        <Typography variant="body2" color="text.secondary">
-                            {t('onboarding.browse.empty', {defaultValue: 'No providers match your search.'})}
-                        </Typography>
-                    </Box>
-                </Box>
-            ) : (
+            {chinaProviders.length > 0 && (
                 <>
-                    {globalProviders.length > 0 && (
-                        <>
-                            <SectionHeader
-                                icon={<PublicIcon sx={{fontSize: 18}}/>}
-                                title={t('onboarding.browse.section.global', {defaultValue: 'Global'})}
-                                count={globalProviders.length}
-                                accent="global"
-                            />
-                            <Box sx={gridSx}>
-                                <CustomProviderCard onPick={() => onPick(emptyForm())}/>
-                                {globalProviders.map(p => (
-                                    <ProviderCard key={p.id} provider={p} onPick={handlePick}/>
-                                ))}
-                            </Box>
-                        </>
-                    )}
-
-                    {chinaProviders.length > 0 && (
-                        <>
-                            <SectionHeader
-                                icon={<LocationOnIcon sx={{fontSize: 18}}/>}
-                                title={t('onboarding.browse.section.china', {defaultValue: 'China (Mainland)'})}
-                                count={chinaProviders.length}
-                                accent="cn"
-                            />
-                            <Box sx={gridSx}>
-                                {globalProviders.length === 0 && (
-                                    <CustomProviderCard onPick={() => onPick(emptyForm())}/>
-                                )}
-                                {chinaProviders.map(p => (
-                                    <ProviderCard key={p.id} provider={p} onPick={handlePick}/>
-                                ))}
-                            </Box>
-                        </>
-                    )}
+                    <SectionHeader
+                        icon={<LocationOnIcon sx={{fontSize: 18}}/>}
+                        title={t('onboarding.browse.section.china', {defaultValue: 'China (Mainland)'})}
+                        count={chinaProviders.length}
+                        accent="cn"
+                    />
+                    <Box sx={gridSx}>
+                        {chinaProviders.map(p => (
+                            <ProviderCard key={p.id} provider={p} onPick={handlePick}/>
+                        ))}
+                    </Box>
                 </>
             )}
+
+            {globalProviders.length > 0 && (
+                <>
+                    <SectionHeader
+                        icon={<PublicIcon sx={{fontSize: 18}}/>}
+                        title={t('onboarding.browse.section.global', {defaultValue: 'Global'})}
+                        count={globalProviders.length}
+                        accent="global"
+                    />
+                    <Box sx={gridSx}>
+                        {globalProviders.map(p => (
+                            <ProviderCard key={p.id} provider={p} onPick={handlePick}/>
+                        ))}
+                    </Box>
+                </>
+            )}
+
+            {isEmpty && (
+                <Box sx={{py: 6, textAlign: 'center'}}>
+                    <Typography variant="body2" color="text.secondary">
+                        {t('onboarding.browse.empty', {defaultValue: 'No providers match your search.'})}
+                    </Typography>
+                </Box>
+            )}
+
+            <SectionHeader
+                icon={<AddIcon sx={{fontSize: 18}}/>}
+                title={t('onboarding.browse.section.custom', {defaultValue: 'Custom'})}
+                accent="custom"
+            />
+            <Box sx={gridSx}>
+                <CustomProviderCard onPick={() => onPick(emptyForm())}/>
+            </Box>
         </Box>
     );
 };

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -316,6 +316,15 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                 />
             </Box>
 
+            <SectionHeader
+                icon={<AddIcon sx={{fontSize: 18}}/>}
+                title={t('onboarding.browse.section.custom', {defaultValue: 'Custom'})}
+                accent="custom"
+            />
+            <Box sx={gridSx}>
+                <CustomProviderCard onPick={() => onPick(emptyForm())}/>
+            </Box>
+
             {chinaProviders.length > 0 && (
                 <>
                     <SectionHeader
@@ -355,15 +364,6 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                     </Typography>
                 </Box>
             )}
-
-            <SectionHeader
-                icon={<AddIcon sx={{fontSize: 18}}/>}
-                title={t('onboarding.browse.section.custom', {defaultValue: 'Custom'})}
-                accent="custom"
-            />
-            <Box sx={gridSx}>
-                <CustomProviderCard onPick={() => onPick(emptyForm())}/>
-            </Box>
         </Box>
     );
 };

--- a/frontend/src/components/onboarding/BrowseProviders.tsx
+++ b/frontend/src/components/onboarding/BrowseProviders.tsx
@@ -15,6 +15,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import LanguageIcon from '@mui/icons-material/Language';
 import DescriptionIcon from '@mui/icons-material/Description';
 import AddIcon from '@mui/icons-material/Add';
+import PublicIcon from '@mui/icons-material/Public';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
 import ProviderIcon from '@/components/ProviderIcon';
 import {useProviderTemplates, type UniqueProvider} from '@/services/serviceProviders';
 import type {EnhancedProviderFormData} from '@/components/ProviderFormDialog';
@@ -34,24 +36,97 @@ const emptyForm = (): EnhancedProviderFormData => ({
     proxyUrl: '',
 });
 
-// Common card styles to ensure consistent dimensions
+const CARD_HEIGHT = 84;
+
 const cardSx = {
     borderRadius: 2,
-    height: 80,
+    height: CARD_HEIGHT,
     display: 'flex',
     flexDirection: 'column' as const,
+    transition: 'transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: 4,
+        borderColor: 'primary.light',
+    },
 };
 
 const cardActionAreaSx = {
-    height: 80,
+    height: CARD_HEIGHT,
     p: 1.5,
     display: 'flex',
     alignItems: 'center',
 };
 
-// Custom provider card component
-const CustomProviderCard: React.FC<{ onPick: () => void }> = ({ onPick }) => {
-    const { t } = useTranslation();
+const gridSx = {
+    display: 'grid',
+    gap: 1.5,
+    gridTemplateColumns: {
+        xs: '1fr',
+        sm: 'repeat(2, 1fr)',
+        md: 'repeat(3, 1fr)',
+        xl: 'repeat(4, 1fr)',
+    },
+};
+
+interface SectionHeaderProps {
+    icon: React.ReactNode;
+    title: string;
+    count: number;
+    accent: 'global' | 'cn';
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({icon, title, count, accent}) => {
+    const accentColor = accent === 'cn' ? 'error.main' : 'primary.main';
+    const accentBg = accent === 'cn' ? 'error.50' : 'primary.50';
+    return (
+        <Stack
+            direction="row"
+            alignItems="center"
+            spacing={1.25}
+            sx={{
+                mt: 2.5,
+                mb: 1.5,
+                pb: 1,
+                borderBottom: 1,
+                borderColor: 'divider',
+            }}
+        >
+            <Box
+                sx={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: '50%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    bgcolor: accentBg,
+                    color: accentColor,
+                }}
+            >
+                {icon}
+            </Box>
+            <Typography variant="subtitle1" fontWeight={700} sx={{color: 'text.primary'}}>
+                {title}
+            </Typography>
+            <Chip
+                label={count}
+                size="small"
+                sx={{
+                    height: 20,
+                    fontSize: '0.7rem',
+                    fontWeight: 600,
+                    bgcolor: accentBg,
+                    color: accentColor,
+                    border: 'none',
+                }}
+            />
+        </Stack>
+    );
+};
+
+const CustomProviderCard: React.FC<{onPick: () => void}> = ({onPick}) => {
+    const {t} = useTranslation();
     return (
         <Card
             variant="outlined"
@@ -60,23 +135,108 @@ const CustomProviderCard: React.FC<{ onPick: () => void }> = ({ onPick }) => {
                 borderStyle: 'dashed',
                 borderColor: 'primary.main',
                 bgcolor: 'primary.50',
-                transition: 'all 0.2s',
                 '&:hover': {
                     bgcolor: 'primary.100',
                     borderColor: 'primary.dark',
+                    transform: 'translateY(-2px)',
+                    boxShadow: 4,
                 },
             }}
         >
             <CardActionArea onClick={onPick} sx={cardActionAreaSx}>
                 <Stack direction="row" spacing={1.5} alignItems="center" width="100%">
-                    <AddIcon sx={{ color: 'primary.main', fontSize: 32 }} />
-                    <Typography
-                        variant="subtitle2"
-                        fontWeight={600}
-                        color="primary.main"
+                    <Box
+                        sx={{
+                            width: 32,
+                            height: 32,
+                            borderRadius: 1,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            bgcolor: 'primary.main',
+                            color: 'primary.contrastText',
+                        }}
                     >
-                        {t('onboarding.browse.customProvider', { defaultValue: 'Custom Provider' })}
-                    </Typography>
+                        <AddIcon sx={{fontSize: 22}}/>
+                    </Box>
+                    <Box sx={{minWidth: 0, flex: 1}}>
+                        <Typography variant="subtitle2" fontWeight={700} color="primary.main" noWrap>
+                            {t('onboarding.browse.customProvider', {defaultValue: 'Custom Provider'})}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary" noWrap>
+                            {t('onboarding.browse.customProviderHint', {defaultValue: 'Bring your own endpoint'})}
+                        </Typography>
+                    </Box>
+                </Stack>
+            </CardActionArea>
+        </Card>
+    );
+};
+
+interface ProviderCardProps {
+    provider: UniqueProvider;
+    onPick: (p: UniqueProvider) => void;
+}
+
+const ProviderCard: React.FC<ProviderCardProps> = ({provider: p, onPick}) => {
+    return (
+        <Card variant="outlined" sx={cardSx}>
+            <CardActionArea onClick={() => onPick(p)} sx={cardActionAreaSx}>
+                <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between" width="100%">
+                    <Stack direction="row" spacing={1.5} alignItems="center" sx={{minWidth: 0, flex: 1}}>
+                        <ProviderIcon identifier={p.icon || p.id} size={32}/>
+                        <Box sx={{minWidth: 0, flex: 1}}>
+                            <Typography
+                                variant="subtitle2"
+                                fontWeight={600}
+                                sx={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: 2,
+                                    WebkitBoxOrient: 'vertical',
+                                    lineHeight: 1.3,
+                                }}
+                                title={p.alias || p.name}
+                            >
+                                {p.alias || p.name}
+                            </Typography>
+                            <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
+                                {p.supportsOpenAI && (
+                                    <Chip label="OpenAI" size="small" sx={{height: 18, fontSize: '0.65rem'}}/>
+                                )}
+                                {p.supportsAnthropic && (
+                                    <Chip label="Anthropic" size="small" sx={{height: 18, fontSize: '0.65rem'}}/>
+                                )}
+                            </Stack>
+                        </Box>
+                    </Stack>
+                    <Stack direction="row" spacing={0.3}>
+                        {p.website && (
+                            <IconButton
+                                size="small"
+                                href={p.website}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Official Website"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                <LanguageIcon fontSize="small"/>
+                            </IconButton>
+                        )}
+                        {p.apiDoc && (
+                            <IconButton
+                                size="small"
+                                href={p.apiDoc}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="API Documentation"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                <DescriptionIcon fontSize="small"/>
+                            </IconButton>
+                        )}
+                    </Stack>
                 </Stack>
             </CardActionArea>
         </Card>
@@ -96,6 +256,16 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
             return haystack.includes(term);
         });
     }, [providers, search]);
+
+    const {globalProviders, chinaProviders} = useMemo(() => {
+        const g: UniqueProvider[] = [];
+        const c: UniqueProvider[] = [];
+        for (const p of filtered) {
+            if (p.region === 'cn') c.push(p);
+            else g.push(p);
+        }
+        return {globalProviders: g, chinaProviders: c};
+    }, [filtered]);
 
     const handlePick = (p: UniqueProvider) => {
         const apiStyle: 'openai' | 'anthropic' = p.supportsOpenAI ? 'openai' : 'anthropic';
@@ -117,9 +287,12 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
         });
     };
 
+    const totalMatched = filtered.length;
+    const isEmpty = totalMatched === 0;
+
     return (
         <Box>
-            <Box sx={{mb: 2}}>
+            <Box sx={{mb: 1}}>
                 <TextField
                     size="small"
                     fullWidth
@@ -132,103 +305,62 @@ const BrowseProviders: React.FC<BrowseProvidersProps> = ({onPick}) => {
                                 <SearchIcon fontSize="small"/>
                             </InputAdornment>
                         ),
+                        sx: {
+                            borderRadius: 2,
+                            bgcolor: 'background.paper',
+                        },
                     }}
                 />
             </Box>
 
-            <Box
-                sx={{
-                    display: 'grid',
-                    gap: 1.5,
-                    gridTemplateColumns: {
-                        xs: '1fr',
-                        sm: 'repeat(2, 1fr)',
-                        md: 'repeat(3, 1fr)',
-                        xl: 'repeat(4, 1fr)',
-                    },
-                }}
-            >
-                {/* Custom provider card - always visible, even when no providers match search */}
-                <CustomProviderCard onPick={() => onPick(emptyForm())} />
-                {filtered.length === 0 ? (
+            {isEmpty ? (
+                <Box sx={gridSx}>
+                    <CustomProviderCard onPick={() => onPick(emptyForm())}/>
                     <Box sx={{py: 6, textAlign: 'center', gridColumn: '1 / -1'}}>
                         <Typography variant="body2" color="text.secondary">
-                            {t('onboarding.browse.empty', {defaultValue: 'No providers match your filters.'})}
+                            {t('onboarding.browse.empty', {defaultValue: 'No providers match your search.'})}
                         </Typography>
                     </Box>
-                ) : (
-                    filtered.map(p => (
-                        <Card key={p.id} variant="outlined" sx={cardSx}>
-                            <CardActionArea onClick={() => handlePick(p)} sx={cardActionAreaSx}>
-                                <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between" width="100%">
-                                    <Stack direction="row" spacing={1.5} alignItems="center">
-                                        <ProviderIcon identifier={p.icon || p.id} size={32}/>
-                                        <Box sx={{minWidth: 0, flex: 1}}>
-                                            <Typography
-                                                variant="subtitle2"
-                                                fontWeight={600}
-                                                sx={{
-                                                    overflow: 'hidden',
-                                                    textOverflow: 'ellipsis',
-                                                    display: '-webkit-box',
-                                                    WebkitLineClamp: 2,
-                                                    WebkitBoxOrient: 'vertical',
-                                                    lineHeight: 1.3,
-                                                }}
-                                                title={p.alias || p.name}
-                                            >
-                                                {p.alias || p.name}
-                                            </Typography>
-                                            <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
-                                                {p.supportsOpenAI && (
-                                                    <Chip
-                                                        label="OpenAI"
-                                                        size="small"
-                                                        sx={{height: 18, fontSize: '0.65rem'}}
-                                                    />
-                                                )}
-                                                {p.supportsAnthropic && (
-                                                    <Chip
-                                                        label="Anthropic"
-                                                        size="small"
-                                                        sx={{height: 18, fontSize: '0.65rem'}}
-                                                    />
-                                                )}
-                                            </Stack>
-                                        </Box>
-                                    </Stack>
-                                    <Stack direction="row" spacing={0.3}>
-                                        {p.website && (
-                                            <IconButton
-                                                size="small"
-                                                href={p.website}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                title="Official Website"
-                                                onClick={(e) => e.stopPropagation()}
-                                            >
-                                                <LanguageIcon fontSize="small" />
-                                            </IconButton>
-                                        )}
-                                        {p.apiDoc && (
-                                            <IconButton
-                                                size="small"
-                                                href={p.apiDoc}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                title="API Documentation"
-                                                onClick={(e) => e.stopPropagation()}
-                                            >
-                                                <DescriptionIcon fontSize="small" />
-                                            </IconButton>
-                                        )}
-                                    </Stack>
-                                </Stack>
-                            </CardActionArea>
-                        </Card>
-                    ))
-                )}
-            </Box>
+                </Box>
+            ) : (
+                <>
+                    {globalProviders.length > 0 && (
+                        <>
+                            <SectionHeader
+                                icon={<PublicIcon sx={{fontSize: 18}}/>}
+                                title={t('onboarding.browse.section.global', {defaultValue: 'Global'})}
+                                count={globalProviders.length}
+                                accent="global"
+                            />
+                            <Box sx={gridSx}>
+                                <CustomProviderCard onPick={() => onPick(emptyForm())}/>
+                                {globalProviders.map(p => (
+                                    <ProviderCard key={p.id} provider={p} onPick={handlePick}/>
+                                ))}
+                            </Box>
+                        </>
+                    )}
+
+                    {chinaProviders.length > 0 && (
+                        <>
+                            <SectionHeader
+                                icon={<LocationOnIcon sx={{fontSize: 18}}/>}
+                                title={t('onboarding.browse.section.china', {defaultValue: 'China (Mainland)'})}
+                                count={chinaProviders.length}
+                                accent="cn"
+                            />
+                            <Box sx={gridSx}>
+                                {globalProviders.length === 0 && (
+                                    <CustomProviderCard onPick={() => onPick(emptyForm())}/>
+                                )}
+                                {chinaProviders.map(p => (
+                                    <ProviderCard key={p.id} provider={p} onPick={handlePick}/>
+                                ))}
+                            </Box>
+                        </>
+                    )}
+                </>
+            )}
         </Box>
     );
 };

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -841,7 +841,8 @@ export default {
       "customProviderHint": "Bring your own endpoint",
       "section": {
         "global": "Global",
-        "china": "China (Mainland)"
+        "china": "China (Mainland)",
+        "custom": "Custom"
       }
     },
     "paste": {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -836,7 +836,13 @@ export default {
     "browse": {
       "searchPlaceholder": "Search providers",
       "empty": "No providers match your search.",
-      "selectProvider": "Select this provider"
+      "selectProvider": "Select this provider",
+      "customProvider": "Custom Provider",
+      "customProviderHint": "Bring your own endpoint",
+      "section": {
+        "global": "Global",
+        "china": "China (Mainland)"
+      }
     },
     "paste": {
       "detectButton": "Detect",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -841,7 +841,8 @@ export default {
       "customProviderHint": "使用自定义接入地址",
       "section": {
         "global": "国际",
-        "china": "中国大陆"
+        "china": "中国大陆",
+        "custom": "自定义"
       }
     },
     "paste": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -836,7 +836,13 @@ export default {
     "browse": {
       "searchPlaceholder": "搜索提供商",
       "empty": "没有匹配的提供商。",
-      "selectProvider": "选择此提供商"
+      "selectProvider": "选择此提供商",
+      "customProvider": "自定义提供商",
+      "customProviderHint": "使用自定义接入地址",
+      "section": {
+        "global": "国际",
+        "china": "中国大陆"
+      }
     },
     "paste": {
       "detectButton": "识别",

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -120,7 +120,17 @@ const Onboarding: React.FC = () => {
                     <Tabs
                         value={tab}
                         onChange={(_, v) => setTab(v as OnboardingTab)}
-                        sx={{mb: 2, borderBottom: 1, borderColor: 'divider'}}
+                        sx={{
+                            mb: 2,
+                            borderBottom: 1,
+                            borderColor: 'divider',
+                            '& .MuiTab-root': {
+                                textTransform: 'none',
+                                fontWeight: 600,
+                                fontSize: '0.95rem',
+                                minHeight: 44,
+                            },
+                        }}
                     >
                         <Tab
                             value="browse"

--- a/frontend/src/services/serviceProviders.ts
+++ b/frontend/src/services/serviceProviders.ts
@@ -161,6 +161,23 @@ export interface UniqueProvider {
     website?: string;
     apiDoc?: string;
     icon?: string; // Icon identifier for Lobe Icons
+    region?: 'cn' | 'global'; // Derived region grouping for UI
+}
+
+// Heuristic classification of a provider into "cn" (China) or "global".
+// Prefers explicit region from Schema V2 when present; otherwise falls back
+// to id/name patterns (e.g. "(CN)" suffix, "-speciale" coding-only CN endpoint).
+function classifyRegion(sp: ServiceProvider): 'cn' | 'global' {
+    const explicit = (sp.region || '').toLowerCase();
+    if (explicit === 'cn') return 'cn';
+    if (explicit === 'intl' || explicit === 'global') return 'global';
+
+    const id = (sp.id || '').toLowerCase();
+    const name = (sp.name || '').toLowerCase();
+    if (name.includes('(cn)') || name.includes('（cn）')) return 'cn';
+    if (id.endsWith('-speciale')) return 'cn';
+    if (id.endsWith('-cn')) return 'cn';
+    return 'global';
 }
 
 // Get all unique providers (not split by API style)
@@ -187,6 +204,7 @@ export function getAllUniqueProviders(): UniqueProvider[] {
             website: sp.website,
             apiDoc: sp.api_doc,
             icon: sp.icon,
+            region: classifyRegion(sp),
         });
     });
 


### PR DESCRIPTION
## Summary
Restructured the provider browsing interface to organize providers by region (Global and China) with improved visual hierarchy, enhanced card styling, and better component composition.

## Key Changes

- **Regional Provider Grouping**: Added region classification logic to categorize providers as 'cn' (China) or 'global' based on explicit region field or heuristic patterns (name/id suffixes)
  - Implemented `classifyRegion()` function in `serviceProviders.ts` to determine provider region
  - Added `region` field to `UniqueProvider` interface

- **Refactored Provider Card Components**: 
  - Extracted provider card rendering into dedicated `ProviderCard` component for better reusability
  - Enhanced `CustomProviderCard` with improved styling and hint text
  - Added consistent hover effects with smooth transitions (transform, shadow, border color)

- **New Section Header Component**: Created `SectionHeader` component to display regional sections with:
  - Icon, title, and provider count badge
  - Color-coded accents for different section types (global, china, custom)
  - Consistent visual styling with divider

- **Improved Layout Structure**:
  - Extracted grid styling into reusable `gridSx` constant
  - Organized providers into three sections: Custom, China (Mainland), and Global
  - Empty state now displays only when no providers match search

- **Enhanced Visual Polish**:
  - Added smooth transitions to card hover states (0.18s ease)
  - Improved custom provider card with icon background box
  - Better spacing and typography hierarchy
  - Added rounded corners to search input

- **Localization Updates**: Added new translation keys for section headers and custom provider hint in both English and Chinese

- **Tab Styling**: Enhanced onboarding tab appearance with better font weight and sizing

## Implementation Details

- Region classification uses a fallback approach: prefers explicit `region` field from provider schema, then applies heuristics (CN suffix patterns, special endpoint markers)
- Provider cards maintain consistent 84px height with improved flex layout
- Section headers use accent colors (primary for global, error for china, secondary for custom) with matching background chips
- Empty state message updated to reference "search" instead of "filters"

https://claude.ai/code/session_0157NXC5YVufc8Rt2YN9jRNX


<img width="3010" height="1528" alt="image" src="https://github.com/user-attachments/assets/76d9f8f6-06f1-49d2-ad95-7e8b8307a7ea" />
