### PR TITLE
feat(agent, ui, api): add image generation playground and quick start guide

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "devicons-react": "^1.5.0",
     "i18next": "^25.10.10",
     "i18next-browser-languagedetector": "^8.2.1",
+    "openai": "^6.37.0",
     "openapi-fetch": "^0.17.0",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.2.1
         version: 8.2.1
+      openai:
+        specifier: ^6.37.0
+        version: 6.37.0(zod@4.3.6)
       openapi-fetch:
         specifier: ^0.17.0
         version: 0.17.0
@@ -2135,6 +2138,18 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
+
+  openai@6.37.0:
+    resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openapi-fetch@0.17.0:
     resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
@@ -4446,6 +4461,10 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openai@6.37.0(zod@4.3.6):
+    optionalDependencies:
+      zod: 4.3.6
 
   openapi-fetch@0.17.0:
     dependencies:

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.4'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import UseXcodePage from './pages/scenario/UseXcodePage';
 import UseVSCodePage from './pages/scenario/UseVSCodePage';
 import UseEmbedPage from './pages/scenario/UseEmbedPage';
 import UseImageGenPage from './pages/scenario/UseImageGenPage';
+import PlaygroundPage from './pages/scenario/PlaygroundPage';
 import CredentialPage from './pages/CredentialPage';
 import ProviderListPage from './pages/ProviderListPage';
 import System from './pages/System';
@@ -352,6 +353,7 @@ function AppContent() {
                     <Route path="/agent/vscode" element={<UseVSCodePage />} />
                     <Route path="/agent/embed" element={<UseEmbedPage />} />
                     <Route path="/agent/imagegen" element={<UseImageGenPage />} />
+                    <Route path="/agent/playground" element={<PlaygroundPage />} />
                     {/* Legacy redirects */}
                     <Route path="/use-openai" element={<Navigate to="/agent/openai" replace />} />
                     <Route path="/use-anthropic" element={<Navigate to="/agent/anthropic" replace />} />

--- a/frontend/src/components/ImageGenQuickStartCard.tsx
+++ b/frontend/src/components/ImageGenQuickStartCard.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Box, Tab, Tabs } from '@mui/material';
+import UnifiedCard from '@/components/UnifiedCard';
+import CodeBlock from '@/components/CodeBlock';
+
+interface ImageGenQuickStartCardProps {
+    baseUrl: string;
+    /** Default model name shown in snippets. */
+    model?: string;
+    onCopy?: (text: string, label: string) => void;
+}
+
+type Lang = 'python' | 'typescript' | 'curl';
+
+const TABS: { value: Lang; label: string; filename: string }[] = [
+    { value: 'python', label: 'Python', filename: 'imagegen.py' },
+    { value: 'typescript', label: 'TypeScript', filename: 'imagegen.ts' },
+    { value: 'curl', label: 'curl', filename: 'imagegen.sh' },
+];
+
+const buildSnippet = (lang: Lang, baseUrl: string, model: string): string => {
+    const endpoint = `${baseUrl}/tingly/imagegen/v1`;
+    const prompt = 'A cozy cabin in a snowy forest at dusk, cinematic lighting';
+    switch (lang) {
+        case 'python':
+            return `# pip install openai
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="${endpoint}",
+    api_key="<TINGLY_MODEL_TOKEN>",  # GET /api/v1/token
+)
+
+resp = client.images.generate(
+    model="${model}",
+    prompt="${prompt}",
+    size="1024x1024",
+    quality="auto",
+    n=1,
+)
+
+print(resp.data[0].url or resp.data[0].b64_json[:64])
+`;
+        case 'typescript':
+            return `// npm i openai
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "${endpoint}",
+  apiKey: "<TINGLY_MODEL_TOKEN>", // GET /api/v1/token
+});
+
+const resp = await client.images.generate({
+  model: "${model}",
+  prompt: "${prompt}",
+  size: "1024x1024",
+  quality: "auto",
+  n: 1,
+});
+
+console.log(resp.data[0].url ?? resp.data[0].b64_json?.slice(0, 64));
+`;
+        case 'curl':
+            return `curl ${endpoint}/images/generations \\
+  -H "Authorization: Bearer <TINGLY_MODEL_TOKEN>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${model}",
+    "prompt": "${prompt}",
+    "size": "1024x1024",
+    "quality": "auto",
+    "n": 1
+  }'
+`;
+    }
+};
+
+const ImageGenQuickStartCard: React.FC<ImageGenQuickStartCardProps> = ({
+    baseUrl,
+    model = 'gpt-image-1',
+    onCopy,
+}) => {
+    const [tab, setTab] = useState<Lang>('python');
+    const active = TABS.find((t) => t.value === tab)!;
+    const code = buildSnippet(tab, baseUrl, model);
+
+    return (
+        <UnifiedCard
+            size="full"
+            title="Quick Start"
+            subtitle="Call the image generation endpoint via the OpenAI SDK or curl. Token comes from GET /api/v1/token."
+        >
+            <Box>
+                <Tabs
+                    value={tab}
+                    onChange={(_, v) => setTab(v)}
+                    sx={{ minHeight: 32, mb: 1, '& .MuiTabs-indicator': { height: 3 } }}
+                >
+                    {TABS.map((t) => (
+                        <Tab
+                            key={t.value}
+                            value={t.value}
+                            label={t.label}
+                            sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }}
+                        />
+                    ))}
+                </Tabs>
+                <CodeBlock
+                    code={code}
+                    language={tab === 'curl' ? 'bash' : tab}
+                    filename={active.filename}
+                    onCopy={onCopy ? (c) => onCopy(c, active.filename) : undefined}
+                    maxHeight={360}
+                    wrap={false}
+                />
+            </Box>
+        </UnifiedCard>
+    );
+};
+
+export default ImageGenQuickStartCard;

--- a/frontend/src/components/ImageGenQuickStartCard.tsx
+++ b/frontend/src/components/ImageGenQuickStartCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Box, Tab, Tabs } from '@mui/material';
+import { Box, Collapse, IconButton, Tab, Tabs } from '@mui/material';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import UnifiedCard from '@/components/UnifiedCard';
 import CodeBlock from '@/components/CodeBlock';
 
@@ -81,6 +82,7 @@ const ImageGenQuickStartCard: React.FC<ImageGenQuickStartCardProps> = ({
     onCopy,
 }) => {
     const [tab, setTab] = useState<Lang>('python');
+    const [expanded, setExpanded] = useState(true);
     const active = TABS.find((t) => t.value === tab)!;
     const code = buildSnippet(tab, baseUrl, model);
 
@@ -89,31 +91,38 @@ const ImageGenQuickStartCard: React.FC<ImageGenQuickStartCardProps> = ({
             size="full"
             title="Quick Start"
             subtitle="Call the image generation endpoint via the OpenAI SDK or curl. Token comes from GET /api/v1/token."
+            rightAction={
+                <IconButton size="small" onClick={() => setExpanded((v) => !v)}>
+                    {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+                </IconButton>
+            }
         >
-            <Box>
-                <Tabs
-                    value={tab}
-                    onChange={(_, v) => setTab(v)}
-                    sx={{ minHeight: 32, mb: 1, '& .MuiTabs-indicator': { height: 3 } }}
-                >
-                    {TABS.map((t) => (
-                        <Tab
-                            key={t.value}
-                            value={t.value}
-                            label={t.label}
-                            sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }}
-                        />
-                    ))}
-                </Tabs>
-                <CodeBlock
-                    code={code}
-                    language={tab === 'curl' ? 'bash' : tab}
-                    filename={active.filename}
-                    onCopy={onCopy ? (c) => onCopy(c, active.filename) : undefined}
-                    maxHeight={360}
-                    wrap={false}
-                />
-            </Box>
+            <Collapse in={expanded} timeout="auto">
+                <Box>
+                    <Tabs
+                        value={tab}
+                        onChange={(_, v) => setTab(v)}
+                        sx={{ minHeight: 32, mb: 1, '& .MuiTabs-indicator': { height: 3 } }}
+                    >
+                        {TABS.map((t) => (
+                            <Tab
+                                key={t.value}
+                                value={t.value}
+                                label={t.label}
+                                sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }}
+                            />
+                        ))}
+                    </Tabs>
+                    <CodeBlock
+                        code={code}
+                        language={tab === 'curl' ? 'bash' : tab}
+                        filename={active.filename}
+                        onCopy={onCopy ? (c) => onCopy(c, active.filename) : undefined}
+                        maxHeight={200}
+                        wrap={false}
+                    />
+                </Box>
+            </Collapse>
         </UnifiedCard>
     );
 };

--- a/frontend/src/components/UnifiedCard.tsx
+++ b/frontend/src/components/UnifiedCard.tsx
@@ -152,7 +152,7 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
         }}
       >
         {title && (
-          <Box sx={{ mb: 1, flexShrink: 0 }}>
+          <Box sx={{ mb: 2, flexShrink: 0 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: subtitle ? 1 : 0 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
                 <Typography variant="h4" sx={{ fontWeight: 600, color: 'text.primary' }}>
@@ -193,12 +193,11 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
             </Alert>
           </Box>
         )}
-        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
           <Box
             sx={{
               flex: 1,
               minHeight: 0,
-              overflow: 'hidden',
               position: 'relative',
             }}
           >

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -45,6 +45,7 @@ export default {
       "useVSCode": "VS Code",
       "useEmbed": "Embed",
       "useImageGen": "Image Gen",
+      "playground": "Playground",
       "apiKeys": "API Keys",
       "oauth": "OAuth",
       "credential": "Credential",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -43,7 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
-      "useEmbed": "Embeddings",
+      "useEmbed": "Embedding",
       "useImageGen": "Image Gen",
       "playground": "Playground",
       "apiKeys": "API Keys",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -43,7 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
-      "useEmbed": "Embed",
+      "useEmbed": "Embeddings",
       "useImageGen": "Image Gen",
       "playground": "Playground",
       "apiKeys": "API Keys",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -43,7 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
-      "useEmbed": "Embed 嵌入",
+      "useEmbed": "向量嵌入",
       "useImageGen": "图像生成",
       "playground": "Playground",
       "apiKeys": "API 密钥",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -43,7 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
-      "useEmbed": "Embeddings",
+      "useEmbed": "Embedding",
       "useImageGen": "图像生成",
       "playground": "Playground",
       "apiKeys": "API 密钥",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -43,7 +43,7 @@ export default {
       "useOpenCode": "OpenCode",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
-      "useEmbed": "向量嵌入",
+      "useEmbed": "Embeddings",
       "useImageGen": "图像生成",
       "playground": "Playground",
       "apiKeys": "API 密钥",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -45,6 +45,7 @@ export default {
       "useVSCode": "VS Code",
       "useEmbed": "Embed 嵌入",
       "useImageGen": "图像生成",
+      "playground": "Playground",
       "apiKeys": "API 密钥",
       "oauth": "OAuth 凭证",
       "credential": "凭证",

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -123,10 +123,10 @@ export function useActivityItems(): ActivityItem[] {
             if (scenarioChildren.length > 0) scenarioChildren.push({ type: 'divider' });
             scenarioChildren.push(...group);
         };
-        pushGroup(playgroundTool);
         pushGroup(codingTools);
         pushGroup(sdkTools);
         pushGroup(agentTools);
+        pushGroup(playgroundTool);
 
         const items: ActivityItem[] = [
             {

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -98,7 +98,7 @@ export function useActivityItems(): ActivityItem[] {
         const sdkTools = visible([
             { id: 'openai', nav: { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> } },
             { id: 'anthropic', nav: { path: '/agent/anthropic', label: t('layout.nav.useAnthropic', { defaultValue: 'Anthropic' }), icon: <Anthropic size={20} /> } },
-            { id: 'embed', nav: { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embed' }), icon: <IconVector size={20} /> } },
+            { id: 'embed', nav: { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embeddings' }), icon: <IconVector size={20} /> } },
             { id: 'imagegen', nav: { path: '/agent/imagegen', label: t('layout.nav.useImageGen', { defaultValue: 'Image Gen' }), icon: <IconPhoto size={20} /> } },
         ]);
         const agentTools = visible([

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -22,6 +22,7 @@ import {
     IconVector,
     IconPhoto,
     IconFlask,
+    IconPlayerPlay,
 } from '@tabler/icons-react';
 import { OpenAI, Anthropic, Claude, OpenCode, Xcode, VSCode, Telegram, Feishu, Lark, DingTalk, Weixin, WeCom, Codex, OpenClaw } from '../components/BrandIcons';
 import { SettingsApplications } from '@mui/icons-material';
@@ -85,6 +86,9 @@ export function useActivityItems(): ActivityItem[] {
         const visible = (group: HideableScenario[]): NavItem[] =>
             group.filter(s => !hiddenScenarios.has(s.id)).map(s => s.nav);
 
+        const playgroundTool: NavItem[] = [
+            { path: '/agent/playground', label: t('layout.nav.playground', { defaultValue: 'Playground' }), icon: <IconPlayerPlay size={20} /> },
+        ];
         const codingTools = visible([
             { id: 'codex', nav: { path: '/agent/codex', label: t('layout.nav.useCodex', { defaultValue: 'Codex' }), icon: <Codex size={20} /> } },
             { id: 'opencode', nav: { path: '/agent/opencode', label: t('layout.nav.useOpenCode', { defaultValue: 'OpenCode' }), icon: <OpenCode size={20} /> } },
@@ -119,6 +123,7 @@ export function useActivityItems(): ActivityItem[] {
             if (scenarioChildren.length > 0) scenarioChildren.push({ type: 'divider' });
             scenarioChildren.push(...group);
         };
+        pushGroup(playgroundTool);
         pushGroup(codingTools);
         pushGroup(sdkTools);
         pushGroup(agentTools);

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -98,7 +98,7 @@ export function useActivityItems(): ActivityItem[] {
         const sdkTools = visible([
             { id: 'openai', nav: { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> } },
             { id: 'anthropic', nav: { path: '/agent/anthropic', label: t('layout.nav.useAnthropic', { defaultValue: 'Anthropic' }), icon: <Anthropic size={20} /> } },
-            { id: 'embed', nav: { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embeddings' }), icon: <IconVector size={20} /> } },
+            { id: 'embed', nav: { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embedding' }), icon: <IconVector size={20} /> } },
             { id: 'imagegen', nav: { path: '/agent/imagegen', label: t('layout.nav.useImageGen', { defaultValue: 'Image Gen' }), icon: <IconPhoto size={20} /> } },
         ]);
         const agentTools = visible([

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -550,4 +550,66 @@ export const handlers = [
             }
         })
     }),
+
+    // --- Playground (imagegen) mocks ---
+
+    http.get('/api/v1/token', () => {
+        return HttpResponse.json({ token: 'mock-model-token', type: 'Bearer' })
+    }),
+
+    http.get('/api/v1/rules', ({ request }) => {
+        const url = new URL(request.url)
+        const scenario = url.searchParams.get('scenario')
+        if (scenario === 'imagegen') {
+            return HttpResponse.json({
+                success: true,
+                data: [
+                    {
+                        uuid: 'mock-imagegen-1',
+                        request_model: 'gpt-image-1',
+                        scenario: 'imagegen',
+                        disabled: false,
+                        services: [{ provider: 'mock', model: 'gpt-image-1' }],
+                    },
+                    {
+                        uuid: 'mock-imagegen-2',
+                        request_model: 'dall-e-3',
+                        scenario: 'imagegen',
+                        disabled: false,
+                        services: [{ provider: 'mock', model: 'dall-e-3' }],
+                    },
+                ],
+            })
+        }
+        return HttpResponse.json({ success: true, data: [] })
+    }),
+
+    http.post('*/tingly/imagegen/v1/images/generations', async ({ request }) => {
+        const body = (await request.json()) as any
+        const n = Math.max(1, Math.min(10, Number(body?.n) || 1))
+        const size = typeof body?.size === 'string' ? body.size : '1024x1024'
+        const [w, h] = size.split('x').map(Number)
+        const palette = ['#7c3aed', '#06b6d4', '#10b981', '#f59e0b', '#ef4444', '#3b82f6']
+        const promptText = String(body?.prompt ?? '').slice(0, 80).replace(/[<>&"]/g, '')
+
+        const makeSvgDataUrl = (idx: number): string => {
+            const bg = palette[idx % palette.length]
+            const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">`
+                + `<rect width="100%" height="100%" fill="${bg}"/>`
+                + `<text x="50%" y="45%" font-family="sans-serif" font-size="${Math.round(w / 18)}" fill="white" text-anchor="middle" font-weight="700">MOCK #${idx + 1}</text>`
+                + `<text x="50%" y="56%" font-family="sans-serif" font-size="${Math.round(w / 36)}" fill="white" fill-opacity="0.85" text-anchor="middle">${promptText}</text>`
+                + `<text x="50%" y="95%" font-family="monospace" font-size="${Math.round(w / 50)}" fill="white" fill-opacity="0.7" text-anchor="middle">${body?.model ?? ''} · ${size} · q=${body?.quality ?? 'auto'}</text>`
+                + `</svg>`
+            const b64 = btoa(unescape(encodeURIComponent(svg)))
+            return `data:image/svg+xml;base64,${b64}`
+        }
+
+        // Simulate a small latency so the loading state is visible
+        await new Promise((r) => setTimeout(r, 600))
+
+        return HttpResponse.json({
+            created: Math.floor(Date.now() / 1000),
+            data: Array.from({ length: n }, (_, i) => ({ url: makeSvgDataUrl(i) })),
+        })
+    }),
 ]

--- a/frontend/src/pages/scenario/AgentOverviewPage.tsx
+++ b/frontend/src/pages/scenario/AgentOverviewPage.tsx
@@ -125,11 +125,15 @@ export const SCENARIOS: ScenarioDescriptor[] = [
 
 const STORAGE_KEY = 'scenario.hiddenScenarios';
 const VISIBILITY_EVENT = 'scenario-visibility-change';
+const DEFAULT_HIDDEN = ['agent'];
 
 const readHidden = (): string[] => {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
-        if (!raw) return [];
+        if (raw === null) {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(DEFAULT_HIDDEN));
+            return DEFAULT_HIDDEN;
+        }
         const parsed = JSON.parse(raw);
         return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
     } catch {

--- a/frontend/src/pages/scenario/PlaygroundPage.tsx
+++ b/frontend/src/pages/scenario/PlaygroundPage.tsx
@@ -11,8 +11,6 @@ import {
     MenuItem,
     Select,
     Stack,
-    Tab,
-    Tabs,
     TextField,
     Typography,
 } from '@mui/material';
@@ -22,14 +20,6 @@ import PageLayout from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import CardGrid from '@/components/CardGrid';
 
-type Mode = 'chat' | 'image';
-
-interface ChatMessage {
-    role: 'user' | 'assistant';
-    content: string;
-}
-
-const CHAT_SCENARIOS = ['openai', 'anthropic', 'agent'] as const;
 const IMAGE_SCENARIO = 'imagegen';
 
 const extractModelsFromRules = (rules: any[] | undefined | null): string[] => {
@@ -47,386 +37,192 @@ const extractModelsFromRules = (rules: any[] | undefined | null): string[] => {
 
 const PlaygroundPage: React.FC = () => {
     const { t } = useTranslation();
-    const [mode, setMode] = useState<Mode>('image');
 
-    // Chat state
-    const [chatScenario, setChatScenario] = useState<string>('openai');
-    const [chatModels, setChatModels] = useState<string[]>([]);
-    const [chatModel, setChatModel] = useState<string>('');
-    const [chatInput, setChatInput] = useState<string>('');
-    const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
-    const [chatSending, setChatSending] = useState(false);
-
-    // Image state
-    const [imageModels, setImageModels] = useState<string[]>([]);
-    const [imageModel, setImageModel] = useState<string>('');
-    const [imagePrompt, setImagePrompt] = useState<string>('');
-    const [imageSize, setImageSize] = useState<string>('1024x1024');
-    const [imageCount, setImageCount] = useState<number>(1);
-    const [imageResults, setImageResults] = useState<{ url?: string; b64_json?: string }[]>([]);
-    const [imageSending, setImageSending] = useState(false);
-
+    const [models, setModels] = useState<string[]>([]);
+    const [model, setModel] = useState<string>('');
+    const [prompt, setPrompt] = useState<string>('');
+    const [size, setSize] = useState<string>('1024x1024');
+    const [count, setCount] = useState<number>(1);
+    const [results, setResults] = useState<{ url?: string; b64_json?: string }[]>([]);
+    const [sending, setSending] = useState(false);
     const [error, setError] = useState<string>('');
     const [loadingModels, setLoadingModels] = useState(false);
 
-    const loadModels = useCallback(async (scenario: string): Promise<string[]> => {
-        const result = await api.getRules(scenario);
-        if (!result || result.success === false) {
-            return [];
-        }
-        const rules = Array.isArray(result.data) ? result.data : (Array.isArray(result) ? result : []);
-        return extractModelsFromRules(rules);
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            setLoadingModels(true);
+            const resp = await api.getRules(IMAGE_SCENARIO);
+            const rules = Array.isArray(resp?.data) ? resp.data : (Array.isArray(resp) ? resp : []);
+            const list = extractModelsFromRules(rules);
+            if (!cancelled) {
+                setModels(list);
+                setModel((current) => current || list[0] || '');
+                setLoadingModels(false);
+            }
+        })();
+        return () => { cancelled = true; };
     }, []);
 
-    // Load image models once
-    useEffect(() => {
-        let cancelled = false;
-        (async () => {
-            setLoadingModels(true);
-            const models = await loadModels(IMAGE_SCENARIO);
-            if (!cancelled) {
-                setImageModels(models);
-                setImageModel((current) => current || models[0] || '');
-                setLoadingModels(false);
-            }
-        })();
-        return () => { cancelled = true; };
-    }, [loadModels]);
-
-    // Load chat models when scenario changes
-    useEffect(() => {
-        let cancelled = false;
-        (async () => {
-            setLoadingModels(true);
-            const models = await loadModels(chatScenario);
-            if (!cancelled) {
-                setChatModels(models);
-                setChatModel((current) => (models.includes(current) ? current : models[0] || ''));
-                setLoadingModels(false);
-            }
-        })();
-        return () => { cancelled = true; };
-    }, [chatScenario, loadModels]);
-
-    const handleSendChat = useCallback(async () => {
-        if (!chatInput.trim() || !chatModel) return;
-        const userMsg: ChatMessage = { role: 'user', content: chatInput.trim() };
-        const next = [...chatHistory, userMsg];
-        setChatHistory(next);
-        setChatInput('');
-        setChatSending(true);
+    const handleGenerate = useCallback(async () => {
+        if (!prompt.trim() || !model) return;
+        setSending(true);
         setError('');
-        try {
-            const resp = await api.playgroundChatCompletions(chatScenario, {
-                model: chatModel,
-                messages: next.map((m) => ({ role: m.role, content: m.content })),
-            });
-            if (resp?.error) {
-                setError(resp.error.message || JSON.stringify(resp.error));
-            } else {
-                const reply: string = resp?.choices?.[0]?.message?.content ?? '';
-                setChatHistory((prev) => [...prev, { role: 'assistant', content: reply }]);
-            }
-        } catch (err: any) {
-            setError(err?.message || 'Request failed');
-        } finally {
-            setChatSending(false);
-        }
-    }, [chatInput, chatModel, chatScenario, chatHistory]);
-
-    const handleGenerateImage = useCallback(async () => {
-        if (!imagePrompt.trim() || !imageModel) return;
-        setImageSending(true);
-        setError('');
-        setImageResults([]);
+        setResults([]);
         try {
             const resp = await api.playgroundImageGenerate(IMAGE_SCENARIO, {
-                model: imageModel,
-                prompt: imagePrompt.trim(),
-                n: imageCount,
-                size: imageSize,
+                model,
+                prompt: prompt.trim(),
+                n: count,
+                size,
             });
             if (resp?.error) {
                 setError(resp.error.message || JSON.stringify(resp.error));
             } else if (Array.isArray(resp?.data)) {
-                setImageResults(resp.data);
+                setResults(resp.data);
             } else {
                 setError('Unexpected response shape');
             }
         } catch (err: any) {
             setError(err?.message || 'Request failed');
         } finally {
-            setImageSending(false);
+            setSending(false);
         }
-    }, [imagePrompt, imageModel, imageCount, imageSize]);
+    }, [prompt, model, count, size]);
 
-    const noChatModels = useMemo(() => chatModels.length === 0, [chatModels]);
-    const noImageModels = useMemo(() => imageModels.length === 0, [imageModels]);
+    const noModels = useMemo(() => models.length === 0, [models]);
 
     return (
         <PageLayout loading={false}>
             <CardGrid>
                 <UnifiedCard
                     size="full"
-                    title={t('playground.title', { defaultValue: 'Playground' })}
+                    title={t('playground.imageTitle', { defaultValue: 'Image Generation Playground' })}
                 >
-                    <Tabs
-                        value={mode}
-                        onChange={(_, v) => { setMode(v); setError(''); }}
-                        sx={{ mb: 2 }}
-                    >
-                        <Tab
-                            value="image"
-                            label={t('playground.image', { defaultValue: 'Image Generation' })}
-                        />
-                        <Tab
-                            value="chat"
-                            label={t('playground.chat', { defaultValue: 'Chat' })}
-                        />
-                    </Tabs>
+                    <Stack spacing={2}>
+                        {error && (
+                            <Alert severity="error" onClose={() => setError('')}>
+                                {error}
+                            </Alert>
+                        )}
 
-                    {error && (
-                        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
-                            {error}
-                        </Alert>
-                    )}
-
-                    {mode === 'image' && (
-                        <Stack spacing={2}>
-                            {noImageModels && !loadingModels && (
-                                <Alert severity="info">
-                                    {t('playground.noImageModels', {
-                                        defaultValue: 'No image generation rules configured. Add one on the Image Gen page first.',
-                                    })}
-                                </Alert>
-                            )}
-                            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-                                <FormControl size="small" sx={{ minWidth: 240 }}>
-                                    <InputLabel id="image-model-label">
-                                        {t('playground.model', { defaultValue: 'Model' })}
-                                    </InputLabel>
-                                    <Select
-                                        labelId="image-model-label"
-                                        label={t('playground.model', { defaultValue: 'Model' })}
-                                        value={imageModel}
-                                        onChange={(e) => setImageModel(e.target.value)}
-                                        disabled={noImageModels}
-                                    >
-                                        {imageModels.map((m) => (
-                                            <MenuItem key={m} value={m}>{m}</MenuItem>
-                                        ))}
-                                    </Select>
-                                </FormControl>
-                                <FormControl size="small" sx={{ minWidth: 140 }}>
-                                    <InputLabel id="image-size-label">
-                                        {t('playground.size', { defaultValue: 'Size' })}
-                                    </InputLabel>
-                                    <Select
-                                        labelId="image-size-label"
-                                        label={t('playground.size', { defaultValue: 'Size' })}
-                                        value={imageSize}
-                                        onChange={(e) => setImageSize(e.target.value)}
-                                    >
-                                        <MenuItem value="256x256">256x256</MenuItem>
-                                        <MenuItem value="512x512">512x512</MenuItem>
-                                        <MenuItem value="1024x1024">1024x1024</MenuItem>
-                                        <MenuItem value="1024x1792">1024x1792</MenuItem>
-                                        <MenuItem value="1792x1024">1792x1024</MenuItem>
-                                    </Select>
-                                </FormControl>
-                                <TextField
-                                    size="small"
-                                    type="number"
-                                    label={t('playground.count', { defaultValue: 'N' })}
-                                    value={imageCount}
-                                    onChange={(e) => {
-                                        const n = Number(e.target.value);
-                                        setImageCount(Number.isFinite(n) && n > 0 ? Math.min(n, 10) : 1);
-                                    }}
-                                    sx={{ width: 100 }}
-                                    inputProps={{ min: 1, max: 10 }}
-                                />
-                            </Stack>
-                            <TextField
-                                multiline
-                                minRows={4}
-                                fullWidth
-                                placeholder={t('playground.promptPlaceholder', {
-                                    defaultValue: 'Describe the image you want to generate…',
+                        {noModels && !loadingModels && (
+                            <Alert severity="info">
+                                {t('playground.noImageModels', {
+                                    defaultValue: 'No image generation rules configured. Add one on the Image Gen page first.',
                                 })}
-                                value={imagePrompt}
-                                onChange={(e) => setImagePrompt(e.target.value)}
-                                disabled={noImageModels}
+                            </Alert>
+                        )}
+
+                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                            <FormControl size="small" sx={{ minWidth: 240 }}>
+                                <InputLabel id="image-model-label">
+                                    {t('playground.model', { defaultValue: 'Model' })}
+                                </InputLabel>
+                                <Select
+                                    labelId="image-model-label"
+                                    label={t('playground.model', { defaultValue: 'Model' })}
+                                    value={model}
+                                    onChange={(e) => setModel(e.target.value)}
+                                    disabled={noModels}
+                                >
+                                    {models.map((m) => (
+                                        <MenuItem key={m} value={m}>{m}</MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+                            <FormControl size="small" sx={{ minWidth: 140 }}>
+                                <InputLabel id="image-size-label">
+                                    {t('playground.size', { defaultValue: 'Size' })}
+                                </InputLabel>
+                                <Select
+                                    labelId="image-size-label"
+                                    label={t('playground.size', { defaultValue: 'Size' })}
+                                    value={size}
+                                    onChange={(e) => setSize(e.target.value)}
+                                >
+                                    <MenuItem value="256x256">256x256</MenuItem>
+                                    <MenuItem value="512x512">512x512</MenuItem>
+                                    <MenuItem value="1024x1024">1024x1024</MenuItem>
+                                    <MenuItem value="1024x1792">1024x1792</MenuItem>
+                                    <MenuItem value="1792x1024">1792x1024</MenuItem>
+                                </Select>
+                            </FormControl>
+                            <TextField
+                                size="small"
+                                type="number"
+                                label={t('playground.count', { defaultValue: 'N' })}
+                                value={count}
+                                onChange={(e) => {
+                                    const n = Number(e.target.value);
+                                    setCount(Number.isFinite(n) && n > 0 ? Math.min(n, 10) : 1);
+                                }}
+                                sx={{ width: 100 }}
+                                inputProps={{ min: 1, max: 10 }}
                             />
-                            <Box>
-                                <Button
-                                    variant="contained"
-                                    onClick={handleGenerateImage}
-                                    disabled={imageSending || noImageModels || !imagePrompt.trim() || !imageModel}
-                                    startIcon={imageSending ? <CircularProgress size={16} /> : undefined}
-                                >
-                                    {imageSending
-                                        ? t('playground.generating', { defaultValue: 'Generating…' })
-                                        : t('playground.generate', { defaultValue: 'Generate' })}
-                                </Button>
-                            </Box>
-                            {imageResults.length > 0 && (
-                                <Box
-                                    sx={{
-                                        display: 'grid',
-                                        gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
-                                        gap: 2,
-                                    }}
-                                >
-                                    {imageResults.map((img, idx) => {
-                                        const src = img.url
-                                            ? img.url
-                                            : img.b64_json
-                                                ? `data:image/png;base64,${img.b64_json}`
-                                                : '';
-                                        return (
-                                            <Card key={idx} variant="outlined">
-                                                <CardContent sx={{ p: 1, '&:last-child': { pb: 1 } }}>
-                                                    {src ? (
-                                                        <Box
-                                                            component="img"
-                                                            src={src}
-                                                            alt={`result-${idx}`}
-                                                            sx={{ width: '100%', display: 'block', borderRadius: 1 }}
-                                                        />
-                                                    ) : (
-                                                        <Typography variant="caption" color="text.secondary">
-                                                            empty
-                                                        </Typography>
-                                                    )}
-                                                </CardContent>
-                                            </Card>
-                                        );
-                                    })}
-                                </Box>
-                            )}
                         </Stack>
-                    )}
 
-                    {mode === 'chat' && (
-                        <Stack spacing={2}>
-                            {noChatModels && !loadingModels && (
-                                <Alert severity="info">
-                                    {t('playground.noChatModels', {
-                                        defaultValue: 'No chat rules configured for this scenario.',
-                                    })}
-                                </Alert>
-                            )}
-                            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-                                <FormControl size="small" sx={{ minWidth: 160 }}>
-                                    <InputLabel id="chat-scenario-label">
-                                        {t('playground.scenario', { defaultValue: 'Scenario' })}
-                                    </InputLabel>
-                                    <Select
-                                        labelId="chat-scenario-label"
-                                        label={t('playground.scenario', { defaultValue: 'Scenario' })}
-                                        value={chatScenario}
-                                        onChange={(e) => setChatScenario(e.target.value)}
-                                    >
-                                        {CHAT_SCENARIOS.map((s) => (
-                                            <MenuItem key={s} value={s}>{s}</MenuItem>
-                                        ))}
-                                    </Select>
-                                </FormControl>
-                                <FormControl size="small" sx={{ minWidth: 240 }}>
-                                    <InputLabel id="chat-model-label">
-                                        {t('playground.model', { defaultValue: 'Model' })}
-                                    </InputLabel>
-                                    <Select
-                                        labelId="chat-model-label"
-                                        label={t('playground.model', { defaultValue: 'Model' })}
-                                        value={chatModel}
-                                        onChange={(e) => setChatModel(e.target.value)}
-                                        disabled={noChatModels}
-                                    >
-                                        {chatModels.map((m) => (
-                                            <MenuItem key={m} value={m}>{m}</MenuItem>
-                                        ))}
-                                    </Select>
-                                </FormControl>
-                                <Button
-                                    variant="outlined"
-                                    size="small"
-                                    onClick={() => setChatHistory([])}
-                                    disabled={chatHistory.length === 0}
-                                >
-                                    {t('playground.clear', { defaultValue: 'Clear' })}
-                                </Button>
-                            </Stack>
+                        <TextField
+                            multiline
+                            minRows={4}
+                            fullWidth
+                            placeholder={t('playground.promptPlaceholder', {
+                                defaultValue: 'Describe the image you want to generate…',
+                            })}
+                            value={prompt}
+                            onChange={(e) => setPrompt(e.target.value)}
+                            disabled={noModels}
+                        />
 
+                        <Box>
+                            <Button
+                                variant="contained"
+                                onClick={handleGenerate}
+                                disabled={sending || noModels || !prompt.trim() || !model}
+                                startIcon={sending ? <CircularProgress size={16} /> : undefined}
+                            >
+                                {sending
+                                    ? t('playground.generating', { defaultValue: 'Generating…' })
+                                    : t('playground.generate', { defaultValue: 'Generate' })}
+                            </Button>
+                        </Box>
+
+                        {results.length > 0 && (
                             <Box
                                 sx={{
-                                    border: 1,
-                                    borderColor: 'divider',
-                                    borderRadius: 1,
-                                    p: 2,
-                                    minHeight: 240,
-                                    maxHeight: 480,
-                                    overflowY: 'auto',
-                                    bgcolor: 'background.default',
+                                    display: 'grid',
+                                    gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+                                    gap: 2,
                                 }}
                             >
-                                {chatHistory.length === 0 ? (
-                                    <Typography variant="body2" color="text.secondary">
-                                        {t('playground.chatEmpty', { defaultValue: 'No messages yet.' })}
-                                    </Typography>
-                                ) : (
-                                    chatHistory.map((m, idx) => (
-                                        <Box key={idx} sx={{ mb: 1.5 }}>
-                                            <Typography
-                                                variant="caption"
-                                                color={m.role === 'user' ? 'primary' : 'secondary'}
-                                                sx={{ fontWeight: 600 }}
-                                            >
-                                                {m.role}
-                                            </Typography>
-                                            <Typography
-                                                variant="body2"
-                                                sx={{ whiteSpace: 'pre-wrap', mt: 0.25 }}
-                                            >
-                                                {m.content}
-                                            </Typography>
-                                        </Box>
-                                    ))
-                                )}
-                            </Box>
-
-                            <TextField
-                                multiline
-                                minRows={2}
-                                fullWidth
-                                placeholder={t('playground.chatPlaceholder', {
-                                    defaultValue: 'Type a message…',
+                                {results.map((img, idx) => {
+                                    const src = img.url
+                                        ? img.url
+                                        : img.b64_json
+                                            ? `data:image/png;base64,${img.b64_json}`
+                                            : '';
+                                    return (
+                                        <Card key={idx} variant="outlined">
+                                            <CardContent sx={{ p: 1, '&:last-child': { pb: 1 } }}>
+                                                {src ? (
+                                                    <Box
+                                                        component="img"
+                                                        src={src}
+                                                        alt={`result-${idx}`}
+                                                        sx={{ width: '100%', display: 'block', borderRadius: 1 }}
+                                                    />
+                                                ) : (
+                                                    <Typography variant="caption" color="text.secondary">
+                                                        empty
+                                                    </Typography>
+                                                )}
+                                            </CardContent>
+                                        </Card>
+                                    );
                                 })}
-                                value={chatInput}
-                                onChange={(e) => setChatInput(e.target.value)}
-                                disabled={noChatModels}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                                        e.preventDefault();
-                                        handleSendChat();
-                                    }
-                                }}
-                            />
-                            <Box>
-                                <Button
-                                    variant="contained"
-                                    onClick={handleSendChat}
-                                    disabled={chatSending || noChatModels || !chatInput.trim() || !chatModel}
-                                    startIcon={chatSending ? <CircularProgress size={16} /> : undefined}
-                                >
-                                    {chatSending
-                                        ? t('playground.sending', { defaultValue: 'Sending…' })
-                                        : t('playground.send', { defaultValue: 'Send' })}
-                                </Button>
                             </Box>
-                        </Stack>
-                    )}
+                        )}
+                    </Stack>
                 </UnifiedCard>
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/scenario/PlaygroundPage.tsx
+++ b/frontend/src/pages/scenario/PlaygroundPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { api } from '@/services/api';
+import { getOpenAIClient } from '@/services/openaiClient';
 import PageLayout from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import CardGrid from '@/components/CardGrid';
@@ -70,19 +71,14 @@ const PlaygroundPage: React.FC = () => {
         setError('');
         setResults([]);
         try {
-            const resp = await api.playgroundImageGenerate(IMAGE_SCENARIO, {
+            const client = await getOpenAIClient(IMAGE_SCENARIO);
+            const resp = await client.images.generate({
                 model,
                 prompt: prompt.trim(),
                 n: count,
-                size,
+                size: size as any,
             });
-            if (resp?.error) {
-                setError(resp.error.message || JSON.stringify(resp.error));
-            } else if (Array.isArray(resp?.data)) {
-                setResults(resp.data);
-            } else {
-                setError('Unexpected response shape');
-            }
+            setResults(resp.data ?? []);
         } catch (err: any) {
             setError(err?.message || 'Request failed');
         } finally {

--- a/frontend/src/pages/scenario/PlaygroundPage.tsx
+++ b/frontend/src/pages/scenario/PlaygroundPage.tsx
@@ -1,0 +1,436 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CircularProgress,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    Stack,
+    Tab,
+    Tabs,
+    TextField,
+    Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { api } from '@/services/api';
+import PageLayout from '@/components/PageLayout';
+import UnifiedCard from '@/components/UnifiedCard';
+import CardGrid from '@/components/CardGrid';
+
+type Mode = 'chat' | 'image';
+
+interface ChatMessage {
+    role: 'user' | 'assistant';
+    content: string;
+}
+
+const CHAT_SCENARIOS = ['openai', 'anthropic', 'agent'] as const;
+const IMAGE_SCENARIO = 'imagegen';
+
+const extractModelsFromRules = (rules: any[] | undefined | null): string[] => {
+    if (!Array.isArray(rules)) return [];
+    const seen = new Set<string>();
+    rules.forEach((r) => {
+        if (r?.disabled) return;
+        const name = r?.request_model;
+        if (typeof name === 'string' && name.trim()) {
+            seen.add(name.trim());
+        }
+    });
+    return Array.from(seen);
+};
+
+const PlaygroundPage: React.FC = () => {
+    const { t } = useTranslation();
+    const [mode, setMode] = useState<Mode>('image');
+
+    // Chat state
+    const [chatScenario, setChatScenario] = useState<string>('openai');
+    const [chatModels, setChatModels] = useState<string[]>([]);
+    const [chatModel, setChatModel] = useState<string>('');
+    const [chatInput, setChatInput] = useState<string>('');
+    const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
+    const [chatSending, setChatSending] = useState(false);
+
+    // Image state
+    const [imageModels, setImageModels] = useState<string[]>([]);
+    const [imageModel, setImageModel] = useState<string>('');
+    const [imagePrompt, setImagePrompt] = useState<string>('');
+    const [imageSize, setImageSize] = useState<string>('1024x1024');
+    const [imageCount, setImageCount] = useState<number>(1);
+    const [imageResults, setImageResults] = useState<{ url?: string; b64_json?: string }[]>([]);
+    const [imageSending, setImageSending] = useState(false);
+
+    const [error, setError] = useState<string>('');
+    const [loadingModels, setLoadingModels] = useState(false);
+
+    const loadModels = useCallback(async (scenario: string): Promise<string[]> => {
+        const result = await api.getRules(scenario);
+        if (!result || result.success === false) {
+            return [];
+        }
+        const rules = Array.isArray(result.data) ? result.data : (Array.isArray(result) ? result : []);
+        return extractModelsFromRules(rules);
+    }, []);
+
+    // Load image models once
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            setLoadingModels(true);
+            const models = await loadModels(IMAGE_SCENARIO);
+            if (!cancelled) {
+                setImageModels(models);
+                setImageModel((current) => current || models[0] || '');
+                setLoadingModels(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [loadModels]);
+
+    // Load chat models when scenario changes
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            setLoadingModels(true);
+            const models = await loadModels(chatScenario);
+            if (!cancelled) {
+                setChatModels(models);
+                setChatModel((current) => (models.includes(current) ? current : models[0] || ''));
+                setLoadingModels(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [chatScenario, loadModels]);
+
+    const handleSendChat = useCallback(async () => {
+        if (!chatInput.trim() || !chatModel) return;
+        const userMsg: ChatMessage = { role: 'user', content: chatInput.trim() };
+        const next = [...chatHistory, userMsg];
+        setChatHistory(next);
+        setChatInput('');
+        setChatSending(true);
+        setError('');
+        try {
+            const resp = await api.playgroundChatCompletions(chatScenario, {
+                model: chatModel,
+                messages: next.map((m) => ({ role: m.role, content: m.content })),
+            });
+            if (resp?.error) {
+                setError(resp.error.message || JSON.stringify(resp.error));
+            } else {
+                const reply: string = resp?.choices?.[0]?.message?.content ?? '';
+                setChatHistory((prev) => [...prev, { role: 'assistant', content: reply }]);
+            }
+        } catch (err: any) {
+            setError(err?.message || 'Request failed');
+        } finally {
+            setChatSending(false);
+        }
+    }, [chatInput, chatModel, chatScenario, chatHistory]);
+
+    const handleGenerateImage = useCallback(async () => {
+        if (!imagePrompt.trim() || !imageModel) return;
+        setImageSending(true);
+        setError('');
+        setImageResults([]);
+        try {
+            const resp = await api.playgroundImageGenerate(IMAGE_SCENARIO, {
+                model: imageModel,
+                prompt: imagePrompt.trim(),
+                n: imageCount,
+                size: imageSize,
+            });
+            if (resp?.error) {
+                setError(resp.error.message || JSON.stringify(resp.error));
+            } else if (Array.isArray(resp?.data)) {
+                setImageResults(resp.data);
+            } else {
+                setError('Unexpected response shape');
+            }
+        } catch (err: any) {
+            setError(err?.message || 'Request failed');
+        } finally {
+            setImageSending(false);
+        }
+    }, [imagePrompt, imageModel, imageCount, imageSize]);
+
+    const noChatModels = useMemo(() => chatModels.length === 0, [chatModels]);
+    const noImageModels = useMemo(() => imageModels.length === 0, [imageModels]);
+
+    return (
+        <PageLayout loading={false}>
+            <CardGrid>
+                <UnifiedCard
+                    size="full"
+                    title={t('playground.title', { defaultValue: 'Playground' })}
+                >
+                    <Tabs
+                        value={mode}
+                        onChange={(_, v) => { setMode(v); setError(''); }}
+                        sx={{ mb: 2 }}
+                    >
+                        <Tab
+                            value="image"
+                            label={t('playground.image', { defaultValue: 'Image Generation' })}
+                        />
+                        <Tab
+                            value="chat"
+                            label={t('playground.chat', { defaultValue: 'Chat' })}
+                        />
+                    </Tabs>
+
+                    {error && (
+                        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+                            {error}
+                        </Alert>
+                    )}
+
+                    {mode === 'image' && (
+                        <Stack spacing={2}>
+                            {noImageModels && !loadingModels && (
+                                <Alert severity="info">
+                                    {t('playground.noImageModels', {
+                                        defaultValue: 'No image generation rules configured. Add one on the Image Gen page first.',
+                                    })}
+                                </Alert>
+                            )}
+                            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                                <FormControl size="small" sx={{ minWidth: 240 }}>
+                                    <InputLabel id="image-model-label">
+                                        {t('playground.model', { defaultValue: 'Model' })}
+                                    </InputLabel>
+                                    <Select
+                                        labelId="image-model-label"
+                                        label={t('playground.model', { defaultValue: 'Model' })}
+                                        value={imageModel}
+                                        onChange={(e) => setImageModel(e.target.value)}
+                                        disabled={noImageModels}
+                                    >
+                                        {imageModels.map((m) => (
+                                            <MenuItem key={m} value={m}>{m}</MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <FormControl size="small" sx={{ minWidth: 140 }}>
+                                    <InputLabel id="image-size-label">
+                                        {t('playground.size', { defaultValue: 'Size' })}
+                                    </InputLabel>
+                                    <Select
+                                        labelId="image-size-label"
+                                        label={t('playground.size', { defaultValue: 'Size' })}
+                                        value={imageSize}
+                                        onChange={(e) => setImageSize(e.target.value)}
+                                    >
+                                        <MenuItem value="256x256">256x256</MenuItem>
+                                        <MenuItem value="512x512">512x512</MenuItem>
+                                        <MenuItem value="1024x1024">1024x1024</MenuItem>
+                                        <MenuItem value="1024x1792">1024x1792</MenuItem>
+                                        <MenuItem value="1792x1024">1792x1024</MenuItem>
+                                    </Select>
+                                </FormControl>
+                                <TextField
+                                    size="small"
+                                    type="number"
+                                    label={t('playground.count', { defaultValue: 'N' })}
+                                    value={imageCount}
+                                    onChange={(e) => {
+                                        const n = Number(e.target.value);
+                                        setImageCount(Number.isFinite(n) && n > 0 ? Math.min(n, 10) : 1);
+                                    }}
+                                    sx={{ width: 100 }}
+                                    inputProps={{ min: 1, max: 10 }}
+                                />
+                            </Stack>
+                            <TextField
+                                multiline
+                                minRows={4}
+                                fullWidth
+                                placeholder={t('playground.promptPlaceholder', {
+                                    defaultValue: 'Describe the image you want to generate…',
+                                })}
+                                value={imagePrompt}
+                                onChange={(e) => setImagePrompt(e.target.value)}
+                                disabled={noImageModels}
+                            />
+                            <Box>
+                                <Button
+                                    variant="contained"
+                                    onClick={handleGenerateImage}
+                                    disabled={imageSending || noImageModels || !imagePrompt.trim() || !imageModel}
+                                    startIcon={imageSending ? <CircularProgress size={16} /> : undefined}
+                                >
+                                    {imageSending
+                                        ? t('playground.generating', { defaultValue: 'Generating…' })
+                                        : t('playground.generate', { defaultValue: 'Generate' })}
+                                </Button>
+                            </Box>
+                            {imageResults.length > 0 && (
+                                <Box
+                                    sx={{
+                                        display: 'grid',
+                                        gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+                                        gap: 2,
+                                    }}
+                                >
+                                    {imageResults.map((img, idx) => {
+                                        const src = img.url
+                                            ? img.url
+                                            : img.b64_json
+                                                ? `data:image/png;base64,${img.b64_json}`
+                                                : '';
+                                        return (
+                                            <Card key={idx} variant="outlined">
+                                                <CardContent sx={{ p: 1, '&:last-child': { pb: 1 } }}>
+                                                    {src ? (
+                                                        <Box
+                                                            component="img"
+                                                            src={src}
+                                                            alt={`result-${idx}`}
+                                                            sx={{ width: '100%', display: 'block', borderRadius: 1 }}
+                                                        />
+                                                    ) : (
+                                                        <Typography variant="caption" color="text.secondary">
+                                                            empty
+                                                        </Typography>
+                                                    )}
+                                                </CardContent>
+                                            </Card>
+                                        );
+                                    })}
+                                </Box>
+                            )}
+                        </Stack>
+                    )}
+
+                    {mode === 'chat' && (
+                        <Stack spacing={2}>
+                            {noChatModels && !loadingModels && (
+                                <Alert severity="info">
+                                    {t('playground.noChatModels', {
+                                        defaultValue: 'No chat rules configured for this scenario.',
+                                    })}
+                                </Alert>
+                            )}
+                            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                                <FormControl size="small" sx={{ minWidth: 160 }}>
+                                    <InputLabel id="chat-scenario-label">
+                                        {t('playground.scenario', { defaultValue: 'Scenario' })}
+                                    </InputLabel>
+                                    <Select
+                                        labelId="chat-scenario-label"
+                                        label={t('playground.scenario', { defaultValue: 'Scenario' })}
+                                        value={chatScenario}
+                                        onChange={(e) => setChatScenario(e.target.value)}
+                                    >
+                                        {CHAT_SCENARIOS.map((s) => (
+                                            <MenuItem key={s} value={s}>{s}</MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <FormControl size="small" sx={{ minWidth: 240 }}>
+                                    <InputLabel id="chat-model-label">
+                                        {t('playground.model', { defaultValue: 'Model' })}
+                                    </InputLabel>
+                                    <Select
+                                        labelId="chat-model-label"
+                                        label={t('playground.model', { defaultValue: 'Model' })}
+                                        value={chatModel}
+                                        onChange={(e) => setChatModel(e.target.value)}
+                                        disabled={noChatModels}
+                                    >
+                                        {chatModels.map((m) => (
+                                            <MenuItem key={m} value={m}>{m}</MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    onClick={() => setChatHistory([])}
+                                    disabled={chatHistory.length === 0}
+                                >
+                                    {t('playground.clear', { defaultValue: 'Clear' })}
+                                </Button>
+                            </Stack>
+
+                            <Box
+                                sx={{
+                                    border: 1,
+                                    borderColor: 'divider',
+                                    borderRadius: 1,
+                                    p: 2,
+                                    minHeight: 240,
+                                    maxHeight: 480,
+                                    overflowY: 'auto',
+                                    bgcolor: 'background.default',
+                                }}
+                            >
+                                {chatHistory.length === 0 ? (
+                                    <Typography variant="body2" color="text.secondary">
+                                        {t('playground.chatEmpty', { defaultValue: 'No messages yet.' })}
+                                    </Typography>
+                                ) : (
+                                    chatHistory.map((m, idx) => (
+                                        <Box key={idx} sx={{ mb: 1.5 }}>
+                                            <Typography
+                                                variant="caption"
+                                                color={m.role === 'user' ? 'primary' : 'secondary'}
+                                                sx={{ fontWeight: 600 }}
+                                            >
+                                                {m.role}
+                                            </Typography>
+                                            <Typography
+                                                variant="body2"
+                                                sx={{ whiteSpace: 'pre-wrap', mt: 0.25 }}
+                                            >
+                                                {m.content}
+                                            </Typography>
+                                        </Box>
+                                    ))
+                                )}
+                            </Box>
+
+                            <TextField
+                                multiline
+                                minRows={2}
+                                fullWidth
+                                placeholder={t('playground.chatPlaceholder', {
+                                    defaultValue: 'Type a message…',
+                                })}
+                                value={chatInput}
+                                onChange={(e) => setChatInput(e.target.value)}
+                                disabled={noChatModels}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                                        e.preventDefault();
+                                        handleSendChat();
+                                    }
+                                }}
+                            />
+                            <Box>
+                                <Button
+                                    variant="contained"
+                                    onClick={handleSendChat}
+                                    disabled={chatSending || noChatModels || !chatInput.trim() || !chatModel}
+                                    startIcon={chatSending ? <CircularProgress size={16} /> : undefined}
+                                >
+                                    {chatSending
+                                        ? t('playground.sending', { defaultValue: 'Sending…' })
+                                        : t('playground.send', { defaultValue: 'Send' })}
+                                </Button>
+                            </Box>
+                        </Stack>
+                    )}
+                </UnifiedCard>
+            </CardGrid>
+        </PageLayout>
+    );
+};
+
+export default PlaygroundPage;

--- a/frontend/src/pages/scenario/PlaygroundPage.tsx
+++ b/frontend/src/pages/scenario/PlaygroundPage.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-    Alert,
     Box,
     Button,
     Card,
@@ -17,11 +16,14 @@ import {
 import { useTranslation } from 'react-i18next';
 import { api } from '@/services/api';
 import { getOpenAIClient } from '@/services/openaiClient';
+import { useFunctionPanelData } from '@/hooks/useFunctionPanelData';
 import PageLayout from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import CardGrid from '@/components/CardGrid';
 
 const IMAGE_SCENARIO = 'imagegen';
+
+type Quality = 'auto' | 'high' | 'medium' | 'low' | 'standard';
 
 const extractModelsFromRules = (rules: any[] | undefined | null): string[] => {
     if (!Array.isArray(rules)) return [];
@@ -38,15 +40,16 @@ const extractModelsFromRules = (rules: any[] | undefined | null): string[] => {
 
 const PlaygroundPage: React.FC = () => {
     const { t } = useTranslation();
+    const { notification, showNotification } = useFunctionPanelData();
 
     const [models, setModels] = useState<string[]>([]);
     const [model, setModel] = useState<string>('');
     const [prompt, setPrompt] = useState<string>('');
     const [size, setSize] = useState<string>('1024x1024');
+    const [quality, setQuality] = useState<Quality>('auto');
     const [count, setCount] = useState<number>(1);
     const [results, setResults] = useState<{ url?: string; b64_json?: string }[]>([]);
     const [sending, setSending] = useState(false);
-    const [error, setError] = useState<string>('');
     const [loadingModels, setLoadingModels] = useState(false);
 
     useEffect(() => {
@@ -68,7 +71,6 @@ const PlaygroundPage: React.FC = () => {
     const handleGenerate = useCallback(async () => {
         if (!prompt.trim() || !model) return;
         setSending(true);
-        setError('');
         setResults([]);
         try {
             const client = await getOpenAIClient(IMAGE_SCENARIO);
@@ -77,41 +79,38 @@ const PlaygroundPage: React.FC = () => {
                 prompt: prompt.trim(),
                 n: count,
                 size: size as any,
+                quality,
             });
             setResults(resp.data ?? []);
         } catch (err: any) {
-            setError(err?.message || 'Request failed');
+            const status = err?.status ? `${err.status}: ` : '';
+            const msg = err?.error?.message || err?.message || 'Request failed';
+            showNotification(`${status}${msg}`, 'error');
         } finally {
             setSending(false);
         }
-    }, [prompt, model, count, size]);
+    }, [prompt, model, count, size, quality, showNotification]);
 
     const noModels = useMemo(() => models.length === 0, [models]);
 
     return (
-        <PageLayout loading={false}>
+        <PageLayout loading={false} notification={notification}>
             <CardGrid>
                 <UnifiedCard
                     size="full"
                     title={t('playground.imageTitle', { defaultValue: 'Image Generation Playground' })}
                 >
                     <Stack spacing={2}>
-                        {error && (
-                            <Alert severity="error" onClose={() => setError('')}>
-                                {error}
-                            </Alert>
-                        )}
-
                         {noModels && !loadingModels && (
-                            <Alert severity="info">
+                            <Typography variant="body2" color="text.secondary">
                                 {t('playground.noImageModels', {
                                     defaultValue: 'No image generation rules configured. Add one on the Image Gen page first.',
                                 })}
-                            </Alert>
+                            </Typography>
                         )}
 
-                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-                            <FormControl size="small" sx={{ minWidth: 240 }}>
+                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} flexWrap="wrap">
+                            <FormControl size="small" sx={{ minWidth: 220 }}>
                                 <InputLabel id="image-model-label">
                                     {t('playground.model', { defaultValue: 'Model' })}
                                 </InputLabel>
@@ -142,6 +141,23 @@ const PlaygroundPage: React.FC = () => {
                                     <MenuItem value="1024x1024">1024x1024</MenuItem>
                                     <MenuItem value="1024x1792">1024x1792</MenuItem>
                                     <MenuItem value="1792x1024">1792x1024</MenuItem>
+                                </Select>
+                            </FormControl>
+                            <FormControl size="small" sx={{ minWidth: 140 }}>
+                                <InputLabel id="image-quality-label">
+                                    {t('playground.quality', { defaultValue: 'Quality' })}
+                                </InputLabel>
+                                <Select
+                                    labelId="image-quality-label"
+                                    label={t('playground.quality', { defaultValue: 'Quality' })}
+                                    value={quality}
+                                    onChange={(e) => setQuality(e.target.value as Quality)}
+                                >
+                                    <MenuItem value="auto">auto</MenuItem>
+                                    <MenuItem value="low">low</MenuItem>
+                                    <MenuItem value="medium">medium</MenuItem>
+                                    <MenuItem value="high">high</MenuItem>
+                                    <MenuItem value="standard">standard</MenuItem>
                                 </Select>
                             </FormControl>
                             <TextField

--- a/frontend/src/pages/scenario/UseImageGenPage.tsx
+++ b/frontend/src/pages/scenario/UseImageGenPage.tsx
@@ -1,6 +1,7 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
+import ImageGenQuickStartCard from "@/components/ImageGenQuickStartCard.tsx";
 import { Box, Button } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { useNavigate } from 'react-router-dom';
@@ -17,8 +18,11 @@ const UseImageGenPageContent: React.FC = () => {
         notification,
         copyToClipboard,
         baseUrl,
+        rules,
     } = useScenarioPageInternal(scenario);
     const navigate = useNavigate();
+
+    const firstModel = rules?.find((r: any) => !r?.disabled && r?.request_model)?.request_model;
 
     return (
         <PageLayout loading={isLoading} notification={notification}>
@@ -48,6 +52,11 @@ const UseImageGenPageContent: React.FC = () => {
                         onCopy={copyToClipboard}
                     />
                 </UnifiedCard>
+                <ImageGenQuickStartCard
+                    baseUrl={baseUrl}
+                    model={firstModel || 'gpt-image-1'}
+                    onCopy={copyToClipboard}
+                />
                 <TemplatePage
                     scenario={scenario}
                     title="Image Generation Models and Forwarding Rules"

--- a/frontend/src/pages/scenario/UseImageGenPage.tsx
+++ b/frontend/src/pages/scenario/UseImageGenPage.tsx
@@ -1,7 +1,9 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { useNavigate } from 'react-router-dom';
 import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
@@ -16,6 +18,7 @@ const UseImageGenPageContent: React.FC = () => {
         copyToClipboard,
         baseUrl,
     } = useScenarioPageInternal(scenario);
+    const navigate = useNavigate();
 
     return (
         <PageLayout loading={isLoading} notification={notification}>
@@ -27,6 +30,16 @@ const UseImageGenPageContent: React.FC = () => {
                         </Box>
                     }
                     size="full"
+                    rightAction={
+                        <Button
+                            onClick={() => navigate('/agent/playground')}
+                            variant="contained"
+                            size="small"
+                            startIcon={<PlayArrowIcon />}
+                        >
+                            Open Playground
+                        </Button>
+                    }
                 >
                     <ProviderConfigCard
                         title="Image Generation API Configuration"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -762,21 +762,13 @@ export const api = {
     listOpenAIModels: (): Promise<any> => modelAPI('/openai/v1/models'),
     listAnthropicModels: (): Promise<any> => modelAPI('/anthropic/v1/models'),
 
-    // Playground: scenario-prefixed transparent passthrough endpoints
-    // (frontend SDK is swagger-generated and does not cover model-side routes,
-    // so these are hand-written placeholders — replace with codegen later)
-    playgroundChatCompletions: (scenario: string, data: any): Promise<any> =>
-        modelAPI(`/tingly/${scenario}/v1/chat/completions`, {
-            method: 'POST',
-            body: JSON.stringify(data),
-        }),
+    // Playground: scenario-prefixed transparent passthrough endpoint
+    // (model-side route, not covered by swagger codegen — hand-written placeholder)
     playgroundImageGenerate: (scenario: string, data: any): Promise<any> =>
         modelAPI(`/tingly/${scenario}/v1/images/generations`, {
             method: 'POST',
             body: JSON.stringify(data),
         }),
-    playgroundListModels: (scenario: string): Promise<any> =>
-        modelAPI(`/tingly/${scenario}/v1/models`),
 
 
     // Service management within rules

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -762,14 +762,6 @@ export const api = {
     listOpenAIModels: (): Promise<any> => modelAPI('/openai/v1/models'),
     listAnthropicModels: (): Promise<any> => modelAPI('/anthropic/v1/models'),
 
-    // Playground: scenario-prefixed transparent passthrough endpoint
-    // (model-side route, not covered by swagger codegen — hand-written placeholder)
-    playgroundImageGenerate: (scenario: string, data: any): Promise<any> =>
-        modelAPI(`/tingly/${scenario}/v1/images/generations`, {
-            method: 'POST',
-            body: JSON.stringify(data),
-        }),
-
 
     // Service management within rules
     addServiceToRule: (ruleName: string, serviceData: any): Promise<any> => uiAPI(`/rule/${ruleName}/services`, {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -762,6 +762,22 @@ export const api = {
     listOpenAIModels: (): Promise<any> => modelAPI('/openai/v1/models'),
     listAnthropicModels: (): Promise<any> => modelAPI('/anthropic/v1/models'),
 
+    // Playground: scenario-prefixed transparent passthrough endpoints
+    // (frontend SDK is swagger-generated and does not cover model-side routes,
+    // so these are hand-written placeholders — replace with codegen later)
+    playgroundChatCompletions: (scenario: string, data: any): Promise<any> =>
+        modelAPI(`/tingly/${scenario}/v1/chat/completions`, {
+            method: 'POST',
+            body: JSON.stringify(data),
+        }),
+    playgroundImageGenerate: (scenario: string, data: any): Promise<any> =>
+        modelAPI(`/tingly/${scenario}/v1/images/generations`, {
+            method: 'POST',
+            body: JSON.stringify(data),
+        }),
+    playgroundListModels: (scenario: string): Promise<any> =>
+        modelAPI(`/tingly/${scenario}/v1/models`),
+
 
     // Service management within rules
     addServiceToRule: (ruleName: string, serviceData: any): Promise<any> => uiAPI(`/rule/${ruleName}/services`, {

--- a/frontend/src/services/openaiClient.ts
+++ b/frontend/src/services/openaiClient.ts
@@ -1,0 +1,34 @@
+import OpenAI from 'openai';
+import TinglyService from '@/bindings';
+import { getApiBaseUrl } from '@/utils/protocol';
+
+const MODEL_TOKEN_KEY = 'model_token';
+
+const resolveToken = async (): Promise<string> => {
+    const stored = localStorage.getItem(MODEL_TOKEN_KEY);
+    if (stored) return stored;
+    if (import.meta.env.VITE_PKG_MODE === 'gui' && TinglyService) {
+        try {
+            const guiToken = await TinglyService.GetUserAuthToken();
+            if (guiToken) return guiToken;
+        } catch (err) {
+            console.error('Failed to get GUI token for OpenAI client:', err);
+        }
+    }
+    return '';
+};
+
+/**
+ * Build an OpenAI SDK client targeting a tingly scenario passthrough endpoint.
+ * The frontend is trusted in dev/GUI contexts, so dangerouslyAllowBrowser is
+ * intentional — calls go through our own gateway, not directly to a provider.
+ */
+export const getOpenAIClient = async (scenario: string): Promise<OpenAI> => {
+    const base = await getApiBaseUrl();
+    const apiKey = await resolveToken();
+    return new OpenAI({
+        baseURL: `${base}/tingly/${scenario}/v1`,
+        apiKey: apiKey || 'tingly',
+        dangerouslyAllowBrowser: true,
+    });
+};

--- a/frontend/src/services/openaiClient.ts
+++ b/frontend/src/services/openaiClient.ts
@@ -1,42 +1,20 @@
 import OpenAI from 'openai';
-import TinglyService from '@/bindings';
 import { getApiBaseUrl } from '@/utils/protocol';
 import { api } from '@/services/api';
 
-const MODEL_TOKEN_KEY = 'model_token';
-
-const resolveToken = async (): Promise<string> => {
-    const stored = localStorage.getItem(MODEL_TOKEN_KEY);
-    if (stored) return stored;
-    if (import.meta.env.VITE_PKG_MODE === 'gui' && TinglyService) {
-        try {
-            const guiToken = await TinglyService.GetUserAuthToken();
-            if (guiToken) return guiToken;
-        } catch (err) {
-            console.error('Failed to get GUI token for OpenAI client:', err);
-        }
-    }
-    // Fall back to the backend's auto-managed model token
-    try {
-        const result = await api.getToken();
-        if (result?.token) return result.token;
-    } catch (err) {
-        console.error('Failed to fetch model token:', err);
-    }
-    return '';
-};
-
 /**
  * Build an OpenAI SDK client targeting a tingly scenario passthrough endpoint.
- * The frontend is trusted in dev/GUI contexts, so dangerouslyAllowBrowser is
- * intentional — calls go through our own gateway, not directly to a provider.
+ * The model token is always sourced from /api/v1/token — the backend manages
+ * (and auto-generates) it. dangerouslyAllowBrowser is intentional since calls
+ * go through our own gateway, not directly to a provider.
  */
 export const getOpenAIClient = async (scenario: string): Promise<OpenAI> => {
     const base = await getApiBaseUrl();
-    const apiKey = await resolveToken();
+    const result = await api.getToken();
+    const apiKey = result?.token ?? '';
     return new OpenAI({
         baseURL: `${base}/tingly/${scenario}/v1`,
-        apiKey: apiKey || 'tingly',
+        apiKey,
         dangerouslyAllowBrowser: true,
     });
 };

--- a/frontend/src/services/openaiClient.ts
+++ b/frontend/src/services/openaiClient.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import TinglyService from '@/bindings';
 import { getApiBaseUrl } from '@/utils/protocol';
+import { api } from '@/services/api';
 
 const MODEL_TOKEN_KEY = 'model_token';
 
@@ -14,6 +15,13 @@ const resolveToken = async (): Promise<string> => {
         } catch (err) {
             console.error('Failed to get GUI token for OpenAI client:', err);
         }
+    }
+    // Fall back to the backend's auto-managed model token
+    try {
+        const result = await api.getToken();
+        if (result?.token) return result.token;
+    } catch (err) {
+        console.error('Failed to fetch model token:', err);
     }
     return '';
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,11 @@ export default defineConfig(({ mode }) => {
                     target: 'http://localhost:12580',
                     changeOrigin: true,
                     secure: false,
+                },
+                '/tingly/': {
+                    target: 'http://localhost:12580',
+                    changeOrigin: true,
+                    secure: false,
                 }
             },
             port: 3000


### PR DESCRIPTION
## Summary
This PR adds an interactive image generation playground and quick start guide to the Image Gen scenario page, allowing users to test image generation models directly from the UI.

## Key Changes

- **New Playground Page** (`PlaygroundPage.tsx`): Interactive UI for generating images with configurable parameters (model, size, quality, count). Displays generated images in a grid layout with support for both URL and base64-encoded responses.

- **Quick Start Card** (`ImageGenQuickStartCard.tsx`): Collapsible code snippet component with multi-language support (Python, TypeScript, curl) showing how to call the image generation endpoint via OpenAI SDK or curl.

- **OpenAI Client Service** (`openaiClient.ts`): Helper function to instantiate an OpenAI SDK client targeting the tingly scenario passthrough endpoint, with automatic token management.

- **Mock Service Worker Setup**: Added MSW service worker file and expanded mock handlers to support:
  - `/api/v1/token` endpoint for retrieving model tokens
  - `/api/v1/rules` endpoint for fetching image generation rules
  - `/tingly/imagegen/v1/images/generations` endpoint with SVG-based mock image generation

- **Navigation Integration**: Added "Playground" button to the Image Gen page with navigation to the new playground route. Updated activity items to include playground navigation icon.

- **UI/UX Improvements**:
  - Updated `UnifiedCard` spacing (mb: 1 → mb: 2)
  - Added vite proxy configuration for `/tingly/` routes
  - Updated i18n translations for new playground strings and "Embed" → "Embedding" label

- **Dependencies**: Added `openai` package (v6.37.0) for SDK integration

## Implementation Details

- The playground loads available models from the image generation rules on mount
- Mock image generation returns colorful SVG placeholders with metadata overlays
- The OpenAI client uses `dangerouslyAllowBrowser: true` since requests route through the application's own gateway
- Token management is centralized via the `/api/v1/token` endpoint
- Code snippets are dynamically generated based on selected language and model

https://claude.ai/code/session_0183Nmrn73p9yNhQGisNdxV4