### PR TITLE
refactor(frontend): unify onboarding and credentials provider selection flow

### DIFF
--- a/frontend/src/components/ConnectProviderDialog.tsx
+++ b/frontend/src/components/ConnectProviderDialog.tsx
@@ -3,7 +3,6 @@ import RegionBadge from './RegionBadge';
 import {
     Box,
     Card,
-    CardActionArea,
     Chip,
     Dialog,
     DialogContent,
@@ -101,50 +100,49 @@ const ProviderCard: React.FC<{
                 border: 1, borderColor: 'divider', borderRadius: 1,
                 p: 1.25, display: 'flex', alignItems: 'center', gap: 1.25,
                 cursor: 'pointer',
-                boxShadow: 'none',
+                boxShadow: 0,
                 transition: 'border-color 0.15s ease, background-color 0.15s ease',
                 '&:hover': {
                     borderColor: 'primary.main',
                     bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
                 },
             }}
+            onClick={onClick}
         >
-            <CardActionArea onClick={onClick} sx={{flex: 1, display: 'flex', alignItems: 'center', gap: 1.25, justifyContent: 'flex-start'}}>
-                <Box sx={{width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0}}>
-                    {icon}
-                </Box>
-                <Box sx={{minWidth: 0, flex: 1}}>
-                    <Typography
-                        variant="body2"
-                        fontWeight={600}
-                        sx={{
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            display: '-webkit-box',
-                            WebkitLineClamp: 2,
-                            WebkitBoxOrient: 'vertical',
-                            lineHeight: 1.3,
-                        }}
-                        title={name}
-                    >
-                        {name}
-                    </Typography>
-                    <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
-                        {showDetails ? (
-                            <>
-                                {/* Show protocol chips in details mode */}
-                                {meta.split(' · ').map((protocol, idx) => (
-                                    <Chip key={idx} label={protocol} size="small" sx={{height: 18}}/>
-                                ))}
-                            </>
-                        ) : (
-                            <Typography variant="caption" color="text.secondary" noWrap sx={{display: 'block'}}>
-                                {meta}
-                            </Typography>
-                        )}
-                    </Stack>
-                </Box>
-            </CardActionArea>
+            <Box sx={{width: 30, height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0}}>
+                {icon}
+            </Box>
+            <Box sx={{minWidth: 0, flex: 1}}>
+                <Typography
+                    variant="body2"
+                    fontWeight={600}
+                    sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        lineHeight: 1.3,
+                    }}
+                    title={name}
+                >
+                    {name}
+                </Typography>
+                <Stack direction="row" spacing={0.5} sx={{mt: 0.5}}>
+                    {showDetails ? (
+                        <>
+                            {/* Show protocol chips in details mode */}
+                            {meta.split(' · ').map((protocol, idx) => (
+                                <Chip key={idx} label={protocol} size="small" sx={{height: 18}}/>
+                            ))}
+                        </>
+                    ) : (
+                        <Typography variant="caption" color="text.secondary" noWrap sx={{display: 'block'}}>
+                            {meta}
+                        </Typography>
+                    )}
+                </Stack>
+            </Box>
             {showDetails && (
                 <Stack direction="row" spacing={0.3} sx={{pr: 10}}>
                     {website && (
@@ -187,7 +185,7 @@ const ProviderCard: React.FC<{
 
 const CardGrid: React.FC<{children: React.ReactNode; single?: boolean; wide?: boolean}> = ({children, single, wide}) => {
     // single: force 1 column (for API key providers in dialog mode)
-    // wide: allow 2-3 columns (for onboarding/page mode)
+    // wide: 3 columns for onboarding/page mode
     // default: 1-2 columns (for cards in dialog mode)
     if (single) {
         return (
@@ -202,9 +200,7 @@ const CardGrid: React.FC<{children: React.ReactNode; single?: boolean; wide?: bo
                 display: 'grid',
                 gridTemplateColumns: {
                     xs: '1fr',
-                    sm: 'repeat(2, 1fr)',
-                    md: 'repeat(3, 1fr)',
-                    lg: 'repeat(3, 1fr)',
+                    sm: 'repeat(3, 1fr)',
                 },
                 gap: 1.5,
             }}>
@@ -382,7 +378,7 @@ export const ProviderListContent: React.FC<ProviderListContentProps> = ({
                                         {cnKeyProviders.length} providers
                                     </Typography>
                                 </Stack>
-                                <CardGrid single={!wide}>
+                                <CardGrid wide={wide}>
                                     {cnKeyProviders.map((p) => (
                                         <ProviderCard
                                             key={`key-${p.id}`}
@@ -408,7 +404,7 @@ export const ProviderListContent: React.FC<ProviderListContentProps> = ({
                                         {globalKeyProviders.length} providers
                                     </Typography>
                                 </Stack>
-                                <CardGrid single={!wide}>
+                                <CardGrid wide={wide}>
                                     {globalKeyProviders.map((p) => (
                                         <ProviderCard
                                             key={`key-${p.id}`}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -5,8 +5,6 @@ import {
     Alert,
     Box,
     Button,
-    Card,
-    CardContent,
     Dialog,
     DialogActions,
     DialogContent,
@@ -26,12 +24,15 @@ import PageLayout from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import ProviderFormDialog, {type EnhancedProviderFormData} from '@/components/ProviderFormDialog';
 import {ProviderListContent, type ConnectSelection} from '@/components/ConnectProviderDialog';
+import OAuthDialog from '@/components/OAuthDialog';
 import PasteAndDetect from '@/components/onboarding/PasteAndDetect';
 import {api} from '@/services/api';
 
 type OnboardingTab = 'browse' | 'paste';
 
-const emptyForm = (): EnhancedProviderFormData => ({
+type ProviderFormData = EnhancedProviderFormData;
+
+const emptyForm = (): ProviderFormData => ({
     name: '',
     apiBase: '',
     apiStyle: undefined,
@@ -45,9 +46,17 @@ const Onboarding: React.FC = () => {
     const {t} = useTranslation();
     const navigate = useNavigate();
     const [tab, setTab] = useState<OnboardingTab>('browse');
-    const [dialogOpen, setDialogOpen] = useState(false);
     const [browseQuery, setBrowseQuery] = useState('');
-    const [formData, setFormData] = useState<EnhancedProviderFormData>(emptyForm());
+
+    // Dialog state
+    const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
+    const [providerFormData, setProviderFormData] = useState<ProviderFormData>(emptyForm());
+    const [isLocalProvider, setIsLocalProvider] = useState(false);
+
+    // OAuth Dialog state
+    const [oauthDialogOpen, setOAuthDialogOpen] = useState(false);
+    const [oauthAutoStartId, setOAuthAutoStartId] = useState<string | null>(null);
+
     const [snackbar, setSnackbar] = useState<{open: boolean; message: string; severity: 'success' | 'error' | 'info'}>({
         open: false,
         message: '',
@@ -59,73 +68,63 @@ const Onboarding: React.FC = () => {
         setSnackbar({open: true, message, severity});
     };
 
-    const openDialogWith = (prefill: EnhancedProviderFormData) => {
-        setFormData({
+    const openDialogWith = (prefill: ProviderFormData) => {
+        setProviderFormData({
             ...emptyForm(),
             ...prefill,
         });
-        setDialogOpen(true);
+        setApiKeyDialogOpen(true);
     };
 
+    // Route a pick from the provider list to the matching dialog.
+    // This is the single truth for provider selection - same as CredentialPage.
     const handleBrowseSelect = (selection: ConnectSelection) => {
+        if (selection.kind === 'oauth') {
+            setOAuthAutoStartId(selection.providerId);
+            setOAuthDialogOpen(true);
+            return;
+        }
+
         if (selection.kind === 'custom') {
             openDialogWith(emptyForm());
             return;
         }
 
-        if (selection.kind === 'oauth') {
-            showMessage('OAuth flow coming soon', 'info');
-            return;
-        }
-
         if (selection.kind === 'local') {
-            const p = selection.provider;
-            const apiBase = p.baseUrlOpenAI || p.baseUrlAnthropic || '';
-            const apiStyle: 'openai' | 'anthropic' = p.baseUrlOpenAI ? 'openai' : 'anthropic';
+            const lp = selection.provider as any; // Cast to access url/defaultApiKey
+            setIsLocalProvider(true);
             openDialogWith({
-                name: p.alias || p.name,
-                apiBase,
-                apiStyle,
-                token: '',
+                name: lp.alias || lp.name,
+                apiBase: lp.url || lp.baseUrlOpenAI || lp.baseUrlAnthropic || '',
+                apiStyle: 'openai' as any,
+                token: lp.defaultApiKey ?? '',
                 enabled: true,
-                noKeyRequired: true,
-                protocols: p.supportsOpenAI && p.supportsAnthropic ? ['openai', 'anthropic'] : p.supportsOpenAI ? ['openai'] : ['anthropic'],
-                providerBaseUrls: {
-                    openai: p.baseUrlOpenAI,
-                    anthropic: p.baseUrlAnthropic,
-                },
+                noKeyRequired: !lp.defaultApiKey,
             });
             return;
         }
 
-        if (selection.kind === 'key') {
-            const p = selection.provider;
-            const apiBase = p.baseUrlOpenAI || p.baseUrlAnthropic || '';
-            const apiStyle: 'openai' | 'anthropic' = p.baseUrlOpenAI ? 'openai' : 'anthropic';
-            openDialogWith({
-                name: p.alias || p.name,
-                apiBase,
-                apiStyle,
-                token: '',
-                enabled: true,
-                protocols: p.supportsOpenAI && p.supportsAnthropic ? ['openai', 'anthropic'] : p.supportsOpenAI ? ['openai'] : ['anthropic'],
-                providerBaseUrls: {
-                    openai: p.baseUrlOpenAI,
-                    anthropic: p.baseUrlAnthropic,
-                },
-            });
-            return;
-        }
+        const p = selection.provider;
+        openDialogWith({
+            name: p.alias || p.name,
+            apiBase: p.baseUrlOpenAI || p.baseUrlAnthropic || '',
+            apiStyle: (p.baseUrlOpenAI ? 'openai' : 'anthropic') as any,
+            token: '',
+            enabled: true,
+            protocols: p.supportsOpenAI && p.supportsAnthropic ? ['openai', 'anthropic'] : p.supportsOpenAI ? ['openai'] : ['anthropic'],
+            providerBaseUrls: {
+                openai: p.baseUrlOpenAI,
+                anthropic: p.baseUrlAnthropic,
+            },
+        });
     };
 
-    const handleFieldChange = (field: keyof EnhancedProviderFormData, value: any) => {
-        setFormData(prev => ({...prev, [field]: value}));
+    const handleFieldChange = (field: keyof ProviderFormData, value: any) => {
+        setProviderFormData(prev => ({...prev, [field]: value}));
     };
 
-    const submitProvider = async (force: boolean, resolved?: Partial<EnhancedProviderFormData>) => {
-        // Merge dialog-resolved fields over form state; they arrive via async
-        // onChange and may not be in state yet at submit time.
-        const fd = { ...formData, ...(resolved || {}) };
+    const submitProvider = async (force: boolean, resolved?: Partial<ProviderFormData>) => {
+        const fd = {...providerFormData, ...(resolved || {})};
         const payload = {
             name: fd.name,
             api_base: fd.apiBase,
@@ -136,20 +135,25 @@ const Onboarding: React.FC = () => {
         };
         const result = await api.addProvider(payload, force);
         if (result?.success) {
-            setDialogOpen(false);
+            setApiKeyDialogOpen(false);
             setSuccessDialogOpen(true);
         } else {
             showMessage(`Failed to add provider: ${result?.error || 'unknown error'}`, 'error');
         }
     };
 
-    const handleSubmit = async (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => {
+    const handleSubmit = async (e: React.FormEvent, resolved?: Partial<ProviderFormData>) => {
         e.preventDefault();
         await submitProvider(false, resolved);
     };
 
     const handleForceAdd = async () => {
         await submitProvider(true);
+    };
+
+    const handleOAuthSuccess = () => {
+        showMessage('Provider added successfully!', 'success');
+        setSuccessDialogOpen(true);
     };
 
     const handleGoToAgents = () => {
@@ -169,7 +173,7 @@ const Onboarding: React.FC = () => {
                     size="full"
                     title={t('onboarding.title', {defaultValue: 'Welcome to Tingly Box'})}
                     subtitle={t('onboarding.subtitle', {
-                        defaultValue: 'Add your first AI provider to get started. Browse the catalog or paste a config snippet — we’ll figure out the rest.',
+                        defaultValue: 'Add your first AI provider to get started. Browse the catalog or paste a config snippet — we\'ll figure out the rest.',
                     })}
                 >
                     <Tabs
@@ -216,15 +220,31 @@ const Onboarding: React.FC = () => {
                 </UnifiedCard>
             </Box>
 
+            {/* API Key Provider Dialog */}
             <ProviderFormDialog
-                open={dialogOpen}
-                onClose={() => setDialogOpen(false)}
+                open={apiKeyDialogOpen}
+                onClose={() => {
+                    setApiKeyDialogOpen(false);
+                    setIsLocalProvider(false);
+                }}
                 onSubmit={handleSubmit}
                 onForceAdd={handleForceAdd}
-                data={formData}
+                data={providerFormData}
                 onChange={handleFieldChange}
                 mode="add"
                 isFirstProvider
+                optionalEditableToken={isLocalProvider}
+            />
+
+            {/* OAuth Add Dialog - now functional in onboarding */}
+            <OAuthDialog
+                open={oauthDialogOpen}
+                autoStartProviderId={oauthAutoStartId}
+                onClose={() => {
+                    setOAuthDialogOpen(false);
+                    setOAuthAutoStartId(null);
+                }}
+                onSuccess={handleOAuthSuccess}
             />
 
             <Dialog


### PR DESCRIPTION
## Summary
Onboarding provider selection was implemented separately from CredentialPage, creating duplicate code and inconsistent UX. OAuth providers were non-functional in onboarding ("coming soon" placeholder). 

This unifies both flows to use the same provider selection logic.

### Major
- OAuth providers now work in onboarding (removed "coming soon" placeholder)
- Both pages use identical provider selection routing logic
- Provider cards are fully clickable (entire card, not just text area)
- Wide layout shows 3 columns consistently across all provider sections

### Minor
- Removed CardActionArea wrapper for cleaner card interaction
- Fixed CardGrid to properly respect wide layout for API key providers
- Removed card shadows (boxShadow: 0) for cleaner appearance 
- Maintained onboarding's embedded provider list design (wide layout, details view)