### PR TITLE
feat(bot, cc): add /resume command to list and resume Claude sessions

### DIFF
--- a/agentboot/agentboot.go
+++ b/agentboot/agentboot.go
@@ -30,7 +30,10 @@ type AgentBoot struct {
 }
 
 // New creates a new AgentBoot instance.
-// Returns an error only if ClaudeProjectsDir is set but cannot be initialized.
+// The Claude session store is always initialized: when ClaudeProjectsDir is
+// empty the underlying store falls back to ~/.claude/projects, which is the
+// canonical location Claude Code writes its session JSONL files to. Returns
+// an error only if the store fails to initialize.
 func New(config Config) (*AgentBoot, error) {
 	if config.DefaultAgent == "" {
 		config.DefaultAgent = AgentTypeClaude
@@ -47,13 +50,11 @@ func New(config Config) (*AgentBoot, error) {
 		agents: make(map[AgentType]Agent),
 	}
 
-	if config.ClaudeProjectsDir != "" {
-		store, err := NewClaudeStore(config.ClaudeProjectsDir)
-		if err != nil {
-			return nil, fmt.Errorf("initialize session store: %w", err)
-		}
-		ab.store = store
+	store, err := NewClaudeStore(config.ClaudeProjectsDir)
+	if err != nil {
+		return nil, fmt.Errorf("initialize session store: %w", err)
 	}
+	ab.store = store
 
 	return ab, nil
 }

--- a/agentboot/agentboot_test.go
+++ b/agentboot/agentboot_test.go
@@ -20,10 +20,10 @@ func TestNew_DefaultsApplied(t *testing.T) {
 	assert.Equal(t, 100, ab.config.StreamBufferSize)
 }
 
-func TestNew_NoProjectsDir_StoreNil(t *testing.T) {
+func TestNew_NoProjectsDir_StoreDefaultsToHome(t *testing.T) {
 	ab, err := New(Config{})
 	require.NoError(t, err)
-	assert.Nil(t, ab.store, "store should be nil when ClaudeProjectsDir not set")
+	assert.NotNil(t, ab.store, "store should default to ~/.claude/projects when ClaudeProjectsDir not set")
 }
 
 func TestNew_InvalidProjectsDir_StoreStillInitialized(t *testing.T) {
@@ -42,19 +42,23 @@ func TestNew_ValidProjectsDir_StoreInitialized(t *testing.T) {
 
 // --- Session API ---
 
-func TestListRecentSessions_NoStore_ReturnsError(t *testing.T) {
+func TestListRecentSessions_DefaultStore_NoError(t *testing.T) {
 	ab, err := New(Config{})
 	require.NoError(t, err)
 
-	_, err = ab.ListRecentSessions(context.Background(), "/some/path", 10)
-	assert.Error(t, err)
+	// Default store points at ~/.claude/projects; an unknown path inside it
+	// returns an empty slice (not an error), matching the on-disk store
+	// behavior for missing project dirs.
+	_, err = ab.ListRecentSessions(context.Background(), "/nonexistent/path/xyz", 10)
+	assert.NoError(t, err)
 }
 
-func TestGetSessionSummary_NoStore_ReturnsError(t *testing.T) {
+func TestGetSessionSummary_DefaultStore_ReturnsNotFound(t *testing.T) {
 	ab, err := New(Config{})
 	require.NoError(t, err)
 
-	_, err = ab.GetSessionSummary(context.Background(), "session-id", 5, 5)
+	// Store is configured; the session simply doesn't exist on disk.
+	_, err = ab.GetSessionSummary(context.Background(), "definitely-not-a-real-session-id", 5, 5)
 	assert.Error(t, err)
 }
 

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -248,6 +248,57 @@ func (h *BotHandler) formatHelpWithFooter(hCtx HandlerContext, helpText string) 
 	return h.formatResponseWithFooter(meta, helpText)
 }
 
+// handleResumePick processes a tap on a /resume keyboard button. Mirrors the
+// `/resume <n>` text path: validate agent + project, arm the picked session,
+// and acknowledge in chat. We resolve project/agent via the chat itself
+// (rather than trusting callback payloads) so a stale keyboard cannot be used
+// to act on a different project than the one currently bound.
+func (h *BotHandler) handleResumePick(hCtx HandlerContext, sessionID string, msg imbot.Message) {
+	if h.commandAdapter == nil {
+		h.SendText(hCtx, "Command adapter not initialized.")
+		return
+	}
+	agentType, _ := h.commandAdapter.GetCurrentAgent(hCtx.ChatID)
+	if agentType != AgentNameClaude {
+		h.SendText(hCtx, "⚠️ /resume only works with Claude Code (@cc). Switch with: @cc")
+		return
+	}
+	projectPath := resolveProjectPath(h.commandAdapter, hCtx.ChatID, string(hCtx.Platform))
+	if projectPath == "" {
+		h.SendText(hCtx, "No project bound. Use /cd <path> first.")
+		return
+	}
+	if err := h.commandAdapter.PrepareResume(hCtx.ChatID, agentType, projectPath, sessionID); err != nil {
+		h.SendText(hCtx, fmt.Sprintf("Failed to arm resume: %v", err))
+		return
+	}
+
+	// Strip the keyboard from the original listing message so the user can't
+	// double-tap into a stale state. Best-effort; ignore failures.
+	if msgID, _ := msg.Metadata["message_id"].(string); msgID != "" {
+		if tgBot, ok := imbot.AsTelegramBot(hCtx.Bot); ok {
+			if err := tgBot.RemoveMessageKeyboard(context.Background(), hCtx.ChatID, msgID); err != nil {
+				logrus.WithError(err).Debug("Failed to remove resume keyboard")
+			}
+		}
+	}
+
+	h.SendText(hCtx, fmt.Sprintf(
+		"✅ Armed resume for session %s.\nSend your next message to continue, or /clear to abort.",
+		shortSessionID(sessionID)))
+}
+
+// handleResumeCancel removes the resume keyboard and confirms cancellation.
+// No state to clean up — armed state only flips on `pick`.
+func (h *BotHandler) handleResumeCancel(hCtx HandlerContext, msg imbot.Message) {
+	if msgID, _ := msg.Metadata["message_id"].(string); msgID != "" {
+		if tgBot, ok := imbot.AsTelegramBot(hCtx.Bot); ok {
+			_ = tgBot.RemoveMessageKeyboard(context.Background(), hCtx.ChatID, msgID)
+		}
+	}
+	h.SendText(hCtx, "Resume cancelled.")
+}
+
 // normalizeAllowlistToMap converts a string slice to a map for O(1) lookups
 func normalizeAllowlistToMap(values []string) map[string]struct{} {
 	result := make(map[string]struct{})

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -747,8 +747,7 @@ func newResumeCommand(adapter BotHandlerAdapter) imbot.Command {
 			// /resume: list recent sessions for the bound project.
 			sessions, err := adapter.ListResumableSessions(projectPath, resumeListLimit)
 			if err != nil {
-				return sendCommandTextf(adapter, ctx,
-					"Failed to list sessions: %v\n\nTip: ensure ClaudeProjectsDir is configured.", err)
+				return sendCommandTextf(adapter, ctx, "Failed to list sessions: %v", err)
 			}
 			if len(sessions) == 0 {
 				return sendCommandText(adapter, ctx, fmt.Sprintf(

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -31,6 +31,7 @@ func RegisterBuiltinCommands(registry *imbot.CommandRegistry, botHandler BotHand
 		newVerboseCommand(botHandler),
 		newQuietCommand(botHandler),
 		newMockCommand(botHandler),
+		newResumeCommand(botHandler),
 	}
 
 	for _, cmd := range commands {
@@ -117,6 +118,36 @@ type BotHandlerAdapter interface {
 	// command replies append for context continuity. Returns an empty string
 	// when neither agent nor project path is resolvable for the chat.
 	BuildReplyFooter(chatID, platform string) string
+
+	// ListResumableSessions lists the most recent Claude sessions on disk for
+	// the given project, newest first, capped to limit.
+	ListResumableSessions(projectPath string, limit int) ([]ResumableSession, error)
+
+	// PrepareResume binds the given Claude session_id as the next session for
+	// (chatID, agentType, projectPath). The next user message will be sent with
+	// --resume <sessionID>.
+	PrepareResume(chatID, agentType, projectPath, sessionID string) error
+
+	// RememberResumeListing stores the session IDs presented to the user so
+	// /resume <n> can resolve back to them. Order is the same as the displayed
+	// list (1-indexed externally).
+	RememberResumeListing(chatID string, sessionIDs []string)
+
+	// RecallResumeListing returns the most recently displayed session IDs, in
+	// display order. Returns nil if no listing was remembered.
+	RecallResumeListing(chatID string) []string
+}
+
+// ResumableSession is the per-row info returned by ListResumableSessions.
+// Channel-neutral so command code can render either compact text or buttons.
+type ResumableSession struct {
+	SessionID    string
+	ProjectPath  string
+	StartTime    time.Time
+	EndTime      time.Time
+	NumTurns     int
+	Status       string
+	FirstMessage string
 }
 
 // SessionInfo holds session information.
@@ -137,6 +168,11 @@ const (
 	usageJoin     = "Usage: /join <group_id|@username|invite_link>"
 	usagePairBind = "Usage: /bind <code>"
 	usageVerbose  = "Usage: /verbose <on|off>"
+	usageResume   = "Usage: /resume [number]   (no number = list recent sessions)"
+
+	// resumeListLimit caps how many recent sessions /resume shows. Keep small
+	// enough that the list fits on a phone screen.
+	resumeListLimit = 10
 )
 
 func sendCommandText(adapter BotHandlerAdapter, ctx *imbot.HandlerContext, text string) error {
@@ -663,4 +699,162 @@ func newPairBindCommand(adapter BotHandlerAdapter) imbot.Command {
 		WithCategory("system").
 		WithPriority(95).
 		MustBuild()
+}
+
+// newResumeCommand registers `/resume`. With no args it lists the most recent
+// Claude on-disk sessions for the chat's currently-bound project; `/resume <n>`
+// arms the Nth session from that list so the user's next message resumes it.
+func newResumeCommand(adapter BotHandlerAdapter) imbot.Command {
+	return imbot.NewCommand("cmd-resume", "resume", "List or resume recent Claude sessions in the current project").
+		WithAliases("r").
+		WithHandler(func(ctx *imbot.HandlerContext, args []string) error {
+			agentType, _ := adapter.GetCurrentAgent(ctx.ChatID)
+			if agentType != AgentNameClaude {
+				return sendCommandText(adapter, ctx,
+					"⚠️ /resume only works with Claude Code (@cc). Switch with: @cc")
+			}
+
+			projectPath := resolveProjectPath(adapter, ctx.ChatID, string(ctx.Platform))
+			if projectPath == "" {
+				return sendCommandText(adapter, ctx,
+					"No project bound. Use /cd <path> or /project to bind one first.")
+			}
+
+			// /resume <n>: pick from the previously displayed listing.
+			if input, ok := firstArg(args); ok {
+				idx, ok := parsePositiveInt(input)
+				if !ok {
+					return sendCommandText(adapter, ctx, usageResume)
+				}
+				ids := adapter.RecallResumeListing(ctx.ChatID)
+				if len(ids) == 0 {
+					return sendCommandText(adapter, ctx,
+						"No recent /resume listing in this chat. Run /resume first to see options.")
+				}
+				if idx < 1 || idx > len(ids) {
+					return sendCommandTextf(adapter, ctx,
+						"Invalid number: %d (have %d). Run /resume to refresh the list.", idx, len(ids))
+				}
+				picked := ids[idx-1]
+				if err := adapter.PrepareResume(ctx.ChatID, agentType, projectPath, picked); err != nil {
+					return sendCommandTextf(adapter, ctx, "Failed to arm resume: %v", err)
+				}
+				return sendCommandTextf(adapter, ctx,
+					"✅ Armed resume for session %s.\nSend your next message to continue, or /clear to abort.",
+					shortSessionID(picked))
+			}
+
+			// /resume: list recent sessions for the bound project.
+			sessions, err := adapter.ListResumableSessions(projectPath, resumeListLimit)
+			if err != nil {
+				return sendCommandTextf(adapter, ctx,
+					"Failed to list sessions: %v\n\nTip: ensure ClaudeProjectsDir is configured.", err)
+			}
+			if len(sessions) == 0 {
+				return sendCommandText(adapter, ctx, fmt.Sprintf(
+					"No prior sessions in %s.\nSwitch project with /p (list) + /cd <n>, or just send a message to start a new one.",
+					ShortenPath(projectPath)))
+			}
+
+			ids := make([]string, 0, len(sessions))
+			for _, s := range sessions {
+				ids = append(ids, s.SessionID)
+			}
+			adapter.RememberResumeListing(ctx.ChatID, ids)
+
+			return sendCommandText(adapter, ctx, buildResumeListText(projectPath, sessions))
+		}).
+		WithCategory("session").
+		WithPriority(85).
+		MustBuild()
+}
+
+// buildResumeListText renders the compact one-line-per-session list shown by
+// /resume. Lines are kept short so phone screens can fit ~10 entries without
+// wrapping into noise.
+func buildResumeListText(projectPath string, sessions []ResumableSession) string {
+	var buf strings.Builder
+	buf.WriteString("Recent sessions in ")
+	buf.WriteString(ShortenPath(projectPath))
+	buf.WriteString(":\n")
+	for i, s := range sessions {
+		fmt.Fprintf(&buf, "  %d. %s · %s · %s%s\n",
+			i+1,
+			formatRelativeTime(latestTime(s)),
+			formatTurns(s.NumTurns),
+			truncateRunes(strings.ReplaceAll(s.FirstMessage, "\n", " "), 50),
+			statusGlyph(s.Status),
+		)
+	}
+	buf.WriteString("\nUse /resume <number> to resume. Switch project with /p + /cd.")
+	return buf.String()
+}
+
+func latestTime(s ResumableSession) time.Time {
+	if !s.EndTime.IsZero() {
+		return s.EndTime
+	}
+	return s.StartTime
+}
+
+func formatTurns(n int) string {
+	if n <= 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%dt", n)
+}
+
+// formatRelativeTime renders a coarse "Nm/h/d ago" suitable for compact lists.
+// We avoid pulling in a humanize dependency for one call site.
+func formatRelativeTime(t time.Time) string {
+	if t.IsZero() {
+		return "?"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	default:
+		return t.Format("2006-01-02")
+	}
+}
+
+func statusGlyph(status string) string {
+	switch strings.ToLower(status) {
+	case "complete", "completed":
+		return " ✓"
+	case "error", "failed":
+		return " ✗"
+	case "active", "running":
+		return " …"
+	default:
+		return ""
+	}
+}
+
+// truncateRunes trims s to max runes (not bytes) and appends an ellipsis when
+// it had to cut. Avoids slicing inside a multi-byte rune, which matters for
+// Chinese first-message previews.
+func truncateRunes(s string, max int) string {
+	if max <= 1 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+func shortSessionID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
 }

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -762,11 +762,61 @@ func newResumeCommand(adapter BotHandlerAdapter) imbot.Command {
 			}
 			adapter.RememberResumeListing(ctx.ChatID, ids)
 
-			return sendCommandText(adapter, ctx, buildResumeListText(projectPath, sessions))
+			text := buildResumeListText(projectPath, sessions)
+
+			// DM on a platform with inline keyboards: also surface buttons so
+			// users can tap a session instead of typing /resume <n>. Group
+			// chats and platforms without interaction stay text-only.
+			caps := imbot.GetPlatformCapabilities(string(ctx.Platform))
+			if ctx.IsDirectMessage && caps != nil && caps.SupportsInteraction() {
+				keyboard := buildResumeKeyboard(sessions)
+				tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
+				_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
+					Text:     text + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
+					Metadata: buildTrackedReplyMetadata(tgKeyboard),
+				})
+				if err != nil {
+					logrus.WithError(err).Error("Failed to send resume list with keyboard")
+					return sendCommandText(adapter, ctx, text)
+				}
+				return nil
+			}
+
+			return sendCommandText(adapter, ctx, text)
 		}).
 		WithCategory("session").
 		WithPriority(85).
 		MustBuild()
+}
+
+// buildResumeKeyboard renders a 2-buttons-per-row keyboard for /resume in
+// DMs. Each button's label stays compact ("#1 · 2h · 14t") because the
+// detailed previews already live in the message body; the button is just a
+// tap-target keyed to the session's index. Callback data carries the actual
+// session_id so the handler doesn't need to re-read the listing cache.
+func buildResumeKeyboard(sessions []ResumableSession) imbot.InlineKeyboardMarkup {
+	const cols = 2
+	var rows [][]imbot.InlineKeyboardButton
+	var current []imbot.InlineKeyboardButton
+	for i, s := range sessions {
+		label := fmt.Sprintf("#%d · %s · %s", i+1, formatRelativeTime(latestTime(s)), formatTurns(s.NumTurns))
+		current = append(current, imbot.InlineKeyboardButton{
+			Text:         label,
+			CallbackData: imbot.FormatCallbackData("resume", "pick", s.SessionID),
+		})
+		if len(current) == cols {
+			rows = append(rows, current)
+			current = nil
+		}
+	}
+	if len(current) > 0 {
+		rows = append(rows, current)
+	}
+	rows = append(rows, []imbot.InlineKeyboardButton{{
+		Text:         "Cancel",
+		CallbackData: imbot.FormatCallbackData("resume", "cancel"),
+	}})
+	return imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 // buildResumeListText renders the compact one-line-per-session list shown by

--- a/internal/remote_control/bot/command_integration.go
+++ b/internal/remote_control/bot/command_integration.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -226,6 +227,95 @@ func (a *botHandlerAdapter) BuildReplyFooter(chatID, platform string) string {
 		return ""
 	}
 	return BuildFooter(agentType, projectPath)
+}
+
+// ListResumableSessions delegates to the AgentBoot session store, returning
+// the most recent Claude on-disk sessions for the project. Returns an empty
+// slice (and no error) if the store has no entries; only configuration or I/O
+// failures bubble up.
+func (a *botHandlerAdapter) ListResumableSessions(projectPath string, limit int) ([]ResumableSession, error) {
+	if a.handler.agentBoot == nil {
+		return nil, fmt.Errorf("agentboot not configured")
+	}
+	if limit <= 0 {
+		limit = resumeListLimit
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	metas, err := a.handler.agentBoot.ListRecentSessions(ctx, projectPath, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ResumableSession, 0, len(metas))
+	for _, m := range metas {
+		out = append(out, ResumableSession{
+			SessionID:    m.SessionID,
+			ProjectPath:  m.ProjectPath,
+			StartTime:    m.StartTime,
+			EndTime:      m.EndTime,
+			NumTurns:     m.NumTurns,
+			Status:       string(m.Status),
+			FirstMessage: m.FirstMessage,
+		})
+	}
+	return out, nil
+}
+
+// PrepareResume closes any existing remote-session record for (chat, agent,
+// project) and creates a new one whose ID matches the picked Claude session
+// on disk. The next user message hitting resolveSession will then run with
+// Resume=true. We deliberately do NOT launch Claude here — Claude needs an
+// initial prompt, and the user picking from a list is not yet that prompt.
+func (a *botHandlerAdapter) PrepareResume(chatID, agentType, projectPath, sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("empty session id")
+	}
+	if old := a.handler.sessionMgr.FindBy(chatID, agentType, projectPath); old != nil && old.ID != sessionID {
+		a.handler.sessionMgr.Close(old.ID)
+	}
+	if existing, ok := a.handler.sessionMgr.GetOrLoad(sessionID); ok {
+		// Already present (perhaps user re-armed the same id). Just refresh
+		// the binding to make sure FindBy returns it next time.
+		a.handler.sessionMgr.Update(sessionID, func(s *session.Session) {
+			s.ChatID = chatID
+			s.Agent = agentType
+			s.Project = projectPath
+			s.Status = session.StatusPending
+			s.ExpiresAt = time.Time{}
+		})
+		_ = existing
+		return nil
+	}
+	if sess := a.handler.sessionMgr.CreateWithID(sessionID, chatID, agentType, projectPath); sess == nil {
+		return fmt.Errorf("failed to bind resume session %s", sessionID)
+	}
+	return nil
+}
+
+// RememberResumeListing stores the displayed session-id list for /resume <n>.
+func (a *botHandlerAdapter) RememberResumeListing(chatID string, sessionIDs []string) {
+	a.handler.resumeListingsMu.Lock()
+	defer a.handler.resumeListingsMu.Unlock()
+	if len(sessionIDs) == 0 {
+		delete(a.handler.resumeListings, chatID)
+		return
+	}
+	clone := make([]string, len(sessionIDs))
+	copy(clone, sessionIDs)
+	a.handler.resumeListings[chatID] = clone
+}
+
+// RecallResumeListing returns a copy of the cached listing for /resume <n>.
+func (a *botHandlerAdapter) RecallResumeListing(chatID string) []string {
+	a.handler.resumeListingsMu.RLock()
+	defer a.handler.resumeListingsMu.RUnlock()
+	ids, ok := a.handler.resumeListings[chatID]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(ids))
+	copy(out, ids)
+	return out
 }
 
 // InitCommandRegistry initializes the command registry with built-in commands.

--- a/internal/remote_control/bot/handler_constructor.go
+++ b/internal/remote_control/bot/handler_constructor.go
@@ -104,6 +104,7 @@ func NewBotHandler(
 		runningCancel:       make(map[string]context.CancelFunc),
 		pendingBinds:        make(map[string]*PendingBind),
 		actionMenuMessageID: make(map[string]string),
+		resumeListings:      make(map[string][]string),
 		verbose:             true, // Default to verbose mode
 		feishuCardRenderer:  feature.NewFeishuCardRenderer(),
 		pairing:             pairing,

--- a/internal/remote_control/bot/handler_types.go
+++ b/internal/remote_control/bot/handler_types.go
@@ -51,6 +51,12 @@ type BotHandler struct {
 	actionMenuMessageID   map[string]string
 	actionMenuMessageIDMu sync.RWMutex
 
+	// resumeListings caches the session-id list most recently shown by /resume
+	// per chat, so /resume <n> can resolve N back to a session_id without
+	// re-reading the on-disk store. Best-effort, no persistence.
+	resumeListings   map[string][]string
+	resumeListingsMu sync.RWMutex
+
 	// verbose controls whether to show intermediate messages (onMessage details)
 	// true = show all messages (default), false = show only final results
 	verbose   bool

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -77,6 +77,21 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 			h.handleProjectSwitch(hCtx, projectID)
 		}
 
+	case "resume":
+		if len(parts) < 2 {
+			return
+		}
+		subAction := parts[1]
+		switch subAction {
+		case "pick":
+			if len(parts) < 3 {
+				return
+			}
+			h.handleResumePick(hCtx, parts[2], msg)
+		case "cancel":
+			h.handleResumeCancel(hCtx, msg)
+		}
+
 	case "bind":
 		// Remove the action keyboard before handling
 		h.removeActionKeyboard(bot, chatID)

--- a/remote/session/manager.go
+++ b/remote/session/manager.go
@@ -141,6 +141,48 @@ func (m *Manager) CreateWith(chatID, agent, project string) *Session {
 	return session
 }
 
+// CreateWithID creates a new session bound to a caller-supplied ID instead of
+// generating a UUID. Used by /resume to align the remote session record with a
+// Claude on-disk session_id so the next message naturally triggers --resume.
+// Returns nil if a session with that ID already exists in memory.
+func (m *Manager) CreateWithID(id, chatID, agent, project string) *Session {
+	if id == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.sessions[id]; exists {
+		return nil
+	}
+
+	now := time.Now()
+	sess := &Session{
+		ID:           id,
+		ChatID:       chatID,
+		Agent:        agent,
+		Project:      project,
+		Status:       StatusPending,
+		CreatedAt:    now,
+		LastActivity: now,
+		ExpiresAt:    time.Time{}, // persistent: caller will drive lifecycle
+		Context:      make(map[string]interface{}),
+	}
+	if project != "" {
+		sess.Context["project_path"] = project
+	}
+	m.sessions[id] = sess
+	logrus.Debugf("Session resumed-bind: %s (chat=%s, agent=%s, project=%s)",
+		id, chatID, agent, project)
+	if m.store != nil {
+		_ = m.store.Set(id, sess)
+		if jsonStore, ok := m.store.(*SessionStoreJSON); ok {
+			_ = jsonStore.ForceSave()
+		}
+	}
+	return sess
+}
+
 // Get retrieves a session by ID
 func (m *Manager) Get(id string) (*Session, bool) {
 	m.mu.RLock()


### PR DESCRIPTION
## Summary
Implements a new `/resume` command that allows users to list recent Claude sessions for the current project and resume a previous session by selecting from the list.

## Key Changes

- **New `/resume` command** (`newResumeCommand`):
  - With no arguments: lists the most recent Claude on-disk sessions (up to 10) for the currently-bound project
  - With a number argument: resumes the Nth session from the previously displayed list
  - Only works with Claude Code agent (@cc); shows a helpful message if another agent is active
  - Requires a project to be bound via `/cd` or `/project`

- **Session listing and resumption flow**:
  - `ListResumableSessions`: queries the AgentBoot session store for recent sessions in a project
  - `RememberResumeListing` / `RecallResumeListing`: caches the displayed session IDs per chat so `/resume <n>` can resolve the number back to a session ID
  - `PrepareResume`: binds a picked session ID to the chat/agent/project tuple, marking it as pending so the next user message triggers `--resume`

- **Interactive keyboard UI** (Telegram DMs):
  - `buildResumeKeyboard`: renders a 2-column inline keyboard with compact session buttons (#1 · 2h · 14t format)
  - Includes a Cancel button to dismiss the keyboard
  - Callback handlers (`handleResumePick`, `handleResumeCancel`) process button taps and clean up the keyboard

- **Compact text formatting**:
  - `buildResumeListText`: renders a one-line-per-session list with relative timestamps, turn counts, and first-message previews
  - Helper functions: `formatRelativeTime`, `formatTurns`, `statusGlyph`, `truncateRunes` for readable output
  - `shortSessionID`: abbreviates session IDs to 8 characters in user-facing messages

- **Session manager enhancement**:
  - `CreateWithID`: new method to create a session with a caller-supplied ID (instead of generating a UUID), used to align the remote session record with Claude's on-disk session_id

- **AgentBoot store initialization**:
  - Changed to always initialize the Claude session store, defaulting to `~/.claude/projects` when `ClaudeProjectsDir` is not explicitly set
  - Updated tests to reflect that the store is now always available

- **Callback routing**:
  - Added "resume" action handler in `handleCallbackQuery` to route button taps to `handleResumePick` or `handleResumeCancel`

## Implementation Details

- Resume listings are cached in-memory per chat (`resumeListings` map with RWMutex) for fast `/resume <n>` resolution without re-reading disk
- The command validates that the user's current agent and project haven't changed before arming a resume, preventing stale keyboard taps from acting on a different context
- Session state is set to `StatusPending` and expiry is cleared so the session persists until the user sends a message or explicitly clears it
- Keyboard removal is best-effort to prevent double-taps; failures are logged but don't block the user experience

https://claude.ai/code/session_01HZ4mNHEH8P2BAhLFyhFNQ7

---

<img width="936" height="794" alt="image" src="https://github.com/user-attachments/assets/a6ec6465-9653-43b7-8974-d85ee2d05498" />
