### PR TITLE
feat(flag, affinity): add scenario affinity and set enable as default for some scenarios

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -129,6 +129,7 @@ func RuleFlagRegistry() []FlagSpec { … }
 | `openai_endpoint_override` | enum (`auto`/`chat`/`responses`) | request | 强制单条 rule 的 OpenAI 出口走 Chat 或 Responses；与 provider 声明的 `OpenAIEndpointMode` 冲突时 provider 赢（见 `.design/openai-endpoint-routing.md`）| `ParseEndpointOverride` → `ResolveOpenAIEndpoint`（Type 4：路由层决策）|
 | `block_tools` | string (逗号分隔) | request | 按名字从请求 tool list 中剔除指定工具（发出前），跨 OpenAI Chat / Responses / Anthropic / Google 入站形态生效 | `transform.ToolBlockTransform` → `ops.ApplyToolBlock*`（Type 1b-pre：pre-Base chain stage）|
 | `claude_code_compat` | bool | app | 把 `messages` 数组中 `role == "system"` 的条目重写为 `"user"`。Claude Code 会在 messages 中写入 system role（非标准扩展），严格遵守规范的第三方 Anthropic 兼容 Provider 会拒绝该字段；此 flag 在转发前归一化。同时作为 `ScenarioFlags.ClaudeCodeCompat` 存在，场景级启用后自动注入到该场景所有 rule（同 `CleanHeader` 模式）。| `transform.ClaudeCodeCompatTransform` → `ops.ApplyClaudeCodeCompatRoleRewrite` / `ops.ApplyClaudeCodeBetaCompatRoleRewrite`（Type 1b-pre：pre-Base chain stage，仅对 Anthropic 入站形态生效）|
+| `session_affinity` | int (seconds) | routing | 会话亲和 TTL（秒），0=禁用，>0=启用。Pin 会话到服务以提升缓存命中率 → 更快响应 + 更低 token 成本。Session ID 解析优先级：Anthropic metadata.user_id > X-Tingly-Session-ID header > 客户端 IP。支持 rule 级覆盖（显式设置 rule.Flags.SessionAffinity > 0 时优先）和 scenario 级继承（rule 未设置时继承 ScenarioFlags.SessionAffinity）。| `internal/server/routing/selector.go::ProviderResolver.PostProcess()` → `Config.GetEffectiveAffinity(rule)`（Type 5：路由层决策）|
 
 ---
 
@@ -163,6 +164,12 @@ Type 4   Routing-decision input
          的 OpenAIEndpointMode 优先于 rule flag 冲突时（详见
          .design/openai-endpoint-routing.md）。不进 ExtraFields、不进
          ctx。例：openai_endpoint_override。
+
+Type 5   Routing behavior (service selection)
+         路由层在 PostProcess() 时读取 flag 影响服务选择逻辑。例：
+         session_affinity 通过 Config.GetEffectiveAffinity(rule) 解析
+         继承链（rule explicit > scenario default > disabled），然后在
+         ProviderResolver.PostProcess() 中应用会话亲和策略。
 ```
 
 任何新 flag 都应归入这几类之一。pre-Base 和 post-Base Transform 都是同一
@@ -440,7 +447,73 @@ Extensions Card 操作。
 
 ---
 
-## 12. 未做 / 后续可做
+## 12. Scenario-level Flags（场景级 Flag）
+
+部分 flag 不仅存在于 RuleFlags，也存在于 ScenarioFlags：
+
+| Flag | Rule级 | Scenario级 | 继承行为 |
+|------|--------|------------|----------|
+| `session_affinity` | ✅ | ✅ | Rule 显式设置 > Scenario 默认 > 禁用（0） |
+| `claude_code_compat` | ✅ | ✅ | Scenario 启用时自动注入到该场景所有 rule |
+
+**继承逻辑实现**：
+
+```go
+// session_affinity 解析顺序
+func (c *Config) GetEffectiveAffinity(rule *typ.Rule) time.Duration {
+    // 1. Rule 显式设置
+    if rule.Flags.SessionAffinity > 0 {
+        return time.Duration(rule.Flags.SessionAffinity) * time.Second
+    }
+
+    // 2. Scenario 默认（profiled scenario 先找自己，没有则 fallback 到 base）
+    scenarioConfig := c.scenarioConfigLocked(rule.GetScenario())
+    if scenarioConfig != nil && scenarioConfig.Flags.SessionAffinity > 0 {
+        return time.Duration(scenarioConfig.Flags.SessionAffinity) * time.Second
+    }
+
+    // 3. 禁用
+    return 0
+}
+
+// scenarioConfigLocked 的查找顺序
+func (c *Config) scenarioConfigLocked(scenario typ.RuleScenario) *typ.ScenarioConfig {
+    // 1. 精确匹配 profiled scenario（如 claude_code:p1）
+    for i := range c.Scenarios {
+        if c.Scenarios[i].Scenario == scenario {
+            return &c.Scenarios[i]
+        }
+    }
+
+    // 2. Profile fallback 到 base scenario
+    baseScenario, profileID := typ.ParseScenarioProfile(scenario)
+    if profileID != "" {
+        for i := range c.Scenarios {
+            if c.Scenarios[i].Scenario == baseScenario {
+                return &c.Scenarios[i]
+            }
+        }
+    }
+
+    return nil
+}
+```
+
+**默认值策略**：
+
+- IDE/Agent 场景（claude_code, claude_desktop, vscode, xcode, agent, codex, opencode）：默认 1800 秒（30 分钟）
+- API 场景（openai, anthropic, embed, imagegen）：默认禁用（0）
+- Profile（如 claude_code:p1）：继承 base scenario 默认，可独立配置覆盖
+
+**持久化语义**：
+
+- Scenario 配置**只在不存在时创建默认**，用户配置后不会被覆盖
+- Rule 的 `0` 值表示"未设置"而非"禁用"，通过继承链决定实际值
+- Profile 删除时清理独立的 scenario config（防止遗留）
+
+---
+
+## 13. 未做 / 后续可做
 
 - **UI**：string flag 加独立 enable Switch，让"空"与"未启用"可区分。
 - **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时

--- a/frontend/src/components/ConfigRow.tsx
+++ b/frontend/src/components/ConfigRow.tsx
@@ -21,8 +21,8 @@ interface ConfigRowProps {
     activeTab: TabKey;
     /** Callback when tab changes */
     onTabChange: (tabKey: TabKey) => void;
-    /** Maximum width of the row (default: 700) */
-    maxWidth?: number;
+    /** Maximum width of the row (default: responsive - no fixed limit) */
+    maxWidth?: number | 'responsive';
 }
 
 // ============================================================================
@@ -76,7 +76,7 @@ export const ConfigRow: React.FC<ConfigRowProps> = ({
                                                         tabs,
                                                         activeTab,
                                                         onTabChange,
-                                                        maxWidth = 700,
+                                                        maxWidth = 'responsive',
                                                     }) => {
     // Get current tab data
     const currentTab = tabs.find(t => t.key === activeTab) || tabs[0];
@@ -99,10 +99,18 @@ export const ConfigRow: React.FC<ConfigRowProps> = ({
         </Box>
     );
 
+    // Responsive width: use maxWidth if provided as number, otherwise use 100% with breakpoints
+    const widthStyle = maxWidth === 'responsive'
+        ? {
+            width: '100%',
+            maxWidth: { xs: '100%', sm: '100%', md: '100%', lg: '100%', xl: 1200 }
+          }
+        : { maxWidth };
+
     return (
-        <Box sx={{display: 'flex', alignItems: 'center', gap: 3, maxWidth}}>
+        <Box sx={{display: 'flex', alignItems: 'center', gap: 3, ...widthStyle}}>
             {/* Left: Tabs (with | separator if multiple) */}
-            <Box sx={{minWidth: "200px"}}>
+            <Box sx={{minWidth: { xs: 80, sm: 120, md: 150, lg: 200 }}}>
                 {leftContent}
             </Box>
 

--- a/frontend/src/components/PluginFeatures.tsx
+++ b/frontend/src/components/PluginFeatures.tsx
@@ -20,6 +20,7 @@ import type { SelectChangeEvent } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { api } from '../services/api';
 import { ConfigRow } from './ConfigRow';
+import { SessionAffinityControl } from './flags';
 import ModelSelectDialog from './ModelSelectDialog';
 import type { ProviderSelectTabOption } from './ModelSelectDialog';
 import type { Provider } from '@/types/provider';
@@ -66,6 +67,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
     const [features, setFeatures] = useState<Record<string, boolean>>({});
     const [effort, setEffort] = useState<string>('');
     const [recordV2Mode, setRecordV2Mode] = useState<string>('');
+    const [sessionAffinity, setSessionAffinity] = useState<number>(0);
     const [loading, setLoading] = useState(true);
     const [updating, setUpdating] = useState<Record<string, boolean>>({});
     const [menuAnchor, setMenuAnchor] = useState<Record<string, HTMLElement | null>>({});
@@ -102,6 +104,11 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             const recordV2Result = await api.getScenarioStringFlag(scenario, 'recording_v2');
             if (recordV2Result?.success && recordV2Result?.data?.value !== undefined) {
                 setRecordV2Mode(recordV2Result.data.value);
+            }
+
+            const affinityResult = await api.getScenarioIntFlag(scenario, 'session_affinity');
+            if (affinityResult?.success && affinityResult?.data?.value !== undefined) {
+                setSessionAffinity(affinityResult.data.value);
             }
 
             // Vision proxy service (provider + model) lives in ScenarioConfig.Extensions
@@ -202,6 +209,21 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
             })
             .catch(() => loadData())
             .finally(() => setUpdating(prev => ({ ...prev, recordV2: false })));
+    };
+
+    const handleSessionAffinityChange = async (value: number) => {
+        if (updating.session_affinity || value === sessionAffinity) return;
+        setUpdating(prev => ({ ...prev, session_affinity: true }));
+        api.setScenarioIntFlag(scenario, 'session_affinity', value)
+            .then((result) => {
+                if (result.success) {
+                    setSessionAffinity(value);
+                } else {
+                    loadData();
+                }
+            })
+            .catch(() => loadData())
+            .finally(() => setUpdating(prev => ({ ...prev, session_affinity: false })));
     };
 
     useEffect(() => {
@@ -348,6 +370,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
         );
     };
 
+
     if (loading) {
         return (
             <Box sx={{ display: 'flex', flexDirection: 'column', py: 2, gap: 2, alignItems: 'center', justifyContent: 'center', minHeight: 100 }}>
@@ -366,11 +389,16 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                         key: 'plugin',
                         label: 'Plugin',
                         content: (
-                            <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', columnGap: 1.5, rowGap: 1 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', columnGap: 1.5, rowGap: 1, width: '100%' }}>
                                 {renderEffortButton()}
                                 {renderPluginButtons()}
                                 {renderVisionProxyButton()}
                                 {renderRecordV2Button()}
+                                <SessionAffinityControl
+                                    value={sessionAffinity}
+                                    onChange={handleSessionAffinityChange}
+                                    disabled={updating.session_affinity || false}
+                                />
                             </Box>
                         ),
                     },
@@ -517,6 +545,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                     </MenuItem>
                 ))}
             </Menu>
+
         </Box>
     );
 };

--- a/frontend/src/components/PluginFeatures.tsx
+++ b/frontend/src/components/PluginFeatures.tsx
@@ -377,6 +377,7 @@ const PluginFeatures: React.FC<PluginFeaturesProps> = ({ scenario }) => {
                 ]}
                 activeTab="plugin"
                 onTabChange={() => {}}
+                maxWidth="responsive"
             />
 
             {/* Effort Menu */}

--- a/frontend/src/components/UnifiedCard.tsx
+++ b/frontend/src/components/UnifiedCard.tsx
@@ -7,7 +7,7 @@ interface UnifiedCardProps {
   title?: string | ReactNode;
   subtitle?: string;
   children: ReactNode;
-  size?: 'small' | 'medium' | 'large' | 'full' | 'header';
+  size?: 'small' | 'medium' | 'large' | 'full' | 'header' | 'footer';
   variant?: 'default' | 'outlined' | 'elevated';
   // Custom width, prioritized if provided
   width?: number | string;
@@ -50,7 +50,6 @@ const presetCardDimensions: Record<string, PresetDimensions> = {
   },
   header: {
     width: '100%',
-    minHeight: '160px',
   },
 };
 

--- a/frontend/src/components/flags/README.md
+++ b/frontend/src/components/flags/README.md
@@ -1,0 +1,33 @@
+# Flag Components
+
+This directory contains reusable UI components for controlling various scenario flags.
+
+## Components
+
+### SessionAffinityControl
+Control for session affinity TTL with preset options and custom value input.
+
+**Props:**
+- `value: number` - Current TTL value in seconds (0 = disabled)
+- `onChange: (value: number) => void` - Callback when value changes
+- `disabled?: boolean` - Disable the control
+
+## Usage
+
+```tsx
+import { SessionAffinityControl } from '@/components/flags';
+
+<SessionAffinityControl
+    value={sessionAffinity}
+    onChange={handleSessionAffinityChange}
+    disabled={updating}
+/>
+```
+
+## Future Components
+
+Consider adding more flag control components here:
+- `ThinkingControl.tsx` - Thinking effort level control
+- `VisionProxyControl.tsx` - Vision proxy service picker
+- `RecordingControl.tsx` - Recording mode control
+- `PluginFlagControl.tsx` - Generic boolean flag toggle

--- a/frontend/src/components/flags/SessionAffinityControl.tsx
+++ b/frontend/src/components/flags/SessionAffinityControl.tsx
@@ -1,0 +1,129 @@
+import {
+    IconCheck,
+    IconCircleFilled,
+    IconChevronDown,
+} from '@tabler/icons-react';
+import {
+    Box,
+    Button,
+    Menu,
+    MenuItem,
+    ListItemText,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import React, { useState } from 'react';
+
+interface SessionAffinityControlProps {
+    value: number;
+    onChange: (value: number) => void;
+    disabled?: boolean;
+}
+
+const AFFINITY_OPTIONS = [
+    { value: 0, label: 'Off', description: 'Disable affinity (no cache optimization, may increase cost)' },
+    { value: 1800, label: '30 minutes', description: '30 min pin → better cache hits for short sessions' },
+    { value: 3600, label: '1 hour', description: '1 hour pin → optimal cache hits for coding sessions' },
+    { value: 7200, label: '2 hours', description: '2 hour pin → extended cache optimization for long sessions' },
+] as const;
+
+export const SessionAffinityControl: React.FC<SessionAffinityControlProps> = ({
+    value,
+    onChange,
+    disabled = false,
+}) => {
+    const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+
+    const isEnabled = value > 0;
+    const displayValue = isEnabled ? `${value}s` : 'Off';
+
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        if (!disabled) {
+            setMenuAnchor(event.currentTarget);
+        }
+    };
+
+    const handleMenuClose = () => {
+        setMenuAnchor(null);
+    };
+
+    const handleChange = (newValue: number) => {
+        onChange(newValue);
+        handleMenuClose();
+    };
+
+    return (
+        <>
+            <Tooltip
+                title={`Session Affinity: ${isEnabled ? `Pin to service → cache hits → faster + cheaper (TTL: ${value}s)` : 'Disabled (no cache optimization)'}`}
+                placement="right"
+                arrow
+            >
+                <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={handleMenuOpen}
+                    disabled={disabled}
+                    endIcon={<IconChevronDown size={18} />}
+                    sx={{
+                        minWidth: 120,
+                        textTransform: 'none',
+                        whiteSpace: 'nowrap',
+                        bgcolor: isEnabled ? 'primary.main' : 'transparent',
+                        color: isEnabled ? 'primary.contrastText' : 'text.primary',
+                        fontWeight: isEnabled ? 600 : 400,
+                        border: isEnabled ? 'none' : '1px solid',
+                        borderColor: 'divider',
+                        opacity: disabled ? 0.6 : 1,
+                        '&:hover': { bgcolor: isEnabled ? 'primary.dark' : 'action.selected' },
+                    }}
+                >
+                    <IconCircleFilled size={14} style={{ marginRight: '4px' }} />
+                    Affinity: {displayValue}
+                </Button>
+            </Tooltip>
+
+            <Menu
+                anchorEl={menuAnchor}
+                open={Boolean(menuAnchor)}
+                onClose={handleMenuClose}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            >
+                {AFFINITY_OPTIONS.map((option) => (
+                    <MenuItem
+                        key={option.value}
+                        selected={value === option.value}
+                        onClick={() => handleChange(option.value)}
+                        title={option.description}
+                    >
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                            <ListItemText primary={option.label} primaryTypographyProps={{ variant: 'body2' }} />
+                            {value === option.value && <IconCheck size={16} />}
+                        </Box>
+                    </MenuItem>
+                ))}
+                <MenuItem sx={{ flexDirection: 'column', alignItems: 'flex-start', gap: 1 }}>
+                    <TextField
+                        size="small"
+                        type="number"
+                        label="Custom TTL (seconds)"
+                        value={value || ''}
+                        onChange={(e) => {
+                            const val = parseInt(e.target.value) || 0;
+                            if (val >= 0) {
+                                handleChange(val);
+                            }
+                        }}
+                        inputProps={{ min: 0, step: 60 }}
+                        sx={{ width: 200 }}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                        Custom TTL (seconds). Longer pin → more cache hits → lower cost
+                    </Typography>
+                </MenuItem>
+            </Menu>
+        </>
+    );
+};

--- a/frontend/src/components/flags/index.ts
+++ b/frontend/src/components/flags/index.ts
@@ -1,0 +1,2 @@
+// Flag-related control components
+export { SessionAffinityControl } from './SessionAffinityControl';

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -252,7 +252,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
 
     return (
         <UnifiedCard
-            size="full"
+            size="header"
             title={
                 <Stack direction="row" alignItems="center" spacing={1} sx={{ flex: 1 }}>
                     <Typography variant="subtitle1" fontWeight={600}>Quick Start</Typography>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -561,6 +561,17 @@ export const api = {
         });
     },
 
+    getScenarioIntFlag: async (scenario: string, flag: string): Promise<any> => {
+        return uiAPI(`/scenario/${scenario}/int-flag/${flag}`);
+    },
+
+    setScenarioIntFlag: async (scenario: string, flag: string, value: number): Promise<any> => {
+        return uiAPI(`/scenario/${scenario}/int-flag/${flag}`, {
+            method: 'PUT',
+            body: JSON.stringify({value}),
+        });
+    },
+
     // Profile API
     getProfiles: async (scenario: string): Promise<any> => {
         return uiAPI(`/scenario/${scenario}/profiles`);

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -314,6 +314,14 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
+
+				// Run migration on fresh install to set up scenario defaults
+				if !options.enableMigration {
+					logrus.Warnf("migration disabled")
+				} else {
+					Migrate(cfg)
+					cfg.Save()
+				}
 		} else {
 			return nil, fmt.Errorf("failed to load global cfg: %w", err)
 		}
@@ -335,9 +343,6 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 		cfg.InsertDefaultRule()
 	}
 
-	// Ensure default scenario configs are set
-	cfg.EnsureDefaultScenarioConfigs()
-	cfg.Save()
 
 	// Ensure tokens exist even for existing configs
 	updated := false
@@ -578,6 +583,31 @@ func (c *Config) SaveCurrentServiceID(ruleUUID string, serviceID string) error {
 		return nil
 	}
 	return c.ruleStateStore.SetServiceID(ruleUUID, serviceID)
+}
+
+// GetEffectiveAffinity returns the effective affinity TTL for a rule,
+// considering both scenario default and rule override. Returns 0 if disabled.
+// Resolution order:
+// 1. Rule explicit SessionAffinity (> 0)
+// 2. Scenario SessionAffinity (> 0)
+// 3. Disabled (0)
+func (c *Config) GetEffectiveAffinity(rule *typ.Rule) time.Duration {
+	// 1. Rule explicit value
+	if rule.Flags.SessionAffinity > 0 {
+		return time.Duration(rule.Flags.SessionAffinity) * time.Second
+	}
+
+	// 2. Scenario default
+	c.mu.RLock()
+	scenarioConfig := c.scenarioConfigLocked(rule.GetScenario())
+	c.mu.RUnlock()
+
+	if scenarioConfig != nil && scenarioConfig.Flags.SessionAffinity > 0 {
+		return time.Duration(scenarioConfig.Flags.SessionAffinity) * time.Second
+	}
+
+	// 3. Disabled
+	return 0
 }
 
 // AddRule updates the default Rule
@@ -1326,12 +1356,27 @@ func (c *Config) GetScenarioConfig(scenario typ.RuleScenario) *typ.ScenarioConfi
 
 // scenarioConfigLocked returns the scenario config without acquiring the mutex.
 // Callers must hold at least a read lock.
+// For profiled scenarios (e.g., "claude_code:p1"):
+// 1. First looks for profiled scenario's own config
+// 2. Falls back to base scenario config if profiled config not found
 func (c *Config) scenarioConfigLocked(scenario typ.RuleScenario) *typ.ScenarioConfig {
+	// Try exact match first (for profiled scenarios with their own config)
 	for i := range c.Scenarios {
 		if c.Scenarios[i].Scenario == scenario {
 			return &c.Scenarios[i]
 		}
 	}
+
+	// For profiled scenarios, fallback to base scenario config
+	baseScenario, profileID := typ.ParseScenarioProfile(scenario)
+	if profileID != "" {
+		for i := range c.Scenarios {
+			if c.Scenarios[i].Scenario == baseScenario {
+				return &c.Scenarios[i]
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1548,6 +1593,11 @@ func (c *Config) DeleteProfile(baseScenario typ.RuleScenario, profileID string) 
 		return r.Scenario == profiledScenario
 	})
 
+	// Remove scenario config for this profile (if it exists)
+	c.Scenarios = slices.DeleteFunc(c.Scenarios, func(sc typ.ScenarioConfig) bool {
+		return sc.Scenario == profiledScenario
+	})
+
 	return c.Save()
 }
 
@@ -1725,6 +1775,61 @@ func (c *Config) SetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 		config.Flags.RecordingV2 = typ.RecordingMode(value)
 	default:
 		return fmt.Errorf("unknown string flag name: %s", flagName)
+	}
+
+	return c.Save()
+}
+
+// GetScenarioIntFlag returns an integer flag value for a scenario
+func (c *Config) GetScenarioIntFlag(scenario typ.RuleScenario, flagName string) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	config := c.scenarioConfigLocked(scenario)
+	if config == nil {
+		return 0
+	}
+	switch flagName {
+	case FlagSessionAffinity:
+		return config.Flags.SessionAffinity
+	default:
+		return 0
+	}
+}
+
+// SetScenarioIntFlag sets an integer flag value for a scenario
+func (c *Config) SetScenarioIntFlag(scenario typ.RuleScenario, flagName string, value int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Find or create scenario config
+	var config *typ.ScenarioConfig
+	for i := range c.Scenarios {
+		if c.Scenarios[i].Scenario == scenario {
+			config = &c.Scenarios[i]
+			break
+		}
+	}
+
+	if config == nil {
+		// Create new scenario config
+		newConfig := typ.ScenarioConfig{
+			Scenario:   scenario,
+			Flags:      typ.ScenarioFlags{},
+			Extensions: make(map[string]interface{}),
+		}
+		c.Scenarios = append(c.Scenarios, newConfig)
+		config = &c.Scenarios[len(c.Scenarios)-1]
+	}
+
+	// Set the specific flag
+	switch flagName {
+	case FlagSessionAffinity:
+		if value < 0 {
+			return fmt.Errorf("session_affinity must be >= 0, got %d", value)
+		}
+		config.Flags.SessionAffinity = value
+	default:
+		return fmt.Errorf("unknown int flag name: %s", flagName)
 	}
 
 	return c.Save()
@@ -2029,41 +2134,6 @@ func (c *Config) InsertDefaultRule() error {
 	return nil
 }
 
-// EnsureDefaultScenarioConfigs ensures that all scenarios have default config with appropriate flags
-func (c *Config) EnsureDefaultScenarioConfigs() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Define default scenario configs
-	// xcode: DisableStreamUsage = true (to fix compatibility with Xcode client)
-	// others: DisableStreamUsage = false (default behavior, include usage in streaming)
-	defaultScenarios := []typ.ScenarioConfig{
-		{
-			Scenario: typ.ScenarioXcode,
-			Flags: typ.ScenarioFlags{
-				DisableStreamUsage: true, // Xcode client cannot handle usage in streaming chunks
-			},
-		},
-	}
-
-	// Add or update scenario configs
-	for _, defaultConfig := range defaultScenarios {
-		found := false
-		for i := range c.Scenarios {
-			if c.Scenarios[i].Scenario == defaultConfig.Scenario {
-				// Update existing config if flags are not set
-				if !c.Scenarios[i].Flags.DisableStreamUsage {
-					c.Scenarios[i].Flags.DisableStreamUsage = defaultConfig.Flags.DisableStreamUsage
-				}
-				found = true
-				break
-			}
-		}
-		if !found {
-			c.Scenarios = append(c.Scenarios, defaultConfig)
-		}
-	}
-}
 
 // logProxyEnvironment logs proxy-related environment variables and the
 // RespectEnvProxy config value so operators can diagnose unexpected proxy usage

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -1,0 +1,230 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestCreateProfile_FillsFirstGap(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	scenario := typ.RuleScenario("claude_code")
+
+	// Create p1, p2, p3
+	p1, err := cfg.CreateProfile(scenario, "profile-1", true)
+	if err != nil {
+		t.Fatalf("CreateProfile p1 failed: %v", err)
+	}
+	if p1.ID != "p1" {
+		t.Errorf("expected p1.ID = 'p1', got %q", p1.ID)
+	}
+
+	p2, err := cfg.CreateProfile(scenario, "profile-2", true)
+	if err != nil {
+		t.Fatalf("CreateProfile p2 failed: %v", err)
+	}
+	if p2.ID != "p2" {
+		t.Errorf("expected p2.ID = 'p2', got %q", p2.ID)
+	}
+
+	p3, err := cfg.CreateProfile(scenario, "profile-3", true)
+	if err != nil {
+		t.Fatalf("CreateProfile p3 failed: %v", err)
+	}
+	if p3.ID != "p3" {
+		t.Errorf("expected p3.ID = 'p3', got %q", p3.ID)
+	}
+
+	// Delete p2 — now IDs in use are [p1, p3]
+	if err := cfg.DeleteProfile(scenario, "p2"); err != nil {
+		t.Fatalf("DeleteProfile p2 failed: %v", err)
+	}
+
+	// Create a new profile — should reuse p2 (first gap), not p4
+	pNew, err := cfg.CreateProfile(scenario, "profile-new", true)
+	if err != nil {
+		t.Fatalf("CreateProfile after delete failed: %v", err)
+	}
+	if pNew.ID != "p2" {
+		t.Errorf("expected new profile ID = 'p2' (first gap), got %q", pNew.ID)
+	}
+}
+
+func TestCreateProfile_SequentialWhenNoGaps(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	scenario := typ.RuleScenario("claude_code")
+
+	for i := 1; i <= 3; i++ {
+		name := fmt.Sprintf("profile-%d", i)
+		p, err := cfg.CreateProfile(scenario, name, true)
+		if err != nil {
+			t.Fatalf("CreateProfile %d failed: %v", i, err)
+		}
+		want := fmt.Sprintf("p%d", i)
+		if p.ID != want {
+			t.Errorf("expected ID %q, got %q", want, p.ID)
+		}
+	}
+}
+
+func TestCreateProfile_DuplicateNameError(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	scenario := typ.RuleScenario("claude_code")
+
+	if _, err := cfg.CreateProfile(scenario, "same-name", true); err != nil {
+		t.Fatalf("first CreateProfile failed: %v", err)
+	}
+
+	_, err = cfg.CreateProfile(scenario, "same-name", true)
+	if err == nil {
+		t.Fatal("expected error for duplicate profile name, got nil")
+	}
+}
+
+func TestCreateProfile_FillsMultipleGaps(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	scenario := typ.RuleScenario("claude_code")
+
+	// Create p1, p2, p3, p4, p5
+	for i := 1; i <= 5; i++ {
+		name := fmt.Sprintf("profile-%d", i)
+		if _, err := cfg.CreateProfile(scenario, name, true); err != nil {
+			t.Fatalf("CreateProfile %d failed: %v", i, err)
+		}
+	}
+
+	// Delete p2 and p4 — gaps at [p2, p4]
+	if err := cfg.DeleteProfile(scenario, "p2"); err != nil {
+		t.Fatalf("DeleteProfile p2 failed: %v", err)
+	}
+	if err := cfg.DeleteProfile(scenario, "p4"); err != nil {
+		t.Fatalf("DeleteProfile p4 failed: %v", err)
+	}
+
+	// First new profile should fill p2 (smallest gap)
+	pA, err := cfg.CreateProfile(scenario, "profile-a", true)
+	if err != nil {
+		t.Fatalf("CreateProfile a failed: %v", err)
+	}
+	if pA.ID != "p2" {
+		t.Errorf("expected first gap ID 'p2', got %q", pA.ID)
+	}
+
+	// Second new profile should fill p4 (next smallest gap)
+	pB, err := cfg.CreateProfile(scenario, "profile-b", true)
+	if err != nil {
+		t.Fatalf("CreateProfile b failed: %v", err)
+	}
+	if pB.ID != "p4" {
+		t.Errorf("expected second gap ID 'p4', got %q", pB.ID)
+	}
+
+	// Third new profile should get p6 (no more gaps)
+	pC, err := cfg.CreateProfile(scenario, "profile-c", true)
+	if err != nil {
+		t.Fatalf("CreateProfile c failed: %v", err)
+	}
+	if pC.ID != "p6" {
+		t.Errorf("expected sequential ID 'p6', got %q", pC.ID)
+	}
+}
+
+func TestCreateProfile_EmptyProfilesStartsAtP1(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	scenario := typ.RuleScenario("claude_code")
+
+	p, err := cfg.CreateProfile(scenario, "first", true)
+	if err != nil {
+		t.Fatalf("CreateProfile failed: %v", err)
+	}
+	if p.ID != "p1" {
+		t.Errorf("expected first profile ID = 'p1', got %q", p.ID)
+	}
+}
+
+func TestGetServerHost_DefaultReturnsLocalhost(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	host := cfg.GetServerHost()
+	if host != "localhost" {
+		t.Errorf("expected default host 'localhost', got %q", host)
+	}
+}
+
+func TestSetServerHost_StoresAndReturnsHost(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Set custom host
+	err = cfg.SetServerHost("192.168.1.100")
+	if err != nil {
+		t.Fatalf("SetServerHost failed: %v", err)
+	}
+
+	host := cfg.GetServerHost()
+	if host != "192.168.1.100" {
+		t.Errorf("expected host '192.168.1.100', got %q", host)
+	}
+}
+
+func TestSetServerHost_ZeroAll(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Set to 0.0.0.0 (bind to all interfaces)
+	err = cfg.SetServerHost("0.0.0.0")
+	if err != nil {
+		t.Fatalf("SetServerHost failed: %v", err)
+	}
+
+	host := cfg.GetServerHost()
+	if host != "0.0.0.0" {
+		t.Errorf("expected host '0.0.0.0', got %q", host)
+	}
+}
+
+func TestSetServerHost_EmptyStringReturnsLocalhost(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Set to empty string (should still return localhost)
+	err = cfg.SetServerHost("")
+	if err != nil {
+		t.Fatalf("SetServerHost failed: %v", err)
+	}
+
+	host := cfg.GetServerHost()
+	if host != "localhost" {
+		t.Errorf("expected empty string to return 'localhost', got %q", host)
+	}
+}

--- a/internal/server/config/flag_keys.go
+++ b/internal/server/config/flag_keys.go
@@ -18,3 +18,9 @@ const (
 	FlagThinkingEffort = "thinking_effort"
 	FlagRecordingV2    = "recording_v2"
 )
+
+// ScenarioFlags int field keys. Same contract as above but for
+// GetScenarioIntFlag / SetScenarioIntFlag.
+const (
+	FlagSessionAffinity = "session_affinity"
+)

--- a/internal/server/config/flag_test.go
+++ b/internal/server/config/flag_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestScenarioFlags_SessionAffinity(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    typ.ScenarioFlags
+		expected int
+	}{
+		{
+			name:     "zero value",
+			flags:    typ.ScenarioFlags{},
+			expected: 0,
+		},
+		{
+			name: "session affinity set",
+			flags: typ.ScenarioFlags{
+				SessionAffinity: 1800,
+			},
+			expected: 1800,
+		},
+		{
+			name: "session affinity with other flags",
+			flags: typ.ScenarioFlags{
+				Unified:          true,
+				SessionAffinity:  7200,
+				DisableStreamUsage: true,
+			},
+			expected: 7200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.flags.SessionAffinity != tt.expected {
+				t.Errorf("SessionAffinity = %v, want %v", tt.flags.SessionAffinity, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfig_GetEffectiveAffinity(t *testing.T) {
+	tests := []struct {
+		name               string
+		ruleFlags          typ.RuleFlags
+		scenarioAffinity   int
+		wantTTL            time.Duration
+		useNoAffinityScenario bool
+		explicitlySetScenario bool
+	}{
+		{
+			name:               "rule explicit affinity takes precedence",
+			ruleFlags:          typ.RuleFlags{SessionAffinity: 1800},
+			scenarioAffinity:   1800,
+			wantTTL:            1800 * time.Second,
+			useNoAffinityScenario: false,
+		},
+		{
+			name:               "scenario affinity when rule has none",
+			ruleFlags:          typ.RuleFlags{SessionAffinity: 0},
+			scenarioAffinity:   1800,
+			wantTTL:            1800 * time.Second,
+			useNoAffinityScenario: false,
+		},
+		{
+			name:               "disabled when neither rule nor scenario has affinity",
+			ruleFlags:          typ.RuleFlags{SessionAffinity: 0},
+			scenarioAffinity:   0,
+			wantTTL:            0,
+			useNoAffinityScenario: true,
+		},
+		{
+			name:               "scenario default affinity can be overridden",
+			ruleFlags:          typ.RuleFlags{SessionAffinity: 900},
+			scenarioAffinity:   1800,
+			wantTTL:            900 * time.Second,
+			useNoAffinityScenario: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+			if err != nil {
+				t.Fatalf("NewConfig error: %v", err)
+			}
+
+			// Choose scenario based on test
+			scenario := typ.ScenarioClaudeCode
+			if tt.useNoAffinityScenario {
+				scenario = typ.ScenarioOpenAI // This scenario has no default affinity
+			}
+
+			// Setup scenario config
+			if tt.scenarioAffinity > 0 || tt.explicitlySetScenario {
+				// Find and update existing scenario config, or add new one
+				found := false
+				for i := range cfg.Scenarios {
+					if cfg.Scenarios[i].Scenario == scenario {
+						cfg.Scenarios[i].Flags.SessionAffinity = tt.scenarioAffinity
+						found = true
+						break
+					}
+				}
+				if !found {
+					cfg.Scenarios = append(cfg.Scenarios, typ.ScenarioConfig{
+						Scenario: scenario,
+						Flags: typ.ScenarioFlags{
+							SessionAffinity: tt.scenarioAffinity,
+						},
+					})
+				}
+			}
+
+			// Create rule
+			rule := &typ.Rule{
+				UUID:     "test-rule-uuid",
+				Scenario: scenario,
+				Flags:    tt.ruleFlags,
+			}
+
+			got := cfg.GetEffectiveAffinity(rule)
+			if got != tt.wantTTL {
+				t.Errorf("GetEffectiveAffinity() = %v, want %v", got, tt.wantTTL)
+			}
+		})
+	}
+}
+
+func TestScenarioDefaultAffinity(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Test that default scenarios have affinity set
+	expectedAffinityScenarios := []typ.RuleScenario{
+		typ.ScenarioClaudeCode,
+		typ.ScenarioClaudeDesktop,
+		typ.ScenarioVSCode,
+		typ.ScenarioAgent,
+		typ.ScenarioCodex,
+		typ.ScenarioOpenCode,
+	}
+
+	for _, scenario := range expectedAffinityScenarios {
+		t.Run(string(scenario), func(t *testing.T) {
+			scenarioConfig := cfg.GetScenarioConfig(scenario)
+			if scenarioConfig == nil {
+				t.Errorf("Scenario config not found for %s", scenario)
+				return
+			}
+			if scenarioConfig.Flags.SessionAffinity != 1800 {
+				t.Errorf("Scenario %s: expected SessionAffinity = 1800, got %d",
+					scenario, scenarioConfig.Flags.SessionAffinity)
+			}
+		})
+	}
+
+	// Test that API scenarios don't have affinity by default
+	noAffinityScenarios := []typ.RuleScenario{
+		typ.ScenarioOpenAI,
+		typ.ScenarioAnthropic,
+		typ.ScenarioEmbed,
+	}
+
+	for _, scenario := range noAffinityScenarios {
+		t.Run(string(scenario)+"_no_affinity", func(t *testing.T) {
+			scenarioConfig := cfg.GetScenarioConfig(scenario)
+			// Scenario might not exist, that's OK
+			if scenarioConfig != nil && scenarioConfig.Flags.SessionAffinity != 0 {
+				t.Errorf("Scenario %s: expected SessionAffinity = 0, got %d",
+					scenario, scenarioConfig.Flags.SessionAffinity)
+			}
+		})
+	}
+}
+
+func TestRuleWithInheritedAffinity(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Setup scenario with affinity
+	scenario := typ.ScenarioClaudeCode
+	cfg.Scenarios = append(cfg.Scenarios, typ.ScenarioConfig{
+		Scenario: scenario,
+		Flags: typ.ScenarioFlags{
+			SessionAffinity: 1800,
+		},
+	})
+
+	// Create rule without explicit affinity
+	rule := &typ.Rule{
+		UUID:     "test-rule-uuid",
+		Scenario: scenario,
+		Flags:    typ.RuleFlags{SessionAffinity: 0},
+	}
+
+	// Get effective affinity
+	got := cfg.GetEffectiveAffinity(rule)
+	expected := 1800 * time.Second
+
+	if got != expected {
+		t.Errorf("GetEffectiveAffinity() = %v, want %v", got, expected)
+	}
+
+	// Now set rule-level affinity
+	rule.Flags.SessionAffinity = 1800
+	got = cfg.GetEffectiveAffinity(rule)
+	expected = 1800 * time.Second
+
+	if got != expected {
+		t.Errorf("GetEffectiveAffinity() with rule override = %v, want %v", got, expected)
+	}
+}

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -48,6 +48,7 @@ func Migrate(c *Config) error {
 	migrate20260521(c) // Add Claude Desktop haiku-4-5 built-in rule
 	migrate20260517(c) // Rewrite 127.0.0.1 to localhost in tingly-owned agent configs
 	migrate20260518(c) // Set OpenAIEndpointMode=responses on existing Codex OAuth providers
+	migrate20260606(c) // Add default scenario configs with session affinity
 	return nil
 }
 
@@ -569,4 +570,85 @@ func migrate20260521(c *Config) {
 	c.Rules = append(c.Rules, newRule)
 	_ = c.Save()
 	logrus.Info("Migration 2026-05-21 completed: added Claude Desktop haiku-4-5 rule")
+}
+
+func migrate20260606(c *Config) {
+	if c.hasMigrationCompleted("20260606") {
+		return
+	}
+
+	// Track if we need to save
+	needsSave := false
+
+	// IDE and Agent scenarios that should get 1800s session affinity by default
+	ideAgentScenarios := []typ.RuleScenario{
+		typ.ScenarioClaudeCode,
+		typ.ScenarioClaudeDesktop,
+		typ.ScenarioVSCode,
+		typ.ScenarioAgent,
+		typ.ScenarioCodex,
+		typ.ScenarioOpenCode,
+	}
+
+	// xcode scenario needs DisableStreamUsage=true + affinity
+	xcodeConfig := typ.ScenarioConfig{
+		Scenario: typ.ScenarioXcode,
+		Flags: typ.ScenarioFlags{
+			DisableStreamUsage: true, // Xcode client cannot handle usage in streaming chunks
+			SessionAffinity:     1800, // 30-minute affinity for cache optimization
+		},
+	}
+
+	// Add or update xcode config
+	found := false
+	for i := range c.Scenarios {
+		if c.Scenarios[i].Scenario == typ.ScenarioXcode {
+			// Set DisableStreamUsage if user hasn't explicitly set it
+			// Note: false means "not set" due to omitempty, true means explicitly enabled
+			if !c.Scenarios[i].Flags.DisableStreamUsage {
+				c.Scenarios[i].Flags.DisableStreamUsage = true
+				needsSave = true
+			}
+			// Set SessionAffinity if user hasn't set it (0 means not set)
+			if c.Scenarios[i].Flags.SessionAffinity == 0 {
+				c.Scenarios[i].Flags.SessionAffinity = 1800
+				needsSave = true
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.Scenarios = append(c.Scenarios, xcodeConfig)
+		needsSave = true
+	}
+	// Add or update IDE/Agent scenarios with 1800s affinity
+	for _, scenario := range ideAgentScenarios {
+		found := false
+		for i := range c.Scenarios {
+			if c.Scenarios[i].Scenario == scenario {
+				// Only set affinity if not already configured by user
+				if c.Scenarios[i].Flags.SessionAffinity == 0 {
+					c.Scenarios[i].Flags.SessionAffinity = 1800
+					needsSave = true
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Add new scenario config with default affinity
+			c.Scenarios = append(c.Scenarios, typ.ScenarioConfig{
+				Scenario: scenario,
+				Flags:    typ.ScenarioFlags{SessionAffinity: 1800},
+			})
+			needsSave = true
+		}
+	}
+
+	c.markMigrationCompleted("20260606")
+	if needsSave {
+		_ = c.Save()
+		logrus.Info("Migration 2026-06-06 completed: added default scenario configs with session affinity")
+	}
 }

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestMigrate20260606(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg, err := NewConfig(WithConfigDir(tmpDir))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Trigger migration manually since it already ran during NewConfig
+	migrate20260606(cfg)
+
+	// Verify migration completed flag
+	if !cfg.hasMigrationCompleted("20260606") {
+		t.Error("Migration 20260606 should be marked as completed")
+	}
+
+	// Check that IDE/Agent scenarios have affinity
+	expectedAffinityScenarios := []typ.RuleScenario{
+		typ.ScenarioClaudeCode,
+		typ.ScenarioClaudeDesktop,
+		typ.ScenarioVSCode,
+		typ.ScenarioAgent,
+		typ.ScenarioCodex,
+		typ.ScenarioOpenCode,
+	}
+
+	for _, scenario := range expectedAffinityScenarios {
+		t.Run(string(scenario), func(t *testing.T) {
+			scenarioConfig := cfg.GetScenarioConfig(scenario)
+			if scenarioConfig == nil {
+				t.Errorf("Scenario config not found for %s", scenario)
+				return
+			}
+			if scenarioConfig.Flags.SessionAffinity != 1800 {
+				t.Errorf("Scenario %s: expected SessionAffinity = 1800, got %d",
+					scenario, scenarioConfig.Flags.SessionAffinity)
+			}
+		})
+	}
+
+	// Check xcode scenario
+	xcodeConfig := cfg.GetScenarioConfig(typ.ScenarioXcode)
+	if xcodeConfig == nil {
+		t.Error("Xcode scenario config not found")
+		return
+	}
+	if !xcodeConfig.Flags.DisableStreamUsage {
+		t.Error("Xcode should have DisableStreamUsage = true")
+	}
+	if xcodeConfig.Flags.SessionAffinity != 1800 {
+		t.Errorf("Xcode: expected SessionAffinity = 1800, got %d",
+			xcodeConfig.Flags.SessionAffinity)
+	}
+}
+
+func TestMigrate20260606_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// First run - migration should add defaults
+	cfg1, err := NewConfig(WithConfigDir(tmpDir))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Debug: print migrations completed
+	t.Logf("After first NewConfig, MigrationsCompleted: %v", cfg1.MigrationsCompleted)
+
+	// Verify migration ran
+	if !cfg1.hasMigrationCompleted("20260606") {
+		t.Error("Migration should have completed after first NewConfig")
+	}
+
+	// Verify defaults were set
+	claudeCodeConfig1 := cfg1.GetScenarioConfig(typ.ScenarioClaudeCode)
+	if claudeCodeConfig1 == nil {
+		t.Fatal("Claude Code scenario config should exist after migration")
+	}
+	if claudeCodeConfig1.Flags.SessionAffinity != 1800 {
+		t.Errorf("Expected default SessionAffinity = 1800 after migration, got %d",
+			claudeCodeConfig1.Flags.SessionAffinity)
+	}
+
+	// Now user explicitly changes the value
+	for i := range cfg1.Scenarios {
+		if cfg1.Scenarios[i].Scenario == typ.ScenarioClaudeCode {
+			cfg1.Scenarios[i].Flags.SessionAffinity = 3600
+			cfg1.Save()
+			break
+		}
+	}
+
+	// Second run - migration should NOT run again (already completed)
+	// and should NOT overwrite user's explicit setting
+	cfg2, err := NewConfig(WithConfigDir(tmpDir))
+	if err != nil {
+		t.Fatalf("NewConfig error (second run): %v", err)
+	}
+
+	// Debug: print migrations completed
+	t.Logf("After second NewConfig, MigrationsCompleted: %v", cfg2.MigrationsCompleted)
+
+	// Verify migration is still marked as completed
+	if !cfg2.hasMigrationCompleted("20260606") {
+		t.Error("Migration should still be marked as completed")
+	}
+
+	claudeCodeConfig2 := cfg2.GetScenarioConfig(typ.ScenarioClaudeCode)
+	if claudeCodeConfig2 == nil {
+		t.Fatal("Claude Code scenario config should still exist")
+	}
+
+	// Should preserve user's explicit 3600 value
+	if claudeCodeConfig2.Flags.SessionAffinity != 3600 {
+		t.Errorf("Expected to preserve user's explicit SessionAffinity = 3600, got %d",
+			claudeCodeConfig2.Flags.SessionAffinity)
+	}
+}
+
+func TestMigrate20260606_PartialCustomization(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create config with xcode scenario that has DisableStreamUsage=false (user override)
+	cfg, err := NewConfig(WithConfigDir(tmpDir))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// Manually set xcode DisableStreamUsage to false (user explicitly disabled it)
+	for i := range cfg.Scenarios {
+		if cfg.Scenarios[i].Scenario == typ.ScenarioXcode {
+			cfg.Scenarios[i].Flags.DisableStreamUsage = false
+			cfg.Save()
+			break
+		}
+	}
+
+	// Reload config
+	cfg2, err := NewConfig(WithConfigDir(tmpDir))
+	if err != nil {
+		t.Fatalf("NewConfig error (reload): %v", err)
+	}
+
+	// Verify that migration completed but didn't re-run
+	if !cfg2.hasMigrationCompleted("20260606") {
+		t.Error("Migration should still be marked as completed")
+	}
+
+	// Verify that user's DisableStreamUsage=false is preserved
+	xcodeConfig := cfg2.GetScenarioConfig(typ.ScenarioXcode)
+	if xcodeConfig == nil {
+		t.Fatal("Xcode scenario config should exist")
+	}
+
+	if xcodeConfig.Flags.DisableStreamUsage != false {
+		t.Errorf("Expected user's DisableStreamUsage=false to be preserved, got %v",
+			xcodeConfig.Flags.DisableStreamUsage)
+	}
+
+	// Verify that SessionAffinity still got the default value
+	if xcodeConfig.Flags.SessionAffinity != 1800 {
+		t.Errorf("Expected SessionAffinity=1800 to be set even with customized DisableStreamUsage, got %d",
+			xcodeConfig.Flags.SessionAffinity)
+	}
+}

--- a/internal/server/module/scenario/handler.go
+++ b/internal/server/module/scenario/handler.go
@@ -324,6 +324,105 @@ func (h *Handler) SetScenarioStringFlag(c *gin.Context) {
 	})
 }
 
+// GetScenarioIntFlag returns a specific integer flag value for a scenario
+func (h *Handler) GetScenarioIntFlag(c *gin.Context) {
+	scenario := typ.RuleScenario(c.Param("scenario"))
+	if scenario == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Scenario parameter is required",
+		})
+		return
+	}
+
+	flag := c.Param("flag")
+	if flag == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Flag parameter is required",
+		})
+		return
+	}
+
+	if h.config == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Global config not available",
+		})
+		return
+	}
+
+	value := h.config.GetScenarioIntFlag(scenario, flag)
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"scenario": scenario,
+			"flag":     flag,
+			"value":    value,
+		},
+	})
+}
+
+// SetScenarioIntFlag sets a specific integer flag value for a scenario
+func (h *Handler) SetScenarioIntFlag(c *gin.Context) {
+	scenario := typ.RuleScenario(c.Param("scenario"))
+	if scenario == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Scenario parameter is required",
+		})
+		return
+	}
+
+	flag := c.Param("flag")
+	if flag == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Flag parameter is required",
+		})
+		return
+	}
+
+	request := new(ScenarioIntFlagUpdateRequest)
+	if err := c.ShouldBindJSON(&request); err != nil {
+		logrus.Printf("[ERROR] SetScenarioIntFlag ShouldBindJSON failed: %v, scenario=%s, flag=%s", err, scenario, flag)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	logrus.Printf("[DEBUG] SetScenarioIntFlag: scenario=%s, flag=%s, value=%d", scenario, flag, request.Value)
+
+	if h.config == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Global config not available",
+		})
+		return
+	}
+
+	if err := h.config.SetScenarioIntFlag(scenario, flag, request.Value); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to save scenario flag: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Scenario flag saved successfully",
+		"data": gin.H{
+			"scenario": scenario,
+			"flag":     flag,
+			"value":    request.Value,
+		},
+	})
+}
+
 // GetProfiles returns all profiles for a base scenario
 func (h *Handler) GetProfiles(c *gin.Context) {
 	scenario := typ.RuleScenario(c.Param("scenario"))

--- a/internal/server/module/scenario/routes.go
+++ b/internal/server/module/scenario/routes.go
@@ -56,6 +56,21 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithResponseModel(ScenarioFlagResponse{}),
 	)
 
+	// GET /scenario/:scenario/int-flag/:flag - Get a specific integer flag value for a scenario
+	router.GET("/scenario/:scenario/int-flag/:flag", handler.GetScenarioIntFlag,
+		swagger.WithDescription("Get a specific integer flag value for a scenario"),
+		swagger.WithTags("scenarios"),
+		swagger.WithResponseModel(ScenarioFlagResponse{}),
+	)
+
+	// PUT /scenario/:scenario/int-flag/:flag - Set a specific integer flag value for a scenario
+	router.PUT("/scenario/:scenario/int-flag/:flag", handler.SetScenarioIntFlag,
+		swagger.WithDescription("Set a specific integer flag value for a scenario"),
+		swagger.WithTags("scenarios"),
+		swagger.WithRequestModel(ScenarioIntFlagUpdateRequest{}),
+		swagger.WithResponseModel(ScenarioFlagResponse{}),
+	)
+
 	// --- Profile endpoints ---
 
 	// GET /scenario/:scenario/profiles - List profiles for a scenario

--- a/internal/server/module/scenario/types.go
+++ b/internal/server/module/scenario/types.go
@@ -12,6 +12,11 @@ type ScenarioStringFlagUpdateRequest struct {
 	Value string `json:"value"`
 }
 
+// ScenarioIntFlagUpdateRequest represents the request to update an integer flag
+type ScenarioIntFlagUpdateRequest struct {
+	Value int `json:"value"`
+}
+
 // ScenarioUpdateRequest represents the request to update a scenario
 type ScenarioUpdateRequest struct {
 	Scenario typ.RuleScenario  `json:"scenario" binding:"required" example:"claude_code"`

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -15,6 +15,9 @@ import (
 type ProviderResolver interface {
 	GetProviderByUUID(uuid string) (*typ.Provider, error)
 	SaveCurrentServiceID(ruleUUID string, serviceID string) error
+	// GetEffectiveAffinity returns the effective affinity TTL for a rule,
+	// considering both scenario default and rule override. Returns 0 if disabled.
+	GetEffectiveAffinity(rule *typ.Rule) time.Duration
 }
 
 // LoadBalancer defines the interface for load balancing operations.
@@ -257,14 +260,14 @@ func (s *ServiceSelector) getHealthFilter() *typ.HealthFilter {
 // Locks affinity whenever affinity is enabled and the source is not "affinity"
 // (i.e., don't re-lock an already-locked entry).
 func (s *ServiceSelector) postProcess(ctx *SelectionContext, result *SelectionResult) {
-	if result.Source == "affinity" || !ctx.Rule.AffinityEnabled() || ctx.SessionID.IsEmpty() {
+	if result.Source == "affinity" || ctx.SessionID.IsEmpty() {
 		return
 	}
 
-	ttl := ctx.Rule.AffinityTTL()
+	ttl := s.config.GetEffectiveAffinity(ctx.Rule)
 	if ttl == 0 {
-		// Legacy SmartAffinity bool — use a sensible default.
-		ttl = 2 * time.Hour
+		// Affinity disabled (no rule value, no scenario value, no legacy bool)
+		return
 	}
 	s.affinityStore.Set(ctx.Rule.UUID, ctx.SessionID.String(), &AffinityEntry{
 		Service:   result.Service,

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -145,7 +145,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "session_affinity",
 			Label:       "Session affinity",
-			Description: "TTL in seconds for session-to-service pinning. Once a session lands on a service, follow-up requests in the same session keep hitting that service until the entry expires. 0 disables affinity. Works with any load-balancing tactic; does not require smart routing. Session identity is resolved from Anthropic metadata.user_id, the X-Tingly-Session-ID header, or the client IP.",
+			Description: "TTL in seconds for session-to-service pinning. Pinning improves cache hit rate → faster responses + lower token costs. Once a session lands on a service, follow-up requests keep hitting that service until the entry expires. 0 disables affinity. Works with any load-balancing tactic; does not require smart routing. Session identity is resolved from Anthropic metadata.user_id, the X-Tingly-Session-ID header, or the client IP.",
 			Type:        FlagTypeInt,
 			Category:    FlagCategoryRouting,
 			Placeholder: "e.g. 3600",

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -169,6 +169,12 @@ type ScenarioFlags struct {
 	// list (a non-standard extension); this flag normalizes them so third-party
 	// providers that reject that role do not error out.
 	ClaudeCodeCompat bool `json:"claude_code_compat,omitempty" yaml:"claude_code_compat,omitempty"`
+
+	// SessionAffinity sets default session affinity TTL for all rules under this
+	// scenario. Value in seconds (0 = disabled, >0 = enabled). Individual rules
+	// can override via RuleFlags.SessionAffinity. Rules under this scenario will
+	// inherit this value unless they set their own explicit SessionAffinity.
+	SessionAffinity int `json:"session_affinity,omitempty" yaml:"session_affinity,omitempty"`
 }
 
 // RuleFlags represents per-rule feature flags.


### PR DESCRIPTION
This PR introduce new scenario flag for anffinity (same as rule flag) which help user enable it in some agent scenario like claude code (TTL 1800s).
