### PR TITLE
bugfix: fix "no service available" error on transient rate limits

### DIFF
--- a/internal/server/load_balancer.go
+++ b/internal/server/load_balancer.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	typ "github.com/tingly-dev/tingly-box/internal/typ"
@@ -74,12 +76,18 @@ func (lb *LoadBalancer) SelectService(rule *typ.Rule) (*loadbalance.Service, err
 		return nil, fmt.Errorf("no active services for rule %s", rule.RequestModel)
 	}
 
-	// Filter healthy services using health filter
+	// Filter healthy services using health filter. When every active service is
+	// currently marked unhealthy (e.g. a transient 429 on a single-service rule,
+	// or all services inside the recovery window at once), fall back to the full
+	// active set instead of failing the whole rule. Trying an unhealthy upstream
+	// is strictly better than a hard "no service available": the service may have
+	// already recovered, and if it really is still failing the caller gets the
+	// real upstream error (e.g. 429) rather than a confusing routing error.
 	healthyServices := lb.healthFilter.Filter(activeServices)
-
-	// If no healthy services, return error
 	if len(healthyServices) == 0 {
-		return nil, fmt.Errorf("no healthy services available for rule %s", rule.RequestModel)
+		logrus.Warnf("[load_balancer] all %d active services for rule %s are unhealthy; "+
+			"falling back to active set", len(activeServices), rule.RequestModel)
+		healthyServices = activeServices
 	}
 
 	// For single healthy service rules, return it directly

--- a/internal/server_test/health_filter_test.go
+++ b/internal/server_test/health_filter_test.go
@@ -116,10 +116,13 @@ func TestHealthFilter_AllUnhealthy(t *testing.T) {
 	healthMonitor.ReportRateLimit(rule.Services[0].ServiceID())
 	healthMonitor.ReportRateLimit(rule.Services[1].ServiceID())
 
-	// SelectService should return error when no healthy services
-	_, err = lb.SelectService(rule)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no healthy services")
+	// When every active service is unhealthy, SelectService falls back to the
+	// active set instead of failing the whole rule, so the caller still gets a
+	// service to try (which may have recovered, or will surface the real
+	// upstream error).
+	svc, err := lb.SelectService(rule)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 }
 
 // TestHealthFilter_Recovery tests that services recover after time-based timeout
@@ -162,15 +165,17 @@ func TestHealthFilter_Recovery(t *testing.T) {
 	serviceID := rule.Services[0].ServiceID()
 	healthMonitor.ReportRateLimit(serviceID)
 
-	// Should get error immediately
-	_, err = lb.SelectService(rule)
-	assert.Error(t, err)
+	// Even while marked unhealthy, a single-service rule falls back to the only
+	// service rather than failing outright.
+	service, err := lb.SelectService(rule)
+	assert.NoError(t, err)
+	assert.NotNil(t, service)
 
 	// Wait for recovery timeout
 	time.Sleep(1100 * time.Millisecond)
 
 	// Service should be healthy again
-	service, err := lb.SelectService(rule)
+	service, err = lb.SelectService(rule)
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
 	assert.Equal(t, "provider1", service.Provider)
@@ -277,9 +282,11 @@ func TestHealthFilter_ConsecutiveErrors(t *testing.T) {
 	healthMonitor.ReportError(serviceID, assert.AnError)
 	assert.False(t, healthMonitor.IsHealthy(serviceID))
 
-	// Should get error
-	_, err = lb.SelectService(rule)
-	assert.Error(t, err)
+	// The only service is unhealthy, but SelectService falls back to it rather
+	// than failing the whole rule.
+	svc, err := lb.SelectService(rule)
+	assert.NoError(t, err)
+	assert.NotNil(t, svc)
 }
 
 // TestHealthFilter_InactiveServices tests that inactive services are not selected

--- a/internal/server_test/no_service_available_repro_test.go
+++ b/internal/server_test/no_service_available_repro_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/server"
+	"github.com/tingly-dev/tingly-box/internal/server/routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestRepro_NoServiceAvailable_SingleServiceRateLimited reproduces the reported
+// intermittent "no service available for rule ..." failure end-to-end through
+// the real ServiceSelector pipeline.
+//
+// Scenario: a rule (like the built-in cc-default) has a single, correctly
+// configured, active service. The service hits a transient 429. The health
+// monitor marks it unhealthy for the recovery window. From that moment every
+// request to the rule fails with "no service available for rule" even though
+// the rule and service are configured correctly and the upstream may already
+// have recovered.
+//
+// Before the fix this test fails at the rate-limited step with that exact
+// error. After the fix (fall back to the active set) selection still returns
+// the service.
+func TestRepro_NoServiceAvailable_SingleServiceRateLimited(t *testing.T) {
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+	cfg := appConfig.GetGlobalConfig()
+
+	// A correctly configured, enabled provider.
+	providerUUID := uuid.New().String()
+	require.NoError(t, cfg.AddProvider(&typ.Provider{
+		UUID:    providerUUID,
+		Name:    "cc-default-provider",
+		APIBase: "https://example.invalid",
+		Token:   "sk-test",
+		Enabled: true,
+	}))
+
+	// Build the real selection stack exactly as server.go wires it.
+	healthMonitor := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+	healthFilter := typ.NewHealthFilter(healthMonitor)
+	lb := server.NewLoadBalancer(cfg, healthFilter)
+	defer lb.Stop()
+	affinityStore := server.NewAffinityStore(0)
+	selector := routing.NewServiceSelector(cfg, affinityStore, lb)
+
+	// A single-service rule, no smart routing / affinity -> no-affinity pipeline.
+	svc := &loadbalance.Service{
+		Provider:   providerUUID,
+		Model:      "tingly/cc-default",
+		Weight:     1,
+		Active:     true,
+		TimeWindow: 300,
+	}
+	rule := &typ.Rule{
+		Scenario:     typ.ScenarioClaudeCode,
+		RequestModel: "tingly/cc-default",
+		UUID:         "built-in-cc-default",
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticAdaptive,
+			Params: typ.DefaultAdaptiveParams(),
+		},
+		Services: []*loadbalance.Service{svc},
+		Active:   true,
+	}
+
+	ctx := &routing.SelectionContext{Rule: rule, MatchedSmartRuleIndex: -1}
+
+	// Sanity: while healthy, selection works.
+	res, err := selector.Select(ctx)
+	require.NoError(t, err, "healthy single service should select fine")
+	require.NotNil(t, res)
+	require.Equal(t, "tingly/cc-default", res.Service.Model)
+
+	// Now the only service hits a transient 429 -> marked unhealthy.
+	healthMonitor.ReportRateLimit(svc.ServiceID())
+	require.False(t, healthMonitor.IsHealthy(svc.ServiceID()),
+		"service should be unhealthy right after a 429")
+
+	// This is the reported failure point. Pre-fix: selector.Select returns
+	// "no service available for rule built-in-cc-default ...". Post-fix: it
+	// falls back to the active service and succeeds.
+	res, err = selector.Select(ctx)
+	require.NoError(t, err,
+		"single rate-limited service must not blow up the whole rule")
+	require.NotNil(t, res)
+	require.Equal(t, "tingly/cc-default", res.Service.Model)
+}


### PR DESCRIPTION
## Summary
Fixes an intermittent failure where rules with rate-limited services would fail with "no service available for rule" errors, even though the services were correctly configured and the upstream may have already recovered.

## Problem
When a service hits a transient 429 (rate limit), the health monitor marks it as unhealthy for a recovery window. During this window, `SelectService` would fail with "no healthy services available" error, causing the entire rule to become unavailable. This was particularly problematic for single-service rules where there's no fallback option.

## Solution
Modified the load balancer to fall back to the active service set when all services are marked unhealthy, rather than failing the entire rule. This approach is strictly better than a hard failure because:
- The service may have already recovered from the transient error
- If the service is still failing, the caller gets the real upstream error (e.g., 429) instead of a confusing routing error
- Single-service rules no longer become completely unavailable during recovery windows

## Key Changes
- **`internal/server/load_balancer.go`**: Modified `SelectService` to fall back to active services when no healthy services are available, with appropriate warning logging
- **`internal/server_test/health_filter_test.go`**: Updated existing tests to reflect the new fallback behavior instead of expecting errors
- **`internal/server_test/no_service_available_repro_test.go`**: Added end-to-end reproduction test demonstrating the fix through the real `ServiceSelector` pipeline

## Implementation Details
The fallback is logged as a warning to maintain observability while preventing hard failures. This graceful degradation allows the system to be more resilient to transient upstream issues.

https://claude.ai/code/session_01PfgrMhyjC7bjVgrLXfnh7c