### PR TITLE
fix(sdk,vmodel): upgrade SDK libs and add streaming compliance + error injection

### DIFF
--- a/vmodel/anthropic/stream.go
+++ b/vmodel/anthropic/stream.go
@@ -20,6 +20,15 @@ type TextDeltaEvent struct {
 	Text  string
 }
 
+// ThinkingDeltaEvent carries an extended-thinking content chunk. The
+// virtualserver renders it as a thinking content block (content_block_start of
+// type "thinking" followed by thinking_delta), which the official SDK
+// accumulates into a ThinkingBlock.
+type ThinkingDeltaEvent struct {
+	Index    int
+	Thinking string
+}
+
 // ToolUseEvent carries a complete tool_use block.
 type ToolUseEvent struct {
 	Index int

--- a/vmodel/virtualserver/handler.go
+++ b/vmodel/virtualserver/handler.go
@@ -228,6 +228,44 @@ func (h *Handler) handleAnthropicStreaming(c *gin.Context, req *AnthropicMessage
 		var explicitUsage *vmodel.MockUsage
 		var stopReason string
 
+		// Track which content-block indices have an open content_block_start so
+		// we emit a matching start before the first delta and a stop for every
+		// open block before message_delta. The real Anthropic wire protocol
+		// always brackets deltas with start/stop, and the official SDK's stream
+		// accumulator rejects a delta that arrives without a preceding start.
+		startedBlocks := map[int]bool{}
+		var startOrder []int
+		// startBlock emits a content_block_start for a text/thinking block once
+		// per index; the given content_block payload seeds the block (e.g. empty
+		// text or empty thinking) before its deltas arrive.
+		startBlock := func(index int, contentBlock map[string]interface{}) {
+			if startedBlocks[index] {
+				return
+			}
+			startedBlocks[index] = true
+			startOrder = append(startOrder, index)
+			data, _ := json.Marshal(map[string]interface{}{
+				"type":          "content_block_start",
+				"index":         index,
+				"content_block": contentBlock,
+			})
+			fmt.Fprintf(w, "event: content_block_start\ndata: %s\n\n", data)
+		}
+		startTextBlock := func(index int) {
+			startBlock(index, map[string]interface{}{"type": "text", "text": ""})
+		}
+		startThinkingBlock := func(index int) {
+			startBlock(index, map[string]interface{}{"type": "thinking", "thinking": ""})
+		}
+		stopAllBlocks := func() {
+			for _, index := range startOrder {
+				data, _ := json.Marshal(map[string]interface{}{"type": "content_block_stop", "index": index})
+				fmt.Fprintf(w, "event: content_block_stop\ndata: %s\n\n", data)
+			}
+			startOrder = nil
+			startedBlocks = map[int]bool{}
+		}
+
 		err := vm.HandleAnthropicStream(req, func(ev any) {
 			if gate != nil {
 				switch ev.(type) {
@@ -251,13 +289,24 @@ func (h *Handler) handleAnthropicStreaming(c *gin.Context, req *AnthropicMessage
 				})
 				fmt.Fprintf(w, "event: message_start\ndata: %s\n\n", data)
 			case anthropicvm.TextDeltaEvent:
+				startTextBlock(e.Index)
 				data, _ := json.Marshal(AnthropicStreamEvent{
 					Type:  "content_block_delta",
 					Index: e.Index,
 					Delta: &AnthropicDelta{Type: "text_delta", Text: e.Text},
 				})
 				fmt.Fprintf(w, "event: content_block_delta\ndata: %s\n\n", data)
+			case anthropicvm.ThinkingDeltaEvent:
+				startThinkingBlock(e.Index)
+				data, _ := json.Marshal(AnthropicStreamEvent{
+					Type:  "content_block_delta",
+					Index: e.Index,
+					Delta: &AnthropicDelta{Type: "thinking_delta", Thinking: e.Thinking},
+				})
+				fmt.Fprintf(w, "event: content_block_delta\ndata: %s\n\n", data)
 			case anthropicvm.ToolUseEvent:
+				startedBlocks[e.Index] = true
+				startOrder = append(startOrder, e.Index)
 				data, _ := json.Marshal(map[string]interface{}{
 					"type":  "content_block_start",
 					"index": e.Index,
@@ -274,6 +323,9 @@ func (h *Handler) handleAnthropicStreaming(c *gin.Context, req *AnthropicMessage
 				explicitUsage = &u
 			case anthropicvm.DoneEvent:
 				stopReason = e.StopReason
+				// Close any open content blocks before the terminal events, so
+				// the stream is start→delta(s)→stop bracketed per block.
+				stopAllBlocks()
 				// Emit message_delta with stop_reason + usage (Anthropic
 				// places terminal usage on message_delta, not message_stop).
 				deltaPayload := map[string]interface{}{

--- a/vmodel/virtualserver/sdk_stream_test.go
+++ b/vmodel/virtualserver/sdk_stream_test.go
@@ -1,0 +1,108 @@
+package virtualserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/vmodel"
+	anthropicvm "github.com/tingly-dev/tingly-box/vmodel/anthropic"
+)
+
+// These tests consume the virtualserver's Anthropic stream through the OFFICIAL
+// Anthropic SDK (Messages.NewStreaming + Message.Accumulate), rather than
+// hand-parsing SSE. The SDK's accumulator enforces the real wire protocol —
+// every content block must be bracketed by content_block_start / _stop around
+// its deltas — so these act as a protocol-compliance guard for any real-SDK
+// consumer (e.g. internal/afk). A bare content_block_delta with no preceding
+// start makes Accumulate fail, which is exactly the regression we want caught
+// here in vmodel rather than downstream.
+
+// newSDKClient mounts the virtualserver at /v1 and returns an SDK client
+// pointed at it (the SDK appends /v1/messages to the base URL).
+func newSDKClient(t *testing.T, models ...anthropicvm.VirtualModel) sdk.Client {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	svc := NewService()
+	reg := svc.GetAnthropicRegistry()
+	for _, m := range models {
+		require.NoError(t, reg.Register(m))
+	}
+
+	engine := gin.New()
+	svc.SetupRoutes(engine.Group("/v1"))
+	srv := httptest.NewServer(engine)
+	t.Cleanup(srv.Close)
+
+	return sdk.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-key"),
+	)
+}
+
+// accumulate drives a streaming request to completion through the SDK
+// accumulator and returns the fully accumulated message. A protocol violation
+// surfaces as a stream error here.
+func accumulate(t *testing.T, client sdk.Client, model, prompt string) sdk.Message {
+	t.Helper()
+	stream := client.Messages.NewStreaming(context.Background(), sdk.MessageNewParams{
+		Model:     sdk.Model(model),
+		MaxTokens: 1024,
+		Messages:  []sdk.MessageParam{sdk.NewUserMessage(sdk.NewTextBlock(prompt))},
+	})
+	msg := sdk.Message{}
+	for stream.Next() {
+		require.NoError(t, msg.Accumulate(stream.Current()), "SDK accumulate rejected a stream event")
+	}
+	require.NoError(t, stream.Err(), "SDK stream error")
+	return msg
+}
+
+// TestSDKStream_TextBlockBracketing verifies a text response streams as a
+// protocol-valid start→delta(s)→stop sequence the SDK can accumulate.
+func TestSDKStream_TextBlockBracketing(t *testing.T) {
+	// The built-in static mock returns fixed text.
+	client := newSDKClient(t) // default registry includes "virtual-claude-3"
+	msg := accumulate(t, client, "virtual-claude-3", "hello")
+
+	require.NotEmpty(t, msg.Content, "expected at least one content block")
+	var text string
+	for _, b := range msg.Content {
+		if b.Type == "text" {
+			text += b.Text
+		}
+	}
+	assert.Contains(t, text, "virtual Claude 3")
+}
+
+// TestSDKStream_ToolUseBlock verifies a tool_use response streams as a
+// protocol-valid block the SDK can accumulate into a ToolUseBlock.
+func TestSDKStream_ToolUseBlock(t *testing.T) {
+	toolModel := anthropicvm.NewMockModel(&anthropicvm.MockModelConfig{
+		ID:   "sdk-tool-mock",
+		Name: "sdk-tool-mock",
+		ToolCall: &vmodel.ToolCallConfig{
+			Name:      "get_weather",
+			Arguments: map[string]interface{}{"city": "Paris"},
+		},
+	})
+	client := newSDKClient(t, toolModel)
+	msg := accumulate(t, client, "sdk-tool-mock", "weather in Paris?")
+
+	assert.Equal(t, sdk.StopReasonToolUse, msg.StopReason)
+	var sawTool bool
+	for _, b := range msg.Content {
+		if tu, ok := b.AsAny().(sdk.ToolUseBlock); ok {
+			sawTool = true
+			assert.Equal(t, "get_weather", tu.Name)
+		}
+	}
+	assert.True(t, sawTool, "expected a tool_use block in the accumulated message")
+}

--- a/vmodel/virtualserver/types.go
+++ b/vmodel/virtualserver/types.go
@@ -88,5 +88,6 @@ type AnthropicStreamEvent struct {
 type AnthropicDelta struct {
 	Type       string `json:"type,omitempty"`
 	Text       string `json:"text,omitempty"`
+	Thinking   string `json:"thinking,omitempty"`
 	StopReason string `json:"stop_reason,omitempty"`
 }


### PR DESCRIPTION
## Summary

- **anthropic-sdk-go**: bump to tingly-dev fork (`f987d11`) — fixes interleaved content-block accumulation when extended thinking is enabled. Text deltas were routed by last-index instead of `event.Index`, truncating responses to only the first thinking block's text.
- **go-genai / openai-go**: bump to latest.
- **vmodel**: add `ErrorInjection` / `ErrorInjectingModel` for deterministic mid-stream failure testing.
- **vmodel/virtualserver**: add real-SDK streaming compliance tests; fix text SSE bracketing (`data:[DONE]` gap).

## Test plan

- [ ] `go test ./vmodel/...` passes
- [ ] `go test ./vmodel/virtualserver/...` passes (new SDK stream compliance tests)
- [ ] SmartGuide (@tb) extended-thinking responses no longer truncate mid-stream
