### PR TITLE
bugfix(db): missing OpenAIEndpointMode field to provider storage and migration

### DIFF
--- a/internal/data/db/provider_store.go
+++ b/internal/data/db/provider_store.go
@@ -42,6 +42,10 @@ type ProviderRecord struct {
 	APIBaseOpenAI    string `gorm:"column:api_base_openai"`
 	APIBaseAnthropic string `gorm:"column:api_base_anthropic"`
 
+	// OpenAIEndpointMode declares which OpenAI endpoints this provider exposes
+	// ("", "chat", "responses", "both"). See ai.OpenAIEndpointMode.
+	OpenAIEndpointMode string `gorm:"column:openai_endpoint_mode"`
+
 	// Credential fields - stored with provider as a unit
 	// For api_key auth: stores the API key
 	// For oauth auth: stores OAuth access token
@@ -67,19 +71,20 @@ func (ProviderRecord) TableName() string {
 // toProvider converts a ProviderRecord to typ.Provider
 func (r *ProviderRecord) toProvider() *typ.Provider {
 	provider := &typ.Provider{
-		UUID:             r.UUID,
-		Name:             r.Name,
-		APIBase:          r.APIBase,
-		APIStyle:         protocol.APIStyle(r.APIStyle),
-		APIBaseOpenAI:    r.APIBaseOpenAI,
-		APIBaseAnthropic: r.APIBaseAnthropic,
-		AuthType:         typ.AuthType(r.AuthType),
-		Source:           typ.ProviderSource(r.Source),
-		NoKeyRequired:    r.NoKeyRequired,
-		Enabled:          r.Enabled,
-		ProxyURL:         r.ProxyURL,
-		Timeout:          r.Timeout,
-		LastUpdated:      r.LastUpdated,
+		UUID:               r.UUID,
+		Name:               r.Name,
+		APIBase:            r.APIBase,
+		APIStyle:           protocol.APIStyle(r.APIStyle),
+		APIBaseOpenAI:      r.APIBaseOpenAI,
+		APIBaseAnthropic:   r.APIBaseAnthropic,
+		AuthType:           typ.AuthType(r.AuthType),
+		Source:             typ.ProviderSource(r.Source),
+		NoKeyRequired:      r.NoKeyRequired,
+		Enabled:            r.Enabled,
+		ProxyURL:           r.ProxyURL,
+		Timeout:            r.Timeout,
+		LastUpdated:        r.LastUpdated,
+		OpenAIEndpointMode: ai.OpenAIEndpointMode(r.OpenAIEndpointMode),
 	}
 
 	// Parse tags JSON
@@ -120,21 +125,22 @@ func toRecord(p *typ.Provider) *ProviderRecord {
 	now := time.Now()
 
 	record := &ProviderRecord{
-		UUID:             p.UUID,
-		Name:             p.Name,
-		APIBase:          p.APIBase,
-		APIStyle:         string(p.APIStyle),
-		APIBaseOpenAI:    p.APIBaseOpenAI,
-		APIBaseAnthropic: p.APIBaseAnthropic,
-		AuthType:         string(p.AuthType),
-		Source:           string(p.Source),
-		NoKeyRequired:    p.NoKeyRequired,
-		Enabled:          p.Enabled,
-		ProxyURL:         p.ProxyURL,
-		Timeout:          p.Timeout,
-		LastUpdated:      p.LastUpdated,
-		CreatedAt:        now,
-		UpdatedAt:        now,
+		UUID:               p.UUID,
+		Name:               p.Name,
+		APIBase:            p.APIBase,
+		APIStyle:           string(p.APIStyle),
+		APIBaseOpenAI:      p.APIBaseOpenAI,
+		APIBaseAnthropic:   p.APIBaseAnthropic,
+		AuthType:           string(p.AuthType),
+		Source:             string(p.Source),
+		NoKeyRequired:      p.NoKeyRequired,
+		Enabled:            p.Enabled,
+		ProxyURL:           p.ProxyURL,
+		Timeout:            p.Timeout,
+		LastUpdated:        p.LastUpdated,
+		OpenAIEndpointMode: string(p.OpenAIEndpointMode),
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 
 	// Initialize OAuth fields if OAuthDetail exists
@@ -187,6 +193,7 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 	record.ProxyURL = p.ProxyURL
 	record.Timeout = p.Timeout
 	record.LastUpdated = p.LastUpdated
+	record.OpenAIEndpointMode = string(p.OpenAIEndpointMode)
 	record.UpdatedAt = time.Now()
 
 	// Marshal tags to JSON

--- a/internal/data/db/provider_store_test.go
+++ b/internal/data/db/provider_store_test.go
@@ -595,3 +595,48 @@ func TestProviderCount(t *testing.T) {
 		t.Errorf("Expected 5 providers, got %d", count)
 	}
 }
+
+func TestProviderOpenAIEndpointModeRoundTrip(t *testing.T) {
+	store, _ := setupTestProviderStore(t)
+	defer store.Close()
+
+	provider := &typ.Provider{
+		UUID:               "test-endpoint-mode-uuid",
+		Name:               "codex-oauth",
+		APIBase:            "https://chatgpt.com/backend-api/codex",
+		APIStyle:           protocol.APIStyleOpenAI,
+		AuthType:           typ.AuthTypeOAuth,
+		OpenAIEndpointMode: ai.EndpointModeResponses,
+		OAuthDetail: &typ.OAuthDetail{
+			AccessToken: "tok",
+			Issuer:      ai.IssuerCodex,
+			UserID:      "u1",
+		},
+		Enabled: true,
+	}
+
+	if err := store.Save(provider); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.GetByUUID("test-endpoint-mode-uuid")
+	if err != nil {
+		t.Fatalf("GetByUUID: %v", err)
+	}
+	if got.OpenAIEndpointMode != ai.EndpointModeResponses {
+		t.Errorf("OpenAIEndpointMode after create: got %q, want %q", got.OpenAIEndpointMode, ai.EndpointModeResponses)
+	}
+
+	// Update path must also persist the field.
+	got.OpenAIEndpointMode = ai.EndpointModeBoth
+	if err := store.Save(got); err != nil {
+		t.Fatalf("Save update: %v", err)
+	}
+	got2, err := store.GetByUUID("test-endpoint-mode-uuid")
+	if err != nil {
+		t.Fatalf("GetByUUID after update: %v", err)
+	}
+	if got2.OpenAIEndpointMode != ai.EndpointModeBoth {
+		t.Errorf("OpenAIEndpointMode after update: got %q, want %q", got2.OpenAIEndpointMode, ai.EndpointModeBoth)
+	}
+}

--- a/internal/server/config/migration_codex_endpoint_mode.go
+++ b/internal/server/config/migration_codex_endpoint_mode.go
@@ -35,6 +35,29 @@ func migrate20260518(c *Config) {
 		logrus.WithField("provider_uuid", p.UUID).Info("Backfilled openai_endpoint_mode=responses on Codex provider")
 	}
 
+	// Providers live in SQLite (the JSON c.Providers slice is legacy backup).
+	// Backfill the DB-stored ones directly so the resolver sees the right mode.
+	if c.providerStore != nil {
+		if oauthProviders, err := c.providerStore.ListOAuth(); err == nil {
+			for _, p := range oauthProviders {
+				if p.OAuthDetail == nil || p.OAuthDetail.GetIssuer() != ai.IssuerCodex {
+					continue
+				}
+				if p.OpenAIEndpointMode == ai.EndpointModeResponses {
+					continue
+				}
+				p.OpenAIEndpointMode = ai.EndpointModeResponses
+				if err := c.providerStore.Save(p); err != nil {
+					logrus.WithError(err).WithField("provider_uuid", p.UUID).Warn("Failed to backfill openai_endpoint_mode on Codex provider")
+					continue
+				}
+				logrus.WithField("provider_uuid", p.UUID).Info("Backfilled openai_endpoint_mode=responses on Codex provider (db)")
+			}
+		} else {
+			logrus.WithError(err).Warn("Failed to list OAuth providers for openai_endpoint_mode backfill")
+		}
+	}
+
 	c.markMigrationCompleted("20260518")
 	if needsSave {
 		_ = c.Save()


### PR DESCRIPTION
## Summary
This PR adds support for persisting the `OpenAIEndpointMode` field in the provider database schema and ensures proper round-trip serialization/deserialization of this configuration.

## Key Changes
- **Database Schema**: Added `openai_endpoint_mode` column to `ProviderRecord` struct with documentation explaining the field values ("", "chat", "responses", "both")
- **Data Conversion**: Updated `toProvider()` and `toRecord()` functions to map between database string representation and `ai.OpenAIEndpointMode` type
- **Update Path**: Modified `updateRecordFromProvider()` to persist `OpenAIEndpointMode` changes when providers are updated
- **Migration**: Extended migration `20260518` to backfill `openai_endpoint_mode=responses` for Codex OAuth providers stored in the database (in addition to the existing JSON config backfill)
- **Testing**: Added comprehensive test `TestProviderOpenAIEndpointModeRoundTrip` to verify the field persists correctly through both create and update operations

## Implementation Details
- The field is stored as a string in the database and converted to/from the `ai.OpenAIEndpointMode` type during serialization
- The migration handles both legacy JSON-based providers and database-stored OAuth providers
- Struct field alignment was adjusted for consistency during the conversion function updates

https://claude.ai/code/session_017RLDejTzdba1WybNWE9ic5