### PR TITLE
bugfix(protocol): always emit reasoning_tokens / cached_tokens in Responses usage

### DIFF
--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -361,6 +361,19 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream *openaistrea
 			}
 		}
 
+		// Codex CLI's ResponseCompleted decoder rejects events whose
+		// output_tokens_details lacks reasoning_tokens. Backfill 0 when the
+		// upstream provider (e.g. DeepSeek) omits it.
+		if gjson.Get(eventRaw, "response.usage").Exists() {
+			if !gjson.Get(eventRaw, "response.usage.output_tokens_details.reasoning_tokens").Exists() {
+				if modified, err := sjson.SetRaw(eventRaw, "response.usage.output_tokens_details.reasoning_tokens", "0"); err == nil {
+					eventRaw = modified
+				} else {
+					logrus.WithError(err).Error("Failed to set reasoning tokens")
+				}
+			}
+		}
+
 		if len(eventRaw) > 0 {
 			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
 				if modified, err := sjson.Set(eventRaw, "response.model", responseModel); err == nil {

--- a/internal/protocol/stream/openai_responses_type.go
+++ b/internal/protocol/stream/openai_responses_type.go
@@ -70,12 +70,16 @@ type responsesUsageWire struct {
 	OutputTokensDetails responsesOutputTokensDetailsWire `json:"output_tokens_details,omitempty"`
 }
 
+// Codex CLI's ResponseCompleted decoder requires cached_tokens and
+// reasoning_tokens to be present; omitempty would drop them when zero and
+// cause "missing field 'reasoning_tokens'" parse errors for chat-only
+// providers (e.g. DeepSeek) routed through chat-to-responses.
 type responsesInputTokensDetailsWire struct {
-	CachedTokens int64 `json:"cached_tokens,omitempty"`
+	CachedTokens int64 `json:"cached_tokens"`
 }
 
 type responsesOutputTokensDetailsWire struct {
-	ReasoningTokens int64 `json:"reasoning_tokens,omitempty"`
+	ReasoningTokens int64 `json:"reasoning_tokens"`
 }
 
 type responsesOutputItemAddedEvent struct {


### PR DESCRIPTION
## Summary

Codex CLI's `ResponseCompleted` decoder requires `output_tokens_details.reasoning_tokens` (and `input_tokens_details.cached_tokens`) to be present. With `omitempty` on the wire DTOs, chat-only providers routed through chat-to-responses (e.g. **DeepSeek**) emitted `"output_tokens_details":{}` when `reasoning_tokens` was 0, causing Codex CLI to fail with:

```
failed to parse ResponseCompleted: missing field 'reasoning_tokens'
```

and disconnect mid-stream.

## Changes

- `internal/protocol/stream/openai_responses_type.go`: drop `omitempty` from `CachedTokens` / `ReasoningTokens` in the wire types so zero values are always serialized.
- `internal/protocol/stream/openai_passthrough.go`: mirror the existing `cached_tokens` backfill to also inject `reasoning_tokens=0` when upstream Responses providers omit it.

## Test plan

- [x] `go test ./internal/protocol/...` passes
- [ ] Verify Codex CLI no longer disconnects when targeting DeepSeek through tingly-box

Same fix is also being applied to the v0.260514 hotfix line via #971.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEzjJbwRvLMW3eYT7vAoju)_