### PR TITLE
refactor(imbot): move Weixin QR provisioning client into the imbot module

### DIFF
--- a/imbot/platform/weixin/registration.go
+++ b/imbot/platform/weixin/registration.go
@@ -1,0 +1,139 @@
+package weixin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// defaultQRBaseURL is the Weixin iLink endpoint used to provision bot
+// credentials via the QR-code onboarding flow.
+const defaultQRBaseURL = "https://ilinkai.weixin.qq.com"
+
+// QRClient talks to the Weixin iLink API to provision bot credentials through
+// the QR-code onboarding flow: fetch a QR code, then poll until the user scans
+// and confirms it. This is distinct from InteractionHandler's QR login, which
+// authenticates an already-provisioned bot's runtime session.
+type QRClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewQRClient creates a QRClient. An empty baseURL falls back to the default
+// Weixin iLink endpoint. The HTTP client timeout is long enough to cover the
+// status long-poll.
+func NewQRClient(baseURL string) *QRClient {
+	if baseURL == "" {
+		baseURL = defaultQRBaseURL
+	}
+	return &QRClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 35 * time.Second},
+	}
+}
+
+// BotQRCode is the QR code payload returned by the Weixin iLink API.
+type BotQRCode struct {
+	Qrcode           string `json:"qrcode,omitempty"`
+	QrcodeImgContent string `json:"qrcode_img_content,omitempty"`
+}
+
+// QRStatus is the QR scan status returned by the Weixin iLink API. When Status
+// is "confirmed" the credential fields are populated.
+type QRStatus struct {
+	Status      string `json:"status,omitempty"` // wait, scaned, confirmed, expired
+	BotToken    string `json:"bot_token,omitempty"`
+	IlinkBotID  string `json:"ilink_bot_id,omitempty"`
+	IlinkUserID string `json:"ilink_user_id,omitempty"`
+	BaseURL     string `json:"baseurl,omitempty"`
+}
+
+// GetBotQRCode fetches a QR code for Weixin bot provisioning. botType defaults
+// to "3" (官方小程序机器人) when empty.
+func (c *QRClient) GetBotQRCode(ctx context.Context, botType string) (*BotQRCode, error) {
+	if botType == "" {
+		botType = "3"
+	}
+
+	u, err := url.Parse(c.baseURL + "/ilink/bot/get_bot_qrcode")
+	if err != nil {
+		return nil, fmt.Errorf("parse URL: %w", err)
+	}
+	query := u.Query()
+	query.Set("bot_type", botType)
+	u.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error: %d %s: %s", resp.StatusCode, resp.Status, string(body))
+	}
+
+	var result BotQRCode
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetQRStatus polls the scan status for a QR code. A request timeout is treated
+// as a normal "wait" outcome so the caller can keep polling.
+func (c *QRClient) GetQRStatus(ctx context.Context, qrcode string) (*QRStatus, error) {
+	u, err := url.Parse(c.baseURL + "/ilink/bot/get_qrcode_status")
+	if err != nil {
+		return nil, fmt.Errorf("parse URL: %w", err)
+	}
+	query := u.Query()
+	query.Set("qrcode", qrcode)
+	u.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("iLink-App-ClientVersion", "1")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// A timed-out long-poll is expected; report it as "wait".
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return &QRStatus{Status: "wait"}, nil
+		}
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error: %d %s: %s", resp.StatusCode, resp.Status, string(body))
+	}
+
+	var result QRStatus
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return &result, nil
+}

--- a/imbot/platform/weixin/registration_e2e_test.go
+++ b/imbot/platform/weixin/registration_e2e_test.go
@@ -1,0 +1,48 @@
+//go:build e2e
+// +build e2e
+
+package weixin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQRClient_GetBotQRCode exercises QR code generation against the live
+// Weixin iLink API.
+func TestQRClient_GetBotQRCode(t *testing.T) {
+	client := NewQRClient("")
+
+	ctx := context.Background()
+	resp, err := client.GetBotQRCode(ctx, "3")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	if resp.Qrcode == "" {
+		t.Error("Expected non-empty QR code")
+	}
+	if resp.QrcodeImgContent == "" {
+		t.Error("Expected non-empty QR image content")
+	}
+}
+
+// TestQRClient_GetQRStatus exercises QR status polling against the live Weixin
+// iLink API.
+func TestQRClient_GetQRStatus(t *testing.T) {
+	client := NewQRClient("")
+
+	ctx := context.Background()
+	resp, err := client.GetQRStatus(ctx, "test-qr-id")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	if resp.Status == "" {
+		t.Error("Expected non-empty status")
+	}
+	assert.Contains(t, []string{"wait", "scaned", "confirmed", "expired"}, resp.Status)
+}

--- a/imbot/platform/weixin/registration_test.go
+++ b/imbot/platform/weixin/registration_test.go
@@ -1,0 +1,28 @@
+package weixin
+
+import "testing"
+
+// TestNewQRClient_BaseURL tests base URL handling.
+func TestNewQRClient_BaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		expected string
+	}{
+		{"Default URL", "", defaultQRBaseURL},
+		{"Explicit default", "https://ilinkai.weixin.qq.com", "https://ilinkai.weixin.qq.com"},
+		{"Custom URL", "https://custom.wechat.com", "https://custom.wechat.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewQRClient(tt.baseURL)
+			if client.baseURL != tt.expected {
+				t.Errorf("Expected base URL '%s', got '%s'", tt.expected, client.baseURL)
+			}
+			if client.httpClient == nil {
+				t.Error("Expected non-nil HTTP client")
+			}
+		})
+	}
+}

--- a/internal/server/module/imbot/wechat_qr.go
+++ b/internal/server/module/imbot/wechat_qr.go
@@ -2,25 +2,22 @@
 package imbot
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/imbot/platform/weixin"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 )
 
 // WeChatQRLoginHandler handles Weixin QR code login flow
 type WeChatQRLoginHandler struct {
 	settingsStore *db.ImBotSettingsStore
+	qrClient      *weixin.QRClient
 	sessions      map[string]*qrSession
 	mu            sync.RWMutex
 	// Rate limiting: track recent QR requests per bot
@@ -46,15 +43,11 @@ type qrSession struct {
 	botPlatform string
 }
 
-type wechatQRClient struct {
-	baseURL    string
-	httpClient *http.Client
-}
-
 // NewWeChatQRLoginHandler creates a new Weixin QR login handler
 func NewWeChatQRLoginHandler(settingsStore *db.ImBotSettingsStore) *WeChatQRLoginHandler {
 	return &WeChatQRLoginHandler{
 		settingsStore: settingsStore,
+		qrClient:      weixin.NewQRClient(""),
 		sessions:      make(map[string]*qrSession),
 		rateLimitMap:  make(map[string][]time.Time),
 	}
@@ -141,16 +134,8 @@ func (h *WeChatQRLoginHandler) QRStart(c *gin.Context) {
 		return
 	}
 
-	// Create QR code client
-	client := &wechatQRClient{
-		baseURL: "https://ilinkai.weixin.qq.com",
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-	}
-
 	// Fetch QR code
-	qrResp, err := client.GetBotQRCode(c.Request.Context(), botType)
+	qrResp, err := h.qrClient.GetBotQRCode(c.Request.Context(), botType)
 	if err != nil {
 		logrus.WithError(err).WithField("bot", botUUID).Error("Failed to get QR code")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get QR code"})
@@ -234,16 +219,8 @@ func (h *WeChatQRLoginHandler) QRStatus(c *gin.Context) {
 		return
 	}
 
-	// Create client for this request
-	client := &wechatQRClient{
-		baseURL: "https://ilinkai.weixin.qq.com",
-		httpClient: &http.Client{
-			Timeout: 35 * time.Second, // Longer timeout for long-poll
-		},
-	}
-
 	// Poll QR status
-	statusResp, err := client.GetQRStatus(c.Request.Context(), qrID)
+	statusResp, err := h.qrClient.GetQRStatus(c.Request.Context(), qrID)
 	if err != nil {
 		h.mu.Lock()
 		delete(h.sessions, botUUID)
@@ -316,7 +293,7 @@ func (h *WeChatQRLoginHandler) QRCancel(c *gin.Context) {
 
 // saveCredentials saves the Weixin credentials to the database.
 // If the bot doesn't exist yet (temp UUID), it creates a new record and returns the real UUID.
-func (h *WeChatQRLoginHandler) saveCredentials(session *qrSession, status *qrStatusResponse) (string, error) {
+func (h *WeChatQRLoginHandler) saveCredentials(session *qrSession, status *weixin.QRStatus) (string, error) {
 	authConfig := map[string]string{
 		"token":    status.BotToken,
 		"bot_id":   status.IlinkBotID,
@@ -368,130 +345,6 @@ func (h *WeChatQRLoginHandler) saveCredentials(session *qrSession, status *qrSta
 		"bot_id": status.IlinkBotID,
 	}).Info("Weixin bot created with credentials")
 	return created.UUID, nil
-}
-
-// qrBotQRCodeResponse represents the QR code response from Weixin API
-type qrBotQRCodeResponse struct {
-	Qrcode           string `json:"qrcode,omitempty"`
-	QrcodeImgContent string `json:"qrcode_img_content,omitempty"`
-}
-
-// qrStatusResponse represents the QR status response from Weixin API
-type qrStatusResponse struct {
-	Status      string `json:"status,omitempty"` // wait, scaned, confirmed, expired
-	BotToken    string `json:"bot_token,omitempty"`
-	IlinkBotID  string `json:"ilink_bot_id,omitempty"`
-	IlinkUserID string `json:"ilink_user_id,omitempty"`
-	BaseURL     string `json:"baseurl,omitempty"`
-}
-
-// GetBotQRCode fetches a QR code for Weixin bot login
-func (c *wechatQRClient) GetBotQRCode(ctx context.Context, botType string) (*qrBotQRCodeResponse, error) {
-	if botType == "" {
-		botType = "3" // Default bot type
-	}
-
-	// Build URL with query params (GET request)
-	u, err := url.Parse(c.baseURL + "/ilink/bot/get_bot_qrcode")
-	if err != nil {
-		return nil, fmt.Errorf("parse URL: %w", err)
-	}
-	query := u.Query()
-	query.Set("bot_type", botType)
-	u.RawQuery = query.Encode()
-
-	logrus.Debugf("GetBotQRCode URL: %s", u.String())
-
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-
-	// Set headers (no Authorization for QR code request)
-	req.Header.Set("Content-Type", "application/json")
-
-	// Send request
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Read response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-
-	// Log response for debugging
-	logrus.Debugf("GetBotQRCode response: %s", string(body))
-
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error: %d %s: %s", resp.StatusCode, resp.Status, string(body))
-	}
-
-	// Unmarshal response
-	var result qrBotQRCodeResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	return &result, nil
-}
-
-// GetQRStatus polls the QR code status
-func (c *wechatQRClient) GetQRStatus(ctx context.Context, qrcode string) (*qrStatusResponse, error) {
-	// Build URL with query params
-	u, err := url.Parse(c.baseURL + "/ilink/bot/get_qrcode_status")
-	if err != nil {
-		return nil, fmt.Errorf("parse URL: %w", err)
-	}
-	query := u.Query()
-	query.Set("qrcode", qrcode)
-	u.RawQuery = query.Encode()
-
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-
-	// Set headers
-	req.Header.Set("Content-Type", "application/json")
-	// Add required header for QR status polling
-	req.Header.Set("iLink-App-ClientVersion", "1")
-
-	// Send request
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		// Timeout is normal, return "wait" status
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return &qrStatusResponse{Status: "wait"}, nil
-		}
-		return nil, fmt.Errorf("send request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Read response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error: %d %s: %s", resp.StatusCode, resp.Status, string(body))
-	}
-
-	// Unmarshal response
-	var result qrStatusResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	return &result, nil
 }
 
 // checkRateLimit checks if the bot has exceeded the QR code request rate limit

--- a/internal/server/module/imbot/wechat_qr_test.go
+++ b/internal/server/module/imbot/wechat_qr_test.go
@@ -4,13 +4,12 @@
 package imbot
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/imbot/platform/weixin"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 )
 
@@ -128,45 +127,6 @@ func TestQRStatusResponse_ValidStatuses(t *testing.T) {
 	}
 }
 
-// TestWeChatQRClient_GetBotQRCode tests QR code generation (mock)
-func TestWeChatQRClient_GetBotQRCode(t *testing.T) {
-	client := &wechatQRClient{
-		baseURL: "https://ilinkai.weixin.qq.com",
-	}
-
-	ctx := context.Background()
-	resp, err := client.GetBotQRCode(ctx, "3")
-
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-
-	if resp.Qrcode == "" {
-		t.Error("Expected non-empty QR code")
-	}
-	if resp.QrcodeImgContent == "" {
-		t.Error("Expected non-empty QR image content")
-	}
-}
-
-// TestWeChatQRClient_GetQRStatus tests QR status polling (mock)
-func TestWeChatQRClient_GetQRStatus(t *testing.T) {
-	client := &wechatQRClient{
-		baseURL: "https://ilinkai.weixin.qq.com",
-	}
-
-	ctx := context.Background()
-	resp, err := client.GetQRStatus(ctx, "test-qr-id")
-
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-
-	if resp.Status == "" {
-		t.Error("Expected non-empty status")
-	}
-	// Mock returns "wait"
-	assert.Contains(t, []string{"wait", "scaned", "confirmed", "expired"}, resp.Status)
-}
-
 // TestQRSessionCreation tests QR session creation
 func TestQRSessionCreation(t *testing.T) {
 	session := &qrSession{
@@ -216,7 +176,7 @@ func TestQRSessionExpiration(t *testing.T) {
 
 // TestCredentialMapping tests credential mapping from QR response
 func TestCredentialMapping(t *testing.T) {
-	status := &qrStatusResponse{
+	status := &weixin.QRStatus{
 		Status:      "confirmed",
 		BotToken:    "test-bot-token",
 		IlinkBotID:  "ilink-bot-123",
@@ -271,30 +231,6 @@ func TestJSONSerialization(t *testing.T) {
 	}
 	if decoded.Data.ExpiresIn != startResp.Data.ExpiresIn {
 		t.Errorf("JSON roundtrip failed for ExpiresIn")
-	}
-}
-
-// TestWeChatQRClientBaseURL tests client base URL handling
-func TestWeChatQRClientBaseURL(t *testing.T) {
-	tests := []struct {
-		name     string
-		baseURL  string
-		expected string
-	}{
-		{"Default URL", "https://ilinkai.weixin.qq.com", "https://ilinkai.weixin.qq.com"},
-		{"Custom URL", "https://custom.wechat.com", "https://custom.wechat.com"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client := &wechatQRClient{
-				baseURL: tt.baseURL,
-			}
-
-			if client.baseURL != tt.expected {
-				t.Errorf("Expected base URL '%s', got '%s'", tt.expected, client.baseURL)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Follow-up to the Feishu one-click registration work (#927). Applies the same layering fix to the Weixin QR flow.

The iLink QR client that provisions Weixin bot credentials lived in the server-layer handler (`internal/server/module/imbot/wechat_qr.go`), so the reusable `imbot` module (CLI + GUI) couldn't use it. This extracts the platform-level core into the `imbot` module, mirroring `imbot/platform/feishu/registration.go`.

## Changes

**`imbot` module (reusable core)** — new `imbot/platform/weixin/registration.go`
- `QRClient` (was the server-private `wechatQRClient`): owns the iLink endpoints, `GetBotQRCode` / `GetQRStatus`, and the `BotQRCode` / `QRStatus` response types.
- `NewQRClient(baseURL)` — empty `baseURL` falls back to the default iLink endpoint; sets a working `http.Client` (the old tests constructed the client with a nil `http.Client`).
- Stdlib-only — no new dependencies on the `imbot` module.
- Distinct from `InteractionHandler`'s QR login, which authenticates an already-provisioned bot's runtime session — documented in the type comment.

**Server layer** — `internal/server/module/imbot/wechat_qr.go`
- `WeChatQRLoginHandler` now holds a `*weixin.QRClient` (created once in the constructor instead of per-request).
- Keeps only the HTTP start/status/cancel session model, rate limiting and credential persistence.

**Tests**
- Client tests (`GetBotQRCode`, `GetQRStatus`, base-URL handling) move to the `weixin` package. The two network-hitting tests stay `e2e`-tagged in `registration_e2e_test.go`; the pure base-URL test becomes a regular unit test.
- Server test keeps the handler/session/type tests; `TestCredentialMapping` now references `weixin.QRStatus`.

## Layering result

| Layer | Location |
|---|---|
| Weixin iLink QR client | `imbot/platform/weixin/registration.go` (reusable: imbot module + server + CLI) |
| Session model + persistence | `internal/server/module/imbot/wechat_qr.go` (server only) |

## Test plan
- [x] `go build ./...`, `go vet` (incl. `-tags=e2e`), gofmt — passing locally
- [x] `go test ./imbot/platform/weixin/` — passing
- [ ] Pre-existing `TestGetSettings_*` failures in the server `imbot` package are unrelated (fail identically on `main`)
- [ ] Weixin QR binding not verified end-to-end against the live iLink API

https://claude.ai/code/session_01DbQ5BQjMFP1pezwDYHq8i3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbQ5BQjMFP1pezwDYHq8i3)_