### PR TITLE
feat(oauth, client): refactor Code Assist (Gemini / Antigravity) envelope handling into dedicated client types

### DIFF
--- a/ai/oauth/gemini_hook_test.go
+++ b/ai/oauth/gemini_hook_test.go
@@ -1,0 +1,123 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGeminiHook_AfterToken_LoadCodeAssistDirect verifies that GeminiHook
+// extracts cloudaicompanionProject from a loadCodeAssist response directly
+// without needing the onboardUser fallback.
+func TestGeminiHook_AfterToken_LoadCodeAssistDirect(t *testing.T) {
+	var loadCalled, onboardCalled bool
+
+	// Stub the Code Assist endpoint. The userinfo call goes to a different host
+	// and will fail in tests — that's expected; only project_id matters here.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, ":loadCodeAssist"):
+			loadCalled = true
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Errorf("expected Bearer auth, got %q", got)
+			}
+			_, _ = io.WriteString(w, `{"cloudaicompanionProject":"discovered-project"}`)
+		case strings.HasSuffix(r.URL.Path, ":onboardUser"):
+			onboardCalled = true
+			_, _ = io.WriteString(w, `{"done":true,"response":{"cloudaicompanionProject":{"id":"onboarded"}}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	// Redirect Code Assist calls to the test server by using its URL as the
+	// endpoint constant. We do this with a transport that rewrites the host.
+	httpClient := &http.Client{Transport: &hostRewriteTransport{
+		base:   http.DefaultTransport,
+		target: srv.URL,
+		hosts:  map[string]bool{"cloudcode-pa.googleapis.com": true, "www.googleapis.com": true},
+	}}
+
+	hook := &GeminiHook{}
+	meta, err := hook.AfterToken(context.Background(), "test-token", httpClient)
+	if err != nil {
+		t.Fatalf("AfterToken returned error: %v", err)
+	}
+
+	if !loadCalled {
+		t.Error("expected loadCodeAssist to be called")
+	}
+	if onboardCalled {
+		t.Error("expected onboardUser NOT to be called when project is returned directly")
+	}
+	if got := meta["project_id"]; got != "discovered-project" {
+		t.Errorf("expected project_id=discovered-project, got %v", got)
+	}
+}
+
+// TestGeminiHook_AfterToken_OnboardFallback verifies that when loadCodeAssist
+// returns no project, GeminiHook falls back to onboardUser and extracts the
+// project id from the long-running operation response.
+func TestGeminiHook_AfterToken_OnboardFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, ":loadCodeAssist"):
+			_, _ = io.WriteString(w, `{"allowedTiers":[{"id":"free-tier","isDefault":true}]}`)
+		case strings.HasSuffix(r.URL.Path, ":onboardUser"):
+			body, _ := io.ReadAll(r.Body)
+			var parsed map[string]any
+			_ = json.Unmarshal(body, &parsed)
+			if parsed["tierId"] != "free-tier" {
+				t.Errorf("expected tierId=free-tier picked from default tier, got %v", parsed["tierId"])
+			}
+			_, _ = io.WriteString(w, `{"done":true,"response":{"cloudaicompanionProject":{"id":"onboarded-project"}}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	httpClient := &http.Client{Transport: &hostRewriteTransport{
+		base:   http.DefaultTransport,
+		target: srv.URL,
+		hosts:  map[string]bool{"cloudcode-pa.googleapis.com": true, "www.googleapis.com": true},
+	}}
+
+	hook := &GeminiHook{}
+	meta, err := hook.AfterToken(context.Background(), "tok", httpClient)
+	if err != nil {
+		t.Fatalf("AfterToken returned error: %v", err)
+	}
+	if got := meta["project_id"]; got != "onboarded-project" {
+		t.Errorf("expected project_id=onboarded-project, got %v", got)
+	}
+}
+
+// hostRewriteTransport reroutes requests for any host in `hosts` to `target`
+// (preserving the path/query). Used by tests so we don't need to monkey-patch
+// the Code Assist endpoint constants.
+type hostRewriteTransport struct {
+	base   http.RoundTripper
+	target string
+	hosts  map[string]bool
+}
+
+func (h *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if h.hosts[req.URL.Host] {
+		u := *req.URL
+		// Replace scheme+host with the test server's.
+		parsed, err := http.NewRequest(req.Method, h.target+req.URL.RequestURI(), req.Body)
+		if err != nil {
+			return nil, err
+		}
+		parsed.Header = req.Header.Clone()
+		_ = u
+		return h.base.RoundTrip(parsed)
+	}
+	return h.base.RoundTrip(req)
+}

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -85,37 +86,162 @@ func (h *GeminiHook) BeforeToken(body map[string]string, header http.Header) err
 }
 
 func (h *GeminiHook) AfterToken(ctx context.Context, accessToken string, httpClient *http.Client) (map[string]any, error) {
+	metadata := make(map[string]any)
+
 	// Fetch user email from Google userinfo endpoint
 	type userInfo struct {
 		Email string `json:"email"`
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://www.googleapis.com/oauth2/v1/userinfo?alt=json", nil)
+	if err == nil {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		resp, err := httpClient.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+				var info userInfo
+				if json.NewDecoder(resp.Body).Decode(&info) == nil && info.Email != "" {
+					metadata["email"] = info.Email
+				}
+			}
+		}
+	}
+
+	// Discover Code Assist project ID via loadCodeAssist + onboardUser.
+	// Gemini CLI calls https://cloudcode-pa.googleapis.com/v1internal:* to obtain
+	// the cloudaicompanionProject required by every subsequent generateContent
+	// request. Without it the Code Assist API rejects the call.
+	if projectID, err := fetchGeminiProjectID(ctx, accessToken, httpClient); err == nil && projectID != "" {
+		metadata["project_id"] = projectID
+	}
+
+	return metadata, nil
+}
+
+// Gemini Code Assist API constants (shared with Antigravity host).
+const (
+	geminiCodeAssistEndpoint = "https://cloudcode-pa.googleapis.com"
+	geminiCodeAssistVersion  = "v1internal"
+	geminiCodeAssistUA       = "GeminiCLI/0.1.0 (linux; amd64)"
+)
+
+// fetchGeminiProjectID resolves the cloudaicompanionProject for the authenticated
+// user. It first calls loadCodeAssist; if the current tier is missing or the
+// response does not include a project ID, it falls back to onboardUser to create
+// one and waits for the long-running operation to finish.
+func fetchGeminiProjectID(ctx context.Context, accessToken string, httpClient *http.Client) (string, error) {
+	loadResp, err := geminiCodeAssistCall(ctx, accessToken, httpClient, "loadCodeAssist", map[string]any{
+		"metadata": map[string]string{
+			"ideType":    "IDE_UNSPECIFIED",
+			"platform":   "PLATFORM_UNSPECIFIED",
+			"pluginType": "GEMINI",
+		},
+	})
 	if err != nil {
-		return nil, err
+		return "", err
+	}
+
+	if id := extractGeminiProjectID(loadResp); id != "" {
+		return id, nil
+	}
+
+	tierID := "free-tier"
+	if tiers, ok := loadResp["allowedTiers"].([]any); ok {
+		for _, t := range tiers {
+			tier, ok := t.(map[string]any)
+			if !ok {
+				continue
+			}
+			if def, _ := tier["isDefault"].(bool); def {
+				if id, _ := tier["id"].(string); id != "" {
+					tierID = id
+				}
+				break
+			}
+		}
+	}
+
+	onboardBody := map[string]any{
+		"tierId": tierID,
+		"metadata": map[string]string{
+			"ideType":    "IDE_UNSPECIFIED",
+			"platform":   "PLATFORM_UNSPECIFIED",
+			"pluginType": "GEMINI",
+		},
+	}
+
+	for attempt := 0; attempt < 6; attempt++ {
+		lroResp, err := geminiCodeAssistCall(ctx, accessToken, httpClient, "onboardUser", onboardBody)
+		if err != nil {
+			return "", err
+		}
+		if done, _ := lroResp["done"].(bool); done {
+			if response, ok := lroResp["response"].(map[string]any); ok {
+				if id := extractGeminiProjectID(response); id != "" {
+					return id, nil
+				}
+			}
+			return "", fmt.Errorf("onboardUser completed without project id")
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return "", fmt.Errorf("onboardUser did not complete in time")
+}
+
+func geminiCodeAssistCall(ctx context.Context, accessToken string, httpClient *http.Client, method string, body map[string]any) (map[string]any, error) {
+	rawBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s body: %w", method, err)
+	}
+
+	endpoint := fmt.Sprintf("%s/%s:%s", geminiCodeAssistEndpoint, geminiCodeAssistVersion, method)
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(string(rawBody)))
+	if err != nil {
+		return nil, fmt.Errorf("build %s request: %w", method, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", geminiCodeAssistUA)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("execute %s: %w", method, err)
 	}
 	defer resp.Body.Close()
 
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s response: %w", method, err)
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, nil
+		return nil, fmt.Errorf("%s failed with status %d: %s", method, resp.StatusCode, string(respBody))
 	}
 
-	var info userInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, err
+	parsed := make(map[string]any)
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("decode %s response: %w", method, err)
 	}
+	return parsed, nil
+}
 
-	metadata := make(map[string]any)
-	if info.Email != "" {
-		metadata["email"] = info.Email
+// extractGeminiProjectID pulls cloudaicompanionProject from a loadCodeAssist or
+// onboardUser response. It accepts the field as either a raw string or a nested
+// object with an "id" key (gemini-cli observes both shapes in the wild).
+func extractGeminiProjectID(resp map[string]any) string {
+	if id, ok := resp["cloudaicompanionProject"].(string); ok {
+		return strings.TrimSpace(id)
 	}
-	return metadata, nil
+	if projectMap, ok := resp["cloudaicompanionProject"].(map[string]any); ok {
+		if id, okID := projectMap["id"].(string); okID {
+			return strings.TrimSpace(id)
+		}
+	}
+	return ""
 }
 
 // AntigravityHook implements Antigravity OAuth specific behavior.

--- a/internal/client/antigravity_client.go
+++ b/internal/client/antigravity_client.go
@@ -1,0 +1,174 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// AntigravityClient wraps GoogleClient with Antigravity OAuth-specific
+// behaviors. Antigravity also speaks the Google Code Assist envelope (same
+// host as Gemini CLI) but with its own User-Agent, requestType, and the
+// "request"/"requestId" shape from the desktop Antigravity client.
+type AntigravityClient struct {
+	*GoogleClient
+}
+
+// NewAntigravityClient builds an AntigravityClient. The project_id must already
+// be present in OAuth metadata (populated by AntigravityHook.AfterToken via
+// loadCodeAssist).
+func NewAntigravityClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*AntigravityClient, error) {
+	if provider.OAuthDetail == nil || provider.OAuthDetail.GetIssuer() != ai.IssuerAntigravity {
+		return nil, fmt.Errorf("antigravity client requires an antigravity OAuth provider")
+	}
+
+	project := ""
+	if provider.OAuthDetail.ExtraFields != nil {
+		if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
+			project = p
+		}
+	}
+	if project == "" {
+		logrus.Warnf("[Antigravity] provider %s has no project_id in OAuth metadata; Code Assist calls will fail until loadCodeAssist populates it", provider.Name)
+	}
+
+	transport := &antigravityRoundTripper{
+		RoundTripper: createSessionBoundTransport(provider, sessionID),
+		project:      project,
+		proxyURL:     provider.ProxyURL,
+	}
+	httpClient := &http.Client{Transport: transport}
+
+	base, err := newGoogleClientFromHTTPClient(provider, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base Google client: %w", err)
+	}
+	return &AntigravityClient{GoogleClient: base}, nil
+}
+
+// antigravityRoundTripper applies the Antigravity desktop Code Assist envelope:
+//
+//	{
+//	  "project":     "<project_id>",
+//	  "requestId":   "agent-<uuid>",
+//	  "request":     { ...original google genai body, minus "model"... },
+//	  "model":       "<model>",
+//	  "userAgent":   "antigravity",
+//	  "requestType": "agent"
+//	}
+//
+// Like the Gemini path, it rewrites the URL to /v1internal:<op>, swaps the
+// API-key header for Authorization: Bearer, and unwraps the "response"
+// envelope from the upstream reply (streaming and non-streaming).
+type antigravityRoundTripper struct {
+	http.RoundTripper
+	project, model string
+	proxyURL       string
+}
+
+func (t *antigravityRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Header.Get("X-Goog-Api-Key")
+	isStreaming := isStreamingRequest(req)
+
+	originalPath := req.URL.Path
+	newPath := originalPath
+	model := ""
+
+	if strings.Contains(newPath, ":generateContent") || strings.Contains(newPath, ":streamGenerateContent") {
+		parts := strings.Split(newPath, ":")
+		if len(parts) >= 2 {
+			subparts := strings.Split(parts[0], "/")
+			model = subparts[len(subparts)-1]
+			operation := parts[1]
+			newPath = fmt.Sprintf("/v1internal:%s", operation)
+		}
+	}
+
+	if newPath != originalPath {
+		logrus.Debugf("[Antigravity] Rewriting URL path: %s -> %s", originalPath, newPath)
+		req.URL.Path = newPath
+	}
+
+	if req.Body != nil && t.project != "" && model != "" {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+
+		var originalBody map[string]any
+		if err := json.Unmarshal(body, &originalBody); err == nil {
+			cleanBody := make(map[string]any)
+			for k, v := range originalBody {
+				if k != "model" {
+					cleanBody[k] = v
+				}
+			}
+
+			wrapped := map[string]any{
+				"project":     t.project,
+				"requestId":   fmt.Sprintf("agent-%s", uuid.New().String()),
+				"request":     cleanBody,
+				"model":       model,
+				"userAgent":   "antigravity",
+				"requestType": "agent",
+			}
+
+			wrappedBody, err := json.Marshal(wrapped)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal wrapped body: %w", err)
+			}
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(wrappedBody)), nil
+			}
+			req.Body = io.NopCloser(bytes.NewReader(wrappedBody))
+			req.ContentLength = int64(len(wrappedBody))
+		}
+	}
+
+	req.Header = http.Header{}
+	req.Header.Set("User-Agent", "antigravity/1.11.5 windows/amd64")
+	req.Header.Set("Content-Type", "application/json")
+	if req.ContentLength > 0 {
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
+	}
+	if key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+
+	logrus.Debugf("[Antigravity] Sending request to %s, Content-Length=%d, isStreaming=%v", req.URL.Path, req.ContentLength, isStreaming)
+
+	resp, err := t.RoundTripper.RoundTrip(req)
+	if err != nil {
+		logrus.Errorf("[Antigravity] Request failed: %v", err)
+		return nil, err
+	}
+
+	logrus.Debugf("[Antigravity] Response received, status=%d", resp.StatusCode)
+
+	if resp.Body != nil {
+		if isStreaming {
+			resp.Body = &streamingUnwrapReader{reader: resp.Body}
+		} else {
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+			unwrapped := unwrapCodeAssistJSON(body)
+			resp.Body = io.NopCloser(bytes.NewReader(unwrapped))
+			resp.ContentLength = int64(len(unwrapped))
+		}
+	}
+
+	return resp, nil
+}

--- a/internal/client/antigravity_client_test.go
+++ b/internal/client/antigravity_client_test.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestNewAntigravityClient_AppliesRoundTripper verifies that NewAntigravityClient
+// builds a GoogleClient whose http.Client is wrapped with antigravityRoundTripper
+// carrying the project_id from OAuth metadata.
+func TestNewAntigravityClient_AppliesRoundTripper(t *testing.T) {
+	provider := &typ.Provider{
+		UUID:     "test-provider-antigravity",
+		Name:     "Antigravity Provider",
+		APIBase:  "https://cloudcode-pa.googleapis.com",
+		AuthType: typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			Issuer:       ai.IssuerAntigravity,
+			ProviderType: string(ai.IssuerAntigravity),
+			AccessToken:  "token",
+			ExtraFields:  map[string]interface{}{"project_id": "antigrav-proj"},
+		},
+	}
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "antigrav-client-test"}
+
+	c, err := NewAntigravityClient(provider, "gemini-2.5-pro", sessionID)
+	if err != nil {
+		t.Fatalf("NewAntigravityClient: %v", err)
+	}
+	if c == nil || c.GoogleClient == nil {
+		t.Fatal("expected AntigravityClient wrapping a GoogleClient")
+	}
+	if c.httpClient == nil {
+		t.Fatal("expected embedded http.Client to be set")
+	}
+
+	rt, ok := c.httpClient.Transport.(*antigravityRoundTripper)
+	if !ok {
+		t.Fatalf("expected transport to be *antigravityRoundTripper, got %T", c.httpClient.Transport)
+	}
+	if rt.project != "antigrav-proj" {
+		t.Errorf("expected project_id=antigrav-proj on round tripper, got %q", rt.project)
+	}
+}
+
+// TestNewAntigravityClient_RejectsWrongIssuer guards against misuse.
+func TestNewAntigravityClient_RejectsWrongIssuer(t *testing.T) {
+	provider := &typ.Provider{
+		AuthType: typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			Issuer: ai.IssuerGemini,
+		},
+	}
+	if _, err := NewAntigravityClient(provider, "x", typ.SessionID{}); err == nil {
+		t.Error("expected NewAntigravityClient to reject a non-antigravity provider")
+	}
+}

--- a/internal/client/code_assist_envelope.go
+++ b/internal/client/code_assist_envelope.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Helpers shared by clients that talk to the Google Code Assist host
+// (https://cloudcode-pa.googleapis.com): Gemini CLI and Antigravity. The Code
+// Assist API takes a wrapper envelope on requests and returns the inner
+// response under a "response" key — these helpers handle that envelope.
+
+// isStreamingRequest reports whether the URL targets a Google streaming
+// generateContent operation.
+func isStreamingRequest(req *http.Request) bool {
+	return strings.Contains(req.URL.Path, ":streamGenerateContent")
+}
+
+// streamingUnwrapReader strips the Code Assist `"response"` wrapper from each
+// SSE data line on the fly:
+//
+//	data: {"response": {...}}    ->    data: {...}
+//
+// Lines that don't match (comments, keep-alives, malformed JSON, JSON without
+// the wrapper) pass through unchanged.
+type streamingUnwrapReader struct {
+	reader io.ReadCloser
+	buffer []byte
+	err    error
+}
+
+func (r *streamingUnwrapReader) Read(p []byte) (n int, err error) {
+	if len(r.buffer) > 0 {
+		n = copy(p, r.buffer)
+		r.buffer = r.buffer[n:]
+		return n, nil
+	}
+
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	buf := make([]byte, 4096)
+	var lineBuffer bytes.Buffer
+
+	for {
+		nn, readErr := r.reader.Read(buf)
+		if nn > 0 {
+			lineBuffer.Write(buf[:nn])
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				if lineBuffer.Len() > 0 {
+					r.buffer = r.processBuffer(lineBuffer.Bytes())
+					n = copy(p, r.buffer)
+					r.buffer = r.buffer[n:]
+					if len(r.buffer) == 0 {
+						r.err = io.EOF
+					}
+					return n, nil
+				}
+				return 0, io.EOF
+			}
+			r.err = readErr
+			return 0, readErr
+		}
+
+		processed := r.processBuffer(lineBuffer.Bytes())
+		if len(processed) > 0 {
+			n = copy(p, processed)
+			r.buffer = processed[n:]
+			return n, nil
+		}
+
+		if lineBuffer.Len() > 40960 {
+			n = copy(p, lineBuffer.Bytes())
+			lineBuffer.Next(n)
+			return n, nil
+		}
+	}
+}
+
+func (r *streamingUnwrapReader) processBuffer(data []byte) []byte {
+	lines := bytes.Split(data, []byte("\n"))
+	var result bytes.Buffer
+
+	for i, line := range lines {
+		if bytes.HasPrefix(line, []byte("data:")) {
+			jsonData := bytes.TrimSpace(line[5:])
+			if len(jsonData) == 0 {
+				result.Write(line)
+			} else {
+				var wrapped map[string]any
+				if err := json.Unmarshal(jsonData, &wrapped); err == nil {
+					if innerResponse, ok := wrapped["response"]; ok {
+						unwrapped, err := json.Marshal(innerResponse)
+						if err == nil {
+							result.Write([]byte("data: "))
+							result.Write(unwrapped)
+						} else {
+							result.Write(line)
+						}
+					} else {
+						result.Write(line)
+					}
+				} else {
+					result.Write(line)
+				}
+			}
+		} else {
+			result.Write(line)
+		}
+
+		if i < len(lines)-1 || data[len(data)-1] == '\n' {
+			result.WriteByte('\n')
+		}
+	}
+
+	return result.Bytes()
+}
+
+func (r *streamingUnwrapReader) Close() error {
+	return r.reader.Close()
+}
+
+// unwrapCodeAssistJSON strips the `"response"` wrapper from a non-streaming
+// Code Assist JSON body. Returns the raw bytes unchanged when parsing fails or
+// no wrapper is present, so callers always get a body they can forward.
+func unwrapCodeAssistJSON(body []byte) []byte {
+	var wrapped map[string]any
+	if err := json.Unmarshal(body, &wrapped); err != nil {
+		return body
+	}
+	inner, ok := wrapped["response"]
+	if !ok {
+		return body
+	}
+	out, err := json.Marshal(inner)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/internal/client/gemini_client.go
+++ b/internal/client/gemini_client.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// GeminiClient wraps GoogleClient with Gemini CLI OAuth-specific behaviors.
+// It embeds *GoogleClient to inherit standard genai SDK functionality, while
+// swapping in a transport that speaks the Google Code Assist envelope.
+//
+// Gemini CLI (Google Code Assist OAuth) requirements:
+//   - Authorization: Bearer <token>     (not X-Goog-Api-Key)
+//   - Rewrite /v1beta/models/<m>:<op> → /v1internal:<op>
+//   - Wrap body with {model, project, user_prompt_id, request}
+//   - Unwrap the "response" envelope on the way back
+type GeminiClient struct {
+	*GoogleClient
+}
+
+// NewGeminiClient builds a GeminiClient. The project_id stored on the OAuth
+// detail by GeminiHook.AfterToken (loadCodeAssist/onboardUser) is required for
+// every generateContent call — without it the Code Assist API rejects the
+// request, so we still construct the client but log a warning.
+func NewGeminiClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*GeminiClient, error) {
+	if provider.OAuthDetail == nil || provider.OAuthDetail.GetIssuer() != ai.IssuerGemini {
+		return nil, fmt.Errorf("gemini client requires a gemini OAuth provider")
+	}
+
+	project := ""
+	if provider.OAuthDetail.ExtraFields != nil {
+		if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
+			project = p
+		}
+	}
+	if project == "" {
+		logrus.Warnf("[Gemini] provider %s has no project_id in OAuth metadata; Code Assist calls will fail until loadCodeAssist/onboardUser populates it", provider.Name)
+	}
+
+	transport := &geminiRoundTripper{
+		RoundTripper: createSessionBoundTransport(provider, sessionID),
+		project:      project,
+		proxyURL:     provider.ProxyURL,
+	}
+	httpClient := &http.Client{Transport: transport}
+
+	base, err := newGoogleClientFromHTTPClient(provider, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base Google client: %w", err)
+	}
+	return &GeminiClient{GoogleClient: base}, nil
+}
+
+// geminiRoundTripper applies the Gemini CLI Code Assist envelope around an
+// upstream Google genai request and unwraps the response envelope on the way
+// back. The body shape mirrors gemini-cli/packages/core/src/code_assist:
+//
+//	{
+//	  "model":          "<model>",
+//	  "project":        "<project_id>",
+//	  "user_prompt_id": "<uuid>",
+//	  "request":        { ...original google genai body, minus "model"... }
+//	}
+type geminiRoundTripper struct {
+	http.RoundTripper
+	project  string
+	proxyURL string
+}
+
+func (t *geminiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Header.Get("X-Goog-Api-Key")
+	isStreaming := isStreamingRequest(req)
+
+	originalPath := req.URL.Path
+	newPath := originalPath
+	model := ""
+
+	if strings.Contains(newPath, ":generateContent") || strings.Contains(newPath, ":streamGenerateContent") {
+		parts := strings.Split(newPath, ":")
+		if len(parts) >= 2 {
+			subparts := strings.Split(parts[0], "/")
+			model = subparts[len(subparts)-1]
+			newPath = fmt.Sprintf("/v1internal:%s", parts[1])
+		}
+	}
+
+	if newPath != originalPath {
+		logrus.Debugf("[Gemini] Rewriting URL path: %s -> %s", originalPath, newPath)
+		req.URL.Path = newPath
+	}
+
+	if req.Body != nil && t.project != "" && model != "" {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+
+		var originalBody map[string]any
+		if err := json.Unmarshal(body, &originalBody); err == nil {
+			cleanBody := make(map[string]any)
+			for k, v := range originalBody {
+				if k != "model" {
+					cleanBody[k] = v
+				}
+			}
+
+			wrapped := map[string]any{
+				"model":          model,
+				"project":        t.project,
+				"user_prompt_id": uuid.New().String(),
+				"request":        cleanBody,
+			}
+
+			wrappedBody, err := json.Marshal(wrapped)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal wrapped body: %w", err)
+			}
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(wrappedBody)), nil
+			}
+			req.Body = io.NopCloser(bytes.NewReader(wrappedBody))
+			req.ContentLength = int64(len(wrappedBody))
+		}
+	}
+
+	req.Header = http.Header{}
+	req.Header.Set("User-Agent", "GeminiCLI/0.1.0 (linux; amd64)")
+	req.Header.Set("Content-Type", "application/json")
+	if req.ContentLength > 0 {
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
+	}
+	if key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+
+	logrus.Debugf("[Gemini] Sending request to %s, Content-Length=%d, isStreaming=%v", req.URL.Path, req.ContentLength, isStreaming)
+
+	resp, err := t.RoundTripper.RoundTrip(req)
+	if err != nil {
+		logrus.Errorf("[Gemini] Request failed: %v", err)
+		return nil, err
+	}
+
+	logrus.Debugf("[Gemini] Response received, status=%d", resp.StatusCode)
+
+	if resp.Body != nil {
+		if isStreaming {
+			resp.Body = &streamingUnwrapReader{reader: resp.Body}
+		} else {
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+			unwrapped := unwrapCodeAssistJSON(body)
+			resp.Body = io.NopCloser(bytes.NewReader(unwrapped))
+			resp.ContentLength = int64(len(unwrapped))
+		}
+	}
+
+	return resp, nil
+}

--- a/internal/client/gemini_client_test.go
+++ b/internal/client/gemini_client_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestNewGeminiClient_AppliesRoundTripper verifies that NewGeminiClient builds
+// a GoogleClient whose http.Client is wrapped with geminiRoundTripper carrying
+// the project_id from OAuth metadata.
+func TestNewGeminiClient_AppliesRoundTripper(t *testing.T) {
+	provider := &typ.Provider{
+		UUID:     "test-provider-gemini",
+		Name:     "Gemini Provider",
+		APIBase:  "https://cloudcode-pa.googleapis.com",
+		AuthType: typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			Issuer:       ai.IssuerGemini,
+			ProviderType: string(ai.IssuerGemini),
+			AccessToken:  "token",
+			ExtraFields:  map[string]interface{}{"project_id": "test-project"},
+		},
+	}
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "gemini-client-test"}
+
+	c, err := NewGeminiClient(provider, "gemini-2.5-pro", sessionID)
+	if err != nil {
+		t.Fatalf("NewGeminiClient: %v", err)
+	}
+	if c == nil || c.GoogleClient == nil {
+		t.Fatal("expected GeminiClient wrapping a GoogleClient")
+	}
+
+	if c.httpClient == nil {
+		t.Fatal("expected embedded http.Client to be set")
+	}
+	rt, ok := c.httpClient.Transport.(*geminiRoundTripper)
+	if !ok {
+		t.Fatalf("expected transport to be *geminiRoundTripper, got %T", c.httpClient.Transport)
+	}
+	if rt.project != "test-project" {
+		t.Errorf("expected project_id=test-project on round tripper, got %q", rt.project)
+	}
+}
+
+// TestNewGeminiClient_RejectsWrongIssuer guards against constructing a
+// GeminiClient for a non-Gemini provider — the upstream wire format is wrong
+// for any other issuer.
+func TestNewGeminiClient_RejectsWrongIssuer(t *testing.T) {
+	provider := &typ.Provider{
+		UUID:     "test-provider-wrong",
+		APIBase:  "https://cloudcode-pa.googleapis.com",
+		AuthType: typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			Issuer: ai.IssuerAntigravity,
+		},
+	}
+	if _, err := NewGeminiClient(provider, "x", typ.SessionID{}); err == nil {
+		t.Error("expected NewGeminiClient to reject a non-gemini provider")
+	}
+}
+
+// Compile-time check: GeminiClient embeds *GoogleClient so callers expecting
+// *GoogleClient (e.g. forwarding.ForwardGoogle) continue to work after dispatch.
+var _ = (*GeminiClient)(nil)

--- a/internal/client/gemini_round_tripper_test.go
+++ b/internal/client/gemini_round_tripper_test.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// fakeRoundTripper captures the outbound request and returns a canned response.
+type fakeRoundTripper struct {
+	captured *http.Request
+	body     []byte
+	resp     *http.Response
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.captured = req
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		f.body = b
+	}
+	resp := f.resp
+	if resp == nil {
+		resp = &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"response":{"candidates":[]}}`)),
+		}
+	}
+	return resp, nil
+}
+
+// TestGeminiRoundTripper_WrapsGenerateContent verifies that requests to the
+// standard Google genai path get rewritten to /v1internal:<op>, that the body
+// is wrapped with project/model/user_prompt_id, and that the Code Assist
+// "response" envelope is unwrapped on the way back.
+func TestGeminiRoundTripper_WrapsGenerateContent(t *testing.T) {
+	innerBody := map[string]any{
+		"model": "gemini-2.5-pro",
+		"contents": []map[string]any{
+			{"role": "user", "parts": []map[string]any{{"text": "hi"}}},
+		},
+	}
+	rawInner, _ := json.Marshal(innerBody)
+
+	req, err := http.NewRequest("POST",
+		"https://cloudcode-pa.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+		bytes.NewReader(rawInner))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("X-Goog-Api-Key", "ya29.test-access-token")
+	req.ContentLength = int64(len(rawInner))
+
+	fake := &fakeRoundTripper{}
+	rt := &geminiRoundTripper{RoundTripper: fake, project: "my-project"}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if fake.captured.URL.Path != "/v1internal:generateContent" {
+		t.Errorf("expected path rewrite to /v1internal:generateContent, got %s", fake.captured.URL.Path)
+	}
+
+	if got := fake.captured.Header.Get("Authorization"); got != "Bearer ya29.test-access-token" {
+		t.Errorf("expected Bearer auth from X-Goog-Api-Key swap, got %q", got)
+	}
+	if got := fake.captured.Header.Get("X-Goog-Api-Key"); got != "" {
+		t.Errorf("expected X-Goog-Api-Key stripped, got %q", got)
+	}
+	if got := fake.captured.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", got)
+	}
+
+	var wrapped map[string]any
+	if err := json.Unmarshal(fake.body, &wrapped); err != nil {
+		t.Fatalf("body is not valid JSON: %v\nbody=%s", err, string(fake.body))
+	}
+	if wrapped["model"] != "gemini-2.5-pro" {
+		t.Errorf("expected wrapped.model=gemini-2.5-pro, got %v", wrapped["model"])
+	}
+	if wrapped["project"] != "my-project" {
+		t.Errorf("expected wrapped.project=my-project, got %v", wrapped["project"])
+	}
+	if _, ok := wrapped["user_prompt_id"].(string); !ok {
+		t.Error("expected wrapped.user_prompt_id to be a string uuid")
+	}
+	inner, ok := wrapped["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected wrapped.request to be a JSON object, got %T", wrapped["request"])
+	}
+	if _, has := inner["model"]; has {
+		t.Error("expected inner request to have model stripped (lifted to top level)")
+	}
+	if _, has := inner["contents"]; !has {
+		t.Error("expected inner request to retain contents")
+	}
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	var unwrapped map[string]any
+	if err := json.Unmarshal(out, &unwrapped); err != nil {
+		t.Fatalf("response not JSON: %v\nbody=%s", err, string(out))
+	}
+	if _, has := unwrapped["response"]; has {
+		t.Errorf("expected Code Assist response wrapper to be stripped, got %s", string(out))
+	}
+	if _, has := unwrapped["candidates"]; !has {
+		t.Errorf("expected unwrapped response to include candidates, got %s", string(out))
+	}
+}
+
+// TestGeminiRoundTripper_NoProjectIDSkipsWrap ensures that when project_id
+// hasn't been discovered yet, we don't malform the body — we still rewrite the
+// URL and swap auth, but leave the payload alone so the caller sees a clean
+// upstream error rather than a partially-formed envelope.
+func TestGeminiRoundTripper_NoProjectIDSkipsWrap(t *testing.T) {
+	raw := []byte(`{"model":"gemini-2.5-pro","contents":[]}`)
+	req, _ := http.NewRequest("POST",
+		"https://cloudcode-pa.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+		bytes.NewReader(raw))
+	req.Header.Set("X-Goog-Api-Key", "tok")
+	req.ContentLength = int64(len(raw))
+
+	fake := &fakeRoundTripper{}
+	rt := &geminiRoundTripper{RoundTripper: fake, project: ""}
+
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+
+	if !bytes.Equal(fake.body, raw) {
+		t.Errorf("expected body unchanged when project is empty, got %s", string(fake.body))
+	}
+	if fake.captured.URL.Path != "/v1internal:generateContent" {
+		t.Errorf("expected path rewrite even without project, got %s", fake.captured.URL.Path)
+	}
+}

--- a/internal/client/google.go
+++ b/internal/client/google.go
@@ -26,13 +26,16 @@ type GoogleClient struct {
 	recordSink *obs.Sink
 }
 
-// NewGoogleClient creates a new Google client wrapper
-// sessionID is used for session-scoped transport creation for OAuth providers
+// NewGoogleClient creates a new Google client wrapper.
+// sessionID is used for session-scoped transport creation for OAuth providers.
+//
+// For provider-specific wire formats (Gemini CLI / Antigravity Code Assist
+// envelope), prefer the dedicated *Client constructors (NewGeminiClient,
+// NewAntigravityClient) — they layer the right round tripper on top of the
+// session-bound transport. NewGoogleClient itself stays generic.
 func NewGoogleClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*GoogleClient, error) {
-	// Create HTTP client with session-bound transport
 	var transport http.RoundTripper
 	if provider.AuthType == typ.AuthTypeOAuth || provider.ProxyURL != "" {
-		// Use createSessionBoundTransport which applies OAuth hooks and uses shared transport
 		transport = createSessionBoundTransport(provider, sessionID)
 
 		issuer := ""
@@ -49,11 +52,14 @@ func NewGoogleClient(provider *typ.Provider, model string, sessionID typ.Session
 		transport = http.DefaultTransport
 	}
 
-	httpClient := &http.Client{
-		Transport: transport,
-	}
+	httpClient := &http.Client{Transport: transport}
+	return newGoogleClientFromHTTPClient(provider, httpClient)
+}
 
-	// Create Google client config
+// newGoogleClientFromHTTPClient builds a GoogleClient around an already-configured
+// http.Client. Provider-specific clients (Gemini, Antigravity) use this to
+// inject their round tripper without going through the generic transport path.
+func newGoogleClientFromHTTPClient(provider *typ.Provider, httpClient *http.Client) (*GoogleClient, error) {
 	httpOptions := genai.HTTPOptions{
 		BaseURL: provider.APIBase,
 	}
@@ -64,7 +70,6 @@ func NewGoogleClient(provider *typ.Provider, model string, sessionID typ.Session
 		HTTPClient:  httpClient,
 	}
 
-	// Create Google client (requires context)
 	ctx := context.Background()
 	client, err := genai.NewClient(ctx, config)
 	if err != nil {

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -344,6 +344,138 @@ func (t *antigravityRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	return resp, nil
 }
 
+// geminiRoundTripper wraps requests to the Gemini CLI Code Assist endpoint
+// (https://cloudcode-pa.googleapis.com). It mirrors what Antigravity does but
+// follows the Gemini CLI request envelope:
+//
+//	{
+//	  "model":          "<model>",
+//	  "project":        "<project_id>",
+//	  "user_prompt_id": "<uuid>",
+//	  "request":        { /* original google genai body without "model" */ }
+//	}
+//
+// It also rewrites the URL path from /v1beta/models/<model>:<op> to
+// /v1internal:<op>, swaps X-Goog-Api-Key for Authorization: Bearer, and unwraps
+// the "response" field from Code Assist responses (both streaming and not).
+type geminiRoundTripper struct {
+	http.RoundTripper
+	project  string
+	proxyURL string
+}
+
+func (t *geminiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Header.Get("X-Goog-Api-Key")
+	isStreaming := isStreamingRequest(req)
+
+	originalPath := req.URL.Path
+	newPath := originalPath
+	model := ""
+
+	if strings.Contains(newPath, ":generateContent") || strings.Contains(newPath, ":streamGenerateContent") {
+		parts := strings.Split(newPath, ":")
+		if len(parts) >= 2 {
+			subparts := strings.Split(parts[0], "/")
+			model = subparts[len(subparts)-1]
+			newPath = fmt.Sprintf("/v1internal:%s", parts[1])
+		}
+	}
+
+	if newPath != originalPath {
+		logrus.Debugf("[Gemini] Rewriting URL path: %s -> %s", originalPath, newPath)
+		req.URL.Path = newPath
+	}
+
+	if req.Body != nil && t.project != "" && model != "" {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+
+		var originalBody map[string]any
+		if err := json.Unmarshal(body, &originalBody); err == nil {
+			cleanBody := make(map[string]any)
+			for k, v := range originalBody {
+				if k != "model" {
+					cleanBody[k] = v
+				}
+			}
+
+			wrapped := map[string]any{
+				"model":          model,
+				"project":        t.project,
+				"user_prompt_id": uuid.New().String(),
+				"request":        cleanBody,
+			}
+
+			wrappedBody, err := json.Marshal(wrapped)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal wrapped body: %w", err)
+			}
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(wrappedBody)), nil
+			}
+			req.Body = io.NopCloser(bytes.NewReader(wrappedBody))
+			req.ContentLength = int64(len(wrappedBody))
+		}
+	}
+
+	req.Header = http.Header{}
+	req.Header.Set("User-Agent", "GeminiCLI/0.1.0 (linux; amd64)")
+	req.Header.Set("Content-Type", "application/json")
+	if req.ContentLength > 0 {
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
+	}
+	if key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+
+	logrus.Debugf("[Gemini] Sending request to %s, Content-Length=%d, isStreaming=%v", req.URL.Path, req.ContentLength, isStreaming)
+
+	resp, err := t.RoundTripper.RoundTrip(req)
+	if err != nil {
+		logrus.Errorf("[Gemini] Request failed: %v", err)
+		return nil, err
+	}
+
+	logrus.Debugf("[Gemini] Response received, status=%d", resp.StatusCode)
+
+	// Code Assist API wraps the underlying response in a "response" field —
+	// same envelope Antigravity uses, so we reuse the unwrap logic.
+	if resp.Body != nil {
+		if isStreaming {
+			resp.Body = &streamingUnwrapReader{reader: resp.Body}
+		} else {
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			var wrappedResponse map[string]any
+			if err := json.Unmarshal(body, &wrappedResponse); err == nil {
+				if innerResponse, ok := wrappedResponse["response"]; ok {
+					unwrappedBody, err := json.Marshal(innerResponse)
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal unwrapped response: %w", err)
+					}
+					resp.Body = io.NopCloser(bytes.NewReader(unwrappedBody))
+					resp.ContentLength = int64(len(unwrappedBody))
+				} else {
+					resp.Body = io.NopCloser(bytes.NewReader(body))
+					resp.ContentLength = int64(len(body))
+				}
+			} else {
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+				resp.ContentLength = int64(len(body))
+			}
+		}
+	}
+
+	return resp, nil
+}
+
 // CreateHTTPClientWithProxy creates an HTTP client with proxy support
 func CreateHTTPClientWithProxy(proxyURL string) *http.Client {
 	if proxyURL == "" {
@@ -496,6 +628,20 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 				model:        model,
 				proxyURL:     provider.ProxyURL,
 			}
+		case ai.IssuerGemini:
+			// Gemini CLI uses Google Code Assist API and needs a project_id discovered
+			// by the OAuth hook (loadCodeAssist/onboardUser) and stored in ExtraFields.
+			project := ""
+			if provider.OAuthDetail != nil && provider.OAuthDetail.ExtraFields != nil {
+				if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
+					project = p
+				}
+			}
+			return &geminiRoundTripper{
+				RoundTripper: baseTransport,
+				project:      project,
+				proxyURL:     provider.ProxyURL,
+			}
 		}
 	}
 
@@ -557,6 +703,30 @@ func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID
 				proxyURL:     effectiveProxy,
 			}
 			logrus.Infof("Created Antigravity RoundTripper with project=%s, model=%s, proxy=%s", project, model, effectiveProxy)
+		case ai.IssuerGemini:
+			if provider.OAuthDetail == nil {
+				return nil
+			}
+			project := ""
+			if provider.OAuthDetail.ExtraFields != nil {
+				if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
+					project = p
+				}
+			}
+			var geminiTransport http.RoundTripper = transport
+			effectiveProxy := provider.ProxyURL
+			if effectiveProxy != "" {
+				proxyClient := CreateHTTPClientWithProxy(effectiveProxy)
+				if proxyClient.Transport != nil {
+					geminiTransport = proxyClient.Transport
+				}
+			}
+			client.Transport = &geminiRoundTripper{
+				RoundTripper: geminiTransport,
+				project:      project,
+				proxyURL:     effectiveProxy,
+			}
+			logrus.Infof("Created Gemini RoundTripper with project=%s, proxy=%s", project, effectiveProxy)
 		case ai.IssuerClaudeCode:
 			// For Claude Code OAuth, use claudeRoundTripper for request/response transformations
 			var claudeTransport http.RoundTripper = transport

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1,16 +1,11 @@
 package client
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
 	"golang.org/x/net/proxy"
@@ -18,478 +13,20 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// HookFunc is a function that can modify the request before it's sent
-type HookFunc func(req *http.Request) error
-
-// oauthHookFunctions defines custom hooks for OAuth providers based on provider type
-// Each hook handles custom headers, query params, and any special request modifications
-var oauthHookFunctions = map[ai.Issuer]HookFunc{
-	ai.IssuerAntigravity: antigravityHook,
-}
-
-func antigravityHook(req *http.Request) error {
-	key := req.Header.Get("X-Goog-Api-Key")
-
-	// Rewrite URL path from standard Google format to Antigravity format
-	// Standard: /v1beta/models/{model}:generateContent
-	// Antigravity: /v1internal:generateContent
-	originalPath := req.URL.Path
-	newPath := originalPath
-
-	// Check if this is a generateContent request
-	if strings.Contains(newPath, ":generateContent") {
-		// Extract the operation name (generateContent, streamGenerateContent, etc.)
-		parts := strings.Split(newPath, ":")
-		if len(parts) >= 2 {
-			operation := parts[1]
-			// Rewrite to Antigravity format
-			newPath = fmt.Sprintf("/v1internal:%s", operation)
-		}
-	}
-
-	// Apply the path rewrite if changed
-	if newPath != originalPath {
-		logrus.Debugf("[Antigravity] Rewriting URL path: %s -> %s", originalPath, newPath)
-		req.URL.Path = newPath
-	}
-
-	// Set headers (will be applied after URL rewrite)
-	req.Header = http.Header{}
-	req.Header.Set("User-Agent", "antigravity/1.11.5 windows/amd64")
-	req.Header.Set("Content-Type", "application/json")
-	if key != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
-	}
-	return nil
-}
-
-// requestModifier wraps an http.RoundTripper to apply hooks to each request
-type requestModifier struct {
-	http.RoundTripper
-	hooks []HookFunc
-}
-
-func (t *requestModifier) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Execute hooks in order
-	for _, hook := range t.hooks {
-		if err := hook(req); err != nil {
-			return nil, err
-		}
-	}
-	return t.RoundTripper.RoundTrip(req)
-}
-
-// antigravityRoundTripper wraps an http.RoundTripper to handle Antigravity's
-// custom request/response format
-type antigravityRoundTripper struct {
-	http.RoundTripper
-	project, model string
-	proxyURL       string
-}
-
-// isStreamingRequest checks if the request is for streaming generate content
-func isStreamingRequest(req *http.Request) bool {
-	return strings.Contains(req.URL.Path, ":streamGenerateContent")
-}
-
-// streamingUnwrapReader wraps an io.Reader to unwrap Antigravity's streaming response format
-// Antigravity wraps each SSE event's data in a "response" field, e.g.:
-//
-//	data: {"response": {...actual google response...}}
-//
-// This reader unwraps it to:
-//
-//	data: {...actual google response...}
-type streamingUnwrapReader struct {
-	reader io.ReadCloser
-	buffer []byte
-	err    error
-}
-
-func (r *streamingUnwrapReader) Read(p []byte) (n int, err error) {
-	// Return any buffered data first
-	if len(r.buffer) > 0 {
-		n = copy(p, r.buffer)
-		r.buffer = r.buffer[n:]
-		return n, nil
-	}
-
-	// Return previous error if any
-	if r.err != nil {
-		return 0, r.err
-	}
-
-	// Read data line by line from source
-	buf := make([]byte, 4096)
-	var lineBuffer bytes.Buffer
-
-	for {
-		nn, readErr := r.reader.Read(buf)
-		if nn > 0 {
-			lineBuffer.Write(buf[:nn])
-		}
-		if readErr != nil {
-			if readErr == io.EOF {
-				// Flush remaining buffer at EOF
-				if lineBuffer.Len() > 0 {
-					r.buffer = r.processBuffer(lineBuffer.Bytes())
-					n = copy(p, r.buffer)
-					r.buffer = r.buffer[n:]
-					if len(r.buffer) == 0 {
-						r.err = io.EOF
-					}
-					return n, nil
-				}
-				return 0, io.EOF
-			}
-			r.err = readErr
-			return 0, readErr
-		}
-
-		// Process the buffer to extract complete lines
-		processed := r.processBuffer(lineBuffer.Bytes())
-		if len(processed) > 0 {
-			// Return processed data
-			n = copy(p, processed)
-			r.buffer = processed[n:]
-			return n, nil
-		}
-
-		// Check if we have enough data to work with
-		if lineBuffer.Len() > 40960 {
-			// Buffer too large, return as-is (fallback)
-			n = copy(p, lineBuffer.Bytes())
-			lineBuffer.Next(n)
-			return n, nil
-		}
-	}
-}
-
-func (r *streamingUnwrapReader) processBuffer(data []byte) []byte {
-	// Process SSE format, unwrapping "response" field in data lines
-	lines := bytes.Split(data, []byte("\n"))
-	var result bytes.Buffer
-
-	for i, line := range lines {
-		if bytes.HasPrefix(line, []byte("data:")) {
-			// Extract JSON from data line
-			jsonData := bytes.TrimSpace(line[5:]) // Skip "data:"
-			if len(jsonData) == 0 {
-				result.Write(line)
-			} else {
-				// Try to unwrap the JSON
-				var wrapped map[string]any
-				if err := json.Unmarshal(jsonData, &wrapped); err == nil {
-					if innerResponse, ok := wrapped["response"]; ok {
-						// Unwrap: extract inner "response" field
-						unwrapped, err := json.Marshal(innerResponse)
-						if err == nil {
-							result.Write([]byte("data: "))
-							result.Write(unwrapped)
-						} else {
-							// Failed to marshal, keep original
-							result.Write(line)
-						}
-					} else {
-						// No "response" field, keep original
-						result.Write(line)
-					}
-				} else {
-					// Not valid JSON, keep original
-					result.Write(line)
-				}
-			}
-		} else {
-			result.Write(line)
-		}
-
-		// Add newline back (except for last line if original didn't end with \n)
-		if i < len(lines)-1 || data[len(data)-1] == '\n' {
-			result.WriteByte('\n')
-		}
-	}
-
-	return result.Bytes()
-}
-
-func (r *streamingUnwrapReader) Close() error {
-	return r.reader.Close()
-}
-
-func (t *antigravityRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	key := req.Header.Get("X-Goog-Api-Key")
-	isStreaming := isStreamingRequest(req)
-
-	// Rewrite URL path from standard Google format to Antigravity format
-	originalPath := req.URL.Path
-	newPath := originalPath
-	model := ""
-
-	if strings.Contains(newPath, ":generateContent") || strings.Contains(newPath, ":streamGenerateContent") {
-		parts := strings.Split(newPath, ":")
-		if len(parts) >= 2 {
-			subparts := strings.Split(parts[0], "/")
-			model = subparts[len(subparts)-1]
-			operation := parts[1]
-			newPath = fmt.Sprintf("/v1internal:%s", operation)
-		}
-	}
-
-	if newPath != originalPath {
-		logrus.Debugf("[Antigravity] Rewriting URL path: %s -> %s", originalPath, newPath)
-		req.URL.Path = newPath
-	}
-
-	// Read and wrap request body
-	if req.Body != nil && t.project != "" && model != "" {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read request body: %w", err)
-		}
-		req.Body.Close()
-
-		// Parse original body
-		var originalBody map[string]any
-		if err := json.Unmarshal(body, &originalBody); err == nil {
-			// Remove model from original body
-			cleanBody := make(map[string]any)
-			for k, v := range originalBody {
-				if k != "model" {
-					cleanBody[k] = v
-				}
-			}
-
-			// Wrap in Antigravity format
-			wrapped := map[string]any{
-				"project":     t.project,
-				"requestId":   fmt.Sprintf("agent-%s", uuid.New().String()),
-				"request":     cleanBody,
-				"model":       model,
-				"userAgent":   "antigravity",
-				"requestType": "agent",
-			}
-
-			wrappedBody, err := json.Marshal(wrapped)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal wrapped body: %w", err)
-			}
-			// Set GetBody to allow retries and redirects
-			req.GetBody = func() (io.ReadCloser, error) {
-				return io.NopCloser(bytes.NewReader(wrappedBody)), nil
-			}
-			req.Body = io.NopCloser(bytes.NewReader(wrappedBody))
-			req.ContentLength = int64(len(wrappedBody))
-		}
-	}
-
-	// Set headers
-	req.Header = http.Header{}
-	req.Header.Set("User-Agent", "antigravity/1.11.5 windows/amd64")
-	req.Header.Set("Content-Type", "application/json")
-	if req.ContentLength > 0 {
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
-	}
-	if key != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
-	}
-
-	logrus.Debugf("[Antigravity] Sending request to %s, Content-Length=%d, isStreaming=%v", req.URL.Path, req.ContentLength, isStreaming)
-
-	// Send request
-	resp, err := t.RoundTripper.RoundTrip(req)
-	if err != nil {
-		logrus.Errorf("[Antigravity] Request failed: %v", err)
-		return nil, err
-	}
-
-	logrus.Debugf("[Antigravity] Response received, status=%d", resp.StatusCode)
-
-	// Unwrap response body
-	// Antigravity wraps the response in a "response" field
-	// For streaming: we need to unwrap each SSE event's data field
-	// For non-streaming: we can unwrap the entire JSON response
-	if resp.Body != nil {
-		if isStreaming {
-			// For streaming responses, wrap the body with streamingUnwrapReader
-			// to unwrap each SSE event's data field on-the-fly
-			resp.Body = &streamingUnwrapReader{reader: resp.Body}
-		} else {
-			// For non-streaming responses, read and unwrap the entire JSON body
-			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				return nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-
-			// Try to unwrap the response
-			var wrappedResponse map[string]any
-			if err := json.Unmarshal(body, &wrappedResponse); err == nil {
-				if innerResponse, ok := wrappedResponse["response"]; ok {
-					// Unwrap: extract the inner "response" field
-					unwrappedBody, err := json.Marshal(innerResponse)
-					if err != nil {
-						return nil, fmt.Errorf("failed to marshal unwrapped response: %w", err)
-					}
-					resp.Body = io.NopCloser(bytes.NewReader(unwrappedBody))
-					resp.ContentLength = int64(len(unwrappedBody))
-				}
-			} else {
-				// If parsing fails, return original body (might not be wrapped)
-				resp.Body = io.NopCloser(bytes.NewReader(body))
-				resp.ContentLength = int64(len(body))
-			}
-		}
-	}
-
-	return resp, nil
-}
-
-// geminiRoundTripper wraps requests to the Gemini CLI Code Assist endpoint
-// (https://cloudcode-pa.googleapis.com). It mirrors what Antigravity does but
-// follows the Gemini CLI request envelope:
-//
-//	{
-//	  "model":          "<model>",
-//	  "project":        "<project_id>",
-//	  "user_prompt_id": "<uuid>",
-//	  "request":        { /* original google genai body without "model" */ }
-//	}
-//
-// It also rewrites the URL path from /v1beta/models/<model>:<op> to
-// /v1internal:<op>, swaps X-Goog-Api-Key for Authorization: Bearer, and unwraps
-// the "response" field from Code Assist responses (both streaming and not).
-type geminiRoundTripper struct {
-	http.RoundTripper
-	project  string
-	proxyURL string
-}
-
-func (t *geminiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	key := req.Header.Get("X-Goog-Api-Key")
-	isStreaming := isStreamingRequest(req)
-
-	originalPath := req.URL.Path
-	newPath := originalPath
-	model := ""
-
-	if strings.Contains(newPath, ":generateContent") || strings.Contains(newPath, ":streamGenerateContent") {
-		parts := strings.Split(newPath, ":")
-		if len(parts) >= 2 {
-			subparts := strings.Split(parts[0], "/")
-			model = subparts[len(subparts)-1]
-			newPath = fmt.Sprintf("/v1internal:%s", parts[1])
-		}
-	}
-
-	if newPath != originalPath {
-		logrus.Debugf("[Gemini] Rewriting URL path: %s -> %s", originalPath, newPath)
-		req.URL.Path = newPath
-	}
-
-	if req.Body != nil && t.project != "" && model != "" {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read request body: %w", err)
-		}
-		req.Body.Close()
-
-		var originalBody map[string]any
-		if err := json.Unmarshal(body, &originalBody); err == nil {
-			cleanBody := make(map[string]any)
-			for k, v := range originalBody {
-				if k != "model" {
-					cleanBody[k] = v
-				}
-			}
-
-			wrapped := map[string]any{
-				"model":          model,
-				"project":        t.project,
-				"user_prompt_id": uuid.New().String(),
-				"request":        cleanBody,
-			}
-
-			wrappedBody, err := json.Marshal(wrapped)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal wrapped body: %w", err)
-			}
-			req.GetBody = func() (io.ReadCloser, error) {
-				return io.NopCloser(bytes.NewReader(wrappedBody)), nil
-			}
-			req.Body = io.NopCloser(bytes.NewReader(wrappedBody))
-			req.ContentLength = int64(len(wrappedBody))
-		}
-	}
-
-	req.Header = http.Header{}
-	req.Header.Set("User-Agent", "GeminiCLI/0.1.0 (linux; amd64)")
-	req.Header.Set("Content-Type", "application/json")
-	if req.ContentLength > 0 {
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
-	}
-	if key != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
-	}
-
-	logrus.Debugf("[Gemini] Sending request to %s, Content-Length=%d, isStreaming=%v", req.URL.Path, req.ContentLength, isStreaming)
-
-	resp, err := t.RoundTripper.RoundTrip(req)
-	if err != nil {
-		logrus.Errorf("[Gemini] Request failed: %v", err)
-		return nil, err
-	}
-
-	logrus.Debugf("[Gemini] Response received, status=%d", resp.StatusCode)
-
-	// Code Assist API wraps the underlying response in a "response" field —
-	// same envelope Antigravity uses, so we reuse the unwrap logic.
-	if resp.Body != nil {
-		if isStreaming {
-			resp.Body = &streamingUnwrapReader{reader: resp.Body}
-		} else {
-			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				return nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-
-			var wrappedResponse map[string]any
-			if err := json.Unmarshal(body, &wrappedResponse); err == nil {
-				if innerResponse, ok := wrappedResponse["response"]; ok {
-					unwrappedBody, err := json.Marshal(innerResponse)
-					if err != nil {
-						return nil, fmt.Errorf("failed to marshal unwrapped response: %w", err)
-					}
-					resp.Body = io.NopCloser(bytes.NewReader(unwrappedBody))
-					resp.ContentLength = int64(len(unwrappedBody))
-				} else {
-					resp.Body = io.NopCloser(bytes.NewReader(body))
-					resp.ContentLength = int64(len(body))
-				}
-			} else {
-				resp.Body = io.NopCloser(bytes.NewReader(body))
-				resp.ContentLength = int64(len(body))
-			}
-		}
-	}
-
-	return resp, nil
-}
-
-// CreateHTTPClientWithProxy creates an HTTP client with proxy support
+// CreateHTTPClientWithProxy creates an HTTP client with proxy support.
+// Supports http(s) and socks5 proxy URLs; falls back to http.DefaultClient
+// for any parse/scheme failure (logged).
 func CreateHTTPClientWithProxy(proxyURL string) *http.Client {
 	if proxyURL == "" {
 		return http.DefaultClient
 	}
 
-	// Parse the proxy URL
 	parsedURL, err := url.Parse(proxyURL)
 	if err != nil {
 		logrus.Errorf("Failed to parse proxy URL %s: %v, using default client", proxyURL, err)
 		return http.DefaultClient
 	}
 
-	// Create transport with proxy
 	transport := &http.Transport{}
 
 	switch parsedURL.Scheme {
@@ -565,22 +102,18 @@ func (t *SessionBoundTransport) RoundTrip(req *http.Request) (*http.Response, er
 		t.sessionID,
 	)
 
-	// Execute request
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		release()
 		return nil, err
 	}
 
-	// Wrap response body to auto-release refCount on close.
-	// This ensures long-running streaming requests keep the transport alive.
 	if resp.Body != nil {
 		resp.Body = &refCountedBody{ReadCloser: resp.Body, onclose: release}
 	} else {
 		release()
 	}
 
-	// Apply response wrapper if needed (e.g., tool prefix stripping)
 	if t.responseWrapper != nil {
 		resp = t.responseWrapper(resp)
 	}
@@ -588,9 +121,11 @@ func (t *SessionBoundTransport) RoundTrip(req *http.Request) (*http.Response, er
 	return resp, nil
 }
 
-// createSessionBoundTransport creates a session-bound transport with
-// optional provider-specific wrapping (claudeRoundTripper, codexRoundTripper, etc.).
-// This helper builds the layered transport chain based on provider configuration.
+// createSessionBoundTransport builds the base session-bound transport for a
+// provider. It is intentionally generic — provider-specific wire-format
+// adapters (Code Assist envelope, ChatGPT backend translation, etc.) live in
+// their dedicated xxx_client.go files and layer their RoundTripper on top of
+// what this returns.
 func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID) http.RoundTripper {
 	var issuer ai.Issuer
 	if provider.OAuthDetail != nil {
@@ -598,192 +133,14 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 	}
 
 	if provider.ProxyURL != "" {
-		logrus.Infof("Using proxy for OpenAI client: %s", provider.ProxyURL)
+		logrus.Debugf("Using proxy for provider %s: %s", provider.UUID, provider.ProxyURL)
 	}
 
-	// Base: SessionBoundTransport
-	baseTransport := &SessionBoundTransport{
+	return &SessionBoundTransport{
 		transportPool: GetGlobalTransportPool(),
 		providerUUID:  provider.UUID,
 		proxyURL:      provider.ProxyURL,
 		issuer:        issuer,
 		sessionID:     sessionID,
 	}
-
-	// Layer provider-specific transformations
-	if provider.AuthType == typ.AuthTypeOAuth {
-		switch issuer {
-		case ai.IssuerAntigravity:
-			// Antigravity needs extra config (project_id) and special wrapping
-			project := ""
-			model := ""
-			if provider.OAuthDetail != nil && provider.OAuthDetail.ExtraFields != nil {
-				if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
-					project = p
-				}
-			}
-			return &antigravityRoundTripper{
-				RoundTripper: baseTransport,
-				project:      project,
-				model:        model,
-				proxyURL:     provider.ProxyURL,
-			}
-		case ai.IssuerGemini:
-			// Gemini CLI uses Google Code Assist API and needs a project_id discovered
-			// by the OAuth hook (loadCodeAssist/onboardUser) and stored in ExtraFields.
-			project := ""
-			if provider.OAuthDetail != nil && provider.OAuthDetail.ExtraFields != nil {
-				if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
-					project = p
-				}
-			}
-			return &geminiRoundTripper{
-				RoundTripper: baseTransport,
-				project:      project,
-				proxyURL:     provider.ProxyURL,
-			}
-		}
-	}
-
-	return baseTransport
-}
-
-// CreateHTTPClientForProvider creates an HTTP client configured for the given provider
-// It handles proxy and OAuth hooks if applicable
-// The model parameter is used for transport pool keying (provider+model+proxy)
-// The sessionID parameter is used for session-scoped transport creation for OAuth providers
-//
-// Deprecated: Use createSessionBoundTransport instead. This function is kept for
-// backward compatibility during the migration to SessionBoundTransport.
-//
-// Returns a configured http.Client
-func CreateHTTPClientForProvider(provider *typ.Provider, model string, sessionID typ.SessionID) *http.Client {
-	var issuer ai.Issuer
-	if provider.OAuthDetail != nil {
-		issuer = ai.Issuer(provider.OAuthDetail.GetIssuer())
-	}
-
-	// Get shared transport from transport pool (keyed by providerUUID + sessionID for OAuth)
-	// proxyURL is used to configure the transport but is NOT part of the key
-	transport := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, issuer, sessionID)
-
-	client := &http.Client{
-		Transport: transport,
-	}
-
-	if provider.AuthType == typ.AuthTypeOAuth {
-		switch issuer {
-		case ai.IssuerAntigravity:
-			// For Antigravity, create a specialized RoundTripper with provider-specific config
-			if provider.OAuthDetail == nil {
-				return nil
-			}
-			project, model := "", ""
-			if provider.OAuthDetail.ExtraFields != nil {
-				if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
-					project = p
-				}
-			}
-			// Create a separate transport with proxy for Antigravity
-			var antigravityTransport http.RoundTripper = transport
-			effectiveProxy := provider.ProxyURL
-			if effectiveProxy != "" {
-				// Use CreateHTTPClientWithProxy to create a transport with proxy
-				proxyClient := CreateHTTPClientWithProxy(effectiveProxy)
-				if proxyClient.Transport != nil {
-					antigravityTransport = proxyClient.Transport
-				}
-			}
-
-			// Use antigravityRoundTripper for both request wrapping and response unwrapping
-			client.Transport = &antigravityRoundTripper{
-				RoundTripper: antigravityTransport,
-				project:      project,
-				model:        model,
-				proxyURL:     effectiveProxy,
-			}
-			logrus.Infof("Created Antigravity RoundTripper with project=%s, model=%s, proxy=%s", project, model, effectiveProxy)
-		case ai.IssuerGemini:
-			if provider.OAuthDetail == nil {
-				return nil
-			}
-			project := ""
-			if provider.OAuthDetail.ExtraFields != nil {
-				if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
-					project = p
-				}
-			}
-			var geminiTransport http.RoundTripper = transport
-			effectiveProxy := provider.ProxyURL
-			if effectiveProxy != "" {
-				proxyClient := CreateHTTPClientWithProxy(effectiveProxy)
-				if proxyClient.Transport != nil {
-					geminiTransport = proxyClient.Transport
-				}
-			}
-			client.Transport = &geminiRoundTripper{
-				RoundTripper: geminiTransport,
-				project:      project,
-				proxyURL:     effectiveProxy,
-			}
-			logrus.Infof("Created Gemini RoundTripper with project=%s, proxy=%s", project, effectiveProxy)
-		case ai.IssuerClaudeCode:
-			// For Claude Code OAuth, use claudeRoundTripper for request/response transformations
-			var claudeTransport http.RoundTripper = transport
-			if ep := provider.ProxyURL; ep != "" {
-				proxyClient := CreateHTTPClientWithProxy(ep)
-				if proxyClient.Transport != nil {
-					claudeTransport = proxyClient.Transport
-				}
-			}
-
-			client.Transport = claudeTransport
-			logrus.Infof("Created Claude Code transport with proxy=%s (SDK middleware handles transformations)", provider.ProxyURL)
-		case ai.IssuerCodex:
-			// Create base transport with proxy support if needed
-			var baseTransport http.RoundTripper = transport
-			if ep := provider.ProxyURL; ep != "" {
-				// Explicitly create transport with proxy for this provider
-				proxyClient := CreateHTTPClientWithProxy(ep)
-				if proxyClient.Transport != nil {
-					baseTransport = proxyClient.Transport
-					logrus.Infof("Created proxy transport for %s: %s", issuer, ep)
-				}
-			}
-
-			// For ChatGPT backend API, wrap with response transformer
-			// This transforms the custom ChatGPT backend response format to OpenAI Responses API format
-			baseTransport = &codexRoundTripper{
-				RoundTripper: baseTransport,
-			}
-			logrus.Infof("Created ChatGPT backend response transformer RoundTripper with proxy=%s", provider.ProxyURL)
-
-			client.Transport = baseTransport
-		default:
-			// For other OAuth providers, use the hook-based approach
-			hook, ok := oauthHookFunctions[issuer]
-			if ok {
-				// Create base transport with proxy support if needed
-				var baseTransport http.RoundTripper = transport
-				if ep := provider.ProxyURL; ep != "" {
-					// Explicitly create transport with proxy for this provider
-					proxyClient := CreateHTTPClientWithProxy(ep)
-					if proxyClient.Transport != nil {
-						baseTransport = proxyClient.Transport
-						logrus.Infof("Created proxy transport for %s: %s", issuer, ep)
-					}
-				}
-
-				// Build the transport chain: base transport -> request modifier (hook) -> response transformer (if ChatGPT backend)
-				baseTransport = &requestModifier{
-					RoundTripper: baseTransport,
-					hooks:        []HookFunc{hook},
-				}
-
-				client.Transport = baseTransport
-			}
-		}
-	}
-
-	return client
 }

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -139,12 +139,14 @@ func (p *ClientPool) GetAnthropicClient(ctx context.Context, provider *typ.Provi
 }
 
 // GetGoogleClient returns a Google client wrapper for the specified provider.
+// For Gemini CLI / Antigravity OAuth providers it dispatches to the dedicated
+// xxx_client constructors, which layer the Code Assist envelope transport.
 // sessionID is resolved from ctx via typ.GetSessionID; pass context.Background() when no session is available.
 func (p *ClientPool) GetGoogleClient(ctx context.Context, provider *typ.Provider, model string) *GoogleClient {
 	sessionID := typ.GetSessionID(ctx)
 	logrus.Debugf("Creating Google client for provider: %s, session: %s", provider.Name, sessionID.Value)
 
-	client, err := NewGoogleClient(provider, model, sessionID)
+	client, err := newGoogleClientForProvider(provider, model, sessionID)
 	if err != nil {
 		logrus.Errorf("Failed to create Google client for provider %s: %v", provider.Name, err)
 		return nil
@@ -163,6 +165,30 @@ func (p *ClientPool) GetGoogleClient(ctx context.Context, provider *typ.Provider
 	})
 
 	return client
+}
+
+// newGoogleClientForProvider selects the right Google-flavored constructor
+// based on the provider's OAuth issuer. Returns *GoogleClient so existing
+// forwarding code keeps working unchanged — the provider-specific transport
+// is already baked into the embedded client.
+func newGoogleClientForProvider(provider *typ.Provider, model string, sessionID typ.SessionID) (*GoogleClient, error) {
+	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
+		switch provider.OAuthDetail.GetIssuer() {
+		case ai.IssuerGemini:
+			c, err := NewGeminiClient(provider, model, sessionID)
+			if err != nil {
+				return nil, err
+			}
+			return c.GoogleClient, nil
+		case ai.IssuerAntigravity:
+			c, err := NewAntigravityClient(provider, model, sessionID)
+			if err != nil {
+				return nil, err
+			}
+			return c.GoogleClient, nil
+		}
+	}
+	return NewGoogleClient(provider, model, sessionID)
 }
 
 // SetRecordSink sets the record sink for the client pool.

--- a/internal/client/session_bound_transport_test.go
+++ b/internal/client/session_bound_transport_test.go
@@ -547,6 +547,40 @@ func TestCreateSessionBoundTransport_Antigravity(t *testing.T) {
 	}
 }
 
+// TestCreateSessionBoundTransport_Gemini tests Gemini CLI provider which is
+// wrapped by geminiRoundTripper so requests get routed through the Code Assist
+// API envelope (URL rewrite, project_id wrapping, Bearer auth).
+func TestCreateSessionBoundTransport_Gemini(t *testing.T) {
+	provider := &typ.Provider{
+		UUID:     "test-provider-gemini",
+		Name:     "Gemini Provider",
+		Token:    "test-token",
+		APIBase:  "https://cloudcode-pa.googleapis.com",
+		AuthType: typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			ProviderType: "gemini",
+			ExtraFields: map[string]interface{}{
+				"project_id": "test-project",
+			},
+		},
+	}
+	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "gemini-test"}
+
+	transport := createSessionBoundTransport(provider, sessionID)
+
+	if transport == nil {
+		t.Fatal("Expected non-nil transport")
+	}
+
+	rt, ok := transport.(*geminiRoundTripper)
+	if !ok {
+		t.Fatalf("Expected geminiRoundTripper for Gemini provider, got %T", transport)
+	}
+	if rt.project != "test-project" {
+		t.Errorf("Expected project_id propagated to geminiRoundTripper, got %q", rt.project)
+	}
+}
+
 // TestCreateSessionBoundTransport_Codex tests Codex provider
 // which uses codexRoundTripper for response transformation.
 func TestCreateSessionBoundTransport_Codex(t *testing.T) {

--- a/internal/client/session_bound_transport_test.go
+++ b/internal/client/session_bound_transport_test.go
@@ -517,8 +517,9 @@ func TestCreateSessionBoundTransport(t *testing.T) {
 	}
 }
 
-// TestCreateSessionBoundTransport_Antigravity tests Antigravity provider
-// which has special wrapping requirements.
+// TestCreateSessionBoundTransport_Antigravity verifies that the transport
+// layer stays generic for Antigravity — provider-specific request/response
+// transformation lives in AntigravityClient, not in createSessionBoundTransport.
 func TestCreateSessionBoundTransport_Antigravity(t *testing.T) {
 	provider := &typ.Provider{
 		UUID:     "test-provider-antigravity",
@@ -536,20 +537,15 @@ func TestCreateSessionBoundTransport_Antigravity(t *testing.T) {
 	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "antigravity-test"}
 
 	transport := createSessionBoundTransport(provider, sessionID)
-
 	if transport == nil {
 		t.Fatal("Expected non-nil transport")
 	}
-
-	// Should be antigravityRoundTripper wrapping SessionBoundTransport
-	if _, ok := transport.(*antigravityRoundTripper); !ok {
-		t.Error("Expected antigravityRoundTripper for Antigravity provider")
+	if _, ok := transport.(*SessionBoundTransport); !ok {
+		t.Errorf("Expected bare SessionBoundTransport (Code Assist envelope is applied by AntigravityClient), got %T", transport)
 	}
 }
 
-// TestCreateSessionBoundTransport_Gemini tests Gemini CLI provider which is
-// wrapped by geminiRoundTripper so requests get routed through the Code Assist
-// API envelope (URL rewrite, project_id wrapping, Bearer auth).
+// TestCreateSessionBoundTransport_Gemini is the symmetric check for Gemini.
 func TestCreateSessionBoundTransport_Gemini(t *testing.T) {
 	provider := &typ.Provider{
 		UUID:     "test-provider-gemini",
@@ -567,22 +563,17 @@ func TestCreateSessionBoundTransport_Gemini(t *testing.T) {
 	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "gemini-test"}
 
 	transport := createSessionBoundTransport(provider, sessionID)
-
 	if transport == nil {
 		t.Fatal("Expected non-nil transport")
 	}
-
-	rt, ok := transport.(*geminiRoundTripper)
-	if !ok {
-		t.Fatalf("Expected geminiRoundTripper for Gemini provider, got %T", transport)
-	}
-	if rt.project != "test-project" {
-		t.Errorf("Expected project_id propagated to geminiRoundTripper, got %q", rt.project)
+	if _, ok := transport.(*SessionBoundTransport); !ok {
+		t.Errorf("Expected bare SessionBoundTransport (Code Assist envelope is applied by GeminiClient), got %T", transport)
 	}
 }
 
-// TestCreateSessionBoundTransport_Codex tests Codex provider
-// which uses codexRoundTripper for response transformation.
+// TestCreateSessionBoundTransport_Codex verifies that the transport layer
+// stays generic for Codex too — codexRoundTripper is layered on top by
+// NewCodexClient, not by createSessionBoundTransport.
 func TestCreateSessionBoundTransport_Codex(t *testing.T) {
 	provider := &typ.Provider{
 		UUID:     "test-provider-codex",
@@ -597,14 +588,11 @@ func TestCreateSessionBoundTransport_Codex(t *testing.T) {
 	sessionID := typ.SessionID{Source: typ.SessionSourceUser, Value: "codex-test"}
 
 	transport := createSessionBoundTransport(provider, sessionID)
-
 	if transport == nil {
 		t.Fatal("Expected non-nil transport")
 	}
-
-	// Should be codexRoundTripper wrapping SessionBoundTransport
-	if _, ok := transport.(*codexRoundTripper); !ok {
-		t.Error("Expected codexRoundTripper for Codex provider")
+	if _, ok := transport.(*SessionBoundTransport); !ok {
+		t.Errorf("Expected bare SessionBoundTransport (codex envelope is applied by CodexClient), got %T", transport)
 	}
 }
 

--- a/internal/command/oauth.go
+++ b/internal/command/oauth.go
@@ -551,6 +551,10 @@ func getProviderConfig(issuer string) (*ProviderOAuthConfig, error) {
 	case ai.IssuerAntigravity:
 		apiBase = "https://api.antigravity.com/v1"
 		apiStyle = "openai"
+	case ai.IssuerGemini:
+		// Gemini CLI uses Google Code Assist API
+		apiBase = "https://cloudcode-pa.googleapis.com"
+		apiStyle = "google"
 	default:
 		// For other providers, use a default
 		apiBase = "https://api.example.com/v1"

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -972,6 +972,10 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 		case ai.IssuerAntigravity:
 			apiBase = "https://cloudcode-pa.googleapis.com"
 			apiStyle = protocol.APIStyleGoogle
+		case ai.IssuerGemini:
+			// Gemini CLI authenticates via Google Code Assist endpoint (same host as Antigravity)
+			apiBase = "https://cloudcode-pa.googleapis.com"
+			apiStyle = protocol.APIStyleGoogle
 		case ai.IssuerOpenAI:
 			apiBase = "https://api.openai.com/v1"
 			apiStyle = protocol.APIStyleOpenAI


### PR DESCRIPTION
## Summary
Extracted provider-specific wire-format handling (Gemini CLI and Antigravity Code Assist envelope) from the generic HTTP client layer into dedicated `GeminiClient` and `AntigravityClient` types. This improves separation of concerns by keeping the base `GoogleClient` and transport pool generic, while provider-specific request/response transformation lives in their own modules.

## Key Changes

- **New dedicated client types:**
  - `GeminiClient` wraps `GoogleClient` with `geminiRoundTripper` for Gemini CLI Code Assist envelope (model/project/user_prompt_id wrapper)
  - `AntigravityClient` wraps `GoogleClient` with `antigravityRoundTripper` for Antigravity Code Assist envelope (project/requestId/request wrapper)

- **Extracted shared Code Assist helpers:**
  - New `code_assist_envelope.go` module with `streamingUnwrapReader`, `unwrapCodeAssistJSON`, and `isStreamingRequest` helpers used by both Gemini and Antigravity round trippers

- **Enhanced OAuth hook for Gemini:**
  - `GeminiHook.AfterToken` now calls `loadCodeAssist` to discover the `cloudaicompanionProject` required by Code Assist API
  - Falls back to `onboardUser` with retry logic if project is not returned directly
  - Stores `project_id` in OAuth metadata for later use by `GeminiClient`

- **Simplified base transport layer:**
  - `createSessionBoundTransport` now returns bare `SessionBoundTransport` without provider-specific wrapping
  - Removed `CreateHTTPClientForProvider` (deprecated function) and `requestModifier`/`HookFunc` infrastructure
  - `SessionBoundTransport` remains generic and session-aware

- **Updated client pool:**
  - `GetGoogleClient` dispatches to `NewGeminiClient` or `NewAntigravityClient` based on provider issuer type
  - Falls back to generic `NewGoogleClient` for other providers

- **Added comprehensive tests:**
  - `gemini_round_tripper_test.go`: verifies envelope wrapping/unwrapping and auth header transformation
  - `gemini_client_test.go`: validates `NewGeminiClient` construction and round tripper application
  - `antigravity_client_test.go`: validates `NewAntigravityClient` construction
  - `gemini_hook_test.go`: tests `loadCodeAssist` direct path and `onboardUser` fallback with polling

## Implementation Details

- Both `geminiRoundTripper` and `antigravityRoundTripper` rewrite `/v1beta/models/<m>:<op>` → `/v1internal:<op>` and swap `X-Goog-Api-Key` header for `Authorization: Bearer`
- Streaming responses use `streamingUnwrapReader` to unwrap the `"response"` field from each SSE event on-the-fly
- Non-streaming responses use `unwrapCodeAssistJSON` helper to strip the wrapper from the full JSON body
- Project ID discovery for Gemini is lazy (happens in `AfterToken`) and stored in OAuth metadata, allowing clients to be constructed even if discovery fails (with a warning)

https://claude.ai/code/session_01X4TvY1PGUi3KxnH3Fnzhzf