### PR TITLE
feat(routing): [1m]-aware rule matching and context-1m auto-detection

### DIFF
--- a/internal/client/claude_round_tripper.go
+++ b/internal/client/claude_round_tripper.go
@@ -151,6 +151,9 @@ const (
 	// Model-specific beta flags
 	anthropicContext1m = "context-1m-2025-08-07"
 
+	// AnthropicContext1m is the exported version for use in other packages
+	AnthropicContext1m = anthropicContext1m
+
 	// Content negotiation
 	acceptHeader = "application/json"
 

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -481,13 +481,51 @@ func ruleFlagCases() []flagCase {
 		}},
 
 		// ── context_1m ───────────────────────────────────────────────────────
-		// The rule flag alone — the client sends no beta header — must get the
-		// context-1m beta flag injected into the upstream request
-		// (context1mBetaTransport via the context hint attached at flag
-		// resolution time).
+		// Asserted on the real claude_code path: (1) a [1m]-suffixed incoming
+		// model still routes to its bare-named rule (suffix-normalized
+		// matching), and (2) the rule flag alone — the client sends no beta
+		// header here — gets the context-1m beta flag injected into the
+		// upstream request (context1mBetaTransport via the context hint).
 		{key: "context_1m", run: func(t flagTB, env *TestEnv) {
-			model := env.SetupRouteWithFlags(protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta, flagScenario(), typ.RuleFlags{Context1M: true})
-			sendFlag(t, env, protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta, model, false, nil, nil)
+			s := flagScenario()
+			env.virtual.RegisterScenario(s)
+			const providerName = "flag-1m-anthropic"
+			_ = env.appConfig.AddProvider(&typ.Provider{
+				UUID:     providerName,
+				Name:     providerName,
+				APIBase:  env.virtual.URL(),
+				APIStyle: protocol.APIStyleAnthropic,
+				Token:    "virtual-token",
+				Enabled:  true,
+				Timeout:  int64(constant.DefaultRequestTimeout),
+			})
+
+			const reqModel = "pv-flag-1m"
+			providerModel := "virtual-model-" + s.Name
+			rule := typ.Rule{
+				UUID:          reqModel,
+				Scenario:      typ.ScenarioClaudeCode,
+				RequestModel:  reqModel,
+				ResponseModel: providerModel,
+				Services: []*loadbalance.Service{
+					{Provider: providerName, Model: providerModel, Weight: 1, Active: true, TimeWindow: 300},
+				},
+				LBTactic: typ.Tactic{Type: loadbalance.TacticAdaptive, Params: typ.DefaultAdaptiveParams()},
+				Active:   true,
+				Flags:    typ.RuleFlags{Context1M: true},
+			}
+			_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
+
+			_, body := flagBaseRequest(protocol.TypeAnthropicV1, reqModel+"[1m]", false)
+			res, err := env.dispatch(protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta, s.Name,
+				"/tingly/claude_code/v1/messages", body, nil, false)
+			if err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			if res.HTTPStatus != 200 {
+				t.Fatalf("[1m]-suffixed model failed to route to its bare-named rule: status=%d body=%s",
+					res.HTTPStatus, truncate(string(res.RawBody), 300))
+			}
 			up := env.virtual.LastRequest(EndpointAnthropic)
 			if up == nil {
 				t.Fatal("no upstream request captured")

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -19,6 +19,9 @@ import (
 
 // AnthropicMessagesV1Beta implements beta messages API
 func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, proxyModel string, provider *typ.Provider, actualModel string, rule *typ.Rule) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an Anthropic-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -17,6 +17,9 @@ import (
 
 // AnthropicMessagesV1 implements standard v1 messages API
 func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessagesRequest, proxyModel string, provider *typ.Provider, actualModel string, rule *typ.Rule) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an Anthropic-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -809,6 +809,21 @@ func (c *Config) MatchRuleByModelAndScenario(requestModel string, scenario typ.R
 		}
 	}
 
+	// Claude scenarios advertise the 1M context window via a "[1m]"
+	// model-name suffix that may be present on either side independently:
+	// Claude Code strips it from outgoing requests while the env carries it,
+	// Claude Desktop picks names verbatim from /v1/models where renamed
+	// rules list it, and a stale client config may still send a suffix the
+	// rule no longer has. Normalize both sides before comparing.
+	if base := scenario.Base(); base == typ.ScenarioClaudeCode || base == typ.ScenarioClaudeDesktop {
+		want := TrimContext1M(requestModel)
+		for _, rule := range c.Rules {
+			if TrimContext1M(rule.RequestModel) == want && rule.GetScenario() == scenario {
+				return &rule
+			}
+		}
+	}
+
 	// Then, try wildcard match
 	for _, rule := range c.Rules {
 		if IsWildcardRuleName(rule.RequestModel) && rule.GetScenario() == scenario {

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -732,11 +732,14 @@ func migrate20260611(c *Config) {
 				continue
 			}
 		} else {
-			// Profile: identify the tier by request model.
-			if !ccProfileTiers[rule.RequestModel] {
+			// Profile: identify the tier by request model. Strip the [1m]
+			// context-window suffix first so a tier rule renamed for 1M
+			// support (e.g. "haiku[1m]") still normalizes to its tier UUID.
+			tier := TrimContext1M(rule.RequestModel)
+			if !ccProfileTiers[tier] {
 				continue
 			}
-			canonical = BuiltinRuleUUID(rule.Scenario, rule.RequestModel)
+			canonical = BuiltinRuleUUID(rule.Scenario, tier)
 		}
 		if rule.UUID == canonical {
 			continue

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -212,6 +212,9 @@ func TestMigrate20260611_NormalizesProfileRuleUUIDs(t *testing.T) {
 			{UUID: RuleUUIDBuiltinCC, Scenario: typ.ScenarioClaudeCode, RequestModel: "tingly/cc"},
 			// Main-scenario user rule with a random UUID → untouched.
 			{UUID: "5f1c2a9e-0000-0000-0000-000000000005", Scenario: typ.ScenarioClaudeCode, RequestModel: "haiku"},
+			// Tier rule renamed for 1M context → tier identified after
+			// stripping the [1m] suffix; request model kept as-is.
+			{UUID: "5f1c2a9e-0000-0000-0000-000000000006", Scenario: p2, RequestModel: "haiku[1m]"},
 		},
 	}
 
@@ -226,6 +229,7 @@ func TestMigrate20260611_NormalizesProfileRuleUUIDs(t *testing.T) {
 		5: RuleUUIDCCHaiku,
 		6: RuleUUIDCC,
 		7: "5f1c2a9e-0000-0000-0000-000000000005",
+		8: "builtin:claude_code:p2:haiku",
 	}
 	for i, want := range wants {
 		if got := c.Rules[i].UUID; got != want {

--- a/internal/server/config/rule_1m_test.go
+++ b/internal/server/config/rule_1m_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestMatchRule_Context1MNormalized(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			// Desktop rule carrying the [1m] advertisement in its name.
+			{UUID: "d1", Scenario: typ.ScenarioClaudeDesktop, RequestModel: "claude-sonnet-4-6[1m]"},
+			// Bare CC profile rule; client env may advertise "haiku[1m]".
+			{UUID: "p1", Scenario: typ.RuleScenario("claude_code:p1"), RequestModel: "haiku"},
+			// Non-Claude scenario must NOT be normalized.
+			{UUID: "o1", Scenario: typ.ScenarioOpenAI, RequestModel: "gpt-4o"},
+		},
+	}
+
+	// Stale Desktop config sends the bare name → matches the renamed rule.
+	if r := c.MatchRuleByModelAndScenario("claude-sonnet-4-6", typ.ScenarioClaudeDesktop); r == nil || r.UUID != "d1" {
+		t.Errorf("bare name should match [1m]-named desktop rule, got %+v", r)
+	}
+	// Suffixed pick from /v1/models matches exactly (fast path).
+	if r := c.MatchRuleByModelAndScenario("claude-sonnet-4-6[1m]", typ.ScenarioClaudeDesktop); r == nil || r.UUID != "d1" {
+		t.Errorf("suffixed name should match [1m]-named desktop rule, got %+v", r)
+	}
+	// Suffixed request against a bare profile rule (profiled scenario → base
+	// scenario is claude_code, so normalization applies).
+	if r := c.MatchRuleByModelAndScenario("haiku[1m]", typ.RuleScenario("claude_code:p1")); r == nil || r.UUID != "p1" {
+		t.Errorf("suffixed request should match bare profile rule, got %+v", r)
+	}
+	// Non-Claude scenarios keep strict matching.
+	if r := c.MatchRuleByModelAndScenario("gpt-4o[1m]", typ.ScenarioOpenAI); r != nil {
+		t.Errorf("openai scenario must not 1m-normalize, got %+v", r)
+	}
+}

--- a/internal/server/config/util.go
+++ b/internal/server/config/util.go
@@ -4,11 +4,22 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/tingly-dev/tingly-box/internal/constant"
 )
+
+// Context1MSuffix is the model-name suffix Claude clients use to advertise
+// the 1M context window (Claude Code strips it back off and sends the
+// context-1m beta header; Claude Desktop picks names verbatim from /v1/models).
+const Context1MSuffix = "[1m]"
+
+// TrimContext1M removes the [1m] context-window suffix from a model name.
+func TrimContext1M(model string) string {
+	return strings.TrimSuffix(model, Context1MSuffix)
+}
 
 // generateSecret generates a random secret for JWT
 func generateSecret() string {

--- a/internal/server/context_1m_integration.go
+++ b/internal/server/context_1m_integration.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// detectAndApplyContext1MFromIncomingRequest checks if the incoming request
+// contains the context-1m beta header and updates the matched rule copy
+// accordingly. This handles Claude Code/Desktop automatically triggering 1M
+// context mode.
+//
+// The rule passed in is the per-request copy returned by rule matching, so
+// the changes below scope to this request only (flag → upstream beta-header
+// injection, [1m] name suffix → response model display); nothing persists to
+// the stored config.
+//
+// For Claude Code/Desktop scenarios (profiles included):
+// - If incoming request has context-1m beta header → set flag + [1m] name suffix
+//
+// For Codex scenario:
+// - Only sets the flag (no name suffix); Codex manages model names independently
+func detectAndApplyContext1MFromIncomingRequest(c *gin.Context, rule *typ.Rule) {
+	if rule == nil {
+		return
+	}
+
+	// Match on the base scenario so profile rules (e.g. "claude_code:p1")
+	// get the same treatment as the main scenario.
+	var nameSuffix string
+	switch rule.Scenario.Base() {
+	case typ.ScenarioClaudeCode, typ.ScenarioClaudeDesktop:
+		nameSuffix = config.Context1MSuffix
+	case typ.ScenarioCodex:
+		// flag only, no name suffix
+	default:
+		// Other scenarios: no auto-detection
+		return
+	}
+
+	// Check for incoming context-1m beta header
+	betaHeader := c.GetHeader("anthropic-beta")
+	if betaHeader == "" || !strings.Contains(betaHeader, client.AnthropicContext1m) {
+		return
+	}
+
+	if !rule.Flags.Context1M {
+		// Downstream effects ride this flag: resolveRuleFlagsWithScenario turns
+		// it into the context hint the outbound Anthropic transport reads to
+		// inject the context-1m beta flag upstream.
+		rule.Flags.Context1M = true
+
+		// Update rule name with suffix for Claude Code/Desktop
+		if nameSuffix != "" && rule.RequestModel != "" && !strings.HasSuffix(rule.RequestModel, nameSuffix) {
+			rule.RequestModel = rule.RequestModel + nameSuffix
+			if rule.ResponseModel != "" {
+				rule.ResponseModel = rule.ResponseModel + nameSuffix
+			}
+		}
+	}
+}

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -165,6 +165,9 @@ func (s *Server) HandleOpenAIChatCompletions(c *gin.Context) {
 }
 
 func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCompletionRequest, responseModel string, provider *typ.Provider, scenarioType typ.RuleScenario, rule *typ.Rule) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an OpenAI-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleOpenAI)

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -180,6 +180,9 @@ func (s *Server) HandleResponsesCreate(c *gin.Context) {
 }
 
 func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, provider *typ.Provider, rule *typ.Rule, req protocol.ResponseCreateRequest, responseModel string, maxAllowed int) {
+	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex
+	detectAndApplyContext1MFromIncomingRequest(c, rule)
+
 	// Resolve fusion endpoint: when the provider has an OpenAI-compatible
 	// fusion URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleOpenAI)


### PR DESCRIPTION
## Summary
Claude clients speak a `[1m]` model-name protocol around the 1M context window: Claude Code strips the suffix from env names and sends the beta flag instead, while names on rules may carry it. Routing previously matched names strictly, so any suffix asymmetry between client config and rule 404'd. This slice teaches routing the protocol and auto-detects client-initiated 1M.

**Stack 2/5**, on top of #1186 (`context_1m` flag, merged). Follow-ups: #1189 launchers/persistence, #1190 UI, #1191 Codex catalog.

### Major
- `MatchRuleByModelAndScenario` normalizes the `[1m]` suffix on **both** the incoming model and the rule name before comparing, for claude_code / claude_desktop base scenarios (profiles included). The suffix can legitimately exist on either side alone — a `[1m]`-named rule vs. a stale client config, or a suffixed client env vs. a bare rule. Exact match still wins first; other scenarios keep strict matching.
- `detectAndApplyContext1MFromIncomingRequest`: when the incoming request carries the context-1m beta flag, set `Context1M` on the request-scoped rule copy (feeding the upstream beta injection from #1186) and mirror the `[1m]` suffix onto the copy's request/response model for response display. Matches on the base scenario so profile rules get the same treatment; Codex sets the flag only.

### Minor
- `migrate20260611` strips the `[1m]` suffix before identifying a profile rule's tier, so a tier rule named e.g. `haiku[1m]` still normalizes to its canonical UUID.
- Shared `Context1MSuffix` / `TrimContext1M` helpers in the config package; the flag harness case now exercises the real claude_code path with a `[1m]`-suffixed model.

https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY