### PR TITLE
feat(scenario): Add hidden "Team" scenario for shared central model deployment

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import UseClaudeCodePage from './pages/scenario/UseClaudeCodePage';
 import ClaudeCodeProfilePage from './pages/scenario/ClaudeCodeProfilePage';
 import UseClaudeDesktopPage from './pages/scenario/UseClaudeDesktopPage';
 import UseAgentPage from './pages/scenario/UseAgentPage';
+import UseTeamPage from './pages/scenario/UseTeamPage';
 import AgentOverviewPage from './pages/scenario/AgentOverviewPage';
 import UseOpenCodePage from './pages/scenario/UseOpenCodePage';
 import UseXcodePage from './pages/scenario/UseXcodePage';
@@ -196,6 +197,7 @@ function AppContent() {
                     <Route path="/agent/claude_code/profile/:profileId" element={<ClaudeCodeProfilePage />} />
                     <Route path="/agent/claude_desktop" element={<UseClaudeDesktopPage />} />
                     <Route path="/agent/agent" element={<UseAgentPage />} />
+                    <Route path="/agent/team" element={<UseTeamPage />} />
                     <Route path="/agent/opencode" element={<UseOpenCodePage />} />
                     <Route path="/agent/xcode" element={<UseXcodePage />} />
                     <Route path="/agent/vscode" element={<UseVSCodePage />} />

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -114,6 +114,7 @@ import {
     IconFilter,
     IconFilterOff,
     IconUser,
+    IconUsers,
     IconShield,
     IconReload,
     IconStar,
@@ -279,6 +280,7 @@ export const NearMeOutlined = tablerMui(IconNavigation);
 // --- People / identity -------------------------------------------------------
 export const Person = tablerMui(IconUser);
 export const AccountCircle = tablerMui(IconUser);
+export const Users = tablerMui(IconUsers);
 
 // --- Security / trust --------------------------------------------------------
 export const Shield = tablerMui(IconShield);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -45,6 +45,7 @@ export default {
       "useVSCode": "VS Code",
       "useEmbed": "Embedding",
       "useImageGen": "Image Gen",
+      "useTeam": "Team",
       "playground": "Playground",
       "apiKeys": "API Keys",
       "oauth": "OAuth",
@@ -1123,7 +1124,8 @@ export default {
       "anthropic": "Drop-in Anthropic-compatible SDK endpoint.",
       "embed": "Route embedding requests to your provider.",
       "imagegen": "Route image generation through Tingly Box.",
-      "agent": "OpenClaw — universal agent runner."
+      "agent": "OpenClaw — universal agent runner.",
+      "team": "Shared central model deployment for your whole team. Hidden by default."
     }
   }
 };

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -46,6 +46,7 @@ export default {
       "useVSCode": "VS Code",
       "useEmbed": "Embedding",
       "useImageGen": "Image Gen",
+      "useTeam": "Team",
       "playground": "Playground",
       "apiKeys": "API 密钥",
       "oauth": "OAuth 凭证",

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -23,6 +23,7 @@ import {
     Lock as IconLock,
     Vector as IconVector,
     Photo as IconPhoto,
+    Users as IconUsers,
     Science as IconFlask,
     PlayArrow as IconPlayerPlay,
     Handyman as IconTools,
@@ -106,6 +107,7 @@ export function useActivityItems(): ActivityItem[] {
         ]);
         const agentTools = visible([
             { id: 'agent', nav: { path: '/agent/agent', label: t('common.openClaw', { defaultValue: 'OpenClaw' }), icon: <OpenClaw size={20} /> } },
+            { id: 'team', nav: { path: '/agent/team', label: t('layout.nav.useTeam', { defaultValue: 'Team' }), icon: <IconUsers sx={{ fontSize: 20 }} /> } },
         ]);
 
         const scenarioChildren: NavItem[] = [];

--- a/frontend/src/pages/scenario/AgentOverviewPage.tsx
+++ b/frontend/src/pages/scenario/AgentOverviewPage.tsx
@@ -9,7 +9,7 @@ import {
     Typography,
     alpha,
 } from '@mui/material';
-import { AiAgents as IconAiAgents, Photo as IconPhoto, Vector as IconVector } from '@/components/icons';
+import { AiAgents as IconAiAgents, Photo as IconPhoto, Vector as IconVector, Users as IconUsers } from '@/components/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -127,11 +127,19 @@ export const SCENARIOS: ScenarioDescriptor[] = [
         icon: (size) => <OpenClaw size={size} />,
         hideable: true,
     },
+    {
+        id: 'team',
+        labelKey: 'layout.nav.useTeam',
+        descKey: 'scenarioOverview.descriptions.team',
+        path: '/agent/team',
+        icon: (size) => <IconUsers sx={{ fontSize: size }} />,
+        hideable: true,
+    },
 ];
 
 const STORAGE_KEY = 'scenario.hiddenScenarios';
 const VISIBILITY_EVENT = 'scenario-visibility-change';
-const DEFAULT_HIDDEN = ['agent'];
+const DEFAULT_HIDDEN = ['agent', 'team'];
 
 const readHidden = (): string[] => {
     try {

--- a/frontend/src/pages/scenario/UseTeamPage.tsx
+++ b/frontend/src/pages/scenario/UseTeamPage.tsx
@@ -1,0 +1,60 @@
+import CardGrid from "@/components/CardGrid.tsx";
+import UnifiedCard from "@/components/UnifiedCard.tsx";
+import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
+import { Box } from '@mui/material';
+import PageLayout from '@/components/PageLayout';
+import TemplatePage from './components/TemplatePage.tsx';
+import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
+import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
+
+const scenario = "team";
+
+const UseTeamPageContent: React.FC = () => {
+    const {
+        isLoading,
+        notification,
+        copyToClipboard,
+        baseUrl,
+    } = useScenarioPageInternal(scenario);
+
+    return (
+        <PageLayout loading={isLoading} notification={notification}>
+            <CardGrid>
+                <UnifiedCard
+                    title={
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <span>Team</span>
+                        </Box>
+                    }
+                    size="full"
+                >
+                    <ProviderConfigCard
+                        title="Team"
+                        baseUrlPath="/tingly/team"
+                        baseUrl={baseUrl}
+                        onCopy={copyToClipboard}
+                        compact={true}
+                        scenario={scenario}
+                    />
+                </UnifiedCard>
+
+                <TemplatePage
+                    scenario={scenario}
+                    title="Models and Forwarding Rules"
+                    collapsible={true}
+                    allowDeleteRule={true}
+                />
+            </CardGrid>
+        </PageLayout>
+    );
+};
+
+const UseTeamPage: React.FC = () => {
+    return (
+        <ScenarioPageModalProvider>
+            <UseTeamPageContent />
+        </ScenarioPageModalProvider>
+    );
+};
+
+export default UseTeamPage;

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -49,6 +49,19 @@ func init() {
 			Active: true,
 		},
 		{
+			UUID:          "built-in-team",
+			Scenario:      typ.ScenarioTeam,
+			RequestModel:  "tingly-team",
+			ResponseModel: "",
+			Description:   "Default proxy rule for team (shared central model deployment)",
+			Services:      []*loadbalance.Service{}, // Empty services initially; operator binds the central provider/model
+			LBTactic: typ.Tactic{ // Initialize with default adaptive tactic
+				Type:   loadbalance.TacticAdaptive,
+				Params: typ.DefaultAdaptiveParams(),
+			},
+			Active: true,
+		},
+		{
 			UUID:          "built-in-openai",
 			Scenario:      typ.ScenarioOpenAI,
 			RequestModel:  "tingly-gpt",

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -351,6 +351,8 @@ func (c *TBClientImpl) GetScenarioEndpointPath(scenario typ.RuleScenario) string
 		return "/tingly/xcode"
 	case typ.ScenarioVSCode:
 		return "/tingly/vscode"
+	case typ.ScenarioTeam:
+		return "/tingly/team"
 	default:
 		// Default to OpenAI scenario path
 		return "/tingly/openai"

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -294,6 +294,8 @@ func TestGetScenarioEndpointPath(t *testing.T) {
 		{"opencode:p1", "/tingly/opencode"},
 		{typ.ScenarioXcode, "/tingly/xcode"},
 		{typ.ScenarioVSCode, "/tingly/vscode"},
+		{typ.ScenarioTeam, "/tingly/team"},
+		{"team:p1", "/tingly/team"},
 		{typ.ScenarioSmartGuide, "/tingly/_smart_guide"},
 		{typ.ScenarioOpenAI, "/tingly/openai"},
 	}

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -88,6 +88,16 @@ func builtinScenarioDescriptorFor(scenario RuleScenario) ScenarioDescriptor {
 			AllowRuleBinding:   true,
 			AllowDirectPathUse: true,
 		}
+	case ScenarioTeam:
+		// Centrally deployed model shared across a team. Accepts both OpenAI
+		// and Anthropic transports so any agent/client can point at
+		// /tingly/team regardless of protocol.
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
 	case ScenarioCodex, ScenarioOpenCode, ScenarioXcode, ScenarioVSCode:
 		return ScenarioDescriptor{
 			ID:                 scenario,

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -123,13 +123,31 @@ func TestClaudeCodeSupportsProfiles(t *testing.T) {
 }
 
 func TestNonProfileScenariosDoNotSupportProfiles(t *testing.T) {
-	for _, s := range []RuleScenario{ScenarioOpenAI, ScenarioAnthropic, ScenarioAgent} {
+	for _, s := range []RuleScenario{ScenarioOpenAI, ScenarioAnthropic, ScenarioAgent, ScenarioTeam} {
 		d, ok := GetScenarioDescriptor(s)
 		if !ok {
 			continue
 		}
 		if d.SupportsProfiles {
 			t.Errorf("scenario %q should not have SupportsProfiles=true", s)
+		}
+	}
+}
+
+func TestTeamScenarioDescriptor(t *testing.T) {
+	d, ok := GetScenarioDescriptor(ScenarioTeam)
+	if !ok {
+		t.Fatal("team descriptor not found")
+	}
+	if !d.AllowRuleBinding {
+		t.Error("team should allow rule binding")
+	}
+	if !d.AllowDirectPathUse {
+		t.Error("team should allow direct path use")
+	}
+	for _, transport := range []ScenarioTransport{TransportOpenAI, TransportAnthropic} {
+		if !ScenarioSupportsTransport(ScenarioTeam, transport) {
+			t.Errorf("team should support transport %q", transport)
 		}
 	}
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -54,6 +54,7 @@ const (
 	ScenarioOpenAI        RuleScenario = "openai"
 	ScenarioAnthropic     RuleScenario = "anthropic"
 	ScenarioAgent         RuleScenario = "agent"
+	ScenarioTeam          RuleScenario = "team" // Centrally deployed model shared across a team; hidden by default in the UI
 	ScenarioCodex         RuleScenario = "codex"
 	ScenarioClaudeCode    RuleScenario = "claude_code"
 	ScenarioOpenCode      RuleScenario = "opencode"
@@ -71,6 +72,7 @@ func BuiltinScenarios() []RuleScenario {
 		ScenarioOpenAI,
 		ScenarioAnthropic,
 		ScenarioAgent,
+		ScenarioTeam,
 		ScenarioCodex,
 		ScenarioClaudeCode,
 		ScenarioOpenCode,


### PR DESCRIPTION
## Summary
Introduces a new **Team** scenario: a gateway routing scenario for a centrally deployed model that a whole team shares. Agents and clients on different protocols (OpenAI or Anthropic) point at a single `/tingly/team` endpoint regardless of transport. It behaves like the other agent scenarios — rules route to a provider+model through the normal pipeline — and is **hidden by default** in the UI, mirroring the existing `agent`/OpenClaw pattern.

## Key Changes

**Backend**
- Added `ScenarioTeam` constant (`"team"`) to the scenario enum + `BuiltinScenarios()`
- Scenario descriptor supports **both** OpenAI and Anthropic transports, with rule binding and direct path use enabled (routes `/tingly/team`, `/openai/team`, `/anthropic/team` go live automatically — they're validated dynamically against the registry)
- `tbclient` endpoint path mapping (`/tingly/team`)
- Built-in seed rule `built-in-team` (request model `tingly-team`, empty services — operator binds the central provider/model) with adaptive load balancing
- Test coverage for descriptor transports and endpoint path

**Frontend**
- Created `UseTeamPage` component following the standard scenario page pattern (provider config + template/rule management)
- Added Team navigation item to the agent tools section using a new reusable `Users` icon
- Registered Team in the scenario overview with description and routing
- **Hidden by default** in the UI (added to `DEFAULT_HIDDEN`) while remaining fully functional via direct navigation
- Added i18n labels for English and Chinese

## Implementation Details
- Runs the standard gateway pipeline (rule → flags → routing → provider), not a bypass — consistent with UX principle #7 (diagnostics/paths traverse the real path)
- Protocol-agnostic: a single endpoint serves both OpenAI and Anthropic clients
- Follows existing scenario architecture (`ScenarioPageModalProvider`, `useScenarioPageInternal`) and icon conventions (`@/components/icons`)

https://claude.ai/code/session_016LigJoLrANna35CeH4k13x