### PR TITLE
bugfix(api): simplify scenario scoping: remove transport-based visibility

### DIFF
--- a/internal/server/model_list_scope.go
+++ b/internal/server/model_list_scope.go
@@ -2,44 +2,10 @@ package server
 
 import "github.com/tingly-dev/tingly-box/internal/typ"
 
-func scenarioSupportsTransport(scenario typ.RuleScenario, transport typ.ScenarioTransport) bool {
-	descriptor, ok := typ.GetScenarioDescriptor(scenario)
-	if !ok {
-		return false
-	}
-	for _, supported := range descriptor.SupportedTransport {
-		if supported == transport {
-			return true
-		}
-	}
-	return false
-}
-
+// shouldIncludeRuleInModelList reports whether a rule should appear in the
+// model list for the requested scenario. Each scenario — base or profiled —
+// is an isolated scope: it only lists rules bound to that exact scenario.
+// Transport compatibility does not grant cross-scenario visibility.
 func shouldIncludeRuleInModelList(requestedScenario typ.RuleScenario, ruleScenario typ.RuleScenario) bool {
-	// If requested scenario is a profile (e.g., "claude_code:p1"), only include exact matches.
-	// Profiles are isolated scopes and should not fallback to transport-based reachability.
-	if typ.IsProfiledScenario(requestedScenario) {
-		return requestedScenario == ruleScenario
-	}
-
-	// If the rule belongs to a profiled scenario, it must not be visible to non-profile requests.
-	// Profile rules are exclusively scoped to their own profile.
-	if typ.IsProfiledScenario(ruleScenario) {
-		return false
-	}
-
-	if requestedScenario == ruleScenario {
-		return true
-	}
-
-	requestedDescriptor, ok := typ.GetScenarioDescriptor(requestedScenario)
-	if !ok {
-		return false
-	}
-	for _, transport := range requestedDescriptor.SupportedTransport {
-		if scenarioSupportsTransport(ruleScenario, transport) {
-			return true
-		}
-	}
-	return false
+	return requestedScenario == ruleScenario
 }

--- a/internal/server/model_list_scope_test.go
+++ b/internal/server/model_list_scope_test.go
@@ -6,69 +6,32 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func TestShouldIncludeRuleInModelList_TransportReachabilityForOpenAI(t *testing.T) {
+func TestShouldIncludeRuleInModelList_OnlyExactScenarioMatch(t *testing.T) {
 	if !shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioOpenCode) {
 		t.Fatalf("expected exact scenario match to be included")
 	}
-	if !shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioCodex) {
-		t.Fatalf("expected openai-transport scenario to include transport-reachable scenario")
+	// Scenarios are isolated: sharing a transport must not grant visibility.
+	if shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioCodex) {
+		t.Fatalf("expected transport-reachable scenario to be excluded")
 	}
 	if shouldIncludeRuleInModelList(typ.ScenarioOpenCode, typ.ScenarioAnthropic) {
-		t.Fatalf("expected openai-transport scenario to exclude anthropic-only scenario")
+		t.Fatalf("expected unrelated scenario to be excluded")
 	}
 }
 
-func TestShouldIncludeRuleInModelList_TransportReachabilityForAnthropic(t *testing.T) {
-	customScenario := typ.RuleScenario("general_test_transport_anthropic")
-	err := typ.RegisterScenario(typ.ScenarioDescriptor{
-		ID:                 customScenario,
-		SupportedTransport: []typ.ScenarioTransport{typ.TransportAnthropic},
-		AllowRuleBinding:   true,
-		AllowDirectPathUse: true,
-	})
-	if err != nil {
-		t.Fatalf("register custom scenario: %v", err)
+func TestShouldIncludeRuleInModelList_ClaudeCodeExcludesOtherScenarios(t *testing.T) {
+	if !shouldIncludeRuleInModelList(typ.ScenarioClaudeCode, typ.ScenarioClaudeCode) {
+		t.Fatalf("expected claude_code to include its own rules")
 	}
-
-	if !shouldIncludeRuleInModelList(typ.ScenarioAnthropic, customScenario) {
-		t.Fatalf("expected anthropic model list to include transport-reachable custom scenario")
-	}
-	if shouldIncludeRuleInModelList(typ.ScenarioOpenAI, customScenario) {
-		t.Fatalf("expected openai model list to exclude anthropic-only custom scenario")
-	}
-}
-
-func TestShouldIncludeRuleInModelList_ClaudeCodeUsesAnthropicTransport(t *testing.T) {
-	if !shouldIncludeRuleInModelList(typ.ScenarioClaudeCode, typ.ScenarioAnthropic) {
-		t.Fatalf("expected claude_code model list to include anthropic-transport scenario")
+	if shouldIncludeRuleInModelList(typ.ScenarioClaudeCode, typ.ScenarioAnthropic) {
+		t.Fatalf("expected claude_code model list to exclude anthropic scenario")
 	}
 	if shouldIncludeRuleInModelList(typ.ScenarioClaudeCode, typ.ScenarioOpenAI) {
-		t.Fatalf("expected claude_code model list to exclude openai-only scenario")
-	}
-}
-
-func TestShouldIncludeRuleInModelList_CustomScenarioWithBothTransports(t *testing.T) {
-	customScenario := typ.RuleScenario("general_test_transport_both")
-	err := typ.RegisterScenario(typ.ScenarioDescriptor{
-		ID:                 customScenario,
-		SupportedTransport: []typ.ScenarioTransport{typ.TransportOpenAI, typ.TransportAnthropic},
-		AllowRuleBinding:   true,
-		AllowDirectPathUse: true,
-	})
-	if err != nil {
-		t.Fatalf("register custom scenario: %v", err)
-	}
-
-	if !shouldIncludeRuleInModelList(customScenario, typ.ScenarioOpenAI) {
-		t.Fatalf("expected custom scenario to include openai transport scenario")
-	}
-	if !shouldIncludeRuleInModelList(customScenario, typ.ScenarioAnthropic) {
-		t.Fatalf("expected custom scenario to include anthropic transport scenario")
+		t.Fatalf("expected claude_code model list to exclude openai scenario")
 	}
 }
 
 func TestShouldIncludeRuleInModelList_ProfileOnlyIncludesExactMatch(t *testing.T) {
-	// Test that profile scenarios only include exact matches, not transport-reachable scenarios
 	profiledScenario := typ.RuleScenario("claude_code:p1")
 	baseScenario := typ.RuleScenario("claude_code")
 
@@ -77,19 +40,19 @@ func TestShouldIncludeRuleInModelList_ProfileOnlyIncludesExactMatch(t *testing.T
 		t.Fatalf("expected profile to include exact match rule")
 	}
 
-	// Profile should NOT include base scenario rules (even though they share transport)
+	// Profile should NOT include base scenario rules
 	if shouldIncludeRuleInModelList(profiledScenario, baseScenario) {
 		t.Fatalf("expected profile to exclude base scenario rules")
 	}
 
-	// Profile should NOT include other scenarios with compatible transport
+	// Profile should NOT include other scenarios
 	if shouldIncludeRuleInModelList(profiledScenario, typ.ScenarioAnthropic) {
-		t.Fatalf("expected profile to exclude other anthropic transport scenarios")
+		t.Fatalf("expected profile to exclude other scenarios")
 	}
 
-	// Base scenario should still include transport-reachable scenarios
-	if !shouldIncludeRuleInModelList(baseScenario, typ.ScenarioAnthropic) {
-		t.Fatalf("expected base scenario to include transport-reachable scenarios")
+	// Base scenario should NOT include other scenarios either
+	if shouldIncludeRuleInModelList(baseScenario, typ.ScenarioAnthropic) {
+		t.Fatalf("expected base scenario to exclude unrelated scenarios")
 	}
 }
 
@@ -97,7 +60,7 @@ func TestShouldIncludeRuleInModelList_BaseScenarioExcludesProfileRules(t *testin
 	baseScenario := typ.RuleScenario("claude_code")
 	profiledScenario := typ.RuleScenario("claude_code:p1")
 
-	// Base scenario should NOT include profile rules (profiles are exclusively scoped)
+	// Base scenario should NOT include profile rules
 	if shouldIncludeRuleInModelList(baseScenario, profiledScenario) {
 		t.Fatalf("expected base scenario to exclude profiled scenario rules")
 	}
@@ -105,11 +68,6 @@ func TestShouldIncludeRuleInModelList_BaseScenarioExcludesProfileRules(t *testin
 	// Base scenario should still include its own rules
 	if !shouldIncludeRuleInModelList(baseScenario, baseScenario) {
 		t.Fatalf("expected base scenario to include its own rules")
-	}
-
-	// Base scenario should still include transport-reachable non-profile scenarios
-	if !shouldIncludeRuleInModelList(baseScenario, typ.ScenarioAnthropic) {
-		t.Fatalf("expected base scenario to include transport-reachable scenarios")
 	}
 }
 


### PR DESCRIPTION
## Summary
This change simplifies the scenario scoping model by removing transport-based cross-scenario visibility. Each scenario (base or profiled) is now treated as an isolated scope that only includes rules bound to that exact scenario.

## Key Changes
- **Removed transport compatibility logic**: Deleted `scenarioSupportsTransport()` function and all transport-based rule visibility checks
- **Simplified `shouldIncludeRuleInModelList()`**: Now performs exact scenario matching only, eliminating the complex fallback logic that previously allowed rules to be visible across scenarios sharing the same transport
- **Updated test suite**: Removed 4 transport-reachability test cases and simplified remaining tests to reflect the new isolated-scope behavior:
  - `TestShouldIncludeRuleInModelList_TransportReachabilityForOpenAI` → `TestShouldIncludeRuleInModelList_OnlyExactScenarioMatch`
  - Removed `TestShouldIncludeRuleInModelList_TransportReachabilityForAnthropic`
  - Removed `TestShouldIncludeRuleInModelList_CustomScenarioWithBothTransports`
  - Renamed and updated `TestShouldIncludeRuleInModelList_ClaudeCodeUsesAnthropicTransport` → `TestShouldIncludeRuleInModelList_ClaudeCodeExcludesOtherScenarios`
- **Updated test assertions**: Changed expectations to verify that scenarios do NOT include rules from other scenarios, even if they share a transport

## Implementation Details
The new implementation is a single equality check: `requestedScenario == ruleScenario`. This ensures:
- Profiled scenarios (e.g., `claude_code:p1`) remain isolated from their base scenarios
- Base scenarios remain isolated from profiled variants
- No implicit visibility based on shared transport mechanisms

https://claude.ai/code/session_01S4Wf8GYk9WJ1QLu7YiUuFt