### PR TITLE
style(credential): align OAuth table column widths with API Key table

### DIFF
--- a/frontend/src/components/OAuthTable.tsx
+++ b/frontend/src/components/OAuthTable.tsx
@@ -210,11 +210,11 @@ const OAuthTable = ({ providers, onEdit, onToggle, onDelete, onReauthorize, onRe
                     <TableRow>
                         <TableCell sx={{ fontWeight: 600, width: 90 }}>Status</TableCell>
                         <TableCell sx={{ fontWeight: 600, width: 140 }}>Name</TableCell>
-                        <TableCell sx={{ fontWeight: 600, width: 120 }}>API Style</TableCell>
-                        <TableCell sx={{ fontWeight: 600, width: 120 }}>Provider</TableCell>
-                        <TableCell sx={{ fontWeight: 600, width: 130 }}>Expires At</TableCell>
+                        <TableCell sx={{ fontWeight: 600, width: 140 }}>API Style</TableCell>
+                        <TableCell sx={{ fontWeight: 600, width: 200 }}>Provider</TableCell>
+                        <TableCell sx={{ fontWeight: 600, width: 140 }}>Expires At</TableCell>
                         <TableCell sx={{ fontWeight: 600, width: 60 }}>Proxy</TableCell>
-                        <TableCell sx={{ fontWeight: 600, width: 240 }}>Actions</TableCell>
+                        <TableCell sx={{ fontWeight: 600, width: 200 }}>Actions</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>


### PR DESCRIPTION
Align column widths in OAuthTable to match ApiKeyTable for consistency:
- API Style: 120 → 140
- Provider: 120 → 200
- Expires At: 130 → 140
- Actions: 240 → 200