### PR TITLE
feat(ui): 1M context toggle and config-apply flow

### DIFF
--- a/frontend/src/components/ModelRequestHeader.tsx
+++ b/frontend/src/components/ModelRequestHeader.tsx
@@ -8,6 +8,7 @@ import {
     Menu,
     MenuItem,
     ListItemText,
+    Switch,
 } from '@mui/material';
 import { alpha, styled } from '@mui/material/styles';
 import React, { useState } from 'react';
@@ -81,6 +82,9 @@ export interface ModelRequestHeaderProps {
     extraActions?: React.ReactNode;
     isExpanded?: boolean;
     onToggleExpanded?: () => void;
+    // 1M context window props
+    context1M?: boolean;
+    onContext1MToggle?: () => void;
 }
 
 export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
@@ -95,6 +99,8 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
     extraActions,
     isExpanded = true,
     onToggleExpanded,
+    context1M = false,
+    onContext1MToggle,
 }) => {
     const [editMode, setEditMode] = useState(false);
     const [tempValue, setTempValue] = useState(modelName);
@@ -246,6 +252,42 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                         <EditIcon sx={{ fontSize: '0.95rem' }} />
                     </IconButton>
                 </Tooltip>
+
+                {/* 1M Context Toggle */}
+                {onContext1MToggle && (
+                    <Tooltip title={context1M ? "Disable 1M context window" : "Enable 1M context window"}>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                ml: 0.5,
+                                opacity: active ? 1 : 0.5,
+                                pointerEvents: active ? 'auto' : 'none',
+                            }}
+                        >
+                            <Typography
+                                variant="caption"
+                                sx={{
+                                    fontSize: '0.7rem',
+                                    fontWeight: 600,
+                                    color: context1M ? 'primary.main' : 'text.secondary',
+                                    userSelect: 'none'
+                                }}
+                            >
+                                1M
+                            </Typography>
+                            <Switch
+                                size="small"
+                                checked={context1M}
+                                onChange={(e) => {
+                                    e.stopPropagation();
+                                    onContext1MToggle();
+                                }}
+                            />
+                        </Box>
+                    </Tooltip>
+                )}
             </Box>
         );
     };

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -70,6 +70,7 @@ export interface RuleFlags {
     visionProxyService?: VisionProxyServiceRef;
     claudeCodeCompat?: boolean;
     cleanHeader?: boolean;
+    context1m?: boolean;
 }
 
 export interface RuleFlagsApi {
@@ -86,6 +87,7 @@ export interface RuleFlagsApi {
     vision_proxy_service?: VisionProxyServiceRef;
     claude_code_compat?: boolean;
     clean_header?: boolean;
+    context_1m?: boolean;
 }
 
 export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref';

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -17,6 +17,7 @@ import RulePluginsCard from '@/components/rule-card/RulePluginsCard';
 import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
 import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
 import { getFlagValue, setFlagValue } from '@/components/rule-card/flagHelpers';
+import { formatModelNameWithContext1M } from '@/components/rule-card/modelNameUtils';
 
 // Module-level cache so we only fetch the flag catalog once per session.
 // `undefined` = never fetched; `[]` = fetched but empty (don't re-fetch).
@@ -58,6 +59,7 @@ export interface RuleCardProps {
     onRuleDelete?: (ruleUuid: string) => void;
     allowToggleRule?: boolean;
     onToggleExpanded?: () => void;
+    onContext1MToggle?: (newState: boolean, ruleUuid?: string) => void;
 }
 
 export const RuleCard: React.FC<RuleCardProps> = ({
@@ -76,6 +78,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     onRuleDelete,
     allowToggleRule = true,
     onToggleExpanded,
+    onContext1MToggle,
 }) => {
     // Expansion state management
     const { expanded, handleToggleExpanded } = useRuleCardExpanded({
@@ -291,9 +294,9 @@ export const RuleCard: React.FC<RuleCardProps> = ({
             onToggleActive={() => updateField(configRecord, setConfigRecord, 'active', !configRecord.active)}
             onEditFlags={handleOpenFlagEditor}
             ruleUuid={rule.uuid}
-            ruleName={rule.request_model || rule.uuid}
+            ruleName={formatModelNameWithContext1M(rule.request_model || rule.uuid, configRecord.flags)}
             scenario={rule.scenario}
-            model={rule.request_model}
+            model={formatModelNameWithContext1M(rule.request_model, configRecord.flags)}
         />
     );
 
@@ -322,6 +325,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 onAddServiceToSmartRule={handleAddServiceToSmartRuleByUuid}
                 onDeleteServiceFromSmartRule={smartHandlers.handleDeleteServiceFromSmartRule}
                 onSwitchRoutingMode={handleRoutingModeSwitch}
+                onContext1MToggle={onContext1MToggle}
             />
 
             {/* Delete Confirmation Dialog */}

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -63,7 +63,7 @@ const RULE_GRAPH_STYLES = {
     },
 } as const;
 
-const {header, graphContainer, graph} = RULE_GRAPH_STYLES;
+const {graphContainer, graph} = RULE_GRAPH_STYLES;
 
 export interface UnifiedRoutingGraphProps {
     // Mode control
@@ -100,6 +100,9 @@ export interface UnifiedRoutingGraphProps {
 
     // Routing mode switch
     onSwitchRoutingMode?: () => void;
+
+    // 1M context window toggle - receives the new state for scenario-specific handling
+    onContext1MToggle?: (newState: boolean, ruleUuid?: string) => void;
 
     // Slots
     extraActions?: React.ReactNode;
@@ -183,6 +186,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                                             onAddServiceToSmartRule,
                                                                             onDeleteServiceFromSmartRule,
                                                                             onSwitchRoutingMode,
+                                                                            onContext1MToggle,
                                                                             extraActions,
                                                                             extensionsCard,
                                                                             autoScroll,
@@ -461,6 +465,15 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 extraActions={extraActions}
                 isExpanded={isExpanded}
                 onToggleExpanded={onToggleExpanded}
+                context1M={record.flags?.context1m || false}
+                onContext1MToggle={() => {
+                    const newState = !(record.flags?.context1m || false);
+                    // Update the flags
+                    const updatedFlags = { ...record.flags, context1m: newState };
+                    onUpdateRecord?.('flags', updatedFlags);
+                    // Notify parent for scenario-specific handling
+                    onContext1MToggle?.(newState, record.uuid);
+                }}
             />
 
             {/* Tier Guide Dialog */}

--- a/frontend/src/components/rule-card/flagHelpers.ts
+++ b/frontend/src/components/rule-card/flagHelpers.ts
@@ -1,11 +1,15 @@
 import type { FlagSpec, RuleFlags, RuleFlagsApi, VisionProxyServiceRef } from '@/components/RoutingGraphTypes';
 
 export function snakeToCamel(s: string): string {
-    return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    return s.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
 }
 
 export function camelToSnake(s: string): string {
-    return s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+    // First handle the special case of digits at the end (e.g., context1m -> context_1m)
+    let result = s.replace(/([a-z])([0-9])([a-z])/g, '$1_$2$3');
+    // Then handle regular camelCase to snake_case (only uppercase letters)
+    result = result.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
+    return result;
 }
 
 export function getFlagValue(flags: RuleFlags | undefined, key: string): unknown {

--- a/frontend/src/components/rule-card/modelNameUtils.ts
+++ b/frontend/src/components/rule-card/modelNameUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Model name utilities for the 1M context window feature.
+ *
+ * The [1m] advertisement is part of the model string itself; the suffix
+ * lives on the wire, not as a separate field. These helpers are the single
+ * frontend source of truth for adding/removing/checking it.
+ */
+
+const ONE_M_SUFFIX = '[1m]';
+
+/** Returns true if the model name carries the [1m] suffix. */
+export function has1M(model: string | undefined): boolean {
+    return !!model && model.endsWith(ONE_M_SUFFIX);
+}
+
+/** Returns the model name with the [1m] suffix toggled on or off. */
+export function with1M(model: string | undefined, on: boolean): string {
+    const base = (model || '').replace(/\[1m\]$/, '');
+    return on && base !== '' ? base + ONE_M_SUFFIX : base;
+}
+
+/**
+ * Formats a model name with the [1m] suffix when the rule's context_1m flag
+ * (camelCase RuleFlags shape) is enabled; display helper for rule cards.
+ */
+export function formatModelNameWithContext1M(model: string, flags?: any): string {
+    if (!model || !flags?.context1m) {
+        return model;
+    }
+    return with1M(model, true);
+}

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -10,7 +10,7 @@ import UnifiedCard from "@/components/UnifiedCard.tsx";
 import {useScenarioPageInternal} from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import {api} from '@/services/api';
 import {toggleButtonGroupStyle, toggleButtonStyle} from "@/styles/toggleStyles";
-import { Info as InfoIcon } from '@/components/icons';
+import { Info as InfoIcon, Refresh as RestartIcon } from '@/components/icons';
 import {
     Box,
     Button,
@@ -22,7 +22,8 @@ import {
     ToggleButton,
     ToggleButtonGroup,
     Tooltip,
-    Typography
+    Typography,
+    Alert
 } from '@mui/material';
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -57,6 +58,14 @@ const UseClaudeCodePageContent: React.FC = () => {
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
+    const [pendingContext1MChange, setPendingContext1MChange] = useState<{ enabled: boolean; ruleUuid?: string } | null>(null);
+
+    const handleContext1MToggle = (newState: boolean, ruleUuid?: string) => {
+        // Store the pending change (scoped to the toggled rule) and open the
+        // config panel so the user can apply the matching env update.
+        setPendingContext1MChange({ enabled: newState, ruleUuid });
+        setConfigModalOpen(true);
+    };
 
     // Load scenario config to get config mode
     const loadScenarioConfig = async () => {
@@ -277,6 +286,7 @@ const UseClaudeCodePageContent: React.FC = () => {
                     collapsible={true}
                     allowToggleRule={false}
                     allowAddRule={false}
+                    onContext1MToggle={handleContext1MToggle}
                 />
 
                 <Dialog
@@ -306,7 +316,10 @@ const UseClaudeCodePageContent: React.FC = () => {
 
                 <ClaudeCodeConfigModal
                     open={configModalOpen}
-                    onClose={() => setConfigModalOpen(false)}
+                    onClose={() => {
+                        setConfigModalOpen(false);
+                        setPendingContext1MChange(null);
+                    }}
                     configMode={configMode}
                     baseUrl={baseUrl}
                     rules={rules}
@@ -315,6 +328,7 @@ const UseClaudeCodePageContent: React.FC = () => {
                         applyPrefs(prefs as Record<string, string>, installStatusLine)
                     }
                     isApplyLoading={isApplyLoading}
+                    pendingContext1MChange={pendingContext1MChange}
                 />
 
                 <ConnectProviderFlow

--- a/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
@@ -1,8 +1,8 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import { Box, Button, Tooltip, IconButton } from '@mui/material';
-import { Info as InfoIcon } from '@/components/icons';
+import { Box, Button, Tooltip, IconButton, Dialog, DialogActions, DialogContent, DialogTitle, Typography, Alert } from '@mui/material';
+import { Info as InfoIcon, Refresh as RestartIcon } from '@/components/icons';
 import { useState } from 'react';
 import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
@@ -20,11 +20,19 @@ const UseClaudeDesktopPageContent: React.FC = () => {
         baseUrl,
         rules,
         loadRules,
+        showNotification,
     } = useScenarioPageInternal(scenario);
 
     const [configModalOpen, setConfigModalOpen] = useState(false);
+    const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
 
     const handleOpenConfigModal = () => {
+        setConfigModalOpen(true);
+    };
+
+    const handleContext1MToggle = (newState: boolean) => {
+        // Store the pending change and directly open config panel
+        setPendingContext1MChange(newState);
         setConfigModalOpen(true);
     };
 
@@ -70,15 +78,20 @@ const UseClaudeDesktopPageContent: React.FC = () => {
                     title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
+                    onContext1MToggle={handleContext1MToggle}
                 />
 
                 <ClaudeDesktopConfigModal
                     open={configModalOpen}
-                    onClose={() => setConfigModalOpen(false)}
+                    onClose={() => {
+                        setConfigModalOpen(false);
+                        setPendingContext1MChange(null);
+                    }}
                     baseUrl={baseUrl}
                     copyToClipboard={copyToClipboard}
                     rules={rules}
                     onRulesRefresh={loadRules}
+                    pendingContext1MChange={pendingContext1MChange}
                 />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -6,8 +6,8 @@ import { defaultCodexPrefs } from "./components/CodexQuickConfig";
 import { api } from '@/services/api';
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import { Box, Button, IconButton, Tooltip } from '@mui/material';
-import { Info as InfoIcon } from '@/components/icons';
+import { Box, Button, IconButton, Tooltip, Dialog, DialogActions, DialogContent, DialogTitle, Typography, Alert } from '@mui/material';
+import { Info as InfoIcon, Refresh as RestartIcon } from '@/components/icons';
 import { useState } from 'react';
 import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
@@ -29,6 +29,7 @@ const UseCodexPageContent: React.FC = () => {
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
+    const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
 
     const handleApply = async (): Promise<AgentApplyResult> => {
         try {
@@ -55,6 +56,12 @@ const UseCodexPageContent: React.FC = () => {
         } finally {
             setIsApplyLoading(false);
         }
+    };
+
+    const handleContext1MToggle = (newState: boolean) => {
+        // Store the pending change and directly open config panel
+        setPendingContext1MChange(newState);
+        setConfigModalOpen(true);
     };
 
     return (
@@ -110,12 +117,17 @@ const UseCodexPageContent: React.FC = () => {
                     title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
+                    onContext1MToggle={handleContext1MToggle}
                 />
 
                 <CodexConfigModal
                     open={configModalOpen}
-                    onClose={() => setConfigModalOpen(false)}
+                    onClose={() => {
+                        setConfigModalOpen(false);
+                        setPendingContext1MChange(null);
+                    }}
                     copyToClipboard={copyToClipboard}
+                    pendingContext1MChange={pendingContext1MChange}
                 />
 
                 <ConnectProviderFlow

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -9,6 +9,7 @@ import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageConte
 import ClaudeCodeQuickConfig, { derivePrefsFromRules, prefsToEnvPreview } from './ClaudeCodeQuickConfig';
 import type { ClaudeCodePrefs } from './ClaudeCodeQuickConfig';
 import type { AgentApplyResult } from './AgentSetupCard';
+import Context1MChangeBanner from './Context1MChangeBanner';
 
 type ConfigMode = 'unified' | 'separate' | 'smart';
 
@@ -25,6 +26,8 @@ interface ClaudeCodeConfigModalProps {
     // which files were touched and where the backup landed.
     onApplyWithPrefs?: (prefs: ClaudeCodePrefs, installStatusLine: boolean) => Promise<AgentApplyResult>;
     isApplyLoading?: boolean;
+    // Pending 1M context change (scoped to the toggled rule) to preview in the modal
+    pendingContext1MChange?: { enabled: boolean; ruleUuid?: string } | null;
 }
 
 type MainTab = 'quick' | 'manual';
@@ -98,6 +101,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     copyToClipboard,
     onApplyWithPrefs,
     isApplyLoading = false,
+    pendingContext1MChange,
 }) => {
     const { token } = useScenarioPageModal();
     const { t, i18n } = useTranslation();
@@ -120,6 +124,27 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
             setApplyResult(null);
         }
     }, [open, configMode, rules]);
+
+    // When 1M context changes, regenerate prefs to reflect the new state.
+    // The pending change is scoped to the toggled rule — other tiers keep
+    // their own context_1m state (in separate mode each tier is independent).
+    React.useEffect(() => {
+        if (open && pendingContext1MChange != null) {
+            const tempRules = rules.map(rule => {
+                if (pendingContext1MChange.ruleUuid && rule.uuid !== pendingContext1MChange.ruleUuid) {
+                    return rule;
+                }
+                return {
+                    ...rule,
+                    flags: {
+                        ...rule.flags,
+                        context1m: pendingContext1MChange.enabled,
+                    },
+                };
+            });
+            setPrefs(derivePrefsFromRules({ rules: tempRules, mode: configMode }));
+        }
+    }, [pendingContext1MChange, rules, configMode, open]);
 
     // Editing prefs after a previous Apply invalidates the success state —
     // hide the old alert so the user can tell their next Apply hasn't run yet.
@@ -283,6 +308,10 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                 </DialogTitle>
 
                 <DialogContent sx={{ p: 3 }}>
+                    {pendingContext1MChange != null && (
+                        <Context1MChangeBanner enabled={pendingContext1MChange.enabled} clientName="Claude Code" />
+                    )}
+
                     {applyResult && (
                         <Alert
                             severity={applyResult.success ? 'success' : 'error'}

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Collapse,
     Divider,
     IconButton,
     InputAdornment,
@@ -11,8 +12,10 @@ import {
 } from '@mui/material';
 import { InfoOutlined as InfoOutlinedIcon } from '@/components/icons';
 import { RestartAlt as RestartAltIcon } from '@/components/icons';
+import { ExpandMore as ExpandMoreIcon } from '@/components/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { has1M, with1M } from '@/components/rule-card/modelNameUtils';
 
 // ClaudeCodePrefs mirrors the Go struct in internal/agent/prefs.go.
 // Keys are the literal Claude Code env var names so the object can be
@@ -59,34 +62,35 @@ interface FieldStruct {
     group: Group;
     kind: Kind;
     unit?: string;
+    advanced?: boolean; // Mark advanced fields that should be collapsed by default
 }
 
 const FIELD_STRUCT: FieldStruct[] = [
-    // Models
-    { envName: 'ANTHROPIC_MODEL', group: 'model', kind: 'model' },
-    { envName: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', group: 'model', kind: 'model' },
-    { envName: 'ANTHROPIC_DEFAULT_SONNET_MODEL', group: 'model', kind: 'model' },
-    { envName: 'ANTHROPIC_DEFAULT_OPUS_MODEL', group: 'model', kind: 'model' },
-    { envName: 'CLAUDE_CODE_SUBAGENT_MODEL', group: 'model', kind: 'model' },
-    // Limits
-    { envName: 'API_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'CLAUDE_CODE_MAX_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens' },
-    { envName: 'MAX_THINKING_TOKENS', group: 'limits', kind: 'int', unit: 'tokens' },
-    { envName: 'BASH_DEFAULT_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'BASH_MAX_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'MCP_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'MCP_TOOL_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms' },
-    { envName: 'MAX_MCP_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens' },
-    // Switches
-    { envName: 'DISABLE_TELEMETRY', group: 'switches', kind: 'bool' },
-    { envName: 'DISABLE_ERROR_REPORTING', group: 'switches', kind: 'bool' },
-    { envName: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', group: 'switches', kind: 'bool' },
-    { envName: 'DISABLE_AUTOUPDATER', group: 'switches', kind: 'bool' },
-    { envName: 'USE_BUILTIN_RIPGREP', group: 'switches', kind: 'bool' },
-    // Network proxy
-    { envName: 'HTTP_PROXY', group: 'network', kind: 'text' },
-    { envName: 'HTTPS_PROXY', group: 'network', kind: 'text' },
-    { envName: 'NO_PROXY', group: 'network', kind: 'text' },
+    // Models (always visible - most commonly adjusted)
+    { envName: 'ANTHROPIC_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'ANTHROPIC_DEFAULT_SONNET_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'ANTHROPIC_DEFAULT_OPUS_MODEL', group: 'model', kind: 'model', advanced: false },
+    { envName: 'CLAUDE_CODE_SUBAGENT_MODEL', group: 'model', kind: 'model', advanced: false },
+    // Limits (advanced - rarely changed)
+    { envName: 'API_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'CLAUDE_CODE_MAX_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    { envName: 'MAX_THINKING_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    { envName: 'BASH_DEFAULT_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'BASH_MAX_TIMEOUT_MS', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'MCP_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'MCP_TOOL_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
+    { envName: 'MAX_MCP_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    // Switches (advanced - usually don't need to change)
+    { envName: 'DISABLE_TELEMETRY', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'DISABLE_ERROR_REPORTING', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'DISABLE_AUTOUPDATER', group: 'switches', kind: 'bool', advanced: true },
+    { envName: 'USE_BUILTIN_RIPGREP', group: 'switches', kind: 'bool', advanced: true },
+    // Network proxy (advanced - rarely needed)
+    { envName: 'HTTP_PROXY', group: 'network', kind: 'text', advanced: true },
+    { envName: 'HTTPS_PROXY', group: 'network', kind: 'text', advanced: true },
+    { envName: 'NO_PROXY', group: 'network', kind: 'text', advanced: true },
 ];
 
 // ── Localized text bundles ─────────────────────────────────────────────
@@ -419,17 +423,6 @@ const useLang = (): Lang => {
     return i18n.language === 'zh' ? 'zh' : 'en';
 };
 
-// ── 1M-context suffix helpers ──────────────────────────────────────────
-// 1M is part of the model string itself; the suffix lives on the wire,
-// not as a separate prefs field. The UI just toggles the trailing [1m].
-
-const ONE_M_SUFFIX = '[1m]';
-const has1M = (v: string | undefined) => !!v && v.endsWith(ONE_M_SUFFIX);
-const with1M = (v: string | undefined, on: boolean): string => {
-    const base = (v || '').replace(/\[1m\]$/, '');
-    return on ? base + ONE_M_SUFFIX : base;
-};
-
 // ── Default prefs derivation ───────────────────────────────────────────
 // Build initial prefs from the active routing rules, mirroring how the
 // legacy modal picks models per slot. Anything not derivable falls back
@@ -447,15 +440,45 @@ export const derivePrefsFromRules = ({ rules, mode }: DerivePrefsInput): ClaudeC
         return rule?.request_model || fallback;
     };
 
+    // Get the 1M context window flag from a specific rule. Rules here come
+    // straight from the API (snake_case flags); accept the camelCase shape
+    // too in case a converted rule object is passed in.
+    const getContext1MStateForRule = (rule: any): boolean => {
+        if (!rule || !rule.flags) return false;
+        return rule.flags?.context_1m || rule.flags?.context1m || false;
+    };
+
+    // Get the 1M state for a specific variant (only used in separate mode)
+    const getContext1MStateForVariant = (variant: string): boolean => {
+        if (mode === 'unified') {
+            // In unified mode, use the first rule's context1m state
+            return getContext1MStateForRule(rules[0]);
+        }
+        // In separate mode, check the specific rule for this variant
+        const rule = rules.find((r: any) => r?.uuid === `builtin:claude_code:${variant}`);
+        return getContext1MStateForRule(rule);
+    };
+
+    const context1MEnabled = mode === 'unified'
+        ? getContext1MStateForRule(rules[0])
+        : getContext1MStateForRule(rules.find((r: any) => r?.uuid === 'builtin:claude_code:default'));
+
+
     const isUnified = mode !== 'separate';
     const defaultModel = isUnified ? 'tingly/cc' : 'tingly/cc-default';
 
+    // Apply 1M suffix to models if their corresponding rule has context1m enabled
+    const apply1MSuffix = (model: string, variant: string): string => {
+        const variantContext1M = getContext1MStateForVariant(variant);
+        return with1M(model, variantContext1M);
+    };
+
     return {
-        ANTHROPIC_MODEL: modelForVariant('default', defaultModel),
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: modelForVariant('haiku', isUnified ? defaultModel : 'tingly/cc-haiku'),
-        ANTHROPIC_DEFAULT_SONNET_MODEL: modelForVariant('sonnet', isUnified ? defaultModel : 'tingly/cc-sonnet'),
-        ANTHROPIC_DEFAULT_OPUS_MODEL: modelForVariant('opus', isUnified ? defaultModel : 'tingly/cc-opus'),
-        CLAUDE_CODE_SUBAGENT_MODEL: modelForVariant('subagent', isUnified ? defaultModel : 'tingly/cc-subagent'),
+        ANTHROPIC_MODEL: apply1MSuffix(modelForVariant('default', defaultModel), 'default'),
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: apply1MSuffix(modelForVariant('haiku', isUnified ? defaultModel : 'tingly/cc-haiku'), 'haiku'),
+        ANTHROPIC_DEFAULT_SONNET_MODEL: apply1MSuffix(modelForVariant('sonnet', isUnified ? defaultModel : 'tingly/cc-sonnet'), 'sonnet'),
+        ANTHROPIC_DEFAULT_OPUS_MODEL: apply1MSuffix(modelForVariant('opus', isUnified ? defaultModel : 'tingly/cc-opus'), 'opus'),
+        CLAUDE_CODE_SUBAGENT_MODEL: apply1MSuffix(modelForVariant('subagent', isUnified ? defaultModel : 'tingly/cc-subagent'), 'subagent'),
 
         API_TIMEOUT_MS: '3000000',
         CLAUDE_CODE_MAX_OUTPUT_TOKENS: '32000',
@@ -575,7 +598,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, text, oneMTooltip, prefs, se
                         value={field.kind === 'model' ? value.replace(/\[1m\]$/, '') : value}
                         onChange={(e) => {
                             const next = e.target.value;
-                            setValue(field.kind === 'model' && has1M(value) ? next + ONE_M_SUFFIX : next);
+                            setValue(field.kind === 'model' ? with1M(next, has1M(value)) : next);
                         }}
                         placeholder={text.placeholder}
                         sx={{ width: field.kind === 'model' ? 280 : field.kind === 'text' ? 320 : 180 }}
@@ -594,7 +617,15 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, text, oneMTooltip, prefs, se
                             <Switch
                                 size="small"
                                 checked={has1M(value)}
-                                onChange={(_, c) => setValue(with1M(value, c))}
+                                disabled={true}
+                                sx={{
+                                    '& .Mui-checked': {
+                                        color: has1M(value) ? 'primary.main' : 'text.disabled',
+                                    },
+                                    '& .Mui-checked + .MuiSwitch-track': {
+                                        backgroundColor: has1M(value) ? 'primary.main' : 'text.disabled',
+                                    },
+                                }}
                             />
                         </Box>
                     </Tooltip>
@@ -614,29 +645,51 @@ interface SectionProps {
 }
 
 const Section: React.FC<SectionProps> = ({ group, lang, prefs, setPrefs }) => {
+    const [expanded, setExpanded] = React.useState(group === 'model'); // Only model group expanded by default
     const meta = SECTION_TEXT[lang][group];
     const fieldsText = FIELDS_TEXT[lang];
     const oneMTooltip = UI_TEXT[lang].oneMTooltip;
     const fields = FIELD_STRUCT.filter(f => f.group === group);
+    const hasAdvancedFields = fields.some(f => f.advanced);
+
+    const toggleExpanded = () => setExpanded(!expanded);
+
     return (
         <Box>
             <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 0.5 }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{meta.title}</Typography>
-                <Typography variant="caption" color="text.secondary">{meta.hint}</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flex: 1 }}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{meta.title}</Typography>
+                    <Typography variant="caption" color="text.secondary">{meta.hint}</Typography>
+                </Box>
+                {hasAdvancedFields && (
+                    <IconButton
+                        size="small"
+                        onClick={toggleExpanded}
+                        sx={{
+                            transition: 'transform 0.2s',
+                            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                            p: 0.5,
+                        }}
+                    >
+                        <ExpandMoreIcon fontSize="small" />
+                    </IconButton>
+                )}
             </Box>
-            <Divider />
-            <Stack divider={<Divider flexItem />}>
-                {fields.map(f => (
-                    <FieldRow
-                        key={f.envName}
-                        field={f}
-                        text={fieldsText[f.envName]}
-                        oneMTooltip={oneMTooltip}
-                        prefs={prefs}
-                        setPrefs={setPrefs}
-                    />
-                ))}
-            </Stack>
+            <Collapse in={expanded} timeout={300}>
+                <Divider />
+                <Stack divider={<Divider flexItem />}>
+                    {fields.map(f => (
+                        <FieldRow
+                            key={f.envName}
+                            field={f}
+                            text={fieldsText[f.envName]}
+                            oneMTooltip={oneMTooltip}
+                            prefs={prefs}
+                            setPrefs={setPrefs}
+                        />
+                    ))}
+                </Stack>
+            </Collapse>
         </Box>
     );
 };

--- a/frontend/src/pages/scenario/components/ClaudeDesktopConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeDesktopConfigModal.tsx
@@ -18,6 +18,7 @@ import { Delete as DeleteIcon } from '@/components/icons';
 import { Add as AddIcon } from '@/components/icons';
 import { ContentCopy as ContentCopyIcon } from '@/components/icons';
 import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageContext';
+import Context1MChangeBanner from './Context1MChangeBanner';
 import api from '@/services/api';
 
 interface ClaudeDesktopConfigModalProps {
@@ -27,6 +28,7 @@ interface ClaudeDesktopConfigModalProps {
     copyToClipboard: (text: string, label: string) => Promise<void>;
     rules?: any[];
     onRulesRefresh?: () => void;
+    pendingContext1MChange?: boolean | null;
 }
 
 const MODEL_PREFIX = 'claude-';
@@ -48,6 +50,7 @@ const ClaudeDesktopConfigModal: React.FC<ClaudeDesktopConfigModalProps> = ({
     copyToClipboard,
     rules = [],
     onRulesRefresh,
+    pendingContext1MChange,
 }) => {
     const { token } = useScenarioPageModal();
     const [newModelName, setNewModelName] = useState('');
@@ -135,6 +138,9 @@ const ClaudeDesktopConfigModal: React.FC<ClaudeDesktopConfigModalProps> = ({
             </DialogTitle>
 
             <DialogContent sx={{ pt: 1 }}>
+                {pendingContext1MChange != null && (
+                    <Context1MChangeBanner enabled={pendingContext1MChange} clientName="Claude Desktop" requiresApply={false} />
+                )}
                 <Stack spacing={2}>
                     {/* Step 1 */}
                     <Box sx={{ p: 2, borderRadius: 1, border: 1, borderColor: 'divider' }}>

--- a/frontend/src/pages/scenario/components/CodexConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/CodexConfigModal.tsx
@@ -2,6 +2,7 @@ import { Alert, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, 
 import React from 'react';
 import CodeBlock from '@/components/CodeBlock';
 import CodexQuickConfig, { type CodexPrefs, defaultCodexPrefs } from './CodexQuickConfig';
+import Context1MChangeBanner from './Context1MChangeBanner';
 import { shouldIgnoreDialogClose } from '@/components/dialogClose';
 import { api } from '@/services/api';
 import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageContext';
@@ -10,6 +11,7 @@ interface CodexConfigModalProps {
     open: boolean;
     onClose: () => void;
     copyToClipboard: (text: string, label: string) => Promise<void>;
+    pendingContext1MChange?: boolean | null;
 }
 
 type MainTab = 'quick' | 'manual';
@@ -49,6 +51,7 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     open,
     onClose,
     copyToClipboard,
+    pendingContext1MChange,
 }) => {
     // Keep token in context as a fallback for the auth.json preview while
     // the preview API request is in flight.
@@ -278,6 +281,10 @@ EOF`;
             </DialogTitle>
 
             <DialogContent sx={{ p: 3 }}>
+                {pendingContext1MChange != null && (
+                    <Context1MChangeBanner enabled={pendingContext1MChange} clientName="Codex" />
+                )}
+
                 <Box sx={{ mb: 2, p: 2, borderRadius: 2, bgcolor: 'action.hover' }}>
                     <Typography variant="subtitle2" sx={{ mb: 1 }}>
                         Auth source

--- a/frontend/src/pages/scenario/components/Context1MChangeBanner.tsx
+++ b/frontend/src/pages/scenario/components/Context1MChangeBanner.tsx
@@ -1,0 +1,40 @@
+import { Alert, AlertTitle, Typography } from '@mui/material';
+import React from 'react';
+
+interface Context1MChangeBannerProps {
+    enabled: boolean;
+    // Client name used in the call-to-action line, e.g. "Claude Code".
+    clientName: string;
+    // Whether the user must re-apply the generated config (launcher-based
+    // clients). Desktop picks renamed models straight from /v1/models, so it
+    // only needs a restart / re-pick.
+    requiresApply?: boolean;
+}
+
+// Context1MChangeBanner is the shared pending-change notice the scenario
+// config modals show after the user toggles 1M context on a rule, explaining
+// what changed and what the user must do for the client to pick it up.
+const Context1MChangeBanner: React.FC<Context1MChangeBannerProps> = ({ enabled, clientName, requiresApply = true }) => (
+    <Alert
+        severity={enabled ? 'success' : 'warning'}
+        sx={{
+            mb: 2,
+            borderRadius: 2,
+            '& .MuiAlert-icon': { fontSize: 28 },
+        }}
+    >
+        <AlertTitle>{enabled ? '1M Context Window Enabled' : '1M Context Window Disabled'}</AlertTitle>
+        <Typography variant="body2" sx={{ mb: 1 }}>
+            {enabled
+                ? 'Model names have been updated with [1m] suffix for extended context support.'
+                : 'Model names have been updated to remove [1m] suffix.'}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+            {requiresApply
+                ? `Please apply the configuration below and restart ${clientName} for changes to take effect.`
+                : `Please restart ${clientName} and re-select the model for changes to take effect.`}
+        </Typography>
+    </Alert>
+);
+
+export default Context1MChangeBanner;

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -81,6 +81,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         rightAction: customRightAction,
         onAddApiKeyClick,
         newlyCreatedRuleUuids = internalData.newlyCreatedRuleUuids,
+        onContext1MToggle,
     } = props;
 
     const isLoading = isInternalMode ? internalData.isLoading : false;
@@ -437,6 +438,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
                                             onRuleDelete={onRuleDelete}
                                             allowToggleRule={allowToggleRule}
                                             onToggleExpanded={() => handleRuleExpandToggle(rule.uuid)}
+                                            onContext1MToggle={onContext1MToggle}
                                         />
                                     )}
                                 </div>

--- a/frontend/src/pages/scenario/components/TemplatePage.types.ts
+++ b/frontend/src/pages/scenario/components/TemplatePage.types.ts
@@ -57,6 +57,7 @@ export interface TemplatePageExternalProps {
     emptyStateTitle?: string;
     emptyStateDescription?: string;
     onAddApiKeyClick?: () => void;
+    onContext1MToggle?: (newState: boolean, ruleUuid?: string) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
User-facing controls for the 1M context feature: a per-rule toggle on the routing graph, and a guided re-apply flow so the client config stays in sync with the rule change.

**Stack 4/5**, on top of #1189. Follow-up: #1191 Codex catalog.

### Major
- Per-rule 1M toggle on the routing graph's model header (ModelNode / ModelRequestHeader); the toggle updates the rule's `context_1m` flag and notifies the page for scenario-specific follow-up.
- Claude Code / Claude Desktop / Codex pages open their config modal on toggle, with a pending-change banner explaining that the generated config must be re-applied and the client restarted. The pending change carries the toggled rule's uuid so the preview only flips that rule — in separate mode each tier stays independent.
- `derivePrefsFromRules` appends `[1m]` to env model names per tier based on each rule's `context_1m` state, so the applied env matches what the launchers (#1189) generate. Reads both the raw API snake_case and converted camelCase flag shapes.

### Minor
- `modelNameUtils` helpers (`[1m]` format/strip/detect) for display logic.

https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY