### PR TITLE
feat(obs): add structured LB fields and improve failover logging

### DIFF
--- a/internal/constant/tracking_ctx.go
+++ b/internal/constant/tracking_ctx.go
@@ -1,0 +1,19 @@
+package constant
+
+// Gin context key constants for per-request tracking metadata.
+// Defined here so that server/, routing/, and middleware/ sub-packages
+// can all reference the same values without import cycles.
+const (
+	CtxKeyRule           = "tracking_rule"             // *typ.Rule
+	CtxKeyProvider       = "tracking_provider"         // *typ.Provider
+	CtxKeyModel          = "tracking_model"            // string (actual model used)
+	CtxKeyRequestModel   = "tracking_request_model"    // string (model requested by user)
+	CtxKeyScenario       = "tracking_scenario"         // string (extracted from request path)
+	CtxKeyStreamed       = "tracking_streamed"         // bool
+	CtxKeyStartTime      = "tracking_start_time"       // time.Time
+	CtxKeyFirstTokenTime = "tracking_first_token_time" // time.Time (for TTFT calculation)
+	CtxKeyCacheHit       = "tracking_cache_hit"        // bool (cache hit status)
+	CtxKeySessionID      = "tracking_session_id"       // string (resolved session ID for affinity)
+	CtxKeyLBServiceID    = "tracking_lb_service_id"    // string (selected upstream, e.g. "provider-uuid:model")
+	CtxKeyLBTactic       = "tracking_lb_tactic"        // string (tactic name, e.g. "token_based")
+)

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -361,14 +361,30 @@ func (s *Server) dispatchWithPriorityFailover(
 
 		nextProvider, nextService, err := s.selectFallbackService(rule, tried, initialProvider.APIStyle)
 		if err != nil {
-			logrus.WithContext(c.Request.Context()).Warnf("[failover] load balancer failed selecting fallback after %d attempt(s) status=%d: %v", i+1, status, err)
+			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+				"stage":   "failover",
+				"attempt": i + 1,
+				"status":  status,
+				"error":   err.Error(),
+			}).Warnf("[failover] load balancer failed selecting fallback after %d attempt(s) status=%d: %v", i+1, status, err)
 			return
 		}
 		if nextProvider == nil || nextService == nil {
-			logrus.WithContext(c.Request.Context()).Debugf("[failover] giving up after %d attempt(s) status=%d (no more services)", i+1, status)
+			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+				"stage":   "failover",
+				"attempt": i + 1,
+				"status":  status,
+			}).Warnf("[failover] giving up after %d attempt(s) status=%d (no more services)", i+1, status)
 			return
 		}
-		logrus.WithContext(c.Request.Context()).Infof("[failover] %s status=%d → retrying with %s:%s", serviceID, status, nextProvider.UUID, nextService.Model)
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"stage":        "failover",
+			"attempt":      i + 1,
+			"status":       status,
+			"from_service": serviceID,
+			"to_provider":  nextProvider.Name,
+			"to_model":     nextService.Model,
+		}).Infof("[failover] status=%d → retrying with %s/%s", status, nextProvider.Name, nextService.Model)
 
 		gate.Discard()
 		provider = nextProvider

--- a/internal/server/failover_logging_test.go
+++ b/internal/server/failover_logging_test.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+	"github.com/tingly-dev/tingly-box/pkg/obs"
+)
+
+// logCapture is a logrus hook that records every entry fired through it.
+type logCapture struct {
+	entries []*logrus.Entry
+}
+
+func (h *logCapture) Levels() []logrus.Level { return logrus.AllLevels }
+func (h *logCapture) Fire(e *logrus.Entry) error {
+	// Copy fields to avoid mutation after Fire returns.
+	fields := make(logrus.Fields, len(e.Data))
+	for k, v := range e.Data {
+		fields[k] = v
+	}
+	h.entries = append(h.entries, &logrus.Entry{
+		Logger:  e.Logger,
+		Data:    fields,
+		Time:    e.Time,
+		Level:   e.Level,
+		Message: e.Message,
+	})
+	return nil
+}
+
+// printCapturedLog prints entries in a human-readable table for manual inspection.
+func printCapturedLog(t *testing.T, entries []*logrus.Entry) {
+	t.Helper()
+	t.Log("\n── captured log entries ──────────────────────────────────────────")
+	for i, e := range entries {
+		fields := make([]string, 0, len(e.Data))
+		for k, v := range e.Data {
+			fields = append(fields, fmt.Sprintf("%s=%v", k, v))
+		}
+		t.Logf("[%d] level=%-5s msg=%q\n        fields={%s}", i, e.Level, e.Message, strings.Join(fields, "  "))
+	}
+	t.Log("──────────────────────────────────────────────────────────────────")
+}
+
+// TestFailoverLogging exercises dispatchWithPriorityFailover and verifies
+// the structured log fields emitted during retry and give-up scenarios.
+//
+// Run with:
+//
+//	go test -v -run TestFailoverLogging ./internal/server/
+//
+// The captured log entries are printed for human inspection.
+func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
+	// Build a real (temp-dir backed) config so GetProviderByUUID works.
+	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	providerT0 := &typ.Provider{UUID: "prov-t0", Name: "ProviderAlpha", Enabled: true, APIStyle: "openai", APIBase: "https://api.example-alpha.com/v1"}
+	providerT1 := &typ.Provider{UUID: "prov-t1", Name: "ProviderBeta", Enabled: true, APIStyle: "openai", APIBase: "https://api.example-beta.com/v1"}
+	if err := cfg.AddProvider(providerT0); err != nil {
+		t.Fatalf("AddProvider T0: %v", err)
+	}
+	if err := cfg.AddProvider(providerT1); err != nil {
+		t.Fatalf("AddProvider T1: %v", err)
+	}
+
+	rule := &typ.Rule{
+		UUID: "test-rule",
+		LBTactic: typ.Tactic{
+			Type: loadbalance.TacticTier,
+			Params: &typ.TierParams{
+				WithinTierTactic: loadbalance.TacticRandom,
+			},
+		},
+		Services: []*loadbalance.Service{
+			{Provider: providerT0.UUID, Model: "gpt-4o", Active: true, Tier: 0},
+			{Provider: providerT1.UUID, Model: "gpt-4o-mini", Active: true, Tier: 1},
+		},
+	}
+
+	hm := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+	hf := typ.NewHealthFilter(hm)
+	s := &Server{
+		config:        cfg,
+		loadBalancer:  NewLoadBalancer(cfg, hf),
+		healthMonitor: hm,
+	}
+
+	newCtx := func(reqID string) *gin.Context {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", nil)
+		c.Request = c.Request.WithContext(obs.ContextWithRequestID(c.Request.Context(), reqID))
+		return c
+	}
+
+	t.Run("retry_then_succeed", func(t *testing.T) {
+		hook := &logCapture{}
+		logrus.AddHook(hook)
+		defer logrus.StandardLogger().ReplaceHooks(logrus.LevelHooks{})
+
+		c := newCtx("req-retry-001")
+		callCount := 0
+		attempt := func(provider *typ.Provider, model string) {
+			callCount++
+			if callCount == 1 {
+				// Tier-0 returns 429 — retryable, gate stays uncommitted.
+				c.Writer.WriteHeader(http.StatusTooManyRequests)
+			} else {
+				// Tier-1 succeeds and commits the gate.
+				c.Writer.WriteHeader(http.StatusOK)
+				if gate, ok := c.Writer.(*firstChunkGate); ok {
+					gate.CommitFirstChunk()
+				}
+			}
+		}
+
+		s.dispatchWithPriorityFailover(c, rule, providerT0, "gpt-4o", attempt)
+
+		printCapturedLog(t, hook.entries)
+
+		var sawRetry bool
+		for _, e := range hook.entries {
+			if e.Data["stage"] == "failover" && e.Data["to_provider"] != nil {
+				sawRetry = true
+				for _, field := range []string{"attempt", "status", "from_service", "to_provider", "to_model"} {
+					if e.Data[field] == nil {
+						t.Errorf("retry log missing field: %s", field)
+					}
+				}
+			}
+		}
+		if !sawRetry {
+			t.Error("expected a failover retry log entry with to_provider field, got none")
+		}
+	})
+
+	t.Run("all_services_fail_give_up", func(t *testing.T) {
+		hook := &logCapture{}
+		logrus.AddHook(hook)
+		defer logrus.StandardLogger().ReplaceHooks(logrus.LevelHooks{})
+
+		c := newCtx("req-giveup-001")
+		attempt := func(provider *typ.Provider, model string) {
+			// Every attempt 429s — gate never commits.
+			c.Writer.WriteHeader(http.StatusTooManyRequests)
+		}
+
+		s.dispatchWithPriorityFailover(c, rule, providerT0, "gpt-4o", attempt)
+
+		printCapturedLog(t, hook.entries)
+
+		var sawGiveUp bool
+		for _, e := range hook.entries {
+			if e.Data["stage"] == "failover" && e.Data["to_provider"] == nil && e.Data["attempt"] != nil {
+				sawGiveUp = true
+				if e.Level != logrus.WarnLevel {
+					t.Errorf("give-up log should be Warn level, got %s", e.Level)
+				}
+				for _, field := range []string{"attempt", "status"} {
+					if e.Data[field] == nil {
+						t.Errorf("give-up log missing field: %s", field)
+					}
+				}
+			}
+		}
+		if !sawGiveUp {
+			t.Error("expected a failover give-up log entry, got none")
+		}
+	})
+}

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/obs"
 )
@@ -172,21 +173,27 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		}
 
 		// Append routing metadata when set by AI handlers (absent for non-AI routes)
-		if rm := c.GetString("tracking_request_model"); rm != "" {
+		if rm := c.GetString(constant.CtxKeyRequestModel); rm != "" {
 			fields["request_model"] = rm
 		}
-		if am := c.GetString("tracking_model"); am != "" {
+		if am := c.GetString(constant.CtxKeyModel); am != "" {
 			fields["routed_model"] = am
 		}
-		if sc := c.GetString("tracking_scenario"); sc != "" {
+		if sc := c.GetString(constant.CtxKeyScenario); sc != "" {
 			fields["scenario"] = sc
 		}
-		if pv, exists := c.Get("tracking_provider"); exists {
+		if pv, exists := c.Get(constant.CtxKeyProvider); exists {
 			if p, ok := pv.(*typ.Provider); ok && p != nil {
 				fields["routed_provider"] = p.Name
 				fields["api_style"] = string(p.APIStyle)
 				fields["base_url"] = p.APIBase
 			}
+		}
+		if svcID := c.GetString(constant.CtxKeyLBServiceID); svcID != "" {
+			fields["lb_service_id"] = svcID
+		}
+		if tactic := c.GetString(constant.CtxKeyLBTactic); tactic != "" {
+			fields["lb_tactic"] = tactic
 		}
 
 		// Log with structured fields including error details

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -76,10 +77,20 @@ func (s *SimpleSelector) SelectService(
 	}
 
 	// Automatically store sessionID in gin context for downstream handlers
-	c.Set("tracking_session_id", ctx.SessionID.String())
+	c.Set(constant.CtxKeySessionID, ctx.SessionID.String())
 
 	// Store result metadata for observability
 	c.Set("routing_source", result.Source)
+
+	// Store LB trajectory: which upstream was selected and via which tactic.
+	// "smart_routing" and "affinity" sources bypass the normal LB tactic, so
+	// label them explicitly; otherwise use the rule's configured tactic name.
+	c.Set(constant.CtxKeyLBServiceID, result.Service.ServiceID())
+	tacticName := result.Source
+	if result.Source != "smart_routing" && result.Source != "affinity" {
+		tacticName = rule.GetTacticType().String()
+	}
+	c.Set(constant.CtxKeyLBTactic, tacticName)
 
 	setRoutingDebugHeaders(c, result.Provider.Name, result.Provider.UUID, result.Service.Model, result.Source, result.MatchedSmartRuleIndex)
 

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -5,24 +5,27 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// Gin context keys for tracking metadata.
-// These keys are used to store tracking information in the gin context
-// to avoid explicit parameter passing throughout the handler chain.
+// Gin context key aliases — canonical values live in constant so that
+// routing/ and middleware/ sub-packages can reference them without an
+// import cycle.
 const (
-	ContextKeyRule           = "tracking_rule"             // *typ.Rule
-	ContextKeyProvider       = "tracking_provider"         // *typ.Provider
-	ContextKeyModel          = "tracking_model"            // string (actual model used)
-	ContextKeyRequestModel   = "tracking_request_model"    // string (model requested by user)
-	ContextKeyScenario       = "tracking_scenario"         // string (extracted from request path)
-	ContextKeyStreamed       = "tracking_streamed"         // bool
-	ContextKeyStartTime      = "tracking_start_time"       // time.Time
-	ContextKeyFirstTokenTime = "tracking_first_token_time" // time.Time (for TTFT calculation)
-	ContextKeyCacheHit       = "tracking_cache_hit"        // bool (cache hit status)
-	ContextKeySessionID      = "tracking_session_id"       // string (resolved session ID for affinity)
+	ContextKeyRule           = constant.CtxKeyRule
+	ContextKeyProvider       = constant.CtxKeyProvider
+	ContextKeyModel          = constant.CtxKeyModel
+	ContextKeyRequestModel   = constant.CtxKeyRequestModel
+	ContextKeyScenario       = constant.CtxKeyScenario
+	ContextKeyStreamed       = constant.CtxKeyStreamed
+	ContextKeyStartTime      = constant.CtxKeyStartTime
+	ContextKeyFirstTokenTime = constant.CtxKeyFirstTokenTime
+	ContextKeyCacheHit       = constant.CtxKeyCacheHit
+	ContextKeySessionID      = constant.CtxKeySessionID
+	ContextKeyLBServiceID    = constant.CtxKeyLBServiceID
+	ContextKeyLBTactic       = constant.CtxKeyLBTactic
 )
 
 // SetTrackingContext sets all tracking metadata in the gin context.


### PR DESCRIPTION
## Summary
Debugging load-balancer behavior previously required manually piecing together log lines. 

This PR makes the routing and failover path fully observable: every request now includes the selected upstream (`lb_service_id`) and tactic (`lb_tactic`) in its access log, and failover retries emit structured fields instead of format strings.

### Major
- **Centralized context keys**: Tracking key strings that were duplicated across `server/`, `routing/`, and `middleware/` are now defined once in `internal/constant/tracking_ctx.go`, eliminating silent divergence bugs.
- **LB trajectory in access log**: `SimpleSelector` stores the selected service ID and tactic name on the Gin context; `MultiModeMemoryLogMiddleware` reads these to log which upstream was actually used and how it was chosen.
- **Structured failover logs**: Retry and give-up events in `dispatchWithPriorityFailover` now carry `stage`, `attempt`, `status`, `from_service`, `to_provider`, and `to_model` as discrete fields, making them directly filterable in log aggregators.

### Minor
- Give-up log level upgraded from `Debug` to `Warn` so it surfaces in production without enabling verbose logging.
- `tracking_context.go` constants are now aliases to `constant.*` — backward compatible, no call-site changes needed.
- Added `failover_logging_test.go` with two sub-tests (`retry_then_succeed`, `all_services_fail_give_up`) that hook into logrus and assert structured fields.