### PR TITLE
Add feedback button to activity bar

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -77,7 +77,9 @@ export default {
       "enterZenMode": "Enter Zen Mode:",
       "more": "More",
       "exitZen": "Exit",
-      "click": "Click"
+      "click": "Click",
+      "feedback": "Feedback",
+      "feedbackTooltip": "Send Feedback (opens GitHub Issues)"
     },
     "themeMenu": {
       "switchTo": "Switch to:",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -78,7 +78,9 @@ export default {
       "enterZenMode": "进入禅模式：",
       "more": "更多",
       "exitZen": "退出",
-      "click": "点击"
+      "click": "点击",
+      "feedback": "反馈",
+      "feedbackTooltip": "发送反馈（跳转到 GitHub Issues）"
     },
     "themeMenu": {
       "switchTo": "切换到：",

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -371,7 +371,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                 <Tooltip title={t('layout.activityBar.feedbackTooltip')} placement="right" arrow>
                     <ListItemButton
                         component="a"
-                        href="https://github.com/tingly-dev/tingly-box/issues/new"
+                        href="https://github.com/tingly-dev/tingly-box/issues/new/choose"
                         target="_blank"
                         rel="noopener noreferrer"
                         sx={{

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -4,6 +4,7 @@ import {
     IconDots,
     IconLanguage,
     IconWand,
+    IconMessageReport,
 } from '@tabler/icons-react';
 import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import React, { useState } from 'react';
@@ -354,6 +355,49 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                         </ListItemButton>
                     </Tooltip>
                 )}
+            </Box>
+
+            {/* Feedback button - bottom-left, above language icon */}
+            <Box
+                sx={{
+                    py: 0.5,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                }}
+            >
+                <Tooltip title={t('layout.activityBar.feedbackTooltip')} placement="right" arrow>
+                    <ListItemButton
+                        component="a"
+                        href="https://github.com/tingly-dev/tingly-box/issues/new"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                            minHeight: 48,
+                            mx: 0.5,
+                            px: activityItemPaddingX,
+                            py: 0.75,
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: 0.25,
+                            position: 'relative',
+                            color: 'text.secondary',
+                            borderRadius: activityItemRadius,
+                            cursor: 'pointer',
+                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                        }}
+                    >
+                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                            <IconMessageReport size={22} />
+                        </ListItemIcon>
+                        <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
+                            {t('layout.activityBar.feedback')}
+                        </Typography>
+                    </ListItemButton>
+                </Tooltip>
             </Box>
 
             {/* Language button - bottom-left, above user icon */}


### PR DESCRIPTION
## Summary
Added a new feedback button to the ZenActivityBar that allows users to quickly report issues and provide feedback by opening GitHub Issues in a new tab.

## Changes
- **Frontend Component**: Added a new feedback button in `ZenActivityBar.tsx` positioned in the bottom-left area, above the language icon
  - Uses `IconMessageReport` icon from Tabler Icons
  - Links directly to GitHub Issues creation page (`https://github.com/tingly-dev/tingly-box/issues/new/choose`)
  - Includes hover effects matching the existing activity bar styling
  - Displays a tooltip with action description

- **Internationalization**: Added translation strings for both English and Chinese locales
  - `feedback`: Button label text
  - `feedbackTooltip`: Tooltip text describing the feedback action

## Implementation Details
- The button follows the existing ZenActivityBar component patterns and styling conventions
- Uses MUI components (`ListItemButton`, `Tooltip`, `Typography`) consistent with the codebase
- Properly styled with responsive padding, colors, and hover states
- Opens GitHub Issues in a new tab with `target="_blank"` and `rel="noopener noreferrer"` for security

https://claude.ai/code/session_016EMrEHokxJ957hxPpqpj7D