### PR TITLE
feat(oauth, client): Add Kimi Code OAuth & client round-trip implementation

### DIFF
--- a/.design/kimi-config.md
+++ b/.design/kimi-config.md
@@ -1,0 +1,278 @@
+# Kimi Code OAuth & Client Round Trip: Design and Decisions
+
+> Audience: tingly-box contributors touching the Kimi Code provider path,
+> or anyone adding a new CLI-impersonation OAuth provider.
+> This document records the OAuth device-code flow, the `kimiRoundTripper`
+> impersonation headers, request body normalization, and how device ID is
+> bound to a credential — verified against the
+> [kimi-cli](https://github.com/MoonshotAI/kimi-cli) reference implementation.
+
+---
+
+## 1. Background
+
+Kimi Code (`kimi.com/code`) is Moonshot AI's coding assistant. It does not
+expose a plain API-key endpoint to third parties; access requires a user
+account authenticated via OAuth. The OAuth flow follows
+**RFC 8628 Device Authorization Grant** (device code flow): the user visits a
+verification URL on their phone/browser, and the server polls until the user
+approves.
+
+After authentication, all inference requests must carry a set of
+`X-Msh-*` headers that identify the client as `kimi_cli` — the same headers
+kimi-cli sends. Without them the API rejects the request.
+
+The backend target for Kimi Code OAuth tokens is `https://api.kimi.com/coding/v1`,
+**not** the standard Moonshot API (`api.moonshot.cn/v1`). These are separate
+products with separate auth systems.
+
+---
+
+## 2. OAuth device-code flow
+
+### 2.1 Provider configuration
+
+```go
+// ai/oauth/provider.go
+registry.Register(&ProviderConfig{
+    Type:               ai.IssuerKimiCode,
+    GrantType:          "urn:ietf:params:oauth:grant-type:device_code",
+    ClientID:           "17e5f671-d194-4dfb-9706-5516cb48c098",
+    DeviceCodeURL:      "https://auth.kimi.com/api/oauth/device_authorization",
+    TokenURL:           "https://auth.kimi.com/api/oauth/token",
+    Scopes:             nil,            // kimi-cli sends no scope parameter
+    AuthStyle:          AuthStyleInNone,
+    OAuthMethod:        OAuthMethodDeviceCode,
+    TokenRequestFormat: TokenRequestFormatForm,
+})
+```
+
+Key points:
+- **No client secret** — public device-code client, per kimi-cli.
+- **No scopes** — kimi-cli does not send a `scope` parameter; sending one
+  causes the device_authorization request to fail.
+- **Form encoding** — token requests use `application/x-www-form-urlencoded`,
+  not JSON.
+- **Client ID verified** against `KIMI_CODE_CLIENT_ID` in kimi-cli's
+  `auth/oauth.py`.
+
+### 2.2 `KimiHook` — per-request headers on auth calls
+
+Every token-related HTTP call (device authorization, token polling, refresh)
+goes through `KimiHook.BeforeToken`, which sets the same fingerprint headers
+that kimi-cli sends:
+
+```go
+// ai/oauth/hook.go
+func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error {
+    header.Set("X-Msh-Platform",   "kimi_cli")
+    header.Set("X-Msh-Version",    "1.10.6")
+    header.Set("X-Msh-Device-Name", KimiDeviceName())   // os.Hostname()
+    header.Set("X-Msh-Device-Model", KimiDeviceModel()) // "macOS arm64"
+    header.Set("X-Msh-Os-Version",  KimiOsVersion())    // see §4
+    return nil
+}
+```
+
+`X-Msh-Device-Id` is **not** set here — see §3 for why.
+
+### 2.3 Device ID binding per credential
+
+kimi-cli generates one UUID on first launch and stores it at
+`~/.kimi-cli/share/device_id`, reusing the same ID for all sessions and all
+API calls.
+
+tingly-box takes a different approach: a fresh UUID is generated **per OAuth
+flow** and stored in `OAuthDetail.DeviceID`. Every subsequent refresh and
+inference request for that credential reuses the same ID. Multiple
+credentials therefore appear as different devices to Kimi — which is
+functionally correct (each credential IS a separate account/session).
+
+The device ID is injected via `oauth.WithExtraHeader`:
+
+```go
+// internal/server/module/oauth/handler.go
+if issuer == ai.IssuerKimiCode {
+    kimiDeviceID = uuid.New().String()
+    deviceOpts = append(deviceOpts, WithKimiDeviceID(kimiDeviceID))
+}
+```
+
+`WithKimiDeviceID` wraps `oauth.WithExtraHeader("X-Msh-Device-Id", id)`, which
+the OAuth manager applies to every token request via `applyExtraHeaders`.
+After the flow succeeds, the device ID is persisted in `OAuthDetail.DeviceID`
+and reattached on refresh (`oauth_refresher.go`, `handler.go:RefreshOAuthToken`).
+
+### 2.4 Polling and refresh
+
+Token polling and refresh both go through `oauth.Manager.PollForToken` /
+`Manager.RefreshToken`. Both paths call `BeforeToken` (including the
+`X-Msh-Device-Id` extra header), so the device ID is consistent across the
+entire credential lifetime.
+
+---
+
+## 3. Client round tripper — inference impersonation
+
+Every inference request to `https://api.kimi.com/coding/v1` is wrapped by
+`kimiRoundTripper`, which adds the CLI fingerprint headers and normalizes
+the request body:
+
+```go
+// internal/client/kimi_round_tripper.go
+const (
+    kimiCLIUserAgent = "KimiCLI/1.10.6"
+    kimiCLIPlatform  = "kimi_cli"
+    kimiCLIVersion   = "1.10.6"
+)
+
+func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+    req.Header.Set("User-Agent",        kimiCLIUserAgent)
+    req.Header.Set("X-Msh-Platform",    kimiCLIPlatform)
+    req.Header.Set("X-Msh-Version",     kimiCLIVersion)
+    req.Header.Set("X-Msh-Device-Name", t.deviceName)
+    req.Header.Set("X-Msh-Device-Model", t.deviceModel)
+    req.Header.Set("X-Msh-Os-Version",  t.osVersion)
+    if t.deviceID != "" {
+        req.Header.Set("X-Msh-Device-Id", t.deviceID)
+    }
+    // body normalization (see §5)
+    ...
+}
+```
+
+The `deviceName`, `deviceModel`, `osVersion` are resolved once at construction
+(no per-request syscall). `deviceID` comes from `provider.OAuthDetail.DeviceID`.
+
+**Header consistency**: `KimiHook` (auth) and `kimiRoundTripper` (inference)
+must send the same values. The shared `oauth.KimiDeviceName()`,
+`KimiDeviceModel()`, `KimiOsVersion()` helpers in `ai/oauth/hook.go` ensure
+both paths use identical logic.
+
+---
+
+## 4. OS version headers
+
+`X-Msh-Os-Version` is set to a hardcoded representative value per platform,
+matching the style of `platform.version()` output from kimi-cli:
+
+```go
+// ai/oauth/hook.go
+func KimiOsVersion() string {
+    switch runtime.GOOS {
+    case "darwin":
+        return "14.6.1"     // macOS Sonoma latest stable
+    case "windows":
+        return "10.0.22631" // Windows 11 23H2
+    default:                // linux and others
+        return "6.8.0"      // Ubuntu 24.04 LTS kernel
+    }
+}
+```
+
+Hardcoded rather than dynamic (`/proc/sys/kernel/osrelease`, `sw_vers`) to
+avoid I/O on every request and to stay consistent regardless of the host the
+server runs on.
+
+---
+
+## 5. Request body normalization
+
+kimi-cli is a Python CLI client; it does no body rewriting. tingly-box acts as
+a proxy, so it must normalize OpenAI-style payloads before forwarding. The
+normalization logic is based on the CLIProxyAPI Go reference:
+
+### 5.1 Model name prefix stripping
+
+Kimi's API does not accept the `"kimi-"` prefix:
+
+```
+"kimi-k2"  →  "k2"
+"kimi-K2"  →  "K2"    (prefix check is case-insensitive, remainder preserved)
+"k2"       →  "k2"    (no-op)
+```
+
+### 5.2 Empty assistant message filtering
+
+Assistant messages with no content, no tool calls, no function call, and no
+`reasoning_content` are dropped. These arise from multi-turn traces where a
+turn produced only a tool call and the assistant content field was left empty.
+Kimi's API rejects such messages.
+
+### 5.3 Tool message normalization
+
+Two fixups applied to every `messages` array:
+
+1. **`call_id` → `tool_call_id`**: Some clients send `call_id` instead of the
+   OpenAI-standard `tool_call_id`. When `tool_call_id` is absent but `call_id`
+   is present, `tool_call_id` is added (both fields coexist; no data removed).
+
+2. **Infer missing `tool_call_id`**: If a `tool` message has no ID at all and
+   exactly one assistant tool call is still pending, the pending call's ID is
+   used. Ambiguous cases (multiple pending) are left untouched.
+
+### 5.4 `reasoning_content` on tool-calling assistant messages
+
+Kimi requires `reasoning_content` on every assistant message that has
+`tool_calls`. When the field is absent or empty:
+
+- If a prior assistant message in the same conversation had non-empty
+  `reasoning_content`, that value is reused (carries the last known reasoning
+  forward).
+- Otherwise, the content text of the current message is used as a fallback.
+- If nothing is available, an empty string `""` is written.
+
+No sentinel string is injected — empty string signals "no reasoning available"
+without introducing a non-standard marker.
+
+---
+
+## 6. API base and style
+
+```go
+case ai.IssuerKimiCode:
+    apiBase  = "https://api.kimi.com/coding/v1"
+    apiStyle = protocol.APIStyleOpenAI
+```
+
+Kimi Code exposes an OpenAI-compatible chat completions endpoint, so no
+protocol translation is required. The `kimiRoundTripper` layers on top of the
+standard OpenAI SDK transport.
+
+---
+
+## 7. Reference verification
+
+All constants and endpoint URLs were verified against
+`src/kimi_cli/auth/oauth.py` and `src/kimi_cli/auth/platforms.py` in the
+[MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli) repository:
+
+| Item | kimi-cli | tingly-box |
+|------|----------|-----------|
+| Client ID | `17e5f671-d194-4dfb-9706-5516cb48c098` | same |
+| Device auth URL | `https://auth.kimi.com/api/oauth/device_authorization` | same |
+| Token URL | `https://auth.kimi.com/api/oauth/token` | same |
+| Grant type | `urn:ietf:params:oauth:grant-type:device_code` | same |
+| API base | `https://api.kimi.com/coding/v1` | same |
+| Scopes | none (no `scope` param) | `nil` |
+| `X-Msh-Platform` | `"kimi_cli"` | `"kimi_cli"` |
+| `X-Msh-Version` | `VERSION` (≈ `1.10.6`) | `"1.10.6"` |
+| `X-Msh-Device-Name` | `os.hostname()` | `os.Hostname()` |
+| `X-Msh-Device-Model` | `"<OS> <arch>"` | `KimiDeviceModel()` |
+| `X-Msh-Os-Version` | `platform.version()` | hardcoded per platform |
+| `X-Msh-Device-Id` | persistent per-device UUID | persistent per-credential UUID |
+| Token format | form-encoded | `TokenRequestFormatForm` |
+
+---
+
+## 8. Key files
+
+| Layer | File | Role |
+|---|---|---|
+| OAuth config | `ai/oauth/provider.go` | `IssuerKimiCode` provider registration |
+| OAuth hook | `ai/oauth/hook.go` | `KimiHook`, `KimiDeviceName`, `KimiDeviceModel`, `KimiOsVersion` |
+| OAuth helper | `internal/server/module/oauth/kimi.go` | `WithKimiDeviceID` — injects `X-Msh-Device-Id` into token requests |
+| Auth handler | `internal/server/module/oauth/handler.go` | device ID generation, `pollForDeviceCodeToken`, `createProviderFromToken` |
+| Background refresh | `internal/server/background/oauth_refresher.go` | reattaches device ID on token refresh |
+| Round tripper | `internal/client/kimi_round_tripper.go` | inference headers + body normalization |
+| Round tripper test | `internal/client/kimi_round_tripper_test.go` | normalization unit tests |

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -600,14 +601,22 @@ func KimiDeviceModel() string {
 	return goos + " " + runtime.GOARCH
 }
 
-// KimiOsVersion returns a fixed OS version string for the X-Msh-Os-Version header.
+// KimiOsVersion returns the OS version string for the X-Msh-Os-Version header,
+// mirroring Python's platform.version() used by kimi-cli.
 func KimiOsVersion() string {
 	switch runtime.GOOS {
+	case "linux":
+		if data, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+			return strings.TrimSpace(string(data))
+		}
 	case "darwin":
-		return "14.0"
+		if out, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
 	case "windows":
-		return "10.0"
-	default:
-		return "6.1.0"
+		if out, err := exec.Command("cmd", "/c", "ver").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
 	}
+	return runtime.GOOS
 }

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -601,22 +600,14 @@ func KimiDeviceModel() string {
 	return goos + " " + runtime.GOARCH
 }
 
-// KimiOsVersion returns the OS version string for the X-Msh-Os-Version header,
-// mirroring Python's platform.version() used by kimi-cli.
+// KimiOsVersion returns a fixed OS version string for the X-Msh-Os-Version header.
 func KimiOsVersion() string {
 	switch runtime.GOOS {
-	case "linux":
-		if data, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
-			return strings.TrimSpace(string(data))
-		}
 	case "darwin":
-		if out, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
-			return strings.TrimSpace(string(out))
-		}
+		return "14.0"
 	case "windows":
-		if out, err := exec.Command("cmd", "/c", "ver").Output(); err == nil {
-			return strings.TrimSpace(string(out))
-		}
+		return "10.0"
+	default:
+		return "6.1.0"
 	}
-	return runtime.GOOS
 }

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -502,6 +503,7 @@ func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error
 	header.Set("X-Msh-Version", "1.10.6")
 	header.Set("X-Msh-Device-Name", KimiDeviceName())
 	header.Set("X-Msh-Device-Model", KimiDeviceModel())
+	header.Set("X-Msh-Os-Version", KimiOsVersion())
 	return nil
 }
 
@@ -597,4 +599,24 @@ func KimiDeviceModel() string {
 		goos = "Windows"
 	}
 	return goos + " " + runtime.GOARCH
+}
+
+// KimiOsVersion returns the OS version string for the X-Msh-Os-Version header,
+// mirroring Python's platform.version() used by kimi-cli.
+func KimiOsVersion() string {
+	switch runtime.GOOS {
+	case "linux":
+		if data, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+			return strings.TrimSpace(string(data))
+		}
+	case "darwin":
+		if out, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	case "windows":
+		if out, err := exec.Command("cmd", "/c", "ver").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
+	return runtime.GOOS
 }

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -612,6 +612,6 @@ func KimiOsVersion() string {
 	case "windows":
 		return "10.0.22631"
 	default: // linux and others
-		return "5.15.0"
+		return "6.8.0"
 	}
 }

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -601,22 +600,18 @@ func KimiDeviceModel() string {
 	return goos + " " + runtime.GOARCH
 }
 
-// KimiOsVersion returns the OS version string for the X-Msh-Os-Version header,
-// mirroring Python's platform.version() used by kimi-cli.
+// KimiOsVersion returns a representative OS version string for the X-Msh-Os-Version header.
+// Values mirror typical platform.version() output from kimi-cli:
+//   - Linux   → Ubuntu 22.04 LTS default kernel
+//   - macOS   → macOS Sonoma 14.6.1
+//   - Windows → Windows 11 23H2
 func KimiOsVersion() string {
 	switch runtime.GOOS {
-	case "linux":
-		if data, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
-			return strings.TrimSpace(string(data))
-		}
 	case "darwin":
-		if out, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
-			return strings.TrimSpace(string(out))
-		}
+		return "14.6.1"
 	case "windows":
-		if out, err := exec.Command("cmd", "/c", "ver").Output(); err == nil {
-			return strings.TrimSpace(string(out))
-		}
+		return "10.0.22631"
+	default: // linux and others
+		return "5.15.0"
 	}
-	return runtime.GOOS
 }

--- a/ai/oauth/hook.go
+++ b/ai/oauth/hook.go
@@ -498,8 +498,8 @@ func (h *KimiHook) BeforeAuth(params map[string]string) error {
 }
 
 func (h *KimiHook) BeforeToken(body map[string]string, header http.Header) error {
-	header.Set("X-Msh-Platform", "kimi cli")
-	header.Set("X-Msh-Version", "1.0.0")
+	header.Set("X-Msh-Platform", "kimi_cli")
+	header.Set("X-Msh-Version", "1.10.6")
 	header.Set("X-Msh-Device-Name", KimiDeviceName())
 	header.Set("X-Msh-Device-Model", KimiDeviceModel())
 	return nil

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -32,6 +32,7 @@ type kimiRoundTripper struct {
 	deviceID    string
 	deviceName  string
 	deviceModel string
+	osVersion   string
 }
 
 func newKimiRoundTripper(inner http.RoundTripper, provider *typ.Provider) *kimiRoundTripper {
@@ -44,6 +45,7 @@ func newKimiRoundTripper(inner http.RoundTripper, provider *typ.Provider) *kimiR
 		deviceID:     deviceID,
 		deviceName:   oauth.KimiDeviceName(),
 		deviceModel:  oauth.KimiDeviceModel(),
+		osVersion:    oauth.KimiOsVersion(),
 	}
 }
 
@@ -53,6 +55,7 @@ func (t *kimiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	req.Header.Set("X-Msh-Version", kimiCLIVersion)
 	req.Header.Set("X-Msh-Device-Name", t.deviceName)
 	req.Header.Set("X-Msh-Device-Model", t.deviceModel)
+	req.Header.Set("X-Msh-Os-Version", t.osVersion)
 	if t.deviceID != "" {
 		req.Header.Set("X-Msh-Device-Id", t.deviceID)
 	}

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -403,5 +403,5 @@ func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string)
 		}
 	}
 
-	return "[reasoning unavailable]"
+	return ""
 }

--- a/internal/client/kimi_round_tripper.go
+++ b/internal/client/kimi_round_tripper.go
@@ -400,5 +400,5 @@ func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string)
 		}
 	}
 
-	return ""
+	return "[reasoning unavailable]"
 }

--- a/internal/client/kimi_round_tripper_test.go
+++ b/internal/client/kimi_round_tripper_test.go
@@ -84,7 +84,7 @@ func TestNormalizeRequest(t *testing.T) {
 		{
 			name:     "keep assistant message with tool calls and add reasoning_content",
 			input:    `{"model":"k2","messages":[{"role":"assistant","content":"","tool_calls":[{"id":"123","function":{"name":"test"}}]},{"role":"user","content":"hi"}]}`,
-			expected: `{"model":"k2","messages":[{"role":"assistant","content":"","tool_calls":[{"id":"123","function":{"name":"test"}}],"reasoning_content":"[reasoning unavailable]"},{"role":"user","content":"hi"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","content":"","tool_calls":[{"id":"123","function":{"name":"test"}}],"reasoning_content":""},{"role":"user","content":"hi"}]}`,
 		},
 		{
 			name:     "invalid json - return as is",
@@ -121,17 +121,17 @@ func TestNormalizeToolMessages_FixToolCallID(t *testing.T) {
 		{
 			name:     "fix call_id to tool_call_id (keeps both fields)",
 			input:    `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}]},{"role":"tool","call_id":"tc1","content":"result"}]}`,
-			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}],"reasoning_content":"[reasoning unavailable]"},{"role":"tool","call_id":"tc1","tool_call_id":"tc1","content":"result"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}],"reasoning_content":""},{"role":"tool","call_id":"tc1","tool_call_id":"tc1","content":"result"}]}`,
 		},
 		{
 			name:     "infer missing tool_call_id from single pending",
 			input:    `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}]},{"role":"tool","content":"result"}]}`,
-			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}],"reasoning_content":"[reasoning unavailable]"},{"role":"tool","tool_call_id":"tc1","content":"result"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1"}],"reasoning_content":""},{"role":"tool","tool_call_id":"tc1","content":"result"}]}`,
 		},
 		{
 			name:     "add reasoning_content to assistant with tool calls",
 			input:    `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1","function":{"name":"test"}}]}]}`,
-			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1","function":{"name":"test"}}],"reasoning_content":"[reasoning unavailable]"}]}`,
+			expected: `{"model":"k2","messages":[{"role":"assistant","tool_calls":[{"id":"tc1","function":{"name":"test"}}],"reasoning_content":""}]}`,
 		},
 	}
 


### PR DESCRIPTION
## Summary
Implements complete OAuth device-code flow and inference request handling for Kimi Code (`kimi.com/code`), including per-credential device ID binding, CLI fingerprint header injection, and request body normalization to match the kimi-cli reference implementation.

## Key Changes

### OAuth Configuration & Authentication
- **Provider registration** (`ai/oauth/provider.go`): Configured `IssuerKimiCode` with RFC 8628 device-code grant, targeting `https://auth.kimi.com/api/oauth/` endpoints
- **KimiHook updates** (`ai/oauth/hook.go`):
  - Fixed `X-Msh-Platform` header from `"kimi cli"` → `"kimi_cli"` (underscore, matches kimi-cli)
  - Updated `X-Msh-Version` from `"1.0.0"` → `"1.10.6"` (verified against kimi-cli reference)
  - Added `X-Msh-Os-Version` header with platform-specific hardcoded values (macOS 14.6.1, Windows 10.0.22631, Linux 6.8.0)
  - Added `KimiOsVersion()` helper function for consistent OS version reporting

### Device ID Management
- **Per-credential device ID binding**: Fresh UUID generated per OAuth flow, stored in `OAuthDetail.DeviceID`, reused across all token refreshes and inference requests for that credential
- **Device ID injection**: Implemented via `WithKimiDeviceID()` helper in `internal/server/module/oauth/kimi.go`, applied to all token requests through `applyExtraHeaders`
- **Persistence**: Device ID reattached on token refresh (`oauth_refresher.go`, `handler.go`)

### Inference Request Handling
- **kimiRoundTripper enhancements** (`internal/client/kimi_round_tripper.go`):
  - Added `osVersion` field to round tripper struct
  - Injects all CLI fingerprint headers (`X-Msh-Platform`, `X-Msh-Version`, `X-Msh-Device-Name`, `X-Msh-Device-Model`, `X-Msh-Os-Version`, `X-Msh-Device-Id`)
  - Implements request body normalization (model prefix stripping, empty message filtering, tool call ID fixups, reasoning_content injection)

### Request Body Normalization
- **Model name prefix stripping**: `"kimi-k2"` → `"k2"` (case-insensitive prefix check)
- **Empty assistant message filtering**: Drops assistant messages with no content, tool calls, or reasoning_content
- **Tool message fixups**:
  - Maps `call_id` → `tool_call_id` when missing
  - Infers missing `tool_call_id` from pending assistant tool calls
- **Reasoning content injection**: Adds `reasoning_content` to assistant messages with tool calls, reusing prior reasoning or falling back to message content (empty string if unavailable — no sentinel markers)

### Testing & Documentation
- **Test updates** (`internal/client/kimi_round_tripper_test.go`): Changed sentinel `"[reasoning unavailable]"` → `""` (empty string) for reasoning_content fallback
- **Design document** (`.design/kimi-config.md`): Comprehensive reference covering OAuth flow, device ID binding, header consistency, body normalization rules, and verification against kimi-cli source

## Implementation Details
- **No client secret**: Public device-code client per kimi-cli design
- **No scopes**: Kimi OAuth does not accept scope parameter
- **Form-encoded tokens**: Token requests use `application/x-www-form-urlencoded`
- **Separate API base**: `https://api.kimi.com/coding/v1` (not standard Moonshot API)
- **Header consistency**: Shared helpers (`KimiDeviceName()`, `KimiDeviceModel()`, `KimiOsVersion()`) ensure auth and inference paths send identical values
- **All constants verified** against [MoonshotAI/kimi

https://claude.ai/code/session_01HGSbQmjjGJR1iU8BrVGDze