### PR TITLE
feat(ui): add opt-in Fusion provider creation and show dual API badges when both base URLs exist

### DIFF
--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -28,7 +28,6 @@ import type { ProviderQuota } from '@/types/quota';
 import React, {useCallback, useState} from 'react';
 import api from '../services/api';
 import type { Provider } from '../types/provider';
-import { useFeatureFlags } from '@/contexts/FeatureFlagsContext';
 
 interface ApiKeyTableProps {
     providers: Provider[];
@@ -60,7 +59,6 @@ interface ModelListDialogState {
 }
 
 const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, providerQuotas, refreshingQuotas, onQuotaRefresh }: ApiKeyTableProps) => {
-    const { enableFusion } = useFeatureFlags();
     const [tokenModal, setTokenModal] = useState<TokenModalState>({
         open: false,
         providerName: '',
@@ -237,7 +235,7 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, pr
                             </TableCell>
                             {/* API Style */}
                             <TableCell>
-                                {enableFusion && provider.api_base_openai && provider.api_base_anthropic ? (
+                                {provider.api_base_openai && provider.api_base_anthropic ? (
                                     <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap">
                                         <ApiStyleBadge apiStyle="openai" compact />
                                         <ApiStyleBadge apiStyle="anthropic" compact />

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -45,6 +45,7 @@ export interface EnhancedProviderFormData {
     // inbound protocol natively. When only one is set, falls back to apiBase.
     apiBaseOpenAI?: string;
     apiBaseAnthropic?: string;
+    createFusionProvider?: boolean;
 }
 
 interface PresetProviderFormDialogProps {
@@ -117,6 +118,7 @@ const ProviderFormDialog = ({
     const [providerInputValue, setProviderInputValue] = useState('');
     const [useGlobalProxy, setUseGlobalProxy] = useState(false);
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
+    const [createFusionProvider, setCreateFusionProvider] = useState(false);
 
     const {enableFusion} = useFeatureFlags();
 
@@ -192,6 +194,10 @@ const ProviderFormDialog = ({
     useEffect(() => {
         setNoApiKey(data.noKeyRequired || false);
     }, [data.noKeyRequired]);
+
+    useEffect(() => {
+        setCreateFusionProvider(!!data.createFusionProvider);
+    }, [data.createFusionProvider]);
 
     // Fetch global proxy URL once on mount
     useEffect(() => {
@@ -295,6 +301,7 @@ const ProviderFormDialog = ({
                 // on. With the flag OFF, picking both protocols falls through
                 // to the legacy two-record split handled by the parent submit.
                 const fusion = enableFusionRef.current
+                    && createFusionProvider
                     && nextOpenAI && nextAnthropic
                     && !!provider.baseUrlOpenAI && !!provider.baseUrlAnthropic;
 
@@ -323,7 +330,7 @@ const ProviderFormDialog = ({
                 cb('apiBaseAnthropic', '');
             }
         },
-        []
+        [createFusionProvider]
     );
 
     const handleUseGlobalProxyChange = (checked: boolean) => {
@@ -742,6 +749,24 @@ const ProviderFormDialog = ({
                                 </Box>
                             </Stack>
                         </FormControl>
+                        {enableFusion && mode === 'add' && protocolOpenAI && protocolAnthropic && (
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        size="small"
+                                        checked={createFusionProvider}
+                                        onChange={(e) => {
+                                            const checked = e.target.checked;
+                                            setCreateFusionProvider(checked);
+                                            onChange('createFusionProvider', checked);
+                                            syncProtocolsToParent(protocolOpenAI, protocolAnthropic, selectedProvider);
+                                            setVerificationResult(null);
+                                        }}
+                                    />
+                                }
+                                label={t('providerDialog.fusion.createCheckbox')}
+                            />
+                        )}
 
                         <Box>
                             <TextField

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -1,4 +1,4 @@
-import {Close, Visibility, VisibilityOff} from '@mui/icons-material';
+import {Close, InfoOutlined, Visibility, VisibilityOff} from '@mui/icons-material';
 import {
     Alert,
     Autocomplete,
@@ -19,6 +19,7 @@ import {
     Stack,
     Switch,
     TextField,
+    Tooltip,
     Typography,
 } from '@mui/material';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -764,7 +765,32 @@ const ProviderFormDialog = ({
                                         }}
                                     />
                                 }
-                                label={t('providerDialog.fusion.createCheckbox')}
+                                label={(
+                                    <Stack direction="row" spacing={0.75} alignItems="center">
+                                        <Typography variant="body2">
+                                            {t('providerDialog.fusion.modeLabel')}
+                                        </Typography>
+                                        <Tooltip
+                                            arrow
+                                            placement="top"
+                                            title={
+                                                <Box>
+                                                    <Typography variant="body2" sx={{fontWeight: 600, mb: 0.5}}>
+                                                        {t('providerDialog.fusion.tooltipTitle')}
+                                                    </Typography>
+                                                    <Typography variant="caption" sx={{display: 'block'}}>
+                                                        {t('providerDialog.fusion.normalModeDesc')}
+                                                    </Typography>
+                                                    <Typography variant="caption" sx={{display: 'block', mt: 0.75}}>
+                                                        {t('providerDialog.fusion.fusionModeDesc')}
+                                                    </Typography>
+                                                </Box>
+                                            }
+                                        >
+                                            <InfoOutlined sx={{fontSize: 16, color: 'text.secondary'}} />
+                                        </Tooltip>
+                                    </Stack>
+                                )}
                             />
                         )}
 

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -774,6 +774,30 @@ const ProviderFormDialog = ({
                                             <Tooltip
                                                 arrow
                                                 placement="top"
+                                                slotProps={{
+                                                    tooltip: {
+                                                        sx: (theme) => ({
+                                                            maxWidth: 360,
+                                                            bgcolor: 'background.paper',
+                                                            color: 'text.primary',
+                                                            border: `1px solid ${theme.palette.divider}`,
+                                                            boxShadow: theme.shadows[6],
+                                                            p: 1.25,
+                                                            '& .MuiTypography-caption': {
+                                                                color: 'text.secondary',
+                                                                lineHeight: 1.45,
+                                                            },
+                                                        }),
+                                                    },
+                                                    arrow: {
+                                                        sx: (theme) => ({
+                                                            color: theme.palette.background.paper,
+                                                            '&:before': {
+                                                                border: `1px solid ${theme.palette.divider}`,
+                                                            },
+                                                        }),
+                                                    },
+                                                }}
                                                 title={
                                                     <Box>
                                                         <Typography variant="body2" sx={{fontWeight: 600, mb: 0.5}}>

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -751,47 +751,50 @@ const ProviderFormDialog = ({
                             </Stack>
                         </FormControl>
                         {enableFusion && mode === 'add' && protocolOpenAI && protocolAnthropic && (
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        size="small"
-                                        checked={createFusionProvider}
-                                        onChange={(e) => {
-                                            const checked = e.target.checked;
-                                            setCreateFusionProvider(checked);
-                                            onChange('createFusionProvider', checked);
-                                            syncProtocolsToParent(protocolOpenAI, protocolAnthropic, selectedProvider);
-                                            setVerificationResult(null);
-                                        }}
-                                    />
-                                }
-                                label={(
-                                    <Stack direction="row" spacing={0.75} alignItems="center">
-                                        <Typography variant="body2">
-                                            {t('providerDialog.fusion.modeLabel')}
-                                        </Typography>
-                                        <Tooltip
-                                            arrow
-                                            placement="top"
-                                            title={
-                                                <Box>
-                                                    <Typography variant="body2" sx={{fontWeight: 600, mb: 0.5}}>
-                                                        {t('providerDialog.fusion.tooltipTitle')}
-                                                    </Typography>
-                                                    <Typography variant="caption" sx={{display: 'block'}}>
-                                                        {t('providerDialog.fusion.normalModeDesc')}
-                                                    </Typography>
-                                                    <Typography variant="caption" sx={{display: 'block', mt: 0.75}}>
-                                                        {t('providerDialog.fusion.fusionModeDesc')}
-                                                    </Typography>
-                                                </Box>
-                                            }
-                                        >
-                                            <InfoOutlined sx={{fontSize: 16, color: 'text.secondary'}} />
-                                        </Tooltip>
-                                    </Stack>
-                                )}
-                            />
+                            <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: -0.5, pr: 2}}>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            size="small"
+                                            checked={createFusionProvider}
+                                            onChange={(e) => {
+                                                const checked = e.target.checked;
+                                                setCreateFusionProvider(checked);
+                                                onChange('createFusionProvider', checked);
+                                                syncProtocolsToParent(protocolOpenAI, protocolAnthropic, selectedProvider);
+                                                setVerificationResult(null);
+                                            }}
+                                        />
+                                    }
+                                    label={(
+                                        <Stack direction="row" spacing={0.75} alignItems="center">
+                                            <Typography variant="body2">
+                                                {t('providerDialog.fusion.modeLabel')}
+                                            </Typography>
+                                            <Tooltip
+                                                arrow
+                                                placement="top"
+                                                title={
+                                                    <Box>
+                                                        <Typography variant="body2" sx={{fontWeight: 600, mb: 0.5}}>
+                                                            {t('providerDialog.fusion.tooltipTitle')}
+                                                        </Typography>
+                                                        <Typography variant="caption" sx={{display: 'block'}}>
+                                                            {t('providerDialog.fusion.normalModeDesc')}
+                                                        </Typography>
+                                                        <Typography variant="caption" sx={{display: 'block', mt: 0.75}}>
+                                                            {t('providerDialog.fusion.fusionModeDesc')}
+                                                        </Typography>
+                                                    </Box>
+                                                }
+                                            >
+                                                <InfoOutlined sx={{fontSize: 16, color: 'text.secondary'}} />
+                                            </Tooltip>
+                                        </Stack>
+                                    )}
+                                    labelPlacement="start"
+                                />
+                            </Box>
                         )}
 
                         <Box>

--- a/frontend/src/components/model-select/ProviderSidebar.tsx
+++ b/frontend/src/components/model-select/ProviderSidebar.tsx
@@ -108,8 +108,15 @@ export function ProviderSidebar({
                                                     <CheckCircle color="primary" sx={{ fontSize: 14, flexShrink: 0 }} />
                                                 )}
                                             </Stack>
-                                            {provider.api_style && (
-                                                <ApiStyleBadge compact={true} apiStyle={provider.api_style} sx={{ flexShrink: 0, width: "100px" }} />
+                                            {provider.api_base_openai && provider.api_base_anthropic ? (
+                                                <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+                                                    <ApiStyleBadge compact={true} apiStyle="openai" />
+                                                    <ApiStyleBadge compact={true} apiStyle="anthropic" />
+                                                </Stack>
+                                            ) : (
+                                                provider.api_style && (
+                                                    <ApiStyleBadge compact={true} apiStyle={provider.api_style} sx={{ flexShrink: 0, width: "100px" }} />
+                                                )
                                             )}
                                         </Stack>
                                     </Box>

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -14,7 +14,6 @@ import {
 import { styled } from '@mui/material/styles';
 import React, { useState } from 'react';
 import type { Provider } from '@/types/provider.ts';
-import { useFeatureFlags } from '@/contexts/FeatureFlagsContext';
 import { ApiStyleBadge } from '../ApiStyleBadge.tsx';
 import { ProbeV2Menu } from '../probe';
 import type { ConfigProvider } from '../RoutingGraphTypes.ts';
@@ -68,7 +67,6 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
     onDelete,
     onNodeClick
 }) => {
-    const { enableFusion } = useFeatureFlags();
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const [probeAnchorEl, setProbeAnchorEl] = useState<null | HTMLElement>(null);
     const menuOpen = Boolean(menuAnchorEl);
@@ -182,7 +180,7 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
                 {/* Bottom Layer - API Style Badge(s) */}
                 {provider.provider && (
                     <Box sx={NODE_LAYER_STYLES.bottomLayer}>
-                        {enableFusion && providerInfo.provider?.api_base_openai && providerInfo.provider?.api_base_anthropic ? (
+                        {providerInfo.provider?.api_base_openai && providerInfo.provider?.api_base_anthropic ? (
                             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5, width: '100%' }}>
                                 <ApiStyleBadge
                                     apiStyle="openai"

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -227,6 +227,9 @@ export default {
     "protocol": {
       "label": "Protocol"
     },
+    "fusion": {
+      "createCheckbox": "Create as Fusion Provider (single combined provider)"
+    },
     "keyName": {
       "label": "API Key Name",
       "placeholder": "e.g., OpenAI API Key",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -228,7 +228,10 @@ export default {
       "label": "Protocol"
     },
     "fusion": {
-      "createCheckbox": "Create as Fusion Provider (single combined provider)"
+      "modeLabel": "Fusion mode",
+      "tooltipTitle": "How provider creation works",
+      "normalModeDesc": "Normal mode (unchecked): create two independent providers, one for OpenAI and one for Anthropic.",
+      "fusionModeDesc": "Fusion mode (checked): create one provider with both OpenAI and Anthropic base URLs."
     },
     "keyName": {
       "label": "API Key Name",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -228,7 +228,10 @@ export default {
       "label": "协议"
     },
     "fusion": {
-      "createCheckbox": "创建为融合 Provider（单条组合 Provider）"
+      "modeLabel": "Fusion 模式",
+      "tooltipTitle": "创建方式说明",
+      "normalModeDesc": "普通模式（未勾选）：会创建两个独立 Provider（OpenAI 与 Anthropic 各一个）。",
+      "fusionModeDesc": "Fusion 模式（已勾选）：会创建一个同时包含 OpenAI 与 Anthropic Base URL 的 Provider。"
     },
     "keyName": {
       "label": "API 密钥名称",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -227,6 +227,9 @@ export default {
     "protocol": {
       "label": "协议"
     },
+    "fusion": {
+      "createCheckbox": "创建为融合 Provider（单条组合 Provider）"
+    },
     "keyName": {
       "label": "API 密钥名称",
       "placeholder": "例如：OpenAI API Key",

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -92,6 +92,7 @@ const CredentialPage = () => {
                     enabled: true,
                     noKeyRequired: false,
                     proxyUrl: '',
+                    createFusionProvider: false,
                 } as any);
                 setApiKeyDialogOpen(true);
             }
@@ -124,6 +125,7 @@ const CredentialPage = () => {
             enabled: true,
             noKeyRequired: false,
             proxyUrl: '',
+            createFusionProvider: false,
         } as any);
         setApiKeyDialogOpen(true);
     };
@@ -163,8 +165,9 @@ const CredentialPage = () => {
             protocols.length === 2 &&
             !!providerBaseUrls?.openai &&
             !!providerBaseUrls?.anthropic;
+        const shouldCreateFusion = enableFusion && !!(providerFormData as any).createFusionProvider;
 
-        if (bothProtocols && enableFusion) {
+        if (bothProtocols && shouldCreateFusion) {
             return {
                 name: providerFormData.name,
                 api_base: providerBaseUrls!.openai,
@@ -179,7 +182,7 @@ const CredentialPage = () => {
             };
         }
 
-        if (bothProtocols && !enableFusion) {
+        if (bothProtocols && !shouldCreateFusion) {
             // Legacy split: emit one record per protocol so the user gets
             // two independent Provider entries sharing the same credential.
             const baseRecord = {

--- a/frontend/src/pages/ModelTestPage.tsx
+++ b/frontend/src/pages/ModelTestPage.tsx
@@ -54,7 +54,14 @@ const ModelCard = ({ model, provider, isTesting, onTest, onViewResult, hasResult
             <CardContent sx={{ flexGrow: 1, p: 2 }}>
                 <Stack spacing={1.5}>
                     <Stack direction="row" justifyContent="space-between" alignItems="center">
-                        <ApiStyleBadge apiStyle={provider.api_style} />
+                        {provider.api_base_openai && provider.api_base_anthropic ? (
+                            <Stack direction="row" spacing={0.5}>
+                                <ApiStyleBadge compact apiStyle="openai" />
+                                <ApiStyleBadge compact apiStyle="anthropic" />
+                            </Stack>
+                        ) : (
+                            <ApiStyleBadge apiStyle={provider.api_style} />
+                        )}
                         {hasResult && (
                             <Tooltip title="View test result">
                                 <IconButton
@@ -143,7 +150,14 @@ const TestResultDialog = ({ open, onClose, probeResult, model, provider }: TestR
                             <Typography variant="body2" sx={{ fontWeight: 500 }}>
                                 {provider.name}
                             </Typography>
-                            <ApiStyleBadge apiStyle={provider.api_style} />
+                            {provider.api_base_openai && provider.api_base_anthropic ? (
+                                <Stack direction="row" spacing={0.5}>
+                                    <ApiStyleBadge compact apiStyle="openai" />
+                                    <ApiStyleBadge compact apiStyle="anthropic" />
+                                </Stack>
+                            ) : (
+                                <ApiStyleBadge apiStyle={provider.api_style} />
+                            )}
                         </Stack>
                         <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
                             Model: {model}
@@ -341,7 +355,14 @@ const ModelTestPage = () => {
                         <Typography variant="body1" sx={{ fontWeight: 500 }}>
                             {provider.name}
                         </Typography>
-                        <ApiStyleBadge apiStyle={provider.api_style} />
+                        {provider.api_base_openai && provider.api_base_anthropic ? (
+                            <Stack direction="row" spacing={0.5}>
+                                <ApiStyleBadge compact apiStyle="openai" />
+                                <ApiStyleBadge compact apiStyle="anthropic" />
+                            </Stack>
+                        ) : (
+                            <ApiStyleBadge apiStyle={provider.api_style} />
+                        )}
                     </Stack>
                 </Stack>
                 <Button


### PR DESCRIPTION
### Motivation
- Allow users to choose to create a single "fusion" provider (one provider with both OpenAI and Anthropic base URLs) when both protocols are enabled instead of always splitting into two records or forcing fusion globally.
- Render dual API style badges whenever a provider record contains both `api_base_openai` and `api_base_anthropic`, independent of the global experiment flag.
- Expose the new option in the provider form UX and persist it through the add flow.

### Description
- Added `createFusionProvider` to `EnhancedProviderFormData`, initialized it when opening the add dialog, and exposed a new checkbox in `ProviderFormDialog` shown when both protocols are selected and `enableFusion` is on.
- Mirrored `createFusionProvider` into local state and into the `syncProtocolsToParent` callback so fusion state affects `apiBaseOpenAI`/`apiBaseAnthropic` values sent to the parent form state.
- Updated `CredentialPage.buildAddProviderPayload` to read a `createFusionProvider` flag and create either a single fusion payload or the legacy two-record split depending on the user choice and the global `enableFusion` flag.
- Adjusted UI components (`ApiKeyTable`, `ProviderSidebar`, `ProviderNode`, `ModelTestPage`, etc.) to render two compact `ApiStyleBadge` components whenever a provider has both `api_base_openai` and `api_base_anthropic`, removing reliance on showing badges only when the global feature flag was set.
- Added i18n strings for the new fusion checkbox in English and Chinese and wired `createFusionProvider` into form initialization points (URL dialog open and add button flows).
- Removed several now-unused usages/imports of `useFeatureFlags` where components no longer gate dual-badge rendering on the feature flag.

### Testing
- Ran TypeScript typecheck and a local build to validate typings and compilation, which completed successfully.
- Executed the frontend unit test suite and component snapshot checks available locally, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4fdaf67c832a88b8e47f6f4c378a)