### PR TITLE
feat(oauth, config): Add native ChatGPT OAuth mode for Codex CLI configuration

### DIFF
--- a/ai/agent/codex.go
+++ b/ai/agent/codex.go
@@ -11,10 +11,12 @@ type CodexConfig struct{}
 
 // CodexParams contains parameters for applying Codex configuration
 type CodexParams struct {
-	// CodexBaseURL is the base URL for Codex API endpoint
+	// CodexBaseURL is the base URL for Codex API endpoint. Ignored when
+	// AuthMode is CodexAuthChatGPT (native OAuth uses OpenAI directly and we
+	// leave the user's own ~/.codex/config.toml untouched).
 	CodexBaseURL string
 
-	// APIKey is the authentication token
+	// APIKey is the authentication token used in gateway / apikey mode.
 	APIKey string
 
 	// Models is a list of model names for the Codex profiles
@@ -30,6 +32,16 @@ type CodexParams struct {
 	// /model picker can list tingly-served models. Defaults to true for the CLI
 	// path; the HTTP handler derives it from the request.
 	WriteCatalog bool
+
+	// AuthMode selects how ~/.codex/auth.json is populated. Empty defaults to
+	// CodexAuthAPIKey (gateway). CodexAuthChatGPT exports native OAuth tokens
+	// for direct codex-to-OpenAI use; tingly-box stops managing the tokens
+	// after the one-shot write.
+	AuthMode serverconfig.CodexAuthMode
+
+	// ChatGPTTokens carries the OAuth credentials used when AuthMode is
+	// CodexAuthChatGPT. Ignored otherwise.
+	ChatGPTTokens *serverconfig.CodexChatGPTTokens
 }
 
 // Apply applies Codex CLI configuration
@@ -39,41 +51,44 @@ func (c *CodexConfig) Apply(paramsInterface interface{}) (*ApplyAgentResult, err
 		return nil, fmt.Errorf("invalid params type, expected *CodexParams")
 	}
 
-	// Apply config.toml
-	configResult, err := serverconfig.ApplyCodexConfig(params.CodexBaseURL, params.Models, params.Prefs, params.WriteCatalog)
-	if err != nil {
-		return nil, fmt.Errorf("failed to apply Codex config: %w", err)
+	result := &ApplyAgentResult{
+		AgentType: AgentTypeCodex,
+		Success:   true,
+	}
+
+	// In ChatGPT mode the user is going direct-to-OpenAI; we don't touch
+	// config.toml — their existing model_provider / base_url stay intact.
+	if params.AuthMode != serverconfig.CodexAuthChatGPT {
+		configResult, err := serverconfig.ApplyCodexConfig(params.CodexBaseURL, params.Models, params.Prefs, params.WriteCatalog)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply Codex config: %w", err)
+		}
+		result.Success = result.Success && configResult.Success
+		if configResult.Success {
+			suffix := " (updated)"
+			if configResult.Created {
+				suffix = " (created)"
+			}
+			result.ConfigFiles = append(result.ConfigFiles, "~/.codex/config.toml"+suffix)
+		}
+		if configResult.BackupPath != "" {
+			result.BackupPaths = append(result.BackupPaths, configResult.BackupPath)
+		}
 	}
 
 	// Apply auth.json
-	authResult, err := serverconfig.ApplyCodexAuth(params.APIKey)
+	authResult, err := serverconfig.ApplyCodexAuth(params.AuthMode, params.APIKey, params.ChatGPTTokens)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply Codex auth: %w", err)
 	}
+	result.Success = result.Success && authResult.Success
 
-	result := &ApplyAgentResult{
-		AgentType: AgentTypeCodex,
-		Success:   configResult.Success && authResult.Success,
-	}
-
-	// Build config files list
-	if configResult.Success {
-		suffix := " (updated)"
-		if configResult.Created {
-			suffix = " (created)"
-		}
-		result.ConfigFiles = append(result.ConfigFiles, "~/.codex/config.toml"+suffix)
-	}
 	if authResult.Success {
 		suffix := " (updated)"
 		if authResult.Created {
 			suffix = " (created)"
 		}
 		result.ConfigFiles = append(result.ConfigFiles, "~/.codex/auth.json"+suffix)
-	}
-
-	if configResult.BackupPath != "" {
-		result.BackupPaths = append(result.BackupPaths, configResult.BackupPath)
 	}
 	if authResult.BackupPath != "" {
 		result.BackupPaths = append(result.BackupPaths, authResult.BackupPath)

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -531,11 +532,17 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 			logrus.Warnf("[OAuth] Failed to parse ID token for Codex provider")
 		}
 	} else if config.Type == ai.IssuerCodex {
-		// Log the actual response fields so we can tell whether OpenAI omitted
-		// id_token entirely or returned it under a different key.
+		// Log only the key set so we can tell whether OpenAI omitted id_token
+		// or returned it under a different key — never the values, which
+		// contain access_token / refresh_token.
 		var raw map[string]json.RawMessage
 		if jsonErr := json.Unmarshal(rawBody, &raw); jsonErr == nil {
-			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response fields: %v", raw)
+			keys := make([]string, 0, len(raw))
+			for k := range raw {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response field names: %v", keys)
 		} else {
 			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; could not inspect response: %v", jsonErr)
 		}

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -535,11 +535,7 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 		// id_token entirely or returned it under a different key.
 		var raw map[string]json.RawMessage
 		if jsonErr := json.Unmarshal(rawBody, &raw); jsonErr == nil {
-			fields := make([]string, 0, len(raw))
-			for k := range raw {
-				fields = append(fields, k)
-			}
-			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response fields: %v", fields)
+			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response fields: %v", raw)
 		} else {
 			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; could not inspect response: %v", jsonErr)
 		}

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -496,9 +496,14 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 		return nil, fmt.Errorf("token exchange failed: status %d, body: %s", resp.StatusCode, bodyStr)
 	}
 
-	// Parse response directly into Token
+	// Read response body so we can both decode it and log it on failure.
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading token response: %w", err)
+	}
+
 	token := &Token{}
-	if err := json.NewDecoder(resp.Body).Decode(token); err != nil {
+	if err := json.Unmarshal(rawBody, token); err != nil {
 		return nil, fmt.Errorf("data decode: %w: %v", ErrTokenExchangeFailed, err)
 	}
 
@@ -526,7 +531,18 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 			logrus.Warnf("[OAuth] Failed to parse ID token for Codex provider")
 		}
 	} else if config.Type == ai.IssuerCodex {
-		logrus.Warnf("[OAuth] Codex provider token has no ID token (id_token field is empty)")
+		// Log the actual response fields so we can tell whether OpenAI omitted
+		// id_token entirely or returned it under a different key.
+		var raw map[string]json.RawMessage
+		if jsonErr := json.Unmarshal(rawBody, &raw); jsonErr == nil {
+			fields := make([]string, 0, len(raw))
+			for k := range raw {
+				fields = append(fields, k)
+			}
+			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response fields: %v", fields)
+		} else {
+			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; could not inspect response: %v", jsonErr)
+		}
 	}
 
 	// Call provider's after-token hook to fetch additional metadata

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -144,6 +144,16 @@ func (o *OAuthDetail) IsExpired() bool {
 	return time.Now().Add(5 * time.Minute).After(expiryTime) // Consider expired if within 5 minutes
 }
 
+// GetExtraFieldString returns a string value from ExtraFields by key.
+// Returns "" if the key is absent or the value is not a string.
+func (o *OAuthDetail) GetExtraFieldString(key string) string {
+	if o == nil || o.ExtraFields == nil {
+		return ""
+	}
+	v, _ := o.ExtraFields[key].(string)
+	return v
+}
+
 // GetIssuer returns the OAuth issuer, with backward compatibility for ProviderType.
 // It returns Issuer if set, otherwise falls back to the deprecated ProviderType.
 func (o *OAuthDetail) GetIssuer() Issuer {

--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -128,12 +128,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
 
 	// Resolve account_id from OAuth extra_fields
-	var accountID string
-	if provider.OAuthDetail != nil && provider.OAuthDetail.ExtraFields != nil {
-		if aid, ok := provider.OAuthDetail.ExtraFields["account_id"].(string); ok {
-			accountID = aid
-		}
-	}
+	accountID := provider.OAuthDetail.GetExtraFieldString("account_id")
 
 	apiBase := "https://chatgpt.com"
 	if f.baseURL != "" {

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -87,10 +87,10 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
         setPrefs(defaultCodexPrefs());
     }, [open]);
 
-    // Fetch Codex OAuth providers once when the modal opens so the ChatGPT
-    // mode dropdown is ready before the user toggles to it.
+    // Fetch Codex OAuth providers only the first time the user selects chatgpt
+    // mode — no point paying the network cost if they stay in apikey mode.
     React.useEffect(() => {
-        if (!open) return;
+        if (!open || authMode !== 'chatgpt') return;
         let cancelled = false;
         (async () => {
             try {
@@ -107,7 +107,7 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
             }
         })();
         return () => { cancelled = true; };
-    }, [open]);
+    }, [open, authMode]);
 
     // Re-render the server-authoritative TOML whenever prefs or writeCatalog change
     // while the modal is open. Debounced so dragging through Select options doesn't

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -85,6 +85,9 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
             return;
         }
         setPrefs(defaultCodexPrefs());
+        setAuthMode('apikey');
+        setSelectedOAuthProvider('');
+        setCodexOAuthProviders([]);
     }, [open]);
 
     // Fetch Codex OAuth providers only the first time the user selects chatgpt

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -20,6 +20,7 @@ type AuthMode = 'apikey' | 'chatgpt';
 interface CodexOAuthProviderOption {
     uuid: string;
     name: string;
+    email?: string;
 }
 
 interface ApplyCodexConfigResponse {
@@ -99,7 +100,11 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
                 const list: any[] = Array.isArray(resp?.data) ? resp.data : [];
                 const codexOAuth = list
                     .filter((p) => p?.auth_type === 'oauth' && (p?.oauth_detail?.issuer === 'codex' || p?.oauth_detail?.provider_type === 'codex'))
-                    .map((p) => ({ uuid: p.uuid, name: p.name }));
+                    .map((p) => ({
+                        uuid: p.uuid,
+                        name: p.name,
+                        email: p?.oauth_detail?.extra_fields?.email,
+                    }));
                 setCodexOAuthProviders(codexOAuth);
                 setSelectedOAuthProvider((prev) => prev || codexOAuth[0]?.uuid || '');
             } catch {
@@ -309,7 +314,9 @@ EOF`;
                                             : 'Select a Codex OAuth provider'}
                                     </MenuItem>
                                     {codexOAuthProviders.map((p) => (
-                                        <MenuItem key={p.uuid} value={p.uuid}>{p.name}</MenuItem>
+                                        <MenuItem key={p.uuid} value={p.uuid}>
+                                            {p.email ? `${p.name} (${p.email})` : p.name}
+                                        </MenuItem>
                                     ))}
                                 </Select>
                             </FormControl>

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -314,10 +314,12 @@ EOF`;
                                 </Select>
                             </FormControl>
                             <Alert severity="info" variant="outlined" sx={{ py: 0.5 }}>
-                                Exports the OAuth tokens to <code>~/.codex/auth.json</code> so codex CLI talks
-                                directly to OpenAI. Tingly Box will <strong>not</strong> manage refresh after this —
-                                codex CLI owns the token lifecycle from here on. Your existing
-                                <code> ~/.codex/config.toml </code> is left untouched.
+                                Exports the OAuth tokens to <code>~/.codex/auth.json</code> and removes the
+                                tingly gateway keys from <code>config.toml</code> so codex CLI talks directly to
+                                OpenAI. Tingly Box will <strong>not</strong> manage token refresh after this —
+                                codex CLI owns the token lifecycle from here on.{' '}
+                                If <code>id_token</code> is missing in the exported file, re-authenticate
+                                via the OAuth page and apply again.
                             </Alert>
                         </Box>
                     )}
@@ -551,34 +553,14 @@ EOF`;
                             Configuration applied successfully!
                         </Typography>
                         <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                            {applyResult.configResult?.created && (
+                            {applyResult.configResult?.message && (
                                 <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                                    ✓ Created ~/.codex/config.toml
+                                    ✓ {applyResult.configResult.message}
                                 </Typography>
                             )}
-                            {applyResult.configResult?.updated && (
+                            {applyResult.authResult?.message && (
                                 <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                                    ✓ Updated ~/.codex/config.toml
-                                </Typography>
-                            )}
-                            {applyResult.authResult?.created && (
-                                <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                                    ✓ Created ~/.codex/auth.json
-                                </Typography>
-                            )}
-                            {applyResult.authResult?.updated && (
-                                <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                                    ✓ Updated ~/.codex/auth.json
-                                </Typography>
-                            )}
-                            {applyResult.catalogWritten && (
-                                <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                                    ✓ Written ~/.codex/tingly-model-catalog.json
-                                </Typography>
-                            )}
-                            {applyResult.models && applyResult.models.length > 0 && (
-                                <Typography variant="caption" color="text.secondary">
-                                    Models: {applyResult.models.join(', ')}
+                                    ✓ {applyResult.authResult.message}
                                 </Typography>
                             )}
                             {applyResult.configResult?.backupPath && (

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -20,7 +20,6 @@ type AuthMode = 'apikey' | 'chatgpt';
 interface CodexOAuthProviderOption {
     uuid: string;
     name: string;
-    email?: string;
 }
 
 interface ApplyCodexConfigResponse {
@@ -100,11 +99,7 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
                 const list: any[] = Array.isArray(resp?.data) ? resp.data : [];
                 const codexOAuth = list
                     .filter((p) => p?.auth_type === 'oauth' && (p?.oauth_detail?.issuer === 'codex' || p?.oauth_detail?.provider_type === 'codex'))
-                    .map((p) => ({
-                        uuid: p.uuid,
-                        name: p.name,
-                        email: p?.oauth_detail?.extra_fields?.email,
-                    }));
+                    .map((p) => ({ uuid: p.uuid, name: p.name }));
                 setCodexOAuthProviders(codexOAuth);
                 setSelectedOAuthProvider((prev) => prev || codexOAuth[0]?.uuid || '');
             } catch {
@@ -314,9 +309,7 @@ EOF`;
                                             : 'Select a Codex OAuth provider'}
                                     </MenuItem>
                                     {codexOAuthProviders.map((p) => (
-                                        <MenuItem key={p.uuid} value={p.uuid}>
-                                            {p.email ? `${p.name} (${p.email})` : p.name}
-                                        </MenuItem>
+                                        <MenuItem key={p.uuid} value={p.uuid}>{p.name}</MenuItem>
                                     ))}
                                 </Select>
                             </FormControl>

--- a/frontend/src/components/CodexConfigModal.tsx
+++ b/frontend/src/components/CodexConfigModal.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, Tab, Tabs, Typography } from '@mui/material';
+import { Alert, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, MenuItem, Radio, RadioGroup, Select, Tab, Tabs, Typography } from '@mui/material';
 import React from 'react';
 import CodeBlock from './CodeBlock';
 import CodexQuickConfig, { type CodexPrefs, defaultCodexPrefs } from './CodexQuickConfig';
@@ -15,6 +15,12 @@ interface CodexConfigModalProps {
 type MainTab = 'quick' | 'manual';
 type ScriptTab = 'json' | 'windows' | 'unix';
 type SessionAction = 'import' | 'undo';
+type AuthMode = 'apikey' | 'chatgpt';
+
+interface CodexOAuthProviderOption {
+    uuid: string;
+    name: string;
+}
 
 interface ApplyCodexConfigResponse {
     success: boolean;
@@ -50,6 +56,9 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     const [mainTab, setMainTab] = React.useState<MainTab>('quick');
     const [prefs, setPrefs] = React.useState<CodexPrefs>(() => defaultCodexPrefs());
     const [writeCatalog, setWriteCatalog] = React.useState(true);
+    const [authMode, setAuthMode] = React.useState<AuthMode>('apikey');
+    const [codexOAuthProviders, setCodexOAuthProviders] = React.useState<CodexOAuthProviderOption[]>([]);
+    const [selectedOAuthProvider, setSelectedOAuthProvider] = React.useState<string>('');
     const [configTab, setConfigTab] = React.useState<ScriptTab>('json');
     const [authTab, setAuthTab] = React.useState<ScriptTab>('json');
     const [catalogTab, setCatalogTab] = React.useState<ScriptTab>('json');
@@ -78,11 +87,36 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
         setPrefs(defaultCodexPrefs());
     }, [open]);
 
+    // Fetch Codex OAuth providers once when the modal opens so the ChatGPT
+    // mode dropdown is ready before the user toggles to it.
+    React.useEffect(() => {
+        if (!open) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const resp = await api.getProviders();
+                if (cancelled) return;
+                const list: any[] = Array.isArray(resp?.data) ? resp.data : [];
+                const codexOAuth = list
+                    .filter((p) => p?.auth_type === 'oauth' && (p?.oauth_detail?.issuer === 'codex' || p?.oauth_detail?.provider_type === 'codex'))
+                    .map((p) => ({ uuid: p.uuid, name: p.name }));
+                setCodexOAuthProviders(codexOAuth);
+                setSelectedOAuthProvider((prev) => prev || codexOAuth[0]?.uuid || '');
+            } catch {
+                setCodexOAuthProviders([]);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [open]);
+
     // Re-render the server-authoritative TOML whenever prefs or writeCatalog change
     // while the modal is open. Debounced so dragging through Select options doesn't
     // spam the backend.
     React.useEffect(() => {
         if (!open) return;
+        // ChatGPT-mode preview would render OAuth tokens — skip it entirely;
+        // the user gets an info card on the modal instead.
+        if (authMode === 'chatgpt') return;
         let cancelled = false;
         const handle = setTimeout(async () => {
             try {
@@ -100,7 +134,7 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
             }
         }, 250);
         return () => { cancelled = true; clearTimeout(handle); };
-    }, [open, prefs, writeCatalog, token]);
+    }, [open, prefs, writeCatalog, token, authMode]);
 
     const windowsCatalogScript = `$catalogDir = Join-Path $HOME ".codex"
 $catalogPath = Join-Path $catalogDir "tingly-model-catalog.json"
@@ -173,11 +207,20 @@ EOF`;
     };
 
     const handleApplyConfiguration = async () => {
+        if (authMode === 'chatgpt' && !selectedOAuthProvider) {
+            setApplyError('Select a Codex OAuth provider to export.');
+            return;
+        }
         setIsApplying(true);
         setApplyError(null);
         setApplyResult(null);
         try {
-            const response = await api.applyCodexConfig(prefs as Record<string, string>, writeCatalog);
+            const response = await api.applyCodexConfig(
+                prefs as Record<string, string>,
+                writeCatalog,
+                authMode,
+                authMode === 'chatgpt' ? selectedOAuthProvider : undefined,
+            );
             if (response?.success) {
                 setApplyResult(response);
             } else {
@@ -232,7 +275,54 @@ EOF`;
             </DialogTitle>
 
             <DialogContent sx={{ p: 3 }}>
-                {mainTab === 'quick' && (
+                <Box sx={{ mb: 2, p: 2, borderRadius: 2, bgcolor: 'action.hover' }}>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                        Auth source
+                    </Typography>
+                    <RadioGroup
+                        row
+                        value={authMode}
+                        onChange={(e) => setAuthMode(e.target.value as AuthMode)}
+                    >
+                        <FormControlLabel
+                            value="apikey"
+                            control={<Radio size="small" />}
+                            label="Via Tingly Box gateway (API key)"
+                        />
+                        <FormControlLabel
+                            value="chatgpt"
+                            control={<Radio size="small" />}
+                            label="Native ChatGPT OAuth (direct to OpenAI)"
+                        />
+                    </RadioGroup>
+                    {authMode === 'chatgpt' && (
+                        <Box sx={{ mt: 1.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                            <FormControl size="small" sx={{ maxWidth: 360 }}>
+                                <Select
+                                    displayEmpty
+                                    value={selectedOAuthProvider}
+                                    onChange={(e) => setSelectedOAuthProvider(e.target.value as string)}
+                                >
+                                    <MenuItem value="" disabled>
+                                        {codexOAuthProviders.length === 0
+                                            ? 'No Codex OAuth provider — log in first'
+                                            : 'Select a Codex OAuth provider'}
+                                    </MenuItem>
+                                    {codexOAuthProviders.map((p) => (
+                                        <MenuItem key={p.uuid} value={p.uuid}>{p.name}</MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+                            <Alert severity="info" variant="outlined" sx={{ py: 0.5 }}>
+                                Exports the OAuth tokens to <code>~/.codex/auth.json</code> so codex CLI talks
+                                directly to OpenAI. Tingly Box will <strong>not</strong> manage refresh after this —
+                                codex CLI owns the token lifecycle from here on. Your existing
+                                <code> ~/.codex/config.toml </code> is left untouched.
+                            </Alert>
+                        </Box>
+                    )}
+                </Box>
+                {authMode !== 'chatgpt' && mainTab === 'quick' && (
                     <CodexQuickConfig
                         prefs={prefs}
                         setPrefs={setPrefs}
@@ -242,7 +332,7 @@ EOF`;
                     />
                 )}
 
-                {mainTab === 'manual' && (
+                {authMode !== 'chatgpt' && mainTab === 'manual' && (
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                             <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1070,17 +1070,37 @@ export const api = {
         });
     },
 
-    applyCodexConfig: async (preferences?: Record<string, string>, writeCatalog?: boolean): Promise<any> => {
+    applyCodexConfig: async (
+        preferences?: Record<string, string>,
+        writeCatalog?: boolean,
+        authMode?: 'apikey' | 'chatgpt',
+        oauthProviderUuid?: string,
+    ): Promise<any> => {
         return uiAPI('/config/apply/codex', {
             method: 'POST',
-            body: JSON.stringify({ preferences: preferences ?? null, writeCatalog: writeCatalog ?? true }),
+            body: JSON.stringify({
+                preferences: preferences ?? null,
+                writeCatalog: writeCatalog ?? true,
+                authMode: authMode ?? 'apikey',
+                oauthProviderUuid: oauthProviderUuid ?? '',
+            }),
         });
     },
 
-    getCodexConfigPreview: async (preferences?: Record<string, string>, writeCatalog?: boolean): Promise<any> => {
+    getCodexConfigPreview: async (
+        preferences?: Record<string, string>,
+        writeCatalog?: boolean,
+        authMode?: 'apikey' | 'chatgpt',
+        oauthProviderUuid?: string,
+    ): Promise<any> => {
         return uiAPI('/config/preview/codex', {
             method: 'POST',
-            body: JSON.stringify({ preferences: preferences ?? null, writeCatalog: writeCatalog ?? true }),
+            body: JSON.stringify({
+                preferences: preferences ?? null,
+                writeCatalog: writeCatalog ?? true,
+                authMode: authMode ?? 'apikey',
+                oauthProviderUuid: oauthProviderUuid ?? '',
+            }),
         });
     },
 

--- a/internal/client/antigravity_client.go
+++ b/internal/client/antigravity_client.go
@@ -31,12 +31,7 @@ func NewAntigravityClient(provider *typ.Provider, model string, sessionID typ.Se
 		return nil, fmt.Errorf("antigravity client requires an antigravity OAuth provider")
 	}
 
-	project := ""
-	if provider.OAuthDetail.ExtraFields != nil {
-		if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
-			project = p
-		}
-	}
+	project := provider.OAuthDetail.GetExtraFieldString("project_id")
 	if project == "" {
 		logrus.Warnf("[Antigravity] provider %s has no project_id in OAuth metadata; Code Assist calls will fail until loadCodeAssist populates it", provider.Name)
 	}

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -51,7 +51,7 @@ func NewCodexClient(provider *typ.Provider, model string, sessionID typ.SessionI
 	// The codexHook will transform this to ChatGPT-Account-ID and add other required headers
 	// Reference: https://github.com/SamSaffron/term-llm/blob/main/internal/llm/chatgpt.go
 	var options = []option.RequestOption{}
-	if accountID, ok := provider.OAuthDetail.ExtraFields["account_id"].(string); ok && accountID != "" {
+	if accountID := provider.OAuthDetail.GetExtraFieldString("account_id"); accountID != "" {
 		options = append(options, option.WithHeader("X-ChatGPT-Account-ID", accountID))
 	}
 

--- a/internal/client/gemini_client.go
+++ b/internal/client/gemini_client.go
@@ -37,12 +37,7 @@ func NewGeminiClient(provider *typ.Provider, model string, sessionID typ.Session
 		return nil, fmt.Errorf("gemini client requires a gemini OAuth provider")
 	}
 
-	project := ""
-	if provider.OAuthDetail.ExtraFields != nil {
-		if p, ok := provider.OAuthDetail.ExtraFields["project_id"].(string); ok {
-			project = p
-		}
-	}
+	project := provider.OAuthDetail.GetExtraFieldString("project_id")
 	if project == "" {
 		logrus.Warnf("[Gemini] provider %s has no project_id in OAuth metadata; Code Assist calls will fail until loadCodeAssist/onboardUser populates it", provider.Name)
 	}

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -664,10 +664,8 @@ func (c *OpenAIClient) probeCodexResponsesEndpoint(ctx context.Context, model st
 	req.Header.Set("originator", "tingly-box")
 
 	// Add ChatGPT-Account-ID header if available
-	if c.provider.OAuthDetail != nil && c.provider.OAuthDetail.ExtraFields != nil {
-		if accountID, ok := c.provider.OAuthDetail.ExtraFields["account_id"].(string); ok && accountID != "" {
-			req.Header.Set("ChatGPT-Account-ID", accountID)
-		}
+	if accountID := c.provider.OAuthDetail.GetExtraFieldString("account_id"); accountID != "" {
+		req.Header.Set("ChatGPT-Account-ID", accountID)
 	}
 
 	// Make the request

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1198,11 +1198,39 @@ func sanitizeCodexProfileKey(name string) string {
 	return out
 }
 
-// ApplyCodexAuth writes `~/.codex/auth.json` with `OPENAI_API_KEY` set to the
-// tingly-box model token. If the file already exists, other top-level keys are
-// preserved; only `OPENAI_API_KEY` is overwritten. The previous version is
-// backed up before modification.
-func ApplyCodexAuth(apiKey string) (*ApplyResult, error) {
+// CodexAuthMode selects how `~/.codex/auth.json` is populated.
+type CodexAuthMode string
+
+const (
+	// CodexAuthAPIKey writes only `OPENAI_API_KEY` — used when codex CLI
+	// should talk to tingly-box as a gateway.
+	CodexAuthAPIKey CodexAuthMode = "apikey"
+	// CodexAuthChatGPT exports a native ChatGPT-login auth.json so codex CLI
+	// can talk to OpenAI directly using OAuth tokens previously obtained by
+	// tingly-box. tingly-box does NOT refresh these tokens afterwards —
+	// codex CLI owns their lifecycle from that point on.
+	CodexAuthChatGPT CodexAuthMode = "chatgpt"
+)
+
+// CodexChatGPTTokens carries the OAuth credentials needed to materialize a
+// native ChatGPT-login `auth.json`.
+type CodexChatGPTTokens struct {
+	IDToken      string
+	AccessToken  string
+	RefreshToken string
+	AccountID    string
+}
+
+// ApplyCodexAuth writes `~/.codex/auth.json`. The previous version (if any) is
+// backed up before modification; existing top-level keys outside the managed
+// set are preserved.
+//
+// Mode semantics:
+//   - CodexAuthAPIKey: sets `OPENAI_API_KEY` to the supplied key (gateway mode).
+//   - CodexAuthChatGPT: writes `tokens` / `last_refresh` / `auth_mode: "chatgpt"`
+//     and clears `OPENAI_API_KEY`. Tokens come from the caller; tingly-box does
+//     not subsequently refresh them.
+func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTTokens) (*ApplyResult, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
@@ -1234,7 +1262,32 @@ func ApplyCodexAuth(apiKey string) (*ApplyResult, error) {
 		result.Created = true
 	}
 
-	existing["OPENAI_API_KEY"] = apiKey
+	switch mode {
+	case CodexAuthChatGPT:
+		if tokens == nil || tokens.AccessToken == "" || tokens.RefreshToken == "" {
+			result.Message = "ChatGPT auth requires access_token and refresh_token"
+			return result, nil
+		}
+		existing["OPENAI_API_KEY"] = nil
+		existing["auth_mode"] = "chatgpt"
+		tokensMap := map[string]interface{}{
+			"access_token":  tokens.AccessToken,
+			"refresh_token": tokens.RefreshToken,
+		}
+		if tokens.IDToken != "" {
+			tokensMap["id_token"] = tokens.IDToken
+		}
+		if tokens.AccountID != "" {
+			tokensMap["account_id"] = tokens.AccountID
+		}
+		existing["tokens"] = tokensMap
+		existing["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
+	case "", CodexAuthAPIKey:
+		existing["OPENAI_API_KEY"] = apiKey
+	default:
+		result.Message = fmt.Sprintf("Unknown Codex auth mode: %q", mode)
+		return result, nil
+	}
 
 	output, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1317,6 +1317,33 @@ type CodexChatGPTTokens struct {
 //     and clears `OPENAI_API_KEY`. Tokens come from the caller; tingly-box does
 //     not subsequently refresh them.
 func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTTokens) (*ApplyResult, error) {
+	// Validate inputs before touching disk so a malformed request can't leave
+	// orphaned backups behind.
+	payload := map[string]interface{}{}
+	switch mode {
+	case CodexAuthChatGPT:
+		if tokens == nil || tokens.AccessToken == "" || tokens.RefreshToken == "" {
+			return &ApplyResult{Message: "ChatGPT auth requires access_token and refresh_token"}, nil
+		}
+		payload["auth_mode"] = "chatgpt"
+		tokensMap := map[string]interface{}{
+			"access_token":  tokens.AccessToken,
+			"refresh_token": tokens.RefreshToken,
+		}
+		if tokens.IDToken != "" {
+			tokensMap["id_token"] = tokens.IDToken
+		}
+		if tokens.AccountID != "" {
+			tokensMap["account_id"] = tokens.AccountID
+		}
+		payload["tokens"] = tokensMap
+		payload["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
+	case "", CodexAuthAPIKey:
+		payload["OPENAI_API_KEY"] = apiKey
+	default:
+		return &ApplyResult{Message: fmt.Sprintf("Unknown Codex auth mode: %q", mode)}, nil
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
@@ -1331,12 +1358,11 @@ func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTToken
 		return result, nil
 	}
 
-	existing := map[string]interface{}{}
-	if data, err := os.ReadFile(targetPath); err == nil {
-		if err := json.Unmarshal(data, &existing); err != nil {
-			result.Message = fmt.Sprintf("Failed to parse existing JSON: %v", err)
-			return result, nil
-		}
+	// Each mode writes a fresh file — no merging with the previous auth.json.
+	// Switching apikey→chatgpt must not leave OPENAI_API_KEY behind, and
+	// chatgpt→apikey must not leave the tokens block behind. The backup
+	// preserves whatever the user had.
+	if _, err := os.Stat(targetPath); err == nil {
 		backupPath, err := backupFile(targetPath)
 		if err != nil {
 			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
@@ -1348,34 +1374,7 @@ func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTToken
 		result.Created = true
 	}
 
-	switch mode {
-	case CodexAuthChatGPT:
-		if tokens == nil || tokens.AccessToken == "" || tokens.RefreshToken == "" {
-			result.Message = "ChatGPT auth requires access_token and refresh_token"
-			return result, nil
-		}
-		existing["OPENAI_API_KEY"] = nil
-		existing["auth_mode"] = "chatgpt"
-		tokensMap := map[string]interface{}{
-			"access_token":  tokens.AccessToken,
-			"refresh_token": tokens.RefreshToken,
-		}
-		if tokens.IDToken != "" {
-			tokensMap["id_token"] = tokens.IDToken
-		}
-		if tokens.AccountID != "" {
-			tokensMap["account_id"] = tokens.AccountID
-		}
-		existing["tokens"] = tokensMap
-		existing["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
-	case "", CodexAuthAPIKey:
-		existing["OPENAI_API_KEY"] = apiKey
-	default:
-		result.Message = fmt.Sprintf("Unknown Codex auth mode: %q", mode)
-		return result, nil
-	}
-
-	output, err := json.MarshalIndent(existing, "", "  ")
+	output, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to marshal JSON: %v", err)
 		return result, nil

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -20,6 +20,16 @@ import (
 // rotateBackups after each new backup is created.
 const defaultBackupRetention = 3
 
+// codexGatewayProviderName is the tingly-box provider key written into
+// config.toml's [model_providers] table by mergeCodexConfig and removed by
+// ClearCodexGatewayConfig.
+const codexGatewayProviderName = "tingly-box"
+
+// codexGatewayTopLevelKeys are the top-level config.toml keys owned by
+// tingly-box. Both mergeCodexConfig (writer) and ClearCodexGatewayConfig
+// (eraser) reference this list so the two functions stay in sync.
+var codexGatewayTopLevelKeys = []string{"model", "model_provider", "model_catalog_json"}
+
 // backupTimestampLayout matches the timestamp format embedded in backup
 // filenames produced by generateBackupPath.
 const backupTimestampLayout = "20060102-150405"
@@ -1104,7 +1114,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	if len(models) > 0 {
 		cfg["model"] = models[0]
 	}
-	cfg["model_provider"] = "tingly-box"
+	cfg["model_provider"] = codexGatewayProviderName
 	if catalogPath != "" {
 		cfg["model_catalog_json"] = catalogPath
 	}
@@ -1113,7 +1123,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	if providers == nil {
 		providers = map[string]interface{}{}
 	}
-	providers["tingly-box"] = map[string]interface{}{
+	providers[codexGatewayProviderName] = map[string]interface{}{
 		"name":                  "OpenAI using Tingly Box",
 		"base_url":              baseURL,
 		"preferred_auth_method": "apikey",
@@ -1128,7 +1138,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	for _, model := range models {
 		profile := map[string]interface{}{
 			"model":          model,
-			"model_provider": "tingly-box",
+			"model_provider": codexGatewayProviderName,
 		}
 		for k, v := range coerced {
 			profile[k] = v
@@ -1242,7 +1252,7 @@ func ClearCodexGatewayConfig() (*ApplyResult, error) {
 	}
 
 	changed := false
-	for _, k := range []string{"model", "model_provider", "model_catalog_json"} {
+	for _, k := range codexGatewayTopLevelKeys {
 		if _, ok := cfg[k]; ok {
 			delete(cfg, k)
 			changed = true
@@ -1250,8 +1260,8 @@ func ClearCodexGatewayConfig() (*ApplyResult, error) {
 	}
 	// Also remove the tingly-box provider stanza if present.
 	if providers, ok := cfg["model_providers"].(map[string]interface{}); ok {
-		if _, ok := providers["tingly-box"]; ok {
-			delete(providers, "tingly-box")
+		if _, ok := providers[codexGatewayProviderName]; ok {
+			delete(providers, codexGatewayProviderName)
 			if len(providers) == 0 {
 				delete(cfg, "model_providers")
 			}

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1245,6 +1246,17 @@ func ClearCodexGatewayConfig() (*ApplyResult, error) {
 		result.Message = "no config.toml found, nothing to clear"
 		return result, nil
 	}
+
+	// Fast path: if the file mentions neither the tingly provider name nor any
+	// managed top-level key, skip the unmarshal/marshal round-trip entirely.
+	// Re-marshaling user TOML loses comments and reorders keys, so avoiding it
+	// in the common no-op case is also a correctness win.
+	if !bytes.Contains(data, []byte(codexGatewayProviderName)) {
+		result.Success = true
+		result.Message = "config.toml has no tingly gateway keys, nothing to clear"
+		return result, nil
+	}
+
 	cfg := map[string]interface{}{}
 	if err := tomlpkg.Unmarshal(data, &cfg); err != nil {
 		result.Message = fmt.Sprintf("Failed to parse config.toml: %v", err)
@@ -1358,6 +1370,14 @@ func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTToken
 		return result, nil
 	}
 
+	// Marshal before touching disk so a malformed payload can't leave an
+	// orphan backup behind.
+	output, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal JSON: %v", err)
+		return result, nil
+	}
+
 	// Each mode writes a fresh file — no merging with the previous auth.json.
 	// Switching apikey→chatgpt must not leave OPENAI_API_KEY behind, and
 	// chatgpt→apikey must not leave the tokens block behind. The backup
@@ -1374,11 +1394,6 @@ func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTToken
 		result.Created = true
 	}
 
-	output, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		result.Message = fmt.Sprintf("Failed to marshal JSON: %v", err)
-		return result, nil
-	}
 	if err := os.WriteFile(targetPath, output, 0600); err != nil {
 		result.Message = fmt.Sprintf("Failed to write file: %v", err)
 		return result, nil

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1212,6 +1212,82 @@ const (
 	CodexAuthChatGPT CodexAuthMode = "chatgpt"
 )
 
+// ClearCodexGatewayConfig removes tingly-managed top-level keys from
+// ~/.codex/config.toml so that when a user switches to native ChatGPT OAuth
+// mode the codex CLI falls back to its own defaults rather than trying to
+// route requests through the (now-unused) tingly-box gateway.
+//
+// Only the tingly-managed top-level fields are removed; everything else
+// (other provider entries, profiles, user prefs) is left intact. The previous
+// config.toml is backed up before modification.
+func ClearCodexGatewayConfig() (*ApplyResult, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	targetPath := filepath.Join(homeDir, ".codex", "config.toml")
+	result := &ApplyResult{}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		// Nothing to clear — treat as success.
+		result.Success = true
+		result.Message = "no config.toml found, nothing to clear"
+		return result, nil
+	}
+	cfg := map[string]interface{}{}
+	if err := tomlpkg.Unmarshal(data, &cfg); err != nil {
+		result.Message = fmt.Sprintf("Failed to parse config.toml: %v", err)
+		return result, nil
+	}
+
+	changed := false
+	for _, k := range []string{"model", "model_provider", "model_catalog_json"} {
+		if _, ok := cfg[k]; ok {
+			delete(cfg, k)
+			changed = true
+		}
+	}
+	// Also remove the tingly-box provider stanza if present.
+	if providers, ok := cfg["model_providers"].(map[string]interface{}); ok {
+		if _, ok := providers["tingly-box"]; ok {
+			delete(providers, "tingly-box")
+			if len(providers) == 0 {
+				delete(cfg, "model_providers")
+			}
+			changed = true
+		}
+	}
+
+	if !changed {
+		result.Success = true
+		result.Message = "config.toml has no tingly gateway keys, nothing to clear"
+		return result, nil
+	}
+
+	backupPath, err := backupFile(targetPath)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+		return result, nil
+	}
+	result.BackupPath = backupPath
+
+	out, err := tomlpkg.Marshal(cfg)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal TOML: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, out, 0644); err != nil {
+		result.Message = fmt.Sprintf("Failed to write config.toml: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	result.Updated = true
+	result.Message = fmt.Sprintf("Cleared tingly gateway keys from %s (backup: %s)", targetPath, backupPath)
+	return result, nil
+}
+
 // CodexChatGPTTokens carries the OAuth credentials needed to materialize a
 // native ChatGPT-login `auth.json`.
 type CodexChatGPTTokens struct {

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/agent"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -695,15 +696,36 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 	apiKey := h.config.GetModelToken()
 
 	writeCatalog := req.WriteCatalog == nil || *req.WriteCatalog
-	configResult, err := config.ApplyCodexConfig(codexBaseURL, models, prefs, writeCatalog)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
-			Success: false,
-			Message: "Internal error: " + err.Error(),
-		})
-		return
+
+	authMode := config.CodexAuthMode(req.AuthMode)
+	var chatgptTokens *config.CodexChatGPTTokens
+	if authMode == config.CodexAuthChatGPT {
+		tokens, err := h.loadCodexChatGPTTokens(req.OAuthProviderUUID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ApplyCodexConfigResponse{
+				Success: false,
+				Message: err.Error(),
+			})
+			return
+		}
+		chatgptTokens = tokens
 	}
-	authResult, err := config.ApplyCodexAuth(apiKey)
+
+	// ChatGPT mode: skip the gateway config.toml rewrite entirely — the user
+	// is going direct-to-OpenAI and their existing config should be left alone.
+	configResult := &config.ApplyResult{Success: true, Message: "skipped (chatgpt mode)"}
+	if authMode != config.CodexAuthChatGPT {
+		var err error
+		configResult, err = config.ApplyCodexConfig(codexBaseURL, models, prefs, writeCatalog)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
+				Success: false,
+				Message: "Internal error: " + err.Error(),
+			})
+			return
+		}
+	}
+	authResult, err := config.ApplyCodexAuth(authMode, apiKey, chatgptTokens)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
 			Success: false,
@@ -716,9 +738,43 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 		Success:        configResult.Success && authResult.Success,
 		ConfigResult:   *configResult,
 		AuthResult:     *authResult,
-		CatalogWritten: writeCatalog && len(models) > 0,
+		CatalogWritten: writeCatalog && len(models) > 0 && authMode != config.CodexAuthChatGPT,
 		Models:         models,
 	})
+}
+
+// loadCodexChatGPTTokens pulls the OAuth credentials of the Codex provider
+// identified by uuid out of config storage and shapes them for the native
+// auth.json writer. We rely on the provider record (not oauth.Manager) because
+// configapply already has the global config in hand and providers are the
+// canonical persistence target for OAuth tokens.
+func (h *Handler) loadCodexChatGPTTokens(uuid string) (*config.CodexChatGPTTokens, error) {
+	if uuid == "" {
+		return nil, fmt.Errorf("oauthProviderUuid is required for chatgpt auth mode")
+	}
+	provider, err := h.config.GetProviderByUUID(uuid)
+	if err != nil {
+		return nil, fmt.Errorf("oauth provider not found: %w", err)
+	}
+	if provider.OAuthDetail == nil {
+		return nil, fmt.Errorf("provider %q is not an OAuth provider", provider.Name)
+	}
+	if provider.OAuthDetail.GetIssuer() != ai.IssuerCodex {
+		return nil, fmt.Errorf("provider %q is not a Codex OAuth provider", provider.Name)
+	}
+	tokens := &config.CodexChatGPTTokens{
+		AccessToken:  provider.OAuthDetail.AccessToken,
+		RefreshToken: provider.OAuthDetail.RefreshToken,
+	}
+	if extra := provider.OAuthDetail.ExtraFields; extra != nil {
+		if v, ok := extra["id_token"].(string); ok {
+			tokens.IDToken = v
+		}
+		if v, ok := extra["account_id"].(string); ok {
+			tokens.AccountID = v
+		}
+	}
+	return tokens, nil
 }
 
 // GetCodexConfigPreview returns the TOML/JSON that ApplyCodexConfigFromState

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -714,27 +714,21 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 	// ChatGPT mode: clear tingly gateway keys from config.toml so codex CLI
 	// uses its own defaults, then leave the rest of config.toml untouched.
 	// Gateway mode: full rewrite as before.
-	var configResult *config.ApplyResult
+	var (
+		configResult *config.ApplyResult
+		err          error
+	)
 	if authMode == config.CodexAuthChatGPT {
-		var err error
 		configResult, err = config.ClearCodexGatewayConfig()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
-				Success: false,
-				Message: "Internal error: " + err.Error(),
-			})
-			return
-		}
 	} else {
-		var err error
 		configResult, err = config.ApplyCodexConfig(codexBaseURL, models, prefs, writeCatalog)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
-				Success: false,
-				Message: "Internal error: " + err.Error(),
-			})
-			return
-		}
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
+			Success: false,
+			Message: "Internal error: " + err.Error(),
+		})
+		return
 	}
 	authResult, err := config.ApplyCodexAuth(authMode, apiKey, chatgptTokens)
 	if err != nil {
@@ -773,19 +767,12 @@ func (h *Handler) loadCodexChatGPTTokens(uuid string) (*config.CodexChatGPTToken
 	if provider.OAuthDetail.GetIssuer() != ai.IssuerCodex {
 		return nil, fmt.Errorf("provider %q is not a Codex OAuth provider", provider.Name)
 	}
-	tokens := &config.CodexChatGPTTokens{
+	return &config.CodexChatGPTTokens{
 		AccessToken:  provider.OAuthDetail.AccessToken,
 		RefreshToken: provider.OAuthDetail.RefreshToken,
-	}
-	if extra := provider.OAuthDetail.ExtraFields; extra != nil {
-		if v, ok := extra["id_token"].(string); ok {
-			tokens.IDToken = v
-		}
-		if v, ok := extra["account_id"].(string); ok {
-			tokens.AccountID = v
-		}
-	}
-	return tokens, nil
+		IDToken:      provider.OAuthDetail.GetExtraFieldString("id_token"),
+		AccountID:    provider.OAuthDetail.GetExtraFieldString("account_id"),
+	}, nil
 }
 
 // GetCodexConfigPreview returns the TOML/JSON that ApplyCodexConfigFromState

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -711,10 +711,21 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 		chatgptTokens = tokens
 	}
 
-	// ChatGPT mode: skip the gateway config.toml rewrite entirely — the user
-	// is going direct-to-OpenAI and their existing config should be left alone.
-	configResult := &config.ApplyResult{Success: true, Message: "skipped (chatgpt mode)"}
-	if authMode != config.CodexAuthChatGPT {
+	// ChatGPT mode: clear tingly gateway keys from config.toml so codex CLI
+	// uses its own defaults, then leave the rest of config.toml untouched.
+	// Gateway mode: full rewrite as before.
+	var configResult *config.ApplyResult
+	if authMode == config.CodexAuthChatGPT {
+		var err error
+		configResult, err = config.ClearCodexGatewayConfig()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
+				Success: false,
+				Message: "Internal error: " + err.Error(),
+			})
+			return
+		}
+	} else {
 		var err error
 		configResult, err = config.ApplyCodexConfig(codexBaseURL, models, prefs, writeCatalog)
 		if err != nil {

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/agent"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -761,10 +760,7 @@ func (h *Handler) loadCodexChatGPTTokens(uuid string) (*config.CodexChatGPTToken
 	if err != nil {
 		return nil, fmt.Errorf("oauth provider not found: %w", err)
 	}
-	if provider.OAuthDetail == nil {
-		return nil, fmt.Errorf("provider %q is not an OAuth provider", provider.Name)
-	}
-	if provider.OAuthDetail.GetIssuer() != ai.IssuerCodex {
+	if !provider.IsCodexProvider() || provider.OAuthDetail == nil {
 		return nil, fmt.Errorf("provider %q is not a Codex OAuth provider", provider.Name)
 	}
 	return &config.CodexChatGPTTokens{

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -48,6 +48,17 @@ type OpenCodeConfigPreviewResponse struct {
 type ApplyCodexConfigRequest struct {
 	Preferences  *config.CodexPrefs `json:"preferences"`
 	WriteCatalog *bool              `json:"writeCatalog"`
+
+	// AuthMode selects how ~/.codex/auth.json is populated. "" / "apikey"
+	// writes the gateway key (existing behavior); "chatgpt" exports the
+	// OAuth tokens of the provider identified by OAuthProviderUUID so codex
+	// CLI talks directly to OpenAI. tingly-box stops managing the tokens
+	// after a chatgpt-mode apply — codex CLI owns refresh from then on.
+	AuthMode string `json:"authMode,omitempty"`
+
+	// OAuthProviderUUID identifies the Codex OAuth provider whose tokens
+	// should be exported. Required when AuthMode == "chatgpt".
+	OAuthProviderUUID string `json:"oauthProviderUuid,omitempty"`
 }
 
 // ApplyCodexConfigResponse is the response for ApplyCodexConfigFromState.

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -597,6 +597,15 @@ func (h *Handler) RefreshOAuthToken(c *gin.Context) {
 		provider.OAuthDetail.RefreshToken = token.RefreshToken
 	}
 	provider.OAuthDetail.ExpiresAt = token.Expiry.Format(time.RFC3339)
+	// Codex's native auth.json export reads id_token from ExtraFields. Keep
+	// it in lockstep with AccessToken so refreshed providers don't ship an
+	// expired identity assertion alongside a fresh bearer.
+	if token.IDToken != "" {
+		if provider.OAuthDetail.ExtraFields == nil {
+			provider.OAuthDetail.ExtraFields = map[string]interface{}{}
+		}
+		provider.OAuthDetail.ExtraFields["id_token"] = token.IDToken
+	}
 
 	if err := h.config.UpdateProvider(provider.UUID, provider); err != nil {
 		c.JSON(http.StatusInternalServerError, OAuthErrorResponse{

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -1044,6 +1044,11 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 			provider.OAuthDetail.ExtraFields[k] = v
 		}
 	}
+	// Preserve id_token: required for native Codex `~/.codex/auth.json` export
+	// (chatgpt auth mode). Mirrors the CLI flow in internal/command/oauth.go.
+	if token.IDToken != "" {
+		provider.OAuthDetail.ExtraFields["id_token"] = token.IDToken
+	}
 
 	// Save provider to config
 	if err := h.config.AddProvider(provider); err != nil {


### PR DESCRIPTION
## Summary
Adds support for exporting native ChatGPT OAuth credentials to Codex CLI as an alternative to the existing gateway (API key) mode. In ChatGPT mode, Tingly Box does a **one-shot export** of the OAuth tokens to `~/.codex/auth.json` and strips its managed keys out of `~/.codex/config.toml`; from that point on Codex CLI owns refresh — Tingly Box does not touch the tokens again.

## Key changes

### Backend — Codex config & auth
- `CodexAuthMode` enum (`apikey` / `chatgpt`) plus `CodexChatGPTTokens` payload struct (`apply_config.go`).
- `ApplyCodexAuth(mode, apiKey, tokens)` writes a **fresh** `auth.json` per mode — no merging — so switching apikey→chatgpt can't leave `OPENAI_API_KEY` behind and chatgpt→apikey can't leave a stale `tokens` block. Marshals before backing up so a malformed payload never leaves an orphan backup.
- `ClearCodexGatewayConfig()` surgically removes Tingly's keys from `config.toml` (top-level `model` / `model_provider` / `model_catalog_json` + `[model_providers.tingly-box]`). Shared `codexGatewayProviderName` + `codexGatewayTopLevelKeys` constants keep the writer (`mergeCodexConfig`) and eraser in sync. Fast-paths when `config.toml` never mentions the tingly provider so we don't re-marshal user TOML (which would lose comments and reorder keys).

### HTTP / agent wiring
- `ApplyCodexConfigRequest` gains `authMode` + `oauthProviderUuid`.
- Handler branches: chatgpt mode pulls tokens from the selected provider via `loadCodexChatGPTTokens` (which reuses `Provider.IsCodexProvider()`) and calls `ClearCodexGatewayConfig`; apikey mode keeps the existing `ApplyCodexConfig` path.
- `CodexParams` (agent) carries the same two fields so the CLI/agent path mirrors the handler.

### OAuth token plumbing
- `OAuthDetail.ExtraFields["id_token"]` is now populated on both initial auth **and** refresh, so the exported `auth.json` ships an identity assertion in lockstep with the access token.
- Added `OAuthDetail.GetExtraFieldString(key)` helper; migrated 5 existing call sites (`codex_client`, `openai`, `gemini_client`, `antigravity_client`, `quota/fetcher/codex`) off the hand-rolled `ExtraFields[k].(string)` cast.
- Diagnostic warning logs the **sorted key set** of the token-exchange response when `id_token` is missing — no secret values leak into logs.

### Frontend
- Auth-source radio group in `CodexConfigModal`: "Via Tingly Box gateway (API key)" vs "Native ChatGPT OAuth".
- Lazy-fetches the list of Codex OAuth providers only when the user selects chatgpt mode; provider selector dropdown shows the chosen credential.
- Resets `authMode` / `selectedOAuthProvider` / provider list on every modal open so a deleted provider can't leave a stale UUID selected.
- Info alert explains the one-shot export and the re-auth note for missing `id_token`. Quick / Manual config tabs and preview are hidden in chatgpt mode.

## Test plan
- [ ] Apply gateway mode (existing flow): `config.toml` updated with tingly keys, `auth.json` has `OPENAI_API_KEY` only, no `tokens` block.
- [ ] Apply chatgpt mode: `config.toml` has tingly keys stripped while user's other settings are preserved; `auth.json` has `auth_mode: "chatgpt"` + `tokens` block, no `OPENAI_API_KEY`.
- [ ] Switch apikey → chatgpt → apikey: each transition writes a fresh `auth.json` with only the keys belonging to the active mode.
- [ ] Backup files exist at `~/.codex/backup/*.bak-<timestamp>{.toml,.json}` after each apply; nothing left behind on validation failure.
- [ ] Codex CLI starts under chatgpt mode and can refresh its tokens on its own.
- [ ] Token refresh through Tingly Box updates `id_token` in storage (verify via subsequent apply).

https://claude.ai/code/session_0116Ba5FwRHZBwRk8dZzRBpP