### PR TITLE
migrate(rule): migrate remaining legacy built-in rule UUIDs to modern form

### DIFF
--- a/.design/rule-uuid.md
+++ b/.design/rule-uuid.md
@@ -19,10 +19,8 @@ that is system-seeded must have a deterministic UUID; randomness is
 reserved for rules the user creates.
 
 **Direction:** `builtin:<scenario>:<model>` is the target convention.
-Claude Code (main scenario + profiles) and Claude Desktop are already on
-it; the remaining legacy built-ins (openai / anthropic / codex / opencode
-/ tingly) will be migrated when their scenarios are next touched. New
-system-seeded rules must use the modern form from day one.
+All system-seeded built-ins now use this form. New system-seeded rules
+must use the modern form from day one.
 
 ## Claude Code main scenario
 

--- a/.design/rule-uuid.md
+++ b/.design/rule-uuid.md
@@ -7,7 +7,7 @@ stable constant:
 
 | Kind | Format | Example |
 |---|---|---|
-| Modern built-ins | `builtin:<scenario>:<model>` | `builtin:claude_code:haiku`, `builtin:claude_desktop:claude-haiku-4-5` |
+| Modern built-ins | `builtin:<scenario>:<tier>` | `builtin:claude_code:haiku`, `builtin:openai:default`, `builtin:claude_desktop:claude-haiku-4-5` |
 | Legacy built-ins | hyphenated string | `built-in-openai`, `built-in-codex`, `built-in-opencode` |
 | SmartGuide internal | `_internal_smart_guide_<botUUID>` | — |
 | User-created rules | random v4 UUID | — |

--- a/internal/command/tui/quickstart.go
+++ b/internal/command/tui/quickstart.go
@@ -509,15 +509,15 @@ func qsRules(ctx StepContext, s quickstartState) (quickstartState, StepResult, e
 		uuid string
 		desc string
 	}{
-		{serverconfig.RuleUUIDBuiltinOpenAI, "OpenAI scenario"},
-		{serverconfig.RuleUUIDBuiltinAnthropic, "Anthropic scenario"},
+		{serverconfig.RuleUUIDOpenAI, "OpenAI scenario"},
+		{serverconfig.RuleUIDAnthropic, "Anthropic scenario"},
 		{serverconfig.RuleUUIDCC, "Claude Code · unified"},
 		{serverconfig.RuleUUIDCCDefault, "Claude Code · default"},
 		{serverconfig.RuleUUIDCCHaiku, "Claude Code · haiku"},
 		{serverconfig.RuleUUIDCCOpus, "Claude Code · opus"},
 		{serverconfig.RuleUUIDCCSonnet, "Claude Code · sonnet"},
 		{serverconfig.RuleUUIDCCSubagent, "Claude Code · subagent"},
-		{"built-in-opencode", "OpenCode scenario"},
+		{serverconfig.RuleUUIDOpenCode, "OpenCode scenario"},
 	}
 
 	type rv struct{ uuid, desc string }

--- a/internal/protocoltest/agent_env.go
+++ b/internal/protocoltest/agent_env.go
@@ -269,10 +269,10 @@ func (env *AgentTestEnv) SetupAgent(AgentType AgentType, providerName string, mo
 		builtinUUID = "builtin:claude_code:cc"
 		requestModel = "tingly/cc"
 	case AgentTypeCodex:
-		builtinUUID = "built-in-codex"
+		builtinUUID = serverconfig.RuleUUIDCodex
 		requestModel = "tingly-codex"
 	case AgentTypeOpenCode:
-		builtinUUID = "built-in-opencode"
+		builtinUUID = serverconfig.RuleUUIDOpenCode
 		requestModel = "tingly-opencode"
 	default:
 		return fmt.Errorf("unknown Agent type: %s", AgentType)
@@ -334,10 +334,10 @@ func (env *AgentTestEnv) SetupRealAgent(AgentType AgentType, providerName string
 		builtinUUID = "builtin:claude_code:cc"
 		requestModel = "tingly/cc"
 	case AgentTypeCodex:
-		builtinUUID = "built-in-codex"
+		builtinUUID = serverconfig.RuleUUIDCodex
 		requestModel = "tingly-codex"
 	case AgentTypeOpenCode:
-		builtinUUID = "built-in-opencode"
+		builtinUUID = serverconfig.RuleUUIDOpenCode
 		requestModel = "tingly-opencode"
 	default:
 		return fmt.Errorf("unknown Agent type: %s", AgentType)

--- a/internal/protocoltest/replay.go
+++ b/internal/protocoltest/replay.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
+	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -46,9 +47,9 @@ func (env *AgentTestEnv) repointBuiltinRule(agentType AgentType, providerUUID, u
 	case AgentTypeClaudeCode:
 		builtinUUID, requestModel = "builtin:claude_code:cc", "tingly/cc"
 	case AgentTypeCodex:
-		builtinUUID, requestModel = "built-in-codex", "tingly-codex"
+		builtinUUID, requestModel = serverconfig.RuleUUIDCodex, "tingly-codex"
 	case AgentTypeOpenCode:
-		builtinUUID, requestModel = "built-in-opencode", "tingly-opencode"
+		builtinUUID, requestModel = serverconfig.RuleUUIDOpenCode, "tingly-opencode"
 	default:
 		return fmt.Errorf("unknown Agent type: %s", agentType)
 	}

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -16,33 +16,33 @@ const defaultSessionAffinitySeconds = 1800
 func init() {
 	DefaultRules = []typ.Rule{
 		{
-			UUID:          "built-in-anthropic",
+			UUID:          RuleUIDAnthropic,
 			Scenario:      typ.ScenarioAnthropic,
 			RequestModel:  "tingly-claude",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for general use with Anthropic",
-			Services:      []*loadbalance.Service{}, // Empty services initially
-			LBTactic: typ.Tactic{ // Initialize with default adaptive tactic
+			Services:      []*loadbalance.Service{},
+			LBTactic: typ.Tactic{
 				Type:   loadbalance.TacticAdaptive,
 				Params: typ.DefaultAdaptiveParams(),
 			},
 			Active: true,
 		},
 		{
-			UUID:          "built-in-agent",
+			UUID:          RuleUUIDAgent,
 			Scenario:      typ.ScenarioAgent,
 			RequestModel:  "tingly-agent",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for agent",
-			Services:      []*loadbalance.Service{}, // Empty services initially
-			LBTactic: typ.Tactic{ // Initialize with default adaptive tactic
+			Services:      []*loadbalance.Service{},
+			LBTactic: typ.Tactic{
 				Type:   loadbalance.TacticAdaptive,
 				Params: typ.DefaultAdaptiveParams(),
 			},
 			Active: true,
 		},
 		{
-			UUID:          "built-in-agent-claw",
+			UUID:          RuleUUIDAgentClaw,
 			Scenario:      typ.ScenarioAgent,
 			RequestModel:  "tingly-claw",
 			ResponseModel: "",
@@ -55,33 +55,33 @@ func init() {
 			Active: true,
 		},
 		{
-			UUID:          "built-in-team",
+			UUID:          RuleUUIDTeam,
 			Scenario:      typ.ScenarioTeam,
 			RequestModel:  "tingly-team",
 			ResponseModel: "",
 			Description:   "Default proxy rule for team (shared central model deployment)",
-			Services:      []*loadbalance.Service{}, // Empty services initially; operator binds the central provider/model
-			LBTactic: typ.Tactic{ // Initialize with default adaptive tactic
+			Services:      []*loadbalance.Service{},
+			LBTactic: typ.Tactic{
 				Type:   loadbalance.TacticAdaptive,
 				Params: typ.DefaultAdaptiveParams(),
 			},
 			Active: true,
 		},
 		{
-			UUID:          "built-in-openai",
+			UUID:          RuleUUIDOpenAI,
 			Scenario:      typ.ScenarioOpenAI,
 			RequestModel:  "tingly-gpt",
 			ResponseModel: "",
 			Description:   "Default proxy rule in tingly-box for general use with OpenAI",
-			Services:      []*loadbalance.Service{}, // Empty services initially
-			LBTactic: typ.Tactic{ // Initialize with default adaptive tactic
+			Services:      []*loadbalance.Service{},
+			LBTactic: typ.Tactic{
 				Type:   loadbalance.TacticAdaptive,
 				Params: typ.DefaultAdaptiveParams(),
 			},
 			Active: true,
 		},
 		{
-			UUID:          "built-in-codex",
+			UUID:          RuleUUIDCodex,
 			Scenario:      typ.ScenarioCodex,
 			RequestModel:  "tingly-codex",
 			ResponseModel: "",
@@ -102,7 +102,7 @@ func init() {
 		ccRule(RuleUUIDCCDefault, "tingly/cc-default", "Claude Code - Default model - for general task"),
 		ccRule(RuleUUIDCCSubagent, "tingly/cc-subagent", "Claude Code - Subagent model - model to use for subagents"),
 		{
-			UUID:          "built-in-opencode",
+			UUID:          RuleUUIDOpenCode,
 			Scenario:      typ.ScenarioOpenCode,
 			RequestModel:  "tingly-opencode",
 			ResponseModel: "",

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -41,15 +41,15 @@ const (
 	RuleUUIDBuiltinCCDefault  = "built-in-cc-default"
 	RuleUUIDBuiltinCCSubagent = "built-in-cc-subagent"
 
-	// Modern built-in rules — "builtin:<scenario>:<request_model>" form.
+	// Modern built-in rules — "builtin:<scenario>:<tier>" form.
 	// These are the target UUIDs after migrate20260612 renames the legacy ones.
-	RuleUUIDOpenAI    = "builtin:openai:tingly-gpt"
-	RuleUIDAnthropic  = "builtin:anthropic:tingly-claude"
-	RuleUUIDCodex     = "builtin:codex:tingly-codex"
-	RuleUUIDOpenCode  = "builtin:opencode:tingly-opencode"
-	RuleUUIDAgent     = "builtin:agent:tingly-agent"
-	RuleUUIDAgentClaw = "builtin:agent:tingly-claw"
-	RuleUUIDTeam      = "builtin:team:tingly-team"
+	RuleUUIDOpenAI    = "builtin:openai:default"
+	RuleUIDAnthropic  = "builtin:anthropic:default"
+	RuleUUIDCodex     = "builtin:codex:default"
+	RuleUUIDOpenCode  = "builtin:opencode:default"
+	RuleUUIDAgent     = "builtin:agent:default"
+	RuleUUIDAgentClaw = "builtin:agent:claw"
+	RuleUUIDTeam      = "builtin:team:default"
 
 	// Claude Code built-in rules (modern "builtin:<scenario>:<tier>" form)
 	RuleUUIDCC         = "builtin:claude_code:cc"

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -13,11 +13,22 @@ import (
 
 // Built-in rule UUID constants
 const (
-	RuleUUIDTingly           = "tingly"
+	// Very old / pre-scenario-split legacy UUIDs. Still present in configs
+	// written before the scenario model was introduced.
+	RuleUUIDTingly     = "tingly"
+	RuleUUIDClaudeCode = "claude-code"
+
+	// Legacy built-in UUIDs (hyphenated "built-in-*" form). Live configs are
+	// renamed to the modern RuleUUID* values by migrate20260612; these
+	// constants remain so older migrations and compatibility fallbacks can
+	// still address pre-rename configs.
 	RuleUUIDBuiltinOpenAI    = "built-in-openai"
 	RuleUUIDBuiltinAnthropic = "built-in-anthropic"
 	RuleUUIDBuiltinCodex     = "built-in-codex"
-	RuleUUIDClaudeCode       = "claude-code"
+	RuleUUIDBuiltinOpenCode  = "built-in-opencode"
+	RuleUUIDBuiltinAgent     = "built-in-agent"
+	RuleUUIDBuiltinAgentClaw = "built-in-agent-claw"
+	RuleUUIDBuiltinTeam      = "built-in-team"
 
 	// Legacy Claude Code built-in UUIDs. Live configs are renamed to the
 	// modern RuleUUIDCC* values by migrate20260611; these constants remain so
@@ -29,6 +40,16 @@ const (
 	RuleUUIDBuiltinCCOpus     = "built-in-cc-opus"
 	RuleUUIDBuiltinCCDefault  = "built-in-cc-default"
 	RuleUUIDBuiltinCCSubagent = "built-in-cc-subagent"
+
+	// Modern built-in rules — "builtin:<scenario>:<request_model>" form.
+	// These are the target UUIDs after migrate20260612 renames the legacy ones.
+	RuleUUIDOpenAI    = "builtin:openai:tingly-gpt"
+	RuleUIDAnthropic  = "builtin:anthropic:tingly-claude"
+	RuleUUIDCodex     = "builtin:codex:tingly-codex"
+	RuleUUIDOpenCode  = "builtin:opencode:tingly-opencode"
+	RuleUUIDAgent     = "builtin:agent:tingly-agent"
+	RuleUUIDAgentClaw = "builtin:agent:tingly-claw"
+	RuleUUIDTeam      = "builtin:team:tingly-team"
 
 	// Claude Code built-in rules (modern "builtin:<scenario>:<tier>" form)
 	RuleUUIDCC         = "builtin:claude_code:cc"
@@ -56,6 +77,20 @@ var legacyCCRuleUUIDs = map[string]string{
 	RuleUUIDBuiltinCCSonnet:   RuleUUIDCCSonnet,
 	RuleUUIDBuiltinCCOpus:     RuleUUIDCCOpus,
 	RuleUUIDBuiltinCCSubagent: RuleUUIDCCSubagent,
+}
+
+// legacySimpleRuleUUIDs maps the remaining legacy built-in UUIDs (all
+// non-CC single-rule scenarios) to their modern "builtin:<scenario>:<model>"
+// counterparts. Used by migrate20260612 and defaultRuleByUUID.
+var legacySimpleRuleUUIDs = map[string]string{
+	RuleUUIDTingly:           RuleUUIDOpenAI, // very old "tingly" rule preceded the openai scenario
+	RuleUUIDBuiltinOpenAI:    RuleUUIDOpenAI,
+	RuleUUIDBuiltinAnthropic: RuleUIDAnthropic,
+	RuleUUIDBuiltinCodex:     RuleUUIDCodex,
+	RuleUUIDBuiltinOpenCode:  RuleUUIDOpenCode,
+	RuleUUIDBuiltinAgent:     RuleUUIDAgent,
+	RuleUUIDBuiltinAgentClaw: RuleUUIDAgentClaw,
+	RuleUUIDBuiltinTeam:      RuleUUIDTeam,
 }
 
 // BuiltinRuleUUID builds a built-in rule UUID in the modern
@@ -89,7 +124,14 @@ var ccProfileTiers = map[string]bool{
 // those moves so each migration reads as intent, not bookkeeping.
 
 // findRuleByUUID returns a pointer to the rule with the given UUID, or nil.
+// Legacy simple-rule UUIDs (openai, anthropic, codex, …) are resolved to
+// their modern "builtin:<scenario>:<model>" aliases so that older migrations
+// which guard on the legacy UUID (e.g. migrate20260306) keep finding the
+// rule after migrate20260612 has renamed it.
 func (c *Config) findRuleByUUID(uuid string) *typ.Rule {
+	if modern, ok := legacySimpleRuleUUIDs[uuid]; ok {
+		uuid = modern
+	}
 	for i := range c.Rules {
 		if c.Rules[i].UUID == uuid {
 			return &c.Rules[i]
@@ -99,10 +141,12 @@ func (c *Config) findRuleByUUID(uuid string) *typ.Rule {
 }
 
 // defaultRuleByUUID looks up a built-in rule template (from DefaultRules) by
-// UUID. Legacy Claude Code UUIDs are resolved to their modern aliases so
-// migrations written before the rename keep finding their templates.
+// UUID. Legacy UUIDs (CC and simple scenarios) are resolved to their modern
+// aliases so migrations written before the rename keep finding their templates.
 func defaultRuleByUUID(uuid string) (typ.Rule, bool) {
 	if modern, ok := legacyCCRuleUUIDs[uuid]; ok {
+		uuid = modern
+	} else if modern, ok := legacySimpleRuleUUIDs[uuid]; ok {
 		uuid = modern
 	}
 	for _, r := range DefaultRules {
@@ -163,6 +207,7 @@ func Migrate(c *Config) error {
 	migrate20260606(c) // Default SkipUsage on for the Xcode scenario
 	migrate20260610(c) // Seed default rule flags (claude_code_compat / clean_header / session_affinity) for CC / Desktop / Codex rules
 	migrate20260611(c) // Normalize Claude Code profile rule UUIDs to "<builtin-uuid>:<profileID>"
+	migrate20260612(c) // Rename remaining legacy built-in UUIDs to "builtin:<scenario>:<model>" form
 	return nil
 }
 
@@ -778,4 +823,58 @@ func migrate20260611(c *Config) {
 
 	_ = c.Save()
 	logrus.Infof("Migration 20260611 completed: normalized %d Claude Code rule UUID(s)", len(renames))
+}
+
+// migrate20260612 renames the remaining legacy built-in rule UUIDs
+// (openai / anthropic / codex / opencode / agent / team / tingly) to the
+// modern "builtin:<scenario>:<request_model>" form established by
+// migrate20260611 for Claude Code.
+//
+// The pass is idempotent and not marker-gated: rules already carrying a
+// modern UUID are skipped, so a config written by a newer build is left
+// intact on every restart. A rename is skipped (with a warning) if the
+// canonical UUID is already taken, preventing accidental UUID collisions.
+// SQLite state keyed by rule UUID is re-keyed alongside each rule so
+// load-balancer position and usage history survive the rename.
+func migrate20260612(c *Config) {
+	renames := map[string]string{}
+	for i := range c.Rules {
+		rule := &c.Rules[i]
+		canonical, ok := legacySimpleRuleUUIDs[rule.UUID]
+		if !ok {
+			continue
+		}
+		if rule.UUID == canonical {
+			continue
+		}
+		if c.findRuleByUUID(canonical) != nil {
+			logrus.WithFields(logrus.Fields{
+				"rule_uuid": rule.UUID,
+				"canonical": canonical,
+			}).Warn("Migration 20260612: canonical rule UUID already taken, skipping rename")
+			continue
+		}
+		renames[rule.UUID] = canonical
+		rule.UUID = canonical
+	}
+
+	if len(renames) == 0 {
+		return
+	}
+
+	for oldUUID, newUUID := range renames {
+		if c.ruleStateStore != nil {
+			if err := c.ruleStateStore.RenameRuleUUID(oldUUID, newUUID); err != nil {
+				logrus.WithError(err).Warnf("Migration 20260612: failed to rename rule state %s -> %s", oldUUID, newUUID)
+			}
+		}
+		if c.usageStore != nil {
+			if err := c.usageStore.RenameRuleUUID(oldUUID, newUUID); err != nil {
+				logrus.WithError(err).Warnf("Migration 20260612: failed to rename usage records %s -> %s", oldUUID, newUUID)
+			}
+		}
+	}
+
+	_ = c.Save()
+	logrus.Infof("Migration 20260612 completed: renamed %d built-in rule UUID(s) to modern form", len(renames))
 }


### PR DESCRIPTION
## Summary
Completes the migration of all legacy built-in rule UUIDs (openai, anthropic, codex, opencode, agent, team, and the very old "tingly") to the modern `builtin:<scenario>:<tier>` form established by the Claude Code migration. This ensures all system-seeded rules follow a consistent, deterministic naming convention.

## Key Changes

- **New migration `migrate20260612`**: Renames remaining legacy built-in UUIDs to modern form while preserving SQLite state (load-balancer position and usage history) by re-keying rule state and usage records alongside each rename. The migration is idempotent and skips rules already in modern form or where the canonical UUID is already taken.

- **Updated rule UUID constants**: 
  - Added modern form constants (`RuleUUIDOpenAI`, `RuleUIDAnthropic`, `RuleUUIDCodex`, `RuleUUIDOpenCode`, `RuleUUIDAgent`, `RuleUUIDAgentClaw`, `RuleUUIDTeam`)
  - Reorganized legacy constants with clear comments distinguishing pre-scenario-split UUIDs, legacy hyphenated form, and modern form
  - Added `legacySimpleRuleUUIDs` map for migration and compatibility fallbacks

- **Updated rule lookup logic**:
  - `findRuleByUUID()` now resolves legacy simple-rule UUIDs to their modern aliases, ensuring older migrations that guard on legacy UUIDs continue to find rules after rename
  - `defaultRuleByUUID()` extended to handle both CC and simple scenario legacy UUIDs

- **Updated DefaultRules initialization**: Changed all built-in rule UUIDs in `init.go` to use the new modern form constants

- **Updated test and command code**: Replaced hardcoded legacy UUID strings with the appropriate modern form constants in `agent_env.go`, `replay.go`, and `quickstart.go`

- **Updated design documentation**: Clarified that all system-seeded built-ins now use the modern `builtin:<scenario>:<tier>` form

## Implementation Details

The migration follows the same pattern as `migrate20260611` (Claude Code):
- Idempotent: rules already in modern form are skipped
- Safe: collision detection prevents accidental UUID overwrites
- Stateful: rule state and usage records are re-keyed to survive the rename
- Logged: completion message reports number of rules renamed

The `legacySimpleRuleUUIDs` map serves dual purpose: enabling the migration itself and providing compatibility fallbacks so migrations written before the rename continue to work correctly.

https://claude.ai/code/session_01PUvzNPXE5dvHhq2TrTmowm