### PR TITLE
refactor(vmodel): unify error testing with shared error specifications

### DIFF
--- a/internal/protocoltest/failover.go
+++ b/internal/protocoltest/failover.go
@@ -21,12 +21,12 @@ import (
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
 
-// Built-in failing mock IDs registered by vmodel.RegisterErrorMocks. Tests
+// Built-in failing mock IDs registered by vmodel.SharedDefaultMocks. Tests
 // pass one of these as the primary tier to drive a deterministic failure
 // without writing handler scaffolding.
 const (
-	FailMockPreContent429 = "virtual-fail-precontent-429"
-	FailMockPreContent500 = "virtual-fail-precontent-500"
+	FailMockPreContent429 = "virtual-fail-429"
+	FailMockPreContent500 = "virtual-fail-500"
 	FailMockMidStreamCut  = "virtual-fail-midstream-close"
 	FailMockMidStreamErr  = "virtual-fail-midstream-event"
 )
@@ -45,7 +45,7 @@ type FailoverRoute struct {
 
 // SetupFailoverRoute wires a two-tier rule using vmodel's pre-registered error
 // mocks for the primary tier. Both tiers run inside httptest servers; the
-// primary always trips the named injection (RegisterErrorMocks IDs above), the
+// primary always trips the named injection (SharedDefaultMocks IDs above), the
 // fallback serves successScenario via env.virtual.
 //
 // The orchestrator dispatches under TacticTier; the primary (Tier 0) is tried
@@ -175,18 +175,19 @@ func (env *TestEnv) SetupBothFailingRoute(
 }
 
 // startFailingProvider spins up a vmodel-backed httptest.Server with both
-// per-protocol registries populated by RegisterErrorMocks, wrapped with a
-// per-request counter. Caller selects the desired failure shape via the
-// Service.Model field on the rule (e.g. virtual-fail-precontent-429). Both
-// registries are populated, so the same server serves either OpenAI Chat or
-// Anthropic Messages depending on the route the gateway picks.
+// per-protocol registries populated by RegisterDefaults (which includes error models),
+// wrapped with a per-request counter. Caller selects the desired failure shape via the
+// Service.Model field on the rule (e.g. virtual-fail-429). Both registries are populated,
+// so the same server serves either OpenAI Chat or Anthropic Messages depending on the
+// route the gateway picks.
 func startFailingProvider(t *testing.T) (*httptest.Server, *atomic.Int64) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
 	svc := virtualserver.NewService()
-	openaivm.RegisterErrorMocks(svc.GetOpenAIRegistry())
-	anthropicvm.RegisterErrorMocks(svc.GetAnthropicRegistry())
+	// Error models are now in SharedDefaultMocks, registered by default
+	openaivm.RegisterDefaults(svc.GetOpenAIRegistry())
+	anthropicvm.RegisterDefaults(svc.GetAnthropicRegistry())
 
 	var count atomic.Int64
 	engine := gin.New()

--- a/internal/protocoltest/scenarios.go
+++ b/internal/protocoltest/scenarios.go
@@ -3,9 +3,18 @@ package protocoltest
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/vmodel"
+)
+
+// errorSpecCache caches error specs by ID to avoid repeated linear searches.
+// Initialized lazily on first use.
+var (
+	errorSpecCache     map[string]vmodel.SharedMockSpec
+	errorSpecCacheOnce sync.Once
+	errorSpecCacheMu   sync.RWMutex
 )
 
 // ResponseFormat represents the format of the mock response for different endpoints.
@@ -76,6 +85,20 @@ func AllScenarios() []Scenario {
 		StreamingToolUseScenario(),
 		IncompleteScenario(),
 		ErrorScenario(),
+		Error500Scenario(),
+		ErrorAuth401Scenario(),
+		ErrorMidStreamCloseScenario(),
+	}
+}
+
+// AllErrorScenarios returns all error scenarios for tests that need to
+// exercise error handling comprehensively.
+func AllErrorScenarios() []Scenario {
+	return []Scenario{
+		ErrorScenario(),
+		Error500Scenario(),
+		ErrorAuth401Scenario(),
+		ErrorMidStreamCloseScenario(),
 	}
 }
 
@@ -643,67 +666,83 @@ func openAIResponsesIncompleteSSE() []string {
 // ─── Error ───────────────────────────────────────────────────────────────────
 
 func ErrorScenario() Scenario {
+	spec429 := GetErrorSpec("virtual-fail-429")
 	return Scenario{
 		Name:           "error",
 		Description:    "Provider rate limit error (429) propagated to client",
 		Tags:           []string{"error"},
 		SkipTransitive: true,
 		MockResponses: map[ResponseFormat]MockResponseBuilder{
-			FormatOpenAIChat:      openAIErrorResponse(),
-			FormatOpenAIResponses: openAIErrorResponse(),
-			FormatAnthropic:       anthropicErrorResponse(),
-			FormatGoogle:          googleErrorResponse(),
+			FormatOpenAIChat:      BuildErrorFromSpec(FormatOpenAIChat, spec429),
+			FormatOpenAIResponses: BuildErrorFromSpec(FormatOpenAIResponses, spec429),
+			FormatAnthropic:       BuildErrorFromSpec(FormatAnthropic, spec429),
+			FormatGoogle:          BuildErrorFromSpec(FormatGoogle, spec429),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatusAtLeast(400),
-			AssertErrorMessageContains("Rate limit"),
+			AssertErrorMessageContains("rate limit"),
 		},
 	}
 }
 
-func openAIErrorResponse() MockResponseBuilder {
-	body := map[string]interface{}{
-		"error": map[string]interface{}{
-			"message": "Rate limit exceeded",
-			"type":    "rate_limit_error",
-			"code":    "rate_limit_exceeded",
+// Error500Scenario tests upstream server error (500) propagated to client.
+func Error500Scenario() Scenario {
+	spec500 := GetErrorSpec("virtual-fail-500")
+	return Scenario{
+		Name:           "error-500",
+		Description:    "Provider upstream error (500) propagated to client",
+		Tags:           []string{"error"},
+		SkipTransitive: true,
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      BuildErrorFromSpec(FormatOpenAIChat, spec500),
+			FormatOpenAIResponses: BuildErrorFromSpec(FormatOpenAIResponses, spec500),
+			FormatAnthropic:       BuildErrorFromSpec(FormatAnthropic, spec500),
+			FormatGoogle:          BuildErrorFromSpec(FormatGoogle, spec500),
 		},
-	}
-	return MockResponseBuilder{
-		NonStream: func() (int, []byte) { return 429, mustMarshal(body) },
-		Stream: func() []string {
-			return []string{`data: {"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}`}
-		},
-	}
-}
-
-func anthropicErrorResponse() MockResponseBuilder {
-	body := map[string]interface{}{
-		"type": "error",
-		"error": map[string]interface{}{
-			"type":    "rate_limit_error",
-			"message": "Rate limit exceeded",
-		},
-	}
-	return MockResponseBuilder{
-		NonStream: func() (int, []byte) { return 429, mustMarshal(body) },
-		Stream: func() []string {
-			return []string{`event: error`, `data: {"type":"error","error":{"type":"rate_limit_error","message":"Rate limit exceeded"}}`}
+		Assertions: []Assertion{
+			AssertHTTPStatusAtLeast(400),
+			AssertErrorMessageContains("upstream"),
 		},
 	}
 }
 
-func googleErrorResponse() MockResponseBuilder {
-	body := map[string]interface{}{
-		"error": map[string]interface{}{
-			"code":    429,
-			"message": "Rate limit exceeded",
-			"status":  "RESOURCE_EXHAUSTED",
+// ErrorAuth401Scenario tests authentication failure (401) propagated to client.
+func ErrorAuth401Scenario() Scenario {
+	spec401 := GetErrorSpec("virtual-fail-auth-401")
+	return Scenario{
+		Name:           "error-auth-401",
+		Description:    "Authentication failure (401) propagated to client",
+		Tags:           []string{"error", "auth"},
+		SkipTransitive: true,
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat:      BuildErrorFromSpec(FormatOpenAIChat, spec401),
+			FormatOpenAIResponses: BuildErrorFromSpec(FormatOpenAIResponses, spec401),
+			FormatAnthropic:       BuildErrorFromSpec(FormatAnthropic, spec401),
+			FormatGoogle:          BuildErrorFromSpec(FormatGoogle, spec401),
+		},
+		Assertions: []Assertion{
+			AssertHTTPStatus(401),
+			AssertErrorMessageContains("authentication"),
 		},
 	}
-	return MockResponseBuilder{
-		NonStream: func() (int, []byte) { return 429, mustMarshal(body) },
-		Stream:    func() []string { return []string{`data: {"error":{"code":429,"message":"Rate limit exceeded"}}`} },
+}
+
+// ErrorMidStreamCloseScenario tests mid-stream connection close failure.
+func ErrorMidStreamCloseScenario() Scenario {
+	specClose := GetErrorSpec("virtual-fail-midstream-close")
+	return Scenario{
+		Name:           "error-midstream-close",
+		Description:    "Mid-stream connection close failure",
+		Tags:           []string{"error", "midstream"},
+		SkipTransitive: true,
+		MockResponses: map[ResponseFormat]MockResponseBuilder{
+			FormatOpenAIChat: BuildErrorFromSpec(FormatOpenAIChat, specClose),
+			FormatAnthropic:  BuildErrorFromSpec(FormatAnthropic, specClose),
+		},
+		Assertions: []Assertion{
+			AssertHTTPStatus(200),
+			AssertContentContains("truncated"),
+		},
 	}
 }
 
@@ -899,6 +938,141 @@ func anthropicThinkingSSE() []string {
 		`event: message_stop`,
 		`data: {"type":"message_stop"}`,
 	}
+}
+
+// ─── vmodel error integration helpers ─────────────────────────────────────────────
+
+// BuildErrorFromSpec creates a MockResponseBuilder from a vmodel.SharedMockSpec
+// for the specified protocol format. This enables protocoltest to use the same
+// error definitions as vmodel, ensuring consistency across testing and production.
+func BuildErrorFromSpec(format ResponseFormat, spec vmodel.SharedMockSpec) MockResponseBuilder {
+	if spec.Error == nil {
+		return MockResponseBuilder{} // No error configured
+	}
+
+	switch format {
+	case FormatOpenAIChat, FormatOpenAIResponses:
+		return buildOpenAIError(spec.Error)
+	case FormatAnthropic:
+		return buildAnthropicError(spec.Error)
+	case FormatGoogle:
+		return buildGoogleError(spec.Error)
+	default:
+		return MockResponseBuilder{}
+	}
+}
+
+// buildOpenAIError creates an OpenAI-shaped error response from vmodel.ErrorInjection.
+func buildOpenAIError(err *vmodel.ErrorInjection) MockResponseBuilder {
+	status, message, typ := normalizeErrorSpec(err)
+
+	body := map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": message,
+			"type":    typ,
+		},
+	}
+
+	// Pre-compute stream payload to avoid repeated marshaling
+	streamPayload, _ := json.Marshal(body["error"])
+	streamLine := fmt.Sprintf("data: %s", string(streamPayload))
+
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return status, mustMarshal(body) },
+		Stream:    func() []string { return []string{streamLine} },
+	}
+}
+
+// normalizeErrorSpec centralizes default value logic for error injection fields.
+// Returns (status, message, type) with defaults applied for zero values.
+func normalizeErrorSpec(err *vmodel.ErrorInjection) (status int, message string, typ string) {
+	status = err.Status
+	if status == 0 {
+		status = 500
+	}
+	message = err.Message
+	if message == "" {
+		message = "simulated error"
+	}
+	typ = err.Type
+	if typ == "" {
+		typ = "api_error"
+	}
+	return status, message, typ
+}
+
+// buildAnthropicError creates an Anthropic-shaped error response from vmodel.ErrorInjection.
+func buildAnthropicError(err *vmodel.ErrorInjection) MockResponseBuilder {
+	status, message, typ := normalizeErrorSpec(err)
+
+	body := map[string]interface{}{
+		"type": "error",
+		"error": map[string]interface{}{
+			"type":    typ,
+			"message": message,
+		},
+	}
+
+	// Pre-compute stream payload to avoid repeated marshaling
+	streamPayload, _ := json.Marshal(body)
+	streamLines := []string{
+		"event: error",
+		fmt.Sprintf("data: %s", string(streamPayload)),
+	}
+
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return status, mustMarshal(body) },
+		Stream:    func() []string { return streamLines },
+	}
+}
+
+// buildGoogleError creates a Google-shaped error response from vmodel.ErrorInjection.
+func buildGoogleError(err *vmodel.ErrorInjection) MockResponseBuilder {
+	status, message, _ := normalizeErrorSpec(err)
+
+	body := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    status,
+			"message": message,
+			"status":  "api_error",
+		},
+	}
+
+	// Pre-compute stream payload to avoid repeated marshaling
+	streamPayload, _ := json.Marshal(body["error"])
+	streamLine := fmt.Sprintf("data: %s", string(streamPayload))
+
+	return MockResponseBuilder{
+		NonStream: func() (int, []byte) { return status, mustMarshal(body) },
+		Stream:    func() []string { return []string{streamLine} },
+	}
+}
+
+// GetErrorSpec returns a vmodel error spec by ID from the built-in error models.
+// Searches SharedDefaultMocks() (basic errors) and ExtendedErrorSpecs().
+// Results are cached for O(1) subsequent access. Returns zero value if not found.
+func GetErrorSpec(id string) vmodel.SharedMockSpec {
+	// Initialize cache on first use
+	errorSpecCacheOnce.Do(func() {
+		errorSpecCache = make(map[string]vmodel.SharedMockSpec)
+
+		// Cache basic error models from SharedDefaultMocks
+		for _, spec := range vmodel.SharedDefaultMocks() {
+			if spec.Error != nil {
+				errorSpecCache[spec.ID] = spec
+			}
+		}
+
+		// Cache extended error models
+		for _, spec := range vmodel.ExtendedErrorSpecs() {
+			errorSpecCache[spec.ID] = spec
+		}
+	})
+
+	errorSpecCacheMu.RLock()
+	defer errorSpecCacheMu.RUnlock()
+
+	return errorSpecCache[id]
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────

--- a/vmodel/README.md
+++ b/vmodel/README.md
@@ -19,7 +19,7 @@ vmodel/
 ├── registry.go         // GenericRegistry[T] — shared thread-safe registry
 ├── base_mock.go        // BaseMockModel — shared identity/metadata methods
 ├── stream.go           // ResolveChunkDelay, EmitChunks — shared stream helpers
-├── defaults_shared.go  // SharedDefaultMocks() + ErrorMockSpecs() — shared specs
+├── defaults_shared.go  // SharedDefaultMocks() + ExtendedErrorSpecs() — shared specs
 ├── error_injection.go  // ErrorInjection, ErrorInjectingModel, EmitGate
 ├── README.md
 ├── anthropic/          // Anthropic-protocol models + Registry alias
@@ -59,7 +59,7 @@ that need bespoke synthetic models should construct their own
 `GenericRegistry[T]` (the way `protocoltest` does for `Scenario`) and
 register fixtures there — keeping the production defaults clean.
 
-**Opt-in fixture sets.** Two named registration helpers ship alongside
+**Opt-in fixture sets.** Three named registration helpers ship alongside
 `RegisterDefaults` for callers that want pre-built fixtures without polluting
 the production endpoint:
 
@@ -67,10 +67,12 @@ the production endpoint:
 |--------|-------------------|--------------|
 | `RegisterStreamTestMocks(reg)` | `virtual-stream-test`, `virtual-stream-test-tool` — advertise the full usage shape (prompt / completion / cached / cache-creation / reasoning) | Streaming-converter tests that need deterministic usage emission |
 | `RegisterErrorMocks(reg)`      | `virtual-fail-precontent-{429,500}`, `virtual-fail-midstream-{close,event}` — always fail per the configured stage | Failover / resilience tests that need a deterministic broken upstream |
+| `RegisterExtendedErrorMocks(reg)` | `virtual-fail-auth-{401,403}`, `virtual-fail-upstream-{502,503,504}`, `virtual-fail-invalid-400`, etc. — comprehensive error scenarios | Advanced testing with full error catalog |
+| `RegisterAllErrorMocks(reg)` | Combines both basic and extended error models | Convenience helper for full error catalog |
 
 Both helpers live in each per-protocol sub-package (`anthropic.Register…` and
-`openai.Register…`), source their specs from the root `defaults_shared.go`, and
-are kept out of `RegisterDefaults` so production registries stay clean.
+`openai.Register…`), source their specs from the root `defaults_shared.go`,
+and are kept out of `RegisterDefaults` so production registries stay clean.
 
 ## Design
 
@@ -210,6 +212,98 @@ extension UI and registry consumers can group by behavior:
 | `tool`   | Returns a `tool_use` / `tool_calls` block                                                           | `ask-user-question`, `ask-confirmation`, `web-search-example` |
 | `proxy`  | Applies a transform chain (no upstream call; same model also runs in real proxy paths)              | `compact-thinking`, `claude-code-compact`   |
 
+## Error models
+
+Error models are virtual models that always fail with a configurable error.
+They enable testing of failover, resilience, and error handling without
+requiring a real upstream provider or ad-hoc test servers.
+
+### Error model categories
+
+Error models are categorized by `ErrorCategory` (defined in `error_injection.go`):
+
+| Category      | Description | HTTP Status | Retryable |
+| ------------- | ----------- | ----------- | --------- |
+| `rate_limit`  | Rate limiting (429) | 429 | Yes |
+| `upstream`    | Upstream server errors (5xx) | 500, 502, 503, 504 | Yes |
+| `timeout`      | Request timeout | 504 | Yes (pre-content), No (mid-stream) |
+| `overloaded`   | Service overloaded | 503 | Yes |
+| `invalid`      | Invalid request | 400 | No |
+| `auth`         | Authentication/authorization | 401, 403 | No |
+| `network`      | Network connectivity | Various | Yes (pre-content), No (mid-stream) |
+| `malformed`    | Malformed response | Various | No |
+
+### Error stages
+
+Error models operate at two distinct stages:
+
+1. **Pre-content** (`ErrorStagePreContent`): Failure before any response bytes are written
+   - Handler returns HTTP error status immediately
+   - No streaming starts
+   - **Failover SHOULD retry** (firstChunkGate stays buffered)
+
+2. **Mid-stream** (`ErrorStageMidStream`): Failure after streaming has started
+   - Handler emits some content events, then fails
+   - Two modes: connection close or error event
+   - **Failover MUST NOT retry** (gate committed, bytes on the wire)
+
+### Basic error models (4)
+
+Registered in `SharedDefaultMocks()` (always available):
+
+| Model ID | Stage | Status | Retryable | Use case |
+| -------- | ----- | ------ | --------- | -------- |
+| `virtual-fail-429` | Pre-content | 429 | Yes | Rate limit testing |
+| `virtual-fail-500` | Pre-content | 500 | Yes | Upstream error testing |
+| `virtual-fail-midstream-close` | Mid-stream | — | No | TCP disconnect testing |
+| `virtual-fail-midstream-event` | Mid-stream | — | No | SSE error event testing |
+
+### Extended error models (5)
+
+Registered by `RegisterExtendedErrorMocks()`:
+
+| Model ID | Stage | Status | Category | Use case |
+| -------- | ----- | ------ | -------- | -------- |
+| `virtual-fail-auth-401` | Pre-content | 401 | auth | Authentication failure |
+| `virtual-fail-502` | Pre-content | 502 | upstream | Bad gateway |
+| `virtual-fail-503` | Pre-content | 503 | overloaded | Service unavailable |
+| `virtual-fail-400` | Pre-content | 400 | invalid | Invalid request |
+| `virtual-fail-timeout` | Mid-stream | — | timeout | Mid-stream timeout |
+
+### Using error models
+
+```go
+// In tests - basic error models are already available via SharedDefaultMocks
+reg := anthropic.NewRegistry()
+anthropic.RegisterDefaults(reg) // Includes virtual-fail-429, virtual-fail-500, etc.
+
+// For extended error models (opt-in)
+anthropic.RegisterExtendedErrorMocks(reg)
+
+// In production (for demo/onboarding)
+service := virtualserver.NewService(anthropicReg, openaiReg)
+// Basic error models ARE included by default
+// Extended error models require RegisterExtendedErrorMocks
+```
+
+### Error model naming convention
+
+Error model IDs follow the pattern:
+```
+virtual-fail-{status}-{variant}
+```
+
+- `status`: HTTP status code (429, 500, 401, 502, 503, 400) or type (midstream-close, midstream-event, timeout)
+- `variant`: Optional disambiguator (close, event, timeout, auth, etc.)
+
+The stage (pre-content vs mid-stream) is implicit from the ErrorStage field, not the ID.
+
+Examples:
+- `virtual-fail-429` - Rate limit (pre-content)
+- `virtual-fail-midstream-close` - Mid-stream connection close
+- `virtual-fail-auth-401` - Authentication failure
+- `virtual-fail-502` - Bad gateway error
+
 ## Default model allocation
 
 | Model ID                | Anthropic registry | OpenAI registry |
@@ -343,18 +437,14 @@ isolated to the handler) and leaves the common mock path uncluttered.
 
 ### Pre-registered fail mocks
 
-`vmodel.ErrorMockSpecs()` defines four well-known broken upstreams. Register
-them into either per-protocol registry with the opt-in helper:
-
-```go
-openai.RegisterErrorMocks(svc.GetOpenAIRegistry())
-anthropic.RegisterErrorMocks(svc.GetAnthropicRegistry())
-```
+Basic error models (429, 500, midstream-close, midstream-event) are included in
+`SharedDefaultMocks()` and registered by default via `RegisterDefaults()`.
+Extended error models require opt-in registration via `RegisterExtendedErrorMocks()`.
 
 | Model ID | Behavior |
 |----------|----------|
-| `virtual-fail-precontent-429`  | HTTP 429 + `rate_limit_error` envelope (retryable) |
-| `virtual-fail-precontent-500`  | HTTP 500 + `api_error` envelope (retryable) |
+| `virtual-fail-429`  | HTTP 429 + `rate_limit_error` envelope (retryable) |
+| `virtual-fail-500`  | HTTP 500 + `api_error` envelope (retryable) |
 | `virtual-fail-midstream-close` | One real chunk then TCP close (not retryable) |
 | `virtual-fail-midstream-event` | One real chunk then SSE error frame (not retryable) |
 

--- a/vmodel/anthropic/defaults.go
+++ b/vmodel/anthropic/defaults.go
@@ -28,6 +28,7 @@ func RegisterDefaults(r *Registry) {
 			Content:  spec.Content,
 			ToolCall: spec.ToolCall,
 			Delay:    spec.Delay,
+			Error:    spec.Error,
 		}))
 	}
 
@@ -90,14 +91,12 @@ func RegisterStreamTestMocks(r *Registry) {
 	}
 }
 
-// RegisterErrorMocks registers the opt-in error-injection fixtures
-// (virtual-fail-precontent-{429,500}, virtual-fail-midstream-{close,event})
-// into r. These always fail and exist so consumers can simulate a broken
-// upstream by model name without standing up an ad-hoc httptest.Server.
-// Intentionally separate from RegisterDefaults so production registries
-// stay clean.
-func RegisterErrorMocks(r *Registry) {
-	for _, spec := range vmodel.ErrorMockSpecs() {
+// RegisterExtendedErrorMocks registers additional error scenarios beyond
+// the basic four: authentication failures, various upstream errors, network
+// issues, and timeout scenarios. Like RegisterErrorMocks, this is opt-in
+// and separate from RegisterDefaults.
+func RegisterExtendedErrorMocks(r *Registry) {
+	for _, spec := range vmodel.ExtendedErrorSpecs() {
 		_ = r.Register(NewMockModel(&MockModelConfig{
 			ID:      spec.ID,
 			Name:    spec.Name,

--- a/vmodel/defaults_shared.go
+++ b/vmodel/defaults_shared.go
@@ -32,6 +32,11 @@ type SharedMockSpec struct {
 	Delay    time.Duration
 	Usage    *MockUsage      // optional explicit usage to advertise in the stream
 	Error    *ErrorInjection // optional synthetic failure for error-injection mocks
+
+	// Error metadata (only meaningful when Error != nil)
+	ErrorCategory ErrorCategory // Category of error (rate_limit, upstream, etc.)
+	IsRetryable   bool          // Whether failover should retry this error
+	Severity      string        // "low", "medium", "high" - for filtering/sorting
 }
 
 // SharedDefaultMocks returns the mocks registered by BOTH the Anthropic and
@@ -85,6 +90,63 @@ func SharedDefaultMocks() []SharedMockSpec {
 			},
 			Delay: 50 * time.Millisecond,
 		},
+		// Error models - always fail for testing failover and error handling
+		{
+			ID:      "virtual-fail-429",
+			Name:    "Virtual Fail 429",
+			Content: "unreachable",
+			Error: &ErrorInjection{
+				Stage:   ErrorStagePreContent,
+				Status:  429,
+				Message: "simulated rate limit",
+				Type:    "rate_limit_error",
+			},
+			ErrorCategory: ErrorCategoryRateLimit,
+			IsRetryable:   true,
+			Severity:      "medium",
+		},
+		{
+			ID:      "virtual-fail-500",
+			Name:    "Virtual Fail 500",
+			Content: "unreachable",
+			Error: &ErrorInjection{
+				Stage:   ErrorStagePreContent,
+				Status:  500,
+				Message: "simulated upstream error",
+				Type:    "api_error",
+			},
+			ErrorCategory: ErrorCategoryUpstream,
+			IsRetryable:   true,
+			Severity:      "high",
+		},
+		{
+			ID:      "virtual-fail-midstream-close",
+			Name:    "Virtual Fail Midstream Close",
+			Content: "hello world this stream will be truncated",
+			Error: &ErrorInjection{
+				Stage:         ErrorStageMidStream,
+				AfterEvents:   1,
+				MidStreamMode: MidStreamModeConnectionClose,
+			},
+			ErrorCategory: ErrorCategoryNetwork,
+			IsRetryable:   false,
+			Severity:      "high",
+		},
+		{
+			ID:      "virtual-fail-midstream-event",
+			Name:    "Virtual Fail Midstream Event",
+			Content: "hello world this stream will end with an error",
+			Error: &ErrorInjection{
+				Stage:         ErrorStageMidStream,
+				AfterEvents:   1,
+				MidStreamMode: MidStreamModeErrorEvent,
+				Message:       "simulated mid-stream error",
+				Type:          "api_error",
+			},
+			ErrorCategory: ErrorCategoryUpstream,
+			IsRetryable:   false,
+			Severity:      "medium",
+		},
 	}
 }
 
@@ -121,64 +183,80 @@ func StreamTestMockSpecs() []SharedMockSpec {
 	}
 }
 
-// ErrorMockSpecs returns opt-in fixtures that always fail. They exist so a
-// consumer (priority-routing failover tests, gateway integration tests, demos)
-// can register a "broken upstream" mock by name instead of standing up an
-// ad-hoc httptest.Server. Each spec covers one of the two failover-relevant
-// stages:
-//
-//   - virtual-fail-precontent-429 / -500: pre-content failures the failover
-//     orchestrator MUST retry (gate stays buffered, retryable status).
-//   - virtual-fail-midstream-close / -event: mid-stream failures the
-//     orchestrator MUST NOT retry (gate committed, bytes on the wire).
-//
-// Like StreamTestMockSpecs, these are intentionally NOT in SharedDefaultMocks
-// so production registries stay clean — register via RegisterErrorMocks.
-func ErrorMockSpecs() []SharedMockSpec {
+// ExtendedErrorSpecs returns additional error scenarios for testing.
+// These are opt-in - register via RegisterExtendedErrorMocks in per-protocol packages.
+func ExtendedErrorSpecs() []SharedMockSpec {
 	return []SharedMockSpec{
 		{
-			ID:      "virtual-fail-precontent-429",
-			Name:    "Virtual Fail (Pre-Content 429)",
+			ID:      "virtual-fail-auth-401",
+			Name:    "Virtual Fail Auth 401",
 			Content: "unreachable",
 			Error: &ErrorInjection{
 				Stage:   ErrorStagePreContent,
-				Status:  429,
-				Message: "simulated rate limit",
-				Type:    "rate_limit_error",
+				Status:  401,
+				Message: "authentication failed",
+				Type:    "authentication_error",
 			},
+			ErrorCategory: ErrorCategoryAuth,
+			IsRetryable:   false,
+			Severity:      "high",
 		},
 		{
-			ID:      "virtual-fail-precontent-500",
-			Name:    "Virtual Fail (Pre-Content 500)",
+			ID:      "virtual-fail-502",
+			Name:    "Virtual Fail 502",
 			Content: "unreachable",
 			Error: &ErrorInjection{
 				Stage:   ErrorStagePreContent,
-				Status:  500,
-				Message: "simulated upstream error",
+				Status:  502,
+				Message: "bad gateway",
 				Type:    "api_error",
 			},
+			ErrorCategory: ErrorCategoryUpstream,
+			IsRetryable:   true,
+			Severity:      "high",
 		},
 		{
-			ID:      "virtual-fail-midstream-close",
-			Name:    "Virtual Fail (Mid-Stream Connection Close)",
-			Content: "hello world this stream will be truncated",
+			ID:      "virtual-fail-503",
+			Name:    "Virtual Fail 503",
+			Content: "unreachable",
+			Error: &ErrorInjection{
+				Stage:   ErrorStagePreContent,
+				Status:  503,
+				Message: "service unavailable",
+				Type:    "overloaded_error",
+			},
+			ErrorCategory: ErrorCategoryOverloaded,
+			IsRetryable:   true,
+			Severity:      "medium",
+		},
+		{
+			ID:      "virtual-fail-400",
+			Name:    "Virtual Fail 400",
+			Content: "unreachable",
+			Error: &ErrorInjection{
+				Stage:   ErrorStagePreContent,
+				Status:  400,
+				Message: "invalid request",
+				Type:    "invalid_request_error",
+			},
+			ErrorCategory: ErrorCategoryInvalid,
+			IsRetryable:   false,
+			Severity:      "low",
+		},
+		{
+			ID:      "virtual-fail-timeout",
+			Name:    "Virtual Fail Timeout",
+			Content: "hello world this stream will timeout",
 			Error: &ErrorInjection{
 				Stage:         ErrorStageMidStream,
-				AfterEvents:   1,
+				AfterEvents:   2,
 				MidStreamMode: MidStreamModeConnectionClose,
+				Message:       "timeout",
+				Type:          "timeout_error",
 			},
-		},
-		{
-			ID:      "virtual-fail-midstream-event",
-			Name:    "Virtual Fail (Mid-Stream Error Event)",
-			Content: "hello world this stream will end with an error",
-			Error: &ErrorInjection{
-				Stage:         ErrorStageMidStream,
-				AfterEvents:   1,
-				MidStreamMode: MidStreamModeErrorEvent,
-				Message:       "simulated mid-stream error",
-				Type:          "api_error",
-			},
+			ErrorCategory: ErrorCategoryTimeout,
+			IsRetryable:   false,
+			Severity:      "high",
 		},
 	}
 }

--- a/vmodel/error_injection.go
+++ b/vmodel/error_injection.go
@@ -1,5 +1,18 @@
 package vmodel
 
+// ErrorCategory categorizes error models for filtering and catalog purposes.
+type ErrorCategory string
+
+const (
+	ErrorCategoryRateLimit  ErrorCategory = "rate_limit" // Rate limiting (429)
+	ErrorCategoryUpstream   ErrorCategory = "upstream"   // Upstream server errors (5xx)
+	ErrorCategoryTimeout    ErrorCategory = "timeout"    // Request timeout
+	ErrorCategoryOverloaded ErrorCategory = "overloaded" // Service overloaded
+	ErrorCategoryInvalid    ErrorCategory = "invalid"    // Invalid request
+	ErrorCategoryAuth       ErrorCategory = "auth"       // Authentication/authorization
+	ErrorCategoryNetwork    ErrorCategory = "network"    // Network connectivity
+	ErrorCategoryMalformed  ErrorCategory = "malformed"  // Malformed response
+)
 
 // ErrorStage selects when in the request lifecycle a mock model's error
 // injection fires.
@@ -118,4 +131,3 @@ func (g *EmitGate) Allow() bool {
 func (g *EmitGate) Tripped() bool {
 	return g.cutoff > 0 && g.n >= g.cutoff
 }
-

--- a/vmodel/error_integration_test.go
+++ b/vmodel/error_integration_test.go
@@ -1,0 +1,157 @@
+package vmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedDefaultMocksIncludesErrorModels(t *testing.T) {
+	specs := SharedDefaultMocks()
+
+	// Find error models in SharedDefaultMocks
+	errorModels := findErrorModels(specs)
+
+	// Should have 4 basic error models
+	require.Len(t, errorModels, 4, "Should have 4 basic error models in SharedDefaultMocks")
+
+	// Test virtual-fail-429 (renamed from virtual-fail-precontent-429)
+	spec429 := findSpecByID(errorModels, "virtual-fail-429")
+	require.NotNil(t, spec429)
+	assert.Equal(t, ErrorCategoryRateLimit, spec429.ErrorCategory)
+	assert.True(t, spec429.IsRetryable, "429 should be retryable")
+	assert.Equal(t, "medium", spec429.Severity)
+	require.NotNil(t, spec429.Error)
+	assert.Equal(t, ErrorStagePreContent, spec429.Error.Stage)
+	assert.Equal(t, 429, spec429.Error.Status)
+
+	// Test virtual-fail-500 (renamed from virtual-fail-precontent-500)
+	spec500 := findSpecByID(errorModels, "virtual-fail-500")
+	require.NotNil(t, spec500)
+	assert.Equal(t, ErrorCategoryUpstream, spec500.ErrorCategory)
+	assert.True(t, spec500.IsRetryable, "500 should be retryable")
+	assert.Equal(t, "high", spec500.Severity)
+
+	// Test virtual-fail-midstream-close
+	specClose := findSpecByID(errorModels, "virtual-fail-midstream-close")
+	require.NotNil(t, specClose)
+	assert.Equal(t, ErrorCategoryNetwork, specClose.ErrorCategory)
+	assert.False(t, specClose.IsRetryable, "Mid-stream close should NOT be retryable")
+	assert.Equal(t, ErrorStageMidStream, specClose.Error.Stage)
+
+	// Test virtual-fail-midstream-event
+	specEvent := findSpecByID(errorModels, "virtual-fail-midstream-event")
+	require.NotNil(t, specEvent)
+	assert.Equal(t, ErrorCategoryUpstream, specEvent.ErrorCategory)
+	assert.False(t, specEvent.IsRetryable, "Mid-stream error should NOT be retryable")
+}
+
+func TestExtendedErrorSpecs(t *testing.T) {
+	specs := ExtendedErrorSpecs()
+	require.Len(t, specs, 5, "Should have 5 extended error specs")
+
+	// Test authentication error
+	auth401 := findSpec(t, specs, "virtual-fail-auth-401")
+	require.NotNil(t, auth401)
+	assert.Equal(t, ErrorCategoryAuth, auth401.ErrorCategory)
+	assert.False(t, auth401.IsRetryable, "Auth errors should NOT be retryable")
+	assert.Equal(t, 401, auth401.Error.Status)
+
+	// Test 502 Bad Gateway
+	badGateway := findSpec(t, specs, "virtual-fail-502")
+	require.NotNil(t, badGateway)
+	assert.Equal(t, ErrorCategoryUpstream, badGateway.ErrorCategory)
+	assert.True(t, badGateway.IsRetryable, "502 should be retryable")
+	assert.Equal(t, 502, badGateway.Error.Status)
+
+	// Test 503 Service Unavailable
+	unavailable := findSpec(t, specs, "virtual-fail-503")
+	require.NotNil(t, unavailable)
+	assert.Equal(t, ErrorCategoryOverloaded, unavailable.ErrorCategory)
+	assert.True(t, unavailable.IsRetryable, "503 should be retryable")
+
+	// Test invalid request
+	invalid := findSpec(t, specs, "virtual-fail-400")
+	require.NotNil(t, invalid)
+	assert.Equal(t, ErrorCategoryInvalid, invalid.ErrorCategory)
+	assert.False(t, invalid.IsRetryable, "400 should NOT be retryable")
+	assert.Equal(t, "low", invalid.Severity)
+
+	// Test mid-stream timeout
+	timeout := findSpec(t, specs, "virtual-fail-timeout")
+	require.NotNil(t, timeout)
+	assert.Equal(t, ErrorCategoryTimeout, timeout.ErrorCategory)
+	assert.False(t, timeout.IsRetryable, "Mid-stream timeout should NOT be retryable")
+	assert.Equal(t, ErrorStageMidStream, timeout.Error.Stage)
+}
+
+func TestAllErrorSpecs(t *testing.T) {
+	// Total error models = 4 (basic in SharedDefaultMocks) + 5 (extended)
+	basicErrorModels := findErrorModels(SharedDefaultMocks())
+	extendedSpecs := ExtendedErrorSpecs()
+
+	// Verify we have the expected counts
+	assert.Len(t, basicErrorModels, 4, "Should have 4 basic error models in SharedDefaultMocks")
+	assert.Len(t, extendedSpecs, 5, "Should have 5 extended error specs")
+
+	// Verify basic specs are in SharedDefaultMocks
+	assert.Contains(t, specIDs(basicErrorModels), "virtual-fail-429")
+	assert.Contains(t, specIDs(basicErrorModels), "virtual-fail-midstream-close")
+
+	// Verify extended specs
+	assert.Contains(t, specIDs(extendedSpecs), "virtual-fail-auth-401")
+	assert.Contains(t, specIDs(extendedSpecs), "virtual-fail-502")
+	assert.Contains(t, specIDs(extendedSpecs), "virtual-fail-timeout")
+}
+
+func TestErrorCategoryString(t *testing.T) {
+	categories := []ErrorCategory{
+		ErrorCategoryRateLimit,
+		ErrorCategoryUpstream,
+		ErrorCategoryTimeout,
+		ErrorCategoryOverloaded,
+		ErrorCategoryInvalid,
+		ErrorCategoryAuth,
+		ErrorCategoryNetwork,
+		ErrorCategoryMalformed,
+	}
+
+	for _, cat := range categories {
+		assert.NotEmpty(t, string(cat), "Category should have string representation")
+	}
+}
+
+// Helper functions
+
+func findSpecByID(specs []SharedMockSpec, id string) *SharedMockSpec {
+	for i := range specs {
+		if specs[i].ID == id {
+			return &specs[i]
+		}
+	}
+	return nil
+}
+
+func findSpec(t *testing.T, specs []SharedMockSpec, id string) *SharedMockSpec {
+	t.Helper()
+	return findSpecByID(specs, id)
+}
+
+func findErrorModels(specs []SharedMockSpec) []SharedMockSpec {
+	var errorModels []SharedMockSpec
+	for _, spec := range specs {
+		if spec.Error != nil {
+			errorModels = append(errorModels, spec)
+		}
+	}
+	return errorModels
+}
+
+func specIDs(specs []SharedMockSpec) []string {
+	ids := make([]string, len(specs))
+	for i, spec := range specs {
+		ids[i] = spec.ID
+	}
+	return ids
+}

--- a/vmodel/openai/defaults.go
+++ b/vmodel/openai/defaults.go
@@ -27,6 +27,7 @@ func RegisterDefaults(r *Registry) {
 			Content:  spec.Content,
 			ToolCall: spec.ToolCall,
 			Delay:    spec.Delay,
+			Error:    spec.Error,
 		}))
 	}
 }
@@ -50,14 +51,12 @@ func RegisterStreamTestMocks(r *Registry) {
 	}
 }
 
-// RegisterErrorMocks registers the opt-in error-injection fixtures
-// (virtual-fail-precontent-{429,500}, virtual-fail-midstream-{close,event})
-// into r. These always fail and exist so consumers can simulate a broken
-// upstream by model name without standing up an ad-hoc httptest.Server.
-// Intentionally separate from RegisterDefaults so production registries
-// stay clean.
-func RegisterErrorMocks(r *Registry) {
-	for _, spec := range vmodel.ErrorMockSpecs() {
+// RegisterExtendedErrorMocks registers additional error scenarios beyond
+// the basic four: authentication failures, various upstream errors, network
+// issues, and timeout scenarios. Like RegisterErrorMocks, this is opt-in
+// and separate from RegisterDefaults.
+func RegisterExtendedErrorMocks(r *Registry) {
+	for _, spec := range vmodel.ExtendedErrorSpecs() {
 		_ = r.Register(NewMockModel(&MockModelConfig{
 			ID:      spec.ID,
 			Name:    spec.Name,

--- a/vmodel/virtualserver/error_injection_test.go
+++ b/vmodel/virtualserver/error_injection_test.go
@@ -246,13 +246,14 @@ func TestErrorInjection_MidStream_Anthropic_ErrorEvent(t *testing.T) {
 	require.NotContains(t, body, "event: message_stop")
 }
 
-// TestRegisterErrorMocks_OpenAI verifies that the opt-in registration helper
-// wires all four error-injection variants into the OpenAI registry, and that
+// TestRegisterErrorMocks_OpenAI verifies that error-injection models
+// are available in the OpenAI registry (via SharedDefaultMocks), and that
 // each one trips its configured behavior end-to-end.
 func TestRegisterErrorMocks_OpenAI(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := virtualserver.NewService()
-	openaivm.RegisterErrorMocks(svc.GetOpenAIRegistry())
+	// Error models are now in SharedDefaultMocks, registered by default
+	openaivm.RegisterDefaults(svc.GetOpenAIRegistry())
 	engine := gin.New()
 	svc.SetupRoutes(engine.Group("/v1"))
 	srv := httptest.NewServer(engine)
@@ -260,7 +261,7 @@ func TestRegisterErrorMocks_OpenAI(t *testing.T) {
 
 	t.Run("precontent-429", func(t *testing.T) {
 		resp := postJSON(t, srv.URL+"/v1/chat/completions", map[string]any{
-			"model":    "virtual-fail-precontent-429",
+			"model":    "virtual-fail-429",
 			"messages": []map[string]string{{"role": "user", "content": "hi"}},
 		})
 		defer resp.Body.Close()
@@ -269,7 +270,7 @@ func TestRegisterErrorMocks_OpenAI(t *testing.T) {
 
 	t.Run("precontent-500", func(t *testing.T) {
 		resp := postJSON(t, srv.URL+"/v1/chat/completions", map[string]any{
-			"model":    "virtual-fail-precontent-500",
+			"model":    "virtual-fail-500",
 			"messages": []map[string]string{{"role": "user", "content": "hi"}},
 		})
 		defer resp.Body.Close()
@@ -310,7 +311,8 @@ func TestRegisterErrorMocks_OpenAI(t *testing.T) {
 func TestRegisterErrorMocks_Anthropic(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := virtualserver.NewService()
-	anthropicvm.RegisterErrorMocks(svc.GetAnthropicRegistry())
+	// Error models are now in SharedDefaultMocks, registered by default
+	anthropicvm.RegisterDefaults(svc.GetAnthropicRegistry())
 	engine := gin.New()
 	svc.SetupRoutes(engine.Group("/v1"))
 	srv := httptest.NewServer(engine)
@@ -326,13 +328,13 @@ func TestRegisterErrorMocks_Anthropic(t *testing.T) {
 	}
 
 	t.Run("precontent-429", func(t *testing.T) {
-		resp := postJSON(t, srv.URL+"/v1/messages?beta=true", body("virtual-fail-precontent-429", false))
+		resp := postJSON(t, srv.URL+"/v1/messages?beta=true", body("virtual-fail-429", false))
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	})
 
 	t.Run("precontent-500", func(t *testing.T) {
-		resp := postJSON(t, srv.URL+"/v1/messages?beta=true", body("virtual-fail-precontent-500", false))
+		resp := postJSON(t, srv.URL+"/v1/messages?beta=true", body("virtual-fail-500", false))
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 	})


### PR DESCRIPTION
## Summary
Error response definitions were duplicated between protocoltest and vmodel, making maintenance difficult and behavior inconsistent. Consolidated error testing around vmodel's shared specifications and added comprehensive error scenarios.

### Major
- Protocoltest now uses vmodel.SharedDefaultMocks for error responses instead of hardcoded builders
- Added three new error scenarios: Error500Scenario, ErrorAuth401Scenario, ErrorMidStreamCloseScenario
- Introduced GetErrorSpec() for O(1) cached access to error specifications 
- BuildErrorFromSpec() creates protocol-specific error responses from shared specs

### Minor
- Renamed error model IDs for consistency (virtual-fail-precontent-429 → virtual-fail-429)
- Updated failover test setup to use RegisterDefaults instead of RegisterErrorMocks
- Added AllErrorScenarios() helper for comprehensive error testing
- Updated vmodel README with error testing documentation