### PR TITLE
fix(client): drop clear_thinking context edit when thinking is disabled

### DIFF
--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -140,9 +140,13 @@ func (c *ClaudeClient) ProbeModelsEndpoint(ctx context.Context) ProbeResult {
 }
 
 func (c *ClaudeClient) Guard(ctx context.Context, req *anthropic.MessageNewParams) (*AnthropicClient, map[string]string) {
-	// Apply thinking transformation for Claude Code OAuth
-	if req.Thinking.OfEnabled == nil && req.Thinking.OfAdaptive == nil && req.Thinking.OfDisabled == nil {
-		// Clear thinking field
+	// Apply thinking transformation for Claude Code OAuth. Thinking can be expressed
+	// either through the thinking union (enabled/adaptive/disabled) or through
+	// output_config.effort (the effort-based adaptive thinking used by newer models).
+	// Only default to disabled when the client specified neither, otherwise we would
+	// silently turn off effort-based thinking the client explicitly requested.
+	thinkingSet := req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || req.Thinking.OfDisabled != nil
+	if !thinkingSet && req.OutputConfig.Effort == "" {
 		req.Thinking = anthropic.ThinkingConfigParamUnion{OfDisabled: &anthropic.ThinkingConfigDisabledParam{}}
 	}
 
@@ -171,17 +175,25 @@ func (c *ClaudeClient) Guard(ctx context.Context, req *anthropic.MessageNewParam
 }
 
 func (c *ClaudeClient) GuardBeta(ctx context.Context, req *anthropic.BetaMessageNewParams) (*AnthropicClient, map[string]string) {
-	// Apply thinking transformation for Claude Code OAuth
-	if req.Thinking.OfEnabled == nil && req.Thinking.OfAdaptive == nil && req.Thinking.OfDisabled == nil {
-		// Clear thinking field
+	// Apply thinking transformation for Claude Code OAuth. Thinking can be expressed
+	// either through the thinking union (enabled/adaptive/disabled) or through
+	// output_config.effort (the effort-based adaptive thinking used by newer models).
+	// Only default to disabled when the client specified neither, otherwise we would
+	// silently turn off effort-based thinking the client explicitly requested.
+	effortSet := req.OutputConfig.Effort != ""
+	thinkingSet := req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || req.Thinking.OfDisabled != nil
+	if !thinkingSet && !effortSet {
 		req.Thinking = anthropic.BetaThinkingConfigParamUnion{OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{}}
 	}
 
-	// When thinking is disabled, drop any clear_thinking_20251015 context-management
-	// edit. Anthropic rejects that edit unless thinking is enabled or adaptive
-	// ("clear_thinking_20251015 requires `thinking` to be enabled or adaptive"), and
-	// newer Claude Code clients send it alongside requests where we force thinking off.
-	if req.Thinking.OfDisabled != nil {
+	// clear_thinking_20251015 is only valid when thinking is enabled or adaptive;
+	// effort-based thinking counts as adaptive. An explicit disabled config wins even
+	// if effort is also present. Drop the edit otherwise, since Anthropic rejects it
+	// with "clear_thinking_20251015 requires `thinking` to be enabled or adaptive" —
+	// which is what newer Claude Code clients hit when we force thinking off.
+	thinkingActive := req.Thinking.OfDisabled == nil &&
+		(req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || effortSet)
+	if !thinkingActive {
 		stripBetaClearThinkingEdit(req)
 	}
 

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -177,6 +177,14 @@ func (c *ClaudeClient) GuardBeta(ctx context.Context, req *anthropic.BetaMessage
 		req.Thinking = anthropic.BetaThinkingConfigParamUnion{OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{}}
 	}
 
+	// When thinking is disabled, drop any clear_thinking_20251015 context-management
+	// edit. Anthropic rejects that edit unless thinking is enabled or adaptive
+	// ("clear_thinking_20251015 requires `thinking` to be enabled or adaptive"), and
+	// newer Claude Code clients send it alongside requests where we force thinking off.
+	if req.Thinking.OfDisabled != nil {
+		stripBetaClearThinkingEdit(req)
+	}
+
 	// Remap tool names to Claude Code TitleCase equivalents to avoid Anthropic fingerprinting
 	reverseMap := remapBetaToolNames(req.Tools)
 
@@ -337,6 +345,26 @@ func (c *ClaudeClient) ProbeStream(ctx context.Context, model, message string, t
 
 	chunksJSON, _ := json.Marshal(chunks)
 	return ToProbeResult(string(chunksJSON), time.Since(startTime).Milliseconds(), c.AnthropicClient.provider.APIBase+"/v1/messages", true), nil
+}
+
+// stripBetaClearThinkingEdit removes any clear_thinking_20251015 context-management
+// edit from the request. The Anthropic API rejects this edit type when thinking is not
+// enabled or adaptive, so it must be dropped whenever thinking is disabled — otherwise
+// Claude Code OAuth traffic that ships the edit (while we force thinking off) fails with
+// "clear_thinking_20251015 requires `thinking` to be enabled or adaptive".
+func stripBetaClearThinkingEdit(req *anthropic.BetaMessageNewParams) {
+	edits := req.ContextManagement.Edits
+	if len(edits) == 0 {
+		return
+	}
+	filtered := make([]anthropic.BetaContextManagementConfigEditUnionParam, 0, len(edits))
+	for _, edit := range edits {
+		if edit.OfClearThinking20251015 != nil {
+			continue
+		}
+		filtered = append(filtered, edit)
+	}
+	req.ContextManagement.Edits = filtered
 }
 
 // remapToolNames renames OfTool tools in-place using oauthToolRenameMap.

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -319,6 +319,58 @@ func TestGuardBeta_PreservesExistingThinking(t *testing.T) {
 	assert.NotNil(t, base)
 }
 
+func TestGuardBeta_StripsClearThinkingEditWhenThinkingDisabled(t *testing.T) {
+	provider := newOAuthProvider()
+	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	require.NoError(t, err)
+
+	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
+	req := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model("claude-sonnet-4-6"),
+		MaxTokens: 512,
+		Messages:  []anthropic.BetaMessageParam{anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi"))},
+	}
+	req.Metadata.UserID = param.NewOpt(userID)
+	// Thinking unset → GuardBeta forces it disabled. The clear_thinking edit must be dropped
+	// to avoid "clear_thinking_20251015 requires `thinking` to be enabled or adaptive".
+	req.ContextManagement.Edits = []anthropic.BetaContextManagementConfigEditUnionParam{
+		{OfClearToolUses20250919: &anthropic.BetaClearToolUses20250919EditParam{}},
+		{OfClearThinking20251015: &anthropic.BetaClearThinking20251015EditParam{}},
+	}
+
+	base, _ := c.GuardBeta(context.Background(), req)
+	assert.NotNil(t, req.Thinking.OfDisabled)
+	require.Len(t, req.ContextManagement.Edits, 1, "clear_thinking edit should be removed")
+	assert.NotNil(t, req.ContextManagement.Edits[0].OfClearToolUses20250919, "other edits must be preserved")
+	assert.NotNil(t, base)
+}
+
+func TestGuardBeta_KeepsClearThinkingEditWhenThinkingEnabled(t *testing.T) {
+	provider := newOAuthProvider()
+	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	require.NoError(t, err)
+
+	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
+	req := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model("claude-sonnet-4-6"),
+		MaxTokens: 512,
+		Messages:  []anthropic.BetaMessageParam{anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi"))},
+	}
+	req.Metadata.UserID = param.NewOpt(userID)
+	req.Thinking = anthropic.BetaThinkingConfigParamUnion{
+		OfEnabled: &anthropic.BetaThinkingConfigEnabledParam{BudgetTokens: 500},
+	}
+	req.ContextManagement.Edits = []anthropic.BetaContextManagementConfigEditUnionParam{
+		{OfClearThinking20251015: &anthropic.BetaClearThinking20251015EditParam{}},
+	}
+
+	base, _ := c.GuardBeta(context.Background(), req)
+	assert.NotNil(t, req.Thinking.OfEnabled)
+	require.Len(t, req.ContextManagement.Edits, 1, "clear_thinking edit must be kept when thinking is enabled")
+	assert.NotNil(t, req.ContextManagement.Edits[0].OfClearThinking20251015)
+	assert.NotNil(t, base)
+}
+
 // ===================================================================
 // Guard — tool remapping
 // ===================================================================

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -371,6 +371,75 @@ func TestGuardBeta_KeepsClearThinkingEditWhenThinkingEnabled(t *testing.T) {
 	assert.NotNil(t, base)
 }
 
+func TestGuardBeta_KeepsClearThinkingEditWhenEffortSet(t *testing.T) {
+	provider := newOAuthProvider()
+	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	require.NoError(t, err)
+
+	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
+	req := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model("claude-opus-4-7"),
+		MaxTokens: 512,
+		Messages:  []anthropic.BetaMessageParam{anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi"))},
+	}
+	req.Metadata.UserID = param.NewOpt(userID)
+	// Effort-based adaptive thinking, no thinking union (newer models). GuardBeta must
+	// not force-disable thinking nor strip the clear_thinking edit.
+	req.OutputConfig.Effort = anthropic.BetaOutputConfigEffortMedium
+	req.ContextManagement.Edits = []anthropic.BetaContextManagementConfigEditUnionParam{
+		{OfClearThinking20251015: &anthropic.BetaClearThinking20251015EditParam{}},
+	}
+
+	base, _ := c.GuardBeta(context.Background(), req)
+	assert.Nil(t, req.Thinking.OfDisabled, "effort-based thinking must not be force-disabled")
+	require.Len(t, req.ContextManagement.Edits, 1, "clear_thinking edit must be kept when effort is set")
+	assert.NotNil(t, req.ContextManagement.Edits[0].OfClearThinking20251015)
+	assert.NotNil(t, base)
+}
+
+func TestGuardBeta_StripsClearThinkingWhenDisabledOverridesEffort(t *testing.T) {
+	provider := newOAuthProvider()
+	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	require.NoError(t, err)
+
+	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
+	req := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model("claude-opus-4-7"),
+		MaxTokens: 512,
+		Messages:  []anthropic.BetaMessageParam{anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi"))},
+	}
+	req.Metadata.UserID = param.NewOpt(userID)
+	// Contradictory input: explicit disabled wins, so the edit must still be dropped.
+	req.OutputConfig.Effort = anthropic.BetaOutputConfigEffortMedium
+	req.Thinking = anthropic.BetaThinkingConfigParamUnion{OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{}}
+	req.ContextManagement.Edits = []anthropic.BetaContextManagementConfigEditUnionParam{
+		{OfClearThinking20251015: &anthropic.BetaClearThinking20251015EditParam{}},
+	}
+
+	base, _ := c.GuardBeta(context.Background(), req)
+	require.Empty(t, req.ContextManagement.Edits, "explicit disabled must drop clear_thinking even when effort is set")
+	assert.NotNil(t, base)
+}
+
+func TestGuard_DoesNotDisableThinkingWhenEffortSet(t *testing.T) {
+	provider := newOAuthProvider()
+	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	require.NoError(t, err)
+
+	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
+	req := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-opus-4-7"),
+		MaxTokens: 512,
+		Messages:  []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock("hi"))},
+	}
+	req.Metadata.UserID = param.NewOpt(userID)
+	req.OutputConfig.Effort = anthropic.OutputConfigEffortMedium
+
+	base, _ := c.Guard(context.Background(), req)
+	assert.Nil(t, req.Thinking.OfDisabled, "effort-based thinking must not be force-disabled")
+	assert.NotNil(t, base)
+}
+
 // ===================================================================
 // Guard — tool remapping
 // ===================================================================


### PR DESCRIPTION
## Problem

Multiple users reported that connecting Claude Code OAuth fails with:

> `clear_thinking_20251015 requires `thinking` to be enabled or adaptive`

## Root cause

`clear_thinking_20251015` is not a beta flag — it's an Anthropic **context-management edit type** (peer of `clear_tool_uses_20250919`), carried in the request body's `context_management.edits` array. Newer Claude Code clients ship this edit.

Claude Code OAuth traffic flows through `ClientPool` → `NewClaudeClient` → `ClaudeClient.GuardBeta`. `GuardBeta` force-disables thinking whenever the client did not explicitly set a thinking config:

```go
if req.Thinking.OfEnabled == nil && req.Thinking.OfAdaptive == nil && req.Thinking.OfDisabled == nil {
    req.Thinking = ...OfDisabled...
}
```

So when a request omits an explicit thinking config but carries a `clear_thinking_20251015` edit, we disable thinking and forward it to Anthropic, which rejects the now-inconsistent request.

## Fix

In `GuardBeta`, when the resolved thinking config is disabled, strip any `clear_thinking_20251015` edit from `context_management.edits` so the request stays internally consistent. The edit is preserved when thinking remains enabled/adaptive, so context management still works in those cases.

## Tests

- `TestGuardBeta_StripsClearThinkingEditWhenThinkingDisabled` — edit removed, other edits preserved.
- `TestGuardBeta_KeepsClearThinkingEditWhenThinkingEnabled` — edit kept when thinking enabled.

Both pass, as do the existing GuardBeta/thinking tests.

https://claude.ai/code/session_019Fb54hhEWxpEdmC7kvm6Vf

---
_Generated by [Claude Code](https://claude.ai/code/session_019Fb54hhEWxpEdmC7kvm6Vf)_