### PR TITLE
feat(ui, rule, config): redesign FlagCatalogDialog with category sidebar and active flags strip

### DIFF
--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -6,7 +6,6 @@ import {
     DialogActions,
     DialogContent,
     DialogTitle,
-    Divider,
     FormControl,
     InputLabel,
     MenuItem,
@@ -16,7 +15,13 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
-import React, { useEffect, useMemo, useState } from 'react';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import CableIcon from '@mui/icons-material/Cable';
+import OutboundIcon from '@mui/icons-material/Outbound';
+import TerminalIcon from '@mui/icons-material/Terminal';
+import ExtensionIcon from '@mui/icons-material/Extension';
+import CloseIcon from '@mui/icons-material/Close';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
 
 // Default enum value treated as "unset" (matches the registry's first option).
@@ -42,6 +47,8 @@ const flagToBool = (flags: RuleFlags | undefined, key: string): boolean => {
             return !!flags.skipUsage;
         case 'use_max_completion_tokens':
             return !!flags.useMaxCompletionTokens;
+        case 'use_max_tokens':
+            return !!flags.useMaxTokens;
         default:
             return false;
     }
@@ -69,6 +76,8 @@ const setBool = (flags: RuleFlags, key: string, value: boolean): RuleFlags => {
             return { ...flags, skipUsage: value };
         case 'use_max_completion_tokens':
             return { ...flags, useMaxCompletionTokens: value };
+        case 'use_max_tokens':
+            return { ...flags, useMaxTokens: value };
         default:
             return flags;
     }
@@ -86,10 +95,34 @@ const setString = (flags: RuleFlags, key: string, value: string): RuleFlags => {
     }
 };
 
-const CATEGORY_LABEL: Record<string, string> = {
-    compatibility: 'Compatibility',
-    request: 'Request',
-    response: 'Response',
+const isFlagActive = (spec: FlagSpec, flags: RuleFlags): boolean => {
+    if (spec.type === 'bool') return flagToBool(flags, spec.key);
+    const v = flagToString(flags, spec.key);
+    if (spec.type === 'enum') return v !== '' && v !== ENUM_DEFAULT_VALUE;
+    return v !== '';
+};
+
+const resetFlag = (flags: RuleFlags, spec: FlagSpec): RuleFlags => {
+    if (spec.type === 'bool') return setBool(flags, spec.key, false);
+    return setString(flags, spec.key, '');
+};
+
+interface CategoryMeta {
+    label: string;
+    icon: React.ReactElement;
+}
+
+// Defaults for known categories; unknown ones fall through to a generic style.
+const CATEGORY_META: Record<string, CategoryMeta> = {
+    ide: { label: 'IDE', icon: <TerminalIcon fontSize="small" /> },
+    openai: { label: 'OpenAI', icon: <AutoAwesomeIcon fontSize="small" /> },
+    http: { label: 'HTTP', icon: <CableIcon fontSize="small" /> },
+    response: { label: 'Response', icon: <OutboundIcon fontSize="small" /> },
+};
+
+const categoryMeta = (category: string): CategoryMeta => CATEGORY_META[category] || {
+    label: category.charAt(0).toUpperCase() + category.slice(1),
+    icon: <ExtensionIcon fontSize="small" />,
 };
 
 export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
@@ -101,21 +134,45 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     onSave,
 }) => {
     const [draft, setDraft] = useState<RuleFlags>(flags || {});
+    const [activeCategory, setActiveCategory] = useState<string | undefined>();
+    const [pulseKey, setPulseKey] = useState<string | undefined>();
+    const flagRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-    // Reset the working copy whenever the dialog is (re-)opened with new flags.
+    // Reset working copy whenever the dialog is (re-)opened with new flags.
     useEffect(() => {
-        if (open) setDraft(flags ? { ...flags } : {});
+        if (open) {
+            setDraft(flags ? { ...flags } : {});
+            setPulseKey(undefined);
+        }
     }, [open, flags]);
 
+    // Group registry entries by category, preserving the order they first
+    // appear in the registry — backend dictates display order.
     const grouped = useMemo(() => {
+        const order: string[] = [];
         const groups = new Map<string, FlagSpec[]>();
         (registry || []).forEach((spec) => {
-            const list = groups.get(spec.category) || [];
-            list.push(spec);
-            groups.set(spec.category, list);
+            if (!groups.has(spec.category)) {
+                order.push(spec.category);
+                groups.set(spec.category, []);
+            }
+            groups.get(spec.category)!.push(spec);
         });
-        return Array.from(groups.entries());
+        return order.map((cat) => ({ category: cat, specs: groups.get(cat) || [] }));
     }, [registry]);
+
+    // Default the selected category to the first one with content.
+    useEffect(() => {
+        if (!open) return;
+        if (activeCategory && grouped.some((g) => g.category === activeCategory)) return;
+        if (grouped.length > 0) setActiveCategory(grouped[0].category);
+    }, [open, grouped, activeCategory]);
+
+    const activeFlags = useMemo(() => {
+        return (registry || []).filter((spec) => isFlagActive(spec, draft));
+    }, [registry, draft]);
+
+    const currentGroup = grouped.find((g) => g.category === activeCategory);
 
     const handleToggle = (key: string, value: boolean) => {
         setDraft((d) => setBool(d, key, value));
@@ -125,120 +182,237 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
         setDraft((d) => setString(d, key, value));
     };
 
+    const jumpToFlag = (spec: FlagSpec) => {
+        if (spec.category !== activeCategory) setActiveCategory(spec.category);
+        // Defer scroll/pulse until the right pane has rendered the target.
+        requestAnimationFrame(() => {
+            const node = flagRefs.current[spec.key];
+            if (node) node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            setPulseKey(spec.key);
+            window.setTimeout(() => {
+                setPulseKey((k) => (k === spec.key ? undefined : k));
+            }, 1200);
+        });
+    };
+
+    const handleRemoveActive = (spec: FlagSpec) => {
+        setDraft((d) => resetFlag(d, spec));
+    };
+
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-            <DialogTitle>
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+            <DialogTitle sx={{ pb: 1 }}>
                 Rule Extensions
                 <Typography variant="caption" component="div" color="text.secondary">
                     Pre-installed flags applied at the rule level.
                 </Typography>
             </DialogTitle>
-            <DialogContent dividers>
+
+            {/* Active flags strip — empty state stays hidden to save vertical space. */}
+            {activeFlags.length > 0 && (
+                <Box
+                    sx={{
+                        px: 3,
+                        py: 1.25,
+                        borderTop: 1,
+                        borderBottom: 1,
+                        borderColor: 'divider',
+                        bgcolor: 'action.hover',
+                    }}
+                >
+                    <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
+                        <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
+                            Active ({activeFlags.length})
+                        </Typography>
+                        {activeFlags.map((spec) => {
+                            const meta = categoryMeta(spec.category);
+                            return (
+                                <Chip
+                                    key={spec.key}
+                                    size="small"
+                                    icon={meta.icon}
+                                    label={spec.label}
+                                    onClick={() => jumpToFlag(spec)}
+                                    onDelete={() => handleRemoveActive(spec)}
+                                    deleteIcon={<CloseIcon />}
+                                    sx={{ maxWidth: 220 }}
+                                />
+                            );
+                        })}
+                    </Stack>
+                </Box>
+            )}
+
+            <DialogContent sx={{ p: 0, display: 'flex', minHeight: 420 }} dividers={false}>
                 {loading && (
-                    <Typography variant="body2" color="text.secondary">
-                        Loading flag catalog…
-                    </Typography>
+                    <Box sx={{ p: 3 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            Loading flag catalog…
+                        </Typography>
+                    </Box>
                 )}
                 {!loading && grouped.length === 0 && (
-                    <Typography variant="body2" color="text.secondary">
-                        No flags available.
-                    </Typography>
+                    <Box sx={{ p: 3 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            No flags available.
+                        </Typography>
+                    </Box>
                 )}
-                <Stack spacing={2}>
-                    {grouped.map(([category, specs]) => (
-                        <Box key={category}>
-                            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
-                                <Typography variant="overline" sx={{ color: 'text.secondary', lineHeight: 1 }}>
-                                    {CATEGORY_LABEL[category] || category}
-                                </Typography>
-                                <Divider sx={{ flexGrow: 1 }} />
-                            </Stack>
-                            <Stack spacing={1.5}>
-                                {specs.map((spec) => {
-                                    let enabled = false;
-                                    if (spec.type === 'bool') {
-                                        enabled = flagToBool(draft, spec.key);
-                                    } else if (spec.type === 'enum') {
-                                        const v = flagToString(draft, spec.key);
-                                        enabled = v !== '' && v !== ENUM_DEFAULT_VALUE;
-                                    } else {
-                                        enabled = flagToString(draft, spec.key) !== '';
-                                    }
-                                    const enumValue = spec.type === 'enum'
-                                        ? (flagToString(draft, spec.key) || ENUM_DEFAULT_VALUE)
-                                        : '';
-                                    return (
-                                        <Box
-                                            key={spec.key}
+
+                {!loading && grouped.length > 0 && (
+                    <>
+                        {/* Left: category sidebar */}
+                        <Box
+                            sx={{
+                                width: 200,
+                                flexShrink: 0,
+                                borderRight: 1,
+                                borderColor: 'divider',
+                                bgcolor: 'background.paper',
+                                overflowY: 'auto',
+                            }}
+                        >
+                            {grouped.map(({ category, specs }) => {
+                                const meta = categoryMeta(category);
+                                const activeCount = specs.filter((s) => isFlagActive(s, draft)).length;
+                                const selected = category === activeCategory;
+                                return (
+                                    <Box
+                                        key={category}
+                                        onClick={() => setActiveCategory(category)}
+                                        sx={{
+                                            px: 2,
+                                            py: 1.25,
+                                            cursor: 'pointer',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: 1,
+                                            borderLeft: 3,
+                                            borderLeftColor: selected ? 'primary.main' : 'transparent',
+                                            bgcolor: selected ? 'action.selected' : 'transparent',
+                                            '&:hover': {
+                                                bgcolor: selected ? 'action.selected' : 'action.hover',
+                                            },
+                                            transition: 'background-color 0.15s',
+                                        }}
+                                    >
+                                        <Box sx={{ color: selected ? 'primary.main' : 'text.secondary', display: 'flex' }}>
+                                            {meta.icon}
+                                        </Box>
+                                        <Typography
+                                            variant="body2"
                                             sx={{
-                                                p: 1,
-                                                border: '1px solid',
-                                                borderColor: enabled ? 'primary.light' : 'divider',
-                                                borderRadius: 1,
-                                                backgroundColor: enabled ? 'action.hover' : 'transparent',
+                                                flexGrow: 1,
+                                                fontWeight: selected ? 600 : 400,
+                                                color: selected ? 'primary.main' : 'text.primary',
                                             }}
                                         >
-                                            <Stack direction="row" alignItems="center" spacing={1}>
-                                                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                                                    <Stack direction="row" alignItems="center" spacing={0.75}>
-                                                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                                            {spec.label}
+                                            {meta.label}
+                                        </Typography>
+                                        <Chip
+                                            size="small"
+                                            label={activeCount > 0 ? `${activeCount}/${specs.length}` : `${specs.length}`}
+                                            color={activeCount > 0 ? 'primary' : 'default'}
+                                            variant={activeCount > 0 ? 'filled' : 'outlined'}
+                                            sx={{ height: 18, fontSize: '0.65rem' }}
+                                        />
+                                    </Box>
+                                );
+                            })}
+                        </Box>
+
+                        {/* Right: flag detail pane */}
+                        <Box sx={{ flexGrow: 1, p: 2, overflowY: 'auto' }}>
+                            {currentGroup && (
+                                <Stack spacing={1.5}>
+                                    {currentGroup.specs.map((spec) => {
+                                        const enabled = isFlagActive(spec, draft);
+                                        const enumValue = spec.type === 'enum'
+                                            ? (flagToString(draft, spec.key) || ENUM_DEFAULT_VALUE)
+                                            : '';
+                                        const pulsing = pulseKey === spec.key;
+                                        return (
+                                            <Box
+                                                key={spec.key}
+                                                ref={(el: HTMLDivElement | null) => {
+                                                    flagRefs.current[spec.key] = el;
+                                                }}
+                                                sx={{
+                                                    p: 1.25,
+                                                    border: '1px solid',
+                                                    borderColor: pulsing
+                                                        ? 'primary.main'
+                                                        : enabled
+                                                            ? 'primary.light'
+                                                            : 'divider',
+                                                    borderRadius: 1,
+                                                    backgroundColor: enabled ? 'action.hover' : 'transparent',
+                                                    boxShadow: pulsing ? '0 0 0 3px rgba(25,118,210,0.18)' : 'none',
+                                                    transition: 'box-shadow 0.2s, border-color 0.2s',
+                                                }}
+                                            >
+                                                <Stack direction="row" alignItems="center" spacing={1}>
+                                                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                                                        <Stack direction="row" alignItems="center" spacing={0.75}>
+                                                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                                                {spec.label}
+                                                            </Typography>
+                                                            <Chip
+                                                                size="small"
+                                                                label={spec.key}
+                                                                sx={{ height: 16, fontSize: '0.6rem' }}
+                                                                variant="outlined"
+                                                            />
+                                                        </Stack>
+                                                        <Typography variant="caption" color="text.secondary">
+                                                            {spec.description}
                                                         </Typography>
-                                                        <Chip
+                                                    </Box>
+                                                    {spec.type === 'bool' && (
+                                                        <Switch
                                                             size="small"
-                                                            label={spec.key}
-                                                            sx={{ height: 16, fontSize: '0.6rem' }}
-                                                            variant="outlined"
+                                                            checked={flagToBool(draft, spec.key)}
+                                                            onChange={(e) => handleToggle(spec.key, e.target.checked)}
                                                         />
-                                                    </Stack>
-                                                    <Typography variant="caption" color="text.secondary">
-                                                        {spec.description}
-                                                    </Typography>
-                                                </Box>
-                                                {spec.type === 'bool' && (
-                                                    <Switch
+                                                    )}
+                                                </Stack>
+                                                {spec.type === 'string' && (
+                                                    <TextField
+                                                        fullWidth
                                                         size="small"
-                                                        checked={flagToBool(draft, spec.key)}
-                                                        onChange={(e) => handleToggle(spec.key, e.target.checked)}
+                                                        placeholder={spec.placeholder}
+                                                        value={flagToString(draft, spec.key)}
+                                                        onChange={(e) => handleStringChange(spec.key, e.target.value)}
+                                                        sx={{ mt: 1 }}
                                                     />
                                                 )}
-                                            </Stack>
-                                            {spec.type === 'string' && (
-                                                <TextField
-                                                    fullWidth
-                                                    size="small"
-                                                    placeholder={spec.placeholder}
-                                                    value={flagToString(draft, spec.key)}
-                                                    onChange={(e) => handleStringChange(spec.key, e.target.value)}
-                                                    sx={{ mt: 1 }}
-                                                />
-                                            )}
-                                            {spec.type === 'enum' && (
-                                                <FormControl fullWidth size="small" sx={{ mt: 1 }}>
-                                                    <InputLabel id={`flag-enum-${spec.key}-label`}>
-                                                        {spec.label}
-                                                    </InputLabel>
-                                                    <Select
-                                                        labelId={`flag-enum-${spec.key}-label`}
-                                                        label={spec.label}
-                                                        value={enumValue}
-                                                        onChange={(e) => handleStringChange(spec.key, String(e.target.value))}
-                                                    >
-                                                        {(spec.options || []).map((opt) => (
-                                                            <MenuItem key={opt.value} value={opt.value}>
-                                                                {opt.label}
-                                                            </MenuItem>
-                                                        ))}
-                                                    </Select>
-                                                </FormControl>
-                                            )}
-                                        </Box>
-                                    );
-                                })}
-                            </Stack>
+                                                {spec.type === 'enum' && (
+                                                    <FormControl fullWidth size="small" sx={{ mt: 1 }}>
+                                                        <InputLabel id={`flag-enum-${spec.key}-label`}>
+                                                            {spec.label}
+                                                        </InputLabel>
+                                                        <Select
+                                                            labelId={`flag-enum-${spec.key}-label`}
+                                                            label={spec.label}
+                                                            value={enumValue}
+                                                            onChange={(e) => handleStringChange(spec.key, String(e.target.value))}
+                                                        >
+                                                            {(spec.options || []).map((opt) => (
+                                                                <MenuItem key={opt.value} value={opt.value}>
+                                                                    {opt.label}
+                                                                </MenuItem>
+                                                            ))}
+                                                        </Select>
+                                                    </FormControl>
+                                                )}
+                                            </Box>
+                                        );
+                                    })}
+                                </Stack>
+                            )}
                         </Box>
-                    ))}
-                </Stack>
+                    </>
+                )}
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color="primary">

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -1,5 +1,5 @@
 import { Add as AddIcon, Extension as ExtensionIcon } from '@mui/icons-material';
-import { Box, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { Box, Chip, Stack, Tooltip, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React from 'react';
 import { PROVIDER_NODE_STYLES } from '@/components/nodes/styles';
@@ -27,8 +27,13 @@ const StyledExtensionsCard = styled(Box, {
     height: CARD_STYLES.height,
     boxShadow: theme.shadows[1],
     opacity: active ? 1 : 0.6,
+    cursor: 'pointer',
     transition: 'all 0.2s ease-in-out',
     overflow: 'hidden',
+    '&:hover': {
+        borderColor: theme.palette.primary.main,
+        boxShadow: theme.shadows[2],
+    },
 }));
 
 export interface RuleExtensionsCardProps {
@@ -92,23 +97,21 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
     });
 
     return (
-        <StyledExtensionsCard active={active}>
+        <StyledExtensionsCard active={active} onClick={onOpenCatalog}>
             {/* Fixed-height header so the body has a stable scroll region */}
             <Stack direction="row" alignItems="center" spacing={0.5} sx={{ flexShrink: 0, mb: 0.25 }}>
                 <ExtensionIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
                 <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.65rem', color: 'text.secondary', flexGrow: 1, lineHeight: 1 }}>
                     Extensions{enabled.length > 0 ? ` (${enabled.length})` : ''}
                 </Typography>
+                {/* Visual affordance only — the whole card is clickable. */}
                 <Tooltip title="Configure rule extensions">
-                    <IconButton size="small" onClick={onOpenCatalog} sx={{ p: 0.125 }}>
-                        <AddIcon sx={{ fontSize: 12 }} />
-                    </IconButton>
+                    <AddIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
                 </Tooltip>
             </Stack>
 
             {enabled.length === 0 ? (
                 <Box
-                    onClick={onOpenCatalog}
                     sx={{
                         flexGrow: 1,
                         display: 'flex',
@@ -116,7 +119,6 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                         justifyContent: 'center',
                         color: 'text.disabled',
                         fontSize: '0.65rem',
-                        cursor: 'pointer',
                         textAlign: 'center',
                         px: 0.25,
                     }}
@@ -158,10 +160,14 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                                         label={label}
                                         color="primary"
                                         variant="outlined"
-                                        onClick={onOpenCatalog}
                                         onDelete={
                                             spec.type === 'bool' && onToggleFlag
-                                                ? () => onToggleFlag(spec.key)
+                                                ? (e: React.MouseEvent) => {
+                                                    // Don't let the X bubble into the
+                                                    // card-level "open catalog" handler.
+                                                    e.stopPropagation();
+                                                    onToggleFlag(spec.key);
+                                                }
                                                 : undefined
                                         }
                                         sx={{ maxWidth: '100%', fontSize: '0.6rem', height: 18 }}

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -13,9 +13,15 @@ const (
 type FlagCategory string
 
 const (
-	FlagCategoryCompatibility FlagCategory = "compatibility"
-	FlagCategoryRequest       FlagCategory = "request"
-	FlagCategoryResponse      FlagCategory = "response"
+	// FlagCategoryIDE — flags that target a specific IDE/client (e.g. Cursor).
+	FlagCategoryIDE FlagCategory = "ide"
+	// FlagCategoryOpenAI — OpenAI-specific request-shape adjustments
+	// (max_tokens vs max_completion_tokens, chat vs responses endpoint, ...).
+	FlagCategoryOpenAI FlagCategory = "openai"
+	// FlagCategoryHTTP — transport-level overrides (custom User-Agent, etc).
+	FlagCategoryHTTP FlagCategory = "http"
+	// FlagCategoryResponse — flags that modify the response body/stream.
+	FlagCategoryResponse FlagCategory = "response"
 )
 
 // FlagOption is one selectable value for a FlagTypeEnum spec.
@@ -48,14 +54,14 @@ func RuleFlagRegistry() []FlagSpec {
 			Label:       "Cursor compatibility",
 			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor IDE clients.",
 			Type:        FlagTypeBool,
-			Category:    FlagCategoryCompatibility,
+			Category:    FlagCategoryIDE,
 		},
 		{
 			Key:         "cursor_compat_auto",
 			Label:       "Auto-detect Cursor",
 			Description: "Apply cursor compatibility automatically when request headers identify Cursor.",
 			Type:        FlagTypeBool,
-			Category:    FlagCategoryCompatibility,
+			Category:    FlagCategoryIDE,
 		},
 		{
 			Key:         "skip_usage",
@@ -69,21 +75,21 @@ func RuleFlagRegistry() []FlagSpec {
 			Label:       "Use max_completion_tokens",
 			Description: "Rewrite request field `max_tokens` to `max_completion_tokens` (required by o1/o3/gpt-5 family).",
 			Type:        FlagTypeBool,
-			Category:    FlagCategoryRequest,
+			Category:    FlagCategoryOpenAI,
 		},
 		{
 			Key:         "use_max_tokens",
 			Label:       "Use max_tokens (legacy)",
 			Description: "Rewrite request field `max_completion_tokens` back to the legacy `max_tokens`. Use for providers that reject the newer field name.",
 			Type:        FlagTypeBool,
-			Category:    FlagCategoryRequest,
+			Category:    FlagCategoryOpenAI,
 		},
 		{
 			Key:         "custom_user_agent",
 			Label:       "Custom User-Agent",
 			Description: "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent.",
 			Type:        FlagTypeString,
-			Category:    FlagCategoryRequest,
+			Category:    FlagCategoryHTTP,
 			Placeholder: "e.g. MyApp/1.0",
 		},
 		{
@@ -91,7 +97,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Label:       "OpenAI endpoint override",
 			Description: "Force OpenAI Chat Completions or Responses regardless of the adaptive router's probe-based decision. OpenAI providers only; Anthropic/Google providers ignore this. On Codex OAuth providers, \"chat\" is ignored (Codex has no Chat endpoint).",
 			Type:        FlagTypeEnum,
-			Category:    FlagCategoryRequest,
+			Category:    FlagCategoryOpenAI,
 			Options: []FlagOption{
 				{Value: "auto", Label: "Auto (adaptive)"},
 				{Value: "chat", Label: "Force Chat Completions"},


### PR DESCRIPTION
## Summary
Redesigned the FlagCatalogDialog component to improve usability and visual organization. The dialog now features a two-pane layout with a category sidebar on the left and flag details on the right, plus an active flags strip at the top for quick access and management.

## Key Changes

### Frontend (FlagCatalogDialog.tsx)
- **Layout restructure**: Changed from single-column to two-pane layout (category sidebar + flag detail pane)
- **Active flags strip**: Added a new top section displaying all currently enabled flags with quick-access chips
  - Chips show flag label and category icon
  - Click to jump to flag in the detail pane
  - Delete button to quickly disable flags
- **Category sidebar**: 
  - Clickable category buttons with icons and active flag counts
  - Visual indicator (left border + highlight) for selected category
  - Icons for known categories (IDE, OpenAI, HTTP, Response) with fallback for unknown ones
- **Enhanced flag interaction**:
  - Added `jumpToFlag()` to scroll and pulse-highlight a flag when clicked from active strip
  - Added `resetFlag()` helper to clear flag values
  - Added `isFlagActive()` helper to determine if a flag is currently enabled
- **New helper functions**:
  - `categoryMeta()` to provide labels and icons for categories
  - Improved state management with `activeCategory`, `pulseKey`, and `flagRefs`
- **Dialog sizing**: Increased maxWidth from "sm" to "md" to accommodate two-pane layout
- **Removed**: Unused `Divider` import and `CATEGORY_LABEL` constant

### Backend (flag_registry.go)
- **Category reorganization**: Renamed and restructured flag categories for better semantic grouping:
  - `FlagCategoryCompatibility` → `FlagCategoryIDE` (IDE/client-specific flags)
  - `FlagCategoryRequest` split into:
    - `FlagCategoryOpenAI` (OpenAI-specific request shape adjustments)
    - `FlagCategoryHTTP` (transport-level overrides)
  - `FlagCategoryResponse` (unchanged, response body/stream modifications)
- **Updated flag categorization**: Reassigned existing flags to new categories:
  - `cursor_compat*` flags → IDE category
  - `use_max_completion_tokens`, `use_max_tokens` → OpenAI category
  - `custom_user_agent` → HTTP category
- **Added documentation**: Added detailed comments explaining each category's purpose

### Frontend (RuleExtensionsCard.tsx)
- **Improved interaction**: Made entire card clickable (not just the add button)
- **Visual feedback**: Added hover state with primary border and shadow
- **Simplified UI**: Removed separate IconButton, now shows AddIcon as visual affordance only
- **Removed**: Unused `IconButton` import

### Type Updates (FlagCatalogDialog.tsx)
- Added support for `use_max_tokens` flag in `flagToBool()` and `setBool()` functions

## Implementation Details
- Category metadata (labels and icons) is now centralized in `CATEGORY_META` with a fallback function for unknown categories
- The active flags list is computed via `useMemo` to avoid unnecessary recalculations
- Smooth scrolling and pulse animation (1.2s) provide visual feedback when jumping to flags
- Category selection persists within a dialog session and defaults to the first category with content
- The layout uses flexbox with proper overflow handling for both sidebar and detail pane

https://claude.ai/code/session_01Mnf2FeE8ETcnEbhTgZe4uT