### PR TITLE
refactor(UI, extention): merge thinking_mode + thinking_effort into a single control

### DIFF
--- a/frontend/src/components/PluginFeatures.tsx
+++ b/frontend/src/components/PluginFeatures.tsx
@@ -1,10 +1,5 @@
 import {
     IconCheck,
-    IconBrain,
-    IconFlask,
-    IconSettings,
-    IconRefresh,
-    IconBolt,
     IconChevronDown,
     IconCircleFilled,
 } from '@tabler/icons-react';
@@ -12,7 +7,6 @@ import {
     Box,
     Button,
     CircularProgress,
-    ListItemIcon,
     ListItemText,
     Menu,
     MenuItem,
@@ -42,17 +36,12 @@ const PLUGIN_FEATURES: PluginFeatureConfig[] = [
 ];
 
 const EFFORT_LEVELS = [
-    { value: '', label: 'By Client', description: 'Use model default' },
-    { value: 'low', label: 'Low', description: '~1K tokens - Fast' },
-    { value: 'medium', label: 'Medium', description: '~5K tokens - Balanced' },
-    { value: 'high', label: 'High', description: '~20K tokens - Deep' },
-    { value: 'max', label: 'Max', description: '~32K tokens - Max quality' },
-] as const;
-
-const THINKING_MODES = [
-    { value: 'default', label: 'By Client', description: 'Use client request config', icon: IconSettings },
-    { value: 'adaptive', label: 'Adaptive', description: 'Adapter to use extended thinking (enable / adaptive)', icon: IconRefresh },
-    { value: 'force', label: 'Force', description: 'Force to use extended thinking', icon: IconBolt },
+    { value: '', label: 'By Client', description: 'Pass the client\'s thinking config through unchanged' },
+    { value: 'off', label: 'Off', description: 'Force extended thinking disabled' },
+    { value: 'low', label: 'Low', description: '~1K tokens — Fast' },
+    { value: 'medium', label: 'Medium', description: '~5K tokens — Balanced' },
+    { value: 'high', label: 'High', description: '~20K tokens — Deep' },
+    { value: 'max', label: 'Max', description: '~32K tokens — Max quality' },
 ] as const;
 
 const RECORD_V2_MODES = [
@@ -67,7 +56,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
 
     const [features, setFeatures] = useState<Record<string, boolean>>({});
     const [effort, setEffort] = useState<string>('');
-    const [thinkingMode, setThinkingMode] = useState<string>('default');
     const [recordV2Mode, setRecordV2Mode] = useState<string>('');
     const [loading, setLoading] = useState(true);
     const [updating, setUpdating] = useState<Record<string, boolean>>({});
@@ -81,13 +69,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             const effortResult = await api.getScenarioStringFlag(scenario, 'thinking_effort');
             if (effortResult?.success && effortResult?.data?.value !== undefined) {
                 setEffort(effortResult.data.value);
-            }
-
-            if (baseScenario === 'claude_code') {
-                const thinkingModeResult = await api.getScenarioStringFlag(scenario, 'thinking_mode');
-                if (thinkingModeResult?.success && thinkingModeResult?.data?.value !== undefined) {
-                    setThinkingMode(thinkingModeResult.data.value);
-                }
             }
 
             const featureResults = await Promise.all(
@@ -152,21 +133,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             .finally(() => setUpdating(prev => ({ ...prev, effort: false })));
     };
 
-    const updateThinkingMode = (mode: string) => {
-        if (updating.thinkingMode || mode === thinkingMode) return;
-        setUpdating(prev => ({ ...prev, thinkingMode: true }));
-        api.setScenarioStringFlag(scenario, 'thinking_mode', mode)
-            .then((result) => {
-                if (result.success) {
-                    setThinkingMode(mode);
-                } else {
-                    loadData();
-                }
-            })
-            .catch(() => loadData())
-            .finally(() => setUpdating(prev => ({ ...prev, thinkingMode: false })));
-    };
-
     const handleRecordV2Change = (event: SelectChangeEvent<string>) => {
         const newMode = event.target.value;
         if (updating.recordV2 || newMode === recordV2Mode) return;
@@ -191,7 +157,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
         const currentLevel = EFFORT_LEVELS.find(l => l.value === effort);
         const isActive = effort !== '';
         return (
-            <Tooltip title={`Thinking Effort: ${currentLevel?.label || 'Default'}`} placement="right" arrow>
+            <Tooltip title={`Thinking: ${currentLevel?.description || 'By Client'}`} placement="right" arrow>
                 <Button
                     size="small"
                     variant="outlined"
@@ -210,37 +176,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         '&:hover': { bgcolor: isActive ? 'primary.dark' : 'action.selected' },
                     }}
                 >
-                    Thinking Effort: {currentLevel?.label || 'Default'}
-                </Button>
-            </Tooltip>
-        );
-    };
-
-    const renderThinkingModeButton = () => {
-        if (baseScenario !== 'claude_code') return null;
-        const currentMode = THINKING_MODES.find(m => m.value === thinkingMode);
-        const isActive = thinkingMode !== 'default';
-        return (
-            <Tooltip title={`Thinking: ${currentMode?.label || 'Default'}`} placement="right" arrow>
-                <Button
-                    size="small"
-                    variant="outlined"
-                    onClick={(e) => !updating.thinkingMode && handleMenuOpen('thinkingMode', e)}
-                    disabled={updating.thinkingMode}
-                    endIcon={<IconChevronDown size={18} />}
-                    sx={{
-                        minWidth: 110,
-                        textTransform: 'none',
-                        whiteSpace: 'nowrap',
-                        bgcolor: isActive ? 'primary.main' : 'transparent',
-                        color: isActive ? 'primary.contrastText' : 'text.primary',
-                        border: isActive ? 'none' : '1px solid',
-                        borderColor: 'divider',
-                        opacity: updating.thinkingMode ? 0.6 : 1,
-                        '&:hover': { bgcolor: isActive ? 'primary.dark' : 'action.selected' },
-                    }}
-                >
-                    Thinking: {currentMode?.label || 'Default'}
+                    Thinking: {currentLevel?.label || 'By Client'}
                 </Button>
             </Tooltip>
         );
@@ -336,7 +272,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         content: (
                             <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', columnGap: 1.5, rowGap: 1 }}>
                                 {renderEffortButton()}
-                                {renderThinkingModeButton()}
                                 {renderPluginButtons()}
                                 {renderRecordV2Button()}
                             </Box>
@@ -369,37 +304,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                     </MenuItem>
                 ))}
             </Menu>
-
-            {/* Thinking Mode Menu (claude_code only) */}
-            {baseScenario === 'claude_code' && (
-                <Menu
-                    anchorEl={menuAnchor['thinkingMode']}
-                    open={Boolean(menuAnchor['thinkingMode'])}
-                    onClose={() => handleMenuClose('thinkingMode')}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                >
-                    {THINKING_MODES.map((mode) => {
-                        const Icon = mode.icon;
-                        return (
-                            <MenuItem
-                                key={mode.value}
-                                selected={mode.value === thinkingMode}
-                                onClick={() => { updateThinkingMode(mode.value); handleMenuClose('thinkingMode'); }}
-                                title={mode.description}
-                            >
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                                    <ListItemIcon sx={{ mr: -1 }}>
-                                        <Icon size={16} />
-                                    </ListItemIcon>
-                                    <ListItemText primary={mode.label} primaryTypographyProps={{ variant: 'body2' }} />
-                                    {mode.value === thinkingMode && <IconCheck size={16} />}
-                                </Box>
-                            </MenuItem>
-                        );
-                    })}
-                </Menu>
-            )}
 
             {/* Plugin Feature Menus */}
             {visibleFeatures.map((feature) => {

--- a/frontend/src/components/PluginFeatures.tsx
+++ b/frontend/src/components/PluginFeatures.tsx
@@ -55,7 +55,6 @@ const THINKING_MODES = [
     { value: 'force', label: 'Force', description: 'Force to use extended thinking', icon: IconBolt },
 ] as const;
 
-// Record V2 modes
 const RECORD_V2_MODES = [
     { value: '', label: 'Off', description: 'Recording disabled' },
     { value: 'request', label: 'Request Only', description: 'Record the final outbound request only' },
@@ -64,7 +63,6 @@ const RECORD_V2_MODES = [
 ] as const;
 
 const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
-    // Extract base scenario for profiled scenarios (e.g., "claude_code:p1" -> "claude_code")
     const baseScenario = scenario.includes(':') ? scenario.split(':')[0] : scenario;
 
     const [features, setFeatures] = useState<Record<string, boolean>>({});
@@ -75,19 +73,16 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
     const [updating, setUpdating] = useState<Record<string, boolean>>({});
     const [menuAnchor, setMenuAnchor] = useState<Record<string, HTMLElement | null>>({});
 
-    // Filter features based on base scenario (if scenarios are specified, only show for those scenarios)
     const visibleFeatures = PLUGIN_FEATURES.filter(f => !f.scenarios || f.scenarios.includes(baseScenario as any));
 
     const loadData = async () => {
         try {
             setLoading(true);
-            // Load effort level first (will be displayed first)
             const effortResult = await api.getScenarioStringFlag(scenario, 'thinking_effort');
             if (effortResult?.success && effortResult?.data?.value !== undefined) {
                 setEffort(effortResult.data.value);
             }
 
-            // Load thinking mode (for claude_code scenario)
             if (baseScenario === 'claude_code') {
                 const thinkingModeResult = await api.getScenarioStringFlag(scenario, 'thinking_mode');
                 if (thinkingModeResult?.success && thinkingModeResult?.data?.value !== undefined) {
@@ -95,7 +90,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                 }
             }
 
-            // Load plugin features (only visible ones)
             const featureResults = await Promise.all(
                 visibleFeatures.map(f => api.getScenarioFlag(scenario, f.key))
             );
@@ -109,7 +103,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             });
             setFeatures(newFeatures);
 
-            // Load Record V2 mode (string flag)
             const recordV2Result = await api.getScenarioStringFlag(scenario, 'recording_v2');
             if (recordV2Result?.success && recordV2Result?.data?.value !== undefined) {
                 setRecordV2Mode(recordV2Result.data.value);
@@ -123,114 +116,82 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
 
     const setFeature = (featureKey: string, value: boolean) => {
         if (updating[featureKey]) return;
-
         setUpdating(prev => ({ ...prev, [featureKey]: true }));
-
         api.setScenarioFlag(scenario, featureKey, value)
             .then((result) => {
                 if (result.success) {
                     setFeatures(prev => ({ ...prev, [featureKey]: value }));
                 } else {
-                    console.error('Failed to update feature:', result.error);
                     loadData();
                 }
             })
-            .catch((error) => {
-                console.error('Failed to update feature:', error);
-                loadData();
-            })
-            .finally(() => {
-                setUpdating(prev => ({ ...prev, [featureKey]: false }));
-            });
+            .catch(() => loadData())
+            .finally(() => setUpdating(prev => ({ ...prev, [featureKey]: false })));
     };
 
-    const handleMenuOpen = (featureKey: string, event: React.MouseEvent<HTMLElement>) => {
-        setMenuAnchor(prev => ({ ...prev, [featureKey]: event.currentTarget }));
+    const handleMenuOpen = (key: string, event: React.MouseEvent<HTMLElement>) => {
+        setMenuAnchor(prev => ({ ...prev, [key]: event.currentTarget }));
     };
 
-    const handleMenuClose = (featureKey: string) => {
-        setMenuAnchor(prev => ({ ...prev, [featureKey]: null }));
+    const handleMenuClose = (key: string) => {
+        setMenuAnchor(prev => ({ ...prev, [key]: null }));
     };
 
     const setEffortLevel = (level: string) => {
-        if (updating.effort || level === effort) return; // Prevent rapid clicks or no-ops
-
+        if (updating.effort || level === effort) return;
         setUpdating(prev => ({ ...prev, effort: true }));
-
         api.setScenarioStringFlag(scenario, 'thinking_effort', level)
             .then((result) => {
                 if (result.success) {
                     setEffort(level);
                 } else {
-                    console.error('Failed to update effort level:', result.error);
                     loadData();
                 }
             })
-            .catch((error) => {
-                console.error('Failed to update effort level:', error);
-                loadData();
-            })
-            .finally(() => {
-                setUpdating(prev => ({ ...prev, effort: false }));
-            });
+            .catch(() => loadData())
+            .finally(() => setUpdating(prev => ({ ...prev, effort: false })));
     };
 
     const updateThinkingMode = (mode: string) => {
         if (updating.thinkingMode || mode === thinkingMode) return;
-
         setUpdating(prev => ({ ...prev, thinkingMode: true }));
-
         api.setScenarioStringFlag(scenario, 'thinking_mode', mode)
             .then((result) => {
                 if (result.success) {
                     setThinkingMode(mode);
                 } else {
-                    console.error('Failed to update thinking mode:', result.error);
                     loadData();
                 }
             })
-            .catch((error) => {
-                console.error('Failed to update thinking mode:', error);
-                loadData();
-            })
-            .finally(() => {
-                setUpdating(prev => ({ ...prev, thinkingMode: false }));
-            });
+            .catch(() => loadData())
+            .finally(() => setUpdating(prev => ({ ...prev, thinkingMode: false })));
     };
 
     const handleRecordV2Change = (event: SelectChangeEvent<string>) => {
         const newMode = event.target.value;
         if (updating.recordV2 || newMode === recordV2Mode) return;
-
         setUpdating(prev => ({ ...prev, recordV2: true }));
-
         api.setScenarioStringFlag(scenario, 'recording_v2', newMode)
             .then((result) => {
                 if (result.success) {
                     setRecordV2Mode(newMode);
                 } else {
-                    console.error('Failed to set recording_v2 mode:', result);
                     loadData();
                 }
             })
-            .catch((err) => {
-                console.error('Failed to set recording_v2 mode:', err);
-                loadData();
-            })
-            .finally(() => {
-                setUpdating(prev => ({ ...prev, recordV2: false }));
-            });
+            .catch(() => loadData())
+            .finally(() => setUpdating(prev => ({ ...prev, recordV2: false })));
     };
 
     useEffect(() => {
         loadData();
     }, [scenario]);
 
-    // Helper to render effort button
     const renderEffortButton = () => {
         const currentLevel = EFFORT_LEVELS.find(l => l.value === effort);
+        const isActive = effort !== '';
         return (
-            <Tooltip title={`Effort: ${currentLevel?.label || 'Default'}`} placement="right" arrow>
+            <Tooltip title={`Thinking Effort: ${currentLevel?.label || 'Default'}`} placement="right" arrow>
                 <Button
                     size="small"
                     variant="outlined"
@@ -241,28 +202,26 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         minWidth: 110,
                         textTransform: 'none',
                         whiteSpace: 'nowrap',
-                        bgcolor: effort && effort !== '' ? 'primary.main' : 'transparent',
-                        color: effort && effort !== '' ? 'primary.contrastText' : 'text.primary',
-                        border: effort && effort !== '' ? 'none' : '1px solid',
+                        bgcolor: isActive ? 'primary.main' : 'transparent',
+                        color: isActive ? 'primary.contrastText' : 'text.primary',
+                        border: isActive ? 'none' : '1px solid',
                         borderColor: 'divider',
                         opacity: updating.effort ? 0.6 : 1,
-                        '&:hover': {
-                            bgcolor: effort && effort !== '' ? 'primary.dark' : 'action.selected',
-                        },
+                        '&:hover': { bgcolor: isActive ? 'primary.dark' : 'action.selected' },
                     }}
                 >
-                    Effort: {currentLevel?.label || 'Default'}
+                    Thinking Effort: {currentLevel?.label || 'Default'}
                 </Button>
             </Tooltip>
         );
     };
 
-    // Helper to render thinking mode button (claude_code only)
     const renderThinkingModeButton = () => {
         if (baseScenario !== 'claude_code') return null;
         const currentMode = THINKING_MODES.find(m => m.value === thinkingMode);
+        const isActive = thinkingMode !== 'default';
         return (
-            <Tooltip title={`Mode: ${currentMode?.label || 'Default'}`} placement="right" arrow>
+            <Tooltip title={`Thinking: ${currentMode?.label || 'Default'}`} placement="right" arrow>
                 <Button
                     size="small"
                     variant="outlined"
@@ -273,25 +232,22 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         minWidth: 110,
                         textTransform: 'none',
                         whiteSpace: 'nowrap',
-                        bgcolor: thinkingMode && thinkingMode !== 'default' ? 'primary.main' : 'transparent',
-                        color: thinkingMode && thinkingMode !== 'default' ? 'primary.contrastText' : 'text.primary',
-                        border: thinkingMode && thinkingMode !== 'default' ? 'none' : '1px solid',
+                        bgcolor: isActive ? 'primary.main' : 'transparent',
+                        color: isActive ? 'primary.contrastText' : 'text.primary',
+                        border: isActive ? 'none' : '1px solid',
                         borderColor: 'divider',
                         opacity: updating.thinkingMode ? 0.6 : 1,
-                        '&:hover': {
-                            bgcolor: thinkingMode && thinkingMode !== 'default' ? 'primary.dark' : 'action.selected',
-                        },
+                        '&:hover': { bgcolor: isActive ? 'primary.dark' : 'action.selected' },
                     }}
                 >
-                    Mode: {currentMode?.label || 'Default'}
+                    Thinking: {currentMode?.label || 'Default'}
                 </Button>
             </Tooltip>
         );
     };
 
-    // Helper to render plugin feature buttons
     const renderPluginButtons = () => (
-        <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', columnGap: 1.5, rowGap: 1 }}>
+        <>
             {visibleFeatures.map((feature) => {
                 const isEnabled = features[feature.key] || false;
                 const isUpdating = updating[feature.key] || false;
@@ -313,9 +269,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                                 border: isEnabled ? 'none' : '1px solid',
                                 borderColor: 'divider',
                                 opacity: isUpdating ? 0.6 : 1,
-                                '&:hover': {
-                                    bgcolor: isEnabled ? 'primary.dark' : 'action.selected',
-                                },
+                                '&:hover': { bgcolor: isEnabled ? 'primary.dark' : 'action.selected' },
                             }}
                         >
                             {feature.label}: {isEnabled ? 'On' : 'Off'}
@@ -323,10 +277,9 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                     </Tooltip>
                 );
             })}
-        </Box>
+        </>
     );
 
-    // Helper to render record V2 button
     const renderRecordV2Button = () => {
         const currentRecordMode = RECORD_V2_MODES.find(m => m.value === recordV2Mode);
         const isRecordV2Enabled = recordV2Mode !== '';
@@ -353,9 +306,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         border: isRecordV2Enabled ? 'none' : '1px solid',
                         borderColor: 'divider',
                         opacity: isUpdatingRecordV2 ? 0.6 : 1,
-                        '&:hover': {
-                            bgcolor: isRecordV2Enabled ? 'primary.dark' : 'action.selected',
-                        },
+                        '&:hover': { bgcolor: isRecordV2Enabled ? 'primary.dark' : 'action.selected' },
                     }}
                 >
                     <IconCircleFilled size={14} style={{ marginRight: '4px' }} />
@@ -376,25 +327,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {/* Thinking Row */}
-            <ConfigRow
-                tabs={[
-                    {
-                        key: 'thinking',
-                        label: 'Thinking',
-                        content: (
-                            <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', columnGap: 1.5, rowGap: 1 }}>
-                                {renderEffortButton()}
-                                {renderThinkingModeButton()}
-                            </Box>
-                        ),
-                    },
-                ]}
-                activeTab="thinking"
-                onTabChange={() => {}}
-            />
-
-            {/* Plugin Features Row */}
+            {/* Single Plugin row: thinking controls first, then plugin features */}
             <ConfigRow
                 tabs={[
                     {
@@ -402,6 +335,8 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         label: 'Plugin',
                         content: (
                             <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', columnGap: 1.5, rowGap: 1 }}>
+                                {renderEffortButton()}
+                                {renderThinkingModeButton()}
                                 {renderPluginButtons()}
                                 {renderRecordV2Button()}
                             </Box>
@@ -412,7 +347,6 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                 onTabChange={() => {}}
             />
 
-            {/* Menus */}
             {/* Effort Menu */}
             <Menu
                 anchorEl={menuAnchor['effort']}
@@ -425,21 +359,18 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                     <MenuItem
                         key={level.value}
                         selected={level.value === effort}
-                        onClick={() => {
-                            setEffortLevel(level.value);
-                            handleMenuClose('effort');
-                        }}
+                        onClick={() => { setEffortLevel(level.value); handleMenuClose('effort'); }}
                         title={level.description}
                     >
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                            <ListItemText>{level.label}</ListItemText>
+                            <ListItemText primary={level.label} primaryTypographyProps={{ variant: 'body2' }} />
                             {level.value === effort && <IconCheck size={16} />}
                         </Box>
                     </MenuItem>
                 ))}
             </Menu>
 
-            {/* Thinking Mode Menu */}
+            {/* Thinking Mode Menu (claude_code only) */}
             {baseScenario === 'claude_code' && (
                 <Menu
                     anchorEl={menuAnchor['thinkingMode']}
@@ -454,17 +385,14 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                             <MenuItem
                                 key={mode.value}
                                 selected={mode.value === thinkingMode}
-                                onClick={() => {
-                                    updateThinkingMode(mode.value);
-                                    handleMenuClose('thinkingMode');
-                                }}
+                                onClick={() => { updateThinkingMode(mode.value); handleMenuClose('thinkingMode'); }}
                                 title={mode.description}
                             >
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
                                     <ListItemIcon sx={{ mr: -1 }}>
                                         <Icon size={16} />
                                     </ListItemIcon>
-                                    <ListItemText>{mode.label}</ListItemText>
+                                    <ListItemText primary={mode.label} primaryTypographyProps={{ variant: 'body2' }} />
                                     {mode.value === thinkingMode && <IconCheck size={16} />}
                                 </Box>
                             </MenuItem>
@@ -476,38 +404,29 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             {/* Plugin Feature Menus */}
             {visibleFeatures.map((feature) => {
                 const isEnabled = features[feature.key] || false;
-                const anchorEl = menuAnchor[feature.key];
                 return (
                     <Menu
                         key={feature.key}
-                        anchorEl={anchorEl}
-                        open={Boolean(anchorEl)}
+                        anchorEl={menuAnchor[feature.key]}
+                        open={Boolean(menuAnchor[feature.key])}
                         onClose={() => handleMenuClose(feature.key)}
                         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
                         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
                     >
                         <MenuItem
                             selected={isEnabled}
-                            onClick={() => {
-                                setFeature(feature.key, true);
-                                handleMenuClose(feature.key);
-                            }}
-                            sx={{ width: '100%' }}
+                            onClick={() => { setFeature(feature.key, true); handleMenuClose(feature.key); }}
                             title={feature.description}
                         >
-                            <ListItemText>On</ListItemText>
+                            <ListItemText primary="On" primaryTypographyProps={{ variant: 'body2' }} />
                             {isEnabled && <IconCheck size={16} />}
                         </MenuItem>
                         <MenuItem
                             selected={!isEnabled}
-                            onClick={() => {
-                                setFeature(feature.key, false);
-                                handleMenuClose(feature.key);
-                            }}
-                            sx={{ width: '100%' }}
+                            onClick={() => { setFeature(feature.key, false); handleMenuClose(feature.key); }}
                             title={feature.description}
                         >
-                            <ListItemText>Off</ListItemText>
+                            <ListItemText primary="Off" primaryTypographyProps={{ variant: 'body2' }} />
                             {!isEnabled && <IconCheck size={16} />}
                         </MenuItem>
                     </Menu>
@@ -533,7 +452,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         title={mode.description}
                     >
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                            <ListItemText>{mode.label}</ListItemText>
+                            <ListItemText primary={mode.label} primaryTypographyProps={{ variant: 'body2' }} />
                             {mode.value === recordV2Mode && <IconCheck size={16} />}
                         </Box>
                     </MenuItem>

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -60,6 +60,7 @@ export interface RuleFlags {
     useMaxTokens?: boolean;
     openaiEndpointOverride?: string;
     blockTools?: string;
+    thinkingEffort?: string;
 }
 
 export interface RuleFlagsApi {
@@ -71,6 +72,7 @@ export interface RuleFlagsApi {
     use_max_tokens?: boolean;
     openai_endpoint_override?: string;
     block_tools?: string;
+    thinking_effort?: string;
 }
 
 export type FlagValueType = 'bool' | 'string' | 'enum';

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -107,6 +107,7 @@ import {
     IconMinus,
     IconList,
     IconNavigation,
+    IconBrain,
 } from '@tabler/icons-react';
 import { tablerMui } from './tablerMui';
 
@@ -199,6 +200,7 @@ export const LocationOn = tablerMui(IconMapPin);
 export const Hub = tablerMui(IconShare);
 export const Cable = tablerMui(IconPlugConnected);
 export const Input = tablerMui(IconArrowBarToRight);
+export const Psychology = tablerMui(IconBrain);
 
 // --- Devices / brand / theme -------------------------------------------------
 export const Laptop = tablerMui(IconDeviceLaptop);

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -15,18 +15,18 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
-import { AutoAwesome as AutoAwesomeIcon } from '@/components/icons';
-import { Cable as CableIcon } from '@/components/icons';
-import { Outbound as OutboundIcon } from '@/components/icons';
-import { Terminal as TerminalIcon } from '@/components/icons';
-import { Extension as ExtensionIcon } from '@/components/icons';
-import { Input as InputIcon } from '@/components/icons';
-import { Close as CloseIcon } from '@/components/icons';
+import {
+    AutoAwesome as AutoAwesomeIcon,
+    Cable as CableIcon,
+    Close as CloseIcon,
+    Extension as ExtensionIcon,
+    Input as InputIcon,
+    Outbound as OutboundIcon,
+    Psychology as PsychologyIcon,
+    Terminal as TerminalIcon,
+} from '@/components/icons';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
-
-// Default enum value treated as "unset" (matches the registry's first option).
-const ENUM_DEFAULT_VALUE = 'auto';
 
 export interface FlagCatalogDialogProps {
     open: boolean;
@@ -64,6 +64,8 @@ const flagToString = (flags: RuleFlags | undefined, key: string): string => {
             return flags.openaiEndpointOverride || '';
         case 'block_tools':
             return flags.blockTools || '';
+        case 'thinking_effort':
+            return flags.thinkingEffort || '';
         default:
             return '';
     }
@@ -92,18 +94,25 @@ const setString = (flags: RuleFlags, key: string, value: string): RuleFlags => {
             return { ...flags, customUserAgent: value };
         case 'openai_endpoint_override':
             // Persist "auto" as empty string so omitempty hides it on the wire.
-            return { ...flags, openaiEndpointOverride: value === ENUM_DEFAULT_VALUE ? '' : value };
+            return { ...flags, openaiEndpointOverride: value === 'auto' ? '' : value };
         case 'block_tools':
             return { ...flags, blockTools: value };
+        case 'thinking_effort':
+            // First option already uses "" for the inactive ("By Client") value.
+            return { ...flags, thinkingEffort: value };
         default:
             return flags;
     }
 };
 
+// The inactive/default value for an enum flag is its first registry option
+// (e.g. "auto" for endpoint override, "" for thinking effort, "default" for thinking mode).
+const enumDefault = (spec: FlagSpec): string => spec.options?.[0]?.value ?? '';
+
 const isFlagActive = (spec: FlagSpec, flags: RuleFlags): boolean => {
     if (spec.type === 'bool') return flagToBool(flags, spec.key);
     const v = flagToString(flags, spec.key);
-    if (spec.type === 'enum') return v !== '' && v !== ENUM_DEFAULT_VALUE;
+    if (spec.type === 'enum') return v !== '' && v !== enumDefault(spec);
     return v !== '';
 };
 
@@ -124,6 +133,7 @@ const CATEGORY_META: Record<string, CategoryMeta> = {
     http: { label: 'HTTP', icon: <CableIcon fontSize="small" /> },
     response: { label: 'Response', icon: <OutboundIcon fontSize="small" /> },
     request: { label: 'Request', icon: <InputIcon fontSize="small" /> },
+    reasoning: { label: 'Reasoning', icon: <PsychologyIcon fontSize="small" /> },
 };
 
 const categoryMeta = (category: string): CategoryMeta => CATEGORY_META[category] || {
@@ -334,7 +344,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                     {currentGroup.specs.map((spec) => {
                                         const enabled = isFlagActive(spec, draft);
                                         const enumValue = spec.type === 'enum'
-                                            ? (flagToString(draft, spec.key) || ENUM_DEFAULT_VALUE)
+                                            ? (flagToString(draft, spec.key) || enumDefault(spec))
                                             : '';
                                         const pulsing = pulseKey === spec.key;
                                         return (

--- a/frontend/src/components/rule-card/RuleExtensionsCard.tsx
+++ b/frontend/src/components/rule-card/RuleExtensionsCard.tsx
@@ -78,13 +78,12 @@ const flagStringValue = (flags: RuleFlags | undefined, key: string): string => {
             return flags.openaiEndpointOverride || '';
         case 'block_tools':
             return flags.blockTools || '';
+        case 'thinking_effort':
+            return flags.thinkingEffort || '';
         default:
             return '';
     }
 };
-
-// Enum default that should be treated as "unset" (registry's first option).
-const ENUM_DEFAULT_VALUE = 'auto';
 
 /**
  * RuleExtensionsCard renders a compact card displaying the rule's enabled
@@ -102,7 +101,9 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
         if (spec.type === 'bool') return flagBoolValue(flags, spec.key);
         if (spec.type === 'enum') {
             const v = flagStringValue(flags, spec.key);
-            return v !== '' && v !== ENUM_DEFAULT_VALUE;
+            // The first registry option is the inactive/default value.
+            const inactive = spec.options?.[0]?.value ?? '';
+            return v !== '' && v !== inactive;
         }
         return flagStringValue(flags, spec.key) !== '';
     });

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -123,6 +123,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         use_max_tokens: newConfigRecord.flags?.useMaxTokens || false,
                         openai_endpoint_override: newConfigRecord.flags?.openaiEndpointOverride || '',
                         block_tools: newConfigRecord.flags?.blockTools || '',
+                        thinking_effort: newConfigRecord.flags?.thinkingEffort || '',
                     },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -74,6 +74,7 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
             useMaxTokens: rule.flags?.use_max_tokens || false,
             openaiEndpointOverride: rule.flags?.openai_endpoint_override || '',
             blockTools: rule.flags?.block_tools || '',
+            thinkingEffort: rule.flags?.thinking_effort || '',
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
@@ -225,11 +226,18 @@ const FALSE_VALUES = new Set(['false', '0', 'no', 'off']);
 
 const ENUM_FLAG_VALUES: Record<string, Set<string>> = {
     openai_endpoint_override: new Set(['auto', 'chat', 'responses']),
+    thinking_effort: new Set(['off', 'low', 'medium', 'high', 'max']),
+};
+
+// The sentinel value that means "inactive/By Client" for each enum flag.
+// Empty string (omitted on the wire) is always inactive too.
+const ENUM_INACTIVE_VALUE: Record<string, string> = {
+    openai_endpoint_override: 'auto',
+    thinking_effort: '',
 };
 
 function isEnumActive(key: string, value: string): boolean {
-    // "auto" (and empty) are inactive defaults; anything else counts as active.
-    return value !== '' && value !== 'auto';
+    return value !== '' && value !== (ENUM_INACTIVE_VALUE[key] ?? '');
 }
 
 export function formatRuleFlags(flags?: RuleFlags): string {
@@ -245,6 +253,9 @@ export function formatRuleFlags(flags?: RuleFlags): string {
         entries.push(`openai_endpoint_override=${flags.openaiEndpointOverride}`);
     }
     if (flags.blockTools) entries.push(`block_tools=${flags.blockTools}`);
+    if (flags.thinkingEffort && isEnumActive('thinking_effort', flags.thinkingEffort)) {
+        entries.push(`thinking_effort=${flags.thinkingEffort}`);
+    }
     return entries.join(',');
 }
 
@@ -261,6 +272,7 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
         useMaxTokens: false,
         openaiEndpointOverride: '',
         blockTools: '',
+        thinkingEffort: '',
     };
 
     const trimmed = input.trim();
@@ -301,6 +313,9 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             switch (rawKey) {
                 case 'openai_endpoint_override':
                     flags.openaiEndpointOverride = rawValue;
+                    break;
+                case 'thinking_effort':
+                    flags.thinkingEffort = rawValue;
                     break;
             }
             continue;
@@ -352,6 +367,7 @@ export function countActiveFlags(flags?: RuleFlags): number {
     if (flags.customUserAgent && flags.customUserAgent.trim() !== '') n++;
     if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) n++;
     if (flags.blockTools && flags.blockTools.trim() !== '') n++;
+    if (flags.thinkingEffort && isEnumActive('thinking_effort', flags.thinkingEffort)) n++;
     return n;
 }
 

--- a/frontend/src/pages/scenario/UseAgentPage.tsx
+++ b/frontend/src/pages/scenario/UseAgentPage.tsx
@@ -34,6 +34,7 @@ const UseAgentPageContent: React.FC = () => {
                         baseUrl={baseUrl}
                         onCopy={copyToClipboard}
                         compact={true}
+                        scenario={scenario}
                     />
                 </UnifiedCard>
 

--- a/frontend/src/pages/scenario/UseAnthropicPage.tsx
+++ b/frontend/src/pages/scenario/UseAnthropicPage.tsx
@@ -33,6 +33,7 @@ const UseAnthropicPageContent: React.FC = () => {
                         baseUrlPath="/tingly/anthropic"
                         baseUrl={baseUrl}
                         onCopy={copyToClipboard}
+                        scenario={scenario}
                     />
                 </UnifiedCard>
                 <TemplatePage

--- a/frontend/src/pages/scenario/UseEmbedPage.tsx
+++ b/frontend/src/pages/scenario/UseEmbedPage.tsx
@@ -33,6 +33,7 @@ const UseEmbedPageContent: React.FC = () => {
                         baseUrlPath="/tingly/embed"
                         baseUrl={baseUrl}
                         onCopy={copyToClipboard}
+                        scenario={scenario}
                     />
                 </UnifiedCard>
                 <TemplatePage

--- a/frontend/src/pages/scenario/UseImageGenPage.tsx
+++ b/frontend/src/pages/scenario/UseImageGenPage.tsx
@@ -50,6 +50,7 @@ const UseImageGenPageContent: React.FC = () => {
                         baseUrlPath="/tingly/imagegen"
                         baseUrl={baseUrl}
                         onCopy={copyToClipboard}
+                        scenario={scenario}
                     />
                 </UnifiedCard>
                 <ImageGenQuickStartCard

--- a/frontend/src/pages/scenario/UseOpenAIPage.tsx
+++ b/frontend/src/pages/scenario/UseOpenAIPage.tsx
@@ -33,6 +33,7 @@ const UseOpenAIPageContent: React.FC = () => {
                         baseUrlPath="/tingly/openai"
                         baseUrl={baseUrl}
                         onCopy={copyToClipboard}
+                        scenario={scenario}
                     />
                 </UnifiedCard>
                 <TemplatePage

--- a/internal/protocol/transform/rule_thinking.go
+++ b/internal/protocol/transform/rule_thinking.go
@@ -70,10 +70,12 @@ func disableThinking(req interface{}) {
 		r.Thinking = anthropic.ThinkingConfigParamUnion{
 			OfDisabled: &anthropic.ThinkingConfigDisabledParam{},
 		}
+		r.OutputConfig.Effort = ""
 	case *anthropic.BetaMessageNewParams:
 		r.Thinking = anthropic.BetaThinkingConfigParamUnion{
 			OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{},
 		}
+		r.OutputConfig.Effort = ""
 	case *openai.ChatCompletionNewParams:
 		r.ReasoningEffort = ""
 		stripOpenAIThinkingExtra(r)

--- a/internal/protocol/transform/rule_thinking.go
+++ b/internal/protocol/transform/rule_thinking.go
@@ -1,0 +1,131 @@
+package transform
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// RuleThinkingTransform applies the unified thinking_effort control at the
+// rule level. It runs as a post-base stage so the type-switch sees the
+// upstream-bound request shape after protocol conversion.
+//
+// Effort semantics:
+//   - "" (default): pass through, no change.
+//   - "off": force thinking disabled. For Anthropic this sets OfDisabled;
+//     for OpenAI this clears reasoning_effort and removes any stray `thinking`
+//     extension some clients/vendors leave in ExtraFields (DeepSeek and friends
+//     reject requests that carry both reasoning_effort and thinking.type).
+//   - "low"/"medium"/"high"/"max": force thinking enabled with the matching
+//     budget. "max" collapses to "high" for OpenAI which has no "max".
+//
+// Only added to the chain when Effort is non-default.
+type RuleThinkingTransform struct {
+	Effort string
+}
+
+// NewRuleThinkingTransform returns a transform that applies the given effort.
+func NewRuleThinkingTransform(effort string) *RuleThinkingTransform {
+	return &RuleThinkingTransform{Effort: effort}
+}
+
+func (t *RuleThinkingTransform) Name() string { return "rule_thinking" }
+
+// Apply enforces the configured thinking_effort on the target request. For
+// shapes it does not recognize (e.g. Google) it is a no-op.
+func (t *RuleThinkingTransform) Apply(ctx *TransformContext) error {
+	ApplyThinkingEffort(ctx.Request, t.Effort)
+	return nil
+}
+
+// ApplyThinkingEffort is the shared implementation behind both the rule-level
+// and scenario-level thinking_effort handling. It is exported so the
+// server-side prechain (scenario flags) can reuse the same semantics without
+// duplicating the type-switch.
+//
+// Behavior is documented on RuleThinkingTransform.
+func ApplyThinkingEffort(req interface{}, effort string) {
+	switch effort {
+	case typ.ThinkingEffortDefault:
+		return
+	case typ.ThinkingEffortOff:
+		disableThinking(req)
+		return
+	}
+	budget, ok := typ.ThinkingBudgetMapping[effort]
+	if !ok {
+		return
+	}
+	enableThinking(req, effort, budget)
+}
+
+// disableThinking turns thinking off on the target request and scrubs any
+// conflicting extension fields. Conservative: only touches the union variant
+// matching the request type.
+func disableThinking(req interface{}) {
+	switch r := req.(type) {
+	case *anthropic.MessageNewParams:
+		r.Thinking = anthropic.ThinkingConfigParamUnion{
+			OfDisabled: &anthropic.ThinkingConfigDisabledParam{},
+		}
+	case *anthropic.BetaMessageNewParams:
+		r.Thinking = anthropic.BetaThinkingConfigParamUnion{
+			OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{},
+		}
+	case *openai.ChatCompletionNewParams:
+		r.ReasoningEffort = ""
+		stripOpenAIThinkingExtra(r)
+	case *responses.ResponseNewParams:
+		r.Reasoning.Effort = ""
+	}
+}
+
+// enableThinking turns thinking on with the matching budget / effort. As with
+// disable, it also clears any stray `thinking` extension on OpenAI requests
+// so the typed field is the single source of truth.
+func enableThinking(req interface{}, effort string, budget int64) {
+	switch r := req.(type) {
+	case *anthropic.MessageNewParams:
+		r.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
+	case *anthropic.BetaMessageNewParams:
+		r.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budget)
+	case *openai.ChatCompletionNewParams:
+		r.ReasoningEffort = openaiReasoningEffort(effort)
+		stripOpenAIThinkingExtra(r)
+	case *responses.ResponseNewParams:
+		r.Reasoning.Effort = openaiReasoningEffort(effort)
+	}
+}
+
+// stripOpenAIThinkingExtra removes any non-standard `thinking` blob from an
+// OpenAI Chat request's ExtraFields. Several upstreams (DeepSeek, Moonshot)
+// reject requests that carry both the typed `reasoning_effort` and a
+// `thinking.type` extension — they want one or the other. Once the transform
+// has expressed intent through the typed field, the extras blob is redundant
+// at best and a 400 trigger at worst.
+func stripOpenAIThinkingExtra(req *openai.ChatCompletionNewParams) {
+	extra := req.ExtraFields()
+	if extra == nil {
+		return
+	}
+	if _, ok := extra["thinking"]; !ok {
+		return
+	}
+	delete(extra, "thinking")
+	req.SetExtraFields(extra)
+}
+
+// openaiReasoningEffort maps a rule effort level to a valid OpenAI
+// reasoning_effort. "max" collapses to "high" because OpenAI has no "max".
+func openaiReasoningEffort(effort string) shared.ReasoningEffort {
+	switch effort {
+	case typ.ThinkingEffortLow:
+		return shared.ReasoningEffortLow
+	case typ.ThinkingEffortHigh, typ.ThinkingEffortMax:
+		return shared.ReasoningEffortHigh
+	default:
+		return shared.ReasoningEffortMedium
+	}
+}

--- a/internal/protocol/transform/rule_thinking.go
+++ b/internal/protocol/transform/rule_thinking.go
@@ -85,11 +85,22 @@ func disableThinking(req interface{}) {
 // enableThinking turns thinking on with the matching budget / effort. As with
 // disable, it also clears any stray `thinking` extension on OpenAI requests
 // so the typed field is the single source of truth.
+//
+// For Anthropic requests: max_tokens is a hard operator limit and must not be
+// raised. Anthropic enforces budget_tokens <= max_tokens, so if the requested
+// budget exceeds the current max_tokens the budget is capped at max_tokens
+// (floor 1024) rather than overriding the operator's limit.
 func enableThinking(req interface{}, effort string, budget int64) {
 	switch r := req.(type) {
 	case *anthropic.MessageNewParams:
+		if r.MaxTokens > 0 && budget > r.MaxTokens {
+			budget = max(1024, r.MaxTokens)
+		}
 		r.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
 	case *anthropic.BetaMessageNewParams:
+		if r.MaxTokens > 0 && budget > r.MaxTokens {
+			budget = max(1024, r.MaxTokens)
+		}
 		r.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budget)
 	case *openai.ChatCompletionNewParams:
 		r.ReasoningEffort = openaiReasoningEffort(effort)

--- a/internal/protocol/transform/rule_thinking_test.go
+++ b/internal/protocol/transform/rule_thinking_test.go
@@ -123,6 +123,91 @@ func TestRuleThinkingTransform_ResponsesEffort(t *testing.T) {
 	}
 }
 
+func TestRuleThinkingTransform_AnthropicBetaBudget(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortHigh).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.Thinking.OfEnabled == nil {
+		t.Fatalf("expected thinking enabled, got %#v", req.Thinking)
+	}
+	if got := req.Thinking.OfEnabled.BudgetTokens; got != typ.ThinkingBudgetMapping[typ.ThinkingEffortHigh] {
+		t.Errorf("budget = %d, want %d", got, typ.ThinkingBudgetMapping[typ.ThinkingEffortHigh])
+	}
+}
+
+func TestRuleThinkingTransform_AnthropicBetaOffDisables(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Thinking: anthropic.BetaThinkingConfigParamOfEnabled(20480),
+	}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortOff).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.Thinking.OfDisabled == nil {
+		t.Fatalf("expected OfDisabled, got %#v", req.Thinking)
+	}
+	if req.Thinking.OfEnabled != nil {
+		t.Errorf("expected OfEnabled cleared, got %#v", req.Thinking.OfEnabled)
+	}
+}
+
+func TestRuleThinkingTransform_ResponsesOff(t *testing.T) {
+	req := &responses.ResponseNewParams{}
+	req.Reasoning.Effort = shared.ReasoningEffortMedium
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortOff).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.Reasoning.Effort != "" {
+		t.Errorf("reasoning.effort = %q, want empty", req.Reasoning.Effort)
+	}
+}
+
+func TestRuleThinkingTransform_AnthropicCapsBudgetToMaxTokens(t *testing.T) {
+	budget := typ.ThinkingBudgetMapping[typ.ThinkingEffortHigh]
+	req := &anthropic.MessageNewParams{}
+	req.MaxTokens = budget / 2 // smaller than the budget
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortHigh).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// max_tokens must not be raised (hard operator limit)
+	if req.MaxTokens != budget/2 {
+		t.Errorf("max_tokens changed from %d to %d — must not be raised", budget/2, req.MaxTokens)
+	}
+	// budget must be capped at max_tokens so Anthropic doesn't reject
+	if got := req.Thinking.OfEnabled; got == nil {
+		t.Fatalf("expected thinking enabled")
+	} else if got.BudgetTokens > req.MaxTokens {
+		t.Errorf("budget_tokens %d exceeds max_tokens %d", got.BudgetTokens, req.MaxTokens)
+	}
+}
+
+func TestRuleThinkingTransform_AnthropicDoesNotReduceBudgetWhenMaxTokensSufficient(t *testing.T) {
+	budget := typ.ThinkingBudgetMapping[typ.ThinkingEffortLow]
+	req := &anthropic.MessageNewParams{}
+	req.MaxTokens = budget * 4 // already larger than budget
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortLow).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.MaxTokens != budget*4 {
+		t.Errorf("max_tokens = %d, should not have changed from %d", req.MaxTokens, budget*4)
+	}
+	if got := req.Thinking.OfEnabled; got == nil {
+		t.Fatalf("expected thinking enabled")
+	} else if got.BudgetTokens != budget {
+		t.Errorf("budget = %d, want %d", got.BudgetTokens, budget)
+	}
+}
+
 func TestRuleThinkingTransform_DefaultIsNoop(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		ReasoningEffort: shared.ReasoningEffortMedium,

--- a/internal/protocol/transform/rule_thinking_test.go
+++ b/internal/protocol/transform/rule_thinking_test.go
@@ -1,0 +1,150 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestRuleThinkingTransform_AnthropicBudget(t *testing.T) {
+	req := &anthropic.MessageNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortHigh).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.Thinking.OfEnabled == nil {
+		t.Fatalf("expected thinking enabled, got %#v", req.Thinking)
+	}
+	if got := req.Thinking.OfEnabled.BudgetTokens; got != typ.ThinkingBudgetMapping[typ.ThinkingEffortHigh] {
+		t.Errorf("budget = %d, want %d", got, typ.ThinkingBudgetMapping[typ.ThinkingEffortHigh])
+	}
+}
+
+func TestRuleThinkingTransform_AnthropicOffDisables(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Thinking: anthropic.ThinkingConfigParamOfEnabled(20480),
+	}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortOff).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.Thinking.OfDisabled == nil {
+		t.Fatalf("expected OfDisabled, got %#v", req.Thinking)
+	}
+	if req.Thinking.OfEnabled != nil {
+		t.Errorf("expected OfEnabled cleared, got %#v", req.Thinking.OfEnabled)
+	}
+}
+
+func TestRuleThinkingTransform_OpenAIChatEffort(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortLow).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.ReasoningEffort != shared.ReasoningEffortLow {
+		t.Errorf("reasoning_effort = %q, want %q", req.ReasoningEffort, shared.ReasoningEffortLow)
+	}
+}
+
+func TestRuleThinkingTransform_OpenAIMaxCollapsesToHigh(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortMax).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.ReasoningEffort != shared.ReasoningEffortHigh {
+		t.Errorf("max should collapse to high, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestRuleThinkingTransform_OpenAIOffStripsThinkingExtra(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		ReasoningEffort: shared.ReasoningEffortMedium,
+	}
+	// Simulate an upstream-bound request that picked up a `thinking` blob
+	// from a prior Anthropic-style client or vendor transform.
+	req.SetExtraFields(map[string]interface{}{
+		"thinking": map[string]interface{}{"type": "enabled"},
+	})
+
+	ctx := &TransformContext{Request: req}
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortOff).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.ReasoningEffort != "" {
+		t.Errorf("reasoning_effort = %q, want empty", req.ReasoningEffort)
+	}
+	if _, has := req.ExtraFields()["thinking"]; has {
+		t.Errorf("expected `thinking` extra field to be stripped, still present: %#v", req.ExtraFields())
+	}
+}
+
+func TestRuleThinkingTransform_OpenAILevelStripsThinkingExtra(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{}
+	req.SetExtraFields(map[string]interface{}{
+		"thinking": map[string]interface{}{"type": "disabled"},
+		"other":    "keep-me",
+	})
+
+	ctx := &TransformContext{Request: req}
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortHigh).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.ReasoningEffort != shared.ReasoningEffortHigh {
+		t.Errorf("reasoning_effort = %q, want high", req.ReasoningEffort)
+	}
+	extras := req.ExtraFields()
+	if _, has := extras["thinking"]; has {
+		t.Errorf("expected `thinking` extra stripped, got %#v", extras)
+	}
+	if extras["other"] != "keep-me" {
+		t.Errorf("unrelated extras should be preserved, got %#v", extras)
+	}
+}
+
+func TestRuleThinkingTransform_ResponsesEffort(t *testing.T) {
+	req := &responses.ResponseNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortMedium).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.Reasoning.Effort != shared.ReasoningEffortMedium {
+		t.Errorf("reasoning.effort = %q, want %q", req.Reasoning.Effort, shared.ReasoningEffortMedium)
+	}
+}
+
+func TestRuleThinkingTransform_DefaultIsNoop(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		ReasoningEffort: shared.ReasoningEffortMedium,
+	}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortDefault).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.ReasoningEffort != shared.ReasoningEffortMedium {
+		t.Errorf("default effort must not touch reasoning_effort, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestRuleThinkingTransform_UnknownEffortIsNoop(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{}
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform("bogus").Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.ReasoningEffort != "" {
+		t.Errorf("expected no-op for unknown effort, got %q", req.ReasoningEffort)
+	}
+}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1289,6 +1289,12 @@ func (c *Config) GetScenarios() []typ.ScenarioConfig {
 func (c *Config) GetScenarioConfig(scenario typ.RuleScenario) *typ.ScenarioConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	return c.scenarioConfigLocked(scenario)
+}
+
+// scenarioConfigLocked returns the scenario config without acquiring the mutex.
+// Callers must hold at least a read lock.
+func (c *Config) scenarioConfigLocked(scenario typ.RuleScenario) *typ.ScenarioConfig {
 	for i := range c.Scenarios {
 		if c.Scenarios[i].Scenario == scenario {
 			return &c.Scenarios[i]
@@ -1534,7 +1540,7 @@ func (c *Config) ResolveProfileNameOrID(baseScenario typ.RuleScenario, input str
 func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	config := c.GetScenarioConfig(scenario)
+	config := c.scenarioConfigLocked(scenario)
 	if config == nil {
 		return false
 	}
@@ -1649,7 +1655,7 @@ func (c *Config) SetScenarioFlag(scenario typ.RuleScenario, flagName string, val
 func (c *Config) GetScenarioStringFlag(scenario typ.RuleScenario, flagName string) string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	config := c.GetScenarioConfig(scenario)
+	config := c.scenarioConfigLocked(scenario)
 	if config == nil {
 		return ""
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1657,8 +1657,6 @@ func (c *Config) GetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 	switch flagName {
 	case "thinking_effort":
 		return flags.ThinkingEffort
-	case "thinking_mode":
-		return flags.ThinkingMode
 	case "recording_v2":
 		return string(flags.RecordingV2)
 	default:
@@ -1695,8 +1693,6 @@ func (c *Config) SetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 	switch flagName {
 	case "thinking_effort":
 		config.Flags.ThinkingEffort = typ.ThinkingEffortLevel(value)
-	case "thinking_mode":
-		config.Flags.ThinkingMode = value
 	case "recording_v2":
 		if !typ.IsValidRecordingMode(value) {
 			return fmt.Errorf("invalid recording_v2 value: %s (must be one of: request, request_response, staged_request_response, or empty)", value)

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -61,6 +61,9 @@ func ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform {
 			flags.UseMaxTokens,
 		))
 	}
+	if flags.ThinkingEffort != typ.ThinkingEffortDefault {
+		extras = append(extras, transform.NewRuleThinkingTransform(flags.ThinkingEffort))
+	}
 	return extras
 }
 

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -190,6 +190,27 @@ func TestRuleExtraTransforms_UseMaxTokens(t *testing.T) {
 	}
 }
 
+func TestRuleExtraTransforms_ThinkingEffort(t *testing.T) {
+	got := ruleExtraTransforms(typ.RuleFlags{ThinkingEffort: typ.ThinkingEffortHigh})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 transform, got %d", len(got))
+	}
+	tf, ok := got[0].(*transform.RuleThinkingTransform)
+	if !ok {
+		t.Fatalf("expected *transform.RuleThinkingTransform, got %T", got[0])
+	}
+	if tf.Effort != typ.ThinkingEffortHigh {
+		t.Errorf("effort not propagated: got %q, want %q", tf.Effort, typ.ThinkingEffortHigh)
+	}
+}
+
+func TestRuleExtraTransforms_ThinkingEffortEmpty_NoTransform(t *testing.T) {
+	got := ruleExtraTransforms(typ.RuleFlags{ThinkingEffort: typ.ThinkingEffortDefault})
+	if got != nil {
+		t.Errorf("empty thinking effort should add no transform, got %d", len(got))
+	}
+}
+
 func TestRuleExtraTransforms_CursorCompatAlone_NoTransform(t *testing.T) {
 	// CursorCompat is a pre-Base flag — it must not surface in the post-Base
 	// extras list. This is the safety net for the rule-flag-to-transform

--- a/internal/server/transform_max_tokens.go
+++ b/internal/server/transform_max_tokens.go
@@ -44,8 +44,15 @@ func (t *MaxTokensTransform) applyAnthropicV1(req *anthropic.MessageNewParams) {
 	if req.MaxTokens > maxAllowed {
 		req.MaxTokens = maxAllowed
 	}
-	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil && *thinkBudget > maxAllowed {
-		req.Thinking = anthropic.ThinkingConfigParamOfEnabled(max(1024, int64(t.MaxAllowed/10)))
+	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil {
+		if *thinkBudget > maxAllowed {
+			req.Thinking = anthropic.ThinkingConfigParamOfEnabled(max(1024, int64(t.MaxAllowed/10)))
+		}
+		// Anthropic enforces budget_tokens <= max_tokens. max_tokens is a hard
+		// operator limit — cap the budget rather than raising the limit.
+		if budget := req.Thinking.GetBudgetTokens(); budget != nil && *budget > req.MaxTokens {
+			req.Thinking = anthropic.ThinkingConfigParamOfEnabled(max(1024, req.MaxTokens))
+		}
 	}
 }
 
@@ -57,7 +64,14 @@ func (t *MaxTokensTransform) applyAnthropicBeta(req *anthropic.BetaMessageNewPar
 	if req.MaxTokens > maxAllowed {
 		req.MaxTokens = maxAllowed
 	}
-	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil && *thinkBudget > maxAllowed {
-		req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(max(1024, int64(t.MaxAllowed/10)))
+	if thinkBudget := req.Thinking.GetBudgetTokens(); thinkBudget != nil {
+		if *thinkBudget > maxAllowed {
+			req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(max(1024, int64(t.MaxAllowed/10)))
+		}
+		// Anthropic enforces budget_tokens <= max_tokens. max_tokens is a hard
+		// operator limit — cap the budget rather than raising the limit.
+		if budget := req.Thinking.GetBudgetTokens(); budget != nil && *budget > req.MaxTokens {
+			req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(max(1024, req.MaxTokens))
+		}
 	}
 }

--- a/internal/server/transform_prechain.go
+++ b/internal/server/transform_prechain.go
@@ -17,8 +17,8 @@ func buildAnthropicPreChain(
 
 	if scenarioConfig != nil {
 		flags := &scenarioConfig.Flags
-		if flags.ThinkingMode != "" {
-			chain = append(chain, NewThinkingModeTransform(scenarioConfig))
+		if flags.ThinkingEffort != typ.ThinkingEffortDefault {
+			chain = append(chain, NewThinkingEffortTransform(flags.ThinkingEffort))
 		}
 		if flags.CleanHeader {
 			chain = append(chain, NewCleanHeaderTransform())

--- a/internal/server/transform_thinking_mode.go
+++ b/internal/server/transform_thinking_mode.go
@@ -1,99 +1,27 @@
 package server
 
 import (
-	"github.com/anthropics/anthropic-sdk-go"
 	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
-	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// ThinkingModeTransform controls how extended thinking is enabled based on scenario config.
+// ThinkingEffortTransform is the scenario-level pre-base transform that
+// applies the unified thinking_effort control on the inbound request. It is
+// a thin wrapper around protocoltransform.ApplyThinkingEffort so the
+// scenario-level and rule-level chains share a single implementation.
 //
-// Supported modes:
-//   - Force: always enable thinking with the configured budget.
-//   - Adaptive: convert any existing thinking config (OfEnabled or OfAdaptive) to OfEnabled.
-//   - Default: only convert OfEnabled to use the configured budget; leave OfAdaptive untouched.
-//   - Any other value: disable thinking entirely.
-//
-// Budget resolution priority: client-provided budget > effort-level mapping > medium fallback.
-// Only added to the chain when ThinkingMode is non-empty.
-type ThinkingModeTransform struct {
-	ScenarioConfig *typ.ScenarioConfig
+// Only added to the chain when Effort is non-default ("" / "by client").
+type ThinkingEffortTransform struct {
+	Effort string
 }
 
-// NewThinkingModeTransform creates a ThinkingModeTransform.
-func NewThinkingModeTransform(scenarioConfig *typ.ScenarioConfig) *ThinkingModeTransform {
-	return &ThinkingModeTransform{ScenarioConfig: scenarioConfig}
+// NewThinkingEffortTransform creates a ThinkingEffortTransform.
+func NewThinkingEffortTransform(effort string) *ThinkingEffortTransform {
+	return &ThinkingEffortTransform{Effort: effort}
 }
 
-func (t *ThinkingModeTransform) Name() string { return "thinking_mode" }
+func (t *ThinkingEffortTransform) Name() string { return "thinking_effort" }
 
-func (t *ThinkingModeTransform) Apply(ctx *protocoltransform.TransformContext) error {
-	switch req := ctx.Request.(type) {
-	case *anthropic.MessageNewParams:
-		t.applyAnthropicV1(req)
-	case *anthropic.BetaMessageNewParams:
-		t.applyAnthropicBeta(req)
-	}
+func (t *ThinkingEffortTransform) Apply(ctx *protocoltransform.TransformContext) error {
+	protocoltransform.ApplyThinkingEffort(ctx.Request, t.Effort)
 	return nil
-}
-
-// resolveBudgetTokens determines the thinking budget to use.
-// Client-provided budget takes precedence over effort-level mapping.
-func (t *ThinkingModeTransform) resolveBudgetTokens(thinkBudget *int64) int64 {
-	effort := t.ScenarioConfig.Flags.ThinkingEffort
-	if effort == typ.ThinkingEffortDefault {
-		effort = typ.ThinkingEffortMedium
-	}
-	budgetTokens, ok := typ.ThinkingBudgetMapping[effort]
-	if !ok {
-		budgetTokens = typ.ThinkingBudgetMapping[typ.ThinkingEffortMedium]
-	}
-	if thinkBudget != nil {
-		budgetTokens = *thinkBudget
-	}
-	return budgetTokens
-}
-
-func (t *ThinkingModeTransform) applyAnthropicV1(req *anthropic.MessageNewParams) {
-	budgetTokens := t.resolveBudgetTokens(req.Thinking.GetBudgetTokens())
-
-	switch typ.ThinkingMode(t.ScenarioConfig.Flags.ThinkingMode) {
-	case typ.ThinkingModeForce:
-		req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budgetTokens)
-	case typ.ThinkingModeAdaptive:
-		switch {
-		case req.Thinking.OfEnabled != nil:
-			req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budgetTokens)
-		case req.Thinking.OfAdaptive != nil:
-			req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budgetTokens)
-		}
-	case typ.ThinkingModeDefault:
-		if req.Thinking.OfEnabled != nil {
-			req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budgetTokens)
-		}
-	default:
-		req.Thinking = anthropic.ThinkingConfigParamUnion{OfDisabled: &anthropic.ThinkingConfigDisabledParam{}}
-	}
-}
-
-func (t *ThinkingModeTransform) applyAnthropicBeta(req *anthropic.BetaMessageNewParams) {
-	budgetTokens := t.resolveBudgetTokens(req.Thinking.GetBudgetTokens())
-
-	switch typ.ThinkingMode(t.ScenarioConfig.Flags.ThinkingMode) {
-	case typ.ThinkingModeForce:
-		req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budgetTokens)
-	case typ.ThinkingModeAdaptive:
-		switch {
-		case req.Thinking.OfEnabled != nil:
-			req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budgetTokens)
-		case req.Thinking.OfAdaptive != nil:
-			req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budgetTokens)
-		}
-	case typ.ThinkingModeDefault:
-		if req.Thinking.OfEnabled != nil {
-			req.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budgetTokens)
-		}
-	default:
-		req.Thinking = anthropic.BetaThinkingConfigParamUnion{OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{}}
-	}
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -25,6 +25,8 @@ const (
 	// FlagCategoryRequest — protocol-agnostic request-body guard rails
 	// (tool blocking, etc).
 	FlagCategoryRequest FlagCategory = "request"
+	// FlagCategoryReasoning — extended-thinking / reasoning-effort controls.
+	FlagCategoryReasoning FlagCategory = "reasoning"
 )
 
 // FlagOption is one selectable value for a FlagTypeEnum spec.
@@ -114,6 +116,21 @@ func RuleFlagRegistry() []FlagSpec {
 			Type:        FlagTypeString,
 			Category:    FlagCategoryRequest,
 			Placeholder: "e.g. web_search,run_terminal_cmd",
+		},
+		{
+			Key:         "thinking_effort",
+			Label:       "Thinking",
+			Description: "Single control for extended thinking. \"By Client\" passes the client's thinking config through unchanged. \"Off\" forces thinking disabled. The level values force thinking on with the matching budget — mapped to budget_tokens for Anthropic targets (low 1K / medium 5K / high 20K / max 32K) and to reasoning_effort for OpenAI targets (\"max\" collapses to \"high\").",
+			Type:        FlagTypeEnum,
+			Category:    FlagCategoryReasoning,
+			Options: []FlagOption{
+				{Value: "", Label: "By Client"},
+				{Value: "off", Label: "Off"},
+				{Value: "low", Label: "Low (~1K tokens)"},
+				{Value: "medium", Label: "Medium (~5K tokens)"},
+				{Value: "high", Label: "High (~20K tokens)"},
+				{Value: "max", Label: "Max (~32K tokens)"},
+			},
 		},
 	}
 }

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -85,7 +85,9 @@ func TestRuleFlagRegistry_TypesAreValid(t *testing.T) {
 }
 
 // TestRuleFlagRegistry_EnumOptions asserts that every FlagTypeEnum spec
-// declares at least two options with non-empty Value and Label.
+// declares at least two options with non-empty Labels. The first option's
+// Value may be empty (it acts as the inactive/"By Client" sentinel that
+// `omitempty` hides on the wire); subsequent options must carry a value.
 func TestRuleFlagRegistry_EnumOptions(t *testing.T) {
 	for _, spec := range RuleFlagRegistry() {
 		if spec.Type != FlagTypeEnum {
@@ -96,8 +98,8 @@ func TestRuleFlagRegistry_EnumOptions(t *testing.T) {
 		}
 		seen := map[string]bool{}
 		for i, opt := range spec.Options {
-			if opt.Value == "" {
-				t.Errorf("enum flag %q option %d has empty Value", spec.Key, i)
+			if opt.Value == "" && i != 0 {
+				t.Errorf("enum flag %q option %d has empty Value (only the first option may be empty as the inactive sentinel)", spec.Key, i)
 			}
 			if opt.Label == "" {
 				t.Errorf("enum flag %q option %d has empty Label", spec.Key, i)

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -109,14 +109,17 @@ var ThinkingBudgetMapping = map[ThinkingEffortLevel]int64{
 	ThinkingEffortMax:    31999, // ~32K tokens - maximum
 }
 
-// ThinkingMode represents the thinking mode for extended thinking.
-// Used by the scenario-level thinking_mode flag.
+// ThinkingMode is retained for backward compatibility with the deprecated
+// per-scenario / per-rule "thinking_mode" flag. New code should use
+// ThinkingEffortLevel (with "off" / level / "" semantics) instead.
 type ThinkingMode string
 
 const (
-	ThinkingModeDefault  ThinkingMode = "default"  // Use model default
-	ThinkingModeAdaptive ThinkingMode = "adaptive" // Model decides when to use
-	ThinkingModeForce    ThinkingMode = "force"    // Force for all requests
+	ThinkingModeDefault  ThinkingMode = "default"  // Use client request config
+	ThinkingModeEnable   ThinkingMode = "enable"   // Force extended thinking on
+	ThinkingModeDisable  ThinkingMode = "disable"  // Force extended thinking off
+	ThinkingModeAdaptive ThinkingMode = "adaptive" // Convert existing thinking config to enabled
+	ThinkingModeForce    ThinkingMode = "force"    // Deprecated alias for ThinkingModeEnable
 )
 
 // RecordingMode represents the recording mode for scenario recording
@@ -153,12 +156,10 @@ type ScenarioFlags struct {
 	// Stream configuration flags
 	DisableStreamUsage bool `json:"disable_stream_usage,omitempty" yaml:"disable_stream_usage,omitempty"` // Don't include usage in streaming chunks (for incompatible clients like xcode)
 
-	// Thinking effort level (empty string = use model default)
+	// ThinkingEffort is the unified extended-thinking control. Recognized
+	// values: "" (by client, default), "off" (force disabled), or one of
+	// "low"/"medium"/"high"/"max" (force enabled with the matching budget).
 	ThinkingEffort ThinkingEffortLevel `json:"thinking_effort,omitempty" yaml:"thinking_effort,omitempty"`
-
-	// Thinking mode for claude_code scenario (default/adaptive/force)
-	// Using string directly instead of ThinkingMode type to avoid naming conflicts
-	ThinkingMode string `json:"thinking_mode,omitempty" yaml:"thinking_mode,omitempty"`
 
 	CleanHeader bool `json:"clean_header,omitempty" yaml:"clean_header,omitempty"` // Remove billing header from system messages (Claude Code only)
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -87,24 +87,30 @@ func BuiltinScenarios() []RuleScenario {
 type ThinkingEffortLevel = string
 
 const (
-	ThinkingEffortLow     ThinkingEffortLevel = "low"
-	ThinkingEffortMedium  ThinkingEffortLevel = "medium"
-	ThinkingEffortHigh    ThinkingEffortLevel = "high"
-	ThinkingEffortMax     ThinkingEffortLevel = "max"
-	ThinkingEffortDefault ThinkingEffortLevel = "" // Use model default
+	// ThinkingEffortDefault is the "by client" sentinel: pass the client's
+	// thinking config through unchanged. Empty string so omitempty hides it.
+	ThinkingEffortDefault ThinkingEffortLevel = ""
+	// ThinkingEffortOff is the "explicitly disabled" sentinel: strip thinking
+	// from the outbound request regardless of what the client sent.
+	ThinkingEffortOff    ThinkingEffortLevel = "off"
+	ThinkingEffortLow    ThinkingEffortLevel = "low"
+	ThinkingEffortMedium ThinkingEffortLevel = "medium"
+	ThinkingEffortHigh   ThinkingEffortLevel = "high"
+	ThinkingEffortMax    ThinkingEffortLevel = "max"
 )
 
-// ThinkingBudgetMapping defines budget_tokens for each effort level
-// Note: Default max is 31,999 tokens per Claude Code documentation
+// ThinkingBudgetMapping defines budget_tokens for each effort level.
+// "off" / "" are intentionally absent — they signal disabled / pass-through,
+// not a budget value, and are handled out-of-band by the transform layer.
 var ThinkingBudgetMapping = map[ThinkingEffortLevel]int64{
-	ThinkingEffortDefault: 31999,
-	ThinkingEffortLow:     1024,  // ~1K tokens - minimal reasoning (minimum allowed)
-	ThinkingEffortMedium:  5120,  // ~5K tokens - balanced
-	ThinkingEffortHigh:    20480, // ~20K tokens - deep reasoning
-	ThinkingEffortMax:     31999, // ~32K tokens - maximum (default)
+	ThinkingEffortLow:    1024,  // ~1K tokens - minimal reasoning (minimum allowed)
+	ThinkingEffortMedium: 5120,  // ~5K tokens - balanced
+	ThinkingEffortHigh:   20480, // ~20K tokens - deep reasoning
+	ThinkingEffortMax:    31999, // ~32K tokens - maximum
 }
 
-// ThinkingMode represents the thinking mode for extended thinking
+// ThinkingMode represents the thinking mode for extended thinking.
+// Used by the scenario-level thinking_mode flag.
 type ThinkingMode string
 
 const (
@@ -191,6 +197,13 @@ type RuleFlags struct {
 	// inbound request's tool list before it is forwarded upstream. Matching is
 	// exact on the tool name as the client sent it. Empty means no blocking.
 	BlockTools string `json:"block_tools,omitempty" yaml:"block_tools,omitempty"`
+
+	// ThinkingEffort is the unified extended-thinking control. Recognized
+	// values: "" (by client, default), "off" (force disabled), or one of
+	// "low"/"medium"/"high"/"max" (force enabled with the matching budget).
+	// Maps to budget_tokens for Anthropic and reasoning_effort for OpenAI
+	// ("max" collapses to "high" for OpenAI which has no "max").
+	ThinkingEffort ThinkingEffortLevel `json:"thinking_effort,omitempty" yaml:"thinking_effort,omitempty"`
 }
 
 // ProfileMeta stores metadata for a scenario profile.

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -223,13 +223,17 @@ type ScenarioConfig struct {
 	Extensions map[string]interface{} `json:"extensions,omitempty" yaml:"extensions,omitempty"` // Reserved for future extensions
 }
 
-// GetDefaultFlags returns default flags for a scenario
+// GetDefaultFlags returns the effective flags for a scenario.
+// If no routing mode (Unified/Separate/Smart) is explicitly set, Unified
+// defaults to true so callers that depend on exactly one mode being active
+// always see a consistent value. All other flags are returned as stored.
 func (sc *ScenarioConfig) GetDefaultFlags() ScenarioFlags {
 	if sc.Flags.Unified || sc.Flags.Separate || sc.Flags.Smart {
 		return sc.Flags
 	}
-	// Default to unified if no flag is set
-	return ScenarioFlags{Unified: true}
+	result := sc.Flags
+	result.Unified = true
+	return result
 }
 
 // AuthType represents the authentication type for a provider


### PR DESCRIPTION
## Summary

Collapses `thinking_mode` + `thinking_effort` into a single
`thinking_effort` enum at both the rule and scenario level. The split
created a contradictory cross-product (`mode=disable + effort=high`)
and 400s where one transform set `reasoning_effort` while the other
left `thinking.type=disabled` in extras.

## The new shape

`thinking_effort` is a single enum on both `RuleFlags` and `ScenarioFlags`:

| Value | Meaning |
| --- | --- |
| `""` | **By Client** — passthrough |
| `"off"` | Force disabled |
| `"low"` / `"medium"` / `"high"` / `"max"` | Force enabled with the matching budget |

Anthropic targets → `thinking.budget_tokens` (1K / 5K / 20K / 32K).
OpenAI targets → `reasoning_effort` (`max` collapses to `high`).

## Implementation

- New `ApplyThinkingEffort(req, effort)` is the single source of truth,
  shared by the rule-level `RuleThinkingTransform` and the
  scenario-level `ThinkingEffortTransform`. Covers all four protocol
  shapes (Anthropic v1/Beta, OpenAI Chat/Responses).
- OpenAI Chat: whenever we set the typed `reasoning_effort`, also strip
  any stray `thinking` blob from `ExtraFields()` (this was the
  DeepSeek 400 trigger).
- Anthropic: `off` also clears `OutputConfig.Effort` so downstream
  conversion can't re-derive a stale effort. Enable path caps budget
  at `max_tokens` (hard operator limit, never raised).
- Bug fix: `GetDefaultFlags` was returning a bare `{Unified: true}`
  sentinel when no routing-mode flag was set, silently dropping all
  stored feature flags on refresh.
- Bug fix: `GetScenarioFlag` / `GetScenarioStringFlag` re-entered
  `GetScenarioConfig` while holding the read lock — replaced with an
  internal unlocked helper.
- Frontend: collapses the two buttons / fields / catalog entries into
  one. Fixes 5 scenario pages that were missing `scenario` on
  `ProviderConfigCard`, so `PluginFeatures` never mounted.

## Test plan
- [x] `go test ./internal/typ/ ./internal/protocol/transform/ ./internal/server/config/` passes
- [x] `npx tsc --noEmit` clean for touched files
- [ ] In the UI, verify the Plugin row shows a single Thinking button
      with six options and selection persists across refresh
- [ ] In a rule's Extensions dialog, verify `Off` produces an Anthropic
      `OfDisabled` upstream with no `reasoning_effort` leak

https://claude.ai/code/session_01Mnf2FeE8ETcnEbhTgZe4uT