### PR TITLE
refactor(logs): improve logging system UX with AI/System split

### DIFF
--- a/Taskfile.curl.yml
+++ b/Taskfile.curl.yml
@@ -436,14 +436,14 @@ tasks:
   smart-rule:
     cmds:
       - |
-        curl -X POST http://localhost:12580/tingly/anthropic/v1/chat/completions \
+        curl -X POST http://localhost:12580/tingly/openai/v1/chat/completions \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer {{.TINGLY_BOX_KEY}}" \
         -d '{
-          "model": "smart",
+          "model": "tingly-smart",
           "messages": [
             {"role":"system","content":"You are a professional language assistant."},
-            {"role": "user", "content": "who are you?"}
+            {"role": "user", "content": "@@@ who are you?"}
           ]
         }'
   

--- a/frontend/src/components/LogExplorer.tsx
+++ b/frontend/src/components/LogExplorer.tsx
@@ -8,17 +8,16 @@ import RequestsViewer, {
 } from '@/components/RequestsViewer';
 
 interface LogExplorerProps {
-    // When set, the Requests tab is pre-filtered and locked to this scenario.
-    // System logs are global (not scenario-scoped), so the System tab is
-    // unaffected — both surfaces stay structurally identical.
-    lockedScenario?: string;
+    // When set, the scenario filter is initialized to this value but can be changed/cleared by the user.
+    // Used by the per-scenario quick-open dialog to provide context without locking the view.
+    initialScenario?: string;
 }
 
 const getAuthHeader = () => ({
     Authorization: `Bearer ${localStorage.getItem('user_auth_token') || ''}`,
 });
 
-const LogExplorer = ({ lockedScenario }: LogExplorerProps) => {
+const LogExplorer = ({ initialScenario }: LogExplorerProps) => {
     const [tab, setTab] = useState(0);
 
     const getRequests = useCallback(async (params?: RequestFilters) => {
@@ -70,7 +69,7 @@ const LogExplorer = ({ lockedScenario }: LogExplorerProps) => {
     return (
         <Stack sx={{ height: '100%', minHeight: 0 }} spacing={0}>
             <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
-                <Tab label="Requests" />
+                <Tab label="AI Logs" />
                 <Tab label="System Logs" />
             </Tabs>
 
@@ -78,7 +77,7 @@ const LogExplorer = ({ lockedScenario }: LogExplorerProps) => {
                 <RequestsViewer
                     getRequests={getRequests}
                     getRequestDetail={getRequestDetail}
-                    lockedScenario={lockedScenario}
+                    initialScenario={initialScenario}
                 />
             </Box>
             <Box sx={{ flex: 1, minHeight: 0, display: tab === 1 ? 'flex' : 'none', flexDirection: 'column' }}>

--- a/frontend/src/components/RequestsViewer.tsx
+++ b/frontend/src/components/RequestsViewer.tsx
@@ -60,9 +60,9 @@ export interface RequestFilters {
 interface RequestsViewerProps {
     getRequests: (params?: RequestFilters) => Promise<{ total: number; requests: ModelRequestSummary[] }>;
     getRequestDetail: (id: string) => Promise<ModelRequestDetail | null>;
-    // When set, the scenario filter is fixed to this value and its input is
-    // hidden (used by the per-scenario quick-open dialog).
-    lockedScenario?: string;
+    // When set, the scenario filter is initialized to this value but can be changed/cleared.
+    // Used by the per-scenario quick-open dialog to provide context without locking the view.
+    initialScenario?: string;
 }
 
 const statusColor = (status?: number): 'default' | 'success' | 'warning' | 'error' => {
@@ -128,19 +128,27 @@ const SUPPRESSED_FIELDS = new Set([
     'request',
 ]);
 
-const RequestsViewer = ({ getRequests, getRequestDetail, lockedScenario }: RequestsViewerProps) => {
+const RequestsViewer = ({ getRequests, getRequestDetail, initialScenario }: RequestsViewerProps) => {
     const [requests, setRequests] = useState<ModelRequestSummary[]>([]);
     const [loading, setLoading] = useState(false);
     const [autoRefresh, setAutoRefresh] = useState(false);
     const [expandedId, setExpandedId] = useState<string | null>(null);
     const [details, setDetails] = useState<Record<string, ModelRequestDetail>>({});
     const [error, setError] = useState<string | null>(null);
-    const [scenario, setScenario] = useState('');
+    // Initialize scenario filter from initialScenario prop on mount
+    const [scenario, setScenario] = useState(initialScenario ?? '');
     const [provider, setProvider] = useState('');
     const [status, setStatus] = useState('');
     const tableContainerRef = useRef<HTMLDivElement>(null);
     // Whether the user is pinned to the bottom; controls live-tail auto-scroll.
     const atBottomRef = useRef(true);
+
+    // Initialize scenario from initialScenario when prop changes
+    useEffect(() => {
+        if (initialScenario !== undefined) {
+            setScenario(initialScenario);
+        }
+    }, [initialScenario]);
 
     const loadRequests = async () => {
         setLoading(true);
@@ -148,7 +156,7 @@ const RequestsViewer = ({ getRequests, getRequestDetail, lockedScenario }: Reque
         try {
             const response = await getRequests({
                 limit: 200,
-                scenario: lockedScenario ?? (scenario || undefined),
+                scenario: scenario || undefined,
                 provider: provider || undefined,
                 status: status || undefined,
             });
@@ -169,7 +177,7 @@ const RequestsViewer = ({ getRequests, getRequestDetail, lockedScenario }: Reque
     useEffect(() => {
         loadRequests();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scenario, provider, status, lockedScenario]);
+    }, [scenario, provider, status]);
 
     useEffect(() => {
         if (autoRefresh) {
@@ -177,7 +185,7 @@ const RequestsViewer = ({ getRequests, getRequestDetail, lockedScenario }: Reque
             return () => clearInterval(id);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [autoRefresh, scenario, provider, status, lockedScenario]);
+    }, [autoRefresh, scenario, provider, status]);
 
     // Live-tail: only auto-scroll to the newest row when the user is already
     // pinned at the bottom, so polling doesn't yank them away from a row
@@ -355,15 +363,13 @@ const RequestsViewer = ({ getRequests, getRequestDetail, lockedScenario }: Reque
                     </Typography>
                 </Stack>
                 <Stack direction="row" spacing={1} alignItems="center">
-                    {!lockedScenario && (
-                        <TextField
-                            size="small"
-                            label="Scenario"
-                            value={scenario}
-                            onChange={(e) => setScenario(e.target.value.trim())}
-                            sx={{ width: 130 }}
-                        />
-                    )}
+                    <TextField
+                        size="small"
+                        label="Scenario"
+                        value={scenario}
+                        onChange={(e) => setScenario(e.target.value.trim())}
+                        sx={{ width: 130 }}
+                    />
                     <TextField
                         size="small"
                         label="Provider"
@@ -378,6 +384,16 @@ const RequestsViewer = ({ getRequests, getRequestDetail, lockedScenario }: Reque
                         onChange={(e) => setStatus(e.target.value.trim())}
                         sx={{ width: 90 }}
                     />
+                    {(scenario || provider || status) && (
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={() => { setScenario(''); setProvider(''); setStatus(''); }}
+                            sx={{ fontSize: '0.7rem', py: 0.5, px: 1 }}
+                        >
+                            Clear
+                        </Button>
+                    )}
                 </Stack>
                 <Box sx={{ flex: 1 }} />
                 <Typography variant="caption" color="text.secondary">

--- a/frontend/src/components/RuleLogDialog.tsx
+++ b/frontend/src/components/RuleLogDialog.tsx
@@ -16,7 +16,7 @@ interface ScenarioLogDialogProps {
     scenario: string;
 }
 
-const ScenarioLogDialog = ({ open, onClose, scenario }: ScenarioLogDialogProps) => {
+const ScenarioLogDialog = ({ open, onClose, scenario, initialScenario }: ScenarioLogDialogProps) => {
     return (
         <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth PaperProps={{ sx: { height: '80vh' } }}>
             <DialogTitle sx={{ pb: 1 }}>
@@ -32,7 +32,7 @@ const ScenarioLogDialog = ({ open, onClose, scenario }: ScenarioLogDialogProps) 
             </DialogTitle>
 
             <DialogContent sx={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', pt: 1.5 }}>
-                <LogExplorer lockedScenario={scenario} />
+                <LogExplorer initialScenario={scenario} />
             </DialogContent>
         </Dialog>
     );

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -255,52 +255,52 @@ func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) bool {
 	if item.OfReasoning != nil {
 		item.OfReasoning.ID = strings.TrimSpace(item.OfReasoning.ID)
 		if item.OfReasoning.ID == "" || !isValidCodexID(item.OfReasoning.ID) {
-			logrus.Warnf("[Codex] Dropping reasoning input item with invalid id: %q", item.OfReasoning.ID)
+			logrus.Debugf("[Codex] Dropping reasoning input item with invalid id: %q", item.OfReasoning.ID)
 			return false
 		}
 	}
 	if item.OfFileSearchCall != nil && !isValidCodexIDStrict(item.OfFileSearchCall.ID) {
-		logrus.Warnf("[Codex] Dropping file_search_call input item with invalid id: %q", item.OfFileSearchCall.ID)
+		logrus.Debugf("[Codex] Dropping file_search_call input item with invalid id: %q", item.OfFileSearchCall.ID)
 		return false
 	}
 	if item.OfComputerCall != nil && !isValidCodexIDStrict(item.OfComputerCall.ID) {
-		logrus.Warnf("[Codex] Dropping computer_call input item with invalid id: %q", item.OfComputerCall.ID)
+		logrus.Debugf("[Codex] Dropping computer_call input item with invalid id: %q", item.OfComputerCall.ID)
 		return false
 	}
 	if item.OfWebSearchCall != nil && !isValidCodexIDStrict(item.OfWebSearchCall.ID) {
-		logrus.Warnf("[Codex] Dropping web_search_call input item with invalid id: %q", item.OfWebSearchCall.ID)
+		logrus.Debugf("[Codex] Dropping web_search_call input item with invalid id: %q", item.OfWebSearchCall.ID)
 		return false
 	}
 	if item.OfImageGenerationCall != nil && !isValidCodexIDStrict(item.OfImageGenerationCall.ID) {
-		logrus.Warnf("[Codex] Dropping image_generation_call input item with invalid id: %q", item.OfImageGenerationCall.ID)
+		logrus.Debugf("[Codex] Dropping image_generation_call input item with invalid id: %q", item.OfImageGenerationCall.ID)
 		return false
 	}
 	if item.OfCodeInterpreterCall != nil && !isValidCodexIDStrict(item.OfCodeInterpreterCall.ID) {
-		logrus.Warnf("[Codex] Dropping code_interpreter_call input item with invalid id: %q", item.OfCodeInterpreterCall.ID)
+		logrus.Debugf("[Codex] Dropping code_interpreter_call input item with invalid id: %q", item.OfCodeInterpreterCall.ID)
 		return false
 	}
 	if item.OfLocalShellCall != nil && !isValidCodexIDStrict(item.OfLocalShellCall.ID) {
-		logrus.Warnf("[Codex] Dropping local_shell_call input item with invalid id: %q", item.OfLocalShellCall.ID)
+		logrus.Debugf("[Codex] Dropping local_shell_call input item with invalid id: %q", item.OfLocalShellCall.ID)
 		return false
 	}
 	if item.OfLocalShellCallOutput != nil && !isValidCodexIDStrict(item.OfLocalShellCallOutput.ID) {
-		logrus.Warnf("[Codex] Dropping local_shell_call_output input item with invalid id: %q", item.OfLocalShellCallOutput.ID)
+		logrus.Debugf("[Codex] Dropping local_shell_call_output input item with invalid id: %q", item.OfLocalShellCallOutput.ID)
 		return false
 	}
 	if item.OfMcpListTools != nil && !isValidCodexIDStrict(item.OfMcpListTools.ID) {
-		logrus.Warnf("[Codex] Dropping mcp_list_tools input item with invalid id: %q", item.OfMcpListTools.ID)
+		logrus.Debugf("[Codex] Dropping mcp_list_tools input item with invalid id: %q", item.OfMcpListTools.ID)
 		return false
 	}
 	if item.OfMcpApprovalRequest != nil && !isValidCodexIDStrict(item.OfMcpApprovalRequest.ID) {
-		logrus.Warnf("[Codex] Dropping mcp_approval_request input item with invalid id: %q", item.OfMcpApprovalRequest.ID)
+		logrus.Debugf("[Codex] Dropping mcp_approval_request input item with invalid id: %q", item.OfMcpApprovalRequest.ID)
 		return false
 	}
 	if item.OfMcpCall != nil && !isValidCodexIDStrict(item.OfMcpCall.ID) {
-		logrus.Warnf("[Codex] Dropping mcp_call input item with invalid id: %q", item.OfMcpCall.ID)
+		logrus.Debugf("[Codex] Dropping mcp_call input item with invalid id: %q", item.OfMcpCall.ID)
 		return false
 	}
 	if item.OfItemReference != nil && !isValidCodexIDStrict(item.OfItemReference.ID) {
-		logrus.Warnf("[Codex] Dropping item_reference input item with invalid id: %q", item.OfItemReference.ID)
+		logrus.Debugf("[Codex] Dropping item_reference input item with invalid id: %q", item.OfItemReference.ID)
 		return false
 	}
 	return true
@@ -419,13 +419,13 @@ func (c *CodexClient) buildImageGenerationResponsesRequest(req openai.ImageGener
 	if req.N.Valid() {
 		n := req.N.Value
 		if n > 1 {
-			logrus.Warnf("[Codex] Multiple images (N=%d) not supported, using N=1", n)
+			logrus.Debugf("[Codex] Multiple images (N=%d) not supported, using N=1", n)
 		}
 	}
 
 	// Log warning for unsupported style parameter
 	if req.Style != "" {
-		logrus.Warnf("[Codex] Style parameter not supported for image generation")
+		logrus.Debugf("[Codex] Style parameter not supported for image generation")
 	}
 
 	// Set stream=true via ExtraFields

--- a/internal/server/system_log_handler.go
+++ b/internal/server/system_log_handler.go
@@ -46,10 +46,10 @@ func (s *Server) GetSystemLogs(c *gin.Context) {
 		limit = 1000 // Max limit
 	}
 
-	// Read logs from JSON log file, keeping only genuine system logs. HTTP
-	// access logs, model-request stage logs and smart-routing traces are
-	// request-scoped and surfaced through the Requests view instead.
-	entries, err := s.multiLogger.ReadJSONLogsBySource(limit, obs.LogSourceSystem, obs.LogSourceAction, obs.LogSourceUnknown)
+	// Read logs from JSON log file, keeping system logs and HTTP access logs.
+	// AI model endpoint requests are included here; their detailed timeline
+	// is available in the AI Logs view (correlated by request_id).
+	entries, err := s.multiLogger.ReadJSONLogsBySource(limit, obs.LogSourceSystem, obs.LogSourceAction, obs.LogSourceUnknown, obs.LogSourceHTTP)
 	if err != nil {
 		logrus.Errorf("Failed to read system logs: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{


### PR DESCRIPTION
## Summary
The logging system UX was confusing with unclear tab labels and locked scenario filters. 
This refactor clarifies the separation between AI model request traces and general system logs while giving users more control over filtering.

### Major
- Renamed "Requests" tab to "AI Logs" for clearer purpose (AI model request traces)
- System Logs now include HTTP access logs - AI endpoint requests are visible here with basic info, detailed timeline available in AI Logs view
- Scenario filter changed from locked to initial value - users can now modify or clear the filter after opening from a scenario context
- Added Clear button to reset all filters (scenario/provider/status) at once

### Minor
- Updated prop naming: `lockedScenario` → `initialScenario` across LogExplorer, RequestsViewer, and RuleLogDialog
- Scenario filter input now always visible (previously hidden when locked)