### PR TITLE
feat(UI/UX): unify Connect AI flow, import integration, and action bar UX

### DIFF
--- a/frontend/src/components/AILogViewer.tsx
+++ b/frontend/src/components/AILogViewer.tsx
@@ -135,7 +135,7 @@ const SUPPRESSED_FIELDS = new Set([
 const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: RequestsViewerProps) => {
     const [requests, setRequests] = useState<ModelRequestSummary[]>([]);
     const [loading, setLoading] = useState(false);
-    const [autoRefresh, setAutoRefresh] = useState(true);
+    const [autoRefresh, setAutoRefresh] = useState(false);
     const [expandedId, setExpandedId] = useState<string | null>(null);
     const [details, setDetails] = useState<Record<string, ModelRequestDetail>>({});
     const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/AILogViewer.tsx
+++ b/frontend/src/components/AILogViewer.tsx
@@ -135,7 +135,7 @@ const SUPPRESSED_FIELDS = new Set([
 const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: RequestsViewerProps) => {
     const [requests, setRequests] = useState<ModelRequestSummary[]>([]);
     const [loading, setLoading] = useState(false);
-    const [autoRefresh, setAutoRefresh] = useState(false);
+    const [autoRefresh, setAutoRefresh] = useState(true);
     const [expandedId, setExpandedId] = useState<string | null>(null);
     const [details, setDetails] = useState<Record<string, ModelRequestDetail>>({});
     const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/ConnectProviderDialog.tsx
+++ b/frontend/src/components/ConnectProviderDialog.tsx
@@ -1,4 +1,4 @@
-import {Add, Close, Computer, Key, Login, Search, Language, Description} from '@/components/icons';
+import {Add, Close, Computer, Key, Login, Search, Language, Description, Upload} from '@/components/icons';
 import RegionBadge from './RegionBadge';
 import {
     Box,
@@ -26,7 +26,8 @@ export type ConnectSelection =
     | {kind: 'key'; provider: UniqueProvider}
     | {kind: 'oauth'; providerId: string}
     | {kind: 'local'; provider: UniqueProvider}
-    | {kind: 'custom'};
+    | {kind: 'custom'}
+    | {kind: 'import'};
 
 interface ConnectProviderDialogProps {
     open: boolean;
@@ -244,7 +245,7 @@ export const ProviderListContent: React.FC<ProviderListContentProps> = ({
     const filteredOAuth = needle
         ? oauthProviders.filter((p) => `${p.name} ${p.displayName}`.toLowerCase().includes(needle))
         : oauthProviders;
-    const showCustom = !needle || 'custom endpoint'.includes(needle);
+    const showCustom = !needle || 'custom endpoint import'.includes(needle);
 
     // Group key providers by region (CN vs Global vs Self-hosted)
     const {cnKeyProviders, globalKeyProviders, selfHostedProviders} = useMemo(() => {
@@ -321,6 +322,13 @@ export const ProviderListContent: React.FC<ProviderListContentProps> = ({
                                 meta="Any compatible API"
                                 badge={keyBadge}
                                 onClick={() => onSelect({kind: 'custom'})}
+                            />
+                            <ProviderCard
+                                icon={<Upload/>}
+                                name="Import"
+                                meta="From file or clipboard"
+                                badge={keyBadge}
+                                onClick={() => onSelect({kind: 'import'})}
                             />
                         </CardGrid>
                     </>

--- a/frontend/src/components/ConnectProviderFlow.tsx
+++ b/frontend/src/components/ConnectProviderFlow.tsx
@@ -33,6 +33,9 @@ const ConnectProviderFlow: React.FC<ConnectProviderFlowProps> = ({
             setOAuthDialogOpen(true);
             return;
         }
+        if (selection.kind === 'import') {
+            return;
+        }
         if (selection.kind === 'custom') {
             setIsLocalProvider(false);
             setProviderFormData({

--- a/frontend/src/components/EmptyStateGuide.tsx
+++ b/frontend/src/components/EmptyStateGuide.tsx
@@ -17,7 +17,7 @@ const EmptyStateGuide: React.FC<EmptyStateGuideProps> = ({
     description = "Get started by adding your first API key or OAuth provider to access AI services",
     showOAuthButton = true,
     showHeroIcon = true,
-    primaryButtonLabel = "Add API Key",
+    primaryButtonLabel = "Connect AI",
     secondaryButtonLabel = "Add OAuth",
     onAddApiKeyClick,
     onAddOAuthClick,

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -66,8 +66,14 @@ export const ImportModal = ({ open, onClose, onImport, loading = false }: Import
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-            <DialogTitle>Import Rule</DialogTitle>
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            maxWidth="sm"
+            fullWidth
+            PaperProps={{sx: {maxHeight: '82vh', display: 'flex', flexDirection: 'column'}}}
+        >
+            <DialogTitle>Import</DialogTitle>
             <DialogContent>
                 <Tabs
                     value={tabValue}

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -87,7 +87,7 @@ export const ImportModal = ({ open, onClose, onImport, loading = false }: Import
 
                 <TabPanel value={tabValue} index={0}>
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                        Paste the JSONL formatted rule export data below.
+                        Paste exported data in JSONL format below.
                     </Typography>
                     <TextField
                         fullWidth
@@ -103,7 +103,7 @@ export const ImportModal = ({ open, onClose, onImport, loading = false }: Import
 
                 <TabPanel value={tabValue} index={1}>
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                        Paste the base64 encoded rule export data below.
+                        Paste exported data in Base64 format below.
                     </Typography>
                     <TextField
                         fullWidth
@@ -119,7 +119,7 @@ export const ImportModal = ({ open, onClose, onImport, loading = false }: Import
 
                 <TabPanel value={tabValue} index={2}>
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                        Upload a file containing the rule export data (JSONL or Base64 format).
+                        Upload a file containing exported data (JSONL or Base64 format).
                     </Typography>
                     <Button
                         variant="outlined"

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -572,7 +572,8 @@ const ProviderFormDialog = ({
     // Persistent /v1 suffix hint: shown in custom mode when an OpenAI
     // protocol is selected and the current URL doesn't already end with /v1.
     const currentUrl = data.apiBase || providerInputValue;
-    const showV1Hint = customMode && protocolOpenAI && !!currentUrl.trim() && !(/\/v1\/?$/.test(currentUrl));
+    const showV1Hint = customMode && protocolOpenAI;
+    const urlAlreadyHasV1 = /\/v1\/?$/.test(currentUrl);
     const applyV1Suffix = () => {
         const base = currentUrl.replace(/\/+$/, '');
         const newUrl = `${base}/v1`;
@@ -624,23 +625,25 @@ const ProviderFormDialog = ({
                                     <Stack direction="row" alignItems="center" spacing={0.75}>
                                         <Typography variant="caption">
                                             {t('providerDialog.v1Hint.message', {
-                                                defaultValue: 'Most OpenAI-compatible APIs need /v1 suffix.',
+                                                defaultValue: 'Most OpenAI-compatible APIs need a /v1 suffix.',
                                             })}
                                         </Typography>
-                                        <Link
-                                            component="button"
-                                            type="button"
-                                            variant="caption"
-                                            onClick={applyV1Suffix}
-                                            sx={{
-                                                color: 'warning.light',
-                                                fontWeight: 700,
-                                                whiteSpace: 'nowrap',
-                                                textDecorationColor: 'inherit',
-                                            }}
-                                        >
-                                            {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
-                                        </Link>
+                                        {!urlAlreadyHasV1 && (
+                                            <Link
+                                                component="button"
+                                                type="button"
+                                                variant="caption"
+                                                onClick={applyV1Suffix}
+                                                underline="always"
+                                                sx={{
+                                                    color: 'inherit',
+                                                    fontWeight: 700,
+                                                    whiteSpace: 'nowrap',
+                                                }}
+                                            >
+                                                {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
+                                            </Link>
+                                        )}
                                     </Stack>
                                 }
                                 placement="top-end"
@@ -648,17 +651,6 @@ const ProviderFormDialog = ({
                                 disableFocusListener
                                 disableHoverListener
                                 disableTouchListener
-                                slotProps={{
-                                    tooltip: {
-                                        sx: {
-                                            bgcolor: 'grey.800',
-                                            maxWidth: 320,
-                                            py: 0.75,
-                                            px: 1.5,
-                                        },
-                                    },
-                                    arrow: { sx: { color: 'grey.800' } },
-                                }}
                             >
                                 <TextField
                                     size="small"

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -662,6 +662,7 @@ const ProviderFormDialog = ({
                                     },
                                     arrow: {
                                         sx: {
+                                            fontSize: 16,
                                             color: 'background.paper',
                                             '&::before': {
                                                 border: 1,

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -623,7 +623,7 @@ const ProviderFormDialog = ({
                                 open={showV1Hint}
                                 title={
                                     <Stack direction="row" alignItems="center" spacing={0.75}>
-                                        <Typography variant="caption">
+                                        <Typography variant="body2" color="text.secondary">
                                             {t('providerDialog.v1Hint.message', {
                                                 defaultValue: 'Most OpenAI-compatible APIs need a /v1 suffix.',
                                             })}
@@ -632,12 +632,11 @@ const ProviderFormDialog = ({
                                             <Link
                                                 component="button"
                                                 type="button"
-                                                variant="caption"
+                                                variant="body2"
                                                 onClick={applyV1Suffix}
                                                 underline="always"
                                                 sx={{
-                                                    color: 'inherit',
-                                                    fontWeight: 700,
+                                                    fontWeight: 600,
                                                     whiteSpace: 'nowrap',
                                                 }}
                                             >
@@ -651,6 +650,28 @@ const ProviderFormDialog = ({
                                 disableFocusListener
                                 disableHoverListener
                                 disableTouchListener
+                                slotProps={{
+                                    tooltip: {
+                                        sx: {
+                                            bgcolor: 'background.paper',
+                                            color: 'text.primary',
+                                            border: 1,
+                                            borderColor: 'divider',
+                                            boxShadow: 2,
+                                            px: 1.5,
+                                            py: 1,
+                                        },
+                                    },
+                                    arrow: {
+                                        sx: {
+                                            color: 'background.paper',
+                                            '&::before': {
+                                                border: 1,
+                                                borderColor: 'divider',
+                                            },
+                                        },
+                                    },
+                                }}
                             >
                                 <TextField
                                     size="small"

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -13,9 +13,11 @@ import {
     DialogTitle,
     FormControlLabel,
     IconButton,
+    Link,
     Stack,
     Switch,
     TextField,
+    Tooltip,
     Typography,
 } from '@mui/material';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -616,27 +618,70 @@ const ProviderFormDialog = ({
                         )}
 
                         {customMode ? (
-                            <TextField
-                                size="small"
-                                fullWidth
-                                label={t('providerDialog.provider.label')}
-                                placeholder={t('providerDialog.provider.customPlaceholder', {defaultValue: 'https://api.example.com/v1'})}
-                                value={providerInputValue}
-                                onChange={(e) => {
-                                    const val = e.target.value;
-                                    setProviderInputValue(val);
-                                    if (val.trim()) setBaseUrlError(false);
+                            <Tooltip
+                                open={showV1Hint}
+                                title={
+                                    <Stack direction="row" alignItems="center" spacing={0.75}>
+                                        <Typography variant="caption">
+                                            {t('providerDialog.v1Hint.message', {
+                                                defaultValue: 'Most OpenAI-compatible APIs need /v1 suffix.',
+                                            })}
+                                        </Typography>
+                                        <Link
+                                            component="button"
+                                            type="button"
+                                            variant="caption"
+                                            onClick={applyV1Suffix}
+                                            sx={{
+                                                color: 'warning.light',
+                                                fontWeight: 700,
+                                                whiteSpace: 'nowrap',
+                                                textDecorationColor: 'inherit',
+                                            }}
+                                        >
+                                            {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
+                                        </Link>
+                                    </Stack>
+                                }
+                                placement="top-end"
+                                arrow
+                                disableFocusListener
+                                disableHoverListener
+                                disableTouchListener
+                                slotProps={{
+                                    tooltip: {
+                                        sx: {
+                                            bgcolor: 'grey.800',
+                                            maxWidth: 320,
+                                            py: 0.75,
+                                            px: 1.5,
+                                        },
+                                    },
+                                    arrow: { sx: { color: 'grey.800' } },
                                 }}
-                                onBlur={() => {
-                                    if (data.apiBase !== providerInputValue) {
-                                        onChangeRef.current('apiBase', providerInputValue);
-                                        onChangeRef.current('providerBaseUrls', undefined);
-                                    }
-                                }}
-                                required
-                                error={baseUrlError}
-                                helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
-                            />
+                            >
+                                <TextField
+                                    size="small"
+                                    fullWidth
+                                    label={t('providerDialog.provider.label')}
+                                    placeholder={t('providerDialog.provider.customPlaceholder', {defaultValue: 'https://api.example.com/v1'})}
+                                    value={providerInputValue}
+                                    onChange={(e) => {
+                                        const val = e.target.value;
+                                        setProviderInputValue(val);
+                                        if (val.trim()) setBaseUrlError(false);
+                                    }}
+                                    onBlur={() => {
+                                        if (data.apiBase !== providerInputValue) {
+                                            onChangeRef.current('apiBase', providerInputValue);
+                                            onChangeRef.current('providerBaseUrls', undefined);
+                                        }
+                                    }}
+                                    required
+                                    error={baseUrlError}
+                                    helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
+                                />
+                            </Tooltip>
                         ) : (
                             <ProviderAutocomplete
                                 options={allProviders}
@@ -649,48 +694,6 @@ const ProviderFormDialog = ({
                                 error={baseUrlError}
                                 helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
                             />
-                        )}
-
-                        {showV1Hint && (
-                            <Stack
-                                direction="row"
-                                alignItems="center"
-                                spacing={1}
-                                sx={{
-                                    mt: -1.5,
-                                    px: 1.5,
-                                    py: 0.75,
-                                    borderRadius: 1,
-                                    bgcolor: (theme) => theme.palette.mode === 'dark'
-                                        ? 'rgba(255, 167, 38, 0.08)'
-                                        : 'rgba(237, 108, 2, 0.06)',
-                                    border: '1px dashed',
-                                    borderColor: 'warning.main',
-                                }}
-                            >
-                                <InfoOutlined sx={{fontSize: 15, color: 'warning.main', flexShrink: 0}}/>
-                                <Typography variant="caption" color="text.secondary" sx={{flex: 1, lineHeight: 1.4}}>
-                                    {t('providerDialog.v1Hint.message', {
-                                        defaultValue: 'Most OpenAI-compatible APIs require a /v1 suffix',
-                                    })}
-                                </Typography>
-                                <Button
-                                    size="small"
-                                    variant="text"
-                                    color="warning"
-                                    onClick={applyV1Suffix}
-                                    sx={{
-                                        minWidth: 'auto',
-                                        whiteSpace: 'nowrap',
-                                        px: 1,
-                                        py: 0.25,
-                                        fontSize: '0.75rem',
-                                        fontWeight: 600,
-                                    }}
-                                >
-                                    {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
-                                </Button>
-                            </Stack>
                         )}
 
                         <ApiKeyField

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -70,6 +70,9 @@ interface PresetProviderFormDialogProps {
     isFirstProvider?: boolean;
     /** Pass true for local providers: token field stays editable but is not required. */
     optionalEditableToken?: boolean;
+    /** When true, the user entered via "Custom endpoint" — hide the provider
+     *  dropdown and show a plain URL text field instead. */
+    customMode?: boolean;
 }
 
 const ProviderFormDialog = ({
@@ -84,6 +87,7 @@ const ProviderFormDialog = ({
                                 submitText,
                                 isFirstProvider = false,
                                 optionalEditableToken = false,
+                                customMode = false,
                             }: PresetProviderFormDialogProps) => {
     const {t} = useTranslation();
     const defaultTitle = mode === 'add' ? t('providerDialog.addTitle') : t('providerDialog.editTitle');
@@ -599,17 +603,41 @@ const ProviderFormDialog = ({
                             </Alert>
                         )}
 
-                        <ProviderAutocomplete
-                            options={allProviders}
-                            value={selectedProvider}
-                            inputValue={providerInputValue}
-                            onChange={handleProviderSelect}
-                            onInputChange={handleProviderInputChange}
-                            onBlur={handleProviderInputBlur}
-                            required
-                            error={baseUrlError}
-                            helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
-                        />
+                        {customMode ? (
+                            <TextField
+                                size="small"
+                                fullWidth
+                                label={t('providerDialog.provider.label')}
+                                placeholder={t('providerDialog.provider.customPlaceholder', {defaultValue: 'https://api.example.com/v1'})}
+                                value={providerInputValue}
+                                onChange={(e) => {
+                                    const val = e.target.value;
+                                    setProviderInputValue(val);
+                                    if (val.trim()) setBaseUrlError(false);
+                                }}
+                                onBlur={() => {
+                                    if (data.apiBase !== providerInputValue) {
+                                        onChangeRef.current('apiBase', providerInputValue);
+                                        onChangeRef.current('providerBaseUrls', undefined);
+                                    }
+                                }}
+                                required
+                                error={baseUrlError}
+                                helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
+                            />
+                        ) : (
+                            <ProviderAutocomplete
+                                options={allProviders}
+                                value={selectedProvider}
+                                inputValue={providerInputValue}
+                                onChange={handleProviderSelect}
+                                onInputChange={handleProviderInputChange}
+                                onBlur={handleProviderInputBlur}
+                                required
+                                error={baseUrlError}
+                                helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
+                            />
+                        )}
 
                         <ApiKeyField
                             mode={mode}
@@ -699,6 +727,18 @@ const ProviderFormDialog = ({
                             <VerificationResultPanel
                                 result={verificationResult}
                                 onClose={() => setVerificationResult(null)}
+                                v1Hint={{
+                                    show: !verificationResult.success
+                                        && protocolOpenAI
+                                        && !(/\/v1\/?$/.test(data.apiBase || providerInputValue)),
+                                    onApply: () => {
+                                        const base = (data.apiBase || providerInputValue).replace(/\/+$/, '');
+                                        const newUrl = `${base}/v1`;
+                                        setProviderInputValue(newUrl);
+                                        onChangeRef.current('apiBase', newUrl);
+                                        setVerificationResult(null);
+                                    },
+                                }}
                             />
                         )}
 

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -572,8 +572,8 @@ const ProviderFormDialog = ({
     // Persistent /v1 suffix hint: shown in custom mode when an OpenAI
     // protocol is selected and the current URL doesn't already end with /v1.
     const currentUrl = data.apiBase || providerInputValue;
-    const showV1Hint = customMode && protocolOpenAI;
     const urlAlreadyHasV1 = /\/v1\/?$/.test(currentUrl);
+    const showV1Hint = customMode && protocolOpenAI && !urlAlreadyHasV1;
     const applyV1Suffix = () => {
         const base = currentUrl.replace(/\/+$/, '');
         const newUrl = `${base}/v1`;
@@ -628,24 +628,22 @@ const ProviderFormDialog = ({
                                                 defaultValue: 'Most OpenAI-compatible APIs need a /v1 suffix.',
                                             })}
                                         </Typography>
-                                        {!urlAlreadyHasV1 && (
-                                            <Link
-                                                component="button"
-                                                type="button"
-                                                variant="body2"
-                                                onClick={applyV1Suffix}
-                                                underline="always"
-                                                sx={{
-                                                    fontWeight: 600,
-                                                    whiteSpace: 'nowrap',
-                                                }}
-                                            >
-                                                {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
-                                            </Link>
-                                        )}
+                                        <Link
+                                            component="button"
+                                            type="button"
+                                            variant="body2"
+                                            onClick={applyV1Suffix}
+                                            underline="always"
+                                            sx={{
+                                                fontWeight: 600,
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
+                                        </Link>
                                     </Stack>
                                 }
-                                placement="top-end"
+                                placement="top"
                                 arrow
                                 disableFocusListener
                                 disableHoverListener

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -567,6 +567,18 @@ const ProviderFormDialog = ({
 
     const hasAnyProtocol = protocolOpenAI || protocolAnthropic;
 
+    // Persistent /v1 suffix hint: shown in custom mode when an OpenAI
+    // protocol is selected and the current URL doesn't already end with /v1.
+    const currentUrl = data.apiBase || providerInputValue;
+    const showV1Hint = customMode && protocolOpenAI && !!currentUrl.trim() && !(/\/v1\/?$/.test(currentUrl));
+    const applyV1Suffix = () => {
+        const base = currentUrl.replace(/\/+$/, '');
+        const newUrl = `${base}/v1`;
+        setProviderInputValue(newUrl);
+        onChangeRef.current('apiBase', newUrl);
+        setVerificationResult(null);
+    };
+
     // When both protocols are checked on a template that exposes two base URLs,
     // the outcome ("merge into one" vs "create two") is otherwise invisible.
     // Surface it as a one-line hint that tracks the fusion toggle.
@@ -637,6 +649,48 @@ const ProviderFormDialog = ({
                                 error={baseUrlError}
                                 helperText={baseUrlError ? t('providerDialog.provider.required', {defaultValue: 'Base URL is required'}) : undefined}
                             />
+                        )}
+
+                        {showV1Hint && (
+                            <Stack
+                                direction="row"
+                                alignItems="center"
+                                spacing={1}
+                                sx={{
+                                    mt: -1.5,
+                                    px: 1.5,
+                                    py: 0.75,
+                                    borderRadius: 1,
+                                    bgcolor: (theme) => theme.palette.mode === 'dark'
+                                        ? 'rgba(255, 167, 38, 0.08)'
+                                        : 'rgba(237, 108, 2, 0.06)',
+                                    border: '1px dashed',
+                                    borderColor: 'warning.main',
+                                }}
+                            >
+                                <InfoOutlined sx={{fontSize: 15, color: 'warning.main', flexShrink: 0}}/>
+                                <Typography variant="caption" color="text.secondary" sx={{flex: 1, lineHeight: 1.4}}>
+                                    {t('providerDialog.v1Hint.message', {
+                                        defaultValue: 'Most OpenAI-compatible APIs require a /v1 suffix',
+                                    })}
+                                </Typography>
+                                <Button
+                                    size="small"
+                                    variant="text"
+                                    color="warning"
+                                    onClick={applyV1Suffix}
+                                    sx={{
+                                        minWidth: 'auto',
+                                        whiteSpace: 'nowrap',
+                                        px: 1,
+                                        py: 0.25,
+                                        fontSize: '0.75rem',
+                                        fontWeight: 600,
+                                    }}
+                                >
+                                    {t('providerDialog.v1Hint.apply', {defaultValue: 'Append /v1'})}
+                                </Button>
+                            </Stack>
                         )}
 
                         <ApiKeyField

--- a/frontend/src/components/RuleLogDialog.tsx
+++ b/frontend/src/components/RuleLogDialog.tsx
@@ -22,7 +22,7 @@ const ScenarioLogDialog = ({ open, onClose, scenario, initialScenario }: Scenari
             <DialogTitle sx={{ pb: 1 }}>
                 <Stack direction="row" alignItems="center" justifyContent="space-between">
                     <Stack direction="row" alignItems="center" spacing={1}>
-                        <Typography variant="h6">Logs</Typography>
+                        <Typography variant="h6">Troubleshoot</Typography>
                         <Chip label={scenario} size="small" variant="outlined" sx={{ fontSize: '0.72rem', height: 22 }} />
                     </Stack>
                     <IconButton size="small" onClick={onClose}>

--- a/frontend/src/components/RuleLogDialog.tsx
+++ b/frontend/src/components/RuleLogDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import { Close as CloseIcon } from '@/components/icons';
 import LogExplorer from '@/components/LogExplorer';
+import { useTranslation } from 'react-i18next';
 
 interface ScenarioLogDialogProps {
     open: boolean;
@@ -17,12 +18,13 @@ interface ScenarioLogDialogProps {
 }
 
 const ScenarioLogDialog = ({ open, onClose, scenario, initialScenario }: ScenarioLogDialogProps) => {
+    const { t } = useTranslation();
     return (
         <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth PaperProps={{ sx: { height: '80vh' } }}>
             <DialogTitle sx={{ pb: 1 }}>
                 <Stack direction="row" alignItems="center" justifyContent="space-between">
                     <Stack direction="row" alignItems="center" spacing={1}>
-                        <Typography variant="h6">Troubleshoot</Typography>
+                        <Typography variant="h6">{t('templateActions.troubleshoot')}</Typography>
                         <Chip label={scenario} size="small" variant="outlined" sx={{ fontSize: '0.72rem', height: 22 }} />
                     </Stack>
                     <IconButton size="small" onClick={onClose}>

--- a/frontend/src/components/SystemLogViewer.tsx
+++ b/frontend/src/components/SystemLogViewer.tsx
@@ -55,7 +55,7 @@ const SystemLogViewer = ({ getLogs, getRequestBody }: SystemLogViewerProps) => {
     // Multi-select level filter: empty set = show all
     const [selectedLevels, setSelectedLevels] = useState<Set<string>>(new Set());
     const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
-    const [autoRefresh, setAutoRefresh] = useState(true);
+    const [autoRefresh, setAutoRefresh] = useState(false);
     const tableContainerRef = useRef<HTMLDivElement>(null);
     // Sorting state
     const [sortField, setSortField] = useState<SortField>('time');

--- a/frontend/src/components/SystemLogViewer.tsx
+++ b/frontend/src/components/SystemLogViewer.tsx
@@ -55,7 +55,7 @@ const SystemLogViewer = ({ getLogs, getRequestBody }: SystemLogViewerProps) => {
     // Multi-select level filter: empty set = show all
     const [selectedLevels, setSelectedLevels] = useState<Set<string>>(new Set());
     const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
-    const [autoRefresh, setAutoRefresh] = useState(false);
+    const [autoRefresh, setAutoRefresh] = useState(true);
     const tableContainerRef = useRef<HTMLDivElement>(null);
     // Sorting state
     const [sortField, setSortField] = useState<SortField>('time');

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -109,6 +109,8 @@ import {
     IconList,
     IconNavigation,
     IconBrain,
+    IconFoldDown,
+    IconFoldUp,
 } from '@tabler/icons-react';
 import { tablerMui } from './tablerMui';
 
@@ -220,6 +222,8 @@ export const DataUsage = tablerMui(IconChartDonut);
 export const Route = tablerMui(IconRoute);
 export const Router = tablerMui(IconRouter);
 export const UnfoldMore = tablerMui(IconSelector);
+export const FoldDown = tablerMui(IconFoldDown);
+export const FoldUp = tablerMui(IconFoldUp);
 export const Speed = tablerMui(IconGauge);
 export const Stream = tablerMui(IconActivity);
 export const Build = tablerMui(IconTool);

--- a/frontend/src/components/providerFormDialog/VerificationResultPanel.tsx
+++ b/frontend/src/components/providerFormDialog/VerificationResultPanel.tsx
@@ -1,14 +1,16 @@
 import {Check, Close} from '@/components/icons';
-import {Box, IconButton, Stack, Typography} from '@mui/material';
+import {Box, Button, IconButton, Stack, Typography} from '@mui/material';
 import React from 'react';
 import type {VerificationResult} from './probe';
 
 interface VerificationResultPanelProps {
     result: VerificationResult;
     onClose: () => void;
+    /** When the probe fails on an OpenAI URL without /v1, suggest appending it. */
+    v1Hint?: { show: boolean; onApply: () => void };
 }
 
-const VerificationResultPanel: React.FC<VerificationResultPanelProps> = ({result, onClose}) => {
+const VerificationResultPanel: React.FC<VerificationResultPanelProps> = ({result, onClose, v1Hint}) => {
     const details = (result.details ?? '').split(' • ').filter(d => d.trim());
 
     return (
@@ -97,6 +99,22 @@ const VerificationResultPanel: React.FC<VerificationResultPanelProps> = ({result
                     );
                 })}
             </Stack>
+
+            {v1Hint?.show && (
+                <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={1}
+                    sx={{mt: 1.5, p: 1, borderRadius: 1, bgcolor: 'warning.lighter', border: '1px solid', borderColor: 'warning.light'}}
+                >
+                    <Typography variant="caption" sx={{flex: 1}}>
+                        Some OpenAI-compatible APIs require a <code>/v1</code> suffix on the base URL.
+                    </Typography>
+                    <Button size="small" variant="outlined" color="warning" onClick={v1Hint.onApply} sx={{whiteSpace: 'nowrap', minWidth: 'auto'}}>
+                        Try /v1
+                    </Button>
+                </Stack>
+            )}
 
             <Typography
                 variant="caption"

--- a/frontend/src/components/providerFormDialog/VerificationResultPanel.tsx
+++ b/frontend/src/components/providerFormDialog/VerificationResultPanel.tsx
@@ -1,5 +1,5 @@
 import {Check, Close} from '@/components/icons';
-import {Box, Button, IconButton, Stack, Typography} from '@mui/material';
+import {Box, Button, IconButton, Stack, Typography, alpha} from '@mui/material';
 import React from 'react';
 import type {VerificationResult} from './probe';
 
@@ -105,7 +105,7 @@ const VerificationResultPanel: React.FC<VerificationResultPanelProps> = ({result
                     direction="row"
                     alignItems="center"
                     spacing={1}
-                    sx={{mt: 1.5, p: 1, borderRadius: 1, bgcolor: 'warning.lighter', border: '1px solid', borderColor: 'warning.light'}}
+                    sx={{mt: 1.5, p: 1, borderRadius: 1, bgcolor: (theme) => alpha(theme.palette.warning.main, 0.08), border: '1px solid', borderColor: 'warning.light'}}
                 >
                     <Typography variant="caption" sx={{flex: 1}}>
                         Some OpenAI-compatible APIs require a <code>/v1</code> suffix on the base URL.

--- a/frontend/src/hooks/useModelSelectDialog.tsx
+++ b/frontend/src/hooks/useModelSelectDialog.tsx
@@ -317,7 +317,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
                 {mode === 'create-rule'
                     ? 'Select a model for your new rule'
                     : mode === 'add'
-                        ? 'Add API Key'
+                        ? 'Connect AI'
                         : 'Choose Model'}
             </DialogTitle>
             <DialogContent>

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { api } from '../services/api';
 import type { EnhancedProviderFormData } from '@/components/ProviderFormDialog';
+import type { ConnectSelection } from '@/components/ConnectProviderDialog';
 
 interface UseProviderDialogOptions {
     defaultApiStyle?: 'openai' | 'anthropic' | undefined;
@@ -10,12 +11,29 @@ interface UseProviderDialogOptions {
 interface UseProviderDialogReturn {
     providerDialogOpen: boolean;
     providerFormData: EnhancedProviderFormData;
+    /** @deprecated Use handleConnectAIClick to open the picker instead. */
     handleAddProviderClick: () => void;
     handleProviderSubmit: (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => Promise<void>;
     handleProviderForceAdd: () => Promise<void>;
     handleCloseDialog: () => void;
     handleFieldChange: (field: keyof EnhancedProviderFormData, value: any) => void;
+    connectDialogOpen: boolean;
+    handleConnectAIClick: () => void;
+    handleConnectSelect: (selection: ConnectSelection) => void;
+    handleCloseConnect: () => void;
+    customMode: boolean;
+    fromConnectPicker: boolean;
 }
+
+const emptyForm = (apiStyle?: 'openai' | 'anthropic'): EnhancedProviderFormData => ({
+    name: '',
+    apiBase: '',
+    apiStyle: apiStyle || undefined,
+    token: '',
+    enabled: true,
+    noKeyRequired: false,
+    proxyUrl: '',
+});
 
 export const useProviderDialog = (
     showNotification: (message: string, severity: 'success' | 'error') => void,
@@ -24,28 +42,75 @@ export const useProviderDialog = (
     const { defaultApiStyle, onProviderAdded } = options;
 
     const [providerDialogOpen, setProviderDialogOpen] = useState(false);
-    const [providerFormData, setProviderFormData] = useState<EnhancedProviderFormData>({
-        name: '',
-        apiBase: '',
-        apiStyle: defaultApiStyle || undefined,
-        token: '',
-        enabled: true,
-        noKeyRequired: false,
-        proxyUrl: '',
-    });
+    const [connectDialogOpen, setConnectDialogOpen] = useState(false);
+    const [customMode, setCustomMode] = useState(false);
+    const [fromConnectPicker, setFromConnectPicker] = useState(false);
+    const [providerFormData, setProviderFormData] = useState<EnhancedProviderFormData>(emptyForm(defaultApiStyle));
 
     const handleAddProviderClick = () => {
+        setProviderFormData(emptyForm(defaultApiStyle));
+        setCustomMode(false);
+        setFromConnectPicker(false);
+        setProviderDialogOpen(true);
+    };
+
+    const handleConnectAIClick = useCallback(() => {
+        setConnectDialogOpen(true);
+    }, []);
+
+    const handleCloseConnect = useCallback(() => {
+        setConnectDialogOpen(false);
+    }, []);
+
+    const handleConnectSelect = useCallback((selection: ConnectSelection) => {
+        setConnectDialogOpen(false);
+        setFromConnectPicker(true);
+
+        if (selection.kind === 'oauth') {
+            return;
+        }
+
+        if (selection.kind === 'custom') {
+            setCustomMode(true);
+            setProviderFormData(emptyForm(defaultApiStyle));
+            setProviderDialogOpen(true);
+            return;
+        }
+
+        if (selection.kind === 'local') {
+            const lp = selection.provider as any;
+            setCustomMode(false);
+            setProviderFormData({
+                name: lp.alias || lp.name,
+                apiBase: lp.url || lp.baseUrlOpenAI || lp.baseUrlAnthropic || '',
+                apiStyle: 'openai',
+                token: lp.defaultApiKey ?? '',
+                enabled: true,
+                noKeyRequired: !lp.defaultApiKey,
+            });
+            setProviderDialogOpen(true);
+            return;
+        }
+
+        const p = selection.provider;
+        setCustomMode(false);
         setProviderFormData({
-            name: '',
-            apiBase: '',
-            apiStyle: defaultApiStyle || undefined,
+            name: p.alias || p.name,
+            apiBase: p.baseUrlOpenAI || p.baseUrlAnthropic || '',
+            apiStyle: undefined,
             token: '',
             enabled: true,
             noKeyRequired: false,
             proxyUrl: '',
+            userAgent: '',
+            createFusionProvider: false,
+            providerBaseUrls: { openai: p.baseUrlOpenAI, anthropic: p.baseUrlAnthropic },
+            protocols: p.supportsOpenAI && p.supportsAnthropic
+                ? ['openai', 'anthropic']
+                : p.supportsOpenAI ? ['openai'] : ['anthropic'],
         });
         setProviderDialogOpen(true);
-    };
+    }, [defaultApiStyle]);
 
     const handleProviderSubmit = async (e: React.FormEvent, resolved?: Partial<EnhancedProviderFormData>) => {
         e.preventDefault();
@@ -67,11 +132,11 @@ export const useProviderDialog = (
         const result = await api.addProvider(providerData);
 
         if (result.success) {
-            showNotification('API Key added successfully!', 'success');
+            showNotification('Provider connected successfully!', 'success');
             setProviderDialogOpen(false);
             onProviderAdded?.();
         } else {
-            showNotification(`Failed to add API Key: ${result.error}`, 'error');
+            showNotification(`Failed to connect provider: ${result.error}`, 'error');
         }
     };
 
@@ -95,17 +160,19 @@ export const useProviderDialog = (
         console.log('addProvider result:', result);
 
         if (result.success) {
-            showNotification('API Key added successfully!', 'success');
+            showNotification('Provider connected successfully!', 'success');
             setProviderDialogOpen(false);
             onProviderAdded?.();
         } else {
             console.error('Force add failed:', result);
-            showNotification(`Failed to add API Key: ${result.error}`, 'error');
+            showNotification(`Failed to connect provider: ${result.error}`, 'error');
         }
     };
 
     const handleCloseDialog = () => {
         setProviderDialogOpen(false);
+        setCustomMode(false);
+        setFromConnectPicker(false);
     };
 
     const handleFieldChange = (field: keyof EnhancedProviderFormData, value: any) => {
@@ -120,5 +187,11 @@ export const useProviderDialog = (
         handleProviderForceAdd,
         handleCloseDialog,
         handleFieldChange,
+        connectDialogOpen,
+        handleConnectAIClick,
+        handleConnectSelect,
+        handleCloseConnect,
+        customMode,
+        fromConnectPicker,
     };
 };

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -6,6 +6,7 @@ import type { ConnectSelection } from '@/components/ConnectProviderDialog';
 interface UseProviderDialogOptions {
     defaultApiStyle?: 'openai' | 'anthropic' | undefined;
     onProviderAdded?: () => void;
+    onImport?: () => void;
 }
 
 interface UseProviderDialogReturn {
@@ -39,7 +40,7 @@ export const useProviderDialog = (
     showNotification: (message: string, severity: 'success' | 'error') => void,
     options: UseProviderDialogOptions = {}
 ): UseProviderDialogReturn => {
-    const { defaultApiStyle, onProviderAdded } = options;
+    const { defaultApiStyle, onProviderAdded, onImport } = options;
 
     const [providerDialogOpen, setProviderDialogOpen] = useState(false);
     const [connectDialogOpen, setConnectDialogOpen] = useState(false);
@@ -67,6 +68,11 @@ export const useProviderDialog = (
         setFromConnectPicker(true);
 
         if (selection.kind === 'oauth') {
+            return;
+        }
+
+        if (selection.kind === 'import') {
+            onImport?.();
             return;
         }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -175,7 +175,7 @@ export default {
     "emptyState": {
       "title": "No API Keys Available",
       "description": "Get started by adding your first AI API Key to use the service.",
-      "button": "Add Your First API Key"
+      "button": "Connect Your First AI"
     },
     "token": {
       "generated": "{{label}} copied to clipboard!",
@@ -197,10 +197,10 @@ export default {
     "pageTitle": "Credentials",
     "subtitleWithCount": "Managing {{count}} providers and API keys",
     "subtitleEmpty": "No API keys configured yet",
-    "addButton": "Add API Key",
+    "addButton": "Connect AI",
     "emptyCardTitle": "No Model API Key Configured",
-    "emptyCardSubtitle": "Get started by adding your first API token or key",
-    "emptyCardButton": "Add Your First Provider",
+    "emptyCardSubtitle": "Get started by connecting your first AI provider",
+    "emptyCardButton": "Connect Your First Provider",
     "emptyCardContent": "Configure your API tokens and keys to access AI services",
     "notifications": {
       "loadFailed": "Failed to load providers: {{error}}",
@@ -215,10 +215,10 @@ export default {
     }
   },
   "providerDialog": {
-    "addTitle": "Add New API Key",
+    "addTitle": "Connect AI",
     "addDescription": "Select a provider and enter your API key to connect AI services. Multiple protocols can be enabled for providers that support them.",
-    "editTitle": "Edit API Key",
-    "addButton": "Add API Key",
+    "editTitle": "Edit Connection",
+    "addButton": "Connect",
     "apiStyle": {
       "label": "API Style",
       "placeholder": "Select API style...",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -121,7 +121,7 @@ export default {
     "system": "System",
     "general": "General",
     "experimental": "Experimental",
-    "logs": "Logs",
+    "logs": "Troubleshoot",
     "userRequest": "User Request",
     "skills": "Skills",
     "addProfile": "Add Profile",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -333,6 +333,16 @@ export default {
       "closeTooltip": "Close"
     }
   },
+  "templateActions": {
+    "troubleshoot": "Troubleshoot",
+    "collapse": "Collapse",
+    "expand": "Expand",
+    "collapseAllRules": "Collapse all rules",
+    "expandAllRules": "Expand all rules",
+    "connectAI": "Connect AI",
+    "newRule": "New Rule",
+    "createNewRule": "Create new routing rule"
+  },
   "rule": {
     "pageTitle": "Advanced Proxy Configuration",
     "subtitle": "Configure local models to forward requests to remote providers",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -335,8 +335,6 @@ export default {
   },
   "templateActions": {
     "troubleshoot": "Troubleshoot",
-    "collapse": "Collapse",
-    "expand": "Expand",
     "collapseAllRules": "Collapse all rules",
     "expandAllRules": "Expand all rules",
     "connectAI": "Connect AI",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -122,7 +122,7 @@ export default {
     "system": "系统",
     "general": "通用",
     "experimental": "实验功能",
-    "logs": "日志",
+    "logs": "错误检查",
     "userRequest": "用户请求",
     "skills": "技能",
     "addProfile": "添加配置文件",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -334,6 +334,16 @@ export default {
       "closeTooltip": "关闭"
     }
   },
+  "templateActions": {
+    "troubleshoot": "错误检查",
+    "collapse": "收起",
+    "expand": "展开",
+    "collapseAllRules": "收起所有规则",
+    "expandAllRules": "展开所有规则",
+    "connectAI": "连接 AI",
+    "newRule": "新建规则",
+    "createNewRule": "创建新的路由规则"
+  },
   "rule": {
     "pageTitle": "高级代理配置",
     "subtitle": "配置本地模型以将请求转发到远程提供商",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -176,7 +176,7 @@ export default {
     "emptyState": {
       "title": "没有可用的 API 密钥",
       "description": "添加您的第一个 AI API 密钥以开始使用服务。",
-      "button": "添加您的第一个 API 密钥"
+      "button": "连接您的第一个 AI"
     },
     "token": {
       "generated": "{{label}} 已复制到剪贴板！",
@@ -198,10 +198,10 @@ export default {
     "pageTitle": "凭证",
     "subtitleWithCount": "正在管理 {{count}} 个提供商和 API 密钥",
     "subtitleEmpty": "尚未配置 API 密钥",
-    "addButton": "添加 API 密钥",
+    "addButton": "连接 AI",
     "emptyCardTitle": "未配置模型 API 密钥",
-    "emptyCardSubtitle": "添加您的第一个 API 令牌或密钥以开始使用",
-    "emptyCardButton": "添加您的第一个提供商",
+    "emptyCardSubtitle": "连接您的第一个 AI 提供商以开始使用",
+    "emptyCardButton": "连接您的第一个提供商",
     "emptyCardContent": "配置您的 API 令牌和密钥以访问 AI 服务",
     "notifications": {
       "loadFailed": "加载提供商失败：{{error}}",
@@ -216,10 +216,10 @@ export default {
     }
   },
   "providerDialog": {
-    "addTitle": "添加新的 API 密钥",
+    "addTitle": "连接 AI",
     "addDescription": "选择提供商并输入您的 API 密钥以连接 AI 服务。支持多种协议的提供商可以启用多个协议。",
-    "editTitle": "编辑 API 密钥",
-    "addButton": "添加 API 密钥",
+    "editTitle": "编辑连接",
+    "addButton": "连接",
     "apiStyle": {
       "label": "API 风格",
       "placeholder": "选择 API 风格...",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -218,7 +218,7 @@ export default {
   "providerDialog": {
     "addTitle": "连接 AI",
     "addDescription": "选择提供商并输入您的 API 密钥以连接 AI 服务。支持多种协议的提供商可以启用多个协议。",
-    "editTitle": "编辑连接",
+    "editTitle": "修改连接",
     "addButton": "连接",
     "apiStyle": {
       "label": "API 风格",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -336,8 +336,6 @@ export default {
   },
   "templateActions": {
     "troubleshoot": "错误检查",
-    "collapse": "收起",
-    "expand": "展开",
     "collapseAllRules": "收起所有规则",
     "expandAllRules": "展开所有规则",
     "connectAI": "连接 AI",

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -149,6 +149,10 @@ const CredentialPage = () => {
             setOAuthDialogOpen(true);
             return;
         }
+        if (selection.kind === 'import') {
+            setShowImportModal(true);
+            return;
+        }
         if (selection.kind === 'custom') {
             setFromConnectPicker(true);
             setIsCustomMode(true);

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -55,6 +55,7 @@ const CredentialPage = () => {
 
     const [isLocalProvider, setIsLocalProvider] = useState(false);
     const [fromConnectPicker, setFromConnectPicker] = useState(false);
+    const [isCustomMode, setIsCustomMode] = useState(false);
 
     // OAuth Dialog state
     const [oauthDialogOpen, setOAuthDialogOpen] = useState(false);
@@ -150,6 +151,7 @@ const CredentialPage = () => {
         }
         if (selection.kind === 'custom') {
             setFromConnectPicker(true);
+            setIsCustomMode(true);
             handleAddApiKey();
             return;
         }
@@ -613,7 +615,7 @@ const CredentialPage = () => {
                             description="Configure API keys to access AI services like OpenAI, Anthropic, etc."
                             showOAuthButton={false}
                             showHeroIcon={false}
-                            primaryButtonLabel="Add API Key"
+                            primaryButtonLabel="Connect AI"
                             onAddApiKeyClick={handleAddApiKey}
                         />
                     )}
@@ -624,7 +626,7 @@ const CredentialPage = () => {
             {/* API Key Provider Dialog */}
             <ProviderFormDialog
                 open={apiKeyDialogOpen}
-                onClose={() => { setApiKeyDialogOpen(false); setIsLocalProvider(false); setFromConnectPicker(false); }}
+                onClose={() => { setApiKeyDialogOpen(false); setIsLocalProvider(false); setFromConnectPicker(false); setIsCustomMode(false); }}
                 onBack={fromConnectPicker ? () => setConnectOpen(true) : undefined}
                 onSubmit={handleProviderSubmit}
                 onForceAdd={handleProviderForceAdd}
@@ -632,6 +634,7 @@ const CredentialPage = () => {
                 onChange={handleProviderFormChange}
                 mode={apiKeyDialogMode}
                 optionalEditableToken={isLocalProvider}
+                customMode={isCustomMode}
             />
 
             {/* Unified provider picker */}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -52,6 +52,7 @@ const Onboarding: React.FC = () => {
     const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
     const [providerFormData, setProviderFormData] = useState<ProviderFormData>(emptyForm());
     const [isLocalProvider, setIsLocalProvider] = useState(false);
+    const [isCustomMode, setIsCustomMode] = useState(false);
 
     // OAuth Dialog state
     const [oauthDialogOpen, setOAuthDialogOpen] = useState(false);
@@ -86,6 +87,7 @@ const Onboarding: React.FC = () => {
         }
 
         if (selection.kind === 'custom') {
+            setIsCustomMode(true);
             openDialogWith(emptyForm());
             return;
         }
@@ -226,6 +228,7 @@ const Onboarding: React.FC = () => {
                 onClose={() => {
                     setApiKeyDialogOpen(false);
                     setIsLocalProvider(false);
+                    setIsCustomMode(false);
                 }}
                 onSubmit={handleSubmit}
                 onForceAdd={handleForceAdd}
@@ -234,6 +237,7 @@ const Onboarding: React.FC = () => {
                 mode="add"
                 isFirstProvider
                 optionalEditableToken={isLocalProvider}
+                customMode={isCustomMode}
             />
 
             {/* OAuth Add Dialog - now functional in onboarding */}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -86,6 +86,10 @@ const Onboarding: React.FC = () => {
             return;
         }
 
+        if (selection.kind === 'import') {
+            return;
+        }
+
         if (selection.kind === 'custom') {
             setIsCustomMode(true);
             openDialogWith(emptyForm());

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -282,7 +282,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 </Typography>
                             )}
                             {providerDone && onConnectProvider && (
-                                <Button size="small" variant="text" onClick={onConnectProvider} sx={{ py: 0, textTransform: 'none', minWidth: 0 }}>+ Add</Button>
+                                <Button size="small" variant="text" onClick={onConnectProvider} sx={{ py: 0, textTransform: 'none', minWidth: 0 }}>+ Connect</Button>
                             )}
                         </Stack>
                         <Collapse in={!providerDone && firstIncomplete === 0}>

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -178,6 +178,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         onProviderAdded: () => {
             void onProvidersLoad?.();
         },
+        onImport: () => setShowImportModal(true),
     });
 
     const handleAddApiKeyClick = useCallback(() => {
@@ -336,8 +337,6 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
             allowAddRule={allowAddRule}
             onCreateRule={handleCreateRule}
             showExpandCollapseButton={showExpandCollapseButton}
-            showImportButton={showImportButton}
-            onImportFromClipboard={handleImportFromClipboard}
             onViewLogs={scenario ? () => setLogDialogOpen(true) : undefined}
             scenario={scenario}
         />

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -8,6 +8,7 @@ import EmptyStateGuide from '@/components/EmptyStateGuide';
 import RuleCard from '@/components/RuleCard.tsx';
 import ImportModal from '@/components/ImportModal';
 import ProviderFormDialog from '@/components/ProviderFormDialog';
+import ConnectProviderDialog from '@/components/ConnectProviderDialog';
 import UnifiedCard from '@/components/UnifiedCard';
 import type {TabTemplatePageProps} from './TemplatePage.types';
 import {TemplatePageActions} from './TemplatePageActions';
@@ -163,11 +164,16 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
     const {
         providerDialogOpen,
         providerFormData,
-        handleAddProviderClick,
         handleProviderSubmit,
         handleProviderForceAdd,
         handleCloseDialog,
         handleFieldChange,
+        connectDialogOpen,
+        handleConnectAIClick,
+        handleConnectSelect,
+        handleCloseConnect,
+        customMode,
+        fromConnectPicker,
     } = useProviderDialog(showNotification, {
         onProviderAdded: () => {
             void onProvidersLoad?.();
@@ -175,8 +181,8 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
     });
 
     const handleAddApiKeyClick = useCallback(() => {
-        handleAddProviderClick();
-    }, [handleAddProviderClick]);
+        handleConnectAIClick();
+    }, [handleConnectAIClick]);
 
     const handleCreateRule = useCallback(() => {
         openModelSelectForCreate();
@@ -431,14 +437,22 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
                 loading={importing}
             />
 
+            <ConnectProviderDialog
+                open={connectDialogOpen}
+                onClose={handleCloseConnect}
+                onSelect={handleConnectSelect}
+            />
+
             <ProviderFormDialog
                 open={providerDialogOpen}
                 onClose={handleCloseDialog}
+                onBack={fromConnectPicker ? () => { handleCloseDialog(); handleConnectAIClick(); } : undefined}
                 onSubmit={handleProviderSubmit}
                 onForceAdd={handleProviderForceAdd}
                 data={providerFormData}
                 onChange={handleFieldChange}
                 mode="add"
+                customMode={customMode}
             />
 
             {showScrollTop && (

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import {
     Add as AddIcon,
-    Article as LogsIcon,
+    BugReport as TroubleshootIcon,
     ExpandMore as ExpandMoreIcon,
     Key as KeyIcon,
     UnfoldMore as UnfoldMoreIcon,
@@ -53,11 +53,11 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
             {onViewLogs && (
                 <Button
                     variant="outlined"
-                    startIcon={<LogsIcon />}
+                    startIcon={<TroubleshootIcon />}
                     onClick={onViewLogs}
                     size="small"
                 >
-                    Logs
+                    Troubleshoot
                 </Button>
             )}
             {showExpandCollapseButton && collapsible && (

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -5,7 +5,6 @@ import {
     ExpandMore as ExpandMoreIcon,
     Key as KeyIcon,
     UnfoldMore as UnfoldMoreIcon,
-    Upload as ImportIcon,
     Speed as SpeedIcon,
 } from '@/components/icons';
 import { Button, Stack, Tooltip } from '@mui/material';
@@ -20,8 +19,6 @@ export interface TemplatePageActionsProps {
     allowAddRule: boolean;
     onCreateRule: () => void;
     showExpandCollapseButton?: boolean;
-    showImportButton?: boolean;
-    onImportFromClipboard?: () => void;
     onViewLogs?: () => void;
     // Probe V2 props
     scenario?: string;
@@ -36,8 +33,6 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
     allowAddRule,
     onCreateRule,
     showExpandCollapseButton = true,
-    showImportButton = true,
-    onImportFromClipboard,
     onViewLogs,
     scenario,
 }) => {
@@ -86,18 +81,6 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
                         size="small"
                     >
                         Connect AI
-                    </Button>
-                </Tooltip>
-            )}
-            {showImportButton && onImportFromClipboard && (
-                <Tooltip title="Import rule and keys from file or clipboard">
-                    <Button
-                        variant="outlined"
-                        startIcon={<ImportIcon/>}
-                        onClick={onImportFromClipboard}
-                        size="small"
-                    >
-                        Import
                     </Button>
                 </Tooltip>
             )}

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -8,7 +8,7 @@ import {
     UnfoldMore as UnfoldMoreIcon,
     Speed as SpeedIcon,
 } from '@/components/icons';
-import { Button, Stack, Tooltip } from '@mui/material';
+import { Button, IconButton, Stack, Tooltip } from '@mui/material';
 import { ProbeMenu } from '@/components/probe';
 
 export interface TemplatePageActionsProps {
@@ -51,7 +51,7 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
     };
 
     return (
-        <Stack direction="row" spacing={1}>
+        <Stack direction="row" spacing={1} alignItems="center">
             {onViewLogs && (
                 <Button
                     variant="outlined"
@@ -61,18 +61,6 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
                 >
                     {t('templateActions.troubleshoot')}
                 </Button>
-            )}
-            {showExpandCollapseButton && collapsible && (
-                <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
-                    <Button
-                        variant="outlined"
-                        startIcon={allExpanded ? <UnfoldMoreIcon/> : <ExpandMoreIcon/>}
-                        onClick={onToggleExpandAll}
-                        size="small"
-                    >
-                        {allExpanded ? t('templateActions.collapse') : t('templateActions.expand')}
-                    </Button>
-                </Tooltip>
             )}
             {showAddApiKeyButton && (
                 <Tooltip title={t('templateActions.connectAI')}>
@@ -96,6 +84,13 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
                     >
                         {t('templateActions.newRule')}
                     </Button>
+                </Tooltip>
+            )}
+            {showExpandCollapseButton && collapsible && (
+                <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
+                    <IconButton size="small" onClick={onToggleExpandAll}>
+                        {allExpanded ? <UnfoldMoreIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                    </IconButton>
                 </Tooltip>
             )}
         </Stack>

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -78,14 +78,14 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
                 </Tooltip>
             )}
             {showAddApiKeyButton && (
-                <Tooltip title="Add new API Key">
+                <Tooltip title="Connect AI">
                     <Button
                         variant="outlined"
                         startIcon={<KeyIcon/>}
                         onClick={onAddApiKeyClick}
                         size="small"
                     >
-                        New Key
+                        Connect AI
                     </Button>
                 </Tooltip>
             )}

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
     Add as AddIcon,
     BugReport as TroubleshootIcon,
@@ -36,6 +37,7 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
     onViewLogs,
     scenario,
 }) => {
+    const { t } = useTranslation();
     const [probeAnchorEl, setProbeAnchorEl] = useState<null | HTMLElement>(null);
     const probeMenuOpen = Boolean(probeAnchorEl);
 
@@ -57,42 +59,42 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
                     onClick={onViewLogs}
                     size="small"
                 >
-                    Troubleshoot
+                    {t('templateActions.troubleshoot')}
                 </Button>
             )}
             {showExpandCollapseButton && collapsible && (
-                <Tooltip title={allExpanded ? "Collapse all rules" : "Expand all rules"}>
+                <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
                     <Button
                         variant="outlined"
                         startIcon={allExpanded ? <UnfoldMoreIcon/> : <ExpandMoreIcon/>}
                         onClick={onToggleExpandAll}
                         size="small"
                     >
-                        {allExpanded ? "Collapse" : "Expand"}
+                        {allExpanded ? t('templateActions.collapse') : t('templateActions.expand')}
                     </Button>
                 </Tooltip>
             )}
             {showAddApiKeyButton && (
-                <Tooltip title="Connect AI">
+                <Tooltip title={t('templateActions.connectAI')}>
                     <Button
                         variant="outlined"
                         startIcon={<KeyIcon/>}
                         onClick={onAddApiKeyClick}
                         size="small"
                     >
-                        Connect AI
+                        {t('templateActions.connectAI')}
                     </Button>
                 </Tooltip>
             )}
             {allowAddRule && (
-                <Tooltip title="Create new routing rule">
+                <Tooltip title={t('templateActions.createNewRule')}>
                     <Button
                         variant="contained"
                         startIcon={<AddIcon/>}
                         onClick={onCreateRule}
                         size="small"
                     >
-                        New Rule
+                        {t('templateActions.newRule')}
                     </Button>
                 </Tooltip>
             )}

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next';
 import {
     Add as AddIcon,
     BugReport as TroubleshootIcon,
-    ExpandMore as ExpandMoreIcon,
+    FoldUp as FoldUpIcon,
+    FoldDown as FoldDownIcon,
     Key as KeyIcon,
-    UnfoldMore as UnfoldMoreIcon,
     Speed as SpeedIcon,
 } from '@/components/icons';
 import { Button, IconButton, Stack, Tooltip } from '@mui/material';
@@ -89,7 +89,7 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
             {showExpandCollapseButton && collapsible && (
                 <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
                     <IconButton size="small" onClick={onToggleExpandAll}>
-                        {allExpanded ? <UnfoldMoreIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                        {allExpanded ? <FoldUpIcon fontSize="small" /> : <FoldDownIcon fontSize="small" />}
                     </IconButton>
                 </Tooltip>
             )}


### PR DESCRIPTION
## Summary

- **Unified terminology**: All "Add API Key" / "Add New API Key" labels replaced with "Connect AI" across the app (buttons, dialogs, empty states, i18n en/zh)
- **Custom endpoint UX**: Custom mode shows a plain URL text field instead of provider autocomplete dropdown; persistent v1 suffix tooltip appears when OpenAI protocol is selected and URL lacks `/v1`
- **Import in ConnectAI picker**: Import card added to the ConnectAI dialog, removing the standalone Import button from the toolbar; ImportModal dimensions and copy aligned with the picker
- **Action bar improvements**:
  - "Logs" → "Troubleshoot / 错误检查" with BugReport icon
  - Collapse/Expand moved to a trailing IconButton with FoldUp/FoldDown icons
  - All button labels wired through i18n (`templateActions.*` keys)
- **Consistent flow**: All pages (CredentialPage, TemplatePage, Onboarding) route through ConnectProviderDialog for provider selection

## Changed files

- `ConnectProviderDialog.tsx` — added `{kind: 'import'}` selection, Import card in custom section
- `ProviderFormDialog.tsx` — `customMode` prop, persistent v1 tooltip with theme-aware styling
- `VerificationResultPanel.tsx` — v1 hint for probe failures
- `TemplatePageActions.tsx` — i18n, Troubleshoot rename, collapse as trailing icon button
- `RuleLogDialog.tsx` — i18n title
- `ImportModal.tsx` — title, dimensions, generic copy
- `ConnectProviderFlow.tsx` — handle import selection kind
- `useProviderDialog.tsx` — ConnectAI dialog state, import callback
- `EmptyStateGuide.tsx` — default label "Connect AI"
- `AgentSetupCard.tsx` — step 1 button "+ Connect"
- `TemplatePage.tsx`, `CredentialPage.tsx`, `Onboarding.tsx` — customMode, import routing
- `icons/index.tsx` — added FoldUp, FoldDown exports
- `en.ts`, `zh.ts` — new and updated i18n keys

## Test plan

- [ ] Verify "Connect AI" label appears consistently on all pages (Credentials, Templates, Onboarding, empty states)
- [ ] Custom endpoint: confirm no autocomplete dropdown, v1 tooltip appears/disappears correctly
- [ ] Import card in ConnectAI picker opens ImportModal with correct title and copy
- [ ] Troubleshoot button opens log dialog; collapse/expand icon button works at end of action bar
- [ ] Switch language to zh and verify all new labels render correctly

https://claude.ai/code/session_011TvknTbytWy2DzhU2Sgupr
