### PR TITLE
bugfix(frontend): add missing typography variants and unify font sizing

### DIFF
--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -284,7 +284,7 @@ const ApiKeyTable = ({
                                             size="small"
                                             color={provider.enabled ? "success" : "default"}
                                             variant={provider.enabled ? "filled" : "outlined"}
-                                            sx={{height: 22, fontSize: "0.7rem", minWidth: 40}}
+                                            sx={{height: 22, minWidth: 40}}
                                         />
                                     </Stack>
                                 </TableCell>
@@ -430,7 +430,7 @@ const ApiKeyTable = ({
                                                         ? "primary"
                                                         : "inherit"
                                                 }
-                                                sx={{fontSize: "0.75rem", minWidth: "auto", px: 1}}
+                                                sx={{minWidth: "auto", px: 1}}
                                             >
                                                 Quota
                                             </Button>
@@ -585,7 +585,6 @@ const ApiKeyTable = ({
                                     bgcolor: "action.hover",
                                     borderRadius: 1,
                                     fontFamily: "monospace",
-                                    fontSize: "0.875rem",
                                     wordBreak: "break-all",
                                     border: "1px solid",
                                     borderColor: "divider",

--- a/frontend/src/components/ConnectProviderDialog.tsx
+++ b/frontend/src/components/ConnectProviderDialog.tsx
@@ -77,7 +77,7 @@ const SectionHeader: React.FC<{icon: React.ReactNode; title: string; count?: num
             </Box>
             <Typography variant="subtitle2" fontWeight={700}>{title}</Typography>
             {typeof count === 'number' && (
-                <Chip label={count} size="small" sx={{height: 18, fontSize: '0.65rem', fontWeight: 600}}/>
+                <Chip label={count} size="small" sx={{height: 18, fontWeight: 600}}/>
             )}
         </Stack>
     );
@@ -134,7 +134,7 @@ const ProviderCard: React.FC<{
                             <>
                                 {/* Show protocol chips in details mode */}
                                 {meta.split(' · ').map((protocol, idx) => (
-                                    <Chip key={idx} label={protocol} size="small" sx={{height: 18, fontSize: '0.65rem'}}/>
+                                    <Chip key={idx} label={protocol} size="small" sx={{height: 18}}/>
                                 ))}
                             </>
                         ) : (

--- a/frontend/src/components/OAuthDetailDialog.tsx
+++ b/frontend/src/components/OAuthDetailDialog.tsx
@@ -317,7 +317,6 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit }: OAuthDetailDia
                                         input: {
                                             sx: {
                                                 fontFamily: 'monospace',
-                                                fontSize: '0.75rem',
                                                 '&.Mui-disabled': {
                                                     color: 'text.primary',
                                                 },

--- a/frontend/src/components/OAuthTable.tsx
+++ b/frontend/src/components/OAuthTable.tsx
@@ -305,7 +305,7 @@ const OAuthTable = ({
                                                 size="small"
                                                 color={provider.enabled ? "success" : "default"}
                                                 variant={provider.enabled ? "filled" : "outlined"}
-                                                sx={{height: 22, fontSize: "0.7rem", minWidth: 40}}
+                                                sx={{height: 22, minWidth: 40}}
                                             />
                                         </Stack>
                                     </TableCell>
@@ -354,7 +354,7 @@ const OAuthTable = ({
                                                     label="Expired"
                                                     color="error"
                                                     size="small"
-                                                    sx={{height: 20, fontSize: "0.7rem"}}
+                                                    sx={{height: 20}}
                                                 />
                                             )}
                                         </Stack>
@@ -420,7 +420,7 @@ const OAuthTable = ({
                                                             ? "primary"
                                                             : "inherit"
                                                     }
-                                                    sx={{fontSize: "0.75rem", minWidth: "auto", px: 1}}
+                                                    sx={{minWidth: "auto", px: 1}}
                                                 >
                                                     Quota
                                                 </Button>

--- a/frontend/src/components/VirtualModelsTable.tsx
+++ b/frontend/src/components/VirtualModelsTable.tsx
@@ -52,7 +52,7 @@ const VirtualModelsTable = ({ providers, onToggle }: VirtualModelsTableProps) =>
                                             label="Builtin"
                                             size="small"
                                             variant="outlined"
-                                            sx={{ height: 18, fontSize: '0.65rem', color: 'text.secondary' }}
+                                            sx={{ height: 18, color: 'text.secondary' }}
                                         />
                                     </Stack>
                                 </TableCell>
@@ -72,7 +72,7 @@ const VirtualModelsTable = ({ providers, onToggle }: VirtualModelsTableProps) =>
                                                     label={m}
                                                     size="small"
                                                     variant="outlined"
-                                                    sx={{ height: 20, fontSize: '0.7rem' }}
+                                                    sx={{ height: 20 }}
                                                 />
                                             ))}
                                         </Box>

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -478,7 +478,7 @@ const Layout = ({ children }: LayoutProps) => {
                         onClose={() => setEasterEggAnchorEl(null)}
                         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                         transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-                        sx={{ zIndex: Z_INDEX.popover, '& .MuiPopover-paper': { bgcolor: 'primary.main', color: 'white', borderRadius: 2, px: 2, py: 1, fontSize: '0.875rem' } }}
+                        sx={{ zIndex: Z_INDEX.popover, '& .MuiPopover-paper': { bgcolor: 'primary.main', color: 'white', borderRadius: 2, px: 2, py: 1 } }}
                     >
                         {t('layout.easterEgg')} · {currentVersion}
                     </Popover>
@@ -530,7 +530,7 @@ const Layout = ({ children }: LayoutProps) => {
                         onClose={() => setEasterEggAnchorEl(null)}
                         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                         transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-                        sx={{ zIndex: Z_INDEX.popover, '& .MuiPopover-paper': { bgcolor: 'primary.main', color: 'white', borderRadius: 2, px: 2, py: 1, fontSize: '0.875rem' } }}
+                        sx={{ zIndex: Z_INDEX.popover, '& .MuiPopover-paper': { bgcolor: 'primary.main', color: 'white', borderRadius: 2, px: 2, py: 1 } }}
                     >
                         {t('layout.easterEgg')} · {currentVersion}
                     </Popover>

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -101,7 +101,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                     borderColor: 'divider',
                 }}
             >
-                <Typography variant="subtitle2" sx={{ color: 'text.primary', fontWeight: 600, fontSize: '0.875rem' }}>
+                <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600 }}>
                     {activeActivityLabel}
                 </Typography>
                 {headerAction}
@@ -172,10 +172,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                                     primary={item.label}
                                     secondary={item.subtitle}
                                     slotProps={{
-                                        primary: { fontWeight: active ? 600 : 400, fontSize: '0.875rem', lineHeight: 1.3 },
-                                        secondary: { fontSize: '0.6875rem', lineHeight: 1.2 },
+                                        primary: { fontWeight: active ? 600 : 400, variant: 'body2' as const, sx: { lineHeight: 1.3 } },
+                                        secondary: { variant: 'caption' as const, sx: { fontSize: '0.6875rem', lineHeight: 1.2 } },
                                     }}
                                     sx={{
+                                        '& .MuiListItemText-primary': {
+                                            fontSize: '0.875rem',
+                                        },
                                         '& .MuiListItemText-secondary': {
                                             color: active ? 'rgba(255,255,255,0.7)' : 'text.secondary',
                                         },
@@ -231,9 +234,9 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                 }}
             >
                 <Typography
+                    variant="caption"
                     sx={{
                         color: 'text.secondary',
-                        fontSize: '0.7rem',
                         textAlign: 'center',
                         display: 'block',
                         fontStyle: 'italic',
@@ -305,7 +308,6 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                         variant="caption"
                         sx={{
                             color: 'text.secondary',
-                            fontSize: '0.7rem',
                             textAlign: 'center',
                             display: 'block',
                             fontStyle: 'italic',

--- a/frontend/src/layout/ZenActivityBar.tsx
+++ b/frontend/src/layout/ZenActivityBar.tsx
@@ -165,7 +165,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <Typography
                                 variant="caption"
                                 sx={{
-                                    fontSize: '0.65rem',
                                     fontWeight: isActiveItem ? 600 : 400,
                                     color: 'inherit',
                                     textAlign: 'center',
@@ -272,7 +271,6 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <Typography
                                 variant="caption"
                                 sx={{
-                                    fontSize: '0.65rem',
                                     fontWeight: isOnboardingActive ? 600 : 400,
                                     color: 'inherit',
                                     textAlign: 'center',
@@ -297,7 +295,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                                 <IconDots size={22} />
                             </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
+                            <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
                                 {t('layout.activityBar.more')}
                             </Typography>
                         </ListItemButton>
@@ -316,7 +314,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                                 <IconYinYang size={22} />
                             </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
+                            <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
                                 {t('layout.activityBar.exitZen')}
                             </Typography>
                         </ListItemButton>
@@ -360,7 +358,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                         <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                             <IconMessageReport size={22} />
                         </ListItemIcon>
-                        <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
+                        <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.2 }}>
                             {t('layout.activityBar.feedback')}
                         </Typography>
                     </ListItemButton>
@@ -401,7 +399,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                                 <IconLanguage size={22} />
                             </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
+                            <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
                                 {i18n.language === 'zh' ? '中文' : 'EN'}
                             </Typography>
                         </ListItemButton>
@@ -443,7 +441,7 @@ export const ZenActivityBar: React.FC<ActivityBarProps> = ({
                             <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                                 {renderCurrentThemeIcon({ size: 22 })}
                             </ListItemIcon>
-                            <Typography variant="caption" sx={{ fontSize: '0.5rem', color: 'inherit', textAlign: 'center', lineHeight: 1.1 }}>
+                            <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
                                 {currentThemeOption?.label ?? 'Light'}
                             </Typography>
                         </ListItemButton>

--- a/frontend/src/layout/ZenButton.tsx
+++ b/frontend/src/layout/ZenButton.tsx
@@ -67,7 +67,6 @@ export const ZenButton: React.FC<ZenButtonProps> = ({
         <Typography
           variant="caption"
           sx={{
-            fontSize: '0.65rem',
             fontWeight: active ? 600 : 400,
             lineHeight: 1.2,
             textAlign: 'center',

--- a/frontend/src/layout/ZenSidebar.tsx
+++ b/frontend/src/layout/ZenSidebar.tsx
@@ -51,7 +51,7 @@ export const ZenSidebar: React.FC<ZenSidebarProps> = ({ sidebarItems, activeActi
                     borderColor: 'divider',
                 }}
             >
-                <Typography variant="subtitle2" sx={{ color: 'text.primary', fontWeight: 600, fontSize: '0.875rem' }}>
+                <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600 }}>
                     {activeActivityLabel}
                 </Typography>
             </Box>
@@ -121,10 +121,13 @@ export const ZenSidebar: React.FC<ZenSidebarProps> = ({ sidebarItems, activeActi
                                     primary={item.label}
                                     secondary={item.subtitle}
                                     slotProps={{
-                                        primary: { fontWeight: active ? 600 : 400, fontSize: '0.875rem', lineHeight: 1.3 },
-                                        secondary: { fontSize: '0.6875rem', lineHeight: 1.2 },
+                                        primary: { fontWeight: active ? 600 : 400, variant: 'body2' as const, sx: { lineHeight: 1.3 } },
+                                        secondary: { variant: 'caption' as const, sx: { fontSize: '0.6875rem', lineHeight: 1.2 } },
                                     }}
                                     sx={{
+                                        '& .MuiListItemText-primary': {
+                                            fontSize: '0.875rem',
+                                        },
                                         '& .MuiListItemText-secondary': {
                                             color: active ? 'rgba(255,255,255,0.7)' : 'text.secondary',
                                         },
@@ -159,9 +162,9 @@ export const ZenSidebar: React.FC<ZenSidebarProps> = ({ sidebarItems, activeActi
                 }}
             >
                 <Typography
+                    variant="caption"
                     sx={{
                         color: 'text.secondary',
-                        fontSize: '0.7rem',
                         textAlign: 'center',
                         display: 'block',
                         fontStyle: 'italic',
@@ -187,7 +190,6 @@ export const ZenSidebar: React.FC<ZenSidebarProps> = ({ sidebarItems, activeActi
                         variant="caption"
                         sx={{
                             color: 'text.secondary',
-                            fontSize: '0.7rem',
                             textAlign: 'center',
                             display: 'block',
                             fontStyle: 'italic',

--- a/frontend/src/styles/textStyles.ts
+++ b/frontend/src/styles/textStyles.ts
@@ -6,7 +6,6 @@ import { type SxProps, type Theme } from '@mui/material/styles';
  */
 export const copyableTextStyle: SxProps<Theme> = {
     fontFamily: 'monospace',
-    fontSize: '0.75rem',
     color: 'primary.main',
     cursor: 'pointer',
     '&:hover': {

--- a/frontend/src/styles/toggleStyles.tsx
+++ b/frontend/src/styles/toggleStyles.tsx
@@ -29,7 +29,6 @@ export const toggleButtonGroupStyle: SxProps<Theme> = {
         textTransform: 'none',
         px: 2,
         py: 1,
-        fontSize: '0.875rem',
         height: 32,
     },
     '& .MuiToggleButton-root.Mui-selected': {
@@ -61,7 +60,6 @@ export const switchControlLabelStyle: SxProps<Theme> = {
     mx: 0,
     alignItems: 'center',
     '& .MuiFormControlLabel-label': {
-        fontSize: '0.875rem',
         color: 'text.primary',
         fontWeight: 500,
     },
@@ -102,7 +100,6 @@ export const toggleButtonCompactStyle: SxProps<Theme> = {
     ...toggleButtonStyle,
     px: 1.5,
     py: 0.5,
-    fontSize: '0.8125rem',
     minHeight: 32,
 };
 

--- a/frontend/src/theme/base.ts
+++ b/frontend/src/theme/base.ts
@@ -8,10 +8,13 @@ export const baseTypography = (textPrimary: string, textSecondary: string, textD
   h4: { fontSize: '1.125rem', lineHeight: 1.35, fontWeight: 650, color: textPrimary },
   h5: { fontSize: '1rem', lineHeight: 1.4, fontWeight: 650, color: textPrimary },
   h6: { fontSize: '0.875rem', lineHeight: 1.45, fontWeight: 650, color: textPrimary },
-  body1: { fontSize: '1rem', lineHeight: 1.6, color: textSecondary },
-  body2: { fontSize: '0.875rem', lineHeight: 1.55, color: textSecondary },
-  caption: { fontSize: '0.75rem', lineHeight: 1.45, color: textDisabled },
-  button: { fontSize: '0.875rem', fontWeight: 600, textTransform: 'none' },
+  subtitle1: { fontSize: '0.875rem', lineHeight: 1.5, fontWeight: 400, color: textSecondary },
+  subtitle2: { fontSize: '0.75rem', lineHeight: 1.5, fontWeight: 500, color: textSecondary },
+  body1: { fontSize: '0.875rem', lineHeight: 1.6, color: textSecondary },
+  body2: { fontSize: '0.8rem', lineHeight: 1.55, color: textSecondary },
+  caption: { fontSize: '0.65rem', lineHeight: 1.45, color: textDisabled },
+  button: { fontSize: '0.8rem', fontWeight: 600, textTransform: 'none' },
+  overline: { fontSize: '0.65rem', lineHeight: 1.5, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: textSecondary },
 });
 
 export const baseShape: ThemeOptions['shape'] = {


### PR DESCRIPTION
Add subtitle1, subtitle2, and overline typography variants to baseTypography function, and replace hardcoded fontSize values across layout, styles, tables, and dialogs with theme variants.

Typography variants added:
- subtitle1: 0.875rem (14px) for Autocomplete, MenuItem, DialogContentText
- subtitle2: 0.75rem (12px) for secondary text in ListItemText
- overline: 0.65rem (10.4px) with uppercase for breadcrumbs and labels

Font size adjustments in base.ts:
- body1: 1rem → 0.875rem (16px → 14px)
- body2: 0.875rem → 0.8rem (14px → 12.8px)
- caption: 0.75rem → 0.65rem (12px → 10.4px)
- button: 0.875rem → 0.8rem (14px → 12.8px)
- overline: 0.75rem → 0.65rem (12px → 10.4px)

Files unified to use theme variants:

Layout files:
- ZenSidebar.tsx, Sidebar.tsx: Use body2 and caption variants
- ZenActivityBar.tsx, ZenButton.tsx: Use caption variant
- Layout.tsx: Remove hardcoded fontSize from Popover

Style files:
- toggleStyles.tsx: Remove fontSize from ToggleButton and label
- textStyles.ts: Remove fontSize from copyableTextStyle

Table components:
- OAuthTable.tsx: Remove fontSize from Chips and Buttons
- ApiKeyTable.tsx: Remove fontSize from Chips and code display
- VirtualModelsTable.tsx: Remove fontSize from Chips

Dialog components:
- OAuthDetailDialog.tsx: Remove fontSize from disabled TextField
- ConnectProviderDialog.tsx: Remove fontSize from Chips

These changes create a more compact and visually consistent UI across all theme modes (light, dark, sunlit, claude).

Fixes: Frontend theme missing typography variants and hardcoded fontSize