### PR TITLE
refactor(server): move cursor_compat into the transform chain

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -57,23 +57,25 @@
    │  inbound handler (openai.go / openai_responses.go /            │
    │                   anthropic_v1.go / anthropic_beta.go)         │
    │                                                                │
-   │   flags := resolveRuleFlags(rule)                              │
+   │   flags := resolveRuleFlags(c, rule)                           │
    │   ├─ WithCustomUserAgent(ctx, flags.CustomUserAgent)           │  Type 2
    │   ├─ reqCtx.Extra["skip_usage"] = flags.SkipUsage              │  Type 3
-   │   ├─ applyCursorCompatFlag(req, cursorCompat)                  │  Type 1a
-   │   └─ extras := ruleExtraTransforms(flags)                      │  Type 1b
+   │   ├─ preBase := rulePreBaseTransforms(flags)                   │  Type 1b-pre
+   │   │   → [transform.OpenAICursorCompatTransform{}]              │
+   │   └─ extras := ruleExtraTransforms(flags)                      │  Type 1b-post
    │       → [transform.OpenAIMaxTokensRewriteTransform{...}]       │
    └───────────────────────────┬───────────────────────────────────┘
                                │
                                ▼
    ┌───────────────────────────────────────────────────────────────┐
-   │   transformXxxx(..., extras...) :                              │
+   │   transformXxxx(..., preBase, extras...) :                     │
    │     chain := BuildTransformChain(...)                          │
+   │     prependPreBaseTransforms(chain, preBase)                   │
    │     appendExtraTransforms(chain, extras)                       │
    │     chain.Execute(ctx)                                         │
    │                                                                │
-   │     Base  →  MCP  →  Consistency  →  Vendor  →  extras         │
-   │                                              (post-base stages)│
+   │     preBase → Base → MCP → Consistency → Vendor → extras       │
+   │   (pre-base stages)                       (post-base stages)   │
    └───────────────────────────┬───────────────────────────────────┘
                                ▼
                        upstream provider
@@ -118,8 +120,8 @@ func RuleFlagRegistry() []FlagSpec { … }
 
 | Key | Type | 类别 | 作用 | 注入点 |
 |-----|------|------|------|--------|
-| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + 工具门控 + stream usage 抑制 | `cursor_compat.go`（Type 1a，pre-chain mutation）|
-| `cursor_compat_auto` | bool | compatibility | 通过请求头识别 Cursor，自动启用 cursor_compat | `cursor_compat.go::resolveCursorCompat` |
+| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + stream usage 抑制 | `transform.OpenAICursorCompatTransform` → `ops.ApplyCursorCompatContentNormalization`（Type 1b-pre：pre-Base chain stage）|
+| `cursor_compat_auto` | bool | compatibility | 通过请求头识别 Cursor，自动折叠进 `cursor_compat` | `resolveRuleFlags(c, rule)` 在 handler 入口合并 |
 | `skip_usage` | bool | response | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)`（Type 3）|
 | `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `transform.OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite`（Type 1b）|
 | `use_max_tokens` | bool | request | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b）|
@@ -131,15 +133,18 @@ func RuleFlagRegistry() []FlagSpec { … }
 ## 5. 五种 flag 注入手法
 
 ```
-Type 1a  Request body, pre-chain mutation
-         在 handler 入口直接 mutate inbound 请求或往 ExtraFields 写
-         hint。例：cursor_compat 在 openai.go 入口写
-         __tb_cursor_compat=true。
+Type 1b-pre  Request body, pre-Base Transform
+         作为 Transform 接口的实现 prepend 到 chain 最前（BaseTransform
+         之前）运行；type-switch 决定是否对 inbound request 形态生效。
+         例：OpenAICursorCompatTransform —— 在 Base 把 OpenAI Chat 转
+         成其他形态之前 flatten 富文本内容。聚合点：
+         `internal/server/rule_flags.go::rulePreBaseTransforms`。
 
-Type 1b  Request body, post-base Transform（推荐）
-         作为 Transform 接口的实现挂在 chain 中，在 BaseTransform 完
-         成协议转换之后运行；type-switch 决定是否对当前 request 形态
-         生效。例：OpenAIMaxTokensRewriteTransform。
+Type 1b-post Request body, post-Base Transform（推荐用于跨协议 rewrite）
+         作为 Transform 接口的实现 append 到 chain 末尾，在 BaseTransform
+         完成协议转换之后运行；type-switch 决定是否对目标 request 形态
+         生效。例：OpenAIMaxTokensRewriteTransform。聚合点：
+         `internal/server/rule_flags.go::ruleExtraTransforms`。
 
 Type 2   Per-request context hint
          handler 把 c.Request 的 ctx 替换成带 hint 的；transport /
@@ -158,18 +163,21 @@ Type 4   Routing-decision input
          ctx。例：openai_endpoint_override。
 ```
 
-任何新 flag 都应归入这五类之一。
+任何新 flag 都应归入这几类之一。pre-Base 和 post-Base Transform 都是同一
+个 `Transform` 接口的实现，区别只在 chain 中的位置：pre 在 BaseTransform
+之前（看见 inbound 形态），post 在之后（看见目标形态）。聚合点
+`rulePreBaseTransforms` / `ruleExtraTransforms` 决定 flag 装哪边。
 
 ---
 
 ## 6. op vs Transform —— Type 1b 内部的分层
 
-Type 1b（post-base Transform）涉及两层抽象，**职责必须分开**：
+Type 1b（pre-Base 与 post-Base 同形）涉及两层抽象，**职责必须分开**：
 
 | 层 | 位置 | 职责 | 例子 |
 |----|------|------|------|
-| **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数。对某个具体 request 类型做无副作用的字段改写。**不感知链路、不感知 rule、不感知 ctx**。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)` |
-| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口。构造期接受配置；`Apply()` 里 type-switch `ctx.Request`，匹配目标类型时调 op。**仅依赖协议层 / SDK 类型**。 | `transform.OpenAIMaxTokensRewriteTransform`（接受 `UseMaxCompletionTokens`、`UseMaxTokens` 两个 bool）|
+| **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数。对某个具体 request 类型做无副作用的字段改写。**不感知链路、不感知 rule、不感知 ctx**。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)`、`ops.ApplyCursorCompatContentNormalization(*openai.ChatCompletionNewParams)` |
+| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口。构造期接受配置；`Apply()` 里 type-switch `ctx.Request`，匹配目标类型时调 op。**仅依赖协议层 / SDK 类型**。pre/post 之分由聚合点（`rulePreBaseTransforms` / `ruleExtraTransforms`）决定，与 Transform 实现本身无关。 | `transform.OpenAIMaxTokensRewriteTransform`、`transform.OpenAICursorCompatTransform` |
 | **Transform（链路阶段，server-domain）** | `internal/server/transform_*.go` | 同 Transform 接口，但需要 server-domain 类型（如 `*typ.ScenarioConfig`）。 | `ThinkingModeTransform`、`MaxTokensTransform`（Anthropic 上限）、`CleanHeaderTransform` |
 
 **为什么必须分两层？**
@@ -178,9 +186,13 @@ Type 1b（post-base Transform）涉及两层抽象，**职责必须分开**：
   Google）。如果在链外直接改 inbound 请求，遇到 "Anthropic inbound →
   OpenAI Chat target" 的路径，改的还是 Anthropic 形态，rewrite 在
   Base 转换之后就丢失。
-- 把 rewrite 包成一个 Transform 并加在 Base **之后**，它看见的是已经
-  转换好的 `*openai.ChatCompletionNewParams`——无论 inbound 是什么形
-  态，目标是 OpenAI Chat 时就能命中。
+- 把 rewrite 包成一个 Transform 并加在 Base **之后**（post-Base），它
+  看见的是已经转换好的 `*openai.ChatCompletionNewParams`——无论 inbound
+  是什么形态，目标是 OpenAI Chat 时就能命中。`max_tokens` 走这条。
+- 反过来，如果 mutation 的语义就是"在 inbound 形态上做归一化"，则放
+  Base **之前**（pre-Base）。`cursor_compat` 走这条：cursor IDE 只发
+  OpenAI Chat，归一化只在 inbound=Chat 时有意义；放 post-Base 反而要
+  对每个目标形态各写一遍 op。
 - op 是纯函数：可以独立单测（含 wire 序列化）、可以被多个 Transform
   复用、可以被多端调用而不被 chain 绑死。
 
@@ -196,34 +208,42 @@ Type 1b（post-base Transform）涉及两层抽象，**职责必须分开**：
 ## 7. 链路 wiring
 
 ```
-handler                         transformXxxx                       chain
-  │                                  │                                │
-  │ flags := resolveRuleFlags(rule)  │                                │
-  │ extras := ruleExtraTransforms(   │                                │
-  │             flags)               │                                │
-  │  (e.g. [OpenAIMaxTokensRewrite]) │                                │
-  ├──────── extras... ──────────────►│                                │
-  │                                  │  chain := BuildTransformChain  │
-  │                                  │           (...)                │
-  │                                  ├──────────────────────────────►│
-  │                                  │  appendExtraTransforms(        │
-  │                                  │      chain, extraTransforms)   │
-  │                                  │  chain.Execute(ctx)            │
-  │                                  ├──────────────────────────────►│
+handler                            transformXxxx                       chain
+  │                                     │                                │
+  │ flags  := resolveRuleFlags(c, rule) │                                │
+  │ preBase:= rulePreBaseTransforms(    │                                │
+  │             flags)                  │                                │
+  │  (e.g. [OpenAICursorCompat])        │                                │
+  │ extras := ruleExtraTransforms(      │                                │
+  │             flags)                  │                                │
+  │  (e.g. [OpenAIMaxTokensRewrite])    │                                │
+  ├──────── preBase, extras... ────────►│                                │
+  │                                     │  chain := BuildTransformChain  │
+  │                                     │           (...)                │
+  │                                     ├──────────────────────────────►│
+  │                                     │  prependPreBaseTransforms(     │
+  │                                     │      chain, preBase)           │
+  │                                     │  appendExtraTransforms(        │
+  │                                     │      chain, extraTransforms)   │
+  │                                     │  chain.Execute(ctx)            │
+  │                                     ├──────────────────────────────►│
 ```
 
 关键约束：
 
 - `BuildTransformChain` 不感知 rule flag。它的输入是 scenario / provider
-  / recording——把哪些 rule-extra Transform 要追加的决策留给 handler。
+  / recording——把哪些 rule Transform 要 prepend / append 的决策留给
+  handler。
 - 所有 4 个 `transformXxxx`（`transformAnthropicV1`、
   `transformAnthropicBeta`、`transformOpenAIChat`、
-  `transformOpenAIResponses`）都接受 variadic
-  `extraTransforms ...transform.Transform`，并用
-  `appendExtraTransforms(chain, extras)` 把它们追加到 chain 末尾。
-- `ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform`
-  （`internal/server/rule_flags.go`）是 rule→Transform 的唯一聚合点。新
-  增 rule-driven Transform 都在这里追加返回值，handler 端不需要再加调用。
+  `transformOpenAIResponses`）都接受一个 `preBaseTransforms []transform.Transform`
+  位置参数 + variadic `extraTransforms ...transform.Transform`，分别用
+  `prependPreBaseTransforms(chain, preBase)` 和
+  `appendExtraTransforms(chain, extras)` 装到 chain 两端。
+- `rulePreBaseTransforms(flags)` 和 `ruleExtraTransforms(flags)`
+  （`internal/server/rule_flags.go`）是 rule→Transform 的两个聚合点。
+  新增 rule-driven Transform 时，按"作用于 inbound 形态" / "作用于目标
+  形态"二选一，往对应聚合点追加 case；handler 端不需要改动。
 
 ---
 
@@ -335,10 +355,7 @@ Extensions Card 操作。
 3. 选定 §5 的注入类型，落地行为：
 
    ┌─────────────────────────────────────────────────────────────┐
-   │ Type 1a (pre-chain 请求 mutation)                            │
-   │   handler 入口直接调 helper，例：cursor_compat              │
-   │                                                              │
-   │ Type 1b (post-base Transform — 推荐)                         │
+   │ Type 1b (Transform — 推荐)                                   │
    │   ① internal/protocol/transform/ops/<xxx>.go：写 op 原语，    │
    │      签名形如 ApplyXxx(*openai.ChatCompletionNewParams) 或    │
    │      其他具体 request 类型。op 必须纯函数、无 rule 感知。     │
@@ -346,10 +363,13 @@ Extensions Card 操作。
    │      构造期接受配置，Apply() 里 type-switch ctx.Request，     │
    │      匹配目标类型时调 op。如需 server-domain 类型才放到       │
    │      internal/server/ 下。                                    │
-   │   ③ internal/server/rule_flags.go::ruleExtraTransforms：     │
-   │      根据 flag 决定是否 append 新 Transform。                 │
+   │   ③ pre-Base / post-Base 二选一：                             │
+   │      • 作用于 inbound 形态（cursor_compat 类）→               │
+   │        internal/server/rule_flags.go::rulePreBaseTransforms   │
+   │      • 作用于目标形态（max_tokens 类）→                       │
+   │        internal/server/rule_flags.go::ruleExtraTransforms     │
    │   ④ handler 端无需改动——4 个 handler 都已调                  │
-   │      ruleExtraTransforms(resolveRuleFlags(rule))...           │
+   │      rulePreBaseTransforms(flags) / ruleExtraTransforms(flags)│
    │                                                              │
    │ Type 2 (context-passed hint)                                 │
    │   ① 在 internal/typ/id.go 加 contextKey + 一对                │
@@ -367,8 +387,11 @@ Extensions Card 操作。
    ├─ op 单元测试 → 与 op 同包 (`internal/protocol/transform/ops/`)
    ├─ Transform 行为测试 → 与 Transform 同包
    │     必备 case：在目标 request 类型上启用 / 在其他类型上 no-op /
-   │              chain 中跟一个 stub BaseTransform，验证 post-base
-   │              形态生效（这是 max_tokens 的回归测试模式）。
+   │              chain 中配合 stub BaseTransform 验证位置正确：
+   │              • post-Base：跟在 stub Base 之后，验证目标形态生效
+   │                （max_tokens 模式）。
+   │              • pre-Base：跟在 stub Base 之前，验证 inbound 形态
+   │                生效（cursor_compat 模式）。
    └─ wire 序列化测试（仅对改字段名的 op 有意义）：marshal 前后断言
        JSON 顶层 key 出现/消失，挡 SDK omitzero tag 失效。
 
@@ -420,11 +443,12 @@ Extensions Card 操作。
 - **UI**：string flag 加独立 enable Switch，让"空"与"未启用"可区分。
 - **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时
   会拥挤）。
-- **后端**：`cursor_compat` 内容归一化目前是 Type 1a（pre-chain，在
-  `openai.go` 入口直接调 `ops.ApplyCursorCompatContentNormalization`）。
-  长期看可以包成 post-base Transform，让 inbound 是 Anthropic 时也能
-  在 Base 转换后正确生效——但与 `max_tokens` 不同，cursor 归一化只对
-  OpenAI 入站才有意义，优先级不高。
+- ~~**后端**：`cursor_compat` 内容归一化目前是 Type 1a（pre-chain）~~。
+  **已完成**：cursor_compat 现在是 Type 1b-pre（pre-Base Transform，
+  `transform.OpenAICursorCompatTransform`），通过
+  `rulePreBaseTransforms` prepend 到 chain 最前；handler 入口的 pre-chain
+  mutation 已移除。Inbound 形态非 OpenAI Chat 时 type-switch 自然 no-op，
+  与 "cursor 归一化只对 OpenAI 入站才有意义" 的设计意图一致。
 - **后端**：`internal/client/openai.go` 通用 OpenAI client 用
   `http.DefaultTransport` 而非 `createSessionBoundTransport`，没有走
   transport pool / session 隔离——独立问题，不在 rule flag 范畴，但

--- a/ai/protocol.go
+++ b/ai/protocol.go
@@ -55,9 +55,6 @@ type OpenAIConfig struct {
 	// Defaults to "low" when HasThinking is true
 	ReasoningEffort shared.ReasoningEffort
 
-	// CursorCompat indicates Cursor compatibility handling is enabled for this request.
-	CursorCompat bool
-
 	// Future fields can be added here as needed for provider-specific transformations
 }
 

--- a/internal/protocol/transform/base.go
+++ b/internal/protocol/transform/base.go
@@ -301,12 +301,5 @@ func buildOpenAIConfigFromRequest(req *openai.ChatCompletionNewParams) *protocol
 		}
 	}
 
-	// Check for cursor_compat field
-	if cursorCompatRaw, ok := extraFields["cursor_compat"]; ok {
-		if enabled, ok := cursorCompatRaw.(bool); ok && enabled {
-			config.CursorCompat = true
-		}
-	}
-
 	return config
 }

--- a/internal/protocol/transform/openai_cursor_compat.go
+++ b/internal/protocol/transform/openai_cursor_compat.go
@@ -1,0 +1,44 @@
+package transform
+
+import (
+	"github.com/openai/openai-go/v3"
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
+)
+
+// OpenAICursorCompatTransform flattens rich content blocks in OpenAI Chat
+// messages for Cursor-style clients that only accept plain string content.
+//
+// It runs as a pre-Base stage so it sees the inbound request in its original
+// shape — Cursor IDE always sends OpenAI Chat, so the type-switch matches and
+// flattening happens before BaseTransform converts to the target shape.
+// For non-Chat inbound shapes (Anthropic, Responses, Google) it is a no-op:
+// Cursor compatibility is only meaningful when the source-of-truth message
+// structure is OpenAI Chat.
+//
+// The transform is a thin shell — ops.ApplyCursorCompatContentNormalization is
+// the operation primitive; this stage only decides when to invoke it based on
+// the inbound request type.
+//
+// Only added to the chain when the rule's cursor_compat flag is enabled.
+type OpenAICursorCompatTransform struct{}
+
+// NewOpenAICursorCompatTransform creates a new pre-Base cursor compatibility
+// transform.
+func NewOpenAICursorCompatTransform() *OpenAICursorCompatTransform {
+	return &OpenAICursorCompatTransform{}
+}
+
+func (t *OpenAICursorCompatTransform) Name() string {
+	return "openai_cursor_compat"
+}
+
+// Apply flattens rich content on OpenAI Chat requests. For any other shape
+// (Anthropic v1/beta, Responses, Google) it is a no-op.
+func (t *OpenAICursorCompatTransform) Apply(ctx *TransformContext) error {
+	req, ok := ctx.Request.(*openai.ChatCompletionNewParams)
+	if !ok {
+		return nil
+	}
+	ops.ApplyCursorCompatContentNormalization(req)
+	return nil
+}

--- a/internal/protocol/transform/openai_cursor_compat_test.go
+++ b/internal/protocol/transform/openai_cursor_compat_test.go
@@ -1,0 +1,184 @@
+package transform
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// richContentUserMessage builds an OpenAI Chat user message with array-of-parts
+// content — the shape that Cursor-compat is meant to flatten into a plain
+// string.
+func richContentUserMessage(t *testing.T) openai.ChatCompletionMessageParamUnion {
+	t.Helper()
+	msgMap := map[string]any{
+		"role": "user",
+		"content": []any{
+			map[string]any{"type": "text", "text": "hello"},
+			map[string]any{"type": "text", "text": "world"},
+		},
+	}
+	msgBytes, err := json.Marshal(msgMap)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var msg openai.ChatCompletionMessageParamUnion
+	if err := json.Unmarshal(msgBytes, &msg); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	return msg
+}
+
+// messageContent JSON-roundtrips a message and returns its "content" field so
+// tests can assert on the flattened wire shape regardless of which variant
+// (OfUser, OfSystem, …) carries the data.
+func messageContent(t *testing.T, msg openai.ChatCompletionMessageParamUnion) any {
+	t.Helper()
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	return m["content"]
+}
+
+func TestOpenAICursorCompatTransform_Name(t *testing.T) {
+	tf := NewOpenAICursorCompatTransform()
+	if tf.Name() != "openai_cursor_compat" {
+		t.Errorf("unexpected name: %q", tf.Name())
+	}
+}
+
+func TestOpenAICursorCompatTransform_FlattensOpenAIChatContent(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			richContentUserMessage(t),
+		},
+	}
+	ctx := &TransformContext{Request: req}
+
+	tf := NewOpenAICursorCompatTransform()
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	got := messageContent(t, req.Messages[0])
+	str, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected flattened string content, got %T (%v)", got, got)
+	}
+	if str != "hello\nworld" {
+		t.Errorf("unexpected flattened content: %q", str)
+	}
+}
+
+func TestOpenAICursorCompatTransform_NoOpOnAnthropicV1(t *testing.T) {
+	req := &anthropic.MessageNewParams{MaxTokens: 1024}
+	ctx := &TransformContext{Request: req}
+
+	tf := NewOpenAICursorCompatTransform()
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if req.MaxTokens != 1024 {
+		t.Errorf("Anthropic v1 request unexpectedly modified")
+	}
+}
+
+func TestOpenAICursorCompatTransform_NoOpOnAnthropicBeta(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{MaxTokens: 1024}
+	ctx := &TransformContext{Request: req}
+
+	tf := NewOpenAICursorCompatTransform()
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if req.MaxTokens != 1024 {
+		t.Errorf("Anthropic beta request unexpectedly modified")
+	}
+}
+
+func TestOpenAICursorCompatTransform_NoOpOnResponses(t *testing.T) {
+	req := &responses.ResponseNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	tf := NewOpenAICursorCompatTransform()
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	// Responses has no flatten op — verify the transform didn't crash and
+	// didn't try to swap the request type.
+	if _, ok := ctx.Request.(*responses.ResponseNewParams); !ok {
+		t.Errorf("Responses request type unexpectedly swapped")
+	}
+}
+
+func TestOpenAICursorCompatTransform_NilRequest(t *testing.T) {
+	ctx := &TransformContext{Request: nil}
+	tf := NewOpenAICursorCompatTransform()
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("Apply on nil request failed: %v", err)
+	}
+}
+
+// TestOpenAICursorCompatTransform_FiresBeforeBase verifies the intended chain
+// ordering: the transform is meant to flatten inbound OpenAI Chat content
+// before BaseTransform converts it to a target shape. We chain
+// cursor-compat *before* a stub base that "converts" Chat → Chat verbatim,
+// and assert flattening happened on the inbound shape.
+func TestOpenAICursorCompatTransform_FiresBeforeBase(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			richContentUserMessage(t),
+		},
+	}
+	ctx := &TransformContext{Request: req}
+
+	chain := NewTransformChain([]Transform{
+		NewOpenAICursorCompatTransform(),
+		stubBaseTransform{},
+	})
+	if _, err := chain.Execute(ctx); err != nil {
+		t.Fatalf("chain.Execute failed: %v", err)
+	}
+
+	got := messageContent(t, req.Messages[0])
+	str, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected flattened string content, got %T (%v)", got, got)
+	}
+	if str != "hello\nworld" {
+		t.Errorf("unexpected flattened content: %q", str)
+	}
+}
+
+// TestOpenAICursorCompatTransform_NoOpOnAnthropicInbound documents the design
+// boundary: cursor_compat only acts on OpenAI Chat *inbound*. When inbound is
+// Anthropic and base converts it to OpenAI Chat downstream, cursor_compat
+// (placed pre-base) sees Anthropic and skips — matching .design/rule-flags.md
+// §12 "cursor 归一化只对 OpenAI 入站才有意义".
+func TestOpenAICursorCompatTransform_NoOpOnAnthropicInbound(t *testing.T) {
+	original := &anthropic.MessageNewParams{MaxTokens: 4096}
+	ctx := &TransformContext{Request: original}
+
+	chain := NewTransformChain([]Transform{
+		NewOpenAICursorCompatTransform(),
+		stubBaseTransform{},
+	})
+	if _, err := chain.Execute(ctx); err != nil {
+		t.Fatalf("chain.Execute failed: %v", err)
+	}
+
+	// After stub base swap, request is OpenAI Chat shape — but no flattening
+	// happened (no messages to flatten in this fixture, and importantly no
+	// panic / no type-confused mutation on the Anthropic shape).
+	if _, ok := ctx.Request.(*openai.ChatCompletionNewParams); !ok {
+		t.Fatalf("expected OpenAI Chat after stub base, got %T", ctx.Request)
+	}
+}

--- a/internal/protocol/transform/ops/request_openai_deepseek.go
+++ b/internal/protocol/transform/ops/request_openai_deepseek.go
@@ -9,9 +9,6 @@ import (
 // This is required by DeepSeek's and Moonshot's reasoning models
 // The base conversion preserves thinking content in "x_thinking" field
 func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
-	if config.CursorCompat {
-		normalizeCursorContent(req)
-	}
 	for i := range req.Messages {
 		if req.Messages[i].OfAssistant != nil {
 			// Read/write extra fields on OfAssistant (variant level), not on union level.

--- a/internal/protocol/transform/ops/request_openai_extensions.go
+++ b/internal/protocol/transform/ops/request_openai_extensions.go
@@ -205,11 +205,6 @@ func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol
 // ApplyProviderTransforms applies provider-specific transformations
 // Falls back to default handling if no specific transform found
 func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
-	// When cursor_compat is enabled, ALWAYS flatten content regardless of provider
-	// This ensures Cursor compatibility for all providers
-	if config.CursorCompat {
-		normalizeCursorContent(req)
-	}
 	if transform := GetProviderTransform(providerURL, model); transform != nil {
 		return transform(req, providerURL, model, config)
 	}

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -69,7 +69,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, resolveRuleFlags(rule), IncomingAPIResponses)
+		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, resolveRuleFlags(c, rule), IncomingAPIResponses)
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
@@ -89,7 +89,8 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 		recorder = s.EnsureProtocolRecorder(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
-	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(resolveRuleFlags(rule))...)
+	ruleFlags := resolveRuleFlags(c, rule)
+	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -65,7 +65,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, resolveRuleFlags(rule), IncomingAPIResponses)
+		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, resolveRuleFlags(c, rule), IncomingAPIResponses)
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
@@ -85,7 +85,8 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 		recorder = s.EnsureProtocolRecorder(c, string(scenarioType), provider, actualModel, s.GetScenarioRecordMode(scenarioType))
 	}
 
-	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, ruleExtraTransforms(resolveRuleFlags(rule))...)
+	ruleFlags := resolveRuleFlags(c, rule)
+	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/cursor_compat.go
+++ b/internal/server/cursor_compat.go
@@ -4,29 +4,11 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/openai/openai-go/v3"
-	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-const cursorCompatExtraField = "__tb_cursor_compat"
-
-// resolveCursorCompat determines whether Cursor compatibility handling should be enabled.
-// Primary mechanism is rule flags; optional auto-detection is enabled via rule flags.
-func resolveCursorCompat(c *gin.Context, rule *typ.Rule) bool {
-	if rule == nil {
-		return false
-	}
-
-	flags := rule.Flags
-	if flags.CursorCompat {
-		return true
-	}
-	if flags.CursorCompatAuto && isCursorRequest(c) {
-		return true
-	}
-	return false
-}
-
+// isCursorRequest reports whether the inbound request looks like it came from
+// the Cursor IDE, based on common request headers. Used by resolveRuleFlags to
+// fold the cursor_compat_auto flag into an effective cursor_compat decision.
 func isCursorRequest(c *gin.Context) bool {
 	if c == nil {
 		return false
@@ -44,18 +26,4 @@ func isCursorRequest(c *gin.Context) bool {
 		return true
 	}
 	return false
-}
-
-// applyCursorCompatFlag embeds a transient flag in request extra fields for downstream transforms.
-// The flag is stripped before sending to the provider.
-func applyCursorCompatFlag(req *openai.ChatCompletionNewParams, enabled bool) {
-	if req == nil || !enabled {
-		return
-	}
-	extra := req.ExtraFields()
-	if extra == nil {
-		extra = map[string]interface{}{}
-	}
-	extra[cursorCompatExtraField] = true
-	req.SetExtraFields(extra)
 }

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -21,7 +21,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
-	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
 	"github.com/tingly-dev/tingly-box/internal/server/forwarding"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -171,9 +170,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	isStreaming := req.Stream
 	actualModel := req.Model
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
-	cursorCompat := resolveCursorCompat(c, rule)
-	applyCursorCompatFlag(&req.ChatCompletionNewParams, cursorCompat)
-	ruleFlags := resolveRuleFlags(rule)
+	ruleFlags := resolveRuleFlags(c, rule)
 	if ruleFlags.CustomUserAgent != "" {
 		c.Request = c.Request.WithContext(typ.WithCustomUserAgent(c.Request.Context(), ruleFlags.CustomUserAgent))
 	}
@@ -186,10 +183,6 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	SetTrackingContext(c, rule, provider, actualModel, responseModel, isStreaming)
 
 	apiStyle := provider.APIStyle
-	// === Cursor compat content normalization (before transform) ===
-	if cursorCompat {
-		ops.ApplyCursorCompatContentNormalization(&req.ChatCompletionNewParams)
-	}
 	transform.AlignToolMessagesForOpenAI(&req.ChatCompletionNewParams)
 
 	// === Cap max_tokens at model's maximum ===
@@ -229,7 +222,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	}
 
 	// === Transform via pipeline ===
-	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, ruleExtraTransforms(ruleFlags)...)
+	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{
@@ -239,7 +232,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 		})
 		return
 	}
-	reqCtx.Extra["cursor_compat"] = cursorCompat
+	reqCtx.Extra["cursor_compat"] = ruleFlags.CursorCompat
 	reqCtx.Extra["skip_usage"] = ruleFlags.SkipUsage
 
 	// === Dispatch via transform chain ===

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -201,7 +201,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 		})
 		return
 	case protocol.APIStyleOpenAI:
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, resolveRuleFlags(rule), IncomingAPIResponses)
+		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, resolveRuleFlags(c, rule), IncomingAPIResponses)
 		if routeErr != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
@@ -224,7 +224,8 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	}
 
 	// Execute transform chain
-	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, ruleExtraTransforms(resolveRuleFlags(rule))...)
+	ruleFlags := resolveRuleFlags(c, rule)
+	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// appendExtraTransforms tacks rule-driven post-base transforms onto a chain
+// appendExtraTransforms tacks rule-driven post-Base transforms onto a chain
 // built by BuildTransformChain. Kept rule-agnostic — the caller decides what
 // to append.
 func appendExtraTransforms(chain *transform.TransformChain, extras []transform.Transform) {
@@ -17,13 +17,30 @@ func appendExtraTransforms(chain *transform.TransformChain, extras []transform.T
 	}
 }
 
-func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+// prependPreBaseTransforms prepends rule-driven pre-Base transforms onto a
+// chain built by BuildTransformChain. They run before any existing stage
+// (including StagePre recording) — same position smart_compact uses — so the
+// type-switch in each transform sees the inbound request shape exactly as the
+// client sent it.
+func prependPreBaseTransforms(chain *transform.TransformChain, preBase []transform.Transform) {
+	if len(preBase) == 0 {
+		return
+	}
+	existing := chain.GetTransforms()
+	merged := make([]transform.Transform, 0, len(preBase)+len(existing))
+	merged = append(merged, preBase...)
+	merged = append(merged, existing...)
+	chain.SetTransforms(merged)
+}
+
+func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
+	prependPreBaseTransforms(chain, preBaseTransforms)
 	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
@@ -87,12 +104,13 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	return finalCtx, nil
 }
 
-func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
+	prependPreBaseTransforms(chain, preBaseTransforms)
 	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
@@ -153,12 +171,13 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
+	prependPreBaseTransforms(chain, preBaseTransforms)
 	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
@@ -208,12 +227,13 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
 	if err != nil {
 		return nil, err
 	}
+	prependPreBaseTransforms(chain, preBaseTransforms)
 	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -1,14 +1,34 @@
 package server
 
 import (
+	"github.com/gin-gonic/gin"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// ruleExtraTransforms builds the per-rule list of post-base transforms to
-// append to the protocol chain. Returns nil when no rule-level flag requires
-// a chain stage so callers can pass the result straight to a variadic
-// `extraTransforms ...transform.Transform` parameter.
+// rulePreBaseTransforms builds the per-rule list of pre-Base transforms to
+// prepend onto the protocol chain. Pre-Base transforms act on the *inbound*
+// request shape — they run before BaseTransform's protocol conversion, so the
+// type-switch inside each transform sees what the client actually sent.
+//
+// Returns nil when no rule-level flag requires a pre-Base stage so callers
+// can pass the result straight to prependPreBaseTransforms.
+func rulePreBaseTransforms(flags typ.RuleFlags) []transform.Transform {
+	var pre []transform.Transform
+	if flags.CursorCompat {
+		pre = append(pre, transform.NewOpenAICursorCompatTransform())
+	}
+	return pre
+}
+
+// ruleExtraTransforms builds the per-rule list of post-Base transforms to
+// append to the protocol chain. Post-Base transforms act on the *target*
+// request shape — they run after BaseTransform's protocol conversion, so the
+// type-switch inside each transform matches the upstream-bound form.
+//
+// Returns nil when no rule-level flag requires a chain stage so callers can
+// pass the result straight to a variadic `extraTransforms ...transform.Transform`
+// parameter.
 //
 // Takes already-resolved flags so callers that need other fields off
 // RuleFlags (CustomUserAgent, SkipUsage) can resolve once and share.
@@ -23,13 +43,23 @@ func ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform {
 	return extras
 }
 
-// resolveRuleFlags returns a copy of the rule's flags, or the zero value when
-// no rule is bound. Callers may always read fields without nil-checking.
-func resolveRuleFlags(rule *typ.Rule) typ.RuleFlags {
+// resolveRuleFlags returns the effective flags for this request: a copy of
+// the rule's persisted flags, with cursor_compat_auto folded into
+// cursor_compat when the inbound request carries Cursor headers. Returns the
+// zero value when no rule is bound.
+//
+// Folding happens here (not at each handler call site) so that
+// rulePreBaseTransforms and downstream consumers like reqCtx.Extra both read
+// the same merged value with no duplication.
+func resolveRuleFlags(c *gin.Context, rule *typ.Rule) typ.RuleFlags {
 	if rule == nil {
 		return typ.RuleFlags{}
 	}
-	return rule.Flags
+	flags := rule.Flags
+	if flags.CursorCompatAuto && isCursorRequest(c) {
+		flags.CursorCompat = true
+	}
+	return flags
 }
 
 // shouldStripUsage merges the cursor_compat and skip_usage hints carried in

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -1,14 +1,27 @@
 package server
 
 import (
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// newGinContext builds a minimal *gin.Context for tests that only need to
+// read request headers (auto-detect path). Header values can be set on the
+// returned request before passing the context into the unit under test.
+func newGinContext(t *testing.T) *gin.Context {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+	return c
+}
+
 func TestResolveRuleFlags_NilRule(t *testing.T) {
-	got := resolveRuleFlags(nil)
+	got := resolveRuleFlags(newGinContext(t), nil)
 	want := typ.RuleFlags{}
 	if got != want {
 		t.Errorf("resolveRuleFlags(nil) = %#v, want zero value %#v", got, want)
@@ -25,12 +38,41 @@ func TestResolveRuleFlags_CopiesFlags(t *testing.T) {
 			UseMaxTokens:           true,
 		},
 	}
-	got := resolveRuleFlags(rule)
+	got := resolveRuleFlags(newGinContext(t), rule)
 	if !got.CursorCompat || !got.SkipUsage || !got.UseMaxCompletionTokens || !got.UseMaxTokens {
 		t.Errorf("bool flags lost: %#v", got)
 	}
 	if got.CustomUserAgent != "MyApp/1.0" {
 		t.Errorf("CustomUserAgent = %q, want %q", got.CustomUserAgent, "MyApp/1.0")
+	}
+}
+
+func TestResolveRuleFlags_AutoDetectFoldedIn(t *testing.T) {
+	rule := &typ.Rule{
+		Flags: typ.RuleFlags{
+			CursorCompat:     false,
+			CursorCompatAuto: true,
+		},
+	}
+	c := newGinContext(t)
+	c.Request.Header.Set("User-Agent", "Cursor/0.42")
+
+	got := resolveRuleFlags(c, rule)
+	if !got.CursorCompat {
+		t.Errorf("expected CursorCompat folded to true via auto-detect, got %#v", got)
+	}
+}
+
+func TestResolveRuleFlags_AutoDetectInactiveWithoutHeader(t *testing.T) {
+	rule := &typ.Rule{
+		Flags: typ.RuleFlags{
+			CursorCompat:     false,
+			CursorCompatAuto: true,
+		},
+	}
+	got := resolveRuleFlags(newGinContext(t), rule)
+	if got.CursorCompat {
+		t.Errorf("expected CursorCompat to stay false without Cursor headers, got %#v", got)
 	}
 }
 
@@ -86,6 +128,36 @@ func TestShouldStripUsage_NonBoolValueIgnored(t *testing.T) {
 	}
 }
 
+func TestRulePreBaseTransforms_NoFlags(t *testing.T) {
+	got := rulePreBaseTransforms(typ.RuleFlags{})
+	if got != nil {
+		t.Errorf("expected nil for zero-value flags, got %d transforms", len(got))
+	}
+}
+
+func TestRulePreBaseTransforms_CursorCompat(t *testing.T) {
+	got := rulePreBaseTransforms(typ.RuleFlags{CursorCompat: true})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 transform, got %d", len(got))
+	}
+	if _, ok := got[0].(*transform.OpenAICursorCompatTransform); !ok {
+		t.Errorf("expected *transform.OpenAICursorCompatTransform, got %T", got[0])
+	}
+}
+
+func TestRulePreBaseTransforms_OtherFlagsAlone_NoTransform(t *testing.T) {
+	// Post-base flags must not surface in the pre-base list.
+	got := rulePreBaseTransforms(typ.RuleFlags{
+		UseMaxCompletionTokens: true,
+		UseMaxTokens:           true,
+		SkipUsage:              true,
+		CustomUserAgent:        "Foo/1.0",
+	})
+	if got != nil {
+		t.Errorf("expected nil, got %d transforms", len(got))
+	}
+}
+
 func TestRuleExtraTransforms_NoFlags(t *testing.T) {
 	got := ruleExtraTransforms(typ.RuleFlags{})
 	if got != nil {
@@ -118,9 +190,11 @@ func TestRuleExtraTransforms_UseMaxTokens(t *testing.T) {
 	}
 }
 
-func TestRuleExtraTransforms_OtherFlagsAlone_NoTransform(t *testing.T) {
-	// Flags that have their own injection paths (UA via context, skip_usage
-	// via Extra) shouldn't surface here.
+func TestRuleExtraTransforms_CursorCompatAlone_NoTransform(t *testing.T) {
+	// CursorCompat is a pre-Base flag — it must not surface in the post-Base
+	// extras list. This is the safety net for the rule-flag-to-transform
+	// migration: if anyone wires cursor_compat into ruleExtraTransforms by
+	// mistake, this test goes red.
 	got := ruleExtraTransforms(typ.RuleFlags{
 		CursorCompat:    true,
 		SkipUsage:       true,


### PR DESCRIPTION
`cursor_compat` was a rule flag whose request-side mutation still lived
as an inline call in the OpenAI Chat handler, plus a few dead paths
(`__tb_cursor_compat` writer with no reader, `OpenAIConfig.CursorCompat`
gated branches that never fired). This PR finishes the migration by
turning it into a real `Transform`.

- New `OpenAICursorCompatTransform`, prepended to the chain before
  `BaseTransform` (same prepend pattern `smart_compact` uses).
- `ruleExtraTransforms` split into `rulePreBaseTransforms` (inbound-shape
  mutations) and `ruleExtraTransforms` (target-shape mutations). Each
  rule flag now picks one side.
- `cursor_compat_auto` header detection folded into
  `resolveRuleFlags(c, rule)` so handlers see one effective flag.
- Dead paths removed: `applyCursorCompatFlag`, the `cursor_compat` read
  in `buildOpenAIConfigFromRequest`, `config.CursorCompat` branches in
  `ApplyProviderTransforms` / `applyDeepSeekTransform`, and the
  `OpenAIConfig.CursorCompat` field.
- `.design/rule-flags.md` updated to reflect the new pre/post-Base
  split.

## Test plan

- [x] `go test ./internal/protocol/transform/... ./internal/server/`
- [x] New tests in `openai_cursor_compat_test.go` cover Chat flatten,
  no-op on other shapes, and chain ordering.
- [x] `rule_flags_test.go` updated for the pre/post split and the
  auto-detect fold.

https://claude.ai/code/session_01PDPRsAQ2MQVEEFP6YRUd6F