### PR TITLE
bugfix(server): add-API-key flow: key not saved, plus provider dialog UX

### DIFF
--- a/.claude/skills/ui-preview/SKILL.md
+++ b/.claude/skills/ui-preview/SKILL.md
@@ -90,6 +90,32 @@ for the specific change you're verifying.
    complain otherwise.
 3. Optionally `pkill -f "vite --mode mock"` to free the port.
 
+## Regression tests (committed)
+
+`regression-credentials.mjs` (next to this file) is a committed, assertion-based
+regression for the provider "Add API Key" flow on `/credentials`. It guards the
+fixes from PR #996:
+
+- a free-typed provider produces a well-formed POST payload (name + api_base +
+  token) **without** clicking "Test Connection" first;
+- notifications render via the unified top-right stack (not a bottom-right
+  page-local Snackbar);
+- the submit button shows a spinner while the request is in flight.
+
+Run it after the Setup + dev-server steps above (it resolves `playwright` from
+the cwd, so run from `frontend/`):
+
+```bash
+node ../.claude/skills/ui-preview/regression-credentials.mjs   # exits 0 / 1
+```
+
+It drives a real headless browser and asserts on the captured outgoing request
+and DOM. In mock mode there is no `POST /api/v2/providers` handler, so the
+request 404s and you'll see a `[pageerror] ... reading 'success'` line — that's
+expected; the test asserts on the payload + the resulting top-right error toast,
+not on a successful save. Unlike `screenshot.mjs`, this file IS committed — it's
+the regression asset, not throwaway tooling.
+
 ## Why not Playwright MCP / Chrome MCP?
 
 MCP servers are configured at the harness level (`settings.json`) and cannot

--- a/.claude/skills/ui-preview/regression-credentials.mjs
+++ b/.claude/skills/ui-preview/regression-credentials.mjs
@@ -1,0 +1,121 @@
+// Regression test for the provider "Add API Key" flow on /credentials.
+//
+// Guards against the bugs fixed in PR #996:
+//   1. Free-typed provider must produce a well-formed POST payload WITHOUT
+//      first clicking "Test Connection" (name + api_base + token populated).
+//      Regression: a stale-state race sent name:"" and the backend rejected it.
+//   2. Notifications must render via the unified top-right stack (top:24,
+//      right:24), not a page-local bottom-right Snackbar.
+//   3. The submit button must show a spinner while the request is in flight.
+//
+// Setup (see SKILL.md): download Chrome for Testing to /tmp/chrome, then from
+// frontend/:  npm i -D playwright && npm i @emotion/react @emotion/styled
+// Run the mock dev server:  USE_MOCK=true npm run dev:mock   (serves :3000)
+// Then, from frontend/:     node ../.claude/skills/ui-preview/regression-credentials.mjs
+//
+// Exits 0 on success, 1 on any failed assertion. Screenshot: /tmp/regression-credentials.png
+//
+// Note: in mock mode there is no POST /api/v2/providers handler, so the request
+// 404s — that is fine. We assert on the OUTGOING payload (captured in-page) and
+// on the resulting top-right error toast, not on a successful save.
+
+// Resolve playwright from the cwd (run this from frontend/, where playwright
+// is installed) rather than from this script's folder under .claude/skills/.
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+const require = createRequire(join(process.cwd(), 'noop.js'));
+const { chromium } = require('playwright');
+
+const CHROME_PATH = process.env.CHROME_PATH || '/tmp/chrome/chrome-linux64/chrome';
+const BASE = process.env.BASE_URL || 'http://localhost:3000';
+const VIEWPORT_W = 1440;
+
+const failures = [];
+const assert = (cond, msg) => { if (!cond) failures.push(msg); console.log(`${cond ? 'PASS' : 'FAIL'}: ${msg}`); };
+
+const browser = await chromium.launch({
+    executablePath: CHROME_PATH,
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+const context = await browser.newContext({ viewport: { width: VIEWPORT_W, height: 1000 }, deviceScaleFactor: 1 });
+
+await context.addInitScript(() => {
+    // Skip the login gate.
+    localStorage.setItem('user_auth_token', 'mock-token');
+    // Record outgoing POSTs to the providers endpoint, and delay them so the
+    // in-flight submit spinner is observable.
+    window.__posts = [];
+    const orig = window.fetch;
+    window.fetch = async (input, init) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const method = (input instanceof Request ? input.method : (init?.method || 'GET')).toUpperCase();
+        if (url.includes('/api/v2/providers') && method === 'POST') {
+            let bodyText;
+            if (input instanceof Request) { try { bodyText = await input.clone().text(); } catch {} }
+            else if (init?.body != null) { bodyText = typeof init.body === 'string' ? init.body : JSON.stringify(init.body); }
+            let body = bodyText; try { body = JSON.parse(bodyText); } catch {}
+            window.__posts.push({ url, body });
+            await new Promise(r => setTimeout(r, 1500));
+        }
+        return orig(input, init);
+    };
+});
+
+const page = await context.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message.slice(0, 160)));
+
+await page.goto(`${BASE}/credentials`, { waitUntil: 'networkidle', timeout: 60000 });
+await page.waitForTimeout(2000);
+
+// Open the Add API Key dialog and fill a free-typed provider — deliberately
+// WITHOUT clicking "Test Connection".
+await page.getByRole('button', { name: 'Add API Key' }).first().click();
+const dialog = page.getByRole('dialog');
+await dialog.waitFor({ timeout: 10000 });
+await page.waitForTimeout(400);
+await dialog.getByPlaceholder('Select a provider or enter custom base URL').fill('https://custom.example.com/v1');
+await dialog.getByText('OpenAI Compatible', { exact: false }).click();
+await dialog.getByPlaceholder('Your API key').fill('sk-regression-123');
+await dialog.getByRole('button', { name: 'Add API Key' }).click();
+
+// Mid-flight (request delayed 1.5s): the submit button should show a spinner.
+await page.waitForTimeout(500);
+const spinnerVisible = await page.evaluate(() => {
+    // Multiple [role=dialog] nodes can be mounted (e.g. a placeholder plus the
+    // real one), so scan submit buttons across all of them.
+    const submit = Array.from(document.querySelectorAll('[role="dialog"] button[type="submit"]')).pop();
+    if (!submit) return false;
+    const hasProgress = !!submit.querySelector('.MuiCircularProgress-root, [role="progressbar"]');
+    // While submitting, the label is replaced by the spinner, so the button is
+    // disabled with no visible text.
+    const disabledNoText = submit.disabled && submit.innerText.trim() === '';
+    return hasProgress || disabledNoText;
+});
+await page.screenshot({ path: '/tmp/regression-credentials.png' });
+assert(spinnerVisible, 'submit button shows a spinner while the request is in flight');
+
+// Let the request settle (404 in mock) and the error toast appear.
+await page.waitForTimeout(2000);
+
+// Assertion 1: outgoing payload is well-formed.
+const posts = await page.evaluate(() => window.__posts || []);
+const body = posts.length ? (posts[posts.length - 1].body || {}) : {};
+assert(posts.length > 0, 'a POST /api/v2/providers request was sent');
+assert(!!body.name, `payload.name is populated (got ${JSON.stringify(body.name)})`);
+assert(!!body.api_base, `payload.api_base is populated (got ${JSON.stringify(body.api_base)})`);
+assert(!!body.token, 'payload.token is populated');
+
+// Assertion 2: notifications render via the unified top-right stack.
+const toasts = await page.evaluate(() => Array.from(document.querySelectorAll('.MuiAlert-root')).map(a => {
+    const r = a.getBoundingClientRect();
+    return { top: Math.round(r.top), right: Math.round(window.innerWidth - r.right) };
+}));
+const topRight = toasts.some(t => t.top <= 60 && t.right <= 60);
+assert(toasts.length > 0, 'a notification toast is shown');
+assert(topRight, `at least one toast is anchored top-right (got ${JSON.stringify(toasts)})`);
+
+await browser.close();
+
+console.log(`\n=== ${failures.length === 0 ? 'ALL CHECKS PASSED' : `${failures.length} CHECK(S) FAILED`} ===`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -53,7 +53,11 @@ export interface EnhancedProviderFormData {
 interface PresetProviderFormDialogProps {
     open: boolean;
     onClose: () => void;
-    onSubmit: (e: React.FormEvent) => void;
+    // `resolved` carries fields the dialog finalises at submit time (free-typed
+    // apiBase, the auto-generated name, etc). Parents must merge it over their
+    // form state because those values are committed via async onChange and are
+    // not yet visible in state when this fires.
+    onSubmit: (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => void;
     onForceAdd?: () => void;
     data: EnhancedProviderFormData;
     onChange: (field: keyof EnhancedProviderFormData, value: any) => void;
@@ -462,13 +466,22 @@ const ProviderFormDialog = ({
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
+        // Collect the values we finalise here so the parent can use them
+        // directly. onChange writes to parent state asynchronously, so the
+        // parent's submit closure would otherwise read stale values — that's
+        // why a free-typed provider could not be added without first clicking
+        // "Test Connection" (which triggered extra renders that flushed state).
+        const resolved: Partial<EnhancedProviderFormData> = {};
+
         // Make sure any free-form text in the provider input is committed before submit.
         if (!selectedProvider && data.apiBase !== providerInputValue) {
             onChangeRef.current('apiBase', providerInputValue);
             onChangeRef.current('providerBaseUrls', undefined);
+            resolved.apiBase = providerInputValue;
+            (resolved as any).providerBaseUrls = undefined;
         }
 
-        ensureName();
+        resolved.name = ensureName();
 
         // NO MANDATORY VERIFICATION - allow adding keys without testing
         // Verification is optional via the "Test Connection" button.
@@ -477,7 +490,7 @@ const ProviderFormDialog = ({
         // and closes the dialog itself only after the add/update succeeds.
         // Closing eagerly dismissed the dialog even when the request failed,
         // making it look like the key was saved when it was not.
-        onSubmit(e);
+        onSubmit(e, resolved);
     };
 
     const hasAnyProtocol = protocolOpenAI || protocolAnthropic;

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -57,7 +57,7 @@ interface PresetProviderFormDialogProps {
     // apiBase, the auto-generated name, etc). Parents must merge it over their
     // form state because those values are committed via async onChange and are
     // not yet visible in state when this fires.
-    onSubmit: (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => void;
+    onSubmit: (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => void | Promise<void>;
     onForceAdd?: () => void;
     data: EnhancedProviderFormData;
     onChange: (field: keyof EnhancedProviderFormData, value: any) => void;
@@ -83,6 +83,7 @@ const ProviderFormDialog = ({
     const defaultSubmitText = mode === 'add' ? t('providerDialog.addButton') : t('common.saveChanges');
 
     const [verifying, setVerifying] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
     const [noApiKey, setNoApiKey] = useState(data.noKeyRequired || false);
     const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
     const [selectedProvider, setSelectedProvider] = useState<UniqueProvider | null>(null);
@@ -490,7 +491,16 @@ const ProviderFormDialog = ({
         // and closes the dialog itself only after the add/update succeeds.
         // Closing eagerly dismissed the dialog even when the request failed,
         // making it look like the key was saved when it was not.
-        onSubmit(e, resolved);
+        //
+        // Await so the button can show a spinner while the request is in
+        // flight. On success the parent unmounts this dialog; on failure it
+        // stays open and the spinner clears so the user can retry.
+        setSubmitting(true);
+        try {
+            await onSubmit(e, resolved);
+        } finally {
+            setSubmitting(false);
+        }
     };
 
     const hasAnyProtocol = protocolOpenAI || protocolAnthropic;
@@ -643,7 +653,7 @@ const ProviderFormDialog = ({
                         type="button"
                         variant="outlined"
                         size="small"
-                        disabled={!hasAnyProtocol || verifying}
+                        disabled={!hasAnyProtocol || verifying || submitting}
                         onClick={handleVerify}
                         title="Test connection using available endpoints (optional check)"
                     >
@@ -657,12 +667,12 @@ const ProviderFormDialog = ({
                         type="submit"
                         variant="contained"
                         size="small"
-                        disabled={!hasAnyProtocol}
+                        disabled={!hasAnyProtocol || verifying || submitting}
                         sx={{
-                            minWidth: verifying ? '80px' : 'auto',
+                            minWidth: verifying || submitting ? '80px' : 'auto',
                         }}
                     >
-                        {verifying ? (
+                        {submitting ? (
                             <CircularProgress size={20} thickness={4}/>
                         ) : (
                             submitText || defaultSubmitText

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -471,9 +471,12 @@ const ProviderFormDialog = ({
         ensureName();
 
         // NO MANDATORY VERIFICATION - allow adding keys without testing
-        // Verification is optional via the "Test Connection" button
-
-        onClose();
+        // Verification is optional via the "Test Connection" button.
+        //
+        // Do NOT close the dialog here: the parent's submit handler is async
+        // and closes the dialog itself only after the add/update succeeds.
+        // Closing eagerly dismissed the dialog even when the request failed,
+        // making it look like the key was saved when it was not.
         onSubmit(e);
     };
 

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -11,7 +11,7 @@ interface UseProviderDialogReturn {
     providerDialogOpen: boolean;
     providerFormData: EnhancedProviderFormData;
     handleAddProviderClick: () => void;
-    handleProviderSubmit: (e: React.FormEvent) => Promise<void>;
+    handleProviderSubmit: (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => Promise<void>;
     handleProviderForceAdd: () => Promise<void>;
     handleCloseDialog: () => void;
     handleFieldChange: (field: keyof EnhancedProviderFormData, value: any) => void;
@@ -47,18 +47,21 @@ export const useProviderDialog = (
         setProviderDialogOpen(true);
     };
 
-    const handleProviderSubmit = async (e: React.FormEvent) => {
+    const handleProviderSubmit = async (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => {
         e.preventDefault();
 
+        // Merge dialog-resolved fields over form state; they arrive via async
+        // onChange and may not be in state yet at submit time.
+        const fd = { ...providerFormData, ...(resolved || {}) };
         const providerData = {
-            name: providerFormData.name,
-            api_base: providerFormData.apiBase,
-            api_style: providerFormData.apiStyle,
-            api_base_openai: providerFormData.apiBaseOpenAI || undefined,
-            api_base_anthropic: providerFormData.apiBaseAnthropic || undefined,
-            token: providerFormData.token,
-            no_key_required: providerFormData.noKeyRequired,
-            proxy_url: providerFormData.proxyUrl,
+            name: fd.name,
+            api_base: fd.apiBase,
+            api_style: fd.apiStyle,
+            api_base_openai: fd.apiBaseOpenAI || undefined,
+            api_base_anthropic: fd.apiBaseAnthropic || undefined,
+            token: fd.token,
+            no_key_required: fd.noKeyRequired,
+            proxy_url: fd.proxyUrl,
         };
 
         const result = await api.addProvider(providerData);

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -10,12 +10,10 @@ import UnifiedCard from '@/components/UnifiedCard';
 import { useProviderQuota } from '@/hooks/useProviderQuota';
 import { Add, ListAlt, Upload, VpnKey } from '@mui/icons-material';
 import {
-    Alert,
     Box,
     Button,
     Chip,
     Divider,
-    Snackbar,
     Stack,
     Typography,
 } from '@mui/material';
@@ -23,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../services/api';
 import { useFeatureFlags } from '@/contexts/FeatureFlagsContext';
+import { useNotify } from '@/hooks/useNotify';
 
 type ProviderFormData = EnhancedProviderFormData;
 
@@ -39,11 +38,7 @@ const CredentialPage = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const [providers, setProviders] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
-    const [snackbar, setSnackbar] = useState<{
-        open: boolean;
-        message: string;
-        severity: 'success' | 'error';
-    }>({ open: false, message: '', severity: 'success' });
+    const notify = useNotify();
 
     // API Key Dialog state
     const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
@@ -112,7 +107,7 @@ const CredentialPage = () => {
     } = useProviderQuota(providers, { fetchOnMount: true });
 
     const showNotification = (message: string, severity: 'success' | 'error') => {
-        setSnackbar({ open: true, message, severity });
+        notify[severity](message);
     };
 
     const handleAddApiKey = () => {
@@ -524,9 +519,7 @@ const CredentialPage = () => {
                             onToggle={handleToggleProvider}
                             onDelete={handleDeleteProvider}
                             onRefreshToken={handleRefreshToken}
-                            onNotification={(message, severity) => {
-                                setSnackbar({ open: true, message, severity });
-                            }}
+                            onNotification={showNotification}
                             providerQuotas={quotaData}
                             refreshingQuotas={refreshing}
                             onQuotaRefresh={refreshQuota}
@@ -565,9 +558,7 @@ const CredentialPage = () => {
                             onEdit={handleEditProvider}
                             onToggle={handleToggleProvider}
                             onDelete={handleDeleteProvider}
-                            onNotification={(message, severity) => {
-                                setSnackbar({ open: true, message, severity });
-                            }}
+                            onNotification={showNotification}
                             providerQuotas={quotaData}
                             refreshingQuotas={refreshing}
                             onQuotaRefresh={refreshQuota}
@@ -633,23 +624,6 @@ const CredentialPage = () => {
                 onImport={handleImportData}
                 loading={importing}
             />
-
-            {/* Snackbar for notifications */}
-            <Snackbar
-                open={snackbar.open}
-                autoHideDuration={6000}
-                onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
-                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-            >
-                <Alert
-                    onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
-                    severity={snackbar.severity}
-                    variant="filled"
-                    sx={{ width: '100%' }}
-                >
-                    {snackbar.message}
-                </Alert>
-            </Snackbar>
         </PageLayout>
     );
 };

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -155,11 +155,15 @@ const CredentialPage = () => {
     // - Flag OFF + BOTH protocols → return an ARRAY of two single-protocol
     //   payloads, restoring the legacy "create two providers" behavior.
     // - Single protocol selected → single provider payload (unchanged).
-    const buildAddProviderPayload = (): any | any[] => {
+    const buildAddProviderPayload = (override?: Partial<ProviderFormData>): any | any[] => {
+        // Merge dialog-resolved fields (e.g. free-typed apiBase / auto name)
+        // over the form state; those land via async onChange and may not be in
+        // state yet when submit fires.
+        const fd: any = { ...providerFormData, ...(override || {}) };
         const protocols =
-            (providerFormData as any).protocols as ('openai' | 'anthropic')[] ||
-            [providerFormData.apiStyle].filter(Boolean) as ('openai' | 'anthropic')[];
-        const providerBaseUrls = (providerFormData as any).providerBaseUrls as
+            (fd as any).protocols as ('openai' | 'anthropic')[] ||
+            [fd.apiStyle].filter(Boolean) as ('openai' | 'anthropic')[];
+        const providerBaseUrls = (fd as any).providerBaseUrls as
             | { openai?: string; anthropic?: string }
             | undefined;
 
@@ -167,20 +171,20 @@ const CredentialPage = () => {
             protocols.length === 2 &&
             !!providerBaseUrls?.openai &&
             !!providerBaseUrls?.anthropic;
-        const shouldCreateFusion = enableFusion && !!(providerFormData as any).createFusionProvider;
+        const shouldCreateFusion = enableFusion && !!(fd as any).createFusionProvider;
 
         if (bothProtocols && shouldCreateFusion) {
             return {
-                name: providerFormData.name,
+                name: fd.name,
                 api_base: providerBaseUrls!.openai,
                 api_style: 'openai' as const,
                 api_base_openai: providerBaseUrls!.openai,
                 api_base_anthropic: providerBaseUrls!.anthropic,
-                token: providerFormData.token,
-                no_key_required: (providerFormData as any).noKeyRequired || false,
+                token: fd.token,
+                no_key_required: (fd as any).noKeyRequired || false,
                 enabled: true,
-                proxy_url: (providerFormData as any).proxyUrl ?? '',
-                user_agent: (providerFormData as any).userAgent ?? '',
+                proxy_url: (fd as any).proxyUrl ?? '',
+                user_agent: (fd as any).userAgent ?? '',
                 auth_type: 'api_key',
             };
         }
@@ -189,23 +193,23 @@ const CredentialPage = () => {
             // Legacy split: emit one record per protocol so the user gets
             // two independent Provider entries sharing the same credential.
             const baseRecord = {
-                token: providerFormData.token,
-                no_key_required: (providerFormData as any).noKeyRequired || false,
+                token: fd.token,
+                no_key_required: (fd as any).noKeyRequired || false,
                 enabled: true,
-                proxy_url: (providerFormData as any).proxyUrl ?? '',
-                user_agent: (providerFormData as any).userAgent ?? '',
+                proxy_url: (fd as any).proxyUrl ?? '',
+                user_agent: (fd as any).userAgent ?? '',
                 auth_type: 'api_key',
             };
             return [
                 {
                     ...baseRecord,
-                    name: providerFormData.name,
+                    name: fd.name,
                     api_base: providerBaseUrls!.openai,
                     api_style: 'openai' as const,
                 },
                 {
                     ...baseRecord,
-                    name: providerFormData.name,
+                    name: fd.name,
                     api_base: providerBaseUrls!.anthropic,
                     api_style: 'anthropic' as const,
                 },
@@ -213,16 +217,16 @@ const CredentialPage = () => {
         }
 
         const protocol = protocols[0];
-        const apiBase = providerBaseUrls?.[protocol] || providerFormData.apiBase;
+        const apiBase = providerBaseUrls?.[protocol] || fd.apiBase;
         return {
-            name: providerFormData.name,
+            name: fd.name,
             api_base: apiBase,
             api_style: protocol,
-            token: providerFormData.token,
-            no_key_required: (providerFormData as any).noKeyRequired || false,
+            token: fd.token,
+            no_key_required: (fd as any).noKeyRequired || false,
             enabled: true,
-            proxy_url: (providerFormData as any).proxyUrl ?? '',
-            user_agent: (providerFormData as any).userAgent ?? '',
+            proxy_url: (fd as any).proxyUrl ?? '',
+            user_agent: (fd as any).userAgent ?? '',
             auth_type: 'api_key',
         };
     };
@@ -230,20 +234,21 @@ const CredentialPage = () => {
     // Build the body for an edit/update request. When fusion is OFF, omit
     // the fusion fields entirely so the backend (which ignores them under
     // flag-off anyway) doesn't get spurious empty-string pointers.
-    const buildEditProviderPayload = () => {
+    const buildEditProviderPayload = (override?: Partial<ProviderFormData>) => {
+        const fd: any = { ...providerFormData, ...(override || {}) };
         const base: any = {
-            name: providerFormData.name,
-            api_base: providerFormData.apiBase,
-            api_style: providerFormData.apiStyle,
-            token: providerFormData.token || undefined,
-            no_key_required: (providerFormData as any).noKeyRequired || false,
-            enabled: providerFormData.enabled,
-            proxy_url: (providerFormData as any).proxyUrl ?? '',
-            user_agent: (providerFormData as any).userAgent ?? '',
+            name: fd.name,
+            api_base: fd.apiBase,
+            api_style: fd.apiStyle,
+            token: fd.token || undefined,
+            no_key_required: (fd as any).noKeyRequired || false,
+            enabled: fd.enabled,
+            proxy_url: (fd as any).proxyUrl ?? '',
+            user_agent: (fd as any).userAgent ?? '',
         };
         if (enableFusion) {
-            base.api_base_openai = (providerFormData as any).apiBaseOpenAI ?? '';
-            base.api_base_anthropic = (providerFormData as any).apiBaseAnthropic ?? '';
+            base.api_base_openai = (fd as any).apiBaseOpenAI ?? '';
+            base.api_base_anthropic = (fd as any).apiBaseAnthropic ?? '';
         }
         return base;
     };
@@ -269,11 +274,11 @@ const CredentialPage = () => {
     };
 
     // API Key handlers
-    const handleProviderSubmit = async (e: React.FormEvent) => {
+    const handleProviderSubmit = async (e: React.FormEvent, resolved?: Partial<ProviderFormData>) => {
         e.preventDefault();
 
         if (apiKeyDialogMode === 'edit') {
-            const providerData = buildEditProviderPayload();
+            const providerData = buildEditProviderPayload(resolved);
             const result = await api.updateProvider(providerFormData.uuid!, providerData);
             if (result.success) {
                 showNotification('Provider updated successfully!', 'success');
@@ -283,7 +288,7 @@ const CredentialPage = () => {
                 showNotification(`Failed to update provider: ${result.error}`, 'error');
             }
         } else {
-            const result = await submitProviderPayloads(buildAddProviderPayload());
+            const result = await submitProviderPayloads(buildAddProviderPayload(resolved));
             if (result.success) {
                 showNotification('Provider added successfully!', 'success');
                 setApiKeyDialogOpen(false);

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -70,14 +70,17 @@ const Onboarding: React.FC = () => {
         setFormData(prev => ({...prev, [field]: value}));
     };
 
-    const submitProvider = async (force: boolean) => {
+    const submitProvider = async (force: boolean, resolved?: Partial<EnhancedProviderFormData>) => {
+        // Merge dialog-resolved fields over form state; they arrive via async
+        // onChange and may not be in state yet at submit time.
+        const fd = { ...formData, ...(resolved || {}) };
         const payload = {
-            name: formData.name,
-            api_base: formData.apiBase,
-            api_style: formData.apiStyle,
-            token: formData.token,
-            no_key_required: formData.noKeyRequired,
-            proxy_url: formData.proxyUrl,
+            name: fd.name,
+            api_base: fd.apiBase,
+            api_style: fd.apiStyle,
+            token: fd.token,
+            no_key_required: fd.noKeyRequired,
+            proxy_url: fd.proxyUrl,
         };
         const result = await api.addProvider(payload, force);
         if (result?.success) {
@@ -88,9 +91,9 @@ const Onboarding: React.FC = () => {
         }
     };
 
-    const handleSubmit = async (e: React.FormEvent) => {
+    const handleSubmit = async (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => {
         e.preventDefault();
-        await submitProvider(false);
+        await submitProvider(false, resolved);
     };
 
     const handleForceAdd = async () => {

--- a/internal/server/provider_handler.go
+++ b/internal/server/provider_handler.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/obs"
-	"github.com/tingly-dev/tingly-box/internal/probe"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -81,9 +80,6 @@ func (s *Server) GetProviders(c *gin.Context) {
 
 // CreateProvider adds a new provider
 func (s *Server) CreateProvider(c *gin.Context) {
-	forceParam := c.Query("force")
-	force := forceParam == "true"
-
 	var req CreateProviderRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -103,27 +99,10 @@ func (s *Server) CreateProvider(c *gin.Context) {
 		return
 	}
 
-	// Backend verification: Verify provider connection before saving (skip if no key required)
-	// This is a safety measure in addition to frontend verification
-	if !req.NoKeyRequired && req.Token != "" {
-		probeReq := &probe.ProbeProviderRequest{
-			Name:     req.Name,
-			APIBase:  req.APIBase,
-			APIStyle: req.APIStyle,
-			Token:    req.Token,
-		}
-
-		if !force {
-			success, message, _, err := s.testProviderConnectivity(probeReq)
-			if err != nil || !success {
-				c.JSON(http.StatusBadRequest, gin.H{
-					"success": false,
-					"error":   fmt.Sprintf("Provider verification failed: %s", message),
-				})
-				return
-			}
-		}
-	}
+	// Connectivity verification is intentionally NOT enforced here: provider
+	// keys can be added regardless of probe results (some providers don't
+	// support every endpoint). Connection testing is available separately as
+	// an optional, informational check via the lightweight probe endpoint.
 
 	// Set default enabled status if not provided
 	if !req.Enabled {


### PR DESCRIPTION
## Summary
Users reported that after adding an API key the dialog closed but the key was not actually saved. Investigation found several bugs in the add-provider flow (frontend + backend); this PR fixes all of them so a key can be added directly, with connection testing remaining purely optional. It also cleans up two related provider-dialog UX issues.

## Root causes & fixes

### 1. Backend still enforced mandatory connectivity verification (`internal/server/provider_handler.go`)
`CreateProvider` still ran a connectivity probe and rejected the request when it failed, contradicting the intent of #964 (the probe is meant to be optional/informational). Providers that don't support every endpoint — or any environment with restricted egress — could never be added.
- Removed the mandatory verification block (and the now-unused `force` query param and `probe` import).
- The lightweight probe endpoint remains for opt-in "Test Connection" testing.

### 2. Dialog closed before the request finished (`ProviderFormDialog.tsx`)
`handleSubmit` called `onClose()` before the async `onSubmit()`, so the dialog dismissed regardless of success/failure — making a failed add look like it had worked.
- Removed the eager `onClose()`; the parent's submit handler now closes the dialog only after the add/update succeeds. On failure the dialog stays open with the error.

### 3. Stale-state race made "Add" fail unless "Test Connection" was clicked first
For a free-typed provider, the dialog committed the auto-generated `name` (and `apiBase`) via async `onChange` and then immediately called `onSubmit`. The parent's submit closure read **stale, empty** values, so the payload went out with `name: ""` and the backend's required-field validation rejected it. Clicking "Test Connection" first happened to flush the name via `ensureName()`, which is why adding only worked after testing.
- The dialog now passes the finalized fields to `onSubmit(e, resolved)`, and each caller (`CredentialPage`, `Onboarding`, `useProviderDialog`) merges them over its form state before building the payload.

### 4. Notifications didn't use the unified component (`CredentialPage.tsx`)
The provider page rendered its own MUI `Snackbar` anchored **bottom-right** instead of the shared notification stack.
- Routed all notifications through `useNotify`, so they render **top-right** via the unified `NotificationProvider`. Removed the page's local `Snackbar`/`Alert` and snackbar state.

### 5. No feedback while the save request is in flight (`ProviderFormDialog.tsx`)
The submit button only spun for "Test Connection", not for the actual add/update.
- `handleSubmit` now awaits `onSubmit`, showing a spinner on the submit button and disabling the actions while the request is in flight. On success the parent closes the dialog; on failure the spinner clears so the user can retry. (`onSubmit` type widened to `void | Promise<void>`.)

## Verification
Drove the frontend in mock mode (headless Chrome) and confirmed:
- Adding a free-typed provider **without** clicking Test Connection now sends a well-formed payload (`name`, `api_base`, `token` all populated). Before: `name: ""` → backend rejects.
- Notifications render top-right (`top:24, right:24`) via the unified component.
- The submit button shows a spinner while the request is in flight.

Backend `go build` passes; frontend `tsc` introduces no new type errors (pre-existing errors unrelated to this change).

## Files changed
- `internal/server/provider_handler.go`
- `frontend/src/components/ProviderFormDialog.tsx`
- `frontend/src/pages/CredentialPage.tsx`
- `frontend/src/pages/Onboarding.tsx`
- `frontend/src/hooks/useProviderDialog.tsx`

https://claude.ai/code/session_013kcdpeu9JJQUrtmYafAe8U