### PR TITLE
feat(frontend,server): extend 1M context window support to Codex and Claude Code/Desktop

### DIFF
--- a/frontend/src/components/ModelRequestHeader.tsx
+++ b/frontend/src/components/ModelRequestHeader.tsx
@@ -8,6 +8,7 @@ import {
     Menu,
     MenuItem,
     ListItemText,
+    Switch,
 } from '@mui/material';
 import { alpha, styled } from '@mui/material/styles';
 import React, { useState } from 'react';
@@ -81,6 +82,9 @@ export interface ModelRequestHeaderProps {
     extraActions?: React.ReactNode;
     isExpanded?: boolean;
     onToggleExpanded?: () => void;
+    // 1M context window props
+    context1M?: boolean;
+    onContext1MToggle?: () => void;
 }
 
 export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
@@ -95,6 +99,8 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
     extraActions,
     isExpanded = true,
     onToggleExpanded,
+    context1M = false,
+    onContext1MToggle,
 }) => {
     const [editMode, setEditMode] = useState(false);
     const [tempValue, setTempValue] = useState(modelName);
@@ -246,6 +252,42 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                         <EditIcon sx={{ fontSize: '0.95rem' }} />
                     </IconButton>
                 </Tooltip>
+
+                {/* 1M Context Toggle */}
+                {onContext1MToggle && (
+                    <Tooltip title={context1M ? "Disable 1M context window" : "Enable 1M context window"}>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                ml: 0.5,
+                                opacity: active ? 1 : 0.5,
+                                pointerEvents: active ? 'auto' : 'none',
+                            }}
+                        >
+                            <Typography
+                                variant="caption"
+                                sx={{
+                                    fontSize: '0.7rem',
+                                    fontWeight: 600,
+                                    color: context1M ? 'primary.main' : 'text.secondary',
+                                    userSelect: 'none'
+                                }}
+                            >
+                                1M
+                            </Typography>
+                            <Switch
+                                size="small"
+                                checked={context1M}
+                                onChange={(e) => {
+                                    e.stopPropagation();
+                                    onContext1MToggle();
+                                }}
+                            />
+                        </Box>
+                    </Tooltip>
+                )}
             </Box>
         );
     };

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -70,6 +70,7 @@ export interface RuleFlags {
     visionProxyService?: VisionProxyServiceRef;
     claudeCodeCompat?: boolean;
     cleanHeader?: boolean;
+    context1m?: boolean;
 }
 
 export interface RuleFlagsApi {
@@ -86,6 +87,7 @@ export interface RuleFlagsApi {
     vision_proxy_service?: VisionProxyServiceRef;
     claude_code_compat?: boolean;
     clean_header?: boolean;
+    context_1m?: boolean;
 }
 
 export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref';

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -17,6 +17,7 @@ import RulePluginsCard from '@/components/rule-card/RulePluginsCard';
 import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
 import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
 import { getFlagValue, setFlagValue } from '@/components/rule-card/flagHelpers';
+import { formatModelNameWithContext1M } from '@/components/rule-card/modelNameUtils';
 
 // Module-level cache so we only fetch the flag catalog once per session.
 // `undefined` = never fetched; `[]` = fetched but empty (don't re-fetch).
@@ -291,9 +292,9 @@ export const RuleCard: React.FC<RuleCardProps> = ({
             onToggleActive={() => updateField(configRecord, setConfigRecord, 'active', !configRecord.active)}
             onEditFlags={handleOpenFlagEditor}
             ruleUuid={rule.uuid}
-            ruleName={rule.request_model || rule.uuid}
+            ruleName={formatModelNameWithContext1M(rule.request_model || rule.uuid, configRecord.flags)}
             scenario={rule.scenario}
-            model={rule.request_model}
+            model={formatModelNameWithContext1M(rule.request_model, configRecord.flags)}
         />
     );
 

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -59,6 +59,7 @@ export interface RuleCardProps {
     onRuleDelete?: (ruleUuid: string) => void;
     allowToggleRule?: boolean;
     onToggleExpanded?: () => void;
+    onContext1MToggle?: (newState: boolean) => void;
 }
 
 export const RuleCard: React.FC<RuleCardProps> = ({
@@ -77,6 +78,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     onRuleDelete,
     allowToggleRule = true,
     onToggleExpanded,
+    onContext1MToggle,
 }) => {
     // Expansion state management
     const { expanded, handleToggleExpanded } = useRuleCardExpanded({
@@ -323,6 +325,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 onAddServiceToSmartRule={handleAddServiceToSmartRuleByUuid}
                 onDeleteServiceFromSmartRule={smartHandlers.handleDeleteServiceFromSmartRule}
                 onSwitchRoutingMode={handleRoutingModeSwitch}
+                onContext1MToggle={onContext1MToggle}
             />
 
             {/* Delete Confirmation Dialog */}

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -101,6 +101,9 @@ export interface UnifiedRoutingGraphProps {
     // Routing mode switch
     onSwitchRoutingMode?: () => void;
 
+    // 1M context window toggle - receives the new state for scenario-specific handling
+    onContext1MToggle?: (newState: boolean) => void;
+
     // Slots
     extraActions?: React.ReactNode;
     extensionsCard?: React.ReactNode;
@@ -183,6 +186,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                                             onAddServiceToSmartRule,
                                                                             onDeleteServiceFromSmartRule,
                                                                             onSwitchRoutingMode,
+                                                                            onContext1MToggle,
                                                                             extraActions,
                                                                             extensionsCard,
                                                                             autoScroll,
@@ -467,6 +471,8 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                     // Update the flags
                     const updatedFlags = { ...record.flags, context1m: newState };
                     onUpdateRecord?.('flags', updatedFlags);
+                    // Notify parent for scenario-specific handling
+                    onContext1MToggle?.(newState);
                 }}
             />
 

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -63,7 +63,7 @@ const RULE_GRAPH_STYLES = {
     },
 } as const;
 
-const {header, graphContainer, graph} = RULE_GRAPH_STYLES;
+const {graphContainer, graph} = RULE_GRAPH_STYLES;
 
 export interface UnifiedRoutingGraphProps {
     // Mode control
@@ -461,6 +461,13 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 extraActions={extraActions}
                 isExpanded={isExpanded}
                 onToggleExpanded={onToggleExpanded}
+                context1M={record.flags?.context1m || false}
+                onContext1MToggle={() => {
+                    const newState = !(record.flags?.context1m || false);
+                    // Update the flags
+                    const updatedFlags = { ...record.flags, context1m: newState };
+                    onUpdateRecord?.('flags', updatedFlags);
+                }}
             />
 
             {/* Tier Guide Dialog */}

--- a/frontend/src/components/nodes/ModelNode.tsx
+++ b/frontend/src/components/nodes/ModelNode.tsx
@@ -16,6 +16,7 @@ import {
     AutoAwesome as AutoAwesomeIcon,
     NearMeOutlined as DirectIcon,
     Settings as SettingsIcon,
+    Psychology as MemoryIcon,
 } from '@/components/icons';
 import { alpha, styled } from '@mui/material/styles';
 import React, { useState } from 'react';
@@ -51,6 +52,9 @@ export interface ModelNodeProps {
     showSmartSwitch?: boolean;
     switchDisabled?: boolean;
     onSwitch?: () => void;
+    // 1M context window props
+    context1M?: boolean;
+    onContext1MToggle?: () => void;
 }
 
 export const ModelNode: React.FC<ModelNodeProps> = ({
@@ -66,6 +70,9 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
     showSmartSwitch = false,
     switchDisabled = false,
     onSwitch,
+    // 1M context window props
+    context1M = false,
+    onContext1MToggle,
 }) => {
     const { t } = useTranslation();
     const [editMode, setEditMode] = useState(false);
@@ -283,6 +290,50 @@ export const ModelNode: React.FC<ModelNodeProps> = ({
                             >
                                 <AutoAwesomeIcon sx={{ fontSize: 13 }} />
                                 Smart
+                            </ToggleButton>
+                        </NodeTooltip>
+                    </Box>
+                )}
+
+                {/* Divider - only show when 1M context switch is visible */}
+                {(context1M || onContext1MToggle) && !editMode && (
+                    <Divider sx={NODE_LAYER_STYLES.divider} />
+                )}
+
+                {/* Bottom Layer - 1M Context Switch */}
+                {(context1M || onContext1MToggle) && !editMode && (
+                    <Box sx={NODE_LAYER_STYLES.bottomLayer}>
+                        <NodeTooltip title={context1M ? "1M context enabled" : "Enable 1M context window"} placement="bottom-start">
+                            <ToggleButton
+                                value="context1m"
+                                selected={context1M}
+                                disabled={!active}
+                                onClick={onContext1MToggle}
+                                sx={(theme) => ({
+                                    ...NODE_LAYER_STYLES.toggleButton,
+                                    flex: 1,
+                                    borderColor: context1M ? alpha(getRouteGraphActiveColor(theme), 0.7) : alpha(theme.palette.text.disabled, 0.5),
+                                    color: context1M ? theme.palette.common.white : theme.palette.text.secondary,
+                                    '&.Mui-selected': {
+                                        backgroundColor: context1M ? getRouteGraphControlFill(theme) : 'transparent',
+                                        color: context1M ? theme.palette.common.white : theme.palette.text.primary,
+                                        borderColor: context1M ? getRouteGraphControlFill(theme) : getRouteGraphActiveColor(theme),
+                                        '& .MuiSvgIcon-root': {
+                                            color: theme.palette.common.white,
+                                        },
+                                        '&:hover': {
+                                            backgroundColor: getRouteGraphControlFillHover(theme),
+                                        },
+                                    },
+                                    '&:hover': {
+                                        backgroundColor: context1M
+                                            ? getRouteGraphControlFillHover(theme)
+                                            : alpha(theme.palette.text.disabled, theme.palette.mode === 'dark' ? 0.16 : 0.08),
+                                    },
+                                })}
+                            >
+                                <PsychologyIcon sx={{ fontSize: 13 }} />
+                                1M
                             </ToggleButton>
                         </NodeTooltip>
                     </Box>

--- a/frontend/src/components/rule-card/flagHelpers.ts
+++ b/frontend/src/components/rule-card/flagHelpers.ts
@@ -1,11 +1,15 @@
 import type { FlagSpec, RuleFlags, RuleFlagsApi, VisionProxyServiceRef } from '@/components/RoutingGraphTypes';
 
 export function snakeToCamel(s: string): string {
-    return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    return s.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
 }
 
 export function camelToSnake(s: string): string {
-    return s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+    // First handle the special case of digits at the end (e.g., context1m -> context_1m)
+    let result = s.replace(/([a-z])([0-9])([a-z])/g, '$1_$2$3');
+    // Then handle regular camelCase to snake_case (only uppercase letters)
+    result = result.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
+    return result;
 }
 
 export function getFlagValue(flags: RuleFlags | undefined, key: string): unknown {

--- a/frontend/src/components/rule-card/modelNameUtils.ts
+++ b/frontend/src/components/rule-card/modelNameUtils.ts
@@ -1,0 +1,48 @@
+/**
+ * Model name utilities for 1M context window feature
+ */
+
+/**
+ * Formats a model name with [1m] suffix if the context_1m flag is enabled
+ * @param model - The base model name
+ * @param flags - Rule flags to check for context_1m
+ * @returns Model name with [1m] suffix if context_1m is enabled, otherwise original model name
+ */
+export function formatModelNameWithContext1M(model: string, flags?: any): string {
+    if (!model || !flags || !flags.context1m) {
+        return model;
+    }
+
+    // Only add suffix if not already present
+    if (!model.endsWith('[1m]')) {
+        return `${model}[1m]`;
+    }
+
+    return model;
+}
+
+/**
+ * Strips the [1m] suffix from a model name if present
+ * @param model - Model name that may contain [1m] suffix
+ * @returns Model name without [1m] suffix
+ */
+export function stripContext1MSuffix(model: string): string {
+    if (!model) {
+        return model;
+    }
+
+    if (model.endsWith('[1m]')) {
+        return model.slice(0, -4); // Remove '[1m]'
+    }
+
+    return model;
+}
+
+/**
+ * Checks if a model name has the 1M context suffix
+ * @param model - Model name to check
+ * @returns true if model name ends with [1m], false otherwise
+ */
+export function hasContext1MSuffix(model: string): boolean {
+    return model && model.endsWith('[1m]');
+}

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -143,6 +143,10 @@ const UseClaudeCodePageContent: React.FC = () => {
             ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Claude Code and restart Claude Code for the changes to take effect.'
             : '1M context window disabled. Model names have been updated. Please reapply the configuration to Claude Code and restart Claude Code for the changes to take effect.';
         showNotification(message, 'success');
+
+        // Auto-open the config panel so user can immediately reapply
+        setConfigModalOpen(true);
+
         setPendingContext1MState(null);
     };
 

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -58,8 +58,13 @@ const UseClaudeCodePageContent: React.FC = () => {
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
-    const [context1MDialogOpen, setContext1MDialogOpen] = useState(false);
-    const [pendingContext1MState, setPendingContext1MState] = useState<boolean | null>(null);
+    const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
+
+    const handleContext1MToggle = (newState: boolean) => {
+        // Store the pending change and directly open config panel
+        setPendingContext1MChange(newState);
+        setConfigModalOpen(true);
+    };
 
     // Load scenario config to get config mode
     const loadScenarioConfig = async () => {
@@ -128,26 +133,6 @@ const UseClaudeCodePageContent: React.FC = () => {
     const cancelModeChange = () => {
         setConfirmDialogOpen(false);
         setPendingMode(null);
-    };
-
-    // Handle 1M context window toggle
-    const handleContext1MToggle = (newState: boolean) => {
-        setPendingContext1MState(newState);
-        setContext1MDialogOpen(true);
-    };
-
-    // Confirm 1M context change
-    const confirmContext1MChange = () => {
-        setContext1MDialogOpen(false);
-        const message = pendingContext1MState
-            ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Claude Code and restart Claude Code for the changes to take effect.'
-            : '1M context window disabled. Model names have been updated. Please reapply the configuration to Claude Code and restart Claude Code for the changes to take effect.';
-        showNotification(message, 'success');
-
-        // Auto-open the config panel so user can immediately reapply
-        setConfigModalOpen(true);
-
-        setPendingContext1MState(null);
     };
 
     useEffect(() => {
@@ -328,42 +313,12 @@ const UseClaudeCodePageContent: React.FC = () => {
                     </DialogActions>
                 </Dialog>
 
-                {/* 1M Context Window Toggle Confirmation Dialog */}
-                <Dialog open={context1MDialogOpen} onClose={() => setContext1MDialogOpen(false)} maxWidth="sm" fullWidth>
-                    <DialogTitle>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <RestartIcon color="primary" />
-                            <span>1M Context Window Change</span>
-                        </Box>
-                    </DialogTitle>
-                    <DialogContent>
-                        <Alert severity="info" sx={{ mb: 2 }}>
-                            {pendingContext1MState
-                                ? 'Enabling 1M context window will update model names with [1m] suffix.'
-                                : 'Disabling 1M context window will remove [1m] suffix from model names.'}
-                        </Alert>
-                        <Typography variant="body1" sx={{ mb: 1 }}>
-                            You are about to {pendingContext1MState ? 'enable' : 'disable'} the 1M context window feature.
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                            This will update model names and requires you to:
-                            1. Reapply the configuration to Claude Code
-                            2. Restart Claude Code for changes to take effect
-                        </Typography>
-                    </DialogContent>
-                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
-                        <Button onClick={() => setContext1MDialogOpen(false)} color="inherit">
-                            Cancel
-                        </Button>
-                        <Button onClick={confirmContext1MChange} variant="contained">
-                            Confirm
-                        </Button>
-                    </DialogActions>
-                </Dialog>
-
                 <ClaudeCodeConfigModal
                     open={configModalOpen}
-                    onClose={() => setConfigModalOpen(false)}
+                    onClose={() => {
+                        setConfigModalOpen(false);
+                        setPendingContext1MChange(null);
+                    }}
                     configMode={configMode}
                     baseUrl={baseUrl}
                     rules={rules}
@@ -372,6 +327,7 @@ const UseClaudeCodePageContent: React.FC = () => {
                         applyPrefs(prefs as Record<string, string>, installStatusLine)
                     }
                     isApplyLoading={isApplyLoading}
+                    pendingContext1MChange={pendingContext1MChange}
                 />
 
                 <ConnectProviderFlow

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -10,7 +10,7 @@ import UnifiedCard from "@/components/UnifiedCard.tsx";
 import {useScenarioPageInternal} from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import {api} from '@/services/api';
 import {toggleButtonGroupStyle, toggleButtonStyle} from "@/styles/toggleStyles";
-import { Info as InfoIcon } from '@/components/icons';
+import { Info as InfoIcon, Refresh as RestartIcon } from '@/components/icons';
 import {
     Box,
     Button,
@@ -22,7 +22,8 @@ import {
     ToggleButton,
     ToggleButtonGroup,
     Tooltip,
-    Typography
+    Typography,
+    Alert
 } from '@mui/material';
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -57,6 +58,8 @@ const UseClaudeCodePageContent: React.FC = () => {
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
+    const [context1MDialogOpen, setContext1MDialogOpen] = useState(false);
+    const [pendingContext1MState, setPendingContext1MState] = useState<boolean | null>(null);
 
     // Load scenario config to get config mode
     const loadScenarioConfig = async () => {
@@ -125,6 +128,22 @@ const UseClaudeCodePageContent: React.FC = () => {
     const cancelModeChange = () => {
         setConfirmDialogOpen(false);
         setPendingMode(null);
+    };
+
+    // Handle 1M context window toggle
+    const handleContext1MToggle = (newState: boolean) => {
+        setPendingContext1MState(newState);
+        setContext1MDialogOpen(true);
+    };
+
+    // Confirm 1M context change
+    const confirmContext1MChange = () => {
+        setContext1MDialogOpen(false);
+        const message = pendingContext1MState
+            ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Claude Code and restart Claude Code for the changes to take effect.'
+            : '1M context window disabled. Model names have been updated. Please reapply the configuration to Claude Code and restart Claude Code for the changes to take effect.';
+        showNotification(message, 'success');
+        setPendingContext1MState(null);
     };
 
     useEffect(() => {
@@ -277,6 +296,7 @@ const UseClaudeCodePageContent: React.FC = () => {
                     collapsible={true}
                     allowToggleRule={false}
                     allowAddRule={false}
+                    onContext1MToggle={handleContext1MToggle}
                 />
 
                 <Dialog
@@ -299,6 +319,39 @@ const UseClaudeCodePageContent: React.FC = () => {
                             Cancel
                         </Button>
                         <Button onClick={confirmModeChange} variant="contained">
+                            Confirm
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+
+                {/* 1M Context Window Toggle Confirmation Dialog */}
+                <Dialog open={context1MDialogOpen} onClose={() => setContext1MDialogOpen(false)} maxWidth="sm" fullWidth>
+                    <DialogTitle>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <RestartIcon color="primary" />
+                            <span>1M Context Window Change</span>
+                        </Box>
+                    </DialogTitle>
+                    <DialogContent>
+                        <Alert severity="info" sx={{ mb: 2 }}>
+                            {pendingContext1MState
+                                ? 'Enabling 1M context window will update model names with [1m] suffix.'
+                                : 'Disabling 1M context window will remove [1m] suffix from model names.'}
+                        </Alert>
+                        <Typography variant="body1" sx={{ mb: 1 }}>
+                            You are about to {pendingContext1MState ? 'enable' : 'disable'} the 1M context window feature.
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            This will update model names and requires you to:
+                            1. Reapply the configuration to Claude Code
+                            2. Restart Claude Code for changes to take effect
+                        </Typography>
+                    </DialogContent>
+                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
+                        <Button onClick={() => setContext1MDialogOpen(false)} color="inherit">
+                            Cancel
+                        </Button>
+                        <Button onClick={confirmContext1MChange} variant="contained">
                             Confirm
                         </Button>
                     </DialogActions>

--- a/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
@@ -42,6 +42,10 @@ const UseClaudeDesktopPageContent: React.FC = () => {
             ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Claude Desktop and restart Claude Desktop for the changes to take effect.'
             : '1M context window disabled. Model names have been updated. Please reapply the configuration to Claude Desktop and restart Claude Desktop for the changes to take effect.';
         showNotification(message, 'success');
+
+        // Auto-open the config panel so user can immediately reapply
+        setConfigModalOpen(true);
+
         setPendingContext1MState(null);
     };
 

--- a/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
@@ -24,29 +24,16 @@ const UseClaudeDesktopPageContent: React.FC = () => {
     } = useScenarioPageInternal(scenario);
 
     const [configModalOpen, setConfigModalOpen] = useState(false);
-    const [context1MDialogOpen, setContext1MDialogOpen] = useState(false);
-    const [pendingContext1MState, setPendingContext1MState] = useState<boolean | null>(null);
+    const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
 
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
     };
 
     const handleContext1MToggle = (newState: boolean) => {
-        setPendingContext1MState(newState);
-        setContext1MDialogOpen(true);
-    };
-
-    const confirmContext1MChange = () => {
-        setContext1MDialogOpen(false);
-        const message = pendingContext1MState
-            ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Claude Desktop and restart Claude Desktop for the changes to take effect.'
-            : '1M context window disabled. Model names have been updated. Please reapply the configuration to Claude Desktop and restart Claude Desktop for the changes to take effect.';
-        showNotification(message, 'success');
-
-        // Auto-open the config panel so user can immediately reapply
+        // Store the pending change and directly open config panel
+        setPendingContext1MChange(newState);
         setConfigModalOpen(true);
-
-        setPendingContext1MState(null);
     };
 
     return (
@@ -96,45 +83,16 @@ const UseClaudeDesktopPageContent: React.FC = () => {
 
                 <ClaudeDesktopConfigModal
                     open={configModalOpen}
-                    onClose={() => setConfigModalOpen(false)}
+                    onClose={() => {
+                        setConfigModalOpen(false);
+                        setPendingContext1MChange(null);
+                    }}
                     baseUrl={baseUrl}
                     copyToClipboard={copyToClipboard}
                     rules={rules}
                     onRulesRefresh={loadRules}
+                    pendingContext1MChange={pendingContext1MChange}
                 />
-
-                {/* 1M Context Window Toggle Confirmation Dialog */}
-                <Dialog open={context1MDialogOpen} onClose={() => setContext1MDialogOpen(false)} maxWidth="sm" fullWidth>
-                    <DialogTitle>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <RestartIcon color="primary" />
-                            <span>1M Context Window Change</span>
-                        </Box>
-                    </DialogTitle>
-                    <DialogContent>
-                        <Alert severity="info" sx={{ mb: 2 }}>
-                            {pendingContext1MState
-                                ? 'Enabling 1M context window will update model names with [1m] suffix.'
-                                : 'Disabling 1M context window will remove [1m] suffix from model names.'}
-                        </Alert>
-                        <Typography variant="body1" sx={{ mb: 1 }}>
-                            You are about to {pendingContext1MState ? 'enable' : 'disable'} the 1M context window feature.
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                            This will update model names and requires you to:
-                            1. Reapply the configuration to Claude Desktop
-                            2. Restart Claude Desktop for changes to take effect
-                        </Typography>
-                    </DialogContent>
-                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
-                        <Button onClick={() => setContext1MDialogOpen(false)} color="inherit">
-                            Cancel
-                        </Button>
-                        <Button onClick={confirmContext1MChange} variant="contained">
-                            Confirm
-                        </Button>
-                    </DialogActions>
-                </Dialog>
             </CardGrid>
         </PageLayout>
     );

--- a/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
@@ -1,8 +1,8 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import { Box, Button, Tooltip, IconButton } from '@mui/material';
-import { Info as InfoIcon } from '@/components/icons';
+import { Box, Button, Tooltip, IconButton, Dialog, DialogActions, DialogContent, DialogTitle, Typography, Alert } from '@mui/material';
+import { Info as InfoIcon, Refresh as RestartIcon } from '@/components/icons';
 import { useState } from 'react';
 import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
@@ -20,12 +20,29 @@ const UseClaudeDesktopPageContent: React.FC = () => {
         baseUrl,
         rules,
         loadRules,
+        showNotification,
     } = useScenarioPageInternal(scenario);
 
     const [configModalOpen, setConfigModalOpen] = useState(false);
+    const [context1MDialogOpen, setContext1MDialogOpen] = useState(false);
+    const [pendingContext1MState, setPendingContext1MState] = useState<boolean | null>(null);
 
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
+    };
+
+    const handleContext1MToggle = (newState: boolean) => {
+        setPendingContext1MState(newState);
+        setContext1MDialogOpen(true);
+    };
+
+    const confirmContext1MChange = () => {
+        setContext1MDialogOpen(false);
+        const message = pendingContext1MState
+            ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Claude Desktop and restart Claude Desktop for the changes to take effect.'
+            : '1M context window disabled. Model names have been updated. Please reapply the configuration to Claude Desktop and restart Claude Desktop for the changes to take effect.';
+        showNotification(message, 'success');
+        setPendingContext1MState(null);
     };
 
     return (
@@ -70,6 +87,7 @@ const UseClaudeDesktopPageContent: React.FC = () => {
                     title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
+                    onContext1MToggle={handleContext1MToggle}
                 />
 
                 <ClaudeDesktopConfigModal
@@ -80,6 +98,39 @@ const UseClaudeDesktopPageContent: React.FC = () => {
                     rules={rules}
                     onRulesRefresh={loadRules}
                 />
+
+                {/* 1M Context Window Toggle Confirmation Dialog */}
+                <Dialog open={context1MDialogOpen} onClose={() => setContext1MDialogOpen(false)} maxWidth="sm" fullWidth>
+                    <DialogTitle>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <RestartIcon color="primary" />
+                            <span>1M Context Window Change</span>
+                        </Box>
+                    </DialogTitle>
+                    <DialogContent>
+                        <Alert severity="info" sx={{ mb: 2 }}>
+                            {pendingContext1MState
+                                ? 'Enabling 1M context window will update model names with [1m] suffix.'
+                                : 'Disabling 1M context window will remove [1m] suffix from model names.'}
+                        </Alert>
+                        <Typography variant="body1" sx={{ mb: 1 }}>
+                            You are about to {pendingContext1MState ? 'enable' : 'disable'} the 1M context window feature.
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            This will update model names and requires you to:
+                            1. Reapply the configuration to Claude Desktop
+                            2. Restart Claude Desktop for changes to take effect
+                        </Typography>
+                    </DialogContent>
+                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
+                        <Button onClick={() => setContext1MDialogOpen(false)} color="inherit">
+                            Cancel
+                        </Button>
+                        <Button onClick={confirmContext1MChange} variant="contained">
+                            Confirm
+                        </Button>
+                    </DialogActions>
+                </Dialog>
             </CardGrid>
         </PageLayout>
     );

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -29,8 +29,7 @@ const UseCodexPageContent: React.FC = () => {
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
-    const [context1MDialogOpen, setContext1MDialogOpen] = useState(false);
-    const [pendingContext1MState, setPendingContext1MState] = useState<boolean | null>(null);
+    const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
 
     const handleApply = async (): Promise<AgentApplyResult> => {
         try {
@@ -60,21 +59,9 @@ const UseCodexPageContent: React.FC = () => {
     };
 
     const handleContext1MToggle = (newState: boolean) => {
-        setPendingContext1MState(newState);
-        setContext1MDialogOpen(true);
-    };
-
-    const confirmContext1MChange = () => {
-        setContext1MDialogOpen(false);
-        const message = pendingContext1MState
-            ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Codex and restart Codex for the changes to take effect.'
-            : '1M context window disabled. Model names have been updated. Please reapply the configuration to Codex and restart Codex for the changes to take effect.';
-        showNotification(message, 'success');
-
-        // Auto-open the config panel so user can immediately reapply
+        // Store the pending change and directly open config panel
+        setPendingContext1MChange(newState);
         setConfigModalOpen(true);
-
-        setPendingContext1MState(null);
     };
 
     return (
@@ -135,8 +122,12 @@ const UseCodexPageContent: React.FC = () => {
 
                 <CodexConfigModal
                     open={configModalOpen}
-                    onClose={() => setConfigModalOpen(false)}
+                    onClose={() => {
+                        setConfigModalOpen(false);
+                        setPendingContext1MChange(null);
+                    }}
                     copyToClipboard={copyToClipboard}
+                    pendingContext1MChange={pendingContext1MChange}
                 />
 
                 <ConnectProviderFlow
@@ -145,39 +136,6 @@ const UseCodexPageContent: React.FC = () => {
                     showNotification={showNotification}
                     onProviderAdded={() => window.location.reload()}
                 />
-
-                {/* 1M Context Window Toggle Confirmation Dialog */}
-                <Dialog open={context1MDialogOpen} onClose={() => setContext1MDialogOpen(false)} maxWidth="sm" fullWidth>
-                    <DialogTitle>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <RestartIcon color="primary" />
-                            <span>1M Context Window Change</span>
-                        </Box>
-                    </DialogTitle>
-                    <DialogContent>
-                        <Alert severity="info" sx={{ mb: 2 }}>
-                            {pendingContext1MState
-                                ? 'Enabling 1M context window will update model names with [1m] suffix.'
-                                : 'Disabling 1M context window will remove [1m] suffix from model names.'}
-                        </Alert>
-                        <Typography variant="body1" sx={{ mb: 1 }}>
-                            You are about to {pendingContext1MState ? 'enable' : 'disable'} the 1M context window feature.
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                            This will update model names and requires you to:
-                            1. Reapply the configuration to Codex
-                            2. Restart Codex for changes to take effect
-                        </Typography>
-                    </DialogContent>
-                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
-                        <Button onClick={() => setContext1MDialogOpen(false)} color="inherit">
-                            Cancel
-                        </Button>
-                        <Button onClick={confirmContext1MChange} variant="contained">
-                            Confirm
-                        </Button>
-                    </DialogActions>
-                </Dialog>
             </CardGrid>
         </PageLayout>
     );

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -70,6 +70,10 @@ const UseCodexPageContent: React.FC = () => {
             ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Codex and restart Codex for the changes to take effect.'
             : '1M context window disabled. Model names have been updated. Please reapply the configuration to Codex and restart Codex for the changes to take effect.';
         showNotification(message, 'success');
+
+        // Auto-open the config panel so user can immediately reapply
+        setConfigModalOpen(true);
+
         setPendingContext1MState(null);
     };
 

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -6,8 +6,8 @@ import { defaultCodexPrefs } from "./components/CodexQuickConfig";
 import { api } from '@/services/api';
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import { Box, Button, IconButton, Tooltip } from '@mui/material';
-import { Info as InfoIcon } from '@/components/icons';
+import { Box, Button, IconButton, Tooltip, Dialog, DialogActions, DialogContent, DialogTitle, Typography, Alert } from '@mui/material';
+import { Info as InfoIcon, Refresh as RestartIcon } from '@/components/icons';
 import { useState } from 'react';
 import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
@@ -29,6 +29,8 @@ const UseCodexPageContent: React.FC = () => {
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
+    const [context1MDialogOpen, setContext1MDialogOpen] = useState(false);
+    const [pendingContext1MState, setPendingContext1MState] = useState<boolean | null>(null);
 
     const handleApply = async (): Promise<AgentApplyResult> => {
         try {
@@ -55,6 +57,20 @@ const UseCodexPageContent: React.FC = () => {
         } finally {
             setIsApplyLoading(false);
         }
+    };
+
+    const handleContext1MToggle = (newState: boolean) => {
+        setPendingContext1MState(newState);
+        setContext1MDialogOpen(true);
+    };
+
+    const confirmContext1MChange = () => {
+        setContext1MDialogOpen(false);
+        const message = pendingContext1MState
+            ? '1M context window enabled. Model names have been updated with [1m] suffix. Please reapply the configuration to Codex and restart Codex for the changes to take effect.'
+            : '1M context window disabled. Model names have been updated. Please reapply the configuration to Codex and restart Codex for the changes to take effect.';
+        showNotification(message, 'success');
+        setPendingContext1MState(null);
     };
 
     return (
@@ -110,6 +126,7 @@ const UseCodexPageContent: React.FC = () => {
                     title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
+                    onContext1MToggle={handleContext1MToggle}
                 />
 
                 <CodexConfigModal
@@ -124,6 +141,39 @@ const UseCodexPageContent: React.FC = () => {
                     showNotification={showNotification}
                     onProviderAdded={() => window.location.reload()}
                 />
+
+                {/* 1M Context Window Toggle Confirmation Dialog */}
+                <Dialog open={context1MDialogOpen} onClose={() => setContext1MDialogOpen(false)} maxWidth="sm" fullWidth>
+                    <DialogTitle>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <RestartIcon color="primary" />
+                            <span>1M Context Window Change</span>
+                        </Box>
+                    </DialogTitle>
+                    <DialogContent>
+                        <Alert severity="info" sx={{ mb: 2 }}>
+                            {pendingContext1MState
+                                ? 'Enabling 1M context window will update model names with [1m] suffix.'
+                                : 'Disabling 1M context window will remove [1m] suffix from model names.'}
+                        </Alert>
+                        <Typography variant="body1" sx={{ mb: 1 }}>
+                            You are about to {pendingContext1MState ? 'enable' : 'disable'} the 1M context window feature.
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            This will update model names and requires you to:
+                            1. Reapply the configuration to Codex
+                            2. Restart Codex for changes to take effect
+                        </Typography>
+                    </DialogContent>
+                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
+                        <Button onClick={() => setContext1MDialogOpen(false)} color="inherit">
+                            Cancel
+                        </Button>
+                        <Button onClick={confirmContext1MChange} variant="contained">
+                            Confirm
+                        </Button>
+                    </DialogActions>
+                </Dialog>
             </CardGrid>
         </PageLayout>
     );

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -25,6 +25,8 @@ interface ClaudeCodeConfigModalProps {
     // which files were touched and where the backup landed.
     onApplyWithPrefs?: (prefs: ClaudeCodePrefs, installStatusLine: boolean) => Promise<AgentApplyResult>;
     isApplyLoading?: boolean;
+    // Pending 1M context change to show warning in the modal
+    pendingContext1MChange?: boolean | null;
 }
 
 type MainTab = 'quick' | 'manual';
@@ -98,6 +100,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     copyToClipboard,
     onApplyWithPrefs,
     isApplyLoading = false,
+    pendingContext1MChange,
 }) => {
     const { token } = useScenarioPageModal();
     const { t, i18n } = useTranslation();
@@ -283,6 +286,32 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                 </DialogTitle>
 
                 <DialogContent sx={{ p: 3 }}>
+                    {/* 1M Context Change Warning */}
+                    {pendingContext1MChange !== null && (
+                        <Alert
+                            severity={pendingContext1MChange ? "success" : "warning"}
+                            sx={{
+                                mb: 2,
+                                borderRadius: 2,
+                                '& .MuiAlert-icon': {
+                                    fontSize: 28,
+                                }
+                            }}
+                        >
+                            <AlertTitle>
+                                {pendingContext1MChange ? '1M Context Window Enabled' : '1M Context Window Disabled'}
+                            </AlertTitle>
+                            <Typography variant="body2" sx={{ mb: 1 }}>
+                                {pendingContext1MChange
+                                    ? 'Model names have been updated with [1m] suffix for extended context support.'
+                                    : 'Model names have been updated to remove [1m] suffix.'}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary">
+                                Please apply the configuration below and restart Claude Code for changes to take effect.
+                            </Typography>
+                        </Alert>
+                    )}
+
                     {applyResult && (
                         <Alert
                             severity={applyResult.success ? 'success' : 'error'}

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -124,6 +124,21 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
         }
     }, [open, configMode, rules]);
 
+    // When 1M context changes, regenerate prefs to reflect the new state
+    React.useEffect(() => {
+        if (open && pendingContext1MChange !== null) {
+            // Create temporary rules with the pending 1M state for accurate display
+            const tempRules = rules.map(rule => ({
+                ...rule,
+                flags: {
+                    ...rule.flags,
+                    context1m: pendingContext1MChange, // Use modern camelCase naming
+                }
+            }));
+            setPrefs(derivePrefsFromRules({ rules: tempRules, mode: configMode }));
+        }
+    }, [pendingContext1MChange, rules, configMode, open]);
+
     // Editing prefs after a previous Apply invalidates the success state —
     // hide the old alert so the user can tell their next Apply hasn't run yet.
     const setPrefsAndClearResult = React.useCallback((next: ClaudeCodePrefs) => {

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -460,8 +460,8 @@ export const derivePrefsFromRules = ({ rules, mode }: DerivePrefsInput): ClaudeC
     // Get the 1M context window flag from a specific rule
     const getContext1MStateForRule = (rule: any): boolean => {
         if (!rule || !rule.flags) return false;
-        // Handle both snake_case (from API) and camelCase (already converted)
-        return (rule.flags?.context_1m || rule.flags?.context1m) || false;
+        // Only use the modern camelCase naming convention
+        return rule.flags?.context1m || false;
     };
 
     // Get the 1M state for a specific variant (only used in separate mode)

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -441,21 +441,59 @@ interface DerivePrefsInput {
 }
 
 export const derivePrefsFromRules = ({ rules, mode }: DerivePrefsInput): ClaudeCodePrefs => {
+    // Debug: log the rules data to understand the structure
+    console.log('derivePrefsFromRules - rules:', rules);
+    console.log('derivePrefsFromRules - mode:', mode);
+    if (rules.length > 0) {
+        console.log('First rule structure:', JSON.stringify(rules[0], null, 2));
+    }
+
     const modelForVariant = (variant: string, fallback: string): string => {
         if (mode === 'unified') return rules[0]?.request_model || fallback;
         const rule = rules.find((r: any) => r?.uuid === `built-in-cc-${variant}`);
         return rule?.request_model || fallback;
     };
 
+    // Get the 1M context window flag from a specific rule
+    const getContext1MStateForRule = (rule: any): boolean => {
+        if (!rule || !rule.flags) return false;
+        // Handle both snake_case (from API) and camelCase (already converted)
+        return (rule.flags?.context_1m || rule.flags?.context1m) || false;
+    };
+
+    // Get the 1M state for a specific variant (only used in separate mode)
+    const getContext1MStateForVariant = (variant: string): boolean => {
+        if (mode === 'unified') {
+            // In unified mode, use the first rule's context1m state
+            return getContext1MStateForRule(rules[0]);
+        }
+        // In separate mode, check the specific rule for this variant
+        const rule = rules.find((r: any) => r?.uuid === `built-in-cc-${variant}`);
+        return getContext1MStateForRule(rule);
+    };
+
+    const context1MEnabled = mode === 'unified'
+        ? getContext1MStateForRule(rules[0])
+        : getContext1MStateForRule(rules.find((r: any) => r?.uuid === 'built-in-cc-default'));
+
+    console.log('Mode:', mode, 'Overall context1M enabled:', context1MEnabled);
+
     const isUnified = mode !== 'separate';
     const defaultModel = isUnified ? 'tingly/cc' : 'tingly/cc-default';
 
+    // Apply 1M suffix to models if their corresponding rule has context1m enabled
+    const apply1MSuffix = (model: string, variant: string): string => {
+        const variantContext1M = getContext1MStateForVariant(variant);
+        console.log(`Variant ${variant}: context1m=${variantContext1M}, model=${model}`);
+        return with1M(model, variantContext1M);
+    };
+
     return {
-        ANTHROPIC_MODEL: modelForVariant('default', defaultModel),
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: modelForVariant('haiku', isUnified ? defaultModel : 'tingly/cc-haiku'),
-        ANTHROPIC_DEFAULT_SONNET_MODEL: modelForVariant('sonnet', isUnified ? defaultModel : 'tingly/cc-sonnet'),
-        ANTHROPIC_DEFAULT_OPUS_MODEL: modelForVariant('opus', isUnified ? defaultModel : 'tingly/cc-opus'),
-        CLAUDE_CODE_SUBAGENT_MODEL: modelForVariant('subagent', isUnified ? defaultModel : 'tingly/cc-subagent'),
+        ANTHROPIC_MODEL: apply1MSuffix(modelForVariant('default', defaultModel), 'default'),
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: apply1MSuffix(modelForVariant('haiku', isUnified ? defaultModel : 'tingly/cc-haiku'), 'haiku'),
+        ANTHROPIC_DEFAULT_SONNET_MODEL: apply1MSuffix(modelForVariant('sonnet', isUnified ? defaultModel : 'tingly/cc-sonnet'), 'sonnet'),
+        ANTHROPIC_DEFAULT_OPUS_MODEL: apply1MSuffix(modelForVariant('opus', isUnified ? defaultModel : 'tingly/cc-opus'), 'opus'),
+        CLAUDE_CODE_SUBAGENT_MODEL: apply1MSuffix(modelForVariant('subagent', isUnified ? defaultModel : 'tingly/cc-subagent'), 'subagent'),
 
         API_TIMEOUT_MS: '3000000',
         CLAUDE_CODE_MAX_OUTPUT_TOKENS: '32000',
@@ -594,7 +632,15 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, text, oneMTooltip, prefs, se
                             <Switch
                                 size="small"
                                 checked={has1M(value)}
-                                onChange={(_, c) => setValue(with1M(value, c))}
+                                disabled={true}
+                                sx={{
+                                    '& .Mui-checked': {
+                                        color: has1M(value) ? 'primary.main' : 'text.disabled',
+                                    },
+                                    '& .Mui-checked + .MuiSwitch-track': {
+                                        backgroundColor: has1M(value) ? 'primary.main' : 'text.disabled',
+                                    },
+                                }}
                             />
                         </Box>
                     </Tooltip>

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Collapse,
     Divider,
     IconButton,
     InputAdornment,
@@ -11,6 +12,7 @@ import {
 } from '@mui/material';
 import { InfoOutlined as InfoOutlinedIcon } from '@/components/icons';
 import { RestartAlt as RestartAltIcon } from '@/components/icons';
+import { ExpandMore as ExpandMoreIcon } from '@/components/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -59,34 +61,35 @@ interface FieldStruct {
     group: Group;
     kind: Kind;
     unit?: string;
+    advanced?: boolean; // Mark advanced fields that should be collapsed by default
 }
 
 const FIELD_STRUCT: FieldStruct[] = [
-    // Models
-    { envName: 'ANTHROPIC_MODEL', group: 'model', kind: 'model' },
-    { envName: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', group: 'model', kind: 'model' },
-    { envName: 'ANTHROPIC_DEFAULT_SONNET_MODEL', group: 'model', kind: 'model' },
-    { envName: 'ANTHROPIC_DEFAULT_OPUS_MODEL', group: 'model', kind: 'model' },
-    { envName: 'CLAUDE_CODE_SUBAGENT_MODEL', group: 'model', kind: 'model' },
-    // Limits
-    { envName: 'API_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'CLAUDE_CODE_MAX_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens' },
-    { envName: 'MAX_THINKING_TOKENS', group: 'limits', kind: 'int', unit: 'tokens' },
-    { envName: 'BASH_DEFAULT_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'BASH_MAX_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'MCP_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'MCP_TOOL_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'MAX_MCP_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens' },
-    // Switches
-    { envName: 'DISABLE_TELEMETRY', group: 'switches', kind: 'bool' },
-    { envName: 'DISABLE_ERROR_REPORTING', group: 'switches', kind: 'bool' },
-    { envName: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', group: 'switches', kind: 'bool' },
-    { envName: 'DISABLE_AUTOUPDATER', group: 'switches', kind: 'bool' },
-    { envName: 'USE_BUILTIN_RIPGREP', group: 'switches', kind: 'bool' },
-    // Network proxy
-    { envName: 'HTTP_PROXY', group: 'network', kind: 'text' },
-    { envName: 'HTTPS_PROXY', group: 'network', kind: 'text' },
-    { envName: 'NO_PROXY', group: 'network', kind: 'text' },
+    // Models (always visible - most commonly adjusted)
+    { envName: 'ANTHROPIC_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'ANTHROPIC_DEFAULT_SONNET_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'ANTHROPIC_DEFAULT_OPUS_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'CLAUDE_CODE_SUBAGENT_MODEL', group: 'model', kind: 'model', advanced: false },
+    // Limits (advanced - rarely changed)
+    { envName: 'API_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'CLAUDE_CODE_MAX_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    { envName: 'MAX_THINKING_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    { envName: 'BASH_DEFAULT_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'BASH_MAX_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'MCP_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'MCP_TOOL_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'MAX_MCP_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    // Switches (advanced - usually don't need to change)
+    { envName: 'DISABLE_TELEMETRY', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'DISABLE_ERROR_REPORTING', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'DISABLE_AUTOUPDATER', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'USE_BUILTIN_RIPGREP', group: 'switches', kind: 'bool', advanced: true },
+    // Network proxy (advanced - rarely needed)
+    { envName: 'HTTP_PROXY', group: 'network', kind: 'text', advanced: true },
+    { envName: 'HTTPS_PROXY', group: 'network', kind: 'text', advanced: true },
+    { envName: 'NO_PROXY', group: 'network', kind: 'text', advanced: true },
 ];
 
 // ── Localized text bundles ─────────────────────────────────────────────
@@ -660,29 +663,51 @@ interface SectionProps {
 }
 
 const Section: React.FC<SectionProps> = ({ group, lang, prefs, setPrefs }) => {
+    const [expanded, setExpanded] = React.useState(group === 'model'); // Only model group expanded by default
     const meta = SECTION_TEXT[lang][group];
     const fieldsText = FIELDS_TEXT[lang];
     const oneMTooltip = UI_TEXT[lang].oneMTooltip;
     const fields = FIELD_STRUCT.filter(f => f.group === group);
+    const hasAdvancedFields = fields.some(f => f.advanced);
+
+    const toggleExpanded = () => setExpanded(!expanded);
+
     return (
         <Box>
             <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 0.5 }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{meta.title}</Typography>
-                <Typography variant="caption" color="text.secondary">{meta.hint}</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flex: 1 }}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{meta.title}</Typography>
+                    <Typography variant="caption" color="text.secondary">{meta.hint}</Typography>
+                </Box>
+                {hasAdvancedFields && (
+                    <IconButton
+                        size="small"
+                        onClick={toggleExpanded}
+                        sx={{
+                            transition: 'transform 0.2s',
+                            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                            p: 0.5,
+                        }}
+                    >
+                        <ExpandMoreIcon fontSize="small" />
+                    </IconButton>
+                )}
             </Box>
-            <Divider />
-            <Stack divider={<Divider flexItem />}>
-                {fields.map(f => (
-                    <FieldRow
-                        key={f.envName}
-                        field={f}
-                        text={fieldsText[f.envName]}
-                        oneMTooltip={oneMTooltip}
-                        prefs={prefs}
-                        setPrefs={setPrefs}
-                    />
-                ))}
-            </Stack>
+            <Collapse in={expanded} timeout={300}>
+                <Divider />
+                <Stack divider={<Divider flexItem />}>
+                    {fields.map(f => (
+                        <FieldRow
+                            key={f.envName}
+                            field={f}
+                            text={fieldsText[f.envName]}
+                            oneMTooltip={oneMTooltip}
+                            prefs={prefs}
+                            setPrefs={setPrefs}
+                        />
+                    ))}
+                </Stack>
+            </Collapse>
         </Box>
     );
 };

--- a/frontend/src/pages/scenario/components/ClaudeDesktopConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeDesktopConfigModal.tsx
@@ -27,6 +27,7 @@ interface ClaudeDesktopConfigModalProps {
     copyToClipboard: (text: string, label: string) => Promise<void>;
     rules?: any[];
     onRulesRefresh?: () => void;
+    pendingContext1MChange?: boolean | null;
 }
 
 const MODEL_PREFIX = 'claude-';

--- a/frontend/src/pages/scenario/components/CodexConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/CodexConfigModal.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, MenuItem, Radio, RadioGroup, Select, Tab, Tabs, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, MenuItem, Radio, RadioGroup, Select, Tab, Tabs, Typography } from '@mui/material';
 import React from 'react';
 import CodeBlock from '@/components/CodeBlock';
 import CodexQuickConfig, { type CodexPrefs, defaultCodexPrefs } from './CodexQuickConfig';
@@ -10,6 +10,7 @@ interface CodexConfigModalProps {
     open: boolean;
     onClose: () => void;
     copyToClipboard: (text: string, label: string) => Promise<void>;
+    pendingContext1MChange?: boolean | null;
 }
 
 type MainTab = 'quick' | 'manual';
@@ -49,6 +50,7 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     open,
     onClose,
     copyToClipboard,
+    pendingContext1MChange,
 }) => {
     // Keep token in context as a fallback for the auth.json preview while
     // the preview API request is in flight.
@@ -278,6 +280,32 @@ EOF`;
             </DialogTitle>
 
             <DialogContent sx={{ p: 3 }}>
+                {/* 1M Context Change Warning */}
+                {pendingContext1MChange !== null && (
+                    <Alert
+                        severity={pendingContext1MChange ? "success" : "warning"}
+                        sx={{
+                            mb: 2,
+                            borderRadius: 2,
+                            '& .MuiAlert-icon': {
+                                fontSize: 28,
+                            }
+                        }}
+                    >
+                        <AlertTitle>
+                            {pendingContext1MChange ? '1M Context Window Enabled' : '1M Context Window Disabled'}
+                        </AlertTitle>
+                        <Typography variant="body2" sx={{ mb: 1 }}>
+                            {pendingContext1MChange
+                                ? 'Model names have been updated with [1m] suffix for extended context support.'
+                                : 'Model names have been updated to remove [1m] suffix.'}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Please apply the configuration below and restart Codex for changes to take effect.
+                        </Typography>
+                    </Alert>
+                )}
+
                 <Box sx={{ mb: 2, p: 2, borderRadius: 2, bgcolor: 'action.hover' }}>
                     <Typography variant="subtitle2" sx={{ mb: 1 }}>
                         Auth source

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -81,6 +81,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         rightAction: customRightAction,
         onAddApiKeyClick,
         newlyCreatedRuleUuids = internalData.newlyCreatedRuleUuids,
+        onContext1MToggle,
     } = props;
 
     const isLoading = isInternalMode ? internalData.isLoading : false;
@@ -437,6 +438,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
                                             onRuleDelete={onRuleDelete}
                                             allowToggleRule={allowToggleRule}
                                             onToggleExpanded={() => handleRuleExpandToggle(rule.uuid)}
+                                            onContext1MToggle={onContext1MToggle}
                                         />
                                     )}
                                 </div>

--- a/frontend/src/pages/scenario/components/TemplatePage.types.ts
+++ b/frontend/src/pages/scenario/components/TemplatePage.types.ts
@@ -57,6 +57,7 @@ export interface TemplatePageExternalProps {
     emptyStateTitle?: string;
     emptyStateDescription?: string;
     onAddApiKeyClick?: () => void;
+    onContext1MToggle?: (newState: boolean) => void;
 }
 
 /**

--- a/internal/client/claude_round_tripper.go
+++ b/internal/client/claude_round_tripper.go
@@ -151,6 +151,9 @@ const (
 	// Model-specific beta flags
 	anthropicContext1m = "context-1m-2025-08-07"
 
+	// AnthropicContext1m is the exported version for use in other packages
+	AnthropicContext1m = anthropicContext1m
+
 	// Content negotiation
 	acceptHeader = "application/json"
 

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -19,6 +19,9 @@ import (
 
 // AnthropicMessagesV1Beta implements beta messages API
 func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, proxyModel string, provider *typ.Provider, actualModel string, rule *typ.Rule) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an Anthropic-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -17,6 +17,9 @@ import (
 
 // AnthropicMessagesV1 implements standard v1 messages API
 func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessagesRequest, proxyModel string, provider *typ.Provider, actualModel string, rule *typ.Rule) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an Anthropic-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -14,6 +14,7 @@ import (
 
 	tomlpkg "github.com/pelletier/go-toml/v2"
 	"github.com/tingly-dev/tingly-box/internal"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // defaultBackupRetention is the default number of backup files to keep per
@@ -965,35 +966,19 @@ func (p *CodexPrefs) toConfig() map[string]interface{} {
 // and writes ~/.codex/tingly-model-catalog.json with one entry per supplied
 // model so Codex's `/model` picker can see them.
 //
-// MERGE semantics: only fields tingly-box manages are overwritten. Everything
-// else the user put in config.toml — other top-level keys, other entries under
-// `[model_providers.*]`, and unrelated `[profiles.*]` blocks — is left alone.
-//
-// Managed fields:
-//   - top-level `model` (set to models[0] when models is non-empty)
-//   - top-level `model_provider = "tingly-box"`
-//   - top-level `model_catalog_json` (set to the absolute path of the
-//     catalog file when models is non-empty; cleared otherwise so we don't
-//     point at a missing file)
-//   - `[model_providers.tingly-box]` (always re-pinned to the supplied base URL)
-//   - `[profiles.<sanitized(model)>]` for each model — overwritten unconditionally
-//     under that key; `agent restore codex` recovers the previous file if needed
-//   - the whitelisted user prefs (see codexPrefSpec, e.g.
-//     `model_reasoning_effort`, `model_reasoning_summary`,
-//     `model_supports_reasoning_summaries`, `model_verbosity`) at the top level
-//     and inside each managed profile
-//
-// Note: Codex's `model_catalog_json` REPLACES the bundled catalog (it does not
-// merge), and is read on startup only — switching via `/model` doesn't reload
-// it. Users wanting native OpenAI entries in `/model` should keep the bundled
-// catalog (i.e. not run apply) or merge by hand.
-//
-// Orphan tingly profiles from earlier applies are NOT garbage-collected; if
-// the user has trimmed their rules they can remove stale profiles by hand.
-//
-// The previous config.toml and catalog (if any) are backed up before being
-// rewritten.
+// This is the backward-compatible version that uses default context windows.
+// For context window support, use ApplyCodexConfigWithContextWindows.
 func ApplyCodexConfig(baseURL string, models []string, prefs *CodexPrefs, writeCatalog bool) (*ApplyResult, error) {
+	return ApplyCodexConfigWithContextWindows(baseURL, models, prefs, writeCatalog, nil)
+}
+
+// ApplyCodexConfigWithContextWindows merges tingly-box Codex settings into ~/.codex/config.toml
+// and writes ~/.codex/tingly-model-catalog.json with one entry per supplied
+// model so Codex's `/model` picker can see them.
+//
+// The contextWindows parameter allows specifying custom context windows for specific models
+// (e.g., 1M context window for models with context_1m flag). If nil, uses defaults.
+func ApplyCodexConfigWithContextWindows(baseURL string, models []string, prefs *CodexPrefs, writeCatalog bool, contextWindows map[string]int) (*ApplyResult, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
@@ -1056,7 +1041,7 @@ func ApplyCodexConfig(baseURL string, models []string, prefs *CodexPrefs, writeC
 				return result, nil
 			}
 		}
-		catalogBytes, err := RenderCodexModelCatalog(models)
+		catalogBytes, err := RenderCodexModelCatalog(models, contextWindows)
 		if err != nil {
 			result.Message = fmt.Sprintf("Failed to render model catalog: %v", err)
 			return result, nil
@@ -1161,6 +1146,9 @@ const (
 	codexDefaultMaxContextWindow         = 200000
 	codexEffectiveContextWindowPercent   = 92
 	codexDefaultAutoCompactTokenLimitPct = 85
+
+	// 1M context window for models that support it (Sonnet 4.6+, Opus 4.6+)
+	codex1MContextWindow = 1000000
 )
 
 // renderCodexModelCatalog produces the JSON payload for
@@ -1170,7 +1158,10 @@ const (
 // no verbosity knob). Codex 0.124+ deserializes this into
 // `protocol::openai_models::ModelsResponse`; field names and value types must
 // stay in sync with that struct.
-func RenderCodexModelCatalog(models []string) ([]byte, error) {
+//
+// The contextWindows parameter allows overriding the default context window
+// for specific models (e.g., 1M context window models). If nil, uses default.
+func RenderCodexModelCatalog(models []string, contextWindows map[string]int) ([]byte, error) {
 	// supported_reasoning_levels is Vec<ReasoningEffortPreset>, not a bare
 	// string list — each element is an {effort, description} object. Values
 	// mirror Codex's bundled catalog for GPT-5 so /model shows the familiar
@@ -1183,6 +1174,18 @@ func RenderCodexModelCatalog(models []string) ([]byte, error) {
 	}
 	entries := make([]map[string]interface{}, 0, len(models))
 	for _, model := range models {
+		// Determine context window for this model
+		contextWindow := codexDefaultContextWindow
+		maxContextWindow := codexDefaultMaxContextWindow
+
+		// Check if this model has a custom context window (e.g., 1M context)
+		if contextWindows != nil {
+			if cw, ok := contextWindows[model]; ok {
+				contextWindow = cw
+				maxContextWindow = cw
+			}
+		}
+
 		entries = append(entries, map[string]interface{}{
 			"slug":                             model,
 			"display_name":                     model,
@@ -1199,9 +1202,9 @@ func RenderCodexModelCatalog(models []string) ([]byte, error) {
 			"support_verbosity":                false,
 			"truncation_policy":                map[string]interface{}{"mode": "tokens", "limit": 10000},
 			"supports_parallel_tool_calls":     true,
-			"context_window":                   codexDefaultContextWindow,
-			"max_context_window":               codexDefaultMaxContextWindow,
-			"auto_compact_token_limit":         codexAutoCompactTokenLimit(codexDefaultContextWindow),
+			"context_window":                   contextWindow,
+			"max_context_window":               maxContextWindow,
+			"auto_compact_token_limit":         codexAutoCompactTokenLimit(contextWindow),
 			"effective_context_window_percent": codexEffectiveContextWindowPercent,
 			"experimental_supported_tools":     []string{},
 			"input_modalities":                 []string{"text", "image"},
@@ -1217,6 +1220,39 @@ func RenderCodexModelCatalog(models []string) ([]byte, error) {
 
 func codexAutoCompactTokenLimit(contextWindow int) int {
 	return contextWindow * codexDefaultAutoCompactTokenLimitPct / 100
+}
+
+// BuildContextWindowsFromRules extracts model context windows from rules
+// for Codex catalog generation. Returns a map of model name -> context window size.
+// Models with context_1m flag enabled get 1M context window, others use default.
+func BuildContextWindowsFromRules(cfg *Config) map[string]int {
+	contextWindows := make(map[string]int)
+
+	for _, rule := range cfg.GetRequestConfigs() {
+		// Only process Codex scenario rules
+		if rule.GetScenario() != typ.ScenarioCodex || !rule.Active {
+			continue
+		}
+
+		// Check if context_1m flag is enabled
+		if rule.Flags.Context1M {
+			// Use 1M context window for models with the flag
+			modelName := rule.RequestModel
+			if modelName != "" {
+				// Strip [1m] suffix if present to get base model name
+				modelName = strings.TrimSuffix(modelName, "[1m]")
+				contextWindows[modelName] = codex1MContextWindow
+			}
+
+			// Also handle response model if different
+			if rule.ResponseModel != "" && rule.ResponseModel != rule.RequestModel {
+				responseModel := strings.TrimSuffix(rule.ResponseModel, "[1m]")
+				contextWindows[responseModel] = codex1MContextWindow
+			}
+		}
+	}
+
+	return contextWindows
 }
 
 var codexProfileKeyInvalid = regexp.MustCompile(`[^A-Za-z0-9_-]`)

--- a/internal/server/context_1m_integration.go
+++ b/internal/server/context_1m_integration.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// detectAndApplyContext1MFromIncomingRequest checks if the incoming request
+// contains the context-1m beta header and updates the rule accordingly.
+// This handles Claude Code/Desktop automatically triggering 1M context mode.
+//
+// For Claude Code/Desktop scenarios:
+// - If incoming request has context-1m beta header → update rule name + flag
+// - Rule name gets [1m] suffix appended
+// - Rule.Context1M flag is set to true
+//
+// For Codex scenario:
+// - Only updates the flag (no name suffix)
+// - Codex manages model names independently
+func detectAndApplyContext1MFromIncomingRequest(c *gin.Context, rule *typ.Rule) {
+	if rule == nil {
+		return
+	}
+
+	// Check if this is a scenario where we should auto-detect context-1m
+	scenario := rule.Scenario
+	autoDetect := false
+	var nameSuffix string
+
+	switch scenario {
+	case typ.ScenarioClaudeCode, typ.ScenarioClaudeDesktop:
+		// Claude Code/Desktop: auto-detect + name suffix
+		autoDetect = true
+		nameSuffix = "[1m]"
+	case typ.ScenarioCodex:
+		// Codex: auto-detect only (no name suffix)
+		autoDetect = true
+		nameSuffix = ""
+	default:
+		// Other scenarios: no auto-detection
+		return
+	}
+
+	if !autoDetect {
+		return
+	}
+
+	// Check for incoming context-1m beta header
+	betaHeader := c.GetHeader("anthropic-beta")
+	if betaHeader == "" {
+		return
+	}
+
+	// Check if context-1m is present in the beta header
+	hasContext1M := strings.Contains(betaHeader, client.AnthropicContext1m) ||
+		strings.Contains(betaHeader, "context-1m-2025-08-07")
+
+	// Update the rule based on detected context-1m
+	if hasContext1M {
+		// Set the flag
+		if !rule.Flags.Context1M {
+			rule.Flags.Context1M = true
+
+			// Update rule name with suffix for Claude Code/Desktop
+			if nameSuffix != "" && !strings.HasSuffix(rule.RequestModel, nameSuffix) {
+				rule.RequestModel = rule.RequestModel + nameSuffix
+				if rule.ResponseModel != "" {
+					rule.ResponseModel = rule.ResponseModel + nameSuffix
+				}
+			}
+
+			// Log the automatic detection
+			c.Set("context_1m_detected", true)
+		}
+	} else {
+		// If context-1m was previously enabled but not in this request,
+		// we could optionally disable it, but for now we leave it as-is
+		// to avoid flipping back and forth on requests that don't specify it
+	}
+}
+
+// shouldApplyContext1MToRule checks if we should apply context-1m to a rule
+// based on the current rule state and incoming request.
+// This is used by transforms and client code to determine if beta header injection is needed.
+func shouldApplyContext1MToRule(c *gin.Context, rule *typ.Rule) bool {
+	if rule == nil {
+		return false
+	}
+
+	// If rule flag is explicitly set, use that
+	if rule.Flags.Context1M {
+		return true
+	}
+
+	// Check if context-1m was detected from incoming request
+	if detected, exists := c.Get("context_1m_detected"); exists {
+		if detectedBool, ok := detected.(bool); ok && detectedBool {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getModelWithContext1MSuffix returns the model name with [1m] suffix if context-1m
+// is enabled for the rule, otherwise returns the model name unchanged.
+func getModelWithContext1MSuffix(model string, rule *typ.Rule) string {
+	if rule == nil || model == "" {
+		return model
+	}
+
+	// Only add suffix for display purposes - the actual model sent to Anthropic
+	// should remain unchanged (context-1m is handled via beta header)
+	if rule.Flags.Context1M && !strings.HasSuffix(model, "[1m]") {
+		return model + "[1m]"
+	}
+
+	return model
+}
+
+// stripContext1MSuffix removes the [1m] suffix from a model name if present.
+// This is used to get the actual model name for API calls.
+func stripContext1MSuffix(model string) string {
+	if strings.HasSuffix(model, "[1m]") {
+		return strings.TrimSuffix(model, "[1m]")
+	}
+	return model
+}

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -687,6 +687,9 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 
 	models := collectCodexRuleModels(cfg)
 
+	// Build context windows map from rules for models with context_1m flag
+	contextWindows := config.BuildContextWindowsFromRules(cfg)
+
 	port := h.config.ServerPort
 	if port == 0 {
 		port = 12580
@@ -720,7 +723,7 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 	if authMode == config.CodexAuthChatGPT {
 		configResult, err = config.ClearCodexGatewayConfig()
 	} else {
-		configResult, err = config.ApplyCodexConfig(codexBaseURL, models, prefs, writeCatalog)
+		configResult, err = config.ApplyCodexConfigWithContextWindows(codexBaseURL, models, prefs, writeCatalog, contextWindows)
 	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ApplyCodexConfigResponse{
@@ -794,6 +797,9 @@ func (h *Handler) GetCodexConfigPreview(c *gin.Context) {
 
 	models := collectCodexRuleModels(cfg)
 
+	// Build context windows map from rules for models with context_1m flag
+	contextWindows := config.BuildContextWindowsFromRules(cfg)
+
 	port := h.config.ServerPort
 	if port == 0 {
 		port = 12580
@@ -827,7 +833,7 @@ func (h *Handler) GetCodexConfigPreview(c *gin.Context) {
 		Models:     models,
 	}
 	if writeCatalog && len(models) > 0 {
-		catalogBytes, err := config.RenderCodexModelCatalog(models)
+		catalogBytes, err := config.RenderCodexModelCatalog(models, contextWindows)
 		if err == nil {
 			resp.CatalogJson = string(catalogBytes)
 		}

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -165,6 +165,9 @@ func (s *Server) HandleOpenAIChatCompletions(c *gin.Context) {
 }
 
 func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCompletionRequest, responseModel string, provider *typ.Provider, scenarioType typ.RuleScenario, rule *typ.Rule) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an OpenAI-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleOpenAI)

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -180,6 +180,9 @@ func (s *Server) HandleResponsesCreate(c *gin.Context) {
 }
 
 func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, provider *typ.Provider, rule *typ.Rule, req protocol.ResponseCreateRequest, responseModel string, maxAllowed int) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an OpenAI-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleOpenAI)

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -221,5 +221,12 @@ func RuleFlagRegistry() []FlagSpec {
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryApp,
 		},
+		{
+			Key:         "context_1m",
+			Label:       "1M Context Window",
+			Description: "Enable Anthropic's 1M token context window for supported models (Sonnet 4.6+, Opus 4.6+). Injects the context-1m-2025-08-07 beta header into requests and appends [1m] to model display names for routing. The actual model name sent to Anthropic remains unchanged. Only enable for models that support the 1M context window.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryRequestAnthropic,
+		},
 	}
 }

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -250,6 +250,13 @@ type RuleFlags struct {
 	// vision proxy (ScenarioConfig.Extensions["vision_proxy_service"]), only
 	// narrower in scope; when both are set the rule-level service wins.
 	VisionProxyService *VisionProxyService `json:"vision_proxy_service,omitempty" yaml:"vision_proxy_service,omitempty"`
+
+	// Context1M enables Anthropic's 1M token context window for supported models
+	// (Sonnet 4.6+, Opus 4.6+). When enabled, injects the context-1m-2025-08-07
+	// beta header into requests and influences model name formatting for routing
+	// purposes (appends [1m] suffix to display names). The actual model name sent
+	// to Anthropic remains unchanged - only the beta header changes behavior.
+	Context1M bool `json:"context_1m,omitempty" yaml:"context_1m,omitempty"`
 }
 
 // VisionProxyService identifies the upstream used to describe images for the


### PR DESCRIPTION
## Summary
The 1M context window feature existed but wasn't integrated with Codex and Claude Code/Desktop scenarios. 

This adds complete UI controls and backend handling so users can toggle 1M context for these scenarios through the interface.

### Major
- **Frontend UI controls**: Added 1M context toggle switches in model nodes and request headers for Claude Code, Claude Desktop, and Codex pages
- **Visual feedback**: Model names display with [1m] suffix when 1M context is enabled, making the extended context mode visible 
- **Configuration workflow**: Toggle triggers config modal with contextual warning, guiding users to apply changes and restart their application
- **Backend protocol handling**: New `context_1m` flag that injects the `context-1m-2025-08-07` beta header into Anthropic requests for supported models
- **Auto-detection**: Automatically detects 1M context from incoming requests and updates rule state accordingly 
- **Codex catalog integration**: Models with 1M context enabled get 1M token context windows in Codex's model catalog

### Minor
- Exported `AnthropicContext1m` constant from client package for reuse
- Added `context1m` field to `RuleFlags` struct and flag registry
- Enhanced model name formatting utilities to handle [1m] suffix stripping
- Improved Claude Code quick config UI with collapsible advanced sections
- Fixed snake/camelCase conversion helpers to handle digit boundaries (context1m ↔ context_1m)