### PR TITLE
fix(1m): self-heal duplicated [1m] suffixes across all producers

### DIFF
--- a/frontend/src/components/rule-card/modelNameUtils.ts
+++ b/frontend/src/components/rule-card/modelNameUtils.ts
@@ -15,7 +15,7 @@ export function has1M(model: string | undefined): boolean {
 
 /** Returns the model name with the [1m] suffix toggled on or off. */
 export function with1M(model: string | undefined, on: boolean): string {
-    const base = (model || '').replace(/\[1m\]$/, '');
+    const base = (model || '').replace(/(\[1m\])+$/, '');
     return on && base !== '' ? base + ONE_M_SUFFIX : base;
 }
 

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -374,8 +374,10 @@ func generateCCEnv(cfg *config.Config, baseURL, apiKey, scenarioPath string, uni
 						// context flag advertises itself to Claude Code via the
 						// [1m] model-name suffix (the client strips it back off
 						// and sends the context-1m beta header instead).
-						if r.Flags.Context1M && !strings.HasSuffix(m, config.Context1MSuffix) {
-							m += config.Context1MSuffix
+						// Normalize first so a rule name already carrying the
+						// suffix (or duplicated ones) yields exactly one.
+						if r.Flags.Context1M {
+							m = config.TrimContext1M(m) + config.Context1MSuffix
 						}
 						return m
 					}

--- a/internal/server/config/rule_1m_test.go
+++ b/internal/server/config/rule_1m_test.go
@@ -77,3 +77,27 @@ func TestUpdateRule_DesktopSyncsContext1MName(t *testing.T) {
 		t.Errorf("claude_code rule must keep its bare name, got %q", got)
 	}
 }
+
+func TestContext1MSuffixSelfHealing(t *testing.T) {
+	// Dirty names with duplicated suffixes (from older builds) normalize to
+	// exactly one suffix when enabled and none when disabled.
+	if got := syncContext1MSuffix("cc[1m][1m]", true); got != "cc[1m]" {
+		t.Errorf("sync(enabled) = %q, want %q", got, "cc[1m]")
+	}
+	if got := syncContext1MSuffix("cc[1m][1m]", false); got != "cc" {
+		t.Errorf("sync(disabled) = %q, want %q", got, "cc")
+	}
+	if got := TrimContext1M("cc[1m][1m]"); got != "cc" {
+		t.Errorf("TrimContext1M = %q, want %q", got, "cc")
+	}
+
+	// Matching normalizes dirty incoming names too.
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: "p1", Scenario: typ.RuleScenario("claude_code:p1"), RequestModel: "cc[1m]"},
+		},
+	}
+	if r := c.MatchRuleByModelAndScenario("cc[1m][1m]", typ.RuleScenario("claude_code:p1")); r == nil || r.UUID != "p1" {
+		t.Errorf("double-suffixed request should match single-suffixed rule, got %+v", r)
+	}
+}

--- a/internal/server/config/util.go
+++ b/internal/server/config/util.go
@@ -17,23 +17,28 @@ import (
 const Context1MSuffix = "[1m]"
 
 // TrimContext1M removes the [1m] context-window suffix from a model name.
+// Repeated suffixes (dirty data from older builds) are stripped entirely so
+// matching and env generation self-heal.
 func TrimContext1M(model string) string {
-	return strings.TrimSuffix(model, Context1MSuffix)
+	for strings.HasSuffix(model, Context1MSuffix) {
+		model = strings.TrimSuffix(model, Context1MSuffix)
+	}
+	return model
 }
 
 // syncContext1MSuffix keeps a model name's [1m] suffix in sync with the
-// rule's context_1m flag: appended when enabled, stripped when disabled.
+// rule's context_1m flag: exactly one suffix when enabled, none when
+// disabled. Normalizing through TrimContext1M (instead of append-if-missing)
+// repairs names that picked up duplicated suffixes from older builds.
 func syncContext1MSuffix(model string, enabled bool) string {
 	if model == "" {
 		return model
 	}
-	if enabled && !strings.HasSuffix(model, Context1MSuffix) {
-		return model + Context1MSuffix
+	base := TrimContext1M(model)
+	if enabled {
+		return base + Context1MSuffix
 	}
-	if !enabled {
-		return strings.TrimSuffix(model, Context1MSuffix)
-	}
-	return model
+	return base
 }
 
 // generateSecret generates a random secret for JWT

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -191,9 +191,10 @@ func (c *TBClientImpl) resolveClaudeCodeModels() claudeCodeModels {
 		if m := strings.TrimSpace(rule.RequestModel); m != "" {
 			// A rule with the 1M context flag advertises itself to Claude Code
 			// via the [1m] model-name suffix (the client strips it back off and
-			// sends the context-1m beta header instead).
-			if rule.Flags.Context1M && !strings.HasSuffix(m, serverconfig.Context1MSuffix) {
-				m += serverconfig.Context1MSuffix
+			// sends the context-1m beta header instead). Normalize first so a
+			// rule name already carrying the suffix yields exactly one.
+			if rule.Flags.Context1M {
+				m = serverconfig.TrimContext1M(m) + serverconfig.Context1MSuffix
 			}
 			byUUID[rule.UUID] = m
 		}


### PR DESCRIPTION
## Summary
A user hit `cc[1m][1m]` in Claude Code's `/model` picker. Every `[1m]` suffix producer guarded against double-appending in isolation (`HasSuffix` check / single-layer strip), but none *repaired* a name that already carried a duplicated suffix — dirty data written by an earlier build stays dirty forever, and `TrimContext1M` only stripped one layer, so even routing normalization could miss a doubly-suffixed name.

### Major
- Switch the whole suffix chain from append-if-missing to **normalize-then-append**: `TrimContext1M` now strips repeated suffixes entirely, and `syncContext1MSuffix` (Desktop rename), `generateCCEnv`, and `tbclient.resolveClaudeCodeModels` normalize through it before appending exactly one suffix — dirty rule names self-heal on the next update / launch instead of propagating into env and the picker.
- Frontend `with1M` strips repeated suffixes the same way.

### Minor
- Tests covering double-suffix repair in sync/trim and `[1m][1m]` incoming names matching single-suffixed rules.

https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BznuTeP4uPpMrY4ZPcy7aY)_