### PR TITLE
bugfix(protocol, codex): fix SSE streaming lifecycle and codex ID validation

### DIFF
--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -50,7 +50,6 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	// ChatGPT backend API does NOT support: max_tokens, max_completion_tokens, temperature, top_p, max_output_tokens
 
 	var filtered []byte
-	var isStreaming = false
 	if req.Body != nil && req.Method == "POST" {
 		body, err := io.ReadAll(req.Body)
 		_ = req.Body.Close()
@@ -84,11 +83,8 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		return nil, fmt.Errorf("request failed with status %s: %s", resp.Status, string(errorBody))
 	}
 
-	if isStreaming {
-		resp.Header.Set("Content-Type", "text/event-stream")
-	} else {
-		logrus.Warnf("[Codex] Do not support request without stream: %s", resp.Status)
-	}
+	resp.Header.Set("Content-Type", "text/event-stream")
+	logrus.Debugf("[Codex] Must use stream: %s", resp.Status)
 
 	return resp, nil
 }

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
 
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -36,9 +37,9 @@ type CodexClient struct {
 // NewCodexClient creates a new Codex client wrapper.
 // The base OpenAIClient is configured with codexRoundTripper for path/header transformation.
 func NewCodexClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*CodexClient, error) {
-	if provider.OAuthDetail == nil {
-		logrus.Fatalf("OpenAI client not configured with OAuthDetail")
-		panic("OpenAI client not configured with OAuthDetail")
+	if provider.OAuthDetail == nil && provider.APIBase != protocol.CodexAPIBase {
+		logrus.Fatalf("Codex client not configured with Codex provider")
+		panic("Codex client not configured with Codex provider")
 	}
 
 	if provider.OAuthDetail.Issuer != ai.IssuerCodex {
@@ -117,8 +118,6 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 
 // applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
 func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
-	logCodexInvalidInputIDs(req, "before_sanitize")
-
 	// Set default instructions if not provided
 	if !req.Instructions.Valid() {
 		req.Instructions = param.NewOpt(defaultInstructions)
@@ -171,87 +170,34 @@ func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
 	// ChatGPT Codex rejects empty/invalid item ids in input[].
 	// These ids are optional for request items, so strip malformed values.
 	sanitizeResponseInputIDs(req)
-	logCodexInvalidInputIDs(req, "after_sanitize")
 
 	// Set the modified extra fields back
 	req.SetExtraFields(extraFields)
 }
 
 // sanitizeResponseInputIDs sanitizes item IDs in ResponseNewParams.Input for Codex.
-// ChatGPT Codex rejects empty/invalid item ids, so we strip malformed values.
+// ChatGPT Codex rejects empty/invalid item ids, so we strip malformed values
+// and drop reasoning items whose required plain-string ID cannot be omitted.
 func sanitizeResponseInputIDs(req *responses.ResponseNewParams) {
-	// Check if Input is set and is of type OfInputItemList
 	if req.Input.OfInputItemList == nil {
 		return
 	}
 
 	inputItems := req.Input.OfInputItemList
+	sanitized := inputItems[:0]
 	for i := range inputItems {
-		item := &inputItems[i]
-		sanitizeInputItemID(item)
-	}
-
-	req.Input.OfInputItemList = inputItems
-}
-
-func logCodexInvalidInputIDs(req *responses.ResponseNewParams, stage string) {
-	if req.Input.OfInputItemList == nil {
-		return
-	}
-
-	for i := range req.Input.OfInputItemList {
-		logCodexInvalidItemIDs(req.Input.OfInputItemList[i], i, stage)
-	}
-}
-
-func logCodexInvalidItemIDs(item responses.ResponseInputItemUnionParam, index int, stage string) {
-	check := func(kind string, field string, id string, valid bool) {
-		trimmed := strings.TrimSpace(id)
-		if trimmed == "" || !valid {
-			logrus.Warnf("[Codex] Invalid input item id detected stage=%s index=%d kind=%s field=%s raw_id=%q trimmed_id=%q", stage, index, kind, field, id, trimmed)
-		} else {
-			logrus.Warnf("[Codex] Valid input item id observed stage=%s index=%d kind=%s field=%s raw_id=%q", stage, index, kind, field, id)
+		item := inputItems[i]
+		if sanitizeInputItemID(&item) {
+			sanitized = append(sanitized, item)
 		}
 	}
 
-	if item.OfFunctionCall != nil && item.OfFunctionCall.ID.Valid() {
-		check("function_call", "id", item.OfFunctionCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfFunctionCall.ID.Value)))
-	}
-	if item.OfFunctionCallOutput != nil && item.OfFunctionCallOutput.ID.Valid() {
-		check("function_call_output", "id", item.OfFunctionCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfFunctionCallOutput.ID.Value)))
-	}
-	if item.OfComputerCallOutput != nil && item.OfComputerCallOutput.ID.Valid() {
-		check("computer_call_output", "id", item.OfComputerCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfComputerCallOutput.ID.Value)))
-	}
-	if item.OfCustomToolCall != nil && item.OfCustomToolCall.ID.Valid() {
-		check("custom_tool_call", "id", item.OfCustomToolCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfCustomToolCall.ID.Value)))
-	}
-	if item.OfCustomToolCallOutput != nil && item.OfCustomToolCallOutput.ID.Valid() {
-		check("custom_tool_call_output", "id", item.OfCustomToolCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfCustomToolCallOutput.ID.Value)))
-	}
-	if item.OfToolSearchCall != nil && item.OfToolSearchCall.ID.Valid() {
-		check("tool_search_call", "id", item.OfToolSearchCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfToolSearchCall.ID.Value)))
-	}
-	if item.OfShellCall != nil && item.OfShellCall.ID.Valid() {
-		check("shell_call", "id", item.OfShellCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfShellCall.ID.Value)))
-	}
-	if item.OfShellCallOutput != nil && item.OfShellCallOutput.ID.Valid() {
-		check("shell_call_output", "id", item.OfShellCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfShellCallOutput.ID.Value)))
-	}
-	if item.OfApplyPatchCall != nil && item.OfApplyPatchCall.ID.Valid() {
-		check("apply_patch_call", "id", item.OfApplyPatchCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfApplyPatchCall.ID.Value)))
-	}
-	if item.OfApplyPatchCallOutput != nil && item.OfApplyPatchCallOutput.ID.Valid() {
-		check("apply_patch_call_output", "id", item.OfApplyPatchCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfApplyPatchCallOutput.ID.Value)))
-	}
-	if item.OfMcpApprovalResponse != nil && item.OfMcpApprovalResponse.ID.Valid() {
-		check("mcp_approval_response", "id", item.OfMcpApprovalResponse.ID.Value, isValidCodexID(strings.TrimSpace(item.OfMcpApprovalResponse.ID.Value)))
-	}
+	req.Input.OfInputItemList = sanitized
 }
 
 // sanitizeInputItemID sanitizes the ID field in a ResponseInputItemUnionParam
 // by clearing invalid IDs directly on the inner SDK struct fields.
-func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) {
+func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) bool {
 	if item.OfFunctionCall != nil {
 		sanitizeOptID(&item.OfFunctionCall.ID)
 	}
@@ -267,6 +213,14 @@ func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) {
 	if item.OfCustomToolCallOutput != nil {
 		sanitizeOptID(&item.OfCustomToolCallOutput.ID)
 	}
+	if item.OfReasoning != nil {
+		item.OfReasoning.ID = strings.TrimSpace(item.OfReasoning.ID)
+		if item.OfReasoning.ID == "" || !isValidCodexID(item.OfReasoning.ID) {
+			logrus.Warnf("[Codex] Dropping reasoning input item with invalid id: %q", item.OfReasoning.ID)
+			return false
+		}
+	}
+	return true
 }
 
 func sanitizeOptID(id *param.Opt[string]) {

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -117,6 +117,8 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 
 // applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
 func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
+	logCodexInvalidInputIDs(req, "before_sanitize")
+
 	// Set default instructions if not provided
 	if !req.Instructions.Valid() {
 		req.Instructions = param.NewOpt(defaultInstructions)
@@ -169,6 +171,7 @@ func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
 	// ChatGPT Codex rejects empty/invalid item ids in input[].
 	// These ids are optional for request items, so strip malformed values.
 	sanitizeResponseInputIDs(req)
+	logCodexInvalidInputIDs(req, "after_sanitize")
 
 	// Set the modified extra fields back
 	req.SetExtraFields(extraFields)
@@ -189,6 +192,61 @@ func sanitizeResponseInputIDs(req *responses.ResponseNewParams) {
 	}
 
 	req.Input.OfInputItemList = inputItems
+}
+
+func logCodexInvalidInputIDs(req *responses.ResponseNewParams, stage string) {
+	if req.Input.OfInputItemList == nil {
+		return
+	}
+
+	for i := range req.Input.OfInputItemList {
+		logCodexInvalidItemIDs(req.Input.OfInputItemList[i], i, stage)
+	}
+}
+
+func logCodexInvalidItemIDs(item responses.ResponseInputItemUnionParam, index int, stage string) {
+	check := func(kind string, field string, id string, valid bool) {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" || !valid {
+			logrus.Warnf("[Codex] Invalid input item id detected stage=%s index=%d kind=%s field=%s raw_id=%q trimmed_id=%q", stage, index, kind, field, id, trimmed)
+		} else {
+			logrus.Warnf("[Codex] Valid input item id observed stage=%s index=%d kind=%s field=%s raw_id=%q", stage, index, kind, field, id)
+		}
+	}
+
+	if item.OfFunctionCall != nil && item.OfFunctionCall.ID.Valid() {
+		check("function_call", "id", item.OfFunctionCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfFunctionCall.ID.Value)))
+	}
+	if item.OfFunctionCallOutput != nil && item.OfFunctionCallOutput.ID.Valid() {
+		check("function_call_output", "id", item.OfFunctionCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfFunctionCallOutput.ID.Value)))
+	}
+	if item.OfComputerCallOutput != nil && item.OfComputerCallOutput.ID.Valid() {
+		check("computer_call_output", "id", item.OfComputerCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfComputerCallOutput.ID.Value)))
+	}
+	if item.OfCustomToolCall != nil && item.OfCustomToolCall.ID.Valid() {
+		check("custom_tool_call", "id", item.OfCustomToolCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfCustomToolCall.ID.Value)))
+	}
+	if item.OfCustomToolCallOutput != nil && item.OfCustomToolCallOutput.ID.Valid() {
+		check("custom_tool_call_output", "id", item.OfCustomToolCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfCustomToolCallOutput.ID.Value)))
+	}
+	if item.OfToolSearchCall != nil && item.OfToolSearchCall.ID.Valid() {
+		check("tool_search_call", "id", item.OfToolSearchCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfToolSearchCall.ID.Value)))
+	}
+	if item.OfShellCall != nil && item.OfShellCall.ID.Valid() {
+		check("shell_call", "id", item.OfShellCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfShellCall.ID.Value)))
+	}
+	if item.OfShellCallOutput != nil && item.OfShellCallOutput.ID.Valid() {
+		check("shell_call_output", "id", item.OfShellCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfShellCallOutput.ID.Value)))
+	}
+	if item.OfApplyPatchCall != nil && item.OfApplyPatchCall.ID.Valid() {
+		check("apply_patch_call", "id", item.OfApplyPatchCall.ID.Value, isValidCodexID(strings.TrimSpace(item.OfApplyPatchCall.ID.Value)))
+	}
+	if item.OfApplyPatchCallOutput != nil && item.OfApplyPatchCallOutput.ID.Valid() {
+		check("apply_patch_call_output", "id", item.OfApplyPatchCallOutput.ID.Value, isValidCodexID(strings.TrimSpace(item.OfApplyPatchCallOutput.ID.Value)))
+	}
+	if item.OfMcpApprovalResponse != nil && item.OfMcpApprovalResponse.ID.Valid() {
+		check("mcp_approval_response", "id", item.OfMcpApprovalResponse.ID.Value, isValidCodexID(strings.TrimSpace(item.OfMcpApprovalResponse.ID.Value)))
+	}
 }
 
 // sanitizeInputItemID sanitizes the ID field in a ResponseInputItemUnionParam

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -83,7 +83,7 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 	)
 
 	// Process the stream with context cancellation checking
-	c.Stream(func(w io.Writer) bool {
+	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
 		case <-c.Request.Context().Done():

--- a/internal/protocol/stream/anthropic_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_to_openai_responses.go
@@ -69,7 +69,7 @@ func HandleAnthropicToOpenAIResponsesStream(
 	completedSent := false
 
 	// Process the stream
-	c.Stream(func(w io.Writer) bool {
+	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
 		case <-c.Request.Context().Done():

--- a/internal/protocol/stream/anthropic_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_to_openai_responses.go
@@ -548,7 +548,11 @@ func sendResponsesEvent(c *gin.Context, event any, flusher http.Flusher) {
 	default:
 	}
 
-	OpenAISSE(c, event)
+	if e, ok := event.(responsesEvent); ok {
+		OpenAIResponsesEvent(c, e.EventType(), event)
+	} else {
+		OpenAISSE(c, event)
+	}
 }
 
 // sendResponsesErrorEvent sends an error event in Responses API format

--- a/internal/protocol/stream/loop.go
+++ b/internal/protocol/stream/loop.go
@@ -1,0 +1,37 @@
+package stream
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// StreamLoop is a drop-in replacement for c.Stream() that does NOT finalize the
+// HTTP response writer when it returns.
+//
+// MENTION: c.Stream() closes the HTTP response writer on exit, so any writes after
+// it (error events, final chunks, usage stats) are silently dropped. Use StreamLoop
+// whenever the caller needs to write to the response after the loop ends.
+//
+// Returns true if the client disconnected mid-stream (mirrors c.Stream behavior).
+func StreamLoop(c *gin.Context, step func(w io.Writer) bool) bool {
+	w := c.Writer
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return false
+	}
+	clientGone := w.CloseNotify()
+	for {
+		select {
+		case <-clientGone:
+			return true
+		default:
+			if !step(w) {
+				flusher.Flush()
+				return false
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/protocol/stream/openai_chat_to_responses.go
+++ b/internal/protocol/stream/openai_chat_to_responses.go
@@ -98,7 +98,7 @@ func HandleOpenAIChatToResponsesStream(c *gin.Context, stream *openaistream.Stre
 	completedSent := false
 
 	// Process the stream
-	c.Stream(func(w io.Writer) bool {
+	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
 		case <-c.Request.Context().Done():

--- a/internal/protocol/stream/openai_chat_to_responses.go
+++ b/internal/protocol/stream/openai_chat_to_responses.go
@@ -238,7 +238,7 @@ func HandleOpenAIChatToResponsesStream(c *gin.Context, stream *openaistream.Stre
 				Type:    "stream_error",
 			},
 		}
-		OpenAISSE(c, errorEvent)
+		OpenAIResponsesEvent(c, errorEvent.EventType(), errorEvent)
 
 		return protocol.NewTokenUsageWithCache(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens)), err
 	}
@@ -269,7 +269,7 @@ func sendResponsesCreatedEvent(c *gin.Context, state *chatToResponsesState, flus
 		SequenceNumber: nextSequenceNumber(state),
 		Response:       newResponsesWireResponse(state, "in_progress", nil, ""),
 	}
-	OpenAISSE(c, event)
+	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
 func sendResponsesOutputTextItemAdded(c *gin.Context, state *chatToResponsesState, flusher http.Flusher) {
@@ -282,7 +282,7 @@ func sendResponsesOutputTextItemAdded(c *gin.Context, state *chatToResponsesStat
 		OutputIndex:    0,
 		Item:           newResponsesMessageItem(state.textItemID, "in_progress", ""),
 	}
-	OpenAISSE(c, event)
+	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
 // sendResponsesOutputTextDelta sends response.output_text.delta event
@@ -296,7 +296,7 @@ func sendResponsesOutputTextDelta(c *gin.Context, state *chatToResponsesState, d
 		Delta:          delta,
 		Logprobs:       []interface{}{},
 	}
-	OpenAISSE(c, event)
+	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
 // sendResponsesOutputItemAdded sends response.output_item.added event for tool calls
@@ -310,7 +310,7 @@ func sendResponsesOutputItemAdded(c *gin.Context, state *chatToResponsesState, i
 		OutputIndex:    outputIndex,
 		Item:           newResponsesFunctionCallItem(itemID, callID, name, "", "in_progress"),
 	}
-	OpenAISSE(c, event)
+	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
 // sendResponsesFunctionCallArgumentsDelta sends response.function_call_arguments.delta event
@@ -322,7 +322,7 @@ func sendResponsesFunctionCallArgumentsDelta(c *gin.Context, state *chatToRespon
 		OutputIndex:    outputIndex,
 		Delta:          delta,
 	}
-	OpenAISSE(c, event)
+	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
 // sendResponsesCompletedEvent sends the response.completed event
@@ -338,7 +338,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 			Text:           text,
 			Logprobs:       []interface{}{},
 		}
-		OpenAISSE(c, textDone)
+		OpenAIResponsesEvent(c, textDone.EventType(), textDone)
 
 		textItemDone := responsesOutputItemDoneEvent{
 			Type:           "response.output_item.done",
@@ -346,7 +346,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 			OutputIndex:    0,
 			Item:           newResponsesMessageItem(state.textItemID, "completed", text),
 		}
-		OpenAISSE(c, textItemDone)
+		OpenAIResponsesEvent(c, textItemDone.EventType(), textItemDone)
 	}
 
 	sortedIndexes := make([]int, 0, len(state.pendingToolCalls))
@@ -370,7 +370,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 			Name:           ptc.name,
 			Arguments:      arguments,
 		}
-		OpenAISSE(c, argumentsDone)
+		OpenAIResponsesEvent(c, argumentsDone.EventType(), argumentsDone)
 
 		itemDone := responsesOutputItemDoneEvent{
 			Type:           "response.output_item.done",
@@ -378,7 +378,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 			OutputIndex:    ptc.outputIdx,
 			Item:           newResponsesFunctionCallItem(ptc.itemID, callID, ptc.name, arguments, "completed"),
 		}
-		OpenAISSE(c, itemDone)
+		OpenAIResponsesEvent(c, itemDone.EventType(), itemDone)
 	}
 
 	var output []responsesOutputItemWire
@@ -401,7 +401,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 		Response:       newResponsesWireResponse(state, "completed", output, model),
 	}
 
-	OpenAISSE(c, event)
+	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
 func newResponsesWireResponse(state *chatToResponsesState, status string, output []responsesOutputItemWire, model string) responsesWireResponse {

--- a/internal/protocol/stream/openai_helper.go
+++ b/internal/protocol/stream/openai_helper.go
@@ -12,20 +12,30 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func OpenAIResponsesEvent(c *gin.Context, event string, v any) {
+	switch vv := v.(type) {
+	case []byte:
+		c.Writer.WriteString(fmt.Sprintf("event: %s\ndata: %s\n\n", event, string(vv)))
+	case string:
+		c.Writer.WriteString(fmt.Sprintf("event: %s\ndata: %s\n\n", event, vv))
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			logrus.Errorf("OpenAISSE: failed to marshal: %v", err)
+			return
+		}
+		c.Writer.WriteString(fmt.Sprintf("event: %s\ndata: %s\n\n", event, data))
+	}
+}
+
 // OpenAISSE marshals v to JSON and writes it as an OpenAI-style SSE data line, then flushes.
 // MENTION: Must keep extra space after "data:" to match OpenAI wire format.
 func OpenAISSE(c *gin.Context, v any) {
 	switch vv := v.(type) {
 	case []byte:
 		c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", string(vv)))
-		if flusher, ok := c.Writer.(http.Flusher); ok {
-			flusher.Flush()
-		}
 	case string:
 		c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", vv))
-		if flusher, ok := c.Writer.(http.Flusher); ok {
-			flusher.Flush()
-		}
 	default:
 		data, err := json.Marshal(v)
 		if err != nil {
@@ -33,18 +43,12 @@ func OpenAISSE(c *gin.Context, v any) {
 			return
 		}
 		c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", data))
-		if flusher, ok := c.Writer.(http.Flusher); ok {
-			flusher.Flush()
-		}
 	}
 }
 
 // OpenAISSEDone writes the SSE [DONE] terminator and flushes.
 func OpenAISSEDone(c *gin.Context) {
 	c.Writer.WriteString("data: [DONE]\n\n")
-	if flusher, ok := c.Writer.(http.Flusher); ok {
-		flusher.Flush()
-	}
 }
 
 func nextSequenceNumber(state *chatToResponsesState) int64 {

--- a/internal/protocol/stream/openai_helper.go
+++ b/internal/protocol/stream/openai_helper.go
@@ -15,14 +15,27 @@ import (
 // OpenAISSE marshals v to JSON and writes it as an OpenAI-style SSE data line, then flushes.
 // MENTION: Must keep extra space after "data:" to match OpenAI wire format.
 func OpenAISSE(c *gin.Context, v any) {
-	data, err := json.Marshal(v)
-	if err != nil {
-		logrus.Errorf("OpenAISSE: failed to marshal: %v", err)
-		return
-	}
-	c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", data))
-	if flusher, ok := c.Writer.(http.Flusher); ok {
-		flusher.Flush()
+	switch vv := v.(type) {
+	case []byte:
+		c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", string(vv)))
+		if flusher, ok := c.Writer.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	case string:
+		c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", vv))
+		if flusher, ok := c.Writer.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			logrus.Errorf("OpenAISSE: failed to marshal: %v", err)
+			return
+		}
+		c.Writer.WriteString(fmt.Sprintf("data: %s\n\n", data))
+		if flusher, ok := c.Writer.(http.Flusher); ok {
+			flusher.Flush()
+		}
 	}
 }
 

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -314,28 +315,19 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 	c.Header("Access-Control-Allow-Origin", "*")
 	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
-	flusher, ok := c.Writer.(http.Flusher)
-	if !ok {
-		return protocol.ZeroTokenUsage(), fmt.Errorf("streaming not supported by this connection")
-	}
-
 	var inputTokens, outputTokens, cacheTokens int64
 	var hasUsage bool
 
-	// MENTION: Do NOT replace this loop with c.Stream(). c.Stream() finalizes the HTTP response writer
-	// when it returns, so any writes after the loop (error events, etc.) are silently dropped.
-	// This manual loop + explicit flusher.Flush() keeps full control over connection lifetime.
-	for {
-		// Check context cancellation
+	StreamLoop(c, func(w io.Writer) bool {
 		select {
 		case <-c.Request.Context().Done():
 			logrus.Debug("Client disconnected, stopping Responses stream")
-			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+			return false
 		default:
 		}
 
 		if !stream.Next() {
-			break
+			return false
 		}
 
 		evt := stream.Current()
@@ -355,7 +347,6 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		eventRaw := evt.RawJSON()
 		eventType := evt.Type
 
-		// Extract cached tokens using gjson
 		if gjson.Get(eventRaw, "response.usage.input_tokens_details").Exists() {
 			if cachedTokens := gjson.Get(eventRaw, "response.usage.input_tokens_details.cached_tokens"); cachedTokens.Exists() {
 				cacheTokens = cachedTokens.Int()
@@ -370,7 +361,6 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 			}
 		}
 
-		// Apply model override if the event contains a response object with a model field
 		if len(eventRaw) > 0 {
 			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
 				if modified, err := sjson.Set(eventRaw, "response.model", responseModel); err == nil {
@@ -380,8 +370,8 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		}
 
 		OpenAIResponsesEvent(c, eventType, eventRaw)
-		flusher.Flush()
-	}
+		return true
+	})
 
 	if err := stream.Err(); err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
@@ -398,7 +388,6 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 			},
 		}
 		OpenAIResponsesEvent(c, "error", errorChunk)
-		flusher.Flush()
 		return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
 	}
 

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -315,42 +314,28 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 	c.Header("Access-Control-Allow-Origin", "*")
 	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return protocol.ZeroTokenUsage(), fmt.Errorf("streaming not supported by this connection")
+	}
+
 	var inputTokens, outputTokens, cacheTokens int64
 	var hasUsage bool
 
-	// Panic recovery
-	defer func() {
-		if r := recover(); r != nil {
-			logrus.Errorf("Panic in Responses streaming handler: %v", r)
-			if hasUsage {
-				// Track panic as error with any usage we accumulated
-				// Usage tracking will be handled by caller
-			}
-			// Try to send an error event if possible
-			if c.Writer != nil {
-				c.Writer.WriteHeader(http.StatusInternalServerError)
-				c.Writer.Write([]byte("data: {\"error\":{\"message\":\"Internal streaming error\",\"type\":\"internal_error\"}}\n\n"))
-				if flusher, ok := c.Writer.(http.Flusher); ok {
-					flusher.Flush()
-				}
-			}
-		}
-	}()
-
-	// Process the stream with context cancellation checking
-	c.Stream(func(w io.Writer) bool {
-		// Check context cancellation first
+	// MENTION: Do NOT replace this loop with c.Stream(). c.Stream() finalizes the HTTP response writer
+	// when it returns, so any writes after the loop (error events, etc.) are silently dropped.
+	// This manual loop + explicit flusher.Flush() keeps full control over connection lifetime.
+	for {
+		// Check context cancellation
 		select {
 		case <-c.Request.Context().Done():
 			logrus.Debug("Client disconnected, stopping Responses stream")
-			return false
+			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
 		default:
 		}
 
-		// Try to get next event
 		if !stream.Next() {
-			// Stream ended naturally
-			return false
+			break
 		}
 
 		evt := stream.Current()
@@ -363,6 +348,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		if evt.Response.Usage.OutputTokens > 0 {
 			outputTokens = evt.Response.Usage.OutputTokens
 		}
+
 		// Note: Responses API may include cache tokens in usage details
 		// Check if available in the raw JSON
 		// Marshal event using RawJSON() to avoid serializing empty union fields
@@ -370,7 +356,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		eventType := evt.Type
 
 		// Extract cached tokens using gjson
-		if token_details := gjson.Get(eventRaw, "response.usage.input_tokens_details"); token_details.Exists() {
+		if gjson.Get(eventRaw, "response.usage.input_tokens_details").Exists() {
 			if cachedTokens := gjson.Get(eventRaw, "response.usage.input_tokens_details.cached_tokens"); cachedTokens.Exists() {
 				cacheTokens = cachedTokens.Int()
 				logrus.Debugf("cached tokens: %v", cacheTokens)
@@ -378,7 +364,6 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 				// set raw use "0" as 0
 				if modified, err := sjson.SetRaw(eventRaw, "response.usage.input_tokens_details.cached_tokens", "0"); err == nil {
 					eventRaw = modified
-					logrus.Debugf("event raw missing cached tokens: %v", eventRaw)
 				} else {
 					logrus.WithError(err).Error("Failed to set cached tokens")
 				}
@@ -387,37 +372,24 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 
 		// Apply model override if the event contains a response object with a model field
 		if len(eventRaw) > 0 {
-			// Use gjson to check if response.model exists and is non-empty
 			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
-				// Use sjson to set the new model value
 				if modified, err := sjson.Set(eventRaw, "response.model", responseModel); err == nil {
 					eventRaw = modified
 				}
 			}
 		}
 
-		// Send SSE event with event type (e.g., "response.created", "response.output_text.delta")
 		OpenAIResponsesEvent(c, eventType, eventRaw)
-		return true
-	})
+		flusher.Flush()
+	}
 
-	// Check for stream errors after loop completes
 	if err := stream.Err(); err != nil {
-		// Check if it was a client cancellation
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.Debug("Responses stream canceled by client")
-			if hasUsage {
-				return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
-			}
-			return protocol.ZeroTokenUsage(), nil
+			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
 		}
 
 		logrus.Errorf("Responses stream error: %v", err)
-		if hasUsage {
-			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
-		}
-
-		// Send error chunk
 		errorChunk := map[string]interface{}{
 			"error": map[string]interface{}{
 				"message": err.Error(),
@@ -425,17 +397,13 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 				"code":    "stream_failed",
 			},
 		}
-
 		OpenAIResponsesEvent(c, "error", errorChunk)
+		flusher.Flush()
 		return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
 	}
 
-	// Track successful streaming completion
-	if hasUsage {
-		return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
-	}
-
-	return protocol.ZeroTokenUsage(), nil
+	_ = hasUsage
+	return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
 }
 
 // ===================================================================

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -15,6 +15,8 @@ import (
 	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
 )
@@ -375,41 +377,34 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		}
 		// Note: Responses API may include cache tokens in usage details
 		// Check if available in the raw JSON
-		var evtParsed map[string]interface{}
-		if err := json.Unmarshal([]byte(evt.RawJSON()), &evtParsed); err == nil {
-			if response, ok := evtParsed["response"].(map[string]interface{}); ok {
-				if usage, ok := response["usage"].(map[string]interface{}); ok {
-					if details, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
-						if cached, ok := details["cached_tokens"].(float64); ok {
-							cacheTokens = int64(cached)
-						}
-					}
-				}
+		// Marshal event using RawJSON() to avoid serializing empty union fields
+		eventRaw := evt.RawJSON()
+
+		// Extract cached tokens using gjson
+		if cachedTokens := gjson.Get(eventRaw, "response.usage.input_tokens_details.cached_tokens"); cachedTokens.Exists() {
+			cacheTokens = cachedTokens.Int()
+		} else {
+			// set raw use "0" as 0
+			if modified, err := sjson.SetRaw(eventRaw, "response.usage.input_tokens_details.cached_tokens", "0"); err == nil {
+				eventRaw = modified
+			} else {
+				logrus.WithError(err).Error("Failed to set cached tokens")
 			}
 		}
 
-		// Marshal event using RawJSON() to avoid serializing empty union fields
-		jsonBytes := []byte(evt.RawJSON())
-
 		// Apply model override if the event contains a response object with a model field
-		if len(jsonBytes) > 0 {
-			var parsed map[string]interface{}
-			if err := json.Unmarshal(jsonBytes, &parsed); err == nil {
-				// Check if this event has a response field with a model
-				if response, ok := parsed["response"].(map[string]interface{}); ok {
-					if model, ok2 := response["model"].(string); ok2 && model != "" {
-						response["model"] = responseModel
-						modified, err := json.Marshal(parsed)
-						if err == nil {
-							jsonBytes = modified
-						}
-					}
+		if len(eventRaw) > 0 {
+			// Use gjson to check if response.model exists and is non-empty
+			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
+				// Use sjson to set the new model value
+				if modified, err := sjson.SetRaw(eventRaw, "response.model", responseModel); err == nil {
+					eventRaw = modified
 				}
 			}
 		}
 
 		// Send SSE event with event type (e.g., "response.created", "response.output_text.delta")
-		OpenAISSE(c, json.RawMessage(jsonBytes))
+		OpenAISSE(c, eventRaw)
 		return true
 	})
 

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -404,7 +404,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		}
 
 		// Send SSE event with event type (e.g., "response.created", "response.output_text.delta")
-		OpenAISSE(c, eventRaw)
+		OpenAIResponsesEvent(c, eventType, eventRaw)
 		return true
 	})
 
@@ -436,9 +436,6 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		OpenAISSE(c, errorChunk)
 		return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
 	}
-
-	// Send final [DONE] message
-	OpenAISSEDone(c)
 
 	// Track successful streaming completion
 	if hasUsage {

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -337,18 +337,6 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		}
 	}()
 
-	_, ok := c.Writer.(http.Flusher)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, protocol.ErrorResponse{
-			Error: protocol.ErrorDetail{
-				Message: "Streaming not supported by this connection",
-				Type:    "api_error",
-				Code:    "streaming_unsupported",
-			},
-		})
-		return protocol.ZeroTokenUsage(), fmt.Errorf("streaming not supported")
-	}
-
 	// Process the stream with context cancellation checking
 	c.Stream(func(w io.Writer) bool {
 		// Check context cancellation first
@@ -379,16 +367,21 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 		// Check if available in the raw JSON
 		// Marshal event using RawJSON() to avoid serializing empty union fields
 		eventRaw := evt.RawJSON()
+		eventType := evt.Type
 
 		// Extract cached tokens using gjson
-		if cachedTokens := gjson.Get(eventRaw, "response.usage.input_tokens_details.cached_tokens"); cachedTokens.Exists() {
-			cacheTokens = cachedTokens.Int()
-		} else {
-			// set raw use "0" as 0
-			if modified, err := sjson.SetRaw(eventRaw, "response.usage.input_tokens_details.cached_tokens", "0"); err == nil {
-				eventRaw = modified
+		if token_details := gjson.Get(eventRaw, "response.usage.input_tokens_details"); token_details.Exists() {
+			if cachedTokens := gjson.Get(eventRaw, "response.usage.input_tokens_details.cached_tokens"); cachedTokens.Exists() {
+				cacheTokens = cachedTokens.Int()
+				logrus.Debugf("cached tokens: %v", cacheTokens)
 			} else {
-				logrus.WithError(err).Error("Failed to set cached tokens")
+				// set raw use "0" as 0
+				if modified, err := sjson.SetRaw(eventRaw, "response.usage.input_tokens_details.cached_tokens", "0"); err == nil {
+					eventRaw = modified
+					logrus.Debugf("event raw missing cached tokens: %v", eventRaw)
+				} else {
+					logrus.WithError(err).Error("Failed to set cached tokens")
+				}
 			}
 		}
 
@@ -397,7 +390,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 			// Use gjson to check if response.model exists and is non-empty
 			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
 				// Use sjson to set the new model value
-				if modified, err := sjson.SetRaw(eventRaw, "response.model", responseModel); err == nil {
+				if modified, err := sjson.Set(eventRaw, "response.model", responseModel); err == nil {
 					eventRaw = modified
 				}
 			}
@@ -433,7 +426,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 			},
 		}
 
-		OpenAISSE(c, errorChunk)
+		OpenAIResponsesEvent(c, "error", errorChunk)
 		return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
 	}
 

--- a/internal/protocol/stream/openai_responses_to_chat.go
+++ b/internal/protocol/stream/openai_responses_to_chat.go
@@ -95,7 +95,7 @@ func HandleResponsesToOpenAIChatStream(
 	}
 
 	// Process the stream
-	c.Stream(func(w io.Writer) bool {
+	StreamLoop(c, func(w io.Writer) bool {
 		select {
 		case <-c.Request.Context().Done():
 			logrus.Debug("Client disconnected, stopping Responses to Chat stream")

--- a/internal/protocol/stream/openai_responses_type.go
+++ b/internal/protocol/stream/openai_responses_type.go
@@ -3,6 +3,25 @@ package stream
 // Responses stream DTOs preserve the minimal outbound JSON shape emitted by this proxy.
 // Keep these fields checked against openai-go Responses SDK event types when updating the SDK.
 
+// responsesEvent is implemented by all Responses API SSE event structs.
+// The EventType() return value is used as the SSE event name.
+type responsesEvent interface {
+	EventType() string
+}
+
+func (e responsesStreamErrorEvent) EventType() string                { return e.Type }
+func (e responsesCreatedEvent) EventType() string                    { return e.Type }
+func (e responsesInProgressEvent) EventType() string                 { return e.Type }
+func (e responsesCompletedEvent) EventType() string                  { return e.Type }
+func (e responsesOutputItemAddedEvent) EventType() string            { return e.Type }
+func (e responsesOutputItemDoneEvent) EventType() string             { return e.Type }
+func (e responsesContentPartAddedEvent) EventType() string           { return e.Type }
+func (e responsesContentPartDoneEvent) EventType() string            { return e.Type }
+func (e responsesOutputTextDeltaEvent) EventType() string            { return e.Type }
+func (e responsesOutputTextDoneEvent) EventType() string             { return e.Type }
+func (e responsesFunctionCallArgumentsDeltaEvent) EventType() string { return e.Type }
+func (e responsesFunctionCallArgumentsDoneEvent) EventType() string  { return e.Type }
+
 type responsesStreamErrorEvent struct {
 	Type           string                   `json:"type"`
 	SequenceNumber int64                    `json:"sequence_number"`

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -143,7 +143,7 @@ func handleOpenAIToAnthropicStreamResponse(
 
 	// Process the stream with context cancellation checking
 	chunkCount := 0
-	c.Stream(func(w io.Writer) bool {
+	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
 		case <-c.Request.Context().Done():

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -128,7 +128,7 @@ func handleOpenAIToAnthropicBetaStream(
 
 	// Process the stream with context cancellation checking
 	chunkCount := 0
-	c.Stream(func(w io.Writer) bool {
+	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
 		case <-c.Request.Context().Done():

--- a/internal/server/adaptive_probe.go
+++ b/internal/server/adaptive_probe.go
@@ -429,39 +429,3 @@ func (ap *AdaptiveProbe) InvalidateProviderCache(providerUUID string) {
 		ap.server.probeCache.InvalidateProvider(providerUUID)
 	}
 }
-
-// ProbeProviderModels probes all models for a provider concurrently
-func (ap *AdaptiveProbe) ProbeProviderModels(ctx context.Context, provider *typ.Provider, models []string) map[string]*ProbeResult {
-	results := make(map[string]*ProbeResult)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	// Limit concurrency to avoid overwhelming the provider
-	semaphore := make(chan struct{}, 5)
-
-	for _, model := range models {
-		wg.Add(1)
-		go func(modelID string) {
-			defer wg.Done()
-
-			// Acquire semaphore
-			semaphore <- struct{}{}
-			defer func() { <-semaphore }()
-
-			req := ModelProbeRequest{
-				ProviderUUID: provider.UUID,
-				ModelID:      modelID,
-			}
-
-			result, err := ap.ProbeModelEndpoints(ctx, req)
-			if err == nil {
-				mu.Lock()
-				results[modelID] = result
-				mu.Unlock()
-			}
-		}(model)
-	}
-
-	wg.Wait()
-	return results
-}

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -305,7 +305,7 @@ func (s *Server) handleOpenAIStreamResponse(c *gin.Context, streamResp *ssestrea
 	}
 
 	// Process the stream with context cancellation checking
-	c.Stream(func(w io.Writer) bool {
+	stream.StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
 		case <-c.Request.Context().Done():


### PR DESCRIPTION
## Summary
Gin's `c.Stream()` prematurely finalizes the HTTP response writer, preventing post-loop writes (error events, final chunks). Replaced with custom `StreamLoop()` across all streaming paths. 

Also fixed Codex provider issues with empty reasoning item IDs and missing cached_tokens.

### Major
- Introduced `StreamLoop()` as drop-in replacement for `c.Stream()` that keeps response writer open after loop exits
- Replaced all `c.Stream()` calls with `StreamLoop()` across 7 streaming handlers
- Added `OpenAIResponsesEvent()` helper for proper `event:` + `data:` SSE format
- Added `responsesEvent` interface with `EventType()` method for type-safe SSE event names
- Fixed Codex provider to drop reasoning items with empty/invalid IDs (ChatGPT backend rejects them)
- Fixed missing `cached_tokens` in Responses API usage stats using `sjson`/`gjson` raw JSON manipulation

### Minor
- Removed dead code: `ProbeProviderModels()` from `adaptive_probe.go`
- Removed unused `isStreaming` variable in `codex.go`
- Improved error messaging for Codex client validation
- Cleaned up panic recovery code in `HandleOpenAIResponsesStream()` (no longer needed with `StreamLoop`)