### PR TITLE
bugfix(protocol): preserve cache and reasoning tokens in OpenAI↔Anthropic streams

### DIFF
--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -1,0 +1,255 @@
+# Stream Usage Tracking
+
+> 适用对象：tingly-box 后端贡献者，特别是改 `internal/protocol/stream/`、`internal/protocol/token/`、`internal/protocol/assembler/`、`internal/server/recording_hooks.go`，或在 `vmodel/` 内增 mock 的人。
+
+**Status: shipped** in PR #1063 on `claude/keen-ramanujan-qUaXP`。
+
+---
+
+## 1. 问题域
+
+OpenAI ↔ Anthropic 互转的 stream handler 要把上游 usage 一路带到：
+
+1. 客户端看到的 Anthropic `message_delta.usage`（输出协议层）
+2. 返回给调用方的 `*ai.TokenUsage`（in-process API 层）
+3. 计费 / 记录用的 `trackUsageWithTokenUsage`（observability 层）
+4. 录制下来的 assembled response（PR/日志回放层）
+
+完整 usage shape 不只有 input/output，还有：
+
+| 维度 | OpenAI Chat | OpenAI Responses | Anthropic |
+|---|---|---|---|
+| Prompt | `usage.prompt_tokens` | `usage.input_tokens` | `usage.input_tokens` |
+| Completion | `usage.completion_tokens` | `usage.output_tokens` | `usage.output_tokens` |
+| Cache read | `usage.prompt_tokens_details.cached_tokens` | `usage.input_tokens_details.cached_tokens` | `usage.cache_read_input_tokens` |
+| Cache creation | — | — | `usage.cache_creation_input_tokens` |
+| Reasoning | `usage.completion_tokens_details.reasoning_tokens` | `usage.output_tokens_details.reasoning_tokens` | —（计入 output_tokens） |
+
+任何一段没拿全，下游记录就缺字段。
+
+---
+
+## 2. 改动前的三个 bug
+
+### 2.1 OpenAI 流的尾 usage chunk 被丢
+
+OpenAI 在 `stream_options.include_usage=true` 时（tingly-box 在 Anthropic→OpenAI 请求转换里强制开启），最后一个 chunk 形态为：
+
+```
+{ "choices": [],   "usage": {"prompt_tokens": ..., "completion_tokens": ..., ...} }
+```
+
+它 **晚于** 携带 `finish_reason` 的 chunk。旧版 `handleOpenAIToAnthropicStreamResponse` 在收到 `finish_reason` 立刻 `return false`，于是这条 usage-only chunk 永远读不到 —— `state.cacheTokens` / `state.reasoningTokens` / 甚至权威的 `input_tokens` / `output_tokens` 都丢了，只剩本地 tiktoken 估算。
+
+### 2.2 Anthropic→OpenAI 反向只搬基础字段
+
+`anthropic_to_openai.go` 抽 `message_delta.usage` 时只读 `InputTokens` / `OutputTokens`，`CacheReadInputTokens` 静默丢弃。Anthropic 没有 reasoning_tokens（thinking tokens 已计入 output），这一侧 N/A。
+
+### 2.3 streamRecorder 截胡 cache
+
+`streamRecorder.Finish(model, in, out)` 只接 input/output；`AnthropicStreamAssembler.SetUsage(in, out)` 也只存 input/output；assembled `anthropic.Message.Usage.CacheReadInputTokens = 0`。converter 那侧拼了命算出来的 cache 进 recorder 前就被丢了。
+
+### 2.4 缺一个能落到 Info 日志的 usage 总览
+
+`trackUsageWithTokenUsage` 仅在 `Trace` 级别打全字段（默认不可见）；converter 本身一行总览都没有。线上想看一次请求的 token 分布就只能开 trace。
+
+---
+
+## 3. 设计
+
+### 3.1 Stream 转换：drain 到底再发终态
+
+`handleOpenAIToAnthropicStreamResponse` / `handleOpenAIToAnthropicBetaStream` 改为：
+
+- `finish_reason` chunk 不再立刻 `return false`，只记录 `pendingFinishReason` + `finishSeen = true` 然后继续循环
+- `len(choices) == 0` 的 chunk（包含尾 usage-only chunk）落入既有的 token-counter 喂入分支
+- 流自然结束（`stream.Next()` 返回 false）后，在 post-loop 里读最终 counter，发 stop / message_delta / message_stop
+
+```go
+StreamLoop(c, func(w io.Writer) bool {
+    // ... process content / tool_calls deltas ...
+
+    if len(chunk.Choices) == 0 {
+        tokenCounter.ConsumeOpenAIChunk(&chunk) // 尾 usage chunk 走这里
+        return true
+    }
+
+    if choice.FinishReason != "" {
+        pendingFinishReason = choice.FinishReason
+        finishSeen = true
+        // 不返回 false，继续 drain
+    }
+    return true
+})
+
+if finishSeen && hookErr == nil {
+    // 从 counter 同步最终 input/output/cache/reasoning
+    // 发 message_delta + message_stop
+    // 打一条 Info "OpenAI->Anthropic stream usage"
+}
+```
+
+### 3.2 StreamTokenCounter 扩展 cache + reasoning
+
+`StreamTokenCounter` 之前只抽 `chunk.Usage.PromptTokens` / `CompletionTokens`。新增：
+
+```go
+// 读 chunk.Usage.PromptTokensDetails.CachedTokens
+// 读 chunk.Usage.CompletionTokensDetails.ReasoningTokens
+func (c *StreamTokenCounter) GetUpstreamDetails() (cacheTokens, reasoningTokens int)
+```
+
+post-finish 块从这里取，写进 `state.cacheTokens` / `state.reasoningTokens`，最终走 `sendMessageDelta`（已支持 `cache_read_input_tokens`）和返回的 `ai.TokenUsage`。
+
+### 3.3 反向流：anthropic_to_openai 映射 cache_read
+
+```go
+chunk.Usage = openai.CompletionUsage{
+    PromptTokens:     usage.InputTokens,
+    CompletionTokens: usage.OutputTokens,
+    TotalTokens:      usage.InputTokens + usage.OutputTokens,
+}
+if usage.CacheReadInputTokens > 0 {
+    chunk.Usage.PromptTokensDetails.CachedTokens = usage.CacheReadInputTokens
+}
+```
+
+Anthropic 的 `CacheCreationInputTokens` 在 OpenAI Chat 协议里没对应字段，物理上不能搬。reasoning N/A。
+
+### 3.4 Recorder 链：以 `*ai.TokenUsage` 为流通货币
+
+把 `(int, int)` 这种到处散落的字段对替换成 canonical type，避免每加一个字段就改一圈签名：
+
+```go
+// 旧：streamRecorder.Finish(model, inputTokens, outputTokens)
+// 新：
+func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage)
+
+// 旧：assembler.SetUsage(inputTokens, outputTokens)
+// 新增（旧保留作为简单入口）：
+func (a *AnthropicStreamAssembler) SetUsageFromTokenUsage(u *ai.TokenUsage)
+```
+
+`SetUsageFromTokenUsage` 把 `CacheInputTokens` 落到 `anthropic.Usage.CacheReadInputTokens`。reasoning 在 Anthropic 没有对应字段，丢弃（与协议一致）。
+
+同时修补一个独立的丢字段：`AnthropicStreamAssembler.RecordV1Event` / `RecordV1BetaEvent` 处理 `message_delta` 时本来只复制 input/output，新版把 `event.Usage.CacheReadInputTokens` 也带上 —— 上游事件里就有，但被 assembler 截胡的话本 PR 后半段的 cache_read 通路在某些路径上其实通不到底。
+
+### 3.5 Info 级 usage 总览
+
+v1 + beta 流终态各打一条：
+
+```
+level=info msg="OpenAI->Anthropic stream usage"
+  model=virtual-stream-test
+  input_tokens=42  output_tokens=17
+  cache_tokens=11  reasoning_tokens=9
+  stop_reason=end_turn
+```
+
+`trackUsage` 旁路日志从 Trace 升到 Debug，并补 `reasoning_tokens` 字段。
+
+---
+
+## 4. vmodel 测试基建
+
+PR 顺手补了一个能在 in-process 测端到端 usage 的开关。
+
+### 4.1 MockUsage
+
+`vmodel/defaults_shared.go`：
+
+```go
+type MockUsage struct {
+    PromptTokens             int64
+    CompletionTokens         int64
+    CachedInputTokens        int64 // OpenAI cached_tokens / Anthropic cache_read
+    CacheCreationInputTokens int64 // Anthropic only
+    ReasoningTokens          int64 // OpenAI only
+}
+```
+
+写进 SharedMockSpec（仅协议无关字段），两个协议的 `MockModelConfig` 都加 `Usage *vmodel.MockUsage` 字段。
+
+### 4.2 UsageEvent
+
+`vmodel/openai/stream.go` 和 `vmodel/anthropic/stream.go` 各加：
+
+```go
+type UsageEvent struct { Usage vmodel.MockUsage }
+```
+
+`MockModel.HandleOpenAIChatStream` / `HandleAnthropicStream` 在 `DoneEvent` 之前 emit。
+
+### 4.3 virtualserver 渲染成 wire 格式
+
+- **OpenAI**：`req.StreamOptions.IncludeUsage.Value || explicitUsage != nil` 时，在 `finish_reason` chunk 后、`[DONE]` 前发尾 usage-only chunk，`PromptTokensDetails.CachedTokens` / `CompletionTokensDetails.ReasoningTokens` 都填。
+- **Anthropic**：在 `message_stop` 前发 `message_delta`，usage 块带 `input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` / `reasoning_tokens`。
+
+### 4.4 opt-in 注册
+
+```go
+openaivm.RegisterStreamTestMocks(svc.GetOpenAIRegistry())
+anthropicvm.RegisterStreamTestMocks(svc.GetAnthropicRegistry())
+```
+
+故意不进 `RegisterDefaults` —— 生产 registry / 用户面 demo 列表保持干净。规范见 `defaults_shared.go` 的 doc-comment：「Test-only fixtures must NOT be added to SharedDefaultMocks.」
+
+两个 spec：
+
+| ID | 类型 | 用途 |
+|---|---|---|
+| `virtual-stream-test` | static text | 验完整 usage shape 在 text 路径上 |
+| `virtual-stream-test-tool` | tool_call | 验完整 usage shape 在 tool path + `stop_reason=tool_use` 映射 |
+
+usage 数值固定（PromptTokens=42, CompletionTokens=17, CachedInputTokens=11, CacheCreationInputTokens=5, ReasoningTokens=9），断言端可硬编码。
+
+### 4.5 测试落点
+
+| 测试 | 覆盖 |
+|---|---|
+| `vmodel/virtualserver/stream_test_mocks_test.go` | 两个协议的 wire 格式（OpenAI 尾 usage chunk 字段、Anthropic message_delta.usage 字段），static + tool 两种变体 |
+| `internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go::TestOpenAIToAnthropicStream_VModelFullUsage` | OpenAI→Anthropic 完整链路：vmodel 上游 + converter + 终端 `ai.TokenUsage` 四字段 + `stop_reason=tool_use` 映射 |
+| `internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go::TestAnthropicToOpenAIStream_VModelFullUsage` | 反向链路：上游 cache_read 落到下游 prompt_tokens_details.cached_tokens |
+| `internal/protocol/assembler/anthropic_assembler_test.go::TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesCacheRead` | 单测：cache_read 经 assembler 进 assembled response |
+
+回滚验证：把 converter 那侧的 fix `git stash` 掉，上述 E2E 测试会失败（OutputTokens=0 / cached_tokens=0），证明测试真在抓 bug。
+
+---
+
+## 5. 日志策略
+
+每 chunk 一条 Debug 是这个 PR 在追那个 finish_reason→usage drop bug 时的产物。落地后清理标准：
+
+**保留**：
+- 每请求 ≤ 1 次的 Start / Finish 边界
+- 每请求 1 次的终态 Info `OpenAI->Anthropic stream usage`（前述总览）
+- 每 block 1 次的 `Initializing thinking block` / `Thinking block done`
+- 异常路径（panic, client disconnect, stream error）
+- 状态事件（in_progress / completed / generating / searching 等，每请求顶多几条）
+
+**删**：
+- 任何"每 chunk"或"每 delta"的 Debug（content、thinking、annotation、audio、code-interpreter、output_item.added 等）
+- 任何 dump 完整 RawJSON 或 marshalled message 的 Debug（前 N chunk dump、Assemble response 等）—— 大 payload 本身就是 HTTP body，重复存档没意义
+- 只服务于这些日志的本地变量（`chunkCount`、`eventCount`、`hasValidUsage`、`hasNonZeroUsage`、`preview` 等）
+
+清理范围限本 PR 引入或受影响的文件，不动 stream package 里其他历史日志。
+
+---
+
+## 6. 类似 bug 的扫描清单
+
+PR 期间用 Explore agent 扫了 `internal/protocol/stream/` + `internal/protocol/nonstream/`，按"提前 return"与"字段映射不全"两条标准查同类 bug。
+
+| 文件 | 状态 | 备注 |
+|---|---|---|
+| `stream/openai_to_anthropic.go` + `_beta.go` | ✅ 修 | 本 PR 主题 |
+| `stream/anthropic_to_openai.go` | ✅ 修 | cache_read 字段补全 |
+| `stream/anthropic_beta_to_openai_responses.go` | OK | 已抽 cache_read；`CacheCreationInputTokens` 在目标协议里没字段 |
+| `stream/openai_chat_to_responses.go` | OK | usage 持续抽取，无早退 |
+| `stream/openai_responses_to_chat.go` | OK | 完整抽 input/output/cache/reasoning |
+| `nonstream/openai_to_anthropic.go` | OK | reasoning 在 Anthropic 无对等字段；其余完整 |
+| `nonstream/anthropic_to_openai.go` | OK | cache_read 已映射；Anthropic 不发 reasoning |
+| `nonstream/openai_responses_to_chat.go` | OK | 完整 |
+| `stream/google_to_any.go` + `nonstream/google_to.go` | skip | 当前不投入 |
+
+新增 stream converter 时按这个清单核对一遍。

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -55,8 +55,9 @@ func (a *AnthropicStreamAssembler) RecordV1Event(event *anthropic.MessageStreamE
 		a.stopSeq = event.Delta.StopSequence
 		if event.Usage.InputTokens > 0 || event.Usage.OutputTokens > 0 {
 			a.usageData = &anthropic.Usage{
-				InputTokens:  event.Usage.InputTokens,
-				OutputTokens: event.Usage.OutputTokens,
+				InputTokens:          event.Usage.InputTokens,
+				OutputTokens:         event.Usage.OutputTokens,
+				CacheReadInputTokens: event.Usage.CacheReadInputTokens,
 			}
 		}
 	}
@@ -82,8 +83,9 @@ func (a *AnthropicStreamAssembler) RecordV1BetaEvent(event *anthropic.BetaRawMes
 		a.stopSeq = event.Delta.StopSequence
 		if event.Usage.InputTokens > 0 || event.Usage.OutputTokens > 0 {
 			a.usageData = &anthropic.Usage{
-				InputTokens:  event.Usage.InputTokens,
-				OutputTokens: event.Usage.OutputTokens,
+				InputTokens:          event.Usage.InputTokens,
+				OutputTokens:         event.Usage.OutputTokens,
+				CacheReadInputTokens: event.Usage.CacheReadInputTokens,
 			}
 		}
 	}
@@ -228,22 +230,13 @@ func (a *AnthropicStreamAssembler) Finish(model string, inputTokens, outputToken
 	}
 	stopSeq := a.stopSeq
 
-	// Build usage
+	// Build usage. Prefer values set via SetUsage*; fall back to the
+	// caller-supplied counts only when nothing was tracked in-stream.
 	usage := a.usageData
 	if usage == nil {
 		usage = &anthropic.Usage{
 			InputTokens:  int64(inputTokens),
 			OutputTokens: int64(outputTokens),
-		}
-	} else {
-		// Keep any in-stream usage (incl. cache_read) but let explicit
-		// totals from Finish override input/output if they're larger
-		// (handles the post-finish_reason usage chunk path).
-		if int64(inputTokens) > usage.InputTokens {
-			usage.InputTokens = int64(inputTokens)
-		}
-		if int64(outputTokens) > usage.OutputTokens {
-			usage.OutputTokens = int64(outputTokens)
 		}
 	}
 

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -188,6 +188,15 @@ func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 	}
 }
 
+// SetUsageFull sets the usage data including cache tokens.
+func (a *AnthropicStreamAssembler) SetUsageFull(inputTokens, outputTokens, cacheReadTokens int) {
+	a.usageData = &anthropic.Usage{
+		InputTokens:          int64(inputTokens),
+		OutputTokens:         int64(outputTokens),
+		CacheReadInputTokens: int64(cacheReadTokens),
+	}
+}
+
 // Finish assembles the final response and returns it as anthropic.Message
 func (a *AnthropicStreamAssembler) Finish(model string, inputTokens, outputTokens int) *anthropic.Message {
 	if a == nil || a.msgID == "" {
@@ -215,6 +224,16 @@ func (a *AnthropicStreamAssembler) Finish(model string, inputTokens, outputToken
 		usage = &anthropic.Usage{
 			InputTokens:  int64(inputTokens),
 			OutputTokens: int64(outputTokens),
+		}
+	} else {
+		// Keep any in-stream usage (incl. cache_read) but let explicit
+		// totals from Finish override input/output if they're larger
+		// (handles the post-finish_reason usage chunk path).
+		if int64(inputTokens) > usage.InputTokens {
+			usage.InputTokens = int64(inputTokens)
+		}
+		if int64(outputTokens) > usage.OutputTokens {
+			usage.OutputTokens = int64(outputTokens)
 		}
 	}
 

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+
+	"github.com/tingly-dev/tingly-box/ai"
 )
 
 // AnthropicStreamAssembler assembles Anthropic streaming responses
@@ -180,7 +182,9 @@ func (a *AnthropicStreamAssembler) handleContentBlockDeltaBeta(blockIndex int, d
 	a.blocks[blockIndex] = block
 }
 
-// SetUsage sets the usage data
+// SetUsage sets the usage data from raw input/output counts.
+// Prefer SetUsageFromTokenUsage when you have an *ai.TokenUsage in hand —
+// it carries cache and reasoning fields the bare counts cannot.
 func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 	a.usageData = &anthropic.Usage{
 		InputTokens:  int64(inputTokens),
@@ -188,12 +192,18 @@ func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 	}
 }
 
-// SetUsageFull sets the usage data including cache tokens.
-func (a *AnthropicStreamAssembler) SetUsageFull(inputTokens, outputTokens, cacheReadTokens int) {
+// SetUsageFromTokenUsage sets the assembled response usage from the canonical
+// ai.TokenUsage type. Cache-read input tokens are mapped to
+// anthropic.Usage.CacheReadInputTokens; reasoning_tokens has no Anthropic
+// analogue (extended-thinking tokens are billed inside output_tokens).
+func (a *AnthropicStreamAssembler) SetUsageFromTokenUsage(u *ai.TokenUsage) {
+	if u == nil {
+		return
+	}
 	a.usageData = &anthropic.Usage{
-		InputTokens:          int64(inputTokens),
-		OutputTokens:         int64(outputTokens),
-		CacheReadInputTokens: int64(cacheReadTokens),
+		InputTokens:          int64(u.InputTokens),
+		OutputTokens:         int64(u.OutputTokens),
+		CacheReadInputTokens: int64(u.CacheInputTokens),
 	}
 }
 

--- a/internal/protocol/assembler/anthropic_assembler_test.go
+++ b/internal/protocol/assembler/anthropic_assembler_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/ai"
 )
 
 func TestNewAnthropicStreamAssembler(t *testing.T) {
@@ -119,9 +121,13 @@ func TestAnthropicStreamAssembler_SetUsage(t *testing.T) {
 	assert.Equal(t, int64(50), assembler.usageData.OutputTokens)
 }
 
-func TestAnthropicStreamAssembler_SetUsageFull_CarriesCacheRead(t *testing.T) {
+func TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesCacheRead(t *testing.T) {
 	assembler := NewAnthropicStreamAssembler()
-	assembler.SetUsageFull(42, 17, 11)
+	assembler.SetUsageFromTokenUsage(&ai.TokenUsage{
+		InputTokens:      42,
+		OutputTokens:     17,
+		CacheInputTokens: 11,
+	})
 	assembler.msgID = "msg_cache"
 	assembler.blocks[0] = anthropic.ContentBlockUnion{Type: "text", Text: "ok"}
 

--- a/internal/protocol/assembler/anthropic_assembler_test.go
+++ b/internal/protocol/assembler/anthropic_assembler_test.go
@@ -119,6 +119,19 @@ func TestAnthropicStreamAssembler_SetUsage(t *testing.T) {
 	assert.Equal(t, int64(50), assembler.usageData.OutputTokens)
 }
 
+func TestAnthropicStreamAssembler_SetUsageFull_CarriesCacheRead(t *testing.T) {
+	assembler := NewAnthropicStreamAssembler()
+	assembler.SetUsageFull(42, 17, 11)
+	assembler.msgID = "msg_cache"
+	assembler.blocks[0] = anthropic.ContentBlockUnion{Type: "text", Text: "ok"}
+
+	result := assembler.Finish("model", 0, 0)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(42), result.Usage.InputTokens)
+	assert.Equal(t, int64(17), result.Usage.OutputTokens)
+	assert.Equal(t, int64(11), result.Usage.CacheReadInputTokens, "cache_read must survive into assembled response")
+}
+
 func TestAnthropicStreamAssembler_Finish_WithUsageFromAssembler(t *testing.T) {
 	assembler := NewAnthropicStreamAssembler()
 

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -290,12 +290,20 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 				},
 			}
 
-			// Add usage if available and not disabled
+			// Add usage if available and not disabled.
+			// Anthropic's message_delta usage carries cache_read / cache_creation
+			// counts; forward cached prompt tokens into OpenAI's
+			// prompt_tokens_details.cached_tokens so downstream consumers see
+			// the full shape. (Anthropic has no reasoning_tokens analogue —
+			// extended-thinking tokens are billed inside output_tokens.)
 			if !disableStreamUsage && usage != nil {
 				chunk.Usage = openai.CompletionUsage{
 					PromptTokens:     usage.InputTokens,
 					CompletionTokens: usage.OutputTokens,
 					TotalTokens:      usage.InputTokens + usage.OutputTokens,
+				}
+				if usage.CacheReadInputTokens > 0 {
+					chunk.Usage.PromptTokensDetails.CachedTokens = usage.CacheReadInputTokens
 				}
 			}
 

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -1,0 +1,116 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicOption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	anthropicvm "github.com/tingly-dev/tingly-box/vmodel/anthropic"
+	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
+)
+
+// TestAnthropicToOpenAIStream_VModelFullUsage wires the vmodel virtualserver
+// (with stream-test mocks registered) as the Anthropic upstream and runs
+// the response through AnthropicToOpenAIStream. Verifies that the upstream
+// message_delta usage — including cache_read_input_tokens — flows into the
+// OpenAI final chunk's prompt_tokens_details.cached_tokens. Without the
+// fix the cache count was dropped on the way through.
+func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	svc := virtualserver.NewService()
+	anthropicvm.RegisterStreamTestMocks(svc.GetAnthropicRegistry())
+
+	engine := gin.New()
+	svc.SetupAnthropicRoutes(engine.Group("/virtual/anthropic"))
+	upstream := httptest.NewServer(engine)
+	defer upstream.Close()
+
+	client := anthropic.NewClient(
+		anthropicOption.WithAPIKey("test-key"),
+		anthropicOption.WithBaseURL(upstream.URL+"/virtual/anthropic/"),
+	)
+
+	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
+		modelID := modelID
+		t.Run(modelID, func(t *testing.T) {
+			stream := client.Beta.Messages.NewStreaming(context.Background(), anthropic.BetaMessageNewParams{
+				Model:     anthropic.Model(modelID),
+				MaxTokens: int64(64),
+				Messages: []anthropic.BetaMessageParam{
+					anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi")),
+				},
+			})
+
+			w := &closeNotifyRecorder{httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", nil)
+
+			input, output, err := AnthropicToOpenAIStream(c, nil, stream, modelID, false)
+			require.NoError(t, err)
+			assert.Equal(t, 42, input, "InputTokens should reflect upstream input_tokens")
+			assert.Equal(t, 17, output, "OutputTokens should reflect upstream output_tokens")
+
+			body := w.Body.String()
+
+			// Find the final OpenAI chunk that carries usage (chunk with
+			// non-zero PromptTokens). That chunk should also expose
+			// cached_tokens via prompt_tokens_details.
+			usageChunk := lastOpenAIChunkUsage(t, body)
+			require.NotNil(t, usageChunk, "anthropic_to_openai stream should attach usage to the final chunk")
+
+			assert.EqualValues(t, 42, jsonNumber(usageChunk, "prompt_tokens"))
+			assert.EqualValues(t, 17, jsonNumber(usageChunk, "completion_tokens"))
+
+			details, _ := usageChunk["prompt_tokens_details"].(map[string]interface{})
+			require.NotNil(t, details, "prompt_tokens_details should be populated when upstream advertises cache_read_input_tokens")
+			assert.EqualValues(t, 11, jsonNumber(details, "cached_tokens"))
+		})
+	}
+}
+
+// lastOpenAIChunkUsage returns the parsed `usage` object from the last SSE
+// chunk in the body whose usage carries non-zero token counts.
+func lastOpenAIChunkUsage(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var last map[string]interface{}
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		u, ok := chunk["usage"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if jsonNumber(u, "prompt_tokens") == 0 && jsonNumber(u, "completion_tokens") == 0 {
+			continue
+		}
+		last = u
+	}
+	return last
+}
+
+func jsonNumber(m map[string]interface{}, key string) float64 {
+	if v, ok := m[key].(float64); ok {
+		return v
+	}
+	return 0
+}

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -487,11 +487,6 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream *openaistream
 		}
 
 		evt := stream.Current()
-
-		if chunkCount < 3 {
-			logrus.WithContext(c.Request.Context()).Debugf("[ChatGPT] SSE chunk #%d: %s", chunkCount+1, evt.RawJSON())
-		}
-
 		chunkCount++
 
 		// Extract content from the response event

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -146,7 +146,6 @@ func handleOpenAIToAnthropicStreamResponse(
 	// usage-only chunk (choices:[], usage:{...}) AFTER the finish_reason chunk.
 	// We must keep draining the stream after seeing finish_reason so the
 	// upstream usage isn't silently dropped.
-	chunkCount := 0
 	pendingFinishReason := ""
 	finishSeen := false
 	StreamLoop(c, func(w io.Writer) bool {
@@ -163,7 +162,6 @@ func handleOpenAIToAnthropicStreamResponse(
 			return false
 		}
 
-		chunkCount++
 		chunk := stream.Current()
 
 		// Skip empty chunks (no choices).
@@ -544,9 +542,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 	senders.SendMessageStart(messageStartEvent, flusher)
 
 	// Process the stream
-	eventCount := 0
 	for stream.Next() {
-		eventCount++
 		currentEvent := stream.Current()
 
 		switch currentEvent.Type {

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -166,11 +166,10 @@ func handleOpenAIToAnthropicStreamResponse(
 		chunkCount++
 		chunk := stream.Current()
 
-		logrus.WithContext(c.Request.Context()).Debugf("[Stream] Got chunk #%d: len(choices)=%d", chunkCount, len(chunk.Choices))
-
-		// Skip empty chunks (no choices)
+		// Skip empty chunks (no choices).
+		// The trailing usage-only chunk (choices:[], usage:{...}) lands here
+		// when stream_options.include_usage=true.
 		if len(chunk.Choices) == 0 {
-			// Token counter will handle usage tracking if present in chunk
 			if tokenCounter != nil {
 				_, _, _ = tokenCounter.ConsumeOpenAIChunk(&chunk)
 				inputTokens, outputTokens := tokenCounter.GetCounts()
@@ -185,20 +184,6 @@ func handleOpenAIToAnthropicStreamResponse(
 		}
 
 		choice := chunk.Choices[0]
-
-		// Check if usage is present - use same logic as stream counter
-		hasValidUsage := chunk.JSON.Usage.Valid()
-		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
-		hasUsage := hasValidUsage || hasNonZeroUsage
-
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
-			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
-
-		// Log first few chunks in detail for debugging
-		if chunkCount <= 5 || choice.FinishReason != "" {
-			logrus.WithContext(c.Request.Context()).Debugf("Full chunk #%d: %v", chunkCount, chunk)
-		}
 
 		delta := choice.Delta
 

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -401,6 +401,13 @@ func handleOpenAIToAnthropicStreamResponse(
 			inputTokens, outputTokens := tokenCounter.GetCounts()
 			state.inputTokens = int64(inputTokens)
 			state.outputTokens = int64(outputTokens)
+			cacheTokens, reasoningTokens := tokenCounter.GetUpstreamDetails()
+			if cacheTokens > 0 {
+				state.cacheTokens = int64(cacheTokens)
+			}
+			if reasoningTokens > 0 {
+				state.reasoningTokens = int64(reasoningTokens)
+			}
 		}
 		ensureMessageStart()
 		sendStopEvents(c, state, flusher)

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -180,9 +180,14 @@ func handleOpenAIToAnthropicStreamResponse(
 
 		choice := chunk.Choices[0]
 
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
+		// Check if usage is present - use same logic as stream counter
+		hasValidUsage := chunk.JSON.Usage.Valid()
+		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
+		hasUsage := hasValidUsage || hasNonZeroUsage
+
+		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
 			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason)
+			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
 
 		// Log first few chunks in detail for debugging
 		if chunkCount <= 5 || choice.FinishReason != "" {

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -584,7 +584,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				"text": textDelta.Delta,
 			}, flusher)
 			lastOutputItemType = "text"
-			logrus.WithContext(c.Request.Context()).Debugf("Processing Responses API event #%d: type=%s", eventCount, textDelta.Delta)
 		case "response.output_text.done", "response.content_part.done":
 			if state.textBlockIndex != -1 {
 				senders.SendContentBlockStop(state, state.textBlockIndex, flusher)
@@ -600,8 +599,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Initializing thinking block at index %d", state.thinkingBlockIndex)
 				senders.SendContentBlockStart(state.thinkingBlockIndex, blockTypeThinking, map[string]interface{}{"thinking": ""}, flusher)
 			}
-			preview := reasoningDelta.Delta
-			logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
 			senders.SendContentBlockDelta(state.thinkingBlockIndex, map[string]interface{}{
 				"type":     deltaTypeThinkingDelta,
 				"thinking": reasoningDelta.Delta,
@@ -677,8 +674,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 					logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Initializing thinking block at index %d", state.thinkingBlockIndex)
 					senders.SendContentBlockStart(state.thinkingBlockIndex, blockTypeThinking, map[string]interface{}{"thinking": ""}, flusher)
 				}
-				preview := reasoningDelta.Delta
-				logrus.WithContext(c.Request.Context()).Debugf("[Thinking][ResponsesAPI] Sending thinking_delta: len=%d, preview=%q", len(reasoningDelta.Delta), preview)
 				senders.SendContentBlockDelta(state.thinkingBlockIndex, map[string]interface{}{
 					"type":     deltaTypeThinkingDelta,
 					"thinking": reasoningDelta.Delta,
@@ -905,26 +900,10 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 				state.reasoningSummaryBlockIndex = -1
 			}
 
-		case "response.audio.delta":
-			audioDelta := currentEvent.AsResponseAudioDelta()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio delta: sequence=%d, len=%d", audioDelta.SequenceNumber, len(audioDelta.Delta))
-
-		case "response.audio.done":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio done")
-
-		case "response.audio.transcript.delta":
-			transcriptDelta := currentEvent.AsResponseAudioTranscriptDelta()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio transcript delta: sequence=%d, len=%d", transcriptDelta.SequenceNumber, len(transcriptDelta.Delta))
-
-		case "response.audio.transcript.done":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Audio transcript done")
-
-		case "response.code_interpreter_call_code.delta":
-			codeDelta := currentEvent.AsResponseCodeInterpreterCallCodeDelta()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Code interpreter code delta: len=%d", len(codeDelta.Delta))
-
-		case "response.code_interpreter_call_code.done":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Code interpreter code done")
+		case "response.audio.delta", "response.audio.done",
+			"response.audio.transcript.delta", "response.audio.transcript.done",
+			"response.code_interpreter_call_code.delta", "response.code_interpreter_call_code.done":
+			// Pass-through events not converted to Anthropic blocks; ignore silently.
 
 		case "response.code_interpreter_call.in_progress":
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Code interpreter in progress")

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -141,8 +141,14 @@ func handleOpenAIToAnthropicStreamResponse(
 		messageStarted = true
 	}
 
-	// Process the stream with context cancellation checking
+	// Process the stream with context cancellation checking.
+	// Note: when stream_options.include_usage=true, OpenAI sends a final
+	// usage-only chunk (choices:[], usage:{...}) AFTER the finish_reason chunk.
+	// We must keep draining the stream after seeing finish_reason so the
+	// upstream usage isn't silently dropped.
 	chunkCount := 0
+	pendingFinishReason := ""
+	finishSeen := false
 	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
@@ -359,14 +365,13 @@ func handleOpenAIToAnthropicStreamResponse(
 			}
 		}
 
-		// Handle finish_reason (last chunk for this choice)
+		// Handle finish_reason (last chunk for this choice).
+		// Keep the loop alive so the trailing usage-only chunk (sent when
+		// stream_options.include_usage=true) is still consumed; the final
+		// Anthropic events are emitted after the loop.
 		if choice.FinishReason != "" {
-			// Get final token counts from counter
-			if tokenCounter != nil {
-				inputTokens, outputTokens := tokenCounter.GetCounts()
-				state.inputTokens = int64(inputTokens)
-				state.outputTokens = int64(outputTokens)
-			}
+			pendingFinishReason = choice.FinishReason
+			finishSeen = true
 			if hooks != nil && hooks.OnToolCallsFinal != nil && len(state.pendingToolCalls) > 0 {
 				toolCalls := make([]OpenAIToAnthropicToolCall, 0, len(state.pendingToolCalls))
 				for _, tc := range state.pendingToolCalls {
@@ -381,19 +386,28 @@ func handleOpenAIToAnthropicStreamResponse(
 					return false
 				}
 			}
-
 			if !messageStarted && errors.Is(hookErr, ErrMCPStreamContinue) {
 				return false
 			}
-			ensureMessageStart()
-			sendStopEvents(c, state, flusher)
-			sendMessageDelta(c, state, mapOpenAIFinishReasonToAnthropic(choice.FinishReason), flusher)
-			sendMessageStop(c, messageID, responseModel, state, mapOpenAIFinishReasonToAnthropic(choice.FinishReason), flusher)
-			return false
 		}
 
 		return true
 	})
+
+	// Emit the terminal Anthropic events using the final tallied usage
+	// (which may have been updated by a post-finish_reason usage chunk).
+	if finishSeen && hookErr == nil {
+		if tokenCounter != nil {
+			inputTokens, outputTokens := tokenCounter.GetCounts()
+			state.inputTokens = int64(inputTokens)
+			state.outputTokens = int64(outputTokens)
+		}
+		ensureMessageStart()
+		sendStopEvents(c, state, flusher)
+		stopReason := mapOpenAIFinishReasonToAnthropic(pendingFinishReason)
+		sendMessageDelta(c, state, stopReason, flusher)
+		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr
 	}

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -663,7 +663,6 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 
 		case "response.output_item.added":
 			itemAdded := currentEvent.AsResponseOutputItemAdded()
-			logrus.WithContext(c.Request.Context()).Debugf("item type: %s", itemAdded.Item.Type)
 			switch itemAdded.Item.Type {
 			case "reasoning":
 				reasoningDelta := currentEvent.AsResponseReasoningTextDelta()
@@ -862,10 +861,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 			return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
 
 		case "response.output_text.annotation.added":
-			annotationAdded := currentEvent.AsResponseOutputTextAnnotationAdded()
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Text annotation added: index=%d, citation_type=%s",
-				annotationAdded.OutputIndex,
-				annotationAdded.Annotation)
+			// Per-annotation event; pass through silently.
 
 		case "response.text.done":
 			// Finalize text content - already handled by content_part.done for output_text type
@@ -918,7 +914,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream *openaistream.Stre
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] File search in progress")
 
 		case "response.file_search_call.searching":
-			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] File search searching: query=%s", currentEvent.RawJSON())
+			// Status event; query payload elided to keep logs small.
 
 		case "response.file_search_call.completed":
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] File search completed")
@@ -1083,9 +1079,6 @@ func HandleResponsesToAnthropicV1Assembly(c *gin.Context, stream *openaistream.S
 			if state.cacheTokens > 0 {
 				msg.Usage.CacheReadInputTokens = state.cacheTokens
 			}
-
-			bs, _ := json.Marshal(msg)
-			logrus.WithContext(c.Request.Context()).Debugf("Assemble response: %s", string(bs))
 
 			// Send result
 			c.JSON(200, msg)

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -414,6 +414,14 @@ func handleOpenAIToAnthropicStreamResponse(
 		stopReason := mapOpenAIFinishReasonToAnthropic(pendingFinishReason)
 		sendMessageDelta(c, state, stopReason, flusher)
 		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"model":            responseModel,
+			"input_tokens":     state.inputTokens,
+			"output_tokens":    state.outputTokens,
+			"cache_tokens":     state.cacheTokens,
+			"reasoning_tokens": state.reasoningTokens,
+			"stop_reason":      stopReason,
+		}).Info("OpenAI->Anthropic stream usage")
 	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -382,6 +382,13 @@ func handleOpenAIToAnthropicBetaStream(
 			inputTokens, outputTokens := tokenCounter.GetCounts()
 			state.inputTokens = int64(inputTokens)
 			state.outputTokens = int64(outputTokens)
+			cacheTokens, reasoningTokens := tokenCounter.GetUpstreamDetails()
+			if cacheTokens > 0 {
+				state.cacheTokens = int64(cacheTokens)
+			}
+			if reasoningTokens > 0 {
+				state.reasoningTokens = int64(reasoningTokens)
+			}
 		}
 		ensureMessageStart()
 		sendStopEvents(c, state, flusher)

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -532,9 +532,6 @@ func HandleResponsesToAnthropicBetaAssembly(c *gin.Context, stream *openaistream
 				msg.Usage.CacheReadInputTokens = state.cacheTokens
 			}
 
-			bs, _ := json.Marshal(msg)
-			logrus.WithContext(c.Request.Context()).Debugf("Assemble response: %s", string(bs))
-
 			// Send result
 			c.JSON(200, msg)
 			flusher.Flush()

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -131,7 +131,6 @@ func handleOpenAIToAnthropicBetaStream(
 	// usage-only chunk (choices:[], usage:{...}) AFTER the finish_reason chunk.
 	// We must keep draining the stream after seeing finish_reason so the
 	// upstream usage isn't silently dropped.
-	chunkCount := 0
 	pendingFinishReason := ""
 	finishSeen := false
 	StreamLoop(c, func(w io.Writer) bool {
@@ -148,7 +147,6 @@ func handleOpenAIToAnthropicBetaStream(
 			return false
 		}
 
-		chunkCount++
 		chunk := stream.Current()
 
 		// Skip empty chunks (no choices)

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -395,6 +395,14 @@ func handleOpenAIToAnthropicBetaStream(
 		stopReason := mapOpenAIFinishReasonToAnthropicBeta(pendingFinishReason)
 		sendMessageDelta(c, state, stopReason, flusher)
 		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"model":            responseModel,
+			"input_tokens":     state.inputTokens,
+			"output_tokens":    state.outputTokens,
+			"cache_tokens":     state.cacheTokens,
+			"reasoning_tokens": state.reasoningTokens,
+			"stop_reason":      stopReason,
+		}).Info("OpenAI->Anthropic beta stream usage")
 	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -126,8 +126,14 @@ func handleOpenAIToAnthropicBetaStream(
 		messageStarted = true
 	}
 
-	// Process the stream with context cancellation checking
+	// Process the stream with context cancellation checking.
+	// Note: when stream_options.include_usage=true, OpenAI sends a final
+	// usage-only chunk (choices:[], usage:{...}) AFTER the finish_reason chunk.
+	// We must keep draining the stream after seeing finish_reason so the
+	// upstream usage isn't silently dropped.
 	chunkCount := 0
+	pendingFinishReason := ""
+	finishSeen := false
 	StreamLoop(c, func(w io.Writer) bool {
 		// Check context cancellation first
 		select {
@@ -340,14 +346,13 @@ func handleOpenAIToAnthropicBetaStream(
 			}
 		}
 
-		// Handle finish_reason (last chunk for this choice)
+		// Handle finish_reason (last chunk for this choice).
+		// Keep the loop alive so the trailing usage-only chunk (sent when
+		// stream_options.include_usage=true) is still consumed; the final
+		// Anthropic events are emitted after the loop.
 		if choice.FinishReason != "" {
-			// Get final token counts from counter
-			if tokenCounter != nil {
-				inputTokens, outputTokens := tokenCounter.GetCounts()
-				state.inputTokens = int64(inputTokens)
-				state.outputTokens = int64(outputTokens)
-			}
+			pendingFinishReason = choice.FinishReason
+			finishSeen = true
 			if hooks != nil && hooks.OnToolCallsFinal != nil && len(state.pendingToolCalls) > 0 {
 				toolCalls := make([]OpenAIToAnthropicToolCall, 0, len(state.pendingToolCalls))
 				for _, tc := range state.pendingToolCalls {
@@ -362,19 +367,28 @@ func handleOpenAIToAnthropicBetaStream(
 					return false
 				}
 			}
-
 			if !messageStarted && errors.Is(hookErr, ErrMCPStreamContinue) {
 				return false
 			}
-			ensureMessageStart()
-			sendStopEvents(c, state, flusher)
-			sendMessageDelta(c, state, mapOpenAIFinishReasonToAnthropicBeta(choice.FinishReason), flusher)
-			sendMessageStop(c, messageID, responseModel, state, mapOpenAIFinishReasonToAnthropicBeta(choice.FinishReason), flusher)
-			return false
 		}
 
 		return true
 	})
+
+	// Emit the terminal Anthropic events using the final tallied usage
+	// (which may have been updated by a post-finish_reason usage chunk).
+	if finishSeen && hookErr == nil {
+		if tokenCounter != nil {
+			inputTokens, outputTokens := tokenCounter.GetCounts()
+			state.inputTokens = int64(inputTokens)
+			state.outputTokens = int64(outputTokens)
+		}
+		ensureMessageStart()
+		sendStopEvents(c, state, flusher)
+		stopReason := mapOpenAIFinishReasonToAnthropicBeta(pendingFinishReason)
+		sendMessageDelta(c, state, stopReason, flusher)
+		sendMessageStop(c, messageID, responseModel, state, stopReason, flusher)
+	}
 	if hookErr != nil {
 		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), hookErr
 	}

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -168,16 +168,6 @@ func handleOpenAIToAnthropicBetaStream(
 		}
 
 		choice := chunk.Choices[0]
-
-		// Check if usage is present - use same logic as stream counter
-		hasValidUsage := chunk.JSON.Usage.Valid()
-		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
-		hasUsage := hasValidUsage || hasNonZeroUsage
-
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
-			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
-
 		delta := choice.Delta
 
 		// Check for server_tool_use at chunk level (not delta level)

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -163,9 +163,14 @@ func handleOpenAIToAnthropicBetaStream(
 
 		choice := chunk.Choices[0]
 
-		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q",
+		// Check if usage is present - use same logic as stream counter
+		hasValidUsage := chunk.JSON.Usage.Valid()
+		hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
+		hasUsage := hasValidUsage || hasNonZeroUsage
+
+		logrus.WithContext(c.Request.Context()).Debugf("Processing chunk #%d: len(choices)=%d, content=%q, finish_reason=%q, has_usage=%v (Valid=%v, NonZero=%v)",
 			chunkCount, len(chunk.Choices),
-			choice.Delta.Content, choice.FinishReason)
+			choice.Delta.Content, choice.FinishReason, hasUsage, hasValidUsage, hasNonZeroUsage)
 
 		delta := choice.Delta
 

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -201,8 +201,6 @@ func handleOpenAIToAnthropicBetaStream(
 					// Extract thinking content (handle different types)
 					thinkingText := extractString(v)
 					if thinkingText != "" {
-						preview := thinkingText
-						logrus.WithContext(c.Request.Context()).Debugf("[Thinking] Sending thinking_delta: len=%d, preview=%q", len(thinkingText), preview)
 						// Send content_block_delta with thinking_delta
 						ensureMessageStart()
 						sendContentBlockDelta(c, state.thinkingBlockIndex, map[string]interface{}{

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -1,0 +1,113 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	openaiOption "github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
+)
+
+// TestOpenAIToAnthropicStream_VModelUsage drives a real OpenAI streaming client
+// against the in-process vmodel virtualserver and runs the response through
+// HandleOpenAIToAnthropicStreamResponse. It exists to lock down the
+// finish_reason/usage-chunk ordering: real OpenAI emits the usage-only chunk
+// AFTER the finish_reason chunk, and the converter must keep draining past
+// finish_reason to capture it.
+func TestOpenAIToAnthropicStream_VModelUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Spin up the vmodel virtualserver as the OpenAI upstream.
+	svc := virtualserver.NewService()
+	engine := gin.New()
+	svc.SetupOpenAIRoutes(engine.Group("/virtual/openai"))
+	upstream := httptest.NewServer(engine)
+	defer upstream.Close()
+
+	client := openai.NewClient(
+		openaiOption.WithAPIKey("test-key"),
+		openaiOption.WithBaseURL(upstream.URL+"/virtual/openai/v1/"),
+	)
+
+	stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+		Model: "virtual-gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Hello, world!"),
+		},
+		StreamOptions: openai.ChatCompletionStreamOptionsParam{
+			IncludeUsage: param.Opt[bool]{Value: true},
+		},
+	})
+
+	w := &closeNotifyRecorder{httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/messages", nil)
+
+	usage, err := HandleOpenAIToAnthropicStreamResponse(c, nil, stream, "virtual-gpt-4")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+
+	body := w.Body.String()
+	t.Logf("Response body:\n%s", body)
+
+	// Locate the message_delta event and inspect its usage block. With the
+	// bug present, output_tokens would still be zero (or only the
+	// incrementally-counted value) because the upstream usage chunk arrives
+	// after finish_reason and gets dropped.
+	events := splitSSEEventsByType(body)
+
+	msgDeltaRaw, ok := events[eventTypeMessageDelta]
+	require.True(t, ok, "should emit message_delta")
+
+	var msgDelta map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(msgDeltaRaw), &msgDelta))
+
+	delta := msgDelta["delta"].(map[string]interface{})
+	assert.Equal(t, "end_turn", delta["stop_reason"], "stop_reason should map from openai 'stop'")
+
+	usageBlock, _ := msgDelta["usage"].(map[string]interface{})
+	require.NotNil(t, usageBlock, "message_delta should carry a usage block")
+
+	// Output tokens come from the upstream usage-only chunk.
+	outTokens, _ := usageBlock["output_tokens"].(float64)
+	assert.Greater(t, outTokens, float64(0), "output_tokens should be populated from trailing usage chunk; if 0, the converter dropped the post-finish_reason usage chunk")
+
+	// And the returned UsageStat should match.
+	assert.Greater(t, usage.InputTokens, 0, "InputTokens should reflect upstream prompt_tokens")
+	assert.Greater(t, usage.OutputTokens, 0, "OutputTokens should reflect upstream completion_tokens")
+
+	// Sanity: standard SSE envelope still in place.
+	assert.Contains(t, body, "event:message_start")
+	assert.Contains(t, body, "event:message_stop")
+}
+
+// splitSSEEventsByType returns a map from event name to the LAST data payload
+// observed for that event in the SSE body. Sufficient for terminal events
+// like message_delta / message_stop, which only fire once.
+func splitSSEEventsByType(body string) map[string]string {
+	out := make(map[string]string)
+	current := ""
+	for _, line := range strings.Split(body, "\n") {
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			current = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			if current != "" {
+				out[current] = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		case line == "":
+			current = ""
+		}
+	}
+	return out
+}

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	openaivm "github.com/tingly-dev/tingly-box/vmodel/openai"
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
 
@@ -89,6 +90,79 @@ func TestOpenAIToAnthropicStream_VModelUsage(t *testing.T) {
 	// Sanity: standard SSE envelope still in place.
 	assert.Contains(t, body, "event:message_start")
 	assert.Contains(t, body, "event:message_stop")
+}
+
+// TestOpenAIToAnthropicStream_VModelFullUsage exercises the full usage
+// shape — prompt, completion, cached input, reasoning — by wiring the
+// stream-test mock (virtual-stream-test) which advertises explicit
+// MockUsage values. Asserts those values flow into the Anthropic
+// message_delta.usage block.
+func TestOpenAIToAnthropicStream_VModelFullUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Custom service so we can opt into the stream-test mocks without
+	// polluting the production defaults set.
+	svc := virtualserver.NewService()
+	openaivm.RegisterStreamTestMocks(svc.GetOpenAIRegistry())
+
+	engine := gin.New()
+	svc.SetupOpenAIRoutes(engine.Group("/virtual/openai"))
+	upstream := httptest.NewServer(engine)
+	defer upstream.Close()
+
+	client := openai.NewClient(
+		openaiOption.WithAPIKey("test-key"),
+		openaiOption.WithBaseURL(upstream.URL+"/virtual/openai/v1/"),
+	)
+
+	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
+		modelID := modelID
+		t.Run(modelID, func(t *testing.T) {
+			stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+				Model: modelID,
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("Hello, world!"),
+				},
+				StreamOptions: openai.ChatCompletionStreamOptionsParam{
+					IncludeUsage: param.Opt[bool]{Value: true},
+				},
+			})
+
+			w := &closeNotifyRecorder{httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/messages", nil)
+
+			usage, err := HandleOpenAIToAnthropicStreamResponse(c, nil, stream, modelID)
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+
+			body := w.Body.String()
+			events := splitSSEEventsByType(body)
+
+			msgDeltaRaw, ok := events[eventTypeMessageDelta]
+			require.True(t, ok, "should emit message_delta")
+
+			var msgDelta map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(msgDeltaRaw), &msgDelta))
+			usageBlock, _ := msgDelta["usage"].(map[string]interface{})
+			require.NotNil(t, usageBlock)
+
+			// MockUsage from StreamTestMockSpecs: prompt=42 completion=17 cached=11 reasoning=9
+			assert.EqualValues(t, 17, usageBlock["output_tokens"], "output_tokens from explicit MockUsage.CompletionTokens")
+			assert.EqualValues(t, 11, usageBlock["cache_read_input_tokens"], "cache_read_input_tokens from prompt_tokens_details.cached_tokens")
+
+			assert.Equal(t, 42, usage.InputTokens)
+			assert.Equal(t, 17, usage.OutputTokens)
+			assert.Equal(t, 11, usage.CacheInputTokens)
+			assert.Equal(t, 9, usage.ReasoningTokens)
+
+			// tool variant should map finish_reason=tool_calls to stop_reason=tool_use
+			if modelID == "virtual-stream-test-tool" {
+				delta := msgDelta["delta"].(map[string]interface{})
+				assert.Equal(t, "tool_use", delta["stop_reason"])
+			}
+		})
+	}
 }
 
 // splitSSEEventsByType returns a map from event name to the LAST data payload

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/sirupsen/logrus"
 	"github.com/tiktoken-go/tokenizer"
 )
 
@@ -76,9 +77,21 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 	defer c.mu.Unlock()
 
 	// Process usage if provided in the chunk (usually only in the final chunk)
-	// Check if Usage is present by checking if the JSON field is valid
-	if chunk.JSON.Usage.Valid() {
+	// Check if Usage is present by checking:
+	// 1. The JSON field is valid (status > invalid)
+	// 2. OR the usage field has non-zero values (SDK bug workaround)
+	// The SDK's Valid() method incorrectly returns false for some valid usage fields
+	hasValidUsage := chunk.JSON.Usage.Valid()
+	hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
+
+	logrus.Debugf("[StreamTokenCounter] Usage check: Valid()=%v, hasNonZeroValues=%v, PromptTokens=%d, CompletionTokens=%d",
+		hasValidUsage, hasNonZeroUsage, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
+
+	if hasValidUsage || hasNonZeroUsage {
 		usage := chunk.Usage
+		logrus.Debugf("[StreamTokenCounter] Chunk contains usage field - PromptTokens=%d, CompletionTokens=%d",
+			usage.PromptTokens, usage.CompletionTokens)
+
 		if usage.PromptTokens > 0 {
 			c.inputTokens = int(usage.PromptTokens)
 		}

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/openai/openai-go/v3"
-	"github.com/sirupsen/logrus"
 	"github.com/tiktoken-go/tokenizer"
 )
 
@@ -78,22 +77,12 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Process usage if provided in the chunk (usually only in the final chunk)
-	// Check if Usage is present by checking:
-	// 1. The JSON field is valid (status > invalid)
-	// 2. OR the usage field has non-zero values (SDK bug workaround)
-	// The SDK's Valid() method incorrectly returns false for some valid usage fields
-	hasValidUsage := chunk.JSON.Usage.Valid()
-	hasNonZeroUsage := chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0
-
-	logrus.Debugf("[StreamTokenCounter] Usage check: Valid()=%v, hasNonZeroValues=%v, PromptTokens=%d, CompletionTokens=%d",
-		hasValidUsage, hasNonZeroUsage, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
-
-	if hasValidUsage || hasNonZeroUsage {
+	// Process usage if provided in the chunk (usually only the trailing
+	// usage-only chunk when stream_options.include_usage=true). The SDK's
+	// Valid() check misses some legitimate cases, so we also accept any
+	// non-zero prompt/completion count as evidence that usage is present.
+	if chunk.JSON.Usage.Valid() || chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
 		usage := chunk.Usage
-		logrus.Debugf("[StreamTokenCounter] Chunk contains usage field - PromptTokens=%d, CompletionTokens=%d",
-			usage.PromptTokens, usage.CompletionTokens)
-
 		if usage.PromptTokens > 0 {
 			c.inputTokens = int(usage.PromptTokens)
 		}

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -27,6 +27,8 @@ type StreamTokenCounter struct {
 	outputTokens         int
 	upstreamInputTokens  int64
 	upstreamOutputTokens int64
+	upstreamCacheTokens  int64 // prompt_tokens_details.cached_tokens
+	upstreamReasoning    int64 // completion_tokens_details.reasoning_tokens
 }
 
 // NewStreamTokenCounter creates a new streaming token counter.
@@ -104,6 +106,12 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 		if chunk.Usage.CompletionTokens > 0 {
 			c.upstreamOutputTokens = chunk.Usage.CompletionTokens
 		}
+		if chunk.Usage.PromptTokensDetails.CachedTokens > 0 {
+			c.upstreamCacheTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+		}
+		if chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
+			c.upstreamReasoning = chunk.Usage.CompletionTokensDetails.ReasoningTokens
+		}
 		return int(c.upstreamInputTokens), int(c.upstreamOutputTokens), nil
 	}
 
@@ -160,6 +168,14 @@ func (c *StreamTokenCounter) GetCounts() (inputTokens, outputTokens int) {
 		o = int(c.upstreamOutputTokens)
 	}
 	return i, o
+}
+
+// GetUpstreamDetails returns cache and reasoning token counts harvested
+// from upstream usage chunks (zero if upstream did not advertise them).
+func (c *StreamTokenCounter) GetUpstreamDetails() (cacheTokens, reasoningTokens int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return int(c.upstreamCacheTokens), int(c.upstreamReasoning)
 }
 
 // SetInputTokens sets the input token count.

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -235,7 +235,7 @@ func (s *Server) streamResponsesToAnthropicBeta(c *gin.Context, proxyModel strin
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 
@@ -288,7 +288,7 @@ func (s *Server) assembleResponsesToAnthropicBeta(c *gin.Context, proxyModel str
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -205,7 +205,7 @@ func (s *Server) streamResponsesToAnthropic(c *gin.Context, proxyModel string, a
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 
@@ -258,7 +258,7 @@ func (s *Server) assembleResponsesToAnthropic(c *gin.Context, proxyModel string,
 
 	// Finish recording and assemble response
 	if streamRec != nil {
-		streamRec.Finish(proxyModel, usage.InputTokens, usage.OutputTokens)
+		streamRec.Finish(proxyModel, usage)
 		streamRec.RecordResponse(provider, actualModel)
 	}
 

--- a/internal/server/openai_mcp.go
+++ b/internal/server/openai_mcp.go
@@ -105,7 +105,7 @@ func (s *Server) streamOpenAIChatToAnthropicBetaWithMCP(
 		}
 		s.trackUsageWithTokenUsage(c, usage, nil)
 		if streamRec != nil {
-			streamRec.Finish(responseModel, usage.InputTokens, usage.OutputTokens)
+			streamRec.Finish(responseModel, usage)
 			streamRec.RecordResponse(provider, actualModel)
 		}
 		return

--- a/internal/server/recording_hooks.go
+++ b/internal/server/recording_hooks.go
@@ -52,21 +52,25 @@ func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage) {
 	if sr == nil {
 		return
 	}
-	inputTokens, outputTokens, cacheReadTokens := 0, 0, 0
+	// Fall back to in-stream usage when the converter didn't return one
+	// (e.g. early errors before message_delta usage was tallied).
+	if usage == nil || (usage.InputTokens == 0 && usage.OutputTokens == 0) {
+		if sr.hasUsage {
+			usage = &protocol.TokenUsage{
+				InputTokens:      sr.inputTokens,
+				OutputTokens:     sr.outputTokens,
+				CacheInputTokens: sr.cacheReadTokens,
+			}
+		}
+	}
+	if usage != nil {
+		sr.assembler.SetUsageFromTokenUsage(usage)
+	}
+	var inputTokens, outputTokens, cacheReadTokens int
 	if usage != nil {
 		inputTokens = usage.InputTokens
 		outputTokens = usage.OutputTokens
 		cacheReadTokens = usage.CacheInputTokens
-	}
-	if inputTokens == 0 && outputTokens == 0 && sr.hasUsage {
-		inputTokens = sr.inputTokens
-		outputTokens = sr.outputTokens
-		if cacheReadTokens == 0 {
-			cacheReadTokens = sr.cacheReadTokens
-		}
-	}
-	if cacheReadTokens > 0 {
-		sr.assembler.SetUsageFull(inputTokens, outputTokens, cacheReadTokens)
 	}
 	assembled := sr.assembler.Finish(model, inputTokens, outputTokens)
 	if assembled != nil {

--- a/internal/server/recording_hooks.go
+++ b/internal/server/recording_hooks.go
@@ -25,11 +25,12 @@ const streamRecorderContextKey = "stream_event_recorder"
 // use AttachRecorderHooks, which relies on the assembler that protocol's
 // HandleContext now owns.
 type streamRecorder struct {
-	recorder     *ProtocolRecorder
-	assembler    *assembler.AnthropicStreamAssembler
-	inputTokens  int
-	outputTokens int
-	hasUsage     bool
+	recorder        *ProtocolRecorder
+	assembler       *assembler.AnthropicStreamAssembler
+	inputTokens     int
+	outputTokens    int
+	cacheReadTokens int
+	hasUsage        bool
 }
 
 func newStreamRecorder(recorder *ProtocolRecorder) *streamRecorder {
@@ -43,13 +44,29 @@ func newStreamRecorder(recorder *ProtocolRecorder) *streamRecorder {
 	}
 }
 
-func (sr *streamRecorder) Finish(model string, inputTokens, outputTokens int) {
+// Finish carries the converter's final TokenUsage into the assembler so the
+// recorded response has the full shape (input/output + cache_read).
+// usage may be nil; in that case any in-stream usage harvested via
+// RecordRawMapEvent is used as a fallback.
+func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage) {
 	if sr == nil {
 		return
+	}
+	inputTokens, outputTokens, cacheReadTokens := 0, 0, 0
+	if usage != nil {
+		inputTokens = usage.InputTokens
+		outputTokens = usage.OutputTokens
+		cacheReadTokens = usage.CacheInputTokens
 	}
 	if inputTokens == 0 && outputTokens == 0 && sr.hasUsage {
 		inputTokens = sr.inputTokens
 		outputTokens = sr.outputTokens
+		if cacheReadTokens == 0 {
+			cacheReadTokens = sr.cacheReadTokens
+		}
+	}
+	if cacheReadTokens > 0 {
+		sr.assembler.SetUsageFull(inputTokens, outputTokens, cacheReadTokens)
 	}
 	assembled := sr.assembler.Finish(model, inputTokens, outputTokens)
 	if assembled != nil {
@@ -59,10 +76,14 @@ func (sr *streamRecorder) Finish(model string, inputTokens, outputTokens int) {
 	if len(sr.recorder.streamChunks) > 0 {
 		fallback := baseMessageMap(model, sr.recorder.startTime)
 		fallback["stop_reason"] = sr.recorder.c.Query("stop_reason")
-		fallback["usage"] = map[string]interface{}{
+		usageMap := map[string]interface{}{
 			"input_tokens":  inputTokens,
 			"output_tokens": outputTokens,
 		}
+		if cacheReadTokens > 0 {
+			usageMap["cache_read_input_tokens"] = cacheReadTokens
+		}
+		fallback["usage"] = usageMap
 		sr.recorder.SetAssembledResponse(fallback)
 		logrus.Debugf("obs: streamRecorder using fallback response, chunks=%d", len(sr.recorder.streamChunks))
 	}
@@ -105,6 +126,9 @@ func (sr *streamRecorder) RecordRawMapEvent(eventType string, event map[string]i
 			}
 			if v, ok := mapInt(usage, "output_tokens"); ok {
 				sr.outputTokens = v
+			}
+			if v, ok := mapInt(usage, "cache_read_input_tokens"); ok {
+				sr.cacheReadTokens = v
 			}
 			sr.hasUsage = true
 		}

--- a/internal/server/recording_hooks.go
+++ b/internal/server/recording_hooks.go
@@ -46,51 +46,43 @@ func newStreamRecorder(recorder *ProtocolRecorder) *streamRecorder {
 
 // Finish carries the converter's final TokenUsage into the assembler so the
 // recorded response has the full shape (input/output + cache_read).
-// usage may be nil; in that case any in-stream usage harvested via
+// When usage is nil or empty, any in-stream usage harvested via
 // RecordRawMapEvent is used as a fallback.
 func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage) {
 	if sr == nil {
 		return
 	}
-	// Fall back to in-stream usage when the converter didn't return one
-	// (e.g. early errors before message_delta usage was tallied).
-	if usage == nil || (usage.InputTokens == 0 && usage.OutputTokens == 0) {
-		if sr.hasUsage {
-			usage = &protocol.TokenUsage{
-				InputTokens:      sr.inputTokens,
-				OutputTokens:     sr.outputTokens,
-				CacheInputTokens: sr.cacheReadTokens,
-			}
+	if (usage == nil || (usage.InputTokens == 0 && usage.OutputTokens == 0)) && sr.hasUsage {
+		usage = &protocol.TokenUsage{
+			InputTokens:      sr.inputTokens,
+			OutputTokens:     sr.outputTokens,
+			CacheInputTokens: sr.cacheReadTokens,
 		}
 	}
-	if usage != nil {
-		sr.assembler.SetUsageFromTokenUsage(usage)
+	if usage == nil {
+		usage = &protocol.TokenUsage{}
 	}
-	var inputTokens, outputTokens, cacheReadTokens int
-	if usage != nil {
-		inputTokens = usage.InputTokens
-		outputTokens = usage.OutputTokens
-		cacheReadTokens = usage.CacheInputTokens
-	}
-	assembled := sr.assembler.Finish(model, inputTokens, outputTokens)
-	if assembled != nil {
+	sr.assembler.SetUsageFromTokenUsage(usage)
+
+	if assembled := sr.assembler.Finish(model, usage.InputTokens, usage.OutputTokens); assembled != nil {
 		sr.recorder.SetAssembledResponse(assembled)
 		return
 	}
-	if len(sr.recorder.streamChunks) > 0 {
-		fallback := baseMessageMap(model, sr.recorder.startTime)
-		fallback["stop_reason"] = sr.recorder.c.Query("stop_reason")
-		usageMap := map[string]interface{}{
-			"input_tokens":  inputTokens,
-			"output_tokens": outputTokens,
-		}
-		if cacheReadTokens > 0 {
-			usageMap["cache_read_input_tokens"] = cacheReadTokens
-		}
-		fallback["usage"] = usageMap
-		sr.recorder.SetAssembledResponse(fallback)
-		logrus.Debugf("obs: streamRecorder using fallback response, chunks=%d", len(sr.recorder.streamChunks))
+	if len(sr.recorder.streamChunks) == 0 {
+		return
 	}
+	fallback := baseMessageMap(model, sr.recorder.startTime)
+	fallback["stop_reason"] = sr.recorder.c.Query("stop_reason")
+	usageMap := map[string]interface{}{
+		"input_tokens":  usage.InputTokens,
+		"output_tokens": usage.OutputTokens,
+	}
+	if usage.CacheInputTokens > 0 {
+		usageMap["cache_read_input_tokens"] = usage.CacheInputTokens
+	}
+	fallback["usage"] = usageMap
+	sr.recorder.SetAssembledResponse(fallback)
+	logrus.Debugf("obs: streamRecorder using fallback response, chunks=%d", len(sr.recorder.streamChunks))
 }
 
 func (sr *streamRecorder) RecordError(err error) {

--- a/internal/server/usage_tracking.go
+++ b/internal/server/usage_tracking.go
@@ -190,18 +190,19 @@ func (s *Server) trackUsageWithTokenUsage(c *gin.Context, usage *protocol.TokenU
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"provider":      provider.Name,
-		"model":         model,
-		"scenario":      scenario,
-		"input_tokens":  usage.InputTokens,
-		"output_tokens": usage.OutputTokens,
-		"cache_tokens":  usage.CacheInputTokens,
-		"system_tokens": usage.SystemTokens,
-		"total_tokens":  usage.TotalTokens(),
-		"status":        status,
-		"streamed":      streamed,
-		"latency_ms":    latencyMs,
-	}).Trace("trackUsageWithTokenUsage: recording token usage")
+		"provider":         provider.Name,
+		"model":            model,
+		"scenario":         scenario,
+		"input_tokens":     usage.InputTokens,
+		"output_tokens":    usage.OutputTokens,
+		"cache_tokens":     usage.CacheInputTokens,
+		"reasoning_tokens": usage.ReasoningTokens,
+		"system_tokens":    usage.SystemTokens,
+		"total_tokens":     usage.TotalTokens(),
+		"status":           status,
+		"streamed":         streamed,
+		"latency_ms":       latencyMs,
+	}).Debug("trackUsage: token usage recorded")
 
 	// Detect cache hit from usage data and set in context
 	cacheHit := detectCacheHit(usage)


### PR DESCRIPTION
## Summary
Usage tokens — especially cached prompt tokens and reasoning tokens — were being dropped in streaming responses due to incomplete handling of the post-finish_reason usage chunk and missing cache token forwarding across protocol boundaries. 

This fix ensures accurate token accounting for cross-protocol streams.

### Major
- **Post-finish_reason usage handling**: When `stream_options.include_usage=true`, OpenAI sends a final usage-only chunk after the finish_reason chunk. The stream loop now continues draining past finish_reason to capture this usage, preventing silent token loss.
- **Cache token preservation**: Cache-read input tokens now flow through Anthropic→OpenAI streams via `prompt_tokens_details.cached_tokens` and are preserved in OpenAI→Anthropic streams via the new `cacheTokens` field.
- **Reasoning token tracking**: Extended-thinking (reasoning) tokens are now counted and logged in OpenAI→Anthropic streams, previously untracked.
- **Canonical usage type**: Introduced `SetUsageFromTokenUsage()` in `AnthropicStreamAssembler` to consume the canonical `ai.TokenUsage` type (which carries cache and reasoning fields) instead of bare input/output counts.

### Minor
- Added vmodel e2e tests for Anthropic→OpenAI and OpenAI→Anthropic streams with full usage shape (cache + reasoning)
- Removed noisy per-chunk debug logging across protocol/stream modules
- Updated usage tracking and recording hooks to handle cache/reasoning tokens
- Streamlined per-event logging in Responses API handlers (grouped pass-through events)