### PR TITLE
refactor(migration): Clean up config migrations: dedupe helpers, fix latent bugs, tidy tests

### DIFF
--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -32,6 +32,64 @@ const (
 	RuleUUIDBuiltinClaudeDesktopHaiku45  = "builtin:claude_desktop:claude-haiku-4-5"
 )
 
+// --- Shared migration helpers -------------------------------------------------
+//
+// Several migrations seed or repair built-in rules with the same moves: look a
+// rule up by UUID, pull a template from DefaultRules, and copy a reference
+// rule's upstream services onto a freshly added rule. These helpers centralize
+// those moves so each migration reads as intent, not bookkeeping.
+
+// findRuleByUUID returns a pointer to the rule with the given UUID, or nil.
+func (c *Config) findRuleByUUID(uuid string) *typ.Rule {
+	for i := range c.Rules {
+		if c.Rules[i].UUID == uuid {
+			return &c.Rules[i]
+		}
+	}
+	return nil
+}
+
+// defaultRuleByUUID looks up a built-in rule template (from DefaultRules) by UUID.
+func defaultRuleByUUID(uuid string) (typ.Rule, bool) {
+	for _, r := range DefaultRules {
+		if r.UUID == uuid {
+			return r, true
+		}
+	}
+	return typ.Rule{}, false
+}
+
+// cloneServices returns a shallow copy of a load-balancing services slice
+// (nil for an empty input) so a seeded rule gets its own slice header rather
+// than aliasing the source rule's.
+func cloneServices(src []*loadbalance.Service) []*loadbalance.Service {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]*loadbalance.Service, len(src))
+	copy(dst, src)
+	return dst
+}
+
+// referenceServicesFor returns a copy of the services of the first rule whose
+// scenario matches one of the given scenarios and that has a non-empty service
+// list, or nil when none exists. Used to seed a new built-in rule with the same
+// upstream services the user already configured for a sibling scenario.
+func (c *Config) referenceServicesFor(scenarios ...typ.RuleScenario) []*loadbalance.Service {
+	for i := range c.Rules {
+		rule := &c.Rules[i]
+		if len(rule.Services) == 0 {
+			continue
+		}
+		for _, s := range scenarios {
+			if rule.Scenario.Is(s) {
+				return cloneServices(rule.Services)
+			}
+		}
+	}
+	return nil
+}
+
 func Migrate(c *Config) error {
 	migrate20251220(c)
 	migrate20251221(c)
@@ -45,9 +103,9 @@ func Migrate(c *Config) error {
 	migrate20260421(c) // Migrate profile unified model from "*" to "cc"
 	migrate20260502(c) // Remove wildcard (*) rules for smart_guide scenario
 	migrate20260513(c) // Add Claude Desktop built-in rules
-	migrate20260521(c) // Add Claude Desktop haiku-4-5 built-in rule
 	migrate20260517(c) // Rewrite 127.0.0.1 to localhost in tingly-owned agent configs
 	migrate20260518(c) // Set OpenAIEndpointMode=responses on existing Codex OAuth providers
+	migrate20260521(c) // Add Claude Desktop haiku-4-5 built-in rule
 	migrate20260606(c) // Default SkipUsage on for the Xcode scenario
 	migrate20260610(c) // Seed default rule flags (claude_code_compat / clean_header / session_affinity) for CC / Desktop / Codex rules
 	return nil
@@ -159,12 +217,20 @@ func migrate20251221(c *Config) {
 	}
 }
 
+// migrate20251225 clamps any legacy JSON-config provider timeout above the max
+// to the cap. Runs before migrateProvidersToDB, so it only affects the one-time
+// JSON→DB import; once providers live in SQLite the JSON list is empty and this
+// is a no-op.
 func migrate20251225(c *Config) {
+	needsSave := false
 	for _, p := range c.Providers {
-		// second
-		if p.Timeout >= 30*60 {
+		if p.Timeout > int64(constant.DefaultMaxTimeout) {
 			p.Timeout = int64(constant.DefaultMaxTimeout)
+			needsSave = true
 		}
+	}
+	if needsSave {
+		_ = c.Save()
 	}
 }
 
@@ -214,17 +280,9 @@ func migrate20260110(c *Config) {
 		return
 	}
 
-	// Find the source rule (built-in-cc)
-	var fallbackRule *typ.Rule
-	for i := range c.Rules {
-		if c.Rules[i].UUID == RuleUUIDBuiltinCC {
-			fallbackRule = &c.Rules[i]
-			break
-		}
-	}
-
-	// If source rule doesn't exist or has no services, nothing to copy.
-	// Still mark as completed so we don't keep retrying on every restart.
+	// Source rule (built-in-cc). If it's missing or has no services there's
+	// nothing to copy — still mark completed so we don't retry every restart.
+	fallbackRule := c.findRuleByUUID(RuleUUIDBuiltinCC)
 	if fallbackRule == nil || len(fallbackRule.Services) == 0 {
 		c.markMigrationCompleted("20260110")
 		return
@@ -239,37 +297,23 @@ func migrate20260110(c *Config) {
 		RuleUUIDBuiltinCCSubagent,
 	}
 
-	defaultMap := map[string]typ.Rule{}
-
-	for _, targetUUID := range targetUUIDs {
-		for _, defaultRule := range DefaultRules {
-			if targetUUID == defaultRule.UUID {
-				defaultMap[targetUUID] = defaultRule
-			}
-		}
-	}
-
 	needsSave := false
-	for i := range c.Rules {
-		rule := &c.Rules[i]
-
-		// Check if this is a target rule
-		var defaultRule typ.Rule
-		var ok bool
-		if defaultRule, ok = defaultMap[rule.UUID]; !ok {
+	for _, targetUUID := range targetUUIDs {
+		defaultRule, ok := defaultRuleByUUID(targetUUID)
+		if !ok {
 			continue
 		}
-
-		rule.Description = defaultRule.Description
-
-		// If services is not empty, skip
-		if len(rule.Services) > 0 {
+		target := c.findRuleByUUID(targetUUID)
+		if target == nil {
 			continue
 		}
+		target.Description = defaultRule.Description
 
-		// Copy services from fallback rule
-		rule.Services = make([]*loadbalance.Service, len(fallbackRule.Services))
-		copy(rule.Services, fallbackRule.Services)
+		// Only fill services when the target has none of its own.
+		if len(target.Services) > 0 {
+			continue
+		}
+		target.Services = cloneServices(fallbackRule.Services)
 		needsSave = true
 	}
 
@@ -303,22 +347,9 @@ func migrate20260210(c *Config) {
 		return
 	}
 
-	// Find required rules.
-	var haikuRule *typ.Rule
-	var subagentRule *typ.Rule
-	for i := range c.Rules {
-		rule := &c.Rules[i]
-		if rule.UUID == RuleUUIDBuiltinCCHaiku {
-			haikuRule = rule
-			continue
-		}
-		if rule.UUID == RuleUUIDBuiltinCCSubagent {
-			subagentRule = rule
-		}
-	}
-
 	// Without a haiku model, there's nothing to mirror.
 	// Mark as completed so we don't retry every restart.
+	haikuRule := c.findRuleByUUID(RuleUUIDBuiltinCCHaiku)
 	if haikuRule == nil {
 		c.markMigrationCompleted("20260210")
 		return
@@ -326,30 +357,22 @@ func migrate20260210(c *Config) {
 
 	needsSave := false
 
-	// Ensure subagent rule exists (add default if missing).
+	// Ensure subagent rule exists (add the default template if missing).
+	subagentRule := c.findRuleByUUID(RuleUUIDBuiltinCCSubagent)
 	if subagentRule == nil {
-		for _, defaultRule := range DefaultRules {
-			if defaultRule.UUID == RuleUUIDBuiltinCCSubagent {
-				c.Rules = append(c.Rules, defaultRule)
-				subagentRule = &c.Rules[len(c.Rules)-1]
-				needsSave = true
-				break
-			}
-		}
-		if subagentRule == nil {
+		defaultRule, ok := defaultRuleByUUID(RuleUUIDBuiltinCCSubagent)
+		if !ok {
 			c.markMigrationCompleted("20260210")
-			if needsSave {
-				_ = c.Save()
-			}
 			return
 		}
+		c.Rules = append(c.Rules, defaultRule)
+		subagentRule = &c.Rules[len(c.Rules)-1]
+		needsSave = true
 	}
 
-	// Keep subagent request model as-is; only mirror services.
-	// Mirror haiku's services if subagent has none.
+	// Keep subagent request model as-is; mirror haiku's services if it has none.
 	if len(subagentRule.Services) == 0 && len(haikuRule.Services) > 0 {
-		subagentRule.Services = make([]*loadbalance.Service, len(haikuRule.Services))
-		copy(subagentRule.Services, haikuRule.Services)
+		subagentRule.Services = cloneServices(haikuRule.Services)
 		needsSave = true
 	}
 
@@ -359,19 +382,14 @@ func migrate20260210(c *Config) {
 	}
 }
 
+// migrate20260306 adds the built-in Codex rule if it's missing.
 func migrate20260306(c *Config) {
-	for _, rule := range c.Rules {
-		if rule.UUID == RuleUUIDBuiltinCodex {
-			return
-		}
+	if c.findRuleByUUID(RuleUUIDBuiltinCodex) != nil {
+		return
 	}
-
-	for _, defaultRule := range DefaultRules {
-		if defaultRule.UUID == RuleUUIDBuiltinCodex {
-			c.Rules = append(c.Rules, defaultRule)
-			_ = c.Save()
-			return
-		}
+	if defaultRule, ok := defaultRuleByUUID(RuleUUIDBuiltinCodex); ok {
+		c.Rules = append(c.Rules, defaultRule)
+		_ = c.Save()
 	}
 }
 
@@ -385,20 +403,12 @@ func migrate20260416(c *Config) {
 		return
 	}
 
-	// Enable multi-tenant with default settings
-	// Only set values that are not already configured
-	if c.MultiTenantConfig.APITokenSecret == "" {
-		c.MultiTenantConfig.APITokenSecret = generateSecret()
-	}
-	if c.MultiTenantConfig.APITokenAlgorithm == "" {
-		c.MultiTenantConfig.APITokenAlgorithm = "HS256"
-	}
-	if c.MultiTenantConfig.APITokenIssuer == "" {
-		c.MultiTenantConfig.APITokenIssuer = "tingly-box"
-	}
-	// Always enable multi-tenant (this is the main purpose of the migration)
+	// All three token fields are empty (guaranteed by the guard above), so seed
+	// the defaults and enable multi-tenant — the main purpose of the migration.
+	c.MultiTenantConfig.APITokenSecret = generateSecret()
+	c.MultiTenantConfig.APITokenAlgorithm = "HS256"
+	c.MultiTenantConfig.APITokenIssuer = "tingly-box"
 	c.MultiTenantConfig.Enabled = true
-	// Keep global token enabled for backward compatibility
 
 	_ = c.Save()
 }
@@ -471,51 +481,27 @@ func migrate20260502(c *Config) {
 // - builtin:claude_desktop:claude-opus-4-6
 // - builtin:claude_desktop:claude-opus-4-7
 func migrate20260513(c *Config) {
+	desktopUUIDs := []string{
+		RuleUUIDBuiltinClaudeDesktopSonnet46,
+		RuleUUIDBuiltinClaudeDesktopOpus46,
+		RuleUUIDBuiltinClaudeDesktopOpus47,
+	}
+
+	// Seed new desktop rules with the services the user already uses for a
+	// sibling agent scenario (prefer claude_code, then codex).
+	refServices := c.referenceServicesFor(typ.ScenarioClaudeCode, typ.ScenarioCodex)
+
 	needsSave := false
-
-	// Check if Claude Desktop rules already exist
-	existingRules := map[string]bool{
-		RuleUUIDBuiltinClaudeDesktopSonnet46: false,
-		RuleUUIDBuiltinClaudeDesktopOpus46:   false,
-		RuleUUIDBuiltinClaudeDesktopOpus47:   false,
-	}
-
-	for _, rule := range c.Rules {
-		if _, exists := existingRules[rule.UUID]; exists {
-			existingRules[rule.UUID] = true
-		}
-	}
-
-	// Find a reference rule to copy services from (prefer claude_code or codex)
-	var referenceRule *typ.Rule
-	for i := range c.Rules {
-		rule := &c.Rules[i]
-		if rule.Scenario.Is(typ.ScenarioClaudeCode) || rule.Scenario.Is(typ.ScenarioCodex) {
-			if len(rule.Services) > 0 {
-				referenceRule = rule
-				break
-			}
-		}
-	}
-
-	// Add missing Claude Desktop rules
-	for _, defaultRule := range DefaultRules {
-		uuid := defaultRule.UUID
-		alreadyExists, exists := existingRules[uuid]
-		if !exists {
-			continue // Not a Claude Desktop rule
-		}
-
-		if alreadyExists {
+	for _, uuid := range desktopUUIDs {
+		if c.findRuleByUUID(uuid) != nil {
 			continue // Rule already exists, skip
 		}
-
-		// Add the rule
-		newRule := defaultRule
-		// Copy services from reference rule if available
-		if referenceRule != nil && len(referenceRule.Services) > 0 {
-			newRule.Services = make([]*loadbalance.Service, len(referenceRule.Services))
-			copy(newRule.Services, referenceRule.Services)
+		newRule, ok := defaultRuleByUUID(uuid)
+		if !ok {
+			continue
+		}
+		if services := cloneServices(refServices); services != nil {
+			newRule.Services = services
 		}
 
 		c.Rules = append(c.Rules, newRule)
@@ -534,39 +520,20 @@ func migrate20260513(c *Config) {
 	}
 }
 
-// migrate20260521 adds the claude-haiku-4-5 built-in rule for Claude Desktop
+// migrate20260521 adds the claude-haiku-4-5 built-in rule for Claude Desktop.
 func migrate20260521(c *Config) {
-	for _, rule := range c.Rules {
-		if rule.UUID == RuleUUIDBuiltinClaudeDesktopHaiku45 {
-			return
-		}
+	if c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopHaiku45) != nil {
+		return
 	}
 
-	var referenceRule *typ.Rule
-	for i := range c.Rules {
-		rule := &c.Rules[i]
-		if rule.Scenario.Is(typ.ScenarioClaudeDesktop) && len(rule.Services) > 0 {
-			referenceRule = rule
-			break
-		}
+	// Use the init.go template so this rule's flags/tactic stay in sync with the
+	// other built-in Claude Desktop rules instead of drifting from a local copy.
+	newRule, ok := defaultRuleByUUID(RuleUUIDBuiltinClaudeDesktopHaiku45)
+	if !ok {
+		return
 	}
-
-	newRule := typ.Rule{
-		UUID:         RuleUUIDBuiltinClaudeDesktopHaiku45,
-		Scenario:     typ.ScenarioClaudeDesktop,
-		RequestModel: "claude-haiku-4-5",
-		Description:  "Claude Desktop - Haiku 4.5 model for fast responses",
-		Services:     []*loadbalance.Service{},
-		LBTactic: typ.Tactic{
-			Type:   loadbalance.TacticAdaptive,
-			Params: typ.DefaultAdaptiveParams(),
-		},
-		Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true},
-		Active: true,
-	}
-	if referenceRule != nil && len(referenceRule.Services) > 0 {
-		newRule.Services = make([]*loadbalance.Service, len(referenceRule.Services))
-		copy(newRule.Services, referenceRule.Services)
+	if services := c.referenceServicesFor(typ.ScenarioClaudeDesktop); services != nil {
+		newRule.Services = services
 	}
 
 	c.Rules = append(c.Rules, newRule)

--- a/internal/server/config/migration_helpers_test.go
+++ b/internal/server/config/migration_helpers_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func svc(provider string) *loadbalance.Service {
+	return &loadbalance.Service{Provider: provider, Model: "m", Active: true}
+}
+
+func TestMigrationHelpers(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: "a", Scenario: typ.ScenarioOpenAI},
+			{UUID: "b", Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("p1")}},
+			{UUID: "c", Scenario: typ.ScenarioCodex, Services: []*loadbalance.Service{svc("p2")}},
+		},
+	}
+
+	t.Run("findRuleByUUID", func(t *testing.T) {
+		if got := c.findRuleByUUID("b"); got == nil || got.UUID != "b" {
+			t.Fatalf("findRuleByUUID(b) = %v", got)
+		}
+		if got := c.findRuleByUUID("missing"); got != nil {
+			t.Fatalf("findRuleByUUID(missing) = %v, want nil", got)
+		}
+	})
+
+	t.Run("defaultRuleByUUID", func(t *testing.T) {
+		if _, ok := defaultRuleByUUID(RuleUUIDBuiltinCC); !ok {
+			t.Error("expected built-in-cc in DefaultRules")
+		}
+		if _, ok := defaultRuleByUUID("nope"); ok {
+			t.Error("did not expect unknown UUID in DefaultRules")
+		}
+	})
+
+	t.Run("cloneServices", func(t *testing.T) {
+		if got := cloneServices(nil); got != nil {
+			t.Errorf("cloneServices(nil) = %v, want nil", got)
+		}
+		src := []*loadbalance.Service{svc("p1")}
+		got := cloneServices(src)
+		if len(got) != 1 {
+			t.Fatalf("cloneServices len = %d, want 1", len(got))
+		}
+		// Distinct slice header (mutating the copy must not touch the source).
+		got[0] = svc("changed")
+		if src[0].Provider != "p1" {
+			t.Error("cloneServices returned an aliasing slice")
+		}
+	})
+
+	t.Run("referenceServicesFor prefers first match in arg order over rule order", func(t *testing.T) {
+		// claude_code (rule b) and codex (rule c) both have services; the first
+		// rule in c.Rules that matches any requested scenario wins.
+		got := c.referenceServicesFor(typ.ScenarioCodex, typ.ScenarioClaudeCode)
+		if len(got) != 1 || got[0].Provider != "p1" {
+			t.Fatalf("referenceServicesFor = %v, want services from rule b (p1)", got)
+		}
+		if c.referenceServicesFor(typ.ScenarioAnthropic) != nil {
+			t.Error("expected nil when no rule matches")
+		}
+	})
+}
+
+func TestMigrate20260513_SeedsDesktopRules(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: "built-in-cc", Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("p1")}},
+			// One desktop rule already present — must be left untouched / not duplicated.
+			{UUID: RuleUUIDBuiltinClaudeDesktopSonnet46, Scenario: typ.ScenarioClaudeDesktop},
+		},
+	}
+
+	migrate20260513(c)
+
+	// Sonnet already existed (not duplicated); Opus46 + Opus47 added with copied services.
+	for _, uuid := range []string{
+		RuleUUIDBuiltinClaudeDesktopSonnet46,
+		RuleUUIDBuiltinClaudeDesktopOpus46,
+		RuleUUIDBuiltinClaudeDesktopOpus47,
+	} {
+		if c.findRuleByUUID(uuid) == nil {
+			t.Errorf("expected desktop rule %q to exist", uuid)
+		}
+	}
+	count := 0
+	for _, r := range c.Rules {
+		if r.UUID == RuleUUIDBuiltinClaudeDesktopSonnet46 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("sonnet rule duplicated: count = %d", count)
+	}
+	opus := c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopOpus46)
+	if opus == nil || len(opus.Services) != 1 || opus.Services[0].Provider != "p1" {
+		t.Errorf("opus46 should inherit reference services, got %+v", opus)
+	}
+}
+
+func TestMigrate20260521_AddsHaikuFromTemplate(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: RuleUUIDBuiltinClaudeDesktopSonnet46, Scenario: typ.ScenarioClaudeDesktop, Services: []*loadbalance.Service{svc("pd")}},
+		},
+	}
+
+	migrate20260521(c)
+
+	haiku := c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopHaiku45)
+	if haiku == nil {
+		t.Fatal("expected haiku-4-5 desktop rule to be added")
+	}
+	// Pulled from the init.go template, so it carries the built-in desktop flags.
+	if !haiku.Flags.ClaudeCodeCompat || !haiku.Flags.CleanHeader {
+		t.Errorf("haiku rule missing built-in flags: %+v", haiku.Flags)
+	}
+	// Services mirrored from the existing desktop rule.
+	if len(haiku.Services) != 1 || haiku.Services[0].Provider != "pd" {
+		t.Errorf("haiku rule should inherit desktop reference services, got %+v", haiku.Services)
+	}
+
+	// Idempotent: running again does not duplicate it.
+	migrate20260521(c)
+	count := 0
+	for _, r := range c.Rules {
+		if r.UUID == RuleUUIDBuiltinClaudeDesktopHaiku45 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("haiku rule duplicated: count = %d", count)
+	}
+}
+
+func TestMigrate20260110_CopiesCCServices(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: RuleUUIDBuiltinCC, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("cc")}},
+			{UUID: RuleUUIDBuiltinCCHaiku, Scenario: typ.ScenarioClaudeCode}, // empty → should inherit
+			{UUID: RuleUUIDBuiltinCCSonnet, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("own")}}, // own → kept
+		},
+	}
+
+	migrate20260110(c)
+
+	if !c.hasMigrationCompleted("20260110") {
+		t.Error("migration should be marked completed")
+	}
+	haiku := c.findRuleByUUID(RuleUUIDBuiltinCCHaiku)
+	if haiku == nil || len(haiku.Services) != 1 || haiku.Services[0].Provider != "cc" {
+		t.Errorf("haiku should inherit built-in-cc services, got %+v", haiku)
+	}
+	sonnet := c.findRuleByUUID(RuleUUIDBuiltinCCSonnet)
+	if sonnet == nil || len(sonnet.Services) != 1 || sonnet.Services[0].Provider != "own" {
+		t.Errorf("sonnet's own services must be preserved, got %+v", sonnet)
+	}
+}

--- a/internal/server/config/migration_helpers_test.go
+++ b/internal/server/config/migration_helpers_test.go
@@ -7,8 +7,20 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// svc builds a minimal load-balancing service for migration tests.
 func svc(provider string) *loadbalance.Service {
 	return &loadbalance.Service{Provider: provider, Model: "m", Active: true}
+}
+
+// countRules counts how many rules carry the given UUID (duplicate detection).
+func countRules(c *Config, uuid string) int {
+	n := 0
+	for _, r := range c.Rules {
+		if r.UUID == uuid {
+			n++
+		}
+	}
+	return n
 }
 
 func TestMigrationHelpers(t *testing.T) {
@@ -38,25 +50,21 @@ func TestMigrationHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("cloneServices", func(t *testing.T) {
+	t.Run("cloneServices returns a distinct slice", func(t *testing.T) {
 		if got := cloneServices(nil); got != nil {
 			t.Errorf("cloneServices(nil) = %v, want nil", got)
 		}
 		src := []*loadbalance.Service{svc("p1")}
 		got := cloneServices(src)
-		if len(got) != 1 {
-			t.Fatalf("cloneServices len = %d, want 1", len(got))
-		}
-		// Distinct slice header (mutating the copy must not touch the source).
 		got[0] = svc("changed")
 		if src[0].Provider != "p1" {
 			t.Error("cloneServices returned an aliasing slice")
 		}
 	})
 
-	t.Run("referenceServicesFor prefers first match in arg order over rule order", func(t *testing.T) {
-		// claude_code (rule b) and codex (rule c) both have services; the first
-		// rule in c.Rules that matches any requested scenario wins.
+	t.Run("referenceServicesFor matches in arg order", func(t *testing.T) {
+		// Both rule b (claude_code) and rule c (codex) have services; the first
+		// rule in c.Rules matching any requested scenario wins.
 		got := c.referenceServicesFor(typ.ScenarioCodex, typ.ScenarioClaudeCode)
 		if len(got) != 1 || got[0].Provider != "p1" {
 			t.Fatalf("referenceServicesFor = %v, want services from rule b (p1)", got)
@@ -65,99 +73,4 @@ func TestMigrationHelpers(t *testing.T) {
 			t.Error("expected nil when no rule matches")
 		}
 	})
-}
-
-func TestMigrate20260513_SeedsDesktopRules(t *testing.T) {
-	c := &Config{
-		Rules: []typ.Rule{
-			{UUID: "built-in-cc", Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("p1")}},
-			// One desktop rule already present — must be left untouched / not duplicated.
-			{UUID: RuleUUIDBuiltinClaudeDesktopSonnet46, Scenario: typ.ScenarioClaudeDesktop},
-		},
-	}
-
-	migrate20260513(c)
-
-	// Sonnet already existed (not duplicated); Opus46 + Opus47 added with copied services.
-	for _, uuid := range []string{
-		RuleUUIDBuiltinClaudeDesktopSonnet46,
-		RuleUUIDBuiltinClaudeDesktopOpus46,
-		RuleUUIDBuiltinClaudeDesktopOpus47,
-	} {
-		if c.findRuleByUUID(uuid) == nil {
-			t.Errorf("expected desktop rule %q to exist", uuid)
-		}
-	}
-	count := 0
-	for _, r := range c.Rules {
-		if r.UUID == RuleUUIDBuiltinClaudeDesktopSonnet46 {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Errorf("sonnet rule duplicated: count = %d", count)
-	}
-	opus := c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopOpus46)
-	if opus == nil || len(opus.Services) != 1 || opus.Services[0].Provider != "p1" {
-		t.Errorf("opus46 should inherit reference services, got %+v", opus)
-	}
-}
-
-func TestMigrate20260521_AddsHaikuFromTemplate(t *testing.T) {
-	c := &Config{
-		Rules: []typ.Rule{
-			{UUID: RuleUUIDBuiltinClaudeDesktopSonnet46, Scenario: typ.ScenarioClaudeDesktop, Services: []*loadbalance.Service{svc("pd")}},
-		},
-	}
-
-	migrate20260521(c)
-
-	haiku := c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopHaiku45)
-	if haiku == nil {
-		t.Fatal("expected haiku-4-5 desktop rule to be added")
-	}
-	// Pulled from the init.go template, so it carries the built-in desktop flags.
-	if !haiku.Flags.ClaudeCodeCompat || !haiku.Flags.CleanHeader {
-		t.Errorf("haiku rule missing built-in flags: %+v", haiku.Flags)
-	}
-	// Services mirrored from the existing desktop rule.
-	if len(haiku.Services) != 1 || haiku.Services[0].Provider != "pd" {
-		t.Errorf("haiku rule should inherit desktop reference services, got %+v", haiku.Services)
-	}
-
-	// Idempotent: running again does not duplicate it.
-	migrate20260521(c)
-	count := 0
-	for _, r := range c.Rules {
-		if r.UUID == RuleUUIDBuiltinClaudeDesktopHaiku45 {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Errorf("haiku rule duplicated: count = %d", count)
-	}
-}
-
-func TestMigrate20260110_CopiesCCServices(t *testing.T) {
-	c := &Config{
-		Rules: []typ.Rule{
-			{UUID: RuleUUIDBuiltinCC, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("cc")}},
-			{UUID: RuleUUIDBuiltinCCHaiku, Scenario: typ.ScenarioClaudeCode}, // empty → should inherit
-			{UUID: RuleUUIDBuiltinCCSonnet, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("own")}}, // own → kept
-		},
-	}
-
-	migrate20260110(c)
-
-	if !c.hasMigrationCompleted("20260110") {
-		t.Error("migration should be marked completed")
-	}
-	haiku := c.findRuleByUUID(RuleUUIDBuiltinCCHaiku)
-	if haiku == nil || len(haiku.Services) != 1 || haiku.Services[0].Provider != "cc" {
-		t.Errorf("haiku should inherit built-in-cc services, got %+v", haiku)
-	}
-	sonnet := c.findRuleByUUID(RuleUUIDBuiltinCCSonnet)
-	if sonnet == nil || len(sonnet.Services) != 1 || sonnet.Services[0].Provider != "own" {
-		t.Errorf("sonnet's own services must be preserved, got %+v", sonnet)
-	}
 }

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -3,104 +3,124 @@ package config
 import (
 	"testing"
 
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func TestMigrate20260606(t *testing.T) {
-	tmpDir := t.TempDir()
-	cfg, err := NewConfig(WithConfigDir(tmpDir))
-	if err != nil {
-		t.Fatalf("NewConfig error: %v", err)
+func TestMigrate20260110_CopiesCCServices(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: RuleUUIDBuiltinCC, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("cc")}},
+			{UUID: RuleUUIDBuiltinCCHaiku, Scenario: typ.ScenarioClaudeCode}, // empty → should inherit
+			{UUID: RuleUUIDBuiltinCCSonnet, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("own")}}, // own → kept
+		},
 	}
 
-	// Trigger migration manually since it already ran during NewConfig
-	migrate20260606(cfg)
+	migrate20260110(c)
 
-	// Verify migration completed flag
-	if !cfg.hasMigrationCompleted("20260606") {
-		t.Error("Migration 20260606 should be marked as completed")
+	if !c.hasMigrationCompleted("20260110") {
+		t.Error("migration should be marked completed")
 	}
-
-	// migrate20260606 now only defaults SkipUsage on for the Xcode scenario;
-	// session_affinity has moved to a rule-only flag (migrate20260610).
-	xcodeConfig := cfg.GetScenarioConfig(typ.ScenarioXcode)
-	if xcodeConfig == nil {
-		t.Error("Xcode scenario config not found")
-		return
+	haiku := c.findRuleByUUID(RuleUUIDBuiltinCCHaiku)
+	if haiku == nil || len(haiku.Services) != 1 || haiku.Services[0].Provider != "cc" {
+		t.Errorf("haiku should inherit built-in-cc services, got %+v", haiku)
 	}
-	if !xcodeConfig.Flags.SkipUsage {
-		t.Error("Xcode should have SkipUsage = true")
+	sonnet := c.findRuleByUUID(RuleUUIDBuiltinCCSonnet)
+	if sonnet == nil || len(sonnet.Services) != 1 || sonnet.Services[0].Provider != "own" {
+		t.Errorf("sonnet's own services must be preserved, got %+v", sonnet)
 	}
 }
 
-func TestMigrate20260606_Idempotent(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// First run - migration should add defaults
-	cfg1, err := NewConfig(WithConfigDir(tmpDir))
-	if err != nil {
-		t.Fatalf("NewConfig error: %v", err)
+func TestMigrate20260513_SeedsDesktopRules(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: RuleUUIDBuiltinCC, Scenario: typ.ScenarioClaudeCode, Services: []*loadbalance.Service{svc("p1")}},
+			// One desktop rule already present — must be left untouched / not duplicated.
+			{UUID: RuleUUIDBuiltinClaudeDesktopSonnet46, Scenario: typ.ScenarioClaudeDesktop},
+		},
 	}
 
-	// Debug: print migrations completed
-	t.Logf("After first NewConfig, MigrationsCompleted: %v", cfg1.MigrationsCompleted)
+	migrate20260513(c)
 
-	// Verify migration ran
-	if !cfg1.hasMigrationCompleted("20260606") {
-		t.Error("Migration should have completed after first NewConfig")
-	}
-
-	// Verify the Xcode SkipUsage default was set
-	xcodeConfig1 := cfg1.GetScenarioConfig(typ.ScenarioXcode)
-	if xcodeConfig1 == nil {
-		t.Fatal("Xcode scenario config should exist after migration")
-	}
-	if !xcodeConfig1.Flags.SkipUsage {
-		t.Error("Expected default SkipUsage = true after migration")
-	}
-
-	// Now user explicitly disables it
-	for i := range cfg1.Scenarios {
-		if cfg1.Scenarios[i].Scenario == typ.ScenarioXcode {
-			cfg1.Scenarios[i].Flags.SkipUsage = false
-			cfg1.Save()
-			break
+	for _, uuid := range []string{
+		RuleUUIDBuiltinClaudeDesktopSonnet46,
+		RuleUUIDBuiltinClaudeDesktopOpus46,
+		RuleUUIDBuiltinClaudeDesktopOpus47,
+	} {
+		if c.findRuleByUUID(uuid) == nil {
+			t.Errorf("expected desktop rule %q to exist", uuid)
 		}
 	}
-
-	// Second run - migration should NOT run again (already completed)
-	// and should NOT overwrite user's explicit setting
-	cfg2, err := NewConfig(WithConfigDir(tmpDir))
-	if err != nil {
-		t.Fatalf("NewConfig error (second run): %v", err)
+	if n := countRules(c, RuleUUIDBuiltinClaudeDesktopSonnet46); n != 1 {
+		t.Errorf("sonnet rule duplicated: count = %d", n)
 	}
-
-	// Verify migration is still marked as completed
-	if !cfg2.hasMigrationCompleted("20260606") {
-		t.Error("Migration should still be marked as completed")
-	}
-
-	xcodeConfig2 := cfg2.GetScenarioConfig(typ.ScenarioXcode)
-	if xcodeConfig2 == nil {
-		t.Fatal("Xcode scenario config should still exist")
-	}
-
-	// Should preserve user's explicit choice to disable
-	if xcodeConfig2.Flags.SkipUsage {
-		t.Error("Expected to preserve user's explicit SkipUsage = false")
+	opus := c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopOpus46)
+	if opus == nil || len(opus.Services) != 1 || opus.Services[0].Provider != "p1" {
+		t.Errorf("opus46 should inherit reference services, got %+v", opus)
 	}
 }
 
-func TestMigrate20260606_PartialCustomization(t *testing.T) {
-	tmpDir := t.TempDir()
+func TestMigrate20260521_AddsHaikuFromTemplate(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: RuleUUIDBuiltinClaudeDesktopSonnet46, Scenario: typ.ScenarioClaudeDesktop, Services: []*loadbalance.Service{svc("pd")}},
+		},
+	}
 
-	// Create config with xcode scenario that has SkipUsage=false (user override)
-	cfg, err := NewConfig(WithConfigDir(tmpDir))
+	migrate20260521(c)
+
+	haiku := c.findRuleByUUID(RuleUUIDBuiltinClaudeDesktopHaiku45)
+	if haiku == nil {
+		t.Fatal("expected haiku-4-5 desktop rule to be added")
+	}
+	// Pulled from the init.go template, so it carries the built-in desktop flags.
+	if !haiku.Flags.ClaudeCodeCompat || !haiku.Flags.CleanHeader {
+		t.Errorf("haiku rule missing built-in flags: %+v", haiku.Flags)
+	}
+	// Services mirrored from the existing desktop rule.
+	if len(haiku.Services) != 1 || haiku.Services[0].Provider != "pd" {
+		t.Errorf("haiku rule should inherit desktop reference services, got %+v", haiku.Services)
+	}
+
+	// Idempotent: running again does not duplicate it.
+	migrate20260521(c)
+	if n := countRules(c, RuleUUIDBuiltinClaudeDesktopHaiku45); n != 1 {
+		t.Errorf("haiku rule duplicated: count = %d", n)
+	}
+}
+
+func TestMigrate20260606_DefaultsXcodeSkipUsage(t *testing.T) {
+	// NewConfig runs Migrate, which applies migrate20260606.
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewConfig error: %v", err)
 	}
 
-	// Manually set xcode SkipUsage to false (user explicitly disabled it)
+	if !cfg.hasMigrationCompleted("20260606") {
+		t.Error("migration 20260606 should be marked completed")
+	}
+	xcode := cfg.GetScenarioConfig(typ.ScenarioXcode)
+	if xcode == nil {
+		t.Fatal("Xcode scenario config not found")
+	}
+	if !xcode.Flags.SkipUsage {
+		t.Error("Xcode should default SkipUsage = true")
+	}
+}
+
+func TestMigrate20260606_PreservesUserOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// First boot applies the default.
+	cfg, err := NewConfig(WithConfigDir(tmpDir))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+	if x := cfg.GetScenarioConfig(typ.ScenarioXcode); x == nil || !x.Flags.SkipUsage {
+		t.Fatalf("expected SkipUsage defaulted on after first boot, got %+v", x)
+	}
+
+	// User explicitly disables it.
 	for i := range cfg.Scenarios {
 		if cfg.Scenarios[i].Scenario == typ.ScenarioXcode {
 			cfg.Scenarios[i].Flags.SkipUsage = false
@@ -109,26 +129,16 @@ func TestMigrate20260606_PartialCustomization(t *testing.T) {
 		}
 	}
 
-	// Reload config
+	// Second boot: migration is marker-gated, so the user's choice survives.
 	cfg2, err := NewConfig(WithConfigDir(tmpDir))
 	if err != nil {
 		t.Fatalf("NewConfig error (reload): %v", err)
 	}
-
-	// Verify that migration completed but didn't re-run
 	if !cfg2.hasMigrationCompleted("20260606") {
-		t.Error("Migration should still be marked as completed")
+		t.Error("migration should still be marked completed after reload")
 	}
-
-	// Verify that user's SkipUsage=false is preserved
-	xcodeConfig := cfg2.GetScenarioConfig(typ.ScenarioXcode)
-	if xcodeConfig == nil {
-		t.Fatal("Xcode scenario config should exist")
-	}
-
-	if xcodeConfig.Flags.SkipUsage != false {
-		t.Errorf("Expected user's SkipUsage=false to be preserved, got %v",
-			xcodeConfig.Flags.SkipUsage)
+	if x := cfg2.GetScenarioConfig(typ.ScenarioXcode); x == nil || x.Flags.SkipUsage {
+		t.Errorf("user's SkipUsage=false should be preserved across reload, got %+v", x)
 	}
 }
 


### PR DESCRIPTION
## Summary
Housekeeping pass over `internal/server/config` migrations. No change to live data behavior beyond the explicit bug fixes; mostly deduplication, two latent-bug fixes, and test tidying.

## Bug fixes / redundancy
- **`migrate20251225`**: add the missing `c.Save()` — it clamped legacy JSON provider timeouts in memory but never persisted them (relied on re-running every boot). Now only saves when a value actually changes, and uses the `DefaultMaxTimeout` constant instead of a magic `30*60`.
- **`migrate20260416`**: drop the per-field empty checks that the early-return guard already guarantees.
- **Reorder** the migrate list chronologically (`20260517`/`20260518` were listed after `20260521`).

## Shared helpers (dedupe 5 rule-seeding migrations)
New helpers: `findRuleByUUID`, `defaultRuleByUUID`, `cloneServices`, `referenceServicesFor`.
- Refactored `migrate20260110` / `20260210` / `20260306` / `20260513` / `20260521` to use them — centralizing the "look up rule → pull template → copy services" pattern.
- `migrate20260521` now pulls its rule from the `DefaultRules` template instead of a hand-maintained literal, so its flags stay in sync with `init.go`'s `cdRule` — **fixes a drift** where the literal was missing `session_affinity`.
- `cloneServices` returns `nil` for empty input (matching how migrations test for missing services); `referenceServicesFor` matches in argument order while iterating rules in config order (deterministic).

## Tests
- Added coverage for the helpers and the previously-untested `migrate20260110` / `20260513` / `20260521`.
- Tidied the suite: merged the two near-identical `20260606` cases (`Idempotent` + `PartialCustomization`) into one `PreservesUserOverride`, kept a focused default-value test, and split files by concern — `migration_test.go` for migration-function tests (ordered by date), `migration_helpers_test.go` for helper unit tests + shared `svc()`/`countRules()` fixtures.

## Evaluation: legacy provider migrations (kept, not removed)
`migrate20251221` (v1→v2) and `migrate20251225` operate on the legacy JSON provider fields. `Migrate()` runs *before* `migrateProvidersToDB()`, so these only matter on the one-time JSON→DB import path; for anyone already on a DB build they're permanent no-ops. **Kept** them — removing would break direct upgrades from pre-DB (pre-2026 v1) configs (provider data loss). Flagging in case we decide to drop pre-DB upgrade support.

## Validation
`go build ./...` clean; `internal/server/config` + `internal/server/...` suites pass. Net −33 lines in `migration.go`.

https://claude.ai/code/session_01SKEfxJ4DybS3sdfcHPjjGp