### PR TITLE
feat(oauth): Implement Kimi OAuth device-code flow with CLI impersonation

### DIFF
--- a/ai/oauth/config.go
+++ b/ai/oauth/config.go
@@ -320,7 +320,6 @@ type DeviceCodeData struct {
 	ExpiresAt    time.Time
 	InitiatedAt  time.Time
 	CodeVerifier string // PKCE code verifier (for Device Code PKCE flow)
-	KimiDeviceID string // Kimi X-Msh-Device-Id, generated on authorize, reused on polling
 }
 
 // DeviceTokenRequest represents the request to poll for token with device code

--- a/ai/oauth/config.go
+++ b/ai/oauth/config.go
@@ -320,6 +320,7 @@ type DeviceCodeData struct {
 	ExpiresAt    time.Time
 	InitiatedAt  time.Time
 	CodeVerifier string // PKCE code verifier (for Device Code PKCE flow)
+	KimiDeviceID string // Kimi X-Msh-Device-Id, generated on authorize, reused on polling
 }
 
 // DeviceTokenRequest represents the request to poll for token with device code

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -486,12 +486,17 @@ func (h *IFlowHook) AfterToken(ctx context.Context, accessToken string, httpClie
 	return metadata, nil
 }
 
+// KimiDeviceIDMetadataKey is the Token.Metadata / OAuthDetail.ExtraFields
+// key under which the per-credential Kimi X-Msh-Device-Id is persisted.
+// Co-located with KimiHook because both belong to the Kimi provider's wire
+// contract — not part of the generic OAuth surface.
+const KimiDeviceIDMetadataKey = "kimi_device_id"
+
 // KimiHook implements Kimi OAuth device-code flow specific behavior.
 // Reference: https://github.com/router-for-me/CLIProxyAPI internal/auth/kimi/kimi.go
 //
 // The X-Msh-Device-Id header is intentionally NOT set here: device id is
-// per-flow state managed by the OAuth manager (generated on authorize,
-// reused on polling, stored with the token, reused on refresh). The hook
+// per-flow state injected by the caller via oauth.WithExtraHeader. The hook
 // only sets headers that are constant for the Kimi auth wire format.
 type KimiHook struct{}
 
@@ -511,18 +516,6 @@ func (h *KimiHook) AfterToken(ctx context.Context, accessToken string, httpClien
 	// Kimi has no public userinfo endpoint; CLIProxyAPI hardcodes the display label.
 	return nil, nil
 }
-
-// NewKimiDeviceID returns a fresh, random Kimi device id (UUID v4) to be
-// bound to a single OAuth flow / token. Matches CLIProxyAPI's behavior of
-// generating one device id per Auth instance, except we persist it in the
-// credential DB instead of a local file.
-func NewKimiDeviceID() string {
-	return uuid.New().String()
-}
-
-// KimiDeviceIDMetadataKey is the Token.Metadata / ExtraFields key under
-// which the per-provider Kimi device id is stored.
-const KimiDeviceIDMetadataKey = "kimi_device_id"
 
 // CodexHook implements Codex (OpenAI) OAuth specific behavior.
 type CodexHook struct{}

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -488,6 +488,11 @@ func (h *IFlowHook) AfterToken(ctx context.Context, accessToken string, httpClie
 
 // KimiHook implements Kimi OAuth device-code flow specific behavior.
 // Reference: https://github.com/router-for-me/CLIProxyAPI internal/auth/kimi/kimi.go
+//
+// The X-Msh-Device-Id header is intentionally NOT set here: device id is
+// per-flow state managed by the OAuth manager (generated on authorize,
+// reused on polling, stored with the token, reused on refresh). The hook
+// only sets headers that are constant for the Kimi auth wire format.
 type KimiHook struct{}
 
 func (h *KimiHook) BeforeAuth(params map[string]string) error {
@@ -499,7 +504,6 @@ func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error
 	header.Set("X-Msh-Version", "1.0.0")
 	header.Set("X-Msh-Device-Name", getKimiDeviceName())
 	header.Set("X-Msh-Device-Model", getKimiDeviceModel())
-	header.Set("X-Msh-Device-Id", getKimiDeviceId())
 	return nil
 }
 
@@ -507,6 +511,18 @@ func (h *KimiHook) AfterToken(ctx context.Context, accessToken string, httpClien
 	// Kimi has no public userinfo endpoint; CLIProxyAPI hardcodes the display label.
 	return nil, nil
 }
+
+// NewKimiDeviceID returns a fresh, random Kimi device id (UUID v4) to be
+// bound to a single OAuth flow / token. Matches CLIProxyAPI's behavior of
+// generating one device id per Auth instance, except we persist it in the
+// credential DB instead of a local file.
+func NewKimiDeviceID() string {
+	return uuid.New().String()
+}
+
+// KimiDeviceIDMetadataKey is the Token.Metadata / ExtraFields key under
+// which the per-provider Kimi device id is stored.
+const KimiDeviceIDMetadataKey = "kimi_device_id"
 
 // CodexHook implements Codex (OpenAI) OAuth specific behavior.
 type CodexHook struct{}
@@ -572,56 +588,6 @@ func (h *CodexHook) AfterToken(ctx context.Context, accessToken string, httpClie
 		metadata["name"] = info.Name
 	}
 	return metadata, nil
-}
-
-// Kimi device info helpers
-// These functions generate device information headers required by Kimi OAuth
-
-var (
-	kimiDeviceId     string
-	kimiDeviceIdOnce bool
-)
-
-// GetKimiDeviceID returns a persistent device ID for Kimi OAuth/inference calls.
-// Exported so inference round trippers can reuse the same value the OAuth flow used.
-func GetKimiDeviceID() string {
-	return getKimiDeviceId()
-}
-
-// getKimiDeviceId returns a persistent device ID for Kimi OAuth
-// Attempts to read from ~/.kimi/device_id, generates a new UUID if not found
-func getKimiDeviceId() string {
-	if kimiDeviceIdOnce {
-		return kimiDeviceId
-	}
-
-	// Try to read from kimi-cli's device file
-	homeDir, err := os.UserHomeDir()
-	if err == nil {
-		deviceIDPath := homeDir + "/.kimi/device_id"
-		if data, err := os.ReadFile(deviceIDPath); err == nil {
-			kimiDeviceId = strings.TrimSpace(string(data))
-			kimiDeviceIdOnce = true
-			if kimiDeviceId != "" {
-				return kimiDeviceId
-			}
-		}
-	}
-
-	// Generate a new device ID
-	kimiDeviceId = uuid.New().String()
-	kimiDeviceIdOnce = true
-
-	// Try to save to kimi-cli's device file
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		kimiDir := homeDir + "/.kimi"
-		if err := os.MkdirAll(kimiDir, 0755); err == nil {
-			deviceIDPath := kimiDir + "/device_id"
-			_ = os.WriteFile(deviceIDPath, []byte(kimiDeviceId), 0644)
-		}
-	}
-
-	return kimiDeviceId
 }
 
 // getKimiDeviceName returns the hostname for Kimi OAuth

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -489,9 +489,8 @@ func (h *IFlowHook) AfterToken(ctx context.Context, accessToken string, httpClie
 // KimiHook implements Kimi OAuth device-code flow specific behavior.
 // Reference: https://github.com/router-for-me/CLIProxyAPI internal/auth/kimi/kimi.go
 //
-// The X-Msh-Device-Id header is intentionally NOT set here: device id is
-// per-flow state injected by the caller via oauth.WithExtraHeader. The hook
-// only sets headers that are constant for the Kimi auth wire format.
+// X-Msh-Device-Id is NOT set here — it's per-flow state injected by the
+// caller via oauth.WithExtraHeader, so refresh and inference can reuse it.
 type KimiHook struct{}
 
 func (h *KimiHook) BeforeAuth(params map[string]string) error {
@@ -501,8 +500,8 @@ func (h *KimiHook) BeforeAuth(params map[string]string) error {
 func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error {
 	header.Set("X-Msh-Platform", "cli-proxy-api")
 	header.Set("X-Msh-Version", "1.0.0")
-	header.Set("X-Msh-Device-Name", getKimiDeviceName())
-	header.Set("X-Msh-Device-Model", getKimiDeviceModel())
+	header.Set("X-Msh-Device-Name", KimiDeviceName())
+	header.Set("X-Msh-Device-Model", KimiDeviceModel())
 	return nil
 }
 
@@ -577,17 +576,17 @@ func (h *CodexHook) AfterToken(ctx context.Context, accessToken string, httpClie
 	return metadata, nil
 }
 
-// getKimiDeviceName returns the hostname for Kimi OAuth
-func getKimiDeviceName() string {
+// KimiDeviceName returns the hostname for Kimi headers (auth and inference).
+func KimiDeviceName() string {
 	if hostname, err := os.Hostname(); err == nil {
 		return hostname
 	}
 	return "unknown"
 }
 
-// getKimiDeviceModel returns the device model for Kimi OAuth in the
-// "<GOOS> <GOARCH>" format used by CLIProxyAPI (e.g. "darwin arm64").
-func getKimiDeviceModel() string {
+// KimiDeviceModel returns the device model in the "<OS> <GOARCH>" format
+// CLIProxyAPI uses for Kimi headers (e.g. "macOS arm64").
+func KimiDeviceModel() string {
 	goos := runtime.GOOS
 	switch goos {
 	case "darwin":

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -486,6 +486,8 @@ func (h *IFlowHook) AfterToken(ctx context.Context, accessToken string, httpClie
 	return metadata, nil
 }
 
+// KimiHook implements Kimi OAuth device-code flow specific behavior.
+// Reference: https://github.com/router-for-me/CLIProxyAPI internal/auth/kimi/kimi.go
 type KimiHook struct{}
 
 func (h *KimiHook) BeforeAuth(params map[string]string) error {
@@ -493,17 +495,16 @@ func (h *KimiHook) BeforeAuth(params map[string]string) error {
 }
 
 func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error {
-	// Kimi 需要设备信息头，模拟 kimi-cli 的请求头
-	header.Set("X-Msh-Platform", "mac")
+	header.Set("X-Msh-Platform", "cli-proxy-api")
 	header.Set("X-Msh-Version", "1.0.0")
 	header.Set("X-Msh-Device-Name", getKimiDeviceName())
 	header.Set("X-Msh-Device-Model", getKimiDeviceModel())
-	header.Set("X-Msh-Os-Version", getKimiOsVersion())
 	header.Set("X-Msh-Device-Id", getKimiDeviceId())
 	return nil
 }
 
 func (h *KimiHook) AfterToken(ctx context.Context, accessToken string, httpClient *http.Client) (map[string]any, error) {
+	// Kimi has no public userinfo endpoint; CLIProxyAPI hardcodes the display label.
 	return nil, nil
 }
 
@@ -581,6 +582,12 @@ var (
 	kimiDeviceIdOnce bool
 )
 
+// GetKimiDeviceID returns a persistent device ID for Kimi OAuth/inference calls.
+// Exported so inference round trippers can reuse the same value the OAuth flow used.
+func GetKimiDeviceID() string {
+	return getKimiDeviceId()
+}
+
 // getKimiDeviceId returns a persistent device ID for Kimi OAuth
 // Attempts to read from ~/.kimi/device_id, generates a new UUID if not found
 func getKimiDeviceId() string {
@@ -625,42 +632,17 @@ func getKimiDeviceName() string {
 	return "unknown"
 }
 
-// getKimiDeviceModel returns the device model for Kimi OAuth
+// getKimiDeviceModel returns the device model for Kimi OAuth in the
+// "<GOOS> <GOARCH>" format used by CLIProxyAPI (e.g. "darwin arm64").
 func getKimiDeviceModel() string {
-	// Return a generic model identifier based on OS and architecture
-	os := runtime.GOOS
-	arch := runtime.GOARCH
-
-	// Map to Kimi's expected format
-	switch os {
+	goos := runtime.GOOS
+	switch goos {
 	case "darwin":
-		if arch == "arm64" {
-			return "Mac14,6" // Apple Silicon Mac
-		}
-		return "MacBookPro18,1" // Intel Mac
+		goos = "macOS"
 	case "linux":
-		return "Linux-" + arch
+		goos = "Linux"
 	case "windows":
-		return "Windows-" + arch
-	default:
-		return os + "-" + arch
+		goos = "Windows"
 	}
-}
-
-// getKimiOsVersion returns the OS version for Kimi OAuth
-func getKimiOsVersion() string {
-	os := runtime.GOOS
-
-	switch os {
-	case "darwin":
-		// Return macOS version (placeholder, should be dynamic in production)
-		return "14.5.0"
-	case "linux":
-		// Return a generic Linux version string
-		return "5.15.0-generic"
-	case "windows":
-		return "10.0.22621"
-	default:
-		return "1.0.0"
-	}
+	return goos + " " + runtime.GOARCH
 }

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -498,7 +498,7 @@ func (h *KimiHook) BeforeAuth(params map[string]string) error {
 }
 
 func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error {
-	header.Set("X-Msh-Platform", "cli-proxy-api")
+	header.Set("X-Msh-Platform", "kimi cli")
 	header.Set("X-Msh-Version", "1.0.0")
 	header.Set("X-Msh-Device-Name", KimiDeviceName())
 	header.Set("X-Msh-Device-Model", KimiDeviceModel())

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -486,12 +486,6 @@ func (h *IFlowHook) AfterToken(ctx context.Context, accessToken string, httpClie
 	return metadata, nil
 }
 
-// KimiDeviceIDMetadataKey is the Token.Metadata / OAuthDetail.ExtraFields
-// key under which the per-credential Kimi X-Msh-Device-Id is persisted.
-// Co-located with KimiHook because both belong to the Kimi provider's wire
-// contract — not part of the generic OAuth surface.
-const KimiDeviceIDMetadataKey = "kimi_device_id"
-
 // KimiHook implements Kimi OAuth device-code flow specific behavior.
 // Reference: https://github.com/router-for-me/CLIProxyAPI internal/auth/kimi/kimi.go
 //

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -783,7 +783,9 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 	// Build common parameters
 	params := map[string]string{
 		"client_id": config.ClientID,
-		"scope":     strings.Join(config.Scopes, " "),
+	}
+	if len(config.Scopes) > 0 {
+		params["scope"] = strings.Join(config.Scopes, " ")
 	}
 	// Add PKCE parameters for Device Code PKCE flow
 	if config.OAuthMethod == OAuthMethodDeviceCodePKCE {

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -631,6 +631,11 @@ func (m *Manager) refreshToken(ctx context.Context, providerType ai.Issuer, refr
 	// Set Content-Type after hook (hook may have modified it)
 	req.Header.Set("Content-Type", contentType)
 
+	// Kimi refresh requires the same X-Msh-Device-Id that was bound to the token.
+	if providerType == ai.IssuerKimiCode && opts.KimiDeviceID != "" {
+		req.Header.Set("X-Msh-Device-Id", opts.KimiDeviceID)
+	}
+
 	// Debug: print request details
 	m.debugRequest(req, config.TokenRequestFormat)
 
@@ -820,6 +825,17 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 		req.Header.Set("Content-Type", contentType)
 	}
 
+	// Kimi: bind a fresh device id to this flow if the caller did not supply one.
+	// The same id must travel through device-authorize, token polling, and the
+	// stored credential so refresh and inference reuse it.
+	kimiDeviceID := options.KimiDeviceID
+	if providerType == ai.IssuerKimiCode {
+		if kimiDeviceID == "" {
+			kimiDeviceID = NewKimiDeviceID()
+		}
+		req.Header.Set("X-Msh-Device-Id", kimiDeviceID)
+	}
+
 	client := m.getHTTPClient(options)
 	client.Timeout = 30 * time.Second
 	resp, err := client.Do(req)
@@ -850,6 +866,7 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 		InitiatedAt:        now,
 		ExpiresAt:          now.Add(time.Duration(deviceResp.ExpiresIn) * time.Second),
 		CodeVerifier:       codeVerifier, // Store PKCE verifier for token polling
+		KimiDeviceID:       kimiDeviceID, // empty for non-Kimi providers
 	}
 
 	return data, nil
@@ -892,7 +909,12 @@ func (m *Manager) PollForToken(ctx context.Context, data *DeviceCodeData, callba
 			return nil, ctx.Err()
 		case <-ticker.C:
 			fmt.Printf("[OAuth] Polling token endpoint for %s...\n", data.Provider)
-			token, err := m.pollTokenRequest(ctx, config, data.DeviceCode, data.CodeVerifier, options)
+			// Ensure the same Kimi device id used at authorize travels into the poll request.
+			pollOpts := *options
+			if data.KimiDeviceID != "" {
+				pollOpts.KimiDeviceID = data.KimiDeviceID
+			}
+			token, err := m.pollTokenRequest(ctx, config, data.DeviceCode, data.CodeVerifier, &pollOpts)
 			if err != nil {
 				// Check if error is a transient error that we should retry
 				if isTransientDeviceCodeError(err) {
@@ -909,6 +931,15 @@ func (m *Manager) PollForToken(ctx context.Context, data *DeviceCodeData, callba
 			token.Provider = data.Provider
 			token.RedirectTo = data.RedirectTo
 			token.Name = data.Name
+
+			// Persist the per-flow Kimi device id with the token so refresh and
+			// inference calls can reuse it from the credential DB.
+			if data.Provider == ai.IssuerKimiCode && data.KimiDeviceID != "" {
+				if token.Metadata == nil {
+					token.Metadata = make(map[string]any)
+				}
+				token.Metadata[KimiDeviceIDMetadataKey] = data.KimiDeviceID
+			}
 
 			// Save token
 			if err := m.config.TokenStorage.SaveToken(data.UserID, data.Provider, token); err != nil {
@@ -964,6 +995,11 @@ func (m *Manager) pollTokenRequest(ctx context.Context, config *ProviderConfig, 
 			return nil, fmt.Errorf("failed to rebuild request body: %w", err)
 		}
 		req.Body = io.NopCloser(reqBody)
+	}
+
+	// Kimi: send the per-flow device id with every poll.
+	if config.Type == ai.IssuerKimiCode && opts.KimiDeviceID != "" {
+		req.Header.Set("X-Msh-Device-Id", opts.KimiDeviceID)
 	}
 
 	client := m.getHTTPClient(opts)

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -468,6 +468,8 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 		req.Body = io.NopCloser(reqBody)
 	}
 
+	applyExtraHeaders(req.Header, opts.ExtraHeaders)
+
 	// Debug: print request details
 	m.debugRequest(req, config.TokenRequestFormat)
 
@@ -631,10 +633,7 @@ func (m *Manager) refreshToken(ctx context.Context, providerType ai.Issuer, refr
 	// Set Content-Type after hook (hook may have modified it)
 	req.Header.Set("Content-Type", contentType)
 
-	// Kimi refresh requires the same X-Msh-Device-Id that was bound to the token.
-	if providerType == ai.IssuerKimiCode && opts.KimiDeviceID != "" {
-		req.Header.Set("X-Msh-Device-Id", opts.KimiDeviceID)
-	}
+	applyExtraHeaders(req.Header, opts.ExtraHeaders)
 
 	// Debug: print request details
 	m.debugRequest(req, config.TokenRequestFormat)
@@ -825,16 +824,7 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 		req.Header.Set("Content-Type", contentType)
 	}
 
-	// Kimi: bind a fresh device id to this flow if the caller did not supply one.
-	// The same id must travel through device-authorize, token polling, and the
-	// stored credential so refresh and inference reuse it.
-	kimiDeviceID := options.KimiDeviceID
-	if providerType == ai.IssuerKimiCode {
-		if kimiDeviceID == "" {
-			kimiDeviceID = NewKimiDeviceID()
-		}
-		req.Header.Set("X-Msh-Device-Id", kimiDeviceID)
-	}
+	applyExtraHeaders(req.Header, options.ExtraHeaders)
 
 	client := m.getHTTPClient(options)
 	client.Timeout = 30 * time.Second
@@ -866,10 +856,21 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 		InitiatedAt:        now,
 		ExpiresAt:          now.Add(time.Duration(deviceResp.ExpiresIn) * time.Second),
 		CodeVerifier:       codeVerifier, // Store PKCE verifier for token polling
-		KimiDeviceID:       kimiDeviceID, // empty for non-Kimi providers
 	}
 
 	return data, nil
+}
+
+// applyExtraHeaders merges caller-supplied per-flow headers onto an outbound
+// request. Called by every token-related request site in the manager so that
+// provider-specific header state (e.g. Kimi's X-Msh-Device-Id) can be injected
+// without the manager knowing about any specific provider.
+func applyExtraHeaders(dst http.Header, src http.Header) {
+	for k, vs := range src {
+		for _, v := range vs {
+			dst.Set(k, v)
+		}
+	}
 }
 
 // PollForToken polls the token endpoint until the user completes authentication
@@ -909,12 +910,7 @@ func (m *Manager) PollForToken(ctx context.Context, data *DeviceCodeData, callba
 			return nil, ctx.Err()
 		case <-ticker.C:
 			fmt.Printf("[OAuth] Polling token endpoint for %s...\n", data.Provider)
-			// Ensure the same Kimi device id used at authorize travels into the poll request.
-			pollOpts := *options
-			if data.KimiDeviceID != "" {
-				pollOpts.KimiDeviceID = data.KimiDeviceID
-			}
-			token, err := m.pollTokenRequest(ctx, config, data.DeviceCode, data.CodeVerifier, &pollOpts)
+			token, err := m.pollTokenRequest(ctx, config, data.DeviceCode, data.CodeVerifier, options)
 			if err != nil {
 				// Check if error is a transient error that we should retry
 				if isTransientDeviceCodeError(err) {
@@ -931,15 +927,6 @@ func (m *Manager) PollForToken(ctx context.Context, data *DeviceCodeData, callba
 			token.Provider = data.Provider
 			token.RedirectTo = data.RedirectTo
 			token.Name = data.Name
-
-			// Persist the per-flow Kimi device id with the token so refresh and
-			// inference calls can reuse it from the credential DB.
-			if data.Provider == ai.IssuerKimiCode && data.KimiDeviceID != "" {
-				if token.Metadata == nil {
-					token.Metadata = make(map[string]any)
-				}
-				token.Metadata[KimiDeviceIDMetadataKey] = data.KimiDeviceID
-			}
 
 			// Save token
 			if err := m.config.TokenStorage.SaveToken(data.UserID, data.Provider, token); err != nil {
@@ -997,10 +984,7 @@ func (m *Manager) pollTokenRequest(ctx context.Context, config *ProviderConfig, 
 		req.Body = io.NopCloser(reqBody)
 	}
 
-	// Kimi: send the per-flow device id with every poll.
-	if config.Type == ai.IssuerKimiCode && opts.KimiDeviceID != "" {
-		req.Header.Set("X-Msh-Device-Id", opts.KimiDeviceID)
-	}
+	applyExtraHeaders(req.Header, opts.ExtraHeaders)
 
 	client := m.getHTTPClient(opts)
 	client.Timeout = 30 * time.Second

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -861,10 +861,8 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 	return data, nil
 }
 
-// applyExtraHeaders merges caller-supplied per-flow headers onto an outbound
-// request. Called by every token-related request site in the manager so that
-// provider-specific header state (e.g. Kimi's X-Msh-Device-Id) can be injected
-// without the manager knowing about any specific provider.
+// applyExtraHeaders lets callers inject provider-specific header state
+// (e.g. Kimi's X-Msh-Device-Id) without the manager knowing the provider.
 func applyExtraHeaders(dst http.Header, src http.Header) {
 	for k, vs := range src {
 		for _, v := range vs {

--- a/ai/oauth/options.go
+++ b/ai/oauth/options.go
@@ -20,6 +20,12 @@ type Options struct {
 
 	// HTTPClient allows passing a custom HTTP client
 	HTTPClient *http.Client
+
+	// KimiDeviceID is the per-flow X-Msh-Device-Id sent to Kimi's auth/token
+	// endpoints. It must be stable across the device-authorize, polling, and
+	// refresh requests of a single flow, then persisted with the token so
+	// future refresh / inference calls reuse the same id.
+	KimiDeviceID string
 }
 
 // WithProxyURL sets a proxy URL for the request
@@ -67,6 +73,14 @@ func WithHTTPClient(client *http.Client) Option {
 func WithBaseURL(baseURL string) Option {
 	return func(o *Options) {
 		o.BaseURL = baseURL
+	}
+}
+
+// WithKimiDeviceID sets the X-Msh-Device-Id used for Kimi OAuth requests in
+// this flow. Pass the stored id when refreshing an existing Kimi token.
+func WithKimiDeviceID(deviceID string) Option {
+	return func(o *Options) {
+		o.KimiDeviceID = deviceID
 	}
 }
 

--- a/ai/oauth/options.go
+++ b/ai/oauth/options.go
@@ -22,11 +22,8 @@ type Options struct {
 	HTTPClient *http.Client
 
 	// ExtraHeaders are merged into every token-related outbound request
-	// (device-code, polling, refresh, code exchange). It's a generic escape
-	// hatch for providers that need per-flow header state — for example,
-	// binding a stable X-Msh-Device-Id across all requests of a Kimi flow.
-	// The OAuth manager itself stays oblivious to provider semantics; callers
-	// own the per-provider semantics.
+	// (device-code, polling, refresh, code exchange). Escape hatch for
+	// per-flow header state like Kimi's X-Msh-Device-Id binding.
 	ExtraHeaders http.Header
 }
 
@@ -78,10 +75,8 @@ func WithBaseURL(baseURL string) Option {
 	}
 }
 
-// WithExtraHeader appends a header to be applied to every token-related
-// OAuth request in this flow. Use it for per-flow header state (e.g.
-// pinning a device id binding for the entire authorize → poll → refresh
-// lifecycle). Repeated calls accumulate; values for the same key replace.
+// WithExtraHeader sets a header applied to every token-related OAuth
+// request in this flow. Repeated calls accumulate; same-key values replace.
 func WithExtraHeader(key, value string) Option {
 	return func(o *Options) {
 		if key == "" {

--- a/ai/oauth/options.go
+++ b/ai/oauth/options.go
@@ -21,11 +21,13 @@ type Options struct {
 	// HTTPClient allows passing a custom HTTP client
 	HTTPClient *http.Client
 
-	// KimiDeviceID is the per-flow X-Msh-Device-Id sent to Kimi's auth/token
-	// endpoints. It must be stable across the device-authorize, polling, and
-	// refresh requests of a single flow, then persisted with the token so
-	// future refresh / inference calls reuse the same id.
-	KimiDeviceID string
+	// ExtraHeaders are merged into every token-related outbound request
+	// (device-code, polling, refresh, code exchange). It's a generic escape
+	// hatch for providers that need per-flow header state — for example,
+	// binding a stable X-Msh-Device-Id across all requests of a Kimi flow.
+	// The OAuth manager itself stays oblivious to provider semantics; callers
+	// own the per-provider semantics.
+	ExtraHeaders http.Header
 }
 
 // WithProxyURL sets a proxy URL for the request
@@ -76,11 +78,19 @@ func WithBaseURL(baseURL string) Option {
 	}
 }
 
-// WithKimiDeviceID sets the X-Msh-Device-Id used for Kimi OAuth requests in
-// this flow. Pass the stored id when refreshing an existing Kimi token.
-func WithKimiDeviceID(deviceID string) Option {
+// WithExtraHeader appends a header to be applied to every token-related
+// OAuth request in this flow. Use it for per-flow header state (e.g.
+// pinning a device id binding for the entire authorize → poll → refresh
+// lifecycle). Repeated calls accumulate; values for the same key replace.
+func WithExtraHeader(key, value string) Option {
 	return func(o *Options) {
-		o.KimiDeviceID = deviceID
+		if key == "" {
+			return
+		}
+		if o.ExtraHeaders == nil {
+			o.ExtraHeaders = make(http.Header)
+		}
+		o.ExtraHeaders.Set(key, value)
 	}
 }
 

--- a/ai/oauth/provider.go
+++ b/ai/oauth/provider.go
@@ -191,14 +191,18 @@ func DefaultRegistry() *Registry {
 		Hook:               &CodexHook{},
 	})
 
+	// Kimi OAuth (Device Authorization Flow)
+	// Reference: https://github.com/router-for-me/CLIProxyAPI internal/auth/kimi/kimi.go
+	// Public device flow, no client secret; no scope parameter on the wire.
 	registry.Register(&ProviderConfig{
 		Type:               ai.IssuerKimiCode,
+		GrantType:          "urn:ietf:params:oauth:grant-type:device_code",
 		DisplayName:        "Kimi CLI",
 		ClientID:           "17e5f671-d194-4dfb-9706-5516cb48c098",
-		ClientSecret:       "", // No ClientSecret for Device Authorization Flow
+		ClientSecret:       "",
 		DeviceCodeURL:      "https://auth.kimi.com/api/oauth/device_authorization",
 		TokenURL:           "https://auth.kimi.com/api/oauth/token",
-		Scopes:             []string{"kimi-code"},
+		Scopes:             nil,
 		AuthStyle:          AuthStyleInNone,
 		OAuthMethod:        OAuthMethodDeviceCode,
 		TokenRequestFormat: TokenRequestFormatForm,

--- a/ai/oauth/provider.go
+++ b/ai/oauth/provider.go
@@ -197,7 +197,7 @@ func DefaultRegistry() *Registry {
 	registry.Register(&ProviderConfig{
 		Type:               ai.IssuerKimiCode,
 		GrantType:          "urn:ietf:params:oauth:grant-type:device_code",
-		DisplayName:        "Kimi CLI",
+		DisplayName:        "Kimi Code",
 		ClientID:           "17e5f671-d194-4dfb-9706-5516cb48c098",
 		ClientSecret:       "",
 		DeviceCodeURL:      "https://auth.kimi.com/api/oauth/device_authorization",

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -76,6 +76,7 @@ type OAuthDetail struct {
 	UserID       string                 `json:"user_id"`                // OAuth user identifier
 	RefreshToken string                 `json:"refresh_token"`          // Token for refreshing access token
 	ExpiresAt    string                 `json:"expires_at"`             // Token expiration time (RFC3339)
+	DeviceID     string                 `json:"device_id,omitempty"`    // Per-credential device id (e.g. Kimi's X-Msh-Device-Id). Bound at OAuth time and reused on refresh + inference.
 	ExtraFields  map[string]interface{} `json:"extra_fields,omitempty"` // Any extra field for some special clients
 
 	// Deprecated: Use Issuer instead. Kept for backward compatibility.

--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -92,7 +92,7 @@ export const FALLBACK_OAUTH_PROVIDERS: OAuthProvider[] = [
         description: 'Access Kimi Code via device code flow',
         icon: <Kimi size={32}/>,
         color: '#6366F1',
-        enabled: false, // DISABLED: Kimi OAuth backend wiring in progress
+        enabled: true,
         deviceCodeFlow: true,
     },
     {

--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -88,7 +88,7 @@ export const FALLBACK_OAUTH_PROVIDERS: OAuthProvider[] = [
     {
         id: 'kimi_code',
         name: 'Kimi Code',
-        displayName: 'Kimi CLI',
+        displayName: 'Kimi Code',
         description: 'Access Kimi Code via device code flow',
         icon: <Kimi size={32}/>,
         color: '#6366F1',

--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -92,7 +92,7 @@ export const FALLBACK_OAUTH_PROVIDERS: OAuthProvider[] = [
         description: 'Access Kimi Code via device code flow',
         icon: <Kimi size={32}/>,
         color: '#6366F1',
-        enabled: true,
+        enabled: false, // DISABLED: Kimi OAuth backend wiring in progress
         deviceCodeFlow: true,
     },
     {

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -2,31 +2,30 @@ package client
 
 import (
 	"net/http"
-	"os"
-	"runtime"
 
+	"github.com/tingly-dev/tingly-box/ai/oauth"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// Kimi CLI client identification headers used when calling Kimi's coding API.
-// Reference: https://github.com/router-for-me/CLIProxyAPI internal/runtime/executor/kimi_executor.go
+// Kimi-cli impersonation values sent with every inference request.
+// Reference: CLIProxyAPI internal/runtime/executor/kimi_executor.go.
 const (
 	kimiCLIUserAgent = "KimiCLI/1.10.6"
 	kimiCLIPlatform  = "kimi_cli"
 	kimiCLIVersion   = "1.10.6"
 )
 
-// kimiRoundTripper layers the kimi-cli impersonation headers on top of an
-// inner transport. The Authorization Bearer header is set by the OpenAI SDK
-// from the provider's access token.
+// kimiRoundTripper layers kimi-cli impersonation headers on an inner
+// transport. The Authorization Bearer is set by the OpenAI SDK.
 //
-// deviceID is bound at construction time from the credential's typed
-// OAuthDetail.DeviceID — the same id Kimi minted the token against. Matches
-// CLIProxyAPI's per-token device-id binding, persisted to our credential DB
-// instead of a kimi-cli file path.
+// All header values are bound at construction so per-request RoundTrip stays
+// allocation-free: device id (per-credential, persisted in OAuthDetail.DeviceID),
+// hostname (one os.Hostname syscall), and the GOOS/GOARCH-derived model.
 type kimiRoundTripper struct {
 	http.RoundTripper
-	deviceID string
+	deviceID    string
+	deviceName  string
+	deviceModel string
 }
 
 func newKimiRoundTripper(inner http.RoundTripper, provider *typ.Provider) *kimiRoundTripper {
@@ -34,37 +33,22 @@ func newKimiRoundTripper(inner http.RoundTripper, provider *typ.Provider) *kimiR
 	if provider != nil && provider.OAuthDetail != nil {
 		deviceID = provider.OAuthDetail.DeviceID
 	}
-	return &kimiRoundTripper{RoundTripper: inner, deviceID: deviceID}
+	return &kimiRoundTripper{
+		RoundTripper: inner,
+		deviceID:     deviceID,
+		deviceName:   oauth.KimiDeviceName(),
+		deviceModel:  oauth.KimiDeviceModel(),
+	}
 }
 
 func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", kimiCLIUserAgent)
 	req.Header.Set("X-Msh-Platform", kimiCLIPlatform)
 	req.Header.Set("X-Msh-Version", kimiCLIVersion)
-	req.Header.Set("X-Msh-Device-Name", kimiDeviceName())
-	req.Header.Set("X-Msh-Device-Model", kimiDeviceModel())
+	req.Header.Set("X-Msh-Device-Name", t.deviceName)
+	req.Header.Set("X-Msh-Device-Model", t.deviceModel)
 	if t.deviceID != "" {
 		req.Header.Set("X-Msh-Device-Id", t.deviceID)
 	}
 	return t.RoundTripper.RoundTrip(req)
-}
-
-func kimiDeviceName() string {
-	if h, err := os.Hostname(); err == nil && h != "" {
-		return h
-	}
-	return "unknown"
-}
-
-func kimiDeviceModel() string {
-	goos := runtime.GOOS
-	switch goos {
-	case "darwin":
-		goos = "macOS"
-	case "linux":
-		goos = "Linux"
-	case "windows":
-		goos = "Windows"
-	}
-	return goos + " " + runtime.GOARCH
 }

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/tingly-dev/tingly-box/ai/oauth"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -21,8 +20,8 @@ const (
 // inner transport. The Authorization Bearer header is set by the OpenAI SDK
 // from the provider's access token.
 //
-// deviceID is bound at construction time from provider.OAuthDetail.ExtraFields
-// so each Kimi account uses the same id it was OAuth'd with — matching
+// deviceID is bound at construction time from the credential's typed
+// OAuthDetail.DeviceID — the same id Kimi minted the token against. Matches
 // CLIProxyAPI's per-token device-id binding, persisted to our credential DB
 // instead of a kimi-cli file path.
 type kimiRoundTripper struct {
@@ -31,10 +30,11 @@ type kimiRoundTripper struct {
 }
 
 func newKimiRoundTripper(inner http.RoundTripper, provider *typ.Provider) *kimiRoundTripper {
-	return &kimiRoundTripper{
-		RoundTripper: inner,
-		deviceID:     kimiDeviceIDForProvider(provider),
+	var deviceID string
+	if provider != nil && provider.OAuthDetail != nil {
+		deviceID = provider.OAuthDetail.DeviceID
 	}
+	return &kimiRoundTripper{RoundTripper: inner, deviceID: deviceID}
 }
 
 func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -47,19 +47,6 @@ func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		req.Header.Set("X-Msh-Device-Id", t.deviceID)
 	}
 	return t.RoundTripper.RoundTrip(req)
-}
-
-// kimiDeviceIDForProvider returns the device id persisted with the Kimi
-// credential at OAuth time. The OAuth flow stores it on the token metadata,
-// which the provider creation path copies into OAuthDetail.ExtraFields.
-func kimiDeviceIDForProvider(provider *typ.Provider) string {
-	if provider == nil || provider.OAuthDetail == nil || provider.OAuthDetail.ExtraFields == nil {
-		return ""
-	}
-	if v, ok := provider.OAuthDetail.ExtraFields[oauth.KimiDeviceIDMetadataKey].(string); ok {
-		return v
-	}
-	return ""
 }
 
 func kimiDeviceName() string {

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"net/http"
+	"os"
+	"runtime"
+
+	"github.com/tingly-dev/tingly-box/ai/oauth"
+)
+
+// Kimi CLI client identification headers used when calling Kimi's coding API.
+// Reference: https://github.com/router-for-me/CLIProxyAPI internal/runtime/executor/kimi_executor.go
+const (
+	kimiCLIUserAgent = "KimiCLI/1.10.6"
+	kimiCLIPlatform  = "kimi_cli"
+	kimiCLIVersion   = "1.10.6"
+)
+
+// kimiRoundTripper layers the kimi-cli impersonation headers on top of an
+// inner transport. The Authorization Bearer header is set by the OpenAI SDK
+// from the provider's access token.
+type kimiRoundTripper struct {
+	http.RoundTripper
+}
+
+func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", kimiCLIUserAgent)
+	req.Header.Set("X-Msh-Platform", kimiCLIPlatform)
+	req.Header.Set("X-Msh-Version", kimiCLIVersion)
+	req.Header.Set("X-Msh-Device-Name", kimiDeviceName())
+	req.Header.Set("X-Msh-Device-Model", kimiDeviceModel())
+	req.Header.Set("X-Msh-Device-Id", oauth.GetKimiDeviceID())
+	return t.RoundTripper.RoundTrip(req)
+}
+
+func kimiDeviceName() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "unknown"
+}
+
+func kimiDeviceModel() string {
+	goos := runtime.GOOS
+	switch goos {
+	case "darwin":
+		goos = "macOS"
+	case "linux":
+		goos = "Linux"
+	case "windows":
+		goos = "Windows"
+	}
+	return goos + " " + runtime.GOARCH
+}

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -1,8 +1,14 @@
 package client
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"github.com/tingly-dev/tingly-box/ai/oauth"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -50,5 +56,349 @@ func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	if t.deviceID != "" {
 		req.Header.Set("X-Msh-Device-Id", t.deviceID)
 	}
+
+	// Normalize request body for Kimi API compatibility
+	// This includes stripping model name prefix and normalizing tool messages
+	if req.Body != nil && req.Method == "POST" {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err == nil && len(bodyBytes) > 0 {
+			normalized, normErr := NormalizeRequest(bodyBytes)
+			if normErr == nil {
+				req.Body = io.NopCloser(bytes.NewReader(normalized))
+				req.ContentLength = int64(len(normalized))
+			}
+			// If normalization fails, proceed with original body
+		}
+	}
+
 	return t.RoundTripper.RoundTrip(req)
+}
+
+// NormalizeRequest applies Kimi-specific normalization to API request bodies.
+// This includes:
+// 1. Stripping the "kimi-" prefix from model names
+// 2. Normalizing tool message format for Kimi API compatibility
+// Reference: CLIProxyAPI internal/runtime/executor/kimi_executor.go
+func NormalizeRequest(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+
+	// Step 1: Strip kimi- prefix from model name
+	body = stripKimiPrefixFromBody(body)
+
+	// Step 2: Normalize tool messages
+	normalized, err := normalizeToolMessages(body)
+	if err != nil {
+		return body, fmt.Errorf("failed to normalize tool messages: %w", err)
+	}
+
+	return normalized, nil
+}
+
+// stripKimiPrefixFromBody removes the "kimi-" prefix from the model field.
+// Reference: CLIProxyAPI kimi_executor.go:742-749
+// Example: "kimi-k2" → "k2", "Kimi-K2" → "Kimi-K2" (case-sensitive)
+func stripKimiPrefixFromBody(body []byte) []byte {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+
+	model := gjson.GetBytes(body, "model")
+	if !model.Exists() {
+		return body
+	}
+
+	modelName := model.String()
+	stripped := stripKimiPrefix(modelName)
+	if stripped != modelName {
+		// Model name was modified, update the body
+		updated, err := sjson.SetBytes(body, "model", stripped)
+		if err != nil {
+			return body // Return original on error
+		}
+		return updated
+	}
+
+	return body
+}
+
+// stripKimiPrefix removes the "kimi-" prefix from model names.
+// The prefix check is case-insensitive, but the replacement preserves
+// the original case of the remaining part.
+// Reference: CLIProxyAPI kimi_executor.go:742-749
+func stripKimiPrefix(model string) string {
+	model = strings.TrimSpace(model)
+	if strings.HasPrefix(strings.ToLower(model), "kimi-") {
+		return model[5:] // Remove "kimi-" prefix (5 characters)
+	}
+	return model
+}
+
+// normalizeToolMessages normalizes tool message format for Kimi API compatibility.
+// This includes:
+// 1. Filtering empty assistant messages
+// 2. Adding reasoning_content to tool call messages
+// 3. Fixing tool_call_id vs call_id field names
+// Reference: CLIProxyAPI kimi_executor.go:326-449
+func normalizeToolMessages(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	msgs := messages.Array()
+
+	// Step 1: Filter empty assistant messages
+	out, dropped, err := filterEmptyAssistantMessages(body, msgs)
+	if err != nil {
+		return body, err
+	}
+	if dropped > 0 {
+		// Re-read messages after filtering
+		messages = gjson.GetBytes(out, "messages")
+		if !messages.Exists() || !messages.IsArray() {
+			return out, nil
+		}
+		msgs = messages.Array()
+	}
+
+	// Step 2: Normalize tool message fields
+	pending := make([]string, 0)
+	patched := 0
+	patchedReasoning := 0
+	latestReasoning := ""
+	hasLatestReasoning := false
+
+	removePending := func(id string) {
+		for idx := range pending {
+			if pending[idx] != id {
+				continue
+			}
+			pending = append(pending[:idx], pending[idx+1:]...)
+			return
+		}
+	}
+
+	for msgIdx := range msgs {
+		msg := msgs[msgIdx]
+		role := strings.TrimSpace(msg.Get("role").String())
+
+		switch role {
+		case "assistant":
+			// Track reasoning content for later use
+			reasoning := msg.Get("reasoning_content")
+			if reasoning.Exists() {
+				reasoningText := reasoning.String()
+				if strings.TrimSpace(reasoningText) != "" {
+					latestReasoning = reasoningText
+					hasLatestReasoning = true
+				}
+			}
+
+			// Track pending tool calls
+			toolCalls := msg.Get("tool_calls")
+			if !toolCalls.Exists() || !toolCalls.IsArray() || len(toolCalls.Array()) == 0 {
+				continue
+			}
+
+			// Add reasoning_content if missing
+			if !reasoning.Exists() || strings.TrimSpace(reasoning.String()) == "" {
+				reasoningText := fallbackAssistantReasoning(msg, hasLatestReasoning, latestReasoning)
+				path := fmt.Sprintf("messages.%d.reasoning_content", msgIdx)
+				next, err := sjson.SetBytes(out, path, reasoningText)
+				if err != nil {
+					return body, fmt.Errorf("failed to set assistant reasoning_content: %w", err)
+				}
+				out = next
+				patchedReasoning++
+			}
+
+			// Collect tool call IDs
+			for _, tc := range toolCalls.Array() {
+				id := strings.TrimSpace(tc.Get("id").String())
+				if id != "" {
+					pending = append(pending, id)
+				}
+			}
+
+		case "tool":
+			// Fix tool_call_id vs call_id field names
+			toolCallID := strings.TrimSpace(msg.Get("tool_call_id").String())
+			if toolCallID == "" {
+				toolCallID = strings.TrimSpace(msg.Get("call_id").String())
+				if toolCallID != "" {
+					// Fix: rename call_id to tool_call_id
+					path := fmt.Sprintf("messages.%d.tool_call_id", msgIdx)
+					next, err := sjson.SetBytes(out, path, toolCallID)
+					if err != nil {
+						return body, fmt.Errorf("failed to set tool_call_id from call_id: %w", err)
+					}
+					out = next
+					patched++
+				}
+			}
+
+			// Infer missing tool_call_id from pending tool calls
+			if toolCallID == "" {
+				if len(pending) == 1 {
+					toolCallID = pending[0]
+					path := fmt.Sprintf("messages.%d.tool_call_id", msgIdx)
+					next, err := sjson.SetBytes(out, path, toolCallID)
+					if err != nil {
+						return body, fmt.Errorf("failed to infer tool_call_id: %w", err)
+					}
+					out = next
+					patched++
+				}
+				// Note: If len(pending) > 1, we can't infer which ID to use
+				// This case is logged but not an error
+			}
+
+			// Remove used tool call ID from pending list
+			if toolCallID != "" {
+				removePending(toolCallID)
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// filterEmptyAssistantMessages removes empty assistant messages that don't contain
+// tool calls, function calls, reasoning, or meaningful content.
+// Reference: CLIProxyAPI kimi_executor.go:451-471
+func filterEmptyAssistantMessages(body []byte, msgs []gjson.Result) ([]byte, int, error) {
+	kept := make([]string, 0, len(msgs))
+	dropped := 0
+
+	for _, msg := range msgs {
+		if shouldDropAssistantMessage(msg) {
+			dropped++
+			continue
+		}
+		kept = append(kept, msg.Raw)
+	}
+
+	if dropped == 0 {
+		return body, 0, nil
+	}
+
+	rawMessages := []byte("[" + strings.Join(kept, ",") + "]")
+	out, err := sjson.SetRawBytes(body, "messages", rawMessages)
+	if err != nil {
+		return body, 0, fmt.Errorf("failed to drop empty assistant messages: %w", err)
+	}
+
+	return out, dropped, nil
+}
+
+// shouldDropAssistantMessage determines if an assistant message should be dropped.
+// Reference: CLIProxyAPI kimi_executor.go:473-481
+func shouldDropAssistantMessage(msg gjson.Result) bool {
+	if strings.TrimSpace(msg.Get("role").String()) != "assistant" {
+		return false
+	}
+
+	if hasToolCalls(msg) || hasLegacyFunctionCall(msg) || hasAssistantReasoning(msg) {
+		return false
+	}
+
+	return isAssistantContentEmpty(msg.Get("content"))
+}
+
+// hasToolCalls checks if message has tool_calls array with items.
+func hasToolCalls(msg gjson.Result) bool {
+	toolCalls := msg.Get("tool_calls")
+	return toolCalls.Exists() && toolCalls.IsArray() && len(toolCalls.Array()) > 0
+}
+
+// hasLegacyFunctionCall checks if message has a non-empty function_call.
+func hasLegacyFunctionCall(msg gjson.Result) bool {
+	functionCall := msg.Get("function_call")
+	if !functionCall.Exists() || functionCall.Type == gjson.Null {
+		return false
+	}
+	if functionCall.IsObject() && strings.TrimSpace(functionCall.Raw) == "{}" {
+		return false
+	}
+	return strings.TrimSpace(functionCall.Raw) != ""
+}
+
+// hasAssistantReasoning checks if message has reasoning_content.
+func hasAssistantReasoning(msg gjson.Result) bool {
+	reasoning := msg.Get("reasoning_content")
+	return reasoning.Exists() && strings.TrimSpace(reasoning.String()) != ""
+}
+
+// isAssistantContentEmpty checks if content field is empty or null.
+func isAssistantContentEmpty(content gjson.Result) bool {
+	if !content.Exists() || content.Type == gjson.Null {
+		return true
+	}
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String()) == ""
+	}
+	if !content.IsArray() {
+		return false
+	}
+	for _, part := range content.Array() {
+		if !isAssistantContentPartEmpty(part) {
+			return false
+		}
+	}
+	return true
+}
+
+// isAssistantContentPartEmpty checks if a content part is empty.
+func isAssistantContentPartEmpty(part gjson.Result) bool {
+	if !part.Exists() || part.Type == gjson.Null {
+		return true
+	}
+	if part.Type == gjson.String {
+		return strings.TrimSpace(part.String()) == ""
+	}
+	if !part.IsObject() {
+		return false
+	}
+	if text := part.Get("text"); text.Exists() {
+		return strings.TrimSpace(text.String()) == ""
+	}
+	if strings.TrimSpace(part.Get("type").String()) == "text" {
+		return true
+	}
+	return strings.TrimSpace(part.Raw) == "{}"
+}
+
+// fallbackAssistantReasoning provides reasoning content when missing.
+// Reference: CLIProxyAPI kimi_executor.go:541-567
+func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string) string {
+	if hasLatest && strings.TrimSpace(latest) != "" {
+		return latest
+	}
+
+	content := msg.Get("content")
+	if content.Type == gjson.String {
+		if text := strings.TrimSpace(content.String()); text != "" {
+			return text
+		}
+	}
+	if content.IsArray() {
+		parts := make([]string, 0, len(content.Array()))
+		for _, item := range content.Array() {
+			text := strings.TrimSpace(item.Get("text").String())
+			if text != "" {
+				parts = append(parts, text)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n")
+		}
+	}
+
+	return "[reasoning unavailable]"
 }

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -16,9 +16,9 @@ import (
 // Kimi-cli impersonation values sent with every inference request.
 // Reference: CLIProxyAPI internal/runtime/executor/kimi_executor.go.
 const (
-	kimiCLIUserAgent = "KimiCLI/1.45.0"
+	kimiCLIUserAgent = "KimiCLI/1.10.6"
 	kimiCLIPlatform  = "kimi_cli"
-	kimiCLIVersion   = "1.45.0"
+	kimiCLIVersion   = "1.10.6"
 )
 
 // kimiRoundTripper layers kimi-cli impersonation headers on an inner

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -16,9 +16,9 @@ import (
 // Kimi-cli impersonation values sent with every inference request.
 // Reference: CLIProxyAPI internal/runtime/executor/kimi_executor.go.
 const (
-	kimiCLIUserAgent = "KimiCLI/1.10.6"
+	kimiCLIUserAgent = "KimiCLI/1.45.0"
 	kimiCLIPlatform  = "kimi_cli"
-	kimiCLIVersion   = "1.10.6"
+	kimiCLIVersion   = "1.45.0"
 )
 
 // kimiRoundTripper layers kimi-cli impersonation headers on an inner

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -400,5 +400,5 @@ func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string)
 		}
 	}
 
-	return "[reasoning unavailable]"
+	return ""
 }

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/tingly-dev/tingly-box/ai/oauth"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // Kimi CLI client identification headers used when calling Kimi's coding API.
@@ -19,8 +20,21 @@ const (
 // kimiRoundTripper layers the kimi-cli impersonation headers on top of an
 // inner transport. The Authorization Bearer header is set by the OpenAI SDK
 // from the provider's access token.
+//
+// deviceID is bound at construction time from provider.OAuthDetail.ExtraFields
+// so each Kimi account uses the same id it was OAuth'd with — matching
+// CLIProxyAPI's per-token device-id binding, persisted to our credential DB
+// instead of a kimi-cli file path.
 type kimiRoundTripper struct {
 	http.RoundTripper
+	deviceID string
+}
+
+func newKimiRoundTripper(inner http.RoundTripper, provider *typ.Provider) *kimiRoundTripper {
+	return &kimiRoundTripper{
+		RoundTripper: inner,
+		deviceID:     kimiDeviceIDForProvider(provider),
+	}
 }
 
 func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -29,8 +43,23 @@ func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	req.Header.Set("X-Msh-Version", kimiCLIVersion)
 	req.Header.Set("X-Msh-Device-Name", kimiDeviceName())
 	req.Header.Set("X-Msh-Device-Model", kimiDeviceModel())
-	req.Header.Set("X-Msh-Device-Id", oauth.GetKimiDeviceID())
+	if t.deviceID != "" {
+		req.Header.Set("X-Msh-Device-Id", t.deviceID)
+	}
 	return t.RoundTripper.RoundTrip(req)
+}
+
+// kimiDeviceIDForProvider returns the device id persisted with the Kimi
+// credential at OAuth time. The OAuth flow stores it on the token metadata,
+// which the provider creation path copies into OAuthDetail.ExtraFields.
+func kimiDeviceIDForProvider(provider *typ.Provider) string {
+	if provider == nil || provider.OAuthDetail == nil || provider.OAuthDetail.ExtraFields == nil {
+		return ""
+	}
+	if v, ok := provider.OAuthDetail.ExtraFields[oauth.KimiDeviceIDMetadataKey].(string); ok {
+		return v
+	}
+	return ""
 }
 
 func kimiDeviceName() string {

--- a/internal/client/kimi_round_tripper_test.go
+++ b/internal/client/kimi_round_tripper_test.go
@@ -1,0 +1,231 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestStripKimiPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strip lowercase kimi prefix",
+			input:    "kimi-k2",
+			expected: "k2",
+		},
+		{
+			name:     "preserve case after prefix",
+			input:    "kimi-K2",
+			expected: "K2",
+		},
+		{
+			name:     "no prefix - already stripped",
+			input:    "k2",
+			expected: "k2",
+		},
+		{
+			name:     "case insensitive prefix check",
+			input:    "Kimi-K2",
+			expected: "K2",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    "  kimi-k2  ",
+			expected: "k2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripKimiPrefix(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strip kimi prefix from model",
+			input:    `{"model":"kimi-k2","messages":[{"role":"user","content":"hi"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:     "preserve case in model name",
+			input:    `{"model":"kimi-K2","messages":[]}`,
+			expected: `{"model":"K2","messages":[]}`,
+		},
+		{
+			name:     "no change for non-kimi model",
+			input:    `{"model":"gpt-4","messages":[]}`,
+			expected: `{"model":"gpt-4","messages":[]}`,
+		},
+		{
+			name:     "filter empty assistant message",
+			input:    `{"model":"k2","messages":[{"role":"assistant","content":""},{"role":"user","content":"hi"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:     "keep assistant message with tool calls and add reasoning_content",
+			input:    `{"model":"k2","messages":[{"role":"assistant","content":"","tool_calls":[{"id":"123","function":{"name":"test"}}]},{"role":"user","content":"hi"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","content":"","tool_calls":[{"id":"123","function":{"name":"test"}}],"reasoning_content":"[reasoning unavailable]"},{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:     "invalid json - return as is",
+			input:    `not valid json`,
+			expected: `not valid json`,
+		},
+		{
+			name:     "empty input - return as is",
+			input:    ``,
+			expected: ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NormalizeRequest([]byte(tt.input))
+			require.NoError(t, err)
+			// For invalid JSON, compare raw strings
+			if tt.name == "invalid json - return as is" || tt.name == "empty input - return as is" {
+				assert.Equal(t, tt.expected, string(result))
+			} else {
+				assert.JSONEq(t, tt.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestNormalizeToolMessages_FixToolCallID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "fix call_id to tool_call_id (keeps both fields)",
+			input:    `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}]},{"role":"tool","call_id":"tc1","content":"result"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}],"reasoning_content":"[reasoning unavailable]"},{"role":"tool","call_id":"tc1","tool_call_id":"tc1","content":"result"}]}`,
+		},
+		{
+			name:     "infer missing tool_call_id from single pending",
+			input:    `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}]},{"role":"tool","content":"result"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}],"reasoning_content":"[reasoning unavailable]"},{"role":"tool","tool_call_id":"tc1","content":"result"}]}`,
+		},
+		{
+			name:     "add reasoning_content to assistant with tool calls",
+			input:    `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1","function":{"name":"test"}}]}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1","function":{"name":"test"}}],"reasoning_content":"[reasoning unavailable]"}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NormalizeRequest([]byte(tt.input))
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestStripKimiPrefixFromBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strip prefix",
+			input:    `{"model":"kimi-k2"}`,
+			expected: `{"model":"k2"}`,
+		},
+		{
+			name:     "no model field",
+			input:    `{"messages":[]}`,
+			expected: `{"messages":[]}`,
+		},
+		{
+			name:     "invalid json",
+			input:    `not json`,
+			expected: `not json`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripKimiPrefixFromBody([]byte(tt.input))
+			if tt.input == "not json" {
+				assert.Equal(t, tt.input, string(result))
+			} else {
+				assert.JSONEq(t, tt.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestFilterEmptyAssistantMessages(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		expectedDropped int
+		expectedMsg     string
+	}{
+		{
+			name:            "drop empty assistant",
+			input:           `[{"role":"assistant","content":""},{"role":"user","content":"hi"}]`,
+			expectedDropped: 1,
+			expectedMsg:     `[{"role":"user","content":"hi"}]`,
+		},
+		{
+			name:            "keep assistant with tool calls",
+			input:           `[{"role":"assistant","tool_calls":[{"id":"1"}]}]`,
+			expectedDropped: 0,
+			expectedMsg:     `[{"role":"assistant","tool_calls":[{"id":"1"}]}]`,
+		},
+		{
+			name:            "keep assistant with reasoning",
+			input:           `[{"role":"assistant","reasoning_content":"thinking"}]`,
+			expectedDropped: 0,
+			expectedMsg:     `[{"role":"assistant","reasoning_content":"thinking"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"model":"k2","messages":` + tt.input + `}`)
+			result, dropped, err := filterEmptyAssistantMessages(body, parseMessages(t, tt.input))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedDropped, dropped)
+			// Check messages array in result
+			assert.JSONEq(t, `{"model":"k2","messages":`+tt.expectedMsg+`}`, string(result))
+		})
+	}
+}
+
+// parseMessages is a test helper to parse JSON messages array
+func parseMessages(t *testing.T, jsonMsgs string) []gjson.Result {
+	t.Helper()
+	var msgs []interface{}
+	err := json.Unmarshal([]byte(jsonMsgs), &msgs)
+	require.NoError(t, err)
+
+	raw, _ := json.Marshal(msgs)
+	result := gjson.ParseBytes(raw)
+	return result.Array()
+}

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -93,9 +93,7 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	if provider.AuthType == typ.AuthTypeOAuth &&
 		provider.OAuthDetail != nil &&
 		provider.OAuthDetail.GetIssuer() == ai.IssuerKimiCode {
-		transport = &kimiRoundTripper{
-			RoundTripper: createSessionBoundTransport(provider, sessionID),
-		}
+		transport = newKimiRoundTripper(createSessionBoundTransport(provider, sessionID), provider)
 	}
 
 	httpClient := &http.Client{

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -86,7 +86,7 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	transport = wrapWithUserAgent(transport, provider)
 	transport = wrapWithLogging(transport, provider)
 
-	// Kimi CLI OAuth requires kimi-cli impersonation headers on every request.
+	// Kimi Code OAuth requires kimi-cli impersonation headers on every request.
 	// Layer the Kimi round tripper on top of a session-bound transport so each
 	// session gets its own connection pool while still emitting the right
 	// X-Msh-* / User-Agent headers.

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -86,6 +86,18 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	transport = wrapWithUserAgent(transport, provider)
 	transport = wrapWithLogging(transport, provider)
 
+	// Kimi CLI OAuth requires kimi-cli impersonation headers on every request.
+	// Layer the Kimi round tripper on top of a session-bound transport so each
+	// session gets its own connection pool while still emitting the right
+	// X-Msh-* / User-Agent headers.
+	if provider.AuthType == typ.AuthTypeOAuth &&
+		provider.OAuthDetail != nil &&
+		provider.OAuthDetail.GetIssuer() == ai.IssuerKimiCode {
+		transport = &kimiRoundTripper{
+			RoundTripper: createSessionBoundTransport(provider, sessionID),
+		}
+	}
+
 	httpClient := &http.Client{
 		Transport: transport,
 	}

--- a/internal/server/background/oauth_refresher.go
+++ b/internal/server/background/oauth_refresher.go
@@ -205,12 +205,18 @@ func (tr *OAuthRefresher) refreshProviderToken(provider *typ.Provider) {
 		return
 	}
 
+	refreshOpts := []oauth.Option{oauth.WithProxyString(provider.ProxyURL)}
+	if issuer == ai.IssuerKimiCode {
+		if v, ok := provider.OAuthDetail.ExtraFields[oauth.KimiDeviceIDMetadataKey].(string); ok && v != "" {
+			refreshOpts = append(refreshOpts, oauth.WithKimiDeviceID(v))
+		}
+	}
 	token, err := tr.manager.RefreshToken(
 		context.Background(),
 		provider.OAuthDetail.UserID,
 		issuer,
 		provider.OAuthDetail.RefreshToken,
-		oauth.WithProxyString(provider.ProxyURL),
+		refreshOpts...,
 	)
 
 	if err != nil {

--- a/internal/server/background/oauth_refresher.go
+++ b/internal/server/background/oauth_refresher.go
@@ -207,10 +207,8 @@ func (tr *OAuthRefresher) refreshProviderToken(provider *typ.Provider) {
 	}
 
 	refreshOpts := []oauth.Option{oauth.WithProxyString(provider.ProxyURL)}
-	if issuer == ai.IssuerKimiCode {
-		if id := oauthmodule.KimiDeviceIDFromExtraFields(provider.OAuthDetail.ExtraFields); id != "" {
-			refreshOpts = append(refreshOpts, oauthmodule.WithKimiDeviceID(id))
-		}
+	if issuer == ai.IssuerKimiCode && provider.OAuthDetail.DeviceID != "" {
+		refreshOpts = append(refreshOpts, oauthmodule.WithKimiDeviceID(provider.OAuthDetail.DeviceID))
 	}
 	token, err := tr.manager.RefreshToken(
 		context.Background(),

--- a/internal/server/background/oauth_refresher.go
+++ b/internal/server/background/oauth_refresher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/ai/oauth"
+	oauthmodule "github.com/tingly-dev/tingly-box/internal/server/module/oauth"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -207,8 +208,8 @@ func (tr *OAuthRefresher) refreshProviderToken(provider *typ.Provider) {
 
 	refreshOpts := []oauth.Option{oauth.WithProxyString(provider.ProxyURL)}
 	if issuer == ai.IssuerKimiCode {
-		if v, ok := provider.OAuthDetail.ExtraFields[oauth.KimiDeviceIDMetadataKey].(string); ok && v != "" {
-			refreshOpts = append(refreshOpts, oauth.WithKimiDeviceID(v))
+		if id := oauthmodule.KimiDeviceIDFromExtraFields(provider.OAuthDetail.ExtraFields); id != "" {
+			refreshOpts = append(refreshOpts, oauthmodule.WithKimiDeviceID(id))
 		}
 	}
 	token, err := tr.manager.RefreshToken(

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -983,7 +983,9 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 			apiBase = protocol.CodexAPIBase
 			apiStyle = protocol.APIStyleOpenAI
 		case ai.IssuerKimiCode:
-			apiBase = "https://api.moonshot.cn/v1"
+			// Kimi OAuth tokens target kimi.com's coding API, not Moonshot.
+			// Reference: CLIProxyAPI internal/runtime/executor/kimi_executor.go.
+			apiBase = "https://api.kimi.com/coding/v1"
 			apiStyle = protocol.APIStyleOpenAI
 		default:
 			apiBase = "mock"

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -344,6 +344,17 @@ func (h *Handler) AuthorizeOAuth(c *gin.Context) {
 	}
 
 	deviceOpts := OAuthOptions(proxyURL, callbackBaseURL)
+
+	// Kimi binds a single X-Msh-Device-Id to every request of a flow and
+	// expects refresh / inference to keep using it. Generate it here so the
+	// device-authorize call, polling, and the eventual persisted credential
+	// all carry the same id.
+	var kimiDeviceID string
+	if issuer == ai.IssuerKimiCode {
+		kimiDeviceID = newKimiDeviceID()
+		deviceOpts = append(deviceOpts, WithKimiDeviceID(kimiDeviceID))
+	}
+
 	// Handle device code flow
 	if config.OAuthMethod == oauth.OAuthMethodDeviceCode || config.OAuthMethod == oauth.OAuthMethodDeviceCodePKCE {
 		deviceCodeData, err := h.oauthManager.InitiateDeviceCodeFlow(c.Request.Context(), userID, issuer, req.Redirect, req.Name, deviceOpts...)
@@ -356,7 +367,7 @@ func (h *Handler) AuthorizeOAuth(c *gin.Context) {
 		}
 
 		// Start polling for token in background
-		go h.pollForDeviceCodeToken(c.Request.Context(), deviceCodeData, issuer, req.Name, sessionID, proxyURL)
+		go h.pollForDeviceCodeToken(c.Request.Context(), deviceCodeData, issuer, req.Name, sessionID, proxyURL, kimiDeviceID)
 
 		// Return device code flow response
 		resp := OAuthAuthorizeResponse{
@@ -399,16 +410,29 @@ func (h *Handler) AuthorizeOAuth(c *gin.Context) {
 }
 
 // pollForDeviceCodeToken polls for token in background after device code flow initiation
-func (h *Handler) pollForDeviceCodeToken(ctx context.Context, deviceCodeData *oauth.DeviceCodeData, issuer ai.Issuer, customName, sessionID, proxyURL string) {
+func (h *Handler) pollForDeviceCodeToken(ctx context.Context, deviceCodeData *oauth.DeviceCodeData, issuer ai.Issuer, customName, sessionID, proxyURL, kimiDeviceID string) {
 	fmt.Printf("[OAuth] Starting device code polling for %s in background\n", issuer)
 	ctx, cancel := context.WithTimeout(context.Background(), oauth.DefaultSessionExpiry)
 	defer cancel()
 
-	token, err := h.oauthManager.PollForToken(ctx, deviceCodeData, nil, OAuthOptions(proxyURL, "")...)
+	pollOpts := OAuthOptions(proxyURL, "")
+	if kimiDeviceID != "" {
+		pollOpts = append(pollOpts, WithKimiDeviceID(kimiDeviceID))
+	}
+	token, err := h.oauthManager.PollForToken(ctx, deviceCodeData, nil, pollOpts...)
 	if err != nil {
 		fmt.Printf("[OAuth] Device code polling failed for %s: %v\n", issuer, err)
 		_ = h.oauthManager.UpdateSessionStatus(sessionID, oauth.SessionStatusFailed, "", err.Error())
 		return
+	}
+
+	// Stash the per-flow Kimi device id onto the token so the existing
+	// provider-creation path persists it into OAuthDetail.ExtraFields.
+	if kimiDeviceID != "" {
+		if token.Metadata == nil {
+			token.Metadata = make(map[string]any)
+		}
+		token.Metadata[oauth.KimiDeviceIDMetadataKey] = kimiDeviceID
 	}
 
 	fmt.Printf("[OAuth] Device code polling succeeded for %s, creating provider\n", issuer)
@@ -560,8 +584,8 @@ func (h *Handler) RefreshOAuthToken(c *gin.Context) {
 	// Refresh token
 	refreshOpts := []oauth.Option{oauth.WithProxyString(provider.ProxyURL)}
 	if issuer == ai.IssuerKimiCode {
-		if deviceID := kimiDeviceIDFromExtraFields(provider.OAuthDetail.ExtraFields); deviceID != "" {
-			refreshOpts = append(refreshOpts, oauth.WithKimiDeviceID(deviceID))
+		if deviceID := KimiDeviceIDFromExtraFields(provider.OAuthDetail.ExtraFields); deviceID != "" {
+			refreshOpts = append(refreshOpts, WithKimiDeviceID(deviceID))
 		}
 	}
 	token, err := h.oauthManager.RefreshToken(
@@ -1102,18 +1126,6 @@ func SafeTokenPreview(token string) string {
 		return token
 	}
 	return token[:20] + "..."
-}
-
-// kimiDeviceIDFromExtraFields safely extracts the per-provider Kimi device id
-// stored on OAuthDetail.ExtraFields. Returns "" when missing or malformed.
-func kimiDeviceIDFromExtraFields(extra map[string]interface{}) string {
-	if extra == nil {
-		return ""
-	}
-	if v, ok := extra[oauth.KimiDeviceIDMetadataKey].(string); ok {
-		return v
-	}
-	return ""
 }
 
 func OAuthOptions(proxyURL, baseURL string) []oauth.Option {

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -558,12 +558,18 @@ func (h *Handler) RefreshOAuthToken(c *gin.Context) {
 	}
 
 	// Refresh token
+	refreshOpts := []oauth.Option{oauth.WithProxyString(provider.ProxyURL)}
+	if issuer == ai.IssuerKimiCode {
+		if deviceID := kimiDeviceIDFromExtraFields(provider.OAuthDetail.ExtraFields); deviceID != "" {
+			refreshOpts = append(refreshOpts, oauth.WithKimiDeviceID(deviceID))
+		}
+	}
 	token, err := h.oauthManager.RefreshToken(
 		c.Request.Context(),
 		provider.OAuthDetail.UserID,
 		issuer,
 		provider.OAuthDetail.RefreshToken,
-		oauth.WithProxyString(provider.ProxyURL),
+		refreshOpts...,
 	)
 
 	if err != nil {
@@ -1096,6 +1102,18 @@ func SafeTokenPreview(token string) string {
 		return token
 	}
 	return token[:20] + "..."
+}
+
+// kimiDeviceIDFromExtraFields safely extracts the per-provider Kimi device id
+// stored on OAuthDetail.ExtraFields. Returns "" when missing or malformed.
+func kimiDeviceIDFromExtraFields(extra map[string]interface{}) string {
+	if extra == nil {
+		return ""
+	}
+	if v, ok := extra[oauth.KimiDeviceIDMetadataKey].(string); ok {
+		return v
+	}
+	return ""
 }
 
 func OAuthOptions(proxyURL, baseURL string) []oauth.Option {

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -426,13 +426,13 @@ func (h *Handler) pollForDeviceCodeToken(ctx context.Context, deviceCodeData *oa
 		return
 	}
 
-	// Stash the per-flow Kimi device id onto the token so the existing
-	// provider-creation path persists it into OAuthDetail.ExtraFields.
+	// Hand the per-flow device id to createProviderFromToken via the token's
+	// metadata bag; it'll be lifted onto the typed OAuthDetail.DeviceID field.
 	if kimiDeviceID != "" {
 		if token.Metadata == nil {
 			token.Metadata = make(map[string]any)
 		}
-		token.Metadata[oauth.KimiDeviceIDMetadataKey] = kimiDeviceID
+		token.Metadata[tokenMetadataDeviceID] = kimiDeviceID
 	}
 
 	fmt.Printf("[OAuth] Device code polling succeeded for %s, creating provider\n", issuer)
@@ -583,10 +583,8 @@ func (h *Handler) RefreshOAuthToken(c *gin.Context) {
 
 	// Refresh token
 	refreshOpts := []oauth.Option{oauth.WithProxyString(provider.ProxyURL)}
-	if issuer == ai.IssuerKimiCode {
-		if deviceID := KimiDeviceIDFromExtraFields(provider.OAuthDetail.ExtraFields); deviceID != "" {
-			refreshOpts = append(refreshOpts, WithKimiDeviceID(deviceID))
-		}
+	if issuer == ai.IssuerKimiCode && provider.OAuthDetail.DeviceID != "" {
+		refreshOpts = append(refreshOpts, WithKimiDeviceID(provider.OAuthDetail.DeviceID))
 	}
 	token, err := h.oauthManager.RefreshToken(
 		c.Request.Context(),
@@ -1050,10 +1048,19 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 		},
 	}
 
-	// Store account_id from token metadata for ChatGPT API
+	// Copy provider-specific metadata into the typed credential schema. Keys
+	// that map to first-class OAuthDetail fields (DeviceID, ...) are lifted
+	// out so the generic ExtraFields bag only carries truly opaque data.
 	if token.Metadata != nil {
 		for k, v := range token.Metadata {
-			provider.OAuthDetail.ExtraFields[k] = v
+			switch k {
+			case tokenMetadataDeviceID:
+				if s, ok := v.(string); ok {
+					provider.OAuthDetail.DeviceID = s
+				}
+			default:
+				provider.OAuthDetail.ExtraFields[k] = v
+			}
 		}
 	}
 

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -50,7 +50,7 @@ func (h *Handler) SetCallbackServerManager(csm CallbackServerManager) {
 
 // CreateProviderFromToken is exported for use by the server's root OAuth callback
 func (h *Handler) CreateProviderFromToken(token *oauth.Token, issuer ai.Issuer, customName, sessionID string) (string, error) {
-	return h.createProviderFromToken(token, issuer, customName, sessionID)
+	return h.createProviderFromToken(token, issuer, customName, sessionID, "")
 }
 
 // =============================================
@@ -345,13 +345,11 @@ func (h *Handler) AuthorizeOAuth(c *gin.Context) {
 
 	deviceOpts := OAuthOptions(proxyURL, callbackBaseURL)
 
-	// Kimi binds a single X-Msh-Device-Id to every request of a flow and
-	// expects refresh / inference to keep using it. Generate it here so the
-	// device-authorize call, polling, and the eventual persisted credential
-	// all carry the same id.
+	// Kimi binds one X-Msh-Device-Id to every request of a flow and to the
+	// persisted credential — refresh and inference must keep using it.
 	var kimiDeviceID string
 	if issuer == ai.IssuerKimiCode {
-		kimiDeviceID = newKimiDeviceID()
+		kimiDeviceID = uuid.New().String()
 		deviceOpts = append(deviceOpts, WithKimiDeviceID(kimiDeviceID))
 	}
 
@@ -426,17 +424,8 @@ func (h *Handler) pollForDeviceCodeToken(ctx context.Context, deviceCodeData *oa
 		return
 	}
 
-	// Hand the per-flow device id to createProviderFromToken via the token's
-	// metadata bag; it'll be lifted onto the typed OAuthDetail.DeviceID field.
-	if kimiDeviceID != "" {
-		if token.Metadata == nil {
-			token.Metadata = make(map[string]any)
-		}
-		token.Metadata[tokenMetadataDeviceID] = kimiDeviceID
-	}
-
 	fmt.Printf("[OAuth] Device code polling succeeded for %s, creating provider\n", issuer)
-	providerUUID, err := h.createProviderFromToken(token, issuer, customName, sessionID)
+	providerUUID, err := h.createProviderFromToken(token, issuer, customName, sessionID, kimiDeviceID)
 	if err != nil {
 		fmt.Printf("[OAuth] Failed to create provider for %s: %v\n", issuer, err)
 		_ = h.oauthManager.UpdateSessionStatus(sessionID, oauth.SessionStatusFailed, "", err.Error())
@@ -907,7 +896,7 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 
 	// Use createProviderFromToken to create the provider
 	// Pass session ID to retrieve proxy URL from the session
-	providerUUID, err := h.createProviderFromToken(token, token.Provider, "", token.SessionID)
+	providerUUID, err := h.createProviderFromToken(token, token.Provider, "", token.SessionID, "")
 	if err != nil {
 		log.Printf("[OAuth] Failed to create provider for token.SessionID %s: %v", token.SessionID, err)
 		_ = h.oauthManager.UpdateSessionStatus(token.SessionID, oauth.SessionStatusFailed, "", err.Error())
@@ -950,7 +939,7 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 // =============================================
 
 // createProviderFromToken creates a provider from OAuth token
-func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, customName, sessionID string) (string, error) {
+func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, customName, sessionID, deviceID string) (string, error) {
 	// Get custom name from token (stored in state during authorize)
 	if customName == "" {
 		customName = token.Name
@@ -1044,23 +1033,15 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 			UserID:       uuid.New().String(),
 			RefreshToken: token.RefreshToken,
 			ExpiresAt:    expiresAt,
+			DeviceID:     deviceID,
 			ExtraFields:  make(map[string]interface{}),
 		},
 	}
 
-	// Copy provider-specific metadata into the typed credential schema. Keys
-	// that map to first-class OAuthDetail fields (DeviceID, ...) are lifted
-	// out so the generic ExtraFields bag only carries truly opaque data.
+	// Store account_id from token metadata for ChatGPT API
 	if token.Metadata != nil {
 		for k, v := range token.Metadata {
-			switch k {
-			case tokenMetadataDeviceID:
-				if s, ok := v.(string); ok {
-					provider.OAuthDetail.DeviceID = s
-				}
-			default:
-				provider.OAuthDetail.ExtraFields[k] = v
-			}
+			provider.OAuthDetail.ExtraFields[k] = v
 		}
 	}
 

--- a/internal/server/module/oauth/kimi.go
+++ b/internal/server/module/oauth/kimi.go
@@ -1,31 +1,14 @@
 package oauth
 
-import (
-	"github.com/google/uuid"
-
-	"github.com/tingly-dev/tingly-box/ai/oauth"
-)
+import "github.com/tingly-dev/tingly-box/ai/oauth"
 
 // kimiDeviceIDHeader is the HTTP header Kimi's auth and inference endpoints
 // use to bind a credential to a specific device.
 const kimiDeviceIDHeader = "X-Msh-Device-Id"
 
-// tokenMetadataDeviceID is the temporary Token.Metadata key the handler uses
-// to hand the per-flow device id to createProviderFromToken, which lifts it
-// onto the typed OAuthDetail.DeviceID field. Not part of any persisted shape.
-const tokenMetadataDeviceID = "device_id"
-
-// newKimiDeviceID returns a fresh device id for a new Kimi OAuth flow.
-// Matches CLIProxyAPI's per-Auth instance generation, but our generated id
-// rides along with the credential in the DB rather than a kimi-cli file.
-func newKimiDeviceID() string {
-	return uuid.New().String()
-}
-
-// WithKimiDeviceID returns an oauth.Option that pins X-Msh-Device-Id on
-// every token-related request made through the OAuth manager during a flow.
-// Exported so the background refresher can rehydrate the same id on refresh
-// without duplicating the header name.
+// WithKimiDeviceID pins X-Msh-Device-Id on every token-related request the
+// OAuth manager makes during a flow. Exported so the background refresher
+// can rehydrate the same id on refresh.
 func WithKimiDeviceID(deviceID string) oauth.Option {
 	return oauth.WithExtraHeader(kimiDeviceIDHeader, deviceID)
 }

--- a/internal/server/module/oauth/kimi.go
+++ b/internal/server/module/oauth/kimi.go
@@ -10,6 +10,11 @@ import (
 // use to bind a credential to a specific device.
 const kimiDeviceIDHeader = "X-Msh-Device-Id"
 
+// tokenMetadataDeviceID is the temporary Token.Metadata key the handler uses
+// to hand the per-flow device id to createProviderFromToken, which lifts it
+// onto the typed OAuthDetail.DeviceID field. Not part of any persisted shape.
+const tokenMetadataDeviceID = "device_id"
+
 // newKimiDeviceID returns a fresh device id for a new Kimi OAuth flow.
 // Matches CLIProxyAPI's per-Auth instance generation, but our generated id
 // rides along with the credential in the DB rather than a kimi-cli file.
@@ -23,16 +28,4 @@ func newKimiDeviceID() string {
 // without duplicating the header name.
 func WithKimiDeviceID(deviceID string) oauth.Option {
 	return oauth.WithExtraHeader(kimiDeviceIDHeader, deviceID)
-}
-
-// KimiDeviceIDFromExtraFields safely extracts the persisted Kimi device id
-// from OAuthDetail.ExtraFields. Returns "" when missing or malformed.
-func KimiDeviceIDFromExtraFields(extra map[string]interface{}) string {
-	if extra == nil {
-		return ""
-	}
-	if v, ok := extra[oauth.KimiDeviceIDMetadataKey].(string); ok {
-		return v
-	}
-	return ""
 }

--- a/internal/server/module/oauth/kimi.go
+++ b/internal/server/module/oauth/kimi.go
@@ -1,0 +1,38 @@
+package oauth
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/tingly-dev/tingly-box/ai/oauth"
+)
+
+// kimiDeviceIDHeader is the HTTP header Kimi's auth and inference endpoints
+// use to bind a credential to a specific device.
+const kimiDeviceIDHeader = "X-Msh-Device-Id"
+
+// newKimiDeviceID returns a fresh device id for a new Kimi OAuth flow.
+// Matches CLIProxyAPI's per-Auth instance generation, but our generated id
+// rides along with the credential in the DB rather than a kimi-cli file.
+func newKimiDeviceID() string {
+	return uuid.New().String()
+}
+
+// WithKimiDeviceID returns an oauth.Option that pins X-Msh-Device-Id on
+// every token-related request made through the OAuth manager during a flow.
+// Exported so the background refresher can rehydrate the same id on refresh
+// without duplicating the header name.
+func WithKimiDeviceID(deviceID string) oauth.Option {
+	return oauth.WithExtraHeader(kimiDeviceIDHeader, deviceID)
+}
+
+// KimiDeviceIDFromExtraFields safely extracts the persisted Kimi device id
+// from OAuthDetail.ExtraFields. Returns "" when missing or malformed.
+func KimiDeviceIDFromExtraFields(extra map[string]interface{}) string {
+	if extra == nil {
+		return ""
+	}
+	if v, ok := extra[oauth.KimiDeviceIDMetadataKey].(string); ok {
+		return v
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
Implements complete Kimi OAuth device-code flow support with proper CLI client impersonation headers for both OAuth token acquisition and subsequent API calls to Kimi's coding API.

## Key Changes

### OAuth Flow Updates (`ai/oauth/`)
- **hook.go**: Updated `KimiHook` to use `cli-proxy-api` platform identifier instead of `mac`, removed OS version header, and added documentation references
- **provider.go**: Configured Kimi OAuth provider with device authorization flow (no client secret, no scope parameter), targeting `https://auth.kimi.com` endpoints
- **manager.go**: Made scope parameter optional in device code flow to support providers like Kimi that don't use scopes

### API Client Integration (`internal/client/`)
- **kimi_round_tripper.go** (new): Implements HTTP round tripper that layers Kimi CLI impersonation headers (`X-Msh-*` headers, User-Agent) on every API request, reusing the persistent device ID from OAuth flow
- **openai.go**: Integrated `kimiRoundTripper` for Kimi OAuth providers to ensure all inference requests include proper CLI identification headers

### API Endpoint Configuration (`internal/server/`)
- **handler.go**: Updated Kimi OAuth token handler to target `https://api.kimi.com/coding/v1` (Kimi's coding API) instead of Moonshot endpoint

### Device ID Management
- Exported `GetKimiDeviceID()` function to allow inference round trippers to reuse the same persistent device ID generated during OAuth flow
- Simplified `getKimiDeviceModel()` to use standardized `<GOOS> <GOARCH>` format (e.g., "macOS arm64")

### Frontend
- Disabled Kimi OAuth in UI (`OAuthDialog.tsx`) pending backend wiring completion

## Implementation Details
- Device ID persists to `~/.kimi/device_id` for consistency across OAuth and inference calls
- Kimi OAuth uses device authorization flow without client secret or scope parameters
- All Kimi API requests (both OAuth and inference) include consistent CLI impersonation headers matching `kimi-cli` v1.10.6
- Session-bound transport ensures each session maintains its own connection pool while emitting correct headers

https://claude.ai/code/session_01Ega9DWMxKZt6B43QL1giLX