### PR TITLE
Fix reasoning_tokens field handling in OpenAI responses

### DIFF
--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -361,6 +361,19 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 			}
 		}
 
+		// Codex CLI's ResponseCompleted decoder rejects events whose
+		// output_tokens_details lacks reasoning_tokens. Backfill 0 when the
+		// upstream provider (e.g. DeepSeek) omits it.
+		if gjson.Get(eventRaw, "response.usage").Exists() {
+			if !gjson.Get(eventRaw, "response.usage.output_tokens_details.reasoning_tokens").Exists() {
+				if modified, err := sjson.SetRaw(eventRaw, "response.usage.output_tokens_details.reasoning_tokens", "0"); err == nil {
+					eventRaw = modified
+				} else {
+					logrus.WithError(err).Error("Failed to set reasoning tokens")
+				}
+			}
+		}
+
 		if len(eventRaw) > 0 {
 			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
 				if modified, err := sjson.Set(eventRaw, "response.model", responseModel); err == nil {

--- a/internal/protocol/stream/openai_responses_type.go
+++ b/internal/protocol/stream/openai_responses_type.go
@@ -70,12 +70,16 @@ type responsesUsageWire struct {
 	OutputTokensDetails responsesOutputTokensDetailsWire `json:"output_tokens_details,omitempty"`
 }
 
+// Codex CLI's ResponseCompleted decoder requires cached_tokens and
+// reasoning_tokens to be present; omitempty would drop them when zero and
+// cause "missing field 'reasoning_tokens'" parse errors for chat-only
+// providers (e.g. DeepSeek) routed through chat-to-responses.
 type responsesInputTokensDetailsWire struct {
-	CachedTokens int64 `json:"cached_tokens,omitempty"`
+	CachedTokens int64 `json:"cached_tokens"`
 }
 
 type responsesOutputTokensDetailsWire struct {
-	ReasoningTokens int64 `json:"reasoning_tokens,omitempty"`
+	ReasoningTokens int64 `json:"reasoning_tokens"`
 }
 
 type responsesOutputItemAddedEvent struct {


### PR DESCRIPTION
## Summary
Fixes compatibility issues with Codex CLI's ResponseCompleted decoder by ensuring `reasoning_tokens` and `cached_tokens` fields are always present in OpenAI response streams, even when upstream providers (like DeepSeek) omit them.

## Key Changes
- **openai_responses_type.go**: Removed `omitempty` tags from `reasoning_tokens` and `cached_tokens` fields in `responsesOutputTokensDetailsWire` and `responsesInputTokensDetailsWire` structs. This ensures these fields are always serialized, preventing parse errors in Codex CLI's decoder.
- **openai_passthrough.go**: Added logic to backfill `reasoning_tokens` with a value of `0` when the upstream provider omits it from the response stream. This handles cases where chat-only providers routed through chat-to-responses don't include reasoning token information.

## Implementation Details
- The backfill logic checks if `response.usage` exists and only adds `reasoning_tokens` if it's missing
- Uses `sjson.SetRaw()` to inject the field with proper error handling and logging
- The fix is applied during stream event processing before model name substitution

https://claude.ai/code/session_01TEzjJbwRvLMW3eYT7vAoju