### PR TITLE
bugfix(remote_control): fix localhost:12580 connection failure for @tb SmartGuide

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ProvidersV1 map[string]*typ.Provider `json:"providers"`
 	Providers   []*typ.Provider          `json:"providers_v2"`
 	ServerPort  int                      `json:"-"`
+	ServerHost  string                   `json:"-"` // Server host address (e.g., "localhost", "0.0.0.0", "192.168.1.100")
 	JWTSecret   string                   `json:"jwt_secret"`
 
 	// Server settings
@@ -1104,6 +1105,27 @@ func (c *Config) SetServerPort(port int) error {
 	defer c.mu.Unlock()
 
 	c.ServerPort = port
+	return c.Save()
+}
+
+// GetServerHost returns the configured server host
+// Returns "localhost" if no host is configured
+func (c *Config) GetServerHost() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.ServerHost == "" {
+		return "localhost"
+	}
+	return c.ServerHost
+}
+
+// SetServerHost updates the server host
+func (c *Config) SetServerHost(host string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.ServerHost = host
 	return c.Save()
 }
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -63,6 +63,15 @@ func (s *Server) Start(port int) error {
 	}
 
 	resolvedHost := network.ResolveHost(s.host)
+
+	// Store the resolved server host in config for TBClient to use
+	// This ensures 0.0.0.0 resolves to actual local IP for client connections
+	if resolvedHost != "" {
+		if err := s.config.SetServerHost(resolvedHost); err != nil {
+			logrus.WithError(err).Warn("Failed to store server host in config")
+		}
+	}
+
 	scheme := "http"
 
 	// CASE 1: Non-UI Mode ---

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -107,7 +107,8 @@ func (c *TBClientImpl) buildBaseURL() string {
 	if port == 0 {
 		port = 12580
 	}
-	return fmt.Sprintf("http://localhost:%d/tingly/claude_code", port)
+	host := c.config.GetServerHost()
+	return fmt.Sprintf("http://%s:%d/tingly/claude_code", host, port)
 }
 
 // findFirstClaudeCodeRule finds the first active ClaudeCode rule
@@ -147,7 +148,8 @@ func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	if port == 0 {
 		port = 12580
 	}
-	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	host := c.config.GetServerHost()
+	baseURL := fmt.Sprintf("http://%s:%d", host, port)
 	apiKey := c.config.GetModelToken()
 
 	models := c.resolveClaudeCodeModels()
@@ -321,10 +323,11 @@ func (c *TBClientImpl) GetHTTPEndpointForScenario(ctx context.Context, scenario 
 	if port == 0 {
 		port = 12580
 	}
+	host := c.config.GetServerHost()
 
 	// Build scenario-specific path
 	scenarioPath := c.GetScenarioEndpointPath(scenario)
-	baseURL := fmt.Sprintf("http://localhost:%d%s", port, scenarioPath)
+	baseURL := fmt.Sprintf("http://%s:%d%s", host, port, scenarioPath)
 
 	// Get API key from config
 	apiKey := c.config.GetModelToken()

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -29,10 +29,36 @@ func TestTBClient_BuildBaseURL(t *testing.T) {
 }
 
 func TestTBClient_BuildBaseURL_DefaultPort(t *testing.T) {
-	cfg := &serverconfig.Config{} // ServerPort = 0
+	cfg := &serverconfig.Config{} // ServerPort = 0, ServerHost = ""
 	client := NewTBClient(cfg, nil)
 
 	assert.Equal(t, "http://localhost:12580/tingly/claude_code", client.buildBaseURL())
+}
+
+func TestTBClient_BuildBaseURL_CustomHost(t *testing.T) {
+	cfg := &serverconfig.Config{ServerPort: 8080}
+	_ = cfg.SetServerHost("192.168.1.100") // Set custom host
+	client := NewTBClient(cfg, nil)
+
+	assert.Equal(t, "http://192.168.1.100:8080/tingly/claude_code", client.buildBaseURL())
+}
+
+func TestTBClient_BuildBaseURL_HostZeroAll(t *testing.T) {
+	cfg := &serverconfig.Config{ServerPort: 9000}
+	_ = cfg.SetServerHost("0.0.0.0") // Note: In actual runtime, server resolves 0.0.0.0 to actual local IP before storing
+	client := NewTBClient(cfg, nil)
+
+	assert.Equal(t, "http://0.0.0.0:9000/tingly/claude_code", client.buildBaseURL())
+}
+
+func TestTBClient_BuildBaseURL_ResolvedLocalIP(t *testing.T) {
+	cfg := &serverconfig.Config{ServerPort: 9000}
+	// Simulate what server does: network.ResolveHost("0.0.0.0") returns actual local IP
+	// For test consistency, we directly set a resolved IP
+	_ = cfg.SetServerHost("192.168.1.100")
+	client := NewTBClient(cfg, nil)
+
+	assert.Equal(t, "http://192.168.1.100:9000/tingly/claude_code", client.buildBaseURL())
 }
 
 func TestProviderInfo_Structure(t *testing.T) {


### PR DESCRIPTION
Fix @tb (SmartGuide) connection failure on devices where server binds to non-localhost addresses (e.g., --host 0.0.0.0 or specific IP).

Root cause: TBClient hardcoded "localhost:12580" in URL construction, ignoring the configured server host. When server bound to 0.0.0.0 or specific IP, @tb failed to connect while @cc worked correctly.

Changes:
- Add ServerHost field to Config struct with GetServerHost()/SetServerHost()
- Server startup now stores resolved host (handles 0.0.0.0 -> actual local IP)
- TBClient.buildBaseURL(), GetClaudeCodeEnv(), GetHTTPEndpointForScenario() now use configured host instead of hardcoded "localhost"
- Added comprehensive tests for host configuration scenarios

Behavior:
- Default (no --host): TBClient -> localhost:12580 ✅
- --host 0.0.0.0: Server resolves to actual IP, TBClient -> resolved IP ✅
- --host <IP>: TBClient -> specific IP ✅
- --host localhost: TBClient -> localhost ✅

Fixes: #localhost-12580-connection-failure