### PR TITLE
feat(UI): Add system theme mode with enhanced mobile navigation and UI improvements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import ProtectedRoute from './components/ProtectedRoute';
-import { SunlitBackground } from './components/SunlitBackground';
 import { AuthProvider } from './contexts/AuthContext';
 import { FeatureFlagsProvider } from './contexts/FeatureFlagsContext';
 import { HealthProvider, useHealth } from './contexts/HealthContext';
@@ -457,14 +456,12 @@ function AppContent() {
 
 // Inner component that uses theme context
 function AppWithTheme() {
-    const { mode } = useThemeMode();
-    const theme = useMemo(() => createAppTheme(mode), [mode]);
+    const { effectiveMode } = useThemeMode();
+    const theme = useMemo(() => createAppTheme(effectiveMode), [effectiveMode]);
 
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
-            {/* Sunlit background effect */}
-            {mode === 'sunlit' && <SunlitBackground />}
             <NotificationProvider>
                 <BrowserRouter>
                     <HealthProvider>

--- a/frontend/src/components/FloatingStatusIndicators.tsx
+++ b/frontend/src/components/FloatingStatusIndicators.tsx
@@ -19,10 +19,11 @@ export const FloatingStatusIndicators = () => {
         <Box
             sx={{
                 position: 'fixed',
-                bottom: 16,
-                right: 16,
+                top: { xs: 8, md: 'auto' },
+                right: { xs: 8, md: 16 },
+                bottom: { xs: 'auto', md: 16 },
                 display: 'flex',
-                flexDirection: 'column',
+                flexDirection: { xs: 'row', md: 'column' },
                 gap: 1,
                 zIndex: Z_INDEX.popover,
             }}
@@ -41,13 +42,13 @@ export const FloatingStatusIndicators = () => {
                         onClick={showDisconnectDialog}
                         size="small"
                         sx={{
-                            width: 40,
-                            height: 40,
-                            bgcolor: 'background.paper',
+                            width: { xs: 44, md: 40 },
+                            height: { xs: 44, md: 40 },
+                            bgcolor: { xs: 'transparent', md: 'background.paper' },
                             color: 'error.main',
-                            border: '1px solid',
+                            border: { xs: 'none', md: '1px solid' },
                             borderColor: 'divider',
-                            boxShadow: 2,
+                            boxShadow: { xs: 0, md: 2 },
                             '&:hover': {
                                 bgcolor: 'action.hover',
                                 color: 'error.dark',
@@ -73,13 +74,13 @@ export const FloatingStatusIndicators = () => {
                         onClick={showUpdateDialog}
                         size="small"
                         sx={{
-                            width: 40,
-                            height: 40,
-                            bgcolor: 'background.paper',
+                            width: { xs: 44, md: 40 },
+                            height: { xs: 44, md: 40 },
+                            bgcolor: { xs: 'transparent', md: 'background.paper' },
                             color: import.meta.env.DEV && !hasUpdate ? 'success.main' : 'info.main',
-                            border: '1px solid',
+                            border: { xs: 'none', md: '1px solid' },
                             borderColor: 'divider',
-                            boxShadow: 2,
+                            boxShadow: { xs: 0, md: 2 },
                             '&:hover': {
                                 bgcolor: 'action.hover',
                             },

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
-
-type ThemeMode = 'light' | 'dark' | 'sunlit' | 'claude';
+import type { ResolvedThemeMode, ThemeMode } from '@/theme';
 
 interface ThemeContextType {
   mode: ThemeMode;
+  effectiveMode: ResolvedThemeMode;
   toggleTheme: () => void;
   setTheme: (mode: ThemeMode) => void;
 }
@@ -24,25 +24,27 @@ interface ThemeModeProviderProps {
 
 const STORAGE_KEY = 'tingly-theme-mode';
 
+const getSystemMode = (): ResolvedThemeMode => {
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+  return 'light';
+};
+
 export const ThemeModeProvider: React.FC<ThemeModeProviderProps> = ({ children }) => {
   const [mode, setMode] = useState<ThemeMode>(() => {
-    // Check localStorage first
     const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
-    if (stored === 'light' || stored === 'dark' || stored === 'sunlit' || stored === 'claude') {
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
       return stored;
     }
-    // Check system preference
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark';
-    }
-    return 'light';
+    return 'system';
   });
+  const [systemMode, setSystemMode] = useState<ResolvedThemeMode>(getSystemMode);
 
   const toggleTheme = () => {
     setMode((prev) => {
       if (prev === 'light') return 'dark';
-      if (prev === 'dark') return 'sunlit';
-      if (prev === 'sunlit') return 'claude';
+      if (prev === 'dark') return 'system';
       return 'light';
     });
   };
@@ -52,14 +54,32 @@ export const ThemeModeProvider: React.FC<ThemeModeProviderProps> = ({ children }
   };
 
   useEffect(() => {
-    // Persist to localStorage
+    if (!window.matchMedia) return;
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemModeChange = (event: MediaQueryListEvent) => {
+      setSystemMode(event.matches ? 'dark' : 'light');
+    };
+
+    setSystemMode(mediaQuery.matches ? 'dark' : 'light');
+    mediaQuery.addEventListener('change', handleSystemModeChange);
+    return () => mediaQuery.removeEventListener('change', handleSystemModeChange);
+  }, []);
+
+  const effectiveMode = mode === 'system' ? systemMode : mode;
+
+  useEffect(() => {
     localStorage.setItem(STORAGE_KEY, mode);
-    // Update document class for any CSS that depends on it
-    document.documentElement.classList.remove('light', 'dark', 'sunlit', 'claude');
-    document.documentElement.classList.add(mode);
   }, [mode]);
 
-  const value = useMemo(() => ({ mode, toggleTheme, setTheme }), [mode]);
+  useEffect(() => {
+    document.documentElement.classList.remove('light', 'dark', 'system', 'sunlit', 'claude');
+    document.documentElement.classList.add(effectiveMode);
+    if (mode === 'system') {
+      document.documentElement.classList.add('system');
+    }
+  }, [effectiveMode, mode]);
+
+  const value = useMemo(() => ({ mode, effectiveMode, toggleTheme, setTheme }), [mode, effectiveMode]);
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 };

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import type { ResolvedThemeMode, ThemeMode } from '@/theme';
+import { isThemeMode, SYSTEM_THEME_MODE_VALUES, THEME_MODE_VALUES } from '@/theme/options';
 
 interface ThemeContextType {
   mode: ThemeMode;
@@ -33,8 +34,8 @@ const getSystemMode = (): ResolvedThemeMode => {
 
 export const ThemeModeProvider: React.FC<ThemeModeProviderProps> = ({ children }) => {
   const [mode, setMode] = useState<ThemeMode>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
-    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (isThemeMode(stored)) {
       return stored;
     }
     return 'system';
@@ -43,9 +44,8 @@ export const ThemeModeProvider: React.FC<ThemeModeProviderProps> = ({ children }
 
   const toggleTheme = () => {
     setMode((prev) => {
-      if (prev === 'light') return 'dark';
-      if (prev === 'dark') return 'system';
-      return 'light';
+      const currentIndex = THEME_MODE_VALUES.indexOf(prev);
+      return THEME_MODE_VALUES[(currentIndex + 1) % THEME_MODE_VALUES.length];
     });
   };
 
@@ -57,10 +57,10 @@ export const ThemeModeProvider: React.FC<ThemeModeProviderProps> = ({ children }
     if (!window.matchMedia) return;
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleSystemModeChange = (event: MediaQueryListEvent) => {
-      setSystemMode(event.matches ? 'dark' : 'light');
+      setSystemMode(event.matches ? SYSTEM_THEME_MODE_VALUES[1] : SYSTEM_THEME_MODE_VALUES[0]);
     };
 
-    setSystemMode(mediaQuery.matches ? 'dark' : 'light');
+    setSystemMode(mediaQuery.matches ? SYSTEM_THEME_MODE_VALUES[1] : SYSTEM_THEME_MODE_VALUES[0]);
     mediaQuery.addEventListener('change', handleSystemModeChange);
     return () => mediaQuery.removeEventListener('change', handleSystemModeChange);
   }, []);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -408,7 +408,8 @@ export default {
       "connected": "Connected",
       "uptime": "Uptime",
       "lastUpdated": "Last Updated: {{time}}",
-      "loading": "Loading..."
+      "loading": "Loading...",
+      "unavailable": "Unavailable"
     },
     "prompts": {
       "enterPort": "Enter port for server:",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -72,6 +72,7 @@ export default {
       "theme": "Theme",
       "light": "Light",
       "dark": "Dark",
+      "system": "System",
       "sunlit": "Sunlit",
       "claude": "Claude",
       "zenMode": "Zen Mode",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -73,6 +73,7 @@ export default {
       "theme": "主题",
       "light": "浅色",
       "dark": "深色",
+      "system": "跟随系统",
       "sunlit": "日光",
       "claude": "Claude",
       "zenMode": "禅模式",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -409,7 +409,8 @@ export default {
       "connected": "已连接",
       "uptime": "运行时间",
       "lastUpdated": "最后更新：{{time}}",
-      "loading": "加载中..."
+      "loading": "加载中...",
+      "unavailable": "不可用"
     },
     "prompts": {
       "enterPort": "输入服务器端口：",

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { Box, Drawer, IconButton, Popover, Tooltip, Typography, Menu, MenuItem, Stack } from '@mui/material';
-import { IconMenu, IconDots, IconYinYang, IconSun, IconMoon, IconSunHigh, IconSparkles, IconPencil } from '@tabler/icons-react';
+import { BrightnessAuto, DarkMode, LightMode } from '@mui/icons-material';
+import { IconMenu, IconDots, IconYinYang, IconPencil } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -439,20 +440,16 @@ const Layout = ({ children }: LayoutProps) => {
                                     </Typography>
                                 </MenuItem>
                                 <MenuItem onClick={() => setTheme('light')} sx={{ gap: 1.5 }}>
-                                    <IconSun size={18} />
+                                    <LightMode sx={{ fontSize: 18 }} />
                                     <Typography>{t('layout.activityBar.light')}</Typography>
                                 </MenuItem>
                                 <MenuItem onClick={() => setTheme('dark')} sx={{ gap: 1.5 }}>
-                                    <IconMoon size={18} />
+                                    <DarkMode sx={{ fontSize: 18 }} />
                                     <Typography>{t('layout.activityBar.dark')}</Typography>
                                 </MenuItem>
-                                <MenuItem onClick={() => setTheme('sunlit')} sx={{ gap: 1.5 }}>
-                                    <IconSunHigh size={18} />
-                                    <Typography>{t('layout.activityBar.sunlit')}</Typography>
-                                </MenuItem>
-                                <MenuItem onClick={() => setTheme('claude')} sx={{ gap: 1.5 }}>
-                                    <IconSparkles size={18} />
-                                    <Typography>{t('layout.activityBar.claude')}</Typography>
+                                <MenuItem onClick={() => setTheme('system')} sx={{ gap: 1.5 }}>
+                                    <BrightnessAuto sx={{ fontSize: 18 }} />
+                                    <Typography>{t('layout.activityBar.system')}</Typography>
                                 </MenuItem>
                             </>
                         )}

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -1,5 +1,4 @@
 import { Box, Drawer, IconButton, Popover, Tooltip, Typography, Menu, MenuItem, Stack } from '@mui/material';
-import { BrightnessAuto, DarkMode, LightMode } from '@mui/icons-material';
 import { IconMenu, IconDots, IconYinYang, IconPencil } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -14,9 +13,58 @@ import { useActivityItems } from './useActivityItems.tsx';
 import { useZenMode } from '../hooks/useZenMode';
 import { useProfileContext } from '../contexts/ProfileContext';
 import type { ActivityItem, LayoutProps } from './types';
+import { getThemeOptions } from '@/theme/options';
 import { Claude, Codex, OpenCode, Xcode, VSCode, OpenAI, Anthropic, OpenClaw } from '../components/BrandIcons';
 import { FloatingStatusIndicators } from '../components/FloatingStatusIndicators';
 import { IconPlus } from '@tabler/icons-react';
+
+const mobileContentSx = {
+    flex: 1,
+    px: { xs: 2, md: 3 },
+    pt: { xs: 9, md: 3 },
+    pb: 3,
+    overflowY: 'auto',
+    scrollBehavior: 'smooth',
+    '&::-webkit-scrollbar': { width: 8 },
+    '&::-webkit-scrollbar-track': { backgroundColor: 'grey.100', borderRadius: 1 },
+    '&::-webkit-scrollbar-thumb': {
+        backgroundColor: 'grey.300',
+        borderRadius: 1,
+        '&:hover': { backgroundColor: 'grey.400' },
+    },
+} as const;
+
+const MobileNavigationBar = ({ onMenuClick }: { onMenuClick: () => void }) => (
+    <Box
+        sx={{
+            display: { xs: 'flex', md: 'none' },
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 56,
+            zIndex: Z_INDEX.mobileToggle,
+            alignItems: 'center',
+            px: 1,
+            bgcolor: 'background.paper',
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+        }}
+    >
+        <IconButton
+            color="primary"
+            aria-label="Open navigation menu"
+            onClick={onMenuClick}
+            sx={{
+                width: 44,
+                height: 44,
+                '&:hover': { bgcolor: 'action.hover' },
+            }}
+        >
+            <IconMenu size={24} />
+        </IconButton>
+    </Box>
+);
 
 const Layout = ({ children }: LayoutProps) => {
     const { t } = useTranslation();
@@ -24,6 +72,7 @@ const Layout = ({ children }: LayoutProps) => {
     const navigate = useNavigate();
     const { currentVersion } = useAppVersion();
     const { setTheme } = useThemeMode();
+    const themeMenuOptions = useMemo(() => getThemeOptions(t), [t]);
     const [mobileOpen, setMobileOpen] = useState(false);
     const [easterEggAnchorEl, setEasterEggAnchorEl] = useState<HTMLElement | null>(null);
     const [moreMenuAnchorEl, setMoreMenuAnchorEl] = useState<HTMLElement | null>(null);
@@ -64,6 +113,7 @@ const Layout = ({ children }: LayoutProps) => {
 
     // Determine active activity from current path, falling back to localStorage
     const activeActivity = useMemo(() => {
+        if (location.pathname === '/onboarding') return 'onboarding';
         for (const item of activityItems) {
             if (item.path && isActive(item.path)) return item.key;
             if (item.children && isChildActive(item.children)) return item.key;
@@ -183,7 +233,10 @@ const Layout = ({ children }: LayoutProps) => {
     }, [effectiveZenEnabled, zenAgent, zenMoreActivity, zenActiveActivity, activityItems, activeActivity]);
 
     const handleActivityClick = (item: ActivityItem) => {
-        setMobileOpen(false);
+        const hasSidebarItems = item.children?.some(child => child.type !== 'divider') ?? false;
+        if (!hasSidebarItems) {
+            setMobileOpen(false);
+        }
         setMoreMenuAnchorEl(null); // Close more menu if open
 
         // If clicking a zen path item, clear the zenMoreActivity to restore zen sidebar
@@ -276,6 +329,7 @@ const Layout = ({ children }: LayoutProps) => {
                     window.location.reload();
                 }}
                 zenEnabled={effectiveZenEnabled}
+                onStandaloneNavigate={() => setMobileOpen(false)}
             />
             {sidebarItems.length > 0 && (
                 <Sidebar
@@ -302,6 +356,7 @@ const Layout = ({ children }: LayoutProps) => {
                 }}
                 zenEnabled={effectiveZenEnabled}
                 onMoreClick={(e) => setMoreMenuAnchorEl(e.currentTarget)}
+                onStandaloneNavigate={() => setMobileOpen(false)}
             />
             {sidebarItems.length > 0 && (
                 <Sidebar
@@ -342,26 +397,7 @@ const Layout = ({ children }: LayoutProps) => {
                         {zenNavigationContent}
                     </Drawer>
 
-                    {/* Mobile toggle */}
-                    <IconButton
-                        color="primary"
-                        aria-label="Open navigation menu"
-                        onClick={() => setMobileOpen(!mobileOpen)}
-                        sx={{
-                            display: { xs: 'flex', md: 'none' },
-                            position: 'fixed',
-                            top: 12,
-                            left: 12,
-                            zIndex: Z_INDEX.mobileToggle,
-                            boxShadow: 3,
-                            width: 44,
-                            height: 44,
-                            '&:hover': { bgcolor: 'action.hover', transform: 'scale(1.05)' },
-                            transition: 'all 0.15s',
-                        }}
-                    >
-                        <IconMenu size={24} />
-                    </IconButton>
+                    <MobileNavigationBar onMenuClick={() => setMobileOpen(!mobileOpen)} />
 
                     {/* Main content */}
                     <Box
@@ -369,19 +405,7 @@ const Layout = ({ children }: LayoutProps) => {
                         sx={{ flexGrow: 1, height: '100vh', display: 'flex', flexDirection: 'column', overflowX: 'hidden', position: 'relative', zIndex: 1 }}
                     >
                         <Box
-                            sx={{
-                                flex: 1,
-                                p: 3,
-                                overflowY: 'auto',
-                                scrollBehavior: 'smooth',
-                                '&::-webkit-scrollbar': { width: 8 },
-                                '&::-webkit-scrollbar-track': { backgroundColor: 'grey.100', borderRadius: 1 },
-                                '&::-webkit-scrollbar-thumb': {
-                                    backgroundColor: 'grey.300',
-                                    borderRadius: 1,
-                                    '&:hover': { backgroundColor: 'grey.400' },
-                                },
-                            }}
+                            sx={mobileContentSx}
                         >
                             {children ?? <Outlet />}
                         </Box>
@@ -433,26 +457,18 @@ const Layout = ({ children }: LayoutProps) => {
 
                         {/* Theme options - only in zen mode */}
                         {effectiveZenEnabled && (
-                            <>
-                                <MenuItem disabled sx={{ opacity: 0.6 }}>
-                                    <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                                        {t('layout.themeMenu.theme')}
-                                    </Typography>
-                                </MenuItem>
-                                <MenuItem onClick={() => setTheme('light')} sx={{ gap: 1.5 }}>
-                                    <LightMode sx={{ fontSize: 18 }} />
-                                    <Typography>{t('layout.activityBar.light')}</Typography>
-                                </MenuItem>
-                                <MenuItem onClick={() => setTheme('dark')} sx={{ gap: 1.5 }}>
-                                    <DarkMode sx={{ fontSize: 18 }} />
-                                    <Typography>{t('layout.activityBar.dark')}</Typography>
-                                </MenuItem>
-                                <MenuItem onClick={() => setTheme('system')} sx={{ gap: 1.5 }}>
-                                    <BrightnessAuto sx={{ fontSize: 18 }} />
-                                    <Typography>{t('layout.activityBar.system')}</Typography>
-                                </MenuItem>
-                            </>
+                            <MenuItem disabled sx={{ opacity: 0.6 }}>
+                                <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                                    {t('layout.themeMenu.theme')}
+                                </Typography>
+                            </MenuItem>
                         )}
+                        {effectiveZenEnabled && themeMenuOptions.map(({ value, label, renderIcon }) => (
+                            <MenuItem key={value} onClick={() => setTheme(value)} sx={{ gap: 1.5 }}>
+                                {renderIcon({ size: 18 })}
+                                <Typography>{label}</Typography>
+                            </MenuItem>
+                        ))}
                     </Menu>
 
                     {/* Easter Egg Popover */}
@@ -493,26 +509,7 @@ const Layout = ({ children }: LayoutProps) => {
                         {navigationContent}
                     </Drawer>
 
-                    {/* Mobile toggle */}
-                    <IconButton
-                        color="primary"
-                        aria-label="Open navigation menu"
-                        onClick={() => setMobileOpen(!mobileOpen)}
-                        sx={{
-                            display: { xs: 'flex', md: 'none' },
-                            position: 'fixed',
-                            top: 12,
-                            left: 12,
-                            zIndex: Z_INDEX.mobileToggle,
-                            boxShadow: 3,
-                            width: 44,
-                            height: 44,
-                            '&:hover': { bgcolor: 'action.hover', transform: 'scale(1.05)' },
-                            transition: 'all 0.15s',
-                        }}
-                    >
-                        <IconMenu size={24} />
-                    </IconButton>
+                    <MobileNavigationBar onMenuClick={() => setMobileOpen(!mobileOpen)} />
 
                     {/* Main content */}
                     <Box
@@ -520,19 +517,7 @@ const Layout = ({ children }: LayoutProps) => {
                         sx={{ flexGrow: 1, height: '100vh', display: 'flex', flexDirection: 'column', overflowX: 'hidden', position: 'relative', zIndex: 1 }}
                     >
                         <Box
-                            sx={{
-                                flex: 1,
-                                p: 3,
-                                overflowY: 'auto',
-                                scrollBehavior: 'smooth',
-                                '&::-webkit-scrollbar': { width: 8 },
-                                '&::-webkit-scrollbar-track': { backgroundColor: 'grey.100', borderRadius: 1 },
-                                '&::-webkit-scrollbar-thumb': {
-                                    backgroundColor: 'grey.300',
-                                    borderRadius: 1,
-                                    '&:hover': { backgroundColor: 'grey.400' },
-                                },
-                            }}
+                            sx={mobileContentSx}
                         >
                             {children ?? <Outlet />}
                         </Box>

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -6,11 +6,13 @@ import {
     IconWand,
     IconMessageReport,
 } from '@tabler/icons-react';
+import { BrightnessAuto, DarkMode, LightMode } from '@mui/icons-material';
 import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import React, { useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useVersion as useAppVersion } from '../contexts/VersionContext';
+import { useThemeMode } from '../contexts/ThemeContext';
 import {
     activityBarWidth,
     activityContainerPaddingY,
@@ -43,7 +45,11 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
 }) => {
     const { t, i18n } = useTranslation();
     const { currentVersion } = useAppVersion();
+    const { mode: themeMode, effectiveMode, setTheme } = useThemeMode();
     const [languageMenuAnchorEl, setLanguageMenuAnchorEl] = useState<HTMLElement | null>(null);
+    const [themeMenuAnchorEl, setThemeMenuAnchorEl] = useState<HTMLElement | null>(null);
+
+    const CurrentThemeIcon = themeMode === 'system' ? BrightnessAuto : effectiveMode === 'dark' ? DarkMode : LightMode;
 
     const handleLanguageMenuClick = (event: React.MouseEvent<HTMLElement>) => {
         setLanguageMenuAnchorEl(event.currentTarget);
@@ -57,6 +63,19 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
         i18n.changeLanguage(lng);
         localStorage.setItem('i18nextLng', lng);
         handleLanguageMenuClose();
+    };
+
+    const handleThemeMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+        setThemeMenuAnchorEl(event.currentTarget);
+    };
+
+    const handleThemeMenuClose = () => {
+        setThemeMenuAnchorEl(null);
+    };
+
+    const handleThemeChange = (mode: 'light' | 'dark' | 'system') => {
+        setTheme(mode);
+        handleThemeMenuClose();
     };
 
     return (
@@ -204,6 +223,40 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                     </Menu>
                 )}
 
+                {!zenEnabled && (
+                    <Menu
+                        anchorEl={themeMenuAnchorEl}
+                        open={Boolean(themeMenuAnchorEl)}
+                        onClose={handleThemeMenuClose}
+                        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                        slotProps={{
+                            paper: {
+                                sx: {
+                                    minWidth: 156,
+                                    mt: 1,
+                                },
+                            },
+                        }}
+                    >
+                        {([
+                            { value: 'light', label: t('layout.activityBar.light'), Icon: LightMode },
+                            { value: 'dark', label: t('layout.activityBar.dark'), Icon: DarkMode },
+                            { value: 'system', label: t('layout.activityBar.system'), Icon: BrightnessAuto },
+                        ] as const).map(({ value, label, Icon }) => (
+                            <MenuItem
+                                key={value}
+                                selected={themeMode === value}
+                                onClick={() => handleThemeChange(value)}
+                                sx={{ gap: 1.5 }}
+                            >
+                                <Icon sx={{ fontSize: 18 }} />
+                                <Typography>{label}</Typography>
+                            </MenuItem>
+                        ))}
+                    </Menu>
+                )}
+
                 {/* Onboarding Quick Add Button - above Zen */}
                 {!zenEnabled && (
                     <Tooltip title={t('layout.onboarding', { defaultValue: 'Quick Add Provider' })} placement="right" arrow>
@@ -342,6 +395,48 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             </ListItemIcon>
                             <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
                                 {i18n.language === 'zh' ? '中文' : 'EN'}
+                            </Typography>
+                        </ListItemButton>
+                    </Tooltip>
+                </Box>
+            )}
+
+            {/* Theme button - bottom-left, above language icon */}
+            {!zenEnabled && (
+                <Box
+                    sx={{
+                        py: 0.5,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                    }}
+                >
+                    <Tooltip title={t('layout.activityBar.theme')} placement="right" arrow>
+                        <ListItemButton
+                            onClick={handleThemeMenuClick}
+                            sx={{
+                                minHeight: 48,
+                                mx: 0.5,
+                                px: activityItemPaddingX,
+                                py: 0.75,
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: 0.25,
+                                position: 'relative',
+                                color: 'text.secondary',
+                                borderRadius: activityItemRadius,
+                                cursor: 'pointer',
+                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                            }}
+                        >
+                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                                <CurrentThemeIcon sx={{ fontSize: 22 }} />
+                            </ListItemIcon>
+                            <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
+                                {themeMode === 'system' ? 'SYS' : effectiveMode === 'dark' ? 'Dark' : 'Light'}
                             </Typography>
                         </ListItemButton>
                     </Tooltip>

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -6,10 +6,9 @@ import {
     IconWand,
     IconMessageReport,
 } from '@tabler/icons-react';
-import { BrightnessAuto, DarkMode, LightMode } from '@mui/icons-material';
 import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
-import React, { useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import React, { useMemo, useState } from 'react';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useVersion as useAppVersion } from '../contexts/VersionContext';
 import { useThemeMode } from '../contexts/ThemeContext';
@@ -23,6 +22,8 @@ import {
     headerHeight,
 } from './constants';
 import type { ActivityItem } from './types';
+import type { ThemeMode } from '@/theme';
+import { getThemeOptions } from '@/theme/options';
 
 interface ActivityBarProps {
     activityItems: ActivityItem[];
@@ -32,6 +33,7 @@ interface ActivityBarProps {
     onZenToggle?: () => void;
     zenEnabled?: boolean;
     onMoreClick?: (event: React.MouseEvent<HTMLElement>) => void;
+    onStandaloneNavigate?: () => void;
 }
 
 export const ZenActivityBar: React.FC<ActivityBarProps> = ({
@@ -42,14 +44,19 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
     onZenToggle,
     zenEnabled = false,
     onMoreClick,
+    onStandaloneNavigate,
 }) => {
     const { t, i18n } = useTranslation();
+    const location = useLocation();
     const { currentVersion } = useAppVersion();
-    const { mode: themeMode, effectiveMode, setTheme } = useThemeMode();
+    const { mode: themeMode, setTheme } = useThemeMode();
     const [languageMenuAnchorEl, setLanguageMenuAnchorEl] = useState<HTMLElement | null>(null);
     const [themeMenuAnchorEl, setThemeMenuAnchorEl] = useState<HTMLElement | null>(null);
 
-    const CurrentThemeIcon = themeMode === 'system' ? BrightnessAuto : effectiveMode === 'dark' ? DarkMode : LightMode;
+    const themeOptions = useMemo(() => getThemeOptions(t), [t]);
+    const currentThemeOption = themeOptions.find((option) => option.value === themeMode);
+    const renderCurrentThemeIcon = currentThemeOption?.renderIcon ?? themeOptions[0].renderIcon;
+    const isOnboardingActive = location.pathname === '/onboarding';
 
     const handleLanguageMenuClick = (event: React.MouseEvent<HTMLElement>) => {
         setLanguageMenuAnchorEl(event.currentTarget);
@@ -73,7 +80,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
         setThemeMenuAnchorEl(null);
     };
 
-    const handleThemeChange = (mode: 'light' | 'dark' | 'system') => {
+    const handleThemeChange = (mode: ThemeMode) => {
         setTheme(mode);
         handleThemeMenuClose();
     };
@@ -239,18 +246,14 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             },
                         }}
                     >
-                        {([
-                            { value: 'light', label: t('layout.activityBar.light'), Icon: LightMode },
-                            { value: 'dark', label: t('layout.activityBar.dark'), Icon: DarkMode },
-                            { value: 'system', label: t('layout.activityBar.system'), Icon: BrightnessAuto },
-                        ] as const).map(({ value, label, Icon }) => (
+                        {themeOptions.map(({ value, label, renderIcon }) => (
                             <MenuItem
                                 key={value}
                                 selected={themeMode === value}
                                 onClick={() => handleThemeChange(value)}
                                 sx={{ gap: 1.5 }}
                             >
-                                <Icon sx={{ fontSize: 18 }} />
+                                {renderIcon({ size: 18 })}
                                 <Typography>{label}</Typography>
                             </MenuItem>
                         ))}
@@ -263,14 +266,43 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                         <ListItemButton
                             component={RouterLink}
                             to="/onboarding"
+                            onClick={onStandaloneNavigate}
                             sx={activityItemSx({
-                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                                '&:hover': {
+                                    bgcolor: isOnboardingActive ? 'primary.dark' : 'action.hover',
+                                    color: isOnboardingActive ? 'primary.contrastText' : 'primary.main',
+                                },
+                                ...(isOnboardingActive && {
+                                    bgcolor: 'primary.main',
+                                    color: 'primary.contrastText',
+                                    '&::before': {
+                                        content: '""',
+                                        position: 'absolute',
+                                        left: 0,
+                                        top: '50%',
+                                        transform: 'translateY(-50%)',
+                                        width: 3,
+                                        height: 28,
+                                        bgcolor: 'primary.light',
+                                        borderRadius: '0 2px 2px 0',
+                                        boxShadow: '0 0 8px rgba(37, 99, 235, 0.5)',
+                                    },
+                                }),
                             })}
                         >
                             <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                                 <IconWand size={22} />
                             </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
+                            <Typography
+                                variant="caption"
+                                sx={{
+                                    fontSize: '0.65rem',
+                                    fontWeight: isOnboardingActive ? 600 : 400,
+                                    color: 'inherit',
+                                    textAlign: 'center',
+                                    lineHeight: 1.2,
+                                }}
+                            >
                                 {t('layout.onboardingShort', { defaultValue: 'Onboard' })}
                             </Typography>
                         </ListItemButton>
@@ -433,10 +465,10 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             }}
                         >
                             <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <CurrentThemeIcon sx={{ fontSize: 22 }} />
+                                {renderCurrentThemeIcon({ size: 22 })}
                             </ListItemIcon>
                             <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
-                                {themeMode === 'system' ? 'SYS' : effectiveMode === 'dark' ? 'Dark' : 'Light'}
+                                {currentThemeOption?.label ?? 'Light'}
                             </Typography>
                         </ListItemButton>
                     </Tooltip>

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -706,6 +706,16 @@ export const handlers = [
         })
     }),
 
+    http.get('/api/v1/status', () => {
+        return HttpResponse.json({
+            success: true,
+            data: {
+                server_running: true,
+                uptime: 'Mock mode',
+            }
+        })
+    }),
+
     // ============================================
     // v2 Providers API
     // ============================================

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -1,11 +1,11 @@
 import CardGrid from '@/components/CardGrid';
 import { PageLayout } from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
-import { BrightnessAuto, DarkMode, LightMode, Logout } from '@mui/icons-material';
+import { Logout } from '@mui/icons-material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
-import { IconCircleCheck, IconCircleX, IconInfoCircle, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconWorld, IconCheck } from '@tabler/icons-react';
+import { IconCircleCheck, IconCircleX, IconInfoCircle, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconWorld, IconCheck, IconClock } from '@tabler/icons-react';
 import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHealth } from '@/contexts/HealthContext';
 import { useVersion } from '@/contexts/VersionContext';
@@ -13,6 +13,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useThemeMode } from '@/contexts/ThemeContext';
 import { useNotify } from '@/hooks/useNotify';
 import { api } from '@/services/api';
+import { getThemeOptions } from '@/theme/options';
 
 const System = () => {
     const { t, i18n } = useTranslation();
@@ -20,6 +21,7 @@ const System = () => {
     const { isHealthy, checking, checkHealth } = useHealth();
     const { logout: authLogout } = useAuth();
     const { mode: themeMode, setTheme } = useThemeMode();
+    const themeOptions = useMemo(() => getThemeOptions(t), [t]);
     const notify = useNotify();
     const [serverStatus, setServerStatus] = useState<any>(null);
     const [loading, setLoading] = useState(true);
@@ -27,6 +29,10 @@ const System = () => {
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
     const [globalProxyInput, setGlobalProxyInput] = useState('');
     const [proxyUrlSaving, setProxyUrlSaving] = useState(false);
+    const isServerStatusAvailable = Boolean(serverStatus);
+    const serverStatusLabel = !isServerStatusAvailable
+        ? t('system.status.unavailable')
+        : serverStatus.server_running ? t('system.status.running') : t('system.status.stopped');
 
     const handleForceLogout = () => {
         authLogout();
@@ -139,171 +145,168 @@ const System = () => {
                         </Stack>
                     }
                 >
-                    {serverStatus ? (
-                        <Stack spacing={1.5}>
-                            {/* Server Status */}
+                    <Stack spacing={1.5}>
+                        {/* Server Status */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                {serverStatus?.server_running ? (
+                                    <IconCircleCheck size={16} style={{ color: 'var(--mui-palette-success-main)' }} />
+                                ) : (
+                                    <IconCircleX
+                                        size={16}
+                                        style={{
+                                            color: isServerStatusAvailable
+                                                ? 'var(--mui-palette-error-main)'
+                                                : 'var(--mui-palette-text-secondary)',
+                                        }}
+                                    />
+                                )}
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {t('system.serverStatus.server')}
+                                </Typography>
+                            </Box>
+                            <Box sx={{ flex: 1 }}>
+                                <Typography variant="body2" sx={{ color: 'text.primary' }}>
+                                    {serverStatusLabel}
+                                    {isHealthy && (
+                                        <Typography component="span" variant="body2" color="success.main" sx={{ ml: 1 }}>
+                                            · {t('system.status.connected')}
+                                        </Typography>
+                                    )}
+                                </Typography>
+                            </Box>
+                        </Box>
+
+                        {/* Uptime */}
+                        {serverStatus?.uptime && (
                             <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                    {serverStatus.server_running ? (
-                                        <IconCircleCheck size={16} style={{ color: 'var(--mui-palette-success-main)' }} />
-                                    ) : (
-                                        <IconCircleX size={16} style={{ color: 'var(--mui-palette-error-main)' }} />
-                                    )}
+                                    <IconClock size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
                                     <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('system.serverStatus.server')}
+                                        {t('system.status.uptime')}
                                     </Typography>
                                 </Box>
                                 <Box sx={{ flex: 1 }}>
                                     <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                                        {serverStatus.server_running ? t('system.status.running') : t('system.status.stopped')}
-                                        {isHealthy && (
-                                            <Typography component="span" variant="body2" color="success.main" sx={{ ml: 1 }}>
-                                                · {t('system.status.connected')}
-                                            </Typography>
-                                        )}
+                                        {serverStatus.uptime}
                                     </Typography>
                                 </Box>
                             </Box>
+                        )}
 
-                            {/* Uptime */}
-                            {serverStatus.uptime && (
-                                <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                            {t('system.status.uptime')}
-                                        </Typography>
-                                    </Box>
-                                    <Box sx={{ flex: 1 }}>
-                                        <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                                            {serverStatus.uptime}
-                                        </Typography>
-                                    </Box>
-                                </Box>
-                            )}
-
-                            {/* Proxy Settings */}
-                            <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                    <IconLock size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('system.proxy.label')}
-                                    </Typography>
-                                </Box>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                                    {respectEnvProxy !== null && (
-                                        <Tooltip
-                                            title={t('system.proxy.respectEnvProxy.helper')}
-                                            arrow
-                                        >
-                                            <Chip
-                                                label={`${respectEnvProxy ? t('system.proxy.respectEnvProxy.label') : t('common.direct')} · ${respectEnvProxy ? t('common.on') : t('common.off')}`}
-                                                onClick={toggleProxy}
-                                                size="small"
-                                                sx={(theme) => ({
-                                                    bgcolor: respectEnvProxy ? 'primary.main' : 'action.hover',
-                                                    color: respectEnvProxy ? 'primary.contrastText' : 'text.primary',
-                                                    fontWeight: respectEnvProxy ? 600 : 400,
-                                                    border: respectEnvProxy ? 'none' : '1px solid',
-                                                    borderColor: 'divider',
-                                                    '&:hover': {
-                                                        bgcolor: respectEnvProxy ? 'primary.dark' : 'action.selected',
-                                                    },
-                                                })}
-                                            />
-                                        </Tooltip>
-                                    )}
-                                </Box>
+                        {/* Proxy Settings */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                <IconLock size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {t('system.proxy.label')}
+                                </Typography>
                             </Box>
-
-                            {/* Language — merged from the standalone Language Settings card */}
-                            <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                    <IconLanguage size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('system.language.title')}
-                                    </Typography>
-                                </Box>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
-                                    <Chip
-                                        label={t('system.language.en')}
-                                        onClick={() => changeLanguage('en')}
-                                        size="small"
-                                        sx={{
-                                            bgcolor: i18n.language === 'en' ? 'primary.main' : 'action.hover',
-                                            color: i18n.language === 'en' ? 'primary.contrastText' : 'text.primary',
-                                            fontWeight: i18n.language === 'en' ? 600 : 400,
-                                            border: i18n.language === 'en' ? 'none' : '1px solid',
-                                            borderColor: 'divider',
-                                            cursor: 'pointer',
-                                            '&:hover': {
-                                                bgcolor: i18n.language === 'en' ? 'primary.dark' : 'action.selected',
-                                            },
-                                        }}
-                                    />
-                                    <Chip
-                                        label={t('system.language.zh')}
-                                        onClick={() => changeLanguage('zh')}
-                                        size="small"
-                                        sx={{
-                                            bgcolor: i18n.language === 'zh' ? 'primary.main' : 'action.hover',
-                                            color: i18n.language === 'zh' ? 'primary.contrastText' : 'text.primary',
-                                            fontWeight: i18n.language === 'zh' ? 600 : 400,
-                                            border: i18n.language === 'zh' ? 'none' : '1px solid',
-                                            borderColor: 'divider',
-                                            cursor: 'pointer',
-                                            '&:hover': {
-                                                bgcolor: i18n.language === 'zh' ? 'primary.dark' : 'action.selected',
-                                            },
-                                        }}
-                                    />
-                                </Box>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
+                                {respectEnvProxy !== null && (
+                                    <Tooltip title={t('system.proxy.respectEnvProxy.helper')} arrow>
+                                        <Chip
+                                            label={`${respectEnvProxy ? t('system.proxy.respectEnvProxy.label') : t('common.direct')} · ${respectEnvProxy ? t('common.on') : t('common.off')}`}
+                                            onClick={toggleProxy}
+                                            size="small"
+                                            sx={(theme) => ({
+                                                bgcolor: respectEnvProxy ? 'primary.main' : 'action.hover',
+                                                color: respectEnvProxy ? 'primary.contrastText' : 'text.primary',
+                                                fontWeight: respectEnvProxy ? 600 : 400,
+                                                border: respectEnvProxy ? 'none' : '1px solid',
+                                                borderColor: 'divider',
+                                                '&:hover': {
+                                                    bgcolor: respectEnvProxy ? 'primary.dark' : 'action.selected',
+                                                },
+                                            })}
+                                        />
+                                    </Tooltip>
+                                )}
                             </Box>
+                        </Box>
 
-                            {/* Theme — moved from the activity bar */}
-                            <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                    <IconBrush size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('common.theme')}
-                                    </Typography>
-                                </Box>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
-                                    {([
-                                        { value: 'light', label: t('layout.activityBar.light'), Icon: LightMode },
-                                        { value: 'dark', label: t('layout.activityBar.dark'), Icon: DarkMode },
-                                        { value: 'system', label: t('layout.activityBar.system'), Icon: BrightnessAuto },
-                                    ] as const).map(({ value, label, Icon }) => {
-                                        const selected = themeMode === value;
-                                        return (
-                                            <Chip
-                                                key={value}
-                                                icon={<Icon sx={{ fontSize: 14 }} />}
-                                                label={label}
-                                                onClick={() => setTheme(value)}
-                                                size="small"
-                                                sx={{
-                                                    bgcolor: selected ? 'primary.main' : 'action.hover',
-                                                    color: selected ? 'primary.contrastText' : 'text.primary',
-                                                    fontWeight: selected ? 600 : 400,
-                                                    border: selected ? 'none' : '1px solid',
-                                                    borderColor: 'divider',
-                                                    cursor: 'pointer',
-                                                    '& .MuiChip-icon': {
-                                                        color: 'inherit',
-                                                    },
-                                                    '&:hover': {
-                                                        bgcolor: selected ? 'primary.dark' : 'action.selected',
-                                                    },
-                                                }}
-                                            />
-                                        );
-                                    })}
-                                </Box>
+                        {/* Language — merged from the standalone Language Settings card */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                <IconLanguage size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {t('system.language.title')}
+                                </Typography>
                             </Box>
-                        </Stack>
-                    ) : (
-                        <Typography color="text.secondary">{t('system.status.loading')}</Typography>
-                    )}
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
+                                <Chip
+                                    label={t('system.language.en')}
+                                    onClick={() => changeLanguage('en')}
+                                    size="small"
+                                    sx={{
+                                        bgcolor: i18n.language === 'en' ? 'primary.main' : 'action.hover',
+                                        color: i18n.language === 'en' ? 'primary.contrastText' : 'text.primary',
+                                        fontWeight: i18n.language === 'en' ? 600 : 400,
+                                        border: i18n.language === 'en' ? 'none' : '1px solid',
+                                        borderColor: 'divider',
+                                        cursor: 'pointer',
+                                        '&:hover': {
+                                            bgcolor: i18n.language === 'en' ? 'primary.dark' : 'action.selected',
+                                        },
+                                    }}
+                                />
+                                <Chip
+                                    label={t('system.language.zh')}
+                                    onClick={() => changeLanguage('zh')}
+                                    size="small"
+                                    sx={{
+                                        bgcolor: i18n.language === 'zh' ? 'primary.main' : 'action.hover',
+                                        color: i18n.language === 'zh' ? 'primary.contrastText' : 'text.primary',
+                                        fontWeight: i18n.language === 'zh' ? 600 : 400,
+                                        border: i18n.language === 'zh' ? 'none' : '1px solid',
+                                        borderColor: 'divider',
+                                        cursor: 'pointer',
+                                        '&:hover': {
+                                            bgcolor: i18n.language === 'zh' ? 'primary.dark' : 'action.selected',
+                                        },
+                                    }}
+                                />
+                            </Box>
+                        </Box>
+
+                        {/* Theme — moved from the activity bar */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                <IconBrush size={14} style={{ color: 'var(--mui-palette-text-secondary)' }} />
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {t('common.theme')}
+                                </Typography>
+                            </Box>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
+                                {themeOptions.map(({ value, label, renderIcon }) => {
+                                    const selected = themeMode === value;
+                                    return (
+                                        <Chip
+                                            key={value}
+                                            icon={renderIcon({ size: 14 })}
+                                            label={label}
+                                            onClick={() => setTheme(value)}
+                                            size="small"
+                                            sx={{
+                                                bgcolor: selected ? 'primary.main' : 'action.hover',
+                                                color: selected ? 'primary.contrastText' : 'text.primary',
+                                                fontWeight: selected ? 600 : 400,
+                                                border: selected ? 'none' : '1px solid',
+                                                borderColor: 'divider',
+                                                cursor: 'pointer',
+                                                '& .MuiChip-icon': {
+                                                    color: 'inherit',
+                                                },
+                                                '&:hover': {
+                                                    bgcolor: selected ? 'primary.dark' : 'action.selected',
+                                                },
+                                            }}
+                                        />
+                                    );
+                                })}
+                            </Box>
+                        </Box>
+                    </Stack>
                 </UnifiedCard>
 
                 {/* Quick Proxy — dedicated card for the reusable proxy preset */}

--- a/frontend/src/pages/System.tsx
+++ b/frontend/src/pages/System.tsx
@@ -1,9 +1,9 @@
 import CardGrid from '@/components/CardGrid';
 import { PageLayout } from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
-import { Logout } from '@mui/icons-material';
+import { BrightnessAuto, DarkMode, LightMode, Logout } from '@mui/icons-material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
-import { IconCircleCheck, IconCircleX, IconInfoCircle, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconSun, IconMoon, IconSunHigh, IconSparkles, IconWorld, IconCheck } from '@tabler/icons-react';
+import { IconCircleCheck, IconCircleX, IconInfoCircle, IconLock, IconStar, IconLicense, IconBrandGithub, IconLanguage, IconBrush, IconWorld, IconCheck } from '@tabler/icons-react';
 import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -269,16 +269,15 @@ const System = () => {
                                 </Box>
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
                                     {([
-                                        { value: 'light', label: t('layout.activityBar.light'), Icon: IconSun },
-                                        { value: 'dark', label: t('layout.activityBar.dark'), Icon: IconMoon },
-                                        { value: 'sunlit', label: t('layout.activityBar.sunlit'), Icon: IconSunHigh },
-                                        { value: 'claude', label: t('layout.activityBar.claude'), Icon: IconSparkles },
+                                        { value: 'light', label: t('layout.activityBar.light'), Icon: LightMode },
+                                        { value: 'dark', label: t('layout.activityBar.dark'), Icon: DarkMode },
+                                        { value: 'system', label: t('layout.activityBar.system'), Icon: BrightnessAuto },
                                     ] as const).map(({ value, label, Icon }) => {
                                         const selected = themeMode === value;
                                         return (
                                             <Chip
                                                 key={value}
-                                                icon={<Icon size={14} />}
+                                                icon={<Icon sx={{ fontSize: 14 }} />}
                                                 label={label}
                                                 onClick={() => setTheme(value)}
                                                 size="small"

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,23 +1,17 @@
 import { createTheme } from '@mui/material/styles';
-import type { ThemeMode } from './types';
+import type { ResolvedThemeMode } from './types';
 import { baseTypography, baseShape, baseComponents } from './base';
 import { lightPalette } from './palettes/light';
 import { darkPalette } from './palettes/dark';
-import { sunlitPalette } from './palettes/sunlit';
-import { claudePalette } from './palettes/claude';
 import { lightComponents } from './components/light';
 import { darkComponents } from './components/dark';
-import { sunlitComponents } from './components/sunlit';
-import { claudeComponents } from './components/claude';
 
 const THEME_REGISTRY = {
   light: { palette: lightPalette, components: lightComponents },
   dark: { palette: darkPalette, components: darkComponents },
-  sunlit: { palette: sunlitPalette, components: sunlitComponents },
-  claude: { palette: claudePalette, components: claudeComponents },
 } as const;
 
-const createAppTheme = (mode: ThemeMode) => {
+const createAppTheme = (mode: ResolvedThemeMode) => {
   const { palette, components } = THEME_REGISTRY[mode];
   const textColors = palette.text as { primary: string; secondary: string; disabled: string };
 
@@ -33,4 +27,4 @@ const createAppTheme = (mode: ThemeMode) => {
 };
 
 export default createAppTheme;
-export type { ThemeMode } from './types';
+export type { ResolvedThemeMode, ThemeMode } from './types';

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -3,12 +3,18 @@ import type { ResolvedThemeMode } from './types';
 import { baseTypography, baseShape, baseComponents } from './base';
 import { lightPalette } from './palettes/light';
 import { darkPalette } from './palettes/dark';
+import { sunlitPalette } from './palettes/sunlit';
+import { claudePalette } from './palettes/claude';
 import { lightComponents } from './components/light';
 import { darkComponents } from './components/dark';
+import { sunlitComponents } from './components/sunlit';
+import { claudeComponents } from './components/claude';
 
 const THEME_REGISTRY = {
   light: { palette: lightPalette, components: lightComponents },
   dark: { palette: darkPalette, components: darkComponents },
+  sunlit: { palette: sunlitPalette, components: sunlitComponents },
+  claude: { palette: claudePalette, components: claudeComponents },
 } as const;
 
 const createAppTheme = (mode: ResolvedThemeMode) => {

--- a/frontend/src/theme/options.ts
+++ b/frontend/src/theme/options.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DarkMode, LightMode, Sync, WbSunny } from '@mui/icons-material';
+import { Computer, DarkMode, LightMode, WbTwilight } from '@mui/icons-material';
 import { SvgIcon } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
 import type { SvgIconComponent } from '@mui/icons-material';
@@ -36,7 +36,7 @@ export const isThemeMode = (value: string | null): value is ThemeMode => (
 export const getThemeOptions = (t: ThemeLabelResolver) => [
     { value: 'light', label: t('layout.activityBar.light'), renderIcon: createMuiThemeIcon(LightMode) },
     { value: 'dark', label: t('layout.activityBar.dark'), renderIcon: createMuiThemeIcon(DarkMode) },
-    { value: 'sunlit', label: t('layout.activityBar.sunlit'), renderIcon: createMuiThemeIcon(WbSunny) },
+    { value: 'sunlit', label: t('layout.activityBar.sunlit'), renderIcon: createMuiThemeIcon(WbTwilight) },
     { value: 'claude', label: t('layout.activityBar.claude'), renderIcon: ClaudeThemeIcon },
-    { value: 'system', label: t('layout.activityBar.system'), renderIcon: createMuiThemeIcon(Sync) },
+    { value: 'system', label: t('layout.activityBar.system'), renderIcon: createMuiThemeIcon(Computer) },
 ] as const;

--- a/frontend/src/theme/options.ts
+++ b/frontend/src/theme/options.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import { DarkMode, LightMode, Sync, WbSunny } from '@mui/icons-material';
+import { SvgIcon } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material';
+import type { SvgIconComponent } from '@mui/icons-material';
+import type { ThemeMode, ResolvedThemeMode } from './types';
+
+export const THEME_MODE_VALUES = ['light', 'dark', 'sunlit', 'claude', 'system'] as const satisfies readonly ThemeMode[];
+export const SYSTEM_THEME_MODE_VALUES = ['light', 'dark'] as const satisfies readonly ResolvedThemeMode[];
+
+type ThemeLabelResolver = (key: string) => string;
+type ThemeIconProps = {
+    size?: number;
+    sx?: SxProps<Theme>;
+};
+
+const createMuiThemeIcon = (Icon: SvgIconComponent) => ({ size = 18, sx }: ThemeIconProps) => (
+    React.createElement(Icon, { sx: { fontSize: size, ...sx } })
+);
+
+const ClaudeThemeIcon = ({ size = 18, sx }: ThemeIconProps) => (
+    React.createElement(
+        SvgIcon,
+        { viewBox: '0 0 24 24', sx: { fontSize: size, ...sx } },
+        React.createElement('path', {
+            fillRule: 'evenodd',
+            d: 'M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z',
+        }),
+    )
+);
+
+export const isThemeMode = (value: string | null): value is ThemeMode => (
+    THEME_MODE_VALUES.some((mode) => mode === value)
+);
+
+export const getThemeOptions = (t: ThemeLabelResolver) => [
+    { value: 'light', label: t('layout.activityBar.light'), renderIcon: createMuiThemeIcon(LightMode) },
+    { value: 'dark', label: t('layout.activityBar.dark'), renderIcon: createMuiThemeIcon(DarkMode) },
+    { value: 'sunlit', label: t('layout.activityBar.sunlit'), renderIcon: createMuiThemeIcon(WbSunny) },
+    { value: 'claude', label: t('layout.activityBar.claude'), renderIcon: ClaudeThemeIcon },
+    { value: 'system', label: t('layout.activityBar.system'), renderIcon: createMuiThemeIcon(Sync) },
+] as const;

--- a/frontend/src/theme/types.ts
+++ b/frontend/src/theme/types.ts
@@ -1,6 +1,7 @@
 import type { PaletteOptions, ThemeOptions } from '@mui/material/styles';
 
-export type ThemeMode = 'light' | 'dark' | 'sunlit' | 'claude';
+export type ResolvedThemeMode = 'light' | 'dark';
+export type ThemeMode = ResolvedThemeMode | 'system';
 
 export interface DashboardTokenColors {
   main: string;

--- a/frontend/src/theme/types.ts
+++ b/frontend/src/theme/types.ts
@@ -1,6 +1,6 @@
 import type { PaletteOptions, ThemeOptions } from '@mui/material/styles';
 
-export type ResolvedThemeMode = 'light' | 'dark';
+export type ResolvedThemeMode = 'light' | 'dark' | 'sunlit' | 'claude';
 export type ThemeMode = ResolvedThemeMode | 'system';
 
 export interface DashboardTokenColors {


### PR DESCRIPTION
This PR introduces a system-aware theme mode that automatically follows the user's OS preference, along with several UI/UX improvements for better mobile experience and theme management.

### Key Changes

#### 1. System Theme Mode
- Added **'system'** theme option that automatically switches between light/dark based on OS preference
- Implemented `window.matchMedia('(prefers-color-scheme: dark)')` listener for real-time theme synchronization
- Created centralized theme configuration in `frontend/src/theme/options.ts`
- Distinguished between `ThemeMode` (user selection) and `ResolvedThemeMode` (actual applied theme)

#### 2. Theme Selection Improvements
- Added theme button in the activity bar (visible in non-zen mode)
- Consolidated theme settings into System page for centralized configuration
- Created custom Claude theme icon for better visual consistency
- Added theme option indicator with current selection highlighting

#### 3. Mobile Navigation Enhancements
- Introduced fixed `MobileNavigationBar` component for consistent mobile header
- Improved navigation behavior: sidebar drawer now stays open when navigating to items with sub-items
- Better visual feedback for active navigation state

#### 4. UI Polish
- Integrated language settings, proxy settings, and theme controls in System page
- Added loading state for server status display
- Enhanced onboarding button with active state styling

#### 5. Icon update
- icons are updated as below

<img height="225" alt="image" src="https://github.com/user-attachments/assets/f100b229-3dac-41d0-9eef-0cc97c4bc471" />

<img height="225" alt="image" src="https://github.com/user-attachments/assets/b8c29e07-64f5-4860-8a09-3ebc262a8285" />


### Screenshots

**Theme Selection in Activity Bar**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/842d2a3a-fe19-4d1b-a046-a67ebfc65b55" />

<img width="223" height="220" alt="image" src="https://github.com/user-attachments/assets/f75d959a-f800-4006-9140-e222c0c914c0" />

**Mobile Navigation**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/304f0dff-7a1b-4148-bff3-7995398f9b7d" />


**System Theme Mode Behavior**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/4be48145-eebd-450a-875b-2cfa5fe028a8" />

### Technical Details

- **Theme Registry**: Centralized theme option definitions with icons
- **Media Query Listener**: Automatic theme updates on OS preference change
- **LocalStorage Persistence**: Theme preference saved as `'light'`, `'dark'`, `'sunlit'`, `'claude'`, or `'system'`
- **Mock Mode Support**: Added `/api/v1/status` endpoint for development

### Files Changed
- `frontend/src/theme/` - Theme types, options, and registry
- `frontend/src/contexts/ThemeContext.tsx` - System theme mode support
- `frontend/src/layout/` - Mobile navigation and activity bar updates
- `frontend/src/pages/System.tsx` - Integrated settings page
- `frontend/src/mocks/handlers.ts` - Mock API support

### Testing
- [x] System theme mode correctly syncs with OS preference
- [x] Theme persists across page reloads
- [x] Mobile navigation drawer behavior is correct
- [x] All 5 theme options work properly (light, dark, sunlit, claude, system)
- [x] Theme button appears in activity bar in non-zen mode
