### PR TITLE
feat(UI): Add provider quota API mocks and refactor provider table actions

### DIFF
--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -1,9 +1,8 @@
 import { ApiStyleBadge } from '@/components/ApiStyleBadge.tsx';
 import ModelListDialog from '@/components/ModelListDialog';
-import ProviderExportMenu from '@/components/ProviderExportMenu';
 import { exportProvider, exportProviderAsBase64ToClipboard, exportProviderAsJsonlToClipboard } from '@/components/rule-card/utils';
 import { ProviderQuotaDetailRow } from '@/components/credential/ProviderQuotaDetailRow';
-import { Cancel, ContentCopy, DataUsage, Delete, Edit, ListAlt, Route, Visibility } from '@mui/icons-material';
+import { Cancel, ContentCopy, DataUsage, Delete, Download, Edit, ListAlt, MoreVert, Route, Visibility } from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -11,6 +10,8 @@ import {
     CircularProgress,
     Divider,
     IconButton,
+    Menu,
+    MenuItem,
     Modal,
     Paper,
     Stack,
@@ -75,6 +76,16 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, pr
         open: false,
         provider: null,
     });
+    const [moreMenu, setMoreMenu] = useState<{ anchorEl: HTMLElement | null; providerUuid: string }>({
+        anchorEl: null,
+        providerUuid: '',
+    });
+
+    const handleMoreOpen = (e: React.MouseEvent<HTMLElement>, providerUuid: string) => {
+        e.stopPropagation();
+        setMoreMenu({ anchorEl: e.currentTarget, providerUuid });
+    };
+    const handleMoreClose = () => setMoreMenu({ anchorEl: null, providerUuid: '' });
 
     const fetchFullToken = async (providerUuid: string): Promise<string> => {
         try {
@@ -300,16 +311,10 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, pr
                                         borderColor: 'divider',
                                         borderRadius: 1.5,
                                         p: 0.5,
-                                        pr: 1,
-                                        width: 200,
+                                        width: 'fit-content',
                                     }}
                                 >
-                                    <ProviderExportMenu
-                                        provider={provider}
-                                        onExport={handleExportProvider}
-                                        onCopyJsonl={handleCopyProviderJsonl}
-                                        onCopyBase64={handleCopyProviderBase64}
-                                    />
+                                    {/* Edit — primary action, always visible */}
                                     {onEdit && (
                                         <Tooltip title="Edit">
                                             <IconButton size="small" color="primary" onClick={() => onEdit(provider.uuid)}>
@@ -317,52 +322,39 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, pr
                                             </IconButton>
                                         </Tooltip>
                                     )}
-                                    {onDelete && (
-                                        <Tooltip title="Delete">
-                                            <IconButton size="small" color="error" onClick={() => handleDeleteClick(provider.uuid)}>
-                                                <Delete fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    )}
-                                    {onQuotaRefresh && (
-                                        <Tooltip title={
-                                            refreshingQuotas?.has(provider.uuid)
-                                                ? 'Fetching quota...'
-                                                : providerQuotas?.[provider.uuid]
-                                                    ? `Refresh Quota\nFetched: ${new Date(providerQuotas[provider.uuid].fetched_at!).toLocaleString()}`
-                                                    : 'Fetch Quota'
-                                        }>
-                                            <span>
-                                                <IconButton
-                                                    size="small"
-                                                    color={providerQuotas?.[provider.uuid] ? 'primary' : 'default'}
-                                                    onClick={() => onQuotaRefresh(provider.uuid)}
-                                                    disabled={refreshingQuotas?.has(provider.uuid)}
-                                                >
-                                                    {refreshingQuotas?.has(provider.uuid) ? (
-                                                        <CircularProgress size={16} />
-                                                    ) : (
-                                                        <DataUsage fontSize="small" />
-                                                    )}
-                                                </IconButton>
-                                            </span>
-                                        </Tooltip>
-                                    )}
                                     <Divider orientation="vertical" flexItem />
+                                    {/* Quota text button */}
+                                    {onQuotaRefresh && (
+                                        <Button
+                                            variant="text"
+                                            size="small"
+                                            startIcon={refreshingQuotas?.has(provider.uuid)
+                                                ? <CircularProgress size={12} />
+                                                : <DataUsage fontSize="small" />}
+                                            onClick={() => onQuotaRefresh(provider.uuid)}
+                                            disabled={refreshingQuotas?.has(provider.uuid)}
+                                            color={providerQuotas?.[provider.uuid] ? 'primary' : 'inherit'}
+                                            sx={{ fontSize: '0.75rem', minWidth: 'auto', px: 1 }}
+                                        >
+                                            Quota
+                                        </Button>
+                                    )}
+                                    {/* Models text button */}
                                     <Button
                                         variant="text"
                                         size="small"
                                         startIcon={<ListAlt />}
                                         onClick={() => handleModelListClick(provider.uuid)}
                                         disabled={!provider.enabled}
-                                        sx={{
-                                            fontSize: '0.75rem',
-                                            minWidth: 'auto',
-                                            px: 1,
-                                        }}
+                                        sx={{ fontSize: '0.75rem', minWidth: 'auto', px: 1 }}
                                     >
                                         Models
                                     </Button>
+                                    <Divider orientation="vertical" flexItem />
+                                    {/* Overflow menu for less common actions */}
+                                    <IconButton size="small" onClick={(e) => handleMoreOpen(e, provider.uuid)}>
+                                        <MoreVert fontSize="small" />
+                                    </IconButton>
                                 </Box>
                             </TableCell>
                         </TableRow>
@@ -380,6 +372,46 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, pr
                 ))}
                 </TableBody>
             </Table>
+
+            {/* Overflow menu (shared, driven by moreMenu state) */}
+            <Menu
+                anchorEl={moreMenu.anchorEl}
+                open={Boolean(moreMenu.anchorEl)}
+                onClose={handleMoreClose}
+                onClick={(e) => e.stopPropagation()}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                {(() => {
+                    const p = providers.find(p => p.uuid === moreMenu.providerUuid);
+                    if (!p) return null;
+                    return [
+                        p.token && (
+                            <MenuItem key="view-token" onClick={() => { handleMoreClose(); handleViewToken(p.uuid); }}>
+                                <Visibility fontSize="small" sx={{ mr: 1 }} /> View Token
+                            </MenuItem>
+                        ),
+                        <MenuItem key="export-jsonl" onClick={() => { handleMoreClose(); handleExportProvider(p, 'jsonl'); }}>
+                            <Download fontSize="small" sx={{ mr: 1 }} /> Download JSONL
+                        </MenuItem>,
+                        <MenuItem key="export-base64" onClick={() => { handleMoreClose(); handleExportProvider(p, 'base64'); }}>
+                            <Download fontSize="small" sx={{ mr: 1 }} /> Download Base64
+                        </MenuItem>,
+                        <MenuItem key="copy-jsonl" onClick={() => { handleMoreClose(); handleCopyProviderJsonl(p); }}>
+                            <ContentCopy fontSize="small" sx={{ mr: 1 }} /> Copy JSONL
+                        </MenuItem>,
+                        <MenuItem key="copy-base64" onClick={() => { handleMoreClose(); handleCopyProviderBase64(p); }}>
+                            <ContentCopy fontSize="small" sx={{ mr: 1 }} /> Copy Base64
+                        </MenuItem>,
+                        onDelete && <Divider key="divider" />,
+                        onDelete && (
+                            <MenuItem key="delete" onClick={() => { handleMoreClose(); handleDeleteClick(p.uuid); }} sx={{ color: 'error.main' }}>
+                                <Delete fontSize="small" sx={{ mr: 1 }} /> Delete
+                            </MenuItem>
+                        ),
+                    ].filter(Boolean);
+                })()}
+            </Menu>
 
             {/* Token View Modal */}
             <Modal open={tokenModal.open} onClose={handleCloseTokenModal}>

--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -3,11 +3,12 @@ import ModelListDialog from '@/components/ModelListDialog';
 import ProviderExportMenu from '@/components/ProviderExportMenu';
 import { exportProvider, exportProviderAsBase64ToClipboard, exportProviderAsJsonlToClipboard } from '@/components/rule-card/utils';
 import { ProviderQuotaDetailRow } from '@/components/credential/ProviderQuotaDetailRow';
-import { Cancel, ContentCopy, Delete, Edit, ListAlt, Route, Visibility } from '@mui/icons-material';
+import { Cancel, ContentCopy, DataUsage, Delete, Edit, ListAlt, Route, Visibility } from '@mui/icons-material';
 import {
     Box,
     Button,
     Chip,
+    CircularProgress,
     Divider,
     IconButton,
     Modal,
@@ -321,6 +322,30 @@ const ApiKeyTable = ({ providers, onEdit, onToggle, onDelete, onNotification, pr
                                             <IconButton size="small" color="error" onClick={() => handleDeleteClick(provider.uuid)}>
                                                 <Delete fontSize="small" />
                                             </IconButton>
+                                        </Tooltip>
+                                    )}
+                                    {onQuotaRefresh && (
+                                        <Tooltip title={
+                                            refreshingQuotas?.has(provider.uuid)
+                                                ? 'Fetching quota...'
+                                                : providerQuotas?.[provider.uuid]
+                                                    ? `Refresh Quota\nFetched: ${new Date(providerQuotas[provider.uuid].fetched_at!).toLocaleString()}`
+                                                    : 'Fetch Quota'
+                                        }>
+                                            <span>
+                                                <IconButton
+                                                    size="small"
+                                                    color={providerQuotas?.[provider.uuid] ? 'primary' : 'default'}
+                                                    onClick={() => onQuotaRefresh(provider.uuid)}
+                                                    disabled={refreshingQuotas?.has(provider.uuid)}
+                                                >
+                                                    {refreshingQuotas?.has(provider.uuid) ? (
+                                                        <CircularProgress size={16} />
+                                                    ) : (
+                                                        <DataUsage fontSize="small" />
+                                                    )}
+                                                </IconButton>
+                                            </span>
                                         </Tooltip>
                                     )}
                                     <Divider orientation="vertical" flexItem />

--- a/frontend/src/components/OAuthTable.tsx
+++ b/frontend/src/components/OAuthTable.tsx
@@ -1,9 +1,8 @@
 import { ApiStyleBadge } from '@/components/ApiStyleBadge.tsx';
 import ModelListDialog from '@/components/ModelListDialog';
-import ProviderExportMenu from '@/components/ProviderExportMenu';
 import { exportProvider, exportProviderAsBase64ToClipboard, exportProviderAsJsonlToClipboard } from '@/components/rule-card/utils';
 import { ProviderQuotaDetailRow } from '@/components/credential/ProviderQuotaDetailRow';
-import { DataUsage, Delete, Edit, ListAlt, Refresh as RefreshIcon, Route, Schedule, VpnKey } from '@mui/icons-material';
+import { ContentCopy, DataUsage, Delete, Download, Edit, ListAlt, MoreVert, Refresh as RefreshIcon, Route, Schedule, VpnKey } from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -11,6 +10,8 @@ import {
     CircularProgress,
     Divider,
     IconButton,
+    Menu,
+    MenuItem,
     Modal,
     Paper,
     Stack,
@@ -78,6 +79,16 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
         open: false,
         provider: null,
     });
+    const [moreMenu, setMoreMenu] = useState<{ anchorEl: HTMLElement | null; providerUuid: string }>({
+        anchorEl: null,
+        providerUuid: '',
+    });
+
+    const handleMoreOpen = (e: React.MouseEvent<HTMLElement>, providerUuid: string) => {
+        e.stopPropagation();
+        setMoreMenu({ anchorEl: e.currentTarget, providerUuid });
+    };
+    const handleMoreClose = () => setMoreMenu({ anchorEl: null, providerUuid: '' });
 
     const handleDeleteClick = (providerUuid: string) => {
         const provider = providers.find((p) => p.uuid === providerUuid);
@@ -286,16 +297,10 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                                             borderColor: 'divider',
                                             borderRadius: 1.5,
                                             p: 0.5,
-                                            pr: 1,
-                                            width: 240,
+                                            width: 'fit-content',
                                         }}
                                     >
-                                        <ProviderExportMenu
-                                            provider={provider}
-                                            onExport={handleExportProvider}
-                                            onCopyJsonl={handleCopyProviderJsonl}
-                                            onCopyBase64={handleCopyProviderBase64}
-                                        />
+                                        {/* Edit — primary action */}
                                         {onEdit && (
                                             <Tooltip title="View Details">
                                                 <IconButton size="small" color="primary" onClick={() => onEdit(provider.uuid)}>
@@ -303,79 +308,39 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                                                 </IconButton>
                                             </Tooltip>
                                         )}
-                                        {onRefreshToken && provider.oauth_detail?.refresh_token && (
-                                            <Tooltip title="Refresh Token">
-                                                <IconButton
-                                                    size="small"
-                                                    color="info"
-                                                    onClick={() => handleRefreshClick(provider.uuid)}
-                                                    disabled={refreshing === provider.uuid}
-                                                >
-                                                    {refreshing === provider.uuid ? (
-                                                        <CircularProgress size={16} />
-                                                    ) : (
-                                                        <RefreshIcon fontSize="small" />
-                                                    )}
-                                                </IconButton>
-                                            </Tooltip>
-                                        )}
-                                        {onReauthorize && (
-                                            <Tooltip title="Reauthorize">
-                                                <IconButton
-                                                    size="small"
-                                                    color={isExpired ? 'warning' : 'default'}
-                                                    onClick={() => onReauthorize(provider.uuid)}
-                                                >
-                                                    <VpnKey fontSize="small" />
-                                                </IconButton>
-                                            </Tooltip>
-                                        )}
-                                        {onDelete && (
-                                            <Tooltip title="Delete">
-                                                <IconButton size="small" color="error" onClick={() => handleDeleteClick(provider.uuid)}>
-                                                    <Delete fontSize="small" />
-                                                </IconButton>
-                                            </Tooltip>
-                                        )}
-                                        {onQuotaRefresh && (
-                                            <Tooltip title={
-                                                refreshingQuotas?.has(provider.uuid)
-                                                    ? 'Fetching quota...'
-                                                    : providerQuotas?.[provider.uuid]
-                                                        ? `Refresh Quota\nFetched: ${new Date(providerQuotas[provider.uuid].fetched_at!).toLocaleString()}`
-                                                        : 'Fetch Quota'
-                                            }>
-                                                <span>
-                                                    <IconButton
-                                                        size="small"
-                                                        color={providerQuotas?.[provider.uuid] ? 'primary' : 'default'}
-                                                        onClick={() => onQuotaRefresh(provider.uuid)}
-                                                        disabled={refreshingQuotas?.has(provider.uuid)}
-                                                    >
-                                                        {refreshingQuotas?.has(provider.uuid) ? (
-                                                            <CircularProgress size={16} />
-                                                        ) : (
-                                                            <DataUsage fontSize="small" />
-                                                        )}
-                                                    </IconButton>
-                                                </span>
-                                            </Tooltip>
-                                        )}
                                         <Divider orientation="vertical" flexItem />
+                                        {/* Quota text button */}
+                                        {onQuotaRefresh && (
+                                            <Button
+                                                variant="text"
+                                                size="small"
+                                                startIcon={refreshingQuotas?.has(provider.uuid)
+                                                    ? <CircularProgress size={12} />
+                                                    : <DataUsage fontSize="small" />}
+                                                onClick={() => onQuotaRefresh(provider.uuid)}
+                                                disabled={refreshingQuotas?.has(provider.uuid)}
+                                                color={providerQuotas?.[provider.uuid] ? 'primary' : 'inherit'}
+                                                sx={{ fontSize: '0.75rem', minWidth: 'auto', px: 1 }}
+                                            >
+                                                Quota
+                                            </Button>
+                                        )}
+                                        {/* Models text button */}
                                         <Button
                                             variant="text"
                                             size="small"
                                             startIcon={<ListAlt />}
                                             onClick={() => handleModelListClick(provider.uuid)}
                                             disabled={!provider.enabled}
-                                            sx={{
-                                                fontSize: '0.75rem',
-                                                minWidth: 'auto',
-                                                px: 1,
-                                            }}
+                                            sx={{ fontSize: '0.75rem', minWidth: 'auto', px: 1 }}
                                         >
                                             Models
                                         </Button>
+                                        <Divider orientation="vertical" flexItem />
+                                        {/* Overflow menu */}
+                                        <IconButton size="small" onClick={(e) => handleMoreOpen(e, provider.uuid)}>
+                                            <MoreVert fontSize="small" />
+                                        </IconButton>
                                     </Box>
                                 </TableCell>
                             </TableRow>
@@ -394,6 +359,61 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                     })}
                 </TableBody>
             </Table>
+
+            {/* Overflow menu (shared) */}
+            <Menu
+                anchorEl={moreMenu.anchorEl}
+                open={Boolean(moreMenu.anchorEl)}
+                onClose={handleMoreClose}
+                onClick={(e) => e.stopPropagation()}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                {(() => {
+                    const p = providers.find(p => p.uuid === moreMenu.providerUuid);
+                    if (!p) return null;
+                    const hasRefreshToken = onRefreshToken && p.oauth_detail?.refresh_token;
+                    const expired = p.oauth_detail?.expires_at
+                        ? new Date(p.oauth_detail.expires_at) < new Date()
+                        : false;
+                    return [
+                        hasRefreshToken && (
+                            <MenuItem key="refresh-token" onClick={() => { handleMoreClose(); handleRefreshClick(p.uuid); }}
+                                disabled={refreshing === p.uuid}>
+                                {refreshing === p.uuid
+                                    ? <CircularProgress size={14} sx={{ mr: 1 }} />
+                                    : <RefreshIcon fontSize="small" sx={{ mr: 1 }} />}
+                                Refresh Token
+                            </MenuItem>
+                        ),
+                        onReauthorize && (
+                            <MenuItem key="reauthorize" onClick={() => { handleMoreClose(); onReauthorize(p.uuid); }}
+                                sx={{ color: expired ? 'warning.main' : undefined }}>
+                                <VpnKey fontSize="small" sx={{ mr: 1 }} /> Reauthorize
+                            </MenuItem>
+                        ),
+                        <Divider key="div1" />,
+                        <MenuItem key="export-jsonl" onClick={() => { handleMoreClose(); handleExportProvider(p, 'jsonl'); }}>
+                            <Download fontSize="small" sx={{ mr: 1 }} /> Download JSONL
+                        </MenuItem>,
+                        <MenuItem key="export-base64" onClick={() => { handleMoreClose(); handleExportProvider(p, 'base64'); }}>
+                            <Download fontSize="small" sx={{ mr: 1 }} /> Download Base64
+                        </MenuItem>,
+                        <MenuItem key="copy-jsonl" onClick={() => { handleMoreClose(); handleCopyProviderJsonl(p); }}>
+                            <ContentCopy fontSize="small" sx={{ mr: 1 }} /> Copy JSONL
+                        </MenuItem>,
+                        <MenuItem key="copy-base64" onClick={() => { handleMoreClose(); handleCopyProviderBase64(p); }}>
+                            <ContentCopy fontSize="small" sx={{ mr: 1 }} /> Copy Base64
+                        </MenuItem>,
+                        onDelete && <Divider key="div2" />,
+                        onDelete && (
+                            <MenuItem key="delete" onClick={() => { handleMoreClose(); handleDeleteClick(p.uuid); }} sx={{ color: 'error.main' }}>
+                                <Delete fontSize="small" sx={{ mr: 1 }} /> Delete
+                            </MenuItem>
+                        ),
+                    ].filter(Boolean);
+                })()}
+            </Menu>
 
             {/* Delete Confirmation Modal */}
             <Modal open={deleteModal.open} onClose={handleCloseDeleteModal}>

--- a/frontend/src/components/OAuthTable.tsx
+++ b/frontend/src/components/OAuthTable.tsx
@@ -3,7 +3,7 @@ import ModelListDialog from '@/components/ModelListDialog';
 import ProviderExportMenu from '@/components/ProviderExportMenu';
 import { exportProvider, exportProviderAsBase64ToClipboard, exportProviderAsJsonlToClipboard } from '@/components/rule-card/utils';
 import { ProviderQuotaDetailRow } from '@/components/credential/ProviderQuotaDetailRow';
-import { Delete, Edit, ListAlt, Refresh as RefreshIcon, Route, Schedule, VpnKey } from '@mui/icons-material';
+import { DataUsage, Delete, Edit, ListAlt, Refresh as RefreshIcon, Route, Schedule, VpnKey } from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -335,6 +335,30 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                                                 <IconButton size="small" color="error" onClick={() => handleDeleteClick(provider.uuid)}>
                                                     <Delete fontSize="small" />
                                                 </IconButton>
+                                            </Tooltip>
+                                        )}
+                                        {onQuotaRefresh && (
+                                            <Tooltip title={
+                                                refreshingQuotas?.has(provider.uuid)
+                                                    ? 'Fetching quota...'
+                                                    : providerQuotas?.[provider.uuid]
+                                                        ? `Refresh Quota\nFetched: ${new Date(providerQuotas[provider.uuid].fetched_at!).toLocaleString()}`
+                                                        : 'Fetch Quota'
+                                            }>
+                                                <span>
+                                                    <IconButton
+                                                        size="small"
+                                                        color={providerQuotas?.[provider.uuid] ? 'primary' : 'default'}
+                                                        onClick={() => onQuotaRefresh(provider.uuid)}
+                                                        disabled={refreshingQuotas?.has(provider.uuid)}
+                                                    >
+                                                        {refreshingQuotas?.has(provider.uuid) ? (
+                                                            <CircularProgress size={16} />
+                                                        ) : (
+                                                            <DataUsage fontSize="small" />
+                                                        )}
+                                                    </IconButton>
+                                                </span>
                                             </Tooltip>
                                         )}
                                         <Divider orientation="vertical" flexItem />

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -167,17 +167,6 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
           </Box>
         </Box>
 
-        {/* Reset time */}
-        {resetTime && (
-          <Typography
-            variant="caption"
-            color="text.disabled"
-            sx={{ minWidth: 40, whiteSpace: 'nowrap' }}
-          >
-            {resetTime}
-          </Typography>
-        )}
-
         {/* Percent */}
         <Typography
           variant="body2"

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -178,18 +178,22 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
           {formatUsageDisplay()}
         </Typography>
 
+        {/* Reset time */}
+        {resetTime && (
+          <Typography
+            variant="caption"
+            color="text.disabled"
+            sx={{ minWidth: 40, whiteSpace: 'nowrap' }}
+          >
+            {resetTime}
+          </Typography>
+        )}
+
         {/* Optional details inline */}
         {showDetails && (
-          <>
-            <Typography variant="caption" color="text.secondary">
-              {detailedInfo}
-            </Typography>
-            {resetTime && (
-              <Typography variant="caption" color="text.secondary">
-                ({resetTime})
-              </Typography>
-            )}
-          </>
+          <Typography variant="caption" color="text.secondary">
+            {detailedInfo}
+          </Typography>
         )}
       </Stack>
     </Tooltip>

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -167,17 +167,6 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
           </Box>
         </Box>
 
-        {/* Percent */}
-        <Typography
-          variant="body2"
-          sx={{
-            color: barColor,
-            minWidth: 35,
-          }}
-        >
-          {formatUsageDisplay()}
-        </Typography>
-
         {/* Reset time */}
         {resetTime && (
           <Typography
@@ -188,6 +177,17 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
             {resetTime}
           </Typography>
         )}
+
+        {/* Percent */}
+        <Typography
+          variant="body2"
+          sx={{
+            color: barColor,
+            minWidth: 35,
+          }}
+        >
+          {formatUsageDisplay()}
+        </Typography>
 
         {/* Optional details inline */}
         {showDetails && (

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack, IconButton, Typography, CircularProgress, Tooltip } from '@mui/material';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import InfoIcon from '@mui/icons-material/Info';
 import { QuotaBarItem } from './QuotaBarItem';
@@ -152,6 +153,26 @@ export function QuotaInlineDisplay({
             )}
           </IconButton>
         </Tooltip>
+
+        {/* Fetched time */}
+        {quota?.fetched_at && !isRefreshing && (
+          <Tooltip title={`Fetched at ${new Date(quota.fetched_at).toLocaleString()}`} arrow>
+            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ cursor: 'default' }}>
+              <AccessTimeIcon sx={{ fontSize: 12, color: 'text.disabled' }} />
+              <Typography variant="caption" color="text.disabled" sx={{ whiteSpace: 'nowrap' }}>
+                {(() => {
+                  const diffMs = Date.now() - new Date(quota.fetched_at!).getTime();
+                  const mins = Math.floor(diffMs / 60000);
+                  if (mins < 1) return 'just now';
+                  if (mins < 60) return `${mins}m ago`;
+                  const hrs = Math.floor(mins / 60);
+                  if (hrs < 24) return `${hrs}h ago`;
+                  return `${Math.floor(hrs / 24)}d ago`;
+                })()}
+              </Typography>
+            </Stack>
+          </Tooltip>
+        )}
       </Stack>
 
       {/* Quota items */}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,5 +1,160 @@
 import { http, HttpResponse } from 'msw'
 
+// ============================================
+// Mock Providers (v2 API with uuid)
+// ============================================
+const mockV2Providers = [
+    {
+        uuid: 'mock-provider-anthropic',
+        name: 'Anthropic',
+        api_base: 'https://api.anthropic.com',
+        api_style: 'anthropic',
+        auth_type: 'api_key',
+        token: 'sk-ant-****abcd',
+        enabled: true,
+        proxy_url: '',
+        api_base_openai: null,
+        api_base_anthropic: null,
+    },
+    {
+        uuid: 'mock-provider-openai',
+        name: 'OpenAI',
+        api_base: 'https://api.openai.com/v1',
+        api_style: 'openai',
+        auth_type: 'api_key',
+        token: 'sk-****efgh',
+        enabled: true,
+        proxy_url: '',
+        api_base_openai: null,
+        api_base_anthropic: null,
+    },
+    {
+        uuid: 'mock-provider-openrouter',
+        name: 'OpenRouter',
+        api_base: 'https://openrouter.ai/api/v1',
+        api_style: 'openai',
+        auth_type: 'api_key',
+        token: 'sk-or-****ijkl',
+        enabled: false,
+        proxy_url: '',
+        api_base_openai: null,
+        api_base_anthropic: null,
+    },
+]
+
+// ============================================
+// Mock Quota Data
+// ============================================
+const now = new Date()
+const inOneHour = new Date(now.getTime() + 60 * 60 * 1000).toISOString()
+const inTwoDays = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000).toISOString()
+const inSixDays = new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString()
+const inThirtyDays = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString()
+
+const mockQuotas: Record<string, any> = {
+    'mock-provider-anthropic': {
+        provider_uuid: 'mock-provider-anthropic',
+        provider_name: 'Anthropic',
+        provider_type: 'anthropic',
+        fetched_at: now.toISOString(),
+        expires_at: inOneHour,
+        primary: {
+            type: 'session',
+            used: 42350,
+            limit: 80000,
+            used_percent: 52.9,
+            resets_at: inOneHour,
+            unit: 'tokens',
+            label: 'Session',
+            description: 'Current session token usage',
+        },
+        secondary: {
+            type: 'weekly',
+            used: 1230000,
+            limit: 3000000,
+            used_percent: 41.0,
+            resets_at: inSixDays,
+            unit: 'tokens',
+            label: 'Weekly',
+            description: 'Weekly token usage',
+        },
+        tertiary: {
+            type: 'monthly',
+            used: 4200000,
+            limit: 10000000,
+            used_percent: 42.0,
+            resets_at: inThirtyDays,
+            unit: 'tokens',
+            label: 'Monthly',
+            description: 'Monthly token usage',
+        },
+        cost: {
+            used: 12.50,
+            limit: 50.00,
+            currency_code: '$',
+            resets_at: inThirtyDays,
+            label: 'Monthly Cost',
+        },
+        account: {
+            id: 'acc-mock-001',
+            name: 'Mock Account',
+            email: 'mock@example.com',
+            tier: 'pro',
+        },
+    },
+    'mock-provider-openai': {
+        provider_uuid: 'mock-provider-openai',
+        provider_name: 'OpenAI',
+        provider_type: 'openai',
+        fetched_at: now.toISOString(),
+        expires_at: inOneHour,
+        primary: {
+            type: 'daily',
+            used: 850,
+            limit: 1000,
+            used_percent: 85.0,
+            resets_at: inTwoDays,
+            unit: 'requests',
+            label: 'Daily',
+            description: 'Daily request limit',
+        },
+        secondary: {
+            type: 'monthly',
+            used: 18500,
+            limit: 30000,
+            used_percent: 61.7,
+            resets_at: inThirtyDays,
+            unit: 'requests',
+            label: 'Monthly',
+            description: 'Monthly request limit',
+        },
+        cost: {
+            used: 38.20,
+            limit: 100.00,
+            currency_code: '$',
+            resets_at: inThirtyDays,
+            label: 'Monthly Cost',
+        },
+    },
+    'mock-provider-openrouter': {
+        provider_uuid: 'mock-provider-openrouter',
+        provider_name: 'OpenRouter',
+        provider_type: 'openrouter',
+        fetched_at: now.toISOString(),
+        expires_at: inOneHour,
+        primary: {
+            type: 'balance',
+            used: 7.30,
+            limit: 20.00,
+            used_percent: 36.5,
+            resets_at: null,
+            unit: 'currency',
+            label: 'Balance',
+            description: 'Remaining credit balance',
+        },
+    },
+}
+
 // Mock remote graphs data
 const mockRemoteGraphs: any[] = [
     {
@@ -549,6 +704,76 @@ export const handlers = [
                 message: "Running with mock data"
             }
         })
+    }),
+
+    // ============================================
+    // v2 Providers API
+    // ============================================
+    http.get('/api/v2/providers', () => {
+        return HttpResponse.json({
+            success: true,
+            data: mockV2Providers,
+        })
+    }),
+
+    http.get('/api/v2/providers/:uuid', ({ params }) => {
+        const { uuid } = params
+        const provider = mockV2Providers.find(p => p.uuid === uuid)
+        if (provider) {
+            return HttpResponse.json({ success: true, data: provider })
+        }
+        return HttpResponse.json({ success: false, error: 'Not found' }, { status: 404 })
+    }),
+
+    http.post('/api/v2/providers', async ({ request }) => {
+        const body = await request.json() as any
+        const newProvider = {
+            uuid: `mock-provider-${Date.now()}`,
+            ...body,
+            token: body.token || '',
+            enabled: true,
+        }
+        mockV2Providers.push(newProvider)
+        return HttpResponse.json({ success: true, data: newProvider })
+    }),
+
+    // ============================================
+    // Provider Quota API (v1)
+    // ============================================
+    http.post('/api/v1/provider-quota/batch', async ({ request }) => {
+        const body = await request.json() as any
+        const uuids: string[] = body?.provider_uuids || []
+        const result: Record<string, any> = {}
+        for (const uuid of uuids) {
+            if (mockQuotas[uuid]) {
+                result[uuid] = { ...mockQuotas[uuid], fetched_at: new Date().toISOString() }
+            }
+        }
+        return HttpResponse.json({ success: true, data: result })
+    }),
+
+    http.get('/api/v1/provider-quota/:uuid', ({ params }) => {
+        const { uuid } = params as { uuid: string }
+        if (mockQuotas[uuid]) {
+            return HttpResponse.json({ success: true, data: { ...mockQuotas[uuid], fetched_at: new Date().toISOString() } })
+        }
+        return HttpResponse.json({ success: false, error: 'No quota data' }, { status: 404 })
+    }),
+
+    http.post('/api/v1/provider-quota/:uuid/refresh', async ({ params }) => {
+        const { uuid } = params as { uuid: string }
+        // Simulate a short delay
+        await new Promise(r => setTimeout(r, 800))
+        if (mockQuotas[uuid]) {
+            const refreshed = { ...mockQuotas[uuid], fetched_at: new Date().toISOString() }
+            return HttpResponse.json({ success: true, data: refreshed })
+        }
+        return HttpResponse.json({ success: false, error: 'No quota data' }, { status: 404 })
+    }),
+
+    http.post('/api/v1/provider-quota/refresh', async () => {
+        await new Promise(r => setTimeout(r, 1000))
+        return HttpResponse.json({ success: true })
     }),
 
     // --- Playground (imagegen) mocks ---


### PR DESCRIPTION
## Summary
This PR adds comprehensive mock data and API handlers for provider quota management, and refactors the provider action buttons in both OAuth and API Key tables to improve UX by moving less common actions into an overflow menu.

## Key Changes

### Mock Data & API Handlers (`frontend/src/mocks/handlers.ts`)
- Added `mockV2Providers` with three sample providers (Anthropic, OpenAI, OpenRouter) including uuid, credentials, and configuration
- Added `mockQuotas` with detailed quota data for each provider including:
  - Primary/secondary/tertiary quota windows (session, weekly, monthly)
  - Cost tracking with limits and reset times
  - Account information
- Implemented v2 Providers API endpoints:
  - `GET /api/v2/providers` - list all providers
  - `GET /api/v2/providers/:uuid` - get single provider
  - `POST /api/v2/providers` - create new provider
- Implemented v1 Provider Quota API endpoints:
  - `POST /api/v1/provider-quota/batch` - fetch quotas for multiple providers
  - `GET /api/v1/provider-quota/:uuid` - get quota for single provider
  - `POST /api/v1/provider-quota/:uuid/refresh` - refresh quota with simulated delay
  - `POST /api/v1/provider-quota/refresh` - refresh all quotas

### Provider Table UI Refactoring (`OAuthTable.tsx` & `ApiKeyTable.tsx`)
- Removed `ProviderExportMenu` component usage and replaced with inline menu-driven actions
- Reorganized action buttons into primary and secondary groups:
  - **Primary actions** (always visible): Edit button
  - **Secondary actions** (text buttons): Quota and Models buttons
  - **Overflow menu** (MoreVert icon): Refresh Token, Reauthorize, Export/Copy options, Delete
- Added quota refresh button with loading state and color indication
- Implemented shared `Menu` component for overflow actions with proper event handling
- Improved layout by using `width: 'fit-content'` instead of fixed widths

### Quota Display Enhancement (`QuotaInlineDisplay.tsx`)
- Added "Fetched at" timestamp display with relative time formatting (e.g., "5m ago", "2h ago")
- Shows tooltip with full timestamp on hover
- Displays only when quota data exists and not currently refreshing

### Minor Cleanup (`QuotaBarItem.tsx`)
- Simplified details display by removing unnecessary wrapper fragment
- Consolidated caption typography for cleaner code

## Implementation Details
- Quota mock data includes realistic values with different reset times (1 hour, 2 days, 6 days, 30 days)
- API handlers properly simulate async operations with delays for refresh endpoints
- Menu state management uses provider UUID to track which provider's menu is open
- All menu items properly stop event propagation to prevent row selection conflicts
- Quota button color changes to primary when quota data is available

https://claude.ai/code/session_015T1BHHXtBU53KHj5m9B8BM