### PR TITLE
harness(protocol, gateway): propagate upstream error status, fix truncated-stream OOM & non-deterministic routing (+ harness error/idempotence modeling)

### DIFF
--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -20,9 +20,9 @@ type MatrixCmd struct {
 	Scenarios  []string `kong:"name='scenario',sep=',',help='Filter by scenario name (can repeat or comma-separate)'"`
 	Sources    []string `kong:"name='source',sep=',',help='Filter by source protocol (can repeat or comma-separate)'"`
 	Targets    []string `kong:"name='target',sep=',',help='Filter by target protocol (can repeat or comma-separate)'"`
-	Streaming  bool   `kong:"name='streaming',help='Run only streaming tests'"`
-	NonStream  bool   `kong:"name='non-streaming',help='Run only non-streaming tests'"`
-	Mode       string `kong:"name='mode',default='all',enum='all,single,transitive',help='Hop selection: all (default), single (A→B only), transitive (A→B→C only)'"`
+	Streaming  bool     `kong:"name='streaming',help='Run only streaming tests'"`
+	NonStream  bool     `kong:"name='non-streaming',help='Run only non-streaming tests'"`
+	Mode       string   `kong:"name='mode',default='default',enum='default,all,single,transitive,idempotent',help='Section selection: default (single + idempotent round-trip; two-hop OFF), all (single + transitive + idempotent), single (A→B only), transitive (A→B→C only), idempotent (round-trip g(f(A))==A only)'"`
 	JsonOutput bool     `kong:"name='json',help='Output results as JSON'"`
 	Verbose    int      `kong:"name='verbose',short='v',type='counter',help='Verbose output (repeat for more detail)'"`
 	RecordDir  string   `kong:"name='record-dir',env='HARNESS_RECORD_DIR',help='Directory for recording requests/responses (default: disabled)'"`
@@ -34,11 +34,18 @@ type MatrixCmd struct {
 // Help returns extended help text shown by `harness matrix --help`.
 func (*MatrixCmd) Help() string {
 	return `Examples:
-  # Run everything: single-hop + two-hop (default)
+  # Default: single-hop (A→B) + idempotent round-trips (g(f(A))==A).
+  # Two-hop (A→B→C) transitive chains are OFF by default.
   harness matrix
+
+  # Run absolutely everything: single + two-hop + idempotent
+  harness matrix --mode=all
 
   # Run only two-hop (A→B→C) transitive chain tests
   harness matrix --mode=transitive
+
+  # Run only idempotent round-trip tests
+  harness matrix --mode=idempotent
 
   # Run only single-hop (A→B) tests
   harness matrix --mode=single
@@ -112,13 +119,20 @@ func (m *MatrixCmd) Run() error {
 		matrix = matrix.WithMCPEnabled()
 	}
 
-	// Collect results for selected hop sections (--mode controls which).
+	// Collect results for the selected sections (--mode controls which).
+	//
+	//   single-hop (A→B)        runs unless mode is transitive/idempotent
+	//   transitive (A→B→C)      runs only for all/transitive (OFF by default)
+	//   idempotent (g(f(A))==A) runs for default/all/idempotent
 	var combined []protocoltest.TestResult
-	if m.Mode != "transitive" {
+	if m.Mode != "transitive" && m.Mode != "idempotent" {
 		combined = append(combined, matrix.ExecuteAll()...)
 	}
-	if m.Mode != "single" {
+	if m.Mode == "all" || m.Mode == "transitive" {
 		combined = append(combined, matrix.ExecuteAllTransitive()...)
+	}
+	if m.Mode == "default" || m.Mode == "all" || m.Mode == "idempotent" {
+		combined = append(combined, matrix.ExecuteAllIdempotent()...)
 	}
 	results := filterResults(combined, m)
 
@@ -172,4 +186,3 @@ func contains(slice []string, item string) bool {
 	}
 	return false
 }
-

--- a/internal/protocol/stream/anthropic_helper.go
+++ b/internal/protocol/stream/anthropic_helper.go
@@ -69,10 +69,14 @@ func SendInvalidRequestBodyError(c *gin.Context, err error) {
 	})
 }
 
-// SendStreamingError sends an error response for streaming request failures
+// SendStreamingError sends an error response for streaming request failures.
+// When the failure occurs before any SSE frame has been written (the caller
+// guards this with conv.MessageStarted()), the HTTP status is still settable, so
+// we propagate the upstream provider's status (401/429/4xx) instead of
+// flattening every pre-stream failure into a 500.
 func SendStreamingError(c *gin.Context, err error) {
 	c.Error(err).SetType(gin.ErrorTypePublic) //nolint:errcheck
-	c.JSON(http.StatusInternalServerError, protocol.ErrorResponse{
+	c.JSON(protocol.UpstreamStatus(err, http.StatusInternalServerError), protocol.ErrorResponse{
 		Error: protocol.ErrorDetail{
 			Message: "Failed to create streaming request: " + err.Error(),
 			Type:    "api_error",
@@ -80,10 +84,11 @@ func SendStreamingError(c *gin.Context, err error) {
 	})
 }
 
-// SendForwardingError sends an error response for request forwarding failures
+// SendForwardingError sends an error response for request forwarding failures,
+// propagating the upstream provider's HTTP status when the error carries one.
 func SendForwardingError(c *gin.Context, err error) {
 	c.Error(err).SetType(gin.ErrorTypePublic) //nolint:errcheck
-	c.JSON(http.StatusInternalServerError, protocol.ErrorResponse{
+	c.JSON(protocol.UpstreamStatus(err, http.StatusInternalServerError), protocol.ErrorResponse{
 		Error: protocol.ErrorDetail{
 			Message: "Failed to forward request: " + err.Error(),
 			Type:    "api_error",

--- a/internal/protocol/stream/openai_responses_to_chat_converter.go
+++ b/internal/protocol/stream/openai_responses_to_chat_converter.go
@@ -249,6 +249,12 @@ func (c *responsesToChatConverter) emitCompletedOutput(output []responses.Respon
 }
 
 func (c *responsesToChatConverter) emitFallbackCompletion() {
+	// Mark completed first: this runs when the upstream stream ended without a
+	// response.completed event (e.g. a truncated / mid-stream-cut stream). The
+	// terminal chunk is emitted exactly once — without this flag the Next() loop
+	// would re-enter on the next exhausted stream.Next() and re-emit the
+	// fallback forever, flushing chunks unboundedly until the process OOMs.
+	c.completed = true
 	if !c.hasSentCreated {
 		c.pending = append(c.pending, c.roleChunk())
 	}

--- a/internal/protocol/upstream_error.go
+++ b/internal/protocol/upstream_error.go
@@ -1,0 +1,38 @@
+package protocol
+
+import (
+	"errors"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"google.golang.org/genai"
+)
+
+// UpstreamStatus extracts the HTTP status code that an upstream provider
+// returned, so the gateway can propagate it to the client instead of flattening
+// every forwarding failure into a 500. It understands the error types returned
+// by each vendor SDK (OpenAI / Anthropic share apierror.Error; google-genai
+// uses genai.APIError). When the error does not carry a usable upstream status
+// (e.g. a transport-level failure with no HTTP response), it returns fallback.
+func UpstreamStatus(err error, fallback int) int {
+	if err == nil {
+		return fallback
+	}
+
+	var oaiErr *openai.Error
+	if errors.As(err, &oaiErr) && oaiErr.StatusCode >= 400 {
+		return oaiErr.StatusCode
+	}
+
+	var anthropicErr *anthropic.Error
+	if errors.As(err, &anthropicErr) && anthropicErr.StatusCode >= 400 {
+		return anthropicErr.StatusCode
+	}
+
+	var genaiErr genai.APIError
+	if errors.As(err, &genaiErr) && genaiErr.Code >= 400 {
+		return genaiErr.Code
+	}
+
+	return fallback
+}

--- a/internal/protocoltest/idempotent.go
+++ b/internal/protocoltest/idempotent.go
@@ -3,6 +3,7 @@ package protocoltest
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -240,6 +241,136 @@ func (m *Matrix) RunIdempotent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ExecuteAllIdempotent runs round-trip idempotency tests without requiring
+// testing.T. It is the CLI-compatible counterpart of RunIdempotent, returning
+// []TestResult. For each scenario × case × mode it wires the baseline and
+// round-trip routes in one gateway, drives both requests, and records whether
+// the client-visible results are semantically equivalent (g(f(A)) == A).
+//
+// Name format: "scenario/<case>/mode" (e.g. "text/openai_chat_via_anthropic/stream").
+func (m *Matrix) ExecuteAllIdempotent() []TestResult {
+	var results []TestResult
+	cases := DefaultIdempotentCases()
+
+	for _, scenario := range m.Scenarios {
+		// Error propagation through two hops is out of scope: the inner gateway
+		// wraps upstream errors, so the byte-for-byte error shape is not
+		// expected to survive a round-trip.
+		if scenario.Name == "error" {
+			continue
+		}
+
+		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
+		if err != nil {
+			for _, ic := range cases {
+				for _, streaming := range m.Streaming {
+					results = append(results, TestResult{
+						Name:      idempotentTestName(scenario.Name, ic, streaming),
+						Scenario:  scenario.Name,
+						Source:    ic.Source,
+						Target:    ic.Mid,
+						Streaming: streaming,
+						Passed:    false,
+						Errors:    []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("failed to create test env: %v", err)}},
+					})
+				}
+			}
+			continue
+		}
+
+		for _, ic := range cases {
+			for _, streaming := range m.Streaming {
+				results = append(results, m.executeIdempotentCase(env, scenario, ic, streaming))
+			}
+		}
+		env.Close()
+	}
+	return results
+}
+
+func idempotentTestName(scenarioName string, ic IdempotentCase, streaming bool) string {
+	return fmt.Sprintf("%s/%s/%s", scenarioName, ic.Name, streamMode(streaming))
+}
+
+// executeIdempotentCase runs a single baseline-vs-round-trip comparison and
+// returns its TestResult.
+func (m *Matrix) executeIdempotentCase(env *TestEnv, scenario Scenario, ic IdempotentCase, streaming bool) TestResult {
+	base := TestResult{
+		Name:      idempotentTestName(scenario.Name, ic, streaming),
+		Scenario:  scenario.Name,
+		Source:    ic.Source,
+		Target:    ic.Mid,
+		Streaming: streaming,
+	}
+
+	if reason, skip := skipIdempotentScenario(ic, scenario.Name); skip {
+		base.Skipped = true
+		base.SkipReason = reason
+		return base
+	}
+	if reason, skip := streamingSkipReason(scenario, streaming); skip {
+		base.Skipped = true
+		base.SkipReason = reason
+		return base
+	}
+
+	start := time.Now()
+
+	// Baseline: A → A' passthrough through the virtual server.
+	env.SetupRoute(ic.Source, ic.Baseline, scenario)
+	baseModel := env.findRouteModel(ic.Source, ic.Baseline, scenario.Name)
+
+	// Chain tail: B → A' through the virtual server.
+	env.SetupRoute(ic.Mid, ic.Baseline, scenario)
+	tailModel := env.findRouteModel(ic.Mid, ic.Baseline, scenario.Name)
+
+	// Chain head: A → B, forwarding back into the gateway carrying tailModel.
+	headModel := fmt.Sprintf("idem-%s-%s", ic.Name, scenario.Name)
+	env.setupChainHopRoute(ic.Source, ic.Mid, scenario, headModel, tailModel)
+
+	baseline, err := env.sendModel(ic.Source, ic.Baseline, scenario.Name, baseModel, streaming)
+	if err != nil {
+		base.Passed = false
+		base.Errors = []AssertionError{{Assertion: "baseline:send", Error: err.Error()}}
+		base.Duration = time.Since(start)
+		return base
+	}
+	roundtrip, err := env.sendModel(ic.Source, ic.Mid, scenario.Name, headModel, streaming)
+	if err != nil {
+		base.Passed = false
+		base.Errors = []AssertionError{{Assertion: "roundtrip:send", Error: err.Error()}}
+		base.Duration = time.Since(start)
+		return base
+	}
+
+	var errs []AssertionError
+	for _, a := range scenario.Assertions {
+		if checkErr := a.Check(baseline); checkErr != nil {
+			errs = append(errs, AssertionError{
+				Assertion: "baseline:" + a.Name,
+				Error:     checkErr.Error(),
+				Context:   truncate(string(baseline.RawBody), 300),
+			})
+		}
+		if checkErr := a.Check(roundtrip); checkErr != nil {
+			errs = append(errs, AssertionError{
+				Assertion: "roundtrip:" + a.Name,
+				Error:     checkErr.Error(),
+				Context:   truncate(string(roundtrip.RawBody), 300),
+			})
+		}
+	}
+	label := fmt.Sprintf("%s→%s→%s vs %s→%s", ic.Source, ic.Mid, ic.Baseline, ic.Source, ic.Baseline)
+	errs = append(errs, semanticEquivalenceErrors(label, baseline, roundtrip)...)
+
+	base.Passed = len(errs) == 0
+	base.Errors = errs
+	base.Duration = time.Since(start)
+	base.HTTPStatus = roundtrip.HTTPStatus
+	base.Response = roundtrip
+	return base
 }
 
 // skipIdempotentScenario reports whether a case+scenario should be skipped

--- a/internal/protocoltest/scenarios.go
+++ b/internal/protocoltest/scenarios.go
@@ -31,6 +31,14 @@ const (
 type MockResponseBuilder struct {
 	NonStream func() (statusCode int, body []byte)
 	Stream    func() []string
+
+	// StreamHTTPError, when >= 400, makes the streaming endpoint reply with this
+	// HTTP status and the NonStream JSON body instead of a 200 SSE stream. It
+	// models pre-content failures (auth / rate-limit / 5xx) that real providers
+	// surface as an HTTP error even for streaming requests — the failure happens
+	// before any SSE frame is written, so the status line itself carries it.
+	// Mid-stream failures leave this zero and use the 200 + SSE path.
+	StreamHTTPError int
 }
 
 // Scenario is a named test scenario describing what the mock provider returns
@@ -736,8 +744,10 @@ func ErrorMidStreamCloseScenario() Scenario {
 		Tags:           []string{"error", "midstream"},
 		SkipTransitive: true,
 		MockResponses: map[ResponseFormat]MockResponseBuilder{
-			FormatOpenAIChat: BuildErrorFromSpec(FormatOpenAIChat, specClose),
-			FormatAnthropic:  BuildErrorFromSpec(FormatAnthropic, specClose),
+			FormatOpenAIChat:      BuildErrorFromSpec(FormatOpenAIChat, specClose),
+			FormatOpenAIResponses: BuildErrorFromSpec(FormatOpenAIResponses, specClose),
+			FormatAnthropic:       BuildErrorFromSpec(FormatAnthropic, specClose),
+			FormatGoogle:          BuildErrorFromSpec(FormatGoogle, specClose),
 		},
 		Assertions: []Assertion{
 			AssertHTTPStatus(200),
@@ -950,6 +960,14 @@ func BuildErrorFromSpec(format ResponseFormat, spec vmodel.SharedMockSpec) MockR
 		return MockResponseBuilder{} // No error configured
 	}
 
+	// Mid-stream failures are not HTTP-level errors: the upstream starts a
+	// normal 200 response, emits partial content, then the connection drops. We
+	// model that as a truncated content stream so the gateway forwards a 200
+	// with the partial body (rather than an error envelope).
+	if spec.Error.Stage == vmodel.ErrorStageMidStream {
+		return buildMidStreamTruncated(format, spec.Content)
+	}
+
 	switch format {
 	case FormatOpenAIChat, FormatOpenAIResponses:
 		return buildOpenAIError(spec.Error)
@@ -957,6 +975,104 @@ func BuildErrorFromSpec(format ResponseFormat, spec vmodel.SharedMockSpec) MockR
 		return buildAnthropicError(spec.Error)
 	case FormatGoogle:
 		return buildGoogleError(spec.Error)
+	default:
+		return MockResponseBuilder{}
+	}
+}
+
+// buildMidStreamTruncated produces a 200 response whose streaming variant emits
+// partial content and then stops without the terminal frames ([DONE] /
+// message_stop), simulating a provider connection that drops mid-stream. The
+// non-streaming variant returns the same text as a complete 200 body, since a
+// non-streaming request cannot observe a mid-stream cut. content is the partial
+// text the client should still receive (e.g. "...this stream will be truncated").
+func buildMidStreamTruncated(format ResponseFormat, content string) MockResponseBuilder {
+	if content == "" {
+		content = "partial content before the stream was truncated"
+	}
+	switch format {
+	case FormatOpenAIChat:
+		body := map[string]interface{}{
+			"id":      "chatcmpl-validate-midstream",
+			"object":  "chat.completion",
+			"created": time.Now().Unix(),
+			"model":   "gpt-4o",
+			"choices": []map[string]interface{}{
+				{
+					"index":         0,
+					"message":       map[string]interface{}{"role": "assistant", "content": content},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]interface{}{"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18},
+		}
+		return MockResponseBuilder{
+			NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+			Stream: func() []string {
+				delta := mustMarshal(map[string]interface{}{
+					"id": "chatcmpl-validate-midstream", "object": "chat.completion.chunk",
+					"created": 1700000000, "model": "gpt-4o",
+					"choices": []map[string]interface{}{{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": content}, "finish_reason": nil}},
+				})
+				// No finish_reason chunk and no `[DONE]`: the stream is cut short.
+				return []string{"data: " + string(delta)}
+			},
+		}
+	case FormatOpenAIResponses:
+		body := map[string]interface{}{
+			"id": "resp-validate-midstream", "object": "realtime.response", "model": "gpt-4o", "status": "completed",
+			"output": []map[string]interface{}{{
+				"id": "item-validate-midstream", "type": "message", "role": "assistant", "status": "completed",
+				"content": []map[string]interface{}{{"type": "output_text", "text": content}},
+			}},
+			"usage": map[string]interface{}{"input_tokens": 10, "output_tokens": 8, "total_tokens": 18},
+		}
+		return MockResponseBuilder{
+			NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+			Stream: func() []string {
+				created := `data: {"type":"response.created","response":{"id":"resp-validate-midstream","object":"realtime.response","model":"gpt-4o","status":"in_progress","output":[]}}`
+				added := `data: {"type":"response.output_item.added","response_id":"resp-validate-midstream","item":{"id":"item-validate-midstream","type":"message","role":"assistant","status":"in_progress","content":[]}}`
+				delta := mustMarshal(map[string]interface{}{"type": "response.output_text.delta", "response_id": "resp-validate-midstream", "item_id": "item-validate-midstream", "output_index": 0, "content_index": 0, "delta": content})
+				// No response.output_text.done / response.completed / [DONE]: cut short.
+				return []string{created, added, "data: " + string(delta)}
+			},
+		}
+	case FormatAnthropic:
+		body := map[string]interface{}{
+			"id": "msg-validate-midstream", "type": "message", "role": "assistant",
+			"content":     []map[string]interface{}{{"type": "text", "text": content}},
+			"model":       "claude-3-5-sonnet-20241022",
+			"stop_reason": "end_turn", "stop_sequence": nil,
+			"usage": map[string]interface{}{"input_tokens": 10, "output_tokens": 8},
+		}
+		return MockResponseBuilder{
+			NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+			Stream: func() []string {
+				start := mustMarshal(map[string]interface{}{"type": "message_start", "message": map[string]interface{}{"id": "msg-validate-midstream", "type": "message", "role": "assistant", "content": []interface{}{}, "model": "claude-3-5-sonnet-20241022", "stop_reason": nil, "usage": map[string]interface{}{"input_tokens": 10, "output_tokens": 0}}})
+				delta := mustMarshal(map[string]interface{}{"type": "content_block_delta", "index": 0, "delta": map[string]interface{}{"type": "text_delta", "text": content}})
+				// No content_block_stop / message_delta / message_stop: cut short.
+				return []string{
+					"event: message_start", "data: " + string(start),
+					"event: content_block_start", `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+					"event: content_block_delta", "data: " + string(delta),
+				}
+			},
+		}
+	case FormatGoogle:
+		body := map[string]interface{}{
+			"candidates": []map[string]interface{}{{
+				"content": map[string]interface{}{"role": "model", "parts": []map[string]interface{}{{"text": content}}},
+				"index":   0,
+			}},
+			"usageMetadata": map[string]interface{}{"promptTokenCount": 10, "candidatesTokenCount": 8, "totalTokenCount": 18},
+		}
+		return MockResponseBuilder{
+			NonStream: func() (int, []byte) { return 200, mustMarshal(body) },
+			Stream: func() []string {
+				chunk := mustMarshal(map[string]interface{}{"candidates": []map[string]interface{}{{"content": map[string]interface{}{"role": "model", "parts": []map[string]interface{}{{"text": content}}}, "index": 0}}})
+				return []string{"data: " + string(chunk)}
+			},
+		}
 	default:
 		return MockResponseBuilder{}
 	}
@@ -978,9 +1094,20 @@ func buildOpenAIError(err *vmodel.ErrorInjection) MockResponseBuilder {
 	streamLine := fmt.Sprintf("data: %s", string(streamPayload))
 
 	return MockResponseBuilder{
-		NonStream: func() (int, []byte) { return status, mustMarshal(body) },
-		Stream:    func() []string { return []string{streamLine} },
+		NonStream:       func() (int, []byte) { return status, mustMarshal(body) },
+		Stream:          func() []string { return []string{streamLine} },
+		StreamHTTPError: preContentStreamStatus(err, status),
 	}
+}
+
+// preContentStreamStatus returns the HTTP status a streaming request should fail
+// with for a pre-content error injection, or 0 for mid-stream injections (which
+// must reply 200 and surface the failure inside the SSE stream).
+func preContentStreamStatus(err *vmodel.ErrorInjection, status int) int {
+	if err != nil && err.Stage == vmodel.ErrorStagePreContent {
+		return status
+	}
+	return 0
 }
 
 // normalizeErrorSpec centralizes default value logic for error injection fields.
@@ -1021,8 +1148,9 @@ func buildAnthropicError(err *vmodel.ErrorInjection) MockResponseBuilder {
 	}
 
 	return MockResponseBuilder{
-		NonStream: func() (int, []byte) { return status, mustMarshal(body) },
-		Stream:    func() []string { return streamLines },
+		NonStream:       func() (int, []byte) { return status, mustMarshal(body) },
+		Stream:          func() []string { return streamLines },
+		StreamHTTPError: preContentStreamStatus(err, status),
 	}
 }
 
@@ -1043,8 +1171,9 @@ func buildGoogleError(err *vmodel.ErrorInjection) MockResponseBuilder {
 	streamLine := fmt.Sprintf("data: %s", string(streamPayload))
 
 	return MockResponseBuilder{
-		NonStream: func() (int, []byte) { return status, mustMarshal(body) },
-		Stream:    func() []string { return []string{streamLine} },
+		NonStream:       func() (int, []byte) { return status, mustMarshal(body) },
+		Stream:          func() []string { return []string{streamLine} },
+		StreamHTTPError: preContentStreamStatus(err, status),
 	}
 }
 

--- a/internal/protocoltest/virtual_server.go
+++ b/internal/protocoltest/virtual_server.go
@@ -134,6 +134,22 @@ func (vs *VirtualServer) recordHit(kind EndpointKind) {
 
 // ─── HTTP handlers ─────────────────────────────────────────────────────────────
 
+// writeBuilderResponse serves a MockResponseBuilder over HTTP. For streaming
+// requests it writes a 200 SSE stream, except when the builder declares a
+// pre-content HTTP error (StreamHTTPError >= 400) — those fail at the HTTP
+// status line, the same way a real provider rejects an auth/rate-limit/5xx error
+// before any SSE frame is emitted.
+func writeBuilderResponse(w http.ResponseWriter, builder MockResponseBuilder, streaming bool) {
+	if streaming && builder.StreamHTTPError < 400 {
+		sse.WriteSSEResponse(w, builder.Stream())
+		return
+	}
+	status, body := builder.NonStream()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(body)
+}
+
 func (vs *VirtualServer) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 	vs.recordHit(EndpointChat)
 
@@ -154,14 +170,7 @@ func (vs *VirtualServer) handleOpenAIChat(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if streaming {
-		sse.WriteSSEResponse(w, builder.Stream())
-	} else {
-		status, body := builder.NonStream()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		w.Write(body)
-	}
+	writeBuilderResponse(w, builder, streaming)
 }
 
 func (vs *VirtualServer) handleOpenAIResponses(w http.ResponseWriter, r *http.Request) {
@@ -188,14 +197,7 @@ func (vs *VirtualServer) handleOpenAIResponses(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	if streaming {
-		sse.WriteSSEResponse(w, builder.Stream())
-	} else {
-		status, body := builder.NonStream()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		w.Write(body)
-	}
+	writeBuilderResponse(w, builder, streaming)
 }
 
 func (vs *VirtualServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
@@ -218,14 +220,7 @@ func (vs *VirtualServer) handleAnthropicMessages(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if streaming {
-		sse.WriteSSEResponse(w, builder.Stream())
-	} else {
-		status, body := builder.NonStream()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		w.Write(body)
-	}
+	writeBuilderResponse(w, builder, streaming)
 }
 
 func (vs *VirtualServer) handleGoogle(w http.ResponseWriter, r *http.Request) {
@@ -248,14 +243,7 @@ func (vs *VirtualServer) handleGoogle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if streaming {
-		sse.WriteSSEResponse(w, builder.Stream())
-	} else {
-		status, body := builder.NonStream()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		w.Write(body)
-	}
+	writeBuilderResponse(w, builder, streaming)
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -264,7 +264,7 @@ func (s *Server) nonstreamOpenAIChat(c *gin.Context, provider *typ.Provider, ori
 		// Track error with no usage
 		usage := protocol.NewTokenUsageWithCache(0, 0, 0)
 		s.trackUsageWithTokenUsage(c, usage, err)
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
+		c.JSON(upstreamForwardStatus(err), ErrorResponse{
 			Error: ErrorDetail{
 				Message: "Failed to forward request: " + err.Error(),
 				Type:    "api_error",
@@ -347,7 +347,7 @@ func (s *Server) streamOpenAIChat(c *gin.Context, provider *typ.Provider, origin
 		// Track error with no usage
 		usage := protocol.NewTokenUsageWithCache(0, 0, 0)
 		s.trackUsageWithTokenUsage(c, usage, err)
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
+		c.JSON(upstreamForwardStatus(err), ErrorResponse{
 			Error: ErrorDetail{
 				Message: "Failed to create streaming request: " + err.Error(),
 				Type:    "api_error",

--- a/internal/server/openai_embeddings.go
+++ b/internal/server/openai_embeddings.go
@@ -142,7 +142,7 @@ func (s *Server) HandleOpenAIEmbeddings(c *gin.Context) {
 		usage := protocol.NewTokenUsageWithCache(0, 0, 0)
 		s.trackUsageWithTokenUsage(c, usage, err)
 		logrus.Errorf("Failed to forward embeddings request: %v", err)
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
+		c.JSON(upstreamForwardStatus(err), ErrorResponse{
 			Error: ErrorDetail{
 				Message: "Failed to forward request: " + err.Error(),
 				Type:    "api_error",

--- a/internal/server/openai_images.go
+++ b/internal/server/openai_images.go
@@ -137,7 +137,7 @@ func (s *Server) HandleOpenAIImageGeneration(c *gin.Context) {
 		usage := protocol.NewTokenUsageWithCache(0, 0, 0)
 		s.trackUsageWithTokenUsage(c, usage, err)
 		logrus.Errorf("Failed to forward image generation request: %v", err)
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
+		c.JSON(upstreamForwardStatus(err), ErrorResponse{
 			Error: ErrorDetail{
 				Message: "Failed to forward request: " + err.Error(),
 				Type:    "api_error",

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -286,7 +286,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 		}
 		if err != nil {
 			s.trackUsageFromContext(c, 0, 0, err)
-			SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
+			SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
 			if recorder != nil {
 				recorder.RecordError(err)
 			}
@@ -303,7 +303,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 				// Track error even when no tokens were received (e.g., early 1302 rate limit)
 				s.trackUsageFromContext(c, 0, 0, err)
 			}
-			SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
+			SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
 			if recorder != nil {
 				recorder.RecordError(err)
 			}
@@ -341,7 +341,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 			}
 			if forwardErr != nil {
 				s.trackUsageFromContext(c, 0, 0, forwardErr)
-				SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to forward Anthropic request: : %w", forwardErr), "api_error")
+				SendErrorResponse(c, upstreamForwardStatus(forwardErr), fmt.Errorf("Failed to forward Anthropic request: : %w", forwardErr), "api_error")
 				if recorder != nil {
 					recorder.RecordError(forwardErr)
 				}
@@ -876,7 +876,7 @@ func (s *Server) nonstreamResponsesToChat(c *gin.Context, reqCtx *transform.Tran
 	}
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to forward request: : %w", err), "api_error")
+		SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to forward request: : %w", err), "api_error")
 		if recorder != nil {
 			recorder.RecordError(err)
 		}
@@ -904,7 +904,7 @@ func (s *Server) nonstreamOpenAIResponses(c *gin.Context, reqCtx *transform.Tran
 	}
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to forward request: : %w", err), "api_error")
+		SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to forward request: : %w", err), "api_error")
 		if recorder != nil {
 			recorder.RecordError(err)
 		}
@@ -969,7 +969,7 @@ func (s *Server) nonstreamOpenAIChatToResponses(c *gin.Context, reqCtx *transfor
 	chatResp, _, err := forwarding.ForwardOpenAIChat(fc, wrapper, chatReq)
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to forward request: : %w", err), "api_error")
+		SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to forward request: : %w", err), "api_error")
 		if recorder != nil {
 			recorder.RecordError(err)
 		}
@@ -995,7 +995,7 @@ func (s *Server) streamOpenAIChatToResponses(c *gin.Context, reqCtx *transform.T
 	}
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
+		SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
 		if recorder != nil {
 			recorder.RecordError(err)
 		}
@@ -1021,7 +1021,7 @@ func (s *Server) nonstreamAnthropicBetaFromResponses(c *gin.Context, reqCtx *tra
 	}
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to forward request: : %w", err), "api_error")
+		SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to forward request: : %w", err), "api_error")
 		if recorder != nil {
 			recorder.RecordError(err)
 		}
@@ -1050,7 +1050,7 @@ func (s *Server) streamAnthropicBetaFromResponses(c *gin.Context, reqCtx *transf
 	}
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
-		SendErrorResponse(c, http.StatusInternalServerError, fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
+		SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
 		if recorder != nil {
 			recorder.RecordError(err)
 		}

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -75,33 +75,37 @@ func newSelectionState(rule *typ.Rule) *selectionState {
 		return &selectionState{candidateServices: nil}
 	}
 
-	// Use a map to deduplicate services by service ID
-	serviceMap := make(map[string]*loadbalance.Service)
+	// Deduplicate services by service ID while preserving first-seen order.
+	// Map iteration order in Go is randomized, so building the candidate slice
+	// from a map would make routing (and tests) non-deterministic. We keep an
+	// ordered slice and use the index map only to dedupe / override in place.
+	services := make([]*loadbalance.Service, 0, len(rule.Services))
+	indexByID := make(map[string]int)
 
-	// Add default services
-	if rule.Services != nil {
-		for _, svc := range rule.Services {
-			if svc != nil {
-				serviceMap[svc.GetServiceID().String()] = svc
-			}
+	add := func(svc *loadbalance.Service) {
+		if svc == nil {
+			return
 		}
-	}
-
-	// Add smart_routing services (override defaults if same ID)
-	for _, sr := range rule.SmartRouting {
-		if sr.Services != nil {
-			for _, svc := range sr.Services {
-				if svc != nil {
-					serviceMap[svc.GetServiceID().String()] = svc
-				}
-			}
+		id := svc.GetServiceID().String()
+		if i, ok := indexByID[id]; ok {
+			// Override the existing entry in place, keeping its position.
+			services[i] = svc
+			return
 		}
-	}
-
-	// Convert map back to slice
-	services := make([]*loadbalance.Service, 0, len(serviceMap))
-	for _, svc := range serviceMap {
+		indexByID[id] = len(services)
 		services = append(services, svc)
+	}
+
+	// Add default services.
+	for _, svc := range rule.Services {
+		add(svc)
+	}
+
+	// Add smart_routing services (override defaults if same ID).
+	for _, sr := range rule.SmartRouting {
+		for _, svc := range sr.Services {
+			add(svc)
+		}
 	}
 
 	return &selectionState{candidateServices: services}

--- a/internal/server/upstream_error.go
+++ b/internal/server/upstream_error.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// upstreamForwardStatus returns the status code to send to the client when a
+// non-streaming forward fails. It propagates the upstream provider's HTTP status
+// when the error carries one (so a 401/429/4xx is not flattened into a 500) and
+// defaults to 500 Internal Server Error otherwise.
+func upstreamForwardStatus(err error) int {
+	return protocol.UpstreamStatus(err, http.StatusInternalServerError)
+}


### PR DESCRIPTION
## Summary

While running the full test suite + harness matrix on `main`, three real gateway bugs surfaced (one of them an OOM/hang). This PR fixes them, and extends the protocol-test harness so it actually exercises the error and idempotence paths that exposed them.

The headline is the **gateway fixes**; the harness changes are what made the bugs reproducible and keep them from regressing.

## Gateway fixes (the actual bugs)

### 1. Upstream error status flattened to 500
Every forwarding failure was returned to the client as HTTP 500, so an upstream `401`/`429`/`4xx` reached the caller as `500` — wrong status, and it defeated failover heuristics that key off the status code.
- New `protocol.UpstreamStatus(err, fallback)` extracts the real status from the vendor SDK error types (OpenAI/Anthropic `apierror.Error`, google-genai `genai.APIError`).
- New `server.upstreamForwardStatus()` wrapper (defaults to 500 when no upstream status is available).
- Wired into **all** non-stream forward sites (chat, responses, anthropic, embeddings, images) and the streaming pre-frame helpers `SendStreamingError()` / `SendForwardingError()`, which now propagate the upstream status before any SSE frame is written.

### 2. Truncated Responses→Chat stream OOM / hang
`responsesToChatConverter.emitFallbackCompletion()` never set `completed = true`, so a Responses stream that ended without `response.completed` (a truncated / mid-stream-cut stream) re-emitted the terminal chunk **forever**, flushing chunks unboundedly until the process OOMed (this was the source of the matrix OOM-kills). Now marks completed exactly once.

### 3. Non-deterministic routing / flaky test
`newSelectionState()` rebuilt the candidate slice by iterating a Go map, randomizing service order (`TestHealthStage_FiltersUnhealthy` failed ~50% of runs). Now dedupes by service ID while preserving first-seen order — fixing both the test and the underlying routing non-determinism. `smart_routing` still overrides defaults, in place.

## Harness changes (made the bugs reproducible / regression-proof)

- **Pre-content vs mid-stream errors**: `MockResponseBuilder` gains `StreamHTTPError`; `BuildErrorFromSpec()` routes on `ErrorStagePreContent` vs `ErrorStageMidStream`. Pre-content failures now fail at the HTTP status line for streaming requests too (matching real providers), while mid-stream cuts return `200` + partial content via the new `buildMidStreamTruncated()` (OpenAI Chat/Responses, Anthropic, Google).
- `writeBuilderResponse()` refactor in the virtual server honors `StreamHTTPError`.
- `ErrorMidStreamCloseScenario` extended to cover OpenAI Responses and Google alongside Chat and Anthropic.

## CLI: two-hop off by default, idempotence on

The matrix CLI conflated **two-hop (A→B→C semantic preservation)** with **idempotence (`g(f(A)) == A` round-trip)** — and idempotence was only reachable under `go test -tags e2e`.
- New `Matrix.ExecuteAllIdempotent()` — a `testing.T`-free executor (CLI counterpart of `RunIdempotent`).
- `--mode` reworked: **default = single + idempotent (two-hop OFF)**, `all` = single + transitive + idempotent, plus `single` / `transitive` / `idempotent` selectors.

## Validation

- `go test ./internal/... ./vmodel/...` — green (pre-existing, unrelated `internal/server/config` build failure: `migrate20260609`, fails identically on clean `main`).
- `harness matrix --mode=all` — 666 pass / 150 skip / **0 fail** (previously failing + OOM-killing).
- `harness matrix` (new default) — single + idempotent: 363 pass / 57 skip / 0 fail; two-hop opt-in.
- `TestIdempotent` (e2e, true round-trip) — 165 / 24 skip / 0 fail, including the error scenarios touched here.

13 files changed, +416 / −87.

https://claude.ai/code/session_01DjmwasYy1tzWvotoZEhVXT