### PR TITLE
bugfix(cli): should use UUID instead of name for provider lookups

### DIFF
--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -63,13 +63,11 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 		// Parse agent type with alias support (cc, claude-code, etc.)
 		parsedType, err := agent.ParseAgentType(a.AgentType)
 		if err != nil {
-			// Invalid agent type provided - fail fast with helpful message
-			fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
 			fmt.Fprintln(os.Stderr, "Available agent types:")
 			fmt.Fprintln(os.Stderr, "  cc, claude-code - Claude Code CLI agent (@cc)")
 			fmt.Fprintln(os.Stderr, "  oc, opencode   - OpenCode editor agent (@oc)")
 			fmt.Fprintln(os.Stderr, "  cx, codex      - OpenAI Codex CLI (@codex)")
-			return fmt.Errorf("invalid agent type: %s", a.AgentType)
+			return err
 		}
 		req.AgentType = parsedType
 	}
@@ -118,9 +116,7 @@ func (a *AgentShowFlagCmdKong) Run(appManager *AppManager) error {
 	// Parse agent type with alias support (cc, claude-code, etc.)
 	agentType, err := agent.ParseAgentType(a.AgentType)
 	if err != nil {
-		// Invalid agent type provided - fail fast with helpful message
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		return fmt.Errorf("invalid agent type: %s", a.AgentType)
+		return err
 	}
 
 	return showAgentConfig(appManager, agentType)
@@ -150,9 +146,7 @@ func (a *AgentRestoreFlagCmdKong) Run(appManager *AppManager) error {
 		// Parse agent type with alias support (cc, claude-code, etc.)
 		parsedType, err := agent.ParseAgentType(a.AgentType)
 		if err != nil {
-			// Invalid agent type provided - fail fast with helpful message
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			return fmt.Errorf("invalid agent type: %s", a.AgentType)
+			return err
 		}
 		req.AgentType = parsedType
 	}
@@ -594,7 +588,7 @@ func showAgentConfig(appManager *AppManager, agentType agent.AgentType) error {
 	case agent.AgentTypeClaudeCode:
 		requestModel = "tingly/cc"
 	case agent.AgentTypeOpenCode:
-		requestModel = "tingly/oc"
+		requestModel = "tingly-opencode"
 	case agent.AgentTypeCodex:
 		requestModel = "tingly-codex"
 	}

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -283,22 +283,9 @@ func promptForAgentConfig(reader *bufio.Reader, appManager *AppManager, req *age
 func resolveAgentConfigFromRules(appManager *AppManager, req *agent.ApplyAgentRequest) error {
 	globalConfig := appManager.GetGlobalConfig()
 
-	// Determine request model and scenario based on agent type
-	var requestModel string
-	var scenario typ.RuleScenario
-
-	switch req.AgentType {
-	case agent.AgentTypeClaudeCode:
-		requestModel = "tingly/cc"
-		scenario = typ.ScenarioClaudeCode
-	case agent.AgentTypeOpenCode:
-		requestModel = "tingly-opencode"
-		scenario = typ.ScenarioOpenCode
-	case agent.AgentTypeCodex:
-		requestModel = "tingly-codex"
-		scenario = typ.ScenarioCodex
-	default:
-		return fmt.Errorf("unsupported agent type: %s", req.AgentType)
+	requestModel, scenario, err := agentRoutingKey(req.AgentType)
+	if err != nil {
+		return err
 	}
 
 	// Look for existing routing rule
@@ -569,6 +556,23 @@ func listAgentTypes() error {
 	return nil
 }
 
+// agentRoutingKey returns the canonical request model + scenario pair that
+// identifies the routing rule for an agent type. apply / show / restore must
+// agree on this mapping or they will look at different rules and disagree
+// about whether the agent is configured.
+func agentRoutingKey(agentType agent.AgentType) (string, typ.RuleScenario, error) {
+	switch agentType {
+	case agent.AgentTypeClaudeCode:
+		return "tingly/cc", typ.ScenarioClaudeCode, nil
+	case agent.AgentTypeOpenCode:
+		return "tingly-opencode", typ.ScenarioOpenCode, nil
+	case agent.AgentTypeCodex:
+		return "tingly-codex", typ.ScenarioCodex, nil
+	default:
+		return "", "", fmt.Errorf("unsupported agent type: %s", agentType)
+	}
+}
+
 // showAgentConfig shows current configuration for an agent type
 func showAgentConfig(appManager *AppManager, agentType agent.AgentType) error {
 	globalConfig := appManager.GetGlobalConfig()
@@ -582,15 +586,9 @@ func showAgentConfig(appManager *AppManager, agentType agent.AgentType) error {
 	fmt.Printf("Scenario:  %s\n", info.Scenario)
 	fmt.Println()
 
-	// Show routing rule for this scenario
-	var requestModel string
-	switch agentType {
-	case agent.AgentTypeClaudeCode:
-		requestModel = "tingly/cc"
-	case agent.AgentTypeOpenCode:
-		requestModel = "tingly-opencode"
-	case agent.AgentTypeCodex:
-		requestModel = "tingly-codex"
+	requestModel, _, err := agentRoutingKey(agentType)
+	if err != nil {
+		return err
 	}
 
 	rule := globalConfig.GetRuleByRequestModelAndScenario(requestModel, typ.RuleScenario(info.Scenario))

--- a/internal/command/agent_routing_test.go
+++ b/internal/command/agent_routing_test.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/agent"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestAgentRoutingKey locks down the (agent type → request model, scenario)
+// mapping that apply / show / restore all use to look up routing rules. The
+// strings must match the canonical request models registered by the rule
+// system (internal/agent/rule.go) — drift previously caused `agent show
+// opencode` to always report "No routing rule configured" even after apply.
+func TestAgentRoutingKey(t *testing.T) {
+	cases := []struct {
+		agentType    agent.AgentType
+		wantModel    string
+		wantScenario typ.RuleScenario
+	}{
+		{agent.AgentTypeClaudeCode, "tingly/cc", typ.ScenarioClaudeCode},
+		{agent.AgentTypeOpenCode, "tingly-opencode", typ.ScenarioOpenCode},
+		{agent.AgentTypeCodex, "tingly-codex", typ.ScenarioCodex},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.agentType), func(t *testing.T) {
+			gotModel, gotScenario, err := agentRoutingKey(tc.agentType)
+			if err != nil {
+				t.Fatalf("agentRoutingKey(%q) returned error: %v", tc.agentType, err)
+			}
+			if gotModel != tc.wantModel {
+				t.Errorf("request model: got %q, want %q", gotModel, tc.wantModel)
+			}
+			if gotScenario != tc.wantScenario {
+				t.Errorf("scenario: got %q, want %q", gotScenario, tc.wantScenario)
+			}
+		})
+	}
+}
+
+func TestAgentRoutingKeyUnknown(t *testing.T) {
+	_, _, err := agentRoutingKey(agent.AgentType("not-a-real-agent"))
+	if err == nil {
+		t.Fatal("expected error for unknown agent type, got nil")
+	}
+}

--- a/internal/command/provider.go
+++ b/internal/command/provider.go
@@ -379,11 +379,18 @@ func runProviderGetInteractive(appManager *AppManager, reader *bufio.Reader) err
 	return runProviderGet(appManager, name)
 }
 
-// runProviderGet displays provider details
-func runProviderGet(appManager *AppManager, name string) error {
-	provider, err := appManager.GetProvider(name)
-	if err != nil {
-		return fmt.Errorf("provider not found: %s", name)
+// runProviderGet displays provider details. The argument is interpreted as a
+// provider name first (matching `config get`'s "Provider name" help text); if
+// that misses, we try it as a UUID so users with a UUID at hand still work.
+// Providers are keyed by UUID, so a bare name lookup must go through the
+// dedicated name index — not GetProvider, which expects a UUID.
+func runProviderGet(appManager *AppManager, nameOrUUID string) error {
+	provider, err := appManager.GetProviderByName(nameOrUUID)
+	if err != nil || provider == nil {
+		provider, err = appManager.GetProvider(nameOrUUID)
+	}
+	if err != nil || provider == nil {
+		return fmt.Errorf("provider not found: %s", nameOrUUID)
 	}
 
 	fmt.Println("\n🔍 Provider Details")

--- a/internal/command/provider.go
+++ b/internal/command/provider.go
@@ -67,16 +67,18 @@ func (p *ProviderUpdateCmdKong) Run(appManager *AppManager) error {
 	return runProviderUpdateInteractive(appManager, bufio.NewReader(os.Stdin))
 }
 
-// ProviderDetailsCmdKong displays provider details (without name drops to interactive)
+// ProviderDetailsCmdKong displays provider details. Without a UUID it drops
+// to interactive selection. Names are not unique (UUID is the PK), so the
+// positional argument is the UUID.
 type ProviderDetailsCmdKong struct {
-	Name string `kong:"arg,optional,help='Provider name'"`
+	UUID string `kong:"arg,optional,help='Provider UUID'"`
 }
 
 func (p *ProviderDetailsCmdKong) Run(appManager *AppManager) error {
-	if p.Name == "" {
+	if p.UUID == "" {
 		return runProviderGetInteractive(appManager, bufio.NewReader(os.Stdin))
 	}
-	return runProviderGet(appManager, p.Name)
+	return runProviderGet(appManager, p.UUID)
 }
 
 // ============== Business Logic Functions ==============
@@ -169,6 +171,7 @@ func runProviderList(appManager *AppManager) error {
 			status = "✅ Enabled"
 		}
 		fmt.Printf("%d. %s\n", i+1, provider.Name)
+		fmt.Printf("   UUID: %s\n", provider.UUID)
 		fmt.Printf("   URL: %s\n", provider.APIBase)
 		fmt.Printf("   Style: %s\n", provider.APIStyle)
 		fmt.Printf("   Status: %s\n", status)
@@ -202,7 +205,7 @@ func runProviderUpdateInteractive(appManager *AppManager, reader *bufio.Reader) 
 		if !provider.Enabled {
 			status = "[Disabled]"
 		}
-		fmt.Printf("%d. %s %s\n", i+1, status, provider.Name)
+		fmt.Printf("%d. %s %s (%s)\n", i+1, status, provider.Name, provider.UUID)
 	}
 
 	fmt.Print("\nEnter provider number: ")
@@ -308,7 +311,7 @@ func runProviderDeleteInteractive(appManager *AppManager, reader *bufio.Reader) 
 		if !provider.Enabled {
 			status = "[Disabled]"
 		}
-		fmt.Printf("%d. %s %s\n", i+1, status, provider.Name)
+		fmt.Printf("%d. %s %s (%s)\n", i+1, status, provider.Name, provider.UUID)
 	}
 
 	fmt.Print("\nEnter provider number: ")
@@ -348,7 +351,9 @@ func runProviderDeleteByUUID(appManager *AppManager, uuid, name string) error {
 	return nil
 }
 
-// runProviderGetInteractive runs interactive get mode
+// runProviderGetInteractive runs interactive get mode. Selection happens by
+// menu number so we can pass the chosen provider's UUID downstream (names
+// aren't unique, so picking by name is ambiguous).
 func runProviderGetInteractive(appManager *AppManager, reader *bufio.Reader) error {
 	providers := appManager.ListProviders()
 
@@ -361,36 +366,30 @@ func runProviderGetInteractive(appManager *AppManager, reader *bufio.Reader) err
 	fmt.Println("\nSelect a provider:")
 
 	for i, provider := range providers {
-		fmt.Printf("%d. %s\n", i+1, provider.Name)
+		fmt.Printf("%d. %s (%s)\n", i+1, provider.Name, provider.UUID)
 	}
 
-	fmt.Print("\nEnter provider number or name: ")
+	fmt.Print("\nEnter provider number or UUID: ")
 	input, _ := reader.ReadString('\n')
 	choice := strings.TrimSpace(strings.TrimSuffix(input, "\n"))
 
-	var name string
+	var uuid string
 	var num int
 	if _, err := fmt.Sscanf(choice, "%d", &num); err == nil && num > 0 && num <= len(providers) {
-		name = providers[num-1].Name
+		uuid = providers[num-1].UUID
 	} else {
-		name = choice
+		uuid = choice
 	}
 
-	return runProviderGet(appManager, name)
+	return runProviderGet(appManager, uuid)
 }
 
-// runProviderGet displays provider details. The argument is interpreted as a
-// provider name first (matching `config get`'s "Provider name" help text); if
-// that misses, we try it as a UUID so users with a UUID at hand still work.
-// Providers are keyed by UUID, so a bare name lookup must go through the
-// dedicated name index — not GetProvider, which expects a UUID.
-func runProviderGet(appManager *AppManager, nameOrUUID string) error {
-	provider, err := appManager.GetProviderByName(nameOrUUID)
+// runProviderGet displays provider details for the given UUID. Providers are
+// keyed by UUID; names are not unique and must not be used as lookup keys.
+func runProviderGet(appManager *AppManager, uuid string) error {
+	provider, err := appManager.GetProvider(uuid)
 	if err != nil || provider == nil {
-		provider, err = appManager.GetProvider(nameOrUUID)
-	}
-	if err != nil || provider == nil {
-		return fmt.Errorf("provider not found: %s", nameOrUUID)
+		return fmt.Errorf("provider not found: %s", uuid)
 	}
 
 	fmt.Println("\n🔍 Provider Details")

--- a/internal/command/provider_add.go
+++ b/internal/command/provider_add.go
@@ -320,8 +320,10 @@ func runAdd(appManager *AppManager, args []string) error {
 		}
 	}
 
-	// Check if provider already exists
-	if existingProvider, err := appManager.GetProvider(name); err == nil && existingProvider != nil {
+	// Check if provider already exists. Providers are keyed by UUID, so
+	// duplicate detection has to go through the name index — GetProvider
+	// takes a UUID and would never match a freshly-typed name.
+	if existingProvider, err := appManager.GetProviderByName(name); err == nil && existingProvider != nil {
 		fmt.Printf("Provider '%s' already exists. Please use a different name or update the existing provider.\n", name)
 		return fmt.Errorf("provider already exists")
 	}
@@ -356,8 +358,16 @@ func runAdd(appManager *AppManager, args []string) error {
 	return addProviderWithConfirmation(appManager, reader, name, apiBase, token, apiStyle)
 }
 
-// addProviderWithConfirmation displays summary and adds the provider
+// addProviderWithConfirmation displays summary and adds the provider.
+// Enforces the duplicate-name check here too, because runAdd's positional-arg
+// fast path skips the interactive pre-check and would otherwise let users
+// register multiple providers with the same name (each gets a unique UUID).
 func addProviderWithConfirmation(appManager *AppManager, reader *bufio.Reader, name, apiBase, token string, apiStyle APIStyle) error {
+	if existingProvider, err := appManager.GetProviderByName(name); err == nil && existingProvider != nil {
+		fmt.Printf("Provider '%s' already exists. Please use a different name or update the existing provider.\n", name)
+		return fmt.Errorf("provider already exists")
+	}
+
 	// Display summary and get confirmation
 	fmt.Println("\n--- Configuration Summary ---")
 	fmt.Printf("Provider Name: %s\n", name)

--- a/internal/command/provider_add.go
+++ b/internal/command/provider_add.go
@@ -82,17 +82,18 @@ func (c *ConfigUpdateCmdKong) Run(appManager *AppManager) error {
 	return runProviderUpdateInteractive(appManager, bufio.NewReader(os.Stdin))
 }
 
-// ConfigGetCmdKong displays a provider's details. Without a name it drops
-// into interactive selection.
+// ConfigGetCmdKong displays a provider's details. Without a UUID it drops
+// into interactive selection. The lookup is by UUID because provider names
+// are not unique (UUID is the primary key).
 type ConfigGetCmdKong struct {
-	Name string `kong:"arg,optional,help='Provider name'"`
+	UUID string `kong:"arg,optional,help='Provider UUID'"`
 }
 
 func (c *ConfigGetCmdKong) Run(appManager *AppManager) error {
-	if c.Name == "" {
+	if c.UUID == "" {
 		return runProviderGetInteractive(appManager, bufio.NewReader(os.Stdin))
 	}
-	return runProviderGet(appManager, c.Name)
+	return runProviderGet(appManager, c.UUID)
 }
 
 // ConfigExportCmdKong exports configuration to file or stdout
@@ -320,14 +321,6 @@ func runAdd(appManager *AppManager, args []string) error {
 		}
 	}
 
-	// Check if provider already exists. Providers are keyed by UUID, so
-	// duplicate detection has to go through the name index — GetProvider
-	// takes a UUID and would never match a freshly-typed name.
-	if existingProvider, err := appManager.GetProviderByName(name); err == nil && existingProvider != nil {
-		fmt.Printf("Provider '%s' already exists. Please use a different name or update the existing provider.\n", name)
-		return fmt.Errorf("provider already exists")
-	}
-
 	// Get API base URL (if not provided)
 	if apiBase == "" {
 		var err error
@@ -359,15 +352,10 @@ func runAdd(appManager *AppManager, args []string) error {
 }
 
 // addProviderWithConfirmation displays summary and adds the provider.
-// Enforces the duplicate-name check here too, because runAdd's positional-arg
-// fast path skips the interactive pre-check and would otherwise let users
-// register multiple providers with the same name (each gets a unique UUID).
+// Note: provider names are not unique — only UUIDs are — so we don't reject
+// "duplicate" names. The user explicitly chose the name; AddProvider will mint
+// a fresh UUID either way.
 func addProviderWithConfirmation(appManager *AppManager, reader *bufio.Reader, name, apiBase, token string, apiStyle APIStyle) error {
-	if existingProvider, err := appManager.GetProviderByName(name); err == nil && existingProvider != nil {
-		fmt.Printf("Provider '%s' already exists. Please use a different name or update the existing provider.\n", name)
-		return fmt.Errorf("provider already exists")
-	}
-
 	// Display summary and get confirmation
 	fmt.Println("\n--- Configuration Summary ---")
 	fmt.Printf("Provider Name: %s\n", name)

--- a/internal/command/provider_cli_test.go
+++ b/internal/command/provider_cli_test.go
@@ -1,0 +1,238 @@
+package command
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// withSilencedStdout captures and discards everything written to os.Stdout
+// while fn runs. The CLI helpers under test print directly, so tests that
+// don't care about the printed output use this to keep test logs clean.
+func withSilencedStdout(t *testing.T, fn func()) {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, r)
+		close(done)
+	}()
+	defer func() {
+		_ = w.Close()
+		os.Stdout = oldStdout
+		<-done
+	}()
+	fn()
+}
+
+// newTestAppManager builds an AppManager with a throwaway config directory.
+func newTestAppManager(t *testing.T) *AppManager {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "tingly-test-provider-cli-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	am, err := NewAppManager(tempDir)
+	if err != nil {
+		t.Fatalf("NewAppManager failed: %v", err)
+	}
+	return am
+}
+
+// TestRunProviderGetByUUID verifies that runProviderGet looks providers up
+// strictly by UUID. Names are not unique (UUID is the PK), so a successful
+// "lookup by name" would re-introduce the ambiguity bug the previous fix
+// closed.
+func TestRunProviderGetByUUID(t *testing.T) {
+	am := newTestAppManager(t)
+
+	uuid, err := am.AddProvider("my-provider", "https://api.example.com", "tok", protocol.APIStyleOpenAI)
+	if err != nil {
+		t.Fatalf("AddProvider failed: %v", err)
+	}
+
+	t.Run("known UUID resolves", func(t *testing.T) {
+		withSilencedStdout(t, func() {
+			if err := runProviderGet(am, uuid); err != nil {
+				t.Errorf("runProviderGet(uuid) returned error: %v", err)
+			}
+		})
+	})
+
+	t.Run("name is not accepted as a lookup key", func(t *testing.T) {
+		var err error
+		withSilencedStdout(t, func() {
+			err = runProviderGet(am, "my-provider")
+		})
+		if err == nil {
+			t.Error("runProviderGet(name) should error — names are not the PK")
+		}
+	})
+
+	t.Run("unknown UUID returns error", func(t *testing.T) {
+		var err error
+		withSilencedStdout(t, func() {
+			err = runProviderGet(am, "00000000-0000-0000-0000-000000000000")
+		})
+		if err == nil {
+			t.Error("expected error for unknown UUID, got nil")
+		}
+	})
+}
+
+// TestRunProviderListDisplaysUUID verifies the list output includes each
+// provider's UUID. Operators need the UUID to pass to `config get` /
+// `provider details`, so hiding it would defeat the lookup-by-UUID design.
+func TestRunProviderListDisplaysUUID(t *testing.T) {
+	am := newTestAppManager(t)
+
+	uuid, err := am.AddProvider("listed", "https://api.example.com", "tok", protocol.APIStyleOpenAI)
+	if err != nil {
+		t.Fatalf("AddProvider failed: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+
+	listErr := runProviderList(am)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if listErr != nil {
+		t.Fatalf("runProviderList returned error: %v", listErr)
+	}
+	if !strings.Contains(string(out), uuid) {
+		t.Errorf("list output should include UUID %q; got:\n%s", uuid, out)
+	}
+}
+
+// withControlledStdin replaces os.Stdin with a pipe and gives fn a writer it
+// can use to feed input on demand. Each runAdd creates its own
+// bufio.NewReader(os.Stdin), so the caller must avoid letting one reader
+// gulp input intended for the next — write each prompt response only after
+// the prior call finishes.
+func withControlledStdin(t *testing.T, fn func(stdin io.Writer)) {
+	t.Helper()
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdin = r
+	defer func() {
+		_ = w.Close()
+		os.Stdin = oldStdin
+		_ = r.Close()
+	}()
+	fn(w)
+}
+
+// TestRunAddAllowsDuplicateNames is the regression for the (now-reverted)
+// duplicate-name rejection. Two providers with the same display name must
+// both be acceptable because the system disambiguates them by UUID.
+func TestRunAddAllowsDuplicateNames(t *testing.T) {
+	am := newTestAppManager(t)
+
+	args := []string{"dup", "https://api.example.com", "tok", "openai"}
+
+	// runAdd with 4 positional args still calls addProviderWithConfirmation,
+	// which prompts y/N. Write each "y" only after the prior call returns
+	// so each invocation's freshly-allocated bufio reader sees its prompt.
+	withControlledStdin(t, func(stdin io.Writer) {
+		withSilencedStdout(t, func() {
+			_, _ = io.WriteString(stdin, "y\n")
+			if err := runAdd(am, args); err != nil {
+				t.Fatalf("first runAdd failed: %v", err)
+			}
+			_, _ = io.WriteString(stdin, "y\n")
+			if err := runAdd(am, args); err != nil {
+				t.Fatalf("second runAdd with the same name should succeed, got: %v", err)
+			}
+		})
+	})
+
+	count := 0
+	for _, p := range am.ListProviders() {
+		if p.Name == "dup" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected 2 providers named %q, got %d", "dup", count)
+	}
+}
+
+// TestRunAddRejectsInvalidAPIStyle locks down the only validation runAdd
+// performs on positional input — anything other than openai/anthropic must
+// fail loud rather than silently defaulting.
+func TestRunAddRejectsInvalidAPIStyle(t *testing.T) {
+	am := newTestAppManager(t)
+
+	var err error
+	withSilencedStdout(t, func() {
+		err = runAdd(am, []string{"p", "https://api.example.com", "tok", "bogus-style"})
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid API style, got nil")
+	}
+}
+
+// TestProviderDetailsCmdKongUsesUUID is a structural assertion: the field
+// the user supplies on the command line must be named UUID (not Name), so
+// the help text and behavior are consistent with "providers are keyed by
+// UUID". A regression here would silently rename the positional arg back
+// to a name.
+func TestProviderDetailsCmdKongUsesUUID(t *testing.T) {
+	cmd := ProviderDetailsCmdKong{UUID: "abc"}
+	if cmd.UUID != "abc" {
+		t.Errorf("ProviderDetailsCmdKong.UUID round-trip failed: got %q", cmd.UUID)
+	}
+
+	cfg := ConfigGetCmdKong{UUID: "abc"}
+	if cfg.UUID != "abc" {
+		t.Errorf("ConfigGetCmdKong.UUID round-trip failed: got %q", cfg.UUID)
+	}
+}
+
+// TestProviderDetailsCmdKongRunWithUUID verifies the Run method forwards a
+// supplied UUID to runProviderGet (rather than going through interactive
+// mode). We test the happy path; the error path is covered by the helper
+// tests above.
+func TestProviderDetailsCmdKongRunWithUUID(t *testing.T) {
+	am := newTestAppManager(t)
+
+	uuid, err := am.AddProvider("p", "https://api.example.com", "tok", protocol.APIStyleOpenAI)
+	if err != nil {
+		t.Fatalf("AddProvider failed: %v", err)
+	}
+
+	cmd := ProviderDetailsCmdKong{UUID: uuid}
+	withSilencedStdout(t, func() {
+		if err := cmd.Run(am); err != nil {
+			t.Errorf("ProviderDetailsCmdKong.Run with valid UUID returned error: %v", err)
+		}
+	})
+
+	cfg := ConfigGetCmdKong{UUID: uuid}
+	withSilencedStdout(t, func() {
+		if err := cfg.Run(am); err != nil {
+			t.Errorf("ConfigGetCmdKong.Run with valid UUID returned error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Refactored provider lookup logic to use UUID as the primary identifier instead of provider names. This change addresses the fact that provider names are not unique in the system, while UUIDs serve as the actual primary key.

## Key Changes

- **Provider Details Command**: Changed `ProviderDetailsCmdKong` positional argument from `Name` to `UUID` with updated help text and logic
- **Provider Get Operations**: Updated `runProviderGet()` to accept and lookup by UUID instead of name, with improved error handling for nil providers
- **Interactive Selection**: Modified `runProviderGetInteractive()` to:
  - Display UUIDs alongside provider names in selection menus
  - Accept UUID input in addition to menu numbers
  - Pass UUID to downstream functions instead of names
- **UI Improvements**: 
  - Added UUID display in provider list output
  - Updated interactive menus to show UUIDs in parentheses for clarity
  - Changed prompt text from "name" to "UUID" where applicable
- **Config Get Command**: Updated `ConfigGetCmdKong` similarly to use UUID for lookups
- **Provider Addition**: Removed duplicate name validation check since names are not unique; added clarifying comments
- **Agent Commands**: Simplified error handling by removing redundant error message formatting and returning the original error directly
- **Agent Model Name**: Fixed OpenCode agent model name from "tingly/oc" to "tingly-opencode"

## Implementation Details

- All provider lookup operations now use UUID as the key, ensuring unambiguous identification
- Interactive menus still allow users to select by number for convenience, but internally resolve to UUID
- Added clarifying comments throughout explaining why UUID is used instead of name
- Error messages now reference UUID instead of name for consistency

https://claude.ai/code/session_01A6vCiy1XngqtiKyqDUU9DP