### PR TITLE
bugfix(client): codex client method missing for nonstream

### DIFF
--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -96,6 +96,9 @@ func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
 
 	bodyStr := string(body)
 
+	// codex require false here
+	bodyStr, _ = sjson.SetRaw(bodyStr, "store", "false")
+
 	// Remove unsupported parameters (ignore errors if key doesn't exist)
 	bodyStr, _ = sjson.Delete(bodyStr, "max_tokens")
 	bodyStr, _ = sjson.Delete(bodyStr, "max_completion_tokens")

--- a/internal/client/codex.go
+++ b/internal/client/codex.go
@@ -98,6 +98,7 @@ func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
 
 	// codex require false here
 	bodyStr, _ = sjson.SetRaw(bodyStr, "store", "false")
+	bodyStr, _ = sjson.SetRaw(bodyStr, "stream", "true")
 
 	// Remove unsupported parameters (ignore errors if key doesn't exist)
 	bodyStr, _ = sjson.Delete(bodyStr, "max_tokens")

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -437,6 +437,77 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 }
 
 // parseImageGenerationStream parses the streaming Responses API response
+// and extracts the generated image data from the output array.
+//
+// The image data comes through two event types:
+// 1. response.image_generation_call.partial_image - streaming partial image chunks
+// 2. response.output_item.done - final status of the image generation call
+func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
+	defer stream.Close()
+
+	var b64JSON string
+	var imageCallID string
+
+	// Collect image data from stream events
+	for stream.Next() {
+		event := stream.Current()
+
+		switch event.Type {
+		case "response.image_generation_call.partial_image":
+			// Partial image chunks during generation
+			partialEvent := event.AsResponseImageGenerationCallPartialImage()
+			if partialEvent.PartialImageB64 != "" {
+				b64JSON += partialEvent.PartialImageB64
+				imageCallID = partialEvent.ItemID
+				logrus.Debugf("[Codex] Received partial image chunk, item_id: %s, total_size: %d",
+					partialEvent.ItemID, len(b64JSON))
+			}
+
+		case "response.output_item.done":
+			// Final status of output items
+			doneEvent := event.AsResponseOutputItemDone()
+			item := doneEvent.Item
+
+			if item.Type == "image_generation_call" {
+				imageCall := item.AsImageGenerationCall()
+				// Check for image result in the done event
+				// The status can be "generating", "completed", or other values
+				// If we haven't received partial images, use the Result field
+				if b64JSON == "" && imageCall.Result != "" {
+					b64JSON = imageCall.Result
+					imageCallID = imageCall.ID
+					logrus.Debugf("[Codex] Received image result in done event, id: %s, status: %s",
+						imageCall.ID, imageCall.Status)
+				}
+				// Update imageCallID even if we already have data from partial events
+				if imageCallID == "" {
+					imageCallID = imageCall.ID
+				}
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, fmt.Errorf("stream error: %w", err)
+	}
+
+	if b64JSON == "" {
+		return nil, fmt.Errorf("no image data in response (image_call_id: %s)", imageCallID)
+	}
+
+	logrus.Infof("[Codex] Successfully extracted image data, id: %s, size: %d bytes", imageCallID, len(b64JSON))
+
+	// Build standard ImagesResponse from extracted data
+	return &openai.ImagesResponse{
+		Data: []openai.Image{
+			{
+				B64JSON: b64JSON,
+			},
+		},
+	}, nil
+}
+
+// parseImageGenerationStreamNext parses the streaming Responses API response
 // and extracts the generated image data using the ResponsesAssembler.
 //
 // The image data comes through two event types:
@@ -444,7 +515,7 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 // 2. response.output_item.done - final status of the image generation call
 //
 // Supports multiple images via different output indices.
-func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
+func (c *CodexClient) parseImageGenerationStreamNext(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
 	defer stream.Close()
 
 	// Use assembler to accumulate streaming events

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -15,9 +15,9 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
-	"github.com/tingly-dev/tingly-box/internal/protocol"
-
 	"github.com/tingly-dev/tingly-box/internal/obs"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/assembler"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -90,6 +90,21 @@ func (c *CodexClient) ChatCompletionsNew(ctx context.Context, req openai.ChatCom
 func (c *CodexClient) ChatCompletionsNewStreaming(ctx context.Context, req openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
 	logrus.Errorf("[Codex] Chat Completions Streaming not supported, use Responses API instead")
 	return nil
+}
+
+// ResponsesNew creates a new Responses API request.
+// For Codex, this internally uses streaming mode and assembles the result
+// into a non-streaming Response, as required by the ChatGPT backend API.
+func (c *CodexClient) ResponsesNew(ctx context.Context, req responses.ResponseNewParams) (*responses.Response, error) {
+	// Apply Codex-specific defaults to the request
+	applyCodexDefaultsToParams(&req)
+
+	// Call streaming API
+	stream := c.OpenAIClient.ResponsesNewStreaming(ctx, req)
+	defer stream.Close()
+
+	// Parse streaming response and assemble into non-streaming Response
+	return c.parseResponsesStream(ctx, stream)
 }
 
 // ResponsesNewStreaming creates a new streaming Responses API request with Codex-specific defaults.
@@ -490,6 +505,39 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 			},
 		},
 	}, nil
+}
+
+// parseResponsesStream parses the streaming Responses API response
+// and assembles it into a complete non-streaming Response object using
+// the ResponsesAssembler.
+func (c *CodexClient) parseResponsesStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*responses.Response, error) {
+	defer stream.Close()
+
+	// Use assembler to accumulate streaming events
+	asm := assembler.NewResponsesAssembler()
+
+	for stream.Next() {
+		event := stream.Current()
+		asm.Accumulate(event)
+
+		// Early exit on terminal states
+		if asm.IsFinished() {
+			break
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, fmt.Errorf("stream error: %w", err)
+	}
+
+	// Get the final response from assembler
+	resp := asm.Finish()
+	if resp == nil {
+		return nil, fmt.Errorf("response assembly failed: status=%s", asm.Status())
+	}
+
+	logrus.Debugf("[Codex] Response assembled via assembler, id: %s, status: %s", resp.ID, asm.Status())
+	return resp, nil
 }
 
 // SetRecordSink sets the record sink for the client.

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -442,6 +442,8 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 // The image data comes through two event types:
 // 1. response.image_generation_call.partial_image - streaming partial image chunks
 // 2. response.output_item.done - final status of the image generation call
+//
+// Supports multiple images via different output indices.
 func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
 	defer stream.Close()
 
@@ -462,23 +464,34 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 		return nil, fmt.Errorf("stream error: %w", err)
 	}
 
-	// Get image data from assembler
-	b64JSON := asm.ImageData()
-	imageCallID := asm.ImageCallID()
-
-	if b64JSON == "" {
-		return nil, fmt.Errorf("no image data in response (image_call_id: %s)", imageCallID)
+	// Get all images from assembler
+	imagesMap := asm.Images()
+	if len(imagesMap) == 0 {
+		return nil, fmt.Errorf("no image data in response")
 	}
 
-	logrus.Infof("[Codex] Successfully extracted image data via assembler, id: %s, size: %d bytes", imageCallID, len(b64JSON))
+	// Build ImagesResponse with all images
+	// Sort by output index to maintain order
+	imageCount := asm.ImageCount()
+	data := make([]openai.Image, 0, imageCount)
+	for idx := 0; idx < imageCount; idx++ {
+		b64JSON := asm.ImageDataAt(idx)
+		if b64JSON == "" {
+			logrus.Warnf("[Codex] Missing image data at index %d", idx)
+			continue
+		}
+		data = append(data, openai.Image{
+			B64JSON: b64JSON,
+		})
+	}
 
-	// Build standard ImagesResponse from extracted data
+	if len(data) == 0 {
+		return nil, fmt.Errorf("no valid image data in response")
+	}
+
+	logrus.Infof("[Codex] Successfully extracted %d image(s) via assembler", len(data))
 	return &openai.ImagesResponse{
-		Data: []openai.Image{
-			{
-				B64JSON: b64JSON,
-			},
-		},
+		Data: data,
 	}, nil
 }
 

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -20,6 +23,9 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/assembler"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
+
+// Image generation persistence directory
+const imagePersistDir = ".tingly-image"
 
 // CodexClient wraps OpenAIClient with Codex-specific behaviors.
 // It embeds OpenAIClient to inherit standard OpenAI API functionality,
@@ -118,6 +124,7 @@ func (c *CodexClient) ResponsesNewStreaming(ctx context.Context, req responses.R
 // ImagesGenerate creates a new image generation request.
 // For Codex, this transforms the request to use the Responses API with the image_generation tool,
 // as ChatGPT backend API does not support the standard /images/generations endpoint.
+// Generated images and prompts are persisted to .tingly-image/ directory for debugging.
 func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
 	logrus.Debugf("[Codex] Using Responses API for image generation, model: %s", req.Model)
 
@@ -128,7 +135,15 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 	stream := c.OpenAIClient.ResponsesNewStreaming(ctx, responsesReq)
 
 	// Parse streaming response
-	return c.parseImageGenerationStream(ctx, stream)
+	resp, err := c.parseImageGenerationStream(ctx, stream)
+	if err != nil {
+		return nil, err
+	}
+
+	// Persist images and prompts
+	c.persistImageGeneration(req, resp)
+
+	return resp, nil
 }
 
 // applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
@@ -693,4 +708,76 @@ func (c *CodexClient) ProbeResponsesStream(ctx context.Context, model, message s
 
 	chunksJSON, _ := json.Marshal(chunks)
 	return ToProbeResult(string(chunksJSON), time.Since(startTime).Milliseconds(), c.provider.APIBase+"/responses", true), nil
+}
+
+// persistImageGeneration saves generated images and their prompts to disk.
+// Images are saved as PNG files with base64 data decoded.
+// Prompts are saved as .txt files alongside the images.
+// Files are organized in .tingly-image/ directory by timestamp.
+func (c *CodexClient) persistImageGeneration(req openai.ImageGenerateParams, resp *openai.ImagesResponse) {
+	if resp == nil || len(resp.Data) == 0 {
+		logrus.Warn("[Codex] No image data to persist")
+		return
+	}
+
+	// Create timestamp for this generation
+	timestamp := time.Now().Format("20060102-150405")
+
+	// Create directory: .tingly-image/YYYYMMDD/
+	dateDir := filepath.Join(imagePersistDir, time.Now().Format("20060102"))
+	if err := os.MkdirAll(dateDir, 0755); err != nil {
+		logrus.Errorf("[Codex] Failed to create image directory: %v", err)
+		return
+	}
+
+	// Save each image with its prompt
+	for i, img := range resp.Data {
+		// Generate filename: timestamp-index.png
+		var filename string
+		if i == 0 {
+			filename = fmt.Sprintf("%s.png", timestamp)
+		} else {
+			filename = fmt.Sprintf("%s-%d.png", timestamp, i)
+		}
+		imagePath := filepath.Join(dateDir, filename)
+
+		// Decode base64 and save as PNG
+		imageData, err := base64.StdEncoding.DecodeString(img.B64JSON)
+		if err != nil {
+			logrus.Errorf("[Codex] Failed to decode base64 image data: %v", err)
+			continue
+		}
+
+		if err := os.WriteFile(imagePath, imageData, 0644); err != nil {
+			logrus.Errorf("[Codex] Failed to write image file: %v", err)
+			continue
+		}
+
+		logrus.Infof("[Codex] Saved image to: %s", imagePath)
+
+		// Save prompt as .txt file
+		promptFilename := strings.Replace(filename, ".png", ".txt", 1)
+		promptPath := filepath.Join(dateDir, promptFilename)
+
+		// Build prompt metadata
+		promptContent := fmt.Sprintf("Prompt: %s\n\nModel: %s\nSize: %s\nQuality: %s\nFormat: %s\nTimestamp: %s\n",
+			req.Prompt,
+			req.Model,
+			req.Size,
+			req.Quality,
+			req.ResponseFormat,
+			time.Now().Format(time.RFC3339),
+		)
+
+		if req.Style != "" {
+			promptContent += fmt.Sprintf("Style: %s\n", req.Style)
+		}
+
+		if err := os.WriteFile(promptPath, []byte(promptContent), 0644); err != nil {
+			logrus.Errorf("[Codex] Failed to write prompt file: %v", err)
+			continue
+		}
+
+		logrus.Infof("[Codex] Saved prompt to: %s", promptPath)
+	}
 }

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -437,7 +437,7 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 }
 
 // parseImageGenerationStream parses the streaming Responses API response
-// and extracts the generated image data from the output array.
+// and extracts the generated image data using the ResponsesAssembler.
 //
 // The image data comes through two event types:
 // 1. response.image_generation_call.partial_image - streaming partial image chunks
@@ -445,45 +445,16 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
 	defer stream.Close()
 
-	var b64JSON string
-	var imageCallID string
+	// Use assembler to accumulate streaming events
+	asm := assembler.NewResponsesAssembler()
 
-	// Collect image data from stream events
 	for stream.Next() {
 		event := stream.Current()
+		asm.Accumulate(event)
 
-		switch event.Type {
-		case "response.image_generation_call.partial_image":
-			// Partial image chunks during generation
-			partialEvent := event.AsResponseImageGenerationCallPartialImage()
-			if partialEvent.PartialImageB64 != "" {
-				b64JSON += partialEvent.PartialImageB64
-				imageCallID = partialEvent.ItemID
-				logrus.Debugf("[Codex] Received partial image chunk, item_id: %s, total_size: %d",
-					partialEvent.ItemID, len(b64JSON))
-			}
-
-		case "response.output_item.done":
-			// Final status of output items
-			doneEvent := event.AsResponseOutputItemDone()
-			item := doneEvent.Item
-
-			if item.Type == "image_generation_call" {
-				imageCall := item.AsImageGenerationCall()
-				// Check for image result in the done event
-				// The status can be "generating", "completed", or other values
-				// If we haven't received partial images, use the Result field
-				if b64JSON == "" && imageCall.Result != "" {
-					b64JSON = imageCall.Result
-					imageCallID = imageCall.ID
-					logrus.Debugf("[Codex] Received image result in done event, id: %s, status: %s",
-						imageCall.ID, imageCall.Status)
-				}
-				// Update imageCallID even if we already have data from partial events
-				if imageCallID == "" {
-					imageCallID = imageCall.ID
-				}
-			}
+		// Early exit on terminal states
+		if asm.IsFinished() {
+			break
 		}
 	}
 
@@ -491,11 +462,15 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 		return nil, fmt.Errorf("stream error: %w", err)
 	}
 
+	// Get image data from assembler
+	b64JSON := asm.ImageData()
+	imageCallID := asm.ImageCallID()
+
 	if b64JSON == "" {
 		return nil, fmt.Errorf("no image data in response (image_call_id: %s)", imageCallID)
 	}
 
-	logrus.Infof("[Codex] Successfully extracted image data, id: %s, size: %d bytes", imageCallID, len(b64JSON))
+	logrus.Infof("[Codex] Successfully extracted image data via assembler, id: %s, size: %d bytes", imageCallID, len(b64JSON))
 
 	// Build standard ImagesResponse from extracted data
 	return &openai.ImagesResponse{

--- a/internal/protocol/assembler/openai_responses_assembler.go
+++ b/internal/protocol/assembler/openai_responses_assembler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ResponsesAssembler accumulates OpenAI Responses API streaming events.
-// It focuses on core functionality: text accumulation, tool calls, and final response construction.
+// It focuses on core functionality: text accumulation, tool calls, image generation, and final response construction.
 // Inspired by internal/protocol/stream/anthropic_to_openai_responses.go
 type ResponsesAssembler struct {
 	// Final response when completed
@@ -30,6 +30,11 @@ type ResponsesAssembler struct {
 
 	// Tool call tracking
 	pendingToolCalls map[int]*pendingResponseToolCall
+
+	// Image generation tracking
+	imageData       strings.Builder // Accumulated base64 image data
+	imageCallID     string          // ID of the image generation call
+	imageInProgress bool            // True when image generation is in progress
 }
 
 // pendingResponseToolCall tracks a tool call being assembled from stream chunks
@@ -118,7 +123,19 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 		return true
 
 	case "response.output_item.done":
-		// Item is complete
+		// Item is complete - check for image_generation_call result
+		doneItem := event.Item
+		if doneItem.Type == "image_generation_call" {
+			// Extract result from the done event if we haven't received partial images
+			imgCall := doneItem.AsImageGenerationCall()
+			if a.imageData.Len() == 0 && imgCall.Result != "" {
+				a.imageData.WriteString(imgCall.Result)
+			}
+			if a.imageCallID == "" {
+				a.imageCallID = imgCall.ID
+			}
+			a.imageInProgress = false
+		}
 		return true
 
 	// Content part events
@@ -138,6 +155,26 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 
 	case "response.refusal.done":
 		// delta events already accumulated the refusal; nothing extra to append.
+		return true
+
+	// Image generation events
+	case "response.image_generation_call.in_progress":
+		a.imageInProgress = true
+		a.imageCallID = event.ItemID
+		return true
+
+	case "response.image_generation_call.partial_image":
+		// Accumulate base64 image chunks
+		// Note: Access fields directly from the union, not via AsResponseImageGenerationCallPartialImage()
+		// because the event may not have been unmarshaled from JSON
+		a.imageData.WriteString(event.PartialImageB64)
+		if a.imageCallID == "" {
+			a.imageCallID = event.ItemID
+		}
+		return true
+
+	case "response.image_generation_call.completed":
+		a.imageInProgress = false
 		return true
 
 	// Completion events
@@ -169,11 +206,11 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 	// - response.code_interpreter_call.*
 	// - response.file_search_call.*
 	// - response.web_search_call.*
-	// - response.image_generation_call.*
 	// - response.mcp_call.*
 	// - response.reasoning.*
 	// - response.output_text.annotation.added
 	// - response.custom_tool_call_input.delta/done
+	// - response.image_generation_call.generating
 
 	default:
 		// Silently ignore unsupported events
@@ -320,4 +357,27 @@ func (a *ResponsesAssembler) SetResponseID(id string) {
 // SetItemID sets a custom item ID.
 func (a *ResponsesAssembler) SetItemID(id string) {
 	a.itemID = id
+}
+
+// ImageData returns the accumulated base64 image data.
+// Returns empty string if no image data was accumulated.
+func (a *ResponsesAssembler) ImageData() string {
+	if a == nil {
+		return ""
+	}
+	return a.imageData.String()
+}
+
+// ImageCallID returns the image generation call ID.
+// Returns empty string if no image generation was tracked.
+func (a *ResponsesAssembler) ImageCallID() string {
+	if a == nil {
+		return ""
+	}
+	return a.imageCallID
+}
+
+// HasImage returns true if image data was accumulated.
+func (a *ResponsesAssembler) HasImage() bool {
+	return a != nil && a.imageData.Len() > 0
 }

--- a/internal/protocol/assembler/openai_responses_assembler.go
+++ b/internal/protocol/assembler/openai_responses_assembler.go
@@ -31,10 +31,14 @@ type ResponsesAssembler struct {
 	// Tool call tracking
 	pendingToolCalls map[int]*pendingResponseToolCall
 
-	// Image generation tracking
-	imageData       strings.Builder // Accumulated base64 image data
-	imageCallID     string          // ID of the image generation call
-	imageInProgress bool            // True when image generation is in progress
+	// Image generation tracking - maps output index to image data
+	images map[int]*pendingImageData
+}
+
+// pendingImageData tracks an image being assembled from stream chunks
+type pendingImageData struct {
+	callID string
+	data   strings.Builder
 }
 
 // pendingResponseToolCall tracks a tool call being assembled from stream chunks
@@ -49,6 +53,7 @@ func NewResponsesAssembler() *ResponsesAssembler {
 	return &ResponsesAssembler{
 		status:           "queued",
 		pendingToolCalls: make(map[int]*pendingResponseToolCall),
+		images:           make(map[int]*pendingImageData),
 		createdAt:        time.Now().Unix(),
 	}
 }
@@ -60,6 +65,7 @@ func NewResponsesAssemblerWithID(responseID, itemID string) *ResponsesAssembler 
 		itemID:           itemID,
 		status:           "queued",
 		pendingToolCalls: make(map[int]*pendingResponseToolCall),
+		images:           make(map[int]*pendingImageData),
 		createdAt:        time.Now().Unix(),
 	}
 }
@@ -128,13 +134,16 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 		if doneItem.Type == "image_generation_call" {
 			// Extract result from the done event if we haven't received partial images
 			imgCall := doneItem.AsImageGenerationCall()
-			if a.imageData.Len() == 0 && imgCall.Result != "" {
-				a.imageData.WriteString(imgCall.Result)
+			idx := int(event.OutputIndex)
+			if a.images[idx] == nil {
+				a.images[idx] = &pendingImageData{}
 			}
-			if a.imageCallID == "" {
-				a.imageCallID = imgCall.ID
+			if a.images[idx].data.Len() == 0 && imgCall.Result != "" {
+				a.images[idx].data.WriteString(imgCall.Result)
 			}
-			a.imageInProgress = false
+			if a.images[idx].callID == "" {
+				a.images[idx].callID = imgCall.ID
+			}
 		}
 		return true
 
@@ -159,22 +168,31 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 
 	// Image generation events
 	case "response.image_generation_call.in_progress":
-		a.imageInProgress = true
-		a.imageCallID = event.ItemID
+		idx := int(event.OutputIndex)
+		if a.images[idx] == nil {
+			a.images[idx] = &pendingImageData{}
+		}
+		a.images[idx].callID = event.ItemID
 		return true
 
 	case "response.image_generation_call.partial_image":
-		// Accumulate base64 image chunks
-		// Note: Access fields directly from the union, not via AsResponseImageGenerationCallPartialImage()
-		// because the event may not have been unmarshaled from JSON
-		a.imageData.WriteString(event.PartialImageB64)
-		if a.imageCallID == "" {
-			a.imageCallID = event.ItemID
+		// Accumulate base64 image chunks for the specific output index
+		idx := int(event.OutputIndex)
+		if a.images[idx] == nil {
+			a.images[idx] = &pendingImageData{}
+		}
+		a.images[idx].data.WriteString(event.PartialImageB64)
+		if a.images[idx].callID == "" {
+			a.images[idx].callID = event.ItemID
 		}
 		return true
 
 	case "response.image_generation_call.completed":
-		a.imageInProgress = false
+		// Mark this image as completed
+		idx := int(event.OutputIndex)
+		if a.images[idx] != nil {
+			// Image is complete, keep the data
+		}
 		return true
 
 	// Completion events
@@ -359,25 +377,60 @@ func (a *ResponsesAssembler) SetItemID(id string) {
 	a.itemID = id
 }
 
-// ImageData returns the accumulated base64 image data.
-// Returns empty string if no image data was accumulated.
-func (a *ResponsesAssembler) ImageData() string {
+// Images returns all accumulated images as a map of output index to image data.
+func (a *ResponsesAssembler) Images() map[int]string {
 	if a == nil {
-		return ""
+		return nil
 	}
-	return a.imageData.String()
+	result := make(map[int]string, len(a.images))
+	for idx, img := range a.images {
+		result[idx] = img.data.String()
+	}
+	return result
 }
 
-// ImageCallID returns the image generation call ID.
-// Returns empty string if no image generation was tracked.
-func (a *ResponsesAssembler) ImageCallID() string {
-	if a == nil {
+// ImageDataAt returns the image data at the specific output index.
+func (a *ResponsesAssembler) ImageDataAt(idx int) string {
+	if a == nil || a.images[idx] == nil {
 		return ""
 	}
-	return a.imageCallID
+	return a.images[idx].data.String()
 }
 
-// HasImage returns true if image data was accumulated.
+// ImageCallIDs returns all image generation call IDs as a map of output index to call ID.
+func (a *ResponsesAssembler) ImageCallIDs() map[int]string {
+	if a == nil {
+		return nil
+	}
+	result := make(map[int]string, len(a.images))
+	for idx, img := range a.images {
+		result[idx] = img.callID
+	}
+	return result
+}
+
+// ImageCallIDAt returns the image call ID at the specific output index.
+func (a *ResponsesAssembler) ImageCallIDAt(idx int) string {
+	if a == nil || a.images[idx] == nil {
+		return ""
+	}
+	return a.images[idx].callID
+}
+
+// ImageCount returns the number of images accumulated.
+func (a *ResponsesAssembler) ImageCount() int {
+	if a == nil {
+		return 0
+	}
+	return len(a.images)
+}
+
+// HasImage returns true if any image data was accumulated.
 func (a *ResponsesAssembler) HasImage() bool {
-	return a != nil && a.imageData.Len() > 0
+	return a != nil && len(a.images) > 0
+}
+
+// HasImageAt returns true if image data was accumulated at the specific output index.
+func (a *ResponsesAssembler) HasImageAt(idx int) bool {
+	return a != nil && a.images[idx] != nil && a.images[idx].data.Len() > 0
 }

--- a/internal/protocol/assembler/openai_responses_assembler_test.go
+++ b/internal/protocol/assembler/openai_responses_assembler_test.go
@@ -387,7 +387,7 @@ func TestResponsesAssembler_UnsupportedEvents(t *testing.T) {
 		"response.file_search_call.searching",
 		"response.web_search_call.in_progress",
 		"response.reasoning_text.delta",
-		"response.image_generation_call.in_progress",
+		"response.image_generation_call.generating",
 		"response.mcp_call.in_progress",
 	}
 
@@ -565,5 +565,149 @@ func TestResponsesAssembler_ToolCalls(t *testing.T) {
 
 	if len(toolCalls) != 0 {
 		t.Errorf("expected 0 tool calls, got %d", len(toolCalls))
+	}
+}
+
+// TestResponsesAssembler_ImageGenerationInProgress tests image generation in_progress event
+func TestResponsesAssembler_ImageGenerationInProgress(t *testing.T) {
+	assembler := NewResponsesAssembler()
+
+	event := responses.ResponseStreamEventUnion{
+		Type:   "response.image_generation_call.in_progress",
+		ItemID: "img-123",
+	}
+
+	if !assembler.Accumulate(event) {
+		t.Error("Accumulate returned false for image_generation_call.in_progress")
+	}
+
+	if assembler.ImageCallID() != "img-123" {
+		t.Errorf("expected image call ID 'img-123', got '%s'", assembler.ImageCallID())
+	}
+
+	if !assembler.imageInProgress {
+		t.Error("imageInProgress should be true")
+	}
+}
+
+// TestResponsesAssembler_ImageGenerationPartialImage tests partial image accumulation
+func TestResponsesAssembler_ImageGenerationPartialImage(t *testing.T) {
+	assembler := NewResponsesAssembler()
+
+	// Simulate partial image chunks
+	events := []responses.ResponseStreamEventUnion{
+		{
+			Type:              "response.image_generation_call.partial_image",
+			ItemID:            "img-123",
+			OutputIndex:       0,
+			PartialImageB64:   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+			PartialImageIndex: 0,
+		},
+		{
+			Type:              "response.image_generation_call.partial_image",
+			ItemID:            "img-123",
+			OutputIndex:       0,
+			PartialImageB64:   "CAYAAAADRsF0YAAAAZElEQVQoz2NgQAUc",
+			PartialImageIndex: 1,
+		},
+	}
+
+	for _, event := range events {
+		if !assembler.Accumulate(event) {
+			t.Error("Accumulate returned false for partial_image event")
+		}
+	}
+
+	expected := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAADRsF0YAAAAZElEQVQoz2NgQAUc"
+	if assembler.ImageData() != expected {
+		t.Errorf("expected image data '%s', got '%s'", expected, assembler.ImageData())
+	}
+
+	if !assembler.HasImage() {
+		t.Error("HasImage should return true")
+	}
+}
+
+// TestResponsesAssembler_ImageGenerationCompleted tests completion event
+func TestResponsesAssembler_ImageGenerationCompleted(t *testing.T) {
+	assembler := NewResponsesAssembler()
+
+	event := responses.ResponseStreamEventUnion{
+		Type: "response.image_generation_call.completed",
+	}
+
+	if !assembler.Accumulate(event) {
+		t.Error("Accumulate returned false for image_generation_call.completed")
+	}
+
+	if assembler.imageInProgress {
+		t.Error("imageInProgress should be false after completed")
+	}
+}
+
+// TestResponsesAssembler_ImageGenerationFullFlow tests complete image generation flow
+func TestResponsesAssembler_ImageGenerationFullFlow(t *testing.T) {
+	assembler := NewResponsesAssembler()
+
+	// Simulate a complete image generation flow
+	events := []responses.ResponseStreamEventUnion{
+		{Type: "response.created", Response: responses.Response{ID: "resp-img-123"}},
+		{Type: "response.in_progress"},
+		{Type: "response.output_item.added", ItemID: "img-123", OutputIndex: 0},
+		{Type: "response.image_generation_call.in_progress", ItemID: "img-123", OutputIndex: 0},
+		{
+			Type:              "response.image_generation_call.partial_image",
+			ItemID:            "img-123",
+			OutputIndex:       0,
+			PartialImageB64:   "base64data1",
+			PartialImageIndex: 0,
+		},
+		{
+			Type:              "response.image_generation_call.partial_image",
+			ItemID:            "img-123",
+			OutputIndex:       0,
+			PartialImageB64:   "base64data2",
+			PartialImageIndex: 1,
+		},
+		{Type: "response.image_generation_call.completed"},
+		{Type: "response.output_item.done"},
+		{Type: "response.completed", Response: responses.Response{
+			ID:     "resp-img-123",
+			Status: "completed",
+			Output: []responses.ResponseOutputItemUnion{},
+		}},
+	}
+
+	for _, event := range events {
+		assembler.Accumulate(event)
+	}
+
+	if assembler.ImageData() != "base64data1base64data2" {
+		t.Errorf("expected concatenated image data, got '%s'", assembler.ImageData())
+	}
+
+	if assembler.ImageCallID() != "img-123" {
+		t.Errorf("expected image call ID 'img-123', got '%s'", assembler.ImageCallID())
+	}
+
+	if !assembler.HasImage() {
+		t.Error("HasImage should return true")
+	}
+}
+
+// TestResponsesAssembler_ImageDataNilSafety tests image data methods with nil assembler
+func TestResponsesAssembler_ImageDataNilSafety(t *testing.T) {
+	var assembler *ResponsesAssembler
+
+	if assembler.ImageData() != "" {
+		t.Error("ImageData should return empty string for nil assembler")
+	}
+
+	if assembler.ImageCallID() != "" {
+		t.Error("ImageCallID should return empty string for nil assembler")
+	}
+
+	if assembler.HasImage() {
+		t.Error("HasImage should return false for nil assembler")
 	}
 }

--- a/internal/protocol/assembler/openai_responses_assembler_test.go
+++ b/internal/protocol/assembler/openai_responses_assembler_test.go
@@ -573,20 +573,21 @@ func TestResponsesAssembler_ImageGenerationInProgress(t *testing.T) {
 	assembler := NewResponsesAssembler()
 
 	event := responses.ResponseStreamEventUnion{
-		Type:   "response.image_generation_call.in_progress",
-		ItemID: "img-123",
+		Type:        "response.image_generation_call.in_progress",
+		ItemID:      "img-123",
+		OutputIndex: 0,
 	}
 
 	if !assembler.Accumulate(event) {
 		t.Error("Accumulate returned false for image_generation_call.in_progress")
 	}
 
-	if assembler.ImageCallID() != "img-123" {
-		t.Errorf("expected image call ID 'img-123', got '%s'", assembler.ImageCallID())
+	if assembler.ImageCallIDAt(0) != "img-123" {
+		t.Errorf("expected image call ID 'img-123', got '%s'", assembler.ImageCallIDAt(0))
 	}
 
-	if !assembler.imageInProgress {
-		t.Error("imageInProgress should be true")
+	if assembler.ImageCount() != 1 {
+		t.Errorf("expected ImageCount 1, got %d", assembler.ImageCount())
 	}
 }
 
@@ -619,12 +620,16 @@ func TestResponsesAssembler_ImageGenerationPartialImage(t *testing.T) {
 	}
 
 	expected := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAADRsF0YAAAAZElEQVQoz2NgQAUc"
-	if assembler.ImageData() != expected {
-		t.Errorf("expected image data '%s', got '%s'", expected, assembler.ImageData())
+	if assembler.ImageDataAt(0) != expected {
+		t.Errorf("expected image data '%s', got '%s'", expected, assembler.ImageDataAt(0))
 	}
 
 	if !assembler.HasImage() {
 		t.Error("HasImage should return true")
+	}
+
+	if !assembler.HasImageAt(0) {
+		t.Error("HasImageAt(0) should return true")
 	}
 }
 
@@ -633,15 +638,17 @@ func TestResponsesAssembler_ImageGenerationCompleted(t *testing.T) {
 	assembler := NewResponsesAssembler()
 
 	event := responses.ResponseStreamEventUnion{
-		Type: "response.image_generation_call.completed",
+		Type:        "response.image_generation_call.completed",
+		OutputIndex: 0,
 	}
 
 	if !assembler.Accumulate(event) {
 		t.Error("Accumulate returned false for image_generation_call.completed")
 	}
 
-	if assembler.imageInProgress {
-		t.Error("imageInProgress should be false after completed")
+	// After completed, image should still be tracked (if it was added before)
+	if assembler.ImageCount() != 0 {
+		t.Error("ImageCount should be 0 since no image was added")
 	}
 }
 
@@ -682,16 +689,20 @@ func TestResponsesAssembler_ImageGenerationFullFlow(t *testing.T) {
 		assembler.Accumulate(event)
 	}
 
-	if assembler.ImageData() != "base64data1base64data2" {
-		t.Errorf("expected concatenated image data, got '%s'", assembler.ImageData())
+	if assembler.ImageDataAt(0) != "base64data1base64data2" {
+		t.Errorf("expected concatenated image data, got '%s'", assembler.ImageDataAt(0))
 	}
 
-	if assembler.ImageCallID() != "img-123" {
-		t.Errorf("expected image call ID 'img-123', got '%s'", assembler.ImageCallID())
+	if assembler.ImageCallIDAt(0) != "img-123" {
+		t.Errorf("expected image call ID 'img-123', got '%s'", assembler.ImageCallIDAt(0))
 	}
 
 	if !assembler.HasImage() {
 		t.Error("HasImage should return true")
+	}
+
+	if !assembler.HasImageAt(0) {
+		t.Error("HasImageAt(0) should return true")
 	}
 }
 
@@ -699,15 +710,110 @@ func TestResponsesAssembler_ImageGenerationFullFlow(t *testing.T) {
 func TestResponsesAssembler_ImageDataNilSafety(t *testing.T) {
 	var assembler *ResponsesAssembler
 
-	if assembler.ImageData() != "" {
-		t.Error("ImageData should return empty string for nil assembler")
+	if assembler.ImageDataAt(0) != "" {
+		t.Error("ImageDataAt should return empty string for nil assembler")
 	}
 
-	if assembler.ImageCallID() != "" {
-		t.Error("ImageCallID should return empty string for nil assembler")
+	if assembler.ImageCallIDAt(0) != "" {
+		t.Error("ImageCallIDAt should return empty string for nil assembler")
+	}
+
+	if assembler.Images() != nil {
+		t.Error("Images should return nil for nil assembler")
+	}
+
+	if assembler.ImageCallIDs() != nil {
+		t.Error("ImageCallIDs should return nil for nil assembler")
 	}
 
 	if assembler.HasImage() {
 		t.Error("HasImage should return false for nil assembler")
+	}
+
+	if assembler.HasImageAt(0) {
+		t.Error("HasImageAt should return false for nil assembler")
+	}
+
+	if assembler.ImageCount() != 0 {
+		t.Error("ImageCount should return 0 for nil assembler")
+	}
+}
+
+// TestResponsesAssembler_MultipleImages tests multiple image generation
+func TestResponsesAssembler_MultipleImages(t *testing.T) {
+	assembler := NewResponsesAssembler()
+
+	// Simulate multiple images being generated
+	events := []responses.ResponseStreamEventUnion{
+		{Type: "response.created", Response: responses.Response{ID: "resp-multi-123"}},
+		{Type: "response.in_progress"},
+
+		// First image (index 0)
+		{Type: "response.output_item.added", ItemID: "img-0", OutputIndex: 0},
+		{Type: "response.image_generation_call.in_progress", ItemID: "img-0", OutputIndex: 0},
+		{Type: "response.image_generation_call.partial_image", ItemID: "img-0", OutputIndex: 0, PartialImageB64: "image0_part1", PartialImageIndex: 0},
+		{Type: "response.image_generation_call.partial_image", ItemID: "img-0", OutputIndex: 0, PartialImageB64: "image0_part2", PartialImageIndex: 1},
+		{Type: "response.image_generation_call.completed", OutputIndex: 0},
+		{Type: "response.output_item.done", OutputIndex: 0},
+
+		// Second image (index 1)
+		{Type: "response.output_item.added", ItemID: "img-1", OutputIndex: 1},
+		{Type: "response.image_generation_call.in_progress", ItemID: "img-1", OutputIndex: 1},
+		{Type: "response.image_generation_call.partial_image", ItemID: "img-1", OutputIndex: 1, PartialImageB64: "image1_part1", PartialImageIndex: 0},
+		{Type: "response.image_generation_call.partial_image", ItemID: "img-1", OutputIndex: 1, PartialImageB64: "image1_part2", PartialImageIndex: 1},
+		{Type: "response.image_generation_call.completed", OutputIndex: 1},
+		{Type: "response.output_item.done", OutputIndex: 1},
+
+		{Type: "response.completed", Response: responses.Response{
+			ID:     "resp-multi-123",
+			Status: "completed",
+			Output: []responses.ResponseOutputItemUnion{},
+		}},
+	}
+
+	for _, event := range events {
+		assembler.Accumulate(event)
+	}
+
+	if assembler.ImageCount() != 2 {
+		t.Errorf("expected 2 images, got %d", assembler.ImageCount())
+	}
+
+	// Check first image
+	if assembler.ImageDataAt(0) != "image0_part1image0_part2" {
+		t.Errorf("expected 'image0_part1image0_part2' at index 0, got '%s'", assembler.ImageDataAt(0))
+	}
+	if assembler.ImageCallIDAt(0) != "img-0" {
+		t.Errorf("expected call ID 'img-0' at index 0, got '%s'", assembler.ImageCallIDAt(0))
+	}
+
+	// Check second image
+	if assembler.ImageDataAt(1) != "image1_part1image1_part2" {
+		t.Errorf("expected 'image1_part1image1_part2' at index 1, got '%s'", assembler.ImageDataAt(1))
+	}
+	if assembler.ImageCallIDAt(1) != "img-1" {
+		t.Errorf("expected call ID 'img-1' at index 1, got '%s'", assembler.ImageCallIDAt(1))
+	}
+
+	// Check Images() map
+	imagesMap := assembler.Images()
+	if len(imagesMap) != 2 {
+		t.Errorf("expected 2 images in map, got %d", len(imagesMap))
+	}
+
+	// Check ImageCallIDs() map
+	idsMap := assembler.ImageCallIDs()
+	if len(idsMap) != 2 {
+		t.Errorf("expected 2 call IDs in map, got %d", len(idsMap))
+	}
+
+	// Verify first image data at index 0
+	if assembler.ImageDataAt(0) != "image0_part1image0_part2" {
+		t.Errorf("expected 'image0_part1image0_part2' at index 0, got '%s'", assembler.ImageDataAt(0))
+	}
+
+	// Verify first call ID at index 0
+	if assembler.ImageCallIDAt(0) != "img-0" {
+		t.Errorf("expected 'img-0' at index 0, got '%s'", assembler.ImageCallIDAt(0))
 	}
 }


### PR DESCRIPTION
In some cases, a client may request Codex via a non-stream request. 
The Codex client does not support non-stream requests, which breaks Codex streaming and field limitations.

This PR updates the OpenAI responses assembler to fix this issue and also includes image processing.

Furthermore, this PR adds persistent for image gen and keep to use codex special imagegen assembler.