### PR TITLE
Bugfix(rule, flag): Fix rule flag preservation when switching service models

### DIFF
--- a/frontend/src/components/rule-card/ruleUpdatePayload.test.ts
+++ b/frontend/src/components/rule-card/ruleUpdatePayload.test.ts
@@ -1,0 +1,77 @@
+import { buildRuleUpdatePayload } from './ruleUpdatePayload';
+import type { ConfigRecord, Rule } from '@/components/RoutingGraphTypes';
+
+const baseRule: Pick<Rule, 'uuid' | 'scenario'> = {
+    uuid: 'rule-1',
+    scenario: 'anthropic',
+};
+
+function makeConfig(overrides: Partial<ConfigRecord> = {}): ConfigRecord {
+    return {
+        uuid: 'rule-1',
+        scenario: 'anthropic',
+        requestModel: 'gpt-4',
+        responseModel: '',
+        active: true,
+        description: 'desc',
+        flags: { cursorCompat: true, skipUsage: true },
+        providers: [
+            { uuid: 'svc-1', provider: 'prov-1', model: 'old-model', tier: 0 },
+        ],
+        smartEnabled: false,
+        smartRouting: [],
+        ...overrides,
+    };
+}
+
+describe('buildRuleUpdatePayload', () => {
+    it('includes flags (snake_case) so switching a model never wipes them', () => {
+        // Simulate the model-select path: same config, but the service model
+        // swapped to a new model — flags must survive the update payload.
+        const switched = makeConfig({
+            providers: [{ uuid: 'svc-1', provider: 'prov-2', model: 'new-model', tier: 0 }],
+        });
+
+        const payload = buildRuleUpdatePayload(baseRule, switched);
+
+        expect(payload.flags).toEqual({ cursor_compat: true, skip_usage: true });
+        expect(payload.services).toEqual([
+            { provider: 'prov-2', model: 'new-model', weight: 0, active: true, time_window: 0, tier: 0 },
+        ]);
+    });
+
+    it('emits an empty flags object (never undefined) when the rule has no flags', () => {
+        const payload = buildRuleUpdatePayload(baseRule, makeConfig({ flags: undefined }));
+        expect(payload.flags).toEqual({});
+    });
+
+    it('carries the full set of replace-semantics fields', () => {
+        const payload = buildRuleUpdatePayload(baseRule, makeConfig());
+        expect(payload).toMatchObject({
+            uuid: 'rule-1',
+            scenario: 'anthropic',
+            request_model: 'gpt-4',
+            response_model: '',
+            active: true,
+            description: 'desc',
+            smart_enabled: false,
+            smart_routing: [],
+        });
+    });
+
+    it('drops services missing a provider or model', () => {
+        const payload = buildRuleUpdatePayload(
+            baseRule,
+            makeConfig({
+                providers: [
+                    { uuid: 'a', provider: 'prov-1', model: 'm1' },
+                    { uuid: 'b', provider: '', model: 'm2' },
+                    { uuid: 'c', provider: 'prov-3', model: '' },
+                ],
+            }),
+        );
+        expect(payload.services).toEqual([
+            { provider: 'prov-1', model: 'm1', weight: 0, active: true, time_window: 0, tier: 0 },
+        ]);
+    });
+});

--- a/frontend/src/components/rule-card/ruleUpdatePayload.ts
+++ b/frontend/src/components/rule-card/ruleUpdatePayload.ts
@@ -1,0 +1,61 @@
+import type { ConfigRecord, Rule, RuleFlagsApi, SmartRouting } from '@/components/RoutingGraphTypes';
+import { flagsToApi } from './flagHelpers';
+
+export interface RuleUpdateService {
+    provider: string;
+    model: string;
+    weight: number;
+    active: boolean;
+    time_window: number;
+    tier: number;
+}
+
+export interface RuleUpdatePayload {
+    uuid: string;
+    scenario: string;
+    request_model: string;
+    response_model: string;
+    active: boolean;
+    description?: string;
+    flags: RuleFlagsApi;
+    services: RuleUpdateService[];
+    smart_enabled: boolean;
+    smart_routing: SmartRouting[];
+}
+
+/**
+ * Builds the full rule-update request body from a ConfigRecord.
+ *
+ * The UpdateRule endpoint uses full-replace (PUT) semantics: every field the
+ * backend persists must be present here, otherwise it gets cleared. In
+ * particular `flags` MUST always be included — omitting it on the model-select
+ * path was the cause of the "switching a rule's model wiped its flags" bug.
+ * Centralizing the payload here keeps every call site (model-select dialog,
+ * rule-card auto-save) in sync so a field can't silently go missing on one path.
+ */
+export function buildRuleUpdatePayload(
+    rule: Pick<Rule, 'uuid' | 'scenario'>,
+    config: ConfigRecord,
+): RuleUpdatePayload {
+    return {
+        uuid: rule.uuid,
+        scenario: rule.scenario,
+        request_model: config.requestModel,
+        response_model: config.responseModel,
+        active: config.active,
+        description: config.description,
+        flags: flagsToApi(config.flags),
+        services: config.providers
+            .filter((p) => p.provider && p.model)
+            .map((provider) => ({
+                provider: provider.provider,
+                model: provider.model,
+                weight: provider.weight || 0,
+                active: provider.active !== undefined ? provider.active : true,
+                time_window: provider.time_window || 0,
+                tier: provider.tier ?? 0,
+            })),
+        smart_enabled: config.smartEnabled || false,
+        smart_routing: config.smartRouting || [],
+    };
+}

--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -13,7 +13,7 @@ import {
     pickLbTactic,
     type ExportFormat,
 } from './utils';
-import { flagsToApi } from './flagHelpers';
+import { buildRuleUpdatePayload } from './ruleUpdatePayload';
 
 // ============================================================================
 // Types
@@ -108,27 +108,7 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
 
             try {
                 const lbTactic = pickLbTactic(newConfigRecord);
-                const ruleData: Record<string, any> = {
-                    uuid: rule.uuid,
-                    scenario: rule.scenario,
-                    request_model: newConfigRecord.requestModel,
-                    response_model: newConfigRecord.responseModel,
-                    active: newConfigRecord.active,
-                    description: newConfigRecord.description,
-                    flags: flagsToApi(newConfigRecord.flags),
-                    services: newConfigRecord.providers
-                        .filter((p) => p.provider && p.model)
-                        .map((provider) => ({
-                            provider: provider.provider,
-                            model: provider.model,
-                            weight: provider.weight || 0,
-                            active: provider.active !== undefined ? provider.active : true,
-                            time_window: provider.time_window || 0,
-                            tier: provider.tier ?? 0,
-                        })),
-                    smart_enabled: newConfigRecord.smartEnabled || false,
-                    smart_routing: newConfigRecord.smartRouting || [],
-                };
+                const ruleData: Record<string, any> = buildRuleUpdatePayload(rule, newConfigRecord);
                 if (lbTactic) {
                     ruleData.lb_tactic = lbTactic;
                 }

--- a/frontend/src/hooks/useModelSelectDialog.tsx
+++ b/frontend/src/hooks/useModelSelectDialog.tsx
@@ -5,6 +5,7 @@ import ModelSelectDialog, { type ProviderSelectTabOption } from '@/components/Mo
 import type { ConfigRecord, Rule } from '@/components/RoutingGraphTypes.ts';
 import { v4 as uuidv4 } from 'uuid';
 import api from "@/services/api.ts";
+import { flagsToApi } from '@/components/rule-card/flagHelpers';
 
 export interface ModelSelectOptions {
     ruleUuid: string;
@@ -218,6 +219,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
                 response_model: updated.responseModel,
                 active: updated.active,
                 description: updated.description,
+                flags: flagsToApi(updated.flags),
                 services: updated.providers
                     .filter(p => p.provider && p.model)
                     .map(provider => ({
@@ -243,6 +245,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
                             response_model: ruleData.response_model,
                             active: ruleData.active,
                             description: ruleData.description,
+                            flags: ruleData.flags,
                             services: ruleData.services,
                             smart_enabled: ruleData.smart_enabled,
                             smart_routing: ruleData.smart_routing,

--- a/frontend/src/hooks/useModelSelectDialog.tsx
+++ b/frontend/src/hooks/useModelSelectDialog.tsx
@@ -5,7 +5,7 @@ import ModelSelectDialog, { type ProviderSelectTabOption } from '@/components/Mo
 import type { ConfigRecord, Rule } from '@/components/RoutingGraphTypes.ts';
 import { v4 as uuidv4 } from 'uuid';
 import api from "@/services/api.ts";
-import { flagsToApi } from '@/components/rule-card/flagHelpers';
+import { buildRuleUpdatePayload } from '@/components/rule-card/ruleUpdatePayload';
 
 export interface ModelSelectOptions {
     ruleUuid: string;
@@ -212,27 +212,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         // Save to backend
         const rule = rules.find(r => r.uuid === currentRuleUuid);
         if (rule && updated) {
-            const ruleData = {
-                uuid: rule.uuid,
-                scenario: rule.scenario,
-                request_model: updated.requestModel,
-                response_model: updated.responseModel,
-                active: updated.active,
-                description: updated.description,
-                flags: flagsToApi(updated.flags),
-                services: updated.providers
-                    .filter(p => p.provider && p.model)
-                    .map(provider => ({
-                        provider: provider.provider,
-                        model: provider.model,
-                        weight: provider.weight || 0,
-                        active: provider.active !== undefined ? provider.active : true,
-                        time_window: provider.time_window || 0,
-                        tier: provider.tier ?? 0,
-                    })),
-                smart_enabled: updated.smartEnabled || false,
-                smart_routing: updated.smartRouting || [],
-            };
+            const ruleData = buildRuleUpdatePayload(rule, updated);
 
             api.updateRule(rule.uuid, ruleData).then((result) => {
                 if (result.success) {

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -384,6 +384,91 @@ func TestUpdateRule_Success(t *testing.T) {
 	}
 }
 
+// TestUpdateRule_ModelChangePreservesFlags locks the contract behind the
+// "switching a rule's model wiped its flags" bug. The endpoint uses full-replace
+// (PUT) semantics, so the frontend must send the complete rule — including flags —
+// on every update. This test mirrors the corrected model-switch payload: it changes
+// the service model while carrying the existing flags, and asserts they survive.
+func TestUpdateRule_ModelChangePreservesFlags(t *testing.T) {
+	registerTestRuleScenario(t, typ.RuleScenario("test-scenario"))
+
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg)
+
+	router.PUT("/rules/:uuid", handler.UpdateRule)
+
+	// A provider the rule's services can reference (validateRuleServices requires it).
+	provider := &typ.Provider{
+		UUID:     "prov-flags-1",
+		Name:     "FlagProvider",
+		APIBase:  "https://api.test.com",
+		APIStyle: protocol.APIStyleOpenAI,
+		AuthType: typ.AuthTypeAPIKey,
+		Token:    "sk-test",
+		Enabled:  true,
+	}
+	cfg.AddProvider(provider)
+
+	// Original rule with flags set and a service pointing at the old model.
+	testUUID := uuid.New().String()
+	originalRule := typ.Rule{
+		UUID:         testUUID,
+		RequestModel: "gpt-4",
+		Scenario:     "test-scenario",
+		Active:       true,
+		Flags: typ.RuleFlags{
+			CursorCompat: true,
+			SkipUsage:    true,
+		},
+		Services: []*loadbalance.Service{
+			{Provider: provider.UUID, Model: "old-model", Weight: 100},
+		},
+	}
+	if err := cfg.AddRule(originalRule); err != nil {
+		t.Fatalf("Failed to add test rule: %v", err)
+	}
+
+	// Update payload: model switched to "new-model", flags carried along (as the
+	// fixed frontend now does). Flags must still be present after the update.
+	updatedRule := typ.Rule{
+		RequestModel: "gpt-4",
+		Scenario:     "test-scenario",
+		Active:       true,
+		Flags: typ.RuleFlags{
+			CursorCompat: true,
+			SkipUsage:    true,
+		},
+		Services: []*loadbalance.Service{
+			{Provider: provider.UUID, Model: "new-model", Weight: 100},
+		},
+	}
+	body, _ := json.Marshal(updatedRule)
+	req, _ := http.NewRequest("PUT", "/rules/"+testUUID, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	retrieved := cfg.GetRuleByUUID(testUUID)
+	if retrieved == nil {
+		t.Fatal("Rule not found after update")
+	}
+	if len(retrieved.Services) != 1 || retrieved.Services[0].Model != "new-model" {
+		t.Fatalf("expected service model 'new-model', got %+v", retrieved.Services)
+	}
+	if !retrieved.Flags.CursorCompat {
+		t.Error("CursorCompat flag was cleared after a model-changing update")
+	}
+	if !retrieved.Flags.SkipUsage {
+		t.Error("SkipUsage flag was cleared after a model-changing update")
+	}
+}
+
 func TestDeleteRule_Success(t *testing.T) {
 	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Summary
Fixes a bug where updating a rule's service model would clear all rule flags. The root cause was that the frontend's model-select dialog was not including the `flags` field in the update payload, and the backend's PUT endpoint uses full-replace semantics (any omitted field gets cleared).

## Changes

### Backend
- **`internal/server/module/rule/handler_test.go`**: Added `TestUpdateRule_ModelChangePreservesFlags` test that locks the contract: when a rule's service model is switched while carrying existing flags in the payload, those flags must survive the update.

### Frontend
- **`frontend/src/components/rule-card/ruleUpdatePayload.ts`** (new): Centralized payload builder that ensures all required fields (especially `flags`) are always included in rule update requests. This prevents the bug from recurring on any code path that updates rules.
  
- **`frontend/src/components/rule-card/ruleUpdatePayload.test.ts`** (new): Comprehensive test suite verifying:
  - Flags are preserved when switching models
  - Flags are always present (never undefined) in the payload
  - All full-replace semantics fields are included
  - Invalid services (missing provider or model) are filtered out

- **`frontend/src/components/rule-card/useRuleCardHooks.ts`**: Refactored auto-save to use `buildRuleUpdatePayload()` instead of inline payload construction, eliminating duplication and ensuring consistency.

- **`frontend/src/hooks/useModelSelectDialog.tsx`**: Refactored model-select dialog to use `buildRuleUpdatePayload()` and now correctly includes `flags` in the state update after a successful backend save.

## Implementation Details
The `buildRuleUpdatePayload()` function is the single source of truth for rule update payloads. It:
- Always includes `flags` (converted to snake_case via `flagsToApi()`)
- Filters out services with missing provider or model
- Normalizes all optional fields with sensible defaults
- Ensures both the auto-save and model-select paths stay in sync

This prevents silent field omissions that could cause data loss on future changes.

https://claude.ai/code/session_01XsU5TGLCvWgcVPuspzDMF5