### PR TITLE
feat(smart_routing): add agent.claude_code position for request kind routing

### DIFF
--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -14,7 +14,7 @@ export interface ConfigProvider {
 
 export interface SmartOp {
     uuid: string;
-    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'tool_use' | 'token' | 'service_ttft' | 'service_capacity';
+    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'tool_use' | 'token' | 'service_ttft' | 'service_capacity' | 'agent.claude_code';
     operation: string;
     value: string;
     meta?: {

--- a/frontend/src/components/SmartRuleEditDialog.tsx
+++ b/frontend/src/components/SmartRuleEditDialog.tsx
@@ -23,6 +23,7 @@ import type { SmartRouting, SmartOp } from './RoutingGraphTypes';
 
 // Position options with descriptions
 const POSITION_OPTIONS = [
+    { value: 'agent.claude_code', label: 'Agent: Claude Code', description: 'Claude Code request kind (main / subagent / compact)' },
     // { value: 'model', label: 'Model', description: 'Request model name' },
     { value: 'context_system', label: 'System Prompt', description: 'System prompt message in context' },
     // { value: 'context_user', label: 'User Context', description: 'User messages in context' },
@@ -32,7 +33,6 @@ const POSITION_OPTIONS = [
     { value: 'token', label: 'Token Count', description: 'Token count' },
     { value: 'service_ttft', label: 'Service TTFT', description: 'Time to first token across services (ms)' },
     { value: 'service_capacity', label: 'Service Capacity', description: 'Seat utilization across services (%)' },
-    { value: 'agent.claude_code', label: 'Agent: Claude Code', description: 'Claude Code request kind (main / subagent / compact)' },
 ] as const;
 
 // Per-position enumerated value options. When a position has an entry here,

--- a/frontend/src/components/SmartRuleEditDialog.tsx
+++ b/frontend/src/components/SmartRuleEditDialog.tsx
@@ -32,7 +32,18 @@ const POSITION_OPTIONS = [
     { value: 'token', label: 'Token Count', description: 'Token count' },
     { value: 'service_ttft', label: 'Service TTFT', description: 'Time to first token across services (ms)' },
     { value: 'service_capacity', label: 'Service Capacity', description: 'Seat utilization across services (%)' },
+    { value: 'agent.claude_code', label: 'Agent: Claude Code', description: 'Claude Code request kind (main / subagent / compact)' },
 ] as const;
+
+// Per-position enumerated value options. When a position has an entry here,
+// the value field renders as a Select instead of a free-form TextField.
+const VALUE_OPTIONS: Record<string, Array<{ value: string; label: string }> | undefined> = {
+    'agent.claude_code': [
+        { value: 'main', label: 'Main' },
+        { value: 'subagent', label: 'Subagent' },
+        { value: 'compact', label: 'Compact' },
+    ],
+};
 
 // Operation options grouped by position
 const OPERATION_OPTIONS: Record<string, Array<{ value: string; label: string; description: string; valueType: 'string' | 'int' | 'bool' }>> = {
@@ -77,6 +88,9 @@ const OPERATION_OPTIONS: Record<string, Array<{ value: string; label: string; de
         { value: 'util_ge', label: 'Utilization ≥', description: 'Avg seat utilization across services >= value (%)', valueType: 'int' },
         { value: 'util_lt', label: 'Utilization <', description: 'Avg seat utilization across services < value (%)', valueType: 'int' },
         { value: 'util_gt', label: 'Utilization >', description: 'Avg seat utilization across services > value (%)', valueType: 'int' },
+    ],
+    'agent.claude_code': [
+        { value: 'equals', label: 'Equals', description: 'Claude Code request kind equals the value', valueType: 'string' },
     ],
 };
 
@@ -341,20 +355,40 @@ const SmartRuleEditDialog: React.FC<SmartRuleEditDialogProps> = ({
 
                                         {/* Value Input - only show for string and int types */}
                                         {op.meta?.type !== 'bool' && (
-                                            <TextField
-                                                size="small"
-                                                label="Value"
-                                                value={getDisplayValue(op)}
-                                                onChange={(e) => handleValueChange(op.uuid, e.target.value)}
-                                                placeholder={
-                                                    op.position === 'service_capacity' ? '0–100' :
-                                                    op.position === 'service_ttft' ? 'ms' :
-                                                    op.meta?.type === 'int' ? '1,234' :
-                                                    'enter value'
-                                                }
-                                                sx={{ flex: 1 }}
-                                                type="text"
-                                            />
+                                            VALUE_OPTIONS[op.position] ? (
+                                                <FormControl size="small" sx={{ flex: 1, minWidth: 150 }}>
+                                                    <InputLabel>Value</InputLabel>
+                                                    <Select
+                                                        value={op.value || ''}
+                                                        label="Value"
+                                                        onChange={(e) => handleValueChange(op.uuid, e.target.value as string)}
+                                                    >
+                                                        <MenuItem value="">
+                                                            <em>Select...</em>
+                                                        </MenuItem>
+                                                        {VALUE_OPTIONS[op.position]!.map((opt) => (
+                                                            <MenuItem key={opt.value} value={opt.value}>
+                                                                {opt.label}
+                                                            </MenuItem>
+                                                        ))}
+                                                    </Select>
+                                                </FormControl>
+                                            ) : (
+                                                <TextField
+                                                    size="small"
+                                                    label="Value"
+                                                    value={getDisplayValue(op)}
+                                                    onChange={(e) => handleValueChange(op.uuid, e.target.value)}
+                                                    placeholder={
+                                                        op.position === 'service_capacity' ? '0–100' :
+                                                        op.position === 'service_ttft' ? 'ms' :
+                                                        op.meta?.type === 'int' ? '1,234' :
+                                                        'enter value'
+                                                    }
+                                                    sx={{ flex: 1 }}
+                                                    type="text"
+                                                />
+                                            )
                                         )}
                                     </Stack>
 

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -48,6 +48,13 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		return nil, false
 	}
 
+	// Annotate the request context with the agent.claude_code request kind when
+	// the scenario is claude_code. Other scenarios leave the field empty so the
+	// agent.claude_code SmartOp simply does not match.
+	if ctx.Scenario == typ.ScenarioClaudeCode {
+		reqCtx.ClaudeCodeRequestKind = smartrouting.DetectClaudeCodeRequestKind(reqCtx)
+	}
+
 	// Pre-collect capacity info for all services across all smart routing rules.
 	// evaluateRule will filter this down to per-rule services when evaluating.
 	reqCtx.ServiceCapacity = s.collectAllCapacityInfo(rule.SmartRouting)

--- a/internal/server/routing/stage_smart_routing_test.go
+++ b/internal/server/routing/stage_smart_routing_test.go
@@ -3,10 +3,12 @@ package routing
 import (
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 func TestSmartRouting_RuleMatch(t *testing.T) {
@@ -148,4 +150,118 @@ func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
 func TestSmartRouting_Name(t *testing.T) {
 	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
 	require.Equal(t, "smart_routing", stage.Name())
+}
+
+func TestSmartRouting_AgentClaudeCode_SubagentRoutesToCheapPool(t *testing.T) {
+	cheapSvc := testService("provider-cheap", "haiku", true)
+	mainSvc := testService("provider-main", "sonnet", true)
+	allServices := []*loadbalance.Service{cheapSvc, mainSvc}
+
+	rule := testRule("rule-cc", "claude-3-5-sonnet", allServices)
+	rule.Scenario = typ.ScenarioClaudeCode
+	rule.SmartEnabled = true
+	rule.SmartRouting = []smartrouting.SmartRouting{
+		{
+			Description: "subagent → cheap pool",
+			Ops: []smartrouting.SmartOp{
+				{
+					Position:  smartrouting.PositionAgentClaudeCode,
+					Operation: smartrouting.OpAgentClaudeCodeEquals,
+					Value:     smartrouting.ClaudeCodeKindSubagent,
+				},
+			},
+			Services: []*loadbalance.Service{cheapSvc},
+		},
+	}
+
+	subagentReq := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
+		MaxTokens: 100,
+		System: []anthropic.TextBlockParam{
+			{Text: "You are an agent investigating the user's question. Report back when done."},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("find callers of foo")),
+		},
+	}
+
+	ctx := testContext(rule, "")
+	ctx.Scenario = typ.ScenarioClaudeCode
+	ctx.Request = subagentReq
+
+	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled, "subagent request should match")
+	require.Equal(t, "provider-cheap", result.Service.Provider)
+}
+
+func TestSmartRouting_AgentClaudeCode_MainDoesNotMatchSubagentRule(t *testing.T) {
+	cheapSvc := testService("provider-cheap", "haiku", true)
+
+	rule := testRule("rule-cc", "claude-3-5-sonnet", []*loadbalance.Service{cheapSvc})
+	rule.Scenario = typ.ScenarioClaudeCode
+	rule.SmartEnabled = true
+	rule.SmartRouting = []smartrouting.SmartRouting{
+		{
+			Description: "subagent → cheap pool",
+			Ops: []smartrouting.SmartOp{
+				{
+					Position:  smartrouting.PositionAgentClaudeCode,
+					Operation: smartrouting.OpAgentClaudeCodeEquals,
+					Value:     smartrouting.ClaudeCodeKindSubagent,
+				},
+			},
+			Services: []*loadbalance.Service{cheapSvc},
+		},
+	}
+
+	mainReq := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
+		MaxTokens: 100,
+		System: []anthropic.TextBlockParam{
+			{Text: "You are Claude Code, Anthropic's official CLI for Claude."},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
+		},
+	}
+
+	ctx := testContext(rule, "")
+	ctx.Scenario = typ.ScenarioClaudeCode
+	ctx.Request = mainReq
+
+	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled, "main-agent request should not match subagent-only rule")
+}
+
+func TestSmartRouting_AgentClaudeCode_NonClaudeCodeScenarioDoesNotMatch(t *testing.T) {
+	// Even with subagent-shaped body, a non-claude_code scenario must NOT trigger
+	// the agent.claude_code op (no detection runs, kind stays empty).
+	svc := testService("provider", "gpt-4", true)
+
+	rule := testRule("rule-x", "gpt-4", []*loadbalance.Service{svc})
+	rule.Scenario = typ.ScenarioOpenAI
+	rule.SmartEnabled = true
+	rule.SmartRouting = []smartrouting.SmartRouting{
+		{
+			Description: "subagent → cheap",
+			Ops: []smartrouting.SmartOp{
+				{
+					Position:  smartrouting.PositionAgentClaudeCode,
+					Operation: smartrouting.OpAgentClaudeCodeEquals,
+					Value:     smartrouting.ClaudeCodeKindSubagent,
+				},
+			},
+			Services: []*loadbalance.Service{svc},
+		},
+	}
+
+	ctx := testContext(rule, "")
+	ctx.Scenario = typ.ScenarioOpenAI
+	ctx.Request = testOpenAIRequest("gpt-4")
+
+	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled, "non-claude_code scenarios should not satisfy agent.claude_code ops")
 }

--- a/internal/smart_routing/agent_detect.go
+++ b/internal/smart_routing/agent_detect.go
@@ -1,0 +1,78 @@
+package smartrouting
+
+import "strings"
+
+// Claude Code request kinds. These are the values emitted by
+// DetectClaudeCodeRequestKind and accepted by the agent.claude_code SmartOp.
+const (
+	ClaudeCodeKindMain     = "main"
+	ClaudeCodeKindSubagent = "subagent"
+	ClaudeCodeKindCompact  = "compact"
+)
+
+// Signal fragments used to fingerprint Claude Code request types.
+// Sourced from Claude Code CLI prompt templates as of 2026-05.
+const (
+	// Compact: Claude Code's /compact emits a system prompt asking the model to
+	// produce a structured summary of the prior conversation. The phrase
+	// "summary of the conversation" appears prominently and is rare in normal
+	// chat traffic.
+	claudeCodeCompactMarker = "summary of the conversation"
+
+	// Main: the primary Claude Code agent's system prompt opens with a fixed
+	// identity preamble. Presence of this string indicates the main agent loop.
+	claudeCodeMainPreamble = "You are Claude Code"
+
+	// Subagent: the Task tool injects a fresh sub-agent system prompt that
+	// opens with "You are an agent" (and notably does NOT include the main
+	// preamble). This is also stable across versions because it's part of the
+	// Task tool description embedded in Claude Code's binary.
+	claudeCodeSubagentMarker = "You are an agent"
+)
+
+// DetectClaudeCodeRequestKind inspects an already-built RequestContext and
+// returns one of the ClaudeCodeKind* values. Callers must ensure the request
+// scenario is claude_code before invoking; for other scenarios the result is
+// not meaningful.
+//
+// Precedence is compact → subagent → main (most-specific first).
+func DetectClaudeCodeRequestKind(ctx *RequestContext) string {
+	if ctx == nil {
+		return ClaudeCodeKindMain
+	}
+	if isClaudeCodeCompactRequest(ctx) {
+		return ClaudeCodeKindCompact
+	}
+	if isClaudeCodeSubagentRequest(ctx) {
+		return ClaudeCodeKindSubagent
+	}
+	return ClaudeCodeKindMain
+}
+
+func isClaudeCodeCompactRequest(ctx *RequestContext) bool {
+	for _, sys := range ctx.SystemMessages {
+		if strings.Contains(sys, claudeCodeCompactMarker) {
+			return true
+		}
+	}
+	for _, user := range ctx.UserMessages {
+		if strings.Contains(user, claudeCodeCompactMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isClaudeCodeSubagentRequest(ctx *RequestContext) bool {
+	for _, sys := range ctx.SystemMessages {
+		if strings.Contains(sys, claudeCodeMainPreamble) {
+			return false
+		}
+	}
+	for _, sys := range ctx.SystemMessages {
+		if strings.Contains(sys, claudeCodeSubagentMarker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/smart_routing/agent_detect_test.go
+++ b/internal/smart_routing/agent_detect_test.go
@@ -1,0 +1,72 @@
+package smartrouting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectClaudeCodeRequestKind_Main(t *testing.T) {
+	ctx := &RequestContext{
+		SystemMessages: []string{"You are Claude Code, Anthropic's official CLI for Claude. Help the user with software engineering."},
+		UserMessages:   []string{"refactor this function"},
+	}
+	require.Equal(t, ClaudeCodeKindMain, DetectClaudeCodeRequestKind(ctx))
+}
+
+func TestDetectClaudeCodeRequestKind_Subagent(t *testing.T) {
+	ctx := &RequestContext{
+		SystemMessages: []string{"You are an agent for a coding assistant. Investigate this question and report back."},
+		UserMessages:   []string{"find all callers of foo()"},
+	}
+	require.Equal(t, ClaudeCodeKindSubagent, DetectClaudeCodeRequestKind(ctx))
+}
+
+func TestDetectClaudeCodeRequestKind_Compact(t *testing.T) {
+	ctx := &RequestContext{
+		SystemMessages: []string{"Your task is to create a detailed summary of the conversation so far."},
+		UserMessages:   []string{"<conversation history dump>"},
+	}
+	require.Equal(t, ClaudeCodeKindCompact, DetectClaudeCodeRequestKind(ctx))
+}
+
+func TestDetectClaudeCodeRequestKind_CompactInUserMessage(t *testing.T) {
+	// Some compact templates carry the marker in the user message instead of system.
+	ctx := &RequestContext{
+		SystemMessages: []string{},
+		UserMessages:   []string{"Please produce a summary of the conversation that captures key decisions."},
+	}
+	require.Equal(t, ClaudeCodeKindCompact, DetectClaudeCodeRequestKind(ctx))
+}
+
+func TestDetectClaudeCodeRequestKind_EmptyContext(t *testing.T) {
+	ctx := &RequestContext{}
+	require.Equal(t, ClaudeCodeKindMain, DetectClaudeCodeRequestKind(ctx))
+}
+
+func TestDetectClaudeCodeRequestKind_NilContext(t *testing.T) {
+	require.Equal(t, ClaudeCodeKindMain, DetectClaudeCodeRequestKind(nil))
+}
+
+func TestDetectClaudeCodeRequestKind_PriorityCompactOverSubagent(t *testing.T) {
+	// Both markers present — compact wins (most specific).
+	ctx := &RequestContext{
+		SystemMessages: []string{
+			"You are an agent. Now your task is to produce a summary of the conversation.",
+		},
+	}
+	require.Equal(t, ClaudeCodeKindCompact, DetectClaudeCodeRequestKind(ctx))
+}
+
+func TestDetectClaudeCodeRequestKind_MainPreambleSuppressesSubagent(t *testing.T) {
+	// If the main Claude Code preamble is present, "You are an agent" elsewhere
+	// in the system messages should NOT trigger subagent classification (the
+	// main agent commonly references subagents in its tool descriptions).
+	ctx := &RequestContext{
+		SystemMessages: []string{
+			"You are Claude Code, Anthropic's official CLI for Claude.",
+			"You can dispatch tasks to a subagent: 'You are an agent...'",
+		},
+	}
+	require.Equal(t, ClaudeCodeKindMain, DetectClaudeCodeRequestKind(ctx))
+}

--- a/internal/smart_routing/context.go
+++ b/internal/smart_routing/context.go
@@ -29,6 +29,10 @@ type RequestContext struct {
 	LatestContentType string
 	EstimatedTokens   int
 
+	// ClaudeCodeRequestKind is one of "main", "subagent", "compact" — populated by the
+	// SmartRoutingStage only when the request scenario is claude_code. Empty otherwise.
+	ClaudeCodeRequestKind string
+
 	// Service runtime characteristics — populated by SmartRoutingStage before router evaluation.
 	// These fields are set per-rule inside evaluateRule to avoid cross-rule contamination.
 	ServiceStats    []loadbalance.ServiceStats // TTFT / latency snapshots

--- a/internal/smart_routing/op.go
+++ b/internal/smart_routing/op.go
@@ -189,6 +189,16 @@ var Operations = []SmartOp{
 		},
 	},
 
+	// Agent (Claude Code) request kind operations
+	{
+		Position:  PositionAgentClaudeCode,
+		Operation: OpAgentClaudeCodeEquals,
+		Meta: SmartOpMeta{
+			Description: "Claude Code request kind equals the value ('main', 'subagent', 'compact')",
+			Type:        ValueTypeString,
+		},
+	},
+
 	// Service capacity operations (seat utilization %)
 	{
 		Position:  PositionServiceCapacity,
@@ -234,6 +244,7 @@ const (
 	PositionToken           SmartOpPosition = "token"            // Token count
 	PositionServiceTTFT     SmartOpPosition = "service_ttft"     // Service TTFT characteristics
 	PositionServiceCapacity SmartOpPosition = "service_capacity" // Service seat capacity (affinity utilization)
+	PositionAgentClaudeCode SmartOpPosition = "agent.claude_code" // Claude Code agent request kind (main / subagent / compact)
 )
 
 const (
@@ -279,4 +290,7 @@ const (
 	OpServiceCapacityUtilGe SmartOpOperation = "util_ge" // Avg seat utilization >= value (%)
 	OpServiceCapacityUtilLt SmartOpOperation = "util_lt" // Avg seat utilization < value (%)
 	OpServiceCapacityUtilGt SmartOpOperation = "util_gt" // Avg seat utilization > value (%)
+
+	// Agent (Claude Code) request kind operations
+	OpAgentClaudeCodeEquals SmartOpOperation = "equals" // Claude Code request kind equals the value
 )

--- a/internal/smart_routing/router_test.go
+++ b/internal/smart_routing/router_test.go
@@ -618,3 +618,81 @@ func TestValidateOpValueType(t *testing.T) {
 		})
 	}
 }
+
+func TestEvaluate_AgentClaudeCode_MatchesEachKind(t *testing.T) {
+	svcMain := &loadbalance.Service{Provider: "p", Model: "m-main", Weight: 1, Active: true}
+	svcSub := &loadbalance.Service{Provider: "p", Model: "m-sub", Weight: 1, Active: true}
+	svcCompact := &loadbalance.Service{Provider: "p", Model: "m-compact", Weight: 1, Active: true}
+
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "compact",
+			Ops: []SmartOp{
+				{Position: PositionAgentClaudeCode, Operation: OpAgentClaudeCodeEquals, Value: ClaudeCodeKindCompact},
+			},
+			Services: []*loadbalance.Service{svcCompact},
+		},
+		{
+			Description: "subagent",
+			Ops: []SmartOp{
+				{Position: PositionAgentClaudeCode, Operation: OpAgentClaudeCodeEquals, Value: ClaudeCodeKindSubagent},
+			},
+			Services: []*loadbalance.Service{svcSub},
+		},
+		{
+			Description: "main",
+			Ops: []SmartOp{
+				{Position: PositionAgentClaudeCode, Operation: OpAgentClaudeCodeEquals, Value: ClaudeCodeKindMain},
+			},
+			Services: []*loadbalance.Service{svcMain},
+		},
+	})
+	require.NoError(t, err)
+
+	cases := []struct {
+		kind     string
+		wantSvc  string
+	}{
+		{ClaudeCodeKindMain, "m-main"},
+		{ClaudeCodeKindSubagent, "m-sub"},
+		{ClaudeCodeKindCompact, "m-compact"},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			ctx := &RequestContext{ClaudeCodeRequestKind: c.kind}
+			services, matched := router.EvaluateRequest(ctx)
+			require.True(t, matched)
+			require.Len(t, services, 1)
+			require.Equal(t, c.wantSvc, services[0].Model)
+		})
+	}
+}
+
+func TestEvaluate_AgentClaudeCode_EmptyKindDoesNotMatch(t *testing.T) {
+	svc := &loadbalance.Service{Provider: "p", Model: "m", Weight: 1, Active: true}
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "any kind",
+			Ops: []SmartOp{
+				{Position: PositionAgentClaudeCode, Operation: OpAgentClaudeCodeEquals, Value: ClaudeCodeKindMain},
+			},
+			Services: []*loadbalance.Service{svc},
+		},
+	})
+	require.NoError(t, err)
+
+	// Empty ClaudeCodeRequestKind (e.g., non-claude_code scenario) → no match.
+	ctx := &RequestContext{}
+	_, matched := router.EvaluateRequest(ctx)
+	require.False(t, matched)
+}
+
+func TestValidateSmartOp_AgentClaudeCode(t *testing.T) {
+	op := SmartOp{
+		Position:  PositionAgentClaudeCode,
+		Operation: OpAgentClaudeCodeEquals,
+		Value:     ClaudeCodeKindSubagent,
+	}
+	require.NoError(t, ValidateSmartOp(&op))
+}
+

--- a/internal/smart_routing/routing.go
+++ b/internal/smart_routing/routing.go
@@ -93,6 +93,8 @@ func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) bool {
 		return r.evaluateServiceTTFTOp(ctx, op)
 	case PositionServiceCapacity:
 		return r.evaluateServiceCapacityOp(ctx, op)
+	case PositionAgentClaudeCode:
+		return r.evaluateAgentClaudeCodeOp(ctx, op)
 	default:
 		return false
 	}
@@ -362,6 +364,27 @@ func (r *Router) evaluateTokenOp(ctx *RequestContext, op *SmartOp) bool {
 		return tokens <= target
 	case OpTokenLt:
 		return tokens < target
+	default:
+		return false
+	}
+}
+
+// evaluateAgentClaudeCodeOp evaluates operations on the agent.claude_code position.
+// The ctx.ClaudeCodeRequestKind field is populated by SmartRoutingStage only when
+// the request scenario is claude_code; for other scenarios it is empty and no
+// value will match — which is the desired behavior.
+func (r *Router) evaluateAgentClaudeCodeOp(ctx *RequestContext, op *SmartOp) bool {
+	value, err := op.String()
+	if err != nil {
+		log.Printf("[smart_routing] invalid agent.claude_code value '%s': %v", op.Value, err)
+		return false
+	}
+	switch op.Operation {
+	case OpAgentClaudeCodeEquals:
+		if ctx.ClaudeCodeRequestKind == "" {
+			return false
+		}
+		return ctx.ClaudeCodeRequestKind == value
 	default:
 		return false
 	}

--- a/internal/smart_routing/type.go
+++ b/internal/smart_routing/type.go
@@ -73,7 +73,7 @@ type SmartRouting struct {
 func (p SmartOpPosition) IsValid() bool {
 	switch p {
 	case PositionModel, PositionThinking, PositionContextSystem, PositionContextUser, PositionLatestUser, PositionToolUse, PositionToken,
-		PositionServiceTTFT, PositionServiceCapacity:
+		PositionServiceTTFT, PositionServiceCapacity, PositionAgentClaudeCode:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- Adds new SmartOp position `agent.claude_code` with values `{main, subagent, compact}`
- Body-based detector gated on `Rule.Scenario == claude_code` so it composes
  cleanly with existing positions and doesn't run for other scenarios
- Lets routing rules send Claude Code subagent traffic to cheaper pools and
  compact requests to summarization-tuned models, without affecting the main
  agent loop

## Why
Same scenario + model combination today routes uniformly. Claude Code's main /
subagent / compact requests have very different cost-quality tradeoffs;
exposing the kind as a SmartOp value lets users write targeted rules without
introducing a new abstraction layer.

## Test plan
- [x] `go test ./internal/smart_routing/...` — all green
- [x] New stage tests pass: subagent body matches subagent rule; main body
      doesn't match subagent rule; non-claude_code scenarios don't satisfy
      `agent.claude_code` ops
- [ ] Manual: configure a rule `Rule.Scenario=claude_code` + SmartOp
      `agent.claude_code==subagent` → cheap pool, send a Task-tool subagent
      request, verify routing in logs