### PR TITLE
bugfix(ui, server): rule name conflict handling with scenario-scoped uniqueness

### DIFF
--- a/frontend/src/pages/scenario/hooks/useTemplatePageRules.ts
+++ b/frontend/src/pages/scenario/hooks/useTemplatePageRules.ts
@@ -110,11 +110,17 @@ export const useTemplatePageRules = ({
             };
 
             // Create rule via API (empty string for UUID signals backend to generate new UUID)
-            const result = await api.createRule('', newRuleData);
+            let result = await api.createRule('', newRuleData);
+
+            // If backend reports name conflict, retry once with a random suffix
+            if (!result?.success && result?.error?.includes('already exists')) {
+                newRuleData.request_model = `${requestModel}-${uuidv4().slice(0, 6)}`;
+                result = await api.createRule('', newRuleData);
+            }
 
             // Validate response has required data
-            if (!result.success) {
-                showNotification(`Failed to create rule: ${result.error || 'Unknown error'}`, 'error');
+            if (!result?.success) {
+                showNotification(`Failed to create rule: ${result?.error || 'Unknown error'}`, 'error');
                 return null;
             }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -456,6 +456,10 @@ export const api = {
                 headers,
                 body: data
             });
+            if (response.error) {
+                const errBody = response.error as any;
+                return {success: false, error: errBody?.error || 'Request failed'};
+            }
             return response.data;
         } catch (error: any) {
             return {success: false, error: error.message};

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -580,11 +580,11 @@ func (c *Config) AddRule(rule typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Guard name unique
+	// Guard name unique within same scenario
 	for _, rc := range c.Rules {
-		if rc.RequestModel == rule.RequestModel {
+		if rc.RequestModel == rule.RequestModel && rc.Scenario == rule.Scenario {
 			if rc.UUID != rule.UUID {
-				return fmt.Errorf("rule with Name %s already exists", rule.RequestModel)
+				return fmt.Errorf("rule with Name %s already exists in same scenario", rule.RequestModel)
 			}
 		}
 	}

--- a/internal/server/config/rule_test.go
+++ b/internal/server/config/rule_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestAddRule_DuplicateNameSameScenario(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	rule1 := typ.Rule{
+		UUID:         "uuid-1",
+		Scenario:     "openai",
+		RequestModel: "gpt-4",
+	}
+	if err := cfg.AddRule(rule1); err != nil {
+		t.Fatalf("first AddRule failed: %v", err)
+	}
+
+	rule2 := typ.Rule{
+		UUID:         "uuid-2",
+		Scenario:     "openai",
+		RequestModel: "gpt-4",
+	}
+	err = cfg.AddRule(rule2)
+	if err == nil {
+		t.Fatal("expected error for duplicate name in same scenario, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAddRule_DuplicateNameDifferentScenario(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	rule1 := typ.Rule{
+		UUID:         "uuid-1",
+		Scenario:     "openai",
+		RequestModel: "gpt-4",
+	}
+	if err := cfg.AddRule(rule1); err != nil {
+		t.Fatalf("first AddRule failed: %v", err)
+	}
+
+	// Same request_model but different scenario — must succeed
+	rule2 := typ.Rule{
+		UUID:         "uuid-2",
+		Scenario:     "anthropic",
+		RequestModel: "gpt-4",
+	}
+	if err := cfg.AddRule(rule2); err != nil {
+		t.Errorf("AddRule with same name in different scenario should succeed, got: %v", err)
+	}
+}
+
+func TestAddRule_DuplicateUUID(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	rule1 := typ.Rule{
+		UUID:         "uuid-1",
+		Scenario:     "openai",
+		RequestModel: "gpt-4",
+	}
+	if err := cfg.AddRule(rule1); err != nil {
+		t.Fatalf("first AddRule failed: %v", err)
+	}
+
+	rule2 := typ.Rule{
+		UUID:         "uuid-1", // same UUID, different model
+		Scenario:     "openai",
+		RequestModel: "gpt-3.5-turbo",
+	}
+	if err := cfg.AddRule(rule2); err == nil {
+		t.Fatal("expected error for duplicate UUID, got nil")
+	}
+}

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -231,6 +231,75 @@ func TestCreateRule_Success(t *testing.T) {
 	assert.Contains(t, bodyResp, `"uuid"`)
 }
 
+func TestCreateRule_DuplicateNameSameScenario(t *testing.T) {
+	registerTestRuleScenario(t, typ.RuleScenario("test-scenario"))
+
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg)
+	router.POST("/rules", handler.CreateRule)
+
+	rule := typ.Rule{
+		RequestModel: "gpt-4",
+		Scenario:     "test-scenario",
+		Active:       true,
+	}
+	body, _ := json.Marshal(rule)
+
+	// First creation must succeed
+	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first create failed: %d %s", w.Code, w.Body.String())
+	}
+
+	// Second creation with same name and scenario must fail
+	req2, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	if w2.Code == http.StatusOK {
+		t.Errorf("expected failure for duplicate name in same scenario, got 200")
+	}
+	assert.Contains(t, w2.Body.String(), `"success":false`)
+}
+
+func TestCreateRule_DuplicateNameDifferentScenario(t *testing.T) {
+	registerTestRuleScenario(t, typ.RuleScenario("scenario-a"))
+	registerTestRuleScenario(t, typ.RuleScenario("scenario-b"))
+
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg)
+	router.POST("/rules", handler.CreateRule)
+
+	ruleA := typ.Rule{RequestModel: "gpt-4", Scenario: "scenario-a", Active: true}
+	bodyA, _ := json.Marshal(ruleA)
+	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(bodyA))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create in scenario-a failed: %d %s", w.Code, w.Body.String())
+	}
+
+	// Same model name in a different scenario must succeed
+	ruleB := typ.Rule{RequestModel: "gpt-4", Scenario: "scenario-b", Active: true}
+	bodyB, _ := json.Marshal(ruleB)
+	req2, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(bodyB))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Errorf("create with same name in different scenario should succeed: %d %s", w2.Code, w2.Body.String())
+	}
+	assert.Contains(t, w2.Body.String(), `"success":true`)
+}
+
 func TestCreateRule_NoScenario(t *testing.T) {
 	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Summary
This PR improves rule creation by implementing scenario-scoped name uniqueness validation and adding automatic retry logic with a random suffix when name conflicts occur.

## Key Changes

- **Backend (config.go)**: Modified rule uniqueness constraint to be scenario-scoped rather than global
  - Rule names must now be unique only within the same scenario, not across all scenarios
  - Updated validation logic to check both `RequestModel` and `Scenario` fields
  - Improved error message to clarify the scope of the uniqueness constraint

- **Frontend (useTemplatePageRules.ts)**: Added intelligent retry mechanism for rule creation
  - Detects name conflict errors from the backend
  - Automatically retries rule creation with a random 6-character suffix appended to the request model name
  - Uses optional chaining (`?.`) for safer null/undefined checks in error handling

- **Frontend (api.ts)**: Enhanced error handling in API responses
  - Added explicit error response handling to properly extract and return error messages from failed requests
  - Ensures error information is consistently formatted before returning to callers

## Implementation Details
The retry logic uses `uuidv4().slice(0, 6)` to generate a short random suffix, making rule names unique while keeping them readable. This provides a better user experience by automatically resolving naming conflicts without requiring manual intervention.

https://claude.ai/code/session_012toNPdqL8ZqC9KxkSim1EH