### PR TITLE
feat(server): Implement mid-request failover for priority routing

### DIFF
--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -1,57 +1,36 @@
 # Priority-Based Service Routing
 
-Status: shipped (v1) on branch `claude/priority-service-routing-dIQfX`.
-Tracking commits: `a362ca3`, `5221109`.
+Status: shipped (v1) on branch `claude/priority-service-routing-dIQfX`. Tracking commits: `a362ca3`, `5221109`.
 
 ## Why
 
-Existing routing in tingly-box treats every service in a rule as an equal
-peer. `random`, `token_based`, `latency_based`, `speed_based`, `adaptive`,
-`capacity_based` — all of them spread load across services. That is the
-right default for "I have several equivalent providers, share the load".
+Existing routing in tingly-box treats every service in a rule as an equal peer. `random`, `token_based`, `latency_based`, `speed_based`, `adaptive`, `capacity_based` — all of them spread load across services. That is the right default for "I have several equivalent providers, share the load".
 
 It is the wrong default for the other very common shape:
 
-> "Use account A. If A is broken, use account B. Once A is healthy
-> again, go back to A."
+> "Use account A. If A is broken, use account B. Once A is healthy again, go back to A."
 
-People with two Anthropic accounts (one primary, one as backup), or a
-cheap-and-fast model with an expensive fallback, or any home-rolled
-"direct + fallback" setup, were stuck:
+People with two Anthropic accounts (one primary, one as backup), or a cheap-and-fast model with an expensive fallback, or any home-rolled "direct + fallback" setup, were stuck:
 
-- They could either include the backup in the pool (and have it pick up
-  random traffic), or
+- They could either include the backup in the pool (and have it pick up random traffic), or
 - Mark it inactive and manually flip it on when the primary failed.
 
 Neither is acceptable. We need first-class **direct + fallback**.
 
-A second, related gap: when an upstream service starts failing, nothing
-in the box notices. Every request keeps trying the same broken service
-until the user disables it. We need a lightweight **circuit breaker** so
-the next request automatically uses the backup, and the next-after-next
-returns to the primary once it recovers.
+A second, related gap: when an upstream service starts failing, nothing in the box notices. Every request keeps trying the same broken service until the user disables it. We need a lightweight **circuit breaker** so the next request automatically uses the backup, and the next-after-next returns to the primary once it recovers.
 
 ## What this is not
 
-- **Not** a cross-request load balancer rebalance — existing tactics stay
-  intact and remain the default.
-- **Not** a request-level retry loop. When a request fails mid-flight,
-  the client still sees the error. Failover happens on the **next**
-  request after the breaker trips. (Mid-request retry is parked as v2 —
-  see "Future work".)
-- **Not** a global health system. The breaker is process-local and rule-
-  scoped through the service-id key; we deliberately avoided Redis-level
-  shared state to keep the deployment story simple.
+- **Not** a cross-request load balancer rebalance — existing tactics stay intact and remain the default.
+- **Not** a request-level retry loop. When a request fails mid-flight, the client still sees the error. Failover happens on the **next** request after the breaker trips. (Mid-request retry is parked as v2 — see "Future work".)
+- **Not** a global health system. The breaker is process-local and rule- scoped through the service-id key; we deliberately avoided Redis-level shared state to keep the deployment story simple.
 
 ## How
 
 ### Two new concepts
 
-1. **`Service.Priority int`** — a per-service number inside a rule.
-   Higher = tried first. `0` is "unset" and sinks to the bottom.
-2. **`TacticPriority`** — a new `Tactic` value. When selected, the rule
-   ranks services by `Priority` and picks the highest tier whose circuit
-   breaker is closed.
+1. **`Service.Priority int`** — a per-service number inside a rule. Higher = tried first. `0` is "unset" and sinks to the bottom.
+2. **`TacticPriority`** — a new `Tactic` value. When selected, the rule ranks services by `Priority` and picks the highest tier whose circuit breaker is closed.
 
 ### Selection algorithm
 
@@ -70,38 +49,23 @@ SelectService(rule):
 
 Three properties fall out:
 
-- **Distinct priorities ⇒ pure failover.** Service at priority 10 is
-  used until it fails; service at priority 5 takes over; once the 10's
-  breaker closes, the next request snaps back to it.
-- **Tied priorities ⇒ load sharing within a tier.** Two services at
-  priority 10 share traffic via the sub-tactic (random by default).
-- **All tiers tripped ⇒ degrade, don't disappear.** Picking nothing
-  would let the caller bypass the real upstream error message; picking
-  the top tier guarantees the client sees the actual provider's 5xx /
-  rate-limit text.
+- **Distinct priorities ⇒ pure failover.** Service at priority 10 is used until it fails; service at priority 5 takes over; once the 10's breaker closes, the next request snaps back to it.
+- **Tied priorities ⇒ load sharing within a tier.** Two services at priority 10 share traffic via the sub-tactic (random by default).
+- **All tiers tripped ⇒ degrade, don't disappear.** Picking nothing would let the caller bypass the real upstream error message; picking the top tier guarantees the client sees the actual provider's 5xx / rate-limit text.
 
 ### Recovery
 
 The breaker is a three-state machine (`Closed → Open → HalfOpen`):
 
 - **Closed** — normal. `Allow()` returns true, failures are counted.
-- **Open** — too many consecutive failures (`FailureThreshold`, default
-  3). `Allow()` returns false. After `OpenDuration` (default 30 s) the
-  next `Allow()` call lazily flips to HalfOpen.
-- **HalfOpen** — exactly one probe is permitted. Success → Closed,
-  failure → Open with a fresh timer.
+- **Open** — too many consecutive failures (`FailureThreshold`, default 3). `Allow()` returns false. After `OpenDuration` (default 30 s) the next `Allow()` call lazily flips to HalfOpen.
+- **HalfOpen** — exactly one probe is permitted. Success → Closed, failure → Open with a fresh timer.
 
-Recovery requires **no separate scheduler**. Selection re-evaluates the
-priority list every request, and the breaker's lazy state transition
-admits one probe naturally. Active probing was considered and rejected
-for v1 — for hot rules it's redundant, and for cold rules there is no
-one to serve anyway.
+Recovery requires **no separate scheduler**. Selection re-evaluates the priority list every request, and the breaker's lazy state transition admits one probe naturally. Active probing was considered and rejected for v1 — for hot rules it's redundant, and for cold rules there is no one to serve anyway.
 
 ### End-to-end flow: how the tactic switch actually takes effect
 
-The "user clicks a number on a service node" event has to cross five
-layers before it changes how the next API request is routed. Each layer
-is wired explicitly:
+The "user clicks a number on a service node" event has to cross five layers before it changes how the next API request is routed. Each layer is wired explicitly:
 
 ```
 ┌─ Frontend ───────────────────────────────────────────────────────────┐
@@ -162,37 +126,25 @@ is wired explicitly:
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
-The single transformation point that turns the JSON payload into live
-runtime behaviour is `Tactic.Instantiate()` at
-`internal/server/load_balancer.go:92`. Every dispatch path — Anthropic
-v1/Beta, OpenAI Chat/Responses/Embeddings/Images, Google, smart routing
-matches — funnels through `LoadBalancer.SelectService`, so the tactic
-switch is enforced uniformly with no per-protocol changes required.
+The single transformation point that turns the JSON payload into live runtime behaviour is `Tactic.Instantiate()` at `internal/server/load_balancer.go:92`. Every dispatch path — Anthropic v1/Beta, OpenAI Chat/Responses/Embeddings/Images, Google, smart routing matches — funnels through `LoadBalancer.SelectService`, so the tactic switch is enforced uniformly with no per-protocol changes required.
 
-This is pinned down by `TestPriorityRouting_EndToEnd` in
-`internal/server/priority_routing_e2e_test.go`, which:
+This is pinned down by `TestPriorityRouting_EndToEnd` in `internal/server/priority_routing_e2e_test.go`, which:
 
 1. Unmarshals a Rule JSON with `lb_tactic.type = "priority"`,
 2. Asserts `LBTactic.Params` is a `*PriorityParams` after decode,
-3. Calls `LoadBalancer.SelectService` and asserts the high-priority
-   service is picked,
-4. Trips the breaker via `DefaultBreakerStore.RecordFailure` exactly
-   as the recorder does,
+3. Calls `LoadBalancer.SelectService` and asserts the high-priority service is picked,
+4. Trips the breaker via `DefaultBreakerStore.RecordFailure` exactly as the recorder does,
 5. Asserts the next pick falls back,
 6. Records a success and asserts the pick returns to the primary.
 
 ### Wiring failures to the breaker
 
-`ProtocolRecorder` already sees every success and failure of every
-upstream call. We added two lines:
+`ProtocolRecorder` already sees every success and failure of every upstream call. We added two lines:
 
 - `RecordResponse(provider, model)` → `RecordServiceSuccess(serviceID)`
 - `RecordError(err)` → `RecordServiceFailure(serviceID)`
 
-The `serviceID` is computed from `provider.UUID + ":" + model`, matching
-the format `Service.ServiceID()` produces, so the breaker registry's
-keys line up exactly with the selection pool. **Zero changes** to the
-dispatch hot path were required.
+The `serviceID` is computed from `provider.UUID + ":" + model`, matching the format `Service.ServiceID()` produces, so the breaker registry's keys line up exactly with the selection pool. **Zero changes** to the dispatch hot path were required.
 
 ### Frontend UX
 
@@ -200,20 +152,12 @@ A clickable badge on the top-left corner of each provider node:
 
 - Shows the current priority (`1`, `2`, …, `–` when unset).
 - Click → small popover with a number input. Setting `0` clears.
-- The badge is sized to overlap the corner, matching the existing
-  badge convention used elsewhere (e.g. SmartOpNode index badges).
+- The badge is sized to overlap the corner, matching the existing badge convention used elsewhere (e.g. SmartOpNode index badges).
 - The provider list re-sorts descending by priority as the user edits.
 
-The design choice here is **implicit mode activation**: assigning any
-service a priority > 0 flips the rule's `lb_tactic` to `priority` on
-save. No separate tactic-selector UI is exposed. Clearing every priority
-back to 0 leaves the previous tactic intact (the auto-save now
-round-trips `lb_tactic`, which it didn't before).
+The design choice here is **implicit mode activation**: assigning any service a priority > 0 flips the rule's `lb_tactic` to `priority` on save. No separate tactic-selector UI is exposed. Clearing every priority back to 0 leaves the previous tactic intact (the auto-save now round-trips `lb_tactic`, which it didn't before).
 
-Why implicit: tactic concepts are jargon for most users. "Set priorities
-on services" is concrete and matches a real intent ("I want this one
-first"). The tactic switch is plumbing — it shouldn't be a separate
-question.
+Why implicit: tactic concepts are jargon for most users. "Set priorities on services" is concrete and matches a real intent ("I want this one first"). The tactic switch is plumbing — it shouldn't be a separate question.
 
 ## Value
 
@@ -224,13 +168,11 @@ question.
 | Operators of any production rule | Free circuit breaking. Even users on the existing tactics get failure isolation as soon as they assign a single priority. |
 | Anyone debugging | The recorder now reports per-service success/failure into the breaker, and the breaker state is exposed via `BreakerStore.Snapshot()` for future surfacing. |
 
-The feature is **additive**: rules without explicit priorities behave
-exactly as before; the new tactic is opt-in via the UI.
+The feature is **additive**: rules without explicit priorities behave exactly as before; the new tactic is opt-in via the UI.
 
 ## Comparison to claude-code-hub
 
-A separate project (`ding113/claude-code-hub`) ships similar capability;
-we deliberately did **not** clone its design.
+A separate project (`ding113/claude-code-hub`) ships similar capability; we deliberately did **not** clone its design.
 
 | Their design | Ours | Why we differ |
 |---|---|---|
@@ -239,51 +181,70 @@ we deliberately did **not** clone its design.
 | Per-user-group priority overrides. | Not implemented. | Users already express user-group-specific routing by having separate rules. Adding overrides would duplicate that mechanism. |
 | Redis-shared breaker state. | In-memory, process-local. | Single-instance is the dominant deployment shape. Redis can be added later with no model changes — `BreakerStore` is an interface boundary. |
 | Active probing scheduler for half-open. | Lazy half-open on next request. | Strictly simpler. Hot rules don't need it; cold rules don't matter. |
-| Mid-stream retry across providers using deferred finalization. | Not implemented in v1. | Touches every dispatch path; v2. |
+| Mid-stream retry across providers using deferred finalization. | Not implemented. | Pre-stream retry landed in v2 via the buffering wrapper (see "Mid-request failover" below). Mid-stream stays parked as v3. |
 | 32 KiB "fake 200" body sniffing. | Not implemented. | Niche; revisit if we see real cases. |
 | Dispatch simulator UI. | Not implemented. | Excellent idea, separable feature, v2. |
 
+## Mid-request failover (v2 — landed)
+
+Status: shipped in the follow-up branch `claude/priority-routing-retry-followup`.
+
+v1 only handled cross-request failover: a request that failed returned the error to the client, and the *next* request used the fallback. v2 fixes that for the common pre-stream-failure case so the same request falls over silently.
+
+**Where the wiring lives:** `internal/server/failover_dispatch.go`.
+
+**How it works** — a layered hand-off, not a smart shim. Each layer owns one concern so a bug in one can't corrupt the whole pipeline:
+
+1. **Producer** (the dispatch handler) writes its response — body or error — normally, exactly as it does without failover. The hot path still writes errors directly to `gin.ResponseWriter` (`SendErrorResponse`, `stream.SendForwardingError`, …) across 20+ call sites; none of them are aware of failover.
+2. **`firstChunkGate`** is a passive, protocol-agnostic byte buffer wrapping `c.Writer`. It makes no decisions in its write path: writes land in memory until an explicit signal commits them. Crucially, **single-service requests skip the gate entirely** (`len(GetActiveServices()) <= 1`), so the common case never touches the buffer — zero blast radius.
+3. **Orchestrator** (`dispatchWithPriorityFailover`) owns the retry decision. After each attempt it reads the gate's state:
+   - `gate.Committed()` → the stream's first real chunk already reached the wire; retry is impossible, return.
+   - else `gate.Status()` retryable (429, 500, 502, 503, 504) → `gate.Discard()`, pick the next priority tier via `selectFallbackService`, try again.
+   - else (200, other 4xx, status 0) → terminal; the deferred `gate.CommitIfBuffered()` flushes the captured error to the client.
+4. **Commit seam.** Streaming producers raise `CommitFirstChunk` on their first real chunk (centralised in `ProcessStream`/`StreamLoop`, plus the explicit `message_start` senders), which flushes captured headers + body and switches the gate to pass-through — preserving incremental delivery.
+5. Budget caps at the number of active services so we never loop unbounded. The same service is never tried twice in one request (in-request `tried` map, complementary to the cross-request breaker). The recorder's bound provider is re-set before each attempt (`SetActiveService`), so a second-attempt failure trips the *second* service's breaker — not the first's.
+
+### Streaming: priming the first event
+
+A vanilla retry can't catch streaming pre-content failures because the OpenAI and Anthropic SDKs construct streams lazily — `wrapper.ResponsesNewStreaming(...)` returns a `*Stream` without issuing the HTTP request, so a 503 from the upstream only surfaces inside the first `stream.Next()` call. By that time the handler has already written SSE headers (`Content-Type: text/event-stream`, status 200) to the response.
+
+Two pieces work together to make streaming retryable without losing incremental delivery once the stream is actually flowing:
+
+1. **`ResponsesStreamIter` + `PrimeResponsesStream`** (`internal/protocol/stream/prime.go`). Right after the forwarder returns, dispatch calls `PrimeResponsesStream` which performs one `Next()` to force the lazy HTTP request and surface the upstream's real verdict. On failure the caller writes a regular 500 response (which the `firstChunkGate` captures and the orchestrator retries). On success the read event is wrapped in a `firstEventReplayStream` that replays it on the first iteration and then delegates to the SDK stream, so handlers keep their existing per-event loop unchanged. (This is unrelated to the circuit-breaker probe and to `client.ProbeResponsesStream`, which issues a separate synthetic health-check request — priming sends nothing extra, it just pulls the real stream's first event.)
+2. **The commit seam.** `firstChunkGate` buffers everything until the producer signals its first real chunk via `CommitFirstChunk`, at which point captured headers + buffered body flush to the wire and subsequent writes pass straight through. For a prime-success streaming request the handler's `message_start` (or first `ProcessStream`/`StreamLoop` event) raises that signal, so the client sees output immediately. Once committed, retry is no longer possible — but by then we know the upstream has committed to delivering content.
+
+**Scope constraints:**
+
+- **First-chunk only.** Priming catches errors before any byte leaves the process. Once the first content event has been forwarded to the client, mid-stream failures still surface as SSE error events and cannot trigger failover — that would require buffering full responses or a more invasive stream reassembly pattern.
+- **Pre-content failures are retryable on every streaming path.** Two mechanisms, applied uniformly: (1) the OpenAI Responses path uses `PrimeResponsesStream`, which forces the first `Next()` out-of-band and returns the error before the handler runs; (2) every other converter detects it in-line. Two pieces make the in-line route work: the stream loops (`StreamLoop` and `ProcessStream`) no longer flush when a step produced nothing — gin's `Flush()` calls `WriteHeaderNow()` and would otherwise lock in a 200 — and each converter emits a retryable 5xx via `SendStreamingError` when the stream errors with nothing written yet (`!c.Writer.Written()`, or `!messageStarted`). The `ProcessStream`-based passthroughs additionally had a `nextFunc` that checked `stream.Err()` *before* `Next()`, reporting a first-`Next()` error as a clean end; they now propagate the error after `Next()`. Either route lands a retryable status in the `firstChunkGate` without committing a 200 first. Once content is flowing, mid-stream failures still surface as SSE error events (no retry — see "First-chunk only").
+- **Same API style only.** `selectFallbackService` filters out candidates whose `Provider.APIStyle` differs from the original. The transformed request body in `reqCtx` was built for the original provider's protocol; switching styles mid-request would feed a mismatched payload to the next upstream. Heterogeneous fallback (e.g. OpenAI → Anthropic within one rule) would need re-running the transform chain and is deferred.
+- **Wired into:** `AnthropicMessagesV1Beta`, `AnthropicMessagesV1`, the OpenAI Chat handler, and the OpenAI Responses handler. Google and embeddings/images use a different code shape and can be added incrementally if real demand surfaces.
+
+**What the user sees:** if the primary service hits a 429 or 5xx on this exact request, the request quietly switches to the next priority tier and the client gets the successful response — no error returned, no client-side retry needed. If every tier fails, the last upstream's error reaches the client untouched so the message is honest.
+
 ## Future work
 
-1. **Mid-request failover (v2)** — wrap `forwarding.Forward*` returns
-   with a "try next priority tier" loop, gated on error class:
-   - retryable: ECONNREFUSED, ETIMEDOUT, 429, 5xx
-   - not retryable: 4xx (non-429), content-filter, client disconnect
-2. **Streaming pre-first-delta failover (v3)** — detect that the
-   upstream stream has not yet emitted a real content event, and on
-   disconnect rewire to the next tier without writing anything to the
-   client.
-3. **Active half-open probing** — opt-in goroutine that probes Open
-   breakers on a cadence, useful for cold rules.
-4. **Per-rule breaker thresholds** — currently process-wide defaults.
-   Could be surfaced as a Rule-level config block.
-5. **Failover decision log + UI** — the recorder already sees every
-   success/failure attribution; we can surface "request X went to
-   service A → fell back to B" in the system log page.
-6. **Dispatch simulator** — read-only "explain plan" that shows which
-   service a hypothetical request would land on. Particularly useful
-   in combination with smart routing.
+1. **Mid-stream failover (v3)** — pre-content retry is in place on every streaming path; the remaining gap is reconnecting to the next tier after content has already started flowing. Needs response reassembly or protocol-aware "rewind" semantics; out of scope until users actually hit it.
+2. **Heterogeneous fallback** — re-run the transform chain when the fallback provider has a different API style. Lifts the "same-style only" v2 constraint. (Related: the current fallback swaps provider only and reuses the original transformed body + model, so mixing different models across priority tiers in one rule isn't supported yet.)
+3. **Active half-open probing** — opt-in goroutine that probes Open breakers on a cadence, useful for cold rules.
+4. **Per-rule breaker thresholds** — currently process-wide defaults. Could be surfaced as a Rule-level config block.
+5. **Failover decision log + UI** — the recorder already sees every success/failure attribution; surface "request X went to service A → fell back to B" in the system log page.
+6. **Dispatch simulator** — read-only "explain plan" that shows which service a hypothetical request would land on. Particularly useful in combination with smart routing.
 
 ## File map
 
 Backend
-- `internal/loadbalance/load_balancing.go` — `Service.Priority`,
-  `TacticPriority` enum.
+- `internal/loadbalance/load_balancing.go` — `Service.Priority`, `TacticPriority` enum.
 - `internal/loadbalance/breaker.go` — three-state breaker + store.
 - `internal/loadbalance/breaker_test.go`
-- `internal/typ/tactics.go` — `PriorityParams`, `PriorityTactic`,
-  `groupServicesByPriority`.
+- `internal/typ/tactics.go` — `PriorityParams`, `PriorityTactic`, `groupServicesByPriority`.
 - `internal/typ/priority_tactic_test.go`
 - `internal/server/protocol_recording.go` — recorder → breaker bridge.
 
 Frontend
 - `frontend/src/components/RoutingGraphTypes.ts` — `ConfigProvider.priority`, `ConfigRecord.lbTactic`.
-- `frontend/src/components/rule-card/utils.ts` — `pickLbTactic`,
-  `hasPriorityAssigned`.
-- `frontend/src/components/rule-card/useRuleCardHooks.ts` — autosave
-  round-trips `lb_tactic` and `priority`.
+- `frontend/src/components/rule-card/utils.ts` — `pickLbTactic`, `hasPriorityAssigned`.
+- `frontend/src/components/rule-card/useRuleCardHooks.ts` — autosave round-trips `lb_tactic` and `priority`.
 - `frontend/src/components/RuleCard.tsx` — `handleProviderPriorityChange`.
-- `frontend/src/components/RoutingGraph.tsx` — priority-sorted list,
-  prop plumbing.
-- `frontend/src/components/nodes/ProviderNode.tsx` — `PriorityBadge`
-  component overlapping the top-left corner.
+- `frontend/src/components/RoutingGraph.tsx` — priority-sorted list, prop plumbing.
+- `frontend/src/components/nodes/ProviderNode.tsx` — `PriorityBadge` component overlapping the top-left corner.

--- a/.design/priority-routing.pencil.md
+++ b/.design/priority-routing.pencil.md
@@ -1,0 +1,370 @@
+# Priority Routing — Pencil Graph
+
+Visual companion to `priority-routing.md`. Shows the runtime flow of priority service routing and its two complementary failover levels: **cross-request** (priority tactic + circuit breaker) and **in-request** (the passive `firstChunkGate` + stream priming). The in-request path is a **layered hand-off**: the producer emits chunks normally, a passive gate buffers them, and the orchestrator owns the retry decision.
+
+Contents:
+
+- Two complementary failover levels (map)
+- Cross-request — PriorityTactic bucket walk
+- Cross-request — circuit breaker state machine
+- Cross-request — recorder → breaker feedback loop
+- In-request — three layers
+- In-request — dispatchWithPriorityFailover flow
+- In-request — stream priming (`firstEventReplayStream`)
+- In-request — per-attempt timelines (two scenarios)
+- firstChunkGate state machine
+- Commit-seam coverage map
+- selectFallbackService filter pipeline
+- Key invariants
+
+## Two complementary failover levels
+
+```
+                     one logical "use A, else B" rule
+                                  │
+        ┌─────────────────────────┴──────────────────────────┐
+        ▼                                                     ▼
+CROSS-REQUEST  (between requests)                IN-REQUEST  (within one request)
+PriorityTactic + circuit breaker                firstChunkGate + stream priming
+        │                                                     │
+  request N hits broken A                          request N's attempt on A
+  → recorder trips A's breaker                     fails pre-stream (429/5xx)
+        │                                                     │
+  request N+1 selection skips A,                   → gate discards buffer,
+  picks B (next tier)                                orchestrator retries B
+        │                                              in the SAME request
+  A's breaker half-opens after 30s                          │
+  → request N+k probes A, snaps back               client sees B's success;
+                                                    no error, no client retry
+        │                                                     │
+        └── feedback: recorder.RecordResponse/RecordError ────┘
+                 writes the breaker the next request reads
+```
+
+## Cross-request — PriorityTactic bucket walk
+
+`PriorityTactic.SelectService` (`internal/typ/tactics.go`) runs once per request inside `LoadBalancer.SelectService`. It groups the rule's active services into priority tiers and walks them highest-first, taking the first tier with a breaker-permitted service.
+
+```
+active = rule.GetActiveServices()
+       │
+       ▼
+groupServicesByPriority(active)        ← descending; Priority 0 (unset) sinks last
+       │
+   buckets: [ {prio 10: A,A'}, {prio 5: B}, {prio 0: C} ]
+       │
+       ├─ tier prio=10 ─ store.Allow(A)? store.Allow(A')?
+       │       │
+       │       ├─ ≥1 allowed → pickWithinTier(allowed) ──► RETURN
+       │       │     (1 svc → that svc; N svc → WithinTierTactic, default random)
+       │       │
+       │       └─ none allowed (all breakers Open) → next tier
+       │
+       ├─ tier prio=5  ─ store.Allow(B)?
+       │       └─ allowed → pickWithinTier ──► RETURN
+       │
+       ├─ tier prio=0  ─ store.Allow(C)?
+       │       └─ allowed → pickWithinTier ──► RETURN
+       │
+       └─ EVERY tier tripped
+              └─ pickWithinTier(fallback = first/highest bucket) ──► RETURN
+                   (degrade, don't disappear: surface the real upstream 5xx
+                    instead of rejecting locally)
+```
+
+## Cross-request — circuit breaker state machine
+
+Per-service three-state breaker (`internal/loadbalance/breaker.go`), keyed by `serviceID = provider.UUID + ":" + model`. No scheduler — the Open→HalfOpen flip is lazy, evaluated on the next `Allow()`.
+
+```
+                         RecordSuccess()
+            ┌──────────────────────────────────────────┐
+            │                                           │
+            ▼                                           │
+   ┌─────────────────┐  consecFails ≥ FailureThreshold  │
+   │     CLOSED      │  (default 3)                     │
+   │ Allow() = true  │ ───────────────────────────────►│
+   │ count failures  │                                  ▼
+   └─────────────────┘                        ┌──────────────────┐
+            ▲                                  │      OPEN        │
+            │ RecordSuccess()                  │ Allow() = false  │
+            │ (probe ok)                       │ openedAt = now   │
+            │                                  └────────┬─────────┘
+   ┌─────────────────┐                                  │
+   │    HALF-OPEN    │  time.Since(openedAt) ≥           │
+   │ Allow():        │  OpenDuration (default 30s)      │
+   │  1st caller=true│ ◄────────────────────────────────┘
+   │  others = false │      (lazy flip on next Allow())
+   └────────┬────────┘
+            │ RecordFailure()  → back to OPEN, openedAt reset, probe slot freed
+            └────────────────────────────────────────────────────────┘
+
+State() applies the same lazy Open→HalfOpen flip for read-consistent
+introspection (BreakerStore.Snapshot() for future UI surfacing).
+```
+
+## Cross-request — recorder → breaker feedback loop
+
+The dispatch hot path needs **zero** changes: `ProtocolRecorder` already observes every outcome, and two lines bridge it to the breaker store the selection logic reads.
+
+```
+   request N                                   request N+1 selection
+       │                                              ▲
+       ▼                                              │
+  dispatch attempt on serviceID                       │
+       │                                              │
+       ├─ success → recorder.RecordResponse           │
+       │              └─ RecordServiceSuccess(id) ──┐  │
+       │                                            ▼  │
+       └─ failure → recorder.RecordError            DefaultBreakerStore
+                      └─ RecordServiceFailure(id) ─►  (same keys: UUID:model)
+                                                     │
+                                                     └─ store.Allow(id) consulted
+                                                        by PriorityTactic above
+   In-request failover re-binds the recorder per attempt
+   (rec.SetActiveService) so a 2nd-attempt failure trips the
+   SECOND service's breaker, not the first's.
+```
+
+## In-request — three layers
+
+```
+┌── Producer (protocol handler) ─────────────────────────────────────┐
+│   emits SSE chunks / writes responses normally, unaware of failover │
+│   on its FIRST real chunk → CommitFirstChunk(c)  (one signal)       │
+└─────────────────────────────────────────────────────────────────────┘
+                 │ writes through c.Writer
+                 ▼
+┌── firstChunkGate (passive byte buffer) ────────────────────────────┐
+│   protocol-agnostic; NO decisions in Write/WriteHeader             │
+│   records bytes until CommitFirstChunk / CommitIfBuffered          │
+└─────────────────────────────────────────────────────────────────────┘
+                 │ committed / status read back
+                 ▼
+┌── Orchestrator (dispatchWithPriorityFailover) ─────────────────────┐
+│   owns retry: committed→done, retryable status→Discard+next tier   │
+│   installs the gate ONLY when len(activeServices) > 1              │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## In-request — dispatchWithPriorityFailover flow
+
+```
+Request arrives at handler (e.g. AnthropicMessagesV1Beta)
+│
+├─ transform request body (once, before loop)
+│
+└─ dispatchWithPriorityFailover(rule, initialProvider, attempt)
+       │
+       ├─ len(activeServices) ≤ 1 ? ──YES──► attempt(...) directly, return
+       │       (common case never touches the buffer — zero blast radius)
+       │
+       ├─ wrap c.Writer in firstChunkGate  ◄──────────────────────────────┐
+       │                                                                   │
+       ├─ for i = 0..len(activeServices)-1:                               │
+       │       │                                                           │
+       │       ├─ mark tried[serviceID]                                   │
+       │       ├─ rec.SetActiveService(provider, model)  ← rebind         │
+       │       │                                                           │
+       │       └─ attempt(provider, model)  ← runs dispatchChainResult    │
+       │              │                                                    │
+       │              ├── streaming path ───────────────────────────────► │
+       │              │      ForwardOpenAIResponsesStream()                │
+       │              │         │                                          │
+       │              │         ├─ err ≠ nil → handlePreStreamFailure     │
+       │              │         │     (status 500 buffered in gate)        │
+       │              │         │                                          │
+       │              │         └─ err = nil → PrimeResponsesStream()     │
+       │              │               │                                    │
+       │              │               ├─ stream.Next() fails              │
+       │              │               │   → handlePreStreamFailure (500)  │
+       │              │               │                                    │
+       │              │               ├─ stream.Next() false + no err     │
+       │              │               │   → return bare SDK stream        │
+       │              │               │                                    │
+       │              │               └─ stream.Next() true               │
+       │              │                   → return firstEventReplayStream  │
+       │              │                                                    │
+       │              │      Producer reaches first real chunk            │
+       │              │         └─ CommitFirstChunk(c)                     │
+       │              │               gate.committed = true               │
+       │              │               flush hdr+status+buf → real wire    │
+       │              │               subsequent writes → pass-through     │
+       │              │                                                    │
+       │              │      Commit signal seams (one per producer kind): │
+       │              │        • ProcessStream  (hc-based handlers)        │
+       │              │        • StreamLoop      (raw-c handlers)          │
+       │              │        • responses→anthropic message_start sender  │
+       │              │        • google→anthropic message_start sender     │
+       │              │        • assembly path → NEVER commits (terminal   │
+       │              │              c.JSON, behaves non-streaming)        │
+       │              │                                                    │
+       │              └── non-streaming path                              │
+       │                     ForwardRequest() → resp                      │
+       │                     status buffered in gate                      │
+       │                                                                   │
+       ├─ gate.Committed()? ──YES──► return (first chunk on wire, done)   │
+       │                                                                   │
+       ├─ isRetryableStatus(gate.Status())? ──NO──► return (terminal err) │
+       │                                                                   │
+       ├─ selectFallbackService(tried, sameAPIStyle)                       │
+       │       │                                                           │
+       │       ├─ no candidates → Debugf, return                          │
+       │       ├─ LB error    → Warnf, return                             │
+       │       └─ found next  → Infof, gate.Discard() ───────────────────►│
+       │                          (reset buf, status, headers)             │
+       │                          provider = nextProvider                   │
+       │                          model = nextService.Model                 │
+       │                                                                    │
+       └─ deferred on return: c.Writer = realWriter; gate.CommitIfBuffered()
+              │
+              ├─ committed? → no-op (already on wire)
+              ├─ buf empty + status 0? → no-op
+              └─ else → flush last buffered error to real writer
+```
+
+## In-request — stream priming (`firstEventReplayStream`)
+
+SDK streams are lazy: `ResponsesNewStreaming(...)` returns a `*Stream` without issuing HTTP, so a 503 only surfaces inside the first `Next()`. `PrimeResponsesStream` (`internal/protocol/stream/prime.go`) forces that first `Next()` out-of-band so failover can act before any byte is gated, then replays the read event so the handler's per-event loop is unchanged. (Distinct from the circuit-breaker probe and `client.ProbeResponsesStream`'s synthetic health check — priming sends nothing extra.)
+
+```
+PrimeResponsesStream(sdkStream)
+       │
+       ├─ inner.Next() == false
+       │     ├─ inner.Err() ≠ nil → return (nil, err)   → handlePreStreamFailure (500, retryable)
+       │     └─ inner.Err() == nil → return (bareStream, nil)   (empty stream, nothing to replay)
+       │
+       └─ inner.Next() == true   (first event already pulled & cached)
+             └─ return (&firstEventReplayStream{inner, first: cached}, nil)
+
+firstEventReplayStream replays the cached first event:
+       Next() call #1  → nextCount=1, return true   (inner NOT advanced again)
+       Current() @ #1  → returns the cached first event
+       Next() call #≥2 → delegates inner.Next()
+       Current() @ #≥2 → delegates inner.Current()
+       Err()/Close()   → always delegate to inner
+```
+
+## In-request — per-attempt timelines
+
+Two decisive scenarios, showing Producer ↔ firstChunkGate ↔ Orchestrator over time.
+
+```
+SCENARIO A — pre-stream failure on tier 1, success on tier 2
+────────────────────────────────────────────────────────────
+Orchestrator  Producer (attempt)        firstChunkGate            real wire
+   │ wrap ───────────────────────────────► (buffered)
+   │ attempt(A) ─► forward + prime A
+   │                 prime fails ─► handlePreStreamFailure
+   │                   WriteHeader(500)+body ─► buf=500/body          (nothing)
+   │ ◄─ return
+   │ Committed()? no
+   │ Status()=500 retryable? yes
+   │ selectFallbackService → B
+   │ gate.Discard() ─────────────────────► buf reset, status 0
+   │ attempt(B) ─► forward + prime B
+   │                 prime ok ─► first chunk
+   │                   CommitFirstChunk ──► commit: hdr+200+buf ───► FLUSHED
+   │                   write events ──────► pass-through ──────────► streamed
+   │ ◄─ return
+   │ Committed()? YES → return
+   └ defer CommitIfBuffered() → no-op (already committed)
+
+SCENARIO B — first chunk commits, later mid-stream error (no retry)
+────────────────────────────────────────────────────────────
+   │ attempt(A) ─► prime ok ─► first chunk
+   │                 CommitFirstChunk ────► commit ────────────────► FLUSHED
+   │                 stream events… ───────► pass-through ─────────► streamed
+   │                 upstream dies mid-stream
+   │                 SSE error event ──────► pass-through ─────────► streamed (honest error)
+   │ ◄─ return
+   │ Committed()? YES → return       (retry impossible: bytes already on wire)
+   └ defer CommitIfBuffered() → no-op
+```
+
+## firstChunkGate State Machine
+
+```
+                     ┌────────────────────────────────────────────────────┐
+                     │                  BUFFERED                          │
+                     │  status=0, buf=empty, hdr={}                       │
+                     │                                                     │
+  WriteHeader(code)  │  WriteHeader → status=code                         │
+  Write(bytes)       │  Write       → buf += bytes (status defaults 200)  │
+        ──────────── │  NO status inspection, NO commit decision         │
+                     │  Flush() = no-op   Discard() = reset for retry     │
+                     └───────────┬────────────────────────────────────────┘
+                                 │ CommitFirstChunk()  (producer signal)
+                                 │   — or —
+                                 │ CommitIfBuffered()  (orchestrator defer)
+                                 ▼
+                     ┌────────────────────────────────────────────────────┐
+                     │                 COMMITTED (pass-through)           │
+                     │  committed=true                                    │
+                     │  copy hdr→real, WriteHeader(status|200), flush buf │
+                     │  all future reads/writes go direct to real writer  │
+                     │  Flush() delegates, Discard()/CommitIfBuffered noop │
+                     └────────────────────────────────────────────────────┘
+```
+
+## Commit-seam coverage map
+
+Every streaming producer must raise `CommitFirstChunk` on its first real chunk. Three seams cover the families; two hand-rolled handlers call it directly; the assembly path deliberately never commits.
+
+```
+seam: ProcessStream (internal/protocol/context.go)      ← hc-based handlers
+   ├─ HandleOpenAIChatStream
+   ├─ Anthropic v1 / beta passthroughs
+   ├─ HandleResponsesToOpenAIChatStream
+   └─ generic-MCP stream dispatchers
+
+seam: StreamLoop (internal/protocol/stream/loop.go)     ← raw-c handlers
+   ├─ handleOpenAIToAnthropicStreamResponse (+ WithMCPHooks)
+   ├─ AnthropicToOpenAIStream
+   ├─ HandleOpenAIChatToResponsesStream
+   ├─ HandleOpenAIResponsesStream
+   └─ HandleAnthropicBetaToOpenAIResponsesStream
+
+explicit CommitFirstChunk(c) in message_start senders   ← hand-rolled for…range
+   ├─ HandleResponsesToAnthropicV1Stream      (openai_to_anthropic.go)
+   ├─ HandleResponsesToAnthropicBetaStream    (openai_to_anthropic_beta.go)
+   ├─ HandleGoogleToAnthropicStreamResponse   (google_to_any.go)
+   └─ HandleGoogleToAnthropicBetaStreamResponse
+
+NEVER commits (terminal c.JSON, behaves non-streaming)
+   ├─ HandleResponsesToAnthropicV1Assembly
+   └─ HandleResponsesToAnthropicBetaAssembly
+        ↑ shares handlerResponsesToAnthropicStream with the *Stream variants,
+          so the commit lives in the per-variant message_start sender, NOT
+          in the shared core — otherwise assembly would flush an SSE 200
+          before its single terminal JSON.
+```
+
+## selectFallbackService Filter Pipeline
+
+```
+rule.GetActiveServices()
+       │
+       ├─ exclude tried[svc.ServiceID()]
+       ├─ skip if provider lookup fails
+       ├─ skip if provider.APIStyle ≠ requireAPIStyle   ← same style only
+       │
+       └─ available[] → build tempRule (no affinity carryover)
+              │
+              └─ s.loadBalancer.SelectService(tempRule)
+                     │
+                     ├─ err → (nil,nil,err)  Warnf at call site
+                     ├─ nil → (nil,nil,nil)  Debugf at call site
+                     └─ svc → (provider, svc, nil)  Infof at call site
+```
+
+## Key Invariants
+
+- The gate is **passive**: it makes no protocol or status decisions. The producer signals the first real chunk; the orchestrator decides retry. Each layer owns one concern, so a gate bug cannot pick the wrong tier and an orchestrator bug cannot corrupt bytes.
+- Single-service requests (`len(activeServices) ≤ 1`) bypass the gate entirely — the common case stays on the original `c.Writer`.
+- Transform happens once before the loop — only the provider/model pointer changes on retry; the serialized request body is reused as-is.
+- `APIStyle` is pinned to `initialProvider.APIStyle` — cross-style fallback would require re-transformation and is explicitly out of scope.
+- Once `committed`, the connection is on the wire; `Discard()` and `CommitIfBuffered()` both become no-ops.
+- `Status() == 0` (untouched writer) ⇒ non-retryable — matches a client disconnect / no-write completion.
+- Budget cap = `len(activeServices)` — worst case visits each service once.
+- The assembly path (`HandleResponsesToAnthropic{V1,Beta}Assembly`) never commits mid-stream: it buffers a struct and emits one terminal `c.JSON`, so it flows through the gate like a non-streaming response.

--- a/internal/loadbalance/load_balancing.go
+++ b/internal/loadbalance/load_balancing.go
@@ -22,7 +22,16 @@ type Service struct {
 // ServiceID returns a unique string identifier for the service (provider:model).
 // Deprecated: use GetServiceID() for the typed form.
 func (s *Service) ServiceID() string {
-	return fmt.Sprintf("%s:%s", s.Provider, s.Model)
+	return FormatServiceID(s.Provider, s.Model)
+}
+
+// FormatServiceID formats a (providerUUID, model) pair into the canonical
+// "provider:model" string used as the breaker key and exclusion map key
+// throughout the gateway. Sites that don't have a full *Service in hand
+// (the failover orchestrator, the recorder, usage tracking) call this
+// directly so all paths agree on the same key shape.
+func FormatServiceID(providerUUID, model string) string {
+	return fmt.Sprintf("%s:%s", providerUUID, model)
 }
 
 // GetServiceID returns the typed service identifier.

--- a/internal/protocol_validate/failover.go
+++ b/internal/protocol_validate/failover.go
@@ -1,0 +1,269 @@
+package protocol_validate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// FailoverRoute is the handle returned by SetupFailoverRoute. It carries the
+// gateway-facing model name (use with SendWithModel) and the primary tier's
+// per-request call counter so tests can assert how many attempts hit the
+// failing upstream before falloff to the success tier.
+type FailoverRoute struct {
+	ModelName        string
+	PrimaryCallCount *atomic.Int64
+	primaryServer    *httptest.Server
+}
+
+// Close shuts down the primary fail server.
+func (r *FailoverRoute) Close() {
+	if r.primaryServer != nil {
+		r.primaryServer.Close()
+	}
+}
+
+// SetupFailoverRoute registers a two-tier priority failover rule:
+//   - Primary (priority=10) is a fresh httptest.Server that always responds
+//     with failStatus and a minimal JSON error body. No SSE, no body content
+//     content beyond the JSON error.
+//   - Fallback (priority=5) is env.virtual with successScenario registered.
+//
+// The gateway dispatches under TacticPriority, so the primary is tried first.
+// A retryable failStatus (429/5xx) triggers gate.Discard() + fallback retry.
+//
+// Returns a FailoverRoute with ModelName (pass to SendWithModel) and a counter
+// pointing at the primary handler's atomic call count.
+func (env *TestEnv) SetupFailoverRoute(
+	t *testing.T,
+	source, target protocol.APIType,
+	successScenario Scenario,
+	failStatus int,
+) FailoverRoute {
+	t.Helper()
+
+	env.virtual.RegisterScenario(successScenario.toVirtualServerScenario())
+
+	modelSuffix := successScenario.Name
+	if target == protocol.TypeOpenAIResponses {
+		modelSuffix = successScenario.Name + "-codex"
+	} else if target == protocol.TypeOpenAIChat {
+		modelSuffix = successScenario.Name + "-chat"
+	}
+	providerModel := fmt.Sprintf("virtual-model-%s", modelSuffix)
+	requestModel := fmt.Sprintf("fo-%s-to-%s-%s-%d", source, target, successScenario.Name, failStatus)
+
+	var counter atomic.Int64
+	primaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(failStatus)
+		_, _ = fmt.Fprintf(w, `{"error":{"message":"simulated upstream %d","type":"upstream_error","code":"failover_test"}}`, failStatus)
+	}))
+	t.Cleanup(primaryServer.Close)
+
+	apiStyle := targetToAPIStyle(target)
+
+	primaryUUID := fmt.Sprintf("virtual-primary-%s-%d", successScenario.Name, failStatus)
+	primaryAPIBase := primaryServer.URL
+	if apiStyle == protocol.APIStyleOpenAI {
+		primaryAPIBase = primaryServer.URL + "/v1"
+	}
+	_ = env.appConfig.AddProvider(&typ.Provider{
+		UUID:     primaryUUID,
+		Name:     primaryUUID,
+		APIBase:  primaryAPIBase,
+		APIStyle: apiStyle,
+		Token:    "primary-token",
+		Enabled:  true,
+		Timeout:  int64(constant.DefaultRequestTimeout),
+	})
+
+	fallbackUUID := fmt.Sprintf("virtual-fallback-%s-%d", successScenario.Name, failStatus)
+	fallbackAPIBase := env.virtual.URL()
+	if apiStyle == protocol.APIStyleOpenAI {
+		fallbackAPIBase = env.virtual.URL() + "/v1"
+	}
+	_ = env.appConfig.AddProvider(&typ.Provider{
+		UUID:     fallbackUUID,
+		Name:     fallbackUUID,
+		APIBase:  fallbackAPIBase,
+		APIStyle: apiStyle,
+		Token:    "fallback-token",
+		Enabled:  true,
+		Timeout:  int64(constant.DefaultRequestTimeout),
+	})
+
+	rule := typ.Rule{
+		UUID:          requestModel,
+		Scenario:      sourceToRuleScenario(source),
+		RequestModel:  requestModel,
+		ResponseModel: providerModel,
+		Services: []*loadbalance.Service{
+			{Provider: primaryUUID, Model: providerModel, Weight: 1, Active: true, Priority: 10, TimeWindow: 300},
+			{Provider: fallbackUUID, Model: providerModel, Weight: 1, Active: true, Priority: 5, TimeWindow: 300},
+		},
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticPriority,
+			Params: &typ.PriorityParams{WithinTierTactic: loadbalance.TacticRandom},
+		},
+		Active: true,
+	}
+	_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
+
+	return FailoverRoute{
+		ModelName:        requestModel,
+		PrimaryCallCount: &counter,
+		primaryServer:    primaryServer,
+	}
+}
+
+// CustomFailoverRoute lets a test wire arbitrary http.Handlers as both tiers of
+// a priority rule. Used for mid-stream-failure and all-tiers-fail tests where
+// the canned SetupFailoverRoute behavior doesn't fit.
+type CustomFailoverRoute struct {
+	ModelName        string
+	PrimaryCallCount *atomic.Int64
+	FallbackCallCount *atomic.Int64
+}
+
+// SetupCustomFailoverRoute registers a two-tier priority rule with caller-
+// supplied http.Handlers. Both handlers are wrapped to increment a counter
+// each call. Both servers receive cleanup via t.Cleanup.
+func (env *TestEnv) SetupCustomFailoverRoute(
+	t *testing.T,
+	source, target protocol.APIType,
+	primaryHandler, fallbackHandler http.Handler,
+	scenarioName string,
+) CustomFailoverRoute {
+	t.Helper()
+
+	var primaryCount, fallbackCount atomic.Int64
+
+	primaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryCount.Add(1)
+		primaryHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(primaryServer.Close)
+
+	fallbackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCount.Add(1)
+		fallbackHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(fallbackServer.Close)
+
+	apiStyle := targetToAPIStyle(target)
+	providerModel := fmt.Sprintf("virtual-model-%s", scenarioName)
+	requestModel := fmt.Sprintf("fo-custom-%s-to-%s-%s", source, target, scenarioName)
+
+	primaryAPIBase := primaryServer.URL
+	fallbackAPIBase := fallbackServer.URL
+	if apiStyle == protocol.APIStyleOpenAI {
+		primaryAPIBase = primaryServer.URL + "/v1"
+		fallbackAPIBase = fallbackServer.URL + "/v1"
+	}
+
+	primaryUUID := "virtual-custom-primary-" + scenarioName
+	fallbackUUID := "virtual-custom-fallback-" + scenarioName
+
+	_ = env.appConfig.AddProvider(&typ.Provider{
+		UUID: primaryUUID, Name: primaryUUID, APIBase: primaryAPIBase, APIStyle: apiStyle,
+		Token: "primary-token", Enabled: true, Timeout: int64(constant.DefaultRequestTimeout),
+	})
+	_ = env.appConfig.AddProvider(&typ.Provider{
+		UUID: fallbackUUID, Name: fallbackUUID, APIBase: fallbackAPIBase, APIStyle: apiStyle,
+		Token: "fallback-token", Enabled: true, Timeout: int64(constant.DefaultRequestTimeout),
+	})
+
+	rule := typ.Rule{
+		UUID:          requestModel,
+		Scenario:      sourceToRuleScenario(source),
+		RequestModel:  requestModel,
+		ResponseModel: providerModel,
+		Services: []*loadbalance.Service{
+			{Provider: primaryUUID, Model: providerModel, Weight: 1, Active: true, Priority: 10, TimeWindow: 300},
+			{Provider: fallbackUUID, Model: providerModel, Weight: 1, Active: true, Priority: 5, TimeWindow: 300},
+		},
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticPriority,
+			Params: &typ.PriorityParams{WithinTierTactic: loadbalance.TacticRandom},
+		},
+		Active: true,
+	}
+	_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
+
+	return CustomFailoverRoute{
+		ModelName:         requestModel,
+		PrimaryCallCount:  &primaryCount,
+		FallbackCallCount: &fallbackCount,
+	}
+}
+
+// SendWithModel sends a request using an explicit model name (bypassing the
+// SetupRoute route map). Used for failover tests where the rule's request
+// model doesn't follow SetupRoute's naming convention.
+func (env *TestEnv) SendWithModel(t *testing.T, source protocol.APIType, modelName string, streaming bool) *RoundTripResult {
+	t.Helper()
+
+	path, body := buildRequest(source, modelName, streaming)
+	result := &RoundTripResult{
+		SourceProtocol: source,
+		ScenarioName:   modelName,
+		IsStreaming:    streaming,
+	}
+
+	if streaming {
+		url := env.gatewayServer.URL + path
+		req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+env.modelToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do streaming request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		result.HTTPStatus = resp.StatusCode
+		result.StreamEvents, result.RawBody = sse.ReadSSELines(resp.Body)
+		parsed := assembleFromEvents(result.StreamEvents, sourceToStyle(source))
+		fillFromParsedResult(result, parsed, sourceToStyle(source), true)
+	} else {
+		req, err := http.NewRequest("POST", path, bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+env.modelToken)
+
+		w := httptest.NewRecorder()
+		env.ginEngine.ServeHTTP(w, req)
+		result.HTTPStatus = w.Code
+		result.RawBody = w.Body.Bytes()
+		parsed := parseFromJSON(result.RawBody, sourceToStyle(source))
+		fillFromParsedResult(result, parsed, sourceToStyle(source), false)
+	}
+
+	return result
+}
+
+// failoverJSONBody is a convenience helper for tests that need to peek at the
+// JSON error body returned by the gateway after all tiers fail.
+func failoverJSONBody(b []byte) map[string]interface{} {
+	var m map[string]interface{}
+	_ = json.Unmarshal(b, &m)
+	return m
+}

--- a/internal/protocol_validate/failover_test.go
+++ b/internal/protocol_validate/failover_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+// +build e2e
+
+package protocol_validate_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	pt "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+)
+
+// TestFailover_Nonstream_429_RetriesAndSucceeds verifies the priority routing
+// tactic: primary tier returns 429, dispatch discards the buffered error and
+// retries the fallback tier, client receives a 200 from the fallback.
+func TestFailover_Nonstream_429_RetriesAndSucceeds(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	route := env.SetupFailoverRoute(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, pt.TextScenario(), http.StatusTooManyRequests)
+
+	result := env.SendWithModel(t, protocol.TypeOpenAIChat, route.ModelName, false)
+
+	require.Equal(t, 200, result.HTTPStatus, "fallback must serve a success after primary 429")
+	assert.Equal(t, int64(1), route.PrimaryCallCount.Load(), "primary tier should be hit exactly once")
+	assert.NotEmpty(t, result.Content, "fallback must produce real content")
+}
+
+// TestFailover_Nonstream_500_RetriesAndSucceeds is the symmetric 5xx case;
+// retryableUpstreamStatuses includes 500 so this exercises the same path.
+func TestFailover_Nonstream_500_RetriesAndSucceeds(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	route := env.SetupFailoverRoute(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, pt.TextScenario(), http.StatusInternalServerError)
+
+	result := env.SendWithModel(t, protocol.TypeOpenAIChat, route.ModelName, false)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.Equal(t, int64(1), route.PrimaryCallCount.Load())
+	assert.NotEmpty(t, result.Content)
+}
+
+// TestFailover_Stream_PreContent_429_RetriesAndSucceeds is the streaming
+// counterpart. The primary returns plain JSON with 429 (no SSE), so the gate
+// stays buffered (CommitFirstChunk never fires); the orchestrator sees
+// gate.Status()=429, discards, retries fallback. Fallback's streaming response
+// commits the gate on the first real SSE event and the client receives the
+// stream.
+func TestFailover_Stream_PreContent_429_RetriesAndSucceeds(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	route := env.SetupFailoverRoute(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, pt.StreamingTextScenario(), http.StatusTooManyRequests)
+
+	result := env.SendWithModel(t, protocol.TypeOpenAIChat, route.ModelName, true)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.NotEmpty(t, result.StreamEvents, "fallback must produce an SSE stream")
+	assert.Equal(t, int64(1), route.PrimaryCallCount.Load())
+}
+
+// TestFailover_Stream_PreContent_500_RetriesAndSucceeds — same shape but
+// against a 500. 500 is in retryableUpstreamStatuses specifically because
+// SendStreamingError emits 500 for pre-stream errors.
+func TestFailover_Stream_PreContent_500_RetriesAndSucceeds(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	route := env.SetupFailoverRoute(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, pt.StreamingTextScenario(), http.StatusInternalServerError)
+
+	result := env.SendWithModel(t, protocol.TypeOpenAIChat, route.ModelName, true)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.NotEmpty(t, result.StreamEvents)
+	assert.Equal(t, int64(1), route.PrimaryCallCount.Load())
+}
+
+// TestFailover_AllTiersFail_ClientSeesLastError — both services return 429.
+// After the loop exhausts the candidate pool, the deferred CommitIfBuffered
+// flushes the last buffered error to the wire. The client must see a non-200,
+// not a hung connection or a panic.
+func TestFailover_AllTiersFail_ClientSeesLastError(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	failHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"all tiers down","type":"upstream_error","code":"failover_test"}}`)
+	})
+
+	route := env.SetupCustomFailoverRoute(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, failHandler, failHandler, "all-fail")
+
+	result := env.SendWithModel(t, protocol.TypeOpenAIChat, route.ModelName, false)
+
+	assert.NotEqual(t, 200, result.HTTPStatus, "no tier produced a success — client must not see a 200")
+	assert.Equal(t, int64(1), route.PrimaryCallCount.Load(), "primary attempted once")
+	assert.Equal(t, int64(1), route.FallbackCallCount.Load(), "fallback attempted once")
+}
+
+// TestFailover_MidStream_NoRetry_GateCommitted is the critical safety guarantee:
+// once CommitFirstChunk has flushed the first real chunk to the wire, retry is
+// impossible. The primary sends one valid SSE delta, flushes, then hijacks and
+// closes the TCP connection. The gateway has already passed the first chunk
+// through — gate.Committed() is true. The orchestrator must observe this and
+// NOT retry the fallback.
+func TestFailover_MidStream_NoRetry_GateCommitted(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	midstreamFailHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		_, _ = fmt.Fprint(w,
+			"data: {\"id\":\"chatcmpl-x\",\"object\":\"chat.completion.chunk\","+
+				"\"created\":1,\"model\":\"gpt-4o\","+
+				"\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\n")
+		flusher.Flush()
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	})
+
+	// Fallback handler — should NOT be invoked because the gate committed
+	// on the primary's first chunk.
+	fallbackHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"FALLBACK\",\"choices\":[]}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	})
+
+	route := env.SetupCustomFailoverRoute(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, midstreamFailHandler, fallbackHandler, "mid-stream")
+
+	result := env.SendWithModel(t, protocol.TypeOpenAIChat, route.ModelName, true)
+
+	require.Equal(t, 200, result.HTTPStatus, "first chunk committed → client sees 200")
+	assert.Equal(t, int64(1), route.PrimaryCallCount.Load(), "primary attempted once")
+	assert.Equal(t, int64(0), route.FallbackCallCount.Load(), "fallback MUST NOT be retried after gate commit")
+	assert.NotEmpty(t, result.StreamEvents, "client must have received the committed first chunk")
+}
+
+// TestFailover_SingleService_Bypass — single-service rules bypass the gate
+// entirely (orchestrator's len(activeServices) <= 1 short-circuit). The
+// existing SetupRoute path exercises this — assertion is just that the
+// streaming path still produces a clean SSE 200, proving the bypass didn't
+// regress alongside the gate refactor.
+func TestFailover_SingleService_Bypass(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupRoute(protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, pt.StreamingTextScenario())
+
+	result := env.SendAs(t, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, pt.StreamingTextScenario(), true)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.NotEmpty(t, result.StreamEvents)
+	assert.NotEmpty(t, result.Content)
+}

--- a/internal/protocol_validate/roundtrip_test.go
+++ b/internal/protocol_validate/roundtrip_test.go
@@ -160,6 +160,73 @@ func TestRoundTrip_ErrorPassthrough(t *testing.T) {
 	assert.NotEqual(t, 200, result.HTTPStatus)
 }
 
+// AnthropicBeta → OpenAIResponses is the path where the streaming
+// first-event prime lives (see internal/protocol/stream/prime.go).
+// The happy-path test exercises prime + replay wrapper end-to-end:
+// the gateway forces the upstream's first SSE event, hands a wrapped
+// iterator off to the handler, and the handler converts the rest of
+// the Responses-API events into Anthropic Messages SSE frames.
+func TestRoundTrip_AnthropicBeta_To_OpenAIResponses_Streaming(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupRoute(protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.StreamingTextScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.StreamingTextScenario(), true)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.NotEmpty(t, result.StreamEvents)
+	assert.Contains(t, result.Content, "Paris")
+}
+
+// Pre-stream prime failure: ErrorScenario's streaming branch returns
+// `data: {"error":...}` as the first SSE line. The SDK's Stream errors
+// out on its first Next() call (gjson "error" key detection). Priming
+// surfaces that as a non-2xx — the buffered failover writer
+// captures it, and since there's only one service in the rule the
+// captured error commits as the terminal reply. The client sees a
+// real 500 with a JSON error body, not a 200 with a malformed SSE
+// stream that includes an upstream error event.
+func TestRoundTrip_StreamingPrimeFailure_To_OpenAIResponses(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupRoute(protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.ErrorScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.ErrorScenario(), true)
+
+	// The HTTP status must reflect the upstream failure rather than
+	// silently 200-with-error-event. 500 is what SendStreamingError
+	// emits, which isRetryableStatus accepts; if either side flips to
+	// 200 the buffered writer's promotion logic broke.
+	assert.Equal(t, 500, result.HTTPStatus,
+		"pre-stream prime failure must surface as a 5xx, not a 200 SSE")
+	// Parsed assistant content should be empty — no real upstream
+	// content ever streamed, so the handler had nothing to convert.
+	assert.Empty(t, result.Content,
+		"no assistant content should be assembled from a prime-failed stream")
+}
+
+// Anthropic-native passthrough: client and provider both speak Anthropic,
+// so the request flows through HandleAnthropicBeta (ProcessStream over the
+// Anthropic SDK stream). A pre-content upstream error must surface as a
+// retryable 5xx, not a 200 SSE error event — the in-line !Written guard in
+// the passthrough converter + ProcessStream's no-empty-flush. This is the
+// common multi-Anthropic-account failover shape.
+func TestRoundTrip_StreamingPreContentFailure_AnthropicNative(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupRoute(protocol.TypeAnthropicBeta, protocol.TypeAnthropicBeta, pt.ErrorScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeAnthropicBeta, pt.ErrorScenario(), true)
+
+	assert.Equal(t, 500, result.HTTPStatus,
+		"Anthropic-native pre-content failure must surface as a 5xx, not a 200 SSE")
+	assert.Empty(t, result.Content,
+		"no assistant content should be assembled from a failed pre-content stream")
+}
+
 func TestRoundTrip_AllSources_TextScenario_NonStreaming(t *testing.T) {
 	sources := []protocol.APIType{
 		protocol.TypeAnthropicV1,

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -99,7 +99,11 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	reqCtx.RequestModel = actualModel
 	reqCtx.ResponseModel = proxyModel
 
-	s.dispatchChainResult(c, reqCtx, rule, provider, isStreaming, recorder)
+	s.dispatchWithPriorityFailover(c, rule, provider, actualModel,
+		func(p *typ.Provider, _ string) {
+			retryProvider := s.resolveProviderForClient(p, protocol.APIStyleAnthropic)
+			s.dispatchChainResult(c, reqCtx, rule, retryProvider, isStreaming, recorder)
+		})
 }
 
 // handleAnthropicStreamResponseV1Beta processes the Anthropic beta streaming response and sends it to the client
@@ -210,17 +214,17 @@ func (s *Server) streamResponsesToAnthropicBeta(c *gin.Context, proxyModel strin
 		defer cancel()
 	}
 	if err != nil {
-		s.trackUsageFromContext(c, 0, 0, err)
-		stream.SendStreamingError(c, err)
-		if streamRec != nil {
-			streamRec.RecordError(err)
-		}
+		s.handlePreStreamFailure(c, err, streamRec)
 		return
 	}
 
-	// Handle the streaming response
-	// Use the dedicated stream handler to convert Responses API to Anthropic beta format
-	usage, err := stream.HandleResponsesToAnthropicBetaStream(c, streamResp, proxyModel)
+	primedStream, primeErr := stream.PrimeResponsesStream(streamResp)
+	if primeErr != nil {
+		s.handlePreStreamFailure(c, primeErr, streamRec)
+		return
+	}
+
+	usage, err := stream.HandleResponsesToAnthropicBetaStream(c, primedStream, proxyModel)
 
 	// Track usage from stream handler
 	if err != nil {
@@ -263,17 +267,17 @@ func (s *Server) assembleResponsesToAnthropicBeta(c *gin.Context, proxyModel str
 		defer cancel()
 	}
 	if err != nil {
-		s.trackUsageFromContext(c, 0, 0, err)
-		stream.SendStreamingError(c, err)
-		if streamRec != nil {
-			streamRec.RecordError(err)
-		}
+		s.handlePreStreamFailure(c, err, streamRec)
 		return
 	}
 
-	// Handle the streaming response
-	// Use the dedicated stream handler to convert Responses API to Anthropic beta format
-	usage, err := stream.HandleResponsesToAnthropicBetaAssembly(c, streamResp, proxyModel)
+	primedStream, primeErr := stream.PrimeResponsesStream(streamResp)
+	if primeErr != nil {
+		s.handlePreStreamFailure(c, primeErr, streamRec)
+		return
+	}
+
+	usage, err := stream.HandleResponsesToAnthropicBetaAssembly(c, primedStream, proxyModel)
 
 	// Track usage from stream handler
 	if err != nil {

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -95,7 +95,11 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	reqCtx.RequestModel = actualModel
 	reqCtx.ResponseModel = proxyModel
 
-	s.dispatchChainResult(c, reqCtx, rule, provider, isStreaming, recorder)
+	s.dispatchWithPriorityFailover(c, rule, provider, actualModel,
+		func(p *typ.Provider, _ string) {
+			retryProvider := s.resolveProviderForClient(p, protocol.APIStyleAnthropic)
+			s.dispatchChainResult(c, reqCtx, rule, retryProvider, isStreaming, recorder)
+		})
 }
 
 // nonstreamResponsesToAnthropic handles non-streaming Responses API request for v1
@@ -188,9 +192,16 @@ func (s *Server) streamResponsesToAnthropic(c *gin.Context, proxyModel string, a
 		return
 	}
 
-	// Handle the streaming response
-	// Use the dedicated stream handler to convert Responses API to Anthropic v1 format
-	usage, err := stream.HandleResponsesToAnthropicV1Stream(c, streamResp, proxyModel)
+	// Prime the stream: SDK streams are lazy, real upstream errors only
+	// surface on first Next(). Forcing it here lets failover retry
+	// before any byte hits the wire.
+	primedStream, primeErr := stream.PrimeResponsesStream(streamResp)
+	if primeErr != nil {
+		s.handlePreStreamFailure(c, primeErr, streamRec)
+		return
+	}
+
+	usage, err := stream.HandleResponsesToAnthropicV1Stream(c, primedStream, proxyModel)
 
 	// Track usage from stream handler
 	if err != nil {
@@ -233,17 +244,17 @@ func (s *Server) assembleResponsesToAnthropic(c *gin.Context, proxyModel string,
 		defer cancel()
 	}
 	if err != nil {
-		s.trackUsageFromContext(c, 0, 0, err)
-		stream.SendStreamingError(c, err)
-		if streamRec != nil {
-			streamRec.RecordError(err)
-		}
+		s.handlePreStreamFailure(c, err, streamRec)
 		return
 	}
 
-	// Handle the streaming response
-	// Use the dedicated stream handler to convert Responses API to Anthropic beta format
-	usage, err := stream.HandleResponsesToAnthropicV1Assembly(c, streamResp, proxyModel)
+	primedStream, primeErr := stream.PrimeResponsesStream(streamResp)
+	if primeErr != nil {
+		s.handlePreStreamFailure(c, primeErr, streamRec)
+		return
+	}
+
+	usage, err := stream.HandleResponsesToAnthropicV1Assembly(c, primedStream, proxyModel)
 
 	// Track usage from stream handler
 	if err != nil {

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -1,0 +1,362 @@
+// Package server — failover_dispatch.go
+//
+// Mid-request failover for the priority routing tactic, built as a
+// layered hand-off rather than a smart shim fused into the main path:
+//
+//   - Producer (the protocol handler) emits chunks normally, unaware of
+//     failover. On its first real stream chunk it raises one signal,
+//     CommitFirstChunk, and otherwise does nothing differently.
+//   - firstChunkGate is a passive, protocol-agnostic byte buffer. It
+//     makes no decisions: it records writes until CommitFirstChunk (or
+//     the orchestrator's terminal flush) lets them through.
+//   - Orchestrator (dispatchWithPriorityFailover) owns the retry
+//     decision. It reads the gate's committed/status state after each
+//     attempt and either commits, discards + retries the next tier, or
+//     flushes the buffered terminal error.
+//
+// Single-service requests skip the gate entirely, so the common case
+// never touches the buffer.
+
+package server
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// preStreamErrorRecorder narrows the recorder contract to what
+// pre-stream failure sites need — both *ProtocolRecorder and
+// *streamRecorder fit.
+type preStreamErrorRecorder interface {
+	RecordError(error)
+}
+
+// handlePreStreamFailure emits the canonical "upstream failed
+// pre-stream" response: status 500 + JSON error, captured by the
+// buffered failover writer so the orchestrator can retry the next
+// priority tier.
+func (s *Server) handlePreStreamFailure(c *gin.Context, err error, recorder preStreamErrorRecorder) {
+	s.trackUsageFromContext(c, 0, 0, err)
+	stream.SendStreamingError(c, err)
+	if recorder != nil {
+		recorder.RecordError(err)
+	}
+}
+
+// retryableUpstreamStatuses are the HTTP status codes treated as
+// "upstream transiently sick, try the next priority tier".
+//
+// 500 is included because in-process error helpers (SendStreamingError,
+// SendErrorResponse on forwarding failure) wrap upstream pre-stream
+// errors as 500. 502 covers the explicit "upstream stream failed" path.
+// Keeping both means refactors that change one helper's status code
+// don't silently break failover.
+var retryableUpstreamStatuses = map[int]bool{
+	http.StatusTooManyRequests:     true,
+	http.StatusBadGateway:          true,
+	http.StatusServiceUnavailable:  true,
+	http.StatusGatewayTimeout:      true,
+	http.StatusInternalServerError: true,
+}
+
+// isRetryableStatus reports whether a buffered status code from a
+// dispatch attempt should trigger failover. Status 0 means the writer
+// was never touched — treat as terminal (the handler ran to completion
+// without writing, retrying would just repeat the no-op).
+func isRetryableStatus(status int) bool {
+	return status != 0 && retryableUpstreamStatuses[status]
+}
+
+// firstChunkGate is a passive, protocol-agnostic byte buffer placed
+// between a dispatch attempt and the real response writer. It makes no
+// decisions of its own: it records writes into a buffer until an
+// explicit signal commits them. The retry decision lives in the
+// orchestrator; the "first real chunk arrived" signal comes from the
+// streaming producer via CommitFirstChunk.
+//
+// Lifecycle:
+//   - buffered  — Write/WriteHeader capture into buf/hdr/status.
+//   - committed — after CommitFirstChunk or CommitIfBuffered, all I/O
+//     passes straight through to the real writer.
+//   - discarded — Discard resets the buffer for the next retry tier
+//     (valid only while uncommitted).
+type firstChunkGate struct {
+	gin.ResponseWriter
+	real      gin.ResponseWriter
+	buf       bytes.Buffer
+	hdr       http.Header
+	status    int
+	committed bool
+}
+
+func newFirstChunkGate(w gin.ResponseWriter) *firstChunkGate {
+	return &firstChunkGate{
+		ResponseWriter: w,
+		real:           w,
+		hdr:            http.Header{},
+	}
+}
+
+func (g *firstChunkGate) Header() http.Header {
+	if g.committed {
+		return g.real.Header()
+	}
+	return g.hdr
+}
+
+func (g *firstChunkGate) Write(p []byte) (int, error) {
+	if g.committed {
+		return g.real.Write(p)
+	}
+	if g.status == 0 {
+		g.status = http.StatusOK
+	}
+	return g.buf.Write(p)
+}
+
+func (g *firstChunkGate) WriteString(s string) (int, error) {
+	return g.Write([]byte(s))
+}
+
+func (g *firstChunkGate) WriteHeader(code int) {
+	if g.committed {
+		g.real.WriteHeader(code)
+		return
+	}
+	g.status = code
+}
+
+// WriteHeaderNow is swallowed while buffered, delegated once committed.
+func (g *firstChunkGate) WriteHeaderNow() {
+	if g.committed {
+		g.real.WriteHeaderNow()
+	}
+}
+
+// Flush is a no-op while buffered (so partial SSE can't leak past the
+// gate before commit) and delegates once committed (so streaming clients
+// keep getting incremental delivery). ProcessStream type-asserts the
+// writer for http.Flusher, so this method must exist concretely.
+func (g *firstChunkGate) Flush() {
+	if !g.committed {
+		return
+	}
+	if f, ok := g.real.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Status returns the captured status: 0 while untouched, the recorded
+// code otherwise (Write defaults it to 200). Once committed it reflects
+// the real writer. The orchestrator treats 0 as terminal (non-retryable).
+func (g *firstChunkGate) Status() int {
+	if g.committed {
+		return g.real.Status()
+	}
+	return g.status
+}
+
+func (g *firstChunkGate) Size() int {
+	if g.committed {
+		return g.real.Size()
+	}
+	return g.buf.Len()
+}
+
+func (g *firstChunkGate) Written() bool {
+	if g.committed {
+		return g.real.Written()
+	}
+	return g.buf.Len() > 0 || g.status != 0
+}
+
+// Committed reports whether the gate has flushed to the wire. Once
+// committed, retry is impossible — bytes have left the process.
+func (g *firstChunkGate) Committed() bool {
+	return g.committed
+}
+
+// CommitFirstChunk is the producer's "first real chunk arrived" signal.
+// It flushes captured headers + status + buffered body to the real
+// writer and switches to pass-through. Idempotent.
+func (g *firstChunkGate) CommitFirstChunk() {
+	g.commit()
+}
+
+// CommitIfBuffered is the orchestrator's deferred terminal flush of an
+// uncommitted buffered response (the last error after retries are
+// exhausted). No-op when already committed or never touched.
+func (g *firstChunkGate) CommitIfBuffered() {
+	if g.committed || (g.buf.Len() == 0 && g.status == 0) {
+		return
+	}
+	g.commit()
+}
+
+// commit copies captured headers, status, and body to the real writer
+// and enters pass-through mode. gin defers WriteHeader to the first
+// Write or WriteHeaderNow, so for body-less responses WriteHeaderNow is
+// forced explicitly.
+func (g *firstChunkGate) commit() {
+	if g.committed {
+		return
+	}
+	g.committed = true
+	dst := g.real.Header()
+	for k, vs := range g.hdr {
+		dst[k] = vs
+	}
+	status := g.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	g.real.WriteHeader(status)
+	if g.buf.Len() > 0 {
+		_, _ = g.real.Write(g.buf.Bytes())
+		g.buf.Reset()
+	} else {
+		g.real.WriteHeaderNow()
+	}
+}
+
+// Discard resets captured state for the next retry tier. No-op once committed.
+func (g *firstChunkGate) Discard() {
+	if g.committed {
+		return
+	}
+	g.buf.Reset()
+	g.status = 0
+	for k := range g.hdr {
+		delete(g.hdr, k)
+	}
+}
+
+// selectFallbackService picks the next priority tier excluding services
+// already tried in this request. requireAPIStyle keeps candidates
+// compatible with the already-transformed request body — heterogeneous
+// fallback would need re-transformation, out of scope here.
+//
+// Returns (nil, nil, nil) when no compatible candidate remains.
+func (s *Server) selectFallbackService(
+	rule *typ.Rule,
+	excluded map[string]bool,
+	requireAPIStyle protocol.APIStyle,
+) (*typ.Provider, *loadbalance.Service, error) {
+	available := make([]*loadbalance.Service, 0)
+	candidateProviders := make(map[string]*typ.Provider)
+	for _, svc := range rule.GetActiveServices() {
+		if excluded[svc.ServiceID()] {
+			continue
+		}
+		p, err := s.config.GetProviderByUUID(svc.Provider)
+		if err != nil || p == nil {
+			continue
+		}
+		if requireAPIStyle != "" && p.APIStyle != requireAPIStyle {
+			continue
+		}
+		available = append(available, svc)
+		candidateProviders[svc.ServiceID()] = p
+	}
+	if len(available) == 0 {
+		return nil, nil, nil
+	}
+
+	tempRule := *rule
+	tempRule.Services = available
+	tempRule.CurrentServiceID = ""
+
+	svc, err := s.loadBalancer.SelectService(&tempRule)
+	if err != nil {
+		return nil, nil, err
+	}
+	if svc == nil {
+		return nil, nil, nil
+	}
+	return candidateProviders[svc.ServiceID()], svc, nil
+}
+
+// dispatchAttempt is the per-attempt callback. It writes through
+// c.Writer, which is the gate during the failover loop.
+type dispatchAttempt func(provider *typ.Provider, model string)
+
+// dispatchWithPriorityFailover runs `attempt` repeatedly, retrying on
+// retryable buffered failures until either the gate commits (the
+// stream's first real chunk reached the wire, retry impossible) or the
+// candidate pool is exhausted (the last buffered error flushes on the
+// deferred return).
+//
+// Single-service requests bypass the gate entirely: with no fallback
+// tier, failover is impossible and there is no reason to buffer.
+func (s *Server) dispatchWithPriorityFailover(
+	c *gin.Context,
+	rule *typ.Rule,
+	initialProvider *typ.Provider,
+	initialModel string,
+	attempt dispatchAttempt,
+) {
+	activeServices := rule.GetActiveServices()
+	if len(activeServices) <= 1 {
+		attempt(initialProvider, initialModel)
+		return
+	}
+
+	realWriter := c.Writer
+	gate := newFirstChunkGate(realWriter)
+	c.Writer = gate
+	defer func() {
+		c.Writer = realWriter
+		gate.CommitIfBuffered()
+	}()
+
+	tried := map[string]bool{}
+	provider := initialProvider
+	model := initialModel
+
+	// Keep the recorder's bound service in sync per attempt so the
+	// breaker store gets fed the right serviceID on failure.
+	rec, _ := getRecorderFromContext(c)
+
+	for i := 0; i < len(activeServices); i++ {
+		serviceID := loadbalance.FormatServiceID(provider.UUID, model)
+		tried[serviceID] = true
+		if rec != nil {
+			rec.SetActiveService(provider, model)
+		}
+
+		attempt(provider, model)
+
+		// A committed gate means the stream's first real chunk reached
+		// the wire — bytes have left the process, retry is impossible.
+		if gate.Committed() {
+			return
+		}
+		status := gate.Status()
+		if !isRetryableStatus(status) {
+			return
+		}
+
+		nextProvider, nextService, err := s.selectFallbackService(rule, tried, initialProvider.APIStyle)
+		if err != nil {
+			logrus.WithContext(c.Request.Context()).Warnf("[failover] load balancer failed selecting fallback after %d attempt(s) status=%d: %v", i+1, status, err)
+			return
+		}
+		if nextProvider == nil || nextService == nil {
+			logrus.WithContext(c.Request.Context()).Debugf("[failover] giving up after %d attempt(s) status=%d (no more services)", i+1, status)
+			return
+		}
+		logrus.WithContext(c.Request.Context()).Infof("[failover] %s status=%d → retrying with %s:%s", serviceID, status, nextProvider.UUID, nextService.Model)
+
+		gate.Discard()
+		provider = nextProvider
+		model = nextService.Model
+	}
+}

--- a/internal/server/failover_dispatch_test.go
+++ b/internal/server/failover_dispatch_test.go
@@ -1,0 +1,265 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestFirstChunkGate_BufferCaptureBeforeCommit(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+
+	g.WriteHeader(500)
+	if _, err := g.WriteString(`{"error":"boom"}`); err != nil {
+		t.Fatal(err)
+	}
+
+	if g.Committed() {
+		t.Fatal("gate must not be committed before an explicit commit signal")
+	}
+	if g.Status() != 500 {
+		t.Fatalf("Status() = %d, want 500", g.Status())
+	}
+	if g.Size() == 0 {
+		t.Fatal("Size() = 0 after write")
+	}
+	if rec.Code != 200 {
+		t.Fatalf("real recorder code = %d, want 200 (nothing flushed yet)", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("real recorder body should be empty before commit, got %q", rec.Body.String())
+	}
+}
+
+func TestFirstChunkGate_CommitFirstChunkFlushesThenPassesThrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+
+	g.Header().Set("Content-Type", "text/event-stream")
+	if _, err := g.WriteString("event: first\n\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Producer signals the first real chunk arrived.
+	g.CommitFirstChunk()
+
+	if !g.Committed() {
+		t.Fatal("gate must be committed after CommitFirstChunk")
+	}
+	if rec.Code != 200 {
+		t.Fatalf("committed code = %d, want 200 (default)", rec.Code)
+	}
+	if rec.Body.String() != "event: first\n\n" {
+		t.Fatalf("flushed body = %q", rec.Body.String())
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("flushed Content-Type missing: %v", rec.Header())
+	}
+
+	// Subsequent writes pass straight through to the real writer.
+	if _, err := g.WriteString("event: second\n\n"); err != nil {
+		t.Fatal(err)
+	}
+	g.Flush()
+	if rec.Body.String() != "event: first\n\nevent: second\n\n" {
+		t.Fatalf("pass-through body = %q", rec.Body.String())
+	}
+}
+
+func TestFirstChunkGate_CommitIfBufferedTerminalError(t *testing.T) {
+	// The orchestrator's deferred terminal flush: an uncommitted buffered
+	// error (the last failure after retries) reaches the wire.
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	g.Header().Set("X-Test", "yes")
+	g.WriteHeader(503)
+	_, _ = g.WriteString("oh no")
+
+	if g.Committed() {
+		t.Fatal("503 must not commit on its own")
+	}
+	g.CommitIfBuffered()
+
+	if rec.Code != 503 {
+		t.Fatalf("committed code = %d, want 503", rec.Code)
+	}
+	if rec.Body.String() != "oh no" {
+		t.Fatalf("committed body = %q, want %q", rec.Body.String(), "oh no")
+	}
+	if rec.Header().Get("X-Test") != "yes" {
+		t.Fatalf("committed header missing: %v", rec.Header())
+	}
+}
+
+func TestFirstChunkGate_CommitIfBufferedNoopWhenUntouched(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+
+	g.CommitIfBuffered() // nothing buffered → must be a no-op
+
+	if g.Committed() {
+		t.Fatal("untouched gate must not commit")
+	}
+	if rec.Code != 200 || rec.Body.Len() != 0 {
+		t.Fatalf("untouched gate leaked to wire: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFirstChunkGate_CommitIfBufferedNoopAfterCommit(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	_, _ = g.WriteString("chunk")
+	g.CommitFirstChunk()
+
+	// A second terminal flush must not double-write.
+	g.CommitIfBuffered()
+	if rec.Body.String() != "chunk" {
+		t.Fatalf("double-write detected: %q", rec.Body.String())
+	}
+}
+
+func TestFirstChunkGate_DiscardResetsThenRetry(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	g.Header().Set("X-Try-1", "yes")
+	g.WriteHeader(429)
+	_, _ = g.WriteString("rate limited")
+	g.Discard()
+
+	if g.Status() != 0 {
+		t.Fatalf("after Discard Status() = %d, want 0 (reset/untouched)", g.Status())
+	}
+	if g.Size() != 0 {
+		t.Fatalf("after Discard Size() = %d, want 0", g.Size())
+	}
+	if got := g.Header().Get("X-Try-1"); got != "" {
+		t.Fatalf("after Discard header still present: %q", got)
+	}
+
+	// Next attempt succeeds and commits a fresh response.
+	_, _ = g.WriteString(`{"ok":true}`)
+	g.CommitFirstChunk()
+
+	if rec.Code != 200 {
+		t.Fatalf("final code = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != `{"ok":true}` {
+		t.Fatalf("final body = %q, want fresh ok body", rec.Body.String())
+	}
+	if rec.Header().Get("X-Try-1") != "" {
+		t.Fatalf("stale header leaked through Discard")
+	}
+}
+
+func TestFirstChunkGate_DiscardNoopAfterCommit(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	_, _ = g.WriteString("hello")
+	g.CommitFirstChunk()
+
+	g.Discard() // committed → no-op, bytes already on the wire
+	if rec.Body.String() != "hello" {
+		t.Fatalf("Discard after commit must not affect wire: got %q", rec.Body.String())
+	}
+}
+
+func TestFirstChunkGate_CommitFirstChunkIdempotent(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	_, _ = g.WriteString("once")
+	g.CommitFirstChunk()
+	g.CommitFirstChunk() // second call must not re-flush the buffer
+
+	if rec.Body.String() != "once" {
+		t.Fatalf("idempotency broken, body = %q", rec.Body.String())
+	}
+}
+
+func TestFirstChunkGate_StatusDefaults(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+
+	if g.Status() != 0 {
+		t.Fatalf("untouched Status() = %d, want 0", g.Status())
+	}
+	_, _ = g.WriteString("body")
+	if g.Status() != 200 {
+		t.Fatalf("buffered Status() = %d, want 200 default", g.Status())
+	}
+}
+
+func TestFirstChunkGate_FlushNoopUntilCommitted(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	_, _ = g.WriteString("buffered")
+	g.Flush() // must not leak buffered bytes before commit
+
+	if rec.Body.Len() != 0 {
+		t.Fatalf("Flush leaked buffered bytes before commit: %q", rec.Body.String())
+	}
+
+	g.CommitFirstChunk()
+	if rec.Body.String() != "buffered" {
+		t.Fatalf("post-commit body = %q", rec.Body.String())
+	}
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	cases := []struct {
+		code int
+		want bool
+	}{
+		{0, false},   // writer never written → terminal, no retry
+		{200, false}, // 2xx → success
+		{201, false},
+		{400, false}, // 4xx (not 429) → client error, don't retry
+		{401, false},
+		{403, false},
+		{404, false},
+		{422, false},
+		{429, true}, // rate limit
+		{500, true}, // includes our own SendErrorResponse on forwarding errors
+		{502, true},
+		{503, true},
+		{504, true},
+		{501, false}, // not in the gateway-error set
+	}
+	for _, tc := range cases {
+		if got := isRetryableStatus(tc.code); got != tc.want {
+			t.Errorf("isRetryableStatus(%d) = %v, want %v", tc.code, got, tc.want)
+		}
+	}
+}
+
+func TestFirstChunkGate_HeaderOnlyResponseCommits(t *testing.T) {
+	// A status-only response (e.g. 204) still flushes via CommitIfBuffered.
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	g := newFirstChunkGate(c.Writer)
+	g.WriteHeader(http.StatusNoContent)
+
+	if g.Status() != http.StatusNoContent {
+		t.Fatalf("Status() = %d, want %d", g.Status(), http.StatusNoContent)
+	}
+	g.CommitIfBuffered()
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("committed code = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -238,7 +238,10 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	// === Dispatch via transform chain ===
 	reqCtx.RequestModel = actualModel
 	reqCtx.ResponseModel = responseModel
-	s.dispatchChainResult(c, reqCtx, rule, provider, isStreaming, nil)
+	s.dispatchWithPriorityFailover(c, rule, provider, actualModel,
+		func(p *typ.Provider, _ string) {
+			s.dispatchChainResult(c, reqCtx, rule, p, isStreaming, nil)
+		})
 }
 
 // nonstreamOpenAIChat handles non-streaming chat completion requests with MCP runtime support.

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -236,8 +236,11 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 		return
 	}
 
-	// Use unified dispatch
-	s.dispatchChainResult(c, reqCtx, rule, provider, isStreaming, nil)
+	// Use unified dispatch with mid-request failover (non-streaming only).
+	s.dispatchWithPriorityFailover(c, rule, provider, string(req.Model),
+		func(p *typ.Provider, _ string) {
+			s.dispatchChainResult(c, reqCtx, rule, p, isStreaming, nil)
+		})
 }
 
 // buildResponsesPayloadFromChat converts a Chat completion response to Responses API format

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -758,11 +758,13 @@ func (s *Server) streamResponsesToChat(c *gin.Context, reqCtx *transform.Transfo
 		defer cancel()
 	}
 	if err != nil {
-		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
-		if recorder != nil {
-			recorder.RecordError(err)
-		}
+		s.handlePreStreamFailure(c, err, recorder)
+		return
+	}
+
+	primedStream, primeErr := stream.PrimeResponsesStream(responsesStream)
+	if primeErr != nil {
+		s.handlePreStreamFailure(c, primeErr, recorder)
 		return
 	}
 
@@ -775,7 +777,7 @@ func (s *Server) streamResponsesToChat(c *gin.Context, reqCtx *transform.Transfo
 		}
 		return nil
 	})
-	usage, err := stream.HandleResponsesToOpenAIChatStream(hc, responsesStream, responseModel)
+	usage, err := stream.HandleResponsesToOpenAIChatStream(hc, primedStream, responseModel)
 	s.trackUsageWithTokenUsage(c, usage, err)
 	if recorder != nil {
 		recorder.RecordResponse(provider, reqCtx.RequestModel)
@@ -890,12 +892,13 @@ func (s *Server) streamOpenAIResponses(c *gin.Context, reqCtx *transform.Transfo
 		defer cancel()
 	}
 	if err != nil {
-		// Track error with no usage
-		s.trackUsageFromContext(c, 0, 0, err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
-		if recorder != nil {
-			recorder.RecordError(err)
-		}
+		s.handlePreStreamFailure(c, err, recorder)
+		return
+	}
+
+	primedStream, primeErr := stream.PrimeResponsesStream(respStream)
+	if primeErr != nil {
+		s.handlePreStreamFailure(c, primeErr, recorder)
 		return
 	}
 
@@ -909,7 +912,7 @@ func (s *Server) streamOpenAIResponses(c *gin.Context, reqCtx *transform.Transfo
 		}
 		return nil
 	})
-	usage, err := stream.HandleOpenAIResponsesStream(hc, respStream, responseModel)
+	usage, err := stream.HandleOpenAIResponsesStream(hc, primedStream, responseModel)
 
 	// Track usage from stream handler
 	s.trackUsageWithTokenUsage(c, usage, err)

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -60,15 +60,24 @@ type ProtocolRecorder struct {
 	mode         obs.RecordMode
 }
 
+// SetActiveService re-binds the recorder to a new provider/model. The
+// failover orchestrator calls this between attempts so a subsequent
+// RecordError attributes the failure to the right service rather than
+// to whichever service the recorder was last bound to.
+func (sr *ProtocolRecorder) SetActiveService(provider *typ.Provider, model string) {
+	if sr == nil {
+		return
+	}
+	sr.bindProvider(provider, model, "")
+}
+
 // breakerServiceID returns the loadbalance service identifier for the
-// active provider+model, or "" if either is unknown. The ID format must
-// match Service.ServiceID() so circuit-breaker lookups line up with the
-// keys used by the priority tactic.
+// active provider+model, or "" if either is unknown.
 func (sr *ProtocolRecorder) breakerServiceID() string {
 	if sr == nil || sr.providerUUID == "" || sr.model == "" {
 		return ""
 	}
-	return sr.providerUUID + ":" + sr.model
+	return loadbalance.FormatServiceID(sr.providerUUID, sr.model)
 }
 
 // EnsureProtocolRecorder returns a ProtocolRecorder for the given scenario,

--- a/internal/server/usage_tracking.go
+++ b/internal/server/usage_tracking.go
@@ -3,13 +3,13 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/otel/tracker"
@@ -435,7 +435,7 @@ func (s *Server) reportHealthStatus(provider *typ.Provider, model string, err er
 		return
 	}
 
-	serviceID := fmt.Sprintf("%s:%s", provider.UUID, model)
+	serviceID := loadbalance.FormatServiceID(provider.UUID, model)
 
 	logrus.WithFields(logrus.Fields{
 		"provider":   provider.Name,


### PR DESCRIPTION
## Summary

Mid-request failover for the priority routing tactic. When the primary service fails **before any content reaches the client** (429, 5xx, or a pre-stream/lazy-stream error), the request is retried against the next priority tier instead of surfacing the error — complementing the existing cross-request circuit-breaker failover.

Built as a **layered hand-off**, not a smart shim fused into the main path, so a bug in one layer can't corrupt the whole pipeline:

- **Producer** (the dispatch handler) writes its response normally, unaware of failover.
- **`firstChunkGate`** (`failover_dispatch.go`) is a passive, protocol-agnostic byte buffer wrapping `c.Writer`. No decisions in its write path: it buffers until an explicit signal commits. **Single-service requests skip the gate entirely** (`len(GetActiveServices()) <= 1`) — zero blast radius on the common case.
- **Orchestrator** (`dispatchWithPriorityFailover`) owns the retry decision: after each attempt, `Committed()` → first chunk on the wire, return; else retryable `Status()` → `Discard()` + next tier; else the deferred `CommitIfBuffered()` flushes the captured error.
- **Commit seam**: streaming producers raise `CommitFirstChunk` on their first real chunk (centralised in `ProcessStream` / `StreamLoop`, plus the explicit `message_start` senders).

## Streaming pre-content failures

SDK streams are lazy — `ResponsesNewStreaming(...)` returns a `*Stream` without issuing HTTP, so the real upstream verdict (or an in-band `{"error":…}`) only surfaces on the first `Next()`. Two mechanisms turn that into a retryable status before a 200 is committed, applied across **every** streaming path:

- **OpenAI Responses** — `PrimeResponsesStream` (`stream/prime.go`) forces the first `Next()` out-of-band and replays the read event via `firstEventReplayStream`. (Unrelated to `client.ProbeResponsesStream`, a separate synthetic health check.)
- **All other converters** — in-line guard: the stream loops (`StreamLoop`, `ProcessStream`) no longer flush when a step produced nothing (gin's `Flush()` calls `WriteHeaderNow()` and would lock in a 200), and each converter emits a retryable 5xx via `SendStreamingError` when the stream errors with nothing written yet (`!c.Writer.Written()` / `!messageStarted`). The `ProcessStream`-based passthroughs additionally had a `nextFunc` that checked `stream.Err()` *before* `Next()` — a first-`Next()` error was reported as a clean end and swallowed (200 + finish); now fixed to propagate after `Next()`.

## Scope

- **Pre-content only.** Once content is flowing, mid-stream failures surface as SSE error events (no retry) — full reassembly is parked as v3.
- **Same API style only.** Fallback swaps **provider only**, reusing the original transformed body + model — mixing different models across tiers in one rule isn't supported yet.
- Retry budget capped at the rule's active-service count; `SetActiveService` re-bound per attempt so failures trip the right service's breaker.
- **Wired into:** `AnthropicMessagesV1Beta`, `AnthropicMessagesV1`, OpenAI Chat, OpenAI Responses.

## Logging

Failover retry/give-up decisions are logged via `logrus.WithContext(c.Request.Context())` so they correlate into the per-request timeline introduced by the logging redesign.

## Tests

Unit tests for the passive gate (buffer/commit/discard/idempotency/status defaults) and the prime replay wrapper. E2e (`internal/protocol_validate`, `-tags e2e`) covers the happy-path stream and pre-content failure on two representative paths: `TestRoundTrip_StreamingPrimeFailure_To_OpenAIResponses` (routes through the Chat endpoint) and `TestRoundTrip_StreamingPreContentFailure_AnthropicNative` (Anthropic→Anthropic passthrough — the common multi-account failover shape). `TestPriorityRouting_EndToEnd` covers the cross-request retry loop.

> Note: `TestResolveOpenAIEndpoint` and `TestScenario_Error` fail on `main` as well and are unrelated to this PR.

## Design docs

`.design/priority-routing.md` and `.design/priority-routing.pencil.md`.