### PR TITLE
fix(agent): warn instead of erroring when no routing service is configed.

### DIFF
--- a/internal/agent/apply.go
+++ b/internal/agent/apply.go
@@ -42,23 +42,34 @@ func (aa *AgentApply) ApplyAgent(req *ApplyAgentRequest) (*ApplyAgentResult, err
 	}
 }
 
-// applyClaudeCode applies Claude Code configuration
+// applyClaudeCode applies Claude Code configuration.
+// When no provider/model is supplied (i.e. no routing service is configured
+// yet), the config files are still written and routing-rule sync is skipped
+// with a warning — apply should not hard-fail just because rules are unset.
 func (aa *AgentApply) applyClaudeCode(req *ApplyAgentRequest) (*ApplyAgentResult, error) {
 	result := &ApplyAgentResult{
 		AgentType: req.AgentType,
 	}
 
-	// Get provider
-	provider, err := aa.config.GetProviderByUUID(req.Provider)
-	if err != nil {
-		return nil, fmt.Errorf("provider not found: %w", err)
+	hasService := req.Provider != "" && req.Model != ""
+
+	if hasService {
+		provider, err := aa.config.GetProviderByUUID(req.Provider)
+		if err != nil || provider == nil {
+			// Provider lookup failed — downgrade to "no service" rather than
+			// blocking the file-level apply. Tell the caller via Warnings.
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("provider %s not found; skipping routing rule update", req.Provider))
+			hasService = false
+		} else {
+			result.ProviderName = provider.Name
+			result.ProviderUUID = provider.UUID
+			result.Model = req.Model
+		}
+	} else {
+		result.Warnings = append(result.Warnings,
+			"no routing service configured; applying config files only (routing rules will not be created)")
 	}
-	if provider == nil {
-		return nil, fmt.Errorf("provider %s not found", req.Provider)
-	}
-	result.ProviderName = provider.Name
-	result.ProviderUUID = provider.UUID
-	result.Model = req.Model
 
 	// Get base URL and token for Claude settings
 	baseURL, apiKey := aa.getBaseURLAndToken()
@@ -83,36 +94,50 @@ func (aa *AgentApply) applyClaudeCode(req *ApplyAgentRequest) (*ApplyAgentResult
 	result.ConfigFiles = aa.collectConfigFiles(settingsResult, onboardingResult)
 	result.BackupPaths = aa.collectBackupPaths(settingsResult, onboardingResult)
 
-	// Create or update routing rules (all tingly/cc-* rules for convenience)
-	ruleCreated, ruleUpdated, err := aa.createOrUpdateClaudeCodeRules(provider.UUID, req.Model)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create/update routing rules: %w", err)
+	if hasService {
+		ruleCreated, ruleUpdated, err := aa.createOrUpdateClaudeCodeRules(result.ProviderUUID, req.Model)
+		if err != nil {
+			// Surface as a warning so the user still gets the config files;
+			// failing the whole apply here would defeat the purpose of the
+			// "warn, don't error" contract.
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("failed to create/update routing rules: %v", err))
+		} else {
+			result.RulesCreated = ruleCreated
+			result.RulesUpdated = ruleUpdated
+		}
 	}
-	result.RulesCreated = ruleCreated
-	result.RulesUpdated = ruleUpdated
 
 	result.Message = aa.buildResultMessage(result)
 
 	return result, nil
 }
 
-// applyOpenCode applies OpenCode configuration
+// applyOpenCode applies OpenCode configuration.
+// Mirrors applyClaudeCode: writes config files unconditionally and only
+// creates/updates routing rules when a provider+model are supplied.
 func (aa *AgentApply) applyOpenCode(req *ApplyAgentRequest) (*ApplyAgentResult, error) {
 	result := &ApplyAgentResult{
 		AgentType: req.AgentType,
 	}
 
-	// Get provider
-	provider, err := aa.config.GetProviderByUUID(req.Provider)
-	if err != nil {
-		return nil, fmt.Errorf("provider not found: %w", err)
+	hasService := req.Provider != "" && req.Model != ""
+
+	if hasService {
+		provider, err := aa.config.GetProviderByUUID(req.Provider)
+		if err != nil || provider == nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("provider %s not found; skipping routing rule update", req.Provider))
+			hasService = false
+		} else {
+			result.ProviderName = provider.Name
+			result.ProviderUUID = provider.UUID
+			result.Model = req.Model
+		}
+	} else {
+		result.Warnings = append(result.Warnings,
+			"no routing service configured; applying config files only (routing rules will not be created)")
 	}
-	if provider == nil {
-		return nil, fmt.Errorf("provider %s not found", req.Provider)
-	}
-	result.ProviderName = provider.Name
-	result.ProviderUUID = provider.UUID
-	result.Model = req.Model
 
 	// Get base URL and token for OpenCode config
 	baseURL, apiKey := aa.getBaseURLAndToken()
@@ -141,13 +166,16 @@ func (aa *AgentApply) applyOpenCode(req *ApplyAgentRequest) (*ApplyAgentResult, 
 		result.BackupPaths = []string{applyResult.BackupPath}
 	}
 
-	// Create or update routing rules (tingly-opencode)
-	ruleCreated, ruleUpdated, err := aa.createOrUpdateOpenCodeRules(provider.UUID, req.Model)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create/update routing rules: %w", err)
+	if hasService {
+		ruleCreated, ruleUpdated, err := aa.createOrUpdateOpenCodeRules(result.ProviderUUID, req.Model)
+		if err != nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("failed to create/update routing rules: %v", err))
+		} else {
+			result.RulesCreated = ruleCreated
+			result.RulesUpdated = ruleUpdated
+		}
 	}
-	result.RulesCreated = ruleCreated
-	result.RulesUpdated = ruleUpdated
 
 	result.Message = aa.buildResultMessage(result)
 
@@ -404,8 +432,12 @@ func (aa *AgentApply) buildResultMessage(result *ApplyAgentResult) string {
 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Configuration applied for %s\n", result.AgentType))
-	sb.WriteString(fmt.Sprintf("Provider: %s\n", result.ProviderName))
-	sb.WriteString(fmt.Sprintf("Model: %s\n", result.Model))
+	if result.ProviderName != "" {
+		sb.WriteString(fmt.Sprintf("Provider: %s\n", result.ProviderName))
+	}
+	if result.Model != "" {
+		sb.WriteString(fmt.Sprintf("Model: %s\n", result.Model))
+	}
 
 	if len(result.ConfigFiles) > 0 {
 		sb.WriteString("\nFiles modified:\n")
@@ -425,6 +457,13 @@ func (aa *AgentApply) buildResultMessage(result *ApplyAgentResult) string {
 		sb.WriteString("\nBackups:\n")
 		for _, p := range result.BackupPaths {
 			sb.WriteString(fmt.Sprintf("  - %s\n", p))
+		}
+	}
+
+	if len(result.Warnings) > 0 {
+		sb.WriteString("\nWarnings:\n")
+		for _, w := range result.Warnings {
+			sb.WriteString(fmt.Sprintf("  - %s\n", w))
 		}
 	}
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -108,6 +108,10 @@ type ApplyAgentResult struct {
 	// RulesUpdated indicates how many existing routing rules were updated
 	RulesUpdated int
 
+	// Warnings collects non-fatal messages emitted during apply, e.g. when
+	// no routing service is configured yet so rule sync is skipped.
+	Warnings []string
+
 	// Message contains a human-readable result message
 	Message string
 }

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -327,11 +327,45 @@ func resolveAgentConfigFromRules(appManager *AppManager, req *agent.ApplyAgentRe
 		}
 	}
 
-	// No rule found or rule is invalid - prompt for configuration
+	// No rule or no usable service is configured yet. This is not fatal:
+	// `agent apply` can still write the agent's config files so the agent
+	// CLI points at tingly-box. Routing rules can be configured later via
+	// `tingly-box tui`. Only fall back to the interactive prompt when there
+	// are providers available AND we're on a TTY; otherwise just warn.
+	fmt.Fprintf(os.Stderr,
+		"Warning: no routing service configured for '%s' (scenario '%s').\n",
+		requestModel, scenario)
+	fmt.Fprintln(os.Stderr,
+		"Config files will still be applied. Run 'tingly-box tui' to set up routing rules later.")
+
+	providers := appManager.ListProviders()
+	if len(providers) == 0 || !isStdinTTY() {
+		// Nothing to prompt for, or stdin is non-interactive — proceed
+		// without provider/model. applyClaudeCode/applyOpenCode handles
+		// the empty case by skipping rule sync.
+		return nil
+	}
+
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf("\nNo routing rule found for '%s' in scenario '%s'.\n", requestModel, scenario)
-	fmt.Println("You may need to run 'tingly-box tui' first, or configure manually:")
-	return promptForAgentConfig(reader, appManager, req)
+	fmt.Fprintln(os.Stderr, "You may optionally select a provider/model now to also create routing rules:")
+	if err := promptForAgentConfig(reader, appManager, req); err != nil {
+		// Prompt failed (e.g. user aborted) — degrade to "config files only"
+		// rather than blocking the whole apply.
+		fmt.Fprintf(os.Stderr, "Warning: skipping routing rule setup: %v\n", err)
+		req.Provider = ""
+		req.Model = ""
+	}
+	return nil
+}
+
+// isStdinTTY reports whether stdin is connected to a terminal. It is used to
+// decide whether interactive prompts are appropriate.
+func isStdinTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
 // promptForAgentProviderChoice prompts user to select a provider
@@ -433,8 +467,12 @@ func promptForAgentModelInput(reader *bufio.Reader, prompt string) (string, erro
 func confirmApply(reader *bufio.Reader, req *agent.ApplyAgentRequest) error {
 	fmt.Println("\nConfiguration preview:")
 	fmt.Printf("  Agent:  %s\n", req.AgentType)
-	fmt.Printf("  Provider:  (will be resolved)\n")
-	fmt.Printf("  Model:  %s\n", req.Model)
+	if req.Provider == "" && req.Model == "" {
+		fmt.Println("  Routing:  (no service configured — config files only, no routing rules)")
+	} else {
+		fmt.Printf("  Provider:  (will be resolved)\n")
+		fmt.Printf("  Model:  %s\n", req.Model)
+	}
 	if req.AgentType == agent.AgentTypeClaudeCode {
 		mode := "unified"
 		if !req.Unified {
@@ -464,13 +502,17 @@ func showPreview(appManager *AppManager, req *agent.ApplyAgentRequest) error {
 
 	fmt.Println("\nConfiguration preview:")
 	fmt.Printf("  Agent:  %s\n", info.Name)
-	fmt.Printf("  Provider:  (will be resolved)\n")
-	fmt.Printf("  Model:  %s\n", req.Model)
+	if req.Provider == "" && req.Model == "" {
+		fmt.Println("  Routing:  (no service configured — config files only, no routing rules)")
+	} else {
+		fmt.Printf("  Provider:  (will be resolved)\n")
+		fmt.Printf("  Model:  %s\n", req.Model)
 
-	// Get provider info
-	if req.Provider != "" {
-		if provider, err := appManager.GetProvider(req.Provider); err == nil && provider != nil {
-			fmt.Printf("  Provider:  %s\n", provider.Name)
+		// Get provider info
+		if req.Provider != "" {
+			if provider, err := appManager.GetProvider(req.Provider); err == nil && provider != nil {
+				fmt.Printf("  Provider:  %s\n", provider.Name)
+			}
 		}
 	}
 
@@ -479,9 +521,11 @@ func showPreview(appManager *AppManager, req *agent.ApplyAgentRequest) error {
 		fmt.Printf("  - %s\n", f)
 	}
 
-	fmt.Println("\nRouting rule:")
-	fmt.Printf("  Scenario:  %s\n", info.Scenario)
-	fmt.Printf("  Request Model:  tingly/%s\n", strings.TrimPrefix(string(req.AgentType), "claude-"))
+	if req.Provider != "" && req.Model != "" {
+		fmt.Println("\nRouting rule:")
+		fmt.Printf("  Scenario:  %s\n", info.Scenario)
+		fmt.Printf("  Request Model:  tingly/%s\n", strings.TrimPrefix(string(req.AgentType), "claude-"))
+	}
 
 	fmt.Println("\nNo changes will be made in preview mode.")
 	return nil


### PR DESCRIPTION
## Summary
This change makes `agent apply` more resilient by allowing configuration files to be written even when no routing service (provider/model) is configured yet. Previously, the command would fail if provider lookup failed. Now it degrades gracefully, writes config files unconditionally, and only creates/updates routing rules when a valid provider and model are available.

## Key Changes

- **Graceful degradation in `applyClaudeCode` and `applyOpenCode`**: Both functions now check if a provider/model is supplied before attempting provider lookup. If lookup fails or no service is configured, they emit warnings instead of hard errors and proceed with file-level configuration.

- **Warning system**: Added a `Warnings` field to `ApplyAgentResult` to collect non-fatal messages. These are displayed to the user in the result message, informing them when routing rules are skipped due to missing service configuration.

- **Interactive prompt improvements**: Modified `resolveAgentConfigFromRules` to:
  - Warn upfront when no routing service is configured
  - Only prompt for provider/model selection if providers exist AND stdin is a TTY
  - Gracefully handle prompt failures by clearing provider/model and proceeding with config-files-only mode
  - Added `isStdinTTY()` helper to detect interactive terminal

- **Result message formatting**: Updated `buildResultMessage` to:
  - Conditionally display provider/model only when they are set
  - Include a new "Warnings" section in the output
  - Handle empty provider/model gracefully

- **Preview display updates**: Modified `confirmApply` and `showPreview` to show appropriate messaging when no routing service is configured, avoiding confusing "(will be resolved)" placeholders.

## Implementation Details

The core philosophy is: **config files always apply, routing rules are optional**. This allows users to:
1. Set up agent configuration files immediately
2. Configure routing rules later via `tingly-box tui` or manual setup
3. Avoid being blocked by missing provider configuration during initial agent setup

Error handling for routing rule creation is also downgraded from fatal to warning, ensuring that transient issues don't prevent the entire apply operation from succeeding.

https://claude.ai/code/session_01SiBQM3C8aXAvLSKsuSe9Nn