### PR TITLE
refactor(ux,config): simplify Claude Code setup UI and drop default team rule

### DIFF
--- a/frontend/src/components/CardGrid.tsx
+++ b/frontend/src/components/CardGrid.tsx
@@ -30,7 +30,7 @@ const defaultColumns = {
 export const CardGrid = ({
   children,
   columns = defaultColumns,
-  spacing = 3,
+  spacing = 2,
   virtualized = false,
   itemHeight = 300,
   containerHeight: propContainerHeight = 600,

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -201,16 +201,6 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setInstallDone(true);
     };
 
-    const handleApply = async () => {
-        if (!onApply) return;
-        const result = await onApply();
-        setApplyResult(result);
-        if (result.success) {
-            localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');
-            setApplyDone(true);
-        }
-    };
-
     const handleApplyWithStatusLine = async () => {
         if (!onApplyWithStatusLine) return;
         const result = await onApplyWithStatusLine();
@@ -465,13 +455,8 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 </Typography>
                                 <Stack direction="row" spacing={1} flexWrap="wrap" gap={0.5}>
                                     {onApply && (
-                                        <Button variant="contained" size="small" disabled={isApplyLoading} onClick={handleApply} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>
+                                        <Button variant="contained" size="small" disabled={isApplyLoading} onClick={handleApplyWithStatusLine} startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : undefined}>
                                             {applyButtonLabel}
-                                        </Button>
-                                    )}
-                                    {onApplyWithStatusLine && (
-                                        <Button variant="outlined" size="small" disabled={isApplyLoading} onClick={handleApplyWithStatusLine}>
-                                            Auto Config + Status Line
                                         </Button>
                                     )}
                                     {onViewConfig && (

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -1,5 +1,6 @@
-import { Alert, AlertTitle, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Link, Tab, Tabs, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, IconButton, Link, Stack, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import { Close as CloseIcon } from '@/components/icons';
+import { InfoOutlined as InfoOutlinedIcon } from '@/components/icons';
 import { VisibilityOutlined as VisibilityOutlinedIcon } from '@/components/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -112,6 +113,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     const [statusLineTab, setStatusLineTab] = React.useState<ScriptTab>('json');
     const [previewOpen, setPreviewOpen] = React.useState(false);
     const [applyResult, setApplyResult] = React.useState<AgentApplyResult | null>(null);
+    const [installStatusLine, setInstallStatusLine] = React.useState(true);
 
     // Prefs is the single source of truth for both tabs. Re-seed when the
     // modal isn't open so we never clobber the user's unsaved edits.
@@ -568,6 +570,27 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                             </Box>
                         </Box>
                     )}
+
+                    {/* Status line checkbox — visible on both tabs */}
+                    <Box sx={{ mt: 2, pt: 2, borderTop: 1, borderColor: 'divider' }}>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={installStatusLine}
+                                    onChange={(e) => setInstallStatusLine(e.target.checked)}
+                                    size="small"
+                                />
+                            }
+                            label={
+                                <Stack direction="row" spacing={0.5} alignItems="center">
+                                    <Typography variant="body2">Install Tingly-Box Claude Code status line</Typography>
+                                    <Tooltip title="Adds a status line script to ~/.claude/settings.json that shows the current Tingly Box connection status in the Claude Code prompt." arrow placement="top">
+                                        <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
+                                    </Tooltip>
+                                </Stack>
+                            }
+                        />
+                    </Box>
                 </DialogContent>
 
                 <DialogActions sx={{ px: 3, pb: 2, pt: 1, gap: 1, justifyContent: 'space-between' }}>
@@ -581,27 +604,17 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                     </Button>
                     <Box sx={{ display: 'flex', gap: 1 }}>
                         <Button onClick={onClose} color="inherit">
-                            {t('common.cancel')}
+                            Close
                         </Button>
                         {canApply && (
-                            <>
-                                <Button
-                                    onClick={() => handleApply(false)}
-                                    variant="outlined"
-                                    disabled={isApplyLoading}
-                                    startIcon={isApplyLoading ? <CircularProgress size={14} /> : null}
-                                >
-                                    {t('claudeCode.quickApply')}
-                                </Button>
-                                <Button
-                                    onClick={() => handleApply(true)}
-                                    variant="contained"
-                                    disabled={isApplyLoading}
-                                    startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : null}
-                                >
-                                    {t('claudeCode.quickApplyWithStatusLine')}
-                                </Button>
-                            </>
+                            <Button
+                                onClick={() => handleApply(installStatusLine)}
+                                variant="contained"
+                                disabled={isApplyLoading}
+                                startIcon={isApplyLoading ? <CircularProgress size={14} color="inherit" /> : null}
+                            >
+                                {t('claudeCode.quickApply')}
+                            </Button>
                         )}
                     </Box>
                 </DialogActions>
@@ -630,7 +643,7 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                     />
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={() => setPreviewOpen(false)}>{t('common.cancel')}</Button>
+                    <Button onClick={() => setPreviewOpen(false)}>Close</Button>
                 </DialogActions>
             </Dialog>
         </>

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -37,6 +37,8 @@ export interface ClaudeCodePrefs {
     MCP_TOOL_TIMEOUT?: string;
     MAX_MCP_OUTPUT_TOKENS?: string;
 
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE?: string;
+
     DISABLE_TELEMETRY?: string;
     DISABLE_ERROR_REPORTING?: string;
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC?: string;
@@ -81,6 +83,8 @@ const FIELD_STRUCT: FieldStruct[] = [
     { envName: 'MCP_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
     { envName: 'MCP_TOOL_TIMEOUT', group: 'limits', kind: 'int', unit: 'ms', advanced: true },
     { envName: 'MAX_MCP_OUTPUT_TOKENS', group: 'limits', kind: 'int', unit: 'tokens', advanced: true },
+    // Auto-compact (commonly adjusted - not advanced)
+    { envName: 'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE', group: 'limits', kind: 'int', unit: '%', advanced: false },
     // Switches (advanced - usually don't need to change)
     { envName: 'DISABLE_TELEMETRY', group: 'switches', kind: 'bool', advanced: true },
     { envName: 'DISABLE_ERROR_REPORTING', group: 'switches', kind: 'bool', advanced: true },
@@ -185,6 +189,12 @@ const FIELDS_TEXT_ZH: FieldTextMap = {
         purpose: 'MCP 工具单次返回内容的 token 上限',
         tooltip: '官方默认 8192。超过会被截断。',
         placeholder: '8192',
+    },
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: {
+        label: '自动压缩阈值',
+        purpose: '上下文自动压缩的触发百分比',
+        tooltip: 'tb 默认 85。当上下文使用率达到该百分比时触发自动压缩。调低则更早压缩，调高则更晚。设为 0 禁用。',
+        placeholder: '85',
     },
     DISABLE_TELEMETRY: {
         label: '禁用遥测',
@@ -309,6 +319,12 @@ const FIELDS_TEXT_EN: FieldTextMap = {
         purpose: 'Max tokens returned from one MCP tool call',
         tooltip: 'Anthropic default is 8192. Anything larger is truncated.',
         placeholder: '8192',
+    },
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: {
+        label: 'Auto-compact threshold',
+        purpose: 'Context auto-compact trigger percentage',
+        tooltip: 'tb default is 85. Triggers auto-compaction when context usage reaches this %. Lower = earlier compaction, higher = later. Set to 0 to disable.',
+        placeholder: '85',
     },
     DISABLE_TELEMETRY: {
         label: 'Disable telemetry',
@@ -482,6 +498,7 @@ export const derivePrefsFromRules = ({ rules, mode }: DerivePrefsInput): ClaudeC
 
         API_TIMEOUT_MS: '3000000',
         CLAUDE_CODE_MAX_OUTPUT_TOKENS: '32000',
+        CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '85',
 
         DISABLE_TELEMETRY: '1',
         DISABLE_ERROR_REPORTING: '1',

--- a/frontend/src/pages/scenario/components/CodexConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/CodexConfigModal.tsx
@@ -656,7 +656,7 @@ EOF`;
                 </DialogContent>
                 <DialogActions sx={{ px: 3, pb: 2 }}>
                     <Button onClick={() => setSessionAction(null)} color="inherit" disabled={isSubmitting}>
-                        Cancel
+                        Close
                     </Button>
                     <Button
                         onClick={handleSessionAction}

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -55,19 +55,6 @@ func init() {
 			Active: true,
 		},
 		{
-			UUID:          RuleUUIDTeam,
-			Scenario:      typ.ScenarioTeam,
-			RequestModel:  "tingly-team",
-			ResponseModel: "",
-			Description:   "Default proxy rule for team (shared central model deployment)",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
-			},
-			Active: true,
-		},
-		{
 			UUID:          RuleUUIDOpenAI,
 			Scenario:      typ.ScenarioOpenAI,
 			RequestModel:  "tingly-gpt",

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -49,7 +49,6 @@ const (
 	RuleUUIDOpenCode  = "builtin:opencode:default"
 	RuleUUIDAgent     = "builtin:agent:default"
 	RuleUUIDAgentClaw = "builtin:agent:claw"
-	RuleUUIDTeam      = "builtin:team:default"
 
 	// Claude Code built-in rules (modern "builtin:<scenario>:<tier>" form)
 	RuleUUIDCC         = "builtin:claude_code:cc"
@@ -90,7 +89,6 @@ var legacySimpleRuleUUIDs = map[string]string{
 	RuleUUIDBuiltinOpenCode:  RuleUUIDOpenCode,
 	RuleUUIDBuiltinAgent:     RuleUUIDAgent,
 	RuleUUIDBuiltinAgentClaw: RuleUUIDAgentClaw,
-	RuleUUIDBuiltinTeam:      RuleUUIDTeam,
 }
 
 // BuiltinRuleUUID builds a built-in rule UUID in the modern


### PR DESCRIPTION
## Summary
The Claude Code config dialog had a clunky dual-button pattern that forced users to choose between "quick apply" and "quick apply with status line". 
Unified this into a single apply button with an optional checkbox, and made other UX and config cleanups. 

### Major
- **Unified Claude Code apply UX**: Replaced the two-button pattern (`Quick Apply` / `Quick Apply + Status Line`) with a single apply button + a checkbox for status line installation. This eliminates a mode picker — users no longer have to understand what each apply variant does before clicking.
- **Removed default `team` scenario rule**: The built-in rule for the `team` scenario is no longer created automatically on fresh installs. Users who need a team rule must define it explicitly, reducing default clutter.
- **Added auto-compact threshold to Claude Code quick config**: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is now surfaced as a first-class field in the Claude Code config UI (default 85%), so users can adjust compaction behavior without editing raw env vars.

### Minor
- Reduced default card grid spacing (3 → 2) for tighter, more compact layouts.
- Changed `Cancel` to `Close` button labels in config modals for clearer intent (the dialogs save nothing to cancel).
 