### PR TITLE
feat(flag): add context_1m rule flag with upstream beta injection

### DIFF
--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -69,8 +69,11 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 	var transport http.RoundTripper
 	if provider.AuthType == typ.AuthTypeOAuth {
 		if provider.OAuthDetail != nil && provider.OAuthDetail.Issuer == ai.IssuerClaudeCode {
+			// context1m sits inside claudeRoundTripper so the 1M beta flag is
+			// appended after the fingerprint-managed header merge (context-1m
+			// is on the fingerprint-safe allowlist, so this is equivalent).
 			transport = &claudeRoundTripper{
-				RoundTripper: createSessionBoundTransport(provider, sessionID),
+				RoundTripper: &context1mBetaTransport{base: createSessionBoundTransport(provider, sessionID)},
 			}
 			logrus.Infof("Using session-bound transport for OAuth issuer: %s, session: %s",
 				provider.OAuthDetail.GetIssuer(), sessionID.Value)
@@ -78,7 +81,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 			// OAuth provider with an issuer other than ClaudeCode (or missing OAuthDetail).
 			// Use a session-bound transport so proxy_url is respected and env proxy is
 			// not inherited — same guarantee as the non-OAuth path below.
-			transport = createSessionBoundTransport(provider, sessionID)
+			transport = &context1mBetaTransport{base: createSessionBoundTransport(provider, sessionID)}
 		}
 	} else {
 		// Generic non-OAuth Anthropic provider. Apply the same User-Agent
@@ -91,7 +94,8 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 		// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
 		// proxy is explicitly configured for the provider.
 		base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
-		transport = &customUserAgentTransport{base: base}
+		transport = &context1mBetaTransport{base: base}
+		transport = &customUserAgentTransport{base: transport}
 		transport = wrapWithUserAgent(transport, provider)
 		transport = wrapWithLogging(transport, provider)
 	}

--- a/internal/client/context_1m_transport.go
+++ b/internal/client/context_1m_transport.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// context1mBetaTransport appends the context-1m beta flag to the outbound
+// anthropic-beta header when the request context carries the 1M hint
+// (typ.WithContext1M, attached by the gateway when the matched rule has the
+// context_1m flag). This is the Type-2
+// (context-passed hint) injection point, mirroring customUserAgentTransport:
+// upstream providers only honor 1M when this beta flag is present, so the
+// rule flag must reach the wire even for clients that don't send it.
+type context1mBetaTransport struct {
+	base http.RoundTripper
+}
+
+func (t *context1mBetaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if typ.GetContext1M(req.Context()) {
+		req = req.Clone(req.Context())
+		if existing := req.Header.Get("anthropic-beta"); existing == "" {
+			req.Header.Set("anthropic-beta", anthropicContext1m)
+		} else if !strings.Contains(existing, anthropicContext1m) {
+			req.Header.Set("anthropic-beta", existing+","+anthropicContext1m)
+		}
+	}
+	return base.RoundTrip(req)
+}

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -480,6 +480,23 @@ func ruleFlagCases() []flagCase {
 			}
 		}},
 
+		// ── context_1m ───────────────────────────────────────────────────────
+		// The rule flag alone — the client sends no beta header — must get the
+		// context-1m beta flag injected into the upstream request
+		// (context1mBetaTransport via the context hint attached at flag
+		// resolution time).
+		{key: "context_1m", run: func(t flagTB, env *TestEnv) {
+			model := env.SetupRouteWithFlags(protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta, flagScenario(), typ.RuleFlags{Context1M: true})
+			sendFlag(t, env, protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta, model, false, nil, nil)
+			up := env.virtual.LastRequest(EndpointAnthropic)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			if beta := up.Headers.Get("anthropic-beta"); !strings.Contains(beta, "context-1m") {
+				t.Errorf("rule flag did not inject context-1m beta upstream; anthropic-beta=%q", beta)
+			}
+		}},
+
 		// ── vision_proxy_service ─────────────────────────────────────────────
 		// A request whose latest turn carries an image must have that image
 		// described by the configured describer service and replaced with text

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -160,7 +160,23 @@ func resolveRuleFlagsWithScenario(
 	// single merge point, so the chat / v1 / beta handlers don't each repeat it.
 	applyCustomUserAgent(c, flags)
 
+	// Attach the 1M-context hint the same way: the outbound Anthropic transport
+	// (context1mBetaTransport) appends the context-1m beta flag at RoundTrip
+	// time.
+	applyContext1M(c, flags)
+
 	return flags
+}
+
+// applyContext1M attaches the 1M-context hint to the request context so the
+// outbound Anthropic transport injects the context-1m beta flag upstream.
+// Without this, the flag would only ever be advertised to clients ([1m] model
+// names) and never reach providers whose clients don't send it themselves.
+func applyContext1M(c *gin.Context, flags typ.RuleFlags) {
+	if !flags.Context1M || c == nil || c.Request == nil {
+		return
+	}
+	c.Request = c.Request.WithContext(typ.WithContext1M(c.Request.Context()))
 }
 
 // applyCustomUserAgent attaches the effective custom User-Agent (already merged

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -221,5 +221,12 @@ func RuleFlagRegistry() []FlagSpec {
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryApp,
 		},
+		{
+			Key:         "context_1m",
+			Label:       "1M Context Window",
+			Description: "Enable Anthropic's 1M token context window for supported models (Sonnet 4.6+, Opus 4.6+). Injects the context-1m-2025-08-07 beta flag into the upstream anthropic-beta header; the model name sent to the provider is unchanged. Only enable for models that support the 1M context window.",
+			Type:        FlagTypeBool,
+			Category:    FlagCategoryRequestAnthropic,
+		},
 	}
 }

--- a/internal/typ/id.go
+++ b/internal/typ/id.go
@@ -161,3 +161,21 @@ func GetCustomUserAgent(ctx context.Context) string {
 	}
 	return ""
 }
+
+// Context1MKey carries the rule-level 1M-context hint down to the outbound
+// Anthropic transport, which appends the context-1m beta flag at request time.
+const Context1MKey contextKey = "context_1m"
+
+// WithContext1M marks the request as wanting Anthropic's 1M context window.
+func WithContext1M(ctx context.Context) context.Context {
+	return context.WithValue(ctx, Context1MKey, true)
+}
+
+// GetContext1M reports whether the request carries the 1M-context hint.
+func GetContext1M(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(Context1MKey).(bool)
+	return v
+}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -250,6 +250,13 @@ type RuleFlags struct {
 	// vision proxy (ScenarioConfig.Extensions["vision_proxy_service"]), only
 	// narrower in scope; when both are set the rule-level service wins.
 	VisionProxyService *VisionProxyService `json:"vision_proxy_service,omitempty" yaml:"vision_proxy_service,omitempty"`
+
+	// Context1M enables Anthropic's 1M token context window for supported models
+	// (Sonnet 4.6+, Opus 4.6+). When enabled, the gateway injects the
+	// context-1m-2025-08-07 beta flag into the upstream request's
+	// anthropic-beta header. The model name sent to Anthropic is unchanged —
+	// only the beta header changes behavior.
+	Context1M bool `json:"context_1m,omitempty" yaml:"context_1m,omitempty"`
 }
 
 // VisionProxyService identifies the upstream used to describe images for the


### PR DESCRIPTION
## Summary
Anthropic's 1M token context window requires the `context-1m-2025-08-07` beta flag on the upstream request, but tingly-box had no way to enable it per route — users with Sonnet 4.6+/Opus 4.6+ providers were silently capped at 200k. This adds a `context_1m` rule flag that injects the beta flag into the upstream `anthropic-beta` header for any rule that opts in.

**Stack 1/5** of the 1M-context feature, deliberately minimal for precise review: flag definition + upstream wiring + behavior test only. Follow-ups: #2 `[1m]` routing, #3 launchers/persistence, #4 UI, #5 Codex catalog.

### Major
- New `context_1m` rule flag (registry-driven, so it's immediately editable in the rule card's flag editor with no frontend change): enabling it on a rule makes the gateway append `context-1m-2025-08-07` to the upstream `anthropic-beta` header; the model name sent to the provider is unchanged.
- Wiring reuses the established Type-2 context-hint pattern from `custom_user_agent`: the flag-merge point attaches the hint to the request context, and a new `context1mBetaTransport` appends the beta flag at RoundTrip time — covering both Anthropic client chains (inside `claudeRoundTripper` for Claude OAuth, where `context-1m` is already on the fingerprint-safe allowlist, and the generic non-OAuth chain).

### Minor
- Rule-flag harness case asserting the flag alone — no client-sent beta header — reaches the upstream request; this also satisfies the registry's mandatory per-flag coverage check.

https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY)_