### PR TITLE
docs: clarify contributing guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,10 @@ See CONTRIBUTING.md and NOTICE for details.
 
 ---
 
-We welcome contributions!   
-Please check steps below to build from source code.
+We welcome contributions! Check the steps below to build from source code.
+
+<details>
+<summary><strong>Build from Source</strong></summary>
 
 ### Prerequisites
 
@@ -295,6 +297,8 @@ task swagger        # Regenerate openapi.json from Go source
 task codegen        # Regenerate frontend API client from openapi.json
 task go:test        # Run Go unit tests
 ```
+
+</details>
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,9 @@ task build
 
 The output binary is written to `./build/tingly-box`.
 
-### 5. GUI binary (Wails)
+### 5. GUI binary (Wails) *(optional)*
+
+> The GUI build is not yet publicly released. Skip this step unless you are specifically working on the desktop app.
 
 ```bash
 task wails:build

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ See CONTRIBUTING.md and NOTICE for details.
 We welcome contributions! Check the steps below to build from source code.
 
 <details>
-<summary><strong>Build from Source</strong></summary>
+<summary><strong>Contributing Guide — Build &amp; Dev</strong></summary>
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ git submodule update --init --recursive
 
 The frontend is a React + Vite app located in `frontend/`. You can work on it independently of the Go backend.
 
+> **Login token:** the frontend requires an auth token to log in. When the backend starts it prints the full login URL (e.g. `Web UI: http://localhost:12580/login/<token>`). If you need to retrieve it later, run:
+> ```bash
+> tingly-box token view auth --reveal
+> ```
+
 **Mock mode** – no running backend required, uses built-in fixture data:
 
 ```bash
@@ -252,7 +257,7 @@ task web:mock
 cd frontend && pnpm install && pnpm dev:mock
 ```
 
-Open http://localhost:9245 in your browser.
+Open http://localhost:9245 in your browser. Use the token obtained above to log in.
 
 **Dev mode** – proxies API calls to a local backend (start the backend first, see step 3):
 

--- a/README.md
+++ b/README.md
@@ -219,23 +219,81 @@ See CONTRIBUTING.md and NOTICE for details.
 We welcome contributions!   
 Please check steps below to build from source code.
 
-*Requires: Go 1.25+, Node.js 20+, pnpm, task*
+### Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Go | 1.25+ | https://go.dev/doc/install |
+| Node.js | 20+ | https://nodejs.org/ |
+| pnpm | latest | `npm install -g pnpm` |
+| task | latest | `go install github.com/go-task/task/v3/cmd/task@latest` or https://taskfile.dev/installation/ |
+
+> Tip: you can also copy individual shell commands out of `Taskfile.yml` and run them directly if you prefer not to install `task`.
+
+### 1. Clone and init submodules
 
 ```bash
-# Install dependencies
-# - Go: https://go.dev/doc/install
-# - Node.js: https://nodejs.org/
-# - pnpm: `npm install -g pnpm`
-# - task: https://taskfile.dev/installation/, or `go install github.com/go-task/task/v3/cmd/task@latest`
-# - shell: copy and run shell command in taskfile directly
-
+git clone https://github.com/tingly-dev/tingly-box.git
+cd tingly-box
 git submodule update --init --recursive
+```
 
-# Build with frontend
+### 2. Frontend development
+
+The frontend is a React + Vite app located in `frontend/`. You can work on it independently of the Go backend.
+
+**Mock mode** – no running backend required, uses built-in fixture data:
+
+```bash
+task web:mock
+# or directly:
+cd frontend && pnpm install && pnpm dev:mock
+```
+
+Open http://localhost:9245 in your browser.
+
+**Dev mode** – proxies API calls to a local backend (start the backend first, see step 3):
+
+```bash
+task web
+# or directly:
+cd frontend && pnpm install && pnpm dev
+```
+
+### 3. Backend development
+
+Run the Go server (hot-reload via `go run`):
+
+```bash
+task start
+# or directly:
+go run ./cli/tingly-box --verbose start --debug --port 12580 --browser=false
+```
+
+Open http://localhost:12580 in your browser (serves the last built frontend bundle).
+
+### 4. Full build (frontend + backend binary)
+
+Builds the frontend, embeds it into the binary, then compiles Go:
+
+```bash
 task build
+```
 
-# Build GUI binary via wails3
+The output binary is written to `./build/tingly-box`.
+
+### 5. GUI binary (Wails)
+
+```bash
 task wails:build
+```
+
+### Other useful commands
+
+```bash
+task swagger        # Regenerate openapi.json from Go source
+task codegen        # Regenerate frontend API client from openapi.json
+task go:test        # Run Go unit tests
 ```
 
 ## Support


### PR DESCRIPTION
Improves the Contributing section of README.md based on contributor feedback that the build instructions were unclear.

- Wrap build steps in a collapsible `<details>` section (consistent with other README sections)
- Add prerequisites table with versions and install links
- Split frontend dev into **mock mode** (no backend needed) and **dev mode**
- Add login token guidance — backend prints it on startup; `tingly-box token view auth --reveal` to retrieve it later
- Add backend dev server command with direct `go run` fallback
- Explain full build pipeline and output path
- Mark Wails GUI step as optional (not yet publicly released)
- Add common helper commands (swagger, codegen, go:test)

https://claude.ai/code/session_013StjYi6UxgXZXQD6X6pEwM