### PR TITLE
fix(usage): preserve cache/reasoning tokens across protocol conversions

### DIFF
--- a/internal/protocol/nonstream/google_to.go
+++ b/internal/protocol/nonstream/google_to.go
@@ -172,10 +172,16 @@ func ConvertGoogleToAnthropicResponse(googleResp *genai.GenerateContentResponse,
 
 	// Add usage info if available
 	if googleResp.UsageMetadata != nil {
-		responseJSON["usage"] = map[string]interface{}{
+		usage := map[string]interface{}{
 			"input_tokens":  googleResp.UsageMetadata.PromptTokenCount,
 			"output_tokens": googleResp.UsageMetadata.CandidatesTokenCount,
 		}
+		// Gemini's cached-content tokens map to Anthropic cache-read so the
+		// client-facing response reports the cache hit instead of dropping it.
+		if googleResp.UsageMetadata.CachedContentTokenCount > 0 {
+			usage["cache_read_input_tokens"] = googleResp.UsageMetadata.CachedContentTokenCount
+		}
+		responseJSON["usage"] = usage
 	}
 
 	// Marshal and unmarshal to create proper Message struct
@@ -260,10 +266,16 @@ func ConvertGoogleToAnthropicBetaResponse(googleResp *genai.GenerateContentRespo
 
 	// Add usage info if available
 	if googleResp.UsageMetadata != nil {
-		responseJSON["usage"] = map[string]interface{}{
+		usage := map[string]interface{}{
 			"input_tokens":  googleResp.UsageMetadata.PromptTokenCount,
 			"output_tokens": googleResp.UsageMetadata.CandidatesTokenCount,
 		}
+		// Gemini's cached-content tokens map to Anthropic cache-read so the
+		// client-facing response reports the cache hit instead of dropping it.
+		if googleResp.UsageMetadata.CachedContentTokenCount > 0 {
+			usage["cache_read_input_tokens"] = googleResp.UsageMetadata.CachedContentTokenCount
+		}
+		responseJSON["usage"] = usage
 	}
 
 	// Marshal and unmarshal to create proper BetaMessage struct

--- a/internal/protocol/nonstream/google_to_test.go
+++ b/internal/protocol/nonstream/google_to_test.go
@@ -672,6 +672,33 @@ func TestConvertGoogleToAnthropicResponse(t *testing.T) {
 		}
 	})
 
+	t.Run("maps cached content to cache_read_input_tokens", func(t *testing.T) {
+		resp := &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content:      &genai.Content{Role: "model", Parts: []*genai.Part{genai.NewPartFromText("hi")}},
+					FinishReason: genai.FinishReasonStop,
+				},
+			},
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:        30,
+				CandidatesTokenCount:    5,
+				CachedContentTokenCount: 12,
+			},
+		}
+
+		anthropicResp := ConvertGoogleToAnthropicResponse(resp, "gemini-pro")
+
+		// Gemini cached-content tokens must surface as Anthropic cache-read in the
+		// client-facing response body, not be dropped to 0.
+		if anthropicResp.Usage.CacheReadInputTokens != 12 {
+			t.Errorf("expected cache_read_input_tokens 12, got %d", anthropicResp.Usage.CacheReadInputTokens)
+		}
+		if anthropicResp.Usage.InputTokens != 30 {
+			t.Errorf("expected input_tokens 30, got %d", anthropicResp.Usage.InputTokens)
+		}
+	})
+
 	t.Run("with function call", func(t *testing.T) {
 		resp := &genai.GenerateContentResponse{
 			Candidates: []*genai.Candidate{

--- a/internal/protocol/nonstream/openai_responses.go
+++ b/internal/protocol/nonstream/openai_responses.go
@@ -40,17 +40,27 @@ func BuildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, a
 		})
 	}
 
+	usageMap := map[string]any{
+		"input_tokens":  resp.Usage.PromptTokens,
+		"output_tokens": resp.Usage.CompletionTokens,
+		"total_tokens":  resp.Usage.PromptTokens + resp.Usage.CompletionTokens,
+	}
+	// Carry cache-read and reasoning detail so a client reading usage off the
+	// Responses-API body sees them instead of zeros.
+	if cached := resp.Usage.PromptTokensDetails.CachedTokens; cached > 0 {
+		usageMap["input_tokens_details"] = map[string]any{"cached_tokens": cached}
+	}
+	if reasoning := resp.Usage.CompletionTokensDetails.ReasoningTokens; reasoning > 0 {
+		usageMap["output_tokens_details"] = map[string]any{"reasoning_tokens": reasoning}
+	}
+
 	result := map[string]any{
 		"id":     resp.ID,
 		"object": "response",
 		"model":  model,
 		"status": status,
 		"output": output,
-		"usage": map[string]any{
-			"input_tokens":  resp.Usage.PromptTokens,
-			"output_tokens": resp.Usage.CompletionTokens,
-			"total_tokens":  resp.Usage.PromptTokens + resp.Usage.CompletionTokens,
-		},
+		"usage":  usageMap,
 	}
 	if incompleteDetails != nil {
 		result["incomplete_details"] = incompleteDetails
@@ -120,17 +130,26 @@ func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, respons
 		output = append([]map[string]any{msgItem}, output...)
 	}
 
+	// Responses-API input_tokens is the TOTAL prompt cost. Anthropic reports
+	// uncached input separately from cache-read/creation, so fold them in here
+	// (matching the Chat conversion) instead of reporting only the uncached slice.
+	totalInput := resp.Usage.InputTokens + resp.Usage.CacheReadInputTokens + resp.Usage.CacheCreationInputTokens
+	usageMap := map[string]any{
+		"input_tokens":  totalInput,
+		"output_tokens": resp.Usage.OutputTokens,
+		"total_tokens":  totalInput + resp.Usage.OutputTokens,
+	}
+	if cached := resp.Usage.CacheReadInputTokens; cached > 0 {
+		usageMap["input_tokens_details"] = map[string]any{"cached_tokens": cached}
+	}
+
 	result := map[string]any{
 		"id":     resp.ID,
 		"object": "response",
 		"model":  model,
 		"status": status,
 		"output": output,
-		"usage": map[string]any{
-			"input_tokens":  resp.Usage.InputTokens,
-			"output_tokens": resp.Usage.OutputTokens,
-			"total_tokens":  resp.Usage.InputTokens + resp.Usage.OutputTokens,
-		},
+		"usage":  usageMap,
 	}
 	if incompleteDetails != nil {
 		result["incomplete_details"] = incompleteDetails

--- a/internal/protocol/nonstream/openai_responses_usage_test.go
+++ b/internal/protocol/nonstream/openai_responses_usage_test.go
@@ -1,0 +1,83 @@
+package nonstream
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildResponsesPayloadFromChat_UsageDetails verifies that cache-read and
+// reasoning detail survive the Chat→Responses body conversion instead of being
+// dropped to zero.
+func TestBuildResponsesPayloadFromChat_UsageDetails(t *testing.T) {
+	resp := &openai.ChatCompletion{
+		ID: "chatcmpl-1",
+		Choices: []openai.ChatCompletionChoice{
+			{Message: openai.ChatCompletionMessage{Role: "assistant", Content: "hi"}, FinishReason: "stop"},
+		},
+		Usage: openai.CompletionUsage{
+			PromptTokens:     100,
+			CompletionTokens: 40,
+			TotalTokens:      140,
+			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+				CachedTokens: 30,
+			},
+			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+				ReasoningTokens: 12,
+			},
+		},
+	}
+
+	payload := BuildResponsesPayloadFromChat(resp, "gpt-x", "gpt-x")
+	usage, _ := payload["usage"].(map[string]any)
+	require.NotNil(t, usage)
+
+	assert.EqualValues(t, 100, usage["input_tokens"])
+	assert.EqualValues(t, 40, usage["output_tokens"])
+
+	inDetails, _ := usage["input_tokens_details"].(map[string]any)
+	require.NotNil(t, inDetails, "input_tokens_details must carry cached_tokens")
+	assert.EqualValues(t, 30, inDetails["cached_tokens"])
+
+	outDetails, _ := usage["output_tokens_details"].(map[string]any)
+	require.NotNil(t, outDetails, "output_tokens_details must carry reasoning_tokens")
+	assert.EqualValues(t, 12, outDetails["reasoning_tokens"])
+}
+
+// TestBuildResponsesPayloadFromAnthropicBeta_UsageDetails verifies that the
+// Responses-API input_tokens is the TOTAL prompt cost (uncached + cache-read +
+// cache-creation), matching the streaming converter, and that cache-read is
+// surfaced as cached_tokens instead of being dropped.
+func TestBuildResponsesPayloadFromAnthropicBeta_UsageDetails(t *testing.T) {
+	resp := &anthropic.BetaMessage{
+		ID:   "msg_1",
+		Role: "assistant",
+		Type: "message",
+		Content: []anthropic.BetaContentBlockUnion{
+			{Type: "text", Text: "hi"},
+		},
+		Usage: anthropic.BetaUsage{
+			InputTokens:              50,
+			OutputTokens:             20,
+			CacheReadInputTokens:     11,
+			CacheCreationInputTokens: 5,
+		},
+		StopReason: "end_turn",
+	}
+
+	payload := BuildResponsesPayloadFromAnthropicBeta(resp, "claude-x", "claude-x")
+	usage, _ := payload["usage"].(map[string]any)
+	require.NotNil(t, usage)
+
+	// Total input = 50 uncached + 11 cache-read + 5 cache-creation = 66.
+	assert.EqualValues(t, 66, usage["input_tokens"], "input_tokens must be total prompt cost, not uncached only")
+	assert.EqualValues(t, 20, usage["output_tokens"])
+	assert.EqualValues(t, 86, usage["total_tokens"])
+
+	inDetails, _ := usage["input_tokens_details"].(map[string]any)
+	require.NotNil(t, inDetails, "input_tokens_details must carry cached_tokens")
+	assert.EqualValues(t, 11, inDetails["cached_tokens"])
+}

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -28,13 +28,16 @@ type AnthropicToOpenAIMCPHooks struct {
 	OnToolCallsFinal   func(calls []AnthropicToOpenAIToolCall) error
 }
 
-// AnthropicToOpenAIStream processes Anthropic streaming events and converts them to OpenAI format
-// Returns inputTokens, outputTokens, and error for usage tracking
-func AnthropicToOpenAIStream(hc *protocol.HandleContext, req *anthropic.BetaMessageNewParams, stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], responseModel string, disableStreamUsage bool) (int, int, error) {
+// AnthropicToOpenAIStream processes Anthropic streaming events and converts them to OpenAI format.
+// Returns the normalized TokenUsage (input/output plus cache-read and reasoning
+// tokens) and an error for usage tracking. Returning the full usage — rather
+// than just input/output — keeps cache tokens out of the dropped column when
+// the recorded usage is persisted on the conversion path.
+func AnthropicToOpenAIStream(hc *protocol.HandleContext, req *anthropic.BetaMessageNewParams, stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], responseModel string, disableStreamUsage bool) (*protocol.TokenUsage, error) {
 	return AnthropicToOpenAIStreamWithMCPHooks(hc, req, stream, responseModel, disableStreamUsage, nil)
 }
 
-func AnthropicToOpenAIStreamWithMCPHooks(hc *protocol.HandleContext, req *anthropic.BetaMessageNewParams, stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], responseModel string, disableStreamUsage bool, hooks *AnthropicToOpenAIMCPHooks) (int, int, error) {
+func AnthropicToOpenAIStreamWithMCPHooks(hc *protocol.HandleContext, req *anthropic.BetaMessageNewParams, stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], responseModel string, disableStreamUsage bool, hooks *AnthropicToOpenAIMCPHooks) (*protocol.TokenUsage, error) {
 	c := hc.GinContext
 	logrus.WithContext(c.Request.Context()).Info("Starting Anthropic to OpenAI streaming response handler")
 	defer func() {
@@ -55,54 +58,53 @@ func AnthropicToOpenAIStreamWithMCPHooks(hc *protocol.HandleContext, req *anthro
 
 	conv := newAnthropicToOpenAIConverter(stream, responseModel, disableStreamUsage, hooks)
 	usage, err := RunConverter(hc, conv, openaiChatSSEWriter(c))
-	in, out := usage.InputTokens, usage.OutputTokens
 
 	// MCP continuation: hook requested the stream to be retried
 	if hookErr := conv.HookErr(); errors.Is(hookErr, ErrMCPStreamContinue) {
-		return in, out, hookErr
+		return usage, hookErr
 	}
 
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			logrus.WithContext(c.Request.Context()).Debug("Anthropic to OpenAI stream canceled by client")
-			return in, out, nil
+			return usage, nil
 		}
 		if errors.Is(err, io.EOF) {
 			logrus.WithContext(c.Request.Context()).Info("Anthropic stream ended normally (EOF)")
-			return in, out, nil
+			return usage, nil
 		}
 		logrus.WithContext(c.Request.Context()).Errorf("Anthropic stream error: %v", err)
 		streamErr := fmt.Errorf("anthropic stream error: %w", err)
 		hc.DispatchStreamError(streamErr)
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
-			return in, out, streamErr
+			return usage, streamErr
 		}
 		sendOpenAIStreamError(c, err.Error(), "stream_error")
-		return in, out, streamErr
+		return usage, streamErr
 	}
 
 	if err := stream.Err(); err != nil {
 		if errors.Is(err, context.Canceled) {
 			logrus.WithContext(c.Request.Context()).Debug("Anthropic to OpenAI stream canceled by client")
-			return in, out, nil
+			return usage, nil
 		}
 		if errors.Is(err, io.EOF) {
-			return in, out, nil
+			return usage, nil
 		}
 		logrus.WithContext(c.Request.Context()).Errorf("Anthropic stream error: %v", err)
 		streamErr := fmt.Errorf("anthropic stream error: %w", err)
 		hc.DispatchStreamError(streamErr)
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
-			return in, out, streamErr
+			return usage, streamErr
 		}
 		sendOpenAIStreamError(c, err.Error(), "stream_error")
-		return in, out, streamErr
+		return usage, streamErr
 	}
 
 	OpenAISSEDone(c)
-	return in, out, nil
+	return usage, nil
 }
 
 // sendOpenAIStreamChunk sends a ChatCompletionChunk as SSE

--- a/internal/protocol/stream/anthropic_to_openai_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_test.go
@@ -58,7 +58,7 @@ func TestHandleAnthropicToOpenAIStreamResponse(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 
 	// Run the handler
-	_, _, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, model), nil, stream, model, false)
+	_, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, model), nil, stream, model, false)
 	require.NoError(t, err)
 
 	// Verify the response
@@ -120,12 +120,12 @@ func TestAnthropicToOpenAIStream_RealFormatUsage(t *testing.T) {
 	decoder := newFakeAnthropicDecoder(events)
 	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](decoder, nil)
 
-	inputTokens, outputTokens, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, "claude-3-5-sonnet"), nil, stream, "claude-3-5-sonnet", false)
+	usage, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, "claude-3-5-sonnet"), nil, stream, "claude-3-5-sonnet", false)
 	require.NoError(t, err)
 
 	// Returned counts must be correct
-	assert.Equal(t, 35, inputTokens, "input_tokens must come from message_start")
-	assert.Equal(t, 18, outputTokens)
+	assert.Equal(t, 35, usage.InputTokens, "input_tokens must come from message_start")
+	assert.Equal(t, 18, usage.OutputTokens)
 
 	// The SSE body must contain a usage chunk with correct prompt_tokens.
 	// The OpenAI SDK always serializes Usage even when zero, so there may be an early
@@ -176,11 +176,11 @@ func TestAnthropicToOpenAIStream_NonStandardDelta(t *testing.T) {
 	decoder := newFakeAnthropicDecoder(events)
 	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](decoder, nil)
 
-	inputTokens, outputTokens, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, "custom-model"), nil, stream, "custom-model", false)
+	usage, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, "custom-model"), nil, stream, "custom-model", false)
 	require.NoError(t, err)
 
-	assert.Equal(t, 40, inputTokens)
-	assert.Equal(t, 20, outputTokens)
+	assert.Equal(t, 40, usage.InputTokens)
+	assert.Equal(t, 20, usage.OutputTokens)
 }
 
 // TestSendOpenAIStreamChunk tests the helper function

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -56,11 +56,14 @@ func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 			c.Request, _ = http.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", nil)
 
-			input, output, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, modelID), nil, stream, modelID, false)
+			usage, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, modelID), nil, stream, modelID, false)
 			require.NoError(t, err)
 			// Anthropic input_tokens=42, cache_creation=5 → stored as 42+5=47 (non-cache-read total)
-			assert.Equal(t, 47, input, "InputTokens should be input_tokens + cache_creation_input_tokens")
-			assert.Equal(t, 17, output, "OutputTokens should reflect upstream output_tokens")
+			assert.Equal(t, 47, usage.InputTokens, "InputTokens should be input_tokens + cache_creation_input_tokens")
+			assert.Equal(t, 17, usage.OutputTokens, "OutputTokens should reflect upstream output_tokens")
+			// The returned usage (what gets persisted) must retain cache_read_input_tokens
+			// instead of dropping it to 0 on the conversion path.
+			assert.Equal(t, 11, usage.CacheInputTokens, "CacheInputTokens should retain cache_read_input_tokens for recorded usage")
 
 			body := w.Body.String()
 

--- a/internal/server/anthropic_to_openai_mcp_stream.go
+++ b/internal/server/anthropic_to_openai_mcp_stream.go
@@ -41,12 +41,11 @@ func (s *Server) streamAnthropicBetaToOpenAIChatWithMCP(
 
 		hooks := s.buildAnthropicToOpenAIMCPHooks(c.Request.Context(), req)
 		hc := protocol.NewHandleContext(c, responseModel)
-		inputTokens, outputTokens, err := stream.AnthropicToOpenAIStreamWithMCPHooks(hc, req, streamResp, responseModel, disableStreamUsage, hooks)
+		usage, err := stream.AnthropicToOpenAIStreamWithMCPHooks(hc, req, streamResp, responseModel, disableStreamUsage, hooks)
 		if errors.Is(err, stream.ErrMCPStreamContinue) {
 			continue
 		}
 		if err != nil {
-			usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
 			s.trackUsageWithTokenUsage(c, usage, err)
 			stream.SendInternalError(c, err.Error())
 			if recorder != nil {
@@ -55,7 +54,6 @@ func (s *Server) streamAnthropicBetaToOpenAIChatWithMCP(
 			return
 		}
 
-		usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
 		s.trackUsageWithTokenUsage(c, usage, nil)
 		return
 	}

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -294,10 +294,9 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 		}
 
 		hc := protocol.NewHandleContext(c, responseModel)
-		inputTokens, outputTokens, err := stream.AnthropicToOpenAIStream(hc, req, streamResp, responseModel, disableStreamUsage)
+		tokenUsage, err := stream.AnthropicToOpenAIStream(hc, req, streamResp, responseModel, disableStreamUsage)
 		if err != nil {
-			if inputTokens > 0 || outputTokens > 0 {
-				tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
+			if tokenUsage.InputTokens > 0 || tokenUsage.OutputTokens > 0 {
 				s.trackUsageWithTokenUsage(c, tokenUsage, err)
 			} else {
 				// Track error even when no tokens were received (e.g., early 1302 rate limit)
@@ -310,8 +309,7 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 			return
 		}
 
-		if inputTokens > 0 || outputTokens > 0 {
-			tokenUsage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
+		if tokenUsage.InputTokens > 0 || tokenUsage.OutputTokens > 0 {
 			s.trackUsageWithTokenUsage(c, tokenUsage, nil)
 		}
 	} else {
@@ -1110,9 +1108,8 @@ func (s *Server) dispatchOpenAIChatToAnthropicBetaGeneric(
 	// Step 3: Convert Anthropic Beta stream back to OpenAI Chat format on-the-fly
 	// This achieves TRUE streaming with proper format conversion
 	hc := protocol.NewHandleContext(c, responseModel)
-	inputTokens, outputTokens, err := stream.AnthropicToOpenAIStream(hc, anthropicReq, anthropicStream, responseModel, false)
+	usage, err := stream.AnthropicToOpenAIStream(hc, anthropicReq, anthropicStream, responseModel, false)
 	if err != nil {
-		usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
 		s.trackUsageWithTokenUsage(c, usage, err)
 		stream.SendInternalError(c, err.Error())
 		if recorder != nil {
@@ -1121,6 +1118,5 @@ func (s *Server) dispatchOpenAIChatToAnthropicBetaGeneric(
 		return
 	}
 
-	usage := protocol.NewTokenUsageWithCache(inputTokens, outputTokens, 0)
 	s.trackUsageWithTokenUsage(c, usage, nil)
 }


### PR DESCRIPTION
## Summary

Token usage was being lost on several protocol-**conversion** paths. The conversion code had richer usage (cache-read, cache-creation, reasoning) available, but narrowed it before it reached either the persisted analytics record or the client-facing response body. This PR threads the full usage through every wired conversion path.

The audit separated two axes:
- **Persisted analytics** — the `trackUsageWithTokenUsage` → DB/OTel record.
- **Response-body fidelity** — the `usage` block the client reads off the wire.

After this PR, no wired conversion path drops usage on either axis. (The persisted side was already correct everywhere *except* the streaming Anthropic→OpenAI path fixed below.)

## Changes

### 1. Streaming Anthropic→OpenAI — persisted cache dropped to 0 (the original bug)
`AnthropicToOpenAIStream` / `…WithMCPHooks` returned `(int, int, error)`, so every caller rebuilt usage as `NewTokenUsageWithCache(in, out, 0)` — hardcoding cache to **0** in the persisted record, even though the internal `AnthropicAccumulator` had the cache-read count. The SSE response to the client was already correct; only the recorded analytics were wrong.
- Return `*protocol.TokenUsage` from both functions; record it directly at all three call sites (`protocol_dispatch.go`, `anthropic_to_openai_mcp_stream.go`). Error/cancel/EOF branches return the partially-accumulated usage so failures still record what was seen.

### 2. Nonstream Google→Anthropic — response body dropped cache
`ConvertGoogleToAnthropicResponse` / `…BetaResponse` built the usage block with only `input_tokens`/`output_tokens`, dropping Gemini's `CachedContentTokenCount`. Persisted analytics were already correct (extracted directly at dispatch); this is response fidelity — a Gemini-backed Anthropic client saw `cache_read_input_tokens=0`.
- Map `CachedContentTokenCount` → `cache_read_input_tokens` when present.

### 3. Nonstream Responses-API bodies — dropped detail / undercounted input
The nonstream Responses-API builders lagged their streaming counterparts:
- `BuildResponsesPayloadFromChat` omitted `input_tokens_details.cached_tokens` and `output_tokens_details.reasoning_tokens`.
- `BuildResponsesPayloadFromAnthropicBeta` reported `input_tokens` as the **uncached** slice only (undercount), and omitted `cached_tokens`. It now reports total prompt cost (`input + cache_read + cache_creation`) with `cached_tokens` detail — matching `toResponsesUsageWire` on the streaming path.

## Verification
- `go build` / `go vet` clean; `internal/protocol/stream`, `internal/protocol/nonstream`, `internal/protocol/usage`, and `internal/server` suites pass.
- Added regression tests: cache-read retained in the recorded usage (`TestAnthropicToOpenAIStream_VModelFullUsage`), Gemini cached-content → Anthropic cache-read, and both Responses-API builders carry cache/reasoning detail.

## Notes
Three Google converters (`ConvertAnthropicToGoogleResponse`, `ConvertGoogleToOpenAIResponse`, `ConvertOpenAIToGoogleResponse`) also drop cache but have **no dispatch caller** — latent dead code, left untouched here.

https://claude.ai/code/session_01X5bJk5NGbdyYWmwWgcqBtN