### PR TITLE
fix(agent, cc): handle CC v2.1+ stream events, HEAD preflight, and proxy 502s

### DIFF
--- a/agentboot/claude/accumulator.go
+++ b/agentboot/claude/accumulator.go
@@ -103,6 +103,20 @@ func (a *MessageAccumulator) AddEvent(event common.Event) ([]Message, bool, bool
 			a.messages = append(a.messages, msg)
 			newMessages = append(newMessages, msg)
 		}
+
+	case SDKRateLimitEvent,
+		SDKHookStartedMessage, SDKHookProgressMessage, SDKHookResponseMessage,
+		SDKPostTurnSummaryMessage,
+		SDKPartialAssistantMessage, SDKCompactBoundaryMessage,
+		SDKStatusMessage, SDKLocalCommandOutputMessage,
+		SDKToolProgressMessage, SDKAuthStatusMessage,
+		SDKFilesPersistedMessage, SDKToolUseSummaryMessage,
+		SDKPromptSuggestionMessage, SDKTaskProgressMessage,
+		SDKUserMessageReplayMessage:
+		// Infrastructure / housekeeping events emitted by the CLI that carry no
+		// user-facing content. Consume them here so they don't fall through to
+		// the default and produce spurious log noise. Their raw JSON is still
+		// logged at the runner level for diagnostics.
 	}
 
 	return newMessages, hasResult, resultSuccess

--- a/agentboot/claude/accumulator.go
+++ b/agentboot/claude/accumulator.go
@@ -196,6 +196,13 @@ func (a *MessageAccumulator) parseSystemMessage(event common.Event) *SystemMessa
 	if err := unmarshalEvent(event, &msg); err != nil {
 		return nil
 	}
+	// Preserve the full payload so forward-compatible fields (notably the
+	// api_retry/rate_limit metadata, whose names vary by CLI version) survive
+	// for formatting and logging instead of being stripped to the typed fields.
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(event.Raw), &raw); err == nil {
+		msg.Raw = raw
+	}
 	if msg.SessionID != "" {
 		a.sessionID = msg.SessionID
 	}

--- a/agentboot/claude/constant.go
+++ b/agentboot/claude/constant.go
@@ -61,6 +61,13 @@ const SDKControlPrefix = "control_"
 const (
 	SystemSubtypeInit          = "init"
 	SystemSubtypeTaskCompleted = "task_completed"
+	// SystemSubtypeAPIRetry is emitted by the Claude Code CLI when an upstream
+	// API call fails with a retryable error (overload, rate limit, transient
+	// network) and the CLI automatically retries. Surfacing it tells the user
+	// why the agent appears to stall instead of leaving a silent gap.
+	SystemSubtypeAPIRetry = "api_retry"
+	// SystemSubtypeRateLimit is emitted when the CLI is rate limited upstream.
+	SystemSubtypeRateLimit = "rate_limit"
 )
 
 // assistant message error

--- a/agentboot/claude/constant.go
+++ b/agentboot/claude/constant.go
@@ -51,8 +51,12 @@ const (
 	SDKTaskProgressMessage       = "task_progress"
 	SDKFilesPersistedMessage     = "files_persisted"
 	SDKToolUseSummaryMessage     = "tool_use_summary"
-	SDKRateLimitMessage          = "rate_limit"
-	SDKPromptSuggestionMessage   = "prompt_suggestion"
+	// SDKRateLimitEvent is the top-level type emitted by CC v2.1+ when the
+	// upstream rate-limit state changes. The old name was "rate_limit" but the
+	// actual wire value observed in v2.1.157 is "rate_limit_event".
+	SDKRateLimitEvent          = "rate_limit_event"
+	SDKPromptSuggestionMessage = "prompt_suggestion"
+	SDKPostTurnSummaryMessage  = "post_turn_summary"
 )
 
 const SDKControlPrefix = "control_"

--- a/agentboot/claude/formatter.go
+++ b/agentboot/claude/formatter.go
@@ -136,10 +136,43 @@ func (f *TextFormatter) formatSystem(m *SystemMessage) string {
 			b.WriteString(m.Timestamp.Format("2006-01-02 15:04:05"))
 		}
 		return b.String()
+	case SystemSubtypeAPIRetry:
+		return f.formatRetryNotice(m, "Retrying API request")
+	case SystemSubtypeRateLimit:
+		return f.formatRetryNotice(m, "Rate limited, waiting")
 	default:
 		logrus.Debugf("system message, subtype: %s", m.SubType)
 		return ""
 	}
+}
+
+// formatRetryNotice renders an api_retry/rate_limit system notice. The CLI
+// emits these while an upstream call is being retried; surfacing them tells the
+// user why the agent is pausing instead of leaving a silent gap. lead is the
+// human-readable action ("Retrying API request", "Rate limited, waiting").
+func (f *TextFormatter) formatRetryNotice(m *SystemMessage, lead string) string {
+	var b strings.Builder
+	b.WriteString("[RETRY] ")
+	b.WriteString(lead)
+	if n := m.retryAttempt(); n > 0 {
+		fmt.Fprintf(&b, " (attempt %d)", n)
+	}
+	if d := m.retryDelayMS(); d > 0 {
+		fmt.Fprintf(&b, ", retry in %s", formatRetryDelay(d))
+	}
+	if reason := m.retryReason(); reason != "" {
+		b.WriteString(": ")
+		b.WriteString(reason)
+	}
+	return b.String()
+}
+
+// formatRetryDelay renders a millisecond delay as a compact human string.
+func formatRetryDelay(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%.1fs", float64(ms)/1000)
 }
 
 func (f *TextFormatter) formatTaskStarted(m *SystemMessage) string {

--- a/agentboot/claude/formatter_test.go
+++ b/agentboot/claude/formatter_test.go
@@ -47,6 +47,54 @@ func TestTextFormatter_FormatSystemMessage(t *testing.T) {
 	}
 }
 
+func TestTextFormatter_FormatAPIRetry(t *testing.T) {
+	formatter := NewTextFormatter()
+
+	// Typed fields populated (e.g. decoded into the struct directly).
+	typed := &SystemMessage{
+		Type:    SDKSystemMessage,
+		SubType: SystemSubtypeAPIRetry,
+		Attempt: 2,
+		DelayMS: 1500,
+		Error:   "Overloaded",
+	}
+	out := formatter.Format(typed)
+	if out == "" {
+		t.Fatal("Expected non-empty output for api_retry system message")
+	}
+	for _, want := range []string{"[RETRY]", "attempt 2", "1.5s", "Overloaded"} {
+		if !contains(out, want) {
+			t.Errorf("Expected %q in output: %s", want, out)
+		}
+	}
+
+	// Fields only present in Raw under a camelCase spelling the struct does not
+	// declare: the accessors must still find them.
+	rawOnly := &SystemMessage{
+		Type:    SDKSystemMessage,
+		SubType: SystemSubtypeAPIRetry,
+		Raw: map[string]interface{}{
+			"type":    "system",
+			"subtype": "api_retry",
+			"retry":   float64(3),
+			"delayMs": float64(800),
+			"message": "rate_limit_error",
+		},
+	}
+	out = formatter.Format(rawOnly)
+	for _, want := range []string{"attempt 3", "800ms", "rate_limit_error"} {
+		if !contains(out, want) {
+			t.Errorf("Expected %q in output from Raw fallback: %s", want, out)
+		}
+	}
+
+	// rate_limit subtype renders with its own lead text.
+	rl := &SystemMessage{Type: SDKSystemMessage, SubType: SystemSubtypeRateLimit}
+	if out := formatter.Format(rl); !contains(out, "Rate limited") {
+		t.Errorf("Expected rate-limit lead in output: %s", out)
+	}
+}
+
 func TestTextFormatter_FormatAssistantMessage(t *testing.T) {
 	formatter := NewTextFormatter()
 	formatter.SetShowToolDetails(true)

--- a/agentboot/claude/launcher_test.go
+++ b/agentboot/claude/launcher_test.go
@@ -32,6 +32,38 @@ func TestLauncherType(t *testing.T) {
 	assert.Equal(t, agentboot.AgentTypeClaude, launcher.Type())
 }
 
+// TestMessageAccumulator_APIRetryPreservesRaw verifies that an api_retry system
+// message keeps its retry metadata (which the typed struct does not declare by
+// name) in Raw, so GetRawData reports the full payload and the retry accessors
+// can read it.
+func TestMessageAccumulator_APIRetryPreservesRaw(t *testing.T) {
+	accumulator := NewMessageAccumulator()
+
+	raw := `{"type":"system","subtype":"api_retry","session_id":"s-1","attempt":2,"delayMs":1200,"error":"Overloaded"}`
+	ev := common.Event{
+		Type:      SDKSystemMessage,
+		Raw:       raw,
+		Timestamp: time.Now(),
+	}
+	messages, _, _ := accumulator.AddEvent(ev)
+	require.Len(t, messages, 1)
+
+	sm, ok := messages[0].(*SystemMessage)
+	require.True(t, ok, "should be SystemMessage")
+	assert.Equal(t, SystemSubtypeAPIRetry, sm.SubType)
+
+	// GetRawData must expose the original payload, including fields the struct
+	// does not declare (delayMs in camelCase).
+	data := sm.GetRawData()
+	assert.Equal(t, "api_retry", data["subtype"])
+	assert.Contains(t, data, "delayMs")
+
+	// Accessors resolve both typed and Raw-only spellings.
+	assert.Equal(t, 2, sm.retryAttempt())
+	assert.Equal(t, int64(1200), sm.retryDelayMS())
+	assert.Equal(t, "Overloaded", sm.retryReason())
+}
+
 // TestMessageAccumulator tests the message accumulator
 func TestMessageAccumulator(t *testing.T) {
 	accumulator := NewMessageAccumulator()

--- a/agentboot/claude/messages.go
+++ b/agentboot/claude/messages.go
@@ -33,6 +33,22 @@ type SystemMessage struct {
 	TaskID      string `json:"task_id,omitempty"`
 	TaskType    string `json:"task_type,omitempty"`
 	ToolUseID   string `json:"tool_use_id,omitempty"`
+
+	// Retry / rate-limit fields (populated when SubType is api_retry/rate_limit).
+	// The CLI's exact field spelling has shifted across versions, so the typed
+	// fields below are best-effort; the retry* accessors fall back to Raw.
+	Attempt    int    `json:"attempt,omitempty"`
+	MaxRetries int    `json:"max_retries,omitempty"`
+	DelayMS    int64  `json:"delay_ms,omitempty"`
+	Error      string `json:"error,omitempty"`
+	Message    string `json:"message,omitempty"`
+
+	// Raw preserves the full decoded payload. The typed fields above only
+	// capture the names known at compile time; Raw keeps everything else so
+	// forward-compatible fields (notably the retry metadata, whose names vary
+	// by CLI version) survive for formatting and logging. Populated by
+	// parseSystemMessage; nil for messages built in code.
+	Raw map[string]interface{} `json:"-"`
 }
 
 // GetType implements Message
@@ -45,9 +61,44 @@ func (m *SystemMessage) GetTimestamp() time.Time {
 	return m.Timestamp
 }
 
-// GetRawData implements Message
+// GetRawData implements Message. When the message was decoded from the wire it
+// returns the full original payload (so unknown fields are not lost); otherwise
+// it falls back to marshalling the typed struct.
 func (m *SystemMessage) GetRawData() map[string]interface{} {
+	if m.Raw != nil {
+		return m.Raw
+	}
 	return marshalToMap(m)
+}
+
+// retryAttempt returns the retry attempt number for an api_retry/rate_limit
+// notice, checking the typed field first and then Raw under the spellings the
+// CLI has used (snake_case and camelCase).
+func (m *SystemMessage) retryAttempt() int {
+	if m.Attempt > 0 {
+		return m.Attempt
+	}
+	return intFromMap(m.Raw, "attempt", "retry", "retries", "retryCount", "retry_count")
+}
+
+// retryDelayMS returns the delay before the next attempt, in milliseconds.
+func (m *SystemMessage) retryDelayMS() int64 {
+	if m.DelayMS > 0 {
+		return m.DelayMS
+	}
+	return int64(intFromMap(m.Raw, "delay_ms", "delayMs", "delayMS", "retry_after_ms", "retryAfterMs"))
+}
+
+// retryReason returns a human-readable reason for the retry, if the CLI
+// included one.
+func (m *SystemMessage) retryReason() string {
+	if m.Error != "" {
+		return m.Error
+	}
+	if m.Message != "" {
+		return m.Message
+	}
+	return stringFromMap(m.Raw, "error", "message", "reason", "errorType", "error_type")
 }
 
 // AssistantMessage represents assistant messages with content blocks

--- a/agentboot/claude/utils.go
+++ b/agentboot/claude/utils.go
@@ -81,3 +81,24 @@ func getBool(m map[string]interface{}, key string) bool {
 	}
 	return false
 }
+
+// intFromMap returns the first non-zero int found under any of keys. It exists
+// for forward-compatible fields whose spelling varies across CLI versions.
+func intFromMap(m map[string]interface{}, keys ...string) int {
+	for _, k := range keys {
+		if v := getInt(m, k); v != 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// stringFromMap returns the first non-empty string found under any of keys.
+func stringFromMap(m map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		if v := getString(m, k); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/frontend/src/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/components/ClaudeCodeQuickConfig.tsx
@@ -39,11 +39,15 @@ export interface ClaudeCodePrefs {
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC?: string;
     DISABLE_AUTOUPDATER?: string;
     USE_BUILTIN_RIPGREP?: string;
+
+    HTTP_PROXY?: string;
+    HTTPS_PROXY?: string;
+    NO_PROXY?: string;
 }
 
 type PrefsKey = keyof ClaudeCodePrefs;
-type Group = 'model' | 'limits' | 'switches';
-type Kind = 'model' | 'int' | 'bool';
+type Group = 'model' | 'limits' | 'switches' | 'network';
+type Kind = 'model' | 'int' | 'text' | 'bool';
 type Lang = 'zh' | 'en';
 
 // ── Field structure (language-agnostic) ────────────────────────────────
@@ -79,6 +83,10 @@ const FIELD_STRUCT: FieldStruct[] = [
     { envName: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', group: 'switches', kind: 'bool' },
     { envName: 'DISABLE_AUTOUPDATER', group: 'switches', kind: 'bool' },
     { envName: 'USE_BUILTIN_RIPGREP', group: 'switches', kind: 'bool' },
+    // Network proxy
+    { envName: 'HTTP_PROXY', group: 'network', kind: 'text' },
+    { envName: 'HTTPS_PROXY', group: 'network', kind: 'text' },
+    { envName: 'NO_PROXY', group: 'network', kind: 'text' },
 ];
 
 // ── Localized text bundles ─────────────────────────────────────────────
@@ -199,6 +207,24 @@ const FIELDS_TEXT_ZH: FieldTextMap = {
         purpose: 'Claude Code 自带的 ripgrep 优先于系统 PATH',
         tooltip: '官方默认开启。仅在需要用系统自定义 ripgrep 时关闭。',
     },
+    HTTP_PROXY: {
+        label: 'HTTP 代理',
+        purpose: 'Claude Code 发出 HTTP 请求时使用的代理地址',
+        tooltip: '格式：http://host:port。留空则继承系统代理设置。注意：系统代理不会自动排除 localhost，可能导致向本地网关发起的请求被代理拦截而 502。',
+        placeholder: 'http://proxy.example.com:8080',
+    },
+    HTTPS_PROXY: {
+        label: 'HTTPS 代理',
+        purpose: 'Claude Code 发出 HTTPS 请求时使用的代理地址',
+        tooltip: '格式：http://host:port 或 https://host:port。留空则继承系统代理设置。',
+        placeholder: 'http://proxy.example.com:8080',
+    },
+    NO_PROXY: {
+        label: '代理排除列表',
+        purpose: '不走代理的主机/域名列表',
+        tooltip: '逗号分隔，如 "localhost,127.0.0.1,::1"。tb 启动时会自动把 localhost/127.0.0.1/::1 追加进来，即使此处留空也会生效。建议留空（由 tb 自动管理），仅在需要额外排除内网域名时填写。',
+        placeholder: 'localhost,127.0.0.1,::1',
+    },
 };
 
 const FIELDS_TEXT_EN: FieldTextMap = {
@@ -305,6 +331,24 @@ const FIELDS_TEXT_EN: FieldTextMap = {
         purpose: "Prefer Claude Code's bundled ripgrep over system PATH",
         tooltip: "On by default. Disable only if you need to use a custom system ripgrep.",
     },
+    HTTP_PROXY: {
+        label: 'HTTP proxy',
+        purpose: 'Proxy used for outbound HTTP requests from Claude Code',
+        tooltip: 'Format: http://host:port. Leave blank to inherit system proxy settings. Note: system proxies do not automatically bypass localhost, which can cause 502s when proxying requests to the local tb gateway.',
+        placeholder: 'http://proxy.example.com:8080',
+    },
+    HTTPS_PROXY: {
+        label: 'HTTPS proxy',
+        purpose: 'Proxy used for outbound HTTPS requests from Claude Code',
+        tooltip: 'Format: http://host:port or https://host:port. Leave blank to inherit system proxy settings.',
+        placeholder: 'http://proxy.example.com:8080',
+    },
+    NO_PROXY: {
+        label: 'No-proxy list',
+        purpose: 'Comma-separated hosts that bypass the proxy',
+        tooltip: 'e.g. "localhost,127.0.0.1,::1". tb automatically appends localhost/127.0.0.1/::1 at startup even if left blank. Leave blank to let tb manage it automatically; only set this if you need to bypass additional internal hosts.',
+        placeholder: 'localhost,127.0.0.1,::1',
+    },
 };
 
 interface SectionText { title: string; hint: string }
@@ -323,6 +367,10 @@ const SECTION_TEXT_ZH: SectionTextMap = {
         title: '隐私与行为',
         hint: '开启 = 设置为 "1"；关闭 = 不写入。',
     },
+    network: {
+        title: '网络代理',
+        hint: '留空 = 不写入。tb 始终自动将 localhost/127.0.0.1/::1 追加到 NO_PROXY，无需手动设置。',
+    },
 };
 
 const SECTION_TEXT_EN: SectionTextMap = {
@@ -337,6 +385,10 @@ const SECTION_TEXT_EN: SectionTextMap = {
     switches: {
         title: 'Privacy & behavior',
         hint: 'On = set to "1"; Off = not written.',
+    },
+    network: {
+        title: 'Network proxy',
+        hint: 'Blank = not written. tb always appends localhost/127.0.0.1/::1 to NO_PROXY automatically — no manual entry needed.',
     },
 };
 
@@ -417,6 +469,19 @@ export const derivePrefsFromRules = ({ rules, mode }: DerivePrefsInput): ClaudeC
 // ── Materialize prefs to the env map the backend will write ────────────
 // Mirrors internal/agent/prefs.go ToEnv(): strip empties, inject the
 // server-resolved base URL + auth token.
+// appendNoProxy mirrors the Go appendNoProxy helper in internal/agent/prefs.go.
+const appendNoProxy = (current: string, ...hosts: string[]): string => {
+    const existing = new Set(current ? current.split(',').map(h => h.trim()) : []);
+    let result = current;
+    for (const h of hosts) {
+        if (!existing.has(h)) {
+            result = result ? result + ',' + h : h;
+            existing.add(h);
+        }
+    }
+    return result;
+};
+
 export const prefsToEnvPreview = (
     prefs: ClaudeCodePrefs,
     baseURL: string,
@@ -429,6 +494,8 @@ export const prefsToEnvPreview = (
     }
     out.ANTHROPIC_BASE_URL = baseURL.replace(/\/$/, '') + '/tingly/claude_code';
     out.ANTHROPIC_AUTH_TOKEN = token;
+    // Mirror Go's ToEnv(): always ensure localhost entries are in NO_PROXY
+    out.NO_PROXY = appendNoProxy(out.NO_PROXY ?? '', 'localhost', '127.0.0.1', '::1');
     return out;
 };
 
@@ -502,7 +569,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, text, oneMTooltip, prefs, se
                         onChange={(_, c) => setValue(c ? '1' : '')}
                     />
                 )}
-                {(field.kind === 'int' || field.kind === 'model') && (
+                {(field.kind === 'int' || field.kind === 'text' || field.kind === 'model') && (
                     <TextField
                         size="small"
                         value={field.kind === 'model' ? value.replace(/\[1m\]$/, '') : value}
@@ -511,7 +578,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, text, oneMTooltip, prefs, se
                             setValue(field.kind === 'model' && has1M(value) ? next + ONE_M_SUFFIX : next);
                         }}
                         placeholder={text.placeholder}
-                        sx={{ width: field.kind === 'model' ? 280 : 180 }}
+                        sx={{ width: field.kind === 'model' ? 280 : field.kind === 'text' ? 320 : 180 }}
                         InputProps={{
                             endAdornment: field.unit
                                 ? <InputAdornment position="end"><Typography variant="caption" color="text.disabled">{field.unit}</Typography></InputAdornment>
@@ -604,6 +671,7 @@ const ClaudeCodeQuickConfig: React.FC<QuickConfigPanelProps> = ({
             <Section group="model" lang={lang} prefs={prefs} setPrefs={setPrefs} />
             <Section group="limits" lang={lang} prefs={prefs} setPrefs={setPrefs} />
             <Section group="switches" lang={lang} prefs={prefs} setPrefs={setPrefs} />
+            <Section group="network" lang={lang} prefs={prefs} setPrefs={setPrefs} />
         </Box>
     );
 };

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -65,7 +65,36 @@ func (p ClaudeCodePrefs) ToEnv(baseURL, apiKey string) (map[string]string, error
 	}
 	env["ANTHROPIC_BASE_URL"] = strings.TrimRight(baseURL, "/") + "/tingly/claude_code"
 	env["ANTHROPIC_AUTH_TOKEN"] = apiKey
+
+	// If ANTHROPIC_BASE_URL points at localhost the user's system proxy must not
+	// intercept those calls — a proxy cannot reach loopback and will 502 every
+	// request. Append localhost/127.0.0.1 to NO_PROXY (preserving any existing
+	// entries the user may have set via the Extra or typed field).
+	noProxy := env["NO_PROXY"]
+	noProxy = appendNoProxy(noProxy, "localhost", "127.0.0.1", "::1")
+	env["NO_PROXY"] = noProxy
+
 	return env, nil
+}
+
+// appendNoProxy adds hosts to a NO_PROXY value, skipping duplicates.
+func appendNoProxy(current string, hosts ...string) string {
+	existing := make(map[string]bool)
+	if current != "" {
+		for _, h := range strings.Split(current, ",") {
+			existing[strings.TrimSpace(h)] = true
+		}
+	}
+	for _, h := range hosts {
+		if !existing[h] {
+			if current != "" {
+				current += ","
+			}
+			current += h
+			existing[h] = true
+		}
+	}
+	return current
 }
 
 // DefaultClaudeCodePrefs returns tb's canonical defaults for the given

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -42,11 +42,16 @@ func TestClaudeCodePrefs_ToEnv_EmptyOnlyInjectsServerKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToEnv: %v", err)
 	}
-	if len(env) != 2 {
-		t.Errorf("expected exactly 2 server-injected keys, got %d: %v", len(env), env)
+	// ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, and NO_PROXY are always
+	// injected (NO_PROXY bypasses any system proxy for the loopback gateway).
+	if len(env) != 3 {
+		t.Errorf("expected exactly 3 server-injected keys, got %d: %v", len(env), env)
 	}
 	mustEq(t, env, "ANTHROPIC_BASE_URL", "http://localhost:12580/tingly/claude_code")
 	mustEq(t, env, "ANTHROPIC_AUTH_TOKEN", "tok")
+	if env["NO_PROXY"] == "" {
+		t.Error("NO_PROXY must not be empty — loopback gateway must bypass system proxy")
+	}
 }
 
 // A fully-populated prefs should emit every typed env key. Catches future
@@ -272,6 +277,7 @@ func TestDefaultClaudeCodePrefs_Unified(t *testing.T) {
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 		"ANTHROPIC_BASE_URL":                       "http://localhost:12580/tingly/claude_code",
 		"ANTHROPIC_AUTH_TOKEN":                     "test-token",
+		"NO_PROXY":                                 "localhost,127.0.0.1,::1",
 	}
 	assertEnvMapsEqual(t, want, env)
 }
@@ -293,6 +299,7 @@ func TestDefaultClaudeCodePrefs_Separate(t *testing.T) {
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
 		"ANTHROPIC_BASE_URL":                       "http://localhost:12580/tingly/claude_code",
 		"ANTHROPIC_AUTH_TOKEN":                     "test-token",
+		"NO_PROXY":                                 "localhost,127.0.0.1,::1",
 	}
 	assertEnvMapsEqual(t, want, env)
 }

--- a/internal/remote_control/bot/bot_stream.go
+++ b/internal/remote_control/bot/bot_stream.go
@@ -236,9 +236,12 @@ func (h *streamingMessageHandler) handleClaudeMessage(claudeMsg claude.Message) 
 
 	// In quiet mode, only assistant text and final agent results reach the
 	// chat; user echoes, system events, and stream-event noise are dropped.
+	// api_retry / rate_limit notices are the exception: they explain why the
+	// agent is stalling on a slow upstream, so the user should see them even in
+	// quiet mode rather than staring at a silent gap.
 	if !h.verbose {
 		msgType := claudeMsg.GetType()
-		if msgType != "result" && msgType != "assistant" {
+		if msgType != "result" && msgType != "assistant" && !isRetryNotice(claudeMsg) {
 			logrus.WithField("msgType", msgType).Debug("Quiet mode: suppressing non-result message")
 			return nil
 		}
@@ -246,6 +249,17 @@ func (h *streamingMessageHandler) handleClaudeMessage(claudeMsg claude.Message) 
 
 	h.sendMessage(formatted)
 	return nil
+}
+
+// isRetryNotice reports whether the message is a Claude Code api_retry /
+// rate_limit system notice. These carry transient-failure status the user
+// should see even in quiet mode, so the agent doesn't appear to silently stall.
+func isRetryNotice(msg claude.Message) bool {
+	sm, ok := msg.(*claude.SystemMessage)
+	if !ok {
+		return false
+	}
+	return sm.SubType == claude.SystemSubtypeAPIRetry || sm.SubType == claude.SystemSubtypeRateLimit
 }
 
 // isToolOnlyClaudeMessage reports whether the message carries only tool

--- a/internal/remote_control/bot/bot_stream_aggregate_test.go
+++ b/internal/remote_control/bot/bot_stream_aggregate_test.go
@@ -179,6 +179,41 @@ func TestStreamingHandler_QuietSuppressedMessageStillFlushesBuffer(t *testing.T)
 	assert.Contains(t, sent[0], "2 tool call(s)")
 }
 
+func TestStreamingHandler_QuietSurfacesAPIRetry(t *testing.T) {
+	bot := &captureBot{}
+	meta := &ResponseMeta{}
+	h := newStreamingMessageHandler(bot, "chat-1", "reply-1", false, meta)
+
+	// An ordinary system message stays suppressed in quiet mode.
+	require.NoError(t, h.OnMessage(&claude.SystemMessage{
+		Type:      claude.SDKSystemMessage,
+		SubType:   claude.SystemSubtypeInit,
+		SessionID: "s-1",
+	}))
+	assert.Empty(t, bot.snapshot(), "init system message should stay quiet")
+
+	// An api_retry notice must reach the user even in quiet mode, so the agent
+	// does not appear to silently stall while the upstream is retried.
+	require.NoError(t, h.OnMessage(&claude.SystemMessage{
+		Type:    claude.SDKSystemMessage,
+		SubType: claude.SystemSubtypeAPIRetry,
+		Attempt: 1,
+		Error:   "Overloaded",
+	}))
+
+	sent := bot.snapshot()
+	require.Len(t, sent, 1, "api_retry should surface in quiet mode")
+	assert.Contains(t, sent[0], "RETRY")
+	assert.Contains(t, sent[0], "Overloaded")
+}
+
+func TestIsRetryNotice(t *testing.T) {
+	assert.True(t, isRetryNotice(&claude.SystemMessage{SubType: claude.SystemSubtypeAPIRetry}))
+	assert.True(t, isRetryNotice(&claude.SystemMessage{SubType: claude.SystemSubtypeRateLimit}))
+	assert.False(t, isRetryNotice(&claude.SystemMessage{SubType: claude.SystemSubtypeInit}))
+	assert.False(t, isRetryNotice(assistantText("hi")))
+}
+
 // --- Map-path handler tests (handleMapMessage). This is the production path
 // for the smart-guide agent, which streams status/assistant frames as plain
 // maps; tool aggregation must work here too, not only on the claude stream.

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -79,11 +79,16 @@ func (s *Server) UseAIEndpoints() {
 	scenario := s.engine.Group("/tingly/:scenario")
 	scenario.Use(s.contextMiddleware)
 	s.SetupMixinEndpoints(scenario)
+	// Claude Code v2.1+ sends HEAD <ANTHROPIC_BASE_URL> as a connectivity
+	// check before making any API call. Respond 200 so CC doesn't treat the
+	// missing route as a server error and spiral into api_retry storms.
+	scenario.HEAD("", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	// scenario v1 routes with middleware
 	scenarioV1 := s.engine.Group("/tingly/:scenario/v1")
 	scenarioV1.Use(s.contextMiddleware)
 	s.SetupMixinEndpoints(scenarioV1)
+	scenarioV1.HEAD("", func(c *gin.Context) { c.Status(http.StatusOK) })
 }
 
 func (s *Server) SetupMixinEndpoints(group *gin.RouterGroup) {


### PR DESCRIPTION
## Summary

Fix a cluster of Claude Code v2.1+ stream-handling regressions that caused `api_retry` storms, silent log noise, and 502 errors when a system HTTP proxy is active.

- **Surface `api_retry` / `rate_limit` notices** — previously silently dropped; now formatted as `[RETRY] Retrying API request (attempt N), retry in Xs: <reason>` and forwarded to the user in bot streams
- **Handle CC v2.1 event types silently** — `rate_limit_event`, `hook_started/response/progress`, `post_turn_summary`, `compact_boundary`, etc. were hitting an unhandled branch; now consumed as no-ops
- **HEAD preflight handler** — CC v2.1.157+ sends `HEAD <ANTHROPIC_BASE_URL>` before every session as a connectivity check; the missing route caused 404 → `api_retry` storm. Added `HEAD ""` returning 200 OK on both `/tingly/:scenario` and `/tingly/:scenario/v1`
- **Always inject `NO_PROXY=localhost,127.0.0.1,::1`** — when a user's system `HTTP_PROXY`/`HTTPS_PROXY` env vars are set, the proxy intercepts loopback requests to the local tb gateway and returns 502. `ToEnv()` now always appends the loopback entries to `NO_PROXY` regardless of user settings
- **Expose proxy fields in Claude Code frontend config** — added a "Network proxy" section to `ClaudeCodeQuickConfig` with `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` fields, full ZH/EN tooltips explaining the pitfall, and `prefsToEnvPreview` parity with Go's `ToEnv()` auto-injection

## Changed files

| File | Change |
|---|---|
| `agentboot/claude/constant.go` | Add `SystemSubtypeAPIRetry`, `SystemSubtypeRateLimit`, `SDKRateLimitEvent`, new v2.1 event constants |
| `agentboot/claude/messages.go` | Add retry fields (`Attempt`, `MaxRetries`, `DelayMS`, `Error`) + `Raw map[string]interface{}` to `SystemMessage` |
| `agentboot/claude/accumulator.go` | `parseSystemMessage` populates `Raw`; no-op case for all new housekeeping event types |
| `agentboot/claude/formatter.go` | `formatSystem()` handles `api_retry`/`rate_limit`; new `formatRetryNotice`/`formatRetryDelay` helpers |
| `agentboot/claude/utils.go` | `intFromMap`/`stringFromMap` multi-key lookup helpers for forward-compat field parsing |
| `agentboot/claude/formatter_test.go` | `TestTextFormatter_FormatAPIRetry` |
| `agentboot/claude/launcher_test.go` | `TestMessageAccumulator_APIRetryPreservesRaw` |
| `internal/remote_control/bot/bot_stream.go` | `isRetryNotice()` + exempt api_retry from quiet-mode filter |
| `internal/remote_control/bot/bot_stream_aggregate_test.go` | `TestStreamingHandler_QuietSurfacesAPIRetry`, `TestIsRetryNotice` |
| `internal/server/server_routes.go` | `HEAD ""` handler on scenario + scenarioV1 route groups |
| `internal/agent/prefs.go` | `appendNoProxy` helper; `ToEnv()` always sets `NO_PROXY` loopback entries |
| `internal/agent/prefs_test.go` | Update 3 tests to expect `NO_PROXY` in output |
| `frontend/src/components/ClaudeCodeQuickConfig.tsx` | `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` fields in new "Network proxy" section; `prefsToEnvPreview` mirrors Go NO_PROXY injection |

## Test plan

- [ ] Run `@cc` bot session: confirm `[RETRY]` messages appear during API retries instead of silent wait
- [ ] Set `HTTP_PROXY=http://proxy:8080` in env, start tb — verify CC can still reach local gateway (no 502)
- [ ] Open Claude Code quick config, scroll to "Network proxy" section — verify all three fields appear with correct labels/tooltips in ZH and EN
- [ ] `go test ./internal/agent/... ./agentboot/claude/... ./internal/remote_control/bot/...`

https://claude.ai/code/session_01MVnXxBahvyiXzxs8bzM5tr