### PR TITLE
feat(logging, obs): add api_style and base_url to protocol and access logs

### DIFF
--- a/internal/client/logging_roundtripper.go
+++ b/internal/client/logging_roundtripper.go
@@ -16,21 +16,20 @@ import (
 // are never logged.
 type loggingRoundTripper struct {
 	inner    http.RoundTripper
-	provider string
+	provider *typ.Provider
 	proxy    string // redacted (scheme://host) or "direct"
 }
 
 // wrapWithLogging wraps a transport so every provider's upstream call is logged
 // uniformly. It is the single place that surfaces proxy + outcome per request.
 func wrapWithLogging(inner http.RoundTripper, provider *typ.Provider) http.RoundTripper {
-	var proxyRaw, name string
+	var proxyRaw string
 	if provider != nil {
 		proxyRaw = provider.ProxyURL
-		name = provider.Name
 	}
 	return &loggingRoundTripper{
 		inner:    inner,
-		provider: name,
+		provider: provider,
 		proxy:    redactProxy(proxyRaw),
 	}
 }
@@ -50,14 +49,31 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	resp, err := t.inner.RoundTrip(req)
 	latencyMs := time.Since(start).Milliseconds()
 
-	entry := logrus.WithContext(req.Context()).WithFields(logrus.Fields{
+	// Build fields with provider information
+	providerName := ""
+	var apiStyle, baseURL string
+	if t.provider != nil {
+		providerName = t.provider.Name
+		apiStyle = string(t.provider.APIStyle)
+		baseURL = t.provider.APIBase
+	}
+
+	fields := logrus.Fields{
 		"stage":      "upstream",
-		"provider":   t.provider,
+		"provider":   providerName,
 		"proxy":      proxy,
 		"method":     req.Method,
 		"host":       req.URL.Host,
 		"latency_ms": latencyMs,
-	})
+	}
+	if apiStyle != "" {
+		fields["api_style"] = apiStyle
+	}
+	if baseURL != "" {
+		fields["base_url"] = baseURL
+	}
+
+	entry := logrus.WithContext(req.Context()).WithFields(fields)
 	if err != nil {
 		entry.WithError(err).Errorf("upstream call failed via %s", proxy)
 		return resp, err

--- a/internal/obs/record.go
+++ b/internal/obs/record.go
@@ -14,6 +14,10 @@ type Record struct {
 	Scenario   string
 	Model      string
 
+	// Provider connection details for debugging
+	APIStyle string `json:"api_style,omitempty"` // Provider API style (e.g., "openai", "anthropic")
+	BaseURL  string `json:"base_url,omitempty"`  // Provider base URL
+
 	OriginalRequest    *RecordRequest
 	TransformedRequest *RecordRequest
 	ProviderResponse   *RecordResponse

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -184,6 +184,8 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		if pv, exists := c.Get("tracking_provider"); exists {
 			if p, ok := pv.(*typ.Provider); ok && p != nil {
 				fields["routed_provider"] = p.Name
+				fields["api_style"] = string(p.APIStyle)
+				fields["base_url"] = p.APIBase
 			}
 		}
 

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -54,10 +54,12 @@ type ProtocolRecorder struct {
 
 	transformSteps []string
 
-	providerName string
-	providerUUID string
-	model        string
-	mode         obs.RecordMode
+	providerName  string
+	providerUUID  string
+	providerStyle string // API style (e.g., "openai", "anthropic")
+	providerBase  string // Base URL
+	model         string
+	mode          obs.RecordMode
 }
 
 // SetActiveService re-binds the recorder to a new provider/model. The
@@ -176,6 +178,8 @@ func (sr *ProtocolRecorder) bindProvider(provider *typ.Provider, model string, m
 	if provider != nil {
 		sr.providerName = provider.Name
 		sr.providerUUID = provider.UUID
+		sr.providerStyle = string(provider.APIStyle)
+		sr.providerBase = provider.APIBase
 	}
 	if model != "" {
 		sr.model = model
@@ -322,6 +326,8 @@ func (sr *ProtocolRecorder) emit(err error) {
 		Model:      sr.resolveModel(),
 		Steps:      sr.transformSteps,
 		Duration:   time.Since(sr.startTime),
+		APIStyle:   sr.providerStyle,
+		BaseURL:    sr.providerBase,
 	}
 	if err != nil {
 		r.Err = err.Error()


### PR DESCRIPTION
## Summary
Protocol and access logs only showed provider name without API style or base URL, making debugging difficult when multiple providers used the same name or when routing issues occurred. This change adds these connection details to all relevant log sources.

### Major
- Added `api_style` and `base_url` fields to protocol recording logs (obs.Record)
- Added `api_style` and `base_url` fields to HTTP access log entries 
- Added `api_style` and `base_url` fields to upstream call logs (loggingRoundTripper)
- Frontend AI Logs viewer now displays provider connection details for each request

### Minor
- Updated loggingRoundTripper to store full provider object instead of just name
- Updated ProtocolRecorder to capture provider APIStyle and APIBase fields