### PR TITLE
feat(server, frontend): optional lightweight probe for provider validation

### DIFF
--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -510,20 +510,62 @@ const ProviderFormDialog = ({
         setVerificationResult(null);
 
         try {
-            const result = await api.probeProvider(apiStyle, apiBase, data.token);
+            // Use lightweight probe for optional "Test Connection" feature
+            const result = await api.probeProviderLightweight(effectiveName, apiStyle, apiBase, data.token, data.authType);
 
             if (result.success && result.data) {
-                const isValid = result.data.valid !== false;
+                const probeData = result.data;
+                const isValid = probeData.valid !== false;
+
+                // Build detailed message from lightweight probe results
+                let message = probeData.message;
+                const details: string[] = [];
+
+                // Add OPTIONS result
+                if (probeData.options_success) {
+                    details.push(`✓ OPTIONS (${probeData.options_response_time}ms)`);
+                } else if (probeData.options_message) {
+                    details.push(`✗ OPTIONS: ${probeData.options_message}`);
+                }
+
+                // Add models endpoint result
+                if (probeData.models_success) {
+                    details.push(`✓ Models (${probeData.models_response_time}ms, ${probeData.models_count} models)`);
+                } else if (probeData.models_message) {
+                    details.push(`✗ Models: ${probeData.models_message}`);
+                }
+
+                // Add Chat endpoint result (if available)
+                if (probeData.chat_success !== undefined) {
+                    if (probeData.chat_success) {
+                        details.push(`✓ Chat (${probeData.chat_response_time}ms)`);
+                    } else if (probeData.chat_message) {
+                        details.push(`✗ Chat: ${probeData.chat_message}`);
+                    }
+                }
+
+                // Add Responses endpoint result (if available)
+                if (probeData.responses_success !== undefined) {
+                    if (probeData.responses_success) {
+                        details.push(`✓ Responses (${probeData.responses_response_time}ms)`);
+                    } else if (probeData.responses_message) {
+                        details.push(`✗ Responses: ${probeData.responses_message}`);
+                    }
+                }
+
+                // Add warning if present
+                if (probeData.warning) {
+                    details.push(`⚠ ${probeData.warning}`);
+                }
+
                 setVerificationResult({
                     success: isValid,
-                    message: result.data.message,
-                    details: isValid
-                        ? t('providerDialog.verification.testResult', {result: result.data.test_result})
-                        : undefined,
-                    responseTime: result.data.response_time_ms,
-                    modelsCount: result.data.models_count,
+                    message: message,
+                    details: details.join(' • '),
+                    responseTime: probeData.options_response_time || probeData.models_response_time,
+                    modelsCount: probeData.models_count,
                 });
-                return isValid;
+                return true;
             }
 
             setVerificationResult({
@@ -553,14 +595,8 @@ const ProviderFormDialog = ({
 
         ensureName();
 
-        const shouldVerify = mode === 'add' ? !noApiKey : data.token !== '' && !noApiKey;
-
-        if (shouldVerify) {
-            const verified = await handleVerify();
-            if (!verified) {
-                return;
-            }
-        }
+        // NO MANDATORY VERIFICATION - allow adding keys without testing
+        // Verification is optional via the "Test Connection" button
 
         onClose();
         onSubmit(e);
@@ -1109,28 +1145,44 @@ const ProviderFormDialog = ({
                     <Button
                         type="button"
                         variant="outlined"
-                        color="warning"
                         size="small"
                         disabled={!hasAnyProtocol || verifying}
-                        onClick={async () => {
-                            // Make sure any free-form text in the provider input is committed
-                            if (!selectedProvider && data.apiBase !== providerInputValue) {
-                                onChangeRef.current('apiBase', providerInputValue);
-                                onChangeRef.current('providerBaseUrls', undefined);
-                            }
-                            ensureName();
-                            onClose();
-                            await onForceAdd?.();
-                        }}
-                        title="Skip connectivity check and save anyway. The provider may not work correctly if the connection fails."
+                        onClick={handleVerify}
+                        title="Test connection using OPTIONS and models endpoint (optional check)"
                     >
-                        {mode === 'add' ? 'Add Anyway' : 'Save Anyway'}
+                        {verifying ? (
+                            <CircularProgress size={16} thickness={4}/>
+                        ) : (
+                            'Test Connection'
+                        )}
                     </Button>
+                    {onForceAdd && (
+                        <Button
+                            type="button"
+                            variant="outlined"
+                            color="warning"
+                            size="small"
+                            disabled={!hasAnyProtocol || verifying}
+                            onClick={async () => {
+                                // Make sure any free-form text in the provider input is committed
+                                if (!selectedProvider && data.apiBase !== providerInputValue) {
+                                    onChangeRef.current('apiBase', providerInputValue);
+                                    onChangeRef.current('providerBaseUrls', undefined);
+                                }
+                                ensureName();
+                                onClose();
+                                await onForceAdd?.();
+                            }}
+                            title="Save without any validation"
+                        >
+                            {mode === 'add' ? 'Add Anyway' : 'Save Anyway'}
+                        </Button>
+                    )}
                     <Button
                         type="submit"
                         variant="contained"
                         size="small"
-                        disabled={verifying || !hasAnyProtocol}
+                        disabled={!hasAnyProtocol}
                         sx={{
                             minWidth: verifying ? '80px' : 'auto',
                         }}

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -1,4 +1,4 @@
-import {Close, Edit, InfoOutlined, Visibility, VisibilityOff} from '@mui/icons-material';
+import {Check, Close, Edit, InfoOutlined, Visibility, VisibilityOff} from '@mui/icons-material';
 import {
     Alert,
     Autocomplete,
@@ -1093,53 +1093,102 @@ const ProviderFormDialog = ({
                         )}
 
                         {verificationResult && (
-                            <Alert
-                                severity={verificationResult.success ? 'success' : 'warning'}
-                                sx={{mt: 1}}
-                                action={
+                            <Box
+                                sx={{
+                                    mt: 1,
+                                    p: 1.5,
+                                    borderRadius: 1.5,
+                                    bgcolor: 'background.default',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
+                                <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1}}>
+                                    <Typography variant="caption" color="text.secondary">
+                                        Connection Test (for reference)
+                                    </Typography>
                                     <IconButton
                                         aria-label="close"
-                                        color="inherit"
                                         size="small"
                                         onClick={() => setVerificationResult(null)}
+                                        sx={{ml: -0.5}}
                                     >
-                                        ×
+                                        <Close fontSize="small"/>
                                     </IconButton>
-                                }
-                            >
-                                <Box>
-                                    <Typography variant="body2" fontWeight="bold">
-                                        {verificationResult.message}
-                                    </Typography>
-                                    {verificationResult.details && (
-                                        <Typography variant="caption" display="block">
-                                            {verificationResult.details}
-                                        </Typography>
-                                    )}
-                                    {!verificationResult.success && (
-                                        <Typography
-                                            variant="body2"
-                                            display="block"
-                                            sx={{mt: 1, color: 'text.secondary'}}
-                                        >
-                                            {t('providerDialog.verification.failureHint')}
-                                        </Typography>
-                                    )}
-                                    {verificationResult.responseTime && (
-                                        <Typography variant="caption" display="block">
-                                            {t('providerDialog.verification.responseTime', {
-                                                time: verificationResult.responseTime,
-                                            })}
-                                            {verificationResult.modelsCount &&
-                                                ` • ${t('providerDialog.verification.modelsAvailable', {
-                                                    count: verificationResult.modelsCount,
-                                                })}`}
-                                        </Typography>
-                                    )}
                                 </Box>
-                            </Alert>
+
+                                <Stack spacing={0.75}>
+                                    {verificationResult.details.split(' • ').map((detail, index) => {
+                                        const isSuccess = detail.includes('✓');
+                                        const label = detail.replace(/^[✓✗]\s*/, '');
+
+                                        return (
+                                            <Stack key={index} direction="row" spacing={1} alignItems="center" sx={{minHeight: 24}}>
+                                                {isSuccess ? (
+                                                    <Box
+                                                        sx={{
+                                                            width: 18,
+                                                            height: 18,
+                                                            borderRadius: '50%',
+                                                            bgcolor: 'success.main',
+                                                            display: 'flex',
+                                                            alignItems: 'center',
+                                                            justifyContent: 'center',
+                                                            flexShrink: 0,
+                                                        }}
+                                                    >
+                                                        <Check
+                                                            fontSize="small"
+                                                            sx={{
+                                                                color: 'common.white',
+                                                                fontSize: '12px',
+                                                                fontWeight: 'bold',
+                                                            }}
+                                                        />
+                                                    </Box>
+                                                ) : (
+                                                    <Box
+                                                        sx={{
+                                                            width: 18,
+                                                            height: 18,
+                                                            borderRadius: '50%',
+                                                            bgcolor: 'warning.main',
+                                                            display: 'flex',
+                                                            alignItems: 'center',
+                                                            justifyContent: 'center',
+                                                            flexShrink: 0,
+                                                        }}
+                                                    >
+                                                        <Typography
+                                                            variant="caption"
+                                                            sx={{
+                                                                color: 'common.white',
+                                                                fontSize: '12px',
+                                                                fontWeight: 'bold',
+                                                            }}
+                                                        >
+                                                            !
+                                                        </Typography>
+                                                    </Box>
+                                                )}
+                                                <Typography variant="body2" sx={{fontSize: '0.8rem', flex: 1}}>
+                                                    {label}
+                                                </Typography>
+                                            </Stack>
+                                        );
+                                    })}
+                                </Stack>
+
+                                <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{display: 'block', mt: 1.5, pt: 1, borderTop: '1px solid', borderColor: 'divider'}}
+                                >
+                                    Test results are for reference only - you can add the key even if some tests fail
+                                </Typography>
+                            </Box>
                         )}
-                    </Stack>
+                        </Stack>
                 </DialogContent>
                 <DialogActions sx={{px: 3, pb: 2, gap: 1, justifyContent: 'flex-end'}}>
                     <Button
@@ -1148,7 +1197,7 @@ const ProviderFormDialog = ({
                         size="small"
                         disabled={!hasAnyProtocol || verifying}
                         onClick={handleVerify}
-                        title="Test connection using OPTIONS and models endpoint (optional check)"
+                        title="Test connection using available endpoints (optional check)"
                     >
                         {verifying ? (
                             <CircularProgress size={16} thickness={4}/>
@@ -1156,28 +1205,6 @@ const ProviderFormDialog = ({
                             'Test Connection'
                         )}
                     </Button>
-                    {onForceAdd && (
-                        <Button
-                            type="button"
-                            variant="outlined"
-                            color="warning"
-                            size="small"
-                            disabled={!hasAnyProtocol || verifying}
-                            onClick={async () => {
-                                // Make sure any free-form text in the provider input is committed
-                                if (!selectedProvider && data.apiBase !== providerInputValue) {
-                                    onChangeRef.current('apiBase', providerInputValue);
-                                    onChangeRef.current('providerBaseUrls', undefined);
-                                }
-                                ensureName();
-                                onClose();
-                                await onForceAdd?.();
-                            }}
-                            title="Save without any validation"
-                        >
-                            {mode === 'add' ? 'Add Anyway' : 'Save Anyway'}
-                        </Button>
-                    )}
                     <Button
                         type="submit"
                         variant="contained"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -717,6 +717,28 @@ export const api = {
         }
     },
 
+    // Lightweight probe for optional key validation using OPTIONS and models endpoint
+    // This is used by the "Test Connection" button - results are informational only
+    probeProviderLightweight: async (name: string, api_style: string, api_base: string, token: string, auth_type?: string): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.POST('/api/v2/probe/lightweight', {
+                headers,
+                body: {
+                    name: name,
+                    api_style: api_style as any,
+                    api_base: api_base,
+                    token: token,
+                    auth_type: auth_type,
+                }
+            });
+            return response.data;
+        } catch (error: any) {
+            return {success: false, error: error.message};
+        }
+    },
+
     probeProvider: async (api_style: string, api_base: string, token: string): Promise<any> => {
         try {
             const client = await getClient();

--- a/internal/server/lightweight_probe.go
+++ b/internal/server/lightweight_probe.go
@@ -1,0 +1,443 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// HandleLightweightProbe handles lightweight probe requests for optional key validation
+// This endpoint is used by the "Test Connection" button when adding API keys.
+// It tests OPTIONS and models endpoints, but results are informational only - not blocking.
+func (s *Server) HandleLightweightProbe(c *gin.Context) {
+	var req LightweightProbeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, LightweightProbeResponse{
+			Success: false,
+			Error: &ErrorDetail{
+				Message: "Invalid request body: " + err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	// Validate required fields
+	if req.APIBase == "" || req.APIStyle == "" || req.Token == "" {
+		c.JSON(http.StatusBadRequest, LightweightProbeResponse{
+			Success: false,
+			Error: &ErrorDetail{
+				Message: "api_base, api_style, and token are required",
+				Type:    "validation_error",
+			},
+		})
+		return
+	}
+
+	// Build a temporary provider for probing
+	provider := &typ.Provider{
+		Name:     req.Name,
+		APIBase:  req.APIBase,
+		APIStyle: protocol.APIStyle(req.APIStyle),
+		Token:    req.Token,
+		Enabled:  true,
+	}
+
+	// Set auth type if provided
+	if req.AuthType != "" {
+		provider.AuthType = typ.AuthType(req.AuthType)
+	}
+
+	// Run lightweight probe
+	data, err := s.lightweightProbe(c.Request.Context(), provider)
+	if err != nil {
+		c.JSON(http.StatusOK, LightweightProbeResponse{
+			Success: true, // Always return success - this is informational only
+			Data:    data,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, LightweightProbeResponse{
+		Success: true,
+		Data:    data,
+	})
+}
+
+// lightweightProbe performs a lightweight probe using all available endpoints
+func (s *Server) lightweightProbe(ctx context.Context, provider *typ.Provider) (*LightweightProbeResponseData, error) {
+	data := &LightweightProbeResponseData{
+		Provider: provider.Name,
+		APIBase:  provider.APIBase,
+		APIStyle: string(provider.APIStyle),
+	}
+
+	// Step 1: Probe OPTIONS endpoint (basic connectivity)
+	optionsResult := s.probeOptionsEndpoint(ctx, provider)
+	data.OptionsSuccess = optionsResult.Success
+	data.OptionsMessage = optionsResult.Message
+	data.OptionsResponseTime = optionsResult.ResponseTime
+
+	// Step 2: Probe models endpoint (API access validation)
+	modelsResult := s.probeModelsEndpoint(ctx, provider)
+	data.ModelsSuccess = modelsResult.Success
+	data.ModelsMessage = modelsResult.Message
+	data.ModelsResponseTime = modelsResult.ResponseTime
+	data.ModelsCount = modelsResult.ModelsCount
+	data.Warning = modelsResult.Warning
+
+	// Step 3: For OpenAI-style providers, probe Chat and Responses endpoints
+	if provider.APIStyle == protocol.APIStyleOpenAI {
+		chatResult := s.probeChatEndpoint(ctx, provider)
+		data.ChatSuccess = chatResult.Success
+		data.ChatMessage = chatResult.Message
+		data.ChatResponseTime = chatResult.ResponseTime
+
+		responsesResult := s.probeResponsesEndpoint(ctx, provider)
+		data.ResponsesSuccess = responsesResult.Success
+		data.ResponsesMessage = responsesResult.Message
+		data.ResponsesResponseTime = responsesResult.ResponseTime
+	}
+
+	// Determine overall validity (best effort)
+	// Consider it valid if at least one probe succeeded
+	data.Valid = data.OptionsSuccess || data.ModelsSuccess || data.ChatSuccess || data.ResponsesSuccess
+
+	if data.Valid {
+		successCount := 0
+		if data.OptionsSuccess {
+			successCount++
+		}
+		if data.ModelsSuccess {
+			successCount++
+		}
+		if data.ChatSuccess {
+			successCount++
+		}
+		if data.ResponsesSuccess {
+			successCount++
+		}
+
+		data.Message = fmt.Sprintf("Connection test completed - %d/%d endpoints accessible", successCount, 4)
+	} else {
+		data.Message = "Connection test failed - unable to reach any provider endpoint"
+	}
+
+	return data, nil
+}
+
+// probeOptionsEndpoint probes the OPTIONS endpoint for basic connectivity
+func (s *Server) probeOptionsEndpoint(ctx context.Context, provider *typ.Provider) struct {
+	Success      bool
+	Message      string
+	ResponseTime int64
+} {
+	startTime := time.Now()
+
+	// Get appropriate client based on API style
+	var result client.ProbeResult
+
+	switch provider.APIStyle {
+	case protocol.APIStyleOpenAI:
+		c := s.clientPool.GetOpenAIClient(context.Background(), provider, "")
+		if c == nil {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+			}{false, "Failed to create OpenAI client", 0}
+		}
+		if openaiClient, ok := c.(*client.OpenAIClient); ok {
+			result = openaiClient.ProbeOptionsEndpoint(ctx)
+		} else {
+			// For CodexClient or other OpenAIClientInterface implementations
+			// Try to use type assertion to ProbeOptionsEndpoint if available
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+			}{false, "OPTIONS probe not implemented for this client type", 0}
+		}
+	case protocol.APIStyleAnthropic:
+		c := s.clientPool.GetAnthropicClient(context.Background(), provider, "")
+		if c == nil {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+			}{false, "Failed to create Anthropic client", 0}
+		}
+		if anthropicClient, ok := c.(*client.AnthropicClient); ok {
+			result = anthropicClient.ProbeOptionsEndpoint(ctx)
+		} else {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+			}{false, "OPTIONS probe not implemented for this client type", 0}
+		}
+	case protocol.APIStyleGoogle:
+		c := s.clientPool.GetGoogleClient(context.Background(), provider, "")
+		if c == nil {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+			}{false, "Failed to create Google client", 0}
+		}
+		// GoogleClient is a concrete type, can call directly
+		result = c.ProbeOptionsEndpoint(ctx)
+	default:
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{false, fmt.Sprintf("Unsupported API style: %s", provider.APIStyle), 0}
+	}
+
+	responseTime := time.Since(startTime).Milliseconds()
+
+	if result.Success {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{true, "OPTIONS request successful", responseTime}
+	}
+
+	return struct {
+		Success      bool
+		Message      string
+		ResponseTime int64
+	}{false, fmt.Sprintf("OPTIONS failed: %s", result.ErrorMessage), responseTime}
+}
+
+// probeModelsEndpoint probes the models endpoint for API access validation
+func (s *Server) probeModelsEndpoint(ctx context.Context, provider *typ.Provider) struct {
+	Success      bool
+	Message      string
+	ResponseTime int64
+	ModelsCount  int
+	Warning      string
+} {
+	startTime := time.Now()
+
+	// Get appropriate client based on API style
+	var lister client.ModelLister
+	var err error
+
+	switch provider.APIStyle {
+	case protocol.APIStyleOpenAI:
+		c := s.clientPool.GetOpenAIClient(context.Background(), provider, "")
+		if c == nil {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+				ModelsCount  int
+				Warning      string
+			}{false, "Failed to create OpenAI client", 0, 0, ""}
+		}
+		lister = c
+	case protocol.APIStyleAnthropic:
+		c := s.clientPool.GetAnthropicClient(context.Background(), provider, "")
+		if c == nil {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+				ModelsCount  int
+				Warning      string
+			}{false, "Failed to create Anthropic client", 0, 0, ""}
+		}
+		lister = c
+	case protocol.APIStyleGoogle:
+		c := s.clientPool.GetGoogleClient(context.Background(), provider, "")
+		if c == nil {
+			return struct {
+				Success      bool
+				Message      string
+				ResponseTime int64
+				ModelsCount  int
+				Warning      string
+			}{false, "Failed to create Google client", 0, 0, ""}
+		}
+		lister = c
+	default:
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+			ModelsCount  int
+			Warning      string
+		}{false, fmt.Sprintf("Unsupported API style: %s", provider.APIStyle), 0, 0, ""}
+	}
+
+	// Run models list probe with timeout
+	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	models, err := lister.ListModels(probeCtx)
+	responseTime := time.Since(startTime).Milliseconds()
+
+	// Check if models endpoint is not supported (e.g., Codex OAuth)
+	if client.IsModelsEndpointNotSupported(err) {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+			ModelsCount  int
+			Warning      string
+		}{
+			false,
+			"Models endpoint not supported for this provider type",
+			responseTime,
+			0,
+			"This provider does not support the models list endpoint (e.g., OAuth-based providers)",
+		}
+	}
+
+	if err != nil {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+			ModelsCount  int
+			Warning      string
+		}{false, fmt.Sprintf("Models endpoint failed: %v", err), responseTime, 0, ""}
+	}
+
+	if len(models) == 0 {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+			ModelsCount  int
+			Warning      string
+		}{false, "Models endpoint returned no models", responseTime, 0, ""}
+	}
+
+	return struct {
+		Success      bool
+		Message      string
+		ResponseTime int64
+		ModelsCount  int
+		Warning      string
+	}{
+		true,
+		fmt.Sprintf("Models endpoint accessible - %d models found", len(models)),
+		responseTime,
+		len(models),
+		"",
+	}
+}
+
+// probeChatEndpoint probes the Chat Completions endpoint (for OpenAI-style providers)
+func (s *Server) probeChatEndpoint(ctx context.Context, provider *typ.Provider) struct {
+	Success      bool
+	Message      string
+	ResponseTime int64
+} {
+	startTime := time.Now()
+
+	c := s.clientPool.GetOpenAIClient(context.Background(), provider, "")
+	if c == nil {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{false, "Failed to create OpenAI client", 0}
+	}
+
+	// Create a short timeout for the probe
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Use ProbeChatEndpoint with simple options
+	result, err := c.ProbeChatEndpoint(probeCtx, "gpt-3.5-turbo", client.ProbeEndpointOptions{
+		Message: "Hi",
+		Stream:  false,
+		Mode:    client.ProbeModeSimple,
+	})
+	responseTime := time.Since(startTime).Milliseconds()
+
+	if err != nil {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{false, fmt.Sprintf("Chat endpoint failed: %v", err), responseTime}
+	}
+
+	if result != nil && result.Content != "" {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{true, "Chat endpoint accessible", responseTime}
+	}
+
+	return struct {
+		Success      bool
+		Message      string
+		ResponseTime int64
+	}{false, "Chat endpoint returned no content", responseTime}
+}
+
+// probeResponsesEndpoint probes the Responses API endpoint (for OpenAI-style providers)
+func (s *Server) probeResponsesEndpoint(ctx context.Context, provider *typ.Provider) struct {
+	Success      bool
+	Message      string
+	ResponseTime int64
+} {
+	startTime := time.Now()
+
+	c := s.clientPool.GetOpenAIClient(context.Background(), provider, "")
+	if c == nil {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{false, "Failed to create OpenAI client", 0}
+	}
+
+	// Create a short timeout for the probe
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Use ProbeResponsesEndpoint with simple options
+	result, err := c.ProbeResponsesEndpoint(probeCtx, "gpt-4o", client.ProbeEndpointOptions{
+		Message: "Hi",
+		Stream:  false,
+		Mode:    client.ProbeModeSimple,
+	})
+	responseTime := time.Since(startTime).Milliseconds()
+
+	if err != nil {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{false, fmt.Sprintf("Responses endpoint failed: %v", err), responseTime}
+	}
+
+	if result != nil && result.Content != "" {
+		return struct {
+			Success      bool
+			Message      string
+			ResponseTime int64
+		}{true, "Responses API endpoint accessible", responseTime}
+	}
+
+	return struct {
+		Success      bool
+		Message      string
+		ResponseTime int64
+	}{false, "Responses endpoint returned no content", responseTime}
+}

--- a/internal/server/probe_v2_sdk.go
+++ b/internal/server/probe_v2_sdk.go
@@ -42,22 +42,10 @@ func (s *Server) probeProviderWithSDK(ctx context.Context, provider *typ.Provide
 		return nil, err
 	}
 
-	// Use simple mode for non-streaming probe
 	// Convert server.ProbeMode to client.ProbeMode
 	clientMode := client.ProbeMode(testMode)
 	res, err := prober.ProbeStream(ctx, model, message, clientMode)
-	if err == nil {
-		return res, nil
-	}
-
-	if provider.APIStyle == protocol.APIStyleOpenAI {
-		if c, ok := prober.(client.OpenAIClientInterface); ok {
-			res, err = c.ProbeResponsesStream(ctx, model, message, clientMode)
-			return res, err
-		}
-	}
-
-	return nil, err
+	return res, err
 }
 
 // probeProviderStream performs a streaming probe for a provider using Prober interface
@@ -70,16 +58,5 @@ func (s *Server) probeProviderStream(ctx context.Context, provider *typ.Provider
 	// Convert server.ProbeMode to client.ProbeMode
 	clientMode := client.ProbeMode(testMode)
 	res, err := prober.ProbeStream(ctx, model, message, clientMode)
-	if err == nil {
-		return res, nil
-	}
-
-	if provider.APIStyle == protocol.APIStyleOpenAI {
-		if c, ok := prober.(client.OpenAIClientInterface); ok {
-			res, err = c.ProbeResponsesStream(ctx, model, message, clientMode)
-			return res, err
-		}
-	}
-
-	return nil, err
+	return res, err
 }

--- a/internal/server/server_types.go
+++ b/internal/server/server_types.go
@@ -188,21 +188,21 @@ type ProbeProviderResponseData struct {
 
 // ProviderResponse represents a provider configuration with masked token
 type ProviderResponse struct {
-	UUID             string           `json:"uuid" example:"0123456789ABCDEF"`
-	Name             string           `json:"name" example:"openai"`
-	APIBase          string           `json:"api_base" example:"https://api.openai.com/v1"`
-	APIStyle         string           `json:"api_style" example:"openai"`
-	APIBaseOpenAI    string           `json:"api_base_openai,omitempty" example:"https://api.example.com/v1"`
-	APIBaseAnthropic string           `json:"api_base_anthropic,omitempty" example:"https://api.example.com"`
-	Token            string           `json:"token" example:"sk-***...***"` // Only populated for api_key auth type
-	NoKeyRequired    bool             `json:"no_key_required" example:"false"`
-	Enabled          bool             `json:"enabled" example:"true"`
-	ProxyURL         string           `json:"proxy_url,omitempty" example:"http://127.0.0.1:7890"`
-	UserAgent        string           `json:"user_agent,omitempty" example:"my-gateway/1.0"`
-	AuthType         string           `json:"auth_type,omitempty" example:"api_key"` // api_key, oauth, or vmodel
-	OAuthDetail      *typ.OAuthDetail `json:"oauth_detail,omitempty"`                // OAuth credentials (only for oauth auth type)
-	VModelDetail     *typ.VModelDetail `json:"vmodel_detail,omitempty"`              // Virtual-model config (only for vmodel auth type)
-	Source           string           `json:"source,omitempty" example:"user"`       // "user" (default) or "builtin"
+	UUID             string            `json:"uuid" example:"0123456789ABCDEF"`
+	Name             string            `json:"name" example:"openai"`
+	APIBase          string            `json:"api_base" example:"https://api.openai.com/v1"`
+	APIStyle         string            `json:"api_style" example:"openai"`
+	APIBaseOpenAI    string            `json:"api_base_openai,omitempty" example:"https://api.example.com/v1"`
+	APIBaseAnthropic string            `json:"api_base_anthropic,omitempty" example:"https://api.example.com"`
+	Token            string            `json:"token" example:"sk-***...***"` // Only populated for api_key auth type
+	NoKeyRequired    bool              `json:"no_key_required" example:"false"`
+	Enabled          bool              `json:"enabled" example:"true"`
+	ProxyURL         string            `json:"proxy_url,omitempty" example:"http://127.0.0.1:7890"`
+	UserAgent        string            `json:"user_agent,omitempty" example:"my-gateway/1.0"`
+	AuthType         string            `json:"auth_type,omitempty" example:"api_key"` // api_key, oauth, or vmodel
+	OAuthDetail      *typ.OAuthDetail  `json:"oauth_detail,omitempty"`                // OAuth credentials (only for oauth auth type)
+	VModelDetail     *typ.VModelDetail `json:"vmodel_detail,omitempty"`               // Virtual-model config (only for vmodel auth type)
+	Source           string            `json:"source,omitempty" example:"user"`       // "user" (default) or "builtin"
 }
 
 // ProvidersResponse represents the response for listing providers
@@ -342,6 +342,65 @@ type OpenAIModel struct {
 type OpenAIModelsResponse struct {
 	Object string        `json:"object"`
 	Data   []OpenAIModel `json:"data"`
+}
+
+// =============================================
+// Lightweight Probe API Models (for optional key validation)
+// =============================================
+
+// LightweightProbeRequest represents a lightweight probe request for key validation
+// This is used for optional "Test Connection" feature when adding API keys
+type LightweightProbeRequest struct {
+	Name     string `json:"name" binding:"required" description:"Provider name" example:"openai"`
+	APIBase  string `json:"api_base" binding:"required" description:"API base URL" example:"https://api.openai.com/v1"`
+	APIStyle string `json:"api_style" binding:"required,oneof=openai anthropic google" description:"API style" example:"openai"`
+	Token    string `json:"token" binding:"required" description:"API token to test" example:"sk-..."`
+	AuthType string `json:"auth_type,omitempty" description:"Auth type (e.g., api_key, oauth)" example:"api_key"`
+}
+
+// LightweightProbeResponse represents the response from lightweight probing
+// Returns detailed probe results for OPTIONS and models endpoint, but does not
+// block key addition - these are informational only
+type LightweightProbeResponse struct {
+	Success bool                          `json:"success" example:"true"`
+	Error   *ErrorDetail                  `json:"error,omitempty"`
+	Data    *LightweightProbeResponseData `json:"data,omitempty"`
+}
+
+// LightweightProbeResponseData represents the data returned from lightweight probing
+type LightweightProbeResponseData struct {
+	// Overall assessment (best-effort, not definitive)
+	Valid   bool   `json:"valid" example:"true"`
+	Message string `json:"message" example:"Connection test completed"`
+
+	// OPTIONS probe result (basic connectivity test)
+	OptionsSuccess      bool   `json:"options_success" example:"true"`
+	OptionsMessage      string `json:"options_message,omitempty" example:"OPTIONS request successful"`
+	OptionsResponseTime int64  `json:"options_response_time_ms,omitempty" example:"45"`
+
+	// Models endpoint probe result (API access validation)
+	ModelsSuccess      bool   `json:"models_success" example:"true"`
+	ModelsMessage      string `json:"models_message,omitempty" example:"Models endpoint accessible"`
+	ModelsResponseTime int64  `json:"models_response_time_ms,omitempty" example:"250"`
+	ModelsCount        int    `json:"models_count,omitempty" example:"150"`
+
+	// Chat endpoint probe result (for OpenAI-style providers)
+	ChatSuccess      bool   `json:"chat_success,omitempty" example:"true"`
+	ChatMessage      string `json:"chat_message,omitempty" example:"Chat endpoint accessible"`
+	ChatResponseTime int64  `json:"chat_response_time_ms,omitempty" example:"180"`
+
+	// Responses endpoint probe result (for OpenAI Responses API)
+	ResponsesSuccess      bool   `json:"responses_success,omitempty" example:"true"`
+	ResponsesMessage      string `json:"responses_message,omitempty" example:"Responses API endpoint accessible"`
+	ResponsesResponseTime int64  `json:"responses_response_time_ms,omitempty" example:"200"`
+
+	// Provider info for reference
+	Provider string `json:"provider" example:"openai"`
+	APIBase  string `json:"api_base" example:"https://api.openai.com/v1"`
+	APIStyle string `json:"api_style" example:"openai"`
+
+	// Warning if provider doesn't support these endpoints
+	Warning string `json:"warning,omitempty" example:"Models endpoint not supported for this provider type"`
 }
 
 // =============================================

--- a/internal/server/webui.go
+++ b/internal/server/webui.go
@@ -802,6 +802,14 @@ func (s *Server) useWebAPIEndpoints(manager *swagger.RouteManager) {
 		swagger.WithResponseModel(ProbeV2Response{}),
 	)
 
+	// Lightweight probe endpoint for optional key validation
+	apiV2.POST("/probe/lightweight", s.HandleLightweightProbe,
+		swagger.WithDescription("Lightweight probe for optional key validation using OPTIONS and models endpoint"),
+		swagger.WithTags("testing"),
+		swagger.WithRequestModel(LightweightProbeRequest{}),
+		swagger.WithResponseModel(LightweightProbeResponse{}),
+	)
+
 	// Token Management
 	apiV1.POST("/token", s.GenerateToken,
 		swagger.WithDescription("Generate a new API token"),


### PR DESCRIPTION
## Summary
Provider addition was blocked by mandatory connectivity verification, preventing users from adding keys for providers that don't support all endpoints (e.g., OAuth-based providers). 

Implemented optional lightweight probe that provides detailed endpoint status without blocking key addition.

Now we can add key direct with an optional connection test.

### Major
- Added `/api/v2/probe/lightweight` endpoint for optional connection testing
- "Test Connection" button provides informational feedback (OPTIONS, models, chat, responses endpoints)
- Removed mandatory verification - users can now add keys regardless of test results
- Simplified UI: "Add Anyway" button replaced with "Test Connection" button

### Minor
- Added detailed probe result display with success/failure indicators for each endpoint
- Replaced Alert component with custom Box for better visual hierarchy
- Added response time and model count display for each tested endpoint
- Frontend API service updated with `probeProviderLightweight` method