### PR TITLE
fix(codex): apply all rules + merge config.toml + add CLI / HTTP endpoints

### DIFF
--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -8,9 +8,7 @@ import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageConte
 interface CodexConfigModalProps {
     open: boolean;
     onClose: () => void;
-    baseUrl: string;
     copyToClipboard: (text: string, label: string) => Promise<void>;
-    rules?: any[] | null;
 }
 
 type ScriptTab = 'json' | 'windows' | 'unix';
@@ -18,61 +16,13 @@ type SessionAction = 'import' | 'undo';
 
 const SHOW_CODEX_SESSION_IMPORT = false;
 
-const sanitizeProfileKey = (name: string): string => {
-    const cleaned = name.replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
-    return cleaned || 'tingly';
-};
-
-export const buildCodexConfigToml = (codexBaseUrl: string, rules?: any[] | null): string => {
-    const modelNames: string[] = Array.isArray(rules)
-        ? rules
-              .filter(r => r && r.active !== false && typeof r.request_model === 'string' && r.request_model.trim() !== '')
-              .map(r => r.request_model as string)
-        : [];
-    const uniqueModels = Array.from(new Set(modelNames));
-
-    const header = `[model_providers.tingly-box]
-name = "OpenAI using Tingly Box"
-base_url = "${codexBaseUrl}"
-preferred_auth_method = "apikey"
-wire_api = "responses"`;
-
-    if (uniqueModels.length === 0) {
-        return `# No active Codex rules configured yet. Add one in "Models and Forwarding Rules".\nmodel_provider = "tingly-box"\nmodel_supports_reasoning_summaries = true\nmodel_reasoning_summary = "auto"\n\n${header}`;
-    }
-
-    const defaultModel = uniqueModels[0];
-
-    const profileKeys = new Set<string>();
-    const profileBlocks = uniqueModels
-        .map(model => {
-            const key = sanitizeProfileKey(model);
-            let candidate = key;
-            let suffix = 1;
-            while (profileKeys.has(candidate)) {
-                candidate = `${key}-${suffix++}`;
-            }
-            profileKeys.add(candidate);
-            return `\n\n[profiles.${candidate}]\nmodel = "${model}"\nmodel_provider = "tingly-box"`;
-        })
-        .join('');
-
-    return `model = "${defaultModel}"
-model_provider = "tingly-box"
-model_supports_reasoning_summaries = true
-model_reasoning_summary = "auto"
-
-${header}${profileBlocks}`;
-};
-
 const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     open,
     onClose,
-    baseUrl,
     copyToClipboard,
-    rules,
 }) => {
-    // Get token from context
+    // Keep token in context as a fallback for the auth.json preview while
+    // the preview API request is in flight.
     const { token } = useScenarioPageModal();
     const [configTab, setConfigTab] = React.useState<ScriptTab>('json');
     const [authTab, setAuthTab] = React.useState<ScriptTab>('json');
@@ -82,17 +32,27 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     const [error, setError] = React.useState<string | null>(null);
     const [createBackup, setCreateBackup] = React.useState(false);
     const [autoUndoOnStop, setAutoUndoOnStop] = React.useState(false);
+    const [configToml, setConfigToml] = React.useState<string>('# Loading...');
+    const [authJson, setAuthJson] = React.useState<string>(`{\n  "OPENAI_API_KEY": "${token}"\n}`);
 
-    const codexBaseUrl = `${baseUrl}/tingly/codex`;
-
-    const configToml = React.useMemo(
-        () => buildCodexConfigToml(codexBaseUrl, rules),
-        [codexBaseUrl, rules],
-    );
-
-    const authJson = `{
-  "OPENAI_API_KEY": "${token}"
-}`;
+    React.useEffect(() => {
+        if (!open) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const resp = await api.getCodexConfigPreview();
+                if (cancelled) return;
+                if (resp?.success) {
+                    setConfigToml(resp.configToml || '');
+                    setAuthJson(resp.authJson || `{\n  "OPENAI_API_KEY": "${token}"\n}`);
+                }
+            } catch {
+                // Leave existing placeholders in place; the user can still copy the
+                // base URL from the page itself.
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [open, token]);
 
     const windowsConfigScript = `$configDir = Join-Path $HOME ".codex"
 $configPath = Join-Path $configDir "config.toml"

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -18,8 +18,6 @@ type SessionAction = 'import' | 'undo';
 
 const SHOW_CODEX_SESSION_IMPORT = false;
 
-const DEFAULT_CODEX_MODEL = 'tingly-codex';
-
 const sanitizeProfileKey = (name: string): string => {
     const cleaned = name.replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
     return cleaned || 'tingly';
@@ -32,12 +30,23 @@ export const buildCodexConfigToml = (codexBaseUrl: string, rules?: any[] | null)
               .map(r => r.request_model as string)
         : [];
     const uniqueModels = Array.from(new Set(modelNames));
-    const defaultModel = uniqueModels[0] || DEFAULT_CODEX_MODEL;
+
+    const header = `[model_providers.tingly-box]
+name = "OpenAI using Tingly Box"
+base_url = "${codexBaseUrl}"
+preferred_auth_method = "apikey"
+wire_api = "responses"`;
+
+    if (uniqueModels.length === 0) {
+        return `# No active Codex rules configured yet. Add one in "Models and Forwarding Rules".\nmodel_provider = "tingly-box"\nmodel_supports_reasoning_summaries = true\nmodel_reasoning_summary = "auto"\n\n${header}`;
+    }
+
+    const defaultModel = uniqueModels[0];
 
     const profileKeys = new Set<string>();
     const profileBlocks = uniqueModels
         .map(model => {
-            let key = sanitizeProfileKey(model);
+            const key = sanitizeProfileKey(model);
             let candidate = key;
             let suffix = 1;
             while (profileKeys.has(candidate)) {
@@ -53,11 +62,7 @@ model_provider = "tingly-box"
 model_supports_reasoning_summaries = true
 model_reasoning_summary = "auto"
 
-[model_providers.tingly-box]
-name = "OpenAI using Tingly Box"
-base_url = "${codexBaseUrl}"
-preferred_auth_method = "apikey"
-wire_api = "responses"${profileBlocks}`;
+${header}${profileBlocks}`;
 };
 
 const CodexConfigModal: React.FC<CodexConfigModalProps> = ({

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -10,6 +10,7 @@ interface CodexConfigModalProps {
     onClose: () => void;
     baseUrl: string;
     copyToClipboard: (text: string, label: string) => Promise<void>;
+    rules?: any[] | null;
 }
 
 type ScriptTab = 'json' | 'windows' | 'unix';
@@ -17,11 +18,54 @@ type SessionAction = 'import' | 'undo';
 
 const SHOW_CODEX_SESSION_IMPORT = false;
 
+const DEFAULT_CODEX_MODEL = 'tingly-codex';
+
+const sanitizeProfileKey = (name: string): string => {
+    const cleaned = name.replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+    return cleaned || 'tingly';
+};
+
+export const buildCodexConfigToml = (codexBaseUrl: string, rules?: any[] | null): string => {
+    const modelNames: string[] = Array.isArray(rules)
+        ? rules
+              .filter(r => r && r.active !== false && typeof r.request_model === 'string' && r.request_model.trim() !== '')
+              .map(r => r.request_model as string)
+        : [];
+    const uniqueModels = Array.from(new Set(modelNames));
+    const defaultModel = uniqueModels[0] || DEFAULT_CODEX_MODEL;
+
+    const profileKeys = new Set<string>();
+    const profileBlocks = uniqueModels
+        .map(model => {
+            let key = sanitizeProfileKey(model);
+            let candidate = key;
+            let suffix = 1;
+            while (profileKeys.has(candidate)) {
+                candidate = `${key}-${suffix++}`;
+            }
+            profileKeys.add(candidate);
+            return `\n\n[profiles.${candidate}]\nmodel = "${model}"\nmodel_provider = "tingly-box"`;
+        })
+        .join('');
+
+    return `model = "${defaultModel}"
+model_provider = "tingly-box"
+model_supports_reasoning_summaries = true
+model_reasoning_summary = "auto"
+
+[model_providers.tingly-box]
+name = "OpenAI using Tingly Box"
+base_url = "${codexBaseUrl}"
+preferred_auth_method = "apikey"
+wire_api = "responses"${profileBlocks}`;
+};
+
 const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     open,
     onClose,
     baseUrl,
     copyToClipboard,
+    rules,
 }) => {
     // Get token from context
     const { token } = useScenarioPageModal();
@@ -36,16 +80,10 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
 
     const codexBaseUrl = `${baseUrl}/tingly/codex`;
 
-    const configToml = `model = "tingly-codex"
-model_provider = "tingly-box"
-model_supports_reasoning_summaries = true
-model_reasoning_summary = "auto"
-
-[model_providers.tingly-box]
-name = "OpenAI using Tingly Box"
-base_url = "${codexBaseUrl}"
-preferred_auth_method = "apikey"
-wire_api = "responses"`;
+    const configToml = React.useMemo(
+        () => buildCodexConfigToml(codexBaseUrl, rules),
+        [codexBaseUrl, rules],
+    );
 
     const authJson = `{
   "OPENAI_API_KEY": "${token}"

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -1,6 +1,6 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModelsCard } from '@/components/AgentSetupCard';
-import CodexConfigModal from "@/components/CodexConfigModal.tsx";
+import CodexConfigModal, { buildCodexConfigToml } from "@/components/CodexConfigModal.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
 import { Box, Button, IconButton, Tooltip } from '@mui/material';
@@ -27,7 +27,7 @@ const UseCodexPageContent: React.FC = () => {
     // Codex has no backend apply — copy config.toml to clipboard as a convenience
     const handleApply = async (): Promise<AgentApplyResult> => {
         const codexBaseUrl = `${baseUrl}/tingly/codex`;
-        const config = `model = "tingly-codex"\nmodel_provider = "tingly-box"\nmodel_supports_reasoning_summaries = true\nmodel_reasoning_summary = "auto"\n\n[model_providers.tingly-box]\nname = "OpenAI using Tingly Box"\nbase_url = "${codexBaseUrl}"\npreferred_auth_method = "apikey"\nwire_api = "responses"`;
+        const config = buildCodexConfigToml(codexBaseUrl, rules);
         await navigator.clipboard.writeText(config);
         return {
             success: true,
@@ -93,6 +93,7 @@ const UseCodexPageContent: React.FC = () => {
                     onClose={() => setConfigModalOpen(false)}
                     baseUrl={baseUrl}
                     copyToClipboard={copyToClipboard}
+                    rules={rules}
                 />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -1,6 +1,7 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModelsCard } from '@/components/AgentSetupCard';
-import CodexConfigModal, { buildCodexConfigToml } from "@/components/CodexConfigModal.tsx";
+import CodexConfigModal from "@/components/CodexConfigModal.tsx";
+import { api } from '@/services/api';
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
 import { Box, Button, IconButton, Tooltip } from '@mui/material';
@@ -24,15 +25,19 @@ const UseCodexPageContent: React.FC = () => {
 
     const [configModalOpen, setConfigModalOpen] = useState(false);
 
-    // Codex has no backend apply — copy config.toml to clipboard as a convenience
     const handleApply = async (): Promise<AgentApplyResult> => {
-        const codexBaseUrl = `${baseUrl}/tingly/codex`;
-        const config = buildCodexConfigToml(codexBaseUrl, rules);
-        await navigator.clipboard.writeText(config);
-        return {
-            success: true,
-            files: ['~/.codex/config.toml (copied to clipboard — paste manually)'],
-        };
+        try {
+            const result = await api.applyCodexConfig();
+            if (result.success) {
+                return {
+                    success: true,
+                    files: ['~/.codex/config.toml', '~/.codex/auth.json'],
+                };
+            }
+            return { success: false, error: result.message || 'Unknown error' };
+        } catch (err: any) {
+            return { success: false, error: err?.message || 'Failed to apply Codex config' };
+        }
     };
 
     return (
@@ -91,9 +96,7 @@ const UseCodexPageContent: React.FC = () => {
                 <CodexConfigModal
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
-                    baseUrl={baseUrl}
                     copyToClipboard={copyToClipboard}
-                    rules={rules}
                 />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -975,6 +975,19 @@ export const api = {
         });
     },
 
+    applyCodexConfig: async (): Promise<any> => {
+        return uiAPI('/config/apply/codex', {
+            method: 'POST',
+            body: JSON.stringify({}),
+        });
+    },
+
+    getCodexConfigPreview: async (): Promise<any> => {
+        return uiAPI('/config/preview/codex', {
+            method: 'GET',
+        });
+    },
+
     importCodexOpenAISessions: async (payload: {
         sourceProvider?: string;
         targetProvider?: string;

--- a/internal/agent/apply.go
+++ b/internal/agent/apply.go
@@ -232,9 +232,8 @@ func (aa *AgentApply) applyCodex(req *ApplyAgentRequest) (*ApplyAgentResult, err
 	codexBaseURL := baseURL + "/tingly/codex"
 
 	models := aa.collectCodexRuleModels()
-	toml := GenerateCodexConfigToml(codexBaseURL, models)
 
-	configResult, err := serverconfig.ApplyCodexConfig(toml)
+	configResult, err := serverconfig.ApplyCodexConfig(codexBaseURL, models)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply Codex config: %w", err)
 	}
@@ -287,65 +286,6 @@ func (aa *AgentApply) collectCodexRuleModels() []string {
 		}
 		seen[model] = struct{}{}
 		out = append(out, model)
-	}
-	return out
-}
-
-// GenerateCodexConfigToml renders the Codex `config.toml`. The first model is
-// used as the top-level default; every model also becomes a `[profiles.<key>]`
-// block so users can switch via `codex --profile <key>`. The provider entry is
-// always a single `tingly-box` block pointing at the local proxy. When models
-// is empty, a placeholder header is emitted so the file is still well-formed.
-func GenerateCodexConfigToml(codexBaseURL string, models []string) string {
-	header := fmt.Sprintf("[model_providers.tingly-box]\nname = \"OpenAI using Tingly Box\"\nbase_url = %q\npreferred_auth_method = \"apikey\"\nwire_api = \"responses\"", codexBaseURL)
-
-	if len(models) == 0 {
-		return "# No active Codex rules configured yet. Add one in \"Models and Forwarding Rules\".\n" +
-			"model_provider = \"tingly-box\"\n" +
-			"model_supports_reasoning_summaries = true\n" +
-			"model_reasoning_summary = \"auto\"\n\n" +
-			header + "\n"
-	}
-
-	usedKeys := map[string]struct{}{}
-	var profiles strings.Builder
-	for _, model := range models {
-		key := sanitizeCodexProfileKey(model)
-		candidate := key
-		for i := 1; ; i++ {
-			if _, ok := usedKeys[candidate]; !ok {
-				break
-			}
-			candidate = fmt.Sprintf("%s-%d", key, i)
-		}
-		usedKeys[candidate] = struct{}{}
-		fmt.Fprintf(&profiles, "\n\n[profiles.%s]\nmodel = %q\nmodel_provider = \"tingly-box\"", candidate, model)
-	}
-
-	return fmt.Sprintf("model = %q\n", models[0]) +
-		"model_provider = \"tingly-box\"\n" +
-		"model_supports_reasoning_summaries = true\n" +
-		"model_reasoning_summary = \"auto\"\n\n" +
-		header +
-		profiles.String() + "\n"
-}
-
-// sanitizeCodexProfileKey mirrors the frontend behaviour: keep alphanumerics,
-// `_`, `-`; replace anything else with `-`; trim leading/trailing dashes.
-func sanitizeCodexProfileKey(name string) string {
-	var b strings.Builder
-	b.Grow(len(name))
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('-')
-		}
-	}
-	out := strings.Trim(b.String(), "-")
-	if out == "" {
-		return "tingly"
 	}
 	return out
 }

--- a/internal/agent/apply.go
+++ b/internal/agent/apply.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // AgentApply handles agent configuration application
@@ -37,6 +38,8 @@ func (aa *AgentApply) ApplyAgent(req *ApplyAgentRequest) (*ApplyAgentResult, err
 		return aa.applyClaudeCode(req)
 	case AgentTypeOpenCode:
 		return aa.applyOpenCode(req)
+	case AgentTypeCodex:
+		return aa.applyCodex(req)
 	default:
 		return nil, fmt.Errorf("agent type %s not implemented", req.AgentType)
 	}
@@ -180,6 +183,171 @@ func (aa *AgentApply) applyOpenCode(req *ApplyAgentRequest) (*ApplyAgentResult, 
 	result.Message = aa.buildResultMessage(result)
 
 	return result, nil
+}
+
+// applyCodex applies Codex CLI configuration. Codex has no notion of a
+// per-model rule on the agent side, so this:
+//   - Optionally creates/updates the default Codex rule (`tingly-codex`)
+//     when a provider+model is supplied
+//   - Collects every active Codex scenario rule and emits a
+//     `[profiles.<name>]` block for each in `~/.codex/config.toml`
+//   - Writes the model token into `~/.codex/auth.json`
+//
+// The single `tingly-box` model provider is always pinned to the local
+// tingly-box base URL (`/tingly/codex`).
+func (aa *AgentApply) applyCodex(req *ApplyAgentRequest) (*ApplyAgentResult, error) {
+	result := &ApplyAgentResult{
+		AgentType: req.AgentType,
+	}
+
+	hasService := req.Provider != "" && req.Model != ""
+	if hasService {
+		provider, err := aa.config.GetProviderByUUID(req.Provider)
+		if err != nil || provider == nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("provider %s not found; skipping routing rule update", req.Provider))
+			hasService = false
+		} else {
+			result.ProviderName = provider.Name
+			result.ProviderUUID = provider.UUID
+			result.Model = req.Model
+		}
+	} else {
+		result.Warnings = append(result.Warnings,
+			"no routing service configured; applying config files only (routing rules will not be created)")
+	}
+
+	if hasService {
+		ruleCreated, ruleUpdated, err := aa.createOrUpdateCodexRules(result.ProviderUUID, req.Model)
+		if err != nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("failed to create/update routing rules: %v", err))
+		} else {
+			result.RulesCreated = ruleCreated
+			result.RulesUpdated = ruleUpdated
+		}
+	}
+
+	baseURL, apiKey := aa.getBaseURLAndToken()
+	codexBaseURL := baseURL + "/tingly/codex"
+
+	models := aa.collectCodexRuleModels()
+	toml := GenerateCodexConfigToml(codexBaseURL, models)
+
+	configResult, err := serverconfig.ApplyCodexConfig(toml)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply Codex config: %w", err)
+	}
+	authResult, err := serverconfig.ApplyCodexAuth(apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply Codex auth: %w", err)
+	}
+
+	result.Success = configResult.Success && authResult.Success
+	if configResult.Success {
+		suffix := " (updated)"
+		if configResult.Created {
+			suffix = " (created)"
+		}
+		result.ConfigFiles = append(result.ConfigFiles, "~/.codex/config.toml"+suffix)
+	}
+	if authResult.Success {
+		suffix := " (updated)"
+		if authResult.Created {
+			suffix = " (created)"
+		}
+		result.ConfigFiles = append(result.ConfigFiles, "~/.codex/auth.json"+suffix)
+	}
+	if configResult.BackupPath != "" {
+		result.BackupPaths = append(result.BackupPaths, configResult.BackupPath)
+	}
+	if authResult.BackupPath != "" {
+		result.BackupPaths = append(result.BackupPaths, authResult.BackupPath)
+	}
+
+	result.Message = aa.buildResultMessage(result)
+	return result, nil
+}
+
+// collectCodexRuleModels returns the request_models of every active rule under
+// the Codex scenario, deduplicated and in declaration order.
+func (aa *AgentApply) collectCodexRuleModels() []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, rule := range aa.config.GetRequestConfigs() {
+		if rule.GetScenario() != typ.ScenarioCodex || !rule.Active {
+			continue
+		}
+		model := strings.TrimSpace(rule.RequestModel)
+		if model == "" {
+			continue
+		}
+		if _, dup := seen[model]; dup {
+			continue
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	return out
+}
+
+// GenerateCodexConfigToml renders the Codex `config.toml`. The first model is
+// used as the top-level default; every model also becomes a `[profiles.<key>]`
+// block so users can switch via `codex --profile <key>`. The provider entry is
+// always a single `tingly-box` block pointing at the local proxy. When models
+// is empty, a placeholder header is emitted so the file is still well-formed.
+func GenerateCodexConfigToml(codexBaseURL string, models []string) string {
+	header := fmt.Sprintf("[model_providers.tingly-box]\nname = \"OpenAI using Tingly Box\"\nbase_url = %q\npreferred_auth_method = \"apikey\"\nwire_api = \"responses\"", codexBaseURL)
+
+	if len(models) == 0 {
+		return "# No active Codex rules configured yet. Add one in \"Models and Forwarding Rules\".\n" +
+			"model_provider = \"tingly-box\"\n" +
+			"model_supports_reasoning_summaries = true\n" +
+			"model_reasoning_summary = \"auto\"\n\n" +
+			header + "\n"
+	}
+
+	usedKeys := map[string]struct{}{}
+	var profiles strings.Builder
+	for _, model := range models {
+		key := sanitizeCodexProfileKey(model)
+		candidate := key
+		for i := 1; ; i++ {
+			if _, ok := usedKeys[candidate]; !ok {
+				break
+			}
+			candidate = fmt.Sprintf("%s-%d", key, i)
+		}
+		usedKeys[candidate] = struct{}{}
+		fmt.Fprintf(&profiles, "\n\n[profiles.%s]\nmodel = %q\nmodel_provider = \"tingly-box\"", candidate, model)
+	}
+
+	return fmt.Sprintf("model = %q\n", models[0]) +
+		"model_provider = \"tingly-box\"\n" +
+		"model_supports_reasoning_summaries = true\n" +
+		"model_reasoning_summary = \"auto\"\n\n" +
+		header +
+		profiles.String() + "\n"
+}
+
+// sanitizeCodexProfileKey mirrors the frontend behaviour: keep alphanumerics,
+// `_`, `-`; replace anything else with `-`; trim leading/trailing dashes.
+func sanitizeCodexProfileKey(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "tingly"
+	}
+	return out
 }
 
 // getBaseURLAndToken returns the base URL and API token for configuration

--- a/internal/agent/rule.go
+++ b/internal/agent/rule.go
@@ -24,6 +24,13 @@ var OpenCodeRequestModels = []string{
 	"tingly-opencode",
 }
 
+// CodexRequestModels defines the default request models for the Codex scenario.
+// Users typically add additional rules with their own request_model names; this
+// list only seeds the default rule when none exists yet.
+var CodexRequestModels = []string{
+	"tingly-codex",
+}
+
 // createOrUpdateClaudeCodeRules creates or updates all Claude Code rules
 // For convenience, all tingly/cc-* rules are updated with the same provider + model
 func (aa *AgentApply) createOrUpdateClaudeCodeRules(providerUUID, model string) (int, int, error) {
@@ -79,6 +86,42 @@ func (aa *AgentApply) createOrUpdateOpenCodeRules(providerUUID, model string) (i
 			requestModel,
 			service,
 			fmt.Sprintf("OpenCode - %s routing", requestModel),
+		)
+		if err != nil {
+			return created, updated, fmt.Errorf("failed to update rule %s: %w", requestModel, err)
+		}
+
+		if ruleCreated {
+			created++
+		}
+		if ruleUpdated {
+			updated++
+		}
+	}
+
+	return created, updated, nil
+}
+
+// createOrUpdateCodexRules creates or updates the default Codex rule
+// (`tingly-codex`) to point at the supplied provider+model. Other Codex rules
+// the user has added by hand are left alone — Codex apply just needs *some*
+// active rule to seed the generated config.toml.
+func (aa *AgentApply) createOrUpdateCodexRules(providerUUID, model string) (int, int, error) {
+	created := 0
+	updated := 0
+
+	service := &loadbalance.Service{
+		Active:   true,
+		Provider: providerUUID,
+		Model:    model,
+	}
+
+	for _, requestModel := range CodexRequestModels {
+		ruleCreated, ruleUpdated, err := aa.createOrUpdateRule(
+			typ.ScenarioCodex,
+			requestModel,
+			service,
+			fmt.Sprintf("Codex - %s routing", requestModel),
 		)
 		if err != nil {
 			return created, updated, fmt.Errorf("failed to update rule %s: %w", requestModel, err)

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -14,6 +14,9 @@ const (
 
 	// AgentTypeOpenCode represents OpenCode IDE extension
 	AgentTypeOpenCode AgentType = "opencode"
+
+	// AgentTypeCodex represents the OpenAI Codex CLI
+	AgentTypeCodex AgentType = "codex"
 )
 
 // String returns the string representation of AgentType
@@ -24,7 +27,7 @@ func (at AgentType) String() string {
 // IsValid checks if the AgentType is valid
 func (at AgentType) IsValid() bool {
 	switch at {
-	case AgentTypeClaudeCode, AgentTypeOpenCode:
+	case AgentTypeClaudeCode, AgentTypeOpenCode, AgentTypeCodex:
 		return true
 	default:
 		return false
@@ -36,6 +39,7 @@ func (at AgentType) IsValid() bool {
 // Supported aliases:
 //   - "cc", "claude", "claude-code" -> AgentTypeClaudeCode
 //   - "oc", "opencode" -> AgentTypeOpenCode
+//   - "cx", "codex" -> AgentTypeCodex
 func ParseAgentType(input string) (AgentType, error) {
 	if input == "" {
 		return "", fmt.Errorf("agent type cannot be empty")
@@ -48,8 +52,10 @@ func ParseAgentType(input string) (AgentType, error) {
 		return AgentTypeClaudeCode, nil
 	case "oc", "opencode", "open-code":
 		return AgentTypeOpenCode, nil
+	case "cx", "codex":
+		return AgentTypeCodex, nil
 	default:
-		return "", fmt.Errorf("unknown agent type: %s (supported: cc/claude-code, oc/opencode)", input)
+		return "", fmt.Errorf("unknown agent type: %s (supported: cc/claude-code, oc/opencode, cx/codex)", input)
 	}
 }
 
@@ -190,6 +196,16 @@ func ListAgentInfo() []AgentInfo {
 				"~/.config/opencode/opencode.json",
 			},
 			Scenario: "opencode",
+		},
+		{
+			Type:        AgentTypeCodex,
+			Name:        "Codex",
+			Description: "OpenAI Codex CLI (@codex)",
+			ConfigFiles: []string{
+				"~/.codex/config.toml",
+				"~/.codex/auth.json",
+			},
+			Scenario: "codex",
 		},
 	}
 }

--- a/internal/agent/types_test.go
+++ b/internal/agent/types_test.go
@@ -27,6 +27,11 @@ func TestParseAgentType(t *testing.T) {
 		{"open-code with dash", "open-code", AgentTypeOpenCode, false},
 		{"OC uppercase", "OC", AgentTypeOpenCode, false},
 
+		// Valid Codex aliases
+		{"cx alias", "cx", AgentTypeCodex, false},
+		{"codex full", "codex", AgentTypeCodex, false},
+		{"CODEX uppercase", "CODEX", AgentTypeCodex, false},
+
 		// Whitespace handling
 		{"cc with leading space", "  cc", AgentTypeClaudeCode, false},
 		{"cc with trailing space", "cc  ", AgentTypeClaudeCode, false},
@@ -34,7 +39,6 @@ func TestParseAgentType(t *testing.T) {
 		// Invalid inputs
 		{"empty string", "", "", true},
 		{"invalid type", "invalid", "", true},
-		{"codex not supported", "codex", "", true},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +72,7 @@ func TestAgentTypeIsValid(t *testing.T) {
 	}{
 		{"ClaudeCode valid", AgentTypeClaudeCode, true},
 		{"OpenCode valid", AgentTypeOpenCode, true},
+		{"Codex valid", AgentTypeCodex, true},
 		{"empty invalid", "", false},
 		{"random string invalid", "random", false},
 	}
@@ -85,8 +90,8 @@ func TestAgentTypeIsValid(t *testing.T) {
 func TestListAgentInfo(t *testing.T) {
 	info := ListAgentInfo()
 
-	if len(info) != 2 {
-		t.Errorf("ListAgentInfo() returned %d items, want 2", len(info))
+	if len(info) != 3 {
+		t.Errorf("ListAgentInfo() returned %d items, want 3", len(info))
 	}
 
 	// Check Claude Code info
@@ -105,5 +110,23 @@ func TestListAgentInfo(t *testing.T) {
 	}
 	if len(ccInfo.ConfigFiles) != 2 {
 		t.Errorf("Claude Code config files = %d, want 2", len(ccInfo.ConfigFiles))
+	}
+
+	// Check Codex info
+	var cxInfo *AgentInfo
+	for _, i := range info {
+		if i.Type == AgentTypeCodex {
+			cxInfo = &i
+			break
+		}
+	}
+	if cxInfo == nil {
+		t.Fatal("Codex agent info not found")
+	}
+	if cxInfo.Scenario != "codex" {
+		t.Errorf("Codex scenario = %q, want 'codex'", cxInfo.Scenario)
+	}
+	if len(cxInfo.ConfigFiles) != 2 {
+		t.Errorf("Codex config files = %d, want 2", len(cxInfo.ConfigFiles))
 	}
 }

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -33,7 +33,7 @@ func (a *AgentListFlagCmdKong) Run(appManager *AppManager) error {
 
 // AgentApplyFlagCmdKong applies agent configuration via flags
 type AgentApplyFlagCmdKong struct {
-	AgentType  string `kong:"arg,optional,help='Agent type (cc/claude-code, oc/opencode)'"`
+	AgentType  string `kong:"arg,optional,help='Agent type (cc/claude-code, oc/opencode, cx/codex)'"`
 	Provider   string `kong:"flag,name='provider',help='Provider UUID (optional, uses routing rule if not specified)'"`
 	Model      string `kong:"flag,name='model',help='Model name (optional, uses routing rule if not specified)'"`
 	Unified    bool   `kong:"flag,name='unified',default='true',help='Unified mode (claude-code only)'"`
@@ -68,6 +68,7 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 			fmt.Fprintln(os.Stderr, "Available agent types:")
 			fmt.Fprintln(os.Stderr, "  cc, claude-code - Claude Code CLI agent (@cc)")
 			fmt.Fprintln(os.Stderr, "  oc, opencode   - OpenCode editor agent (@oc)")
+			fmt.Fprintln(os.Stderr, "  cx, codex      - OpenAI Codex CLI (@codex)")
 			return fmt.Errorf("invalid agent type: %s", a.AgentType)
 		}
 		req.AgentType = parsedType
@@ -299,6 +300,9 @@ func resolveAgentConfigFromRules(appManager *AppManager, req *agent.ApplyAgentRe
 	case agent.AgentTypeOpenCode:
 		requestModel = "tingly-opencode"
 		scenario = typ.ScenarioOpenCode
+	case agent.AgentTypeCodex:
+		requestModel = "tingly-codex"
+		scenario = typ.ScenarioCodex
 	default:
 		return fmt.Errorf("unsupported agent type: %s", req.AgentType)
 	}
@@ -591,6 +595,8 @@ func showAgentConfig(appManager *AppManager, agentType agent.AgentType) error {
 		requestModel = "tingly/cc"
 	case agent.AgentTypeOpenCode:
 		requestModel = "tingly/oc"
+	case agent.AgentTypeCodex:
+		requestModel = "tingly-codex"
 	}
 
 	rule := globalConfig.GetRuleByRequestModelAndScenario(requestModel, typ.RuleScenario(info.Scenario))

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -953,6 +953,15 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 	return result, nil
 }
 
+// RenderCodexConfigTOML returns the TOML that would be written to a fresh
+// ~/.codex/config.toml — i.e. the merge applied to an empty starting point.
+// Used by the preview endpoint so the UI can show exactly what's pending.
+func RenderCodexConfigTOML(baseURL string, models []string) ([]byte, error) {
+	cfg := map[string]interface{}{}
+	mergeCodexConfig(cfg, baseURL, models)
+	return tomlpkg.Marshal(cfg)
+}
+
 // mergeCodexConfig mutates cfg in place, applying tingly-managed fields while
 // preserving everything else. See ApplyCodexConfig for the contract.
 func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []string) {

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	tomlpkg "github.com/pelletier/go-toml/v2"
 	"github.com/tingly-dev/tingly-box/internal"
 )
 
@@ -877,11 +878,27 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 	return result, nil
 }
 
-// ApplyCodexConfig writes the supplied TOML contents to `~/.codex/config.toml`.
-// The Codex config.toml has a fixed top-level shape (a single `model_provider`
-// plus optional `[profiles.*]` blocks), so we replace the file wholesale rather
-// than attempting a merge — but the previous version is backed up first.
-func ApplyCodexConfig(toml string) (*ApplyResult, error) {
+// ApplyCodexConfig merges tingly-box Codex settings into ~/.codex/config.toml.
+//
+// MERGE semantics: only fields tingly-box manages are overwritten. Everything
+// else the user put in config.toml — other top-level keys, other entries under
+// `[model_providers.*]`, and unrelated `[profiles.*]` blocks — is left alone.
+//
+// Managed fields:
+//   - top-level `model` (set to models[0] when models is non-empty)
+//   - top-level `model_provider = "tingly-box"`,
+//     `model_supports_reasoning_summaries = true`,
+//     `model_reasoning_summary = "auto"`
+//   - `[model_providers.tingly-box]` (always re-pinned to the supplied base URL)
+//   - `[profiles.<sanitized(model)>]` for each model
+//
+// If a profile key collides with one the user already wrote (and that profile
+// is not ours), our profile is suffixed (`-1`, `-2`, …) to avoid clobbering.
+// Orphan tingly profiles from earlier applies are NOT garbage-collected; if
+// the user has trimmed their rules they can remove stale profiles by hand.
+//
+// The previous file (if any) is backed up before being rewritten.
+func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
@@ -896,7 +913,12 @@ func ApplyCodexConfig(toml string) (*ApplyResult, error) {
 		return result, nil
 	}
 
-	if _, err := os.Stat(targetPath); err == nil {
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(targetPath); err == nil {
+		if err := tomlpkg.Unmarshal(data, &existing); err != nil {
+			result.Message = fmt.Sprintf("Failed to parse existing TOML: %v", err)
+			return result, nil
+		}
 		backupPath, err := backupFile(targetPath)
 		if err != nil {
 			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
@@ -908,7 +930,14 @@ func ApplyCodexConfig(toml string) (*ApplyResult, error) {
 		result.Created = true
 	}
 
-	if err := os.WriteFile(targetPath, []byte(toml), 0644); err != nil {
+	mergeCodexConfig(existing, baseURL, models)
+
+	out, err := tomlpkg.Marshal(existing)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal TOML: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, out, 0644); err != nil {
 		result.Message = fmt.Sprintf("Failed to write file: %v", err)
 		return result, nil
 	}
@@ -922,6 +951,87 @@ func ApplyCodexConfig(toml string) (*ApplyResult, error) {
 		result.Message = fmt.Sprintf("Updated %s", targetPath)
 	}
 	return result, nil
+}
+
+// mergeCodexConfig mutates cfg in place, applying tingly-managed fields while
+// preserving everything else. See ApplyCodexConfig for the contract.
+func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []string) {
+	if len(models) > 0 {
+		cfg["model"] = models[0]
+	}
+	cfg["model_provider"] = "tingly-box"
+	cfg["model_supports_reasoning_summaries"] = true
+	cfg["model_reasoning_summary"] = "auto"
+
+	providers, _ := cfg["model_providers"].(map[string]interface{})
+	if providers == nil {
+		providers = map[string]interface{}{}
+	}
+	providers["tingly-box"] = map[string]interface{}{
+		"name":                  "OpenAI using Tingly Box",
+		"base_url":              baseURL,
+		"preferred_auth_method": "apikey",
+		"wire_api":              "responses",
+	}
+	cfg["model_providers"] = providers
+
+	profiles, _ := cfg["profiles"].(map[string]interface{})
+	if profiles == nil {
+		profiles = map[string]interface{}{}
+	}
+	for _, model := range models {
+		key := pickCodexProfileKey(profiles, model)
+		profiles[key] = map[string]interface{}{
+			"model":          model,
+			"model_provider": "tingly-box",
+		}
+	}
+	if len(profiles) > 0 {
+		cfg["profiles"] = profiles
+	}
+}
+
+// pickCodexProfileKey returns the profile key under which we should write our
+// profile for the given model. It prefers the sanitized model name; if that
+// slot is already occupied by a non-tingly profile (or a tingly profile for a
+// different model), it appends `-N` until a writable slot is found. A slot is
+// writable when it is empty OR already points at this exact model via the
+// tingly-box provider (so re-applying is idempotent).
+func pickCodexProfileKey(profiles map[string]interface{}, model string) string {
+	base := sanitizeCodexProfileKey(model)
+	candidate := base
+	for i := 1; ; i++ {
+		existing, occupied := profiles[candidate].(map[string]interface{})
+		if !occupied {
+			return candidate
+		}
+		if mp, _ := existing["model_provider"].(string); mp == "tingly-box" {
+			if m, _ := existing["model"].(string); m == model {
+				return candidate
+			}
+		}
+		candidate = fmt.Sprintf("%s-%d", base, i)
+	}
+}
+
+// sanitizeCodexProfileKey keeps alphanumerics, `_`, `-`; turns anything else
+// into `-`; trims edge dashes. Empty result falls back to "tingly".
+func sanitizeCodexProfileKey(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "tingly"
+	}
+	return out
 }
 
 // ApplyCodexAuth writes `~/.codex/auth.json` with `OPENAI_API_KEY` set to the

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -876,3 +876,109 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 
 	return result, nil
 }
+
+// ApplyCodexConfig writes the supplied TOML contents to `~/.codex/config.toml`.
+// The Codex config.toml has a fixed top-level shape (a single `model_provider`
+// plus optional `[profiles.*]` blocks), so we replace the file wholesale rather
+// than attempting a merge — but the previous version is backed up first.
+func ApplyCodexConfig(toml string) (*ApplyResult, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	configDir := filepath.Join(homeDir, ".codex")
+	targetPath := filepath.Join(configDir, "config.toml")
+	result := &ApplyResult{}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		result.Message = fmt.Sprintf("Failed to create directory: %v", err)
+		return result, nil
+	}
+
+	if _, err := os.Stat(targetPath); err == nil {
+		backupPath, err := backupFile(targetPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+			return result, nil
+		}
+		result.BackupPath = backupPath
+		result.Updated = true
+	} else {
+		result.Created = true
+	}
+
+	if err := os.WriteFile(targetPath, []byte(toml), 0644); err != nil {
+		result.Message = fmt.Sprintf("Failed to write file: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	if result.Created {
+		result.Message = fmt.Sprintf("Created %s", targetPath)
+	} else if result.BackupPath != "" {
+		result.Message = fmt.Sprintf("Updated %s (backup: %s)", targetPath, result.BackupPath)
+	} else {
+		result.Message = fmt.Sprintf("Updated %s", targetPath)
+	}
+	return result, nil
+}
+
+// ApplyCodexAuth writes `~/.codex/auth.json` with `OPENAI_API_KEY` set to the
+// tingly-box model token. If the file already exists, other top-level keys are
+// preserved; only `OPENAI_API_KEY` is overwritten. The previous version is
+// backed up before modification.
+func ApplyCodexAuth(apiKey string) (*ApplyResult, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	configDir := filepath.Join(homeDir, ".codex")
+	targetPath := filepath.Join(configDir, "auth.json")
+	result := &ApplyResult{}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		result.Message = fmt.Sprintf("Failed to create directory: %v", err)
+		return result, nil
+	}
+
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(targetPath); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			result.Message = fmt.Sprintf("Failed to parse existing JSON: %v", err)
+			return result, nil
+		}
+		backupPath, err := backupFile(targetPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+			return result, nil
+		}
+		result.BackupPath = backupPath
+		result.Updated = true
+	} else {
+		result.Created = true
+	}
+
+	existing["OPENAI_API_KEY"] = apiKey
+
+	output, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal JSON: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, output, 0600); err != nil {
+		result.Message = fmt.Sprintf("Failed to write file: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	if result.Created {
+		result.Message = fmt.Sprintf("Created %s", targetPath)
+	} else if result.BackupPath != "" {
+		result.Message = fmt.Sprintf("Updated %s (backup: %s)", targetPath, result.BackupPath)
+	} else {
+		result.Message = fmt.Sprintf("Updated %s", targetPath)
+	}
+	return result, nil
+}

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -890,10 +890,9 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 //     `model_supports_reasoning_summaries = true`,
 //     `model_reasoning_summary = "auto"`
 //   - `[model_providers.tingly-box]` (always re-pinned to the supplied base URL)
-//   - `[profiles.<sanitized(model)>]` for each model
+//   - `[profiles.<sanitized(model)>]` for each model — overwritten unconditionally
+//     under that key; `agent restore codex` recovers the previous file if needed
 //
-// If a profile key collides with one the user already wrote (and that profile
-// is not ours), our profile is suffixed (`-1`, `-2`, …) to avoid clobbering.
 // Orphan tingly profiles from earlier applies are NOT garbage-collected; if
 // the user has trimmed their rules they can remove stale profiles by hand.
 //
@@ -980,37 +979,13 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 		profiles = map[string]interface{}{}
 	}
 	for _, model := range models {
-		key := pickCodexProfileKey(profiles, model)
-		profiles[key] = map[string]interface{}{
+		profiles[sanitizeCodexProfileKey(model)] = map[string]interface{}{
 			"model":          model,
 			"model_provider": "tingly-box",
 		}
 	}
 	if len(profiles) > 0 {
 		cfg["profiles"] = profiles
-	}
-}
-
-// pickCodexProfileKey returns the profile key under which we should write our
-// profile for the given model. It prefers the sanitized model name; if that
-// slot is already occupied by a non-tingly profile (or a tingly profile for a
-// different model), it appends `-N` until a writable slot is found. A slot is
-// writable when it is empty OR already points at this exact model via the
-// tingly-box provider (so re-applying is idempotent).
-func pickCodexProfileKey(profiles map[string]interface{}, model string) string {
-	base := sanitizeCodexProfileKey(model)
-	candidate := base
-	for i := 1; ; i++ {
-		existing, occupied := profiles[candidate].(map[string]interface{})
-		if !occupied {
-			return candidate
-		}
-		if mp, _ := existing["model_provider"].(string); mp == "tingly-box" {
-			if m, _ := existing["model"].(string); m == model {
-				return candidate
-			}
-		}
-		candidate = fmt.Sprintf("%s-%d", base, i)
 	}
 }
 

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -989,20 +990,12 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	}
 }
 
+var codexProfileKeyInvalid = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
 // sanitizeCodexProfileKey keeps alphanumerics, `_`, `-`; turns anything else
 // into `-`; trims edge dashes. Empty result falls back to "tingly".
 func sanitizeCodexProfileKey(name string) string {
-	var b strings.Builder
-	b.Grow(len(name))
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('-')
-		}
-	}
-	out := strings.Trim(b.String(), "-")
+	out := strings.Trim(codexProfileKeyInvalid.ReplaceAllString(name, "-"), "-")
 	if out == "" {
 		return "tingly"
 	}

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestApplyClaudeSettings_NewFile(t *testing.T) {
@@ -821,5 +823,279 @@ func TestApplyClaudeSettingsToPath_DefaultBackupBehavior(t *testing.T) {
 
 	if _, err := os.Stat(result.BackupPath); os.IsNotExist(err) {
 		t.Errorf("Expected backup file to exist at %s by default", result.BackupPath)
+	}
+}
+
+// ============================================================================
+// ApplyCodexConfig tests
+//
+// Contract: writing ~/.codex/config.toml must MERGE — only fields we manage
+// are overwritten. Unrelated top-level keys, user-defined providers, and
+// user-defined profiles must survive.
+// ============================================================================
+
+func loadCodexConfigForTest(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := map[string]interface{}{}
+	if err := toml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal toml: %v\n--- content ---\n%s", err, data)
+	}
+	return out
+}
+
+func TestApplyCodexConfig_NewFile_WritesManagedFields(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	result, err := ApplyCodexConfig("http://127.0.0.1:12580/tingly/codex", []string{"tingly-codex", "tingly-gpt5"})
+	if err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+	if !result.Success || !result.Created {
+		t.Fatalf("expected success+created, got %+v", result)
+	}
+
+	cfg := loadCodexConfigForTest(t, filepath.Join(tempDir, ".codex", "config.toml"))
+	if cfg["model"] != "tingly-codex" {
+		t.Errorf("model = %v, want tingly-codex", cfg["model"])
+	}
+	if cfg["model_provider"] != "tingly-box" {
+		t.Errorf("model_provider = %v, want tingly-box", cfg["model_provider"])
+	}
+	providers, _ := cfg["model_providers"].(map[string]interface{})
+	tb, _ := providers["tingly-box"].(map[string]interface{})
+	if tb["base_url"] != "http://127.0.0.1:12580/tingly/codex" {
+		t.Errorf("base_url = %v", tb["base_url"])
+	}
+	if tb["wire_api"] != "responses" {
+		t.Errorf("wire_api = %v, want responses", tb["wire_api"])
+	}
+	profiles, _ := cfg["profiles"].(map[string]interface{})
+	if len(profiles) != 2 {
+		t.Fatalf("profiles = %d, want 2: %#v", len(profiles), profiles)
+	}
+	for _, model := range []string{"tingly-codex", "tingly-gpt5"} {
+		p, ok := profiles[model].(map[string]interface{})
+		if !ok {
+			t.Fatalf("missing profile %q in %#v", model, profiles)
+		}
+		if p["model"] != model {
+			t.Errorf("profile %s.model = %v", model, p["model"])
+		}
+		if p["model_provider"] != "tingly-box" {
+			t.Errorf("profile %s.model_provider = %v", model, p["model_provider"])
+		}
+	}
+}
+
+func TestApplyCodexConfig_PreservesUserTopLevelFields(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `approval_policy = "untrusted"
+disable_response_storage = true
+model = "user-custom-model"
+hide_agent_reasoning = false
+
+[shell_environment_policy]
+inherit = "all"
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ApplyCodexConfig("http://example/tingly/codex", []string{"my-rule"}); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	cfg := loadCodexConfigForTest(t, filepath.Join(codexDir, "config.toml"))
+	if cfg["approval_policy"] != "untrusted" {
+		t.Errorf("approval_policy lost: %v", cfg["approval_policy"])
+	}
+	if cfg["disable_response_storage"] != true {
+		t.Errorf("disable_response_storage lost: %v", cfg["disable_response_storage"])
+	}
+	if cfg["hide_agent_reasoning"] != false {
+		t.Errorf("hide_agent_reasoning lost: %v", cfg["hide_agent_reasoning"])
+	}
+	shell, _ := cfg["shell_environment_policy"].(map[string]interface{})
+	if shell["inherit"] != "all" {
+		t.Errorf("shell_environment_policy.inherit lost: %v", shell)
+	}
+	// Managed field overwritten with our default (first model)
+	if cfg["model"] != "my-rule" {
+		t.Errorf("model = %v, want my-rule (tingly should overwrite the default)", cfg["model"])
+	}
+}
+
+func TestApplyCodexConfig_PreservesOtherProvidersAndProfiles(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.openai.com/v1"
+wire_api = "chat"
+
+[model_providers.tingly-box]
+name = "Old Tingly"
+base_url = "http://old-host/tingly/codex"
+wire_api = "responses"
+
+[profiles.work]
+model = "gpt-5"
+model_provider = "openai"
+
+[profiles.legacy-tingly]
+model = "tingly-legacy"
+model_provider = "tingly-box"
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ApplyCodexConfig("http://new-host/tingly/codex", []string{"tingly-codex"}); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	cfg := loadCodexConfigForTest(t, filepath.Join(codexDir, "config.toml"))
+	providers, _ := cfg["model_providers"].(map[string]interface{})
+
+	// User's openai provider preserved
+	openai, _ := providers["openai"].(map[string]interface{})
+	if openai["base_url"] != "https://api.openai.com/v1" {
+		t.Errorf("openai provider not preserved: %#v", openai)
+	}
+
+	// Our tingly-box provider overwritten with new base_url
+	tb, _ := providers["tingly-box"].(map[string]interface{})
+	if tb["base_url"] != "http://new-host/tingly/codex" {
+		t.Errorf("tingly-box.base_url = %v, want http://new-host/tingly/codex", tb["base_url"])
+	}
+
+	// User's [profiles.work] preserved
+	profiles, _ := cfg["profiles"].(map[string]interface{})
+	work, _ := profiles["work"].(map[string]interface{})
+	if work["model"] != "gpt-5" || work["model_provider"] != "openai" {
+		t.Errorf("profiles.work not preserved: %#v", work)
+	}
+
+	// User's [profiles.legacy-tingly] preserved (we don't garbage-collect
+	// orphaned tingly profiles from previous applies — the user may want
+	// to keep them).
+	if _, ok := profiles["legacy-tingly"]; !ok {
+		t.Errorf("profiles.legacy-tingly removed; expected preservation")
+	}
+
+	// Our new profile present
+	tingly, _ := profiles["tingly-codex"].(map[string]interface{})
+	if tingly["model"] != "tingly-codex" {
+		t.Errorf("profiles.tingly-codex not written: %#v", profiles)
+	}
+}
+
+func TestApplyCodexConfig_Idempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"a", "b"}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(filepath.Join(tempDir, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"a", "b"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadCodexConfigForTest(t, filepath.Join(tempDir, ".codex", "config.toml"))
+	profiles, _ := cfg["profiles"].(map[string]interface{})
+	if len(profiles) != 2 {
+		t.Errorf("idempotent apply added profiles: got %d, want 2 (%#v)", len(profiles), profiles)
+	}
+	// Sanity: at least the second run produced an updated file (backup exists)
+	// but profile set shouldn't grow.
+	_ = first
+}
+
+func TestApplyCodexConfig_ProfileKeyCollisionWithUserProfile(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// User has a profile literally named "tingly-codex" pointing at someone
+	// else. We must not overwrite it.
+	existing := `[profiles.tingly-codex]
+model = "user-private-model"
+model_provider = "openai"
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"tingly-codex"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := loadCodexConfigForTest(t, filepath.Join(codexDir, "config.toml"))
+	profiles, _ := cfg["profiles"].(map[string]interface{})
+
+	user, _ := profiles["tingly-codex"].(map[string]interface{})
+	if user["model"] != "user-private-model" {
+		t.Errorf("user's profiles.tingly-codex was clobbered: %#v", user)
+	}
+	// Our profile lives under a suffixed key
+	ours, _ := profiles["tingly-codex-1"].(map[string]interface{})
+	if ours == nil || ours["model"] != "tingly-codex" || ours["model_provider"] != "tingly-box" {
+		t.Errorf("expected suffixed profile to be written, got profiles=%#v", profiles)
+	}
+}
+
+func TestApplyCodexConfig_NoModels_OnlyTouchesManagedFields(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `model = "user-custom"
+some_user_flag = true
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := loadCodexConfigForTest(t, filepath.Join(codexDir, "config.toml"))
+	// model untouched because we have nothing to put there
+	if cfg["model"] != "user-custom" {
+		t.Errorf("model should be untouched when no models given, got %v", cfg["model"])
+	}
+	if cfg["some_user_flag"] != true {
+		t.Errorf("some_user_flag lost: %v", cfg["some_user_flag"])
+	}
+	// Provider still installed so codex can talk to tingly-box
+	providers, _ := cfg["model_providers"].(map[string]interface{})
+	if _, ok := providers["tingly-box"]; !ok {
+		t.Errorf("tingly-box provider should still be installed: %#v", providers)
 	}
 }

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -1030,7 +1030,11 @@ func TestApplyCodexConfig_Idempotent(t *testing.T) {
 	_ = first
 }
 
-func TestApplyCodexConfig_ProfileKeyCollisionWithUserProfile(t *testing.T) {
+// When the sanitized profile key already exists, we overwrite. Backups
+// (restored via `agent restore codex`) are the safety net — extra collision
+// logic isn't worth the complexity for users who have explicitly opted in to
+// tingly-box managing their codex config.
+func TestApplyCodexConfig_OverwritesCollidingProfile(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)
 
@@ -1038,10 +1042,8 @@ func TestApplyCodexConfig_ProfileKeyCollisionWithUserProfile(t *testing.T) {
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// User has a profile literally named "tingly-codex" pointing at someone
-	// else. We must not overwrite it.
 	existing := `[profiles.tingly-codex]
-model = "user-private-model"
+model = "stale-value"
 model_provider = "openai"
 `
 	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
@@ -1054,15 +1056,12 @@ model_provider = "openai"
 
 	cfg := loadCodexConfigForTest(t, filepath.Join(codexDir, "config.toml"))
 	profiles, _ := cfg["profiles"].(map[string]interface{})
-
-	user, _ := profiles["tingly-codex"].(map[string]interface{})
-	if user["model"] != "user-private-model" {
-		t.Errorf("user's profiles.tingly-codex was clobbered: %#v", user)
+	ours, _ := profiles["tingly-codex"].(map[string]interface{})
+	if ours["model"] != "tingly-codex" || ours["model_provider"] != "tingly-box" {
+		t.Errorf("expected colliding profile overwritten with tingly values, got %#v", ours)
 	}
-	// Our profile lives under a suffixed key
-	ours, _ := profiles["tingly-codex-1"].(map[string]interface{})
-	if ours == nil || ours["model"] != "tingly-codex" || ours["model_provider"] != "tingly-box" {
-		t.Errorf("expected suffixed profile to be written, got profiles=%#v", profiles)
+	if _, suffixed := profiles["tingly-codex-1"]; suffixed {
+		t.Errorf("did not expect suffixed key; profiles=%#v", profiles)
 	}
 }
 

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -624,3 +624,125 @@ console.log("OpenCode config written to", configPath);`, modelsJSON, configBaseU
 	escapedCode := strings.ReplaceAll(nodeCode, "'", "'\\''")
 	return "# Bash - Run in terminal\nnode -e '" + escapedCode + "'"
 }
+
+// collectCodexRuleModels returns the request_models of every active rule in
+// the Codex scenario, deduplicated and in declaration order.
+func collectCodexRuleModels(cfg *config.Config) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, rule := range cfg.GetRequestConfigs() {
+		if rule.GetScenario() != typ.ScenarioCodex || !rule.Active {
+			continue
+		}
+		model := strings.TrimSpace(rule.RequestModel)
+		if model == "" {
+			continue
+		}
+		if _, dup := seen[model]; dup {
+			continue
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	return out
+}
+
+// ApplyCodexConfigFromState applies the Codex CLI configuration derived from
+// the active Codex scenario rules. Mirrors the OpenCode endpoint: it does NOT
+// touch routing rules — those are managed via the rules UI.
+func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
+	cfg := h.config
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, config.ApplyResult{
+			Success: false,
+			Message: "Global config not available",
+		})
+		return
+	}
+
+	models := collectCodexRuleModels(cfg)
+
+	port := h.config.ServerPort
+	if port == 0 {
+		port = 12580
+	}
+	codexBaseURL := getBaseURLFromRequest(c, port) + "/tingly/codex"
+	apiKey := h.config.GetModelToken()
+
+	configResult, err := config.ApplyCodexConfig(codexBaseURL, models)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
+			Success: false,
+			Message: "Internal error: " + err.Error(),
+		})
+		return
+	}
+	authResult, err := config.ApplyCodexAuth(apiKey)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
+			Success: false,
+			Message: "Internal error: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, ApplyCodexConfigResponse{
+		Success:      configResult.Success && authResult.Success,
+		ConfigResult: *configResult,
+		AuthResult:   *authResult,
+		Models:       models,
+	})
+}
+
+// GetCodexConfigPreview returns the TOML/JSON that ApplyCodexConfigFromState
+// would write to a fresh file. The real apply still merges into any existing
+// ~/.codex/config.toml; this preview just shows the managed slice.
+func (h *Handler) GetCodexConfigPreview(c *gin.Context) {
+	cfg := h.config
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, CodexConfigPreviewResponse{
+			Success: false,
+			Message: "Global config not available",
+		})
+		return
+	}
+
+	models := collectCodexRuleModels(cfg)
+
+	port := h.config.ServerPort
+	if port == 0 {
+		port = 12580
+	}
+	codexBaseURL := getBaseURLFromRequest(c, port) + "/tingly/codex"
+	apiKey := h.config.GetModelToken()
+
+	tomlBytes, err := config.RenderCodexConfigTOML(codexBaseURL, models)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, CodexConfigPreviewResponse{
+			Success: false,
+			Message: "Failed to render config: " + err.Error(),
+		})
+		return
+	}
+
+	authBytes, err := json.MarshalIndent(map[string]string{"OPENAI_API_KEY": apiKey}, "", "  ")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, CodexConfigPreviewResponse{
+			Success: false,
+			Message: "Failed to render auth: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, CodexConfigPreviewResponse{
+		Success:    true,
+		ConfigToml: string(tomlBytes),
+		AuthJson:   string(authBytes),
+		Models:     models,
+	})
+}
+
+// RestoreCodexConfig rolls back Codex config files to their most recent backup.
+func (h *Handler) RestoreCodexConfig(c *gin.Context) {
+	h.restoreAgent(c, agent.AgentTypeCodex)
+}

--- a/internal/server/module/configapply/routes.go
+++ b/internal/server/module/configapply/routes.go
@@ -30,11 +30,23 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithResponseModel(ApplyOpenCodeConfigResponse{}),
 	)
 
+	router.POST("/config/apply/codex", handler.ApplyCodexConfigFromState,
+		swagger.WithDescription("Generate and apply Codex CLI configuration from system state"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(ApplyCodexConfigResponse{}),
+	)
+
 	// Config preview endpoint - returns config for display without applying
 	router.GET("/config/preview/opencode", handler.GetOpenCodeConfigPreview,
 		swagger.WithDescription("Generate OpenCode configuration preview from system state"),
 		swagger.WithTags("config"),
 		swagger.WithResponseModel(OpenCodeConfigPreviewResponse{}),
+	)
+
+	router.GET("/config/preview/codex", handler.GetCodexConfigPreview,
+		swagger.WithDescription("Generate Codex configuration preview from system state"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(CodexConfigPreviewResponse{}),
 	)
 
 	// Config restore endpoints - roll back to the most recent on-disk backup.
@@ -46,6 +58,12 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 
 	router.POST("/config/restore/opencode", handler.RestoreOpenCodeConfig,
 		swagger.WithDescription("Restore OpenCode configuration from the most recent backup"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(RestoreConfigResponse{}),
+	)
+
+	router.POST("/config/restore/codex", handler.RestoreCodexConfig,
+		swagger.WithDescription("Restore Codex configuration from the most recent backup"),
 		swagger.WithTags("config"),
 		swagger.WithResponseModel(RestoreConfigResponse{}),
 	)

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -28,6 +28,24 @@ type OpenCodeConfigPreviewResponse struct {
 	Message    string `json:"message,omitempty"`
 }
 
+// ApplyCodexConfigResponse is the response for ApplyCodexConfigFromState.
+type ApplyCodexConfigResponse struct {
+	Success      bool               `json:"success"`
+	ConfigResult config.ApplyResult `json:"configResult"`
+	AuthResult   config.ApplyResult `json:"authResult"`
+	Models       []string           `json:"models"`
+	Message      string             `json:"message,omitempty"`
+}
+
+// CodexConfigPreviewResponse is the response for GetCodexConfigPreview.
+type CodexConfigPreviewResponse struct {
+	Success    bool     `json:"success"`
+	ConfigToml string   `json:"configToml"`
+	AuthJson   string   `json:"authJson"`
+	Models     []string `json:"models"`
+	Message    string   `json:"message,omitempty"`
+}
+
 // RestoreConfigResponse is the response for the restore endpoints. It mirrors
 // the agent.RestoreAgentResult so callers can drive UI from the same data
 // the CLI prints.


### PR DESCRIPTION
## What

Tingly-box's codex apply had three bugs; this PR fixes them and fills in
the missing CLI / HTTP support.

- **Only one rule was applied.** `config.toml` hardcoded
  `model = "tingly-codex"`. Now the first active codex rule becomes the
  default `model`; every rule also gets a `[profiles.<name>]` block
  sharing the single `tingly-box` provider (`codex --profile <name>`).
- **Apply wiped user customizations.** `ApplyCodexConfig` now parses the
  existing TOML and only overwrites the fields tingly-box manages
  (top-level `model` / reasoning flags, `[model_providers.tingly-box]`,
  profiles named after our rules). Foreign top-level keys, other
  `[model_providers.*]`, and unrelated `[profiles.*]` are preserved.
  Previous file is backed up; `agent restore codex` rolls back.
- **No CLI / HTTP support.** Adds `tingly-box agent apply codex`
  (alias `cx`), plus `POST /config/apply/codex`,
  `GET /config/preview/codex`, `POST /config/restore/codex`. The
  frontend now calls the apply endpoint instead of reimplementing the
  TOML build in JS — the duplicate 75-line JS builder is removed.

## Test plan

- [x] `go test ./internal/agent/... ./internal/server/config/...`
      (6 new merge-contract tests: new file, top-level preservation,
      foreign providers/profiles, idempotency, colliding profile
      overwrite, no-models)
- [x] `go build ./internal/...`, `tsc --noEmit`, `oxlint`
- [x] Manual: apply with a `~/.codex/config.toml` that has
      `approval_policy` and `[model_providers.openai]` — both survive
- [x] Manual: apply with multiple codex rules — all become `[profiles.*]`,
      first rule is the default
- [x] Manual: `agent restore codex` rolls back