### PR TITLE
bugfix(agent): require env to route remote-control @cc through the tingly-box gateway

### DIFF
--- a/agentboot/claude/driver.go
+++ b/agentboot/claude/driver.go
@@ -123,7 +123,11 @@ func (d *Driver) Prepare(ctx context.Context, prompt string, opts agentboot.Exec
 	}
 	env := cleanEnv
 	if len(config.CustomEnv) > 0 {
-		env = MergeEnv(cleanEnv, config.CustomEnv)
+		env = MergeEnv(env, config.CustomEnv)
+	}
+	// Per-execution env overrides (e.g. gateway routing for remote control).
+	if len(opts.Env) > 0 {
+		env = MergeEnv(env, opts.Env)
 	}
 
 	// Build the initial prompt channel (stream-json mode injects a user message into stdin)

--- a/internal/remote_control/bot/agent_claude_code.go
+++ b/internal/remote_control/bot/agent_claude_code.go
@@ -97,6 +97,20 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 
 	streamWriter := e.deps.NewStreamingMessageHandler(req.HCtx, meta)
 
+	// Route the Claude Code CLI through the tingly-box gateway so it uses the
+	// configured provider (including third-party model services) instead of
+	// talking to the Anthropic API directly. Without this, @cc fails whenever
+	// no direct Anthropic credentials are present on the host.
+	var execEnv []string
+	if e.deps.TBClient != nil {
+		ccEnv, eerr := e.deps.TBClient.GetClaudeCodeEnv(ctx)
+		if eerr != nil {
+			logrus.WithError(eerr).Warn("ClaudeCodeExecutor: failed to resolve gateway env; @cc may not reach the configured provider")
+		} else {
+			execEnv = ccEnv
+		}
+	}
+
 	startTime := time.Now()
 	handle, err := agent.Execute(ctx, req.Text, agentboot.ExecutionOptions{
 		ProjectPath:          projectPath,
@@ -107,6 +121,7 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 		BotUUID:              req.HCtx.BotUUID,
 		PermissionPromptTool: "stdio",
 		PermissionMode:       permissionMode,
+		Env:                  execEnv,
 		Store:                e.deps.SessionMgr,
 	})
 	if err != nil {

--- a/internal/tbclient/mock.go
+++ b/internal/tbclient/mock.go
@@ -49,6 +49,15 @@ func (m *MockTBClient) GetConnectionConfig(ctx context.Context) (*ConnectionConf
 	return args.Get(0).(*ConnectionConfig), args.Error(1)
 }
 
+// GetClaudeCodeEnv mocks the GetClaudeCodeEnv method
+func (m *MockTBClient) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 // GetDefaultRuleForScenario mocks the GetDefaultRuleForScenario method
 func (m *MockTBClient) GetDefaultRuleForScenario(ctx context.Context, scenario typ.RuleScenario) (*typ.Rule, error) {
 	args := m.Called(ctx, scenario)

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -136,12 +136,12 @@ func (c *TBClientImpl) GetConnectionConfig(ctx context.Context) (*ConnectionConf
 
 // GetClaudeCodeEnv builds the env vars needed to route the Claude Code CLI
 // through the local tingly-box gateway. ANTHROPIC_BASE_URL points at the
-// claude_code scenario endpoint and the per-tier ANTHROPIC_*_MODEL vars are set
-// to the request models that the user's active claude_code rules actually route
-// (to whichever provider, e.g. a third-party model service, backs them). The
-// model names are derived from the real rule configuration — unified, separate,
-// or custom — rather than assuming a mode, so @cc routes the same way the user
-// configured @cc / `tb cc` to.
+// claude_code scenario endpoint and the per-tier ANTHROPIC_*_MODEL vars carry
+// the request models the user's claude_code rules actually route. The model
+// names are resolved exactly like the frontend's Claude Code config apply
+// (derivePrefsFromRules): the `separate` scenario flag selects per-tier vs
+// unified, and each model name is read from the matching rule's request_model
+// (by stable UUID) so customized model identifiers route correctly.
 func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	port := c.config.GetServerPort()
 	if port == 0 {
@@ -150,19 +150,13 @@ func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
 	apiKey := c.config.GetModelToken()
 
+	models := c.resolveClaudeCodeModels()
 	prefs := tbagent.DefaultClaudeCodePrefs(false)
-	if models := c.resolveClaudeCodeModels(); models != nil {
-		prefs.AnthropicModel = models.def
-		prefs.AnthropicDefaultHaikuModel = models.haiku
-		prefs.AnthropicDefaultSonnetModel = models.sonnet
-		prefs.AnthropicDefaultOpusModel = models.opus
-		prefs.ClaudeCodeSubagentModel = models.subagent
-	} else {
-		// No claude_code rule is wired to a provider; fall back to the
-		// scenario's unified flag and canonical model names so the request
-		// still carries a valid model identifier.
-		prefs = tbagent.DefaultClaudeCodePrefs(c.config.GetScenarioFlag(typ.ScenarioClaudeCode, "unified"))
-	}
+	prefs.AnthropicModel = models.def
+	prefs.AnthropicDefaultHaikuModel = models.haiku
+	prefs.AnthropicDefaultSonnetModel = models.sonnet
+	prefs.AnthropicDefaultOpusModel = models.opus
+	prefs.ClaudeCodeSubagentModel = models.subagent
 
 	envMap, err := prefs.ToEnv(baseURL, apiKey)
 	if err != nil {
@@ -181,52 +175,48 @@ type claudeCodeModels struct {
 	def, haiku, sonnet, opus, subagent string
 }
 
-// resolveClaudeCodeModels derives the per-tier request models from the active
-// claude_code rules that have at least one upstream service configured. This
-// reflects the user's real routing setup (unified, separate, or custom request
-// model names) instead of assuming a mode. Tiers without their own wired rule
-// fall back to the resolved default. Returns nil when no claude_code rule is
-// wired to a provider.
-func (c *TBClientImpl) resolveClaudeCodeModels() *claudeCodeModels {
-	configured := map[string]bool{}
-	var firstModel string
+// resolveClaudeCodeModels resolves the per-tier request models the same way the
+// frontend's derivePrefsFromRules does: the `separate` scenario flag selects
+// per-tier vs unified naming, and each model is taken from the corresponding
+// built-in rule's request_model (looked up by its stable UUID), falling back to
+// tb's canonical model names when a rule is absent.
+func (c *TBClientImpl) resolveClaudeCodeModels() claudeCodeModels {
+	byUUID := map[string]string{}
 	for _, rule := range c.config.GetRequestConfigs() {
 		if rule.GetScenario() != typ.ScenarioClaudeCode || !rule.Active {
 			continue
 		}
-		if len(rule.GetServices()) == 0 {
-			continue
+		if m := strings.TrimSpace(rule.RequestModel); m != "" {
+			byUUID[rule.UUID] = m
 		}
-		model := strings.TrimSpace(rule.RequestModel)
-		if model == "" {
-			continue
-		}
-		configured[model] = true
-		if firstModel == "" {
-			firstModel = model
-		}
-	}
-	if len(configured) == 0 {
-		return nil
 	}
 
-	// pick returns the first wired candidate, else the fallback.
-	pick := func(fb string, candidates ...string) string {
-		for _, m := range candidates {
-			if configured[m] {
-				return m
-			}
+	ruleModel := func(uuid, fallback string) string {
+		if m, ok := byUUID[uuid]; ok {
+			return m
 		}
-		return fb
+		return fallback
 	}
 
-	def := pick(firstModel, "tingly/cc-default", "tingly/cc")
-	return &claudeCodeModels{
-		def:      def,
-		haiku:    pick(def, "tingly/cc-haiku"),
-		sonnet:   pick(def, "tingly/cc-sonnet"),
-		opus:     pick(def, "tingly/cc-opus"),
-		subagent: pick(def, "tingly/cc-subagent"),
+	// `separate` flag → per-tier models; anything else (unset/unified/smart)
+	// → a single unified model for every tier.
+	if c.config.GetScenarioFlag(typ.ScenarioClaudeCode, "separate") {
+		return claudeCodeModels{
+			def:      ruleModel("built-in-cc-default", "tingly/cc-default"),
+			haiku:    ruleModel("built-in-cc-haiku", "tingly/cc-haiku"),
+			sonnet:   ruleModel("built-in-cc-sonnet", "tingly/cc-sonnet"),
+			opus:     ruleModel("built-in-cc-opus", "tingly/cc-opus"),
+			subagent: ruleModel("built-in-cc-subagent", "tingly/cc-subagent"),
+		}
+	}
+
+	unified := ruleModel("built-in-cc", "tingly/cc")
+	return claudeCodeModels{
+		def:      unified,
+		haiku:    unified,
+		sonnet:   unified,
+		opus:     unified,
+		subagent: unified,
 	}
 }
 

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	tbagent "github.com/tingly-dev/tingly-box/internal/agent"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
@@ -134,12 +135,13 @@ func (c *TBClientImpl) GetConnectionConfig(ctx context.Context) (*ConnectionConf
 }
 
 // GetClaudeCodeEnv builds the env vars needed to route the Claude Code CLI
-// through the local tingly-box gateway. ANTHROPIC_BASE_URL is pointed at the
-// claude_code scenario endpoint and ANTHROPIC_MODEL is set to the model name(s)
-// that scenario's rules match on, so the request is forwarded to whichever
-// provider (e.g. a third-party model service) backs that rule. The "unified"
-// scenario flag selects between the single-model and per-tier model naming,
-// mirroring the `tb cc` CLI launcher.
+// through the local tingly-box gateway. ANTHROPIC_BASE_URL points at the
+// claude_code scenario endpoint and the per-tier ANTHROPIC_*_MODEL vars are set
+// to the request models that the user's active claude_code rules actually route
+// (to whichever provider, e.g. a third-party model service, backs them). The
+// model names are derived from the real rule configuration — unified, separate,
+// or custom — rather than assuming a mode, so @cc routes the same way the user
+// configured @cc / `tb cc` to.
 func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	port := c.config.GetServerPort()
 	if port == 0 {
@@ -148,8 +150,21 @@ func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
 	apiKey := c.config.GetModelToken()
 
-	unified := c.config.GetScenarioFlag(typ.ScenarioClaudeCode, "unified")
-	envMap, err := tbagent.DefaultClaudeCodePrefs(unified).ToEnv(baseURL, apiKey)
+	prefs := tbagent.DefaultClaudeCodePrefs(false)
+	if models := c.resolveClaudeCodeModels(); models != nil {
+		prefs.AnthropicModel = models.def
+		prefs.AnthropicDefaultHaikuModel = models.haiku
+		prefs.AnthropicDefaultSonnetModel = models.sonnet
+		prefs.AnthropicDefaultOpusModel = models.opus
+		prefs.ClaudeCodeSubagentModel = models.subagent
+	} else {
+		// No claude_code rule is wired to a provider; fall back to the
+		// scenario's unified flag and canonical model names so the request
+		// still carries a valid model identifier.
+		prefs = tbagent.DefaultClaudeCodePrefs(c.config.GetScenarioFlag(typ.ScenarioClaudeCode, "unified"))
+	}
+
+	envMap, err := prefs.ToEnv(baseURL, apiKey)
 	if err != nil {
 		return nil, fmt.Errorf("build claude code env: %w", err)
 	}
@@ -159,6 +174,60 @@ func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	return env, nil
+}
+
+// claudeCodeModels holds the request-model name for each Claude Code model tier.
+type claudeCodeModels struct {
+	def, haiku, sonnet, opus, subagent string
+}
+
+// resolveClaudeCodeModels derives the per-tier request models from the active
+// claude_code rules that have at least one upstream service configured. This
+// reflects the user's real routing setup (unified, separate, or custom request
+// model names) instead of assuming a mode. Tiers without their own wired rule
+// fall back to the resolved default. Returns nil when no claude_code rule is
+// wired to a provider.
+func (c *TBClientImpl) resolveClaudeCodeModels() *claudeCodeModels {
+	configured := map[string]bool{}
+	var firstModel string
+	for _, rule := range c.config.GetRequestConfigs() {
+		if rule.GetScenario() != typ.ScenarioClaudeCode || !rule.Active {
+			continue
+		}
+		if len(rule.GetServices()) == 0 {
+			continue
+		}
+		model := strings.TrimSpace(rule.RequestModel)
+		if model == "" {
+			continue
+		}
+		configured[model] = true
+		if firstModel == "" {
+			firstModel = model
+		}
+	}
+	if len(configured) == 0 {
+		return nil
+	}
+
+	// pick returns the first wired candidate, else the fallback.
+	pick := func(fb string, candidates ...string) string {
+		for _, m := range candidates {
+			if configured[m] {
+				return m
+			}
+		}
+		return fb
+	}
+
+	def := pick(firstModel, "tingly/cc-default", "tingly/cc")
+	return &claudeCodeModels{
+		def:      def,
+		haiku:    pick(def, "tingly/cc-haiku"),
+		sonnet:   pick(def, "tingly/cc-sonnet"),
+		opus:     pick(def, "tingly/cc-opus"),
+		subagent: pick(def, "tingly/cc-subagent"),
+	}
 }
 
 func (c *TBClientImpl) GetDefaultRule(ctx context.Context) (*typ.Rule, error) {

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	tbagent "github.com/tingly-dev/tingly-box/internal/agent"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -35,6 +36,12 @@ type TBClient interface {
 	// GetConnectionConfig returns base URL and API key
 	// Base URL defaults to ClaudeCode scenario URL if not configured
 	GetConnectionConfig(ctx context.Context) (*ConnectionConfig, error)
+
+	// GetClaudeCodeEnv returns the environment variables (KEY=VALUE) that point
+	// the Claude Code CLI at the tingly-box gateway's claude_code scenario, so
+	// remote-control @cc sessions route through the configured provider
+	// (including third-party model services) instead of the Anthropic API.
+	GetClaudeCodeEnv(ctx context.Context) ([]string, error)
 
 	// GetHTTPEndpointForScenario returns HTTP endpoint configuration for a scenario
 	GetHTTPEndpointForScenario(ctx context.Context, scenario typ.RuleScenario) (*HTTPEndpointConfig, error)
@@ -124,6 +131,34 @@ func (c *TBClientImpl) GetConnectionConfig(ctx context.Context) (*ConnectionConf
 		BaseURL: c.buildBaseURL(),
 		APIKey:  apiKey,
 	}, nil
+}
+
+// GetClaudeCodeEnv builds the env vars needed to route the Claude Code CLI
+// through the local tingly-box gateway. ANTHROPIC_BASE_URL is pointed at the
+// claude_code scenario endpoint and ANTHROPIC_MODEL is set to the model name(s)
+// that scenario's rules match on, so the request is forwarded to whichever
+// provider (e.g. a third-party model service) backs that rule. The "unified"
+// scenario flag selects between the single-model and per-tier model naming,
+// mirroring the `tb cc` CLI launcher.
+func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
+	port := c.config.GetServerPort()
+	if port == 0 {
+		port = 12580
+	}
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	apiKey := c.config.GetModelToken()
+
+	unified := c.config.GetScenarioFlag(typ.ScenarioClaudeCode, "unified")
+	envMap, err := tbagent.DefaultClaudeCodePrefs(unified).ToEnv(baseURL, apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("build claude code env: %w", err)
+	}
+
+	env := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env, nil
 }
 
 func (c *TBClientImpl) GetDefaultRule(ctx context.Context) (*typ.Rule, error) {

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -1,10 +1,13 @@
 package tbclient
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 func TestNewTBClient(t *testing.T) {
@@ -107,4 +110,147 @@ func TestDefaultServiceConfig_Structure(t *testing.T) {
 func TestTBClient_Types(t *testing.T) {
 	// Test that TBClientImpl implements TBClient interface
 	var _ TBClient = (*TBClientImpl)(nil)
+}
+
+// ccRule builds an active claude_code rule with the given UUID and request model.
+func ccRule(uuid, requestModel string) typ.Rule {
+	return typ.Rule{
+		UUID:         uuid,
+		Scenario:     typ.ScenarioClaudeCode,
+		RequestModel: requestModel,
+		Active:       true,
+	}
+}
+
+// ccSeparateFlag returns a scenario config that puts claude_code in separate mode.
+func ccSeparateFlag() typ.ScenarioConfig {
+	return typ.ScenarioConfig{
+		Scenario: typ.ScenarioClaudeCode,
+		Flags:    typ.ScenarioFlags{Separate: true},
+	}
+}
+
+func TestResolveClaudeCodeModels_UnifiedDefault(t *testing.T) {
+	// No scenario config and no rules → unified mode with canonical fallback.
+	client := NewTBClient(&serverconfig.Config{}, nil)
+
+	models := client.resolveClaudeCodeModels()
+
+	assert.Equal(t, "tingly/cc", models.def)
+	assert.Equal(t, "tingly/cc", models.haiku)
+	assert.Equal(t, "tingly/cc", models.sonnet)
+	assert.Equal(t, "tingly/cc", models.opus)
+	assert.Equal(t, "tingly/cc", models.subagent)
+}
+
+func TestResolveClaudeCodeModels_UnifiedFromRule(t *testing.T) {
+	// Unified mode reads the built-in-cc rule's request_model for every tier.
+	cfg := &serverconfig.Config{
+		Rules: []typ.Rule{ccRule("built-in-cc", "tingly/cc")},
+	}
+	client := NewTBClient(cfg, nil)
+
+	models := client.resolveClaudeCodeModels()
+
+	assert.Equal(t, "tingly/cc", models.def)
+	assert.Equal(t, "tingly/cc", models.opus)
+	assert.Equal(t, "tingly/cc", models.subagent)
+}
+
+func TestResolveClaudeCodeModels_UnifiedCustomRequestModel(t *testing.T) {
+	// A customized request_model on the unified rule must propagate to all tiers.
+	cfg := &serverconfig.Config{
+		Rules: []typ.Rule{ccRule("built-in-cc", "team/coder[1m]")},
+	}
+	client := NewTBClient(cfg, nil)
+
+	models := client.resolveClaudeCodeModels()
+
+	assert.Equal(t, "team/coder[1m]", models.def)
+	assert.Equal(t, "team/coder[1m]", models.haiku)
+	assert.Equal(t, "team/coder[1m]", models.sonnet)
+	assert.Equal(t, "team/coder[1m]", models.opus)
+	assert.Equal(t, "team/coder[1m]", models.subagent)
+}
+
+func TestResolveClaudeCodeModels_Separate(t *testing.T) {
+	// Separate mode reads each tier from its own built-in rule's request_model.
+	cfg := &serverconfig.Config{
+		Scenarios: []typ.ScenarioConfig{ccSeparateFlag()},
+		Rules: []typ.Rule{
+			ccRule("built-in-cc-default", "tingly/cc-default"),
+			ccRule("built-in-cc-haiku", "vendor/fast"),
+			ccRule("built-in-cc-sonnet", "tingly/cc-sonnet"),
+			ccRule("built-in-cc-opus", "vendor/smart"),
+			ccRule("built-in-cc-subagent", "tingly/cc-subagent"),
+		},
+	}
+	client := NewTBClient(cfg, nil)
+
+	models := client.resolveClaudeCodeModels()
+
+	assert.Equal(t, "tingly/cc-default", models.def)
+	assert.Equal(t, "vendor/fast", models.haiku)
+	assert.Equal(t, "tingly/cc-sonnet", models.sonnet)
+	assert.Equal(t, "vendor/smart", models.opus)
+	assert.Equal(t, "tingly/cc-subagent", models.subagent)
+}
+
+func TestResolveClaudeCodeModels_SeparateMissingTierFallsBack(t *testing.T) {
+	// Separate mode with a missing tier rule falls back to the canonical name.
+	cfg := &serverconfig.Config{
+		Scenarios: []typ.ScenarioConfig{ccSeparateFlag()},
+		Rules: []typ.Rule{
+			ccRule("built-in-cc-default", "vendor/default"),
+			// no haiku/sonnet/opus/subagent rules
+		},
+	}
+	client := NewTBClient(cfg, nil)
+
+	models := client.resolveClaudeCodeModels()
+
+	assert.Equal(t, "vendor/default", models.def)
+	assert.Equal(t, "tingly/cc-haiku", models.haiku)
+	assert.Equal(t, "tingly/cc-sonnet", models.sonnet)
+	assert.Equal(t, "tingly/cc-opus", models.opus)
+	assert.Equal(t, "tingly/cc-subagent", models.subagent)
+}
+
+func TestResolveClaudeCodeModels_InactiveRuleIgnored(t *testing.T) {
+	// An inactive built-in-cc rule must not override the canonical fallback.
+	inactive := ccRule("built-in-cc", "should/not/use")
+	inactive.Active = false
+	cfg := &serverconfig.Config{Rules: []typ.Rule{inactive}}
+	client := NewTBClient(cfg, nil)
+
+	models := client.resolveClaudeCodeModels()
+
+	assert.Equal(t, "tingly/cc", models.def)
+}
+
+func TestGetClaudeCodeEnv_RoutesThroughGateway(t *testing.T) {
+	cfg := &serverconfig.Config{
+		ServerPort: 9000,
+		Rules:      []typ.Rule{ccRule("built-in-cc", "tingly/cc")},
+	}
+	client := NewTBClient(cfg, nil)
+
+	env, err := client.GetClaudeCodeEnv(context.Background())
+	require.NoError(t, err)
+
+	kv := map[string]string{}
+	for _, e := range env {
+		for i := 0; i < len(e); i++ {
+			if e[i] == '=' {
+				kv[e[:i]] = e[i+1:]
+				break
+			}
+		}
+	}
+
+	assert.Equal(t, "http://localhost:9000/tingly/claude_code", kv["ANTHROPIC_BASE_URL"])
+	assert.Equal(t, "tingly/cc", kv["ANTHROPIC_MODEL"])
+	assert.Equal(t, "tingly/cc", kv["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+	_, hasToken := kv["ANTHROPIC_AUTH_TOKEN"]
+	assert.True(t, hasToken)
 }


### PR DESCRIPTION
## Summary
Remote-control `@cc` launched the Claude Code CLI with no gateway environment, so it talked to the Anthropic API directly and failed whenever only third-party model services were configured. This routes `@cc` through the local tingly-box gateway's `claude_code` scenario, using the same model configuration the frontend applies.

## Changes
- **`TBClient.GetClaudeCodeEnv()`** — builds the env (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, per-tier `ANTHROPIC_*_MODEL`) that points the CLI at `http://localhost:<port>/tingly/claude_code`.
- **`resolveClaudeCodeModels()`** — mirrors the frontend's `derivePrefsFromRules`: the `separate` scenario flag selects unified vs per-tier naming, and each model name is read from the matching built-in rule's `request_model` by stable UUID (`built-in-cc`, `built-in-cc-haiku`, …), falling back to canonical names. This handles customized request models.
- **`ClaudeCodeExecutor`** — resolves the gateway env and passes it per-execution; logs a warning and proceeds if `TBClient` is unavailable.
- **`agentboot/claude/driver.go`** — honors `ExecutionOptions.Env`, merging per-execution overrides on top of the clean/custom env.
- **Mock** — `MockTBClient` updated for the new interface method.
- **Tests** — 7 cases covering unified, separate, custom request_model, missing-tier fallback, inactive-rule handling, and the end-to-end gateway env output.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/tbclient/...`
- [x] `go test ./internal/tbclient/... ./internal/remote_control/bot/... ./agentboot/claude/...`

https://claude.ai/code/session_015VjFeS84ChzZEPaaGABTKE