### PR TITLE
fix(codex): generate model_catalog_json so /model can see tingly models

### DIFF
--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -920,6 +920,13 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
+	if homeDir == "" {
+		// os.UserHomeDir can succeed and return "" in odd container setups
+		// where neither $HOME nor /etc/passwd resolves the current user.
+		// We refuse to proceed because filepath.Join would emit "/.codex/..."
+		// which Codex rejects as a non-absolute catalog path.
+		return nil, fmt.Errorf("home directory resolved to empty path")
+	}
 
 	configDir := filepath.Join(homeDir, ".codex")
 	targetPath := filepath.Join(configDir, "config.toml")
@@ -999,7 +1006,11 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 func RenderCodexConfigTOML(baseURL string, models []string) ([]byte, error) {
 	catalogPathForConfig := ""
 	if len(models) > 0 {
-		if homeDir, err := os.UserHomeDir(); err == nil {
+		// Guard against environments where UserHomeDir returns "" with no
+		// error (rare, but it makes filepath.Join emit "/.codex/..." which
+		// Codex then fails to parse as AbsolutePathBuf). Better to omit the
+		// field entirely than to write a broken path.
+		if homeDir, err := os.UserHomeDir(); err == nil && homeDir != "" {
 			catalogPathForConfig = filepath.Join(homeDir, ".codex", codexModelCatalogFile)
 		}
 	}
@@ -1057,15 +1068,26 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 // with the required fields populated using conservative defaults that match
 // the OpenAI Responses API surface (text-in/text-out, reasoning summaries on,
 // no verbosity knob). Codex 0.124+ deserializes this into
-// `protocol::openai_models::ModelsResponse`.
+// `protocol::openai_models::ModelsResponse`; field names and value types must
+// stay in sync with that struct.
 func renderCodexModelCatalog(models []string) ([]byte, error) {
+	// supported_reasoning_levels is Vec<ReasoningEffortPreset>, not a bare
+	// string list — each element is an {effort, description} object. Values
+	// mirror Codex's bundled catalog for GPT-5 so /model shows the familiar
+	// presets.
+	reasoningPresets := []map[string]interface{}{
+		{"effort": "minimal", "description": "Minimal reasoning for the fastest responses"},
+		{"effort": "low", "description": "Fast responses with lighter reasoning"},
+		{"effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks"},
+		{"effort": "high", "description": "Greater reasoning depth for complex problems"},
+	}
 	entries := make([]map[string]interface{}, 0, len(models))
 	for _, model := range models {
 		entries = append(entries, map[string]interface{}{
 			"slug":                             model,
 			"display_name":                     model,
 			"description":                      "Tingly Box managed model",
-			"supported_reasoning_levels":       []string{"minimal", "low", "medium", "high"},
+			"supported_reasoning_levels":       reasoningPresets,
 			"default_reasoning_level":          "medium",
 			"shell_type":                       "shell_command",
 			"visibility":                       "list",

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -879,7 +879,15 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 	return result, nil
 }
 
-// ApplyCodexConfig merges tingly-box Codex settings into ~/.codex/config.toml.
+// codexModelCatalogFile is the basename of the tingly-managed Codex model
+// catalog file written next to config.toml. config.toml's `model_catalog_json`
+// is pointed at the absolute path of this file so `/model` can enumerate
+// tingly-served models.
+const codexModelCatalogFile = "tingly-model-catalog.json"
+
+// ApplyCodexConfig merges tingly-box Codex settings into ~/.codex/config.toml
+// and writes ~/.codex/tingly-model-catalog.json with one entry per supplied
+// model so Codex's `/model` picker can see them.
 //
 // MERGE semantics: only fields tingly-box manages are overwritten. Everything
 // else the user put in config.toml — other top-level keys, other entries under
@@ -890,14 +898,23 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 //   - top-level `model_provider = "tingly-box"`,
 //     `model_supports_reasoning_summaries = true`,
 //     `model_reasoning_summary = "auto"`
+//   - top-level `model_catalog_json` (set to the absolute path of the
+//     catalog file when models is non-empty; cleared otherwise so we don't
+//     point at a missing file)
 //   - `[model_providers.tingly-box]` (always re-pinned to the supplied base URL)
 //   - `[profiles.<sanitized(model)>]` for each model — overwritten unconditionally
 //     under that key; `agent restore codex` recovers the previous file if needed
 //
+// Note: Codex's `model_catalog_json` REPLACES the bundled catalog (it does not
+// merge), and is read on startup only — switching via `/model` doesn't reload
+// it. Users wanting native OpenAI entries in `/model` should keep the bundled
+// catalog (i.e. not run apply) or merge by hand.
+//
 // Orphan tingly profiles from earlier applies are NOT garbage-collected; if
 // the user has trimmed their rules they can remove stale profiles by hand.
 //
-// The previous file (if any) is backed up before being rewritten.
+// The previous config.toml and catalog (if any) are backed up before being
+// rewritten.
 func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -906,6 +923,7 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 
 	configDir := filepath.Join(homeDir, ".codex")
 	targetPath := filepath.Join(configDir, "config.toml")
+	catalogPath := filepath.Join(configDir, codexModelCatalogFile)
 	result := &ApplyResult{}
 
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -930,7 +948,11 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 		result.Created = true
 	}
 
-	mergeCodexConfig(existing, baseURL, models)
+	catalogPathForConfig := ""
+	if len(models) > 0 {
+		catalogPathForConfig = catalogPath
+	}
+	mergeCodexConfig(existing, baseURL, models, catalogPathForConfig)
 
 	out, err := tomlpkg.Marshal(existing)
 	if err != nil {
@@ -940,6 +962,24 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 	if err := os.WriteFile(targetPath, out, 0644); err != nil {
 		result.Message = fmt.Sprintf("Failed to write file: %v", err)
 		return result, nil
+	}
+
+	if len(models) > 0 {
+		if _, err := os.Stat(catalogPath); err == nil {
+			if _, err := backupFile(catalogPath); err != nil {
+				result.Message = fmt.Sprintf("Failed to back up catalog: %v", err)
+				return result, nil
+			}
+		}
+		catalogBytes, err := renderCodexModelCatalog(models)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to render model catalog: %v", err)
+			return result, nil
+		}
+		if err := os.WriteFile(catalogPath, catalogBytes, 0644); err != nil {
+			result.Message = fmt.Sprintf("Failed to write catalog: %v", err)
+			return result, nil
+		}
 	}
 
 	result.Success = true
@@ -957,20 +997,33 @@ func ApplyCodexConfig(baseURL string, models []string) (*ApplyResult, error) {
 // ~/.codex/config.toml — i.e. the merge applied to an empty starting point.
 // Used by the preview endpoint so the UI can show exactly what's pending.
 func RenderCodexConfigTOML(baseURL string, models []string) ([]byte, error) {
+	catalogPathForConfig := ""
+	if len(models) > 0 {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			catalogPathForConfig = filepath.Join(homeDir, ".codex", codexModelCatalogFile)
+		}
+	}
 	cfg := map[string]interface{}{}
-	mergeCodexConfig(cfg, baseURL, models)
+	mergeCodexConfig(cfg, baseURL, models, catalogPathForConfig)
 	return tomlpkg.Marshal(cfg)
 }
 
 // mergeCodexConfig mutates cfg in place, applying tingly-managed fields while
 // preserving everything else. See ApplyCodexConfig for the contract.
-func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []string) {
+//
+// catalogPath is the absolute path to write into `model_catalog_json`. Pass
+// "" to leave that key untouched (e.g. when no models are configured — we
+// don't want to point Codex at a file we never wrote).
+func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []string, catalogPath string) {
 	if len(models) > 0 {
 		cfg["model"] = models[0]
 	}
 	cfg["model_provider"] = "tingly-box"
 	cfg["model_supports_reasoning_summaries"] = true
 	cfg["model_reasoning_summary"] = "auto"
+	if catalogPath != "" {
+		cfg["model_catalog_json"] = catalogPath
+	}
 
 	providers, _ := cfg["model_providers"].(map[string]interface{})
 	if providers == nil {
@@ -997,6 +1050,41 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	if len(profiles) > 0 {
 		cfg["profiles"] = profiles
 	}
+}
+
+// renderCodexModelCatalog produces the JSON payload for
+// ~/.codex/tingly-model-catalog.json. Each model becomes one ModelInfo entry
+// with the required fields populated using conservative defaults that match
+// the OpenAI Responses API surface (text-in/text-out, reasoning summaries on,
+// no verbosity knob). Codex 0.124+ deserializes this into
+// `protocol::openai_models::ModelsResponse`.
+func renderCodexModelCatalog(models []string) ([]byte, error) {
+	entries := make([]map[string]interface{}, 0, len(models))
+	for _, model := range models {
+		entries = append(entries, map[string]interface{}{
+			"slug":                             model,
+			"display_name":                     model,
+			"description":                      "Tingly Box managed model",
+			"supported_reasoning_levels":       []string{"minimal", "low", "medium", "high"},
+			"default_reasoning_level":          "medium",
+			"shell_type":                       "shell_command",
+			"visibility":                       "list",
+			"supported_in_api":                 true,
+			"priority":                         0,
+			"base_instructions":                "",
+			"supports_reasoning_summaries":     true,
+			"default_reasoning_summary":        "auto",
+			"support_verbosity":                false,
+			"truncation_policy":                map[string]interface{}{"mode": "tokens", "limit": 10000},
+			"supports_parallel_tool_calls":     true,
+			"effective_context_window_percent": 100,
+			"experimental_supported_tools":     []string{},
+			"input_modalities":                 []string{"text"},
+			"apply_patch_tool_type":            "freeform",
+		})
+	}
+	payload := map[string]interface{}{"models": entries}
+	return json.MarshalIndent(payload, "", "  ")
 }
 
 var codexProfileKeyInvalid = regexp.MustCompile(`[^A-Za-z0-9_-]`)

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -1110,6 +1110,50 @@ func TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt(t *testing.T) {
 	}
 }
 
+// supported_reasoning_levels deserializes into Vec<ReasoningEffortPreset>
+// upstream — a list of {effort, description} objects. Regression test for a
+// bug where we emitted bare strings and Codex rejected the catalog at startup
+// with "invalid type: string ..., expected struct ReasoningEffortPreset".
+func TestApplyCodexConfig_CatalogReasoningPresetsAreObjects(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"tingly-codex"}); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tempDir, ".codex", "tingly-model-catalog.json"))
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var catalog struct {
+		Models []struct {
+			SupportedReasoningLevels []struct {
+				Effort      string `json:"effort"`
+				Description string `json:"description"`
+			} `json:"supported_reasoning_levels"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, data)
+	}
+	if len(catalog.Models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(catalog.Models))
+	}
+	levels := catalog.Models[0].SupportedReasoningLevels
+	if len(levels) == 0 {
+		t.Fatal("supported_reasoning_levels empty")
+	}
+	for i, lvl := range levels {
+		if lvl.Effort == "" {
+			t.Errorf("levels[%d].effort empty (likely emitted as bare string)", i)
+		}
+		if lvl.Description == "" {
+			t.Errorf("levels[%d].description empty", i)
+		}
+	}
+}
+
 func TestApplyCodexConfig_NoModels_SkipsCatalog(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -1065,6 +1065,96 @@ model_provider = "openai"
 	}
 }
 
+func TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"tingly-codex", "tingly-gpt5"}); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	cfg := loadCodexConfigForTest(t, filepath.Join(codexDir, "config.toml"))
+
+	wantCatalog := filepath.Join(codexDir, "tingly-model-catalog.json")
+	if cfg["model_catalog_json"] != wantCatalog {
+		t.Errorf("model_catalog_json = %v, want %v", cfg["model_catalog_json"], wantCatalog)
+	}
+
+	data, err := os.ReadFile(wantCatalog)
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var catalog struct {
+		Models []map[string]interface{} `json:"models"`
+	}
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("unmarshal catalog: %v\n%s", err, data)
+	}
+	if len(catalog.Models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(catalog.Models))
+	}
+	gotSlugs := map[string]bool{}
+	for _, m := range catalog.Models {
+		gotSlugs[m["slug"].(string)] = true
+		// Spot-check a few required ModelInfo fields so a future refactor
+		// can't silently drop them and start tripping Codex's deserializer.
+		for _, key := range []string{"display_name", "supported_reasoning_levels", "shell_type", "visibility", "truncation_policy", "input_modalities"} {
+			if _, ok := m[key]; !ok {
+				t.Errorf("catalog entry %v missing required key %q", m["slug"], key)
+			}
+		}
+	}
+	if !gotSlugs["tingly-codex"] || !gotSlugs["tingly-gpt5"] {
+		t.Errorf("catalog slugs = %v, want tingly-codex+tingly-gpt5", gotSlugs)
+	}
+}
+
+func TestApplyCodexConfig_NoModels_SkipsCatalog(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", nil); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	cfg := loadCodexConfigForTest(t, filepath.Join(tempDir, ".codex", "config.toml"))
+	if _, ok := cfg["model_catalog_json"]; ok {
+		t.Errorf("model_catalog_json should not be set when no models: %v", cfg["model_catalog_json"])
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, ".codex", "tingly-model-catalog.json")); !os.IsNotExist(err) {
+		t.Errorf("catalog file should not exist when no models, err=%v", err)
+	}
+}
+
+func TestApplyCodexConfig_BacksUpExistingCatalog(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalogPath := filepath.Join(codexDir, "tingly-model-catalog.json")
+	stale := []byte(`{"models":[{"slug":"old"}]}`)
+	if err := os.WriteFile(catalogPath, stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"new-model"}); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	backupDir := filepath.Join(codexDir, "backup")
+	matches, err := filepath.Glob(filepath.Join(backupDir, "tingly-model-catalog.json.bak-*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) == 0 {
+		t.Errorf("expected backup of existing catalog in %s, none found", backupDir)
+	}
+}
+
 func TestApplyCodexConfig_NoModels_OnlyTouchesManagedFields(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)


### PR DESCRIPTION
## Summary
This change extends the Codex configuration management to generate and maintain a model catalog JSON file that allows Codex's `/model` picker to enumerate tingly-served models. The catalog is written alongside the config.toml and referenced via the `model_catalog_json` configuration key.

## Key Changes
- **New constant and file management**: Added `codexModelCatalogFile` constant for the tingly-managed catalog filename (`tingly-model-catalog.json`)
- **Catalog generation**: Implemented `renderCodexModelCatalog()` function that produces a JSON catalog with one ModelInfo entry per supplied model, using conservative defaults matching OpenAI's Responses API surface
- **Config merging**: Updated `mergeCodexConfig()` to accept and set the `model_catalog_json` path when models are configured, leaving it unset when no models exist (avoiding dangling references)
- **File lifecycle**: 
  - Catalog is only written when models are non-empty
  - Existing catalog files are backed up before being overwritten
  - Config properly points to the absolute path of the catalog file
- **Preview support**: Updated `RenderCodexConfigTOML()` to include the catalog path in preview renders
- **Comprehensive tests**: Added three new test cases covering catalog generation, empty model handling, and backup behavior

## Implementation Details
- Each model catalog entry includes required fields: slug, display_name, description, supported_reasoning_levels, shell_type, visibility, truncation_policy, input_modalities, and others
- The catalog uses conservative defaults (e.g., "medium" reasoning level, 10000 token truncation limit, text-only input modality)
- Catalog path is only set in config when models are provided; this prevents Codex from pointing at a non-existent file
- The implementation preserves backward compatibility—existing user configurations are not affected unless they explicitly run apply with models

https://claude.ai/code/session_01ScPJfxPrt7NbM8bC2TaUMg