### PR TITLE
feat(UI, dashboard): Add request-level usage records view to dashboard

### DIFF
--- a/frontend/src/components/dashboard/RequestScatterChart.tsx
+++ b/frontend/src/components/dashboard/RequestScatterChart.tsx
@@ -1,0 +1,331 @@
+import { useState } from 'react';
+import {
+    Box,
+    Typography,
+    ToggleButtonGroup,
+    ToggleButton,
+    CircularProgress,
+    useTheme,
+} from '@mui/material';
+import {
+    ScatterChart,
+    Scatter,
+    XAxis,
+    YAxis,
+    ZAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+} from 'recharts';
+import { ChartWrapper, LegendItem } from './TokenHistoryChart/components';
+import { getThemeChartStyles } from './chartStyles';
+
+export interface UsageRecord {
+    id: number;
+    provider_uuid: string;
+    provider_name: string;
+    model: string;
+    scenario: string;
+    rule_uuid?: string;
+    user_id?: string;
+    request_model?: string;
+    timestamp: string;
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    cache_input_tokens: number;
+    status: string;
+    error_code?: string;
+    latency_ms: number;
+    streamed: boolean;
+}
+
+type YMetric = 'tokens' | 'latency';
+
+interface ScatterPoint {
+    x: number;
+    y: number;
+    time: string;
+    model: string;
+    provider: string;
+    status: string;
+    error_code?: string;
+    input_tokens: number;
+    output_tokens: number;
+    cache_input_tokens: number;
+    total_tokens: number;
+    latency_ms: number;
+    streamed: boolean;
+}
+
+interface RequestScatterChartProps {
+    records: UsageRecord[];
+    loading: boolean;
+}
+
+const SUCCESS_COLOR = '#10B981';
+const ERROR_COLOR = '#EF4444';
+
+const formatXTick = (ms: number) =>
+    new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+const formatYTokens = (n: number) => {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+    return n.toString();
+};
+
+const formatYLatency = (ms: number) => {
+    if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${ms}ms`;
+};
+
+function TooltipRow({ label, value, color }: { label: string; value: string; color?: string }) {
+    return (
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
+            <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>{label}:</Typography>
+            <Typography sx={{ fontSize: '0.7rem', fontWeight: 600, color: color ?? 'text.primary' }}>
+                {value}
+            </Typography>
+        </Box>
+    );
+}
+
+function ScatterTooltip({ active, payload }: any) {
+    const theme = useTheme();
+    if (!active || !payload?.length) return null;
+    const d: ScatterPoint = payload[0].payload;
+    const total = d.total_tokens || d.input_tokens + d.output_tokens + d.cache_input_tokens;
+
+    return (
+        <Box
+            sx={{
+                backgroundColor: 'background.paper',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 2,
+                p: 1.75,
+                minWidth: 210,
+                boxShadow: theme.shadows[4],
+            }}
+        >
+            <Typography sx={{ fontWeight: 600, fontSize: '0.8rem', mb: 0.25 }}>{d.time}</Typography>
+            <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled', mb: 0.75 }}>{d.provider}</Typography>
+            <Typography
+                sx={{
+                    fontSize: '0.78rem',
+                    fontWeight: 500,
+                    mb: 1,
+                    maxWidth: 220,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                {d.model}
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.3 }}>
+                <TooltipRow label="Total Tokens" value={total.toLocaleString()} />
+                <TooltipRow label="Input" value={d.input_tokens.toLocaleString()} />
+                <TooltipRow label="Output" value={d.output_tokens.toLocaleString()} />
+                {d.cache_input_tokens > 0 && (
+                    <TooltipRow label="Cache" value={d.cache_input_tokens.toLocaleString()} />
+                )}
+                <TooltipRow
+                    label="Latency"
+                    value={d.latency_ms > 0 ? `${d.latency_ms}ms` : '-'}
+                />
+                <TooltipRow
+                    label="Status"
+                    value={d.status}
+                    color={d.status === 'success' ? SUCCESS_COLOR : ERROR_COLOR}
+                />
+                {d.error_code && (
+                    <TooltipRow label="Error" value={d.error_code} color={ERROR_COLOR} />
+                )}
+                {d.streamed && <TooltipRow label="Streamed" value="yes" />}
+            </Box>
+        </Box>
+    );
+}
+
+export default function RequestScatterChart({ records, loading }: RequestScatterChartProps) {
+    const theme = useTheme();
+    const chartStyles = getThemeChartStyles(theme);
+    const [yMetric, setYMetric] = useState<YMetric>('tokens');
+    const [showSuccess, setShowSuccess] = useState(true);
+    const [showError, setShowError] = useState(true);
+
+    const toPoint = (r: UsageRecord): ScatterPoint => ({
+        x: new Date(r.timestamp).getTime(),
+        y:
+            yMetric === 'tokens'
+                ? r.total_tokens || r.input_tokens + r.output_tokens + r.cache_input_tokens
+                : r.latency_ms,
+        time: new Date(r.timestamp).toLocaleTimeString([], {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        }),
+        model: r.model || '-',
+        provider: r.provider_name || '-',
+        status: r.status,
+        error_code: r.error_code,
+        input_tokens: r.input_tokens,
+        output_tokens: r.output_tokens,
+        cache_input_tokens: r.cache_input_tokens,
+        total_tokens: r.total_tokens,
+        latency_ms: r.latency_ms,
+        streamed: r.streamed,
+    });
+
+    const successCount = records.filter((r) => r.status === 'success').length;
+    const errorCount = records.filter((r) => r.status !== 'success').length;
+
+    const successPoints = showSuccess
+        ? records.filter((r) => r.status === 'success').map(toPoint)
+        : [];
+    const errorPoints = showError
+        ? records.filter((r) => r.status !== 'success').map(toPoint)
+        : [];
+
+    const hasData = records.length > 0;
+    const showChart = hasData || loading;
+
+    return (
+        <ChartWrapper title="Requests Over Time" hasData={showChart}>
+            {showChart ? (
+                <>
+                    {/* Controls */}
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            mb: 2,
+                            flexWrap: 'wrap',
+                            gap: 1,
+                        }}
+                    >
+                        {/* Legend toggles */}
+                        <Box sx={{ display: 'flex', gap: 0.5 }}>
+                            <LegendItem
+                                label={`Success (${successCount})`}
+                                color={SUCCESS_COLOR}
+                                visible={showSuccess}
+                                onToggle={() => setShowSuccess((v) => !v)}
+                            />
+                            <LegendItem
+                                label={`Error (${errorCount})`}
+                                color={ERROR_COLOR}
+                                visible={showError}
+                                onToggle={() => setShowError((v) => !v)}
+                            />
+                        </Box>
+
+                        {/* Y-axis metric toggle */}
+                        <ToggleButtonGroup
+                            value={yMetric}
+                            exclusive
+                            onChange={(_, v) => v && setYMetric(v)}
+                            size="small"
+                            sx={{
+                                '& .MuiToggleButton-root': {
+                                    px: 1.25,
+                                    py: 0.25,
+                                    fontSize: '0.72rem',
+                                    textTransform: 'none',
+                                },
+                            }}
+                        >
+                            <ToggleButton value="tokens">Tokens</ToggleButton>
+                            <ToggleButton value="latency">Latency</ToggleButton>
+                        </ToggleButtonGroup>
+                    </Box>
+
+                    {/* Chart area */}
+                    <Box sx={{ position: 'relative' }}>
+                        {loading && (
+                            <Box
+                                sx={{
+                                    position: 'absolute',
+                                    inset: 0,
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    zIndex: 1,
+                                    backgroundColor:
+                                        theme.palette.mode === 'dark'
+                                            ? 'rgba(0,0,0,0.35)'
+                                            : 'rgba(255,255,255,0.65)',
+                                }}
+                            >
+                                <CircularProgress size={28} />
+                            </Box>
+                        )}
+                        <ResponsiveContainer width="100%" height={280}>
+                            <ScatterChart margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+                                <CartesianGrid
+                                    strokeDasharray="3 3"
+                                    stroke={chartStyles.chart.grid}
+                                    strokeOpacity={0.6}
+                                    vertical={false}
+                                />
+                                <XAxis
+                                    dataKey="x"
+                                    type="number"
+                                    domain={['auto', 'auto']}
+                                    tickFormatter={formatXTick}
+                                    scale="time"
+                                    tick={{
+                                        fontSize: 11,
+                                        fill: theme.palette.text.secondary,
+                                        fontWeight: 500,
+                                    }}
+                                    tickLine={false}
+                                    axisLine={{ stroke: chartStyles.chart.axis, strokeWidth: 1.5 }}
+                                    height={36}
+                                />
+                                <YAxis
+                                    dataKey="y"
+                                    type="number"
+                                    tickFormatter={yMetric === 'tokens' ? formatYTokens : formatYLatency}
+                                    tick={{
+                                        fontSize: 11,
+                                        fill: theme.palette.text.secondary,
+                                        fontWeight: 500,
+                                    }}
+                                    tickLine={false}
+                                    axisLine={{ stroke: chartStyles.chart.axis, strokeWidth: 1.5 }}
+                                    width={56}
+                                />
+                                <ZAxis range={[30, 30]} />
+                                <Tooltip
+                                    content={<ScatterTooltip />}
+                                    cursor={{
+                                        strokeDasharray: '3 3',
+                                        stroke: chartStyles.chart.grid,
+                                    }}
+                                />
+                                <Scatter
+                                    name="Success"
+                                    data={successPoints}
+                                    fill={SUCCESS_COLOR}
+                                    fillOpacity={0.65}
+                                    isAnimationActive={false}
+                                />
+                                <Scatter
+                                    name="Error"
+                                    data={errorPoints}
+                                    fill={ERROR_COLOR}
+                                    fillOpacity={0.8}
+                                    isAnimationActive={false}
+                                />
+                            </ScatterChart>
+                        </ResponsiveContainer>
+                    </Box>
+                </>
+            ) : null}
+        </ChartWrapper>
+    );
+}

--- a/frontend/src/components/dashboard/RequestsTable.tsx
+++ b/frontend/src/components/dashboard/RequestsTable.tsx
@@ -1,0 +1,354 @@
+import {
+    Paper,
+    Typography,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TablePagination,
+    Box,
+    Chip,
+    Tooltip,
+    ToggleButtonGroup,
+    ToggleButton,
+    CircularProgress,
+    useTheme,
+} from '@mui/material';
+import { tablerMui } from '@/components/icons';
+import { IconWaveSine } from '@tabler/icons-react';
+
+const StreamIcon = tablerMui(IconWaveSine);
+
+export interface UsageRecord {
+    id: number;
+    provider_uuid: string;
+    provider_name: string;
+    model: string;
+    scenario: string;
+    rule_uuid?: string;
+    user_id?: string;
+    request_model?: string;
+    timestamp: string;
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    cache_input_tokens: number;
+    status: string;
+    error_code?: string;
+    latency_ms: number;
+    streamed: boolean;
+}
+
+interface RequestsTableProps {
+    records: UsageRecord[];
+    total: number;
+    page: number;
+    rowsPerPage: number;
+    statusFilter: 'all' | 'success' | 'error';
+    loading: boolean;
+    onPageChange: (page: number) => void;
+    onRowsPerPageChange: (rowsPerPage: number) => void;
+    onStatusFilterChange: (status: 'all' | 'success' | 'error') => void;
+}
+
+export default function RequestsTable({
+    records,
+    total,
+    page,
+    rowsPerPage,
+    statusFilter,
+    loading,
+    onPageChange,
+    onRowsPerPageChange,
+    onStatusFilterChange,
+}: RequestsTableProps) {
+    const theme = useTheme();
+
+    const formatTime = (timestamp: string): string => {
+        const date = new Date(timestamp);
+        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    };
+
+    const formatTokens = (num: number): string => {
+        if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
+        if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+        return num.toString();
+    };
+
+    const getLatencyColor = (ms: number): string => {
+        if (ms > 2000) return theme.palette.error.main;
+        if (ms > 1000) return theme.palette.warning.main;
+        return theme.palette.success.main;
+    };
+
+    return (
+        <Paper
+            elevation={0}
+            sx={{
+                borderRadius: 2,
+                border: '1px solid',
+                borderColor: 'divider',
+                overflow: 'hidden',
+                backgroundColor: 'background.paper',
+                boxShadow: 'none',
+                width: '100%',
+            }}
+        >
+            {/* Header */}
+            <Box
+                sx={{
+                    px: 2.5,
+                    py: 1.5,
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 2,
+                    flexWrap: 'wrap',
+                }}
+            >
+                <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
+                    Requests
+                    {!loading && (
+                        <Typography component="span" variant="caption" sx={{ ml: 1, color: 'text.secondary' }}>
+                            {total.toLocaleString()} total
+                        </Typography>
+                    )}
+                </Typography>
+                <ToggleButtonGroup
+                    value={statusFilter}
+                    exclusive
+                    onChange={(_, v) => v && onStatusFilterChange(v)}
+                    size="small"
+                    sx={{
+                        '& .MuiToggleButton-root': {
+                            px: 1.5,
+                            py: 0.375,
+                            fontSize: '0.75rem',
+                            textTransform: 'none',
+                            lineHeight: 1.4,
+                        },
+                    }}
+                >
+                    <ToggleButton value="all">All</ToggleButton>
+                    <ToggleButton value="success">Success</ToggleButton>
+                    <ToggleButton value="error">Error</ToggleButton>
+                </ToggleButtonGroup>
+            </Box>
+
+            {/* Table */}
+            <TableContainer sx={{ maxHeight: 420, position: 'relative' }}>
+                {loading && (
+                    <Box
+                        sx={{
+                            position: 'absolute',
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.6)',
+                            zIndex: 1,
+                        }}
+                    >
+                        <CircularProgress size={28} />
+                    </Box>
+                )}
+                <Table stickyHeader size="small">
+                    <TableHead>
+                        <TableRow
+                            sx={{
+                                '& .MuiTableCell-root': {
+                                    fontWeight: 600,
+                                    fontSize: '0.7rem',
+                                    textTransform: 'uppercase',
+                                    letterSpacing: '0.05em',
+                                    color: 'text.secondary',
+                                    py: 1,
+                                    borderBottom: '1px solid',
+                                    borderColor: 'divider',
+                                    whiteSpace: 'nowrap',
+                                    backgroundColor: 'background.paper',
+                                },
+                            }}
+                        >
+                            <TableCell>Time</TableCell>
+                            <TableCell>Provider / Model</TableCell>
+                            <TableCell>Scenario</TableCell>
+                            <TableCell align="right">Input</TableCell>
+                            <TableCell align="right">Output</TableCell>
+                            <TableCell align="right">Cache</TableCell>
+                            <TableCell align="right">Latency</TableCell>
+                            <TableCell align="center">Status</TableCell>
+                            <TableCell align="center">Stream</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {records.length === 0 && !loading ? (
+                            <TableRow>
+                                <TableCell colSpan={9} align="center" sx={{ py: 6 }}>
+                                    <Typography variant="body2" color="text.secondary">
+                                        No requests found
+                                    </Typography>
+                                    <Typography variant="caption" color="text.disabled">
+                                        Try changing the status filter or time range
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            records.map((record) => (
+                                <TableRow
+                                    key={record.id}
+                                    hover
+                                    sx={{
+                                        '& .MuiTableCell-root': {
+                                            py: 0.625,
+                                            borderBottom: '1px solid',
+                                            borderColor: 'divider',
+                                        },
+                                    }}
+                                >
+                                    {/* Time */}
+                                    <TableCell>
+                                        <Tooltip title={new Date(record.timestamp).toLocaleString()} placement="right">
+                                            <Typography
+                                                variant="caption"
+                                                sx={{ fontFamily: 'monospace', fontSize: '0.72rem', color: 'text.secondary', cursor: 'default' }}
+                                            >
+                                                {formatTime(record.timestamp)}
+                                            </Typography>
+                                        </Tooltip>
+                                    </TableCell>
+
+                                    {/* Provider / Model */}
+                                    <TableCell>
+                                        <Typography variant="caption" sx={{ display: 'block', color: 'text.disabled', fontSize: '0.65rem', lineHeight: 1.2 }}>
+                                            {record.provider_name || '-'}
+                                        </Typography>
+                                        <Tooltip title={record.model} placement="top">
+                                            <Typography
+                                                variant="body2"
+                                                sx={{
+                                                    fontSize: '0.78rem',
+                                                    maxWidth: 180,
+                                                    overflow: 'hidden',
+                                                    textOverflow: 'ellipsis',
+                                                    whiteSpace: 'nowrap',
+                                                    lineHeight: 1.4,
+                                                }}
+                                            >
+                                                {record.model || '-'}
+                                            </Typography>
+                                        </Tooltip>
+                                    </TableCell>
+
+                                    {/* Scenario */}
+                                    <TableCell>
+                                        <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.75rem' }}>
+                                            {record.scenario || '-'}
+                                        </Typography>
+                                    </TableCell>
+
+                                    {/* Input tokens */}
+                                    <TableCell align="right">
+                                        <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                                            {formatTokens(record.input_tokens)}
+                                        </Typography>
+                                    </TableCell>
+
+                                    {/* Output tokens */}
+                                    <TableCell align="right">
+                                        <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                                            {formatTokens(record.output_tokens)}
+                                        </Typography>
+                                    </TableCell>
+
+                                    {/* Cache tokens */}
+                                    <TableCell align="right">
+                                        <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'text.secondary' }}>
+                                            {record.cache_input_tokens > 0 ? formatTokens(record.cache_input_tokens) : '-'}
+                                        </Typography>
+                                    </TableCell>
+
+                                    {/* Latency */}
+                                    <TableCell align="right">
+                                        <Typography
+                                            variant="caption"
+                                            sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: record.latency_ms > 0 ? getLatencyColor(record.latency_ms) : 'text.disabled' }}
+                                        >
+                                            {record.latency_ms > 0 ? `${record.latency_ms}ms` : '-'}
+                                        </Typography>
+                                    </TableCell>
+
+                                    {/* Status */}
+                                    <TableCell align="center">
+                                        {record.status === 'success' ? (
+                                            <Chip
+                                                label="OK"
+                                                size="small"
+                                                sx={{
+                                                    height: 18,
+                                                    fontSize: '0.65rem',
+                                                    fontWeight: 700,
+                                                    backgroundColor: 'success.main',
+                                                    color: '#fff',
+                                                    '& .MuiChip-label': { px: 0.75 },
+                                                }}
+                                            />
+                                        ) : (
+                                            <Tooltip title={record.error_code || record.status} placement="top">
+                                                <Chip
+                                                    label="ERR"
+                                                    size="small"
+                                                    sx={{
+                                                        height: 18,
+                                                        fontSize: '0.65rem',
+                                                        fontWeight: 700,
+                                                        backgroundColor: 'error.main',
+                                                        color: '#fff',
+                                                        '& .MuiChip-label': { px: 0.75 },
+                                                    }}
+                                                />
+                                            </Tooltip>
+                                        )}
+                                    </TableCell>
+
+                                    {/* Stream */}
+                                    <TableCell align="center">
+                                        {record.streamed && (
+                                            <Tooltip title="Streamed">
+                                                <Box sx={{ display: 'inline-flex', color: 'primary.main' }}>
+                                                    <StreamIcon sx={{ fontSize: '0.95rem' }} />
+                                                </Box>
+                                            </Tooltip>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            <TablePagination
+                rowsPerPageOptions={[50, 100, 200]}
+                component="div"
+                count={total}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                onPageChange={(_, p) => onPageChange(p)}
+                onRowsPerPageChange={(e) => onRowsPerPageChange(parseInt(e.target.value, 10))}
+                sx={{
+                    borderTop: '1px solid',
+                    borderColor: 'divider',
+                    '& .MuiTablePagination-toolbar': { minHeight: 48 },
+                    '& .MuiTablePagination-selectLabel, & .MuiTablePagination-displayedRows': {
+                        fontSize: '0.75rem',
+                    },
+                }}
+            />
+        </Paper>
+    );
+}

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -1,0 +1,449 @@
+import { useState } from 'react';
+import {
+    Box,
+    Paper,
+    Typography,
+    Chip,
+    Tooltip,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TablePagination,
+    ToggleButtonGroup,
+    ToggleButton,
+    CircularProgress,
+    useTheme,
+} from '@mui/material';
+import {
+    PieChart,
+    Pie,
+    Cell,
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip as ReTooltip,
+    ResponsiveContainer,
+} from 'recharts';
+import { tablerMui } from '@/components/icons';
+import { IconWaveSine } from '@tabler/icons-react';
+import { getThemeChartStyles, TOKEN_COLORS } from './chartStyles';
+
+const StreamIcon = tablerMui(IconWaveSine);
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface UsageRecord {
+    id: number;
+    provider_uuid: string;
+    provider_name: string;
+    model: string;
+    scenario: string;
+    rule_uuid?: string;
+    user_id?: string;
+    request_model?: string;
+    timestamp: string;
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    cache_input_tokens: number;
+    status: string;
+    error_code?: string;
+    latency_ms: number;
+    streamed: boolean;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SUCCESS_COLOR = '#10B981';
+const ERROR_COLOR  = '#EF4444';
+
+const LATENCY_BUCKETS = [
+    { label: '<0.2s',   min: 0,    max: 200  },
+    { label: '0.2-0.5', min: 200,  max: 500  },
+    { label: '0.5-1s',  min: 500,  max: 1000 },
+    { label: '1-2s',    min: 1000, max: 2000 },
+    { label: '2-5s',    min: 2000, max: 5000 },
+    { label: '>5s',     min: 5000, max: Infinity },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const fmtTokens = (n: number) => {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000)     return `${(n / 1_000).toFixed(1)}K`;
+    return n.toString();
+};
+
+const fmtLatency = (ms: number) => {
+    if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${ms}ms`;
+};
+
+const fmtTime = (ts: string) =>
+    new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+// ─── Token Donut ─────────────────────────────────────────────────────────────
+
+function DonutTooltip({ active, payload }: any) {
+    const theme = useTheme();
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    return (
+        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.25, boxShadow: theme.shadows[4] }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: d.color, flexShrink: 0 }} />
+                <Typography sx={{ fontSize: '0.75rem', fontWeight: 600 }}>{d.name}</Typography>
+            </Box>
+            <Typography sx={{ fontSize: '0.72rem', color: 'text.secondary', mt: 0.25 }}>
+                {fmtTokens(d.value)} ({d.pct}%)
+            </Typography>
+        </Box>
+    );
+}
+
+function TokenDonut({ records }: { records: UsageRecord[] }) {
+    const totalInput  = records.reduce((s, r) => s + r.input_tokens, 0);
+    const totalOutput = records.reduce((s, r) => s + r.output_tokens, 0);
+    const totalCache  = records.reduce((s, r) => s + r.cache_input_tokens, 0);
+    const total = totalInput + totalOutput + totalCache;
+
+    const pieData = [
+        { name: 'Input',  value: totalInput,  color: TOKEN_COLORS.input.main,  pct: total > 0 ? ((totalInput  / total) * 100).toFixed(1) : '0' },
+        { name: 'Output', value: totalOutput, color: TOKEN_COLORS.output.main, pct: total > 0 ? ((totalOutput / total) * 100).toFixed(1) : '0' },
+        { name: 'Cache',  value: totalCache,  color: TOKEN_COLORS.cache.main,  pct: total > 0 ? ((totalCache  / total) * 100).toFixed(1) : '0' },
+    ].filter(d => d.value > 0);
+
+    return (
+        <Paper elevation={0} sx={{ p: 2.5, border: '1px solid', borderColor: 'divider', borderRadius: 2, backgroundColor: 'background.paper', boxShadow: 'none' }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', mb: 2 }}>Token Breakdown</Typography>
+            {total === 0 ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 140 }}>
+                    <Typography variant="caption" color="text.disabled">No data</Typography>
+                </Box>
+            ) : (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5 }}>
+                    {/* Donut */}
+                    <Box sx={{ position: 'relative', flexShrink: 0, width: 140, height: 140 }}>
+                        <PieChart width={140} height={140}>
+                            <Pie data={pieData} cx={70} cy={70} innerRadius={42} outerRadius={62} dataKey="value" paddingAngle={2} isAnimationActive={false}>
+                                {pieData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
+                            </Pie>
+                            <ReTooltip content={<DonutTooltip />} />
+                        </PieChart>
+                        {/* Center label */}
+                        <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', textAlign: 'center', pointerEvents: 'none' }}>
+                            <Typography sx={{ fontSize: '0.82rem', fontWeight: 700, lineHeight: 1.2 }}>
+                                {fmtTokens(total)}
+                            </Typography>
+                            <Typography sx={{ fontSize: '0.58rem', color: 'text.secondary', lineHeight: 1.2 }}>
+                                total
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    {/* Legend */}
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, minWidth: 0 }}>
+                        {pieData.map(d => (
+                            <Box key={d.name} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: d.color, flexShrink: 0 }} />
+                                <Box sx={{ minWidth: 0 }}>
+                                    <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', lineHeight: 1.2 }}>{d.name}</Typography>
+                                    <Typography sx={{ fontSize: '0.78rem', fontWeight: 600, lineHeight: 1.3 }}>
+                                        {fmtTokens(d.value)}
+                                        <Typography component="span" sx={{ fontSize: '0.65rem', color: 'text.secondary', ml: 0.5 }}>
+                                            {d.pct}%
+                                        </Typography>
+                                    </Typography>
+                                </Box>
+                            </Box>
+                        ))}
+                        <Box sx={{ mt: 0.5, pt: 0.75, borderTop: '1px solid', borderColor: 'divider' }}>
+                            <Typography sx={{ fontSize: '0.68rem', color: 'text.secondary' }}>
+                                {records.length} requests
+                            </Typography>
+                        </Box>
+                    </Box>
+                </Box>
+            )}
+        </Paper>
+    );
+}
+
+// ─── Latency Histogram ────────────────────────────────────────────────────────
+
+function HistoTooltip({ active, payload, label }: any) {
+    const theme = useTheme();
+    if (!active || !payload?.length) return null;
+    const success = payload.find((p: any) => p.dataKey === 'success')?.value ?? 0;
+    const error   = payload.find((p: any) => p.dataKey === 'error')?.value   ?? 0;
+    return (
+        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.25, boxShadow: theme.shadows[4] }}>
+            <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, mb: 0.5 }}>{label}</Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                <Typography sx={{ fontSize: '0.7rem', color: SUCCESS_COLOR }}>Success: {success}</Typography>
+                {error > 0 && <Typography sx={{ fontSize: '0.7rem', color: ERROR_COLOR }}>Error: {error}</Typography>}
+                <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', fontWeight: 600 }}>Total: {success + error}</Typography>
+            </Box>
+        </Box>
+    );
+}
+
+function LatencyHistogram({ records }: { records: UsageRecord[] }) {
+    const theme = useTheme();
+    const chartStyles = getThemeChartStyles(theme);
+
+    const histData = LATENCY_BUCKETS.map(b => ({
+        label: b.label,
+        success: records.filter(r => r.latency_ms >= b.min && r.latency_ms < b.max && r.status === 'success').length,
+        error:   records.filter(r => r.latency_ms >= b.min && r.latency_ms < b.max && r.status !== 'success').length,
+    }));
+
+    const hasData = records.length > 0;
+
+    return (
+        <Paper elevation={0} sx={{ p: 2.5, border: '1px solid', borderColor: 'divider', borderRadius: 2, backgroundColor: 'background.paper', boxShadow: 'none' }}>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', mb: 2 }}>Latency Distribution</Typography>
+            {!hasData ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 140 }}>
+                    <Typography variant="caption" color="text.disabled">No data</Typography>
+                </Box>
+            ) : (
+                <ResponsiveContainer width="100%" height={140}>
+                    <BarChart data={histData} margin={{ top: 0, right: 4, bottom: 0, left: -20 }} barCategoryGap="20%">
+                        <CartesianGrid strokeDasharray="3 3" stroke={chartStyles.chart.grid} strokeOpacity={0.6} vertical={false} />
+                        <XAxis
+                            dataKey="label"
+                            tick={{ fontSize: 10, fill: theme.palette.text.secondary }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartStyles.chart.axis }}
+                        />
+                        <YAxis
+                            tick={{ fontSize: 10, fill: theme.palette.text.secondary }}
+                            tickLine={false}
+                            axisLine={false}
+                            allowDecimals={false}
+                        />
+                        <ReTooltip content={<HistoTooltip />} cursor={{ fill: theme.palette.action.hover }} />
+                        <Bar dataKey="success" stackId="a" fill={SUCCESS_COLOR} fillOpacity={0.75} isAnimationActive={false} radius={[0, 0, 0, 0]} />
+                        <Bar dataKey="error"   stackId="a" fill={ERROR_COLOR}   fillOpacity={0.85} isAnimationActive={false} radius={[3, 3, 0, 0]} />
+                    </BarChart>
+                </ResponsiveContainer>
+            )}
+        </Paper>
+    );
+}
+
+// ─── Request Table ────────────────────────────────────────────────────────────
+
+const getLatencyColor = (ms: number, theme: any) => {
+    if (ms > 2000) return theme.palette.error.main;
+    if (ms > 1000) return theme.palette.warning.main;
+    return theme.palette.success.main;
+};
+
+interface TableSectionProps {
+    records: UsageRecord[];
+    total: number;
+    page: number;
+    rowsPerPage: number;
+    statusFilter: 'all' | 'success' | 'error';
+    loading: boolean;
+    onStatusFilterChange: (s: 'all' | 'success' | 'error') => void;
+    onPageChange: (p: number) => void;
+    onRowsPerPageChange: (r: number) => void;
+}
+
+function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading, onStatusFilterChange, onPageChange, onRowsPerPageChange }: TableSectionProps) {
+    const theme = useTheme();
+
+    return (
+        <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden', backgroundColor: 'background.paper', boxShadow: 'none' }}>
+            {/* Header */}
+            <Box sx={{ px: 2.5, py: 1.5, borderBottom: '1px solid', borderColor: 'divider', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 1.5 }}>
+                <Typography sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
+                    Requests
+                    <Typography component="span" variant="caption" sx={{ ml: 1, color: 'text.secondary' }}>
+                        {!loading && `${total.toLocaleString()} total`}
+                    </Typography>
+                </Typography>
+                <ToggleButtonGroup
+                    value={statusFilter} exclusive size="small"
+                    onChange={(_, v) => v && onStatusFilterChange(v)}
+                    sx={{ '& .MuiToggleButton-root': { px: 1.5, py: 0.375, fontSize: '0.75rem', textTransform: 'none' } }}
+                >
+                    <ToggleButton value="all">All</ToggleButton>
+                    <ToggleButton value="success">Success</ToggleButton>
+                    <ToggleButton value="error">Error</ToggleButton>
+                </ToggleButtonGroup>
+            </Box>
+
+            {/* Table */}
+            <TableContainer sx={{ maxHeight: 420, position: 'relative' }}>
+                {loading && (
+                    <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.6)' }}>
+                        <CircularProgress size={28} />
+                    </Box>
+                )}
+                <Table stickyHeader size="small">
+                    <TableHead>
+                        <TableRow sx={{ '& .MuiTableCell-root': { fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary', py: 1, borderBottom: '1px solid', borderColor: 'divider', backgroundColor: 'background.paper', whiteSpace: 'nowrap' } }}>
+                            <TableCell>Time</TableCell>
+                            <TableCell>Provider / Model</TableCell>
+                            <TableCell>Scenario</TableCell>
+                            <TableCell align="right">Input</TableCell>
+                            <TableCell align="right">Output</TableCell>
+                            <TableCell align="right">Cache</TableCell>
+                            <TableCell align="right">Latency</TableCell>
+                            <TableCell align="center">Status</TableCell>
+                            <TableCell align="center">Stream</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {records.length === 0 && !loading ? (
+                            <TableRow>
+                                <TableCell colSpan={9} align="center" sx={{ py: 5 }}>
+                                    <Typography variant="body2" color="text.secondary">No requests found</Typography>
+                                    <Typography variant="caption" color="text.disabled">Try changing the status filter</Typography>
+                                </TableCell>
+                            </TableRow>
+                        ) : records.map(r => (
+                            <TableRow key={r.id} hover sx={{ '& .MuiTableCell-root': { py: 0.625, borderBottom: '1px solid', borderColor: 'divider' } }}>
+                                {/* Time */}
+                                <TableCell>
+                                    <Tooltip title={new Date(r.timestamp).toLocaleString()} placement="right">
+                                        <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', color: 'text.secondary', cursor: 'default' }}>
+                                            {fmtTime(r.timestamp)}
+                                        </Typography>
+                                    </Tooltip>
+                                </TableCell>
+
+                                {/* Provider / Model */}
+                                <TableCell>
+                                    <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled', lineHeight: 1.2 }}>
+                                        {r.provider_name || '-'}
+                                    </Typography>
+                                    <Tooltip title={r.model} placement="top">
+                                        <Typography sx={{ fontSize: '0.78rem', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.4 }}>
+                                            {r.model || '-'}
+                                        </Typography>
+                                    </Tooltip>
+                                </TableCell>
+
+                                {/* Scenario */}
+                                <TableCell>
+                                    <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                                        {r.scenario || '-'}
+                                    </Typography>
+                                </TableCell>
+
+                                {/* Tokens */}
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.input.main }}>
+                                        {fmtTokens(r.input_tokens)}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.output.main }}>
+                                        {fmtTokens(r.output_tokens)}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'text.secondary' }}>
+                                        {r.cache_input_tokens > 0 ? fmtTokens(r.cache_input_tokens) : '-'}
+                                    </Typography>
+                                </TableCell>
+
+                                {/* Latency */}
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: r.latency_ms > 0 ? getLatencyColor(r.latency_ms, theme) : 'text.disabled' }}>
+                                        {r.latency_ms > 0 ? fmtLatency(r.latency_ms) : '-'}
+                                    </Typography>
+                                </TableCell>
+
+                                {/* Status */}
+                                <TableCell align="center">
+                                    {r.status === 'success' ? (
+                                        <Chip label="OK" size="small" sx={{ height: 18, fontSize: '0.65rem', fontWeight: 700, backgroundColor: SUCCESS_COLOR, color: '#fff', '& .MuiChip-label': { px: 0.75 } }} />
+                                    ) : (
+                                        <Tooltip title={r.error_code || r.status} placement="top">
+                                            <Chip label="ERR" size="small" sx={{ height: 18, fontSize: '0.65rem', fontWeight: 700, backgroundColor: ERROR_COLOR, color: '#fff', '& .MuiChip-label': { px: 0.75 } }} />
+                                        </Tooltip>
+                                    )}
+                                </TableCell>
+
+                                {/* Stream */}
+                                <TableCell align="center">
+                                    {r.streamed && (
+                                        <Tooltip title="Streamed">
+                                            <Box sx={{ display: 'inline-flex', color: 'primary.main' }}>
+                                                <StreamIcon sx={{ fontSize: '0.95rem' }} />
+                                            </Box>
+                                        </Tooltip>
+                                    )}
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            <TablePagination
+                rowsPerPageOptions={[20, 50, 100]}
+                component="div"
+                count={total}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                onPageChange={(_, p) => onPageChange(p)}
+                onRowsPerPageChange={e => onRowsPerPageChange(parseInt(e.target.value, 10))}
+                sx={{ borderTop: '1px solid', borderColor: 'divider', '& .MuiTablePagination-toolbar': { minHeight: 48 }, '& .MuiTablePagination-selectLabel, & .MuiTablePagination-displayedRows': { fontSize: '0.75rem' } }}
+            />
+        </Paper>
+    );
+}
+
+// ─── Main Export ─────────────────────────────────────────────────────────────
+
+interface RequestsViewProps {
+    records: UsageRecord[];
+    loading: boolean;
+}
+
+export default function RequestsView({ records, loading }: RequestsViewProps) {
+    const [statusFilter, setStatusFilter] = useState<'all' | 'success' | 'error'>('all');
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(50);
+
+    const filtered = statusFilter === 'all'
+        ? records
+        : records.filter(r => statusFilter === 'success' ? r.status === 'success' : r.status !== 'success');
+
+    const paged = filtered.slice(page * rowsPerPage, (page + 1) * rowsPerPage);
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {/* Charts row */}
+            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
+                <TokenDonut records={records} />
+                <LatencyHistogram records={records} />
+            </Box>
+
+            {/* Table */}
+            <RequestTable
+                records={paged}
+                total={filtered.length}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                statusFilter={statusFilter}
+                loading={loading && records.length === 0}
+                onStatusFilterChange={s => { setStatusFilter(s); setPage(0); }}
+                onPageChange={setPage}
+                onRowsPerPageChange={r => { setRowsPerPage(r); setPage(0); }}
+            />
+        </Box>
+    );
+}

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -54,6 +54,7 @@ export interface UsageRecord {
     status: string;
     error_code?: string;
     latency_ms: number;
+    ttft_ms?: number;
     streamed: boolean;
 }
 
@@ -196,21 +197,40 @@ function HistoTooltip({ active, payload, label }: any) {
 function LatencyHistogram({ records }: { records: UsageRecord[] }) {
     const theme = useTheme();
     const chartStyles = getThemeChartStyles(theme);
+    const [metric, setMetric] = useState<'latency' | 'ttft'>('latency');
+
+    const getValue = (r: UsageRecord) => metric === 'latency' ? r.latency_ms : (r.ttft_ms ?? 0);
+    // TTFT is only meaningful for streamed requests
+    const pool = metric === 'ttft' ? records.filter(r => r.streamed && (r.ttft_ms ?? 0) > 0) : records;
 
     const histData = LATENCY_BUCKETS.map(b => ({
         label: b.label,
-        success: records.filter(r => r.latency_ms >= b.min && r.latency_ms < b.max && r.status === 'success').length,
-        error:   records.filter(r => r.latency_ms >= b.min && r.latency_ms < b.max && r.status !== 'success').length,
+        success: pool.filter(r => getValue(r) >= b.min && getValue(r) < b.max && r.status === 'success').length,
+        error:   pool.filter(r => getValue(r) >= b.min && getValue(r) < b.max && r.status !== 'success').length,
     }));
 
-    const hasData = records.length > 0;
+    const hasData = pool.length > 0;
 
     return (
         <Paper elevation={0} sx={{ p: 2.5, border: '1px solid', borderColor: 'divider', borderRadius: 2, backgroundColor: 'background.paper', boxShadow: 'none' }}>
-            <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', mb: 2 }}>Latency Distribution</Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                <Typography sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
+                    {metric === 'latency' ? 'Latency' : 'TTFT'} Distribution
+                </Typography>
+                <ToggleButtonGroup
+                    value={metric} exclusive size="small"
+                    onChange={(_, v) => v && setMetric(v)}
+                    sx={{ '& .MuiToggleButton-root': { px: 1.25, py: 0.25, fontSize: '0.7rem', textTransform: 'none' } }}
+                >
+                    <ToggleButton value="latency">Latency</ToggleButton>
+                    <ToggleButton value="ttft">TTFT</ToggleButton>
+                </ToggleButtonGroup>
+            </Box>
             {!hasData ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 140 }}>
-                    <Typography variant="caption" color="text.disabled">No data</Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: 140, gap: 0.5 }}>
+                    <Typography variant="caption" color="text.disabled">
+                        {metric === 'ttft' ? 'No TTFT data — backend field not yet exposed' : 'No data'}
+                    </Typography>
                 </Box>
             ) : (
                 <ResponsiveContainer width="100%" height={140}>
@@ -299,6 +319,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                             <TableCell align="right">Output</TableCell>
                             <TableCell align="right">Cache</TableCell>
                             <TableCell align="right">Latency</TableCell>
+                            <TableCell align="right">TTFT</TableCell>
                             <TableCell align="center">Status</TableCell>
                             <TableCell align="center">Stream</TableCell>
                         </TableRow>
@@ -306,7 +327,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                     <TableBody>
                         {records.length === 0 && !loading ? (
                             <TableRow>
-                                <TableCell colSpan={9} align="center" sx={{ py: 5 }}>
+                                <TableCell colSpan={10} align="center" sx={{ py: 5 }}>
                                     <Typography variant="body2" color="text.secondary">No requests found</Typography>
                                     <Typography variant="caption" color="text.disabled">Try changing the status filter</Typography>
                                 </TableCell>
@@ -362,6 +383,13 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                                 <TableCell align="right">
                                     <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: r.latency_ms > 0 ? getLatencyColor(r.latency_ms, theme) : 'text.disabled' }}>
                                         {r.latency_ms > 0 ? fmtLatency(r.latency_ms) : '-'}
+                                    </Typography>
+                                </TableCell>
+
+                                {/* TTFT */}
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: (r.ttft_ms ?? 0) > 0 ? getLatencyColor(r.ttft_ms!, theme) : 'text.disabled' }}>
+                                        {(r.ttft_ms ?? 0) > 0 ? fmtLatency(r.ttft_ms!) : '-'}
                                     </Typography>
                                 </TableCell>
 

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -8,3 +8,5 @@ export { default as RequestErrorChart } from './RequestErrorChart';
 export { default as TokenHeatmap } from './TokenHeatmap';
 export type { DailyUsage, HeatmapMetrics } from './TokenHeatmap';
 export { default as AgentQuickNav } from './AgentQuickNav';
+export { default as RequestsTable } from './RequestsTable';
+export type { UsageRecord } from './RequestsTable';

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -8,6 +8,6 @@ export { default as RequestErrorChart } from './RequestErrorChart';
 export { default as TokenHeatmap } from './TokenHeatmap';
 export type { DailyUsage, HeatmapMetrics } from './TokenHeatmap';
 export { default as AgentQuickNav } from './AgentQuickNav';
-export { default as RequestScatterChart } from './RequestScatterChart';
-export type { UsageRecord } from './RequestScatterChart';
+export { default as RequestsView } from './RequestsView';
+export type { UsageRecord } from './RequestsView';
 

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -8,5 +8,6 @@ export { default as RequestErrorChart } from './RequestErrorChart';
 export { default as TokenHeatmap } from './TokenHeatmap';
 export type { DailyUsage, HeatmapMetrics } from './TokenHeatmap';
 export { default as AgentQuickNav } from './AgentQuickNav';
-export { default as RequestsTable } from './RequestsTable';
-export type { UsageRecord } from './RequestsTable';
+export { default as RequestScatterChart } from './RequestScatterChart';
+export type { UsageRecord } from './RequestScatterChart';
+

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1492,6 +1492,65 @@ export const handlers = [
         return HttpResponse.json({ success: true, data })
     }),
 
+    http.get('/api/v1/usage/records', ({ request }) => {
+        const url = new URL(request.url)
+        const limit = parseInt(url.searchParams.get('limit') || '500')
+        const offset = parseInt(url.searchParams.get('offset') || '0')
+        const statusFilter = url.searchParams.get('status') || ''
+
+        const models = [
+            { provider_name: 'Anthropic', model: 'claude-sonnet-4-5', scenario: 'claude_code', streamed: true },
+            { provider_name: 'Anthropic', model: 'claude-opus-4-5',   scenario: 'claude_code', streamed: true },
+            { provider_name: 'OpenAI',    model: 'gpt-4o',            scenario: 'openai',      streamed: true },
+            { provider_name: 'OpenAI',    model: 'gpt-4o-mini',       scenario: 'openai',      streamed: false },
+            { provider_name: 'OpenRouter', model: 'deepseek/deepseek-r1', scenario: 'agent',   streamed: true },
+        ]
+
+        const now = Date.now()
+        const dayStart = new Date()
+        dayStart.setHours(0, 0, 0, 0)
+
+        const total = 120
+        const all = Array.from({ length: total }, (_, i) => {
+            const m = models[i % models.length]
+            const isError = i % 20 === 0
+            const input = Math.round(800 + Math.random() * 4000)
+            const output = Math.round(200 + Math.random() * 1500)
+            const cache = m.provider_name === 'Anthropic' ? Math.round(Math.random() * 800) : 0
+            const latency = Math.round(
+                m.model.includes('opus') ? 1500 + Math.random() * 3000
+                : m.model.includes('mini') ? 200 + Math.random() * 600
+                : 600 + Math.random() * 1800
+            )
+            const ts = new Date(dayStart.getTime() + Math.random() * (now - dayStart.getTime()))
+            return {
+                id: i + 1,
+                provider_uuid: `mock-provider-${m.provider_name.toLowerCase()}`,
+                provider_name: m.provider_name,
+                model: m.model,
+                scenario: m.scenario,
+                timestamp: ts.toISOString(),
+                input_tokens: input,
+                output_tokens: output,
+                total_tokens: input + output + cache,
+                cache_input_tokens: cache,
+                status: isError ? 'error' : 'success',
+                error_code: isError ? 'rate_limit_exceeded' : '',
+                latency_ms: latency,
+                streamed: m.streamed && !isError,
+            }
+        }).sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+
+        const filtered = statusFilter ? all.filter(r => r.status === statusFilter) : all
+        const page = filtered.slice(offset, offset + limit)
+
+        return HttpResponse.json({
+            success: true,
+            meta: { total: filtered.length, limit, offset },
+            data: page,
+        })
+    }),
+
     // ============================================
     // ImBot Settings API (v1)
     // ============================================

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1537,6 +1537,7 @@ export const handlers = [
                 status: isError ? 'error' : 'success',
                 error_code: isError ? 'rate_limit_exceeded' : '',
                 latency_ms: latency,
+                ttft_ms: (m.streamed && !isError) ? Math.round(latency * (0.05 + Math.random() * 0.15)) : 0,
                 streamed: m.streamed && !isError,
             }
         }).sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -27,8 +27,9 @@ import { IconCoin, IconActivity, IconReload } from '@tabler/icons-react';
 const PaidIcon = tablerMui(IconCoin);
 const StreamIcon = tablerMui(IconActivity);
 const CachedIcon = tablerMui(IconReload);
-import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav } from '@/components/dashboard';
-import type { TimeSeriesData, AggregatedStat } from '@/components/dashboard';
+import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsTable } from '@/components/dashboard';
+import type { TimeSeriesData, AggregatedStat, UsageRecord } from '@/components/dashboard';
+import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import PageHeader from '@/components/PageHeader';
 import { switchControlLabelStyle } from '@/styles/toggleStyles';
 import api from '../services/api';
@@ -106,6 +107,8 @@ export default function DashboardPage() {
         ? (urlTimeRange as TimeRange)
         : '7d';
 
+    const isHourlyRange = timeRange === 'today' || timeRange === 'yesterday';
+
     const [loading, setLoading] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
     const [autoRefresh, setAutoRefresh] = useState(false);
@@ -114,42 +117,48 @@ export default function DashboardPage() {
     const [providers, setProviders] = useState<Provider[]>([]);
     const [selectedProvider, setSelectedProvider] = useState<string>('all');
 
+    // By-request view state
+    const [viewMode, setViewMode] = useState<'summary' | 'requests'>('summary');
+    const [records, setRecords] = useState<UsageRecord[]>([]);
+    const [recordsTotal, setRecordsTotal] = useState(0);
+    const [recordsPage, setRecordsPage] = useState(0);
+    const [recordsLimit, setRecordsLimit] = useState(50);
+    const [recordsLoading, setRecordsLoading] = useState(false);
+    const [statusFilter, setStatusFilter] = useState<'all' | 'success' | 'error'>('all');
+    const [recordsTimeParams, setRecordsTimeParams] = useState<{ start_time: string; end_time: string } | null>(null);
+
+    const buildTimeParams = useCallback((provider: string, range: TimeRange) => {
+        const now = new Date();
+        const config = TIME_RANGE_CONFIG[range];
+        const todayStart = getLocalMidnight(now);
+        const startTime = new Date(todayStart);
+        let endTime: Date;
+
+        if (range === 'today') {
+            endTime = now;
+        } else if (range === 'yesterday') {
+            startTime.setDate(startTime.getDate() - 1);
+            endTime = new Date(todayStart);
+        } else {
+            startTime.setDate(startTime.getDate() - (config.days - 1));
+            endTime = new Date(todayStart);
+            endTime.setDate(endTime.getDate() + 1);
+        }
+
+        const params: Record<string, string> = {
+            start_time: toLocalISOString(startTime),
+            end_time: toLocalISOString(endTime),
+        };
+        if (provider && provider !== 'all') {
+            params.provider = provider;
+        }
+        return params;
+    }, []);
+
     const loadData = useCallback(async (provider: string, range: TimeRange) => {
         try {
-            // Build query params based on time range
-            const now = new Date();
             const config = TIME_RANGE_CONFIG[range];
-
-            // Calculate start time based on today 00:00:00 LOCAL time
-            // For multi-day mode, start from (config.days - 1) days ago at 00:00:00
-            // For 'today' mode, start from today 00:00:00
-            const todayStart = getLocalMidnight(now);
-
-            const startTime = new Date(todayStart);
-            let endTime: Date;
-
-            if (range === 'today') {
-                // For today: from today 00:00:00 to now
-                endTime = now;
-            } else if (range === 'yesterday') {
-                // For yesterday: from yesterday 00:00:00 to today 00:00:00
-                startTime.setDate(startTime.getDate() - 1);
-                endTime = new Date(todayStart);
-            } else {
-                // For multi-day mode: from (N-1) days ago 00:00:00 to tomorrow 00:00:00
-                // This ensures we get complete data for today
-                startTime.setDate(startTime.getDate() - (config.days - 1));
-                endTime = new Date(todayStart);
-                endTime.setDate(endTime.getDate() + 1); // Next day at 00:00:00
-            }
-
-            const params: Record<string, string> = {
-                start_time: toLocalISOString(startTime),
-                end_time: toLocalISOString(endTime),
-            };
-            if (provider && provider !== 'all') {
-                params.provider = provider;
-            }
+            const params = buildTimeParams(provider, range);
 
             const [statsResult, timeSeriesResult, providersResult] = await Promise.all([
                 api.getUsageStats({ ...params, group_by: 'model', limit: 100 }),
@@ -166,11 +175,42 @@ export default function DashboardPage() {
             if (providersResult?.success && providersResult?.data) {
                 setProviders(providersResult.data);
             }
+
+            // Store time params for records loading
+            setRecordsTimeParams({ start_time: params.start_time, end_time: params.end_time });
         } catch (error) {
             console.error('Failed to load dashboard data:', error);
         } finally {
             setLoading(false);
             setRefreshing(false);
+        }
+    }, [buildTimeParams]);
+
+    const loadRecords = useCallback(async (
+        timeParams: { start_time: string; end_time: string } | null,
+        provider: string,
+        status: 'all' | 'success' | 'error',
+        page: number,
+        limit: number,
+    ) => {
+        if (!timeParams) return;
+        setRecordsLoading(true);
+        try {
+            const result = await api.getUsageRecords({
+                ...timeParams,
+                ...(provider !== 'all' ? { provider } : {}),
+                ...(status !== 'all' ? { status } : {}),
+                limit,
+                offset: page * limit,
+            });
+            if (result?.data) {
+                setRecords(result.data);
+                setRecordsTotal(result.meta?.total ?? 0);
+            }
+        } catch (error) {
+            console.error('Failed to load records:', error);
+        } finally {
+            setRecordsLoading(false);
         }
     }, []);
 
@@ -178,14 +218,38 @@ export default function DashboardPage() {
         loadData(selectedProvider, timeRange);
     }, [loadData, selectedProvider, timeRange]);
 
+    // Reset view mode when switching away from hourly ranges
+    useEffect(() => {
+        if (!isHourlyRange) {
+            setViewMode('summary');
+        }
+    }, [isHourlyRange]);
+
+    // Load records when entering requests view
+    useEffect(() => {
+        if (viewMode === 'requests') {
+            setRecordsPage(0);
+            loadRecords(recordsTimeParams, selectedProvider, statusFilter, 0, recordsLimit);
+        }
+    }, [viewMode, recordsTimeParams, selectedProvider, statusFilter, recordsLimit, loadRecords]);
+
+    useEffect(() => {
+        if (viewMode === 'requests') {
+            loadRecords(recordsTimeParams, selectedProvider, statusFilter, recordsPage, recordsLimit);
+        }
+    }, [recordsPage]); // eslint-disable-line react-hooks/exhaustive-deps
+
     useEffect(() => {
         if (autoRefresh) {
             const interval = setInterval(() => {
                 loadData(selectedProvider, timeRange);
+                if (viewMode === 'requests') {
+                    loadRecords(recordsTimeParams, selectedProvider, statusFilter, recordsPage, recordsLimit);
+                }
             }, 60000);
             return () => clearInterval(interval);
         }
-    }, [autoRefresh, loadData, selectedProvider, timeRange]);
+    }, [autoRefresh, loadData, selectedProvider, timeRange, viewMode, loadRecords, recordsTimeParams, statusFilter, recordsPage, recordsLimit]);
 
     const handleRefresh = () => {
         setRefreshing(true);
@@ -383,18 +447,60 @@ export default function DashboardPage() {
                         </Grid>
                     </Grid>
 
-                    {/* Time Series Chart - Full Width */}
-                    <Box sx={{ display: 'flex' }}>
-                        {timeRange === 'today' || timeRange === 'yesterday' ? (
-                            <HourlyTokenHistoryChart data={timeSeries} />
+                    {/* Chart / Requests toggle */}
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                        {isHourlyRange && (
+                            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                                <ToggleButtonGroup
+                                    value={viewMode}
+                                    exclusive
+                                    onChange={(_, v) => v && setViewMode(v)}
+                                    size="small"
+                                    sx={{
+                                        '& .MuiToggleButton-root': {
+                                            px: 1.75,
+                                            py: 0.375,
+                                            fontSize: '0.78rem',
+                                            textTransform: 'none',
+                                        },
+                                    }}
+                                >
+                                    <ToggleButton value="summary">Summary</ToggleButton>
+                                    <ToggleButton value="requests">By Request</ToggleButton>
+                                </ToggleButtonGroup>
+                            </Box>
+                        )}
+
+                        {viewMode === 'summary' ? (
+                            timeRange === 'today' || timeRange === 'yesterday' ? (
+                                <HourlyTokenHistoryChart data={timeSeries} />
+                            ) : (
+                                <DailyTokenHistoryChart data={timeSeries} />
+                            )
                         ) : (
-                            <DailyTokenHistoryChart data={timeSeries} />
+                            <RequestsTable
+                                records={records}
+                                total={recordsTotal}
+                                page={recordsPage}
+                                rowsPerPage={recordsLimit}
+                                statusFilter={statusFilter}
+                                loading={recordsLoading}
+                                onPageChange={(p) => setRecordsPage(p)}
+                                onRowsPerPageChange={(limit) => {
+                                    setRecordsLimit(limit);
+                                    setRecordsPage(0);
+                                }}
+                                onStatusFilterChange={(s) => {
+                                    setStatusFilter(s);
+                                    setRecordsPage(0);
+                                }}
+                            />
                         )}
                     </Box>
                 </Box>
 
                 {/* Right Column (20%) - Token Usage List */}
-                <Box sx={{ flex: { xs: 1, md: 3, lg: 2 } }}>
+                <Box sx={{ flex: { xs: 1, md: 3, lg: 2 }, display: viewMode === 'requests' ? 'none' : undefined }}>
                     <Paper
                         elevation={0}
                         sx={{
@@ -545,8 +651,8 @@ export default function DashboardPage() {
                 </Box>
             </Box>
 
-            {/* Stats Table */}
-            <ServiceStatsTable stats={stats} />
+            {/* Stats Table - hidden in requests view */}
+            {viewMode !== 'requests' && <ServiceStatsTable stats={stats} />}
         </Box>
     );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -27,7 +27,7 @@ import { IconCoin, IconActivity, IconReload } from '@tabler/icons-react';
 const PaidIcon = tablerMui(IconCoin);
 const StreamIcon = tablerMui(IconActivity);
 const CachedIcon = tablerMui(IconReload);
-import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestScatterChart } from '@/components/dashboard';
+import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView } from '@/components/dashboard';
 import type { TimeSeriesData, AggregatedStat, UsageRecord } from '@/components/dashboard';
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import PageHeader from '@/components/PageHeader';
@@ -462,7 +462,7 @@ export default function DashboardPage() {
                                 <DailyTokenHistoryChart data={timeSeries} />
                             )
                         ) : (
-                            <RequestScatterChart records={records} loading={recordsLoading} />
+                            <RequestsView records={records} loading={recordsLoading} />
                         )}
                     </Box>
                 </Box>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -27,7 +27,7 @@ import { IconCoin, IconActivity, IconReload } from '@tabler/icons-react';
 const PaidIcon = tablerMui(IconCoin);
 const StreamIcon = tablerMui(IconActivity);
 const CachedIcon = tablerMui(IconReload);
-import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsTable } from '@/components/dashboard';
+import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestScatterChart } from '@/components/dashboard';
 import type { TimeSeriesData, AggregatedStat, UsageRecord } from '@/components/dashboard';
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import PageHeader from '@/components/PageHeader';
@@ -120,11 +120,7 @@ export default function DashboardPage() {
     // By-request view state
     const [viewMode, setViewMode] = useState<'summary' | 'requests'>('summary');
     const [records, setRecords] = useState<UsageRecord[]>([]);
-    const [recordsTotal, setRecordsTotal] = useState(0);
-    const [recordsPage, setRecordsPage] = useState(0);
-    const [recordsLimit, setRecordsLimit] = useState(50);
     const [recordsLoading, setRecordsLoading] = useState(false);
-    const [statusFilter, setStatusFilter] = useState<'all' | 'success' | 'error'>('all');
     const [recordsTimeParams, setRecordsTimeParams] = useState<{ start_time: string; end_time: string } | null>(null);
 
     const buildTimeParams = useCallback((provider: string, range: TimeRange) => {
@@ -189,9 +185,6 @@ export default function DashboardPage() {
     const loadRecords = useCallback(async (
         timeParams: { start_time: string; end_time: string } | null,
         provider: string,
-        status: 'all' | 'success' | 'error',
-        page: number,
-        limit: number,
     ) => {
         if (!timeParams) return;
         setRecordsLoading(true);
@@ -199,13 +192,11 @@ export default function DashboardPage() {
             const result = await api.getUsageRecords({
                 ...timeParams,
                 ...(provider !== 'all' ? { provider } : {}),
-                ...(status !== 'all' ? { status } : {}),
-                limit,
-                offset: page * limit,
+                limit: 500,
+                offset: 0,
             });
             if (result?.data) {
                 setRecords(result.data);
-                setRecordsTotal(result.meta?.total ?? 0);
             }
         } catch (error) {
             console.error('Failed to load records:', error);
@@ -225,31 +216,24 @@ export default function DashboardPage() {
         }
     }, [isHourlyRange]);
 
-    // Load records when entering requests view
+    // Load records when entering requests view or time/provider changes
     useEffect(() => {
         if (viewMode === 'requests') {
-            setRecordsPage(0);
-            loadRecords(recordsTimeParams, selectedProvider, statusFilter, 0, recordsLimit);
+            loadRecords(recordsTimeParams, selectedProvider);
         }
-    }, [viewMode, recordsTimeParams, selectedProvider, statusFilter, recordsLimit, loadRecords]);
-
-    useEffect(() => {
-        if (viewMode === 'requests') {
-            loadRecords(recordsTimeParams, selectedProvider, statusFilter, recordsPage, recordsLimit);
-        }
-    }, [recordsPage]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [viewMode, recordsTimeParams, selectedProvider, loadRecords]);
 
     useEffect(() => {
         if (autoRefresh) {
             const interval = setInterval(() => {
                 loadData(selectedProvider, timeRange);
                 if (viewMode === 'requests') {
-                    loadRecords(recordsTimeParams, selectedProvider, statusFilter, recordsPage, recordsLimit);
+                    loadRecords(recordsTimeParams, selectedProvider);
                 }
             }, 60000);
             return () => clearInterval(interval);
         }
-    }, [autoRefresh, loadData, selectedProvider, timeRange, viewMode, loadRecords, recordsTimeParams, statusFilter, recordsPage, recordsLimit]);
+    }, [autoRefresh, loadData, selectedProvider, timeRange, viewMode, loadRecords, recordsTimeParams]);
 
     const handleRefresh = () => {
         setRefreshing(true);
@@ -478,29 +462,13 @@ export default function DashboardPage() {
                                 <DailyTokenHistoryChart data={timeSeries} />
                             )
                         ) : (
-                            <RequestsTable
-                                records={records}
-                                total={recordsTotal}
-                                page={recordsPage}
-                                rowsPerPage={recordsLimit}
-                                statusFilter={statusFilter}
-                                loading={recordsLoading}
-                                onPageChange={(p) => setRecordsPage(p)}
-                                onRowsPerPageChange={(limit) => {
-                                    setRecordsLimit(limit);
-                                    setRecordsPage(0);
-                                }}
-                                onStatusFilterChange={(s) => {
-                                    setStatusFilter(s);
-                                    setRecordsPage(0);
-                                }}
-                            />
+                            <RequestScatterChart records={records} loading={recordsLoading} />
                         )}
                     </Box>
                 </Box>
 
                 {/* Right Column (20%) - Token Usage List */}
-                <Box sx={{ flex: { xs: 1, md: 3, lg: 2 }, display: viewMode === 'requests' ? 'none' : undefined }}>
+                <Box sx={{ flex: { xs: 1, md: 3, lg: 2 } }}>
                     <Paper
                         elevation={0}
                         sx={{
@@ -651,8 +619,8 @@ export default function DashboardPage() {
                 </Box>
             </Box>
 
-            {/* Stats Table - hidden in requests view */}
-            {viewMode !== 'requests' && <ServiceStatsTable stats={stats} />}
+            {/* Stats Table */}
+            <ServiceStatsTable stats={stats} />
         </Box>
     );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -913,6 +913,40 @@ export const api = {
         }
     },
 
+    getUsageRecords: async (params: {
+        start_time?: string;
+        end_time?: string;
+        provider?: string;
+        model?: string;
+        scenario?: string;
+        status?: string;
+        limit?: number;
+        offset?: number;
+    } = {}): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.GET('/api/v1/usage/records', {
+                headers,
+                params: {
+                    query: {
+                        start_time: params.start_time,
+                        end_time: params.end_time,
+                        provider: params.provider,
+                        model: params.model,
+                        scenario: params.scenario,
+                        status: params.status as any,
+                        limit: params.limit,
+                        offset: params.offset,
+                    }
+                }
+            });
+            return response.data;
+        } catch (error: any) {
+            return {success: false, error: error.message};
+        }
+    },
+
     // ============================================
     // OAuth API
     // ============================================

--- a/internal/server/module/usage/handler.go
+++ b/internal/server/module/usage/handler.go
@@ -219,6 +219,7 @@ func (h *Handler) GetRecords(c *gin.Context) {
 			Status:           r.Status,
 			ErrorCode:        r.ErrorCode,
 			LatencyMs:        r.LatencyMs,
+			TTFTMs:           r.TTFTMs,
 			Streamed:         r.Streamed,
 		}
 	}

--- a/internal/server/module/usage/types.go
+++ b/internal/server/module/usage/types.go
@@ -121,6 +121,7 @@ type UsageRecordResponse struct {
 	Status           string `json:"status" example:"success"`
 	ErrorCode        string `json:"error_code,omitempty"`
 	LatencyMs        int    `json:"latency_ms" example:"1200"`
+	TTFTMs           int    `json:"ttft_ms" example:"180"`
 	Streamed         bool   `json:"streamed" example:"true"`
 }
 


### PR DESCRIPTION
## Summary
Adds a new "Requests" view to the dashboard that displays individual API request records with detailed metrics, charts, and filtering capabilities. This complements the existing summary statistics view and provides granular visibility into request-level performance and token usage.

## Key Changes

### New Components
- **RequestsView.tsx** – Main container component for the requests view, featuring:
  - Token breakdown donut chart (input/output/cache tokens)
  - Latency distribution histogram with success/error breakdown
  - Detailed request table with pagination and status filtering
  - Toggle between latency and TTFT (time-to-first-token) metrics

- **RequestsTable.tsx** – Reusable table component displaying individual requests with:
  - Timestamp, provider/model, scenario columns
  - Token counts (input, output, cache) with formatted display
  - Latency with color-coded severity (green/yellow/red)
  - Status and streaming indicators
  - Pagination and status filtering (all/success/error)

- **RequestScatterChart.tsx** – Time-series scatter plot showing:
  - Requests plotted over time with toggleable Y-axis (tokens vs. latency)
  - Success/error status visualization with legend toggles
  - Interactive tooltips with detailed request metadata

### Dashboard Integration
- **DashboardPage.tsx** – Added:
  - View mode toggle between "Summary" and "Requests"
  - Records loading logic with time range and provider filtering
  - State management for request records and loading states
  - Time parameter calculation for API queries

### API & Mock Data
- **api.ts** – New `getUsageRecords()` method to fetch paginated request records with filtering
- **handlers.ts** – Mock endpoint `/api/v1/usage/records` generating realistic request data with:
  - Multiple providers (Anthropic, OpenAI, OpenRouter)
  - Varied latencies and token counts
  - Error simulation (~5% error rate)
  - Streaming indicators

### Exports
- **dashboard/index.ts** – Exported `RequestsView` and `UsageRecord` type for public use

## Implementation Details
- Uses Recharts for charts (donut, histogram, scatter) with theme-aware styling
- Implements latency bucketing (6 buckets from <0.2s to >5s) for histogram
- Token formatting with K/M suffixes for readability
- Responsive layout with proper loading states and empty states
- Follows existing dashboard styling patterns (Paper, Typography, MUI components)
- TTFT metric support with note about backend field exposure

https://claude.ai/code/session_01TC35eijGRrcWfbyEJfDKrK