### PR TITLE
Refactor(UI): AgentSetupCard to custom step UI with provider connection flow

### DIFF
--- a/frontend/src/components/ConnectProviderFlow.tsx
+++ b/frontend/src/components/ConnectProviderFlow.tsx
@@ -45,8 +45,8 @@ const ConnectProviderFlow: React.FC<ConnectProviderFlowProps> = ({
             const lp = selection.provider;
             setIsLocalProvider(true);
             setProviderFormData({
-                name: lp.name, apiBase: lp.url, apiStyle: 'openai', token: lp.defaultApiKey ?? '',
-                enabled: true, noKeyRequired: !lp.defaultApiKey,
+                name: lp.name, apiBase: lp.baseUrlOpenAI || lp.baseUrlAnthropic || '', apiStyle: 'openai', token: '',
+                enabled: true, noKeyRequired: true,
             } as any);
             setApiKeyDialogOpen(true);
             return;

--- a/frontend/src/components/ConnectProviderFlow.tsx
+++ b/frontend/src/components/ConnectProviderFlow.tsx
@@ -1,0 +1,138 @@
+import ConnectProviderDialog, { type ConnectSelection } from '@/components/ConnectProviderDialog';
+import OAuthDialog from '@/components/OAuthDialog';
+import ProviderFormDialog, { type EnhancedProviderFormData } from '@/components/ProviderFormDialog';
+import { useState, useCallback } from 'react';
+import { api } from '@/services/api';
+
+interface ConnectProviderFlowProps {
+    open: boolean;
+    onClose: () => void;
+    onProviderAdded?: () => void;
+    showNotification?: (message: string, severity: 'success' | 'error') => void;
+}
+
+const ConnectProviderFlow: React.FC<ConnectProviderFlowProps> = ({
+    open,
+    onClose,
+    onProviderAdded,
+    showNotification,
+}) => {
+    const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
+    const [apiKeyDialogMode] = useState<'add'>('add');
+    const [isLocalProvider, setIsLocalProvider] = useState(false);
+    const [oauthDialogOpen, setOAuthDialogOpen] = useState(false);
+    const [oauthAutoStartId, setOAuthAutoStartId] = useState<string | null>(null);
+    const [providerFormData, setProviderFormData] = useState<EnhancedProviderFormData>({
+        name: '', apiBase: '', apiStyle: undefined, token: '', enabled: true, noKeyRequired: false, proxyUrl: '',
+    });
+
+    const handleConnectSelect = useCallback((selection: ConnectSelection) => {
+        onClose();
+        if (selection.kind === 'oauth') {
+            setOAuthAutoStartId(selection.providerId);
+            setOAuthDialogOpen(true);
+            return;
+        }
+        if (selection.kind === 'custom') {
+            setIsLocalProvider(false);
+            setProviderFormData({
+                name: '', apiBase: '', apiStyle: undefined, token: '', enabled: true, noKeyRequired: false, proxyUrl: '',
+            });
+            setApiKeyDialogOpen(true);
+            return;
+        }
+        if (selection.kind === 'local') {
+            const lp = selection.provider;
+            setIsLocalProvider(true);
+            setProviderFormData({
+                name: lp.name, apiBase: lp.url, apiStyle: 'openai', token: lp.defaultApiKey ?? '',
+                enabled: true, noKeyRequired: !lp.defaultApiKey,
+            } as any);
+            setApiKeyDialogOpen(true);
+            return;
+        }
+        const p = selection.provider;
+        setIsLocalProvider(false);
+        setProviderFormData({
+            uuid: undefined, name: p.alias || p.name,
+            apiBase: p.baseUrlOpenAI || p.baseUrlAnthropic || '',
+            apiStyle: undefined, token: '', enabled: true, noKeyRequired: false,
+            proxyUrl: '', userAgent: '', createFusionProvider: false,
+            providerBaseUrls: { openai: p.baseUrlOpenAI, anthropic: p.baseUrlAnthropic },
+        } as any);
+        setApiKeyDialogOpen(true);
+    }, [onClose]);
+
+    const handleProviderSubmit = async (_e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => {
+        const fd = { ...providerFormData, ...(resolved || {}) };
+        const result = await api.addProvider({
+            name: fd.name, api_base: fd.apiBase, api_style: fd.apiStyle,
+            api_base_openai: fd.apiBaseOpenAI || undefined,
+            api_base_anthropic: fd.apiBaseAnthropic || undefined,
+            token: fd.token, no_key_required: fd.noKeyRequired, proxy_url: fd.proxyUrl,
+        });
+        if (result.success) {
+            showNotification?.('Provider added successfully!', 'success');
+            setApiKeyDialogOpen(false);
+            onProviderAdded?.();
+        } else {
+            showNotification?.(`Failed to add provider: ${result.error}`, 'error');
+        }
+    };
+
+    const handleProviderForceAdd = async () => {
+        const result = await api.addProvider({
+            name: providerFormData.name, api_base: providerFormData.apiBase,
+            api_style: providerFormData.apiStyle,
+            api_base_openai: providerFormData.apiBaseOpenAI || undefined,
+            api_base_anthropic: providerFormData.apiBaseAnthropic || undefined,
+            token: providerFormData.token, no_key_required: providerFormData.noKeyRequired,
+            proxy_url: providerFormData.proxyUrl,
+        }, true);
+        if (result.success) {
+            showNotification?.('Provider added successfully!', 'success');
+            setApiKeyDialogOpen(false);
+            onProviderAdded?.();
+        } else {
+            showNotification?.(`Failed to add provider: ${result.error}`, 'error');
+        }
+    };
+
+    const handleFieldChange = (field: keyof EnhancedProviderFormData, value: any) => {
+        setProviderFormData(prev => ({ ...prev, [field]: value }));
+    };
+
+    return (
+        <>
+            <ConnectProviderDialog
+                open={open}
+                onClose={onClose}
+                onSelect={handleConnectSelect}
+            />
+            <ProviderFormDialog
+                open={apiKeyDialogOpen}
+                onClose={() => { setApiKeyDialogOpen(false); setIsLocalProvider(false); }}
+                onBack={() => { setApiKeyDialogOpen(false); onClose(); /* re-open handled by parent */ }}
+                onSubmit={handleProviderSubmit}
+                onForceAdd={handleProviderForceAdd}
+                data={providerFormData}
+                onChange={handleFieldChange}
+                mode={apiKeyDialogMode}
+                optionalEditableToken={isLocalProvider}
+            />
+            <OAuthDialog
+                open={oauthDialogOpen}
+                autoStartProviderId={oauthAutoStartId}
+                onClose={() => { setOAuthDialogOpen(false); setOAuthAutoStartId(null); }}
+                onSuccess={() => {
+                    setOAuthDialogOpen(false);
+                    setOAuthAutoStartId(null);
+                    showNotification?.('Provider connected via OAuth!', 'success');
+                    onProviderAdded?.();
+                }}
+            />
+        </>
+    );
+};
+
+export default ConnectProviderFlow;

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -1,6 +1,7 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
 import ClaudeCodeConfigModal from './components/ClaudeCodeConfigModal';
+import ConnectProviderFlow from '@/components/ConnectProviderFlow';
 import { derivePrefsFromRules } from './components/ClaudeCodeQuickConfig';
 import PageLayout from '@/components/PageLayout';
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
@@ -55,6 +56,7 @@ const UseClaudeCodePageContent: React.FC = () => {
     const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [configModalOpen, setConfigModalOpen] = useState(false);
+    const [connectProviderOpen, setConnectProviderOpen] = useState(false);
 
     // Load scenario config to get config mode
     const loadScenarioConfig = async () => {
@@ -264,6 +266,7 @@ const UseClaudeCodePageContent: React.FC = () => {
                     onViewConfig={() => setConfigModalOpen(true)}
                     hasModelSelected={hasModelOnAnyRule(rules)}
                     onSelectModel={scrollToModelsCard}
+                    onConnectProvider={() => setConnectProviderOpen(true)}
                 />
 
                 <TemplatePage
@@ -312,6 +315,13 @@ const UseClaudeCodePageContent: React.FC = () => {
                         applyPrefs(prefs as Record<string, string>, installStatusLine)
                     }
                     isApplyLoading={isApplyLoading}
+                />
+
+                <ConnectProviderFlow
+                    open={connectProviderOpen}
+                    onClose={() => setConnectProviderOpen(false)}
+                    showNotification={showNotification}
+                    onProviderAdded={() => window.location.reload()}
                 />
 
             </CardGrid>

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -1,6 +1,7 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
 import CodexConfigModal from "./components/CodexConfigModal";
+import ConnectProviderFlow from '@/components/ConnectProviderFlow';
 import { defaultCodexPrefs } from "./components/CodexQuickConfig";
 import { api } from '@/services/api';
 import UnifiedCard from "@/components/UnifiedCard.tsx";
@@ -19,6 +20,7 @@ const UseCodexPageContent: React.FC = () => {
     const {
         isLoading,
         notification,
+        showNotification,
         copyToClipboard,
         baseUrl,
         rules,
@@ -26,6 +28,7 @@ const UseCodexPageContent: React.FC = () => {
 
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [isApplyLoading, setIsApplyLoading] = useState(false);
+    const [connectProviderOpen, setConnectProviderOpen] = useState(false);
 
     const handleApply = async (): Promise<AgentApplyResult> => {
         try {
@@ -99,6 +102,7 @@ const UseCodexPageContent: React.FC = () => {
                     onViewConfig={() => setConfigModalOpen(true)}
                     hasModelSelected={hasModelOnAnyRule(rules)}
                     onSelectModel={scrollToModelsCard}
+                    onConnectProvider={() => setConnectProviderOpen(true)}
                 />
 
                 <TemplatePage
@@ -112,6 +116,13 @@ const UseCodexPageContent: React.FC = () => {
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
                     copyToClipboard={copyToClipboard}
+                />
+
+                <ConnectProviderFlow
+                    open={connectProviderOpen}
+                    onClose={() => setConnectProviderOpen(false)}
+                    showNotification={showNotification}
+                    onProviderAdded={() => window.location.reload()}
                 />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/scenario/UseOpenCodePage.tsx
+++ b/frontend/src/pages/scenario/UseOpenCodePage.tsx
@@ -2,6 +2,7 @@ import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
 import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
+import ConnectProviderFlow from '@/components/ConnectProviderFlow';
 import OpenCodeConfigModal from './components/OpenCodeConfigModal';
 import { Box, Button, IconButton, Tooltip } from '@mui/material';
 import { Info as InfoIcon } from '@/components/icons';
@@ -26,6 +27,7 @@ const UseOpenCodePageContent: React.FC = () => {
 
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [configModalOpen, setConfigModalOpen] = useState(false);
+    const [connectProviderOpen, setConnectProviderOpen] = useState(false);
     const [configJson, setConfigJson] = useState('');
     const [scriptWindows, setScriptWindows] = useState('');
     const [scriptUnix, setScriptUnix] = useState('');
@@ -128,6 +130,7 @@ const UseOpenCodePageContent: React.FC = () => {
                     onViewConfig={handleOpenConfigModal}
                     hasModelSelected={hasModelOnAnyRule(rules)}
                     onSelectModel={scrollToModelsCard}
+                    onConnectProvider={() => setConnectProviderOpen(true)}
                 />
 
                 <TemplatePage
@@ -147,6 +150,13 @@ const UseOpenCodePageContent: React.FC = () => {
                     onApply={async () => { await handleApply(); }}
                     isApplyLoading={isApplyLoading}
                     isLoading={isConfigLoading}
+                />
+
+                <ConnectProviderFlow
+                    open={connectProviderOpen}
+                    onClose={() => setConnectProviderOpen(false)}
+                    showNotification={showNotification}
+                    onProviderAdded={() => window.location.reload()}
                 />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/scenario/UseVSCodePage.tsx
+++ b/frontend/src/pages/scenario/UseVSCodePage.tsx
@@ -2,6 +2,7 @@ import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
 import AgentSetupCard, { hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
+import ConnectProviderFlow from '@/components/ConnectProviderFlow';
 import { Box, Button, Tooltip, IconButton } from '@mui/material';
 import { Info as InfoIcon } from '@/components/icons';
 import { useState } from 'react';
@@ -20,12 +21,14 @@ const UseVSCodePageContent: React.FC = () => {
     const {
         isLoading,
         notification,
+        showNotification,
         copyToClipboard,
         baseUrl,
         rules,
     } = useScenarioPageInternal(scenario);
 
     const [configModalOpen, setConfigModalOpen] = useState(false);
+    const [connectProviderOpen, setConnectProviderOpen] = useState(false);
 
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
@@ -83,6 +86,7 @@ const UseVSCodePageContent: React.FC = () => {
                     viewConfigButtonLabel="Open Guide"
                     hasModelSelected={hasModelOnAnyRule(rules)}
                     onSelectModel={scrollToModelsCard}
+                    onConnectProvider={() => setConnectProviderOpen(true)}
                 />
 
                 <TemplatePage
@@ -95,6 +99,13 @@ const UseVSCodePageContent: React.FC = () => {
                 <VSCodeConfigModal
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
+                />
+
+                <ConnectProviderFlow
+                    open={connectProviderOpen}
+                    onClose={() => setConnectProviderOpen(false)}
+                    showNotification={showNotification}
+                    onProviderAdded={() => window.location.reload()}
                 />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -1,4 +1,5 @@
 import { ContentCopy as ContentCopyIcon } from '@/components/icons';
+import { CheckCircle as CheckCircleIcon } from '@/components/icons';
 import { ExpandLess as ExpandLessIcon } from '@/components/icons';
 import { ExpandMore as ExpandMoreIcon } from '@/components/icons';
 import {
@@ -10,11 +11,9 @@ import {
     Collapse,
     IconButton,
     Stack,
-    Step,
-    StepLabel,
-    Stepper,
     Tooltip,
     Typography,
+    alpha,
 } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import UnifiedCard from '@/components/UnifiedCard';
@@ -23,9 +22,6 @@ import { api } from '@/services/api';
 export interface AgentApplyResult {
     success: boolean;
     files?: string[];
-    // Optional structured breakdown for callers that want richer feedback
-    // (e.g. the Claude Code modal). Existing consumers can keep using
-    // `files` alone — these are additive and may be undefined.
     createdFiles?: string[];
     updatedFiles?: string[];
     backupPaths?: string[];
@@ -55,21 +51,15 @@ export interface AgentSetupCardProps {
     applyButtonLabel?: string;
     applySuccessLabel?: string;
     viewConfigButtonLabel?: string;
-    /** Whether at least one rule has a service with both a provider and model set. */
     hasModelSelected?: boolean;
-    /** Triggered when the user clicks the Step 2 CTA — usually scrolls the page to the rules card. */
     onSelectModel?: () => void;
-    /** Triggered when the user clicks "Connect AI" in Step 1. Opens the provider connection dialog. */
     onConnectProvider?: () => void;
 }
 
 const COLLAPSED_KEY = (agentKey: string) => `setup-card-collapsed-${agentKey}`;
-// Storage key names retain their `step2`/`step3` suffixes for backward compat
-// even though those steps moved to positions 3 and 4 in the UI.
 const INSTALL_DONE_KEY = (agentKey: string) => `setup-card-step2-done-${agentKey}`;
 const APPLY_DONE_KEY = (agentKey: string) => `setup-card-step3-done-${agentKey}`;
 const TOTAL_STEPS = 4;
-const STEP_LABELS = ['Provider', 'Model', 'Install', 'Apply'] as const;
 
 /** True iff at least one rule has a service with both a non-empty provider and model. */
 export const hasModelOnAnyRule = (rules: any[] | null | undefined): boolean =>
@@ -83,6 +73,22 @@ export const scrollToModelsCard = () => {
         block: 'start',
     });
 };
+
+const StepIndicator: React.FC<{ step: number; done: boolean; active: boolean }> = ({ step, done, active }) => (
+    done ? (
+        <CheckCircleIcon sx={{ fontSize: 22, color: 'success.main', flexShrink: 0 }} />
+    ) : (
+        <Box sx={{
+            width: 22, height: 22, borderRadius: '50%', flexShrink: 0,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            bgcolor: active ? 'primary.main' : 'action.disabledBackground',
+            color: active ? 'primary.contrastText' : 'text.disabled',
+            fontSize: '0.7rem', fontWeight: 700,
+        }}>
+            {step}
+        </Box>
+    )
+);
 
 const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     agentKey,
@@ -104,8 +110,6 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     onSelectModel,
     onConnectProvider,
 }) => {
-    // We read the stored collapsed preference once on mount so the auto-collapse
-    // effect below can distinguish "user has not chosen" from "user chose expanded".
     const initialCollapsedPref = useRef<string | null>(localStorage.getItem(COLLAPSED_KEY(agentKey)));
     const [collapsed, setCollapsed] = useState(initialCollapsedPref.current === 'true');
     const [installDone, setInstallDone] = useState(
@@ -136,72 +140,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         return () => { cancelled = true; };
     }, []);
 
-    // Step order: 1) Provider, 2) Model, 3) Install, 4) Apply
     const providerDone = hasProvider;
     const modelDone = hasModelSelected;
     const allDone = providerDone && modelDone && installDone && applyDone;
     const doneCount = [providerDone, modelDone, installDone, applyDone].filter(Boolean).length;
-    const activeStep = !providerDone ? 0 : !modelDone ? 1 : !installDone ? 2 : !applyDone ? 3 : 3;
-    const [stepCursor, setStepCursor] = useState(activeStep);
-    const [skipped, setSkipped] = useState<Set<number>>(new Set());
 
-    useEffect(() => {
-        setStepCursor(prev => (prev < activeStep ? activeStep : prev));
-    }, [activeStep]);
-
-    const isStepSkipped = (step: number) => skipped.has(step);
-    const handleNext = () => {
-        const nextSkipped = new Set(skipped);
-        nextSkipped.delete(stepCursor);
-        setSkipped(nextSkipped);
-        if (stepCursor === 2) {
-            localStorage.setItem(INSTALL_DONE_KEY(agentKey), 'true');
-            setInstallDone(true);
-        }
-        if (stepCursor >= TOTAL_STEPS - 1) {
-            localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
-            setApplyDone(true);
-            setCollapsed(true);
-            localStorage.setItem(COLLAPSED_KEY(agentKey), 'true');
-            return;
-        }
-        setStepCursor(prev => Math.min(prev + 1, TOTAL_STEPS - 1));
-    };
-    const handleBack = () => setStepCursor(prev => Math.max(prev - 1, 0));
-    const handleSkip = () => {
-        const nextSkipped = new Set(skipped);
-        nextSkipped.add(stepCursor);
-        setSkipped(nextSkipped);
-        if (stepCursor === 2) {
-            localStorage.setItem(INSTALL_DONE_KEY(agentKey), 'true');
-            setInstallDone(true);
-        }
-        if (stepCursor >= TOTAL_STEPS - 1) {
-            localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
-            setApplyDone(true);
-            setCollapsed(true);
-            localStorage.setItem(COLLAPSED_KEY(agentKey), 'true');
-            return;
-        }
-        setStepCursor(prev => Math.min(prev + 1, TOTAL_STEPS - 1));
-    };
-    const handleReset = () => {
-        localStorage.removeItem(COLLAPSED_KEY(agentKey));
-        localStorage.removeItem(INSTALL_DONE_KEY(agentKey));
-        localStorage.removeItem(APPLY_DONE_KEY(agentKey));
-        setCollapsed(false);
-        setInstallDone(false);
-        setApplyDone(false);
-        setApplyResult(null);
-        setCopied(false);
-        setCopiedMirror(false);
-        setSkipped(new Set());
-        setStepCursor(!providerDone ? 0 : !modelDone ? 1 : 2);
-    };
-
-    // Auto-collapse on first visit when every step is already complete, but only
-    // when the user hasn't expressed a preference. We wait for providerLoading
-    // so step1Done has settled before we decide.
     const autoCollapsedRef = useRef(false);
     useEffect(() => {
         if (autoCollapsedRef.current) return;
@@ -220,11 +163,6 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setCollapsed(next);
     };
 
-    const handleApplyDone = () => {
-        localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
-        setApplyDone(true);
-    };
-
     const handleCopy = async () => {
         await navigator.clipboard.writeText(installCommand);
         setCopied(true);
@@ -238,12 +176,18 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setTimeout(() => setCopiedMirror(false), 1500);
     };
 
+    const markInstallDone = () => {
+        localStorage.setItem(INSTALL_DONE_KEY(agentKey), 'true');
+        setInstallDone(true);
+    };
+
     const handleApply = async () => {
         if (!onApply) return;
         const result = await onApply();
         setApplyResult(result);
         if (result.success) {
-            handleApplyDone();
+            localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
+            setApplyDone(true);
         }
     };
 
@@ -252,8 +196,21 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         const result = await onApplyWithStatusLine();
         setApplyResult(result);
         if (result.success) {
-            handleApplyDone();
+            localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
+            setApplyDone(true);
         }
+    };
+
+    const handleReset = () => {
+        localStorage.removeItem(COLLAPSED_KEY(agentKey));
+        localStorage.removeItem(INSTALL_DONE_KEY(agentKey));
+        localStorage.removeItem(APPLY_DONE_KEY(agentKey));
+        setCollapsed(false);
+        setInstallDone(false);
+        setApplyDone(false);
+        setApplyResult(null);
+        setCopied(false);
+        setCopiedMirror(false);
     };
 
     const progressLabel = allDone ? 'Done' : `${doneCount}/${TOTAL_STEPS}`;
@@ -267,14 +224,27 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                 ? `Install ${agentName} on your machine`
                 : `One-click ${applyStepLabel} to finish`;
 
+    // Which step is the first incomplete one (determines which expands)
+    const firstIncomplete = !providerDone ? 0 : !modelDone ? 1 : !installDone ? 2 : !applyDone ? 3 : -1;
+
+    const stepRowSx = (done: boolean, active: boolean) => ({
+        py: active ? 1.25 : 0.75,
+        px: 1.5,
+        borderRadius: 1.5,
+        transition: 'background-color 0.15s ease',
+        ...(active && !done ? {
+            bgcolor: (theme: any) => alpha(theme.palette.primary.main, 0.04),
+            border: 1,
+            borderColor: 'divider',
+        } : {}),
+    });
+
     return (
         <UnifiedCard
             size="full"
             title={
                 <Stack direction="row" alignItems="center" spacing={1} sx={{ flex: 1 }}>
-                    <Typography variant="subtitle1" fontWeight={600}>
-                        Quick Start
-                    </Typography>
+                    <Typography variant="subtitle1" fontWeight={600}>Quick Start</Typography>
                     <Chip
                         label={progressLabel}
                         size="small"
@@ -297,207 +267,199 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
             }
         >
             <Collapse in={!collapsed} unmountOnExit={false}>
-                <Stack spacing={2.5}>
-                    <Box sx={{ width: '100%', px: { xs: 0, sm: 1 }, pt: 0.5 }}>
-                    <Stepper activeStep={stepCursor} orientation="horizontal" alternativeLabel>
-                            <Step completed={providerDone}>
-                                <StepLabel optional={isStepSkipped(0) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[0]}</StepLabel>
-                            </Step>
-                            <Step completed={modelDone}>
-                                <StepLabel optional={isStepSkipped(1) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[1]}</StepLabel>
-                            </Step>
-                            <Step completed={installDone}>
-                                <StepLabel optional={isStepSkipped(2) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[2]}</StepLabel>
-                            </Step>
-                            <Step completed={applyDone}>
-                                <StepLabel optional={isStepSkipped(3) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[3]}</StepLabel>
-                            </Step>
-                    </Stepper>
+                <Stack spacing={0.5}>
+
+                    {/* Step 1 — Provider */}
+                    <Box sx={stepRowSx(providerDone, firstIncomplete === 0)}>
+                        <Stack direction="row" spacing={1.25} alignItems="center">
+                            {providerLoading ? <CircularProgress size={20} sx={{ flexShrink: 0 }} /> : <StepIndicator step={1} done={providerDone} active={firstIncomplete === 0} />}
+                            <Typography variant="body2" fontWeight={500} color={providerDone ? 'text.primary' : firstIncomplete === 0 ? 'primary.main' : 'text.disabled'} sx={{ flex: 1 }}>
+                                Connect AI Provider
+                            </Typography>
+                            {providerDone && (
+                                <Typography variant="body2" color="text.secondary">
+                                    {providerCount} provider{providerCount !== 1 ? 's' : ''}
+                                </Typography>
+                            )}
+                            {providerDone && onConnectProvider && (
+                                <Button size="small" variant="text" onClick={onConnectProvider} sx={{ py: 0, textTransform: 'none', minWidth: 0 }}>+ Add</Button>
+                            )}
+                        </Stack>
+                        <Collapse in={!providerDone && firstIncomplete === 0}>
+                            <Stack spacing={0.75} sx={{ mt: 0.75, pl: 4.25 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Connect an AI provider (e.g. OpenAI, Anthropic, DeepSeek) to start using {agentName}.
+                                </Typography>
+                                <Box>
+                                    <Button size="small" variant="contained" onClick={onConnectProvider} sx={{ py: 0.25 }}>
+                                        Connect AI
+                                    </Button>
+                                </Box>
+                            </Stack>
+                        </Collapse>
                     </Box>
 
-                    <Stack spacing={1.5} sx={{ width: '100%', minHeight: 160, justifyContent: 'space-between', border: 1, borderColor: 'divider', borderRadius: 2, p: 1.5 }}>
-                        <Box sx={{ flex: 1 }}>
-                        {stepCursor === 0 && (
-                        <Stack direction="row" spacing={1.5} alignItems="flex-start">
-                            {providerLoading ? <CircularProgress size={20} sx={{ mt: 0.2, flexShrink: 0 }} /> : null}
-                            <Box sx={{ flex: 1 }}>
-                                <Typography variant="body2" fontWeight={500} color={providerDone ? 'text.primary' : 'primary.main'}>
-                                    Step 1 — Connect AI Provider
-                                </Typography>
-                                {providerDone ? (
-                                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
-                                        <Typography variant="body2" color="text.secondary">
-                                            {providerCount === 1
-                                                ? `${providerCount} provider connected`
-                                                : `${providerCount} providers connected`}
-                                        </Typography>
-                                        {onConnectProvider && (
-                                            <Button size="small" variant="text" onClick={onConnectProvider} sx={{ flexShrink: 0, py: 0, textTransform: 'none' }}>
-                                                + Add more
-                                            </Button>
-                                        )}
-                                    </Stack>
-                                ) : (
-                                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                        <Typography variant="body2" color="text.secondary">
-                                            Connect an AI provider (e.g. OpenAI, Anthropic, DeepSeek) to start using {agentName}.
-                                        </Typography>
-                                        <Box>
-                                            <Button
-                                                size="small"
-                                                variant="contained"
-                                                onClick={onConnectProvider}
-                                                sx={{ flexShrink: 0, py: 0.25 }}
-                                            >
-                                                Connect AI
-                                            </Button>
-                                        </Box>
-                                    </Stack>
-                                )}
-                            </Box>
+                    {/* Step 2 — Model */}
+                    <Box sx={stepRowSx(modelDone, firstIncomplete === 1)}>
+                        <Stack direction="row" spacing={1.25} alignItems="center">
+                            <StepIndicator step={2} done={modelDone} active={firstIncomplete === 1} />
+                            <Typography variant="body2" fontWeight={500} color={modelDone ? 'text.primary' : firstIncomplete === 1 ? 'primary.main' : 'text.disabled'} sx={{ flex: 1 }}>
+                                Select a Model
+                            </Typography>
+                            {modelDone && (
+                                <Typography variant="body2" color="text.secondary">Configured</Typography>
+                            )}
+                            {modelDone && onSelectModel && (
+                                <Button size="small" variant="text" onClick={onSelectModel} sx={{ py: 0, textTransform: 'none', minWidth: 0 }}>Change</Button>
+                            )}
                         </Stack>
-                        )}
-
-                        {stepCursor === 1 && (
-                        <Stack direction="row" spacing={1.5} alignItems="flex-start">
-                            <Box sx={{ flex: 1 }}>
-                                <Typography variant="body2" fontWeight={500} color={!providerDone ? 'text.disabled' : modelDone ? 'text.primary' : 'primary.main'}>
-                                    Step 2 — Select a Model
+                        <Collapse in={!modelDone && firstIncomplete === 1}>
+                            <Stack spacing={0.75} sx={{ mt: 0.75, pl: 4.25 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Choose which model {agentName} will use in the <em>Models and Forwarding Rules</em> section below.
                                 </Typography>
-                                {modelDone ? (
-                                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
-                                        <Typography variant="body2" color="text.secondary">Model configured — routing is ready.</Typography>
-                                        {onSelectModel && (
-                                            <Button size="small" variant="text" onClick={onSelectModel} sx={{ flexShrink: 0, py: 0, textTransform: 'none' }}>
-                                                Change model
-                                            </Button>
+                                {onSelectModel && (
+                                    <Box>
+                                        <Button size="small" variant="contained" disabled={!providerDone} onClick={onSelectModel} sx={{ py: 0.25 }}>
+                                            Choose Model
+                                        </Button>
+                                    </Box>
+                                )}
+                            </Stack>
+                        </Collapse>
+                    </Box>
+
+                    {/* Step 3 — Install */}
+                    <Box sx={stepRowSx(installDone, firstIncomplete === 2)}>
+                        <Stack direction="row" spacing={1.25} alignItems="center">
+                            <StepIndicator step={3} done={installDone} active={firstIncomplete === 2} />
+                            <Typography variant="body2" fontWeight={500} color={installDone ? 'text.primary' : firstIncomplete === 2 ? 'primary.main' : 'text.disabled'} sx={{ flex: 1 }}>
+                                Install {agentName}
+                            </Typography>
+                            {installDone && (
+                                <Typography variant="body2" color="text.secondary">Installed</Typography>
+                            )}
+                        </Stack>
+                        <Collapse in={!installDone && firstIncomplete === 2}>
+                            <Stack spacing={0.75} sx={{ mt: 0.75, pl: 4.25 }}>
+                                {installActions?.length ? (
+                                    <>
+                                        {installStepDescription && (
+                                            <Typography variant="body2" color="text.secondary">{installStepDescription}</Typography>
                                         )}
-                                    </Stack>
-                                ) : (
-                                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                        <Typography variant="body2" color="text.secondary">
-                                            Choose which model {agentName} will use. You can configure it in the <em>Models and Forwarding Rules</em> section below.
-                                        </Typography>
-                                        {onSelectModel && (
-                                            <Box>
+                                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ maxWidth: 520 }}>
+                                            {installActions.map((action) => (
                                                 <Button
+                                                    key={`${action.label}-${action.href}`}
+                                                    href={action.href}
+                                                    target={action.external ? '_blank' : undefined}
+                                                    rel={action.external ? 'noopener noreferrer' : undefined}
+                                                    variant={action.variant ?? 'outlined'}
                                                     size="small"
-                                                    variant="contained"
-                                                    disabled={!providerDone}
-                                                    onClick={onSelectModel}
-                                                    sx={{ flexShrink: 0, py: 0.25 }}
+                                                    sx={{ flex: 1 }}
                                                 >
-                                                    Choose Model
+                                                    {action.label}
                                                 </Button>
+                                            ))}
+                                        </Stack>
+                                    </>
+                                ) : (
+                                    <>
+                                        <Alert severity="info" variant="outlined" sx={{ py: 0, px: 1, '& .MuiAlert-message': { py: 0.5 } }}>
+                                            <Typography variant="body2">
+                                                {installStepDescription || `Please install ${agentName} manually on your local machine.`} Copy the command below and run it in your terminal.
+                                            </Typography>
+                                        </Alert>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}>
+                                            <Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm official</Typography>
+                                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}>
+                                                <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+                                                    <IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 16 }} /></IconButton>
+                                                </Tooltip>
+                                                <Typography variant="body2" onClick={handleCopy} sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installCommand}>{installCommand}</Typography>
+                                            </Box>
+                                        </Box>
+                                        {installMirrorCommand && (
+                                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}>
+                                                <Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm mirror</Typography>
+                                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}>
+                                                    <Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}>
+                                                        <IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 16 }} /></IconButton>
+                                                    </Tooltip>
+                                                    <Typography variant="body2" onClick={handleCopyMirror} sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installMirrorCommand}>{installMirrorCommand}</Typography>
+                                                </Box>
                                             </Box>
                                         )}
-                                    </Stack>
+                                    </>
                                 )}
-                            </Box>
-                        </Stack>
-                        )}
+                                <Box>
+                                    <Button size="small" variant="text" onClick={markInstallDone} sx={{ py: 0, textTransform: 'none', color: 'text.secondary' }}>
+                                        I've installed it
+                                    </Button>
+                                </Box>
+                            </Stack>
+                        </Collapse>
+                    </Box>
 
-                        {stepCursor === 2 && (
-                        <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}>
-                            <Typography variant="body2" fontWeight={500} color={!modelDone ? 'text.disabled' : installDone ? 'text.primary' : 'primary.main'}>Step 3 — Install {agentName}</Typography>
-                            {installActions?.length ? (
-                                <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                    {installStepDescription && (
-                                        <Typography variant="body2" color="text.secondary">
-                                            {installStepDescription}
-                                        </Typography>
-                                    )}
-                                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ maxWidth: 520 }}>
-                                        {installActions.map((action) => (
-                                            <Button
-                                                key={`${action.label}-${action.href}`}
-                                                href={action.href}
-                                                target={action.external ? '_blank' : undefined}
-                                                rel={action.external ? 'noopener noreferrer' : undefined}
-                                                variant={action.variant ?? 'outlined'}
-                                                size="small"
-                                                disabled={!modelDone}
-                                                sx={{ flex: 1 }}
-                                            >
-                                                {action.label}
-                                            </Button>
-                                        ))}
-                                    </Stack>
-                                </Stack>
-                            ) : (
-                                <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                    <Alert severity="info" variant="outlined" sx={{ py: 0, px: 1, '& .MuiAlert-message': { py: 0.5 } }}>
-                                        <Typography variant="body2">
-                                            {installStepDescription || `Please install ${agentName} manually on your local machine.`} Copy the command below and run it in your terminal.
-                                        </Typography>
-                                    </Alert>
-                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}><Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm official</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copied ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 16 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopy} sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installCommand}>{installCommand}</Typography></Box></Box>
-                                    {installMirrorCommand && (<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800, mt: 0.25 }}><Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm mirror</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 16 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopyMirror} sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installMirrorCommand}>{installMirrorCommand}</Typography></Box></Box>)}
-                                </Stack>
+                    {/* Step 4 — Apply */}
+                    <Box sx={stepRowSx(applyDone, firstIncomplete === 3)}>
+                        <Stack direction="row" spacing={1.25} alignItems="center">
+                            <StepIndicator step={4} done={applyDone} active={firstIncomplete === 3} />
+                            <Typography variant="body2" fontWeight={500} color={applyDone ? 'text.primary' : firstIncomplete === 3 ? 'primary.main' : 'text.disabled'} sx={{ flex: 1 }}>
+                                {applyStepLabel}
+                            </Typography>
+                            {applyDone && (
+                                <Typography variant="body2" color="text.secondary">Applied</Typography>
                             )}
-                        </Box></Stack>
-                        )}
-
-                        {stepCursor === 3 && (
-                        <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}>
-                            <Typography variant="body2" fontWeight={500} color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}>
-                                Step 4 — {applyStepLabel}
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-                                {applyStepDescription ?? `One click to write the proxy configuration to ${agentName}'s settings file. Advanced users can review the config first.`}
-                            </Typography>
-                            <Collapse in={!applyDone}>
-                                <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
+                        </Stack>
+                        <Collapse in={!applyDone && firstIncomplete === 3}>
+                            <Stack spacing={0.75} sx={{ mt: 0.75, pl: 4.25 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    {applyStepDescription ?? `One click to write the proxy configuration to ${agentName}'s settings file.`}
+                                </Typography>
+                                <Stack direction="row" spacing={1} flexWrap="wrap" gap={0.5}>
                                     {onApply && (
-                                        <Button variant="contained" size="small" disabled={!installDone || isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>
+                                        <Button variant="contained" size="small" disabled={isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>
                                             {applyButtonLabel}
                                         </Button>
                                     )}
                                     {onApplyWithStatusLine && (
-                                        <Button variant="outlined" size="small" disabled={!installDone || isApplyLoading} onClick={handleApplyWithStatusLine}>
+                                        <Button variant="outlined" size="small" disabled={isApplyLoading} onClick={handleApplyWithStatusLine}>
                                             Auto Config + Status Line
                                         </Button>
                                     )}
                                     {onViewConfig && (
-                                        <Button variant="text" size="small" disabled={!installDone} onClick={onViewConfig} sx={{ textTransform: 'none', color: 'text.secondary' }}>
+                                        <Button variant="text" size="small" onClick={onViewConfig} sx={{ textTransform: 'none', color: 'text.secondary' }}>
                                             {viewConfigButtonLabel} (Advanced)
                                         </Button>
                                     )}
                                 </Stack>
-                            </Collapse>
-                            {applyResult && (
-                                <Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 1, py: 0.5 }}>
-                                    {applyResult.success ? (
-                                        <Box>
-                                            <Typography variant="body2" fontWeight={600}>{applySuccessLabel}</Typography>
-                                            {applyResult.files?.map(f => (
-                                                <Typography key={f} variant="body2" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>
-                                            ))}
-                                        </Box>
-                                    ) : (
-                                        <Typography variant="body2">{applyResult.error ?? 'Apply failed'}</Typography>
-                                    )}
-                                </Alert>
-                            )}
-                        </Box></Stack>
-                        )}
-
-                        </Box>
-
-                        <Stack
-                            direction="row"
-                            justifyContent="space-between"
-                            alignItems="center"
-                            sx={{ pt: 1, borderTop: 1, borderColor: 'divider' }}
-                        >
-                            <Button size="small" onClick={handleReset} disabled={stepCursor === 0 && !installDone && !applyDone && skipped.size === 0}>Reset</Button>
-                            <Stack direction="row" spacing={1}>
-                                <Button size="small" onClick={handleBack} disabled={stepCursor === 0}>Back</Button>
-                                <Button size="small" onClick={handleSkip}>Skip</Button>
-                                <Button size="small" variant="contained" onClick={handleNext}>{stepCursor >= TOTAL_STEPS - 1 ? 'Finish' : 'Next'}</Button>
+                                {applyResult && (
+                                    <Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 0.5, py: 0.5 }}>
+                                        {applyResult.success ? (
+                                            <Box>
+                                                <Typography variant="body2" fontWeight={600}>{applySuccessLabel}</Typography>
+                                                {applyResult.files?.map(f => (
+                                                    <Typography key={f} variant="body2" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>
+                                                ))}
+                                            </Box>
+                                        ) : (
+                                            <Typography variant="body2">{applyResult.error ?? 'Apply failed'}</Typography>
+                                        )}
+                                    </Alert>
+                                )}
                             </Stack>
-                        </Stack>
-                    </Stack>
+                        </Collapse>
+                    </Box>
+
+                    {/* Reset link — only visible when something has been manually completed */}
+                    {(installDone || applyDone) && (
+                        <Box sx={{ pt: 0.5, pl: 1.5 }}>
+                            <Button size="small" variant="text" onClick={handleReset} sx={{ py: 0, textTransform: 'none', color: 'text.disabled', fontSize: '0.75rem' }}>
+                                Reset progress
+                            </Button>
+                        </Box>
+                    )}
                 </Stack>
             </Collapse>
         </UnifiedCard>

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -17,7 +17,6 @@ import {
     Typography,
 } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
 import UnifiedCard from '@/components/UnifiedCard';
 import { api } from '@/services/api';
 
@@ -58,8 +57,10 @@ export interface AgentSetupCardProps {
     viewConfigButtonLabel?: string;
     /** Whether at least one rule has a service with both a provider and model set. */
     hasModelSelected?: boolean;
-    /** Triggered when the user clicks the Step 4 CTA — usually scrolls the page to the rules card. */
+    /** Triggered when the user clicks the Step 2 CTA — usually scrolls the page to the rules card. */
     onSelectModel?: () => void;
+    /** Triggered when the user clicks "Connect AI" in Step 1. Opens the provider connection dialog. */
+    onConnectProvider?: () => void;
 }
 
 const COLLAPSED_KEY = (agentKey: string) => `setup-card-collapsed-${agentKey}`;
@@ -101,6 +102,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     viewConfigButtonLabel = 'Config',
     hasModelSelected = false,
     onSelectModel,
+    onConnectProvider,
 }) => {
     // We read the stored collapsed preference once on mount so the auto-collapse
     // effect below can distinguish "user has not chosen" from "user chose expanded".
@@ -258,12 +260,12 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     const progressColor = allDone ? 'success' : 'default';
 
     const collapsedHint = !providerDone
-        ? 'Add a provider to get started'
+        ? 'Connect an AI provider to get started'
         : !modelDone
-            ? 'Pick a model'
+            ? 'Choose a model to continue'
             : !installDone
-                ? `Install ${agentName}`
-                : `${applyStepLabel} to finish`;
+                ? `Install ${agentName} on your machine`
+                : `One-click ${applyStepLabel} to finish`;
 
     return (
         <UnifiedCard
@@ -320,22 +322,36 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                             {providerLoading ? <CircularProgress size={20} sx={{ mt: 0.2, flexShrink: 0 }} /> : null}
                             <Box sx={{ flex: 1 }}>
                                 <Typography variant="body2" fontWeight={500} color={providerDone ? 'text.primary' : 'primary.main'}>
-                                    Step 1 — Add a Provider
+                                    Step 1 — Connect AI Provider
                                 </Typography>
                                 {providerDone ? (
-                                    <Typography variant="caption" color="text.secondary">
-                                        {providerCount === 1
-                                            ? `${providerCount} provider ready`
-                                            : `${providerCount} providers ready`}
-                                    </Typography>
-                                ) : (
                                     <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
                                         <Typography variant="caption" color="text.secondary">
-                                            An AI provider is required to use {agentName}.
+                                            {providerCount === 1
+                                                ? `${providerCount} provider connected`
+                                                : `${providerCount} providers connected`}
                                         </Typography>
-                                        <Button component={Link} to="/onboarding" size="small" variant="outlined" sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem' }}>
-                                            Add Provider
-                                        </Button>
+                                        {onConnectProvider && (
+                                            <Button size="small" variant="text" onClick={onConnectProvider} sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem', textTransform: 'none' }}>
+                                                + Add more
+                                            </Button>
+                                        )}
+                                    </Stack>
+                                ) : (
+                                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                                        <Typography variant="caption" color="text.secondary">
+                                            Connect an AI provider (e.g. OpenAI, Anthropic, DeepSeek) to start using {agentName}.
+                                        </Typography>
+                                        <Box>
+                                            <Button
+                                                size="small"
+                                                variant="contained"
+                                                onClick={onConnectProvider}
+                                                sx={{ flexShrink: 0, py: 0.25, fontSize: '0.75rem' }}
+                                            >
+                                                Connect AI
+                                            </Button>
+                                        </Box>
                                     </Stack>
                                 )}
                             </Box>
@@ -349,11 +365,32 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                     Step 2 — Select a Model
                                 </Typography>
                                 {modelDone ? (
-                                    <Typography variant="caption" color="text.secondary">Model selected — you're ready to go.</Typography>
+                                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
+                                        <Typography variant="caption" color="text.secondary">Model configured — routing is ready.</Typography>
+                                        {onSelectModel && (
+                                            <Button size="small" variant="text" onClick={onSelectModel} sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem', textTransform: 'none' }}>
+                                                Change model
+                                            </Button>
+                                        )}
+                                    </Stack>
                                 ) : (
-                                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }} flexWrap="wrap" gap={1}>
-                                        <Typography variant="caption" color="text.secondary">Pick a model in <em>Models and Forwarding Rules</em> to start routing requests.</Typography>
-                                        {onSelectModel && <Button size="small" variant="outlined" disabled={!providerDone} onClick={onSelectModel} sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem' }}>Choose Model</Button>}
+                                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                                        <Typography variant="caption" color="text.secondary">
+                                            Choose which model {agentName} will use. You can configure it in the <em>Models and Forwarding Rules</em> section below.
+                                        </Typography>
+                                        {onSelectModel && (
+                                            <Box>
+                                                <Button
+                                                    size="small"
+                                                    variant="contained"
+                                                    disabled={!providerDone}
+                                                    onClick={onSelectModel}
+                                                    sx={{ flexShrink: 0, py: 0.25, fontSize: '0.75rem' }}
+                                                >
+                                                    Choose Model
+                                                </Button>
+                                            </Box>
+                                        )}
                                     </Stack>
                                 )}
                             </Box>
@@ -363,39 +400,89 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                         {stepCursor === 2 && (
                         <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}>
                             <Typography variant="body2" fontWeight={500} color={!modelDone ? 'text.disabled' : installDone ? 'text.primary' : 'primary.main'}>Step 3 — Install {agentName}</Typography>
-                            {installStepDescription && (
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-                                    {installStepDescription}
-                                </Typography>
-                            )}
                             {installActions?.length ? (
-                                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ maxWidth: 520 }}>
-                                    {installActions.map((action) => (
-                                        <Button
-                                            key={`${action.label}-${action.href}`}
-                                            href={action.href}
-                                            target={action.external ? '_blank' : undefined}
-                                            rel={action.external ? 'noopener noreferrer' : undefined}
-                                            variant={action.variant ?? 'outlined'}
-                                            size="small"
-                                            disabled={!modelDone}
-                                            sx={{ flex: 1 }}
-                                        >
-                                            {action.label}
-                                        </Button>
-                                    ))}
+                                <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                                    {installStepDescription && (
+                                        <Typography variant="caption" color="text.secondary">
+                                            {installStepDescription}
+                                        </Typography>
+                                    )}
+                                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ maxWidth: 520 }}>
+                                        {installActions.map((action) => (
+                                            <Button
+                                                key={`${action.label}-${action.href}`}
+                                                href={action.href}
+                                                target={action.external ? '_blank' : undefined}
+                                                rel={action.external ? 'noopener noreferrer' : undefined}
+                                                variant={action.variant ?? 'outlined'}
+                                                size="small"
+                                                disabled={!modelDone}
+                                                sx={{ flex: 1 }}
+                                            >
+                                                {action.label}
+                                            </Button>
+                                        ))}
+                                    </Stack>
                                 </Stack>
                             ) : (
-                                <>
+                                <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                                    <Typography variant="caption" color="text.secondary">
+                                        {installStepDescription || `Please install ${agentName} manually on your local machine. Copy the command below and run it in your terminal.`}
+                                    </Typography>
+                                    <Alert severity="info" variant="outlined" sx={{ py: 0, px: 1, '& .MuiAlert-message': { py: 0.5 } }}>
+                                        <Typography variant="caption" sx={{ fontSize: '0.7rem' }}>
+                                            This step requires manual operation — run the command on the machine where you will use {agentName}.
+                                        </Typography>
+                                    </Alert>
                                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}><Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>npm official</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copied ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 14 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopy} sx={{ fontFamily: 'monospace', flex: 1, fontSize: '0.8rem', color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installCommand}>{installCommand}</Typography></Box></Box>
-                                    {installMirrorCommand && (<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800, mt: 0.75 }}><Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>npm mirror</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 14 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopyMirror} sx={{ fontFamily: 'monospace', flex: 1, fontSize: '0.8rem', color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installMirrorCommand}>{installMirrorCommand}</Typography></Box></Box>)}
-                                </>
+                                    {installMirrorCommand && (<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800, mt: 0.25 }}><Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>npm mirror</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 14 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopyMirror} sx={{ fontFamily: 'monospace', flex: 1, fontSize: '0.8rem', color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installMirrorCommand}>{installMirrorCommand}</Typography></Box></Box>)}
+                                </Stack>
                             )}
                         </Box></Stack>
                         )}
 
                         {stepCursor === 3 && (
-                        <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}><Typography variant="body2" fontWeight={500} color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}>Step 4 — {applyStepLabel}</Typography><Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>{applyStepDescription ?? `Write the proxy configuration to ${agentName}'s settings file.`}</Typography><Collapse in={!applyDone}><Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>{onApply && <Button variant="contained" size="small" disabled={!installDone || isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>{applyButtonLabel}</Button>}{onApplyWithStatusLine && <Button variant="outlined" size="small" disabled={!installDone || isApplyLoading} onClick={handleApplyWithStatusLine}>Auto Config + Status Line</Button>}{onViewConfig && <Button variant={onApply ? "outlined" : "contained"} size="small" disabled={!installDone} onClick={onViewConfig}>{viewConfigButtonLabel}</Button>}</Stack></Collapse>{applyResult && (<Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 1, py: 0.5 }}>{applyResult.success ? (<Box><Typography variant="caption" fontWeight={600}>{applySuccessLabel}</Typography>{applyResult.files?.map(f => (<Typography key={f} variant="caption" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>))}</Box>) : (<Typography variant="caption">{applyResult.error ?? 'Apply failed'}</Typography>)}</Alert>)}</Box></Stack>
+                        <Stack direction="row" spacing={1.5} alignItems="flex-start"><Box sx={{ flex: 1 }}>
+                            <Typography variant="body2" fontWeight={500} color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}>
+                                Step 4 — {applyStepLabel}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                                {applyStepDescription ?? `One click to write the proxy configuration to ${agentName}'s settings file. Advanced users can review the config first.`}
+                            </Typography>
+                            <Collapse in={!applyDone}>
+                                <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
+                                    {onApply && (
+                                        <Button variant="contained" size="small" disabled={!installDone || isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>
+                                            {applyButtonLabel}
+                                        </Button>
+                                    )}
+                                    {onApplyWithStatusLine && (
+                                        <Button variant="outlined" size="small" disabled={!installDone || isApplyLoading} onClick={handleApplyWithStatusLine}>
+                                            Auto Config + Status Line
+                                        </Button>
+                                    )}
+                                    {onViewConfig && (
+                                        <Button variant="text" size="small" disabled={!installDone} onClick={onViewConfig} sx={{ textTransform: 'none', color: 'text.secondary' }}>
+                                            {viewConfigButtonLabel} (Advanced)
+                                        </Button>
+                                    )}
+                                </Stack>
+                            </Collapse>
+                            {applyResult && (
+                                <Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 1, py: 0.5 }}>
+                                    {applyResult.success ? (
+                                        <Box>
+                                            <Typography variant="caption" fontWeight={600}>{applySuccessLabel}</Typography>
+                                            {applyResult.files?.map(f => (
+                                                <Typography key={f} variant="caption" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>
+                                            ))}
+                                        </Box>
+                                    ) : (
+                                        <Typography variant="caption">{applyResult.error ?? 'Apply failed'}</Typography>
+                                    )}
+                                </Alert>
+                            )}
+                        </Box></Stack>
                         )}
 
                         </Box>

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -365,11 +365,9 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                     </>
                                 ) : (
                                     <>
-                                        <Alert severity="info" variant="outlined" sx={{ py: 0, px: 1, '& .MuiAlert-message': { py: 0.5 } }}>
-                                            <Typography variant="body2">
-                                                {installStepDescription || `Please install ${agentName} manually on your local machine.`} Copy the command below and run it in your terminal.
-                                            </Typography>
-                                        </Alert>
+                                        <Typography variant="body2" color="text.secondary">
+                                            {installStepDescription || `Install ${agentName} on your local machine — copy and run the command below.`}
+                                        </Typography>
                                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}>
                                             <Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm official</Typography>
                                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}>

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -279,10 +279,10 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                         label={progressLabel}
                         size="small"
                         color={progressColor as any}
-                        sx={{ height: 20, fontSize: '0.7rem' }}
+                        sx={{ height: 20, fontSize: '0.75rem' }}
                     />
                     {collapsed && !allDone && (
-                        <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                        <Typography variant="body2" color="text.secondary" sx={{ ml: 0.5 }}>
                             {collapsedHint}
                         </Typography>
                     )}
@@ -301,16 +301,16 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                     <Box sx={{ width: '100%', px: { xs: 0, sm: 1 }, pt: 0.5 }}>
                     <Stepper activeStep={stepCursor} orientation="horizontal" alternativeLabel>
                             <Step completed={providerDone}>
-                                <StepLabel optional={isStepSkipped(0) ? <Typography variant="caption">Skipped</Typography> : undefined}>{STEP_LABELS[0]}</StepLabel>
+                                <StepLabel optional={isStepSkipped(0) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[0]}</StepLabel>
                             </Step>
                             <Step completed={modelDone}>
-                                <StepLabel optional={isStepSkipped(1) ? <Typography variant="caption">Skipped</Typography> : undefined}>{STEP_LABELS[1]}</StepLabel>
+                                <StepLabel optional={isStepSkipped(1) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[1]}</StepLabel>
                             </Step>
                             <Step completed={installDone}>
-                                <StepLabel optional={isStepSkipped(2) ? <Typography variant="caption">Skipped</Typography> : undefined}>{STEP_LABELS[2]}</StepLabel>
+                                <StepLabel optional={isStepSkipped(2) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[2]}</StepLabel>
                             </Step>
                             <Step completed={applyDone}>
-                                <StepLabel optional={isStepSkipped(3) ? <Typography variant="caption">Skipped</Typography> : undefined}>{STEP_LABELS[3]}</StepLabel>
+                                <StepLabel optional={isStepSkipped(3) ? <Typography variant="body2">Skipped</Typography> : undefined}>{STEP_LABELS[3]}</StepLabel>
                             </Step>
                     </Stepper>
                     </Box>
@@ -326,20 +326,20 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 </Typography>
                                 {providerDone ? (
                                     <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
-                                        <Typography variant="caption" color="text.secondary">
+                                        <Typography variant="body2" color="text.secondary">
                                             {providerCount === 1
                                                 ? `${providerCount} provider connected`
                                                 : `${providerCount} providers connected`}
                                         </Typography>
                                         {onConnectProvider && (
-                                            <Button size="small" variant="text" onClick={onConnectProvider} sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem', textTransform: 'none' }}>
+                                            <Button size="small" variant="text" onClick={onConnectProvider} sx={{ flexShrink: 0, py: 0, textTransform: 'none' }}>
                                                 + Add more
                                             </Button>
                                         )}
                                     </Stack>
                                 ) : (
                                     <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                        <Typography variant="caption" color="text.secondary">
+                                        <Typography variant="body2" color="text.secondary">
                                             Connect an AI provider (e.g. OpenAI, Anthropic, DeepSeek) to start using {agentName}.
                                         </Typography>
                                         <Box>
@@ -347,7 +347,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                                 size="small"
                                                 variant="contained"
                                                 onClick={onConnectProvider}
-                                                sx={{ flexShrink: 0, py: 0.25, fontSize: '0.75rem' }}
+                                                sx={{ flexShrink: 0, py: 0.25 }}
                                             >
                                                 Connect AI
                                             </Button>
@@ -366,16 +366,16 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 </Typography>
                                 {modelDone ? (
                                     <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
-                                        <Typography variant="caption" color="text.secondary">Model configured — routing is ready.</Typography>
+                                        <Typography variant="body2" color="text.secondary">Model configured — routing is ready.</Typography>
                                         {onSelectModel && (
-                                            <Button size="small" variant="text" onClick={onSelectModel} sx={{ flexShrink: 0, py: 0, fontSize: '0.7rem', textTransform: 'none' }}>
+                                            <Button size="small" variant="text" onClick={onSelectModel} sx={{ flexShrink: 0, py: 0, textTransform: 'none' }}>
                                                 Change model
                                             </Button>
                                         )}
                                     </Stack>
                                 ) : (
                                     <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                        <Typography variant="caption" color="text.secondary">
+                                        <Typography variant="body2" color="text.secondary">
                                             Choose which model {agentName} will use. You can configure it in the <em>Models and Forwarding Rules</em> section below.
                                         </Typography>
                                         {onSelectModel && (
@@ -385,7 +385,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                                     variant="contained"
                                                     disabled={!providerDone}
                                                     onClick={onSelectModel}
-                                                    sx={{ flexShrink: 0, py: 0.25, fontSize: '0.75rem' }}
+                                                    sx={{ flexShrink: 0, py: 0.25 }}
                                                 >
                                                     Choose Model
                                                 </Button>
@@ -403,7 +403,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                             {installActions?.length ? (
                                 <Stack spacing={0.75} sx={{ mt: 0.5 }}>
                                     {installStepDescription && (
-                                        <Typography variant="caption" color="text.secondary">
+                                        <Typography variant="body2" color="text.secondary">
                                             {installStepDescription}
                                         </Typography>
                                     )}
@@ -426,16 +426,13 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 </Stack>
                             ) : (
                                 <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-                                    <Typography variant="caption" color="text.secondary">
-                                        {installStepDescription || `Please install ${agentName} manually on your local machine. Copy the command below and run it in your terminal.`}
-                                    </Typography>
                                     <Alert severity="info" variant="outlined" sx={{ py: 0, px: 1, '& .MuiAlert-message': { py: 0.5 } }}>
-                                        <Typography variant="caption" sx={{ fontSize: '0.7rem' }}>
-                                            This step requires manual operation — run the command on the machine where you will use {agentName}.
+                                        <Typography variant="body2">
+                                            {installStepDescription || `Please install ${agentName} manually on your local machine.`} Copy the command below and run it in your terminal.
                                         </Typography>
                                     </Alert>
-                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}><Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>npm official</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copied ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 14 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopy} sx={{ fontFamily: 'monospace', flex: 1, fontSize: '0.8rem', color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installCommand}>{installCommand}</Typography></Box></Box>
-                                    {installMirrorCommand && (<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800, mt: 0.25 }}><Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem', minWidth: '80px' }}>npm mirror</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 14 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopyMirror} sx={{ fontFamily: 'monospace', flex: 1, fontSize: '0.8rem', color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installMirrorCommand}>{installMirrorCommand}</Typography></Box></Box>)}
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800 }}><Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm official</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copied ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopy} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 16 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopy} sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installCommand}>{installCommand}</Typography></Box></Box>
+                                    {installMirrorCommand && (<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, maxWidth: 800, mt: 0.25 }}><Typography variant="body2" color="text.secondary" sx={{ minWidth: '80px' }}>npm mirror</Typography><Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: 1, minWidth: 0 }}><Tooltip title={copiedMirror ? 'Copied!' : 'Copy'}><IconButton size="small" onClick={handleCopyMirror} sx={{ flexShrink: 0, p: 0.25 }}><ContentCopyIcon sx={{ fontSize: 16 }} /></IconButton></Tooltip><Typography variant="body2" onClick={handleCopyMirror} sx={{ fontFamily: 'monospace', flex: 1, color: 'text.primary', cursor: 'pointer', '&:hover': { color: 'primary.main' }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={installMirrorCommand}>{installMirrorCommand}</Typography></Box></Box>)}
                                 </Stack>
                             )}
                         </Box></Stack>
@@ -446,7 +443,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                             <Typography variant="body2" fontWeight={500} color={!installDone ? 'text.disabled' : applyDone ? 'text.primary' : 'primary.main'}>
                                 Step 4 — {applyStepLabel}
                             </Typography>
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                            <Typography variant="body2" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
                                 {applyStepDescription ?? `One click to write the proxy configuration to ${agentName}'s settings file. Advanced users can review the config first.`}
                             </Typography>
                             <Collapse in={!applyDone}>
@@ -472,13 +469,13 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 <Alert severity={applyResult.success ? 'success' : 'error'} sx={{ mt: 1, py: 0.5 }}>
                                     {applyResult.success ? (
                                         <Box>
-                                            <Typography variant="caption" fontWeight={600}>{applySuccessLabel}</Typography>
+                                            <Typography variant="body2" fontWeight={600}>{applySuccessLabel}</Typography>
                                             {applyResult.files?.map(f => (
-                                                <Typography key={f} variant="caption" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>
+                                                <Typography key={f} variant="body2" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>{f}</Typography>
                                             ))}
                                         </Box>
                                     ) : (
-                                        <Typography variant="caption">{applyResult.error ?? 'Apply failed'}</Typography>
+                                        <Typography variant="body2">{applyResult.error ?? 'Apply failed'}</Typography>
                                     )}
                                 </Alert>
                             )}


### PR DESCRIPTION
## Summary
Replaced MUI Stepper component with a custom step indicator UI in AgentSetupCard, improving UX with inline step expansion and better visual feedback. Added a new ConnectProviderFlow component to streamline the provider connection workflow across agent setup pages.

## Key Changes

### AgentSetupCard Component (`frontend/src/pages/scenario/components/AgentSetupCard.tsx`)
- **Removed MUI Stepper**: Replaced the horizontal stepper with a custom step row layout that expands inline to show step-specific content
- **New StepIndicator component**: Custom circular step indicator showing step number or checkmark icon for completed steps
- **Simplified step logic**: Removed complex step navigation (handleNext, handleBack, handleSkip, stepCursor state) in favor of showing only the first incomplete step expanded
- **Improved UX copy**: Updated step labels and hints (e.g., "Connect AI Provider" instead of "Add a Provider", "Choose a model to continue")
- **Better visual hierarchy**: Each step now has its own collapsible section with consistent styling (stepRowSx) and clear action buttons
- **New onConnectProvider prop**: Added callback to trigger provider connection flow from the setup card
- **Cleaner state management**: Removed skipped steps tracking and step cursor navigation; now only tracks completion flags (providerDone, modelDone, installDone, applyDone)

### New ConnectProviderFlow Component (`frontend/src/components/ConnectProviderFlow.tsx`)
- Encapsulates the multi-step provider connection workflow (ConnectProviderDialog → ProviderFormDialog or OAuthDialog)
- Handles provider selection, form submission, and OAuth flow
- Provides success/error notifications and callbacks for parent components
- Reusable across all agent setup pages (Codex, Claude Code, VSCode, OpenCode)

### Integration Updates
- **UseCodexPage.tsx**: Added ConnectProviderFlow state and wired onConnectProvider callback
- **UseClaudeCodePage.tsx**: Added ConnectProviderFlow state and wired onConnectProvider callback
- **UseVSCodePage.tsx**: Added ConnectProviderFlow state and wired onConnectProvider callback
- **UseOpenCodePage.tsx**: Added ConnectProviderFlow state and wired onConnectProvider callback

## Implementation Details
- Step indicators use MUI's `alpha()` utility for subtle active state backgrounds
- Collapse animations provide smooth transitions between expanded/collapsed states
- Reset functionality preserved for manual progress clearing
- All step completion state persists to localStorage (INSTALL_DONE_KEY, APPLY_DONE_KEY)
- Provider count display shows number of connected providers with quick "Add" button

https://claude.ai/code/session_019KzdS81RFBf3Jkokse5CzY