### PR TITLE
Make database authoritative for providers, clear legacy JSON config

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -46,8 +46,13 @@ type Config struct {
 	ClaudeCodeDeviceID string               `json:"claude_code_device_id"`                        // Calc from random claude code device id with sha256
 
 	// Merged fields from Config struct
+	// ProvidersV1 and Providers are legacy JSON-config storage for providers.
+	// Providers now live in SQLite (db.ProviderStore); these fields are only
+	// populated on load for one-time migration to the database and are cleared
+	// by migrateProvidersToDB. The non-omitempty tags ensure that clearing them
+	// results in a JSON null that overrides any stale value in the existing file.
 	ProvidersV1 map[string]*typ.Provider `json:"providers"`
-	Providers   []*typ.Provider          `json:"providers_v2,omitempty"`
+	Providers   []*typ.Provider          `json:"providers_v2"`
 	ServerPort  int                      `json:"-"`
 	JWTSecret   string                   `json:"jwt_secret"`
 

--- a/internal/server/config/provider.go
+++ b/internal/server/config/provider.go
@@ -22,9 +22,11 @@ type ProviderDeleteHook interface {
 	OnProviderDelete(uuid string)
 }
 
-// migrateProvidersToDB migrates providers from JSON config to database
-// This is a one-time migration that runs on startup if the database is empty
-// Note: Providers are kept in JSON config as backup for now, will be cleared in a future version
+// migrateProvidersToDB migrates providers from JSON config to database.
+// This is a one-time migration that runs on startup if the database is empty.
+// After migration (or if the database is already authoritative), the JSON
+// provider fields are cleared and the config is persisted so subsequent
+// startups load empty JSON provider data.
 func (c *Config) migrateProvidersToDB() error {
 	if c.providerStore == nil {
 		return nil // Provider store not initialized, skip migration
@@ -37,7 +39,12 @@ func (c *Config) migrateProvidersToDB() error {
 	}
 
 	if count > 0 {
-		// Database already has providers, skip migration
+		// Database is authoritative. Clear any stale JSON backup left over
+		// from earlier versions that kept providers in JSON post-migration.
+		if len(c.Providers) > 0 || len(c.ProvidersV1) > 0 {
+			logrus.Infof("Clearing stale provider JSON data (%d v2 / %d v1); database is authoritative", len(c.Providers), len(c.ProvidersV1))
+			return c.clearProviderJSON()
+		}
 		logrus.Debugf("Database already has %d providers, skipping migration", count)
 		return nil
 	}
@@ -47,7 +54,7 @@ func (c *Config) migrateProvidersToDB() error {
 		return nil // No providers to migrate
 	}
 
-	logrus.Infof("Migrating %d providers from JSON config to database (keeping JSON as backup)...", len(c.Providers))
+	logrus.Infof("Migrating %d providers from JSON config to database...", len(c.Providers))
 
 	// Migrate each provider to database
 	for _, provider := range c.Providers {
@@ -57,9 +64,18 @@ func (c *Config) migrateProvidersToDB() error {
 	}
 
 	logrus.Infof("Successfully migrated %d providers to database", len(c.Providers))
-	// Note: We keep c.Providers in JSON config as backup for now
-	// In a future version, we will clear: c.Providers = nil; c.ProvidersV1 = nil; c.Save()
 
+	return c.clearProviderJSON()
+}
+
+// clearProviderJSON drops the legacy JSON-config provider fields and persists
+// the change so the on-disk config no longer carries duplicate provider data.
+func (c *Config) clearProviderJSON() error {
+	c.Providers = nil
+	c.ProvidersV1 = nil
+	if err := c.Save(); err != nil {
+		return fmt.Errorf("failed to save config after clearing provider JSON: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
This change finalizes the migration of providers from JSON config to SQLite database by making the database the authoritative source and clearing legacy JSON provider fields after migration. Previously, providers were kept in JSON as a backup; now they are removed to prevent stale data and confusion.

## Key Changes
- **Updated migration logic**: `migrateProvidersToDB()` now clears JSON provider fields after successful migration to ensure the database is the sole source of truth
- **Added cleanup for stale data**: When the database already contains providers (from a previous startup), any remaining JSON provider data is detected and cleared with an informative log message
- **Extracted `clearProviderJSON()` helper**: New method handles the common logic of clearing `Providers` and `ProvidersV1` fields and persisting the config to disk
- **Updated documentation**: Comments now accurately reflect that JSON fields are legacy and will be cleared, rather than kept as backup
- **Fixed JSON serialization**: Removed `omitempty` tag from `Providers` field to ensure `null` values properly override stale data in existing config files

## Implementation Details
- The `clearProviderJSON()` method ensures config changes are persisted to disk, preventing re-migration on subsequent startups
- Log messages distinguish between initial migration and cleanup of stale data for better observability
- The change is backward compatible: existing configs with JSON providers will be migrated once and then cleaned up automatically

https://claude.ai/code/session_01YWWedm7avRCs2CsZ4ssfhR