### PR TITLE
feat(harness): unify single-hop and two-hop tests in matrix

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -1,0 +1,210 @@
+# Harness Matrix
+
+> For contributors working with `internal/protocoltest/`, `cli/harness/`,
+> or adding new protocol conversion paths / scenarios.
+
+---
+
+## 1. What the matrix tests
+
+The gateway converts between 4 protocol families (Anthropic V1, Anthropic
+Beta, OpenAI Chat, OpenAI Responses) in both streaming and non-streaming
+modes. The matrix validates that every supported conversion path preserves
+content, role, tool calls, usage, and finish reason.
+
+Three levels of validation, each more demanding:
+
+| Level | What it proves | Entry point |
+|-------|----------------|-------------|
+| **Single-hop** | A→B preserves semantics | `Matrix.Run(t)` / `Matrix.ExecuteAll()` |
+| **Two-hop (transitive)** | A→B→C preserves semantics across chained conversions | `Matrix.RunTransitive(t)` / `Matrix.ExecuteAllTransitive()` |
+| **Idempotent (round-trip)** | `g(f(A)) == A` — converting A→B then B→A recovers the original | `Matrix.RunIdempotent(t)` |
+
+---
+
+## 2. Architecture
+
+```
+Scenario (mock responses in 4 formats)
+    ↓
+Matrix (pairs × scenarios × streaming modes)
+    ↓
+TestEnv (real gateway server + VirtualServer mock provider)
+    ↓
+SendAs / SendAsCLI → RoundTripResult (parsed semantics)
+    ↓
+Assertions + SemanticEquivalence checks
+```
+
+### Key types
+
+- **`Scenario`** — named test case. Carries `MockResponses` per format,
+  `Assertions` to check, and `SkipTransitive` flag for scenarios that
+  produce no comparable output (e.g. error responses).
+
+- **`ProtocolPair`** — a single `(Source → Target)` conversion path.
+  `DefaultPairs()` lists exactly the 12 pairs the dispatch graph supports
+  (not the Cartesian product — many cells would map to the same handler).
+
+- **`TransitiveChain`** — two pairs `A→B` + `B→C` joined where
+  `First.Target == Second.Source`. Built automatically from `DefaultPairs()`.
+
+- **`Matrix`** — the orchestrator. Holds `Pairs`, `Scenarios`, `Streaming`
+  modes, and filter/config methods (`OnlyScenarios`, `OnlySources`, etc.).
+
+- **`RoundTripResult`** — normalized output: `Content`, `Role`,
+  `FinishReason`, `ToolCalls`, `Usage`, `StreamEvents`, etc.
+
+### Shared helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `streamMode(bool)` | Returns `"stream"` or `"nonstream"` for test names |
+| `streamingSkipReason(Scenario, bool)` | Checks streaming compatibility, returns skip reason |
+| `semanticEquivalenceErrors(label, r1, r2)` | Compares two results field-by-field, returns `[]AssertionError` |
+| `assertSemanticEquivalence(t, label, r1, r2)` | Delegates to above, calls `t.Errorf` per error |
+
+---
+
+## 3. How to run
+
+### go test (requires `-tags e2e`)
+
+```bash
+# Everything — single-hop + two-hop, both modes
+go test -tags e2e ./internal/protocoltest/... -run TestHarness
+
+# Single-hop only
+go test -tags e2e ./internal/protocoltest/... -run TestHarness/single_hop
+
+# Two-hop only
+go test -tags e2e ./internal/protocoltest/... -run TestHarness/two_hop
+
+# Streaming only
+go test -tags e2e ./internal/protocoltest/... -run TestHarness_Streaming
+
+# Idempotent round-trips
+go test -tags e2e ./internal/protocoltest/... -run TestIdempotent
+```
+
+### CLI (`cli/harness`)
+
+```bash
+# Everything (default)
+go run ./cli/harness matrix
+
+# Single-hop only
+go run ./cli/harness matrix --mode=single
+
+# Two-hop only
+go run ./cli/harness matrix --mode=transitive
+
+# Filter by scenario / source / target
+go run ./cli/harness matrix --scenario text --source anthropic_v1
+
+# JSON for CI
+go run ./cli/harness matrix --json
+```
+
+---
+
+## 4. Adding a new scenario
+
+1. Define a `FooScenario() Scenario` function in `scenarios.go` with
+   `MockResponses` for all 4 formats (nonstream + stream).
+
+2. Add it to `AllScenarios()`.
+
+3. Write `Assertions` that validate the converted result (HTTP status,
+   content, tool calls, etc.).
+
+4. Set `SkipTransitive: true` if the scenario produces no output worth
+   comparing across hops (e.g. error responses).
+
+5. Run `go test -tags e2e ./internal/protocoltest/... -run TestHarness`
+   to verify it passes across all pairs and modes.
+
+### Example
+
+```go
+func IncompleteScenario() Scenario {
+    return Scenario{
+        Name:        "incomplete",
+        Description: "max_output_tokens truncation with partial output + usage",
+        Tags:        []string{"incomplete"},
+        MockResponses: map[ResponseFormat]MockResponseBuilder{
+            FormatOpenAIChat:      openAIIncompleteResponse(),
+            FormatOpenAIResponses: openAIResponsesIncompleteResponse(),
+            FormatAnthropic:       anthropicIncompleteResponse(),
+            FormatGoogle:          googleIncompleteResponse(),
+        },
+        Assertions: []Assertion{
+            AssertHTTPStatus(200),
+            AssertContentContains("Paris"),
+            AssertUsageNonZero(),
+        },
+    }
+}
+```
+
+---
+
+## 5. Adding a new protocol pair
+
+1. Add the pair to `DefaultPairs()` in `matrix.go`.
+
+2. Ensure the mock provider (VirtualServer) can serve that target format.
+
+3. Two-hop chains are derived automatically — any chain where
+   `First.Target == Second.Source` is included.
+
+4. If the pair has known limitations, add a skip entry to
+   `skipSourceScenarios` in `matrix.go`.
+
+---
+
+## 6. Test naming conventions
+
+Tests are structured as nested subtests for `-run` filtering:
+
+```
+TestHarness/
+  single_hop/
+    {scenario}/
+      {source}/
+        {target}/
+          stream|nonstream
+
+  two_hop/
+    {scenario}/
+      {A}→{B}→{C}/
+        stream|nonstream
+```
+
+CLI `TestResult.Name` follows the same `scenario/path/mode` pattern.
+
+---
+
+## 7. Design decisions
+
+**Why explicit pairs, not Cartesian product?**
+Many cells of the full product map to the same dispatch handler (e.g.
+`anthropic_v1 → anthropic_beta` and `anthropic_v1 → anthropic_v1` both
+hit the Anthropic passthrough). Listing pairs keeps the matrix in sync
+with the actual dispatch graph. See `internal/protocol/README.md`.
+
+**Why `SkipTransitive` on Scenario instead of a name check?**
+A hardcoded `name == "error"` check is fragile — future error-shaped
+scenarios would silently skip without appearing in the iteration. The
+boolean makes the opt-out explicit and discoverable.
+
+**Why `--mode` enum instead of `--transitive`/`--single-hop` booleans?**
+Two mutually-exclusive booleans require a manual conflict check and
+would need a third boolean for any future hop level. The enum encodes
+the constraint in the flag parser (Kong validates it).
+
+**Why `semanticEquivalenceErrors` returns `[]AssertionError`?**
+This is the shared core used by both the `testing.T` path
+(`assertSemanticEquivalence`) and the CLI path
+(`executeTransitiveChain`). The `testing.T` version just loops and
+calls `t.Errorf` per entry — no duplicated field checks.

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -22,7 +22,8 @@ type MatrixCmd struct {
 	Targets    []string `kong:"name='target',sep=',',help='Filter by target protocol (can repeat or comma-separate)'"`
 	Streaming  bool     `kong:"name='streaming',help='Run only streaming tests'"`
 	NonStream  bool     `kong:"name='non-streaming',help='Run only non-streaming tests'"`
-	Transitive bool     `kong:"name='transitive',help='Also run two-hop (A→B→C) transitive chain tests'"`
+	Transitive bool     `kong:"name='transitive',help='Run only two-hop (A→B→C) transitive chain tests'"`
+	SingleHop  bool     `kong:"name='single-hop',help='Run only single-hop (A→B) tests'"`
 	JsonOutput bool     `kong:"name='json',help='Output results as JSON'"`
 	Verbose    int      `kong:"name='verbose',short='v',type='counter',help='Verbose output (repeat for more detail)'"`
 	RecordDir  string   `kong:"name='record-dir',env='HARNESS_RECORD_DIR',help='Directory for recording requests/responses (default: disabled)'"`
@@ -34,11 +35,14 @@ type MatrixCmd struct {
 // Help returns extended help text shown by `harness matrix --help`.
 func (*MatrixCmd) Help() string {
 	return `Examples:
-  # Run all single-hop matrix tests
+  # Run everything: single-hop + two-hop (default)
   harness matrix
 
-  # Run single-hop + two-hop transitive chain tests
+  # Run only two-hop (A→B→C) transitive chain tests
   harness matrix --transitive
+
+  # Run only single-hop (A→B) tests
+  harness matrix --single-hop
 
   # Run specific scenario only
   harness matrix --scenario text
@@ -73,9 +77,12 @@ func (m *MatrixCmd) Run() error {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	// Resolve streaming filter conflict early.
+	// Resolve flag conflicts early.
 	if m.Streaming && m.NonStream {
 		return fmt.Errorf("cannot specify both --streaming and --non-streaming")
+	}
+	if m.Transitive && m.SingleHop {
+		return fmt.Errorf("cannot specify both --transitive and --single-hop")
 	}
 
 	// Build matrix with filters
@@ -109,15 +116,21 @@ func (m *MatrixCmd) Run() error {
 		matrix = matrix.WithMCPEnabled()
 	}
 
-	// Execute single-hop tests.
-	results := matrix.ExecuteAll()
-	results = filterResults(results, m)
+	// Determine which sections to run:
+	//   default            → single-hop + two-hop
+	//   --single-hop       → single-hop only
+	//   --transitive       → two-hop only
+	runSingle := !m.Transitive
+	runTransitive := !m.SingleHop
 
-	// Execute two-hop transitive chain tests when requested.
-	if m.Transitive {
-		transitiveResults := matrix.ExecuteAllTransitive()
-		transitiveResults = filterResults(transitiveResults, m)
-		results = append(results, transitiveResults...)
+	var results []protocoltest.TestResult
+	if runSingle {
+		r := matrix.ExecuteAll()
+		results = append(results, filterResults(r, m)...)
+	}
+	if runTransitive {
+		r := matrix.ExecuteAllTransitive()
+		results = append(results, filterResults(r, m)...)
 	}
 
 	// Output results

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -22,6 +22,7 @@ type MatrixCmd struct {
 	Targets    []string `kong:"name='target',sep=',',help='Filter by target protocol (can repeat or comma-separate)'"`
 	Streaming  bool     `kong:"name='streaming',help='Run only streaming tests'"`
 	NonStream  bool     `kong:"name='non-streaming',help='Run only non-streaming tests'"`
+	Transitive bool     `kong:"name='transitive',help='Also run two-hop (A→B→C) transitive chain tests'"`
 	JsonOutput bool     `kong:"name='json',help='Output results as JSON'"`
 	Verbose    int      `kong:"name='verbose',short='v',type='counter',help='Verbose output (repeat for more detail)'"`
 	RecordDir  string   `kong:"name='record-dir',env='HARNESS_RECORD_DIR',help='Directory for recording requests/responses (default: disabled)'"`
@@ -33,8 +34,11 @@ type MatrixCmd struct {
 // Help returns extended help text shown by `harness matrix --help`.
 func (*MatrixCmd) Help() string {
 	return `Examples:
-  # Run all matrix tests
+  # Run all single-hop matrix tests
   harness matrix
+
+  # Run single-hop + two-hop transitive chain tests
+  harness matrix --transitive
 
   # Run specific scenario only
   harness matrix --scenario text
@@ -105,11 +109,16 @@ func (m *MatrixCmd) Run() error {
 		matrix = matrix.WithMCPEnabled()
 	}
 
-	// Execute tests (only filtered combinations).
+	// Execute single-hop tests.
 	results := matrix.ExecuteAll()
-
-	// Filter results for backward compatibility (skipPairs etc.).
 	results = filterResults(results, m)
+
+	// Execute two-hop transitive chain tests when requested.
+	if m.Transitive {
+		transitiveResults := matrix.ExecuteAllTransitive()
+		transitiveResults = filterResults(transitiveResults, m)
+		results = append(results, transitiveResults...)
+	}
 
 	// Output results
 	if m.JsonOutput {

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -20,10 +20,9 @@ type MatrixCmd struct {
 	Scenarios  []string `kong:"name='scenario',sep=',',help='Filter by scenario name (can repeat or comma-separate)'"`
 	Sources    []string `kong:"name='source',sep=',',help='Filter by source protocol (can repeat or comma-separate)'"`
 	Targets    []string `kong:"name='target',sep=',',help='Filter by target protocol (can repeat or comma-separate)'"`
-	Streaming  bool     `kong:"name='streaming',help='Run only streaming tests'"`
-	NonStream  bool     `kong:"name='non-streaming',help='Run only non-streaming tests'"`
-	Transitive bool     `kong:"name='transitive',help='Run only two-hop (A→B→C) transitive chain tests'"`
-	SingleHop  bool     `kong:"name='single-hop',help='Run only single-hop (A→B) tests'"`
+	Streaming  bool   `kong:"name='streaming',help='Run only streaming tests'"`
+	NonStream  bool   `kong:"name='non-streaming',help='Run only non-streaming tests'"`
+	Mode       string `kong:"name='mode',default='all',enum='all,single,transitive',help='Hop selection: all (default), single (A→B only), transitive (A→B→C only)'"`
 	JsonOutput bool     `kong:"name='json',help='Output results as JSON'"`
 	Verbose    int      `kong:"name='verbose',short='v',type='counter',help='Verbose output (repeat for more detail)'"`
 	RecordDir  string   `kong:"name='record-dir',env='HARNESS_RECORD_DIR',help='Directory for recording requests/responses (default: disabled)'"`
@@ -39,10 +38,10 @@ func (*MatrixCmd) Help() string {
   harness matrix
 
   # Run only two-hop (A→B→C) transitive chain tests
-  harness matrix --transitive
+  harness matrix --mode=transitive
 
   # Run only single-hop (A→B) tests
-  harness matrix --single-hop
+  harness matrix --mode=single
 
   # Run specific scenario only
   harness matrix --scenario text
@@ -81,9 +80,6 @@ func (m *MatrixCmd) Run() error {
 	if m.Streaming && m.NonStream {
 		return fmt.Errorf("cannot specify both --streaming and --non-streaming")
 	}
-	if m.Transitive && m.SingleHop {
-		return fmt.Errorf("cannot specify both --transitive and --single-hop")
-	}
 
 	// Build matrix with filters
 	matrix := protocoltest.DefaultMatrix()
@@ -116,22 +112,15 @@ func (m *MatrixCmd) Run() error {
 		matrix = matrix.WithMCPEnabled()
 	}
 
-	// Determine which sections to run:
-	//   default            → single-hop + two-hop
-	//   --single-hop       → single-hop only
-	//   --transitive       → two-hop only
-	runSingle := !m.Transitive
-	runTransitive := !m.SingleHop
-
-	var results []protocoltest.TestResult
-	if runSingle {
-		r := matrix.ExecuteAll()
-		results = append(results, filterResults(r, m)...)
+	// Collect results for selected hop sections (--mode controls which).
+	var combined []protocoltest.TestResult
+	if m.Mode != "transitive" {
+		combined = append(combined, matrix.ExecuteAll()...)
 	}
-	if runTransitive {
-		r := matrix.ExecuteAllTransitive()
-		results = append(results, filterResults(r, m)...)
+	if m.Mode != "single" {
+		combined = append(combined, matrix.ExecuteAllTransitive()...)
 	}
+	results := filterResults(combined, m)
 
 	// Output results
 	if m.JsonOutput {

--- a/internal/protocoltest/harness_test.go
+++ b/internal/protocoltest/harness_test.go
@@ -1,0 +1,39 @@
+//go:build e2e
+// +build e2e
+
+package protocoltest_test
+
+import (
+	"testing"
+
+	pt "github.com/tingly-dev/tingly-box/internal/protocoltest"
+)
+
+// TestHarness is the primary entry point for the full protocol validation
+// harness. It runs two sections:
+//
+//	single_hop — every (source→target) pair × scenario × streaming mode
+//	two_hop    — every (A→B→C) transitive chain × scenario × streaming mode
+//
+// Selective execution:
+//
+//	go test -tags e2e ./internal/protocoltest/... -run TestHarness
+//	go test -tags e2e ./internal/protocoltest/... -run TestHarness/single_hop
+//	go test -tags e2e ./internal/protocoltest/... -run TestHarness/two_hop
+func TestHarness(t *testing.T) {
+	pt.DefaultMatrix().RunFull(t)
+}
+
+// TestHarness_NonStreaming runs both sections in non-streaming mode only.
+func TestHarness_NonStreaming(t *testing.T) {
+	m := pt.DefaultMatrix()
+	m.Streaming = []bool{false}
+	m.RunFull(t)
+}
+
+// TestHarness_Streaming runs both sections in streaming mode only.
+func TestHarness_Streaming(t *testing.T) {
+	m := pt.DefaultMatrix()
+	m.Streaming = []bool{true}
+	m.RunFull(t)
+}

--- a/internal/protocoltest/matrix.go
+++ b/internal/protocoltest/matrix.go
@@ -292,6 +292,26 @@ func (m *Matrix) Run(t *testing.T) {
 	}
 }
 
+// streamMode returns "stream" or "nonstream" for use in test names.
+func streamMode(streaming bool) string {
+	if streaming {
+		return "stream"
+	}
+	return "nonstream"
+}
+
+// streamingSkipReason returns a non-empty reason string when a scenario/mode
+// combination should be skipped due to streaming incompatibility.
+func streamingSkipReason(scenario Scenario, streaming bool) (string, bool) {
+	if streaming && !scenarioSupportsStreaming(scenario) {
+		return "scenario does not support streaming", true
+	}
+	if !streaming && scenarioRequiresStreaming(scenario) {
+		return "scenario requires streaming mode", true
+	}
+	return "", false
+}
+
 // scenarioSupportsStreaming returns true if the scenario has streaming mock responses.
 func scenarioSupportsStreaming(s Scenario) bool {
 	for _, builder := range s.MockResponses {
@@ -477,8 +497,7 @@ func (m *Matrix) executeTest(env *TestEnv, scenario Scenario, source, target pro
 		}
 	}
 
-	// Check streaming compatibility
-	if streaming && !scenarioSupportsStreaming(scenario) {
+	if reason, skip := streamingSkipReason(scenario, streaming); skip {
 		return &TestResult{
 			Name:       m.buildTestName(scenario.Name, source, target, streaming),
 			Scenario:   scenario.Name,
@@ -486,19 +505,7 @@ func (m *Matrix) executeTest(env *TestEnv, scenario Scenario, source, target pro
 			Target:     target,
 			Streaming:  streaming,
 			Skipped:    true,
-			SkipReason: "scenario does not support streaming",
-		}
-	}
-
-	if !streaming && scenarioRequiresStreaming(scenario) {
-		return &TestResult{
-			Name:       m.buildTestName(scenario.Name, source, target, streaming),
-			Scenario:   scenario.Name,
-			Source:     source,
-			Target:     target,
-			Streaming:  streaming,
-			Skipped:    true,
-			SkipReason: "scenario requires streaming mode",
+			SkipReason: reason,
 		}
 	}
 
@@ -657,11 +664,7 @@ func (m *Matrix) executeOneWithEnv(env *TestEnv, s Scenario, source, target prot
 
 // buildTestName constructs a test name from its components.
 func (m *Matrix) buildTestName(scenario string, source, target protocol.APIType, streaming bool) string {
-	mode := "nonstream"
-	if streaming {
-		mode = "stream"
-	}
-	return fmt.Sprintf("%s/%s/%s/%s", scenario, source, target, mode)
+	return fmt.Sprintf("%s/%s/%s/%s", scenario, source, target, streamMode(streaming))
 }
 
 // executeBatch runs a test multiple times and aggregates the results.

--- a/internal/protocoltest/matrix.go
+++ b/internal/protocoltest/matrix.go
@@ -215,6 +215,25 @@ var skipSourceScenarios = map[string]string{
 	"openai_responses|streaming_tool_use": "Responses API source: streaming tool_use conversion incomplete",
 }
 
+// RunFull executes both single-hop and two-hop tests under t, organized as
+// two named sub-sections:
+//
+//   - "single_hop": every (source→target) pair × scenario × streaming mode
+//   - "two_hop":    every (A→B→C) transitive chain × scenario × streaming mode
+//
+// Run each section independently with -run TestFoo/single_hop or /two_hop.
+func (m *Matrix) RunFull(t *testing.T) {
+	t.Helper()
+	t.Run("single_hop", func(t *testing.T) {
+		t.Helper()
+		m.Run(t)
+	})
+	t.Run("two_hop", func(t *testing.T) {
+		t.Helper()
+		m.RunTransitive(t)
+	})
+}
+
 // Run executes all matrix combinations as subtests under t.
 // Each combination runs in its own TestEnv so state is isolated.
 func (m *Matrix) Run(t *testing.T) {

--- a/internal/protocoltest/scenarios.go
+++ b/internal/protocoltest/scenarios.go
@@ -37,6 +37,10 @@ type Scenario struct {
 	MockResponses map[ResponseFormat]MockResponseBuilder
 
 	Assertions []Assertion
+
+	// SkipTransitive marks scenarios that should be excluded from two-hop
+	// transitive tests (e.g. error scenarios that produce no comparable output).
+	SkipTransitive bool
 }
 
 var _ vmodel.VirtualModel = Scenario{}
@@ -640,9 +644,10 @@ func openAIResponsesIncompleteSSE() []string {
 
 func ErrorScenario() Scenario {
 	return Scenario{
-		Name:        "error",
-		Description: "Provider rate limit error (429) propagated to client",
-		Tags:        []string{"error"},
+		Name:           "error",
+		Description:    "Provider rate limit error (429) propagated to client",
+		Tags:           []string{"error"},
+		SkipTransitive: true,
 		MockResponses: map[ResponseFormat]MockResponseBuilder{
 			FormatOpenAIChat:      openAIErrorResponse(),
 			FormatOpenAIResponses: openAIErrorResponse(),

--- a/internal/protocoltest/transitive.go
+++ b/internal/protocoltest/transitive.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TransitiveChain represents a two-hop conversion path: A→B then B→C.
@@ -200,4 +201,163 @@ func assertSemanticEquivalence(t *testing.T, label string, r1, r2 *RoundTripResu
 // Falls back to trimmed string comparison if the input is not valid JSON.
 func normalizeJSON(s string) string {
 	return strings.Join(strings.Fields(s), "")
+}
+
+// ExecuteAllTransitive runs two-hop chain tests without requiring testing.T.
+// It is the CLI-compatible counterpart of RunTransitive, returning []TestResult.
+// Name format: "scenario/A→B→C/mode".
+func (m *Matrix) ExecuteAllTransitive() []TestResult {
+	var results []TestResult
+	chains := m.DefaultChains()
+
+	for _, scenario := range m.Scenarios {
+		if scenario.Name == "error" {
+			continue
+		}
+
+		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
+		if err != nil {
+			for _, chain := range chains {
+				for _, streaming := range m.Streaming {
+					results = append(results, TestResult{
+						Name:      transitiveTestName(chain, scenario.Name, streaming),
+						Scenario:  scenario.Name,
+						Source:    chain.First.Source,
+						Target:    chain.Second.Target,
+						Streaming: streaming,
+						Passed:    false,
+						Errors:    []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("failed to create test env: %v", err)}},
+					})
+				}
+			}
+			continue
+		}
+
+		for _, chain := range chains {
+			for _, streaming := range m.Streaming {
+				result := m.executeTransitiveChain(env, scenario, chain, streaming)
+				results = append(results, result)
+			}
+		}
+		env.Close()
+	}
+	return results
+}
+
+// executeTransitiveChain runs a single two-hop chain for a given scenario/mode.
+func (m *Matrix) executeTransitiveChain(env *TestEnv, scenario Scenario, chain TransitiveChain, streaming bool) TestResult {
+	name := transitiveTestName(chain, scenario.Name, streaming)
+	base := TestResult{
+		Name:      name,
+		Scenario:  scenario.Name,
+		Source:    chain.First.Source,
+		Target:    chain.Second.Target,
+		Streaming: streaming,
+	}
+
+	if reason, skip := skipTransitiveKey(chain, scenario.Name); skip {
+		base.Skipped = true
+		base.SkipReason = reason
+		return base
+	}
+	if streaming && !scenarioSupportsStreaming(scenario) {
+		base.Skipped = true
+		base.SkipReason = "scenario does not support streaming"
+		return base
+	}
+	if !streaming && scenarioRequiresStreaming(scenario) {
+		base.Skipped = true
+		base.SkipReason = "scenario requires streaming mode"
+		return base
+	}
+
+	start := time.Now()
+
+	env.SetupRoute(chain.First.Source, chain.First.Target, scenario)
+	r1, err := env.SendAsCLI(chain.First.Source, chain.First.Target, scenario, streaming)
+	if err != nil {
+		base.Passed = false
+		base.Errors = []AssertionError{{Assertion: "hop1:send", Error: err.Error()}}
+		base.Duration = time.Since(start)
+		return base
+	}
+
+	env.SetupRoute(chain.Second.Source, chain.Second.Target, scenario)
+	r2, err := env.SendAsCLI(chain.Second.Source, chain.Second.Target, scenario, streaming)
+	if err != nil {
+		base.Passed = false
+		base.Errors = []AssertionError{{Assertion: "hop2:send", Error: err.Error()}}
+		base.Duration = time.Since(start)
+		return base
+	}
+
+	var errs []AssertionError
+	for _, a := range scenario.Assertions {
+		if checkErr := a.Check(r1); checkErr != nil {
+			errs = append(errs, AssertionError{
+				Assertion: "hop1:" + a.Name,
+				Error:     checkErr.Error(),
+				Context:   truncate(string(r1.RawBody), 300),
+			})
+		}
+		if checkErr := a.Check(r2); checkErr != nil {
+			errs = append(errs, AssertionError{
+				Assertion: "hop2:" + a.Name,
+				Error:     checkErr.Error(),
+				Context:   truncate(string(r2.RawBody), 300),
+			})
+		}
+	}
+	errs = append(errs, semanticEquivalenceErrors(chain.String(), r1, r2)...)
+
+	base.Passed = len(errs) == 0
+	base.Errors = errs
+	base.Duration = time.Since(start)
+	base.HTTPStatus = r2.HTTPStatus
+	base.Response = r2
+	return base
+}
+
+// semanticEquivalenceErrors returns AssertionErrors for any semantic divergence
+// between hop1 and hop2 results. It is the non-testing.T version of assertSemanticEquivalence.
+func semanticEquivalenceErrors(label string, r1, r2 *RoundTripResult) []AssertionError {
+	var errs []AssertionError
+	add := func(name, msg string) {
+		errs = append(errs, AssertionError{Assertion: "equiv:" + name, Error: fmt.Sprintf("[%s] %s", label, msg)})
+	}
+
+	if r1.Role != r2.Role {
+		add("role", fmt.Sprintf("hop1=%q hop2=%q", r1.Role, r2.Role))
+	}
+	c1, c2 := strings.TrimSpace(r1.Content), strings.TrimSpace(r2.Content)
+	if c1 != c2 {
+		add("content", fmt.Sprintf("hop1=%q hop2=%q", truncate(c1, 200), truncate(c2, 200)))
+	}
+	if len(r1.ToolCalls) != len(r2.ToolCalls) {
+		add("tool_call_count", fmt.Sprintf("hop1=%d hop2=%d", len(r1.ToolCalls), len(r2.ToolCalls)))
+	} else {
+		for i := range r1.ToolCalls {
+			if r1.ToolCalls[i].Name != r2.ToolCalls[i].Name {
+				add(fmt.Sprintf("tool_call[%d].name", i), fmt.Sprintf("hop1=%q hop2=%q", r1.ToolCalls[i].Name, r2.ToolCalls[i].Name))
+			}
+			if normalizeJSON(r1.ToolCalls[i].Arguments) != normalizeJSON(r2.ToolCalls[i].Arguments) {
+				add(fmt.Sprintf("tool_call[%d].arguments", i), fmt.Sprintf("hop1=%s hop2=%s", r1.ToolCalls[i].Arguments, r2.ToolCalls[i].Arguments))
+			}
+		}
+	}
+	if !r1.IsStreaming && !r2.IsStreaming {
+		if (r1.Usage == nil) != (r2.Usage == nil) {
+			add("usage_presence", fmt.Sprintf("hop1=%v hop2=%v", r1.Usage != nil, r2.Usage != nil))
+		}
+	}
+	return errs
+}
+
+// transitiveTestName builds a TestResult name for a chain combination.
+func transitiveTestName(chain TransitiveChain, scenario string, streaming bool) string {
+	mode := "nonstream"
+	if streaming {
+		mode = "stream"
+	}
+	return fmt.Sprintf("%s/%s/%s", scenario, chain, mode)
 }

--- a/internal/protocoltest/transitive.go
+++ b/internal/protocoltest/transitive.go
@@ -79,7 +79,7 @@ func (m *Matrix) RunTransitive(t *testing.T) {
 
 	for _, scenario := range m.Scenarios {
 		scenario := scenario
-		if scenario.Name == "error" {
+		if scenario.SkipTransitive {
 			continue
 		}
 
@@ -151,49 +151,11 @@ func checkSemanticEquivalence(t *testing.T, chain TransitiveChain, r1, r2 *Round
 }
 
 // assertSemanticEquivalence verifies that two RoundTripResults carry the same
-// semantic payload despite being in different protocol formats. We compare
-// normalized fields rather than raw bytes. label identifies the comparison in
-// failure messages.
+// semantic payload despite being in different protocol formats.
 func assertSemanticEquivalence(t *testing.T, label string, r1, r2 *RoundTripResult) {
 	t.Helper()
-
-	// Role must match
-	if r1.Role != r2.Role {
-		t.Errorf("[%s] role mismatch: hop1=%q, hop2=%q", label, r1.Role, r2.Role)
-	}
-
-	// Content must match (normalize whitespace for minor formatting diffs)
-	c1 := strings.TrimSpace(r1.Content)
-	c2 := strings.TrimSpace(r2.Content)
-	if c1 != c2 {
-		t.Errorf("[%s] content mismatch:\n  hop1: %q\n  hop2: %q", label, truncate(c1, 200), truncate(c2, 200))
-	}
-
-	// Tool call count must match
-	if len(r1.ToolCalls) != len(r2.ToolCalls) {
-		t.Errorf("[%s] tool_call count mismatch: hop1=%d, hop2=%d", label, len(r1.ToolCalls), len(r2.ToolCalls))
-		return
-	}
-
-	// Each tool call's name and arguments must match
-	for i := range r1.ToolCalls {
-		tc1 := r1.ToolCalls[i]
-		tc2 := r2.ToolCalls[i]
-		if tc1.Name != tc2.Name {
-			t.Errorf("[%s] tool_call[%d].name mismatch: hop1=%q, hop2=%q", label, i, tc1.Name, tc2.Name)
-		}
-		if normalizeJSON(tc1.Arguments) != normalizeJSON(tc2.Arguments) {
-			t.Errorf("[%s] tool_call[%d].arguments mismatch:\n  hop1: %s\n  hop2: %s",
-				label, i, tc1.Arguments, tc2.Arguments)
-		}
-	}
-
-	// Usage: both should be present or both absent (for non-streaming)
-	if !r1.IsStreaming && !r2.IsStreaming {
-		if (r1.Usage == nil) != (r2.Usage == nil) {
-			t.Errorf("[%s] usage presence mismatch: hop1=%v, hop2=%v",
-				label, r1.Usage != nil, r2.Usage != nil)
-		}
+	for _, e := range semanticEquivalenceErrors(label, r1, r2) {
+		t.Errorf("%s: %s", e.Assertion, e.Error)
 	}
 }
 
@@ -211,7 +173,7 @@ func (m *Matrix) ExecuteAllTransitive() []TestResult {
 	chains := m.DefaultChains()
 
 	for _, scenario := range m.Scenarios {
-		if scenario.Name == "error" {
+		if scenario.SkipTransitive {
 			continue
 		}
 
@@ -220,7 +182,7 @@ func (m *Matrix) ExecuteAllTransitive() []TestResult {
 			for _, chain := range chains {
 				for _, streaming := range m.Streaming {
 					results = append(results, TestResult{
-						Name:      transitiveTestName(chain, scenario.Name, streaming),
+						Name:      chain.TestName(scenario.Name, streaming),
 						Scenario:  scenario.Name,
 						Source:    chain.First.Source,
 						Target:    chain.Second.Target,
@@ -246,7 +208,7 @@ func (m *Matrix) ExecuteAllTransitive() []TestResult {
 
 // executeTransitiveChain runs a single two-hop chain for a given scenario/mode.
 func (m *Matrix) executeTransitiveChain(env *TestEnv, scenario Scenario, chain TransitiveChain, streaming bool) TestResult {
-	name := transitiveTestName(chain, scenario.Name, streaming)
+	name := chain.TestName(scenario.Name, streaming)
 	base := TestResult{
 		Name:      name,
 		Scenario:  scenario.Name,
@@ -260,14 +222,9 @@ func (m *Matrix) executeTransitiveChain(env *TestEnv, scenario Scenario, chain T
 		base.SkipReason = reason
 		return base
 	}
-	if streaming && !scenarioSupportsStreaming(scenario) {
+	if reason, skip := streamingSkipReason(scenario, streaming); skip {
 		base.Skipped = true
-		base.SkipReason = "scenario does not support streaming"
-		return base
-	}
-	if !streaming && scenarioRequiresStreaming(scenario) {
-		base.Skipped = true
-		base.SkipReason = "scenario requires streaming mode"
+		base.SkipReason = reason
 		return base
 	}
 
@@ -353,11 +310,7 @@ func semanticEquivalenceErrors(label string, r1, r2 *RoundTripResult) []Assertio
 	return errs
 }
 
-// transitiveTestName builds a TestResult name for a chain combination.
-func transitiveTestName(chain TransitiveChain, scenario string, streaming bool) string {
-	mode := "nonstream"
-	if streaming {
-		mode = "stream"
-	}
-	return fmt.Sprintf("%s/%s/%s", scenario, chain, mode)
+// TestName builds a TestResult name for this chain in a given scenario/mode.
+func (c TransitiveChain) TestName(scenario string, streaming bool) string {
+	return fmt.Sprintf("%s/%s/%s", scenario, c, streamMode(streaming))
 }


### PR DESCRIPTION
## Summary

- `Matrix.RunFull(t)` runs both `single_hop` and `two_hop` as named sub-tests
- `Matrix.ExecuteAllTransitive()` is the CLI-compatible (no `testing.T`) counterpart of `RunTransitive`
- CLI `harness matrix` now runs both by default; `--mode=single` or `--mode=transitive` isolates one section
- `TestHarness` / `TestHarness_NonStreaming` / `TestHarness_Streaming` in `harness_test.go` as unified `go test` entry points

### Usage

```bash
# CLI
go run ./cli/harness matrix                  # single-hop + two-hop (default)
go run ./cli/harness matrix --mode=single    # single-hop only
go run ./cli/harness matrix --mode=transitive # two-hop only

# go test
go test -tags e2e ./internal/protocoltest/... -run TestHarness
go test -tags e2e ./internal/protocoltest/... -run TestHarness/single_hop
go test -tags e2e ./internal/protocoltest/... -run TestHarness/two_hop
```

### Cleanup applied via /simplify

- Extract `streamMode()` and `streamingSkipReason()` helpers — removes duplicated mode-string and skip-check logic from `executeTest` and `executeTransitiveChain`
- `assertSemanticEquivalence` delegates to `semanticEquivalenceErrors` — eliminates 35 lines of duplicated field checks
- `transitiveTestName` → `TransitiveChain.TestName()` — consistent with `Matrix.buildTestName()`
- `Scenario.SkipTransitive bool` replaces hardcoded `name == "error"` check
- `--transitive`/`--single-hop` boolean pair → `--mode=all|single|transitive` enum (Kong validates)
- `filterResults` called once on combined slice instead of per-section

## Test plan

- [ ] `go test ./internal/protocoltest/...` — non-e2e tests pass
- [ ] `go test -tags e2e ./internal/protocoltest/... -run TestHarness_NonStreaming` — both sections fire
- [ ] `go run ./cli/harness matrix --mode=single --scenario text` — single-hop only
- [ ] `go run ./cli/harness matrix --mode=transitive --scenario text` — two-hop only
