### PR TITLE
feat(dashboard): add model filtering, pagination, and improve filter UX

### DIFF
--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -111,6 +111,8 @@ import {
     IconBrain,
     IconFoldDown,
     IconFoldUp,
+    IconFilter,
+    IconFilterOff,
 } from '@tabler/icons-react';
 import { tablerMui } from './tablerMui';
 
@@ -154,6 +156,8 @@ export const OpenInNew = tablerMui(IconExternalLink);
 export const Launch = tablerMui(IconExternalLink);
 export const Link = tablerMui(IconLink);
 export const PlayArrow = tablerMui(IconPlayerPlay);
+export const Filter = tablerMui(IconFilter);
+export const FilterOff = tablerMui(IconFilterOff);
 
 // --- Status / feedback -------------------------------------------------------
 export const Info = tablerMui(IconInfoCircle);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -243,6 +243,22 @@ export default function DashboardPage() {
         setModelsPage(0);
     }, [stats, selectedProvider, selectedModel]);
 
+    // Reset filters if selected provider/model no longer exists in current data
+    useEffect(() => {
+        if (selectedProvider !== 'all') {
+            const providerExists = stats.some(s => s.provider_uuid === selectedProvider);
+            if (!providerExists) {
+                setSelectedProvider('all');
+            }
+        }
+        if (selectedModel !== 'all') {
+            const modelExists = stats.some(s => (s.model || s.key) === selectedModel);
+            if (!modelExists) {
+                setSelectedModel('all');
+            }
+        }
+    }, [stats, selectedProvider, selectedModel]);
+
     useEffect(() => {
         if (autoRefresh) {
             const interval = setInterval(() => {
@@ -336,12 +352,21 @@ export default function DashboardPage() {
     const AUTH_TYPE_ORDER = ['oauth', 'api_key', 'bearer_token', 'basic_auth', 'vmodel'];
 
     const groupedProviderOptions = useMemo(() => {
+        // Extract provider UUIDs that exist in current stats data
+        const providerUuidsInData = new Set(
+            stats
+                .map(s => s.provider_uuid)
+                .filter((uuid): uuid is string => uuid != null && uuid !== '')
+        );
+
         const groups: Record<string, Provider[]> = {};
-        providers.forEach((p) => {
-            const authType = p.auth_type || 'api_key';
-            if (!groups[authType]) groups[authType] = [];
-            groups[authType].push(p);
-        });
+        providers
+            .filter(p => providerUuidsInData.has(p.uuid))  // Only include providers in current data
+            .forEach((p) => {
+                const authType = p.auth_type || 'api_key';
+                if (!groups[authType]) groups[authType] = [];
+                groups[authType].push(p);
+            });
         // Sort providers within each group by name
         Object.values(groups).forEach((list) => list.sort((a, b) => a.name.localeCompare(b.name)));
 
@@ -353,7 +378,7 @@ export default function DashboardPage() {
                 label: authTypeLabel(authType),
                 providers: groups[authType],
             }));
-    }, [providers]);
+    }, [providers, stats]);
 
     // Extract unique models from stats, sorted by usage
     const modelOptions = useMemo(() => {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -19,7 +19,7 @@ import {
     Divider,
     useTheme,
 } from '@mui/material';
-import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon, FilterOff } from '@/components/icons';
+import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon, FilterOff, ChevronLeft, ChevronRight } from '@/components/icons';
 import { tablerMui } from '@/components/icons';
 import { IconCoin, IconActivity, IconReload } from '@tabler/icons-react';
 
@@ -119,6 +119,8 @@ export default function DashboardPage() {
     const [providers, setProviders] = useState<Provider[]>([]);
     const [selectedProvider, setSelectedProvider] = useState<string>('all');
     const [selectedModel, setSelectedModel] = useState<string>('all');
+    const [modelsPage, setModelsPage] = useState(0);
+    const [modelsPerPage] = useState(10);
 
     // By-request view state
     const [viewMode, setViewMode] = useState<'summary' | 'requests'>('summary');
@@ -235,6 +237,11 @@ export default function DashboardPage() {
             loadRecords(recordsTimeParams, selectedProvider, selectedModel);
         }
     }, [viewMode, recordsTimeParams, selectedProvider, selectedModel, loadRecords]);
+
+    // Reset model pagination when filters or data change
+    useEffect(() => {
+        setModelsPage(0);
+    }, [stats, selectedProvider, selectedModel]);
 
     useEffect(() => {
         if (autoRefresh) {
@@ -618,14 +625,29 @@ export default function DashboardPage() {
                             flexDirection: 'column',
                         }}
                     >
-                        <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '0.875rem', mb: 2 }}>
-                            Top Models by Token Usage
-                        </Typography>
-                        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                            {tokenChartData.slice(0, 6).map((item, index) => {
-                                const totalTokens = item.inputTokens + item.outputTokens + (item.cacheTokens || 0);
-                                const maxTokens = Math.max(...tokenChartData.slice(0, 6).map(d => d.inputTokens + d.outputTokens + (d.cacheTokens || 0)));
-                                const percentage = maxTokens > 0 ? (totalTokens / maxTokens) * 100 : 0;
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                            <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
+                                Models by Token Usage
+                            </Typography>
+                            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                                {tokenChartData.length} total
+                            </Typography>
+                        </Box>
+
+                        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1, overflow: 'hidden' }}>
+                            {tokenChartData.length === 0 ? (
+                                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1 }}>
+                                    <Typography variant="body2" color="text.secondary">No models found</Typography>
+                                </Box>
+                            ) : (
+                                <>
+                                    {tokenChartData
+                                        .slice(modelsPage * modelsPerPage, (modelsPage + 1) * modelsPerPage)
+                                        .map((item, index) => {
+                                            const globalIndex = modelsPage * modelsPerPage + index;
+                                            const totalTokens = item.inputTokens + item.outputTokens + (item.cacheTokens || 0);
+                                            const maxTokens = Math.max(...tokenChartData.map(d => d.inputTokens + d.outputTokens + (d.cacheTokens || 0)));
+                                            const percentage = maxTokens > 0 ? (totalTokens / maxTokens) * 100 : 0;
 
                                 return (
                                     <Tooltip
@@ -695,7 +717,7 @@ export default function DashboardPage() {
                                                     flexShrink: 0,
                                                 }}
                                             >
-                                                {index + 1}
+                                                {globalIndex + 1}
                                             </Box>
 
                                             {/* Content */}
@@ -755,6 +777,47 @@ export default function DashboardPage() {
                                     </Tooltip>
                                 );
                             })}
+
+                            {/* Pagination Controls */}
+                            {tokenChartData.length > modelsPerPage && (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        justifyContent: 'center',
+                                        alignItems: 'center',
+                                        gap: 0.5,
+                                        pt: 1.5,
+                                        borderTop: '1px solid',
+                                        borderColor: 'divider',
+                                        mt: 'auto',
+                                    }}
+                                >
+                                    <IconButton
+                                        size="small"
+                                        onClick={() => setModelsPage(p => Math.max(0, p - 1))}
+                                        disabled={modelsPage === 0}
+                                        sx={{ borderRadius: 1 }}
+                                    >
+                                        <ChevronLeft sx={{ fontSize: '1.1rem' }} />
+                                    </IconButton>
+                                    <Typography
+                                        variant="caption"
+                                        sx={{ minWidth: 60, textAlign: 'center', color: 'text.secondary', fontSize: '0.75rem' }}
+                                    >
+                                        {modelsPage + 1} / {Math.ceil(tokenChartData.length / modelsPerPage)}
+                                    </Typography>
+                                    <IconButton
+                                        size="small"
+                                        onClick={() => setModelsPage(p => Math.min(Math.ceil(tokenChartData.length / modelsPerPage) - 1, p + 1))}
+                                        disabled={modelsPage >= Math.ceil(tokenChartData.length / modelsPerPage) - 1}
+                                        sx={{ borderRadius: 1 }}
+                                    >
+                                        <ChevronRight sx={{ fontSize: '1.1rem' }} />
+                                    </IconButton>
+                                </Box>
+                            )}
+                        </>
+                        )}
                         </Box>
                     </Paper>
                 </Box>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -19,7 +19,7 @@ import {
     Divider,
     useTheme,
 } from '@mui/material';
-import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon } from '@/components/icons';
+import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon, FilterOff } from '@/components/icons';
 import { tablerMui } from '@/components/icons';
 import { IconCoin, IconActivity, IconReload } from '@tabler/icons-react';
 
@@ -118,6 +118,7 @@ export default function DashboardPage() {
     const [timeSeries, setTimeSeries] = useState<TimeSeriesData[]>([]);
     const [providers, setProviders] = useState<Provider[]>([]);
     const [selectedProvider, setSelectedProvider] = useState<string>('all');
+    const [selectedModel, setSelectedModel] = useState<string>('all');
 
     // By-request view state
     const [viewMode, setViewMode] = useState<'summary' | 'requests'>('summary');
@@ -125,7 +126,7 @@ export default function DashboardPage() {
     const [recordsLoading, setRecordsLoading] = useState(false);
     const [recordsTimeParams, setRecordsTimeParams] = useState<{ start_time: string; end_time: string } | null>(null);
 
-    const buildTimeParams = useCallback((provider: string, range: TimeRange) => {
+    const buildTimeParams = useCallback((provider: string, model: string, range: TimeRange) => {
         const now = new Date();
         const config = TIME_RANGE_CONFIG[range];
         const todayStart = getLocalMidnight(now);
@@ -150,13 +151,16 @@ export default function DashboardPage() {
         if (provider && provider !== 'all') {
             params.provider = provider;
         }
+        if (model && model !== 'all') {
+            params.model = model;
+        }
         return params;
     }, []);
 
-    const loadData = useCallback(async (provider: string, range: TimeRange) => {
+    const loadData = useCallback(async (provider: string, model: string, range: TimeRange) => {
         try {
             const config = TIME_RANGE_CONFIG[range];
-            const params = buildTimeParams(provider, range);
+            const params = buildTimeParams(provider, model, range);
 
             const [statsResult, timeSeriesResult, providersResult] = await Promise.all([
                 api.getUsageStats({ ...params, group_by: 'model', limit: 100 }),
@@ -187,16 +191,23 @@ export default function DashboardPage() {
     const loadRecords = useCallback(async (
         timeParams: { start_time: string; end_time: string } | null,
         provider: string,
+        model: string,
     ) => {
         if (!timeParams) return;
         setRecordsLoading(true);
         try {
-            const result = await api.getUsageRecords({
+            const filters: Record<string, any> = {
                 ...timeParams,
-                ...(provider !== 'all' ? { provider } : {}),
                 limit: 500,
                 offset: 0,
-            });
+            };
+            if (provider !== 'all') {
+                filters.provider = provider;
+            }
+            if (model !== 'all') {
+                filters.model = model;
+            }
+            const result = await api.getUsageRecords(filters);
             if (result?.data) {
                 setRecords(result.data);
             }
@@ -208,8 +219,8 @@ export default function DashboardPage() {
     }, []);
 
     useEffect(() => {
-        loadData(selectedProvider, timeRange);
-    }, [loadData, selectedProvider, timeRange]);
+        loadData(selectedProvider, selectedModel, timeRange);
+    }, [loadData, selectedProvider, selectedModel, timeRange]);
 
     // Reset view mode when switching away from hourly ranges
     useEffect(() => {
@@ -218,28 +229,28 @@ export default function DashboardPage() {
         }
     }, [isHourlyRange]);
 
-    // Load records when entering requests view or time/provider changes
+    // Load records when entering requests view or time/provider/model changes
     useEffect(() => {
         if (viewMode === 'requests') {
-            loadRecords(recordsTimeParams, selectedProvider);
+            loadRecords(recordsTimeParams, selectedProvider, selectedModel);
         }
-    }, [viewMode, recordsTimeParams, selectedProvider, loadRecords]);
+    }, [viewMode, recordsTimeParams, selectedProvider, selectedModel, loadRecords]);
 
     useEffect(() => {
         if (autoRefresh) {
             const interval = setInterval(() => {
-                loadData(selectedProvider, timeRange);
+                loadData(selectedProvider, selectedModel, timeRange);
                 if (viewMode === 'requests') {
-                    loadRecords(recordsTimeParams, selectedProvider);
+                    loadRecords(recordsTimeParams, selectedProvider, selectedModel);
                 }
             }, 60000);
             return () => clearInterval(interval);
         }
-    }, [autoRefresh, loadData, selectedProvider, timeRange, viewMode, loadRecords, recordsTimeParams]);
+    }, [autoRefresh, loadData, selectedProvider, selectedModel, timeRange, viewMode, loadRecords, recordsTimeParams]);
 
     const handleRefresh = () => {
         setRefreshing(true);
-        loadData(selectedProvider, timeRange);
+        loadData(selectedProvider, selectedModel, timeRange);
     };
 
     // Calculate totals from stats
@@ -337,13 +348,40 @@ export default function DashboardPage() {
             }));
     }, [providers]);
 
+    // Extract unique models from stats, sorted by usage
+    const modelOptions = useMemo(() => {
+        const modelMap = new Map<string, { model: string; providerName: string; totalTokens: number }>();
+        stats.forEach((stat) => {
+            const model = stat.model || stat.key || 'Unknown';
+            const totalTokens = (stat.total_input_tokens || 0) + (stat.total_output_tokens || 0) + (stat.cache_input_tokens || 0);
+            const existing = modelMap.get(model);
+            if (!existing || totalTokens > existing.totalTokens) {
+                modelMap.set(model, {
+                    model,
+                    providerName: stat.provider_name || 'Unknown',
+                    totalTokens,
+                });
+            }
+        });
+        return Array.from(modelMap.values())
+            .sort((a, b) => b.totalTokens - a.totalTokens)
+            .map((m) => m.model);
+    }, [stats]);
+
+    const hasActiveFilters = selectedProvider !== 'all' || selectedModel !== 'all';
+
+    const handleClearFilters = () => {
+        setSelectedProvider('all');
+        setSelectedModel('all');
+    };
+
     if (loading) {
         return <DashboardSkeleton />;
     }
 
     const headerActions = (
         <>
-            <FormControl size="small" sx={{ minWidth: { xs: 180, sm: 150 } }}>
+            <FormControl size="small" sx={{ minWidth: { xs: 140, sm: 160 } }}>
                 <InputLabel sx={{ fontWeight: 500, fontSize: '0.875rem' }}>Provider</InputLabel>
                 <Select
                     value={selectedProvider}
@@ -366,7 +404,6 @@ export default function DashboardPage() {
                                 lineHeight: '28px',
                                 pt: 1,
                                 pl: 1.5,
-                                // colored left accent bar
                                 borderLeft: '3px solid',
                                 borderLeftColor: 'primary.main',
                                 backgroundColor: 'action.hover',
@@ -382,6 +419,45 @@ export default function DashboardPage() {
                     ])}
                 </Select>
             </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: { xs: 140, sm: 160 } }}>
+                <InputLabel sx={{ fontWeight: 500, fontSize: '0.875rem' }}>Model</InputLabel>
+                <Select
+                    value={selectedModel}
+                    label="Model"
+                    onChange={(e) => setSelectedModel(e.target.value)}
+                    disabled={!stats.length}
+                    sx={{
+                        borderRadius: 2,
+                        '& .MuiOutlinedInput-input': { py: 1 },
+                    }}
+                >
+                    <MenuItem value="all">All Models</MenuItem>
+                    {modelOptions.map((model) => (
+                        <MenuItem key={model} value={model}>
+                            {model}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+
+            {hasActiveFilters && (
+                <>
+                    <Divider orientation="vertical" flexItem sx={{ mx: 0.5, display: { xs: 'none', sm: 'block' } }} />
+                    <Tooltip title="Clear all filters">
+                        <IconButton
+                            size="small"
+                            onClick={handleClearFilters}
+                            sx={{
+                                backgroundColor: 'action.hover',
+                                '&:hover': { backgroundColor: 'action.selected' },
+                            }}
+                        >
+                            <FilterOff />
+                        </IconButton>
+                    </Tooltip>
+                </>
+            )}
 
             <Divider orientation="vertical" flexItem sx={{ mx: 0.5, display: { xs: 'none', sm: 'block' } }} />
 
@@ -584,8 +660,9 @@ export default function DashboardPage() {
                                     >
                                         <Box
                                             onClick={() => {
-                                                if (item.providerUuid) {
-                                                    setSelectedProvider(item.providerUuid);
+                                                // When clicking a model, filter by that model
+                                                if (item.model) {
+                                                    setSelectedModel(item.model);
                                                 }
                                             }}
                                             sx={{
@@ -596,7 +673,7 @@ export default function DashboardPage() {
                                                 px: 1,
                                                 borderRadius: 1,
                                                 transition: 'background-color 0.15s ease',
-                                                cursor: item.providerUuid ? 'pointer' : 'default',
+                                                cursor: item.model ? 'pointer' : 'default',
                                                 '&:hover': {
                                                     backgroundColor: 'action.hover',
                                                 },


### PR DESCRIPTION
Dashboard filtering was limited to providers only, and the model list showed only top 6 entries. 
Users could not filter by specific models, and  clicking a model incorrectly filtered by provider instead. 

This change adds comprehensive model filtering, displays all models with pagination, and improves overall filter UX.