### PR TITLE
Add null check for OAuth token expiration time

### DIFF
--- a/internal/server/background/oauth_refresher.go
+++ b/internal/server/background/oauth_refresher.go
@@ -164,6 +164,10 @@ func (tr *OAuthRefresher) CheckAndRefreshTokens() {
 			continue
 		}
 
+		if provider.OAuthDetail.ExpiresAt == "" {
+			continue
+		}
+
 		expiresAt, err := time.Parse(time.RFC3339, provider.OAuthDetail.ExpiresAt)
 		if err != nil {
 			logger.WithFields(logrus.Fields{


### PR DESCRIPTION
## Summary
Added a safety check to handle cases where the OAuth token expiration time (`ExpiresAt`) is empty or not set before attempting to parse it as a timestamp.

## Key Changes
- Added validation to skip token refresh processing when `provider.OAuthDetail.ExpiresAt` is an empty string
- This prevents potential parsing errors and gracefully handles OAuth providers that may not return an expiration time

## Implementation Details
The check is placed before the `time.Parse()` call in the `CheckAndRefreshTokens()` method, ensuring that we only attempt to parse valid timestamp strings. This defensive programming approach prevents runtime errors and allows the token refresh process to continue for other providers even if one provider has missing expiration data.

https://claude.ai/code/session_01PVnso7ZQjJitJzabNTGy32