### PR TITLE
feat(loadbalance): Add priority-based service routing with circuit breaker

### DIFF
--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -1,0 +1,205 @@
+# Priority-Based Service Routing
+
+Status: shipped (v1) on branch `claude/priority-service-routing-dIQfX`.
+Tracking commits: `a362ca3`, `5221109`.
+
+## Why
+
+Existing routing in tingly-box treats every service in a rule as an equal
+peer. `random`, `token_based`, `latency_based`, `speed_based`, `adaptive`,
+`capacity_based` — all of them spread load across services. That is the
+right default for "I have several equivalent providers, share the load".
+
+It is the wrong default for the other very common shape:
+
+> "Use account A. If A is broken, use account B. Once A is healthy
+> again, go back to A."
+
+People with two Anthropic accounts (one primary, one as backup), or a
+cheap-and-fast model with an expensive fallback, or any home-rolled
+"direct + fallback" setup, were stuck:
+
+- They could either include the backup in the pool (and have it pick up
+  random traffic), or
+- Mark it inactive and manually flip it on when the primary failed.
+
+Neither is acceptable. We need first-class **direct + fallback**.
+
+A second, related gap: when an upstream service starts failing, nothing
+in the box notices. Every request keeps trying the same broken service
+until the user disables it. We need a lightweight **circuit breaker** so
+the next request automatically uses the backup, and the next-after-next
+returns to the primary once it recovers.
+
+## What this is not
+
+- **Not** a cross-request load balancer rebalance — existing tactics stay
+  intact and remain the default.
+- **Not** a request-level retry loop. When a request fails mid-flight,
+  the client still sees the error. Failover happens on the **next**
+  request after the breaker trips. (Mid-request retry is parked as v2 —
+  see "Future work".)
+- **Not** a global health system. The breaker is process-local and rule-
+  scoped through the service-id key; we deliberately avoided Redis-level
+  shared state to keep the deployment story simple.
+
+## How
+
+### Two new concepts
+
+1. **`Service.Priority int`** — a per-service number inside a rule.
+   Higher = tried first. `0` is "unset" and sinks to the bottom.
+2. **`TacticPriority`** — a new `Tactic` value. When selected, the rule
+   ranks services by `Priority` and picks the highest tier whose circuit
+   breaker is closed.
+
+### Selection algorithm
+
+```
+SelectService(rule):
+  active = rule.GetActiveServices()
+  buckets = group services by Priority, sorted descending (0 last)
+  for each bucket (highest priority first):
+    candidates = services in bucket whose breaker allows a request
+    if candidates is non-empty:
+      return WithinTierTactic.pick(candidates)   # default: random
+  // every tier is tripped — fall back to the top bucket regardless
+  // so the upstream-error path can surface a real upstream error.
+  return WithinTierTactic.pick(top bucket)
+```
+
+Three properties fall out:
+
+- **Distinct priorities ⇒ pure failover.** Service at priority 10 is
+  used until it fails; service at priority 5 takes over; once the 10's
+  breaker closes, the next request snaps back to it.
+- **Tied priorities ⇒ load sharing within a tier.** Two services at
+  priority 10 share traffic via the sub-tactic (random by default).
+- **All tiers tripped ⇒ degrade, don't disappear.** Picking nothing
+  would let the caller bypass the real upstream error message; picking
+  the top tier guarantees the client sees the actual provider's 5xx /
+  rate-limit text.
+
+### Recovery
+
+The breaker is a three-state machine (`Closed → Open → HalfOpen`):
+
+- **Closed** — normal. `Allow()` returns true, failures are counted.
+- **Open** — too many consecutive failures (`FailureThreshold`, default
+  3). `Allow()` returns false. After `OpenDuration` (default 30 s) the
+  next `Allow()` call lazily flips to HalfOpen.
+- **HalfOpen** — exactly one probe is permitted. Success → Closed,
+  failure → Open with a fresh timer.
+
+Recovery requires **no separate scheduler**. Selection re-evaluates the
+priority list every request, and the breaker's lazy state transition
+admits one probe naturally. Active probing was considered and rejected
+for v1 — for hot rules it's redundant, and for cold rules there is no
+one to serve anyway.
+
+### Wiring failures to the breaker
+
+`ProtocolRecorder` already sees every success and failure of every
+upstream call. We added two lines:
+
+- `RecordResponse(provider, model)` → `RecordServiceSuccess(serviceID)`
+- `RecordError(err)` → `RecordServiceFailure(serviceID)`
+
+The `serviceID` is computed from `provider.UUID + ":" + model`, matching
+the format `Service.ServiceID()` produces, so the breaker registry's
+keys line up exactly with the selection pool. **Zero changes** to the
+dispatch hot path were required.
+
+### Frontend UX
+
+A clickable badge on the top-left corner of each provider node:
+
+- Shows the current priority (`1`, `2`, …, `–` when unset).
+- Click → small popover with a number input. Setting `0` clears.
+- The badge is sized to overlap the corner, matching the existing
+  badge convention used elsewhere (e.g. SmartOpNode index badges).
+- The provider list re-sorts descending by priority as the user edits.
+
+The design choice here is **implicit mode activation**: assigning any
+service a priority > 0 flips the rule's `lb_tactic` to `priority` on
+save. No separate tactic-selector UI is exposed. Clearing every priority
+back to 0 leaves the previous tactic intact (the auto-save now
+round-trips `lb_tactic`, which it didn't before).
+
+Why implicit: tactic concepts are jargon for most users. "Set priorities
+on services" is concrete and matches a real intent ("I want this one
+first"). The tactic switch is plumbing — it shouldn't be a separate
+question.
+
+## Value
+
+| Audience | Value delivered |
+|---|---|
+| Users with multiple equivalent accounts | First-class failover. Set priority 10 on the main, 5 on the backup, walk away. |
+| Users running cost-tiered providers | Same model with a cheap-then-expensive cascade. |
+| Operators of any production rule | Free circuit breaking. Even users on the existing tactics get failure isolation as soon as they assign a single priority. |
+| Anyone debugging | The recorder now reports per-service success/failure into the breaker, and the breaker state is exposed via `BreakerStore.Snapshot()` for future surfacing. |
+
+The feature is **additive**: rules without explicit priorities behave
+exactly as before; the new tactic is opt-in via the UI.
+
+## Comparison to claude-code-hub
+
+A separate project (`ding113/claude-code-hub`) ships similar capability;
+we deliberately did **not** clone its design.
+
+| Their design | Ours | Why we differ |
+|---|---|---|
+| Priority is global across the provider pool. | Priority is scoped to a rule's services. | Our rules already segment requests by model/scenario, so the rule is the natural priority boundary. Global priorities would conflict with our rule isolation. |
+| Numeric priority + cost multiplier + weighted random inside a tier. | Numeric priority + sub-tactic (default random). | Rules typically hold ≤ 5 services. A user-tunable sub-tactic gives flexibility without forcing a second config field on everybody. |
+| Per-user-group priority overrides. | Not implemented. | Users already express user-group-specific routing by having separate rules. Adding overrides would duplicate that mechanism. |
+| Redis-shared breaker state. | In-memory, process-local. | Single-instance is the dominant deployment shape. Redis can be added later with no model changes — `BreakerStore` is an interface boundary. |
+| Active probing scheduler for half-open. | Lazy half-open on next request. | Strictly simpler. Hot rules don't need it; cold rules don't matter. |
+| Mid-stream retry across providers using deferred finalization. | Not implemented in v1. | Touches every dispatch path; v2. |
+| 32 KiB "fake 200" body sniffing. | Not implemented. | Niche; revisit if we see real cases. |
+| Dispatch simulator UI. | Not implemented. | Excellent idea, separable feature, v2. |
+
+## Future work
+
+1. **Mid-request failover (v2)** — wrap `forwarding.Forward*` returns
+   with a "try next priority tier" loop, gated on error class:
+   - retryable: ECONNREFUSED, ETIMEDOUT, 429, 5xx
+   - not retryable: 4xx (non-429), content-filter, client disconnect
+2. **Streaming pre-first-delta failover (v3)** — detect that the
+   upstream stream has not yet emitted a real content event, and on
+   disconnect rewire to the next tier without writing anything to the
+   client.
+3. **Active half-open probing** — opt-in goroutine that probes Open
+   breakers on a cadence, useful for cold rules.
+4. **Per-rule breaker thresholds** — currently process-wide defaults.
+   Could be surfaced as a Rule-level config block.
+5. **Failover decision log + UI** — the recorder already sees every
+   success/failure attribution; we can surface "request X went to
+   service A → fell back to B" in the system log page.
+6. **Dispatch simulator** — read-only "explain plan" that shows which
+   service a hypothetical request would land on. Particularly useful
+   in combination with smart routing.
+
+## File map
+
+Backend
+- `internal/loadbalance/load_balancing.go` — `Service.Priority`,
+  `TacticPriority` enum.
+- `internal/loadbalance/breaker.go` — three-state breaker + store.
+- `internal/loadbalance/breaker_test.go`
+- `internal/typ/tactics.go` — `PriorityParams`, `PriorityTactic`,
+  `groupServicesByPriority`.
+- `internal/typ/priority_tactic_test.go`
+- `internal/server/protocol_recording.go` — recorder → breaker bridge.
+
+Frontend
+- `frontend/src/components/RoutingGraphTypes.ts` — `ConfigProvider.priority`, `ConfigRecord.lbTactic`.
+- `frontend/src/components/rule-card/utils.ts` — `pickLbTactic`,
+  `hasPriorityAssigned`.
+- `frontend/src/components/rule-card/useRuleCardHooks.ts` — autosave
+  round-trips `lb_tactic` and `priority`.
+- `frontend/src/components/RuleCard.tsx` — `handleProviderPriorityChange`.
+- `frontend/src/components/RoutingGraph.tsx` — priority-sorted list,
+  prop plumbing.
+- `frontend/src/components/nodes/ProviderNode.tsx` — `PriorityBadge`
+  component overlapping the top-left corner.

--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -97,6 +97,90 @@ admits one probe naturally. Active probing was considered and rejected
 for v1 — for hot rules it's redundant, and for cold rules there is no
 one to serve anyway.
 
+### End-to-end flow: how the tactic switch actually takes effect
+
+The "user clicks a number on a service node" event has to cross five
+layers before it changes how the next API request is routed. Each layer
+is wired explicitly:
+
+```
+┌─ Frontend ───────────────────────────────────────────────────────────┐
+│  PriorityBadge click → handleProviderPriorityChange                   │
+│       ↓                                                               │
+│  updateField('providers', updated)  ← service gets priority: 10       │
+│       ↓                                                               │
+│  autoSave → pickLbTactic(record)                                      │
+│             returns { type: 'priority',                               │
+│                       params: { within_tier_tactic: 'random' } }      │
+│             whenever any service has priority > 0                     │
+│       ↓                                                               │
+│  POST /api/v1/rule/:uuid  with body containing lb_tactic              │
+└──────────────────────────────────────────────────────────────────────┘
+                                  ↓
+┌─ Backend deserialize ────────────────────────────────────────────────┐
+│  rule/handler.go: ShouldBindJSON(&rule)                               │
+│       ↓                                                               │
+│  typ.Tactic.UnmarshalJSON (tactics.go):                               │
+│    – TacticType.UnmarshalJSON parses "priority" → TacticPriority      │
+│    – switch on tc.Type allocates tc.Params = &PriorityParams{}        │
+│    – aux.Params (raw bytes) unmarshalled into the PriorityParams     │
+│       ↓                                                               │
+│  config.UpdateRule(uid, rule)  → persisted to SQLite                  │
+└──────────────────────────────────────────────────────────────────────┘
+                                  ↓
+┌─ Backend runtime: every LLM request ─────────────────────────────────┐
+│  anthropic.go / openai.go / openai_responses.go / ... :               │
+│       routingSelector.SelectService(c, scenario, rule, req)           │
+│       ↓                                                               │
+│  routing.SimpleSelector → ServiceSelector pipeline →                  │
+│       LoadBalancerStage.Evaluate  (or SmartRoutingStage when matched) │
+│       ↓                                                               │
+│  Both stages call:                                                    │
+│       lb.SelectService(&tempRule)        (load_balancer.go:55)        │
+│       ↓                                                               │
+│  load_balancer.go:92                                                  │
+│       actualTactic := rule.LBTactic.Instantiate()                     │
+│       ↓                                                               │
+│  typ.Tactic.Instantiate → CreateTacticWithTypedParams(type, params)   │
+│       case TacticPriority → NewPriorityTactic(pp.WithinTierTactic)    │
+│       ↓                                                               │
+│  load_balancer.go:111                                                 │
+│       actualTactic.SelectService(tempRule)                            │
+│       ↓                                                               │
+│  PriorityTactic.SelectService:                                        │
+│    – groupServicesByPriority(active) — descending, 0 last             │
+│    – for each bucket: collect svc where DefaultBreakerStore.Allow()   │
+│    – first non-empty bucket → pickWithinTier(sub-tactic)              │
+└──────────────────────────────────────────────────────────────────────┘
+                                  ↓
+┌─ Per-request feedback into the breaker ──────────────────────────────┐
+│  Dispatch finishes → ProtocolRecorder:                                │
+│       RecordResponse → loadbalance.RecordServiceSuccess(serviceID)    │
+│       RecordError    → loadbalance.RecordServiceFailure(serviceID)    │
+│  Same DefaultBreakerStore the selection logic consulted, so the next  │
+│  request's PriorityTactic sees the updated state.                     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The single transformation point that turns the JSON payload into live
+runtime behaviour is `Tactic.Instantiate()` at
+`internal/server/load_balancer.go:92`. Every dispatch path — Anthropic
+v1/Beta, OpenAI Chat/Responses/Embeddings/Images, Google, smart routing
+matches — funnels through `LoadBalancer.SelectService`, so the tactic
+switch is enforced uniformly with no per-protocol changes required.
+
+This is pinned down by `TestPriorityRouting_EndToEnd` in
+`internal/server/priority_routing_e2e_test.go`, which:
+
+1. Unmarshals a Rule JSON with `lb_tactic.type = "priority"`,
+2. Asserts `LBTactic.Params` is a `*PriorityParams` after decode,
+3. Calls `LoadBalancer.SelectService` and asserts the high-priority
+   service is picked,
+4. Trips the breaker via `DefaultBreakerStore.RecordFailure` exactly
+   as the recorder does,
+5. Asserts the next pick falls back,
+6. Records a success and asserts the pick returns to the primary.
+
 ### Wiring failures to the breaker
 
 `ProtocolRecorder` already sees every success and failure of every

--- a/frontend/src/components/RoutingGraph.tsx
+++ b/frontend/src/components/RoutingGraph.tsx
@@ -86,7 +86,7 @@ interface RuleGraphProps {
     recordUuid: string;
     onUpdateRecord: (field: keyof ConfigRecord, value: any) => void;
     onDeleteProvider: (recordId: string, providerId: string) => void;
-    onProviderOrderChange?: (providerUuid: string, order: number) => void;
+    onProviderPriorityChange?: (providerUuid: string, priority: number) => void;
     onToggleExpanded: () => void;
     onProviderNodeClick: (providerUuid: string) => void;
     onAddProviderButtonClick: () => void;
@@ -171,7 +171,7 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
     recordUuid,
     onUpdateRecord,
     onDeleteProvider,
-    onProviderOrderChange,
+    onProviderPriorityChange,
     onToggleExpanded,
     onProviderNodeClick,
     onAddProviderButtonClick,
@@ -185,21 +185,22 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
     // Routing mode switch
     onSwitchRoutingMode,
 }) => {
-    // When users explicitly set priority orders on services we render the
-    // default-providers list sorted by Order (ascending) so the visual
-    // sequence matches the runtime fallback sequence. Without explicit
-    // orders we preserve the array order from the rule.
+    // When users explicitly set priorities on services we render the
+    // default-providers list sorted by Priority (descending — higher
+    // first) so the visual sequence matches the runtime fallback
+    // sequence. Without explicit priorities we preserve the array order
+    // from the rule.
     const sortedDefaultProviders = React.useMemo(() => {
         const list = record.providers;
-        const hasAnyOrder = list.some((p) => (p.order ?? 0) > 0);
-        if (!hasAnyOrder) return list;
+        const hasAnyPriority = list.some((p) => (p.priority ?? 0) > 0);
+        if (!hasAnyPriority) return list;
         return [...list].sort((a, b) => {
-            const ao = a.order ?? 0;
-            const bo = b.order ?? 0;
-            // 0 sinks to the bottom so explicitly-ordered services appear first.
-            if (ao === 0 && bo !== 0) return 1;
-            if (bo === 0 && ao !== 0) return -1;
-            return ao - bo;
+            const ap = a.priority ?? 0;
+            const bp = b.priority ?? 0;
+            // 0 sinks to the bottom so explicitly-prioritised services appear first.
+            if (ap === 0 && bp !== 0) return 1;
+            if (bp === 0 && ap !== 0) return -1;
+            return bp - ap;
         });
     }, [record.providers]);
     // When collapsible, parent controls expanded state (defaults to false when collapsible=true)
@@ -568,8 +569,8 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                                                     title={
                                                         smartEnabled && hasSmartRules
                                                             ? 'Default provider (default when no smart rules match)'
-                                                            : (provider.order ?? 0) > 0
-                                                                ? `Priority ${provider.order} — used in order ${provider.order} (lower = tried first)`
+                                                            : (provider.priority ?? 0) > 0
+                                                                ? `Priority ${provider.priority} (higher = tried first)`
                                                                 : record.providers.length >= 2
                                                                     ? `Provider ${index + 1} of ${record.providers.length} (requests are load balanced)`
                                                                     : 'Provider for request forwarding'
@@ -585,9 +586,9 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                                                             active={record.active && provider.active !== false}
                                                             onDelete={() => onDeleteProvider(recordUuid, provider.uuid)}
                                                             onNodeClick={() => onProviderNodeClick(provider.uuid)}
-                                                            onOrderChange={
-                                                                onProviderOrderChange
-                                                                    ? (order) => onProviderOrderChange(provider.uuid, order)
+                                                            onPriorityChange={
+                                                                onProviderPriorityChange
+                                                                    ? (priority) => onProviderPriorityChange(provider.uuid, priority)
                                                                     : undefined
                                                             }
                                                         />

--- a/frontend/src/components/RoutingGraph.tsx
+++ b/frontend/src/components/RoutingGraph.tsx
@@ -86,6 +86,7 @@ interface RuleGraphProps {
     recordUuid: string;
     onUpdateRecord: (field: keyof ConfigRecord, value: any) => void;
     onDeleteProvider: (recordId: string, providerId: string) => void;
+    onProviderOrderChange?: (providerUuid: string, order: number) => void;
     onToggleExpanded: () => void;
     onProviderNodeClick: (providerUuid: string) => void;
     onAddProviderButtonClick: () => void;
@@ -170,6 +171,7 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
     recordUuid,
     onUpdateRecord,
     onDeleteProvider,
+    onProviderOrderChange,
     onToggleExpanded,
     onProviderNodeClick,
     onAddProviderButtonClick,
@@ -183,6 +185,23 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
     // Routing mode switch
     onSwitchRoutingMode,
 }) => {
+    // When users explicitly set priority orders on services we render the
+    // default-providers list sorted by Order (ascending) so the visual
+    // sequence matches the runtime fallback sequence. Without explicit
+    // orders we preserve the array order from the rule.
+    const sortedDefaultProviders = React.useMemo(() => {
+        const list = record.providers;
+        const hasAnyOrder = list.some((p) => (p.order ?? 0) > 0);
+        if (!hasAnyOrder) return list;
+        return [...list].sort((a, b) => {
+            const ao = a.order ?? 0;
+            const bo = b.order ?? 0;
+            // 0 sinks to the bottom so explicitly-ordered services appear first.
+            if (ao === 0 && bo !== 0) return 1;
+            if (bo === 0 && ao !== 0) return -1;
+            return ao - bo;
+        });
+    }, [record.providers]);
     // When collapsible, parent controls expanded state (defaults to false when collapsible=true)
     // When not collapsible, always show expanded
     const isExpanded = !collapsible || expanded;
@@ -543,15 +562,17 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                                     {/* Providers Container - Default providers for normal mode or default for smart routing */}
                                     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                                         <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'nowrap', justifyContent: 'flex-start', alignItems: 'center' }}>
-                                            {record.providers.map((provider, index) => (
+                                            {sortedDefaultProviders.map((provider, index) => (
                                                 <Tooltip
                                                     key={provider.uuid}
                                                     title={
                                                         smartEnabled && hasSmartRules
                                                             ? 'Default provider (default when no smart rules match)'
-                                                            : record.providers.length >= 2
-                                                                ? `Provider ${index + 1} of ${record.providers.length} (requests are load balanced)`
-                                                                : 'Provider for request forwarding'
+                                                            : (provider.order ?? 0) > 0
+                                                                ? `Priority ${provider.order} — used in order ${provider.order} (lower = tried first)`
+                                                                : record.providers.length >= 2
+                                                                    ? `Provider ${index + 1} of ${record.providers.length} (requests are load balanced)`
+                                                                    : 'Provider for request forwarding'
                                                     }
                                                     placement="top"
                                                     arrow
@@ -564,6 +585,11 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                                                             active={record.active && provider.active !== false}
                                                             onDelete={() => onDeleteProvider(recordUuid, provider.uuid)}
                                                             onNodeClick={() => onProviderNodeClick(provider.uuid)}
+                                                            onOrderChange={
+                                                                onProviderOrderChange
+                                                                    ? (order) => onProviderOrderChange(provider.uuid, order)
+                                                                    : undefined
+                                                            }
                                                         />
                                                     </Box>
                                                 </Tooltip>

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -10,10 +10,10 @@ export interface ConfigProvider {
     weight?: number;
     active?: boolean;
     time_window?: number;
-    // Priority order within a rule. Lower = higher priority; 0 / undefined
-    // = unset, treated as same tier. Setting this on any service flips the
-    // rule's load-balancing tactic to "priority" (direct + fallback).
-    order?: number;
+    // Priority within a rule. Higher = tried first; 0 / undefined =
+    // unset, sinks to the bottom tier. Setting this on any service flips
+    // the rule's load-balancing tactic to "priority" (direct + fallback).
+    priority?: number;
 }
 
 export interface SmartOp {
@@ -75,7 +75,7 @@ export interface Rule {
         weight?: number;
         active?: boolean;
         time_window?: number;
-        order?: number;
+        priority?: number;
     }>;
     // Smart routing fields
     smart_enabled?: boolean;

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -10,6 +10,10 @@ export interface ConfigProvider {
     weight?: number;
     active?: boolean;
     time_window?: number;
+    // Priority order within a rule. Lower = higher priority; 0 / undefined
+    // = unset, treated as same tier. Setting this on any service flips the
+    // rule's load-balancing tactic to "priority" (direct + fallback).
+    order?: number;
 }
 
 export interface SmartOp {
@@ -42,6 +46,9 @@ export interface ConfigRecord {
     // Smart routing fields
     smartEnabled?: boolean;
     smartRouting?: SmartRouting[];
+    // Current load-balancing tactic name. Round-tripped so the priority
+    // tactic flips on automatically once a user assigns service order.
+    lbTactic?: string;
 }
 
 export interface RuleFlags {
@@ -68,8 +75,13 @@ export interface Rule {
         weight?: number;
         active?: boolean;
         time_window?: number;
+        order?: number;
     }>;
     // Smart routing fields
     smart_enabled?: boolean;
     smart_routing?: SmartRouting[];
+    lb_tactic?: {
+        type?: string;
+        params?: Record<string, unknown>;
+    };
 }

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -126,15 +126,16 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         }
     }, [configRecord, rule.uuid, onModelSelectOpen]);
 
-    // Handler: Update a service's priority order. Setting any service's
-    // order to > 0 flips the rule into "priority" tactic on save (handled
-    // in pickLbTactic), so users get direct/fallback routing just by
-    // clicking a number badge — no separate tactic selector to learn.
-    const handleProviderOrderChange = useCallback(
-        async (providerUuid: string, order: number) => {
+    // Handler: Update a service's priority. Setting any service's
+    // priority to > 0 flips the rule into "priority" tactic on save
+    // (handled in pickLbTactic), so users get direct/fallback routing
+    // just by clicking a number badge — no separate tactic selector to
+    // learn. Higher number = higher priority = tried first.
+    const handleProviderPriorityChange = useCallback(
+        async (providerUuid: string, priority: number) => {
             if (!configRecord) return;
             const updated = configRecord.providers.map((p) =>
-                p.uuid === providerUuid ? { ...p, order } : p,
+                p.uuid === providerUuid ? { ...p, priority } : p,
             );
             await updateField(configRecord, setConfigRecord, 'providers', updated);
         },
@@ -274,7 +275,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                     allowToggleRule={allowToggleRule}
                     onUpdateRecord={(field, value) => updateField(configRecord, setConfigRecord, field, value)}
                     onDeleteProvider={handleDeleteProvider}
-                    onProviderOrderChange={handleProviderOrderChange}
+                    onProviderPriorityChange={handleProviderPriorityChange}
                     onToggleExpanded={handleToggleExpanded}
                     onProviderNodeClick={handleProviderNodeClick}
                     onAddProviderButtonClick={handleAddProviderButtonClick}

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -262,6 +262,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                     onAddDefaultProvider={handleAddProviderButtonClick}
                     onDeleteDefaultProvider={smartHandlers.handleDeleteDefaultProvider}
                     onProviderNodeClick={handleProviderNodeClick}
+                    onProviderPriorityChange={handleProviderPriorityChange}
                     onSwitchRoutingMode={handleRoutingModeSwitch}
                 />
             ) : (

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -126,6 +126,21 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         }
     }, [configRecord, rule.uuid, onModelSelectOpen]);
 
+    // Handler: Update a service's priority order. Setting any service's
+    // order to > 0 flips the rule into "priority" tactic on save (handled
+    // in pickLbTactic), so users get direct/fallback routing just by
+    // clicking a number badge — no separate tactic selector to learn.
+    const handleProviderOrderChange = useCallback(
+        async (providerUuid: string, order: number) => {
+            if (!configRecord) return;
+            const updated = configRecord.providers.map((p) =>
+                p.uuid === providerUuid ? { ...p, order } : p,
+            );
+            await updateField(configRecord, setConfigRecord, 'providers', updated);
+        },
+        [configRecord, updateField, setConfigRecord]
+    );
+
     // Adapter: Convert ruleUuid to ruleIndex for smart routing handlers
     const handleAddServiceToSmartRuleByUuid = useCallback(
         (ruleUuid: string) => {
@@ -259,6 +274,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                     allowToggleRule={allowToggleRule}
                     onUpdateRecord={(field, value) => updateField(configRecord, setConfigRecord, field, value)}
                     onDeleteProvider={handleDeleteProvider}
+                    onProviderOrderChange={handleProviderOrderChange}
                     onToggleExpanded={handleToggleExpanded}
                     onProviderNodeClick={handleProviderNodeClick}
                     onAddProviderButtonClick={handleAddProviderButtonClick}

--- a/frontend/src/components/SmartRoutingGraph.tsx
+++ b/frontend/src/components/SmartRoutingGraph.tsx
@@ -78,6 +78,11 @@ interface SmartRoutingGraphProps {
     onAddDefaultProvider?: () => void;
     onDeleteDefaultProvider?: (providerUuid: string) => void;
     onProviderNodeClick?: (providerUuid: string) => void;
+    // Per-service priority edit on the default-providers row. Smart mode's
+    // default providers behave identically to normal-mode services (same
+    // Rule.Services list, same load-balancing tactic), so the same
+    // priority UI applies.
+    onProviderPriorityChange?: (providerUuid: string, priority: number) => void;
     // Additional props matching RoutingGraph
     saving?: boolean;
     collapsible?: boolean;
@@ -161,6 +166,7 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                                                  onAddDefaultProvider,
                                                                  onDeleteDefaultProvider,
                                                                  onProviderNodeClick,
+                                                                 onProviderPriorityChange,
                                                                  saving = false,
                                                                  collapsible = false,
                                                                  expanded = true,
@@ -176,6 +182,21 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
         const provider = providers.find(p => p.uuid === providerUuid);
         return provider?.api_style || 'openai';
     };
+
+    // Same priority-sort the normal RoutingGraph applies, so the visual
+    // sequence of default providers matches the runtime failover order.
+    const sortedDefaultProviders = React.useMemo(() => {
+        const list = record.providers;
+        const hasAnyPriority = list.some((p) => (p.priority ?? 0) > 0);
+        if (!hasAnyPriority) return list;
+        return [...list].sort((a, b) => {
+            const ap = a.priority ?? 0;
+            const bp = b.priority ?? 0;
+            if (ap === 0 && bp !== 0) return 1;
+            if (bp === 0 && ap !== 0) return -1;
+            return bp - ap;
+        });
+    }, [record.providers]);
 
     return (
         <StyledCard active={active}>
@@ -458,13 +479,15 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                                 justifyContent: 'flex-start',
                                                 alignItems: 'center'
                                             }}>
-                                                {record.providers.map((provider, providerIndex) => (
+                                                {sortedDefaultProviders.map((provider, providerIndex) => (
                                                     <Tooltip
                                                         key={provider.uuid}
                                                         title={
-                                                            record.providers.length >= 2
-                                                                ? `Default provider ${providerIndex + 1} of ${record.providers.length} (requests are load balanced)`
-                                                                : 'Default provider for request forwarding'
+                                                            (provider.priority ?? 0) > 0
+                                                                ? `Priority ${provider.priority} (higher = tried first)`
+                                                                : record.providers.length >= 2
+                                                                    ? `Default provider ${providerIndex + 1} of ${record.providers.length} (requests are load balanced)`
+                                                                    : 'Default provider for request forwarding'
                                                         }
                                                         placement="top"
                                                         arrow
@@ -479,6 +502,11 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                                                     onDeleteDefaultProvider?.(provider.uuid);
                                                                 }}
                                                                 onNodeClick={() => onProviderNodeClick?.(provider.uuid)}
+                                                                onPriorityChange={
+                                                                    onProviderPriorityChange
+                                                                        ? (priority) => onProviderPriorityChange(provider.uuid, priority)
+                                                                        : undefined
+                                                                }
                                                             />
                                                         </Box>
                                                     </Tooltip>

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -76,11 +76,8 @@ export interface ProviderNodeComponentProps {
 // non-Tooltip wrapper keeps the visible disk and the hit region in sync.
 const PriorityBadgeAnchor = styled(Box)({
     position: 'absolute',
-    // Pulled out of the corner — about 60% of the disk sits outside the
-    // node, 40% inside. The disk's centre lands inside the node so
-    // clicks land on the badge, not in the gap between siblings.
-    top: -8,
-    left: -8,
+    top: -10,
+    left: -10,
     width: 26,
     height: 26,
     zIndex: 3,

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -77,9 +77,12 @@ const PriorityBadgeButton = styled(Button, {
     shouldForwardProp: (prop) => prop !== 'hasPriority',
 })<{ hasPriority: boolean }>(({ theme, hasPriority }) => ({
     position: 'absolute',
-    top: 4,
-    left: 4,
-    transform: 'translate(-30%, -30%)',
+    // Sit clearly outside the corner so the badge reads as "attached"
+    // visually, while the centre of the hit-box (~width/2 + top) stays
+    // inside the node so clicks always land on this element rather than
+    // bleeding into the gap between siblings.
+    top: -8,
+    left: -8,
     minWidth: 0,
     width: 26,
     height: 26,

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -65,55 +65,67 @@ export interface ProviderNodeComponentProps {
 }
 
 // Clickable priority badge anchored to the top-left corner of the node.
-// The button sits *inside* the node so the click target is always on
-// the node (the badge floating into the gap between siblings would let
-// adjacent nodes swallow the click). A small CSS translate shifts the
-// visual position outward so it still reads as "attached to the corner".
 //
-// Styling is driven by a `hasPriority` prop on the styled element rather
-// than MUI's `variant` / `color` props, because contained-button defaults
-// otherwise win over sx and force a primary background.
-const PriorityBadgeButton = styled(Button, {
-    shouldForwardProp: (prop) => prop !== 'hasPriority',
-})<{ hasPriority: boolean }>(({ theme, hasPriority }) => ({
+// Implementation note: this mirrors the existing SmartOpNode index badge
+// — a styled `Box` rather than a `Button`. When a `Button` is wrapped in
+// `Tooltip`, MUI injects a `<span>` anchor that sizes to the rendered
+// flow of its child; an absolutely-positioned button has zero flow size,
+// so the span's hit region collapses and the visually-overflowing
+// portion of the badge becomes unresponsive to hover/click. Using a
+// `Box` with its own onClick and putting the `position: absolute` on a
+// non-Tooltip wrapper keeps the visible disk and the hit region in sync.
+const PriorityBadgeAnchor = styled(Box)({
     position: 'absolute',
-    // Sit clearly outside the corner so the badge reads as "attached"
-    // visually, while the centre of the hit-box (~width/2 + top) stays
-    // inside the node so clicks always land on this element rather than
-    // bleeding into the gap between siblings.
+    // Pulled out of the corner — about 60% of the disk sits outside the
+    // node, 40% inside. The disk's centre lands inside the node so
+    // clicks land on the badge, not in the gap between siblings.
     top: -8,
     left: -8,
-    minWidth: 0,
     width: 26,
     height: 26,
-    padding: 0,
+    zIndex: 3,
+    pointerEvents: 'auto',
+});
+
+const PriorityBadgeDisk = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'hasPriority' && prop !== 'active',
+})<{ hasPriority: boolean; active: boolean }>(({ theme, hasPriority, active }) => ({
+    width: '100%',
+    height: '100%',
     borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     fontSize: '0.8rem',
     fontWeight: 700,
     lineHeight: 1,
-    boxShadow: theme.shadows[2],
-    zIndex: 3,
-    pointerEvents: 'auto',
     border: '1px solid',
+    boxShadow: theme.shadows[2],
+    userSelect: 'none',
+    cursor: active ? 'pointer' : 'not-allowed',
+    transition: 'background-color 0.15s, border-color 0.15s, color 0.15s',
     ...(hasPriority
         ? {
               backgroundColor: theme.palette.primary.main,
               color: theme.palette.primary.contrastText,
               borderColor: theme.palette.primary.main,
-              '&:hover': {
-                  backgroundColor: theme.palette.primary.dark,
-                  borderColor: theme.palette.primary.dark,
-              },
+              '&:hover': active
+                  ? {
+                        backgroundColor: theme.palette.primary.dark,
+                        borderColor: theme.palette.primary.dark,
+                    }
+                  : {},
           }
         : {
               backgroundColor: theme.palette.background.paper,
               color: theme.palette.text.secondary,
               borderColor: theme.palette.divider,
-              '&:hover': {
-                  backgroundColor: theme.palette.background.paper,
-                  borderColor: theme.palette.primary.main,
-                  color: theme.palette.primary.main,
-              },
+              '&:hover': active
+                  ? {
+                        borderColor: theme.palette.primary.main,
+                        color: theme.palette.primary.main,
+                    }
+                  : {},
           }),
 }));
 
@@ -150,18 +162,17 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
 
     return (
         <>
-            <Tooltip title={tooltip} arrow placement="top">
-                <span>
-                    <PriorityBadgeButton
+            <PriorityBadgeAnchor>
+                <Tooltip title={tooltip} arrow placement="top">
+                    <PriorityBadgeDisk
                         hasPriority={priority > 0}
-                        size="small"
-                        onClick={open}
-                        disabled={!active}
+                        active={active}
+                        onClick={active ? open : undefined}
                     >
                         {label}
-                    </PriorityBadgeButton>
-                </span>
-            </Tooltip>
+                    </PriorityBadgeDisk>
+                </Tooltip>
+            </PriorityBadgeAnchor>
             <Popover
                 open={Boolean(anchor)}
                 anchorEl={anchor}

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -6,10 +6,14 @@ import {
 } from '@mui/icons-material';
 import {
     Box,
+    Button,
     Divider,
     IconButton,
+    Popover,
+    Stack,
+    TextField,
     Tooltip,
-    Typography
+    Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React, { useState } from 'react';
@@ -56,7 +60,113 @@ export interface ProviderNodeComponentProps {
     active: boolean;
     onDelete: () => void;
     onNodeClick: () => void;
+    /** Called when the user edits this service's priority order. Omit to hide the badge. */
+    onOrderChange?: (order: number) => void;
 }
+
+// Small clickable badge in the top-left of the node showing the service's
+// priority order. Click → small popover with a number input. Setting 0
+// clears the priority (the rule falls back to its default tactic when no
+// service has an explicit order).
+const OrderBadgeButton = styled(Button)({
+    position: 'absolute',
+    top: 4,
+    left: 4,
+    minWidth: 0,
+    width: 24,
+    height: 24,
+    padding: 0,
+    borderRadius: '50%',
+    fontSize: '0.75rem',
+    fontWeight: 700,
+    lineHeight: 1,
+    zIndex: 2,
+});
+
+interface OrderBadgeProps {
+    order: number;
+    onChange: (order: number) => void;
+    active: boolean;
+}
+
+const OrderBadge: React.FC<OrderBadgeProps> = ({ order, onChange, active }) => {
+    const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+    const [draft, setDraft] = useState<string>(String(order || ''));
+
+    const open = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+        setDraft(String(order || ''));
+        setAnchor(e.currentTarget);
+    };
+    const close = () => setAnchor(null);
+
+    const commit = () => {
+        const parsed = parseInt(draft, 10);
+        const next = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+        if (next !== order) {
+            onChange(next);
+        }
+        close();
+    };
+
+    const label = order > 0 ? String(order) : '–';
+    const tooltip = order > 0
+        ? `Priority order ${order} (lower = tried first). Click to change.`
+        : 'No priority set. Click to assign an order (1 = primary, 2 = fallback, …).';
+
+    return (
+        <>
+            <Tooltip title={tooltip} arrow placement="top">
+                <span>
+                    <OrderBadgeButton
+                        variant={order > 0 ? 'contained' : 'outlined'}
+                        color={order > 0 ? 'primary' : 'inherit'}
+                        size="small"
+                        onClick={open}
+                        disabled={!active}
+                    >
+                        {label}
+                    </OrderBadgeButton>
+                </span>
+            </Tooltip>
+            <Popover
+                open={Boolean(anchor)}
+                anchorEl={anchor}
+                onClose={close}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <Box sx={{ p: 1.5, width: 220 }}>
+                    <Typography variant="caption" color="text.secondary">
+                        Priority order
+                    </Typography>
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
+                        <TextField
+                            type="number"
+                            size="small"
+                            value={draft}
+                            onChange={(e) => setDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') commit();
+                                if (e.key === 'Escape') close();
+                            }}
+                            inputProps={{ min: 0, step: 1 }}
+                            autoFocus
+                            fullWidth
+                            placeholder="0 = unset"
+                        />
+                        <Button size="small" variant="contained" onClick={commit}>
+                            Set
+                        </Button>
+                    </Stack>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
+                        Lower number runs first. Same number = parallel tier.
+                    </Typography>
+                </Box>
+            </Popover>
+        </>
+    );
+};
 
 // Provider Node Component for Graph View
 export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
@@ -65,7 +175,8 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
     providersData,
     active,
     onDelete,
-    onNodeClick
+    onNodeClick,
+    onOrderChange,
 }) => {
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const [probeAnchorEl, setProbeAnchorEl] = useState<null | HTMLElement>(null);
@@ -122,6 +233,13 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
             )}
 
             <ProviderNodeContainer onClick={onNodeClick} sx={{ cursor: active ? 'pointer' : 'default', display: 'flex', flexDirection: 'column' }}>
+                {onOrderChange && (
+                    <OrderBadge
+                        order={provider.order ?? 0}
+                        onChange={onOrderChange}
+                        active={active}
+                    />
+                )}
                 {/* Top Layer - Provider/Model Field */}
                 <Box sx={NODE_LAYER_STYLES.topLayer}>
                     <Tooltip title={

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -127,11 +127,26 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
             <Tooltip title={tooltip} arrow placement="top">
                 <span>
                     <PriorityBadgeButton
-                        variant={priority > 0 ? 'contained' : 'outlined'}
+                        variant="contained"
+                        // Unset state still needs an opaque background so the
+                        // badge visually covers the node corner underneath
+                        // (the outlined variant was transparent and let the
+                        // node bleed through, reading as "穿透").
                         color={priority > 0 ? 'primary' : 'inherit'}
                         size="small"
                         onClick={open}
                         disabled={!active}
+                        sx={priority > 0 ? undefined : {
+                            backgroundColor: 'background.paper',
+                            color: 'text.secondary',
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            '&:hover': {
+                                backgroundColor: 'background.paper',
+                                borderColor: 'primary.main',
+                                color: 'primary.main',
+                            },
+                        }}
                     >
                         {label}
                     </PriorityBadgeButton>

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -60,42 +60,44 @@ export interface ProviderNodeComponentProps {
     active: boolean;
     onDelete: () => void;
     onNodeClick: () => void;
-    /** Called when the user edits this service's priority order. Omit to hide the badge. */
-    onOrderChange?: (order: number) => void;
+    /** Called when the user edits this service's priority. Omit to hide the badge. */
+    onPriorityChange?: (priority: number) => void;
 }
 
-// Small clickable badge in the top-left of the node showing the service's
-// priority order. Click → small popover with a number input. Setting 0
-// clears the priority (the rule falls back to its default tactic when no
-// service has an explicit order).
-const OrderBadgeButton = styled(Button)({
+// Clickable priority badge that overlaps the top-left corner of the
+// node, matching the existing badge convention elsewhere in the app
+// (e.g. SmartOpNode's index badge). Click → small popover with a number
+// input. Setting 0 clears the priority (the rule falls back to its
+// default tactic when no service has an explicit priority).
+const PriorityBadgeButton = styled(Button)(({ theme }) => ({
     position: 'absolute',
-    top: 4,
-    left: 4,
+    top: -10,
+    left: -10,
     minWidth: 0,
-    width: 24,
-    height: 24,
+    width: 26,
+    height: 26,
     padding: 0,
     borderRadius: '50%',
-    fontSize: '0.75rem',
+    fontSize: '0.8rem',
     fontWeight: 700,
     lineHeight: 1,
-    zIndex: 2,
-});
+    boxShadow: theme.shadows[2],
+    zIndex: 3,
+}));
 
-interface OrderBadgeProps {
-    order: number;
-    onChange: (order: number) => void;
+interface PriorityBadgeProps {
+    priority: number;
+    onChange: (priority: number) => void;
     active: boolean;
 }
 
-const OrderBadge: React.FC<OrderBadgeProps> = ({ order, onChange, active }) => {
+const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, active }) => {
     const [anchor, setAnchor] = useState<HTMLElement | null>(null);
-    const [draft, setDraft] = useState<string>(String(order || ''));
+    const [draft, setDraft] = useState<string>(String(priority || ''));
 
     const open = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
-        setDraft(String(order || ''));
+        setDraft(String(priority || ''));
         setAnchor(e.currentTarget);
     };
     const close = () => setAnchor(null);
@@ -103,30 +105,30 @@ const OrderBadge: React.FC<OrderBadgeProps> = ({ order, onChange, active }) => {
     const commit = () => {
         const parsed = parseInt(draft, 10);
         const next = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-        if (next !== order) {
+        if (next !== priority) {
             onChange(next);
         }
         close();
     };
 
-    const label = order > 0 ? String(order) : '–';
-    const tooltip = order > 0
-        ? `Priority order ${order} (lower = tried first). Click to change.`
-        : 'No priority set. Click to assign an order (1 = primary, 2 = fallback, …).';
+    const label = priority > 0 ? String(priority) : '–';
+    const tooltip = priority > 0
+        ? `Priority ${priority} (higher = tried first). Click to change.`
+        : 'No priority set. Click to assign a priority (higher = tried first).';
 
     return (
         <>
             <Tooltip title={tooltip} arrow placement="top">
                 <span>
-                    <OrderBadgeButton
-                        variant={order > 0 ? 'contained' : 'outlined'}
-                        color={order > 0 ? 'primary' : 'inherit'}
+                    <PriorityBadgeButton
+                        variant={priority > 0 ? 'contained' : 'outlined'}
+                        color={priority > 0 ? 'primary' : 'inherit'}
                         size="small"
                         onClick={open}
                         disabled={!active}
                     >
                         {label}
-                    </OrderBadgeButton>
+                    </PriorityBadgeButton>
                 </span>
             </Tooltip>
             <Popover
@@ -138,7 +140,7 @@ const OrderBadge: React.FC<OrderBadgeProps> = ({ order, onChange, active }) => {
             >
                 <Box sx={{ p: 1.5, width: 220 }}>
                     <Typography variant="caption" color="text.secondary">
-                        Priority order
+                        Priority
                     </Typography>
                     <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
                         <TextField
@@ -160,7 +162,7 @@ const OrderBadge: React.FC<OrderBadgeProps> = ({ order, onChange, active }) => {
                         </Button>
                     </Stack>
                     <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
-                        Lower number runs first. Same number = parallel tier.
+                        Higher number runs first. Same number = parallel tier.
                     </Typography>
                 </Box>
             </Popover>
@@ -176,7 +178,7 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
     active,
     onDelete,
     onNodeClick,
-    onOrderChange,
+    onPriorityChange,
 }) => {
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const [probeAnchorEl, setProbeAnchorEl] = useState<null | HTMLElement>(null);
@@ -233,10 +235,10 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
             )}
 
             <ProviderNodeContainer onClick={onNodeClick} sx={{ cursor: active ? 'pointer' : 'default', display: 'flex', flexDirection: 'column' }}>
-                {onOrderChange && (
-                    <OrderBadge
-                        order={provider.order ?? 0}
-                        onChange={onOrderChange}
+                {onPriorityChange && (
+                    <PriorityBadge
+                        priority={provider.priority ?? 0}
+                        onChange={onPriorityChange}
                         active={active}
                     />
                 )}

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -65,12 +65,17 @@ export interface ProviderNodeComponentProps {
 }
 
 // Clickable priority badge anchored to the top-left corner of the node.
-// The button itself sits *inside* the node so the click target is always
-// on the node (avoids the badge floating into the gap between siblings
-// where adjacent nodes may swallow the click). A small CSS translate
-// shifts the visual position outward so the badge still reads as
-// "attached to the corner", matching the existing badge convention.
-const PriorityBadgeButton = styled(Button)(({ theme }) => ({
+// The button sits *inside* the node so the click target is always on
+// the node (the badge floating into the gap between siblings would let
+// adjacent nodes swallow the click). A small CSS translate shifts the
+// visual position outward so it still reads as "attached to the corner".
+//
+// Styling is driven by a `hasPriority` prop on the styled element rather
+// than MUI's `variant` / `color` props, because contained-button defaults
+// otherwise win over sx and force a primary background.
+const PriorityBadgeButton = styled(Button, {
+    shouldForwardProp: (prop) => prop !== 'hasPriority',
+})<{ hasPriority: boolean }>(({ theme, hasPriority }) => ({
     position: 'absolute',
     top: 4,
     left: 4,
@@ -85,10 +90,28 @@ const PriorityBadgeButton = styled(Button)(({ theme }) => ({
     lineHeight: 1,
     boxShadow: theme.shadows[2],
     zIndex: 3,
-    // Belt-and-suspenders: even though we stopPropagation in the handler,
-    // some MUI internals re-fire click events from the wrapping span. A
-    // dedicated pointer-events region keeps clicks on the badge alone.
     pointerEvents: 'auto',
+    border: '1px solid',
+    ...(hasPriority
+        ? {
+              backgroundColor: theme.palette.primary.main,
+              color: theme.palette.primary.contrastText,
+              borderColor: theme.palette.primary.main,
+              '&:hover': {
+                  backgroundColor: theme.palette.primary.dark,
+                  borderColor: theme.palette.primary.dark,
+              },
+          }
+        : {
+              backgroundColor: theme.palette.background.paper,
+              color: theme.palette.text.secondary,
+              borderColor: theme.palette.divider,
+              '&:hover': {
+                  backgroundColor: theme.palette.background.paper,
+                  borderColor: theme.palette.primary.main,
+                  color: theme.palette.primary.main,
+              },
+          }),
 }));
 
 interface PriorityBadgeProps {
@@ -127,26 +150,10 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
             <Tooltip title={tooltip} arrow placement="top">
                 <span>
                     <PriorityBadgeButton
-                        variant="contained"
-                        // Unset state still needs an opaque background so the
-                        // badge visually covers the node corner underneath
-                        // (the outlined variant was transparent and let the
-                        // node bleed through, reading as "穿透").
-                        color={priority > 0 ? 'primary' : 'inherit'}
+                        hasPriority={priority > 0}
                         size="small"
                         onClick={open}
                         disabled={!active}
-                        sx={priority > 0 ? undefined : {
-                            backgroundColor: 'background.paper',
-                            color: 'text.secondary',
-                            border: '1px solid',
-                            borderColor: 'divider',
-                            '&:hover': {
-                                backgroundColor: 'background.paper',
-                                borderColor: 'primary.main',
-                                color: 'primary.main',
-                            },
-                        }}
                     >
                         {label}
                     </PriorityBadgeButton>

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -64,15 +64,17 @@ export interface ProviderNodeComponentProps {
     onPriorityChange?: (priority: number) => void;
 }
 
-// Clickable priority badge that overlaps the top-left corner of the
-// node, matching the existing badge convention elsewhere in the app
-// (e.g. SmartOpNode's index badge). Click → small popover with a number
-// input. Setting 0 clears the priority (the rule falls back to its
-// default tactic when no service has an explicit priority).
+// Clickable priority badge anchored to the top-left corner of the node.
+// The button itself sits *inside* the node so the click target is always
+// on the node (avoids the badge floating into the gap between siblings
+// where adjacent nodes may swallow the click). A small CSS translate
+// shifts the visual position outward so the badge still reads as
+// "attached to the corner", matching the existing badge convention.
 const PriorityBadgeButton = styled(Button)(({ theme }) => ({
     position: 'absolute',
-    top: -10,
-    left: -10,
+    top: 4,
+    left: 4,
+    transform: 'translate(-30%, -30%)',
     minWidth: 0,
     width: 26,
     height: 26,
@@ -83,6 +85,10 @@ const PriorityBadgeButton = styled(Button)(({ theme }) => ({
     lineHeight: 1,
     boxShadow: theme.shadows[2],
     zIndex: 3,
+    // Belt-and-suspenders: even though we stopPropagation in the handler,
+    // some MUI internals re-fire click events from the wrapping span. A
+    // dedicated pointer-events region keeps clicks on the badge alone.
+    pointerEvents: 'auto',
 }));
 
 interface PriorityBadgeProps {

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -126,7 +126,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                             weight: provider.weight || 0,
                             active: provider.active !== undefined ? provider.active : true,
                             time_window: provider.time_window || 0,
-                            order: provider.order || 0,
+                            priority: provider.priority || 0,
                         })),
                     smart_enabled: newConfigRecord.smartEnabled || false,
                     smart_routing: newConfigRecord.smartRouting || [],

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -10,6 +10,7 @@ import {
     exportRuleWithProviders,
     exportRuleAsJsonlToClipboard,
     exportRuleAsBase64ToClipboard,
+    pickLbTactic,
     type ExportFormat,
 } from './utils';
 
@@ -105,7 +106,8 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
             }
 
             try {
-                const ruleData = {
+                const lbTactic = pickLbTactic(newConfigRecord);
+                const ruleData: Record<string, any> = {
                     uuid: rule.uuid,
                     scenario: rule.scenario,
                     request_model: newConfigRecord.requestModel,
@@ -124,10 +126,14 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                             weight: provider.weight || 0,
                             active: provider.active !== undefined ? provider.active : true,
                             time_window: provider.time_window || 0,
+                            order: provider.order || 0,
                         })),
                     smart_enabled: newConfigRecord.smartEnabled || false,
                     smart_routing: newConfigRecord.smartRouting || [],
                 };
+                if (lbTactic) {
+                    ruleData.lb_tactic = lbTactic;
+                }
 
                 const result = await api.updateRule(rule.uuid, ruleData);
                 if (result.success) {
@@ -142,6 +148,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         services: ruleData.services,
                         smart_enabled: ruleData.smart_enabled,
                         smart_routing: ruleData.smart_routing,
+                        lb_tactic: ruleData.lb_tactic,
                     });
                     showNotification('Configuration saved successfully', 'success');
                     return true;

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -29,6 +29,7 @@ export function serviceToConfigProvider(service: any): ConfigProvider {
         weight: service.weight || 0,
         active: service.active !== undefined ? service.active : true,
         time_window: service.time_window || 0,
+        order: service.order || 0,
     };
 }
 
@@ -70,7 +71,34 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
+        lbTactic: rule.lb_tactic?.type,
     };
+}
+
+/**
+ * Returns whether any service in the record has an explicit priority order
+ * set. Used to pick the rule's load-balancing tactic on save: as soon as
+ * the user assigns at least one Order > 0, the rule is flipped into the
+ * "priority" (direct + fallback) tactic.
+ */
+export function hasPriorityOrdering(record: ConfigRecord): boolean {
+    return record.providers.some((p) => (p.order ?? 0) > 0);
+}
+
+/**
+ * Returns the load-balancing tactic payload to send when saving the rule.
+ * If any service has Order > 0 we force "priority"; otherwise we preserve
+ * the existing tactic so we don't silently clobber what the user (or the
+ * backend default) had selected.
+ */
+export function pickLbTactic(record: ConfigRecord): { type: string; params: Record<string, unknown> } | undefined {
+    if (hasPriorityOrdering(record)) {
+        return { type: 'priority', params: { within_order_tactic: 'random' } };
+    }
+    if (record.lbTactic) {
+        return { type: record.lbTactic, params: {} };
+    }
+    return undefined;
 }
 
 /**
@@ -98,6 +126,7 @@ export function cloneSmartRouting(smartRouting: SmartRouting): SmartRouting {
             weight: service.weight,
             active: service.active,
             time_window: service.time_window,
+            order: service.order,
         })),
     };
 }

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -29,7 +29,7 @@ export function serviceToConfigProvider(service: any): ConfigProvider {
         weight: service.weight || 0,
         active: service.active !== undefined ? service.active : true,
         time_window: service.time_window || 0,
-        order: service.order || 0,
+        priority: service.priority || 0,
     };
 }
 
@@ -76,24 +76,24 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
 }
 
 /**
- * Returns whether any service in the record has an explicit priority order
- * set. Used to pick the rule's load-balancing tactic on save: as soon as
- * the user assigns at least one Order > 0, the rule is flipped into the
+ * Returns whether any service in the record has an explicit priority set.
+ * Used to pick the rule's load-balancing tactic on save: as soon as the
+ * user assigns at least one Priority > 0, the rule is flipped into the
  * "priority" (direct + fallback) tactic.
  */
-export function hasPriorityOrdering(record: ConfigRecord): boolean {
-    return record.providers.some((p) => (p.order ?? 0) > 0);
+export function hasPriorityAssigned(record: ConfigRecord): boolean {
+    return record.providers.some((p) => (p.priority ?? 0) > 0);
 }
 
 /**
  * Returns the load-balancing tactic payload to send when saving the rule.
- * If any service has Order > 0 we force "priority"; otherwise we preserve
- * the existing tactic so we don't silently clobber what the user (or the
- * backend default) had selected.
+ * If any service has Priority > 0 we force "priority"; otherwise we
+ * preserve the existing tactic so we don't silently clobber what the user
+ * (or the backend default) had selected.
  */
 export function pickLbTactic(record: ConfigRecord): { type: string; params: Record<string, unknown> } | undefined {
-    if (hasPriorityOrdering(record)) {
-        return { type: 'priority', params: { within_order_tactic: 'random' } };
+    if (hasPriorityAssigned(record)) {
+        return { type: 'priority', params: { within_tier_tactic: 'random' } };
     }
     if (record.lbTactic) {
         return { type: record.lbTactic, params: {} };
@@ -126,7 +126,7 @@ export function cloneSmartRouting(smartRouting: SmartRouting): SmartRouting {
             weight: service.weight,
             active: service.active,
             time_window: service.time_window,
-            order: service.order,
+            priority: service.priority,
         })),
     };
 }

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -1,0 +1,238 @@
+package loadbalance
+
+import (
+	"sync"
+	"time"
+)
+
+// BreakerState represents the state of a circuit breaker.
+type BreakerState int
+
+const (
+	BreakerClosed   BreakerState = iota // Normal operation; requests pass through
+	BreakerOpen                         // Tripped; requests are blocked
+	BreakerHalfOpen                     // Recovery probe; one request is allowed
+)
+
+// Default circuit breaker tunables.
+const (
+	DefaultBreakerFailureThreshold = 3
+	DefaultBreakerOpenDuration     = 30 * time.Second
+)
+
+// Breaker is a simple three-state circuit breaker for a single service.
+//
+// State transitions:
+//   - Closed → Open when consecutive failures hit FailureThreshold.
+//   - Open → HalfOpen lazily, once OpenDuration has elapsed since the trip.
+//     The next Allow() call observes the elapsed time and flips state.
+//   - HalfOpen → Closed on RecordSuccess.
+//   - HalfOpen → Open on RecordFailure (open timer restarts).
+//
+// While HalfOpen, Allow() returns true for the first caller and false for
+// concurrent callers, so exactly one probe request goes through at a time.
+type Breaker struct {
+	mu               sync.Mutex
+	state            BreakerState
+	consecFails      int
+	openedAt         time.Time
+	halfOpenInFlight bool
+
+	FailureThreshold int
+	OpenDuration     time.Duration
+}
+
+// NewBreaker creates a breaker with the supplied thresholds. Zero values
+// fall back to defaults.
+func NewBreaker(failureThreshold int, openDuration time.Duration) *Breaker {
+	if failureThreshold <= 0 {
+		failureThreshold = DefaultBreakerFailureThreshold
+	}
+	if openDuration <= 0 {
+		openDuration = DefaultBreakerOpenDuration
+	}
+	return &Breaker{
+		state:            BreakerClosed,
+		FailureThreshold: failureThreshold,
+		OpenDuration:     openDuration,
+	}
+}
+
+// Allow reports whether a new request is permitted right now. It also
+// performs the Open→HalfOpen transition when the open timer has expired
+// and arbitrates which caller gets the probe slot.
+func (b *Breaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case BreakerClosed:
+		return true
+	case BreakerOpen:
+		if time.Since(b.openedAt) >= b.OpenDuration {
+			b.state = BreakerHalfOpen
+			b.halfOpenInFlight = true
+			return true
+		}
+		return false
+	case BreakerHalfOpen:
+		if b.halfOpenInFlight {
+			return false
+		}
+		b.halfOpenInFlight = true
+		return true
+	}
+	return true
+}
+
+// RecordSuccess closes the breaker and resets failure tracking.
+func (b *Breaker) RecordSuccess() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.state = BreakerClosed
+	b.consecFails = 0
+	b.halfOpenInFlight = false
+}
+
+// RecordFailure increments failure tracking and trips the breaker when
+// the threshold is reached. A failure during HalfOpen immediately re-opens.
+func (b *Breaker) RecordFailure() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.state == BreakerHalfOpen {
+		b.state = BreakerOpen
+		b.openedAt = time.Now()
+		b.halfOpenInFlight = false
+		return
+	}
+	b.consecFails++
+	if b.consecFails >= b.FailureThreshold {
+		b.state = BreakerOpen
+		b.openedAt = time.Now()
+	}
+}
+
+// State returns the current breaker state. Intended for introspection / UI.
+func (b *Breaker) State() BreakerState {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Apply the lazy Open→HalfOpen transition for read consistency.
+	if b.state == BreakerOpen && time.Since(b.openedAt) >= b.OpenDuration {
+		return BreakerHalfOpen
+	}
+	return b.state
+}
+
+// String renders the breaker state for logs/UI.
+func (s BreakerState) String() string {
+	switch s {
+	case BreakerClosed:
+		return "closed"
+	case BreakerOpen:
+		return "open"
+	case BreakerHalfOpen:
+		return "half_open"
+	}
+	return "unknown"
+}
+
+// BreakerStore is a concurrent-safe registry of breakers keyed by service
+// identifier. Breakers are created lazily on first access.
+//
+// The store is process-wide: two rules that reference the same
+// provider:model share breaker state. This is intentional — if a service
+// is failing, it is generally failing for every rule that uses it.
+type BreakerStore struct {
+	mu       sync.RWMutex
+	breakers map[string]*Breaker
+	failures int
+	openFor  time.Duration
+}
+
+// NewBreakerStore returns a BreakerStore. Defaults are applied for zero
+// values, matching the package defaults.
+func NewBreakerStore(failureThreshold int, openDuration time.Duration) *BreakerStore {
+	if failureThreshold <= 0 {
+		failureThreshold = DefaultBreakerFailureThreshold
+	}
+	if openDuration <= 0 {
+		openDuration = DefaultBreakerOpenDuration
+	}
+	return &BreakerStore{
+		breakers: make(map[string]*Breaker),
+		failures: failureThreshold,
+		openFor:  openDuration,
+	}
+}
+
+// Get returns the breaker for the given serviceID, creating one with the
+// store's default thresholds if needed.
+func (s *BreakerStore) Get(serviceID string) *Breaker {
+	s.mu.RLock()
+	if b, ok := s.breakers[serviceID]; ok {
+		s.mu.RUnlock()
+		return b
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if b, ok := s.breakers[serviceID]; ok {
+		return b
+	}
+	b := NewBreaker(s.failures, s.openFor)
+	s.breakers[serviceID] = b
+	return b
+}
+
+// Allow is a convenience over Get(serviceID).Allow().
+func (s *BreakerStore) Allow(serviceID string) bool {
+	return s.Get(serviceID).Allow()
+}
+
+// RecordSuccess is a convenience over Get(serviceID).RecordSuccess().
+func (s *BreakerStore) RecordSuccess(serviceID string) {
+	s.Get(serviceID).RecordSuccess()
+}
+
+// RecordFailure is a convenience over Get(serviceID).RecordFailure().
+func (s *BreakerStore) RecordFailure(serviceID string) {
+	s.Get(serviceID).RecordFailure()
+}
+
+// Snapshot returns a copy of current breaker states for introspection.
+func (s *BreakerStore) Snapshot() map[string]BreakerState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]BreakerState, len(s.breakers))
+	for id, b := range s.breakers {
+		out[id] = b.State()
+	}
+	return out
+}
+
+// defaultStore is the process-wide breaker registry used by tactics and
+// the recorder integration. Tests may replace it; production code should
+// use the package-level helpers below.
+var defaultStore = NewBreakerStore(DefaultBreakerFailureThreshold, DefaultBreakerOpenDuration)
+
+// DefaultBreakerStore returns the process-wide breaker store.
+func DefaultBreakerStore() *BreakerStore {
+	return defaultStore
+}
+
+// AllowService is a package-level convenience used by selection logic.
+func AllowService(serviceID string) bool {
+	return defaultStore.Allow(serviceID)
+}
+
+// RecordServiceSuccess is a package-level convenience used by dispatch.
+func RecordServiceSuccess(serviceID string) {
+	defaultStore.RecordSuccess(serviceID)
+}
+
+// RecordServiceFailure is a package-level convenience used by dispatch.
+func RecordServiceFailure(serviceID string) {
+	defaultStore.RecordFailure(serviceID)
+}

--- a/internal/loadbalance/breaker_test.go
+++ b/internal/loadbalance/breaker_test.go
@@ -1,0 +1,104 @@
+package loadbalance
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBreakerOpensAfterThreshold(t *testing.T) {
+	b := NewBreaker(3, time.Second)
+	if !b.Allow() {
+		t.Fatal("fresh breaker should allow")
+	}
+	for i := 0; i < 3; i++ {
+		b.RecordFailure()
+	}
+	if b.Allow() {
+		t.Fatal("breaker should be open after 3 failures")
+	}
+	if b.State() != BreakerOpen {
+		t.Fatalf("state = %v, want open", b.State())
+	}
+}
+
+func TestBreakerHalfOpenAfterDuration(t *testing.T) {
+	b := NewBreaker(2, 20*time.Millisecond)
+	b.RecordFailure()
+	b.RecordFailure()
+	if b.Allow() {
+		t.Fatal("breaker should be open")
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	// First Allow() after expiry should pass (half-open probe).
+	if !b.Allow() {
+		t.Fatal("breaker should let one probe through after duration")
+	}
+	// Concurrent caller must not also pass while probe is in flight.
+	if b.Allow() {
+		t.Fatal("half-open should only allow one probe at a time")
+	}
+
+	// Probe success → closed.
+	b.RecordSuccess()
+	if b.State() != BreakerClosed {
+		t.Fatalf("state after success = %v, want closed", b.State())
+	}
+	if !b.Allow() {
+		t.Fatal("closed breaker should allow")
+	}
+}
+
+func TestBreakerHalfOpenFailureReopens(t *testing.T) {
+	b := NewBreaker(1, 10*time.Millisecond)
+	b.RecordFailure() // → open
+	time.Sleep(15 * time.Millisecond)
+	b.Allow() // → half-open
+	b.RecordFailure()
+	if b.State() != BreakerOpen {
+		t.Fatalf("state = %v, want open after half-open failure", b.State())
+	}
+}
+
+func TestBreakerSuccessResetsCounter(t *testing.T) {
+	b := NewBreaker(3, time.Second)
+	b.RecordFailure()
+	b.RecordFailure()
+	b.RecordSuccess()
+	b.RecordFailure()
+	b.RecordFailure()
+	if b.State() != BreakerClosed {
+		t.Fatalf("state = %v, want closed (success should reset)", b.State())
+	}
+}
+
+func TestBreakerStoreLazyCreation(t *testing.T) {
+	store := NewBreakerStore(2, time.Second)
+	b1 := store.Get("svc:a")
+	b2 := store.Get("svc:a")
+	if b1 != b2 {
+		t.Fatal("store should return the same breaker for the same key")
+	}
+	if store.Get("svc:b") == b1 {
+		t.Fatal("store should return different breakers for different keys")
+	}
+}
+
+func TestBreakerStoreConcurrent(t *testing.T) {
+	store := NewBreakerStore(5, time.Second)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			store.Allow("svc:concurrent")
+			store.RecordFailure("svc:concurrent")
+		}()
+	}
+	wg.Wait()
+	// Just need to ensure no panic / race; state is now Open.
+	if store.Get("svc:concurrent").State() != BreakerOpen {
+		t.Fatal("after many failures the breaker should be open")
+	}
+}

--- a/internal/loadbalance/load_balancing.go
+++ b/internal/loadbalance/load_balancing.go
@@ -15,6 +15,7 @@ type Service struct {
 	Active        bool         `yaml:"active" json:"active"`                                     // Whether this service is active
 	TimeWindow    int          `yaml:"time_window" json:"time_window"`                           // Statistics time window in seconds
 	ModelCapacity *int         `yaml:"model_capacity,omitempty" json:"model_capacity,omitempty"` // ModelCapacity overrides the provider's default_model_capacity for this specific model
+	Order         int          `yaml:"order,omitempty" json:"order,omitempty"`                   // Priority order within a rule: lower = higher priority. 0 = unset (treated as same tier). Used by TacticPriority.
 	Stats         ServiceStats `yaml:"-" json:"-"`                                               // Service usage statistics (stored in SQLite, not in config)
 }
 
@@ -463,7 +464,8 @@ const (
 	TacticLatencyBased                    // Route based on response latency
 	TacticSpeedBased                      // Route based on token generation speed
 	TacticAdaptive                        // Composite multi-dimensional routing
-	TacticCapacityBased                   // 6: NEW - capacity-based load balancing
+	TacticCapacityBased                   // 6: capacity-based load balancing
+	TacticPriority                        // 7: priority/failover by Service.Order; ties share via sub-tactic
 )
 
 // MarshalJSON implements json.Marshaler for TacticType
@@ -502,6 +504,8 @@ func (tt TacticType) String() string {
 		return "adaptive"
 	case TacticCapacityBased:
 		return "capacity_based"
+	case TacticPriority:
+		return "priority"
 	default:
 		return "token_based"
 	}
@@ -526,6 +530,8 @@ func ParseTacticType(s string) TacticType {
 		return TacticAdaptive
 	case "capacity_based":
 		return TacticCapacityBased
+	case "priority":
+		return TacticPriority
 	default:
 		return TacticAdaptive // default to adaptive
 	}

--- a/internal/loadbalance/load_balancing.go
+++ b/internal/loadbalance/load_balancing.go
@@ -15,7 +15,7 @@ type Service struct {
 	Active        bool         `yaml:"active" json:"active"`                                     // Whether this service is active
 	TimeWindow    int          `yaml:"time_window" json:"time_window"`                           // Statistics time window in seconds
 	ModelCapacity *int         `yaml:"model_capacity,omitempty" json:"model_capacity,omitempty"` // ModelCapacity overrides the provider's default_model_capacity for this specific model
-	Order         int          `yaml:"order,omitempty" json:"order,omitempty"`                   // Priority order within a rule: lower = higher priority. 0 = unset (treated as same tier). Used by TacticPriority.
+	Priority      int          `yaml:"priority,omitempty" json:"priority,omitempty"`             // Priority within a rule: higher = tried first. 0 = unset (sinks to bottom). Used by TacticPriority.
 	Stats         ServiceStats `yaml:"-" json:"-"`                                               // Service usage statistics (stored in SQLite, not in config)
 }
 
@@ -465,7 +465,7 @@ const (
 	TacticSpeedBased                      // Route based on token generation speed
 	TacticAdaptive                        // Composite multi-dimensional routing
 	TacticCapacityBased                   // 6: capacity-based load balancing
-	TacticPriority                        // 7: priority/failover by Service.Order; ties share via sub-tactic
+	TacticPriority                        // 7: priority/failover by Service.Priority (higher tried first); ties share via sub-tactic
 )
 
 // MarshalJSON implements json.Marshaler for TacticType

--- a/internal/server/priority_routing_e2e_test.go
+++ b/internal/server/priority_routing_e2e_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestPriorityRouting_EndToEnd exercises the full chain the frontend
+// triggers when a user assigns a priority to any service:
+//
+//  1. A rule JSON arrives carrying lb_tactic.type = "priority".
+//  2. The Rule is unmarshalled — Tactic.UnmarshalJSON has to allocate
+//     a *PriorityParams and decode within_tier_tactic into it.
+//  3. LoadBalancer.SelectService is called for that rule.
+//  4. Internally rule.LBTactic.Instantiate() routes through
+//     CreateTacticWithTypedParams → NewPriorityTactic.
+//  5. PriorityTactic.SelectService groups by Priority and consults the
+//     process-wide breaker store.
+//  6. After enough failures on the top-priority service the breaker
+//     trips and the next call falls back; once the breaker closes the
+//     call returns to the top.
+//
+// This is the test that pins down "the tactic actually changes behaviour
+// at runtime", which was missing from the package-level tactic tests
+// that only exercised PriorityTactic in isolation.
+func TestPriorityRouting_EndToEnd(t *testing.T) {
+	ruleJSON := `{
+		"uuid": "rule-e2e",
+		"scenario": "openai",
+		"request_model": "gpt-4",
+		"active": true,
+		"services": [
+			{"provider": "e2e-primary",  "model": "gpt-4", "active": true, "priority": 10},
+			{"provider": "e2e-fallback", "model": "gpt-4", "active": true, "priority": 5}
+		],
+		"lb_tactic": {
+			"type": "priority",
+			"params": {"within_tier_tactic": "random"}
+		}
+	}`
+
+	var rule typ.Rule
+	if err := json.Unmarshal([]byte(ruleJSON), &rule); err != nil {
+		t.Fatalf("rule unmarshal failed: %v", err)
+	}
+
+	// Sanity-check the JSON contract the frontend depends on.
+	if rule.LBTactic.Type != loadbalance.TacticPriority {
+		t.Fatalf("lb_tactic.type = %v, want TacticPriority", rule.LBTactic.Type)
+	}
+	pp, ok := rule.LBTactic.Params.(*typ.PriorityParams)
+	if !ok || pp == nil {
+		t.Fatalf("LBTactic.Params = %T, want *PriorityParams", rule.LBTactic.Params)
+	}
+	if pp.WithinTierTactic != loadbalance.TacticRandom {
+		t.Fatalf("WithinTierTactic = %v, want random", pp.WithinTierTactic)
+	}
+
+	// Build a load balancer with a no-op health filter so the only
+	// thing that can hide a service from the tactic is its breaker.
+	hf := typ.NewHealthFilter(nil)
+	lb := &LoadBalancer{
+		tactics:      make(map[loadbalance.TacticType]typ.LoadBalancingTactic),
+		healthFilter: hf,
+	}
+
+	primaryID := "e2e-primary:gpt-4"
+	fallbackID := "e2e-fallback:gpt-4"
+
+	// 1. Fresh state: the top-priority service is chosen.
+	got, err := lb.SelectService(&rule)
+	if err != nil {
+		t.Fatalf("initial SelectService: %v", err)
+	}
+	if got.ServiceID() != primaryID {
+		t.Fatalf("initial pick = %s, want %s", got.ServiceID(), primaryID)
+	}
+
+	// 2. Trip the primary's breaker via the package-level store — this
+	//    is the same store the recorder writes into on real failures.
+	store := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		store.RecordFailure(primaryID)
+	}
+	defer store.RecordSuccess(primaryID)
+	defer store.RecordSuccess(fallbackID)
+
+	got, err = lb.SelectService(&rule)
+	if err != nil {
+		t.Fatalf("after-trip SelectService: %v", err)
+	}
+	if got.ServiceID() != fallbackID {
+		t.Fatalf("after-trip pick = %s, want fallback %s", got.ServiceID(), fallbackID)
+	}
+
+	// 3. Mark the primary healthy again (mirrors what RecordResponse →
+	//    RecordServiceSuccess does at the end of a good request).
+	store.RecordSuccess(primaryID)
+
+	got, err = lb.SelectService(&rule)
+	if err != nil {
+		t.Fatalf("after-recovery SelectService: %v", err)
+	}
+	if got.ServiceID() != primaryID {
+		t.Fatalf("after-recovery pick = %s, want %s", got.ServiceID(), primaryID)
+	}
+}

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -53,8 +54,20 @@ type ProtocolRecorder struct {
 	transformSteps []string
 
 	providerName string
+	providerUUID string
 	model        string
 	mode         obs.RecordMode
+}
+
+// breakerServiceID returns the loadbalance service identifier for the
+// active provider+model, or "" if either is unknown. The ID format must
+// match Service.ServiceID() so circuit-breaker lookups line up with the
+// keys used by the priority tactic.
+func (sr *ProtocolRecorder) breakerServiceID() string {
+	if sr == nil || sr.providerUUID == "" || sr.model == "" {
+		return ""
+	}
+	return sr.providerUUID + ":" + sr.model
 }
 
 // EnsureProtocolRecorder returns a ProtocolRecorder for the given scenario,
@@ -152,6 +165,7 @@ func (sr *ProtocolRecorder) bindProvider(provider *typ.Provider, model string, m
 	}
 	if provider != nil {
 		sr.providerName = provider.Name
+		sr.providerUUID = provider.UUID
 	}
 	if model != "" {
 		sr.model = model
@@ -264,6 +278,9 @@ func (sr *ProtocolRecorder) RecordResponse(provider *typ.Provider, model string)
 	if sr.finalResponse == nil {
 		sr.finalResponse = sr.synthesizeFinalResponse()
 	}
+	if id := sr.breakerServiceID(); id != "" {
+		loadbalance.RecordServiceSuccess(id)
+	}
 	sr.emit(nil)
 }
 
@@ -271,6 +288,11 @@ func (sr *ProtocolRecorder) RecordResponse(provider *typ.Provider, model string)
 func (sr *ProtocolRecorder) RecordError(err error) {
 	if sr == nil {
 		return
+	}
+	if err != nil {
+		if id := sr.breakerServiceID(); id != "" {
+			loadbalance.RecordServiceFailure(id)
+		}
 	}
 	sr.emit(err)
 }

--- a/internal/typ/priority_tactic_test.go
+++ b/internal/typ/priority_tactic_test.go
@@ -1,0 +1,149 @@
+package typ
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func mkService(provider, model string, order int) *loadbalance.Service {
+	return &loadbalance.Service{
+		Provider: provider,
+		Model:    model,
+		Active:   true,
+		Order:    order,
+	}
+}
+
+func mkPriorityRule(services ...*loadbalance.Service) *Rule {
+	return &Rule{
+		UUID:     "rule-test",
+		Services: services,
+		Active:   true,
+		LBTactic: Tactic{
+			Type:   loadbalance.TacticPriority,
+			Params: DefaultPriorityParams(),
+		},
+	}
+}
+
+func TestPriorityPicksLowestOrderFirst(t *testing.T) {
+	primary := mkService("p1", "m1", 1)
+	backup := mkService("p2", "m1", 2)
+	rule := mkPriorityRule(primary, backup)
+	tactic := NewPriorityTactic(loadbalance.TacticRandom)
+
+	got := tactic.SelectService(rule)
+	if got != primary {
+		t.Fatalf("want primary (order=1), got %v", got)
+	}
+}
+
+func TestPriorityFallsBackWhenBreakerOpen(t *testing.T) {
+	primary := mkService("p1", "m1", 1)
+	backup := mkService("p2", "m1", 2)
+	rule := mkPriorityRule(primary, backup)
+	tactic := NewPriorityTactic(loadbalance.TacticRandom)
+
+	// Trip the primary's breaker.
+	store := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		store.RecordFailure(primary.ServiceID())
+	}
+	defer store.RecordSuccess(primary.ServiceID()) // clean up for other tests
+
+	got := tactic.SelectService(rule)
+	if got != backup {
+		t.Fatalf("primary breaker open, want backup, got %v", got)
+	}
+}
+
+func TestPriorityReturnsToHigherWhenBreakerCloses(t *testing.T) {
+	primary := mkService("recover-p1", "recover-m1", 1)
+	backup := mkService("recover-p2", "recover-m1", 2)
+	rule := mkPriorityRule(primary, backup)
+	tactic := NewPriorityTactic(loadbalance.TacticRandom)
+
+	store := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		store.RecordFailure(primary.ServiceID())
+	}
+	if got := tactic.SelectService(rule); got != backup {
+		t.Fatalf("expected fallback to backup, got %v", got)
+	}
+	store.RecordSuccess(primary.ServiceID())
+	if got := tactic.SelectService(rule); got != primary {
+		t.Fatalf("expected return to primary after recovery, got %v", got)
+	}
+}
+
+func TestPriorityTiesWithinOrderShareLoad(t *testing.T) {
+	a := mkService("tie-a", "m1", 1)
+	b := mkService("tie-b", "m1", 1)
+	backup := mkService("tie-c", "m1", 2)
+	rule := mkPriorityRule(a, b, backup)
+	tactic := NewPriorityTactic(loadbalance.TacticRandom)
+
+	counts := map[string]int{}
+	for i := 0; i < 200; i++ {
+		got := tactic.SelectService(rule)
+		if got == backup {
+			t.Fatalf("backup should never be picked while ties are healthy")
+		}
+		counts[got.ServiceID()]++
+	}
+	if counts[a.ServiceID()] == 0 || counts[b.ServiceID()] == 0 {
+		t.Fatalf("random within-order tactic should hit both tied services, got %v", counts)
+	}
+}
+
+func TestPriorityOrderZeroTreatedAsLowest(t *testing.T) {
+	ordered := mkService("ord-p1", "m1", 1)
+	unset := mkService("ord-p2", "m1", 0)
+	rule := mkPriorityRule(ordered, unset)
+	tactic := NewPriorityTactic(loadbalance.TacticRandom)
+
+	// Order=1 wins over Order=0 (unset).
+	if got := tactic.SelectService(rule); got != ordered {
+		t.Fatalf("explicit order should beat unset, got %v", got)
+	}
+}
+
+func TestPriorityAllBreakersOpenReturnsFirst(t *testing.T) {
+	// Even when every service is tripped we still pick something so the
+	// upstream-error path can surface a real error to the client.
+	a := mkService("allopen-a", "m1", 1)
+	b := mkService("allopen-b", "m1", 2)
+	rule := mkPriorityRule(a, b)
+	tactic := NewPriorityTactic(loadbalance.TacticRandom)
+
+	store := loadbalance.DefaultBreakerStore()
+	for _, svc := range []*loadbalance.Service{a, b} {
+		for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+			store.RecordFailure(svc.ServiceID())
+		}
+	}
+	defer func() {
+		store.RecordSuccess(a.ServiceID())
+		store.RecordSuccess(b.ServiceID())
+	}()
+
+	got := tactic.SelectService(rule)
+	if got == nil {
+		t.Fatal("want a fallback service, got nil")
+	}
+	// Should be the lowest-order bucket (Order=1).
+	if got.Order != 1 {
+		t.Fatalf("want order=1 fallback when all open, got order=%d", got.Order)
+	}
+}
+
+func TestPriorityRoundtripsThroughJSON(t *testing.T) {
+	tactic := Tactic{
+		Type:   loadbalance.TacticPriority,
+		Params: &PriorityParams{WithinOrderTactic: loadbalance.TacticRandom},
+	}
+	_ = tactic // just compile-check; full marshal round-trip is exercised by Rule json tests elsewhere
+	_ = time.Now
+}

--- a/internal/typ/priority_tactic_test.go
+++ b/internal/typ/priority_tactic_test.go
@@ -2,17 +2,16 @@ package typ
 
 import (
 	"testing"
-	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
-func mkService(provider, model string, order int) *loadbalance.Service {
+func mkService(provider, model string, priority int) *loadbalance.Service {
 	return &loadbalance.Service{
 		Provider: provider,
 		Model:    model,
 		Active:   true,
-		Order:    order,
+		Priority: priority,
 	}
 }
 
@@ -28,21 +27,21 @@ func mkPriorityRule(services ...*loadbalance.Service) *Rule {
 	}
 }
 
-func TestPriorityPicksLowestOrderFirst(t *testing.T) {
-	primary := mkService("p1", "m1", 1)
-	backup := mkService("p2", "m1", 2)
+func TestPriorityPicksHighestFirst(t *testing.T) {
+	primary := mkService("p1", "m1", 10)
+	backup := mkService("p2", "m1", 5)
 	rule := mkPriorityRule(primary, backup)
 	tactic := NewPriorityTactic(loadbalance.TacticRandom)
 
 	got := tactic.SelectService(rule)
 	if got != primary {
-		t.Fatalf("want primary (order=1), got %v", got)
+		t.Fatalf("want primary (priority=10), got %v", got)
 	}
 }
 
 func TestPriorityFallsBackWhenBreakerOpen(t *testing.T) {
-	primary := mkService("p1", "m1", 1)
-	backup := mkService("p2", "m1", 2)
+	primary := mkService("fb-p1", "m1", 10)
+	backup := mkService("fb-p2", "m1", 5)
 	rule := mkPriorityRule(primary, backup)
 	tactic := NewPriorityTactic(loadbalance.TacticRandom)
 
@@ -60,8 +59,8 @@ func TestPriorityFallsBackWhenBreakerOpen(t *testing.T) {
 }
 
 func TestPriorityReturnsToHigherWhenBreakerCloses(t *testing.T) {
-	primary := mkService("recover-p1", "recover-m1", 1)
-	backup := mkService("recover-p2", "recover-m1", 2)
+	primary := mkService("recover-p1", "recover-m1", 10)
+	backup := mkService("recover-p2", "recover-m1", 5)
 	rule := mkPriorityRule(primary, backup)
 	tactic := NewPriorityTactic(loadbalance.TacticRandom)
 
@@ -78,10 +77,10 @@ func TestPriorityReturnsToHigherWhenBreakerCloses(t *testing.T) {
 	}
 }
 
-func TestPriorityTiesWithinOrderShareLoad(t *testing.T) {
-	a := mkService("tie-a", "m1", 1)
-	b := mkService("tie-b", "m1", 1)
-	backup := mkService("tie-c", "m1", 2)
+func TestPriorityTiesShareLoad(t *testing.T) {
+	a := mkService("tie-a", "m1", 10)
+	b := mkService("tie-b", "m1", 10)
+	backup := mkService("tie-c", "m1", 5)
 	rule := mkPriorityRule(a, b, backup)
 	tactic := NewPriorityTactic(loadbalance.TacticRandom)
 
@@ -94,56 +93,46 @@ func TestPriorityTiesWithinOrderShareLoad(t *testing.T) {
 		counts[got.ServiceID()]++
 	}
 	if counts[a.ServiceID()] == 0 || counts[b.ServiceID()] == 0 {
-		t.Fatalf("random within-order tactic should hit both tied services, got %v", counts)
+		t.Fatalf("random within-tier tactic should hit both tied services, got %v", counts)
 	}
 }
 
-func TestPriorityOrderZeroTreatedAsLowest(t *testing.T) {
-	ordered := mkService("ord-p1", "m1", 1)
+func TestPriorityZeroTreatedAsUnset(t *testing.T) {
+	prioritised := mkService("ord-p1", "m1", 1)
 	unset := mkService("ord-p2", "m1", 0)
-	rule := mkPriorityRule(ordered, unset)
+	rule := mkPriorityRule(prioritised, unset)
 	tactic := NewPriorityTactic(loadbalance.TacticRandom)
 
-	// Order=1 wins over Order=0 (unset).
-	if got := tactic.SelectService(rule); got != ordered {
-		t.Fatalf("explicit order should beat unset, got %v", got)
+	// Any explicit priority (even 1) beats the unset (0) tier.
+	if got := tactic.SelectService(rule); got != prioritised {
+		t.Fatalf("explicit priority should beat unset, got %v", got)
 	}
 }
 
-func TestPriorityAllBreakersOpenReturnsFirst(t *testing.T) {
+func TestPriorityAllBreakersOpenReturnsHighestTier(t *testing.T) {
 	// Even when every service is tripped we still pick something so the
 	// upstream-error path can surface a real error to the client.
-	a := mkService("allopen-a", "m1", 1)
-	b := mkService("allopen-b", "m1", 2)
-	rule := mkPriorityRule(a, b)
+	high := mkService("allopen-a", "m1", 10)
+	low := mkService("allopen-b", "m1", 1)
+	rule := mkPriorityRule(high, low)
 	tactic := NewPriorityTactic(loadbalance.TacticRandom)
 
 	store := loadbalance.DefaultBreakerStore()
-	for _, svc := range []*loadbalance.Service{a, b} {
+	for _, svc := range []*loadbalance.Service{high, low} {
 		for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
 			store.RecordFailure(svc.ServiceID())
 		}
 	}
 	defer func() {
-		store.RecordSuccess(a.ServiceID())
-		store.RecordSuccess(b.ServiceID())
+		store.RecordSuccess(high.ServiceID())
+		store.RecordSuccess(low.ServiceID())
 	}()
 
 	got := tactic.SelectService(rule)
 	if got == nil {
 		t.Fatal("want a fallback service, got nil")
 	}
-	// Should be the lowest-order bucket (Order=1).
-	if got.Order != 1 {
-		t.Fatalf("want order=1 fallback when all open, got order=%d", got.Order)
+	if got.Priority != 10 {
+		t.Fatalf("want priority=10 fallback when all open, got priority=%d", got.Priority)
 	}
-}
-
-func TestPriorityRoundtripsThroughJSON(t *testing.T) {
-	tactic := Tactic{
-		Type:   loadbalance.TacticPriority,
-		Params: &PriorityParams{WithinOrderTactic: loadbalance.TacticRandom},
-	}
-	_ = tactic // just compile-check; full marshal round-trip is exercised by Rule json tests elsewhere
-	_ = time.Now
 }

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -119,8 +119,8 @@ func ParseTacticFromMap(tacticType loadbalance.TacticType, params map[string]int
 	case loadbalance.TacticPriority:
 		if params != nil {
 			tacticParams = &PriorityParams{
-				WithinOrderTactic: loadbalance.ParseTacticType(
-					getStringParamFromMap(params, "within_order_tactic", "random"),
+				WithinTierTactic: loadbalance.ParseTacticType(
+					getStringParamFromMap(params, "within_tier_tactic", "random"),
 				),
 			}
 		} else {
@@ -960,8 +960,8 @@ func CreateTacticWithTypedParams(tacticType loadbalance.TacticType, params Tacti
 		return GetCapacityBasedTactic()
 	case loadbalance.TacticPriority:
 		within := loadbalance.TacticRandom
-		if pp, ok := params.(*PriorityParams); ok && pp != nil && pp.WithinOrderTactic != 0 {
-			within = pp.WithinOrderTactic
+		if pp, ok := params.(*PriorityParams); ok && pp != nil && pp.WithinTierTactic != 0 {
+			within = pp.WithinTierTactic
 		}
 		return NewPriorityTactic(within)
 	}
@@ -996,19 +996,19 @@ type CapacityBasedParams struct{}
 func (c CapacityBasedParams) isTacticParams() {}
 
 // PriorityParams holds parameters for the priority/failover tactic.
-// WithinOrderTactic decides how to share load among services that have
-// the same Order (i.e. that are "tied" at a priority tier).
+// WithinTierTactic decides how to share load among services that share
+// the same Priority value (i.e. that are "tied" at a priority tier).
 type PriorityParams struct {
-	WithinOrderTactic loadbalance.TacticType `json:"within_order_tactic"`
+	WithinTierTactic loadbalance.TacticType `json:"within_tier_tactic"`
 }
 
 func (p PriorityParams) isTacticParams() {}
 
 // DefaultPriorityParams returns the default priority-tactic params.
-// Random within an order tier is a sensible default: it spreads load
-// across equally-prioritised services without requiring extra config.
+// Random within a tier is a sensible default: it spreads load across
+// equally-prioritised services without requiring extra config.
 func DefaultPriorityParams() TacticParams {
-	return &PriorityParams{WithinOrderTactic: loadbalance.TacticRandom}
+	return &PriorityParams{WithinTierTactic: loadbalance.TacticRandom}
 }
 
 // DefaultCapacityBasedParams returns default capacity-based parameters
@@ -1099,30 +1099,30 @@ func GetCapacityBasedTactic() *CapacityBasedTactic {
 
 // PriorityTactic implements priority/failover load balancing.
 //
-// Services are bucketed by Service.Order (ascending; lower = higher
-// priority). The lowest-order bucket containing at least one service
+// Services are bucketed by Service.Priority (descending; higher = tried
+// first). The highest-priority bucket containing at least one service
 // whose circuit breaker permits a request is selected. Within that
-// bucket, the WithinOrderTactic (e.g. random, token-based) chooses the
+// bucket, the WithinTierTactic (e.g. random, token-based) chooses the
 // final service. This yields:
 //
-//   - "Direct + fallback" when each service has a distinct Order.
+//   - "Direct + fallback" when each service has a distinct Priority.
 //   - "Two equivalent services share a tier, with a backup tier below"
-//     when several services share the same Order.
+//     when several services share the same Priority.
 //
 // Recovery is automatic: every request reconsiders the buckets from the
 // top, so once a higher-priority service's breaker closes the routing
 // returns to it without any extra coordination.
 type PriorityTactic struct {
-	WithinOrderTactic loadbalance.TacticType
+	WithinTierTactic loadbalance.TacticType
 }
 
 // NewPriorityTactic creates a priority tactic with the given sub-tactic
-// used to break ties within an order bucket.
+// used to break ties within a priority tier.
 func NewPriorityTactic(within loadbalance.TacticType) *PriorityTactic {
 	if within == 0 || within == loadbalance.TacticPriority {
 		within = loadbalance.TacticRandom
 	}
-	return &PriorityTactic{WithinOrderTactic: within}
+	return &PriorityTactic{WithinTierTactic: within}
 }
 
 // SelectService returns the highest-priority service whose breaker is
@@ -1135,13 +1135,13 @@ func (pt *PriorityTactic) SelectService(rule *Rule) *loadbalance.Service {
 		return nil
 	}
 
-	// Group by Order, deterministic ascending iteration.
-	buckets := groupServicesByOrder(active)
+	// Group by Priority, deterministic descending iteration.
+	buckets := groupServicesByPriority(active)
 
-	// Pick the lowest-order bucket that has at least one breaker-permitted
-	// service. If every bucket is tripped we fall back to the lowest-order
-	// bucket regardless — better to surface a real upstream error than to
-	// reject the request locally.
+	// Pick the highest-priority bucket that has at least one breaker-
+	// permitted service. If every bucket is tripped we fall back to the
+	// highest-priority bucket regardless — better to surface a real
+	// upstream error than to reject the request locally.
 	store := loadbalance.DefaultBreakerStore()
 	var fallback []*loadbalance.Service
 	for _, group := range buckets {
@@ -1155,25 +1155,25 @@ func (pt *PriorityTactic) SelectService(rule *Rule) *loadbalance.Service {
 			}
 		}
 		if len(allowed) > 0 {
-			return pt.pickWithinOrder(rule, allowed)
+			return pt.pickWithinTier(rule, allowed)
 		}
 	}
 	if len(fallback) > 0 {
-		return pt.pickWithinOrder(rule, fallback)
+		return pt.pickWithinTier(rule, fallback)
 	}
 	return active[0]
 }
 
-func (pt *PriorityTactic) pickWithinOrder(rule *Rule, services []*loadbalance.Service) *loadbalance.Service {
+func (pt *PriorityTactic) pickWithinTier(rule *Rule, services []*loadbalance.Service) *loadbalance.Service {
 	if len(services) == 1 {
 		return services[0]
 	}
-	// Construct an ephemeral Rule view containing only the bucket's
+	// Construct an ephemeral Rule view containing only the tier's
 	// services so the sub-tactic operates on the right pool.
 	sub := *rule
 	sub.Services = services
 	sub.CurrentServiceID = ""
-	tactic := GetDefaultTactic(pt.WithinOrderTactic)
+	tactic := GetDefaultTactic(pt.WithinTierTactic)
 	if tactic == nil {
 		return services[0]
 	}
@@ -1191,28 +1191,28 @@ func (pt *PriorityTactic) GetType() loadbalance.TacticType {
 	return loadbalance.TacticPriority
 }
 
-// orderBucket holds services that share the same Order value.
-type orderBucket struct {
-	order    int
+// priorityBucket holds services that share the same Priority value.
+type priorityBucket struct {
+	priority int
 	services []*loadbalance.Service
 }
 
-// groupServicesByOrder buckets services by their Order field and returns
-// the buckets sorted ascending. Services with Order == 0 are treated as a
-// single "unset" tier; placing them last lets explicit priorities take
-// precedence even when one of the services in a rule was never assigned
-// an order.
-func groupServicesByOrder(services []*loadbalance.Service) []orderBucket {
+// groupServicesByPriority buckets services by their Priority field and
+// returns the buckets sorted descending (higher priority first). Services
+// with Priority == 0 are treated as the "unset" tier; placing them last
+// lets explicitly-prioritised services be tried before unset ones even
+// when both are present in a rule.
+func groupServicesByPriority(services []*loadbalance.Service) []priorityBucket {
 	groups := make(map[int][]*loadbalance.Service)
 	for _, svc := range services {
-		groups[svc.Order] = append(groups[svc.Order], svc)
+		groups[svc.Priority] = append(groups[svc.Priority], svc)
 	}
 
 	keys := make([]int, 0, len(groups))
 	for k := range groups {
 		keys = append(keys, k)
 	}
-	// Ascending, but 0 (unset) sinks to the bottom.
+	// Descending, but 0 (unset) sinks to the bottom regardless of sign.
 	for i := 0; i < len(keys); i++ {
 		for j := i + 1; j < len(keys); j++ {
 			a, b := keys[i], keys[j]
@@ -1222,7 +1222,7 @@ func groupServicesByOrder(services []*loadbalance.Service) []orderBucket {
 				swap = true
 			case a != 0 && b == 0:
 				swap = false
-			case a > b:
+			case a < b:
 				swap = true
 			}
 			if swap {
@@ -1231,9 +1231,9 @@ func groupServicesByOrder(services []*loadbalance.Service) []orderBucket {
 		}
 	}
 
-	out := make([]orderBucket, 0, len(keys))
+	out := make([]priorityBucket, 0, len(keys))
 	for _, k := range keys {
-		out = append(out, orderBucket{order: k, services: groups[k]})
+		out = append(out, priorityBucket{priority: k, services: groups[k]})
 	}
 	return out
 }

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -43,6 +43,8 @@ func (tc *Tactic) UnmarshalJSON(data []byte) error {
 		tc.Params = &AdaptiveParams{}
 	case loadbalance.TacticCapacityBased:
 		tc.Params = &CapacityBasedParams{}
+	case loadbalance.TacticPriority:
+		tc.Params = &PriorityParams{}
 	default:
 		return nil
 	}
@@ -114,6 +116,16 @@ func ParseTacticFromMap(tacticType loadbalance.TacticType, params map[string]int
 		}
 	case loadbalance.TacticCapacityBased:
 		tacticParams = DefaultCapacityBasedParams()
+	case loadbalance.TacticPriority:
+		if params != nil {
+			tacticParams = &PriorityParams{
+				WithinOrderTactic: loadbalance.ParseTacticType(
+					getStringParamFromMap(params, "within_order_tactic", "random"),
+				),
+			}
+		} else {
+			tacticParams = DefaultPriorityParams()
+		}
 	default:
 		tacticParams = DefaultAdaptiveParams()
 	}
@@ -913,6 +925,7 @@ func IsValidTactic(tacticStr string) bool {
 		"latency_based": true,
 		"speed_based":   true,
 		"adaptive":      true,
+		"priority":      true,
 	}
 
 	// Convert to lowercase for case-insensitive comparison
@@ -945,6 +958,12 @@ func CreateTacticWithTypedParams(tacticType loadbalance.TacticType, params Tacti
 		return defaultAdaptiveTactic
 	case loadbalance.TacticCapacityBased:
 		return GetCapacityBasedTactic()
+	case loadbalance.TacticPriority:
+		within := loadbalance.TacticRandom
+		if pp, ok := params.(*PriorityParams); ok && pp != nil && pp.WithinOrderTactic != 0 {
+			within = pp.WithinOrderTactic
+		}
+		return NewPriorityTactic(within)
 	}
 	return GetDefaultTactic(tacticType)
 }
@@ -963,6 +982,8 @@ func GetDefaultTactic(tType loadbalance.TacticType) LoadBalancingTactic {
 		return defaultAdaptiveTactic
 	case loadbalance.TacticCapacityBased:
 		return GetCapacityBasedTactic()
+	case loadbalance.TacticPriority:
+		return defaultPriorityTactic
 	default:
 		return defaultAdaptiveTactic
 	}
@@ -973,6 +994,22 @@ type CapacityBasedParams struct{}
 
 // isTacticParams implements TacticParams interface
 func (c CapacityBasedParams) isTacticParams() {}
+
+// PriorityParams holds parameters for the priority/failover tactic.
+// WithinOrderTactic decides how to share load among services that have
+// the same Order (i.e. that are "tied" at a priority tier).
+type PriorityParams struct {
+	WithinOrderTactic loadbalance.TacticType `json:"within_order_tactic"`
+}
+
+func (p PriorityParams) isTacticParams() {}
+
+// DefaultPriorityParams returns the default priority-tactic params.
+// Random within an order tier is a sensible default: it spreads load
+// across equally-prioritised services without requiring extra config.
+func DefaultPriorityParams() TacticParams {
+	return &PriorityParams{WithinOrderTactic: loadbalance.TacticRandom}
+}
 
 // DefaultCapacityBasedParams returns default capacity-based parameters
 func DefaultCapacityBasedParams() TacticParams {
@@ -1059,3 +1096,147 @@ func GetCapacityBasedTactic() *CapacityBasedTactic {
 	}
 	return capacityBasedTactic
 }
+
+// PriorityTactic implements priority/failover load balancing.
+//
+// Services are bucketed by Service.Order (ascending; lower = higher
+// priority). The lowest-order bucket containing at least one service
+// whose circuit breaker permits a request is selected. Within that
+// bucket, the WithinOrderTactic (e.g. random, token-based) chooses the
+// final service. This yields:
+//
+//   - "Direct + fallback" when each service has a distinct Order.
+//   - "Two equivalent services share a tier, with a backup tier below"
+//     when several services share the same Order.
+//
+// Recovery is automatic: every request reconsiders the buckets from the
+// top, so once a higher-priority service's breaker closes the routing
+// returns to it without any extra coordination.
+type PriorityTactic struct {
+	WithinOrderTactic loadbalance.TacticType
+}
+
+// NewPriorityTactic creates a priority tactic with the given sub-tactic
+// used to break ties within an order bucket.
+func NewPriorityTactic(within loadbalance.TacticType) *PriorityTactic {
+	if within == 0 || within == loadbalance.TacticPriority {
+		within = loadbalance.TacticRandom
+	}
+	return &PriorityTactic{WithinOrderTactic: within}
+}
+
+// SelectService returns the highest-priority service whose breaker is
+// closed (or half-open and unclaimed). It returns nil when every active
+// service is currently tripped — callers should surface the original
+// upstream error in that case.
+func (pt *PriorityTactic) SelectService(rule *Rule) *loadbalance.Service {
+	active := rule.GetActiveServices()
+	if len(active) == 0 {
+		return nil
+	}
+
+	// Group by Order, deterministic ascending iteration.
+	buckets := groupServicesByOrder(active)
+
+	// Pick the lowest-order bucket that has at least one breaker-permitted
+	// service. If every bucket is tripped we fall back to the lowest-order
+	// bucket regardless — better to surface a real upstream error than to
+	// reject the request locally.
+	store := loadbalance.DefaultBreakerStore()
+	var fallback []*loadbalance.Service
+	for _, group := range buckets {
+		if fallback == nil {
+			fallback = group.services
+		}
+		allowed := make([]*loadbalance.Service, 0, len(group.services))
+		for _, svc := range group.services {
+			if store.Allow(svc.ServiceID()) {
+				allowed = append(allowed, svc)
+			}
+		}
+		if len(allowed) > 0 {
+			return pt.pickWithinOrder(rule, allowed)
+		}
+	}
+	if len(fallback) > 0 {
+		return pt.pickWithinOrder(rule, fallback)
+	}
+	return active[0]
+}
+
+func (pt *PriorityTactic) pickWithinOrder(rule *Rule, services []*loadbalance.Service) *loadbalance.Service {
+	if len(services) == 1 {
+		return services[0]
+	}
+	// Construct an ephemeral Rule view containing only the bucket's
+	// services so the sub-tactic operates on the right pool.
+	sub := *rule
+	sub.Services = services
+	sub.CurrentServiceID = ""
+	tactic := GetDefaultTactic(pt.WithinOrderTactic)
+	if tactic == nil {
+		return services[0]
+	}
+	if chosen := tactic.SelectService(&sub); chosen != nil {
+		return chosen
+	}
+	return services[0]
+}
+
+func (pt *PriorityTactic) GetName() string {
+	return "Priority"
+}
+
+func (pt *PriorityTactic) GetType() loadbalance.TacticType {
+	return loadbalance.TacticPriority
+}
+
+// orderBucket holds services that share the same Order value.
+type orderBucket struct {
+	order    int
+	services []*loadbalance.Service
+}
+
+// groupServicesByOrder buckets services by their Order field and returns
+// the buckets sorted ascending. Services with Order == 0 are treated as a
+// single "unset" tier; placing them last lets explicit priorities take
+// precedence even when one of the services in a rule was never assigned
+// an order.
+func groupServicesByOrder(services []*loadbalance.Service) []orderBucket {
+	groups := make(map[int][]*loadbalance.Service)
+	for _, svc := range services {
+		groups[svc.Order] = append(groups[svc.Order], svc)
+	}
+
+	keys := make([]int, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	// Ascending, but 0 (unset) sinks to the bottom.
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			a, b := keys[i], keys[j]
+			swap := false
+			switch {
+			case a == 0 && b != 0:
+				swap = true
+			case a != 0 && b == 0:
+				swap = false
+			case a > b:
+				swap = true
+			}
+			if swap {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+
+	out := make([]orderBucket, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, orderBucket{order: k, services: groups[k]})
+	}
+	return out
+}
+
+// Pre-created singleton priority tactic for the default-tactic registry.
+var defaultPriorityTactic = NewPriorityTactic(loadbalance.TacticRandom)


### PR DESCRIPTION
## Summary

First-class **direct + fallback** routing for a rule's services, with an automatic circuit breaker. Set a number on a service node → tried first. Higher number wins. Same number on two services → they share that tier. No tactic-selector UI to learn — the rule's `lb_tactic` flips to `priority` automatically when any service gets a priority.

Full design rationale: `.design/priority-routing.md`.

## What changed

**Backend**
- `Service.Priority int` + new `TacticPriority`. Higher = tried first; 0 = unset (sinks to bottom).
- New three-state circuit breaker (`Closed → Open → HalfOpen`, defaults: 3 fails / 30s open / lazy half-open). Process-wide store keyed by `provider:model`.
- New `PriorityTactic`: groups by priority desc, picks the highest tier with a breaker-allowed service, ties broken by `WithinTierTactic` (default random). All tripped → still returns the top tier so real upstream errors reach the client.
- `ProtocolRecorder.RecordResponse/RecordError` wired to the breaker store. No dispatch hot-path changes.

**Frontend**
- Clickable priority badge on each service node (top-left corner, mirrors `SmartOpNode` index-badge pattern). Unset = white disk + divider border; set = primary fill.
- Default-providers row sorts by priority desc when any are set. Smart-mode default providers get the same UX (same `Rule.Services` list).
- Implicit activation: any `priority > 0` → autosave sets `lb_tactic = priority`. Otherwise prior tactic preserved. `lb_tactic` now round-trips through autosave.

## How it actually takes effect

`POST /rule/:uuid` → `Tactic.UnmarshalJSON` allocates `*PriorityParams` → SQLite. Per request: `LoadBalancer.SelectService` → `rule.LBTactic.Instantiate()` (the single transformation point, `load_balancer.go:92`) → `PriorityTactic.SelectService` → `DefaultBreakerStore.Allow`. Recorder feeds outcomes back into the same store. Pinned by `TestPriorityRouting_EndToEnd`.

## Out of scope (deferred)

- **Single-request mid-flight retry** across services — failed request returns the error; *next* request fails over.
- Streaming pre-first-delta failover, active half-open probing, per-rule breaker thresholds, failover-event UI.

## Test plan

- [x] `go test ./internal/loadbalance/... ./internal/typ/... ./internal/server/...` green
- [x] `pnpm typecheck` / `pnpm build` clean (one pre-existing `SmartRoutingGraph.allowToggleRule` error untouched)
- [ ] Manual: assign priorities (e.g. 10/5), confirm 10 used; trip upstream → fallback; restore → primary returns after ~30s; same in smart-routing mode; click works on the overhanging part of the badge; clear a priority → reverts to prior tactic.

https://claude.ai/code/session_013w8aPPcmhRbLEAAFKSrtnp

---

ref: part of #953 