### PR TITLE
refactor(UI): Rebrand quick config terminology to auto config

### DIFF
--- a/frontend/src/components/AgentSetupCard.tsx
+++ b/frontend/src/components/AgentSetupCard.tsx
@@ -94,11 +94,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     onApplyWithStatusLine,
     isApplyLoading = false,
     onViewConfig,
-    applyStepLabel = 'Apply Config',
+    applyStepLabel = 'Auto Config',
     applyStepDescription,
-    applyButtonLabel = 'Apply',
+    applyButtonLabel = 'Auto Config',
     applySuccessLabel = 'Config applied!',
-    viewConfigButtonLabel = 'Manual Setup',
+    viewConfigButtonLabel = 'Config',
     hasModelSelected = false,
     onSelectModel,
 }) => {
@@ -271,7 +271,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
             title={
                 <Stack direction="row" alignItems="center" spacing={1} sx={{ flex: 1 }}>
                     <Typography variant="subtitle1" fontWeight={600}>
-                        Guiding
+                        Quick Start
                     </Typography>
                     <Chip
                         label={progressLabel}
@@ -395,7 +395,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                         )}
 
                         {stepCursor === 3 && (
-                        <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}><Typography variant="body2" fontWeight={500} color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}>Step 4 — {applyStepLabel}</Typography><Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>{applyStepDescription ?? `Write the proxy configuration to ${agentName}'s settings file.`}</Typography><Collapse in={!applyDone}><Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>{onApply && <Button variant="contained" size="small" disabled={!installDone || isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>{applyButtonLabel}</Button>}{onApplyWithStatusLine && <Button variant="outlined" size="small" disabled={!installDone || isApplyLoading} onClick={handleApplyWithStatusLine}>Apply + Status Line</Button>}{onViewConfig && <Button variant={onApply ? "outlined" : "contained"} size="small" disabled={!installDone} onClick={onViewConfig}>{viewConfigButtonLabel}</Button>}</Stack></Collapse>{applyResult && (<Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 1, py: 0.5 }}>{applyResult.success ? (<Box><Typography variant="caption" fontWeight={600}>{applySuccessLabel}</Typography>{applyResult.files?.map(f => (<Typography key={f} variant="caption" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>))}</Box>) : (<Typography variant="caption">{applyResult.error ?? 'Apply failed'}</Typography>)}</Alert>)}</Box></Stack>
+                        <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}><Typography variant="body2" fontWeight={500} color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}>Step 4 — {applyStepLabel}</Typography><Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>{applyStepDescription ?? `Write the proxy configuration to ${agentName}'s settings file.`}</Typography><Collapse in={!applyDone}><Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>{onApply && <Button variant="contained" size="small" disabled={!installDone || isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>{applyButtonLabel}</Button>}{onApplyWithStatusLine && <Button variant="outlined" size="small" disabled={!installDone || isApplyLoading} onClick={handleApplyWithStatusLine}>Auto Config + Status Line</Button>}{onViewConfig && <Button variant={onApply ? "outlined" : "contained"} size="small" disabled={!installDone} onClick={onViewConfig}>{viewConfigButtonLabel}</Button>}</Stack></Collapse>{applyResult && (<Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 1, py: 0.5 }}>{applyResult.success ? (<Box><Typography variant="caption" fontWeight={600}>{applySuccessLabel}</Typography>{applyResult.files?.map(f => (<Typography key={f} variant="caption" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>))}</Box>) : (<Typography variant="caption">{applyResult.error ?? 'Apply failed'}</Typography>)}</Alert>)}</Box></Stack>
                         )}
 
                         </Box>

--- a/frontend/src/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/components/ClaudeCodeConfigModal.tsx
@@ -35,8 +35,8 @@ type ScriptTab = 'json' | 'windows' | 'unix';
 // time keeps this file self-contained and easy to tune.
 const MODAL_TEXT = {
     zh: {
-        tabQuick: '快速配置',
-        tabManual: '手动配置',
+        tabQuick: '自动配置',
+        tabManual: '配置',
         previewButton: '预览生成的 env',
         previewTitle: '预览 — 将写入 ~/.claude/settings.json 的 env 段',
         applySuccess: '配置已写入',
@@ -46,8 +46,8 @@ const MODAL_TEXT = {
         backupLabel: '已备份至',
     },
     en: {
-        tabQuick: 'Quick config',
-        tabManual: 'Manual config',
+        tabQuick: 'Auto Config',
+        tabManual: 'Config',
         previewButton: 'Preview generated env',
         previewTitle: 'Preview — env block written to ~/.claude/settings.json',
         applySuccess: 'Configuration applied',

--- a/frontend/src/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/components/ClaudeCodeConfigModal.tsx
@@ -36,7 +36,7 @@ type ScriptTab = 'json' | 'windows' | 'unix';
 const MODAL_TEXT = {
     zh: {
         tabQuick: '自动配置',
-        tabManual: '配置',
+        tabManual: '手动',
         previewButton: '预览生成的 env',
         previewTitle: '预览 — 将写入 ~/.claude/settings.json 的 env 段',
         applySuccess: '配置已写入',
@@ -47,7 +47,7 @@ const MODAL_TEXT = {
     },
     en: {
         tabQuick: 'Auto Config',
-        tabManual: 'Config',
+        tabManual: 'Manual',
         previewButton: 'Preview generated env',
         previewTitle: 'Preview — env block written to ~/.claude/settings.json',
         applySuccess: 'Configuration applied',

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -389,7 +389,7 @@ EOF`;
                         disabled={isApplying}
                         startIcon={isApplying ? <CircularProgress size={16} color="inherit" /> : null}
                     >
-                        {isApplying ? 'Applying...' : 'Apply Configuration'}
+                        {isApplying ? 'Applying...' : 'Auto Config'}
                     </Button>
                 </Box>
             </DialogActions>

--- a/frontend/src/components/OpenCodeConfigModal.tsx
+++ b/frontend/src/components/OpenCodeConfigModal.tsx
@@ -154,7 +154,7 @@ const OpenCodeConfigModal: React.FC<OpenCodeConfigModalProps> = ({
                         disabled={isApplyLoading}
                         startIcon={isApplyLoading ? <CircularProgress size={16} color="inherit" /> : null}
                     >
-                        {isApplyLoading ? 'Applying...' : 'Apply Configuration'}
+                        {isApplyLoading ? 'Applying...' : 'Auto Config'}
                     </Button>
                 )}
             </DialogActions>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -571,9 +571,9 @@ export default {
     "separateConfig": "Separate Configuration",
     "switchToSeparate": "Switch to Separate",
     "switchToUnified": "Switch to Unified",
-    "configButton": "Quick Config",
-    "quickApply": "Quick Apply",
-    "quickApplyWithStatusLine": "Quick Apply & Status Line",
+    "configButton": "Config",
+    "quickApply": "Auto Config",
+    "quickApplyWithStatusLine": "Auto Config & Status Line",
     "statusLine": {
       "description": "Install status line integration to show real-time request information in your terminal.",
       "jsonDescription": "Configure the status line integration to display real-time request information in your terminal prompt.",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -571,7 +571,7 @@ export default {
     "separateConfig": "Separate Configuration",
     "switchToSeparate": "Switch to Separate",
     "switchToUnified": "Switch to Unified",
-    "configButton": "Config",
+    "configButton": "Auto Config",
     "quickApply": "Auto Config",
     "quickApplyWithStatusLine": "Auto Config & Status Line",
     "statusLine": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -572,7 +572,7 @@ export default {
     "separateConfig": "分离配置",
     "switchToSeparate": "切换到分离",
     "switchToUnified": "切换到统一",
-    "configButton": "配置",
+    "configButton": "自动配置",
     "quickApply": "自动配置",
     "quickApplyWithStatusLine": "自动配置和状态行",
     "statusLine": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -572,9 +572,9 @@ export default {
     "separateConfig": "分离配置",
     "switchToSeparate": "切换到分离",
     "switchToUnified": "切换到统一",
-    "configButton": "快速配置",
-    "quickApply": "快速应用",
-    "quickApplyWithStatusLine": "快速应用和状态行",
+    "configButton": "配置",
+    "quickApply": "自动配置",
+    "quickApplyWithStatusLine": "自动配置和状态行",
     "statusLine": {
       "description": "安装状态行集成以在您的终端中显示实时请求信息。",
       "jsonDescription": "配置状态行集成以在您的终端提示符中显示实时请求信息。",

--- a/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
@@ -47,7 +47,7 @@ const UseClaudeDesktopPageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Config Guide
+                            Config
                         </Button>
                     }
                 >

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -74,7 +74,7 @@ const UseCodexPageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Config
+                            Auto Config
                         </Button>
                     }
                 >

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -74,7 +74,7 @@ const UseCodexPageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Config Codex
+                            Config
                         </Button>
                     }
                 >

--- a/frontend/src/pages/scenario/UseOpenCodePage.tsx
+++ b/frontend/src/pages/scenario/UseOpenCodePage.tsx
@@ -103,7 +103,7 @@ const UseOpenCodePageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Quick Config
+                            Config
                         </Button>
                     }
                 >

--- a/frontend/src/pages/scenario/UseOpenCodePage.tsx
+++ b/frontend/src/pages/scenario/UseOpenCodePage.tsx
@@ -103,7 +103,7 @@ const UseOpenCodePageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Config
+                            Auto Config
                         </Button>
                     }
                 >

--- a/frontend/src/pages/scenario/UseVSCodePage.tsx
+++ b/frontend/src/pages/scenario/UseVSCodePage.tsx
@@ -67,7 +67,7 @@ const UseVSCodePageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Config Guide
+                            Config
                         </Button>
                     }
                 >

--- a/frontend/src/pages/scenario/UseXcodePage.tsx
+++ b/frontend/src/pages/scenario/UseXcodePage.tsx
@@ -47,7 +47,7 @@ const UseXcodePageContent: React.FC = () => {
                             variant="contained"
                             size="small"
                         >
-                            Config Guide
+                            Config
                         </Button>
                     }
                 >


### PR DESCRIPTION
## Summary
Updated UI terminology across the application to consistently use "Auto Config" instead of "Quick Config" or "Quick Apply" to better reflect the automated nature of the configuration process.

## Key Changes
- **AgentSetupCard component**: Updated default labels for apply step and button from "Apply Config"/"Apply" to "Auto Config", and changed "Manual Setup" to "Config"
- **Card title**: Changed "Guiding" to "Quick Start" for the setup card header
- **Apply with status line button**: Updated label to "Auto Config + Status Line"
- **ClaudeCodeConfigModal**: Updated tab labels from "Quick config"/"Manual config" to "Auto Config"/"Manual" in both English and Chinese
- **CodexConfigModal & OpenCodeConfigModal**: Changed apply button text from "Apply Configuration" to "Auto Config"
- **Scenario pages**: Standardized button labels across all setup pages:
  - UseClaudeDesktopPage: "Config Guide" → "Config"
  - UseCodexPage: "Config Codex" → "Auto Config"
  - UseOpenCodePage: "Quick Config" → "Auto Config"
  - UseVSCodePage: "Config Guide" → "Config"
  - UseXcodePage: "Config Guide" → "Config"
- **i18n locales**: Updated English and Chinese translation strings for `configButton`, `quickApply`, and `quickApplyWithStatusLine` keys

## Implementation Details
The changes maintain backward compatibility by updating default parameter values and hardcoded strings. All UI text changes are consistent across components and locales, improving the user experience by using clearer terminology that emphasizes the automated configuration process.

https://claude.ai/code/session_01B8B4NZFbAzPny8dqJ34s2D