### PR TITLE
fix(protocol): Correctly handle response.incomplete across all Responses API conversion paths

### DIFF
--- a/internal/protocol/assembler/openai_responses_assembler.go
+++ b/internal/protocol/assembler/openai_responses_assembler.go
@@ -208,8 +208,15 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 		return true
 
 	case "response.incomplete":
+		// Incomplete is a terminal Responses status for cases such as
+		// max_output_tokens/content_filter. It is not equivalent to a broken
+		// transport stream: the terminal event may contain valid output and
+		// final usage, and long Codex tasks rely on that partial response.
 		a.status = "incomplete"
 		a.finished = true
+		if responseHasPayload(&event.Response) {
+			a.response = &event.Response
+		}
 		return true
 
 	// Error event
@@ -341,14 +348,79 @@ func (a *ResponsesAssembler) Finish() *responses.Response {
 		return nil
 	}
 
-	// If we have a completed response, return it
+	// If the upstream sent a terminal response, preserve it. Incomplete
+	// Responses can still contain useful assistant output and usage; callers
+	// should inspect Status() instead of treating them as assembly failure.
 	if a.response != nil {
+		a.ensureResponseHasAccumulatedOutput(a.response)
 		return a.response
 	}
 
-	// For incomplete/failed streams, return nil
-	// The caller can check Status() to determine what happened
+	// Some providers emit text deltas and then terminate incomplete without a
+	// full response object. Return a best-effort incomplete response rather than
+	// discarding the already streamed assistant message; callers can still see
+	// Status()=="incomplete" and decide whether to continue/retry.
+	if a.IsIncomplete() && (a.accumulatedText != "" || a.currentRefusal != "") {
+		resp := a.syntheticResponse("incomplete")
+		a.response = resp
+		return resp
+	}
+
+	// Failed/error streams without a response body are not recoverable here.
 	return nil
+}
+
+func responseHasPayload(resp *responses.Response) bool {
+	if resp == nil {
+		return false
+	}
+	return resp.ID != "" || len(resp.Output) > 0 || resp.Usage.InputTokens != 0 || resp.Usage.OutputTokens != 0 || resp.Usage.TotalTokens != 0
+}
+
+func (a *ResponsesAssembler) ensureResponseHasAccumulatedOutput(resp *responses.Response) {
+	if resp == nil || len(resp.Output) > 0 {
+		return
+	}
+	if a.accumulatedText == "" && a.currentRefusal == "" {
+		return
+	}
+	resp.Output = a.syntheticOutputItems(resp.Status)
+}
+
+func (a *ResponsesAssembler) syntheticResponse(status string) *responses.Response {
+	return &responses.Response{
+		ID:        a.GetOrCreateResponseID(),
+		CreatedAt: float64(a.createdAt),
+		Status:    responses.ResponseStatus(status),
+		Output:    a.syntheticOutputItems(responses.ResponseStatus(status)),
+	}
+}
+
+func (a *ResponsesAssembler) syntheticOutputItems(status responses.ResponseStatus) []responses.ResponseOutputItemUnion {
+	itemStatus := "completed"
+	if status == responses.ResponseStatusIncomplete {
+		itemStatus = "incomplete"
+	}
+	content := make([]responses.ResponseOutputMessageContentUnion, 0, 2)
+	if a.accumulatedText != "" {
+		content = append(content, responses.ResponseOutputMessageContentUnion{
+			Type: "output_text",
+			Text: a.accumulatedText,
+		})
+	}
+	if a.currentRefusal != "" {
+		content = append(content, responses.ResponseOutputMessageContentUnion{
+			Type:    "refusal",
+			Refusal: a.currentRefusal,
+		})
+	}
+	return []responses.ResponseOutputItemUnion{{
+		ID:      a.GetOrCreateItemID(),
+		Type:    "message",
+		Role:    "assistant",
+		Status:  itemStatus,
+		Content: content,
+	}}
 }
 
 // GetOrCreateResponseID returns the response ID, generating one if not set.

--- a/internal/protocol/assembler/openai_responses_assembler_test.go
+++ b/internal/protocol/assembler/openai_responses_assembler_test.go
@@ -315,17 +315,21 @@ func TestResponsesAssembler_Finish(t *testing.T) {
 		}
 	})
 
-	t.Run("incomplete response", func(t *testing.T) {
+	t.Run("incomplete response with upstream body", func(t *testing.T) {
 		assembler := NewResponsesAssembler()
 
 		event := responses.ResponseStreamEventUnion{
 			Type: "response.incomplete",
+			Response: responses.Response{
+				ID:     "resp-incomplete-test",
+				Status: "incomplete",
+			},
 		}
 		assembler.Accumulate(event)
 
 		result := assembler.Finish()
-		if result != nil {
-			t.Error("Finish should return nil for incomplete status")
+		if result == nil {
+			t.Error("Finish should return upstream incomplete response")
 		}
 	})
 
@@ -815,5 +819,32 @@ func TestResponsesAssembler_MultipleImages(t *testing.T) {
 	// Verify first call ID at index 0
 	if assembler.ImageCallIDAt(0) != "img-0" {
 		t.Errorf("expected 'img-0' at index 0, got '%s'", assembler.ImageCallIDAt(0))
+	}
+}
+
+func TestResponsesAssembler_FinishIncompleteWithAccumulatedOutput(t *testing.T) {
+	assembler := NewResponsesAssemblerWithID("resp-incomplete", "msg-incomplete")
+
+	events := []responses.ResponseStreamEventUnion{
+		{Type: "response.created", Response: responses.Response{ID: "resp-incomplete"}},
+		{Type: "response.output_text.delta", Delta: "partial answer"},
+		{Type: "response.incomplete", Response: responses.Response{ID: "resp-incomplete", Status: "incomplete"}},
+	}
+	for _, event := range events {
+		assembler.Accumulate(event)
+	}
+
+	result := assembler.Finish()
+	if result == nil {
+		t.Fatal("Finish should preserve incomplete responses with streamed output")
+	}
+	if result.Status != "incomplete" {
+		t.Errorf("expected incomplete status, got %q", result.Status)
+	}
+	if len(result.Output) != 1 {
+		t.Fatalf("expected one synthetic output item, got %d", len(result.Output))
+	}
+	if result.Output[0].Content[0].Text != "partial answer" {
+		t.Errorf("expected accumulated text, got %q", result.Output[0].Content[0].Text)
 	}
 }

--- a/internal/protocol/nonstream/openai_reponses_to_chat.go
+++ b/internal/protocol/nonstream/openai_reponses_to_chat.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/openai/openai-go/v3/responses"
+
+	usageconv "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 type responsesToChatNonStreamState struct {
@@ -26,19 +28,25 @@ func OpenAIResponsesToChat(resp *responses.Response, responseModel string) map[s
 		},
 	}
 
-	usage := map[string]any{
-		"prompt_tokens":     resp.Usage.InputTokens,
-		"completion_tokens": resp.Usage.OutputTokens,
-		"total_tokens":      resp.Usage.InputTokens + resp.Usage.OutputTokens,
+	normalizedUsage := usageconv.FromOpenAIResponses(resp.Usage)
+	totalInputTokens := normalizedUsage.InputTokens + normalizedUsage.CacheInputTokens
+	totalTokens := int(resp.Usage.TotalTokens)
+	if totalTokens == 0 {
+		totalTokens = totalInputTokens + normalizedUsage.OutputTokens
 	}
-	if resp.Usage.InputTokensDetails.CachedTokens > 0 {
+	usage := map[string]any{
+		"prompt_tokens":     totalInputTokens,
+		"completion_tokens": normalizedUsage.OutputTokens,
+		"total_tokens":      totalTokens,
+	}
+	if normalizedUsage.CacheInputTokens > 0 {
 		usage["prompt_tokens_details"] = map[string]any{
-			"cached_tokens": resp.Usage.InputTokensDetails.CachedTokens,
+			"cached_tokens": normalizedUsage.CacheInputTokens,
 		}
 	}
-	if resp.Usage.OutputTokensDetails.ReasoningTokens > 0 {
+	if normalizedUsage.ReasoningTokens > 0 {
 		usage["completion_tokens_details"] = map[string]any{
-			"reasoning_tokens": resp.Usage.OutputTokensDetails.ReasoningTokens,
+			"reasoning_tokens": normalizedUsage.ReasoningTokens,
 		}
 	}
 

--- a/internal/protocol/nonstream/openai_responses.go
+++ b/internal/protocol/nonstream/openai_responses.go
@@ -18,34 +18,54 @@ func BuildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, a
 		model = actualModel
 	}
 
+	finishReason := ""
 	messageContent := ""
 	if len(resp.Choices) > 0 {
 		messageContent = resp.Choices[0].Message.Content
+		finishReason = string(resp.Choices[0].FinishReason)
 	}
+
+	status, incompleteDetails := chatFinishReasonToResponsesStatus(finishReason)
+	itemStatus := status
 
 	output := []map[string]any{}
 	if messageContent != "" {
 		output = append(output, map[string]any{
 			"type":   "message",
 			"role":   "assistant",
-			"status": "completed",
+			"status": itemStatus,
 			"content": []map[string]any{
 				{"type": "output_text", "text": messageContent},
 			},
 		})
 	}
 
-	return map[string]any{
+	result := map[string]any{
 		"id":     resp.ID,
 		"object": "response",
 		"model":  model,
-		"status": "completed",
+		"status": status,
 		"output": output,
 		"usage": map[string]any{
 			"input_tokens":  resp.Usage.PromptTokens,
 			"output_tokens": resp.Usage.CompletionTokens,
 			"total_tokens":  resp.Usage.PromptTokens + resp.Usage.CompletionTokens,
 		},
+	}
+	if incompleteDetails != nil {
+		result["incomplete_details"] = incompleteDetails
+	}
+	return result
+}
+
+func chatFinishReasonToResponsesStatus(finishReason string) (string, map[string]any) {
+	switch finishReason {
+	case "length":
+		return "incomplete", map[string]any{"reason": "max_output_tokens"}
+	case "content_filter":
+		return "incomplete", map[string]any{"reason": "content_filter"}
+	default:
+		return "completed", nil
 	}
 }
 
@@ -55,6 +75,8 @@ func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, respons
 	if model == "" {
 		model = actualModel
 	}
+
+	status, incompleteDetails := anthropicStopReasonToResponsesStatus(string(resp.StopReason))
 
 	output := []map[string]any{}
 	outputIndex := 0
@@ -92,23 +114,36 @@ func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, respons
 		msgItem := map[string]any{
 			"type":    "message",
 			"role":    "assistant",
-			"status":  "completed",
+			"status":  status,
 			"content": textParts,
 		}
 		output = append([]map[string]any{msgItem}, output...)
 	}
 
-	return map[string]any{
+	result := map[string]any{
 		"id":     resp.ID,
 		"object": "response",
 		"model":  model,
-		"status": "completed",
+		"status": status,
 		"output": output,
 		"usage": map[string]any{
 			"input_tokens":  resp.Usage.InputTokens,
 			"output_tokens": resp.Usage.OutputTokens,
 			"total_tokens":  resp.Usage.InputTokens + resp.Usage.OutputTokens,
 		},
+	}
+	if incompleteDetails != nil {
+		result["incomplete_details"] = incompleteDetails
+	}
+	return result
+}
+
+func anthropicStopReasonToResponsesStatus(stopReason string) (string, map[string]any) {
+	switch stopReason {
+	case "max_tokens":
+		return "incomplete", map[string]any{"reason": "max_output_tokens"}
+	default:
+		return "completed", nil
 	}
 }
 

--- a/internal/protocol/sse/parser.go
+++ b/internal/protocol/sse/parser.go
@@ -292,9 +292,12 @@ func AssembleOpenAIResponsesStream(events []string) *ParsedResult {
 				name, _ := item["name"].(string)
 				r.ToolCalls = append(r.ToolCalls, ParsedToolCall{ID: id, Name: name})
 			}
-		case "response.completed":
+		case "response.completed", "response.incomplete":
 			resp, _ := m["response"].(map[string]interface{})
 			if resp != nil {
+				if status, ok := resp["status"].(string); ok {
+					r.FinishReason = status
+				}
 				if usage, ok := resp["usage"].(map[string]interface{}); ok {
 					r.Usage = &ParsedTokenUsage{
 						InputTokens:  parsedToInt(usage["input_tokens"]),

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -110,6 +110,9 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 
 		case "message_delta":
 			acc.ConsumeBeta(&event)
+			if sr := string(event.Delta.StopReason); sr != "" {
+				state.stopReason = sr
+			}
 
 		case "message_stop":
 			sendCompletionEvent(c, state, flusher, acc.Result())
@@ -181,6 +184,7 @@ type responsesConverterState struct {
 	sequenceNumber   int
 	createdAt        int64
 	currentBlockType string // Track the type of the current block being processed
+	stopReason       string // Anthropic stop_reason from message_delta (e.g. "max_tokens")
 }
 
 // pendingResponseToolCall tracks a tool call being assembled from Anthropic stream chunks
@@ -493,8 +497,9 @@ func toResponsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
 	}
 }
 
-// sendCompletionEvent sends the response.completed event and the final [DONE] marker.
-// u carries the normalized token counts from the accumulator.
+// sendCompletionEvent sends the terminal response event and the final [DONE] marker.
+// When the Anthropic stop_reason indicates truncation (max_tokens), it emits
+// response.incomplete; otherwise response.completed.
 func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher http.Flusher, u *protocol.TokenUsage) {
 	if c == nil || c.Writer == nil || flusher == nil {
 		logrus.Warn("Cannot send completion event: connection is nil")
@@ -503,12 +508,18 @@ func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher
 
 	state.finished = true
 
+	isIncomplete, incompleteReason := anthropicStopReasonToIncomplete(state.stopReason)
+	itemStatus := "completed"
+	if isIncomplete {
+		itemStatus = "incomplete"
+	}
+
 	var output []wire.ResponsesOutputItemWire
 	if state.accumulatedText != "" {
 		output = append(output, wire.ResponsesOutputItemWire{
 			ID:     state.itemID,
 			Type:   "message",
-			Status: "completed",
+			Status: itemStatus,
 			Role:   "assistant",
 			Content: []wire.ResponsesContentPartWire{
 				{Type: "output_text", Text: state.accumulatedText},
@@ -527,22 +538,44 @@ func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher
 		})
 	}
 
-	doneEvent := wire.ResponsesCompletedEvent{
-		Type:           "response.completed",
-		SequenceNumber: int64(state.nextSequenceNumber()),
-		Response: wire.ResponsesWireResponse{
-			ID:          state.responseID,
-			Object:      "response",
-			CreatedAt:   state.createdAt,
-			Status:      "completed",
-			CompletedAt: state.createdAt,
-			Model:       "",
-			Output:      output,
-			Usage: toResponsesUsageWire(u),
-		},
+	resp := wire.ResponsesWireResponse{
+		ID:          state.responseID,
+		Object:      "response",
+		CreatedAt:   state.createdAt,
+		CompletedAt: state.createdAt,
+		Model:       "",
+		Output:      output,
+		Usage:       toResponsesUsageWire(u),
 	}
-	sendResponsesEvent(c, doneEvent, flusher)
+
+	if isIncomplete {
+		resp.Status = "incomplete"
+		resp.IncompleteDetails = &wire.ResponsesIncompleteDetailsWire{Reason: incompleteReason}
+		event := wire.ResponsesIncompleteEvent{
+			Type:           "response.incomplete",
+			SequenceNumber: int64(state.nextSequenceNumber()),
+			Response:       resp,
+		}
+		sendResponsesEvent(c, event, flusher)
+	} else {
+		resp.Status = "completed"
+		event := wire.ResponsesCompletedEvent{
+			Type:           "response.completed",
+			SequenceNumber: int64(state.nextSequenceNumber()),
+			Response:       resp,
+		}
+		sendResponsesEvent(c, event, flusher)
+	}
 	OpenAISSEDone(c)
+}
+
+func anthropicStopReasonToIncomplete(stopReason string) (bool, string) {
+	switch stopReason {
+	case "max_tokens":
+		return true, "max_output_tokens"
+	default:
+		return false, ""
+	}
 }
 
 func newResponsesWireResponseFromState(state *responsesConverterState, status string, output []wire.ResponsesOutputItemWire) wire.ResponsesWireResponse {

--- a/internal/protocol/stream/openai_chat_to_responses.go
+++ b/internal/protocol/stream/openai_chat_to_responses.go
@@ -345,8 +345,17 @@ func sendResponsesFunctionCallArgumentsDelta(c *gin.Context, state *chatToRespon
 	OpenAIResponsesEvent(c, event.EventType(), event)
 }
 
-// sendResponsesCompletedEvent sends the response.completed event
+// sendResponsesCompletedEvent sends the terminal response event.
+// When finishReason indicates truncation ("length" / "content_filter"),
+// it emits response.incomplete with the appropriate reason; otherwise
+// it emits response.completed.
 func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, model, finishReason string, flusher http.Flusher) {
+	isIncomplete, incompleteReason := chatFinishReasonToIncomplete(finishReason)
+	itemStatus := "completed"
+	if isIncomplete {
+		itemStatus = "incomplete"
+	}
+
 	if state.hasTextItem {
 		text := state.accumulatedText.String()
 		textDone := wire.ResponsesOutputTextDoneEvent{
@@ -364,7 +373,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 			Type:           "response.output_item.done",
 			SequenceNumber: nextSequenceNumber(state),
 			OutputIndex:    0,
-			Item:           newResponsesMessageItem(state.textItemID, "completed", text),
+			Item:           newResponsesMessageItem(state.textItemID, itemStatus, text),
 		}
 		OpenAIResponsesEvent(c, textItemDone.EventType(), textItemDone)
 	}
@@ -403,7 +412,7 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 
 	var output []wire.ResponsesOutputItemWire
 	if state.accumulatedText.Len() > 0 {
-		output = append(output, newResponsesMessageItem(state.textItemID, "completed", state.accumulatedText.String()))
+		output = append(output, newResponsesMessageItem(state.textItemID, itemStatus, state.accumulatedText.String()))
 	}
 
 	for _, idx := range sortedIndexes {
@@ -415,13 +424,37 @@ func sendResponsesCompletedEvent(c *gin.Context, state *chatToResponsesState, mo
 		output = append(output, newResponsesFunctionCallItem(ptc.itemID, callID, ptc.name, ptc.arguments.String(), "completed"))
 	}
 
-	event := wire.ResponsesCompletedEvent{
-		Type:           "response.completed",
-		SequenceNumber: nextSequenceNumber(state),
-		Response:       newResponsesWireResponse(state, "completed", output, model),
+	if isIncomplete {
+		resp := newResponsesWireResponse(state, "incomplete", output, model)
+		resp.IncompleteDetails = &wire.ResponsesIncompleteDetailsWire{Reason: incompleteReason}
+		event := wire.ResponsesIncompleteEvent{
+			Type:           "response.incomplete",
+			SequenceNumber: nextSequenceNumber(state),
+			Response:       resp,
+		}
+		OpenAIResponsesEvent(c, event.EventType(), event)
+	} else {
+		event := wire.ResponsesCompletedEvent{
+			Type:           "response.completed",
+			SequenceNumber: nextSequenceNumber(state),
+			Response:       newResponsesWireResponse(state, "completed", output, model),
+		}
+		OpenAIResponsesEvent(c, event.EventType(), event)
 	}
+}
 
-	OpenAIResponsesEvent(c, event.EventType(), event)
+// chatFinishReasonToIncomplete maps a Chat finish_reason to the Responses
+// API incomplete status. Returns (true, reason) when the response should
+// be marked incomplete, or (false, "") for normal completion.
+func chatFinishReasonToIncomplete(finishReason string) (bool, string) {
+	switch finishReason {
+	case "length":
+		return true, "max_output_tokens"
+	case "content_filter":
+		return true, "content_filter"
+	default:
+		return false, ""
+	}
 }
 
 func newResponsesWireResponse(state *chatToResponsesState, status string, output []wire.ResponsesOutputItemWire, model string) wire.ResponsesWireResponse {

--- a/internal/protocol/stream/openai_responses_to_chat.go
+++ b/internal/protocol/stream/openai_responses_to_chat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	usageconv "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
@@ -192,20 +193,21 @@ func HandleResponsesToOpenAIChatStream(
 			}
 
 		case "response.completed":
-			state.cacheTokens = evt.Response.Usage.InputTokensDetails.CachedTokens
-			state.inputTokens = evt.Response.Usage.InputTokens - state.cacheTokens
-			state.outputTokens = evt.Response.Usage.OutputTokens
-			state.reasoningTokens = evt.Response.Usage.OutputTokensDetails.ReasoningTokens
-			if evt.Response.Usage.TotalTokens != 0 {
-				state.totalTokens = evt.Response.Usage.TotalTokens
-			} else {
-				state.totalTokens = state.inputTokens + state.outputTokens
-			}
+			applyResponsesToChatUsage(state, evt.Response.Usage)
 			flushResponsesToChatCompletedOutput(c, flusher, state, responseModel, evt.Response.Output)
-			finishReason := "stop"
-			if state.hasToolCalls {
-				finishReason = openaiFinishReasonToolCalls
-			}
+			finishReason := responsesToChatFinishReason(&evt.Response, state.hasToolCalls)
+			writeResponsesToChatFinalChunk(c, flusher, state, responseModel, finishReason, !hc.DisableStreamUsage)
+			state.completed = true
+
+		case "response.incomplete":
+			// `response.incomplete` is a terminal Responses API event, not a
+			// transport interruption. Long Codex tasks can legitimately stop here
+			// because of max_output_tokens/content_filter while still carrying
+			// assistant output and final usage. Preserve it as a Chat terminal
+			// chunk instead of falling through to the post-loop usage=0 fallback.
+			applyResponsesToChatUsage(state, evt.Response.Usage)
+			flushResponsesToChatCompletedOutput(c, flusher, state, responseModel, evt.Response.Output)
+			finishReason := responsesToChatFinishReason(&evt.Response, state.hasToolCalls)
 			writeResponsesToChatFinalChunk(c, flusher, state, responseModel, finishReason, !hc.DisableStreamUsage)
 			state.completed = true
 
@@ -254,6 +256,37 @@ func HandleResponsesToOpenAIChatStream(
 	flusher.Flush()
 
 	return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
+}
+
+func applyResponsesToChatUsage(state *responsesToChatState, responsesUsage responses.ResponseUsage) {
+	if state == nil {
+		return
+	}
+	usage := usageconv.FromOpenAIResponses(responsesUsage)
+	state.inputTokens = int64(usage.InputTokens)
+	state.outputTokens = int64(usage.OutputTokens)
+	state.cacheTokens = int64(usage.CacheInputTokens)
+	state.reasoningTokens = int64(usage.ReasoningTokens)
+	if responsesUsage.TotalTokens != 0 {
+		state.totalTokens = responsesUsage.TotalTokens
+	} else {
+		state.totalTokens = responsesUsage.InputTokens + responsesUsage.OutputTokens
+	}
+}
+
+func responsesToChatFinishReason(resp *responses.Response, hasToolCalls bool) string {
+	if hasToolCalls {
+		return openaiFinishReasonToolCalls
+	}
+	if resp != nil && resp.Status == responses.ResponseStatusIncomplete {
+		switch resp.IncompleteDetails.Reason {
+		case "max_output_tokens":
+			return "length"
+		case "content_filter":
+			return "content_filter"
+		}
+	}
+	return "stop"
 }
 
 func writeResponsesToChatRoleChunk(c *gin.Context, flusher http.Flusher, state *responsesToChatState, responseModel string) {

--- a/internal/protocol/stream/openai_responses_to_chat_incomplete_test.go
+++ b/internal/protocol/stream/openai_responses_to_chat_incomplete_test.go
@@ -1,0 +1,76 @@
+package stream
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+type responseEventIter struct {
+	events []responses.ResponseStreamEventUnion
+	idx    int
+}
+
+func (s *responseEventIter) Next() bool {
+	if s.idx >= len(s.events) {
+		return false
+	}
+	s.idx++
+	return true
+}
+
+func (s *responseEventIter) Current() responses.ResponseStreamEventUnion { return s.events[s.idx-1] }
+func (s *responseEventIter) Err() error                                  { return nil }
+func (s *responseEventIter) Close() error                                { return nil }
+
+func TestHandleResponsesToOpenAIChatStreamIncompleteKeepsUsageAndLengthFinish(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	iter := &responseEventIter{events: []responses.ResponseStreamEventUnion{
+		{Type: "response.created", Response: responses.Response{ID: "resp_incomplete"}},
+		{Type: "response.output_text.delta", Delta: "partial"},
+		{Type: "response.incomplete", Response: responses.Response{
+			ID:     "resp_incomplete",
+			Status: responses.ResponseStatusIncomplete,
+			IncompleteDetails: responses.ResponseIncompleteDetails{
+				Reason: "max_output_tokens",
+			},
+			Usage: responses.ResponseUsage{
+				InputTokens:  100,
+				OutputTokens: 20,
+				TotalTokens:  120,
+				InputTokensDetails: responses.ResponseUsageInputTokensDetails{
+					CachedTokens: 40,
+				},
+				OutputTokensDetails: responses.ResponseUsageOutputTokensDetails{
+					ReasoningTokens: 5,
+				},
+			},
+		}},
+	}}
+
+	usage, err := HandleResponsesToOpenAIChatStream(protocol.NewHandleContext(c, "proxy-model"), iter, "proxy-model")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, 60, usage.InputTokens)
+	require.Equal(t, 40, usage.CacheInputTokens)
+	require.Equal(t, 20, usage.OutputTokens)
+	require.Equal(t, 5, usage.ReasoningTokens)
+	body := w.Body.String()
+	require.Contains(t, body, `"content":"partial"`)
+	require.Contains(t, body, `"finish_reason":"length"`)
+	require.Contains(t, body, `"prompt_tokens":100`)
+	require.Contains(t, body, `"completion_tokens":20`)
+	require.Contains(t, body, `data: [DONE]`)
+	require.Equal(t, 1, strings.Count(body, `"finish_reason":"length"`))
+}

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -972,7 +972,30 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 		case "response.mcp_list_tools.failed":
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] MCP list tools failed")
 
-		case "error", "response.failed", "response.incomplete":
+		case "response.incomplete":
+			// response.incomplete is a terminal Responses status (max_output_tokens,
+			// content_filter), not a transport error. Preserve the partial output
+			// and map to Anthropic's max_tokens stop reason.
+			incomplete := currentEvent.AsResponseIncomplete()
+			state.cacheTokens = incomplete.Response.Usage.InputTokensDetails.CachedTokens
+			state.inputTokens = incomplete.Response.Usage.InputTokens - state.cacheTokens
+			state.outputTokens = incomplete.Response.Usage.OutputTokens
+			state.reasoningTokens = incomplete.Response.Usage.OutputTokensDetails.ReasoningTokens
+
+			senders.SendStopEvents(state, flusher)
+
+			stopReason := "max_tokens"
+			if incomplete.Response.IncompleteDetails.Reason == "content_filter" {
+				stopReason = "end_turn"
+			}
+
+			senders.SendMessageDelta(state, stopReason, flusher)
+			senders.SendMessageStop(messageID, responseModel, state, stopReason, flusher)
+
+			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Incomplete response: reason=%s, stop_reason=%s", incomplete.Response.IncompleteDetails.Reason, stopReason)
+			return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
+
+		case "error", "response.failed":
 			logrus.WithContext(c.Request.Context()).Errorf("Responses API error event: %v", currentEvent)
 			errorEvent := map[string]interface{}{
 				"type": "error",

--- a/internal/protocol/wire/openai_responses.go
+++ b/internal/protocol/wire/openai_responses.go
@@ -13,6 +13,7 @@ func (e ResponsesStreamErrorEvent) EventType() string                { return e.
 func (e ResponsesCreatedEvent) EventType() string                    { return e.Type }
 func (e ResponsesInProgressEvent) EventType() string                 { return e.Type }
 func (e ResponsesCompletedEvent) EventType() string                  { return e.Type }
+func (e ResponsesIncompleteEvent) EventType() string                 { return e.Type }
 func (e ResponsesOutputItemAddedEvent) EventType() string            { return e.Type }
 func (e ResponsesOutputItemDoneEvent) EventType() string             { return e.Type }
 func (e ResponsesContentPartAddedEvent) EventType() string           { return e.Type }
@@ -51,15 +52,26 @@ type ResponsesCompletedEvent struct {
 	Response       ResponsesWireResponse `json:"response"`
 }
 
+type ResponsesIncompleteEvent struct {
+	Type           string               `json:"type"`
+	SequenceNumber int64                `json:"sequence_number"`
+	Response       ResponsesWireResponse `json:"response"`
+}
+
 type ResponsesWireResponse struct {
-	ID          string                   `json:"id"`
-	Object      string                   `json:"object"`
-	CreatedAt   int64                    `json:"created_at"`
-	Status      string                   `json:"status"`
-	Output      []ResponsesOutputItemWire `json:"output"`
-	Usage       *ResponsesUsageWire      `json:"usage,omitempty"`
-	Model       string                   `json:"model,omitempty"`
-	CompletedAt int64                    `json:"completed_at,omitempty"`
+	ID                string                          `json:"id"`
+	Object            string                          `json:"object"`
+	CreatedAt         int64                           `json:"created_at"`
+	Status            string                          `json:"status"`
+	Output            []ResponsesOutputItemWire       `json:"output"`
+	Usage             *ResponsesUsageWire             `json:"usage,omitempty"`
+	Model             string                          `json:"model,omitempty"`
+	CompletedAt       int64                           `json:"completed_at,omitempty"`
+	IncompleteDetails *ResponsesIncompleteDetailsWire `json:"incomplete_details,omitempty"`
+}
+
+type ResponsesIncompleteDetailsWire struct {
+	Reason string `json:"reason"`
 }
 
 type ResponsesUsageWire struct {

--- a/internal/protocoltest/assertions.go
+++ b/internal/protocoltest/assertions.go
@@ -73,6 +73,24 @@ func AssertFinishReason(expected string) Assertion {
 	}
 }
 
+// AssertFinishReasonOneOf returns an Assertion that the finish_reason matches any
+// of the accepted values. Useful for scenarios where the expected finish reason
+// varies by source protocol (e.g. "length" for Chat, "max_tokens" for Anthropic,
+// "incomplete" for Responses).
+func AssertFinishReasonOneOf(accepted ...string) Assertion {
+	return Assertion{
+		Name: fmt.Sprintf("finish_reason_one_of(%v)", accepted),
+		Check: func(r *RoundTripResult) error {
+			for _, a := range accepted {
+				if r.FinishReason == a {
+					return nil
+				}
+			}
+			return fmt.Errorf("finish_reason: got %q, want one of %v", r.FinishReason, accepted)
+		},
+	}
+}
+
 // AssertHasToolCalls returns an Assertion that exactly count tool calls are present.
 func AssertHasToolCalls(count int) Assertion {
 	return Assertion{

--- a/internal/protocoltest/scenarios.go
+++ b/internal/protocoltest/scenarios.go
@@ -70,6 +70,7 @@ func AllScenarios() []Scenario {
 		MultiTurnScenario(),
 		StreamingTextScenario(),
 		StreamingToolUseScenario(),
+		IncompleteScenario(),
 		ErrorScenario(),
 	}
 }
@@ -445,6 +446,198 @@ func StreamingToolUseScenario() Scenario {
 // ─── Error ────────────────────────────────────────────────────────────────────
 
 // ErrorScenario tests that provider error responses are forwarded to the client.
+// ─── Incomplete ──────────────────────────────────────────────────────────────
+
+// IncompleteScenario exercises the max-output-tokens truncation path.
+// The provider returns a partial response that was cut short; the gateway
+// must preserve the partial content and map the finish reason correctly
+// (Chat → "length", Anthropic → "max_tokens", Responses → "incomplete").
+func IncompleteScenario() Scenario {
+	return Scenario{
+		Name:        "incomplete",
+		Description: "Provider truncated response due to max_output_tokens",
+		Tags:        []string{"incomplete", "length"},
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      openAIIncompleteResponse(),
+			FormatOpenAIResponses: openAIResponsesIncompleteResponse(),
+			FormatAnthropic:       anthropicIncompleteResponse(),
+			FormatGoogle:          googleIncompleteResponse(),
+		},
+		Assertions: []Assertion{
+			AssertHTTPStatus(200),
+			AssertRoleEquals("assistant"),
+			AssertContentContains("truncated"),
+			AssertContentNonEmpty(),
+			AssertUsageNonZero(),
+		},
+	}
+}
+
+func openAIIncompleteResponse() MockResponseBuilder {
+	body := map[string]interface{}{
+		"id":      "chatcmpl-validate-incomplete",
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   "gpt-4o",
+		"choices": []map[string]interface{}{
+			{
+				"index": 0,
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": "This response was truncated due to output limit.",
+				},
+				"finish_reason": "length",
+			},
+		},
+		"usage": map[string]interface{}{
+			"prompt_tokens":     10,
+			"completion_tokens": 50,
+			"total_tokens":      60,
+		},
+	}
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+		Stream:    openAIIncompleteSSE,
+	}
+}
+
+func anthropicIncompleteResponse() MockResponseBuilder {
+	body := map[string]interface{}{
+		"id":   "msg-validate-incomplete",
+		"type": "message",
+		"role": "assistant",
+		"content": []map[string]interface{}{
+			{"type": "text", "text": "This response was truncated due to output limit."},
+		},
+		"model":         "claude-3-5-sonnet-20241022",
+		"stop_reason":   "max_tokens",
+		"stop_sequence": nil,
+		"usage": map[string]interface{}{
+			"input_tokens":  10,
+			"output_tokens": 50,
+		},
+	}
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+		Stream:    anthropicIncompleteSSE,
+	}
+}
+
+func googleIncompleteResponse() MockResponseBuilder {
+	body := map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role": "model",
+					"parts": []map[string]interface{}{
+						{"text": "This response was truncated due to output limit."},
+					},
+				},
+				"finishReason": "MAX_TOKENS",
+				"index":        0,
+			},
+		},
+		"usageMetadata": map[string]interface{}{
+			"promptTokenCount":     10,
+			"candidatesTokenCount": 50,
+			"totalTokenCount":      60,
+		},
+	}
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+		Stream:    googleIncompleteSSE,
+	}
+}
+
+func openAIResponsesIncompleteResponse() MockResponseBuilder {
+	body := map[string]interface{}{
+		"id":     "resp-validate-incomplete",
+		"object": "realtime.response",
+		"model":  "gpt-4o",
+		"status": "incomplete",
+		"incomplete_details": map[string]interface{}{
+			"reason": "max_output_tokens",
+		},
+		"output": []map[string]interface{}{
+			{
+				"id":     "item-validate-incomplete",
+				"type":   "message",
+				"role":   "assistant",
+				"status": "incomplete",
+				"content": []map[string]interface{}{
+					{"type": "output_text", "text": "This response was truncated due to output limit."},
+				},
+			},
+		},
+		"usage": map[string]interface{}{
+			"input_tokens":  10,
+			"output_tokens": 50,
+			"total_tokens":  60,
+		},
+	}
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+		Stream:    openAIResponsesIncompleteSSE,
+	}
+}
+
+func openAIIncompleteSSE() []string {
+	return []string{
+		`data: {"id":"chatcmpl-validate-incomplete","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-validate-incomplete","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"This response was truncated due to output limit."},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-validate-incomplete","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`,
+		`data: [DONE]`,
+	}
+}
+
+func anthropicIncompleteSSE() []string {
+	return []string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg-validate-incomplete","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"This response was truncated due to output limit."}}`,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":50}}`,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+	}
+}
+
+func googleIncompleteSSE() []string {
+	chunk := map[string]interface{}{
+		"candidates": []map[string]interface{}{
+			{
+				"content": map[string]interface{}{
+					"role":  "model",
+					"parts": []map[string]interface{}{{"text": "This response was truncated due to output limit."}},
+				},
+				"finishReason": "MAX_TOKENS",
+				"index":        0,
+			},
+		},
+	}
+	return []string{
+		"data: " + string(mustMarshal(chunk)),
+	}
+}
+
+func openAIResponsesIncompleteSSE() []string {
+	return []string{
+		`data: {"type":"response.created","response":{"id":"resp-validate-incomplete","object":"realtime.response","model":"gpt-4o","status":"in_progress","output":[]}}`,
+		`data: {"type":"response.output_item.added","response_id":"resp-validate-incomplete","item":{"id":"item-validate-incomplete","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
+		`data: {"type":"response.output_text.delta","response_id":"resp-validate-incomplete","item_id":"item-validate-incomplete","output_index":0,"content_index":0,"delta":"This response was truncated due to output limit."}`,
+		`data: {"type":"response.output_text.done","response_id":"resp-validate-incomplete","item_id":"item-validate-incomplete","output_index":0,"content_index":0,"text":"This response was truncated due to output limit."}`,
+		`data: {"type":"response.incomplete","response":{"id":"resp-validate-incomplete","object":"realtime.response","model":"gpt-4o","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"item-validate-incomplete","type":"message","role":"assistant","status":"incomplete","content":[{"type":"output_text","text":"This response was truncated due to output limit."}]}],"usage":{"input_tokens":10,"output_tokens":50,"total_tokens":60}}}`,
+		`data: [DONE]`,
+	}
+}
+
+// ─── Error ───────────────────────────────────────────────────────────────────
+
 func ErrorScenario() Scenario {
 	return Scenario{
 		Name:        "error",


### PR DESCRIPTION
### Motivation

The OpenAI Responses API can terminate with `response.incomplete` (e.g. `max_output_tokens`, `content_filter`) — a valid terminal event carrying partial assistant output and final usage. Before this fix:

- The Responses→Anthropic stream path treated `response.incomplete` as an error and discarded output/usage
- Chat→Responses and Anthropic→Responses generation paths always emitted `response.completed` regardless of upstream truncation
- Nonstream builders (`BuildResponsesPayloadFromChat`, `BuildResponsesPayloadFromAnthropicBeta`) hardcoded `status: "completed"`
- The wire struct `ResponsesWireResponse` was missing `IncompleteDetails`

### Changes

**Wire types** (`internal/protocol/wire/openai_responses.go`)
- Added `IncompleteDetails *ResponsesIncompleteDetailsWire` field to `ResponsesWireResponse`
- Added `ResponsesIncompleteDetailsWire{Reason string}` struct
- Added `ResponsesIncompleteEvent` wire type with `EventType()` method

**Responses→Anthropic stream** (`internal/protocol/stream/openai_to_anthropic.go`)
- Separated `response.incomplete` from `"error"/"response.failed"` case
- Extracts usage, maps stop reason (`max_output_tokens`→`max_tokens`, `content_filter`→`end_turn`), sends proper `message_delta`/`message_stop`

**Assembler** (`internal/protocol/assembler/openai_responses_assembler.go`)
- `response.incomplete` preserves payload via `responseHasPayload`
- `Finish()` returns incomplete responses with accumulated output
- `syntheticResponse` synthesizes best-effort response from accumulated deltas when upstream body is missing

**Responses→Chat stream+nonstream** (`openai_responses_to_chat.go`, `openai_reponses_to_chat.go`)
- `applyResponsesToChatUsage` normalizes usage via `usageconv.FromOpenAIResponses`
- `responsesToChatFinishReason` / `mapResponsesFinishReason` maps `max_output_tokens`→`"length"`, `content_filter`→`"content_filter"`

**Chat→Responses stream** (`internal/protocol/stream/openai_chat_to_responses.go`)
- `sendResponsesCompletedEvent` now checks `finish_reason` and emits `response.incomplete` with `incomplete_details` for `"length"`/`"content_filter"`, sets output item status to `"incomplete"`

**Anthropic→Responses stream** (`internal/protocol/stream/anthropic_beta_to_openai_responses.go`)
- Captures `stop_reason` from `message_delta` event into converter state
- `sendCompletionEvent` emits `response.incomplete` when `stop_reason == "max_tokens"`

**Nonstream builders** (`internal/protocol/nonstream/openai_responses.go`)
- `BuildResponsesPayloadFromChat`: checks `finish_reason` via `chatFinishReasonToResponsesStatus`
- `BuildResponsesPayloadFromAnthropicBeta`: checks `stop_reason` via `anthropicStopReasonToResponsesStatus`
- Both propagate `status: "incomplete"` and `incomplete_details` when upstream indicates truncation

**Protocoltest harness** (`internal/protocoltest/`)
- Added `IncompleteScenario()` covering `max_output_tokens` truncation in all 4 wire formats
- Added `AssertFinishReasonOneOf` assertion helper
- All 12 conversion pairs × 2 modes pass

### Testing

- `go test ./internal/protocol/... ./internal/protocoltest/...` — all pass
- `TestResponsesAssembler_IncompleteEvent` — assembler handles incomplete terminal event
- `TestResponsesAssembler_FinishIncompleteWithAccumulatedOutput` — backfills output from deltas
- `TestHandleResponsesToOpenAIChatStreamIncompleteKeepsUsageAndLengthFinish` — stream Responses→Chat preserves usage and maps finish_reason
- `TestOpenAIResponsesToChatIncompleteReasons` — nonstream finish_reason mapping
- Full protocoltest matrix including `IncompleteScenario` — all green