### PR TITLE
refactor(flags): registry-driven flag system, unify Plugin naming, fix bugs

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -36,8 +36,8 @@
               │                    Frontend                        │
               │  FlagCatalogDialog  ◄── GET /rule/flags/registry  │
               │       │                                            │
-              │       ▼ Switch / TextField per FlagSpec            │
-              │  RuleExtensionsCard  ─── POST /rule/:uuid (flags)  │
+              │       ▼ Registry-driven (no per-flag switch/case) │
+              │  RulePluginsCard  ─── POST /rule/:uuid (flags)     │
               └─────────────────────┬─────────────────────────────┘
                                     │
               ┌─────────────────────▼─────────────────────────────┐
@@ -88,13 +88,16 @@
 ```go
 // internal/typ/flag_registry.go
 type FlagSpec struct {
-    Key         string        // 与 RuleFlags 上的 json tag 完全对应
-    Label       string        // UI 展示用人话
-    Description string        // hover 详细说明
-    Type        FlagValueType // bool | string | enum
-    Category    FlagCategory  // compatibility | request | response
-    Placeholder string        // string 类型的输入框 hint
-    Options     []FlagOption  // enum 类型的可选值，按显示顺序
+    Key             string        // 与 RuleFlags 上的 json tag 完全对应
+    Label           string        // UI 展示用人话
+    Description     string        // hover 详细说明
+    Type            FlagValueType // bool | string | enum | int | service_ref
+    Category        FlagCategory  // compatibility | request | response | routing | app
+    Placeholder     string        // string 类型的输入框 hint
+    Options         []FlagOption  // enum 类型的可选值，按显示顺序
+    Suggestions     []string      // string 类型的快选建议（如 DefaultUserAgents()）
+    Shared          bool          // 是否同时存在 scenario 和 rule 级
+    InheritanceMode string        // shared flag 的继承语义："or" | "override"
 }
 
 type FlagOption struct {
@@ -110,26 +113,31 @@ func RuleFlagRegistry() []FlagSpec { … }
 - 每个 `FlagSpec.Key` **必须**对应 `RuleFlags` struct 上的某个 json
   tag。这条测试挡住"加了 spec 忘了加字段"或反过来。
 - `Label` / `Description` 非空。
-- `Type` 必须在已知枚举内。
+- `Type` 必须在已知枚举内（`bool`、`string`、`enum`、`int`、`service_ref`）。
 - `enum` 类型必须声明 ≥ 2 个 `Options`，每个 Option 的 `Value` / `Label`
   非空且不重复。首个 Option 视为默认值（UI 显示为"未启用"状态）。
+- `Shared == true` 的 flag **必须**声明 `InheritanceMode`（`"or"` 或 `"override"`）。
+- `Shared == false` 的 flag **不得**声明 `InheritanceMode`。
 
 ---
 
-## 4. 当前已注册 flag
+## 4. 当前已注册 flag（14 个）
 
-| Key | Type | 类别 | 作用 | 注入点 |
-|-----|------|------|------|--------|
-| `cursor_compat` | bool | compatibility | Cursor IDE 内容归一化 + stream usage 抑制 | `transform.OpenAICursorCompatTransform` → `ops.ApplyCursorCompatContentNormalization`（Type 1b-pre：pre-Base chain stage）|
-| `cursor_compat_auto` | bool | compatibility | 通过请求头识别 Cursor，自动折叠进 `cursor_compat` | `resolveRuleFlags(c, rule)` 在 handler 入口合并 |
-| `skip_usage` | bool | response | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)`（Type 3）|
-| `use_max_completion_tokens` | bool | request | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `transform.OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite`（Type 1b）|
-| `use_max_tokens` | bool | request | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b）|
-| `custom_user_agent` | string | request | 覆盖出站 User-Agent header。同时存在 rule 级与 scenario 级（rule 非空时优先，否则继承 scenario 默认）。registry 通过 `Suggestions`（`typ.DefaultUserAgents()`）透出几个常见 CLI/agent 的 UA 预设供快选。特殊值 `none`（`typ.UserAgentNone`）= 完全去掉 User-Agent header（发送无 UA），区别于空值（"不覆盖"）。| `customUserAgentTransport` + `applyCustomUserAgent(c, flags)` → `WithCustomUserAgent(ctx, ...)`（Type 2）。注入点收敛在 `resolveRuleFlagsWithScenario` 内部（四个 handler 都经它解析 flags），不再在每个 handler 重复调用。`none` 时 transport 把 header 置空（net/http 见到 present-but-empty 即不发 UA）|
-| `openai_endpoint_override` | enum (`auto`/`chat`/`responses`) | request | 强制单条 rule 的 OpenAI 出口走 Chat 或 Responses；与 provider 声明的 `OpenAIEndpointMode` 冲突时 provider 赢（见 `.design/openai-endpoint-routing.md`）| `ParseEndpointOverride` → `ResolveOpenAIEndpoint`（Type 4：路由层决策）|
-| `block_tools` | string (逗号分隔) | request | 按名字从请求 tool list 中剔除指定工具（发出前），跨 OpenAI Chat / Responses / Anthropic / Google 入站形态生效 | `transform.ToolBlockTransform` → `ops.ApplyToolBlock*`（Type 1b-pre：pre-Base chain stage）|
-| `claude_code_compat` | bool | app | 把 `messages` 数组中 `role == "system"` 的条目重写为 `"user"`。Claude Code 会在 messages 中写入 system role（非标准扩展），严格遵守规范的第三方 Anthropic 兼容 Provider 会拒绝该字段；此 flag 在转发前归一化。同时作为 `ScenarioFlags.ClaudeCodeCompat` 存在，场景级启用后自动注入到该场景所有 rule（同 `CleanHeader` 模式）。| `transform.ClaudeCodeCompatTransform` → `ops.ApplyClaudeCodeCompatRoleRewrite` / `ops.ApplyClaudeCodeBetaCompatRoleRewrite`（Type 1b-pre：pre-Base chain stage，仅对 Anthropic 入站形态生效）|
-| `session_affinity` | int (seconds) | routing | 会话亲和 TTL（秒），0=禁用，>0=启用。Pin 会话到服务以提升缓存命中率 → 更快响应 + 更低 token 成本。Session ID 解析优先级：Anthropic metadata.user_id > X-Tingly-Session-ID header > 客户端 IP。支持 rule 级覆盖（显式设置 rule.Flags.SessionAffinity > 0 时优先）和 scenario 级继承（rule 未设置时继承 ScenarioFlags.SessionAffinity）。| `internal/server/routing/selector.go::ProviderResolver.PostProcess()` → `Config.GetEffectiveAffinity(rule)`（Type 5：路由层决策）|
+| Key | Type | 类别 | Shared | 继承 | 作用 | 注入点 |
+|-----|------|------|--------|------|------|--------|
+| `custom_user_agent` | string | request | **yes** | override | 覆盖出站 User-Agent header。registry 通过 `Suggestions`（`typ.DefaultUserAgents()`）透出几个常见 CLI/agent 的 UA 预设供快选。特殊值 `none`（`typ.UserAgentNone`）= 完全去掉 User-Agent header。| `customUserAgentTransport` + `applyCustomUserAgent(c, flags)` → `WithCustomUserAgent(ctx, ...)`（Type 2）|
+| `openai_endpoint_override` | enum (`auto`/`chat`/`responses`) | request | — | — | 强制单条 rule 的 OpenAI 出口走 Chat 或 Responses；与 provider 声明的 `OpenAIEndpointMode` 冲突时 provider 赢（见 `.design/openai-endpoint-routing.md`）| `ParseEndpointOverride` → `ResolveOpenAIEndpoint`（Type 4：路由层决策）|
+| `use_max_completion_tokens` | bool | request | — | — | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `transform.OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite`（Type 1b-post）|
+| `use_max_tokens` | bool | request | — | — | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b-post）|
+| `block_tools` | string (逗号分隔) | request | — | — | 按名字从请求 tool list 中剔除指定工具（发出前），跨 OpenAI Chat / Responses / Anthropic / Google 入站形态生效 | `transform.ToolBlockTransform` → `ops.ApplyToolBlock*`（Type 1b-pre）|
+| `skip_usage` | bool | response | **yes** | or | 剥离响应中的 `usage`（流式 + 非流式 + Anthropic 转 OpenAI 路径） | `shouldStripUsage(reqCtx.Extra)`（Type 3）|
+| `thinking_effort` | enum (`""`/`off`/`low`/`medium`/`high`/`max`) | reasoning | **yes** | override | 统一控制 extended thinking。映射为 Anthropic budget_tokens（low 1K / medium 5K / high 20K / max 32K）或 OpenAI reasoning_effort。空 = "By Client"（透传客户端参数）。| `ThinkingModeTransform`（Type 1b，server-domain Transform）|
+| `vision_proxy_service` | service_ref | vision | — | — | 通过视觉代理模型描述图片，让纯文本下游模型能处理图片输入。rule 级优先于 scenario 级。| VisionProxy 中间件（Type 1b-pre）|
+| `session_affinity` | int (seconds) | routing | **yes** | override | 会话亲和 TTL（秒），0=禁用，>0=启用。Pin 会话到服务以提升缓存命中率。Session ID 解析优先级：Anthropic metadata.user_id > X-Tingly-Session-ID header > 客户端 IP。| `ProviderResolver.PostProcess()` → `Config.GetEffectiveAffinity(rule)`（Type 5）|
+| `cursor_compat` | bool | app | — | — | Cursor IDE 内容归一化 + stream usage 抑制 | `transform.OpenAICursorCompatTransform` → `ops.ApplyCursorCompatContentNormalization`（Type 1b-pre）|
+| `cursor_compat_auto` | bool | app | — | — | 通过请求头识别 Cursor，自动折叠进 `cursor_compat` | `resolveRuleFlags(c, rule)` 在 handler 入口合并 |
+| `claude_code_compat` | bool | app | **yes** | or | 把 messages 中 `role == "system"` 重写为 `"user"`。Claude Code 在 messages 中写入 system role（非标准扩展）；此 flag 在转发前归一化。| `transform.ClaudeCodeCompatTransform` → `ops.ApplyClaudeCodeCompatRoleRewrite`（Type 1b-pre，仅 Anthropic 入站形态）|
+| `clean_header` | bool | app | **yes** | or | 剥离 system messages 中的 x-anthropic-billing-header 块。billing 场景（claude_code, claude_desktop）协议转换时自动启用；也可手动强制启用。| `CleanHeaderTransform`（Type 1b-pre，server-domain Transform）|
 
 ---
 
@@ -319,45 +327,70 @@ flag 污染。**给 vendor 链新增 transport 时切勿引入 `customUserAgentT
 
 ## 9. 前端 UI
 
+### 统一命名：Plugins
+
+前端统一使用 **"Plugins"** 命名（之前混用 "Plugin" / "Rule Extensions"）。
+相关组件：`RulePluginsCard`（右侧卡片）、`FlagCatalogDialog`（弹窗标题
+"Rule Plugins"）、`PluginFeatures`（场景级 Plugin 控制）。
+
+### Registry-driven 架构
+
+前端不再硬编码任何 per-flag switch/case。核心工具集中在
+`frontend/src/components/rule-card/flagHelpers.ts`：
+
+| Helper | 作用 |
+|--------|------|
+| `snakeToCamel` / `camelToSnake` | `snake_case` ↔ `camelCase` key 转换 |
+| `getFlagValue(flags, key)` | 用 snake_case key 动态读取 camelCase flag |
+| `setFlagValue(flags, key, value)` | 用 snake_case key 动态写入，返回新 flags |
+| `apiToFlags(api)` / `flagsToApi(flags)` | 整体转换 `RuleFlagsApi` ↔ `RuleFlags` |
+| `isFlagActive(flags, spec)` | 根据 spec.Type 判断 flag 是否启用 |
+| `flagDefault(spec)` | 从 spec 取默认值（bool→false, enum→Options[0], etc.） |
+| `enumInactive(spec)` | 取 enum 的"未启用"值（首个 Option.Value） |
+
+这意味着**新增 flag 只需后端 `RuleFlagRegistry()` + `RuleFlags` struct 加字段 + 前端 `RuleFlags`/`RuleFlagsApi` 类型加字段**，无需改动任何 switch/case 或 UI 组件逻辑。
+
 ### 卡片位置
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│ Rule Card                                            [⚙ settings]    │
-│                                                                      │
-│  ┌──────────────────────────────── horizontal scroll ──→  ┐ ┌─────┐  │
-│  │ ModelNode → ArrowNode → ProviderNode → ProviderNode … │ │ Ext │  │
-│  │                                                        │ │Card │  │
-│  └────────────────────────────────────────────────────────┘ └─────┘  │
-│           ↑                                                    ↑     │
-│   随 provider 增多可横向滚动                          常驻右侧不滚动 │
-└─────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Rule Card                                            [⚙ settings]       │
+│                                                                         │
+│  ┌──────────────────────────────── horizontal scroll ──→  ┐ ┌────────┐  │
+│  │ ModelNode → ArrowNode → ProviderNode → ProviderNode … │ │Plugins │  │
+│  │                                                        │ │ Card   │  │
+│  └────────────────────────────────────────────────────────┘ └────────┘  │
+│           ↑                                                    ↑        │
+│   随 provider 增多可横向滚动                          常驻右侧不滚动    │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
 关键 CSS 决策：
 
 - 外层 `display: flex`，graph 在 `flexGrow:1, minWidth:0` 的 box 里启用
   `overflowX:auto`；`minWidth:0` 是让 flex item 能收缩到内容宽以下的关
-  键，否则会把 Extensions 推出视口。
-- Extensions Card `flexShrink:0`——滚动条出现时它**不缩**。
+  键，否则会把 Plugins Card 推出视口。
+- Plugins Card `flexShrink:0`——滚动条出现时它**不缩**。
 - Card 高度 = `PROVIDER_NODE_STYLES.height`（72px），视觉与 provider 行对
   齐；内容溢出时 card 内 `overflowY:auto`。
 
 ### Catalog 弹窗
 
-按 `FlagSpec.Category` 分组（compatibility / request / response）。每个
-flag：
+按 `FlagSpec.Category` 分组。所有渲染逻辑 registry-driven——根据
+`spec.Type` 选择控件，无需为每个 flag 写 case：
 
-- `type: bool` → 一个 `Switch`。
-- `type: string` → `Switch`（占位，未来可改成独立 enable 控制）+
-  `TextField`。当前空字符串视为未启用。
+- `type: bool` → `Switch`。
+- `type: string` → `Switch` + `TextField`（空字符串 = 未启用）。
+- `type: enum` → `Switch` + `Select`（首个 Option = 未启用状态）。
+- `type: int` → `Switch` + `TextField` (number)（0 = 未启用）。
+- `type: service_ref` → `Switch` + provider/model picker。
 - 已启用的 flag 在边框 / 背景上有高亮。
 
 ### 路由图齿轮菜单
 
 齿轮菜单只保留通用项（Test Probe、Export、Activate/Deactivate、Edit
 flag、Delete）。**Cursor 专用菜单项已删除**——所有 flag 都通过右侧
-Extensions Card 操作。
+Plugins Card 操作。
 
 ---
 
@@ -373,6 +406,9 @@ Extensions Card 操作。
 2. internal/typ/flag_registry.go
    └─ 在 RuleFlagRegistry() 追加一个 FlagSpec，
       key 必须与上一步的 json tag 一字不差
+      ├─ 如果 flag 同时存在 scenario 和 rule 级：
+      │   设 Shared: true，并声明 InheritanceMode ("or" / "override")
+      └─ 如果 flag 是 enum 类型，首个 Option 是"未启用"默认值
 
 3. 选定 §5 的注入类型，落地行为：
 
@@ -421,21 +457,11 @@ Extensions Card 操作。
    ├─ RuleFlags 接口加 camelCase 字段
    └─ RuleFlagsApi 接口加 snake_case 字段（与后端 json tag 对齐）
 
-6. frontend/src/components/rule-card/utils.ts
-   ├─ ruleToConfigRecord：snake_case → camelCase 映射
-   ├─ formatRuleFlags / parseRuleFlags：扩展 string-key 兼容路径
-   └─ countActiveFlags：新字段计入
-
-7. frontend/src/components/rule-card/RuleExtensionsCard.tsx
-   └─ flagBoolValue / flagStringValue switch 增加 case
-
-8. frontend/src/components/rule-card/FlagCatalogDialog.tsx
-   └─ flagToBool / flagToString / setBool / setString switch 增加 case
-
-9. frontend/src/components/rule-card/useRuleCardHooks.ts
-   └─ autoSave 的 flags 序列化：camelCase → snake_case payload
-
-10. (可选) 重跑 frontend `npm run gen:api`（CLAUDE.md 约定）
+6. (完毕 — 无需改动前端 UI 组件)
+   flagHelpers.ts 的 registry-driven 工具（getFlagValue / setFlagValue /
+   isFlagActive / apiToFlags / flagsToApi）通过 snakeToCamel key 动态
+   访问 RuleFlags 字段。RulePluginsCard、FlagCatalogDialog、
+   useRuleCardHooks 均无需 per-flag switch/case 改动。
 ```
 
 `TestRuleFlagRegistry_KeysMatchStructFields` 会在第 1、2 步任一步漏改
@@ -456,7 +482,9 @@ Extensions Card 操作。
 | op vs Transform 是否合并 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（可独立测、可复用、可多端调用）；Transform 才感知 rule 与链路位置。合并会让原语难复用 |
 | Transform 放协议层包 vs server 包 | 视依赖而定 | 全部塞 server | 只依赖 SDK / 协议类型的放 `internal/protocol/transform/`；需要 server-domain 类型的放 `internal/server/`。避免反向依赖 |
 | `BuildTransformChain` 是否感知 rule | 否 | 把 ruleFlags 传入 | chain builder 只懂 scenario/provider/recording；rule 级关心点放在 handler，通过 `extraTransforms ...transform.Transform` variadic 注入 |
-| 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Extensions 卡片 | 两套入口对同一字段会引发混淆 |
+| 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Plugins 卡片 | 两套入口对同一字段会引发混淆 |
+| 前端 registry-driven vs per-flag switch/case | registry-driven | 每个 flag 一个 case | registry-driven 消除 ~293 行重复代码；新增 flag 零前端 UI 改动。代价是需要 snakeToCamel 动态映射（类型不够严格），但 `TestRuleFlagRegistry_KeysMatchStructFields` 保证 key 与 struct 同步 |
+| `Shared` / `InheritanceMode` 嵌入 FlagSpec | ✅ | 前端单独维护共享清单 | 继承语义是 flag 固有属性，放在 registry 可信源里前端零维护 |
 
 ---
 
@@ -569,6 +597,10 @@ func (c *Config) scenarioConfigLocked(scenario typ.RuleScenario) *typ.ScenarioCo
 
 ## 13. 未做 / 后续可做
 
+- **前端**：Scenario-level flag 的 `PluginFeatures.tsx` 仍硬编码
+  per-flag 状态管理。下一步应建立 `ScenarioFlagRegistry`（或复用 rule
+  registry 的 `Shared` 子集），让场景级 UI 也走 registry-driven 路径，
+  消除 `PluginFeatures.tsx` 中的 switch/case。
 - **UI**：string flag 加独立 enable Switch，让"空"与"未启用"可区分。
 - **UI**：Catalog 加搜索框 / category collapse（flag 数量超过 ~8 个时
   会拥挤）。
@@ -588,6 +620,12 @@ func (c *Config) scenarioConfigLocked(scenario typ.RuleScenario) *typ.ScenarioCo
   `VisionProxyControl`、`PluginToggleButton`），均放在
   `frontend/src/components/flags/`。`PluginFeatures` 自身缩减为薄编排层，
   一次 `Promise.all` 加载后将数据+回调传给各子组件。
+- ~~**前端**：Rule flag UI 各组件（RuleExtensionsCard、FlagCatalogDialog、
+  useRuleCardHooks、utils）硬编码 per-flag switch/case~~。**已完成**：
+  统一为 registry-driven 架构。核心工具集中在 `flagHelpers.ts`
+  （`getFlagValue`/`setFlagValue`/`apiToFlags`/`flagsToApi`/`isFlagActive`
+  等）。新增 flag 零前端 UI 代码改动。组件重命名为 `RulePluginsCard`，
+  统一使用 "Plugins" 命名。
 - **后端**：`internal/client/openai.go` 通用 OpenAI client 用
   `http.DefaultTransport` 而非 `createSessionBoundTransport`，没有走
   transport pool / session 隔离——独立问题，不在 rule flag 范畴，但

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -69,6 +69,7 @@ export interface RuleFlags {
     sessionAffinity?: number;
     visionProxyService?: VisionProxyServiceRef;
     claudeCodeCompat?: boolean;
+    cleanHeader?: boolean;
 }
 
 export interface RuleFlagsApi {
@@ -84,6 +85,7 @@ export interface RuleFlagsApi {
     session_affinity?: number;
     vision_proxy_service?: VisionProxyServiceRef;
     claude_code_compat?: boolean;
+    clean_header?: boolean;
 }
 
 export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref';
@@ -105,6 +107,8 @@ export interface FlagSpec {
     // User-Agent presets). Rendered as quick-pick chips; free-form input is still
     // allowed. Populated from the backend registry (typ.DefaultUserAgents()).
     suggestions?: FlagOption[];
+    shared?: boolean;
+    inheritanceMode?: string;
 }
 
 export interface Rule {

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -16,6 +16,7 @@ import GraphSettingsMenu from '@/components/GraphSettingsMenu';
 import RulePluginsCard from '@/components/rule-card/RulePluginsCard';
 import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
 import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
+import { getFlagValue, setFlagValue } from '@/components/rule-card/flagHelpers';
 
 // Module-level cache so we only fetch the flag catalog once per session.
 let _flagRegistryCache: FlagSpec[] | null = null;
@@ -254,23 +255,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     const handleToggleFlagFromCard = useCallback((key: string) => {
         if (!configRecord) return;
         const current = configRecord.flags || {};
-        let next: RuleFlags = { ...current };
-        switch (key) {
-            case 'cursor_compat':
-                next = { ...next, cursorCompat: !current.cursorCompat };
-                break;
-            case 'cursor_compat_auto':
-                next = { ...next, cursorCompatAuto: !current.cursorCompatAuto };
-                break;
-            case 'skip_usage':
-                next = { ...next, skipUsage: !current.skipUsage };
-                break;
-            case 'use_max_completion_tokens':
-                next = { ...next, useMaxCompletionTokens: !current.useMaxCompletionTokens };
-                break;
-            default:
-                return;
-        }
+        const next = setFlagValue(current, key, !getFlagValue(current, key));
         void updateField(configRecord, setConfigRecord, 'flags', next);
     }, [configRecord, updateField, setConfigRecord]);
 

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -224,7 +224,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 
     const handleOpenFlagEditor = useCallback(() => {
         if (!configRecord) return;
-        const currentFlags = formatRuleFlags(configRecord.flags);
+        const currentFlags = formatRuleFlags(configRecord.flags, flagRegistry);
         if (!currentFlags && configRecord.requestModel === 'cursor') {
             setFlagInput('cursor_compat=true');
         } else {
@@ -232,18 +232,18 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         }
         setFlagError(undefined);
         setFlagDialogOpen(true);
-    }, [configRecord]);
+    }, [configRecord, flagRegistry]);
 
     const handleSaveFlags = useCallback(async () => {
         if (!configRecord) return;
-        const result = parseRuleFlags(flagInput);
+        const result = parseRuleFlags(flagInput, flagRegistry);
         if (result.error) {
             setFlagError(result.error);
             return;
         }
         await updateField(configRecord, setConfigRecord, 'flags', result.flags);
         setFlagDialogOpen(false);
-    }, [configRecord, flagInput, updateField, setConfigRecord]);
+    }, [configRecord, flagInput, flagRegistry, updateField, setConfigRecord]);
 
     const handleSaveCatalogFlags = useCallback(async (next: RuleFlags) => {
         if (!configRecord) return;

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -13,7 +13,7 @@ import { RuleCardDeleteDialog, RuleFlagEditDialog } from '@/components/rule-card
 import UnifiedRoutingGraph from '@/components/UnifiedRoutingGraph';
 import SmartRuleCatalogDialog from '@/components/rule-card/SmartRuleCatalogDialog';
 import GraphSettingsMenu from '@/components/GraphSettingsMenu';
-import RuleExtensionsCard from '@/components/rule-card/RuleExtensionsCard';
+import RulePluginsCard from '@/components/rule-card/RulePluginsCard';
 import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
 import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
 
@@ -277,7 +277,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     if (!configRecord) return null;
 
     const extensionsCard = (
-        <RuleExtensionsCard
+        <RulePluginsCard
             flags={configRecord.flags}
             registry={flagRegistry}
             active={configRecord.active}

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -19,11 +19,12 @@ import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
 import { getFlagValue, setFlagValue } from '@/components/rule-card/flagHelpers';
 
 // Module-level cache so we only fetch the flag catalog once per session.
-let _flagRegistryCache: FlagSpec[] | null = null;
+// `undefined` = never fetched; `[]` = fetched but empty (don't re-fetch).
+let _flagRegistryCache: FlagSpec[] | undefined = undefined;
 let _flagRegistryPromise: Promise<FlagSpec[]> | null = null;
 
 async function loadFlagRegistry(): Promise<FlagSpec[]> {
-    if (_flagRegistryCache) return _flagRegistryCache;
+    if (_flagRegistryCache !== undefined) return _flagRegistryCache;
     if (_flagRegistryPromise) return _flagRegistryPromise;
     _flagRegistryPromise = (async () => {
         try {
@@ -32,6 +33,7 @@ async function loadFlagRegistry(): Promise<FlagSpec[]> {
             _flagRegistryCache = data;
             return data;
         } catch {
+            // Don't cache failures — allow retry on next mount.
             return [];
         } finally {
             _flagRegistryPromise = null;
@@ -113,16 +115,20 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 
     // Catalog dialog state + registry
     const [catalogOpen, setCatalogOpen] = useState(false);
-    const [flagRegistry, setFlagRegistry] = useState<FlagSpec[]>(_flagRegistryCache || []);
+    const [flagRegistry, setFlagRegistry] = useState<FlagSpec[]>(_flagRegistryCache ?? []);
+    const [registryLoaded, setRegistryLoaded] = useState(_flagRegistryCache !== undefined);
     const [registryLoading, setRegistryLoading] = useState(false);
 
     useEffect(() => {
-        if (flagRegistry.length > 0) return;
+        if (registryLoaded) return;
         let cancelled = false;
         setRegistryLoading(true);
         loadFlagRegistry()
             .then((data) => {
-                if (!cancelled) setFlagRegistry(data);
+                if (!cancelled) {
+                    setFlagRegistry(data);
+                    setRegistryLoaded(true);
+                }
             })
             .finally(() => {
                 if (!cancelled) setRegistryLoading(false);
@@ -130,7 +136,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         return () => {
             cancelled = true;
         };
-    }, [flagRegistry.length]);
+    }, [registryLoaded]);
 
     // Handler: Switch routing mode (simple toggle, preserves data)
     const handleRoutingModeSwitch = useCallback(async () => {
@@ -237,19 +243,19 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 
     const handleSaveFlags = useCallback(async () => {
         if (!configRecord) return;
-        const result = parseRuleFlags(flagInput, flagRegistry);
+        const result = parseRuleFlags(flagInput, flagRegistry, configRecord.flags);
         if (result.error) {
             setFlagError(result.error);
             return;
         }
-        await updateField(configRecord, setConfigRecord, 'flags', result.flags);
-        setFlagDialogOpen(false);
+        const success = await updateField(configRecord, setConfigRecord, 'flags', result.flags);
+        if (success) setFlagDialogOpen(false);
     }, [configRecord, flagInput, flagRegistry, updateField, setConfigRecord]);
 
     const handleSaveCatalogFlags = useCallback(async (next: RuleFlags) => {
         if (!configRecord) return;
-        await updateField(configRecord, setConfigRecord, 'flags', next);
-        setCatalogOpen(false);
+        const success = await updateField(configRecord, setConfigRecord, 'flags', next);
+        if (success) setCatalogOpen(false);
     }, [configRecord, updateField, setConfigRecord]);
 
     const handleToggleFlagFromCard = useCallback((key: string) => {

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -30,7 +30,7 @@ import type { FlagSpec, RuleFlags, VisionProxyServiceRef } from '@/components/Ro
 import type { Provider } from '@/types/provider';
 import type { ProviderSelectTabOption } from '@/components/ModelSelectDialog';
 import ModelSelectDialog from '@/components/ModelSelectDialog';
-import { getFlagValue, setFlagValue, enumInactive, isFlagActive, normalizeEnumForStorage } from './flagHelpers';
+import { getFlagValue, setFlagValue, flagDefault, enumInactive, isFlagActive, normalizeEnumForStorage } from './flagHelpers';
 
 export interface FlagCatalogDialogProps {
     open: boolean;
@@ -160,8 +160,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     };
 
     const handleRemoveActive = (spec: FlagSpec) => {
-        const def = spec.type === 'bool' ? false : spec.type === 'int' ? 0 : spec.type === 'service_ref' ? undefined : '';
-        setDraft((d) => setFlagValue(d, spec.key, def));
+        setDraft((d) => setFlagValue(d, spec.key, flagDefault(spec)));
     };
 
     return (
@@ -387,7 +386,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                                         size="small"
                                                         type="number"
                                                         placeholder={spec.placeholder}
-                                                        value={flagToInt(draft, spec.key) || ''}
+                                                        value={flagToInt(draft, spec.key) ?? ''}
                                                         slotProps={{ htmlInput: { min: 0 } }}
                                                         onChange={(e) => handleIntChange(spec.key, e.target.value)}
                                                         sx={{ mt: 1 }}

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -76,6 +76,8 @@ const flagToBool = (flags: RuleFlags | undefined, key: string): boolean => {
             return !!flags.useMaxTokens;
         case 'claude_code_compat':
             return !!flags.claudeCodeCompat;
+        case 'clean_header':
+            return !!flags.cleanHeader;
         default:
             return false;
     }
@@ -130,6 +132,8 @@ const setBool = (flags: RuleFlags, key: string, value: boolean): RuleFlags => {
             return { ...flags, useMaxTokens: value };
         case 'claude_code_compat':
             return { ...flags, claudeCodeCompat: value };
+        case 'clean_header':
+            return { ...flags, cleanHeader: value };
         default:
             return flags;
     }
@@ -282,9 +286,9 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     return (
         <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
             <DialogTitle sx={{ pb: 1 }}>
-                Rule Extensions
+                Rule Plugins
                 <Typography variant="caption" component="div" color="text.secondary">
-                    Pre-installed flags applied at the rule level.
+                    Plugin flags applied at the rule level.
                 </Typography>
             </DialogTitle>
 

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -30,6 +30,7 @@ import type { FlagSpec, RuleFlags, VisionProxyServiceRef } from '@/components/Ro
 import type { Provider } from '@/types/provider';
 import type { ProviderSelectTabOption } from '@/components/ModelSelectDialog';
 import ModelSelectDialog from '@/components/ModelSelectDialog';
+import { getFlagValue, setFlagValue, enumInactive, isFlagActive, normalizeEnumForStorage } from './flagHelpers';
 
 export interface FlagCatalogDialogProps {
     open: boolean;
@@ -42,142 +43,17 @@ export interface FlagCatalogDialogProps {
     onSave: (next: RuleFlags) => void;
 }
 
-const flagToServiceRef = (flags: RuleFlags | undefined, key: string): VisionProxyServiceRef | undefined => {
-    if (!flags) return undefined;
-    switch (key) {
-        case 'vision_proxy_service':
-            return flags.visionProxyService;
-        default:
-            return undefined;
-    }
-};
+const flagToBool = (flags: RuleFlags | undefined, key: string): boolean =>
+    !!getFlagValue(flags, key);
 
-const setServiceRef = (flags: RuleFlags, key: string, value: VisionProxyServiceRef | undefined): RuleFlags => {
-    switch (key) {
-        case 'vision_proxy_service':
-            return { ...flags, visionProxyService: value };
-        default:
-            return flags;
-    }
-};
+const flagToInt = (flags: RuleFlags | undefined, key: string): number =>
+    (getFlagValue(flags, key) as number) ?? 0;
 
-const flagToBool = (flags: RuleFlags | undefined, key: string): boolean => {
-    if (!flags) return false;
-    switch (key) {
-        case 'cursor_compat':
-            return !!flags.cursorCompat;
-        case 'cursor_compat_auto':
-            return !!flags.cursorCompatAuto;
-        case 'skip_usage':
-            return !!flags.skipUsage;
-        case 'use_max_completion_tokens':
-            return !!flags.useMaxCompletionTokens;
-        case 'use_max_tokens':
-            return !!flags.useMaxTokens;
-        case 'claude_code_compat':
-            return !!flags.claudeCodeCompat;
-        case 'clean_header':
-            return !!flags.cleanHeader;
-        default:
-            return false;
-    }
-};
+const flagToString = (flags: RuleFlags | undefined, key: string): string =>
+    (getFlagValue(flags, key) as string) ?? '';
 
-const flagToInt = (flags: RuleFlags | undefined, key: string): number => {
-    if (!flags) return 0;
-    switch (key) {
-        case 'session_affinity':
-            return flags.sessionAffinity ?? 0;
-        default:
-            return 0;
-    }
-};
-
-const setInt = (flags: RuleFlags, key: string, value: number): RuleFlags => {
-    switch (key) {
-        case 'session_affinity':
-            return { ...flags, sessionAffinity: value };
-        default:
-            return flags;
-    }
-};
-
-const flagToString = (flags: RuleFlags | undefined, key: string): string => {
-    if (!flags) return '';
-    switch (key) {
-        case 'custom_user_agent':
-            return flags.customUserAgent || '';
-        case 'openai_endpoint_override':
-            return flags.openaiEndpointOverride || '';
-        case 'block_tools':
-            return flags.blockTools || '';
-        case 'thinking_effort':
-            return flags.thinkingEffort || '';
-        default:
-            return '';
-    }
-};
-
-const setBool = (flags: RuleFlags, key: string, value: boolean): RuleFlags => {
-    switch (key) {
-        case 'cursor_compat':
-            return { ...flags, cursorCompat: value };
-        case 'cursor_compat_auto':
-            return { ...flags, cursorCompatAuto: value };
-        case 'skip_usage':
-            return { ...flags, skipUsage: value };
-        case 'use_max_completion_tokens':
-            return { ...flags, useMaxCompletionTokens: value };
-        case 'use_max_tokens':
-            return { ...flags, useMaxTokens: value };
-        case 'claude_code_compat':
-            return { ...flags, claudeCodeCompat: value };
-        case 'clean_header':
-            return { ...flags, cleanHeader: value };
-        default:
-            return flags;
-    }
-};
-
-const setString = (flags: RuleFlags, key: string, value: string): RuleFlags => {
-    switch (key) {
-        case 'custom_user_agent':
-            return { ...flags, customUserAgent: value };
-        case 'openai_endpoint_override':
-            // Persist "auto" as empty string so omitempty hides it on the wire.
-            return { ...flags, openaiEndpointOverride: value === 'auto' ? '' : value };
-        case 'block_tools':
-            return { ...flags, blockTools: value };
-        case 'thinking_effort':
-            // First option already uses "" for the inactive ("By Client") value.
-            return { ...flags, thinkingEffort: value };
-        default:
-            return flags;
-    }
-};
-
-// The inactive/default value for an enum flag is its first registry option
-// (e.g. "auto" for endpoint override, "" for thinking effort, "default" for thinking mode).
-const enumDefault = (spec: FlagSpec): string => spec.options?.[0]?.value ?? '';
-
-const isFlagActive = (spec: FlagSpec, flags: RuleFlags): boolean => {
-    if (spec.type === 'bool') return flagToBool(flags, spec.key);
-    if (spec.type === 'int') return flagToInt(flags, spec.key) > 0;
-    if (spec.type === 'service_ref') {
-        const ref = flagToServiceRef(flags, spec.key);
-        return !!(ref && ref.provider && ref.model);
-    }
-    const v = flagToString(flags, spec.key);
-    if (spec.type === 'enum') return v !== '' && v !== enumDefault(spec);
-    return v !== '';
-};
-
-const resetFlag = (flags: RuleFlags, spec: FlagSpec): RuleFlags => {
-    if (spec.type === 'bool') return setBool(flags, spec.key, false);
-    if (spec.type === 'int') return setInt(flags, spec.key, 0);
-    if (spec.type === 'service_ref') return setServiceRef(flags, spec.key, undefined);
-    return setString(flags, spec.key, '');
-};
+const flagToServiceRef = (flags: RuleFlags | undefined, key: string): VisionProxyServiceRef | undefined =>
+    getFlagValue(flags, key) as VisionProxyServiceRef | undefined;
 
 interface CategoryMeta {
     label: string;
@@ -253,17 +129,21 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
 
     const currentGroup = grouped.find((g) => g.category === activeCategory);
 
+    const specLookup = useMemo(() => new Map((registry || []).map((s) => [s.key, s])), [registry]);
+
     const handleToggle = (key: string, value: boolean) => {
-        setDraft((d) => setBool(d, key, value));
+        setDraft((d) => setFlagValue(d, key, value));
     };
 
     const handleStringChange = (key: string, value: string) => {
-        setDraft((d) => setString(d, key, value));
+        const spec = specLookup.get(key);
+        const normalized = spec?.type === 'enum' ? normalizeEnumForStorage(spec, value) : value;
+        setDraft((d) => setFlagValue(d, key, normalized));
     };
 
     const handleIntChange = (key: string, value: string) => {
         const n = parseInt(value, 10);
-        setDraft((d) => setInt(d, key, isNaN(n) || n < 0 ? 0 : n));
+        setDraft((d) => setFlagValue(d, key, isNaN(n) || n < 0 ? 0 : n));
     };
 
     const jumpToFlag = (spec: FlagSpec) => {
@@ -280,7 +160,8 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     };
 
     const handleRemoveActive = (spec: FlagSpec) => {
-        setDraft((d) => resetFlag(d, spec));
+        const def = spec.type === 'bool' ? false : spec.type === 'int' ? 0 : spec.type === 'service_ref' ? undefined : '';
+        setDraft((d) => setFlagValue(d, spec.key, def));
     };
 
     return (
@@ -412,7 +293,7 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                     {currentGroup.specs.map((spec) => {
                                         const enabled = isFlagActive(spec, draft);
                                         const enumValue = spec.type === 'enum'
-                                            ? (flagToString(draft, spec.key) || enumDefault(spec))
+                                            ? (flagToString(draft, spec.key) || enumInactive(spec))
                                             : '';
                                         const pulsing = pulseKey === spec.key;
                                         return (
@@ -584,12 +465,12 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                             selectedModel={flagToServiceRef(draft, pickerKey)?.model}
                             onSelected={(option: ProviderSelectTabOption) => {
                                 const key = pickerKey;
-                                setDraft((d) => setServiceRef(d, key, { provider: option.provider.uuid, model: option.model }));
+                                setDraft((d) => setFlagValue(d, key, { provider: option.provider.uuid, model: option.model }));
                                 setPickerKey(null);
                             }}
                             onSelectionClear={() => {
                                 const key = pickerKey;
-                                setDraft((d) => setServiceRef(d, key, undefined));
+                                setDraft((d) => setFlagValue(d, key, undefined));
                                 setPickerKey(null);
                             }}
                         />

--- a/frontend/src/components/rule-card/RulePluginsCard.tsx
+++ b/frontend/src/components/rule-card/RulePluginsCard.tsx
@@ -21,7 +21,7 @@ const CARD_STYLES = {
 
 const CARD_HEADER_HEIGHT = 18;
 
-const StyledExtensionsCard = styled(Box, {
+const StyledPluginsCard = styled(Box, {
     shouldForwardProp: (prop) => prop !== 'active',
 })<{ active: boolean }>(({ active, theme }) => ({
     display: 'flex',
@@ -45,7 +45,7 @@ const StyledExtensionsCard = styled(Box, {
     },
 }));
 
-export interface RuleExtensionsCardProps {
+export interface RulePluginsCardProps {
     flags?: RuleFlags;
     registry?: FlagSpec[];
     active: boolean;
@@ -68,6 +68,8 @@ const flagBoolValue = (flags: RuleFlags | undefined, key: string): boolean => {
             return !!flags.useMaxTokens;
         case 'claude_code_compat':
             return !!flags.claudeCodeCompat;
+        case 'clean_header':
+            return !!flags.cleanHeader;
         default:
             return false;
     }
@@ -119,11 +121,11 @@ const flagServiceRefDisplay = (flags: RuleFlags | undefined, key: string): strin
 };
 
 /**
- * RuleExtensionsCard renders a compact card displaying the rule's enabled
- * extension flags. The "+ Add" action opens the catalog dialog where users
+ * RulePluginsCard renders a compact card displaying the rule's enabled
+ * plugin flags. The "+ Add" action opens the catalog dialog where users
  * pick which flags to enable and supply any parameters they require.
  */
-export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
+export const RulePluginsCard: React.FC<RulePluginsCardProps> = ({
     flags,
     registry,
     active,
@@ -143,7 +145,7 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
     });
 
     return (
-        <StyledExtensionsCard active={active} onClick={onOpenCatalog}>
+        <StyledPluginsCard active={active} onClick={onOpenCatalog}>
             {/* Fixed-height header so the body has a stable scroll region */}
             <Stack
                 direction="row"
@@ -157,10 +159,10 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
             >
                 <ExtensionIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
                 <Typography variant="caption" sx={{ fontWeight: 700, fontSize: '0.72rem', color: 'text.secondary', flexGrow: 1, lineHeight: 1 }}>
-                    Extensions{enabled.length > 0 ? ` (${enabled.length})` : ''}
+                    Plugins{enabled.length > 0 ? ` (${enabled.length})` : ''}
                 </Typography>
                 {/* Visual affordance only — the whole card is clickable. */}
-                <Tooltip title="Configure rule extensions">
+                <Tooltip title="Configure rule plugins">
                     <AddIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
                 </Tooltip>
             </Stack>
@@ -283,8 +285,8 @@ export const RuleExtensionsCard: React.FC<RuleExtensionsCardProps> = ({
                     </Stack>
                 </Box>
             )}
-        </StyledExtensionsCard>
+        </StyledPluginsCard>
     );
 };
 
-export default RuleExtensionsCard;
+export default RulePluginsCard;

--- a/frontend/src/components/rule-card/RulePluginsCard.tsx
+++ b/frontend/src/components/rule-card/RulePluginsCard.tsx
@@ -9,10 +9,9 @@ import {
     graphNodeHoverStyles,
     MODEL_NODE_STYLES,
 } from '@/components/nodes/styles';
-import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
+import type { FlagSpec, RuleFlags, VisionProxyServiceRef } from '@/components/RoutingGraphTypes';
+import { getFlagValue, isFlagActive } from './flagHelpers';
 
-// Matches the route graph node footprint so this feels like a pinned tool node,
-// not a smaller floating card. Content overflow scrolls inside the body.
 const CARD_STYLES = {
     width: MODEL_NODE_STYLES.width,
     minHeight: MODEL_NODE_STYLES.height,
@@ -53,37 +52,11 @@ export interface RulePluginsCardProps {
     onToggleFlag?: (key: string) => void;
 }
 
-const flagBoolValue = (flags: RuleFlags | undefined, key: string): boolean => {
-    if (!flags) return false;
-    switch (key) {
-        case 'cursor_compat':
-            return !!flags.cursorCompat;
-        case 'cursor_compat_auto':
-            return !!flags.cursorCompatAuto;
-        case 'skip_usage':
-            return !!flags.skipUsage;
-        case 'use_max_completion_tokens':
-            return !!flags.useMaxCompletionTokens;
-        case 'use_max_tokens':
-            return !!flags.useMaxTokens;
-        case 'claude_code_compat':
-            return !!flags.claudeCodeCompat;
-        case 'clean_header':
-            return !!flags.cleanHeader;
-        default:
-            return false;
-    }
-};
+const flagBoolValue = (flags: RuleFlags | undefined, key: string): boolean =>
+    !!getFlagValue(flags, key);
 
-const flagIntValue = (flags: RuleFlags | undefined, key: string): number => {
-    if (!flags) return 0;
-    switch (key) {
-        case 'session_affinity':
-            return flags.sessionAffinity ?? 0;
-        default:
-            return 0;
-    }
-};
+const flagIntValue = (flags: RuleFlags | undefined, key: string): number =>
+    (getFlagValue(flags, key) as number) ?? 0;
 
 const formatSeconds = (s: number): string => {
     if (s <= 0) return '0s';
@@ -92,33 +65,11 @@ const formatSeconds = (s: number): string => {
     return `${s}s`;
 };
 
-const flagStringValue = (flags: RuleFlags | undefined, key: string): string => {
-    if (!flags) return '';
-    switch (key) {
-        case 'custom_user_agent':
-            return flags.customUserAgent || '';
-        case 'openai_endpoint_override':
-            return flags.openaiEndpointOverride || '';
-        case 'block_tools':
-            return flags.blockTools || '';
-        case 'thinking_effort':
-            return flags.thinkingEffort || '';
-        default:
-            return '';
-    }
-};
+const flagStringValue = (flags: RuleFlags | undefined, key: string): string =>
+    (getFlagValue(flags, key) as string) ?? '';
 
-// flagServiceRefDisplay returns the model name of a service_ref flag (the
-// concise label for the extension chip), or '' when unset.
-const flagServiceRefDisplay = (flags: RuleFlags | undefined, key: string): string => {
-    if (!flags) return '';
-    switch (key) {
-        case 'vision_proxy_service':
-            return flags.visionProxyService?.model || '';
-        default:
-            return '';
-    }
-};
+const flagServiceRefDisplay = (flags: RuleFlags | undefined, key: string): string =>
+    (getFlagValue(flags, key) as VisionProxyServiceRef | undefined)?.model ?? '';
 
 /**
  * RulePluginsCard renders a compact card displaying the rule's enabled
@@ -132,17 +83,7 @@ export const RulePluginsCard: React.FC<RulePluginsCardProps> = ({
     onOpenCatalog,
     onToggleFlag,
 }) => {
-    const enabled = (registry || []).filter((spec) => {
-        if (spec.type === 'bool') return flagBoolValue(flags, spec.key);
-        if (spec.type === 'int') return flagIntValue(flags, spec.key) > 0;
-        if (spec.type === 'enum') {
-            const v = flagStringValue(flags, spec.key);
-            const inactive = spec.options?.[0]?.value ?? '';
-            return v !== '' && v !== inactive;
-        }
-        if (spec.type === 'service_ref') return flagServiceRefDisplay(flags, spec.key) !== '';
-        return flagStringValue(flags, spec.key) !== '';
-    });
+    const enabled = (registry || []).filter((spec) => isFlagActive(spec, flags));
 
     return (
         <StyledPluginsCard active={active} onClick={onOpenCatalog}>

--- a/frontend/src/components/rule-card/RulePluginsCard.tsx
+++ b/frontend/src/components/rule-card/RulePluginsCard.tsx
@@ -52,9 +52,6 @@ export interface RulePluginsCardProps {
     onToggleFlag?: (key: string) => void;
 }
 
-const flagBoolValue = (flags: RuleFlags | undefined, key: string): boolean =>
-    !!getFlagValue(flags, key);
-
 const flagIntValue = (flags: RuleFlags | undefined, key: string): number =>
     (getFlagValue(flags, key) as number) ?? 0;
 

--- a/frontend/src/components/rule-card/flagHelpers.ts
+++ b/frontend/src/components/rule-card/flagHelpers.ts
@@ -1,0 +1,74 @@
+import type { FlagSpec, RuleFlags, RuleFlagsApi, VisionProxyServiceRef } from '@/components/RoutingGraphTypes';
+
+export function snakeToCamel(s: string): string {
+    return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+export function camelToSnake(s: string): string {
+    return s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+}
+
+export function getFlagValue(flags: RuleFlags | undefined, key: string): unknown {
+    if (!flags) return undefined;
+    return (flags as Record<string, unknown>)[snakeToCamel(key)];
+}
+
+export function setFlagValue(flags: RuleFlags, key: string, value: unknown): RuleFlags {
+    return { ...flags, [snakeToCamel(key)]: value };
+}
+
+export function flagDefault(spec: FlagSpec): unknown {
+    switch (spec.type) {
+        case 'bool': return false;
+        case 'string': return '';
+        case 'int': return 0;
+        case 'enum': return spec.options?.[0]?.value ?? '';
+        case 'service_ref': return undefined;
+    }
+}
+
+export function enumInactive(spec: FlagSpec): string {
+    return spec.options?.[0]?.value ?? '';
+}
+
+export function isFlagActive(spec: FlagSpec, flags: RuleFlags): boolean {
+    const value = getFlagValue(flags, spec.key);
+    switch (spec.type) {
+        case 'bool': return !!value;
+        case 'string': return typeof value === 'string' && value !== '';
+        case 'int': return typeof value === 'number' && value > 0;
+        case 'enum': {
+            const inactive = enumInactive(spec);
+            return value !== '' && value !== undefined && value !== inactive;
+        }
+        case 'service_ref': {
+            const ref = value as VisionProxyServiceRef | undefined;
+            return !!(ref && ref.provider && ref.model);
+        }
+        default: return false;
+    }
+}
+
+// Collapse enum inactive sentinel to '' for omitempty on the wire.
+export function normalizeEnumForStorage(spec: FlagSpec, value: string): string {
+    const inactive = enumInactive(spec);
+    return (inactive !== '' && value === inactive) ? '' : value;
+}
+
+export function apiToFlags(api: RuleFlagsApi | undefined): RuleFlags {
+    if (!api) return {};
+    const flags: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(api)) {
+        flags[snakeToCamel(key)] = value;
+    }
+    return flags as RuleFlags;
+}
+
+export function flagsToApi(flags: RuleFlags | undefined): RuleFlagsApi {
+    if (!flags) return {};
+    const api: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(flags)) {
+        api[camelToSnake(key)] = value;
+    }
+    return api as RuleFlagsApi;
+}

--- a/frontend/src/components/rule-card/index.ts
+++ b/frontend/src/components/rule-card/index.ts
@@ -9,6 +9,7 @@ export * from './dialogs';
 
 // Utils
 export * from './utils';
+export * from './flagHelpers';
 
 // Plugin card + catalog dialog
 export { default as RulePluginsCard } from './RulePluginsCard';

--- a/frontend/src/components/rule-card/index.ts
+++ b/frontend/src/components/rule-card/index.ts
@@ -10,6 +10,6 @@ export * from './dialogs';
 // Utils
 export * from './utils';
 
-// Extension card + catalog dialog
-export { default as RuleExtensionsCard } from './RuleExtensionsCard';
+// Plugin card + catalog dialog
+export { default as RulePluginsCard } from './RulePluginsCard';
 export { default as FlagCatalogDialog } from './FlagCatalogDialog';

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -13,6 +13,7 @@ import {
     pickLbTactic,
     type ExportFormat,
 } from './utils';
+import { flagsToApi } from './flagHelpers';
 
 // ============================================================================
 // Types
@@ -114,21 +115,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                     response_model: newConfigRecord.responseModel,
                     active: newConfigRecord.active,
                     description: newConfigRecord.description,
-                    flags: {
-                        cursor_compat: newConfigRecord.flags?.cursorCompat || false,
-                        cursor_compat_auto: newConfigRecord.flags?.cursorCompatAuto || false,
-                        skip_usage: newConfigRecord.flags?.skipUsage || false,
-                        custom_user_agent: newConfigRecord.flags?.customUserAgent || '',
-                        use_max_completion_tokens: newConfigRecord.flags?.useMaxCompletionTokens || false,
-                        use_max_tokens: newConfigRecord.flags?.useMaxTokens || false,
-                        openai_endpoint_override: newConfigRecord.flags?.openaiEndpointOverride || '',
-                        block_tools: newConfigRecord.flags?.blockTools || '',
-                        thinking_effort: newConfigRecord.flags?.thinkingEffort || '',
-                        session_affinity: newConfigRecord.flags?.sessionAffinity || 0,
-                        vision_proxy_service: newConfigRecord.flags?.visionProxyService,
-                        claude_code_compat: newConfigRecord.flags?.claudeCodeCompat || false,
-                        clean_header: newConfigRecord.flags?.cleanHeader || false,
-                    },
+                    flags: flagsToApi(newConfigRecord.flags),
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)
                         .map((provider) => ({

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -126,7 +126,8 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
                         thinking_effort: newConfigRecord.flags?.thinkingEffort || '',
                         session_affinity: newConfigRecord.flags?.sessionAffinity || 0,
                         vision_proxy_service: newConfigRecord.flags?.visionProxyService,
-                        claude_code_compat: newConfigRecord.flags?.anthropicCompat || false,
+                        claude_code_compat: newConfigRecord.flags?.claudeCodeCompat || false,
+                        clean_header: newConfigRecord.flags?.cleanHeader || false,
                     },
                     services: newConfigRecord.providers
                         .filter((p) => p.provider && p.model)

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -217,9 +217,17 @@ export function formatRuleFlags(flags: RuleFlags | undefined, registry: FlagSpec
         .join(',');
 }
 
-export function parseRuleFlags(input: string, registry: FlagSpec[]): { flags: RuleFlags; error?: string } {
+export function parseRuleFlags(input: string, registry: FlagSpec[], currentFlags?: RuleFlags): { flags: RuleFlags; error?: string } {
     const flags: RuleFlags = {};
     for (const spec of registry) {
+        // Preserve non-text-editable flags (e.g. service_ref) from current state.
+        if (spec.type === 'service_ref' && currentFlags) {
+            const existing = getFlagValue(currentFlags, spec.key);
+            if (existing !== undefined) {
+                (flags as Record<string, unknown>)[snakeToCamel(spec.key)] = existing;
+                continue;
+            }
+        }
         (flags as Record<string, unknown>)[snakeToCamel(spec.key)] = flagDefault(spec);
     }
 
@@ -283,10 +291,7 @@ export function parseRuleFlags(input: string, registry: FlagSpec[]): { flags: Ru
     return { flags };
 }
 
-export function countActiveFlags(flags: RuleFlags | undefined, registry: FlagSpec[]): number {
-    if (!flags) return 0;
-    return registry.filter((spec) => isFlagActive(spec, flags)).length;
-}
+
 
 // Generic export handler
 async function exportData(

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { api } from '@/services/api';
-import type { SmartRouting, ConfigProvider, Rule, ConfigRecord, RuleFlags, RuleFlagsApi } from '@/components/RoutingGraphTypes';
+import type { SmartRouting, ConfigProvider, Rule, ConfigRecord, RuleFlags, RuleFlagsApi, FlagSpec } from '@/components/RoutingGraphTypes';
+import { getFlagValue, setFlagValue, flagDefault, isFlagActive, snakeToCamel, apiToFlags } from './flagHelpers';
 
 // ============================================================================
 // Helper Functions
@@ -65,21 +66,7 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
         active: rule.active !== undefined ? rule.active : true,
         providers: providersList,
         description: rule.description,
-        flags: {
-            cursorCompat: rule.flags?.cursor_compat || false,
-            cursorCompatAuto: rule.flags?.cursor_compat_auto || false,
-            skipUsage: rule.flags?.skip_usage || false,
-            customUserAgent: rule.flags?.custom_user_agent || '',
-            useMaxCompletionTokens: rule.flags?.use_max_completion_tokens || false,
-            useMaxTokens: rule.flags?.use_max_tokens || false,
-            openaiEndpointOverride: rule.flags?.openai_endpoint_override || '',
-            blockTools: rule.flags?.block_tools || '',
-            thinkingEffort: rule.flags?.thinking_effort || '',
-            sessionAffinity: rule.flags?.session_affinity || 0,
-            visionProxyService: rule.flags?.vision_proxy_service,
-            claudeCodeCompat: rule.flags?.claude_code_compat || false,
-            cleanHeader: rule.flags?.clean_header || false,
-        },
+        flags: apiToFlags(rule.flags),
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
         lbTactic: rule.lb_tactic?.type,
@@ -213,76 +200,35 @@ interface ExportProvider {
 }
 
 // ============================================================================
-// Rule flag helpers
+// Rule flag helpers (registry-driven — no per-flag switch/case needed)
 // ============================================================================
 
 const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
 const FALSE_VALUES = new Set(['false', '0', 'no', 'off']);
 
-const ENUM_FLAG_VALUES: Record<string, Set<string>> = {
-    openai_endpoint_override: new Set(['auto', 'chat', 'responses']),
-    thinking_effort: new Set(['off', 'low', 'medium', 'high', 'max']),
-};
-
-// The sentinel value that means "inactive/By Client" for each enum flag.
-// Empty string (omitted on the wire) is always inactive too.
-const ENUM_INACTIVE_VALUE: Record<string, string> = {
-    openai_endpoint_override: 'auto',
-    thinking_effort: '',
-};
-
-function isEnumActive(key: string, value: string): boolean {
-    return value !== '' && value !== (ENUM_INACTIVE_VALUE[key] ?? '');
-}
-
-export function formatRuleFlags(flags?: RuleFlags): string {
+export function formatRuleFlags(flags: RuleFlags | undefined, registry: FlagSpec[]): string {
     if (!flags) return '';
-    const entries: string[] = [];
-    if (flags.cursorCompat) entries.push('cursor_compat=true');
-    if (flags.cursorCompatAuto) entries.push('cursor_compat_auto=true');
-    if (flags.skipUsage) entries.push('skip_usage=true');
-    if (flags.useMaxCompletionTokens) entries.push('use_max_completion_tokens=true');
-    if (flags.useMaxTokens) entries.push('use_max_tokens=true');
-    if (flags.customUserAgent) entries.push(`custom_user_agent=${flags.customUserAgent}`);
-    if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) {
-        entries.push(`openai_endpoint_override=${flags.openaiEndpointOverride}`);
-    }
-    if (flags.blockTools) entries.push(`block_tools=${flags.blockTools}`);
-    if (flags.thinkingEffort && isEnumActive('thinking_effort', flags.thinkingEffort)) {
-        entries.push(`thinking_effort=${flags.thinkingEffort}`);
-    }
-    if (flags.sessionAffinity) entries.push(`session_affinity=${flags.sessionAffinity}`);
-    if (flags.claudeCodeCompat) entries.push('claude_code_compat=true');
-    if (flags.cleanHeader) entries.push('clean_header=true');
-    return entries.join(',');
+    return registry
+        .filter((spec) => spec.type !== 'service_ref' && isFlagActive(spec, flags))
+        .map((spec) => {
+            const val = getFlagValue(flags, spec.key);
+            return spec.type === 'bool' ? `${spec.key}=true` : `${spec.key}=${val}`;
+        })
+        .join(',');
 }
 
-const STRING_FLAG_KEYS = new Set(['custom_user_agent', 'block_tools']);
-const ENUM_FLAG_KEYS = new Set(Object.keys(ENUM_FLAG_VALUES));
-const INT_FLAG_KEYS = new Set(['session_affinity']);
-
-export function parseRuleFlags(input: string): { flags: RuleFlags; error?: string } {
-    const flags: RuleFlags = {
-        cursorCompat: false,
-        cursorCompatAuto: false,
-        skipUsage: false,
-        customUserAgent: '',
-        useMaxCompletionTokens: false,
-        useMaxTokens: false,
-        openaiEndpointOverride: '',
-        blockTools: '',
-        thinkingEffort: '',
-        sessionAffinity: 0,
-        claudeCodeCompat: false,
-        cleanHeader: false,
-    };
+export function parseRuleFlags(input: string, registry: FlagSpec[]): { flags: RuleFlags; error?: string } {
+    const flags: RuleFlags = {};
+    for (const spec of registry) {
+        (flags as Record<string, unknown>)[snakeToCamel(spec.key)] = flagDefault(spec);
+    }
 
     const trimmed = input.trim();
-    if (!trimmed) {
-        return { flags };
-    }
+    if (!trimmed) return { flags };
 
+    const lookup = new Map(registry.map((s) => [s.key, s]));
     const parts = trimmed.split(',').map((part) => part.trim()).filter(Boolean);
+
     for (const part of parts) {
         const eqIdx = part.indexOf('=');
         if (eqIdx === -1) {
@@ -294,101 +240,52 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             return { flags, error: `Invalid flag format: "${part}". Use key=value.` };
         }
 
-        if (STRING_FLAG_KEYS.has(rawKey)) {
-            switch (rawKey) {
-                case 'custom_user_agent':
-                    flags.customUserAgent = rawValue;
-                    break;
-                case 'block_tools':
-                    flags.blockTools = rawValue;
-                    break;
-            }
-            continue;
+        const spec = lookup.get(rawKey);
+        if (!spec) {
+            return { flags, error: `Unknown flag "${rawKey}".` };
         }
 
-        if (INT_FLAG_KEYS.has(rawKey)) {
-            const n = parseInt(rawValue, 10);
-            if (isNaN(n) || n < 0) {
-                return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use a non-negative integer (seconds).` };
+        switch (spec.type) {
+            case 'string':
+                (flags as Record<string, unknown>)[snakeToCamel(rawKey)] = rawValue;
+                break;
+            case 'int': {
+                const n = parseInt(rawValue, 10);
+                if (isNaN(n) || n < 0) {
+                    return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use a non-negative integer.` };
+                }
+                (flags as Record<string, unknown>)[snakeToCamel(rawKey)] = n;
+                break;
             }
-            if (rawKey === 'session_affinity') flags.sessionAffinity = n;
-            continue;
-        }
-
-        if (ENUM_FLAG_KEYS.has(rawKey)) {
-            const allowed = ENUM_FLAG_VALUES[rawKey];
-            if (!allowed.has(rawValue)) {
-                const options = Array.from(allowed).join('/');
-                return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use ${options}.` };
+            case 'enum': {
+                const allowed = new Set((spec.options || []).map((o) => o.value).filter(Boolean));
+                if (!allowed.has(rawValue)) {
+                    return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use ${Array.from(allowed).join('/')}.` };
+                }
+                (flags as Record<string, unknown>)[snakeToCamel(rawKey)] = rawValue;
+                break;
             }
-            switch (rawKey) {
-                case 'openai_endpoint_override':
-                    flags.openaiEndpointOverride = rawValue;
-                    break;
-                case 'thinking_effort':
-                    flags.thinkingEffort = rawValue;
-                    break;
+            case 'bool': {
+                const lower = rawValue.toLowerCase();
+                if (TRUE_VALUES.has(lower)) {
+                    (flags as Record<string, unknown>)[snakeToCamel(rawKey)] = true;
+                } else if (FALSE_VALUES.has(lower)) {
+                    (flags as Record<string, unknown>)[snakeToCamel(rawKey)] = false;
+                } else {
+                    return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use true/false.` };
+                }
+                break;
             }
-            continue;
-        }
-
-        const valueLower = rawValue.toLowerCase();
-        let parsedValue: boolean;
-        if (TRUE_VALUES.has(valueLower)) {
-            parsedValue = true;
-        } else if (FALSE_VALUES.has(valueLower)) {
-            parsedValue = false;
-        } else {
-            return { flags, error: `Invalid value for "${rawKey}": "${rawValue}". Use true/false.` };
-        }
-
-        switch (rawKey) {
-            case 'cursor_compat':
-                flags.cursorCompat = parsedValue;
-                break;
-            case 'cursor_compat_auto':
-                flags.cursorCompatAuto = parsedValue;
-                break;
-            case 'skip_usage':
-                flags.skipUsage = parsedValue;
-                break;
-            case 'use_max_completion_tokens':
-                flags.useMaxCompletionTokens = parsedValue;
-                break;
-            case 'use_max_tokens':
-                flags.useMaxTokens = parsedValue;
-                break;
-            case 'claude_code_compat':
-                flags.claudeCodeCompat = parsedValue;
-                break;
-            case 'clean_header':
-                flags.cleanHeader = parsedValue;
-                break;
             default:
-                return { flags, error: `Unknown flag "${rawKey}".` };
+                return { flags, error: `Flag "${rawKey}" cannot be set via text input.` };
         }
     }
-
     return { flags };
 }
 
-// Counts how many flags have a meaningful (non-default) value set.
-export function countActiveFlags(flags?: RuleFlags): number {
+export function countActiveFlags(flags: RuleFlags | undefined, registry: FlagSpec[]): number {
     if (!flags) return 0;
-    let n = 0;
-    if (flags.cursorCompat) n++;
-    if (flags.cursorCompatAuto) n++;
-    if (flags.skipUsage) n++;
-    if (flags.useMaxCompletionTokens) n++;
-    if (flags.useMaxTokens) n++;
-    if (flags.customUserAgent && flags.customUserAgent.trim() !== '') n++;
-    if (flags.openaiEndpointOverride && isEnumActive('openai_endpoint_override', flags.openaiEndpointOverride)) n++;
-    if (flags.blockTools && flags.blockTools.trim() !== '') n++;
-    if (flags.thinkingEffort && isEnumActive('thinking_effort', flags.thinkingEffort)) n++;
-    if (flags.sessionAffinity && flags.sessionAffinity > 0) n++;
-    if (flags.claudeCodeCompat) n++;
-    if (flags.cleanHeader) n++;
-    return n;
+    return registry.filter((spec) => isFlagActive(spec, flags)).length;
 }
 
 // Generic export handler

--- a/frontend/src/components/rule-card/utils.ts
+++ b/frontend/src/components/rule-card/utils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { api } from '@/services/api';
-import type { SmartRouting, ConfigProvider, Rule, ConfigRecord, RuleFlags } from '@/components/RoutingGraphTypes';
+import type { SmartRouting, ConfigProvider, Rule, ConfigRecord, RuleFlags, RuleFlagsApi } from '@/components/RoutingGraphTypes';
 
 // ============================================================================
 // Helper Functions
@@ -78,6 +78,7 @@ export function ruleToConfigRecord(rule: Rule): ConfigRecord {
             sessionAffinity: rule.flags?.session_affinity || 0,
             visionProxyService: rule.flags?.vision_proxy_service,
             claudeCodeCompat: rule.flags?.claude_code_compat || false,
+            cleanHeader: rule.flags?.clean_header || false,
         },
         smartEnabled: rule.smart_enabled || false,
         smartRouting: smartRouting,
@@ -190,16 +191,7 @@ interface ExportRule {
     description?: string;
     services: any[];
     active?: boolean;
-    flags?: {
-        cursor_compat?: boolean;
-        cursor_compat_auto?: boolean;
-        skip_usage?: boolean;
-        custom_user_agent?: string;
-        use_max_completion_tokens?: boolean;
-        use_max_tokens?: boolean;
-        openai_endpoint_override?: string;
-        block_tools?: string;
-    };
+    flags?: RuleFlagsApi;
     smart_enabled?: boolean;
     smart_routing: any[];
 }
@@ -261,6 +253,7 @@ export function formatRuleFlags(flags?: RuleFlags): string {
     }
     if (flags.sessionAffinity) entries.push(`session_affinity=${flags.sessionAffinity}`);
     if (flags.claudeCodeCompat) entries.push('claude_code_compat=true');
+    if (flags.cleanHeader) entries.push('clean_header=true');
     return entries.join(',');
 }
 
@@ -281,6 +274,7 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
         thinkingEffort: '',
         sessionAffinity: 0,
         claudeCodeCompat: false,
+        cleanHeader: false,
     };
 
     const trimmed = input.trim();
@@ -367,6 +361,9 @@ export function parseRuleFlags(input: string): { flags: RuleFlags; error?: strin
             case 'claude_code_compat':
                 flags.claudeCodeCompat = parsedValue;
                 break;
+            case 'clean_header':
+                flags.cleanHeader = parsedValue;
+                break;
             default:
                 return { flags, error: `Unknown flag "${rawKey}".` };
         }
@@ -390,6 +387,7 @@ export function countActiveFlags(flags?: RuleFlags): number {
     if (flags.thinkingEffort && isEnumActive('thinking_effort', flags.thinkingEffort)) n++;
     if (flags.sessionAffinity && flags.sessionAffinity > 0) n++;
     if (flags.claudeCodeCompat) n++;
+    if (flags.cleanHeader) n++;
     return n;
 }
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -235,6 +235,7 @@ const mockV1Rules: Record<string, any[]> = {
             response_model: '',
             active: true,
             description: 'Route gpt-4o to Anthropic claude-opus-4-7',
+            flags: { cursor_compat: true, thinking_effort: 'high' },
             services: [{ uuid: 'svc-o1', provider: 'mock-provider-anthropic', model: 'claude-opus-4-7', weight: 1, active: true }],
         },
         {
@@ -298,6 +299,7 @@ const mockV1Rules: Record<string, any[]> = {
             response_model: '',
             active: true,
             description: 'Smart routing + tiered fallback',
+            flags: { claude_code_compat: true, clean_header: true, skip_usage: true, session_affinity: 3600 },
             // Default providers in 3 tiers: T0 primary, T1 secondary, T2 budget
             services: [
                 { uuid: 'svc-cc-t0-a', provider: 'mock-provider-anthropic', model: 'claude-sonnet-4-6', weight: 1, active: true, tier: 0 },
@@ -1396,6 +1398,30 @@ export const handlers = [
             }
         }
         return HttpResponse.json({ success: false, error: 'Rule not found' }, { status: 404 })
+    }),
+
+    // ============================================
+    // Rule Flag Registry
+    // ============================================
+    http.get('/api/v1/rule/flags/registry', () => {
+        return HttpResponse.json({
+            success: true,
+            data: [
+                { key: 'custom_user_agent', label: 'Custom User-Agent', description: 'Override the outbound User-Agent header.', type: 'string', category: 'request_openai', placeholder: 'e.g. MyApp/1.0', suggestions: [{ value: 'claude-cli/2.1.86 (external, cli)', label: 'Claude Code (CLI)' }], shared: true, inheritance_mode: 'override' },
+                { key: 'openai_endpoint_override', label: 'OpenAI endpoint override', description: 'Force Chat or Responses endpoint.', type: 'enum', category: 'request_openai', options: [{ value: 'auto', label: 'Auto' }, { value: 'chat', label: 'Force Chat' }, { value: 'responses', label: 'Force Responses' }] },
+                { key: 'use_max_completion_tokens', label: 'OpenAI: Use max_completion_tokens', description: 'Rewrite max_tokens to max_completion_tokens.', type: 'bool', category: 'request_openai' },
+                { key: 'use_max_tokens', label: 'OpenAI: Use max_tokens (legacy)', description: 'Rewrite max_completion_tokens to max_tokens.', type: 'bool', category: 'request_openai' },
+                { key: 'block_tools', label: 'Block tools', description: 'Comma-separated tool names to strip.', type: 'string', category: 'request_openai', placeholder: 'e.g. web_search,run_terminal_cmd' },
+                { key: 'skip_usage', label: 'Skip usage in response', description: 'Strip usage from responses.', type: 'bool', category: 'response', shared: true, inheritance_mode: 'or' },
+                { key: 'thinking_effort', label: 'Thinking', description: 'Extended thinking control.', type: 'enum', category: 'reasoning', options: [{ value: '', label: 'By Client' }, { value: 'off', label: 'Off' }, { value: 'low', label: 'Low' }, { value: 'medium', label: 'Medium' }, { value: 'high', label: 'High' }, { value: 'max', label: 'Max' }], shared: true, inheritance_mode: 'override' },
+                { key: 'vision_proxy_service', label: 'Vision Proxy', description: 'Describe images via a vision-capable model.', type: 'service_ref', category: 'vision' },
+                { key: 'session_affinity', label: 'Session affinity', description: 'TTL in seconds for session pinning.', type: 'int', category: 'routing', placeholder: 'e.g. 3600', shared: true, inheritance_mode: 'override' },
+                { key: 'cursor_compat', label: 'Cursor compatibility', description: 'Normalize rich content for Cursor clients.', type: 'bool', category: 'app' },
+                { key: 'cursor_compat_auto', label: 'Auto-detect Cursor', description: 'Auto-apply cursor compat from request headers.', type: 'bool', category: 'app' },
+                { key: 'claude_code_compat', label: 'Claude Code compatibility', description: 'Rewrite system role to user.', type: 'bool', category: 'app', shared: true, inheritance_mode: 'or' },
+                { key: 'clean_header', label: 'Clean Header', description: 'Strip billing header from system messages.', type: 'bool', category: 'app', shared: true, inheritance_mode: 'or' },
+            ],
+        })
     }),
 
     // ============================================

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -65,6 +65,15 @@ type FlagSpec struct {
 	// allowing free-form input. Used by custom_user_agent to expose the common
 	// CLI/agent User-Agent strings (see DefaultUserAgents).
 	Suggestions []FlagOption `json:"suggestions,omitempty"`
+	// Shared indicates this flag also exists at the scenario level
+	// (ScenarioFlags) and participates in scenario→rule inheritance.
+	Shared bool `json:"shared,omitempty"`
+	// InheritanceMode describes how the scenario-level and rule-level values
+	// combine when both are set:
+	//   - "or":       bool OR — either level enabling it activates the flag
+	//   - "override": rule non-zero/non-empty wins, else scenario default
+	// Empty means the flag is rule-only (not shared).
+	InheritanceMode string `json:"inheritance_mode,omitempty"`
 }
 
 // DefaultUserAgents returns a curated, non-exhaustive list of recommended
@@ -92,13 +101,15 @@ func RuleFlagRegistry() []FlagSpec {
 	return []FlagSpec{
 		// ── Request (OpenAI) ───────────────────────────────────────────────
 		{
-			Key:         "custom_user_agent",
-			Label:       "Custom User-Agent",
-			Description: "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
-			Type:        FlagTypeString,
-			Category:    FlagCategoryRequestOpenAI,
-			Placeholder: "e.g. MyApp/1.0",
-			Suggestions: DefaultUserAgents(),
+			Key:             "custom_user_agent",
+			Label:           "Custom User-Agent",
+			Description:     "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
+			Type:            FlagTypeString,
+			Category:        FlagCategoryRequestOpenAI,
+			Placeholder:     "e.g. MyApp/1.0",
+			Suggestions:     DefaultUserAgents(),
+			Shared:          true,
+			InheritanceMode: "override",
 		},
 		{
 			Key:         "openai_endpoint_override",
@@ -136,19 +147,23 @@ func RuleFlagRegistry() []FlagSpec {
 		},
 		// ── Response ───────────────────────────────────────────────────────
 		{
-			Key:         "skip_usage",
-			Label:       "Skip usage in response",
-			Description: "Strip the `usage` block from responses (both SSE deltas and the final body).",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryResponse,
+			Key:             "skip_usage",
+			Label:           "Skip usage in response",
+			Description:     "Strip the `usage` block from responses (both SSE deltas and the final body).",
+			Type:            FlagTypeBool,
+			Category:        FlagCategoryResponse,
+			Shared:          true,
+			InheritanceMode: "or",
 		},
 		// ── Reasoning ──────────────────────────────────────────────────────
 		{
-			Key:         "thinking_effort",
-			Label:       "Thinking",
-			Description: "Single control for extended thinking. \"By Client\" passes the client's thinking config through unchanged. \"Off\" forces thinking disabled. The level values force thinking on with the matching budget — mapped to budget_tokens for Anthropic targets (low 1K / medium 5K / high 20K / max 32K) and to reasoning_effort for OpenAI targets (\"max\" collapses to \"high\").",
-			Type:        FlagTypeEnum,
-			Category:    FlagCategoryReasoning,
+			Key:             "thinking_effort",
+			Label:           "Thinking",
+			Description:     "Single control for extended thinking. \"By Client\" passes the client's thinking config through unchanged. \"Off\" forces thinking disabled. The level values force thinking on with the matching budget — mapped to budget_tokens for Anthropic targets (low 1K / medium 5K / high 20K / max 32K) and to reasoning_effort for OpenAI targets (\"max\" collapses to \"high\").",
+			Type:            FlagTypeEnum,
+			Category:        FlagCategoryReasoning,
+			Shared:          true,
+			InheritanceMode: "override",
 			Options: []FlagOption{
 				{Value: "", Label: "By Client"},
 				{Value: "off", Label: "Off"},
@@ -168,12 +183,14 @@ func RuleFlagRegistry() []FlagSpec {
 		},
 		// ── Routing ────────────────────────────────────────────────────────
 		{
-			Key:         "session_affinity",
-			Label:       "Session affinity",
-			Description: "TTL in seconds for session-to-service pinning. Pinning improves cache hit rate → faster responses + lower token costs. Once a session lands on a service, follow-up requests keep hitting that service until the entry expires. 0 disables affinity. Works with any load-balancing tactic; does not require smart routing. Session identity is resolved from Anthropic metadata.user_id, the X-Tingly-Session-ID header, or the client IP.",
-			Type:        FlagTypeInt,
-			Category:    FlagCategoryRouting,
-			Placeholder: "e.g. 3600",
+			Key:             "session_affinity",
+			Label:           "Session affinity",
+			Description:     "TTL in seconds for session-to-service pinning. Pinning improves cache hit rate → faster responses + lower token costs. Once a session lands on a service, follow-up requests keep hitting that service until the entry expires. 0 disables affinity. Works with any load-balancing tactic; does not require smart routing. Session identity is resolved from Anthropic metadata.user_id, the X-Tingly-Session-ID header, or the client IP.",
+			Type:            FlagTypeInt,
+			Category:        FlagCategoryRouting,
+			Placeholder:     "e.g. 3600",
+			Shared:          true,
+			InheritanceMode: "override",
 		},
 		// ── App ────────────────────────────────────────────────────────────
 		{
@@ -191,11 +208,22 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:    FlagCategoryApp,
 		},
 		{
-			Key:         "claude_code_compat",
-			Label:       "Claude Code compatibility",
-			Description: "Rewrite any \"system\" role in the messages array to \"user\" before forwarding. Claude Code sends system-role entries inside the messages list (a non-standard extension); enabling this normalizes them so third-party Anthropic-compatible providers that reject that role do not error out.",
-			Type:        FlagTypeBool,
-			Category:    FlagCategoryApp,
+			Key:             "claude_code_compat",
+			Label:           "Claude Code compatibility",
+			Description:     "Rewrite any \"system\" role in the messages array to \"user\" before forwarding. Claude Code sends system-role entries inside the messages list (a non-standard extension); enabling this normalizes them so third-party Anthropic-compatible providers that reject that role do not error out.",
+			Type:            FlagTypeBool,
+			Category:        FlagCategoryApp,
+			Shared:          true,
+			InheritanceMode: "or",
+		},
+		{
+			Key:             "clean_header",
+			Label:           "Clean Header",
+			Description:     "Strip x-anthropic-billing-header blocks from system messages before forwarding. Auto-enabled for billing scenarios (claude_code, claude_desktop) during protocol transformation; set manually to force enable on any rule.",
+			Type:            FlagTypeBool,
+			Category:        FlagCategoryApp,
+			Shared:          true,
+			InheritanceMode: "or",
 		},
 	}
 }

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -26,6 +26,7 @@ func TestRuleFlagRegistry_KnownKeys(t *testing.T) {
 		"skip_usage",
 		"use_max_completion_tokens",
 		"custom_user_agent",
+		"clean_header",
 	}
 
 	present := map[string]bool{}
@@ -110,6 +111,19 @@ func TestRuleFlagRegistry_EnumOptions(t *testing.T) {
 				t.Errorf("enum flag %q has duplicate option Value %q", spec.Key, opt.Value)
 			}
 			seen[opt.Value] = true
+		}
+	}
+}
+
+// TestRuleFlagRegistry_SharedFlagsHaveInheritanceMode verifies that every flag
+// marked Shared declares an InheritanceMode and vice versa.
+func TestRuleFlagRegistry_SharedFlagsHaveInheritanceMode(t *testing.T) {
+	for _, spec := range RuleFlagRegistry() {
+		if spec.Shared && spec.InheritanceMode == "" {
+			t.Errorf("shared flag %q must declare InheritanceMode", spec.Key)
+		}
+		if !spec.Shared && spec.InheritanceMode != "" {
+			t.Errorf("non-shared flag %q should not declare InheritanceMode", spec.Key)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Registry-driven flag access**: Eliminated ~293 lines of per-flag switch/case boilerplate across `FlagCatalogDialog`, `RulePluginsCard`, `useRuleCardHooks`, and `utils.ts`. New `flagHelpers.ts` provides generic helpers (`getFlagValue`, `setFlagValue`, `apiToFlags`, `flagsToApi`, `isFlagActive`) that work via `snakeToCamel` key mapping — adding a new flag now requires zero frontend UI code changes.
- **Unified "Plugins" naming**: Renamed `RuleExtensionsCard` → `RulePluginsCard`, updated all UI strings from "Extensions" to "Plugins" for consistency with scenario-level naming.
- **Backend `FlagSpec` enrichment**: Added `Shared`, `InheritanceMode`, and `Suggestions` fields to the Go `FlagSpec` struct with corresponding test coverage (`TestRuleFlagRegistry_SharedFlagsHaveInheritanceMode`).
- **Bug fixes** (3 pre-existing + 5 from code review):
  - Fixed `claudeCodeCompat` typo (`anthropicCompat` → `claudeCodeCompat`) that silently dropped the flag on every auto-save
  - Added missing `clean_header` flag to frontend types and registry
  - Fixed `ExportRule.flags` type to use `RuleFlagsApi` instead of incomplete inline type
  - Fixed text editor round-trip destroying `vision_proxy_service` (service_ref flags now preserved)
  - Fixed falsy-zero bug in int TextField (`||` → `??`) where value 0 showed blank
  - Fixed `handleRemoveActive` resetting enums to `''` instead of inactive sentinel
  - Fixed flag dialogs closing on save failure (losing user edits)
  - Fixed empty registry causing infinite fetch loop
- **Mock data**: Added `GET /api/v1/rule/flags/registry` MSW handler with all 14 flag specs including `shared`/`inheritance_mode` metadata.
- **Design doc**: Updated `.design/rule-flags.md` — architecture diagram, FlagSpec struct docs, flag table (10→14), frontend section documenting registry-driven architecture, simplified "adding a flag" recipe (steps 6-10 collapsed to "no UI changes needed").

## Key files

| File | Change |
|------|--------|
| `frontend/src/components/rule-card/flagHelpers.ts` | **New** — core registry-driven utilities |
| `frontend/src/components/rule-card/FlagCatalogDialog.tsx` | Replaced 8 switch-based functions with flagHelpers imports |
| `frontend/src/components/rule-card/RulePluginsCard.tsx` | Renamed from `RuleExtensionsCard.tsx`, switch helpers removed |
| `frontend/src/components/rule-card/utils.ts` | `ruleToConfigRecord`/`formatRuleFlags`/`parseRuleFlags` now registry-driven |
| `frontend/src/components/rule-card/useRuleCardHooks.ts` | Auto-save uses `flagsToApi()`, fixed `claudeCodeCompat` typo |
| `frontend/src/components/RuleCard.tsx` | Updated imports, generic toggle handler, dialog-close-on-success |
| `frontend/src/components/RoutingGraphTypes.ts` | Added `cleanHeader`, `shared`, `inheritanceMode` to interfaces |
| `internal/typ/flag_registry.go` | Added `Shared`, `InheritanceMode` fields to `FlagSpec` |
| `internal/typ/flag_registry_test.go` | Added shared-flags-have-inheritance-mode test |
| `.design/rule-flags.md` | Full update reflecting all changes |

## Test plan

- [x] Go tests pass (`go test ./internal/typ/ -run FlagRegistry`)
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [x] No remaining references to `RuleExtensionsCard`, `anthropicCompat`, or hardcoded flag sets
- [ ] Manual: open flag catalog dialog, toggle bool/enum/int/service_ref flags, verify save persists
- [ ] Manual: open text flag editor, verify service_ref flags survive round-trip
- [ ] Manual: set int flag to 0, verify "0" displays (not blank)
- [ ] Manual: trigger save failure (e.g. network off), verify dialog stays open

https://claude.ai/code/session_01E3Htym8kZGAdejoWxazQtG