### PR TITLE
refactor(ui, rule-card): restructure extension catalog grouping

### DIFF
--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -47,6 +47,7 @@ import {
     IconDeviceLaptop,
     IconDeviceDesktop,
     IconArrowBarToRight,
+    IconArrowBarRight,
     IconPuzzle,
     IconAlertCircle,
     IconAlertTriangle,
@@ -200,6 +201,7 @@ export const LocationOn = tablerMui(IconMapPin);
 export const Hub = tablerMui(IconShare);
 export const Cable = tablerMui(IconPlugConnected);
 export const Input = tablerMui(IconArrowBarToRight);
+export const Output = tablerMui(IconArrowBarRight);
 export const Psychology = tablerMui(IconBrain);
 
 // --- Devices / brand / theme -------------------------------------------------

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -47,7 +47,7 @@ import {
     IconDeviceLaptop,
     IconDeviceDesktop,
     IconArrowBarToRight,
-    IconArrowBarRight,
+    IconArrowBarToLeft,
     IconPuzzle,
     IconAlertCircle,
     IconAlertTriangle,
@@ -201,7 +201,7 @@ export const LocationOn = tablerMui(IconMapPin);
 export const Hub = tablerMui(IconShare);
 export const Cable = tablerMui(IconPlugConnected);
 export const Input = tablerMui(IconArrowBarToRight);
-export const Output = tablerMui(IconArrowBarRight);
+export const Output = tablerMui(IconArrowBarToLeft);
 export const Psychology = tablerMui(IconBrain);
 
 // --- Devices / brand / theme -------------------------------------------------

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -178,37 +178,27 @@ const resetFlag = (flags: RuleFlags, spec: FlagSpec): RuleFlags => {
 interface CategoryMeta {
     label: string;
     icon: React.ReactElement;
+    /** If set, this category's flags are folded into the named display category. */
+    mergeInto?: string;
+    /** Sub-sort order within a merged display group (lower = earlier). */
+    mergeOrder?: number;
 }
-
-// Backend categories merged into a display category (collapsed in sidebar).
-const CATEGORY_MERGE: Record<string, string> = {
-    openai: 'request',
-    http: 'request',
-};
 
 // Display order for the category sidebar. Unknown categories are appended.
 const CATEGORY_ORDER = ['request', 'response', 'reasoning', 'vision', 'routing', 'ide'];
 
-// Within a merged group, sub-sort by original category (lower = earlier).
-const MERGED_SUBCATEGORY_ORDER: Record<string, number> = {
-    http: 0,
-    openai: 1,
-    request: 2,
-};
-
-// Display metadata for both sidebar categories and origin badges.
 const CATEGORY_META: Record<string, CategoryMeta> = {
-    ide: { label: 'IDE', icon: <TerminalIcon fontSize="small" /> },
-    openai: { label: 'OpenAI', icon: <AutoAwesomeIcon fontSize="small" /> },
-    http: { label: 'HTTP', icon: <CableIcon fontSize="small" /> },
-    response: { label: 'Response', icon: <OutboundIcon fontSize="small" /> },
-    request: { label: 'Request', icon: <InputIcon fontSize="small" /> },
-    reasoning: { label: 'Reasoning', icon: <PsychologyIcon fontSize="small" /> },
-    routing: { label: 'Routing', icon: <LinkIcon fontSize="small" /> },
-    vision: { label: 'Vision', icon: <VisibilityIcon fontSize="small" /> },
+    http:     { label: 'HTTP',      icon: <CableIcon      fontSize="small" />, mergeInto: 'request', mergeOrder: 0 },
+    openai:   { label: 'OpenAI',    icon: <AutoAwesomeIcon fontSize="small" />, mergeInto: 'request', mergeOrder: 1 },
+    request:  { label: 'Request',   icon: <InputIcon      fontSize="small" />, mergeOrder: 2 },
+    response: { label: 'Response',  icon: <OutboundIcon   fontSize="small" /> },
+    reasoning:{ label: 'Reasoning', icon: <PsychologyIcon fontSize="small" /> },
+    vision:   { label: 'Vision',    icon: <VisibilityIcon fontSize="small" /> },
+    routing:  { label: 'Routing',   icon: <LinkIcon       fontSize="small" /> },
+    ide:      { label: 'IDE',       icon: <TerminalIcon   fontSize="small" /> },
 };
 
-const categoryMeta = (category: string): CategoryMeta => CATEGORY_META[category] || {
+const categoryMeta = (category: string): CategoryMeta => CATEGORY_META[category] ?? {
     label: category.charAt(0).toUpperCase() + category.slice(1),
     icon: <ExtensionIcon fontSize="small" />,
 };
@@ -237,24 +227,20 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
         }
     }, [open, flags]);
 
-    // Group registry entries by display category (applying CATEGORY_MERGE),
+    // Group registry entries by display category (mergeInto from CATEGORY_META),
     // then sort the groups by CATEGORY_ORDER and sub-sort specs within each
     // merged group (http first, then openai, then native request items).
     const grouped = useMemo(() => {
         const groups = new Map<string, FlagSpec[]>();
         (registry || []).forEach((spec) => {
-            const displayCat = CATEGORY_MERGE[spec.category] ?? spec.category;
+            const displayCat = categoryMeta(spec.category).mergeInto ?? spec.category;
             if (!groups.has(displayCat)) groups.set(displayCat, []);
             groups.get(displayCat)!.push(spec);
         });
 
-        // Sub-sort within each merged group.
+        // Sub-sort within each merged group by mergeOrder.
         groups.forEach((specs) => {
-            specs.sort((a, b) => {
-                const ao = MERGED_SUBCATEGORY_ORDER[a.category] ?? 99;
-                const bo = MERGED_SUBCATEGORY_ORDER[b.category] ?? 99;
-                return ao - bo;
-            });
+            specs.sort((a, b) => (categoryMeta(a.category).mergeOrder ?? 99) - (categoryMeta(b.category).mergeOrder ?? 99));
         });
 
         // Build ordered list: defined order first, then any unknown categories.
@@ -291,7 +277,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     };
 
     const jumpToFlag = (spec: FlagSpec) => {
-        const displayCat = CATEGORY_MERGE[spec.category] ?? spec.category;
+        const displayCat = categoryMeta(spec.category).mergeInto ?? spec.category;
         if (displayCat !== activeCategory) setActiveCategory(displayCat);
         // Defer scroll/pulse until the right pane has rendered the target.
         requestAnimationFrame(() => {
@@ -441,9 +427,8 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                             : '';
                                         const pulsing = pulseKey === spec.key;
                                         // Show origin badge when a flag was merged from another category.
-                                        const originBadge = CATEGORY_MERGE[spec.category]
-                                            ? categoryMeta(spec.category)
-                                            : null;
+                                        const meta = categoryMeta(spec.category);
+                                        const originBadge = meta.mergeInto ? meta : null;
                                         return (
                                             <Box
                                                 key={spec.key}

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -20,7 +20,7 @@ import {
     Extension as ExtensionIcon,
     Input as InputIcon,
     Link as LinkIcon,
-    Outbound as OutboundIcon,
+    Output as OutputIcon,
     Psychology as PsychologyIcon,
     Terminal as TerminalIcon,
     Visibility as VisibilityIcon,
@@ -183,7 +183,7 @@ const CATEGORY_ORDER = ['request', 'response', 'reasoning', 'vision', 'routing',
 
 const CATEGORY_META: Record<string, CategoryMeta> = {
     request:  { label: 'Request',   icon: <InputIcon      fontSize="small" /> },
-    response: { label: 'Response',  icon: <OutboundIcon   fontSize="small" /> },
+    response: { label: 'Response',  icon: <OutputIcon     fontSize="small" /> },
     reasoning:{ label: 'Reasoning', icon: <PsychologyIcon fontSize="small" /> },
     vision:   { label: 'Vision',    icon: <VisibilityIcon fontSize="small" /> },
     routing:  { label: 'Routing',   icon: <LinkIcon       fontSize="small" /> },

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -177,7 +177,7 @@ interface CategoryMeta {
 }
 
 // Display order for the category sidebar. Unknown categories are appended.
-const CATEGORY_ORDER = ['request', 'response', 'reasoning', 'vision', 'routing', 'ide'];
+const CATEGORY_ORDER = ['request', 'response', 'reasoning', 'vision', 'routing', 'app'];
 
 const CATEGORY_META: Record<string, CategoryMeta> = {
     request:  { label: 'Request',   icon: <InputIcon      fontSize="small" /> },
@@ -185,7 +185,7 @@ const CATEGORY_META: Record<string, CategoryMeta> = {
     reasoning:{ label: 'Reasoning', icon: <PsychologyIcon fontSize="small" /> },
     vision:   { label: 'Vision',    icon: <VisibilityIcon fontSize="small" /> },
     routing:  { label: 'Routing',   icon: <LinkIcon       fontSize="small" /> },
-    ide:      { label: 'IDE',       icon: <TerminalIcon   fontSize="small" /> },
+    app:      { label: 'App',       icon: <TerminalIcon   fontSize="small" /> },
 };
 
 const categoryMeta = (category: string): CategoryMeta => CATEGORY_META[category] ?? {

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -226,7 +226,8 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
             groups.get(spec.category)!.push(spec);
         });
         const ordered = CATEGORY_ORDER.filter((cat) => groups.has(cat));
-        groups.forEach((_, cat) => { if (!ordered.includes(cat)) ordered.push(cat); });
+        const orderedSet = new Set(ordered);
+        groups.forEach((_, cat) => { if (!orderedSet.has(cat)) ordered.push(cat); });
         return ordered.map((cat) => ({ category: cat, specs: groups.get(cat) || [] }));
     }, [registry]);
 

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -237,13 +237,6 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
         }
     }, [open, flags]);
 
-    // Original backend category keyed by flag key — used to render origin badges.
-    const originMap = useMemo(() => {
-        const map = new Map<string, string>();
-        (registry || []).forEach((spec) => map.set(spec.key, spec.category));
-        return map;
-    }, [registry]);
-
     // Group registry entries by display category (applying CATEGORY_MERGE),
     // then sort the groups by CATEGORY_ORDER and sub-sort specs within each
     // merged group (http first, then openai, then native request items).
@@ -447,11 +440,9 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                             ? (flagToString(draft, spec.key) || enumDefault(spec))
                                             : '';
                                         const pulsing = pulseKey === spec.key;
-                                        const originCat = originMap.get(spec.key) ?? spec.category;
-                                        const displayCat = CATEGORY_MERGE[originCat] ?? originCat;
                                         // Show origin badge when a flag was merged from another category.
-                                        const originBadge = displayCat !== originCat
-                                            ? categoryMeta(originCat)
+                                        const originBadge = CATEGORY_MERGE[spec.category]
+                                            ? categoryMeta(spec.category)
                                             : null;
                                         return (
                                             <Box

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -16,8 +16,6 @@ import {
     Typography,
 } from '@mui/material';
 import {
-    AutoAwesome as AutoAwesomeIcon,
-    Cable as CableIcon,
     Close as CloseIcon,
     Extension as ExtensionIcon,
     Input as InputIcon,
@@ -178,19 +176,13 @@ const resetFlag = (flags: RuleFlags, spec: FlagSpec): RuleFlags => {
 interface CategoryMeta {
     label: string;
     icon: React.ReactElement;
-    /** If set, this category's flags are folded into the named display category. */
-    mergeInto?: string;
-    /** Sub-sort order within a merged display group (lower = earlier). */
-    mergeOrder?: number;
 }
 
 // Display order for the category sidebar. Unknown categories are appended.
 const CATEGORY_ORDER = ['request', 'response', 'reasoning', 'vision', 'routing', 'ide'];
 
 const CATEGORY_META: Record<string, CategoryMeta> = {
-    http:     { label: 'HTTP',      icon: <CableIcon      fontSize="small" />, mergeInto: 'request', mergeOrder: 0 },
-    openai:   { label: 'OpenAI',    icon: <AutoAwesomeIcon fontSize="small" />, mergeInto: 'request', mergeOrder: 1 },
-    request:  { label: 'Request',   icon: <InputIcon      fontSize="small" />, mergeOrder: 2 },
+    request:  { label: 'Request',   icon: <InputIcon      fontSize="small" /> },
     response: { label: 'Response',  icon: <OutboundIcon   fontSize="small" /> },
     reasoning:{ label: 'Reasoning', icon: <PsychologyIcon fontSize="small" /> },
     vision:   { label: 'Vision',    icon: <VisibilityIcon fontSize="small" /> },
@@ -227,26 +219,16 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
         }
     }, [open, flags]);
 
-    // Group registry entries by display category (mergeInto from CATEGORY_META),
-    // then sort the groups by CATEGORY_ORDER and sub-sort specs within each
-    // merged group (http first, then openai, then native request items).
+    // Group registry entries by category, preserving backend order within each
+    // group, then sort groups by CATEGORY_ORDER (unknown categories appended).
     const grouped = useMemo(() => {
         const groups = new Map<string, FlagSpec[]>();
         (registry || []).forEach((spec) => {
-            const displayCat = categoryMeta(spec.category).mergeInto ?? spec.category;
-            if (!groups.has(displayCat)) groups.set(displayCat, []);
-            groups.get(displayCat)!.push(spec);
+            if (!groups.has(spec.category)) groups.set(spec.category, []);
+            groups.get(spec.category)!.push(spec);
         });
-
-        // Sub-sort within each merged group by mergeOrder.
-        groups.forEach((specs) => {
-            specs.sort((a, b) => (categoryMeta(a.category).mergeOrder ?? 99) - (categoryMeta(b.category).mergeOrder ?? 99));
-        });
-
-        // Build ordered list: defined order first, then any unknown categories.
         const ordered = CATEGORY_ORDER.filter((cat) => groups.has(cat));
         groups.forEach((_, cat) => { if (!ordered.includes(cat)) ordered.push(cat); });
-
         return ordered.map((cat) => ({ category: cat, specs: groups.get(cat) || [] }));
     }, [registry]);
 
@@ -277,8 +259,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     };
 
     const jumpToFlag = (spec: FlagSpec) => {
-        const displayCat = categoryMeta(spec.category).mergeInto ?? spec.category;
-        if (displayCat !== activeCategory) setActiveCategory(displayCat);
+        if (spec.category !== activeCategory) setActiveCategory(spec.category);
         // Defer scroll/pulse until the right pane has rendered the target.
         requestAnimationFrame(() => {
             const node = flagRefs.current[spec.key];
@@ -426,9 +407,6 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                             ? (flagToString(draft, spec.key) || enumDefault(spec))
                                             : '';
                                         const pulsing = pulseKey === spec.key;
-                                        // Show origin badge when a flag was merged from another category.
-                                        const meta = categoryMeta(spec.category);
-                                        const originBadge = meta.mergeInto ? meta : null;
                                         return (
                                             <Box
                                                 key={spec.key}
@@ -451,7 +429,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                             >
                                                 <Stack direction="row" alignItems="center" spacing={1}>
                                                     <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                                                        <Stack direction="row" alignItems="center" spacing={0.75} flexWrap="wrap">
+                                                        <Stack direction="row" alignItems="center" spacing={0.75}>
                                                             <Typography variant="body2" sx={{ fontWeight: 600 }}>
                                                                 {spec.label}
                                                             </Typography>
@@ -461,16 +439,6 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                                                 sx={{ height: 16, fontSize: '0.6rem' }}
                                                                 variant="outlined"
                                                             />
-                                                            {originBadge && (
-                                                                <Chip
-                                                                    size="small"
-                                                                    icon={originBadge.icon}
-                                                                    label={originBadge.label}
-                                                                    sx={{ height: 16, fontSize: '0.6rem' }}
-                                                                    color="default"
-                                                                    variant="filled"
-                                                                />
-                                                            )}
                                                         </Stack>
                                                         <Typography variant="caption" color="text.secondary">
                                                             {spec.description}

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -126,8 +126,6 @@ const setBool = (flags: RuleFlags, key: string, value: boolean): RuleFlags => {
             return { ...flags, useMaxCompletionTokens: value };
         case 'use_max_tokens':
             return { ...flags, useMaxTokens: value };
-        case 'session_affinity':
-            return { ...flags, sessionAffinity: value };
         default:
             return flags;
     }

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -180,7 +180,23 @@ interface CategoryMeta {
     icon: React.ReactElement;
 }
 
-// Defaults for known categories; unknown ones fall through to a generic style.
+// Backend categories merged into a display category (collapsed in sidebar).
+const CATEGORY_MERGE: Record<string, string> = {
+    openai: 'request',
+    http: 'request',
+};
+
+// Display order for the category sidebar. Unknown categories are appended.
+const CATEGORY_ORDER = ['request', 'response', 'reasoning', 'vision', 'routing', 'ide'];
+
+// Within a merged group, sub-sort by original category (lower = earlier).
+const MERGED_SUBCATEGORY_ORDER: Record<string, number> = {
+    http: 0,
+    openai: 1,
+    request: 2,
+};
+
+// Display metadata for both sidebar categories and origin badges.
 const CATEGORY_META: Record<string, CategoryMeta> = {
     ide: { label: 'IDE', icon: <TerminalIcon fontSize="small" /> },
     openai: { label: 'OpenAI', icon: <AutoAwesomeIcon fontSize="small" /> },
@@ -221,19 +237,38 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
         }
     }, [open, flags]);
 
-    // Group registry entries by category, preserving the order they first
-    // appear in the registry — backend dictates display order.
+    // Original backend category keyed by flag key — used to render origin badges.
+    const originMap = useMemo(() => {
+        const map = new Map<string, string>();
+        (registry || []).forEach((spec) => map.set(spec.key, spec.category));
+        return map;
+    }, [registry]);
+
+    // Group registry entries by display category (applying CATEGORY_MERGE),
+    // then sort the groups by CATEGORY_ORDER and sub-sort specs within each
+    // merged group (http first, then openai, then native request items).
     const grouped = useMemo(() => {
-        const order: string[] = [];
         const groups = new Map<string, FlagSpec[]>();
         (registry || []).forEach((spec) => {
-            if (!groups.has(spec.category)) {
-                order.push(spec.category);
-                groups.set(spec.category, []);
-            }
-            groups.get(spec.category)!.push(spec);
+            const displayCat = CATEGORY_MERGE[spec.category] ?? spec.category;
+            if (!groups.has(displayCat)) groups.set(displayCat, []);
+            groups.get(displayCat)!.push(spec);
         });
-        return order.map((cat) => ({ category: cat, specs: groups.get(cat) || [] }));
+
+        // Sub-sort within each merged group.
+        groups.forEach((specs) => {
+            specs.sort((a, b) => {
+                const ao = MERGED_SUBCATEGORY_ORDER[a.category] ?? 99;
+                const bo = MERGED_SUBCATEGORY_ORDER[b.category] ?? 99;
+                return ao - bo;
+            });
+        });
+
+        // Build ordered list: defined order first, then any unknown categories.
+        const ordered = CATEGORY_ORDER.filter((cat) => groups.has(cat));
+        groups.forEach((_, cat) => { if (!ordered.includes(cat)) ordered.push(cat); });
+
+        return ordered.map((cat) => ({ category: cat, specs: groups.get(cat) || [] }));
     }, [registry]);
 
     // Default the selected category to the first one with content.
@@ -263,7 +298,8 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     };
 
     const jumpToFlag = (spec: FlagSpec) => {
-        if (spec.category !== activeCategory) setActiveCategory(spec.category);
+        const displayCat = CATEGORY_MERGE[spec.category] ?? spec.category;
+        if (displayCat !== activeCategory) setActiveCategory(displayCat);
         // Defer scroll/pulse until the right pane has rendered the target.
         requestAnimationFrame(() => {
             const node = flagRefs.current[spec.key];
@@ -411,6 +447,12 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                             ? (flagToString(draft, spec.key) || enumDefault(spec))
                                             : '';
                                         const pulsing = pulseKey === spec.key;
+                                        const originCat = originMap.get(spec.key) ?? spec.category;
+                                        const displayCat = CATEGORY_MERGE[originCat] ?? originCat;
+                                        // Show origin badge when a flag was merged from another category.
+                                        const originBadge = displayCat !== originCat
+                                            ? categoryMeta(originCat)
+                                            : null;
                                         return (
                                             <Box
                                                 key={spec.key}
@@ -433,7 +475,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                             >
                                                 <Stack direction="row" alignItems="center" spacing={1}>
                                                     <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                                                        <Stack direction="row" alignItems="center" spacing={0.75}>
+                                                        <Stack direction="row" alignItems="center" spacing={0.75} flexWrap="wrap">
                                                             <Typography variant="body2" sx={{ fontWeight: 600 }}>
                                                                 {spec.label}
                                                             </Typography>
@@ -443,6 +485,16 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                                                 sx={{ height: 16, fontSize: '0.6rem' }}
                                                                 variant="outlined"
                                                             />
+                                                            {originBadge && (
+                                                                <Chip
+                                                                    size="small"
+                                                                    icon={originBadge.icon}
+                                                                    label={originBadge.label}
+                                                                    sx={{ height: 16, fontSize: '0.6rem' }}
+                                                                    color="default"
+                                                                    variant="filled"
+                                                                />
+                                                            )}
                                                         </Stack>
                                                         <Typography variant="caption" color="text.secondary">
                                                             {spec.description}

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -151,7 +151,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "cursor_compat",
 			Label:       "Cursor compatibility",
-			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor IDE clients.",
+			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor clients.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryApp,
 		},

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -87,14 +87,14 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "use_max_completion_tokens",
 			Label:       "Use max_completion_tokens",
-			Description: "Rewrite request field `max_tokens` to `max_completion_tokens` (required by o1/o3/gpt-5 family).",
+			Description: "OpenAI only. Rewrite `max_tokens` → `max_completion_tokens` in the outgoing request. Required by the o1/o3/gpt-5 model family, which rejects the older field name.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequest,
 		},
 		{
 			Key:         "use_max_tokens",
 			Label:       "Use max_tokens (legacy)",
-			Description: "Rewrite request field `max_completion_tokens` back to the legacy `max_tokens`. Use for providers that reject the newer field name.",
+			Description: "OpenAI only. Rewrite `max_completion_tokens` → `max_tokens` in the outgoing request. Use for older OpenAI-compatible providers that do not yet accept the newer field name.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequest,
 		},

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -21,8 +21,8 @@ const (
 type FlagCategory string
 
 const (
-	// FlagCategoryIDE — flags that target a specific IDE/client (e.g. Cursor).
-	FlagCategoryIDE FlagCategory = "ide"
+	// FlagCategoryApp — flags that target a specific client application (IDE, CLI tool, etc).
+	FlagCategoryApp FlagCategory = "app"
 	// FlagCategoryRequest — request-level adjustments: transport overrides,
 	// OpenAI-specific field rewrites, tool blocking, etc.
 	FlagCategoryRequest FlagCategory = "request"
@@ -147,20 +147,20 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:    FlagCategoryRouting,
 			Placeholder: "e.g. 3600",
 		},
-		// ── IDE ────────────────────────────────────────────────────────────
+		// ── App ────────────────────────────────────────────────────────────
 		{
 			Key:         "cursor_compat",
 			Label:       "Cursor compatibility",
 			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor IDE clients.",
 			Type:        FlagTypeBool,
-			Category:    FlagCategoryIDE,
+			Category:    FlagCategoryApp,
 		},
 		{
 			Key:         "cursor_compat_auto",
 			Label:       "Auto-detect Cursor",
 			Description: "Apply cursor compatibility automatically when request headers identify Cursor.",
 			Type:        FlagTypeBool,
-			Category:    FlagCategoryIDE,
+			Category:    FlagCategoryApp,
 		},
 	}
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -23,16 +23,11 @@ type FlagCategory string
 const (
 	// FlagCategoryIDE — flags that target a specific IDE/client (e.g. Cursor).
 	FlagCategoryIDE FlagCategory = "ide"
-	// FlagCategoryOpenAI — OpenAI-specific request-shape adjustments
-	// (max_tokens vs max_completion_tokens, chat vs responses endpoint, ...).
-	FlagCategoryOpenAI FlagCategory = "openai"
-	// FlagCategoryHTTP — transport-level overrides (custom User-Agent, etc).
-	FlagCategoryHTTP FlagCategory = "http"
+	// FlagCategoryRequest — request-level adjustments: transport overrides,
+	// OpenAI-specific field rewrites, tool blocking, etc.
+	FlagCategoryRequest FlagCategory = "request"
 	// FlagCategoryResponse — flags that modify the response body/stream.
 	FlagCategoryResponse FlagCategory = "response"
-	// FlagCategoryRequest — protocol-agnostic request-body guard rails
-	// (tool blocking, etc).
-	FlagCategoryRequest FlagCategory = "request"
 	// FlagCategoryReasoning — extended-thinking / reasoning-effort controls.
 	FlagCategoryReasoning FlagCategory = "reasoning"
 	// FlagCategoryRouting — routing / load-balancing behavior (session
@@ -64,50 +59,17 @@ type FlagSpec struct {
 }
 
 // RuleFlagRegistry returns the catalog of supported rule flags. The order is
-// the recommended display order in the UI.
+// the recommended display order in the UI — categories are grouped implicitly
+// by adjacent entries sharing the same Category value.
 func RuleFlagRegistry() []FlagSpec {
 	return []FlagSpec{
-		{
-			Key:         "cursor_compat",
-			Label:       "Cursor compatibility",
-			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor IDE clients.",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryIDE,
-		},
-		{
-			Key:         "cursor_compat_auto",
-			Label:       "Auto-detect Cursor",
-			Description: "Apply cursor compatibility automatically when request headers identify Cursor.",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryIDE,
-		},
-		{
-			Key:         "skip_usage",
-			Label:       "Skip usage in response",
-			Description: "Strip the `usage` block from responses (both SSE deltas and the final body).",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryResponse,
-		},
-		{
-			Key:         "use_max_completion_tokens",
-			Label:       "Use max_completion_tokens",
-			Description: "Rewrite request field `max_tokens` to `max_completion_tokens` (required by o1/o3/gpt-5 family).",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryOpenAI,
-		},
-		{
-			Key:         "use_max_tokens",
-			Label:       "Use max_tokens (legacy)",
-			Description: "Rewrite request field `max_completion_tokens` back to the legacy `max_tokens`. Use for providers that reject the newer field name.",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryOpenAI,
-		},
+		// ── Request ────────────────────────────────────────────────────────
 		{
 			Key:         "custom_user_agent",
 			Label:       "Custom User-Agent",
 			Description: "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent.",
 			Type:        FlagTypeString,
-			Category:    FlagCategoryHTTP,
+			Category:    FlagCategoryRequest,
 			Placeholder: "e.g. MyApp/1.0",
 		},
 		{
@@ -115,12 +77,26 @@ func RuleFlagRegistry() []FlagSpec {
 			Label:       "OpenAI endpoint override",
 			Description: "Force OpenAI Chat Completions or Responses for this rule, overriding the provider's declared OpenAIEndpointMode default. OpenAI providers only; Anthropic/Google providers ignore this. If the provider declares mode=responses (e.g. Codex), \"chat\" is ignored; if mode=chat, \"responses\" is ignored.",
 			Type:        FlagTypeEnum,
-			Category:    FlagCategoryOpenAI,
+			Category:    FlagCategoryRequest,
 			Options: []FlagOption{
 				{Value: "auto", Label: "Auto (use provider default)"},
 				{Value: "chat", Label: "Force Chat Completions"},
 				{Value: "responses", Label: "Force Responses API"},
 			},
+		},
+		{
+			Key:         "use_max_completion_tokens",
+			Label:       "Use max_completion_tokens",
+			Description: "Rewrite request field `max_tokens` to `max_completion_tokens` (required by o1/o3/gpt-5 family).",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryRequest,
+		},
+		{
+			Key:         "use_max_tokens",
+			Label:       "Use max_tokens (legacy)",
+			Description: "Rewrite request field `max_completion_tokens` back to the legacy `max_tokens`. Use for providers that reject the newer field name.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryRequest,
 		},
 		{
 			Key:         "block_tools",
@@ -130,6 +106,15 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:    FlagCategoryRequest,
 			Placeholder: "e.g. web_search,run_terminal_cmd",
 		},
+		// ── Response ───────────────────────────────────────────────────────
+		{
+			Key:         "skip_usage",
+			Label:       "Skip usage in response",
+			Description: "Strip the `usage` block from responses (both SSE deltas and the final body).",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryResponse,
+		},
+		// ── Reasoning ──────────────────────────────────────────────────────
 		{
 			Key:         "thinking_effort",
 			Label:       "Thinking",
@@ -145,6 +130,15 @@ func RuleFlagRegistry() []FlagSpec {
 				{Value: "max", Label: "Max (~32K tokens)"},
 			},
 		},
+		// ── Vision ─────────────────────────────────────────────────────────
+		{
+			Key:         "vision_proxy_service",
+			Label:       "Vision Proxy",
+			Description: "Describe images via a vision-capable model so text-only downstream models can read them. Applies only to requests matched by this rule. Same effect as the scenario-level Vision Proxy but scoped to this rule; when both are configured, this rule-level service takes precedence.",
+			Type:        FlagTypeServiceRef,
+			Category:    FlagCategoryVision,
+		},
+		// ── Routing ────────────────────────────────────────────────────────
 		{
 			Key:         "session_affinity",
 			Label:       "Session affinity",
@@ -153,12 +147,20 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:    FlagCategoryRouting,
 			Placeholder: "e.g. 3600",
 		},
+		// ── IDE ────────────────────────────────────────────────────────────
 		{
-			Key:         "vision_proxy_service",
-			Label:       "Vision Proxy",
-			Description: "Describe images via a vision-capable model so text-only downstream models can read them. Applies only to requests matched by this rule. Same effect as the scenario-level Vision Proxy but scoped to this rule; when both are configured, this rule-level service takes precedence.",
-			Type:        FlagTypeServiceRef,
-			Category:    FlagCategoryVision,
+			Key:         "cursor_compat",
+			Label:       "Cursor compatibility",
+			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor IDE clients.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryIDE,
+		},
+		{
+			Key:         "cursor_compat_auto",
+			Label:       "Auto-detect Cursor",
+			Description: "Apply cursor compatibility automatically when request headers identify Cursor.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryIDE,
 		},
 	}
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -86,14 +86,14 @@ func RuleFlagRegistry() []FlagSpec {
 		},
 		{
 			Key:         "use_max_completion_tokens",
-			Label:       "Use max_completion_tokens",
+			Label:       "OpenAI: Use max_completion_tokens",
 			Description: "OpenAI only. Rewrite `max_tokens` → `max_completion_tokens` in the outgoing request. Required by the o1/o3/gpt-5 model family, which rejects the older field name.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequest,
 		},
 		{
 			Key:         "use_max_tokens",
-			Label:       "Use max_tokens (legacy)",
+			Label:       "OpenAI: Use max_tokens (legacy)",
 			Description: "OpenAI only. Rewrite `max_completion_tokens` → `max_tokens` in the outgoing request. Use for older OpenAI-compatible providers that do not yet accept the newer field name.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequest,


### PR DESCRIPTION
## Summary

- **Move grouping to source data**: merge `openai` and `http` backend categories into `request` directly in `flag_registry.go`, eliminating all frontend remapping logic (`CATEGORY_MERGE`, `mergeInto`, `mergeOrder`, origin badges)
- **Enforce sidebar order** via a single `CATEGORY_ORDER` array on the frontend: `request → response → reasoning → vision → routing → app`
- **Rename IDE → App** category (`"ide"` → `"app"`) — not limited to IDEs
- **Reorder registry** to reflect the new grouping: within `request`, HTTP overrides first, then OpenAI-specific field rewrites, then tool blocking
- **Clarify OpenAI flags**: prefix labels with `OpenAI:` and lead descriptions with `OpenAI only.` for `use_max_completion_tokens` / `use_max_tokens`
- **Fix `session_affinity` in `setBool`**: it's an `int` flag, not `bool` — the stray case was silently a no-op
- **Add `Output` icon** (`←|`, `IconArrowBarToLeft`) as the directional counterpart to `Input` (`→|`); use it for the Response sidebar entry

## Test plan

- [ ] Open the extension catalog on any rule — sidebar shows: Request, Response, Reasoning, Vision, Routing, App
- [ ] Request group contains: Custom User-Agent, OpenAI endpoint override, OpenAI: Use max_completion_tokens, OpenAI: Use max_tokens (legacy), Block tools
- [ ] Response sidebar icon is `←|`, Request is `→|`
- [ ] App group contains Cursor flags
- [ ] Active-flag chips navigate correctly to the merged Request group

https://claude.ai/code/session_01FsyXYNdYjEaVAQG6Z1yoyC