### PR TITLE
feat(UI): Polish Routing Graph Card States and Extensions Panel

### DIFF
--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -749,6 +749,13 @@ const ProviderFormDialog = ({
                             disabled={!hasAnyProtocol || verifying || submitting}
                             onClick={handleVerify}
                             title="Test connection using available endpoints (optional check)"
+                            sx={(theme) => ({
+                                '&.Mui-disabled': {
+                                    color: theme.palette.mode === 'dark'
+                                        ? 'rgba(255, 255, 255, 0.68)'
+                                        : theme.palette.text.secondary,
+                                },
+                            })}
                         >
                             {verifying ? (
                                 <CircularProgress size={16} thickness={4}/>
@@ -761,7 +768,12 @@ const ProviderFormDialog = ({
                             variant="contained"
                             size="small"
                             disabled={!hasAnyProtocol || verifying || submitting}
-                            sx={{minWidth: verifying || submitting ? '80px' : 'auto'}}
+                            sx={(theme) => ({
+                                minWidth: verifying || submitting ? '80px' : 'auto',
+                                '&.Mui-disabled': {
+                                    color: theme.palette.primary.contrastText,
+                                },
+                            })}
                         >
                             {submitting ? (
                                 <CircularProgress size={20} thickness={4}/>

--- a/frontend/src/components/RoutingGraph.tsx
+++ b/frontend/src/components/RoutingGraph.tsx
@@ -16,9 +16,9 @@ import {
     Tooltip,
     Typography,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import React from 'react';
-import { graphNodeBaseHoverStyles, graphNodeHoverStyles } from '@/components/nodes/styles';
+import { getRouteGraphActiveColor, graphNodeBaseHoverStyles, graphNodeHoverStyles } from '@/components/nodes/styles';
 import { notify } from '@/utils/notify';
 import type { Provider } from '../types/provider';
 import type { ConfigRecord } from './RoutingGraphTypes.ts';
@@ -621,14 +621,19 @@ const RoutingGraph: React.FC<RuleGraphProps> = ({
                             {extensionsCard && (
                                 <Box
                                     onClick={(e) => e.stopPropagation()}
-                                    sx={{
+                                    sx={(theme) => ({
                                         display: 'flex',
                                         alignItems: 'center',
                                         flexShrink: 0,
-                                        pl: 1,
+                                        alignSelf: 'stretch',
+                                        ml: 1.5,
+                                        pl: 2,
                                         pr: `${graphContainer.marginX}px`,
                                         py: `${graphContainer.marginY}px`,
-                                    }}
+                                        borderLeft: '1px solid',
+                                        borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.28 : 0.18),
+                                        backgroundImage: `linear-gradient(90deg, ${alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.07 : 0.045)}, transparent 18px)`,
+                                    })}
                                 >
                                     {extensionsCard}
                                 </Box>

--- a/frontend/src/components/SmartRoutingGraph.tsx
+++ b/frontend/src/components/SmartRoutingGraph.tsx
@@ -15,7 +15,7 @@ import {
     IconButton,
     Collapse,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import React from 'react';
 import type { Provider } from '../types/provider';
 import {
@@ -25,7 +25,8 @@ import {
     ArrowNode,
     ModelNode,
     NodeContainer,
-    ProviderNode, MODEL_NODE_STYLES
+    ProviderNode, MODEL_NODE_STYLES,
+    getRouteGraphActiveColor,
 } from '@/components/nodes';
 import type { ConfigRecord } from './RoutingGraphTypes.ts';
 
@@ -99,7 +100,7 @@ interface SmartRoutingGraphProps {
 const StyledCard = styled(Card, {
     shouldForwardProp: (prop) => prop !== 'active',
 })<{ active: boolean }>(({ active, theme }) => ({
-    transition: 'border-color 0.16s ease, background-color 0.16s ease, opacity 0.16s ease',
+    transition: 'border-color 0.16s ease, background-color 0.16s ease, opacity 0.16s ease, box-shadow 0.18s ease',
     opacity: active ? 1 : 0.6,
     filter: active ? 'none' : 'grayscale(0.3)',
     border: active ? '1px solid' : '2px dashed',
@@ -121,8 +122,10 @@ const StyledCard = styled(Card, {
         },
     }),
     '&:hover': {
-        borderColor: active ? theme.palette.primary.main : theme.palette.text.disabled,
-        boxShadow: 'none',
+        borderColor: active ? alpha(getRouteGraphActiveColor(theme), 0.55) : theme.palette.text.disabled,
+        boxShadow: active
+            ? `0 0 0 3px ${alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.12 : 0.10)}`
+            : 'none',
     },
 }));
 
@@ -449,14 +452,20 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                                                 startIcon={<AddIcon />}
                                                 onClick={onAddSmartRule}
                                                 disabled={!active}
-                                                sx={{
-                                                    borderColor: 'primary.main',
-                                                    color: 'primary.main',
+                                                sx={(theme) => ({
+                                                    borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.72 : 0.82),
+                                                    color: getRouteGraphActiveColor(theme),
+                                                    backgroundColor: 'transparent',
                                                     '&:hover': {
-                                                        borderColor: 'primary.dark',
-                                                        backgroundColor: 'primary.50',
+                                                        borderColor: getRouteGraphActiveColor(theme),
+                                                        backgroundColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.12 : 0.06),
+                                                        boxShadow: `0 0 0 3px ${alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.14 : 0.10)}`,
                                                     },
-                                                }}
+                                                    '&.Mui-disabled': {
+                                                        borderColor: theme.palette.divider,
+                                                        color: theme.palette.text.disabled,
+                                                    },
+                                                })}
                                             >
                                                 Add Smart Rule
                                             </Button>
@@ -533,14 +542,19 @@ const SmartRoutingGraph: React.FC<SmartRoutingGraphProps> = ({
                             {extensionsCard && (
                                 <Box
                                     onClick={(e) => e.stopPropagation()}
-                                    sx={{
+                                    sx={(theme) => ({
                                         display: 'flex',
                                         alignItems: 'center',
                                         flexShrink: 0,
-                                        pl: 1,
+                                        alignSelf: 'stretch',
+                                        ml: 1.5,
+                                        pl: 2,
                                         pr: `${graphContainer.marginX}px`,
                                         py: `${graphContainer.marginY}px`,
-                                    }}
+                                        borderLeft: '1px solid',
+                                        borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.28 : 0.18),
+                                        backgroundImage: `linear-gradient(90deg, ${alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.07 : 0.045)}, transparent 18px)`,
+                                    })}
                                 >
                                     {extensionsCard}
                                 </Box>

--- a/frontend/src/components/model-select/CustomModelCard.tsx
+++ b/frontend/src/components/model-select/CustomModelCard.tsx
@@ -1,9 +1,11 @@
 import { CheckCircle } from '@mui/icons-material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
-import { Box, Card, CircularProgress, IconButton, Tooltip, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button, alpha } from '@mui/material';
+import { Box, Card, CircularProgress, IconButton, Tooltip, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
 import React, { useState } from 'react';
 import type { Provider } from '../../types/provider.ts';
+import { getModelCardActiveColor, getModelCardStateStyles, modelCardTransition } from './cardStyles';
 
 interface CustomModelCardProps {
     model: string;
@@ -61,29 +63,33 @@ export default function CustomModelCard({
     return (
         <>
             <Card
-                sx={{
+                sx={(theme: Theme) => ({
                     width: '100%',
                     height: 60,
                     border: 1,
-                    borderColor: variant === 'selected' ? 'primary.main' : 'grey.300',
                     borderRadius: 1,
-                    backgroundColor: isSelected ? 'primary.50' : 'background.paper',
                     cursor: loading ? 'wait' : 'pointer',
-                    transition: 'border-color 0.16s ease, background-color 0.16s ease',
+                    transition: modelCardTransition,
                     position: 'relative',
-                    boxShadow: 'none',
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
                     overflow: 'hidden',
-                    '&:hover': loading ? {} : {
-                        borderColor: 'primary.main',
-                        backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.04),
-                        '& .control-bar': {
-                            opacity: 1,
-                        },
+                    ...(loading
+                        ? {
+                            borderColor: theme.palette.divider,
+                            backgroundColor: theme.palette.background.paper,
+                            boxShadow: 'none',
+                            transform: 'translateY(0)',
+                        }
+                        : getModelCardStateStyles(theme, isSelected || variant === 'selected')),
+                    '& .control-bar': {
+                        opacity: 0,
                     },
-                }}
+                    '&:hover .control-bar': {
+                        opacity: 1,
+                    },
+                })}
                 onClick={handleCardClick}
             >
                 {/* Main content area */}
@@ -120,13 +126,13 @@ export default function CustomModelCard({
                 {/* Selected indicator */}
                 {isSelected && !loading && (
                     <CheckCircle
-                        color="primary"
                         sx={{
                             position: 'absolute',
                             top: 4,
                             right: 4,
                             fontSize: 16,
                             zIndex: 2,
+                            color: (theme) => getModelCardActiveColor(theme),
                         }}
                     />
                 )}

--- a/frontend/src/components/model-select/ModelCard.tsx
+++ b/frontend/src/components/model-select/ModelCard.tsx
@@ -1,5 +1,8 @@
 import { CheckCircle } from '@mui/icons-material';
-import { Box, Card, CardContent, CircularProgress, Typography, alpha } from '@mui/material';
+import { Box, Card, CardContent, CircularProgress, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+import { getModelCardActiveColor, getModelCardStateStyles, modelCardTransition } from './cardStyles';
 
 interface ModelCardProps {
     model: string;
@@ -27,36 +30,45 @@ export default function ModelCard({
             border: 1,
             borderRadius: 1,
             cursor: loading ? 'wait' : 'pointer',
-            transition: 'border-color 0.16s ease, background-color 0.16s ease',
+            transition: modelCardTransition,
             position: 'relative' as const,
-            boxShadow: 'none',
-            '&:hover': loading ? {} : {
-                borderColor: 'primary.main',
-                backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.04),
-            },
+            outline: 'none',
+            overflow: 'visible',
         };
 
         if (variant === 'starred') {
-            return {
+            return (theme: Theme) => ({
                 ...baseStyles,
-                borderColor: isSelected ? 'primary.main' : 'warning.main',
-                backgroundColor: isSelected ? 'primary.50' : 'warning.50',
-                '&:hover': {
-                    borderColor: 'primary.main',
-                    backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.04),
-                },
-            };
+                ...(isSelected
+                    ? getModelCardStateStyles(theme, true)
+                    : {
+                        borderColor: theme.palette.warning.main,
+                        backgroundColor: alpha(theme.palette.warning.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+                        boxShadow: 'none',
+                        transform: 'translateY(0)',
+                    }),
+                ...(loading ? {} : {
+                    '&:hover': {
+                        ...(isSelected
+                            ? getModelCardStateStyles(theme, true)
+                            : getModelCardStateStyles(theme, false)['&:hover']),
+                        transform: 'translateY(-1px)',
+                    },
+                }),
+            });
         }
 
-        return {
+        return (theme: Theme) => ({
             ...baseStyles,
-            borderColor: isSelected ? 'primary.main' : 'grey.300',
-            backgroundColor: isSelected ? 'primary.50' : 'background.paper',
-            '&:hover': {
-                borderColor: 'primary.main',
-                backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.04),
-            },
-        };
+            ...(loading
+                ? {
+                    borderColor: theme.palette.divider,
+                    backgroundColor: theme.palette.background.paper,
+                    boxShadow: 'none',
+                    transform: 'translateY(0)',
+                }
+                : getModelCardStateStyles(theme, isSelected)),
+        });
     };
 
     return (
@@ -94,12 +106,12 @@ export default function ModelCard({
                 )}
                 {isSelected && !loading && (
                     <CheckCircle
-                        color="primary"
                         sx={{
                             position: 'absolute',
                             top: 4,
                             right: 4,
-                            fontSize: 16
+                            fontSize: 16,
+                            color: (theme) => getModelCardActiveColor(theme),
                         }}
                     />
                 )}

--- a/frontend/src/components/model-select/cardStyles.ts
+++ b/frontend/src/components/model-select/cardStyles.ts
@@ -1,0 +1,58 @@
+import { alpha, type Theme } from '@mui/material/styles';
+
+const routeActive = '#4F6F9F';
+const routeActiveBg = '#F7F9FC';
+
+export const getModelCardActiveColor = (theme: Theme) =>
+    theme.palette.mode === 'dark' ? '#8EA7CF' : routeActive;
+
+export const modelCardTransition =
+    'border-color 0.16s ease, background-color 0.16s ease, box-shadow 0.18s ease, transform 0.18s ease';
+
+export const getModelCardStateStyles = (theme: Theme, isSelected: boolean) => {
+    const isDark = theme.palette.mode === 'dark';
+    const activeColor = getModelCardActiveColor(theme);
+    const activeBg = isDark ? alpha(routeActive, 0.18) : routeActiveBg;
+
+    if (isSelected) {
+        return {
+            borderColor: activeColor,
+            backgroundColor: activeBg,
+            boxShadow: isDark
+                ? [
+                    '0 14px 30px rgba(0, 0, 0, 0.34)',
+                    `0 0 0 3px ${alpha(activeColor, 0.20)}`,
+                ].join(', ')
+                : [
+                    `0 0 0 3px ${alpha(routeActive, 0.16)}`,
+                    '0 8px 24px rgba(31, 41, 55, 0.10)',
+                ].join(', '),
+            transform: 'translateY(-1px)',
+            '&:hover': {
+                borderColor: activeColor,
+                backgroundColor: activeBg,
+            },
+        };
+    }
+
+    return {
+        borderColor: theme.palette.divider,
+        backgroundColor: theme.palette.background.paper,
+        boxShadow: 'none',
+        transform: 'translateY(0)',
+        '&:hover': {
+            borderColor: activeColor,
+            backgroundColor: activeBg,
+            boxShadow: isDark
+                ? [
+                    '0 12px 24px rgba(0, 0, 0, 0.30)',
+                    `0 0 0 3px ${alpha(activeColor, 0.14)}`,
+                ].join(', ')
+                : [
+                    `0 0 0 3px ${alpha(routeActive, 0.10)}`,
+                    '0 8px 24px rgba(31, 41, 55, 0.08)',
+                ].join(', '),
+            transform: 'translateY(-1px)',
+        },
+    };
+};

--- a/frontend/src/components/nodes/ActionAddNode.tsx
+++ b/frontend/src/components/nodes/ActionAddNode.tsx
@@ -9,7 +9,7 @@ import {
 import { styled } from '@mui/material/styles';
 import React from 'react';
 import NodeTooltip from './NodeTooltip';
-import { graphNodeBaseHoverStyles, graphNodeHoverStyles } from './styles';
+import { getRouteGraphBorderColor, graphNodeBaseHoverStyles, graphNodeHoverStyles } from './styles';
 
 // ActionAddNode dimensions
 const ADD_PROVIDER_NODE_STYLES = {
@@ -30,8 +30,8 @@ const StyledAddProviderNode = styled(Box, {
     justifyContent: 'center',
     padding: node.padding,
     borderRadius: theme.shape.borderRadius,
-    border: 'dashed',
-    borderColor: 'divider',
+    border: '2px dashed',
+    borderColor: getRouteGraphBorderColor(theme),
     backgroundColor: 'background.paper',
     width: node.width,
     height: node.height,

--- a/frontend/src/components/nodes/ModelNode.tsx
+++ b/frontend/src/components/nodes/ModelNode.tsx
@@ -12,11 +12,21 @@ import {
     Divider,
 } from '@mui/material';
 import NodeTooltip from './NodeTooltip.tsx';
-import { Settings as SettingsIcon } from '@mui/icons-material';
-import { styled } from '@mui/material/styles';
+import {
+    AutoAwesome as AutoAwesomeIcon,
+    NearMeOutlined as DirectIcon,
+    Settings as SettingsIcon,
+} from '@mui/icons-material';
+import { alpha, styled } from '@mui/material/styles';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StyledModelNode, NODE_LAYER_STYLES } from './styles.tsx';
+import {
+    getRouteGraphActiveColor,
+    getRouteGraphControlFill,
+    getRouteGraphControlFillHover,
+    StyledModelNode,
+    NODE_LAYER_STYLES,
+} from './styles.tsx';
 import { isWildcardModelName } from '@/components/rule-card/utils';
 
 // Action button container
@@ -183,10 +193,6 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                             display: 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
-                            '&:hover': editable ? {
-                                backgroundColor: 'action.hover',
-                                borderRadius: 1,
-                            } : {},
                         }}
                     >
                         {isWildcard ? (
@@ -229,20 +235,30 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                                 selected={!smartEnabled}
                                 disabled={!active || switchDisabled}
                                 onClick={onSwitch}
-                                sx={{
+                                sx={(theme) => ({
                                     ...NODE_LAYER_STYLES.toggleButton,
                                     flex: 1,
-                                    borderColor: 'text.primary',
+                                    borderColor: alpha(getRouteGraphActiveColor(theme), 0.7),
+                                    color: !smartEnabled ? theme.palette.common.white : theme.palette.text.secondary,
                                     '&.Mui-selected': {
-                                        backgroundColor: !smartEnabled ? 'secondary.main' : 'transparent',
-                                        color: !smartEnabled ? 'white' : 'text.primary',
-                                        borderColor: 'text.primary',
+                                        backgroundColor: !smartEnabled ? getRouteGraphControlFill(theme) : 'transparent',
+                                        color: !smartEnabled ? theme.palette.common.white : theme.palette.text.primary,
+                                        borderColor: !smartEnabled ? getRouteGraphControlFill(theme) : getRouteGraphActiveColor(theme),
+                                        '& .MuiSvgIcon-root': {
+                                            color: theme.palette.common.white,
+                                        },
+                                        '&:hover': {
+                                            backgroundColor: getRouteGraphControlFillHover(theme),
+                                        },
                                     },
                                     '&:hover': {
-                                        backgroundColor: !smartEnabled ? 'secondary.dark' : 'action.hover',
+                                        backgroundColor: !smartEnabled
+                                            ? getRouteGraphControlFillHover(theme)
+                                            : alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.16 : 0.08),
                                     },
-                                }}
+                                })}
                             >
+                                <DirectIcon sx={{ fontSize: 13 }} />
                                 Direct
                             </ToggleButton>
                         </NodeTooltip>
@@ -252,20 +268,30 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                                 selected={smartEnabled}
                                 disabled={!active || switchDisabled}
                                 onClick={onSwitch}
-                                sx={{
+                                sx={(theme) => ({
                                     ...NODE_LAYER_STYLES.toggleButton,
                                     flex: 1,
-                                    borderColor: 'text.primary',
+                                    borderColor: alpha(getRouteGraphActiveColor(theme), 0.7),
+                                    color: smartEnabled ? theme.palette.common.white : theme.palette.text.secondary,
                                     '&.Mui-selected': {
-                                        backgroundColor: smartEnabled ? 'secondary.main' : 'transparent',
-                                        color: smartEnabled ? 'white' : 'text.primary',
-                                        borderColor: 'text.primary',
+                                        backgroundColor: smartEnabled ? getRouteGraphControlFill(theme) : 'transparent',
+                                        color: smartEnabled ? theme.palette.common.white : theme.palette.text.primary,
+                                        borderColor: smartEnabled ? getRouteGraphControlFill(theme) : getRouteGraphActiveColor(theme),
+                                        '& .MuiSvgIcon-root': {
+                                            color: theme.palette.common.white,
+                                        },
+                                        '&:hover': {
+                                            backgroundColor: getRouteGraphControlFillHover(theme),
+                                        },
                                     },
                                     '&:hover': {
-                                        backgroundColor: smartEnabled ? 'secondary.dark' : 'action.hover',
+                                        backgroundColor: smartEnabled
+                                            ? getRouteGraphControlFillHover(theme)
+                                            : alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.16 : 0.08),
                                     },
-                                }}
+                                })}
                             >
+                                <AutoAwesomeIcon sx={{ fontSize: 13 }} />
                                 Smart
                             </ToggleButton>
                         </NodeTooltip>
@@ -279,9 +305,19 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                         <IconButton
                             size="small"
                             onClick={handleMenuClick}
-                            sx={{ p: 0.5, backgroundColor: 'background.paper' }}
+                            sx={(theme) => ({
+                                p: 0.45,
+                                backgroundColor: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.72 : 0.78),
+                                border: '1px solid',
+                                borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.24 : 0.18),
+                                boxShadow: 'none',
+                                '&:hover': {
+                                    backgroundColor: theme.palette.background.paper,
+                                    borderColor: getRouteGraphActiveColor(theme),
+                                },
+                            })}
                         >
-                            <SettingsIcon sx={{ fontSize: '1rem', color: 'text.primary' }} />
+                            <SettingsIcon sx={{ fontSize: '0.95rem', color: 'text.secondary' }} />
                         </IconButton>
                     </NodeTooltip>
                 </ActionButtonsBox>

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -3,7 +3,7 @@ import {
     Warning as WarningIcon,
     MoreVert as MoreVertIcon,
     PlayArrow as PlayIcon,
-    LowPriority as LowPriorityIcon,
+    HorizontalRule as HorizontalRuleIcon,
 } from '@mui/icons-material';
 import {
     Box,
@@ -172,7 +172,7 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
                         active={active}
                         onClick={active ? open : undefined}
                     >
-                        {priority > 0 ? String(priority) : <LowPriorityIcon sx={{ fontSize: 15 }} />}
+                        {priority > 0 ? String(priority) : <HorizontalRuleIcon sx={{ fontSize: 15 }} />}
                     </PriorityBadgeDisk>
                 </NodeTooltip>
             </PriorityBadgeAnchor>

--- a/frontend/src/components/nodes/ProviderNode.tsx
+++ b/frontend/src/components/nodes/ProviderNode.tsx
@@ -2,7 +2,8 @@ import {
     Delete as DeleteIcon,
     Warning as WarningIcon,
     MoreVert as MoreVertIcon,
-    PlayArrow as PlayIcon
+    PlayArrow as PlayIcon,
+    LowPriority as LowPriorityIcon,
 } from '@mui/icons-material';
 import {
     Box,
@@ -158,7 +159,6 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
         close();
     };
 
-    const label = priority > 0 ? String(priority) : '–';
     const tooltip = priority > 0
         ? `Priority ${priority} (higher = tried first). Click to change.`
         : 'No priority set. Click to assign a priority (higher = tried first).';
@@ -172,7 +172,7 @@ const PriorityBadge: React.FC<PriorityBadgeProps> = ({ priority, onChange, activ
                         active={active}
                         onClick={active ? open : undefined}
                     >
-                        {label}
+                        {priority > 0 ? String(priority) : <LowPriorityIcon sx={{ fontSize: 15 }} />}
                     </PriorityBadgeDisk>
                 </NodeTooltip>
             </PriorityBadgeAnchor>

--- a/frontend/src/components/nodes/SmartDefaultNode.tsx
+++ b/frontend/src/components/nodes/SmartDefaultNode.tsx
@@ -1,18 +1,19 @@
 import {
-    Add as AddIcon,
-    Add as DefaultIcon,
-} from '@mui/icons-material';
-import {
     Box,
-    IconButton,
     Typography,
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import React from 'react';
 import {
-    ActionButtonsBox,
+    getRouteGraphActiveColor,
     StyledSmartNodeWarning,
     StyledSmartNodeWrapper,
 } from './styles.tsx';
+
+const DEFAULT_NODE_INTERNAL_STYLES = {
+    contentHeight: 62,
+    fieldHeight: 31,
+} as const;
 
 export interface DefaultNodeProps {
     providersCount: number;
@@ -29,7 +30,14 @@ export const SmartDefaultNode: React.FC<DefaultNodeProps> = ({
         <StyledSmartNodeWrapper>
             <StyledSmartNodeWarning active={active}>
                 {/* Content */}
-                <Box sx={{ mt: 1, width: '100%' }}>
+                <Box
+                    sx={{
+                        width: '100%',
+                        height: DEFAULT_NODE_INTERNAL_STYLES.contentHeight,
+                        display: 'flex',
+                        alignItems: 'center',
+                    }}
+                >
                     {/* Summary Info */}
                     <Box
                         sx={{
@@ -37,18 +45,19 @@ export const SmartDefaultNode: React.FC<DefaultNodeProps> = ({
                         }}
                     >
                         <Box
-                            sx={{
+                            sx={(theme) => ({
                                 width: '100%',
-                                p: 1,
+                                height: DEFAULT_NODE_INTERNAL_STYLES.fieldHeight,
+                                px: 1,
                                 border: '1px solid',
-                                borderColor: 'divider',
+                                borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.34 : 0.22),
                                 borderRadius: 1,
                                 backgroundColor: 'background.paper',
-                                transition: 'all 0.2s',
+                                transition: 'border-color 0.16s ease, background-color 0.16s ease',
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'center',
-                            }}
+                            })}
                         >
                             <Typography
                                 variant="body2"
@@ -56,6 +65,7 @@ export const SmartDefaultNode: React.FC<DefaultNodeProps> = ({
                                     fontSize: '0.8rem',
                                     color: 'text.secondary',
                                     fontWeight: 500,
+                                    lineHeight: 1,
                                 }}
                             >
                                 Default

--- a/frontend/src/components/nodes/SmartOpNode.tsx
+++ b/frontend/src/components/nodes/SmartOpNode.tsx
@@ -1,15 +1,21 @@
 import {Delete as DeleteIcon,} from '@mui/icons-material';
 import {Box, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Typography,} from '@mui/material';
 import NodeTooltip from './NodeTooltip.tsx';
+import { alpha } from '@mui/material/styles';
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {SmartRouting, SmartOp} from '../RoutingGraphTypes.ts';
-import {ActionButtonsBox, StyledSmartNodePrimary, StyledSmartNodeWrapper,} from './styles.tsx';
+import {
+    ActionButtonsBox,
+    getRouteGraphActiveColor,
+    StyledSmartNodePrimary,
+    StyledSmartNodeWrapper,
+} from './styles.tsx';
 
 // Smart node internal dimensions
 const SMART_NODE_INTERNAL_STYLES = {
-    badgeHeight: 20,
-    fieldPadding: 4,
+    contentHeight: 62,
+    fieldHeight: 31,
 } as const;
 
 export interface SmartNodeProps {
@@ -136,7 +142,16 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                     </Box>
                 )}
                 {/* Content */}
-                <Box sx={{mt: 1, width: '100%'}}>
+                <Box
+                    sx={{
+                        width: '100%',
+                        height: SMART_NODE_INTERNAL_STYLES.contentHeight,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'center',
+                        gap: 0.75,
+                    }}
+                >
                     {/* Value display - the truncated value is a subset of the summary
                         below, so it shares the single tooltip on the summary box. */}
                     <Typography
@@ -145,7 +160,7 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                             fontWeight: 600,
                             color: 'text.primary',
                             fontSize: '0.85rem',
-                            mb: 1,
+                            lineHeight: 1.15,
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
                             whiteSpace: 'nowrap',
@@ -162,18 +177,20 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                     >
                         <NodeTooltip title={getMultiOpDisplayFull()} placement="top">
                             <Box
-                                sx={{
+                                sx={(theme) => ({
                                     width: '100%',
-                                    p: 1,
+                                    height: SMART_NODE_INTERNAL_STYLES.fieldHeight,
+                                    px: 1,
                                     border: '1px solid',
-                                    borderColor: 'divider',
+                                    borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.34 : 0.22),
                                     borderRadius: 1,
                                     backgroundColor: 'background.paper',
-                                    transition: 'all 0.2s',
+                                    transition: 'border-color 0.16s ease, background-color 0.16s ease',
                                     display: 'flex',
                                     alignItems: 'center',
                                     justifyContent: 'center',
-                                }}
+                                    overflow: 'hidden',
+                                })}
                             >
                                 <Typography
                                     variant="body2"
@@ -181,6 +198,7 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                                         fontSize: '0.8rem',
                                         color: 'text.secondary',
                                         fontWeight: 500,
+                                        lineHeight: 1,
                                         overflow: 'hidden',
                                         textOverflow: 'ellipsis',
                                         whiteSpace: 'nowrap',

--- a/frontend/src/components/nodes/styles.tsx
+++ b/frontend/src/components/nodes/styles.tsx
@@ -1,10 +1,28 @@
 import { Box } from '@mui/material';
 import { alpha, styled, type Theme } from '@mui/material/styles';
 
+export const routeGraphActive = '#4F6F9F';
+export const routeGraphActiveBg = '#F7F9FC';
+
+export const getRouteGraphActiveColor = (theme: Theme) =>
+    theme.palette.mode === 'dark' ? '#D4E3FF' : routeGraphActive;
+
+export const getRouteGraphControlFill = (theme: Theme) =>
+    theme.palette.mode === 'dark' ? '#4F6F9F' : routeGraphActive;
+
+export const getRouteGraphControlFillHover = (theme: Theme) =>
+    theme.palette.mode === 'dark' ? '#5F82BA' : routeGraphActive;
+
+export const getRouteGraphActiveBg = (theme: Theme) =>
+    theme.palette.mode === 'dark' ? alpha(routeGraphActive, 0.18) : routeGraphActiveBg;
+
+export const getRouteGraphBorderColor = (theme: Theme) =>
+    alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.48 : 0.50);
+
 // Node dimensions constants
 export const MODEL_NODE_STYLES = {
     width: 220,
-    height: 72,
+    height: 76,
     heightCompact: 48,
     widthCompact: 220,
     padding: 5,
@@ -52,12 +70,10 @@ export const ConnectionLine = styled(Box)(() => ({
 
 export const graphNodeHoverStyles = (theme: Theme) => {
     const isDark = theme.palette.mode === 'dark';
-    const emphasisColor = isDark ? theme.palette.primary.light : theme.palette.primary.dark;
-    const tintAlpha = isDark ? 0.12 : 0.045;
+    const emphasisColor = getRouteGraphActiveColor(theme);
 
     return {
         borderColor: emphasisColor,
-        backgroundColor: alpha(theme.palette.primary.main, tintAlpha),
         color: emphasisColor,
         '& .MuiTypography-root': {
             color: emphasisColor,
@@ -67,15 +83,16 @@ export const graphNodeHoverStyles = (theme: Theme) => {
         },
         boxShadow: isDark
             ? [
-                '0 14px 30px rgba(0, 0, 0, 0.38)',
-                `0 0 0 1px ${alpha(emphasisColor, 0.22)}`,
+                `0 0 0 1px ${alpha(emphasisColor, 0.92)}`,
+                `0 0 0 5px ${alpha(emphasisColor, 0.34)}`,
+                '0 18px 38px rgba(0, 0, 0, 0.50)',
             ].join(', ')
             : [
-                '0 10px 24px rgba(15, 23, 42, 0.12)',
-                '0 2px 8px rgba(15, 23, 42, 0.08)',
-                `0 0 0 1px ${alpha(emphasisColor, 0.16)}`,
+                `0 0 0 4px ${alpha(routeGraphActive, 0.18)}`,
+                '0 14px 34px rgba(31, 41, 55, 0.14)',
+                '0 3px 10px rgba(31, 41, 55, 0.08)',
             ].join(', '),
-        transform: 'translateY(-1px)',
+        transform: 'translateY(-2px)',
     };
 };
 
@@ -93,7 +110,7 @@ export const ProviderNodeContainer = styled(Box)(({ theme }: { theme: Theme }) =
     padding: providerNode.padding,
     borderRadius: theme.shape.borderRadius,
     border: '1px solid',
-    borderColor: 'divider',
+    borderColor: getRouteGraphBorderColor(theme),
     backgroundColor: 'background.paper',
     width: providerNode.width,
     height: providerNode.height,
@@ -115,7 +132,7 @@ export const StyledModelNode = styled(Box, { shouldForwardProp: (prop) => prop !
     padding: modelNode.padding,
     borderRadius: theme.shape.borderRadius,
     border: '1px solid',
-    borderColor: 'divider',
+    borderColor: getRouteGraphBorderColor(theme),
     backgroundColor: 'background.paper',
     textAlign: 'center',
     width: compact ? modelNode.widthCompact : modelNode.width,
@@ -154,8 +171,8 @@ const baseSmartNodeStyles = ({ active, theme }: { active: boolean; theme: Theme 
     padding: smartNode.padding,
     borderRadius: theme.shape.borderRadius,
     border: '1px solid',
-    borderColor: active ? 'text.secondary' : 'divider',
-    backgroundColor: active ? 'action.hover' : 'background.paper',
+    borderColor: getRouteGraphBorderColor(theme),
+    backgroundColor: 'background.paper',
     textAlign: 'center' as const,
     width: smartNode.width,
     height: smartNode.height,
@@ -184,22 +201,27 @@ export const NODE_LAYER_STYLES = {
         justifyContent: 'center',
         width: '100%',
     } as const,
-    divider: { width: '78%', my: 0.125 } as const,
+    divider: { width: '84%', my: 0.25 } as const,
     bottomLayer: {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         width: '100%',
-        minHeight: 18,
+        minHeight: 26,
+        px: 0.5,
+        gap: 0.5,
     } as const,
     typography: { fontWeight: 600, fontSize: '0.8rem', lineHeight: 1.15 } as const,
     toggleButton: {
-        height: 20,
-        padding: '0 6px',
-        fontSize: '0.6rem',
+        height: 24,
+        minWidth: 0,
+        padding: '0 8px',
+        gap: 0.5,
+        fontSize: '0.68rem',
         fontWeight: 600,
         textTransform: 'none' as const,
         border: '1px solid',
-        borderRadius: 1,
+        borderRadius: 1.25,
+        lineHeight: 1,
     } as const,
 };

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -1,17 +1,25 @@
 import { Add as AddIcon, Extension as ExtensionIcon } from '@mui/icons-material';
 import { Box, Chip, Stack, Tooltip, Typography } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import React from 'react';
-import { graphNodeBaseHoverStyles, graphNodeHoverStyles, PROVIDER_NODE_STYLES } from '@/components/nodes/styles';
+import {
+    getRouteGraphActiveColor,
+    getRouteGraphBorderColor,
+    graphNodeBaseHoverStyles,
+    graphNodeHoverStyles,
+    MODEL_NODE_STYLES,
+} from '@/components/nodes/styles';
 import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
 
-// Matches ProviderNode dimensions so the extensions card aligns with the
-// providers row visually. Content overflow scrolls inside the card body.
+// Matches the route graph node footprint so this feels like a pinned tool node,
+// not a smaller floating card. Content overflow scrolls inside the body.
 const CARD_STYLES = {
-    width: 180,
-    height: PROVIDER_NODE_STYLES.height,
-    padding: 6,
+    width: MODEL_NODE_STYLES.width,
+    minHeight: MODEL_NODE_STYLES.height,
+    padding: 8,
 } as const;
+
+const CARD_HEADER_HEIGHT = 18;
 
 const StyledExtensionsCard = styled(Box, {
     shouldForwardProp: (prop) => prop !== 'active',
@@ -21,10 +29,11 @@ const StyledExtensionsCard = styled(Box, {
     padding: CARD_STYLES.padding,
     borderRadius: theme.shape.borderRadius,
     border: '1px dashed',
-    borderColor: theme.palette.divider,
+    borderColor: getRouteGraphBorderColor(theme),
     backgroundColor: theme.palette.background.paper,
     width: CARD_STYLES.width,
-    height: CARD_STYLES.height,
+    minHeight: CARD_STYLES.minHeight,
+    maxHeight: '100%',
     boxShadow: 'none',
     opacity: active ? 1 : 0.6,
     cursor: 'pointer',
@@ -101,14 +110,23 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
     return (
         <StyledExtensionsCard active={active} onClick={onOpenCatalog}>
             {/* Fixed-height header so the body has a stable scroll region */}
-            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ flexShrink: 0, mb: 0.25 }}>
-                <ExtensionIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
-                <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.65rem', color: 'text.secondary', flexGrow: 1, lineHeight: 1 }}>
+            <Stack
+                direction="row"
+                alignItems="center"
+                spacing={0.75}
+                sx={{
+                    flexShrink: 0,
+                    height: CARD_HEADER_HEIGHT,
+                    mb: 0.75,
+                }}
+            >
+                <ExtensionIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+                <Typography variant="caption" sx={{ fontWeight: 700, fontSize: '0.72rem', color: 'text.secondary', flexGrow: 1, lineHeight: 1 }}>
                     Extensions{enabled.length > 0 ? ` (${enabled.length})` : ''}
                 </Typography>
                 {/* Visual affordance only — the whole card is clickable. */}
                 <Tooltip title="Configure rule extensions">
-                    <AddIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
+                    <AddIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
                 </Tooltip>
             </Stack>
 
@@ -116,13 +134,15 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                 <Box
                     sx={{
                         flexGrow: 1,
+                        minHeight: 0,
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
                         color: 'text.disabled',
-                        fontSize: '0.65rem',
+                        fontSize: '0.72rem',
+                        lineHeight: 1.25,
                         textAlign: 'center',
-                        px: 0.25,
+                        px: 1,
                     }}
                 >
                     None enabled. Click to configure.
@@ -132,14 +152,25 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                     sx={{
                         flexGrow: 1,
                         minHeight: 0,
+                        pr: 0.25,
                         overflowY: 'auto',
                         // Hide scrollbar visually but keep it functional.
                         scrollbarWidth: 'thin',
-                        '&::-webkit-scrollbar': { width: 4 },
-                        '&::-webkit-scrollbar-thumb': { backgroundColor: 'rgba(0,0,0,0.15)', borderRadius: 2 },
+                        scrollbarGutter: 'stable',
+                        '&::-webkit-scrollbar': { width: 5 },
+                        '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+                        '&::-webkit-scrollbar-thumb': {
+                            backgroundColor: (theme) => alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.34 : 0.24),
+                            borderRadius: 3,
+                        },
+                        '&::-webkit-scrollbar-thumb:hover': {
+                            backgroundColor: (theme) => alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.5 : 0.36),
+                        },
                     }}
+                    onClick={(e) => e.stopPropagation()}
+                    onDoubleClick={(e) => e.stopPropagation()}
                 >
-                    <Stack direction="row" flexWrap="wrap" gap={0.25}>
+                    <Stack direction="row" flexWrap="wrap" gap={0.5}>
                         {enabled.map((spec) => {
                             const isString = spec.type === 'string';
                             const isEnum = spec.type === 'enum';
@@ -160,7 +191,6 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                                     <Chip
                                         size="small"
                                         label={label}
-                                        color="primary"
                                         variant="outlined"
                                         onDelete={
                                             spec.type === 'bool' && onToggleFlag
@@ -172,7 +202,24 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                                                 }
                                                 : undefined
                                         }
-                                        sx={{ maxWidth: '100%', fontSize: '0.6rem', height: 18 }}
+                                        sx={(theme) => ({
+                                            maxWidth: '100%',
+                                            height: 20,
+                                            fontSize: '0.65rem',
+                                            borderColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.55 : 0.48),
+                                            color: getRouteGraphActiveColor(theme),
+                                            backgroundColor: alpha(getRouteGraphActiveColor(theme), theme.palette.mode === 'dark' ? 0.08 : 0.035),
+                                            '& .MuiChip-label': {
+                                                px: 0.75,
+                                            },
+                                            '& .MuiChip-deleteIcon': {
+                                                color: alpha(getRouteGraphActiveColor(theme), 0.72),
+                                                fontSize: 15,
+                                                '&:hover': {
+                                                    color: getRouteGraphActiveColor(theme),
+                                                },
+                                            },
+                                        })}
                                     />
                                 </Tooltip>
                             );


### PR DESCRIPTION
Refines the visual treatment of the Models and Forwarding Rules graph to make routing cards feel more consistent across light, dark, and Sunlit themes.

Changes include:

- Unified route graph node borders around a restrained gray-blue palette.
- Improved hover states with clearer borders, rings, and shadows.
- Refined Direct/Smart segmented controls with better spacing, icons, and dark-mode colors.
- Fixed Smart Rule and Default node inner layout to avoid clipped content.
- Updated Add Smart Rule styling to match the route graph palette.
- Improved Extensions panel sizing, border treatment, chip styling, scrolling behavior, and right-side separation.
- Added shared model-card state styling for model selection cards.

**NOTE：Keep the unset priority badge icon unchanged for now. We will revisit it after reviewing the overall icon strategy to ensure the priority badge uses a consistent visual language across the routing graph.**

https://github.com/user-attachments/assets/fd784f00-b4f6-4674-a146-805239bba005

## Screenshot

### Codex

<img width="700" alt="image" src="https://github.com/user-attachments/assets/5a8ef684-77db-474d-997f-9cc125bfa6ce" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/306f23e3-68e5-42d5-ad44-55770a6987cb" />


### Claude Code

<img width="700" alt="image" src="https://github.com/user-attachments/assets/4f2c77de-be5a-4b18-98a6-70fc6574154f" />


<img width="700" alt="image" src="https://github.com/user-attachments/assets/1cc27ce0-0173-4a30-a09e-159ad3a2f728" />
