### PR TITLE
feat(config): Include explicit context-window metadata in Codex model catalog and add tests

### DIFF
--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1151,6 +1151,16 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	}
 }
 
+const (
+	// The gateway only knows model slugs from routing rules, not provider-native
+	// capabilities. Keep tingly-managed catalog entries conservative and
+	// internally consistent until richer per-model metadata is available.
+	codexDefaultContextWindow            = 200000
+	codexDefaultMaxContextWindow         = 200000
+	codexEffectiveContextWindowPercent   = 92
+	codexDefaultAutoCompactTokenLimitPct = 85
+)
+
 // renderCodexModelCatalog produces the JSON payload for
 // ~/.codex/tingly-model-catalog.json. Each model becomes one ModelInfo entry
 // with the required fields populated using conservative defaults that match
@@ -1187,7 +1197,10 @@ func RenderCodexModelCatalog(models []string) ([]byte, error) {
 			"support_verbosity":                false,
 			"truncation_policy":                map[string]interface{}{"mode": "tokens", "limit": 10000},
 			"supports_parallel_tool_calls":     true,
-			"effective_context_window_percent": 100,
+			"context_window":                   codexDefaultContextWindow,
+			"max_context_window":               codexDefaultMaxContextWindow,
+			"auto_compact_token_limit":         codexAutoCompactTokenLimit(codexDefaultContextWindow),
+			"effective_context_window_percent": codexEffectiveContextWindowPercent,
 			"experimental_supported_tools":     []string{},
 			"input_modalities":                 []string{"text", "image"},
 			"apply_patch_tool_type":            "freeform",
@@ -1195,6 +1208,10 @@ func RenderCodexModelCatalog(models []string) ([]byte, error) {
 	}
 	payload := map[string]interface{}{"models": entries}
 	return json.MarshalIndent(payload, "", "  ")
+}
+
+func codexAutoCompactTokenLimit(contextWindow int) int {
+	return contextWindow * codexDefaultAutoCompactTokenLimitPct / 100
 }
 
 var codexProfileKeyInvalid = regexp.MustCompile(`[^A-Za-z0-9_-]`)

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -896,6 +896,8 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 // tingly-served models.
 const codexModelCatalogFile = "tingly-model-catalog.json"
 
+const codexModelCatalogSchema = "https://raw.githubusercontent.com/tingly-dev/tingly-box/main/internal/server/config/codex-model-catalog.schema.json"
+
 // CodexPrefs is the typed, user-tunable surface of Codex's config.toml.
 // JSON tags map 1:1 to the config.toml keys, so the frontend round-trips the
 // same field names. Values are kept as strings so empty = omit (let Codex use
@@ -1206,7 +1208,10 @@ func RenderCodexModelCatalog(models []string) ([]byte, error) {
 			"apply_patch_tool_type":            "freeform",
 		})
 	}
-	payload := map[string]interface{}{"models": entries}
+	payload := map[string]interface{}{
+		"$schema": codexModelCatalogSchema,
+		"models":  entries,
+	}
 	return json.MarshalIndent(payload, "", "  ")
 }
 

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -1099,7 +1099,7 @@ func TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt(t *testing.T) {
 		gotSlugs[m["slug"].(string)] = true
 		// Spot-check a few required ModelInfo fields so a future refactor
 		// can't silently drop them and start tripping Codex's deserializer.
-		for _, key := range []string{"display_name", "supported_reasoning_levels", "shell_type", "visibility", "truncation_policy", "input_modalities"} {
+		for _, key := range []string{"display_name", "supported_reasoning_levels", "shell_type", "visibility", "truncation_policy", "input_modalities", "context_window", "max_context_window", "auto_compact_token_limit", "effective_context_window_percent"} {
 			if _, ok := m[key]; !ok {
 				t.Errorf("catalog entry %v missing required key %q", m["slug"], key)
 			}
@@ -1107,6 +1107,61 @@ func TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt(t *testing.T) {
 	}
 	if !gotSlugs["tingly-codex"] || !gotSlugs["tingly-gpt5"] {
 		t.Errorf("catalog slugs = %v, want tingly-codex+tingly-gpt5", gotSlugs)
+	}
+}
+
+func TestApplyCodexConfig_CatalogContextMetadataIsExplicit(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	if _, err := ApplyCodexConfig("http://h/tingly/codex", []string{"tingly-codex", "tingly-gpt5"}, DefaultCodexPrefs(), true); err != nil {
+		t.Fatalf("ApplyCodexConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tempDir, ".codex", "tingly-model-catalog.json"))
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var catalog struct {
+		Models []struct {
+			Slug                          string `json:"slug"`
+			ContextWindow                 int    `json:"context_window"`
+			MaxContextWindow              int    `json:"max_context_window"`
+			AutoCompactTokenLimit         int    `json:"auto_compact_token_limit"`
+			EffectiveContextWindowPercent int    `json:"effective_context_window_percent"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, data)
+	}
+	if len(catalog.Models) != 2 {
+		t.Fatalf("models len = %d, want 2", len(catalog.Models))
+	}
+
+	bySlug := map[string]struct {
+		Slug                          string `json:"slug"`
+		ContextWindow                 int    `json:"context_window"`
+		MaxContextWindow              int    `json:"max_context_window"`
+		AutoCompactTokenLimit         int    `json:"auto_compact_token_limit"`
+		EffectiveContextWindowPercent int    `json:"effective_context_window_percent"`
+	}{}
+	for _, model := range catalog.Models {
+		bySlug[model.Slug] = model
+		if model.ContextWindow != codexDefaultContextWindow {
+			t.Errorf("%s context_window = %d, want %d", model.Slug, model.ContextWindow, codexDefaultContextWindow)
+		}
+		if model.AutoCompactTokenLimit != codexAutoCompactTokenLimit(model.ContextWindow) {
+			t.Errorf("%s auto_compact_token_limit = %d, want configured percentage of context_window", model.Slug, model.AutoCompactTokenLimit)
+		}
+		if model.EffectiveContextWindowPercent != codexEffectiveContextWindowPercent {
+			t.Errorf("%s effective_context_window_percent = %d, want %d", model.Slug, model.EffectiveContextWindowPercent, codexEffectiveContextWindowPercent)
+		}
+	}
+	if bySlug["tingly-codex"].MaxContextWindow != codexDefaultMaxContextWindow {
+		t.Errorf("tingly-codex max_context_window = %d, want %d", bySlug["tingly-codex"].MaxContextWindow, codexDefaultMaxContextWindow)
+	}
+	if bySlug["tingly-gpt5"].MaxContextWindow != codexDefaultMaxContextWindow {
+		t.Errorf("tingly-gpt5 max_context_window = %d, want %d", bySlug["tingly-gpt5"].MaxContextWindow, codexDefaultMaxContextWindow)
 	}
 }
 

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -1086,10 +1086,14 @@ func TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt(t *testing.T) {
 		t.Fatalf("read catalog: %v", err)
 	}
 	var catalog struct {
+		Schema string                   `json:"$schema"`
 		Models []map[string]interface{} `json:"models"`
 	}
 	if err := json.Unmarshal(data, &catalog); err != nil {
 		t.Fatalf("unmarshal catalog: %v\n%s", err, data)
+	}
+	if catalog.Schema != codexModelCatalogSchema {
+		t.Errorf("$schema = %q, want %q", catalog.Schema, codexModelCatalogSchema)
 	}
 	if len(catalog.Models) != 2 {
 		t.Fatalf("len(models) = %d, want 2", len(catalog.Models))

--- a/internal/server/config/codex-model-catalog.schema.json
+++ b/internal/server/config/codex-model-catalog.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/tingly-dev/tingly-box/main/internal/server/config/codex-model-catalog.schema.json",
+  "title": "Tingly Box Codex Model Catalog",
+  "description": "Schema for the JSON model catalog written to ~/.codex/tingly-model-catalog.json and referenced by Codex config.toml's model_catalog_json setting.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["models"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "models": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/modelInfo"
+      }
+    }
+  },
+  "definitions": {
+    "reasoningEffortPreset": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["effort", "description"],
+      "properties": {
+        "effort": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "truncationPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "modelInfo": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "slug",
+        "display_name",
+        "supported_reasoning_levels",
+        "shell_type",
+        "visibility",
+        "truncation_policy",
+        "input_modalities",
+        "context_window",
+        "max_context_window",
+        "auto_compact_token_limit",
+        "effective_context_window_percent"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "supported_reasoning_levels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/reasoningEffortPreset"
+          }
+        },
+        "default_reasoning_level": {
+          "type": "string"
+        },
+        "shell_type": {
+          "type": "string"
+        },
+        "visibility": {
+          "type": "string"
+        },
+        "supported_in_api": {
+          "type": "boolean"
+        },
+        "priority": {
+          "type": "integer"
+        },
+        "base_instructions": {
+          "type": "string"
+        },
+        "supports_reasoning_summaries": {
+          "type": "boolean"
+        },
+        "default_reasoning_summary": {
+          "type": "string"
+        },
+        "support_verbosity": {
+          "type": "boolean"
+        },
+        "truncation_policy": {
+          "$ref": "#/definitions/truncationPolicy"
+        },
+        "supports_parallel_tool_calls": {
+          "type": "boolean"
+        },
+        "context_window": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_context_window": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "auto_compact_token_limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "effective_context_window_percent": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "experimental_supported_tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "input_modalities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "apply_patch_tool_type": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Make model catalog entries conservative and explicit about context window sizing and auto-compaction so the gateway supplies consistent, provider-agnostic defaults for Codex consumers.

### Description

- Add constants `codexDefaultContextWindow`, `codexDefaultMaxContextWindow`, `codexEffectiveContextWindowPercent`, and `codexDefaultAutoCompactTokenLimitPct` and wire them into the catalog generation.
- Emit `context_window`, `max_context_window`, `auto_compact_token_limit`, and `effective_context_window_percent` in `RenderCodexModelCatalog` and compute `auto_compact_token_limit` via the new helper `codexAutoCompactTokenLimit`.
- Update existing test `TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt` to assert the new catalog keys are present.
- Add `TestApplyCodexConfig_CatalogContextMetadataIsExplicit` to validate the numeric defaults and calculated `auto_compact_token_limit` values in the written `tingly-model-catalog.json`.

### Testing

- Ran unit tests `TestApplyCodexConfig_WritesCatalogAndPointsConfigAtIt`, `TestApplyCodexConfig_CatalogContextMetadataIsExplicit`, and `TestApplyCodexConfig_CatalogReasoningPresetsAreObjects` under the `internal/server/config` package and they succeeded.
- Verified the generated `~/.codex/tingly-model-catalog.json` includes the new fields and that `auto_compact_token_limit` equals the configured percentage of `context_window`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22382d29c0832a85c2bb0c1b0e60f4)