### PR TITLE
security: generate random tokens instead of using well-known defaults

### DIFF
--- a/.design/security.md
+++ b/.design/security.md
@@ -1,0 +1,109 @@
+# Security: Design Decisions
+
+> Audience: tingly-box backend contributors. This document records
+> security-relevant policy decisions, one section per decision.
+
+---
+
+## Random default authentication tokens
+
+### Problem
+
+tingly-box gates its Web UI and control-plane API behind a `UserToken`,
+and its model proxy behind a `ModelToken`. Historically both had
+well-known compile-time defaults — `tingly-box-user-token` and
+`tingly-box-model-token` — defined in `internal/constant/constant.go`.
+
+A fresh install would write the literal default string into
+`config.json` and use it as the operative credential. Because the value
+is public (in the source tree, in every release binary), anyone who can
+reach the loopback port on a brand-new box can log in as the operator.
+For a gateway that proxies developer LLM traffic and stores upstream
+provider keys on the operator's behalf, that is the wrong default.
+
+An earlier mitigation added secure-random generation
+(`config.GenerateUserToken`, 32 bytes from `crypto/rand`, hex encoded,
+`tb-user-` prefix → 256 bits of entropy) and a startup warning when the
+default string was detected — but **three code paths still wrote the
+well-known constant**:
+
+1. `NewConfig`: on `crypto/rand` failure, fell back to `DefaultUserToken`.
+2. `NewConfig`: on JWT-generation failure for the ModelToken, fell back
+   to `DefaultModelToken` (a separate bug then immediately overwrote
+   that with an empty value, corrupting rather than weakening the
+   config).
+3. `CreateDefaultConfig` (the actual first-run path most installs took):
+   unconditionally assigned `c.UserToken = constant.DefaultUserToken`
+   without ever calling the random generator.
+
+### Policy
+
+A configuration that does not already contain a `user_token` or
+`model_token` MUST receive a fresh cryptographically random value before
+it is persisted. There is no "safe default" fallback string.
+
+If `crypto/rand.Read` fails, bootstrap returns an error and the process
+exits. Booting with a known-weak token is a worse failure mode than
+refusing to boot.
+
+| Path                                            | UserToken                                 | ModelToken                                  | On generator error |
+|-------------------------------------------------|-------------------------------------------|---------------------------------------------|--------------------|
+| `NewConfig` — no token on an existing config    | `GenerateUserToken()` → `tb-user-<64 hex>` | JWT signed with `JWTSecret`                 | Return error       |
+| `CreateDefaultConfig` — true first run          | `GenerateUserToken()` → `tb-user-<64 hex>` | `"tingly-box-" + JWT` (legacy prefix kept)  | Return error       |
+
+### Legacy installs
+
+The two `Default*Token` constants are retained in
+`internal/constant/constant.go`, but their **only** remaining purpose is
+detection. On startup, if `cfg.UserToken == constant.DefaultUserToken`
+we emit a multi-line `SECURITY WARNING` pointing the operator at the
+rotation flows:
+
+1. Web UI → System page → Access Control → "Reset user token".
+2. CLI: `tingly-box auth token --reset` (planned).
+
+We deliberately do **not** silently rotate at startup:
+
+- The operator may have automation, bookmarks, or other clients pinned
+  to the existing value. Rotating without consent would lock them out
+  of their own box on an unrelated upgrade.
+- A persistent warning is more likely to drive rotation to completion
+  than a one-shot silent rewrite the operator never sees.
+
+Rotation is already wired server-side in
+`internal/server/webui_auth.go` (`ResetUserToken`, `ResetModelToken`);
+both routes require an authenticated session, so a legacy-default
+holder can rotate from inside the Web UI without any out-of-band trust
+bootstrap.
+
+### Why keep the default constants at all
+
+Deleting them would silently break:
+
+- The detection branch in `NewConfig` and the `is_default` flag exposed
+  by `GetUserToken` to the Web UI.
+- The "real token vs test token" assertion in
+  `internal/server_test/server_test.go`.
+
+The right read of these constants today is *"the string we look for in
+older configs"*, not *"the value we hand out to new configs"*. Renaming
+to make that clearer is a follow-up.
+
+### Out of scope (follow-ups)
+
+- `JWTSecret` is currently `fmt.Sprintf("%d", time.Now().UnixNano())` —
+  64 bits of guessable timing data, not a secret. Should be upgraded
+  to 32 bytes from `crypto/rand`.
+- No rate-limiting on the Web UI login endpoint. Brute-force protection
+  rests entirely on token entropy. Acceptable at 256 bits; if we ever
+  shorten the token, rate-limiting must come in first.
+
+### Files involved
+
+| File                                       | Role                                                                                  |
+|--------------------------------------------|---------------------------------------------------------------------------------------|
+| `internal/constant/constant.go`            | Holds `DefaultUserToken` / `DefaultModelToken` — detection-only, not fallback.        |
+| `internal/server/config/util.go`           | `GenerateUserToken`, `GenerateModelToken`, `GenerateSecureToken`, `IsDefaultToken`.   |
+| `internal/server/config/config.go`         | `NewConfig` bootstrap and `CreateDefaultConfig`. Both refuse legacy defaults.         |
+| `internal/server/webui_auth.go`            | `GetUserToken` (exposes `is_default`), `ResetUserToken`, `ResetModelToken`.           |
+| `internal/server_test/server_test.go`      | Distinguishes real vs test tokens via the legacy default string.                      |

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -344,23 +344,23 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 		updated = true
 	}
 	if cfg.UserToken == "" {
-		// Generate secure random token instead of using default
+		// Always generate a cryptographically secure random token for new installs.
+		// Falling back to a well-known default would defeat the purpose, so fail loudly instead.
 		userToken, err := GenerateUserToken()
 		if err != nil {
-			logrus.WithError(err).Warn("Failed to generate secure user token, using default")
-			cfg.UserToken = constant.DefaultUserToken
-		} else {
-			cfg.UserToken = userToken
-			logrus.Info("=============================================")
-			logrus.Info("Generated new UserToken for control panel:")
-			logrus.Infof("  %s", cfg.UserToken)
-			logrus.Info("Use this token to log in to the web UI at:")
-			logrus.Infof("  http://localhost:%d/login/%s", cfg.ServerPort, cfg.UserToken)
-			logrus.Info("=============================================")
+			return nil, fmt.Errorf("failed to generate secure user token: %w", err)
 		}
+		cfg.UserToken = userToken
+		logrus.Info("=============================================")
+		logrus.Info("Generated new UserToken for control panel:")
+		logrus.Infof("  %s", cfg.UserToken)
+		logrus.Info("Use this token to log in to the web UI at:")
+		logrus.Infof("  http://localhost:%d/login/%s", cfg.ServerPort, cfg.UserToken)
+		logrus.Info("=============================================")
 		updated = true
 	} else if IsDefaultToken(cfg.UserToken) {
-		// Warn if using default token
+		// Legacy config detected: pre-existing install with the well-known default token.
+		// Warn but do not silently rotate, so the operator can re-distribute the new token.
 		logrus.Warn("=============================================")
 		logrus.Warn("SECURITY WARNING: Using default UserToken!")
 		logrus.Warn("Please reset to a secure token via:")
@@ -371,7 +371,7 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 	if cfg.ModelToken == "" {
 		modelToken, err := auth.NewJWTManager(cfg.JWTSecret).GenerateToken("tingly-box")
 		if err != nil {
-			cfg.ModelToken = constant.DefaultModelToken
+			return nil, fmt.Errorf("failed to generate secure model token: %w", err)
 		}
 		cfg.ModelToken = modelToken
 		updated = true
@@ -1955,14 +1955,19 @@ func (c *Config) CreateDefaultConfig() error {
 	// Create a default Rule
 	c.Rules = []typ.Rule{}
 	c.DefaultRequestID = 0
-	// Set default auth tokens if not already set
+	// Set default auth tokens if not already set. Always generate secure random
+	// values for new installs — never assign the well-known legacy defaults.
 	if c.UserToken == "" {
-		c.UserToken = constant.DefaultUserToken
+		userToken, err := GenerateUserToken()
+		if err != nil {
+			return fmt.Errorf("failed to generate secure user token: %w", err)
+		}
+		c.UserToken = userToken
 	}
 	if c.ModelToken == "" {
 		modelToken, err := auth.NewJWTManager(c.JWTSecret).GenerateToken("tingly-box")
 		if err != nil {
-			c.ModelToken = constant.DefaultModelToken
+			return fmt.Errorf("failed to generate secure model token: %w", err)
 		}
 		c.ModelToken = "tingly-box-" + modelToken
 	}


### PR DESCRIPTION
## Summary

This PR eliminates the use of well-known default authentication tokens (`tingly-box-user-token` and `tingly-box-model-token`) in new installations. Instead, all new configs now receive cryptographically random tokens before being persisted. This closes a security gap where fresh installs were vulnerable to unauthorized access via publicly-known default credentials.

## Key Changes

- **Token Generation on Bootstrap**: Modified `NewConfig()` and `CreateDefaultConfig()` to always call `GenerateUserToken()` and JWT generation for new configs, rather than falling back to well-known constants
- **Fail-Fast on Crypto Errors**: Changed error handling to return an error and exit if token generation fails, instead of silently falling back to weak defaults
- **Legacy Detection Only**: The `DefaultUserToken` and `DefaultModelToken` constants are now retained solely for detecting pre-existing configs with the old defaults
- **Persistent Security Warning**: Existing installations using the default token now receive a multi-line `SECURITY WARNING` on startup, directing operators to rotation flows (Web UI or planned CLI)
- **No Silent Rotation**: Deliberately avoid silently rotating tokens at startup to prevent breaking operator automation and client configurations
- **Design Documentation**: Added `.design/security.md` documenting the policy decision, rationale, legacy handling, and follow-up work

## Implementation Details

- `NewConfig()`: Now returns an error if `GenerateUserToken()` or JWT generation fails, with clear error messages
- `CreateDefaultConfig()`: Generates secure random tokens for first-run installs instead of assigning constants
- Detection logic preserved in `IsDefaultToken()` for backward compatibility with existing configs
- Rotation endpoints (`ResetUserToken`, `ResetModelToken`) already in place for operator-initiated token refresh
- Added comprehensive design documentation covering security policy, legacy install handling, and out-of-scope follow-ups (JWTSecret entropy, rate-limiting)

## Files Modified

- `internal/server/config/config.go`: Updated bootstrap logic to enforce random token generation
- `.design/security.md`: New design decision document (added)

https://claude.ai/code/session_01DjzK6CSfcnQMcNumTEudR2