### PR TITLE
feat(client): launchers and Desktop persistence follow the context_1m flag

### DIFF
--- a/frontend/src/components/rule-card/useRuleCardHooks.ts
+++ b/frontend/src/components/rule-card/useRuleCardHooks.ts
@@ -115,11 +115,15 @@ export function useRuleAutoSave({ rule, onRuleChange, showNotification }: UseRul
 
                 const result = await api.updateRule(rule.uuid, ruleData);
                 if (result.success) {
+                    // Prefer the persisted values echoed by the server — it may
+                    // normalize the rule (e.g. Claude Desktop request models get
+                    // the [1m] suffix synced with the context_1m flag).
+                    const saved = result.data ?? {};
                     onRuleChange?.({
                         ...rule,
                         scenario: ruleData.scenario,
-                        request_model: ruleData.request_model,
-                        response_model: ruleData.response_model,
+                        request_model: saved.request_model ?? ruleData.request_model,
+                        response_model: saved.response_model ?? ruleData.response_model,
                         active: ruleData.active,
                         description: ruleData.description,
                         flags: ruleData.flags,

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -370,6 +370,13 @@ func generateCCEnv(cfg *config.Config, baseURL, apiKey, scenarioPath string, uni
 			for _, uuid := range uuids {
 				if r := cfg.GetRuleByUUID(uuid); r != nil && r.Active {
 					if m := strings.TrimSpace(r.RequestModel); m != "" {
+						// Mirror the frontend quick-config: a rule with the 1M
+						// context flag advertises itself to Claude Code via the
+						// [1m] model-name suffix (the client strips it back off
+						// and sends the context-1m beta header instead).
+						if r.Flags.Context1M && !strings.HasSuffix(m, config.Context1MSuffix) {
+							m += config.Context1MSuffix
+						}
 						return m
 					}
 				}

--- a/internal/command/cc_command_test.go
+++ b/internal/command/cc_command_test.go
@@ -34,6 +34,31 @@ func TestGenerateCCEnv_ProfileSeparate_ResolvesModelsFromCanonicalRules(t *testi
 	}
 }
 
+func TestGenerateCCEnv_Profile_Context1MSuffix(t *testing.T) {
+	cfg := &config.Config{Rules: []typ.Rule{
+		// Flag set → env model advertises [1m] to Claude Code.
+		{UUID: "builtin:claude_code:p1:haiku", Scenario: "claude_code:p1", RequestModel: "haiku",
+			Flags: typ.RuleFlags{Context1M: true}, Active: true},
+		// Already suffixed (e.g. user renamed it) → no double suffix.
+		{UUID: "builtin:claude_code:p1:opus", Scenario: "claude_code:p1", RequestModel: "opus[1m]",
+			Flags: typ.RuleFlags{Context1M: true}, Active: true},
+		// Flag off → untouched.
+		{UUID: "builtin:claude_code:p1:sonnet", Scenario: "claude_code:p1", RequestModel: "sonnet", Active: true},
+	}}
+
+	env := generateCCEnv(cfg, "http://localhost:12580", "tok", "claude_code:p1", false, true)
+
+	if got := env["ANTHROPIC_DEFAULT_HAIKU_MODEL"]; got != "haiku[1m]" {
+		t.Errorf("haiku model = %q, want %q", got, "haiku[1m]")
+	}
+	if got := env["ANTHROPIC_DEFAULT_OPUS_MODEL"]; got != "opus[1m]" {
+		t.Errorf("opus model = %q, want %q (no double suffix)", got, "opus[1m]")
+	}
+	if got := env["ANTHROPIC_DEFAULT_SONNET_MODEL"]; got != "sonnet" {
+		t.Errorf("sonnet model = %q, want %q", got, "sonnet")
+	}
+}
+
 func TestGenerateCCEnv_ProfileUnified_ResolvesCCRule(t *testing.T) {
 	cfg := &config.Config{Rules: []typ.Rule{
 		{UUID: "builtin:claude_code:p2:cc", Scenario: "claude_code:p2", RequestModel: "renamed-cc", Active: true},

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -636,6 +636,17 @@ func (c *Config) UpdateRule(uid string, rule typ.Rule) error {
 		return err
 	}
 
+	// Claude Desktop pulls its model picker from /v1/models, which lists rule
+	// request models verbatim — the [1m] context-window advertisement must
+	// therefore live on the rule name itself. Keep the name suffix in sync
+	// with the context_1m flag so toggling the flag renames the rule.
+	// Claude Code is intentionally excluded: its [1m] advertisement travels
+	// via the launcher env, and the rule keeps its bare routing name.
+	if rule.Scenario.Is(typ.ScenarioClaudeDesktop) {
+		rule.RequestModel = syncContext1MSuffix(rule.RequestModel, rule.Flags.Context1M)
+		rule.ResponseModel = syncContext1MSuffix(rule.ResponseModel, rule.Flags.Context1M)
+	}
+
 	// Guard name unique
 	for _, rc := range c.Rules {
 		if rc.RequestModel == rule.RequestModel && rc.GetScenario() == rule.Scenario {

--- a/internal/server/config/rule_1m_test.go
+++ b/internal/server/config/rule_1m_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -9,7 +10,7 @@ import (
 func TestMatchRule_Context1MNormalized(t *testing.T) {
 	c := &Config{
 		Rules: []typ.Rule{
-			// Desktop rule carrying the [1m] advertisement in its name.
+			// Desktop rule renamed by the 1M toggle.
 			{UUID: "d1", Scenario: typ.ScenarioClaudeDesktop, RequestModel: "claude-sonnet-4-6[1m]"},
 			// Bare CC profile rule; client env may advertise "haiku[1m]".
 			{UUID: "p1", Scenario: typ.RuleScenario("claude_code:p1"), RequestModel: "haiku"},
@@ -20,11 +21,11 @@ func TestMatchRule_Context1MNormalized(t *testing.T) {
 
 	// Stale Desktop config sends the bare name → matches the renamed rule.
 	if r := c.MatchRuleByModelAndScenario("claude-sonnet-4-6", typ.ScenarioClaudeDesktop); r == nil || r.UUID != "d1" {
-		t.Errorf("bare name should match [1m]-named desktop rule, got %+v", r)
+		t.Errorf("bare name should match [1m]-renamed desktop rule, got %+v", r)
 	}
 	// Suffixed pick from /v1/models matches exactly (fast path).
 	if r := c.MatchRuleByModelAndScenario("claude-sonnet-4-6[1m]", typ.ScenarioClaudeDesktop); r == nil || r.UUID != "d1" {
-		t.Errorf("suffixed name should match [1m]-named desktop rule, got %+v", r)
+		t.Errorf("suffixed name should match renamed desktop rule, got %+v", r)
 	}
 	// Suffixed request against a bare profile rule (profiled scenario → base
 	// scenario is claude_code, so normalization applies).
@@ -34,5 +35,45 @@ func TestMatchRule_Context1MNormalized(t *testing.T) {
 	// Non-Claude scenarios keep strict matching.
 	if r := c.MatchRuleByModelAndScenario("gpt-4o[1m]", typ.ScenarioOpenAI); r != nil {
 		t.Errorf("openai scenario must not 1m-normalize, got %+v", r)
+	}
+}
+
+func TestUpdateRule_DesktopSyncsContext1MName(t *testing.T) {
+	c := &Config{
+		ConfigFile: filepath.Join(t.TempDir(), "config.json"),
+		Rules: []typ.Rule{
+			{UUID: "d1", Scenario: typ.ScenarioClaudeDesktop, RequestModel: "claude-sonnet-4-6", Active: true},
+			{UUID: "cc1", Scenario: typ.ScenarioClaudeCode, RequestModel: "tingly/cc-haiku", Active: true},
+		},
+	}
+
+	// Enabling the flag renames the desktop rule so /v1/models lists [1m].
+	r := c.Rules[0]
+	r.Flags.Context1M = true
+	if err := c.UpdateRule("d1", r); err != nil {
+		t.Fatalf("UpdateRule error: %v", err)
+	}
+	if got := c.Rules[0].RequestModel; got != "claude-sonnet-4-6[1m]" {
+		t.Errorf("desktop rule should be renamed with [1m], got %q", got)
+	}
+
+	// Disabling the flag strips the suffix again.
+	r = c.Rules[0]
+	r.Flags.Context1M = false
+	if err := c.UpdateRule("d1", r); err != nil {
+		t.Fatalf("UpdateRule error: %v", err)
+	}
+	if got := c.Rules[0].RequestModel; got != "claude-sonnet-4-6" {
+		t.Errorf("desktop rule should be stripped back, got %q", got)
+	}
+
+	// Claude Code rules are not renamed — their [1m] travels via the env.
+	r = c.Rules[1]
+	r.Flags.Context1M = true
+	if err := c.UpdateRule("cc1", r); err != nil {
+		t.Fatalf("UpdateRule error: %v", err)
+	}
+	if got := c.Rules[1].RequestModel; got != "tingly/cc-haiku" {
+		t.Errorf("claude_code rule must keep its bare name, got %q", got)
 	}
 }

--- a/internal/server/config/util.go
+++ b/internal/server/config/util.go
@@ -21,6 +21,21 @@ func TrimContext1M(model string) string {
 	return strings.TrimSuffix(model, Context1MSuffix)
 }
 
+// syncContext1MSuffix keeps a model name's [1m] suffix in sync with the
+// rule's context_1m flag: appended when enabled, stripped when disabled.
+func syncContext1MSuffix(model string, enabled bool) string {
+	if model == "" {
+		return model
+	}
+	if enabled && !strings.HasSuffix(model, Context1MSuffix) {
+		return model + Context1MSuffix
+	}
+	if !enabled {
+		return strings.TrimSuffix(model, Context1MSuffix)
+	}
+	return model
+}
+
 // generateSecret generates a random secret for JWT
 func generateSecret() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano())

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -212,6 +212,14 @@ func (h *Handler) UpdateRule(c *gin.Context) {
 		return
 	}
 
+	// Echo what was actually persisted: UpdateRule may normalize the rule
+	// (e.g. Claude Desktop request models get the [1m] suffix synced with
+	// the context_1m flag), and the client refreshes its local state from
+	// this response.
+	if saved := h.config.GetRuleByUUID(uid); saved != nil {
+		rule = *saved
+	}
+
 	// Log the action
 	logrus.WithFields(logrus.Fields{
 		"action": "update_rule",

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -189,6 +189,12 @@ func (c *TBClientImpl) resolveClaudeCodeModels() claudeCodeModels {
 			continue
 		}
 		if m := strings.TrimSpace(rule.RequestModel); m != "" {
+			// A rule with the 1M context flag advertises itself to Claude Code
+			// via the [1m] model-name suffix (the client strips it back off and
+			// sends the context-1m beta header instead).
+			if rule.Flags.Context1M && !strings.HasSuffix(m, serverconfig.Context1MSuffix) {
+				m += serverconfig.Context1MSuffix
+			}
 			byUUID[rule.UUID] = m
 		}
 	}

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -259,6 +259,24 @@ func TestResolveClaudeCodeModels_ModernUUIDWinsOverLegacy(t *testing.T) {
 	assert.Equal(t, "modern/model", models.def)
 }
 
+func TestResolveClaudeCodeModels_Context1MSuffix(t *testing.T) {
+	// A rule with the 1M context flag advertises [1m] in the resolved model;
+	// an already-suffixed model is not doubled.
+	flagged := ccRule("builtin:claude_code:cc", "tingly/cc")
+	flagged.Flags.Context1M = true
+	cfg := &serverconfig.Config{Rules: []typ.Rule{flagged}}
+	client := NewTBClient(cfg, nil)
+
+	models := client.resolveClaudeCodeModels()
+	assert.Equal(t, "tingly/cc[1m]", models.def)
+
+	suffixed := ccRule("builtin:claude_code:cc", "team/coder[1m]")
+	suffixed.Flags.Context1M = true
+	cfg2 := &serverconfig.Config{Rules: []typ.Rule{suffixed}}
+	models2 := NewTBClient(cfg2, nil).resolveClaudeCodeModels()
+	assert.Equal(t, "team/coder[1m]", models2.def)
+}
+
 func TestResolveClaudeCodeModels_InactiveRuleIgnored(t *testing.T) {
 	// An inactive built-in-cc rule must not override the canonical fallback.
 	inactive := ccRule("built-in-cc", "should/not/use")


### PR DESCRIPTION
## Summary
With the flag (#1186) and routing (#1188) in place, clients still need to *learn* about 1M through the surfaces they read model names from. This slice makes every launcher and the Desktop picker follow the flag.

**Stack 3/5**, on top of #1188. Follow-ups: #1190 UI, #1191 Codex catalog.

### Major
- Claude Desktop pulls its model picker verbatim from `/v1/models`, which lists rule request models — so the `[1m]` advertisement must live on the rule name itself. `Config.UpdateRule` keeps a claude_desktop rule's request/response model suffix in sync with its `context_1m` flag; claude_code rules intentionally keep bare names (their advertisement travels via the launcher env, and routing normalizes both shapes).
- `tingly-box cc` / `cc --profile` (`generateCCEnv`) and tbclient's `GetClaudeCodeEnv` append `[1m]` to env model names when the resolved rule carries the flag (no doubling when already suffixed). Toggling 1M on a profile rule takes effect on the next launch — profiles have no config modal, so the launcher must do this itself.

### Minor
- The rule update API echoes the persisted rule (UpdateRule may normalize it), and the rule-card auto-save prefers the server's echoed values — so the renamed Desktop model is visible immediately instead of after a reload.

https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY