### PR TITLE
feat(ui, ux): add model selection when creating new rules (select model first before rule)

### DIFF
--- a/frontend/src/hooks/useModelSelectDialog.tsx
+++ b/frontend/src/hooks/useModelSelectDialog.tsx
@@ -18,6 +18,7 @@ export interface UseModelSelectDialogOptions {
     rules: Rule[];
     onRuleChange?: (updatedRule: Rule) => void;
     showNotification: (message: string, severity: 'success' | 'error') => void;
+    onCreateFromModel?: (option: ProviderSelectTabOption) => void;
 }
 
 interface EditingServiceContext {
@@ -36,11 +37,12 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         rules,
         onRuleChange,
         showNotification,
+        onCreateFromModel,
     } = options;
 
     // Dialog state
     const [open, setOpen] = useState(false);
-    const [mode, setMode] = useState<'edit' | 'add'>('add');
+    const [mode, setMode] = useState<'edit' | 'add' | 'create-rule'>('add');
     const [editingProviderUuid, setEditingProviderUuid] = useState<string | null>(null);
     const [currentRuleUuid, setCurrentRuleUuid] = useState<string | null>(null);
     const [currentConfigRecord, setCurrentConfigRecord] = useState<ConfigRecord | null>(null);
@@ -112,8 +114,24 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         setOpen(true);
     }, [findService]);
 
+    const openModelSelectForCreate = useCallback(() => {
+        setMode('create-rule');
+        setCurrentRuleUuid(null);
+        setCurrentConfigRecord(null);
+        setEditingProviderUuid(null);
+        setModelSelectionCleared(false);
+        currentSmartRuleIndexRef.current = null;
+        editingServiceContextRef.current = null;
+        setOpen(true);
+    }, []);
+
     // Handle model selection
     const handleModelSelect = useCallback((option: ProviderSelectTabOption) => {
+        if (mode === 'create-rule') {
+            setOpen(false);
+            onCreateFromModel?.(option);
+            return;
+        }
         if (!currentConfigRecord || !currentRuleUuid) return;
 
         const smartRuleIndex = currentSmartRuleIndexRef.current;
@@ -238,7 +256,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         setEditingProviderUuid(null);
         currentSmartRuleIndexRef.current = null;
         editingServiceContextRef.current = null;
-    }, [currentConfigRecord, currentRuleUuid, mode, editingProviderUuid, rules, onRuleChange, showNotification]);
+    }, [currentConfigRecord, currentRuleUuid, mode, editingProviderUuid, rules, onRuleChange, showNotification, onCreateFromModel]);
 
     // Get selected provider and model for pre-selection
     const getSelectedProvider = useCallback(() => {
@@ -289,7 +307,11 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
             }}
         >
             <DialogTitle sx={{ textAlign: 'center' }}>
-                {mode === 'add' ? 'Add API Key' : 'Choose Model'}
+                {mode === 'create-rule'
+                    ? 'Select a model for your new rule'
+                    : mode === 'add'
+                        ? 'Add API Key'
+                        : 'Choose Model'}
             </DialogTitle>
             <DialogContent>
                 <ModelSelectDialog
@@ -306,6 +328,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
 
     return {
         openModelSelect,
+        openModelSelectForCreate,
         closeModelSelect,
         ModelSelectDialog: WrappedModelSelectDialog,
         isOpen: open,

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -1,5 +1,5 @@
 import ApiKeyModal from '@/components/ApiKeyModal';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Alert, Box, Fab, Snackbar} from '@mui/material';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import {useNavigate} from 'react-router-dom';
@@ -104,12 +104,42 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         setNewRuleUuid,
     } = useScrollToNewRule({rules});
 
+    // Routed through a ref so onCreateFromModel doesn't capture a stale createRule.
+    const createRuleRef = useRef(createRule);
+    useEffect(() => {
+        createRuleRef.current = createRule;
+    }, [createRule]);
+
+    const runCreateRuleAndScroll = useCallback(async (
+        options?: { providerUuid: string; model: string }
+    ) => {
+        const newUuid = await createRuleRef.current(options);
+        if (newUuid) {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    setNewRuleUuid(newUuid);
+                });
+            });
+        }
+    }, [setNewRuleUuid]);
+
     // Model select dialog
-    const {openModelSelect, ModelSelectDialog, isOpen: modelSelectDialogOpen} = useModelSelectDialog({
+    const {
+        openModelSelect,
+        openModelSelectForCreate,
+        ModelSelectDialog,
+        isOpen: modelSelectDialogOpen,
+    } = useModelSelectDialog({
         providers,
         rules,
         onRuleChange: handleRuleChange,
         showNotification,
+        onCreateFromModel: (option) => {
+            void runCreateRuleAndScroll({
+                providerUuid: option.provider.uuid,
+                model: option.model,
+            });
+        },
     });
 
     // Wrapper to maintain compatibility with existing RuleCard interface
@@ -127,18 +157,9 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         navigate('/api-keys?dialog=add');
     }, [navigate]);
 
-    const handleCreateRule = useCallback(async () => {
-        const newUuid = await createRule();
-        if (newUuid) {
-            // Set new rule UUID for scrolling after DOM is fully updated
-            // Use double RAF to ensure parent component has re-rendered
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    setNewRuleUuid(newUuid);
-                });
-            });
-        }
-    }, [createRule, setNewRuleUuid]);
+    const handleCreateRule = useCallback(() => {
+        openModelSelectForCreate();
+    }, [openModelSelectForCreate]);
 
     // Handle expand/collapse all
     const handleToggleExpandAll = useCallback(() => {

--- a/frontend/src/pages/scenario/hooks/useTemplatePageRules.ts
+++ b/frontend/src/pages/scenario/hooks/useTemplatePageRules.ts
@@ -12,14 +12,24 @@ export interface UseTemplatePageRulesParams {
     loadRules?: (scenario: string) => Promise<void>;
 }
 
+export interface CreateRuleOptions {
+    providerUuid: string;
+    model: string;
+}
+
 export interface UseTemplatePageRulesReturn {
     providerModelsByUuid: ProviderModelsDataByUuid;
     refreshingProviders: string[];
     handleRuleChange: (updatedRule: Rule) => void;
     handleProviderModelsChange: (providerUuid: string, models: any) => void;
     handleRefreshModels: (providerUuid: string) => Promise<void>;
-    handleCreateRule: () => Promise<string | null>;
+    handleCreateRule: (options?: CreateRuleOptions) => Promise<string | null>;
 }
+
+const resolveRuleName = (desiredName: string, existingNames: Set<string>): string => {
+    if (!existingNames.has(desiredName)) return desiredName;
+    return `${desiredName}-${uuidv4().slice(0, 6)}`;
+};
 
 export const useTemplatePageRules = ({
     rules,
@@ -70,19 +80,33 @@ export const useTemplatePageRules = ({
         }
     }, [showNotification]);
 
-    const handleCreateRule = useCallback(async (): Promise<string | null> => {
+    const handleCreateRule = useCallback(async (options?: CreateRuleOptions): Promise<string | null> => {
         if (!scenario) {
             showNotification('Cannot create rule: scenario not specified', 'error');
             return null;
         }
 
         try {
+            const existingNames = new Set(rules.map(r => r.request_model).filter(Boolean) as string[]);
+            const requestModel = options?.model
+                ? resolveRuleName(options.model, existingNames)
+                : `model-${uuidv4().slice(0, 8)}`;
+            const initialServices = options
+                ? [{
+                    provider: options.providerUuid,
+                    model: options.model,
+                    weight: 0,
+                    active: true,
+                    time_window: 0,
+                }]
+                : [];
+
             const newRuleData = {
                 scenario: scenario,
-                request_model: `model-${uuidv4().slice(0, 8)}`,
+                request_model: requestModel,
                 response_model: '',
                 active: true,
-                services: []
+                services: initialServices,
             };
 
             // Create rule via API (empty string for UUID signals backend to generate new UUID)


### PR DESCRIPTION
## Summary
Enhanced the rule creation flow to allow users to select a provider and model when creating a new rule, rather than creating empty rules that require manual configuration.

## Key Changes
- **TemplatePage.tsx**: 
  - Added `useRef` hook to maintain stable reference to `createRule` function, preventing stale closures
  - Introduced `runCreateRuleAndScroll` callback that creates a rule with optional provider/model options and handles scrolling to the new rule
  - Modified `handleCreateRule` to open the model selection dialog instead of directly creating a rule
  - Updated `useModelSelectDialog` integration to accept `onCreateFromModel` callback

- **useTemplatePageRules.ts**:
  - Added `CreateRuleOptions` interface to support provider UUID and model selection
  - Enhanced `handleCreateRule` to accept optional `CreateRuleOptions` parameter
  - Implemented `resolveRuleName` helper to handle model name conflicts by appending a UUID suffix
  - Modified rule creation logic to pre-populate `request_model` from selected model and initialize `services` array with the selected provider/model configuration

- **useModelSelectDialog.tsx**:
  - Added `onCreateFromModel` callback option to handle model selection for rule creation
  - Introduced new `'create-rule'` mode to the dialog state machine
  - Added `openModelSelectForCreate` function to open the dialog in create-rule mode
  - Updated `handleModelSelect` to handle create-rule mode by invoking the callback and closing the dialog
  - Updated dialog title to reflect the create-rule mode context

## Implementation Details
- Uses double `requestAnimationFrame` calls to ensure DOM updates complete before scrolling to newly created rule
- Maintains ref-based function updates to prevent stale closure issues in callbacks
- Automatically resolves naming conflicts when multiple rules use the same model name
- Pre-configures new rules with selected provider/model, reducing manual setup steps

https://claude.ai/code/session_01KU6Wrq71ZEAoVjT5za3yEN