### PR TITLE
refactor(test): rename server_test to servertest, and add test infra docs

### DIFF
--- a/.design/test-infrastructure.md
+++ b/.design/test-infrastructure.md
@@ -1,0 +1,66 @@
+# Test Infrastructure
+
+Overview of the test packages, their responsibilities, and how they relate.
+
+## Package Hierarchy
+
+```
+vmodel/vmodeltest/          ← HTTP test client + response parser (no test-framework deps)
+    ↑ embedded by
+internal/protocoltest/      ← Protocol transform validation (VirtualServer + TestEnv + Matrix)
+    ↑ imported by
+cli/harness/                ← CLI entry points for matrix, agent, replay harnesses
+
+internal/servertest/        ← Gateway integration tests (independent, shares nothing above)
+```
+
+## Packages
+
+### `vmodel/vmodeltest`
+
+Standalone HTTP test client for vmodel endpoints.
+
+- **`Client`** — sends model-parameterized requests (`SendOpenAIChatModel`, `SendAnthropicV1Model`, `SendAnthropicBetaModel`)
+- **`ParsedResponse`** — HTTP status + raw body + SSE events + parsed semantics (`sse.ParsedResult`)
+- **Parser helpers** — `ParsedResultFromJSON`, `ParsedResultFromStream` (delegates to `internal/protocol/sse`)
+
+No dependency on `protocoltest` or `servertest`. Used by `vmodel/virtualserver/` tests.
+
+### `internal/protocoltest`
+
+End-to-end protocol transform validation framework. Tests that the gateway correctly converts between provider formats (OpenAI ↔ Anthropic ↔ Google).
+
+**Mock provider layer** (from former `server_validate`):
+- **`VirtualServer`** — scenario-driven mock HTTP provider speaking OpenAI/Anthropic/Google formats at provider-native routes (`/v1/chat/completions`, `/v1/messages`, etc.)
+- **`VirtualClient`** — embeds `vmodeltest.Client`, adds scenario-based send methods (`SendOpenAIChat`, `SendAnthropicV1`, `SendGoogle`) with auto-registration on a bound `VirtualServer`
+
+**Test framework layer** (from former `protocol_validate`):
+- **`Scenario`** — named test case with `MockResponses` per `ResponseFormat` + `Assertions`. Implements `vmodel.VirtualModel` for registry storage.
+- **`TestEnv`** — wires a real gateway server to a VirtualServer, manages routing rules. Provides `SetupRoute()` + `SendAs()` for full round-trip testing.
+- **`AgentTestEnv`** — variant for agent CLI testing (Claude Code, Codex, OpenCode).
+- **`Matrix`** — combinatorial executor: sources × targets × scenarios × streaming modes.
+- **Assertions** — `AssertHTTPStatus`, `AssertContentContains`, `AssertHasToolCalls`, `AssertHasThinking`, etc.
+- **Failover helpers** — two-tier routing rules with vmodel-backed error injection.
+- **Real model config** — `LoadProvidersConfig` for testing against real upstream providers.
+
+Built-in scenarios: `text`, `tool_use`, `tool_result`, `thinking`, `multi_turn`, `streaming_text`, `streaming_tool_use`, `error`.
+
+### `internal/servertest`
+
+Gateway-level integration tests. Tests server features (auth, routing, load balancing) using a simpler mock approach.
+
+- **`MockProviderServer`** — endpoint-level mock (set response per endpoint, track call counts). Simpler than VirtualServer — no scenario registry, no multi-format awareness.
+- **`TestServer`** — wraps a real gateway server + config. Helpers: `AddTestProviders`, `AddTestRule`, `EnsureLoadBalancingRule`.
+- **Request/response helpers** — `CreateTestChatRequest`, `CreateJSONBody`, `AssertJSONResponse`.
+
+Uses `//go:build e2e` tag for some tests. Not imported by any other package.
+
+## When to Use What
+
+| I want to... | Use |
+|---|---|
+| Test a vmodel endpoint handler | `vmodeltest.Client` |
+| Test protocol transforms (OpenAI→Anthropic, etc.) | `protocoltest.TestEnv` + `Matrix` |
+| Test gateway routing / load balancing / auth | `servertest.TestServer` + `MockProviderServer` |
+| Test agent CLI integration | `protocoltest.AgentTestEnv` |
+| Run the full validation matrix from CLI | `cli/harness/` (imports `protocoltest`) |

--- a/cli/harness/PLANNING.md
+++ b/cli/harness/PLANNING.md
@@ -19,7 +19,7 @@ replay, not test artifacts. The goal is an empty skip list.
 
 When the Responses→{Anthropic,Chat} tool_call conversion is completed, remove
 the three `*/codex/tool_use` entries **and** the corresponding
-`skipSourceScenarios` entry in `internal/protocol_validate/matrix.go` together —
+`skipSourceScenarios` entry in `internal/protocoltest/matrix.go` together —
 they describe the same defect at two tiers.
 
 **Done when:** `replay batch --upstream {virtual,vmodel,real}` is fully green

--- a/cli/harness/README.md
+++ b/cli/harness/README.md
@@ -85,10 +85,10 @@ converted payloads.
             every cell = one TestResult (pass / fail / skip)
 ```
 
-- Defined by `protocol_validate.DefaultMatrix()`; filter with
+- Defined by `protocoltest.DefaultMatrix()`; filter with
   `--scenario`, `--source`, `--target`, `--streaming`, `--non-streaming`.
 - Known-broken cells are centralized in
-  `protocol_validate.skipSourceScenarios` (e.g. `openai_responses|tool_use`).
+  `protocoltest.skipSourceScenarios` (e.g. `openai_responses|tool_use`).
 - `--json` for CI; `-v` / `-vv` to raise log verbosity; `--record-dir` to dump
   request/response pairs; `--batch N` for stability runs.
 
@@ -248,7 +248,7 @@ providers.
 cli/harness/
   main.go            Kong CLI root: version / matrix / agent / replay /
                      provider / init-config
-  matrix.go          Tier A command — wraps protocol_validate.Matrix
+  matrix.go          Tier A command — wraps protocoltest.Matrix
   replay.go          Tier B command — fixture replay, upstreams, skip list
   agent.go           Tier C command — agent CLI subprocess driver (+ env wiring)
   agent_real.go      Tier C real-provider mode: config iteration, per-entry runs
@@ -261,7 +261,7 @@ cli/harness/
     anthropic/        text.json, tool_use.json, streaming_text.json
     openai_responses/ text.json, tool_use.json, streaming_text.json
 
-internal/protocol_validate/   shared engine used by all tiers
+internal/protocoltest/   shared engine used by all tiers
   matrix.go          Tier A cross-product engine + skipSourceScenarios
   scenarios.go       Scenario definitions + content-level Assertions (reused by
                      Tier B's virtual upstream)
@@ -275,11 +275,11 @@ internal/protocol_validate/   shared engine used by all tiers
 
 ## How the tiers share code
 
-The three tiers are thin CLI shells over one engine (`internal/protocol_validate`):
+The three tiers are thin CLI shells over one engine (`internal/protocoltest`):
 
 ```
                     ┌───────────────────────────────┐
-                    │   internal/protocol_validate  │
+                    │   internal/protocoltest  │
                     │                               │
                     │   Scenario + Assertions       │◀── Tier A asserts here
                     │   Matrix engine               │◀── Tier A

--- a/internal/protocol/README.md
+++ b/internal/protocol/README.md
@@ -79,7 +79,7 @@ Anything not listed is intentionally unsupported and returns an
   and the request is forwarded as-is.
 - The `—` cells in the `anthropic_v1` target column are the subject of
   the design concern below.
-- The harness validation matrix (`internal/protocol_validate.DefaultPairs`)
+- The harness validation matrix (`internal/protocoltest.DefaultPairs`)
   lists every supported pair explicitly. New rows here should be added
   there too so they get end-to-end coverage.
 

--- a/internal/servertest/adaptor_test.go
+++ b/internal/servertest/adaptor_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package server
+package servertest
 
 import (
 	"encoding/json"

--- a/internal/servertest/concurrency_test.go
+++ b/internal/servertest/concurrency_test.go
@@ -1,4 +1,4 @@
-package server
+package servertest
 
 import (
 	"net/http"

--- a/internal/servertest/health_filter_test.go
+++ b/internal/servertest/health_filter_test.go
@@ -1,4 +1,4 @@
-package server
+package servertest
 
 import (
 	"testing"

--- a/internal/servertest/lb_virtual_validation_test.go
+++ b/internal/servertest/lb_virtual_validation_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package server
+package servertest
 
 import (
 	"fmt"

--- a/internal/servertest/load_balancing_test.go
+++ b/internal/servertest/load_balancing_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package server
+package servertest
 
 import (
 	"bytes"

--- a/internal/servertest/mock_provider.go
+++ b/internal/servertest/mock_provider.go
@@ -1,4 +1,4 @@
-package server
+package servertest
 
 import (
 	"encoding/json"

--- a/internal/servertest/no_service_available_repro_test.go
+++ b/internal/servertest/no_service_available_repro_test.go
@@ -1,4 +1,4 @@
-package server
+package servertest
 
 import (
 	"testing"

--- a/internal/servertest/server_test.go
+++ b/internal/servertest/server_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package server
+package servertest
 
 import (
 	"encoding/json"

--- a/internal/servertest/service_selection_test.go
+++ b/internal/servertest/service_selection_test.go
@@ -1,4 +1,4 @@
-package server
+package servertest
 
 import (
 	"testing"

--- a/internal/servertest/utils.go
+++ b/internal/servertest/utils.go
@@ -1,4 +1,4 @@
-package server
+package servertest
 
 import (
 	"bytes"

--- a/vmodel/README.md
+++ b/vmodel/README.md
@@ -8,7 +8,7 @@ and shipped in the production binary via `server.UseVirtualModelEndpoints`.
 
 The same primitives are reused as an in-process LLM substitute by test
 packages that need wire-format-correct fixtures (see
-`internal/server_validate`).
+`internal/protocoltest`).
 
 ## Layout
 
@@ -44,7 +44,7 @@ Test packages are **secondary consumers** that reuse the same primitives.
 | Role | Surface | Consumer |
 |------|---------|----------|
 | Primary (production) | `/virtual/v1/messages`, `/virtual/v1/chat/completions` | `internal/server` mounts `virtualserver.Service` for end-user demos / onboarding / dry-runs |
-| Secondary (tests)    | In-process `GenericRegistry[T]`                       | `internal/server_validate.Scenario`, `internal/protocol_validate`, `cli/harness --mock` |
+| Secondary (tests)    | In-process `GenericRegistry[T]`                       | `internal/protocoltest.Scenario`, `cli/harness --mock` |
 
 **Registration discipline.** Anything added to `anthropic.RegisterDefaults` or
 `openai.RegisterDefaults` is visible to **end users** of the production
@@ -56,7 +56,7 @@ dry-runs (`echo-model`, `ask-user-question`, `virtual-claude-3`,
 Test-only fixtures (protocol corner cases, wire-format edge cases,
 scenario-specific stubs) **must not** be added to `RegisterDefaults`. Tests
 that need bespoke synthetic models should construct their own
-`GenericRegistry[T]` (the way `server_validate` does for `Scenario`) and
+`GenericRegistry[T]` (the way `protocoltest` does for `Scenario`) and
 register fixtures there — keeping the production defaults clean.
 
 **Opt-in fixture sets.** Two named registration helpers ship alongside
@@ -85,7 +85,7 @@ type Registry = virtualmodel.GenericRegistry[VirtualModel]
 ```
 
 Any package that needs to store objects satisfying `virtualmodel.VirtualModel`
-can instantiate its own `GenericRegistry` directly — `server_validate.Scenario`
+can instantiate its own `GenericRegistry` directly — `protocoltest.Scenario`
 does this for test scenarios.
 
 ### One registry per protocol
@@ -358,7 +358,7 @@ anthropic.RegisterErrorMocks(svc.GetAnthropicRegistry())
 | `virtual-fail-midstream-close` | One real chunk then TCP close (not retryable) |
 | `virtual-fail-midstream-event` | One real chunk then SSE error frame (not retryable) |
 
-Failover e2e tests (`internal/protocol_validate`) use these directly via
+Failover e2e tests (`internal/protocoltest`) use these directly via
 `SetupFailoverRoute(... primaryFailModel: pt.FailMockPreContent429)` instead
 of standing up ad-hoc `httptest.Server` instances.
 
@@ -386,7 +386,7 @@ See `benchmark/examples/` for runnable server and client programs.
 
 - `vmodel/virtualserver` — Production Gin HTTP handler, routes,
   request/response shaping. Owns the v1 → beta lift for Anthropic.
-- `internal/server_validate` — Test-only consumer that **reuses**
+- `internal/protocoltest` — Test-only consumer that **reuses**
   `GenericRegistry[Scenario]` as a primitive (its `Scenario` type satisfies
   `vmodel.VirtualModel`). Serves pre-rendered byte/SSE payloads for
   wire-format protocol testing. It does **not** inherit production defaults


### PR DESCRIPTION
## Summary

- Rename `internal/server_test` → `internal/servertest` to match Go convention (directory = package name)
- Add `.design/test-infrastructure.md` documenting the test package hierarchy, responsibilities, and usage guide
- Update stale `server_validate` / `protocol_validate` references in READMEs (`vmodel/`, `cli/harness/`, `internal/protocol/`) to use the new `protocoltest` name (forward-looking for PR #2)

## Context

This is **PR 1 of 2** for the test infrastructure refactoring. The rename is a safe, mechanical change. The docs describe the target state after PR 2 lands.

- **PR 2**: `refactor/protocoltest-merge` — merges `server_validate` + `protocol_validate` into `protocoltest`, extracts `vmodeltest`, fixes pre-existing bugs

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/servertest/...` passes
- [x] `grep -r server_test --include="*.go"` confirms zero stale import references


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8omnjUCYXJXzxVnYjRB7R)_