### PR TITLE
feat(rule, ui): Implement rule-level flag system with catalog UI

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -1,120 +1,103 @@
 # Rule Flags 设计与实操
 
 > 适用对象：tingly-box 后端 / 前端贡献者。
-> 历史回溯：
-> - 2026-05 引入 registry，把原本仅 2 个布尔 flag 的隐藏入口
->   升级为 catalog 化的"路由规则扩展"系统。
-> - 2026-05（后期）把 `max_tokens` 字段重写从 openai.go 直接 mutate
->   上移到 **post-base Transform 链路阶段**，使其在 Anthropic→OpenAI
->   等跨协议路径上也能正确生效。同时新增 `use_max_tokens`（反向重写
->   到旧字段）。
+> 本文档描述**当前**的 rule flag 系统，按"现在是怎样"来读，不是"演变到这里"。
+
+## 历史（仅留索引，不再溯源叙述）
+
+- 2026-05 引入 registry，把原本零散的 2 个布尔 flag 升级为 catalog 化扩展系统。
+- 2026-05 把 `max_tokens` / `max_completion_tokens` 字段重写从 handler 层
+  pre-chain mutation 改为 post-base Transform 链路阶段；新增反向
+  `use_max_tokens`；删除路由图齿轮菜单中的 Cursor 专用入口。
+- 2026-05 将上述 Transform 从 `internal/server/` 迁回 `internal/protocol/transform/`
+  （它只依赖协议层类型）。
 
 ---
 
 ## 1. 为什么需要 rule 级 flag
 
-我们已有的三层语义：
+三层语义：
 
-| 维度 | 粒度 | 例子 | 现状 |
-|------|------|------|------|
-| Provider | provider 实例 | `user_agent`、`api_base`、`proxy_url`、`timeout` | 全局静态生效 |
-| Scenario flags | scenario | `disable_stream_usage` 等 | 跨 rule 共享 |
-| **Rule flags** | **单条 rule** | **`cursor_compat`、`skip_usage`、`use_max_completion_tokens`、`use_max_tokens` …** | **本文档讨论** |
+| 维度 | 粒度 | 例子 |
+|------|------|------|
+| Provider | provider 实例 | `user_agent`、`api_base`、`proxy_url`、`timeout` |
+| Scenario flags | scenario | `disable_stream_usage` 等 |
+| **Rule flags** | **单条 rule** | **`cursor_compat`、`skip_usage`、`use_max_completion_tokens`、`use_max_tokens`、`custom_user_agent` …** |
 
-很多场景介于"provider 通用"和"协议层通用"之间——它们只对**某一类客户端 / 某一类模型 / 某一种调试目的**有意义。把这些行为塞到 Provider 配置里会污染默认值；做成 Scenario flag 又过于粗粒度。Rule flag 是这一类"局部、可选、可叠加的开关"的归宿。
+很多行为只对**某类客户端 / 某类模型 / 某种调试目的**有意义。塞到 Provider
+配置里会污染默认；做成 Scenario flag 又过于粗粒度。Rule flag 是这类
+"局部、可选、可叠加开关"的归宿。
 
 设计原则：
 
-1. **可发现**：UI 必须能列出所有可选 flag 及其语义，而不是让用户照着源码猜 key 名。
-2. **可叠加**：同一条 rule 可同时启用多个 flag，且语义互不依赖。
-3. **可扩展**：新增 flag 只在**一处**注册元数据（`flag_registry.go`），后端行为代码 + 前端 UI 不应硬编码 flag 列表。
-4. **不污染默认**：未启用时必须是 zero-cost no-op，绝不影响其它 rule 的正常路径。
+1. **可发现**：UI 列出所有可选 flag 及其语义。
+2. **可叠加**：同一条 rule 可同时启用多个 flag。
+3. **可扩展**：新 flag 只在**一处**注册元数据（`flag_registry.go`），后端
+   行为代码 + 前端 UI 不应硬编码 flag 列表。
+4. **不污染默认**：未启用时必须是 zero-cost no-op。
 
 ---
 
-## 2. 整体架构图
+## 2. 架构图
 
 ```
-              ┌─────────────────────────────────────────────────────────┐
-              │                       Frontend                           │
-              │  ┌────────────────┐    GET /rule/flags/registry          │
-              │  │ FlagCatalog    │ ◄────────────────────────────┐       │
-              │  │ Dialog         │                              │       │
-              │  └────────┬───────┘                              │       │
-              │           │ Switch / TextField per FlagSpec       │       │
-              │           ▼                                       │       │
-              │  ┌────────────────┐  POST /rule/:uuid (flags={})  │       │
-              │  │ RuleExtensions │ ─────────────────────────┐    │       │
-              │  │ Card (right    │                          │    │       │
-              │  │  of GraphRow)  │                          │    │       │
-              │  └────────────────┘                          │    │       │
-              └──────────────────────────────────────────────┼────┼───────┘
-                                                             │    │
-                                                             ▼    │
-              ┌─────────────────────────────────────────────────┐ │
-              │                    Backend                       │ │
-              │                                                  │ │
-              │  internal/typ/flag_registry.go ──────────────────┤ │
-              │      RuleFlagRegistry() []FlagSpec  ◄────────────┘ │
-              │                                                    │
-              │  internal/typ/type.go                              │
-              │      Rule.Flags = RuleFlags{ … typed fields … }    │
-              │                                                    │
-              │  Persisted as JSON column on the rule row.         │
-              │                                                    │
-              └─────────────────────┬──────────────────────────────┘
+              ┌───────────────────────────────────────────────────┐
+              │                    Frontend                        │
+              │  FlagCatalogDialog  ◄── GET /rule/flags/registry  │
+              │       │                                            │
+              │       ▼ Switch / TextField per FlagSpec            │
+              │  RuleExtensionsCard  ─── POST /rule/:uuid (flags)  │
+              └─────────────────────┬─────────────────────────────┘
+                                    │
+              ┌─────────────────────▼─────────────────────────────┐
+              │                    Backend                          │
+              │                                                     │
+              │  internal/typ/flag_registry.go                      │
+              │      RuleFlagRegistry() []FlagSpec  ◄── 唯一可信源 │
+              │                                                     │
+              │  internal/typ/type.go                               │
+              │      Rule.Flags = RuleFlags{ ...typed fields... }   │
+              │                                                     │
+              │  Persisted as JSON column on the rule row.          │
+              └─────────────────────┬───────────────────────────────┘
                                     │ rule resolved at request time
                                     ▼
-              ┌─────────────────────────────────────────────────────────┐
-              │   inbound handler (openai.go / anthropic_v1.go /         │
-              │                    anthropic_beta.go / openai_responses) │
-              │   ── ruleFlags := resolveRuleFlags(rule)                 │
-              │   ├─ WithCustomUserAgent(ctx, ruleFlags.UA)              │ ← context-passed
-              │   ├─ reqCtx.Extra["skip_usage"] = …                      │ ← downstream hint
-              │   ├─ (existing) applyCursorCompatFlag(extra hint)        │ ← pre-chain marker
-              │   └─ extras := ruleExtraTransforms(rule)                 │ ← post-base stages
-              │       → [OpenAIMaxTokensRewriteTransform{Use…, Use…}]    │
-              └─────────────────────┬───────────────────────────────────┘
-                                    │
-                                    ▼
-              ┌─────────────────────────────────────────────────────────┐
-              │   transformXxxx(..., extras...) :                        │
-              │     chain := BuildTransformChain(...)                    │
-              │     for _, t := range extras { chain.Add(t) }            │
-              │     chain.Execute(ctx)                                   │
-              │                                                          │
-              │     ┌───────────────────────────────────────────────┐    │
-              │     │ Base  →  MCP  →  Consistency  →  Vendor       │    │
-              │     │                                          │    │    │
-              │     │                                          ▼    │    │
-              │     │                          OpenAIMaxTokensRewrite│   │
-              │     │                          (type-switches on    │    │
-              │     │                           *openai.ChatCompletion;   │
-              │     │                           delegates to ops.*)│    │
-              │     └───────────────────────────────────────────────┘    │
-              └─────────────────────┬───────────────────────────────────┘
-                                    │
-                ┌───────────────────┼───────────────────┐
-                ▼                   ▼                   ▼
-          request mutation     transport chain      response mutation
-         (chain stage:        (UA injection via    (skip_usage strips
-          field rewrite;       customUA RT)         `usage` field in
-          cursor norm.)                              stream + nonstream)
-                                    │
-                                    ▼
-                              upstream provider
+   ┌───────────────────────────────────────────────────────────────┐
+   │  inbound handler (openai.go / openai_responses.go /            │
+   │                   anthropic_v1.go / anthropic_beta.go)         │
+   │                                                                │
+   │   flags := resolveRuleFlags(rule)                              │
+   │   ├─ WithCustomUserAgent(ctx, flags.CustomUserAgent)           │  Type 2
+   │   ├─ reqCtx.Extra["skip_usage"] = flags.SkipUsage              │  Type 3
+   │   ├─ applyCursorCompatFlag(req, cursorCompat)                  │  Type 1a
+   │   └─ extras := ruleExtraTransforms(flags)                      │  Type 1b
+   │       → [transform.OpenAIMaxTokensRewriteTransform{...}]       │
+   └───────────────────────────┬───────────────────────────────────┘
+                               │
+                               ▼
+   ┌───────────────────────────────────────────────────────────────┐
+   │   transformXxxx(..., extras...) :                              │
+   │     chain := BuildTransformChain(...)                          │
+   │     appendExtraTransforms(chain, extras)                       │
+   │     chain.Execute(ctx)                                         │
+   │                                                                │
+   │     Base  →  MCP  →  Consistency  →  Vendor  →  extras         │
+   │                                              (post-base stages)│
+   └───────────────────────────┬───────────────────────────────────┘
+                               ▼
+                       upstream provider
 ```
 
 ---
 
-## 3. Flag Registry：唯一可信源
+## 3. Flag Registry — 唯一可信源
 
 ```go
 // internal/typ/flag_registry.go
 type FlagSpec struct {
     Key         string        // 与 RuleFlags 上的 json tag 完全对应
     Label       string        // UI 展示用人话
-    Description string        // 鼠标 hover 详细说明
+    Description string        // hover 详细说明
     Type        FlagValueType // bool | string
     Category    FlagCategory  // compatibility | request | response
     Placeholder string        // string 类型的输入框 hint
@@ -123,109 +106,123 @@ type FlagSpec struct {
 func RuleFlagRegistry() []FlagSpec { … }
 ```
 
-**约束** (`flag_registry_test.go` 强制)：
+**约束**（`flag_registry_test.go` 强制）：
 
-- 每个 `FlagSpec.Key` **必须**对应 `RuleFlags` struct 上的某个 json tag——这条测试可以挡住"加了 spec 忘了加字段"或反过来。
+- 每个 `FlagSpec.Key` **必须**对应 `RuleFlags` struct 上的某个 json
+  tag。这条测试挡住"加了 spec 忘了加字段"或反过来。
 - `Label` / `Description` 非空。
 - `Type` 必须在已知枚举内。
 
 ---
 
-## 4. 当前已注册 flag 一览
+## 4. 当前已注册 flag
 
 | Key | Type | 类别 | 作用 | 注入点 |
 |-----|------|------|------|--------|
-| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + 工具门控 + stream usage 抑制 | `cursor_compat.go`（pre-chain，配合 ops 同步执行）|
+| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + 工具门控 + stream usage 抑制 | `cursor_compat.go`（Type 1a，pre-chain mutation）|
 | `cursor_compat_auto` | bool | compatibility | 通过请求头识别 Cursor，自动启用 cursor_compat | `cursor_compat.go::resolveCursorCompat` |
-| `skip_usage` | bool | response | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)` |
-| `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite` |
-| `use_max_tokens` | bool | request | 反向重写：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| `OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxTokensRewrite` |
-| `custom_user_agent` | string | request | 覆盖出站 User-Agent header | `customUserAgentTransport` + `WithCustomUserAgent(ctx, …)` |
+| `skip_usage` | bool | response | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)`（Type 3）|
+| `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `transform.OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite`（Type 1b）|
+| `use_max_tokens` | bool | request | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b）|
+| `custom_user_agent` | string | request | 覆盖出站 User-Agent header | `customUserAgentTransport` + `WithCustomUserAgent(ctx, ...)`（Type 2）|
 
 ---
 
-## 5. 三种 flag 的注入手法
+## 5. 四种 flag 注入手法
 
 ```
-┌────────────────────────┐
-│       Request body     │   ← Type 1: 改 request struct，按时机分两小类
-│                        │      1a. pre-chain：handler 入口直接 mutate
-│                        │          inbound 请求（如 cursor 内容归一化标记）
-│                        │      1b. post-base Transform：作为链路阶段，
-│                        │          在 BaseTransform 完成协议转换之后运行
-│                        │          （如 max_tokens 字段重写）
-└────────────────────────┘
+Type 1a  Request body, pre-chain mutation
+         在 handler 入口直接 mutate inbound 请求或往 ExtraFields 写
+         hint。例：cursor_compat 在 openai.go 入口写
+         __tb_cursor_compat=true。
 
-┌────────────────────────┐
-│   Per-request context  │   ← Type 2: 通过 context 把"hint"带到深层组件
-│  (e.g. custom UA)       │     调用位置：handler 把 c.Request 的 ctx 替换
-└────────────────────────┘     消费位置：transport / round-tripper
+Type 1b  Request body, post-base Transform（推荐）
+         作为 Transform 接口的实现挂在 chain 中，在 BaseTransform 完
+         成协议转换之后运行；type-switch 决定是否对当前 request 形态
+         生效。例：OpenAIMaxTokensRewriteTransform。
 
-┌────────────────────────┐
-│  Response post-process │   ← Type 3: 在响应返回前剥/改字段
-│  (e.g. skip_usage)      │     调用位置：protocol_dispatch.go 的派发分支
-└────────────────────────┘     形态：shouldStripUsage(extra) 统一判定
+Type 2   Per-request context hint
+         handler 把 c.Request 的 ctx 替换成带 hint 的；transport /
+         round-tripper 等深层组件读 ctx。例：custom_user_agent。
+
+Type 3   Response post-processing
+         handler 把 flag 写进 reqCtx.Extra；protocol_dispatch.go 的派
+         发分支用 shouldStripUsage 这类统一判定来决定剥/改字段。
+         例：skip_usage。
 ```
 
-任何新 flag 都应归入这三类之一；如果有第四类，先在 PR 描述里说明。
+任何新 flag 都应归入这四类之一。
 
-### 5.1 ops vs Transform — Type 1 内部的分层
+---
 
-`internal/protocol/transform/ops/` 与 `internal/protocol/transform/`
-（含 `internal/server/transform_*.go` 中 server-domain 相关者）承担不同职责：
+## 6. op vs Transform —— Type 1b 内部的分层
+
+Type 1b（post-base Transform）涉及两层抽象，**职责必须分开**：
 
 | 层 | 位置 | 职责 | 例子 |
 |----|------|------|------|
-| **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数，对某个具体 request 类型做无副作用的字段改写。不感知链路、不感知 rule。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)` |
-| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口，按 `ctx.Request` 实际类型决定是否调 op；构造期接受配置参数。仅依赖协议层 / SDK 类型。 | `transform.OpenAIMaxTokensRewriteTransform`（构造期接受 `UseMaxCompletionTokens`、`UseMaxTokens` 两个 bool） |
-| **Transform（链路阶段，server-domain）** | `internal/server/transform_*.go` | 实现 `Transform` 接口，但需要 server-domain 类型（如 `*typ.ScenarioConfig`）。 | `ThinkingModeTransform`、`MaxTokensTransform`（Anthropic 上限）、`CleanHeaderTransform` |
+| **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数。对某个具体 request 类型做无副作用的字段改写。**不感知链路、不感知 rule、不感知 ctx**。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)` |
+| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口。构造期接受配置；`Apply()` 里 type-switch `ctx.Request`，匹配目标类型时调 op。**仅依赖协议层 / SDK 类型**。 | `transform.OpenAIMaxTokensRewriteTransform`（接受 `UseMaxCompletionTokens`、`UseMaxTokens` 两个 bool）|
+| **Transform（链路阶段，server-domain）** | `internal/server/transform_*.go` | 同 Transform 接口，但需要 server-domain 类型（如 `*typ.ScenarioConfig`）。 | `ThinkingModeTransform`、`MaxTokensTransform`（Anthropic 上限）、`CleanHeaderTransform` |
 
 **为什么必须分两层？**
 
 - `BaseTransform` 负责跨协议转换（Anthropic ↔ OpenAI / Responses /
   Google）。如果在链外直接改 inbound 请求，遇到 "Anthropic inbound →
   OpenAI Chat target" 的路径，改的还是 Anthropic 形态，rewrite 在
-  Base 转换之后就丢失了。
+  Base 转换之后就丢失。
 - 把 rewrite 包成一个 Transform 并加在 Base **之后**，它看见的是已经
-  转换好的 `*openai.ChatCompletionNewParams`，无论 inbound 是什么形态
-  都能命中——这就是为什么 `use_max_completion_tokens` / `use_max_tokens`
-  在 4 个 handler 路径上都能生效。
+  转换好的 `*openai.ChatCompletionNewParams`——无论 inbound 是什么形
+  态，目标是 OpenAI Chat 时就能命中。
+- op 是纯函数：可以独立单测（含 wire 序列化）、可以被多个 Transform
+  复用、可以被多端调用而不被 chain 绑死。
 
-### 5.2 链路位置与 wiring
+**为什么再分协议层 vs server-domain？**
+
+- 协议层 Transform 只依赖 SDK 类型，可以放在 `protocol/transform/`，与
+  `BaseTransform`、`ConsistencyTransform`、`VendorTransform` 同包。
+- 一旦 Transform 需要读 `*typ.ScenarioConfig`、`*typ.Rule` 等 server
+  类型，就放到 `internal/server/transform_*.go`，避免反向依赖。
+
+---
+
+## 7. 链路 wiring
 
 ```
 handler                         transformXxxx                       chain
   │                                  │                                │
+  │ flags := resolveRuleFlags(rule)  │                                │
   │ extras := ruleExtraTransforms(   │                                │
-  │             rule)                │                                │
+  │             flags)               │                                │
   │  (e.g. [OpenAIMaxTokensRewrite]) │                                │
   ├──────── extras... ──────────────►│                                │
   │                                  │  chain := BuildTransformChain  │
   │                                  │           (...)                │
   │                                  ├──────────────────────────────►│
-  │                                  │  for _, t := range extras {    │
-  │                                  │      chain.Add(t)              │
-  │                                  │  }                             │
+  │                                  │  appendExtraTransforms(        │
+  │                                  │      chain, extraTransforms)   │
   │                                  │  chain.Execute(ctx)            │
   │                                  ├──────────────────────────────►│
 ```
 
-- `BuildTransformChain` 故意不感知 rule flag——它的输入仍只有 scenario
-  / provider / recording。把"哪些 rule-extra transform 要追加"这件事
-  留给 handler 层，handler 通过新增的 variadic `extraTransforms
-  ...transform.Transform` 把列表传给 `transformAnthropicV1` /
-  `transformAnthropicBeta` / `transformOpenAIChat` /
-  `transformOpenAIResponses`。每个 `transformXxxx` 拿到 `chain` 后用
-  `chain.Add()` 追加 extra，再 `Execute`。
-- `ruleExtraTransforms(rule)`（位于 `internal/server/rule_flags.go`）
-  是这条链路的唯一聚合点；今后再有新的 rule-driven Transform 也都
-  挂到这里返回，handler 不需要再加新的调用。
+关键约束：
+
+- `BuildTransformChain` 不感知 rule flag。它的输入是 scenario / provider
+  / recording——把哪些 rule-extra Transform 要追加的决策留给 handler。
+- 所有 4 个 `transformXxxx`（`transformAnthropicV1`、
+  `transformAnthropicBeta`、`transformOpenAIChat`、
+  `transformOpenAIResponses`）都接受 variadic
+  `extraTransforms ...transform.Transform`，并用
+  `appendExtraTransforms(chain, extras)` 把它们追加到 chain 末尾。
+- `ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform`
+  （`internal/server/rule_flags.go`）是 rule→Transform 的唯一聚合点。新
+  增 rule-driven Transform 都在这里追加返回值，handler 端不需要再加调用。
 
 ---
 
-## 6. UA 链层 — 实操中最容易踩坑的部分
+## 8. UA 链层 — 实操中最易踩坑的部分
 
-User-Agent 优先级：
+User-Agent 优先级（每一层都是"set then delegate"，**innermost wins**）：
 
 ```
    ┌────────────────────────────────────┐
@@ -242,21 +239,21 @@ User-Agent 优先级：
    └────────────────────────────────────┘
 ```
 
-> **innermost wins**：每一层都是"set then delegate"——内层是最后写 header
-> 的人，所以最贴近 wire 的那层决定最终 UA。
-
 最终结果：
 
-| 场景 | rule UA | provider UA | vendor 硬编码 | 实际发出的 UA |
-|------|---------|-------------|--------------|--------------|
+| 场景 | rule UA | provider UA | vendor 硬编码 | 实际发出 |
+|------|---------|-------------|--------------|---------|
 | 默认 | 空 | 空 | claude-cli/… | claude-cli/… |
 | Provider 配了 | 空 | "MyOrg/1.0" | claude-cli/… | MyOrg/1.0 |
 | Rule 配了 | "Bench/1" | "MyOrg/1.0" | claude-cli/… | Bench/1 |
 | Rule 配了 | "Bench/1" | 空 | — | Bench/1 |
 
-⚠️ **重要**：`provider.UserAgent` 一旦设置就会覆盖 vendor 硬编码——这是**有意为之**的调试通道（详见 `ai/provider.go` 上该字段的 doc comment）。Claude Code OAuth 等端点对 UA 有真实校验，错配会让 OAuth 直接被拒；操作员设置该字段时要清楚自己在干嘛。
+⚠️ `provider.UserAgent` 一旦设置就会覆盖 vendor 硬编码——这是**有意为之**
+的调试通道（见 `ai/provider.go` 该字段的 doc comment）。Claude Code OAuth
+等端点对 UA 有真实校验，错配会让 OAuth 直接被拒；设置该字段时要清楚自己
+在干嘛。
 
-并非所有 client 都接入这条链。当前只有：
+并非所有 client 都接入这条链：
 
 | Client | Provider UA | Rule UA |
 |--------|-------------|---------|
@@ -265,11 +262,13 @@ User-Agent 优先级：
 | Claude Code OAuth (`claudeRoundTripper`) | ✅ | ❌ |
 | Codex / Gemini / Google | ✅ | ❌ |
 
-vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握手协议绑定，rule 级覆盖反而会破坏 vendor 校验。这条边界写进了 `flag_registry.go` 中 `custom_user_agent` 的 description 里。
+vendor-specialized 路径不接 rule UA：它们 UA 跟整个 OAuth/握手协议绑
+定，rule 级覆盖反而会破坏 vendor 校验。这条边界写进了
+`flag_registry.go` 中 `custom_user_agent` 的 description 里。
 
 ---
 
-## 7. 前端 UI 设计
+## 9. 前端 UI
 
 ### 卡片位置
 
@@ -288,34 +287,45 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
 
 关键 CSS 决策：
 
-- 外层 `display: flex`，graph 在 `flexGrow:1, minWidth:0` 的 box 里启用 `overflowX:auto`；`minWidth:0` 是让 flex item 能收缩到内容宽以下的关键，否则会把 Extensions 推出视口。
-- Extensions Card `flexShrink:0`，所以滚动条出现时它**不缩**。
-- Card 高度 = `PROVIDER_NODE_STYLES.height`（72px），视觉与 provider 行对齐；内容溢出时 card 内 `overflowY:auto`。
+- 外层 `display: flex`，graph 在 `flexGrow:1, minWidth:0` 的 box 里启用
+  `overflowX:auto`；`minWidth:0` 是让 flex item 能收缩到内容宽以下的关
+  键，否则会把 Extensions 推出视口。
+- Extensions Card `flexShrink:0`——滚动条出现时它**不缩**。
+- Card 高度 = `PROVIDER_NODE_STYLES.height`（72px），视觉与 provider 行对
+  齐；内容溢出时 card 内 `overflowY:auto`。
 
 ### Catalog 弹窗
 
-按 `FlagSpec.Category` 分组（compatibility / request / response）。每个 flag：
+按 `FlagSpec.Category` 分组（compatibility / request / response）。每个
+flag：
 
 - `type: bool` → 一个 `Switch`。
-- `type: string` → `Switch`（占位，未来可改成独立 enable 控制）+ `TextField`。当前空字符串视为未启用。
+- `type: string` → `Switch`（占位，未来可改成独立 enable 控制）+
+  `TextField`。当前空字符串视为未启用。
 - 已启用的 flag 在边框 / 背景上有高亮。
+
+### 路由图齿轮菜单
+
+齿轮菜单只保留通用项（Test Probe、Export、Activate/Deactivate、Edit
+flag、Delete）。**Cursor 专用菜单项已删除**——所有 flag 都通过右侧
+Extensions Card 操作。
 
 ---
 
-## 8. 新增一个 flag — 操作手册
+## 10. 新增一个 flag — 操作手册
 
-按以下顺序走，**勿乱序**，否则前端会因 parser/reducer 缺分支而 cast 失败：
+按以下顺序，**勿乱序**：
 
 ```
 1. internal/typ/type.go
    ├─ 给 RuleFlags struct 加一个字段（snake_case json tag）
-   └─ 注意 yaml tag 与 json 保持一致
+   └─ yaml tag 与 json 保持一致
 
 2. internal/typ/flag_registry.go
-   └─ 在 RuleFlagRegistry() 返回值里追加一个 FlagSpec，
+   └─ 在 RuleFlagRegistry() 追加一个 FlagSpec，
       key 必须与上一步的 json tag 一字不差
 
-3. 选定 §5 中的注入类型：
+3. 选定 §5 的注入类型，落地行为：
 
    ┌─────────────────────────────────────────────────────────────┐
    │ Type 1a (pre-chain 请求 mutation)                            │
@@ -324,37 +334,36 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
    │ Type 1b (post-base Transform — 推荐)                         │
    │   ① internal/protocol/transform/ops/<xxx>.go：写 op 原语，    │
    │      签名形如 ApplyXxx(*openai.ChatCompletionNewParams) 或    │
-   │      其他具体 request 类型。op 必须是纯函数、无 rule 感知。   │
+   │      其他具体 request 类型。op 必须纯函数、无 rule 感知。     │
    │   ② internal/protocol/transform/<xxx>.go：写 Transform，      │
-   │      构造期接受 rule flag bool，Apply() 里 type-switch        │
-   │      ctx.Request，匹配目标类型时调 op。仅依赖协议层类型；     │
-   │      如需 server-domain 类型，才放到 internal/server/。       │
+   │      构造期接受配置，Apply() 里 type-switch ctx.Request，     │
+   │      匹配目标类型时调 op。如需 server-domain 类型才放到       │
+   │      internal/server/ 下。                                    │
    │   ③ internal/server/rule_flags.go::ruleExtraTransforms：     │
-   │      根据 flag 决定是否 append 新 Transform 到 extras 切片。  │
-   │   ④ 4 个 handler 入口不需要再改，他们都已经传                  │
-   │      ruleExtraTransforms(resolveRuleFlags(rule))... 给        │
-   │      transformXxxx。                                          │
+   │      根据 flag 决定是否 append 新 Transform。                 │
+   │   ④ handler 端无需改动——4 个 handler 都已调                  │
+   │      ruleExtraTransforms(resolveRuleFlags(rule))...           │
    │                                                              │
    │ Type 2 (context-passed hint)                                 │
    │   ① 在 internal/typ/id.go 加 contextKey + 一对                │
-   │      WithXxx/GetXxx helper。                                  │
-   │   ② handler 入口 c.Request = c.Request.WithContext(WithXxx)。  │
-   │   ③ 消费方（如 transport / round-tripper）读 GetXxx。         │
+   │      WithXxx / GetXxx helper。                                │
+   │   ② handler 入口 c.Request = c.Request.WithContext(WithXxx)。 │
+   │   ③ 消费方（transport / round-tripper）读 GetXxx。            │
    │                                                              │
    │ Type 3 (response 后置加工)                                    │
    │   ① handler 把 flag 值写进 reqCtx.Extra。                    │
-   │   ② internal/server/protocol_dispatch.go：在派发分支调用       │
+   │   ② internal/server/protocol_dispatch.go：在派发分支调用      │
    │      shouldStripUsage(...) 这类聚合判定。                     │
    └─────────────────────────────────────────────────────────────┘
 
 4. 测试位置随注入类型走：
    ├─ op 单元测试 → 与 op 同包 (`internal/protocol/transform/ops/`)
-   ├─ Transform 行为测试 → 与 Transform 同包 (`internal/server/`)
+   ├─ Transform 行为测试 → 与 Transform 同包
    │     必备 case：在目标 request 类型上启用 / 在其他类型上 no-op /
    │              chain 中跟一个 stub BaseTransform，验证 post-base
-   │              生效（前述 max_tokens 即此模式）。
+   │              形态生效（这是 max_tokens 的回归测试模式）。
    └─ wire 序列化测试（仅对改字段名的 op 有意义）：marshal 前后断言
-       JSON 顶层 key 是否出现/消失，挡 SDK omitzero tag 失效。
+       JSON 顶层 key 出现/消失，挡 SDK omitzero tag 失效。
 
 5. frontend/src/components/RoutingGraphTypes.ts
    ├─ RuleFlags 接口加 camelCase 字段
@@ -374,41 +383,47 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
 9. frontend/src/components/rule-card/useRuleCardHooks.ts
    └─ autoSave 的 flags 序列化：camelCase → snake_case payload
 
-10. (可选) 重新跑 frontend `npm run gen:api`（CLAUDE.md 约定）
+10. (可选) 重跑 frontend `npm run gen:api`（CLAUDE.md 约定）
 ```
 
-测试 `TestRuleFlagRegistry_KeysMatchStructFields` 会在第 1、2 步任一步漏改时立即红，是这条链路最稳的安全网。
+`TestRuleFlagRegistry_KeysMatchStructFields` 会在第 1、2 步任一步漏改
+时立即红——这是链路最稳的安全网。
 
 ---
 
-## 9. 设计取舍
+## 11. 设计取舍
 
 | 选项 | 已采纳 | 备择 | 取舍理由 |
 |------|--------|------|----------|
-| `RuleFlags` 用 typed struct 还是 `map[string]any` | typed struct | map | 编译期检查；JSON 兼容性靠 `omitempty` 与零值 |
-| Registry 由后端 owner | ✅ | 前端硬编码 + 后端硬编码两边对 | 单一可信源，新加 flag 只动一处元数据 |
-| 卡片放路由图内 vs. 路由图外（固定右侧） | 固定右侧 | 卡片随路由图滚动 | flag 是 rule 级而非 provider 级，常驻可见更符合心智模型 |
+| `RuleFlags` 用 typed struct vs `map[string]any` | typed struct | map | 编译期检查；JSON 兼容性靠 `omitempty` 与零值 |
+| Registry 由后端 owner | ✅ | 前端硬编码 + 后端硬编码两边对 | 单一可信源，新 flag 只动一处元数据 |
+| 卡片放路由图内 vs 固定右侧 | 固定右侧 | 卡片随路由图滚动 | flag 是 rule 级而非 provider 级，常驻可见更符合心智模型 |
 | string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
-| UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约用法 |
-| 请求字段重写：handler 直接 mutate vs. post-base Transform | post-base Transform | handler 链外直改 | 链外直改会在 Anthropic→OpenAI 等跨协议路径上失效；Transform 在 Base 之后看见的是最终形态，所有 inbound 类型都能命中 |
-| op vs Transform 是否合并成一类 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（无 rule 感知、可直接被多处复用、易于做 wire 序列化测试）；Transform 才感知 rule 与链路位置。混在一起会让原语难复用、测试难写 |
-| `BuildTransformChain` 是否感知 rule | 否 | 把 ruleFlags 作为参数传入 | 让 chain builder 只懂 scenario/provider/recording；rule 级关心点放在 handler，并通过 `extraTransforms ...transform.Transform` variadic 注入。signature 加 variadic 是 additive 改动 |
-| 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Extensions 卡片 | Extensions 卡片已经能覆盖 cursor_compat / cursor_compat_auto；两套入口对同一字段语义会引发混淆 |
+| UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约 |
+| 请求字段重写：handler pre-chain mutate vs post-base Transform | post-base Transform | handler 链外直改 | 链外直改在跨协议路径（Anthropic→OpenAI）失效；Transform 在 Base 之后看到的是最终形态，所有 inbound 类型都能命中 |
+| op vs Transform 是否合并 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（可独立测、可复用、可多端调用）；Transform 才感知 rule 与链路位置。合并会让原语难复用 |
+| Transform 放协议层包 vs server 包 | 视依赖而定 | 全部塞 server | 只依赖 SDK / 协议类型的放 `internal/protocol/transform/`；需要 server-domain 类型的放 `internal/server/`。避免反向依赖 |
+| `BuildTransformChain` 是否感知 rule | 否 | 把 ruleFlags 传入 | chain builder 只懂 scenario/provider/recording；rule 级关心点放在 handler，通过 `extraTransforms ...transform.Transform` variadic 注入 |
+| 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Extensions 卡片 | 两套入口对同一字段会引发混淆 |
 
 ---
 
-## 10. 当前未做 / 后续可做
+## 12. 未做 / 后续可做
 
-- **UI**：string flag 加独立 enable Switch（让"空"与"未启用"可区分）。
-- **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时会拥挤）。
-- **后端**：`cursor_compat` 内容归一化目前仍走 §5 Type 1a（pre-chain，
-  在 `openai.go` 入口直接调 `ops.ApplyCursorCompatContentNormalization`）。
-  长期看可以把它也包成一个 post-base Transform，让 inbound 是 Anthropic
-  时也能在 Base 转换后正确生效——但与 `max_tokens` 不同，cursor 归一化
-  只对 OpenAI 入站才有意义（其它入站不会经过 Cursor 客户端），所以优先
-  级不高。
-- **后端**：`internal/client/openai.go` 通用 OpenAI client 用 `http.DefaultTransport` 而非 `createSessionBoundTransport`，导致它**没有**走 transport pool / session 隔离——这是个独立问题，不在 rule flag 范畴，但补齐时记得保留 §6 的两层 UA 包装顺序。
-- **后端**：长期看，部分 ScenarioFlags 可以下沉成 rule flag（例如 `disable_stream_usage` 已与 `skip_usage` 高度重叠），等业务确认后做一次合并。
-- **测试**：当前测试覆盖 helper / Transform / op / wire 序列化共 4 层，
-  但缺一个 "rule 配了 skip_usage → 真实 HTTP 响应里没有 usage" 的端到
-  端 case；待 mock provider fixture 成熟后补。
+- **UI**：string flag 加独立 enable Switch，让"空"与"未启用"可区分。
+- **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时
+  会拥挤）。
+- **后端**：`cursor_compat` 内容归一化目前是 Type 1a（pre-chain，在
+  `openai.go` 入口直接调 `ops.ApplyCursorCompatContentNormalization`）。
+  长期看可以包成 post-base Transform，让 inbound 是 Anthropic 时也能
+  在 Base 转换后正确生效——但与 `max_tokens` 不同，cursor 归一化只对
+  OpenAI 入站才有意义，优先级不高。
+- **后端**：`internal/client/openai.go` 通用 OpenAI client 用
+  `http.DefaultTransport` 而非 `createSessionBoundTransport`，没有走
+  transport pool / session 隔离——独立问题，不在 rule flag 范畴，但
+  补齐时记得保留 §8 的两层 UA 包装顺序。
+- **后端**：部分 ScenarioFlags 可下沉成 rule flag（例如
+  `disable_stream_usage` 已与 `skip_usage` 高度重叠）。
+- **测试**：当前覆盖 op / Transform / handler helper / wire 序列化四
+  层，缺一个 "rule 配了 skip_usage → 真实 HTTP 响应里没有 usage" 的端
+  到端 case，待 mock provider fixture 成熟后补。

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -1,0 +1,288 @@
+# Rule Flags 设计与实操
+
+> 适用对象：tingly-box 后端 / 前端贡献者。
+> 历史回溯：2026-05 引入 registry，把原本仅 2 个布尔 flag 的隐藏入口
+> 升级为 catalog 化的"路由规则扩展"系统。
+
+---
+
+## 1. 为什么需要 rule 级 flag
+
+我们已有的三层语义：
+
+| 维度 | 粒度 | 例子 | 现状 |
+|------|------|------|------|
+| Provider | provider 实例 | `user_agent`、`api_base`、`proxy_url`、`timeout` | 全局静态生效 |
+| Scenario flags | scenario | `disable_stream_usage` 等 | 跨 rule 共享 |
+| **Rule flags** | **单条 rule** | **`cursor_compat`、`skip_usage`、`use_max_completion_tokens` …** | **本文档讨论** |
+
+很多场景介于"provider 通用"和"协议层通用"之间——它们只对**某一类客户端 / 某一类模型 / 某一种调试目的**有意义。把这些行为塞到 Provider 配置里会污染默认值；做成 Scenario flag 又过于粗粒度。Rule flag 是这一类"局部、可选、可叠加的开关"的归宿。
+
+设计原则：
+
+1. **可发现**：UI 必须能列出所有可选 flag 及其语义，而不是让用户照着源码猜 key 名。
+2. **可叠加**：同一条 rule 可同时启用多个 flag，且语义互不依赖。
+3. **可扩展**：新增 flag 只在**一处**注册元数据（`flag_registry.go`），后端行为代码 + 前端 UI 不应硬编码 flag 列表。
+4. **不污染默认**：未启用时必须是 zero-cost no-op，绝不影响其它 rule 的正常路径。
+
+---
+
+## 2. 整体架构图
+
+```
+              ┌─────────────────────────────────────────────────────────┐
+              │                       Frontend                           │
+              │  ┌────────────────┐    GET /rule/flags/registry          │
+              │  │ FlagCatalog    │ ◄────────────────────────────┐       │
+              │  │ Dialog         │                              │       │
+              │  └────────┬───────┘                              │       │
+              │           │ Switch / TextField per FlagSpec       │       │
+              │           ▼                                       │       │
+              │  ┌────────────────┐  POST /rule/:uuid (flags={})  │       │
+              │  │ RuleExtensions │ ─────────────────────────┐    │       │
+              │  │ Card (right    │                          │    │       │
+              │  │  of GraphRow)  │                          │    │       │
+              │  └────────────────┘                          │    │       │
+              └──────────────────────────────────────────────┼────┼───────┘
+                                                             │    │
+                                                             ▼    │
+              ┌─────────────────────────────────────────────────┐ │
+              │                    Backend                       │ │
+              │                                                  │ │
+              │  internal/typ/flag_registry.go ──────────────────┤ │
+              │      RuleFlagRegistry() []FlagSpec  ◄────────────┘ │
+              │                                                    │
+              │  internal/typ/type.go                              │
+              │      Rule.Flags = RuleFlags{ … typed fields … }    │
+              │                                                    │
+              │  Persisted as JSON column on the rule row.         │
+              │                                                    │
+              └─────────────────────┬──────────────────────────────┘
+                                    │ rule resolved at request time
+                                    ▼
+              ┌─────────────────────────────────────────────────────┐
+              │   internal/server/openai.go : OpenAIChatCompletion   │
+              │   ── ruleFlags := resolveRuleFlags(rule)             │
+              │   ├─ applyMaxCompletionTokensRewrite(&req)           │ ← request mutation
+              │   ├─ WithCustomUserAgent(ctx, ruleFlags.UA)          │ ← context-passed
+              │   ├─ reqCtx.Extra["skip_usage"] = …                  │ ← downstream hint
+              │   └─ (existing) applyCursorCompatFlag                │
+              └─────────────────────┬───────────────────────────────┘
+                                    │
+                ┌───────────────────┼───────────────────┐
+                ▼                   ▼                   ▼
+          request mutation     transport chain      response mutation
+        (max_tokens rewrite,  (UA injection via   (skip_usage strips
+         cursor norm. etc.)    customUA RT)        `usage` field in
+                                                   stream + nonstream)
+                                    │
+                                    ▼
+                              upstream provider
+```
+
+---
+
+## 3. Flag Registry：唯一可信源
+
+```go
+// internal/typ/flag_registry.go
+type FlagSpec struct {
+    Key         string        // 与 RuleFlags 上的 json tag 完全对应
+    Label       string        // UI 展示用人话
+    Description string        // 鼠标 hover 详细说明
+    Type        FlagValueType // bool | string
+    Category    FlagCategory  // compatibility | request | response
+    Placeholder string        // string 类型的输入框 hint
+}
+
+func RuleFlagRegistry() []FlagSpec { … }
+```
+
+**约束** (`flag_registry_test.go` 强制)：
+
+- 每个 `FlagSpec.Key` **必须**对应 `RuleFlags` struct 上的某个 json tag——这条测试可以挡住"加了 spec 忘了加字段"或反过来。
+- `Label` / `Description` 非空。
+- `Type` 必须在已知枚举内。
+
+---
+
+## 4. 当前已注册 flag 一览
+
+| Key | Type | 类别 | 作用 | 注入点 |
+|-----|------|------|------|--------|
+| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + 工具门控 + stream usage 抑制 | `cursor_compat.go` |
+| `cursor_compat_auto` | bool | compatibility | 通过请求头识别 Cursor，自动启用 cursor_compat | `cursor_compat.go::resolveCursorCompat` |
+| `skip_usage` | bool | response | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)` |
+| `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `applyMaxCompletionTokensRewrite` |
+| `custom_user_agent` | string | request | 覆盖出站 User-Agent header | `customUserAgentTransport` + `WithCustomUserAgent(ctx, …)` |
+
+---
+
+## 5. 三种 flag 的注入手法
+
+```
+┌────────────────────────┐
+│       Request body     │   ← Type 1: 直接改 request struct
+│   (e.g. max_completion │     调用位置：openai.go 在 transform 链之前
+│    _tokens 重写)        │     函数形态：applyXxx(&req)
+└────────────────────────┘
+
+┌────────────────────────┐
+│   Per-request context  │   ← Type 2: 通过 context 把"hint"带到深层组件
+│  (e.g. custom UA)       │     调用位置：openai.go 把 c.Request 的 ctx 替换
+└────────────────────────┘     消费位置：transport / round-tripper
+
+┌────────────────────────┐
+│  Response post-process │   ← Type 3: 在响应返回前剥/改字段
+│  (e.g. skip_usage)      │     调用位置：protocol_dispatch.go 的派发分支
+└────────────────────────┘     形态：shouldStripUsage(extra) 统一判定
+```
+
+任何新 flag 都应归入这三类之一；如果有第四类，先在 PR 描述里说明。
+
+---
+
+## 6. UA 链层 — 实操中最容易踩坑的部分
+
+User-Agent 优先级：
+
+```
+   ┌────────────────────────────────────┐
+   │  outer adapter (e.g. claudeRT)     │ ← vendor 硬编码 UA，先 set
+   │     │  set "claude-cli/2.1.86"     │
+   │     ▼ delegates to                 │
+   │  wrapWithUserAgent(provider)       │ ← provider.UserAgent（调试 override）
+   │     │  if non-empty: set provider  │   非空时覆盖 vendor 硬编码
+   │     ▼                              │
+   │  customUserAgentTransport          │ ← rule-level custom_user_agent
+   │     │  if ctx has UA: set rule UA  │   非空时覆盖一切（innermost wins）
+   │     ▼                              │
+   │  base http.Transport (sends wire)  │
+   └────────────────────────────────────┘
+```
+
+> **innermost wins**：每一层都是"set then delegate"——内层是最后写 header
+> 的人，所以最贴近 wire 的那层决定最终 UA。
+
+最终结果：
+
+| 场景 | rule UA | provider UA | vendor 硬编码 | 实际发出的 UA |
+|------|---------|-------------|--------------|--------------|
+| 默认 | 空 | 空 | claude-cli/… | claude-cli/… |
+| Provider 配了 | 空 | "MyOrg/1.0" | claude-cli/… | MyOrg/1.0 |
+| Rule 配了 | "Bench/1" | "MyOrg/1.0" | claude-cli/… | Bench/1 |
+| Rule 配了 | "Bench/1" | 空 | — | Bench/1 |
+
+⚠️ **重要**：`provider.UserAgent` 一旦设置就会覆盖 vendor 硬编码——这是**有意为之**的调试通道（详见 `ai/provider.go` 上该字段的 doc comment）。Claude Code OAuth 等端点对 UA 有真实校验，错配会让 OAuth 直接被拒；操作员设置该字段时要清楚自己在干嘛。
+
+并非所有 client 都接入这条链。当前只有：
+
+| Client | Provider UA | Rule UA |
+|--------|-------------|---------|
+| 通用 OpenAI (`client/openai.go`) | ✅ | ✅ |
+| 通用 Anthropic 非-OAuth (`client/anthropic.go` else 分支) | ✅ | ✅ |
+| Claude Code OAuth (`claudeRoundTripper`) | ✅ | ❌ |
+| Codex / Gemini / Google | ✅ | ❌ |
+
+vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握手协议绑定，rule 级覆盖反而会破坏 vendor 校验。这条边界写进了 `flag_registry.go` 中 `custom_user_agent` 的 description 里。
+
+---
+
+## 7. 前端 UI 设计
+
+### 卡片位置
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Rule Card                                            [⚙ settings]    │
+│                                                                      │
+│  ┌──────────────────────────────── horizontal scroll ──→  ┐ ┌─────┐  │
+│  │ ModelNode → ArrowNode → ProviderNode → ProviderNode … │ │ Ext │  │
+│  │                                                        │ │Card │  │
+│  └────────────────────────────────────────────────────────┘ └─────┘  │
+│           ↑                                                    ↑     │
+│   随 provider 增多可横向滚动                          常驻右侧不滚动 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+关键 CSS 决策：
+
+- 外层 `display: flex`，graph 在 `flexGrow:1, minWidth:0` 的 box 里启用 `overflowX:auto`；`minWidth:0` 是让 flex item 能收缩到内容宽以下的关键，否则会把 Extensions 推出视口。
+- Extensions Card `flexShrink:0`，所以滚动条出现时它**不缩**。
+- Card 高度 = `PROVIDER_NODE_STYLES.height`（72px），视觉与 provider 行对齐；内容溢出时 card 内 `overflowY:auto`。
+
+### Catalog 弹窗
+
+按 `FlagSpec.Category` 分组（compatibility / request / response）。每个 flag：
+
+- `type: bool` → 一个 `Switch`。
+- `type: string` → `Switch`（占位，未来可改成独立 enable 控制）+ `TextField`。当前空字符串视为未启用。
+- 已启用的 flag 在边框 / 背景上有高亮。
+
+---
+
+## 8. 新增一个 flag — 操作手册
+
+按以下顺序走，**勿乱序**，否则前端会因 parser/reducer 缺分支而 cast 失败：
+
+```
+1. internal/typ/type.go
+   ├─ 给 RuleFlags struct 加一个字段（snake_case json tag）
+   └─ 注意 yaml tag 与 json 保持一致
+
+2. internal/typ/flag_registry.go
+   └─ 在 RuleFlagRegistry() 返回值里追加一个 FlagSpec，
+      key 必须与上一步的 json tag 一字不差
+
+3. internal/server/  (行为落地)
+   ├─ 选定 §5 中的注入类型 (1/2/3)
+   ├─ 在对应 helper（applyXxx / WithXxx / shouldXxx）里加分支
+   └─ 在 openai.go / protocol_dispatch.go 等"枢纽"调用 helper
+
+4. internal/server/rule_flags_test.go  或  与新逻辑同包的 _test.go
+   └─ 覆盖：nil-safe / no-op when flag absent / 启用时的实际效果
+
+5. frontend/src/components/RoutingGraphTypes.ts
+   ├─ RuleFlags 接口加 camelCase 字段
+   └─ RuleFlagsApi 接口加 snake_case 字段（与后端 json tag 对齐）
+
+6. frontend/src/components/rule-card/utils.ts
+   ├─ ruleToConfigRecord：snake_case → camelCase 映射
+   ├─ formatRuleFlags / parseRuleFlags：扩展 string-key 兼容路径
+   └─ countActiveFlags：新字段计入
+
+7. frontend/src/components/rule-card/RuleExtensionsCard.tsx
+   └─ flagBoolValue / flagStringValue switch 增加 case
+
+8. frontend/src/components/rule-card/FlagCatalogDialog.tsx
+   └─ flagToBool / flagToString / setBool / setString switch 增加 case
+
+9. frontend/src/components/rule-card/useRuleCardHooks.ts
+   └─ autoSave 的 flags 序列化：camelCase → snake_case payload
+
+10. (可选) 重新跑 frontend `npm run gen:api`（CLAUDE.md 约定）
+```
+
+测试 `TestRuleFlagRegistry_KeysMatchStructFields` 会在第 1、2 步任一步漏改时立即红，是这条链路最稳的安全网。
+
+---
+
+## 9. 设计取舍
+
+| 选项 | 已采纳 | 备择 | 取舍理由 |
+|------|--------|------|----------|
+| `RuleFlags` 用 typed struct 还是 `map[string]any` | typed struct | map | 编译期检查；JSON 兼容性靠 `omitempty` 与零值 |
+| Registry 由后端 owner | ✅ | 前端硬编码 + 后端硬编码两边对 | 单一可信源，新加 flag 只动一处元数据 |
+| 卡片放路由图内 vs. 路由图外（固定右侧） | 固定右侧 | 卡片随路由图滚动 | flag 是 rule 级而非 provider 级，常驻可见更符合心智模型 |
+| string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
+| UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约用法 |
+
+---
+
+## 10. 当前未做 / 后续可做
+
+- **UI**：string flag 加独立 enable Switch（让"空"与"未启用"可区分）。
+- **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时会拥挤）。
+- **后端**：`internal/client/openai.go` 通用 OpenAI client 用 `http.DefaultTransport` 而非 `createSessionBoundTransport`，导致它**没有**走 transport pool / session 隔离——这是个独立问题，不在 rule flag 范畴，但补齐时记得保留 §6 的两层 UA 包装顺序。
+- **后端**：长期看，部分 ScenarioFlags 可以下沉成 rule flag（例如 `disable_stream_usage` 已与 `skip_usage` 高度重叠），等业务确认后做一次合并。
+- **测试**：当前测试覆盖 helper 级，缺一个 "rule 配了 skip_usage → 真实 HTTP 响应里没有 usage" 的端到端 case；待 mock provider fixture 成熟后补。

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -171,13 +171,14 @@ func RuleFlagRegistry() []FlagSpec { … }
 
 ### 5.1 ops vs Transform — Type 1 内部的分层
 
-`internal/protocol/transform/ops/` 与 `internal/server/transform_*.go`
-承担不同职责：
+`internal/protocol/transform/ops/` 与 `internal/protocol/transform/`
+（含 `internal/server/transform_*.go` 中 server-domain 相关者）承担不同职责：
 
 | 层 | 位置 | 职责 | 例子 |
 |----|------|------|------|
 | **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数，对某个具体 request 类型做无副作用的字段改写。不感知链路、不感知 rule。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)` |
-| **Transform（链路阶段）** | `internal/server/transform_*.go` | 实现 `protocoltransform.Transform` 接口，按 `ctx.Request` 实际类型决定是否调 op；按 rule flag 配置构造。 | `OpenAIMaxTokensRewriteTransform`（构造期接受 `UseMaxCompletionTokens`、`UseMaxTokens` 两个 bool） |
+| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口，按 `ctx.Request` 实际类型决定是否调 op；构造期接受配置参数。仅依赖协议层 / SDK 类型。 | `transform.OpenAIMaxTokensRewriteTransform`（构造期接受 `UseMaxCompletionTokens`、`UseMaxTokens` 两个 bool） |
+| **Transform（链路阶段，server-domain）** | `internal/server/transform_*.go` | 实现 `Transform` 接口，但需要 server-domain 类型（如 `*typ.ScenarioConfig`）。 | `ThinkingModeTransform`、`MaxTokensTransform`（Anthropic 上限）、`CleanHeaderTransform` |
 
 **为什么必须分两层？**
 
@@ -324,13 +325,15 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
    │   ① internal/protocol/transform/ops/<xxx>.go：写 op 原语，    │
    │      签名形如 ApplyXxx(*openai.ChatCompletionNewParams) 或    │
    │      其他具体 request 类型。op 必须是纯函数、无 rule 感知。   │
-   │   ② internal/server/transform_<xxx>.go：写 Transform，        │
+   │   ② internal/protocol/transform/<xxx>.go：写 Transform，      │
    │      构造期接受 rule flag bool，Apply() 里 type-switch        │
-   │      ctx.Request，匹配目标类型时调 op。                       │
+   │      ctx.Request，匹配目标类型时调 op。仅依赖协议层类型；     │
+   │      如需 server-domain 类型，才放到 internal/server/。       │
    │   ③ internal/server/rule_flags.go::ruleExtraTransforms：     │
    │      根据 flag 决定是否 append 新 Transform 到 extras 切片。  │
    │   ④ 4 个 handler 入口不需要再改，他们都已经传                  │
-   │      ruleExtraTransforms(rule)... 给 transformXxxx。          │
+   │      ruleExtraTransforms(resolveRuleFlags(rule))... 给        │
+   │      transformXxxx。                                          │
    │                                                              │
    │ Type 2 (context-passed hint)                                 │
    │   ① 在 internal/typ/id.go 加 contextKey + 一对                │

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -1,16 +1,7 @@
 # Rule Flags 设计与实操
 
 > 适用对象：tingly-box 后端 / 前端贡献者。
-> 本文档描述**当前**的 rule flag 系统，按"现在是怎样"来读，不是"演变到这里"。
-
-## 历史（仅留索引，不再溯源叙述）
-
-- 2026-05 引入 registry，把原本零散的 2 个布尔 flag 升级为 catalog 化扩展系统。
-- 2026-05 把 `max_tokens` / `max_completion_tokens` 字段重写从 handler 层
-  pre-chain mutation 改为 post-base Transform 链路阶段；新增反向
-  `use_max_tokens`；删除路由图齿轮菜单中的 Cursor 专用入口。
-- 2026-05 将上述 Transform 从 `internal/server/` 迁回 `internal/protocol/transform/`
-  （它只依赖协议层类型）。
+> 本文档描述**当前**的 rule flag 系统的最终设计与实操。
 
 ---
 

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -1,8 +1,13 @@
 # Rule Flags 设计与实操
 
 > 适用对象：tingly-box 后端 / 前端贡献者。
-> 历史回溯：2026-05 引入 registry，把原本仅 2 个布尔 flag 的隐藏入口
-> 升级为 catalog 化的"路由规则扩展"系统。
+> 历史回溯：
+> - 2026-05 引入 registry，把原本仅 2 个布尔 flag 的隐藏入口
+>   升级为 catalog 化的"路由规则扩展"系统。
+> - 2026-05（后期）把 `max_tokens` 字段重写从 openai.go 直接 mutate
+>   上移到 **post-base Transform 链路阶段**，使其在 Anthropic→OpenAI
+>   等跨协议路径上也能正确生效。同时新增 `use_max_tokens`（反向重写
+>   到旧字段）。
 
 ---
 
@@ -14,7 +19,7 @@
 |------|------|------|------|
 | Provider | provider 实例 | `user_agent`、`api_base`、`proxy_url`、`timeout` | 全局静态生效 |
 | Scenario flags | scenario | `disable_stream_usage` 等 | 跨 rule 共享 |
-| **Rule flags** | **单条 rule** | **`cursor_compat`、`skip_usage`、`use_max_completion_tokens` …** | **本文档讨论** |
+| **Rule flags** | **单条 rule** | **`cursor_compat`、`skip_usage`、`use_max_completion_tokens`、`use_max_tokens` …** | **本文档讨论** |
 
 很多场景介于"provider 通用"和"协议层通用"之间——它们只对**某一类客户端 / 某一类模型 / 某一种调试目的**有意义。把这些行为塞到 Provider 配置里会污染默认值；做成 Scenario flag 又过于粗粒度。Rule flag 是这一类"局部、可选、可叠加的开关"的归宿。
 
@@ -60,21 +65,41 @@
               └─────────────────────┬──────────────────────────────┘
                                     │ rule resolved at request time
                                     ▼
-              ┌─────────────────────────────────────────────────────┐
-              │   internal/server/openai.go : OpenAIChatCompletion   │
-              │   ── ruleFlags := resolveRuleFlags(rule)             │
-              │   ├─ applyMaxCompletionTokensRewrite(&req)           │ ← request mutation
-              │   ├─ WithCustomUserAgent(ctx, ruleFlags.UA)          │ ← context-passed
-              │   ├─ reqCtx.Extra["skip_usage"] = …                  │ ← downstream hint
-              │   └─ (existing) applyCursorCompatFlag                │
-              └─────────────────────┬───────────────────────────────┘
+              ┌─────────────────────────────────────────────────────────┐
+              │   inbound handler (openai.go / anthropic_v1.go /         │
+              │                    anthropic_beta.go / openai_responses) │
+              │   ── ruleFlags := resolveRuleFlags(rule)                 │
+              │   ├─ WithCustomUserAgent(ctx, ruleFlags.UA)              │ ← context-passed
+              │   ├─ reqCtx.Extra["skip_usage"] = …                      │ ← downstream hint
+              │   ├─ (existing) applyCursorCompatFlag(extra hint)        │ ← pre-chain marker
+              │   └─ extras := ruleExtraTransforms(rule)                 │ ← post-base stages
+              │       → [OpenAIMaxTokensRewriteTransform{Use…, Use…}]    │
+              └─────────────────────┬───────────────────────────────────┘
+                                    │
+                                    ▼
+              ┌─────────────────────────────────────────────────────────┐
+              │   transformXxxx(..., extras...) :                        │
+              │     chain := BuildTransformChain(...)                    │
+              │     for _, t := range extras { chain.Add(t) }            │
+              │     chain.Execute(ctx)                                   │
+              │                                                          │
+              │     ┌───────────────────────────────────────────────┐    │
+              │     │ Base  →  MCP  →  Consistency  →  Vendor       │    │
+              │     │                                          │    │    │
+              │     │                                          ▼    │    │
+              │     │                          OpenAIMaxTokensRewrite│   │
+              │     │                          (type-switches on    │    │
+              │     │                           *openai.ChatCompletion;   │
+              │     │                           delegates to ops.*)│    │
+              │     └───────────────────────────────────────────────┘    │
+              └─────────────────────┬───────────────────────────────────┘
                                     │
                 ┌───────────────────┼───────────────────┐
                 ▼                   ▼                   ▼
           request mutation     transport chain      response mutation
-        (max_tokens rewrite,  (UA injection via   (skip_usage strips
-         cursor norm. etc.)    customUA RT)        `usage` field in
-                                                   stream + nonstream)
+         (chain stage:        (UA injection via    (skip_usage strips
+          field rewrite;       customUA RT)         `usage` field in
+          cursor norm.)                              stream + nonstream)
                                     │
                                     ▼
                               upstream provider
@@ -110,10 +135,11 @@ func RuleFlagRegistry() []FlagSpec { … }
 
 | Key | Type | 类别 | 作用 | 注入点 |
 |-----|------|------|------|--------|
-| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + 工具门控 + stream usage 抑制 | `cursor_compat.go` |
+| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + 工具门控 + stream usage 抑制 | `cursor_compat.go`（pre-chain，配合 ops 同步执行）|
 | `cursor_compat_auto` | bool | compatibility | 通过请求头识别 Cursor，自动启用 cursor_compat | `cursor_compat.go::resolveCursorCompat` |
 | `skip_usage` | bool | response | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)` |
-| `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `applyMaxCompletionTokensRewrite` |
+| `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite` |
+| `use_max_tokens` | bool | request | 反向重写：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| `OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxTokensRewrite` |
 | `custom_user_agent` | string | request | 覆盖出站 User-Agent header | `customUserAgentTransport` + `WithCustomUserAgent(ctx, …)` |
 
 ---
@@ -122,14 +148,17 @@ func RuleFlagRegistry() []FlagSpec { … }
 
 ```
 ┌────────────────────────┐
-│       Request body     │   ← Type 1: 直接改 request struct
-│   (e.g. max_completion │     调用位置：openai.go 在 transform 链之前
-│    _tokens 重写)        │     函数形态：applyXxx(&req)
+│       Request body     │   ← Type 1: 改 request struct，按时机分两小类
+│                        │      1a. pre-chain：handler 入口直接 mutate
+│                        │          inbound 请求（如 cursor 内容归一化标记）
+│                        │      1b. post-base Transform：作为链路阶段，
+│                        │          在 BaseTransform 完成协议转换之后运行
+│                        │          （如 max_tokens 字段重写）
 └────────────────────────┘
 
 ┌────────────────────────┐
 │   Per-request context  │   ← Type 2: 通过 context 把"hint"带到深层组件
-│  (e.g. custom UA)       │     调用位置：openai.go 把 c.Request 的 ctx 替换
+│  (e.g. custom UA)       │     调用位置：handler 把 c.Request 的 ctx 替换
 └────────────────────────┘     消费位置：transport / round-tripper
 
 ┌────────────────────────┐
@@ -139,6 +168,57 @@ func RuleFlagRegistry() []FlagSpec { … }
 ```
 
 任何新 flag 都应归入这三类之一；如果有第四类，先在 PR 描述里说明。
+
+### 5.1 ops vs Transform — Type 1 内部的分层
+
+`internal/protocol/transform/ops/` 与 `internal/server/transform_*.go`
+承担不同职责：
+
+| 层 | 位置 | 职责 | 例子 |
+|----|------|------|------|
+| **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数，对某个具体 request 类型做无副作用的字段改写。不感知链路、不感知 rule。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)` |
+| **Transform（链路阶段）** | `internal/server/transform_*.go` | 实现 `protocoltransform.Transform` 接口，按 `ctx.Request` 实际类型决定是否调 op；按 rule flag 配置构造。 | `OpenAIMaxTokensRewriteTransform`（构造期接受 `UseMaxCompletionTokens`、`UseMaxTokens` 两个 bool） |
+
+**为什么必须分两层？**
+
+- `BaseTransform` 负责跨协议转换（Anthropic ↔ OpenAI / Responses /
+  Google）。如果在链外直接改 inbound 请求，遇到 "Anthropic inbound →
+  OpenAI Chat target" 的路径，改的还是 Anthropic 形态，rewrite 在
+  Base 转换之后就丢失了。
+- 把 rewrite 包成一个 Transform 并加在 Base **之后**，它看见的是已经
+  转换好的 `*openai.ChatCompletionNewParams`，无论 inbound 是什么形态
+  都能命中——这就是为什么 `use_max_completion_tokens` / `use_max_tokens`
+  在 4 个 handler 路径上都能生效。
+
+### 5.2 链路位置与 wiring
+
+```
+handler                         transformXxxx                       chain
+  │                                  │                                │
+  │ extras := ruleExtraTransforms(   │                                │
+  │             rule)                │                                │
+  │  (e.g. [OpenAIMaxTokensRewrite]) │                                │
+  ├──────── extras... ──────────────►│                                │
+  │                                  │  chain := BuildTransformChain  │
+  │                                  │           (...)                │
+  │                                  ├──────────────────────────────►│
+  │                                  │  for _, t := range extras {    │
+  │                                  │      chain.Add(t)              │
+  │                                  │  }                             │
+  │                                  │  chain.Execute(ctx)            │
+  │                                  ├──────────────────────────────►│
+```
+
+- `BuildTransformChain` 故意不感知 rule flag——它的输入仍只有 scenario
+  / provider / recording。把"哪些 rule-extra transform 要追加"这件事
+  留给 handler 层，handler 通过新增的 variadic `extraTransforms
+  ...transform.Transform` 把列表传给 `transformAnthropicV1` /
+  `transformAnthropicBeta` / `transformOpenAIChat` /
+  `transformOpenAIResponses`。每个 `transformXxxx` 拿到 `chain` 后用
+  `chain.Add()` 追加 extra，再 `Execute`。
+- `ruleExtraTransforms(rule)`（位于 `internal/server/rule_flags.go`）
+  是这条链路的唯一聚合点；今后再有新的 rule-driven Transform 也都
+  挂到这里返回，handler 不需要再加新的调用。
 
 ---
 
@@ -234,13 +314,44 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
    └─ 在 RuleFlagRegistry() 返回值里追加一个 FlagSpec，
       key 必须与上一步的 json tag 一字不差
 
-3. internal/server/  (行为落地)
-   ├─ 选定 §5 中的注入类型 (1/2/3)
-   ├─ 在对应 helper（applyXxx / WithXxx / shouldXxx）里加分支
-   └─ 在 openai.go / protocol_dispatch.go 等"枢纽"调用 helper
+3. 选定 §5 中的注入类型：
 
-4. internal/server/rule_flags_test.go  或  与新逻辑同包的 _test.go
-   └─ 覆盖：nil-safe / no-op when flag absent / 启用时的实际效果
+   ┌─────────────────────────────────────────────────────────────┐
+   │ Type 1a (pre-chain 请求 mutation)                            │
+   │   handler 入口直接调 helper，例：cursor_compat              │
+   │                                                              │
+   │ Type 1b (post-base Transform — 推荐)                         │
+   │   ① internal/protocol/transform/ops/<xxx>.go：写 op 原语，    │
+   │      签名形如 ApplyXxx(*openai.ChatCompletionNewParams) 或    │
+   │      其他具体 request 类型。op 必须是纯函数、无 rule 感知。   │
+   │   ② internal/server/transform_<xxx>.go：写 Transform，        │
+   │      构造期接受 rule flag bool，Apply() 里 type-switch        │
+   │      ctx.Request，匹配目标类型时调 op。                       │
+   │   ③ internal/server/rule_flags.go::ruleExtraTransforms：     │
+   │      根据 flag 决定是否 append 新 Transform 到 extras 切片。  │
+   │   ④ 4 个 handler 入口不需要再改，他们都已经传                  │
+   │      ruleExtraTransforms(rule)... 给 transformXxxx。          │
+   │                                                              │
+   │ Type 2 (context-passed hint)                                 │
+   │   ① 在 internal/typ/id.go 加 contextKey + 一对                │
+   │      WithXxx/GetXxx helper。                                  │
+   │   ② handler 入口 c.Request = c.Request.WithContext(WithXxx)。  │
+   │   ③ 消费方（如 transport / round-tripper）读 GetXxx。         │
+   │                                                              │
+   │ Type 3 (response 后置加工)                                    │
+   │   ① handler 把 flag 值写进 reqCtx.Extra。                    │
+   │   ② internal/server/protocol_dispatch.go：在派发分支调用       │
+   │      shouldStripUsage(...) 这类聚合判定。                     │
+   └─────────────────────────────────────────────────────────────┘
+
+4. 测试位置随注入类型走：
+   ├─ op 单元测试 → 与 op 同包 (`internal/protocol/transform/ops/`)
+   ├─ Transform 行为测试 → 与 Transform 同包 (`internal/server/`)
+   │     必备 case：在目标 request 类型上启用 / 在其他类型上 no-op /
+   │              chain 中跟一个 stub BaseTransform，验证 post-base
+   │              生效（前述 max_tokens 即此模式）。
+   └─ wire 序列化测试（仅对改字段名的 op 有意义）：marshal 前后断言
+       JSON 顶层 key 是否出现/消失，挡 SDK omitzero tag 失效。
 
 5. frontend/src/components/RoutingGraphTypes.ts
    ├─ RuleFlags 接口加 camelCase 字段
@@ -276,6 +387,10 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
 | 卡片放路由图内 vs. 路由图外（固定右侧） | 固定右侧 | 卡片随路由图滚动 | flag 是 rule 级而非 provider 级，常驻可见更符合心智模型 |
 | string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
 | UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约用法 |
+| 请求字段重写：handler 直接 mutate vs. post-base Transform | post-base Transform | handler 链外直改 | 链外直改会在 Anthropic→OpenAI 等跨协议路径上失效；Transform 在 Base 之后看见的是最终形态，所有 inbound 类型都能命中 |
+| op vs Transform 是否合并成一类 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（无 rule 感知、可直接被多处复用、易于做 wire 序列化测试）；Transform 才感知 rule 与链路位置。混在一起会让原语难复用、测试难写 |
+| `BuildTransformChain` 是否感知 rule | 否 | 把 ruleFlags 作为参数传入 | 让 chain builder 只懂 scenario/provider/recording；rule 级关心点放在 handler，并通过 `extraTransforms ...transform.Transform` variadic 注入。signature 加 variadic 是 additive 改动 |
+| 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Extensions 卡片 | Extensions 卡片已经能覆盖 cursor_compat / cursor_compat_auto；两套入口对同一字段语义会引发混淆 |
 
 ---
 
@@ -283,6 +398,14 @@ vendor-specialized 路径不接 rule UA，是因为它们 UA 跟整个 OAuth/握
 
 - **UI**：string flag 加独立 enable Switch（让"空"与"未启用"可区分）。
 - **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时会拥挤）。
+- **后端**：`cursor_compat` 内容归一化目前仍走 §5 Type 1a（pre-chain，
+  在 `openai.go` 入口直接调 `ops.ApplyCursorCompatContentNormalization`）。
+  长期看可以把它也包成一个 post-base Transform，让 inbound 是 Anthropic
+  时也能在 Base 转换后正确生效——但与 `max_tokens` 不同，cursor 归一化
+  只对 OpenAI 入站才有意义（其它入站不会经过 Cursor 客户端），所以优先
+  级不高。
 - **后端**：`internal/client/openai.go` 通用 OpenAI client 用 `http.DefaultTransport` 而非 `createSessionBoundTransport`，导致它**没有**走 transport pool / session 隔离——这是个独立问题，不在 rule flag 范畴，但补齐时记得保留 §6 的两层 UA 包装顺序。
 - **后端**：长期看，部分 ScenarioFlags 可以下沉成 rule flag（例如 `disable_stream_usage` 已与 `skip_usage` 高度重叠），等业务确认后做一次合并。
-- **测试**：当前测试覆盖 helper 级，缺一个 "rule 配了 skip_usage → 真实 HTTP 响应里没有 usage" 的端到端 case；待 mock provider fixture 成熟后补。
+- **测试**：当前测试覆盖 helper / Transform / op / wire 序列化共 4 层，
+  但缺一个 "rule 配了 skip_usage → 真实 HTTP 响应里没有 usage" 的端到
+  端 case；待 mock provider fixture 成熟后补。

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -128,7 +128,15 @@ type Provider struct {
 	NoKeyRequired bool     `json:"no_key_required"`
 	Enabled       bool     `json:"enabled"`
 	ProxyURL      string   `json:"proxy_url"`              // HTTP or SOCKS proxy URL (e.g., "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080")
-	UserAgent     string   `json:"user_agent,omitempty"`   // Custom outbound HTTP User-Agent; empty = use built-in/default
+	// UserAgent is treated as a deliberate debug / override knob. Empty means
+	// "use the vendor-appropriate default", which for generic OpenAI / Anthropic
+	// is the SDK default and for specialized clients (Claude Code OAuth,
+	// Codex, Gemini, Google) is the hardcoded vendor UA those round trippers
+	// pin. Setting a non-empty value here will overwrite even those vendor
+	// pins — that is intentional for debugging and bug-reproduction scenarios,
+	// but be aware that some upstreams (notably Claude Code OAuth) verify the
+	// CLI UA and may reject requests with a different value.
+	UserAgent     string   `json:"user_agent,omitempty"`
 	Timeout       int64    `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
 	Tags          []string `json:"tags,omitempty"`         // Provider tags for categorization
 	Models        []string `json:"models,omitempty"`       // Available models for this provider (cached)

--- a/frontend/src/components/GraphSettingsMenu.tsx
+++ b/frontend/src/components/GraphSettingsMenu.tsx
@@ -23,15 +23,11 @@ export interface GraphSettingsMenuProps {
     active: boolean;
     allowToggleRule: boolean;
     saving: boolean;
-    cursorCompatEnabled?: boolean;
-    cursorCompatAutoEnabled?: boolean;
     onExport: (format: ExportFormat) => void;
     onExportAsJsonlToClipboard?: () => void;
     onExportAsBase64ToClipboard?: () => void;
     onDelete: () => void;
     onToggleActive: () => void;
-    onToggleCursorCompat?: () => void;
-    onToggleCursorCompatAuto?: () => void;
     onEditFlags?: () => void;
     // Probe V2 props
     ruleUuid?: string;
@@ -45,15 +41,11 @@ export const GraphSettingsMenu = ({
     active,
     allowToggleRule,
     saving,
-    cursorCompatEnabled,
-    cursorCompatAutoEnabled,
     onExport,
     onExportAsJsonlToClipboard,
     onExportAsBase64ToClipboard,
     onDelete,
     onToggleActive,
-    onToggleCursorCompat,
-    onToggleCursorCompatAuto,
     onEditFlags,
     ruleUuid,
     ruleName,
@@ -119,34 +111,6 @@ export const GraphSettingsMenu = ({
                         </>
                     )}
                 </MenuItem>
-
-                {onToggleCursorCompat && (
-                    <MenuItem onClick={() => { closeMenu(); onToggleCursorCompat(); }}>
-                        {cursorCompatEnabled ? (
-                            <>
-                                <ActiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Compatibility: On
-                            </>
-                        ) : (
-                            <>
-                                <InactiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Compatibility: Off
-                            </>
-                        )}
-                    </MenuItem>
-                )}
-
-                {onToggleCursorCompatAuto && (
-                    <MenuItem onClick={() => { closeMenu(); onToggleCursorCompatAuto(); }}>
-                        {cursorCompatAutoEnabled ? (
-                            <>
-                                <ActiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Auto-Detect: On
-                            </>
-                        ) : (
-                            <>
-                                <InactiveIcon fontSize="small" sx={{ mr: 1 }} />Cursor Auto-Detect: Off
-                            </>
-                        )}
-                    </MenuItem>
-                )}
 
                 {onEditFlags && (
                     <MenuItem onClick={() => { closeMenu(); onEditFlags(); }}>

--- a/frontend/src/components/RoutingGraph.tsx
+++ b/frontend/src/components/RoutingGraph.tsx
@@ -90,6 +90,8 @@ interface RuleGraphProps {
     onProviderNodeClick: (providerUuid: string) => void;
     onAddProviderButtonClick: () => void;
     extraActions?: React.ReactNode;
+    // Slot rendered at the right end of the rule group (e.g. rule extensions card)
+    extensionsCard?: React.ReactNode;
     // Smart routing props
     onAddSmartRule?: () => void;
     onEditSmartRule?: (ruleUuid: string) => void;
@@ -174,6 +176,7 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
     onProviderNodeClick,
     onAddProviderButtonClick,
     extraActions,
+    extensionsCard,
     // Smart routing props
     onAddSmartRule,
     onEditSmartRule,
@@ -581,6 +584,13 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                                             />
                                         </Box>
                                     </Box>
+
+                                    {/* Rule Extensions slot - sits on the right side of the rule group */}
+                                    {extensionsCard && (
+                                        <Box onClick={(e) => e.stopPropagation()} sx={{ display: 'flex', alignItems: 'center', ml: 1 }}>
+                                            {extensionsCard}
+                                        </Box>
+                                    )}
 
                                 </GraphRow>
                             </GraphContainer>

--- a/frontend/src/components/RoutingGraph.tsx
+++ b/frontend/src/components/RoutingGraph.tsx
@@ -310,12 +310,13 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
             <Collapse in={isExpanded} timeout="auto" unmountOnExit>
                 <CardContent sx={{ pt: 0, pb: 0.25, '&:last-child': { pb: 0.25 } }}>
                     <Stack spacing={graph.stackSpacing}>
-                        {/* Graph Visualization */}
-                        <Box sx={{ overflowX: 'auto' }}>
-                            <GraphContainer>
-                                <GraphRow>
-                                    {/* Request Model section */}
-                                    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', pr: 1, }}>
+                        {/* Graph row: scrollable graph + pinned extensions card */}
+                        <Box sx={{ display: 'flex', alignItems: 'stretch', minWidth: 0 }}>
+                            <Box sx={{ flexGrow: 1, minWidth: 0, overflowX: 'auto' }}>
+                                <GraphContainer>
+                                    <GraphRow>
+                                        {/* Request Model section */}
+                                        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', pr: 1, }}>
                                         <NodeContainer>
                                             {record.responseModel ? (
                                                 // Split display when response model is configured
@@ -585,15 +586,25 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                                         </Box>
                                     </Box>
 
-                                    {/* Rule Extensions slot - sits on the right side of the rule group */}
-                                    {extensionsCard && (
-                                        <Box onClick={(e) => e.stopPropagation()} sx={{ display: 'flex', alignItems: 'center', ml: 1 }}>
-                                            {extensionsCard}
-                                        </Box>
-                                    )}
-
-                                </GraphRow>
-                            </GraphContainer>
+                                    </GraphRow>
+                                </GraphContainer>
+                            </Box>
+                            {/* Rule Extensions slot - pinned to the right of the rule group, outside horizontal scroll */}
+                            {extensionsCard && (
+                                <Box
+                                    onClick={(e) => e.stopPropagation()}
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        flexShrink: 0,
+                                        pl: 1,
+                                        pr: `${graphContainer.marginX}px`,
+                                        py: `${graphContainer.marginY}px`,
+                                    }}
+                                >
+                                    {extensionsCard}
+                                </Box>
+                            )}
                         </Box>
                     </Stack>
                 </CardContent>

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -47,6 +47,28 @@ export interface ConfigRecord {
 export interface RuleFlags {
     cursorCompat?: boolean;
     cursorCompatAuto?: boolean;
+    skipUsage?: boolean;
+    customUserAgent?: string;
+    useMaxCompletionTokens?: boolean;
+}
+
+export interface RuleFlagsApi {
+    cursor_compat?: boolean;
+    cursor_compat_auto?: boolean;
+    skip_usage?: boolean;
+    custom_user_agent?: string;
+    use_max_completion_tokens?: boolean;
+}
+
+export type FlagValueType = 'bool' | 'string';
+
+export interface FlagSpec {
+    key: string;
+    label: string;
+    description: string;
+    type: FlagValueType;
+    category: string;
+    placeholder?: string;
 }
 
 export interface Rule {
@@ -56,10 +78,7 @@ export interface Rule {
     response_model?: string;
     active?: boolean;
     description?: string;
-    flags?: {
-        cursor_compat?: boolean;
-        cursor_compat_auto?: boolean;
-    };
+    flags?: RuleFlagsApi;
     services?: Array<{
         id?: string;
         uuid?: string;

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -50,6 +50,7 @@ export interface RuleFlags {
     skipUsage?: boolean;
     customUserAgent?: string;
     useMaxCompletionTokens?: boolean;
+    useMaxTokens?: boolean;
 }
 
 export interface RuleFlagsApi {
@@ -58,6 +59,7 @@ export interface RuleFlagsApi {
     skip_usage?: boolean;
     custom_user_agent?: string;
     use_max_completion_tokens?: boolean;
+    use_max_tokens?: boolean;
 }
 
 export type FlagValueType = 'bool' | 'string';

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { api } from '@/services/api';
 import type { Provider, ProviderModelsDataByUuid, ProviderModelData } from '@/types/provider';
-import type { ConfigRecord, Rule } from '@/components/RoutingGraphTypes';
+import type { ConfigRecord, FlagSpec, Rule, RuleFlags } from '@/components/RoutingGraphTypes';
 import {
     useRuleCardExpanded,
     useRuleCardData,
@@ -14,7 +14,31 @@ import RoutingGraph from '@/components/RoutingGraph';
 import SmartRoutingGraph from '@/components/SmartRoutingGraph';
 import SmartRuleEditDialog from '@/components/SmartRuleEditDialog';
 import GraphSettingsMenu from '@/components/GraphSettingsMenu';
+import RuleExtensionsCard from '@/components/rule-card/RuleExtensionsCard';
+import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
 import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
+
+// Module-level cache so we only fetch the flag catalog once per session.
+let _flagRegistryCache: FlagSpec[] | null = null;
+let _flagRegistryPromise: Promise<FlagSpec[]> | null = null;
+
+async function loadFlagRegistry(): Promise<FlagSpec[]> {
+    if (_flagRegistryCache) return _flagRegistryCache;
+    if (_flagRegistryPromise) return _flagRegistryPromise;
+    _flagRegistryPromise = (async () => {
+        try {
+            const result = await api.getRuleFlagRegistry();
+            const data: FlagSpec[] = Array.isArray(result?.data) ? result.data : [];
+            _flagRegistryCache = data;
+            return data;
+        } catch {
+            return [];
+        } finally {
+            _flagRegistryPromise = null;
+        }
+    })();
+    return _flagRegistryPromise;
+}
 
 export interface RuleCardProps {
     rule: Rule;
@@ -86,6 +110,27 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     const [flagDialogOpen, setFlagDialogOpen] = useState(false);
     const [flagInput, setFlagInput] = useState('');
     const [flagError, setFlagError] = useState<string | undefined>(undefined);
+
+    // Catalog dialog state + registry
+    const [catalogOpen, setCatalogOpen] = useState(false);
+    const [flagRegistry, setFlagRegistry] = useState<FlagSpec[]>(_flagRegistryCache || []);
+    const [registryLoading, setRegistryLoading] = useState(false);
+
+    useEffect(() => {
+        if (flagRegistry.length > 0) return;
+        let cancelled = false;
+        setRegistryLoading(true);
+        loadFlagRegistry()
+            .then((data) => {
+                if (!cancelled) setFlagRegistry(data);
+            })
+            .finally(() => {
+                if (!cancelled) setRegistryLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [flagRegistry.length]);
 
     // Handler: Switch routing mode (simple toggle, preserves data)
     const handleRoutingModeSwitch = useCallback(async () => {
@@ -192,7 +237,46 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         setFlagDialogOpen(false);
     }, [configRecord, flagInput, updateField, setConfigRecord]);
 
+    const handleSaveCatalogFlags = useCallback(async (next: RuleFlags) => {
+        if (!configRecord) return;
+        await updateField(configRecord, setConfigRecord, 'flags', next);
+        setCatalogOpen(false);
+    }, [configRecord, updateField, setConfigRecord]);
+
+    const handleToggleFlagFromCard = useCallback((key: string) => {
+        if (!configRecord) return;
+        const current = configRecord.flags || {};
+        let next: RuleFlags = { ...current };
+        switch (key) {
+            case 'cursor_compat':
+                next = { ...next, cursorCompat: !current.cursorCompat };
+                break;
+            case 'cursor_compat_auto':
+                next = { ...next, cursorCompatAuto: !current.cursorCompatAuto };
+                break;
+            case 'skip_usage':
+                next = { ...next, skipUsage: !current.skipUsage };
+                break;
+            case 'use_max_completion_tokens':
+                next = { ...next, useMaxCompletionTokens: !current.useMaxCompletionTokens };
+                break;
+            default:
+                return;
+        }
+        void updateField(configRecord, setConfigRecord, 'flags', next);
+    }, [configRecord, updateField, setConfigRecord]);
+
     if (!configRecord) return null;
+
+    const extensionsCard = (
+        <RuleExtensionsCard
+            flags={configRecord.flags}
+            registry={flagRegistry}
+            active={configRecord.active}
+            onOpenCatalog={() => setCatalogOpen(true)}
+            onToggleFlag={handleToggleFlagFromCard}
+        />
+    );
 
     // Extra actions menu - shared between RoutingGraph and SmartRoutingGraph
     const extraActions = (
@@ -237,6 +321,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                     expanded={expanded}
                     onToggleExpanded={handleToggleExpanded}
                     extraActions={extraActions}
+                    extensionsCard={extensionsCard}
                     onUpdateRecord={(field, value) => updateField(configRecord, setConfigRecord, field, value)}
                     onAddSmartRule={smartHandlers.handleAddSmartRule}
                     onEditSmartRule={smartHandlers.handleEditSmartRule}
@@ -263,6 +348,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                     onProviderNodeClick={handleProviderNodeClick}
                     onAddProviderButtonClick={handleAddProviderButtonClick}
                     extraActions={extraActions}
+                    extensionsCard={extensionsCard}
                     onAddSmartRule={smartHandlers.handleAddSmartRule}
                     onEditSmartRule={smartHandlers.handleEditSmartRule}
                     onDeleteSmartRule={smartHandlers.handleDeleteSmartRule}
@@ -286,6 +372,16 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 }}
                 onClose={() => setFlagDialogOpen(false)}
                 onSave={handleSaveFlags}
+            />
+
+            {/* Flag Catalog Dialog - rich UI for picking + configuring rule flags */}
+            <FlagCatalogDialog
+                open={catalogOpen}
+                flags={configRecord.flags}
+                registry={flagRegistry}
+                loading={registryLoading}
+                onClose={() => setCatalogOpen(false)}
+                onSave={handleSaveCatalogFlags}
             />
 
             {/* Smart Rule Edit Dialog */}

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -211,8 +211,6 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     }, [rule.uuid, onRuleDelete, showNotification]);
 
     const isSmartMode = rule.smart_enabled;
-    const cursorCompatEnabled = configRecord?.flags?.cursorCompat || false;
-    const cursorCompatAutoEnabled = configRecord?.flags?.cursorCompatAuto || false;
 
     const handleOpenFlagEditor = useCallback(() => {
         if (!configRecord) return;
@@ -285,21 +283,11 @@ export const RuleCard: React.FC<RuleCardProps> = ({
             active={configRecord.active}
             allowToggleRule={allowToggleRule}
             saving={saving}
-            cursorCompatEnabled={cursorCompatEnabled}
-            cursorCompatAutoEnabled={cursorCompatAutoEnabled}
             onExport={handleExport}
             onExportAsJsonlToClipboard={handleExportAsJsonlToClipboard}
             onExportAsBase64ToClipboard={handleExportAsBase64ToClipboard}
             onDelete={handleDeleteButtonClick}
             onToggleActive={() => updateField(configRecord, setConfigRecord, 'active', !configRecord.active)}
-            onToggleCursorCompat={() => updateField(configRecord, setConfigRecord, 'flags', {
-                ...(configRecord.flags || {}),
-                cursorCompat: !cursorCompatEnabled,
-            })}
-            onToggleCursorCompatAuto={() => updateField(configRecord, setConfigRecord, 'flags', {
-                ...(configRecord.flags || {}),
-                cursorCompatAuto: !cursorCompatAutoEnabled,
-            })}
             onEditFlags={handleOpenFlagEditor}
             ruleUuid={rule.uuid}
             ruleName={rule.request_model || rule.uuid}

--- a/frontend/src/components/SmartRoutingGraph.tsx
+++ b/frontend/src/components/SmartRoutingGraph.tsx
@@ -84,6 +84,7 @@ interface SmartRoutingGraphProps {
     expanded?: boolean;
     onToggleExpanded?: () => void;
     extraActions?: React.ReactNode;
+    extensionsCard?: React.ReactNode;
     onUpdateRecord?: (field: keyof ConfigRecord, value: any) => void;
     // Routing mode switch
     onSwitchRoutingMode?: () => void;
@@ -166,6 +167,7 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                                                  expanded = true,
                                                                  onToggleExpanded,
                                                                  extraActions,
+                                                                 extensionsCard,
                                                                  onUpdateRecord,
                                                                  onSwitchRoutingMode,
                                                              }) => {
@@ -493,6 +495,12 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                             </Box>
                                         </GraphRow>
                                     </Box>
+                                    {/* Rule Extensions slot - sits on the right side of the rule group */}
+                                    {extensionsCard && (
+                                        <Box onClick={(e) => e.stopPropagation()} sx={{ display: 'flex', alignItems: 'center', ml: 1, alignSelf: 'center' }}>
+                                            {extensionsCard}
+                                        </Box>
+                                    )}
                                 </GraphRow>
                             </GraphContainer>
                         </Box>

--- a/frontend/src/components/SmartRoutingGraph.tsx
+++ b/frontend/src/components/SmartRoutingGraph.tsx
@@ -286,8 +286,9 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
             <Collapse in={isExpanded} timeout="auto" unmountOnExit>
                 <CardContent sx={{ pt: 0, pb: 0.25, '&:last-child': { pb: 0.25 } }}>
                     <Stack spacing={graph.stackSpacing}>
-                        {/* Graph Visualization */}
-                        <Box sx={{ overflowX: 'auto' }}>
+                        {/* Graph row: scrollable graph + pinned extensions card */}
+                        <Box sx={{ display: 'flex', alignItems: 'stretch', minWidth: 0 }}>
+                            <Box sx={{ flexGrow: 1, minWidth: 0, overflowX: 'auto' }}>
                             <GraphContainer>
                                 <GraphRow sx={{ alignItems: 'flex-start' }}>
                                     {/* Request Model section - label + node + arrow as a unit */}
@@ -495,14 +496,25 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                             </Box>
                                         </GraphRow>
                                     </Box>
-                                    {/* Rule Extensions slot - sits on the right side of the rule group */}
-                                    {extensionsCard && (
-                                        <Box onClick={(e) => e.stopPropagation()} sx={{ display: 'flex', alignItems: 'center', ml: 1, alignSelf: 'center' }}>
-                                            {extensionsCard}
-                                        </Box>
-                                    )}
                                 </GraphRow>
                             </GraphContainer>
+                            </Box>
+                            {/* Rule Extensions slot - pinned to the right of the rule group, outside horizontal scroll */}
+                            {extensionsCard && (
+                                <Box
+                                    onClick={(e) => e.stopPropagation()}
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        flexShrink: 0,
+                                        pl: 1,
+                                        pr: `${graphContainer.marginX}px`,
+                                        py: `${graphContainer.marginY}px`,
+                                    }}
+                                >
+                                    {extensionsCard}
+                                </Box>
+                            )}
                         </Box>
                     </Stack>
                 </CardContent>

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -1,0 +1,215 @@
+import {
+    Box,
+    Button,
+    Chip,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    Stack,
+    Switch,
+    TextField,
+    Typography,
+} from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
+
+export interface FlagCatalogDialogProps {
+    open: boolean;
+    flags?: RuleFlags;
+    registry?: FlagSpec[];
+    loading?: boolean;
+    onClose: () => void;
+    onSave: (next: RuleFlags) => void;
+}
+
+const flagToBool = (flags: RuleFlags | undefined, key: string): boolean => {
+    if (!flags) return false;
+    switch (key) {
+        case 'cursor_compat':
+            return !!flags.cursorCompat;
+        case 'cursor_compat_auto':
+            return !!flags.cursorCompatAuto;
+        case 'skip_usage':
+            return !!flags.skipUsage;
+        case 'use_max_completion_tokens':
+            return !!flags.useMaxCompletionTokens;
+        default:
+            return false;
+    }
+};
+
+const flagToString = (flags: RuleFlags | undefined, key: string): string => {
+    if (!flags) return '';
+    switch (key) {
+        case 'custom_user_agent':
+            return flags.customUserAgent || '';
+        default:
+            return '';
+    }
+};
+
+const setBool = (flags: RuleFlags, key: string, value: boolean): RuleFlags => {
+    switch (key) {
+        case 'cursor_compat':
+            return { ...flags, cursorCompat: value };
+        case 'cursor_compat_auto':
+            return { ...flags, cursorCompatAuto: value };
+        case 'skip_usage':
+            return { ...flags, skipUsage: value };
+        case 'use_max_completion_tokens':
+            return { ...flags, useMaxCompletionTokens: value };
+        default:
+            return flags;
+    }
+};
+
+const setString = (flags: RuleFlags, key: string, value: string): RuleFlags => {
+    switch (key) {
+        case 'custom_user_agent':
+            return { ...flags, customUserAgent: value };
+        default:
+            return flags;
+    }
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+    compatibility: 'Compatibility',
+    request: 'Request',
+    response: 'Response',
+};
+
+export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
+    open,
+    flags,
+    registry,
+    loading,
+    onClose,
+    onSave,
+}) => {
+    const [draft, setDraft] = useState<RuleFlags>(flags || {});
+
+    // Reset the working copy whenever the dialog is (re-)opened with new flags.
+    useEffect(() => {
+        if (open) setDraft(flags ? { ...flags } : {});
+    }, [open, flags]);
+
+    const grouped = useMemo(() => {
+        const groups = new Map<string, FlagSpec[]>();
+        (registry || []).forEach((spec) => {
+            const list = groups.get(spec.category) || [];
+            list.push(spec);
+            groups.set(spec.category, list);
+        });
+        return Array.from(groups.entries());
+    }, [registry]);
+
+    const handleToggle = (key: string, value: boolean) => {
+        setDraft((d) => setBool(d, key, value));
+    };
+
+    const handleStringChange = (key: string, value: string) => {
+        setDraft((d) => setString(d, key, value));
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>
+                Rule Extensions
+                <Typography variant="caption" component="div" color="text.secondary">
+                    Pre-installed flags applied at the rule level.
+                </Typography>
+            </DialogTitle>
+            <DialogContent dividers>
+                {loading && (
+                    <Typography variant="body2" color="text.secondary">
+                        Loading flag catalog…
+                    </Typography>
+                )}
+                {!loading && grouped.length === 0 && (
+                    <Typography variant="body2" color="text.secondary">
+                        No flags available.
+                    </Typography>
+                )}
+                <Stack spacing={2}>
+                    {grouped.map(([category, specs]) => (
+                        <Box key={category}>
+                            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                                <Typography variant="overline" sx={{ color: 'text.secondary', lineHeight: 1 }}>
+                                    {CATEGORY_LABEL[category] || category}
+                                </Typography>
+                                <Divider sx={{ flexGrow: 1 }} />
+                            </Stack>
+                            <Stack spacing={1.5}>
+                                {specs.map((spec) => {
+                                    const enabled = spec.type === 'bool'
+                                        ? flagToBool(draft, spec.key)
+                                        : flagToString(draft, spec.key) !== '';
+                                    return (
+                                        <Box
+                                            key={spec.key}
+                                            sx={{
+                                                p: 1,
+                                                border: '1px solid',
+                                                borderColor: enabled ? 'primary.light' : 'divider',
+                                                borderRadius: 1,
+                                                backgroundColor: enabled ? 'action.hover' : 'transparent',
+                                            }}
+                                        >
+                                            <Stack direction="row" alignItems="center" spacing={1}>
+                                                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                                                    <Stack direction="row" alignItems="center" spacing={0.75}>
+                                                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                                            {spec.label}
+                                                        </Typography>
+                                                        <Chip
+                                                            size="small"
+                                                            label={spec.key}
+                                                            sx={{ height: 16, fontSize: '0.6rem' }}
+                                                            variant="outlined"
+                                                        />
+                                                    </Stack>
+                                                    <Typography variant="caption" color="text.secondary">
+                                                        {spec.description}
+                                                    </Typography>
+                                                </Box>
+                                                {spec.type === 'bool' && (
+                                                    <Switch
+                                                        size="small"
+                                                        checked={flagToBool(draft, spec.key)}
+                                                        onChange={(e) => handleToggle(spec.key, e.target.checked)}
+                                                    />
+                                                )}
+                                            </Stack>
+                                            {spec.type === 'string' && (
+                                                <TextField
+                                                    fullWidth
+                                                    size="small"
+                                                    placeholder={spec.placeholder}
+                                                    value={flagToString(draft, spec.key)}
+                                                    onChange={(e) => handleStringChange(spec.key, e.target.value)}
+                                                    sx={{ mt: 1 }}
+                                                />
+                                            )}
+                                        </Box>
+                                    );
+                                })}
+                            </Stack>
+                        </Box>
+                    ))}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={() => onSave(draft)} color="primary" variant="contained">
+                    Save
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default FlagCatalogDialog;

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -1,0 +1,145 @@
+import { Add as AddIcon, Extension as ExtensionIcon } from '@mui/icons-material';
+import { Box, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import React from 'react';
+import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
+
+const CARD_STYLES = {
+    width: 180,
+    minHeight: 120,
+    padding: 10,
+} as const;
+
+const StyledExtensionsCard = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'active',
+})<{ active: boolean }>(({ active, theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: CARD_STYLES.padding,
+    borderRadius: theme.shape.borderRadius,
+    border: '1px dashed',
+    borderColor: theme.palette.divider,
+    backgroundColor: theme.palette.background.paper,
+    width: CARD_STYLES.width,
+    minHeight: CARD_STYLES.minHeight,
+    boxShadow: theme.shadows[1],
+    opacity: active ? 1 : 0.6,
+    transition: 'all 0.2s ease-in-out',
+}));
+
+export interface RuleExtensionsCardProps {
+    flags?: RuleFlags;
+    registry?: FlagSpec[];
+    active: boolean;
+    onOpenCatalog: () => void;
+    onToggleFlag?: (key: string) => void;
+}
+
+const flagBoolValue = (flags: RuleFlags | undefined, key: string): boolean => {
+    if (!flags) return false;
+    switch (key) {
+        case 'cursor_compat':
+            return !!flags.cursorCompat;
+        case 'cursor_compat_auto':
+            return !!flags.cursorCompatAuto;
+        case 'skip_usage':
+            return !!flags.skipUsage;
+        case 'use_max_completion_tokens':
+            return !!flags.useMaxCompletionTokens;
+        default:
+            return false;
+    }
+};
+
+const flagStringValue = (flags: RuleFlags | undefined, key: string): string => {
+    if (!flags) return '';
+    switch (key) {
+        case 'custom_user_agent':
+            return flags.customUserAgent || '';
+        default:
+            return '';
+    }
+};
+
+/**
+ * RuleExtensionsCard renders a compact card displaying the rule's enabled
+ * extension flags. The "+ Add" action opens the catalog dialog where users
+ * pick which flags to enable and supply any parameters they require.
+ */
+export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
+    flags,
+    registry,
+    active,
+    onOpenCatalog,
+    onToggleFlag,
+}) => {
+    const enabled = (registry || []).filter((spec) => {
+        if (spec.type === 'bool') return flagBoolValue(flags, spec.key);
+        return flagStringValue(flags, spec.key) !== '';
+    });
+
+    return (
+        <StyledExtensionsCard active={active}>
+            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
+                <ExtensionIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+                <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary', flexGrow: 1 }}>
+                    Extensions
+                </Typography>
+                <Tooltip title="Configure rule extensions">
+                    <IconButton size="small" onClick={onOpenCatalog} sx={{ p: 0.25 }}>
+                        <AddIcon sx={{ fontSize: 14 }} />
+                    </IconButton>
+                </Tooltip>
+            </Stack>
+
+            {enabled.length === 0 ? (
+                <Box
+                    onClick={onOpenCatalog}
+                    sx={{
+                        flexGrow: 1,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: 'text.disabled',
+                        fontSize: '0.7rem',
+                        cursor: 'pointer',
+                        textAlign: 'center',
+                        px: 0.5,
+                    }}
+                >
+                    None enabled. Click to configure.
+                </Box>
+            ) : (
+                <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.25 }}>
+                    {enabled.map((spec) => {
+                        const isString = spec.type === 'string';
+                        const stringVal = isString ? flagStringValue(flags, spec.key) : '';
+                        const label = isString && stringVal ? `${spec.label}: ${stringVal}` : spec.label;
+                        const title = isString && stringVal
+                            ? `${spec.description}\nValue: ${stringVal}`
+                            : spec.description;
+                        return (
+                            <Tooltip key={spec.key} title={title}>
+                                <Chip
+                                    size="small"
+                                    label={label}
+                                    color="primary"
+                                    variant="outlined"
+                                    onClick={onOpenCatalog}
+                                    onDelete={
+                                        spec.type === 'bool' && onToggleFlag
+                                            ? () => onToggleFlag(spec.key)
+                                            : undefined
+                                    }
+                                    sx={{ maxWidth: '100%', fontSize: '0.65rem', height: 20 }}
+                                />
+                            </Tooltip>
+                        );
+                    })}
+                </Stack>
+            )}
+        </StyledExtensionsCard>
+    );
+};
+
+export default RuleExtensionsCard;

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -2,12 +2,15 @@ import { Add as AddIcon, Extension as ExtensionIcon } from '@mui/icons-material'
 import { Box, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React from 'react';
+import { PROVIDER_NODE_STYLES } from '@/components/nodes/styles';
 import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
 
+// Matches ProviderNode dimensions so the extensions card aligns with the
+// providers row visually. Content overflow scrolls inside the card body.
 const CARD_STYLES = {
     width: 180,
-    minHeight: 120,
-    padding: 10,
+    height: PROVIDER_NODE_STYLES.height,
+    padding: 6,
 } as const;
 
 const StyledExtensionsCard = styled(Box, {
@@ -21,10 +24,11 @@ const StyledExtensionsCard = styled(Box, {
     borderColor: theme.palette.divider,
     backgroundColor: theme.palette.background.paper,
     width: CARD_STYLES.width,
-    minHeight: CARD_STYLES.minHeight,
+    height: CARD_STYLES.height,
     boxShadow: theme.shadows[1],
     opacity: active ? 1 : 0.6,
     transition: 'all 0.2s ease-in-out',
+    overflow: 'hidden',
 }));
 
 export interface RuleExtensionsCardProps {
@@ -80,14 +84,15 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
 
     return (
         <StyledExtensionsCard active={active}>
-            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
-                <ExtensionIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-                <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary', flexGrow: 1 }}>
-                    Extensions
+            {/* Fixed-height header so the body has a stable scroll region */}
+            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ flexShrink: 0, mb: 0.25 }}>
+                <ExtensionIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
+                <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.65rem', color: 'text.secondary', flexGrow: 1, lineHeight: 1 }}>
+                    Extensions{enabled.length > 0 ? ` (${enabled.length})` : ''}
                 </Typography>
                 <Tooltip title="Configure rule extensions">
-                    <IconButton size="small" onClick={onOpenCatalog} sx={{ p: 0.25 }}>
-                        <AddIcon sx={{ fontSize: 14 }} />
+                    <IconButton size="small" onClick={onOpenCatalog} sx={{ p: 0.125 }}>
+                        <AddIcon sx={{ fontSize: 12 }} />
                     </IconButton>
                 </Tooltip>
             </Stack>
@@ -101,42 +106,54 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                         alignItems: 'center',
                         justifyContent: 'center',
                         color: 'text.disabled',
-                        fontSize: '0.7rem',
+                        fontSize: '0.65rem',
                         cursor: 'pointer',
                         textAlign: 'center',
-                        px: 0.5,
+                        px: 0.25,
                     }}
                 >
                     None enabled. Click to configure.
                 </Box>
             ) : (
-                <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.25 }}>
-                    {enabled.map((spec) => {
-                        const isString = spec.type === 'string';
-                        const stringVal = isString ? flagStringValue(flags, spec.key) : '';
-                        const label = isString && stringVal ? `${spec.label}: ${stringVal}` : spec.label;
-                        const title = isString && stringVal
-                            ? `${spec.description}\nValue: ${stringVal}`
-                            : spec.description;
-                        return (
-                            <Tooltip key={spec.key} title={title}>
-                                <Chip
-                                    size="small"
-                                    label={label}
-                                    color="primary"
-                                    variant="outlined"
-                                    onClick={onOpenCatalog}
-                                    onDelete={
-                                        spec.type === 'bool' && onToggleFlag
-                                            ? () => onToggleFlag(spec.key)
-                                            : undefined
-                                    }
-                                    sx={{ maxWidth: '100%', fontSize: '0.65rem', height: 20 }}
-                                />
-                            </Tooltip>
-                        );
-                    })}
-                </Stack>
+                <Box
+                    sx={{
+                        flexGrow: 1,
+                        minHeight: 0,
+                        overflowY: 'auto',
+                        // Hide scrollbar visually but keep it functional.
+                        scrollbarWidth: 'thin',
+                        '&::-webkit-scrollbar': { width: 4 },
+                        '&::-webkit-scrollbar-thumb': { backgroundColor: 'rgba(0,0,0,0.15)', borderRadius: 2 },
+                    }}
+                >
+                    <Stack direction="row" flexWrap="wrap" gap={0.25}>
+                        {enabled.map((spec) => {
+                            const isString = spec.type === 'string';
+                            const stringVal = isString ? flagStringValue(flags, spec.key) : '';
+                            const label = isString && stringVal ? `${spec.label}: ${stringVal}` : spec.label;
+                            const title = isString && stringVal
+                                ? `${spec.description}\nValue: ${stringVal}`
+                                : spec.description;
+                            return (
+                                <Tooltip key={spec.key} title={title}>
+                                    <Chip
+                                        size="small"
+                                        label={label}
+                                        color="primary"
+                                        variant="outlined"
+                                        onClick={onOpenCatalog}
+                                        onDelete={
+                                            spec.type === 'bool' && onToggleFlag
+                                                ? () => onToggleFlag(spec.key)
+                                                : undefined
+                                        }
+                                        sx={{ maxWidth: '100%', fontSize: '0.6rem', height: 18 }}
+                                    />
+                                </Tooltip>
+                            );
+                        })}
+                    </Stack>
+                </Box>
             )}
         </StyledExtensionsCard>
     );

--- a/frontend/src/components/rule-card/index.ts
+++ b/frontend/src/components/rule-card/index.ts
@@ -9,3 +9,7 @@ export * from './dialogs';
 
 // Utils
 export * from './utils';
+
+// Extension card + catalog dialog
+export { default as RuleExtensionsCard } from './RuleExtensionsCard';
+export { default as FlagCatalogDialog } from './FlagCatalogDialog';

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -115,6 +115,9 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                     flags: {
                         cursor_compat: newConfigRecord.flags?.cursorCompat || false,
                         cursor_compat_auto: newConfigRecord.flags?.cursorCompatAuto || false,
+                        skip_usage: newConfigRecord.flags?.skipUsage || false,
+                        custom_user_agent: newConfigRecord.flags?.customUserAgent || '',
+                        use_max_completion_tokens: newConfigRecord.flags?.useMaxCompletionTokens || false,
                     },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -118,6 +118,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         skip_usage: newConfigRecord.flags?.skipUsage || false,
                         custom_user_agent: newConfigRecord.flags?.customUserAgent || '',
                         use_max_completion_tokens: newConfigRecord.flags?.useMaxCompletionTokens || false,
+                        use_max_tokens: newConfigRecord.flags?.useMaxTokens || false,
                     },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -67,6 +67,9 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
         flags: {
             cursorCompat: rule.flags?.cursor_compat || false,
             cursorCompatAuto: rule.flags?.cursor_compat_auto || false,
+            skipUsage: rule.flags?.skip_usage || false,
+            customUserAgent: rule.flags?.custom_user_agent || '',
+            useMaxCompletionTokens: rule.flags?.use_max_completion_tokens || false,
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
@@ -154,6 +157,9 @@ interface ExportRule {
     flags?: {
         cursor_compat?: boolean;
         cursor_compat_auto?: boolean;
+        skip_usage?: boolean;
+        custom_user_agent?: string;
+        use_max_completion_tokens?: boolean;
     };
     smart_enabled?: boolean;
     smart_routing: any[];
@@ -187,13 +193,21 @@ export function formatRuleFlags(flags?: RuleFlags): string {
     const entries: string[] = [];
     if (flags.cursorCompat) entries.push('cursor_compat=true');
     if (flags.cursorCompatAuto) entries.push('cursor_compat_auto=true');
+    if (flags.skipUsage) entries.push('skip_usage=true');
+    if (flags.useMaxCompletionTokens) entries.push('use_max_completion_tokens=true');
+    if (flags.customUserAgent) entries.push(`custom_user_agent=${flags.customUserAgent}`);
     return entries.join(',');
 }
+
+const STRING_FLAG_KEYS = new Set(['custom_user_agent']);
 
 export function parseRuleFlags(input: string): { flags: RuleFlags; error?: string } {
     const flags: RuleFlags = {
         cursorCompat: false,
         cursorCompatAuto: false,
+        skipUsage: false,
+        customUserAgent: '',
+        useMaxCompletionTokens: false,
     };
 
     const trimmed = input.trim();
@@ -203,9 +217,23 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
 
     const parts = trimmed.split(',').map((part) => part.trim()).filter(Boolean);
     for (const part of parts) {
-        const [rawKey, rawValue] = part.split('=').map((chunk) => chunk.trim());
-        if (!rawKey || rawValue === undefined || rawValue === '') {
+        const eqIdx = part.indexOf('=');
+        if (eqIdx === -1) {
             return { flags, error: `Invalid flag format: "${part}". Use key=value.` };
+        }
+        const rawKey = part.slice(0, eqIdx).trim();
+        const rawValue = part.slice(eqIdx + 1).trim();
+        if (!rawKey || rawValue === '') {
+            return { flags, error: `Invalid flag format: "${part}". Use key=value.` };
+        }
+
+        if (STRING_FLAG_KEYS.has(rawKey)) {
+            switch (rawKey) {
+                case 'custom_user_agent':
+                    flags.customUserAgent = rawValue;
+                    break;
+            }
+            continue;
         }
 
         const valueLower = rawValue.toLowerCase();
@@ -225,12 +253,30 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             case 'cursor_compat_auto':
                 flags.cursorCompatAuto = parsedValue;
                 break;
+            case 'skip_usage':
+                flags.skipUsage = parsedValue;
+                break;
+            case 'use_max_completion_tokens':
+                flags.useMaxCompletionTokens = parsedValue;
+                break;
             default:
                 return { flags, error: `Unknown flag "${rawKey}".` };
         }
     }
 
     return { flags };
+}
+
+// Counts how many flags have a meaningful (non-default) value set.
+export function countActiveFlags(flags?: RuleFlags): number {
+    if (!flags) return 0;
+    let n = 0;
+    if (flags.cursorCompat) n++;
+    if (flags.cursorCompatAuto) n++;
+    if (flags.skipUsage) n++;
+    if (flags.useMaxCompletionTokens) n++;
+    if (flags.customUserAgent && flags.customUserAgent.trim() !== '') n++;
+    return n;
 }
 
 // Generic export handler

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -70,6 +70,7 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
             skipUsage: rule.flags?.skip_usage || false,
             customUserAgent: rule.flags?.custom_user_agent || '',
             useMaxCompletionTokens: rule.flags?.use_max_completion_tokens || false,
+            useMaxTokens: rule.flags?.use_max_tokens || false,
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
@@ -160,6 +161,7 @@ interface ExportRule {
         skip_usage?: boolean;
         custom_user_agent?: string;
         use_max_completion_tokens?: boolean;
+        use_max_tokens?: boolean;
     };
     smart_enabled?: boolean;
     smart_routing: any[];
@@ -195,6 +197,7 @@ export function formatRuleFlags(flags?: RuleFlags): string {
     if (flags.cursorCompatAuto) entries.push('cursor_compat_auto=true');
     if (flags.skipUsage) entries.push('skip_usage=true');
     if (flags.useMaxCompletionTokens) entries.push('use_max_completion_tokens=true');
+    if (flags.useMaxTokens) entries.push('use_max_tokens=true');
     if (flags.customUserAgent) entries.push(`custom_user_agent=${flags.customUserAgent}`);
     return entries.join(',');
 }
@@ -208,6 +211,7 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
         skipUsage: false,
         customUserAgent: '',
         useMaxCompletionTokens: false,
+        useMaxTokens: false,
     };
 
     const trimmed = input.trim();
@@ -259,6 +263,9 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             case 'use_max_completion_tokens':
                 flags.useMaxCompletionTokens = parsedValue;
                 break;
+            case 'use_max_tokens':
+                flags.useMaxTokens = parsedValue;
+                break;
             default:
                 return { flags, error: `Unknown flag "${rawKey}".` };
         }
@@ -275,6 +282,7 @@ export function countActiveFlags(flags?: RuleFlags): number {
     if (flags.cursorCompatAuto) n++;
     if (flags.skipUsage) n++;
     if (flags.useMaxCompletionTokens) n++;
+    if (flags.useMaxTokens) n++;
     if (flags.customUserAgent && flags.customUserAgent.trim() !== '') n++;
     return n;
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -491,6 +491,12 @@ export const api = {
         }
     },
 
+    // PLACEHOLDER: replace with codegen client once openapi schema is regenerated.
+    // Backend: GET /api/v1/rule/flags/registry returns { success, data: FlagSpec[] }
+    getRuleFlagRegistry: async (): Promise<any> => {
+        return uiAPI('/rule/flags/registry', {method: 'GET'});
+    },
+
     importRule: async (data: string, onProviderConflict: string = 'use', onRuleConflict: string = 'new'): Promise<any> => {
         return uiAPI('/rule/import', {
             method: 'POST',

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -81,7 +81,14 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 				provider.OAuthDetail.GetIssuer(), sessionID.Value)
 		}
 	} else {
+		// Generic non-OAuth Anthropic provider. Apply the same User-Agent
+		// layering as the generic OpenAI client (rule > provider): rule-UA
+		// wraps innermost so it overwrites the header last, provider-UA sits
+		// outside. OAuth issuers above keep their dedicated transport chain
+		// unchanged because vendor-specific round-trippers manage UA themselves.
 		transport = http.DefaultTransport
+		transport = &customUserAgentTransport{base: transport}
+		transport = wrapWithUserAgent(transport, provider)
 	}
 
 	httpClient := &http.Client{

--- a/internal/client/custom_ua_transport.go
+++ b/internal/client/custom_ua_transport.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// customUserAgentTransport applies a per-request User-Agent override when one
+// is attached to the request context via typ.WithCustomUserAgent. This lets
+// rule-level flags retarget upstream identification without rebuilding the
+// pooled OpenAI client.
+type customUserAgentTransport struct {
+	base http.RoundTripper
+}
+
+func (t *customUserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if ua := typ.GetCustomUserAgent(req.Context()); ua != "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", ua)
+	}
+	return base.RoundTrip(req)
+}

--- a/internal/client/custom_ua_transport_test.go
+++ b/internal/client/custom_ua_transport_test.go
@@ -1,0 +1,155 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// captureTransport records every request's User-Agent header.
+type captureTransport struct {
+	lastUA string
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.lastUA = req.Header.Get("User-Agent")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+func newReq(t *testing.T, ctx context.Context, ua string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.test/v1/foo", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if ua != "" {
+		req.Header.Set("User-Agent", ua)
+	}
+	return req
+}
+
+func TestCustomUserAgentTransport_NoContextValue_PassesThrough(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &customUserAgentTransport{base: cap}
+	req := newReq(t, context.Background(), "original/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if cap.lastUA != "original/1.0" {
+		t.Errorf("UA = %q, want passthrough %q", cap.lastUA, "original/1.0")
+	}
+}
+
+func TestCustomUserAgentTransport_OverridesWhenContextSet(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &customUserAgentTransport{base: cap}
+	ctx := typ.WithCustomUserAgent(context.Background(), "MyApp/1.0")
+	req := newReq(t, ctx, "original/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if cap.lastUA != "MyApp/1.0" {
+		t.Errorf("UA = %q, want override %q", cap.lastUA, "MyApp/1.0")
+	}
+}
+
+func TestCustomUserAgentTransport_DoesNotMutateOriginalRequest(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &customUserAgentTransport{base: cap}
+	ctx := typ.WithCustomUserAgent(context.Background(), "MyApp/1.0")
+	req := newReq(t, ctx, "original/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	// The caller's request must still see the original UA header because
+	// the transport clones before mutating — otherwise concurrent retries
+	// would race on shared headers.
+	if got := req.Header.Get("User-Agent"); got != "original/1.0" {
+		t.Errorf("caller's req mutated: UA = %q, want %q", got, "original/1.0")
+	}
+}
+
+func TestCustomUserAgentTransport_NilBaseFallsBackToDefault(t *testing.T) {
+	// When base is nil the wrapper must not panic; it falls back to
+	// http.DefaultTransport. We can't easily exercise the fallback without
+	// network access, so just verify the nil case doesn't crash before
+	// dispatching by hitting an httptest server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	wrapped := &customUserAgentTransport{base: nil}
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := wrapped.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+}
+
+func TestCustomUserAgentTransport_EmptyContextValueIsNoOp(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &customUserAgentTransport{base: cap}
+	// WithCustomUserAgent("") explicitly skips attaching the value, so this
+	// effectively tests that an empty rule flag does not blank out an
+	// existing UA header.
+	ctx := typ.WithCustomUserAgent(context.Background(), "")
+	req := newReq(t, ctx, "fallback/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if cap.lastUA != "fallback/1.0" {
+		t.Errorf("UA = %q, want passthrough %q", cap.lastUA, "fallback/1.0")
+	}
+}
+
+func TestWrapWithUserAgent_RuleAndProviderLayering(t *testing.T) {
+	// Simulate the full chain used by client/openai.go and client/anthropic.go:
+	//   wrapWithUserAgent(provider)  -> outer
+	//     customUserAgentTransport   -> rule UA, innermost
+	//       captureTransport         -> wire
+	// Rule UA should win when both are present.
+	cap := &captureTransport{}
+	prov := &typ.Provider{UserAgent: "ProviderUA/1.0"}
+
+	var transport http.RoundTripper = cap
+	transport = &customUserAgentTransport{base: transport}
+	transport = wrapWithUserAgent(transport, prov)
+
+	t.Run("rule overrides provider", func(t *testing.T) {
+		ctx := typ.WithCustomUserAgent(context.Background(), "RuleUA/1.0")
+		req := newReq(t, ctx, "")
+		if _, err := transport.RoundTrip(req); err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		if cap.lastUA != "RuleUA/1.0" {
+			t.Errorf("UA = %q, want rule wins (%q)", cap.lastUA, "RuleUA/1.0")
+		}
+	})
+
+	t.Run("provider wins when rule absent", func(t *testing.T) {
+		req := newReq(t, context.Background(), "")
+		if _, err := transport.RoundTrip(req); err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		if cap.lastUA != "ProviderUA/1.0" {
+			t.Errorf("UA = %q, want provider fallback (%q)", cap.lastUA, "ProviderUA/1.0")
+		}
+	})
+}

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -33,6 +33,13 @@ func (t *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 // wrapWithUserAgent wraps a transport with a User-Agent override when the
 // provider has a custom UA configured. Returns the original transport unchanged
 // when no override is set.
+//
+// Design note: provider.UserAgent is treated as a deliberate debug knob — when
+// non-empty it intentionally overrides even vendor-pinned UAs (claude-cli,
+// GeminiCLI, codex, …) because we don't want to hide the configured value
+// behind silent precedence rules. Operators who set this should know what
+// they're doing; the catch lives in ai/provider.go's UserAgent doc comment.
+// Rule-level custom_user_agent layers innermost so it still wins over both.
 func wrapWithUserAgent(inner http.RoundTripper, provider *typ.Provider) http.RoundTripper {
 	if provider == nil || provider.UserAgent == "" {
 		return inner

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -73,6 +73,7 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 
 	// For non-OAuth providers without proxy, use default transport
 	transport = http.DefaultTransport
+	transport = &customUserAgentTransport{base: transport}
 
 	httpClient := &http.Client{
 		Transport: transport,

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -71,9 +71,15 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	// Create HTTP client with session-bound transport
 	var transport http.RoundTripper
 
-	// For non-OAuth providers without proxy, use default transport
+	// For non-OAuth providers without proxy, use default transport.
+	//
+	// User-Agent layering (rule > provider): rule-UA wraps the base transport
+	// innermost so it overwrites the header last (closest to the wire), then
+	// the provider-UA wrapper sits outside. When the rule flag is absent the
+	// rule-UA wrapper is a no-op, leaving provider-UA in effect.
 	transport = http.DefaultTransport
 	transport = &customUserAgentTransport{base: transport}
+	transport = wrapWithUserAgent(transport, provider)
 
 	httpClient := &http.Client{
 		Transport: transport,

--- a/internal/protocol/transform/openai_max_tokens_rewrite.go
+++ b/internal/protocol/transform/openai_max_tokens_rewrite.go
@@ -1,8 +1,7 @@
-package server
+package transform
 
 import (
 	"github.com/openai/openai-go/v3"
-	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
 )
 
@@ -37,7 +36,7 @@ func (t *OpenAIMaxTokensRewriteTransform) Name() string {
 
 // Apply rewrites the token field on OpenAI Chat requests. For any other
 // post-base shape (Anthropic, Responses, Google) it is a no-op.
-func (t *OpenAIMaxTokensRewriteTransform) Apply(ctx *protocoltransform.TransformContext) error {
+func (t *OpenAIMaxTokensRewriteTransform) Apply(ctx *TransformContext) error {
 	req, ok := ctx.Request.(*openai.ChatCompletionNewParams)
 	if !ok {
 		return nil

--- a/internal/protocol/transform/openai_max_tokens_rewrite_test.go
+++ b/internal/protocol/transform/openai_max_tokens_rewrite_test.go
@@ -1,4 +1,4 @@
-package server
+package transform
 
 import (
 	"testing"
@@ -7,7 +7,6 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
-	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
 )
 
 func TestOpenAIMaxTokensRewriteTransform_Name(t *testing.T) {
@@ -21,7 +20,7 @@ func TestOpenAIMaxTokensRewriteTransform_AppliesOnOpenAIChat(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		MaxTokens: param.NewOpt(int64(1024)),
 	}
-	ctx := &protocoltransform.TransformContext{Request: req}
+	ctx := &TransformContext{Request: req}
 
 	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
 	if err := tf.Apply(ctx); err != nil {
@@ -39,7 +38,7 @@ func TestOpenAIMaxTokensRewriteTransform_ReverseDirection(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		MaxCompletionTokens: param.NewOpt(int64(2048)),
 	}
-	ctx := &protocoltransform.TransformContext{Request: req}
+	ctx := &TransformContext{Request: req}
 
 	tf := NewOpenAIMaxTokensRewriteTransform(false, true)
 	if err := tf.Apply(ctx); err != nil {
@@ -57,7 +56,7 @@ func TestOpenAIMaxTokensRewriteTransform_BothFlagsOff_NoOp(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		MaxTokens: param.NewOpt(int64(1024)),
 	}
-	ctx := &protocoltransform.TransformContext{Request: req}
+	ctx := &TransformContext{Request: req}
 
 	tf := NewOpenAIMaxTokensRewriteTransform(false, false)
 	if err := tf.Apply(ctx); err != nil {
@@ -73,7 +72,7 @@ func TestOpenAIMaxTokensRewriteTransform_BothFlagsOff_NoOp(t *testing.T) {
 
 func TestOpenAIMaxTokensRewriteTransform_NoOpOnAnthropicV1(t *testing.T) {
 	req := &anthropic.MessageNewParams{MaxTokens: 1024}
-	ctx := &protocoltransform.TransformContext{Request: req}
+	ctx := &TransformContext{Request: req}
 
 	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
 	if err := tf.Apply(ctx); err != nil {
@@ -86,7 +85,7 @@ func TestOpenAIMaxTokensRewriteTransform_NoOpOnAnthropicV1(t *testing.T) {
 
 func TestOpenAIMaxTokensRewriteTransform_NoOpOnAnthropicBeta(t *testing.T) {
 	req := &anthropic.BetaMessageNewParams{MaxTokens: 1024}
-	ctx := &protocoltransform.TransformContext{Request: req}
+	ctx := &TransformContext{Request: req}
 
 	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
 	if err := tf.Apply(ctx); err != nil {
@@ -99,7 +98,7 @@ func TestOpenAIMaxTokensRewriteTransform_NoOpOnAnthropicBeta(t *testing.T) {
 
 func TestOpenAIMaxTokensRewriteTransform_NoOpOnResponses(t *testing.T) {
 	req := &responses.ResponseNewParams{}
-	ctx := &protocoltransform.TransformContext{Request: req}
+	ctx := &TransformContext{Request: req}
 
 	tf := NewOpenAIMaxTokensRewriteTransform(true, true)
 	if err := tf.Apply(ctx); err != nil {
@@ -110,7 +109,7 @@ func TestOpenAIMaxTokensRewriteTransform_NoOpOnResponses(t *testing.T) {
 }
 
 func TestOpenAIMaxTokensRewriteTransform_NilRequest(t *testing.T) {
-	ctx := &protocoltransform.TransformContext{Request: nil}
+	ctx := &TransformContext{Request: nil}
 	tf := NewOpenAIMaxTokensRewriteTransform(true, true)
 	if err := tf.Apply(ctx); err != nil {
 		t.Fatalf("Apply on nil request failed: %v", err)
@@ -124,7 +123,7 @@ type stubBaseTransform struct{}
 
 func (stubBaseTransform) Name() string { return "stub_base" }
 
-func (stubBaseTransform) Apply(ctx *protocoltransform.TransformContext) error {
+func (stubBaseTransform) Apply(ctx *TransformContext) error {
 	if a, ok := ctx.Request.(*anthropic.MessageNewParams); ok {
 		ctx.Request = &openai.ChatCompletionNewParams{
 			MaxTokens: param.NewOpt(a.MaxTokens),
@@ -140,9 +139,9 @@ func (stubBaseTransform) Apply(ctx *protocoltransform.TransformContext) error {
 // chain ordering works correctly.
 func TestOpenAIMaxTokensRewriteTransform_FiresAfterBase(t *testing.T) {
 	original := &anthropic.MessageNewParams{MaxTokens: 4096}
-	ctx := &protocoltransform.TransformContext{Request: original}
+	ctx := &TransformContext{Request: original}
 
-	chain := protocoltransform.NewTransformChain([]protocoltransform.Transform{
+	chain := NewTransformChain([]Transform{
 		stubBaseTransform{},
 		NewOpenAIMaxTokensRewriteTransform(true, false),
 	})

--- a/internal/protocol/transform/ops/request_openai_max_tokens.go
+++ b/internal/protocol/transform/ops/request_openai_max_tokens.go
@@ -1,0 +1,37 @@
+package ops
+
+import (
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+// ApplyMaxCompletionTokensRewrite moves the value of `max_tokens` into the
+// newer `max_completion_tokens` field. OpenAI's o1/o3/gpt-5 families reject
+// `max_tokens`; this rewrite lets callers opt in per rule.
+//
+// The cleared field uses the zero `param.Opt[int64]{}` so the SDK's
+// `omitzero` JSON tag drops it from the wire body instead of emitting
+// `"max_tokens": 0`.
+func ApplyMaxCompletionTokensRewrite(req *openai.ChatCompletionNewParams) {
+	if req == nil {
+		return
+	}
+	if req.MaxTokens.Valid() {
+		req.MaxCompletionTokens = param.NewOpt(req.MaxTokens.Value)
+		req.MaxTokens = param.Opt[int64]{}
+	}
+}
+
+// ApplyMaxTokensRewrite moves the value of `max_completion_tokens` back into
+// the legacy `max_tokens` field. Some providers and older model endpoints
+// reject the newer field name; this rewrite lets callers force the legacy
+// field per rule.
+func ApplyMaxTokensRewrite(req *openai.ChatCompletionNewParams) {
+	if req == nil {
+		return
+	}
+	if req.MaxCompletionTokens.Valid() {
+		req.MaxTokens = param.NewOpt(req.MaxCompletionTokens.Value)
+		req.MaxCompletionTokens = param.Opt[int64]{}
+	}
+}

--- a/internal/protocol/transform/ops/request_openai_max_tokens_test.go
+++ b/internal/protocol/transform/ops/request_openai_max_tokens_test.go
@@ -1,0 +1,176 @@
+package ops
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+// marshalTokenFields serializes a ChatCompletionNewParams to a JSON map so
+// tests can assert on wire presence/absence of fields. This proves the SDK's
+// omitzero tag actually drops a cleared field instead of emitting it as zero.
+func marshalTokenFields(t *testing.T, req *openai.ChatCompletionNewParams) map[string]interface{} {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	return m
+}
+
+func jsonKeys(m map[string]interface{}) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
+}
+
+func TestApplyMaxCompletionTokensRewrite_NilSafe(t *testing.T) {
+	ApplyMaxCompletionTokensRewrite(nil)
+}
+
+func TestApplyMaxCompletionTokensRewrite_MovesMaxTokens(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens: param.NewOpt(int64(1024)),
+	}
+	ApplyMaxCompletionTokensRewrite(req)
+
+	if req.MaxTokens.Valid() {
+		t.Errorf("expected MaxTokens cleared after rewrite, got %v", req.MaxTokens.Value)
+	}
+	if !req.MaxCompletionTokens.Valid() {
+		t.Fatalf("expected MaxCompletionTokens populated after rewrite")
+	}
+	if req.MaxCompletionTokens.Value != 1024 {
+		t.Errorf("MaxCompletionTokens = %d, want 1024", req.MaxCompletionTokens.Value)
+	}
+}
+
+func TestApplyMaxCompletionTokensRewrite_NoMaxTokensNoOp(t *testing.T) {
+	// When neither field is set the rewrite is a no-op (avoid emitting an
+	// explicit max_completion_tokens=0 which most providers reject).
+	req := &openai.ChatCompletionNewParams{}
+	ApplyMaxCompletionTokensRewrite(req)
+	if req.MaxTokens.Valid() {
+		t.Errorf("MaxTokens unexpectedly valid: %#v", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("MaxCompletionTokens unexpectedly valid: %#v", req.MaxCompletionTokens)
+	}
+}
+
+func TestApplyMaxCompletionTokensRewrite_PreservesExistingMaxCompletionTokens(t *testing.T) {
+	// If both fields are already present (caller supplied them), prefer the
+	// MaxTokens migration but document the surprising case.
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens:           param.NewOpt(int64(512)),
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+	ApplyMaxCompletionTokensRewrite(req)
+
+	if req.MaxTokens.Valid() {
+		t.Errorf("expected MaxTokens cleared, got %v", req.MaxTokens.Value)
+	}
+	if req.MaxCompletionTokens.Value != 512 {
+		t.Errorf("MaxCompletionTokens = %d, want 512 (rewrite overrides existing)", req.MaxCompletionTokens.Value)
+	}
+}
+
+func TestApplyMaxTokensRewrite_NilSafe(t *testing.T) {
+	ApplyMaxTokensRewrite(nil)
+}
+
+func TestApplyMaxTokensRewrite_MovesMaxCompletionTokens(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+	ApplyMaxTokensRewrite(req)
+
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("expected MaxCompletionTokens cleared after rewrite, got %v", req.MaxCompletionTokens.Value)
+	}
+	if !req.MaxTokens.Valid() {
+		t.Fatalf("expected MaxTokens populated after rewrite")
+	}
+	if req.MaxTokens.Value != 2048 {
+		t.Errorf("MaxTokens = %d, want 2048", req.MaxTokens.Value)
+	}
+}
+
+func TestApplyMaxTokensRewrite_NoMaxCompletionTokensNoOp(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{}
+	ApplyMaxTokensRewrite(req)
+	if req.MaxTokens.Valid() {
+		t.Errorf("MaxTokens unexpectedly valid: %#v", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("MaxCompletionTokens unexpectedly valid: %#v", req.MaxCompletionTokens)
+	}
+}
+
+// TestMaxCompletionTokensRewrite_WireSerialization verifies that after
+// ApplyMaxCompletionTokensRewrite the OpenAI SDK serializes
+// "max_completion_tokens" and omits "max_tokens" from the JSON body.
+// This guards against silent regression where a struct-level change doesn't
+// propagate to the actual HTTP request body.
+func TestMaxCompletionTokensRewrite_WireSerialization(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens: param.NewOpt(int64(1024)),
+	}
+
+	before := marshalTokenFields(t, req)
+	if _, ok := before["max_tokens"]; !ok {
+		t.Errorf("before rewrite: expected 'max_tokens' in JSON, got keys: %v", jsonKeys(before))
+	}
+	if _, ok := before["max_completion_tokens"]; ok {
+		t.Errorf("before rewrite: unexpected 'max_completion_tokens' in JSON")
+	}
+
+	ApplyMaxCompletionTokensRewrite(req)
+
+	after := marshalTokenFields(t, req)
+	if _, ok := after["max_completion_tokens"]; !ok {
+		t.Errorf("after rewrite: expected 'max_completion_tokens' in JSON, got keys: %v", jsonKeys(after))
+	}
+	if _, ok := after["max_tokens"]; ok {
+		t.Errorf("after rewrite: unexpected 'max_tokens' still present in JSON")
+	}
+	if v, _ := after["max_completion_tokens"].(float64); int(v) != 1024 {
+		t.Errorf("after rewrite: max_completion_tokens = %v, want 1024", after["max_completion_tokens"])
+	}
+}
+
+// TestMaxTokensRewrite_WireSerialization verifies the inverse: after
+// ApplyMaxTokensRewrite the SDK emits "max_tokens" and omits
+// "max_completion_tokens".
+func TestMaxTokensRewrite_WireSerialization(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+
+	before := marshalTokenFields(t, req)
+	if _, ok := before["max_completion_tokens"]; !ok {
+		t.Errorf("before rewrite: expected 'max_completion_tokens' in JSON, got keys: %v", jsonKeys(before))
+	}
+
+	ApplyMaxTokensRewrite(req)
+
+	after := marshalTokenFields(t, req)
+	if _, ok := after["max_tokens"]; !ok {
+		t.Errorf("after rewrite: expected 'max_tokens' in JSON, got keys: %v", jsonKeys(after))
+	}
+	if _, ok := after["max_completion_tokens"]; ok {
+		t.Errorf("after rewrite: unexpected 'max_completion_tokens' still present in JSON")
+	}
+	if v, _ := after["max_tokens"].(float64); int(v) != 2048 {
+		t.Errorf("after rewrite: max_tokens = %v, want 2048", after["max_tokens"])
+	}
+}

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -88,7 +88,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 		recorder = s.EnsureProtocolRecorder(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
-	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType)
+	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(rule)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -88,7 +88,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 		recorder = s.EnsureProtocolRecorder(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
-	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(rule)...)
+	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(resolveRuleFlags(rule))...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -82,7 +82,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 		recorder = s.EnsureProtocolRecorder(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
-	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType)
+	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(rule)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -82,7 +82,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 		recorder = s.EnsureProtocolRecorder(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
-	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(rule)...)
+	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(resolveRuleFlags(rule))...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/module/rule/flag_registry_handler_test.go
+++ b/internal/server/module/rule/flag_registry_handler_test.go
@@ -1,0 +1,69 @@
+package rule
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+)
+
+func TestGetFlagRegistry_ReturnsCatalog(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	router := setupTestRouter(cfg)
+	handler := NewHandler(cfg)
+	router.GET("/rule/flags/registry", handler.GetFlagRegistry)
+
+	req, _ := http.NewRequest("GET", "/rule/flags/registry", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	var resp FlagRegistryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v (body=%s)", err, w.Body.String())
+	}
+	if !resp.Success {
+		t.Errorf("Success = false, want true")
+	}
+	if len(resp.Data) == 0 {
+		t.Fatalf("expected non-empty flag registry, got 0 entries")
+	}
+
+	// At least the historical cursor flags must be exposed.
+	want := map[string]bool{
+		"cursor_compat":      false,
+		"cursor_compat_auto": false,
+	}
+	for _, spec := range resp.Data {
+		if _, ok := want[spec.Key]; ok {
+			want[spec.Key] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("registry missing required key %q", k)
+		}
+	}
+}
+
+func TestGetFlagRegistry_NilConfigStillServes(t *testing.T) {
+	// The registry is static metadata that doesn't depend on persisted rule
+	// state, so it must succeed even when the handler was constructed
+	// without a config (e.g. early boot path).
+	router := setupTestRouter(nil)
+	handler := NewHandler(nil)
+	router.GET("/rule/flags/registry", handler.GetFlagRegistry)
+
+	req, _ := http.NewRequest("GET", "/rule/flags/registry", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -272,6 +272,14 @@ func (h *Handler) DeleteRule(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+// GetFlagRegistry returns the catalog of supported rule-level flags.
+func (h *Handler) GetFlagRegistry(c *gin.Context) {
+	c.JSON(http.StatusOK, FlagRegistryResponse{
+		Success: true,
+		Data:    typ.RuleFlagRegistry(),
+	})
+}
+
 // ImportRule imports a rule from base64 encoded data
 func (h *Handler) ImportRule(c *gin.Context) {
 	cfg := h.config

--- a/internal/server/module/rule/routes.go
+++ b/internal/server/module/rule/routes.go
@@ -44,6 +44,13 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithResponseModel(DeleteRuleResponse{}),
 	)
 
+	// GET /rule/flags/registry - Get catalog of supported rule-level flags
+	router.GET("/rule/flags/registry", handler.GetFlagRegistry,
+		swagger.WithDescription("Get the catalog of supported rule-level flags"),
+		swagger.WithTags("rules"),
+		swagger.WithResponseModel(FlagRegistryResponse{}),
+	)
+
 	// POST /rule/import - Import a rule from base64 encoded data
 	router.POST("/rule/import", handler.ImportRule,
 		swagger.WithDescription("Import a rule from base64 encoded data"),

--- a/internal/server/module/rule/types.go
+++ b/internal/server/module/rule/types.go
@@ -81,3 +81,10 @@ type ProviderInfo struct {
 	Name   string `json:"name" example:"openai"`
 	Action string `json:"action" example:"created"` // "created", "used", "skipped"
 }
+
+// FlagRegistryResponse exposes the catalog of supported rule-level flags so the
+// UI can render an extension catalog without hard-coding the list.
+type FlagRegistryResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    []typ.FlagSpec `json:"data"`
+}

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -252,12 +252,6 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	cursorCompat := resolveCursorCompat(c, rule)
 	applyCursorCompatFlag(&req.ChatCompletionNewParams, cursorCompat)
 	ruleFlags := resolveRuleFlags(rule)
-	if ruleFlags.UseMaxCompletionTokens {
-		ops.ApplyMaxCompletionTokensRewrite(&req.ChatCompletionNewParams)
-	}
-	if ruleFlags.UseMaxTokens {
-		ops.ApplyMaxTokensRewrite(&req.ChatCompletionNewParams)
-	}
 	if ruleFlags.CustomUserAgent != "" {
 		c.Request = c.Request.WithContext(typ.WithCustomUserAgent(c.Request.Context(), ruleFlags.CustomUserAgent))
 	}
@@ -307,7 +301,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	}
 
 	// === Transform via pipeline ===
-	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType)
+	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, ruleExtraTransforms(rule)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -251,6 +251,13 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
 	cursorCompat := resolveCursorCompat(c, rule)
 	applyCursorCompatFlag(&req.ChatCompletionNewParams, cursorCompat)
+	ruleFlags := resolveRuleFlags(rule)
+	if ruleFlags.UseMaxCompletionTokens {
+		applyMaxCompletionTokensRewrite(&req.ChatCompletionNewParams)
+	}
+	if ruleFlags.CustomUserAgent != "" {
+		c.Request = c.Request.WithContext(typ.WithCustomUserAgent(c.Request.Context(), ruleFlags.CustomUserAgent))
+	}
 
 	// Inject session ID into request context so all downstream code can access it
 	sessionID := resolveSessionID(c, &req.ChatCompletionNewParams)
@@ -308,6 +315,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 		return
 	}
 	reqCtx.Extra["cursor_compat"] = cursorCompat
+	reqCtx.Extra["skip_usage"] = ruleFlags.SkipUsage
 
 	// === Dispatch via transform chain ===
 	reqCtx.RequestModel = actualModel

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -255,6 +255,9 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	if ruleFlags.UseMaxCompletionTokens {
 		applyMaxCompletionTokensRewrite(&req.ChatCompletionNewParams)
 	}
+	if ruleFlags.UseMaxTokens {
+		applyMaxTokensRewrite(&req.ChatCompletionNewParams)
+	}
 	if ruleFlags.CustomUserAgent != "" {
 		c.Request = c.Request.WithContext(typ.WithCustomUserAgent(c.Request.Context(), ruleFlags.CustomUserAgent))
 	}

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -253,10 +253,10 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	applyCursorCompatFlag(&req.ChatCompletionNewParams, cursorCompat)
 	ruleFlags := resolveRuleFlags(rule)
 	if ruleFlags.UseMaxCompletionTokens {
-		applyMaxCompletionTokensRewrite(&req.ChatCompletionNewParams)
+		ops.ApplyMaxCompletionTokensRewrite(&req.ChatCompletionNewParams)
 	}
 	if ruleFlags.UseMaxTokens {
-		applyMaxTokensRewrite(&req.ChatCompletionNewParams)
+		ops.ApplyMaxTokensRewrite(&req.ChatCompletionNewParams)
 	}
 	if ruleFlags.CustomUserAgent != "" {
 		c.Request = c.Request.WithContext(typ.WithCustomUserAgent(c.Request.Context(), ruleFlags.CustomUserAgent))

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -301,7 +301,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	}
 
 	// === Transform via pipeline ===
-	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, ruleExtraTransforms(rule)...)
+	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, ruleExtraTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -219,7 +219,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	}
 
 	// Execute transform chain
-	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed)
+	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, ruleExtraTransforms(rule)...)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -219,7 +219,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	}
 
 	// Execute transform chain
-	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, ruleExtraTransforms(rule)...)
+	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, ruleExtraTransforms(resolveRuleFlags(rule))...)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -182,15 +182,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 	fc := forwarding.NewForwardContext(ctx, provider)
 
 	if isStreaming {
-		disableStreamUsage := false
-		if v, ok := reqCtx.Extra["cursor_compat"]; ok {
-			disableStreamUsage = v.(bool)
-		}
-		if v, ok := reqCtx.Extra["skip_usage"]; ok {
-			if b, _ := v.(bool); b {
-				disableStreamUsage = true
-			}
-		}
+		disableStreamUsage := shouldStripUsage(reqCtx.Extra)
 		if reqCtx.ScenarioFlags != nil {
 			disableStreamUsage = disableStreamUsage || reqCtx.ScenarioFlags.DisableStreamUsage
 		}
@@ -284,16 +276,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 			}
 			openaiResp = roundtripped
 		}
-		stripUsage := false
-		if v, ok := reqCtx.Extra["cursor_compat"]; ok {
-			stripUsage = v.(bool)
-		}
-		if v, ok := reqCtx.Extra["skip_usage"]; ok {
-			if b, _ := v.(bool); b {
-				stripUsage = true
-			}
-		}
-		if stripUsage {
+		if shouldStripUsage(reqCtx.Extra) {
 			delete(openaiResp, "usage")
 		}
 
@@ -667,15 +650,7 @@ func (s *Server) dispatchOpenAIChat(
 			s.streamOpenAIChatToAnthropicBetaWithMCP(c, provider, req, actualModel, responseModel, recorder)
 		case protocol.TypeOpenAIChat:
 			// OpenAI passthrough: source and target are both OpenAI Chat format
-			disableStreamUsage := false
-			if v, ok := reqCtx.Extra["cursor_compat"]; ok {
-				disableStreamUsage = v.(bool)
-			}
-			if v, ok := reqCtx.Extra["skip_usage"]; ok {
-				if b, _ := v.(bool); b {
-					disableStreamUsage = true
-				}
-			}
+			disableStreamUsage := shouldStripUsage(reqCtx.Extra)
 			if reqCtx.ScenarioFlags != nil {
 				disableStreamUsage = disableStreamUsage || reqCtx.ScenarioFlags.DisableStreamUsage
 			}
@@ -693,15 +668,7 @@ func (s *Server) dispatchOpenAIChat(
 		switch reqCtx.SourceAPI {
 		case protocol.TypeOpenAIChat:
 			// OpenAI passthrough: delegate to handleNonStreamingRequest for tool interceptor support
-			stripUsage := false
-			if v, ok := reqCtx.Extra["cursor_compat"]; ok {
-				stripUsage = v.(bool)
-			}
-			if v, ok := reqCtx.Extra["skip_usage"]; ok {
-				if b, _ := v.(bool); b {
-					stripUsage = true
-				}
-			}
+			stripUsage := shouldStripUsage(reqCtx.Extra)
 
 			if hasDeclaredMCPTools(req) && s.mcpEnabled() {
 				s.dispatchGenericOpenAIChatNonStream(c, reqCtx, rule, provider, recorder)

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -186,6 +186,11 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 		if v, ok := reqCtx.Extra["cursor_compat"]; ok {
 			disableStreamUsage = v.(bool)
 		}
+		if v, ok := reqCtx.Extra["skip_usage"]; ok {
+			if b, _ := v.(bool); b {
+				disableStreamUsage = true
+			}
+		}
 		if reqCtx.ScenarioFlags != nil {
 			disableStreamUsage = disableStreamUsage || reqCtx.ScenarioFlags.DisableStreamUsage
 		}
@@ -279,11 +284,16 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 			}
 			openaiResp = roundtripped
 		}
-		cursorCompat := false
+		stripUsage := false
 		if v, ok := reqCtx.Extra["cursor_compat"]; ok {
-			cursorCompat = v.(bool)
+			stripUsage = v.(bool)
 		}
-		if cursorCompat {
+		if v, ok := reqCtx.Extra["skip_usage"]; ok {
+			if b, _ := v.(bool); b {
+				stripUsage = true
+			}
+		}
+		if stripUsage {
 			delete(openaiResp, "usage")
 		}
 
@@ -661,6 +671,11 @@ func (s *Server) dispatchOpenAIChat(
 			if v, ok := reqCtx.Extra["cursor_compat"]; ok {
 				disableStreamUsage = v.(bool)
 			}
+			if v, ok := reqCtx.Extra["skip_usage"]; ok {
+				if b, _ := v.(bool); b {
+					disableStreamUsage = true
+				}
+			}
 			if reqCtx.ScenarioFlags != nil {
 				disableStreamUsage = disableStreamUsage || reqCtx.ScenarioFlags.DisableStreamUsage
 			}
@@ -681,6 +696,11 @@ func (s *Server) dispatchOpenAIChat(
 			stripUsage := false
 			if v, ok := reqCtx.Extra["cursor_compat"]; ok {
 				stripUsage = v.(bool)
+			}
+			if v, ok := reqCtx.Extra["skip_usage"]; ok {
+				if b, _ := v.(bool); b {
+					stripUsage = true
+				}
 			}
 
 			if hasDeclaredMCPTools(req) && s.mcpEnabled() {

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,12 +8,15 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
+	}
+	for _, t := range extraTransforms {
+		chain.Add(t)
 	}
 
 	// Create transform context
@@ -77,11 +80,14 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	return finalCtx, nil
 }
 
-func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
+	}
+	for _, t := range extraTransforms {
+		chain.Add(t)
 	}
 
 	// Create transform context
@@ -142,11 +148,14 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
+	}
+	for _, t := range extraTransforms {
+		chain.Add(t)
 	}
 
 	// Create transform context
@@ -196,11 +205,14 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
+	}
+	for _, t := range extraTransforms {
+		chain.Add(t)
 	}
 
 	// Create transform context

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,6 +8,15 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// appendExtraTransforms tacks rule-driven post-base transforms onto a chain
+// built by BuildTransformChain. Kept rule-agnostic — the caller decides what
+// to append.
+func appendExtraTransforms(chain *transform.TransformChain, extras []transform.Transform) {
+	for _, t := range extras {
+		chain.Add(t)
+	}
+}
+
 func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support
@@ -15,9 +24,7 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	if err != nil {
 		return nil, err
 	}
-	for _, t := range extraTransforms {
-		chain.Add(t)
-	}
+	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags
@@ -86,9 +93,7 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	if err != nil {
 		return nil, err
 	}
-	for _, t := range extraTransforms {
-		chain.Add(t)
-	}
+	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags
@@ -154,9 +159,7 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	if err != nil {
 		return nil, err
 	}
-	for _, t := range extraTransforms {
-		chain.Add(t)
-	}
+	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags
@@ -211,9 +214,7 @@ func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseC
 	if err != nil {
 		return nil, err
 	}
-	for _, t := range extraTransforms {
-		chain.Add(t)
-	}
+	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -27,3 +27,27 @@ func applyMaxCompletionTokensRewrite(req *openai.ChatCompletionNewParams) {
 		req.MaxTokens = param.Opt[int64]{}
 	}
 }
+
+// shouldStripUsage merges the cursor_compat and skip_usage hints carried in
+// reqCtx.Extra. The dispatch layer ORs both together so a rule that only
+// flips skip_usage still strips the usage block, and cursor_compat keeps its
+// historical behavior of suppressing usage as a side effect.
+//
+// Extracted so the wiring is unit-testable independent of the surrounding
+// transform/forward machinery.
+func shouldStripUsage(extra map[string]interface{}) bool {
+	if extra == nil {
+		return false
+	}
+	if v, ok := extra["cursor_compat"]; ok {
+		if b, _ := v.(bool); b {
+			return true
+		}
+	}
+	if v, ok := extra["skip_usage"]; ok {
+		if b, _ := v.(bool); b {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// resolveRuleFlags returns a copy of the rule's flags, or the zero value when
+// no rule is bound. Callers may always read fields without nil-checking.
+func resolveRuleFlags(rule *typ.Rule) typ.RuleFlags {
+	if rule == nil {
+		return typ.RuleFlags{}
+	}
+	return rule.Flags
+}
+
+// applyMaxCompletionTokensRewrite moves the value of `max_tokens` into the
+// newer `max_completion_tokens` field. OpenAI's o1/o3/gpt-5 families reject
+// `max_tokens`; this rewrite lets callers opt in per rule.
+func applyMaxCompletionTokensRewrite(req *openai.ChatCompletionNewParams) {
+	if req == nil {
+		return
+	}
+	if req.MaxTokens.Valid() {
+		req.MaxCompletionTokens = param.NewOpt(req.MaxTokens.Value)
+		req.MaxTokens = param.Opt[int64]{}
+	}
+}

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -1,8 +1,25 @@
 package server
 
 import (
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
+
+// ruleExtraTransforms builds the per-rule list of post-base transforms to
+// append to the protocol chain. Returns nil when no rule-level flag requires
+// a chain stage so callers can pass the result straight to a variadic
+// `extraTransforms ...transform.Transform` parameter.
+func ruleExtraTransforms(rule *typ.Rule) []transform.Transform {
+	flags := resolveRuleFlags(rule)
+	var extras []transform.Transform
+	if flags.UseMaxCompletionTokens || flags.UseMaxTokens {
+		extras = append(extras, NewOpenAIMaxTokensRewriteTransform(
+			flags.UseMaxCompletionTokens,
+			flags.UseMaxTokens,
+		))
+	}
+	return extras
+}
 
 // resolveRuleFlags returns a copy of the rule's flags, or the zero value when
 // no rule is bound. Callers may always read fields without nil-checking.

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -13,33 +11,6 @@ func resolveRuleFlags(rule *typ.Rule) typ.RuleFlags {
 		return typ.RuleFlags{}
 	}
 	return rule.Flags
-}
-
-// applyMaxCompletionTokensRewrite moves the value of `max_tokens` into the
-// newer `max_completion_tokens` field. OpenAI's o1/o3/gpt-5 families reject
-// `max_tokens`; this rewrite lets callers opt in per rule.
-func applyMaxCompletionTokensRewrite(req *openai.ChatCompletionNewParams) {
-	if req == nil {
-		return
-	}
-	if req.MaxTokens.Valid() {
-		req.MaxCompletionTokens = param.NewOpt(req.MaxTokens.Value)
-		req.MaxTokens = param.Opt[int64]{}
-	}
-}
-
-// applyMaxTokensRewrite moves the value of `max_completion_tokens` back into
-// the legacy `max_tokens` field. Some providers and older model endpoints
-// reject the newer field name; this rewrite lets callers force the legacy
-// field per rule.
-func applyMaxTokensRewrite(req *openai.ChatCompletionNewParams) {
-	if req == nil {
-		return
-	}
-	if req.MaxCompletionTokens.Valid() {
-		req.MaxTokens = param.NewOpt(req.MaxCompletionTokens.Value)
-		req.MaxCompletionTokens = param.Opt[int64]{}
-	}
 }
 
 // shouldStripUsage merges the cursor_compat and skip_usage hints carried in

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -9,8 +9,10 @@ import (
 // append to the protocol chain. Returns nil when no rule-level flag requires
 // a chain stage so callers can pass the result straight to a variadic
 // `extraTransforms ...transform.Transform` parameter.
-func ruleExtraTransforms(rule *typ.Rule) []transform.Transform {
-	flags := resolveRuleFlags(rule)
+//
+// Takes already-resolved flags so callers that need other fields off
+// RuleFlags (CustomUserAgent, SkipUsage) can resolve once and share.
+func ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform {
 	var extras []transform.Transform
 	if flags.UseMaxCompletionTokens || flags.UseMaxTokens {
 		extras = append(extras, NewOpenAIMaxTokensRewriteTransform(

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -28,6 +28,20 @@ func applyMaxCompletionTokensRewrite(req *openai.ChatCompletionNewParams) {
 	}
 }
 
+// applyMaxTokensRewrite moves the value of `max_completion_tokens` back into
+// the legacy `max_tokens` field. Some providers and older model endpoints
+// reject the newer field name; this rewrite lets callers force the legacy
+// field per rule.
+func applyMaxTokensRewrite(req *openai.ChatCompletionNewParams) {
+	if req == nil {
+		return
+	}
+	if req.MaxCompletionTokens.Valid() {
+		req.MaxTokens = param.NewOpt(req.MaxCompletionTokens.Value)
+		req.MaxCompletionTokens = param.Opt[int64]{}
+	}
+}
+
 // shouldStripUsage merges the cursor_compat and skip_usage hints carried in
 // reqCtx.Extra. The dispatch layer ORs both together so a rule that only
 // flips skip_usage still strips the usage block, and cursor_compat keeps its

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -15,7 +15,7 @@ import (
 func ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform {
 	var extras []transform.Transform
 	if flags.UseMaxCompletionTokens || flags.UseMaxTokens {
-		extras = append(extras, NewOpenAIMaxTokensRewriteTransform(
+		extras = append(extras, transform.NewOpenAIMaxTokensRewriteTransform(
 			flags.UseMaxCompletionTokens,
 			flags.UseMaxTokens,
 		))

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestResolveRuleFlags_NilRule(t *testing.T) {
+	got := resolveRuleFlags(nil)
+	// Zero value: all fields default
+	want := typ.RuleFlags{}
+	if got != want {
+		t.Errorf("resolveRuleFlags(nil) = %#v, want zero value %#v", got, want)
+	}
+}
+
+func TestResolveRuleFlags_CopiesFlags(t *testing.T) {
+	rule := &typ.Rule{
+		Flags: typ.RuleFlags{
+			CursorCompat:           true,
+			SkipUsage:              true,
+			CustomUserAgent:        "MyApp/1.0",
+			UseMaxCompletionTokens: true,
+		},
+	}
+	got := resolveRuleFlags(rule)
+	if !got.CursorCompat || !got.SkipUsage || !got.UseMaxCompletionTokens {
+		t.Errorf("bool flags lost: %#v", got)
+	}
+	if got.CustomUserAgent != "MyApp/1.0" {
+		t.Errorf("CustomUserAgent = %q, want %q", got.CustomUserAgent, "MyApp/1.0")
+	}
+}
+
+func TestApplyMaxCompletionTokensRewrite_NilSafe(t *testing.T) {
+	// Must not panic on nil
+	applyMaxCompletionTokensRewrite(nil)
+}
+
+func TestApplyMaxCompletionTokensRewrite_MovesMaxTokens(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens: param.NewOpt(int64(1024)),
+	}
+	applyMaxCompletionTokensRewrite(req)
+
+	if req.MaxTokens.Valid() {
+		t.Errorf("expected MaxTokens cleared after rewrite, got %v", req.MaxTokens.Value)
+	}
+	if !req.MaxCompletionTokens.Valid() {
+		t.Fatalf("expected MaxCompletionTokens populated after rewrite")
+	}
+	if req.MaxCompletionTokens.Value != 1024 {
+		t.Errorf("MaxCompletionTokens = %d, want 1024", req.MaxCompletionTokens.Value)
+	}
+}
+
+func TestApplyMaxCompletionTokensRewrite_NoMaxTokensNoOp(t *testing.T) {
+	// When neither field is set the rewrite is a no-op (avoid emitting an
+	// explicit max_completion_tokens=0 which most providers reject).
+	req := &openai.ChatCompletionNewParams{}
+	applyMaxCompletionTokensRewrite(req)
+	if req.MaxTokens.Valid() {
+		t.Errorf("MaxTokens unexpectedly valid: %#v", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("MaxCompletionTokens unexpectedly valid: %#v", req.MaxCompletionTokens)
+	}
+}
+
+func TestShouldStripUsage_NilExtra(t *testing.T) {
+	if shouldStripUsage(nil) {
+		t.Errorf("nil extra map should not strip usage")
+	}
+}
+
+func TestShouldStripUsage_EmptyExtra(t *testing.T) {
+	if shouldStripUsage(map[string]interface{}{}) {
+		t.Errorf("empty extra map should not strip usage")
+	}
+}
+
+func TestShouldStripUsage_CursorCompatTrue(t *testing.T) {
+	if !shouldStripUsage(map[string]interface{}{"cursor_compat": true}) {
+		t.Errorf("cursor_compat=true should strip usage")
+	}
+}
+
+func TestShouldStripUsage_SkipUsageTrue(t *testing.T) {
+	if !shouldStripUsage(map[string]interface{}{"skip_usage": true}) {
+		t.Errorf("skip_usage=true should strip usage")
+	}
+}
+
+func TestShouldStripUsage_BothTrue(t *testing.T) {
+	if !shouldStripUsage(map[string]interface{}{
+		"cursor_compat": true,
+		"skip_usage":    true,
+	}) {
+		t.Errorf("both flags true should strip usage")
+	}
+}
+
+func TestShouldStripUsage_BothFalse(t *testing.T) {
+	if shouldStripUsage(map[string]interface{}{
+		"cursor_compat": false,
+		"skip_usage":    false,
+	}) {
+		t.Errorf("both flags false should not strip usage")
+	}
+}
+
+func TestShouldStripUsage_NonBoolValueIgnored(t *testing.T) {
+	// Defensive: a non-bool sneaks past the type assertion as false.
+	if shouldStripUsage(map[string]interface{}{
+		"cursor_compat": "yes",
+		"skip_usage":    1,
+	}) {
+		t.Errorf("non-bool values should be treated as false, not strip")
+	}
+}
+
+func TestApplyMaxCompletionTokensRewrite_PreservesExistingMaxCompletionTokens(t *testing.T) {
+	// If both fields are already present (caller supplied them), prefer the
+	// MaxTokens migration but document the surprising case.
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens:           param.NewOpt(int64(512)),
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+	applyMaxCompletionTokensRewrite(req)
+
+	if req.MaxTokens.Valid() {
+		t.Errorf("expected MaxTokens cleared, got %v", req.MaxTokens.Value)
+	}
+	// Current behavior: MaxTokens overwrites MaxCompletionTokens. Track this
+	// in tests so future refactors notice.
+	if req.MaxCompletionTokens.Value != 512 {
+		t.Errorf("MaxCompletionTokens = %d, want 512 (rewrite overrides existing)", req.MaxCompletionTokens.Value)
+	}
+}

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -84,3 +84,48 @@ func TestShouldStripUsage_NonBoolValueIgnored(t *testing.T) {
 		t.Errorf("non-bool values should be treated as false, not strip")
 	}
 }
+
+func TestRuleExtraTransforms_NoFlags(t *testing.T) {
+	got := ruleExtraTransforms(typ.RuleFlags{})
+	if got != nil {
+		t.Errorf("expected nil for zero-value flags, got %d transforms", len(got))
+	}
+}
+
+func TestRuleExtraTransforms_UseMaxCompletionTokens(t *testing.T) {
+	got := ruleExtraTransforms(typ.RuleFlags{UseMaxCompletionTokens: true})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 transform, got %d", len(got))
+	}
+	tf, ok := got[0].(*OpenAIMaxTokensRewriteTransform)
+	if !ok {
+		t.Fatalf("expected *OpenAIMaxTokensRewriteTransform, got %T", got[0])
+	}
+	if !tf.UseMaxCompletionTokens || tf.UseMaxTokens {
+		t.Errorf("flag values not propagated: %#v", tf)
+	}
+}
+
+func TestRuleExtraTransforms_UseMaxTokens(t *testing.T) {
+	got := ruleExtraTransforms(typ.RuleFlags{UseMaxTokens: true})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 transform, got %d", len(got))
+	}
+	tf := got[0].(*OpenAIMaxTokensRewriteTransform)
+	if tf.UseMaxCompletionTokens || !tf.UseMaxTokens {
+		t.Errorf("flag values not propagated: %#v", tf)
+	}
+}
+
+func TestRuleExtraTransforms_OtherFlagsAlone_NoTransform(t *testing.T) {
+	// Flags that have their own injection paths (UA via context, skip_usage
+	// via Extra) shouldn't surface here.
+	got := ruleExtraTransforms(typ.RuleFlags{
+		CursorCompat:    true,
+		SkipUsage:       true,
+		CustomUserAgent: "Foo/1.0",
+	})
+	if got != nil {
+		t.Errorf("expected nil, got %d transforms", len(got))
+	}
+}

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -1,12 +1,29 @@
 package server
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
+
+// marshalTokenFields serializes only the token-related fields of a
+// ChatCompletionNewParams into a JSON map so tests can assert on wire presence.
+func marshalTokenFields(t *testing.T, req *openai.ChatCompletionNewParams) map[string]interface{} {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	return m
+}
 
 func TestResolveRuleFlags_NilRule(t *testing.T) {
 	got := resolveRuleFlags(nil)
@@ -139,4 +156,111 @@ func TestApplyMaxCompletionTokensRewrite_PreservesExistingMaxCompletionTokens(t 
 	if req.MaxCompletionTokens.Value != 512 {
 		t.Errorf("MaxCompletionTokens = %d, want 512 (rewrite overrides existing)", req.MaxCompletionTokens.Value)
 	}
+}
+
+// --- applyMaxTokensRewrite ---
+
+func TestApplyMaxTokensRewrite_NilSafe(t *testing.T) {
+	applyMaxTokensRewrite(nil)
+}
+
+func TestApplyMaxTokensRewrite_MovesMaxCompletionTokens(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+	applyMaxTokensRewrite(req)
+
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("expected MaxCompletionTokens cleared after rewrite, got %v", req.MaxCompletionTokens.Value)
+	}
+	if !req.MaxTokens.Valid() {
+		t.Fatalf("expected MaxTokens populated after rewrite")
+	}
+	if req.MaxTokens.Value != 2048 {
+		t.Errorf("MaxTokens = %d, want 2048", req.MaxTokens.Value)
+	}
+}
+
+func TestApplyMaxTokensRewrite_NoMaxCompletionTokensNoOp(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{}
+	applyMaxTokensRewrite(req)
+	if req.MaxTokens.Valid() {
+		t.Errorf("MaxTokens unexpectedly valid: %#v", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("MaxCompletionTokens unexpectedly valid: %#v", req.MaxCompletionTokens)
+	}
+}
+
+// --- JSON wire serialization: prove the rewrites emit the correct field on the wire ---
+
+// TestMaxCompletionTokensRewrite_WireSerialization verifies that after
+// applyMaxCompletionTokensRewrite the OpenAI SDK serializes
+// "max_completion_tokens" and omits "max_tokens" from the JSON body.
+// This guards against silent regression where a struct-level change doesn't
+// propagate to the actual HTTP request body.
+func TestMaxCompletionTokensRewrite_WireSerialization(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens: param.NewOpt(int64(1024)),
+	}
+
+	// Before rewrite: max_tokens on wire, max_completion_tokens absent.
+	before := marshalTokenFields(t, req)
+	if _, ok := before["max_tokens"]; !ok {
+		t.Errorf("before rewrite: expected 'max_tokens' in JSON, got keys: %v", jsonKeys(before))
+	}
+	if _, ok := before["max_completion_tokens"]; ok {
+		t.Errorf("before rewrite: unexpected 'max_completion_tokens' in JSON")
+	}
+
+	applyMaxCompletionTokensRewrite(req)
+
+	// After rewrite: max_completion_tokens on wire, max_tokens absent.
+	after := marshalTokenFields(t, req)
+	if _, ok := after["max_completion_tokens"]; !ok {
+		t.Errorf("after rewrite: expected 'max_completion_tokens' in JSON, got keys: %v", jsonKeys(after))
+	}
+	if _, ok := after["max_tokens"]; ok {
+		t.Errorf("after rewrite: unexpected 'max_tokens' still present in JSON")
+	}
+	if v, _ := after["max_completion_tokens"].(float64); int(v) != 1024 {
+		t.Errorf("after rewrite: max_completion_tokens = %v, want 1024", after["max_completion_tokens"])
+	}
+}
+
+// TestMaxTokensRewrite_WireSerialization verifies the inverse: after
+// applyMaxTokensRewrite the SDK emits "max_tokens" and omits
+// "max_completion_tokens".
+func TestMaxTokensRewrite_WireSerialization(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+
+	// Before rewrite: max_completion_tokens on wire.
+	before := marshalTokenFields(t, req)
+	if _, ok := before["max_completion_tokens"]; !ok {
+		t.Errorf("before rewrite: expected 'max_completion_tokens' in JSON, got keys: %v", jsonKeys(before))
+	}
+
+	applyMaxTokensRewrite(req)
+
+	// After rewrite: max_tokens on wire, max_completion_tokens absent.
+	after := marshalTokenFields(t, req)
+	if _, ok := after["max_tokens"]; !ok {
+		t.Errorf("after rewrite: expected 'max_tokens' in JSON, got keys: %v", jsonKeys(after))
+	}
+	if _, ok := after["max_completion_tokens"]; ok {
+		t.Errorf("after rewrite: unexpected 'max_completion_tokens' still present in JSON")
+	}
+	if v, _ := after["max_tokens"].(float64); int(v) != 2048 {
+		t.Errorf("after rewrite: max_tokens = %v, want 2048", after["max_tokens"])
+	}
+}
+
+func jsonKeys(m map[string]interface{}) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
 }

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"testing"
 
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -97,9 +98,9 @@ func TestRuleExtraTransforms_UseMaxCompletionTokens(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 transform, got %d", len(got))
 	}
-	tf, ok := got[0].(*OpenAIMaxTokensRewriteTransform)
+	tf, ok := got[0].(*transform.OpenAIMaxTokensRewriteTransform)
 	if !ok {
-		t.Fatalf("expected *OpenAIMaxTokensRewriteTransform, got %T", got[0])
+		t.Fatalf("expected *transform.OpenAIMaxTokensRewriteTransform, got %T", got[0])
 	}
 	if !tf.UseMaxCompletionTokens || tf.UseMaxTokens {
 		t.Errorf("flag values not propagated: %#v", tf)
@@ -111,7 +112,7 @@ func TestRuleExtraTransforms_UseMaxTokens(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 transform, got %d", len(got))
 	}
-	tf := got[0].(*OpenAIMaxTokensRewriteTransform)
+	tf := got[0].(*transform.OpenAIMaxTokensRewriteTransform)
 	if tf.UseMaxCompletionTokens || !tf.UseMaxTokens {
 		t.Errorf("flag values not propagated: %#v", tf)
 	}

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -1,33 +1,13 @@
 package server
 
 import (
-	"encoding/json"
-	"strings"
 	"testing"
 
-	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// marshalTokenFields serializes only the token-related fields of a
-// ChatCompletionNewParams into a JSON map so tests can assert on wire presence.
-func marshalTokenFields(t *testing.T, req *openai.ChatCompletionNewParams) map[string]interface{} {
-	t.Helper()
-	data, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("json.Marshal failed: %v", err)
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("json.Unmarshal failed: %v", err)
-	}
-	return m
-}
-
 func TestResolveRuleFlags_NilRule(t *testing.T) {
 	got := resolveRuleFlags(nil)
-	// Zero value: all fields default
 	want := typ.RuleFlags{}
 	if got != want {
 		t.Errorf("resolveRuleFlags(nil) = %#v, want zero value %#v", got, want)
@@ -41,49 +21,15 @@ func TestResolveRuleFlags_CopiesFlags(t *testing.T) {
 			SkipUsage:              true,
 			CustomUserAgent:        "MyApp/1.0",
 			UseMaxCompletionTokens: true,
+			UseMaxTokens:           true,
 		},
 	}
 	got := resolveRuleFlags(rule)
-	if !got.CursorCompat || !got.SkipUsage || !got.UseMaxCompletionTokens {
+	if !got.CursorCompat || !got.SkipUsage || !got.UseMaxCompletionTokens || !got.UseMaxTokens {
 		t.Errorf("bool flags lost: %#v", got)
 	}
 	if got.CustomUserAgent != "MyApp/1.0" {
 		t.Errorf("CustomUserAgent = %q, want %q", got.CustomUserAgent, "MyApp/1.0")
-	}
-}
-
-func TestApplyMaxCompletionTokensRewrite_NilSafe(t *testing.T) {
-	// Must not panic on nil
-	applyMaxCompletionTokensRewrite(nil)
-}
-
-func TestApplyMaxCompletionTokensRewrite_MovesMaxTokens(t *testing.T) {
-	req := &openai.ChatCompletionNewParams{
-		MaxTokens: param.NewOpt(int64(1024)),
-	}
-	applyMaxCompletionTokensRewrite(req)
-
-	if req.MaxTokens.Valid() {
-		t.Errorf("expected MaxTokens cleared after rewrite, got %v", req.MaxTokens.Value)
-	}
-	if !req.MaxCompletionTokens.Valid() {
-		t.Fatalf("expected MaxCompletionTokens populated after rewrite")
-	}
-	if req.MaxCompletionTokens.Value != 1024 {
-		t.Errorf("MaxCompletionTokens = %d, want 1024", req.MaxCompletionTokens.Value)
-	}
-}
-
-func TestApplyMaxCompletionTokensRewrite_NoMaxTokensNoOp(t *testing.T) {
-	// When neither field is set the rewrite is a no-op (avoid emitting an
-	// explicit max_completion_tokens=0 which most providers reject).
-	req := &openai.ChatCompletionNewParams{}
-	applyMaxCompletionTokensRewrite(req)
-	if req.MaxTokens.Valid() {
-		t.Errorf("MaxTokens unexpectedly valid: %#v", req.MaxTokens)
-	}
-	if req.MaxCompletionTokens.Valid() {
-		t.Errorf("MaxCompletionTokens unexpectedly valid: %#v", req.MaxCompletionTokens)
 	}
 }
 
@@ -137,130 +83,4 @@ func TestShouldStripUsage_NonBoolValueIgnored(t *testing.T) {
 	}) {
 		t.Errorf("non-bool values should be treated as false, not strip")
 	}
-}
-
-func TestApplyMaxCompletionTokensRewrite_PreservesExistingMaxCompletionTokens(t *testing.T) {
-	// If both fields are already present (caller supplied them), prefer the
-	// MaxTokens migration but document the surprising case.
-	req := &openai.ChatCompletionNewParams{
-		MaxTokens:           param.NewOpt(int64(512)),
-		MaxCompletionTokens: param.NewOpt(int64(2048)),
-	}
-	applyMaxCompletionTokensRewrite(req)
-
-	if req.MaxTokens.Valid() {
-		t.Errorf("expected MaxTokens cleared, got %v", req.MaxTokens.Value)
-	}
-	// Current behavior: MaxTokens overwrites MaxCompletionTokens. Track this
-	// in tests so future refactors notice.
-	if req.MaxCompletionTokens.Value != 512 {
-		t.Errorf("MaxCompletionTokens = %d, want 512 (rewrite overrides existing)", req.MaxCompletionTokens.Value)
-	}
-}
-
-// --- applyMaxTokensRewrite ---
-
-func TestApplyMaxTokensRewrite_NilSafe(t *testing.T) {
-	applyMaxTokensRewrite(nil)
-}
-
-func TestApplyMaxTokensRewrite_MovesMaxCompletionTokens(t *testing.T) {
-	req := &openai.ChatCompletionNewParams{
-		MaxCompletionTokens: param.NewOpt(int64(2048)),
-	}
-	applyMaxTokensRewrite(req)
-
-	if req.MaxCompletionTokens.Valid() {
-		t.Errorf("expected MaxCompletionTokens cleared after rewrite, got %v", req.MaxCompletionTokens.Value)
-	}
-	if !req.MaxTokens.Valid() {
-		t.Fatalf("expected MaxTokens populated after rewrite")
-	}
-	if req.MaxTokens.Value != 2048 {
-		t.Errorf("MaxTokens = %d, want 2048", req.MaxTokens.Value)
-	}
-}
-
-func TestApplyMaxTokensRewrite_NoMaxCompletionTokensNoOp(t *testing.T) {
-	req := &openai.ChatCompletionNewParams{}
-	applyMaxTokensRewrite(req)
-	if req.MaxTokens.Valid() {
-		t.Errorf("MaxTokens unexpectedly valid: %#v", req.MaxTokens)
-	}
-	if req.MaxCompletionTokens.Valid() {
-		t.Errorf("MaxCompletionTokens unexpectedly valid: %#v", req.MaxCompletionTokens)
-	}
-}
-
-// --- JSON wire serialization: prove the rewrites emit the correct field on the wire ---
-
-// TestMaxCompletionTokensRewrite_WireSerialization verifies that after
-// applyMaxCompletionTokensRewrite the OpenAI SDK serializes
-// "max_completion_tokens" and omits "max_tokens" from the JSON body.
-// This guards against silent regression where a struct-level change doesn't
-// propagate to the actual HTTP request body.
-func TestMaxCompletionTokensRewrite_WireSerialization(t *testing.T) {
-	req := &openai.ChatCompletionNewParams{
-		MaxTokens: param.NewOpt(int64(1024)),
-	}
-
-	// Before rewrite: max_tokens on wire, max_completion_tokens absent.
-	before := marshalTokenFields(t, req)
-	if _, ok := before["max_tokens"]; !ok {
-		t.Errorf("before rewrite: expected 'max_tokens' in JSON, got keys: %v", jsonKeys(before))
-	}
-	if _, ok := before["max_completion_tokens"]; ok {
-		t.Errorf("before rewrite: unexpected 'max_completion_tokens' in JSON")
-	}
-
-	applyMaxCompletionTokensRewrite(req)
-
-	// After rewrite: max_completion_tokens on wire, max_tokens absent.
-	after := marshalTokenFields(t, req)
-	if _, ok := after["max_completion_tokens"]; !ok {
-		t.Errorf("after rewrite: expected 'max_completion_tokens' in JSON, got keys: %v", jsonKeys(after))
-	}
-	if _, ok := after["max_tokens"]; ok {
-		t.Errorf("after rewrite: unexpected 'max_tokens' still present in JSON")
-	}
-	if v, _ := after["max_completion_tokens"].(float64); int(v) != 1024 {
-		t.Errorf("after rewrite: max_completion_tokens = %v, want 1024", after["max_completion_tokens"])
-	}
-}
-
-// TestMaxTokensRewrite_WireSerialization verifies the inverse: after
-// applyMaxTokensRewrite the SDK emits "max_tokens" and omits
-// "max_completion_tokens".
-func TestMaxTokensRewrite_WireSerialization(t *testing.T) {
-	req := &openai.ChatCompletionNewParams{
-		MaxCompletionTokens: param.NewOpt(int64(2048)),
-	}
-
-	// Before rewrite: max_completion_tokens on wire.
-	before := marshalTokenFields(t, req)
-	if _, ok := before["max_completion_tokens"]; !ok {
-		t.Errorf("before rewrite: expected 'max_completion_tokens' in JSON, got keys: %v", jsonKeys(before))
-	}
-
-	applyMaxTokensRewrite(req)
-
-	// After rewrite: max_tokens on wire, max_completion_tokens absent.
-	after := marshalTokenFields(t, req)
-	if _, ok := after["max_tokens"]; !ok {
-		t.Errorf("after rewrite: expected 'max_tokens' in JSON, got keys: %v", jsonKeys(after))
-	}
-	if _, ok := after["max_completion_tokens"]; ok {
-		t.Errorf("after rewrite: unexpected 'max_completion_tokens' still present in JSON")
-	}
-	if v, _ := after["max_tokens"].(float64); int(v) != 2048 {
-		t.Errorf("after rewrite: max_tokens = %v, want 2048", after["max_tokens"])
-	}
-}
-
-func jsonKeys(m map[string]interface{}) string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return strings.Join(keys, ", ")
 }

--- a/internal/server/transform_openai_max_tokens_rewrite.go
+++ b/internal/server/transform_openai_max_tokens_rewrite.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"github.com/openai/openai-go/v3"
+	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
+)
+
+// OpenAIMaxTokensRewriteTransform rewrites the OpenAI Chat `max_tokens` /
+// `max_completion_tokens` field pair based on per-rule flags. It runs as a
+// post-base stage so it sees the request in its target shape — protocol
+// conversion (Anthropic ↔ OpenAI) has already happened by then.
+//
+// The transform is a thin shell: ops.ApplyMaxCompletionTokensRewrite and
+// ops.ApplyMaxTokensRewrite are the operation primitives; this stage only
+// decides when to invoke them based on the rule and the post-base request
+// shape.
+//
+// Only added to the chain when at least one of the two flags is set.
+type OpenAIMaxTokensRewriteTransform struct {
+	UseMaxCompletionTokens bool
+	UseMaxTokens           bool
+}
+
+// NewOpenAIMaxTokensRewriteTransform creates a new transform configured with
+// the rule flags.
+func NewOpenAIMaxTokensRewriteTransform(useMaxCompletionTokens, useMaxTokens bool) *OpenAIMaxTokensRewriteTransform {
+	return &OpenAIMaxTokensRewriteTransform{
+		UseMaxCompletionTokens: useMaxCompletionTokens,
+		UseMaxTokens:           useMaxTokens,
+	}
+}
+
+func (t *OpenAIMaxTokensRewriteTransform) Name() string {
+	return "openai_max_tokens_rewrite"
+}
+
+// Apply rewrites the token field on OpenAI Chat requests. For any other
+// post-base shape (Anthropic, Responses, Google) it is a no-op.
+func (t *OpenAIMaxTokensRewriteTransform) Apply(ctx *protocoltransform.TransformContext) error {
+	req, ok := ctx.Request.(*openai.ChatCompletionNewParams)
+	if !ok {
+		return nil
+	}
+	if t.UseMaxCompletionTokens {
+		ops.ApplyMaxCompletionTokensRewrite(req)
+	}
+	if t.UseMaxTokens {
+		ops.ApplyMaxTokensRewrite(req)
+	}
+	return nil
+}

--- a/internal/server/transform_openai_max_tokens_rewrite_test.go
+++ b/internal/server/transform_openai_max_tokens_rewrite_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
+)
+
+func TestOpenAIMaxTokensRewriteTransform_Name(t *testing.T) {
+	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
+	if tf.Name() != "openai_max_tokens_rewrite" {
+		t.Errorf("unexpected name: %q", tf.Name())
+	}
+}
+
+func TestOpenAIMaxTokensRewriteTransform_AppliesOnOpenAIChat(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens: param.NewOpt(int64(1024)),
+	}
+	ctx := &protocoltransform.TransformContext{Request: req}
+
+	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if req.MaxTokens.Valid() {
+		t.Errorf("expected MaxTokens cleared, got %v", req.MaxTokens.Value)
+	}
+	if !req.MaxCompletionTokens.Valid() || req.MaxCompletionTokens.Value != 1024 {
+		t.Errorf("expected MaxCompletionTokens=1024, got %#v", req.MaxCompletionTokens)
+	}
+}
+
+func TestOpenAIMaxTokensRewriteTransform_ReverseDirection(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxCompletionTokens: param.NewOpt(int64(2048)),
+	}
+	ctx := &protocoltransform.TransformContext{Request: req}
+
+	tf := NewOpenAIMaxTokensRewriteTransform(false, true)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("expected MaxCompletionTokens cleared, got %v", req.MaxCompletionTokens.Value)
+	}
+	if !req.MaxTokens.Valid() || req.MaxTokens.Value != 2048 {
+		t.Errorf("expected MaxTokens=2048, got %#v", req.MaxTokens)
+	}
+}
+
+func TestOpenAIMaxTokensRewriteTransform_BothFlagsOff_NoOp(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		MaxTokens: param.NewOpt(int64(1024)),
+	}
+	ctx := &protocoltransform.TransformContext{Request: req}
+
+	tf := NewOpenAIMaxTokensRewriteTransform(false, false)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if !req.MaxTokens.Valid() || req.MaxTokens.Value != 1024 {
+		t.Errorf("expected MaxTokens untouched, got %#v", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens.Valid() {
+		t.Errorf("expected MaxCompletionTokens untouched (zero), got %#v", req.MaxCompletionTokens)
+	}
+}
+
+func TestOpenAIMaxTokensRewriteTransform_NoOpOnAnthropicV1(t *testing.T) {
+	req := &anthropic.MessageNewParams{MaxTokens: 1024}
+	ctx := &protocoltransform.TransformContext{Request: req}
+
+	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if req.MaxTokens != 1024 {
+		t.Errorf("Anthropic MaxTokens unexpectedly modified: %d", req.MaxTokens)
+	}
+}
+
+func TestOpenAIMaxTokensRewriteTransform_NoOpOnAnthropicBeta(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{MaxTokens: 1024}
+	ctx := &protocoltransform.TransformContext{Request: req}
+
+	tf := NewOpenAIMaxTokensRewriteTransform(true, false)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if req.MaxTokens != 1024 {
+		t.Errorf("Anthropic Beta MaxTokens unexpectedly modified: %d", req.MaxTokens)
+	}
+}
+
+func TestOpenAIMaxTokensRewriteTransform_NoOpOnResponses(t *testing.T) {
+	req := &responses.ResponseNewParams{}
+	ctx := &protocoltransform.TransformContext{Request: req}
+
+	tf := NewOpenAIMaxTokensRewriteTransform(true, true)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	// No assertion needed beyond "didn't panic / didn't error" — the
+	// Responses struct has no max_completion_tokens duality.
+}
+
+func TestOpenAIMaxTokensRewriteTransform_NilRequest(t *testing.T) {
+	ctx := &protocoltransform.TransformContext{Request: nil}
+	tf := NewOpenAIMaxTokensRewriteTransform(true, true)
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply on nil request failed: %v", err)
+	}
+}
+
+// stubBaseTransform mimics BaseTransform's protocol conversion role for the
+// regression test: it swaps an Anthropic-typed request for an OpenAI Chat
+// one, carrying over the MaxTokens value.
+type stubBaseTransform struct{}
+
+func (stubBaseTransform) Name() string { return "stub_base" }
+
+func (stubBaseTransform) Apply(ctx *protocoltransform.TransformContext) error {
+	if a, ok := ctx.Request.(*anthropic.MessageNewParams); ok {
+		ctx.Request = &openai.ChatCompletionNewParams{
+			MaxTokens: param.NewOpt(a.MaxTokens),
+		}
+	}
+	return nil
+}
+
+// TestOpenAIMaxTokensRewriteTransform_FiresAfterBase is the regression test
+// for the bug this refactor addresses: when the inbound request is Anthropic
+// but the target is OpenAI Chat, the rewrite must fire on the post-base
+// shape. Chaining the stub base transform ahead of the rewrite proves the
+// chain ordering works correctly.
+func TestOpenAIMaxTokensRewriteTransform_FiresAfterBase(t *testing.T) {
+	original := &anthropic.MessageNewParams{MaxTokens: 4096}
+	ctx := &protocoltransform.TransformContext{Request: original}
+
+	chain := protocoltransform.NewTransformChain([]protocoltransform.Transform{
+		stubBaseTransform{},
+		NewOpenAIMaxTokensRewriteTransform(true, false),
+	})
+	if _, err := chain.Execute(ctx); err != nil {
+		t.Fatalf("chain.Execute failed: %v", err)
+	}
+
+	converted, ok := ctx.Request.(*openai.ChatCompletionNewParams)
+	if !ok {
+		t.Fatalf("expected *openai.ChatCompletionNewParams after chain, got %T", ctx.Request)
+	}
+	if converted.MaxTokens.Valid() {
+		t.Errorf("expected MaxTokens cleared post-rewrite, got %v", converted.MaxTokens.Value)
+	}
+	if !converted.MaxCompletionTokens.Valid() || converted.MaxCompletionTokens.Value != 4096 {
+		t.Errorf("expected MaxCompletionTokens=4096 post-rewrite, got %#v", converted.MaxCompletionTokens)
+	}
+}

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -64,7 +64,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "custom_user_agent",
 			Label:       "Custom User-Agent",
-			Description: "Override the outbound User-Agent header sent to the upstream provider.",
+			Description: "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent.",
 			Type:        FlagTypeString,
 			Category:    FlagCategoryRequest,
 			Placeholder: "e.g. MyApp/1.0",

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -1,0 +1,73 @@
+package typ
+
+// FlagValueType describes how a rule flag is represented in storage and UI.
+type FlagValueType string
+
+const (
+	FlagTypeBool   FlagValueType = "bool"
+	FlagTypeString FlagValueType = "string"
+)
+
+// FlagCategory groups flags for presentation in the UI.
+type FlagCategory string
+
+const (
+	FlagCategoryCompatibility FlagCategory = "compatibility"
+	FlagCategoryRequest       FlagCategory = "request"
+	FlagCategoryResponse      FlagCategory = "response"
+)
+
+// FlagSpec describes a single rule-level flag's metadata for the UI catalog.
+// Keys must match the JSON tag name on RuleFlags.
+type FlagSpec struct {
+	Key         string       `json:"key"`
+	Label       string       `json:"label"`
+	Description string       `json:"description"`
+	Type        FlagValueType `json:"type"`
+	Category    FlagCategory `json:"category"`
+	// Placeholder is the hint text shown in string-type input fields.
+	Placeholder string `json:"placeholder,omitempty"`
+}
+
+// RuleFlagRegistry returns the catalog of supported rule flags. The order is
+// the recommended display order in the UI.
+func RuleFlagRegistry() []FlagSpec {
+	return []FlagSpec{
+		{
+			Key:         "cursor_compat",
+			Label:       "Cursor compatibility",
+			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor IDE clients.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryCompatibility,
+		},
+		{
+			Key:         "cursor_compat_auto",
+			Label:       "Auto-detect Cursor",
+			Description: "Apply cursor compatibility automatically when request headers identify Cursor.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryCompatibility,
+		},
+		{
+			Key:         "skip_usage",
+			Label:       "Skip usage in response",
+			Description: "Strip the `usage` block from responses (both SSE deltas and the final body).",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryResponse,
+		},
+		{
+			Key:         "use_max_completion_tokens",
+			Label:       "Use max_completion_tokens",
+			Description: "Rewrite request field `max_tokens` to `max_completion_tokens` (required by o1/o3/gpt-5 family).",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryRequest,
+		},
+		{
+			Key:         "custom_user_agent",
+			Label:       "Custom User-Agent",
+			Description: "Override the outbound User-Agent header sent to the upstream provider.",
+			Type:        FlagTypeString,
+			Category:    FlagCategoryRequest,
+			Placeholder: "e.g. MyApp/1.0",
+		},
+	}
+}

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -62,6 +62,13 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:    FlagCategoryRequest,
 		},
 		{
+			Key:         "use_max_tokens",
+			Label:       "Use max_tokens (legacy)",
+			Description: "Rewrite request field `max_completion_tokens` back to the legacy `max_tokens`. Use for providers that reject the newer field name.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryRequest,
+		},
+		{
 			Key:         "custom_user_agent",
 			Label:       "Custom User-Agent",
 			Description: "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent.",

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -1,0 +1,106 @@
+package typ
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestRuleFlagRegistry_NotEmpty guards against accidentally clearing the
+// registry — every release should expose at least the historical flags.
+func TestRuleFlagRegistry_NotEmpty(t *testing.T) {
+	specs := RuleFlagRegistry()
+	if len(specs) == 0 {
+		t.Fatal("RuleFlagRegistry() returned no specs")
+	}
+}
+
+// TestRuleFlagRegistry_KnownKeys verifies the catalog still surfaces the
+// flags the UI relies on. New flags can be added freely; removing one
+// without coordinating with the frontend will break the catalog dialog.
+func TestRuleFlagRegistry_KnownKeys(t *testing.T) {
+	required := []string{
+		"cursor_compat",
+		"cursor_compat_auto",
+		"skip_usage",
+		"use_max_completion_tokens",
+		"custom_user_agent",
+	}
+
+	present := map[string]bool{}
+	for _, s := range RuleFlagRegistry() {
+		present[s.Key] = true
+	}
+
+	for _, key := range required {
+		if !present[key] {
+			t.Errorf("RuleFlagRegistry missing required key %q", key)
+		}
+	}
+}
+
+// TestRuleFlagRegistry_KeysMatchStructFields prevents the registry from
+// drifting away from RuleFlags. Every registry key must correspond to a
+// JSON tag on the struct so the API contract stays consistent.
+func TestRuleFlagRegistry_KeysMatchStructFields(t *testing.T) {
+	flagsType := reflect.TypeOf(RuleFlags{})
+
+	jsonTags := map[string]bool{}
+	for i := 0; i < flagsType.NumField(); i++ {
+		tag := flagsType.Field(i).Tag.Get("json")
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name != "" && name != "-" {
+			jsonTags[name] = true
+		}
+	}
+
+	for _, spec := range RuleFlagRegistry() {
+		if !jsonTags[spec.Key] {
+			t.Errorf("FlagSpec key %q has no matching json tag on RuleFlags", spec.Key)
+		}
+	}
+}
+
+// TestRuleFlagRegistry_TypesAreValid ensures every flag declares one of the
+// supported value types — otherwise the catalog dialog has no idea how to
+// render it.
+func TestRuleFlagRegistry_TypesAreValid(t *testing.T) {
+	allowed := map[FlagValueType]bool{
+		FlagTypeBool:   true,
+		FlagTypeString: true,
+	}
+	for _, spec := range RuleFlagRegistry() {
+		if !allowed[spec.Type] {
+			t.Errorf("flag %q has unsupported value type %q", spec.Key, spec.Type)
+		}
+		if spec.Label == "" {
+			t.Errorf("flag %q has empty label", spec.Key)
+		}
+		if spec.Description == "" {
+			t.Errorf("flag %q has empty description", spec.Key)
+		}
+	}
+}
+
+// TestRuleFlagRegistry_JSONRoundTrip catches accidental json-tag changes
+// that would break the wire format.
+func TestRuleFlagRegistry_JSONRoundTrip(t *testing.T) {
+	specs := RuleFlagRegistry()
+	raw, err := json.Marshal(specs)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded []FlagSpec
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(decoded) != len(specs) {
+		t.Fatalf("round-trip length mismatch: %d -> %d", len(specs), len(decoded))
+	}
+	for i := range specs {
+		if decoded[i].Key != specs[i].Key {
+			t.Errorf("index %d key mismatch: %q != %q", i, decoded[i].Key, specs[i].Key)
+		}
+	}
+}

--- a/internal/typ/id.go
+++ b/internal/typ/id.go
@@ -112,6 +112,10 @@ type contextKey string
 
 const SessionIDKey contextKey = "session_id"
 
+// CustomUserAgentKey carries a rule-level User-Agent override down to the
+// outbound HTTP transport.
+const CustomUserAgentKey contextKey = "custom_user_agent"
+
 // WithSessionID adds a sessionID to the context.
 // This allows sessionID to be propagated through the call chain
 // without explicit parameter passing.
@@ -129,4 +133,24 @@ func GetSessionID(ctx context.Context) SessionID {
 		return sid
 	}
 	return SessionID{}
+}
+
+// WithCustomUserAgent attaches a User-Agent override that an outbound HTTP
+// transport may read at request time.
+func WithCustomUserAgent(ctx context.Context, ua string) context.Context {
+	if ua == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, CustomUserAgentKey, ua)
+}
+
+// GetCustomUserAgent returns the per-request User-Agent override, or "" if none.
+func GetCustomUserAgent(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if ua, ok := ctx.Value(CustomUserAgentKey).(string); ok {
+		return ua
+	}
+	return ""
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -164,6 +164,17 @@ type RuleFlags struct {
 
 	// CursorCompatAuto enables Cursor auto-detection based on request headers.
 	CursorCompatAuto bool `json:"cursor_compat_auto,omitempty" yaml:"cursor_compat_auto,omitempty"`
+
+	// SkipUsage strips the `usage` field from both streaming and non-streaming responses.
+	SkipUsage bool `json:"skip_usage,omitempty" yaml:"skip_usage,omitempty"`
+
+	// CustomUserAgent overrides the User-Agent header sent to upstream providers.
+	// Empty value means do not override.
+	CustomUserAgent string `json:"custom_user_agent,omitempty" yaml:"custom_user_agent,omitempty"`
+
+	// UseMaxCompletionTokens rewrites the `max_tokens` request field to `max_completion_tokens`
+	// (OpenAI's newer field name for o1/o3/gpt-5 family models).
+	UseMaxCompletionTokens bool `json:"use_max_completion_tokens,omitempty" yaml:"use_max_completion_tokens,omitempty"`
 }
 
 // ProfileMeta stores metadata for a scenario profile.

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -175,6 +175,10 @@ type RuleFlags struct {
 	// UseMaxCompletionTokens rewrites the `max_tokens` request field to `max_completion_tokens`
 	// (OpenAI's newer field name for o1/o3/gpt-5 family models).
 	UseMaxCompletionTokens bool `json:"use_max_completion_tokens,omitempty" yaml:"use_max_completion_tokens,omitempty"`
+
+	// UseMaxTokens rewrites the `max_completion_tokens` request field back to the legacy
+	// `max_tokens` field. Use this for providers or models that reject `max_completion_tokens`.
+	UseMaxTokens bool `json:"use_max_tokens,omitempty" yaml:"use_max_tokens,omitempty"`
 }
 
 // ProfileMeta stores metadata for a scenario profile.


### PR DESCRIPTION
## Summary
Introduces a comprehensive rule-level flag system that allows fine-grained control over request/response behavior at the individual rule level. Includes backend flag registry, frontend catalog dialog, and integration with the transform chain for extensibility.

## Key Changes

### Backend
- **Flag Registry** (`internal/typ/flag_registry.go`): Centralized metadata catalog for all rule flags (cursor_compat, skip_usage, use_max_completion_tokens, use_max_tokens, custom_user_agent, cursor_compat_auto). Single source of truth for UI discovery.
- **Flag Resolution** (`internal/server/rule_flags.go`): Helper functions to resolve rule flags and build post-base transforms based on enabled flags.
- **Transform Integration** (`internal/protocol/transform/openai_max_tokens_rewrite.go`, `internal/protocol/transform/ops/request_openai_max_tokens.go`): New Transform stage for rewriting max_tokens/max_completion_tokens fields, with pure operation primitives in ops/ layer.
- **Custom User-Agent Transport** (`internal/client/custom_ua_transport.go`): Per-request User-Agent override via context hints, enabling rule-level UA customization without client rebuilding.
- **API Endpoint** (`internal/server/module/rule/handler.go`): GET /rule/flags/registry returns the flag catalog for frontend consumption.
- **Type Extensions** (`internal/typ/type.go`): Extended RuleFlags struct with skipUsage, customUserAgent, useMaxCompletionTokens, useMaxTokens fields.
- **Protocol Dispatch Updates** (`internal/server/protocol_dispatch.go`): Unified shouldStripUsage() check for usage field stripping across response paths.

### Frontend
- **Flag Catalog Dialog** (`frontend/src/components/rule-card/FlagCatalogDialog.tsx`): Modal UI for browsing and configuring rule flags, grouped by category (compatibility, request, response). Supports both boolean toggles and string inputs.
- **Rule Extensions Card** (`frontend/src/components/rule-card/RuleExtensionsCard.tsx`): Compact card displaying enabled flags inline on the rule graph, with quick-add button to open catalog.
- **Type Definitions** (`frontend/src/components/RoutingGraphTypes.ts`): Added FlagSpec, FlagValueType, FlagCategory types for type-safe flag handling.
- **API Integration** (`frontend/src/services/api.ts`): Placeholder for getRuleFlagRegistry() (codegen pending).
- **Utils** (`frontend/src/components/rule-card/utils.ts`): Extended flag serialization/deserialization to handle all new flag types.
- **Graph Integration** (`frontend/src/components/RoutingGraph.tsx`, `SmartRoutingGraph.tsx`): Added extensionsCard slot for rendering rule extensions alongside providers.
- **Settings Menu Cleanup** (`frontend/src/components/GraphSettingsMenu.tsx`): Removed hardcoded cursor compat toggles in favor of unified catalog dialog.

### Testing
- Comprehensive test coverage for flag registry validation, transform operations, custom UA transport, and rule flag resolution.
- Tests enforce registry-struct consistency and prevent accidental flag removal.

## Implementation Details

**Four-tier flag injection model:**
1. **Type 1a** (pre-chain mutation): Direct request mutation in handler entry (cursor_compat)
2. **Type 1b** (post-base Transform): Chain-integrated transforms after protocol conversion (max_tokens rewrite)
3. **Type 2** (context hints): Per-request context values for transport-level behavior (custom_user_agent)
4. **Type 3** (response post-processing): Extra map hints for response field stripping (skip_usage)

**Op vs Transform separation:** Pure operation primitives in `ops/` layer (no context/rule awareness) are wrapped by Transform implementations that handle type-switching and chain integration. This enables reuse and independent testing.

**Zero-cost no-op:** Flags are only added to the transform chain when enabled; disabled flags have no runtime overhead.

https://claude.ai/code/session_01Pp95V8QTajqKuKpnTUgtFk