### PR TITLE
Fix Claude Code local proxy bypass for Tingly endpoint

### DIFF
--- a/ai/agent/claude_code.go
+++ b/ai/agent/claude_code.go
@@ -59,6 +59,8 @@ func (p *ClaudeCodeParams) BuildEnv() map[string]string {
 		"API_TIMEOUT_MS":                           "3000000",
 		"ANTHROPIC_BASE_URL":                       p.BaseURL,
 		"ANTHROPIC_AUTH_TOKEN":                     p.APIKey,
+		"NO_PROXY":                                 "localhost,127.0.0.1,::1",
+		"no_proxy":                                 "localhost,127.0.0.1,::1",
 	}
 
 	// Model configuration

--- a/frontend/src/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/components/ClaudeCodeQuickConfig.tsx
@@ -39,9 +39,13 @@ export interface ClaudeCodePrefs {
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC?: string;
     DISABLE_AUTOUPDATER?: string;
     USE_BUILTIN_RIPGREP?: string;
+
+    NO_PROXY?: string;
+    no_proxy?: string;
 }
 
 type PrefsKey = keyof ClaudeCodePrefs;
+type VisiblePrefsKey = Exclude<PrefsKey, 'NO_PROXY' | 'no_proxy'>;
 type Group = 'model' | 'limits' | 'switches';
 type Kind = 'model' | 'int' | 'bool';
 type Lang = 'zh' | 'en';
@@ -51,7 +55,7 @@ type Lang = 'zh' | 'en';
 // FIELDS_TEXT_EN below (TS will flag the missing keys).
 
 interface FieldStruct {
-    envName: PrefsKey;
+    envName: VisiblePrefsKey;
     group: Group;
     kind: Kind;
     unit?: string;
@@ -93,7 +97,7 @@ interface FieldText {
     placeholder?: string;
 }
 
-type FieldTextMap = Record<PrefsKey, FieldText>;
+type FieldTextMap = Record<VisiblePrefsKey, FieldText>;
 
 const FIELDS_TEXT_ZH: FieldTextMap = {
     ANTHROPIC_MODEL: {
@@ -372,6 +376,7 @@ const useLang = (): Lang => {
 // not as a separate prefs field. The UI just toggles the trailing [1m].
 
 const ONE_M_SUFFIX = '[1m]';
+const LOCAL_NO_PROXY = 'localhost,127.0.0.1,::1';
 const has1M = (v: string | undefined) => !!v && v.endsWith(ONE_M_SUFFIX);
 const with1M = (v: string | undefined, on: boolean): string => {
     const base = (v || '').replace(/\[1m\]$/, '');
@@ -411,6 +416,8 @@ export const derivePrefsFromRules = ({ rules, mode }: DerivePrefsInput): ClaudeC
         DISABLE_TELEMETRY: '1',
         DISABLE_ERROR_REPORTING: '1',
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+        NO_PROXY: LOCAL_NO_PROXY,
+        no_proxy: LOCAL_NO_PROXY,
     };
 };
 
@@ -429,7 +436,21 @@ export const prefsToEnvPreview = (
     }
     out.ANTHROPIC_BASE_URL = baseURL.replace(/\/$/, '') + '/tingly/claude_code';
     out.ANTHROPIC_AUTH_TOKEN = token;
+    out.NO_PROXY = appendNoProxyEntries(out.NO_PROXY, LOCAL_NO_PROXY);
+    out.no_proxy = appendNoProxyEntries(out.no_proxy, LOCAL_NO_PROXY);
     return out;
+};
+
+const appendNoProxyEntries = (current: string | undefined, required: string): string => {
+    const parts: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of `${current || ''},${required}`.split(',')) {
+        const part = raw.trim();
+        if (!part || seen.has(part)) continue;
+        seen.add(part);
+        parts.push(part);
+    }
+    return parts.join(',');
 };
 
 // ── Field row (3-column, single line) ──────────────────────────────────

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -42,6 +42,7 @@ type ClaudeCodePrefs struct {
 	HTTPProxy  string `json:"HTTP_PROXY,omitempty"`
 	HTTPSProxy string `json:"HTTPS_PROXY,omitempty"`
 	NoProxy    string `json:"NO_PROXY,omitempty"`
+	NoProxyLC  string `json:"no_proxy,omitempty"`
 
 	// Extra is an escape hatch for env vars not modeled above. Merged in
 	// after marshaling; values here override the typed fields if keys collide.
@@ -65,6 +66,7 @@ func (p ClaudeCodePrefs) ToEnv(baseURL, apiKey string) (map[string]string, error
 	}
 	env["ANTHROPIC_BASE_URL"] = strings.TrimRight(baseURL, "/") + "/tingly/claude_code"
 	env["ANTHROPIC_AUTH_TOKEN"] = apiKey
+	ensureLocalNoProxy(env)
 	return env, nil
 }
 
@@ -78,6 +80,8 @@ func DefaultClaudeCodePrefs(unified bool) ClaudeCodePrefs {
 		DisableTelemetry:                     "1",
 		DisableErrorReporting:                "1",
 		ClaudeCodeDisableNonessentialTraffic: "1",
+		NoProxy:                              localNoProxy,
+		NoProxyLC:                            localNoProxy,
 	}
 	if unified {
 		p.AnthropicModel = "tingly/cc"
@@ -93,4 +97,35 @@ func DefaultClaudeCodePrefs(unified bool) ClaudeCodePrefs {
 		p.ClaudeCodeSubagentModel = "tingly/cc-subagent"
 	}
 	return p
+}
+
+const localNoProxy = "localhost,127.0.0.1,::1"
+
+func ensureLocalNoProxy(env map[string]string) {
+	env["NO_PROXY"] = appendNoProxyEntries(env["NO_PROXY"], localNoProxy)
+	env["no_proxy"] = appendNoProxyEntries(env["no_proxy"], localNoProxy)
+}
+
+func appendNoProxyEntries(current, required string) string {
+	seen := make(map[string]bool)
+	parts := make([]string, 0)
+	for _, part := range strings.Split(current, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if !seen[part] {
+			parts = append(parts, part)
+			seen[part] = true
+		}
+	}
+	for _, part := range strings.Split(required, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" || seen[part] {
+			continue
+		}
+		parts = append(parts, part)
+		seen[part] = true
+	}
+	return strings.Join(parts, ",")
 }

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -36,17 +36,20 @@ func TestClaudeCodePrefs_ToEnv_OmitsEmpty(t *testing.T) {
 }
 
 // Empty prefs must still produce a usable env — the server-injected base
-// URL and auth token are non-negotiable for Claude Code to function at all.
-func TestClaudeCodePrefs_ToEnv_EmptyOnlyInjectsServerKeys(t *testing.T) {
+// URL and auth token are non-negotiable, and localhost must bypass proxies
+// so Claude Code can reach the local tingly-box listener.
+func TestClaudeCodePrefs_ToEnv_EmptyInjectsServerKeysAndNoProxy(t *testing.T) {
 	env, err := ClaudeCodePrefs{}.ToEnv("http://localhost:12580", "tok")
 	if err != nil {
 		t.Fatalf("ToEnv: %v", err)
 	}
-	if len(env) != 2 {
-		t.Errorf("expected exactly 2 server-injected keys, got %d: %v", len(env), env)
+	if len(env) != 4 {
+		t.Errorf("expected exactly 4 server-injected keys, got %d: %v", len(env), env)
 	}
 	mustEq(t, env, "ANTHROPIC_BASE_URL", "http://localhost:12580/tingly/claude_code")
 	mustEq(t, env, "ANTHROPIC_AUTH_TOKEN", "tok")
+	mustEq(t, env, "NO_PROXY", "localhost,127.0.0.1,::1")
+	mustEq(t, env, "no_proxy", "localhost,127.0.0.1,::1")
 }
 
 // A fully-populated prefs should emit every typed env key. Catches future
@@ -73,7 +76,8 @@ func TestClaudeCodePrefs_ToEnv_FullForm(t *testing.T) {
 		UseBuiltinRipgrep:                    "1",
 		HTTPProxy:                            "http://proxy:8080",
 		HTTPSProxy:                           "http://proxy:8443",
-		NoProxy:                              "localhost",
+		NoProxy:                              "internal.local",
+		NoProxyLC:                            "lower.internal",
 	}
 	env, err := p.ToEnv("http://localhost", "tok")
 	if err != nil {
@@ -102,6 +106,7 @@ func TestClaudeCodePrefs_ToEnv_FullForm(t *testing.T) {
 		"HTTP_PROXY",
 		"HTTPS_PROXY",
 		"NO_PROXY",
+		"no_proxy",
 		"ANTHROPIC_BASE_URL",
 		"ANTHROPIC_AUTH_TOKEN",
 	}
@@ -113,6 +118,21 @@ func TestClaudeCodePrefs_ToEnv_FullForm(t *testing.T) {
 	if len(env) != len(wantKeys) {
 		t.Errorf("env has %d keys, want %d. extra: %v", len(env), len(wantKeys), diffKeys(env, wantKeys))
 	}
+	mustEq(t, env, "NO_PROXY", "internal.local,localhost,127.0.0.1,::1")
+	mustEq(t, env, "no_proxy", "lower.internal,localhost,127.0.0.1,::1")
+}
+
+func TestClaudeCodePrefs_ToEnv_NoProxyDeduplicatesLocalEntries(t *testing.T) {
+	p := ClaudeCodePrefs{
+		NoProxy:   "localhost,corp.internal,127.0.0.1",
+		NoProxyLC: "::1,corp.internal",
+	}
+	env, err := p.ToEnv("http://localhost:12580", "tok")
+	if err != nil {
+		t.Fatalf("ToEnv: %v", err)
+	}
+	mustEq(t, env, "NO_PROXY", "localhost,corp.internal,127.0.0.1,::1")
+	mustEq(t, env, "no_proxy", "::1,corp.internal,localhost,127.0.0.1")
 }
 
 func TestClaudeCodePrefs_ToEnv_StripsTrailingSlashOnBaseURL(t *testing.T) {
@@ -272,6 +292,8 @@ func TestDefaultClaudeCodePrefs_Unified(t *testing.T) {
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 		"ANTHROPIC_BASE_URL":                       "http://localhost:12580/tingly/claude_code",
 		"ANTHROPIC_AUTH_TOKEN":                     "test-token",
+		"NO_PROXY":                                 "localhost,127.0.0.1,::1",
+		"no_proxy":                                 "localhost,127.0.0.1,::1",
 	}
 	assertEnvMapsEqual(t, want, env)
 }
@@ -293,6 +315,8 @@ func TestDefaultClaudeCodePrefs_Separate(t *testing.T) {
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 		"ANTHROPIC_BASE_URL":                       "http://localhost:12580/tingly/claude_code",
 		"ANTHROPIC_AUTH_TOKEN":                     "test-token",
+		"NO_PROXY":                                 "localhost,127.0.0.1,::1",
+		"no_proxy":                                 "localhost,127.0.0.1,::1",
 	}
 	assertEnvMapsEqual(t, want, env)
 }

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -354,6 +354,8 @@ func generateCCEnv(baseURL, apiKey, scenarioPath string, unified bool, isProfile
 		"API_TIMEOUT_MS":                           "3000000",
 		"ANTHROPIC_BASE_URL":                       baseURL + "/tingly/" + scenarioPath,
 		"ANTHROPIC_AUTH_TOKEN":                     apiKey,
+		"NO_PROXY":                                 "localhost,127.0.0.1,::1",
+		"no_proxy":                                 "localhost,127.0.0.1,::1",
 	}
 
 	if unified {


### PR DESCRIPTION
## Summary

- add `NO_PROXY` / `no_proxy` defaults for Claude Code config generation
- ensure local Tingly endpoints (`localhost`, `127.0.0.1`, `::1`) bypass system HTTP proxies
- keep frontend Claude Code config preview aligned with backend env materialization
- cover no-proxy merging and default env behavior in tests

## Why

When `HTTP_PROXY` / `HTTPS_PROXY` are set globally, Claude Code can route `localhost:12580` requests through the proxy unless `NO_PROXY` is configured. In that state, requests never reach Tingly, so Tingly has no logs and Claude Code appears unable to connect to the model.

## Validation

- `GOCACHE=/private/tmp/tingly-go-cache go test ./internal/agent ./internal/command ./ai/agent ./internal/tbclient`
- `cd frontend && npx oxlint src/components/ClaudeCodeQuickConfig.tsx`

Note: `npm run typecheck` still fails on pre-existing unrelated repository type errors.