### PR TITLE
refactor(test): merge into protocoltest + extract vmodeltest

### DIFF
--- a/.design/security.md
+++ b/.design/security.md
@@ -83,7 +83,7 @@ Deleting them would silently break:
 - The detection branch in `NewConfig` and the `is_default` flag exposed
   by `GetUserToken` to the Web UI.
 - The "real token vs test token" assertion in
-  `internal/server_test/server_test.go`.
+  `internal/servertest/server_test.go`.
 
 The right read of these constants today is *"the string we look for in
 older configs"*, not *"the value we hand out to new configs"*. Renaming
@@ -106,4 +106,4 @@ to make that clearer is a follow-up.
 | `internal/server/config/util.go`           | `GenerateUserToken`, `GenerateModelToken`, `GenerateSecureToken`, `IsDefaultToken`.   |
 | `internal/server/config/config.go`         | `NewConfig` bootstrap and `CreateDefaultConfig`. Both refuse legacy defaults.         |
 | `internal/server/webui_auth.go`            | `GetUserToken` (exposes `is_default`), `ResetUserToken`, `ResetModelToken`.           |
-| `internal/server_test/server_test.go`      | Distinguishes real vs test tokens via the legacy default string.                      |
+| `internal/servertest/server_test.go`      | Distinguishes real vs test tokens via the legacy default string.                      |

--- a/cli/harness/agent.go
+++ b/cli/harness/agent.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/tingly-dev/tingly-box/agentboot/claude"
 	internalagent "github.com/tingly-dev/tingly-box/internal/agent"
-	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // AgentCmd runs an agent CLI (claude, codex, opencode) end-to-end through the
@@ -252,11 +252,11 @@ func runVirtualAgentTest(agentName string, prompt string, writer *summaryWriter,
 
 // virtualAPIStyle returns the API style used by the virtual upstream for a given agent.
 // It mirrors the branches in AgentTestEnv.SetupAgent.
-func virtualAPIStyle(agentType protocol_validate.AgentType) string {
+func virtualAPIStyle(agentType protocoltest.AgentType) string {
 	switch agentType {
-	case protocol_validate.AgentTypeClaudeCode, protocol_validate.AgentTypeOpenCode:
+	case protocoltest.AgentTypeClaudeCode, protocoltest.AgentTypeOpenCode:
 		return "anthropic"
-	case protocol_validate.AgentTypeCodex:
+	case protocoltest.AgentTypeCodex:
 		return "openai"
 	}
 	return ""
@@ -264,13 +264,13 @@ func virtualAPIStyle(agentType protocol_validate.AgentType) string {
 
 // builtinRequestModel returns the fixed RequestModel used by the built-in rule
 // for each agent type. This is what the agent CLI actually sends to the gateway.
-func builtinRequestModel(agentType protocol_validate.AgentType) string {
+func builtinRequestModel(agentType protocoltest.AgentType) string {
 	switch agentType {
-	case protocol_validate.AgentTypeClaudeCode:
+	case protocoltest.AgentTypeClaudeCode:
 		return "tingly/cc"
-	case protocol_validate.AgentTypeCodex:
+	case protocoltest.AgentTypeCodex:
 		return "tingly-codex"
-	case protocol_validate.AgentTypeOpenCode:
+	case protocoltest.AgentTypeOpenCode:
 		return "tingly-opencode"
 	}
 	return ""
@@ -412,13 +412,13 @@ type AgentTestResult struct {
 }
 
 // executeAgentCommand executes the actual agent CLI command against the virtual-model gateway.
-func executeAgentCommand(agentType protocol_validate.AgentType, prompt string) (*AgentTestResult, error) {
+func executeAgentCommand(agentType protocoltest.AgentType, prompt string) (*AgentTestResult, error) {
 	switch agentType {
-	case protocol_validate.AgentTypeClaudeCode:
+	case protocoltest.AgentTypeClaudeCode:
 		return executeClaudeTest(prompt)
-	case protocol_validate.AgentTypeCodex:
+	case protocoltest.AgentTypeCodex:
 		return executeCodexTest(prompt)
-	case protocol_validate.AgentTypeOpenCode:
+	case protocoltest.AgentTypeOpenCode:
 		return executeOpenCodeTest(prompt)
 	default:
 		return nil, fmt.Errorf("unknown agent type: %s", agentType)
@@ -429,13 +429,13 @@ func executeAgentCommand(agentType protocol_validate.AgentType, prompt string) (
 func executeClaudeTest(prompt string) (*AgentTestResult, error) {
 	const model = "tingly/cc"
 
-	env, err := protocol_validate.NewAgentTestEnv(protocol_validate.AgentTypeClaudeCode)
+	env, err := protocoltest.NewAgentTestEnv(protocoltest.AgentTypeClaudeCode)
 	if err != nil {
 		return nil, fmt.Errorf("create test env: %w", err)
 	}
 	defer env.Close(false)
 
-	if err := env.SetupAgent(protocol_validate.AgentTypeClaudeCode, "virtual-claude", model); err != nil {
+	if err := env.SetupAgent(protocoltest.AgentTypeClaudeCode, "virtual-claude", model); err != nil {
 		return nil, fmt.Errorf("setup profile: %w", err)
 	}
 
@@ -448,7 +448,7 @@ func executeClaudeTest(prompt string) (*AgentTestResult, error) {
 // same canonical defaults the GUI quick-config seeds from — so the harness
 // exercises the real Claude Code configuration shape (telemetry flags,
 // model routing vars) rather than a hand-rolled minimal subset.
-func executeClaudeWithEnv(env *protocol_validate.AgentTestEnv, prompt string) (*AgentTestResult, error) {
+func executeClaudeWithEnv(env *protocoltest.AgentTestEnv, prompt string) (*AgentTestResult, error) {
 	start := time.Now()
 	result := &AgentTestResult{
 		Agent:  "claude",
@@ -520,13 +520,13 @@ func executeClaudeWithEnv(env *protocol_validate.AgentTestEnv, prompt string) (*
 func executeCodexTest(prompt string) (*AgentTestResult, error) {
 	const model = "tingly-codex"
 
-	env, err := protocol_validate.NewAgentTestEnv(protocol_validate.AgentTypeCodex)
+	env, err := protocoltest.NewAgentTestEnv(protocoltest.AgentTypeCodex)
 	if err != nil {
 		return nil, fmt.Errorf("create test env: %w", err)
 	}
 	defer env.Close(false)
 
-	if err := env.SetupAgent(protocol_validate.AgentTypeCodex, "virtual-codex", model); err != nil {
+	if err := env.SetupAgent(protocoltest.AgentTypeCodex, "virtual-codex", model); err != nil {
 		return nil, fmt.Errorf("setup profile: %w", err)
 	}
 
@@ -534,7 +534,7 @@ func executeCodexTest(prompt string) (*AgentTestResult, error) {
 }
 
 // executeCodexWithEnv writes CODEX_HOME config and runs codex CLI against a pre-configured env.
-func executeCodexWithEnv(env *protocol_validate.AgentTestEnv, model string, prompt string) (*AgentTestResult, error) {
+func executeCodexWithEnv(env *protocoltest.AgentTestEnv, model string, prompt string) (*AgentTestResult, error) {
 	start := time.Now()
 	result := &AgentTestResult{
 		Agent:  "codex",
@@ -612,13 +612,13 @@ wire_api = "responses"
 func executeOpenCodeTest(prompt string) (*AgentTestResult, error) {
 	const model = "tingly-opencode"
 
-	env, err := protocol_validate.NewAgentTestEnv(protocol_validate.AgentTypeOpenCode)
+	env, err := protocoltest.NewAgentTestEnv(protocoltest.AgentTypeOpenCode)
 	if err != nil {
 		return nil, fmt.Errorf("create test env: %w", err)
 	}
 	defer env.Close(false)
 
-	if err := env.SetupAgent(protocol_validate.AgentTypeOpenCode, "virtual-opencode", model); err != nil {
+	if err := env.SetupAgent(protocoltest.AgentTypeOpenCode, "virtual-opencode", model); err != nil {
 		return nil, fmt.Errorf("setup profile: %w", err)
 	}
 
@@ -631,7 +631,7 @@ func executeOpenCodeTest(prompt string) (*AgentTestResult, error) {
 // same logic the production `agent apply` flow uses — so the harness exercises
 // the real provider layout (provider key "tingly-box", model map shape)
 // instead of a hand-rolled variant that could drift from production.
-func executeOpenCodeWithEnv(env *protocol_validate.AgentTestEnv, model string, prompt string) (*AgentTestResult, error) {
+func executeOpenCodeWithEnv(env *protocoltest.AgentTestEnv, model string, prompt string) (*AgentTestResult, error) {
 	start := time.Now()
 	result := &AgentTestResult{
 		Agent:  "opencode",
@@ -714,14 +714,14 @@ func exitCode(err error) int {
 }
 
 // parseAgentType converts a string to AgentType
-func parseAgentType(s string) protocol_validate.AgentType {
+func parseAgentType(s string) protocoltest.AgentType {
 	switch strings.ToLower(s) {
 	case "claude", "claude-code", "claudecode", "cc":
-		return protocol_validate.AgentTypeClaudeCode
+		return protocoltest.AgentTypeClaudeCode
 	case "codex":
-		return protocol_validate.AgentTypeCodex
+		return protocoltest.AgentTypeCodex
 	case "opencode", "open-code", "oc":
-		return protocol_validate.AgentTypeOpenCode
+		return protocoltest.AgentTypeOpenCode
 	default:
 		return ""
 	}

--- a/cli/harness/agent_real.go
+++ b/cli/harness/agent_real.go
@@ -7,7 +7,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // RealAgentTestResult holds the result of one real-model Agent run.
@@ -28,7 +28,7 @@ type RealAgentTestResult struct {
 }
 
 // missingFields returns the names of fields required to run a test that are missing or placeholder.
-func missingFields(entry protocol_validate.RealModelEntry) []string {
+func missingFields(entry protocoltest.RealModelEntry) []string {
 	var miss []string
 	if strings.TrimSpace(entry.BaseURL) == "" {
 		miss = append(miss, "baseurl")
@@ -50,8 +50,8 @@ func missingFields(entry protocol_validate.RealModelEntry) []string {
 
 // loadProvidersConfig reads and parses a providers config file (YAML).
 // Returns the expanded list of test entries.
-func loadProvidersConfig(path string) ([]protocol_validate.RealModelEntry, error) {
-	return protocol_validate.LoadProvidersConfig(path)
+func loadProvidersConfig(path string) ([]protocoltest.RealModelEntry, error) {
+	return protocoltest.LoadProvidersConfig(path)
 }
 
 // runRealAgentTests iterates over all model entries and runs the agent against each.
@@ -98,7 +98,7 @@ func runRealAgentTests(agentName string, modelsFile string, prompt string, write
 	matched := make(map[string]struct{}, len(wanted))
 
 	// Separate runnable entries from incomplete ones.
-	var runnable []protocol_validate.RealModelEntry
+	var runnable []protocoltest.RealModelEntry
 	var skipped []string
 	for _, entry := range entries {
 		if wanted != nil {
@@ -178,7 +178,7 @@ func runRealAgentTests(agentName string, modelsFile string, prompt string, write
 }
 
 // runOneRealAgentTest runs the agent CLI for a single model entry.
-func runOneRealAgentTest(agentType protocol_validate.AgentType, entry protocol_validate.RealModelEntry, prompt string) *RealAgentTestResult {
+func runOneRealAgentTest(agentType protocoltest.AgentType, entry protocoltest.RealModelEntry, prompt string) *RealAgentTestResult {
 	result := &RealAgentTestResult{
 		EntryName: entry.Name,
 		Agent:     string(agentType),
@@ -189,7 +189,7 @@ func runOneRealAgentTest(agentType protocol_validate.AgentType, entry protocol_v
 	start := time.Now()
 
 	// Start isolated gateway (virtual server is also started but unused here)
-	env, err := protocol_validate.NewAgentTestEnv(agentType)
+	env, err := protocoltest.NewAgentTestEnv(agentType)
 	if err != nil {
 		result.Error = fmt.Sprintf("create test env: %v", err)
 		result.Duration = time.Since(start)
@@ -197,7 +197,7 @@ func runOneRealAgentTest(agentType protocol_validate.AgentType, entry protocol_v
 	}
 	defer env.Close(false)
 
-	apiStyle, err := protocol_validate.ResolveAPIStyle(entry)
+	apiStyle, err := protocoltest.ResolveAPIStyle(entry)
 	if err != nil {
 		result.Error = fmt.Sprintf("resolve api_style: %v", err)
 		result.Duration = time.Since(start)
@@ -227,11 +227,11 @@ func runOneRealAgentTest(agentType protocol_validate.AgentType, entry protocol_v
 
 	var agentResult *AgentTestResult
 	switch agentType {
-	case protocol_validate.AgentTypeClaudeCode:
+	case protocoltest.AgentTypeClaudeCode:
 		agentResult, err = executeClaudeWithEnv(env, prompt)
-	case protocol_validate.AgentTypeCodex:
+	case protocoltest.AgentTypeCodex:
 		agentResult, err = executeCodexWithEnv(env, requestModel, prompt)
-	case protocol_validate.AgentTypeOpenCode:
+	case protocoltest.AgentTypeOpenCode:
 		agentResult, err = executeOpenCodeWithEnv(env, requestModel, prompt)
 	}
 

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
-	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // MatrixCmd runs the protocol validation matrix tests.
 //
 // The set of (source → target) pairs is defined explicitly in
-// internal/protocol_validate.DefaultPairs() rather than as a Cartesian
+// internal/protocoltest.DefaultPairs() rather than as a Cartesian
 // product, so what's exercised matches the dispatch graph documented
 // in internal/protocol/README.md. Each pair runs against every
 // scenario and both streaming modes.
@@ -75,7 +75,7 @@ func (m *MatrixCmd) Run() error {
 	}
 
 	// Build matrix with filters
-	matrix := protocol_validate.DefaultMatrix()
+	matrix := protocoltest.DefaultMatrix()
 
 	if len(m.Scenarios) > 0 {
 		matrix = matrix.OnlyScenarios(m.Scenarios...)
@@ -130,8 +130,8 @@ func (m *MatrixCmd) Run() error {
 }
 
 // filterResults filters test results based on command options.
-func filterResults(results []protocol_validate.TestResult, m *MatrixCmd) []protocol_validate.TestResult {
-	var filtered []protocol_validate.TestResult
+func filterResults(results []protocoltest.TestResult, m *MatrixCmd) []protocoltest.TestResult {
+	var filtered []protocoltest.TestResult
 
 	for _, r := range results {
 		if len(m.Sources) > 0 && !contains(m.Sources, string(r.Source)) {

--- a/cli/harness/output.go
+++ b/cli/harness/output.go
@@ -9,11 +9,11 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // printTable prints test results in tabular format.
-func printTable(results []protocol_validate.TestResult, verbose int) {
+func printTable(results []protocoltest.TestResult, verbose int) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	// Summary
@@ -90,7 +90,7 @@ func printTable(results []protocol_validate.TestResult, verbose int) {
 }
 
 // printJSON prints test results in JSON format.
-func printJSON(results []protocol_validate.TestResult) error {
+func printJSON(results []protocoltest.TestResult) error {
 	type JSONResult struct {
 		Name       string `json:"name"`
 		Scenario   string `json:"scenario"`
@@ -142,7 +142,7 @@ func printJSON(results []protocol_validate.TestResult) error {
 }
 
 // printFailures prints detailed information about failed tests.
-func printFailures(results []protocol_validate.TestResult, verbose int) {
+func printFailures(results []protocoltest.TestResult, verbose int) {
 	hasFailures := false
 	for _, r := range results {
 		if !r.Passed && !r.Skipped {
@@ -174,7 +174,7 @@ func printFailures(results []protocol_validate.TestResult, verbose int) {
 }
 
 // countResults counts pass/fail/skip totals.
-func countResults(results []protocol_validate.TestResult) (pass, fail, skip int) {
+func countResults(results []protocoltest.TestResult) (pass, fail, skip int) {
 	for _, r := range results {
 		if r.Skipped {
 			skip++

--- a/cli/harness/replay.go
+++ b/cli/harness/replay.go
@@ -9,7 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // fixtureFS holds captured agent request bodies, grouped by API style and
@@ -32,41 +32,41 @@ var fixtureFS embed.FS
 // "real" upstreams the response is not controlled by the test, so only the
 // upstream-independent `structural` assertions are run.
 type replayScenario struct {
-	matrix        protocol_validate.Scenario
+	matrix        protocoltest.Scenario
 	streaming     bool
 	defaultVModel string // vmodel registry ID used when --upstream=vmodel
-	structural    []protocol_validate.Assertion
+	structural    []protocoltest.Assertion
 }
 
 // replayScenarios is the set of scenarios `harness replay` can run. The map
 // key is the scenario name as it appears on the CLI and in fixture paths.
 var replayScenarios = map[string]replayScenario{
 	"text": {
-		matrix:        protocol_validate.TextScenario(),
+		matrix:        protocoltest.TextScenario(),
 		streaming:     false,
 		defaultVModel: "echo-model",
-		structural: []protocol_validate.Assertion{
-			protocol_validate.AssertHTTPStatus(200),
-			protocol_validate.AssertContentNonEmpty(),
+		structural: []protocoltest.Assertion{
+			protocoltest.AssertHTTPStatus(200),
+			protocoltest.AssertContentNonEmpty(),
 		},
 	},
 	"tool_use": {
-		matrix:        protocol_validate.ToolUseScenario(),
+		matrix:        protocoltest.ToolUseScenario(),
 		streaming:     false,
 		defaultVModel: "web-search-example",
-		structural: []protocol_validate.Assertion{
-			protocol_validate.AssertHTTPStatus(200),
-			protocol_validate.AssertHasToolCalls(1),
+		structural: []protocoltest.Assertion{
+			protocoltest.AssertHTTPStatus(200),
+			protocoltest.AssertHasToolCalls(1),
 		},
 	},
 	"streaming_text": {
-		matrix:        protocol_validate.StreamingTextScenario(),
+		matrix:        protocoltest.StreamingTextScenario(),
 		streaming:     true,
 		defaultVModel: "echo-model",
-		structural: []protocol_validate.Assertion{
-			protocol_validate.AssertHTTPStatus(200),
-			protocol_validate.AssertStreamEventCount(1),
-			protocol_validate.AssertContentNonEmpty(),
+		structural: []protocoltest.Assertion{
+			protocoltest.AssertHTTPStatus(200),
+			protocoltest.AssertStreamEventCount(1),
+			protocoltest.AssertContentNonEmpty(),
 		},
 	},
 }
@@ -82,7 +82,7 @@ var replayScenarioOrder = []string{"text", "tool_use", "streaming_text"}
 var replaySkip = map[string]string{
 	// Transform-pipeline gap: codex speaks the OpenAI Responses API, and
 	// tool_use round-trips through the Responses source path, whose
-	// tool_call conversion is incomplete. Mirrors protocol_validate's
+	// tool_call conversion is incomplete. Mirrors protocoltest's
 	// skipSourceScenarios["openai_responses|tool_use"]. Fails on every upstream.
 	"virtual/codex/tool_use": "Responses API source: tool_use conversion incomplete",
 	"vmodel/codex/tool_use":  "Responses API source: tool_use conversion incomplete",
@@ -159,7 +159,7 @@ func (r *ReplayCmd) Run() error {
 		return err
 	}
 
-	var realEntry *protocol_validate.RealModelEntry
+	var realEntry *protocoltest.RealModelEntry
 	if r.Upstream == "real" {
 		realEntry, err = firstRunnableEntry(r.Config)
 		if err != nil {
@@ -196,7 +196,7 @@ func (r *ReplayCmd) Run() error {
 }
 
 // runOne replays a single (agent, scenario) pair against the configured upstream.
-func (r *ReplayCmd) runOne(agentName, scenarioName string, realEntry *protocol_validate.RealModelEntry) replayRow {
+func (r *ReplayCmd) runOne(agentName, scenarioName string, realEntry *protocoltest.RealModelEntry) replayRow {
 	row := replayRow{Agent: agentName, Scenario: scenarioName, Upstream: r.Upstream}
 	start := time.Now()
 
@@ -226,7 +226,7 @@ func (r *ReplayCmd) runOne(agentName, scenarioName string, realEntry *protocol_v
 		return row
 	}
 
-	env, err := protocol_validate.NewAgentTestEnv(agentType)
+	env, err := protocoltest.NewAgentTestEnv(agentType)
 	if err != nil {
 		row.Err = fmt.Sprintf("create test env: %v", err)
 		row.Duration = time.Since(start)
@@ -245,7 +245,7 @@ func (r *ReplayCmd) runOne(agentName, scenarioName string, realEntry *protocol_v
 		}
 		err = env.SetupVModelAgent(agentType, vmodelID)
 	case "real":
-		apiStyle, sErr := protocol_validate.ResolveAPIStyle(*realEntry)
+		apiStyle, sErr := protocoltest.ResolveAPIStyle(*realEntry)
 		if sErr != nil {
 			err = sErr
 			break
@@ -317,7 +317,7 @@ func resolveReplayScenarios(filter []string) ([]string, error) {
 
 // firstRunnableEntry loads a provider config and returns its first entry that
 // has all fields needed to run (used by --upstream=real).
-func firstRunnableEntry(configFile string) (*protocol_validate.RealModelEntry, error) {
+func firstRunnableEntry(configFile string) (*protocoltest.RealModelEntry, error) {
 	if configFile == "" {
 		return nil, fmt.Errorf("--upstream=real requires --config <file>")
 	}
@@ -335,9 +335,9 @@ func firstRunnableEntry(configFile string) (*protocol_validate.RealModelEntry, e
 
 // loadFixture reads testdata/fixtures/<style>/<scenario>.json from the
 // embedded FS. style is derived from the agent type.
-func loadFixture(agentType protocol_validate.AgentType, scenario string) ([]byte, error) {
+func loadFixture(agentType protocoltest.AgentType, scenario string) ([]byte, error) {
 	style := "anthropic"
-	if agentType == protocol_validate.AgentTypeCodex {
+	if agentType == protocoltest.AgentTypeCodex {
 		style = "openai_responses"
 	}
 	path := fmt.Sprintf("testdata/fixtures/%s/%s.json", style, scenario)

--- a/internal/protocol/stream/prime_test.go
+++ b/internal/protocol/stream/prime_test.go
@@ -1,7 +1,7 @@
 // Prime wrapper unit tests. The full end-to-end prime path is covered
 // by TestRoundTrip_AnthropicBeta_To_OpenAIResponses_Streaming and
 // TestRoundTrip_StreamingPrimeFailure_To_OpenAIResponses in
-// internal/protocol_validate; these check the Next/Current contract
+// internal/protocoltest; these check the Next/Current contract
 // of the replay wrapper directly without standing up an SDK stream.
 
 package stream

--- a/internal/protocoltest/agent_env.go
+++ b/internal/protocoltest/agent_env.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"fmt"
@@ -11,7 +11,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/server"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
@@ -100,7 +99,7 @@ type AgentTestEnv struct {
 	gatewayServer *httptest.Server
 
 	// virtualServer is the mock provider server
-	virtualServer *server_validate.VirtualServer
+	virtualServer *VirtualServer
 
 	// baseURL is the base URL for the gateway
 	baseURL string
@@ -148,9 +147,9 @@ func NewAgentTestEnv(AgentType AgentType) (*AgentTestEnv, error) {
 	}
 
 	// Start virtual server (mock provider) and register default scenarios
-	virtualServer := server_validate.NewVirtualServerForCLI()
+	virtualServer := NewVirtualServerForCLI()
 	for _, ps := range AgentScenarios() {
-		virtualServer.RegisterScenario(server_validate.Scenario{
+		virtualServer.RegisterScenario(Scenario{
 			Name:          ps.Name,
 			MockResponses: ps.MockResponses,
 		})

--- a/internal/protocoltest/agent_real_test.go
+++ b/internal/protocoltest/agent_real_test.go
@@ -1,4 +1,4 @@
-package protocol_validate_test
+package protocoltest_test
 
 import (
 	"bytes"
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pt "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	pt "github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // TestSetupRealProfile_ClaudeCode verifies that SetupRealProfile correctly wires

--- a/internal/protocoltest/agent_scenario.go
+++ b/internal/protocoltest/agent_scenario.go
@@ -1,8 +1,5 @@
-package protocol_validate
+package protocoltest
 
-import (
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
-)
 
 // AgentScenario defines a test scenario for profile testing
 // Unlike matrix scenarios which test protocol transformations,
@@ -15,7 +12,7 @@ type AgentScenario struct {
 	Description string
 
 	// MockResponses are the mock responses keyed by API style
-	MockResponses map[server_validate.ResponseFormat]server_validate.MockResponseBuilder
+	MockResponses map[ResponseFormat]MockResponseBuilder
 }
 
 // AgentScenarios returns all built-in profile test scenarios
@@ -32,8 +29,8 @@ func AgentTextScenario() AgentScenario {
 	return AgentScenario{
 		Name:        "text",
 		Description: "Basic text message request and response",
-		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
-			server_validate.FormatAnthropic: {
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello, world!"}],"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":5}}`)
 				},
@@ -63,7 +60,7 @@ func AgentTextScenario() AgentScenario {
 					}
 				},
 			},
-			server_validate.FormatOpenAIChat: {
+			FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-123","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"Hello, world!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
 				},
@@ -95,8 +92,8 @@ func AgentToolUseScenario() AgentScenario {
 	return AgentScenario{
 		Name:        "tool_use",
 		Description: "Tool use request and response",
-		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
-			server_validate.FormatAnthropic: {
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg_456","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_123","name":"bash","input":{"command":"echo 'hello'"}}],"model":"claude-3-5-sonnet-20241022","stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":20}}`)
 				},
@@ -126,7 +123,7 @@ func AgentToolUseScenario() AgentScenario {
 					}
 				},
 			},
-			server_validate.FormatOpenAIChat: {
+			FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-456","object":"chat.completion","created":1234567890,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_123","type":"function","function":{"name":"bash","arguments":"{\"command\":\"echo 'hello'\"}"}}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
 				},

--- a/internal/protocoltest/assertions.go
+++ b/internal/protocoltest/assertions.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"fmt"

--- a/internal/protocoltest/assertions_test.go
+++ b/internal/protocoltest/assertions_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package protocol_validate_test
+package protocoltest_test
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pv "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	pv "github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // TestAssertContentEquals passes when content matches exactly.

--- a/internal/protocoltest/failover.go
+++ b/internal/protocoltest/failover.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"bytes"
@@ -60,7 +60,7 @@ func (env *TestEnv) SetupFailoverRoute(
 ) FailoverRoute {
 	t.Helper()
 
-	env.virtual.RegisterScenario(successScenario.toVirtualServerScenario())
+	env.virtual.RegisterScenario(successScenario)
 
 	modelSuffix := successScenario.Name
 	switch target {

--- a/internal/protocoltest/failover_test.go
+++ b/internal/protocoltest/failover_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package protocol_validate_test
+package protocoltest_test
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	pt "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	pt "github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // TestFailover_Nonstream_429_RetriesAndSucceeds verifies the priority routing

--- a/internal/protocoltest/matrix.go
+++ b/internal/protocoltest/matrix.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"fmt"

--- a/internal/protocoltest/matrix_test.go
+++ b/internal/protocoltest/matrix_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package protocol_validate_test
+package protocoltest_test
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pt "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	pt "github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 func TestDefaultMatrix(t *testing.T) {

--- a/internal/protocoltest/real_model.go
+++ b/internal/protocoltest/real_model.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"fmt"

--- a/internal/protocoltest/replay.go
+++ b/internal/protocoltest/replay.go
@@ -88,7 +88,7 @@ func (env *AgentTestEnv) repointBuiltinRule(agentType AgentType, providerUUID, u
 // scenario's content-level Assertions against the round-trip result.
 //
 // The rule's upstream model encodes the scenario name as
-// "virtual-model-<style>-<scenario>" so the VirtualServer's scenario
+// "virtual-model-<scenario>" so the VirtualServer's scenario
 // detection resolves the right mock.
 func (env *AgentTestEnv) SetupVirtualAgentScenario(agentType AgentType, scenario Scenario) error {
 	virtualURL := env.VirtualServerURL()
@@ -100,15 +100,13 @@ func (env *AgentTestEnv) SetupVirtualAgentScenario(agentType AgentType, scenario
 
 	style := agentAPIStyle(agentType)
 	apiBase := virtualURL
-	styleName := "anthropic"
 	if style == protocol.APIStyleOpenAI {
 		// OpenAI-style providers expect the /v1 prefix on the base URL so the
 		// gateway forwards to {base}/responses etc. — mirrors TestEnv.SetupRoute.
 		apiBase = virtualURL + "/v1"
-		styleName = "openai"
 	}
 
-	const providerName = "virtual-replay"
+	providerName := fmt.Sprintf("virtual-replay-%s-%s", agentType, scenario.Name)
 	provider := &typ.Provider{
 		UUID:     providerName,
 		Name:     providerName,
@@ -122,7 +120,7 @@ func (env *AgentTestEnv) SetupVirtualAgentScenario(agentType AgentType, scenario
 		return fmt.Errorf("add provider: %w", err)
 	}
 
-	upstreamModel := fmt.Sprintf("virtual-model-%s-%s", styleName, scenario.Name)
+	upstreamModel := fmt.Sprintf("virtual-model-%s", scenario.Name)
 	return env.repointBuiltinRule(agentType, providerName, upstreamModel)
 }
 

--- a/internal/protocoltest/replay.go
+++ b/internal/protocoltest/replay.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"bytes"
@@ -96,7 +96,7 @@ func (env *AgentTestEnv) SetupVirtualAgentScenario(agentType AgentType, scenario
 		return fmt.Errorf("virtual server not initialized")
 	}
 
-	env.virtualServer.RegisterScenario(scenario.toVirtualServerScenario())
+	env.virtualServer.RegisterScenario(scenario)
 
 	style := agentAPIStyle(agentType)
 	apiBase := virtualURL

--- a/internal/protocoltest/roundtrip_test.go
+++ b/internal/protocoltest/roundtrip_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package protocol_validate_test
+package protocoltest_test
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	pt "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	pt "github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 func TestRoundTrip_AnthropicV1_To_OpenAIChat_Text(t *testing.T) {

--- a/internal/protocoltest/scenarios.go
+++ b/internal/protocoltest/scenarios.go
@@ -1,38 +1,62 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
+	"github.com/tingly-dev/tingly-box/vmodel"
 )
 
-// MockResponseBuilder re-exports server_validate.MockResponseBuilder for convenience.
-type MockResponseBuilder = server_validate.MockResponseBuilder
+// ResponseFormat represents the format of the mock response for different endpoints.
+type ResponseFormat string
 
-// Scenario is a named test scenario describing:
-//   - What the mock provider should return (MockResponses per ResponseFormat)
-//   - What assertions to run on the round-trip result
+const (
+	FormatOpenAIChat      ResponseFormat = "openai_chat"      // /v1/chat/completions
+	FormatOpenAIResponses ResponseFormat = "openai_responses" // /v1/responses
+	FormatAnthropic       ResponseFormat = "anthropic"        // /v1/messages
+	FormatGoogle          ResponseFormat = "google"           // /v1beta/models/.../generateContent
+)
+
+// MockResponseBuilder defines how a virtual server should respond for one response format.
+type MockResponseBuilder struct {
+	NonStream func() (statusCode int, body []byte)
+	Stream    func() []string
+}
+
+// Scenario is a named test scenario describing what the mock provider returns
+// and what assertions to run on the round-trip result.
+//
+// Scenario satisfies vmodel.VirtualModel so scenario storage can reuse
+// vmodel.GenericRegistry.
 type Scenario struct {
 	Name        string
 	Description string
 	Tags        []string
 
-	// MockResponses keyed by response format (openai_chat, openai_responses, anthropic, google).
-	MockResponses map[server_validate.ResponseFormat]MockResponseBuilder
+	MockResponses map[ResponseFormat]MockResponseBuilder
 
-	// Assertions run after every round-trip for this scenario.
 	Assertions []Assertion
 }
 
-// toVirtualServerScenario converts to a server_validate.Scenario (strips assertions).
-func (s Scenario) toVirtualServerScenario() server_validate.Scenario {
-	return server_validate.Scenario{
-		Name:          s.Name,
-		Description:   s.Description,
-		Tags:          s.Tags,
-		MockResponses: s.MockResponses,
+var _ vmodel.VirtualModel = Scenario{}
+
+func (s Scenario) GetID() string          { return s.Name }
+func (s Scenario) GetName() string        { return s.Name }
+func (s Scenario) GetDescription() string { return s.Description }
+
+func (s Scenario) GetType() vmodel.VirtualModelType {
+	return vmodel.VirtualModelTypeStatic
+}
+
+func (s Scenario) SimulatedDelay() time.Duration { return 0 }
+
+func (s Scenario) ToModel() vmodel.Model {
+	return vmodel.Model{
+		ID:      s.Name,
+		Object:  "model",
+		Created: 0,
+		OwnedBy: vmodel.DefaultMockOwnedBy,
 	}
 }
 
@@ -58,11 +82,11 @@ func TextScenario() Scenario {
 		Name:        "text",
 		Description: "Basic text completion: user asks a question, assistant answers",
 		Tags:        []string{"text"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAITextResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
-			server_validate.FormatAnthropic:       anthropicTextResponse(),
-			server_validate.FormatGoogle:          googleTextResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAITextResponse(),
+			FormatOpenAIResponses: openAIResponsesTextResponse(),
+			FormatAnthropic:       anthropicTextResponse(),
+			FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -156,11 +180,11 @@ func ToolUseScenario() Scenario {
 		Name:        "tool_use",
 		Description: "Single tool call: assistant calls get_weather with location arg",
 		Tags:        []string{"tool_use"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAIToolUseResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesToolUseResponse(),
-			server_validate.FormatAnthropic:       anthropicToolUseResponse(),
-			server_validate.FormatGoogle:          googleToolUseResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAIToolUseResponse(),
+			FormatOpenAIResponses: openAIResponsesToolUseResponse(),
+			FormatAnthropic:       anthropicToolUseResponse(),
+			FormatGoogle:          googleToolUseResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -274,11 +298,11 @@ func ToolResultScenario() Scenario {
 		Name:        "tool_result",
 		Description: "Multi-turn with tool result: user→assistant(tool_use)→user(tool_result)→assistant",
 		Tags:        []string{"tool_use", "multi_turn"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAITextResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
-			server_validate.FormatAnthropic:       anthropicTextResponse(),
-			server_validate.FormatGoogle:          googleTextResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAITextResponse(),
+			FormatOpenAIResponses: openAIResponsesTextResponse(),
+			FormatAnthropic:       anthropicTextResponse(),
+			FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -296,11 +320,11 @@ func ThinkingScenario() Scenario {
 		Name:        "thinking",
 		Description: "Extended thinking: response contains a thinking block before text",
 		Tags:        []string{"thinking"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatAnthropic:       anthropicThinkingResponse(),
-			server_validate.FormatOpenAIChat:      openAITextResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
-			server_validate.FormatGoogle:          googleTextResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatAnthropic:       anthropicThinkingResponse(),
+			FormatOpenAIChat:      openAITextResponse(),
+			FormatOpenAIResponses: openAIResponsesTextResponse(),
+			FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -345,11 +369,11 @@ func MultiTurnScenario() Scenario {
 		Name:        "multi_turn",
 		Description: "Multi-turn conversation: system + user/assistant history + final user message",
 		Tags:        []string{"multi_turn"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAITextResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
-			server_validate.FormatAnthropic:       anthropicTextResponse(),
-			server_validate.FormatGoogle:          googleTextResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAITextResponse(),
+			FormatOpenAIResponses: openAIResponsesTextResponse(),
+			FormatAnthropic:       anthropicTextResponse(),
+			FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -367,11 +391,11 @@ func StreamingTextScenario() Scenario {
 		Name:        "streaming_text",
 		Description: "Streaming text: SSE chunks assembling to a complete text response",
 		Tags:        []string{"text", "streaming"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAITextResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesTextResponse(),
-			server_validate.FormatAnthropic:       anthropicTextResponse(),
-			server_validate.FormatGoogle:          googleTextResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAITextResponse(),
+			FormatOpenAIResponses: openAIResponsesTextResponse(),
+			FormatAnthropic:       anthropicTextResponse(),
+			FormatGoogle:          googleTextResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -389,11 +413,11 @@ func StreamingToolUseScenario() Scenario {
 		Name:        "streaming_tool_use",
 		Description: "Streaming tool use: SSE chunks with tool call deltas",
 		Tags:        []string{"tool_use", "streaming"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAIToolUseResponse(),
-			server_validate.FormatOpenAIResponses: openAIResponsesToolUseResponse(),
-			server_validate.FormatAnthropic:       anthropicToolUseResponse(),
-			server_validate.FormatGoogle:          googleToolUseResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAIToolUseResponse(),
+			FormatOpenAIResponses: openAIResponsesToolUseResponse(),
+			FormatAnthropic:       anthropicToolUseResponse(),
+			FormatGoogle:          googleToolUseResponse(),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -410,11 +434,11 @@ func ErrorScenario() Scenario {
 		Name:        "error",
 		Description: "Provider rate limit error (429) propagated to client",
 		Tags:        []string{"error"},
-		MockResponses: map[server_validate.ResponseFormat]MockResponseBuilder{
-			server_validate.FormatOpenAIChat:      openAIErrorResponse(),
-			server_validate.FormatOpenAIResponses: openAIErrorResponse(),
-			server_validate.FormatAnthropic:       anthropicErrorResponse(),
-			server_validate.FormatGoogle:          googleErrorResponse(),
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAIErrorResponse(),
+			FormatOpenAIResponses: openAIErrorResponse(),
+			FormatAnthropic:       anthropicErrorResponse(),
+			FormatGoogle:          googleErrorResponse(),
 		},
 		Assertions: []Assertion{},
 	}

--- a/internal/protocoltest/scenarios_test.go
+++ b/internal/protocoltest/scenarios_test.go
@@ -1,14 +1,14 @@
 //go:build e2e
 // +build e2e
 
-package protocol_validate_test
+package protocoltest_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	pt "github.com/tingly-dev/tingly-box/internal/protocol_validate"
+	pt "github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 func TestAllScenarios_Registered(t *testing.T) {

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -1,4 +1,4 @@
-package protocol_validate
+package protocoltest
 
 import (
 	"bytes"
@@ -17,7 +17,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
 	"github.com/tingly-dev/tingly-box/internal/server"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -41,7 +40,7 @@ type TestEnv struct {
 		ServeHTTP(http.ResponseWriter, *http.Request)
 	}
 	gatewayServer *httptest.Server // real HTTP server for streaming support
-	virtual       *server_validate.VirtualServer
+	virtual       *VirtualServer
 	modelToken    string
 
 	mu          sync.Mutex
@@ -98,7 +97,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		appConfig:     appConfig,
 		ginEngine:     router,
 		gatewayServer: ts,
-		virtual:       server_validate.NewVirtualServer(t),
+		virtual:       NewVirtualServer(t),
 		modelToken:    appConfig.GetGlobalConfig().GetModelToken(),
 		routeModels:   make(map[string]string),
 		setupRoutes:   make(map[string]bool),
@@ -155,7 +154,7 @@ func NewTestEnvForCLI(opts ...TestEnvOption) (*TestEnv, error) {
 	router := gatewayServer.GetRouter()
 	ts := httptest.NewServer(router)
 
-	virtual := server_validate.NewVirtualServerForCLI()
+	virtual := NewVirtualServerForCLI()
 	if virtual == nil {
 		ts.Close()
 		os.RemoveAll(configDir)
@@ -205,7 +204,7 @@ func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
 	env.setupRoutes[key] = true
 	env.mu.Unlock()
 
-	env.virtual.RegisterScenario(s.toVirtualServerScenario())
+	env.virtual.RegisterScenario(s)
 
 	virtualURL := env.virtual.URL()
 

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -155,11 +155,6 @@ func NewTestEnvForCLI(opts ...TestEnvOption) (*TestEnv, error) {
 	ts := httptest.NewServer(router)
 
 	virtual := NewVirtualServerForCLI()
-	if virtual == nil {
-		ts.Close()
-		os.RemoveAll(configDir)
-		return nil, fmt.Errorf("failed to create virtual server")
-	}
 
 	return &TestEnv{
 		appConfig:     appConfig,
@@ -212,16 +207,7 @@ func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
 	providerUUID := fmt.Sprintf("virtual-%s-%s-%s", source, target, s.Name)
 	providerName := providerUUID // Use UUID as name for uniqueness
 
-	// Build model name that reflects the target type. The "-codex" / "-chat"
-	// suffix is just a debug marker so the test fixture's logs distinguish
-	// virtual providers wired for each endpoint family.
-	modelSuffix := s.Name
-	if target == protocol.TypeOpenAIResponses {
-		modelSuffix = s.Name + "-codex"
-	} else if target == protocol.TypeOpenAIChat {
-		modelSuffix = s.Name + "-chat"
-	}
-	providerModel := fmt.Sprintf("virtual-model-%s", modelSuffix)
+	providerModel := fmt.Sprintf("virtual-model-%s", s.Name)
 	requestModel := fmt.Sprintf("pv-%s-to-%s-%s", source, target, s.Name)
 
 	apiStyle := targetToAPIStyle(target)
@@ -289,6 +275,7 @@ func (env *TestEnv) SendAs(t *testing.T, source, target protocol.APIType, s Scen
 
 	result := &RoundTripResult{
 		SourceProtocol: source,
+		TargetProtocol: target,
 		ScenarioName:   s.Name,
 		IsStreaming:    streaming,
 	}
@@ -350,6 +337,7 @@ func (env *TestEnv) SendAsCLI(source, target protocol.APIType, s Scenario, strea
 
 	result := &RoundTripResult{
 		SourceProtocol: source,
+		TargetProtocol: target,
 		ScenarioName:   s.Name,
 		IsStreaming:    streaming,
 	}

--- a/internal/protocoltest/types.go
+++ b/internal/protocoltest/types.go
@@ -24,7 +24,7 @@
 //	env := protocoltest.NewTestEnv(t)
 //	defer env.Close()
 //	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, protocoltest.TextScenario())
-//	result := env.SendAs(t, protocol.TypeAnthropicV1, protocoltest.TextScenario(), false)
+//	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, protocoltest.TextScenario(), false)
 //	assert.Equal(t, "assistant", result.Role)
 package protocoltest
 

--- a/internal/protocoltest/types.go
+++ b/internal/protocoltest/types.go
@@ -3,7 +3,7 @@
 //
 // # Architecture
 //
-//  1. server_validate.VirtualServer — a mock HTTP provider that speaks OpenAI, Anthropic,
+//  1. VirtualServer — a mock HTTP provider that speaks OpenAI, Anthropic,
 //     and Google response formats. Conceptually a "virtual model" for testing.
 //
 //  2. TestEnv — wires a real gateway Server (with transform pipeline) to a
@@ -11,14 +11,13 @@
 //
 //  3. Matrix — executes the full cross-product of sources × targets × scenarios × streaming modes.
 //
-// Note: This package (protocol_validate) is the test-only framework, while
-// internal/virtualmodel is the production Gin server. They share the
-// vmodel.GenericRegistry primitive for scenario / model storage —
-// server_validate.Scenario implements vmodel.VirtualModel — but their
-// HTTP handlers remain separate by design: virtualserver/handler.go operates
-// on structured request/response shapes, while protocol_validate scenarios
-// serve pre-rendered byte / SSE-line payloads that exercise the gateway
-// transform pipeline at the wire-format level.
+// This package is the test-only framework, while internal/virtualmodel is the
+// production Gin server. They share the vmodel.GenericRegistry primitive for
+// scenario / model storage — Scenario implements vmodel.VirtualModel — but their
+// HTTP handlers remain separate by design: virtualserver/handler.go operates on
+// structured request/response shapes, while protocoltest scenarios serve
+// pre-rendered byte / SSE-line payloads that exercise the gateway transform
+// pipeline at the wire-format level.
 //
 // # Usage
 //
@@ -27,7 +26,7 @@
 //	env.SetupRoute(protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, protocoltest.TextScenario())
 //	result := env.SendAs(t, protocol.TypeAnthropicV1, protocoltest.TextScenario(), false)
 //	assert.Equal(t, "assistant", result.Role)
-package protocol_validate
+package protocoltest
 
 import (
 	"time"

--- a/internal/protocoltest/virtual_client.go
+++ b/internal/protocoltest/virtual_client.go
@@ -1,47 +1,31 @@
 package protocoltest
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
+	"github.com/tingly-dev/tingly-box/vmodel/vmodeltest"
 )
 
 // ParsedResponse is the result of a request sent to a virtual server.
-// It wraps sse.ParsedResult with HTTP-layer fields.
-type ParsedResponse struct {
-	HTTPStatus   int
-	IsStreaming  bool
-	StreamEvents []string
-	RawBody      []byte
-
-	// Parsed semantics (populated from RawBody or StreamEvents)
-	sse.ParsedResult
-}
+type ParsedResponse = vmodeltest.ParsedResponse
 
 // VirtualClient sends provider-native HTTP requests for testing.
-// It can operate standalone (pointed at any URL) or bound to a VirtualServer
-// (which auto-registers scenarios before each request).
+// It embeds vmodeltest.Client for model-parameterized methods and adds
+// scenario-based methods that auto-register on a bound VirtualServer.
 type VirtualClient struct {
-	baseURL    string
-	httpClient *http.Client
-	server     *VirtualServer // optional; set via WithServer
+	*vmodeltest.Client
+	server *VirtualServer // optional; set via WithServer
 }
 
 // NewVirtualClient creates a client pointing at baseURL.
 func NewVirtualClient(baseURL string) *VirtualClient {
 	return &VirtualClient{
-		baseURL:    baseURL,
-		httpClient: http.DefaultClient,
+		Client: vmodeltest.NewClient(baseURL),
 	}
 }
 
 // WithServer binds the client to a VirtualServer.
-// When bound, Send* methods auto-register the scenario before firing the request.
 func (vc *VirtualClient) WithServer(vs *VirtualServer) *VirtualClient {
 	vc.server = vs
 	return vc
@@ -52,7 +36,7 @@ func (vs *VirtualServer) Client() *VirtualClient {
 	return NewVirtualClient(vs.URL()).WithServer(vs)
 }
 
-// ─── Send helpers ──────────────────────────────────────────────────────────────
+// ─── Scenario-based send helpers ─────────────────────────────────────────────
 
 // SendOpenAIChat sends a request to the OpenAI Chat Completions endpoint.
 func (vc *VirtualClient) SendOpenAIChat(t *testing.T, s Scenario, streaming bool) *ParsedResponse {
@@ -63,7 +47,7 @@ func (vc *VirtualClient) SendOpenAIChat(t *testing.T, s Scenario, streaming bool
 		"messages": []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":   streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/chat/completions", body, streaming, protocol.APIStyleOpenAI)
+	return vc.DoRequest(t, "POST", vc.BaseURL+"/v1/chat/completions", body, streaming, protocol.APIStyleOpenAI)
 }
 
 // SendOpenAIResponses sends a request to the OpenAI Responses API endpoint.
@@ -75,7 +59,7 @@ func (vc *VirtualClient) SendOpenAIResponses(t *testing.T, s Scenario, streaming
 		"input":  "What is the capital of France?",
 		"stream": streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/responses", body, streaming, protocol.APIStyleOpenAI)
+	return vc.DoRequest(t, "POST", vc.BaseURL+"/v1/responses", body, streaming, protocol.APIStyleOpenAI)
 }
 
 // SendAnthropicV1 sends a request to the Anthropic Messages endpoint.
@@ -88,7 +72,7 @@ func (vc *VirtualClient) SendAnthropicV1(t *testing.T, s Scenario, streaming boo
 		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":     streaming,
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages", body, streaming, protocol.APIStyleAnthropic)
+	return vc.DoRequest(t, "POST", vc.BaseURL+"/v1/messages", body, streaming, protocol.APIStyleAnthropic)
 }
 
 // SendGoogle sends a request to the Google GenerateContent endpoint.
@@ -104,135 +88,11 @@ func (vc *VirtualClient) SendGoogle(t *testing.T, s Scenario, streaming bool) *P
 	if streaming {
 		suffix = "streamGenerateContent"
 	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1beta/models/gemini-2.0-flash/"+suffix, body, streaming, protocol.APIStyleGoogle)
+	return vc.DoRequest(t, "POST", vc.BaseURL+"/v1beta/models/gemini-2.0-flash/"+suffix, body, streaming, protocol.APIStyleGoogle)
 }
 
-// ─── Model-parameterized send helpers ─────────────────────────────────────────
-
-// SendOpenAIChatModel sends a request to the OpenAI Chat Completions endpoint
-// using the specified model ID instead of the scenario-derived default.
-func (vc *VirtualClient) SendOpenAIChatModel(t *testing.T, modelID string, streaming bool) *ParsedResponse {
-	t.Helper()
-	body := map[string]interface{}{
-		"model":    modelID,
-		"messages": []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
-		"stream":   streaming,
-	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/chat/completions", body, streaming, protocol.APIStyleOpenAI)
-}
-
-// SendAnthropicV1Model sends a request to the Anthropic Messages endpoint
-// using the specified model ID instead of the scenario-derived default.
-func (vc *VirtualClient) SendAnthropicV1Model(t *testing.T, modelID string, streaming bool) *ParsedResponse {
-	t.Helper()
-	body := map[string]interface{}{
-		"model":      modelID,
-		"max_tokens": 1024,
-		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
-		"stream":     streaming,
-	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages", body, streaming, protocol.APIStyleAnthropic)
-}
-
-// SendAnthropicBetaModel sends a request to the Anthropic Messages endpoint
-// with the ?beta=true query flag to exercise the beta wire format.
-func (vc *VirtualClient) SendAnthropicBetaModel(t *testing.T, modelID string, streaming bool) *ParsedResponse {
-	t.Helper()
-	body := map[string]interface{}{
-		"model":      modelID,
-		"max_tokens": 1024,
-		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
-		"stream":     streaming,
-	}
-	return vc.doRequest(t, "POST", vc.baseURL+"/v1/messages?beta=true", body, streaming, protocol.APIStyleAnthropic)
-}
-
-// ─── Internals ─────────────────────────────────────────────────────────────────
-
-// maybeRegister registers the scenario on the bound server, if any.
 func (vc *VirtualClient) maybeRegister(s Scenario) {
 	if vc.server != nil {
 		vc.server.RegisterScenario(s)
 	}
-}
-
-// doRequest sends an HTTP request and returns a ParsedResponse.
-func (vc *VirtualClient) doRequest(t *testing.T, method, url string, body interface{}, streaming bool, style protocol.APIStyle) *ParsedResponse {
-	t.Helper()
-
-	reqBody, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("marshal request: %v", err)
-	}
-
-	req, err := http.NewRequest(method, url, strings.NewReader(string(reqBody)))
-	if err != nil {
-		t.Fatalf("new request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := vc.httpClient.Do(req)
-	if err != nil {
-		t.Fatalf("do request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	result := &ParsedResponse{
-		HTTPStatus:  resp.StatusCode,
-		IsStreaming: streaming,
-	}
-
-	if streaming {
-		result.StreamEvents, result.RawBody = sse.ReadSSELines(resp.Body)
-		result.ParsedResult = parsedResultFromStream(result.StreamEvents, style)
-	} else {
-		result.RawBody, _ = io.ReadAll(resp.Body)
-		result.ParsedResult = parsedResultFromJSON(result.RawBody, style)
-	}
-
-	return result
-}
-
-func parsedResultFromJSON(raw []byte, style protocol.APIStyle) sse.ParsedResult {
-	var m map[string]interface{}
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return sse.ParsedResult{}
-	}
-	var r *sse.ParsedResult
-	switch style {
-	case protocol.APIStyleOpenAI:
-		if _, hasOutput := m["output"]; hasOutput {
-			r = sse.ParseOpenAIResponsesResult(m)
-		} else {
-			r = sse.ParseOpenAIChatResult(m)
-		}
-	case protocol.APIStyleAnthropic:
-		r = sse.ParseAnthropicResult(m)
-	case protocol.APIStyleGoogle:
-		r = sse.ParseGoogleResult(m)
-	default:
-		return sse.ParsedResult{}
-	}
-	if r == nil {
-		return sse.ParsedResult{}
-	}
-	return *r
-}
-
-func parsedResultFromStream(events []string, style protocol.APIStyle) sse.ParsedResult {
-	var r *sse.ParsedResult
-	switch style {
-	case protocol.APIStyleOpenAI:
-		r = sse.AssembleOpenAIStream(events)
-	case protocol.APIStyleAnthropic:
-		r = sse.AssembleAnthropicStream(events)
-	case protocol.APIStyleGoogle:
-		r = sse.AssembleGoogleStream(events)
-	default:
-		return sse.ParsedResult{}
-	}
-	if r == nil {
-		return sse.ParsedResult{}
-	}
-	return *r
 }

--- a/internal/protocoltest/virtual_client.go
+++ b/internal/protocoltest/virtual_client.go
@@ -1,4 +1,4 @@
-package server_validate
+package protocoltest
 
 import (
 	"encoding/json"

--- a/internal/protocoltest/virtual_client_test.go
+++ b/internal/protocoltest/virtual_client_test.go
@@ -1,4 +1,4 @@
-package server_validate_test
+package protocoltest_test
 
 import (
 	"testing"
@@ -6,14 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // TestVirtualClient_BoundToServer verifies the bound-client pattern:
 // vs.Client() auto-registers scenarios and sends provider-native requests.
 
 func TestVirtualClient_OpenAIChat_NonStream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendOpenAIChat(t, newTextScenario(), false)
@@ -26,7 +26,7 @@ func TestVirtualClient_OpenAIChat_NonStream(t *testing.T) {
 }
 
 func TestVirtualClient_OpenAIChat_Stream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendOpenAIChat(t, newTextScenario(), true)
@@ -37,7 +37,7 @@ func TestVirtualClient_OpenAIChat_Stream(t *testing.T) {
 }
 
 func TestVirtualClient_OpenAIResponses_NonStream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	// The Responses endpoint delegates to the OpenAI handler, so use the OpenAI
@@ -48,7 +48,7 @@ func TestVirtualClient_OpenAIResponses_NonStream(t *testing.T) {
 }
 
 func TestVirtualClient_Anthropic_NonStream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendAnthropicV1(t, newTextScenario(), false)
@@ -59,7 +59,7 @@ func TestVirtualClient_Anthropic_NonStream(t *testing.T) {
 }
 
 func TestVirtualClient_Anthropic_Stream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendAnthropicV1(t, newTextScenario(), true)
@@ -70,7 +70,7 @@ func TestVirtualClient_Anthropic_Stream(t *testing.T) {
 }
 
 func TestVirtualClient_Google_NonStream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendGoogle(t, newTextScenario(), false)
@@ -79,7 +79,7 @@ func TestVirtualClient_Google_NonStream(t *testing.T) {
 }
 
 func TestVirtualClient_Google_Stream(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendGoogle(t, newTextScenario(), true)
@@ -89,7 +89,7 @@ func TestVirtualClient_Google_Stream(t *testing.T) {
 }
 
 func TestVirtualClient_ToolUse_OpenAI(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendOpenAIChat(t, newToolUseScenario(), false)
@@ -100,7 +100,7 @@ func TestVirtualClient_ToolUse_OpenAI(t *testing.T) {
 }
 
 func TestVirtualClient_ToolUse_Anthropic(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendAnthropicV1(t, newToolUseScenario(), false)
@@ -111,7 +111,7 @@ func TestVirtualClient_ToolUse_Anthropic(t *testing.T) {
 }
 
 func TestVirtualClient_ToolUse_Google(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendGoogle(t, newToolUseScenario(), false)
@@ -121,7 +121,7 @@ func TestVirtualClient_ToolUse_Google(t *testing.T) {
 }
 
 func TestVirtualClient_Error(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	vc := vs.Client()
 
 	result := vc.SendOpenAIChat(t, newErrorScenario(), false)
@@ -130,11 +130,11 @@ func TestVirtualClient_Error(t *testing.T) {
 
 func TestVirtualClient_Standalone(t *testing.T) {
 	// Standalone: manually register scenario, then use client pointed at same URL.
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	s := newTextScenario()
 	vs.RegisterScenario(s)
 
-	vc := server_validate.NewVirtualClient(vs.URL())
+	vc := protocoltest.NewVirtualClient(vs.URL())
 	result := vc.SendOpenAIChat(t, s, false)
 	require.Equal(t, 200, result.HTTPStatus)
 	assert.Equal(t, "The capital of France is Paris.", result.Content)
@@ -142,8 +142,8 @@ func TestVirtualClient_Standalone(t *testing.T) {
 
 func TestVirtualClient_WithServer(t *testing.T) {
 	// WithServer: create standalone then bind after the fact.
-	vs := server_validate.NewVirtualServer(t)
-	vc := server_validate.NewVirtualClient(vs.URL()).WithServer(vs)
+	vs := protocoltest.NewVirtualServer(t)
+	vc := protocoltest.NewVirtualClient(vs.URL()).WithServer(vs)
 
 	result := vc.SendAnthropicV1(t, newTextScenario(), false)
 	require.Equal(t, 200, result.HTTPStatus)

--- a/internal/protocoltest/virtual_server.go
+++ b/internal/protocoltest/virtual_server.go
@@ -1,22 +1,4 @@
-// Package server_validate provides a mock HTTP provider server that speaks
-// OpenAI, Anthropic, and Google response formats for testing purposes.
-//
-// **Architecture Note**: VirtualServer is a **provider mock**, not a gateway mock.
-// It speaks provider-native formats (OpenAI/Anthropic/Google APIs) at provider-native
-// routes (/v1/chat/completions, /v1/messages, /v1beta/models/...).
-//
-// The test harness routing flow is:
-//
-//	Client → Gateway (/tingly/{scenario}/v1/...) → Protocol Transform → Virtual Server (/v1/...)
-//
-// A VirtualServer acts as a deterministic "virtual model" — scenario responses
-// are pre-configured and returned without any real model calls. It is used by
-// the protocol_validate test framework to exercise the gateway's protocol transform
-// pipeline end-to-end.
-//
-// Use VirtualClient (client.go) to send requests directly to the server and inspect
-// parsed responses. A bound client is obtained via vs.Client().
-package server_validate
+package protocoltest
 
 import (
 	"bytes"
@@ -27,80 +9,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
 	"github.com/tingly-dev/tingly-box/vmodel"
 )
-
-// ResponseFormat represents the format of the mock response for different endpoints.
-type ResponseFormat string
-
-const (
-	FormatOpenAIChat      ResponseFormat = "openai_chat"      // /v1/chat/completions
-	FormatOpenAIResponses ResponseFormat = "openai_responses" // /v1/responses
-	FormatAnthropic       ResponseFormat = "anthropic"        // /v1/messages
-	FormatGoogle          ResponseFormat = "google"           // /v1beta/models/.../generateContent
-)
-
-// MockResponseBuilder defines how a virtual server should respond for one response format.
-type MockResponseBuilder struct {
-	// NonStream returns the HTTP status code and response body bytes.
-	NonStream func() (statusCode int, body []byte)
-	// Stream returns the SSE event lines (each line is "data: ..." or "event: ...").
-	Stream func() []string
-}
-
-// Scenario is a named test scenario describing what the mock provider returns.
-//
-// Scenario also satisfies vmodel.VirtualModel via stub identity methods
-// so that scenario storage can reuse vmodel.GenericRegistry, the same
-// thread-safe registry primitive used by the production virtualmodel sub-
-// packages. The byte-replay handlers in this file are intentionally NOT
-// wired through virtualserver/handler.go — that handler operates on
-// structured request/response shapes, while protocol_validate scenarios are
-// pre-rendered byte / SSE-line payloads. Sharing the registry primitive is
-// the cleanest reuse available without losing wire-format control.
-type Scenario struct {
-	Name        string
-	Description string
-	Tags        []string
-
-	// MockResponses keyed by response format (openai_chat, openai_responses, anthropic, google).
-	// Each endpoint (/v1/chat/completions, /v1/responses, /v1/messages, /v1beta/models/.../generateContent)
-	// returns the corresponding format.
-	MockResponses map[ResponseFormat]MockResponseBuilder
-}
-
-// Compile-time check: Scenario satisfies vmodel.VirtualModel.
-var _ vmodel.VirtualModel = Scenario{}
-
-// GetID returns the scenario name; scenarios are looked up by name.
-func (s Scenario) GetID() string { return s.Name }
-
-// GetName returns the scenario name.
-func (s Scenario) GetName() string { return s.Name }
-
-// GetDescription returns the scenario description.
-func (s Scenario) GetDescription() string { return s.Description }
-
-// GetType is always Static — scenarios serve fixed pre-rendered responses.
-func (s Scenario) GetType() vmodel.VirtualModelType {
-	return vmodel.VirtualModelTypeStatic
-}
-
-// SimulatedDelay is always 0 — protocol-validate scenarios do not simulate latency.
-func (s Scenario) SimulatedDelay() time.Duration { return 0 }
-
-// ToModel returns the OpenAI-compatible models-list entry for this scenario.
-func (s Scenario) ToModel() vmodel.Model {
-	return vmodel.Model{
-		ID:      s.Name,
-		Object:  "model",
-		Created: 0,
-		OwnedBy: vmodel.DefaultMockOwnedBy,
-	}
-}
 
 // VirtualServer is a mock provider server backed by httptest.Server.
 // It speaks OpenAI, Anthropic, and Google response formats and returns

--- a/internal/protocoltest/virtual_server.go
+++ b/internal/protocoltest/virtual_server.go
@@ -276,8 +276,7 @@ func (vs *VirtualServer) detectScenarioFromURLOrBody(urlPath string, body []byte
 }
 
 // detectScenario extracts the scenario name from the request body's model field.
-// The model field is expected to be "virtual-model-{target}-{scenario}" (set by SetupRoute).
-// We extract just the scenario name for lookup.
+// The model field is expected to be "virtual-model-{scenario}" (set by SetupRoute).
 // Falls back to the first registered scenario if extraction fails.
 func (vs *VirtualServer) detectScenario(body []byte) string {
 	var m map[string]interface{}
@@ -285,16 +284,9 @@ func (vs *VirtualServer) detectScenario(body []byte) string {
 		if model, ok := m["model"].(string); ok {
 			const prefix = "virtual-model-"
 			if strings.HasPrefix(model, prefix) {
-				// Format: virtual-model-{target}-{scenario}
-				// We need to extract the scenario name after the target
-				remaining := model[len(prefix):] // "{target}-{scenario}"
-				// Find the last "-" to separate target from scenario
-				lastDash := strings.LastIndex(remaining, "-")
-				if lastDash > 0 {
-					name := remaining[lastDash+1:]
-					if vs.scenarios.Has(name) {
-						return name
-					}
+				name := model[len(prefix):]
+				if vs.scenarios.Has(name) {
+					return name
 				}
 			}
 		}

--- a/internal/protocoltest/virtual_server_test.go
+++ b/internal/protocoltest/virtual_server_test.go
@@ -1,4 +1,4 @@
-package server_validate_test
+package protocoltest_test
 
 import (
 	"testing"
@@ -6,15 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // newTextScenario returns a minimal text scenario for direct virtual server tests.
-func newTextScenario() server_validate.Scenario {
-	return server_validate.Scenario{
+func newTextScenario() protocoltest.Scenario {
+	return protocoltest.Scenario{
 		Name: "text",
-		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
-			server_validate.FormatOpenAIChat: {
+		MockResponses: map[protocoltest.ResponseFormat]protocoltest.MockResponseBuilder{
+			protocoltest.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-test","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"The capital of France is Paris."},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":8,"total_tokens":18}}`)
 				},
@@ -27,7 +27,7 @@ func newTextScenario() server_validate.Scenario {
 					}
 				},
 			},
-			server_validate.FormatAnthropic: {
+			protocoltest.FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg-test","type":"message","role":"assistant","content":[{"type":"text","text":"The capital of France is Paris."}],"model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":8}}`)
 				},
@@ -42,7 +42,7 @@ func newTextScenario() server_validate.Scenario {
 					}
 				},
 			},
-			server_validate.FormatGoogle: {
+			protocoltest.FormatGoogle: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"The capital of France is Paris."}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":8}}`)
 				},
@@ -56,21 +56,21 @@ func newTextScenario() server_validate.Scenario {
 	}
 }
 
-func newToolUseScenario() server_validate.Scenario {
-	return server_validate.Scenario{
+func newToolUseScenario() protocoltest.Scenario {
+	return protocoltest.Scenario{
 		Name: "tool_use",
-		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
-			server_validate.FormatOpenAIChat: {
+		MockResponses: map[protocoltest.ResponseFormat]protocoltest.MockResponseBuilder{
+			protocoltest.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"chatcmpl-tool","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":15,"completion_tokens":20}}`)
 				},
 			},
-			server_validate.FormatAnthropic: {
+			protocoltest.FormatAnthropic: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"id":"msg-tool","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"location":"Paris"}}],"model":"claude-3-5-sonnet-20241022","stop_reason":"tool_use","usage":{"input_tokens":15,"output_tokens":20}}`)
 				},
 			},
-			server_validate.FormatGoogle: {
+			protocoltest.FormatGoogle: {
 				NonStream: func() (int, []byte) {
 					return 200, []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"location":"Paris"}}}]},"finishReason":"STOP"}]}`)
 				},
@@ -79,11 +79,11 @@ func newToolUseScenario() server_validate.Scenario {
 	}
 }
 
-func newErrorScenario() server_validate.Scenario {
-	return server_validate.Scenario{
+func newErrorScenario() protocoltest.Scenario {
+	return protocoltest.Scenario{
 		Name: "error",
-		MockResponses: map[server_validate.ResponseFormat]server_validate.MockResponseBuilder{
-			server_validate.FormatOpenAIChat: {
+		MockResponses: map[protocoltest.ResponseFormat]protocoltest.MockResponseBuilder{
+			protocoltest.FormatOpenAIChat: {
 				NonStream: func() (int, []byte) {
 					return 429, []byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}`)
 				},
@@ -93,7 +93,7 @@ func newErrorScenario() server_validate.Scenario {
 }
 
 func TestServerValidate_Lifecycle(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	require.NotNil(t, vs)
 	defer vs.Close()
 
@@ -103,7 +103,7 @@ func TestServerValidate_Lifecycle(t *testing.T) {
 }
 
 func TestServerValidate_OpenAI_ChatCompletions(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newTextScenario()
@@ -116,7 +116,7 @@ func TestServerValidate_OpenAI_ChatCompletions(t *testing.T) {
 }
 
 func TestServerValidate_OpenAI_ChatCompletions_Streaming(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newTextScenario()
@@ -127,7 +127,7 @@ func TestServerValidate_OpenAI_ChatCompletions_Streaming(t *testing.T) {
 }
 
 func TestServerValidate_Anthropic_Messages(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newTextScenario()
@@ -139,7 +139,7 @@ func TestServerValidate_Anthropic_Messages(t *testing.T) {
 }
 
 func TestServerValidate_Anthropic_Messages_Streaming(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newTextScenario()
@@ -150,7 +150,7 @@ func TestServerValidate_Anthropic_Messages_Streaming(t *testing.T) {
 }
 
 func TestServerValidate_Google_GenerateContent(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newTextScenario()
@@ -160,7 +160,7 @@ func TestServerValidate_Google_GenerateContent(t *testing.T) {
 }
 
 func TestServerValidate_ToolUse_OpenAI(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newToolUseScenario()
@@ -172,7 +172,7 @@ func TestServerValidate_ToolUse_OpenAI(t *testing.T) {
 }
 
 func TestServerValidate_ToolUse_Anthropic(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newToolUseScenario()
@@ -184,7 +184,7 @@ func TestServerValidate_ToolUse_Anthropic(t *testing.T) {
 }
 
 func TestServerValidate_ErrorResponse(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newErrorScenario()
@@ -193,7 +193,7 @@ func TestServerValidate_ErrorResponse(t *testing.T) {
 }
 
 func TestServerValidate_CallCount(t *testing.T) {
-	vs := server_validate.NewVirtualServer(t)
+	vs := protocoltest.NewVirtualServer(t)
 	defer vs.Close()
 
 	s := newTextScenario()

--- a/vmodel/anthropic/scenario.go
+++ b/vmodel/anthropic/scenario.go
@@ -11,7 +11,7 @@ import (
 )
 
 // MockScenario describes a named test scenario with an Anthropic-protocol mock response.
-// It mirrors server_validate.Scenario for cross-package alignment.
+// It mirrors protocoltest.Scenario for cross-package alignment.
 type MockScenario struct {
 	ID           string
 	Name         string

--- a/vmodel/interface.go
+++ b/vmodel/interface.go
@@ -6,7 +6,7 @@
 // These primitives back the production /virtual/v1/* endpoint (onboarding,
 // demos, dry-runs without a real upstream provider) and are also reused as
 // an in-process LLM substitute by test packages such as protocoltest
-// and protocoltest. The production endpoint is the package's primary
+// and servertest. The production endpoint is the package's primary
 // surface; test consumers are secondary and use GenericRegistry directly
 // rather than RegisterDefaults — see README.md "Positioning & registration
 // discipline".

--- a/vmodel/interface.go
+++ b/vmodel/interface.go
@@ -5,8 +5,8 @@
 //
 // These primitives back the production /virtual/v1/* endpoint (onboarding,
 // demos, dry-runs without a real upstream provider) and are also reused as
-// an in-process LLM substitute by test packages such as server_validate
-// and protocol_validate. The production endpoint is the package's primary
+// an in-process LLM substitute by test packages such as protocoltest
+// and protocoltest. The production endpoint is the package's primary
 // surface; test consumers are secondary and use GenericRegistry directly
 // rather than RegisterDefaults — see README.md "Positioning & registration
 // discipline".

--- a/vmodel/virtualserver/vmodel_test.go
+++ b/vmodel/virtualserver/vmodel_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 	virtualserver2 "github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 
-	"github.com/tingly-dev/tingly-box/internal/protocoltest"
+	"github.com/tingly-dev/tingly-box/vmodel/vmodeltest"
 )
 
 // newTestServer spins up a real Gin httptest.Server with virtualserver routes
 // mounted at /v1 to match VirtualClient endpoint paths.
-func newTestServer(t *testing.T) *protocoltest.VirtualClient {
+func newTestServer(t *testing.T) *vmodeltest.Client {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -30,13 +30,13 @@ func newTestServer(t *testing.T) *protocoltest.VirtualClient {
 	srv := httptest.NewServer(engine)
 	t.Cleanup(srv.Close)
 
-	return protocoltest.NewVirtualClient(srv.URL)
+	return vmodeltest.NewClient(srv.URL)
 }
 
 // ─── Typed response parsers ────────────────────────────────────────────────────
 
 // parseOpenAI deserializes RawBody into ChatCompletionResponse and logs it.
-func parseOpenAI(t *testing.T, result *protocoltest.ParsedResponse) virtualserver2.ChatCompletionResponse {
+func parseOpenAI(t *testing.T, result *vmodeltest.ParsedResponse) virtualserver2.ChatCompletionResponse {
 	t.Helper()
 	var resp virtualserver2.ChatCompletionResponse
 	require.NoError(t, json.Unmarshal(result.RawBody, &resp), "unmarshal OpenAI response")
@@ -45,7 +45,7 @@ func parseOpenAI(t *testing.T, result *protocoltest.ParsedResponse) virtualserve
 }
 
 // parseAnthropic deserializes RawBody into AnthropicMessageResponse and logs it.
-func parseAnthropic(t *testing.T, result *protocoltest.ParsedResponse) virtualserver2.AnthropicMessageResponse {
+func parseAnthropic(t *testing.T, result *vmodeltest.ParsedResponse) virtualserver2.AnthropicMessageResponse {
 	t.Helper()
 	var resp virtualserver2.AnthropicMessageResponse
 	require.NoError(t, json.Unmarshal(result.RawBody, &resp), "unmarshal Anthropic response")
@@ -100,7 +100,7 @@ func logAnthropic(t *testing.T, resp *virtualserver2.AnthropicMessageResponse) {
 
 // parseOpenAIStream deserializes each SSE data line into ChatCompletionStreamResponse chunks.
 // Lines that are "[DONE]" or event-type lines are skipped.
-func parseOpenAIStream(t *testing.T, result *protocoltest.ParsedResponse) []virtualserver2.ChatCompletionStreamResponse {
+func parseOpenAIStream(t *testing.T, result *vmodeltest.ParsedResponse) []virtualserver2.ChatCompletionStreamResponse {
 	t.Helper()
 	var chunks []virtualserver2.ChatCompletionStreamResponse
 	for _, line := range result.StreamEvents {
@@ -118,7 +118,7 @@ func parseOpenAIStream(t *testing.T, result *protocoltest.ParsedResponse) []virt
 }
 
 // parseAnthropicStream deserializes each SSE data line into AnthropicStreamEvent items.
-func parseAnthropicStream(t *testing.T, result *protocoltest.ParsedResponse) []virtualserver2.AnthropicStreamEvent {
+func parseAnthropicStream(t *testing.T, result *vmodeltest.ParsedResponse) []virtualserver2.AnthropicStreamEvent {
 	t.Helper()
 	var events []virtualserver2.AnthropicStreamEvent
 	for _, line := range result.StreamEvents {

--- a/vmodel/virtualserver/vmodel_test.go
+++ b/vmodel/virtualserver/vmodel_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 	virtualserver2 "github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 
-	"github.com/tingly-dev/tingly-box/internal/server_validate"
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // newTestServer spins up a real Gin httptest.Server with virtualserver routes
 // mounted at /v1 to match VirtualClient endpoint paths.
-func newTestServer(t *testing.T) *server_validate.VirtualClient {
+func newTestServer(t *testing.T) *protocoltest.VirtualClient {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -30,13 +30,13 @@ func newTestServer(t *testing.T) *server_validate.VirtualClient {
 	srv := httptest.NewServer(engine)
 	t.Cleanup(srv.Close)
 
-	return server_validate.NewVirtualClient(srv.URL)
+	return protocoltest.NewVirtualClient(srv.URL)
 }
 
 // ─── Typed response parsers ────────────────────────────────────────────────────
 
 // parseOpenAI deserializes RawBody into ChatCompletionResponse and logs it.
-func parseOpenAI(t *testing.T, result *server_validate.ParsedResponse) virtualserver2.ChatCompletionResponse {
+func parseOpenAI(t *testing.T, result *protocoltest.ParsedResponse) virtualserver2.ChatCompletionResponse {
 	t.Helper()
 	var resp virtualserver2.ChatCompletionResponse
 	require.NoError(t, json.Unmarshal(result.RawBody, &resp), "unmarshal OpenAI response")
@@ -45,7 +45,7 @@ func parseOpenAI(t *testing.T, result *server_validate.ParsedResponse) virtualse
 }
 
 // parseAnthropic deserializes RawBody into AnthropicMessageResponse and logs it.
-func parseAnthropic(t *testing.T, result *server_validate.ParsedResponse) virtualserver2.AnthropicMessageResponse {
+func parseAnthropic(t *testing.T, result *protocoltest.ParsedResponse) virtualserver2.AnthropicMessageResponse {
 	t.Helper()
 	var resp virtualserver2.AnthropicMessageResponse
 	require.NoError(t, json.Unmarshal(result.RawBody, &resp), "unmarshal Anthropic response")
@@ -100,7 +100,7 @@ func logAnthropic(t *testing.T, resp *virtualserver2.AnthropicMessageResponse) {
 
 // parseOpenAIStream deserializes each SSE data line into ChatCompletionStreamResponse chunks.
 // Lines that are "[DONE]" or event-type lines are skipped.
-func parseOpenAIStream(t *testing.T, result *server_validate.ParsedResponse) []virtualserver2.ChatCompletionStreamResponse {
+func parseOpenAIStream(t *testing.T, result *protocoltest.ParsedResponse) []virtualserver2.ChatCompletionStreamResponse {
 	t.Helper()
 	var chunks []virtualserver2.ChatCompletionStreamResponse
 	for _, line := range result.StreamEvents {
@@ -118,7 +118,7 @@ func parseOpenAIStream(t *testing.T, result *server_validate.ParsedResponse) []v
 }
 
 // parseAnthropicStream deserializes each SSE data line into AnthropicStreamEvent items.
-func parseAnthropicStream(t *testing.T, result *server_validate.ParsedResponse) []virtualserver2.AnthropicStreamEvent {
+func parseAnthropicStream(t *testing.T, result *protocoltest.ParsedResponse) []virtualserver2.AnthropicStreamEvent {
 	t.Helper()
 	var events []virtualserver2.AnthropicStreamEvent
 	for _, line := range result.StreamEvents {

--- a/vmodel/vmodeltest/client.go
+++ b/vmodel/vmodeltest/client.go
@@ -1,0 +1,155 @@
+package vmodeltest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
+)
+
+// ParsedResponse is the result of a request sent to a virtual server.
+type ParsedResponse struct {
+	HTTPStatus   int
+	IsStreaming  bool
+	StreamEvents []string
+	RawBody      []byte
+
+	sse.ParsedResult
+}
+
+// Client sends provider-native HTTP requests for testing vmodel endpoints.
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a client pointing at baseURL.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		BaseURL:    baseURL,
+		HTTPClient: http.DefaultClient,
+	}
+}
+
+// SendOpenAIChatModel sends a request to the OpenAI Chat Completions endpoint.
+func (c *Client) SendOpenAIChatModel(t *testing.T, modelID string, streaming bool) *ParsedResponse {
+	t.Helper()
+	body := map[string]interface{}{
+		"model":    modelID,
+		"messages": []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
+		"stream":   streaming,
+	}
+	return c.DoRequest(t, "POST", c.BaseURL+"/v1/chat/completions", body, streaming, protocol.APIStyleOpenAI)
+}
+
+// SendAnthropicV1Model sends a request to the Anthropic Messages endpoint.
+func (c *Client) SendAnthropicV1Model(t *testing.T, modelID string, streaming bool) *ParsedResponse {
+	t.Helper()
+	body := map[string]interface{}{
+		"model":      modelID,
+		"max_tokens": 1024,
+		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
+		"stream":     streaming,
+	}
+	return c.DoRequest(t, "POST", c.BaseURL+"/v1/messages", body, streaming, protocol.APIStyleAnthropic)
+}
+
+// SendAnthropicBetaModel sends a request to the Anthropic Messages endpoint
+// with the ?beta=true query flag.
+func (c *Client) SendAnthropicBetaModel(t *testing.T, modelID string, streaming bool) *ParsedResponse {
+	t.Helper()
+	body := map[string]interface{}{
+		"model":      modelID,
+		"max_tokens": 1024,
+		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
+		"stream":     streaming,
+	}
+	return c.DoRequest(t, "POST", c.BaseURL+"/v1/messages?beta=true", body, streaming, protocol.APIStyleAnthropic)
+}
+
+// DoRequest sends an HTTP request and returns a ParsedResponse.
+func (c *Client) DoRequest(t *testing.T, method, url string, body interface{}, streaming bool, style protocol.APIStyle) *ParsedResponse {
+	t.Helper()
+
+	reqBody, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req, err := http.NewRequest(method, url, strings.NewReader(string(reqBody)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	result := &ParsedResponse{
+		HTTPStatus: resp.StatusCode,
+		IsStreaming: streaming,
+	}
+
+	if streaming {
+		result.StreamEvents, result.RawBody = sse.ReadSSELines(resp.Body)
+		result.ParsedResult = ParsedResultFromStream(result.StreamEvents, style)
+	} else {
+		result.RawBody, _ = io.ReadAll(resp.Body)
+		result.ParsedResult = ParsedResultFromJSON(result.RawBody, style)
+	}
+
+	return result
+}
+
+// ParsedResultFromJSON parses a JSON response body based on provider style.
+func ParsedResultFromJSON(raw []byte, style protocol.APIStyle) sse.ParsedResult {
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return sse.ParsedResult{}
+	}
+	var r *sse.ParsedResult
+	switch style {
+	case protocol.APIStyleOpenAI:
+		if _, hasOutput := m["output"]; hasOutput {
+			r = sse.ParseOpenAIResponsesResult(m)
+		} else {
+			r = sse.ParseOpenAIChatResult(m)
+		}
+	case protocol.APIStyleAnthropic:
+		r = sse.ParseAnthropicResult(m)
+	case protocol.APIStyleGoogle:
+		r = sse.ParseGoogleResult(m)
+	default:
+		return sse.ParsedResult{}
+	}
+	if r == nil {
+		return sse.ParsedResult{}
+	}
+	return *r
+}
+
+// ParsedResultFromStream assembles a parsed result from SSE events.
+func ParsedResultFromStream(events []string, style protocol.APIStyle) sse.ParsedResult {
+	var r *sse.ParsedResult
+	switch style {
+	case protocol.APIStyleOpenAI:
+		r = sse.AssembleOpenAIStream(events)
+	case protocol.APIStyleAnthropic:
+		r = sse.AssembleAnthropicStream(events)
+	case protocol.APIStyleGoogle:
+		r = sse.AssembleGoogleStream(events)
+	default:
+		return sse.ParsedResult{}
+	}
+	if r == nil {
+		return sse.ParsedResult{}
+	}
+	return *r
+}


### PR DESCRIPTION
## Summary

- Merge `internal/server_validate` + `internal/protocol_validate` into a single `internal/protocoltest` package
- Extract `vmodel/vmodeltest` — standalone HTTP test client for vmodel endpoints, eliminating vmodel's dependency on protocoltest
- Fix 4 pre-existing bugs found during code review

## Changes

### Package merge (`server_validate` + `protocol_validate` → `protocoltest`)
- `Scenario` type unified: was split across two packages, now single type in `protocoltest` implementing `vmodel.VirtualModel`
- `VirtualServer` + `VirtualClient` moved from `server_validate` into `protocoltest`
- `VirtualClient` now embeds `*vmodeltest.Client` for the HTTP plumbing

### vmodeltest extraction
- `vmodel/vmodeltest.Client` — model-parameterized HTTP client (`SendOpenAIChatModel`, `SendAnthropicV1Model`, etc.)
- `vmodel/vmodeltest.ParsedResponse` — response struct with SSE parsing
- `vmodel/virtualserver/vmodel_test.go` imports `vmodeltest` instead of `protocoltest`

### Bug fixes
- **`RoundTripResult.TargetProtocol`** was declared but never populated in `SendAs`/`SendAsCLI` — now set
- **`detectScenario`** broke on OpenAI Chat/Responses targets: the `-chat`/`-codex` model suffix caused `LastIndex("-")` to extract the suffix instead of the scenario name. Simplified model format to `virtual-model-{scenario}`
- **Replay provider UUID** was hardcoded as `"virtual-replay"`, causing duplicate-UUID errors if `SetupVirtualAgentScenario` was called twice on the same env. Now unique per `(agent, scenario)`
- **Dead nil-check** on `NewVirtualServerForCLI()` removed (always returns non-nil)

## Dependency hierarchy after this PR

```
vmodel/vmodeltest/          ← HTTP test client (no framework deps)
    ↑ embedded by
internal/protocoltest/      ← Protocol validation (VirtualServer + TestEnv + Matrix)
    ↑ imported by
cli/harness/                ← CLI entry points
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/protocoltest/...` passes
- [x] `go test ./vmodel/...` passes (all sub-packages)
- [x] `grep -r "server_validate\|protocol_validate" --include="*.go"` confirms zero stale references

Depends on #1118.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8omnjUCYXJXzxVnYjRB7R)_