### PR TITLE
ci: Windows ARM64 release + npx release-notes reuse + approval context

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,5 +1,14 @@
 name: NPX Package Publish from GitHub Release
 
+run-name: >-
+  📦 NPX publish ${{ github.event.inputs.tag || github.event.release.tag_name }}
+  → npm:${{ github.event.inputs.npm_tag || 'auto' }}
+  [cli=${{ github.event.inputs.publish_cli || 'true' }},
+  bundle=${{ github.event.inputs.publish_bundle || 'true' }},
+  gui=${{ github.event.inputs.publish_gui || 'false' }},
+  docker=${{ github.event.inputs.build_docker || 'true' }}]
+  by @${{ github.actor }}
+
 on:
   release:
     types: [published]
@@ -126,6 +135,26 @@ jobs:
           echo "✅ Release $RELEASE_TAG found"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Write publish summary (reference for approval reviewers)
+        run: |
+          {
+            echo "## 📦 NPX Publish Request — pending approval"
+            echo ""
+            echo "Review the details below before approving the \`production\` deployment."
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Trigger | \`${{ github.event_name }}\` |"
+            echo "| Initiated by | @${{ github.actor }} |"
+            echo "| Source release | [\`${{ steps.version.outputs.release_tag }}\`](https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.release_tag }}) |"
+            echo "| npm version | \`${{ steps.version.outputs.npx_version }}\` |"
+            echo "| npm dist-tag | \`${{ steps.set_vars.outputs.npm_tag }}\` |"
+            echo "| Publish CLI (\`tingly-box\`) | ${{ steps.set_vars.outputs.publish_cli }} |"
+            echo "| Publish Bundle (\`tingly-box-bundle\`) | ${{ steps.set_vars.outputs.publish_bundle }} |"
+            echo "| Publish GUI (\`tingly-box-gui\`) | ${{ steps.set_vars.outputs.publish_gui }} |"
+            echo "| Build Docker image | ${{ steps.set_vars.outputs.build_docker }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Publish CLI and Bundle NPX packages (merged)
   publish-cli-bundle:
@@ -307,10 +336,10 @@ jobs:
             npm publish --provenance --access public --tag "$NPM_TAG"
           fi
 
-  # Create a single NPX tag and release for CLI + Bundle
+  # Append NPX install info to the existing version release (no extra tag/release)
   create-release:
     needs: [setup, publish-cli-bundle]
-    name: Create NPX Release
+    name: Annotate Release with NPX Info
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -319,51 +348,39 @@ jobs:
       needs.setup.result == 'success' &&
       (needs.publish-cli-bundle.result == 'success' || needs.publish-cli-bundle.result == 'skipped')
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Create NPX tag and release
+      - name: Append NPX info to release notes
         env:
           VERSION: ${{ needs.setup.outputs.npx_version }}
           RELEASE_TAG: ${{ needs.setup.outputs.release_tag }}
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
-          FULL_TAG="npx-$VERSION"
-
           # Determine which packages were published
           PUBLISHED_CLI="${{ needs.setup.outputs.publish_cli }}"
           PUBLISHED_BUNDLE="${{ needs.setup.outputs.publish_bundle }}"
 
-          echo "Creating NPX tag and release for $FULL_TAG"
+          echo "Annotating release $RELEASE_TAG with NPX info"
           echo "  - CLI: $PUBLISHED_CLI"
           echo "  - Bundle: $PUBLISHED_BUNDLE"
 
           # Only proceed if at least one package was requested
           if [ "$PUBLISHED_CLI" != 'true' ] && [ "$PUBLISHED_BUNDLE" != 'true' ]; then
-            echo "⏭️ No packages to release, skipping..."
+            echo "⏭️ No packages published, skipping annotation..."
             exit 0
           fi
 
-          # Create git tag
-          if git rev-parse "$FULL_TAG" >/dev/null 2>&1; then
-            echo "Tag $FULL_TAG already exists"
-          else
-            git tag "$FULL_TAG"
-            git push origin "$FULL_TAG"
-          fi
+          MARKER="<!-- NPX_PUBLISH_INFO -->"
 
-          # Build release notes
-          cat > npx_release_notes.md << NOTES_EOF
-          ## 📦 NPX Package Release - $VERSION
+          # Reuse the existing version release; strip any previously appended
+          # NPX block so re-runs stay idempotent (no duplicated sections).
+          CURRENT_BODY="$(gh release view "$RELEASE_TAG" --repo "$REPO" --json body -q .body 2>/dev/null || echo "")"
+          BASE_BODY="${CURRENT_BODY%%${MARKER}*}"
 
-          Based on GitHub Release: [${RELEASE_TAG}](https://github.com/tingly-dev/tingly-box/releases/tag/${RELEASE_TAG})
+          {
+            printf '%s\n' "$BASE_BODY"
+            cat << NOTES_EOF
+          ${MARKER}
+          ## 📦 NPX Packages - $VERSION
 
           ### 🚀 Installation
 
@@ -376,8 +393,8 @@ jobs:
           \`\`\`
           NOTES_EOF
 
-          if [ "$PUBLISHED_BUNDLE" = 'true' ]; then
-            cat >> npx_release_notes.md << BUNDLE_EOF
+            if [ "$PUBLISHED_BUNDLE" = 'true' ]; then
+              cat << BUNDLE_EOF
 
           ### ✨ Bundle Package Features
 
@@ -393,40 +410,19 @@ jobs:
           > For a smaller package with download-on-demand, use \`tingly-box\` instead.
           > the bundle package includes pre-built binaries, ~70MB
           BUNDLE_EOF
-          fi
-
-          cat >> npx_release_notes.md << FOOTER_EOF
-
-          ### 🔗 Links
-
-          - 📦 [CLI on npm](https://www.npmjs.com/package/tingly-box/v/$VERSION)
-          FOOTER_EOF
-
-          if [ "$PUBLISHED_BUNDLE" = 'true' ]; then
-            echo "- 📦 [Bundle on npm](https://www.npmjs.com/package/tingly-box-bundle/v/$VERSION)" >> npx_release_notes.md
-          fi
-
-          cat >> npx_release_notes.md << FOOTER2_EOF
-          - 🏷️ [Source Release](https://github.com/tingly-dev/tingly-box/releases/tag/$RELEASE_TAG)
-
-          ---
-          _NPX package automatically published based on release $RELEASE_TAG_
-          FOOTER2_EOF
-
-          # Create or update GitHub release
-          if gh release view "$FULL_TAG" >/dev/null 2>&1; then
-            echo "Release $FULL_TAG already exists, updating..."
-            gh release edit "$FULL_TAG" --notes-file npx_release_notes.md --title "NPX Package $VERSION"
-          else
-            PRERELEASE_FLAG=""
-            if [[ "$VERSION" == *-* ]]; then
-              PRERELEASE_FLAG="--prerelease"
             fi
-            gh release create "$FULL_TAG" \
-              --title "NPX Package $VERSION" \
-              --notes-file npx_release_notes.md \
-              ${PRERELEASE_FLAG}
-          fi
+
+            echo ""
+            echo "### 🔗 NPX Links"
+            echo ""
+            echo "- 📦 [CLI on npm](https://www.npmjs.com/package/tingly-box/v/$VERSION)"
+            if [ "$PUBLISHED_BUNDLE" = 'true' ]; then
+              echo "- 📦 [Bundle on npm](https://www.npmjs.com/package/tingly-box-bundle/v/$VERSION)"
+            fi
+          } > npx_release_notes.md
+
+          echo "Updating release $RELEASE_TAG notes..."
+          gh release edit "$RELEASE_TAG" --repo "$REPO" --notes-file npx_release_notes.md
 
   # Build Docker NPX image after npm release is created
   build-docker-npx:
@@ -539,28 +535,26 @@ jobs:
             npm publish --provenance --access public --tag "$NPM_TAG"
           fi
 
-      - name: Create NPX tag and release
+      - name: Append GUI NPX info to release notes
         env:
           VERSION: ${{ needs.setup.outputs.npx_version }}
           RELEASE_TAG: ${{ needs.setup.outputs.release_tag }}
           PKG_TYPE: ${{ env.PKG_TYPE }}
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
-          FULL_TAG="npx-${PKG_TYPE}-$VERSION"
+          MARKER="<!-- NPX_PUBLISH_INFO_GUI -->"
 
-          echo "Creating NPX tag and release for $FULL_TAG"
+          # Reuse the existing version release; strip any previously appended
+          # GUI block so re-runs stay idempotent.
+          CURRENT_BODY="$(gh release view "$RELEASE_TAG" --repo "$REPO" --json body -q .body 2>/dev/null || echo "")"
+          BASE_BODY="${CURRENT_BODY%%${MARKER}*}"
 
-          if git rev-parse "$FULL_TAG" >/dev/null 2>&1; then
-            echo "Tag $FULL_TAG already exists"
-          else
-            git tag "$FULL_TAG"
-            git push origin "$FULL_TAG"
-          fi
-
-          cat > npx_release_notes.md << EOF
-          ## 📦 NPX Package Release - $VERSION ($PKG_TYPE)
-
-          Based on GitHub Release: [${RELEASE_TAG}](https://github.com/tingly-dev/tingly-box/releases/tag/${RELEASE_TAG})
+          {
+            printf '%s\n' "$BASE_BODY"
+            cat << EOF
+          ${MARKER}
+          ## 📦 NPX Package - $VERSION ($PKG_TYPE)
 
           ### 🚀 Installation
 
@@ -574,22 +568,8 @@ jobs:
 
           ### 🔗 Links
           - 📦 [View on npm](https://www.npmjs.com/package/$PKG_NAME/v/$VERSION)
-          - 🏷️ [Source Release](https://github.com/tingly-dev/tingly-box/releases/tag/$RELEASE_TAG)
-
-          ---
-          _This NPX package was automatically published based on release $RELEASE_TAG_
           EOF
+          } > npx_release_notes.md
 
-          if gh release view "$FULL_TAG" >/dev/null 2>&1; then
-            echo "Release $FULL_TAG already exists, updating..."
-            gh release edit "$FULL_TAG" --notes-file npx_release_notes.md --title "NPX Package $VERSION ($PKG_TYPE)"
-          else
-            PRERELEASE_FLAG=""
-            if [[ "$VERSION" == *-* ]]; then
-              PRERELEASE_FLAG="--prerelease"
-            fi
-            gh release create "$FULL_TAG" \
-              --title "NPX Package $VERSION ($PKG_TYPE)" \
-              --notes-file npx_release_notes.md \
-              ${PRERELEASE_FLAG}
-          fi
+          echo "Updating release $RELEASE_TAG notes with $PKG_TYPE info..."
+          gh release edit "$RELEASE_TAG" --repo "$REPO" --notes-file npx_release_notes.md

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -369,17 +369,19 @@ jobs:
             exit 0
           fi
 
-          MARKER="<!-- NPX_PUBLISH_INFO -->"
+          START="<!-- NPX_PUBLISH_INFO:START -->"
+          END="<!-- NPX_PUBLISH_INFO:END -->"
 
-          # Reuse the existing version release; strip any previously appended
-          # NPX block so re-runs stay idempotent (no duplicated sections).
+          # Reuse the existing version release. Strip only THIS block (bounded by
+          # START/END) so re-runs stay idempotent and never clobber a sibling
+          # block (e.g. the GUI section) appended elsewhere in the body.
           CURRENT_BODY="$(gh release view "$RELEASE_TAG" --repo "$REPO" --json body -q .body 2>/dev/null || echo "")"
-          BASE_BODY="${CURRENT_BODY%%${MARKER}*}"
+          BASE_BODY="$(printf '%s' "$CURRENT_BODY" | sed "/$START/,/$END/d")"
 
           {
             printf '%s\n' "$BASE_BODY"
+            echo "$START"
             cat << NOTES_EOF
-          ${MARKER}
           ## 📦 NPX Packages - $VERSION
 
           ### 🚀 Installation
@@ -419,6 +421,7 @@ jobs:
             if [ "$PUBLISHED_BUNDLE" = 'true' ]; then
               echo "- 📦 [Bundle on npm](https://www.npmjs.com/package/tingly-box-bundle/v/$VERSION)"
             fi
+            echo "$END"
           } > npx_release_notes.md
 
           echo "Updating release $RELEASE_TAG notes..."
@@ -453,7 +456,9 @@ jobs:
 
   # Publish GUI NPX package
   publish-gui:
-    needs: setup
+    # Depend on create-release so the two jobs never edit the same release body
+    # concurrently (avoids a lost-update race on the shared release notes).
+    needs: [setup, create-release]
     name: Publish GUI Package
     runs-on: ubuntu-latest
     environment: production
@@ -543,17 +548,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          MARKER="<!-- NPX_PUBLISH_INFO_GUI -->"
+          START="<!-- NPX_PUBLISH_INFO_GUI:START -->"
+          END="<!-- NPX_PUBLISH_INFO_GUI:END -->"
 
-          # Reuse the existing version release; strip any previously appended
-          # GUI block so re-runs stay idempotent.
+          # Reuse the existing version release. Strip only THIS block (bounded by
+          # START/END) so re-runs stay idempotent and never clobber the CLI block.
           CURRENT_BODY="$(gh release view "$RELEASE_TAG" --repo "$REPO" --json body -q .body 2>/dev/null || echo "")"
-          BASE_BODY="${CURRENT_BODY%%${MARKER}*}"
+          BASE_BODY="$(printf '%s' "$CURRENT_BODY" | sed "/$START/,/$END/d")"
 
           {
             printf '%s\n' "$BASE_BODY"
+            echo "$START"
             cat << EOF
-          ${MARKER}
           ## 📦 NPX Package - $VERSION ($PKG_TYPE)
 
           ### 🚀 Installation
@@ -569,6 +575,7 @@ jobs:
           ### 🔗 Links
           - 📦 [View on npm](https://www.npmjs.com/package/$PKG_NAME/v/$VERSION)
           EOF
+            echo "$END"
           } > npx_release_notes.md
 
           echo "Updating release $RELEASE_TAG notes with $PKG_TYPE info..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,14 @@ jobs:
               LDFLAGS_EXT="-linkmode external -extldflags \"-static\""
             fi
           elif [ "${{ matrix.goos }}" == "windows" ] && [ "${{ matrix.goarch }}" == "arm64" ]; then
-            # Cross-compile Windows on ARM (e.g. Snapdragon) via zig
+            # Cross-compile Windows on ARM (e.g. Snapdragon) via zig.
+            # Link statically so the bare .exe carries no mingw runtime DLL
+            # dependency (libwinpthread/libssp), matching the linux-arm64 leg.
             CC="zig cc -target aarch64-windows-gnu"
             CXX="zig c++ -target aarch64-windows-gnu"
             export CC CXX
             BUILD_TAGS="-tags 'sqlite_omit_load_extension'"
+            LDFLAGS_EXT="-linkmode external -extldflags \"-static\""
           fi
 
           # Build with optimizations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,12 @@ jobs:
             suffix: windows-amd64
             exe: .exe
             runs-on: windows-latest
+          - goos: windows
+            goarch: arm64
+            suffix: windows-arm64
+            exe: .exe
+            runs-on: ubuntu-22.04
+            cross_compile: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -177,7 +183,7 @@ jobs:
           sudo apt-get install -y -qq musl-tools musl-dev  || echo "done"
 
       - name: Install zig (for arm64 cross-compilation)
-        if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
+        if: matrix.cross_compile == true
         run: |
           wget -q https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
           tar -xf zig-linux-x86_64-0.13.0.tar.xz
@@ -230,6 +236,12 @@ jobs:
               BUILD_TAGS="-tags 'sqlite_omit_load_extension'"
               LDFLAGS_EXT="-linkmode external -extldflags \"-static\""
             fi
+          elif [ "${{ matrix.goos }}" == "windows" ] && [ "${{ matrix.goarch }}" == "arm64" ]; then
+            # Cross-compile Windows on ARM (e.g. Snapdragon) via zig
+            CC="zig cc -target aarch64-windows-gnu"
+            CXX="zig c++ -target aarch64-windows-gnu"
+            export CC CXX
+            BUILD_TAGS="-tags 'sqlite_omit_load_extension'"
           fi
 
           # Build with optimizations
@@ -245,7 +257,7 @@ jobs:
           [ "${{ matrix.goos }}" != "windows" ] && chmod +x ./dist/tingly-box${{ matrix.exe }} || true
 
       - name: Install UPX 5.1.1
-        if: matrix.goos != 'darwin'
+        if: matrix.goos != 'darwin' && !(matrix.goos == 'windows' && matrix.goarch == 'arm64')
         shell: bash
         run: |
           if [ "${{ runner.os }}" == "Windows" ]; then
@@ -258,7 +270,7 @@ jobs:
           fi
 
       - name: Compress binary with UPX
-        if: matrix.goos != 'darwin'
+        if: matrix.goos != 'darwin' && !(matrix.goos == 'windows' && matrix.goarch == 'arm64')
         shell: bash
         run: |
           if command -v upx &> /dev/null || [ -f "./upx-5.1.1-amd64_linux/upx" ]; then


### PR DESCRIPTION
Limited CI improvements:

1. **Windows ARM64 (Snapdragon) release support** — add a `windows/arm64` CLI target to `release.yml`, cross-compiled on ubuntu via zig (`aarch64-windows-gnu`); UPX skipped for it.
2. **Reuse the version release for npx** — instead of creating a separate `npx-*` tag + release per publish, annotate the existing version release's notes (idempotent, bounded START/END markers; CLI/bundle and GUI blocks are independent).
3. **Approval context** — dynamic `run-name` + a setup-job step summary so production approval reviewers see version/tag/packages.

Opened to let CI run and to inspect check results on this branch.
