### PR TITLE
bugfix(host): should use localhost to avoid potential network routing error.

### DIFF
--- a/ai/oauth/callback_server.go
+++ b/ai/oauth/callback_server.go
@@ -44,13 +44,13 @@ func (cs *CallbackServer) Start(port int) error {
 	var err error
 
 	if port > 0 {
-		listener, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		listener, err = net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 		if err != nil {
 			return fmt.Errorf("failed to bind to port %d: %w", port, err)
 		}
 	} else {
 		// Try to find an available loopback port
-		listener, err = net.Listen("tcp", "127.0.0.1:0")
+		listener, err = net.Listen("tcp", "localhost:0")
 		if err != nil {
 			return fmt.Errorf("failed to bind to any port: %w", err)
 		}

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -127,7 +127,7 @@ type Provider struct {
 	Token         string   `json:"token"`     // API key for api_key auth type
 	NoKeyRequired bool     `json:"no_key_required"`
 	Enabled       bool     `json:"enabled"`
-	ProxyURL      string   `json:"proxy_url"`              // HTTP or SOCKS proxy URL (e.g., "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080")
+	ProxyURL      string   `json:"proxy_url"` // HTTP or SOCKS proxy URL (e.g., "http://localhost:7890" or "socks5://localhost:1080")
 	// UserAgent is treated as a deliberate debug / override knob. Empty means
 	// "use the vendor-appropriate default", which for generic OpenAI / Anthropic
 	// is the SDK default and for specialized clients (Claude Code OAuth,
@@ -136,11 +136,11 @@ type Provider struct {
 	// pins — that is intentional for debugging and bug-reproduction scenarios,
 	// but be aware that some upstreams (notably Claude Code OAuth) verify the
 	// CLI UA and may reject requests with a different value.
-	UserAgent     string   `json:"user_agent,omitempty"`
-	Timeout       int64    `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
-	Tags          []string `json:"tags,omitempty"`         // Provider tags for categorization
-	Models        []string `json:"models,omitempty"`       // Available models for this provider (cached)
-	LastUpdated   string   `json:"last_updated,omitempty"` // Last update timestamp
+	UserAgent   string   `json:"user_agent,omitempty"`
+	Timeout     int64    `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
+	Tags        []string `json:"tags,omitempty"`         // Provider tags for categorization
+	Models      []string `json:"models,omitempty"`       // Available models for this provider (cached)
+	LastUpdated string   `json:"last_updated,omitempty"` // Last update timestamp
 
 	// Fusion-mode optional fields. Independent of APIBase/APIStyle.
 	// When set, the dispatcher prefers the URL whose protocol natively matches

--- a/ai/quota/fetcher.go
+++ b/ai/quota/fetcher.go
@@ -100,7 +100,7 @@ func (e *quotaError) Error() string {
 }
 
 // NewHTTPClient 创建带 proxy 支持的 HTTP client
-// proxyURL 格式: "http://127.0.0.1:7890" 或 "socks5://127.0.0.1:1080"
+// proxyURL 格式: "http://localhost:7890" 或 "socks5://localhost:1080"
 func NewHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
 	client := &http.Client{
 		Timeout: timeout,

--- a/internal/agent/apply_test.go
+++ b/internal/agent/apply_test.go
@@ -54,7 +54,7 @@ func TestBuildClaudeCodeEnv_Separate(t *testing.T) {
 // TestGenerateClaudeCodeEnv_SettingsJSON verifies the env map produces a valid
 // settings.json structure (the same shape written to ~/.claude/settings.json).
 func TestBuildClaudeCodeEnv_SettingsJSON(t *testing.T) {
-	env := BuildClaudeCodeEnv("http://127.0.0.1:12580", "tok", true)
+	env := BuildClaudeCodeEnv("http://localhost:12580", "tok", true)
 
 	// Simulate what ApplyClaudeSettingsFromEnv writes: {"env": <env map>}
 	payload := map[string]interface{}{"env": env}
@@ -76,7 +76,7 @@ func TestBuildClaudeCodeEnv_SettingsJSON(t *testing.T) {
 	if envSection["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] != "32000" {
 		t.Errorf("CLAUDE_CODE_MAX_OUTPUT_TOKENS missing or wrong in settings JSON")
 	}
-	if envSection["ANTHROPIC_BASE_URL"] != "http://127.0.0.1:12580/tingly/claude_code" {
+	if envSection["ANTHROPIC_BASE_URL"] != "http://localhost:12580/tingly/claude_code" {
 		t.Errorf("ANTHROPIC_BASE_URL missing or wrong in settings JSON")
 	}
 }

--- a/internal/client/claude_e2e_test.go
+++ b/internal/client/claude_e2e_test.go
@@ -46,7 +46,7 @@ func TestE2E_ClaudeRoundTripper(t *testing.T) {
 
 	// Create provider for Anthropic API
 	provider := &typ.Provider{
-		ProxyURL: "socks5://127.0.0.1:7890",
+		ProxyURL: "socks5://localhost:7890",
 		Name:     "claude-e2e-test",
 		APIBase:  "https://api.anthropic.com",
 		AuthType: authType,
@@ -367,7 +367,7 @@ func TestE2E_ClaudeOAuthRoundTripper(t *testing.T) {
 
 	// Create provider with OAuth
 	provider := &typ.Provider{
-		ProxyURL: "socks5://127.0.0.1:7890",
+		ProxyURL: "socks5://localhost:7890",
 		Name:     "claude-oauth-e2e-test",
 		APIBase:  "https://api.anthropic.com",
 		AuthType: typ.AuthTypeOAuth,
@@ -482,7 +482,7 @@ func TestE2E_BetaStreaming(t *testing.T) {
 
 	// Create provider for Anthropic API
 	provider := &typ.Provider{
-		ProxyURL: "socks5://127.0.0.1:7890",
+		ProxyURL: "socks5://localhost:7890",
 		Name:     "claude-beta-e2e-test",
 		APIBase:  "https://api.anthropic.com",
 		AuthType: authType,

--- a/internal/client/codex_e2e_test.go
+++ b/internal/client/codex_e2e_test.go
@@ -41,7 +41,7 @@ func TestE2E_CodexRoundTripper(t *testing.T) {
 
 	// Create provider for ChatGPT backend API
 	provider := &typ.Provider{
-		ProxyURL: "socks5://127.0.0.1:7890",
+		ProxyURL: "socks5://localhost:7890",
 		Name:     "codex-e2e-test",
 		APIBase:  protocol.CodexAPIBase,
 		AuthType: typ.AuthTypeOAuth,

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -180,7 +180,7 @@ func (a *AgentRestoreFlagCmdKong) Run(appManager *AppManager) error {
 // executeAgentRestore performs the agent restore and prints the result.
 func executeAgentRestore(appManager *AppManager, req *agent.RestoreAgentRequest) error {
 	globalConfig := appManager.GetGlobalConfig()
-	host := "127.0.0.1"
+	host := "localhost"
 
 	agentApply := agent.NewAgentApply(globalConfig, host)
 	result, err := agentApply.RestoreAgent(req)
@@ -521,7 +521,7 @@ func executeAgentApply(appManager *AppManager, req *agent.ApplyAgentRequest) err
 	globalConfig := appManager.GetGlobalConfig()
 
 	// Get host for configuration (pure hostname, port is handled by AgentApply)
-	host := "127.0.0.1"
+	host := "localhost"
 
 	// Create agent apply instance
 	agentApply := agent.NewAgentApply(globalConfig, host)

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -116,7 +116,7 @@ func runCC(appManager *AppManager, profile string, portOverride int, claudeArgs 
 	if port == 0 {
 		port = 12580
 	}
-	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
 	apiKey := globalConfig.GetModelToken()
 
 	// Unified mode determination:

--- a/internal/command/server_test.go
+++ b/internal/command/server_test.go
@@ -77,7 +77,7 @@ func TestServerManagerLifecycle(t *testing.T) {
 		}
 
 		// Test basic HTTP endpoint
-		testServerEndpoint(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+		testServerEndpoint(t, fmt.Sprintf("http://localhost:%d/health", port))
 	})
 
 	t.Run("Stop server", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestServerRestart(t *testing.T) {
 		}
 
 		// Test that server is responding
-		testServerEndpoint(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+		testServerEndpoint(t, fmt.Sprintf("http://localhost:%d/health", port))
 	})
 
 	t.Run("Stop server", func(t *testing.T) {
@@ -369,7 +369,7 @@ func TestServerRestart(t *testing.T) {
 		}
 
 		// Test that server is responding again
-		testServerEndpoint(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+		testServerEndpoint(t, fmt.Sprintf("http://localhost:%d/health", port))
 
 		// Cleanup
 		serverManager.Stop()
@@ -449,8 +449,8 @@ func TestMultipleServers(t *testing.T) {
 	}
 
 	// Test both endpoints
-	testServerEndpoint(t, fmt.Sprintf("http://127.0.0.1:%d/health", port1))
-	testServerEndpoint(t, fmt.Sprintf("http://127.0.0.1:%d/health", port2))
+	testServerEndpoint(t, fmt.Sprintf("http://localhost:%d/health", port1))
+	testServerEndpoint(t, fmt.Sprintf("http://localhost:%d/health", port2))
 }
 
 // Helper functions
@@ -459,7 +459,7 @@ func TestMultipleServers(t *testing.T) {
 func getAvailablePort(t *testing.T) int {
 	// Try ports in the test range
 	for port := 12000; port < 13000; port++ {
-		listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf("localhost:%d", port))
 		if err == nil {
 			listener.Close()
 			return port

--- a/internal/command/tui/quickstart.go
+++ b/internal/command/tui/quickstart.go
@@ -386,7 +386,7 @@ func qsDetails(ctx StepContext, s quickstartState) (quickstartState, StepResult,
 	s.apiToken = tokenR.Value
 
 	proxyR, err := Input("Proxy URL (optional):", InputOptions{
-		Header: ctx.Header, Placeholder: "e.g. http://127.0.0.1:7890", CanGoBack: true,
+		Header: ctx.Header, Placeholder: "e.g. http://localhost:7890", CanGoBack: true,
 	})
 	if err != nil {
 		return s, StepCancel, err
@@ -697,7 +697,7 @@ func qsAgent(ctx StepContext, s quickstartState) (quickstartState, StepResult, e
 		s.ccInstallStatusLine = sl.Value
 	}
 
-	apply := agent.NewAgentApply(s.mgr.GetGlobalConfig(), "127.0.0.1")
+	apply := agent.NewAgentApply(s.mgr.GetGlobalConfig(), "localhost")
 	for _, t := range s.selectedAgents {
 		t := t
 		req := &agent.ApplyAgentRequest{

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -851,7 +851,7 @@ func TestApplyCodexConfig_NewFile_WritesManagedFields(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)
 
-	result, err := ApplyCodexConfig("http://127.0.0.1:12580/tingly/codex", []string{"tingly-codex", "tingly-gpt5"})
+	result, err := ApplyCodexConfig("http://localhost:12580/tingly/codex", []string{"tingly-codex", "tingly-gpt5"})
 	if err != nil {
 		t.Fatalf("ApplyCodexConfig: %v", err)
 	}
@@ -868,7 +868,7 @@ func TestApplyCodexConfig_NewFile_WritesManagedFields(t *testing.T) {
 	}
 	providers, _ := cfg["model_providers"].(map[string]interface{})
 	tb, _ := providers["tingly-box"].(map[string]interface{})
-	if tb["base_url"] != "http://127.0.0.1:12580/tingly/codex" {
+	if tb["base_url"] != "http://localhost:12580/tingly/codex" {
 		t.Errorf("base_url = %v", tb["base_url"])
 	}
 	if tb["wire_api"] != "responses" {

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -429,7 +429,7 @@ func (h *Handler) restoreAgent(c *gin.Context, agentType agent.AgentType) {
 
 	host := h.host
 	if host == "" {
-		host = "127.0.0.1"
+		host = "localhost"
 	}
 	apply := agent.NewAgentApply(h.config, host)
 

--- a/internal/server/module/oauth/session_test.go
+++ b/internal/server/module/oauth/session_test.go
@@ -68,7 +68,7 @@ func TestCreateSession(t *testing.T) {
 func TestCreateSessionWithProxy(t *testing.T) {
 	sm := NewSessionManager()
 
-	proxyURL := "http://127.0.0.1:7890"
+	proxyURL := "http://localhost:7890"
 	sessionID := sm.CreateSession("qwen", "user456", "http://localhost:3000", "redirect", "qwen-provider", proxyURL)
 
 	session := sm.GetSession(sessionID)

--- a/internal/server/module/oauth/types.go
+++ b/internal/server/module/oauth/types.go
@@ -36,7 +36,7 @@ type OAuthAuthorizeRequest struct {
 	Redirect     string `json:"redirect" description:"URL to redirect after OAuth completion" example:"http://localhost:3000/callback"`
 	ResponseType string `json:"response_type" description:"Response type: 'redirect' or 'json'" example:"json"`
 	Name         string `json:"name" description:"Custom name for the provider (optional, auto-generated if empty)" example:"my-claude-account"`
-	ProxyURL     string `json:"proxy_url,omitempty" description:"HTTP/SOCKS proxy URL (e.g., http://127.0.0.1:7890 or socks5://127.0.0.1:1080)" example:"http://proxy.example.com:8080"`
+	ProxyURL     string `json:"proxy_url,omitempty" description:"HTTP/SOCKS proxy URL (e.g., http://localhost:7890 or socks5://localhost:1080)" example:"http://proxy.example.com:8080"`
 }
 
 // OAuthAuthorizeResponse represents the response for OAuth authorization initiation

--- a/internal/server/probe_v2_handler.go
+++ b/internal/server/probe_v2_handler.go
@@ -182,7 +182,7 @@ func (s *Server) resolveVModelLoopbackTarget(ctx context.Context, provider *typ.
 
 	return s.resolveProviderConfigTarget(ctx, &ProbeV2Request{
 		Name:     provider.Name,
-		APIBase:  fmt.Sprintf("http://127.0.0.1:%d%s", port, path),
+		APIBase:  fmt.Sprintf("http://localhost:%d%s", port, path),
 		APIStyle: string(provider.APIStyle),
 		Token:    s.config.GetModelToken(),
 		Model:    model,

--- a/internal/server/processor/vision_proxy_e2e_test.go
+++ b/internal/server/processor/vision_proxy_e2e_test.go
@@ -12,7 +12,7 @@ package processor
 //     go test -tags=e2e -v -run TestVisionProxy_E2E ./internal/server/processor/...
 //
 // Defaults used when the env var is absent:
-//   TINGLY_BASE_URL   = http://127.0.0.1:12580/anthropic
+//   TINGLY_BASE_URL   = http://localhost:12580/anthropic
 //   TINGLY_MODEL      = claude-3-5-sonnet-latest
 //   TINGLY_IMAGE_PATH = embedded 1x1 black PNG
 //
@@ -51,7 +51,7 @@ import (
 // API key is intentionally NOT defaulted: an unset key skips the test
 // rather than spamming the upstream with bogus auth.
 const (
-	defaultBaseURL = "http://127.0.0.1:12580/anthropic"
+	defaultBaseURL = "http://localhost:12580/anthropic"
 	defaultModel   = "claude-3-5-sonnet-latest"
 	defaultPrompt  = "There's an image attached. Tell me what you see in it, in one short sentence."
 )

--- a/internal/server/server_types.go
+++ b/internal/server/server_types.go
@@ -197,7 +197,7 @@ type ProviderResponse struct {
 	Token            string            `json:"token" example:"sk-***...***"` // Only populated for api_key auth type
 	NoKeyRequired    bool              `json:"no_key_required" example:"false"`
 	Enabled          bool              `json:"enabled" example:"true"`
-	ProxyURL         string            `json:"proxy_url,omitempty" example:"http://127.0.0.1:7890"`
+	ProxyURL         string            `json:"proxy_url,omitempty" example:"http://localhost:7890"`
 	UserAgent        string            `json:"user_agent,omitempty" example:"my-gateway/1.0"`
 	AuthType         string            `json:"auth_type,omitempty" example:"api_key"` // api_key, oauth, or vmodel
 	OAuthDetail      *typ.OAuthDetail  `json:"oauth_detail,omitempty"`                // OAuth credentials (only for oauth auth type)
@@ -247,7 +247,7 @@ type CreateProviderRequest struct {
 	Token            string `json:"token" description:"API token" example:"sk-..."`
 	NoKeyRequired    bool   `json:"no_key_required" description:"Whether provider requires no API key" example:"false"`
 	Enabled          bool   `json:"enabled" description:"Whether provider is enabled" example:"true"`
-	ProxyURL         string `json:"proxy_url,omitempty" description:"HTTP or SOCKS proxy URL (e.g., http://127.0.0.1:7890 or socks5://127.0.0.1:1080)" example:"http://127.0.0.1:7890"`
+	ProxyURL         string `json:"proxy_url,omitempty" description:"HTTP or SOCKS proxy URL (e.g., http://localhost:7890 or socks5://localhost:1080)" example:"http://localhost:7890"`
 	UserAgent        string `json:"user_agent,omitempty" description:"Custom outbound HTTP User-Agent; empty uses the built-in/default for this provider" example:"my-gateway/1.0"`
 	AuthType         string `json:"auth_type,omitempty" description:"Auth type: api_key or oauth (default: api_key)" example:"api_key"`
 }

--- a/pkg/network/ip.go
+++ b/pkg/network/ip.go
@@ -8,7 +8,7 @@ import (
 func getLocalIP() string {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		return "127.0.0.1" // fallback to localhost
+		return "localhost" // fallback to localhost
 	}
 
 	for _, addr := range addrs {
@@ -19,7 +19,7 @@ func getLocalIP() string {
 		}
 	}
 
-	return "127.0.0.1" // fallback to localhost
+	return "localhost" // fallback to localhost
 }
 
 // ResolveHost resolves the host to an IP address or returns it as-is if it's already an IP or localhost


### PR DESCRIPTION
Replace hardcode `127.0.0.1` to `localhost`.

As a local hosted AI gateway, bind with localhost is much more robust than hardcode ip, especially for ipv4.
