### PR TITLE
Sanitize Codex input item IDs in JSON to prevent backend rejection

### DIFF
--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -102,7 +103,75 @@ func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
 	bodyStr, _ = sjson.Delete(bodyStr, "temperature")
 	bodyStr, _ = sjson.Delete(bodyStr, "top_p")
 
+	// Final gate: ChatGPT backend rejects items with empty or non-conforming id.
+	// The SDK-level sanitizer only covers a subset of input item variants, so
+	// scrub the marshaled JSON to catch every variant the SDK may emit.
+	bodyStr = sanitizeCodexInputIDsJSON(bodyStr)
+
 	return []byte(bodyStr), nil
+}
+
+// sanitizeCodexInputIDsJSON walks the input array and removes invalid ids.
+// For types whose id is required, the entire item is dropped (the backend
+// would reject the request anyway). For types whose id is optional, only
+// the id field is removed.
+func sanitizeCodexInputIDsJSON(bodyStr string) string {
+	input := gjson.Get(bodyStr, "input")
+	if !input.IsArray() {
+		return bodyStr
+	}
+
+	items := input.Array()
+	// Iterate in reverse so deletions don't shift earlier indices.
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		idVal := item.Get("id")
+		if !idVal.Exists() {
+			continue
+		}
+		idStr := strings.TrimSpace(idVal.String())
+		if idStr != "" && isValidCodexID(idStr) {
+			continue
+		}
+
+		itemType := item.Get("type").String()
+		path := fmt.Sprintf("input.%d", i)
+		if codexInputItemIDRequired(itemType) {
+			logrus.Warnf("[Codex] Dropping input[%d] of type %q with invalid id %q", i, itemType, idStr)
+			if updated, err := sjson.Delete(bodyStr, path); err == nil {
+				bodyStr = updated
+			}
+		} else {
+			logrus.Debugf("[Codex] Clearing invalid id on input[%d] type %q", i, itemType)
+			if updated, err := sjson.Delete(bodyStr, path+".id"); err == nil {
+				bodyStr = updated
+			}
+		}
+	}
+	return bodyStr
+}
+
+// codexInputItemIDRequired reports whether the given input item type requires
+// the `id` field per the OpenAI Responses API schema. For these types, the
+// SDK marshals an empty id as "" rather than omitting it, and the ChatGPT
+// backend rejects it.
+func codexInputItemIDRequired(itemType string) bool {
+	switch itemType {
+	case "reasoning",
+		"code_interpreter_call",
+		"computer_call",
+		"file_search_call",
+		"web_search_call",
+		"image_generation_call",
+		"local_shell_call",
+		"local_shell_call_output",
+		"mcp_list_tools",
+		"mcp_approval_request",
+		"mcp_call",
+		"item_reference":
+		return true
+	}
+	return false
 }
 
 func rewriteCodexPath(path string) string {

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -197,7 +197,10 @@ func sanitizeResponseInputIDs(req *responses.ResponseNewParams) {
 
 // sanitizeInputItemID sanitizes the ID field in a ResponseInputItemUnionParam
 // by clearing invalid IDs directly on the inner SDK struct fields.
+// Returns false if the item must be dropped entirely (because its required
+// id field is invalid and cannot be omitted).
 func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) bool {
+	// Optional Opt[string] ids: clear when invalid so the SDK omits the field.
 	if item.OfFunctionCall != nil {
 		sanitizeOptID(&item.OfFunctionCall.ID)
 	}
@@ -213,6 +216,26 @@ func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) bool {
 	if item.OfCustomToolCallOutput != nil {
 		sanitizeOptID(&item.OfCustomToolCallOutput.ID)
 	}
+	if item.OfShellCall != nil {
+		sanitizeOptID(&item.OfShellCall.ID)
+	}
+	if item.OfShellCallOutput != nil {
+		sanitizeOptID(&item.OfShellCallOutput.ID)
+	}
+	if item.OfApplyPatchCall != nil {
+		sanitizeOptID(&item.OfApplyPatchCall.ID)
+	}
+	if item.OfApplyPatchCallOutput != nil {
+		sanitizeOptID(&item.OfApplyPatchCallOutput.ID)
+	}
+	if item.OfMcpApprovalResponse != nil {
+		sanitizeOptID(&item.OfMcpApprovalResponse.ID)
+	}
+	if item.OfCompaction != nil {
+		sanitizeOptID(&item.OfCompaction.ID)
+	}
+
+	// Required plain-string ids: cannot be omitted, drop the item if invalid.
 	if item.OfReasoning != nil {
 		item.OfReasoning.ID = strings.TrimSpace(item.OfReasoning.ID)
 		if item.OfReasoning.ID == "" || !isValidCodexID(item.OfReasoning.ID) {
@@ -220,7 +243,58 @@ func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) bool {
 			return false
 		}
 	}
+	if item.OfFileSearchCall != nil && !isValidCodexIDStrict(item.OfFileSearchCall.ID) {
+		logrus.Warnf("[Codex] Dropping file_search_call input item with invalid id: %q", item.OfFileSearchCall.ID)
+		return false
+	}
+	if item.OfComputerCall != nil && !isValidCodexIDStrict(item.OfComputerCall.ID) {
+		logrus.Warnf("[Codex] Dropping computer_call input item with invalid id: %q", item.OfComputerCall.ID)
+		return false
+	}
+	if item.OfWebSearchCall != nil && !isValidCodexIDStrict(item.OfWebSearchCall.ID) {
+		logrus.Warnf("[Codex] Dropping web_search_call input item with invalid id: %q", item.OfWebSearchCall.ID)
+		return false
+	}
+	if item.OfImageGenerationCall != nil && !isValidCodexIDStrict(item.OfImageGenerationCall.ID) {
+		logrus.Warnf("[Codex] Dropping image_generation_call input item with invalid id: %q", item.OfImageGenerationCall.ID)
+		return false
+	}
+	if item.OfCodeInterpreterCall != nil && !isValidCodexIDStrict(item.OfCodeInterpreterCall.ID) {
+		logrus.Warnf("[Codex] Dropping code_interpreter_call input item with invalid id: %q", item.OfCodeInterpreterCall.ID)
+		return false
+	}
+	if item.OfLocalShellCall != nil && !isValidCodexIDStrict(item.OfLocalShellCall.ID) {
+		logrus.Warnf("[Codex] Dropping local_shell_call input item with invalid id: %q", item.OfLocalShellCall.ID)
+		return false
+	}
+	if item.OfLocalShellCallOutput != nil && !isValidCodexIDStrict(item.OfLocalShellCallOutput.ID) {
+		logrus.Warnf("[Codex] Dropping local_shell_call_output input item with invalid id: %q", item.OfLocalShellCallOutput.ID)
+		return false
+	}
+	if item.OfMcpListTools != nil && !isValidCodexIDStrict(item.OfMcpListTools.ID) {
+		logrus.Warnf("[Codex] Dropping mcp_list_tools input item with invalid id: %q", item.OfMcpListTools.ID)
+		return false
+	}
+	if item.OfMcpApprovalRequest != nil && !isValidCodexIDStrict(item.OfMcpApprovalRequest.ID) {
+		logrus.Warnf("[Codex] Dropping mcp_approval_request input item with invalid id: %q", item.OfMcpApprovalRequest.ID)
+		return false
+	}
+	if item.OfMcpCall != nil && !isValidCodexIDStrict(item.OfMcpCall.ID) {
+		logrus.Warnf("[Codex] Dropping mcp_call input item with invalid id: %q", item.OfMcpCall.ID)
+		return false
+	}
+	if item.OfItemReference != nil && !isValidCodexIDStrict(item.OfItemReference.ID) {
+		logrus.Warnf("[Codex] Dropping item_reference input item with invalid id: %q", item.OfItemReference.ID)
+		return false
+	}
 	return true
+}
+
+// isValidCodexIDStrict returns true when id is non-empty (after trimming) and
+// contains only characters accepted by the ChatGPT backend.
+func isValidCodexIDStrict(id string) bool {
+	trimmed := strings.TrimSpace(id)
+	return trimmed != "" && isValidCodexID(trimmed)
 }
 
 func sanitizeOptID(id *param.Opt[string]) {

--- a/internal/client/codex_test.go
+++ b/internal/client/codex_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeCodexInputIDsJSON_DropsRequiredEmptyID(t *testing.T) {
+	body := `{
+		"model": "gpt-5-codex",
+		"input": [
+			{"type": "message", "role": "user", "content": "hello"},
+			{"type": "reasoning", "id": "", "summary": []},
+			{"type": "reasoning", "id": "rs_abc123", "summary": []}
+		]
+	}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 2, "reasoning item with empty id must be dropped")
+	assert.Equal(t, "message", input[0].Get("type").String())
+	assert.Equal(t, "reasoning", input[1].Get("type").String())
+	assert.Equal(t, "rs_abc123", input[1].Get("id").String())
+}
+
+func TestSanitizeCodexInputIDsJSON_ClearsOptionalEmptyID(t *testing.T) {
+	body := `{
+		"input": [
+			{"type": "function_call", "id": "", "call_id": "c1", "name": "f", "arguments": "{}"},
+			{"type": "shell_call", "id": "", "call_id": "c2", "action": {}},
+			{"type": "apply_patch_call", "id": "", "call_id": "c3", "operation": {}}
+		]
+	}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 3, "optional-id items must not be dropped")
+	for _, item := range input {
+		assert.False(t, item.Get("id").Exists(), "empty id should be deleted from item type %s", item.Get("type").String())
+	}
+}
+
+func TestSanitizeCodexInputIDsJSON_DropsInvalidChars(t *testing.T) {
+	body := `{
+		"input": [
+			{"type": "reasoning", "id": "rs/bad chars!", "summary": []},
+			{"type": "function_call", "id": "fc/bad", "call_id": "c1", "name": "f", "arguments": "{}"}
+		]
+	}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 1, "reasoning with invalid chars must be dropped")
+	assert.Equal(t, "function_call", input[0].Get("type").String())
+	assert.False(t, input[0].Get("id").Exists(), "function_call id with invalid chars must be cleared")
+}
+
+func TestSanitizeCodexInputIDsJSON_NoOpWhenAllValid(t *testing.T) {
+	body := `{"input":[{"type":"reasoning","id":"rs_abc","summary":[]},{"type":"function_call","id":"fc_123","call_id":"c","name":"f","arguments":"{}"}]}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	assert.Equal(t, body, out, "valid ids must not be modified")
+}
+
+func TestSanitizeCodexInputIDsJSON_NoInputArray(t *testing.T) {
+	body := `{"model":"gpt-5-codex","input":"hello"}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	assert.Equal(t, body, out, "non-array input must be passed through")
+}
+
+func TestSanitizeCodexInputIDsJSON_WhitespaceOnlyID(t *testing.T) {
+	body := `{"input":[{"type":"function_call_output","id":"   ","call_id":"c1","output":"ok"}]}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 1)
+	assert.False(t, input[0].Get("id").Exists(), "whitespace-only id should be cleared")
+}
+
+func TestSanitizeCodexInputIDsJSON_HighIndex(t *testing.T) {
+	// Mirrors the production failure: input[186].id == ""
+	var items []string
+	for i := 0; i < 186; i++ {
+		items = append(items, `{"type":"message","role":"user","content":"x"}`)
+	}
+	items = append(items, `{"type":"shell_call","id":"","call_id":"c","action":{}}`)
+	body := `{"input":[` + strings.Join(items, ",") + `]}`
+
+	out := sanitizeCodexInputIDsJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 187)
+	assert.False(t, input[186].Get("id").Exists())
+}
+
+func TestCodexInputItemIDRequired(t *testing.T) {
+	required := []string{
+		"reasoning", "code_interpreter_call", "computer_call", "file_search_call",
+		"web_search_call", "image_generation_call", "local_shell_call",
+		"local_shell_call_output", "mcp_list_tools", "mcp_approval_request",
+		"mcp_call", "item_reference",
+	}
+	optional := []string{
+		"function_call", "function_call_output", "shell_call", "shell_call_output",
+		"apply_patch_call", "apply_patch_call_output", "computer_call_output",
+		"custom_tool_call", "custom_tool_call_output", "mcp_approval_response",
+		"compaction", "message", "output_message",
+	}
+	for _, typ := range required {
+		assert.True(t, codexInputItemIDRequired(typ), "type %q should require id", typ)
+	}
+	for _, typ := range optional {
+		assert.False(t, codexInputItemIDRequired(typ), "type %q should not require id", typ)
+	}
+}


### PR DESCRIPTION
## Summary
Add comprehensive validation and sanitization of input item IDs in the Codex API request body to prevent the ChatGPT backend from rejecting requests with invalid or empty IDs.

## Key Changes
- **New JSON-level sanitization**: Added `sanitizeCodexInputIDsJSON()` function that walks the marshaled JSON request body and removes invalid IDs before sending to the backend
  - For input item types with required IDs (e.g., `reasoning`, `code_interpreter_call`), drops the entire item if the ID is invalid
  - For input item types with optional IDs (e.g., `function_call`, `shell_call`), removes only the invalid ID field to let the SDK omit it
  
- **Extended SDK-level sanitization**: Expanded `sanitizeInputItemID()` to cover additional input item types:
  - Added optional ID sanitization for: `shell_call`, `shell_call_output`, `apply_patch_call`, `apply_patch_call_output`, `mcp_approval_response`, `compaction`
  - Added required ID validation for: `file_search_call`, `computer_call`, `web_search_call`, `image_generation_call`, `code_interpreter_call`, `local_shell_call`, `local_shell_call_output`, `mcp_list_tools`, `mcp_approval_request`, `mcp_call`, `item_reference`

- **New helper functions**:
  - `isValidCodexIDStrict()`: Validates that an ID is non-empty (after trimming whitespace) and contains only valid characters
  - `codexInputItemIDRequired()`: Determines whether a given input item type requires the ID field per the OpenAI Responses API schema

- **Comprehensive test coverage**: Added 8 test cases covering:
  - Dropping items with required empty IDs
  - Clearing optional empty IDs
  - Handling invalid characters in IDs
  - Whitespace-only IDs
  - High-index array items (regression test for production failure at input[186])
  - No-op behavior for valid inputs

## Implementation Details
- The JSON-level sanitizer runs as a final gate after SDK marshaling, catching any invalid IDs the SDK may emit
- Iteration over the input array happens in reverse to prevent index shifting during deletions
- Both empty strings and whitespace-only strings are treated as invalid IDs
- Logging distinguishes between dropped items (warning level) and cleared IDs (debug level)

https://claude.ai/code/session_01LRWoCmmqTZVDaukCKyAPP5