### PR TITLE
Improve API key add flow: inline dialog + name preview with edit

### DIFF
--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -408,8 +408,7 @@ const ProviderFormDialog = ({
             setProviderInputValue(displayName);
 
             if (nameIsAutoFilled || !data.name) {
-                const autoName = t('providerDialog.keyName.autoFill', {title: displayName});
-                cb('name', autoName);
+                cb('name', displayName);
                 setNameIsAutoFilled(true);
             }
             return;
@@ -458,17 +457,17 @@ const ProviderFormDialog = ({
     };
 
     // Compute a sensible default name when the user leaves the field blank.
-    // Prefers the selected provider's display label; otherwise derives from
-    // the apiBase hostname; falls back to a generic label.
+    // Uses the provider's display label directly (no " API Key" suffix — the
+    // credential is already in the API Keys section, so the suffix is noise).
+    // Falls back to apiBase hostname or a generic label.
     const computeAutoName = useCallback((): string => {
         if (selectedProvider) {
-            const displayName = selectedProvider.alias || selectedProvider.name;
-            return t('providerDialog.keyName.autoFill', {title: displayName});
+            return selectedProvider.alias || selectedProvider.name;
         }
         const raw = data.apiBase || providerInputValue || '';
         try {
             const host = new URL(raw).hostname;
-            if (host) return t('providerDialog.keyName.autoFill', {title: host});
+            if (host) return host;
         } catch { /* not a URL */ }
         return t('providerDialog.keyName.fallback', {defaultValue: 'Custom Provider'});
     }, [selectedProvider, data.apiBase, providerInputValue, t]);

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -470,7 +470,7 @@ const ProviderFormDialog = ({
             const host = new URL(raw).hostname;
             if (host) return t('providerDialog.keyName.autoFill', {title: host});
         } catch { /* not a URL */ }
-        return t('providerDialog.keyName.autoFill', {title: 'Custom'});
+        return t('providerDialog.keyName.fallback', {defaultValue: 'Custom Provider'});
     }, [selectedProvider, data.apiBase, providerInputValue, t]);
 
     // Ensure a name exists before submit/verify. Writes back to parent so the

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -1,4 +1,4 @@
-import {Close, InfoOutlined, Visibility, VisibilityOff} from '@mui/icons-material';
+import {Close, Edit, InfoOutlined, Visibility, VisibilityOff} from '@mui/icons-material';
 import {
     Alert,
     Autocomplete,
@@ -928,6 +928,7 @@ const ProviderFormDialog = ({
                             <TextField
                                 size="small"
                                 fullWidth
+                                autoFocus
                                 label={t('providerDialog.keyName.label')}
                                 value={data.name}
                                 onChange={(e) => {
@@ -937,22 +938,57 @@ const ProviderFormDialog = ({
                                 }}
                                 placeholder={computeAutoName()}
                                 helperText={t('providerDialog.keyName.helper', {
-                                    defaultValue: 'Optional. Leave blank to auto-generate. You can rename later.',
+                                    defaultValue: 'Leave blank to use the auto-generated name. You can rename later.',
                                 })}
                             />
                         ) : (
-                            <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: -1}}>
-                                <Button
-                                    type="button"
-                                    size="small"
-                                    variant="text"
-                                    onClick={() => setShowNameField(true)}
-                                    sx={{textTransform: 'none', color: 'text.secondary'}}
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 1,
+                                    px: 1.5,
+                                    py: 0.75,
+                                    borderRadius: 1,
+                                    bgcolor: 'background.default',
+                                    border: 1,
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                <Typography variant="caption" color="text.secondary">
+                                    {t('providerDialog.keyName.label')}
+                                </Typography>
+                                <Typography
+                                    variant="body2"
+                                    sx={{
+                                        flex: 1,
+                                        color: 'text.primary',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                    }}
                                 >
-                                    {t('providerDialog.keyName.customizeAction', {
-                                        defaultValue: 'Customize name (optional)',
+                                    {data.name || computeAutoName()}
+                                </Typography>
+                                <Tooltip
+                                    title={t('providerDialog.keyName.editAction', {
+                                        defaultValue: 'Edit name',
                                     })}
-                                </Button>
+                                    arrow
+                                >
+                                    <IconButton
+                                        size="small"
+                                        onClick={() => {
+                                            if (!data.name) {
+                                                onChangeRef.current('name', computeAutoName());
+                                            }
+                                            setShowNameField(true);
+                                        }}
+                                        sx={{color: 'text.secondary'}}
+                                    >
+                                        <Edit fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
                             </Box>
                         )}
 

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -116,6 +116,10 @@ const ProviderFormDialog = ({
     const [protocolOpenAI, setProtocolOpenAI] = useState(false);
     const [protocolAnthropic, setProtocolAnthropic] = useState(false);
     const [nameIsAutoFilled, setNameIsAutoFilled] = useState(true);
+    // In add mode the name field is hidden by default — almost everyone wants
+    // the auto-generated label and can rename later. Edit mode always shows
+    // the field so users can see/edit the existing name.
+    const [showNameField, setShowNameField] = useState(mode === 'edit');
     const [providerInputValue, setProviderInputValue] = useState('');
     const [useGlobalProxy, setUseGlobalProxy] = useState(false);
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
@@ -214,6 +218,9 @@ const ProviderFormDialog = ({
         if (!open) return;
 
         setVerificationResult(null);
+        // Hide the optional name field on each add-mode open; edit-mode keeps
+        // it visible so users can review the existing name.
+        setShowNameField(mode === 'edit');
 
         if (mode === 'edit') {
             // Hydrate fusion state: existing fusion URLs imply the protocol
@@ -450,6 +457,31 @@ const ProviderFormDialog = ({
         }
     };
 
+    // Compute a sensible default name when the user leaves the field blank.
+    // Prefers the selected provider's display label; otherwise derives from
+    // the apiBase hostname; falls back to a generic label.
+    const computeAutoName = useCallback((): string => {
+        if (selectedProvider) {
+            const displayName = selectedProvider.alias || selectedProvider.name;
+            return t('providerDialog.keyName.autoFill', {title: displayName});
+        }
+        const raw = data.apiBase || providerInputValue || '';
+        try {
+            const host = new URL(raw).hostname;
+            if (host) return t('providerDialog.keyName.autoFill', {title: host});
+        } catch { /* not a URL */ }
+        return t('providerDialog.keyName.autoFill', {title: 'Custom'});
+    }, [selectedProvider, data.apiBase, providerInputValue, t]);
+
+    // Ensure a name exists before submit/verify. Writes back to parent so the
+    // submit payload carries the generated value.
+    const ensureName = (): string => {
+        if (data.name && data.name.trim()) return data.name;
+        const auto = computeAutoName();
+        onChangeRef.current('name', auto);
+        return auto;
+    };
+
     const handleVerify = async () => {
         if (noApiKey) {
             setVerificationResult(null);
@@ -464,7 +496,9 @@ const ProviderFormDialog = ({
                     ? selectedProvider.baseUrlAnthropic
                     : data.apiBase || providerInputValue;
 
-        if (!data.name || !apiBase || !data.token || !apiStyle) {
+        const effectiveName = ensureName();
+
+        if (!effectiveName || !apiBase || !data.token || !apiStyle) {
             setVerificationResult({
                 success: false,
                 message: t('providerDialog.verification.missingFields'),
@@ -516,6 +550,8 @@ const ProviderFormDialog = ({
             onChangeRef.current('apiBase', providerInputValue);
             onChangeRef.current('providerBaseUrls', undefined);
         }
+
+        ensureName();
 
         const shouldVerify = mode === 'add' ? !noApiKey : data.token !== '' && !noApiKey;
 
@@ -888,19 +924,37 @@ const ProviderFormDialog = ({
                             </Box>
                         </Box>
 
-                        <TextField
-                            size="small"
-                            fullWidth
-                            label={t('providerDialog.keyName.label')}
-                            value={data.name}
-                            onChange={(e) => {
-                                onChange('name', e.target.value);
-                                setVerificationResult(null);
-                                setNameIsAutoFilled(false);
-                            }}
-                            required
-                            placeholder={t('providerDialog.keyName.placeholder')}
-                        />
+                        {showNameField ? (
+                            <TextField
+                                size="small"
+                                fullWidth
+                                label={t('providerDialog.keyName.label')}
+                                value={data.name}
+                                onChange={(e) => {
+                                    onChange('name', e.target.value);
+                                    setVerificationResult(null);
+                                    setNameIsAutoFilled(false);
+                                }}
+                                placeholder={computeAutoName()}
+                                helperText={t('providerDialog.keyName.helper', {
+                                    defaultValue: 'Optional. Leave blank to auto-generate. You can rename later.',
+                                })}
+                            />
+                        ) : (
+                            <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: -1}}>
+                                <Button
+                                    type="button"
+                                    size="small"
+                                    variant="text"
+                                    onClick={() => setShowNameField(true)}
+                                    sx={{textTransform: 'none', color: 'text.secondary'}}
+                                >
+                                    {t('providerDialog.keyName.customizeAction', {
+                                        defaultValue: 'Customize name (optional)',
+                                    })}
+                                </Button>
+                            </Box>
+                        )}
 
                         <Box>
                             <TextField
@@ -1016,6 +1070,7 @@ const ProviderFormDialog = ({
                                 onChangeRef.current('apiBase', providerInputValue);
                                 onChangeRef.current('providerBaseUrls', undefined);
                             }
+                            ensureName();
                             onClose();
                             await onForceAdd?.();
                         }}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -237,7 +237,9 @@ export default {
     "keyName": {
       "label": "API Key Name",
       "placeholder": "e.g., OpenAI API Key",
-      "autoFill": "{{title}} API Key"
+      "autoFill": "{{title}} API Key",
+      "helper": "Optional. Leave blank to auto-generate. You can rename later.",
+      "customizeAction": "Customize name (optional)"
     },
     "providerOrUrl": {
       "label": "Provider or Custom Base URL",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -235,11 +235,11 @@ export default {
       "fusionModeDesc": "Fusion mode (checked): create one provider with both OpenAI and Anthropic base URLs."
     },
     "keyName": {
-      "label": "API Key Name",
+      "label": "Name",
       "placeholder": "e.g., OpenAI API Key",
       "autoFill": "{{title}} API Key",
-      "helper": "Optional. Leave blank to auto-generate. You can rename later.",
-      "customizeAction": "Customize name (optional)"
+      "helper": "Leave blank to use the auto-generated name. You can rename later.",
+      "editAction": "Edit name"
     },
     "providerOrUrl": {
       "label": "Provider or Custom Base URL",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -238,6 +238,7 @@ export default {
       "label": "Name",
       "placeholder": "e.g., OpenAI API Key",
       "autoFill": "{{title}} API Key",
+      "fallback": "Custom Provider",
       "helper": "Leave blank to use the auto-generated name. You can rename later.",
       "editAction": "Edit name"
     },

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -236,8 +236,7 @@ export default {
     },
     "keyName": {
       "label": "Name",
-      "placeholder": "e.g., OpenAI API Key",
-      "autoFill": "{{title}} API Key",
+      "placeholder": "e.g., OpenAI",
       "fallback": "Custom Provider",
       "helper": "Leave blank to use the auto-generated name. You can rename later.",
       "editAction": "Edit name"

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -237,7 +237,9 @@ export default {
     "keyName": {
       "label": "API 密钥名称",
       "placeholder": "例如：OpenAI API Key",
-      "autoFill": "{{title}} API 密钥"
+      "autoFill": "{{title}} API 密钥",
+      "helper": "可选。留空将自动生成，创建后可随时重命名。",
+      "customizeAction": "自定义名称（可选）"
     },
     "providerOrUrl": {
       "label": "提供商或自定义基础 URL",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -235,11 +235,11 @@ export default {
       "fusionModeDesc": "Fusion 模式（已勾选）：会创建一个同时包含 OpenAI 与 Anthropic Base URL 的 Provider。"
     },
     "keyName": {
-      "label": "API 密钥名称",
+      "label": "名称",
       "placeholder": "例如：OpenAI API Key",
       "autoFill": "{{title}} API 密钥",
-      "helper": "可选。留空将自动生成，创建后可随时重命名。",
-      "customizeAction": "自定义名称（可选）"
+      "helper": "留空将使用上方自动生成的名称，创建后可随时重命名。",
+      "editAction": "编辑名称"
     },
     "providerOrUrl": {
       "label": "提供商或自定义基础 URL",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -236,8 +236,7 @@ export default {
     },
     "keyName": {
       "label": "名称",
-      "placeholder": "例如：OpenAI API Key",
-      "autoFill": "{{title}} API 密钥",
+      "placeholder": "例如：OpenAI",
       "fallback": "自定义供应商",
       "helper": "留空将使用上方自动生成的名称，创建后可随时重命名。",
       "editAction": "编辑名称"

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -238,6 +238,7 @@ export default {
       "label": "名称",
       "placeholder": "例如：OpenAI API Key",
       "autoFill": "{{title}} API 密钥",
+      "fallback": "自定义供应商",
       "helper": "留空将使用上方自动生成的名称，创建后可随时重命名。",
       "editAction": "编辑名称"
     },

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -6,12 +6,14 @@ import {useNavigate} from 'react-router-dom';
 import EmptyStateGuide from '@/components/EmptyStateGuide';
 import RuleCard from '@/components/RuleCard.tsx';
 import ImportModal from '@/components/ImportModal';
+import ProviderFormDialog from '@/components/ProviderFormDialog';
 import UnifiedCard from '@/components/UnifiedCard';
 import type {TabTemplatePageProps} from './TemplatePage.types';
 import {TemplatePageActions} from './TemplatePageActions';
 import {useTemplatePageRules} from '@/pages/scenario/hooks/useTemplatePageRules';
 import {useScrollToNewRule} from '@/components/hooks/useScrollToNewRule';
 import {useModelSelectDialog} from '@/hooks/useModelSelectDialog';
+import {useProviderDialog} from '@/hooks/useProviderDialog';
 import {useScenarioPageInternal} from '@/pages/scenario/hooks/useScenarioPageInternal';
 import {useScenarioPageModal} from '@/pages/scenario/context/ScenarioPageContext';
 import api from '@/services/api';
@@ -152,10 +154,26 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         openModelSelect({ruleUuid, configRecord, providerUuid, mode});
     }, [openModelSelect]);
 
-    // Unified action handlers
+    // Add-provider dialog opened in place (rather than navigating away).
+    // Refreshes providers locally on success so the new key shows up
+    // without leaving the current scenario.
+    const {
+        providerDialogOpen,
+        providerFormData,
+        handleAddProviderClick,
+        handleProviderSubmit,
+        handleProviderForceAdd,
+        handleCloseDialog,
+        handleFieldChange,
+    } = useProviderDialog(showNotification, {
+        onProviderAdded: () => {
+            void onProvidersLoad?.();
+        },
+    });
+
     const handleAddApiKeyClick = useCallback(() => {
-        navigate('/api-keys?dialog=add');
-    }, [navigate]);
+        handleAddProviderClick();
+    }, [handleAddProviderClick]);
 
     const handleCreateRule = useCallback(() => {
         openModelSelectForCreate();
@@ -407,6 +425,16 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
                 onClose={() => setShowImportModal(false)}
                 onImport={handleImportData}
                 loading={importing}
+            />
+
+            <ProviderFormDialog
+                open={providerDialogOpen}
+                onClose={handleCloseDialog}
+                onSubmit={handleProviderSubmit}
+                onForceAdd={handleProviderForceAdd}
+                data={providerFormData}
+                onChange={handleFieldChange}
+                mode="add"
             />
 
             {showScrollTop && (


### PR DESCRIPTION
## Summary
Fixes two UX papercuts in the "Add API Key" flow:

1. **Scenario "use" pages no longer navigate away.** Previously clicking "Add API Key" on a Use page (Anthropic / Claude Code / Codex / etc.) navigated to `/api-keys?dialog=add`, losing the user's scenario context. The dialog now opens in place via `useProviderDialog`, and providers are refreshed locally on success.

2. **The provider dialog no longer demands a name.** The `Name` field was always required and shown prominently, even though in almost all cases the name can be auto-generated and renamed later. It's now a **read-only preview with an inline edit affordance**: users see exactly what the credential will be named (e.g. `OpenAI`, or `api.example.com` for custom URLs) and can click a pencil icon to override.

## Auto-name rules
- A provider is selected → the provider's display name directly (e.g. `OpenAI`, `Anthropic`). No " API Key" suffix — the credential already lives in the API Keys section.
- Free-form apiBase URL → the hostname (e.g. `api.example.com`).
- Nothing entered → `Custom Provider` (`自定义供应商`).

## Key changes
- `frontend/src/pages/scenario/components/TemplatePage.tsx`
  - Replaced `navigate('/api-keys?dialog=add')` with an inline `ProviderFormDialog` driven by the existing `useProviderDialog` hook.
  - On successful add, calls `onProvidersLoad` so the new key shows up without leaving the page.
- `frontend/src/components/ProviderFormDialog.tsx`
  - Added `computeAutoName()` — derives a name per the rules above.
  - Added `ensureName()` — writes the computed name back to the parent on submit / verify / force-add if the field is blank, so the payload is always valid.
  - Replaced the required `Name` TextField with a preview row (label + computed name + edit icon). Clicking the icon seeds the field with the computed name and switches to an editable TextField.
  - In `edit` mode the field still renders directly (users typically come here to change the name).
- `frontend/src/i18n/locales/{en,zh}.ts`
  - `providerDialog.keyName` updated: shorter `label`, new `helper` / `editAction` / `fallback`, removed the now-unused `autoFill` template.

## Test plan
- [ ] On a Use page with no credentials, click "Add API Key" — dialog opens inline, no navigation.
- [ ] After adding a key from a Use page, the new key appears without leaving the page.
- [ ] In the add dialog with no provider selected and no URL, the preview shows `Custom Provider` (zh: `自定义供应商`).
- [ ] Selecting a provider updates the preview to e.g. `Anthropic` (no " API Key" suffix).
- [ ] Entering a custom apiBase URL updates the preview to the hostname (e.g. `api.example.com`).
- [ ] Submitting without touching the name field creates a credential with the previewed name.
- [ ] Clicking the pencil icon reveals an editable field pre-filled with the computed name; edits are persisted on submit.
- [ ] Edit mode still shows the name as a regular editable field.

https://claude.ai/code/session_01DjHE9D2okRWVCKXLup2vLq