### PR TITLE
feat(smart_routing): eval-trace logging + reuse protocol layer for context extraction

### DIFF
--- a/frontend/src/components/SmartRoutingLogViewer.tsx
+++ b/frontend/src/components/SmartRoutingLogViewer.tsx
@@ -48,9 +48,7 @@ interface RequestSnapshot {
     latest_type?: string;
     estimated_tokens?: number;
     tool_uses?: string[];
-    system_snippet?: string;
-    latest_user?: string;
-    user_snippet?: string;
+    latest_user_head?: string;
     system_msg_count?: number;
     user_msg_count?: number;
 }
@@ -281,9 +279,7 @@ const SmartRoutingLogViewer = ({ getLogs, clearLogs }: SmartRoutingLogViewerProp
                 {fieldRow('tool_uses', req.tool_uses)}
                 {fieldRow('system_msgs', req.system_msg_count)}
                 {fieldRow('user_msgs', req.user_msg_count)}
-                {req.system_snippet && fieldRow('system_snippet', req.system_snippet)}
-                {req.latest_user && fieldRow('latest_user', req.latest_user)}
-                {req.user_snippet && fieldRow('user_snippet', req.user_snippet)}
+                {req.latest_user_head && fieldRow('latest_user', req.latest_user_head)}
             </Stack>
         );
     };

--- a/frontend/src/components/SmartRoutingLogViewer.tsx
+++ b/frontend/src/components/SmartRoutingLogViewer.tsx
@@ -1,0 +1,488 @@
+import {
+    Box,
+    Button,
+    Chip,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography,
+    IconButton,
+    Collapse,
+    Alert,
+} from '@mui/material';
+import { useState, useEffect, useRef } from 'react';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
+
+interface OpEvalResult {
+    uuid?: string;
+    position: string;
+    operation: string;
+    value?: string;
+    actual?: string;
+    matched: boolean;
+    reason?: string;
+}
+
+interface RuleEvalResult {
+    rule_index: number;
+    description?: string;
+    matched: boolean;
+    ops_evaluated: number;
+    ops_total: number;
+    ops?: OpEvalResult[];
+}
+
+interface RequestSnapshot {
+    model?: string;
+    thinking_enabled?: boolean;
+    latest_role?: string;
+    latest_type?: string;
+    estimated_tokens?: number;
+    tool_uses?: string[];
+    system_snippet?: string;
+    latest_user?: string;
+    user_snippet?: string;
+    system_msg_count?: number;
+    user_msg_count?: number;
+}
+
+interface SmartRoutingLogFields {
+    rule_uuid?: string;
+    request_model?: string;
+    matched?: boolean;
+    matched_rule_index?: number;
+    matched_rule_description?: string;
+    matched_services?: number;
+    final_active_count?: number;
+    rules_total?: number;
+    selected_provider?: string;
+    selected_model?: string;
+    outcome?: string;
+    reason?: string;
+    client_ip?: string;
+    request_id?: string;
+    trace?: RuleEvalResult[];
+    request?: RequestSnapshot;
+    [k: string]: unknown;
+}
+
+interface SmartRoutingLogEntry {
+    time: string;
+    level: string;
+    message: string;
+    fields?: SmartRoutingLogFields;
+}
+
+interface SmartRoutingLogViewerProps {
+    getLogs: (params?: { limit?: number }) => Promise<{ total: number; logs: SmartRoutingLogEntry[] }>;
+    clearLogs?: () => Promise<void>;
+}
+
+const outcomeColor = (outcome?: string): 'default' | 'success' | 'warning' | 'error' => {
+    switch (outcome) {
+        case 'selected':
+            return 'success';
+        case 'no_match':
+        case 'no_candidates':
+        case 'no_active_services':
+            return 'warning';
+        case 'lb_failed':
+        case 'router_invalid':
+        case 'extract_failed':
+        case 'no_context':
+            return 'error';
+        default:
+            return 'default';
+    }
+};
+
+const SmartRoutingLogViewer = ({ getLogs, clearLogs }: SmartRoutingLogViewerProps) => {
+    const [logs, setLogs] = useState<SmartRoutingLogEntry[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [autoRefresh, setAutoRefresh] = useState(false);
+    const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+    const [error, setError] = useState<string | null>(null);
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+
+    const loadLogs = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await getLogs({ limit: 200 });
+            if (response && response.logs) {
+                // sort oldest -> newest so the latest sits at the bottom
+                const sorted = [...response.logs].sort(
+                    (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
+                );
+                setLogs(sorted);
+            }
+        } catch (e: any) {
+            setError(e instanceof Error ? e.message : 'Failed to load smart routing logs');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleClear = async () => {
+        if (!clearLogs) return;
+        try {
+            await clearLogs();
+            await loadLogs();
+        } catch (e: any) {
+            setError(e instanceof Error ? e.message : 'Failed to clear logs');
+        }
+    };
+
+    useEffect(() => {
+        loadLogs();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        if (autoRefresh) {
+            const id = setInterval(loadLogs, 5000);
+            return () => clearInterval(id);
+        }
+    }, [autoRefresh]);
+
+    useEffect(() => {
+        if (!tableContainerRef.current || logs.length === 0) return;
+        const el = tableContainerRef.current;
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                el.scrollTop = el.scrollHeight;
+            });
+        });
+    }, [logs]);
+
+    const toggleRow = (i: number) => {
+        const next = new Set(expandedRows);
+        if (next.has(i)) next.delete(i);
+        else next.add(i);
+        setExpandedRows(next);
+    };
+
+    const formatTime = (s: string): string => {
+        try {
+            return new Date(s).toLocaleString();
+        } catch {
+            return s;
+        }
+    };
+
+    const renderOp = (op: OpEvalResult, i: number) => (
+        <Stack
+            key={i}
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            sx={{
+                py: 0.5,
+                px: 1,
+                borderLeft: 3,
+                borderColor: op.matched ? 'success.main' : 'error.main',
+                backgroundColor: op.matched ? 'rgba(16,185,129,0.08)' : 'rgba(239,68,68,0.08)',
+                borderRadius: 0.5,
+                mb: 0.25,
+            }}
+        >
+            {op.matched ? (
+                <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />
+            ) : (
+                <CancelIcon sx={{ fontSize: 16, color: 'error.main' }} />
+            )}
+            <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', minWidth: 130 }}>
+                <strong>{op.position}</strong>.{op.operation}
+            </Typography>
+            {op.value !== undefined && op.value !== '' && (
+                <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', color: 'text.secondary' }}>
+                    = "{op.value}"
+                </Typography>
+            )}
+            <Box sx={{ flex: 1 }} />
+            <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', color: 'text.secondary', wordBreak: 'break-word' }}>
+                {op.reason}
+            </Typography>
+        </Stack>
+    );
+
+    const renderRule = (rule: RuleEvalResult, matchedIdx?: number) => {
+        const isMatchedWinner = matchedIdx !== undefined && matchedIdx === rule.rule_index;
+        return (
+            <Box
+                key={rule.rule_index}
+                sx={{
+                    p: 1,
+                    borderRadius: 1,
+                    border: 1,
+                    borderColor: isMatchedWinner ? 'success.main' : 'divider',
+                    backgroundColor: isMatchedWinner ? 'rgba(16,185,129,0.05)' : 'transparent',
+                    mb: 1,
+                }}
+            >
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+                    <Chip
+                        size="small"
+                        label={`Rule #${rule.rule_index}`}
+                        sx={{ fontSize: '0.7rem', height: 20, fontWeight: 'bold' }}
+                    />
+                    <Typography sx={{ fontWeight: 'bold', fontSize: '0.8rem', flex: 1 }}>
+                        {rule.description || '(no description)'}
+                    </Typography>
+                    <Chip
+                        size="small"
+                        label={rule.matched ? 'MATCH' : 'SKIP'}
+                        color={rule.matched ? 'success' : 'default'}
+                        sx={{ fontSize: '0.65rem', height: 18, fontWeight: 'bold' }}
+                    />
+                    <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>
+                        {rule.ops_evaluated}/{rule.ops_total} ops
+                    </Typography>
+                </Stack>
+                {rule.ops && rule.ops.map(renderOp)}
+            </Box>
+        );
+    };
+
+    const renderRequestSnapshot = (req?: RequestSnapshot) => {
+        if (!req) return null;
+        const fieldRow = (label: string, value: any) => (
+            <Stack direction="row" spacing={1} key={label}>
+                <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', color: 'text.secondary', minWidth: 140 }}>
+                    {label}
+                </Typography>
+                <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', wordBreak: 'break-all' }}>
+                    {value === undefined || value === null
+                        ? '-'
+                        : Array.isArray(value)
+                            ? value.length === 0 ? '[]' : value.join(', ')
+                            : typeof value === 'object'
+                                ? JSON.stringify(value)
+                                : String(value)}
+                </Typography>
+            </Stack>
+        );
+        return (
+            <Stack spacing={0.25} sx={{ p: 1, backgroundColor: 'rgba(0,0,0,0.03)', borderRadius: 1 }}>
+                {fieldRow('model', req.model)}
+                {fieldRow('thinking_enabled', req.thinking_enabled)}
+                {fieldRow('estimated_tokens', req.estimated_tokens)}
+                {fieldRow('latest_role', req.latest_role)}
+                {fieldRow('latest_type', req.latest_type)}
+                {fieldRow('tool_uses', req.tool_uses)}
+                {fieldRow('system_msgs', req.system_msg_count)}
+                {fieldRow('user_msgs', req.user_msg_count)}
+                {req.system_snippet && fieldRow('system_snippet', req.system_snippet)}
+                {req.latest_user && fieldRow('latest_user', req.latest_user)}
+                {req.user_snippet && fieldRow('user_snippet', req.user_snippet)}
+            </Stack>
+        );
+    };
+
+    return (
+        <Stack spacing={1.5} sx={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+            <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="wrap" useFlexGap sx={{ flexShrink: 0 }}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                    <Button
+                        variant={autoRefresh ? 'contained' : 'outlined'}
+                        size="small"
+                        onClick={() => setAutoRefresh(!autoRefresh)}
+                        sx={{ fontSize: '0.75rem' }}
+                    >
+                        Auto
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={loadLogs}
+                        disabled={loading}
+                        startIcon={<RefreshIcon />}
+                        sx={{ fontSize: '0.75rem' }}
+                    >
+                        Refresh
+                    </Button>
+                    {clearLogs && (
+                        <Button
+                            variant="outlined"
+                            size="small"
+                            color="warning"
+                            onClick={handleClear}
+                            startIcon={<DeleteSweepIcon />}
+                            sx={{ fontSize: '0.75rem' }}
+                        >
+                            Clear
+                        </Button>
+                    )}
+                    <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+                        {logs.length} entries
+                    </Typography>
+                </Stack>
+                <Box sx={{ flex: 1 }} />
+                <Typography variant="caption" color="text.secondary">
+                    Each row is one routing decision. Expand to see per-op evaluation and the request fields.
+                </Typography>
+            </Stack>
+
+            {error && (
+                <Alert severity="error" onClose={() => setError(null)}>
+                    {error}
+                </Alert>
+            )}
+
+            <Box
+                ref={tableContainerRef}
+                sx={{
+                    flex: 1,
+                    overflow: 'auto',
+                    minHeight: 0,
+                    backgroundColor: 'background.paper',
+                    borderRadius: 1,
+                    border: 1,
+                    borderColor: 'divider',
+                }}
+            >
+                <TableContainer sx={{ maxHeight: 'none' }}>
+                    <Table stickyHeader size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell padding="checkbox" />
+                                <TableCell sx={{ width: 180 }}>Time</TableCell>
+                                <TableCell sx={{ width: 110 }}>Outcome</TableCell>
+                                <TableCell sx={{ width: 180 }}>Model</TableCell>
+                                <TableCell sx={{ width: 90 }}>Rule</TableCell>
+                                <TableCell>Selected → Provider/Model</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {logs.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                                        <Typography color="text.secondary">
+                                            {loading ? 'Loading...' : 'No smart routing logs yet — send a request to a smart-routed rule.'}
+                                        </Typography>
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                logs.map((log, index) => {
+                                    const f = log.fields || {};
+                                    const matchedIdx = typeof f.matched_rule_index === 'number' ? f.matched_rule_index : -1;
+                                    return (
+                                        <>
+                                            <TableRow
+                                                key={index}
+                                                hover
+                                                sx={{ cursor: 'pointer' }}
+                                                onClick={() => toggleRow(index)}
+                                            >
+                                                <TableCell padding="checkbox">
+                                                    <IconButton size="small">
+                                                        {expandedRows.has(index) ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                                                    </IconButton>
+                                                </TableCell>
+                                                <TableCell sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                                                    {formatTime(log.time)}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Chip
+                                                        size="small"
+                                                        label={(f.outcome || '-').toUpperCase()}
+                                                        color={outcomeColor(f.outcome)}
+                                                        sx={{ fontSize: '0.65rem', height: 20, fontWeight: 'bold' }}
+                                                    />
+                                                </TableCell>
+                                                <TableCell sx={{ fontSize: '0.75rem', fontFamily: 'monospace' }}>
+                                                    {f.request_model || f.request?.model || '-'}
+                                                </TableCell>
+                                                <TableCell sx={{ fontSize: '0.75rem' }}>
+                                                    {matchedIdx >= 0 ? (
+                                                        <Chip
+                                                            size="small"
+                                                            label={`#${matchedIdx}`}
+                                                            sx={{ fontSize: '0.65rem', height: 20, fontWeight: 'bold' }}
+                                                        />
+                                                    ) : (
+                                                        <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>-</Typography>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell sx={{ fontSize: '0.75rem' }}>
+                                                    {f.selected_provider ? (
+                                                        <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                                                            {f.selected_provider} → {f.selected_model}
+                                                        </Typography>
+                                                    ) : (
+                                                        <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                                                            {f.reason || log.message}
+                                                        </Typography>
+                                                    )}
+                                                </TableCell>
+                                            </TableRow>
+                                            <TableRow key={`${index}-expanded`}>
+                                                <TableCell colSpan={6} sx={{ pb: 0, pt: 0, border: 'none' }}>
+                                                    <Collapse in={expandedRows.has(index)} timeout="auto" unmountOnExit>
+                                                        <Box sx={{ p: 1.5, backgroundColor: 'rgba(0,0,0,0.02)' }}>
+                                                            <Stack spacing={1.5}>
+                                                                <Box>
+                                                                    <Typography variant="caption" sx={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'text.secondary' }}>
+                                                                        Request snapshot
+                                                                    </Typography>
+                                                                    {renderRequestSnapshot(f.request)}
+                                                                </Box>
+                                                                <Box>
+                                                                    <Typography variant="caption" sx={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'text.secondary' }}>
+                                                                        Rule evaluation ({f.rules_total ?? f.trace?.length ?? 0} rules)
+                                                                    </Typography>
+                                                                    {f.trace && f.trace.length > 0 ? (
+                                                                        f.trace.map((rule) => renderRule(rule, matchedIdx))
+                                                                    ) : (
+                                                                        <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+                                                                            No rule trace recorded (e.g. context extraction failed before evaluation).
+                                                                        </Typography>
+                                                                    )}
+                                                                </Box>
+                                                                {(f.matched_services !== undefined || f.final_active_count !== undefined) && (
+                                                                    <Box>
+                                                                        <Typography variant="caption" sx={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'text.secondary' }}>
+                                                                            Selection
+                                                                        </Typography>
+                                                                        <Stack direction="row" spacing={2}>
+                                                                            <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem' }}>
+                                                                                matched_services: {f.matched_services ?? '-'}
+                                                                            </Typography>
+                                                                            <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem' }}>
+                                                                                active_after_filter: {f.final_active_count ?? '-'}
+                                                                            </Typography>
+                                                                            {f.client_ip && (
+                                                                                <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem' }}>
+                                                                                    client_ip: {f.client_ip}
+                                                                                </Typography>
+                                                                            )}
+                                                                        </Stack>
+                                                                    </Box>
+                                                                )}
+                                                            </Stack>
+                                                        </Box>
+                                                    </Collapse>
+                                                </TableCell>
+                                            </TableRow>
+                                        </>
+                                    );
+                                })
+                            )}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Box>
+        </Stack>
+    );
+};
+
+export default SmartRoutingLogViewer;

--- a/frontend/src/pages/system/LogsPage.tsx
+++ b/frontend/src/pages/system/LogsPage.tsx
@@ -1,6 +1,7 @@
 import { Box, FormControlLabel, Stack, Switch, Typography, Alert, Tabs, Tab } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import SystemLogViewer from '@/components/SystemLogViewer';
+import SmartRoutingLogViewer from '@/components/SmartRoutingLogViewer';
 import UnifiedCard from '@/components/UnifiedCard';
 
 interface TabPanelProps {
@@ -133,6 +134,40 @@ const LogsPage = () => {
         [],
     );
 
+    const getSmartRoutingLogs = useCallback(async (params?: { limit?: number }) => {
+        const queryParams = new URLSearchParams();
+        if (params?.limit) queryParams.append('limit', params.limit.toString());
+
+        const response = await fetch(`/api/v1/system/smart-routing/logs?${queryParams.toString()}`, {
+            headers: {
+                'Authorization': `Bearer ${localStorage.getItem('user_auth_token') || ''}`,
+            },
+        });
+
+        if (!response.ok) {
+            let errorDetail = `HTTP error! status: ${response.status}`;
+            try {
+                const errorData = await response.json();
+                if (errorData.error) errorDetail = errorData.error;
+            } catch {}
+            throw new Error(errorDetail);
+        }
+        const data = await response.json();
+        return { total: data.total || 0, logs: data.logs || [] };
+    }, []);
+
+    const clearSmartRoutingLogs = useCallback(async () => {
+        const response = await fetch('/api/v1/system/smart-routing/logs', {
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${localStorage.getItem('user_auth_token') || ''}`,
+            },
+        });
+        if (!response.ok) {
+            throw new Error(`Failed to clear smart routing logs (${response.status})`);
+        }
+    }, []);
+
     const getRequestBody = useCallback(async (bodyRef: string) => {
         const response = await fetch(`/api/v1/log/request/${bodyRef}`, {
             headers: {
@@ -177,6 +212,7 @@ const LogsPage = () => {
                 >
                     <Tab label="Model Requests" />
                     <Tab label="System Logs" />
+                    <Tab label="Smart Routing" />
                 </Tabs>
 
                 {logError && (
@@ -197,6 +233,13 @@ const LogsPage = () => {
                     <SystemLogViewer
                         getLogs={getLogs}
                         getRequestBody={getRequestBody}
+                    />
+                </TabPanel>
+
+                <TabPanel value={tabValue} index={2}>
+                    <SmartRoutingLogViewer
+                        getLogs={getSmartRoutingLogs}
+                        clearLogs={clearSmartRoutingLogs}
                     />
                 </TabPanel>
             </Stack>

--- a/internal/protocol/request/anthropic_v1_to_beta.go
+++ b/internal/protocol/request/anthropic_v1_to_beta.go
@@ -1,0 +1,84 @@
+package request
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// ConvertAnthropicV1ToBetaRequest projects an Anthropic v1 MessageNewParams onto
+// the Beta MessageNewParams shape. Beta is a structural superset of v1 in the SDK,
+// so this is a field-by-field copy.
+//
+// Coverage is limited to the fields downstream consumers (currently smart-routing
+// context extraction) read: Model, MaxTokens, Thinking-enabled flag, System text,
+// Messages with text / image / tool_use / tool_result blocks. Extend as needed if
+// other call sites require additional fields.
+func ConvertAnthropicV1ToBetaRequest(req *anthropic.MessageNewParams) *anthropic.BetaMessageNewParams {
+	if req == nil {
+		return nil
+	}
+
+	beta := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model(req.Model),
+		MaxTokens: req.MaxTokens,
+	}
+
+	if req.Thinking.OfEnabled != nil {
+		beta.Thinking = anthropic.BetaThinkingConfigParamUnion{
+			OfEnabled: &anthropic.BetaThinkingConfigEnabledParam{
+				BudgetTokens: req.Thinking.OfEnabled.BudgetTokens,
+			},
+		}
+	}
+
+	if len(req.System) > 0 {
+		beta.System = make([]anthropic.BetaTextBlockParam, 0, len(req.System))
+		for _, s := range req.System {
+			if s.Text == "" {
+				continue
+			}
+			beta.System = append(beta.System, anthropic.BetaTextBlockParam{Text: s.Text})
+		}
+	}
+
+	if len(req.Messages) > 0 {
+		beta.Messages = make([]anthropic.BetaMessageParam, 0, len(req.Messages))
+		for _, msg := range req.Messages {
+			beta.Messages = append(beta.Messages, anthropic.BetaMessageParam{
+				Role:    anthropic.BetaMessageParamRole(msg.Role),
+				Content: convertAnthropicV1ContentToBeta(msg.Content),
+			})
+		}
+	}
+
+	return beta
+}
+
+func convertAnthropicV1ContentToBeta(blocks []anthropic.ContentBlockParamUnion) []anthropic.BetaContentBlockParamUnion {
+	if len(blocks) == 0 {
+		return nil
+	}
+	out := make([]anthropic.BetaContentBlockParamUnion, 0, len(blocks))
+	for _, b := range blocks {
+		switch {
+		case b.OfText != nil:
+			out = append(out, anthropic.NewBetaTextBlock(b.OfText.Text))
+		case b.OfImage != nil:
+			out = append(out, anthropic.BetaContentBlockParamUnion{
+				OfImage: &anthropic.BetaImageBlockParam{},
+			})
+		case b.OfToolUse != nil:
+			out = append(out, anthropic.NewBetaToolUseBlock(
+				b.OfToolUse.ID,
+				b.OfToolUse.Input,
+				b.OfToolUse.Name,
+			))
+		case b.OfToolResult != nil:
+			out = append(out, anthropic.NewBetaToolResultBlock(
+				b.OfToolResult.ToolUseID,
+				"",
+				false,
+			))
+		}
+	}
+	return out
+}

--- a/internal/server/probe_v2_handler.go
+++ b/internal/server/probe_v2_handler.go
@@ -249,7 +249,7 @@ func (s *Server) resolveSmartRoutingForProbe(rule *typ.Rule) (*loadbalance.Servi
 				anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
 			},
 		}
-		reqCtx = smartrouting.ExtractContextFromAnthropicRequest(probeReq)
+		reqCtx = smartrouting.ExtractContext(probeReq)
 	default:
 		probeReq := &openai.ChatCompletionNewParams{
 			Model: openai.ChatModel(rule.RequestModel),
@@ -257,7 +257,7 @@ func (s *Server) resolveSmartRoutingForProbe(rule *typ.Rule) (*loadbalance.Servi
 				openai.UserMessage("hi"),
 			},
 		}
-		reqCtx = smartrouting.ExtractContextFromOpenAIRequest(probeReq)
+		reqCtx = smartrouting.ExtractContext(probeReq)
 	}
 
 	router, err := smartrouting.NewRouter(rule.SmartRouting)

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
+	pkgobs "github.com/tingly-dev/tingly-box/pkg/obs"
 )
 
 // ProviderResolver resolves providers by UUID and persists config state.
@@ -109,6 +110,18 @@ func NewServiceSelector(
 	affinity AffinityStore,
 	lb LoadBalancer,
 ) *ServiceSelector {
+	return NewServiceSelectorWithLogger(cfg, affinity, lb, nil)
+}
+
+// NewServiceSelectorWithLogger is like NewServiceSelector but also wires the
+// multi-logger into smart-routing stages so each evaluation is captured to the
+// dedicated smart_routing log source.
+func NewServiceSelectorWithLogger(
+	cfg ProviderResolver,
+	affinity AffinityStore,
+	lb LoadBalancer,
+	multiLogger *pkgobs.MultiLogger,
+) *ServiceSelector {
 	s := &ServiceSelector{
 		config:        cfg,
 		affinityStore: affinity,
@@ -121,20 +134,28 @@ func NewServiceSelector(
 		healthFilter = p.HealthFilter()
 	}
 
+	newSmart := func() *SmartRoutingStage {
+		stage := NewSmartRoutingStage(lb, affinity)
+		if multiLogger != nil {
+			stage.SetMultiLogger(multiLogger)
+		}
+		return stage
+	}
+
 	// Pre-build all pipeline variants
 	s.pipelines[pipelineModeNoAffinity] = []SelectionStage{
-		NewSmartRoutingStage(lb, affinity),
+		newSmart(),
 		NewLoadBalancerStage(lb),
 	}
 	s.pipelines[pipelineModeGlobalAffinity] = []SelectionStage{
 		NewAffinityStage(affinity, "global"),
-		NewSmartRoutingStage(lb, affinity),
+		newSmart(),
 		NewLoadBalancerStage(lb),
 	}
 	s.pipelines[pipelineModeSmartAffinity] = []SelectionStage{
 		NewHealthStage(healthFilter),
 		NewAffinityStage(affinity, "smart_rule"),
-		NewSmartRoutingStage(lb, affinity),
+		newSmart(),
 		NewLoadBalancerStage(lb),
 	}
 

--- a/internal/server/routing/smart_routing_helper.go
+++ b/internal/server/routing/smart_routing_helper.go
@@ -1,22 +1,10 @@
 package routing
 
 import (
-	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/openai/openai-go/v3"
-
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
 )
 
 // ExtractRequestContext extracts RequestContext from different request types
 func ExtractRequestContext(req interface{}) (*smartrouting.RequestContext, error) {
-	switch r := req.(type) {
-	case *openai.ChatCompletionNewParams:
-		return smartrouting.ExtractContextFromOpenAIRequest(r), nil
-	case *anthropic.MessageNewParams:
-		return smartrouting.ExtractContextFromAnthropicRequest(r), nil
-	case *anthropic.BetaMessageNewParams:
-		return smartrouting.ExtractContextFromBetaRequest(r), nil
-	default:
-		return nil, nil
-	}
+	return smartrouting.ExtractContext(req), nil
 }

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -187,10 +187,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		return nil, false
 	}
 
-	// Per-op trace for logging — independent from the actual selection call.
-	trace := router.TraceEvaluation(reqCtx)
-
-	matchedServices, matchedRuleIndex, matched := router.EvaluateRequestWithIndex(reqCtx)
+	matchedServices, matchedRuleIndex, matched, trace := router.Evaluate(reqCtx)
 	if !matched || len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] no rule matched - matched=%v, services=%d", matched, len(matchedServices))
 		s.emitTrace(ctx, reqCtx, trace, -1, 0, 0, nil, "no_match", "no rule matched the request")

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -1,11 +1,14 @@
 package routing
 
 import (
+	"strings"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
 	"github.com/tingly-dev/tingly-box/internal/typ"
+	pkgobs "github.com/tingly-dev/tingly-box/pkg/obs"
 )
 
 // SmartRoutingStage evaluates smart routing rules and returns matched services.
@@ -13,6 +16,7 @@ import (
 type SmartRoutingStage struct {
 	loadBalancer  LoadBalancer
 	affinityStore AffinityStore
+	multiLogger   *pkgobs.MultiLogger // optional; used to emit structured smart-routing logs
 }
 
 // NewSmartRoutingStage creates a new smart routing stage
@@ -23,9 +27,120 @@ func NewSmartRoutingStage(lb LoadBalancer, affinity AffinityStore) *SmartRouting
 	}
 }
 
+// SetMultiLogger attaches the multi-logger so the stage can emit structured
+// smart-routing evaluation logs viewable from the frontend system log page.
+func (s *SmartRoutingStage) SetMultiLogger(ml *pkgobs.MultiLogger) {
+	s.multiLogger = ml
+}
+
 // Name returns the stage identifier
 func (s *SmartRoutingStage) Name() string {
 	return "smart_routing"
+}
+
+const traceSnippetMaxLen = 200
+
+func snippetForLog(s string) string {
+	if len(s) <= traceSnippetMaxLen {
+		return s
+	}
+	return s[:traceSnippetMaxLen] + "…"
+}
+
+// requestSnapshot captures key request fields used during smart routing
+// evaluation so operators can correlate decisions with what the request
+// actually looked like.
+func requestSnapshot(reqCtx *smartrouting.RequestContext) map[string]interface{} {
+	if reqCtx == nil {
+		return nil
+	}
+	systemCombined := strings.Join(reqCtx.SystemMessages, "\n")
+	userCombined := strings.Join(reqCtx.UserMessages, "\n")
+	return map[string]interface{}{
+		"model":             reqCtx.Model,
+		"thinking_enabled":  reqCtx.ThinkingEnabled,
+		"latest_role":       reqCtx.LatestRole,
+		"latest_type":       reqCtx.LatestContentType,
+		"estimated_tokens":  reqCtx.EstimatedTokens,
+		"tool_uses":         reqCtx.ToolUses,
+		"system_snippet":    snippetForLog(systemCombined),
+		"latest_user":       snippetForLog(reqCtx.GetLatestUserMessage()),
+		"user_snippet":      snippetForLog(userCombined),
+		"system_msg_count":  len(reqCtx.SystemMessages),
+		"user_msg_count":    len(reqCtx.UserMessages),
+	}
+}
+
+// emitTrace writes a structured entry describing the smart-routing evaluation
+// to both the standard system log (logrus.Debug) and the dedicated
+// smart_routing memory sink (when a multiLogger is configured) so the
+// frontend can render an inspectable history.
+func (s *SmartRoutingStage) emitTrace(
+	ctx *SelectionContext,
+	reqCtx *smartrouting.RequestContext,
+	trace []smartrouting.RuleEvalResult,
+	matchedRuleIndex int,
+	matchedServicesCount int,
+	finalActiveCount int,
+	selectedService *loadbalance.Service,
+	outcome string,
+	reason string,
+) {
+	matched := matchedRuleIndex >= 0
+	fields := logrus.Fields{
+		"rule_uuid":           ctx.Rule.UUID,
+		"request_model":       ctx.Rule.RequestModel,
+		"matched":             matched,
+		"matched_rule_index":  matchedRuleIndex,
+		"outcome":             outcome,
+		"reason":              reason,
+		"matched_services":    matchedServicesCount,
+		"final_active_count":  finalActiveCount,
+		"trace":               trace,
+		"request":             requestSnapshot(reqCtx),
+		"rules_total":         len(ctx.Rule.SmartRouting),
+	}
+	if matched && matchedRuleIndex < len(trace) {
+		fields["matched_rule_description"] = trace[matchedRuleIndex].Description
+	}
+	if selectedService != nil {
+		fields["selected_provider"] = selectedService.Provider
+		fields["selected_model"] = selectedService.Model
+	}
+	if ctx.GinContext != nil {
+		fields["client_ip"] = ctx.GinContext.ClientIP()
+		fields["request_id"] = ctx.GinContext.GetString("X-Request-Id")
+	}
+
+	if s.multiLogger != nil {
+		s.multiLogger.GetLogrusLogger(pkgobs.LogSourceSmartRouting).
+			WithFields(fields).
+			Info(formatTraceMessage(matched, matchedRuleIndex, ctx.Rule.RequestModel, outcome))
+	}
+	logrus.WithFields(fields).Debugf("[smart_routing] %s", outcome)
+}
+
+func formatTraceMessage(matched bool, idx int, model, outcome string) string {
+	if matched {
+		return "smart routing matched rule " + indexToString(idx) + " for " + model + " (" + outcome + ")"
+	}
+	return "smart routing fell through for " + model + " (" + outcome + ")"
+}
+
+func indexToString(i int) string {
+	if i < 0 {
+		return "-1"
+	}
+	// avoid pulling strconv just for this
+	if i == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	return string(digits)
 }
 
 // Evaluate evaluates smart routing rules and selects a service
@@ -45,6 +160,11 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	reqCtx, err := ExtractRequestContext(ctx.Request)
 	if err != nil {
 		logrus.Debugf("[smart_routing] failed to extract context: %v", err)
+		s.emitTrace(ctx, nil, nil, -1, 0, 0, nil, "extract_failed", err.Error())
+		return nil, false
+	}
+	if reqCtx == nil {
+		s.emitTrace(ctx, nil, nil, -1, 0, 0, nil, "no_context", "request type not supported for smart routing")
 		return nil, false
 	}
 
@@ -63,12 +183,17 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	router, err := smartrouting.NewRouter(rule.SmartRouting)
 	if err != nil {
 		logrus.Debugf("[smart_routing] failed to create router: %v", err)
+		s.emitTrace(ctx, reqCtx, nil, -1, 0, 0, nil, "router_invalid", err.Error())
 		return nil, false
 	}
+
+	// Per-op trace for logging — independent from the actual selection call.
+	trace := router.TraceEvaluation(reqCtx)
 
 	matchedServices, matchedRuleIndex, matched := router.EvaluateRequestWithIndex(reqCtx)
 	if !matched || len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] no rule matched - matched=%v, services=%d", matched, len(matchedServices))
+		s.emitTrace(ctx, reqCtx, trace, -1, 0, 0, nil, "no_match", "no rule matched the request")
 		return nil, false
 	}
 
@@ -79,6 +204,8 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	}
 	if len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] matched rule has no services in current candidate set")
+		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, 0, 0, nil, "no_candidates",
+			"matched rule has no services in current candidate set")
 		return nil, false
 	}
 
@@ -91,6 +218,8 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	activeServices := FilterActiveServices(matchedServices)
 	if len(activeServices) == 0 {
 		logrus.Debugf("[smart_routing] no active services in matched set")
+		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil, "no_active_services",
+			"matched rule has no active services")
 		return nil, false
 	}
 
@@ -98,17 +227,23 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if len(activeServices) == 1 {
 		result := NewResult(activeServices[0], "smart_routing")
 		result.MatchedSmartRuleIndex = matchedRuleIndex
+		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
+			activeServices[0], "selected", "single active service in matched set")
 		return result, true
 	}
 
 	// Multiple services: apply load balancing within matched set
 	service := s.selectFromServices(activeServices, rule)
 	if service == nil {
+		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
+			nil, "lb_failed", "load balancer returned no service")
 		return nil, false
 	}
 
 	result := NewResult(service, "smart_routing")
 	result.MatchedSmartRuleIndex = matchedRuleIndex
+	s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
+		service, "selected", "load balanced within matched set")
 	return result, true
 }
 

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -1,8 +1,6 @@
 package routing
 
 import (
-	"strings"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -38,36 +36,38 @@ func (s *SmartRoutingStage) Name() string {
 	return "smart_routing"
 }
 
-const traceSnippetMaxLen = 200
+// requestHeadLen is intentionally small — the per-op trace already records a
+// window around the matched substring (or a small head for non-text ops), so
+// the snapshot only needs to surface enough context to recognize *which*
+// request a row corresponds to. We avoid storing the full message bodies.
+const requestHeadLen = 80
 
-func snippetForLog(s string) string {
-	if len(s) <= traceSnippetMaxLen {
+func requestHead(s string) string {
+	if len(s) <= requestHeadLen {
 		return s
 	}
-	return s[:traceSnippetMaxLen] + "…"
+	return s[:requestHeadLen] + "…"
 }
 
 // requestSnapshot captures key request fields used during smart routing
 // evaluation so operators can correlate decisions with what the request
-// actually looked like.
+// actually looked like. Long message bodies are truncated to a short head;
+// the per-op trace owns the matched-substring windowing so we don't duplicate
+// large payloads in memory.
 func requestSnapshot(reqCtx *smartrouting.RequestContext) map[string]interface{} {
 	if reqCtx == nil {
 		return nil
 	}
-	systemCombined := strings.Join(reqCtx.SystemMessages, "\n")
-	userCombined := strings.Join(reqCtx.UserMessages, "\n")
 	return map[string]interface{}{
-		"model":             reqCtx.Model,
-		"thinking_enabled":  reqCtx.ThinkingEnabled,
-		"latest_role":       reqCtx.LatestRole,
-		"latest_type":       reqCtx.LatestContentType,
-		"estimated_tokens":  reqCtx.EstimatedTokens,
-		"tool_uses":         reqCtx.ToolUses,
-		"system_snippet":    snippetForLog(systemCombined),
-		"latest_user":       snippetForLog(reqCtx.GetLatestUserMessage()),
-		"user_snippet":      snippetForLog(userCombined),
-		"system_msg_count":  len(reqCtx.SystemMessages),
-		"user_msg_count":    len(reqCtx.UserMessages),
+		"model":            reqCtx.Model,
+		"thinking_enabled": reqCtx.ThinkingEnabled,
+		"latest_role":      reqCtx.LatestRole,
+		"latest_type":      reqCtx.LatestContentType,
+		"estimated_tokens": reqCtx.EstimatedTokens,
+		"tool_uses":        reqCtx.ToolUses,
+		"latest_user_head": requestHead(reqCtx.GetLatestUserMessage()),
+		"system_msg_count": len(reqCtx.SystemMessages),
+		"user_msg_count":   len(reqCtx.UserMessages),
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -644,8 +644,10 @@ func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
 	// Initialize affinity store for smart routing
 	affinityStore := NewAffinityStore(0) // 0 = use default TTL
 
-	// Initialize routing selector with pipeline
-	serviceSelector := routing.NewServiceSelector(cfg, affinityStore, loadBalancer)
+	// Initialize routing selector with pipeline. Pass multiLogger so smart
+	// routing stages emit per-request evaluation traces to the smart_routing
+	// log source viewable from the frontend system log page.
+	serviceSelector := routing.NewServiceSelectorWithLogger(cfg, affinityStore, loadBalancer, server.multiLogger)
 	simpleSelector := routing.NewSimpleSelector(serviceSelector)
 
 	// Initialize load balancer API

--- a/internal/server/smart_routing_helper.go
+++ b/internal/server/smart_routing_helper.go
@@ -5,8 +5,6 @@ package server
 // These methods are kept for backward compatibility with DetermineProviderAndModelWithScenario.
 
 import (
-	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/openai/openai-go/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -18,17 +16,7 @@ import (
 //
 // Deprecated: Use routing/smart_routing_helper.go ExtractRequestContext() instead.
 func (s *Server) ExtractRequestContext(req interface{}) (*smartrouting.RequestContext, error) {
-	switch r := req.(type) {
-	case *openai.ChatCompletionNewParams:
-		return smartrouting.ExtractContextFromOpenAIRequest(r), nil
-	case *anthropic.MessageNewParams:
-		return smartrouting.ExtractContextFromAnthropicRequest(r), nil
-	case *anthropic.BetaMessageNewParams:
-		return smartrouting.ExtractContextFromBetaRequest(r), nil
-	default:
-		logrus.Debugf("[smart_routing] unknown request type %T, cannot extract context", req)
-		return nil, nil
-	}
+	return smartrouting.ExtractContext(req), nil
 }
 
 // SelectServiceFromSmartRouting selects a service from matched smart routing services

--- a/internal/server/system_log_handler.go
+++ b/internal/server/system_log_handler.go
@@ -234,6 +234,86 @@ func (s *Server) GetActionHistory(c *gin.Context) {
 	})
 }
 
+// SmartRoutingLogEntry mirrors SystemLogEntry but is sourced from the dedicated
+// smart_routing in-memory sink so users can inspect per-request evaluation
+// traces without having to scroll through unrelated system messages.
+type SmartRoutingLogEntry struct {
+	Time    time.Time              `json:"time"`
+	Level   string                 `json:"level"`
+	Message string                 `json:"message"`
+	Fields  map[string]interface{} `json:"fields,omitempty"`
+}
+
+// SmartRoutingLogsResponse represents the API response for smart routing logs
+type SmartRoutingLogsResponse struct {
+	Total int                    `json:"total"`
+	Logs  []SmartRoutingLogEntry `json:"logs"`
+}
+
+// GetSmartRoutingLogs retrieves recent smart routing evaluation traces.
+// Each entry corresponds to a single request that hit a smart-routing-enabled
+// rule and contains a structured trace of which rule/op matched and why.
+//
+// Query parameters:
+//   - limit: maximum number of recent entries to return (default: 100, max: 1000)
+func (s *Server) GetSmartRoutingLogs(c *gin.Context) {
+	if s.multiLogger == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "Smart routing logger not available",
+		})
+		return
+	}
+
+	limitStr := c.DefaultQuery("limit", "100")
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	scoped := s.multiLogger.WithSource(obs.LogSourceSmartRouting)
+	entries := scoped.GetMemoryLatest(limit)
+
+	logs := make([]SmartRoutingLogEntry, 0, len(entries))
+	for _, entry := range entries {
+		fields := make(map[string]interface{}, len(entry.Data))
+		for k, v := range entry.Data {
+			if k == "source" {
+				continue
+			}
+			fields[k] = v
+		}
+		logs = append(logs, SmartRoutingLogEntry{
+			Time:    entry.Time,
+			Level:   entry.Level.String(),
+			Message: entry.Message,
+			Fields:  fields,
+		})
+	}
+
+	c.JSON(http.StatusOK, SmartRoutingLogsResponse{
+		Total: len(logs),
+		Logs:  logs,
+	})
+}
+
+// ClearSmartRoutingLogs empties the in-memory smart routing log buffer. Useful
+// when iterating on routing rules and wanting a clean slate for the next
+// request.
+func (s *Server) ClearSmartRoutingLogs(c *gin.Context) {
+	if s.multiLogger == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "Smart routing logger not available",
+		})
+		return
+	}
+	scoped := s.multiLogger.WithSource(obs.LogSourceSmartRouting)
+	scoped.ClearMemory()
+	c.JSON(http.StatusOK, gin.H{"message": "Smart routing logs cleared"})
+}
+
 // GetActionStats returns statistics about user actions
 func (s *Server) GetActionStats(c *gin.Context) {
 	if s.multiLogger == nil {

--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -729,6 +729,17 @@ func (s *Server) useWebAPIEndpoints(manager *swagger.RouteManager) {
 		swagger.WithTags("system-logs"),
 	)
 
+	// Smart Routing log routes (per-request rule evaluation traces)
+	apiV1.GET("/system/smart-routing/logs", s.GetSmartRoutingLogs,
+		swagger.WithDescription("Get recent smart routing evaluation traces. Each entry contains the request snapshot and per-rule per-op match results."),
+		swagger.WithTags("system-logs"),
+		swagger.WithResponseModel(SmartRoutingLogsResponse{}),
+	)
+	apiV1.DELETE("/system/smart-routing/logs", s.ClearSmartRoutingLogs,
+		swagger.WithDescription("Clear the in-memory smart routing log buffer"),
+		swagger.WithTags("system-logs"),
+	)
+
 	// Action History API routes (user operations/audit log)
 	apiV1.GET("/actions/history", s.GetActionHistory,
 		swagger.WithDescription("Get user action history from memory (recent operations)"),

--- a/internal/smart_routing/README.md
+++ b/internal/smart_routing/README.md
@@ -1,0 +1,228 @@
+# smart_routing
+
+Rule-based request router that picks a service for an LLM request by matching
+operations against an extracted request context. Used by the gateway's
+SmartRoutingStage to choose between multiple upstream services for a single
+scenario.
+
+## Design
+
+Two-pass evaluation, single source of truth:
+
+1. **Extract** request context once via `ExtractContext(req)` — funnels
+   OpenAI / Anthropic v1 / Anthropic Beta requests through
+   `internal/protocol/request/` converters into Anthropic Beta and runs one
+   canonical extractor against it.
+2. **Evaluate** rules in order via `Router.Evaluate(ctx)` — first rule whose
+   ops all match wins. Returns matched services, rule index, matched flag,
+   and a per-rule trace in one pass.
+
+```
+                  ┌────────────────────────────────────────────────┐
+                  │                                                │
+   wire request   │   ExtractContext(req)  ───►  RequestContext    │
+   (OpenAI /      │       │                                        │
+    Anthropic v1/ │       │ uses                                   │
+    Anthropic Beta)       ▼                                        │
+                  │   internal/protocol/request/                   │
+                  │   converters → Anthropic Beta                  │
+                  │                                                │
+                  └────────────────────────────────────────────────┘
+                                                  │
+                                                  ▼
+                  ┌────────────────────────────────────────────────┐
+                  │   Router.Evaluate(ctx)                         │
+                  │     for rule in rules:                         │
+                  │       for op in rule.Ops:                      │
+                  │         res = evaluateOp(ctx, op)              │
+                  │         if not res.Matched: break              │
+                  │       if all matched: pick rule, return        │
+                  │                                                │
+                  │   returns (services, idx, matched, trace)      │
+                  └────────────────────────────────────────────────┘
+```
+
+### Why one canonical protocol
+
+Earlier the package carried its own protocol-specific extractors (one per
+wire format), duplicating logic that already lived in
+`internal/protocol/request/`. We picked **Anthropic Beta** as the canonical
+because:
+
+- It has the richest expressivity (system blocks, content blocks, tool_use,
+  thinking, cache_control).
+- Free converters from OpenAI already exist (`ConvertOpenAIToAnthropicRequest`).
+- Anthropic v1 is structurally a subset (`ConvertAnthropicV1ToBetaRequest`
+  is a thin field copy).
+
+The extractor reads only what routing needs (model, system text, user text,
+tool names, thinking flag, image presence, latest role/content type).
+
+### Why one evaluator
+
+The trace path used to be a parallel re-implementation of the boolean fast
+path — the same per-position switch written twice, plus
+`stage_smart_routing.go` calling both back-to-back per request. That's
+double the CPU and a permanent source of fast/verbose drift (every new
+position risked being added to only one side).
+
+Now `evaluateOp` returns `OpEvalResult { Matched, Reason, Actual, … }`. The
+boolean wrappers (`EvaluateRequest`, `EvaluateRequestWithIndex`) read
+`.Matched`. `TraceEvaluation` and `Evaluate` read the rest. Adding a new
+position means writing one method.
+
+## Concepts
+
+A **rule** (`SmartRouting`) is `[]Op + []Service`. The router iterates rules
+in order and the first rule whose ops *all* match wins.
+
+An **op** (`SmartOp`) is `Position + Operation + Value`:
+
+- **Position** — what aspect of the request to inspect.
+- **Operation** — how to compare it (contains / equals / >= / regex / glob).
+- **Value** — the comparison target.
+
+| Position | Reads | Operations |
+|---|---|---|
+| `model` | request model name | `contains`, `glob`, `equals` |
+| `thinking` | thinking-enabled flag | `enabled`, `disabled` |
+| `context_system` | concatenated system messages | `contains`, `regex` |
+| `context_user` | concatenated user messages | `contains`, `regex` |
+| `latest_user` | latest user message + content type | `contains`, `type` |
+| `tool_use` | tool names from assistant messages | `equals` |
+| `token` | estimated token count (chars/4) | `ge`, `gt`, `le`, `lt` |
+| `service_ttft` | rule services' TTFT stats (ms) | `avg_le`, `avg_ge`, `max_le`, `max_ge` |
+| `service_capacity` | rule services' seat utilization (%) | `util_le`, `util_ge`, `util_lt`, `util_gt` |
+| `agent.claude_code` | detected Claude Code request kind | `equals` (`main` / `subagent` / `compact`) |
+
+`service_ttft` and `service_capacity` are seeded per-rule before evaluation
+(`collectRuleStats` / `filterCapacityForRule`); both **pass** when the
+underlying data is empty so cold-start traffic isn't blocked.
+
+### Claude Code request-kind detection
+
+When the scenario is `claude_code`, the SmartRoutingStage populates
+`RequestContext.ClaudeCodeRequestKind` by fingerprinting the system prompt
+(`agent_detect.go`). Precedence is `compact` → `subagent` → `main`
+(most-specific first). The `agent.claude_code` SmartOp surfaces this as a
+routable position.
+
+### Trace
+
+`Router.Evaluate` returns `[]RuleEvalResult` describing every rule that was
+considered (in order, stopping at the first match). Each entry contains the
+ops evaluated, their `Matched` flag, a human-readable `Reason`, and a
+compact `Actual` snippet of the inspected value.
+
+For text positions (`context_*`, `latest_user`), `Actual` is built by
+`snippetAround` — a window around the matched needle decorated with `…` on
+trimmed sides — so the trace stays small even for huge prompts. When there
+is no match, it falls back to a short head snippet.
+
+The trace is consumed by `internal/server/routing/stage_smart_routing.go`
+and emitted as a structured log line so operators can see *why* a request
+matched a rule (or didn't).
+
+## Use cases
+
+### Route haiku-class models to a cheaper provider
+
+```go
+SmartRouting{
+    Description: "haiku → low-cost provider",
+    Ops: []SmartOp{
+        {Position: PositionModel, Operation: OpModelContains, Value: "haiku"},
+    },
+    Services: []*loadbalance.Service{cheapProviderHaiku},
+}
+```
+
+### Send long prompts to a high-context provider
+
+```go
+SmartRouting{
+    Description: "≥ 1M tokens → long-context provider",
+    Ops: []SmartOp{
+        {Position: PositionToken, Operation: OpTokenGe, Value: "1000000",
+         Meta: SmartOpMeta{Type: ValueTypeInt}},
+    },
+    Services: []*loadbalance.Service{longContextProvider},
+}
+```
+
+### Steer Claude Code subagents to a fast/cheap model
+
+```go
+SmartRouting{
+    Description: "Claude Code subagents → haiku",
+    Ops: []SmartOp{
+        {Position: PositionAgentClaudeCode, Operation: OpAgentClaudeCodeEquals,
+         Value: ClaudeCodeKindSubagent},
+    },
+    Services: []*loadbalance.Service{haikuProvider},
+}
+```
+
+### Avoid services with degraded TTFT
+
+```go
+SmartRouting{
+    Description: "skip slow providers",
+    Ops: []SmartOp{
+        {Position: PositionServiceTTFT, Operation: OpServiceTTFTAvgLe, Value: "2000",
+         Meta: SmartOpMeta{Type: ValueTypeInt}},
+    },
+    Services: []*loadbalance.Service{primary, fallback},
+}
+```
+
+### Drain a near-saturated provider
+
+```go
+SmartRouting{
+    Description: "≥80% seats used → spillover provider",
+    Ops: []SmartOp{
+        {Position: PositionServiceCapacity, Operation: OpServiceCapacityUtilGe,
+         Value: "80", Meta: SmartOpMeta{Type: ValueTypeInt}},
+    },
+    Services: []*loadbalance.Service{spillover},
+}
+```
+
+### Combine multiple ops (AND semantics)
+
+All ops in a rule must match — there is no OR, model OR with multiple rules:
+
+```go
+SmartRouting{
+    Description: "thinking-enabled sonnet → reasoning provider",
+    Ops: []SmartOp{
+        {Position: PositionModel, Operation: OpModelContains, Value: "sonnet"},
+        {Position: PositionThinking, Operation: OpThinkingEnabled},
+    },
+    Services: []*loadbalance.Service{reasoningProvider},
+}
+```
+
+## Adding a new position
+
+1. Add a `Position*` constant in `op.go` and the matching `Op*` constants.
+2. Register the (position, operation, value-type) tuples in the `Operations`
+   slice in `op.go` so `ValidateSmartOp` accepts them.
+3. Add a field to `RequestContext` if the position needs new request data,
+   and populate it in `ExtractContextFromBetaRequest`.
+4. Add a `case PositionXxx:` arm in `Router.evaluateOp` and a
+   `evaluateXxxOp(ctx, op) OpEvalResult` method.
+
+That's it — there is no separate trace evaluator to also update.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `routing.go` | Router, evaluator dispatch, per-position evaluators |
+| `eval_trace.go` | Trace types (`OpEvalResult`, `RuleEvalResult`), snippet helpers, `TraceEvaluation` wrapper |
+| `context.go` | `RequestContext`, `ExtractContext` unified entry, Beta extractor |
+| `agent_detect.go` | Claude Code request-kind fingerprinting |
+| `op.go` | Position + Operation constants, `Operations` registry, `SmartOp` value parsing |
+| `type.go` | `SmartRouting`, `SmartOp`, `SmartOpMeta` types |

--- a/internal/smart_routing/context.go
+++ b/internal/smart_routing/context.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
+	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol/request"
 )
 
 // ServiceCapacityInfo holds seat-capacity info for a single service.
@@ -52,170 +54,34 @@ func (rc *RequestContext) CombineMessages(messages []string) string {
 	return strings.Join(messages, "\n")
 }
 
-// ExtractContextFromOpenAIRequest extracts RequestContext from an OpenAI chat completion request
-func ExtractContextFromOpenAIRequest(req *openai.ChatCompletionNewParams) *RequestContext {
-	ctx := &RequestContext{
-		Model: string(req.Model),
+// ExtractContext is the canonical entry point for building a RequestContext.
+// It funnels every supported wire protocol through the existing protocol/request
+// converters into the Anthropic Beta shape, then runs a single extractor against
+// it. Returns nil for unrecognised request types.
+func ExtractContext(req interface{}) *RequestContext {
+	switch r := req.(type) {
+	case *anthropic.BetaMessageNewParams:
+		return ExtractContextFromBetaRequest(r)
+	case *anthropic.MessageNewParams:
+		return ExtractContextFromBetaRequest(request.ConvertAnthropicV1ToBetaRequest(r))
+	case *openai.ChatCompletionNewParams:
+		return ExtractContextFromBetaRequest(request.ConvertOpenAIToAnthropicRequest(r, 0))
+	default:
+		logrus.Debugf("[smart_routing] unknown request type %T, cannot extract context", req)
+		return nil
 	}
-
-	if req.Messages != nil {
-		for _, msgUnion := range req.Messages {
-			switch {
-			case msgUnion.OfSystem != nil:
-				contentStr := extractOpenAISystemContent(msgUnion.OfSystem.Content)
-				ctx.SystemMessages = append(ctx.SystemMessages, contentStr)
-				ctx.LatestRole = "system"
-			case msgUnion.OfUser != nil:
-				contentStr, hasImage := extractOpenAIUserContent(msgUnion.OfUser.Content)
-				ctx.UserMessages = append(ctx.UserMessages, contentStr)
-				ctx.LatestRole = "user"
-				if hasImage {
-					ctx.LatestContentType = "image"
-				}
-			case msgUnion.OfAssistant != nil:
-				ctx.LatestRole = "assistant"
-				// Extract tool calls from assistant messages
-				if len(msgUnion.OfAssistant.ToolCalls) > 0 {
-					for _, toolCallUnion := range msgUnion.OfAssistant.ToolCalls {
-						if toolCallUnion.OfFunction != nil {
-							ctx.ToolUses = append(ctx.ToolUses, toolCallUnion.OfFunction.Function.Name)
-						}
-					}
-				}
-			case msgUnion.OfTool != nil:
-				ctx.LatestRole = "tool"
-			case msgUnion.OfFunction != nil:
-				ctx.LatestRole = "function"
-			}
-		}
-	}
-
-	// Estimate tokens from all content
-	allContent := strings.Join(append(ctx.SystemMessages, ctx.UserMessages...), "\n")
-	ctx.EstimatedTokens = EstimateTokens(allContent)
-
-	return ctx
-}
-
-// extractOpenAISystemContent extracts string content from system message
-func extractOpenAISystemContent(content openai.ChatCompletionSystemMessageParamContentUnion) string {
-	if content.OfString.Valid() {
-		return content.OfString.Value
-	}
-	// Array of text parts
-	var parts []string
-	for _, textPart := range content.OfArrayOfContentParts {
-		parts = append(parts, textPart.Text)
-	}
-	return strings.Join(parts, "\n")
-}
-
-// extractOpenAIUserContent extracts string content and checks for image from user message content
-func extractOpenAIUserContent(content openai.ChatCompletionUserMessageParamContentUnion) (string, bool) {
-	var parts []string
-	hasImage := false
-
-	// Check if it's a string
-	if content.OfString.Valid() {
-		return content.OfString.Value, false
-	}
-
-	// Check if it's an array of content parts
-	for _, partUnion := range content.OfArrayOfContentParts {
-		switch {
-		case partUnion.OfText != nil:
-			parts = append(parts, partUnion.OfText.Text)
-		case partUnion.OfImageURL != nil:
-			hasImage = true
-			parts = append(parts, "[image]")
-		}
-	}
-
-	return strings.Join(parts, "\n"), hasImage
-}
-
-// ExtractContextFromAnthropicRequest extracts RequestContext from an Anthropic messages request
-func ExtractContextFromAnthropicRequest(req *anthropic.MessageNewParams) *RequestContext {
-	ctx := &RequestContext{
-		Model:           string(req.Model),
-		ThinkingEnabled: req.Thinking.OfEnabled != nil,
-	}
-
-	if req.System != nil {
-		for _, s := range req.System {
-			if s.Text != "" {
-				ctx.SystemMessages = append(ctx.SystemMessages, s.Text)
-			}
-		}
-	}
-
-	if req.Messages != nil {
-		for _, msg := range req.Messages {
-			ctx.LatestRole = string(msg.Role)
-
-			// Only process user messages
-			if string(msg.Role) != "user" {
-				continue
-			}
-
-			contentStr, toolUses := extractAnthropicContent(msg.Content)
-			hasImage := hasImageInAnthropicContent(msg.Content)
-
-			if contentStr != "" {
-				ctx.UserMessages = append(ctx.UserMessages, contentStr)
-			}
-			if hasImage {
-				ctx.LatestContentType = "image"
-			}
-
-			ctx.ToolUses = append(ctx.ToolUses, toolUses...)
-		}
-	}
-
-	// Estimate tokens from all content
-	allContent := strings.Join(append(ctx.SystemMessages, ctx.UserMessages...), "\n")
-	ctx.EstimatedTokens = EstimateTokens(allContent)
-
-	return ctx
-}
-
-// extractAnthropicContent extracts string content and tool uses from Anthropic content blocks
-func extractAnthropicContent(content []anthropic.ContentBlockParamUnion) (string, []string) {
-	var parts []string
-	var tools []string
-
-	for _, blockUnion := range content {
-		switch {
-		case blockUnion.OfText != nil:
-			parts = append(parts, blockUnion.OfText.Text)
-		case blockUnion.OfImage != nil:
-			parts = append(parts, "[image]")
-		case blockUnion.OfToolUse != nil:
-			tools = append(tools, blockUnion.OfToolUse.Name)
-		}
-	}
-
-	return strings.Join(parts, "\n"), tools
-}
-
-// hasImageInAnthropicContent checks if content contains image
-func hasImageInAnthropicContent(content []anthropic.ContentBlockParamUnion) bool {
-	for _, blockUnion := range content {
-		if blockUnion.OfImage != nil {
-			return true
-		}
-	}
-	return false
 }
 
 // ExtractContextFromBetaRequest extracts RequestContext from an Anthropic beta messages request
 func ExtractContextFromBetaRequest(req *anthropic.BetaMessageNewParams) *RequestContext {
+	if req == nil {
+		return nil
+	}
 	ctx := &RequestContext{
 		Model:           string(req.Model),
 		ThinkingEnabled: req.Thinking.OfEnabled != nil,
 	}
 
-	// Extract system messages
 	if req.System != nil {
 		for _, s := range req.System {
 			if s.Text != "" {
@@ -224,12 +90,10 @@ func ExtractContextFromBetaRequest(req *anthropic.BetaMessageNewParams) *Request
 		}
 	}
 
-	// Extract messages and tool uses
 	if req.Messages != nil {
 		for _, msg := range req.Messages {
 			ctx.LatestRole = string(msg.Role)
 
-			// Only process user messages
 			if string(msg.Role) != "user" {
 				continue
 			}
@@ -248,7 +112,6 @@ func ExtractContextFromBetaRequest(req *anthropic.BetaMessageNewParams) *Request
 		}
 	}
 
-	// Estimate tokens from all content
 	allContent := strings.Join(append(ctx.SystemMessages, ctx.UserMessages...), "\n")
 	ctx.EstimatedTokens = EstimateTokens(allContent)
 

--- a/internal/smart_routing/eval_trace.go
+++ b/internal/smart_routing/eval_trace.go
@@ -1,23 +1,19 @@
 package smartrouting
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/gobwas/glob"
-)
+import "strings"
 
 // OpEvalResult captures the outcome of evaluating a single SmartOp against a
-// request context. It is intended for diagnostic logging and surfaces both the
-// configured operation and the runtime value that was compared.
+// request context. It is the unified return type of the evaluator: the
+// fast-path (EvaluateRequest etc.) reads only Matched, while diagnostic
+// callers also read Reason and Actual.
 type OpEvalResult struct {
 	UUID      string `json:"uuid,omitempty"`
 	Position  string `json:"position"`
 	Operation string `json:"operation"`
-	Value     string `json:"value,omitempty"`     // configured comparison value
-	Actual    string `json:"actual,omitempty"`    // value extracted from request (may be truncated)
+	Value     string `json:"value,omitempty"`  // configured comparison value
+	Actual    string `json:"actual,omitempty"` // value extracted from request (may be truncated)
 	Matched   bool   `json:"matched"`
-	Reason    string `json:"reason,omitempty"`    // human-readable explanation
+	Reason    string `json:"reason,omitempty"` // human-readable explanation
 }
 
 // RuleEvalResult captures the outcome of evaluating a single SmartRouting rule.
@@ -32,71 +28,18 @@ type RuleEvalResult struct {
 	Ops          []OpEvalResult `json:"ops,omitempty"`
 }
 
-// TraceEvaluation evaluates rules against a context while recording the
-// per-rule, per-op outcomes. It does not return matched services — callers
-// should still use EvaluateRequestWithIndex for actual selection. The trace
-// contains an entry for every rule that was considered (in order, stopping at
-// the first match).
-func (r *Router) TraceEvaluation(ctx *RequestContext) []RuleEvalResult {
-	trace := make([]RuleEvalResult, 0, len(r.rules))
-	for i := range r.rules {
-		rule := &r.rules[i]
-		opResults := r.evaluateRuleVerbose(ctx, rule)
-
-		ruleMatched := true
-		for _, op := range opResults {
-			if !op.Matched {
-				ruleMatched = false
-				break
-			}
-		}
-
-		trace = append(trace, RuleEvalResult{
-			RuleIndex:    i,
-			Description:  rule.Description,
-			Matched:      ruleMatched,
-			OpsEvaluated: len(opResults),
-			OpsTotal:     len(rule.Ops),
-			Ops:          opResults,
-		})
-
-		if ruleMatched {
-			break
-		}
-	}
-	return trace
-}
-
 // ServiceMatch is a lightweight, log-friendly reference to a matched service.
 type ServiceMatch struct {
 	Provider string `json:"provider"`
 	Model    string `json:"model"`
 }
 
-// evaluateRuleVerbose mirrors evaluateRule but records the outcome of each op.
-// It still short-circuits at the first failed op for parity with the runtime
-// evaluator (we don't want to do extra work or report misleading "matches" for
-// ops that wouldn't have been reached).
-func (r *Router) evaluateRuleVerbose(ctx *RequestContext, rule *SmartRouting) []OpEvalResult {
-	origStats := ctx.ServiceStats
-	origCap := ctx.ServiceCapacity
-	ctx.ServiceStats = collectRuleStats(rule.Services)
-	ctx.ServiceCapacity = filterCapacityForRule(ctx.ServiceCapacity, rule.Services)
-	defer func() {
-		ctx.ServiceStats = origStats
-		ctx.ServiceCapacity = origCap
-	}()
-
-	results := make([]OpEvalResult, 0, len(rule.Ops))
-	for i := range rule.Ops {
-		op := &rule.Ops[i]
-		res := r.evaluateOpVerbose(ctx, op)
-		results = append(results, res)
-		if !res.Matched {
-			break
-		}
-	}
-	return results
+// TraceEvaluation evaluates rules against a context and returns the per-rule
+// trace. Callers that also need the matched services should use
+// (*Router).Evaluate to avoid iterating twice.
+func (r *Router) TraceEvaluation(ctx *RequestContext) []RuleEvalResult {
+	_, _, _, trace := r.Evaluate(ctx)
+	return trace
 }
 
 // snippetMatchCtx is how many characters of leading/trailing context are kept
@@ -111,8 +54,8 @@ const snippetHeadLen = 120
 
 // snippetAround returns a window around the first occurrence of needle inside
 // text, decorated with ellipses on whichever side was trimmed. When needle is
-// empty or not present, it falls back to a head snippet so the trace still
-// shows *some* of the input the rule was evaluated against.
+// empty or not present, falls back to snippetHead so the trace still shows
+// some of the input the rule was evaluated against.
 func snippetAround(text, needle string) string {
 	if text == "" {
 		return ""
@@ -149,320 +92,4 @@ func snippetHead(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
-}
-
-// evaluateOpVerbose returns an OpEvalResult while preserving the existing
-// boolean evaluation logic. The reason / actual fields are populated to make
-// the outcome diagnosable from the system log. Text-position evaluators set
-// Actual themselves so they can show a window around the matched substring
-// (or a small head when there is no match) rather than a useless prefix of a
-// long message.
-func (r *Router) evaluateOpVerbose(ctx *RequestContext, op *SmartOp) OpEvalResult {
-	res := OpEvalResult{
-		UUID:      op.UUID,
-		Position:  string(op.Position),
-		Operation: string(op.Operation),
-		Value:     op.Value,
-	}
-
-	switch op.Position {
-	case PositionModel:
-		res.Actual = ctx.Model
-		matched, reason := evalModel(ctx.Model, op)
-		res.Matched = matched
-		res.Reason = reason
-	case PositionThinking:
-		res.Actual = boolStr(ctx.ThinkingEnabled)
-		matched, reason := evalThinking(ctx.ThinkingEnabled, op)
-		res.Matched = matched
-		res.Reason = reason
-	case PositionContextSystem:
-		combined := ctx.CombineMessages(ctx.SystemMessages)
-		matched, reason, actual := evalContains(combined, op, "system")
-		res.Matched = matched
-		res.Reason = reason
-		res.Actual = actual
-	case PositionContextUser:
-		combined := ctx.CombineMessages(ctx.UserMessages)
-		matched, reason, actual := evalContains(combined, op, "user")
-		res.Matched = matched
-		res.Reason = reason
-		res.Actual = actual
-	case PositionLatestUser:
-		matched, reason, actual := evalLatestUser(ctx, op)
-		res.Matched = matched
-		res.Reason = reason
-		res.Actual = actual
-	case PositionToolUse:
-		res.Actual = strings.Join(ctx.ToolUses, ",")
-		matched, reason := evalToolUse(ctx.ToolUses, op)
-		res.Matched = matched
-		res.Reason = reason
-	case PositionToken:
-		res.Actual = fmt.Sprintf("%d", ctx.EstimatedTokens)
-		matched, reason := evalToken(ctx.EstimatedTokens, op)
-		res.Matched = matched
-		res.Reason = reason
-	case PositionServiceTTFT:
-		matched, reason, actual := evalServiceTTFT(ctx, op)
-		res.Actual = actual
-		res.Matched = matched
-		res.Reason = reason
-	case PositionServiceCapacity:
-		matched, reason, actual := evalServiceCapacity(ctx, op)
-		res.Actual = actual
-		res.Matched = matched
-		res.Reason = reason
-	case PositionAgentClaudeCode:
-		res.Actual = ctx.ClaudeCodeRequestKind
-		matched, reason := evalAgentClaudeCode(ctx.ClaudeCodeRequestKind, op)
-		res.Matched = matched
-		res.Reason = reason
-	default:
-		res.Matched = false
-		res.Reason = fmt.Sprintf("unknown position %q", op.Position)
-	}
-	return res
-}
-
-func boolStr(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}
-
-// --- per-position evaluators (return matched, reason). They duplicate the core
-//     logic in routing.go but produce diagnostic strings so the system log can
-//     explain *why* each op did or didn't match. ---
-
-func evalModel(model string, op *SmartOp) (bool, string) {
-	value, err := op.String()
-	if err != nil {
-		return false, fmt.Sprintf("invalid value: %v", err)
-	}
-	switch op.Operation {
-	case OpModelContains:
-		ok := strings.Contains(model, value)
-		return ok, fmt.Sprintf("model %q contains %q = %v", model, value, ok)
-	case OpModelGlob:
-		g, err := glob.Compile(value)
-		if err != nil {
-			return false, fmt.Sprintf("invalid glob %q: %v", value, err)
-		}
-		ok := g.Match(model)
-		return ok, fmt.Sprintf("model %q matches glob %q = %v", model, value, ok)
-	case OpModelEquals:
-		ok := model == value
-		return ok, fmt.Sprintf("model %q equals %q = %v", model, value, ok)
-	}
-	return false, fmt.Sprintf("unsupported model op %q", op.Operation)
-}
-
-func evalThinking(enabled bool, op *SmartOp) (bool, string) {
-	val, err := op.Bool()
-	if err != nil && op.Value != "" {
-		return false, fmt.Sprintf("invalid bool %q: %v", op.Value, err)
-	}
-	switch op.Operation {
-	case OpThinkingEnabled:
-		if op.Value == "" || val {
-			return enabled, fmt.Sprintf("thinking enabled = %v", enabled)
-		}
-		return false, "value=false; check is no-op"
-	case OpThinkingDisabled:
-		if op.Value == "" || val {
-			return !enabled, fmt.Sprintf("thinking disabled = %v", !enabled)
-		}
-		return false, "value=false; check is no-op"
-	}
-	return false, fmt.Sprintf("unsupported thinking op %q", op.Operation)
-}
-
-// evalContains evaluates the system/user "contains" / "regex" ops and returns
-// the matched flag, a human-readable reason, and a compact snippet of the
-// input. For "contains" we return a window around the match (or a short head
-// when there's no match) so the trace stays small even for huge prompts.
-func evalContains(combined string, op *SmartOp, label string) (bool, string, string) {
-	value, err := op.String()
-	if err != nil {
-		return false, fmt.Sprintf("invalid value: %v", err), ""
-	}
-	// OpContextSystemContains and OpContextUserContains are distinguished by
-	// position (handled by the caller), but share the same operation string
-	// "contains". Same for "regex". Match by string value here.
-	switch string(op.Operation) {
-	case "contains":
-		ok := strings.Contains(combined, value)
-		actual := snippetAround(combined, value)
-		return ok, fmt.Sprintf("%s context contains %q = %v", label, value, ok), actual
-	case "regex":
-		ok, err := stringsMatch(combined, value, true)
-		if err != nil {
-			return false, fmt.Sprintf("regex error: %v", err), snippetHead(combined, snippetHeadLen)
-		}
-		// glob/regex doesn't expose match position; fall back to a head snippet.
-		return ok, fmt.Sprintf("%s context matches %q = %v", label, value, ok), snippetHead(combined, snippetHeadLen)
-	}
-	return false, fmt.Sprintf("unsupported %s op %q", label, op.Operation), snippetHead(combined, snippetHeadLen)
-}
-
-func evalLatestUser(ctx *RequestContext, op *SmartOp) (bool, string, string) {
-	value, err := op.String()
-	if err != nil {
-		return false, fmt.Sprintf("invalid value: %v", err), ""
-	}
-	switch op.Operation {
-	case OpLatestUserContains:
-		latest := ctx.GetLatestUserMessage()
-		if ctx.LatestRole != "user" {
-			return false,
-				fmt.Sprintf("latest role is %q, not user", ctx.LatestRole),
-				snippetHead(latest, snippetHeadLen)
-		}
-		ok := strings.Contains(latest, value)
-		return ok, fmt.Sprintf("latest user contains %q = %v", value, ok), snippetAround(latest, value)
-	case OpLatestUserRequestType:
-		ok := ctx.LatestContentType == value
-		return ok, fmt.Sprintf("latest content_type %q == %q = %v", ctx.LatestContentType, value, ok), ctx.LatestContentType
-	}
-	return false, fmt.Sprintf("unsupported latest_user op %q", op.Operation), ""
-}
-
-func evalToolUse(tools []string, op *SmartOp) (bool, string) {
-	value, err := op.String()
-	if err != nil {
-		return false, fmt.Sprintf("invalid value: %v", err)
-	}
-	if op.Operation != OpToolUseEquals {
-		return false, fmt.Sprintf("unsupported tool_use op %q", op.Operation)
-	}
-	for _, t := range tools {
-		if t == value {
-			return true, fmt.Sprintf("tool %q used", value)
-		}
-	}
-	return false, fmt.Sprintf("tool %q not in [%s]", value, strings.Join(tools, ","))
-}
-
-func evalToken(tokens int, op *SmartOp) (bool, string) {
-	target, err := op.Int()
-	if err != nil {
-		return false, fmt.Sprintf("invalid int: %v", err)
-	}
-	switch op.Operation {
-	case OpTokenGe:
-		ok := tokens >= target
-		return ok, fmt.Sprintf("tokens %d >= %d = %v", tokens, target, ok)
-	case OpTokenGt:
-		ok := tokens > target
-		return ok, fmt.Sprintf("tokens %d > %d = %v", tokens, target, ok)
-	case OpTokenLe:
-		ok := tokens <= target
-		return ok, fmt.Sprintf("tokens %d <= %d = %v", tokens, target, ok)
-	case OpTokenLt:
-		ok := tokens < target
-		return ok, fmt.Sprintf("tokens %d < %d = %v", tokens, target, ok)
-	}
-	return false, fmt.Sprintf("unsupported token op %q", op.Operation)
-}
-
-func evalServiceTTFT(ctx *RequestContext, op *SmartOp) (bool, string, string) {
-	if len(ctx.ServiceStats) == 0 {
-		return true, "no service stats; pass", ""
-	}
-	threshold, err := op.Int()
-	if err != nil {
-		return false, fmt.Sprintf("invalid int: %v", err), ""
-	}
-	var values []float64
-	for _, s := range ctx.ServiceStats {
-		switch op.Operation {
-		case OpServiceTTFTAvgLe, OpServiceTTFTAvgGe:
-			if s.AvgTTFTMs > 0 {
-				values = append(values, s.AvgTTFTMs)
-			}
-		case OpServiceTTFTMaxLe, OpServiceTTFTMaxGe:
-			if s.P99TTFTMs > 0 {
-				values = append(values, s.P99TTFTMs)
-			}
-		}
-	}
-	if len(values) == 0 {
-		return true, "no TTFT samples; pass", ""
-	}
-	thresholdF := float64(threshold)
-	switch op.Operation {
-	case OpServiceTTFTAvgLe:
-		actual := minFloat(values)
-		ok := actual <= thresholdF
-		return ok, fmt.Sprintf("min(avg_ttft) %.0f <= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
-	case OpServiceTTFTAvgGe:
-		actual := avgFloat(values)
-		ok := actual >= thresholdF
-		return ok, fmt.Sprintf("avg(avg_ttft) %.0f >= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
-	case OpServiceTTFTMaxLe:
-		actual := minFloat(values)
-		ok := actual <= thresholdF
-		return ok, fmt.Sprintf("min(p99_ttft) %.0f <= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
-	case OpServiceTTFTMaxGe:
-		actual := avgFloat(values)
-		ok := actual >= thresholdF
-		return ok, fmt.Sprintf("avg(p99_ttft) %.0f >= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
-	}
-	return false, fmt.Sprintf("unsupported service_ttft op %q", op.Operation), ""
-}
-
-func evalAgentClaudeCode(kind string, op *SmartOp) (bool, string) {
-	value, err := op.String()
-	if err != nil {
-		return false, fmt.Sprintf("invalid value: %v", err)
-	}
-	if op.Operation != OpAgentClaudeCodeEquals {
-		return false, fmt.Sprintf("unsupported agent.claude_code op %q", op.Operation)
-	}
-	if kind == "" {
-		return false, "request kind not set (scenario is not claude_code)"
-	}
-	ok := kind == value
-	return ok, fmt.Sprintf("agent.claude_code %q == %q = %v", kind, value, ok)
-}
-
-func evalServiceCapacity(ctx *RequestContext, op *SmartOp) (bool, string, string) {
-	if len(ctx.ServiceCapacity) == 0 {
-		return true, "no capacity info; pass", ""
-	}
-	threshold, err := op.Int()
-	if err != nil {
-		return false, fmt.Sprintf("invalid int: %v", err), ""
-	}
-	var utilValues []float64
-	for _, c := range ctx.ServiceCapacity {
-		if c.Capacity <= 0 {
-			continue
-		}
-		util := float64(c.ActiveCount) / float64(c.Capacity) * 100
-		utilValues = append(utilValues, util)
-	}
-	if len(utilValues) == 0 {
-		return true, "no capacity-configured services; pass", ""
-	}
-	avg := avgFloat(utilValues)
-	thresholdF := float64(threshold)
-	actual := fmt.Sprintf("%.1f%%", avg)
-	switch op.Operation {
-	case OpServiceCapacityUtilLe:
-		ok := avg <= thresholdF
-		return ok, fmt.Sprintf("avg util %.1f%% <= %d%% = %v", avg, threshold, ok), actual
-	case OpServiceCapacityUtilGe:
-		ok := avg >= thresholdF
-		return ok, fmt.Sprintf("avg util %.1f%% >= %d%% = %v", avg, threshold, ok), actual
-	case OpServiceCapacityUtilLt:
-		ok := avg < thresholdF
-		return ok, fmt.Sprintf("avg util %.1f%% < %d%% = %v", avg, threshold, ok), actual
-	case OpServiceCapacityUtilGt:
-		ok := avg > thresholdF
-		return ok, fmt.Sprintf("avg util %.1f%% > %d%% = %v", avg, threshold, ok), actual
-	}
-	return false, fmt.Sprintf("unsupported service_capacity op %q", op.Operation), actual
 }

--- a/internal/smart_routing/eval_trace.go
+++ b/internal/smart_routing/eval_trace.go
@@ -99,18 +99,64 @@ func (r *Router) evaluateRuleVerbose(ctx *RequestContext, rule *SmartRouting) []
 	return results
 }
 
-const traceMaxLen = 200
+// snippetMatchCtx is how many characters of leading/trailing context are kept
+// around a matched substring. Tuned to read like ~one short line on either
+// side (enough for context, but tiny relative to typical chat history).
+const snippetMatchCtx = 80
 
-func truncForTrace(s string) string {
-	if len(s) <= traceMaxLen {
+// snippetHeadLen is the maximum head length kept when there's nothing more
+// specific to point at (e.g. a regex op against a long body). Smaller than
+// snippetAround windows because it carries less diagnostic value.
+const snippetHeadLen = 120
+
+// snippetAround returns a window around the first occurrence of needle inside
+// text, decorated with ellipses on whichever side was trimmed. When needle is
+// empty or not present, it falls back to a head snippet so the trace still
+// shows *some* of the input the rule was evaluated against.
+func snippetAround(text, needle string) string {
+	if text == "" {
+		return ""
+	}
+	if needle == "" {
+		return snippetHead(text, snippetHeadLen)
+	}
+	idx := strings.Index(text, needle)
+	if idx < 0 {
+		return snippetHead(text, snippetHeadLen)
+	}
+	start := idx - snippetMatchCtx
+	if start < 0 {
+		start = 0
+	}
+	end := idx + len(needle) + snippetMatchCtx
+	if end > len(text) {
+		end = len(text)
+	}
+	prefix := ""
+	if start > 0 {
+		prefix = "…"
+	}
+	suffix := ""
+	if end < len(text) {
+		suffix = "…"
+	}
+	return prefix + text[start:end] + suffix
+}
+
+// snippetHead returns the first n chars of s with an ellipsis if truncated.
+func snippetHead(s string, n int) string {
+	if len(s) <= n {
 		return s
 	}
-	return s[:traceMaxLen] + "…"
+	return s[:n] + "…"
 }
 
 // evaluateOpVerbose returns an OpEvalResult while preserving the existing
 // boolean evaluation logic. The reason / actual fields are populated to make
-// the outcome diagnosable from the system log.
+// the outcome diagnosable from the system log. Text-position evaluators set
+// Actual themselves so they can show a window around the matched substring
+// (or a small head when there is no match) rather than a useless prefix of a
+// long message.
 func (r *Router) evaluateOpVerbose(ctx *RequestContext, op *SmartOp) OpEvalResult {
 	res := OpEvalResult{
 		UUID:      op.UUID,
@@ -132,21 +178,21 @@ func (r *Router) evaluateOpVerbose(ctx *RequestContext, op *SmartOp) OpEvalResul
 		res.Reason = reason
 	case PositionContextSystem:
 		combined := ctx.CombineMessages(ctx.SystemMessages)
-		res.Actual = truncForTrace(combined)
-		matched, reason := evalContains(combined, op, "system")
+		matched, reason, actual := evalContains(combined, op, "system")
 		res.Matched = matched
 		res.Reason = reason
+		res.Actual = actual
 	case PositionContextUser:
 		combined := ctx.CombineMessages(ctx.UserMessages)
-		res.Actual = truncForTrace(combined)
-		matched, reason := evalContains(combined, op, "user")
+		matched, reason, actual := evalContains(combined, op, "user")
 		res.Matched = matched
 		res.Reason = reason
+		res.Actual = actual
 	case PositionLatestUser:
 		matched, reason, actual := evalLatestUser(ctx, op)
-		res.Actual = truncForTrace(actual)
 		res.Matched = matched
 		res.Reason = reason
+		res.Actual = actual
 	case PositionToolUse:
 		res.Actual = strings.Join(ctx.ToolUses, ",")
 		matched, reason := evalToolUse(ctx.ToolUses, op)
@@ -233,10 +279,14 @@ func evalThinking(enabled bool, op *SmartOp) (bool, string) {
 	return false, fmt.Sprintf("unsupported thinking op %q", op.Operation)
 }
 
-func evalContains(combined string, op *SmartOp, label string) (bool, string) {
+// evalContains evaluates the system/user "contains" / "regex" ops and returns
+// the matched flag, a human-readable reason, and a compact snippet of the
+// input. For "contains" we return a window around the match (or a short head
+// when there's no match) so the trace stays small even for huge prompts.
+func evalContains(combined string, op *SmartOp, label string) (bool, string, string) {
 	value, err := op.String()
 	if err != nil {
-		return false, fmt.Sprintf("invalid value: %v", err)
+		return false, fmt.Sprintf("invalid value: %v", err), ""
 	}
 	// OpContextSystemContains and OpContextUserContains are distinguished by
 	// position (handled by the caller), but share the same operation string
@@ -244,15 +294,17 @@ func evalContains(combined string, op *SmartOp, label string) (bool, string) {
 	switch string(op.Operation) {
 	case "contains":
 		ok := strings.Contains(combined, value)
-		return ok, fmt.Sprintf("%s context contains %q = %v", label, value, ok)
+		actual := snippetAround(combined, value)
+		return ok, fmt.Sprintf("%s context contains %q = %v", label, value, ok), actual
 	case "regex":
 		ok, err := stringsMatch(combined, value, true)
 		if err != nil {
-			return false, fmt.Sprintf("regex error: %v", err)
+			return false, fmt.Sprintf("regex error: %v", err), snippetHead(combined, snippetHeadLen)
 		}
-		return ok, fmt.Sprintf("%s context matches %q = %v", label, value, ok)
+		// glob/regex doesn't expose match position; fall back to a head snippet.
+		return ok, fmt.Sprintf("%s context matches %q = %v", label, value, ok), snippetHead(combined, snippetHeadLen)
 	}
-	return false, fmt.Sprintf("unsupported %s op %q", label, op.Operation)
+	return false, fmt.Sprintf("unsupported %s op %q", label, op.Operation), snippetHead(combined, snippetHeadLen)
 }
 
 func evalLatestUser(ctx *RequestContext, op *SmartOp) (bool, string, string) {
@@ -262,12 +314,14 @@ func evalLatestUser(ctx *RequestContext, op *SmartOp) (bool, string, string) {
 	}
 	switch op.Operation {
 	case OpLatestUserContains:
-		if ctx.LatestRole != "user" {
-			return false, fmt.Sprintf("latest role is %q, not user", ctx.LatestRole), ctx.GetLatestUserMessage()
-		}
 		latest := ctx.GetLatestUserMessage()
+		if ctx.LatestRole != "user" {
+			return false,
+				fmt.Sprintf("latest role is %q, not user", ctx.LatestRole),
+				snippetHead(latest, snippetHeadLen)
+		}
 		ok := strings.Contains(latest, value)
-		return ok, fmt.Sprintf("latest user contains %q = %v", value, ok), latest
+		return ok, fmt.Sprintf("latest user contains %q = %v", value, ok), snippetAround(latest, value)
 	case OpLatestUserRequestType:
 		ok := ctx.LatestContentType == value
 		return ok, fmt.Sprintf("latest content_type %q == %q = %v", ctx.LatestContentType, value, ok), ctx.LatestContentType

--- a/internal/smart_routing/eval_trace.go
+++ b/internal/smart_routing/eval_trace.go
@@ -1,0 +1,414 @@
+package smartrouting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// OpEvalResult captures the outcome of evaluating a single SmartOp against a
+// request context. It is intended for diagnostic logging and surfaces both the
+// configured operation and the runtime value that was compared.
+type OpEvalResult struct {
+	UUID      string `json:"uuid,omitempty"`
+	Position  string `json:"position"`
+	Operation string `json:"operation"`
+	Value     string `json:"value,omitempty"`     // configured comparison value
+	Actual    string `json:"actual,omitempty"`    // value extracted from request (may be truncated)
+	Matched   bool   `json:"matched"`
+	Reason    string `json:"reason,omitempty"`    // human-readable explanation
+}
+
+// RuleEvalResult captures the outcome of evaluating a single SmartRouting rule.
+// Ops contains entries for every op evaluated; evaluation short-circuits at the
+// first failed op (so the slice may end with a non-matching entry).
+type RuleEvalResult struct {
+	RuleIndex    int            `json:"rule_index"`
+	Description  string         `json:"description,omitempty"`
+	Matched      bool           `json:"matched"`
+	OpsEvaluated int            `json:"ops_evaluated"`
+	OpsTotal     int            `json:"ops_total"`
+	Ops          []OpEvalResult `json:"ops,omitempty"`
+}
+
+// TraceEvaluation evaluates rules against a context while recording the
+// per-rule, per-op outcomes. It does not return matched services — callers
+// should still use EvaluateRequestWithIndex for actual selection. The trace
+// contains an entry for every rule that was considered (in order, stopping at
+// the first match).
+func (r *Router) TraceEvaluation(ctx *RequestContext) []RuleEvalResult {
+	trace := make([]RuleEvalResult, 0, len(r.rules))
+	for i := range r.rules {
+		rule := &r.rules[i]
+		opResults := r.evaluateRuleVerbose(ctx, rule)
+
+		ruleMatched := true
+		for _, op := range opResults {
+			if !op.Matched {
+				ruleMatched = false
+				break
+			}
+		}
+
+		trace = append(trace, RuleEvalResult{
+			RuleIndex:    i,
+			Description:  rule.Description,
+			Matched:      ruleMatched,
+			OpsEvaluated: len(opResults),
+			OpsTotal:     len(rule.Ops),
+			Ops:          opResults,
+		})
+
+		if ruleMatched {
+			break
+		}
+	}
+	return trace
+}
+
+// ServiceMatch is a lightweight, log-friendly reference to a matched service.
+type ServiceMatch struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// evaluateRuleVerbose mirrors evaluateRule but records the outcome of each op.
+// It still short-circuits at the first failed op for parity with the runtime
+// evaluator (we don't want to do extra work or report misleading "matches" for
+// ops that wouldn't have been reached).
+func (r *Router) evaluateRuleVerbose(ctx *RequestContext, rule *SmartRouting) []OpEvalResult {
+	origStats := ctx.ServiceStats
+	origCap := ctx.ServiceCapacity
+	ctx.ServiceStats = collectRuleStats(rule.Services)
+	ctx.ServiceCapacity = filterCapacityForRule(ctx.ServiceCapacity, rule.Services)
+	defer func() {
+		ctx.ServiceStats = origStats
+		ctx.ServiceCapacity = origCap
+	}()
+
+	results := make([]OpEvalResult, 0, len(rule.Ops))
+	for i := range rule.Ops {
+		op := &rule.Ops[i]
+		res := r.evaluateOpVerbose(ctx, op)
+		results = append(results, res)
+		if !res.Matched {
+			break
+		}
+	}
+	return results
+}
+
+const traceMaxLen = 200
+
+func truncForTrace(s string) string {
+	if len(s) <= traceMaxLen {
+		return s
+	}
+	return s[:traceMaxLen] + "…"
+}
+
+// evaluateOpVerbose returns an OpEvalResult while preserving the existing
+// boolean evaluation logic. The reason / actual fields are populated to make
+// the outcome diagnosable from the system log.
+func (r *Router) evaluateOpVerbose(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := OpEvalResult{
+		UUID:      op.UUID,
+		Position:  string(op.Position),
+		Operation: string(op.Operation),
+		Value:     op.Value,
+	}
+
+	switch op.Position {
+	case PositionModel:
+		res.Actual = ctx.Model
+		matched, reason := evalModel(ctx.Model, op)
+		res.Matched = matched
+		res.Reason = reason
+	case PositionThinking:
+		res.Actual = boolStr(ctx.ThinkingEnabled)
+		matched, reason := evalThinking(ctx.ThinkingEnabled, op)
+		res.Matched = matched
+		res.Reason = reason
+	case PositionContextSystem:
+		combined := ctx.CombineMessages(ctx.SystemMessages)
+		res.Actual = truncForTrace(combined)
+		matched, reason := evalContains(combined, op, "system")
+		res.Matched = matched
+		res.Reason = reason
+	case PositionContextUser:
+		combined := ctx.CombineMessages(ctx.UserMessages)
+		res.Actual = truncForTrace(combined)
+		matched, reason := evalContains(combined, op, "user")
+		res.Matched = matched
+		res.Reason = reason
+	case PositionLatestUser:
+		matched, reason, actual := evalLatestUser(ctx, op)
+		res.Actual = truncForTrace(actual)
+		res.Matched = matched
+		res.Reason = reason
+	case PositionToolUse:
+		res.Actual = strings.Join(ctx.ToolUses, ",")
+		matched, reason := evalToolUse(ctx.ToolUses, op)
+		res.Matched = matched
+		res.Reason = reason
+	case PositionToken:
+		res.Actual = fmt.Sprintf("%d", ctx.EstimatedTokens)
+		matched, reason := evalToken(ctx.EstimatedTokens, op)
+		res.Matched = matched
+		res.Reason = reason
+	case PositionServiceTTFT:
+		matched, reason, actual := evalServiceTTFT(ctx, op)
+		res.Actual = actual
+		res.Matched = matched
+		res.Reason = reason
+	case PositionServiceCapacity:
+		matched, reason, actual := evalServiceCapacity(ctx, op)
+		res.Actual = actual
+		res.Matched = matched
+		res.Reason = reason
+	case PositionAgentClaudeCode:
+		res.Actual = ctx.ClaudeCodeRequestKind
+		matched, reason := evalAgentClaudeCode(ctx.ClaudeCodeRequestKind, op)
+		res.Matched = matched
+		res.Reason = reason
+	default:
+		res.Matched = false
+		res.Reason = fmt.Sprintf("unknown position %q", op.Position)
+	}
+	return res
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// --- per-position evaluators (return matched, reason). They duplicate the core
+//     logic in routing.go but produce diagnostic strings so the system log can
+//     explain *why* each op did or didn't match. ---
+
+func evalModel(model string, op *SmartOp) (bool, string) {
+	value, err := op.String()
+	if err != nil {
+		return false, fmt.Sprintf("invalid value: %v", err)
+	}
+	switch op.Operation {
+	case OpModelContains:
+		ok := strings.Contains(model, value)
+		return ok, fmt.Sprintf("model %q contains %q = %v", model, value, ok)
+	case OpModelGlob:
+		g, err := glob.Compile(value)
+		if err != nil {
+			return false, fmt.Sprintf("invalid glob %q: %v", value, err)
+		}
+		ok := g.Match(model)
+		return ok, fmt.Sprintf("model %q matches glob %q = %v", model, value, ok)
+	case OpModelEquals:
+		ok := model == value
+		return ok, fmt.Sprintf("model %q equals %q = %v", model, value, ok)
+	}
+	return false, fmt.Sprintf("unsupported model op %q", op.Operation)
+}
+
+func evalThinking(enabled bool, op *SmartOp) (bool, string) {
+	val, err := op.Bool()
+	if err != nil && op.Value != "" {
+		return false, fmt.Sprintf("invalid bool %q: %v", op.Value, err)
+	}
+	switch op.Operation {
+	case OpThinkingEnabled:
+		if op.Value == "" || val {
+			return enabled, fmt.Sprintf("thinking enabled = %v", enabled)
+		}
+		return false, "value=false; check is no-op"
+	case OpThinkingDisabled:
+		if op.Value == "" || val {
+			return !enabled, fmt.Sprintf("thinking disabled = %v", !enabled)
+		}
+		return false, "value=false; check is no-op"
+	}
+	return false, fmt.Sprintf("unsupported thinking op %q", op.Operation)
+}
+
+func evalContains(combined string, op *SmartOp, label string) (bool, string) {
+	value, err := op.String()
+	if err != nil {
+		return false, fmt.Sprintf("invalid value: %v", err)
+	}
+	// OpContextSystemContains and OpContextUserContains are distinguished by
+	// position (handled by the caller), but share the same operation string
+	// "contains". Same for "regex". Match by string value here.
+	switch string(op.Operation) {
+	case "contains":
+		ok := strings.Contains(combined, value)
+		return ok, fmt.Sprintf("%s context contains %q = %v", label, value, ok)
+	case "regex":
+		ok, err := stringsMatch(combined, value, true)
+		if err != nil {
+			return false, fmt.Sprintf("regex error: %v", err)
+		}
+		return ok, fmt.Sprintf("%s context matches %q = %v", label, value, ok)
+	}
+	return false, fmt.Sprintf("unsupported %s op %q", label, op.Operation)
+}
+
+func evalLatestUser(ctx *RequestContext, op *SmartOp) (bool, string, string) {
+	value, err := op.String()
+	if err != nil {
+		return false, fmt.Sprintf("invalid value: %v", err), ""
+	}
+	switch op.Operation {
+	case OpLatestUserContains:
+		if ctx.LatestRole != "user" {
+			return false, fmt.Sprintf("latest role is %q, not user", ctx.LatestRole), ctx.GetLatestUserMessage()
+		}
+		latest := ctx.GetLatestUserMessage()
+		ok := strings.Contains(latest, value)
+		return ok, fmt.Sprintf("latest user contains %q = %v", value, ok), latest
+	case OpLatestUserRequestType:
+		ok := ctx.LatestContentType == value
+		return ok, fmt.Sprintf("latest content_type %q == %q = %v", ctx.LatestContentType, value, ok), ctx.LatestContentType
+	}
+	return false, fmt.Sprintf("unsupported latest_user op %q", op.Operation), ""
+}
+
+func evalToolUse(tools []string, op *SmartOp) (bool, string) {
+	value, err := op.String()
+	if err != nil {
+		return false, fmt.Sprintf("invalid value: %v", err)
+	}
+	if op.Operation != OpToolUseEquals {
+		return false, fmt.Sprintf("unsupported tool_use op %q", op.Operation)
+	}
+	for _, t := range tools {
+		if t == value {
+			return true, fmt.Sprintf("tool %q used", value)
+		}
+	}
+	return false, fmt.Sprintf("tool %q not in [%s]", value, strings.Join(tools, ","))
+}
+
+func evalToken(tokens int, op *SmartOp) (bool, string) {
+	target, err := op.Int()
+	if err != nil {
+		return false, fmt.Sprintf("invalid int: %v", err)
+	}
+	switch op.Operation {
+	case OpTokenGe:
+		ok := tokens >= target
+		return ok, fmt.Sprintf("tokens %d >= %d = %v", tokens, target, ok)
+	case OpTokenGt:
+		ok := tokens > target
+		return ok, fmt.Sprintf("tokens %d > %d = %v", tokens, target, ok)
+	case OpTokenLe:
+		ok := tokens <= target
+		return ok, fmt.Sprintf("tokens %d <= %d = %v", tokens, target, ok)
+	case OpTokenLt:
+		ok := tokens < target
+		return ok, fmt.Sprintf("tokens %d < %d = %v", tokens, target, ok)
+	}
+	return false, fmt.Sprintf("unsupported token op %q", op.Operation)
+}
+
+func evalServiceTTFT(ctx *RequestContext, op *SmartOp) (bool, string, string) {
+	if len(ctx.ServiceStats) == 0 {
+		return true, "no service stats; pass", ""
+	}
+	threshold, err := op.Int()
+	if err != nil {
+		return false, fmt.Sprintf("invalid int: %v", err), ""
+	}
+	var values []float64
+	for _, s := range ctx.ServiceStats {
+		switch op.Operation {
+		case OpServiceTTFTAvgLe, OpServiceTTFTAvgGe:
+			if s.AvgTTFTMs > 0 {
+				values = append(values, s.AvgTTFTMs)
+			}
+		case OpServiceTTFTMaxLe, OpServiceTTFTMaxGe:
+			if s.P99TTFTMs > 0 {
+				values = append(values, s.P99TTFTMs)
+			}
+		}
+	}
+	if len(values) == 0 {
+		return true, "no TTFT samples; pass", ""
+	}
+	thresholdF := float64(threshold)
+	switch op.Operation {
+	case OpServiceTTFTAvgLe:
+		actual := minFloat(values)
+		ok := actual <= thresholdF
+		return ok, fmt.Sprintf("min(avg_ttft) %.0f <= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
+	case OpServiceTTFTAvgGe:
+		actual := avgFloat(values)
+		ok := actual >= thresholdF
+		return ok, fmt.Sprintf("avg(avg_ttft) %.0f >= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
+	case OpServiceTTFTMaxLe:
+		actual := minFloat(values)
+		ok := actual <= thresholdF
+		return ok, fmt.Sprintf("min(p99_ttft) %.0f <= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
+	case OpServiceTTFTMaxGe:
+		actual := avgFloat(values)
+		ok := actual >= thresholdF
+		return ok, fmt.Sprintf("avg(p99_ttft) %.0f >= %d = %v", actual, threshold, ok), fmt.Sprintf("%.0f", actual)
+	}
+	return false, fmt.Sprintf("unsupported service_ttft op %q", op.Operation), ""
+}
+
+func evalAgentClaudeCode(kind string, op *SmartOp) (bool, string) {
+	value, err := op.String()
+	if err != nil {
+		return false, fmt.Sprintf("invalid value: %v", err)
+	}
+	if op.Operation != OpAgentClaudeCodeEquals {
+		return false, fmt.Sprintf("unsupported agent.claude_code op %q", op.Operation)
+	}
+	if kind == "" {
+		return false, "request kind not set (scenario is not claude_code)"
+	}
+	ok := kind == value
+	return ok, fmt.Sprintf("agent.claude_code %q == %q = %v", kind, value, ok)
+}
+
+func evalServiceCapacity(ctx *RequestContext, op *SmartOp) (bool, string, string) {
+	if len(ctx.ServiceCapacity) == 0 {
+		return true, "no capacity info; pass", ""
+	}
+	threshold, err := op.Int()
+	if err != nil {
+		return false, fmt.Sprintf("invalid int: %v", err), ""
+	}
+	var utilValues []float64
+	for _, c := range ctx.ServiceCapacity {
+		if c.Capacity <= 0 {
+			continue
+		}
+		util := float64(c.ActiveCount) / float64(c.Capacity) * 100
+		utilValues = append(utilValues, util)
+	}
+	if len(utilValues) == 0 {
+		return true, "no capacity-configured services; pass", ""
+	}
+	avg := avgFloat(utilValues)
+	thresholdF := float64(threshold)
+	actual := fmt.Sprintf("%.1f%%", avg)
+	switch op.Operation {
+	case OpServiceCapacityUtilLe:
+		ok := avg <= thresholdF
+		return ok, fmt.Sprintf("avg util %.1f%% <= %d%% = %v", avg, threshold, ok), actual
+	case OpServiceCapacityUtilGe:
+		ok := avg >= thresholdF
+		return ok, fmt.Sprintf("avg util %.1f%% >= %d%% = %v", avg, threshold, ok), actual
+	case OpServiceCapacityUtilLt:
+		ok := avg < thresholdF
+		return ok, fmt.Sprintf("avg util %.1f%% < %d%% = %v", avg, threshold, ok), actual
+	case OpServiceCapacityUtilGt:
+		ok := avg > thresholdF
+		return ok, fmt.Sprintf("avg util %.1f%% > %d%% = %v", avg, threshold, ok), actual
+	}
+	return false, fmt.Sprintf("unsupported service_capacity op %q", op.Operation), actual
+}

--- a/internal/smart_routing/eval_trace_test.go
+++ b/internal/smart_routing/eval_trace_test.go
@@ -1,6 +1,7 @@
 package smartrouting
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,61 @@ func TestTraceEvaluation_MatchAndMiss(t *testing.T) {
 	require.True(t, trace[1].Matched)
 	require.True(t, trace[1].Ops[0].Matched)
 	require.Equal(t, "5000", trace[1].Ops[0].Actual)
+}
+
+func TestTraceEvaluation_SnippetWindowAroundMatch(t *testing.T) {
+	// Build a long user message with the needle buried in the middle so the
+	// trace has to extract a window around it instead of dumping the whole body.
+	prefix := strings.Repeat("aaaaaaaaaa ", 200) // ~2200 chars
+	suffix := strings.Repeat(" bbbbbbbbbb", 200)
+	body := prefix + "NEEDLE" + suffix
+
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "user contains NEEDLE",
+			Ops: []SmartOp{
+				{Position: PositionContextUser, Operation: OpContextUserContains, Value: "NEEDLE"},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "p", Model: "m", Weight: 1, Active: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	trace := router.TraceEvaluation(&RequestContext{UserMessages: []string{body}})
+	require.Len(t, trace, 1)
+	require.True(t, trace[0].Matched)
+
+	actual := trace[0].Ops[0].Actual
+	require.Contains(t, actual, "NEEDLE", "snippet should contain the matched needle")
+	require.True(t, strings.HasPrefix(actual, "…"), "long-prefix matches should be ellipsised on the left")
+	require.True(t, strings.HasSuffix(actual, "…"), "long-suffix matches should be ellipsised on the right")
+	require.Less(t, len(actual), 300, "snippet should be much smaller than the original body")
+}
+
+func TestTraceEvaluation_NoMatchKeepsHeadSnippet(t *testing.T) {
+	body := strings.Repeat("xxxxxxxxxx", 500) // 5000 chars
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "user contains zzz (won't match)",
+			Ops: []SmartOp{
+				{Position: PositionContextUser, Operation: OpContextUserContains, Value: "zzz"},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "p", Model: "m", Weight: 1, Active: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	trace := router.TraceEvaluation(&RequestContext{UserMessages: []string{body}})
+	require.Len(t, trace, 1)
+	require.False(t, trace[0].Matched)
+
+	actual := trace[0].Ops[0].Actual
+	require.True(t, strings.HasSuffix(actual, "…"), "no-match should fall back to a head snippet with trailing ellipsis")
+	require.LessOrEqual(t, len(actual), snippetHeadLen+5, "no-match head snippet should stay small")
 }
 
 func TestTraceEvaluation_ShortCircuitsAtFirstFailedOp(t *testing.T) {

--- a/internal/smart_routing/eval_trace_test.go
+++ b/internal/smart_routing/eval_trace_test.go
@@ -1,0 +1,80 @@
+package smartrouting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func TestTraceEvaluation_MatchAndMiss(t *testing.T) {
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "haiku only",
+			Ops: []SmartOp{
+				{Position: PositionModel, Operation: OpModelContains, Value: "haiku"},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "p1", Model: "claude-haiku", Weight: 1, Active: true},
+			},
+		},
+		{
+			Description: "long context",
+			Ops: []SmartOp{
+				{Position: PositionToken, Operation: OpTokenGe, Value: "1000",
+					Meta: SmartOpMeta{Type: ValueTypeInt}},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "p2", Model: "claude-opus", Weight: 1, Active: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := &RequestContext{
+		Model:           "claude-sonnet",
+		EstimatedTokens: 5000,
+	}
+	trace := router.TraceEvaluation(ctx)
+	require.Len(t, trace, 2, "second rule should still be evaluated since first failed")
+
+	// Rule 0 — model contains haiku, should be a miss with explanation
+	require.Equal(t, 0, trace[0].RuleIndex)
+	require.False(t, trace[0].Matched)
+	require.Equal(t, 1, trace[0].OpsTotal)
+	require.Len(t, trace[0].Ops, 1)
+	require.False(t, trace[0].Ops[0].Matched)
+	require.NotEmpty(t, trace[0].Ops[0].Reason)
+	require.Equal(t, "claude-sonnet", trace[0].Ops[0].Actual)
+
+	// Rule 1 — token >= 1000 with 5000, should match and stop evaluation
+	require.Equal(t, 1, trace[1].RuleIndex)
+	require.True(t, trace[1].Matched)
+	require.True(t, trace[1].Ops[0].Matched)
+	require.Equal(t, "5000", trace[1].Ops[0].Actual)
+}
+
+func TestTraceEvaluation_ShortCircuitsAtFirstFailedOp(t *testing.T) {
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "two ops, second never reached when first fails",
+			Ops: []SmartOp{
+				{Position: PositionModel, Operation: OpModelEquals, Value: "no-such-model"},
+				{Position: PositionToken, Operation: OpTokenGe, Value: "10",
+					Meta: SmartOpMeta{Type: ValueTypeInt}},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "p", Model: "m", Weight: 1, Active: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	trace := router.TraceEvaluation(&RequestContext{Model: "actually-different", EstimatedTokens: 100})
+	require.Len(t, trace, 1)
+	require.False(t, trace[0].Matched)
+	require.Equal(t, 1, trace[0].OpsEvaluated, "second op should not be evaluated after first miss")
+	require.Equal(t, 2, trace[0].OpsTotal)
+	require.Len(t, trace[0].Ops, 1)
+}

--- a/internal/smart_routing/router_test.go
+++ b/internal/smart_routing/router_test.go
@@ -45,7 +45,7 @@ func TestSmartRouting_Integration_OpenAI(t *testing.T) {
 	}
 
 	// Extract context and evaluate
-	ctx := ExtractContextFromOpenAIRequest(req)
+	ctx := ExtractContext(req)
 	services, matched := router.EvaluateRequest(ctx)
 
 	require.True(t, matched, "should match the gpt routing rule")
@@ -116,7 +116,7 @@ func TestSmartRouting_Integration_Anthropic(t *testing.T) {
 		},
 	}
 
-	ctx := ExtractContextFromAnthropicRequest(reqThinking)
+	ctx := ExtractContext(reqThinking)
 	services, matched := router.EvaluateRequest(ctx)
 
 	require.True(t, matched, "should match the thinking routing rule")
@@ -133,7 +133,7 @@ func TestSmartRouting_Integration_Anthropic(t *testing.T) {
 		},
 	}
 
-	ctx = ExtractContextFromAnthropicRequest(reqHaiku)
+	ctx = ExtractContext(reqHaiku)
 	services, matched = router.EvaluateRequest(ctx)
 
 	require.True(t, matched, "should match the haiku routing rule")
@@ -154,7 +154,7 @@ func TestSmartRouting_Integration_Anthropic_ImageContent(t *testing.T) {
 		},
 	}
 
-	ctx := ExtractContextFromAnthropicRequest(req)
+	ctx := ExtractContext(req)
 	require.Equal(t, "image", ctx.LatestContentType)
 }
 

--- a/internal/smart_routing/routing.go
+++ b/internal/smart_routing/routing.go
@@ -17,43 +17,52 @@ type Router struct {
 
 // NewRouter creates a new smart routing router
 func NewRouter(rules []SmartRouting) (*Router, error) {
-	// Validate all rules
 	for i, rule := range rules {
 		if err := ValidateSmartRouting(&rule); err != nil {
 			return nil, fmt.Errorf("rule[%d]: %w", i, err)
 		}
 	}
-
-	return &Router{
-		rules: rules,
-	}, nil
+	return &Router{rules: rules}, nil
 }
 
-// EvaluateRequest evaluates a request against smart routing rules
-// Returns the matched services and true if a rule matched, otherwise empty and false
+// Evaluate runs the rule list against ctx in a single pass and returns the
+// matched services (or nil), the matched rule index (or -1), the matched flag,
+// and the per-rule trace. All other public Evaluate* / TraceEvaluation methods
+// are thin wrappers around this.
+func (r *Router) Evaluate(ctx *RequestContext) (services []*loadbalance.Service, ruleIdx int, matched bool, trace []RuleEvalResult) {
+	trace = make([]RuleEvalResult, 0, len(r.rules))
+	ruleIdx = -1
+	for i := range r.rules {
+		rule := &r.rules[i]
+		ruleRes := r.evaluateRule(ctx, rule, i)
+		trace = append(trace, ruleRes)
+		if ruleRes.Matched {
+			services = rule.Services
+			ruleIdx = i
+			matched = true
+			break
+		}
+	}
+	return
+}
+
+// EvaluateRequest evaluates a request against smart routing rules.
+// Returns the matched services and true if a rule matched, otherwise nil and false.
 func (r *Router) EvaluateRequest(ctx *RequestContext) ([]*loadbalance.Service, bool) {
-	for i := range r.rules {
-		if r.evaluateRule(ctx, &r.rules[i]) {
-			return r.rules[i].Services, true
-		}
-	}
-	return nil, false
+	services, _, matched, _ := r.Evaluate(ctx)
+	return services, matched
 }
 
-// EvaluateRequestWithIndex evaluates a request against smart routing rules
-// Returns the matched services, the matched rule index, and true if a rule matched
+// EvaluateRequestWithIndex is EvaluateRequest plus the matched rule index.
 func (r *Router) EvaluateRequestWithIndex(ctx *RequestContext) ([]*loadbalance.Service, int, bool) {
-	for i := range r.rules {
-		if r.evaluateRule(ctx, &r.rules[i]) {
-			return r.rules[i].Services, i, true
-		}
-	}
-	return nil, -1, false
+	services, idx, matched, _ := r.Evaluate(ctx)
+	return services, idx, matched
 }
 
-// evaluateRule evaluates if a context matches a single rule
-func (r *Router) evaluateRule(ctx *RequestContext, rule *SmartRouting) bool {
-	// Inject per-rule service data to avoid cross-rule contamination
+// evaluateRule evaluates a single rule and returns the per-op trace plus the
+// composite Matched flag. Evaluation short-circuits at the first failed op so
+// the returned Ops slice may end on a non-matching entry.
+func (r *Router) evaluateRule(ctx *RequestContext, rule *SmartRouting, idx int) RuleEvalResult {
 	origStats := ctx.ServiceStats
 	origCap := ctx.ServiceCapacity
 	ctx.ServiceStats = collectRuleStats(rule.Services)
@@ -63,17 +72,29 @@ func (r *Router) evaluateRule(ctx *RequestContext, rule *SmartRouting) bool {
 		ctx.ServiceCapacity = origCap
 	}()
 
-	// All operations must match (AND logic)
-	for _, op := range rule.Ops {
-		if !r.evaluateOp(ctx, &op) {
-			return false
+	res := RuleEvalResult{
+		RuleIndex:   idx,
+		Description: rule.Description,
+		OpsTotal:    len(rule.Ops),
+		Matched:     true,
+		Ops:         make([]OpEvalResult, 0, len(rule.Ops)),
+	}
+	for i := range rule.Ops {
+		opRes := r.evaluateOp(ctx, &rule.Ops[i])
+		res.Ops = append(res.Ops, opRes)
+		if !opRes.Matched {
+			res.Matched = false
+			break
 		}
 	}
-	return true
+	res.OpsEvaluated = len(res.Ops)
+	return res
 }
 
-// evaluateOp evaluates if a context matches a single operation
-func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) bool {
+// evaluateOp dispatches to the per-position evaluator. The returned
+// OpEvalResult always has Position/Operation/Value populated; per-position
+// methods set Matched plus optional Reason and Actual.
+func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
 	switch op.Position {
 	case PositionModel:
 		return r.evaluateModelOp(ctx, op)
@@ -96,7 +117,20 @@ func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) bool {
 	case PositionAgentClaudeCode:
 		return r.evaluateAgentClaudeCodeOp(ctx, op)
 	default:
-		return false
+		res := newOpResult(op)
+		res.Reason = fmt.Sprintf("unknown position %q", op.Position)
+		return res
+	}
+}
+
+// newOpResult seeds an OpEvalResult with the configured op metadata. Matched
+// defaults to false; per-position evaluators set it on success.
+func newOpResult(op *SmartOp) OpEvalResult {
+	return OpEvalResult{
+		UUID:      op.UUID,
+		Position:  string(op.Position),
+		Operation: string(op.Operation),
+		Value:     op.Value,
 	}
 }
 
@@ -105,21 +139,17 @@ func ValidateSmartRouting(rule *SmartRouting) error {
 	if rule.Description == "" {
 		return fmt.Errorf("description cannot be empty")
 	}
-
 	if len(rule.Ops) == 0 {
 		return fmt.Errorf("ops cannot be empty")
 	}
-
 	for i, op := range rule.Ops {
 		if err := ValidateSmartOp(&op); err != nil {
 			return fmt.Errorf("op[%d]: %w", i, err)
 		}
 	}
-
 	if len(rule.Services) == 0 {
 		return fmt.Errorf("services cannot be empty")
 	}
-
 	for i, svc := range rule.Services {
 		if svc.Provider == "" {
 			return fmt.Errorf("services[%d]: provider cannot be empty", i)
@@ -128,7 +158,6 @@ func ValidateSmartRouting(rule *SmartRouting) error {
 			return fmt.Errorf("services[%d]: model cannot be empty", i)
 		}
 	}
-
 	return nil
 }
 
@@ -137,28 +166,17 @@ func ValidateSmartOp(op *SmartOp) error {
 	if !op.Position.IsValid() {
 		return fmt.Errorf("invalid position: %s", op.Position)
 	}
-
 	if op.Operation == "" {
 		return fmt.Errorf("operation cannot be empty")
 	}
-
-	// Validate operation is compatible with position
 	if !isValidOperationForPosition(op.Position, op.Operation) {
 		return fmt.Errorf("operation '%s' is not valid for position '%s'", op.Operation, op.Position)
 	}
-
-	// Validate value matches the expected type
-	if err := validateOpValueType(op); err != nil {
-		return err
-	}
-
-	return nil
+	return validateOpValueType(op)
 }
 
-// validateOpValueType checks if the value can be parsed as the expected type
 func validateOpValueType(op *SmartOp) error {
-	// Get the expected type from Operations registry
-	expectedType := ValueTypeString // Default to string for backward compatibility
+	expectedType := ValueTypeString
 	for _, validOp := range Operations {
 		if validOp.Position == op.Position && validOp.Operation == op.Operation {
 			if validOp.Meta.Type != "" {
@@ -167,16 +185,11 @@ func validateOpValueType(op *SmartOp) error {
 			break
 		}
 	}
-
-	// Skip validation if no type specified (backward compatibility)
 	if expectedType == ValueTypeString && op.Meta.Type == "" {
 		return nil
 	}
-
-	// Validate the value can be parsed as expected type
 	switch expectedType {
 	case ValueTypeString:
-		// Any string is valid
 		return nil
 	case ValueTypeInt:
 		_, err := op.Int()
@@ -189,8 +202,6 @@ func validateOpValueType(op *SmartOp) error {
 	}
 }
 
-// isValidOperationForPosition checks if an operation is valid for a given position
-// by looking it up in the global Operations registry
 func isValidOperationForPosition(pos SmartOpPosition, op SmartOpOperation) bool {
 	for _, validOp := range Operations {
 		if validOp.Position == pos && validOp.Operation == op {
@@ -200,246 +211,209 @@ func isValidOperationForPosition(pos SmartOpPosition, op SmartOpOperation) bool 
 	return false
 }
 
-// evaluateModelOp evaluates operations on the model field
-func (r *Router) evaluateModelOp(ctx *RequestContext, op *SmartOp) bool {
-	model := ctx.Model
+func (r *Router) evaluateModelOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	res.Actual = ctx.Model
 	value, err := op.String()
 	if err != nil {
 		log.Printf("[smart_routing] invalid model value '%s': %v", op.Value, err)
-		return false
+		res.Reason = fmt.Sprintf("invalid value: %v", err)
+		return res
 	}
-
 	switch op.Operation {
 	case OpModelContains:
-		return strings.Contains(model, value)
+		res.Matched = strings.Contains(ctx.Model, value)
+		res.Reason = fmt.Sprintf("model %q contains %q", ctx.Model, value)
 	case OpModelGlob:
 		g, err := glob.Compile(value)
 		if err != nil {
 			log.Printf("[smart_routing] invalid glob pattern '%s' in model operation: %v", value, err)
-			return false
+			res.Reason = fmt.Sprintf("invalid glob %q: %v", value, err)
+			return res
 		}
-		return g.Match(model)
+		res.Matched = g.Match(ctx.Model)
+		res.Reason = fmt.Sprintf("model %q glob %q", ctx.Model, value)
 	case OpModelEquals:
-		return model == value
+		res.Matched = ctx.Model == value
+		res.Reason = fmt.Sprintf("model %q equals %q", ctx.Model, value)
 	default:
-		return false
+		res.Reason = fmt.Sprintf("unsupported model op %q", op.Operation)
 	}
+	return res
 }
 
-// evaluateThinkingOp evaluates operations on the thinking field
-func (r *Router) evaluateThinkingOp(ctx *RequestContext, op *SmartOp) bool {
-	enabled := ctx.ThinkingEnabled
-
+func (r *Router) evaluateThinkingOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	res.Actual = boolStr(ctx.ThinkingEnabled)
+	val, err := op.Bool()
+	if err != nil && op.Value != "" {
+		log.Printf("[smart_routing] invalid thinking value '%s': %v", op.Value, err)
+		res.Reason = fmt.Sprintf("invalid bool %q: %v", op.Value, err)
+		return res
+	}
 	switch op.Operation {
 	case OpThinkingEnabled:
-		// Parse value as bool; empty string defaults to true (just checking enabled state)
-		val, err := op.Bool()
-		if err != nil && op.Value != "" {
-			log.Printf("[smart_routing] invalid thinking value '%s': %v", op.Value, err)
-			return false
-		}
-		// If value parsed successfully and is true, check if enabled
-		// If value is empty, just check if enabled
 		if op.Value == "" || val {
-			return enabled
+			res.Matched = ctx.ThinkingEnabled
+			res.Reason = "thinking enabled"
+		} else {
+			res.Reason = "value=false; check is no-op"
 		}
-		return false
 	case OpThinkingDisabled:
-		val, err := op.Bool()
-		if err != nil && op.Value != "" {
-			log.Printf("[smart_routing] invalid thinking value '%s': %v", op.Value, err)
-			return false
-		}
 		if op.Value == "" || val {
-			return !enabled
+			res.Matched = !ctx.ThinkingEnabled
+			res.Reason = "thinking disabled"
+		} else {
+			res.Reason = "value=false; check is no-op"
 		}
-		return false
 	default:
-		return false
+		res.Reason = fmt.Sprintf("unsupported thinking op %q", op.Operation)
 	}
+	return res
 }
 
-// evaluateContextSystemOp evaluates operations on the context system message field
-func (r *Router) evaluateContextSystemOp(ctx *RequestContext, op *SmartOp) bool {
+func (r *Router) evaluateContextSystemOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
 	combined := ctx.CombineMessages(ctx.SystemMessages)
-	value, err := op.String()
-	if err != nil {
-		log.Printf("[smart_routing] invalid system value '%s': %v", op.Value, err)
-		return false
-	}
-
-	switch op.Operation {
-	case OpContextSystemContains:
-		return strings.Contains(combined, value)
-	case OpContextSystemRegex:
-		// Basic regex support - can be extended with regexp package
-		matched, err := stringsMatch(combined, value, true)
-		if err != nil {
-			return false
-		}
-		return matched
-	default:
-		return false
-	}
+	return evaluateTextContains(op, combined, "system context",
+		OpContextSystemContains, OpContextSystemRegex)
 }
 
-// evaluateContextUserOp evaluates operations on the context user message field
-func (r *Router) evaluateContextUserOp(ctx *RequestContext, op *SmartOp) bool {
+func (r *Router) evaluateContextUserOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
 	combined := ctx.CombineMessages(ctx.UserMessages)
-	value, err := op.String()
-	if err != nil {
-		log.Printf("[smart_routing] invalid user value '%s': %v", op.Value, err)
-		return false
-	}
-
-	switch op.Operation {
-	case OpContextUserContains:
-		return strings.Contains(combined, value)
-	case OpContextUserRegex:
-		matched, err := stringsMatch(combined, value, true)
-		if err != nil {
-			return false
-		}
-		return matched
-	default:
-		return false
-	}
+	return evaluateTextContains(op, combined, "user context",
+		OpContextUserContains, OpContextUserRegex)
 }
 
-// evaluateLatestUserOp evaluates operations on the latest user message field
-func (r *Router) evaluateLatestUserOp(ctx *RequestContext, op *SmartOp) bool {
+// evaluateTextContains is the shared body for system/user contains+regex ops.
+// containsOp/regexOp are typed so we don't depend on string equality of "contains".
+func evaluateTextContains(op *SmartOp, text, label string, containsOp, regexOp SmartOpOperation) OpEvalResult {
+	res := newOpResult(op)
+	value, err := op.String()
+	if err != nil {
+		log.Printf("[smart_routing] invalid %s value '%s': %v", label, op.Value, err)
+		res.Reason = fmt.Sprintf("invalid value: %v", err)
+		return res
+	}
+	switch op.Operation {
+	case containsOp:
+		res.Matched = strings.Contains(text, value)
+		res.Actual = snippetAround(text, value)
+		res.Reason = fmt.Sprintf("%s contains %q", label, value)
+	case regexOp:
+		ok, err := stringsMatch(text, value, true)
+		if err != nil {
+			res.Actual = snippetHead(text, snippetHeadLen)
+			res.Reason = fmt.Sprintf("regex error: %v", err)
+			return res
+		}
+		res.Matched = ok
+		res.Actual = snippetHead(text, snippetHeadLen)
+		res.Reason = fmt.Sprintf("%s matches regex %q", label, value)
+	default:
+		res.Actual = snippetHead(text, snippetHeadLen)
+		res.Reason = fmt.Sprintf("unsupported %s op %q", label, op.Operation)
+	}
+	return res
+}
+
+func (r *Router) evaluateLatestUserOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
 	value, err := op.String()
 	if err != nil {
 		log.Printf("[smart_routing] invalid latest user value '%s': %v", op.Value, err)
-		return false
+		res.Reason = fmt.Sprintf("invalid value: %v", err)
+		return res
 	}
-
 	switch op.Operation {
 	case OpLatestUserContains:
-		// Check if latest role is user
-		if ctx.LatestRole != "user" {
-			return false
-		}
 		latest := ctx.GetLatestUserMessage()
-		return strings.Contains(latest, value)
+		if ctx.LatestRole != "user" {
+			res.Actual = snippetHead(latest, snippetHeadLen)
+			res.Reason = fmt.Sprintf("latest role is %q, not user", ctx.LatestRole)
+			return res
+		}
+		res.Matched = strings.Contains(latest, value)
+		res.Actual = snippetAround(latest, value)
+		res.Reason = fmt.Sprintf("latest user contains %q", value)
 	case OpLatestUserRequestType:
-		return ctx.LatestContentType == value
+		res.Actual = ctx.LatestContentType
+		res.Matched = ctx.LatestContentType == value
+		res.Reason = fmt.Sprintf("latest content_type %q == %q", ctx.LatestContentType, value)
 	default:
-		return false
+		res.Reason = fmt.Sprintf("unsupported latest_user op %q", op.Operation)
 	}
+	return res
 }
 
-// evaluateToolUseOp evaluates operations on the tool_use field
-func (r *Router) evaluateToolUseOp(ctx *RequestContext, op *SmartOp) bool {
+func (r *Router) evaluateToolUseOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	res.Actual = strings.Join(ctx.ToolUses, ",")
 	value, err := op.String()
 	if err != nil {
 		log.Printf("[smart_routing] invalid tool_use value '%s': %v", op.Value, err)
-		return false
+		res.Reason = fmt.Sprintf("invalid value: %v", err)
+		return res
 	}
-
-	// Check if any tool use matches
-	for _, toolUse := range ctx.ToolUses {
-		if op.Operation == OpToolUseEquals && toolUse == value {
-			return true
+	if op.Operation != OpToolUseEquals {
+		res.Reason = fmt.Sprintf("unsupported tool_use op %q", op.Operation)
+		return res
+	}
+	for _, t := range ctx.ToolUses {
+		if t == value {
+			res.Matched = true
+			res.Reason = fmt.Sprintf("tool %q used", value)
+			return res
 		}
 	}
-	return false
+	res.Reason = fmt.Sprintf("tool %q not in [%s]", value, strings.Join(ctx.ToolUses, ","))
+	return res
 }
 
-// evaluateTokenOp evaluates operations on the token count field
-func (r *Router) evaluateTokenOp(ctx *RequestContext, op *SmartOp) bool {
-	tokens := ctx.EstimatedTokens
+func (r *Router) evaluateTokenOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	res.Actual = fmt.Sprintf("%d", ctx.EstimatedTokens)
 	target, err := op.Int()
 	if err != nil {
 		log.Printf("[smart_routing] invalid token value '%s': %v", op.Value, err)
-		return false
+		res.Reason = fmt.Sprintf("invalid int: %v", err)
+		return res
 	}
-
+	tokens := ctx.EstimatedTokens
 	switch op.Operation {
 	case OpTokenGe:
-		return tokens >= target
+		res.Matched = tokens >= target
+		res.Reason = fmt.Sprintf("tokens %d >= %d", tokens, target)
 	case OpTokenGt:
-		return tokens > target
+		res.Matched = tokens > target
+		res.Reason = fmt.Sprintf("tokens %d > %d", tokens, target)
 	case OpTokenLe:
-		return tokens <= target
+		res.Matched = tokens <= target
+		res.Reason = fmt.Sprintf("tokens %d <= %d", tokens, target)
 	case OpTokenLt:
-		return tokens < target
+		res.Matched = tokens < target
+		res.Reason = fmt.Sprintf("tokens %d < %d", tokens, target)
 	default:
-		return false
+		res.Reason = fmt.Sprintf("unsupported token op %q", op.Operation)
 	}
+	return res
 }
 
-// evaluateAgentClaudeCodeOp evaluates operations on the agent.claude_code position.
-// The ctx.ClaudeCodeRequestKind field is populated by SmartRoutingStage only when
-// the request scenario is claude_code; for other scenarios it is empty and no
-// value will match — which is the desired behavior.
-func (r *Router) evaluateAgentClaudeCodeOp(ctx *RequestContext, op *SmartOp) bool {
-	value, err := op.String()
-	if err != nil {
-		log.Printf("[smart_routing] invalid agent.claude_code value '%s': %v", op.Value, err)
-		return false
-	}
-	switch op.Operation {
-	case OpAgentClaudeCodeEquals:
-		if ctx.ClaudeCodeRequestKind == "" {
-			return false
-		}
-		return ctx.ClaudeCodeRequestKind == value
-	default:
-		return false
-	}
-}
-
-// stringsMatch provides basic regex matching support
-// For now, it provides simple pattern matching with support for:
-// - Wildcards (*)
-// - Character classes ([abc])
-// - Alternatives (a|b)
-func stringsMatch(text, pattern string, useRegex bool) (bool, error) {
-	if !useRegex {
-		return strings.Contains(text, pattern), nil
-	}
-
-	// For simple patterns, use glob
-	// For complex regex, we'd use the regexp package
-	// This is a simplified implementation
-	g, err := glob.Compile(pattern)
-	if err != nil {
-		log.Printf("[smart_routing] invalid glob/regex pattern '%s', falling back to contains: %v", pattern, err)
-		// Try as simple contains
-		return strings.Contains(text, pattern), nil
-	}
-	return g.Match(text), nil
-}
-
-// EstimateTokens estimates token count from text (rough approximation: 4 chars per token)
-func EstimateTokens(text string) int {
-	if text == "" {
-		return 0
-	}
-	// Rough approximation: ~4 characters per token
-	return len(text) / 4
-}
-
-// GetRules returns the router's rules
-func (r *Router) GetRules() []SmartRouting {
-	return r.rules
-}
-
-// evaluateServiceTTFTOp evaluates operations on service TTFT characteristics.
-// Operates on ctx.ServiceStats, which is pre-filtered per-rule by evaluateRule.
-// Returns true (pass) when there is no data (cold-start friendliness).
-func (r *Router) evaluateServiceTTFTOp(ctx *RequestContext, op *SmartOp) bool {
+// evaluateServiceTTFTOp operates on ctx.ServiceStats, which is pre-filtered
+// per-rule by evaluateRule. Returns Matched=true (pass) when there is no data
+// (cold-start friendliness).
+func (r *Router) evaluateServiceTTFTOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
 	if len(ctx.ServiceStats) == 0 {
-		return true
+		res.Matched = true
+		res.Reason = "no service stats; pass"
+		return res
 	}
-
 	threshold, err := op.Int()
 	if err != nil {
 		log.Printf("[smart_routing] invalid service_ttft value '%s': %v", op.Value, err)
-		return false
+		res.Reason = fmt.Sprintf("invalid int: %v", err)
+		return res
 	}
-
 	var values []float64
 	for _, s := range ctx.ServiceStats {
 		switch op.Operation {
@@ -453,67 +427,149 @@ func (r *Router) evaluateServiceTTFTOp(ctx *RequestContext, op *SmartOp) bool {
 			}
 		}
 	}
-
 	if len(values) == 0 {
-		return true // no samples yet — do not block
+		res.Matched = true
+		res.Reason = "no TTFT samples; pass"
+		return res
 	}
-
 	thresholdF := float64(threshold)
 	switch op.Operation {
 	case OpServiceTTFTAvgLe:
-		return minFloat(values) <= thresholdF
+		actual := minFloat(values)
+		res.Matched = actual <= thresholdF
+		res.Actual = fmt.Sprintf("%.0f", actual)
+		res.Reason = fmt.Sprintf("min(avg_ttft) %.0f <= %d", actual, threshold)
 	case OpServiceTTFTAvgGe:
-		return avgFloat(values) >= thresholdF
+		actual := avgFloat(values)
+		res.Matched = actual >= thresholdF
+		res.Actual = fmt.Sprintf("%.0f", actual)
+		res.Reason = fmt.Sprintf("avg(avg_ttft) %.0f >= %d", actual, threshold)
 	case OpServiceTTFTMaxLe:
-		return minFloat(values) <= thresholdF
+		actual := minFloat(values)
+		res.Matched = actual <= thresholdF
+		res.Actual = fmt.Sprintf("%.0f", actual)
+		res.Reason = fmt.Sprintf("min(p99_ttft) %.0f <= %d", actual, threshold)
 	case OpServiceTTFTMaxGe:
-		return avgFloat(values) >= thresholdF
+		actual := avgFloat(values)
+		res.Matched = actual >= thresholdF
+		res.Actual = fmt.Sprintf("%.0f", actual)
+		res.Reason = fmt.Sprintf("avg(p99_ttft) %.0f >= %d", actual, threshold)
+	default:
+		res.Reason = fmt.Sprintf("unsupported service_ttft op %q", op.Operation)
 	}
-	return false
+	return res
 }
 
-// evaluateServiceCapacityOp evaluates seat-utilization operations.
-// Utilization = activeCount / capacity * 100 per service; averaged across services that have a capacity set.
-// Services with no ModelCapacity (capacity == 0) are treated as unlimited and skipped.
-// Returns true (pass) when no service has a capacity configured.
-func (r *Router) evaluateServiceCapacityOp(ctx *RequestContext, op *SmartOp) bool {
+// evaluateServiceCapacityOp computes seat utilization = activeCount / capacity * 100
+// per service, averaged across services with capacity configured. Services with
+// capacity == 0 are unlimited and skipped. Returns Matched=true (pass) when no
+// service has capacity configured.
+func (r *Router) evaluateServiceCapacityOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
 	if len(ctx.ServiceCapacity) == 0 {
-		return true
+		res.Matched = true
+		res.Reason = "no capacity info; pass"
+		return res
 	}
-
 	threshold, err := op.Int()
 	if err != nil {
 		log.Printf("[smart_routing] invalid service_capacity value '%s': %v", op.Value, err)
-		return false
+		res.Reason = fmt.Sprintf("invalid int: %v", err)
+		return res
 	}
-
 	var utilValues []float64
 	for _, c := range ctx.ServiceCapacity {
 		if c.Capacity <= 0 {
-			continue // unlimited — skip
+			continue
 		}
-		util := float64(c.ActiveCount) / float64(c.Capacity) * 100
-		utilValues = append(utilValues, util)
+		utilValues = append(utilValues, float64(c.ActiveCount)/float64(c.Capacity)*100)
 	}
-
 	if len(utilValues) == 0 {
-		return true // no capacity-configured services — do not block
+		res.Matched = true
+		res.Reason = "no capacity-configured services; pass"
+		return res
 	}
-
 	avg := avgFloat(utilValues)
 	thresholdF := float64(threshold)
-
+	res.Actual = fmt.Sprintf("%.1f%%", avg)
 	switch op.Operation {
 	case OpServiceCapacityUtilLe:
-		return avg <= thresholdF
+		res.Matched = avg <= thresholdF
+		res.Reason = fmt.Sprintf("avg util %.1f%% <= %d%%", avg, threshold)
 	case OpServiceCapacityUtilGe:
-		return avg >= thresholdF
+		res.Matched = avg >= thresholdF
+		res.Reason = fmt.Sprintf("avg util %.1f%% >= %d%%", avg, threshold)
 	case OpServiceCapacityUtilLt:
-		return avg < thresholdF
+		res.Matched = avg < thresholdF
+		res.Reason = fmt.Sprintf("avg util %.1f%% < %d%%", avg, threshold)
 	case OpServiceCapacityUtilGt:
-		return avg > thresholdF
+		res.Matched = avg > thresholdF
+		res.Reason = fmt.Sprintf("avg util %.1f%% > %d%%", avg, threshold)
+	default:
+		res.Reason = fmt.Sprintf("unsupported service_capacity op %q", op.Operation)
 	}
-	return false
+	return res
+}
+
+// evaluateAgentClaudeCodeOp evaluates the agent.claude_code position.
+// ctx.ClaudeCodeRequestKind is populated by SmartRoutingStage only when the
+// request scenario is claude_code; for other scenarios it is empty and no
+// value matches — which is the desired behavior.
+func (r *Router) evaluateAgentClaudeCodeOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	res.Actual = ctx.ClaudeCodeRequestKind
+	value, err := op.String()
+	if err != nil {
+		log.Printf("[smart_routing] invalid agent.claude_code value '%s': %v", op.Value, err)
+		res.Reason = fmt.Sprintf("invalid value: %v", err)
+		return res
+	}
+	if op.Operation != OpAgentClaudeCodeEquals {
+		res.Reason = fmt.Sprintf("unsupported agent.claude_code op %q", op.Operation)
+		return res
+	}
+	if ctx.ClaudeCodeRequestKind == "" {
+		res.Reason = "request kind not set (scenario is not claude_code)"
+		return res
+	}
+	res.Matched = ctx.ClaudeCodeRequestKind == value
+	res.Reason = fmt.Sprintf("agent.claude_code %q == %q", ctx.ClaudeCodeRequestKind, value)
+	return res
+}
+
+// stringsMatch provides basic regex matching support.
+// For now, it provides simple pattern matching with support for:
+// - Wildcards (*)
+// - Character classes ([abc])
+// - Alternatives (a|b)
+func stringsMatch(text, pattern string, useRegex bool) (bool, error) {
+	if !useRegex {
+		return strings.Contains(text, pattern), nil
+	}
+	g, err := glob.Compile(pattern)
+	if err != nil {
+		log.Printf("[smart_routing] invalid glob/regex pattern '%s', falling back to contains: %v", pattern, err)
+		return strings.Contains(text, pattern), nil
+	}
+	return g.Match(text), nil
+}
+
+// EstimateTokens estimates token count from text (rough approximation: 4 chars per token)
+func EstimateTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	return len(text) / 4
+}
+
+// GetRules returns the router's rules
+func (r *Router) GetRules() []SmartRouting { return r.rules }
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // collectRuleStats returns a snapshot of ServiceStats for each service in the rule.

--- a/pkg/obs/multi_logger.go
+++ b/pkg/obs/multi_logger.go
@@ -23,6 +23,8 @@ const (
 	LogSourceSystem LogSource = "system"
 	// LogSourceAction indicates logs from user actions/operations
 	LogSourceAction LogSource = "action"
+	// LogSourceSmartRouting indicates logs from smart routing rule evaluation
+	LogSourceSmartRouting LogSource = "smart_routing"
 	// LogSourceUnknown indicates unknown log source
 	LogSourceUnknown LogSource = "unknown"
 )
@@ -122,9 +124,10 @@ func DefaultMultiLoggerConfig(configDir string) *MultiLoggerConfig {
 
 		// Default memory sink sizes
 		MemorySinkConfig: map[LogSource]MemorySinkConfig{
-			LogSourceHTTP:   {MaxEntries: 1000}, // HTTP requests: high volume
-			LogSourceSystem: {MaxEntries: 500},  // System logs: medium volume
-			LogSourceAction: {MaxEntries: 100},  // User actions: low volume, important
+			LogSourceHTTP:         {MaxEntries: 1000}, // HTTP requests: high volume
+			LogSourceSystem:       {MaxEntries: 500},  // System logs: medium volume
+			LogSourceAction:       {MaxEntries: 100},  // User actions: low volume, important
+			LogSourceSmartRouting: {MaxEntries: 500},  // Smart routing evaluations: per-request
 		},
 	}
 }
@@ -260,6 +263,8 @@ func (m *MultiLogger) getDefaultMemorySinkSize(source LogSource) int {
 		return 500
 	case LogSourceAction:
 		return 100
+	case LogSourceSmartRouting:
+		return 500
 	default:
 		return 100
 	}


### PR DESCRIPTION
## Summary

- Adds per-rule eval traces to the smart-routing evaluator so operators can see
  exactly why a request matched (or didn't match) a rule, including the
  position, operation, value, and a short snippet of the matched content.
- Adds `agent.claude_code` request-kind detection (`main` / `subagent` /
  `compact`) via system-prompt fingerprinting, plumbed through
  `RequestContext.ClaudeCodeRequestKind` and surfaced as a new SmartOp position.
- Removes the redundant per-protocol `ExtractContextFrom*Request` family in
  `internal/smart_routing/`. The smart-routing layer now funnels every
  supported wire protocol through the existing `internal/protocol/request/`
  converters into Anthropic Beta and runs a single canonical extractor.
  - New `ConvertAnthropicV1ToBetaRequest` lives in the protocol layer where it
    belongs (Beta is a structural superset of v1).
  - Net: **−77 lines** in the smart-routing package; one entry point
    (`smartrouting.ExtractContext`) replaces three.

## Why

Two things became clear while extending smart-routing logging:

1. The eval path was a black box on rule-miss — the trace addition fixes this
   without changing the matching semantics.
2. The smart-routing package was carrying a *second* intermediate
   representation (one extractor per wire protocol) parallel to
   `internal/protocol/request/`'s already-complete transform layer. Picking
   Anthropic Beta as the canonical (richest expressivity, free converters from
   OpenAI, v1 is a strict subset) lets us delete the duplication instead of
   growing it as new protocols land.

## Test plan

- [x] `go build ./internal/... ./pkg/...`
- [x] `go test ./internal/smart_routing/...` — all pass, including the three
      integration tests covering OpenAI, Anthropic v1 with thinking, and
      Anthropic v1 with image content (each now exercising the unified
      `ExtractContext`).
- [x] Pre-existing test failures in `internal/protocol/request/` (DeepSeek
      `x_thinking`) and `internal/server/routing/` (HealthStage flake,
      affinity) confirmed to fail identically on the branch base via
      `git stash` — not introduced by this PR.
- [ ] Manual smoke against a live `claude_code` session to confirm
      `eval_trace` reasons render correctly for `agent.claude_code` rules.