### PR TITLE
Prevent migrations from re-running and overwriting user changes

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -91,6 +91,11 @@ type Config struct {
 	// MultiTenantConfig holds settings for multi-tenant API token authentication
 	MultiTenantConfig MultiTenantConfig `yaml:"multi_tenant,omitempty" json:"multi_tenant,omitempty"`
 
+	// MigrationsCompleted tracks which one-time migrations have already been applied.
+	// This prevents idempotency-breaking migrations (e.g. service auto-fill) from
+	// re-running on every restart and overwriting intentional user changes.
+	MigrationsCompleted []string `json:"migrations_completed,omitempty" yaml:"migrations_completed,omitempty"`
+
 	ConfigFile string `yaml:"-" json:"-"` // Not serialized to YAML (exported to preserve field)
 	ConfigDir  string `yaml:"-" json:"-"`
 
@@ -2064,4 +2069,21 @@ func (c *Config) ApplyHTTPTransportConfig() {
 		RespectEnvProxy:     c.HTTPTransport.RespectEnvProxy,
 	}
 	client.SetTransportConfig(config)
+}
+
+// hasMigrationCompleted reports whether the named one-time migration has already run.
+func (c *Config) hasMigrationCompleted(name string) bool {
+	for _, m := range c.MigrationsCompleted {
+		if m == name {
+			return true
+		}
+	}
+	return false
+}
+
+// markMigrationCompleted records a one-time migration as done so it is skipped on future startups.
+func (c *Config) markMigrationCompleted(name string) {
+	if !c.hasMigrationCompleted(name) {
+		c.MigrationsCompleted = append(c.MigrationsCompleted, name)
+	}
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -200,9 +200,13 @@ func migrate20260103(c *Config) {
 	}
 }
 
-// migrate20260110 copies services from built-in-cc to built-in-cc-* rules if they are empty
+// migrate20260110 copies services from built-in-cc to built-in-cc-* rules if they are empty.
+// This migration runs only once; subsequent restarts skip it so that a user who intentionally
+// clears a rule's services does not have them silently refilled.
 func migrate20260110(c *Config) {
-	needsSave := false
+	if c.hasMigrationCompleted("20260110") {
+		return
+	}
 
 	// Find the source rule (built-in-cc)
 	var fallbackRule *typ.Rule
@@ -213,8 +217,10 @@ func migrate20260110(c *Config) {
 		}
 	}
 
-	// If source rule doesn't exist or has no services, skip migration
+	// If source rule doesn't exist or has no services, nothing to copy.
+	// Still mark as completed so we don't keep retrying on every restart.
 	if fallbackRule == nil || len(fallbackRule.Services) == 0 {
+		c.markMigrationCompleted("20260110")
 		return
 	}
 
@@ -237,6 +243,7 @@ func migrate20260110(c *Config) {
 		}
 	}
 
+	needsSave := false
 	for i := range c.Rules {
 		rule := &c.Rules[i]
 
@@ -260,6 +267,7 @@ func migrate20260110(c *Config) {
 		needsSave = true
 	}
 
+	c.markMigrationCompleted("20260110")
 	if needsSave {
 		_ = c.Save()
 	}
@@ -282,7 +290,13 @@ func migrate20260114(c *Config) {
 }
 
 // migrate20260210 ensures the subagent rule exists and mirrors the haiku model.
+// This migration runs only once so that a user who intentionally clears the subagent
+// rule's services does not have them silently restored on the next restart.
 func migrate20260210(c *Config) {
+	if c.hasMigrationCompleted("20260210") {
+		return
+	}
+
 	// Find required rules.
 	var haikuRule *typ.Rule
 	var subagentRule *typ.Rule
@@ -298,7 +312,9 @@ func migrate20260210(c *Config) {
 	}
 
 	// Without a haiku model, there's nothing to mirror.
+	// Mark as completed so we don't retry every restart.
 	if haikuRule == nil {
+		c.markMigrationCompleted("20260210")
 		return
 	}
 
@@ -315,6 +331,7 @@ func migrate20260210(c *Config) {
 			}
 		}
 		if subagentRule == nil {
+			c.markMigrationCompleted("20260210")
 			if needsSave {
 				_ = c.Save()
 			}
@@ -330,6 +347,7 @@ func migrate20260210(c *Config) {
 		needsSave = true
 	}
 
+	c.markMigrationCompleted("20260210")
 	if needsSave {
 		_ = c.Save()
 	}


### PR DESCRIPTION
## Summary
Add a migration tracking system to prevent one-time migrations from re-running on every restart and inadvertently overwriting intentional user changes (e.g., when a user clears services from a rule).

## Key Changes
- **New field in Config**: Added `MigrationsCompleted` slice to track which migrations have already been applied
- **Helper methods**: Implemented `hasMigrationCompleted()` and `markMigrationCompleted()` to manage migration state
- **Updated migrate20260110**: Now checks if migration has run before and marks completion even when skipping (no services to copy)
- **Updated migrate20260210**: Now checks if migration has run before and marks completion even when skipping (no haiku rule found)
- **Idempotency guarantee**: Both migrations now persist their completion status to prevent re-running on subsequent restarts

## Implementation Details
- Migrations check `hasMigrationCompleted()` at the start and return early if already applied
- `markMigrationCompleted()` is called in all exit paths (early returns and normal completion) to ensure the migration is recorded as done
- The completion state is persisted to the config file, so it survives restarts
- This approach prevents silent data mutations while still allowing the initial migration to run once

https://claude.ai/code/session_01DX3qneV7hCevwUkH51rS6H