### PR TITLE
feat(bot): add bot restart endpoint and improve lifecycle management

### DIFF
--- a/frontend/src/components/bot/BotCard.tsx
+++ b/frontend/src/components/bot/BotCard.tsx
@@ -1,4 +1,4 @@
-import {Delete as DeleteIcon, Edit as EditIcon, Warning as WarningIcon} from '@mui/icons-material';
+import {Delete as DeleteIcon, Edit as EditIcon, RestartAlt as RestartIcon, Warning as WarningIcon} from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -98,9 +98,11 @@ interface BotCardProps {
     onEdit: () => void;
     onDelete: () => void;
     onBotToggle: () => void;
+    onRestart: () => void;
     onModelClick: () => void;
     onCWDChange: (cwd: string) => void;
     isToggling?: boolean;
+    isRestarting?: boolean;
 }
 
 const BotCard: React.FC<BotCardProps> = ({
@@ -109,9 +111,11 @@ const BotCard: React.FC<BotCardProps> = ({
                                              onEdit,
                                              onDelete,
                                              onBotToggle,
+                                             onRestart,
                                              onModelClick,
                                              onCWDChange,
                                              isToggling = false,
+                                             isRestarting = false,
                                          }) => {
     const isActive = bot.enabled ?? true;
     const isExpanded = true;
@@ -202,12 +206,24 @@ const BotCard: React.FC<BotCardProps> = ({
                             disabled={isToggling}
                         />
                     </Tooltip>
+                    <Tooltip title={isActive ? 'Restart Bot' : 'Enable bot to restart'}>
+                        <span>
+                            <IconButton
+                                size="small"
+                                color="primary"
+                                onClick={onRestart}
+                                disabled={!isActive || isToggling || isRestarting}
+                            >
+                                <RestartIcon fontSize="small"/>
+                            </IconButton>
+                        </span>
+                    </Tooltip>
                     <Tooltip title="Edit">
                         <IconButton
                             size="small"
                             color="primary"
                             onClick={onEdit}
-                            disabled={isToggling}
+                            disabled={isToggling || isRestarting}
                         >
                             <EditIcon fontSize="small"/>
                         </IconButton>
@@ -217,7 +233,7 @@ const BotCard: React.FC<BotCardProps> = ({
                             size="small"
                             color="error"
                             onClick={handleDeleteClick}
-                            disabled={isToggling}
+                            disabled={isToggling || isRestarting}
                         >
                             <DeleteIcon fontSize="small"/>
                         </IconButton>

--- a/frontend/src/components/bot/BotCardGrid.tsx
+++ b/frontend/src/components/bot/BotCardGrid.tsx
@@ -12,11 +12,13 @@ interface BotCardGridProps {
     onEdit?: (uuid: string) => void;
     onDelete?: (uuid: string) => void;
     onBotToggle?: (uuid: string, enabled: boolean) => void;
+    onBotRestart?: (uuid: string) => void;
     onBotModelSelect?: (botUuid: string) => void;
     onCWDChange?: (botUuid: string, cwd: string) => void;
     loading?: boolean;
     error?: string | null;
     togglingBotUuid?: string | null;
+    restartingBotUuid?: string | null;
 }
 
 const SkeletonCard = () => (
@@ -45,11 +47,13 @@ const BotCardGrid: React.FC<BotCardGridProps> = ({
     onEdit,
     onDelete,
     onBotToggle,
+    onBotRestart,
     onBotModelSelect,
     onCWDChange,
     loading = false,
     error = null,
     togglingBotUuid = null,
+    restartingBotUuid = null,
 }) => {
     const [deleteModal, setDeleteModal] = useState<{ open: boolean; uuid: string; name: string }>({
         open: false,
@@ -133,9 +137,11 @@ const BotCardGrid: React.FC<BotCardGridProps> = ({
                                 onEdit={() => onEdit?.(bot.uuid!)}
                                 onDelete={() => handleDeleteClick(bot.uuid!)}
                                 onBotToggle={() => handleBotToggle(bot.uuid!, !bot.enabled)}
+                                onRestart={() => onBotRestart?.(bot.uuid!)}
                                 onModelClick={() => handleBotModelClick(bot.uuid!)}
                                 onCWDChange={(cwd) => handleCWDChange(bot.uuid!, cwd)}
                                 isToggling={isToggling}
+                                isRestarting={restartingBotUuid === bot.uuid}
                             />
                         </CardGridItem>
                     );

--- a/frontend/src/pages/remote-control/BotPage.tsx
+++ b/frontend/src/pages/remote-control/BotPage.tsx
@@ -55,6 +55,7 @@ const BotPage = () => {
 
     // Toggle loading state
     const [togglingBotUuid, setTogglingBotUuid] = useState<string | null>(null);
+    const [restartingBotUuid, setRestartingBotUuid] = useState<string | null>(null);
 
     // Snackbar notification state
     const [snackbar, setSnackbar] = useState<{
@@ -298,6 +299,24 @@ const BotPage = () => {
         }
     }, [loadBotSettings, showNotification]);
 
+    const handleBotRestart = useCallback(async (uuid: string) => {
+        setRestartingBotUuid(uuid);
+        try {
+            const result = await api.restartImBot(uuid);
+            if (result?.success) {
+                showNotification('Bot restarted', 'success');
+                await loadBotSettings();
+            } else {
+                showNotification(`Failed to restart bot: ${result?.error || 'Unknown error'}`, 'error');
+            }
+        } catch (err) {
+            console.error('Failed to restart bot:', err);
+            showNotification('Failed to restart bot', 'error');
+        } finally {
+            setRestartingBotUuid(null);
+        }
+    }, [loadBotSettings, showNotification]);
+
     const handleDeleteBot = useCallback(async (uuid: string) => {
         try {
             const result = await api.deleteImBotSetting(uuid);
@@ -437,9 +456,11 @@ const BotPage = () => {
                                 onEdit={() => handleOpenBotTokenDialog(bot.uuid)}
                                 onDelete={() => handleDeleteBot(bot.uuid!)}
                                 onBotToggle={() => handleBotToggle(bot.uuid!, !bot.enabled)}
+                                onRestart={() => handleBotRestart(bot.uuid!)}
                                 onModelClick={() => handleBotModelSelect(bot.uuid!)}
                                 onCWDChange={(cwd) => handleCWDChange(bot.uuid!, cwd)}
                                 isToggling={togglingBotUuid === bot.uuid}
+                                isRestarting={restartingBotUuid === bot.uuid}
                             />
                         </div>
                     ))

--- a/frontend/src/pages/remote-control/PlatformBotPage.tsx
+++ b/frontend/src/pages/remote-control/PlatformBotPage.tsx
@@ -54,6 +54,7 @@ const PlatformBotPage = ({ platformId, platformName, platformGuide }: PlatformBo
 
     // Toggle loading state
     const [togglingBotUuid, setTogglingBotUuid] = useState<string | null>(null);
+    const [restartingBotUuid, setRestartingBotUuid] = useState<string | null>(null);
 
     // Snackbar notification state
     const [snackbar, setSnackbar] = useState<{
@@ -266,6 +267,24 @@ const PlatformBotPage = ({ platformId, platformName, platformGuide }: PlatformBo
         }
     }, [loadBotSettings, showNotification]);
 
+    const handleBotRestart = useCallback(async (uuid: string) => {
+        setRestartingBotUuid(uuid);
+        try {
+            const result = await api.restartImBot(uuid);
+            if (result?.success) {
+                showNotification('Bot restarted', 'success');
+                await loadBotSettings();
+            } else {
+                showNotification(`Failed to restart bot: ${result?.error || 'Unknown error'}`, 'error');
+            }
+        } catch (err) {
+            console.error('Failed to restart bot:', err);
+            showNotification('Failed to restart bot', 'error');
+        } finally {
+            setRestartingBotUuid(null);
+        }
+    }, [loadBotSettings, showNotification]);
+
     const handleDeleteBot = useCallback(async (uuid: string) => {
         try {
             const result = await api.deleteImBotSetting(uuid);
@@ -378,9 +397,11 @@ const PlatformBotPage = ({ platformId, platformName, platformGuide }: PlatformBo
                                 onEdit={() => handleOpenBotTokenDialog(bot.uuid)}
                                 onDelete={() => handleDeleteBot(bot.uuid!)}
                                 onBotToggle={() => handleBotToggle(bot.uuid!, !bot.enabled)}
+                                onRestart={() => handleBotRestart(bot.uuid!)}
                                 onModelClick={() => handleBotModelSelect(bot.uuid!)}
                                 onCWDChange={(cwd) => handleCWDChange(bot.uuid!, cwd)}
                                 isToggling={togglingBotUuid === bot.uuid}
+                                isRestarting={restartingBotUuid === bot.uuid}
                             />
                         </div>
                     ))

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1602,6 +1602,23 @@ export const api = {
         }
     },
 
+    restartImBot: async (uuid: string): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.POST('/api/v1/imbot-admin/restart/{uuid}' as any, {
+                headers,
+                params: {path: {uuid}}
+            });
+            return response.data;
+        } catch (error: any) {
+            if (error.response?.status === 404) {
+                return {success: false, error: 'ImBot setting not found'};
+            }
+            return {success: false, error: error.message};
+        }
+    },
+
     toggleImBotSetting: async (uuid: string): Promise<any> => {
         try {
             const client = await getClient();

--- a/imbot/platform/feishu/bot_sdk.go
+++ b/imbot/platform/feishu/bot_sdk.go
@@ -173,8 +173,11 @@ func (b *Bot) StartReceiving(ctx context.Context) error {
 
 	b.wsClient = wsClient
 
-	// Start WebSocket connection in background
-	b.eventCtx, b.eventCancel = context.WithCancel(context.Background())
+	// Start WebSocket connection in background.
+	// Derive eventCtx from the parent ctx so cancellation of the bot's
+	// lifecycle context tears down the WS goroutine even if Disconnect()
+	// is bypassed (e.g. panic upstream).
+	b.eventCtx, b.eventCancel = context.WithCancel(ctx)
 
 	go func() {
 		b.Logger().Info("%s WebSocket connecting...", b.domain)

--- a/internal/remote_control/bot/manager.go
+++ b/internal/remote_control/bot/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -416,19 +417,57 @@ func (m *Manager) Start(parentCtx context.Context, uuid string) error {
 	auditLog := m.audit
 	store := m.store
 	channels := m.channels
-	go func() {
-		defer close(doneChan) // Signal that goroutine is done
-		if err := runBotWithSettings(ctx, s, dataPath, m.sessionMgr, m.agentBoot, tbClient, pairing, auditLog, store, channels); err != nil {
-			logrus.WithError(err).WithField("uuid", uuid).Warn("Bot stopped with error")
-		}
-
-		// Bot stopped, remove from running map
-		m.removeRunning(uuid)
-		logrus.WithField("uuid", uuid).Info("Bot stopped")
-	}()
+	go m.runBotSupervised(ctx, uuid, s, dataPath, tbClient, pairing, auditLog, store, channels, doneChan)
 
 	logrus.WithField("uuid", uuid).WithField("name", name).WithField("platform", platform).Info("Bot started")
 	return nil
+}
+
+// runBotSupervised executes runBotWithSettings with panic recovery so a crash in
+// any third-party IM SDK is contained to this bot's goroutine instead of
+// propagating to the runtime and taking down the whole tingly-box process.
+// Always closes doneChan and removes the bot from the running map, regardless
+// of whether the bot exited normally, with error, or via panic.
+func (m *Manager) runBotSupervised(
+	ctx context.Context,
+	uuid string,
+	s BotSetting,
+	dataPath string,
+	tbClient tbclient.TBClient,
+	pairing *PairingManager,
+	auditLog *audit.Logger,
+	store SettingsStore,
+	channels *channel.Registry,
+	doneChan chan struct{},
+) {
+	defer close(doneChan)
+	defer m.removeRunning(uuid)
+
+	defer func() {
+		if r := recover(); r != nil {
+			stack := string(debug.Stack())
+			logrus.WithFields(logrus.Fields{
+				"uuid":     uuid,
+				"name":     s.Name,
+				"platform": s.Platform,
+				"panic":    fmt.Sprintf("%v", r),
+				"stack":    stack,
+			}).Error("Bot goroutine panicked; isolated from main process")
+			if auditLog != nil {
+				auditLog.Error("bot_panic", "", "", fmt.Sprintf("bot %s (%s) panicked: %v", uuid, s.Platform, r), false, map[string]interface{}{
+					"uuid":     uuid,
+					"name":     s.Name,
+					"platform": s.Platform,
+					"stack":    stack,
+				})
+			}
+		}
+	}()
+
+	if err := runBotWithSettings(ctx, s, dataPath, m.sessionMgr, m.agentBoot, tbClient, pairing, auditLog, store, channels); err != nil {
+		logrus.WithError(err).WithField("uuid", uuid).Warn("Bot stopped with error")
+	}
+	logrus.WithField("uuid", uuid).Info("Bot stopped")
 }
 
 // Stop stops a bot by UUID
@@ -472,7 +511,10 @@ func (m *Manager) WaitForStop(uuid string, timeout time.Duration) bool {
 	case <-doneChan:
 		return true
 	case <-time.After(timeout):
-		logrus.WithField("uuid", uuid).Warn("Timeout waiting for bot to stop")
+		logrus.WithFields(logrus.Fields{
+			"uuid":    uuid,
+			"timeout": timeout.String(),
+		}).Warn("Timeout waiting for bot to stop; goroutine may still be running and could leak resources or duplicate connections on restart")
 		return false
 	}
 }

--- a/internal/remote_control/bot/manager_lifecycle_test.go
+++ b/internal/remote_control/bot/manager_lifecycle_test.go
@@ -1,0 +1,194 @@
+package bot_test
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+	"github.com/tingly-dev/tingly-box/imbot/platform/tingly"
+	"github.com/tingly-dev/tingly-box/internal/data/db"
+	"github.com/tingly-dev/tingly-box/internal/remote_control/bot"
+	"github.com/tingly-dev/tingly-box/remote/session"
+)
+
+// fakeSettingsStore is the minimum SettingsStore implementation needed to
+// drive bot.Manager.Start in a test. Only the methods bot.Manager actually
+// touches are implemented.
+type fakeSettingsStore struct {
+	mu       sync.Mutex
+	settings map[string]db.Settings
+}
+
+func (s *fakeSettingsStore) GetSettingsByUUIDInterface(uuid string) (interface{}, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.settings[uuid]
+	if !ok {
+		return nil, fmt.Errorf("settings not found: %s", uuid)
+	}
+	return rec, nil
+}
+
+func (s *fakeSettingsStore) ListEnabledSettingsInterface() (interface{}, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]db.Settings, 0, len(s.settings))
+	for _, rec := range s.settings {
+		if rec.Enabled {
+			out = append(out, rec)
+		}
+	}
+	return out, nil
+}
+
+// newLifecycleManager spins up a bot.Manager with a fakeSettingsStore
+// containing a single enabled tingly bot, and registers an InProcessTransport
+// for that UUID so the bot can actually serve traffic. Returns the manager,
+// the bot UUID, and the transport for inspection.
+func newLifecycleManager(t *testing.T) (*bot.Manager, string, *tingly.InProcessTransport) {
+	t.Helper()
+
+	uuid := fmt.Sprintf("lifecycle-bot-%d", time.Now().UnixNano())
+
+	tr := tingly.NewInProcessTransport()
+	tingly.Register(uuid, tr)
+	t.Cleanup(func() { tingly.Unregister(uuid) })
+
+	store := &fakeSettingsStore{
+		settings: map[string]db.Settings{
+			uuid: {
+				UUID:     uuid,
+				Name:     "lifecycle-test",
+				Platform: "tingly",
+				AuthType: "none",
+				Auth:     map[string]string{},
+				Enabled:  true,
+			},
+		},
+	}
+
+	sessionMgr := session.NewManager(session.Config{
+		Timeout:          10 * time.Minute,
+		MessageRetention: time.Hour,
+	}, nil)
+
+	ab, err := agentboot.New(agentboot.Config{ClaudeProjectsDir: t.TempDir()})
+	require.NoError(t, err)
+
+	m := bot.NewManager(store, sessionMgr, ab)
+	m.SetDataPath(t.TempDir() + "/chats.json")
+
+	return m, uuid, tr
+}
+
+// TestManager_RestartBot_Tingly exercises the full stop/start cycle that the
+// new POST /api/v1/imbot-admin/restart/:uuid endpoint relies on. It asserts
+// that ctx cancellation reliably stops the bot within WaitForStop's timeout
+// and that no goroutines leak across multiple cycles.
+func TestManager_RestartBot_Tingly(t *testing.T) {
+	m, uuid, _ := newLifecycleManager(t)
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, m.Start(parentCtx, uuid))
+	require.True(t, m.IsRunning(uuid))
+
+	// Let the imbot.Manager's Connect path complete so all transient
+	// startup goroutines have settled before we sample the baseline.
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < 3; i++ {
+		m.Stop(uuid)
+		require.True(t,
+			m.WaitForStop(uuid, 5*time.Second),
+			"iter %d: WaitForStop timed out — goroutine likely leaked", i)
+		require.False(t, m.IsRunning(uuid))
+
+		require.NoError(t, m.Start(parentCtx, uuid))
+		time.Sleep(50 * time.Millisecond)
+		require.True(t, m.IsRunning(uuid))
+	}
+
+	m.Stop(uuid)
+	require.True(t, m.WaitForStop(uuid, 5*time.Second))
+
+	// Allow shutdown machinery to settle before sampling.
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	final := runtime.NumGoroutine()
+
+	// A small slack accounts for non-bot goroutines (logrus rotation,
+	// pprof, etc.). The point is to catch a per-iteration leak — 3
+	// restarts would inflate the count well beyond +4 if any goroutine
+	// per cycle escaped ctx cancel.
+	require.LessOrEqualf(t, final, baseline+4,
+		"goroutine leak: baseline=%d final=%d (after 3 restarts)", baseline, final)
+}
+
+// TestManager_StopOneBotDoesNotAffectOthers asserts the core "independent
+// restart" guarantee: stopping bot A must leave bot B running. This is the
+// in-process equivalent of the subprocess isolation we deferred.
+func TestManager_StopOneBotDoesNotAffectOthers(t *testing.T) {
+	uuidA := fmt.Sprintf("indep-bot-A-%d", time.Now().UnixNano())
+	uuidB := fmt.Sprintf("indep-bot-B-%d", time.Now().UnixNano())
+
+	trA := tingly.NewInProcessTransport()
+	trB := tingly.NewInProcessTransport()
+	tingly.Register(uuidA, trA)
+	tingly.Register(uuidB, trB)
+	t.Cleanup(func() {
+		tingly.Unregister(uuidA)
+		tingly.Unregister(uuidB)
+	})
+
+	store := &fakeSettingsStore{
+		settings: map[string]db.Settings{
+			uuidA: {UUID: uuidA, Name: "A", Platform: "tingly", AuthType: "none", Auth: map[string]string{}, Enabled: true},
+			uuidB: {UUID: uuidB, Name: "B", Platform: "tingly", AuthType: "none", Auth: map[string]string{}, Enabled: true},
+		},
+	}
+
+	sessionMgr := session.NewManager(session.Config{
+		Timeout:          10 * time.Minute,
+		MessageRetention: time.Hour,
+	}, nil)
+	ab, err := agentboot.New(agentboot.Config{ClaudeProjectsDir: t.TempDir()})
+	require.NoError(t, err)
+
+	m := bot.NewManager(store, sessionMgr, ab)
+	m.SetDataPath(t.TempDir() + "/chats.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, m.Start(ctx, uuidA))
+	require.NoError(t, m.Start(ctx, uuidB))
+	require.True(t, m.IsRunning(uuidA))
+	require.True(t, m.IsRunning(uuidB))
+
+	// Stop A; B must remain running.
+	m.Stop(uuidA)
+	require.True(t, m.WaitForStop(uuidA, 5*time.Second))
+	require.False(t, m.IsRunning(uuidA))
+	require.True(t, m.IsRunning(uuidB), "stopping bot A must not affect bot B")
+
+	// Restart A while B is still running; B must still be untouched.
+	require.NoError(t, m.Start(ctx, uuidA))
+	time.Sleep(50 * time.Millisecond)
+	require.True(t, m.IsRunning(uuidA))
+	require.True(t, m.IsRunning(uuidB))
+
+	m.Stop(uuidA)
+	m.Stop(uuidB)
+	require.True(t, m.WaitForStop(uuidA, 5*time.Second))
+	require.True(t, m.WaitForStop(uuidB, 5*time.Second))
+}

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -12,7 +12,21 @@ import (
 	"github.com/tingly-dev/tingly-box/imbot"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/remote/channel"
 )
+
+// LifecycleController is the narrow surface the server uses to drive the
+// imbot module's lifecycle. Replacing the previous untyped interface{} +
+// inline type assertions makes the contract explicit and is the single
+// seam at which an out-of-process implementation could later be swapped in.
+type LifecycleController interface {
+	StartAllEnabled(ctx context.Context) error
+	StopAll()
+	RestartBotByUUID(ctx context.Context, uuid string) error
+	Sync(ctx context.Context) error
+	Shutdown()
+	SetChannelRegistry(reg *channel.Registry)
+}
 
 // Handler handles ImBot settings HTTP requests
 type Handler struct {
@@ -519,9 +533,14 @@ func normalizeAllowlist(values []string) []string {
 	return out
 }
 
-// BotManager returns the bot manager for server integration
-func (h *Handler) BotManager() *BotManager {
-	return h.botMgr
+// SetChannelRegistry wires the remote channel registry through to the
+// underlying bot manager. Used by the server during route registration so
+// each running bot exposes itself as a remote.channel.Channel.
+func (h *Handler) SetChannelRegistry(reg *channel.Registry) {
+	if h.botMgr == nil {
+		return
+	}
+	h.botMgr.SetChannelRegistry(reg)
 }
 
 // StartAllEnabled starts all enabled bots (delegates to BotManager)
@@ -530,6 +549,58 @@ func (h *Handler) StartAllEnabled(ctx context.Context) error {
 		return fmt.Errorf("bot manager is nil")
 	}
 	return h.botMgr.StartAllEnabled(ctx)
+}
+
+// RestartBotByUUID stops then starts a single bot. Used by both the admin
+// HTTP endpoint and the LifecycleController interface.
+func (h *Handler) RestartBotByUUID(ctx context.Context, uuid string) error {
+	if h.botMgr == nil {
+		return fmt.Errorf("bot manager is nil")
+	}
+	return h.botMgr.RestartBot(ctx, uuid)
+}
+
+// RestartBot is the HTTP handler for POST /imbot-admin/restart/:uuid.
+// Restarts a single bot without affecting the rest of the server.
+func (h *Handler) RestartBot(c *gin.Context) {
+	if h.botMgr == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Bot manager not available"})
+		return
+	}
+
+	uuid := c.Param("uuid")
+	if uuid == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "UUID is required"})
+		return
+	}
+
+	if err := h.botMgr.RestartBot(c.Request.Context(), uuid); err != nil {
+		logrus.WithError(err).WithField("uuid", uuid).Warn("Failed to restart bot")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	logrus.WithField("uuid", uuid).Info("Bot restarted via admin API")
+	c.JSON(http.StatusOK, gin.H{"success": true, "uuid": uuid, "running": h.botMgr.IsRunning(uuid)})
+}
+
+// Reload is the HTTP handler for POST /imbot-admin/reload. Re-reads bot
+// settings and starts/stops bots to match the current enabled flags. Does
+// not restart bots whose enabled state has not changed.
+func (h *Handler) Reload(c *gin.Context) {
+	if h.botMgr == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Bot manager not available"})
+		return
+	}
+
+	if err := h.botMgr.Sync(c.Request.Context()); err != nil {
+		logrus.WithError(err).Warn("Failed to reload bots")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	logrus.Info("Bot configuration reloaded via admin API")
+	c.JSON(http.StatusOK, gin.H{"success": true})
 }
 
 // StopAll stops all running bots (delegates to BotManager)

--- a/internal/server/module/imbot/manager.go
+++ b/internal/server/module/imbot/manager.go
@@ -207,6 +207,32 @@ func (bm *BotManager) StopBot(uuid string) error {
 	return nil
 }
 
+// RestartBot stops a single bot and starts it again, preserving its UUID.
+// Useful for recovering from a panic-isolated bot or applying configuration
+// changes without restarting the whole server. Waits for the stop to fully
+// complete (up to 5s via WaitForStop in StopBot) before starting again so
+// the new instance does not race with the old goroutine.
+func (bm *BotManager) RestartBot(ctx context.Context, uuid string) error {
+	if bm == nil {
+		return fmt.Errorf("bot manager is nil")
+	}
+	if uuid == "" {
+		return fmt.Errorf("uuid is empty")
+	}
+
+	// StopBot is a no-op if the bot is not running, so this also covers
+	// "restart a crashed bot" without a special branch.
+	if bm.IsRunning(uuid) {
+		if err := bm.StopBot(uuid); err != nil {
+			return fmt.Errorf("stop before restart: %w", err)
+		}
+	}
+	if err := bm.StartBot(ctx, uuid); err != nil {
+		return fmt.Errorf("start after stop: %w", err)
+	}
+	return nil
+}
+
 // StartAllEnabled starts all bots that have enabled: true in their settings.
 // Logs errors for individual bots but continues starting others.
 func (bm *BotManager) StartAllEnabled(ctx context.Context) error {

--- a/internal/server/module/imbot/routes.go
+++ b/internal/server/module/imbot/routes.go
@@ -96,6 +96,26 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		),
 	)
 
+	// POST /imbot-admin/restart/:uuid - Restart a single bot in place
+	router.POST("/imbot-admin/restart/:uuid", handler.RestartBot,
+		swagger.WithTags("imbot-admin"),
+		swagger.WithDescription("Stops and restarts a single bot without affecting other bots or the HTTP server"),
+		swagger.WithPathParam("uuid", "string", "ImBot configuration UUID"),
+		swagger.WithErrorResponses(
+			swagger.ErrorResponseConfig{Code: 400, Message: "UUID is required"},
+			swagger.ErrorResponseConfig{Code: 503, Message: "Bot manager not available"},
+		),
+	)
+
+	// POST /imbot-admin/reload - Reload bot configurations and reconcile enabled state
+	router.POST("/imbot-admin/reload", handler.Reload,
+		swagger.WithTags("imbot-admin"),
+		swagger.WithDescription("Re-reads bot settings and starts/stops bots to match enabled flags"),
+		swagger.WithErrorResponses(
+			swagger.ErrorResponseConfig{Code: 503, Message: "Bot manager not available"},
+		),
+	)
+
 	// GET /imbot-platforms - Get all supported platforms
 	router.GET("/imbot-platforms", handler.GetPlatforms,
 		swagger.WithTags("imbot-settings"),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/server/hooks"
 	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/internal/server/module/codeximport"
+	imbotmodule "github.com/tingly-dev/tingly-box/internal/server/module/imbot"
 	oauthmodule "github.com/tingly-dev/tingly-box/internal/server/module/oauth"
 	providerQuotaModule "github.com/tingly-dev/tingly-box/internal/server/module/provider_quota"
 	"github.com/tingly-dev/tingly-box/internal/server/routing"
@@ -79,8 +80,10 @@ type Server struct {
 	// OAuth handler (module)
 	oauthHandler *oauthmodule.Handler
 
-	// ImBot settings handler (module)
-	imbotSettingsHandler interface{}
+	// ImBot lifecycle controller (module). Concrete impl is *imbot.Handler;
+	// using the interface keeps the seam narrow and replaces the previous
+	// untyped interface{} that required inline type assertions everywhere.
+	imbotSettingsHandler imbotmodule.LifecycleController
 
 	// remote middle-layer state. The channel registry holds running
 	// imbot Channel adapters; the interaction registry stores pending
@@ -1468,14 +1471,6 @@ func (s *Server) StartRemoteCoder() error {
 		return fmt.Errorf("imbotsettings handler not available")
 	}
 
-	// Use type assertion to access BotManager methods
-	handler, ok := s.imbotSettingsHandler.(interface {
-		StartAllEnabled(context.Context) error
-	})
-	if !ok {
-		return fmt.Errorf("imbotsettings handler does not support StartAllEnabled")
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	s.remoteCoderCtx = ctx
 	s.remoteCoderCancel = cancel
@@ -1484,7 +1479,7 @@ func (s *Server) StartRemoteCoder() error {
 
 	// Start all enabled bots through the imbotsettings handler
 	go func() {
-		if err := handler.StartAllEnabled(ctx); err != nil && ctx.Err() == nil {
+		if err := s.imbotSettingsHandler.StartAllEnabled(ctx); err != nil && ctx.Err() == nil {
 			logrus.WithError(err).Warn("Failed to start some enabled bots")
 		}
 		// Keep context alive until canceled
@@ -1512,10 +1507,8 @@ func (s *Server) StopRemoteCoder() {
 
 	// Stop all bots through the imbotsettings handler
 	if s.imbotSettingsHandler != nil {
-		if handler, ok := s.imbotSettingsHandler.(interface{ StopAll() }); ok {
-			handler.StopAll()
-			logrus.Info("All bots stopped via imbotsettings handler")
-		}
+		s.imbotSettingsHandler.StopAll()
+		logrus.Info("All bots stopped via imbotsettings handler")
 	}
 
 	logrus.Info("Remote-coder stopped")
@@ -1530,15 +1523,10 @@ func (s *Server) IsRemoteCoderRunning() bool {
 
 // SyncRemoteCoderBots syncs bots with the remote control bot manager
 func (s *Server) SyncRemoteCoderBots(ctx context.Context) error {
-	// Use the imbotsettings handler's bot manager if available
-	if s.imbotSettingsHandler != nil {
-		if handler, ok := s.imbotSettingsHandler.(interface {
-			Sync(context.Context) error
-		}); ok {
-			return handler.Sync(ctx)
-		}
+	if s.imbotSettingsHandler == nil {
+		return fmt.Errorf("bot manager not available")
 	}
-	return fmt.Errorf("bot manager not available")
+	return s.imbotSettingsHandler.Sync(ctx)
 }
 
 // Stop gracefully stops the HTTP server
@@ -1558,10 +1546,8 @@ func (s *Server) Stop(ctx context.Context) error {
 
 	// Shutdown ImBot settings handler
 	if s.imbotSettingsHandler != nil {
-		if handler, ok := s.imbotSettingsHandler.(interface{ Shutdown() }); ok {
-			handler.Shutdown()
-			log.Println("ImBot settings handler stopped")
-		}
+		s.imbotSettingsHandler.Shutdown()
+		log.Println("ImBot settings handler stopped")
 	}
 
 	// Stop token refresher

--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -143,9 +143,7 @@ func (s *Server) UseUIEndpoints(ctx context.Context) {
 		// as a remote.channel.Channel reachable from /tingly/:scenario
 		// scenario plugins.
 		if s.channelRegistry != nil {
-			if bm := imbotHandler.BotManager(); bm != nil {
-				bm.SetChannelRegistry(s.channelRegistry)
-			}
+			imbotHandler.SetChannelRegistry(s.channelRegistry)
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR adds the ability to restart individual bots without affecting the entire server or other running bots. It includes a new HTTP endpoint, improved bot lifecycle management with panic recovery, and frontend UI support for restarting bots.

## Key Changes

### Backend
- **New REST endpoint**: `POST /api/v1/imbot-admin/restart/:uuid` to restart a single bot in place
- **New REST endpoint**: `POST /api/v1/imbot-admin/reload` to re-read bot settings and reconcile enabled state
- **Panic isolation**: Added `runBotSupervised()` wrapper that catches panics in bot goroutines, logs them with full stack traces, and prevents them from crashing the main process
- **Improved lifecycle interface**: Introduced `LifecycleController` interface to replace untyped `interface{}` assertions throughout the server, making the contract explicit and testable
- **New `RestartBot()` method**: Cleanly stops then starts a bot, with proper error handling and sequencing
- **Enhanced logging**: Better error messages for timeout scenarios that could indicate goroutine leaks
- **Feishu SDK fix**: Changed WebSocket context derivation to use parent lifecycle context instead of background context, ensuring proper cleanup on bot shutdown

### Frontend
- **Restart button**: Added restart icon button to bot cards in both `BotPage` and `PlatformBotPage`
- **Loading state**: Added `isRestarting` state to track restart operations and disable UI during restart
- **API integration**: New `restartImBot()` API method to call the restart endpoint
- **Grid component**: Updated `BotCardGrid` to support restart callbacks

### Testing
- **Comprehensive lifecycle tests**: Added `manager_lifecycle_test.go` with two test suites:
  - `TestManager_RestartBot_Tingly`: Exercises full stop/start cycles, verifies context cancellation works reliably, and detects goroutine leaks across multiple restart iterations
  - `TestManager_StopOneBotDoesNotAffectOthers`: Verifies that stopping one bot leaves others running (independent restart guarantee)
- **Test infrastructure**: Created `fakeSettingsStore` and `newLifecycleManager()` helper for driving bot lifecycle in tests

## Notable Implementation Details
- Panic recovery uses `runtime/debug.Stack()` to capture full stack traces for debugging
- Restart operation waits for the stop to fully complete (via `WaitForStop` with 5s timeout) before starting to prevent race conditions
- The `LifecycleController` interface replaces scattered type assertions, improving maintainability and enabling future out-of-process implementations
- Feishu WebSocket context now properly inherits cancellation from the bot's lifecycle, fixing a potential resource leak on shutdown

https://claude.ai/code/session_01G6SSbqCyZAkHeUAwCvtfWK