### PR TITLE
bugfix(smart_routing): op latest_user shoud matching to exclude tool_result messages

### DIFF
--- a/internal/server/routing/stage_smart_routing_test.go
+++ b/internal/server/routing/stage_smart_routing_test.go
@@ -11,6 +11,40 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// betaRequestWithToolResult builds a BetaMessageNewParams that simulates a
+// typical agentic turn: user text → assistant tool_use → user tool_result.
+// The keyword appears only in the original user text, not in the tool_result.
+func betaRequestWithToolResult(keyword string) *anthropic.BetaMessageNewParams {
+	return &anthropic.BetaMessageNewParams{
+		Model: anthropic.Model("claude-3-5-sonnet-20241022"),
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "please search for " + keyword}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "I will search now"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfToolResult: &anthropic.BetaToolResultBlockParam{
+						ToolUseID: "toolu_01",
+						Content: []anthropic.BetaToolResultBlockParamContentUnion{
+							{OfText: &anthropic.BetaTextBlockParam{Text: "search results"}},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
 func TestSmartRouting_RuleMatch(t *testing.T) {
 	lb := &mockLoadBalancer{service: testService("provider-a", "gpt-4", true)}
 	services := []*loadbalance.Service{testService("provider-a", "gpt-4", true)}
@@ -233,6 +267,82 @@ func TestSmartRouting_AgentClaudeCode_MainDoesNotMatchSubagentRule(t *testing.T)
 	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled, "main-agent request should not match subagent-only rule")
+}
+
+// TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch is the stage-level
+// regression test for the "lock-in" bug: after a user sends a tool_result
+// (role=user but no text), the latest_user contains rule must NOT match against
+// the stale previous user text and must fall through to the load-balancer
+// (default) instead of staying locked on the smart-routing branch.
+func TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch(t *testing.T) {
+	specialSvc := testService("provider-special", "model-special", true)
+
+	rule := testSmartRule("rule-lu", "claude-3-5-sonnet-20241022",
+		[]*loadbalance.Service{specialSvc},
+		smartrouting.SmartOp{
+			Position:  smartrouting.PositionLatestUser,
+			Operation: smartrouting.OpLatestUserContains,
+			Value:     "keyword",
+		},
+	)
+
+	// Latest message is a tool_result — must fall through, not lock on branch.
+	ctx := testContext(rule, "")
+	ctx.Request = betaRequestWithToolResult("keyword")
+
+	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled,
+		"tool_result as last user message must not match latest_user contains rule")
+}
+
+// TestSmartRouting_LatestUser_TextMatchesAfterToolResult verifies that when a
+// real user text message follows the tool_result exchange and contains the
+// keyword, the rule correctly fires again.
+func TestSmartRouting_LatestUser_TextMatchesAfterToolResult(t *testing.T) {
+	specialSvc := testService("provider-special", "model-special", true)
+
+	rule := testSmartRule("rule-lu", "claude-3-5-sonnet-20241022",
+		[]*loadbalance.Service{specialSvc},
+		smartrouting.SmartOp{
+			Position:  smartrouting.PositionLatestUser,
+			Operation: smartrouting.OpLatestUserContains,
+			Value:     "keyword",
+		},
+	)
+
+	// Four-turn conversation ending with a real user text containing the keyword.
+	req := &anthropic.BetaMessageNewParams{
+		Model: anthropic.Model("claude-3-5-sonnet-20241022"),
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "initial message"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "response"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "now search for keyword please"}},
+				},
+			},
+		},
+	}
+
+	ctx := testContext(rule, "")
+	ctx.Request = req
+
+	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled, "real user text with keyword must match")
+	require.Equal(t, "provider-special", result.Service.Provider)
 }
 
 func TestSmartRouting_AgentClaudeCode_NonClaudeCodeScenarioDoesNotMatch(t *testing.T) {

--- a/internal/smart_routing/context.go
+++ b/internal/smart_routing/context.go
@@ -29,6 +29,11 @@ type RequestContext struct {
 	ToolUses          []string
 	LatestRole        string // Latest message role (user, assistant, tool, function, etc.)
 	LatestContentType string
+	// LatestUserHasText is true when the most recent user-role message contained
+	// extractable text content. It is false when the last user message was a
+	// tool_result (no text), which means GetLatestUserMessage() would return a
+	// stale previous message — not suitable for latest_user matching.
+	LatestUserHasText bool
 	// HasImage is true when ANY message in the conversation (any role,
 	// any position — not just the latest) contains an image content block.
 	// proxy_vision uses this because its responsibilities include cleaning
@@ -117,9 +122,22 @@ func ExtractContextFromBetaRequest(req *anthropic.BetaMessageNewParams) *Request
 
 			if contentStr != "" {
 				ctx.UserMessages = append(ctx.UserMessages, contentStr)
+				ctx.LatestUserHasText = true
+			} else {
+				// User message with no extractable text (e.g. tool_result blocks).
+				// Mark that the latest user turn is not a text message so that
+				// latest_user contains/type ops do not match against a stale
+				// previous user text.
+				ctx.LatestUserHasText = false
 			}
-			if ctx.HasImage {
+
+			// LatestContentType reflects the CURRENT user message's content type,
+			// not the cumulative HasImage flag — an earlier image in the
+			// conversation (any role) must not bleed into a later text-only turn.
+			if hasImageInBetaContent(msg.Content) {
 				ctx.LatestContentType = "image"
+			} else {
+				ctx.LatestContentType = ""
 			}
 
 			ctx.ToolUses = append(ctx.ToolUses, toolUses...)

--- a/internal/smart_routing/context.go
+++ b/internal/smart_routing/context.go
@@ -102,10 +102,11 @@ func ExtractContextFromBetaRequest(req *anthropic.BetaMessageNewParams) *Request
 		}
 	}
 
-	if req.Messages != nil {
+	if len(req.Messages) > 0 {
+		// Pass 1 — accumulate data that spans the entire history.
+		// HasImage, UserMessages, and ToolUses are cumulative: a single
+		// scan from oldest to newest is enough.
 		for _, msg := range req.Messages {
-			ctx.LatestRole = string(msg.Role)
-
 			// HasImage tracks images across every role so proxy_vision
 			// (which cleans historical images) matches when the image
 			// lives in an assistant message or tool result — not only
@@ -113,34 +114,34 @@ func ExtractContextFromBetaRequest(req *anthropic.BetaMessageNewParams) *Request
 			if hasImageInBetaContent(msg.Content) {
 				ctx.HasImage = true
 			}
-
 			if string(msg.Role) != "user" {
 				continue
 			}
-
 			contentStr, toolUses := extractBetaContent(msg.Content)
-
 			if contentStr != "" {
 				ctx.UserMessages = append(ctx.UserMessages, contentStr)
-				ctx.LatestUserHasText = true
-			} else {
-				// User message with no extractable text (e.g. tool_result blocks).
-				// Mark that the latest user turn is not a text message so that
-				// latest_user contains/type ops do not match against a stale
-				// previous user text.
-				ctx.LatestUserHasText = false
 			}
+			ctx.ToolUses = append(ctx.ToolUses, toolUses...)
+		}
 
-			// LatestContentType reflects the CURRENT user message's content type,
-			// not the cumulative HasImage flag — an earlier image in the
-			// conversation (any role) must not bleed into a later text-only turn.
+		// Step 2 — locate: what is the role of the very last message?
+		ctx.LatestRole = string(req.Messages[len(req.Messages)-1].Role)
+
+		// Step 3 — locate then analyze: find the last user-role message and
+		// inspect only that message for latest_user op fields. Walking
+		// backwards keeps the intent explicit and avoids any state bleed from
+		// earlier turns.
+		for i := len(req.Messages) - 1; i >= 0; i-- {
+			msg := req.Messages[i]
+			if string(msg.Role) != "user" {
+				continue
+			}
+			contentStr, _ := extractBetaContent(msg.Content)
+			ctx.LatestUserHasText = contentStr != ""
 			if hasImageInBetaContent(msg.Content) {
 				ctx.LatestContentType = "image"
-			} else {
-				ctx.LatestContentType = ""
 			}
-
-			ctx.ToolUses = append(ctx.ToolUses, toolUses...)
+			break
 		}
 	}
 

--- a/internal/smart_routing/router_test.go
+++ b/internal/smart_routing/router_test.go
@@ -696,3 +696,148 @@ func TestValidateSmartOp_AgentClaudeCode(t *testing.T) {
 	require.NoError(t, ValidateSmartOp(&op))
 }
 
+// TestLatestUser_ToolResultDoesNotFalseMatch verifies that when the most recent
+// user-role message is a tool_result (no text content), a latest_user contains
+// rule does NOT match against the stale previous user text — the request must
+// fall through to the default provider instead of incorrectly routing to the
+// smart-routing branch.
+func TestLatestUser_ToolResultDoesNotFalseMatch(t *testing.T) {
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "route when user says keyword",
+			Ops: []SmartOp{
+				{Position: PositionLatestUser, Operation: OpLatestUserContains, Value: "keyword"},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "special", Model: "m", Weight: 1, Active: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate: user text containing "keyword", then assistant tool_use,
+	// then user tool_result (no text). The smart routing must NOT match
+	// because the latest user turn carries no text content.
+	req := &anthropic.BetaMessageNewParams{
+		Model: anthropic.Model("claude-3-5-sonnet-20241022"),
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "please search for keyword"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "I will search now"}},
+				},
+			},
+			{
+				// tool_result user message — no text, only tool result block
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfToolResult: &anthropic.BetaToolResultBlockParam{
+						ToolUseID: "toolu_01",
+						Content: []anthropic.BetaToolResultBlockParamContentUnion{
+							{OfText: &anthropic.BetaTextBlockParam{Text: "search results here"}},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	ctx := ExtractContextFromBetaRequest(req)
+	require.Equal(t, "user", ctx.LatestRole)
+	require.False(t, ctx.LatestUserHasText, "tool_result user message should not set LatestUserHasText")
+
+	_, matched := router.EvaluateRequest(ctx)
+	require.False(t, matched, "should NOT match: latest user turn is tool_result, not a text message containing keyword")
+}
+
+// TestLatestUser_TextAfterToolResult verifies that after a tool_result exchange,
+// a subsequent real user text message is matched correctly.
+func TestLatestUser_TextAfterToolResult(t *testing.T) {
+	router, err := NewRouter([]SmartRouting{
+		{
+			Description: "route when user says keyword",
+			Ops: []SmartOp{
+				{Position: PositionLatestUser, Operation: OpLatestUserContains, Value: "keyword"},
+			},
+			Services: []*loadbalance.Service{
+				{Provider: "special", Model: "m", Weight: 1, Active: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := &anthropic.BetaMessageNewParams{
+		Model: anthropic.Model("claude-3-5-sonnet-20241022"),
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "first message without keyword"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "response"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "now use keyword here"}},
+				},
+			},
+		},
+	}
+
+	ctx := ExtractContextFromBetaRequest(req)
+	require.True(t, ctx.LatestUserHasText)
+
+	_, matched := router.EvaluateRequest(ctx)
+	require.True(t, matched, "should match: latest user text contains keyword")
+}
+
+// TestLatestContentType_NotBleededFromPreviousImage verifies that LatestContentType
+// is set based on the current user message only, not the cumulative HasImage flag.
+func TestLatestContentType_NotBleededFromPreviousImage(t *testing.T) {
+	// First user message has an image, second is text-only.
+	// LatestContentType should be "" (not "image") for the second message.
+	req := &anthropic.BetaMessageNewParams{
+		Model: anthropic.Model("claude-3-5-sonnet-20241022"),
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					anthropic.NewBetaImageBlock(anthropic.BetaBase64ImageSourceParam{
+						Data:      "/9j/4AAQ...",
+						MediaType: anthropic.BetaBase64ImageSourceMediaTypeImageJPEG,
+					}),
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "I see an image"}},
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfText: &anthropic.BetaTextBlockParam{Text: "now a text-only follow-up"}},
+				},
+			},
+		},
+	}
+
+	ctx := ExtractContextFromBetaRequest(req)
+	require.True(t, ctx.HasImage, "HasImage should still be true (cumulative)")
+	require.Equal(t, "", ctx.LatestContentType, "LatestContentType should be empty for the latest text-only user message")
+	require.True(t, ctx.LatestUserHasText)
+}
+

--- a/internal/smart_routing/routing.go
+++ b/internal/smart_routing/routing.go
@@ -334,10 +334,23 @@ func (r *Router) evaluateLatestUserOp(ctx *RequestContext, op *SmartOp) OpEvalRe
 			res.Reason = fmt.Sprintf("latest role is %q, not user", ctx.LatestRole)
 			return res
 		}
+		if !ctx.LatestUserHasText {
+			// Latest user-role message was a tool_result (no text). Matching
+			// against GetLatestUserMessage() would return a stale previous text
+			// and could produce a false positive — return no-match instead so
+			// the request falls through to the default.
+			res.Reason = "latest user message has no text content (tool_result)"
+			return res
+		}
 		res.Matched = strings.Contains(latest, value)
 		res.Actual = snippetAround(latest, value)
 		res.Reason = fmt.Sprintf("latest user contains %q", value)
 	case OpLatestUserRequestType:
+		if ctx.LatestRole != "user" || !ctx.LatestUserHasText {
+			res.Actual = ctx.LatestContentType
+			res.Reason = fmt.Sprintf("latest role is %q, not user text", ctx.LatestRole)
+			return res
+		}
 		res.Actual = ctx.LatestContentType
 		res.Matched = ctx.LatestContentType == value
 		res.Reason = fmt.Sprintf("latest content_type %q == %q", ctx.LatestContentType, value)


### PR DESCRIPTION
## Summary
Fixes a bug where `latest_user` smart routing rules could incorrectly match against stale previous user text when the most recent user-role message was a `tool_result` (containing no text content). This caused requests to be locked into the smart-routing branch instead of falling through to the default load-balancer.

## Key Changes

- **context.go**: Added `LatestUserHasText` field to `RequestContext` to track whether the most recent user-role message contains extractable text. Refactored `ExtractContextFromBetaRequest()` to:
  - Accumulate cumulative data (HasImage, UserMessages, ToolUses) in a first pass
  - Locate the latest role in a second pass
  - Walk backwards to find the last user-role message and inspect only that message for `latest_user` op fields, avoiding state bleed from earlier turns

- **routing.go**: Updated `evaluateLatestUserOp()` to check `LatestUserHasText` before matching:
  - `OpLatestUserContains`: Returns no-match if latest user message has no text (tool_result), preventing false positives
  - `OpLatestUserRequestType`: Added guard to ensure latest role is user with text before evaluating content type

- **router_test.go**: Added three comprehensive unit tests:
  - `TestLatestUser_ToolResultDoesNotFalseMatch`: Verifies tool_result messages don't match latest_user rules
  - `TestLatestUser_TextAfterToolResult`: Confirms real user text after tool_result exchanges matches correctly
  - `TestLatestContentType_NotBleededFromPreviousImage`: Ensures LatestContentType is based on current message only, not cumulative HasImage

- **stage_smart_routing_test.go**: Added helper function `betaRequestWithToolResult()` and two stage-level regression tests:
  - `TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch`: Verifies tool_result doesn't lock request on smart-routing branch
  - `TestSmartRouting_LatestUser_TextMatchesAfterToolResult`: Confirms matching works correctly when real user text follows tool_result exchange

## Implementation Details
The fix distinguishes between cumulative conversation state (HasImage, UserMessages) and latest-message-specific state (LatestUserHasText, LatestContentType). This prevents tool_result messages from being treated as valid text content for `latest_user` matching while preserving correct behavior for subsequent real user messages.

https://claude.ai/code/session_01VNg4ELNkHeKPR9m7mGe8b6