### PR TITLE
fix(gateway): make responses faithful to real SDK clients (gosdk / python / node / AI SDK)

### DIFF
--- a/internal/protocol/nonstream/anthropic_write.go
+++ b/internal/protocol/nonstream/anthropic_write.go
@@ -1,0 +1,29 @@
+package nonstream
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// WriteAnthropicMessage writes a non-streaming Anthropic message response.
+//
+// It prefers the SDK message's RawJSON, which is clean by construction — the
+// upstream's original body on passthrough, and the converter's wire bytes on
+// converted paths (the converters build a wire DTO, so RawJSON carries no
+// zero-value noise like content[].citations: null that a plain struct marshal
+// would emit and that strict clients reject). It falls back to a marshal only
+// when RawJSON is empty.
+//
+// Callers that mutate the message after receiving it (e.g. the MCP tool loop
+// filtering virtual tool_use blocks) must NOT use this helper: RawJSON would
+// be stale. They marshal the struct directly so the wire reflects the mutation.
+func WriteAnthropicMessage(c *gin.Context, msg any) {
+	if r, ok := msg.(interface{ RawJSON() string }); ok {
+		if raw := r.RawJSON(); raw != "" {
+			c.Data(http.StatusOK, "application/json; charset=utf-8", []byte(raw))
+			return
+		}
+	}
+	c.JSON(http.StatusOK, msg)
+}

--- a/internal/protocol/nonstream/openai_passthrough.go
+++ b/internal/protocol/nonstream/openai_passthrough.go
@@ -14,10 +14,18 @@ import (
 // overriding the model field in the response when responseModel differs from the request model.
 // Corresponds to stream.HandleOpenAIResponsesStream.
 func HandleOpenAIResponsesPassthroughNonStream(hc *protocol.HandleContext, resp *responses.Response) (*protocol.TokenUsage, error) {
-	responseJSON, err := json.Marshal(resp)
-	if err != nil {
-		hc.SendError(err, "api_error", "marshal_failed")
-		return protocol.ZeroTokenUsage(), err
+	// Prefer the upstream's actual body: re-marshaling the SDK struct emits
+	// every union field with its zero value (e.g. output[].phase: "",
+	// content[].annotations: null), which strict clients like the AI SDK's
+	// zod schemas reject. RawJSON is empty only for locally-built responses.
+	responseJSON := []byte(resp.RawJSON())
+	if len(responseJSON) == 0 {
+		var err error
+		responseJSON, err = json.Marshal(resp)
+		if err != nil {
+			hc.SendError(err, "api_error", "marshal_failed")
+			return protocol.ZeroTokenUsage(), err
+		}
 	}
 	var responseMap map[string]any
 	if err := json.Unmarshal(responseJSON, &responseMap); err != nil {

--- a/internal/protocol/nonstream/openai_responses.go
+++ b/internal/protocol/nonstream/openai_responses.go
@@ -3,6 +3,7 @@ package nonstream
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
@@ -31,11 +32,16 @@ func BuildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, a
 	output := []map[string]any{}
 	if messageContent != "" {
 		output = append(output, map[string]any{
+			// The real Responses API always assigns output items an id;
+			// strict clients (AI SDK zod) require it.
+			"id":     "msg_" + resp.ID,
 			"type":   "message",
 			"role":   "assistant",
 			"status": itemStatus,
 			"content": []map[string]any{
-				{"type": "output_text", "text": messageContent},
+				// The real Responses API always includes annotations on
+				// output_text; strict clients (AI SDK zod) require it.
+				{"type": "output_text", "text": messageContent, "annotations": []any{}},
 			},
 		})
 	}
@@ -55,12 +61,13 @@ func BuildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, a
 	}
 
 	result := map[string]any{
-		"id":     resp.ID,
-		"object": "response",
-		"model":  model,
-		"status": status,
-		"output": output,
-		"usage":  usageMap,
+		"id":         resp.ID,
+		"object":     "response",
+		"created_at": time.Now().Unix(),
+		"model":      model,
+		"status":     status,
+		"output":     output,
+		"usage":      usageMap,
 	}
 	if incompleteDetails != nil {
 		result["incomplete_details"] = incompleteDetails
@@ -99,8 +106,9 @@ func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, respons
 				continue
 			}
 			textParts = append(textParts, map[string]any{
-				"type": "output_text",
-				"text": block.Text,
+				"type":        "output_text",
+				"text":        block.Text,
+				"annotations": []any{},
 			})
 		case "tool_use":
 			argsJSON := "{}"
@@ -122,6 +130,7 @@ func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, respons
 
 	if len(textParts) > 0 {
 		msgItem := map[string]any{
+			"id":      "msg_" + resp.ID,
 			"type":    "message",
 			"role":    "assistant",
 			"status":  status,
@@ -144,12 +153,13 @@ func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, respons
 	}
 
 	result := map[string]any{
-		"id":     resp.ID,
-		"object": "response",
-		"model":  model,
-		"status": status,
-		"output": output,
-		"usage":  usageMap,
+		"id":         resp.ID,
+		"object":     "response",
+		"created_at": time.Now().Unix(),
+		"model":      model,
+		"status":     status,
+		"output":     output,
+		"usage":      usageMap,
 	}
 	if incompleteDetails != nil {
 		result["incomplete_details"] = incompleteDetails

--- a/internal/protocol/request/openai_responses_to_chat.go
+++ b/internal/protocol/request/openai_responses_to_chat.go
@@ -22,8 +22,12 @@ func ConvertOpenAIResponsesToChat(params *responses.ResponseNewParams, defaultMa
 		result.Messages = append(result.Messages, openai.SystemMessage(params.Instructions.Value))
 	}
 
-	// Convert input items to messages
-	if !param.IsOmitted(params.Input.OfInputItemList) {
+	// Convert input to messages. The Responses API accepts either a plain
+	// string (shorthand for a single user message — the SDKs' idiomatic form)
+	// or a list of input items.
+	if !param.IsOmitted(params.Input.OfString) && params.Input.OfString.Value != "" {
+		result.Messages = append(result.Messages, openai.UserMessage(params.Input.OfString.Value))
+	} else if !param.IsOmitted(params.Input.OfInputItemList) {
 		messages := ConvertResponsesInputToMessages(params.Input.OfInputItemList)
 		result.Messages = append(result.Messages, messages...)
 	}

--- a/internal/protocol/request/openai_responses_to_chat_test.go
+++ b/internal/protocol/request/openai_responses_to_chat_test.go
@@ -12,6 +12,23 @@ import (
 )
 
 func TestConvertOpenAIResponsesToChat(t *testing.T) {
+	t.Run("string input shorthand", func(t *testing.T) {
+		// The Responses API accepts `input` as a plain string (the SDKs'
+		// idiomatic form); it must convert to a single user message.
+		params := &responses.ResponseNewParams{
+			Model: "gpt-4",
+			Input: responses.ResponseNewParamsInputUnion{
+				OfString: param.NewOpt("Hello, world!"),
+			},
+		}
+
+		result := ConvertOpenAIResponsesToChat(params, 4096)
+
+		require.Len(t, result.Messages, 1)
+		assert.Equal(t, "user", getMessageRole(t, result.Messages[0]))
+		assert.Equal(t, "Hello, world!", getMessageContent(t, result.Messages[0]))
+	})
+
 	t.Run("simple user message", func(t *testing.T) {
 		params := &responses.ResponseNewParams{
 			Model: "gpt-4",

--- a/internal/protocol/stream/anthropic_helper.go
+++ b/internal/protocol/stream/anthropic_helper.go
@@ -46,15 +46,6 @@ func MarshalAndSendErrorEvent(c *gin.Context, message, errorType, code string) {
 	}
 }
 
-// SendFinishEvent sends a message_stop event to indicate completion
-func SendFinishEvent(c *gin.Context) {
-	finishEvent := map[string]interface{}{
-		"type": "message_stop",
-	}
-	finishJSON, _ := json.Marshal(finishEvent)
-	c.SSEvent("", string(finishJSON))
-}
-
 // =============================================
 // HTTP Error Response Helpers
 // =============================================

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -21,6 +21,7 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 	hc.SetupSSEHeaders()
 
 	acc := usage.NewAnthropicAccumulator()
+	var sawMessageStart, sawMessageStop bool
 
 	err := hc.ProcessStream(
 		func() (bool, error, interface{}) {
@@ -40,6 +41,12 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 		},
 		func(event interface{}) error {
 			evt := event.(*anthropic.MessageStreamEventUnion)
+			switch evt.Type {
+			case "message_start":
+				sawMessageStart = true
+			case "message_stop":
+				sawMessageStop = true
+			}
 
 			acc.Consume(evt)
 
@@ -95,7 +102,14 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 		return acc.Result(), err
 	}
 
-	SendFinishEvent(hc.GinContext)
+	// Upstream cut mid-stream (content started but never terminated): surface
+	// an honest error event rather than fabricating a clean message_stop. Real
+	// SDK clients raise on it (the turn was truncated); lenient clients keep
+	// the partial content already sent. Cleanly finished streams already
+	// forwarded their own message_delta / message_stop.
+	if sawMessageStart && !sawMessageStop {
+		MarshalAndSendErrorEvent(hc.GinContext, "upstream stream ended before completion", "stream_error", "incomplete_stream")
+	}
 
 	return acc.Result(), nil
 }
@@ -108,6 +122,7 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 	hc.SetupSSEHeaders()
 
 	acc := usage.NewAnthropicAccumulator()
+	var sawMessageStart, sawMessageStop bool
 
 	err := hc.ProcessStream(
 		func() (bool, error, interface{}) {
@@ -127,6 +142,12 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 		},
 		func(event interface{}) error {
 			evt := event.(*anthropic.BetaRawMessageStreamEventUnion)
+			switch evt.Type {
+			case "message_start":
+				sawMessageStart = true
+			case "message_stop":
+				sawMessageStop = true
+			}
 
 			acc.ConsumeBeta(evt)
 
@@ -182,7 +203,11 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 		return acc.Result(), err
 	}
 
-	SendFinishEvent(hc.GinContext)
+	// See HandleAnthropic: surface an honest error event when the upstream was
+	// cut after content started.
+	if sawMessageStart && !sawMessageStop {
+		MarshalAndSendErrorEvent(hc.GinContext, "upstream stream ended before completion", "stream_error", "incomplete_stream")
+	}
 
 	return acc.Result(), nil
 }

--- a/internal/protocol/stream/openai_responses_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_converter.go
@@ -77,7 +77,25 @@ func (r *responsesToAnthropicConverter) Next() (interface{}, bool, error) {
 
 	for {
 		if !r.stream.Next() {
+			// Upstream cut without a terminal Responses event: surface an
+			// honest error event rather than fabricating a clean message_stop.
+			// Real SDK clients raise on it (the turn was truncated); lenient
+			// clients keep the partial content already sent.
+			if r.convErr == nil && !r.done {
+				r.emitAnthropic("error", map[string]interface{}{
+					"type": "error",
+					"error": map[string]interface{}{
+						"type":    "stream_error",
+						"message": "upstream stream ended before completion",
+					},
+				})
+			}
 			r.done = true
+			if len(r.pending) > 0 {
+				evt := r.pending[0]
+				r.pending = r.pending[1:]
+				return evt, false, nil
+			}
 			return nil, true, nil
 		}
 		r.processEvent(r.stream.Current())

--- a/internal/protocol/stream/openai_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_to_anthropic_converter.go
@@ -84,7 +84,14 @@ func (c *openAIToAnthropicConverter) Next() (interface{}, bool, error) {
 	for {
 		if !c.stream.Next() {
 			if c.finishSeen && c.hookErr == nil {
+				// Upstream finished normally.
 				c.emitTerminalEvents()
+			} else if c.messageStarted && c.hookErr == nil {
+				// Upstream cut mid-stream after content started: surface an
+				// honest error event rather than fabricating a clean end_turn.
+				// Real SDK clients raise on it (the turn really was truncated);
+				// lenient clients keep the partial content already sent.
+				c.emitTruncatedError()
 			}
 			c.done = true
 			if len(c.pending) > 0 {
@@ -309,6 +316,18 @@ func (c *openAIToAnthropicConverter) emitTerminalEvents() {
 }
 
 // emit helpers — these build the event maps and push to pending.
+
+// emitTruncatedError queues an Anthropic `error` event for a stream that
+// ended mid-content without a finish signal (truncated upstream).
+func (c *openAIToAnthropicConverter) emitTruncatedError() {
+	c.emitAnthropic("error", map[string]interface{}{
+		"type": "error",
+		"error": map[string]interface{}{
+			"type":    "stream_error",
+			"message": "upstream stream ended before completion",
+		},
+	})
+}
 
 func (c *openAIToAnthropicConverter) emitAnthropic(eventType string, data map[string]interface{}) {
 	c.pending = append(c.pending, anthropicStreamEvent{eventType: eventType, data: data})

--- a/internal/protocol/wire/openai_responses.go
+++ b/internal/protocol/wire/openai_responses.go
@@ -1,5 +1,7 @@
 package wire
 
+import "encoding/json"
+
 // Responses stream DTOs preserve the minimal outbound JSON shape emitted by this proxy.
 // Keep these fields checked against openai-go Responses SDK event types when updating the SDK.
 
@@ -123,6 +125,29 @@ type ResponsesContentPartWire struct {
 	Type        string        `json:"type"`
 	Text        string        `json:"text,omitempty"`
 	Annotations []interface{} `json:"annotations,omitempty"`
+}
+
+// MarshalJSON ensures output_text parts always carry "text" and
+// "annotations" (an empty array when unset): the real Responses API always
+// includes both, and strict clients (the AI SDK's zod schemas) require them.
+func (p ResponsesContentPartWire) MarshalJSON() ([]byte, error) {
+	m := map[string]interface{}{"type": p.Type}
+	if p.Type == "output_text" {
+		m["text"] = p.Text
+		if p.Annotations != nil {
+			m["annotations"] = p.Annotations
+		} else {
+			m["annotations"] = []interface{}{}
+		}
+		return json.Marshal(m)
+	}
+	if p.Text != "" {
+		m["text"] = p.Text
+	}
+	if p.Annotations != nil {
+		m["annotations"] = p.Annotations
+	}
+	return json.Marshal(m)
 }
 
 type ResponsesContentPartAddedEvent struct {

--- a/internal/protocoltest/client_gosdk.go
+++ b/internal/protocoltest/client_gosdk.go
@@ -104,10 +104,11 @@ func (c *goSDKClient) sendAnthropicV1(ctx context.Context, spec SendSpec) (*Roun
 		if res, rerr := anthropicErrorResult(result, err); rerr == nil {
 			return res, nil
 		}
-		// Mid-stream cut: keep whatever accumulated; the gateway replied 200.
-		if len(result.StreamEvents) == 0 {
-			return nil, fmt.Errorf("anthropic SDK stream: %w", err)
-		}
+		// Mid-stream error (e.g. an in-band error event for a truncated
+		// upstream): report it rather than presenting partial content as success.
+		result.HTTPStatus = 200
+		result.RawBody = []byte(err.Error())
+		return result, nil
 	}
 	result.HTTPStatus = 200
 	raw, err := json.Marshal(msg)
@@ -154,9 +155,9 @@ func (c *goSDKClient) sendAnthropicBeta(ctx context.Context, spec SendSpec) (*Ro
 		if res, rerr := anthropicErrorResult(result, err); rerr == nil {
 			return res, nil
 		}
-		if len(result.StreamEvents) == 0 {
-			return nil, fmt.Errorf("anthropic beta SDK stream: %w", err)
-		}
+		result.HTTPStatus = 200
+		result.RawBody = []byte(err.Error())
+		return result, nil
 	}
 	result.HTTPStatus = 200
 	raw, err := json.Marshal(msg)
@@ -208,9 +209,9 @@ func (c *goSDKClient) sendOpenAIChat(ctx context.Context, spec SendSpec) (*Round
 		if res, rerr := openaiErrorResult(result, err); rerr == nil {
 			return res, nil
 		}
-		if len(result.StreamEvents) == 0 {
-			return nil, fmt.Errorf("openai SDK stream: %w", err)
-		}
+		result.HTTPStatus = 200
+		result.RawBody = []byte(err.Error())
+		return result, nil
 	}
 	result.HTTPStatus = 200
 	raw, err := json.Marshal(acc.ChatCompletion)

--- a/internal/protocoltest/idempotent.go
+++ b/internal/protocoltest/idempotent.go
@@ -160,10 +160,11 @@ func (m *Matrix) RunIdempotent(t *testing.T) {
 
 	for _, scenario := range m.Scenarios {
 		scenario := scenario
-		// Error propagation through two hops is out of scope: the inner
-		// gateway wraps upstream errors, so the byte-for-byte error shape is
-		// not expected to survive a round-trip.
-		if scenario.Name == "error" {
+		// Error / truncation scenarios are not round-trippable: the inner
+		// gateway wraps upstream errors and a mid-stream cut surfaces as an
+		// error on one hop but partial content on another, so the two paths
+		// legitimately diverge. SkipTransitive marks exactly these.
+		if scenario.SkipTransitive {
 			continue
 		}
 
@@ -255,10 +256,8 @@ func (m *Matrix) ExecuteAllIdempotent() []TestResult {
 	cases := DefaultIdempotentCases()
 
 	for _, scenario := range m.Scenarios {
-		// Error propagation through two hops is out of scope: the inner gateway
-		// wraps upstream errors, so the byte-for-byte error shape is not
-		// expected to survive a round-trip.
-		if scenario.Name == "error" {
+		// Error / truncation scenarios are not round-trippable (see RunIdempotent).
+		if scenario.SkipTransitive {
 			continue
 		}
 

--- a/internal/protocoltest/scenarios.go
+++ b/internal/protocoltest/scenarios.go
@@ -751,8 +751,13 @@ func ErrorMidStreamCloseScenario() Scenario {
 			FormatGoogle:          BuildErrorFromSpec(FormatGoogle, specClose),
 		},
 		Assertions: []Assertion{
+			// A mid-stream cut must be handled gracefully: the response stays
+			// 200 (headers were already sent) and the stream terminates in a
+			// client-consumable way. Anthropic-target paths surface it as an
+			// in-band error event (real SDK clients raise — the turn was
+			// truncated, not completed); OpenAI-target paths end with the
+			// partial content. The gateway must not 5xx or hang either way.
 			AssertHTTPStatus(200),
-			AssertContentContains("truncated"),
 		},
 	}
 }

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -189,7 +189,7 @@ func (s *Server) nonstreamResponsesToAnthropicBeta(c *gin.Context, proxyModel st
 		recorder.SetAssembledResponse(anthropicResp)
 		recorder.RecordResponse(provider, actualModel)
 	}
-	c.JSON(http.StatusOK, anthropicResp)
+	nonstream.WriteAnthropicMessage(c, anthropicResp)
 
 }
 

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -159,7 +159,7 @@ func (s *Server) nonstreamResponsesToAnthropic(c *gin.Context, proxyModel string
 		recorder.SetAssembledResponse(anthropicResp)
 		recorder.RecordResponse(provider, actualModel)
 	}
-	c.JSON(http.StatusOK, anthropicResp)
+	nonstream.WriteAnthropicMessage(c, anthropicResp)
 }
 
 // streamResponsesToAnthropic handles streaming Responses API request for v1

--- a/internal/server/mcp_anthropic_v1_helper.go
+++ b/internal/server/mcp_anthropic_v1_helper.go
@@ -9,11 +9,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	guardrailsadapter "github.com/tingly-dev/tingly-box/internal/guardrails/adapter"
-	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/nonstream"
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/server/forwarding"
 	"github.com/tingly-dev/tingly-box/internal/server/module/mcp"
+	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -337,7 +338,7 @@ func (s *Server) dispatchGenericAnthropicV1NonStream(
 	}
 
 	// Return response
-	c.JSON(http.StatusOK, response)
+	nonstream.WriteAnthropicMessage(c, response)
 }
 
 // dispatchGenericAnthropicV1Stream handles A→A streaming with generic interceptor
@@ -549,7 +550,7 @@ func (s *Server) dispatchGenericAnthropicBetaNonStream(
 	}
 
 	// Return response
-	c.JSON(http.StatusOK, response)
+	nonstream.WriteAnthropicMessage(c, response)
 }
 
 // dispatchGenericAnthropicBetaStream handles Aβ→Aβ streaming with generic interceptor

--- a/internal/server/module/mcp/anthropic_beta_adapter.go
+++ b/internal/server/module/mcp/anthropic_beta_adapter.go
@@ -267,6 +267,17 @@ func (a *AnthropicBetaAdapter) FilterVirtualTools(response any, externalTools []
 		filtered = append(filtered, block)
 	}
 
+	if len(filtered) != len(msg.Content) {
+		// A virtual tool_use block was removed; re-parse so RawJSON reflects
+		// the filtered content (downstream writers prefer RawJSON).
+		msg.Content = filtered
+		if b, err := json.Marshal(msg); err == nil {
+			var fresh anthropic.BetaMessage
+			if json.Unmarshal(b, &fresh) == nil {
+				return &fresh, nil
+			}
+		}
+	}
 	msg.Content = filtered
 	return msg, nil
 }

--- a/internal/server/module/mcp/anthropic_beta_adapter.go
+++ b/internal/server/module/mcp/anthropic_beta_adapter.go
@@ -309,6 +309,11 @@ func (a *AnthropicBetaAdapter) SendFinalMessage(c *gin.Context) error {
 			"stop_reason":   "end_turn",
 			"stop_sequence": nil,
 		},
+		// The Anthropic protocol requires usage on message_delta; strict SDK
+		// accumulators (e.g. Python) crash on a delta without it.
+		"usage": map[string]interface{}{
+			"output_tokens": 0,
+		},
 	})
 	if err := a.SendEvent(c, "message_delta", deltaJSON); err != nil {
 		return err

--- a/internal/server/module/mcp/anthropic_v1_adapter.go
+++ b/internal/server/module/mcp/anthropic_v1_adapter.go
@@ -261,6 +261,17 @@ func (a *AnthropicV1Adapter) FilterVirtualTools(response any, externalTools []To
 		}
 	}
 
+	if len(filtered) != len(msg.Content) {
+		// A virtual tool_use block was removed; re-parse so RawJSON reflects
+		// the filtered content (downstream writers prefer RawJSON).
+		msg.Content = filtered
+		if b, err := json.Marshal(msg); err == nil {
+			var fresh anthropic.Message
+			if json.Unmarshal(b, &fresh) == nil {
+				return &fresh, nil
+			}
+		}
+	}
 	msg.Content = filtered
 	return msg, nil
 }

--- a/internal/server/module/mcp/anthropic_v1_adapter.go
+++ b/internal/server/module/mcp/anthropic_v1_adapter.go
@@ -275,7 +275,20 @@ func (a *AnthropicV1Adapter) SetupSSEHeaders(c *gin.Context) {
 }
 
 func (a *AnthropicV1Adapter) SendEvent(c *gin.Context, eventType string, payload []byte) error {
-	c.SSEvent("", payload)
+	// Anthropic SSE requires a named `event:` line per frame: official SDKs
+	// dispatch on it and silently drop frames without one. Prefer the type
+	// embedded in the payload, falling back to the caller-supplied name.
+	name := eventType
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err == nil {
+		if typ, ok := raw["type"].(string); ok && typ != "" {
+			name = typ
+		}
+	}
+	if name == "" {
+		name = "message"
+	}
+	fmt.Fprintf(c.Writer, "event: %s\ndata: %s\n\n", name, payload)
 	c.Writer.Flush()
 	return nil
 }
@@ -294,11 +307,11 @@ func (a *AnthropicV1Adapter) SendFinalMessage(c *gin.Context) error {
 			"stop_sequence": nil,
 		},
 	})
-	c.SSEvent("", string(deltaJSON))
+	if err := a.SendEvent(c, "message_delta", deltaJSON); err != nil {
+		return err
+	}
 	stopJSON, _ := json.Marshal(map[string]interface{}{"type": "message_stop"})
-	c.SSEvent("", string(stopJSON))
-	c.Writer.Flush()
-	return nil
+	return a.SendEvent(c, "message_stop", stopJSON)
 }
 
 // Event processing

--- a/internal/server/module/mcp/anthropic_v1_adapter.go
+++ b/internal/server/module/mcp/anthropic_v1_adapter.go
@@ -306,6 +306,11 @@ func (a *AnthropicV1Adapter) SendFinalMessage(c *gin.Context) error {
 			"stop_reason":   "end_turn",
 			"stop_sequence": nil,
 		},
+		// The Anthropic protocol requires usage on message_delta; strict SDK
+		// accumulators (e.g. Python) crash on a delta without it.
+		"usage": map[string]interface{}{
+			"output_tokens": 0,
+		},
 	})
 	if err := a.SendEvent(c, "message_delta", deltaJSON); err != nil {
 		return err

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -401,8 +401,16 @@ func (i *GenericStreamInterceptor) routeEvent(event any, eventType EventType) er
 		return nil
 
 	default:
-		// Pass through unknown events
-		return i.adapter.SendEvent(i.c, "message", []byte{})
+		// Pass through unknown events (e.g. thinking deltas) with their
+		// original payload. Replacing them with an empty frame breaks real
+		// SDK consumers: an `event:` line with empty JSON data aborts the
+		// official Anthropic stream decoders mid-stream.
+		payload, err := i.extractEventPayload(event)
+		if err != nil || len(payload) == 0 {
+			// Nothing forwardable; drop rather than emit an empty frame.
+			return nil
+		}
+		return i.adapter.SendEvent(i.c, "", payload)
 	}
 }
 

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -142,7 +142,7 @@ func (i *GenericStreamInterceptor) Run(req any) error {
 		switch decision {
 		case DecisionNoTools:
 			logrus.Debugf("[MCP-Interceptor] Round %d: no tools, ending", i.round)
-			return i.adapter.SendFinalMessage(i.c)
+			return i.sendFinalEvents()
 
 		case DecisionPureVirtual:
 			logrus.Debugf("[MCP-Interceptor] Round %d: pure virtual, continuing", i.round)
@@ -170,7 +170,27 @@ func (i *GenericStreamInterceptor) Run(req any) error {
 
 	// Max rounds exceeded
 	logrus.Infof("[MCP-Interceptor] Max rounds (%d) exceeded", i.config.MaxRounds)
-	return i.adapter.SendFinalMessage(i.c)
+	return i.sendFinalEvents()
+}
+
+// sendFinalEvents terminates the client stream. When the upstream's terminal
+// events were captured (Anthropic-style message_delta / message_stop), they
+// are forwarded as-is so the client sees the real stop_reason and usage —
+// strict SDK accumulators (e.g. the Python SDK) reject a message_delta
+// without usage. Otherwise falls back to the adapter's synthesized final
+// message (e.g. [DONE] for OpenAI Chat).
+func (i *GenericStreamInterceptor) sendFinalEvents() error {
+	if i.roundMessageDelta == nil {
+		return i.adapter.SendFinalMessage(i.c)
+	}
+	if err := i.adapter.SendEvent(i.c, "message_delta", i.roundMessageDelta); err != nil {
+		return err
+	}
+	stop := i.roundMessageStop
+	if stop == nil {
+		stop, _ = json.Marshal(map[string]interface{}{"type": "message_stop"})
+	}
+	return i.adapter.SendEvent(i.c, "message_stop", stop)
 }
 
 // handlePureExternal hands non-virtual tools back to the client. Only virtual

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -467,7 +467,7 @@ func (s *Server) passthroughAnthropicBeta(
 			recorder.SetAssembledResponse(anthropicResp)
 			recorder.RecordResponse(provider, reqCtx.RequestModel)
 		}
-		c.JSON(http.StatusOK, anthropicResp)
+		nonstream.WriteAnthropicMessage(c, anthropicResp)
 	}
 }
 
@@ -689,7 +689,7 @@ func (s *Server) dispatchGoogle(
 				recorder.SetAssembledResponse(anthropicResp)
 				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
-			c.JSON(http.StatusOK, anthropicResp)
+			nonstream.WriteAnthropicMessage(c, anthropicResp)
 		case protocol.TypeAnthropicBeta:
 			anthropicResp := nonstream.ConvertGoogleToAnthropicBetaResponse(resp, responseModel)
 			s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
@@ -697,7 +697,7 @@ func (s *Server) dispatchGoogle(
 				recorder.SetAssembledResponse(anthropicResp)
 				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
-			c.JSON(http.StatusOK, anthropicResp)
+			nonstream.WriteAnthropicMessage(c, anthropicResp)
 		}
 	}
 }
@@ -810,7 +810,7 @@ func (s *Server) dispatchOpenAIChat(
 				recorder.SetAssembledResponse(anthropicResp)
 				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
-			c.JSON(http.StatusOK, anthropicResp)
+			nonstream.WriteAnthropicMessage(c, anthropicResp)
 		case protocol.TypeAnthropicBeta:
 			anthropicResp := nonstream.ConvertOpenAIToAnthropicBetaResponse(resp, responseModel)
 			s.updateAffinityMessageID(c, rule, anthropicResp.ID)
@@ -818,7 +818,7 @@ func (s *Server) dispatchOpenAIChat(
 				recorder.SetAssembledResponse(anthropicResp)
 				recorder.RecordResponse(provider, reqCtx.RequestModel)
 			}
-			c.JSON(http.StatusOK, anthropicResp)
+			nonstream.WriteAnthropicMessage(c, anthropicResp)
 		}
 	}
 }

--- a/tests/clients/node/driver.mjs
+++ b/tests/clients/node/driver.mjs
@@ -66,11 +66,19 @@ async function runAnthropic(req, beta) {
 
   const stream = svc.stream(params, opts);
   let count = 0;
-  for await (const _event of stream) count++;
-  const msg = await stream.finalMessage();
-  const resp = normalizeAnthropicMessage(msg);
-  resp.stream_event_count = count;
-  return resp;
+  try {
+    for await (const _event of stream) count++;
+    const msg = await stream.finalMessage();
+    const resp = normalizeAnthropicMessage(msg);
+    resp.stream_event_count = count;
+    return resp;
+  } catch (e) {
+    if (isAPIError(e)) return apiErrorResponse(e);
+    // Mid-stream error event (e.g. a truncated upstream): the SDK raised; the
+    // turn was not completed. Report it in-band rather than crashing.
+    return { http_status: 200, stream_event_count: count, raw_body: String(e?.message ?? e),
+      error: { status: 0, type: e?.name ?? "StreamError", message: String(e?.message ?? e) } };
+  }
 }
 
 // ── OpenAI Chat Completions ──────────────────────────────────────────────────

--- a/tests/clients/python/driver.py
+++ b/tests/clients/python/driver.py
@@ -93,13 +93,22 @@ def run_anthropic(req, beta):
             return normalize_anthropic_message(msg)
 
         count = 0
-        with svc.stream(**kwargs) as stream:
-            for _event in stream:
-                count += 1
-            msg = stream.get_final_message()
-        resp = normalize_anthropic_message(msg)
-        resp["stream_event_count"] = count
-        return resp
+        try:
+            with svc.stream(**kwargs) as stream:
+                for _event in stream:
+                    count += 1
+                msg = stream.get_final_message()
+            resp = normalize_anthropic_message(msg)
+            resp["stream_event_count"] = count
+            return resp
+        except anthropic.APIStatusError:
+            raise
+        except Exception as e:
+            # Mid-stream error event (truncated upstream): the SDK raised; the
+            # turn was not completed. Report it in-band rather than crashing.
+            return {"http_status": 200, "stream_event_count": count,
+                    "raw_body": str(e),
+                    "error": {"status": 0, "type": type(e).__name__, "message": str(e)}}
     except anthropic.APIStatusError as e:
         return api_error_response(e)
 


### PR DESCRIPTION
## Why

The real-SDK harness drivers from #1201 (merged) drive the protocol matrix through official client stacks instead of hand-crafted JSON. Pointed at the current gateway they fail where the lenient HTTP path is silent — the gateway emits responses that real SDKs (strict parsing, SSE event dispatch, stream accumulators, zod schemas) reject or silently misread. This PR makes the gateway's output faithful to what those clients require.

## Impact

With this PR the matrix is **green across all five client drivers** (baseline = failures on current `main`):

| driver (`--mode=single`) | main | this PR |
|---|---|---|
| http | 0 | 0 |
| gosdk | 9 | **0** |
| python | 9 | **0** |
| node | 14 | **0** |
| aisdk | 58 | **0** |

User-facing: streamed and non-streamed responses now parse cleanly in the official Anthropic/OpenAI SDKs and the Vercel AI SDK; truncated upstreams are surfaced honestly as errors instead of being presented as complete.

## Structure — one commit per client tier

Each commit turns one driver's leg green, in the order the strictness ladder surfaces the defects:

**1. `wire-protocol violations surfaced by the gosdk harness driver`**
- v1 SSE frames were written without an `event:` name → official SDKs dispatch on the event line and discarded every frame (empty message). `SendEvent` now derives the name from the payload type.
- the stream interceptor's "unknown event" branch emitted an empty frame that aborts SDK decoders mid-stream → forwards the original payload.
- Responses string `input` (the SDKs' idiomatic form) converted to a chat request with zero messages → handled.

**2. `message_delta without usage crashes the Python SDK accumulator`**
- the protocol requires `usage` on `message_delta`; the interceptor now forwards the upstream's captured terminal events (real `stop_reason`/`usage`) and any synthesized fallback carries `usage`.

**3. `surface mid-stream truncation as an error, not a fake finish`** *(revised per review)*
- a mid-stream cut no longer fabricates a clean `stop_reason: end_turn` (which hid the truncation). It now surfaces as an Anthropic `error` event — the mechanism the converter handlers already use for real errors. Real SDKs raise (the turn *was* truncated); lenient clients keep the partial content. Passthrough + both converters updated; `SendSyntheticAnthropicFinish` deleted. Harness aligned (graceful-200 assertion, idempotent skips non-round-trippable scenarios, drivers report mid-stream errors in-band).

**4. `write Anthropic responses from RawJSON, drop the prune band-aid`** *(revised per review)*
- replaces the marshal-then-prune helper (which lived in `internal/server` and pruned the zero-value nulls its own marshal introduced). The converters build a clean wire DTO, so the SDK struct's `RawJSON()` is already clean — the new protocol-layer `nonstream.WriteAnthropicMessage` writes it (falls back to marshal only when empty). Callers that mutate (MCP `FilterVirtualTools`) re-parse so RawJSON can't go stale. Gateway-built Responses payloads gain the always-present `output[].id` / `created_at` / `annotations`.

## Testing

- `go build ./...`, `go test ./internal/... ./vmodel/...` green.
- All five `--client` matrix legs 0 FAIL (`http`/`gosdk` at `--mode=all`); the per-client CI legs from #1201 validate the same on this branch.

https://claude.ai/code/session_014FHWeqJr7SQhKLvXE4p3Yg