### PR TITLE
feat(frontend,tier): add routing education system and improve node UX

### DIFF
--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -10,9 +10,10 @@ import {
     Collapse,
     IconButton,
     Stack,
+    Typography,
 } from '@mui/material';
 import { alpha, styled } from '@mui/material/styles';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getRouteGraphActiveColor, SMART_NODE_STYLES, PROVIDER_NODE_STYLES } from '@/components/nodes/styles';
 import {
@@ -26,6 +27,7 @@ import {
 } from '@/components/nodes';
 import { EntryNode } from '@/components/nodes';
 import ModelRequestHeader from '@/components/ModelRequestHeader';
+import { TierGuideDialog } from '@/components/tier/TierGuideDialog';
 import type { Provider } from '../types/provider';
 import type { ConfigRecord } from './RoutingGraphTypes';
 
@@ -82,6 +84,9 @@ export interface UnifiedRoutingGraphProps {
     saving?: boolean;
     expanded?: boolean;
     collapsible?: boolean;
+
+    // Guide mode - for demo/tier guide display
+    guideMode?: boolean;
 
     // Callbacks
     onUpdateRecord?: (field: keyof ConfigRecord, value: any) => void;
@@ -167,6 +172,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
     saving = false,
     expanded = true,
     collapsible = false,
+    guideMode = false,
     onUpdateRecord,
     onProviderNodeClick,
     onTierChange,
@@ -185,6 +191,18 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
 }) => {
     const { t } = useTranslation();
     const isExpanded = !collapsible || expanded;
+
+    // Track which tier is being hovered
+    const [hoveredTier, setHoveredTier] = React.useState<number | null>(null);
+    const [showTierGuide, setShowTierGuide] = React.useState(false);
+
+    const handleShowGuide = () => {
+        setShowTierGuide(true);
+    };
+
+    const handleGuideClose = () => {
+        setShowTierGuide(false);
+    };
 
     // Determine effective mode
     const smartEnabled = record.smartEnabled || false;
@@ -236,6 +254,10 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
     const renderTierLayout = React.useCallback(() => {
         // Always show at least T0, even when no providers exist
         const groups = tierGroups.length > 0 ? tierGroups : [{ tier: 0, providers: [] as typeof sortedDefaultProviders }];
+
+        // In guide mode, always show action buttons on all services
+        const shouldShowActions = guideMode ? true : undefined;
+
         return (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
                 {groups.map((group, idx) => (
@@ -243,7 +265,12 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                         key={group.tier}
                         sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'nowrap' }}
                     >
-                        <TierNode priority={group.tier} active={active} />
+                        <TierNode
+                            priority={group.tier}
+                            active={active}
+                            onHover={guideMode ? undefined : (hovering) => setHoveredTier(hovering ? group.tier : null)}
+                            onShowGuide={handleShowGuide}
+                        />
                         {group.providers.map((p) => (
                             <ServiceNode
                                 key={p.uuid}
@@ -254,6 +281,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                 onDelete={() => onDeleteProvider?.(p.uuid)}
                                 onNodeClick={() => onProviderNodeClick?.(p.uuid)}
                                 showTier={false}
+                                forceShowActions={shouldShowActions ?? (hoveredTier === group.tier)}
                                 onMoveTierUp={group.tier > 0 && onTierChange ? () => onTierChange(p.uuid, group.tier - 1) : undefined}
                                 onMoveTierDown={onTierChange ? () => onTierChange(p.uuid, group.tier + 1) : undefined}
                             />
@@ -272,7 +300,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 ))}
             </Box>
         );
-    }, [t, tierGroups, active, saving, record.providers.length, getApiStyle, providers, onDeleteProvider, onProviderNodeClick, onTierChange, onAddService]);
+    }, [t, tierGroups, active, saving, record.providers.length, getApiStyle, providers, onDeleteProvider, onProviderNodeClick, onTierChange, onAddService, hoveredTier, guideMode, handleShowGuide]);
 
     // Render smart rules section
     const renderSmartRules = () => {
@@ -401,6 +429,12 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 extraActions={extraActions}
                 isExpanded={isExpanded}
                 onToggleExpanded={onToggleExpanded}
+            />
+
+            {/* Tier Guide Dialog */}
+            <TierGuideDialog
+                open={showTierGuide}
+                onClose={handleGuideClose}
             />
 
             {/* Graph Content */}

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -28,6 +28,7 @@ import {
 import { EntryNode } from '@/components/nodes';
 import ModelRequestHeader from '@/components/ModelRequestHeader';
 import { TierGuideDialog } from '@/components/tier/TierGuideDialog';
+import { EntryGuideDialog } from '@/components/tier/EntryGuideDialog';
 import type { Provider } from '../types/provider';
 import type { ConfigRecord } from './RoutingGraphTypes';
 
@@ -195,6 +196,8 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
     // Track which tier is being hovered
     const [hoveredTier, setHoveredTier] = React.useState<number | null>(null);
     const [showTierGuide, setShowTierGuide] = React.useState(false);
+    const [showEntryGuide, setShowEntryGuide] = React.useState(false);
+    const [entryGuideMode, setEntryGuideMode] = React.useState<'direct' | 'smart'>('direct');
 
     const handleShowGuide = () => {
         setShowTierGuide(true);
@@ -202,6 +205,20 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
 
     const handleGuideClose = () => {
         setShowTierGuide(false);
+    };
+
+    const handleShowDirectGuide = () => {
+        setEntryGuideMode('direct');
+        setShowEntryGuide(true);
+    };
+
+    const handleShowSmartGuide = () => {
+        setEntryGuideMode('smart');
+        setShowEntryGuide(true);
+    };
+
+    const handleEntryGuideClose = () => {
+        setShowEntryGuide(false);
     };
 
     // Determine effective mode
@@ -437,6 +454,13 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 onClose={handleGuideClose}
             />
 
+            {/* Entry Guide Dialog */}
+            <EntryGuideDialog
+                open={showEntryGuide}
+                onClose={handleEntryGuideClose}
+                mode={entryGuideMode}
+            />
+
             {/* Graph Content */}
             <Collapse in={isExpanded} timeout="auto" unmountOnExit>
                 <CardContent sx={{ pt: 0, pb: 0.25, '&:last-child': { pb: 0.25 } }}>
@@ -458,6 +482,8 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                 smartEnabled={smartEnabled}
                                                 onSwitch={onSwitchRoutingMode}
                                                 switchDisabled={saving}
+                                                onShowDirectGuide={handleShowDirectGuide}
+                                                onShowSmartGuide={handleShowSmartGuide}
                                             />
                                         </Box>
 

--- a/frontend/src/components/nodes/EntryNode.tsx
+++ b/frontend/src/components/nodes/EntryNode.tsx
@@ -1,6 +1,7 @@
-import { ToggleButton } from '@mui/material';
+import { ToggleButton, Tooltip, Box } from '@mui/material';
 import { alpha, styled } from '@mui/material/styles';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
     getRouteGraphActiveColor,
     getRouteGraphControlFill,
@@ -12,6 +13,7 @@ import {
     AutoAwesome as AutoAwesomeIcon,
     NearMeOutlined as DirectIcon,
 } from '@/components/icons';
+import { NodeTooltip } from './NodeTooltip';
 
 // Styled EntryNode matching ActionAddNode style
 const StyledEntryNode = styled('div')<{ active: boolean; compact?: boolean }>(
@@ -36,13 +38,14 @@ const StyledEntryNode = styled('div')<{ active: boolean; compact?: boolean }>(
         cursor: active ? 'pointer' : 'default',
         opacity: active ? 1 : 0.5,
         outline: 'none',
+        position: 'relative',
         '&:hover': active ? {
             borderColor: getRouteGraphActiveColor(theme),
             boxShadow: [
                 `0 0 0 4px ${alpha(getRouteGraphActiveColor(theme), 0.18)}`,
                 '0 14px 34px rgba(31, 41, 55, 0.14)',
                 '0 3px 10px rgba(31, 41, 55, 0.08)',
-            ].join(', '),
+            ].join(','),
             transform: 'translateY(-2px)',
         } : {},
     })
@@ -84,6 +87,8 @@ export interface EntryNodeProps {
     switchDisabled?: boolean;
     compact?: boolean;  // Horizontal layout
     orientation?: 'horizontal' | 'vertical';  // Alias for compact
+    onShowDirectGuide?: () => void;
+    onShowSmartGuide?: () => void;
 }
 
 /**
@@ -104,66 +109,123 @@ export const EntryNode: React.FC<EntryNodeProps> = ({
     switchDisabled = false,
     compact = false,
     orientation,
+    onShowDirectGuide,
+    onShowSmartGuide,
 }) => {
+    const { t } = useTranslation();
     // Support both compact and orientation props
     const isCompact = compact || orientation === 'horizontal';
 
-    return (
-        <StyledEntryNode active={active} compact={isCompact}>
-            {isCompact ? (
-                // Horizontal layout - buttons side by side
-                <>
-                    <ToggleButtonStyled
-                        value="direct"
-                        selected={!smartEnabled}
-                        disabled={!active || switchDisabled}
-                        onClick={smartEnabled ? onSwitch : undefined}
-                        aria-label="Direct routing mode"
-                        aria-pressed={!smartEnabled}
-                    >
-                        <DirectIcon sx={{ fontSize: 9, transform: 'rotate(90deg)' }} />
-                        Direct
-                    </ToggleButtonStyled>
-                    <ToggleButtonStyled
-                        value="smart"
-                        selected={smartEnabled}
-                        disabled={!active || switchDisabled}
-                        onClick={smartEnabled ? undefined : onSwitch}
-                        aria-label="Smart routing mode"
-                        aria-pressed={smartEnabled}
-                    >
-                        <AutoAwesomeIcon sx={{ fontSize: 9 }} />
-                        Smart
-                    </ToggleButtonStyled>
-                </>
-            ) : (
-                // Vertical layout - buttons stacked
-                <>
-                    <ToggleButtonStyled
-                        value="direct"
-                        selected={!smartEnabled}
-                        disabled={!active || switchDisabled}
-                        onClick={smartEnabled ? onSwitch : undefined}
-                        aria-label="Direct routing mode"
-                        aria-pressed={!smartEnabled}
-                    >
-                        <DirectIcon sx={{ fontSize: 10, transform: 'rotate(90deg)' }} />
-                        Direct
-                    </ToggleButtonStyled>
-                    <ToggleButtonStyled
-                        value="smart"
-                        selected={smartEnabled}
-                        disabled={!active || switchDisabled}
-                        onClick={smartEnabled ? undefined : onSwitch}
-                        aria-label="Smart routing mode"
-                        aria-pressed={smartEnabled}
-                    >
-                        <AutoAwesomeIcon sx={{ fontSize: 10 }} />
-                        Smart
-                    </ToggleButtonStyled>
-                </>
+    const directTitle = t('rule.routing.directTooltipTitle', { defaultValue: 'Direct Routing' });
+    const directBody = t('rule.routing.directTooltipBody', { defaultValue: 'Load balance across all services in tier order. Simple and predictable.' });
+    const smartTitle = t('rule.routing.smartTooltipTitle', { defaultValue: 'Smart Routing' });
+    const smartBody = t('rule.routing.smartTooltipBody', { defaultValue: 'Route based on custom conditions like model name, token count, or user groups.' });
+
+    // Enhanced tooltip with both Direct and Smart info
+    const tooltipContent = (
+        <Box sx={{ whiteSpace: 'pre-line', maxWidth: 280 }}>
+            <strong>{directTitle}</strong>
+            {`\n${directBody}\n\n`}
+            <strong>{smartTitle}</strong>
+            {`\n${smartBody}\n\n`}
+            <Box component="span" sx={{ opacity: 0.7 }}>
+                {t('rule.routing.tooltipHint', { defaultValue: 'Click a button to switch modes' })}
+            </Box>
+            {(onShowDirectGuide || onShowSmartGuide) && (
+                <Box sx={{ mt: 1 }}>
+                    {onShowDirectGuide && (
+                        <Box
+                            component="span"
+                            onClick={(e) => { e.stopPropagation(); onShowDirectGuide(); }}
+                            sx={{
+                                display: 'block',
+                                color: 'primary.main',
+                                cursor: 'pointer',
+                                fontWeight: 500,
+                                '&:hover': { textDecoration: 'underline' }
+                            }}
+                        >
+                            {t('rule.routing.viewDirectGuide', { defaultValue: 'View direct routing guide →' })}
+                        </Box>
+                    )}
+                    {onShowSmartGuide && (
+                        <Box
+                            component="span"
+                            onClick={(e) => { e.stopPropagation(); onShowSmartGuide(); }}
+                            sx={{
+                                display: 'block',
+                                color: 'primary.main',
+                                cursor: 'pointer',
+                                fontWeight: 500,
+                                '&:hover': { textDecoration: 'underline' }
+                            }}
+                        >
+                            {t('rule.routing.viewSmartGuide', { defaultValue: 'View smart routing guide →' })}
+                        </Box>
+                    )}
+                </Box>
             )}
-        </StyledEntryNode>
+        </Box>
+    );
+
+    return (
+        <NodeTooltip title={tooltipContent} placement="top">
+            <StyledEntryNode active={active} compact={isCompact}>
+                {isCompact ? (
+                    // Horizontal layout - buttons side by side
+                    <>
+                        <ToggleButtonStyled
+                            value="direct"
+                            selected={!smartEnabled}
+                            disabled={!active || switchDisabled}
+                            onClick={smartEnabled ? onSwitch : undefined}
+                            aria-label="Direct routing mode"
+                            aria-pressed={!smartEnabled}
+                        >
+                            <DirectIcon sx={{ fontSize: 9, transform: 'rotate(90deg)' }} />
+                            Direct
+                        </ToggleButtonStyled>
+                        <ToggleButtonStyled
+                            value="smart"
+                            selected={smartEnabled}
+                            disabled={!active || switchDisabled}
+                            onClick={smartEnabled ? undefined : onSwitch}
+                            aria-label="Smart routing mode"
+                            aria-pressed={smartEnabled}
+                        >
+                            <AutoAwesomeIcon sx={{ fontSize: 9 }} />
+                            Smart
+                        </ToggleButtonStyled>
+                    </>
+                ) : (
+                    // Vertical layout - buttons stacked
+                    <>
+                        <ToggleButtonStyled
+                            value="direct"
+                            selected={!smartEnabled}
+                            disabled={!active || switchDisabled}
+                            onClick={smartEnabled ? onSwitch : undefined}
+                            aria-label="Direct routing mode"
+                            aria-pressed={!smartEnabled}
+                        >
+                            <DirectIcon sx={{ fontSize: 10, transform: 'rotate(90deg)' }} />
+                            Direct
+                        </ToggleButtonStyled>
+                        <ToggleButtonStyled
+                            value="smart"
+                            selected={smartEnabled}
+                            disabled={!active || switchDisabled}
+                            onClick={smartEnabled ? undefined : onSwitch}
+                            aria-label="Smart routing mode"
+                            aria-pressed={smartEnabled}
+                        >
+                            <AutoAwesomeIcon sx={{ fontSize: 10 }} />
+                            Smart
+                        </ToggleButtonStyled>
+                    </>
+                )}
+            </StyledEntryNode>
+        </NodeTooltip>
     );
 };
 

--- a/frontend/src/components/nodes/ServiceNode.tsx
+++ b/frontend/src/components/nodes/ServiceNode.tsx
@@ -32,6 +32,7 @@ const ServiceNodeWrapper = styled(Box, {
     forceShowActions = false,
 }) => ({
     position: 'relative',
+    overflow: 'visible', // Allow action buttons to extend beyond boundaries
     '&:hover .action-buttons': { opacity: 1 },
     ...(forceShowActions && {
         '& .action-buttons': { opacity: 1 },

--- a/frontend/src/components/nodes/ServiceNode.tsx
+++ b/frontend/src/components/nodes/ServiceNode.tsx
@@ -308,7 +308,7 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
                 {/* Action buttons (hover) */}
                 <ActionButtonsBox className="action-buttons">
                     {onMoveTierUp && (
-                        <NodeTooltip title={t('common.moveUp', { defaultValue: 'Move up' })} placement="bottom">
+                        <NodeTooltip title={t('rule.tier.adjustTier', { defaultValue: 'Adjust tier' })} placement="bottom">
                             <IconButton
                                 size="small"
                                 onClick={(e) => { e.stopPropagation(); onMoveTierUp(); }}
@@ -319,7 +319,7 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
                         </NodeTooltip>
                     )}
                     {onMoveTierDown && (
-                        <NodeTooltip title={t('common.moveDown', { defaultValue: 'Move down' })} placement="bottom">
+                        <NodeTooltip title={t('rule.tier.adjustTier', { defaultValue: 'Adjust tier' })} placement="bottom">
                             <IconButton
                                 size="small"
                                 onClick={(e) => { e.stopPropagation(); onMoveTierDown(); }}

--- a/frontend/src/components/nodes/ServiceNode.tsx
+++ b/frontend/src/components/nodes/ServiceNode.tsx
@@ -26,9 +26,16 @@ import { ServiceNodeContainer, NODE_LAYER_STYLES, ActionButtonsBox } from './sty
 import ServiceNodeContent from './ServiceNodeContent.tsx';
 import NodeTooltip from './NodeTooltip.tsx';
 
-const ServiceNodeWrapper = styled(Box)(() => ({
+const ServiceNodeWrapper = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'forceShowActions',
+})<{ forceShowActions?: boolean }>(({
+    forceShowActions = false,
+}) => ({
     position: 'relative',
     '&:hover .action-buttons': { opacity: 1 },
+    ...(forceShowActions && {
+        '& .action-buttons': { opacity: 1 },
+    }),
 }));
 
 // Inline tier disk — lives inside the left column of the node, no overflow.
@@ -70,6 +77,7 @@ export interface ServiceNodeProps {
     showTier?: boolean;
     onMoveTierUp?: () => void;
     onMoveTierDown?: () => void;
+    forceShowActions?: boolean;
 }
 
 /** @deprecated Use ServiceNodeProps */
@@ -181,6 +189,7 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
     showTier = true,
     onMoveTierUp,
     onMoveTierDown,
+    forceShowActions = false,
 }) => {
     const { t } = useTranslation();
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
@@ -212,7 +221,7 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
     const hasTier = showTier && !!onTierChange;
 
     return (
-        <ServiceNodeWrapper>
+        <ServiceNodeWrapper forceShowActions={forceShowActions}>
             <ServiceNodeContent
                 menuAnchorEl={menuAnchorEl}
                 menuOpen={menuOpen}

--- a/frontend/src/components/nodes/TierNode.tsx
+++ b/frontend/src/components/nodes/TierNode.tsx
@@ -83,40 +83,52 @@ export const TierNode: React.FC<TierNodeProps> = ({
                 onMouseEnter={() => onHover?.(true)}
                 onMouseLeave={() => onHover?.(false)}
             >
-                <Typography
+                <Box
                     sx={{
-                        fontSize: '0.8rem',
-                        fontWeight: 600,
-                        color: 'text.secondary',
-                        lineHeight: 1.15,
+                        position: 'relative',
+                        width: '100%',
+                        height: '100%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
                     }}
                 >
-                    {`T${priority}`}
-                </Typography>
-                {onShowGuide && (
-                    <IconButton
-                        size="small"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            onShowGuide();
-                        }}
+                    <Typography
                         sx={{
-                            position: 'absolute',
-                            top: -8,
-                            right: -8,
-                            p: 0.25,
-                            backgroundColor: 'background.paper',
-                            border: '1px solid',
-                            borderColor: 'divider',
-                            '&:hover': {
-                                backgroundColor: 'action.hover',
-                            }
+                            fontSize: '0.8rem',
+                            fontWeight: 600,
+                            color: 'text.secondary',
+                            lineHeight: 1.15,
                         }}
-                        aria-label={t('rule.tier.guideButtonAriaLabel', { defaultValue: 'Learn about tiers' })}
                     >
-                        <Info sx={{ fontSize: '0.85rem' }} />
-                    </IconButton>
-                )}
+                        {`T${priority}`}
+                    </Typography>
+                    {onShowGuide && (
+                        <IconButton
+                            size="small"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onShowGuide();
+                            }}
+                            sx={{
+                                position: 'absolute',
+                                top: 2,
+                                right: 2,
+                                p: 0.25,
+                                minWidth: 20,
+                                minHeight: 20,
+                                backgroundColor: 'transparent',
+                                border: 'none',
+                                '&:hover': {
+                                    backgroundColor: 'action.hover',
+                                }
+                            }}
+                            aria-label={t('rule.tier.guideButtonAriaLabel', { defaultValue: 'Learn about tiers' })}
+                        >
+                            <Info sx={{ fontSize: '0.7rem' }} />
+                        </IconButton>
+                    )}
+                </Box>
             </Box>
         </NodeTooltip>
     );

--- a/frontend/src/components/nodes/TierNode.tsx
+++ b/frontend/src/components/nodes/TierNode.tsx
@@ -1,7 +1,6 @@
-import { Box, IconButton, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Info } from '@/components/icons';
 import NodeTooltip from './NodeTooltip.tsx';
 import { getRouteGraphBorderColor, PROVIDER_NODE_STYLES } from './styles.tsx';
 
@@ -64,13 +63,14 @@ export const TierNode: React.FC<TierNodeProps> = ({
         <NodeTooltip title={tooltipContent} placement="left" enterDelay={400}>
             <Box
                 sx={(theme) => ({
-                    position: 'relative',
                     width: TIER_NODE_WIDTH,
                     height: PROVIDER_NODE_STYLES.height,
                     flexShrink: 0,
                     display: 'flex',
+                    flexDirection: 'column',
                     alignItems: 'center',
                     justifyContent: 'center',
+                    gap: 0.5,
                     borderRadius: `${theme.shape.borderRadius}px`,
                     border: '1px solid',
                     borderColor: getRouteGraphBorderColor(theme),
@@ -83,52 +83,16 @@ export const TierNode: React.FC<TierNodeProps> = ({
                 onMouseEnter={() => onHover?.(true)}
                 onMouseLeave={() => onHover?.(false)}
             >
-                <Box
+                <Typography
                     sx={{
-                        position: 'relative',
-                        width: '100%',
-                        height: '100%',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
+                        fontSize: '0.8rem',
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        lineHeight: 1.15,
                     }}
                 >
-                    <Typography
-                        sx={{
-                            fontSize: '0.8rem',
-                            fontWeight: 600,
-                            color: 'text.secondary',
-                            lineHeight: 1.15,
-                        }}
-                    >
-                        {`T${priority}`}
-                    </Typography>
-                    {onShowGuide && (
-                        <IconButton
-                            size="small"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                onShowGuide();
-                            }}
-                            sx={{
-                                position: 'absolute',
-                                top: 2,
-                                right: 2,
-                                p: 0.25,
-                                minWidth: 20,
-                                minHeight: 20,
-                                backgroundColor: 'transparent',
-                                border: 'none',
-                                '&:hover': {
-                                    backgroundColor: 'action.hover',
-                                }
-                            }}
-                            aria-label={t('rule.tier.guideButtonAriaLabel', { defaultValue: 'Learn about tiers' })}
-                        >
-                            <Info sx={{ fontSize: '0.7rem' }} />
-                        </IconButton>
-                    )}
-                </Box>
+                    {`T${priority}`}
+                </Typography>
             </Box>
         </NodeTooltip>
     );

--- a/frontend/src/components/nodes/TierNode.tsx
+++ b/frontend/src/components/nodes/TierNode.tsx
@@ -1,12 +1,15 @@
-import { Box, Typography } from '@mui/material';
+import { Box, IconButton, Typography } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Info } from '@/components/icons';
 import NodeTooltip from './NodeTooltip.tsx';
 import { getRouteGraphBorderColor, PROVIDER_NODE_STYLES } from './styles.tsx';
 
 export interface TierNodeProps {
     priority: number;
     active: boolean;
+    onHover?: (hovering: boolean) => void;
+    onShowGuide?: () => void;
 }
 
 export const TIER_NODE_WIDTH = 52;
@@ -17,6 +20,8 @@ export const PRIORITY_TIER_NODE_WIDTH = TIER_NODE_WIDTH;
 export const TierNode: React.FC<TierNodeProps> = ({
     priority,
     active,
+    onHover,
+    onShowGuide,
 }) => {
     const { t } = useTranslation();
 
@@ -29,12 +34,29 @@ export const TierNode: React.FC<TierNodeProps> = ({
         ? t('rule.tier.nodeTooltipPrimaryBody', { defaultValue: 'Tried first on every request. Services here are load-balanced.' })
         : t('rule.tier.nodeTooltipFallbackBody', { tier: priority, prev: priority - 1, defaultValue: 'Tried only when all higher-priority tiers are unavailable (lower number = higher priority). Services here are load-balanced.' });
     const hint = t('rule.tier.nodeMoveHint', { defaultValue: '↑ / ↓  on a service card to move it to a different tier' });
+    const learnMoreLink = onShowGuide ? t('rule.tier.nodeTooltipLearnMore', { defaultValue: 'Learn more about tiers' }) : null;
 
     const tooltipContent = (
         <Box sx={{ whiteSpace: 'pre-line', maxWidth: 240 }}>
             <strong>{title}</strong>
             {`\n${body}\n\n`}
             <Box component="span" sx={{ opacity: 0.7 }}>{hint}</Box>
+            {learnMoreLink && (
+                <Box
+                    component="span"
+                    onClick={(e) => { e.stopPropagation(); onShowGuide(); }}
+                    sx={{
+                        display: 'block',
+                        mt: 1,
+                        color: 'primary.main',
+                        cursor: 'pointer',
+                        fontWeight: 500,
+                        '&:hover': { textDecoration: 'underline' }
+                    }}
+                >
+                    {learnMoreLink}
+                </Box>
+            )}
         </Box>
     );
 
@@ -42,6 +64,7 @@ export const TierNode: React.FC<TierNodeProps> = ({
         <NodeTooltip title={tooltipContent} placement="left" enterDelay={400}>
             <Box
                 sx={(theme) => ({
+                    position: 'relative',
                     width: TIER_NODE_WIDTH,
                     height: PROVIDER_NODE_STYLES.height,
                     flexShrink: 0,
@@ -57,6 +80,8 @@ export const TierNode: React.FC<TierNodeProps> = ({
                     userSelect: 'none',
                     cursor: 'default',
                 })}
+                onMouseEnter={() => onHover?.(true)}
+                onMouseLeave={() => onHover?.(false)}
             >
                 <Typography
                     sx={{
@@ -68,6 +93,30 @@ export const TierNode: React.FC<TierNodeProps> = ({
                 >
                     {`T${priority}`}
                 </Typography>
+                {onShowGuide && (
+                    <IconButton
+                        size="small"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onShowGuide();
+                        }}
+                        sx={{
+                            position: 'absolute',
+                            top: -8,
+                            right: -8,
+                            p: 0.25,
+                            backgroundColor: 'background.paper',
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            '&:hover': {
+                                backgroundColor: 'action.hover',
+                            }
+                        }}
+                        aria-label={t('rule.tier.guideButtonAriaLabel', { defaultValue: 'Learn about tiers' })}
+                    >
+                        <Info sx={{ fontSize: '0.85rem' }} />
+                    </IconButton>
+                )}
             </Box>
         </NodeTooltip>
     );

--- a/frontend/src/components/nodes/styles.tsx
+++ b/frontend/src/components/nodes/styles.tsx
@@ -159,16 +159,22 @@ export const StyledModelNode = styled(Box, { shouldForwardProp: (prop) => prop !
 // are always readable regardless of node opacity or background content.
 export const ActionButtonsBox = styled(Box)(({ theme }: { theme: Theme }) => ({
     position: 'absolute',
-    top: 4,
-    right: 4,
+    top: -36,
+    right: 8,
     display: 'flex',
     gap: 2,
     opacity: 0,
-    transition: 'opacity 0.2s',
+    transition: 'opacity 0.2s, transform 0.2s',
     backgroundColor: theme.palette.background.paper,
     borderRadius: theme.shape.borderRadius,
-    padding: '2px',
-    boxShadow: theme.shadows[1],
+    padding: '4px',
+    boxShadow: theme.shadows[2],
+    border: '1px solid',
+    borderColor: alpha(getRouteGraphBorderColor(theme), 0.6),
+    zIndex: 10,
+    '&:hover': {
+        transform: 'translateY(-2px)',
+    },
 }));
 
 // Smart node wrapper

--- a/frontend/src/components/nodes/styles.tsx
+++ b/frontend/src/components/nodes/styles.tsx
@@ -159,8 +159,8 @@ export const StyledModelNode = styled(Box, { shouldForwardProp: (prop) => prop !
 // are always readable regardless of node opacity or background content.
 export const ActionButtonsBox = styled(Box)(({ theme }: { theme: Theme }) => ({
     position: 'absolute',
-    top: -36,
-    right: 8,
+    top: 0,
+    right: 0,
     display: 'flex',
     gap: 2,
     opacity: 0,

--- a/frontend/src/components/tier/EntryGuideDialog.tsx
+++ b/frontend/src/components/tier/EntryGuideDialog.tsx
@@ -1,0 +1,311 @@
+import {
+    Box,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    Paper,
+    Step,
+    StepLabel,
+    Stepper,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
+import { Close as CloseIcon } from '@/components/icons';
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ROUTING_GUIDE_STEPS, type GuideStep } from './diagrams';
+import { StaticGraphViewer } from './StaticGraphViewer';
+
+export interface EntryGuideDialogProps {
+    open: boolean;
+    onClose: () => void;
+    initialStep?: number;
+    mode?: 'direct' | 'smart';
+}
+
+export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
+    open,
+    onClose,
+    initialStep = 0,
+    mode = 'direct',
+}) => {
+    const { t } = useTranslation();
+    const theme = useTheme();
+    const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+    const [activeStep, setActiveStep] = React.useState(initialStep);
+    const maxSteps = ROUTING_GUIDE_STEPS.length;
+    const currentStep = ROUTING_GUIDE_STEPS[activeStep];
+    const triggerRef = useRef<HTMLElement | null>(null);
+
+    // Filter steps based on mode
+    const filteredSteps = ROUTING_GUIDE_STEPS.filter((step, index) => {
+        if (mode === 'direct') {
+            // Show steps 1-3 (Direct routing)
+            return index < 3;
+        } else {
+            // Show steps 4-6 (Smart routing)
+            return index >= 3;
+        }
+    });
+
+    const adjustedMaxSteps = filteredSteps.length;
+    const adjustedActiveStep = mode === 'direct' ? activeStep : activeStep - 3;
+    const currentFilteredStep = filteredSteps[adjustedActiveStep] || filteredSteps[0];
+
+    // Store trigger element for focus restoration
+    React.useEffect(() => {
+        if (open && !triggerRef.current) {
+            triggerRef.current = document.activeElement as HTMLElement;
+        }
+        return () => {
+            triggerRef.current = null;
+        };
+    }, [open]);
+
+    // Handle keyboard escape
+    React.useEffect(() => {
+        const handleEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && open) {
+                handleClose();
+            }
+        };
+        document.addEventListener('keydown', handleEscape);
+        return () => document.removeEventListener('keydown', handleEscape);
+    }, [open]);
+
+    // Adjust active step when mode changes
+    React.useEffect(() => {
+        if (mode === 'smart' && activeStep < 3) {
+            setActiveStep(3);
+        } else if (mode === 'direct' && activeStep >= 3) {
+            setActiveStep(0);
+        }
+    }, [mode]);
+
+    const handleNext = () => {
+        const nextStep = mode === 'direct' ? activeStep + 1 : activeStep + 1;
+        if (mode === 'direct' && nextStep < 3) {
+            setActiveStep(nextStep);
+        } else if (mode === 'smart' && nextStep < ROUTING_GUIDE_STEPS.length) {
+            setActiveStep(nextStep);
+        } else {
+            handleClose();
+        }
+    };
+
+    const handleBack = () => {
+        if (mode === 'direct') {
+            setActiveStep(Math.max(0, activeStep - 1));
+        } else {
+            setActiveStep(Math.max(3, activeStep - 1));
+        }
+    };
+
+    const handleClose = () => {
+        setActiveStep(mode === 'direct' ? 0 : 3);
+        onClose();
+        // Restore focus to trigger element
+        if (triggerRef.current) {
+            triggerRef.current.focus();
+        }
+    };
+
+    const handleStepChange = (step: number) => {
+        setActiveStep(mode === 'direct' ? step : step + 3);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleNext();
+        }
+    };
+
+    const guideTitle = mode === 'direct'
+        ? t('rule.routing.guide.directTitle', { defaultValue: 'Direct Routing Guide' })
+        : t('rule.routing.guide.smartTitle', { defaultValue: 'Smart Routing Guide' });
+
+    return (
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            fullScreen={fullScreen}
+            maxWidth="lg"
+            aria-labelledby="entry-guide-dialog-title"
+            aria-describedby="entry-guide-dialog-description"
+            onKeyDown={handleKeyDown}
+            PaperProps={{
+                sx: {
+                    borderRadius: fullScreen ? 0 : 2,
+                    maxHeight: '90vh',
+                    width: fullScreen ? '100%' : '90vw',
+                    maxWidth: fullScreen ? '100vw' : '900px',
+                }
+            }}
+        >
+            <DialogTitle id="entry-guide-dialog-title" sx={{ pr: 8 }}>
+                <Typography variant="h6" component="div">
+                    {guideTitle}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                    {t('rule.routing.guide.subtitle', { defaultValue: 'Step {{current}} of {{total}}', current: adjustedActiveStep + 1, total: adjustedMaxSteps })}
+                </Typography>
+            </DialogTitle>
+            <IconButton
+                aria-label={t('common.close', { defaultValue: 'Close' })}
+                onClick={handleClose}
+                sx={{
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: (theme) => theme.palette.grey[500],
+                }}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent id="entry-guide-dialog-description" dividers sx={{ p: 0 }}>
+                <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%', gap: 2 }}>
+                    {/* Left side: Vertical Stepper */}
+                    <Box sx={{
+                        width: { xs: '100%', sm: 220 },
+                        py: { xs: 2, sm: 3 },
+                        px: { xs: 2, sm: 1 },
+                        display: 'flex',
+                        flexDirection: { xs: 'row', sm: 'column' },
+                        alignItems: { xs: 'center', sm: 'flex-start' },
+                        overflowX: { xs: 'auto', sm: 'visible' },
+                        flexShrink: 0,
+                    }}>
+                        <Stepper
+                            activeStep={adjustedActiveStep}
+                            orientation={fullScreen ? 'horizontal' : 'vertical'}
+                            sx={{
+                                '& .MuiStepLabel-root': {
+                                    cursor: 'pointer',
+                                },
+                                '& .Mui-completed,& .Mui-active': {
+                                    '& .MuiStepLabel-iconContainer': {
+                                        color: 'primary.main',
+                                    },
+                                },
+                            }}
+                        >
+                            {filteredSteps.map((step, index) => (
+                                <Step key={index} onClick={() => handleStepChange(index)}>
+                                    <StepLabel>
+                                        {fullScreen ? '' : t(step.title, { defaultValue: `Step ${index + 1}` })}
+                                    </StepLabel>
+                                </Step>
+                            ))}
+                        </Stepper>
+                    </Box>
+
+                    {/* Right side: Content */}
+                    <Box sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        minWidth: 0,
+                        py: { xs: 2, sm: 3 },
+                        px: { xs: 2, sm: 3 },
+                    }}>
+                        {/* Static Graph Diagram */}
+                        <Box sx={{
+                            bgcolor: 'background.default',
+                            p: { xs: 2, sm: 3 },
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            minHeight: 280,
+                            maxHeight: 400,
+                            overflow: 'auto',
+                            borderRadius: 1,
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            position: 'relative',
+                        }}>
+                            <Box sx={{ width: '100%', maxWidth: 700 }}>
+                                <StaticGraphViewer
+                                    scenario={currentFilteredStep.diagram}
+                                    interactive={true}
+                                />
+                            </Box>
+                            {/* Hover hint */}
+                            <Box sx={{
+                                position: 'absolute',
+                                bottom: 8,
+                                right: 8,
+                                bgcolor: 'rgba(0,0,0,0.7)',
+                                color: 'white',
+                                px: 1.5,
+                                py: 0.5,
+                                borderRadius: 1,
+                                fontSize: '0.75rem',
+                                opacity: 0.8,
+                            }}>
+                                💡 {t('rule.routing.guide.hoverHint', { defaultValue: 'Action buttons shown - try hovering over nodes!' })}
+                            </Box>
+                        </Box>
+
+                        {/* Explanation Text */}
+                        <Box sx={{ mt: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
+                            <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
+                                {t(currentFilteredStep.content, { defaultValue: currentFilteredStep.content })}
+                            </Typography>
+
+                            {/* Annotations */}
+                            {currentFilteredStep.annotations && currentFilteredStep.annotations.length > 0 && (
+                                <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {currentFilteredStep.annotations.map((annotation, idx) => (
+                                        <Paper
+                                            key={idx}
+                                            variant="outlined"
+                                            sx={{
+                                                p: 1.5,
+                                                bgcolor: 'action.hover',
+                                                borderRadius: 1,
+                                                flex: '1 1 45%',
+                                            }}
+                                        >
+                                            <Typography variant="caption" color="primary" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+                                                {t(annotation.text, { defaultValue: annotation.text })}
+                                            </Typography>
+                                        </Paper>
+                                    ))}
+                                </Box>
+                            )}
+                        </Box>
+                    </Box>
+                </Box>
+            </DialogContent>
+            <DialogActions sx={{ justifyContent: 'space-between', px: { xs: 2, sm: 3 }, py: 2 }}>
+                <Button
+                    disabled={adjustedActiveStep === 0}
+                    onClick={handleBack}
+                    variant="outlined"
+                    size="small"
+                    sx={{ minWidth: 100 }}
+                >
+                    {t('rule.routing.guide.previous', { defaultValue: 'Previous' })}
+                </Button>
+                <Button
+                    onClick={handleNext}
+                    variant="contained"
+                    size="small"
+                    sx={{ minWidth: 100 }}
+                >
+                    {adjustedActiveStep === adjustedMaxSteps - 1
+                        ? t('rule.routing.guide.gotIt', { defaultValue: 'Got it!' })
+                        : t('rule.routing.guide.next', { defaultValue: 'Next' })
+                    }
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default EntryGuideDialog;

--- a/frontend/src/components/tier/StaticGraphViewer.tsx
+++ b/frontend/src/components/tier/StaticGraphViewer.tsx
@@ -1,0 +1,92 @@
+import { Box, type SxProps } from '@mui/material';
+import React from 'react';
+import { UnifiedRoutingGraph } from '@/components/UnifiedRoutingGraph';
+import type { ConfigRecord, Provider } from '@/components';
+import { TIER_DIAGRAM_DATA } from './diagrams';
+
+export interface StaticGraphViewerProps {
+    scenario: string;
+    interactive?: boolean;
+    sx?: SxProps;
+}
+
+/**
+ * StaticGraphViewer - Renders a non-functional UnifiedRoutingGraph for demonstration purposes.
+ *
+ * This component wraps UnifiedRoutingGraph with demo-mode settings that:
+ * - Disable all action callbacks (no actual configuration changes)
+ * - Preserve hover states and tooltips for interactivity
+ * - Show the visual structure of tier configurations
+ */
+export const StaticGraphViewer: React.FC<StaticGraphViewerProps> = ({
+    scenario,
+    interactive = false,
+    sx,
+    ...props
+}) => {
+    const diagramData = TIER_DIAGRAM_DATA[scenario];
+    if (!diagramData) {
+        return (
+            <Box sx={{ textAlign: 'center', color: 'text.secondary', ...sx }} {...props}>
+                Diagram not found: {scenario}
+            </Box>
+        );
+    }
+
+    const {
+        record,
+        providers,
+        active = true,
+    } = diagramData;
+
+    // Create demo callbacks that do nothing
+    const handleUpdateRecord = () => {};
+    const handleProviderNodeClick = () => {};
+    const handleTierChange = () => {};
+    const handleDeleteProvider = () => {};
+    const handleAddService = () => {};
+    const handleAddSmartRule = () => {};
+    const handleEditSmartRule = () => {};
+    const handleDeleteSmartRule = () => {};
+    const handleMoveSmartRule = () => {};
+    const handleAddServiceToSmartRule = () => {};
+    const handleDeleteServiceFromSmartRule = () => {};
+    const handleSwitchRoutingMode = () => {};
+
+    return (
+        <Box
+            sx={{
+                width: '100%',
+                maxWidth: '100%',
+                minWidth: 300,
+                ...sx,
+            }}
+            {...props}
+        >
+            <UnifiedRoutingGraph
+                mode="auto"
+                record={record}
+                providers={providers}
+                active={active}
+                saving={false}
+                expanded={true}
+                collapsible={false}
+                guideMode={true}
+                onUpdateRecord={handleUpdateRecord}
+                onProviderNodeClick={handleProviderNodeClick}
+                onTierChange={handleTierChange}
+                onDeleteProvider={handleDeleteProvider}
+                onAddService={handleAddService}
+                onAddSmartRule={handleAddSmartRule}
+                onEditSmartRule={handleEditSmartRule}
+                onDeleteSmartRule={handleDeleteSmartRule}
+                onMoveSmartRule={handleMoveSmartRule}
+                onAddServiceToSmartRule={handleAddServiceToSmartRule}
+                onDeleteServiceFromSmartRule={handleDeleteServiceFromSmartRule}
+                onSwitchRoutingMode={handleSwitchRoutingMode}
+            />
+        </Box>
+    );
+};
+
+export default StaticGraphViewer;

--- a/frontend/src/components/tier/TierGuideDialog.tsx
+++ b/frontend/src/components/tier/TierGuideDialog.tsx
@@ -1,0 +1,274 @@
+import {
+    Box,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    Paper,
+    Step,
+    StepLabel,
+    Stepper,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
+import { Close as CloseIcon } from '@/components/icons';
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TIER_GUIDE_STEPS, type GuideStep } from './diagrams';
+import { StaticGraphViewer } from './StaticGraphViewer';
+
+export interface TierGuideDialogProps {
+    open: boolean;
+    onClose: () => void;
+    initialStep?: number;
+}
+
+export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
+    open,
+    onClose,
+    initialStep = 0,
+}) => {
+    const { t } = useTranslation();
+    const theme = useTheme();
+    const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+    const [activeStep, setActiveStep] = React.useState(initialStep);
+    const maxSteps = TIER_GUIDE_STEPS.length;
+    const currentStep = TIER_GUIDE_STEPS[activeStep];
+    const triggerRef = useRef<HTMLElement | null>(null);
+
+    // Store trigger element for focus restoration
+    React.useEffect(() => {
+        if (open && !triggerRef.current) {
+            triggerRef.current = document.activeElement as HTMLElement;
+        }
+        return () => {
+            triggerRef.current = null;
+        };
+    }, [open]);
+
+    // Handle keyboard escape
+    React.useEffect(() => {
+        const handleEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && open) {
+                handleClose();
+            }
+        };
+        document.addEventListener('keydown', handleEscape);
+        return () => document.removeEventListener('keydown', handleEscape);
+    }, [open]);
+
+    const handleNext = () => {
+        if (activeStep < maxSteps - 1) {
+            setActiveStep(activeStep + 1);
+        } else {
+            handleClose();
+        }
+    };
+
+    const handleBack = () => {
+        setActiveStep(Math.max(0, activeStep - 1));
+    };
+
+    const handleClose = () => {
+        setActiveStep(0);
+        onClose();
+        // Restore focus to trigger element
+        if (triggerRef.current) {
+            triggerRef.current.focus();
+        }
+    };
+
+    const handleStepChange = (step: number) => {
+        setActiveStep(step);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleNext();
+        }
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            fullScreen={fullScreen}
+            maxWidth="lg"
+            aria-labelledby="tier-guide-dialog-title"
+            aria-describedby="tier-guide-dialog-description"
+            onKeyDown={handleKeyDown}
+            PaperProps={{
+                sx: {
+                    borderRadius: fullScreen ? 0 : 2,
+                    maxHeight: '90vh',
+                    width: fullScreen ? '100%' : '90vw',
+                    maxWidth: fullScreen ? '100vw' : '900px',
+                }
+            }}
+        >
+            <DialogTitle id="tier-guide-dialog-title" sx={{ pr: 8 }}>
+                <Typography variant="h6" component="div">
+                    {t(`rule.tier.guide.steps.${activeStep + 1}.title`)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                    {t('rule.tier.guide.subtitle', { defaultValue: 'Step {{current}} of {{total}}', current: activeStep + 1, total: maxSteps })}
+                </Typography>
+            </DialogTitle>
+            <IconButton
+                aria-label={t('common.close', { defaultValue: 'Close' })}
+                onClick={handleClose}
+                sx={{
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: (theme) => theme.palette.grey[500],
+                }}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent id="tier-guide-dialog-description" dividers sx={{ p: 0 }}>
+                <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%', gap: 2 }}>
+                    {/* Left side: Vertical Stepper */}
+                    <Box sx={{
+                        width: { xs: '100%', sm: 220 },
+                        py: { xs: 2, sm: 3 },
+                        px: { xs: 2, sm: 1 },
+                        display: 'flex',
+                        flexDirection: { xs: 'row', sm: 'column' },
+                        alignItems: { xs: 'center', sm: 'flex-start' },
+                        overflowX: { xs: 'auto', sm: 'visible' },
+                        flexShrink: 0,
+                    }}>
+                        <Stepper
+                            activeStep={activeStep}
+                            orientation={fullScreen ? 'horizontal' : 'vertical'}
+                            sx={{
+                                '& .MuiStepLabel-root': {
+                                    cursor: 'pointer',
+                                },
+                                '& .Mui-completed,& .Mui-active': {
+                                    '& .MuiStepLabel-iconContainer': {
+                                        color: 'primary.main',
+                                    },
+                                },
+                            }}
+                        >
+                            {TIER_GUIDE_STEPS.map((step, index) => (
+                                <Step key={index} onClick={() => handleStepChange(index)}>
+                                    <StepLabel>
+                                        {fullScreen ? '' : t(step.title, { defaultValue: `Step ${index + 1}` })}
+                                    </StepLabel>
+                                </Step>
+                            ))}
+                        </Stepper>
+                    </Box>
+
+                    {/* Right side: Content */}
+                    <Box sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        minWidth: 0,
+                        py: { xs: 2, sm: 3 },
+                        px: { xs: 2, sm: 3 },
+                    }}>
+                        {/* Static Graph Diagram */}
+                        <Box sx={{
+                            bgcolor: 'background.default',
+                            p: { xs: 2, sm: 3 },
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            minHeight: 280,
+                            maxHeight: 400,
+                            overflow: 'auto',
+                            borderRadius: 1,
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            position: 'relative',
+                        }}>
+                            <Box sx={{ width: '100%', maxWidth: 700 }}>
+                                <StaticGraphViewer
+                                    scenario={currentStep.diagram}
+                                    interactive={true}
+                                />
+                            </Box>
+                            {/* Hover hint */}
+                            <Box sx={{
+                                position: 'absolute',
+                                bottom: 8,
+                                right: 8,
+                                bgcolor: 'rgba(0,0,0,0.7)',
+                                color: 'white',
+                                px: 1.5,
+                                py: 0.5,
+                                borderRadius: 1,
+                                fontSize: '0.75rem',
+                                opacity: 0.8,
+                            }}>
+                                💡 {t('rule.tier.guide.hoverHint', { defaultValue: 'Action buttons shown - try hovering over nodes!' })}
+                            </Box>
+                        </Box>
+
+                        {/* Explanation Text */}
+                        <Box sx={{ mt: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
+                            <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
+                                {t(currentStep.content, { defaultValue: currentStep.content })}
+                            </Typography>
+
+                            {/* Annotations */}
+                            {currentStep.annotations && currentStep.annotations.length > 0 && (
+                                <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {currentStep.annotations.map((annotation, idx) => (
+                                        <Paper
+                                            key={idx}
+                                            variant="outlined"
+                                            sx={{
+                                                p: 1.5,
+                                                bgcolor: 'action.hover',
+                                                borderRadius: 1,
+                                                flex: '1 1 45%',
+                                            }}
+                                        >
+                                            <Typography variant="caption" color="primary" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+                                                {t(annotation.text, { defaultValue: annotation.text })}
+                                            </Typography>
+                                        </Paper>
+                                    ))}
+                                </Box>
+                            )}
+                        </Box>
+                    </Box>
+                </Box>
+            </DialogContent>
+            <DialogActions sx={{ justifyContent: 'space-between', px: { xs: 2, sm: 3 }, py: 2 }}>
+                <Button
+                    disabled={activeStep === 0}
+                    onClick={handleBack}
+                    variant="outlined"
+                    size="small"
+                    sx={{ minWidth: 100 }}
+                >
+                    {t('rule.tier.guide.previous', { defaultValue: 'Previous' })}
+                </Button>
+                <Button
+                    onClick={handleNext}
+                    variant="contained"
+                    size="small"
+                    sx={{ minWidth: 100 }}
+                >
+                    {activeStep === maxSteps - 1
+                        ? t('rule.tier.guide.gotIt', { defaultValue: 'Got it!' })
+                        : t('rule.tier.guide.next', { defaultValue: 'Next' })
+                    }
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default TierGuideDialog;

--- a/frontend/src/components/tier/diagrams.ts
+++ b/frontend/src/components/tier/diagrams.ts
@@ -11,6 +11,13 @@ export enum TierDiagramType {
     TWO_PROVIDERS_DIFFERENT_TIERS = 'two-providers-different-tiers',
     THREE_TIERS = 'three-tiers',
     RUNTIME_FAILOVER = 'runtime-failover',
+    // Direct routing diagrams
+    DIRECT_SINGLE = 'direct-single',
+    DIRECT_MULTIPLE_TIERS = 'direct-multiple-tiers',
+    // Smart routing diagrams
+    SMART_BASIC = 'smart-basic',
+    SMART_CONDITIONS = 'smart-conditions',
+    SMART_COMPLEX = 'smart-complex',
 }
 
 /**
@@ -231,6 +238,218 @@ export const TIER_DIAGRAM_DATA: Record<string, {
         providers: MOCK_PROVIDERS,
         active: true,
     },
+
+    // Direct routing diagrams
+    [TierDiagramType.DIRECT_SINGLE]: {
+        record: {
+            uuid: 'rule-direct-single',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Direct routing with single provider',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'random', params: {} },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.DIRECT_MULTIPLE_TIERS]: {
+        record: {
+            uuid: 'rule-direct-multi',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Direct routing with multiple tiers',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-3',
+                    provider: 'provider-3',
+                    model: 'gpt-4',
+                    tier: 1,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'tier', params: { within_tier_tactic: 'random' } },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    // Smart routing diagrams
+    [TierDiagramType.SMART_BASIC]: {
+        record: {
+            uuid: 'rule-smart-basic',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Smart routing with basic conditions',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 0,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'smart', params: {} },
+            smartEnabled: true,
+            smartRouting: [
+                {
+                    service: 'svc-2',
+                    condition: {
+                        field: 'request_model',
+                        op: 'contains',
+                        value: 'claude',
+                    },
+                },
+            ],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.SMART_CONDITIONS]: {
+        record: {
+            uuid: 'rule-smart-conditions',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Smart routing with multiple conditions',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-3',
+                    provider: 'provider-3',
+                    model: 'gpt-4',
+                    tier: 1,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'smart', params: {} },
+            smartEnabled: true,
+            smartRouting: [
+                {
+                    service: 'svc-2',
+                    condition: {
+                        field: 'request_model',
+                        op: 'contains',
+                        value: 'claude',
+                    },
+                },
+                {
+                    service: 'svc-3',
+                    condition: {
+                        field: 'max_tokens',
+                        op: 'gt',
+                        value: '4000',
+                    },
+                },
+            ],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.SMART_COMPLEX]: {
+        record: {
+            uuid: 'rule-smart-complex',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Smart routing with complex conditions',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-3',
+                    provider: 'provider-3',
+                    model: 'gpt-4',
+                    tier: 1,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'smart', params: {} },
+            smartEnabled: true,
+            smartRouting: [
+                {
+                    service: 'svc-2',
+                    condition: {
+                        field: 'request_model',
+                        op: 'contains',
+                        value: 'claude',
+                    },
+                },
+                {
+                    service: 'svc-3',
+                    condition: {
+                        field: 'max_tokens',
+                        op: 'gt',
+                        value: '4000',
+                    },
+                },
+                {
+                    service: 'svc-1',
+                    condition: {
+                        field: 'user_group',
+                        op: 'eq',
+                        value: 'premium',
+                    },
+                },
+            ],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
 };
 
 /**
@@ -287,6 +506,77 @@ export const TIER_GUIDE_STEPS: GuideStep[] = [
         annotations: [
             { target: '.tier-node-0', text: 'rule.tier.guide.steps.5.annotation.priority' },
             { target: '.tier-node-1', text: 'rule.tier.guide.steps.5.annotation.cascade' },
+        ],
+    },
+];
+
+/**
+ * Routing guide steps configuration for Direct vs Smart routing
+ *
+ * Each step includes:
+ * - diagram: Which scenario to display
+ * - title: i18n key for step title (format: `rule.routing.guide.steps.{stepNumber}.title`)
+ * - content: i18n key for explanation text
+ * - annotations: Optional callout annotations for key elements
+ */
+export const ROUTING_GUIDE_STEPS: GuideStep[] = [
+    {
+        diagram: TierDiagramType.DIRECT_SINGLE,
+        title: 'rule.routing.guide.steps.1.title',
+        content: 'rule.routing.guide.steps.1.content',
+        annotations: [
+            { target: '.entry-node', text: 'rule.routing.guide.steps.1.annotation.entryNode' },
+            { target: '.direct-button', text: 'rule.routing.guide.steps.1.annotation.directButton' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.TWO_PROVIDERS_SAME_TIER,
+        title: 'rule.routing.guide.steps.2.title',
+        content: 'rule.routing.guide.steps.2.content',
+        annotations: [
+            { target: '.entry-node', text: 'rule.routing.guide.steps.2.annotation.loadBalance' },
+            { target: '.service-node-0', text: 'rule.routing.guide.steps.2.annotation.services' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.DIRECT_MULTIPLE_TIERS,
+        title: 'rule.routing.guide.steps.3.title',
+        content: 'rule.routing.guide.steps.3.content',
+        annotations: [
+            { target: '.tier-node-0', text: 'rule.routing.guide.steps.3.annotation.primary' },
+            { target: '.tier-node-1', text: 'rule.routing.guide.steps.3.annotation.fallback' },
+            { target: '.entry-node', text: 'rule.routing.guide.steps.3.annotation.tierBased' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.SMART_BASIC,
+        title: 'rule.routing.guide.steps.4.title',
+        content: 'rule.routing.guide.steps.4.content',
+        annotations: [
+            { target: '.entry-node', text: 'rule.routing.guide.steps.4.annotation.smartMode' },
+            { target: '.smart-button', text: 'rule.routing.guide.steps.4.annotation.smartButton' },
+            { target: '.service-node-1', text: 'rule.routing.guide.steps.4.annotation.conditional' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.SMART_CONDITIONS,
+        title: 'rule.routing.guide.steps.5.title',
+        content: 'rule.routing.guide.steps.5.content',
+        annotations: [
+            { target: '.entry-node', text: 'rule.routing.guide.steps.5.annotation.conditions' },
+            { target: '.service-node-1', text: 'rule.routing.guide.steps.5.annotation.modelBased' },
+            { target: '.service-node-2', text: 'rule.routing.guide.steps.5.annotation.tokenBased' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.SMART_COMPLEX,
+        title: 'rule.routing.guide.steps.6.title',
+        content: 'rule.routing.guide.steps.6.content',
+        annotations: [
+            { target: '.entry-node', text: 'rule.routing.guide.steps.6.annotation.complex' },
+            { target: '.service-node-0', text: 'rule.routing.guide.steps.6.annotation.defaultRoute' },
+            { target: '.service-node-1', text: 'rule.routing.guide.steps.6.annotation.claudeRoute' },
+            { target: '.service-node-2', text: 'rule.routing.guide.steps.6.annotation.largeContext' },
         ],
     },
 ];

--- a/frontend/src/components/tier/diagrams.ts
+++ b/frontend/src/components/tier/diagrams.ts
@@ -1,0 +1,292 @@
+import type { ConfigRecord } from '@/components/RoutingGraphTypes';
+import type { Provider } from '@/types/provider';
+
+/**
+ * Tier diagram types for different configuration scenarios
+ */
+export enum TierDiagramType {
+    EMPTY = 'empty',
+    SINGLE_PROVIDER = 'single-provider',
+    TWO_PROVIDERS_SAME_TIER = 'two-providers-same-tier',
+    TWO_PROVIDERS_DIFFERENT_TIERS = 'two-providers-different-tiers',
+    THREE_TIERS = 'three-tiers',
+    RUNTIME_FAILOVER = 'runtime-failover',
+}
+
+/**
+ * Annotation for diagram elements
+ */
+export interface Annotation {
+    target: string; // CSS selector or element identifier
+    text: string; // i18n key
+    position?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+/**
+ * Single step in the tier guide
+ */
+export interface GuideStep {
+    diagram: TierDiagramType;
+    title: string; // i18n key (will be looked up as `rule.tier.guide.steps.{stepNumber}.title`)
+    content: string; // i18n key
+    annotations?: Annotation[];
+}
+
+/**
+ * Mock provider data for diagrams
+ */
+const MOCK_PROVIDERS: Provider[] = [
+    {
+        uuid: 'provider-1',
+        name: 'OpenAI',
+        api_base: 'https://api.openai.com',
+        api_key: 'sk-***',
+        api_style: 'openai',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+        uuid: 'provider-2',
+        name: 'Anthropic',
+        api_base: 'https://api.anthropic.com',
+        api_key: 'sk-ant-***',
+        api_style: 'anthropic',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+        uuid: 'provider-3',
+        name: 'Azure OpenAI',
+        api_base: 'https://azure.openai.com',
+        api_key: 'sk-azure-***',
+        api_style: 'openai',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+    },
+];
+
+/**
+ * Diagram data for each scenario
+ */
+export const TIER_DIAGRAM_DATA: Record<string, {
+    record: ConfigRecord;
+    providers: Provider[];
+    active: boolean;
+}> = {
+    [TierDiagramType.EMPTY]: {
+        record: {
+            uuid: 'rule-empty',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Example rule',
+            providers: [],
+            lbTactic: { type: 'random', params: {} },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.SINGLE_PROVIDER]: {
+        record: {
+            uuid: 'rule-single',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Single provider rule',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'random', params: {} },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.TWO_PROVIDERS_SAME_TIER]: {
+        record: {
+            uuid: 'rule-same-tier',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Load balancing example',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 0,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'tier', params: { within_tier_tactic: 'random' } },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.TWO_PROVIDERS_DIFFERENT_TIERS]: {
+        record: {
+            uuid: 'rule-different-tiers',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Primary and fallback example',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 1,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'tier', params: { within_tier_tactic: 'random' } },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.THREE_TIERS]: {
+        record: {
+            uuid: 'rule-three-tiers',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Multi-tier fallback example',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 1,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-3',
+                    provider: 'provider-3',
+                    model: 'gpt-4',
+                    tier: 2,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'tier', params: { within_tier_tactic: 'random' } },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+
+    [TierDiagramType.RUNTIME_FAILOVER]: {
+        record: {
+            uuid: 'rule-failover',
+            requestModel: 'claude-3-5-sonnet-20241022',
+            description: 'Failover scenario',
+            providers: [
+                {
+                    uuid: 'svc-1',
+                    provider: 'provider-1',
+                    model: 'gpt-4',
+                    tier: 0,
+                    active: true,
+                },
+                {
+                    uuid: 'svc-2',
+                    provider: 'provider-2',
+                    model: 'claude-3-5-sonnet-20241022',
+                    tier: 1,
+                    active: true,
+                },
+            ],
+            lbTactic: { type: 'tier', params: { within_tier_tactic: 'random' } },
+            smartEnabled: false,
+            smartRouting: [],
+        },
+        providers: MOCK_PROVIDERS,
+        active: true,
+    },
+};
+
+/**
+ * Tier guide steps configuration
+ *
+ * Each step includes:
+ * - diagram: Which scenario to display
+ * - title: i18n key for step title (format: `rule.tier.guide.steps.{stepNumber}.title`)
+ * - content: i18n key for explanation text
+ * - annotations: Optional callout annotations for key elements
+ */
+export const TIER_GUIDE_STEPS: GuideStep[] = [
+    {
+        diagram: TierDiagramType.SINGLE_PROVIDER,
+        title: 'rule.tier.guide.steps.1.title',
+        content: 'rule.tier.guide.steps.1.content',
+        annotations: [
+            { target: '.tier-node-0', text: 'rule.tier.guide.steps.1.annotation.tier' },
+            { target: '.service-node-0', text: 'rule.tier.guide.steps.1.annotation.service' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.TWO_PROVIDERS_SAME_TIER,
+        title: 'rule.tier.guide.steps.2.title',
+        content: 'rule.tier.guide.steps.2.content',
+        annotations: [
+            { target: '.tier-node-0', text: 'rule.tier.guide.steps.2.annotation.loadBalance' },
+            { target: '.service-node-0', text: 'rule.tier.guide.steps.2.annotation.multiple' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.TWO_PROVIDERS_DIFFERENT_TIERS,
+        title: 'rule.tier.guide.steps.3.title',
+        content: 'rule.tier.guide.steps.3.content',
+        annotations: [
+            { target: '.tier-node-0', text: 'rule.tier.guide.steps.3.annotation.primary' },
+            { target: '.tier-node-1', text: 'rule.tier.guide.steps.3.annotation.fallback' },
+            { target: '.service-node-0', text: 'rule.tier.guide.steps.3.annotation.actionButtons' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.RUNTIME_FAILOVER,
+        title: 'rule.tier.guide.steps.4.title',
+        content: 'rule.tier.guide.steps.4.content',
+        annotations: [
+            { target: '.tier-node-0', text: 'rule.tier.guide.steps.4.annotation.circuitBreaker' },
+            { target: '.tier-node-1', text: 'rule.tier.guide.steps.4.annotation.automaticFailover' },
+        ],
+    },
+    {
+        diagram: TierDiagramType.THREE_TIERS,
+        title: 'rule.tier.guide.steps.5.title',
+        content: 'rule.tier.guide.steps.5.content',
+        annotations: [
+            { target: '.tier-node-0', text: 'rule.tier.guide.steps.5.annotation.priority' },
+            { target: '.tier-node-1', text: 'rule.tier.guide.steps.5.annotation.cascade' },
+        ],
+    },
+];

--- a/frontend/src/components/tier/index.ts
+++ b/frontend/src/components/tier/index.ts
@@ -1,0 +1,11 @@
+export { TierGuideDialog } from './TierGuideDialog';
+export { default as TierGuideDialog } from './TierGuideDialog';
+export type { TierGuideDialogProps } from './TierGuideDialog';
+
+export { StaticGraphViewer } from './StaticGraphViewer';
+export { default as StaticGraphViewer } from './StaticGraphViewer';
+export type { StaticGraphViewerProps } from './StaticGraphViewer';
+
+export { TIER_GUIDE_STEPS, TIER_DIAGRAM_DATA } from './diagrams';
+export type { GuideStep, Annotation } from './diagrams';
+export { TierDiagramType } from './diagrams';

--- a/frontend/src/hooks/useTierGuidePreferences.ts
+++ b/frontend/src/hooks/useTierGuidePreferences.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+
+const TIER_GUIDE_PREFERENCES_KEY = 'tingly.tierGuide.preferences';
+
+export interface TierGuidePreferences {
+    seen: boolean;
+    dismissedAt: number | null;
+    lastVersion: string;
+    context: {
+        firstProviderShown: boolean;
+        tierHoverShown: boolean;
+        manualShown: boolean;
+    };
+}
+
+const DEFAULT_PREFERENCES: TierGuidePreferences = {
+    seen: false,
+    dismissedAt: null,
+    lastVersion: '1.0.0',
+    context: {
+        firstProviderShown: false,
+        tierHoverShown: false,
+        manualShown: false,
+    },
+};
+
+/**
+ * Load tier guide preferences from localStorage
+ */
+export const loadTierGuidePreferences = (): TierGuidePreferences => {
+    if (typeof window === 'undefined') {
+        return DEFAULT_PREFERENCES;
+    }
+
+    try {
+        const stored = localStorage.getItem(TIER_GUIDE_PREFERENCES_KEY);
+        if (stored) {
+            return { ...DEFAULT_PREFERENCES, ...JSON.parse(stored) };
+        }
+    } catch (error) {
+        console.warn('Failed to load tier guide preferences:', error);
+    }
+
+    return DEFAULT_PREFERENCES;
+};
+
+/**
+ * Save tier guide preferences to localStorage
+ */
+export const saveTierGuidePreferences = (preferences: TierGuidePreferences): void => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        localStorage.setItem(TIER_GUIDE_PREFERENCES_KEY, JSON.stringify(preferences));
+    } catch (error) {
+        console.warn('Failed to save tier guide preferences:', error);
+    }
+};
+
+/**
+ * Hook to manage tier guide preferences
+ *
+ * Provides:
+ * - Current preferences state
+ * - Function to mark guide as seen
+ * - Function to update context flags
+ * - Function to reset preferences (for testing/settings)
+ */
+export const useTierGuidePreferences = () => {
+    const [preferences, setPreferences] = useState<TierGuidePreferences>(DEFAULT_PREFERENCES);
+    const [loaded, setLoaded] = useState(false);
+
+    // Load preferences on mount
+    useEffect(() => {
+        setPreferences(loadTierGuidePreferences());
+        setLoaded(true);
+    }, []);
+
+    const markAsSeen = (context: 'first-provider' | 'tier-hover' | 'manual') => {
+        const updated = {
+            ...preferences,
+            seen: true,
+            dismissedAt: Date.now(),
+            context: {
+                ...preferences.context,
+                [context === 'first-provider' ? 'firstProviderShown' : context === 'tier-hover' ? 'tierHoverShown' : 'manualShown']: true,
+            },
+        };
+        setPreferences(updated);
+        saveTierGuidePreferences(updated);
+    };
+
+    const updateContext = (updates: Partial<TierGuidePreferences['context']>) => {
+        const updated = {
+            ...preferences,
+            context: {
+                ...preferences.context,
+                ...updates,
+            },
+        };
+        setPreferences(updated);
+        saveTierGuidePreferences(updated);
+    };
+
+    const resetPreferences = () => {
+        setPreferences(DEFAULT_PREFERENCES);
+        saveTierGuidePreferences(DEFAULT_PREFERENCES);
+    };
+
+    const shouldShowFirstRunHint = loaded && !preferences.context.firstProviderShown;
+
+    return {
+        preferences,
+        loaded,
+        markAsSeen,
+        updateContext,
+        resetPreferences,
+        shouldShowFirstRunHint,
+    };
+};

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -383,6 +383,7 @@ export default {
       "ariaLabel": "Tier {{tier}}",
       "ariaUnset": "No tier",
       "editTitle": "Set Tier",
+      "adjustTier": "Adjust tier",
       "helpHigher": "Lower number = higher priority (T0 is tried first). Services in the same tier are load balanced.",
       "helpZero": "Set to 0 for T0 — the first tier.",
       "tierLabel": "T{{index}}",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -395,8 +395,8 @@ export default {
       "nodeTooltipFallbackTitle": "T{{tier}} — Fallback tier",
       "nodeTooltipFallbackBody": "Tried only when all higher-priority tiers are unavailable (lower number = higher priority). Services here are load-balanced.",
       "nodeMoveHint": "↑ / ↓  on a service card to move it to a different tier",
-      "nodeTooltipLearnMore": "Learn more about tiers",
-      "guideButtonAriaLabel": "Learn about tiers",
+      "nodeTooltipLearnMore": "View tier guide →",
+      "guideButtonAriaLabel": "View tier guide",
       "guide": {
         "title": "Understanding Tiers",
         "subtitle": "Step {{current}} of {{total}}",
@@ -447,6 +447,80 @@ export default {
             "annotation": {
               "priority": "Lower number = higher priority",
               "cascade": "Traffic cascades down through tiers"
+            }
+          }
+        }
+      }
+    },
+    "routing": {
+      "directTooltipTitle": "Direct Routing",
+      "directTooltipBody": "Load balance across all services in tier order. Simple and predictable.",
+      "smartTooltipTitle": "Smart Routing",
+      "smartTooltipBody": "Route based on custom conditions like model name, token count, or user groups.",
+      "tooltipHint": "Click a button to switch modes",
+      "viewDirectGuide": "View direct routing guide →",
+      "viewSmartGuide": "View smart routing guide →",
+      "guide": {
+        "directTitle": "Direct Routing Guide",
+        "smartTitle": "Smart Routing Guide",
+        "subtitle": "Step {{current}} of {{total}}",
+        "previous": "Previous",
+        "next": "Next",
+        "gotIt": "Got it!",
+        "close": "Close",
+        "hoverHint": "Action buttons shown - try hovering over nodes!",
+        "steps": {
+          "1": {
+            "title": "What is Direct Routing?",
+            "content": "Direct routing is the simplest way to forward requests. Traffic flows through your tiers in order — T0 first, then T1, T2, and so on. Within each tier, services are load-balanced evenly. This works great when all your services are equivalent and you just need primary/fallback layers.",
+            "annotation": {
+              "entryNode": "Entry node - routing mode selector",
+              "directButton": "Direct mode selected"
+            }
+          },
+          "2": {
+            "title": "Load Balancing Within Tiers",
+            "content": "When multiple services are in the same tier, they share the incoming traffic evenly. This load balancing distributes requests across all services in the tier, preventing any single service from becoming overwhelmed.",
+            "annotation": {
+              "loadBalance": "Same tier = load balanced",
+              "services": "Multiple services share traffic"
+            }
+          },
+          "3": {
+            "title": "Tier-Based Fallback Chain",
+            "content": "Services in T0 are your primary choice. If all T0 services fail, traffic automatically falls back to T1, then T2, and so on. This creates a cascading failover chain that ensures high availability for your applications.",
+            "annotation": {
+              "primary": "T0 — Primary services (tried first)",
+              "fallback": "T1 — Fallback services (used when T0 fails)",
+              "tierBased": "Tier-based automatic failover"
+            }
+          },
+          "4": {
+            "title": "What is Smart Routing?",
+            "content": "Smart routing lets you define custom conditions to control which service handles each request. Route based on model name, token count, user groups, or any request parameter. This gives you fine-grained control without managing complex tier configurations.",
+            "annotation": {
+              "smartMode": "Smart mode selected",
+              "smartButton": "Smart routing button",
+              "conditional": "Conditional routing based on rules"
+            }
+          },
+          "5": {
+            "title": "Smart Routing Conditions",
+            "content": "Each smart rule has a condition that determines when it applies. Common conditions include: model name matching (e.g., 'contains claude'), token count (e.g., 'gt 4000' for large contexts), or custom fields. Rules are evaluated in order — the first matching rule wins.",
+            "annotation": {
+              "conditions": "Multiple smart rules with conditions",
+              "modelBased": "Route by model name",
+              "tokenBased": "Route by token count"
+            }
+          },
+          "6": {
+            "title": "Advanced Smart Routing",
+            "content": "Combine multiple smart rules to create sophisticated routing strategies. For example: route Claude requests to one service, large contexts to another, and premium users to a third. The default service handles everything that doesn't match any rule.",
+            "annotation": {
+              "complex": "Complex routing with multiple conditions",
+              "defaultRoute": "Default route for unmatched requests",
+              "claudeRoute": "Route for Claude models",
+              "largeContext": "Route for large context windows"
             }
           }
         }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -394,7 +394,63 @@ export default {
       "nodeTooltipPrimaryBody": "Tried first on every request. Services here are load-balanced.",
       "nodeTooltipFallbackTitle": "T{{tier}} — Fallback tier",
       "nodeTooltipFallbackBody": "Tried only when all higher-priority tiers are unavailable (lower number = higher priority). Services here are load-balanced.",
-      "nodeMoveHint": "↑ / ↓  on a service card to move it to a different tier"
+      "nodeMoveHint": "↑ / ↓  on a service card to move it to a different tier",
+      "nodeTooltipLearnMore": "Learn more about tiers",
+      "guideButtonAriaLabel": "Learn about tiers",
+      "guide": {
+        "title": "Understanding Tiers",
+        "subtitle": "Step {{current}} of {{total}}",
+        "previous": "Previous",
+        "next": "Next",
+        "gotIt": "Got it!",
+        "close": "Close",
+        "firstRunHint": "💡 You just added your second provider. Configure tiers to set up primary and fallback routing!",
+        "dontShowAgain": "Don't show this again",
+        "hoverHint": "Action buttons shown - try hovering over nodes!",
+        "steps": {
+          "1": {
+            "title": "What is a Tier?",
+            "content": "Tiers organize your services by priority. T0 (tier zero) is the highest priority tier — services here are tried first on every request. Lower tier numbers mean higher priority.",
+            "annotation": {
+              "tier": "T0 — Highest priority tier",
+              "service": "Your service card with model and provider info"
+            }
+          },
+          "2": {
+            "title": "Multiple Services in One Tier",
+            "content": "When you have multiple services in the same tier (like T0), they share the incoming traffic. This is called load balancing — requests are distributed across all services in the tier.",
+            "annotation": {
+              "loadBalance": "Same tier = load balanced",
+              "multiple": "Multiple services share traffic"
+            }
+          },
+          "3": {
+            "title": "Setting Up Primary and Fallback",
+            "content": "Use the ↑/↓ buttons on service cards to move them between tiers. Services in T0 are your primary choice. Services in T1, T2, etc. act as fallbacks — they only run when all higher-priority tiers fail.",
+            "annotation": {
+              "primary": "T0 — Primary services (tried first)",
+              "fallback": "T1 — Fallback services (used when T0 fails)",
+              "actionButtons": "↑/↓ buttons move services between tiers"
+            }
+          },
+          "4": {
+            "title": "Automatic Failover",
+            "content": "When all services in a tier fail (circuit breaker opens), traffic automatically falls back to the next tier. Once the tier recovers (circuit breaker closes), traffic returns to it automatically. You don't need to do anything — it just works.",
+            "annotation": {
+              "circuitBreaker": "Circuit breaker monitors service health",
+              "automaticFailover": "Automatic failover to next tier"
+            }
+          },
+          "5": {
+            "title": "Multi-Tier Fallback Chain",
+            "content": "You can create as many tiers as you need. T0 → T1 → T2 → ... Traffic cascades down until it finds a working tier. Use this for cost optimization (cheap first, expensive as backup) or regional failover (local first, remote as backup).",
+            "annotation": {
+              "priority": "Lower number = higher priority",
+              "cascade": "Traffic cascades down through tiers"
+            }
+          }
+        }
+      }
     },
     "menu": {
       "refreshModels": "Refresh Models",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -384,6 +384,7 @@ export default {
       "ariaLabel": "层级 {{tier}}",
       "ariaUnset": "未设置层级",
       "editTitle": "设置层级",
+      "adjustTier": "调整层级",
       "helpHigher": "数值越小越优先（T0 最先尝试），同一层级内的服务将负载均衡。",
       "helpZero": "设为 0 即 T0——第一层级。",
       "tierLabel": "T{{index}}",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -395,7 +395,63 @@ export default {
       "nodeTooltipPrimaryBody": "每次请求优先尝试，同层级内服务负载均衡。",
       "nodeTooltipFallbackTitle": "T{{tier}} — 后备层级",
       "nodeTooltipFallbackBody": "仅当更高优先级的层级（编号越小越优先）全部不可用时才启用，同层级内服务负载均衡。",
-      "nodeMoveHint": "↑ / ↓  拖动服务卡片可移动到其他层级"
+      "nodeMoveHint": "↑ / ↓  拖动服务卡片可移动到其他层级",
+      "nodeTooltipLearnMore": "了解更多层级信息",
+      "guideButtonAriaLabel": "了解层级配置",
+      "guide": {
+        "title": "了解层级",
+        "subtitle": "步骤 {{current}} / {{total}}",
+        "previous": "上一步",
+        "next": "下一步",
+        "gotIt": "明白了！",
+        "close": "关闭",
+        "firstRunHint": "💡 您刚刚添加了第二个提供商。配置层级以设置主备路由！",
+        "dontShowAgain": "不再显示",
+        "hoverHint": "操作按钮已显示 - 尝试悬停节点查看！",
+        "steps": {
+          "1": {
+            "title": "什么是层级？",
+            "content": "层级按优先级组织您的服务。T0（零层）是最高优先级层级——这里的服务会在每次请求时首先被尝试。层级编号越小，优先级越高。",
+            "annotation": {
+              "tier": "T0 — 最高优先级层级",
+              "service": "您的服务卡片，包含模型和提供商信息"
+            }
+          },
+          "2": {
+            "title": "同一层级的多个服务",
+            "content": "当同一层级（如 T0）中有多个服务时，它们会共享传入的流量。这称为负载均衡——请求会在该层级的所有服务之间分配。",
+            "annotation": {
+              "loadBalance": "同一层级 = 负载均衡",
+              "multiple": "多个服务共享流量"
+            }
+          },
+          "3": {
+            "title": "设置主备服务",
+            "content": "使用服务卡片上的 ↑/↓ 按钮在不同层级之间移动服务。T0 中的服务是您的首选。T1、T2 等层级中的服务作为备选——只有在所有更高优先级层级都失败时才会运行。",
+            "annotation": {
+              "primary": "T0 — 主服务（首先尝试）",
+              "fallback": "T1 — 备选服务（T0 失败时使用）",
+              "actionButtons": "↑/↓ 按钮在不同层级间移动服务"
+            }
+          },
+          "4": {
+            "title": "自动故障转移",
+            "content": "当一个层级中的所有服务都失败（熔断器打开）时，流量会自动降级到下一个层级。一旦层级恢复（熔断器关闭），流量会自动返回。您无需做任何操作——一切都是自动的。",
+            "annotation": {
+              "circuitBreaker": "熔断器监控服务健康状态",
+              "automaticFailover": "自动降级到下一层级"
+            }
+          },
+          "5": {
+            "title": "多层级故障转移链",
+            "content": "您可以根据需要创建任意数量的层级。T0 → T1 → T2 → ... 流量会级联下降，直到找到正常工作的层级。这可用于成本优化（先用便宜的，贵的作为备选）或区域故障转移（先用本地的，远程作为备选）。",
+            "annotation": {
+              "priority": "编号越小 = 优先级越高",
+              "cascade": "流量在层级间级联下降"
+            }
+          }
+        }
+      }
     },
     "menu": {
       "refreshModels": "刷新模型",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -396,8 +396,8 @@ export default {
       "nodeTooltipFallbackTitle": "T{{tier}} — 后备层级",
       "nodeTooltipFallbackBody": "仅当更高优先级的层级（编号越小越优先）全部不可用时才启用，同层级内服务负载均衡。",
       "nodeMoveHint": "↑ / ↓  拖动服务卡片可移动到其他层级",
-      "nodeTooltipLearnMore": "了解更多层级信息",
-      "guideButtonAriaLabel": "了解层级配置",
+      "nodeTooltipLearnMore": "查看层级图解 →",
+      "guideButtonAriaLabel": "查看层级图解",
       "guide": {
         "title": "了解层级",
         "subtitle": "步骤 {{current}} / {{total}}",
@@ -448,6 +448,80 @@ export default {
             "annotation": {
               "priority": "编号越小 = 优先级越高",
               "cascade": "流量在层级间级联下降"
+            }
+          }
+        }
+      }
+    },
+    "routing": {
+      "directTooltipTitle": "直接路由",
+      "directTooltipBody": "按层级顺序在所有服务间负载均衡。简单可预测。",
+      "smartTooltipTitle": "智能路由",
+      "smartTooltipBody": "基于自定义条件路由，如模型名称、令牌数量或用户组。",
+      "tooltipHint": "点击按钮切换模式",
+      "viewDirectGuide": "查看直接路由图解 →",
+      "viewSmartGuide": "查看智能路由图解 →",
+      "guide": {
+        "directTitle": "直接路由指南",
+        "smartTitle": "智能路由指南",
+        "subtitle": "步骤 {{current}} / {{total}}",
+        "previous": "上一步",
+        "next": "下一步",
+        "gotIt": "明白了！",
+        "close": "关闭",
+        "hoverHint": "操作按钮已显示 - 尝试悬停节点查看！",
+        "steps": {
+          "1": {
+            "title": "什么是直接路由？",
+            "content": "直接路由是最简单的请求转发方式。流量按层级顺序流动——首先是 T0，然后是 T1、T2，依此类推。在每个层级内，服务之间均匀负载均衡。当您的所有服务等效且只需要主备层级时，这非常适用。",
+            "annotation": {
+              "entryNode": "入口节点 - 路由模式选择器",
+              "directButton": "已选择直接模式"
+            }
+          },
+          "2": {
+            "title": "层级内负载均衡",
+            "content": "当同一层级中有多个服务时，它们会均匀共享传入流量。这种负载均衡将请求分配给该层级中的所有服务，防止任何一个服务过载。",
+            "annotation": {
+              "loadBalance": "同一层级 = 负载均衡",
+              "services": "多个服务共享流量"
+            }
+          },
+          "3": {
+            "title": "基于层级的故障转移链",
+            "content": "T0 中的服务是您的首选。如果所有 T0 服务都失败，流量会自动降级到 T1，然后是 T2，依此类推。这创建了一个级联故障转移链，确保您的应用程序具有高可用性。",
+            "annotation": {
+              "primary": "T0 — 主服务（首先尝试）",
+              "fallback": "T1 — 备选服务（T0 失败时使用）",
+              "tierBased": "基于层级的自动故障转移"
+            }
+          },
+          "4": {
+            "title": "什么是智能路由？",
+            "content": "智能路由让您定义自定义条件来控制哪个服务处理每个请求。可以基于模型名称、令牌数量、用户组或任何请求参数进行路由。这为您提供精细控制，而无需管理复杂的层级配置。",
+            "annotation": {
+              "smartMode": "已选择智能模式",
+              "smartButton": "智能路由按钮",
+              "conditional": "基于规则的条件路由"
+            }
+          },
+          "5": {
+            "title": "智能路由条件",
+            "content": "每个智能规则都有一个条件，决定何时应用。常见条件包括：模型名称匹配（例如「包含 claude」）、令牌数量（例如「大于 4000」用于大上下文）或自定义字段。规则按顺序评估——第一个匹配的规则获胜。",
+            "annotation": {
+              "conditions": "多个带有条件的智能规则",
+              "modelBased": "按模型名称路由",
+              "tokenBased": "按令牌数量路由"
+            }
+          },
+          "6": {
+            "title": "高级智能路由",
+            "content": "组合多个智能规则以创建复杂的路由策略。例如：将 Claude 请求路由到一个服务，大上下文路由到另一个服务，高级用户路由到第三个服务。默认服务处理不匹配任何规则的所有内容。",
+            "annotation": {
+              "complex": "带有多个条件的复杂路由",
+              "defaultRoute": "不匹配请求的默认路由",
+              "claudeRoute": "Claude 模型的路由",
+              "largeContext": "大上下文窗口的路由"
             }
           }
         }

--- a/frontend/src/theme/components/claude.ts
+++ b/frontend/src/theme/components/claude.ts
@@ -178,12 +178,13 @@ export const claudeComponents: ThemeOptions['components'] = {
   MuiTooltip: {
     styleOverrides: {
       tooltip: {
-        backgroundColor: 'rgba(20, 20, 19, 0.92)',
-        color: '#FAF9F5',
+        backgroundColor: '#FFFFFF',
+        color: '#141413',
         fontSize: '0.75rem',
-        border: 'none',
+        border: '1px solid #E8E6DC',
+        boxShadow: '0 4px 12px rgba(20, 20, 19, 0.08)',
       },
-      arrow: { color: 'rgba(20, 20, 19, 0.92)' },
+      arrow: { color: '#FFFFFF' },
     },
   },
   MuiDivider: {

--- a/frontend/src/theme/components/dark.ts
+++ b/frontend/src/theme/components/dark.ts
@@ -192,12 +192,13 @@ export const darkComponents: ThemeOptions['components'] = {
   MuiTooltip: {
     styleOverrides: {
       tooltip: {
-        backgroundColor: 'rgba(40, 44, 56, 0.96)',
-        color: '#f8fafc',
+        backgroundColor: darkBgRaised,
+        color: '#f3f5f9',
         fontSize: '0.75rem',
         border: '1px solid rgba(255, 255, 255, 0.1)',
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)',
       },
-      arrow: { color: 'rgba(40, 44, 56, 0.96)' },
+      arrow: { color: darkBgRaised },
     },
   },
   MuiDivider: {

--- a/frontend/src/theme/components/light.ts
+++ b/frontend/src/theme/components/light.ts
@@ -177,12 +177,13 @@ export const lightComponents: ThemeOptions['components'] = {
   MuiTooltip: {
     styleOverrides: {
       tooltip: {
-        backgroundColor: 'rgba(15, 23, 42, 0.92)',
-        color: '#f8fafc',
+        backgroundColor: '#ffffff',
+        color: '#1e293b',
         fontSize: '0.75rem',
-        border: 'none',
+        border: '1px solid #e2e8f0',
+        boxShadow: '0 4px 12px rgba(15, 23, 42, 0.08)',
       },
-      arrow: { color: 'rgba(15, 23, 42, 0.92)' },
+      arrow: { color: '#ffffff' },
     },
   },
   MuiDivider: {

--- a/frontend/src/theme/components/sunlit.ts
+++ b/frontend/src/theme/components/sunlit.ts
@@ -223,12 +223,13 @@ export const sunlitComponents: ThemeOptions['components'] = {
   MuiTooltip: {
     styleOverrides: {
       tooltip: {
-        backgroundColor: 'rgba(15, 23, 42, 0.92)',
-        color: '#f8fafc',
+        backgroundColor: '#ffffff',
+        color: '#1e293b',
         fontSize: '0.75rem',
-        border: 'none',
+        border: '1px solid #e2e8f0',
+        boxShadow: '0 4px 12px rgba(15, 23, 42, 0.08)',
       },
-      arrow: { color: 'rgba(15, 23, 42, 0.92)' },
+      arrow: { color: '#ffffff' },
     },
   },
   MuiDivider: {


### PR DESCRIPTION
## Summary
Users struggled to understand Direct vs Smart routing modes and tier concepts. Added comprehensive visual guides with interactive diagrams and
improved node discoverability through enhanced tooltips and better action button positioning.

### Major
- EntryGuideDialog: 6-step interactive guide for Direct and Smart routing modes with visual diagrams
- TierGuideDialog: Vertical stepper guide for tier concepts with hover annotations
- Enhanced ServiceNode action buttons with better visual separation
- Theme-consistent tooltip styling across all themes (light: white bg, dark: dark bg)

### Minor
- Added 5 routing diagram types (DIRECT_SINGLE, DIRECT_MULTIPLE_TIERS, SMART_BASIC, etc.)
- Improved tier adjustment button tooltips from "Move up/down" to "Adjust tier"
- Enhanced ServiceNode action buttons with border and shadow for better visibility
- Comprehensive bilingual translations (English/Chinese) for all guides 
- Simplified TierNode UI by removing redundant info icon 