### PR TITLE
Unify routing graph components and add stream usage tracking

### DIFF
--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -188,6 +188,15 @@ func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 	}
 }
 
+// SetUsageFull sets the usage data including cache tokens.
+func (a *AnthropicStreamAssembler) SetUsageFull(inputTokens, outputTokens, cacheReadTokens int) {
+	a.usageData = &anthropic.Usage{
+		InputTokens:          int64(inputTokens),
+		OutputTokens:         int64(outputTokens),
+		CacheReadInputTokens: int64(cacheReadTokens),
+	}
+}
+
 // Finish assembles the final response and returns it as anthropic.Message
 func (a *AnthropicStreamAssembler) Finish(model string, inputTokens, outputTokens int) *anthropic.Message {
 	if a == nil || a.msgID == "" {
@@ -215,6 +224,16 @@ func (a *AnthropicStreamAssembler) Finish(model string, inputTokens, outputToken
 		usage = &anthropic.Usage{
 			InputTokens:  int64(inputTokens),
 			OutputTokens: int64(outputTokens),
+		}
+	} else {
+		// Keep any in-stream usage (incl. cache_read) but let explicit
+		// totals from Finish override input/output if they're larger
+		// (handles the post-finish_reason usage chunk path).
+		if int64(inputTokens) > usage.InputTokens {
+			usage.InputTokens = int64(inputTokens)
+		}
+		if int64(outputTokens) > usage.OutputTokens {
+			usage.OutputTokens = int64(outputTokens)
 		}
 	}
 

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+
+	"github.com/tingly-dev/tingly-box/ai"
 )
 
 // AnthropicStreamAssembler assembles Anthropic streaming responses
@@ -180,7 +182,9 @@ func (a *AnthropicStreamAssembler) handleContentBlockDeltaBeta(blockIndex int, d
 	a.blocks[blockIndex] = block
 }
 
-// SetUsage sets the usage data
+// SetUsage sets the usage data from raw input/output counts.
+// Prefer SetUsageFromTokenUsage when you have an *ai.TokenUsage in hand —
+// it carries cache and reasoning fields the bare counts cannot.
 func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 	a.usageData = &anthropic.Usage{
 		InputTokens:  int64(inputTokens),
@@ -188,12 +192,18 @@ func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 	}
 }
 
-// SetUsageFull sets the usage data including cache tokens.
-func (a *AnthropicStreamAssembler) SetUsageFull(inputTokens, outputTokens, cacheReadTokens int) {
+// SetUsageFromTokenUsage sets the assembled response usage from the canonical
+// ai.TokenUsage type. Cache-read input tokens are mapped to
+// anthropic.Usage.CacheReadInputTokens; reasoning_tokens has no Anthropic
+// analogue (extended-thinking tokens are billed inside output_tokens).
+func (a *AnthropicStreamAssembler) SetUsageFromTokenUsage(u *ai.TokenUsage) {
+	if u == nil {
+		return
+	}
 	a.usageData = &anthropic.Usage{
-		InputTokens:          int64(inputTokens),
-		OutputTokens:         int64(outputTokens),
-		CacheReadInputTokens: int64(cacheReadTokens),
+		InputTokens:          int64(u.InputTokens),
+		OutputTokens:         int64(u.OutputTokens),
+		CacheReadInputTokens: int64(u.CacheInputTokens),
 	}
 }
 

--- a/internal/protocol/assembler/anthropic_assembler_test.go
+++ b/internal/protocol/assembler/anthropic_assembler_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/ai"
 )
 
 func TestNewAnthropicStreamAssembler(t *testing.T) {
@@ -119,9 +121,13 @@ func TestAnthropicStreamAssembler_SetUsage(t *testing.T) {
 	assert.Equal(t, int64(50), assembler.usageData.OutputTokens)
 }
 
-func TestAnthropicStreamAssembler_SetUsageFull_CarriesCacheRead(t *testing.T) {
+func TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesCacheRead(t *testing.T) {
 	assembler := NewAnthropicStreamAssembler()
-	assembler.SetUsageFull(42, 17, 11)
+	assembler.SetUsageFromTokenUsage(&ai.TokenUsage{
+		InputTokens:      42,
+		OutputTokens:     17,
+		CacheInputTokens: 11,
+	})
 	assembler.msgID = "msg_cache"
 	assembler.blocks[0] = anthropic.ContentBlockUnion{Type: "text", Text: "ok"}
 

--- a/internal/protocol/assembler/anthropic_assembler_test.go
+++ b/internal/protocol/assembler/anthropic_assembler_test.go
@@ -119,6 +119,19 @@ func TestAnthropicStreamAssembler_SetUsage(t *testing.T) {
 	assert.Equal(t, int64(50), assembler.usageData.OutputTokens)
 }
 
+func TestAnthropicStreamAssembler_SetUsageFull_CarriesCacheRead(t *testing.T) {
+	assembler := NewAnthropicStreamAssembler()
+	assembler.SetUsageFull(42, 17, 11)
+	assembler.msgID = "msg_cache"
+	assembler.blocks[0] = anthropic.ContentBlockUnion{Type: "text", Text: "ok"}
+
+	result := assembler.Finish("model", 0, 0)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(42), result.Usage.InputTokens)
+	assert.Equal(t, int64(17), result.Usage.OutputTokens)
+	assert.Equal(t, int64(11), result.Usage.CacheReadInputTokens, "cache_read must survive into assembled response")
+}
+
 func TestAnthropicStreamAssembler_Finish_WithUsageFromAssembler(t *testing.T) {
 	assembler := NewAnthropicStreamAssembler()
 

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -290,12 +290,20 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 				},
 			}
 
-			// Add usage if available and not disabled
+			// Add usage if available and not disabled.
+			// Anthropic's message_delta usage carries cache_read / cache_creation
+			// counts; forward cached prompt tokens into OpenAI's
+			// prompt_tokens_details.cached_tokens so downstream consumers see
+			// the full shape. (Anthropic has no reasoning_tokens analogue —
+			// extended-thinking tokens are billed inside output_tokens.)
 			if !disableStreamUsage && usage != nil {
 				chunk.Usage = openai.CompletionUsage{
 					PromptTokens:     usage.InputTokens,
 					CompletionTokens: usage.OutputTokens,
 					TotalTokens:      usage.InputTokens + usage.OutputTokens,
+				}
+				if usage.CacheReadInputTokens > 0 {
+					chunk.Usage.PromptTokensDetails.CachedTokens = usage.CacheReadInputTokens
 				}
 			}
 

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -1,0 +1,116 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicOption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	anthropicvm "github.com/tingly-dev/tingly-box/vmodel/anthropic"
+	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
+)
+
+// TestAnthropicToOpenAIStream_VModelFullUsage wires the vmodel virtualserver
+// (with stream-test mocks registered) as the Anthropic upstream and runs
+// the response through AnthropicToOpenAIStream. Verifies that the upstream
+// message_delta usage — including cache_read_input_tokens — flows into the
+// OpenAI final chunk's prompt_tokens_details.cached_tokens. Without the
+// fix the cache count was dropped on the way through.
+func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	svc := virtualserver.NewService()
+	anthropicvm.RegisterStreamTestMocks(svc.GetAnthropicRegistry())
+
+	engine := gin.New()
+	svc.SetupAnthropicRoutes(engine.Group("/virtual/anthropic"))
+	upstream := httptest.NewServer(engine)
+	defer upstream.Close()
+
+	client := anthropic.NewClient(
+		anthropicOption.WithAPIKey("test-key"),
+		anthropicOption.WithBaseURL(upstream.URL+"/virtual/anthropic/"),
+	)
+
+	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
+		modelID := modelID
+		t.Run(modelID, func(t *testing.T) {
+			stream := client.Beta.Messages.NewStreaming(context.Background(), anthropic.BetaMessageNewParams{
+				Model:     anthropic.Model(modelID),
+				MaxTokens: int64(64),
+				Messages: []anthropic.BetaMessageParam{
+					anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi")),
+				},
+			})
+
+			w := &closeNotifyRecorder{httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", nil)
+
+			input, output, err := AnthropicToOpenAIStream(c, nil, stream, modelID, false)
+			require.NoError(t, err)
+			assert.Equal(t, 42, input, "InputTokens should reflect upstream input_tokens")
+			assert.Equal(t, 17, output, "OutputTokens should reflect upstream output_tokens")
+
+			body := w.Body.String()
+
+			// Find the final OpenAI chunk that carries usage (chunk with
+			// non-zero PromptTokens). That chunk should also expose
+			// cached_tokens via prompt_tokens_details.
+			usageChunk := lastOpenAIChunkUsage(t, body)
+			require.NotNil(t, usageChunk, "anthropic_to_openai stream should attach usage to the final chunk")
+
+			assert.EqualValues(t, 42, jsonNumber(usageChunk, "prompt_tokens"))
+			assert.EqualValues(t, 17, jsonNumber(usageChunk, "completion_tokens"))
+
+			details, _ := usageChunk["prompt_tokens_details"].(map[string]interface{})
+			require.NotNil(t, details, "prompt_tokens_details should be populated when upstream advertises cache_read_input_tokens")
+			assert.EqualValues(t, 11, jsonNumber(details, "cached_tokens"))
+		})
+	}
+}
+
+// lastOpenAIChunkUsage returns the parsed `usage` object from the last SSE
+// chunk in the body whose usage carries non-zero token counts.
+func lastOpenAIChunkUsage(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var last map[string]interface{}
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		u, ok := chunk["usage"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if jsonNumber(u, "prompt_tokens") == 0 && jsonNumber(u, "completion_tokens") == 0 {
+			continue
+		}
+		last = u
+	}
+	return last
+}
+
+func jsonNumber(m map[string]interface{}, key string) float64 {
+	if v, ok := m[key].(float64); ok {
+		return v
+	}
+	return 0
+}

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -487,11 +487,6 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream *openaistream
 		}
 
 		evt := stream.Current()
-
-		if chunkCount < 3 {
-			logrus.WithContext(c.Request.Context()).Debugf("[ChatGPT] SSE chunk #%d: %s", chunkCount+1, evt.RawJSON())
-		}
-
 		chunkCount++
 
 		// Extract content from the response event

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -166,11 +166,10 @@ func handleOpenAIToAnthropicStreamResponse(
 		chunkCount++
 		chunk := stream.Current()
 
-		logrus.WithContext(c.Request.Context()).Debugf("[Stream] Got chunk #%d: len(choices)=%d", chunkCount, len(chunk.Choices))
-
-		// Skip empty chunks (no choices)
+		// Skip empty chunks (no choices).
+		// The trailing usage-only chunk (choices:[], usage:{...}) lands here
+		// when stream_options.include_usage=true.
 		if len(chunk.Choices) == 0 {
-			// Token counter will handle usage tracking if present in chunk
 			if tokenCounter != nil {
 				_, _, _ = tokenCounter.ConsumeOpenAIChunk(&chunk)
 				inputTokens, outputTokens := tokenCounter.GetCounts()
@@ -185,20 +184,6 @@ func handleOpenAIToAnthropicStreamResponse(
 		}
 
 		choice := chunk.Choices[0]
-
-		// Check if usage is present - use same logic as stream counter
-		hasValidUsage := chunk.JSON.Usage.Valid()
-		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
-		hasUsage := hasValidUsage || hasNonZeroUsage
-
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
-			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
-
-		// Log first few chunks in detail for debugging
-		if chunkCount <= 5 || choice.FinishReason != "" {
-			logrus.WithContext(c.Request.Context()).Debugf("Full chunk #%d: %v", chunkCount, chunk)
-		}
 
 		delta := choice.Delta
 

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -401,6 +401,13 @@ func handleOpenAIToAnthropicStreamResponse(
 			inputTokens, outputTokens := tokenCounter.GetCounts()
 			state.inputTokens = int64(inputTokens)
 			state.outputTokens = int64(outputTokens)
+			cacheTokens, reasoningTokens := tokenCounter.GetUpstreamDetails()
+			if cacheTokens > 0 {
+				state.cacheTokens = int64(cacheTokens)
+			}
+			if reasoningTokens > 0 {
+				state.reasoningTokens = int64(reasoningTokens)
+			}
 		}
 		ensureMessageStart()
 		sendStopEvents(c, state, flusher)

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -180,9 +180,14 @@ func handleOpenAIToAnthropicStreamResponse(
 
 		choice := chunk.Choices[0]
 
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
+		// Check if usage is present - use same logic as stream counter
+		hasValidUsage := chunk.JSON.Usage.Valid()
+		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
+		hasUsage := hasValidUsage || hasNonZeroUsage
+
+		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
 			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason)
+			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
 
 		// Log first few chunks in detail for debugging
 		if chunkCount <= 5 || choice.FinishReason != "" {

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -584,7 +584,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				"text": textDelta.Delta,
 			}, flusher)
 			lastOutputItemType = "text"
-			logrus.WithContext(c.Request.Context()).Debugf("Processing Responses API event #%d: type=%s", eventCount, textDelta.Delta)
 		case "response.output_text.done", "response.content_part.done":
 			if state.textBlockIndex != -1 {
 				senders.SendContentBlockStop(state, state.textBlockIndex, flusher)
@@ -600,8 +599,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Initializing thinking block at index %d", state.thinkingBlockIndex)
 				senders.SendContentBlockStart(state.thinkingBlockIndex, blockTypeThinking, map[string]interface{}{"thinking": ""}, flusher)
 			}
-			preview := reasoningDelta.Delta
-			logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
 			senders.SendContentBlockDelta(state.thinkingBlockIndex, map[string]interface{}{
 				"type":     deltaTypeThinkingDelta,
 				"thinking": reasoningDelta.Delta,
@@ -677,8 +674,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 					logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Initializing thinking block at index %d", state.thinkingBlockIndex)
 					senders.SendContentBlockStart(state.thinkingBlockIndex, blockTypeThinking, map[string]interface{}{"thinking": ""}, flusher)
 				}
-				preview := reasoningDelta.Delta
-				logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
 				senders.SendContentBlockDelta(state.thinkingBlockIndex, map[string]interface{}{
 					"type":     deltaTypeThinkingDelta,
 					"thinking": reasoningDelta.Delta,
@@ -905,26 +900,10 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				state.reasoningSummaryBlockIndex = -1
 			}
 
-		case "response.audio.delta":
-			audioDelta := currentEvent.AsResponseAudioDelta()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio delta: sequence=%d, len=%d", audioDelta.SequenceNumber, len(audioDelta.Delta))
-
-		case "response.audio.done":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio done")
-
-		case "response.audio.transcript.delta":
-			transcriptDelta := currentEvent.AsResponseAudioTranscriptDelta()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio transcript delta: sequence=%d, len=%d", transcriptDelta.SequenceNumber, len(transcriptDelta.Delta))
-
-		case "response.audio.transcript.done":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio transcript done")
-
-		case "response.code_interpreter_call_code.delta":
-			codeDelta := currentEvent.AsResponseCodeInterpreterCallCodeDelta()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Code interpreter code delta: len=%d", len(codeDelta.Delta))
-
-		case "response.code_interpreter_call_code.done":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Code interpreter code done")
+		case "response.audio.delta", "response.audio.done",
+			"response.audio.transcript.delta", "response.audio.transcript.done",
+			"response.code_interpreter_call_code.delta", "response.code_interpreter_call_code.done":
+			// Pass-through events not converted to Anthropic blocks; ignore silently.
 
 		case "response.code_interpreter_call.in_progress":
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Code interpreter in progress")

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -141,8 +141,14 @@ func handleOpenAIToAnthropicStreamResponse(
 		messageStarted = true
 	}
 
-	// Process the stream with context cancellation checking
+	// Process the stream with context cancellation checking.
+	// Note: when stream_options.include_usage=true, OpenAI sends a final
+	// usage-only chunk (choices:[], usage:{...}) AFTER the finish_reason chunk.
+	// We must keep draining the stream after seeing finish_reason so the
+	// upstream usage isn't silently dropped.
 	chunkCount := 0
+	pendingFinishReason := ""
+	finishSeen := false
 	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
@@ -359,14 +365,13 @@ func handleOpenAIToAnthropicStreamResponse(
 			}
 		}
 
-		// Handle finish_reason (last chunk for this choice)
+		// Handle finish_reason (last chunk for this choice).
+		// Keep the loop alive so the trailing usage-only chunk (sent when
+		// stream_options.include_usage=true) is still consumed; the final
+		// Anthropic events are emitted after the loop.
 		if choice.FinishReason != "" {
-			// Get final token counts from counter
-			if tokenCounter != nil {
-				inputTokens, outputTokens := tokenCounter.GetCounts()
-				state.inputTokens = int64(inputTokens)
-				state.outputTokens = int64(outputTokens)
-			}
+			pendingFinishReason = choice.FinishReason
+			finishSeen = true
 			if hooks != nil && hooks.OnToolCallsFinal != nil && len(state.pendingToolCalls) > 0 {
 				toolCalls := make([]OpenAIToAnthropicToolCall, 0, len(state.pendingToolCalls))
 				for _, tc := range state.pendingToolCalls {
@@ -381,19 +386,28 @@ func handleOpenAIToAnthropicStreamResponse(
 					return false
 				}
 			}
-
 			if !messageStarted && errors.Is(hookErr, ErrMCPStreamContinue) {
 				return false
 			}
-			ensureMessageStart()
-			sendStopEvents(c, state, flusher)
-			sendMessageDelta(c, state, mapOpenAIFinishReasonToAnthropic(choice.FinishReason), flusher)
-			sendMessageStop(c, messageID, responseModel, state, mapOpenAIFinishReasonToAnthropic(choice.FinishReason), flusher)
-			return false
 		}
 
 		return true
 	})
+
+	// Emit the terminal Anthropic events using the final tallied usage
+	// (which may have been updated by a post-finish_reason usage chunk).
+	if finishSeen && hookErr == nil {
+		if tokenCounter != nil {
+			inputTokens, outputTokens := tokenCounter.GetCounts()
+			state.inputTokens = int64(inputTokens)
+			state.outputTokens = int64(outputTokens)
+		}
+		ensureMessageStart()
+		sendStopEvents(c, state, flusher)
+		stopReason := mapOpenAIFinishReasonToAnthropic(pendingFinishReason)
+		sendMessageDelta(c, state, stopReason, flusher)
+		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr
 	}

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -663,7 +663,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 
 		case "response.output_item.added":
 			itemAdded := currentEvent.AsResponseOutputItemAdded()
-			logrus.WithContext(c.Request.Context()).Debugf("item type: %s", itemAdded.Item.Type)
 			switch itemAdded.Item.Type {
 			case "reasoning":
 				reasoningDelta := currentEvent.AsResponseReasoningTextDelta()
@@ -862,10 +861,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 			return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
 
 		case "response.output_text.annotation.added":
-			annotationAdded := currentEvent.AsResponseOutputTextAnnotationAdded()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Text annotation added: index=%d, citation_type=%s",
-				annotationAdded.OutputIndex,
-				annotationAdded.Annotation)
+			// Per-annotation event; pass through silently.
 
 		case "response.text.done":
 			// Finalize text content - already handled by content_part.done for output_text type
@@ -918,7 +914,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] File search in progress")
 
 		case "response.file_search_call.searching":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] File search searching: query=%s", currentEvent.RawJSON())
+			// Status event; query payload elided to keep logs small.
 
 		case "response.file_search_call.completed":
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] File search completed")
@@ -1083,9 +1079,6 @@ func HandleResponsesToAnthropicV1Assembly(c *gin.Context, stream *openaistream.S
 			if state.cacheTokens > 0 {
 				msg.Usage.CacheReadInputTokens = state.cacheTokens
 			}
-
-			bs, _ := json.Marshal(msg)
-			logrus.WithContext(c.Request.Context()).Debugf("Assemble response: %s", string(bs))
 
 			// Send result
 			c.JSON(200, msg)

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -414,6 +414,14 @@ func handleOpenAIToAnthropicStreamResponse(
 		stopReason := mapOpenAIFinishReasonToAnthropic(pendingFinishReason)
 		sendMessageDelta(c, state, stopReason, flusher)
 		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"model":            responseModel,
+			"input_tokens":     state.inputTokens,
+			"output_tokens":    state.outputTokens,
+			"cache_tokens":     state.cacheTokens,
+			"reasoning_tokens": state.reasoningTokens,
+			"stop_reason":      stopReason,
+		}).Info("OpenAI->Anthropic stream usage")
 	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -382,6 +382,13 @@ func handleOpenAIToAnthropicBetaStream(
 			inputTokens, outputTokens := tokenCounter.GetCounts()
 			state.inputTokens = int64(inputTokens)
 			state.outputTokens = int64(outputTokens)
+			cacheTokens, reasoningTokens := tokenCounter.GetUpstreamDetails()
+			if cacheTokens > 0 {
+				state.cacheTokens = int64(cacheTokens)
+			}
+			if reasoningTokens > 0 {
+				state.reasoningTokens = int64(reasoningTokens)
+			}
 		}
 		ensureMessageStart()
 		sendStopEvents(c, state, flusher)

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -532,9 +532,6 @@ func HandleResponsesToAnthropicBetaAssembly(c *gin.Context, stream *openaistream
 				msg.Usage.CacheReadInputTokens = state.cacheTokens
 			}
 
-			bs, _ := json.Marshal(msg)
-			logrus.WithContext(c.Request.Context()).Debugf("Assemble response: %s", string(bs))
-
 			// Send result
 			c.JSON(200, msg)
 			flusher.Flush()

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -395,6 +395,14 @@ func handleOpenAIToAnthropicBetaStream(
 		stopReason := mapOpenAIFinishReasonToAnthropicBeta(pendingFinishReason)
 		sendMessageDelta(c, state, stopReason, flusher)
 		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"model":            responseModel,
+			"input_tokens":     state.inputTokens,
+			"output_tokens":    state.outputTokens,
+			"cache_tokens":     state.cacheTokens,
+			"reasoning_tokens": state.reasoningTokens,
+			"stop_reason":      stopReason,
+		}).Info("OpenAI->Anthropic beta stream usage")
 	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -126,8 +126,14 @@ func handleOpenAIToAnthropicBetaStream(
 		messageStarted = true
 	}
 
-	// Process the stream with context cancellation checking
+	// Process the stream with context cancellation checking.
+	// Note: when stream_options.include_usage=true, OpenAI sends a final
+	// usage-only chunk (choices:[], usage:{...}) AFTER the finish_reason chunk.
+	// We must keep draining the stream after seeing finish_reason so the
+	// upstream usage isn't silently dropped.
 	chunkCount := 0
+	pendingFinishReason := ""
+	finishSeen := false
 	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
@@ -340,14 +346,13 @@ func handleOpenAIToAnthropicBetaStream(
 			}
 		}
 
-		// Handle finish_reason (last chunk for this choice)
+		// Handle finish_reason (last chunk for this choice).
+		// Keep the loop alive so the trailing usage-only chunk (sent when
+		// stream_options.include_usage=true) is still consumed; the final
+		// Anthropic events are emitted after the loop.
 		if choice.FinishReason != "" {
-			// Get final token counts from counter
-			if tokenCounter != nil {
-				inputTokens, outputTokens := tokenCounter.GetCounts()
-				state.inputTokens = int64(inputTokens)
-				state.outputTokens = int64(outputTokens)
-			}
+			pendingFinishReason = choice.FinishReason
+			finishSeen = true
 			if hooks != nil && hooks.OnToolCallsFinal != nil && len(state.pendingToolCalls) > 0 {
 				toolCalls := make([]OpenAIToAnthropicToolCall, 0, len(state.pendingToolCalls))
 				for _, tc := range state.pendingToolCalls {
@@ -362,19 +367,28 @@ func handleOpenAIToAnthropicBetaStream(
 					return false
 				}
 			}
-
 			if !messageStarted && errors.Is(hookErr, ErrMCPStreamContinue) {
 				return false
 			}
-			ensureMessageStart()
-			sendStopEvents(c, state, flusher)
-			sendMessageDelta(c, state, mapOpenAIFinishReasonToAnthropicBeta(choice.FinishReason), flusher)
-			sendMessageStop(c, messageID, responseModel, state, mapOpenAIFinishReasonToAnthropicBeta(choice.FinishReason), flusher)
-			return false
 		}
 
 		return true
 	})
+
+	// Emit the terminal Anthropic events using the final tallied usage
+	// (which may have been updated by a post-finish_reason usage chunk).
+	if finishSeen && hookErr == nil {
+		if tokenCounter != nil {
+			inputTokens, outputTokens := tokenCounter.GetCounts()
+			state.inputTokens = int64(inputTokens)
+			state.outputTokens = int64(outputTokens)
+		}
+		ensureMessageStart()
+		sendStopEvents(c, state, flusher)
+		stopReason := mapOpenAIFinishReasonToAnthropicBeta(pendingFinishReason)
+		sendMessageDelta(c, state, stopReason, flusher)
+		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr
 	}

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -168,16 +168,6 @@ func handleOpenAIToAnthropicBetaStream(
 		}
 
 		choice := chunk.Choices[0]
-
-		// Check if usage is present - use same logic as stream counter
-		hasValidUsage := chunk.JSON.Usage.Valid()
-		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
-		hasUsage := hasValidUsage || hasNonZeroUsage
-
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
-			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
-
 		delta := choice.Delta
 
 		// Check for server_tool_use at chunk level (not delta level)

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -163,9 +163,14 @@ func handleOpenAIToAnthropicBetaStream(
 
 		choice := chunk.Choices[0]
 
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
+		// Check if usage is present - use same logic as stream counter
+		hasValidUsage := chunk.JSON.Usage.Valid()
+		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
+		hasUsage := hasValidUsage || hasNonZeroUsage
+
+		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
 			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason)
+			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
 
 		delta := choice.Delta
 

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -201,8 +201,6 @@ func handleOpenAIToAnthropicBetaStream(
 					// Extract thinking content (handle different types)
 					thinkingText := extractString(v)
 					if thinkingText != "" {
-						preview := thinkingText
-						logrus.WithContext(c.Request.Context()).Debugf("[Thinking] Sending thinking_delta: len=%d, preview=%q", len(thinkingText), preview)
 						// Send content_block_delta with thinking_delta
 						ensureMessageStart()
 						sendContentBlockDelta(c, state.thinkingBlockIndex, map[string]interface{}{

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -1,0 +1,113 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	openaiOption "github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
+)
+
+// TestOpenAIToAnthropicStream_VModelUsage drives a real OpenAI streaming client
+// against the in-process vmodel virtualserver and runs the response through
+// HandleOpenAIToAnthropicStreamResponse. It exists to lock down the
+// finish_reason/usage-chunk ordering: real OpenAI emits the usage-only chunk
+// AFTER the finish_reason chunk, and the converter must keep draining past
+// finish_reason to capture it.
+func TestOpenAIToAnthropicStream_VModelUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Spin up the vmodel virtualserver as the OpenAI upstream.
+	svc := virtualserver.NewService()
+	engine := gin.New()
+	svc.SetupOpenAIRoutes(engine.Group("/virtual/openai"))
+	upstream := httptest.NewServer(engine)
+	defer upstream.Close()
+
+	client := openai.NewClient(
+		openaiOption.WithAPIKey("test-key"),
+		openaiOption.WithBaseURL(upstream.URL+"/virtual/openai/v1/"),
+	)
+
+	stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model: "virtual-gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Hello, world!"),
+		},
+		StreamOptions: openai.ChatCompletionStreamOptionsParam{
+			IncludeUsage: param.Opt[bool]{Value: true},
+		},
+	})
+
+	w := &closeNotifyRecorder{httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/messages", nil)
+
+	usage, err := HandleOpenAIToAnthropicStreamResponse(c, nil, stream, "virtual-gpt-4")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+
+	body := w.Body.String()
+	t.Logf("Response body:\n%s", body)
+
+	// Locate the message_delta event and inspect its usage block. With the
+	// bug present, output_tokens would still be zero (or only the
+	// incrementally-counted value) because the upstream usage chunk arrives
+	// after finish_reason and gets dropped.
+	events := splitSSEEventsByType(body)
+
+	msgDeltaRaw, ok := events[eventTypeMessageDelta]
+	require.True(t, ok, "should emit message_delta")
+
+	var msgDelta map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(msgDeltaRaw), &msgDelta))
+
+	delta := msgDelta["delta"].(map[string]interface{})
+	assert.Equal(t, "end_turn", delta["stop_reason"], "stop_reason should map from openai 'stop'")
+
+	usageBlock, _ := msgDelta["usage"].(map[string]interface{})
+	require.NotNil(t, usageBlock, "message_delta should carry a usage block")
+
+	// Output tokens come from the upstream usage-only chunk.
+	outTokens, _ := usageBlock["output_tokens"].(float64)
+	assert.Greater(t, outTokens, float64(0), "output_tokens should be populated from trailing usage chunk; if 0, the converter dropped the post-finish_reason usage chunk")
+
+	// And the returned UsageStat should match.
+	assert.Greater(t, usage.InputTokens, 0, "InputTokens should reflect upstream prompt_tokens")
+	assert.Greater(t, usage.OutputTokens, 0, "OutputTokens should reflect upstream completion_tokens")
+
+	// Sanity: standard SSE envelope still in place.
+	assert.Contains(t, body, "event:message_start")
+	assert.Contains(t, body, "event:message_stop")
+}
+
+// splitSSEEventsByType returns a map from event name to the LAST data payload
+// observed for that event in the SSE body. Sufficient for terminal events
+// like message_delta / message_stop, which only fire once.
+func splitSSEEventsByType(body string) map[string]string {
+	out := make(map[string]string)
+	current := ""
+	for _, line := range strings.Split(body, "\n") {
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			current = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			if current != "" {
+				out[current] = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		case line == "":
+			current = ""
+		}
+	}
+	return out
+}

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	openaivm "github.com/tingly-dev/tingly-box/vmodel/openai"
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
 
@@ -89,6 +90,79 @@ func TestOpenAIToAnthropicStream_VModelUsage(t *testing.T) {
 	// Sanity: standard SSE envelope still in place.
 	assert.Contains(t, body, "event:message_start")
 	assert.Contains(t, body, "event:message_stop")
+}
+
+// TestOpenAIToAnthropicStream_VModelFullUsage exercises the full usage
+// shape — prompt, completion, cached input, reasoning — by wiring the
+// stream-test mock (virtual-stream-test) which advertises explicit
+// MockUsage values. Asserts those values flow into the Anthropic
+// message_delta.usage block.
+func TestOpenAIToAnthropicStream_VModelFullUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Custom service so we can opt into the stream-test mocks without
+	// polluting the production defaults set.
+	svc := virtualserver.NewService()
+	openaivm.RegisterStreamTestMocks(svc.GetOpenAIRegistry())
+
+	engine := gin.New()
+	svc.SetupOpenAIRoutes(engine.Group("/virtual/openai"))
+	upstream := httptest.NewServer(engine)
+	defer upstream.Close()
+
+	client := openai.NewClient(
+		openaiOption.WithAPIKey("test-key"),
+		openaiOption.WithBaseURL(upstream.URL+"/virtual/openai/v1/"),
+	)
+
+	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
+		modelID := modelID
+		t.Run(modelID, func(t *testing.T) {
+			stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+				Model: modelID,
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("Hello, world!"),
+				},
+				StreamOptions: openai.ChatCompletionStreamOptionsParam{
+					IncludeUsage: param.Opt[bool]{Value: true},
+				},
+			})
+
+			w := &closeNotifyRecorder{httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/messages", nil)
+
+			usage, err := HandleOpenAIToAnthropicStreamResponse(c, nil, stream, modelID)
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+
+			body := w.Body.String()
+			events := splitSSEEventsByType(body)
+
+			msgDeltaRaw, ok := events[eventTypeMessageDelta]
+			require.True(t, ok, "should emit message_delta")
+
+			var msgDelta map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(msgDeltaRaw), &msgDelta))
+			usageBlock, _ := msgDelta["usage"].(map[string]interface{})
+			require.NotNil(t, usageBlock)
+
+			// MockUsage from StreamTestMockSpecs: prompt=42 completion=17 cached=11 reasoning=9
+			assert.EqualValues(t, 17, usageBlock["output_tokens"], "output_tokens from explicit MockUsage.CompletionTokens")
+			assert.EqualValues(t, 11, usageBlock["cache_read_input_tokens"], "cache_read_input_tokens from prompt_tokens_details.cached_tokens")
+
+			assert.Equal(t, 42, usage.InputTokens)
+			assert.Equal(t, 17, usage.OutputTokens)
+			assert.Equal(t, 11, usage.CacheInputTokens)
+			assert.Equal(t, 9, usage.ReasoningTokens)
+
+			// tool variant should map finish_reason=tool_calls to stop_reason=tool_use
+			if modelID == "virtual-stream-test-tool" {
+				delta := msgDelta["delta"].(map[string]interface{})
+				assert.Equal(t, "tool_use", delta["stop_reason"])
+			}
+		})
+	}
 }
 
 // splitSSEEventsByType returns a map from event name to the LAST data payload

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/sirupsen/logrus"
 	"github.com/tiktoken-go/tokenizer"
 )
 
@@ -76,9 +77,21 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 	defer c.mu.Unlock()
 
 	// Process usage if provided in the chunk (usually only in the final chunk)
-	// Check if Usage is present by checking if the JSON field is valid
-	if chunk.JSON.Usage.Valid() {
+	// Check if Usage is present by checking:
+	// 1. The JSON field is valid (status > invalid)
+	// 2. OR the usage field has non-zero values (SDK bug workaround)
+	// The SDK's Valid() method incorrectly returns false for some valid usage fields
+	hasValidUsage := chunk.JSON.Usage.Valid()
+	hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
+
+	logrus.Debugf("[StreamTokenCounter] Usage check: Valid()=%v, hasNonZeroValues=%v, PromptTokens=%d, CompletionTokens=%d",
+		hasValidUsage, hasNonZeroUsage, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
+
+	if hasValidUsage || hasNonZeroUsage {
 		usage := chunk.Usage
+		logrus.Debugf("[StreamTokenCounter] Chunk contains usage field - PromptTokens=%d, CompletionTokens=%d",
+			usage.PromptTokens, usage.CompletionTokens)
+
 		if usage.PromptTokens > 0 {
 			c.inputTokens = int(usage.PromptTokens)
 		}

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/openai/openai-go/v3"
-	"github.com/sirupsen/logrus"
 	"github.com/tiktoken-go/tokenizer"
 )
 
@@ -78,22 +77,12 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Process usage if provided in the chunk (usually only in the final chunk)
-	// Check if Usage is present by checking:
-	// 1. The JSON field is valid (status > invalid)
-	// 2. OR the usage field has non-zero values (SDK bug workaround)
-	// The SDK's Valid() method incorrectly returns false for some valid usage fields
-	hasValidUsage := chunk.JSON.Usage.Valid()
-	hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
-
-	logrus.Debugf("[StreamTokenCounter] Usage check: Valid()=%v, hasNonZeroValues=%v, PromptTokens=%d, CompletionTokens=%d",
-		hasValidUsage, hasNonZeroUsage, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
-
-	if hasValidUsage || hasNonZeroUsage {
+	// Process usage if provided in the chunk (usually only the trailing
+	// usage-only chunk when stream_options.include_usage=true). The SDK's
+	// Valid() check misses some legitimate cases, so we also accept any
+	// non-zero prompt/completion count as evidence that usage is present.
+	if chunk.JSON.Usage.Valid() || chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
 		usage := chunk.Usage
-		logrus.Debugf("[StreamTokenCounter] Chunk contains usage field - PromptTokens=%d, CompletionTokens=%d",
-			usage.PromptTokens, usage.CompletionTokens)
-
 		if usage.PromptTokens > 0 {
 			c.inputTokens = int(usage.PromptTokens)
 		}

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -27,6 +27,8 @@ type StreamTokenCounter struct {
 	outputTokens         int
 	upstreamInputTokens  int64
 	upstreamOutputTokens int64
+	upstreamCacheTokens  int64 // prompt_tokens_details.cached_tokens
+	upstreamReasoning    int64 // completion_tokens_details.reasoning_tokens
 }
 
 // NewStreamTokenCounter creates a new streaming token counter.
@@ -104,6 +106,12 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 		if chunk.Usage.CompletionTokens > 0 {
 			c.upstreamOutputTokens = chunk.Usage.CompletionTokens
 		}
+		if chunk.Usage.PromptTokensDetails.CachedTokens > 0 {
+			c.upstreamCacheTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+		}
+		if chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
+			c.upstreamReasoning = chunk.Usage.CompletionTokensDetails.ReasoningTokens
+		}
 		return int(c.upstreamInputTokens), int(c.upstreamOutputTokens), nil
 	}
 
@@ -160,6 +168,14 @@ func (c *StreamTokenCounter) GetCounts() (inputTokens, outputTokens int) {
 		o = int(c.upstreamOutputTokens)
 	}
 	return i, o
+}
+
+// GetUpstreamDetails returns cache and reasoning token counts harvested
+// from upstream usage chunks (zero if upstream did not advertise them).
+func (c *StreamTokenCounter) GetUpstreamDetails() (cacheTokens, reasoningTokens int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return int(c.upstreamCacheTokens), int(c.upstreamReasoning)
 }
 
 // SetInputTokens sets the input token count.

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -235,7 +235,7 @@ func (s *Server) streamResponsesToAnthropicBeta(c *gin.Context, proxyModel strin
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 
@@ -288,7 +288,7 @@ func (s *Server) assembleResponsesToAnthropicBeta(c *gin.Context, proxyModel str
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -205,7 +205,7 @@ func (s *Server) streamResponsesToAnthropic(c *gin.Context, proxyModel string, a
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 
@@ -258,7 +258,7 @@ func (s *Server) assembleResponsesToAnthropic(c *gin.Context, proxyModel string,
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 

--- a/internal/server/openai_mcp.go
+++ b/internal/server/openai_mcp.go
@@ -105,7 +105,7 @@ func (s *Server) streamOpenAIChatToAnthropicBetaWithMCP(
 		}
 		s.trackUsageWithTokenUsage(c, usage, nil)
 		if streamRec != nil {
-			streamRec.Finish(responseModel, usage.InputTokens, usage.OutputTokens)
+			streamRec.Finish(responseModel, usage)
 			streamRec.RecordResponse(provider, actualModel)
 		}
 		return

--- a/internal/server/recording_hooks.go
+++ b/internal/server/recording_hooks.go
@@ -52,21 +52,25 @@ func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage) {
 	if sr == nil {
 		return
 	}
-	inputTokens, outputTokens, cacheReadTokens := 0, 0, 0
+	// Fall back to in-stream usage when the converter didn't return one
+	// (e.g. early errors before message_delta usage was tallied).
+	if usage == nil || (usage.InputTokens == 0 && usage.OutputTokens == 0) {
+		if sr.hasUsage {
+			usage = &protocol.TokenUsage{
+				InputTokens:      sr.inputTokens,
+				OutputTokens:     sr.outputTokens,
+				CacheInputTokens: sr.cacheReadTokens,
+			}
+		}
+	}
+	if usage != nil {
+		sr.assembler.SetUsageFromTokenUsage(usage)
+	}
+	var inputTokens, outputTokens, cacheReadTokens int
 	if usage != nil {
 		inputTokens = usage.InputTokens
 		outputTokens = usage.OutputTokens
 		cacheReadTokens = usage.CacheInputTokens
-	}
-	if inputTokens == 0 && outputTokens == 0 && sr.hasUsage {
-		inputTokens = sr.inputTokens
-		outputTokens = sr.outputTokens
-		if cacheReadTokens == 0 {
-			cacheReadTokens = sr.cacheReadTokens
-		}
-	}
-	if cacheReadTokens > 0 {
-		sr.assembler.SetUsageFull(inputTokens, outputTokens, cacheReadTokens)
 	}
 	assembled := sr.assembler.Finish(model, inputTokens, outputTokens)
 	if assembled != nil {

--- a/internal/server/recording_hooks.go
+++ b/internal/server/recording_hooks.go
@@ -25,11 +25,12 @@ const streamRecorderContextKey = "stream_event_recorder"
 // use AttachRecorderHooks, which relies on the assembler that protocol's
 // HandleContext now owns.
 type streamRecorder struct {
-	recorder     *ProtocolRecorder
-	assembler    *assembler.AnthropicStreamAssembler
-	inputTokens  int
-	outputTokens int
-	hasUsage     bool
+	recorder        *ProtocolRecorder
+	assembler       *assembler.AnthropicStreamAssembler
+	inputTokens     int
+	outputTokens    int
+	cacheReadTokens int
+	hasUsage        bool
 }
 
 func newStreamRecorder(recorder *ProtocolRecorder) *streamRecorder {
@@ -43,13 +44,29 @@ func newStreamRecorder(recorder *ProtocolRecorder) *streamRecorder {
 	}
 }
 
-func (sr *streamRecorder) Finish(model string, inputTokens, outputTokens int) {
+// Finish carries the converter's final TokenUsage into the assembler so the
+// recorded response has the full shape (input/output + cache_read).
+// usage may be nil; in that case any in-stream usage harvested via
+// RecordRawMapEvent is used as a fallback.
+func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage) {
 	if sr == nil {
 		return
+	}
+	inputTokens, outputTokens, cacheReadTokens := 0, 0, 0
+	if usage != nil {
+		inputTokens = usage.InputTokens
+		outputTokens = usage.OutputTokens
+		cacheReadTokens = usage.CacheInputTokens
 	}
 	if inputTokens == 0 && outputTokens == 0 && sr.hasUsage {
 		inputTokens = sr.inputTokens
 		outputTokens = sr.outputTokens
+		if cacheReadTokens == 0 {
+			cacheReadTokens = sr.cacheReadTokens
+		}
+	}
+	if cacheReadTokens > 0 {
+		sr.assembler.SetUsageFull(inputTokens, outputTokens, cacheReadTokens)
 	}
 	assembled := sr.assembler.Finish(model, inputTokens, outputTokens)
 	if assembled != nil {
@@ -59,10 +76,14 @@ func (sr *streamRecorder) Finish(model string, inputTokens, outputTokens int) {
 	if len(sr.recorder.streamChunks) > 0 {
 		fallback := baseMessageMap(model, sr.recorder.startTime)
 		fallback["stop_reason"] = sr.recorder.c.Query("stop_reason")
-		fallback["usage"] = map[string]interface{}{
+		usageMap := map[string]interface{}{
 			"input_tokens":  inputTokens,
 			"output_tokens": outputTokens,
 		}
+		if cacheReadTokens > 0 {
+			usageMap["cache_read_input_tokens"] = cacheReadTokens
+		}
+		fallback["usage"] = usageMap
 		sr.recorder.SetAssembledResponse(fallback)
 		logrus.Debugf("obs: streamRecorder using fallback response, chunks=%d", len(sr.recorder.streamChunks))
 	}
@@ -105,6 +126,9 @@ func (sr *streamRecorder) RecordRawMapEvent(eventType string, event map[string]i
 			}
 			if v, ok := mapInt(usage, "output_tokens"); ok {
 				sr.outputTokens = v
+			}
+			if v, ok := mapInt(usage, "cache_read_input_tokens"); ok {
+				sr.cacheReadTokens = v
 			}
 			sr.hasUsage = true
 		}

--- a/internal/server/usage_tracking.go
+++ b/internal/server/usage_tracking.go
@@ -190,18 +190,19 @@ func (s *Server) trackUsageWithTokenUsage(c *gin.Context, usage *protocol.TokenU
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"provider":      provider.Name,
-		"model":         model,
-		"scenario":      scenario,
-		"input_tokens":  usage.InputTokens,
-		"output_tokens": usage.OutputTokens,
-		"cache_tokens":  usage.CacheInputTokens,
-		"system_tokens": usage.SystemTokens,
-		"total_tokens":  usage.TotalTokens(),
-		"status":        status,
-		"streamed":      streamed,
-		"latency_ms":    latencyMs,
-	}).Trace("trackUsageWithTokenUsage: recording token usage")
+		"provider":         provider.Name,
+		"model":            model,
+		"scenario":         scenario,
+		"input_tokens":     usage.InputTokens,
+		"output_tokens":    usage.OutputTokens,
+		"cache_tokens":     usage.CacheInputTokens,
+		"reasoning_tokens": usage.ReasoningTokens,
+		"system_tokens":    usage.SystemTokens,
+		"total_tokens":     usage.TotalTokens(),
+		"status":           status,
+		"streamed":         streamed,
+		"latency_ms":       latencyMs,
+	}).Debug("trackUsage: token usage recorded")
 
 	// Detect cache hit from usage data and set in context
 	cacheHit := detectCacheHit(usage)


### PR DESCRIPTION
## Summary
This PR consolidates the separate `RoutingGraph` and `SmartRoutingGraph` components into a single `UnifiedRoutingGraph` component with mode-based display control, while adding comprehensive token usage tracking for streaming responses across protocol converters.

## Key Changes

### Frontend
- **New `UnifiedRoutingGraph` component** (`frontend/src/components/UnifiedRoutingGraph.tsx`):
  - Replaces dual `RoutingGraph` / `SmartRoutingGraph` with a single component supporting both smart and direct routing modes
  - Mode auto-detection based on `smartEnabled` flag
  - Unified callback interface for all routing operations
  - Consistent styling and node rendering across both modes

- **New `ModelRequestHeader` component** (`frontend/src/components/ModelRequestHeader.tsx`):
  - Extracted header logic for model name display and editing
  - Supports collapsible state and extra action slots
  - Reusable across routing graph and other contexts

- **New `EntryNode` component** (`frontend/src/components/nodes/EntryNode.tsx`):
  - Visual entry point for routing graphs
  - Toggle between smart/direct routing modes
  - Compact and expanded layout variants

- **Updated `ProviderNode`**:
  - Refactored priority badge to inline hollow-style disk (differentiates from smart-routing solid disks)
  - Simplified styling and removed unused menu icons
  - Improved visual consistency with priority display

- **Updated `SmartOpNode`** and **`SmartDefaultNode`**:
  - Added move-up/move-down controls for smart rules
  - Improved button styling and layout

- **Updated `RuleCard`**:
  - Replaced dual graph imports with single `UnifiedRoutingGraph`
  - Simplified mode detection logic

- **Dependencies**: Added `@emotion/react` and `@emotion/styled` for MUI styling support

### Backend
- **Stream usage tracking across protocol converters**:
  - `openai_to_anthropic.go` / `openai_to_anthropic_beta.go`: Fixed handling of trailing usage-only chunks when `stream_options.include_usage=true`; now correctly drains stream after `finish_reason` to capture upstream usage
  - `anthropic_to_openai.go`: Properly maps Anthropic cache/usage fields to OpenAI format
  - `StreamTokenCounter`: Added fields for `upstreamCacheTokens` and `upstreamReasoning` to track cached and reasoning token usage

- **Virtual model (vmodel) enhancements**:
  - New `MockUsage` struct in `vmodel/defaults_shared.go` for deterministic test usage values
  - `UsageEvent` types in `vmodel/openai/stream.go` and `vmodel/anthropic/stream.go` for explicit token usage emission
  - Mock model configs now support `Usage` field for streaming test fixtures
  - `RegisterStreamTestMocks()` functions in both OpenAI and Anthropic registries for opt-in test models

- **Virtualserver handler** (`vmodel/virtualserver/handler.go`):
  - Captures and emits explicit usage from mock models
  - Properly constructs Anthropic `message_delta` with `stop_reason` and usage block

- **Stream assembler** (`internal/protocol/assembler/anthropic_assembler.go`):
  - Enhanced `SetUsage()` to track cache creation tokens

- **Recording hooks** (`internal/server/recording_hooks.go`):
  - Added `cacheReadTokens` field to stream recorder for cache usage tracking

- **Usage tracking** (`internal/server/usage_tracking.go`):
  - Logs cache token usage alongside standard input/output tokens

### Tests
- **New E2E streaming tests**:
  - `openai_to_anthropic_vmodel_e2e_test.go`: Verifies OpenAI→Anthropic conversion preserves trailing usage chunks
  - `anthropic_to_openai_vmodel_e2e_test.go`: Verifies Anthropic→OpenAI conversion includes cache tokens
  - `vmodel/virtualserver/stream_test

https://claude.ai/code/session_01DFPYWpNFytBLFZ9L4BTbfF