### PR TITLE
perf(remote): aggregate tool-call events to reduce chat spam

### DIFF
--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -25,7 +25,25 @@ type streamingMessageHandler struct {
 	formatter *claude.TextFormatter
 	verbose   bool          // If false, only show final results (hide intermediate messages)
 	meta      *ResponseMeta // Pointer so OnComplete sees updates from SmartGuideCompletionCallback
+
+	// toolBuffer accumulates formatted tool-only renders between text-bearing
+	// messages. Messages act as the splitting boundary: when a text-bearing
+	// claude.Message arrives (assistant text, result, system notice), the
+	// buffered tool renders are flushed as a single aggregated message before
+	// the new text is sent. This avoids flooding the chat with one IM message
+	// per tool call when the agent runs long tool chains.
+	toolBuffer []string
 }
+
+// toolBufferFlushThreshold is the upper bound on buffered tool entries; when
+// reached without an intervening text-bearing message, the buffer is flushed
+// to ensure the user still sees progress on long-running tool chains.
+const toolBufferFlushThreshold = 20
+
+// quietToolPreviewCount is how many of the buffered tool entries are inlined
+// into the aggregated summary shown in quiet mode. The rest are folded into
+// an "(+N more)" suffix.
+const quietToolPreviewCount = 3
 
 // Ensure streamingMessageHandler implements required interfaces
 var _ agentboot.MessageStreamer = (*streamingMessageHandler)(nil)
@@ -110,6 +128,10 @@ func (f *streamingMessageHandler) OnAsk(context.Context, agentboot.AskRequest) (
 func (f *streamingMessageHandler) OnComplete(result *agentboot.CompletionResult) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	// Drain any tool renders that never met a trailing text message so the
+	// user sees them before the completion banner.
+	f.flushToolBufferLocked()
 
 	// Build action keyboard
 	kb := feature.BuildActionKeyboard()
@@ -207,9 +229,13 @@ func (h *streamingMessageHandler) handleAgentMessage(msg agentboot.AgentMessage)
 	}
 }
 
-// handleClaudeMessage processes claude-specific messages
+// handleClaudeMessage processes claude-specific messages.
+//
+// Messages are the splitting boundary for output: tool-only renders accumulate
+// in toolBuffer, and a text-bearing message flushes the buffer (as a single
+// aggregated message) before being sent itself. Quiet mode renders the
+// flushed buffer as a short summary; verbose mode keeps one line per tool.
 func (h *streamingMessageHandler) handleClaudeMessage(claudeMsg claude.Message) error {
-	// Format using the formatter
 	formatted := h.formatter.Format(claudeMsg)
 	d, _ := json.Marshal(claudeMsg.GetRawData())
 	logrus.Infof("[bot] Raw: %s", d)
@@ -220,18 +246,102 @@ func (h *streamingMessageHandler) handleClaudeMessage(claudeMsg claude.Message) 
 		return nil
 	}
 
-	// In non-verbose mode, only show the final result (assistant turn end), not tool use / intermediate
+	if isToolOnlyClaudeMessage(claudeMsg) {
+		h.appendToolBuffer(formatted)
+		return nil
+	}
+
+	// Text-bearing message. In quiet mode, still suppress user-echo and
+	// stream-event noise — only assistant text, agent results, and system
+	// notices reach the chat.
 	if !h.verbose {
 		msgType := claudeMsg.GetType()
-		// Only forward "result" type messages in quiet mode; skip tool use, system etc.
-		if msgType != "result" && msgType != "assistant" {
+		if msgType != "result" && msgType != "assistant" && msgType != "system" {
 			logrus.WithField("msgType", msgType).Debug("Quiet mode: suppressing non-result message")
 			return nil
 		}
 	}
 
+	h.flushToolBufferLocked()
 	h.sendMessage(formatted)
 	return nil
+}
+
+// isToolOnlyClaudeMessage reports whether the message carries only tool
+// activity (no user-facing text). Such messages are buffered until the next
+// text-bearing message flushes them.
+func isToolOnlyClaudeMessage(msg claude.Message) bool {
+	switch m := msg.(type) {
+	case *claude.ToolUseMessage, *claude.ToolResultMessage:
+		return true
+	case *claude.AssistantMessage:
+		if m == nil {
+			return false
+		}
+		for _, c := range m.Message.Content {
+			if c.Type == claude.ContentBlockTypeText && strings.TrimSpace(c.Text) != "" {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// appendToolBuffer records a formatted tool render. The caller must hold h.mu.
+// When the buffer reaches toolBufferFlushThreshold it is flushed immediately
+// so the user still sees progress on long tool chains.
+func (h *streamingMessageHandler) appendToolBuffer(formatted string) {
+	if strings.TrimSpace(formatted) == "" {
+		return
+	}
+	h.toolBuffer = append(h.toolBuffer, formatted)
+	if len(h.toolBuffer) >= toolBufferFlushThreshold {
+		h.flushToolBufferLocked()
+	}
+}
+
+// flushToolBufferLocked sends any buffered tool renders as a single aggregated
+// message and clears the buffer. The caller must hold h.mu.
+func (h *streamingMessageHandler) flushToolBufferLocked() {
+	if len(h.toolBuffer) == 0 {
+		return
+	}
+	text := h.renderToolBuffer(h.toolBuffer)
+	h.toolBuffer = h.toolBuffer[:0]
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	h.sendMessage(text)
+}
+
+// renderToolBuffer turns the accumulated tool renders into the single message
+// that will be sent to the user. Verbose mode keeps every entry on its own
+// line; quiet mode collapses to a count + preview of the first few entries.
+func (h *streamingMessageHandler) renderToolBuffer(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	if h.verbose {
+		return strings.Join(items, "\n")
+	}
+
+	previewN := quietToolPreviewCount
+	if previewN > len(items) {
+		previewN = len(items)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "🔧 %d tool call(s)\n", len(items))
+	for _, p := range items[:previewN] {
+		b.WriteString("• ")
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	if rest := len(items) - previewN; rest > 0 {
+		fmt.Fprintf(&b, "…(+%d more)", rest)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // handleAgentbootEvent processes agentboot.Event messages (fallback for unknown event types)
@@ -311,6 +421,10 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 func (h *streamingMessageHandler) OnError(err error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Surface any buffered tool activity before the error so the user has
+	// context on what was happening when the failure occurred.
+	h.flushToolBufferLocked()
 
 	errStr := err.Error()
 	var errMsg string

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/remote_control/bot/feature"
@@ -231,12 +232,11 @@ func (h *streamingMessageHandler) handleAgentMessage(msg agentboot.AgentMessage)
 	}
 }
 
-// renderToolUseSummary produces a one-line summary of a tool invocation
-// for the main-path handlers (handleAgentMessage / handleAgentbootEvent /
-// handleMapMessage), where the rich claude.TextFormatter isn't available.
-// Output goes into the shared toolBuffer and is rendered the same as
-// handleClaudeMessage renders — verbose joins by newline, quiet collapses
-// to a count + preview.
+// maxToolHintLen bounds the input hint appended to a tool-use render.
+const maxToolHintLen = 80
+
+// renderToolUseSummary produces a one-line summary of a tool invocation for
+// the main-path handlers, which don't carry the rich claude.TextFormatter.
 func renderToolUseSummary(name string, input map[string]interface{}) string {
 	if name == "" {
 		name = "tool"
@@ -254,35 +254,34 @@ func renderToolResultSummary(name string, isError bool) string {
 	if isError {
 		label = "error"
 	}
-	if name == "" {
-		return "↳ " + label
+	if name != "" {
+		label = name + " " + label
 	}
-	return "↳ " + name + " " + label
+	return IconToolResult + " " + label
 }
 
 // briefInputHint picks a short, recognizable string from a tool's input map
-// (file path, command, URL, query) so each buffered tool render carries
-// enough context to be useful in the aggregated message.
+// (file path, command, URL, query). The result is rune-safe truncated so a
+// multibyte path or command can't be sliced mid-rune.
 func briefInputHint(input map[string]interface{}) string {
 	if input == nil {
 		return ""
 	}
 	for _, k := range []string{"command", "file_path", "path", "url", "query"} {
-		if v, ok := input[k].(string); ok && v != "" {
-			const max = 80
-			if len(v) > max {
-				v = v[:max-3] + "..."
-			}
-			return v
+		v, ok := input[k].(string)
+		if !ok || v == "" {
+			continue
 		}
+		if utf8.RuneCountInString(v) > maxToolHintLen {
+			v = string([]rune(v)[:maxToolHintLen-1]) + "…"
+		}
+		return v
 	}
 	return ""
 }
 
-// toolEventFields captures the fields the main-path handlers need from a
-// tool-related event, regardless of source shape (typed AgentMessage, Event,
-// or raw map). Field extraction lives per-source so the shared dispatcher
-// stays format-agnostic.
+// toolEventFields is the source-agnostic shape the main-path handlers feed
+// into bufferToolEvent. Per-source extraction lives in toolFieldsFrom*.
 type toolEventFields struct {
 	Name    string
 	Input   map[string]interface{}
@@ -304,19 +303,25 @@ func toolFieldsFromRaw(raw map[string]interface{}) toolEventFields {
 // toolFieldsFromNestedMap reads tool fields from a map message whose fields
 // may live either at the top level or nested under a "data" sub-object.
 func toolFieldsFromNestedMap(m map[string]interface{}) toolEventFields {
-	name, _ := mapToolName(m)
-	input, _ := mapFieldAsMap(m, "input")
-	isError, _ := mapBoolField(m, "is_error")
+	name, _ := mapNestedField[string](m, "tool_name")
+	input, _ := mapNestedField[map[string]interface{}](m, "input")
+	isError, _ := mapNestedField[bool](m, "is_error")
 	return toolEventFields{Name: name, Input: input, IsError: isError}
 }
 
-// bufferToolEvent appends the right render for a tool_use / tool_result event
-// to the shared tool buffer. Returns true when the event was a tool event and
-// fully handled, so callers can early-return. The caller must hold h.mu.
-//
-// This is the one place all three main-path handlers (AgentMessage / Event /
-// map) agree on: same fields in, same buffer out. Source-specific field
-// extraction stays in the caller via toolFieldsFrom* helpers.
+// assistantTextFromMap resolves assistant text from a map message: a "message"
+// field (top-level or nested under "data") preferred over a top-level "text".
+func assistantTextFromMap(m map[string]interface{}) string {
+	if v, ok := mapNestedField[string](m, "message"); ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	text, _ := m["text"].(string)
+	return text
+}
+
+// bufferToolEvent appends the render for a tool_use / tool_result event to the
+// shared tool buffer. Returns true when the event was a tool event and fully
+// handled, so callers can early-return. The caller must hold h.mu.
 func (h *streamingMessageHandler) bufferToolEvent(eventType string, f toolEventFields) bool {
 	switch eventType {
 	case agentboot.EventTypeToolUse:
@@ -330,9 +335,7 @@ func (h *streamingMessageHandler) bufferToolEvent(eventType string, f toolEventF
 }
 
 // sendText flushes any buffered tool renders and then sends text to the user.
-// No-op when text is effectively empty. Keeps messages the splitting boundary
-// for output — the same invariant handleClaudeMessage relies on. The caller
-// must hold h.mu.
+// No-op when text is effectively empty. The caller must hold h.mu.
 func (h *streamingMessageHandler) sendText(text string) {
 	if strings.TrimSpace(text) == "" {
 		return
@@ -472,11 +475,7 @@ func (h *streamingMessageHandler) handleAgentbootEvent(event agentboot.Event) er
 
 	switch event.Type {
 	case agentboot.EventTypeAssistant:
-		text, _ := event.Data["message"].(string)
-		if strings.TrimSpace(text) == "" {
-			text, _ = event.Data["text"].(string)
-		}
-		h.sendText(text)
+		h.sendText(assistantTextFromMap(event.Data))
 	case agentboot.EventTypePermissionRequest:
 		logrus.WithFields(logrus.Fields{
 			"request_id": event.Data["request_id"],
@@ -525,17 +524,7 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 			}).Info("Permission request received (will be handled by IMPrompter)")
 		}
 	case agentboot.EventTypeAssistant:
-		var text string
-		if data, ok := m["data"].(map[string]interface{}); ok {
-			text, _ = data["message"].(string)
-		}
-		if strings.TrimSpace(text) == "" {
-			text, _ = m["message"].(string)
-		}
-		if strings.TrimSpace(text) == "" {
-			text, _ = m["text"].(string)
-		}
-		h.sendText(text)
+		h.sendText(assistantTextFromMap(m))
 	case agentboot.EventTypeResult:
 		// Flush trailing tool renders before OnComplete's banner.
 		h.flushToolBufferLocked()
@@ -545,40 +534,20 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 	return nil
 }
 
-func mapToolName(m map[string]interface{}) (string, bool) {
-	if v, ok := m["tool_name"].(string); ok && v != "" {
+// mapNestedField reads a typed field from a map message, looking at the top
+// level first and then under a "data" sub-object. Map messages from different
+// agents put fields at either depth.
+func mapNestedField[T any](m map[string]interface{}, key string) (T, bool) {
+	if v, ok := m[key].(T); ok {
 		return v, true
 	}
 	if data, ok := m["data"].(map[string]interface{}); ok {
-		if v, ok := data["tool_name"].(string); ok && v != "" {
+		if v, ok := data[key].(T); ok {
 			return v, true
 		}
 	}
-	return "", false
-}
-
-func mapBoolField(m map[string]interface{}, key string) (bool, bool) {
-	if v, ok := m[key].(bool); ok {
-		return v, true
-	}
-	if data, ok := m["data"].(map[string]interface{}); ok {
-		if v, ok := data[key].(bool); ok {
-			return v, true
-		}
-	}
-	return false, false
-}
-
-func mapFieldAsMap(m map[string]interface{}, key string) (map[string]interface{}, bool) {
-	if v, ok := m[key].(map[string]interface{}); ok {
-		return v, true
-	}
-	if data, ok := m["data"].(map[string]interface{}); ok {
-		if v, ok := data[key].(map[string]interface{}); ok {
-			return v, true
-		}
-	}
-	return nil, false
+	var zero T
+	return zero, false
 }
 
 // OnError implements agentboot.MessageStreamer

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -163,13 +163,31 @@ func (h *streamingMessageHandler) handleAgentMessage(msg agentboot.AgentMessage)
 
 	switch msg.GetType() {
 	case agentboot.EventTypeAssistant:
-		// Assistant message - send to user (always show final assistant messages)
+		// Assistant message - send to user (always show final assistant messages).
+		// Flush any buffered tool renders first so messages remain the
+		// splitting boundary on this path too.
 		if assistantMsg, ok := msg.(*agentboot.AssistantMessage); ok {
 			text := assistantMsg.GetText()
 			if strings.TrimSpace(text) != "" {
+				h.flushToolBufferLocked()
 				h.sendMessage(text)
 			}
 		}
+		return nil
+
+	case agentboot.EventTypeToolUse:
+		// agentboot has no typed ToolUseMessage; fall back to raw data.
+		raw := msg.GetRawData()
+		name, _ := raw["tool_name"].(string)
+		input, _ := raw["input"].(map[string]interface{})
+		h.appendToolBuffer(renderToolUseSummary(name, input))
+		return nil
+
+	case agentboot.EventTypeToolResult:
+		raw := msg.GetRawData()
+		name, _ := raw["tool_name"].(string)
+		isError, _ := raw["is_error"].(bool)
+		h.appendToolBuffer(renderToolResultSummary(name, isError))
 		return nil
 
 	case agentboot.EventTypePermissionRequest:
@@ -201,7 +219,9 @@ func (h *streamingMessageHandler) handleAgentMessage(msg agentboot.AgentMessage)
 		return nil
 
 	case agentboot.EventTypeResult:
-		// Result events are handled by OnComplete
+		// Result events are handled by OnComplete; still flush so a trailing
+		// run of tool events shows up before OnComplete's completion banner.
+		h.flushToolBufferLocked()
 		if resultMsg, ok := msg.(*agentboot.ResultMessage); ok {
 			logrus.WithFields(logrus.Fields{
 				"status":  resultMsg.Status,
@@ -227,6 +247,54 @@ func (h *streamingMessageHandler) handleAgentMessage(msg agentboot.AgentMessage)
 		logrus.WithField("type", msg.GetType()).Debug("Unhandled agent message type")
 		return nil
 	}
+}
+
+// renderToolUseSummary produces a one-line summary of a tool invocation
+// for the main-path handlers (handleAgentMessage / handleAgentbootEvent /
+// handleMapMessage), where the rich claude.TextFormatter isn't available.
+// Output goes into the shared toolBuffer and is rendered the same as
+// handleClaudeMessage renders — verbose joins by newline, quiet collapses
+// to a count + preview.
+func renderToolUseSummary(name string, input map[string]interface{}) string {
+	if name == "" {
+		name = "tool"
+	}
+	summary := IconTool + " " + name
+	if hint := briefInputHint(input); hint != "" {
+		summary += " " + hint
+	}
+	return summary
+}
+
+// renderToolResultSummary mirrors renderToolUseSummary for tool_result events.
+func renderToolResultSummary(name string, isError bool) string {
+	label := "ok"
+	if isError {
+		label = "error"
+	}
+	if name == "" {
+		return "↳ " + label
+	}
+	return "↳ " + name + " " + label
+}
+
+// briefInputHint picks a short, recognizable string from a tool's input map
+// (file path, command, URL, query) so each buffered tool render carries
+// enough context to be useful in the aggregated message.
+func briefInputHint(input map[string]interface{}) string {
+	if input == nil {
+		return ""
+	}
+	for _, k := range []string{"command", "file_path", "path", "url", "query"} {
+		if v, ok := input[k].(string); ok && v != "" {
+			const max = 80
+			if len(v) > max {
+				v = v[:max-3] + "..."
+			}
+			return v
+		}
+	}
+	return ""
 }
 
 // handleClaudeMessage processes claude-specific messages.
@@ -356,12 +424,23 @@ func (h *streamingMessageHandler) handleAgentbootEvent(event agentboot.Event) er
 
 	switch event.Type {
 	case agentboot.EventTypeAssistant:
-		// Handle assistant message from event
+		// Handle assistant message from event. Flush buffered tool renders
+		// first so messages remain the splitting boundary.
 		if msg, ok := event.Data["message"].(string); ok && strings.TrimSpace(msg) != "" {
+			h.flushToolBufferLocked()
 			h.sendMessage(msg)
 		} else if msg, ok := event.Data["text"].(string); ok && strings.TrimSpace(msg) != "" {
+			h.flushToolBufferLocked()
 			h.sendMessage(msg)
 		}
+	case agentboot.EventTypeToolUse:
+		name, _ := event.Data["tool_name"].(string)
+		input, _ := event.Data["input"].(map[string]interface{})
+		h.appendToolBuffer(renderToolUseSummary(name, input))
+	case agentboot.EventTypeToolResult:
+		name, _ := event.Data["tool_name"].(string)
+		isError, _ := event.Data["is_error"].(bool)
+		h.appendToolBuffer(renderToolResultSummary(name, isError))
 	case agentboot.EventTypePermissionRequest:
 		logrus.WithFields(logrus.Fields{
 			"request_id": event.Data["request_id"],
@@ -370,6 +449,8 @@ func (h *streamingMessageHandler) handleAgentbootEvent(event agentboot.Event) er
 	case agentboot.EventTypePermissionResult:
 		logrus.WithField("request_id", event.Data["request_id"]).Debug("Permission result event")
 	case agentboot.EventTypeResult:
+		// Flush trailing tool renders before OnComplete emits the banner.
+		h.flushToolBufferLocked()
 		status, _ := event.Data["status"].(string)
 		logrus.WithField("status", status).Info("Agent result event received")
 	case agentboot.EventTypeInit, agentboot.EventTypeSystem:
@@ -404,20 +485,82 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 			}).Info("Permission request received (will be handled by IMPrompter)")
 		}
 	case agentboot.EventTypeAssistant:
-		// Assistant message - check for message in data
+		// Assistant message - check for message in data. Flush buffered tool
+		// renders first so messages remain the splitting boundary.
+		var text string
 		if data, ok := m["data"].(map[string]interface{}); ok {
-			if msg, ok := data["message"].(string); ok && strings.TrimSpace(msg) != "" {
-				h.sendMessage(msg)
-			}
-		} else if msg, ok := m["message"].(string); ok && strings.TrimSpace(msg) != "" {
-			h.sendMessage(msg)
-		} else if msg, ok := m["text"].(string); ok && strings.TrimSpace(msg) != "" {
-			h.sendMessage(msg)
+			text, _ = data["message"].(string)
 		}
+		if strings.TrimSpace(text) == "" {
+			text, _ = m["message"].(string)
+		}
+		if strings.TrimSpace(text) == "" {
+			text, _ = m["text"].(string)
+		}
+		if strings.TrimSpace(text) != "" {
+			h.flushToolBufferLocked()
+			h.sendMessage(text)
+		}
+	case agentboot.EventTypeToolUse:
+		name, input := toolFieldsFromMap(m)
+		h.appendToolBuffer(renderToolUseSummary(name, input))
+	case agentboot.EventTypeToolResult:
+		name, _ := mapToolName(m)
+		isError, _ := mapBoolField(m, "is_error")
+		h.appendToolBuffer(renderToolResultSummary(name, isError))
+	case agentboot.EventTypeResult:
+		// Flush trailing tool renders before OnComplete's banner.
+		h.flushToolBufferLocked()
 	default:
 		logrus.WithField("type", msgType).Debug("Unhandled map message type")
 	}
 	return nil
+}
+
+// toolFieldsFromMap pulls tool_name + input out of a map message that may
+// carry the fields either at the top level or under a "data" sub-object.
+func toolFieldsFromMap(m map[string]interface{}) (string, map[string]interface{}) {
+	name, _ := mapToolName(m)
+	if input, ok := mapFieldAsMap(m, "input"); ok {
+		return name, input
+	}
+	return name, nil
+}
+
+func mapToolName(m map[string]interface{}) (string, bool) {
+	if v, ok := m["tool_name"].(string); ok && v != "" {
+		return v, true
+	}
+	if data, ok := m["data"].(map[string]interface{}); ok {
+		if v, ok := data["tool_name"].(string); ok && v != "" {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func mapBoolField(m map[string]interface{}, key string) (bool, bool) {
+	if v, ok := m[key].(bool); ok {
+		return v, true
+	}
+	if data, ok := m["data"].(map[string]interface{}); ok {
+		if v, ok := data[key].(bool); ok {
+			return v, true
+		}
+	}
+	return false, false
+}
+
+func mapFieldAsMap(m map[string]interface{}, key string) (map[string]interface{}, bool) {
+	if v, ok := m[key].(map[string]interface{}); ok {
+		return v, true
+	}
+	if data, ok := m["data"].(map[string]interface{}); ok {
+		if v, ok := data[key].(map[string]interface{}); ok {
+			return v, true
+		}
+	}
+	return nil, false
 }
 
 // OnError implements agentboot.MessageStreamer

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -161,33 +161,15 @@ func (h *streamingMessageHandler) handleAgentMessage(msg agentboot.AgentMessage)
 		"verbose":   h.verbose,
 	}).Debug("Handling unified agent message")
 
+	if h.bufferToolEvent(msg.GetType(), toolFieldsFromRaw(msg.GetRawData())) {
+		return nil
+	}
+
 	switch msg.GetType() {
 	case agentboot.EventTypeAssistant:
-		// Assistant message - send to user (always show final assistant messages).
-		// Flush any buffered tool renders first so messages remain the
-		// splitting boundary on this path too.
 		if assistantMsg, ok := msg.(*agentboot.AssistantMessage); ok {
-			text := assistantMsg.GetText()
-			if strings.TrimSpace(text) != "" {
-				h.flushToolBufferLocked()
-				h.sendMessage(text)
-			}
+			h.sendText(assistantMsg.GetText())
 		}
-		return nil
-
-	case agentboot.EventTypeToolUse:
-		// agentboot has no typed ToolUseMessage; fall back to raw data.
-		raw := msg.GetRawData()
-		name, _ := raw["tool_name"].(string)
-		input, _ := raw["input"].(map[string]interface{})
-		h.appendToolBuffer(renderToolUseSummary(name, input))
-		return nil
-
-	case agentboot.EventTypeToolResult:
-		raw := msg.GetRawData()
-		name, _ := raw["tool_name"].(string)
-		isError, _ := raw["is_error"].(bool)
-		h.appendToolBuffer(renderToolResultSummary(name, isError))
 		return nil
 
 	case agentboot.EventTypePermissionRequest:
@@ -295,6 +277,68 @@ func briefInputHint(input map[string]interface{}) string {
 		}
 	}
 	return ""
+}
+
+// toolEventFields captures the fields the main-path handlers need from a
+// tool-related event, regardless of source shape (typed AgentMessage, Event,
+// or raw map). Field extraction lives per-source so the shared dispatcher
+// stays format-agnostic.
+type toolEventFields struct {
+	Name    string
+	Input   map[string]interface{}
+	IsError bool
+}
+
+// toolFieldsFromRaw reads tool fields from a flat map — the shape produced by
+// agentboot.AgentMessage.GetRawData() and agentboot.Event.Data.
+func toolFieldsFromRaw(raw map[string]interface{}) toolEventFields {
+	if raw == nil {
+		return toolEventFields{}
+	}
+	name, _ := raw["tool_name"].(string)
+	input, _ := raw["input"].(map[string]interface{})
+	isError, _ := raw["is_error"].(bool)
+	return toolEventFields{Name: name, Input: input, IsError: isError}
+}
+
+// toolFieldsFromNestedMap reads tool fields from a map message whose fields
+// may live either at the top level or nested under a "data" sub-object.
+func toolFieldsFromNestedMap(m map[string]interface{}) toolEventFields {
+	name, _ := mapToolName(m)
+	input, _ := mapFieldAsMap(m, "input")
+	isError, _ := mapBoolField(m, "is_error")
+	return toolEventFields{Name: name, Input: input, IsError: isError}
+}
+
+// bufferToolEvent appends the right render for a tool_use / tool_result event
+// to the shared tool buffer. Returns true when the event was a tool event and
+// fully handled, so callers can early-return. The caller must hold h.mu.
+//
+// This is the one place all three main-path handlers (AgentMessage / Event /
+// map) agree on: same fields in, same buffer out. Source-specific field
+// extraction stays in the caller via toolFieldsFrom* helpers.
+func (h *streamingMessageHandler) bufferToolEvent(eventType string, f toolEventFields) bool {
+	switch eventType {
+	case agentboot.EventTypeToolUse:
+		h.appendToolBuffer(renderToolUseSummary(f.Name, f.Input))
+		return true
+	case agentboot.EventTypeToolResult:
+		h.appendToolBuffer(renderToolResultSummary(f.Name, f.IsError))
+		return true
+	}
+	return false
+}
+
+// sendText flushes any buffered tool renders and then sends text to the user.
+// No-op when text is effectively empty. Keeps messages the splitting boundary
+// for output — the same invariant handleClaudeMessage relies on. The caller
+// must hold h.mu.
+func (h *streamingMessageHandler) sendText(text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	h.flushToolBufferLocked()
+	h.sendMessage(text)
 }
 
 // handleClaudeMessage processes claude-specific messages.
@@ -422,25 +466,17 @@ func (h *streamingMessageHandler) handleAgentbootEvent(event agentboot.Event) er
 		"chatID":    h.chatID,
 	}).Debug("Handling agentboot event")
 
+	if h.bufferToolEvent(event.Type, toolFieldsFromRaw(event.Data)) {
+		return nil
+	}
+
 	switch event.Type {
 	case agentboot.EventTypeAssistant:
-		// Handle assistant message from event. Flush buffered tool renders
-		// first so messages remain the splitting boundary.
-		if msg, ok := event.Data["message"].(string); ok && strings.TrimSpace(msg) != "" {
-			h.flushToolBufferLocked()
-			h.sendMessage(msg)
-		} else if msg, ok := event.Data["text"].(string); ok && strings.TrimSpace(msg) != "" {
-			h.flushToolBufferLocked()
-			h.sendMessage(msg)
+		text, _ := event.Data["message"].(string)
+		if strings.TrimSpace(text) == "" {
+			text, _ = event.Data["text"].(string)
 		}
-	case agentboot.EventTypeToolUse:
-		name, _ := event.Data["tool_name"].(string)
-		input, _ := event.Data["input"].(map[string]interface{})
-		h.appendToolBuffer(renderToolUseSummary(name, input))
-	case agentboot.EventTypeToolResult:
-		name, _ := event.Data["tool_name"].(string)
-		isError, _ := event.Data["is_error"].(bool)
-		h.appendToolBuffer(renderToolResultSummary(name, isError))
+		h.sendText(text)
 	case agentboot.EventTypePermissionRequest:
 		logrus.WithFields(logrus.Fields{
 			"request_id": event.Data["request_id"],
@@ -474,6 +510,10 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 		"chatID": h.chatID,
 	}).Debug("Handling map message")
 
+	if h.bufferToolEvent(msgType, toolFieldsFromNestedMap(m)) {
+		return nil
+	}
+
 	switch msgType {
 	case agentboot.EventTypePermissionRequest:
 		// Permission requests come from mock agent before going through IMPrompter
@@ -485,8 +525,6 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 			}).Info("Permission request received (will be handled by IMPrompter)")
 		}
 	case agentboot.EventTypeAssistant:
-		// Assistant message - check for message in data. Flush buffered tool
-		// renders first so messages remain the splitting boundary.
 		var text string
 		if data, ok := m["data"].(map[string]interface{}); ok {
 			text, _ = data["message"].(string)
@@ -497,17 +535,7 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 		if strings.TrimSpace(text) == "" {
 			text, _ = m["text"].(string)
 		}
-		if strings.TrimSpace(text) != "" {
-			h.flushToolBufferLocked()
-			h.sendMessage(text)
-		}
-	case agentboot.EventTypeToolUse:
-		name, input := toolFieldsFromMap(m)
-		h.appendToolBuffer(renderToolUseSummary(name, input))
-	case agentboot.EventTypeToolResult:
-		name, _ := mapToolName(m)
-		isError, _ := mapBoolField(m, "is_error")
-		h.appendToolBuffer(renderToolResultSummary(name, isError))
+		h.sendText(text)
 	case agentboot.EventTypeResult:
 		// Flush trailing tool renders before OnComplete's banner.
 		h.flushToolBufferLocked()
@@ -515,16 +543,6 @@ func (h *streamingMessageHandler) handleMapMessage(m map[string]interface{}) err
 		logrus.WithField("type", msgType).Debug("Unhandled map message type")
 	}
 	return nil
-}
-
-// toolFieldsFromMap pulls tool_name + input out of a map message that may
-// carry the fields either at the top level or under a "data" sub-object.
-func toolFieldsFromMap(m map[string]interface{}) (string, map[string]interface{}) {
-	name, _ := mapToolName(m)
-	if input, ok := mapFieldAsMap(m, "input"); ok {
-		return name, input
-	}
-	return name, nil
 }
 
 func mapToolName(m map[string]interface{}) (string, bool) {

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -251,18 +251,21 @@ func (h *streamingMessageHandler) handleClaudeMessage(claudeMsg claude.Message) 
 		return nil
 	}
 
-	// Text-bearing message. In quiet mode, still suppress user-echo and
-	// stream-event noise — only assistant text, agent results, and system
-	// notices reach the chat.
+	// Text-bearing message. Flush the buffered tool renders first so messages
+	// always act as the splitting boundary, even when the current message is
+	// itself going to be suppressed by the quiet filter below.
+	h.flushToolBufferLocked()
+
+	// In quiet mode, only assistant text and final agent results reach the
+	// chat; user echoes, system events, and stream-event noise are dropped.
 	if !h.verbose {
 		msgType := claudeMsg.GetType()
-		if msgType != "result" && msgType != "assistant" && msgType != "system" {
+		if msgType != "result" && msgType != "assistant" {
 			logrus.WithField("msgType", msgType).Debug("Quiet mode: suppressing non-result message")
 			return nil
 		}
 	}
 
-	h.flushToolBufferLocked()
 	h.sendMessage(formatted)
 	return nil
 }
@@ -332,7 +335,7 @@ func (h *streamingMessageHandler) renderToolBuffer(items []string) string {
 		previewN = len(items)
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "🔧 %d tool call(s)\n", len(items))
+	fmt.Fprintf(&b, "%s %d tool call(s)\n", IconTool, len(items))
 	for _, p := range items[:previewN] {
 		b.WriteString("• ")
 		b.WriteString(p)

--- a/internal/remote_control/bot/bot_stream_aggregate_test.go
+++ b/internal/remote_control/bot/bot_stream_aggregate_test.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -71,7 +72,9 @@ func TestStreamingHandler_BuffersToolsUntilTextFlush_Verbose(t *testing.T) {
 
 	sent := bot.snapshot()
 	require.Len(t, sent, 2, "expected one aggregated tool message followed by the text message")
-	assert.Contains(t, sent[0], "\n", "verbose flush should keep each tool on its own line")
+	// Both tool renders must end up in the same aggregated message.
+	assert.Contains(t, sent[0], "b.go", "Read render should appear in the aggregated message")
+	assert.Contains(t, sent[0], "ls", "Bash render should appear in the aggregated message")
 	assert.Contains(t, sent[1], "All done reading.")
 }
 
@@ -145,6 +148,46 @@ func TestStreamingHandler_AssistantWithTextDoesNotBuffer(t *testing.T) {
 	sent := bot.snapshot()
 	require.Len(t, sent, 1, "text-bearing assistant message should send immediately")
 	assert.Contains(t, sent[0], "Looking up file...")
+}
+
+func TestStreamingHandler_OnErrorFlushesBuffer(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, meta)
+
+	require.NoError(t, h.OnMessage(toolUseMsg("Read", "id-1", map[string]interface{}{"file_path": "/a.go"})))
+	h.OnError(errors.New("boom"))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 2, "OnError should flush buffered tools, then send the error message")
+	assert.Contains(t, sent[0], "a.go", "buffered tool render must surface before the error")
+	assert.Contains(t, sent[1], "boom")
+}
+
+// TestStreamingHandler_QuietSuppressedMessageStillFlushesBuffer guards the
+// "messages are the splitting boundary" invariant: even when a text-bearing
+// claude message would itself be suppressed by the quiet filter (e.g. a
+// UserMessage echo), the act of receiving it must still flush the buffered
+// tool renders so they don't pile up across boundaries.
+func TestStreamingHandler_QuietSuppressedMessageStillFlushesBuffer(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", false, meta)
+
+	require.NoError(t, h.OnMessage(toolUseMsg("Read", "id-1", map[string]interface{}{"file_path": "/a.go"})))
+	require.NoError(t, h.OnMessage(toolUseMsg("Read", "id-2", map[string]interface{}{"file_path": "/b.go"})))
+	assert.Empty(t, bot.snapshot(), "tools should be buffered before any text-bearing message")
+
+	// UserMessage is text-bearing but quiet mode drops it; the flush must
+	// still happen so the boundary is honored.
+	require.NoError(t, h.OnMessage(&claude.UserMessage{
+		Type:    claude.SDKUserMessage,
+		Message: "ignored in quiet mode",
+	}))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 1, "buffer should flush even though the user message itself is suppressed")
+	assert.Contains(t, sent[0], "2 tool call(s)")
 }
 
 func TestIsToolOnlyClaudeMessage(t *testing.T) {

--- a/internal/remote_control/bot/bot_stream_aggregate_test.go
+++ b/internal/remote_control/bot/bot_stream_aggregate_test.go
@@ -3,8 +3,10 @@ package bot
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
@@ -349,14 +351,16 @@ func TestBriefInputHint_PicksKnownKeys(t *testing.T) {
 	assert.Equal(t, "", briefInputHint(nil))
 	assert.Equal(t, "", briefInputHint(map[string]interface{}{"unrelated": 1}))
 
-	// Long values truncate to <=80 chars with an ellipsis.
-	long := ""
-	for i := 0; i < 100; i++ {
-		long += "x"
-	}
-	got := briefInputHint(map[string]interface{}{"command": long})
-	assert.LessOrEqual(t, len(got), 80)
-	assert.Contains(t, got, "...")
+	// Long ASCII values truncate to <=80 runes with an ellipsis.
+	got := briefInputHint(map[string]interface{}{"command": strings.Repeat("x", 100)})
+	assert.LessOrEqual(t, utf8.RuneCountInString(got), maxToolHintLen)
+	assert.Contains(t, got, "…")
+
+	// Multibyte values truncate on a rune boundary — the result must stay
+	// valid UTF-8, never sliced mid-rune.
+	gotCJK := briefInputHint(map[string]interface{}{"command": strings.Repeat("查", 100)})
+	assert.LessOrEqual(t, utf8.RuneCountInString(gotCJK), maxToolHintLen)
+	assert.True(t, utf8.ValidString(gotCJK), "truncated hint must be valid UTF-8")
 }
 
 func TestIsToolOnlyClaudeMessage(t *testing.T) {

--- a/internal/remote_control/bot/bot_stream_aggregate_test.go
+++ b/internal/remote_control/bot/bot_stream_aggregate_test.go
@@ -297,6 +297,52 @@ func TestHandleMapMessage_AggregatesToolEvents(t *testing.T) {
 	assert.Contains(t, sent[1], "ok")
 }
 
+// TestBufferToolEvent_SharedAcrossSources is the dispatcher-level test: it
+// asserts that the same eventType+fields produces the same buffer entry
+// regardless of which source extractor (Raw vs NestedMap) fed it. That's
+// the whole point of the refactor — if these ever diverge, all three
+// main-path handlers diverge too.
+func TestBufferToolEvent_SharedAcrossSources(t *testing.T) {
+	bot := &captureBot{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, &ResponseMeta{})
+
+	flatFields := toolFieldsFromRaw(map[string]interface{}{
+		"tool_name": "Bash",
+		"input":     map[string]interface{}{"command": "echo hi"},
+	})
+	nestedFields := toolFieldsFromNestedMap(map[string]interface{}{
+		"data": map[string]interface{}{
+			"tool_name": "Bash",
+			"input":     map[string]interface{}{"command": "echo hi"},
+		},
+	})
+	assert.Equal(t, flatFields, nestedFields,
+		"flat and nested extractors must produce identical toolEventFields")
+
+	h.mu.Lock()
+	require.True(t, h.bufferToolEvent(agentboot.EventTypeToolUse, flatFields))
+	require.True(t, h.bufferToolEvent(agentboot.EventTypeToolUse, nestedFields))
+	// Non-tool types are not handled by the dispatcher.
+	require.False(t, h.bufferToolEvent(agentboot.EventTypeAssistant, flatFields))
+	h.mu.Unlock()
+	assert.Empty(t, bot.snapshot(), "buffered tool events must not send yet")
+
+	// sendText flushes the buffer, then sends the text. Empty text is a no-op.
+	h.mu.Lock()
+	h.sendText("   ")
+	h.mu.Unlock()
+	assert.Empty(t, bot.snapshot(), "sendText(empty) must be a no-op")
+
+	h.mu.Lock()
+	h.sendText("done")
+	h.mu.Unlock()
+	sent := bot.snapshot()
+	require.Len(t, sent, 2)
+	// Aggregated tool message contains both Bash entries.
+	assert.Contains(t, sent[0], "Bash")
+	assert.Equal(t, "done", sent[1])
+}
+
 func TestBriefInputHint_PicksKnownKeys(t *testing.T) {
 	assert.Equal(t, "ls -la", briefInputHint(map[string]interface{}{"command": "ls -la"}))
 	assert.Equal(t, "/a.go", briefInputHint(map[string]interface{}{"file_path": "/a.go"}))

--- a/internal/remote_control/bot/bot_stream_aggregate_test.go
+++ b/internal/remote_control/bot/bot_stream_aggregate_test.go
@@ -1,0 +1,180 @@
+package bot
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot/claude"
+	imbot "github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+// captureBot records every SendMessage call. The other Bot methods are
+// inherited from stubBot (no-ops) and are sufficient for the streaming
+// handler tests, which only exercise SendMessage.
+type captureBot struct {
+	stubBot
+	mu   sync.Mutex
+	sent []string
+}
+
+func (b *captureBot) SendMessage(ctx context.Context, target string, opts *imbot.SendMessageOptions) (*imbot.SendResult, error) {
+	b.mu.Lock()
+	b.sent = append(b.sent, opts.Text)
+	b.mu.Unlock()
+	return &imbot.SendResult{MessageID: "msg"}, nil
+}
+
+func (b *captureBot) snapshot() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.sent))
+	copy(out, b.sent)
+	return out
+}
+
+func assistantText(text string) *claude.AssistantMessage {
+	return &claude.AssistantMessage{
+		Type: claude.SDKAssistantMessage,
+		Message: anthropic.Message{
+			Content: []anthropic.ContentBlockUnion{
+				{Type: claude.ContentBlockTypeText, Text: text},
+			},
+		},
+	}
+}
+
+func toolUseMsg(name, id string, input map[string]interface{}) *claude.ToolUseMessage {
+	return &claude.ToolUseMessage{
+		Type:      claude.SDKToolUseMessage,
+		Name:      name,
+		ToolUseID: id,
+		Input:     input,
+	}
+}
+
+func TestStreamingHandler_BuffersToolsUntilTextFlush_Verbose(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, meta)
+
+	require.NoError(t, h.OnMessage(toolUseMsg("Read", "id-1", map[string]interface{}{"file_path": "/a/b.go"})))
+	require.NoError(t, h.OnMessage(toolUseMsg("Bash", "id-2", map[string]interface{}{"command": "ls"})))
+
+	assert.Empty(t, bot.snapshot(), "tool-only messages should be buffered, not sent immediately")
+
+	require.NoError(t, h.OnMessage(assistantText("All done reading.")))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 2, "expected one aggregated tool message followed by the text message")
+	assert.Contains(t, sent[0], "\n", "verbose flush should keep each tool on its own line")
+	assert.Contains(t, sent[1], "All done reading.")
+}
+
+func TestStreamingHandler_QuietFlushRendersSummary(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", false, meta)
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, h.OnMessage(toolUseMsg("Read", "id", map[string]interface{}{
+			"file_path": "/x/y.go",
+		})))
+	}
+	assert.Empty(t, bot.snapshot(), "tool buffer should hold messages until a text-bearing message arrives")
+
+	require.NoError(t, h.OnMessage(assistantText("Summary text.")))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 2)
+	assert.Contains(t, sent[0], "5 tool call(s)", "quiet mode should aggregate to a count")
+	assert.Contains(t, sent[0], "(+2 more)", "quiet mode should fold extras beyond the preview")
+	assert.Contains(t, sent[1], "Summary text.")
+}
+
+func TestStreamingHandler_FlushOnThreshold(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, meta)
+
+	for i := 0; i < toolBufferFlushThreshold; i++ {
+		require.NoError(t, h.OnMessage(toolUseMsg("Bash", "id", map[string]interface{}{"command": "echo"})))
+	}
+	sent := bot.snapshot()
+	require.Len(t, sent, 1, "buffer should auto-flush at the threshold")
+	assert.NotEmpty(t, sent[0])
+}
+
+func TestStreamingHandler_OnCompleteFlushesBuffer(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{AgentType: "claude"}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, meta)
+
+	require.NoError(t, h.OnMessage(toolUseMsg("Read", "id-1", map[string]interface{}{"file_path": "/a.go"})))
+	h.OnComplete(nil)
+
+	sent := bot.snapshot()
+	require.GreaterOrEqual(t, len(sent), 2, "OnComplete should flush buffered tools before the completion banner")
+	assert.NotEmpty(t, sent[0])
+	assert.Contains(t, sent[len(sent)-1], MsgTaskDone)
+}
+
+func TestStreamingHandler_AssistantWithTextDoesNotBuffer(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, meta)
+
+	// AssistantMessage with both text and tool_use blocks is text-bearing:
+	// the formatter groups text + tools into a single render, so it must
+	// not be diverted into the buffer.
+	mixed := &claude.AssistantMessage{
+		Type: claude.SDKAssistantMessage,
+		Message: anthropic.Message{
+			Content: []anthropic.ContentBlockUnion{
+				{Type: claude.ContentBlockTypeText, Text: "Looking up file..."},
+				{Type: claude.ContentBlockTypeToolUse, ID: "id-1", Name: "Read"},
+			},
+		},
+	}
+	require.NoError(t, h.OnMessage(mixed))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 1, "text-bearing assistant message should send immediately")
+	assert.Contains(t, sent[0], "Looking up file...")
+}
+
+func TestIsToolOnlyClaudeMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  claude.Message
+		want bool
+	}{
+		{"tool_use", &claude.ToolUseMessage{Type: claude.SDKToolUseMessage}, true},
+		{"tool_result", &claude.ToolResultMessage{Type: claude.SDKToolResultMessage}, true},
+		{"assistant_text", assistantText("hi"), false},
+		{"assistant_tool_only", &claude.AssistantMessage{
+			Type: claude.SDKAssistantMessage,
+			Message: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: claude.ContentBlockTypeToolUse, ID: "x"},
+			}},
+		}, true},
+		{"assistant_whitespace_text_then_tool", &claude.AssistantMessage{
+			Type: claude.SDKAssistantMessage,
+			Message: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: claude.ContentBlockTypeText, Text: "   "},
+				{Type: claude.ContentBlockTypeToolUse, ID: "x"},
+			}},
+		}, true},
+		{"user", &claude.UserMessage{Type: claude.SDKUserMessage, Message: "hi"}, false},
+		{"result", &claude.ResultMessage{Type: claude.SDKResultMessage}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isToolOnlyClaudeMessage(tc.msg))
+		})
+	}
+}

--- a/internal/remote_control/bot/bot_stream_aggregate_test.go
+++ b/internal/remote_control/bot/bot_stream_aggregate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tingly-dev/tingly-box/agentboot"
 	"github.com/tingly-dev/tingly-box/agentboot/claude"
 	imbot "github.com/tingly-dev/tingly-box/imbot/core"
 )
@@ -188,6 +189,128 @@ func TestStreamingHandler_QuietSuppressedMessageStillFlushesBuffer(t *testing.T)
 	sent := bot.snapshot()
 	require.Len(t, sent, 1, "buffer should flush even though the user message itself is suppressed")
 	assert.Contains(t, sent[0], "2 tool call(s)")
+}
+
+// --- Main-path handler tests (handleAgentMessage / handleAgentbootEvent /
+// handleMapMessage). These are the production paths for both Claude Code and
+// Tingly Box agents; aggregation must work here, not only on the claude
+// stream path.
+
+func agentToolUseMsg(name, input string) agentboot.AgentMessage {
+	return agentboot.MessageFromEvent(agentboot.Event{
+		Type: agentboot.EventTypeToolUse,
+		Data: map[string]interface{}{
+			"tool_name": name,
+			"input":     map[string]interface{}{"command": input},
+		},
+	}, agentboot.AgentType("claude"))
+}
+
+func agentAssistantMsg(text string) agentboot.AgentMessage {
+	return agentboot.MessageFromEvent(agentboot.Event{
+		Type: agentboot.EventTypeAssistant,
+		Data: map[string]interface{}{"message": text},
+	}, agentboot.AgentType("claude"))
+}
+
+func TestHandleAgentMessage_AggregatesToolEvents(t *testing.T) {
+	bot := &captureBot{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, &ResponseMeta{})
+
+	require.NoError(t, h.OnMessage(agentToolUseMsg("Bash", "ls -la")))
+	require.NoError(t, h.OnMessage(agentToolUseMsg("Read", "/x.go")))
+	assert.Empty(t, bot.snapshot(), "tool events on the AgentMessage path should buffer")
+
+	require.NoError(t, h.OnMessage(agentAssistantMsg("done")))
+	sent := bot.snapshot()
+	require.Len(t, sent, 2, "expected one aggregated tool message then the assistant text")
+	assert.Contains(t, sent[0], "Bash")
+	assert.Contains(t, sent[0], "Read")
+	assert.Contains(t, sent[1], "done")
+}
+
+func TestHandleAgentbootEvent_AggregatesToolEvents(t *testing.T) {
+	bot := &captureBot{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, &ResponseMeta{})
+
+	// Force the Event path: pass an Event whose Type has no MessageFromEvent
+	// case, so OnMessage routes via handleAgentbootEvent fallback. We do this
+	// by calling handleAgentbootEvent directly under the handler lock to
+	// mirror what OnMessage does.
+	h.mu.Lock()
+	require.NoError(t, h.handleAgentbootEvent(agentboot.Event{
+		Type: agentboot.EventTypeToolUse,
+		Data: map[string]interface{}{
+			"tool_name": "Bash",
+			"input":     map[string]interface{}{"command": "ls"},
+		},
+	}))
+	require.NoError(t, h.handleAgentbootEvent(agentboot.Event{
+		Type: agentboot.EventTypeToolResult,
+		Data: map[string]interface{}{"tool_name": "Bash", "is_error": false},
+	}))
+	h.mu.Unlock()
+	assert.Empty(t, bot.snapshot(), "tool events on the Event path should buffer")
+
+	h.mu.Lock()
+	require.NoError(t, h.handleAgentbootEvent(agentboot.Event{
+		Type: agentboot.EventTypeAssistant,
+		Data: map[string]interface{}{"message": "wrap up"},
+	}))
+	h.mu.Unlock()
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 2)
+	assert.Contains(t, sent[0], "Bash")
+	assert.Contains(t, sent[1], "wrap up")
+}
+
+func TestHandleMapMessage_AggregatesToolEvents(t *testing.T) {
+	bot := &captureBot{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", true, &ResponseMeta{})
+
+	// Buffer two tool events (mix top-level fields and nested data) ...
+	require.NoError(t, h.OnMessage(map[string]interface{}{
+		"type":      agentboot.EventTypeToolUse,
+		"tool_name": "Read",
+		"input":     map[string]interface{}{"file_path": "/a.go"},
+	}))
+	require.NoError(t, h.OnMessage(map[string]interface{}{
+		"type": agentboot.EventTypeToolResult,
+		"data": map[string]interface{}{
+			"tool_name": "Read",
+			"is_error":  true,
+		},
+	}))
+	assert.Empty(t, bot.snapshot(), "tool events on the map path should buffer")
+
+	// ... and confirm an assistant map flushes them.
+	require.NoError(t, h.OnMessage(map[string]interface{}{
+		"type":    agentboot.EventTypeAssistant,
+		"message": "ok",
+	}))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 2)
+	assert.Contains(t, sent[0], "Read")
+	assert.Contains(t, sent[0], "error", "tool_result with is_error=true should surface as error")
+	assert.Contains(t, sent[1], "ok")
+}
+
+func TestBriefInputHint_PicksKnownKeys(t *testing.T) {
+	assert.Equal(t, "ls -la", briefInputHint(map[string]interface{}{"command": "ls -la"}))
+	assert.Equal(t, "/a.go", briefInputHint(map[string]interface{}{"file_path": "/a.go"}))
+	assert.Equal(t, "", briefInputHint(nil))
+	assert.Equal(t, "", briefInputHint(map[string]interface{}{"unrelated": 1}))
+
+	// Long values truncate to <=80 chars with an ellipsis.
+	long := ""
+	for i := 0; i < 100; i++ {
+		long += "x"
+	}
+	got := briefInputHint(map[string]interface{}{"command": long})
+	assert.LessOrEqual(t, len(got), 80)
+	assert.Contains(t, got, "...")
 }
 
 func TestIsToolOnlyClaudeMessage(t *testing.T) {

--- a/internal/remote_control/bot/output.go
+++ b/internal/remote_control/bot/output.go
@@ -8,19 +8,20 @@ import (
 // Centralized for easy customization and i18n support
 const (
 	// Icons
-	IconProject = "📁"  // Project/folder
-	IconChat    = "💬"  // Chat/conversation
-	IconUser    = "👤"  // User
-	IconSession = "🔄"  // Session
-	IconAgentTB = "🎯"  // Tingly-Box agent (@tb)
-	IconAgentCC = "💬"  // Claude Code agent (@cc)
-	IconDone    = "✅"  // Task completed
-	IconError   = "❌"  // Error
-	IconWarning = "⚠️" // Warning
-	IconStop    = "🛑"  // Stopped
-	IconProcess = "⏳"  // Processing
-	IconMock    = "🧪"  // Mock agent
-	IconTool    = "🔧"  // Tool call
+	IconProject    = "📁"  // Project/folder
+	IconChat       = "💬"  // Chat/conversation
+	IconUser       = "👤"  // User
+	IconSession    = "🔄"  // Session
+	IconAgentTB    = "🎯"  // Tingly-Box agent (@tb)
+	IconAgentCC    = "💬"  // Claude Code agent (@cc)
+	IconDone       = "✅"  // Task completed
+	IconError      = "❌"  // Error
+	IconWarning    = "⚠️" // Warning
+	IconStop       = "🛑"  // Stopped
+	IconProcess    = "⏳"  // Processing
+	IconMock       = "🧪"  // Mock agent
+	IconTool       = "🔧"  // Tool call
+	IconToolResult = "↳"  // Tool result
 )
 
 // Agent display names

--- a/internal/remote_control/bot/output.go
+++ b/internal/remote_control/bot/output.go
@@ -20,6 +20,7 @@ const (
 	IconStop    = "🛑"  // Stopped
 	IconProcess = "⏳"  // Processing
 	IconMock    = "🧪"  // Mock agent
+	IconTool    = "🔧"  // Tool call
 )
 
 // Agent display names


### PR DESCRIPTION
## Summary
Long agent runs flood the chat with one message per tool call. This PR buffers tool events and flushes them as a single aggregated message when text arrives — on all handler paths the bot uses, not just the Claude stream path. Verbose keeps one line per tool; quiet collapses to a count + preview.

## Before / After

```
 BEFORE (one message per event)        AFTER — verbose            AFTER — quiet
 ───────────────────────────────       ──────────────────         ─────────────────────────
 🔧 Bash tail -n 50 app.log            我看看日志和代码           我看看日志和代码
 ↳ Bash ok
 🔧 Read internal/api/auth.go          🔧 Bash tail -n 50 ...     🔧 6 tool call(s)
 ↳ Read ok                             ↳ Bash ok                 • 🔧 Bash tail -n 50 ...
 🔧 Grep "status 500"                  🔧 Read internal/api/...   • ↳ Bash ok
 ↳ Grep ok                             ↳ Read ok                 • 🔧 Read internal/api/...
 找到了：auth.go:88 ...                🔧 Grep "status 500"      …(+3 more)
                                       ↳ Grep ok
 = 7 chat messages                                               找到了：auth.go:88 ...
                                       找到了：auth.go:88 ...
                                                                 = 3 chat messages
                                       = 3 chat messages
```

A text-bearing message is the flush boundary. Buffer also auto-flushes at 20 entries, and on `OnComplete` / `OnError`.

## Key Changes
- **`toolBuffer`** on `streamingMessageHandler` accumulates tool renders between text messages; verbose joins by line, quiet shows `🔧 N tool call(s)` + first 3 + `…(+N more)`.
- **Main-path coverage**: `handleAgentMessage` / `handleAgentbootEvent` / `handleMapMessage` (the production paths for Claude Code *and* Tingly Box agents) now feed the same buffer — previously tool events there were log-only.
- **Shared primitives**: `bufferToolEvent` (event → buffer entry) and `sendText` (flush, then send) capture the boundary rule once; `toolFieldsFromRaw` / `toolFieldsFromNestedMap` + generic `mapNestedField[T]` handle per-source field extraction.

## Test plan
- [x] `go build` / `go vet` / `go test ./internal/remote_control/bot/`
- [x] Covers flush triggers, verbose/quiet rendering, per-handler aggregation, multibyte truncation
- [ ] Manual: run a tool-heavy chain in verbose and quiet modes

https://claude.ai/code/session_01V1RGjkRQnifk9ihpUnmTMk