### PR TITLE
feat: Graduate Fusion Provider from experimental to stable

### DIFF
--- a/.design/connect-provider-flow.md
+++ b/.design/connect-provider-flow.md
@@ -43,7 +43,7 @@ Layout top → bottom:
 1. **Base URL \*** — required; inline error if submitted empty
 2. **API Key** — password field with show/hide toggle
 3. **No API Key Required** — right-aligned checkbox; disables the key field
-4. **API Style** — OpenAI / Anthropic checkboxes; topology hint appears when both are checked on a dual-URL template
+4. **API Style** — OpenAI / Anthropic checkboxes; when both are checked on a dual-URL template a **Fusion mode** toggle and topology hint appear (see [fusion-provider.md](fusion-provider.md))
 5. **Advanced accordion** — collapsed by default in add mode, auto-expanded in edit mode
 
 When opened from the picker, the form shows a **← Back** button (bottom-left) that

--- a/.design/fusion-provider.md
+++ b/.design/fusion-provider.md
@@ -1,0 +1,200 @@
+# Fusion Provider
+
+A **fusion provider** is a single `Provider` record that exposes two base URLs —
+one for the OpenAI-compatible protocol and one for the Anthropic-compatible
+protocol — under the same API credential.  The dispatcher routes each inbound
+request to whichever URL matches the client's protocol natively, eliminating
+protocol translation overhead for providers that support both natively (e.g.
+Vertex AI, Bedrock, many inference platforms).
+
+Fusion mode is always active (graduated from experimental in May 2026).
+
+---
+
+## Data model
+
+```
+Provider {
+    APIBase:          "https://api.example.com/openai/v1"   // primary / legacy fallback
+    APIStyle:         "openai"                              // primary style (openai by convention)
+    APIBaseOpenAI:    "https://api.example.com/openai/v1"  // fusion: OpenAI-side URL
+    APIBaseAnthropic: "https://api.example.com/anthropic"  // fusion: Anthropic-side URL
+    AuthType:         "api_key"                             // fusion requires api_key
+    Token:            "..."
+}
+```
+
+`APIBaseOpenAI` and `APIBaseAnthropic` are optional.  A provider is considered
+"fusion" when **both** are non-empty.  `APIBase`/`APIStyle` are always populated
+for backward compatibility with model-probe and model-list code that reads them
+directly.  By convention, `APIBase` is set to the OpenAI URL.
+
+### Constraints
+
+| Constraint | Reason |
+|---|---|
+| `AuthType` must be `api_key` | OAuth tokens are issuer-specific; the token's scope is tied to one protocol endpoint |
+| `APIStyle` must not be `google` | Google auth is per-project, not per-endpoint |
+| Template required for the upgrade path | Free-form entries have no second URL to discover |
+
+---
+
+## Dispatch (`resolveProviderForClient`)
+
+`internal/server/fusion.go` — called at the top of every inbound handler before
+any protocol translation.
+
+```
+resolveProviderForClient(p, clientStyle):
+    (baseURL, style) = p.ResolveEndpoint(clientStyle)
+    if unchanged → return p as-is
+    clone p; set clone.APIBase = baseURL, clone.APIStyle = style
+    return clone
+```
+
+`Provider.ResolveEndpoint` (`ai/provider.go`):
+
+| Inbound client style | APIBaseOpenAI set? | APIBaseAnthropic set? | Result |
+|---|---|---|---|
+| `openai` | ✓ | any | `(APIBaseOpenAI, openai)` |
+| `anthropic` | any | ✓ | `(APIBaseAnthropic, anthropic)` |
+| any | ✗ | ✗ | `(APIBase, APIStyle)` — legacy single-protocol |
+
+The returned shallow clone is used by downstream HTTP clients and protocol
+transformers.  The stored provider record is never mutated.
+
+---
+
+## Add flow
+
+See also: [connect-provider-flow.md](connect-provider-flow.md) for the full
+picker → form sequence.
+
+When the user selects a provider template that has both `baseUrlOpenAI` and
+`baseUrlAnthropic`, the form lets them pick both protocol checkboxes.  Once both
+are checked, a **Fusion mode** toggle appears below the protocol selector.
+
+| Fusion toggle | Outcome |
+|---|---|
+| Off (default) | Two separate `Provider` records are created — one `openai`, one `anthropic` — sharing the same credential. |
+| On | One fusion `Provider` record is created with both URLs and `APIStyle: openai` as primary. |
+
+A topology hint below the toggle tells the user which outcome is selected
+("merged into one" vs "saved as two separate providers").
+
+Free-form (no template match): fusion is not available — the second URL cannot
+be inferred.
+
+---
+
+## Edit flow
+
+Edit mode enforces three rules that differ from add mode.
+
+### Rule 1 — Protocol lock for non-fusion providers
+
+If the provider being edited is **not** a fusion provider (only one of
+`APIBaseOpenAI`/`APIBaseAnthropic` is set, or neither), the protocol checkboxes
+are **disabled**.  The user cannot change the protocol by clicking them.
+
+*Rationale:* switching an existing OpenAI provider to Anthropic would silently
+change its routing behavior for all rules that reference it.  Creating a new
+entry is explicit and leaves the old one intact.
+
+### Rule 2 — Fusion upgrade via toggle
+
+If the template matched to the provider's `APIBase` supports **both** protocols,
+a **Fusion mode** toggle appears in edit mode even for non-fusion providers.
+
+Enabling the toggle:
+- auto-selects both protocol checkboxes
+- populates `APIBaseOpenAI` and `APIBaseAnthropic` from the template
+- sets `APIBase` to the OpenAI URL (by convention), `APIStyle` to `openai`
+- on submit, `updateProvider` stores the new fusion fields
+
+Disabling the toggle (reverting):
+- restores the original single-protocol state from a snapshot taken when the dialog opened (`initialFusionRef`)
+- clears both fusion URL fields
+- restores original `APIBase`/`APIStyle`
+
+The snapshot is captured on dialog open so stale React state is never read
+during the revert operation.
+
+### Rule 3 — Fusion downgrade
+
+If the provider being edited **is** a fusion provider, both protocol checkboxes
+are enabled and either can be deselected.
+
+Deselecting one side:
+- retains the remaining protocol's URL as `APIBase`
+- sets `APIStyle` to match the remaining protocol
+- clears both `APIBaseOpenAI` and `APIBaseAnthropic` (the provider reverts to single-protocol)
+
+The URL for the remaining side is read from the snapshot (not from React state)
+to avoid async-update races.
+
+Deselecting the **last** protocol is blocked — at least one must remain.
+
+---
+
+## State & implementation
+
+### `ProviderFormDialog.tsx`
+
+| State / ref | Purpose |
+|---|---|
+| `isExistingFusion` | True when the dialog opens on a provider with both fusion URLs set |
+| `initialFusionRef` | Snapshot of `{ openAI, anthropic, apiBase, apiStyle }` taken on open |
+| `createFusionProvider` | Tracks the fusion toggle state (also written to parent as `createFusionProvider` field) |
+| `effectiveLocked` | `fusionLocked \|\| protocolLocked`; passed to `ProtocolSelector` as `fusionLocked` |
+| `showFusionToggle` | add: `protocolOpenAI && protocolAnthropic`; edit: `!isExistingFusion && hasBothBaseUrls` |
+
+`handleFusionDowngrade(nextOpenAI, nextAnthropic)` — called from protocol toggle
+handlers when `isExistingFusion` is true.  Reads from `initialFusionRef` and
+fires `onChange` to push the updated fields to the parent.
+
+### `CredentialPage.tsx` — `buildAddProviderPayload`
+
+When `bothProtocols && shouldCreateFusion` (fusion toggle on):
+
+```ts
+{
+    api_base: openaiUrl,
+    api_style: 'openai',
+    api_base_openai: openaiUrl,
+    api_base_anthropic: anthropicUrl,
+    ...
+}
+```
+
+When `bothProtocols && !shouldCreateFusion` (toggle off): returns an **array**
+of two single-protocol payloads, one per protocol.
+
+### `CredentialPage.tsx` — `buildEditProviderPayload`
+
+Always includes `api_base_openai` and `api_base_anthropic`.  Sending empty
+strings clears the fields on the backend, enabling the downgrade path.
+
+### `internal/server/provider_handler.go`
+
+`CreateProvider`: validates that fusion URLs (`api_base_openai` /
+`api_base_anthropic`) are only supplied for `api_key` auth and non-Google style.
+
+`UpdateProvider`: applies `api_base_openai` / `api_base_anthropic` unconditionally
+(no flag gate since fusion is stable).
+
+---
+
+## Key files
+
+| File | Role |
+|---|---|
+| `ai/provider.go` | `Provider` type; `IsFusion()`, `ResolveEndpoint()`, `HasFusionURL()` |
+| `ai/provider_test.go` | Unit tests for `ResolveEndpoint` and `IsFusion` |
+| `internal/server/fusion.go` | `resolveProviderForClient` — dispatch-time endpoint resolution |
+| `internal/server/provider_handler.go` | `CreateProvider` / `UpdateProvider` — fusion field validation and persistence |
+| `frontend/src/components/ProviderFormDialog.tsx` | Add + edit form; fusion toggle, protocol lock, upgrade/downgrade logic |
+| `frontend/src/components/providerFormDialog/FusionToggle.tsx` | Fusion checkbox with tooltip |
+| `frontend/src/components/providerFormDialog/ProtocolSelector.tsx` | Protocol checkboxes; respects `fusionLocked` (covers both OAuth and edit-mode lock) |
+| `frontend/src/pages/CredentialPage.tsx` | `buildAddProviderPayload` (split vs fusion), `buildEditProviderPayload` |
+| `frontend/src/i18n/locales/en.ts` | `providerDialog.fusion.*` strings |

--- a/ai/README.md
+++ b/ai/README.md
@@ -32,7 +32,9 @@ Provider {
 `APIStyle` controls request/response translation: `openai` (default) or
 `anthropic`.  For providers that speak both natively, the optional fusion
 fields `APIBaseOpenAI` / `APIBaseAnthropic` let the dispatcher pick the
-matching endpoint without protocol conversion.
+matching endpoint without protocol conversion.  See
+[`.design/fusion-provider.md`](../.design/fusion-provider.md) for the full
+design, dispatch logic, and edit-mode rules.
 
 ---
 

--- a/frontend/src/components/GlobalExperimentalFeatures.tsx
+++ b/frontend/src/components/GlobalExperimentalFeatures.tsx
@@ -1,6 +1,6 @@
 import {useFeatureFlags} from '@/contexts/FeatureFlagsContext';
 import { IconBrain, IconShield } from '@tabler/icons-react';
-import { SettingsApplications, Hub as HubIcon } from '@/components/icons';
+import { SettingsApplications } from '@/components/icons';
 import {Alert, Box, Chip, Tooltip, Typography,} from '@mui/material';
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -20,7 +20,6 @@ const GlobalExperimentalFeatures: React.FC = () => {
     const [features, setFeatures] = useState<Record<string, boolean>>({});
     const [guardrailsEnabled, setGuardrailsEnabled] = useState(false);
     const [mcpEnabled, setMCPEnabled] = useState(false);
-    const [fusionEnabled, setFusionEnabled] = useState(false);
     const [loading, setLoading] = useState(true);
     const {refresh} = useFeatureFlags();
 
@@ -44,10 +43,6 @@ const GlobalExperimentalFeatures: React.FC = () => {
             // Load MCP flag
             const mcpResult = await api.getScenarioFlag('_global', 'mcp');
             setMCPEnabled(mcpResult?.data?.value || false);
-
-            // Load Fusion Provider flag
-            const fusionResult = await api.getScenarioFlag('_global', 'fusion_provider');
-            setFusionEnabled(fusionResult?.data?.value || false);
 
         } catch (error) {
             console.error('Failed to load global experimental features:', error);
@@ -108,24 +103,6 @@ const GlobalExperimentalFeatures: React.FC = () => {
             })
             .catch((err) => {
                 console.error('Failed to set MCP:', err);
-                loadFeatures();
-            });
-    };
-
-    const toggleFusion = () => {
-        const newValue = !fusionEnabled;
-        api.setScenarioFlag('_global', 'fusion_provider', newValue)
-            .then((result) => {
-                if (result.success) {
-                    setFusionEnabled(newValue);
-                    refresh();
-                } else {
-                    console.error('Failed to set Fusion Provider:', result);
-                    loadFeatures();
-                }
-            })
-            .catch((err) => {
-                console.error('Failed to set Fusion Provider:', err);
                 loadFeatures();
             });
     };
@@ -244,34 +221,6 @@ const GlobalExperimentalFeatures: React.FC = () => {
                 </Alert>
             )}
 
-            {/* Fusion Provider Section */}
-            <Box sx={{ display: 'flex', alignItems: 'center', py: 2, gap: 3 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 180 }}>
-                    <HubIcon sx={{ fontSize: '1rem', color: 'text.secondary' }} />
-                    <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
-                        {t('system.experimentalFeatures.fusion')}
-                    </Typography>
-                </Box>
-
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                    <Tooltip title={t('system.experimentalFeatures.enableFusion') + (fusionEnabled ? ` (${t('system.experimentalFeatures.enabled')})` : ` (${t('system.experimentalFeatures.disabled')})`)} arrow>
-                        <Chip
-                            label={`${t('system.experimentalFeatures.fusion')} · ${fusionEnabled ? t('common.on') : t('common.off')}`}
-                            onClick={toggleFusion}
-                            size="small"
-                            sx={{ ...chipStyle(fusionEnabled), cursor: 'pointer', pointerEvents: 'auto' }}
-                        />
-                    </Tooltip>
-                </Box>
-            </Box>
-
-            {fusionEnabled && (
-                <Alert severity="info" sx={{ mt: 1 }}>
-                    <Typography variant="body2">
-                        {t('system.experimentalFeatures.fusionEnabledInfo')}
-                    </Typography>
-                </Alert>
-            )}
         </Box>
     );
 };

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -22,7 +22,6 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {type UniqueProvider, useProviderTemplates} from '../services/serviceProviders';
 import {api} from '../services/api';
-import {useFeatureFlags} from '@/contexts/FeatureFlagsContext';
 import ApiKeyField from './providerFormDialog/ApiKeyField';
 import FusionToggle from './providerFormDialog/FusionToggle';
 import KeyNameField from './providerFormDialog/KeyNameField';
@@ -109,8 +108,6 @@ const ProviderFormDialog = ({
     const [advancedOpen, setAdvancedOpen] = useState(false);
     const [baseUrlError, setBaseUrlError] = useState(false);
 
-    const {enableFusion} = useFeatureFlags();
-
     const allProviders = useProviderTemplates();
 
     // Keep onChange in a ref so we can call it from effects/handlers without
@@ -119,14 +116,6 @@ const ProviderFormDialog = ({
     useEffect(() => {
         onChangeRef.current = onChange;
     });
-
-    // Mirror the fusion flag into a ref so syncProtocolsToParent can read the
-    // current value without being re-created (and thus not re-triggering the
-    // open-effect that hydrates state).
-    const enableFusionRef = useRef(enableFusion);
-    useEffect(() => {
-        enableFusionRef.current = enableFusion;
-    }, [enableFusion]);
 
     const openAICapabilities = useMemo(
         () => detectOpenAICapabilities(selectedProvider),
@@ -262,11 +251,7 @@ const ProviderFormDialog = ({
                     anthropic: provider.baseUrlAnthropic,
                 });
 
-                // Fusion-mode is only available when the global experiment is
-                // on. With the flag OFF, picking both protocols falls through
-                // to the legacy two-record split handled by the parent submit.
-                const fusion = enableFusionRef.current
-                    && createFusionProvider
+                const fusion = createFusionProvider
                     && nextOpenAI && nextAnthropic
                     && !!provider.baseUrlOpenAI && !!provider.baseUrlAnthropic;
 
@@ -525,14 +510,14 @@ const ProviderFormDialog = ({
     };
 
     const hasAnyProtocol = protocolOpenAI || protocolAnthropic;
-    const showFusionToggle = enableFusion && mode === 'add' && protocolOpenAI && protocolAnthropic;
+    const showFusionToggle = mode === 'add' && protocolOpenAI && protocolAnthropic;
 
     // When both protocols are checked on a template that exposes two base URLs,
     // the outcome ("merge into one" vs "create two") is otherwise invisible.
     // Surface it as a one-line hint that tracks the fusion toggle.
     const hasBothBaseUrls = !!selectedProvider?.baseUrlOpenAI && !!selectedProvider?.baseUrlAnthropic;
     const showTopologyHint = mode === 'add' && protocolOpenAI && protocolAnthropic && hasBothBaseUrls;
-    const willMergeBaseUrls = enableFusion && createFusionProvider;
+    const willMergeBaseUrls = createFusionProvider;
 
     return (
         <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -107,6 +107,12 @@ const ProviderFormDialog = ({
     const [createFusionProvider, setCreateFusionProvider] = useState(false);
     const [advancedOpen, setAdvancedOpen] = useState(false);
     const [baseUrlError, setBaseUrlError] = useState(false);
+    // Whether the provider being edited already has both fusion URLs stored.
+    const [isExistingFusion, setIsExistingFusion] = useState(false);
+    // Snapshot of fusion URLs captured on dialog open, used for downgrade/revert.
+    const initialFusionRef = useRef<{ openAI: string; anthropic: string; apiBase: string; apiStyle: string }>({
+        openAI: '', anthropic: '', apiBase: '', apiStyle: 'openai',
+    });
 
     const allProviders = useProviderTemplates();
 
@@ -173,6 +179,16 @@ const ProviderFormDialog = ({
             // is already enabled, regardless of the legacy apiStyle pin.
             const hasFusionOpenAI = !!data.apiBaseOpenAI;
             const hasFusionAnthropic = !!data.apiBaseAnthropic;
+            const existingFusion = hasFusionOpenAI && hasFusionAnthropic;
+            setIsExistingFusion(existingFusion);
+            // Snapshot for downgrade/revert operations.
+            initialFusionRef.current = {
+                openAI: data.apiBaseOpenAI || '',
+                anthropic: data.apiBaseAnthropic || '',
+                apiBase: data.apiBase,
+                apiStyle: data.apiStyle || 'openai',
+            };
+            setCreateFusionProvider(false);
             setProtocolOpenAI(hasFusionOpenAI || data.apiStyle === 'openai');
             setProtocolAnthropic(hasFusionAnthropic || data.apiStyle === 'anthropic');
             setSelectedProvider(matchingProvider);
@@ -195,6 +211,8 @@ const ProviderFormDialog = ({
                 setProtocolOpenAI(false);
                 setProtocolAnthropic(false);
             }
+            setIsExistingFusion(false);
+            setCreateFusionProvider(false);
             // If the parent prefilled apiBase to a known provider (onboarding
             // browse / paste-detect), seed the Autocomplete with it so users
             // see the picked provider rather than a blank field.
@@ -293,26 +311,60 @@ const ProviderFormDialog = ({
         }
     };
 
-    // OAuth-bound providers are issuer-locked to a single protocol; fusion
-    // is api_key only.
+    // OAuth-bound providers are issuer-locked to a single protocol.
+    // In edit mode, non-fusion providers are also locked — protocol changes
+    // require upgrading to fusion (via the fusion toggle) or creating a new entry.
     const fusionLocked = data.authType === 'oauth';
+    const protocolLocked = mode === 'edit' && !isExistingFusion;
+    const effectiveLocked = fusionLocked || protocolLocked;
+
+    // For an existing fusion provider being edited: deselecting one side
+    // downgrades it to a single-protocol provider.
+    const handleFusionDowngrade = (nextOpenAI: boolean, nextAnthropic: boolean) => {
+        const cb = onChangeRef.current;
+        const snap = initialFusionRef.current;
+        if (nextOpenAI && !nextAnthropic) {
+            cb('apiBase', snap.openAI || snap.apiBase);
+            cb('apiStyle', 'openai');
+            cb('apiBaseOpenAI', '');
+            cb('apiBaseAnthropic', '');
+        } else if (!nextOpenAI && nextAnthropic) {
+            cb('apiBase', snap.anthropic);
+            cb('apiStyle', 'anthropic');
+            cb('apiBaseOpenAI', '');
+            cb('apiBaseAnthropic', '');
+        }
+        // Disallowing both-false: ignore the toggle if it would leave no protocol.
+    };
 
     const toggleOpenAIProtocol = () => {
-        if (fusionLocked) return;
+        if (effectiveLocked) return;
         if (selectedProvider && !selectedProvider.supportsOpenAI) return;
         const next = !protocolOpenAI;
+        // Prevent deselecting the last protocol on a fusion provider.
+        if (isExistingFusion && !next && !protocolAnthropic) return;
         setProtocolOpenAI(next);
         setVerificationResult(null);
-        syncProtocolsToParent(next, protocolAnthropic, selectedProvider);
+        if (isExistingFusion) {
+            handleFusionDowngrade(next, protocolAnthropic);
+        } else {
+            syncProtocolsToParent(next, protocolAnthropic, selectedProvider);
+        }
     };
 
     const toggleAnthropicProtocol = () => {
-        if (fusionLocked) return;
+        if (effectiveLocked) return;
         if (selectedProvider && !selectedProvider.supportsAnthropic) return;
         const next = !protocolAnthropic;
+        // Prevent deselecting the last protocol on a fusion provider.
+        if (isExistingFusion && !next && !protocolOpenAI) return;
         setProtocolAnthropic(next);
         setVerificationResult(null);
-        syncProtocolsToParent(protocolOpenAI, next, selectedProvider);
+        if (isExistingFusion) {
+            handleFusionDowngrade(protocolOpenAI, next);
+        } else {
+            syncProtocolsToParent(protocolOpenAI, next, selectedProvider);
+        }
     };
 
     const handleProviderSelect = (newValue: string | UniqueProvider | null) => {
@@ -510,13 +562,17 @@ const ProviderFormDialog = ({
     };
 
     const hasAnyProtocol = protocolOpenAI || protocolAnthropic;
-    const showFusionToggle = mode === 'add' && protocolOpenAI && protocolAnthropic;
 
     // When both protocols are checked on a template that exposes two base URLs,
     // the outcome ("merge into one" vs "create two") is otherwise invisible.
     // Surface it as a one-line hint that tracks the fusion toggle.
     const hasBothBaseUrls = !!selectedProvider?.baseUrlOpenAI && !!selectedProvider?.baseUrlAnthropic;
-    const showTopologyHint = mode === 'add' && protocolOpenAI && protocolAnthropic && hasBothBaseUrls;
+    // add mode: shown when both protocols are selected
+    // edit mode: shown for non-fusion providers when the template supports both sides (upgrade path)
+    const showFusionToggle = mode === 'add'
+        ? (protocolOpenAI && protocolAnthropic)
+        : (!isExistingFusion && hasBothBaseUrls);
+    const showTopologyHint = protocolOpenAI && protocolAnthropic && hasBothBaseUrls;
     const willMergeBaseUrls = createFusionProvider;
 
     return (
@@ -578,7 +634,7 @@ const ProviderFormDialog = ({
                             selectedProvider={selectedProvider}
                             protocolOpenAI={protocolOpenAI}
                             protocolAnthropic={protocolAnthropic}
-                            fusionLocked={fusionLocked}
+                            fusionLocked={effectiveLocked}
                             openAICapabilities={openAICapabilities}
                             onToggleOpenAI={toggleOpenAIProtocol}
                             onToggleAnthropic={toggleAnthropicProtocol}
@@ -590,7 +646,28 @@ const ProviderFormDialog = ({
                                 onChange={(checked) => {
                                     setCreateFusionProvider(checked);
                                     onChange('createFusionProvider', checked);
-                                    syncProtocolsToParent(protocolOpenAI, protocolAnthropic, selectedProvider);
+                                    if (mode === 'edit' && selectedProvider) {
+                                        if (checked) {
+                                            // Upgrade: auto-select both protocols and populate URLs from template.
+                                            setProtocolOpenAI(true);
+                                            setProtocolAnthropic(true);
+                                            onChange('apiBaseOpenAI', selectedProvider.baseUrlOpenAI || '');
+                                            onChange('apiBaseAnthropic', selectedProvider.baseUrlAnthropic || '');
+                                            onChange('apiBase', selectedProvider.baseUrlOpenAI || data.apiBase);
+                                            onChange('apiStyle', 'openai');
+                                        } else {
+                                            // Revert: restore original single-protocol state.
+                                            const snap = initialFusionRef.current;
+                                            setProtocolOpenAI(snap.apiStyle === 'openai');
+                                            setProtocolAnthropic(snap.apiStyle === 'anthropic');
+                                            onChange('apiBaseOpenAI', '');
+                                            onChange('apiBaseAnthropic', '');
+                                            onChange('apiBase', snap.apiBase);
+                                            onChange('apiStyle', snap.apiStyle as 'openai' | 'anthropic');
+                                        }
+                                    } else {
+                                        syncProtocolsToParent(protocolOpenAI, protocolAnthropic, selectedProvider);
+                                    }
                                     setVerificationResult(null);
                                 }}
                             />

--- a/frontend/src/contexts/FeatureFlagsContext.tsx
+++ b/frontend/src/contexts/FeatureFlagsContext.tsx
@@ -8,7 +8,6 @@ interface FeatureFlagsContextType {
     skillIde: boolean;
     enableGuardrails: boolean;
     enableMCP: boolean;
-    enableFusion: boolean;
     loading: boolean;
     refresh: () => void;
 }
@@ -33,23 +32,20 @@ export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({ chil
     const [skillIde, setSkillIde] = useState(false);
     const [enableGuardrails, setEnableGuardrails] = useState(false);
     const [enableMCP, setEnableMCP] = useState(false);
-    const [enableFusion, setEnableFusion] = useState(false);
     const [loading, setLoading] = useState(true);
 
     const loadFlags = async () => {
         try {
-            const [skillUserResult, skillIdeResult, guardrailsResult, mcpResult, fusionResult] = await Promise.all([
+            const [skillUserResult, skillIdeResult, guardrailsResult, mcpResult] = await Promise.all([
                 api.getScenarioFlag('_global', 'skill_user'),
                 api.getScenarioFlag('_global', 'skill_ide'),
                 api.getScenarioFlag('_global', 'guardrails'),
                 api.getScenarioFlag('_global', 'mcp'),
-                api.getScenarioFlag('_global', 'fusion_provider'),
             ]);
             setSkillUser(skillUserResult?.data?.value || false);
             setSkillIde(skillIdeResult?.data?.value || false);
             setEnableGuardrails(guardrailsResult?.data?.value || false);
             setEnableMCP(mcpResult?.data?.value || false);
-            setEnableFusion(fusionResult?.data?.value || false);
         } catch (error) {
             // Silently fail - flags will default to false
             // Don't log to console to avoid noise during initial auth
@@ -71,7 +67,7 @@ export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({ chil
     };
 
     return (
-        <FeatureFlagsContext.Provider value={{ skillUser, skillIde, enableGuardrails, enableMCP, enableFusion, loading, refresh }}>
+        <FeatureFlagsContext.Provider value={{ skillUser, skillIde, enableGuardrails, enableMCP, loading, refresh }}>
             {children}
         </FeatureFlagsContext.Provider>
     );

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -496,18 +496,15 @@ export default {
       "skills": "Skills",
       "guardrails": "Guardrails",
       "mcp": "MCP",
-      "fusion": "Fusion Provider",
       "enableIdeSkills": "Enable IDE Skills feature for managing code snippets and skills from IDEs",
       "enableGuardrails": "Enable Guardrails - block risky tool calls and filter sensitive outputs",
       "enableMCP": "Enable MCP Tools - Configure MCP (Model Context Protocol) tools like web search and web fetch",
-      "enableFusion": "Allow a single provider entry to expose both OpenAI- and Anthropic-compatible base URLs. Inbound requests route natively to the matching protocol with no transform.",
       "on": "On",
       "off": "Off",
       "enabled": "enabled",
       "disabled": "disabled - Click to enable",
       "guardrailsEnabledInfo": "Guardrails is enabled. A \"Guardrails\" page is available in the sidebar for rule management.",
-      "mcpEnabledInfo": "MCP Tools is enabled. An \"MCP Tools\" page is available under System in the sidebar for configuration.",
-      "fusionEnabledInfo": "Fusion Provider is enabled. The provider form now lets you configure OpenAI and Anthropic URLs on a single entry."
+      "mcpEnabledInfo": "MCP Tools is enabled. An \"MCP Tools\" page is available under System in the sidebar for configuration."
     },
     "about": {
       "title": "About",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -497,18 +497,15 @@ export default {
       "skills": "Skills",
       "guardrails": "Guardrails",
       "mcp": "MCP",
-      "fusion": "融合 Provider",
       "enableIdeSkills": "启用 IDE Skills 功能，用于管理来自 IDE 的代码片段和技能",
       "enableGuardrails": "启用 Guardrails - 阻止有风险的工具调用并过滤敏感输出",
       "enableMCP": "启用 MCP Tools - 配置 MCP（Model Context Protocol）工具，如网页搜索和网页获取",
-      "enableFusion": "允许单个 Provider 条目同时暴露 OpenAI 和 Anthropic 兼容的 base URL，入站请求按协议原生路由，无需协议转换。",
       "on": "On",
       "off": "Off",
       "enabled": "已启用",
       "disabled": "已禁用 - 点击启用",
       "guardrailsEnabledInfo": "Guardrails 已启用。侧边栏中提供了「Guardrails」页面用于规则管理。",
-      "mcpEnabledInfo": "MCP Tools 已启用。侧边栏 System 下方提供了「MCP Tools」页面进行配置。",
-      "fusionEnabledInfo": "融合 Provider 已启用。Provider 表单现在允许在同一条目中配置 OpenAI 与 Anthropic 的 URL。"
+      "mcpEnabledInfo": "MCP Tools 已启用。侧边栏 System 下方提供了「MCP Tools」页面进行配置。"
     },
     "about": {
       "title": "关于",

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -20,7 +20,6 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { api } from '../services/api';
-import { useFeatureFlags } from '@/contexts/FeatureFlagsContext';
 import { useNotify } from '@/hooks/useNotify';
 
 type ProviderFormData = EnhancedProviderFormData;
@@ -34,7 +33,6 @@ interface OAuthEditFormData {
 }
 
 const CredentialPage = () => {
-    const { enableFusion } = useFeatureFlags();
     const [searchParams, setSearchParams] = useSearchParams();
     const [providers, setProviders] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -202,14 +200,10 @@ const CredentialPage = () => {
         setLoading(false);
     };
 
-    // Build the body for an add request. The shape depends on the global
-    // fusion experiment:
-    //
-    // - Flag ON + BOTH protocols + both base URLs available → single
-    //   fusion-mode provider (one entry, two URLs, one credential).
-    // - Flag OFF + BOTH protocols → return an ARRAY of two single-protocol
-    //   payloads, restoring the legacy "create two providers" behavior.
-    // - Single protocol selected → single provider payload (unchanged).
+    // Build the body for an add request:
+    // - BOTH protocols + both base URLs + fusion toggle ON → single fusion-mode provider.
+    // - BOTH protocols + fusion toggle OFF → two separate single-protocol payloads.
+    // - Single protocol selected → single provider payload.
     const buildAddProviderPayload = (override?: Partial<ProviderFormData>): any | any[] => {
         // Merge dialog-resolved fields (e.g. free-typed apiBase / auto name)
         // over the form state; those land via async onChange and may not be in
@@ -226,7 +220,7 @@ const CredentialPage = () => {
             protocols.length === 2 &&
             !!providerBaseUrls?.openai &&
             !!providerBaseUrls?.anthropic;
-        const shouldCreateFusion = enableFusion && !!(fd as any).createFusionProvider;
+        const shouldCreateFusion = !!(fd as any).createFusionProvider;
 
         if (bothProtocols && shouldCreateFusion) {
             return {
@@ -286,12 +280,9 @@ const CredentialPage = () => {
         };
     };
 
-    // Build the body for an edit/update request. When fusion is OFF, omit
-    // the fusion fields entirely so the backend (which ignores them under
-    // flag-off anyway) doesn't get spurious empty-string pointers.
     const buildEditProviderPayload = (override?: Partial<ProviderFormData>) => {
         const fd: any = { ...providerFormData, ...(override || {}) };
-        const base: any = {
+        return {
             name: fd.name,
             api_base: fd.apiBase,
             api_style: fd.apiStyle,
@@ -300,12 +291,9 @@ const CredentialPage = () => {
             enabled: fd.enabled,
             proxy_url: (fd as any).proxyUrl ?? '',
             user_agent: (fd as any).userAgent ?? '',
+            api_base_openai: (fd as any).apiBaseOpenAI ?? '',
+            api_base_anthropic: (fd as any).apiBaseAnthropic ?? '',
         };
-        if (enableFusion) {
-            base.api_base_openai = (fd as any).apiBaseOpenAI ?? '';
-            base.api_base_anthropic = (fd as any).apiBaseAnthropic ?? '';
-        }
-        return base;
     };
 
     // Submit a single payload OR an array of payloads (legacy split). Returns

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1571,11 +1571,6 @@ func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) boo
 			return val
 		}
 		return false
-	case FeatureFusionProvider:
-		if val, ok := config.Extensions[FeatureFusionProvider].(bool); ok {
-			return val
-		}
-		return false
 	default:
 		return false
 	}
@@ -1642,11 +1637,6 @@ func (c *Config) SetScenarioFlag(scenario typ.RuleScenario, flagName string, val
 			config.Extensions = make(map[string]interface{})
 		}
 		config.Extensions["mcp"] = value
-	case FeatureFusionProvider:
-		if config.Extensions == nil {
-			config.Extensions = make(map[string]interface{})
-		}
-		config.Extensions[FeatureFusionProvider] = value
 	default:
 		return fmt.Errorf("unknown flag name: %s", flagName)
 	}

--- a/internal/server/config/flag.go
+++ b/internal/server/config/flag.go
@@ -2,6 +2,5 @@ package config
 
 // Experimental feature flag names
 const (
-	FeatureSmartCompact   = "smart_compact"
-	FeatureFusionProvider = "fusion_provider"
+	FeatureSmartCompact = "smart_compact"
 )

--- a/internal/server/experimental.go
+++ b/internal/server/experimental.go
@@ -5,6 +5,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+
 // ApplySmartCompact checks if smart_compact should be applied for a scenario
 func (s *Server) ApplySmartCompact(scenario typ.RuleScenario) bool {
 	return s.config.GetScenarioFlag(scenario, config.FeatureSmartCompact)
@@ -16,11 +17,3 @@ func (s *Server) ApplyRecording(scenario typ.RuleScenario) bool {
 	return s.config.IsScenarioRecordingEnabled(scenario)
 }
 
-// IsFusionEnabled reports whether the global fusion-provider experiment is on.
-// Fusion mode lets a single Provider entry expose both OpenAI- and
-// Anthropic-compatible base URLs; when this flag is off, fusion fields on
-// Provider records are inert and dispatch falls back to the legacy
-// APIBase/APIStyle pair.
-func (s *Server) IsFusionEnabled() bool {
-	return s.config.GetScenarioFlag(typ.ScenarioGlobal, config.FeatureFusionProvider)
-}

--- a/internal/server/fusion.go
+++ b/internal/server/fusion.go
@@ -17,19 +17,12 @@ import (
 // APIBase/APIStyle pair is preserved so single-protocol providers behave
 // exactly as before.
 //
-// When the global fusion-provider experiment flag is OFF, the original
-// provider is returned unchanged — fusion fields are inert at dispatch time
-// and existing single-protocol behavior is preserved bit-for-bit.
-//
 // Downstream HTTP clients and protocol-transform code read APIBase and
 // APIStyle off of the provider; returning a shallow copy keeps that contract
 // without requiring changes to every client constructor.
 func (s *Server) resolveProviderForClient(p *typ.Provider, clientStyle protocol.APIStyle) *typ.Provider {
 	if p == nil {
 		return nil
-	}
-	if !s.IsFusionEnabled() {
-		return p
 	}
 	baseURL, style := p.ResolveEndpoint(clientStyle)
 	if baseURL == p.APIBase && style == p.APIStyle {

--- a/internal/server/provider_handler.go
+++ b/internal/server/provider_handler.go
@@ -120,18 +120,8 @@ func (s *Server) CreateProvider(c *gin.Context) {
 	}
 
 	// Fusion-mode constraints: optional dual base URLs are only valid for
-	// api_key auth, and Google-style providers cannot opt in. The global
-	// fusion experiment must also be enabled — when off, fusion fields on
-	// new records are rejected so users cannot accidentally opt in until
-	// they explicitly turn on the experiment.
+	// api_key auth, and Google-style providers cannot opt in.
 	if req.APIBaseOpenAI != "" || req.APIBaseAnthropic != "" {
-		if !s.IsFusionEnabled() {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"success": false,
-				"error":   "Fusion provider mode is disabled. Enable it under System → Experimental Features, or save the OpenAI and Anthropic providers separately.",
-			})
-			return
-		}
 		if req.AuthType != string(typ.AuthTypeAPIKey) {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"success": false,
@@ -322,17 +312,11 @@ func (s *Server) UpdateProvider(c *gin.Context) {
 	if req.APIStyle != nil {
 		provider.APIStyle = protocol.APIStyle(*req.APIStyle)
 	}
-	// Apply fusion-field updates only when the global fusion experiment is on.
-	// When off, incoming fusion pointers are ignored — existing stored values
-	// are preserved (so flipping the flag back on reactivates them) and no
-	// new fusion data can be introduced via the update path.
-	if s.IsFusionEnabled() {
-		if req.APIBaseOpenAI != nil {
-			provider.APIBaseOpenAI = *req.APIBaseOpenAI
-		}
-		if req.APIBaseAnthropic != nil {
-			provider.APIBaseAnthropic = *req.APIBaseAnthropic
-		}
+	if req.APIBaseOpenAI != nil {
+		provider.APIBaseOpenAI = *req.APIBaseOpenAI
+	}
+	if req.APIBaseAnthropic != nil {
+		provider.APIBaseAnthropic = *req.APIBaseAnthropic
 	}
 	// Only update token if it's provided and not empty
 	if req.Token != nil && *req.Token != "" {


### PR DESCRIPTION
## Summary

Fusion Provider mode is now a first-class, always-on feature. This PR removes the `fusion_provider` experiment flag entirely and adds proper edit-mode semantics for fusion providers.

- Remove all feature-flag infrastructure for `fusion_provider` (backend + frontend)
- Fix provider edit flow: protocol lock, fusion upgrade, and fusion downgrade
- Add `.design/fusion-provider.md` design document

## Changes

### 1 — Remove experiment flag

**Backend**
- `config/flag.go` — remove `FeatureFusionProvider` constant
- `config/config.go` — remove `fusion_provider` cases from `GetScenarioFlag` / `SetScenarioFlag`
- `experimental.go` — remove `IsFusionEnabled()` method
- `fusion.go` — remove `!IsFusionEnabled()` early-return; `resolveProviderForClient` is now unconditional
- `provider_handler.go` — remove flag gate in `CreateProvider` (the "disabled" error) and the conditional block in `UpdateProvider`

**Frontend**
- `FeatureFlagsContext` — drop `enableFusion` from context type, state, and API call
- `GlobalExperimentalFeatures` — remove Fusion Provider toggle section
- `ProviderFormDialog` — remove `enableFusion` / `enableFusionRef` guards
- `CredentialPage` — `shouldCreateFusion` now depends only on the per-form toggle; fusion fields always sent in edit payloads
- `en.ts` / `zh.ts` — remove experimental-feature strings (`fusion`, `enableFusion`, `fusionEnabledInfo`); providerDialog fusion strings retained

### 2 — Edit-mode protocol / fusion rules

Three rules now enforced when editing a provider:

**Rule 1 — Protocol lock (non-fusion providers)**
The protocol checkboxes are disabled for non-fusion providers in edit mode. To change protocol, the user creates a new entry. Implemented via `protocolLocked = mode === 'edit' && !isExistingFusion`, combined into `effectiveLocked` passed to `ProtocolSelector`.

**Rule 2 — Fusion upgrade via toggle**
When the matched template supports both OpenAI and Anthropic URLs, the Fusion mode toggle appears in edit mode for non-fusion providers. Enabling it auto-selects both protocols and populates both URLs from the template. Disabling it reverts to the original single-protocol state using a snapshot (`initialFusionRef`) captured when the dialog opens.

**Rule 3 — Fusion downgrade**
Editing a fusion provider allows deselecting one protocol. Doing so clears both fusion URL fields and sets `APIBase`/`APIStyle` to the remaining side. The last protocol cannot be deselected. URL values are read from the snapshot to avoid async-state races.

### 3 — Design documentation

- `.design/fusion-provider.md` — new doc covering data model, dispatch logic, add flow, edit flow (three rules), state/implementation index, and key files
- `.design/connect-provider-flow.md` — link to fusion doc from API Style description
- `ai/README.md` — cross-reference pointer from fusion field mention

## Test plan

- [ ] Add a dual-protocol provider with Fusion mode ON → single entry with both URLs stored
- [ ] Add a dual-protocol provider with Fusion mode OFF → two separate entries created
- [ ] Edit a non-fusion provider → protocol checkboxes are disabled
- [ ] Edit a non-fusion provider with a dual-URL template → Fusion toggle appears; enabling it auto-selects both protocols and populates both URLs
- [ ] Enable then disable fusion toggle in edit → reverts to original single-protocol state
- [ ] Edit a fusion provider → deselect one protocol → provider saved as single-protocol, fusion URLs cleared
- [ ] Edit a fusion provider → attempt to deselect both protocols → last checkbox cannot be unchecked
- [ ] Verify `System → Experimental Features` no longer shows a Fusion Provider toggle

https://claude.ai/code/session_012jAAk4MjRPBhGDLzvwNPMN