### PR TITLE
Enable Gemini OAuth provider

### DIFF
--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -54,7 +54,7 @@ const FALLBACK_OAUTH_PROVIDERS: OAuthProvider[] = [
         description: 'Access Gemini CLI models via OAuth',
         icon: <Gemini size={32}/>,
         color: '#4285F4',
-        enabled: false,
+        enabled: true,
     },
     {
         id: 'antigravity',


### PR DESCRIPTION
## Summary
Enable the Gemini OAuth provider in the fallback OAuth providers configuration, allowing users to access Gemini CLI models via OAuth authentication.

## Changes
- Set `enabled: true` for the Gemini OAuth provider in `FALLBACK_OAUTH_PROVIDERS` configuration

## Details
The Gemini OAuth provider was previously disabled (`enabled: false`) in the fallback configuration. This change activates it, making it available as an authentication option for users to access Gemini CLI models through the OAuth dialog.

https://claude.ai/code/session_01DByQuMt7R7MAwdDF3WPpGJ