### PR TITLE
bugfix: restore rule endpoint override priority over provider mode

### DIFF
--- a/internal/server/endpoint_resolution.go
+++ b/internal/server/endpoint_resolution.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -31,6 +32,10 @@ const (
 //     EndpointModeResponses            → Responses
 //     EndpointModeBoth                 → mirror incoming
 //
+// Rule override is honored unconditionally (per design intent). When an override
+// conflicts with the provider's declared mode, a warning is logged but the override
+// takes effect. This allows explicit routing control for debugging and special cases.
+//
 // Defaulting unknown providers to Chat (not "mirror incoming") is intentional:
 // most OpenAI-compatible vendors implement only /chat/completions. Providers
 // that genuinely support Responses must declare it via template or OAuth.
@@ -48,18 +53,23 @@ func ResolveOpenAIEndpoint(provider *typ.Provider, flags typ.RuleFlags, incoming
 
 	mode := provider.OpenAIEndpointMode
 
-	// Overrides only apply when the provider supports both endpoints.
-	// A chat-only or responses-only declaration is authoritative; the rule
-	// override cannot force the unsupported path.
-	if mode == ai.EndpointModeBoth {
-		switch ParseEndpointOverride(flags.OpenAIEndpointOverride) {
-		case OverrideChat:
-			return protocol.TypeOpenAIChat, nil
-		case OverrideResponses:
-			return protocol.TypeOpenAIResponses, nil
+	// Rule override takes first priority (per design intent from .design/openai-endpoint-routing.md)
+	// Log warning when override conflicts with provider's declared mode
+	switch ParseEndpointOverride(flags.OpenAIEndpointOverride) {
+	case OverrideChat:
+		if mode == ai.EndpointModeResponses {
+			logrus.Warnf("Rule forces chat endpoint on responses-only provider %s", provider.UUID)
 		}
+		return protocol.TypeOpenAIChat, nil
+
+	case OverrideResponses:
+		if mode == ai.EndpointModeChat {
+			logrus.Warnf("Rule forces responses endpoint on chat-only provider %s", provider.UUID)
+		}
+		return protocol.TypeOpenAIResponses, nil
 	}
 
+	// Fall back to provider mode when no override specified
 	switch mode {
 	case ai.EndpointModeResponses:
 		return protocol.TypeOpenAIResponses, nil

--- a/internal/server/endpoint_resolution_test.go
+++ b/internal/server/endpoint_resolution_test.go
@@ -62,20 +62,20 @@ func TestResolveOpenAIEndpoint(t *testing.T) {
 			want:     protocol.TypeOpenAIResponses,
 		},
 
-		// Rule overrides
+		// Rule overrides (override takes priority over provider mode)
 		{
-			name:     "override=responses on default chat-mode provider is ignored",
+			name:     "override=responses on default chat-mode provider forces responses",
 			provider: chatOnly,
 			flags:    typ.RuleFlags{OpenAIEndpointOverride: "responses"},
 			incoming: IncomingAPIChat,
-			want:     protocol.TypeOpenAIChat,
+			want:     protocol.TypeOpenAIResponses,
 		},
 		{
-			name:     "override=chat on responses-only provider is ignored",
+			name:     "override=chat on responses-only provider forces chat",
 			provider: responsesOnly,
 			flags:    typ.RuleFlags{OpenAIEndpointOverride: "chat"},
 			incoming: IncomingAPIChat,
-			want:     protocol.TypeOpenAIResponses,
+			want:     protocol.TypeOpenAIChat,
 		},
 		{
 			name:     "override=chat on both-mode provider forces chat",


### PR DESCRIPTION
This commit restores the design intent from commit 8f6b7971 where rule flags (openai_endpoint_override) take priority over provider endpoint mode configuration.

Changes:
- Remove guard condition that limited override to EndpointModeBoth
- Rule override now takes effect unconditionally
- Add warning logs when override conflicts with provider mode
- Update tests to reflect new behavior

This fixes the issue where openai_endpoint_override rule extension was being silently ignored for chat-only and responses-only providers.
