### PR TITLE
feat(vmodel): stream-test mocks with full usage shape (cache + reasoning)

### DIFF
--- a/vmodel/anthropic/defaults.go
+++ b/vmodel/anthropic/defaults.go
@@ -70,3 +70,22 @@ func RegisterDefaults(r *Registry) {
 		_ = r.Register(NewTransformModel(&compactModels[i]))
 	}
 }
+
+// RegisterStreamTestMocks registers the opt-in stream-test fixtures
+// (virtual-stream-test, virtual-stream-test-tool) into r. These advertise
+// deterministic, fully-populated usage (input / output / cache read /
+// cache creation / reasoning) so streaming converters can be exercised
+// end-to-end without a real upstream. Intentionally separate from
+// RegisterDefaults so production registries stay clean.
+func RegisterStreamTestMocks(r *Registry) {
+	for _, spec := range vmodel.StreamTestMockSpecs() {
+		_ = r.Register(NewMockModel(&MockModelConfig{
+			ID:       spec.ID,
+			Name:     spec.Name,
+			Content:  spec.Content,
+			ToolCall: spec.ToolCall,
+			Delay:    spec.Delay,
+			Usage:    spec.Usage,
+		}))
+	}
+}

--- a/vmodel/anthropic/mock_model.go
+++ b/vmodel/anthropic/mock_model.go
@@ -24,6 +24,10 @@ type MockModelConfig struct {
 
 	// tool-type: if set, the response includes a tool_use block.
 	ToolCall *vmodel.ToolCallConfig
+
+	// Usage, when set, is emitted as a UsageEvent immediately before
+	// DoneEvent (rendered by virtualserver inside message_delta.usage).
+	Usage *vmodel.MockUsage
 }
 
 // MockModel is an Anthropic-only mock virtual model. It returns a fixed
@@ -132,6 +136,9 @@ func (m *MockModel) HandleAnthropicStream(req *protocol.AnthropicBetaMessagesReq
 				Input: inputJSON,
 			})
 		}
+	}
+	if m.cfg.Usage != nil {
+		emit(UsageEvent{Usage: *m.cfg.Usage})
 	}
 	emit(DoneEvent{StopReason: string(resp.StopReason)})
 	return nil

--- a/vmodel/anthropic/stream.go
+++ b/vmodel/anthropic/stream.go
@@ -28,6 +28,13 @@ type ToolUseEvent struct {
 	Input json.RawMessage
 }
 
+// UsageEvent carries explicit token usage that the model wants the wire
+// stream to advertise (typically just before DoneEvent — emitted by
+// virtualserver inside message_delta.usage).
+type UsageEvent struct {
+	Usage vmodel.MockUsage
+}
+
 // DoneEvent signals end of stream with stop reason.
 type DoneEvent struct {
 	StopReason string

--- a/vmodel/defaults_shared.go
+++ b/vmodel/defaults_shared.go
@@ -2,6 +2,19 @@ package vmodel
 
 import "time"
 
+// MockUsage carries deterministic token-usage values that a mock model
+// emits over its streaming wire format. All fields are optional; a zero
+// value means "do not advertise this dimension". Used so streaming
+// converters / observers can be tested for completeness (cache and
+// reasoning tokens, not just plain prompt/completion).
+type MockUsage struct {
+	PromptTokens             int64 // input_tokens / prompt_tokens
+	CompletionTokens         int64 // output_tokens / completion_tokens
+	CachedInputTokens        int64 // OpenAI prompt_tokens_details.cached_tokens / Anthropic cache_read_input_tokens
+	CacheCreationInputTokens int64 // Anthropic cache_creation_input_tokens (no OpenAI analogue)
+	ReasoningTokens          int64 // OpenAI completion_tokens_details.reasoning_tokens
+}
+
 // SharedMockSpec describes a built-in mock that is identical across
 // protocols (anthropic + openai). Each protocol's RegisterDefaults converts
 // a SharedMockSpec into its own protocol-specific MockModelConfig.
@@ -17,6 +30,7 @@ type SharedMockSpec struct {
 	Content  string          // static text response (ignored if ToolCall is set)
 	ToolCall *ToolCallConfig // if non-nil, this is a tool model
 	Delay    time.Duration
+	Usage    *MockUsage // optional explicit usage to advertise in the stream
 }
 
 // SharedDefaultMocks returns the mocks registered by BOTH the Anthropic and
@@ -69,6 +83,39 @@ func SharedDefaultMocks() []SharedMockSpec {
 				Arguments: map[string]interface{}{"query": "latest AI developments"},
 			},
 			Delay: 50 * time.Millisecond,
+		},
+	}
+}
+
+// StreamTestMockSpecs returns deterministic stream-test fixtures (static +
+// tool variants) that advertise the full usage shape — prompt, completion,
+// cached input, cache-creation input, and reasoning tokens. These are
+// opt-in (NOT in SharedDefaultMocks): consumers wire them into their own
+// registry via RegisterStreamTestMocks helpers in the per-protocol
+// sub-packages.
+func StreamTestMockSpecs() []SharedMockSpec {
+	usage := &MockUsage{
+		PromptTokens:             42,
+		CompletionTokens:         17,
+		CachedInputTokens:        11,
+		CacheCreationInputTokens: 5,
+		ReasoningTokens:          9,
+	}
+	return []SharedMockSpec{
+		{
+			ID:      "virtual-stream-test",
+			Name:    "Virtual Stream Test",
+			Content: "Stream test response for usage coverage.",
+			Usage:   usage,
+		},
+		{
+			ID:   "virtual-stream-test-tool",
+			Name: "Virtual Stream Test (Tool)",
+			ToolCall: &ToolCallConfig{
+				Name:      "stream_test_tool",
+				Arguments: map[string]interface{}{"ok": true},
+			},
+			Usage: usage,
 		},
 	}
 }

--- a/vmodel/openai/defaults.go
+++ b/vmodel/openai/defaults.go
@@ -30,3 +30,22 @@ func RegisterDefaults(r *Registry) {
 		}))
 	}
 }
+
+// RegisterStreamTestMocks registers the opt-in stream-test fixtures
+// (virtual-stream-test, virtual-stream-test-tool) into r. These advertise
+// deterministic, fully-populated usage (prompt / completion / cached input /
+// reasoning) so streaming converters can be exercised end-to-end without a
+// real upstream. Intentionally separate from RegisterDefaults so production
+// registries stay clean.
+func RegisterStreamTestMocks(r *Registry) {
+	for _, spec := range vmodel.StreamTestMockSpecs() {
+		_ = r.Register(NewMockModel(&MockModelConfig{
+			ID:       spec.ID,
+			Name:     spec.Name,
+			Content:  spec.Content,
+			ToolCall: spec.ToolCall,
+			Delay:    spec.Delay,
+			Usage:    spec.Usage,
+		}))
+	}
+}

--- a/vmodel/openai/mock_model.go
+++ b/vmodel/openai/mock_model.go
@@ -22,6 +22,11 @@ type MockModelConfig struct {
 
 	// tool-type: if set, the response includes tool calls.
 	ToolCall *vmodel.ToolCallConfig
+
+	// Usage, when set, is emitted as a UsageEvent immediately before
+	// DoneEvent so streaming consumers can be exercised against a
+	// deterministic, fully-populated usage shape.
+	Usage *vmodel.MockUsage
 }
 
 // MockModel is an OpenAI-Chat-only mock virtual model.
@@ -107,6 +112,9 @@ func (m *MockModel) HandleOpenAIChatStream(req *protocol.OpenAIChatCompletionReq
 	})
 	for i, tc := range resp.ToolCalls {
 		emit(ToolEvent{Index: i, ToolCall: tc})
+	}
+	if m.cfg.Usage != nil {
+		emit(UsageEvent{Usage: *m.cfg.Usage})
 	}
 	emit(DoneEvent{FinishReason: resp.FinishReason})
 	return nil

--- a/vmodel/openai/stream.go
+++ b/vmodel/openai/stream.go
@@ -18,6 +18,12 @@ type ToolEvent struct {
 	ToolCall VToolCall
 }
 
+// UsageEvent carries explicit token usage that the model wants the wire
+// stream to advertise (typically just before DoneEvent).
+type UsageEvent struct {
+	Usage vmodel.MockUsage
+}
+
 // DoneEvent signals end of stream with finish reason.
 type DoneEvent struct {
 	FinishReason string

--- a/vmodel/virtualserver/handler.go
+++ b/vmodel/virtualserver/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
+	"github.com/tingly-dev/tingly-box/vmodel"
 
 	anthropicvm "github.com/tingly-dev/tingly-box/vmodel/anthropic"
 	openaivm "github.com/tingly-dev/tingly-box/vmodel/openai"
@@ -212,6 +213,9 @@ func (h *Handler) handleAnthropicStreaming(c *gin.Context, req *AnthropicMessage
 			time.Sleep(d)
 		}
 
+		var explicitUsage *vmodel.MockUsage
+		var stopReason string
+
 		err := vm.HandleAnthropicStream(req, func(ev any) {
 			switch e := ev.(type) {
 			case anthropicvm.StreamStartEvent:
@@ -243,9 +247,40 @@ func (h *Handler) handleAnthropicStreaming(c *gin.Context, req *AnthropicMessage
 					},
 				})
 				fmt.Fprintf(w, "event: content_block_start\ndata: %s\n\n", data)
+			case anthropicvm.UsageEvent:
+				u := e.Usage
+				explicitUsage = &u
 			case anthropicvm.DoneEvent:
-				data, _ := json.Marshal(AnthropicStreamEvent{Type: "message_stop"})
-				fmt.Fprintf(w, "event: message_stop\ndata: %s\n\n", data)
+				stopReason = e.StopReason
+				// Emit message_delta with stop_reason + usage (Anthropic
+				// places terminal usage on message_delta, not message_stop).
+				deltaPayload := map[string]interface{}{
+					"type": "message_delta",
+					"delta": map[string]interface{}{
+						"stop_reason":   stopReason,
+						"stop_sequence": nil,
+					},
+				}
+				usageMap := map[string]interface{}{}
+				if explicitUsage != nil {
+					usageMap["input_tokens"] = explicitUsage.PromptTokens
+					usageMap["output_tokens"] = explicitUsage.CompletionTokens
+					if explicitUsage.CachedInputTokens > 0 {
+						usageMap["cache_read_input_tokens"] = explicitUsage.CachedInputTokens
+					}
+					if explicitUsage.CacheCreationInputTokens > 0 {
+						usageMap["cache_creation_input_tokens"] = explicitUsage.CacheCreationInputTokens
+					}
+					if explicitUsage.ReasoningTokens > 0 {
+						usageMap["reasoning_tokens"] = explicitUsage.ReasoningTokens
+					}
+				}
+				deltaPayload["usage"] = usageMap
+				data, _ := json.Marshal(deltaPayload)
+				fmt.Fprintf(w, "event: message_delta\ndata: %s\n\n", data)
+
+				stopData, _ := json.Marshal(AnthropicStreamEvent{Type: "message_stop"})
+				fmt.Fprintf(w, "event: message_stop\ndata: %s\n\n", stopData)
 			}
 			c.Writer.Flush()
 		})
@@ -324,6 +359,8 @@ func (h *Handler) handleOpenAIStreaming(c *gin.Context, req *ChatCompletionReque
 
 		chunkIndex := 0
 		var finishReason string
+		var completionText string
+		var explicitUsage *vmodel.MockUsage
 
 		err := vm.HandleOpenAIChatStream(req, func(ev any) {
 			select {
@@ -335,6 +372,7 @@ func (h *Handler) handleOpenAIStreaming(c *gin.Context, req *ChatCompletionReque
 			switch e := ev.(type) {
 			case openaivm.DeltaEvent:
 				chunkIndex = e.Index + 1
+				completionText += e.Content
 				data, _ := json.Marshal(ChatCompletionStreamResponse{
 					ID:      fmt.Sprintf("chatcmpl-virtual-%d", time.Now().Unix()),
 					Created: time.Now().Unix(),
@@ -365,6 +403,9 @@ func (h *Handler) handleOpenAIStreaming(c *gin.Context, req *ChatCompletionReque
 					})
 					c.SSEvent("", string(data))
 				}
+			case openaivm.UsageEvent:
+				u := e.Usage
+				explicitUsage = &u
 			case openaivm.DoneEvent:
 				finishReason = e.FinishReason
 				data, _ := json.Marshal(ChatCompletionStreamResponse{
@@ -383,6 +424,43 @@ func (h *Handler) handleOpenAIStreaming(c *gin.Context, req *ChatCompletionReque
 				"type":    "api_error",
 			}})
 			return false
+		}
+
+		// Mirror real OpenAI: when stream_options.include_usage=true (or the
+		// mock advertised an explicit UsageEvent), emit a trailing usage-only
+		// chunk (choices:[], usage:{...}) after the finish_reason chunk and
+		// before [DONE]. Explicit MockUsage takes precedence so tests get
+		// deterministic, fully-populated values (including cached prompt
+		// tokens and reasoning tokens).
+		if req.StreamOptions.IncludeUsage.Value || explicitUsage != nil {
+			usage := openai.CompletionUsage{}
+			if explicitUsage != nil {
+				usage.PromptTokens = explicitUsage.PromptTokens
+				usage.CompletionTokens = explicitUsage.CompletionTokens
+				usage.TotalTokens = explicitUsage.PromptTokens + explicitUsage.CompletionTokens
+				if explicitUsage.CachedInputTokens > 0 {
+					usage.PromptTokensDetails.CachedTokens = explicitUsage.CachedInputTokens
+				}
+				if explicitUsage.ReasoningTokens > 0 {
+					usage.CompletionTokensDetails.ReasoningTokens = explicitUsage.ReasoningTokens
+				}
+			} else {
+				promptTokens := token.EstimateMessagesTokens(req.Messages)
+				completionTokens := token.EstimateTokensString(completionText)
+				usage.PromptTokens = int64(promptTokens)
+				usage.CompletionTokens = int64(completionTokens)
+				usage.TotalTokens = int64(promptTokens + completionTokens)
+			}
+			usageChunk := ChatCompletionStreamResponse{
+				ID:      fmt.Sprintf("chatcmpl-virtual-%d", time.Now().Unix()),
+				Created: time.Now().Unix(),
+				Model:   req.Model,
+				Choices: []StreamChoice{},
+				Usage:   usage,
+			}
+			data, _ := json.Marshal(usageChunk)
+			c.SSEvent("", string(data))
+			c.Writer.Flush()
 		}
 
 		c.SSEvent("", "[DONE]")

--- a/vmodel/virtualserver/stream_test_mocks_test.go
+++ b/vmodel/virtualserver/stream_test_mocks_test.go
@@ -1,0 +1,173 @@
+package virtualserver_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	anthropicvm "github.com/tingly-dev/tingly-box/vmodel/anthropic"
+	openaivm "github.com/tingly-dev/tingly-box/vmodel/openai"
+	virtualserver "github.com/tingly-dev/tingly-box/vmodel/virtualserver"
+)
+
+// newStreamTestServer wires a virtualserver with the opt-in stream-test
+// mocks registered in both per-protocol registries and exposes them under
+// /v1.
+func newStreamTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	svc := virtualserver.NewService()
+	openaivm.RegisterStreamTestMocks(svc.GetOpenAIRegistry())
+	anthropicvm.RegisterStreamTestMocks(svc.GetAnthropicRegistry())
+
+	engine := gin.New()
+	svc.SetupRoutes(engine.Group("/v1"))
+
+	srv := httptest.NewServer(engine)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestStreamTestMocks_OpenAIUsageChunk verifies that the stream-test mock
+// emits a trailing usage-only chunk with the full deterministic shape
+// (prompt, completion, cached prompt tokens, reasoning tokens) — even
+// when stream_options.include_usage is NOT set on the request, because
+// the model explicitly advertises usage.
+func TestStreamTestMocks_OpenAIUsageChunk(t *testing.T) {
+	srv := newStreamTestServer(t)
+
+	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
+		modelID := modelID
+		t.Run(modelID, func(t *testing.T) {
+			body := map[string]interface{}{
+				"model":  modelID,
+				"stream": true,
+				"messages": []map[string]string{
+					{"role": "user", "content": "hi"},
+				},
+			}
+			raw, _ := json.Marshal(body)
+			resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", bytes.NewReader(raw))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			b, _ := io.ReadAll(resp.Body)
+			text := string(b)
+
+			usageChunk := lastUsageChunk(t, text)
+			require.NotNil(t, usageChunk, "stream-test mock must emit a trailing usage chunk")
+
+			assert.EqualValues(t, 42, jsonNum(usageChunk, "prompt_tokens"))
+			assert.EqualValues(t, 17, jsonNum(usageChunk, "completion_tokens"))
+			assert.EqualValues(t, 59, jsonNum(usageChunk, "total_tokens"))
+
+			details := usageChunk["prompt_tokens_details"].(map[string]interface{})
+			assert.EqualValues(t, 11, jsonNum(details, "cached_tokens"))
+			complDetails := usageChunk["completion_tokens_details"].(map[string]interface{})
+			assert.EqualValues(t, 9, jsonNum(complDetails, "reasoning_tokens"))
+		})
+	}
+}
+
+// TestStreamTestMocks_AnthropicMessageDelta verifies the Anthropic side:
+// message_delta carries input/output/cache_read/cache_creation/reasoning
+// tokens harvested from the explicit MockUsage.
+func TestStreamTestMocks_AnthropicMessageDelta(t *testing.T) {
+	srv := newStreamTestServer(t)
+
+	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
+		modelID := modelID
+		t.Run(modelID, func(t *testing.T) {
+			body := map[string]interface{}{
+				"model":      modelID,
+				"stream":     true,
+				"max_tokens": 16,
+				"messages": []map[string]string{
+					{"role": "user", "content": "hi"},
+				},
+			}
+			raw, _ := json.Marshal(body)
+			resp, err := http.Post(srv.URL+"/v1/messages?beta=true", "application/json", bytes.NewReader(raw))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			b, _ := io.ReadAll(resp.Body)
+			text := string(b)
+
+			deltaData := findSSEEventData(text, "message_delta")
+			require.NotEmpty(t, deltaData, "stream-test mock must emit message_delta with usage")
+
+			var delta map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(deltaData), &delta))
+
+			usage := delta["usage"].(map[string]interface{})
+			assert.EqualValues(t, 42, jsonNum(usage, "input_tokens"))
+			assert.EqualValues(t, 17, jsonNum(usage, "output_tokens"))
+			assert.EqualValues(t, 11, jsonNum(usage, "cache_read_input_tokens"))
+			assert.EqualValues(t, 5, jsonNum(usage, "cache_creation_input_tokens"))
+			assert.EqualValues(t, 9, jsonNum(usage, "reasoning_tokens"))
+		})
+	}
+}
+
+// lastUsageChunk returns the parsed `usage` object from the last SSE
+// chat-completion chunk that carries a non-empty usage block (the trailing
+// usage-only chunk in OpenAI streams).
+func lastUsageChunk(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var last map[string]interface{}
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		u, ok := chunk["usage"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if jsonNum(u, "prompt_tokens") == 0 && jsonNum(u, "completion_tokens") == 0 {
+			continue
+		}
+		last = u
+	}
+	return last
+}
+
+func findSSEEventData(body, eventName string) string {
+	current := ""
+	for _, line := range strings.Split(body, "\n") {
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			current = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:") && current == eventName:
+			return strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		}
+	}
+	return ""
+}
+
+func jsonNum(m map[string]interface{}, key string) float64 {
+	if v, ok := m[key].(float64); ok {
+		return v
+	}
+	return 0
+}


### PR DESCRIPTION
Add new vmodel for stream testing, and especially for token usage checking.