### PR TITLE
minor(UI): Clarify graph add node label

### DIFF
--- a/frontend/src/components/nodes/ActionAddNode.tsx
+++ b/frontend/src/components/nodes/ActionAddNode.tsx
@@ -49,7 +49,7 @@ export const ActionAddNode: React.FC<AddProviderNodeProps> = ({
     active,
     warning = false,
     onAdd,
-    tooltip = 'Add provider',
+    tooltip = 'Add model',
 }) => {
     return (
         <NodeTooltip title={tooltip} placement="top">
@@ -60,7 +60,7 @@ export const ActionAddNode: React.FC<AddProviderNodeProps> = ({
             >
                 <AddIcon sx={{ fontSize: 24, color: 'text.secondary' }} />
                 <Typography variant="caption" color="text.secondary" textAlign="center" sx={{ fontSize: '0.6rem', lineHeight: 1.1 }}>
-                    Add
+                    Add model
                 </Typography>
             </StyledAddProviderNode>
         </NodeTooltip>


### PR DESCRIPTION
### Motivation
- The graph action node only showed a generic `Add` label which is ambiguous; changing it to `Add model` makes the intent clearer for users when adding models.

### Description
- Update `frontend/src/components/nodes/ActionAddNode.tsx` to change the default tooltip from `Add provider` to `Add model` and the visible caption from `Add` to `Add model`, then commit the change.

### Testing
- Ran `pnpm lint` which completed (reported warnings only) and ran `pnpm typecheck` which failed due to unrelated repository TypeScript/environment issues (missing generated modules such as `@/bindings` and `./schema`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214d017150832a8d670334b6adbcb9)