### PR TITLE
feat(clean_header+claude_code_compat): default-on for Claude Code & Desktop rules + OAuth suppression

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -137,7 +137,7 @@ func RuleFlagRegistry() []FlagSpec { … }
 | `cursor_compat` | bool | app | — | — | Cursor IDE 内容归一化 + stream usage 抑制 | `transform.OpenAICursorCompatTransform` → `ops.ApplyCursorCompatContentNormalization`（Type 1b-pre）|
 | `cursor_compat_auto` | bool | app | — | — | 通过请求头识别 Cursor，自动折叠进 `cursor_compat` | `resolveRuleFlags(c, rule)` 在 handler 入口合并 |
 | `claude_code_compat` | bool | app | **yes** | or | 归一化 Claude Code 的会话中段 `role == "system"` 消息。Claude Code 在 messages 中写入 system role（非标准扩展，对应 Anthropic `mid-conversation-system` beta）；三方 Anthropic-compatible provider 拒绝该 role。**位置感知**：把每条 system 消息**就地并入相邻 user turn**，方向由左右邻居唯一决定（不是自由选择）——前邻是 user 则**向后并**入它；前邻是 assistant/开头则**向前并**入下一条 user；两侧都不是 user 才独立成一个 user turn。决策需先知道 next 的角色，故实现用 pending 缓冲，到下一条非 system 消息（或数组末尾）才落位。这样既保住位置、又避免产生连续 user 消息（严格 provider 同样会以 "roles must alternate" 拒绝）。**不做 hoist**：messages 里的 system 按 beta 契约必是中段消息（不能是 `messages[0]`），全局 system prompt 已在顶层 `system` 字段；hoist 会把"截至第 N 轮"的指令重排为全局、并击穿 prompt cache。**built-in CC rule 默认开**（`init.go::ccRule` + `newCCProfileRules` 种子 / `migrate20260608` 存量），可在 Plugins 卡片按 rule 关闭以保真原生 Anthropic。| `transform.ClaudeCodeCompatTransform` → `ops.ApplyClaudeCodeCompatRoleRewrite`（Type 1b-pre，仅 Anthropic 入站形态）|
-| `clean_header` | bool | app | **yes** | or | 剥离 system messages 中的 x-anthropic-billing-header 块。billing 场景（claude_code, claude_desktop）协议转换时自动启用；也可手动强制启用。| `CleanHeaderTransform`（Type 1b-pre，server-domain Transform）|
+| `clean_header` | bool | app | — | — | 剥离 system messages 中的 x-anthropic-billing-header 块。Claude Code 注入该 header 仅供自家计费，绝不能泄漏给三方 provider。**rule-only**（已从 scenario plugin 移除 —— 不再有 `ScenarioFlags.CleanHeader` / OR 注入）。**built-in CC rule 默认开**（`init.go::ccRule` + `newCCProfileRules` 种子 / `migrate20260609` 存量），可按 rule 关闭以保真原生 Anthropic。**Claude OAuth provider 自动抑制**：OAuth 订阅走原生 Anthropic，其计费后端要消费这个 header，故 `resolveRuleFlagsWithScenario` 在解析末尾对 `provider.IsClaudeCodeProvider()` 命中的请求清掉该 flag。claude_desktop 仍靠 `autoSetCleanHeaderFlag` 在协议转换时自动启用（claude_desktop 未做 rule 级默认）。| `CleanHeaderTransform`（Type 1b-pre，server-domain Transform）|
 
 ---
 
@@ -498,7 +498,6 @@ rule flag 在请求级覆盖或继承它。`resolveRuleFlagsWithScenario`（`int
 |------|--------|------------|----------|
 | `skip_usage` | ✅ | ✅ | Scenario 启用时自动 OR 进 rule 的 `SkipUsage`（rule 未禁用即生效）|
 | `thinking_effort` | ✅ | ✅ | Rule 显式设置 > Scenario 默认 > By Client（空字符串）|
-| `clean_header` | ✅ | ✅ | Scenario 启用时自动 OR 进 rule 的 `CleanHeader`；billing 场景协议转换时自动启用 |
 | `claude_code_compat` | ✅ | ✅ | Scenario 启用时自动 OR 进 rule 的 `ClaudeCodeCompat` |
 | `custom_user_agent` | ✅ | ✅ | Rule 显式设置（非空）> Scenario 默认 > 不覆盖（空）。注入点 `applyCustomUserAgent`（Type 2，写入 c.Request.Context()）|
 | `session_affinity` | ✅ | ✅ | Rule 显式设置（>0）> Scenario 默认 > 禁用（0）|
@@ -510,6 +509,8 @@ rule flag 在请求级覆盖或继承它。`resolveRuleFlagsWithScenario`（`int
 | `smart_compact` | 从会话历史中移除 thinking blocks 以减少 context |
 | `recording_v2` | 控制请求/响应录制模式（off / request / request_response / staged） |
 | `unified` / `separate` / `smart` | 路由模式开关 |
+
+**Rule-only flags（曾是 scenario 级、已下放为纯 rule 级）**：`clean_header` 原本是 scenario-shared（OR 继承），现已从 scenario plugin 移除——`ScenarioFlags.CleanHeader` 字段、`GetScenarioFlag`/`SetScenarioFlag` 的 `clean_header` 分支、`FlagCleanHeader` 常量、以及 `resolveRuleFlagsWithScenario` 里的 OR 注入全部删除。改为 built-in CC rule 默认开（见上方主表与 §built-in 默认），UI 上只在 Plugins 卡片按 rule 呈现真实值，不再有 scenario 级开关。
 
 **继承逻辑实现**：
 
@@ -523,8 +524,8 @@ func resolveRuleFlagsWithScenario(...) typ.RuleFlags {
         if flags.ThinkingEffort == "" && scenarioConfig.Flags.ThinkingEffort != "" {
             flags.ThinkingEffort = scenarioConfig.Flags.ThinkingEffort
         }
-        // CleanHeader / ClaudeCodeCompat / SkipUsage：OR 语义（任一启用即生效）
-        flags.CleanHeader      = flags.CleanHeader || scenarioConfig.Flags.CleanHeader
+        // ClaudeCodeCompat / SkipUsage：OR 语义（任一启用即生效）
+        // 注意：clean_header 已不在此 —— 它是 rule-only，无 scenario 级 OR 注入。
         flags.ClaudeCodeCompat = flags.ClaudeCodeCompat || scenarioConfig.Flags.ClaudeCodeCompat
         flags.SkipUsage        = flags.SkipUsage || scenarioConfig.Flags.SkipUsage
         // CustomUserAgent：rule 非空时优先，否则继承 scenario 默认
@@ -536,8 +537,12 @@ func resolveRuleFlagsWithScenario(...) typ.RuleFlags {
             flags.SessionAffinity = scenarioConfig.Flags.SessionAffinity
         }
     }
-    // billing 场景协议转换时自动启用 CleanHeader
+    // claude_desktop 等 billing 场景：协议转换时自动启用 CleanHeader（claude_code 已 rule 级默认开）
     flags = autoSetCleanHeaderFlag(flags, sourceAPI, targetAPI, scenarioType)
+    // Claude OAuth provider：原生 Anthropic 计费后端要消费 billing header，抑制 CleanHeader
+    if flags.CleanHeader && provider.IsClaudeCodeProvider() {
+        flags.CleanHeader = false
+    }
     return flags
 }
 

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -91,7 +91,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 
 	// Resolve flags with scenario injection and auto-apply for CleanHeader.
 	// (This also applies the custom User-Agent to the request context.)
-	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target)
+	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target, provider)
 
 	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -87,7 +87,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 
 	// Resolve flags with scenario injection and auto-apply for CleanHeader.
 	// (This also applies the custom User-Agent to the request context.)
-	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target)
+	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target, provider)
 
 	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1647,8 +1647,6 @@ func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) boo
 		return flags.SmartCompact
 	case FlagSkipUsage:
 		return flags.SkipUsage
-	case FlagCleanHeader:
-		return flags.CleanHeader
 	default:
 		if config.Extensions == nil {
 			return false
@@ -1695,8 +1693,6 @@ func (c *Config) SetScenarioFlag(scenario typ.RuleScenario, flagName string, val
 		config.Flags.SmartCompact = value
 	case FlagSkipUsage:
 		config.Flags.SkipUsage = value
-	case FlagCleanHeader:
-		config.Flags.CleanHeader = value
 	case ExtensionSkillUser:
 		if config.Extensions == nil {
 			config.Extensions = make(map[string]interface{})

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1445,10 +1445,11 @@ func newCCProfileRules(profiledScenario typ.RuleScenario, unified bool) []typ.Ru
 				Type:   loadbalance.TacticAdaptive,
 				Params: typ.DefaultAdaptiveParams(),
 			},
-			// Claude Code profiles inherit the built-in CC default: normalize the
-			// mid-conversation system role so third-party providers accept the
-			// request. Override per-rule for native Anthropic fidelity.
-			Flags:  typ.RuleFlags{ClaudeCodeCompat: true},
+			// Claude Code profiles inherit the built-in CC defaults: normalize the
+			// mid-conversation system role (ClaudeCodeCompat) so third-party
+			// providers accept the request, and strip the billing header
+			// (CleanHeader) so it never leaks to external providers.
+			Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true},
 			Active: true,
 		}
 	}

--- a/internal/server/config/flag_keys.go
+++ b/internal/server/config/flag_keys.go
@@ -9,7 +9,6 @@ const (
 	FlagSmart        = "smart"
 	FlagSmartCompact = "smart_compact"
 	FlagSkipUsage    = "skip_usage"
-	FlagCleanHeader  = "clean_header"
 )
 
 // ScenarioFlags string field keys. Same contract as above but for

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -93,58 +93,30 @@ func init() {
 			},
 			Active: true,
 		},
-		{
-			UUID:          "builtin:claude_desktop:claude-sonnet-4-6",
-			Scenario:      typ.ScenarioClaudeDesktop,
-			RequestModel:  "claude-sonnet-4-6",
-			ResponseModel: "",
-			Description:   "Claude Desktop - Sonnet 4.6 model for balanced performance",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
-			},
-			Active: true,
+		cdRule("builtin:claude_desktop:claude-sonnet-4-6", "claude-sonnet-4-6", "Claude Desktop - Sonnet 4.6 model for balanced performance"),
+		cdRule("builtin:claude_desktop:claude-opus-4-6", "claude-opus-4-6", "Claude Desktop - Opus 4.6 model for complex tasks"),
+		cdRule("builtin:claude_desktop:claude-opus-4-7", "claude-opus-4-7", "Claude Desktop - Opus 4.7 model for advanced reasoning"),
+		cdRule("builtin:claude_desktop:claude-haiku-4-5", "claude-haiku-4-5", "Claude Desktop - Haiku 4.5 model for fast responses"),
+	}
+}
+
+// cdRule builds a built-in Claude Desktop rule with the shared defaults: an empty
+// service list, the default adaptive load-balancing tactic, Active, and the
+// clean_header flag on. Claude Desktop injects x-anthropic-billing-header blocks
+// into system messages that must not reach external providers (CleanHeader).
+func cdRule(uuid, requestModel, description string) typ.Rule {
+	return typ.Rule{
+		UUID:         uuid,
+		Scenario:     typ.ScenarioClaudeDesktop,
+		RequestModel: requestModel,
+		Description:  description,
+		Services:     []*loadbalance.Service{},
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticAdaptive,
+			Params: typ.DefaultAdaptiveParams(),
 		},
-		{
-			UUID:          "builtin:claude_desktop:claude-opus-4-6",
-			Scenario:      typ.ScenarioClaudeDesktop,
-			RequestModel:  "claude-opus-4-6",
-			ResponseModel: "",
-			Description:   "Claude Desktop - Opus 4.6 model for complex tasks",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
-			},
-			Active: true,
-		},
-		{
-			UUID:          "builtin:claude_desktop:claude-opus-4-7",
-			Scenario:      typ.ScenarioClaudeDesktop,
-			RequestModel:  "claude-opus-4-7",
-			ResponseModel: "",
-			Description:   "Claude Desktop - Opus 4.7 model for advanced reasoning",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
-			},
-			Active: true,
-		},
-		{
-			UUID:          "builtin:claude_desktop:claude-haiku-4-5",
-			Scenario:      typ.ScenarioClaudeDesktop,
-			RequestModel:  "claude-haiku-4-5",
-			ResponseModel: "",
-			Description:   "Claude Desktop - Haiku 4.5 model for fast responses",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
-			},
-			Active: true,
-		},
+		Flags:  typ.RuleFlags{CleanHeader: true},
+		Active: true,
 	}
 }
 

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -150,10 +150,10 @@ func init() {
 
 // ccRule builds a built-in Claude Code rule with the shared defaults: an empty
 // service list, the default adaptive load-balancing tactic, Active, and the
-// claude_code_compat flag on. Claude Code emits mid-conversation system-role
-// messages that third-party Anthropic-compatible providers reject; normalizing
-// them is the right default for the built-in CC rules. Users can override the
-// flag per-rule from the Plugins card for native Anthropic fidelity.
+// claude_code_compat + clean_header flags on. Claude Code emits mid-conversation
+// system-role messages that third-party Anthropic-compatible providers reject
+// (ClaudeCodeCompat), and injects x-anthropic-billing-header blocks into system
+// messages that should never leak to external providers (CleanHeader).
 func ccRule(uuid, requestModel, description string) typ.Rule {
 	return typ.Rule{
 		UUID:         uuid,
@@ -165,7 +165,7 @@ func ccRule(uuid, requestModel, description string) typ.Rule {
 			Type:   loadbalance.TacticAdaptive,
 			Params: typ.DefaultAdaptiveParams(),
 		},
-		Flags:  typ.RuleFlags{ClaudeCodeCompat: true},
+		Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true},
 		Active: true,
 	}
 }

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -102,8 +102,10 @@ func init() {
 
 // cdRule builds a built-in Claude Desktop rule with the shared defaults: an empty
 // service list, the default adaptive load-balancing tactic, Active, and the
-// clean_header flag on. Claude Desktop injects x-anthropic-billing-header blocks
-// into system messages that must not reach external providers (CleanHeader).
+// clean_header + claude_code_compat flags on. Claude Desktop injects
+// x-anthropic-billing-header blocks into system messages (CleanHeader) and sends
+// mid-conversation system-role messages that third-party Anthropic-compatible
+// providers reject (ClaudeCodeCompat).
 func cdRule(uuid, requestModel, description string) typ.Rule {
 	return typ.Rule{
 		UUID:         uuid,
@@ -115,7 +117,7 @@ func cdRule(uuid, requestModel, description string) typ.Rule {
 			Type:   loadbalance.TacticAdaptive,
 			Params: typ.DefaultAdaptiveParams(),
 		},
-		Flags:  typ.RuleFlags{CleanHeader: true},
+		Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true},
 		Active: true,
 	}
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -52,6 +52,7 @@ func Migrate(c *Config) error {
 	migrate20260608(c)   // Default claude_code_compat on for existing Claude Code rules
 	migrate20260608_2(c) // Default clean_header on for existing Claude Code rules
 	migrate20260608_3(c) // Default clean_header on for existing Claude Desktop rules
+	migrate20260608_4(c) // Default claude_code_compat on for existing Claude Desktop rules
 	return nil
 }
 
@@ -563,7 +564,7 @@ func migrate20260521(c *Config) {
 			Type:   loadbalance.TacticAdaptive,
 			Params: typ.DefaultAdaptiveParams(),
 		},
-		Flags:  typ.RuleFlags{CleanHeader: true},
+		Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true},
 		Active: true,
 	}
 	if referenceRule != nil && len(referenceRule.Services) > 0 {
@@ -754,5 +755,36 @@ func migrate20260608_3(c *Config) {
 	if needsSave {
 		_ = c.Save()
 		logrus.Info("Migration 20260608_3 completed: defaulted clean_header on for Claude Desktop rules")
+	}
+}
+
+// migrate20260608_4 defaults claude_code_compat on for existing Claude Desktop rules.
+// Claude Desktop sends mid-conversation system-role messages (same non-standard
+// extension as Claude Code) that third-party Anthropic-compatible providers reject.
+// Mirrors migrate20260608 but targets ScenarioClaudeDesktop.
+//
+// One-time only — gated by the migration marker — so a user who later turns the
+// flag off on a specific rule keeps it off across restarts.
+func migrate20260608_4(c *Config) {
+	if c.hasMigrationCompleted("20260608_4") {
+		return
+	}
+
+	needsSave := false
+	for i := range c.Rules {
+		base, _ := typ.ParseScenarioProfile(c.Rules[i].Scenario)
+		if base != typ.ScenarioClaudeDesktop {
+			continue
+		}
+		if !c.Rules[i].Flags.ClaudeCodeCompat {
+			c.Rules[i].Flags.ClaudeCodeCompat = true
+			needsSave = true
+		}
+	}
+
+	c.markMigrationCompleted("20260608_4")
+	if needsSave {
+		_ = c.Save()
+		logrus.Info("Migration 20260608_4 completed: defaulted claude_code_compat on for Claude Desktop rules")
 	}
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -51,6 +51,7 @@ func Migrate(c *Config) error {
 	migrate20260606(c) // Add default scenario configs with session affinity
 	migrate20260608(c) // Default claude_code_compat on for existing Claude Code rules
 	migrate20260609(c) // Default clean_header on for existing Claude Code rules
+	migrate20260610(c) // Default clean_header on for existing Claude Desktop rules
 	return nil
 }
 
@@ -562,6 +563,7 @@ func migrate20260521(c *Config) {
 			Type:   loadbalance.TacticAdaptive,
 			Params: typ.DefaultAdaptiveParams(),
 		},
+		Flags:  typ.RuleFlags{CleanHeader: true},
 		Active: true,
 	}
 	if referenceRule != nil && len(referenceRule.Services) > 0 {
@@ -721,5 +723,36 @@ func migrate20260609(c *Config) {
 	if needsSave {
 		_ = c.Save()
 		logrus.Info("Migration 2026-06-09 completed: defaulted clean_header on for Claude Code rules")
+	}
+}
+
+// migrate20260610 defaults clean_header on for existing Claude Desktop rules.
+// Claude Desktop injects x-anthropic-billing-header blocks into system messages
+// (same billing mechanism as Claude Code); these must not leak to external
+// providers. Mirrors migrate20260609 but targets ScenarioClaudeDesktop.
+//
+// One-time only — gated by the migration marker — so a user who later turns the
+// flag off on a specific rule keeps it off across restarts.
+func migrate20260610(c *Config) {
+	if c.hasMigrationCompleted("20260610") {
+		return
+	}
+
+	needsSave := false
+	for i := range c.Rules {
+		base, _ := typ.ParseScenarioProfile(c.Rules[i].Scenario)
+		if base != typ.ScenarioClaudeDesktop {
+			continue
+		}
+		if !c.Rules[i].Flags.CleanHeader {
+			c.Rules[i].Flags.CleanHeader = true
+			needsSave = true
+		}
+	}
+
+	c.markMigrationCompleted("20260610")
+	if needsSave {
+		_ = c.Save()
+		logrus.Info("Migration 2026-06-10 completed: defaulted clean_header on for Claude Desktop rules")
 	}
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -49,9 +49,9 @@ func Migrate(c *Config) error {
 	migrate20260517(c) // Rewrite 127.0.0.1 to localhost in tingly-owned agent configs
 	migrate20260518(c) // Set OpenAIEndpointMode=responses on existing Codex OAuth providers
 	migrate20260606(c) // Add default scenario configs with session affinity
-	migrate20260608(c) // Default claude_code_compat on for existing Claude Code rules
-	migrate20260609(c) // Default clean_header on for existing Claude Code rules
-	migrate20260610(c) // Default clean_header on for existing Claude Desktop rules
+	migrate20260608(c)   // Default claude_code_compat on for existing Claude Code rules
+	migrate20260608_2(c) // Default clean_header on for existing Claude Code rules
+	migrate20260608_3(c) // Default clean_header on for existing Claude Desktop rules
 	return nil
 }
 
@@ -691,7 +691,7 @@ func migrate20260608(c *Config) {
 	}
 }
 
-// migrate20260609 defaults clean_header on for existing Claude Code rules —
+// migrate20260608_2 defaults clean_header on for existing Claude Code rules —
 // the built-in CC rules and any claude_code:<profile> profile rules. Claude Code
 // injects x-anthropic-billing-header blocks into system messages; these are a
 // CC-internal billing mechanism and should never reach external providers.
@@ -702,8 +702,8 @@ func migrate20260608(c *Config) {
 //
 // One-time only — gated by the migration marker — so a user who later turns the
 // flag off on a specific rule keeps it off across restarts.
-func migrate20260609(c *Config) {
-	if c.hasMigrationCompleted("20260609") {
+func migrate20260608_2(c *Config) {
+	if c.hasMigrationCompleted("20260608_2") {
 		return
 	}
 
@@ -719,22 +719,22 @@ func migrate20260609(c *Config) {
 		}
 	}
 
-	c.markMigrationCompleted("20260609")
+	c.markMigrationCompleted("20260608_2")
 	if needsSave {
 		_ = c.Save()
-		logrus.Info("Migration 2026-06-09 completed: defaulted clean_header on for Claude Code rules")
+		logrus.Info("Migration 20260608_2 completed: defaulted clean_header on for Claude Code rules")
 	}
 }
 
-// migrate20260610 defaults clean_header on for existing Claude Desktop rules.
+// migrate20260608_3 defaults clean_header on for existing Claude Desktop rules.
 // Claude Desktop injects x-anthropic-billing-header blocks into system messages
 // (same billing mechanism as Claude Code); these must not leak to external
-// providers. Mirrors migrate20260609 but targets ScenarioClaudeDesktop.
+// providers. Mirrors migrate20260608_2 but targets ScenarioClaudeDesktop.
 //
 // One-time only — gated by the migration marker — so a user who later turns the
 // flag off on a specific rule keeps it off across restarts.
-func migrate20260610(c *Config) {
-	if c.hasMigrationCompleted("20260610") {
+func migrate20260608_3(c *Config) {
+	if c.hasMigrationCompleted("20260608_3") {
 		return
 	}
 
@@ -750,9 +750,9 @@ func migrate20260610(c *Config) {
 		}
 	}
 
-	c.markMigrationCompleted("20260610")
+	c.markMigrationCompleted("20260608_3")
 	if needsSave {
 		_ = c.Save()
-		logrus.Info("Migration 2026-06-10 completed: defaulted clean_header on for Claude Desktop rules")
+		logrus.Info("Migration 20260608_3 completed: defaulted clean_header on for Claude Desktop rules")
 	}
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -50,6 +50,7 @@ func Migrate(c *Config) error {
 	migrate20260518(c) // Set OpenAIEndpointMode=responses on existing Codex OAuth providers
 	migrate20260606(c) // Add default scenario configs with session affinity
 	migrate20260608(c) // Default claude_code_compat on for existing Claude Code rules
+	migrate20260609(c) // Default clean_header on for existing Claude Code rules
 	return nil
 }
 
@@ -685,5 +686,40 @@ func migrate20260608(c *Config) {
 	if needsSave {
 		_ = c.Save()
 		logrus.Info("Migration 2026-06-08 completed: defaulted claude_code_compat on for Claude Code rules")
+	}
+}
+
+// migrate20260609 defaults clean_header on for existing Claude Code rules —
+// the built-in CC rules and any claude_code:<profile> profile rules. Claude Code
+// injects x-anthropic-billing-header blocks into system messages; these are a
+// CC-internal billing mechanism and should never reach external providers.
+// Previously the header was only stripped on protocol transformation (Anthropic →
+// OpenAI/other); defaulting the flag at rule level strips it unconditionally,
+// regardless of the target protocol, and makes the Plugins card show the true
+// active state.
+//
+// One-time only — gated by the migration marker — so a user who later turns the
+// flag off on a specific rule keeps it off across restarts.
+func migrate20260609(c *Config) {
+	if c.hasMigrationCompleted("20260609") {
+		return
+	}
+
+	needsSave := false
+	for i := range c.Rules {
+		base, _ := typ.ParseScenarioProfile(c.Rules[i].Scenario)
+		if base != typ.ScenarioClaudeCode {
+			continue
+		}
+		if !c.Rules[i].Flags.CleanHeader {
+			c.Rules[i].Flags.CleanHeader = true
+			needsSave = true
+		}
+	}
+
+	c.markMigrationCompleted("20260609")
+	if needsSave {
+		_ = c.Save()
+		logrus.Info("Migration 2026-06-09 completed: defaulted clean_header on for Claude Code rules")
 	}
 }

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -215,3 +215,51 @@ func TestMigrate20260608_OneTime_PreservesUserOff(t *testing.T) {
 		t.Error("migration re-enabled a user-disabled flag; one-time gate is broken")
 	}
 }
+
+func TestMigrate20260609_DefaultsCleanHeader(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: "built-in-cc", Scenario: typ.ScenarioClaudeCode},
+			{UUID: "cc-profile", Scenario: typ.RuleScenario("claude_code:p1")},
+			{UUID: "already-on", Scenario: typ.ScenarioClaudeCode, Flags: typ.RuleFlags{CleanHeader: true}},
+			{UUID: "desktop", Scenario: typ.ScenarioClaudeDesktop},
+			{UUID: "openai", Scenario: typ.ScenarioOpenAI},
+		},
+	}
+
+	migrate20260609(c)
+
+	if !c.hasMigrationCompleted("20260609") {
+		t.Fatal("migration should be marked completed")
+	}
+	want := map[string]bool{
+		"built-in-cc": true,  // claude_code base → defaulted on
+		"cc-profile":  true,  // claude_code:<profile> → defaulted on
+		"already-on":  true,  // unchanged
+		"desktop":     false, // claude_desktop — not in scope for this migration
+		"openai":      false, // non-claude_code → untouched
+	}
+	for _, r := range c.Rules {
+		if got := r.Flags.CleanHeader; got != want[r.UUID] {
+			t.Errorf("rule %q CleanHeader = %v, want %v", r.UUID, got, want[r.UUID])
+		}
+	}
+}
+
+func TestMigrate20260609_OneTime_PreservesUserOff(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{{UUID: "built-in-cc", Scenario: typ.ScenarioClaudeCode}},
+	}
+
+	migrate20260609(c)
+	if !c.Rules[0].Flags.CleanHeader {
+		t.Fatal("first run should default the flag on")
+	}
+
+	// User turns it off; a later boot must not re-enable it.
+	c.Rules[0].Flags.CleanHeader = false
+	migrate20260609(c)
+	if c.Rules[0].Flags.CleanHeader {
+		t.Error("migration re-enabled a user-disabled flag; one-time gate is broken")
+	}
+}

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -227,7 +227,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	// === Resolve flags with scenario injection ===
 	// (resolveRuleFlagsWithScenario also applies the custom User-Agent to the
 	// request context, so no separate call is needed here.)
-	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target)
+	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target, provider)
 
 	// === Transform via pipeline ===
 	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -226,7 +226,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	// Resolve flags with scenario injection, consistent with the chat/v1/beta
 	// handlers (this also applies the custom User-Agent to the request context).
 	scenarioConfig := s.config.GetScenarioConfig(scenarioType)
-	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target)
+	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target, provider)
 	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -158,7 +157,7 @@ func resolveRuleFlagsWithScenario(
 	// consumed by Anthropic's billing backend; stripping it would break billing
 	// for OAuth subscribers even though it must be stripped for every other
 	// provider type (third-party Anthropic-compatible, OpenAI, etc.).
-	if flags.CleanHeader && isClaudeOAuthProvider(provider) {
+	if flags.CleanHeader && provider.IsClaudeCodeProvider() {
 		flags.CleanHeader = false
 	}
 
@@ -167,18 +166,6 @@ func resolveRuleFlagsWithScenario(
 	applyCustomUserAgent(c, flags)
 
 	return flags
-}
-
-// isClaudeOAuthProvider reports whether a provider routes to Anthropic via a
-// Claude Code OAuth token. These providers carry an x-anthropic-billing-header
-// that Anthropic's backend uses for subscription billing; it must not be stripped.
-func isClaudeOAuthProvider(provider *typ.Provider) bool {
-	if provider == nil {
-		return false
-	}
-	return provider.AuthType == typ.AuthTypeOAuth &&
-		provider.OAuthDetail != nil &&
-		provider.OAuthDetail.GetIssuer() == ai.IssuerClaudeCode
 }
 
 // applyCustomUserAgent attaches the effective custom User-Agent (already merged

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -77,7 +77,6 @@ func ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform {
 // resolveRuleFlags returns the effective flags for this request: a copy of
 // the rule's persisted flags, with:
 // - cursor_compat_auto folded into cursor_compat when the inbound request carries Cursor headers
-// - scenario flags (ThinkingEffort, CleanHeader) injected for billing scenarios during transformation
 // Returns the zero value when no rule is bound.
 //
 // All flag folding/injection happens here (not at each handler call site) so that
@@ -100,11 +99,11 @@ func resolveRuleFlags(c *gin.Context, rule *typ.Rule) typ.RuleFlags {
 // flags and auto-apply CleanHeader for protocol transformation scenarios.
 //
 // This is the main entry point that merges:
-// 1. Rule-level flags (from the rule definition)
-// 2. Scenario flags (from the scenario configuration)
-// 3. Auto-applied flags (like CleanHeader for protocol transformation)
-// 4. Provider-driven suppressions (CleanHeader is cleared for Claude OAuth providers;
-//    the billing header must reach Anthropic's billing backend unchanged).
+//  1. Rule-level flags (from the rule definition)
+//  2. Scenario flags (from the scenario configuration)
+//  3. Auto-applied flags (like CleanHeader for protocol transformation)
+//  4. Provider-driven suppressions (CleanHeader is cleared for Claude OAuth providers;
+//     the billing header must reach Anthropic's billing backend unchanged).
 //
 // Side effect: it also attaches the resolved CustomUserAgent to the request
 // context (applyCustomUserAgent) so callers don't have to repeat that at each
@@ -126,9 +125,6 @@ func resolveRuleFlagsWithScenario(
 		if flags.ThinkingEffort == typ.ThinkingEffortDefault && scenarioConfig.Flags.ThinkingEffort != typ.ThinkingEffortDefault {
 			flags.ThinkingEffort = scenarioConfig.Flags.ThinkingEffort
 		}
-
-		// Inject scenario-level CleanHeader if not already set at rule level
-		flags.CleanHeader = flags.CleanHeader || scenarioConfig.Flags.CleanHeader
 
 		// Inject scenario-level ClaudeCodeCompat if not already set at rule level
 		flags.ClaudeCodeCompat = flags.ClaudeCodeCompat || scenarioConfig.Flags.ClaudeCodeCompat

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -103,6 +104,8 @@ func resolveRuleFlags(c *gin.Context, rule *typ.Rule) typ.RuleFlags {
 // 1. Rule-level flags (from the rule definition)
 // 2. Scenario flags (from the scenario configuration)
 // 3. Auto-applied flags (like CleanHeader for protocol transformation)
+// 4. Provider-driven suppressions (CleanHeader is cleared for Claude OAuth providers;
+//    the billing header must reach Anthropic's billing backend unchanged).
 //
 // Side effect: it also attaches the resolved CustomUserAgent to the request
 // context (applyCustomUserAgent) so callers don't have to repeat that at each
@@ -115,6 +118,7 @@ func resolveRuleFlagsWithScenario(
 	scenarioType typ.RuleScenario,
 	scenarioConfig *typ.ScenarioConfig,
 	sourceAPI, targetAPI protocol.APIType,
+	provider *typ.Provider,
 ) typ.RuleFlags {
 	flags := resolveRuleFlags(c, rule)
 
@@ -149,11 +153,32 @@ func resolveRuleFlagsWithScenario(
 	// Auto-apply CleanHeader for protocol transformation in billing scenarios
 	flags = autoSetCleanHeaderFlag(flags, sourceAPI, targetAPI, scenarioType)
 
+	// Suppress CleanHeader when the provider is Claude OAuth (native Anthropic
+	// subscription). The x-anthropic-billing-header injected by Claude Code is
+	// consumed by Anthropic's billing backend; stripping it would break billing
+	// for OAuth subscribers even though it must be stripped for every other
+	// provider type (third-party Anthropic-compatible, OpenAI, etc.).
+	if flags.CleanHeader && isClaudeOAuthProvider(provider) {
+		flags.CleanHeader = false
+	}
+
 	// Attach the resolved User-Agent override to the request context here, at the
 	// single merge point, so the chat / v1 / beta handlers don't each repeat it.
 	applyCustomUserAgent(c, flags)
 
 	return flags
+}
+
+// isClaudeOAuthProvider reports whether a provider routes to Anthropic via a
+// Claude Code OAuth token. These providers carry an x-anthropic-billing-header
+// that Anthropic's backend uses for subscription billing; it must not be stripped.
+func isClaudeOAuthProvider(provider *typ.Provider) bool {
+	if provider == nil {
+		return false
+	}
+	return provider.AuthType == typ.AuthTypeOAuth &&
+		provider.OAuthDetail != nil &&
+		provider.OAuthDetail.GetIssuer() == ai.IssuerClaudeCode
 }
 
 // applyCustomUserAgent attaches the effective custom User-Agent (already merged

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -426,6 +427,7 @@ func TestResolveRuleFlagsWithScenario_ThinkingEffort(t *testing.T) {
 				scenarioConfig,
 				protocol.TypeAnthropicV1,
 				protocol.TypeOpenAIChat,
+				nil,
 			)
 
 			if result.ThinkingEffort != tt.wantThinkingEffort {
@@ -481,11 +483,45 @@ func TestResolveRuleFlagsWithScenario_CustomUserAgent(t *testing.T) {
 				scenarioConfig,
 				protocol.TypeAnthropicV1,
 				protocol.TypeOpenAIChat,
+				nil,
 			)
 
 			if result.CustomUserAgent != tt.wantUA {
 				t.Errorf("CustomUserAgent = %q, want %q", result.CustomUserAgent, tt.wantUA)
 			}
 		})
+	}
+}
+
+func TestResolveRuleFlagsWithScenario_CleanHeaderSuppressedForClaudeOAuth(t *testing.T) {
+	oauthProvider := &typ.Provider{
+		AuthType:    typ.AuthTypeOAuth,
+		OAuthDetail: &ai.OAuthDetail{Issuer: ai.IssuerClaudeCode},
+	}
+	otherProvider := &typ.Provider{AuthType: typ.AuthTypeAPIKey}
+
+	c, _ := gin.CreateTestContext(nil)
+	rule := &typ.Rule{Flags: typ.RuleFlags{CleanHeader: true}}
+	scenarioConfig := &typ.ScenarioConfig{}
+
+	// CleanHeader should be suppressed for Claude OAuth provider.
+	got := resolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, scenarioConfig,
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, oauthProvider)
+	if got.CleanHeader {
+		t.Error("CleanHeader should be suppressed for Claude OAuth provider")
+	}
+
+	// CleanHeader should be preserved for any other provider type.
+	got = resolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, scenarioConfig,
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, otherProvider)
+	if !got.CleanHeader {
+		t.Error("CleanHeader should be preserved for non-OAuth provider")
+	}
+
+	// nil provider: no suppression.
+	got = resolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, scenarioConfig,
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+	if !got.CleanHeader {
+		t.Error("CleanHeader should be preserved when provider is nil")
 	}
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -217,13 +217,11 @@ func RuleFlagRegistry() []FlagSpec {
 			InheritanceMode: "or",
 		},
 		{
-			Key:             "clean_header",
-			Label:           "Clean Header",
-			Description:     "Strip x-anthropic-billing-header blocks from system messages before forwarding. Auto-enabled for billing scenarios (claude_code, claude_desktop) during protocol transformation; set manually to force enable on any rule.",
-			Type:            FlagTypeBool,
-			Category:        FlagCategoryApp,
-			Shared:          true,
-			InheritanceMode: "or",
+			Key:         "clean_header",
+			Label:       "Clean Header",
+			Description: "Strip x-anthropic-billing-header blocks from system messages before forwarding. Claude Code injects this header for its own billing; it must not leak to third-party providers. On by default for the built-in Claude Code rules, and automatically suppressed when the rule routes to a Claude OAuth provider (whose billing backend consumes the header). Still auto-enabled for claude_desktop during protocol transformation. Turn off only for native Anthropic fidelity.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryApp,
 		},
 	}
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -162,8 +162,6 @@ type ScenarioFlags struct {
 	// "low"/"medium"/"high"/"max" (force enabled with the matching budget).
 	ThinkingEffort ThinkingEffortLevel `json:"thinking_effort,omitempty" yaml:"thinking_effort,omitempty"`
 
-	CleanHeader bool `json:"clean_header,omitempty" yaml:"clean_header,omitempty"` // Remove billing header from system messages (Claude Code only)
-
 	// CustomUserAgent overrides the outbound User-Agent header for every rule
 	// under this scenario. Acts as a scenario-wide default; individual rules can
 	// override it via RuleFlags.CustomUserAgent (rule value wins when non-empty).


### PR DESCRIPTION
## Summary

Defaults `clean_header` and `claude_code_compat` on for all built-in Claude Code **and** Claude Desktop rules, adds runtime suppression of `clean_header` for Claude OAuth providers, and removes `clean_header` from the scenario plugin surface entirely.

## Changes

### `clean_header` — default-on for Claude Code & Desktop

Claude Code and Claude Desktop both inject `x-anthropic-billing-header` blocks into system messages. This is an Anthropic-internal billing mechanism; the header must never reach external providers.

Previously the header was only stripped during Anthropic→OpenAI protocol transformation (via `autoSetCleanHeaderFlag`). It is now default-on at rule level for both scenarios, so it applies unconditionally regardless of target protocol, and the Plugins card shows the true active state.

### `claude_code_compat` — default-on for Claude Desktop

Claude Desktop sends mid-conversation `role:"system"` messages (same non-standard extension as Claude Code) that third-party Anthropic-compatible providers reject. `claude_code_compat` was already default-on for Claude Code rules; this PR extends that to Claude Desktop.

### Claude OAuth suppression

When a rule routes to a Claude OAuth provider (native Anthropic subscription), `CleanHeader` is forcibly cleared at runtime in `resolveRuleFlagsWithScenario`. The billing header is consumed by Anthropic's billing backend for OAuth subscribers — stripping it would break subscription billing.

Uses the existing `provider.IsClaudeCodeProvider()` method (nil-safe).

### `clean_header` demoted from scenario plugin

`clean_header` is now rule-only. Removed `ScenarioFlags.CleanHeader` field, `GetScenarioFlag`/`SetScenarioFlag` branches, `FlagCleanHeader` constant, and the scenario OR-injection in `resolveRuleFlagsWithScenario`. The scenario-level flag had no remaining value once CC and Desktop rules default it on at rule level.

## Files changed

| File | Change |
|------|--------|
| `internal/server/config/init.go` | `ccRule()`: `ClaudeCodeCompat+CleanHeader: true`; new `cdRule()` factory with same flags; 4 inline Desktop structs replaced |
| `internal/server/config/config.go` | `newCCProfileRules`: `ClaudeCodeCompat+CleanHeader: true`; removed `GetScenarioFlag`/`SetScenarioFlag` branches for `clean_header` |
| `internal/server/config/migration.go` | `migrate20260608` (CC compat), `20260608_2` (CC clean_header), `20260608_3` (Desktop clean_header), `20260608_4` (Desktop compat); `migrate20260521` haiku rule updated |
| `internal/server/config/flag_keys.go` | Removed `FlagCleanHeader` constant |
| `internal/server/rule_flags.go` | `resolveRuleFlagsWithScenario` gains `provider` param; OAuth suppression added; scenario OR-injection removed |
| `internal/server/anthropic_message_v1.go` | Updated call site (pass `provider`) |
| `internal/server/anthropic_message_beta.go` | Updated call site (pass `provider`) |
| `internal/server/openai_chat.go` | Updated call site (pass `provider`) |
| `internal/server/openai_responses.go` | Updated call site (pass `provider`) |
| `internal/server/rule_flags_test.go` | Updated existing tests; new OAuth suppression test |
| `internal/typ/type.go` | Removed `ScenarioFlags.CleanHeader` field |
| `internal/typ/flag_registry.go` | `clean_header` spec: removed `Shared`/`InheritanceMode`; updated description |
| `.design/rule-flags.md` | Documented all changes |

## Notes

- `autoSetCleanHeaderFlag` is unchanged — it still auto-enables `CleanHeader` for `claude_desktop` during Anthropic→OpenAI protocol transformation.
- All four migrations are one-time gated (`hasMigrationCompleted`) so user overrides survive restarts.