### PR TITLE
Add comprehensive platform documentation for all IM integrations

### DIFF
--- a/imbot/README.md
+++ b/imbot/README.md
@@ -15,16 +15,21 @@ A unified, extensible framework for building IM bots that work across multiple m
 
 ## Supported Platforms
 
-- ✅ **Telegram** - Full support with inline keyboards, menus, commands, and media
-- ✅ **Feishu/Lark** - Full support with quick actions and interactive cards
-- ✅ **DingTalk** - Basic support with message handling
-- ✅ **Weixin** - Basic support
-- ✅ **WeWork** - Basic support (enterprise WeChat)
-- 🚧 **Discord** - Planned
-- 🚧 **Slack** - Planned
-- 🚧 **WhatsApp** - Planned
-- 🚧 **Google Chat** - Planned
-- 🚧 **Signal** - Planned
+| Platform | Status | Auth | Connection |
+|---|---|---|---|
+| **Telegram** | ✅ Full | Token | Polling / WebSocket |
+| **Discord** | ✅ Full | Token | WebSocket (Gateway) |
+| **Slack** | ✅ Full | Token | RTM |
+| **Feishu** | ✅ Full | OAuth | WebSocket (Event Push) |
+| **Lark** | ✅ Full | OAuth | WebSocket (Event Push) |
+| **DingTalk** | ✅ Full | OAuth | Stream SDK |
+| **Weixin** | ✅ Basic | Token + AccountID | WebSocket |
+| **WeCom** | ✅ Basic | OAuth | WebSocket |
+| **WhatsApp** | ✅ Basic | Token | HTTP Webhook |
+| **Google Chat** | 🚧 Planned | — | — |
+| **Signal** | 🚧 Planned | — | — |
+
+See [`platform/README.md`](platform/README.md) for per-platform design details and configuration reference.
 
 ## Architecture
 

--- a/imbot/platform/README.md
+++ b/imbot/platform/README.md
@@ -1,41 +1,32 @@
-# imbot/platform — Platform Implementations
+# imbot/platform
 
-Each subdirectory implements the `core.Bot` interface for one messaging platform.
-All platforms share the same connection lifecycle, event model, and message types
-defined in `imbot/core`; differences are handled inside each package via an
-**Adapter** and optional **Interaction/Menu** adapters.
+Each subdirectory implements `core.Bot` for one messaging platform. All platforms share the same lifecycle, event model, and message types from `imbot/core`; differences are encapsulated in per-package **Adapter**, **Interaction**, and **Menu** adapters.
 
-## Directory layout
+## Platforms
 
-```
-platform/
-├── registry.go      # Global factory — maps Platform → BotCreator func
-├── telegram/
-├── discord/
-├── slack/
-├── feishu/
-├── lark/            # Feishu alias (larksuite.com domain)
-├── dingtalk/
-├── weixin/          # WeChat personal / official account
-├── wecom/           # WeCom (Enterprise WeChat AI Bot)
-├── whatsapp/
-└── tingly/          # Internal test platform + E2E harness
-```
+| Platform | README | Auth | Connection |
+|---|---|---|---|
+| Telegram | [telegram/](telegram/README.md) | token | Long-polling |
+| Discord | [discord/](discord/README.md) | token | WebSocket (Gateway) |
+| Slack | [slack/](slack/README.md) | token | RTM |
+| Feishu | [feishu/](feishu/README.md) | oauth | WebSocket (Event Push) |
+| Lark | [lark/](lark/README.md) | oauth | WebSocket (Event Push) |
+| DingTalk | [dingtalk/](dingtalk/README.md) | oauth | Stream SDK |
+| Weixin | [weixin/](weixin/README.md) | token | WebSocket |
+| WeCom | [wecom/](wecom/README.md) | oauth | WebSocket |
+| WhatsApp | [whatsapp/](whatsapp/README.md) | token | REST (Meta Cloud API) |
+| Tingly | [tingly/](tingly/README.md) | none | InProcess / pluggable |
 
-## How the registry works
+## Registry
 
-`registry.go` holds a global `Registry` that maps `core.Platform` values to
-constructor functions (`BotCreator`).  The factory is called through:
+`registry.go` maps `core.Platform` values to constructor functions. Use the global helpers:
 
 ```go
-// Create a bot from a config (uses global registry)
 bot, err := platform.Create(config)
-
-// Check support before creating
-if platform.IsSupported(core.PlatformSlack) { ... }
+ok := platform.IsSupported(core.PlatformSlack)
 ```
 
-Custom platforms can be registered at startup:
+Register a custom platform at startup:
 
 ```go
 platform.Register(core.Platform("myplatform"), func(cfg *core.Config) (core.Bot, error) {
@@ -43,377 +34,11 @@ platform.Register(core.Platform("myplatform"), func(cfg *core.Config) (core.Bot,
 })
 ```
 
----
-
-## Platform reference
-
-Each platform has its own README with full configuration and design details:
-
-| Platform | README | Auth | Connection |
-|---|---|---|---|
-| Telegram | [telegram/README.md](telegram/README.md) | token | Long-polling |
-| Discord | [discord/README.md](discord/README.md) | token | WebSocket (Gateway) |
-| Slack | [slack/README.md](slack/README.md) | token | RTM |
-| Feishu | [feishu/README.md](feishu/README.md) | oauth | WebSocket (Event Push) |
-| Lark | [lark/README.md](lark/README.md) | oauth | WebSocket (Event Push) |
-| DingTalk | [dingtalk/README.md](dingtalk/README.md) | oauth | Stream SDK |
-| Weixin | [weixin/README.md](weixin/README.md) | token | WebSocket |
-| WeCom | [wecom/README.md](wecom/README.md) | oauth | WebSocket |
-| WhatsApp | [whatsapp/README.md](whatsapp/README.md) | token | REST (Meta Cloud API) |
-| Tingly | [tingly/README.md](tingly/README.md) | none | InProcess / pluggable |
-
----
-
-### Telegram
-
-| | |
-|---|---|
-| Package | `platform/telegram` |
-| Auth | `token` — bot token from [@BotFather](https://t.me/botfather) |
-| Connection | Long-polling (default) or WebSocket |
-| SDK | `github.com/go-telegram/bot` |
-| Text limit | 4 096 characters |
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformTelegram,
-    Auth: core.AuthConfig{
-        Type:  "token",
-        Token: "123456:ABC-DEF...",  // or "$TELEGRAM_BOT_TOKEN"
-    },
-    Options: map[string]interface{}{
-        "proxy": "socks5://user:pass@host:1080",  // optional SOCKS5/HTTP proxy
-        "debug": false,
-    },
-}
-```
-
-**Capabilities:** inline keyboards, reply keyboards, chat menu button,
-native commands, reactions, message edit/delete, threads, polls, media
-(image, video, audio, document, sticker, GIF).
-
-**Platform-specific methods** (cast via `imbot.AsTelegramBot`):
-
-```go
-if tg, ok := imbot.AsTelegramBot(bot); ok {
-    tg.SetCommandList(registry.BuildTelegramMenuCommands())
-    tg.SetMenuButton(telegram.MenuButtonConfig{Type: telegram.MenuButtonTypeCommands})
-    chatID, _ := tg.ResolveChatID("@username")
-}
-```
-
----
-
-### Discord
-
-| | |
-|---|---|
-| Package | `platform/discord` |
-| Auth | `token` — bot token from the Discord Developer Portal |
-| Connection | WebSocket (Gateway API via `discordgo`) |
-| SDK | `github.com/bwmarrin/discordgo` |
-| Text limit | 2 000 characters |
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformDiscord,
-    Auth: core.AuthConfig{
-        Type:  "token",
-        Token: "Bot MTxxxxxxx...",   // "Bot " prefix is added automatically if omitted
-    },
-    Options: map[string]interface{}{
-        // Gateway intents (default: Guilds + DirectMessages + GuildMessages + MessageContent)
-        "intents": []interface{}{"guilds", "directMessages", "guildMessages", "messageContent"},
-    },
-}
-```
-
-**Capabilities:** components (buttons, select menus), threads, reactions,
-message edit/delete, mentions, media (image, video, audio, document).
-
----
-
-### Slack
-
-| | |
-|---|---|
-| Package | `platform/slack` |
-| Auth | `token` — bot token (`xoxb-...`) from Slack App settings |
-| Connection | RTM (Real-Time Messaging) |
-| SDK | `github.com/slack-go/slack` |
-| Text limit | 40 000 characters |
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformSlack,
-    Auth: core.AuthConfig{
-        Type:  "token",
-        Token: "xoxb-...",
-    },
-    Options: map[string]interface{}{
-        "appToken": "xapp-...", // optional App-Level Token for Socket Mode
-    },
-}
-```
-
-**Capabilities:** Block Kit buttons/menus, reactions, threads, message
-edit, media.
-
----
-
-### Feishu
-
-| | |
-|---|---|
-| Package | `platform/feishu` |
-| Auth | `oauth` — App ID + App Secret from Feishu Open Platform |
-| Connection | WebSocket (Feishu event-push via `larkws`) |
-| SDK | `github.com/larksuite/oapi-sdk-go/v3` |
-| Text limit | 30 720 characters |
-| Domain | `feishu.cn` |
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformFeishu,
-    Auth: core.AuthConfig{
-        Type:         "oauth",
-        ClientID:     "cli_xxxxxxxxxxxxxxxx",   // App ID
-        ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // App Secret
-    },
-}
-```
-
-**Capabilities:** interactive cards (full card builder), quick actions
-(slash-like `/` menu), reactions, threads, message edit/delete, media.
-
-**Platform-specific methods** (cast via `imbot.AsFeishuBot`):
-
-```go
-if fs, ok := imbot.AsFeishuBot(bot); ok {
-    fs.SetQuickActions(actions)
-    actions, _ := fs.GetQuickActions()
-}
-```
-
-**ID routing:** The adapter automatically selects `receive_id_type` based
-on the target ID prefix (`ou_` → `user_id`, `cli_` → `chat_id`,
-`oc_` → `open_id`).
-
----
-
-### Lark
-
-| | |
-|---|---|
-| Package | `platform/lark` |
-| Auth | `oauth` — same as Feishu |
-| Domain | `larksuite.com` (international) |
-
-Lark is the international edition of Feishu.  The `lark` package is a
-thin wrapper around the `feishu` package that sets `DomainLark` so the
-SDK targets `larksuite.com` instead of `feishu.cn`.  Configuration and
-capabilities are identical to Feishu.
-
-```go
-&core.Config{
-    Platform: core.PlatformLark,
-    Auth: core.AuthConfig{
-        Type:         "oauth",
-        ClientID:     "cli_...",
-        ClientSecret: "...",
-    },
-}
-```
-
----
-
-### DingTalk
-
-| | |
-|---|---|
-| Package | `platform/dingtalk` |
-| Auth | `oauth` — AppKey + AppSecret from DingTalk Open Platform |
-| Connection | DingTalk Stream SDK (persistent TCP stream) |
-| SDK | `github.com/open-dingtalk/dingtalk-stream-sdk-go` |
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformDingTalk,
-    Auth: core.AuthConfig{
-        Type:         "oauth",
-        ClientID:     "dingxxxxxxxxxxxxxxxxxx",  // AppKey
-        ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // AppSecret
-    },
-}
-```
-
-**Design notes:**
-
-- Receiving messages uses the **Stream SDK** (no public webhook URL needed).
-- Sending and reactions use a **REST API** with a cached access token
-  (auto-refreshed before expiry).
-- Incoming webhook URLs for sending replies are stored per
-  `conversationID` and populated on first message receipt.
-
-**Capabilities:** chatbot message handling, reactions via REST API, media.
-
----
-
-### Weixin
-
-| | |
-|---|---|
-| Package | `platform/weixin` |
-| Auth | Token + AccountID |
-| Connection | WebSocket via `github.com/tingly-dev/weixin` SDK |
-
-Weixin supports WeChat personal and official accounts through the
-tingly-dev weixin SDK.
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformWeixin,
-    Auth: core.AuthConfig{
-        Type:      "token",
-        Token:     "bot_id:token_key",  // combined token
-        AccountID: "bot_id",            // WeChat bot/account ID
-        AuthDir:   "user_id",           // reused field for user ID
-    },
-    Options: map[string]interface{}{
-        "baseUrl": "https://weixin-gateway.example.com",
-    },
-}
-```
-
-**Capabilities:** text, media (image, audio, video, document), basic
-message routing per account.
-
----
-
-### WeCom
-
-| | |
-|---|---|
-| Package | `platform/wecom` |
-| Auth | `oauth` — Bot ID + Bot Secret |
-| Connection | WebSocket via `github.com/tingly-dev/weixin/wecom` SDK |
-
-WeCom (企业微信) AI Bot integration for enterprise group chats.
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformWecom,
-    Auth: core.AuthConfig{
-        Type:         "oauth",
-        ClientID:     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // Bot ID
-        ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",      // Bot Secret
-    },
-}
-```
-
-**Capabilities:** text and media messages inside WeCom group/direct chats.
-
----
-
-### WhatsApp
-
-| | |
-|---|---|
-| Package | `platform/whatsapp` |
-| Auth | `token` — API key from Meta Business |
-| Connection | HTTP (Meta Business API webhooks) — stateless REST calls |
-
-**Config:**
-
-```go
-&core.Config{
-    Platform: core.PlatformWhatsApp,
-    Auth: core.AuthConfig{
-        Type:    "token",
-        Token:   "EAAxxxxxxxxxx...",  // Meta permanent or temporary token
-        AuthDir: "/path/to/auth/dir", // optional: local session storage
-    },
-    Options: map[string]interface{}{
-        "phoneId": "1234567890",  // WhatsApp Business phone-number ID
-        "apiUrl":  "https://graph.facebook.com/v18.0",
-    },
-}
-```
-
-**Design notes:** Unlike persistent-connection platforms, WhatsApp uses
-stateless REST calls for sending.  Incoming messages arrive via Meta
-webhook events handled externally and fed to the bot via the adapter.
-
-**Capabilities:** text, images, documents, audio, read receipts.
-
----
-
-### Tingly (internal / test)
-
-| | |
-|---|---|
-| Package | `platform/tingly` |
-| Auth | `none` |
-| Connection | Pluggable `Transport` interface |
-
-Tingly is the internal test platform used by the E2E harness under
-`platform/tingly/testenv/`.  It provides **full feature parity** with
-Telegram (inline keyboards, menus, commands, reactions, media) over an
-in-process or network transport.
-
-```go
-// Register a custom in-process transport
-tingly.RegisterTransport(botUUID, myTransport)
-
-// Create bot (no real auth needed)
-&core.Config{
-    Platform: core.PlatformTingly,
-    Auth:     core.AuthConfig{Type: "none"},
-}
-```
-
-The `testenv` sub-package spins up a complete Tingly bot in-process,
-making it possible to write deterministic integration tests without a
-live messaging account.
-
----
-
-## Adapter pattern
-
-Every platform that receives events implements an **Adapter** that
-converts raw SDK types to the unified `core.Message`:
-
-```
-Raw SDK event
-    └─► Adapter.AdaptMessage() / AdaptCallback()
-            └─► core.Message  (emitted to Manager handlers)
-```
-
-Platforms that support interactive elements additionally implement
-`interaction.Adapter` and optionally `menu.Adapter`, wired up in
-`interaction.go` / `menu.go` inside each package.
-
 ## Adding a new platform
 
 1. Create `platform/<name>/<name>.go` embedding `*core.BaseBot`.
-2. Implement `core.Bot` (connect, disconnect, send, react, etc.).
-3. Add an `Adapter` that converts raw events to `core.Message` and calls
-   `b.EmitMessage(msg)`.
-4. Register the constructor in `registry.go` under
-   `RegisterBuiltinPlatforms()`.
-5. Optionally implement `interaction.Adapter` and `menu.Adapter` for
-   richer interactivity.
+2. Implement `core.Bot` (connect, disconnect, send, react, edit, delete).
+3. Add an `Adapter` that converts raw SDK events to `core.Message` and calls `b.EmitMessage(msg)`.
+4. Register the constructor in `registry.go` → `RegisterBuiltinPlatforms()`.
+5. Optionally implement `interaction.Adapter` and `menu.Adapter` for richer interactivity.
+6. Add a `README.md` following the pattern of existing platforms.

--- a/imbot/platform/README.md
+++ b/imbot/platform/README.md
@@ -1,0 +1,402 @@
+# imbot/platform — Platform Implementations
+
+Each subdirectory implements the `core.Bot` interface for one messaging platform.
+All platforms share the same connection lifecycle, event model, and message types
+defined in `imbot/core`; differences are handled inside each package via an
+**Adapter** and optional **Interaction/Menu** adapters.
+
+## Directory layout
+
+```
+platform/
+├── registry.go      # Global factory — maps Platform → BotCreator func
+├── telegram/
+├── discord/
+├── slack/
+├── feishu/
+├── lark/            # Feishu alias (larksuite.com domain)
+├── dingtalk/
+├── weixin/          # WeChat personal / official account
+├── wecom/           # WeCom (Enterprise WeChat AI Bot)
+├── whatsapp/
+└── tingly/          # Internal test platform + E2E harness
+```
+
+## How the registry works
+
+`registry.go` holds a global `Registry` that maps `core.Platform` values to
+constructor functions (`BotCreator`).  The factory is called through:
+
+```go
+// Create a bot from a config (uses global registry)
+bot, err := platform.Create(config)
+
+// Check support before creating
+if platform.IsSupported(core.PlatformSlack) { ... }
+```
+
+Custom platforms can be registered at startup:
+
+```go
+platform.Register(core.Platform("myplatform"), func(cfg *core.Config) (core.Bot, error) {
+    return mypkg.NewBot(cfg), nil
+})
+```
+
+---
+
+## Platform reference
+
+### Telegram
+
+| | |
+|---|---|
+| Package | `platform/telegram` |
+| Auth | `token` — bot token from [@BotFather](https://t.me/botfather) |
+| Connection | Long-polling (default) or WebSocket |
+| SDK | `github.com/go-telegram/bot` |
+| Text limit | 4 096 characters |
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformTelegram,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: "123456:ABC-DEF...",  // or "$TELEGRAM_BOT_TOKEN"
+    },
+    Options: map[string]interface{}{
+        "proxy": "socks5://user:pass@host:1080",  // optional SOCKS5/HTTP proxy
+        "debug": false,
+    },
+}
+```
+
+**Capabilities:** inline keyboards, reply keyboards, chat menu button,
+native commands, reactions, message edit/delete, threads, polls, media
+(image, video, audio, document, sticker, GIF).
+
+**Platform-specific methods** (cast via `imbot.AsTelegramBot`):
+
+```go
+if tg, ok := imbot.AsTelegramBot(bot); ok {
+    tg.SetCommandList(registry.BuildTelegramMenuCommands())
+    tg.SetMenuButton(telegram.MenuButtonConfig{Type: telegram.MenuButtonTypeCommands})
+    chatID, _ := tg.ResolveChatID("@username")
+}
+```
+
+---
+
+### Discord
+
+| | |
+|---|---|
+| Package | `platform/discord` |
+| Auth | `token` — bot token from the Discord Developer Portal |
+| Connection | WebSocket (Gateway API via `discordgo`) |
+| SDK | `github.com/bwmarrin/discordgo` |
+| Text limit | 2 000 characters |
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformDiscord,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: "Bot MTxxxxxxx...",   // "Bot " prefix is added automatically if omitted
+    },
+    Options: map[string]interface{}{
+        // Gateway intents (default: Guilds + DirectMessages + GuildMessages + MessageContent)
+        "intents": []interface{}{"guilds", "directMessages", "guildMessages", "messageContent"},
+    },
+}
+```
+
+**Capabilities:** components (buttons, select menus), threads, reactions,
+message edit/delete, mentions, media (image, video, audio, document).
+
+---
+
+### Slack
+
+| | |
+|---|---|
+| Package | `platform/slack` |
+| Auth | `token` — bot token (`xoxb-...`) from Slack App settings |
+| Connection | RTM (Real-Time Messaging) |
+| SDK | `github.com/slack-go/slack` |
+| Text limit | 40 000 characters |
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformSlack,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: "xoxb-...",
+    },
+    Options: map[string]interface{}{
+        "appToken": "xapp-...", // optional App-Level Token for Socket Mode
+    },
+}
+```
+
+**Capabilities:** Block Kit buttons/menus, reactions, threads, message
+edit, media.
+
+---
+
+### Feishu
+
+| | |
+|---|---|
+| Package | `platform/feishu` |
+| Auth | `oauth` — App ID + App Secret from Feishu Open Platform |
+| Connection | WebSocket (Feishu event-push via `larkws`) |
+| SDK | `github.com/larksuite/oapi-sdk-go/v3` |
+| Text limit | 30 720 characters |
+| Domain | `feishu.cn` |
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformFeishu,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     "cli_xxxxxxxxxxxxxxxx",   // App ID
+        ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // App Secret
+    },
+}
+```
+
+**Capabilities:** interactive cards (full card builder), quick actions
+(slash-like `/` menu), reactions, threads, message edit/delete, media.
+
+**Platform-specific methods** (cast via `imbot.AsFeishuBot`):
+
+```go
+if fs, ok := imbot.AsFeishuBot(bot); ok {
+    fs.SetQuickActions(actions)
+    actions, _ := fs.GetQuickActions()
+}
+```
+
+**ID routing:** The adapter automatically selects `receive_id_type` based
+on the target ID prefix (`ou_` → `user_id`, `cli_` → `chat_id`,
+`oc_` → `open_id`).
+
+---
+
+### Lark
+
+| | |
+|---|---|
+| Package | `platform/lark` |
+| Auth | `oauth` — same as Feishu |
+| Domain | `larksuite.com` (international) |
+
+Lark is the international edition of Feishu.  The `lark` package is a
+thin wrapper around the `feishu` package that sets `DomainLark` so the
+SDK targets `larksuite.com` instead of `feishu.cn`.  Configuration and
+capabilities are identical to Feishu.
+
+```go
+&core.Config{
+    Platform: core.PlatformLark,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     "cli_...",
+        ClientSecret: "...",
+    },
+}
+```
+
+---
+
+### DingTalk
+
+| | |
+|---|---|
+| Package | `platform/dingtalk` |
+| Auth | `oauth` — AppKey + AppSecret from DingTalk Open Platform |
+| Connection | DingTalk Stream SDK (persistent TCP stream) |
+| SDK | `github.com/open-dingtalk/dingtalk-stream-sdk-go` |
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformDingTalk,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     "dingxxxxxxxxxxxxxxxxxx",  // AppKey
+        ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // AppSecret
+    },
+}
+```
+
+**Design notes:**
+
+- Receiving messages uses the **Stream SDK** (no public webhook URL needed).
+- Sending and reactions use a **REST API** with a cached access token
+  (auto-refreshed before expiry).
+- Incoming webhook URLs for sending replies are stored per
+  `conversationID` and populated on first message receipt.
+
+**Capabilities:** chatbot message handling, reactions via REST API, media.
+
+---
+
+### Weixin
+
+| | |
+|---|---|
+| Package | `platform/weixin` |
+| Auth | Token + AccountID |
+| Connection | WebSocket via `github.com/tingly-dev/weixin` SDK |
+
+Weixin supports WeChat personal and official accounts through the
+tingly-dev weixin SDK.
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformWeixin,
+    Auth: core.AuthConfig{
+        Type:      "token",
+        Token:     "bot_id:token_key",  // combined token
+        AccountID: "bot_id",            // WeChat bot/account ID
+        AuthDir:   "user_id",           // reused field for user ID
+    },
+    Options: map[string]interface{}{
+        "baseUrl": "https://weixin-gateway.example.com",
+    },
+}
+```
+
+**Capabilities:** text, media (image, audio, video, document), basic
+message routing per account.
+
+---
+
+### WeCom
+
+| | |
+|---|---|
+| Package | `platform/wecom` |
+| Auth | `oauth` — Bot ID + Bot Secret |
+| Connection | WebSocket via `github.com/tingly-dev/weixin/wecom` SDK |
+
+WeCom (企业微信) AI Bot integration for enterprise group chats.
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformWecom,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // Bot ID
+        ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",      // Bot Secret
+    },
+}
+```
+
+**Capabilities:** text and media messages inside WeCom group/direct chats.
+
+---
+
+### WhatsApp
+
+| | |
+|---|---|
+| Package | `platform/whatsapp` |
+| Auth | `token` — API key from Meta Business |
+| Connection | HTTP (Meta Business API webhooks) — stateless REST calls |
+
+**Config:**
+
+```go
+&core.Config{
+    Platform: core.PlatformWhatsApp,
+    Auth: core.AuthConfig{
+        Type:    "token",
+        Token:   "EAAxxxxxxxxxx...",  // Meta permanent or temporary token
+        AuthDir: "/path/to/auth/dir", // optional: local session storage
+    },
+    Options: map[string]interface{}{
+        "phoneId": "1234567890",  // WhatsApp Business phone-number ID
+        "apiUrl":  "https://graph.facebook.com/v18.0",
+    },
+}
+```
+
+**Design notes:** Unlike persistent-connection platforms, WhatsApp uses
+stateless REST calls for sending.  Incoming messages arrive via Meta
+webhook events handled externally and fed to the bot via the adapter.
+
+**Capabilities:** text, images, documents, audio, read receipts.
+
+---
+
+### Tingly (internal / test)
+
+| | |
+|---|---|
+| Package | `platform/tingly` |
+| Auth | `none` |
+| Connection | Pluggable `Transport` interface |
+
+Tingly is the internal test platform used by the E2E harness under
+`platform/tingly/testenv/`.  It provides **full feature parity** with
+Telegram (inline keyboards, menus, commands, reactions, media) over an
+in-process or network transport.
+
+```go
+// Register a custom in-process transport
+tingly.RegisterTransport(botUUID, myTransport)
+
+// Create bot (no real auth needed)
+&core.Config{
+    Platform: core.PlatformTingly,
+    Auth:     core.AuthConfig{Type: "none"},
+}
+```
+
+The `testenv` sub-package spins up a complete Tingly bot in-process,
+making it possible to write deterministic integration tests without a
+live messaging account.
+
+---
+
+## Adapter pattern
+
+Every platform that receives events implements an **Adapter** that
+converts raw SDK types to the unified `core.Message`:
+
+```
+Raw SDK event
+    └─► Adapter.AdaptMessage() / AdaptCallback()
+            └─► core.Message  (emitted to Manager handlers)
+```
+
+Platforms that support interactive elements additionally implement
+`interaction.Adapter` and optionally `menu.Adapter`, wired up in
+`interaction.go` / `menu.go` inside each package.
+
+## Adding a new platform
+
+1. Create `platform/<name>/<name>.go` embedding `*core.BaseBot`.
+2. Implement `core.Bot` (connect, disconnect, send, react, etc.).
+3. Add an `Adapter` that converts raw events to `core.Message` and calls
+   `b.EmitMessage(msg)`.
+4. Register the constructor in `registry.go` under
+   `RegisterBuiltinPlatforms()`.
+5. Optionally implement `interaction.Adapter` and `menu.Adapter` for
+   richer interactivity.

--- a/imbot/platform/README.md
+++ b/imbot/platform/README.md
@@ -47,6 +47,23 @@ platform.Register(core.Platform("myplatform"), func(cfg *core.Config) (core.Bot,
 
 ## Platform reference
 
+Each platform has its own README with full configuration and design details:
+
+| Platform | README | Auth | Connection |
+|---|---|---|---|
+| Telegram | [telegram/README.md](telegram/README.md) | token | Long-polling |
+| Discord | [discord/README.md](discord/README.md) | token | WebSocket (Gateway) |
+| Slack | [slack/README.md](slack/README.md) | token | RTM |
+| Feishu | [feishu/README.md](feishu/README.md) | oauth | WebSocket (Event Push) |
+| Lark | [lark/README.md](lark/README.md) | oauth | WebSocket (Event Push) |
+| DingTalk | [dingtalk/README.md](dingtalk/README.md) | oauth | Stream SDK |
+| Weixin | [weixin/README.md](weixin/README.md) | token | WebSocket |
+| WeCom | [wecom/README.md](wecom/README.md) | oauth | WebSocket |
+| WhatsApp | [whatsapp/README.md](whatsapp/README.md) | token | REST (Meta Cloud API) |
+| Tingly | [tingly/README.md](tingly/README.md) | none | InProcess / pluggable |
+
+---
+
 ### Telegram
 
 | | |

--- a/imbot/platform/dingtalk/README.md
+++ b/imbot/platform/dingtalk/README.md
@@ -1,0 +1,80 @@
+# platform/dingtalk
+
+DingTalk (钉钉) bot implementation using the official
+[DingTalk Stream SDK](https://github.com/open-dingtalk/dingtalk-stream-sdk-go).
+
+## Authentication
+
+**Type:** `oauth`
+
+Create a **chatbot application** in the
+[DingTalk Open Platform](https://open.dingtalk.com/). Copy the **AppKey** and
+**AppSecret** from the app credentials page.
+
+```go
+Auth: core.AuthConfig{
+    Type:         "oauth",
+    ClientID:     "dingxxxxxxxxxxxxxxxxxx", // AppKey
+    ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // AppSecret
+}
+```
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformDingTalk,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     os.Getenv("DINGTALK_APP_KEY"),
+        ClientSecret: os.Getenv("DINGTALK_APP_SECRET"),
+    },
+}
+```
+
+No additional options are required.
+
+## Connection model
+
+The bot uses a **dual-channel** design:
+
+| Channel | Purpose |
+|---|---|
+| **Stream SDK** (`StreamClient`) | Receives incoming chatbot messages over a persistent TCP stream |
+| **REST API** | Sends messages and reactions; requires a cached access token |
+
+The stream connection is initiated by `Connect` via `cli.Start(ctx)`. No public
+inbound URL is needed — the bot calls DingTalk's stream endpoint.
+
+### Access token caching
+
+REST API calls (e.g. reactions) require an access token obtained via
+`/gettoken`. The bot caches the token in memory and refreshes it automatically
+before expiry (`tokenExpiry`). The cache is protected by `tokenMu`.
+
+### Webhook map
+
+When a chatbot message arrives, DingTalk includes a per-conversation
+`sessionWebhook` URL. The bot stores these in `webhookMap`
+(`conversationID → webhookURL`) so that replies can be routed back to the
+correct conversation without a separate target-resolution call.
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media | ✅ |
+| Reactions (via REST API) | ✅ |
+| Card buttons | ✅ |
+| Edit message | ✅ |
+| Delete message | ✅ |
+| Text limit | 20 000 chars |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `dingtalk.go` | `Bot` struct, lifecycle, send/react/edit/delete; token cache; webhook map |
+| `adapter.go` | Converts `chatbot.BotCallbackDataModel` → `core.Message` |
+| `interaction.go` | Builds DingTalk card button layouts from `interaction.Interaction` |

--- a/imbot/platform/discord/README.md
+++ b/imbot/platform/discord/README.md
@@ -1,0 +1,94 @@
+# platform/discord
+
+Discord bot implementation using [discordgo](https://github.com/bwmarrin/discordgo).
+
+## Authentication
+
+**Type:** `token`
+
+Create a bot application in the [Discord Developer Portal](https://discord.com/developers/applications),
+generate a bot token under **Bot → Token**, and invite the bot to your server with the required permissions.
+
+```go
+Auth: core.AuthConfig{
+    Type:  "token",
+    Token: "MTxxxxxxxxxxxxxxxxxxxxxxxx.Gxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+}
+```
+
+The `"Bot "` prefix is added automatically if omitted from the token string.
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformDiscord,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: os.Getenv("DISCORD_BOT_TOKEN"),
+    },
+    Options: map[string]interface{}{
+        // Gateway intents to subscribe to.
+        // Default: Guilds, DirectMessages, GuildMessages, MessageContent.
+        "intents": []interface{}{
+            "guilds",
+            "directMessages",
+            "guildMessages",
+            "messageContent",
+        },
+    },
+}
+```
+
+### Available intent strings
+
+`guilds`, `guildMembers`, `guildBans`, `guildEmojis`, `guildIntegrations`,
+`guildWebhooks`, `guildInvites`, `guildVoiceStates`, `guildPresences`,
+`guildMessages`, `guildMessageReactions`, `guildMessageTyping`,
+`directMessages`, `directMessageReactions`, `directMessageTyping`,
+`messageContent`, `guildScheduledEvents`.
+
+Note: `messageContent` is a **privileged intent** that must be enabled in the
+Developer Portal for bots in 100+ servers.
+
+## Connection model
+
+`Connect` opens a **WebSocket connection to the Discord Gateway** via
+`discordgo.Session.Open()`. The session is managed by discordgo and
+reconnects automatically on transient failures.
+
+Two Gateway event handlers are registered:
+
+| Event | Purpose |
+|---|---|
+| `MessageCreate` | Incoming guild and DM messages |
+| `Ready` | Marks the bot as ready after gateway handshake |
+
+## Message ID format
+
+Discord encodes message references as `"channelID:messageID"` (colon-separated).
+`React`, `EditMessage`, and `DeleteMessage` all parse this format to call the
+appropriate discordgo API.
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media (images, files) | ✅ |
+| Components (buttons, select menus) | ✅ |
+| Reactions | ✅ |
+| Edit message | ✅ |
+| Delete message | ✅ |
+| Threads | ✅ |
+| Mentions | ✅ |
+| DMs | ✅ |
+| Text limit | 2 000 chars |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `discord.go` | `Bot` struct, lifecycle, send/react/edit/delete |
+| `adapter.go` | Converts `discordgo.Message` → `core.Message` |
+| `interaction.go` | Builds Discord component rows from `interaction.Interaction` |

--- a/imbot/platform/feishu/README.md
+++ b/imbot/platform/feishu/README.md
@@ -1,0 +1,101 @@
+# platform/feishu
+
+Feishu (飞书) bot implementation using the official
+[Lark OpenAPI SDK](https://github.com/larksuite/oapi-sdk-go).
+
+## Authentication
+
+**Type:** `oauth`
+
+Create a **self-built app** in the [Feishu Open Platform](https://open.feishu.cn/),
+enable the required permissions, and copy the **App ID** and **App Secret**.
+
+```go
+Auth: core.AuthConfig{
+    Type:         "oauth",
+    ClientID:     "cli_xxxxxxxxxxxxxxxx",    // App ID
+    ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // App Secret
+}
+```
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformFeishu,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     os.Getenv("FEISHU_APP_ID"),
+        ClientSecret: os.Getenv("FEISHU_APP_SECRET"),
+    },
+}
+```
+
+No additional options are required for standard usage.
+
+## Connection model
+
+`Connect` performs two steps:
+
+1. **Authentication check** — calls `GetTenantAccessTokenBySelfBuiltApp` to
+   verify the credentials immediately.
+2. **WebSocket long connection** — starts `larkws.Client` which maintains a
+   persistent WebSocket to Feishu's event-push endpoint
+   (`open.feishu.cn`). Events are dispatched by `dispatcher.EventDispatcher`.
+
+No public inbound webhook URL is required; the bot initiates the connection.
+
+## ID routing
+
+`SendMessage` automatically selects `receive_id_type` based on the target ID
+prefix:
+
+| Prefix | Type | Usage |
+|---|---|---|
+| `cli_` | `chat_id` | Group chat |
+| `ou_` | `user_id` | User (cross-app, global) |
+| `oc_` | `open_id` | User (app-specific) |
+| *(other)* | `open_id` | Default fallback |
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media (image, audio, video, document) | ✅ |
+| Interactive cards (full Feishu card builder) | ✅ |
+| Quick actions (`/` command menu) | ✅ |
+| Native commands | ✅ |
+| Reactions | ✅ |
+| Edit message | ✅ |
+| Delete message | ✅ |
+| Threads | ✅ |
+| Text limit | 30 720 chars |
+
+## Platform-specific API
+
+```go
+import "github.com/tingly-dev/tingly-box/imbot/platform/feishu"
+
+if fs, ok := bot.(*feishu.Bot); ok {
+    // Register quick actions shown when the user types "/".
+    fs.SetQuickActions(actions)
+
+    // Retrieve the current quick-action configuration.
+    actions, err := fs.GetQuickActions()
+}
+```
+
+`imbot.AsFeishuBot(bot)` is a convenience wrapper for the type assertion.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `bot_sdk.go` | `Bot` struct, lifecycle, send/react/edit/delete; domain constants |
+| `adapter.go` | Converts Feishu event payloads → `core.Message` |
+| `types.go` | Feishu-specific event and payload structs |
+| `interaction.go` | Builds interactive cards from `interaction.Interaction` |
+| `menu.go` | Converts `menu.Menu` → Feishu interactive card buttons |
+| `menu_setup.go` | Registers quick actions via Feishu API |
+| `registration.go` | Registers the platform in the global registry |

--- a/imbot/platform/lark/README.md
+++ b/imbot/platform/lark/README.md
@@ -1,0 +1,55 @@
+# platform/lark
+
+Lark is the international edition of Feishu.  This package is a **thin wrapper**
+around [`platform/feishu`](../feishu/README.md) that targets
+`open.larksuite.com` instead of `open.feishu.cn`.
+
+All behaviour, configuration keys, capabilities, and platform-specific APIs are
+identical to Feishu — only the base URL differs.
+
+## Authentication
+
+**Type:** `oauth`
+
+Create a **self-built app** in [Lark Developer Console](https://open.larksuite.com/).
+
+```go
+Auth: core.AuthConfig{
+    Type:         "oauth",
+    ClientID:     "cli_xxxxxxxxxxxxxxxx",    // App ID
+    ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxx", // App Secret
+}
+```
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformLark,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     os.Getenv("LARK_APP_ID"),
+        ClientSecret: os.Getenv("LARK_APP_SECRET"),
+    },
+}
+```
+
+## Implementation notes
+
+- `lark.NewBot(config)` calls `feishu.NewBot(config, feishu.DomainLark)`.
+- The Lark SDK client is initialised with `lark.LarkBaseUrl`
+  (`https://open.larksuite.com`) as the HTTP base URL.
+- The WebSocket event-push endpoint also targets Lark's infrastructure.
+- `PlatformInfo()` returns `"lark"` as the platform identifier.
+
+## Webhook helpers
+
+`GetWebhookURL(path)` returns `/webhook/lark/<path>` — use this if you
+register a webhook endpoint in your HTTP server for Lark event verification.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `lark.go` | Thin `Bot` wrapper; delegates all calls to `feishu.Bot` |
+| `menu.go` | Lark-specific menu helpers (re-uses Feishu card format) |

--- a/imbot/platform/slack/README.md
+++ b/imbot/platform/slack/README.md
@@ -1,0 +1,82 @@
+# platform/slack
+
+Slack bot implementation using [slack-go/slack](https://github.com/slack-go/slack).
+
+## Authentication
+
+**Type:** `token`
+
+Create a Slack App at [api.slack.com/apps](https://api.slack.com/apps), add a
+bot user, install the app to your workspace, and copy the **Bot User OAuth
+Token** (`xoxb-...`).
+
+```go
+Auth: core.AuthConfig{
+    Type:  "token",
+    Token: "xoxb-YOUR_BOT_TOKEN",
+}
+```
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformSlack,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: os.Getenv("SLACK_BOT_TOKEN"),
+    },
+    Options: map[string]interface{}{
+        // Optional: App-Level Token for Socket Mode (xapp-...).
+        // If provided, the bot uses Socket Mode instead of RTM.
+        "appToken": os.Getenv("SLACK_APP_TOKEN"),
+    },
+}
+```
+
+### Required OAuth scopes
+
+`channels:history`, `channels:read`, `chat:write`, `groups:history`,
+`groups:read`, `im:history`, `im:read`, `mpim:history`, `mpim:read`,
+`reactions:write`, `users:read`.
+
+## Connection model
+
+`Connect` calls `client.AuthTest()` to verify credentials, then starts an
+**RTM (Real-Time Messaging)** session via `slack.NewRTM()`.  The RTM loop
+runs in a background goroutine and delivers events over a channel.
+
+If an `appToken` option is set, Socket Mode is used instead of RTM, which
+does not require a public inbound URL.
+
+## Message ID format
+
+Slack encodes message references as `"channelID:timestamp"` (colon-separated),
+where `timestamp` is the Slack message timestamp string (e.g.
+`"C012AB3CD:1512085950.000216"`).
+
+For threaded replies the format is extended to
+`"channelID:timestamp:thread:threadTimestamp"`.
+
+`React`, `EditMessage`, and `DeleteMessage` all parse this format.
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media (files) | ✅ |
+| Block Kit buttons and menus | ✅ |
+| Reactions | ✅ |
+| Edit message | ✅ |
+| Delete message | ✅ |
+| Threads | ✅ |
+| DMs | ✅ |
+| Text limit | 40 000 chars |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `slack.go` | `Bot` struct, lifecycle, send/react/edit/delete |
+| `slack_test.go` | Unit tests |

--- a/imbot/platform/telegram/README.md
+++ b/imbot/platform/telegram/README.md
@@ -1,0 +1,119 @@
+# platform/telegram
+
+Telegram bot implementation using the [go-telegram/bot](https://github.com/go-telegram/bot) SDK.
+
+## Authentication
+
+**Type:** `token`
+
+Obtain a bot token from [@BotFather](https://t.me/botfather) on Telegram.
+
+```go
+Auth: core.AuthConfig{
+    Type:  "token",
+    Token: "123456:ABC-DEF...",
+}
+```
+
+The token value may be a literal string or an environment-variable reference
+prefixed with `$` (e.g. `"$TELEGRAM_BOT_TOKEN"`).
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformTelegram,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: os.Getenv("TELEGRAM_BOT_TOKEN"),
+    },
+    Options: map[string]interface{}{
+        // Optional: route all API calls through a proxy.
+        // Supported schemes: socks5, socks5h, http, https.
+        "proxy": "socks5://user:pass@proxy-host:1080",
+
+        // Optional: enable verbose SDK-level debug logging.
+        "debug": false,
+    },
+}
+```
+
+## Connection model
+
+The bot uses **long-polling** (`bot.Start(ctx)`) to receive updates from the
+Telegram API. No inbound port or public URL is required. The polling loop runs
+in a background goroutine and is stopped when `Disconnect` cancels the context.
+
+Two handler types are registered on connect:
+
+| Handler type | Purpose |
+|---|---|
+| `HandlerTypeMessageText` | All incoming text messages |
+| `HandlerTypeCallbackQueryData` | Inline keyboard button presses |
+
+Callback queries are automatically acknowledged
+(`AnswerCallbackQuery`) after the adapted message is emitted, which removes
+the loading spinner on the user's button.
+
+## Message ID format
+
+`messageID` is a plain decimal integer string (e.g. `"42"`).
+
+The bot maintains an internal `messageIDMap` (`chatID → last message ID`) so
+that `React` can resolve the target chat from a bare message ID.
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media (photo, video, audio, document, sticker, GIF) | ✅ |
+| Inline keyboards (callback buttons, URL buttons) | ✅ |
+| Reply keyboards | ✅ |
+| Chat menu button | ✅ |
+| Native commands (`/cmd`) | ✅ |
+| Reactions | ✅ |
+| Edit message | ✅ |
+| Delete message | ✅ |
+| Threads (forum topics) | ✅ |
+| Polls | ✅ |
+| Proxy support (SOCKS5 / HTTP) | ✅ |
+| Text limit | 4 096 chars |
+
+## Platform-specific API
+
+Cast the `core.Bot` to `*telegram.Bot` for Telegram-only features:
+
+```go
+import "github.com/tingly-dev/tingly-box/imbot/platform/telegram"
+
+if tg, ok := bot.(*telegram.Bot); ok {
+    // Set the bot command list shown in the Telegram menu.
+    tg.SetCommandList(registry.BuildTelegramMenuCommands())
+
+    // Change the menu button shown in the chat header.
+    tg.SetMenuButton(telegram.MenuButtonConfig{
+        Type: telegram.MenuButtonTypeCommands,
+    })
+
+    // Or link a Web App.
+    tg.SetMenuButton(telegram.MenuButtonConfig{
+        Type: telegram.MenuButtonTypeWebApp,
+        Text: "Open App",
+        URL:  "https://example.com/app",
+    })
+}
+```
+
+`imbot.AsTelegramBot(bot)` is a convenience wrapper that performs the same
+type assertion.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `telegram.go` | `Bot` struct, lifecycle (`Connect`/`Disconnect`), send/react/edit/delete |
+| `adapter.go` | Converts `models.Message` / `CallbackQuery` → `core.Message` |
+| `interaction.go` | Builds Telegram inline keyboards from `interaction.Interaction` |
+| `menu.go` | Converts `menu.Menu` → Telegram reply/inline keyboards |
+| `menu_setup.go` | Sets bot commands and menu button via API |

--- a/imbot/platform/tingly/README.md
+++ b/imbot/platform/tingly/README.md
@@ -1,0 +1,157 @@
+# platform/tingly
+
+Tingly is the **internal test platform** for imbot. It provides full feature
+parity with a real messaging platform (inline keyboards, reactions, edit,
+delete, media) over a pluggable **Transport** seam, making it possible to write
+deterministic integration and E2E tests without a live messaging account.
+
+## Design
+
+```
+tingly.Bot
+  └── Transport  ← seam
+        ├── InProcessTransport   (used by tests and testenv)
+        └── (future WebSocketTransport for a real tingly server)
+```
+
+`Bot` never touches a network directly. Every outbound operation (`SendMessage`,
+`React`, `EditMessage`, `DeleteMessage`) is forwarded to the `Transport`.
+Inbound messages are injected into the bot via `Transport.Subscribe`.
+
+## Authentication
+
+**Type:** `none`
+
+No credentials are required.
+
+```go
+Auth: core.AuthConfig{Type: "none"}
+```
+
+## Configuration
+
+```go
+&core.Config{
+    UUID:     "my-test-bot",   // used by the transport registry
+    Platform: core.PlatformTingly,
+    Auth:     core.AuthConfig{Type: "none"},
+}
+```
+
+## Using in tests with InProcessTransport
+
+### Basic setup
+
+```go
+import (
+    "github.com/tingly-dev/tingly-box/imbot/platform/tingly"
+    "github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+transport := tingly.NewInProcessTransport()
+
+bot, _ := tingly.NewBot(&core.Config{
+    UUID:     "test-bot",
+    Platform: core.PlatformTingly,
+    Auth:     core.AuthConfig{Type: "none"},
+}, transport)
+
+bot.Connect(context.Background())
+```
+
+### Injecting inbound messages
+
+```go
+transport.Inject(core.Message{
+    ID:       "msg-1",
+    Platform: core.PlatformTingly,
+    Sender:   core.Sender{ID: "user-1", DisplayName: "Alice"},
+    Recipient: core.Recipient{ID: "chat-1"},
+    Content:  core.NewTextContent("hello"),
+})
+```
+
+### Asserting outbound events
+
+```go
+// Snapshot of all recorded bot actions.
+events := transport.Events()
+
+// Filter to a single chat.
+chatEvents := transport.EventsForChat("chat-1")
+
+// Wait for the next event on a chat (blocking).
+ch := transport.Channel("chat-1")
+evt := <-ch
+
+switch evt.Kind {
+case tingly.EventSend:
+    fmt.Println("bot sent:", evt.Text)
+    fmt.Println("keyboard:", evt.Keyboard) // decoded inline keyboard
+case tingly.EventReact:
+    fmt.Println("bot reacted:", evt.Emoji)
+case tingly.EventEdit:
+    fmt.Println("bot edited message:", evt.MessageID)
+}
+```
+
+### Event kinds
+
+| `EventKind` | Triggered by |
+|---|---|
+| `EventSend` | `SendMessage` / `SendText` with text |
+| `EventMedia` | `SendMessage` / `SendMedia` with media only |
+| `EventEdit` | `EditMessage` |
+| `EventDelete` | `DeleteMessage` |
+| `EventReact` | `React` |
+
+### Keyboard decoding
+
+The `Event.Keyboard` field is automatically populated when the outbound
+message carries an inline keyboard. Each `Button` exposes `Label`,
+`CallbackData`, and `URL`.
+
+## Using the testenv harness
+
+`platform/tingly/testenv` provides higher-level helpers that wrap the
+transport and expose a chat-centric API:
+
+```go
+import "github.com/tingly-dev/tingly-box/imbot/platform/tingly/testenv"
+
+env := testenv.New()
+chat := env.NewChat("user-1")
+
+chat.Send("hello")                          // inject a user message
+reply := chat.WaitForReply(time.Second)     // wait for the bot to respond
+```
+
+## Registering a transport by UUID
+
+When using `imbot.Manager`, the bot is created via the global registry (not
+directly). Pre-register the transport before adding the bot to the manager:
+
+```go
+tingly.Register("my-test-bot-uuid", transport)
+defer tingly.Unregister("my-test-bot-uuid")
+
+manager.AddBot(&core.Config{
+    UUID:     "my-test-bot-uuid",
+    Platform: core.PlatformTingly,
+    Auth:     core.AuthConfig{Type: "none"},
+})
+```
+
+`NewBotFromConfig` (the registry factory) calls `lookup(config.UUID)` to find
+the pre-registered transport. If none is found, a fresh `InProcessTransport`
+is created automatically.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `tingly.go` | `Bot` struct and lifecycle; delegates all ops to `Transport` |
+| `transport.go` | `Transport` interface; `InProcessTransport`; `Event` types; transport registry |
+| `adapter.go` | Decodes reply markup into `Keyboard` / `Button` structs |
+| `interaction.go` | Builds tingly interaction responses |
+| `testenv/` | High-level E2E harness wrapping `InProcessTransport` |

--- a/imbot/platform/wecom/README.md
+++ b/imbot/platform/wecom/README.md
@@ -1,0 +1,58 @@
+# platform/wecom
+
+WeCom (企业微信, Enterprise WeChat) AI Bot implementation using the
+[tingly-dev/weixin/wecom](https://github.com/tingly-dev/weixin) SDK.
+
+## Authentication
+
+**Type:** `oauth`
+
+Obtain the **Bot ID** and **Bot Secret** from the WeCom admin console
+(企业微信管理后台) under the AI Bot configuration.
+
+```go
+Auth: core.AuthConfig{
+    Type:         "oauth",
+    ClientID:     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // Bot ID
+    ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",      // Bot Secret
+}
+```
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformWecom,
+    Auth: core.AuthConfig{
+        Type:         "oauth",
+        ClientID:     os.Getenv("WECOM_BOT_ID"),
+        ClientSecret: os.Getenv("WECOM_BOT_SECRET"),
+    },
+}
+```
+
+Both `ClientID` and `ClientSecret` are required; the bot will return an error
+during construction if either is empty.
+
+## Connection model
+
+The bot wraps `wecom.WecomBot` from the tingly-dev weixin SDK.  The underlying
+transport is a **WebSocket** connection managed by the SDK.  `Connect` starts
+the WebSocket session and `Disconnect` stops it.
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media | ✅ |
+| Group and direct chat | ✅ |
+| Reactions | ❌ |
+| Edit / Delete message | ❌ |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `wecom.go` | `Bot` struct, lifecycle, send methods |
+| `adapter.go` | Converts WeCom message payloads → `core.Message` |

--- a/imbot/platform/weixin/README.md
+++ b/imbot/platform/weixin/README.md
@@ -1,0 +1,71 @@
+# platform/weixin
+
+WeChat (微信) personal and official account bot implementation using the
+[tingly-dev/weixin](https://github.com/tingly-dev/weixin) SDK.
+
+## Authentication
+
+**Type:** `token` (combined format)
+
+Credentials are sourced from multiple `AuthConfig` fields that are reused for
+WeChat-specific semantics:
+
+| `AuthConfig` field | WeChat meaning |
+|---|---|
+| `Token` | `"bot_id:token_key"` combined token string |
+| `AccountID` | WeChat bot / account ID |
+| `AuthDir` | WeChat user ID |
+
+```go
+Auth: core.AuthConfig{
+    Type:      "token",
+    Token:     "mybot:secretkey123",
+    AccountID: "mybot",
+    AuthDir:   "target_user_id",
+},
+```
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformWeixin,
+    Auth: core.AuthConfig{
+        Type:      "token",
+        Token:     os.Getenv("WEIXIN_TOKEN"),
+        AccountID: os.Getenv("WEIXIN_BOT_ID"),
+        AuthDir:   os.Getenv("WEIXIN_USER_ID"),
+    },
+    Options: map[string]interface{}{
+        // Required: base URL of the WeChat gateway service.
+        "baseUrl": "https://weixin-gateway.example.com",
+        // Alternative key name also accepted:
+        // "base_url": "https://weixin-gateway.example.com",
+    },
+}
+```
+
+## Connection model
+
+The bot wraps `wechat.WechatBot` from the tingly-dev weixin SDK and connects
+via a **WebSocket** to the configured `baseUrl`. Each bot is associated with a
+single WeChat account identified by `accountID`.
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media (image, audio, video, document) | ✅ |
+| Basic message routing per account | ✅ |
+| Reactions | ❌ |
+| Edit / Delete message | ❌ |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `weixin.go` | `Bot` struct, lifecycle, send methods |
+| `adapter.go` | Converts WeChat message types → `core.Message` |
+| `interaction.go` | Interaction adapter (text-mode fallback) |
+| `registration.go` | Registers the platform in the global registry |

--- a/imbot/platform/whatsapp/README.md
+++ b/imbot/platform/whatsapp/README.md
@@ -1,0 +1,81 @@
+# platform/whatsapp
+
+WhatsApp Business bot implementation using the
+[Meta Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api).
+
+## Authentication
+
+**Type:** `token` or `qr`
+
+The `token` type is recommended for production.  Obtain a permanent or
+temporary access token from [Meta for Developers](https://developers.facebook.com/),
+set up a WhatsApp Business App, and note the **Phone Number ID**.
+
+```go
+Auth: core.AuthConfig{
+    Type:  "token",
+    Token: "EAAxxxxxxxxxx...", // Meta access token
+}
+```
+
+`qr` auth requires a pre-configured API key from a Baileys-based session and
+is not recommended for server deployments.
+
+## Configuration
+
+```go
+&core.Config{
+    Platform: core.PlatformWhatsApp,
+    Auth: core.AuthConfig{
+        Type:  "token",
+        Token: os.Getenv("WHATSAPP_TOKEN"),
+    },
+    Options: map[string]interface{}{
+        // Required: WhatsApp Business phone-number ID (not the phone number itself).
+        "phoneId": os.Getenv("WHATSAPP_PHONE_ID"),
+
+        // Optional: Meta Graph API base URL (default: https://graph.facebook.com/v20.0).
+        "apiUrl": "https://graph.facebook.com/v20.0",
+
+        // Optional: local directory for session storage.
+        "authDir": "./whatsapp-auth",
+    },
+}
+```
+
+## Connection model
+
+WhatsApp uses a **stateless REST** design:
+
+- **Sending** — Each `SendMessage` call is an HTTPS POST to
+  `{apiUrl}/{phoneId}/messages` with a 30-second timeout.
+- **Receiving** — Incoming messages arrive as webhook events from Meta. These
+  are fed to the bot from the external HTTP server via the adapter; the bot
+  itself does not open an inbound socket.
+
+`Connect` calls an authentication probe against the Meta API and starts a
+background goroutine for polling/webhook receipt.
+
+## Message structure
+
+Incoming messages are parsed from Meta's
+[`MessageEvent`](whatsapp.go) structure which wraps the standard webhook
+payload format (`object → entry[].changes[].value.messages[]`).
+
+## Capabilities
+
+| Feature | Supported |
+|---|---|
+| Send text | ✅ |
+| Send media (image, audio, video, document) | ✅ |
+| Read receipts | ✅ |
+| Reactions | ❌ |
+| Edit / Delete message | ❌ |
+| Interactive buttons | ❌ (planned via template messages) |
+| Text limit | 4 096 chars |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `whatsapp.go` | `Bot` struct, lifecycle, send methods; `MessageEvent` / `SendMessageResponse` types |


### PR DESCRIPTION
## Summary

This PR adds comprehensive README documentation for all supported messaging platforms in the `imbot/platform` directory, along with an overview document for the platform layer itself. Each platform now has detailed documentation covering authentication, configuration, connection models, capabilities, and implementation details.

## Changes

- **`platform/README.md`** — Overview of the platform architecture, registry system, and guidelines for adding new platforms
- **`platform/telegram/README.md`** — Telegram bot documentation covering token auth, long-polling, inline keyboards, commands, and capabilities
- **`platform/discord/README.md`** — Discord bot documentation covering token auth, WebSocket gateway, intents, components, and capabilities
- **`platform/slack/README.md`** — Slack bot documentation covering token auth, RTM/Socket Mode, Block Kit, and capabilities
- **`platform/feishu/README.md`** — Feishu bot documentation covering OAuth, WebSocket event push, ID routing, interactive cards, and quick actions
- **`platform/lark/README.md`** — Lark bot documentation (thin wrapper around Feishu targeting international endpoints)
- **`platform/dingtalk/README.md`** — DingTalk bot documentation covering OAuth, dual-channel design (Stream SDK + REST API), token caching, and capabilities
- **`platform/weixin/README.md`** — WeChat bot documentation covering token auth, WebSocket connection, and basic capabilities
- **`platform/wecom/README.md`** — WeCom (Enterprise WeChat) bot documentation covering OAuth, WebSocket, and capabilities
- **`platform/whatsapp/README.md`** — WhatsApp bot documentation covering token auth, Meta Cloud API, stateless REST design, and capabilities
- **`platform/tingly/README.md`** — Tingly test platform documentation covering the Transport seam, InProcessTransport, event injection, assertion patterns, and testenv harness
- **`imbot/README.md`** — Updated main README with platform support table showing status, auth type, and connection model for all platforms

## Notable Details

- Each platform document includes authentication type, configuration examples, connection model explanation, and a capabilities matrix
- Platform-specific APIs and advanced features are documented where applicable (e.g., Telegram menu buttons, Feishu quick actions, Discord intents)
- Tingly documentation provides detailed guidance on using the test platform for deterministic E2E testing with code examples
- Main README updated with a structured table replacing the previous unordered list, providing clearer status and connection information

https://claude.ai/code/session_01XcGENK9mK2uvbboRVtxhPT