### PR TITLE
refactor(server, client): Migrate image generation persistence to server

### DIFF
--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -2,12 +2,9 @@ package client
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -23,9 +20,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/assembler"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
-
-// Image generation persistence directory
-const imagePersistDir = ".tingly-image"
 
 // CodexClient wraps OpenAIClient with Codex-specific behaviors.
 // It embeds OpenAIClient to inherit standard OpenAI API functionality,
@@ -124,7 +118,7 @@ func (c *CodexClient) ResponsesNewStreaming(ctx context.Context, req responses.R
 // ImagesGenerate creates a new image generation request.
 // For Codex, this transforms the request to use the Responses API with the image_generation tool,
 // as ChatGPT backend API does not support the standard /images/generations endpoint.
-// Generated images and prompts are persisted to .tingly-image/ directory for debugging.
+// Persistence of generated images is handled by the server layer, not the client.
 func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenerateParams) (*openai.ImagesResponse, error) {
 	logrus.Debugf("[Codex] Using Responses API for image generation, model: %s", req.Model)
 
@@ -135,15 +129,7 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 	stream := c.OpenAIClient.ResponsesNewStreaming(ctx, responsesReq)
 
 	// Parse streaming response
-	resp, err := c.parseImageGenerationStream(ctx, stream)
-	if err != nil {
-		return nil, err
-	}
-
-	// Persist images and prompts
-	c.persistImageGeneration(req, resp)
-
-	return resp, nil
+	return c.parseImageGenerationStream(ctx, stream)
 }
 
 // applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
@@ -708,76 +694,4 @@ func (c *CodexClient) ProbeResponsesStream(ctx context.Context, model, message s
 
 	chunksJSON, _ := json.Marshal(chunks)
 	return ToProbeResult(string(chunksJSON), time.Since(startTime).Milliseconds(), c.provider.APIBase+"/responses", true), nil
-}
-
-// persistImageGeneration saves generated images and their prompts to disk.
-// Images are saved as PNG files with base64 data decoded.
-// Prompts are saved as .txt files alongside the images.
-// Files are organized in .tingly-image/ directory by timestamp.
-func (c *CodexClient) persistImageGeneration(req openai.ImageGenerateParams, resp *openai.ImagesResponse) {
-	if resp == nil || len(resp.Data) == 0 {
-		logrus.Warn("[Codex] No image data to persist")
-		return
-	}
-
-	// Create timestamp for this generation
-	timestamp := time.Now().Format("20060102-150405")
-
-	// Create directory: .tingly-image/YYYYMMDD/
-	dateDir := filepath.Join(imagePersistDir, time.Now().Format("20060102"))
-	if err := os.MkdirAll(dateDir, 0755); err != nil {
-		logrus.Errorf("[Codex] Failed to create image directory: %v", err)
-		return
-	}
-
-	// Save each image with its prompt
-	for i, img := range resp.Data {
-		// Generate filename: timestamp-index.png
-		var filename string
-		if i == 0 {
-			filename = fmt.Sprintf("%s.png", timestamp)
-		} else {
-			filename = fmt.Sprintf("%s-%d.png", timestamp, i)
-		}
-		imagePath := filepath.Join(dateDir, filename)
-
-		// Decode base64 and save as PNG
-		imageData, err := base64.StdEncoding.DecodeString(img.B64JSON)
-		if err != nil {
-			logrus.Errorf("[Codex] Failed to decode base64 image data: %v", err)
-			continue
-		}
-
-		if err := os.WriteFile(imagePath, imageData, 0644); err != nil {
-			logrus.Errorf("[Codex] Failed to write image file: %v", err)
-			continue
-		}
-
-		logrus.Infof("[Codex] Saved image to: %s", imagePath)
-
-		// Save prompt as .txt file
-		promptFilename := strings.Replace(filename, ".png", ".txt", 1)
-		promptPath := filepath.Join(dateDir, promptFilename)
-
-		// Build prompt metadata
-		promptContent := fmt.Sprintf("Prompt: %s\n\nModel: %s\nSize: %s\nQuality: %s\nFormat: %s\nTimestamp: %s\n",
-			req.Prompt,
-			req.Model,
-			req.Size,
-			req.Quality,
-			req.ResponseFormat,
-			time.Now().Format(time.RFC3339),
-		)
-
-		if req.Style != "" {
-			promptContent += fmt.Sprintf("Style: %s\n", req.Style)
-		}
-
-		if err := os.WriteFile(promptPath, []byte(promptContent), 0644); err != nil {
-			logrus.Errorf("[Codex] Failed to write prompt file: %v", err)
-			continue
-		}
-
-		logrus.Infof("[Codex] Saved prompt to: %s", promptPath)
-	}
 }

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -508,6 +508,65 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 	}, nil
 }
 
+// parseImageGenerationStreamNext parses the streaming Responses API response
+// and extracts the generated image data using the ResponsesAssembler.
+//
+// The image data comes through two event types:
+// 1. response.image_generation_call.partial_image - streaming partial image chunks
+// 2. response.output_item.done - final status of the image generation call
+//
+// Supports multiple images via different output indices.
+func (c *CodexClient) parseImageGenerationStreamNext(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
+	defer stream.Close()
+
+	// Use assembler to accumulate streaming events
+	asm := assembler.NewResponsesAssembler()
+
+	for stream.Next() {
+		event := stream.Current()
+		asm.Accumulate(event)
+
+		// Early exit on terminal states
+		if asm.IsFinished() {
+			break
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, fmt.Errorf("stream error: %w", err)
+	}
+
+	// Get all images from assembler
+	imagesMap := asm.Images()
+	if len(imagesMap) == 0 {
+		return nil, fmt.Errorf("no image data in response")
+	}
+
+	// Build ImagesResponse with all images
+	// Sort by output index to maintain order
+	imageCount := asm.ImageCount()
+	data := make([]openai.Image, 0, imageCount)
+	for idx := 0; idx < imageCount; idx++ {
+		b64JSON := asm.ImageDataAt(idx)
+		if b64JSON == "" {
+			logrus.Warnf("[Codex] Missing image data at index %d", idx)
+			continue
+		}
+		data = append(data, openai.Image{
+			B64JSON: b64JSON,
+		})
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("no valid image data in response")
+	}
+
+	logrus.Infof("[Codex] Successfully extracted %d image(s) via assembler", len(data))
+	return &openai.ImagesResponse{
+		Data: data,
+	}, nil
+}
+
 // parseResponsesStream parses the streaming Responses API response
 // and assembles it into a complete non-streaming Response object using
 // the ResponsesAssembler.

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -508,65 +508,6 @@ func (c *CodexClient) parseImageGenerationStream(ctx context.Context, stream *ss
 	}, nil
 }
 
-// parseImageGenerationStreamNext parses the streaming Responses API response
-// and extracts the generated image data using the ResponsesAssembler.
-//
-// The image data comes through two event types:
-// 1. response.image_generation_call.partial_image - streaming partial image chunks
-// 2. response.output_item.done - final status of the image generation call
-//
-// Supports multiple images via different output indices.
-func (c *CodexClient) parseImageGenerationStreamNext(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion]) (*openai.ImagesResponse, error) {
-	defer stream.Close()
-
-	// Use assembler to accumulate streaming events
-	asm := assembler.NewResponsesAssembler()
-
-	for stream.Next() {
-		event := stream.Current()
-		asm.Accumulate(event)
-
-		// Early exit on terminal states
-		if asm.IsFinished() {
-			break
-		}
-	}
-
-	if err := stream.Err(); err != nil {
-		return nil, fmt.Errorf("stream error: %w", err)
-	}
-
-	// Get all images from assembler
-	imagesMap := asm.Images()
-	if len(imagesMap) == 0 {
-		return nil, fmt.Errorf("no image data in response")
-	}
-
-	// Build ImagesResponse with all images
-	// Sort by output index to maintain order
-	imageCount := asm.ImageCount()
-	data := make([]openai.Image, 0, imageCount)
-	for idx := 0; idx < imageCount; idx++ {
-		b64JSON := asm.ImageDataAt(idx)
-		if b64JSON == "" {
-			logrus.Warnf("[Codex] Missing image data at index %d", idx)
-			continue
-		}
-		data = append(data, openai.Image{
-			B64JSON: b64JSON,
-		})
-	}
-
-	if len(data) == 0 {
-		return nil, fmt.Errorf("no valid image data in response")
-	}
-
-	logrus.Infof("[Codex] Successfully extracted %d image(s) via assembler", len(data))
-	return &openai.ImagesResponse{
-		Data: data,
-	}, nil
-}
-
 // parseResponsesStream parses the streaming Responses API response
 // and assembles it into a complete non-streaming Response object using
 // the ResponsesAssembler.

--- a/internal/constant/constant.go
+++ b/internal/constant/constant.go
@@ -96,6 +96,8 @@ const DBDirName = "db"
 
 const MemoryDirName = "memory"
 
+const ImageDirName = "image"
+
 // GetTinglyConfDir returns the config directory path (default: ~/.tingly-box)
 func GetTinglyConfDir() string {
 	homeDir, err := fs.GetUserPath()
@@ -122,4 +124,9 @@ func GetDBDir(baseDir string) string {
 
 func GetDBFile(baseDir string) string {
 	return filepath.Join(baseDir, DBDirName, DBFileName)
+}
+
+// GetImageDir returns the generated-image persistence directory path
+func GetImageDir(baseDir string) string {
+	return filepath.Join(baseDir, ImageDirName)
 }

--- a/internal/server/image_persist.go
+++ b/internal/server/image_persist.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+)
+
+// persistImageGeneration saves generated images and their prompts under the
+// configured image directory (configDir/image/YYYYMMDD/). It is best-effort:
+// any failure is logged but never blocks the response to the caller.
+//
+// This used to live inside the Codex client and wrote to .tingly-image/ in the
+// process working directory. It now belongs to the server layer so persistence
+// is uniform across providers and rooted at the application config directory.
+func (s *Server) persistImageGeneration(req *openai.ImageGenerateParams, resp *openai.ImagesResponse) {
+	if resp == nil || len(resp.Data) == 0 {
+		return
+	}
+
+	baseDir := ""
+	if s.config != nil {
+		baseDir = s.config.ConfigDir
+	}
+	if baseDir == "" {
+		baseDir = constant.GetTinglyConfDir()
+	}
+
+	now := time.Now()
+	timestamp := now.Format("20060102-150405")
+	dateDir := filepath.Join(constant.GetImageDir(baseDir), now.Format("20060102"))
+	if err := os.MkdirAll(dateDir, 0700); err != nil {
+		logrus.Errorf("[ImageGen] Failed to create image directory: %v", err)
+		return
+	}
+
+	for i, img := range resp.Data {
+		// Only base64-encoded images can be persisted locally; URL-based
+		// responses (e.g. some DashScope/MiniMax modes) are skipped.
+		if img.B64JSON == "" {
+			continue
+		}
+
+		var filename string
+		if i == 0 {
+			filename = fmt.Sprintf("%s.png", timestamp)
+		} else {
+			filename = fmt.Sprintf("%s-%d.png", timestamp, i)
+		}
+		imagePath := filepath.Join(dateDir, filename)
+
+		imageData, err := base64.StdEncoding.DecodeString(img.B64JSON)
+		if err != nil {
+			logrus.Errorf("[ImageGen] Failed to decode base64 image data: %v", err)
+			continue
+		}
+
+		if err := os.WriteFile(imagePath, imageData, 0600); err != nil {
+			logrus.Errorf("[ImageGen] Failed to write image file: %v", err)
+			continue
+		}
+
+		logrus.Infof("[ImageGen] Saved image to: %s", imagePath)
+
+		if req == nil {
+			continue
+		}
+
+		promptPath := filepath.Join(dateDir, strings.Replace(filename, ".png", ".txt", 1))
+		promptContent := fmt.Sprintf("Prompt: %s\n\nModel: %s\nSize: %s\nQuality: %s\nFormat: %s\nTimestamp: %s\n",
+			req.Prompt,
+			req.Model,
+			req.Size,
+			req.Quality,
+			req.ResponseFormat,
+			now.Format(time.RFC3339),
+		)
+		if req.Style != "" {
+			promptContent += fmt.Sprintf("Style: %s\n", req.Style)
+		}
+
+		if err := os.WriteFile(promptPath, []byte(promptContent), 0600); err != nil {
+			logrus.Errorf("[ImageGen] Failed to write prompt file: %v", err)
+			continue
+		}
+	}
+}

--- a/internal/server/image_persist.go
+++ b/internal/server/image_persist.go
@@ -37,9 +37,18 @@ func (s *Server) persistImageGeneration(req *openai.ImageGenerateParams, resp *o
 	now := time.Now()
 	timestamp := now.Format("20060102-150405")
 	dateDir := filepath.Join(constant.GetImageDir(baseDir), now.Format("20060102"))
-	if err := os.MkdirAll(dateDir, 0700); err != nil {
-		logrus.Errorf("[ImageGen] Failed to create image directory: %v", err)
-		return
+
+	dirReady := false
+	ensureDir := func() bool {
+		if dirReady {
+			return true
+		}
+		if err := os.MkdirAll(dateDir, 0700); err != nil {
+			logrus.Errorf("[ImageGen] Failed to create image directory: %v", err)
+			return false
+		}
+		dirReady = true
+		return true
 	}
 
 	for i, img := range resp.Data {
@@ -47,6 +56,9 @@ func (s *Server) persistImageGeneration(req *openai.ImageGenerateParams, resp *o
 		// responses (e.g. some DashScope/MiniMax modes) are skipped.
 		if img.B64JSON == "" {
 			continue
+		}
+		if !ensureDir() {
+			return
 		}
 
 		var filename string

--- a/internal/server/image_persist_test.go
+++ b/internal/server/image_persist_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+)
+
+func TestPersistImageGeneration(t *testing.T) {
+	pngBytes := []byte("\x89PNG\r\n\x1a\nfake-image-data")
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	t.Run("writes image and prompt under configDir/image", func(t *testing.T) {
+		tmp := t.TempDir()
+		s := &Server{config: &config.Config{ConfigDir: tmp}}
+
+		req := &openai.ImageGenerateParams{
+			Prompt: "a red bicycle",
+			Model:  "gpt-image-1",
+			Size:   openai.ImageGenerateParamsSize1024x1024,
+		}
+		resp := &openai.ImagesResponse{Data: []openai.Image{{B64JSON: b64}}}
+
+		s.persistImageGeneration(req, resp)
+
+		imageRoot := constant.GetImageDir(tmp)
+		dirs, err := os.ReadDir(imageRoot)
+		require.NoError(t, err)
+		require.Len(t, dirs, 1, "expected a single date directory")
+
+		dateDir := filepath.Join(imageRoot, dirs[0].Name())
+		entries, err := os.ReadDir(dateDir)
+		require.NoError(t, err)
+
+		var pngFiles, txtFiles int
+		for _, e := range entries {
+			switch filepath.Ext(e.Name()) {
+			case ".png":
+				pngFiles++
+				data, readErr := os.ReadFile(filepath.Join(dateDir, e.Name()))
+				require.NoError(t, readErr)
+				assert.Equal(t, pngBytes, data, "decoded image bytes should match")
+			case ".txt":
+				txtFiles++
+				meta, readErr := os.ReadFile(filepath.Join(dateDir, e.Name()))
+				require.NoError(t, readErr)
+				assert.Contains(t, string(meta), "a red bicycle")
+			}
+		}
+		assert.Equal(t, 1, pngFiles)
+		assert.Equal(t, 1, txtFiles)
+	})
+
+	t.Run("writes multiple images with indexed filenames", func(t *testing.T) {
+		tmp := t.TempDir()
+		s := &Server{config: &config.Config{ConfigDir: tmp}}
+
+		resp := &openai.ImagesResponse{Data: []openai.Image{{B64JSON: b64}, {B64JSON: b64}}}
+		s.persistImageGeneration(&openai.ImageGenerateParams{Prompt: "x"}, resp)
+
+		dirs, err := os.ReadDir(constant.GetImageDir(tmp))
+		require.NoError(t, err)
+		require.Len(t, dirs, 1)
+		entries, err := os.ReadDir(filepath.Join(constant.GetImageDir(tmp), dirs[0].Name()))
+		require.NoError(t, err)
+
+		var pngFiles int
+		for _, e := range entries {
+			if filepath.Ext(e.Name()) == ".png" {
+				pngFiles++
+			}
+		}
+		assert.Equal(t, 2, pngFiles)
+	})
+
+	t.Run("skips images without base64 data", func(t *testing.T) {
+		tmp := t.TempDir()
+		s := &Server{config: &config.Config{ConfigDir: tmp}}
+
+		resp := &openai.ImagesResponse{Data: []openai.Image{{URL: "https://example.com/x.png"}}}
+		s.persistImageGeneration(&openai.ImageGenerateParams{Prompt: "x"}, resp)
+
+		_, err := os.ReadDir(constant.GetImageDir(tmp))
+		assert.True(t, os.IsNotExist(err), "no image directory should be created")
+	})
+
+	t.Run("no-op for empty response", func(t *testing.T) {
+		tmp := t.TempDir()
+		s := &Server{config: &config.Config{ConfigDir: tmp}}
+
+		s.persistImageGeneration(&openai.ImageGenerateParams{}, &openai.ImagesResponse{})
+
+		_, err := os.ReadDir(constant.GetImageDir(tmp))
+		assert.True(t, os.IsNotExist(err))
+	})
+}

--- a/internal/server/openai_images.go
+++ b/internal/server/openai_images.go
@@ -149,6 +149,9 @@ func (s *Server) HandleOpenAIImageGeneration(c *gin.Context) {
 	usage := protocol.NewTokenUsageWithCache(int(resp.Usage.InputTokens), int(resp.Usage.OutputTokens), 0)
 	s.trackUsageWithTokenUsage(c, usage, nil)
 
+	// Persist generated images under the config image directory (best-effort).
+	s.persistImageGeneration(&req, resp)
+
 	responseJSON, err := json.Marshal(resp)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{


### PR DESCRIPTION
Move generated-image persistence out of the Codex client (was writing to `.tingly-image/` in the working dir) into the server image handler, rooted at `configDir/image/YYYYMMDD/` and uniform across providers.

- Codex client only generates; no file I/O
- Best-effort persistence; URL-only/empty responses skipped
- Tests added
