### PR TITLE
refactor(server): replace heuristic endpoint selection with capability-aware adaptive routing

### DIFF
--- a/.design/adaptive-endpoint-routing.md
+++ b/.design/adaptive-endpoint-routing.md
@@ -1,0 +1,157 @@
+# Adaptive Endpoint Routing
+
+**Date**: 2026-05-16  
+**Branch**: `refactor/prefer0514`
+
+---
+
+## Problem
+
+OpenAI-compatible providers vary in which HTTP endpoints they expose and whether they support streaming on each. The three variants in practice:
+
+| Provider kind                     | Chat Completions (`/chat/completions`) | Responses API (`/responses`) |
+|-----------------------------------|----------------------------------------|------------------------------|
+| Standard OpenAI / third-party     | ✅                                      | optional                     |
+| Codex (OAuth)                     | ❌                                      | ✅ only                       |
+| Anthropic / Google (pass-through) | native (not OpenAI)                    | —                            |
+
+Before this refactor, the server chose an endpoint by string-matching the model name (
+`"codex"`) or the provider base URL (
+`"chatgpt.com"`). That heuristic broke for providers that host Codex-style models under arbitrary names, and it could not express that a specific endpoint does not support streaming.
+
+Two concrete failure modes:
+
+1. A request routed to Chat Completions for a provider that only exposes Responses API returns a 404 or a protocol error.
+2. A streaming request sent to an endpoint that accepts the base call but does not support
+   `stream: true` hangs or fails mid-stream.
+
+---
+
+## Design
+
+### Core principle: probe once, route per-request
+
+The routing decision is made at request time from cached probe data, not from static configuration or model name patterns. The probe result is the source of truth; routing logic is code, not persisted state.
+
+### Data model: `SupportsStream` is first-class
+
+`EndpointStatus` (in-memory) and `ModelCapability` (SQLite) both carry a `SupportsStream` boolean alongside
+`Available`. An endpoint that accepts non-streaming calls but hangs on streaming is treated as unavailable for streaming requests.
+
+```
+EndpointStatus {
+    Available      bool
+    SupportsStream bool
+    LatencyMs      int
+    ErrorMessage   string
+    LastChecked    time.Time
+}
+```
+
+The DB column `supports_stream` mirrors this. `SaveEndpointCapability` replaces the old `SaveCapability`.
+
+### Probe layer (`adaptive_probe.go`)
+
+`ProbeModelEndpoints` runs Chat and Responses probes concurrently under a single
+`DefaultProbeTimeout` (10 s) context. Each sub-probe uses that same context directly — no nested timeout.
+
+Codex providers skip the Chat probe entirely (they are known to not support it); the Chat status is set to unavailable immediately without a network round-trip.
+
+The probe result is written to:
+
+1. In-memory `ProbeCache` (fast path for subsequent requests)
+2. SQLite via `ModelCapabilityStore` (survives restarts)
+
+`PreferredEndpoint` is never persisted. It is always recalculated from raw `Available`/`SupportsStream` state by
+`determinePreferredEndpoint`. This means routing behavior can be changed by a code deploy without a DB migration or cache flush.
+
+### Routing layer (`adaptive_endpoint_router.go`)
+
+`SelectOpenAIEndpoint` is the single entry point for all four OpenAI-style handlers:
+
+```
+SelectOpenAIEndpoint(
+    ctx         context.Context,
+    provider    *typ.Provider,
+    modelID     string,
+    incoming    IncomingAPIType,   // "chat" or "responses"
+    isStreaming bool,
+    responsesReq *protocol.ResponseCreateRequest,  // nil for chat incoming
+) (*EndpointSelection, error)
+```
+
+Decision tree:
+
+```
+Codex provider?
+  └─ yes → Responses (always)
+
+No cached capability?
+  └─ fire background probe; respect incoming API (non-blocking)
+
+incoming = chat:
+  Chat usable (available ∧ (non-stream ∨ supportsStream))?
+    └─ yes → Chat
+  Responses usable?
+    └─ yes → Responses
+  └─ fallback → Chat (pass through; let provider error propagate)
+
+incoming = responses:
+  Responses usable?
+    └─ yes → Responses
+  Chat usable?
+    └─ can downgrade? (no previous_response_id, include, background, truncation, reasoning)
+       └─ yes → Chat
+       └─ no  → error 400 (unsupported_endpoint)
+  └─ fallback → Responses
+```
+
+`endpointUsable(available, supportsStream, isStreaming bool) bool` encodes the stream compatibility check as a single pure function, making it trivially testable.
+
+`CanDowngradeResponsesToChat` checks Responses-API-only fields that cannot be represented in Chat Completions. If any are set, the downgrade is rejected with a 400 rather than silently dropping request semantics.
+
+### Client probe methods (`openai.go`, `probe.go`)
+
+Two explicit probe methods replace the overloaded `ProbeStream`:
+
+- `ProbeChatEndpoint(ctx, model, ProbeEndpointOptions)` — always hits `/chat/completions`
+- `ProbeResponsesEndpoint(ctx, model, ProbeEndpointOptions)` — always hits `/responses`
+
+`ProbeStream` is retained for backwards compatibility with the Anthropic client path but is deprecated for new endpoint-routing use.
+
+`ProbeEndpointOptions` carries `Message`, `Stream`, and
+`Mode` so callers control exactly what is sent without needing wrapper variants.
+
+---
+
+## Key invariants
+
+1. **`PreferredEndpoint` is never read from the database.** It is always computed from current `Available` and
+   `SupportsStream` state. Code changes take effect on the next `GetModelCapability` call.
+
+2. **Routing never blocks a request on an unknown model.
+   ** If capability is not cached, the incoming API is honoured and a background probe is scheduled. The probe result improves future routing without adding latency to the current request.
+
+3. **Stream incompatibility is a hard routing constraint.** `endpointUsable` returns `false` when
+   `isStreaming && !supportsStream`. The router tries the other endpoint before falling back. If neither endpoint is usable for streaming, the fallback is the primary-preference endpoint for that incoming type — the error comes from the upstream provider, which is the right place for it.
+
+4. **Codex is special-cased at the provider identity level**, not by model name. The check is
+   `provider.OAuthDetail.GetIssuer() == ai.IssuerCodex`, which is stable regardless of what model ID is requested.
+
+---
+
+## Files changed
+
+| File                                               | Role                                                                                                              |
+|----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `internal/server/adaptive_endpoint_router.go`      | New: `SelectOpenAIEndpoint`, routing decision tree                                                                |
+| `internal/server/adaptive_endpoint_router_test.go` | New: unit tests for `endpointUsable`, `defaultEndpointSelection`, `CanDowngradeResponsesToChat`                   |
+| `internal/server/adaptive_probe.go`                | Refactored: Codex fast-path, `SupportsStream` propagation, single timeout per probe run                           |
+| `internal/server/probe_cache.go`                   | `ModelEndpointCapability` + `EndpointStatus` gain `SupportsStream`/`ChatSupportsStream`/`ResponsesSupportsStream` |
+| `internal/data/db/model_capability.go`             | DB schema gains `supports_stream`; new `SaveEndpointCapability`; `PreferredEndpoint` deprecated on struct         |
+| `internal/client/openai.go`                        | `ProbeChatEndpoint`, `ProbeResponsesEndpoint` replacing overloaded `ProbeStream` for endpoint-explicit probing    |
+| `internal/client/probe.go`                         | `ProbeEndpointOptions`; `ProbeStream` marked deprecated for routing                                               |
+| `internal/server/anthropic_beta.go`                | Migrated to `SelectOpenAIEndpoint`                                                                                |
+| `internal/server/anthropic_v1.go`                  | Migrated to `SelectOpenAIEndpoint`                                                                                |
+| `internal/server/openai.go`                        | Migrated to `SelectOpenAIEndpoint`                                                                                |
+| `internal/server/openai_responses.go`              | Migrated to `SelectOpenAIEndpoint`; `CanDowngradeResponsesToChat` guard                                           |

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -46,6 +46,8 @@ type OpenAIClientInterface interface {
 	Probe(ctx context.Context, model string) ProbeResult
 	ProbeStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error)
 	ProbeResponsesStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error)
+	ProbeChatEndpoint(ctx context.Context, model string, opts ProbeEndpointOptions) (*ProbeResult, error)
+	ProbeResponsesEndpoint(ctx context.Context, model string, opts ProbeEndpointOptions) (*ProbeResult, error)
 
 	// Client returns the underlying OpenAI SDK client (for advanced usage)
 	Client() *openai.Client
@@ -324,7 +326,7 @@ func (c *OpenAIClient) Probe(ctx context.Context, model string) ProbeResult {
 	if c.provider.AuthType == typ.AuthTypeOAuth &&
 		c.provider.OAuthDetail != nil &&
 		c.provider.OAuthDetail.GetIssuer() == ai.IssuerCodex {
-		return c.probeResponsesEndpoint(ctx, model)
+		return c.probeCodexResponsesEndpoint(ctx, model)
 	}
 
 	// Create chat completion request using OpenAI SDK
@@ -380,24 +382,24 @@ func (c *OpenAIClient) Probe(ctx context.Context, model string) ProbeResult {
 	}
 }
 
-// probeStream performs a streaming probe with configurable test mode
-
-// ProbeStream performs a streaming probe with configurable test mode (public interface)
-func (c *OpenAIClient) ProbeStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error) {
-	return c.probeStream(ctx, model, message, testMode)
-}
-func (c *OpenAIClient) probeStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error) {
-
-	// Check if this is a Codex OAuth provider
-	if c.provider.AuthType == typ.AuthTypeOAuth &&
-		c.provider.OAuthDetail != nil &&
-		c.provider.OAuthDetail.GetIssuer() == ai.IssuerCodex {
-		return c.ProbeResponsesStream(ctx, model, message, testMode)
+// ProbeChatEndpoint explicitly probes the Chat Completions endpoint.
+func (c *OpenAIClient) ProbeChatEndpoint(ctx context.Context, model string, opts ProbeEndpointOptions) (*ProbeResult, error) {
+	message := opts.Message
+	if message == "" {
+		message = "Hi"
 	}
+	mode := opts.Mode
+	if mode == "" {
+		mode = ProbeModeSimple
+	}
+	if opts.Stream {
+		mode = ProbeModeStreaming
+	}
+	return c.probeChatEndpoint(ctx, model, message, mode, opts.Stream)
+}
 
+func (c *OpenAIClient) probeChatEndpoint(ctx context.Context, model, message string, testMode ProbeMode, forceStream bool) (*ProbeResult, error) {
 	startTime := time.Now()
-
-	// Build request based on test mode
 	messages := []openai.ChatCompletionMessageParamUnion{
 		openai.SystemMessage("work as `echo` if possible"),
 		openai.UserMessage(message),
@@ -407,7 +409,6 @@ func (c *OpenAIClient) probeStream(ctx context.Context, model, message string, t
 		Model:    model,
 		Messages: messages,
 	}
-
 	if testMode == ProbeModeTool {
 		params.Tools = GetProbeToolsOpenAI()
 		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
@@ -415,18 +416,15 @@ func (c *OpenAIClient) probeStream(ctx context.Context, model, message string, t
 		}
 	}
 
-	// For simple mode, use non-streaming request
-	if testMode == ProbeModeSimple {
+	if !forceStream && testMode == ProbeModeSimple {
 		resp, err := c.client.Chat.Completions.New(ctx, params)
 		if err != nil {
 			return nil, err
 		}
-
 		respJSON, _ := json.Marshal(resp)
 		return ToProbeResult(string(respJSON), time.Since(startTime).Milliseconds(), c.provider.APIBase+"/chat/completions", false), nil
 	}
 
-	// For streaming and tool modes, use streaming
 	stream := c.client.Chat.Completions.NewStreaming(ctx, params)
 	defer stream.Close()
 
@@ -434,19 +432,28 @@ func (c *OpenAIClient) probeStream(ctx context.Context, model, message string, t
 	for stream.Next() {
 		chunks = append(chunks, stream.Current())
 	}
-
 	if err := stream.Err(); err != nil {
 		return nil, err
 	}
-
 	chunksJSON, _ := json.Marshal(chunks)
 	return ToProbeResult(string(chunksJSON), time.Since(startTime).Milliseconds(), c.provider.APIBase+"/chat/completions", true), nil
 }
 
-// ProbeResponsesStream performs a streaming probe using Responses API (for Codex)
-func (c *OpenAIClient) ProbeResponsesStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error) {
-	startTime := time.Now()
+// ProbeResponsesEndpoint explicitly probes the Responses API endpoint.
+func (c *OpenAIClient) ProbeResponsesEndpoint(ctx context.Context, model string, opts ProbeEndpointOptions) (*ProbeResult, error) {
+	message := opts.Message
+	if message == "" {
+		message = "Hi"
+	}
+	mode := opts.Mode
+	if mode == "" {
+		mode = ProbeModeSimple
+	}
+	return c.probeResponsesEndpoint(ctx, model, message, mode, opts.Stream)
+}
 
+func (c *OpenAIClient) probeResponsesEndpoint(ctx context.Context, model, message string, testMode ProbeMode, stream bool) (*ProbeResult, error) {
+	startTime := time.Now()
 	params := responses.ResponseNewParams{
 		Model:        model,
 		Instructions: param.NewOpt("work as `echo` if possible"),
@@ -461,7 +468,6 @@ func (c *OpenAIClient) ProbeResponsesStream(ctx context.Context, model, message 
 			},
 		},
 	}
-
 	if testMode == ProbeModeTool {
 		params.Tools = GetProbeToolsResponses()
 		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
@@ -469,20 +475,45 @@ func (c *OpenAIClient) ProbeResponsesStream(ctx context.Context, model, message 
 		}
 	}
 
-	stream := c.ResponsesNewStreaming(ctx, params)
-	defer stream.Close()
+	if !stream {
+		resp, err := c.ResponsesNew(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		respJSON, _ := json.Marshal(resp)
+		return ToProbeResult(string(respJSON), time.Since(startTime).Milliseconds(), c.provider.APIBase+"/responses", false), nil
+	}
+
+	streamResp := c.ResponsesNewStreaming(ctx, params)
+	defer streamResp.Close()
 
 	var chunks []interface{}
-	for stream.Next() {
-		chunks = append(chunks, stream.Current())
+	for streamResp.Next() {
+		chunks = append(chunks, streamResp.Current())
 	}
-
-	if err := stream.Err(); err != nil {
+	if err := streamResp.Err(); err != nil {
 		return nil, err
 	}
-
 	chunksJSON, _ := json.Marshal(chunks)
 	return ToProbeResult(string(chunksJSON), time.Since(startTime).Milliseconds(), c.provider.APIBase+"/responses", true), nil
+}
+
+// probeStream performs a streaming probe with configurable test mode
+
+// ProbeStream performs a streaming probe with configurable test mode (public interface)
+func (c *OpenAIClient) ProbeStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error) {
+	// Keep legacy Codex behavior. Non-Codex legacy probes target Chat explicitly.
+	if c.provider.AuthType == typ.AuthTypeOAuth &&
+		c.provider.OAuthDetail != nil &&
+		c.provider.OAuthDetail.GetIssuer() == ai.IssuerCodex {
+		return c.ProbeResponsesStream(ctx, model, message, testMode)
+	}
+	return c.probeChatEndpoint(ctx, model, message, testMode, testMode != ProbeModeSimple)
+}
+
+// ProbeResponsesStream performs a streaming probe using Responses API (for Codex)
+func (c *OpenAIClient) ProbeResponsesStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error) {
+	return c.probeResponsesEndpoint(ctx, model, message, testMode, true)
 }
 
 // ProbeModelsEndpoint tests the models list endpoint
@@ -570,7 +601,7 @@ func (c *OpenAIClient) ProbeOptionsEndpoint(ctx context.Context) ProbeResult {
 }
 
 // probeResponsesEndpoint tests the Responses API (for Codex OAuth providers)
-func (c *OpenAIClient) probeResponsesEndpoint(ctx context.Context, model string) ProbeResult {
+func (c *OpenAIClient) probeCodexResponsesEndpoint(ctx context.Context, model string) ProbeResult {
 	startTime := time.Now()
 
 	// Build ChatGPT backend API request format

--- a/internal/client/probe.go
+++ b/internal/client/probe.go
@@ -58,8 +58,9 @@ type Prober interface {
 	// Returns a ProbeResult with success status, latency, and any response content
 	Probe(ctx context.Context, model string) ProbeResult
 
-	// ProbeStream performs a streaming probe with configurable test mode
-	// Returns ProbeResult with streaming content, tool calls, usage, and latency
+	// ProbeStream performs a streaming probe with configurable test mode.
+	// Deprecated for endpoint capability routing: use endpoint-explicit probe methods
+	// such as OpenAIClient.ProbeChatEndpoint and OpenAIClient.ProbeResponsesEndpoint.
 	ProbeStream(ctx context.Context, model, message string, testMode ProbeMode) (*ProbeResult, error)
 }
 
@@ -71,4 +72,19 @@ func ToProbeResult(content string, latencyMs int64, requestURL string, isStreami
 		RequestURL: requestURL,
 		Stream:     isStreaming,
 	}
+}
+
+// ProbeEndpointType identifies which OpenAI-compatible endpoint a probe must hit.
+type ProbeEndpointType string
+
+const (
+	ProbeEndpointChat      ProbeEndpointType = "chat"
+	ProbeEndpointResponses ProbeEndpointType = "responses"
+)
+
+// ProbeEndpointOptions controls endpoint-explicit probing.
+type ProbeEndpointOptions struct {
+	Message string
+	Stream  bool
+	Mode    ProbeMode
 }

--- a/internal/data/db/model_capability.go
+++ b/internal/data/db/model_capability.go
@@ -24,15 +24,16 @@ const (
 
 // ModelCapability stores endpoint capability information for each model
 type ModelCapability struct {
-	ProviderUUID string       `gorm:"primaryKey;column:provider_uuid"`
-	ModelID      string       `gorm:"primaryKey;column:model_id"`
-	EndpointType EndpointType `gorm:"primaryKey;column:endpoint_type"`
-	Available    bool         `gorm:"column:available"`
-	LatencyMs    int          `gorm:"column:latency_ms"`
-	LastChecked  time.Time    `gorm:"column:last_checked"`
-	ErrorMessage string       `gorm:"column:error_message"`
-	CreatedAt    time.Time    `gorm:"column:created_at"`
-	UpdatedAt    time.Time    `gorm:"column:updated_at"`
+	ProviderUUID   string       `gorm:"primaryKey;column:provider_uuid"`
+	ModelID        string       `gorm:"primaryKey;column:model_id"`
+	EndpointType   EndpointType `gorm:"primaryKey;column:endpoint_type"`
+	Available      bool         `gorm:"column:available"`
+	SupportsStream bool         `gorm:"column:supports_stream"`
+	LatencyMs      int          `gorm:"column:latency_ms"`
+	LastChecked    time.Time    `gorm:"column:last_checked"`
+	ErrorMessage   string       `gorm:"column:error_message"`
+	CreatedAt      time.Time    `gorm:"column:created_at"`
+	UpdatedAt      time.Time    `gorm:"column:updated_at"`
 }
 
 // TableName specifies the table name for ModelCapability
@@ -42,16 +43,18 @@ func (ModelCapability) TableName() string {
 
 // ModelEndpointCapability represents aggregated endpoint capabilities for a model
 type ModelEndpointCapability struct {
-	ProviderUUID       string
-	ModelID            string
-	SupportsChat       bool
-	ChatLatencyMs      int
-	ChatError          string
-	SupportsResponses  bool
-	ResponsesLatencyMs int
-	ResponsesError     string
-	PreferredEndpoint  string // "chat", "responses", or ""
-	LastVerified       time.Time
+	ProviderUUID            string
+	ModelID                 string
+	SupportsChat            bool
+	ChatSupportsStream      bool
+	ChatLatencyMs           int
+	ChatError               string
+	SupportsResponses       bool
+	ResponsesSupportsStream bool
+	ResponsesLatencyMs      int
+	ResponsesError          string
+	PreferredEndpoint       string // deprecated: routing must not rely on persisted preferred endpoint
+	LastVerified            time.Time
 }
 
 // ModelCapabilityStore persists model endpoint capability information in SQLite using GORM.
@@ -90,31 +93,34 @@ func NewModelCapabilityStore(baseDir string) (*ModelCapabilityStore, error) {
 	return store, nil
 }
 
-// SaveCapability saves a single endpoint capability for a model
+// SaveCapability saves a single endpoint capability for a model.
+// Deprecated: use SaveEndpointCapability when stream/non-stream state is available.
 func (mcs *ModelCapabilityStore) SaveCapability(providerUUID, modelID string, endpointType EndpointType, available bool, latencyMs int, errorMsg string) error {
+	return mcs.SaveEndpointCapability(providerUUID, modelID, endpointType, available, false, latencyMs, errorMsg)
+}
+
+// SaveEndpointCapability saves a single endpoint capability for a model, including stream support.
+func (mcs *ModelCapabilityStore) SaveEndpointCapability(providerUUID, modelID string, endpointType EndpointType, available, supportsStream bool, latencyMs int, errorMsg string) error {
 	mcs.mu.Lock()
 	defer mcs.mu.Unlock()
 
 	now := time.Now()
-
-	// Use Save to create or update the record
 	record := ModelCapability{
-		ProviderUUID: providerUUID,
-		ModelID:      modelID,
-		EndpointType: endpointType,
-		Available:    available,
-		LatencyMs:    latencyMs,
-		LastChecked:  now,
-		ErrorMessage: errorMsg,
-		UpdatedAt:    now,
+		ProviderUUID:   providerUUID,
+		ModelID:        modelID,
+		EndpointType:   endpointType,
+		Available:      available,
+		SupportsStream: supportsStream,
+		LatencyMs:      latencyMs,
+		LastChecked:    now,
+		ErrorMessage:   errorMsg,
+		UpdatedAt:      now,
 	}
 
-	// Check if record exists
 	var existing ModelCapability
 	err := mcs.db.Where("provider_uuid = ? AND model_id = ? AND endpoint_type = ?",
 		providerUUID, modelID, endpointType).First(&existing).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		// Create new record
 		record.CreatedAt = now
 		if err := mcs.db.Create(&record).Error; err != nil {
 			return fmt.Errorf("failed to create capability record: %w", err)
@@ -122,7 +128,6 @@ func (mcs *ModelCapabilityStore) SaveCapability(providerUUID, modelID string, en
 	} else if err != nil {
 		return fmt.Errorf("failed to query existing record: %w", err)
 	} else {
-		// Update existing record, preserve CreatedAt
 		record.CreatedAt = existing.CreatedAt
 		if err := mcs.db.Model(&existing).Updates(&record).Error; err != nil {
 			return fmt.Errorf("failed to update capability record: %w", err)
@@ -176,10 +181,12 @@ func (mcs *ModelCapabilityStore) GetModelCapability(providerUUID, modelID string
 		switch record.EndpointType {
 		case EndpointTypeChat:
 			capability.SupportsChat = record.Available
+			capability.ChatSupportsStream = record.SupportsStream
 			capability.ChatLatencyMs = record.LatencyMs
 			capability.ChatError = record.ErrorMessage
 		case EndpointTypeResponses:
 			capability.SupportsResponses = record.Available
+			capability.ResponsesSupportsStream = record.SupportsStream
 			capability.ResponsesLatencyMs = record.LatencyMs
 			capability.ResponsesError = record.ErrorMessage
 		}
@@ -187,12 +194,7 @@ func (mcs *ModelCapabilityStore) GetModelCapability(providerUUID, modelID string
 
 	capability.LastVerified = maxLastChecked
 
-	// NOTE: PreferredEndpoint is NOT calculated here.
-	// The database stores only raw state (availability, latency, errors).
-	// PreferredEndpoint is calculated by AdaptiveProbe.determinePreferredEndpoint()
-	// which has access to more information (like streaming support) and can be
-	// updated without database migrations.
-	// The PreferredEndpoint field in the returned struct will be set by the caller.
+	// NOTE: PreferredEndpoint is not calculated or persisted here. Routing is decided per request.
 
 	return capability, true
 }
@@ -231,10 +233,12 @@ func (mcs *ModelCapabilityStore) GetProviderCapabilities(providerUUID string) ma
 			switch record.EndpointType {
 			case EndpointTypeChat:
 				capability.SupportsChat = record.Available
+				capability.ChatSupportsStream = record.SupportsStream
 				capability.ChatLatencyMs = record.LatencyMs
 				capability.ChatError = record.ErrorMessage
 			case EndpointTypeResponses:
 				capability.SupportsResponses = record.Available
+				capability.ResponsesSupportsStream = record.SupportsStream
 				capability.ResponsesLatencyMs = record.LatencyMs
 				capability.ResponsesError = record.ErrorMessage
 			}
@@ -242,11 +246,7 @@ func (mcs *ModelCapabilityStore) GetProviderCapabilities(providerUUID string) ma
 
 		capability.LastVerified = maxLastChecked
 
-		// Determine preferred endpoint
-		// NOTE: This is REMOVED - PreferredEndpoint is now calculated by
-		// AdaptiveProbe.determinePreferredEndpoint() which has access to
-		// streaming support information. The database only stores raw state.
-		// The PreferredEndpoint field will remain empty ("") here.
+		// PreferredEndpoint is intentionally not calculated here.
 
 		result[modelID] = capability
 	}

--- a/internal/server/adaptive_endpoint_router.go
+++ b/internal/server/adaptive_endpoint_router.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+type IncomingAPIType string
+
+const (
+	IncomingAPIChat      IncomingAPIType = "chat"
+	IncomingAPIResponses IncomingAPIType = "responses"
+)
+
+type EndpointSelection struct {
+	Target protocol.APIType
+	Reason string
+}
+
+func (s *Server) SelectOpenAIEndpoint(ctx context.Context, provider *typ.Provider, modelID string, incoming IncomingAPIType, isStreaming bool, responsesReq *protocol.ResponseCreateRequest) (*EndpointSelection, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is required for endpoint selection")
+	}
+
+	if isCodexProvider(provider) {
+		return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "Codex provider supports Responses API only"}, nil
+	}
+
+	capability, err := NewAdaptiveProbe(s).GetModelCapability(provider.UUID, modelID)
+	if err != nil || capability == nil {
+		// Unknown capability: respect the incoming API instead of blocking the request on probe.
+		go func() {
+			probeCtx, cancel := context.WithTimeout(context.Background(), DefaultProbeTimeout)
+			defer cancel()
+			_, _ = NewAdaptiveProbe(s).ProbeModelEndpoints(probeCtx, ModelProbeRequest{ProviderUUID: provider.UUID, ModelID: modelID})
+		}()
+		return defaultEndpointSelection(incoming, "no cached capability; respecting incoming API"), nil
+	}
+
+	switch incoming {
+	case IncomingAPIChat:
+		if endpointUsable(capability.SupportsChat, capability.ChatSupportsStream, isStreaming) {
+			return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: "chat endpoint supports incoming chat request"}, nil
+		}
+		if endpointUsable(capability.SupportsResponses, capability.ResponsesSupportsStream, isStreaming) {
+			return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "chat endpoint unavailable; responses endpoint is usable"}, nil
+		}
+		return defaultEndpointSelection(IncomingAPIChat, "no usable probed endpoint for chat request; falling back to chat"), nil
+
+	case IncomingAPIResponses:
+		if endpointUsable(capability.SupportsResponses, capability.ResponsesSupportsStream, isStreaming) {
+			return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "responses endpoint supports incoming responses request"}, nil
+		}
+		if endpointUsable(capability.SupportsChat, capability.ChatSupportsStream, isStreaming) {
+			if responsesReq != nil {
+				if ok, reason := CanDowngradeResponsesToChat(*responsesReq); !ok {
+					return nil, fmt.Errorf("responses endpoint unavailable and request cannot be safely downgraded to chat: %s", reason)
+				}
+			}
+			return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: "responses endpoint unavailable; chat endpoint is usable and downgrade is safe"}, nil
+		}
+		return defaultEndpointSelection(IncomingAPIResponses, "no usable probed endpoint for responses request; falling back to responses"), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported incoming API type: %s", incoming)
+	}
+}
+
+func defaultEndpointSelection(incoming IncomingAPIType, reason string) *EndpointSelection {
+	if incoming == IncomingAPIResponses {
+		return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: reason}
+	}
+	return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: reason}
+}
+
+func endpointUsable(available, supportsStream, isStreaming bool) bool {
+	if !available {
+		return false
+	}
+	if isStreaming {
+		return supportsStream
+	}
+	return true
+}
+
+func isCodexProvider(provider *typ.Provider) bool {
+	return provider != nil && provider.OAuthDetail != nil && provider.OAuthDetail.GetIssuer() == ai.IssuerCodex
+}
+
+func CanDowngradeResponsesToChat(req protocol.ResponseCreateRequest) (bool, string) {
+	p := req.ResponseNewParams
+	switch {
+	case p.PreviousResponseID.Valid():
+		return false, "previous_response_id cannot be represented in Chat Completions"
+	case len(p.Include) > 0:
+		return false, "include cannot be represented in Chat Completions"
+	case p.Background.Valid() && p.Background.Value:
+		return false, "background mode is not supported by Chat Completions"
+	case !param.IsOmitted(p.Truncation):
+		return false, "Responses truncation cannot be safely represented in Chat Completions"
+	case !param.IsOmitted(p.Reasoning):
+		return false, "Responses reasoning configuration cannot be safely represented in Chat Completions"
+	}
+	return true, ""
+}

--- a/internal/server/adaptive_endpoint_router_test.go
+++ b/internal/server/adaptive_endpoint_router_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+func TestEndpointUsable(t *testing.T) {
+	assert.True(t, endpointUsable(true, false, false))
+	assert.True(t, endpointUsable(true, true, true))
+	assert.False(t, endpointUsable(true, false, true))
+	assert.False(t, endpointUsable(false, true, false))
+}
+
+func TestDefaultEndpointSelectionRespectsIncomingAPI(t *testing.T) {
+	assert.Equal(t, protocol.TypeOpenAIChat, defaultEndpointSelection(IncomingAPIChat, "").Target)
+	assert.Equal(t, protocol.TypeOpenAIResponses, defaultEndpointSelection(IncomingAPIResponses, "").Target)
+}
+
+func TestCanDowngradeResponsesToChatPlainRequest(t *testing.T) {
+	ok, reason := CanDowngradeResponsesToChat(protocol.ResponseCreateRequest{})
+	assert.True(t, ok)
+	assert.Empty(t, reason)
+}

--- a/internal/server/adaptive_probe.go
+++ b/internal/server/adaptive_probe.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -48,51 +47,8 @@ func (ap *AdaptiveProbe) ProbeModelEndpoints(ctx context.Context, req ModelProbe
 		}
 	}
 
-	// Step 3: Run probes concurrently
-	var wg sync.WaitGroup
-	var chatStatus, responsesStatus EndpointStatus
-
-	// Create context with timeout for both probes
-	probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
-	defer cancel()
-
-	// Probe chat endpoint
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		chatStatus = ap.probeChatEndpoint(probeCtx, provider, req.ModelID)
-	}()
-
-	// Probe responses endpoint (only for OpenAI-style providers)
-	if provider.APIStyle == protocol.APIStyleOpenAI {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			responsesStatus = ap.probeOpenAIResponsesEndpoint(probeCtx, provider, req.ModelID)
-		}()
-	} else {
-		// Mark responses as unavailable for non-OpenAI providers
-		responsesStatus = EndpointStatus{
-			Available:    false,
-			ErrorMessage: "Responses API is only supported by OpenAI-style providers",
-			LastChecked:  time.Now(),
-		}
-	}
-
-	// Wait for all probes to complete
-	wg.Wait()
-
-	// Step 4: Determine preferred endpoint
-	preferred := ap.determinePreferredEndpoint(&chatStatus, &responsesStatus)
-
-	result := &ProbeResult{
-		ProviderUUID:      req.ProviderUUID,
-		ModelID:           req.ModelID,
-		ChatEndpoint:      chatStatus,
-		ResponsesEndpoint: responsesStatus,
-		PreferredEndpoint: preferred,
-		LastUpdated:       time.Now(),
-	}
+	// Step 3: Run probes concurrently.
+	result := ap.runEndpointProbes(ctx, provider, req)
 
 	// Step 5: Cache results
 	if ap.server.probeCache != nil {
@@ -105,6 +61,45 @@ func (ap *AdaptiveProbe) ProbeModelEndpoints(ctx context.Context, req ModelProbe
 	}
 
 	return result, nil
+}
+
+func (ap *AdaptiveProbe) runEndpointProbes(ctx context.Context, provider *typ.Provider, req ModelProbeRequest) *ProbeResult {
+	var wg sync.WaitGroup
+	var chatStatus, responsesStatus EndpointStatus
+
+	probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
+	defer cancel()
+
+	if !isCodexProvider(provider) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			chatStatus = ap.probeChatEndpoint(probeCtx, provider, req.ModelID)
+		}()
+	} else {
+		chatStatus = EndpointStatus{Available: false, ErrorMessage: "Codex provider does not support Chat Completions API", LastChecked: time.Now()}
+	}
+
+	if provider.APIStyle == protocol.APIStyleOpenAI {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			responsesStatus = ap.probeOpenAIResponsesEndpoint(probeCtx, provider, req.ModelID)
+		}()
+	} else {
+		responsesStatus = EndpointStatus{Available: false, ErrorMessage: "Responses API is only supported by OpenAI-style providers", LastChecked: time.Now()}
+	}
+
+	wg.Wait()
+	preferred := ap.determinePreferredEndpoint(&chatStatus, &responsesStatus)
+	return &ProbeResult{
+		ProviderUUID:      req.ProviderUUID,
+		ModelID:           req.ModelID,
+		ChatEndpoint:      chatStatus,
+		ResponsesEndpoint: responsesStatus,
+		PreferredEndpoint: preferred,
+		LastUpdated:       time.Now(),
+	}
 }
 
 // probeChatEndpoint probes the chat completions endpoint for a model using Prober interface
@@ -123,7 +118,17 @@ func (ap *AdaptiveProbe) probeChatEndpoint(ctx context.Context, provider *typ.Pr
 				LastChecked:  time.Now(),
 			}
 		}
-		prober = wrapper
+		probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
+		defer cancel()
+		result, err := wrapper.ProbeChatEndpoint(probeCtx, modelID, client.ProbeEndpointOptions{Message: "Hi", Stream: true, Mode: client.ProbeModeStreaming})
+		latency := int(time.Since(startTime).Milliseconds())
+		if err != nil {
+			return EndpointStatus{Available: false, LatencyMs: latency, ErrorMessage: fmt.Sprintf("Chat probe failed: %v", err), LastChecked: time.Now()}
+		}
+		if result != nil && result.Content != "" {
+			return EndpointStatus{Available: true, SupportsStream: true, LatencyMs: latency, LastChecked: time.Now()}
+		}
+		return EndpointStatus{Available: false, LatencyMs: latency, ErrorMessage: "Chat probe returned no content", LastChecked: time.Now()}
 	case protocol.APIStyleAnthropic:
 		wrapper := ap.server.clientPool.GetAnthropicClient(context.Background(), provider, "")
 		if wrapper == nil {
@@ -161,10 +166,11 @@ func (ap *AdaptiveProbe) probeChatEndpoint(ctx context.Context, provider *typ.Pr
 
 	if result != nil && result.Content != "" {
 		return EndpointStatus{
-			Available:    true,
-			LatencyMs:    latency,
-			ErrorMessage: "",
-			LastChecked:  time.Now(),
+			Available:      true,
+			SupportsStream: true,
+			LatencyMs:      latency,
+			ErrorMessage:   "",
+			LastChecked:    time.Now(),
 		}
 	}
 
@@ -195,8 +201,8 @@ func (ap *AdaptiveProbe) probeOpenAIResponsesEndpoint(ctx context.Context, provi
 	probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
 	defer cancel()
 
-	// Use ProbeStream with simple mode to test the Responses endpoint
-	result, err := wrapper.ProbeStream(probeCtx, modelID, "Hi", client.ProbeModeSimple)
+	// Explicitly probe the Responses endpoint.
+	result, err := wrapper.ProbeResponsesEndpoint(probeCtx, modelID, client.ProbeEndpointOptions{Message: "Hi", Stream: true, Mode: client.ProbeModeStreaming})
 	latency := int(time.Since(startTime).Milliseconds())
 
 	if err != nil {
@@ -261,11 +267,12 @@ func (ap *AdaptiveProbe) determinePreferredEndpoint(chat, responses *EndpointSta
 // persistResult persists probe result to database
 func (ap *AdaptiveProbe) persistResult(result *ProbeResult) {
 	// Save chat endpoint capability
-	err := ap.server.capabilityStore.SaveCapability(
+	err := ap.server.capabilityStore.SaveEndpointCapability(
 		result.ProviderUUID,
 		result.ModelID,
 		db.EndpointTypeChat,
 		result.ChatEndpoint.Available,
+		result.ChatEndpoint.SupportsStream,
 		result.ChatEndpoint.LatencyMs,
 		result.ChatEndpoint.ErrorMessage,
 	)
@@ -274,11 +281,12 @@ func (ap *AdaptiveProbe) persistResult(result *ProbeResult) {
 	}
 
 	// Save responses endpoint capability
-	err = ap.server.capabilityStore.SaveCapability(
+	err = ap.server.capabilityStore.SaveEndpointCapability(
 		result.ProviderUUID,
 		result.ModelID,
 		db.EndpointTypeResponses,
 		result.ResponsesEndpoint.Available,
+		result.ResponsesEndpoint.SupportsStream,
 		result.ResponsesEndpoint.LatencyMs,
 		result.ResponsesEndpoint.ErrorMessage,
 	)
@@ -293,16 +301,18 @@ func (ap *AdaptiveProbe) cachedCapabilityToResult(capability *ModelEndpointCapab
 		ProviderUUID: capability.ProviderUUID,
 		ModelID:      capability.ModelID,
 		ChatEndpoint: EndpointStatus{
-			Available:    capability.SupportsChat,
-			LatencyMs:    capability.ChatLatencyMs,
-			ErrorMessage: capability.ChatError,
-			LastChecked:  capability.LastVerified,
+			Available:      capability.SupportsChat,
+			SupportsStream: capability.ChatSupportsStream,
+			LatencyMs:      capability.ChatLatencyMs,
+			ErrorMessage:   capability.ChatError,
+			LastChecked:    capability.LastVerified,
 		},
 		ResponsesEndpoint: EndpointStatus{
-			Available:    capability.SupportsResponses,
-			LatencyMs:    capability.ResponsesLatencyMs,
-			ErrorMessage: capability.ResponsesError,
-			LastChecked:  capability.LastVerified,
+			Available:      capability.SupportsResponses,
+			SupportsStream: capability.ResponsesSupportsStream,
+			LatencyMs:      capability.ResponsesLatencyMs,
+			ErrorMessage:   capability.ResponsesError,
+			LastChecked:    capability.LastVerified,
 		},
 		PreferredEndpoint: capability.PreferredEndpoint,
 		LastUpdated:       capability.LastVerified,
@@ -327,16 +337,18 @@ func (ap *AdaptiveProbe) GetModelCapability(providerUUID, modelID string) (*Mode
 		if dbCapability, found := ap.server.capabilityStore.GetModelCapability(providerUUID, modelID); found {
 			// Reconstruct endpoint status from database
 			chatStatus := EndpointStatus{
-				Available:    dbCapability.SupportsChat,
-				LatencyMs:    dbCapability.ChatLatencyMs,
-				ErrorMessage: dbCapability.ChatError,
-				LastChecked:  dbCapability.LastVerified,
+				Available:      dbCapability.SupportsChat,
+				SupportsStream: dbCapability.ChatSupportsStream,
+				LatencyMs:      dbCapability.ChatLatencyMs,
+				ErrorMessage:   dbCapability.ChatError,
+				LastChecked:    dbCapability.LastVerified,
 			}
 			responsesStatus := EndpointStatus{
-				Available:    dbCapability.SupportsResponses,
-				LatencyMs:    dbCapability.ResponsesLatencyMs,
-				ErrorMessage: dbCapability.ResponsesError,
-				LastChecked:  dbCapability.LastVerified,
+				Available:      dbCapability.SupportsResponses,
+				SupportsStream: dbCapability.ResponsesSupportsStream,
+				LatencyMs:      dbCapability.ResponsesLatencyMs,
+				ErrorMessage:   dbCapability.ResponsesError,
+				LastChecked:    dbCapability.LastVerified,
 			}
 
 			// Recalculate PreferredEndpoint using current logic (NOT from database)
@@ -344,16 +356,18 @@ func (ap *AdaptiveProbe) GetModelCapability(providerUUID, modelID string) (*Mode
 			preferredEndpoint := ap.determinePreferredEndpoint(&chatStatus, &responsesStatus)
 
 			capability := &ModelEndpointCapability{
-				ProviderUUID:       dbCapability.ProviderUUID,
-				ModelID:            dbCapability.ModelID,
-				SupportsChat:       dbCapability.SupportsChat,
-				ChatLatencyMs:      dbCapability.ChatLatencyMs,
-				ChatError:          dbCapability.ChatError,
-				SupportsResponses:  dbCapability.SupportsResponses,
-				ResponsesLatencyMs: dbCapability.ResponsesLatencyMs,
-				ResponsesError:     dbCapability.ResponsesError,
-				PreferredEndpoint:  preferredEndpoint, // Recalculated, not from DB
-				LastVerified:       dbCapability.LastVerified,
+				ProviderUUID:            dbCapability.ProviderUUID,
+				ModelID:                 dbCapability.ModelID,
+				SupportsChat:            dbCapability.SupportsChat,
+				ChatSupportsStream:      dbCapability.ChatSupportsStream,
+				ChatLatencyMs:           dbCapability.ChatLatencyMs,
+				ChatError:               dbCapability.ChatError,
+				SupportsResponses:       dbCapability.SupportsResponses,
+				ResponsesSupportsStream: dbCapability.ResponsesSupportsStream,
+				ResponsesLatencyMs:      dbCapability.ResponsesLatencyMs,
+				ResponsesError:          dbCapability.ResponsesError,
+				PreferredEndpoint:       preferredEndpoint, // Recalculated, not from DB
+				LastVerified:            dbCapability.LastVerified,
 			}
 
 			// Cache the recalculated capability
@@ -391,12 +405,8 @@ func (ap *AdaptiveProbe) GetModelCapability(providerUUID, modelID string) (*Mode
 // NOTE: The PreferredEndpoint is ALWAYS calculated by determinePreferredEndpoint(),
 // never read from database. This ensures behavior changes take effect immediately.
 func (ap *AdaptiveProbe) GetPreferredEndpoint(provider *typ.Provider, modelID string) string {
-	// For now, all models with "codex" in their name (case insensitive) prefer completions
-	// In the future, this can be extended to support more models or be configured per-model
-	if strings.Contains(strings.ToLower(modelID), "codex") {
-		return string(db.EndpointTypeResponses)
-	}
-	if strings.Contains(strings.ToLower(provider.APIBase), "chatgpt.com") {
+	// Codex providers only support Responses API — never probe or route to chat
+	if provider.OAuthDetail != nil && provider.OAuthDetail.GetIssuer() == "codex" {
 		return string(db.EndpointTypeResponses)
 	}
 

--- a/internal/server/adaptive_probe.go
+++ b/internal/server/adaptive_probe.go
@@ -118,9 +118,7 @@ func (ap *AdaptiveProbe) probeChatEndpoint(ctx context.Context, provider *typ.Pr
 				LastChecked:  time.Now(),
 			}
 		}
-		probeCtx, cancel := context.WithTimeout(ctx, DefaultProbeTimeout)
-		defer cancel()
-		result, err := wrapper.ProbeChatEndpoint(probeCtx, modelID, client.ProbeEndpointOptions{Message: "Hi", Stream: true, Mode: client.ProbeModeStreaming})
+		result, err := wrapper.ProbeChatEndpoint(ctx, modelID, client.ProbeEndpointOptions{Message: "Hi", Stream: true, Mode: client.ProbeModeStreaming})
 		latency := int(time.Since(startTime).Milliseconds())
 		if err != nil {
 			return EndpointStatus{Available: false, LatencyMs: latency, ErrorMessage: fmt.Sprintf("Chat probe failed: %v", err), LastChecked: time.Now()}

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -8,7 +8,6 @@ import (
 	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3/responses"
-	"github.com/sirupsen/logrus"
 	guardrailsadapter "github.com/tingly-dev/tingly-box/internal/guardrails/adapter"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/nonstream"
@@ -70,16 +69,18 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		// Check if model prefers Responses API (for models like Codex)
-		// This is used for ChatGPT backend API which only supports Responses API
-		preferredEndpoint := s.GetPreferredEndpointForModel(provider, actualModel)
-		logrus.Debugf("[AnthropicV1] Preferred endpoint for model=%s: %s", actualModel, preferredEndpoint)
-		useResponsesAPI := preferredEndpoint == "responses"
-		if useResponsesAPI {
-			target = protocol.TypeOpenAIResponses
-		} else {
-			target = protocol.TypeOpenAIChat
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil)
+		if routeErr != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error: ErrorDetail{
+					Message: routeErr.Error(),
+					Type:    "invalid_request_error",
+					Code:    "unsupported_endpoint",
+				},
+			})
+			return
 		}
+		target = selection.Target
 	}
 
 	// Get or create the recorder for dual-stage recording

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -66,14 +66,18 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		preferredEndpoint := s.GetPreferredEndpointForModel(provider, actualModel)
-		logrus.Debugf("[AnthropicV1] Preferred endpoint for model=%s: %s", actualModel, preferredEndpoint)
-		useResponsesAPI := preferredEndpoint == "responses"
-		if useResponsesAPI {
-			target = protocol.TypeOpenAIResponses
-		} else {
-			target = protocol.TypeOpenAIChat
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil)
+		if routeErr != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error: ErrorDetail{
+					Message: routeErr.Error(),
+					Type:    "invalid_request_error",
+					Code:    "unsupported_endpoint",
+				},
+			})
+			return
 		}
+		target = selection.Target
 	}
 
 	// Get or create the recorder for dual-stage recording

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -280,12 +280,18 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		prefer := s.GetPreferredEndpointForModel(provider, actualModel)
-		if prefer == "responses" {
-			target = protocol.TypeOpenAIResponses
-		} else {
-			target = protocol.TypeOpenAIChat
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIChat, isStreaming, nil)
+		if routeErr != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error: ErrorDetail{
+					Message: routeErr.Error(),
+					Type:    "invalid_request_error",
+					Code:    "unsupported_endpoint",
+				},
+			})
+			return
 		}
+		target = selection.Target
 	default:
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -202,12 +202,18 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 		})
 		return
 	case protocol.APIStyleOpenAI:
-		if provider.APIBase != protocol.CodexAPIBase {
-			preferredEndpoint := NewAdaptiveProbe(s).GetPreferredEndpoint(provider, actualModel)
-			if preferredEndpoint != "responses" {
-				target = protocol.TypeOpenAIChat
-			}
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, &req)
+		if routeErr != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error: ErrorDetail{
+					Message: routeErr.Error(),
+					Type:    "invalid_request_error",
+					Code:    "unsupported_endpoint",
+				},
+			})
+			return
 		}
+		target = selection.Target
 	default:
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/probe_cache.go
+++ b/internal/server/probe_cache.go
@@ -20,16 +20,18 @@ type CachedModelCapability struct {
 
 // ModelEndpointCapability represents the endpoint capability information for a model
 type ModelEndpointCapability struct {
-	ProviderUUID       string
-	ModelID            string
-	SupportsChat       bool
-	ChatLatencyMs      int
-	ChatError          string
-	SupportsResponses  bool
-	ResponsesLatencyMs int
-	ResponsesError     string
-	PreferredEndpoint  string // "chat", "responses", or ""
-	LastVerified       time.Time
+	ProviderUUID            string
+	ModelID                 string
+	SupportsChat            bool
+	ChatSupportsStream      bool
+	ChatLatencyMs           int
+	ChatError               string
+	SupportsResponses       bool
+	ResponsesSupportsStream bool
+	ResponsesLatencyMs      int
+	ResponsesError          string
+	PreferredEndpoint       string // deprecated: use per-request routing decisions instead
+	LastVerified            time.Time
 }
 
 // EndpointStatus represents the status of a single endpoint
@@ -101,16 +103,18 @@ func (pc *ProbeCache) Set(providerUUID, modelID string, capability *ModelEndpoin
 // SetFromProbeResult stores probe result in cache
 func (pc *ProbeCache) SetFromProbeResult(result *ProbeResult) {
 	capability := &ModelEndpointCapability{
-		ProviderUUID:       result.ProviderUUID,
-		ModelID:            result.ModelID,
-		SupportsChat:       result.ChatEndpoint.Available,
-		ChatLatencyMs:      result.ChatEndpoint.LatencyMs,
-		ChatError:          result.ChatEndpoint.ErrorMessage,
-		SupportsResponses:  result.ResponsesEndpoint.Available,
-		ResponsesLatencyMs: result.ResponsesEndpoint.LatencyMs,
-		ResponsesError:     result.ResponsesEndpoint.ErrorMessage,
-		PreferredEndpoint:  result.PreferredEndpoint,
-		LastVerified:       result.LastUpdated,
+		ProviderUUID:            result.ProviderUUID,
+		ModelID:                 result.ModelID,
+		SupportsChat:            result.ChatEndpoint.Available,
+		ChatSupportsStream:      result.ChatEndpoint.SupportsStream,
+		ChatLatencyMs:           result.ChatEndpoint.LatencyMs,
+		ChatError:               result.ChatEndpoint.ErrorMessage,
+		SupportsResponses:       result.ResponsesEndpoint.Available,
+		ResponsesSupportsStream: result.ResponsesEndpoint.SupportsStream,
+		ResponsesLatencyMs:      result.ResponsesEndpoint.LatencyMs,
+		ResponsesError:          result.ResponsesEndpoint.ErrorMessage,
+		PreferredEndpoint:       result.PreferredEndpoint,
+		LastVerified:            result.LastUpdated,
 	}
 	pc.Set(result.ProviderUUID, result.ModelID, capability)
 }


### PR DESCRIPTION
## Summary
Routing OpenAI-compatible requests to the right endpoint (Chat Completions vs Responses API)
was done by string-matching model names and base URLs. 

This broke for Codex-hosted models with arbitrary names and could not account for whether an endpoint supports streaming.
Replaced with a probe-driven routing system that tests endpoints at runtime and selects
based on actual observed capability.

### Major
- New `SelectOpenAIEndpoint` function consolidates all OpenAI routing decisions: all four
handlers (`openai.go`, `openai_responses.go`, `anthropic_v1.go`, `anthropic_beta.go`)
now call one place instead of duplicating heuristic logic
- Endpoints are classified by both availability and streaming support; a streaming request
is never routed to an endpoint that doesn't support it
- Codex providers are identified by OAuth issuer identity (not model name), short-circuiting
directly to Responses API without a probe
- Downgrade from Responses → Chat is guarded by `CanDowngradeResponsesToChat`, which
rejects requests that use Responses-only fields (`previous_response_id`, `include`,
`background`, `truncation`, `reasoning`) with a 400 rather than silently dropping semantics
- Unknown models are handled non-blockingly: routing respects the incoming API and schedules
a background probe to improve future requests

### Minor
- `SupportsStream` added to `EndpointStatus`, `ModelCapability` DB schema, and all cache
reconstruction paths so stream capability survives restarts
- `ProbeChatEndpoint` and `ProbeResponsesEndpoint` replace the overloaded `ProbeStream`
for endpoint-explicit probing; `ProbeStream` retained but deprecated
- `PreferredEndpoint` is no longer persisted to the database; it is always recomputed from
raw availability state so routing logic changes take effect on deploy without a DB migration
- Fixed a double `context.WithTimeout` in `probeChatEndpoint` (OpenAI path) that allowed
the probe to run up to 2× the intended timeout
- Codex providers skip the Chat probe entirely instead of probing and discarding