### PR TITLE
refactor(usage): centralize token usage normalization + fix wire-format bugs

### DIFF
--- a/internal/protocol/nonstream/anthropic_passthrough.go
+++ b/internal/protocol/nonstream/anthropic_passthrough.go
@@ -5,30 +5,21 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // HandleAnthropicV1NonStream handles Anthropic v1 non-streaming response.
 // Returns (UsageStat, error)
 func HandleAnthropicV1NonStream(hc *protocol.HandleContext, resp *anthropic.Message) (*protocol.TokenUsage, error) {
-	inputTokens := int(resp.Usage.InputTokens) + int(resp.Usage.CacheCreationInputTokens)
-	outputTokens := int(resp.Usage.OutputTokens)
-	cacheTokens := int(resp.Usage.CacheReadInputTokens)
-
 	resp.Model = anthropic.Model(hc.ResponseModel)
-
 	hc.GinContext.JSON(http.StatusOK, resp)
-	return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+	return usage.FromAnthropicMessage(resp.Usage), nil
 }
 
 // HandleAnthropicV1BetaNonStream handles Anthropic v1 beta non-streaming response.
 // Returns (UsageStat, error)
 func HandleAnthropicV1BetaNonStream(hc *protocol.HandleContext, resp *anthropic.BetaMessage) (*protocol.TokenUsage, error) {
-	inputTokens := int(resp.Usage.InputTokens) + int(resp.Usage.CacheCreationInputTokens)
-	outputTokens := int(resp.Usage.OutputTokens)
-	cacheTokens := int(resp.Usage.CacheReadInputTokens)
-
 	resp.Model = anthropic.Model(hc.ResponseModel)
-
 	hc.GinContext.JSON(http.StatusOK, resp)
-	return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+	return usage.FromAnthropicBetaMessage(resp.Usage), nil
 }

--- a/internal/protocol/nonstream/anthropic_passthrough.go
+++ b/internal/protocol/nonstream/anthropic_passthrough.go
@@ -10,7 +10,7 @@ import (
 // HandleAnthropicV1NonStream handles Anthropic v1 non-streaming response.
 // Returns (UsageStat, error)
 func HandleAnthropicV1NonStream(hc *protocol.HandleContext, resp *anthropic.Message) (*protocol.TokenUsage, error) {
-	inputTokens := int(resp.Usage.InputTokens)
+	inputTokens := int(resp.Usage.InputTokens) + int(resp.Usage.CacheCreationInputTokens)
 	outputTokens := int(resp.Usage.OutputTokens)
 	cacheTokens := int(resp.Usage.CacheReadInputTokens)
 
@@ -23,7 +23,7 @@ func HandleAnthropicV1NonStream(hc *protocol.HandleContext, resp *anthropic.Mess
 // HandleAnthropicV1BetaNonStream handles Anthropic v1 beta non-streaming response.
 // Returns (UsageStat, error)
 func HandleAnthropicV1BetaNonStream(hc *protocol.HandleContext, resp *anthropic.BetaMessage) (*protocol.TokenUsage, error) {
-	inputTokens := int(resp.Usage.InputTokens)
+	inputTokens := int(resp.Usage.InputTokens) + int(resp.Usage.CacheCreationInputTokens)
 	outputTokens := int(resp.Usage.OutputTokens)
 	cacheTokens := int(resp.Usage.CacheReadInputTokens)
 

--- a/internal/protocol/nonstream/anthropic_to_openai.go
+++ b/internal/protocol/nonstream/anthropic_to_openai.go
@@ -73,10 +73,15 @@ func ConvertAnthropicToOpenAIResponse(anthropicResp *anthropic.BetaMessage, resp
 		finishReason = "length"
 	}
 
+	// OpenAI wire: prompt_tokens = total (uncached + cache_read + cache_creation).
+	// Anthropic wire: input_tokens = uncached only, with cache fields separate.
+	promptTokens := anthropicResp.Usage.InputTokens +
+		anthropicResp.Usage.CacheReadInputTokens +
+		anthropicResp.Usage.CacheCreationInputTokens
 	usage := map[string]interface{}{
-		"prompt_tokens":     anthropicResp.Usage.InputTokens,
+		"prompt_tokens":     promptTokens,
 		"completion_tokens": anthropicResp.Usage.OutputTokens,
-		"total_tokens":      anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens,
+		"total_tokens":      promptTokens + anthropicResp.Usage.OutputTokens,
 	}
 	if anthropicResp.Usage.CacheReadInputTokens > 0 {
 		usage["prompt_tokens_details"] = map[string]interface{}{

--- a/internal/protocol/nonstream/anthropic_to_openai.go
+++ b/internal/protocol/nonstream/anthropic_to_openai.go
@@ -7,64 +7,92 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 )
 
-// ConvertAnthropicToOpenAIResponse converts an Anthropic response to OpenAI format
-func ConvertAnthropicToOpenAIResponse(anthropicResp *anthropic.BetaMessage, responseModel string) map[string]interface{} {
+// ChatCompletionWire is the OpenAI Chat Completions response wire format.
+type ChatCompletionWire struct {
+	ID      string                    `json:"id"`
+	Object  string                    `json:"object"`
+	Created int64                     `json:"created"`
+	Model   string                    `json:"model"`
+	Choices []ChatCompletionChoiceWire `json:"choices"`
+	Usage   ChatCompletionUsageWire   `json:"usage"`
+}
 
-	message := make(map[string]interface{})
-	var toolCalls []map[string]interface{}
+// ToMap serializes to a generic map for callers that apply runtime transforms.
+func (r ChatCompletionWire) ToMap() map[string]interface{} {
+	raw, _ := json.Marshal(r)
+	var m map[string]interface{}
+	_ = json.Unmarshal(raw, &m)
+	return m
+}
+
+// ChatCompletionChoiceWire is a single choice in the OpenAI Chat Completions response.
+type ChatCompletionChoiceWire struct {
+	Index        int                      `json:"index"`
+	Message      ChatCompletionMessageWire `json:"message"`
+	FinishReason string                   `json:"finish_reason"`
+}
+
+// ChatCompletionMessageWire is the message inside a choice.
+type ChatCompletionMessageWire struct {
+	Role             string                       `json:"role"`
+	Content          string                       `json:"content,omitempty"`
+	ToolCalls        []ChatCompletionToolCallWire `json:"tool_calls,omitempty"`
+	ReasoningContent string                       `json:"reasoning_content,omitempty"`
+}
+
+// ChatCompletionToolCallWire is a single tool call inside a message.
+type ChatCompletionToolCallWire struct {
+	ID       string                      `json:"id"`
+	Type     string                      `json:"type"`
+	Function ChatCompletionFunctionWire  `json:"function"`
+}
+
+// ChatCompletionFunctionWire carries the function name and JSON-encoded arguments.
+type ChatCompletionFunctionWire struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// ChatCompletionUsageWire is the usage block in the OpenAI Chat Completions response.
+// prompt_tokens = TOTAL (uncached + cached); cached_tokens is a reported subset.
+type ChatCompletionUsageWire struct {
+	PromptTokens     int64                              `json:"prompt_tokens"`
+	CompletionTokens int64                              `json:"completion_tokens"`
+	TotalTokens      int64                              `json:"total_tokens"`
+	PromptTokensDetails *ChatCompletionPromptDetailsWire `json:"prompt_tokens_details,omitempty"`
+}
+
+// ChatCompletionPromptDetailsWire breaks down prompt token categories.
+type ChatCompletionPromptDetailsWire struct {
+	CachedTokens int64 `json:"cached_tokens"`
+}
+
+// ConvertAnthropicToOpenAIResponse converts an Anthropic BetaMessage to the
+// OpenAI Chat Completions wire format.
+func ConvertAnthropicToOpenAIResponse(anthropicResp *anthropic.BetaMessage, responseModel string) ChatCompletionWire {
+	var toolCalls []ChatCompletionToolCallWire
 	var textContent string
 	var thinking string
 
-	// Walk Anthropic content blocks
 	for _, block := range anthropicResp.Content {
-
 		switch block.Type {
-
 		case "text":
 			textContent += block.Text
-
 		case "tool_use":
-			// Anthropic → OpenAI tool call
-			toolCalls = append(toolCalls, map[string]interface{}{
-				"id":   block.ID,
-				"type": "function",
-				"function": map[string]interface{}{
-					"name":      block.Name,
-					"arguments": block.Input, // map[string]any (NOT stringified yet)
+			argsJSON, _ := json.Marshal(block.Input)
+			toolCalls = append(toolCalls, ChatCompletionToolCallWire{
+				ID:   block.ID,
+				Type: "function",
+				Function: ChatCompletionFunctionWire{
+					Name:      block.Name,
+					Arguments: string(argsJSON),
 				},
 			})
-
 		case "thinking":
-			// Collect thinking content for reasoning_content field
 			thinking += block.Text
 		}
 	}
 
-	// OpenAI expects arguments as STRING
-	for _, tc := range toolCalls {
-		fn := tc["function"].(map[string]interface{})
-		if args, ok := fn["arguments"]; ok {
-			if b, err := json.Marshal(args); err == nil {
-				fn["arguments"] = string(b)
-			}
-		}
-	}
-
-	// Set role from Anthropic response (required by OpenAI format)
-	message["role"] = string(anthropicResp.Role)
-
-	if textContent != "" {
-		message["content"] = textContent
-	}
-	if len(toolCalls) > 0 {
-		message["tool_calls"] = toolCalls
-	}
-	// Add reasoning_content if thinking blocks were present
-	if thinking != "" {
-		message["reasoning_content"] = thinking
-	}
-
-	// Map stop reason
 	finishReason := "stop"
 	switch anthropicResp.StopReason {
 	case "tool_use":
@@ -73,36 +101,42 @@ func ConvertAnthropicToOpenAIResponse(anthropicResp *anthropic.BetaMessage, resp
 		finishReason = "length"
 	}
 
+	msg := ChatCompletionMessageWire{
+		Role:             string(anthropicResp.Role),
+		Content:          textContent,
+		ReasoningContent: thinking,
+	}
+	if len(toolCalls) > 0 {
+		msg.ToolCalls = toolCalls
+	}
+
 	// OpenAI wire: prompt_tokens = total (uncached + cache_read + cache_creation).
-	// Anthropic wire: input_tokens = uncached only, with cache fields separate.
 	promptTokens := anthropicResp.Usage.InputTokens +
 		anthropicResp.Usage.CacheReadInputTokens +
 		anthropicResp.Usage.CacheCreationInputTokens
-	usage := map[string]interface{}{
-		"prompt_tokens":     promptTokens,
-		"completion_tokens": anthropicResp.Usage.OutputTokens,
-		"total_tokens":      promptTokens + anthropicResp.Usage.OutputTokens,
+	usage := ChatCompletionUsageWire{
+		PromptTokens:     promptTokens,
+		CompletionTokens: anthropicResp.Usage.OutputTokens,
+		TotalTokens:      promptTokens + anthropicResp.Usage.OutputTokens,
 	}
 	if anthropicResp.Usage.CacheReadInputTokens > 0 {
-		usage["prompt_tokens_details"] = map[string]interface{}{
-			"cached_tokens": anthropicResp.Usage.CacheReadInputTokens,
+		usage.PromptTokensDetails = &ChatCompletionPromptDetailsWire{
+			CachedTokens: anthropicResp.Usage.CacheReadInputTokens,
 		}
 	}
 
-	response := map[string]interface{}{
-		"id":      anthropicResp.ID,
-		"object":  "chat.completion",
-		"created": time.Now().Unix(),
-		"model":   responseModel,
-		"choices": []map[string]interface{}{
+	return ChatCompletionWire{
+		ID:      anthropicResp.ID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   responseModel,
+		Choices: []ChatCompletionChoiceWire{
 			{
-				"index":         0,
-				"message":       message,
-				"finish_reason": finishReason,
+				Index:        0,
+				Message:      msg,
+				FinishReason: finishReason,
 			},
 		},
-		"usage": usage,
+		Usage: usage,
 	}
-
-	return response
 }

--- a/internal/protocol/nonstream/nonstream_test.go
+++ b/internal/protocol/nonstream/nonstream_test.go
@@ -77,54 +77,36 @@ func TestConvertAnthropicToOpenAIResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ConvertAnthropicToOpenAIResponse(tt.anthropicResp, tt.responseModel)
 
-			// Check that the result has the correct structure
-			assert.Equal(t, tt.anthropicResp.ID, result["id"])
-			assert.Equal(t, "chat.completion", result["object"])
-			assert.Equal(t, tt.responseModel, result["model"])
+			assert.Equal(t, tt.anthropicResp.ID, result.ID)
+			assert.Equal(t, "chat.completion", result.Object)
+			assert.Equal(t, tt.responseModel, result.Model)
 
-			// Check choices
-			choices, ok := result["choices"].([]map[string]interface{})
-			require.True(t, ok)
-			require.Len(t, choices, 1)
+			require.Len(t, result.Choices, 1)
+			choice := result.Choices[0]
+			assert.Equal(t, 0, choice.Index)
 
-			choice := choices[0]
-			assert.Equal(t, int(0), choice["index"])
-
-			// Check message
-			message, ok := choice["message"].(map[string]interface{})
-			require.True(t, ok)
-
-			// Check content
 			if tt.expectContent != "" {
-				assert.Equal(t, tt.expectContent, message["content"])
+				assert.Equal(t, tt.expectContent, choice.Message.Content)
 			}
 
-			// Check tool calls
 			if tt.expectTools {
-				toolCalls, ok := message["tool_calls"].([]map[string]interface{})
-				require.True(t, ok)
-				require.Len(t, toolCalls, 1)
-
-				toolCall := toolCalls[0]
-				assert.Equal(t, "tool_123", toolCall["id"])
-				assert.Equal(t, "function", toolCall["type"])
-
-				funcMap := toolCall["function"].(map[string]interface{})
-				assert.Equal(t, "get_weather", funcMap["name"])
-				assert.Equal(t, `{"location":"New York","unit":"celsius"}`, funcMap["arguments"])
+				require.Len(t, choice.Message.ToolCalls, 1)
+				tc := choice.Message.ToolCalls[0]
+				assert.Equal(t, "tool_123", tc.ID)
+				assert.Equal(t, "function", tc.Type)
+				assert.Equal(t, "get_weather", tc.Function.Name)
+				assert.Equal(t, `{"location":"New York","unit":"celsius"}`, tc.Function.Arguments)
 			}
 
-			// Check usage
-			usage, ok := result["usage"].(map[string]interface{})
-			require.True(t, ok)
-			assert.Equal(t, tt.anthropicResp.Usage.InputTokens, usage["prompt_tokens"])
-			assert.Equal(t, tt.anthropicResp.Usage.OutputTokens, usage["completion_tokens"])
-			assert.Equal(t, tt.anthropicResp.Usage.InputTokens+tt.anthropicResp.Usage.OutputTokens, usage["total_tokens"])
+			// prompt_tokens = total (uncached + cache_read + cache_creation)
+			wantPrompt := tt.anthropicResp.Usage.InputTokens +
+				tt.anthropicResp.Usage.CacheReadInputTokens +
+				tt.anthropicResp.Usage.CacheCreationInputTokens
+			assert.Equal(t, wantPrompt, result.Usage.PromptTokens)
+			assert.Equal(t, tt.anthropicResp.Usage.OutputTokens, result.Usage.CompletionTokens)
+			assert.Equal(t, wantPrompt+tt.anthropicResp.Usage.OutputTokens, result.Usage.TotalTokens)
 
-			// Check that created timestamp is recent (within 5 seconds)
-			created, ok := result["created"].(int64)
-			require.True(t, ok)
-			assert.InDelta(t, time.Now().Unix(), created, 5)
+			assert.InDelta(t, time.Now().Unix(), result.Created, 5)
 		})
 	}
 }

--- a/internal/protocol/nonstream/openai_passthrough.go
+++ b/internal/protocol/nonstream/openai_passthrough.go
@@ -12,9 +12,9 @@ import (
 // HandleOpenAIChatNonStream handles OpenAI chat non-streaming response.
 // Returns (UsageStat, error)
 func HandleOpenAIChatNonStream(hc *protocol.HandleContext, resp *openai.ChatCompletion) (*protocol.TokenUsage, error) {
-	inputTokens := int(resp.Usage.PromptTokens)
-	outputTokens := int(resp.Usage.CompletionTokens)
 	cacheTokens := int(resp.Usage.PromptTokensDetails.CachedTokens)
+	inputTokens := int(resp.Usage.PromptTokens) - cacheTokens
+	outputTokens := int(resp.Usage.CompletionTokens)
 	reasoningTokens := int(resp.Usage.CompletionTokensDetails.ReasoningTokens)
 
 	// Convert response to JSON map for modification
@@ -40,9 +40,9 @@ func HandleOpenAIChatNonStream(hc *protocol.HandleContext, resp *openai.ChatComp
 // HandleOpenAIResponsesNonStream handles OpenAI Responses API non-streaming response.
 // Returns (UsageStat, error)
 func HandleOpenAIResponsesNonStream(hc *protocol.HandleContext, resp *responses.Response) (*protocol.TokenUsage, error) {
-	inputTokens := int(resp.Usage.InputTokens)
-	outputTokens := int(resp.Usage.OutputTokens)
 	cacheTokens := int(resp.Usage.InputTokensDetails.CachedTokens)
+	inputTokens := int(resp.Usage.InputTokens) - cacheTokens
+	outputTokens := int(resp.Usage.OutputTokens)
 	reasoningTokens := int(resp.Usage.OutputTokensDetails.ReasoningTokens)
 
 	hc.GinContext.JSON(http.StatusOK, resp)

--- a/internal/protocol/nonstream/openai_passthrough.go
+++ b/internal/protocol/nonstream/openai_passthrough.go
@@ -7,16 +7,12 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // HandleOpenAIChatNonStream handles OpenAI chat non-streaming response.
 // Returns (UsageStat, error)
 func HandleOpenAIChatNonStream(hc *protocol.HandleContext, resp *openai.ChatCompletion) (*protocol.TokenUsage, error) {
-	cacheTokens := int(resp.Usage.PromptTokensDetails.CachedTokens)
-	inputTokens := int(resp.Usage.PromptTokens) - cacheTokens
-	outputTokens := int(resp.Usage.CompletionTokens)
-	reasoningTokens := int(resp.Usage.CompletionTokensDetails.ReasoningTokens)
-
 	// Convert response to JSON map for modification
 	responseJSON, err := json.Marshal(resp)
 	if err != nil {
@@ -34,17 +30,12 @@ func HandleOpenAIChatNonStream(hc *protocol.HandleContext, resp *openai.ChatComp
 	responseMap["model"] = hc.ResponseModel
 
 	hc.GinContext.JSON(http.StatusOK, responseMap)
-	return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), nil
+	return usage.FromOpenAIChatCompletion(resp.Usage), nil
 }
 
 // HandleOpenAIResponsesNonStream handles OpenAI Responses API non-streaming response.
 // Returns (UsageStat, error)
 func HandleOpenAIResponsesNonStream(hc *protocol.HandleContext, resp *responses.Response) (*protocol.TokenUsage, error) {
-	cacheTokens := int(resp.Usage.InputTokensDetails.CachedTokens)
-	inputTokens := int(resp.Usage.InputTokens) - cacheTokens
-	outputTokens := int(resp.Usage.OutputTokens)
-	reasoningTokens := int(resp.Usage.OutputTokensDetails.ReasoningTokens)
-
 	hc.GinContext.JSON(http.StatusOK, resp)
-	return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), nil
+	return usage.FromOpenAIResponses(resp.Usage), nil
 }

--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -22,8 +22,9 @@ func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model s
 		"model":         model,
 		"stop_reason":   "end_turn",
 		"stop_sequence": "",
+		// Anthropic wire: input_tokens = uncached only; OpenAI PromptTokens = total.
 		"usage": map[string]interface{}{
-			"input_tokens":            openaiResp.Usage.PromptTokens,
+			"input_tokens":            openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptTokensDetails.CachedTokens,
 			"output_tokens":           openaiResp.Usage.CompletionTokens,
 			"cache_read_input_tokens": openaiResp.Usage.PromptTokensDetails.CachedTokens,
 		},
@@ -97,8 +98,9 @@ func ConvertOpenAIToAnthropicBetaResponse(openaiResp *openai.ChatCompletion, mod
 		"model":         model,
 		"stop_reason":   string(anthropic.BetaStopReasonEndTurn),
 		"stop_sequence": "",
+		// Anthropic wire: input_tokens = uncached only; OpenAI PromptTokens = total.
 		"usage": map[string]interface{}{
-			"input_tokens":            openaiResp.Usage.PromptTokens,
+			"input_tokens":            openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptTokensDetails.CachedTokens,
 			"output_tokens":           openaiResp.Usage.CompletionTokens,
 			"cache_read_input_tokens": openaiResp.Usage.PromptTokensDetails.CachedTokens,
 		},
@@ -171,8 +173,9 @@ func ConvertResponsesToAnthropicBetaResponse(responsesResp *responses.Response, 
 		"model":         model,
 		"stop_reason":   string(anthropic.BetaStopReasonEndTurn),
 		"stop_sequence": "",
+		// Anthropic wire: input_tokens = uncached only; OpenAI Responses InputTokens = total.
 		"usage": map[string]interface{}{
-			"input_tokens":            responsesResp.Usage.InputTokens,
+			"input_tokens":            responsesResp.Usage.InputTokens - responsesResp.Usage.InputTokensDetails.CachedTokens,
 			"output_tokens":           responsesResp.Usage.OutputTokens,
 			"cache_read_input_tokens": responsesResp.Usage.InputTokensDetails.CachedTokens,
 		},
@@ -271,8 +274,9 @@ func ConvertResponsesToAnthropicV1Response(responsesResp *responses.Response, mo
 		"model":         model,
 		"stop_reason":   "end_turn",
 		"stop_sequence": "",
+		// Anthropic wire: input_tokens = uncached only; OpenAI Responses InputTokens = total.
 		"usage": map[string]interface{}{
-			"input_tokens":            responsesResp.Usage.InputTokens,
+			"input_tokens":            responsesResp.Usage.InputTokens - responsesResp.Usage.InputTokensDetails.CachedTokens,
 			"output_tokens":           responsesResp.Usage.OutputTokens,
 			"cache_read_input_tokens": responsesResp.Usage.InputTokensDetails.CachedTokens,
 		},

--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -11,355 +11,276 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
+// anthropicMsgWire is the intermediate JSON representation used to build
+// anthropic.Message / anthropic.BetaMessage via marshal+unmarshal, which is
+// necessary because the SDK content union types have no public constructors.
+type anthropicMsgWire struct {
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	Role         string                 `json:"role"`
+	Content      interface{}            `json:"content"`
+	Model        string                 `json:"model"`
+	StopReason   string                 `json:"stop_reason"`
+	StopSequence string                 `json:"stop_sequence"`
+	Usage        anthropicUsageWire     `json:"usage"`
+	ServerToolUse interface{}           `json:"server_tool_use,omitempty"`
+}
+
+// anthropicUsageWire represents the Anthropic usage wire format.
+// input_tokens = uncached only; cache_read and cache_creation are separate.
+type anthropicUsageWire struct {
+	InputTokens           int64 `json:"input_tokens"`
+	OutputTokens          int64 `json:"output_tokens"`
+	CacheReadInputTokens  int64 `json:"cache_read_input_tokens"`
+}
+
 func ConvertOpenAIToAnthropicResponse(openaiResp *openai.ChatCompletion, model string) *anthropic.BetaMessage {
-	// Create the response as JSON first, then unmarshal into Message
-	// This is a workaround for the complex union types
-	responseJSON := map[string]interface{}{
-		"id":            fmt.Sprintf("msg_%d", time.Now().Unix()),
-		"type":          "message",
-		"role":          "assistant",
-		"content":       []map[string]interface{}{},
-		"model":         model,
-		"stop_reason":   "end_turn",
-		"stop_sequence": "",
+	wire := anthropicMsgWire{
+		ID:           fmt.Sprintf("msg_%d", time.Now().Unix()),
+		Type:         "message",
+		Role:         "assistant",
+		Content:      []interface{}{},
+		Model:        model,
+		StopReason:   "end_turn",
+		StopSequence: "",
 		// Anthropic wire: input_tokens = uncached only; OpenAI PromptTokens = total.
-		"usage": map[string]interface{}{
-			"input_tokens":            openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptTokensDetails.CachedTokens,
-			"output_tokens":           openaiResp.Usage.CompletionTokens,
-			"cache_read_input_tokens": openaiResp.Usage.PromptTokensDetails.CachedTokens,
+		Usage: anthropicUsageWire{
+			InputTokens:          openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptTokensDetails.CachedTokens,
+			OutputTokens:         openaiResp.Usage.CompletionTokens,
+			CacheReadInputTokens: openaiResp.Usage.PromptTokensDetails.CachedTokens,
 		},
 	}
 
 	// Preserve server_tool_use from ExtraFields if present
 	if openaiResp.JSON.ExtraFields != nil {
 		if serverToolUse, exists := openaiResp.JSON.ExtraFields["server_tool_use"]; exists && serverToolUse.Valid() {
-			responseJSON["server_tool_use"] = serverToolUse.Raw()
+			wire.ServerToolUse = json.RawMessage(serverToolUse.Raw())
 		}
 	}
 
-	// Add content from OpenAI response
 	var contentBlocks []anthropic.ContentBlockParamUnion
 	for _, choice := range openaiResp.Choices {
-		// Handle refusal (when model refuses to respond due to safety policies)
 		if choice.Message.Refusal != "" {
 			contentBlocks = append(contentBlocks, anthropic.NewTextBlock(choice.Message.Refusal))
 		}
-
-		// Add text content if present
 		if choice.Message.Content != "" {
 			contentBlocks = append(contentBlocks, anthropic.NewTextBlock(choice.Message.Content))
 		}
-
 		if extra := choice.Message.JSON.ExtraFields; extra != nil {
 			if thinking, ok := extra["reasoning_content"]; ok {
-				// a fake signature for thinking block
 				contentBlocks = append(contentBlocks, anthropic.NewThinkingBlock("thinking-"+uuid.New().String()[0:6], fmt.Sprintf("%s", thinking.Raw())))
 			}
 		}
-
-		// Convert tool_calls to tool_use blocks
-		if len(choice.Message.ToolCalls) > 0 {
-			for _, toolCall := range choice.Message.ToolCalls {
-				// MENTION: must use map for anthropic tool input
-				var input map[string]interface{}
-				if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
-					input = make(map[string]interface{})
-				}
-				contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
+		for _, toolCall := range choice.Message.ToolCalls {
+			var input map[string]interface{}
+			if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
+				input = make(map[string]interface{})
 			}
-
-			// If there were tool calls, set stop_reason to tool_use
-			if choice.FinishReason == "tool_calls" {
-				responseJSON["stop_reason"] = "tool_use"
-			}
+			contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
+		}
+		if choice.FinishReason == "tool_calls" {
+			wire.StopReason = "tool_use"
 		}
 		break
 	}
+	wire.Content = contentBlocks
 
-	responseJSON["content"] = contentBlocks
-
-	// Marshal and unmarshal to create proper Message struct
-	jsonBytes, _ := json.Marshal(responseJSON)
+	jsonBytes, _ := json.Marshal(wire)
 	var msg anthropic.BetaMessage
 	json.Unmarshal(jsonBytes, &msg)
-
 	return &msg
 }
 
 // ConvertOpenAIToAnthropicBetaResponse converts OpenAI response to Anthropic beta format
 func ConvertOpenAIToAnthropicBetaResponse(openaiResp *openai.ChatCompletion, model string) anthropic.BetaMessage {
-	// Create the response as JSON first, then unmarshal into BetaMessage
-	// This is a workaround for the complex union types
-	responseJSON := map[string]interface{}{
-		"id":            fmt.Sprintf("msg_%d", time.Now().Unix()),
-		"type":          "message",
-		"role":          "assistant",
-		"content":       []map[string]interface{}{},
-		"model":         model,
-		"stop_reason":   string(anthropic.BetaStopReasonEndTurn),
-		"stop_sequence": "",
+	wire := anthropicMsgWire{
+		ID:           fmt.Sprintf("msg_%d", time.Now().Unix()),
+		Type:         "message",
+		Role:         "assistant",
+		Content:      []interface{}{},
+		Model:        model,
+		StopReason:   string(anthropic.BetaStopReasonEndTurn),
+		StopSequence: "",
 		// Anthropic wire: input_tokens = uncached only; OpenAI PromptTokens = total.
-		"usage": map[string]interface{}{
-			"input_tokens":            openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptTokensDetails.CachedTokens,
-			"output_tokens":           openaiResp.Usage.CompletionTokens,
-			"cache_read_input_tokens": openaiResp.Usage.PromptTokensDetails.CachedTokens,
+		Usage: anthropicUsageWire{
+			InputTokens:          openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptTokensDetails.CachedTokens,
+			OutputTokens:         openaiResp.Usage.CompletionTokens,
+			CacheReadInputTokens: openaiResp.Usage.PromptTokensDetails.CachedTokens,
 		},
 	}
 
-	// Preserve server_tool_use from ExtraFields if present
 	if openaiResp.JSON.ExtraFields != nil {
 		if serverToolUse, exists := openaiResp.JSON.ExtraFields["server_tool_use"]; exists && serverToolUse.Valid() {
-			responseJSON["server_tool_use"] = serverToolUse.Raw()
+			wire.ServerToolUse = json.RawMessage(serverToolUse.Raw())
 		}
 	}
 
-	// Add content from OpenAI response
 	var contentBlocks []anthropic.BetaContentBlockParamUnion
 	for _, choice := range openaiResp.Choices {
-		// Handle refusal (when model refuses to respond due to safety policies)
 		if choice.Message.Refusal != "" {
 			contentBlocks = append(contentBlocks, anthropic.NewBetaTextBlock(choice.Message.Refusal))
 		}
-
-		// Add text content if present
 		if choice.Message.Content != "" {
 			contentBlocks = append(contentBlocks, anthropic.NewBetaTextBlock(choice.Message.Content))
 		}
-
 		if extra := choice.Message.JSON.ExtraFields; extra != nil {
 			if thinking, ok := extra["reasoning_content"]; ok {
-				// a fake signature for thinking block
 				contentBlocks = append(contentBlocks, anthropic.NewBetaThinkingBlock("thinking-"+uuid.New().String()[0:6], fmt.Sprintf("%s", thinking.Raw())))
 			}
 		}
-
-		// Convert tool_calls to tool_use blocks
-		if len(choice.Message.ToolCalls) > 0 {
-			for _, toolCall := range choice.Message.ToolCalls {
-				// MENTION: must use map for anthropic tool input
-				var input map[string]interface{}
-				if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
-					input = make(map[string]interface{})
-				}
-				contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
+		for _, toolCall := range choice.Message.ToolCalls {
+			var input map[string]interface{}
+			if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
+				input = make(map[string]interface{})
 			}
-
-			// If there were tool calls, set stop_reason to tool_use
-			if choice.FinishReason == "tool_calls" {
-				responseJSON["stop_reason"] = string(anthropic.BetaStopReasonToolUse)
-			}
+			contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
+		}
+		if choice.FinishReason == "tool_calls" {
+			wire.StopReason = string(anthropic.BetaStopReasonToolUse)
 		}
 		break
 	}
+	wire.Content = contentBlocks
 
-	responseJSON["content"] = contentBlocks
-
-	// Marshal and unmarshal to create proper BetaMessage struct
-	jsonBytes, _ := json.Marshal(responseJSON)
+	jsonBytes, _ := json.Marshal(wire)
 	var msg anthropic.BetaMessage
 	json.Unmarshal(jsonBytes, &msg)
-
 	return msg
 }
 
 // ConvertResponsesToAnthropicBetaResponse converts OpenAI Responses API response to Anthropic beta format
 func ConvertResponsesToAnthropicBetaResponse(responsesResp *responses.Response, model string) anthropic.BetaMessage {
-	// Create the response as JSON first, then unmarshal into BetaMessage
-	responseJSON := map[string]interface{}{
-		"id":            responsesResp.ID,
-		"type":          "message",
-		"role":          "assistant",
-		"content":       []map[string]interface{}{},
-		"model":         model,
-		"stop_reason":   string(anthropic.BetaStopReasonEndTurn),
-		"stop_sequence": "",
+	wire := anthropicMsgWire{
+		ID:           responsesResp.ID,
+		Type:         "message",
+		Role:         "assistant",
+		Content:      []interface{}{},
+		Model:        model,
+		StopReason:   string(anthropic.BetaStopReasonEndTurn),
+		StopSequence: "",
 		// Anthropic wire: input_tokens = uncached only; OpenAI Responses InputTokens = total.
-		"usage": map[string]interface{}{
-			"input_tokens":            responsesResp.Usage.InputTokens - responsesResp.Usage.InputTokensDetails.CachedTokens,
-			"output_tokens":           responsesResp.Usage.OutputTokens,
-			"cache_read_input_tokens": responsesResp.Usage.InputTokensDetails.CachedTokens,
+		Usage: anthropicUsageWire{
+			InputTokens:          responsesResp.Usage.InputTokens - responsesResp.Usage.InputTokensDetails.CachedTokens,
+			OutputTokens:         responsesResp.Usage.OutputTokens,
+			CacheReadInputTokens: responsesResp.Usage.InputTokensDetails.CachedTokens,
 		},
 	}
 
-	// Add content from Responses API response
-	// The Responses API has a different output structure
 	var contentBlocks []anthropic.BetaContentBlockParamUnion
 
-	// Process the output array from Responses API
 	for _, output := range responsesResp.Output {
-		// Handle text content
 		for _, content := range output.Content {
 			if content.Type == "output_text" {
 				contentBlocks = append(contentBlocks, anthropic.NewBetaTextBlock(content.Text))
 			}
-			// Handle other content types as needed
 		}
-
-		// Handle tool calls (function_call, custom_tool_call, mcp_call)
 		if output.Type == "function_call" || output.Type == "custom_tool_call" || output.Type == "mcp_call" {
-			// Parse arguments JSON string to map
+			argsStr := resolveResponsesArguments(responsesResp, output)
 			var arguments map[string]interface{}
-			var argsStr string
-
-			// Try to get arguments as string first
-			if output.Arguments.OfString != "" {
-				argsStr = output.Arguments.OfString
-			} else if output.Arguments.OfResponseToolSearchCallArguments != nil {
-				// Convert to JSON string
-				if jsonBytes, err := json.Marshal(output.Arguments.OfResponseToolSearchCallArguments); err == nil {
-					argsStr = string(jsonBytes)
-				}
-			}
-
-			if argsStr != "" {
-				if err := json.Unmarshal([]byte(argsStr), &arguments); err != nil {
-					arguments = make(map[string]interface{})
-				}
-			} else {
+			if err := json.Unmarshal([]byte(argsStr), &arguments); err != nil {
 				arguments = make(map[string]interface{})
 			}
-
-			contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(
-				output.ID,
-				arguments,
-				output.Name,
-			))
-
-			// If there were tool calls, set stop_reason to tool_use
-			responseJSON["stop_reason"] = string(anthropic.BetaStopReasonToolUse)
+			contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(output.ID, arguments, output.Name))
+			wire.StopReason = string(anthropic.BetaStopReasonToolUse)
 		}
 	}
 
-	// Handle reasoning content if present
 	for _, output := range responsesResp.Output {
 		for _, content := range output.Content {
 			if content.Type == "reasoning_text" && content.Text != "" {
-				contentBlocks = append(contentBlocks, anthropic.NewBetaThinkingBlock(
-					"thinking-"+uuid.New().String()[0:6],
-					content.Text,
-				))
+				contentBlocks = append(contentBlocks, anthropic.NewBetaThinkingBlock("thinking-"+uuid.New().String()[0:6], content.Text))
 			}
 		}
 	}
 
-	// Handle refusal if present
 	for _, output := range responsesResp.Output {
 		for _, content := range output.Content {
 			if content.Type == "refusal" && content.Text != "" {
 				contentBlocks = append(contentBlocks, anthropic.NewBetaTextBlock(content.Text))
-				// Set stop_reason to refusal if present
-				responseJSON["stop_reason"] = string(anthropic.BetaStopReasonRefusal)
+				wire.StopReason = string(anthropic.BetaStopReasonRefusal)
 			}
 		}
 	}
 
-	responseJSON["content"] = contentBlocks
+	wire.Content = contentBlocks
 
-	// Marshal and unmarshal to create proper BetaMessage struct
-	jsonBytes, _ := json.Marshal(responseJSON)
+	jsonBytes, _ := json.Marshal(wire)
 	var msg anthropic.BetaMessage
 	json.Unmarshal(jsonBytes, &msg)
-
 	return msg
 }
 
 // ConvertResponsesToAnthropicV1Response converts OpenAI Responses API response to Anthropic v1 format
 func ConvertResponsesToAnthropicV1Response(responsesResp *responses.Response, model string) anthropic.Message {
-	// Create the response as JSON first, then unmarshal into Message
-	responseJSON := map[string]interface{}{
-		"id":            responsesResp.ID,
-		"type":          "message",
-		"role":          "assistant",
-		"content":       []map[string]interface{}{},
-		"model":         model,
-		"stop_reason":   "end_turn",
-		"stop_sequence": "",
+	wire := anthropicMsgWire{
+		ID:           responsesResp.ID,
+		Type:         "message",
+		Role:         "assistant",
+		Content:      []interface{}{},
+		Model:        model,
+		StopReason:   "end_turn",
+		StopSequence: "",
 		// Anthropic wire: input_tokens = uncached only; OpenAI Responses InputTokens = total.
-		"usage": map[string]interface{}{
-			"input_tokens":            responsesResp.Usage.InputTokens - responsesResp.Usage.InputTokensDetails.CachedTokens,
-			"output_tokens":           responsesResp.Usage.OutputTokens,
-			"cache_read_input_tokens": responsesResp.Usage.InputTokensDetails.CachedTokens,
+		Usage: anthropicUsageWire{
+			InputTokens:          responsesResp.Usage.InputTokens - responsesResp.Usage.InputTokensDetails.CachedTokens,
+			OutputTokens:         responsesResp.Usage.OutputTokens,
+			CacheReadInputTokens: responsesResp.Usage.InputTokensDetails.CachedTokens,
 		},
 	}
 
-	// Add content from Responses API response
-	// The Responses API has a different output structure
 	var contentBlocks []anthropic.ContentBlockParamUnion
 
-	// Process the output array from Responses API
 	for _, output := range responsesResp.Output {
-		// Handle text content
 		for _, content := range output.Content {
 			if content.Type == "output_text" {
 				contentBlocks = append(contentBlocks, anthropic.NewTextBlock(content.Text))
 			}
-			// Handle other content types as needed
 		}
-
-		// Handle tool calls (function_call, custom_tool_call, mcp_call)
 		if output.Type == "function_call" || output.Type == "custom_tool_call" || output.Type == "mcp_call" {
-			// Parse arguments JSON string to map
+			argsStr := resolveResponsesArguments(responsesResp, output)
 			var arguments map[string]interface{}
-			var argsStr string
-
-			// Try to get arguments as string first
-			if output.Arguments.OfString != "" {
-				argsStr = output.Arguments.OfString
-			} else if output.Arguments.OfResponseToolSearchCallArguments != nil {
-				// Convert to JSON string
-				if jsonBytes, err := json.Marshal(output.Arguments.OfResponseToolSearchCallArguments); err == nil {
-					argsStr = string(jsonBytes)
-				}
-			}
-
-			if argsStr != "" {
-				if err := json.Unmarshal([]byte(argsStr), &arguments); err != nil {
-					arguments = make(map[string]interface{})
-				}
-			} else {
+			if err := json.Unmarshal([]byte(argsStr), &arguments); err != nil {
 				arguments = make(map[string]interface{})
 			}
-
-			contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(
-				output.ID,
-				arguments,
-				output.Name,
-			))
-
-			// If there were tool calls, set stop_reason to tool_use
-			responseJSON["stop_reason"] = "tool_use"
+			contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(output.ID, arguments, output.Name))
+			wire.StopReason = "tool_use"
 		}
 	}
 
-	// Handle reasoning content if present
 	for _, output := range responsesResp.Output {
 		for _, content := range output.Content {
 			if content.Type == "reasoning_text" && content.Text != "" {
-				contentBlocks = append(contentBlocks, anthropic.NewThinkingBlock(
-					"thinking-"+uuid.New().String()[0:6],
-					content.Text,
-				))
+				contentBlocks = append(contentBlocks, anthropic.NewThinkingBlock("thinking-"+uuid.New().String()[0:6], content.Text))
 			}
 		}
 	}
 
-	// Handle refusal if present
 	for _, output := range responsesResp.Output {
 		for _, content := range output.Content {
 			if content.Type == "refusal" && content.Text != "" {
 				contentBlocks = append(contentBlocks, anthropic.NewTextBlock(content.Text))
-				// Set stop_reason to refusal if present
-				responseJSON["stop_reason"] = "refusal"
+				wire.StopReason = "refusal"
 			}
 		}
 	}
 
-	responseJSON["content"] = contentBlocks
+	wire.Content = contentBlocks
 
-	// Marshal and unmarshal to create proper Message struct
-	jsonBytes, _ := json.Marshal(responseJSON)
+	jsonBytes, _ := json.Marshal(wire)
 	var msg anthropic.Message
 	json.Unmarshal(jsonBytes, &msg)
-
 	return msg
+}
+
+// resolveResponsesArguments extracts the arguments string from a Responses API output item.
+func resolveResponsesArguments(responsesResp *responses.Response, output responses.ResponseOutputItemUnion) string {
+	if output.Arguments.OfString != "" {
+		return output.Arguments.OfString
+	}
+	if output.Arguments.OfResponseToolSearchCallArguments != nil {
+		if b, err := json.Marshal(output.Arguments.OfResponseToolSearchCallArguments); err == nil {
+			return string(b)
+		}
+	}
+	return "{}"
 }

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -141,25 +141,16 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 
 		if errors.Is(err, context.Canceled) {
 			logrus.WithContext(c.Request.Context()).Debug("Anthropic to Responses stream canceled by client")
-			if !acc.HasUsage() {
-				return protocol.ZeroTokenUsage(), nil
-			}
 			return acc.Result(), nil
 		}
 
 		if errors.Is(err, io.EOF) {
 			logrus.WithContext(c.Request.Context()).Info("Anthropic stream ended normally (EOF)")
-			if !acc.HasUsage() {
-				return protocol.ZeroTokenUsage(), nil
-			}
 			return acc.Result(), nil
 		}
 
 		logrus.WithContext(c.Request.Context()).Errorf("Anthropic stream error: %v", err)
 		sendResponsesErrorEvent(c, err.Error(), "stream_error", flusher)
-		if !acc.HasUsage() {
-			return protocol.ZeroTokenUsage(), err
-		}
 		return acc.Result(), err
 	}
 
@@ -174,9 +165,6 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 		completedSent = true
 	}
 
-	if !acc.HasUsage() {
-		return protocol.ZeroTokenUsage(), nil
-	}
 	return acc.Result(), nil
 }
 

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -102,6 +102,11 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 				state.inputTokens = event.Message.Usage.InputTokens
 				hasUsage = true
 			}
+			// Normalize: add cache_creation so inputTokens = input (uncached) + creation (write).
+			if event.Message.Usage.CacheCreationInputTokens != 0 {
+				inputTokens += int(event.Message.Usage.CacheCreationInputTokens)
+				state.inputTokens += event.Message.Usage.CacheCreationInputTokens
+			}
 			if event.Message.Usage.CacheReadInputTokens != 0 {
 				cacheTokens = int(event.Message.Usage.CacheReadInputTokens)
 				state.cacheTokens = event.Message.Usage.CacheReadInputTokens
@@ -475,6 +480,12 @@ func handleMessageDelta(
 	if event.Usage.InputTokens != 0 {
 		state.inputTokens = event.Usage.InputTokens
 		inputTokens = int(event.Usage.InputTokens)
+		hasUsage = true
+	}
+	// Normalize: add cache_creation for non-standard providers that send it in message_delta
+	if event.Usage.CacheCreationInputTokens != 0 {
+		state.inputTokens += event.Usage.CacheCreationInputTokens
+		inputTokens = int(state.inputTokens)
 		hasUsage = true
 	}
 	if event.Usage.OutputTokens != 0 {

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -488,6 +488,22 @@ func sendResponsesErrorEvent(c *gin.Context, message string, errorType string, f
 	sendResponsesEvent(c, errorEvent, f)
 }
 
+// toResponsesUsageWire converts normalized TokenUsage to the Responses API wire
+// usage struct. OpenAI Responses wire: InputTokens = TOTAL (uncached + cached);
+// CachedTokens is a subset. Uses a local struct rather than the SDK type so we
+// can emit cached_tokens without omitempty (required by Codex CLI).
+func toResponsesUsageWire(u *protocol.TokenUsage) *responsesUsageWire {
+	totalInput := int64(u.InputTokens + u.CacheInputTokens)
+	return &responsesUsageWire{
+		InputTokens:  totalInput,
+		OutputTokens: int64(u.OutputTokens),
+		TotalTokens:  totalInput + int64(u.OutputTokens),
+		InputTokensDetails: responsesInputTokensDetailsWire{
+			CachedTokens: int64(u.CacheInputTokens),
+		},
+	}
+}
+
 // sendCompletionEvent sends the response.completed event and the final [DONE] marker.
 // u carries the normalized token counts from the accumulator.
 func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher http.Flusher, u *protocol.TokenUsage) {
@@ -533,14 +549,7 @@ func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher
 			CompletedAt: state.createdAt,
 			Model:       "",
 			Output:      output,
-			Usage: &responsesUsageWire{
-				InputTokens:  int64(u.InputTokens),
-				OutputTokens: int64(u.OutputTokens),
-				TotalTokens:  int64(u.InputTokens + u.OutputTokens),
-				InputTokensDetails: responsesInputTokensDetailsWire{
-					CachedTokens: int64(u.CacheInputTokens),
-				},
-			},
+			Usage: toResponsesUsageWire(u),
 		},
 	}
 	sendResponsesEvent(c, doneEvent, flusher)

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // HandleAnthropicBetaToOpenAIResponsesStream converts Anthropic streaming events
@@ -64,8 +65,7 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 
 	// Initialize converter state
 	state := newResponsesConverterState(time.Now().Unix())
-	var inputTokens, outputTokens, cacheTokens int
-	var hasUsage bool
+	acc := usagepkg.NewAnthropicAccumulator()
 	completedSent := false
 
 	// Process the stream
@@ -77,7 +77,8 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			// Send completion event before returning since client is disconnecting
 			if !completedSent && !state.finished {
 				logrus.WithContext(c.Request.Context()).Info("Client disconnected, sending completion event before close")
-				sendFinalCompletionEvent(c, state, flusher, inputTokens, outputTokens, cacheTokens)
+				r := acc.Result()
+				sendFinalCompletionEvent(c, state, flusher, r.InputTokens, r.OutputTokens, r.CacheInputTokens)
 				completedSent = true
 			}
 			return false
@@ -96,21 +97,10 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 		case "message_start":
 			handleMessageStart(c, state, responseModel, flusher)
 			state.hasSentCreated = true
-			// Anthropic puts input_tokens in message_start, not message_delta.
-			if event.Message.Usage.InputTokens != 0 {
-				inputTokens = int(event.Message.Usage.InputTokens)
-				state.inputTokens = event.Message.Usage.InputTokens
-				hasUsage = true
-			}
-			// Normalize: add cache_creation so inputTokens = input (uncached) + creation (write).
-			if event.Message.Usage.CacheCreationInputTokens != 0 {
-				inputTokens += int(event.Message.Usage.CacheCreationInputTokens)
-				state.inputTokens += event.Message.Usage.CacheCreationInputTokens
-			}
-			if event.Message.Usage.CacheReadInputTokens != 0 {
-				cacheTokens = int(event.Message.Usage.CacheReadInputTokens)
-				state.cacheTokens = event.Message.Usage.CacheReadInputTokens
-			}
+			acc.ConsumeBeta(&event)
+			r := acc.Result()
+			state.inputTokens = int64(r.InputTokens)
+			state.cacheTokens = int64(r.CacheInputTokens)
 
 		case "content_block_start":
 			handleContentBlockStart(c, state, event, flusher)
@@ -122,9 +112,11 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			handleContentBlockStop(c, state, event, flusher)
 
 		case "message_delta":
-			inputTokens, outputTokens, cacheTokens, hasUsage = handleMessageDelta(
-				state, event, inputTokens, outputTokens,
-			)
+			acc.ConsumeBeta(&event)
+			r := acc.Result()
+			state.inputTokens = int64(r.InputTokens)
+			state.outputTokens = int64(r.OutputTokens)
+			state.cacheTokens = int64(r.CacheInputTokens)
 
 		case "message_stop":
 			handleMessageStop(c, state, flusher)
@@ -151,32 +143,33 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			// Send completion event for all errors including context.Canceled
 			// The Stream loop's context check may not have run if stream.Next() was blocking
 			logrus.WithContext(c.Request.Context()).WithError(err).Warn("Stream error occurred, sending completion event")
-			sendFinalCompletionEvent(c, state, flusher, inputTokens, outputTokens, cacheTokens)
+			r := acc.Result()
+			sendFinalCompletionEvent(c, state, flusher, r.InputTokens, r.OutputTokens, r.CacheInputTokens)
 			completedSent = true
 		}
 
 		if errors.Is(err, context.Canceled) {
 			logrus.WithContext(c.Request.Context()).Debug("Anthropic to Responses stream canceled by client")
-			if hasUsage {
-				return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+			if !acc.HasUsage() {
+				return protocol.ZeroTokenUsage(), nil
 			}
-			return protocol.ZeroTokenUsage(), nil
+			return acc.Result(), nil
 		}
 
 		if errors.Is(err, io.EOF) {
 			logrus.WithContext(c.Request.Context()).Info("Anthropic stream ended normally (EOF)")
-			if hasUsage {
-				return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+			if !acc.HasUsage() {
+				return protocol.ZeroTokenUsage(), nil
 			}
-			return protocol.ZeroTokenUsage(), nil
+			return acc.Result(), nil
 		}
 
 		logrus.WithContext(c.Request.Context()).Errorf("Anthropic stream error: %v", err)
 		sendResponsesErrorEvent(c, err.Error(), "stream_error", flusher)
-		if hasUsage {
-			return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), err
+		if !acc.HasUsage() {
+			return protocol.ZeroTokenUsage(), err
 		}
-		return protocol.ZeroTokenUsage(), err
+		return acc.Result(), err
 	}
 
 	// Some providers end the stream without emitting message_stop
@@ -186,14 +179,15 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			handleMessageStart(c, state, responseModel, flusher)
 			state.hasSentCreated = true
 		}
-		sendFinalCompletionEvent(c, state, flusher, inputTokens, outputTokens, cacheTokens)
+		r := acc.Result()
+		sendFinalCompletionEvent(c, state, flusher, r.InputTokens, r.OutputTokens, r.CacheInputTokens)
 		completedSent = true
 	}
 
-	if hasUsage {
-		return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+	if !acc.HasUsage() {
+		return protocol.ZeroTokenUsage(), nil
 	}
-	return protocol.ZeroTokenUsage(), nil
+	return acc.Result(), nil
 }
 
 // responsesConverterState maintains the state during stream conversion
@@ -466,38 +460,6 @@ func handleContentBlockStop(
 			sendResponsesEvent(c, itemDoneEvent, flusher)
 		}
 	}
-}
-
-// handleMessageDelta updates usage information.
-// Anthropic sends input_tokens in message_start and output_tokens in message_delta,
-// so we only overwrite a value when the event actually carries it (non-zero).
-func handleMessageDelta(
-	state *responsesConverterState,
-	event anthropic.BetaRawMessageStreamEventUnion,
-	inputTokens, outputTokens int,
-) (int, int, int, bool) {
-	hasUsage := false
-	if event.Usage.InputTokens != 0 {
-		state.inputTokens = event.Usage.InputTokens
-		inputTokens = int(event.Usage.InputTokens)
-		hasUsage = true
-	}
-	// Normalize: add cache_creation for non-standard providers that send it in message_delta
-	if event.Usage.CacheCreationInputTokens != 0 {
-		state.inputTokens += event.Usage.CacheCreationInputTokens
-		inputTokens = int(state.inputTokens)
-		hasUsage = true
-	}
-	if event.Usage.OutputTokens != 0 {
-		state.outputTokens = event.Usage.OutputTokens
-		outputTokens = int(event.Usage.OutputTokens)
-		hasUsage = true
-	}
-	if event.Usage.CacheReadInputTokens != 0 {
-		state.cacheTokens = event.Usage.CacheReadInputTokens
-		hasUsage = true
-	}
-	return inputTokens, outputTokens, int(state.cacheTokens), hasUsage
 }
 
 // handleMessageStop sends the response.completed event

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -96,6 +96,16 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 		case "message_start":
 			handleMessageStart(c, state, responseModel, flusher)
 			state.hasSentCreated = true
+			// Anthropic puts input_tokens in message_start, not message_delta.
+			if event.Message.Usage.InputTokens != 0 {
+				inputTokens = int(event.Message.Usage.InputTokens)
+				state.inputTokens = event.Message.Usage.InputTokens
+				hasUsage = true
+			}
+			if event.Message.Usage.CacheReadInputTokens != 0 {
+				cacheTokens = int(event.Message.Usage.CacheReadInputTokens)
+				state.cacheTokens = event.Message.Usage.CacheReadInputTokens
+			}
 
 		case "content_block_start":
 			handleContentBlockStart(c, state, event, flusher)
@@ -453,22 +463,30 @@ func handleContentBlockStop(
 	}
 }
 
-// handleMessageDelta updates usage information
+// handleMessageDelta updates usage information.
+// Anthropic sends input_tokens in message_start and output_tokens in message_delta,
+// so we only overwrite a value when the event actually carries it (non-zero).
 func handleMessageDelta(
 	state *responsesConverterState,
 	event anthropic.BetaRawMessageStreamEventUnion,
 	inputTokens, outputTokens int,
 ) (int, int, int, bool) {
-	if event.Usage.InputTokens != 0 || event.Usage.OutputTokens != 0 || event.Usage.CacheReadInputTokens != 0 {
+	hasUsage := false
+	if event.Usage.InputTokens != 0 {
 		state.inputTokens = event.Usage.InputTokens
-		state.outputTokens = event.Usage.OutputTokens
-		state.cacheTokens = event.Usage.CacheReadInputTokens
 		inputTokens = int(event.Usage.InputTokens)
-		outputTokens = int(event.Usage.OutputTokens)
-		cacheTokens := int(event.Usage.CacheReadInputTokens)
-		return inputTokens, outputTokens, cacheTokens, true
+		hasUsage = true
 	}
-	return inputTokens, outputTokens, int(state.cacheTokens), false
+	if event.Usage.OutputTokens != 0 {
+		state.outputTokens = event.Usage.OutputTokens
+		outputTokens = int(event.Usage.OutputTokens)
+		hasUsage = true
+	}
+	if event.Usage.CacheReadInputTokens != 0 {
+		state.cacheTokens = event.Usage.CacheReadInputTokens
+		hasUsage = true
+	}
+	return inputTokens, outputTokens, int(state.cacheTokens), hasUsage
 }
 
 // handleMessageStop sends the response.completed event

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -77,8 +77,7 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			// Send completion event before returning since client is disconnecting
 			if !completedSent && !state.finished {
 				logrus.WithContext(c.Request.Context()).Info("Client disconnected, sending completion event before close")
-				r := acc.Result()
-				sendFinalCompletionEvent(c, state, flusher, r.InputTokens, r.OutputTokens, r.CacheInputTokens)
+				sendCompletionEvent(c, state, flusher, acc.Result())
 				completedSent = true
 			}
 			return false
@@ -98,9 +97,6 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			handleMessageStart(c, state, responseModel, flusher)
 			state.hasSentCreated = true
 			acc.ConsumeBeta(&event)
-			r := acc.Result()
-			state.inputTokens = int64(r.InputTokens)
-			state.cacheTokens = int64(r.CacheInputTokens)
 
 		case "content_block_start":
 			handleContentBlockStart(c, state, event, flusher)
@@ -113,13 +109,9 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 
 		case "message_delta":
 			acc.ConsumeBeta(&event)
-			r := acc.Result()
-			state.inputTokens = int64(r.InputTokens)
-			state.outputTokens = int64(r.OutputTokens)
-			state.cacheTokens = int64(r.CacheInputTokens)
 
 		case "message_stop":
-			handleMessageStop(c, state, flusher)
+			sendCompletionEvent(c, state, flusher, acc.Result())
 			completedSent = true
 			return false
 		}
@@ -143,8 +135,7 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			// Send completion event for all errors including context.Canceled
 			// The Stream loop's context check may not have run if stream.Next() was blocking
 			logrus.WithContext(c.Request.Context()).WithError(err).Warn("Stream error occurred, sending completion event")
-			r := acc.Result()
-			sendFinalCompletionEvent(c, state, flusher, r.InputTokens, r.OutputTokens, r.CacheInputTokens)
+			sendCompletionEvent(c, state, flusher, acc.Result())
 			completedSent = true
 		}
 
@@ -179,8 +170,7 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 			handleMessageStart(c, state, responseModel, flusher)
 			state.hasSentCreated = true
 		}
-		r := acc.Result()
-		sendFinalCompletionEvent(c, state, flusher, r.InputTokens, r.OutputTokens, r.CacheInputTokens)
+		sendCompletionEvent(c, state, flusher, acc.Result())
 		completedSent = true
 	}
 
@@ -196,9 +186,6 @@ type responsesConverterState struct {
 	itemID           string
 	outputIndex      int
 	accumulatedText  string
-	inputTokens      int64
-	outputTokens     int64
-	cacheTokens      int64 // Cache read tokens from Anthropic
 	finished         bool
 	pendingToolCalls map[int]*pendingResponseToolCall
 	hasSentCreated   bool
@@ -462,77 +449,6 @@ func handleContentBlockStop(
 	}
 }
 
-// handleMessageStop sends the response.completed event
-func handleMessageStop(
-	c *gin.Context,
-	state *responsesConverterState,
-	flusher http.Flusher,
-) {
-	state.finished = true
-
-	// Build the final output array with proper message structure
-	var output []responsesOutputItemWire
-
-	// Add text content as a message item if present
-	if state.accumulatedText != "" {
-		output = append(output, responsesOutputItemWire{
-			ID:     state.itemID,
-			Type:   "message",
-			Status: "completed",
-			Role:   "assistant",
-			Content: []responsesContentPartWire{
-				{
-					Type: "output_text",
-					Text: state.accumulatedText,
-				},
-			},
-		})
-	}
-
-	// Add tool calls with proper structure including call_id
-	for _, pending := range state.pendingToolCalls {
-		argumentsStr := pending.arguments.String()
-		output = append(output, responsesOutputItemWire{
-			Type:      "function_call",
-			ID:        pending.itemID,
-			CallID:    pending.itemID,
-			Name:      pending.name,
-			Arguments: &argumentsStr,
-			Status:    "completed",
-		})
-	}
-
-	// Build usage info from state
-	inputTokens := state.inputTokens
-	outputTokens := state.outputTokens
-	cacheTokens := state.cacheTokens
-
-	doneEvent := responsesCompletedEvent{
-		Type:           "response.completed",
-		SequenceNumber: int64(state.nextSequenceNumber()),
-		Response: responsesWireResponse{
-			ID:          state.responseID,
-			Object:      "response",
-			CreatedAt:   state.createdAt,
-			Status:      "completed",
-			CompletedAt: state.createdAt,
-			Model:       "",
-			Output:      output,
-			Usage: &responsesUsageWire{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-				TotalTokens:  inputTokens + outputTokens,
-				InputTokensDetails: responsesInputTokensDetailsWire{
-					CachedTokens: cacheTokens,
-				},
-			},
-		},
-	}
-	sendResponsesEvent(c, doneEvent, flusher)
-
-	// Send final [DONE] message
-	OpenAISSEDone(c)
-}
 
 // sendResponsesEvent sends a single Responses API event as SSE
 func sendResponsesEvent(c *gin.Context, event any, flusher http.Flusher) {
@@ -572,10 +488,9 @@ func sendResponsesErrorEvent(c *gin.Context, message string, errorType string, f
 	sendResponsesEvent(c, errorEvent, f)
 }
 
-// sendFinalCompletionEvent sends the response.completed event with the current state
-// This is used when the stream ends unexpectedly to ensure clients receive a completion event
-func sendFinalCompletionEvent(c *gin.Context, state *responsesConverterState, flusher http.Flusher, inputTokens, outputTokens, cacheTokens int) {
-	// Check if connection is still valid before writing
+// sendCompletionEvent sends the response.completed event and the final [DONE] marker.
+// u carries the normalized token counts from the accumulator.
+func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher http.Flusher, u *protocol.TokenUsage) {
 	if c == nil || c.Writer == nil || flusher == nil {
 		logrus.Warn("Cannot send completion event: connection is nil")
 		return
@@ -583,10 +498,7 @@ func sendFinalCompletionEvent(c *gin.Context, state *responsesConverterState, fl
 
 	state.finished = true
 
-	// Build the final output array with proper message structure
 	var output []responsesOutputItemWire
-
-	// Add text content as a message item if present
 	if state.accumulatedText != "" {
 		output = append(output, responsesOutputItemWire{
 			ID:     state.itemID,
@@ -594,15 +506,10 @@ func sendFinalCompletionEvent(c *gin.Context, state *responsesConverterState, fl
 			Status: "completed",
 			Role:   "assistant",
 			Content: []responsesContentPartWire{
-				{
-					Type: "output_text",
-					Text: state.accumulatedText,
-				},
+				{Type: "output_text", Text: state.accumulatedText},
 			},
 		})
 	}
-
-	// Add tool calls with proper structure including call_id
 	for _, pending := range state.pendingToolCalls {
 		argumentsStr := pending.arguments.String()
 		output = append(output, responsesOutputItemWire{
@@ -613,20 +520,6 @@ func sendFinalCompletionEvent(c *gin.Context, state *responsesConverterState, fl
 			Arguments: &argumentsStr,
 			Status:    "completed",
 		})
-	}
-
-	// Build usage info from state - use provided values if state values are zero
-	inputTokensFinal := int(state.inputTokens)
-	outputTokensFinal := int(state.outputTokens)
-	cacheTokensFinal := int(state.cacheTokens)
-	if inputTokensFinal == 0 && inputTokens > 0 {
-		inputTokensFinal = inputTokens
-	}
-	if outputTokensFinal == 0 && outputTokens > 0 {
-		outputTokensFinal = outputTokens
-	}
-	if cacheTokensFinal == 0 && cacheTokens > 0 {
-		cacheTokensFinal = cacheTokens
 	}
 
 	doneEvent := responsesCompletedEvent{
@@ -641,18 +534,16 @@ func sendFinalCompletionEvent(c *gin.Context, state *responsesConverterState, fl
 			Model:       "",
 			Output:      output,
 			Usage: &responsesUsageWire{
-				InputTokens:  int64(inputTokensFinal),
-				OutputTokens: int64(outputTokensFinal),
-				TotalTokens:  int64(inputTokensFinal + outputTokensFinal),
+				InputTokens:  int64(u.InputTokens),
+				OutputTokens: int64(u.OutputTokens),
+				TotalTokens:  int64(u.InputTokens + u.OutputTokens),
 				InputTokensDetails: responsesInputTokensDetailsWire{
-					CachedTokens: int64(cacheTokensFinal),
+					CachedTokens: int64(u.CacheInputTokens),
 				},
 			},
 		},
 	}
 	sendResponsesEvent(c, doneEvent, flusher)
-
-	// Send final [DONE] message
 	OpenAISSEDone(c)
 }
 

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_test.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_test.go
@@ -24,57 +24,6 @@ func TestNewResponsesConverterState(t *testing.T) {
 	assert.False(t, state.finished)
 }
 
-// TestHandleMessageDelta tests the message delta handler
-func TestHandleMessageDelta(t *testing.T) {
-	state := newResponsesConverterState(time.Now().Unix())
-
-	// Test with usage data
-	eventStr := `{"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": ""}, "usage": {"input_tokens": 100, "output_tokens": 50}}`
-	event := parseTestEvent(eventStr)
-
-	inputTokens, outputTokens, cacheTokens, hasUsage := handleMessageDelta(state, event, 0, 0)
-
-	assert.Equal(t, 100, inputTokens)
-	assert.Equal(t, 50, outputTokens)
-	assert.Equal(t, 0, cacheTokens)
-	assert.True(t, hasUsage)
-	assert.Equal(t, int64(100), state.inputTokens)
-	assert.Equal(t, int64(50), state.outputTokens)
-}
-
-// TestHandleMessageDelta_NoUsage tests delta without usage data
-func TestHandleMessageDelta_NoUsage(t *testing.T) {
-	state := newResponsesConverterState(time.Now().Unix())
-
-	eventStr := `{"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {}}`
-	event := parseTestEvent(eventStr)
-
-	inputTokens, outputTokens, cacheTokens, hasUsage := handleMessageDelta(state, event, 0, 0)
-
-	assert.Equal(t, 0, inputTokens)
-	assert.Equal(t, 0, outputTokens)
-	assert.Equal(t, 0, cacheTokens)
-	assert.False(t, hasUsage)
-}
-
-// TestHandleMessageDelta_WithCache tests delta with cache tokens
-func TestHandleMessageDelta_WithCache(t *testing.T) {
-	state := newResponsesConverterState(time.Now().Unix())
-
-	eventStr := `{"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 200}}`
-	event := parseTestEvent(eventStr)
-
-	inputTokens, outputTokens, cacheTokens, hasUsage := handleMessageDelta(state, event, 0, 0)
-
-	assert.Equal(t, 100, inputTokens)
-	assert.Equal(t, 50, outputTokens)
-	assert.Equal(t, 200, cacheTokens)
-	assert.True(t, hasUsage)
-	assert.Equal(t, int64(100), state.inputTokens)
-	assert.Equal(t, int64(50), state.outputTokens)
-	assert.Equal(t, int64(200), state.cacheTokens)
-}
-
 // TestResponsesConverterState_AccumulatedText tests text accumulation
 func TestResponsesConverterState_AccumulatedText(t *testing.T) {
 	state := newResponsesConverterState(time.Now().Unix())
@@ -221,28 +170,6 @@ func TestSpecialCharacters(t *testing.T) {
 			assert.Equal(t, text, parsed["delta"])
 		})
 	}
-}
-
-// TestHandleMessageDelta_PreserveInputFromMessageStart tests the real Anthropic streaming
-// protocol: input_tokens arrive in message_start (not message_delta). When message_delta
-// only carries output_tokens, the previously captured inputTokens must not be clobbered.
-func TestHandleMessageDelta_PreserveInputFromMessageStart(t *testing.T) {
-	state := newResponsesConverterState(time.Now().Unix())
-
-	// Simulate: message_start already captured input_tokens = 35
-	state.inputTokens = 35
-	presetInput := 35
-
-	// Real Anthropic message_delta has output_tokens only; input_tokens is absent (0).
-	eventStr := `{"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 18}}`
-	event := parseTestEvent(eventStr)
-
-	inputTokens, outputTokens, _, hasUsage := handleMessageDelta(state, event, presetInput, 0)
-
-	assert.Equal(t, 35, inputTokens, "input_tokens must not be overwritten by message_delta")
-	assert.Equal(t, 18, outputTokens)
-	assert.True(t, hasUsage)
-	assert.Equal(t, int64(35), state.inputTokens, "state.inputTokens must not be overwritten")
 }
 
 // Helper to parse event from JSON string

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_test.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // TestNewResponsesConverterState tests the state initialization
@@ -19,8 +21,6 @@ func TestNewResponsesConverterState(t *testing.T) {
 	assert.Equal(t, "item_1234567890", state.itemID)
 	assert.Equal(t, 0, state.outputIndex)
 	assert.Equal(t, "", state.accumulatedText)
-	assert.Equal(t, int64(0), state.inputTokens)
-	assert.Equal(t, int64(0), state.outputTokens)
 	assert.False(t, state.finished)
 }
 
@@ -131,16 +131,18 @@ func TestResponsesConverterState_MultipleDeltas(t *testing.T) {
 	assert.Equal(t, "Hello World!", state.accumulatedText)
 }
 
-// TestResponsesConverterState_UsageAccumulation tests usage tracking
+// TestResponsesConverterState_UsageAccumulation tests that the accumulator produces correct usage
 func TestResponsesConverterState_UsageAccumulation(t *testing.T) {
-	state := newResponsesConverterState(time.Now().Unix())
+	acc := usagepkg.NewAnthropicAccumulator()
 
-	// Simulate multiple delta events with usage
-	state.inputTokens = 100
-	state.outputTokens = 50
+	startEvt := parseTestEvent(`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","content":[],"model":"claude","usage":{"input_tokens":100,"output_tokens":0}}}`)
+	deltaEvt := parseTestEvent(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50}}`)
+	acc.ConsumeBeta(&startEvt)
+	acc.ConsumeBeta(&deltaEvt)
 
-	assert.Equal(t, int64(100), state.inputTokens)
-	assert.Equal(t, int64(50), state.outputTokens)
+	r := acc.Result()
+	assert.Equal(t, 100, r.InputTokens)
+	assert.Equal(t, 50, r.OutputTokens)
 }
 
 // TestSpecialCharacters tests JSON encoding of special characters

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_test.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_test.go
@@ -223,6 +223,28 @@ func TestSpecialCharacters(t *testing.T) {
 	}
 }
 
+// TestHandleMessageDelta_PreserveInputFromMessageStart tests the real Anthropic streaming
+// protocol: input_tokens arrive in message_start (not message_delta). When message_delta
+// only carries output_tokens, the previously captured inputTokens must not be clobbered.
+func TestHandleMessageDelta_PreserveInputFromMessageStart(t *testing.T) {
+	state := newResponsesConverterState(time.Now().Unix())
+
+	// Simulate: message_start already captured input_tokens = 35
+	state.inputTokens = 35
+	presetInput := 35
+
+	// Real Anthropic message_delta has output_tokens only; input_tokens is absent (0).
+	eventStr := `{"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 18}}`
+	event := parseTestEvent(eventStr)
+
+	inputTokens, outputTokens, _, hasUsage := handleMessageDelta(state, event, presetInput, 0)
+
+	assert.Equal(t, 35, inputTokens, "input_tokens must not be overwritten by message_delta")
+	assert.Equal(t, 18, outputTokens)
+	assert.True(t, hasUsage)
+	assert.Equal(t, int64(35), state.inputTokens, "state.inputTokens must not be overwritten")
+}
+
 // Helper to parse event from JSON string
 func parseTestEvent(eventStr string) anthropic.BetaRawMessageStreamEventUnion {
 	var event anthropic.BetaRawMessageStreamEventUnion

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -84,6 +84,14 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 				hasUsage = true
 			}
 
+			// Normalize: add cache_creation_input_tokens to inputTokens so the denominator
+			// covers total prompt cost = input (uncached) + creation (write) + read (cacheTokens).
+			if c := evt.Message.Usage.CacheCreationInputTokens; c > 0 {
+				inputTokens += int(c)
+			} else if c := evt.Usage.CacheCreationInputTokens; c > 0 {
+				inputTokens += int(c)
+			}
+
 			if hc.Guardrails != nil && hc.Guardrails.Enabled {
 				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
 					return err
@@ -193,6 +201,14 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 			} else if evt.Usage.CacheReadInputTokens > 0 {
 				cacheTokens = int(evt.Usage.CacheReadInputTokens)
 				hasUsage = true
+			}
+
+			// Normalize: add cache_creation_input_tokens to inputTokens so the denominator
+			// covers total prompt cost = input (uncached) + creation (write) + read (cacheTokens).
+			if c := evt.Message.Usage.CacheCreationInputTokens; c > 0 {
+				inputTokens += int(c)
+			} else if c := evt.Usage.CacheCreationInputTokens; c > 0 {
+				inputTokens += int(c)
 			}
 
 			if hc.Guardrails != nil && hc.Guardrails.Enabled {

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -44,8 +44,18 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 
 			// Read usage from SDK struct; fall back to raw JSON for providers
 			// or test decoders where apijson doesn't populate struct fields.
+			// Anthropic streaming protocol:
+			//   message_start  → input_tokens at event.Message.Usage (message.usage.input_tokens in JSON)
+			//   message_delta  → output_tokens at event.Usage (usage.output_tokens in JSON)
 			raw := evt.RawJSON()
-			if evt.Usage.InputTokens > 0 {
+			// Input tokens: prefer message_start path, fall back to message_delta path
+			if evt.Message.Usage.InputTokens > 0 {
+				inputTokens = int(evt.Message.Usage.InputTokens)
+				hasUsage = true
+			} else if v := gjson.Get(raw, "message.usage.input_tokens"); v.Int() > 0 {
+				inputTokens = int(v.Int())
+				hasUsage = true
+			} else if evt.Usage.InputTokens > 0 {
 				inputTokens = int(evt.Usage.InputTokens)
 				hasUsage = true
 			} else if v := gjson.Get(raw, "usage.input_tokens"); v.Int() > 0 {
@@ -59,8 +69,15 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 				outputTokens = int(v.Int())
 				hasUsage = true
 			}
-			if evt.Usage.CacheReadInputTokens > 0 {
+			// Cache tokens: check both message_start and message_delta paths
+			if evt.Message.Usage.CacheReadInputTokens > 0 {
+				cacheTokens = int(evt.Message.Usage.CacheReadInputTokens)
+				hasUsage = true
+			} else if evt.Usage.CacheReadInputTokens > 0 {
 				cacheTokens = int(evt.Usage.CacheReadInputTokens)
+				hasUsage = true
+			} else if v := gjson.Get(raw, "message.usage.cache_read_input_tokens"); v.Int() > 0 {
+				cacheTokens = int(v.Int())
 				hasUsage = true
 			} else if v := gjson.Get(raw, "usage.cache_read_input_tokens"); v.Int() > 0 {
 				cacheTokens = int(v.Int())
@@ -156,7 +173,13 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 		func(event interface{}) error {
 			evt := event.(*anthropic.BetaRawMessageStreamEventUnion)
 
-			if evt.Usage.InputTokens > 0 {
+			// Anthropic streaming protocol:
+			//   message_start  → input_tokens at event.Message.Usage
+			//   message_delta  → output_tokens at event.Usage
+			if evt.Message.Usage.InputTokens > 0 {
+				inputTokens = int(evt.Message.Usage.InputTokens)
+				hasUsage = true
+			} else if evt.Usage.InputTokens > 0 {
 				inputTokens = int(evt.Usage.InputTokens)
 				hasUsage = true
 			}
@@ -164,7 +187,10 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 				outputTokens = int(evt.Usage.OutputTokens)
 				hasUsage = true
 			}
-			if evt.Usage.CacheReadInputTokens > 0 {
+			if evt.Message.Usage.CacheReadInputTokens > 0 {
+				cacheTokens = int(evt.Message.Usage.CacheReadInputTokens)
+				hasUsage = true
+			} else if evt.Usage.CacheReadInputTokens > 0 {
 				cacheTokens = int(evt.Usage.CacheReadInputTokens)
 				hasUsage = true
 			}

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -8,9 +8,9 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/sirupsen/logrus"
-	"github.com/tidwall/gjson"
 	guardrailsmutate "github.com/tingly-dev/tingly-box/internal/guardrails/mutate"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // HandleAnthropic handles Anthropic v1 streaming response.
@@ -20,8 +20,7 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 
 	hc.SetupSSEHeaders()
 
-	var inputTokens, outputTokens, cacheTokens int
-	var hasUsage bool
+	acc := usage.NewAnthropicAccumulator()
 
 	err := hc.ProcessStream(
 		func() (bool, error, interface{}) {
@@ -42,55 +41,7 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 		func(event interface{}) error {
 			evt := event.(*anthropic.MessageStreamEventUnion)
 
-			// Read usage from SDK struct; fall back to raw JSON for providers
-			// or test decoders where apijson doesn't populate struct fields.
-			// Anthropic streaming protocol:
-			//   message_start  → input_tokens at event.Message.Usage (message.usage.input_tokens in JSON)
-			//   message_delta  → output_tokens at event.Usage (usage.output_tokens in JSON)
-			raw := evt.RawJSON()
-			// Input tokens: prefer message_start path, fall back to message_delta path
-			if evt.Message.Usage.InputTokens > 0 {
-				inputTokens = int(evt.Message.Usage.InputTokens)
-				hasUsage = true
-			} else if v := gjson.Get(raw, "message.usage.input_tokens"); v.Int() > 0 {
-				inputTokens = int(v.Int())
-				hasUsage = true
-			} else if evt.Usage.InputTokens > 0 {
-				inputTokens = int(evt.Usage.InputTokens)
-				hasUsage = true
-			} else if v := gjson.Get(raw, "usage.input_tokens"); v.Int() > 0 {
-				inputTokens = int(v.Int())
-				hasUsage = true
-			}
-			if evt.Usage.OutputTokens > 0 {
-				outputTokens = int(evt.Usage.OutputTokens)
-				hasUsage = true
-			} else if v := gjson.Get(raw, "usage.output_tokens"); v.Int() > 0 {
-				outputTokens = int(v.Int())
-				hasUsage = true
-			}
-			// Cache tokens: check both message_start and message_delta paths
-			if evt.Message.Usage.CacheReadInputTokens > 0 {
-				cacheTokens = int(evt.Message.Usage.CacheReadInputTokens)
-				hasUsage = true
-			} else if evt.Usage.CacheReadInputTokens > 0 {
-				cacheTokens = int(evt.Usage.CacheReadInputTokens)
-				hasUsage = true
-			} else if v := gjson.Get(raw, "message.usage.cache_read_input_tokens"); v.Int() > 0 {
-				cacheTokens = int(v.Int())
-				hasUsage = true
-			} else if v := gjson.Get(raw, "usage.cache_read_input_tokens"); v.Int() > 0 {
-				cacheTokens = int(v.Int())
-				hasUsage = true
-			}
-
-			// Normalize: add cache_creation_input_tokens to inputTokens so the denominator
-			// covers total prompt cost = input (uncached) + creation (write) + read (cacheTokens).
-			if c := evt.Message.Usage.CacheCreationInputTokens; c > 0 {
-				inputTokens += int(c)
-			} else if c := evt.Usage.CacheCreationInputTokens; c > 0 {
-				inputTokens += int(c)
-			}
+			acc.Consume(evt)
 
 			if hc.Guardrails != nil && hc.Guardrails.Enabled {
 				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
@@ -130,10 +81,10 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 	if err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.WithContext(hc.GinContext.Request.Context()).Debug("Anthropic v1 stream canceled by client")
-			if !hasUsage {
+			if !acc.HasUsage() {
 				return protocol.ZeroTokenUsage(), nil
 			}
-			return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+			return acc.Result(), nil
 		}
 
 		// Stream failed before any content reached the client: surface a
@@ -141,15 +92,15 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 		// instead of a 200 SSE error event.
 		if !hc.GinContext.Writer.Written() {
 			SendStreamingError(hc.GinContext, err)
-			return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), err
+			return acc.Result(), err
 		}
 		MarshalAndSendErrorEvent(hc.GinContext, err.Error(), "stream_error", "stream_failed")
-		return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), err
+		return acc.Result(), err
 	}
 
 	SendFinishEvent(hc.GinContext)
 
-	return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+	return acc.Result(), nil
 }
 
 // HandleAnthropicBeta handles Anthropic v1 beta streaming response.
@@ -159,8 +110,7 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 
 	hc.SetupSSEHeaders()
 
-	var inputTokens, outputTokens, cacheTokens int
-	var hasUsage bool
+	acc := usage.NewAnthropicAccumulator()
 
 	err := hc.ProcessStream(
 		func() (bool, error, interface{}) {
@@ -181,35 +131,7 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 		func(event interface{}) error {
 			evt := event.(*anthropic.BetaRawMessageStreamEventUnion)
 
-			// Anthropic streaming protocol:
-			//   message_start  → input_tokens at event.Message.Usage
-			//   message_delta  → output_tokens at event.Usage
-			if evt.Message.Usage.InputTokens > 0 {
-				inputTokens = int(evt.Message.Usage.InputTokens)
-				hasUsage = true
-			} else if evt.Usage.InputTokens > 0 {
-				inputTokens = int(evt.Usage.InputTokens)
-				hasUsage = true
-			}
-			if evt.Usage.OutputTokens > 0 {
-				outputTokens = int(evt.Usage.OutputTokens)
-				hasUsage = true
-			}
-			if evt.Message.Usage.CacheReadInputTokens > 0 {
-				cacheTokens = int(evt.Message.Usage.CacheReadInputTokens)
-				hasUsage = true
-			} else if evt.Usage.CacheReadInputTokens > 0 {
-				cacheTokens = int(evt.Usage.CacheReadInputTokens)
-				hasUsage = true
-			}
-
-			// Normalize: add cache_creation_input_tokens to inputTokens so the denominator
-			// covers total prompt cost = input (uncached) + creation (write) + read (cacheTokens).
-			if c := evt.Message.Usage.CacheCreationInputTokens; c > 0 {
-				inputTokens += int(c)
-			} else if c := evt.Usage.CacheCreationInputTokens; c > 0 {
-				inputTokens += int(c)
-			}
+			acc.ConsumeBeta(evt)
 
 			if hc.Guardrails != nil && hc.Guardrails.Enabled {
 				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
@@ -249,10 +171,10 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 	if err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.WithContext(hc.GinContext.Request.Context()).Debug("Anthropic v1 beta stream canceled by client")
-			if !hasUsage {
+			if !acc.HasUsage() {
 				return protocol.ZeroTokenUsage(), nil
 			}
-			return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+			return acc.Result(), nil
 		}
 
 		// Stream failed before any content reached the client: surface a
@@ -260,13 +182,13 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 		// instead of a 200 SSE error event.
 		if !hc.GinContext.Writer.Written() {
 			SendStreamingError(hc.GinContext, err)
-			return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), err
+			return acc.Result(), err
 		}
 		MarshalAndSendErrorEvent(hc.GinContext, err.Error(), "stream_error", "stream_failed")
-		return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), err
+		return acc.Result(), err
 	}
 
 	SendFinishEvent(hc.GinContext)
 
-	return protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens), nil
+	return acc.Result(), nil
 }

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -81,9 +81,6 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 	if err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.WithContext(hc.GinContext.Request.Context()).Debug("Anthropic v1 stream canceled by client")
-			if !acc.HasUsage() {
-				return protocol.ZeroTokenUsage(), nil
-			}
 			return acc.Result(), nil
 		}
 
@@ -171,9 +168,6 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 	if err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.WithContext(hc.GinContext.Request.Context()).Debug("Anthropic v1 beta stream canceled by client")
-			if !acc.HasUsage() {
-				return protocol.ZeroTokenUsage(), nil
-			}
 			return acc.Result(), nil
 		}
 

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -288,17 +288,7 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 
 			// Add usage if available and not disabled.
 			if !disableStreamUsage && acc.HasUsage() {
-				result := acc.Result()
-				inputTokens := result.InputTokens
-				outputTokens := result.OutputTokens
-				chunk.Usage = openai.CompletionUsage{
-					PromptTokens:     int64(inputTokens),
-					CompletionTokens: int64(outputTokens),
-					TotalTokens:      int64(inputTokens + outputTokens),
-				}
-				if result.CacheInputTokens > 0 {
-					chunk.Usage.PromptTokensDetails.CachedTokens = int64(result.CacheInputTokens)
-				}
+				chunk.Usage = usagepkg.ChatUsage(acc.Result())
 			}
 
 			sendOpenAIStreamChunk(c, chunk, disableStreamUsage)

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -121,6 +121,10 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 			if event.Message.Usage.InputTokens != 0 {
 				inputTokens = int(event.Message.Usage.InputTokens)
 			}
+			// Normalize: add cache_creation so inputTokens = input (uncached) + creation (write).
+			if event.Message.Usage.CacheCreationInputTokens != 0 {
+				inputTokens += int(event.Message.Usage.CacheCreationInputTokens)
+			}
 
 		case "content_block_start":
 			// Content block starting
@@ -257,6 +261,10 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 				usage = &event.Usage
 				if event.Usage.InputTokens != 0 {
 					inputTokens = int(event.Usage.InputTokens)
+				}
+				// Normalize: add cache_creation for non-standard providers that send it in message_delta
+				if event.Usage.CacheCreationInputTokens != 0 {
+					inputTokens += int(event.Usage.CacheCreationInputTokens)
 				}
 				if event.Usage.OutputTokens != 0 {
 					outputTokens = int(event.Usage.OutputTokens)

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/sirupsen/logrus"
+
+	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 type AnthropicToOpenAIToolCall struct {
@@ -63,14 +65,12 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 
 	// Track streaming state
 	var (
-		chatID       = fmt.Sprintf("chatcmpl-%d", time.Now().Unix())
-		created      = time.Now().Unix()
-		contentText  = strings.Builder{}
-		usage        *anthropic.BetaMessageDeltaUsage
-		inputTokens  int
-		outputTokens int
-		finished     bool
-		hookErr      error
+		chatID      = fmt.Sprintf("chatcmpl-%d", time.Now().Unix())
+		created     = time.Now().Unix()
+		contentText = strings.Builder{}
+		acc         = usagepkg.NewAnthropicAccumulator()
+		finished    bool
+		hookErr     error
 		// Track tool call state for proper streaming
 		toolCallID       string
 		toolCallName     string
@@ -117,14 +117,7 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 				},
 			}
 			sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
-			// Anthropic puts input_tokens in message_start, not message_delta.
-			if event.Message.Usage.InputTokens != 0 {
-				inputTokens = int(event.Message.Usage.InputTokens)
-			}
-			// Normalize: add cache_creation so inputTokens = input (uncached) + creation (write).
-			if event.Message.Usage.CacheCreationInputTokens != 0 {
-				inputTokens += int(event.Message.Usage.CacheCreationInputTokens)
-			}
+			acc.ConsumeBeta(&event)
 
 		case "content_block_start":
 			// Content block starting
@@ -253,23 +246,7 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 			// Content block finished - no specific action needed
 
 		case "message_delta":
-			// Message delta (includes usage info).
-			// Anthropic only sends output_tokens here; input_tokens came from message_start.
-			// Only update a value when the event actually carries it to avoid clobbering
-			// the input_tokens already captured from message_start.
-			if event.Usage.InputTokens != 0 || event.Usage.OutputTokens != 0 {
-				usage = &event.Usage
-				if event.Usage.InputTokens != 0 {
-					inputTokens = int(event.Usage.InputTokens)
-				}
-				// Normalize: add cache_creation for non-standard providers that send it in message_delta
-				if event.Usage.CacheCreationInputTokens != 0 {
-					inputTokens += int(event.Usage.CacheCreationInputTokens)
-				}
-				if event.Usage.OutputTokens != 0 {
-					outputTokens = int(event.Usage.OutputTokens)
-				}
-			}
+			acc.ConsumeBeta(&event)
 
 		case "message_stop":
 			if hooks != nil && hooks.OnToolCallsFinal != nil && len(pendingToolCalls) > 0 {
@@ -310,18 +287,17 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 			}
 
 			// Add usage if available and not disabled.
-			// Use the local inputTokens/outputTokens which are the correctly merged
-			// values: inputTokens is captured from message_start (where Anthropic
-			// puts it) and outputTokens from message_delta. usage.InputTokens from
-			// message_delta is typically 0 for real Anthropic responses.
-			if !disableStreamUsage && (inputTokens > 0 || outputTokens > 0) {
+			if !disableStreamUsage && acc.HasUsage() {
+				result := acc.Result()
+				inputTokens := result.InputTokens
+				outputTokens := result.OutputTokens
 				chunk.Usage = openai.CompletionUsage{
 					PromptTokens:     int64(inputTokens),
 					CompletionTokens: int64(outputTokens),
 					TotalTokens:      int64(inputTokens + outputTokens),
 				}
-				if usage != nil && usage.CacheReadInputTokens > 0 {
-					chunk.Usage.PromptTokensDetails.CachedTokens = usage.CacheReadInputTokens
+				if result.CacheInputTokens > 0 {
+					chunk.Usage.PromptTokensDetails.CachedTokens = int64(result.CacheInputTokens)
 				}
 			}
 
@@ -336,11 +312,13 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 		return true
 	})
 
+	result := acc.Result()
+	in, out := result.InputTokens, result.OutputTokens
 	if errors.Is(hookErr, ErrMCPStreamContinue) {
-		return inputTokens, outputTokens, hookErr
+		return in, out, hookErr
 	}
 	if finished {
-		return inputTokens, outputTokens, nil
+		return in, out, nil
 	}
 
 	// Check for stream errors
@@ -348,12 +326,12 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 		// Check if it was a client cancellation
 		if errors.Is(err, context.Canceled) {
 			logrus.WithContext(c.Request.Context()).Debug("Anthropic to OpenAI stream canceled by client")
-			return inputTokens, outputTokens, nil
+			return in, out, nil
 		}
 		// EOF is expected when stream ends normally
 		if errors.Is(err, io.EOF) {
 			logrus.WithContext(c.Request.Context()).Info("Anthropic stream ended normally (EOF)")
-			return inputTokens, outputTokens, nil
+			return in, out, nil
 		}
 		logrus.WithContext(c.Request.Context()).Errorf("Anthropic stream error: %v", err)
 		// Stream failed before any content reached the client: surface a
@@ -361,14 +339,14 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 		// instead of a 200 SSE error event.
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
-			return inputTokens, outputTokens, fmt.Errorf("anthropic stream error: %w", err)
+			return in, out, fmt.Errorf("anthropic stream error: %w", err)
 		}
 		sendOpenAIStreamError(c, err.Error(), "stream_error")
 		// Return the error so TB's usage tracking can detect and report health status
-		return inputTokens, outputTokens, fmt.Errorf("anthropic stream error: %w", err)
+		return in, out, fmt.Errorf("anthropic stream error: %w", err)
 	}
 
-	return inputTokens, outputTokens, nil
+	return in, out, nil
 }
 
 // sendOpenAIStreamChunk sends a ChatCompletionChunk as SSE

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -302,18 +302,17 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 			}
 
 			// Add usage if available and not disabled.
-			// Anthropic's message_delta usage carries cache_read / cache_creation
-			// counts; forward cached prompt tokens into OpenAI's
-			// prompt_tokens_details.cached_tokens so downstream consumers see
-			// the full shape. (Anthropic has no reasoning_tokens analogue —
-			// extended-thinking tokens are billed inside output_tokens.)
-			if !disableStreamUsage && usage != nil {
+			// Use the local inputTokens/outputTokens which are the correctly merged
+			// values: inputTokens is captured from message_start (where Anthropic
+			// puts it) and outputTokens from message_delta. usage.InputTokens from
+			// message_delta is typically 0 for real Anthropic responses.
+			if !disableStreamUsage && (inputTokens > 0 || outputTokens > 0) {
 				chunk.Usage = openai.CompletionUsage{
-					PromptTokens:     usage.InputTokens,
-					CompletionTokens: usage.OutputTokens,
-					TotalTokens:      usage.InputTokens + usage.OutputTokens,
+					PromptTokens:     int64(inputTokens),
+					CompletionTokens: int64(outputTokens),
+					TotalTokens:      int64(inputTokens + outputTokens),
 				}
-				if usage.CacheReadInputTokens > 0 {
+				if usage != nil && usage.CacheReadInputTokens > 0 {
 					chunk.Usage.PromptTokensDetails.CachedTokens = usage.CacheReadInputTokens
 				}
 			}

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -117,6 +117,10 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 				},
 			}
 			sendOpenAIStreamChunk(c, chunk, disableStreamUsage)
+			// Anthropic puts input_tokens in message_start, not message_delta.
+			if event.Message.Usage.InputTokens != 0 {
+				inputTokens = int(event.Message.Usage.InputTokens)
+			}
 
 		case "content_block_start":
 			// Content block starting
@@ -245,11 +249,18 @@ func AnthropicToOpenAIStreamWithMCPHooks(c *gin.Context, req *anthropic.BetaMess
 			// Content block finished - no specific action needed
 
 		case "message_delta":
-			// Message delta (includes usage info)
+			// Message delta (includes usage info).
+			// Anthropic only sends output_tokens here; input_tokens came from message_start.
+			// Only update a value when the event actually carries it to avoid clobbering
+			// the input_tokens already captured from message_start.
 			if event.Usage.InputTokens != 0 || event.Usage.OutputTokens != 0 {
 				usage = &event.Usage
-				inputTokens = int(event.Usage.InputTokens)
-				outputTokens = int(event.Usage.OutputTokens)
+				if event.Usage.InputTokens != 0 {
+					inputTokens = int(event.Usage.InputTokens)
+				}
+				if event.Usage.OutputTokens != 0 {
+					outputTokens = int(event.Usage.OutputTokens)
+				}
 			}
 
 		case "message_stop":

--- a/internal/protocol/stream/anthropic_to_openai_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicOption "github.com/anthropics/anthropic-sdk-go/option"
+	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
@@ -94,6 +95,91 @@ func TestHandleAnthropicToOpenAIStreamResponse(t *testing.T) {
 	assert.True(t, foundDataChunk, "Should have at least one data chunk")
 	assert.True(t, foundDone, "Should have [DONE] marker")
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+}
+
+// buildMessageStopJSON builds a minimal message_stop event for tests.
+func buildMessageStopJSON() string {
+	return `{"type":"message_stop"}`
+}
+
+// TestAnthropicToOpenAIStream_RealFormatUsage verifies that when the stream follows
+// the real Anthropic SSE protocol (input_tokens in message_start, output_tokens in
+// message_delta), both the returned counts and the SSE usage chunk are correct.
+func TestAnthropicToOpenAIStream_RealFormatUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 35, 0),  // input_tokens=35, cache=0
+		buildAnthropicOutputOnlyDeltaJSON(t, 18),   // output_tokens=18 only
+		buildMessageStopJSON(),
+	}
+	decoder := newFakeAnthropicDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](decoder, nil)
+
+	inputTokens, outputTokens, err := AnthropicToOpenAIStream(c, nil, stream, "claude-3-5-sonnet", false)
+	require.NoError(t, err)
+
+	// Returned counts must be correct
+	assert.Equal(t, 35, inputTokens, "input_tokens must come from message_start")
+	assert.Equal(t, 18, outputTokens)
+
+	// The SSE body must contain a usage chunk with correct prompt_tokens.
+	// The OpenAI SDK always serializes Usage even when zero, so there may be an early
+	// zero-usage chunk from message_start. We track the LAST non-zero usage seen.
+	body := w.Body.String()
+	var lastPromptTokens, lastCompletionTokens float64
+	foundNonZeroUsage := false
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == " [DONE]" || payload == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		if u, ok := chunk["usage"].(map[string]interface{}); ok {
+			if pt, ok := u["prompt_tokens"].(float64); ok && pt > 0 {
+				lastPromptTokens = pt
+				lastCompletionTokens, _ = u["completion_tokens"].(float64)
+				foundNonZeroUsage = true
+			}
+		}
+	}
+	assert.True(t, foundNonZeroUsage, "stream must emit a non-zero usage chunk")
+	assert.EqualValues(t, 35, lastPromptTokens, "final SSE usage chunk prompt_tokens must be 35")
+	assert.EqualValues(t, 18, lastCompletionTokens)
+}
+
+// TestAnthropicToOpenAIStream_NonStandardDelta verifies a non-standard provider that
+// delivers input_tokens only inside message_delta (not message_start) still works.
+func TestAnthropicToOpenAIStream_NonStandardDelta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/v1/messages", nil)
+
+	events := []string{
+		// message_start with no usage (non-standard)
+		`{"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"custom","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		// message_delta with both input and output (non-standard but backward-compat)
+		buildAnthropicMessageDeltaJSON(t, 40, 20, 0),
+		buildMessageStopJSON(),
+	}
+	decoder := newFakeAnthropicDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](decoder, nil)
+
+	inputTokens, outputTokens, err := AnthropicToOpenAIStream(c, nil, stream, "custom-model", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, 40, inputTokens)
+	assert.Equal(t, 20, outputTokens)
 }
 
 // TestSendOpenAIStreamChunk tests the helper function

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -57,7 +57,8 @@ func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
 
 			input, output, err := AnthropicToOpenAIStream(c, nil, stream, modelID, false)
 			require.NoError(t, err)
-			assert.Equal(t, 42, input, "InputTokens should reflect upstream input_tokens")
+			// Anthropic input_tokens=42, cache_creation=5 → stored as 42+5=47 (non-cache-read total)
+			assert.Equal(t, 47, input, "InputTokens should be input_tokens + cache_creation_input_tokens")
 			assert.Equal(t, 17, output, "OutputTokens should reflect upstream output_tokens")
 
 			body := w.Body.String()
@@ -68,7 +69,7 @@ func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
 			usageChunk := lastOpenAIChunkUsage(t, body)
 			require.NotNil(t, usageChunk, "anthropic_to_openai stream should attach usage to the final chunk")
 
-			assert.EqualValues(t, 42, jsonNumber(usageChunk, "prompt_tokens"))
+			assert.EqualValues(t, 47, jsonNumber(usageChunk, "prompt_tokens"))
 			assert.EqualValues(t, 17, jsonNumber(usageChunk, "completion_tokens"))
 
 			details, _ := usageChunk["prompt_tokens_details"].(map[string]interface{})

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -69,7 +69,8 @@ func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
 			usageChunk := lastOpenAIChunkUsage(t, body)
 			require.NotNil(t, usageChunk, "anthropic_to_openai stream should attach usage to the final chunk")
 
-			assert.EqualValues(t, 47, jsonNumber(usageChunk, "prompt_tokens"))
+			// OpenAI wire: prompt_tokens = total (uncached 47 + cached 11 = 58).
+			assert.EqualValues(t, 58, jsonNumber(usageChunk, "prompt_tokens"))
 			assert.EqualValues(t, 17, jsonNumber(usageChunk, "completion_tokens"))
 
 			details, _ := usageChunk["prompt_tokens_details"].(map[string]interface{})

--- a/internal/protocol/stream/openai_chat_to_responses.go
+++ b/internal/protocol/stream/openai_chat_to_responses.go
@@ -28,10 +28,11 @@ type chatToResponsesState struct {
 	hasTextItem      bool
 	pendingToolCalls map[int]*pendingToolCallResponse
 	accumulatedText  strings.Builder
-	inputTokens      int64
-	outputTokens     int64
-	cacheTokens      int64 // Cached tokens from prompt
-	reasoningTokens  int64 // Reasoning tokens from output
+	promptTokensTotal int64 // Raw total prompt_tokens from OpenAI (cached + uncached)
+	inputTokens       int64
+	outputTokens      int64
+	cacheTokens       int64 // Cached tokens from prompt
+	reasoningTokens   int64 // Reasoning tokens from output
 	hasSentCreated   bool
 }
 
@@ -123,7 +124,7 @@ func HandleOpenAIChatToResponsesStream(c *gin.Context, stream *openaistream.Stre
 
 		// Track usage from chunks
 		if chunk.Usage.PromptTokens != 0 {
-			state.inputTokens = int64(chunk.Usage.PromptTokens)
+			state.promptTokensTotal = int64(chunk.Usage.PromptTokens)
 			hasUsage = true
 		}
 		if chunk.Usage.CompletionTokens != 0 {
@@ -139,6 +140,10 @@ func HandleOpenAIChatToResponsesStream(c *gin.Context, stream *openaistream.Stre
 		if chunk.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
 			state.reasoningTokens = int64(chunk.Usage.CompletionTokensDetails.ReasoningTokens)
 			hasUsage = true
+		}
+		// Normalize after each usage update: uncached = total - cached
+		if state.promptTokensTotal > 0 {
+			state.inputTokens = state.promptTokensTotal - state.cacheTokens
 		}
 
 		// Skip empty chunks

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -38,7 +38,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
 
-	var inputTokens, outputTokens, cacheTokens, reasoningTokens int
+	var promptTokensTotal, inputTokens, outputTokens, cacheTokens, reasoningTokens int
 	var hasUsage bool
 	var contentBuilder strings.Builder
 	var firstChunkID string
@@ -79,7 +79,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 
 			// Accumulate usage from chunks (if present)
 			if chunk.Usage.PromptTokens != 0 {
-				inputTokens = int(chunk.Usage.PromptTokens)
+				promptTokensTotal = int(chunk.Usage.PromptTokens)
 				hasUsage = true
 			}
 			if chunk.Usage.CompletionTokens != 0 {
@@ -242,6 +242,12 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 		},
 	)
 
+	// Normalize: OpenAI prompt_tokens = total (cached + uncached); subtract cache
+	// so inputTokens represents uncached-only, matching Anthropic semantics.
+	if promptTokensTotal > 0 {
+		inputTokens = promptTokensTotal - cacheTokens
+	}
+
 	if err != nil && !errors.Is(err, context.Canceled) {
 		if !hasUsage {
 			inputTokens, _ = token.EstimateInputTokens(req)
@@ -330,7 +336,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 	c.Header("Access-Control-Allow-Origin", "*")
 	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
-	var inputTokens, outputTokens, cacheTokens, reasoningTokens int64
+	var promptTokensTotal, inputTokens, outputTokens, cacheTokens, reasoningTokens int64
 	var hasUsage bool
 
 	StreamLoop(c, func(w io.Writer) bool {
@@ -354,7 +360,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 		// Accumulate usage from the raw JSON (SDK struct fields may be zero for
 		// providers that use custom serialisation or in unit-test fake decoders).
 		if it := gjson.Get(eventRaw, "response.usage.input_tokens"); it.Exists() && it.Int() > 0 {
-			inputTokens = it.Int()
+			promptTokensTotal = it.Int()
 			hasUsage = true
 		}
 		if ot := gjson.Get(eventRaw, "response.usage.output_tokens"); ot.Exists() && ot.Int() > 0 {
@@ -403,6 +409,11 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 		OpenAIResponsesEvent(c, eventType, eventRaw)
 		return true
 	})
+
+	// Normalize: OpenAI input_tokens = total; subtract cache for uncached-only semantics.
+	if promptTokensTotal > 0 {
+		inputTokens = promptTokensTotal - cacheTokens
+	}
 
 	if err := stream.Err(); err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
@@ -481,7 +492,7 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream ResponsesStre
 		return protocol.ZeroTokenUsage(), fmt.Errorf("streaming not supported by this connection")
 	}
 
-	var inputTokens, outputTokens, cacheTokens, reasoningTokens int
+	var promptTokensTotal, inputTokens, outputTokens, cacheTokens, reasoningTokens int
 
 	// Generate message ID for Anthropic format
 	messageID := fmt.Sprintf("msg_%d", time.Now().Unix())
@@ -524,7 +535,7 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream ResponsesStre
 
 		// Extract usage from the event
 		if evt.Response.Usage.InputTokens > 0 {
-			inputTokens = int(evt.Response.Usage.InputTokens)
+			promptTokensTotal = int(evt.Response.Usage.InputTokens)
 		}
 		if evt.Response.Usage.OutputTokens > 0 {
 			outputTokens = int(evt.Response.Usage.OutputTokens)
@@ -535,6 +546,11 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream ResponsesStre
 		if evt.Response.Usage.OutputTokensDetails.ReasoningTokens > 0 {
 			reasoningTokens = int(evt.Response.Usage.OutputTokensDetails.ReasoningTokens)
 		}
+	}
+
+	// Normalize: OpenAI input_tokens = total; subtract cache for uncached-only semantics.
+	if promptTokensTotal > 0 {
+		inputTokens = promptTokensTotal - cacheTokens
 	}
 
 	// Check for stream errors

--- a/internal/protocol/stream/openai_responses_to_chat.go
+++ b/internal/protocol/stream/openai_responses_to_chat.go
@@ -191,9 +191,9 @@ func HandleResponsesToOpenAIChatStream(
 			}
 
 		case "response.completed":
-			state.inputTokens = evt.Response.Usage.InputTokens
-			state.outputTokens = evt.Response.Usage.OutputTokens
 			state.cacheTokens = evt.Response.Usage.InputTokensDetails.CachedTokens
+			state.inputTokens = evt.Response.Usage.InputTokens - state.cacheTokens
+			state.outputTokens = evt.Response.Usage.OutputTokens
 			state.reasoningTokens = evt.Response.Usage.OutputTokensDetails.ReasoningTokens
 			if evt.Response.Usage.TotalTokens != 0 {
 				state.totalTokens = evt.Response.Usage.TotalTokens

--- a/internal/protocol/stream/openai_responses_to_chat.go
+++ b/internal/protocol/stream/openai_responses_to_chat.go
@@ -339,12 +339,13 @@ func flushResponsesToChatCompletedOutput(c *gin.Context, flusher http.Flusher, s
 func writeResponsesToChatFinalChunk(c *gin.Context, flusher http.Flusher, state *responsesToChatState, responseModel, finishReason string, includeUsage bool) {
 	finalChunk := newResponsesToChatChunk(state, responseModel, chatCompletionStreamDelta{}, &finishReason)
 	if includeUsage {
+		totalInput := state.inputTokens + state.cacheTokens
 		total := state.totalTokens
 		if total == 0 {
-			total = state.inputTokens + state.outputTokens
+			total = totalInput + state.outputTokens
 		}
 		usage := &chatCompletionStreamUsage{
-			PromptTokens:     state.inputTokens,
+			PromptTokens:     totalInput,
 			CompletionTokens: state.outputTokens,
 			TotalTokens:      total,
 		}

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -789,9 +789,9 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 
 		case "response.completed":
 			completed := currentEvent.AsResponseCompleted()
-			state.inputTokens = completed.Response.Usage.InputTokens
-			state.outputTokens = completed.Response.Usage.OutputTokens
 			state.cacheTokens = completed.Response.Usage.InputTokensDetails.CachedTokens
+			state.inputTokens = completed.Response.Usage.InputTokens - state.cacheTokens
+			state.outputTokens = completed.Response.Usage.OutputTokens
 			state.reasoningTokens = completed.Response.Usage.OutputTokensDetails.ReasoningTokens
 
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Response completed: input_tokens=%d, output_tokens=%d", state.inputTokens, state.outputTokens)

--- a/internal/protocol/stream/openai_to_anthropic_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_test.go
@@ -373,7 +373,8 @@ func TestHandleResponsesToAnthropicV1Stream_UsageTokens(t *testing.T) {
 	usage, err := HandleResponsesToAnthropicV1Stream(c, stream, "gpt-4o")
 	require.NoError(t, err)
 
-	assert.Equal(t, 50, usage.InputTokens)
+	// OpenAI Responses API: input=50 total, cached=8 → stored as 50-8=42 (uncached only)
+	assert.Equal(t, 42, usage.InputTokens)
 	assert.Equal(t, 30, usage.OutputTokens)
 	assert.Equal(t, 8, usage.CacheInputTokens)
 	assert.Equal(t, 12, usage.ReasoningTokens)

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -148,10 +148,11 @@ func TestOpenAIToAnthropicStream_VModelFullUsage(t *testing.T) {
 			require.NotNil(t, usageBlock)
 
 			// MockUsage from StreamTestMockSpecs: prompt=42 completion=17 cached=11 reasoning=9
+			// After normalization: inputTokens = 42 - 11 = 31 (uncached portion only)
 			assert.EqualValues(t, 17, usageBlock["output_tokens"], "output_tokens from explicit MockUsage.CompletionTokens")
 			assert.EqualValues(t, 11, usageBlock["cache_read_input_tokens"], "cache_read_input_tokens from prompt_tokens_details.cached_tokens")
 
-			assert.Equal(t, 42, usage.InputTokens)
+			assert.Equal(t, 31, usage.InputTokens)
 			assert.Equal(t, 17, usage.OutputTokens)
 			assert.Equal(t, 11, usage.CacheInputTokens)
 			assert.Equal(t, 9, usage.ReasoningTokens)

--- a/internal/protocol/stream/passthrough_test.go
+++ b/internal/protocol/stream/passthrough_test.go
@@ -107,6 +107,51 @@ func buildAnthropicMessageDeltaJSON(t *testing.T, inputTokens, outputTokens, cac
 	return string(data)
 }
 
+// buildAnthropicMessageStartJSON creates a message_start event — the real Anthropic
+// streaming format where input_tokens live in message.usage, not in message_delta.
+func buildAnthropicMessageStartJSON(t *testing.T, inputTokens, cacheReadTokens int64) string {
+	t.Helper()
+	event := map[string]interface{}{
+		"type": "message_start",
+		"message": map[string]interface{}{
+			"id":            "msg_test",
+			"type":          "message",
+			"role":          "assistant",
+			"content":       []interface{}{},
+			"model":         "claude-3-5-sonnet-20241022",
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage": map[string]interface{}{
+				"input_tokens":            inputTokens,
+				"output_tokens":           0,
+				"cache_read_input_tokens": cacheReadTokens,
+			},
+		},
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// buildAnthropicOutputOnlyDeltaJSON creates a message_delta with output_tokens only,
+// matching the real Anthropic API (input_tokens are absent from message_delta).
+func buildAnthropicOutputOnlyDeltaJSON(t *testing.T, outputTokens int64) string {
+	t.Helper()
+	event := map[string]interface{}{
+		"type": "message_delta",
+		"delta": map[string]interface{}{
+			"stop_reason":   "end_turn",
+			"stop_sequence": nil,
+		},
+		"usage": map[string]interface{}{
+			"output_tokens": outputTokens,
+		},
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return string(data)
+}
+
 // newTestHandleContext creates a minimal HandleContext wired to the given gin context.
 func newTestHandleContext(c *gin.Context) *protocol.HandleContext {
 	return protocol.NewHandleContext(c, "test-model")
@@ -303,4 +348,59 @@ func TestHandleAnthropic_UsageTokens(t *testing.T) {
 	assert.Equal(t, 18, usage.OutputTokens)
 	assert.Equal(t, 5, usage.CacheInputTokens)
 	assert.Equal(t, 0, usage.ReasoningTokens) // Anthropic SDK has no reasoning tokens
+}
+
+// TestHandleAnthropic_RealStreamFormat verifies input_tokens from message_start are
+// captured. The real Anthropic API puts input_tokens in message_start.message.usage
+// and only output_tokens in message_delta.usage — not input_tokens in both.
+func TestHandleAnthropic_RealStreamFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 35, 5),   // input_tokens=35, cache=5
+		buildAnthropicOutputOnlyDeltaJSON(t, 18),   // output_tokens=18 only
+	}
+	decoder := newFakeAnthropicDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](decoder, nil)
+
+	hc := newTestHandleContext(c)
+
+	usage, err := HandleAnthropic(hc, stream)
+	require.NoError(t, err)
+
+	assert.Equal(t, 35, usage.InputTokens, "input_tokens must come from message_start")
+	assert.Equal(t, 18, usage.OutputTokens)
+	assert.Equal(t, 5, usage.CacheInputTokens)
+}
+
+// ---------------------------------------------------------------------------
+// HandleAnthropicBeta
+// ---------------------------------------------------------------------------
+
+// TestHandleAnthropicBeta_RealStreamFormat verifies input_tokens from message_start
+// are captured for the beta passthrough handler.
+func TestHandleAnthropicBeta_RealStreamFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 40, 8),  // input_tokens=40, cache=8
+		buildAnthropicOutputOnlyDeltaJSON(t, 22),  // output_tokens=22 only
+	}
+	decoder := newFakeAnthropicDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](decoder, nil)
+
+	hc := newTestHandleContext(c)
+
+	usage, err := HandleAnthropicBeta(hc, stream)
+	require.NoError(t, err)
+
+	assert.Equal(t, 40, usage.InputTokens, "input_tokens must come from message_start")
+	assert.Equal(t, 22, usage.OutputTokens)
+	assert.Equal(t, 8, usage.CacheInputTokens)
 }

--- a/internal/protocol/stream/passthrough_test.go
+++ b/internal/protocol/stream/passthrough_test.go
@@ -250,7 +250,8 @@ func TestHandleOpenAIResponsesStream_UsageTokens(t *testing.T) {
 	usage, err := HandleOpenAIResponsesStream(hc, stream, "gpt-4o")
 	require.NoError(t, err)
 
-	assert.Equal(t, 50, usage.InputTokens)
+	// OpenAI Responses API: input=50 total, cached=7 → stored as 50-7=43 (uncached only)
+	assert.Equal(t, 43, usage.InputTokens)
 	assert.Equal(t, 30, usage.OutputTokens)
 	assert.Equal(t, 7, usage.CacheInputTokens)
 	assert.Equal(t, 15, usage.ReasoningTokens)
@@ -296,7 +297,8 @@ func TestHandleOpenAIResponsesStreamToAnthropic_UsageTokens(t *testing.T) {
 	usage, err := HandleOpenAIResponsesStreamToAnthropic(c, stream, "gpt-4o")
 	require.NoError(t, err)
 
-	assert.Equal(t, 60, usage.InputTokens)
+	// OpenAI Responses API: input=60 total, cached=12 → stored as 60-12=48 (uncached only)
+	assert.Equal(t, 48, usage.InputTokens)
 	assert.Equal(t, 25, usage.OutputTokens)
 	assert.Equal(t, 12, usage.CacheInputTokens)
 	assert.Equal(t, 8, usage.ReasoningTokens)

--- a/internal/protocol/token/stream_counter.go
+++ b/internal/protocol/token/stream_counter.go
@@ -101,7 +101,7 @@ func (c *StreamTokenCounter) ConsumeOpenAIChunk(chunk *openai.ChatCompletionChun
 		if chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 			c.upstreamReasoning = chunk.Usage.CompletionTokensDetails.ReasoningTokens
 		}
-		return int(c.upstreamInputTokens), int(c.upstreamOutputTokens), nil
+		return int(c.upstreamInputTokens - c.upstreamCacheTokens), int(c.upstreamOutputTokens), nil
 	}
 
 	// Incremental counting for each delta in choices
@@ -151,7 +151,8 @@ func (c *StreamTokenCounter) GetCounts() (inputTokens, outputTokens int) {
 
 	i, o := c.inputTokens, c.outputTokens
 	if c.upstreamInputTokens > 0 {
-		i = int(c.upstreamInputTokens)
+		// Normalize: subtract cache so inputTokens = uncached-only portion
+		i = int(c.upstreamInputTokens - c.upstreamCacheTokens)
 	}
 	if c.upstreamOutputTokens > 0 {
 		o = int(c.upstreamOutputTokens)

--- a/internal/protocol/usage/README.md
+++ b/internal/protocol/usage/README.md
@@ -127,6 +127,49 @@ the default).
 
 ---
 
+## Where the extractors are used
+
+### `internal/protocol/nonstream/`
+
+All four `Handle*` functions call the shared extractors:
+
+| Function | Extractor |
+|---|---|
+| `HandleOpenAIChatNonStream` | `FromOpenAIChatCompletion` |
+| `HandleOpenAIResponsesNonStream` | `FromOpenAIResponses` |
+| `HandleAnthropicV1NonStream` | `FromAnthropicMessage` |
+| `HandleAnthropicV1BetaNonStream` | `FromAnthropicBetaMessage` |
+
+The `Convert*` helpers in that package (e.g. `ConvertAnthropicToOpenAIResponse`) return
+`map[string]interface{}` wire format and are not in the `*TokenUsage` tracking path.
+
+### `internal/protocol/stream/`
+
+| Function | Mechanism |
+|---|---|
+| `HandleAnthropic` | `AnthropicAccumulator.Consume` |
+| `HandleAnthropicBeta` | `AnthropicAccumulator.ConsumeBeta` |
+| `AnthropicToOpenAIStreamWithMCPHooks` | `AnthropicAccumulator.ConsumeBeta` |
+| `HandleAnthropicBetaToOpenAIResponsesStream` | `AnthropicAccumulator.ConsumeBeta` |
+
+### `internal/server/` (dispatch layer)
+
+Non-stream dispatch paths that receive a complete response:
+
+| Code site | Extractor |
+|---|---|
+| `protocol_dispatch.go` — Anthropic Beta non-stream (direct forward) | `FromAnthropicBetaMessage` |
+| `protocol_dispatch.go` — Anthropic V1 non-stream passthrough | `FromAnthropicBetaMessage` |
+| `protocol_dispatch.go` — OpenAI Chat non-stream | `FromOpenAIChatCompletion` |
+| `protocol_dispatch.go` — OpenAI Responses non-stream (→ Chat) | `FromOpenAIResponses` |
+| `protocol_dispatch.go` — OpenAI Responses passthrough | `FromOpenAIResponses` |
+| `protocol_dispatch.go` — Chat non-stream (→ Responses) | `FromOpenAIChatCompletion` |
+| `protocol_dispatch.go` — Responses → Anthropic Beta non-stream | `FromAnthropicBetaMessage` |
+| `anthropic_message_v1.go` — Responses → Anthropic v1 non-stream | `FromOpenAIResponses` |
+| `anthropic_message_beta.go` — Responses → Anthropic Beta non-stream | `FromOpenAIResponses` |
+
+---
+
 ## What is NOT covered here
 
 | Handler | Why inline extraction remains |
@@ -138,6 +181,9 @@ the default).
 | `stream/google_to_any.go` | Google-specific schema with no SDK usage struct |
 | `nonstream/anthropic_to_openai.go` | Returns `map[string]interface{}` wire format, not `*TokenUsage` |
 | `nonstream/openai_to_anthropic.go` | Same — wire format conversion only |
+| `server/protocol_dispatch.go` — Google non-stream | Google schema has no `CachedTokens` in the SDK struct |
+| `server/protocol_dispatch.go` — streaming return sites | Already normalized by stream-layer accumulators or `StreamTokenCounter` |
 
 These files normalize correctly inline; they are just not candidates for the shared
-extractors because their token variables serve double duty as wire response fields.
+extractors because their token variables serve double duty as wire response fields, or
+use a schema that predates SDK support.

--- a/internal/protocol/usage/README.md
+++ b/internal/protocol/usage/README.md
@@ -1,137 +1,70 @@
 # internal/protocol/usage
 
-Centralized token extraction and normalization for all supported provider protocols.
-Every handler calls into this package instead of re-implementing provider rules inline.
+Centralized token extraction and normalization. All handlers call into this package
+instead of re-implementing provider rules inline.
 
 ---
 
-## Why normalization matters
+## Normalization rules
 
-The `TokenUsage` struct (`InputTokens`, `OutputTokens`, `CacheInputTokens`) is used for
-cost accounting and cache-hit ratio display. The front-end formula is:
+Different providers report tokens with incompatible semantics. We normalize to a
+consistent internal representation so the front-end cache-hit formula works correctly:
 
 ```
 cache_hit_ratio = CacheInputTokens / (InputTokens + CacheInputTokens)
 ```
 
-Different providers report tokens with incompatible semantics, so we normalize to a
-consistent internal representation before populating `TokenUsage`.
+| Provider | Wire semantics | InputTokens stored as | CacheInputTokens stored as |
+|---|---|---|---|
+| **OpenAI Chat / Responses** | `prompt_tokens` = total (cached + uncached) | `prompt_tokens - cached_tokens` | `cached_tokens` |
+| **Anthropic** | `input_tokens` = uncached only; `cache_creation_input_tokens` = write cost | `input_tokens + cache_creation_input_tokens` | `cache_read_input_tokens` |
 
----
+> **Why add `cache_creation` to input?** Creation tokens are billable at a write-cost
+> rate, so they belong in the denominator to correctly represent total prompt spend.
 
-## Provider normalization rules
+### Anthropic streaming event split
 
-### OpenAI — Chat Completions & Responses API
+Anthropic splits usage across two events:
 
-| Wire field | Meaning |
-|---|---|
-| `prompt_tokens` / `input_tokens` | **Total** prompt tokens (cached + uncached) |
-| `prompt_tokens_details.cached_tokens` / `input_tokens_details.cached_tokens` | Cached subset (≤ total) |
-| `completion_tokens` / `output_tokens` | Output tokens |
-| `completion_tokens_details.reasoning_tokens` / `output_tokens_details.reasoning_tokens` | Reasoning subset of output |
+- `message_start` → `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`
+- `message_delta` → `output_tokens` (some non-standard providers also send `input_tokens` here)
 
-**Normalization:**
-```
-InputTokens     = prompt_tokens - cached_tokens   (uncached only)
-CacheInputTokens = cached_tokens
-OutputTokens    = completion_tokens
-ReasoningTokens = reasoning_tokens
-```
-
-Cache hit ratio: `cached / (uncached + cached)` = `cached / prompt_tokens` ✓
-
-### Anthropic — v1 & v1 Beta
-
-| Wire field | Meaning |
-|---|---|
-| `input_tokens` | **Uncached** prompt tokens only |
-| `cache_creation_input_tokens` | Tokens written to cache (priced as write cost) |
-| `cache_read_input_tokens` | Tokens read from cache |
-| `output_tokens` | Output tokens |
-
-**Normalization:**
-```
-InputTokens     = input_tokens + cache_creation_input_tokens   (uncached + write cost)
-CacheInputTokens = cache_read_input_tokens
-OutputTokens    = output_tokens
-```
-
-Cache hit ratio: `cache_read / (uncached + creation + cache_read)` ✓
-
-> **Why add `cache_creation`?** Creation tokens are billable at a write-cost rate, so
-> they belong in the denominator to correctly represent total prompt spend. Omitting
-> them would inflate the apparent hit rate.
-
-### Anthropic Streaming — event split
-
-Anthropic streams usage across two events:
-
-| Event | Fields present |
-|---|---|
-| `message_start` | `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` |
-| `message_delta` | `output_tokens` (occasionally `input_tokens` for non-standard providers) |
-
-`AnthropicAccumulator` handles this split, the priority fallback, and the
-normalization transparently.
-
-### Google GenAI
-
-Google usage is extracted and normalized inline in `stream/google_to_any.go` and
-`nonstream/any_to_google.go`. The Google protocol uses `promptTokenCount` /
-`candidatesTokenCount` with no cache sub-fields exposed in the SDK, so no
-centralized extractor is provided here.
+`AnthropicAccumulator` handles this split, priority fallback, and normalization transparently.
 
 ---
 
 ## API
 
-### Non-streaming (stateless, pure functions)
+### Non-streaming (pure functions)
 
 ```go
-import "github.com/tingly-dev/tingly-box/internal/protocol/usage"
-
-// OpenAI Chat Completions
-tu := usage.FromOpenAIChatCompletion(resp.Usage)
-
-// OpenAI Responses API
-tu := usage.FromOpenAIResponses(resp.Usage)
-
-// Anthropic v1 non-beta message
-tu := usage.FromAnthropicMessage(resp.Usage)
-
-// Anthropic v1 beta message
-tu := usage.FromAnthropicBetaMessage(resp.Usage)
+usage.FromOpenAIChatCompletion(resp.Usage)   // openai.CompletionUsage
+usage.FromOpenAIResponses(resp.Usage)        // responses.ResponseUsage
+usage.FromAnthropicMessage(resp.Usage)       // anthropic.Usage
+usage.FromAnthropicBetaMessage(resp.Usage)   // anthropic.BetaUsage
 ```
-
-Each function returns `*protocol.TokenUsage` with fields already normalized.
 
 ### Streaming — Anthropic accumulator
 
 ```go
 acc := usage.NewAnthropicAccumulator()
 
-// In the event loop:
-acc.Consume(&evt)      // non-beta: MessageStreamEventUnion
-acc.ConsumeBeta(&evt)  // beta:     BetaRawMessageStreamEventUnion
+// In event loop:
+acc.Consume(&evt)      // MessageStreamEventUnion (non-beta)
+acc.ConsumeBeta(&evt)  // BetaRawMessageStreamEventUnion (beta)
 
-// At return points:
+// At return:
 if acc.HasUsage() {
     return acc.Result(), nil
 }
 return protocol.ZeroTokenUsage(), nil
 ```
 
-`Result()` returns `*protocol.TokenUsage` with all normalization applied.
-`HasUsage()` is false if no usage-carrying events were seen (use `ZeroTokenUsage()` as
-the default).
-
 ---
 
-## Where the extractors are used
+## Coverage
 
 ### `internal/protocol/nonstream/`
-
-All four `Handle*` functions call the shared extractors:
 
 | Function | Extractor |
 |---|---|
@@ -139,9 +72,6 @@ All four `Handle*` functions call the shared extractors:
 | `HandleOpenAIResponsesNonStream` | `FromOpenAIResponses` |
 | `HandleAnthropicV1NonStream` | `FromAnthropicMessage` |
 | `HandleAnthropicV1BetaNonStream` | `FromAnthropicBetaMessage` |
-
-The `Convert*` helpers in that package (e.g. `ConvertAnthropicToOpenAIResponse`) return
-`map[string]interface{}` wire format and are not in the `*TokenUsage` tracking path.
 
 ### `internal/protocol/stream/`
 
@@ -154,36 +84,23 @@ The `Convert*` helpers in that package (e.g. `ConvertAnthropicToOpenAIResponse`)
 
 ### `internal/server/` (dispatch layer)
 
-Non-stream dispatch paths that receive a complete response:
-
 | Code site | Extractor |
 |---|---|
-| `protocol_dispatch.go` — Anthropic Beta non-stream (direct forward) | `FromAnthropicBetaMessage` |
-| `protocol_dispatch.go` — Anthropic V1 non-stream passthrough | `FromAnthropicBetaMessage` |
-| `protocol_dispatch.go` — OpenAI Chat non-stream | `FromOpenAIChatCompletion` |
-| `protocol_dispatch.go` — OpenAI Responses non-stream (→ Chat) | `FromOpenAIResponses` |
-| `protocol_dispatch.go` — OpenAI Responses passthrough | `FromOpenAIResponses` |
-| `protocol_dispatch.go` — Chat non-stream (→ Responses) | `FromOpenAIChatCompletion` |
-| `protocol_dispatch.go` — Responses → Anthropic Beta non-stream | `FromAnthropicBetaMessage` |
-| `anthropic_message_v1.go` — Responses → Anthropic v1 non-stream | `FromOpenAIResponses` |
-| `anthropic_message_beta.go` — Responses → Anthropic Beta non-stream | `FromOpenAIResponses` |
+| `protocol_dispatch` — Anthropic Beta non-stream (×2) | `FromAnthropicBetaMessage` |
+| `protocol_dispatch` — Responses → Anthropic Beta | `FromAnthropicBetaMessage` |
+| `protocol_dispatch` — OpenAI Chat non-stream (×2) | `FromOpenAIChatCompletion` |
+| `protocol_dispatch` — OpenAI Responses non-stream (×2) | `FromOpenAIResponses` |
+| `anthropic_message_v1` — Responses → Anthropic v1 | `FromOpenAIResponses` |
+| `anthropic_message_beta` — Responses → Anthropic Beta | `FromOpenAIResponses` |
 
----
+### Intentional inline extraction (not migrated)
 
-## What is NOT covered here
-
-| Handler | Why inline extraction remains |
+| File | Reason |
 |---|---|
-| `stream/openai_passthrough.go` | Streams accumulate per-chunk; also drives estimated usage injection when provider omits usage |
-| `stream/openai_to_anthropic*.go` | Uses `StreamTokenCounter` from `protocol/token` (incremental counting, not extraction) |
-| `stream/openai_chat_to_responses.go` | `state` struct fields are dual-use: also build the wire response body |
-| `stream/openai_responses_to_chat.go` | Same dual-use pattern |
-| `stream/google_to_any.go` | Google-specific schema with no SDK usage struct |
-| `nonstream/anthropic_to_openai.go` | Returns `map[string]interface{}` wire format, not `*TokenUsage` |
-| `nonstream/openai_to_anthropic.go` | Same — wire format conversion only |
-| `server/protocol_dispatch.go` — Google non-stream | Google schema has no `CachedTokens` in the SDK struct |
-| `server/protocol_dispatch.go` — streaming return sites | Already normalized by stream-layer accumulators or `StreamTokenCounter` |
-
-These files normalize correctly inline; they are just not candidates for the shared
-extractors because their token variables serve double duty as wire response fields, or
-use a schema that predates SDK support.
+| `stream/openai_passthrough.go` | Per-chunk accumulation + estimated usage injection fallback |
+| `stream/openai_to_anthropic*.go` | Uses `StreamTokenCounter` (incremental counting, not extraction) |
+| `stream/openai_{chat,responses}_to_*.go` | `state` fields are dual-use: also build the wire response body |
+| `stream/google_to_any.go` | Google SDK has no structured cache sub-fields |
+| `nonstream/anthropic_to_openai.go` | Returns wire format (`map[string]interface{}`), not `*TokenUsage` |
+| `nonstream/openai_to_anthropic.go` | Same |
+| `server/protocol_dispatch` — Google non-stream | Google schema, no cached tokens in SDK struct |

--- a/internal/protocol/usage/README.md
+++ b/internal/protocol/usage/README.md
@@ -1,0 +1,143 @@
+# internal/protocol/usage
+
+Centralized token extraction and normalization for all supported provider protocols.
+Every handler calls into this package instead of re-implementing provider rules inline.
+
+---
+
+## Why normalization matters
+
+The `TokenUsage` struct (`InputTokens`, `OutputTokens`, `CacheInputTokens`) is used for
+cost accounting and cache-hit ratio display. The front-end formula is:
+
+```
+cache_hit_ratio = CacheInputTokens / (InputTokens + CacheInputTokens)
+```
+
+Different providers report tokens with incompatible semantics, so we normalize to a
+consistent internal representation before populating `TokenUsage`.
+
+---
+
+## Provider normalization rules
+
+### OpenAI — Chat Completions & Responses API
+
+| Wire field | Meaning |
+|---|---|
+| `prompt_tokens` / `input_tokens` | **Total** prompt tokens (cached + uncached) |
+| `prompt_tokens_details.cached_tokens` / `input_tokens_details.cached_tokens` | Cached subset (≤ total) |
+| `completion_tokens` / `output_tokens` | Output tokens |
+| `completion_tokens_details.reasoning_tokens` / `output_tokens_details.reasoning_tokens` | Reasoning subset of output |
+
+**Normalization:**
+```
+InputTokens     = prompt_tokens - cached_tokens   (uncached only)
+CacheInputTokens = cached_tokens
+OutputTokens    = completion_tokens
+ReasoningTokens = reasoning_tokens
+```
+
+Cache hit ratio: `cached / (uncached + cached)` = `cached / prompt_tokens` ✓
+
+### Anthropic — v1 & v1 Beta
+
+| Wire field | Meaning |
+|---|---|
+| `input_tokens` | **Uncached** prompt tokens only |
+| `cache_creation_input_tokens` | Tokens written to cache (priced as write cost) |
+| `cache_read_input_tokens` | Tokens read from cache |
+| `output_tokens` | Output tokens |
+
+**Normalization:**
+```
+InputTokens     = input_tokens + cache_creation_input_tokens   (uncached + write cost)
+CacheInputTokens = cache_read_input_tokens
+OutputTokens    = output_tokens
+```
+
+Cache hit ratio: `cache_read / (uncached + creation + cache_read)` ✓
+
+> **Why add `cache_creation`?** Creation tokens are billable at a write-cost rate, so
+> they belong in the denominator to correctly represent total prompt spend. Omitting
+> them would inflate the apparent hit rate.
+
+### Anthropic Streaming — event split
+
+Anthropic streams usage across two events:
+
+| Event | Fields present |
+|---|---|
+| `message_start` | `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` |
+| `message_delta` | `output_tokens` (occasionally `input_tokens` for non-standard providers) |
+
+`AnthropicAccumulator` handles this split, the priority fallback, and the
+normalization transparently.
+
+### Google GenAI
+
+Google usage is extracted and normalized inline in `stream/google_to_any.go` and
+`nonstream/any_to_google.go`. The Google protocol uses `promptTokenCount` /
+`candidatesTokenCount` with no cache sub-fields exposed in the SDK, so no
+centralized extractor is provided here.
+
+---
+
+## API
+
+### Non-streaming (stateless, pure functions)
+
+```go
+import "github.com/tingly-dev/tingly-box/internal/protocol/usage"
+
+// OpenAI Chat Completions
+tu := usage.FromOpenAIChatCompletion(resp.Usage)
+
+// OpenAI Responses API
+tu := usage.FromOpenAIResponses(resp.Usage)
+
+// Anthropic v1 non-beta message
+tu := usage.FromAnthropicMessage(resp.Usage)
+
+// Anthropic v1 beta message
+tu := usage.FromAnthropicBetaMessage(resp.Usage)
+```
+
+Each function returns `*protocol.TokenUsage` with fields already normalized.
+
+### Streaming — Anthropic accumulator
+
+```go
+acc := usage.NewAnthropicAccumulator()
+
+// In the event loop:
+acc.Consume(&evt)      // non-beta: MessageStreamEventUnion
+acc.ConsumeBeta(&evt)  // beta:     BetaRawMessageStreamEventUnion
+
+// At return points:
+if acc.HasUsage() {
+    return acc.Result(), nil
+}
+return protocol.ZeroTokenUsage(), nil
+```
+
+`Result()` returns `*protocol.TokenUsage` with all normalization applied.
+`HasUsage()` is false if no usage-carrying events were seen (use `ZeroTokenUsage()` as
+the default).
+
+---
+
+## What is NOT covered here
+
+| Handler | Why inline extraction remains |
+|---|---|
+| `stream/openai_passthrough.go` | Streams accumulate per-chunk; also drives estimated usage injection when provider omits usage |
+| `stream/openai_to_anthropic*.go` | Uses `StreamTokenCounter` from `protocol/token` (incremental counting, not extraction) |
+| `stream/openai_chat_to_responses.go` | `state` struct fields are dual-use: also build the wire response body |
+| `stream/openai_responses_to_chat.go` | Same dual-use pattern |
+| `stream/google_to_any.go` | Google-specific schema with no SDK usage struct |
+| `nonstream/anthropic_to_openai.go` | Returns `map[string]interface{}` wire format, not `*TokenUsage` |
+| `nonstream/openai_to_anthropic.go` | Same — wire format conversion only |
+
+These files normalize correctly inline; they are just not candidates for the shared
+extractors because their token variables serve double duty as wire response fields.

--- a/internal/protocol/usage/accumulator.go
+++ b/internal/protocol/usage/accumulator.go
@@ -1,0 +1,146 @@
+package usage
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/tidwall/gjson"
+
+	protocol "github.com/tingly-dev/tingly-box/ai"
+)
+
+// AnthropicAccumulator accumulates token usage across a streaming Anthropic
+// response. The Anthropic protocol splits usage across two event types:
+//   - message_start → input_tokens, cache_creation, cache_read
+//   - message_delta → output_tokens (occasionally input for non-standard providers)
+//
+// Both non-beta (MessageStreamEventUnion) and beta
+// (BetaRawMessageStreamEventUnion) streams are supported via Consume and
+// ConsumeBeta respectively.
+type AnthropicAccumulator struct {
+	inputTokens  int
+	outputTokens int
+	cacheTokens  int
+	hasUsage     bool
+}
+
+// NewAnthropicAccumulator returns a zeroed accumulator ready to consume events.
+func NewAnthropicAccumulator() *AnthropicAccumulator {
+	return &AnthropicAccumulator{}
+}
+
+// Consume updates the accumulator from a non-beta streaming event.
+// It is safe to call on every event in the stream; only usage-carrying
+// events (message_start, message_delta) have any effect.
+func (a *AnthropicAccumulator) Consume(evt *anthropic.MessageStreamEventUnion) {
+	raw := evt.RawJSON()
+	a.consumeRaw(
+		evt.Message.Usage.InputTokens,
+		gjson.Get(raw, "message.usage.input_tokens").Int(),
+		evt.Usage.InputTokens,
+		gjson.Get(raw, "usage.input_tokens").Int(),
+		evt.Usage.OutputTokens,
+		gjson.Get(raw, "usage.output_tokens").Int(),
+		evt.Message.Usage.CacheReadInputTokens,
+		evt.Usage.CacheReadInputTokens,
+		gjson.Get(raw, "message.usage.cache_read_input_tokens").Int(),
+		gjson.Get(raw, "usage.cache_read_input_tokens").Int(),
+		evt.Message.Usage.CacheCreationInputTokens,
+		evt.Usage.CacheCreationInputTokens,
+	)
+}
+
+// ConsumeBeta updates the accumulator from a beta streaming event.
+func (a *AnthropicAccumulator) ConsumeBeta(evt *anthropic.BetaRawMessageStreamEventUnion) {
+	// Beta events follow the same protocol as non-beta; no gjson fallback
+	// needed since BetaUsage fields are directly accessible.
+	a.consumeRaw(
+		evt.Message.Usage.InputTokens,
+		0, // no gjson fallback for beta — SDK fields are reliable
+		evt.Usage.InputTokens,
+		0,
+		evt.Usage.OutputTokens,
+		0,
+		evt.Message.Usage.CacheReadInputTokens,
+		evt.Usage.CacheReadInputTokens,
+		0,
+		0,
+		evt.Message.Usage.CacheCreationInputTokens,
+		evt.Usage.CacheCreationInputTokens,
+	)
+}
+
+// consumeRaw merges one event's usage fields into the accumulator.
+// Parameters follow the priority order used in Anthropic streaming:
+//   - Input: prefer message_start (msgStartInput / msgStartInputRaw), fall
+//     back to message_delta (deltaInput / deltaInputRaw)
+//   - Output: delta path only
+//   - Cache read: prefer message_start, fall back to delta
+//   - Cache creation: added to inputTokens (normalization)
+func (a *AnthropicAccumulator) consumeRaw(
+	msgStartInput, msgStartInputRaw int64,
+	deltaInput, deltaInputRaw int64,
+	deltaOutput, deltaOutputRaw int64,
+	msgStartCacheRead, deltaCacheRead int64,
+	msgStartCacheReadRaw, deltaCacheReadRaw int64,
+	msgStartCacheCreation, deltaCacheCreation int64,
+) {
+	// Input tokens — prefer message_start, fall back to message_delta
+	switch {
+	case msgStartInput > 0:
+		a.inputTokens = int(msgStartInput)
+		a.hasUsage = true
+	case msgStartInputRaw > 0:
+		a.inputTokens = int(msgStartInputRaw)
+		a.hasUsage = true
+	case deltaInput > 0:
+		a.inputTokens = int(deltaInput)
+		a.hasUsage = true
+	case deltaInputRaw > 0:
+		a.inputTokens = int(deltaInputRaw)
+		a.hasUsage = true
+	}
+
+	// Output tokens
+	switch {
+	case deltaOutput > 0:
+		a.outputTokens = int(deltaOutput)
+		a.hasUsage = true
+	case deltaOutputRaw > 0:
+		a.outputTokens = int(deltaOutputRaw)
+		a.hasUsage = true
+	}
+
+	// Cache read tokens — stored separately as cacheTokens
+	switch {
+	case msgStartCacheRead > 0:
+		a.cacheTokens = int(msgStartCacheRead)
+		a.hasUsage = true
+	case deltaCacheRead > 0:
+		a.cacheTokens = int(deltaCacheRead)
+		a.hasUsage = true
+	case msgStartCacheReadRaw > 0:
+		a.cacheTokens = int(msgStartCacheReadRaw)
+		a.hasUsage = true
+	case deltaCacheReadRaw > 0:
+		a.cacheTokens = int(deltaCacheReadRaw)
+		a.hasUsage = true
+	}
+
+	// Normalize: add cache_creation to inputTokens so denominator =
+	// input (uncached) + creation (write cost). Cache reads stay in cacheTokens.
+	switch {
+	case msgStartCacheCreation > 0:
+		a.inputTokens += int(msgStartCacheCreation)
+	case deltaCacheCreation > 0:
+		a.inputTokens += int(deltaCacheCreation)
+	}
+}
+
+// Result returns the normalized TokenUsage built from accumulated events.
+func (a *AnthropicAccumulator) Result() *protocol.TokenUsage {
+	return protocol.NewTokenUsageWithCache(a.inputTokens, a.outputTokens, a.cacheTokens)
+}
+
+// HasUsage reports whether any non-zero usage was observed.
+func (a *AnthropicAccumulator) HasUsage() bool {
+	return a.hasUsage
+}

--- a/internal/protocol/usage/extract.go
+++ b/internal/protocol/usage/extract.go
@@ -67,3 +67,22 @@ func FromAnthropicBetaMessage(u anthropic.BetaUsage) *protocol.TokenUsage {
 		int(u.CacheReadInputTokens),
 	)
 }
+
+// ChatUsage converts normalized TokenUsage into an OpenAI Chat Completions
+// CompletionUsage wire struct. OpenAI wire semantics: PromptTokens = TOTAL
+// (uncached + cached), CachedTokens is a reported subset.
+func ChatUsage(u *protocol.TokenUsage) openai.CompletionUsage {
+	totalInput := u.InputTokens + u.CacheInputTokens
+	cu := openai.CompletionUsage{
+		PromptTokens:     int64(totalInput),
+		CompletionTokens: int64(u.OutputTokens),
+		TotalTokens:      int64(totalInput + u.OutputTokens),
+	}
+	if u.CacheInputTokens > 0 {
+		cu.PromptTokensDetails.CachedTokens = int64(u.CacheInputTokens)
+	}
+	if u.ReasoningTokens > 0 {
+		cu.CompletionTokensDetails.ReasoningTokens = int64(u.ReasoningTokens)
+	}
+	return cu
+}

--- a/internal/protocol/usage/extract.go
+++ b/internal/protocol/usage/extract.go
@@ -1,0 +1,69 @@
+// Package usage centralizes token extraction and normalization logic for all
+// supported provider protocols. Every handler calls into this package instead
+// of re-implementing provider-specific rules inline.
+//
+// Normalization rules:
+//   - OpenAI (Chat / Responses): prompt_tokens = total (cached + uncached).
+//     Store inputTokens = total - cached so the frontend ratio formula gives
+//     cache_read / (cache_read + uncached) = correct hit rate.
+//   - Anthropic: input_tokens = uncached only; cache_creation_input_tokens is
+//     an additional write cost that belongs in the denominator.
+//     Store inputTokens = input + creation so the formula covers total prompt cost.
+package usage
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+
+	protocol "github.com/tingly-dev/tingly-box/ai"
+)
+
+// FromOpenAIChatCompletion extracts normalized TokenUsage from an OpenAI Chat
+// Completions usage block. CachedTokens is a SUBSET of PromptTokens, so we
+// subtract it to get the uncached portion.
+func FromOpenAIChatCompletion(u openai.CompletionUsage) *protocol.TokenUsage {
+	cache := int(u.PromptTokensDetails.CachedTokens)
+	reasoning := int(u.CompletionTokensDetails.ReasoningTokens)
+	return protocol.NewTokenUsageFull(
+		int(u.PromptTokens)-cache,
+		int(u.CompletionTokens),
+		cache,
+		reasoning,
+	)
+}
+
+// FromOpenAIResponses extracts normalized TokenUsage from an OpenAI Responses
+// API usage block. Same semantics as Chat: InputTokens = total, CachedTokens
+// is a subset.
+func FromOpenAIResponses(u responses.ResponseUsage) *protocol.TokenUsage {
+	cache := int(u.InputTokensDetails.CachedTokens)
+	reasoning := int(u.OutputTokensDetails.ReasoningTokens)
+	return protocol.NewTokenUsageFull(
+		int(u.InputTokens)-cache,
+		int(u.OutputTokens),
+		cache,
+		reasoning,
+	)
+}
+
+// FromAnthropicMessage extracts normalized TokenUsage from an Anthropic v1
+// (non-beta) Message usage block. CacheCreationInputTokens is added to
+// InputTokens so the denominator covers all non-cache-read prompt cost.
+func FromAnthropicMessage(u anthropic.Usage) *protocol.TokenUsage {
+	return protocol.NewTokenUsageWithCache(
+		int(u.InputTokens)+int(u.CacheCreationInputTokens),
+		int(u.OutputTokens),
+		int(u.CacheReadInputTokens),
+	)
+}
+
+// FromAnthropicBetaMessage extracts normalized TokenUsage from an Anthropic
+// beta BetaMessage usage block. Same normalization as the non-beta path.
+func FromAnthropicBetaMessage(u anthropic.BetaUsage) *protocol.TokenUsage {
+	return protocol.NewTokenUsageWithCache(
+		int(u.InputTokens)+int(u.CacheCreationInputTokens),
+		int(u.OutputTokens),
+		int(u.CacheReadInputTokens),
+	)
+}

--- a/internal/protocol/usage/usage_test.go
+++ b/internal/protocol/usage/usage_test.go
@@ -1,0 +1,361 @@
+package usage_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol/usage"
+)
+
+// ---------------------------------------------------------------------------
+// FromOpenAIChatCompletion
+// ---------------------------------------------------------------------------
+
+func TestFromOpenAIChatCompletion(t *testing.T) {
+	tests := []struct {
+		name             string
+		prompt, cached   int64
+		completion       int64
+		reasoning        int64
+		wantInput        int
+		wantOutput       int
+		wantCache        int
+		wantReasoning    int
+	}{
+		{
+			name: "90% cache hit",
+			prompt: 1000, cached: 900, completion: 200,
+			wantInput: 100, wantOutput: 200, wantCache: 900,
+		},
+		{
+			name: "no cache",
+			prompt: 500, cached: 0, completion: 100,
+			wantInput: 500, wantOutput: 100, wantCache: 0,
+		},
+		{
+			name: "with reasoning",
+			prompt: 200, cached: 50, completion: 80, reasoning: 30,
+			wantInput: 150, wantOutput: 80, wantCache: 50, wantReasoning: 30,
+		},
+		{
+			name: "all zero",
+			wantInput: 0, wantOutput: 0, wantCache: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := openai.CompletionUsage{
+				PromptTokens:     tc.prompt,
+				CompletionTokens: tc.completion,
+			}
+			u.PromptTokensDetails.CachedTokens = tc.cached
+			u.CompletionTokensDetails.ReasoningTokens = tc.reasoning
+
+			got := usage.FromOpenAIChatCompletion(u)
+			assert.Equal(t, tc.wantInput, got.InputTokens)
+			assert.Equal(t, tc.wantOutput, got.OutputTokens)
+			assert.Equal(t, tc.wantCache, got.CacheInputTokens)
+			assert.Equal(t, tc.wantReasoning, got.ReasoningTokens)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FromOpenAIResponses
+// ---------------------------------------------------------------------------
+
+func TestFromOpenAIResponses(t *testing.T) {
+	tests := []struct {
+		name          string
+		input, cached int64
+		output        int64
+		reasoning     int64
+		wantInput     int
+		wantOutput    int
+		wantCache     int
+		wantReasoning int
+	}{
+		{
+			name: "partial cache",
+			input: 500, cached: 200, output: 60,
+			wantInput: 300, wantOutput: 60, wantCache: 200,
+		},
+		{
+			name: "full cache",
+			input: 800, cached: 800, output: 40,
+			wantInput: 0, wantOutput: 40, wantCache: 800,
+		},
+		{
+			name: "no cache with reasoning",
+			input: 300, cached: 0, output: 50, reasoning: 20,
+			wantInput: 300, wantOutput: 50, wantCache: 0, wantReasoning: 20,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := responses.ResponseUsage{
+				InputTokens:  tc.input,
+				OutputTokens: tc.output,
+			}
+			u.InputTokensDetails.CachedTokens = tc.cached
+			u.OutputTokensDetails.ReasoningTokens = tc.reasoning
+
+			got := usage.FromOpenAIResponses(u)
+			assert.Equal(t, tc.wantInput, got.InputTokens)
+			assert.Equal(t, tc.wantOutput, got.OutputTokens)
+			assert.Equal(t, tc.wantCache, got.CacheInputTokens)
+			assert.Equal(t, tc.wantReasoning, got.ReasoningTokens)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FromAnthropicMessage / FromAnthropicBetaMessage
+// ---------------------------------------------------------------------------
+
+func TestFromAnthropicMessage(t *testing.T) {
+	tests := []struct {
+		name                       string
+		input, creation, read      int64
+		output                     int64
+		wantInput, wantOutput      int
+		wantCache                  int
+	}{
+		{
+			name: "cache read only",
+			input: 100, creation: 0, read: 800, output: 50,
+			wantInput: 100, wantOutput: 50, wantCache: 800,
+		},
+		{
+			name: "cache creation included in denominator",
+			input: 100, creation: 900, read: 800, output: 50,
+			wantInput: 1000, wantOutput: 50, wantCache: 800,
+		},
+		{
+			name: "no cache",
+			input: 300, creation: 0, read: 0, output: 80,
+			wantInput: 300, wantOutput: 80, wantCache: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := anthropic.Usage{
+				InputTokens:              tc.input,
+				OutputTokens:             tc.output,
+				CacheCreationInputTokens: tc.creation,
+				CacheReadInputTokens:     tc.read,
+			}
+			got := usage.FromAnthropicMessage(u)
+			assert.Equal(t, tc.wantInput, got.InputTokens)
+			assert.Equal(t, tc.wantOutput, got.OutputTokens)
+			assert.Equal(t, tc.wantCache, got.CacheInputTokens)
+		})
+	}
+}
+
+func TestFromAnthropicBetaMessage(t *testing.T) {
+	u := anthropic.BetaUsage{
+		InputTokens:              100,
+		OutputTokens:             50,
+		CacheCreationInputTokens: 200,
+		CacheReadInputTokens:     400,
+	}
+	got := usage.FromAnthropicBetaMessage(u)
+	assert.Equal(t, 300, got.InputTokens) // 100 + 200
+	assert.Equal(t, 50, got.OutputTokens)
+	assert.Equal(t, 400, got.CacheInputTokens)
+}
+
+// ---------------------------------------------------------------------------
+// AnthropicAccumulator — real streaming format
+// ---------------------------------------------------------------------------
+
+// fakeDecoder replays raw JSON events as Anthropic SSE events.
+type fakeDecoder struct {
+	events  []string
+	current int
+	next    int
+}
+
+func newFakeDecoder(events []string) *fakeDecoder {
+	return &fakeDecoder{events: events, current: -1}
+}
+
+func (f *fakeDecoder) Next() bool {
+	if f.next >= len(f.events) {
+		return false
+	}
+	f.current = f.next
+	f.next++
+	return true
+}
+
+func (f *fakeDecoder) Event() anthropicstream.Event {
+	data := []byte(f.events[f.current])
+	eventType := gjson.GetBytes(data, "type").String()
+	return anthropicstream.Event{Type: eventType, Data: data}
+}
+
+func (f *fakeDecoder) Close() error { return nil }
+func (f *fakeDecoder) Err() error   { return nil }
+
+func messageStartJSON(t *testing.T, inputTokens, cacheCreation, cacheRead int64) string {
+	t.Helper()
+	ev := map[string]interface{}{
+		"type": "message_start",
+		"message": map[string]interface{}{
+			"id": "msg_test", "type": "message", "role": "assistant",
+			"content": []interface{}{}, "model": "claude-3-5-sonnet",
+			"usage": map[string]interface{}{
+				"input_tokens":              inputTokens,
+				"output_tokens":             0,
+				"cache_creation_input_tokens": cacheCreation,
+				"cache_read_input_tokens":   cacheRead,
+			},
+		},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func outputOnlyDeltaJSON(t *testing.T, outputTokens int64) string {
+	t.Helper()
+	ev := map[string]interface{}{
+		"type":  "message_delta",
+		"delta": map[string]interface{}{"stop_reason": "end_turn"},
+		"usage": map[string]interface{}{"output_tokens": outputTokens},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func messageDeltaFullJSON(t *testing.T, inputTokens, outputTokens, cacheRead int64) string {
+	t.Helper()
+	ev := map[string]interface{}{
+		"type":  "message_delta",
+		"delta": map[string]interface{}{"stop_reason": "end_turn"},
+		"usage": map[string]interface{}{
+			"input_tokens":            inputTokens,
+			"output_tokens":           outputTokens,
+			"cache_read_input_tokens": cacheRead,
+		},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// TestAnthropicAccumulator_RealFormat verifies the real Anthropic API format:
+// input_tokens in message_start, output_tokens in message_delta.
+func TestAnthropicAccumulator_RealFormat(t *testing.T) {
+	events := []string{
+		messageStartJSON(t, 35, 0, 5),  // input=35, creation=0, read=5
+		outputOnlyDeltaJSON(t, 18),
+	}
+	dec := newFakeDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](dec, nil)
+
+	acc := usage.NewAnthropicAccumulator()
+	for stream.Next() {
+		evt := stream.Current()
+		acc.Consume(&evt)
+	}
+
+	got := acc.Result()
+	assert.Equal(t, 35, got.InputTokens)
+	assert.Equal(t, 18, got.OutputTokens)
+	assert.Equal(t, 5, got.CacheInputTokens)
+	assert.True(t, acc.HasUsage())
+}
+
+// TestAnthropicAccumulator_WithCacheCreation verifies that cache_creation_input_tokens
+// is added to inputTokens so the denominator covers total prompt cost.
+func TestAnthropicAccumulator_WithCacheCreation(t *testing.T) {
+	events := []string{
+		messageStartJSON(t, 100, 900, 800), // input=100, creation=900, read=800
+		outputOnlyDeltaJSON(t, 50),
+	}
+	dec := newFakeDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](dec, nil)
+
+	acc := usage.NewAnthropicAccumulator()
+	for stream.Next() {
+		evt := stream.Current()
+		acc.Consume(&evt)
+	}
+
+	got := acc.Result()
+	assert.Equal(t, 1000, got.InputTokens) // 100 + 900
+	assert.Equal(t, 50, got.OutputTokens)
+	assert.Equal(t, 800, got.CacheInputTokens)
+}
+
+// TestAnthropicAccumulator_NonStandardDelta verifies backward compat for providers
+// that send input_tokens in message_delta instead of message_start.
+func TestAnthropicAccumulator_NonStandardDelta(t *testing.T) {
+	events := []string{
+		// message_start with zero input (non-standard)
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","content":[],"model":"custom","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		messageDeltaFullJSON(t, 40, 20, 0),
+	}
+	dec := newFakeDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](dec, nil)
+
+	acc := usage.NewAnthropicAccumulator()
+	for stream.Next() {
+		evt := stream.Current()
+		acc.Consume(&evt)
+	}
+
+	got := acc.Result()
+	assert.Equal(t, 40, got.InputTokens)
+	assert.Equal(t, 20, got.OutputTokens)
+}
+
+// TestAnthropicAccumulator_Beta verifies ConsumeBeta works for beta streams.
+func TestAnthropicAccumulator_Beta(t *testing.T) {
+	events := []string{
+		messageStartJSON(t, 40, 5, 8), // input=40, creation=5, read=8
+		outputOnlyDeltaJSON(t, 22),
+	}
+	dec := newFakeDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](dec, nil)
+
+	acc := usage.NewAnthropicAccumulator()
+	for stream.Next() {
+		evt := stream.Current()
+		acc.ConsumeBeta(&evt)
+	}
+
+	got := acc.Result()
+	assert.Equal(t, 45, got.InputTokens) // 40 + 5
+	assert.Equal(t, 22, got.OutputTokens)
+	assert.Equal(t, 8, got.CacheInputTokens)
+}
+
+// TestAnthropicAccumulator_NoUsage verifies HasUsage is false when no usage seen.
+func TestAnthropicAccumulator_NoUsage(t *testing.T) {
+	acc := usage.NewAnthropicAccumulator()
+	assert.False(t, acc.HasUsage())
+	got := acc.Result()
+	assert.Equal(t, 0, got.InputTokens)
+	assert.Equal(t, 0, got.OutputTokens)
+}

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/nonstream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
+	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/server/forwarding"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -172,14 +173,7 @@ func (s *Server) nonstreamResponsesToAnthropicBeta(c *gin.Context, proxyModel st
 		return
 	}
 
-	// Extract usage from response
-	inputTokens := int(response.Usage.InputTokens)
-	outputTokens := int(response.Usage.OutputTokens)
-	cacheTokens := int(response.Usage.InputTokensDetails.CachedTokens)
-	usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
-
-	// Track usage
-	s.trackUsageWithTokenUsage(c, usage, nil)
+	s.trackUsageWithTokenUsage(c, usagepkg.FromOpenAIResponses(response.Usage), nil)
 
 	anthropicResp := nonstream.ConvertResponsesToAnthropicBetaResponse(response, proxyModel)
 

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/nonstream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
+	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/server/forwarding"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -134,14 +135,7 @@ func (s *Server) nonstreamResponsesToAnthropic(c *gin.Context, proxyModel string
 		return
 	}
 
-	// Extract usage from response
-	inputTokens := int(response.Usage.InputTokens)
-	outputTokens := int(response.Usage.OutputTokens)
-	cacheTokens := int(response.Usage.InputTokensDetails.CachedTokens)
-	usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
-
-	// Track usage
-	s.trackUsageWithTokenUsage(c, usage, nil)
+	s.trackUsageWithTokenUsage(c, usagepkg.FromOpenAIResponses(response.Usage), nil)
 
 	// Convert Responses API response back to Anthropic v1 format
 	anthropicResp := nonstream.ConvertResponsesToAnthropicV1Response(response, proxyModel)

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/request"
 	"github.com/tingly-dev/tingly-box/internal/protocol/stream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/server/forwarding"
 	"github.com/tingly-dev/tingly-box/internal/server/module/mcp"
 	coretool "github.com/tingly-dev/tingly-box/internal/tool"
@@ -255,11 +256,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 				}
 				return
 			}
-			usage = protocol.NewTokenUsageWithCache(
-				int(anthropicResp.Usage.InputTokens),
-				int(anthropicResp.Usage.OutputTokens),
-				int(anthropicResp.Usage.CacheReadInputTokens+anthropicResp.Usage.CacheCreationInputTokens),
-			)
+			usage = usagepkg.FromAnthropicBetaMessage(anthropicResp.Usage)
 		}
 
 		s.trackUsageWithTokenUsage(c, usage, nil)
@@ -366,12 +363,7 @@ func (s *Server) passthroughAnthropicBeta(
 				return
 			}
 
-			tokenUsage := protocol.NewTokenUsageWithCache(
-				int(anthropicResp.Usage.InputTokens),
-				int(anthropicResp.Usage.OutputTokens),
-				int(anthropicResp.Usage.CacheReadInputTokens+anthropicResp.Usage.CacheCreationInputTokens),
-			)
-			s.trackUsageWithTokenUsage(c, tokenUsage, nil)
+			s.trackUsageWithTokenUsage(c, usagepkg.FromAnthropicBetaMessage(anthropicResp.Usage), nil)
 		}
 
 		s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
@@ -708,11 +700,7 @@ func (s *Server) dispatchOpenAIChat(
 				}
 				return
 			}
-			usage = protocol.NewTokenUsageWithCache(
-				int(resp.Usage.PromptTokens),
-				int(resp.Usage.CompletionTokens),
-				int(resp.Usage.PromptTokensDetails.CachedTokens),
-			)
+			usage = usagepkg.FromOpenAIChatCompletion(resp.Usage)
 		}
 
 		s.trackUsageWithTokenUsage(c, usage, err)
@@ -804,11 +792,7 @@ func (s *Server) nonstreamResponsesToChat(c *gin.Context, reqCtx *transform.Tran
 		return
 	}
 
-	inputTokens := int(responsesResp.Usage.InputTokens)
-	outputTokens := int(responsesResp.Usage.OutputTokens)
-	cacheTokens := int(responsesResp.Usage.InputTokensDetails.CachedTokens)
-	tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
-	s.trackUsageWithTokenUsage(c, tokenUsage, nil)
+	s.trackUsageWithTokenUsage(c, usagepkg.FromOpenAIResponses(responsesResp.Usage), nil)
 
 	chatResp := nonstream.OpenAIResponsesToChat(responsesResp, responseModel)
 	if recorder != nil {
@@ -846,13 +830,7 @@ func (s *Server) nonstreamOpenAIResponses(c *gin.Context, reqCtx *transform.Tran
 		return
 	}
 
-	// Extract usage from response
-	inputTokens := int64(response.Usage.InputTokens)
-	outputTokens := int64(response.Usage.OutputTokens)
-	cacheTokens := int64(response.Usage.InputTokensDetails.CachedTokens)
-
-	// Track usage
-	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil)
+	s.trackUsageWithTokenUsage(c, usagepkg.FromOpenAIResponses(response.Usage), nil)
 
 	// Override model in response if needed
 	if responseModel != reqCtx.RequestModel {
@@ -935,10 +913,7 @@ func (s *Server) nonstreamOpenAIChatToResponses(c *gin.Context, reqCtx *transfor
 		}
 		return
 	}
-	inputTokens := chatResp.Usage.PromptTokens
-	outputTokens := chatResp.Usage.CompletionTokens
-	cacheTokens := chatResp.Usage.PromptTokensDetails.CachedTokens
-	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil)
+	s.trackUsageWithTokenUsage(c, usagepkg.FromOpenAIChatCompletion(chatResp.Usage), nil)
 	c.JSON(http.StatusOK, buildResponsesPayloadFromChat(chatResp, responseModel, reqCtx.RequestModel))
 }
 
@@ -990,8 +965,7 @@ func (s *Server) nonstreamAnthropicBetaFromResponses(c *gin.Context, reqCtx *tra
 		return
 	}
 
-	cacheTokens := int(anthropicResp.Usage.CacheReadInputTokens)
-	s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(int(anthropicResp.Usage.InputTokens), int(anthropicResp.Usage.OutputTokens), cacheTokens), nil)
+	s.trackUsageWithTokenUsage(c, usagepkg.FromAnthropicBetaMessage(anthropicResp.Usage), nil)
 	c.JSON(http.StatusOK, buildResponsesPayloadFromAnthropicBeta(anthropicResp, responseModel, reqCtx.RequestModel))
 }
 

--- a/internal/server/protocol_roundtrip.go
+++ b/internal/server/protocol_roundtrip.go
@@ -53,9 +53,7 @@ func RoundtripAnthropicBetaResponseViaOpenAI(anthropicResp *anthropic.BetaMessag
 // ConvertAnthropicToOpenAIResponseWithProvider converts an Anthropic response to OpenAI format
 // and applies provider-specific transformations to the response
 func ConvertAnthropicToOpenAIResponseWithProvider(anthropicResp *anthropic.BetaMessage, responseModel string, provider *typ.Provider, model string) map[string]interface{} {
-	// Base conversion
-	openaiResp := nonstream.ConvertAnthropicToOpenAIResponse(anthropicResp, responseModel)
-
-	// Apply provider-specific transformations using the transform system
+	// Convert to typed wire struct, then to map for runtime transform compatibility.
+	openaiResp := nonstream.ConvertAnthropicToOpenAIResponse(anthropicResp, responseModel).ToMap()
 	return ops.ApplyResponseTransforms(openaiResp, provider.APIBase, model)
 }


### PR DESCRIPTION
## Problems Solved

### 1 — Cache-hit ratio: wrong normalization in extraction

The front-end formula is:
```
cache_hit_ratio = CacheInputTokens / (InputTokens + CacheInputTokens)
```

This requires `InputTokens` to be **uncached-only**. Two systematic bugs broke it:

**OpenAI** (`prompt_tokens` = total, `cached_tokens` is a subset):
```go
// WRONG — double-counts cache in denominator
InputTokens = prompt_tokens          // 1000 (uncached 100 + cached 900)
// ratio = 900/(1000+900) = 47%  ← wrong

// RIGHT
InputTokens = prompt_tokens - cached_tokens   // 100
// ratio = 900/(100+900) = 90%  ← correct
```

**Anthropic** (`input_tokens` = uncached only, `cache_creation` = write cost):
```go
// WRONG — omits creation cost from denominator
InputTokens = input_tokens                              // 100
// ratio = 800/(100+800) = 89%  ← inflated

// RIGHT
InputTokens = input_tokens + cache_creation_tokens     // 100+900=1000
// ratio = 800/(1000+800) = 44%  ← correct
```

### 2 — Wire-format: wrong values emitted in protocol conversions

When converting between protocols the inverse transformation must be applied. Five sites sent uncached counts where total was required (or vice versa):

| File | Bug | Fix |
|---|---|---|
| `stream/anthropic_to_openai` | `PromptTokens` = uncached | = uncached + cached (total) |
| `stream/anthropic_beta_to_openai_responses` | `InputTokens` = uncached | = total |
| `stream/openai_responses_to_chat` | `PromptTokens` = uncached | = total |
| `nonstream/anthropic_to_openai` | `prompt_tokens` = Anthropic-style uncached | = OpenAI-style total |
| `nonstream/openai_to_anthropic` (×4) | `input_tokens` = OpenAI-style total | = Anthropic-style uncached |

---

## Solution

### New `internal/protocol/usage` package

Single source of truth for all normalization rules.

**Non-streaming extractors:**
```go
usage.FromOpenAIChatCompletion(resp.Usage)   // prompt - cached → InputTokens
usage.FromOpenAIResponses(resp.Usage)
usage.FromAnthropicMessage(resp.Usage)       // input + creation → InputTokens
usage.FromAnthropicBetaMessage(resp.Usage)
```

**Wire-format emitters** (inverse of extraction):
```go
usage.ChatUsage(u *protocol.TokenUsage) openai.CompletionUsage
// PromptTokens = u.InputTokens + u.CacheInputTokens (total)
```

**Anthropic streaming accumulator** (handles `message_start`/`message_delta` split, gjson fallback for non-standard providers):
```go
acc := usage.NewAnthropicAccumulator()
acc.ConsumeBeta(&evt)   // on each event
return acc.Result(), nil // always safe; returns zeros when no usage seen
```

### Typed wire structs replacing `map[string]interface{}`

`nonstream/anthropic_to_openai.go` — `ConvertAnthropicToOpenAIResponse` now returns `ChatCompletionWire` (typed struct with JSON tags). `.ToMap()` bridges to the server layer that needs a map for `ApplyResponseTransforms`.

`nonstream/openai_to_anthropic.go` — all four converter functions use `anthropicMsgWire` + `anthropicUsageWire` typed intermediates instead of inline map literals.

### Accumulator cleanup

`HasUsage()` guards on every `return` path were redundant — `acc.Result()` already returns all-zeros when no events were consumed, identical to `ZeroTokenUsage()`. Guards removed; `HasUsage()` retained only where it's meaningful: guarding zero-usage injection into SSE stream chunks.

---

## Coverage

Fixed: 4 `nonstream` handlers, 4 `stream` handlers, 9 `server/protocol_dispatch` + `anthropic_message_*.go` dispatch sites.

See `internal/protocol/usage/README.md` for the full normalization rules and coverage map.

## Test plan

- [x] `go test ./internal/protocol/...` — all pass
- [x] `go test ./internal/server/...` — all pass (2 pre-existing failures unrelated)
