### PR TITLE
refactor(protocol, transform): Refactor vendor and thinking transforms to flat dispatch chains

### DIFF
--- a/internal/protocol/ops/request_anthropic_model.go
+++ b/internal/protocol/ops/request_anthropic_model.go
@@ -358,3 +358,51 @@ func extractFirstBetaUserMessageText(messages []anthropic.BetaMessageParam) stri
 	}
 	return ""
 }
+
+// ApplyAnthropicV1DeepSeekThinkingPatch ensures every assistant message carries
+// at least one thinking block. DeepSeek's Anthropic-compatible endpoint rejects
+// assistant turns that lack one — mirrors the reasoning_content fill in
+// applyDeepSeekTransform for the OpenAI Chat path.
+func ApplyAnthropicV1DeepSeekThinkingPatch(req *anthropic.MessageNewParams) {
+	if req == nil {
+		return
+	}
+	for i := range req.Messages {
+		if string(req.Messages[i].Role) != "assistant" {
+			continue
+		}
+		found := false
+		for _, b := range req.Messages[i].Content {
+			if b.OfThinking != nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			req.Messages[i].Content = append(req.Messages[i].Content, anthropic.NewThinkingBlock("", ""))
+		}
+	}
+}
+
+// ApplyAnthropicBetaDeepSeekThinkingPatch is the Beta-variant of
+// ApplyAnthropicV1DeepSeekThinkingPatch.
+func ApplyAnthropicBetaDeepSeekThinkingPatch(req *anthropic.BetaMessageNewParams) {
+	if req == nil {
+		return
+	}
+	for i := range req.Messages {
+		if string(req.Messages[i].Role) != "assistant" {
+			continue
+		}
+		found := false
+		for _, b := range req.Messages[i].Content {
+			if b.OfThinking != nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			req.Messages[i].Content = append(req.Messages[i].Content, anthropic.NewBetaThinkingBlock("", ""))
+		}
+	}
+}

--- a/internal/protocol/ops/request_openai_extensions.go
+++ b/internal/protocol/ops/request_openai_extensions.go
@@ -8,98 +8,37 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
-// ProviderTransform applies provider-specific transformations to OpenAI requests
-type ProviderTransform func(*openai.ChatCompletionNewParams, string, string, *protocol.OpenAIConfig) *openai.ChatCompletionNewParams
-
-// providerConfig maps APIBase patterns to their transforms
-type providerConfig struct {
-	APIBasePattern string
-	ModelPattern   string // Optional: if specified, model name must also match this pattern
-	Transform      ProviderTransform
-}
-
-// ProviderConfigs holds all registered provider configurations
-// Add new providers here with their APIBase domain patterns
-var ProviderConfigs = []providerConfig{
-	// DeepSeek - official API
-	{
-		APIBasePattern: "api.deepseek.com",
-		ModelPattern:   "*", // No specific model pattern needed for DeepSeek official API
-		Transform:      applyDeepSeekTransform,
-	},
-
-	// OpenCode Go - aggregator that may route to DeepSeek models
-	// Only apply DeepSeek transform when the model name contains "deepseek"
-	{
-		APIBasePattern: "opencode.ai/zen/go",
-		ModelPattern:   "deepseek",
-		Transform:      applyDeepSeekTransform,
-	},
-
-	{
-		APIBasePattern: "https://api.kimi.com/coding/v1",
-		ModelPattern:   "*",
-		Transform:      applyDeepSeekTransform,
-	},
-
-	// Moonshot - official API (CN)
-	// Moonshot requires reasoning_content in assistant messages with tool_calls when thinking is enabled
-	// Similar to DeepSeek, we reuse applyDeepSeekTransform to handle x_thinking -> reasoning_content conversion
-	{
-		APIBasePattern: "api.moonshot.cn",
-		ModelPattern:   "*",
-		Transform:      applyDeepSeekTransform,
-	},
-
-	// Moonshot - official API (International)
-	{
-		APIBasePattern: "api.moonshot.ai",
-		ModelPattern:   "*",
-		Transform:      applyDeepSeekTransform,
-	},
-
-	// Gemini - official Google API
-	{
-		APIBasePattern: "generativelanguage.googleapis.com",
-		ModelPattern:   "gemini", // No specific model pattern needed for official Gemini API
-		Transform:      applyGeminiTransform,
-	},
-
-	// Gemini - Poe (only for Gemini models)
-	{
-		APIBasePattern: "poe.com",
-		ModelPattern:   "gemini", // Apply transform only if model name contains "gemini"
-		Transform:      applyGeminiPoeTransform,
-	},
-
-	// Gemini - OpenRouter
-	// {"openrouter.ai", applyGeminiOpenRouterTransform},
-}
-
-// GetProviderTransform identifies provider by APIBase URL string and returns its transform
-// Returns nil if no specific transform is needed (fallback to default)
-func GetProviderTransform(providerURL, model string) ProviderTransform {
-	apiBase := strings.ToLower(providerURL)
+// ApplyProviderTransforms applies provider-specific transformations to an
+// OpenAI Chat request. The dispatch is a flat strings.Contains chain — short,
+// explicit, and parallel to the per-shape dispatch in VendorTransform.
+//
+// New providers are added as new cases here; aliases (e.g. multiple URLs that
+// share a vendor's quirks) sit in the same case body.
+func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
+	url := strings.ToLower(providerURL)
 	modelLower := strings.ToLower(model)
 
-	// Match by APIBase domain and optional ModelPattern
-	if apiBase != "" {
-		for _, config := range ProviderConfigs {
-			if strings.Contains(apiBase, config.APIBasePattern) {
-				if config.ModelPattern == "*" || strings.Contains(modelLower, config.ModelPattern) {
-					return config.Transform
-				}
-			}
-		}
+	switch {
+	case strings.Contains(url, "api.deepseek.com"),
+		strings.Contains(url, "api.moonshot.cn"),
+		strings.Contains(url, "api.moonshot.ai"),
+		strings.Contains(url, "api.kimi.com/coding/v1"),
+		strings.Contains(url, "opencode.ai/zen/go") && strings.Contains(modelLower, "deepseek"):
+		return applyDeepSeekTransform(req, providerURL, model, config)
+
+	case strings.Contains(url, "generativelanguage.googleapis.com") && strings.Contains(modelLower, "gemini"):
+		return applyGeminiTransform(req, providerURL, model, config)
+
+	case strings.Contains(url, "poe.com") && strings.Contains(modelLower, "gemini"):
+		return applyGeminiPoeTransform(req, providerURL, model, config)
 	}
 
-	// No specific transform needed - use default
-	return nil
+	return applyDefaultTransform(req, config)
 }
 
-// normalizeCursorContent flattens rich content in messages for Cursor compatibility.
-// This should be applied for ALL providers when cursor_compat is enabled.
-func normalizeCursorContent(req *openai.ChatCompletionNewParams) {
+// ApplyCursorCompatContentNormalization flattens rich content in messages for
+// Cursor compatibility. Applies to ALL providers when cursor_compat is enabled.
+func ApplyCursorCompatContentNormalization(req *openai.ChatCompletionNewParams) {
 	for i := range req.Messages {
 		msgMap, err := messageToMap(req.Messages[i])
 		if err != nil {
@@ -128,20 +67,11 @@ func normalizeCursorContent(req *openai.ChatCompletionNewParams) {
 	}
 }
 
-// ApplyCursorCompatContentNormalization is the exported version of normalizeCursorContent.
-// It flattens rich content in messages for Cursor compatibility.
-// This should be called for ALL providers when cursor_compat is enabled.
-func ApplyCursorCompatContentNormalization(req *openai.ChatCompletionNewParams) {
-	normalizeCursorContent(req)
-}
-
-// messageToMap converts a ChatCompletionMessageParamUnion to a map for modification
 func messageToMap(msg openai.ChatCompletionMessageParamUnion) (map[string]interface{}, error) {
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
 	}
-
 	var result map[string]interface{}
 	if err := json.Unmarshal(msgBytes, &result); err != nil {
 		return nil, err
@@ -183,37 +113,23 @@ func flattenRichContent(parts []interface{}) (string, bool) {
 	return strings.Join(segments, "\n"), dropped
 }
 
-// applyDefaultTransform applies default transformations for OpenAI-compatible requests
-// This handles standard fields like reasoning_effort that are widely supported
+// applyDefaultTransform applies the standard OpenAI-compatible thinking
+// fallback when no vendor-specific transform matched. Sets reasoning_effort
+// from config, or falls back to a `thinking.type=enabled` extra field for
+// providers that accept the Anthropic-style extension.
 func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
 	if config.HasThinking && config.ReasoningEffort != "" {
-		// Set reasoning_effort from config for OpenAI-compatible APIs
-		// This is widely supported by many providers (OpenAI, Azure, etc.)
 		req.ReasoningEffort = config.ReasoningEffort
 	} else if config.HasThinking {
 		extra := req.ExtraFields()
 		if extra == nil {
 			extra = map[string]interface{}{
-				"thinking": map[string]interface{}{
-					"type": "enabled",
-				},
+				"thinking": map[string]interface{}{"type": "enabled"},
 			}
 		} else {
-			extra["thinking"] = map[string]interface{}{
-				"type": "enabled",
-			}
+			extra["thinking"] = map[string]interface{}{"type": "enabled"}
 		}
 		req.SetExtraFields(extra)
 	}
 	return req
-}
-
-// ApplyProviderTransforms applies provider-specific transformations
-// Falls back to default handling if no specific transform found
-func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
-	if transform := GetProviderTransform(providerURL, model); transform != nil {
-		return transform(req, providerURL, model, config)
-	}
-	// Default: apply standard OpenAI-compatible transformations
-	return applyDefaultTransform(req, config)
 }

--- a/internal/protocol/ops/request_thinking.go
+++ b/internal/protocol/ops/request_thinking.go
@@ -1,0 +1,109 @@
+package ops
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// ApplyThinkingEffort enforces a thinking_effort level on any supported request
+// shape. Shared by both the rule-level and scenario-level thinking transforms.
+//
+// Effort semantics:
+//   - "" (default): pass through, no change.
+//   - "off": force thinking disabled. For Anthropic this sets OfDisabled;
+//     for OpenAI this clears reasoning_effort and removes any stray `thinking`
+//     extension (DeepSeek and friends reject requests that carry both).
+//   - "low"/"medium"/"high"/"max": force thinking enabled with the matching
+//     budget. "max" collapses to "high" for OpenAI which has no "max".
+func ApplyThinkingEffort(req interface{}, effort string) {
+	switch effort {
+	case typ.ThinkingEffortDefault:
+		return
+	case typ.ThinkingEffortOff:
+		disableThinking(req)
+		return
+	}
+	budget, ok := typ.ThinkingBudgetMapping[effort]
+	if !ok {
+		return
+	}
+	enableThinking(req, effort, budget)
+}
+
+// disableThinking turns thinking off on the target request and scrubs any
+// conflicting extension fields.
+func disableThinking(req interface{}) {
+	switch r := req.(type) {
+	case *anthropic.MessageNewParams:
+		r.Thinking = anthropic.ThinkingConfigParamUnion{
+			OfDisabled: &anthropic.ThinkingConfigDisabledParam{},
+		}
+		r.OutputConfig.Effort = ""
+	case *anthropic.BetaMessageNewParams:
+		r.Thinking = anthropic.BetaThinkingConfigParamUnion{
+			OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{},
+		}
+		r.OutputConfig.Effort = ""
+	case *openai.ChatCompletionNewParams:
+		r.ReasoningEffort = ""
+		stripOpenAIThinkingExtra(r)
+	case *responses.ResponseNewParams:
+		r.Reasoning.Effort = ""
+	}
+}
+
+// enableThinking turns thinking on with the matching budget / effort.
+//
+// For Anthropic requests: budget_tokens is capped at max_tokens (floor 1024)
+// so the budget never exceeds the operator's hard limit.
+func enableThinking(req interface{}, effort string, budget int64) {
+	switch r := req.(type) {
+	case *anthropic.MessageNewParams:
+		if r.MaxTokens > 0 && budget > r.MaxTokens {
+			budget = max(1024, r.MaxTokens)
+		}
+		r.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
+	case *anthropic.BetaMessageNewParams:
+		if r.MaxTokens > 0 && budget > r.MaxTokens {
+			budget = max(1024, r.MaxTokens)
+		}
+		r.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budget)
+	case *openai.ChatCompletionNewParams:
+		r.ReasoningEffort = openaiReasoningEffort(effort)
+		stripOpenAIThinkingExtra(r)
+	case *responses.ResponseNewParams:
+		r.Reasoning.Effort = openaiReasoningEffort(effort)
+	}
+}
+
+// stripOpenAIThinkingExtra removes any non-standard `thinking` blob from an
+// OpenAI Chat request's ExtraFields. Several upstreams (DeepSeek, Moonshot)
+// reject requests that carry both the typed `reasoning_effort` and a
+// `thinking.type` extension.
+func stripOpenAIThinkingExtra(req *openai.ChatCompletionNewParams) {
+	extra := req.ExtraFields()
+	if extra == nil {
+		return
+	}
+	if _, ok := extra["thinking"]; !ok {
+		return
+	}
+	delete(extra, "thinking")
+	req.SetExtraFields(extra)
+}
+
+// openaiReasoningEffort maps a rule effort level to a valid OpenAI
+// reasoning_effort. "max" collapses to "high" because OpenAI has no "max".
+func openaiReasoningEffort(effort string) shared.ReasoningEffort {
+	switch effort {
+	case typ.ThinkingEffortLow:
+		return shared.ReasoningEffortLow
+	case typ.ThinkingEffortHigh, typ.ThinkingEffortMax:
+		return shared.ReasoningEffortHigh
+	default:
+		return shared.ReasoningEffortMedium
+	}
+}

--- a/internal/protocol/ops/request_thinking.go
+++ b/internal/protocol/ops/request_thinking.go
@@ -57,18 +57,21 @@ func disableThinking(req interface{}) {
 
 // enableThinking turns thinking on with the matching budget / effort.
 //
-// For Anthropic requests: budget_tokens is capped at max_tokens (floor 1024)
-// so the budget never exceeds the operator's hard limit.
+// For Anthropic requests: budget_tokens is capped at max_tokens so the budget
+// never exceeds the operator's hard limit. When max_tokens itself is below 1024
+// (Anthropic's minimum for extended thinking) we still cap at max_tokens and
+// let the API surface the conflict — silently raising the budget above
+// max_tokens would violate the operator limit.
 func enableThinking(req interface{}, effort string, budget int64) {
 	switch r := req.(type) {
 	case *anthropic.MessageNewParams:
 		if r.MaxTokens > 0 && budget > r.MaxTokens {
-			budget = max(1024, r.MaxTokens)
+			budget = r.MaxTokens
 		}
 		r.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
 	case *anthropic.BetaMessageNewParams:
 		if r.MaxTokens > 0 && budget > r.MaxTokens {
-			budget = max(1024, r.MaxTokens)
+			budget = r.MaxTokens
 		}
 		r.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budget)
 	case *openai.ChatCompletionNewParams:

--- a/internal/protocol/transform/rule_thinking.go
+++ b/internal/protocol/transform/rule_thinking.go
@@ -1,26 +1,12 @@
 package transform
 
-import (
-	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/responses"
-	"github.com/openai/openai-go/v3/shared"
-	"github.com/tingly-dev/tingly-box/internal/typ"
-)
+import "github.com/tingly-dev/tingly-box/internal/protocol/ops"
 
 // RuleThinkingTransform applies the unified thinking_effort control at the
 // rule level. It runs as a post-base stage so the type-switch sees the
 // upstream-bound request shape after protocol conversion.
 //
-// Effort semantics:
-//   - "" (default): pass through, no change.
-//   - "off": force thinking disabled. For Anthropic this sets OfDisabled;
-//     for OpenAI this clears reasoning_effort and removes any stray `thinking`
-//     extension some clients/vendors leave in ExtraFields (DeepSeek and friends
-//     reject requests that carry both reasoning_effort and thinking.type).
-//   - "low"/"medium"/"high"/"max": force thinking enabled with the matching
-//     budget. "max" collapses to "high" for OpenAI which has no "max".
-//
+// Effort semantics are documented on ops.ApplyThinkingEffort.
 // Only added to the chain when Effort is non-default.
 type RuleThinkingTransform struct {
 	Effort string
@@ -33,112 +19,7 @@ func NewRuleThinkingTransform(effort string) *RuleThinkingTransform {
 
 func (t *RuleThinkingTransform) Name() string { return "rule_thinking" }
 
-// Apply enforces the configured thinking_effort on the target request. For
-// shapes it does not recognize (e.g. Google) it is a no-op.
 func (t *RuleThinkingTransform) Apply(ctx *TransformContext) error {
-	ApplyThinkingEffort(ctx.Request, t.Effort)
+	ops.ApplyThinkingEffort(ctx.Request, t.Effort)
 	return nil
-}
-
-// ApplyThinkingEffort is the shared implementation behind both the rule-level
-// and scenario-level thinking_effort handling. It is exported so the
-// server-side prechain (scenario flags) can reuse the same semantics without
-// duplicating the type-switch.
-//
-// Behavior is documented on RuleThinkingTransform.
-func ApplyThinkingEffort(req interface{}, effort string) {
-	switch effort {
-	case typ.ThinkingEffortDefault:
-		return
-	case typ.ThinkingEffortOff:
-		disableThinking(req)
-		return
-	}
-	budget, ok := typ.ThinkingBudgetMapping[effort]
-	if !ok {
-		return
-	}
-	enableThinking(req, effort, budget)
-}
-
-// disableThinking turns thinking off on the target request and scrubs any
-// conflicting extension fields. Conservative: only touches the union variant
-// matching the request type.
-func disableThinking(req interface{}) {
-	switch r := req.(type) {
-	case *anthropic.MessageNewParams:
-		r.Thinking = anthropic.ThinkingConfigParamUnion{
-			OfDisabled: &anthropic.ThinkingConfigDisabledParam{},
-		}
-		r.OutputConfig.Effort = ""
-	case *anthropic.BetaMessageNewParams:
-		r.Thinking = anthropic.BetaThinkingConfigParamUnion{
-			OfDisabled: &anthropic.BetaThinkingConfigDisabledParam{},
-		}
-		r.OutputConfig.Effort = ""
-	case *openai.ChatCompletionNewParams:
-		r.ReasoningEffort = ""
-		stripOpenAIThinkingExtra(r)
-	case *responses.ResponseNewParams:
-		r.Reasoning.Effort = ""
-	}
-}
-
-// enableThinking turns thinking on with the matching budget / effort. As with
-// disable, it also clears any stray `thinking` extension on OpenAI requests
-// so the typed field is the single source of truth.
-//
-// For Anthropic requests: max_tokens is a hard operator limit and must not be
-// raised. Anthropic enforces budget_tokens <= max_tokens, so if the requested
-// budget exceeds the current max_tokens the budget is capped at max_tokens
-// (floor 1024) rather than overriding the operator's limit.
-func enableThinking(req interface{}, effort string, budget int64) {
-	switch r := req.(type) {
-	case *anthropic.MessageNewParams:
-		if r.MaxTokens > 0 && budget > r.MaxTokens {
-			budget = max(1024, r.MaxTokens)
-		}
-		r.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
-	case *anthropic.BetaMessageNewParams:
-		if r.MaxTokens > 0 && budget > r.MaxTokens {
-			budget = max(1024, r.MaxTokens)
-		}
-		r.Thinking = anthropic.BetaThinkingConfigParamOfEnabled(budget)
-	case *openai.ChatCompletionNewParams:
-		r.ReasoningEffort = openaiReasoningEffort(effort)
-		stripOpenAIThinkingExtra(r)
-	case *responses.ResponseNewParams:
-		r.Reasoning.Effort = openaiReasoningEffort(effort)
-	}
-}
-
-// stripOpenAIThinkingExtra removes any non-standard `thinking` blob from an
-// OpenAI Chat request's ExtraFields. Several upstreams (DeepSeek, Moonshot)
-// reject requests that carry both the typed `reasoning_effort` and a
-// `thinking.type` extension — they want one or the other. Once the transform
-// has expressed intent through the typed field, the extras blob is redundant
-// at best and a 400 trigger at worst.
-func stripOpenAIThinkingExtra(req *openai.ChatCompletionNewParams) {
-	extra := req.ExtraFields()
-	if extra == nil {
-		return
-	}
-	if _, ok := extra["thinking"]; !ok {
-		return
-	}
-	delete(extra, "thinking")
-	req.SetExtraFields(extra)
-}
-
-// openaiReasoningEffort maps a rule effort level to a valid OpenAI
-// reasoning_effort. "max" collapses to "high" because OpenAI has no "max".
-func openaiReasoningEffort(effort string) shared.ReasoningEffort {
-	switch effort {
-	case typ.ThinkingEffortLow:
-		return shared.ReasoningEffortLow
-	case typ.ThinkingEffortHigh, typ.ThinkingEffortMax:
-		return shared.ReasoningEffortHigh
-	default:
-		return shared.ReasoningEffortMedium
-	}
 }

--- a/internal/protocol/transform/rule_thinking_test.go
+++ b/internal/protocol/transform/rule_thinking_test.go
@@ -189,6 +189,28 @@ func TestRuleThinkingTransform_AnthropicCapsBudgetToMaxTokens(t *testing.T) {
 	}
 }
 
+func TestRuleThinkingTransform_AnthropicCapsBudgetToMaxTokensWhenBelowMinimum(t *testing.T) {
+	// max_tokens=512 is below Anthropic's 1024 thinking minimum. The old code used
+	// max(1024, MaxTokens) which would set budget=1024 > MaxTokens=512 and cause a
+	// 400 from Anthropic. The correct behavior is to cap at MaxTokens and let the
+	// API surface the conflict rather than silently exceeding the operator limit.
+	req := &anthropic.MessageNewParams{}
+	req.MaxTokens = 512
+	ctx := &TransformContext{Request: req}
+
+	if err := NewRuleThinkingTransform(typ.ThinkingEffortLow).Apply(ctx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if req.MaxTokens != 512 {
+		t.Errorf("max_tokens changed from 512 to %d — must not be raised", req.MaxTokens)
+	}
+	if got := req.Thinking.OfEnabled; got == nil {
+		t.Fatalf("expected thinking enabled")
+	} else if got.BudgetTokens > req.MaxTokens {
+		t.Errorf("budget_tokens %d exceeds max_tokens %d — would cause Anthropic 400", got.BudgetTokens, req.MaxTokens)
+	}
+}
+
 func TestRuleThinkingTransform_AnthropicDoesNotReduceBudgetWhenMaxTokensSufficient(t *testing.T) {
 	budget := typ.ThinkingBudgetMapping[typ.ThinkingEffortLow]
 	req := &anthropic.MessageNewParams{}

--- a/internal/protocol/transform/vendor.go
+++ b/internal/protocol/transform/vendor.go
@@ -10,270 +10,78 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/ops"
 )
 
-// VendorTransform applies provider-specific adjustments to requests
-// This wraps the existing transformer package functionality
+// VendorTransform applies provider-specific request adjustments. Per-shape
+// dispatch is a flat strings.Contains chain — uniform across all request
+// shapes so new vendors land in one place per shape.
 type VendorTransform struct {
-	ProviderURL string // e.g., "api.deepseek.com", "api.moonshot.cn"
+	ProviderURL string
 }
 
-// NewVendorTransform creates a new vendor transform for the given provider URL
+// NewVendorTransform creates a new vendor transform for the given provider URL.
 func NewVendorTransform(providerURL string) *VendorTransform {
-	return &VendorTransform{
-		ProviderURL: providerURL,
-	}
+	return &VendorTransform{ProviderURL: providerURL}
 }
 
-// Name returns the transform name
-func (t *VendorTransform) Name() string {
-	return "vendor_adjust"
-}
+func (t *VendorTransform) Name() string { return "vendor_adjust" }
 
-// Apply applies vendor-specific transformations to the request
+// Apply dispatches to the per-shape vendor logic. Unknown shapes are a no-op.
 func (t *VendorTransform) Apply(ctx *TransformContext) error {
+	url := strings.ToLower(t.ProviderURL)
 	switch req := ctx.Request.(type) {
 	case *openai.ChatCompletionNewParams:
-		return t.applyChatCompletionVendor(ctx, req)
+		ctx.Request = t.applyChat(ctx, req)
 	case *responses.ResponseNewParams:
-		return t.applyResponsesVendor(ctx, req)
+		ctx.Request = t.applyResponses(ctx, req)
 	case *anthropic.MessageNewParams:
-		return t.applyAnthropicV1Vendor(ctx, req)
+		ctx.Request = t.applyAnthropicV1(ctx, req, url)
 	case *anthropic.BetaMessageNewParams:
-		return t.applyAnthropicBetaVendor(ctx, req)
-
-	default:
-		return &ValidationError{
-			Field:   "request",
-			Message: "unsupported request type for vendor transform",
-			Value:   req,
-		}
+		ctx.Request = t.applyAnthropicBeta(ctx, req, url)
 	}
-}
-
-// applyChatCompletionVendor applies vendor-specific transforms for Chat Completions
-func (t *VendorTransform) applyChatCompletionVendor(ctx *TransformContext, req *openai.ChatCompletionNewParams) error {
-	// Extract model from request
-	model := string(req.Model)
-
-	// Extract OpenAIConfig from Config (set by BaseTransform)
-	config := ctx.Config.OpenAIConfig
-	if config == nil {
-		config = &protocol.OpenAIConfig{} // Use default config if not available
-	}
-
-	// Apply vendor-specific transforms using existing transformer package
-	transformed := ops.ApplyProviderTransforms(req, t.ProviderURL, model, config)
-
-	// Update context with transformed request
-	ctx.Request = transformed
-
 	return nil
 }
 
-// applyResponsesVendor applies vendor-specific transforms for Responses API
-func (t *VendorTransform) applyResponsesVendor(ctx *TransformContext, req *responses.ResponseNewParams) error {
-	// Validate request
-	if req == nil {
-		return &ValidationError{
-			Field:   "request",
-			Message: "request cannot be nil",
-		}
-	}
-
-	// Extract model from request
-	model := string(req.Model)
-	if model == "" {
-		return &ValidationError{
-			Field:   "model",
-			Message: "model cannot be empty",
-		}
-	}
-
-	// Extract OpenAIConfig from Config (set by BaseTransform)
+func (t *VendorTransform) applyChat(ctx *TransformContext, req *openai.ChatCompletionNewParams) *openai.ChatCompletionNewParams {
 	config := ctx.Config.OpenAIConfig
 	if config == nil {
-		config = &protocol.OpenAIConfig{} // Use default config if not available
+		config = &protocol.OpenAIConfig{}
 	}
-
-	// Normalize provider URL for matching
-	normalURL := normalizeProviderURL(t.ProviderURL)
-
-	// Apply vendor-specific transformations based on provider URL
-	// Note: Currently only DeepSeek and Moonshot have specific requirements for Responses API
-	// Google's thinking_config and tool schema filtering are Chat Completions-specific
-
-	switch {
-	case t.ProviderURL == protocol.CodexAPIBase:
-		// Codex backend (ChatGPT) requires specific transformations
-		req = t.applyCodexResponsesTransform(ctx, req, config)
-	case strings.Contains(normalURL, "api.deepseek.com"):
-		req = t.applyDeepSeekResponsesTransform(req, config)
-	case strings.Contains(normalURL, "api.moonshot.cn") || strings.Contains(normalURL, "api.moonshot.ai"):
-		req = t.applyMoonshotResponsesTransform(req, config)
-		// Google and other providers don't require vendor-specific adjustments for Responses API yet
-	}
-
-	// Update context with transformed request
-	ctx.Request = req
-
-	return nil
+	return ops.ApplyProviderTransforms(req, t.ProviderURL, string(req.Model), config)
 }
 
-// applyDeepSeekResponsesTransform applies DeepSeek-specific transforms for Responses API
-// This handles the x_thinking -> reasoning_content conversion for assistant messages
-func (t *VendorTransform) applyDeepSeekResponsesTransform(req *responses.ResponseNewParams, config *protocol.OpenAIConfig) *responses.ResponseNewParams {
-	// DeepSeek's reasoning models require reasoning_content in assistant messages
-	// when thinking is enabled
-	if !config.HasThinking {
+func (t *VendorTransform) applyResponses(ctx *TransformContext, req *responses.ResponseNewParams) *responses.ResponseNewParams {
+	if req == nil || req.Model == "" {
 		return req
 	}
-
-	// Check if input contains assistant messages that need transformation
-	// The Responses API uses InputItem types which can include assistant messages
-	// We need to ensure any assistant messages have reasoning_content field set
-
-	// Extract input items - ResponseNewParamsInputUnion can be:
-	// - OfString: simple string input
-	// - OfInputItemList: list of input items
-
-	// For now, we'll handle the simple case where input is a string
-	// Future enhancement: handle InputItemList with assistant messages
-
+	if t.ProviderURL == protocol.CodexAPIBase {
+		return ops.ApplyCodexResponsesTransform(req, ctx.OriginalRequest)
+	}
 	return req
 }
 
-// applyMoonshotResponsesTransform applies Moonshot-specific transforms for Responses API
-// Similar to DeepSeek, Moonshot requires reasoning_content in assistant messages
-func (t *VendorTransform) applyMoonshotResponsesTransform(req *responses.ResponseNewParams, config *protocol.OpenAIConfig) *responses.ResponseNewParams {
-	// Moonshot has the same requirements as DeepSeek
-	return t.applyDeepSeekResponsesTransform(req, config)
-}
-
-// applyCodexResponsesTransform applies Codex-specific transforms for Responses API
-// Codex (ChatGPT backend) requires:
-//   - Thinking -> Reasoning conversion
-//   - Tool name shortening (64 char limit)
-//   - Tool parameter normalization
-//   - Special tool mappings (web_search_20250305 -> web_search)
-func (t *VendorTransform) applyCodexResponsesTransform(ctx *TransformContext, req *responses.ResponseNewParams, config *protocol.OpenAIConfig) *responses.ResponseNewParams {
-	// Extract model from request
-	model := req.Model
-	if model == "" {
+func (t *VendorTransform) applyAnthropicV1(ctx *TransformContext, req *anthropic.MessageNewParams, url string) *anthropic.MessageNewParams {
+	if req.Model == "" {
 		return req
 	}
-
-	// Apply Codex-specific transformations
-	return ops.ApplyCodexResponsesTransform(req, ctx.OriginalRequest)
-}
-
-// applyAnthropicV1Vendor applies Anthropic-specific model filtering for v1 API
-// This handles model-specific limitations such as Haiku not supporting thinking.type="adaptive"
-// Also injects OAuth user_id into metadata when available.
-func (t *VendorTransform) applyAnthropicV1Vendor(ctx *TransformContext, req *anthropic.MessageNewParams) error {
-	// Get model name from context
-	model := req.Model
-	if model == "" {
-		return nil
-	}
-
 	switch {
-	case strings.Contains(t.ProviderURL, "api.anthropic.com") || strings.Contains(t.ProviderURL, "claude.ai"):
-		// Apply Anthropic model-specific transforms
-		req = ops.ApplyAnthropicV1ModelTransform(req, string(model))
-
-		// Inject OAuth user_id metadata if provider is available
+	case strings.Contains(url, "api.anthropic.com"), strings.Contains(url, "claude.ai"):
+		req = ops.ApplyAnthropicV1ModelTransform(req, string(req.Model))
 		req = ops.ApplyAnthropicV1MetadataTransform(req, ctx.configExtraForMetadata())
-
-		ctx.Request = req
-	case strings.Contains(t.ProviderURL, "api.deepseek.com"):
-		// DeepSeek's Anthropic-compatible endpoint requires every assistant
-		// message to carry at least one thinking block. Inject an empty one
-		// when missing — mirrors the reasoning_content fill in
-		// applyDeepSeekTransform for the OpenAI Chat path.
-		for i := range req.Messages {
-			if string(req.Messages[i].Role) != "assistant" {
-				continue
-			}
-			found := false
-			for _, b := range req.Messages[i].Content {
-				if b.OfThinking != nil {
-					found = true
-					break
-				}
-			}
-			if !found {
-				req.Messages[i].Content = append(req.Messages[i].Content, anthropic.NewThinkingBlock("", ""))
-			}
-		}
+	case strings.Contains(url, "api.deepseek.com"):
+		ops.ApplyAnthropicV1DeepSeekThinkingPatch(req)
 	}
-
-	return nil
+	return req
 }
 
-// applyAnthropicBetaVendor applies Anthropic-specific model filtering for beta API
-// This handles model-specific limitations such as Haiku not supporting thinking.type="adaptive"
-// Also injects OAuth user_id into metadata when available.
-func (t *VendorTransform) applyAnthropicBetaVendor(ctx *TransformContext, req *anthropic.BetaMessageNewParams) error {
-	// Get model name from context
-	model := req.Model
-	if model == "" {
-		return nil
+func (t *VendorTransform) applyAnthropicBeta(ctx *TransformContext, req *anthropic.BetaMessageNewParams, url string) *anthropic.BetaMessageNewParams {
+	if req.Model == "" {
+		return req
 	}
-
 	switch {
-	case strings.Contains(t.ProviderURL, "api.anthropic.com") || strings.Contains(t.ProviderURL, "claude.ai"):
-		// Apply Anthropic model-specific transforms
-		req = ops.ApplyAnthropicBetaModelTransform(req, string(model))
-
-		// Inject OAuth user_id metadata if provider is available
+	case strings.Contains(url, "api.anthropic.com"), strings.Contains(url, "claude.ai"):
+		req = ops.ApplyAnthropicBetaModelTransform(req, string(req.Model))
 		req = ops.ApplyAnthropicBetaMetadataTransform(req, ctx.configExtraForMetadata())
-
-		ctx.Request = req
-	case strings.Contains(t.ProviderURL, "api.deepseek.com"):
-		for i := range req.Messages {
-			if string(req.Messages[i].Role) != "assistant" {
-				continue
-			}
-			found := false
-			for _, b := range req.Messages[i].Content {
-				if b.OfThinking != nil {
-					found = true
-					break
-				}
-			}
-			if !found {
-				req.Messages[i].Content = append(req.Messages[i].Content, anthropic.NewBetaThinkingBlock("", ""))
-			}
-		}
+	case strings.Contains(url, "api.deepseek.com"):
+		ops.ApplyAnthropicBetaDeepSeekThinkingPatch(req)
 	}
-
-	return nil
-}
-
-// Helper function to get normalized provider base URL from full URL
-// This ensures consistent provider identification across different URL formats
-func normalizeProviderURL(url string) string {
-	if url == "" {
-		return ""
-	}
-
-	url = strings.TrimSpace(strings.ToLower(url))
-
-	// Remove protocol prefix
-	if strings.HasPrefix(url, "http://") {
-		url = url[7:]
-	} else if strings.HasPrefix(url, "https://") {
-		url = url[8:]
-	}
-
-	// Remove port if present
-	if idx := strings.Index(url, ":"); idx != -1 {
-		url = url[:idx]
-	}
-
-	// Remove path if present
-	if idx := strings.Index(url, "/"); idx != -1 {
-		url = url[:idx]
-	}
-
-	return url
+	return req
 }

--- a/internal/protocol/transform/vendor_test.go
+++ b/internal/protocol/transform/vendor_test.go
@@ -48,22 +48,9 @@ func TestVendorTransform_Apply_MissingOpenAIConfig(t *testing.T) {
 	require.NoError(t, err) // Should use default config
 }
 
-func TestVendorTransform_Apply_InvalidRequestType(t *testing.T) {
-	vt := NewVendorTransform("api.openai.com")
-
-	ctx := &TransformContext{
-		Request:     "invalid",
-		ProviderURL: "api.openai.com",
-		Extra:       map[string]interface{}{},
-	}
-
-	err := vt.Apply(ctx)
-	require.Error(t, err)
-
-	validationErr, ok := err.(*ValidationError)
-	require.True(t, ok)
-	assert.Equal(t, "request", validationErr.Field)
-}
+// TestVendorTransform_Apply_InvalidRequestType removed: VendorTransform now
+// silently no-ops on unknown request shapes (consistent with every other
+// Transform in the chain) rather than returning a ValidationError.
 
 func TestVendorTransform_Apply_NilRequest(t *testing.T) {
 	vt := NewVendorTransform("api.openai.com")
@@ -74,8 +61,11 @@ func TestVendorTransform_Apply_NilRequest(t *testing.T) {
 		Extra:       map[string]interface{}{},
 	}
 
-	err := vt.Apply(ctx)
-	require.Error(t, err)
+	// Nil request is a silent no-op now (same contract as every other
+	// Transform on an unknown / nil shape).
+	if err := vt.Apply(ctx); err != nil {
+		t.Fatalf("expected nil no-op, got error: %v", err)
+	}
 }
 
 func TestVendorTransform_Protocols(t *testing.T) {
@@ -106,30 +96,9 @@ func TestVendorTransform_Protocols(t *testing.T) {
 	}
 }
 
-func TestNormalizeProviderURL(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"https://api.openai.com/v1/chat/completions", "api.openai.com"},
-		{"http://api.deepseek.com:8080/v1", "api.deepseek.com"},
-		{"api.moonshot.cn", "api.moonshot.cn"},
-		{"api.openai.com:443", "api.openai.com"},
-		{"https://api.anthropic.com", "api.anthropic.com"},
-		{"https://api.openai.com/", "api.openai.com"},
-		{"", ""},
-		{"  https://api.openai.com  ", "api.openai.com"},
-		{"HTTPS://API.OPENAI.COM", "api.openai.com"},
-		{"https://api.example.com:8443/v1/models/gpt-4", "api.example.com"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := normalizeProviderURL(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
+// TestNormalizeProviderURL removed alongside the helper itself: vendor
+// dispatch now uses strings.Contains on the raw lowercased URL, no
+// separate parse step.
 
 func TestVendorTransform_TransformerIntegration(t *testing.T) {
 	// Test integration with transformer package

--- a/internal/server/transform_thinking_mode.go
+++ b/internal/server/transform_thinking_mode.go
@@ -2,12 +2,13 @@ package server
 
 import (
 	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	"github.com/tingly-dev/tingly-box/internal/protocol/ops"
 )
 
 // ThinkingEffortTransform is the scenario-level pre-base transform that
 // applies the unified thinking_effort control on the inbound request. It is
-// a thin wrapper around protocoltransform.ApplyThinkingEffort so the
-// scenario-level and rule-level chains share a single implementation.
+// a thin wrapper around ops.ApplyThinkingEffort so the scenario-level and
+// rule-level chains share a single implementation.
 //
 // Only added to the chain when Effort is non-default ("" / "by client").
 type ThinkingEffortTransform struct {
@@ -22,6 +23,6 @@ func NewThinkingEffortTransform(effort string) *ThinkingEffortTransform {
 func (t *ThinkingEffortTransform) Name() string { return "thinking_effort" }
 
 func (t *ThinkingEffortTransform) Apply(ctx *protocoltransform.TransformContext) error {
-	protocoltransform.ApplyThinkingEffort(ctx.Request, t.Effort)
+	ops.ApplyThinkingEffort(ctx.Request, t.Effort)
 	return nil
 }


### PR DESCRIPTION
## Summary
Simplifies the vendor transform and thinking effort logic by replacing configuration-driven dispatch with explicit flat `strings.Contains` chains. Moves thinking effort handling from `transform` package to `ops` package for better code organization and reusability.

## Key Changes

### Vendor Transform Refactoring (`internal/protocol/transform/vendor.go`)
- Replaced per-method vendor handlers with a single flat dispatch chain in `Apply()`
- Removed `normalizeProviderURL()` helper; vendor matching now uses direct `strings.Contains()` on lowercased URLs
- Simplified method signatures: per-shape handlers now return transformed requests instead of errors
- Consolidated Anthropic v1/beta DeepSeek thinking patches into dedicated `ops` functions
- Changed error handling: unknown request shapes are now silent no-ops (consistent with other transforms) instead of returning `ValidationError`

### Provider Transform Refactoring (`internal/protocol/ops/request_openai_extensions.go`)
- Replaced `ProviderConfigs` array and `GetProviderTransform()` lookup with flat `ApplyProviderTransforms()` dispatch
- Removed `providerConfig` struct and pattern-matching logic
- Dispatch is now a simple `strings.Contains` chain with explicit provider URL and model checks
- Improved code clarity: all provider cases are visible in one place

### Thinking Effort Consolidation
- Moved `ApplyThinkingEffort()` and related helpers from `transform/rule_thinking.go` to new `ops/request_thinking.go`
- `RuleThinkingTransform` now delegates to `ops.ApplyThinkingEffort()` for shared semantics
- Enables scenario-level pre-base transform (`server/transform_thinking_mode.go`) to reuse the same logic without duplication

### Bug Fix
- Fixed Anthropic budget capping: when `max_tokens < budget`, now caps at `max_tokens` instead of `max(1024, max_tokens)`, preventing requests that exceed the operator's hard limit
- Added test case `TestRuleThinkingTransform_AnthropicCapsBudgetToMaxTokensWhenBelowMinimum` to prevent regression

## Implementation Details
- Vendor dispatch is now uniform across all request shapes: new vendors are added in one place per shape
- All provider matching uses lowercase URL comparison with `strings.Contains()` for consistency
- Anthropic v1/beta DeepSeek thinking patches extracted to `ops` for reusability across transform types
- Removed unused `normalizeProviderURL()` test cases

https://claude.ai/code/session_01Minn71BCom8aYbcm3qdmtg