### PR TITLE
feat(rule): add tool blocking feature to filter request tools by name

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -127,6 +127,7 @@ func RuleFlagRegistry() []FlagSpec { … }
 | `use_max_tokens` | bool | request | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b）|
 | `custom_user_agent` | string | request | 覆盖出站 User-Agent header | `customUserAgentTransport` + `WithCustomUserAgent(ctx, ...)`（Type 2）|
 | `openai_endpoint_override` | enum (`auto`/`chat`/`responses`) | request | 强制单条 rule 的 OpenAI 出口走 Chat 或 Responses；与 provider 声明的 `OpenAIEndpointMode` 冲突时 provider 赢（见 `.design/openai-endpoint-routing.md`）| `ParseEndpointOverride` → `ResolveOpenAIEndpoint`（Type 4：路由层决策）|
+| `block_tools` | string (逗号分隔) | request | 按名字从请求 tool list 中剔除指定工具（发出前），跨 OpenAI Chat / Responses / Anthropic / Google 入站形态生效 | `transform.ToolBlockTransform` → `ops.ApplyToolBlock*`（Type 1b-pre：pre-Base chain stage）|
 
 ---
 

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -59,6 +59,7 @@ export interface RuleFlags {
     useMaxCompletionTokens?: boolean;
     useMaxTokens?: boolean;
     openaiEndpointOverride?: string;
+    blockTools?: string;
 }
 
 export interface RuleFlagsApi {
@@ -69,6 +70,7 @@ export interface RuleFlagsApi {
     use_max_completion_tokens?: boolean;
     use_max_tokens?: boolean;
     openai_endpoint_override?: string;
+    block_tools?: string;
 }
 
 export type FlagValueType = 'bool' | 'string' | 'enum';

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -20,6 +20,7 @@ import CableIcon from '@mui/icons-material/Cable';
 import OutboundIcon from '@mui/icons-material/Outbound';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import ExtensionIcon from '@mui/icons-material/Extension';
+import InputIcon from '@mui/icons-material/Input';
 import CloseIcon from '@mui/icons-material/Close';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
@@ -61,6 +62,8 @@ const flagToString = (flags: RuleFlags | undefined, key: string): string => {
             return flags.customUserAgent || '';
         case 'openai_endpoint_override':
             return flags.openaiEndpointOverride || '';
+        case 'block_tools':
+            return flags.blockTools || '';
         default:
             return '';
     }
@@ -90,6 +93,8 @@ const setString = (flags: RuleFlags, key: string, value: string): RuleFlags => {
         case 'openai_endpoint_override':
             // Persist "auto" as empty string so omitempty hides it on the wire.
             return { ...flags, openaiEndpointOverride: value === ENUM_DEFAULT_VALUE ? '' : value };
+        case 'block_tools':
+            return { ...flags, blockTools: value };
         default:
             return flags;
     }
@@ -118,6 +123,7 @@ const CATEGORY_META: Record<string, CategoryMeta> = {
     openai: { label: 'OpenAI', icon: <AutoAwesomeIcon fontSize="small" /> },
     http: { label: 'HTTP', icon: <CableIcon fontSize="small" /> },
     response: { label: 'Response', icon: <OutboundIcon fontSize="small" /> },
+    request: { label: 'Request', icon: <InputIcon fontSize="small" /> },
 };
 
 const categoryMeta = (category: string): CategoryMeta => CATEGORY_META[category] || {

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -67,6 +67,8 @@ const flagStringValue = (flags: RuleFlags | undefined, key: string): string => {
             return flags.customUserAgent || '';
         case 'openai_endpoint_override':
             return flags.openaiEndpointOverride || '';
+        case 'block_tools':
+            return flags.blockTools || '';
         default:
             return '';
     }

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -122,6 +122,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         use_max_completion_tokens: newConfigRecord.flags?.useMaxCompletionTokens || false,
                         use_max_tokens: newConfigRecord.flags?.useMaxTokens || false,
                         openai_endpoint_override: newConfigRecord.flags?.openaiEndpointOverride || '',
+                        block_tools: newConfigRecord.flags?.blockTools || '',
                     },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -73,6 +73,7 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
             useMaxCompletionTokens: rule.flags?.use_max_completion_tokens || false,
             useMaxTokens: rule.flags?.use_max_tokens || false,
             openaiEndpointOverride: rule.flags?.openai_endpoint_override || '',
+            blockTools: rule.flags?.block_tools || '',
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
@@ -193,6 +194,7 @@ interface ExportRule {
         use_max_completion_tokens?: boolean;
         use_max_tokens?: boolean;
         openai_endpoint_override?: string;
+        block_tools?: string;
     };
     smart_enabled?: boolean;
     smart_routing: any[];
@@ -242,10 +244,11 @@ export function formatRuleFlags(flags?: RuleFlags): string {
     if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) {
         entries.push(`openai_endpoint_override=${flags.openaiEndpointOverride}`);
     }
+    if (flags.blockTools) entries.push(`block_tools=${flags.blockTools}`);
     return entries.join(',');
 }
 
-const STRING_FLAG_KEYS = new Set(['custom_user_agent']);
+const STRING_FLAG_KEYS = new Set(['custom_user_agent', 'block_tools']);
 const ENUM_FLAG_KEYS = new Set(Object.keys(ENUM_FLAG_VALUES));
 
 export function parseRuleFlags(input: string): { flags: RuleFlags; error?: string } {
@@ -257,6 +260,7 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
         useMaxCompletionTokens: false,
         useMaxTokens: false,
         openaiEndpointOverride: '',
+        blockTools: '',
     };
 
     const trimmed = input.trim();
@@ -280,6 +284,9 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             switch (rawKey) {
                 case 'custom_user_agent':
                     flags.customUserAgent = rawValue;
+                    break;
+                case 'block_tools':
+                    flags.blockTools = rawValue;
                     break;
             }
             continue;
@@ -344,6 +351,7 @@ export function countActiveFlags(flags?: RuleFlags): number {
     if (flags.useMaxTokens) n++;
     if (flags.customUserAgent && flags.customUserAgent.trim() !== '') n++;
     if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) n++;
+    if (flags.blockTools && flags.blockTools.trim() !== '') n++;
     return n;
 }
 

--- a/internal/protocol/transform/ops/request_tool_block.go
+++ b/internal/protocol/transform/ops/request_tool_block.go
@@ -1,0 +1,129 @@
+package ops
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// The ApplyToolBlock* primitives drop every tool whose resolved name is present
+// in the `blocked` set from a request's tool list. They are pure functions over
+// a single concrete request type — no rule, chain, or ctx awareness. Tools that
+// carry no addressable name (vendor built-ins like web_search, computer use,
+// code execution) are left untouched: the block list addresses model-callable
+// function/custom tools by name.
+//
+// When the filtered list becomes empty the field is reset to nil so the SDK's
+// omitzero JSON tag drops it from the wire body instead of emitting an empty
+// `"tools": []`.
+
+// ApplyToolBlockOpenAIChat filters tools on an OpenAI Chat request.
+func ApplyToolBlockOpenAIChat(req *openai.ChatCompletionNewParams, blocked map[string]bool) {
+	if req == nil || len(blocked) == 0 || len(req.Tools) == 0 {
+		return
+	}
+	kept := make([]openai.ChatCompletionToolUnionParam, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		if name := openAIChatToolName(tool); name != "" && blocked[name] {
+			continue
+		}
+		kept = append(kept, tool)
+	}
+	if len(kept) == 0 {
+		req.Tools = nil
+		return
+	}
+	req.Tools = kept
+}
+
+func openAIChatToolName(tool openai.ChatCompletionToolUnionParam) string {
+	if tool.OfFunction != nil {
+		return tool.OfFunction.Function.Name
+	}
+	if tool.OfCustom != nil {
+		return tool.OfCustom.Custom.Name
+	}
+	return ""
+}
+
+// ApplyToolBlockResponses filters tools on an OpenAI Responses request.
+func ApplyToolBlockResponses(req *responses.ResponseNewParams, blocked map[string]bool) {
+	if req == nil || len(blocked) == 0 || len(req.Tools) == 0 {
+		return
+	}
+	kept := make([]responses.ToolUnionParam, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		if tool.OfFunction != nil && blocked[tool.OfFunction.Name] {
+			continue
+		}
+		kept = append(kept, tool)
+	}
+	if len(kept) == 0 {
+		req.Tools = nil
+		return
+	}
+	req.Tools = kept
+}
+
+// ApplyToolBlockAnthropic filters tools on an Anthropic Messages request.
+func ApplyToolBlockAnthropic(req *anthropic.MessageNewParams, blocked map[string]bool) {
+	if req == nil || len(blocked) == 0 || len(req.Tools) == 0 {
+		return
+	}
+	kept := make([]anthropic.ToolUnionParam, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		if tool.OfTool != nil && blocked[tool.OfTool.Name] {
+			continue
+		}
+		kept = append(kept, tool)
+	}
+	if len(kept) == 0 {
+		req.Tools = nil
+		return
+	}
+	req.Tools = kept
+}
+
+// ApplyToolBlockAnthropicBeta filters tools on an Anthropic Beta Messages request.
+func ApplyToolBlockAnthropicBeta(req *anthropic.BetaMessageNewParams, blocked map[string]bool) {
+	if req == nil || len(blocked) == 0 || len(req.Tools) == 0 {
+		return
+	}
+	kept := make([]anthropic.BetaToolUnionParam, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		if tool.OfTool != nil && blocked[tool.OfTool.Name] {
+			continue
+		}
+		kept = append(kept, tool)
+	}
+	if len(kept) == 0 {
+		req.Tools = nil
+		return
+	}
+	req.Tools = kept
+}
+
+// ApplyToolBlockGoogle filters function declarations on a Google request.
+func ApplyToolBlockGoogle(req *protocol.GoogleRequest, blocked map[string]bool) {
+	if req == nil || req.Config == nil || len(blocked) == 0 || len(req.Config.Tools) == 0 {
+		return
+	}
+	for _, tool := range req.Config.Tools {
+		if tool == nil || len(tool.FunctionDeclarations) == 0 {
+			continue
+		}
+		kept := tool.FunctionDeclarations[:0]
+		for _, fd := range tool.FunctionDeclarations {
+			if fd != nil && blocked[fd.Name] {
+				continue
+			}
+			kept = append(kept, fd)
+		}
+		if len(kept) == 0 {
+			tool.FunctionDeclarations = nil
+			continue
+		}
+		tool.FunctionDeclarations = kept
+	}
+}

--- a/internal/protocol/transform/ops/request_tool_block_test.go
+++ b/internal/protocol/transform/ops/request_tool_block_test.go
@@ -1,0 +1,144 @@
+package ops
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"google.golang.org/genai"
+)
+
+func blockSet(names ...string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}
+
+func chatFnTool(name string) openai.ChatCompletionToolUnionParam {
+	return openai.ChatCompletionFunctionTool(shared.FunctionDefinitionParam{Name: name})
+}
+
+func TestApplyToolBlockOpenAIChat(t *testing.T) {
+	t.Run("removes only blocked tools", func(t *testing.T) {
+		req := &openai.ChatCompletionNewParams{
+			Tools: []openai.ChatCompletionToolUnionParam{
+				chatFnTool("keep_a"),
+				chatFnTool("block_me"),
+				chatFnTool("keep_b"),
+			},
+		}
+		ApplyToolBlockOpenAIChat(req, blockSet("block_me"))
+		if len(req.Tools) != 2 {
+			t.Fatalf("expected 2 tools, got %d", len(req.Tools))
+		}
+		for _, tool := range req.Tools {
+			if openAIChatToolName(tool) == "block_me" {
+				t.Fatalf("blocked tool still present")
+			}
+		}
+	})
+
+	t.Run("empty block set is a no-op", func(t *testing.T) {
+		req := &openai.ChatCompletionNewParams{
+			Tools: []openai.ChatCompletionToolUnionParam{chatFnTool("a")},
+		}
+		ApplyToolBlockOpenAIChat(req, blockSet())
+		if len(req.Tools) != 1 {
+			t.Fatalf("expected tools untouched, got %d", len(req.Tools))
+		}
+	})
+
+	t.Run("blocking all tools clears the slice to nil", func(t *testing.T) {
+		req := &openai.ChatCompletionNewParams{
+			Tools: []openai.ChatCompletionToolUnionParam{chatFnTool("a"), chatFnTool("b")},
+		}
+		ApplyToolBlockOpenAIChat(req, blockSet("a", "b"))
+		if req.Tools != nil {
+			t.Fatalf("expected nil tools, got %#v", req.Tools)
+		}
+	})
+
+	t.Run("nil request does not panic", func(t *testing.T) {
+		ApplyToolBlockOpenAIChat(nil, blockSet("a"))
+	})
+}
+
+func TestApplyToolBlockResponses(t *testing.T) {
+	req := &responses.ResponseNewParams{
+		Tools: []responses.ToolUnionParam{
+			{OfFunction: &responses.FunctionToolParam{Name: "keep"}},
+			{OfFunction: &responses.FunctionToolParam{Name: "drop"}},
+		},
+	}
+	ApplyToolBlockResponses(req, blockSet("drop"))
+	if len(req.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(req.Tools))
+	}
+	if req.Tools[0].OfFunction.Name != "keep" {
+		t.Fatalf("wrong tool kept: %q", req.Tools[0].OfFunction.Name)
+	}
+}
+
+func TestApplyToolBlockAnthropic(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Tools: []anthropic.ToolUnionParam{
+			{OfTool: &anthropic.ToolParam{Name: "keep"}},
+			{OfTool: &anthropic.ToolParam{Name: "drop"}},
+		},
+	}
+	ApplyToolBlockAnthropic(req, blockSet("drop"))
+	if len(req.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(req.Tools))
+	}
+	if req.Tools[0].OfTool.Name != "keep" {
+		t.Fatalf("wrong tool kept: %q", req.Tools[0].OfTool.Name)
+	}
+}
+
+func TestApplyToolBlockAnthropicBeta(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Tools: []anthropic.BetaToolUnionParam{
+			{OfTool: &anthropic.BetaToolParam{Name: "keep"}},
+			{OfTool: &anthropic.BetaToolParam{Name: "drop"}},
+		},
+	}
+	ApplyToolBlockAnthropicBeta(req, blockSet("drop"))
+	if len(req.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(req.Tools))
+	}
+	if req.Tools[0].OfTool.Name != "keep" {
+		t.Fatalf("wrong tool kept: %q", req.Tools[0].OfTool.Name)
+	}
+}
+
+func TestApplyToolBlockGoogle(t *testing.T) {
+	req := &protocol.GoogleRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{
+				{
+					FunctionDeclarations: []*genai.FunctionDeclaration{
+						{Name: "keep"},
+						{Name: "drop"},
+					},
+				},
+			},
+		},
+	}
+	ApplyToolBlockGoogle(req, blockSet("drop"))
+	decls := req.Config.Tools[0].FunctionDeclarations
+	if len(decls) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(decls))
+	}
+	if decls[0].Name != "keep" {
+		t.Fatalf("wrong declaration kept: %q", decls[0].Name)
+	}
+
+	t.Run("nil config does not panic", func(t *testing.T) {
+		ApplyToolBlockGoogle(&protocol.GoogleRequest{}, blockSet("x"))
+	})
+}

--- a/internal/protocol/transform/tool_block.go
+++ b/internal/protocol/transform/tool_block.go
@@ -1,0 +1,58 @@
+package transform
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform/ops"
+)
+
+// ToolBlockTransform strips a configured set of tools from the request's tool
+// list. It runs as a pre-Base stage so it sees the request in its inbound shape
+// — the names it matches are the ones the client actually sent, before any
+// protocol conversion or vendor-specific tool renaming.
+//
+// The transform is a thin shell: the ops.ApplyToolBlock* primitives do the
+// per-shape filtering; this stage only type-switches the inbound request to the
+// matching primitive. When no names are configured it is never added to the
+// chain (see rulePreBaseTransforms).
+type ToolBlockTransform struct {
+	blocked map[string]bool
+}
+
+// NewToolBlockTransform builds a transform that blocks the given tool names.
+// Names are matched exactly; empty entries are ignored.
+func NewToolBlockTransform(names []string) *ToolBlockTransform {
+	blocked := make(map[string]bool, len(names))
+	for _, n := range names {
+		if n != "" {
+			blocked[n] = true
+		}
+	}
+	return &ToolBlockTransform{blocked: blocked}
+}
+
+func (t *ToolBlockTransform) Name() string {
+	return "tool_block"
+}
+
+// Apply filters the tool list on whichever inbound request shape is present.
+func (t *ToolBlockTransform) Apply(ctx *TransformContext) error {
+	if len(t.blocked) == 0 {
+		return nil
+	}
+	switch req := ctx.Request.(type) {
+	case *openai.ChatCompletionNewParams:
+		ops.ApplyToolBlockOpenAIChat(req, t.blocked)
+	case *responses.ResponseNewParams:
+		ops.ApplyToolBlockResponses(req, t.blocked)
+	case *anthropic.MessageNewParams:
+		ops.ApplyToolBlockAnthropic(req, t.blocked)
+	case *anthropic.BetaMessageNewParams:
+		ops.ApplyToolBlockAnthropicBeta(req, t.blocked)
+	case *protocol.GoogleRequest:
+		ops.ApplyToolBlockGoogle(req, t.blocked)
+	}
+	return nil
+}

--- a/internal/protocol/transform/tool_block_test.go
+++ b/internal/protocol/transform/tool_block_test.go
@@ -1,0 +1,152 @@
+package transform
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared"
+)
+
+func chatFnTool(name string) openai.ChatCompletionToolUnionParam {
+	return openai.ChatCompletionFunctionTool(shared.FunctionDefinitionParam{Name: name})
+}
+
+func TestToolBlockTransform_Name(t *testing.T) {
+	if got := NewToolBlockTransform([]string{"x"}).Name(); got != "tool_block" {
+		t.Errorf("unexpected name: %q", got)
+	}
+}
+
+func TestToolBlockTransform_FiltersOpenAIChat(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Tools: []openai.ChatCompletionToolUnionParam{
+			chatFnTool("keep"),
+			chatFnTool("drop"),
+		},
+	}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewToolBlockTransform([]string{"drop"}).Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if len(req.Tools) != 1 || req.Tools[0].OfFunction.Function.Name != "keep" {
+		t.Fatalf("unexpected tools after block: %#v", req.Tools)
+	}
+}
+
+func TestToolBlockTransform_FiltersAnthropicV1(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Tools: []anthropic.ToolUnionParam{
+			{OfTool: &anthropic.ToolParam{Name: "keep"}},
+			{OfTool: &anthropic.ToolParam{Name: "drop"}},
+		},
+	}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewToolBlockTransform([]string{"drop"}).Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if len(req.Tools) != 1 || req.Tools[0].OfTool.Name != "keep" {
+		t.Fatalf("unexpected tools after block: %#v", req.Tools)
+	}
+}
+
+func TestToolBlockTransform_EmptyNamesNoOp(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Tools: []openai.ChatCompletionToolUnionParam{chatFnTool("a")},
+	}
+	ctx := &TransformContext{Request: req}
+	if err := NewToolBlockTransform(nil).Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if len(req.Tools) != 1 {
+		t.Fatalf("expected tools untouched, got %d", len(req.Tools))
+	}
+}
+
+func TestToolBlockTransform_NilRequest(t *testing.T) {
+	ctx := &TransformContext{Request: nil}
+	if err := NewToolBlockTransform([]string{"x"}).Apply(ctx); err != nil {
+		t.Fatalf("Apply on nil request failed: %v", err)
+	}
+}
+
+// TestToolBlockTransform_FiresBeforeBase verifies the intended pre-Base
+// ordering: tool blocking acts on the inbound (Anthropic) shape by the names
+// the client sent, before the stub base converts it to OpenAI Chat. The blocked
+// tool must be gone from the converted result.
+func TestToolBlockTransform_FiresBeforeBase(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		MaxTokens: 1024,
+		Tools: []anthropic.ToolUnionParam{
+			{OfTool: &anthropic.ToolParam{Name: "keep"}},
+			{OfTool: &anthropic.ToolParam{Name: "drop"}},
+		},
+	}
+	ctx := &TransformContext{Request: req}
+
+	chain := NewTransformChain([]Transform{
+		NewToolBlockTransform([]string{"drop"}),
+		toolCarryingStubBase{},
+	})
+	if _, err := chain.Execute(ctx); err != nil {
+		t.Fatalf("chain.Execute failed: %v", err)
+	}
+
+	converted, ok := ctx.Request.(*openai.ChatCompletionNewParams)
+	if !ok {
+		t.Fatalf("expected *openai.ChatCompletionNewParams after chain, got %T", ctx.Request)
+	}
+	if len(converted.Tools) != 1 || converted.Tools[0].OfFunction.Function.Name != "keep" {
+		t.Fatalf("blocked tool leaked past base: %#v", converted.Tools)
+	}
+}
+
+// TestToolBlockTransform_BlockAllOmitsToolsOnWire guards the omitzero behavior:
+// blocking every tool resets the slice to nil so the wire body has no "tools"
+// key rather than an empty array.
+func TestToolBlockTransform_BlockAllOmitsToolsOnWire(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Tools: []openai.ChatCompletionToolUnionParam{chatFnTool("a"), chatFnTool("b")},
+	}
+	ctx := &TransformContext{Request: req}
+	if err := NewToolBlockTransform([]string{"a", "b"}).Apply(ctx); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if _, present := m["tools"]; present {
+		t.Fatalf("expected tools key to be omitted, got: %s", raw)
+	}
+}
+
+// toolCarryingStubBase mimics BaseTransform: it converts an Anthropic request to
+// OpenAI Chat, carrying over the (already-filtered) tool list by name.
+type toolCarryingStubBase struct{}
+
+func (toolCarryingStubBase) Name() string { return "stub_base" }
+
+func (toolCarryingStubBase) Apply(ctx *TransformContext) error {
+	a, ok := ctx.Request.(*anthropic.MessageNewParams)
+	if !ok {
+		return nil
+	}
+	out := &openai.ChatCompletionNewParams{}
+	for _, tool := range a.Tools {
+		if tool.OfTool != nil {
+			out.Tools = append(out.Tools, chatFnTool(tool.OfTool.Name))
+		}
+	}
+	ctx.Request = out
+	return nil
+}

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -18,7 +20,26 @@ func rulePreBaseTransforms(flags typ.RuleFlags) []transform.Transform {
 	if flags.CursorCompat {
 		pre = append(pre, transform.NewOpenAICursorCompatTransform())
 	}
+	if names := parseBlockTools(flags.BlockTools); len(names) > 0 {
+		pre = append(pre, transform.NewToolBlockTransform(names))
+	}
 	return pre
+}
+
+// parseBlockTools splits the comma-separated block_tools flag into a list of
+// trimmed, non-empty tool names. Returns nil when the flag is empty so callers
+// can skip adding the transform entirely.
+func parseBlockTools(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var names []string
+	for _, part := range strings.Split(raw, ",") {
+		if name := strings.TrimSpace(part); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // ruleExtraTransforms builds the per-rule list of post-Base transforms to

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -22,6 +22,9 @@ const (
 	FlagCategoryHTTP FlagCategory = "http"
 	// FlagCategoryResponse — flags that modify the response body/stream.
 	FlagCategoryResponse FlagCategory = "response"
+	// FlagCategoryRequest — protocol-agnostic request-body guard rails
+	// (tool blocking, etc).
+	FlagCategoryRequest FlagCategory = "request"
 )
 
 // FlagOption is one selectable value for a FlagTypeEnum spec.
@@ -103,6 +106,14 @@ func RuleFlagRegistry() []FlagSpec {
 				{Value: "chat", Label: "Force Chat Completions"},
 				{Value: "responses", Label: "Force Responses API"},
 			},
+		},
+		{
+			Key:         "block_tools",
+			Label:       "Block tools",
+			Description: "Comma-separated list of tool names to remove from the request before it is forwarded upstream. Matches the tool name as the client sent it; works across OpenAI Chat, OpenAI Responses, Anthropic, and Google requests.",
+			Type:        FlagTypeString,
+			Category:    FlagCategoryRequest,
+			Placeholder: "e.g. web_search,run_terminal_cmd",
 		},
 	}
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -186,6 +186,11 @@ type RuleFlags struct {
 	// and Google providers ignore this. On Codex OAuth providers, "chat"
 	// is silently ignored (Codex has no Chat endpoint) and a warning is logged.
 	OpenAIEndpointOverride string `json:"openai_endpoint_override,omitempty" yaml:"openai_endpoint_override,omitempty"`
+
+	// BlockTools is a comma-separated list of tool names to strip from the
+	// inbound request's tool list before it is forwarded upstream. Matching is
+	// exact on the tool name as the client sent it. Empty means no blocking.
+	BlockTools string `json:"block_tools,omitempty" yaml:"block_tools,omitempty"`
 }
 
 // ProfileMeta stores metadata for a scenario profile.


### PR DESCRIPTION
## Summary
Adds a new `block_tools` rule flag that allows filtering out specific tools from requests before they are forwarded upstream. This feature works across all supported protocols (OpenAI Chat, OpenAI Responses, Anthropic, and Google).

## Key Changes

### Backend
- **New Transform Stage**: `ToolBlockTransform` in `internal/protocol/transform/tool_block.go`
  - Runs as a pre-Base stage to filter tools in the inbound request shape (before protocol conversion), so it matches the tool names the client actually sent — before any vendor-specific renaming
  - Type-switches on the request to apply the appropriate filtering logic

- **Filtering Primitives**: `internal/protocol/transform/ops/request_tool_block.go`
  - `ApplyToolBlockOpenAIChat()` - filters OpenAI Chat function/custom tools
  - `ApplyToolBlockResponses()` - filters OpenAI Responses tools
  - `ApplyToolBlockAnthropic()` - filters Anthropic Messages tools
  - `ApplyToolBlockAnthropicBeta()` - filters Anthropic Beta Messages tools
  - `ApplyToolBlockGoogle()` - filters Google function declarations
  - Pure functions over a single concrete request type (no rule/chain/ctx awareness); tools with no addressable name (vendor built-ins like web_search, computer use) are left untouched
  - All primitives reset the tool list to `nil` when empty (for proper JSON omitzero serialization)

- **Rule Integration**: `internal/server/rule_flags.go`
  - Added `parseBlockTools()` helper to parse comma-separated tool names from the flag
  - Integrated into `rulePreBaseTransforms()` to conditionally add the transform

- **Type Definitions**: `internal/typ/type.go` and `internal/typ/flag_registry.go`
  - Added `BlockTools` field to `RuleFlags` struct
  - Registered `block_tools` flag in the flag registry under a new `FlagCategoryRequest` ("request") category
  - Flag accepts comma-separated tool names (e.g., `web_search,run_terminal_cmd`)

### Frontend
- **Type Updates**: `frontend/src/components/RoutingGraphTypes.ts`
  - Added `blockTools` / `block_tools` fields to the `RuleFlags` / `RuleFlagsApi` interfaces

- **UI Components**:
  - `RuleExtensionsCard.tsx` - added string value handler for `block_tools`
  - `FlagCatalogDialog.tsx` - added the `Request` category (label + `InputIcon`) and `block_tools` get/set handlers
  - `useRuleCardHooks.ts` - integrated `block_tools` into auto-save serialization
  - `utils.ts` - added `blockTools` to config-record conversion, export, and the format/parse/count helpers

- **Documentation**: `.design/rule-flags.md` - documented the new flag in the registered-flags table

## Implementation Details

- Injection type is **1b-pre** (pre-Base Transform), per `.design/rule-flags.md`, aggregated in `rulePreBaseTransforms`
- Tool names are matched exactly as sent by the client (before any vendor-specific renaming)
- Empty or whitespace-only entries in the block list are ignored
- When all tools are blocked, the field is set to `nil` rather than an empty array, ensuring the JSON wire format omits the `tools` key entirely
- The transform is only added to the chain when at least one non-empty tool name is configured

## Testing & Verification

- **Backend**: `go build ./...` passes; new op + transform unit tests pass, covering per-shape filtering across all 5 request types, pre-Base chain ordering (blocked tool does not leak past a stub Base), the omitzero wire behavior when all tools are blocked, and edge cases (nil request, empty block set)
- **Registry safety net**: `internal/typ` tests pass (the registry key ↔ struct-field invariant)
- **Frontend**: `tsc --noEmit` shows no new errors introduced by this change (the repo's pre-existing typecheck errors — e.g. missing `@/bindings` wails codegen — are unchanged at 84 with and without this PR)
- **UI**: verified visually with a headless preview — the Rule Extensions catalog renders a new **Request** category containing the **Block tools** string field, and the rule card reflects the active flag

> Note: `TestResolveOpenAIEndpoint` fails on this branch, but it also fails on `main` (verified by stashing this PR's changes). It is a pre-existing failure unrelated to tool blocking.

https://claude.ai/code/session_01DnutFjD2odAcn2yqkWiFWZ