### PR TITLE
doc: Add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ task wails:build
 | <img width="196" height="196" alt="image" src="https://github.com/user-attachments/assets/56022b70-97da-498f-bf83-822a11668fa7" /> | <img width="196" height="196" alt="image" src="https://github.com/user-attachments/assets/30d24cc5-666c-425a-b8d2-5f353af453de" /> |
 | https://t.me/+V1sqeajw1pYwMzU1 | tingly-box |
 
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=tingly-dev/tingly-box)](https://github.com/tingly-dev/tingly-box/graphs/contributors)
+
 ## Early Contributors
 
 Special badges are minted to recognize the contributions from following contributors:

--- a/README.md
+++ b/README.md
@@ -247,10 +247,6 @@ task wails:build
 | <img width="196" height="196" alt="image" src="https://github.com/user-attachments/assets/56022b70-97da-498f-bf83-822a11668fa7" /> | <img width="196" height="196" alt="image" src="https://github.com/user-attachments/assets/30d24cc5-666c-425a-b8d2-5f353af453de" /> |
 | https://t.me/+V1sqeajw1pYwMzU1 | tingly-box |
 
-## Contributors
-
-[![Contributors](https://contrib.rocks/image?repo=tingly-dev/tingly-box)](https://github.com/tingly-dev/tingly-box/graphs/contributors)
-
 ## Early Contributors
 
 Special badges are minted to recognize the contributions from following contributors:
@@ -276,6 +272,10 @@ Special badges are minted to recognize the contributions from following contribu
     </td>
   </tr>
 </table>
+
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=tingly-dev/tingly-box)](https://github.com/tingly-dev/tingly-box/graphs/contributors)
 
 ## License
 


### PR DESCRIPTION
## Summary
Added a new "Contributors" section to the README that displays an auto-generated contributors badge using contrib.rocks.

## Changes
- Added a new "Contributors" section in the README between the community section and "Early Contributors" section
- Integrated contrib.rocks badge to automatically display all project contributors with a link to the contributors graph

## Details
This change improves project visibility by acknowledging all contributors to the tingly-box project. The contrib.rocks integration provides an automatically updated badge that reflects the current list of contributors without requiring manual maintenance.

https://claude.ai/code/session_01XBG8SmgHBs7ttPfBMzDQQg