### PR TITLE
fix(ui): declutter routing-graph node hover popups

### DIFF
--- a/frontend/src/components/nodes/ActionAddNode.tsx
+++ b/frontend/src/components/nodes/ActionAddNode.tsx
@@ -4,11 +4,11 @@ import {
 import {
     Box,
     IconButton,
-    Tooltip,
     Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React from 'react';
+import NodeTooltip from './NodeTooltip';
 
 // ActionAddNode dimensions
 const ADD_PROVIDER_NODE_STYLES = {
@@ -61,7 +61,7 @@ export const ActionAddNode: React.FC<AddProviderNodeProps> = ({
     tooltip = 'Add provider',
 }) => {
     return (
-        <Tooltip title={tooltip}>
+        <NodeTooltip title={tooltip} placement="top">
             <StyledAddProviderNode
                 active={active}
                 warning={warning}
@@ -72,7 +72,7 @@ export const ActionAddNode: React.FC<AddProviderNodeProps> = ({
                     Add
                 </Typography>
             </StyledAddProviderNode>
-        </Tooltip>
+        </NodeTooltip>
     );
 };
 

--- a/frontend/src/components/nodes/BotModelNode.tsx
+++ b/frontend/src/components/nodes/BotModelNode.tsx
@@ -1,6 +1,7 @@
-import { Box, Typography, styled, Divider, Chip, Tooltip } from '@mui/material';
+import { Box, Typography, styled, Divider, Chip } from '@mui/material';
 import { Warning as WarningIcon } from '@mui/icons-material';
 import { NODE_LAYER_STYLES } from './styles';
+import NodeTooltip from './NodeTooltip';
 import { useCallback } from 'react';
 
 const StyledBotModelNode = styled(Box, { shouldForwardProp: (prop) => prop !== 'active' && prop !== 'clickable' && prop !== 'hasConfig' })<{
@@ -59,11 +60,11 @@ const BotModelNode: React.FC<BotModelNodeProps> = ({
         <StyledBotModelNode active={active} clickable={clickable} hasConfig={hasConfig} onClick={handleClick}>
             {/* Top Layer - Provider name and model display (same as ProviderNode) */}
             <Box sx={NODE_LAYER_STYLES.topLayer}>
-                <Tooltip title={
+                <NodeTooltip title={
                     hasConfig
                         ? <>Provider: {providerName || provider}<br/>Model: {model}</>
                         : 'Click to configure bot model'
-                } arrow>
+                } placement="top">
                     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
                         {/* Warning icon when model not configured - inline with text */}
                         {active && !hasConfig && (
@@ -109,7 +110,7 @@ const BotModelNode: React.FC<BotModelNodeProps> = ({
                             </Typography>
                         )}
                     </Box>
-                </Tooltip>
+                </NodeTooltip>
             </Box>
 
             <Divider sx={NODE_LAYER_STYLES.divider} />

--- a/frontend/src/components/nodes/CrossNode.tsx
+++ b/frontend/src/components/nodes/CrossNode.tsx
@@ -1,6 +1,7 @@
-import { Box, styled, Tooltip } from '@mui/material';
+import { Box, styled } from '@mui/material';
 import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import React from 'react';
+import NodeTooltip from './NodeTooltip';
 
 export interface CrossNodeProps {
     size?: number;
@@ -33,7 +34,7 @@ const CrossNode: React.FC<CrossNodeProps> = ({
     color = 'currentColor',
 }) => {
     return (
-        <Tooltip title={label || 'Union'}>
+        <NodeTooltip title={label || 'Union'} placement="top">
             <CrossContainer sx={{ width: size, height: size }}>
                 <StyledCross active={active}>
                     <CompareArrowsIcon
@@ -44,7 +45,7 @@ const CrossNode: React.FC<CrossNodeProps> = ({
                     />
                 </StyledCross>
             </CrossContainer>
-        </Tooltip>
+        </NodeTooltip>
     );
 };
 

--- a/frontend/src/components/nodes/ModelNode.tsx
+++ b/frontend/src/components/nodes/ModelNode.tsx
@@ -190,7 +190,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                         }}
                     >
                         {isWildcard ? (
-                            <NodeTooltip title="Matches any model (wildcard)" placement="bottom">
+                            <NodeTooltip title="Matches any model (wildcard)" placement="top">
                                 <Chip
                                     label={
                                         <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '0.9rem' }}>
@@ -223,7 +223,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                 {/* Bottom Layer - Smart Switch */}
                 {showSmartSwitch && !editMode && (
                     <Box sx={NODE_LAYER_STYLES.bottomLayer}>
-                        <NodeTooltip title="Direct routing mode" placement="top-start">
+                        <NodeTooltip title="Direct routing mode" placement="bottom-start">
                             <ToggleButton
                                 value="direct"
                                 selected={!smartEnabled}
@@ -246,7 +246,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                                 Direct
                             </ToggleButton>
                         </NodeTooltip>
-                        <NodeTooltip title="Smart routing mode" placement="top-end">
+                        <NodeTooltip title="Smart routing mode" placement="bottom-end">
                             <ToggleButton
                                 value="smart"
                                 selected={smartEnabled}

--- a/frontend/src/components/nodes/ModelNode.tsx
+++ b/frontend/src/components/nodes/ModelNode.tsx
@@ -8,10 +8,10 @@ import {
     ListItemText,
     Menu,
     MenuItem,
-    Tooltip,
     ToggleButton,
     Divider,
 } from '@mui/material';
+import NodeTooltip from './NodeTooltip.tsx';
 import { Settings as SettingsIcon } from '@mui/icons-material';
 import { styled } from '@mui/material/styles';
 import React, { useState } from 'react';
@@ -190,7 +190,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                         }}
                     >
                         {isWildcard ? (
-                            <Tooltip title="Matches any model (wildcard)">
+                            <NodeTooltip title="Matches any model (wildcard)" placement="bottom">
                                 <Chip
                                     label={
                                         <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '0.9rem' }}>
@@ -205,7 +205,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                                         },
                                     }}
                                 />
-                            </Tooltip>
+                            </NodeTooltip>
                         ) : (
                             <Typography variant="body2" sx={{ ...NODE_LAYER_STYLES.typography, color: 'text.primary' }}>
                                 {value || label}
@@ -223,7 +223,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                 {/* Bottom Layer - Smart Switch */}
                 {showSmartSwitch && !editMode && (
                     <Box sx={NODE_LAYER_STYLES.bottomLayer}>
-                        <Tooltip title="Direct routing mode" arrow>
+                        <NodeTooltip title="Direct routing mode" placement="top-start">
                             <ToggleButton
                                 value="direct"
                                 selected={!smartEnabled}
@@ -245,8 +245,8 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                             >
                                 Direct
                             </ToggleButton>
-                        </Tooltip>
-                        <Tooltip title="Smart routing mode" arrow>
+                        </NodeTooltip>
+                        <NodeTooltip title="Smart routing mode" placement="top-end">
                             <ToggleButton
                                 value="smart"
                                 selected={smartEnabled}
@@ -268,14 +268,14 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                             >
                                 Smart
                             </ToggleButton>
-                        </Tooltip>
+                        </NodeTooltip>
                     </Box>
                 )}
             </StyledModelNode>
             {/* Action Buttons - visible on hover */}
             {editable && (
                 <ActionButtonsBox className="action-buttons">
-                    <Tooltip title="Change model">
+                    <NodeTooltip title="Change model" placement="left">
                         <IconButton
                             size="small"
                             onClick={handleMenuClick}
@@ -283,7 +283,7 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                         >
                             <SettingsIcon sx={{ fontSize: '1rem', color: 'text.primary' }} />
                         </IconButton>
-                    </Tooltip>
+                    </NodeTooltip>
                 </ActionButtonsBox>
             )}
         </ModelNodeWrapper>

--- a/frontend/src/components/nodes/NodeTooltip.tsx
+++ b/frontend/src/components/nodes/NodeTooltip.tsx
@@ -1,0 +1,28 @@
+import { Tooltip, TooltipProps } from '@mui/material';
+import React from 'react';
+
+// Shared tooltip wrapper for routing-graph nodes.
+//
+// The routing diagram packs many independent hover targets (provider info,
+// priority badge, action buttons, mode toggles). Default MUI delays (100ms
+// enter) caused a chain of tooltips to fire as the cursor crossed a node.
+// A longer enterDelay means a fast pass-through triggers nothing, and the
+// `enterNextDelay` arms the next tooltip briefly so neighbouring targets do
+// not stack instantly after one closes.
+export const NodeTooltip: React.FC<TooltipProps> = ({
+    enterDelay = 600,
+    enterNextDelay = 200,
+    leaveDelay = 80,
+    arrow = true,
+    ...rest
+}) => (
+    <Tooltip
+        enterDelay={enterDelay}
+        enterNextDelay={enterNextDelay}
+        leaveDelay={leaveDelay}
+        arrow={arrow}
+        {...rest}
+    />
+);
+
+export default NodeTooltip;

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -12,7 +12,6 @@ import {
     Popover,
     Stack,
     TextField,
-    Tooltip,
     Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -23,6 +22,7 @@ import { ProbeV2Menu } from '../probe';
 import type { ConfigProvider } from '../RoutingGraphTypes.ts';
 import { ProviderNodeContainer, NODE_LAYER_STYLES } from './styles.tsx';
 import ProviderNodeContent from './ProviderNodeContent.tsx';
+import NodeTooltip from './NodeTooltip.tsx';
 
 // Action button container
 const ActionButtonsBox = styled(Box)(({ theme }) => ({
@@ -160,7 +160,7 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
     return (
         <>
             <PriorityBadgeAnchor>
-                <Tooltip title={tooltip} arrow placement="top">
+                <NodeTooltip title={tooltip} placement="left">
                     <PriorityBadgeDisk
                         hasPriority={priority > 0}
                         active={active}
@@ -168,7 +168,7 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
                     >
                         {label}
                     </PriorityBadgeDisk>
-                </Tooltip>
+                </NodeTooltip>
             </PriorityBadgeAnchor>
             <Popover
                 open={Boolean(anchor)}
@@ -227,6 +227,23 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
     const providerInfo = getProviderInfo(provider.provider, providersData);
     const isProviderMissing = provider.provider && !providerInfo.exists;
 
+    const hasDualApiStyle = !!(
+        providerInfo.provider?.api_base_openai && providerInfo.provider?.api_base_anthropic
+    );
+    const apiStyleLabel = hasDualApiStyle ? 'openai / anthropic' : apiStyle;
+
+    const identityTooltip = (() => {
+        if (isProviderMissing) {
+            return 'Provider not found. Please refresh the page or re-import the provider.';
+        }
+        if (!provider.provider) return 'Select Provider';
+        const modelLine = provider.model ? `Model: ${provider.model}` : 'Model: (select model)';
+        const styleLine = apiStyleLabel ? `API Style: ${apiStyleLabel}` : '';
+        return [`Provider: ${providerInfo.name}`, modelLine, styleLine]
+            .filter(Boolean)
+            .join('\n');
+    })();
+
     const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
         event.stopPropagation();
         setMenuAnchorEl(event.currentTarget);
@@ -283,18 +300,13 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
                 )}
                 {/* Top Layer - Provider/Model Field */}
                 <Box sx={NODE_LAYER_STYLES.topLayer}>
-                    <Tooltip title={
-                        provider.provider && provider.model
-                            ? `Provider: ${providerInfo.name}\nModel: ${provider.model}`
-                            : provider.provider
-                                ? `Provider: ${providerInfo.name}\nModel: (select model)`
-                                : 'Select Provider'
-                    } arrow>
+                    <NodeTooltip
+                        title={<Box sx={{ whiteSpace: 'pre-line' }}>{identityTooltip}</Box>}
+                        placement="top"
+                    >
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
                             {isProviderMissing && (
-                                <Tooltip title="Provider not found. Please refresh the page or re-import the provider." arrow>
-                                    <WarningIcon sx={{ fontSize: '1rem', color: 'warning.main' }} />
-                                </Tooltip>
+                                <WarningIcon sx={{ fontSize: '1rem', color: 'warning.main' }} />
                             )}
                             <Typography
                                 variant="body2"
@@ -330,7 +342,7 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
                                 </Typography>
                             )}
                         </Box>
-                    </Tooltip>
+                    </NodeTooltip>
                 </Box>
 
                 {/* Divider */}
@@ -381,7 +393,7 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
                 <ActionButtonsBox className="action-buttons">
                     {/* Probe Button */}
                     {provider.provider && providerInfo.exists && (
-                        <Tooltip title="Test Provider">
+                        <NodeTooltip title="Test Provider" placement="bottom">
                             <IconButton
                                 size="small"
                                 onClick={handleProbeClick}
@@ -389,10 +401,10 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
                             >
                                 <PlayIcon sx={{ fontSize: '1rem', color: 'success.main' }} />
                             </IconButton>
-                        </Tooltip>
+                        </NodeTooltip>
                     )}
                     {/* Delete Button */}
-                    <Tooltip title="Delete Provider">
+                    <NodeTooltip title="Delete Provider" placement="bottom">
                         <IconButton
                             size="small"
                             onClick={handleMenuClick}
@@ -400,7 +412,7 @@ export const ProviderNode: React.FC<ProviderNodeComponentProps> = ({
                         >
                             <DeleteIcon sx={{ fontSize: '1rem', color: 'error.main' }} />
                         </IconButton>
-                    </Tooltip>
+                    </NodeTooltip>
                 </ActionButtonsBox>
             </ProviderNodeContainer>
         </ProviderNodeWrapper>

--- a/frontend/src/components/nodes/RoutingModeNode.tsx
+++ b/frontend/src/components/nodes/RoutingModeNode.tsx
@@ -1,8 +1,9 @@
 import {
     Router as RouterIcon
 } from '@mui/icons-material';
-import { Box, Divider, styled, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
+import { Box, Divider, styled, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { NODE_LAYER_STYLES } from './styles';
+import NodeTooltip from './NodeTooltip';
 
 const StyledRoutingNode = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -68,7 +69,7 @@ const RoutingModeNode: React.FC<RoutingModeNodeProps> = ({
                         },
                     }}
                 >
-                    <Tooltip title="Direct routing - send directly to agent" arrow>
+                    <NodeTooltip title="Direct routing - send directly to agent" placement="top-start">
                         <ToggleButton
                             value="direct"
                             sx={{
@@ -87,8 +88,8 @@ const RoutingModeNode: React.FC<RoutingModeNodeProps> = ({
                         >
                             Direct
                         </ToggleButton>
-                    </Tooltip>
-                    <Tooltip title="Smart guide - route through guide agent" arrow>
+                    </NodeTooltip>
+                    <NodeTooltip title="Smart guide - route through guide agent" placement="top-end">
                         <ToggleButton
                             value="smart_guide"
                             sx={{
@@ -107,7 +108,7 @@ const RoutingModeNode: React.FC<RoutingModeNodeProps> = ({
                         >
                             Smart
                         </ToggleButton>
-                    </Tooltip>
+                    </NodeTooltip>
                 </ToggleButtonGroup>
             </Box>
         </StyledRoutingNode>

--- a/frontend/src/components/nodes/RoutingModeNode.tsx
+++ b/frontend/src/components/nodes/RoutingModeNode.tsx
@@ -69,7 +69,7 @@ const RoutingModeNode: React.FC<RoutingModeNodeProps> = ({
                         },
                     }}
                 >
-                    <NodeTooltip title="Direct routing - send directly to agent" placement="top-start">
+                    <NodeTooltip title="Direct routing - send directly to agent" placement="bottom-start">
                         <ToggleButton
                             value="direct"
                             sx={{
@@ -89,7 +89,7 @@ const RoutingModeNode: React.FC<RoutingModeNodeProps> = ({
                             Direct
                         </ToggleButton>
                     </NodeTooltip>
-                    <NodeTooltip title="Smart guide - route through guide agent" placement="top-end">
+                    <NodeTooltip title="Smart guide - route through guide agent" placement="bottom-end">
                         <ToggleButton
                             value="smart_guide"
                             sx={{

--- a/frontend/src/components/nodes/SmartDefaultNode.tsx
+++ b/frontend/src/components/nodes/SmartDefaultNode.tsx
@@ -5,7 +5,6 @@ import {
 import {
     Box,
     IconButton,
-    Tooltip,
     Typography,
 } from '@mui/material';
 import React from 'react';

--- a/frontend/src/components/nodes/SmartOpNode.tsx
+++ b/frontend/src/components/nodes/SmartOpNode.tsx
@@ -1,5 +1,6 @@
 import {Delete as DeleteIcon,} from '@mui/icons-material';
-import {Box, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip, Typography,} from '@mui/material';
+import {Box, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Typography,} from '@mui/material';
+import NodeTooltip from './NodeTooltip.tsx';
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {SmartRouting, SmartOp} from '../RoutingGraphTypes.ts';
@@ -136,23 +137,22 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                 )}
                 {/* Content */}
                 <Box sx={{mt: 1, width: '100%'}}>
-                    {/* Value display - show truncated with operation details on hover */}
-                    <Tooltip title={getMultiOpDisplayFull()} arrow>
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                fontWeight: 600,
-                                color: 'text.primary',
-                                fontSize: '0.85rem',
-                                mb: 1,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                            }}
-                        >
-                            {getTruncatedValue(firstOp) || t('rule.smart.noValue')}
-                        </Typography>
-                    </Tooltip>
+                    {/* Value display - the truncated value is a subset of the summary
+                        below, so it shares the single tooltip on the summary box. */}
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            fontWeight: 600,
+                            color: 'text.primary',
+                            fontSize: '0.85rem',
+                            mb: 1,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {getTruncatedValue(firstOp) || t('rule.smart.noValue')}
+                    </Typography>
 
                     {/* Summary Info */}
                     <Box
@@ -160,7 +160,7 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                             width: '100%',
                         }}
                     >
-                        <Tooltip title={getMultiOpDisplayFull()} arrow>
+                        <NodeTooltip title={getMultiOpDisplayFull()} placement="top">
                             <Box
                                 sx={{
                                     width: '100%',
@@ -190,13 +190,13 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                                     {getMultiOpSummary()}
                                 </Typography>
                             </Box>
-                        </Tooltip>
+                        </NodeTooltip>
                     </Box>
                 </Box>
 
                 {/* Action Buttons - visible on hover */}
                 <ActionButtonsBox className="action-buttons">
-                    <Tooltip title={t('rule.smart.deleteTooltip')}>
+                    <NodeTooltip title={t('rule.smart.deleteTooltip')} placement="bottom">
                         <IconButton
                             size="small"
                             onClick={handleMenuClick}
@@ -204,7 +204,7 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                         >
                             <DeleteIcon sx={{fontSize: '1rem', color: 'error.main'}}/>
                         </IconButton>
-                    </Tooltip>
+                    </NodeTooltip>
                 </ActionButtonsBox>
             </StyledSmartNodePrimary>
 


### PR DESCRIPTION
## Problem
Routing-diagram nodes each carry several independent hover targets (identity info, priority badge, action buttons, mode toggles). All used MUI `Tooltip` with default 100ms enterDelay and default `top` placement, so:

- Moving the cursor across a node fired a chain of tooltips in the same screen region.
- `ProviderNode` had a `Tooltip` wrapping another `Tooltip` (Warning icon nested inside the identity tooltip) — unreliable behaviour in MUI.
- `ProviderNode`'s priority badge had **both** a hover tooltip and a click popover with overlapping content.
- `SmartOpNode` accidentally rendered the same tooltip on two adjacent elements, causing a flicker as the cursor moved between them.
- `RoutingModeNode` / `ModelNode` had two adjacent toggle buttons whose tooltips opened at the same anchor — the second one popped on top of the first.

## Approach
Four principles, no help-mode toggle / no localStorage / no tour library:

1. **Aggregate** info that describes the same concept. `ProviderNode`'s identity tooltip now shows Provider + Model + **API Style** + missing-provider warning in one place; the inner `WarningIcon` tooltip is gone. `SmartOpNode`'s duplicate tooltip is removed (the truncated value is a subset of the summary anyway).
2. **Separate** distinct concepts. Load-balance priority stays on its own tooltip; Test / Delete actions stay independent; Direct vs Smart toggles each keep their own copy.
3. **Spread placements** so a node's multiple tooltips fan out in different directions instead of stacking:

   | Node | Element | Placement |
   |---|---|---|
   | Provider | identity (top layer) | `top` |
   | Provider | priority badge (top-left) | `left` |
   | Provider | Test / Delete (top-right, hover) | `bottom` |
   | SmartOp | summary | `top` |
   | SmartOp | delete (top-right, hover) | `bottom` |
   | RoutingMode | Direct / Smart toggles (bottom of node) | `bottom-start` / `bottom-end` |
   | Model | wildcard chip (top layer) | `top` |
   | Model | settings (top-right, hover) | `left` |
   | Model | Direct / Smart toggles (bottom layer) | `bottom-start` / `bottom-end` |
   | BotModel / ActionAdd / Cross | single tooltip | `top` |

4. **Delay**. New `NodeTooltip` wrapper sets `enterDelay: 600ms`, `enterNextDelay: 200ms`, `leaveDelay: 80ms`, `arrow: true`. A fast cursor pass-through no longer triggers anything.

## Files
- `nodes/NodeTooltip.tsx` — new shared wrapper
- `nodes/ProviderNode.tsx` — merge identity tooltip, drop nested Warning tooltip, reposition priority/actions
- `nodes/SmartOpNode.tsx` — remove duplicate tooltip, reposition delete
- `nodes/RoutingModeNode.tsx` — toggles → `bottom-start` / `bottom-end`
- `nodes/ModelNode.tsx` — toggles → `bottom-start` / `bottom-end`, wildcard `top`, settings `left`
- `nodes/BotModelNode.tsx`, `ActionAddNode.tsx`, `CrossNode.tsx` — adopt `NodeTooltip`
- `nodes/SmartDefaultNode.tsx` — drop unused `Tooltip` import

## Test plan
- [ ] Cursor sweeps across a Provider node in < 600ms: zero tooltips appear.
- [ ] Pause on identity row: only the merged Provider / Model / API Style tooltip shows above.
- [ ] Move to priority badge: identity dismisses, priority tooltip opens to the **left**.
- [ ] Hover Test / Delete buttons (top-right corner): tooltips open **below** the buttons, not on top of identity.
- [ ] SmartOpNode: moving between the truncated-value line and the summary box no longer flickers.
- [ ] RoutingModeNode / ModelNode bottom toggles: Direct tooltip opens to bottom-left, Smart to bottom-right; neither covers the node body.
- [ ] Missing provider: warning icon shows inline, single identity tooltip explains "Provider not found …".

https://claude.ai/code/session_011L9aKhhYDA39Qz3RD5qjPL