### PR TITLE
ci: migrate to use musl for linux build and add npm tag for release (latest, rc).

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -34,6 +34,15 @@ on:
         required: false
         type: boolean
         default: true
+      npm_tag:
+        description: 'npm dist-tag for publish (latest/next/rc). Auto-trigger infers from version: stable→latest, pre-release→next'
+        required: false
+        type: choice
+        options:
+          - latest
+          - next
+          - rc
+        default: 'next'
 
 permissions:
   contents: write
@@ -52,6 +61,7 @@ jobs:
       publish_gui: ${{ steps.set_vars.outputs.publish_gui }}
       publish_bundle: ${{ steps.set_vars.outputs.publish_bundle }}
       build_docker: ${{ steps.set_vars.outputs.build_docker }}
+      npm_tag: ${{ steps.set_vars.outputs.npm_tag }}
       npx_version: ${{ steps.version.outputs.npx_version }}
       release_tag: ${{ steps.version.outputs.release_tag }}
     steps:
@@ -68,11 +78,20 @@ jobs:
             echo "publish_gui=false" >> $GITHUB_OUTPUT
             echo "publish_bundle=true" >> $GITHUB_OUTPUT
             echo "build_docker=true" >> $GITHUB_OUTPUT
+            # Auto-infer npm tag from version: stable → latest, pre-release → next
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+            VERSION="${RELEASE_TAG#v}"
+            if [[ "$VERSION" == *-* ]]; then
+              echo "npm_tag=next" >> $GITHUB_OUTPUT
+            else
+              echo "npm_tag=latest" >> $GITHUB_OUTPUT
+            fi
           else
             echo "publish_cli=${{ github.event.inputs.publish_cli }}" >> $GITHUB_OUTPUT
             echo "publish_gui=${{ github.event.inputs.publish_gui }}" >> $GITHUB_OUTPUT
             echo "publish_bundle=${{ github.event.inputs.publish_bundle }}" >> $GITHUB_OUTPUT
             echo "build_docker=${{ github.event.inputs.build_docker }}" >> $GITHUB_OUTPUT
+            echo "npm_tag=${{ github.event.inputs.npm_tag }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate and extract version
@@ -293,13 +312,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
+          NPM_TAG="${{ needs.setup.outputs.npm_tag }}"
 
-          echo "📦 Publishing ${{ matrix.pkg_name }}@${VERSION} to npm..."
+          echo "📦 Publishing ${{ matrix.pkg_name }}@${VERSION} to npm (tag: ${NPM_TAG})..."
 
           if npm view "${{ matrix.pkg_name }}@${VERSION}" version >/dev/null 2>&1; then
             echo "ℹ️ ${{ matrix.pkg_name }}@${VERSION} already exists on npm. Skipping publish."
           else
-            npm publish --provenance --access public
+            npm publish --provenance --access public --tag "$NPM_TAG"
           fi
 
   # Create a single NPX tag and release for CLI + Bundle
@@ -524,13 +544,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
+          NPM_TAG="${{ needs.setup.outputs.npm_tag }}"
 
-          echo "📦 Publishing $PKG_NAME@${VERSION} to npm..."
+          echo "📦 Publishing $PKG_NAME@${VERSION} to npm (tag: ${NPM_TAG})..."
 
           if npm view "$PKG_NAME@${VERSION}" version >/dev/null 2>&1; then
             echo "ℹ️ $PKG_NAME@${VERSION} already exists on npm. Skipping publish."
           else
-            npm publish --provenance --access public
+            npm publish --provenance --access public --tag "$NPM_TAG"
           fi
 
       - name: Create NPX tag and release

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -35,14 +35,13 @@ on:
         type: boolean
         default: true
       npm_tag:
-        description: 'npm dist-tag for publish (latest/next/rc). Auto-trigger infers from version: stable→latest, pre-release→next'
+        description: 'npm dist-tag for publish (latest/rc). Auto-trigger infers from version: stable→latest, pre-release→rc'
         required: false
         type: choice
         options:
           - latest
-          - next
           - rc
-        default: 'next'
+        default: 'rc'
 
 permissions:
   contents: write
@@ -78,11 +77,11 @@ jobs:
             echo "publish_gui=false" >> $GITHUB_OUTPUT
             echo "publish_bundle=true" >> $GITHUB_OUTPUT
             echo "build_docker=true" >> $GITHUB_OUTPUT
-            # Auto-infer npm tag from version: stable → latest, pre-release → next
+            # Auto-infer npm tag from version: stable → latest, pre-release → rc
             RELEASE_TAG="${{ github.event.release.tag_name }}"
             VERSION="${RELEASE_TAG#v}"
             if [[ "$VERSION" == *-* ]]; then
-              echo "npm_tag=next" >> $GITHUB_OUTPUT
+              echo "npm_tag=rc" >> $GITHUB_OUTPUT
             else
               echo "npm_tag=latest" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,10 +221,12 @@ jobs:
               CC=musl-gcc
               export CC
             elif [ "${{ matrix.goarch }}" == "arm64" ]; then
-              # Use zig for cross-compilation
-              CC="zig cc -target aarch64-linux-gnu"
-              CXX="zig c++ -target aarch64-linux-gnu"
+              # Use zig for cross-compilation with musl (static)
+              CC="zig cc -target aarch64-linux-musl"
+              CXX="zig c++ -target aarch64-linux-musl"
               export CC CXX
+              BUILD_TAGS="-tags 'sqlite_omit_load_extension'"
+              LDFLAGS_EXT="-linkmode external -extldflags \"-static\""
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,8 +168,14 @@ jobs:
           name: frontend-dist
           path: internal/web/dist/
 
-      - name: Install zig (for cross-compilation)
-        if: matrix.cross_compile == true
+      - name: Install musl toolchain (for amd64 static linking)
+        if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq musl-tools musl-dev
+
+      - name: Install zig (for arm64 cross-compilation)
+        if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
         run: |
           wget -q https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
           tar -xf zig-linux-x86_64-0.13.0.tar.xz
@@ -203,17 +209,30 @@ jobs:
           LDFLAGS+=" -X main.goVersion=${GO_VERSION}"
           LDFLAGS+=" -X main.platform=${PLATFORM}"
 
-          # Use zig for cross-compilation if needed
-          if [ "${{ matrix.cross_compile }}" == "true" ]; then
-            CC="zig cc -target aarch64-linux-gnu"
-            CXX="zig c++ -target aarch64-linux-gnu"
-            export CC CXX
+          # Configure build flags based on platform
+          BUILD_TAGS=""
+          LDFLAGS_EXT=""
+
+          if [ "${{ matrix.goos }}" == "linux" ]; then
+            if [ "${{ matrix.goarch }}" == "amd64" ]; then
+              # Static linking with musl for Linux amd64
+              BUILD_TAGS="-tags 'sqlite_omit_load_extension'"
+              LDFLAGS_EXT="-linkmode external -extldflags \"-static\""
+              CC=musl-gcc
+              export CC
+            elif [ "${{ matrix.goarch }}" == "arm64" ]; then
+              # Use zig for cross-compilation
+              CC="zig cc -target aarch64-linux-gnu"
+              CXX="zig c++ -target aarch64-linux-gnu"
+              export CC CXX
+            fi
           fi
 
           # Build with optimizations
           CGO_ENABLED=1 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
             go build \
-            -ldflags="${LDFLAGS}" \
+            ${BUILD_TAGS} \
+            -ldflags="${LDFLAGS} ${LDFLAGS_EXT}" \
             -trimpath \
             -o ./dist/tingly-box${{ matrix.exe }} \
             ./cli/tingly-box

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,8 @@ jobs:
       - name: Install musl toolchain (for amd64 static linking)
         if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq musl-tools musl-dev
+          sudo apt-get update -qq || echo "done"
+          sudo apt-get install -y -qq musl-tools musl-dev  || echo "done"
 
       - name: Install zig (for arm64 cross-compilation)
         if: matrix.goos == 'linux' && matrix.goarch == 'arm64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,12 @@ RUN if [ ! -f libs/go-genai/go.mod ]; then \
 # Download dependencies (must be after source copy due to local replace directive)
 RUN go mod download
 
-# Now build using the created Taskfile
-RUN CGO_ENABLED=1 CI=true task cli:build
+# Build with static linking for SQLite (musl)
+RUN CGO_ENABLED=1 \
+    go build \
+    -tags 'sqlite_omit_load_extension' \
+    -ldflags '-linkmode external -extldflags "-static"' \
+    -o ./build/tingly-box ./cli/tingly-box
 
 # Rename binary to expected name
 RUN mv ./build/tingly-box ./tingly

--- a/cli/tingly-box/main.go
+++ b/cli/tingly-box/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	_ "time/tzdata" // Embed timezone data for static builds
+
 	"github.com/alecthomas/kong"
 	"github.com/sirupsen/logrus"
 


### PR DESCRIPTION
- build: using MUSL for Linux builds helps distribute to almost all Linux distributions and bypasses glibc version limitations.
- release: add tag for npm release to distinguish `rc` and `latest`.