### PR TITLE
feat(rule, probe): Add OpenAI endpoint override rule flag with enum support

### DIFF
--- a/.design/adaptive-endpoint-routing.md
+++ b/.design/adaptive-endpoint-routing.md
@@ -69,22 +69,32 @@ The probe result is written to:
 
 `SelectOpenAIEndpoint` is the single entry point for all four OpenAI-style handlers:
 
-```
+```go
 SelectOpenAIEndpoint(
-    ctx         context.Context,
-    provider    *typ.Provider,
-    modelID     string,
-    incoming    IncomingAPIType,   // "chat" or "responses"
-    isStreaming bool,
-    responsesReq *protocol.ResponseCreateRequest,  // nil for chat incoming
+    ctx      context.Context,
+    provider *typ.Provider,
+    modelID  string,
+    opts     OpenAIEndpointOptions,
 ) (*EndpointSelection, error)
+
+type OpenAIEndpointOptions struct {
+    Incoming         IncomingAPIType  // "chat" or "responses"
+    IsStreaming      bool
+    Override         EndpointOverride // rule-level force; zero = OverrideAuto
+    RequireResponses bool             // caller pre-computed: request can't downgrade
+}
 ```
+
+Provider and model ID stay as direct parameters because they identify the target; everything else lives on `opts`. The zero `OpenAIEndpointOptions{}` is meaningful: `OverrideAuto` + downgrade-allowed.
 
 Decision tree:
 
 ```
 Codex provider?
-  └─ yes → Responses (always)
+  └─ yes → Responses (always; "chat" override logged and ignored)
+
+Override = chat | responses?
+  └─ yes → forced endpoint (skips capability probe)
 
 No cached capability?
   └─ fire background probe; respect incoming API (non-blocking)
@@ -100,15 +110,19 @@ incoming = responses:
   Responses usable?
     └─ yes → Responses
   Chat usable?
-    └─ can downgrade? (no previous_response_id, include, background, truncation, reasoning)
-       └─ yes → Chat
-       └─ no  → error 400 (unsupported_endpoint)
+    └─ opts.RequireResponses set?
+       └─ no  → Chat
+       └─ yes → error 400 (unsupported_endpoint)
   └─ fallback → Responses
 ```
 
 `endpointUsable(available, supportsStream, isStreaming bool) bool` encodes the stream compatibility check as a single pure function, making it trivially testable.
 
-`CanDowngradeResponsesToChat` checks Responses-API-only fields that cannot be represented in Chat Completions. If any are set, the downgrade is rejected with a 400 rather than silently dropping request semantics.
+`CanDowngradeResponsesToChat` checks Responses-API-only fields (`previous_response_id`, `include`, `background`, `truncation`, `reasoning`) that cannot be represented in Chat Completions. It lives at the caller (`ResponsesCreate`), which feeds the result into `opts.RequireResponses`. The router only sees the boolean — keeping it independent of `*protocol.ResponseCreateRequest`. When the constraint forces an error, the router returns a generic message; the specific blocking field stays known to the caller, which can log details at its own discretion.
+
+### Rule-level override (`openai_endpoint_override`)
+
+The `openai_endpoint_override` rule flag (enum: `auto` | `chat` | `responses`) takes precedence over the capability probe. It surfaces as `EndpointOverride` in `endpoint_override.go` and is parsed via `ParseEndpointOverride` at each handler before being passed in `opts.Override`. Auto = current adaptive behavior. Chat / Responses skip the probe and return the forced endpoint directly. On Codex providers, `chat` is logged as a warning and ignored (Codex has no Chat endpoint).
 
 ### Client probe methods (`openai.go`, `probe.go`)
 

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -89,9 +89,15 @@ type FlagSpec struct {
     Key         string        // 与 RuleFlags 上的 json tag 完全对应
     Label       string        // UI 展示用人话
     Description string        // hover 详细说明
-    Type        FlagValueType // bool | string
+    Type        FlagValueType // bool | string | enum
     Category    FlagCategory  // compatibility | request | response
     Placeholder string        // string 类型的输入框 hint
+    Options     []FlagOption  // enum 类型的可选值，按显示顺序
+}
+
+type FlagOption struct {
+    Value string // 持久化到 RuleFlags 的字符串
+    Label string // UI 展示
 }
 
 func RuleFlagRegistry() []FlagSpec { … }
@@ -103,6 +109,8 @@ func RuleFlagRegistry() []FlagSpec { … }
   tag。这条测试挡住"加了 spec 忘了加字段"或反过来。
 - `Label` / `Description` 非空。
 - `Type` 必须在已知枚举内。
+- `enum` 类型必须声明 ≥ 2 个 `Options`，每个 Option 的 `Value` / `Label`
+  非空且不重复。首个 Option 视为默认值（UI 显示为"未启用"状态）。
 
 ---
 
@@ -116,10 +124,11 @@ func RuleFlagRegistry() []FlagSpec { … }
 | `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `transform.OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite`（Type 1b）|
 | `use_max_tokens` | bool | request | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b）|
 | `custom_user_agent` | string | request | 覆盖出站 User-Agent header | `customUserAgentTransport` + `WithCustomUserAgent(ctx, ...)`（Type 2）|
+| `openai_endpoint_override` | enum (`auto`/`chat`/`responses`) | request | 强制 OpenAI 出口走 Chat 或 Responses，绕过自适应路由探针 | `ParseEndpointOverride` → `OpenAIEndpointOptions.Override` 透传给 `SelectOpenAIEndpoint`（Type 4：路由层决策）|
 
 ---
 
-## 5. 四种 flag 注入手法
+## 5. 五种 flag 注入手法
 
 ```
 Type 1a  Request body, pre-chain mutation
@@ -140,9 +149,14 @@ Type 3   Response post-processing
          handler 把 flag 写进 reqCtx.Extra；protocol_dispatch.go 的派
          发分支用 shouldStripUsage 这类统一判定来决定剥/改字段。
          例：skip_usage。
+
+Type 4   Routing-decision input
+         handler 把 flag 解析后作为 SelectOpenAIEndpoint 的 opts 字段
+         传入；路由层在 Transform chain 构造**之前**就决定走哪条出口。
+         不进 ExtraFields、不进 ctx。例：openai_endpoint_override。
 ```
 
-任何新 flag 都应归入这四类之一。
+任何新 flag 都应归入这五类之一。
 
 ---
 

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -58,6 +58,7 @@ export interface RuleFlags {
     customUserAgent?: string;
     useMaxCompletionTokens?: boolean;
     useMaxTokens?: boolean;
+    openaiEndpointOverride?: string;
 }
 
 export interface RuleFlagsApi {
@@ -67,9 +68,15 @@ export interface RuleFlagsApi {
     custom_user_agent?: string;
     use_max_completion_tokens?: boolean;
     use_max_tokens?: boolean;
+    openai_endpoint_override?: string;
 }
 
-export type FlagValueType = 'bool' | 'string';
+export type FlagValueType = 'bool' | 'string' | 'enum';
+
+export interface FlagOption {
+    value: string;
+    label: string;
+}
 
 export interface FlagSpec {
     key: string;
@@ -78,6 +85,7 @@ export interface FlagSpec {
     type: FlagValueType;
     category: string;
     placeholder?: string;
+    options?: FlagOption[];
 }
 
 export interface Rule {

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -7,6 +7,10 @@ import {
     DialogContent,
     DialogTitle,
     Divider,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
     Stack,
     Switch,
     TextField,
@@ -14,6 +18,9 @@ import {
 } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
 import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
+
+// Default enum value treated as "unset" (matches the registry's first option).
+const ENUM_DEFAULT_VALUE = 'auto';
 
 export interface FlagCatalogDialogProps {
     open: boolean;
@@ -45,6 +52,8 @@ const flagToString = (flags: RuleFlags | undefined, key: string): string => {
     switch (key) {
         case 'custom_user_agent':
             return flags.customUserAgent || '';
+        case 'openai_endpoint_override':
+            return flags.openaiEndpointOverride || '';
         default:
             return '';
     }
@@ -69,6 +78,9 @@ const setString = (flags: RuleFlags, key: string, value: string): RuleFlags => {
     switch (key) {
         case 'custom_user_agent':
             return { ...flags, customUserAgent: value };
+        case 'openai_endpoint_override':
+            // Persist "auto" as empty string so omitempty hides it on the wire.
+            return { ...flags, openaiEndpointOverride: value === ENUM_DEFAULT_VALUE ? '' : value };
         default:
             return flags;
     }
@@ -143,9 +155,18 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                             </Stack>
                             <Stack spacing={1.5}>
                                 {specs.map((spec) => {
-                                    const enabled = spec.type === 'bool'
-                                        ? flagToBool(draft, spec.key)
-                                        : flagToString(draft, spec.key) !== '';
+                                    let enabled = false;
+                                    if (spec.type === 'bool') {
+                                        enabled = flagToBool(draft, spec.key);
+                                    } else if (spec.type === 'enum') {
+                                        const v = flagToString(draft, spec.key);
+                                        enabled = v !== '' && v !== ENUM_DEFAULT_VALUE;
+                                    } else {
+                                        enabled = flagToString(draft, spec.key) !== '';
+                                    }
+                                    const enumValue = spec.type === 'enum'
+                                        ? (flagToString(draft, spec.key) || ENUM_DEFAULT_VALUE)
+                                        : '';
                                     return (
                                         <Box
                                             key={spec.key}
@@ -191,6 +212,25 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                                     onChange={(e) => handleStringChange(spec.key, e.target.value)}
                                                     sx={{ mt: 1 }}
                                                 />
+                                            )}
+                                            {spec.type === 'enum' && (
+                                                <FormControl fullWidth size="small" sx={{ mt: 1 }}>
+                                                    <InputLabel id={`flag-enum-${spec.key}-label`}>
+                                                        {spec.label}
+                                                    </InputLabel>
+                                                    <Select
+                                                        labelId={`flag-enum-${spec.key}-label`}
+                                                        label={spec.label}
+                                                        value={enumValue}
+                                                        onChange={(e) => handleStringChange(spec.key, String(e.target.value))}
+                                                    >
+                                                        {(spec.options || []).map((opt) => (
+                                                            <MenuItem key={opt.value} value={opt.value}>
+                                                                {opt.label}
+                                                            </MenuItem>
+                                                        ))}
+                                                    </Select>
+                                                </FormControl>
                                             )}
                                         </Box>
                                     );

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -60,10 +60,15 @@ const flagStringValue = (flags: RuleFlags | undefined, key: string): string => {
     switch (key) {
         case 'custom_user_agent':
             return flags.customUserAgent || '';
+        case 'openai_endpoint_override':
+            return flags.openaiEndpointOverride || '';
         default:
             return '';
     }
 };
+
+// Enum default that should be treated as "unset" (registry's first option).
+const ENUM_DEFAULT_VALUE = 'auto';
 
 /**
  * RuleExtensionsCard renders a compact card displaying the rule's enabled
@@ -79,6 +84,10 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
 }) => {
     const enabled = (registry || []).filter((spec) => {
         if (spec.type === 'bool') return flagBoolValue(flags, spec.key);
+        if (spec.type === 'enum') {
+            const v = flagStringValue(flags, spec.key);
+            return v !== '' && v !== ENUM_DEFAULT_VALUE;
+        }
         return flagStringValue(flags, spec.key) !== '';
     });
 
@@ -129,10 +138,18 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                     <Stack direction="row" flexWrap="wrap" gap={0.25}>
                         {enabled.map((spec) => {
                             const isString = spec.type === 'string';
-                            const stringVal = isString ? flagStringValue(flags, spec.key) : '';
-                            const label = isString && stringVal ? `${spec.label}: ${stringVal}` : spec.label;
-                            const title = isString && stringVal
-                                ? `${spec.description}\nValue: ${stringVal}`
+                            const isEnum = spec.type === 'enum';
+                            const stringVal = isString || isEnum ? flagStringValue(flags, spec.key) : '';
+                            let displayVal = stringVal;
+                            if (isEnum) {
+                                const opt = (spec.options || []).find((o) => o.value === stringVal);
+                                if (opt) displayVal = opt.label;
+                            }
+                            const label = (isString || isEnum) && displayVal
+                                ? `${spec.label}: ${displayVal}`
+                                : spec.label;
+                            const title = (isString || isEnum) && stringVal
+                                ? `${spec.description}\nValue: ${displayVal}`
                                 : spec.description;
                             return (
                                 <Tooltip key={spec.key} title={title}>

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -121,6 +121,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         custom_user_agent: newConfigRecord.flags?.customUserAgent || '',
                         use_max_completion_tokens: newConfigRecord.flags?.useMaxCompletionTokens || false,
                         use_max_tokens: newConfigRecord.flags?.useMaxTokens || false,
+                        openai_endpoint_override: newConfigRecord.flags?.openaiEndpointOverride || '',
                     },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -72,6 +72,7 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
             customUserAgent: rule.flags?.custom_user_agent || '',
             useMaxCompletionTokens: rule.flags?.use_max_completion_tokens || false,
             useMaxTokens: rule.flags?.use_max_tokens || false,
+            openaiEndpointOverride: rule.flags?.openai_endpoint_override || '',
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
@@ -191,6 +192,7 @@ interface ExportRule {
         custom_user_agent?: string;
         use_max_completion_tokens?: boolean;
         use_max_tokens?: boolean;
+        openai_endpoint_override?: string;
     };
     smart_enabled?: boolean;
     smart_routing: any[];
@@ -219,6 +221,15 @@ interface ExportProvider {
 const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
 const FALSE_VALUES = new Set(['false', '0', 'no', 'off']);
 
+const ENUM_FLAG_VALUES: Record<string, Set<string>> = {
+    openai_endpoint_override: new Set(['auto', 'chat', 'responses']),
+};
+
+function isEnumActive(key: string, value: string): boolean {
+    // "auto" (and empty) are inactive defaults; anything else counts as active.
+    return value !== '' && value !== 'auto';
+}
+
 export function formatRuleFlags(flags?: RuleFlags): string {
     if (!flags) return '';
     const entries: string[] = [];
@@ -228,10 +239,14 @@ export function formatRuleFlags(flags?: RuleFlags): string {
     if (flags.useMaxCompletionTokens) entries.push('use_max_completion_tokens=true');
     if (flags.useMaxTokens) entries.push('use_max_tokens=true');
     if (flags.customUserAgent) entries.push(`custom_user_agent=${flags.customUserAgent}`);
+    if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) {
+        entries.push(`openai_endpoint_override=${flags.openaiEndpointOverride}`);
+    }
     return entries.join(',');
 }
 
 const STRING_FLAG_KEYS = new Set(['custom_user_agent']);
+const ENUM_FLAG_KEYS = new Set(Object.keys(ENUM_FLAG_VALUES));
 
 export function parseRuleFlags(input: string): { flags: RuleFlags; error?: string } {
     const flags: RuleFlags = {
@@ -241,6 +256,7 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
         customUserAgent: '',
         useMaxCompletionTokens: false,
         useMaxTokens: false,
+        openaiEndpointOverride: '',
     };
 
     const trimmed = input.trim();
@@ -264,6 +280,20 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             switch (rawKey) {
                 case 'custom_user_agent':
                     flags.customUserAgent = rawValue;
+                    break;
+            }
+            continue;
+        }
+
+        if (ENUM_FLAG_KEYS.has(rawKey)) {
+            const allowed = ENUM_FLAG_VALUES[rawKey];
+            if (!allowed.has(rawValue)) {
+                const options = Array.from(allowed).join('/');
+                return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use ${options}.` };
+            }
+            switch (rawKey) {
+                case 'openai_endpoint_override':
+                    flags.openaiEndpointOverride = rawValue;
                     break;
             }
             continue;
@@ -313,6 +343,7 @@ export function countActiveFlags(flags?: RuleFlags): number {
     if (flags.useMaxCompletionTokens) n++;
     if (flags.useMaxTokens) n++;
     if (flags.customUserAgent && flags.customUserAgent.trim() !== '') n++;
+    if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) n++;
     return n;
 }
 

--- a/internal/server/adaptive_endpoint_router.go
+++ b/internal/server/adaptive_endpoint_router.go
@@ -22,19 +22,36 @@ type EndpointSelection struct {
 	Reason string
 }
 
-func (s *Server) SelectOpenAIEndpoint(ctx context.Context, provider *typ.Provider, modelID string, incoming IncomingAPIType, isStreaming bool, responsesReq *protocol.ResponseCreateRequest, override EndpointOverride) (*EndpointSelection, error) {
+// OpenAIEndpointOptions bundles the per-call inputs to SelectOpenAIEndpoint.
+// Provider and model ID stay as direct parameters because they identify the
+// target; everything else here shapes the routing decision.
+type OpenAIEndpointOptions struct {
+	Incoming    IncomingAPIType
+	IsStreaming bool
+	// Override forces an endpoint regardless of capability. Zero value =
+	// OverrideAuto (defer to the adaptive router).
+	Override EndpointOverride
+	// RequireResponses indicates the incoming Responses request uses features
+	// (previous_response_id / include / background / truncation / reasoning)
+	// that cannot be represented in Chat Completions. When set, the router
+	// refuses to downgrade and returns an error if Responses is unusable.
+	// Only ResponsesCreate sets this; computed via CanDowngradeResponsesToChat.
+	RequireResponses bool
+}
+
+func (s *Server) SelectOpenAIEndpoint(ctx context.Context, provider *typ.Provider, modelID string, opts OpenAIEndpointOptions) (*EndpointSelection, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("provider is required for endpoint selection")
 	}
 
 	if isCodexProvider(provider) {
-		if override == OverrideChat {
+		if opts.Override == OverrideChat {
 			logCodexChatOverrideIgnored(provider)
 		}
 		return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "Codex provider supports Responses API only"}, nil
 	}
 
-	switch override {
+	switch opts.Override {
 	case OverrideChat:
 		return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: "rule override: openai_endpoint_override=chat"}, nil
 	case OverrideResponses:
@@ -49,35 +66,33 @@ func (s *Server) SelectOpenAIEndpoint(ctx context.Context, provider *typ.Provide
 			defer cancel()
 			_, _ = NewAdaptiveProbe(s).ProbeModelEndpoints(probeCtx, ModelProbeRequest{ProviderUUID: provider.UUID, ModelID: modelID})
 		}()
-		return defaultEndpointSelection(incoming, "no cached capability; respecting incoming API"), nil
+		return defaultEndpointSelection(opts.Incoming, "no cached capability; respecting incoming API"), nil
 	}
 
-	switch incoming {
+	switch opts.Incoming {
 	case IncomingAPIChat:
-		if endpointUsable(capability.SupportsChat, capability.ChatSupportsStream, isStreaming) {
+		if endpointUsable(capability.SupportsChat, capability.ChatSupportsStream, opts.IsStreaming) {
 			return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: "chat endpoint supports incoming chat request"}, nil
 		}
-		if endpointUsable(capability.SupportsResponses, capability.ResponsesSupportsStream, isStreaming) {
+		if endpointUsable(capability.SupportsResponses, capability.ResponsesSupportsStream, opts.IsStreaming) {
 			return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "chat endpoint unavailable; responses endpoint is usable"}, nil
 		}
 		return defaultEndpointSelection(IncomingAPIChat, "no usable probed endpoint for chat request; falling back to chat"), nil
 
 	case IncomingAPIResponses:
-		if endpointUsable(capability.SupportsResponses, capability.ResponsesSupportsStream, isStreaming) {
+		if endpointUsable(capability.SupportsResponses, capability.ResponsesSupportsStream, opts.IsStreaming) {
 			return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "responses endpoint supports incoming responses request"}, nil
 		}
-		if endpointUsable(capability.SupportsChat, capability.ChatSupportsStream, isStreaming) {
-			if responsesReq != nil {
-				if ok, reason := CanDowngradeResponsesToChat(*responsesReq); !ok {
-					return nil, fmt.Errorf("responses endpoint unavailable and request cannot be safely downgraded to chat: %s", reason)
-				}
+		if endpointUsable(capability.SupportsChat, capability.ChatSupportsStream, opts.IsStreaming) {
+			if opts.RequireResponses {
+				return nil, fmt.Errorf("responses endpoint is unavailable and request requires Responses API features that cannot be downgraded to Chat Completions")
 			}
 			return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: "responses endpoint unavailable; chat endpoint is usable and downgrade is safe"}, nil
 		}
 		return defaultEndpointSelection(IncomingAPIResponses, "no usable probed endpoint for responses request; falling back to responses"), nil
 
 	default:
-		return nil, fmt.Errorf("unsupported incoming API type: %s", incoming)
+		return nil, fmt.Errorf("unsupported incoming API type: %s", opts.Incoming)
 	}
 }
 

--- a/internal/server/adaptive_endpoint_router.go
+++ b/internal/server/adaptive_endpoint_router.go
@@ -22,13 +22,23 @@ type EndpointSelection struct {
 	Reason string
 }
 
-func (s *Server) SelectOpenAIEndpoint(ctx context.Context, provider *typ.Provider, modelID string, incoming IncomingAPIType, isStreaming bool, responsesReq *protocol.ResponseCreateRequest) (*EndpointSelection, error) {
+func (s *Server) SelectOpenAIEndpoint(ctx context.Context, provider *typ.Provider, modelID string, incoming IncomingAPIType, isStreaming bool, responsesReq *protocol.ResponseCreateRequest, override EndpointOverride) (*EndpointSelection, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("provider is required for endpoint selection")
 	}
 
 	if isCodexProvider(provider) {
+		if override == OverrideChat {
+			logCodexChatOverrideIgnored(provider)
+		}
 		return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "Codex provider supports Responses API only"}, nil
+	}
+
+	switch override {
+	case OverrideChat:
+		return &EndpointSelection{Target: protocol.TypeOpenAIChat, Reason: "rule override: openai_endpoint_override=chat"}, nil
+	case OverrideResponses:
+		return &EndpointSelection{Target: protocol.TypeOpenAIResponses, Reason: "rule override: openai_endpoint_override=responses"}, nil
 	}
 
 	capability, err := NewAdaptiveProbe(s).GetModelCapability(provider.UUID, modelID)

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -69,7 +69,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil)
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil, ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride))
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/anthropic_beta.go
+++ b/internal/server/anthropic_beta.go
@@ -69,7 +69,11 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil, ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride))
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, OpenAIEndpointOptions{
+			Incoming:    IncomingAPIResponses,
+			IsStreaming: isStreaming,
+			Override:    ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride),
+		})
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -66,7 +66,11 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil, ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride))
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, OpenAIEndpointOptions{
+			Incoming:    IncomingAPIResponses,
+			IsStreaming: isStreaming,
+			Override:    ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride),
+		})
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/anthropic_v1.go
+++ b/internal/server/anthropic_v1.go
@@ -66,7 +66,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil)
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, nil, ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride))
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/endpoint_override.go
+++ b/internal/server/endpoint_override.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// EndpointOverride is the typed value of the openai_endpoint_override rule
+// flag. It forces an OpenAI request onto a specific endpoint, bypassing the
+// adaptive router's capability probe.
+type EndpointOverride string
+
+const (
+	OverrideAuto      EndpointOverride = "auto"
+	OverrideChat      EndpointOverride = "chat"
+	OverrideResponses EndpointOverride = "responses"
+)
+
+// ParseEndpointOverride coerces a raw rule-flag string to a known
+// EndpointOverride. Empty, "auto" and any unrecognized value map to
+// OverrideAuto so misconfigured rules degrade safely.
+func ParseEndpointOverride(s string) EndpointOverride {
+	switch s {
+	case string(OverrideChat):
+		return OverrideChat
+	case string(OverrideResponses):
+		return OverrideResponses
+	default:
+		return OverrideAuto
+	}
+}
+
+// logCodexChatOverrideIgnored emits the warning that a "chat" override against
+// a Codex provider was discarded because Codex has no Chat endpoint.
+func logCodexChatOverrideIgnored(provider *typ.Provider) {
+	uuid := ""
+	if provider != nil {
+		uuid = provider.UUID
+	}
+	logrus.Warnf("rule openai_endpoint_override=chat ignored: provider %s is Codex (Chat unsupported)", uuid)
+}

--- a/internal/server/endpoint_override_test.go
+++ b/internal/server/endpoint_override_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestParseEndpointOverride(t *testing.T) {
+	cases := []struct {
+		in   string
+		want EndpointOverride
+	}{
+		{"", OverrideAuto},
+		{"auto", OverrideAuto},
+		{"chat", OverrideChat},
+		{"responses", OverrideResponses},
+		{"unknown", OverrideAuto},
+		{"CHAT", OverrideAuto}, // case-sensitive on purpose; the registry emits lowercase
+	}
+	for _, c := range cases {
+		got := ParseEndpointOverride(c.in)
+		if got != c.want {
+			t.Errorf("ParseEndpointOverride(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsCodexProvider(t *testing.T) {
+	if isCodexProvider(nil) {
+		t.Error("nil provider should not be Codex")
+	}
+	if isCodexProvider(&typ.Provider{UUID: "p-1"}) {
+		t.Error("provider without OAuthDetail should not be Codex")
+	}
+	codex := &typ.Provider{
+		UUID:        "codex-1",
+		OAuthDetail: &typ.OAuthDetail{Issuer: ai.IssuerCodex},
+	}
+	if !isCodexProvider(codex) {
+		t.Error("Codex-issuer OAuth provider should be Codex")
+	}
+}

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -284,7 +284,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIChat, isStreaming, nil)
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIChat, isStreaming, nil, ParseEndpointOverride(ruleFlags.OpenAIEndpointOverride))
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -284,7 +284,11 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIChat, isStreaming, nil, ParseEndpointOverride(ruleFlags.OpenAIEndpointOverride))
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, OpenAIEndpointOptions{
+			Incoming:    IncomingAPIChat,
+			IsStreaming: isStreaming,
+			Override:    ParseEndpointOverride(ruleFlags.OpenAIEndpointOverride),
+		})
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -202,7 +202,13 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 		})
 		return
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, &req, ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride))
+		canDowngrade, _ := CanDowngradeResponsesToChat(req)
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, OpenAIEndpointOptions{
+			Incoming:         IncomingAPIResponses,
+			IsStreaming:      isStreaming,
+			Override:         ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride),
+			RequireResponses: !canDowngrade,
+		})
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -202,7 +202,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 		})
 		return
 	case protocol.APIStyleOpenAI:
-		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, &req)
+		selection, routeErr := s.SelectOpenAIEndpoint(c.Request.Context(), provider, actualModel, IncomingAPIResponses, isStreaming, &req, ParseEndpointOverride(resolveRuleFlags(rule).OpenAIEndpointOverride))
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -6,6 +6,7 @@ type FlagValueType string
 const (
 	FlagTypeBool   FlagValueType = "bool"
 	FlagTypeString FlagValueType = "string"
+	FlagTypeEnum   FlagValueType = "enum"
 )
 
 // FlagCategory groups flags for presentation in the UI.
@@ -17,16 +18,25 @@ const (
 	FlagCategoryResponse      FlagCategory = "response"
 )
 
+// FlagOption is one selectable value for a FlagTypeEnum spec.
+type FlagOption struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
 // FlagSpec describes a single rule-level flag's metadata for the UI catalog.
 // Keys must match the JSON tag name on RuleFlags.
 type FlagSpec struct {
-	Key         string       `json:"key"`
-	Label       string       `json:"label"`
-	Description string       `json:"description"`
+	Key         string        `json:"key"`
+	Label       string        `json:"label"`
+	Description string        `json:"description"`
 	Type        FlagValueType `json:"type"`
-	Category    FlagCategory `json:"category"`
+	Category    FlagCategory  `json:"category"`
 	// Placeholder is the hint text shown in string-type input fields.
 	Placeholder string `json:"placeholder,omitempty"`
+	// Options enumerates the selectable values for FlagTypeEnum flags.
+	// The first option is treated as the default when the stored value is empty.
+	Options []FlagOption `json:"options,omitempty"`
 }
 
 // RuleFlagRegistry returns the catalog of supported rule flags. The order is
@@ -75,6 +85,18 @@ func RuleFlagRegistry() []FlagSpec {
 			Type:        FlagTypeString,
 			Category:    FlagCategoryRequest,
 			Placeholder: "e.g. MyApp/1.0",
+		},
+		{
+			Key:         "openai_endpoint_override",
+			Label:       "OpenAI endpoint override",
+			Description: "Force OpenAI Chat Completions or Responses regardless of the adaptive router's probe-based decision. OpenAI providers only; Anthropic/Google providers ignore this. On Codex OAuth providers, \"chat\" is ignored (Codex has no Chat endpoint).",
+			Type:        FlagTypeEnum,
+			Category:    FlagCategoryRequest,
+			Options: []FlagOption{
+				{Value: "auto", Label: "Auto (adaptive)"},
+				{Value: "chat", Label: "Force Chat Completions"},
+				{Value: "responses", Label: "Force Responses API"},
+			},
 		},
 	}
 }

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -69,6 +69,7 @@ func TestRuleFlagRegistry_TypesAreValid(t *testing.T) {
 	allowed := map[FlagValueType]bool{
 		FlagTypeBool:   true,
 		FlagTypeString: true,
+		FlagTypeEnum:   true,
 	}
 	for _, spec := range RuleFlagRegistry() {
 		if !allowed[spec.Type] {
@@ -79,6 +80,32 @@ func TestRuleFlagRegistry_TypesAreValid(t *testing.T) {
 		}
 		if spec.Description == "" {
 			t.Errorf("flag %q has empty description", spec.Key)
+		}
+	}
+}
+
+// TestRuleFlagRegistry_EnumOptions asserts that every FlagTypeEnum spec
+// declares at least two options with non-empty Value and Label.
+func TestRuleFlagRegistry_EnumOptions(t *testing.T) {
+	for _, spec := range RuleFlagRegistry() {
+		if spec.Type != FlagTypeEnum {
+			continue
+		}
+		if len(spec.Options) < 2 {
+			t.Errorf("enum flag %q has %d options, expected at least 2", spec.Key, len(spec.Options))
+		}
+		seen := map[string]bool{}
+		for i, opt := range spec.Options {
+			if opt.Value == "" {
+				t.Errorf("enum flag %q option %d has empty Value", spec.Key, i)
+			}
+			if opt.Label == "" {
+				t.Errorf("enum flag %q option %d has empty Label", spec.Key, i)
+			}
+			if seen[opt.Value] {
+				t.Errorf("enum flag %q has duplicate option Value %q", spec.Key, opt.Value)
+			}
+			seen[opt.Value] = true
 		}
 	}
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -179,6 +179,13 @@ type RuleFlags struct {
 	// UseMaxTokens rewrites the `max_completion_tokens` request field back to the legacy
 	// `max_tokens` field. Use this for providers or models that reject `max_completion_tokens`.
 	UseMaxTokens bool `json:"use_max_tokens,omitempty" yaml:"use_max_tokens,omitempty"`
+
+	// OpenAIEndpointOverride forces the OpenAI endpoint selection (chat or
+	// responses), overriding the capability-aware adaptive router. Empty or
+	// "auto" preserves adaptive behavior. OpenAI providers only; Anthropic
+	// and Google providers ignore this. On Codex OAuth providers, "chat"
+	// is silently ignored (Codex has no Chat endpoint) and a warning is logged.
+	OpenAIEndpointOverride string `json:"openai_endpoint_override,omitempty" yaml:"openai_endpoint_override,omitempty"`
 }
 
 // ProfileMeta stores metadata for a scenario profile.


### PR DESCRIPTION
## Summary
Adds a new `openai_endpoint_override` rule flag that lets a rule force OpenAI requests to either Chat Completions or Responses, bypassing the adaptive router's capability probe. Also introduces enum-type flag support to the flag registry / UI, and collapses `SelectOpenAIEndpoint`'s grown-too-long parameter list into a single options struct.

## Key Changes

### Backend
- **`OpenAIEndpointOptions` refactor** (`internal/server/adaptive_endpoint_router.go`):
  - `SelectOpenAIEndpoint` signature collapsed from 7 positional params to `(ctx, provider, modelID, opts OpenAIEndpointOptions)`. Provider + model stay direct since they identify the target; everything else (incoming, streaming, override, downgrade constraint) lives on the struct.
  - `opts.RequireResponses bool` replaces the old `responsesReq *protocol.ResponseCreateRequest` parameter. The downgrade-safety check (`CanDowngradeResponsesToChat`) is now performed by `ResponsesCreate` — the only caller that has the request — and the boolean is passed in. The router no longer depends on `*protocol.ResponseCreateRequest` and has no nil-pointer branch.
  - When `RequireResponses` is set and Responses is unusable, the router returns a generic 400; the specific blocking field stays known to the caller.

- **Endpoint override logic** (`internal/server/endpoint_override.go`):
  - `EndpointOverride` type with three values: `auto` (default), `chat`, `responses`
  - `ParseEndpointOverride()` for safe coercion of rule-flag strings (empty / unknown → `OverrideAuto`)
  - `logCodexChatOverrideIgnored()` warns when "chat" is set on a Codex provider

- **Flag registry — enum support** (`internal/typ/flag_registry.go`):
  - New `FlagTypeEnum` value type, `FlagOption{Value, Label}` struct, and `Options []FlagOption` field on `FlagSpec`
  - Registered `openai_endpoint_override` with three options
  - Test `TestRuleFlagRegistry_EnumOptions` enforces: ≥ 2 options, non-empty values/labels, no duplicates

- **Type definitions** (`internal/typ/type.go`):
  - Added `OpenAIEndpointOverride string` field to `RuleFlags`

- **Tests** (`internal/server/endpoint_override_test.go`):
  - `TestParseEndpointOverride` covers empty / auto / chat / responses / unknown / uppercase
  - `TestIsCodexProvider` covers nil, non-OAuth, Codex-issuer cases

### Frontend
- **Catalog dialog** (`frontend/src/components/rule-card/FlagCatalogDialog.tsx`): MUI `Select` rendering for enum-type flags
- **Flag utilities** (`frontend/src/components/rule-card/utils.ts`): `ENUM_FLAG_VALUES` validation map, `isEnumActive()` helper treating "auto" / empty as inactive default, updated `parseRuleFlags` / `formatRuleFlags` / `countActiveFlags`
- **Extensions card** (`frontend/src/components/rule-card/RuleExtensionsCard.tsx`): enum chips render via option label
- **Type definitions** (`frontend/src/components/RoutingGraphTypes.ts`): `FlagValueType = 'enum'`, `FlagOption` interface, `options` on `FlagSpec`, `openaiEndpointOverride` on `RuleFlags` / `RuleFlagsApi`
- **Auto-save** (`frontend/src/components/rule-card/useRuleCardHooks.ts`): `openaiEndpointOverride` plumbed into the serialized payload

### Docs
- `.design/adaptive-endpoint-routing.md`: signature block + decision tree updated; added a section describing the rule-level override
- `.design/rule-flags.md`: `FlagSpec` snippet adds `enum` / `Options`; section 4 table adds the new flag; section 5 grows from "四种" to "五种" with a new **Type 4 — Routing-decision input** category for flags consumed at routing-decision time (before any transform chain)

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/server/ ./internal/typ/`
- [x] `npx tsc --noEmit` (no errors in touched frontend files; pre-existing errors elsewhere are unrelated)
- [ ] Manual: set `openai_endpoint_override=chat` on a rule whose model probe prefers Responses → confirm outbound hits `/v1/chat/completions`
- [ ] Manual: set `openai_endpoint_override=responses` → confirm outbound hits `/v1/responses`
- [ ] Manual: set `openai_endpoint_override=chat` on a Codex rule → confirm still routes to Responses and a warning appears in logs
- [ ] Manual: toggle the catalog Select between Auto / Chat / Responses → confirm Extensions Card chip only appears for non-auto

https://claude.ai/code/session_01Pp95V8QTajqKuKpnTUgtFk