### PR TITLE
fix(protocol): OpenAI chat streaming from Anthropic models fails strict client validation

### DIFF
--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -2,7 +2,6 @@ package stream
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,7 +10,6 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/gin-gonic/gin"
-	"github.com/openai/openai-go/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -107,52 +105,6 @@ func AnthropicToOpenAIStreamWithMCPHooks(hc *protocol.HandleContext, req *anthro
 	return usage, nil
 }
 
-// sendOpenAIStreamChunk sends a ChatCompletionChunk as SSE
-func sendOpenAIStreamChunk(c *gin.Context, chunk openai.ChatCompletionChunk, disableStreamUsage bool) {
-	chunkMap, err := chunkToMap(chunk)
-	if err != nil {
-		logrus.WithContext(c.Request.Context()).Errorf("Failed to convert chunk to map: %v", err)
-		return
-	}
-
-	// Cursor compatibility path must not expose usage in stream chunks.
-	if disableStreamUsage {
-		delete(chunkMap, "usage")
-	}
-
-	OpenAISSE(c, chunkMap)
-}
-
-func chunkToMap(chunk openai.ChatCompletionChunk) (map[string]interface{}, error) {
-	bytes, err := json.Marshal(chunk)
-	if err != nil {
-		return nil, err
-	}
-	var chunkMap map[string]interface{}
-	if err := json.Unmarshal(bytes, &chunkMap); err != nil {
-		return nil, err
-	}
-	// The SDK chunk struct marshals unset fields as zero values, so a delta
-	// without a role serializes as "role":"". Strict clients (e.g. Vercel AI
-	// SDK) validate role against the "assistant" enum and reject "", so drop
-	// the field entirely when it is empty — matching OpenAI's real final
-	// chunk, which sends "delta":{}.
-	if choices, ok := chunkMap["choices"].([]interface{}); ok {
-		for _, choice := range choices {
-			choiceMap, ok := choice.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if delta, ok := choiceMap["delta"].(map[string]interface{}); ok {
-				if role, ok := delta["role"].(string); ok && role == "" {
-					delete(delta, "role")
-				}
-			}
-		}
-	}
-	return chunkMap, nil
-}
-
 // sendOpenAIStreamChunkForce helper function to send a chunk in OpenAI format
 func sendOpenAIStreamChunkForce(c *gin.Context, chunk map[string]interface{}) {
 	OpenAISSE(c, chunk)
@@ -167,43 +119,4 @@ func sendOpenAIStreamError(c *gin.Context, message, errorType string) {
 		},
 	}
 	OpenAISSE(c, errorMap)
-}
-
-// createReasoningContentChunk creates a chunk with reasoning_content field
-// This is a workaround for OpenAI's extended thinking format which is not natively supported in the SDK
-func createReasoningContentChunk(chatID string, created int64, model, reasoning string) openai.ChatCompletionChunk {
-	chunk := openai.ChatCompletionChunk{
-		ID:      chatID,
-		Created: created,
-		Model:   model,
-		Choices: []openai.ChatCompletionChunkChoice{
-			{
-				Index: 0,
-				Delta: openai.ChatCompletionChunkChoiceDelta{
-					Content: "",
-				},
-			},
-		},
-	}
-
-	if reasoning == "" {
-		return chunk
-	}
-
-	chunkJSON, _ := json.Marshal(chunk)
-	var chunkMap map[string]interface{}
-	json.Unmarshal(chunkJSON, &chunkMap)
-
-	if choices, ok := chunkMap["choices"].([]interface{}); ok && len(choices) > 0 {
-		if choice, ok := choices[0].(map[string]interface{}); ok {
-			if delta, ok := choice["delta"].(map[string]interface{}); ok {
-				delta["reasoning_content"] = reasoning
-			}
-		}
-	}
-
-	updatedJSON, _ := json.Marshal(chunkMap)
-	json.Unmarshal(updatedJSON, &chunk)
-
-	return chunk
 }

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -132,6 +132,24 @@ func chunkToMap(chunk openai.ChatCompletionChunk) (map[string]interface{}, error
 	if err := json.Unmarshal(bytes, &chunkMap); err != nil {
 		return nil, err
 	}
+	// The SDK chunk struct marshals unset fields as zero values, so a delta
+	// without a role serializes as "role":"". Strict clients (e.g. Vercel AI
+	// SDK) validate role against the "assistant" enum and reject "", so drop
+	// the field entirely when it is empty — matching OpenAI's real final
+	// chunk, which sends "delta":{}.
+	if choices, ok := chunkMap["choices"].([]interface{}); ok {
+		for _, choice := range choices {
+			choiceMap, ok := choice.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if delta, ok := choiceMap["delta"].(map[string]interface{}); ok {
+				if role, ok := delta["role"].(string); ok && role == "" {
+					delete(delta, "role")
+				}
+			}
+		}
+	}
 	return chunkMap, nil
 }
 

--- a/internal/protocol/stream/anthropic_to_openai_converter.go
+++ b/internal/protocol/stream/anthropic_to_openai_converter.go
@@ -7,14 +7,19 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
-	"github.com/openai/openai-go/v3"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
 // anthropicToOpenAIConverter is a stateful iterator that reads Anthropic Beta stream
-// events and emits OpenAI Chat Completion chunk maps.
+// events and emits OpenAI Chat Completion wire chunks.
+//
+// Chunks are built with wire DTOs (omitempty outbound shapes) rather than the
+// openai-go SDK response structs: the SDK types marshal unset fields as zero
+// values ("role":"", "finish_reason":"", zero usage on every chunk), which
+// strict clients reject.
 type anthropicToOpenAIConverter struct {
 	stream             *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion]
 	responseModel      string
@@ -98,20 +103,7 @@ func (c *anthropicToOpenAIConverter) HookErr() error {
 func (c *anthropicToOpenAIConverter) processEvent(event *anthropic.BetaRawMessageStreamEventUnion) {
 	switch event.Type {
 	case "message_start":
-		chunk := openai.ChatCompletionChunk{
-			ID:      c.chatID,
-			Created: c.created,
-			Model:   c.responseModel,
-			Choices: []openai.ChatCompletionChunkChoice{
-				{
-					Index: 0,
-					Delta: openai.ChatCompletionChunkChoiceDelta{
-						Role: "assistant",
-					},
-				},
-			},
-		}
-		c.emitChunk(chunk)
+		c.emitChunk(wire.ChatStreamDelta{Role: "assistant"}, nil)
 		c.acc.ConsumeBeta(event)
 
 	case "content_block_start":
@@ -124,31 +116,20 @@ func (c *anthropicToOpenAIConverter) processEvent(event *anthropic.BetaRawMessag
 			c.suppressToolCall = c.hooks != nil && c.hooks.ShouldSuppressTool != nil && c.hooks.ShouldSuppressTool(c.toolCallName)
 			if !c.suppressToolCall {
 				c.hasToolCalls = true
-				chunk := openai.ChatCompletionChunk{
-					ID:      c.chatID,
-					Created: c.created,
-					Model:   c.responseModel,
-					Choices: []openai.ChatCompletionChunkChoice{
+				emptyArgs := ""
+				c.emitChunk(wire.ChatStreamDelta{
+					ToolCalls: []wire.ChatStreamToolCall{
 						{
 							Index: 0,
-							Delta: openai.ChatCompletionChunkChoiceDelta{
-								Role: "assistant",
-								ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
-									{
-										Index: 0,
-										ID:    c.toolCallID,
-										Type:  "function",
-										Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
-											Name:      c.toolCallName,
-											Arguments: "",
-										},
-									},
-								},
+							ID:    c.toolCallID,
+							Type:  "function",
+							Function: wire.ChatStreamToolFunction{
+								Name:      c.toolCallName,
+								Arguments: &emptyArgs,
 							},
 						},
 					},
-				}
-				c.emitChunk(chunk)
+				}, nil)
 			}
 		} else if event.ContentBlock.Type == "thinking" {
 			c.thinkingText.Reset()
@@ -159,54 +140,24 @@ func (c *anthropicToOpenAIConverter) processEvent(event *anthropic.BetaRawMessag
 
 	case "content_block_delta":
 		if event.Delta.Type == "text_delta" && event.Delta.Text != "" {
-			text := event.Delta.Text
-			chunk := openai.ChatCompletionChunk{
-				ID:      c.chatID,
-				Created: c.created,
-				Model:   c.responseModel,
-				Choices: []openai.ChatCompletionChunkChoice{
-					{
-						Index: 0,
-						Delta: openai.ChatCompletionChunkChoiceDelta{
-							Role:    "assistant",
-							Content: text,
-						},
-					},
-				},
-			}
-			c.emitChunk(chunk)
+			c.emitChunk(wire.ChatStreamDelta{Content: event.Delta.Text}, nil)
 		} else if event.Delta.Type == "input_json_delta" && event.Delta.PartialJSON != "" {
 			args := event.Delta.PartialJSON
 			c.toolCallArgs.WriteString(args)
 			if !c.suppressToolCall {
-				chunk := openai.ChatCompletionChunk{
-					ID:      c.chatID,
-					Created: c.created,
-					Model:   c.responseModel,
-					Choices: []openai.ChatCompletionChunkChoice{
+				c.emitChunk(wire.ChatStreamDelta{
+					ToolCalls: []wire.ChatStreamToolCall{
 						{
-							Index: 0,
-							Delta: openai.ChatCompletionChunkChoiceDelta{
-								Role: "assistant",
-								ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
-									{
-										Index: 0,
-										Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
-											Arguments: args,
-										},
-									},
-								},
-							},
+							Index:    0,
+							Function: wire.ChatStreamToolFunction{Arguments: &args},
 						},
 					},
-				}
-				c.emitChunk(chunk)
+				}, nil)
 			}
 		} else if event.Delta.Type == "thinking_delta" && event.Delta.Thinking != "" {
 			thinking := event.Delta.Thinking
 			c.thinkingText.WriteString(thinking)
-			chunk := createReasoningContentChunk(c.chatID, c.created, c.responseModel, thinking)
-			c.emitChunk(chunk)
+			c.emitChunk(wire.ChatStreamDelta{ReasoningContent: thinking}, nil)
 		}
 		// signature_delta is intentionally ignored
 
@@ -238,38 +189,47 @@ func (c *anthropicToOpenAIConverter) processEvent(event *anthropic.BetaRawMessag
 		if c.hasToolCalls {
 			finishReason = openaiFinishReasonToolCalls
 		}
-		delta := openai.ChatCompletionChunkChoiceDelta{}
-		if c.hasToolCalls {
-			delta.Content = ""
-		}
-		chunk := openai.ChatCompletionChunk{
-			ID:      c.chatID,
-			Created: c.created,
-			Model:   c.responseModel,
-			Choices: []openai.ChatCompletionChunkChoice{
-				{
-					Index:        0,
-					Delta:        delta,
-					FinishReason: finishReason,
-				},
-			},
-		}
+		chunk := c.newChunk(wire.ChatStreamDelta{}, &finishReason)
 		if !c.disableStreamUsage && c.acc.HasUsage() {
-			chunk.Usage = usagepkg.ChatUsage(c.acc.Result())
+			chunk.Usage = chatStreamUsageWire(c.acc.Result())
 		}
-		c.emitChunk(chunk)
+		c.pending = append(c.pending, chunk)
 		c.done = true
 	}
 }
 
-// emitChunk converts a ChatCompletionChunk to a map and appends to pending.
-func (c *anthropicToOpenAIConverter) emitChunk(chunk openai.ChatCompletionChunk) {
-	m, err := chunkToMap(chunk)
-	if err != nil {
-		return
+// emitChunk appends a wire chunk with the given delta to the pending queue.
+func (c *anthropicToOpenAIConverter) emitChunk(delta wire.ChatStreamDelta, finishReason *string) {
+	c.pending = append(c.pending, c.newChunk(delta, finishReason))
+}
+
+func (c *anthropicToOpenAIConverter) newChunk(delta wire.ChatStreamDelta, finishReason *string) wire.ChatStreamChunk {
+	return wire.ChatStreamChunk{
+		ID:      c.chatID,
+		Object:  "chat.completion.chunk",
+		Created: c.created,
+		Model:   c.responseModel,
+		Choices: []wire.ChatStreamChoice{
+			{Index: 0, Delta: delta, FinishReason: finishReason},
+		},
 	}
-	if c.disableStreamUsage {
-		delete(m, "usage")
+}
+
+// chatStreamUsageWire converts normalized TokenUsage into the Chat Completions
+// stream usage wire shape. Same semantics as usagepkg.ChatUsage: prompt_tokens
+// is the TOTAL (uncached + cached), cached_tokens a reported subset.
+func chatStreamUsageWire(u *protocol.TokenUsage) *wire.ChatStreamUsage {
+	totalInput := u.InputTokens + u.CacheInputTokens
+	su := &wire.ChatStreamUsage{
+		PromptTokens:     int64(totalInput),
+		CompletionTokens: int64(u.OutputTokens),
+		TotalTokens:      int64(totalInput + u.OutputTokens),
 	}
-	c.pending = append(c.pending, m)
+	if u.CacheInputTokens > 0 {
+		su.PromptTokensDetails = &wire.ChatStreamPromptTokenDetails{CachedTokens: int64(u.CacheInputTokens)}
+	}
+	if u.ReasoningTokens > 0 {
+		su.CompletionTokensDetails = &wire.ChatStreamOutputTokenDetails{ReasoningTokens: int64(u.ReasoningTokens)}
+	}
+	return su
 }

--- a/internal/protocol/stream/anthropic_to_openai_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_test.go
@@ -183,6 +183,64 @@ func TestAnthropicToOpenAIStream_NonStandardDelta(t *testing.T) {
 	assert.Equal(t, 20, usage.OutputTokens)
 }
 
+// TestAnthropicToOpenAIStream_FinalChunkOmitsEmptyRole verifies that chunks whose
+// delta has no role (e.g. the final finish_reason chunk) omit the field entirely
+// instead of serializing "role":"". Strict clients such as the Vercel AI SDK
+// validate delta.role against the "assistant" enum and reject empty strings.
+func TestAnthropicToOpenAIStream_FinalChunkOmitsEmptyRole(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 35, 0),
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		buildAnthropicOutputOnlyDeltaJSON(t, 18),
+		buildMessageStopJSON(),
+	}
+	decoder := newFakeAnthropicDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](decoder, nil)
+
+	_, err := AnthropicToOpenAIStream(protocol.NewHandleContext(c, "claude-3-5-sonnet"), nil, stream, "claude-3-5-sonnet", false)
+	require.NoError(t, err)
+
+	sawFinishChunk := false
+	for _, line := range strings.Split(w.Body.String(), "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if strings.TrimSpace(payload) == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(payload), &chunk))
+		choices, ok := chunk["choices"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, choice := range choices {
+			choiceMap := choice.(map[string]interface{})
+			delta, ok := choiceMap["delta"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if role, present := delta["role"]; present {
+				assert.Equal(t, "assistant", role, "delta.role must never be empty: %s", payload)
+			}
+			if fr, _ := choiceMap["finish_reason"].(string); fr == "stop" {
+				sawFinishChunk = true
+				_, present := delta["role"]
+				assert.False(t, present, "final chunk delta must omit role: %s", payload)
+			}
+		}
+	}
+	assert.True(t, sawFinishChunk, "stream must emit a finish_reason chunk")
+}
+
 // TestSendOpenAIStreamChunk tests the helper function
 func TestSendOpenAIStreamChunk(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/protocol/wire/openai_chat.go
+++ b/internal/protocol/wire/openai_chat.go
@@ -23,6 +23,9 @@ type ChatStreamDelta struct {
 	Role      string               `json:"role,omitempty"`
 	Content   string               `json:"content,omitempty"`
 	ToolCalls []ChatStreamToolCall `json:"tool_calls,omitempty"`
+	// ReasoningContent carries extended-thinking text (DeepSeek-style extension;
+	// not part of the official OpenAI Chat schema).
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 type ChatStreamToolCall struct {


### PR DESCRIPTION
## Bug

Requesting an Anthropic model through the OpenAI Chat Completions API with streaming breaks strict OpenAI clients (e.g. Vercel AI SDK):

```
Type validation failed: ... "code": "invalid_value", "values": ["assistant"],
"path": ["choices", 0, "delta", "role"], "message": "Invalid input: expected \"assistant\""
```

## Root cause

The Anthropic→OpenAI stream converter hand-built `openai.ChatCompletionChunk` SDK structs and marshaled them onto the wire. The openai-go types are **response** types: they track field presence in unmarshal-only metadata and have no `omitempty` tags, so hand-constructed values serialize every unset field as its zero value. The final `finish_reason: "stop"` chunk therefore carried `"role": ""` — which fails clients that validate `delta.role` against the `"assistant"` enum — plus other zero-value noise on every chunk: `"finish_reason": ""` instead of `null`, empty `function_call` / `refusal` / `service_tier`, and a zero `usage` block.

## Fix

Emit chunks via the `wire.ChatStream*` outbound DTOs (`omitempty` shapes) already used by the Responses→Chat converter, instead of SDK structs — the same convention the Google→Chat and passthrough paths already follow. Output now matches OpenAI's real stream shape:

- `role` only on the first delta; the final chunk's delta is `{}`
- `finish_reason` is `null` until the terminal chunk
- `usage` only on the final chunk
- extended thinking flows through a new `reasoning_content` field on `wire.ChatStreamDelta` (replacing the JSON round-trip workaround)

Removes the now-dead `chunkToMap()`, `sendOpenAIStreamChunk()`, and `createReasoningContentChunk()` helpers.

## Verification

- New regression test `TestAnthropicToOpenAIStream_FinalChunkOmitsEmptyRole` asserts every emitted delta's `role` is either `"assistant"` or absent, and that the terminal chunk omits it.
- Full `go test ./...` passes, including the cross-protocol `protocoltest` / `servertest` e2e suites.

https://claude.ai/code/session_011DGyvhR7rdk6x2aeiDDEAd