### PR TITLE
refactor(transform): make Vendor the final chain step; centralize assembly in BuildTransformChain

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -60,32 +60,35 @@
    │   flags := resolveRuleFlags(c, rule)                           │
    │   ├─ WithCustomUserAgent(ctx, flags.CustomUserAgent)           │  Type 2
    │   ├─ reqCtx.Extra["skip_usage"] = flags.SkipUsage              │  Type 3
-   │   ├─ preBase := rulePreBaseTransforms(flags)                   │  Type 1b-pre
+   │   ├─ preBase   := rulePreBaseTransforms(flags)                 │  Type 1b-pre
    │   │   → [transform.OpenAICursorCompatTransform{}]              │
-   │   └─ extras := ruleExtraTransforms(flags)                      │  Type 1b-post
+   │   └─ preVendor := rulePreVendorTransforms(flags)              │  Type 1b-post
    │       → [transform.OpenAIMaxTokensRewriteTransform{...}]       │
    └───────────────────────────┬───────────────────────────────────┘
                                │
                                ▼
    ┌───────────────────────────────────────────────────────────────┐
-   │   transformXxxx(..., preBase, extras...) :                     │
-   │     chain := BuildTransformChain(..., preBase, extras)         │
+   │   transformXxxx(..., preBase, preVendor...) :                  │
+   │     chain := BuildTransformChain(..., preBase, preVendor)      │
    │     chain.Execute(ctx)                                         │
    │                                                                │
-   │   preBase → Base → MCP → Consistency → extras → Vendor → ▸rec  │
-   │   └ INBOUND slot                       └ TARGET slot           │
+   │   preBase → Base → MCP → Consistency → preVendor → Vendor → ▸rec│
+   │   └ preBase slot                       └ preVendor slot        │
    │                              Vendor + 录制 = 不可逾越的尾段     │
    └───────────────────────────┬───────────────────────────────────┘
                                ▼
                        upstream provider
 ```
 
+两个动态插入位置本质都是"在某步之前"：**preBase**（Base 之前，看见入站形态）
+与 **preVendor**（Vendor 之前，看见目标形态）。
+
 **不变式：除录制外，没有任何阶段在 `Vendor` 之后运行。** `Vendor` 直面
 provider、做最终且不可逆的改写（model alias、metadata、billing header、
-DeepSeek thinking patch 等），必须是最后一个 mutation；因此 rule 的 TARGET-slot
-extras 装在 `Consistency` 之后、`Vendor` **之前**。这同时修掉了一个隐患：
-StagePost 录制现在落在 `Vendor` 之后，抓到的是真正发出的请求（此前 extras 跑在
-录制之后，录到的"最终请求"与实际出站不一致）。
+DeepSeek thinking patch 等），必须是最后一个 mutation；因此 rule 的 preVendor
+transforms 装在 `Consistency` 之后、`Vendor` **之前**。这同时修掉了一个隐患：
+StagePost 录制现在落在 `Vendor` 之后，抓到的是真正发出的请求（此前这些 transform
+跑在录制之后，录到的"最终请求"与实际出站不一致）。
 
 ---
 
@@ -150,20 +153,20 @@ func RuleFlagRegistry() []FlagSpec { … }
 ## 5. 五种 flag 注入手法
 
 ```
-Type 1b-pre  Request body, INBOUND slot（pre-Base Transform）
+Type 1b-pre  Request body, preBase slot（pre-Base Transform）
          作为 Transform 接口的实现装在 chain 最前（BaseTransform
          之前）运行；type-switch 决定是否对 inbound request 形态生效。
          例：OpenAICursorCompatTransform —— 在 Base 把 OpenAI Chat 转
          成其他形态之前 flatten 富文本内容。聚合点：
          `internal/server/rule_flags.go::rulePreBaseTransforms`。
 
-Type 1b-post Request body, TARGET slot（post-Base Transform，推荐用于跨协议 rewrite）
+Type 1b-post Request body, preVendor slot（post-Base Transform，推荐用于跨协议 rewrite）
          作为 Transform 接口的实现装在 `Consistency` 之后、`Vendor`
          **之前**，在 BaseTransform 完成协议转换之后运行；type-switch
          决定是否对目标 request 形态生效。**绝不在 Vendor 之后**——Vendor
          是直面 provider 的最终步骤，不可逾越。例：
          OpenAIMaxTokensRewriteTransform、RuleThinkingTransform。聚合点：
-         `internal/server/rule_flags.go::ruleExtraTransforms`。
+         `internal/server/rule_flags.go::rulePreVendorTransforms`。
 
 Type 2   Per-request context hint
          handler 把 c.Request 的 ctx 替换成带 hint 的；transport /
@@ -189,10 +192,10 @@ Type 5   Routing behavior (service selection)
 ```
 
 任何新 flag 都应归入这几类之一。pre-Base 和 post-Base Transform 都是同一
-个 `Transform` 接口的实现，区别只在 chain 中的位置：pre 装在 INBOUND slot
-（BaseTransform 之前，看见 inbound 形态），post 装在 TARGET slot
+个 `Transform` 接口的实现，区别只在 chain 中的位置：pre 装在 preBase slot
+（BaseTransform 之前，看见 inbound 形态），post 装在 preVendor slot
 （Consistency 之后、Vendor 之前，看见目标形态）。聚合点
-`rulePreBaseTransforms` / `ruleExtraTransforms` 决定 flag 装哪边。两个 slot
+`rulePreBaseTransforms` / `rulePreVendorTransforms` 决定 flag 装哪边。两个 slot
 之外，chain 的骨架（StagePre 录制 → Base → MCP → Consistency → Vendor →
 StagePost 录制）由 `BuildTransformChain` 固定，**Vendor + 录制是不可逾越的
 尾段**。
@@ -206,7 +209,7 @@ Type 1b（pre-Base 与 post-Base 同形）涉及两层抽象，**职责必须分
 | 层 | 位置 | 职责 | 例子 |
 |----|------|------|------|
 | **op（操作原语）** | `internal/protocol/transform/ops/` | 纯函数。对某个具体 request 类型做无副作用的字段改写。**不感知链路、不感知 rule、不感知 ctx**。 | `ops.ApplyMaxCompletionTokensRewrite(*openai.ChatCompletionNewParams)`、`ops.ApplyCursorCompatContentNormalization(*openai.ChatCompletionNewParams)` |
-| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口。构造期接受配置；`Apply()` 里 type-switch `ctx.Request`，匹配目标类型时调 op。**仅依赖协议层 / SDK 类型**。pre/post 之分由聚合点（`rulePreBaseTransforms` / `ruleExtraTransforms`）决定，与 Transform 实现本身无关。 | `transform.OpenAIMaxTokensRewriteTransform`、`transform.OpenAICursorCompatTransform` |
+| **Transform（链路阶段，协议层）** | `internal/protocol/transform/` | 实现 `Transform` 接口。构造期接受配置；`Apply()` 里 type-switch `ctx.Request`，匹配目标类型时调 op。**仅依赖协议层 / SDK 类型**。pre/post 之分由聚合点（`rulePreBaseTransforms` / `rulePreVendorTransforms`）决定，与 Transform 实现本身无关。 | `transform.OpenAIMaxTokensRewriteTransform`、`transform.OpenAICursorCompatTransform` |
 | **Transform（链路阶段，server-domain）** | `internal/server/transform_*.go` | 同 Transform 接口，但需要 server-domain 类型（如 `*typ.ScenarioConfig`）。 | `ThinkingModeTransform`、`MaxTokensTransform`（Anthropic 上限）、`CleanHeaderTransform` |
 
 **为什么必须分两层？**
@@ -240,15 +243,15 @@ Type 1b（pre-Base 与 post-Base 同形）涉及两层抽象，**职责必须分
 handler                            transformXxxx                       chain
   │                                     │                                │
   │ flags  := resolveRuleFlags(c, rule) │                                │
-  │ preBase:= rulePreBaseTransforms(    │                                │
-  │             flags)                  │                                │
+  │ preBase  := rulePreBaseTransforms(  │                                │
+  │              flags)                 │                                │
   │  (e.g. [OpenAICursorCompat])        │                                │
-  │ extras := ruleExtraTransforms(      │                                │
-  │             flags)                  │                                │
+  │ preVendor:= rulePreVendorTransforms(│                                │
+  │              flags)                 │                                │
   │  (e.g. [OpenAIMaxTokensRewrite])    │                                │
-  ├──────── preBase, extras... ────────►│                                │
+  ├─────── preBase, preVendor... ──────►│                                │
   │                                     │  chain := BuildTransformChain( │
-  │                                     │      ..., preBase, extras)      │
+  │                                     │      ..., preBase, preVendor)   │
   │                                     ├──────────────────────────────►│
   │                                     │  chain.Execute(ctx)            │
   │                                     ├──────────────────────────────►│
@@ -258,23 +261,23 @@ handler                            transformXxxx                       chain
 
 - `BuildTransformChain` 是唯一的 chain 装配点。它接受 scenario / provider
   / recording，外加 `preBase []transform.Transform` 与
-  `extras []transform.Transform` 两个 slot 入参，把它们插进固定骨架的对应
-  位置（preBase 在最前的 INBOUND slot，extras 在 Consistency 之后、Vendor
-  之前的 TARGET slot）。它自身不解析 rule flag——具体装哪些 Transform 仍由
+  `preVendor []transform.Transform` 两个 slot 入参，把它们插进固定骨架的对应
+  位置（preBase 在最前的 preBase slot，preVendor 在 Consistency 之后、Vendor
+  之前的 preVendor slot）。它自身不解析 rule flag——具体装哪些 Transform 仍由
   handler 通过聚合点决定，但**插哪个位置由 builder 统一保证**，handler 不再
   各自 prepend / append。
 - 所有 4 个 `transformXxxx`（`transformAnthropicV1`、
   `transformAnthropicBeta`、`transformOpenAIChat`、
   `transformOpenAIResponses`）都接受一个 `preBaseTransforms []transform.Transform`
-  位置参数 + variadic `extraTransforms ...transform.Transform`，直接透传给
+  位置参数 + variadic `preVendorTransforms ...transform.Transform`，直接透传给
   `BuildTransformChain`。（`smart_compact` 仍在 Anthropic V1 / Beta 两条
   handler 内单独 prepend 到最前，行为不变。）
-- `rulePreBaseTransforms(flags)` 和 `ruleExtraTransforms(flags)`
+- `rulePreBaseTransforms(flags)` 和 `rulePreVendorTransforms(flags)`
   （`internal/server/rule_flags.go`）是 rule→Transform 的两个聚合点。
   新增 rule-driven Transform 时，按"作用于 inbound 形态" / "作用于目标
   形态"二选一，往对应聚合点追加 case；handler 端不需要改动。
 - chain 顺序的回归护栏在
-  `internal/server/protocol_chain_builder_test.go`：`extras` 必须落在
+  `internal/server/protocol_chain_builder_test.go`：`preVendor` 必须落在
   `consistency_normalize` 之后、`vendor_adjust` 之前。
 
 ---
@@ -440,9 +443,9 @@ Plugins Card 操作。
    │      • 作用于 inbound 形态（cursor_compat 类）→               │
    │        internal/server/rule_flags.go::rulePreBaseTransforms   │
    │      • 作用于目标形态（max_tokens 类）→                       │
-   │        internal/server/rule_flags.go::ruleExtraTransforms     │
+   │        internal/server/rule_flags.go::rulePreVendorTransforms │
    │   ④ handler 端无需改动——4 个 handler 都已调                  │
-   │      rulePreBaseTransforms(flags) / ruleExtraTransforms(flags)│
+   │      rulePreBaseTransforms(flags) / rulePreVendorTransforms(flags)│
    │                                                              │
    │ Type 2 (context-passed hint)                                 │
    │   ① 在 internal/typ/id.go 加 contextKey + 一对                │
@@ -494,10 +497,10 @@ Plugins Card 操作。
 | string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
 | UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约 |
 | 请求字段重写：handler pre-chain mutate vs post-base Transform | post-base Transform | handler 链外直改 | 链外直改在跨协议路径（Anthropic→OpenAI）失效；Transform 在 Base 之后看到的是最终形态，所有 inbound 类型都能命中 |
-| post-base extras 的 chain 位置 | Consistency 之后、**Vendor 之前** | append 到 chain 末尾（Vendor 之后） | Vendor 直面 provider 做不可逆改写，必须是最后一个 mutation；extras 跑在 Vendor 之后会破坏"vendor 最终态"且让 StagePost 录制抓不到真实出站请求 |
+| preVendor transforms 的 chain 位置 | Consistency 之后、**Vendor 之前** | append 到 chain 末尾（Vendor 之后） | Vendor 直面 provider 做不可逆改写，必须是最后一个 mutation；preVendor 跑在 Vendor 之后会破坏"vendor 最终态"且让 StagePost 录制抓不到真实出站请求 |
 | op vs Transform 是否合并 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（可独立测、可复用、可多端调用）；Transform 才感知 rule 与链路位置。合并会让原语难复用 |
 | Transform 放协议层包 vs server 包 | 视依赖而定 | 全部塞 server | 只依赖 SDK / 协议类型的放 `internal/protocol/transform/`；需要 server-domain 类型的放 `internal/server/`。避免反向依赖 |
-| `BuildTransformChain` 是否感知 rule | 否（只收已构造好的 Transform） | 把 ruleFlags 传入 | chain builder 不解析 flag，但作为唯一装配点接收 `preBase` / `extras` 两个 slot 入参并保证插入位置（INBOUND / TARGET slot）；rule→Transform 的决策仍在 handler 聚合点。早期版本由各 handler 自行 prepend/append，导致插入位置分散且 extras 误落在 Vendor 之后 |
+| `BuildTransformChain` 是否感知 rule | 否（只收已构造好的 Transform） | 把 ruleFlags 传入 | chain builder 不解析 flag，但作为唯一装配点接收 `preBase` / `preVendor` 两个 slot 入参并保证插入位置（preBase / preVendor slot）；rule→Transform 的决策仍在 handler 聚合点。早期版本由各 handler 自行 prepend/append，导致插入位置分散且 preVendor transforms 误落在 Vendor 之后 |
 | 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Plugins 卡片 | 两套入口对同一字段会引发混淆 |
 | 前端 registry-driven vs per-flag switch/case | registry-driven | 每个 flag 一个 case | registry-driven 消除 ~293 行重复代码；新增 flag 零前端 UI 改动。代价是需要 snakeToCamel 动态映射（类型不够严格），但 `TestRuleFlagRegistry_KeysMatchStructFields` 保证 key 与 struct 同步 |
 | `Shared` / `InheritanceMode` 嵌入 FlagSpec | ✅ | 前端单独维护共享清单 | 继承语义是 flag 固有属性，放在 registry 可信源里前端零维护 |

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -69,17 +69,23 @@
                                ▼
    ┌───────────────────────────────────────────────────────────────┐
    │   transformXxxx(..., preBase, extras...) :                     │
-   │     chain := BuildTransformChain(...)                          │
-   │     prependPreBaseTransforms(chain, preBase)                   │
-   │     appendExtraTransforms(chain, extras)                       │
+   │     chain := BuildTransformChain(..., preBase, extras)         │
    │     chain.Execute(ctx)                                         │
    │                                                                │
-   │     preBase → Base → MCP → Consistency → Vendor → extras       │
-   │   (pre-base stages)                       (post-base stages)   │
+   │   preBase → Base → MCP → Consistency → extras → Vendor → ▸rec  │
+   │   └ INBOUND slot                       └ TARGET slot           │
+   │                              Vendor + 录制 = 不可逾越的尾段     │
    └───────────────────────────┬───────────────────────────────────┘
                                ▼
                        upstream provider
 ```
+
+**不变式：除录制外，没有任何阶段在 `Vendor` 之后运行。** `Vendor` 直面
+provider、做最终且不可逆的改写（model alias、metadata、billing header、
+DeepSeek thinking patch 等），必须是最后一个 mutation；因此 rule 的 TARGET-slot
+extras 装在 `Consistency` 之后、`Vendor` **之前**。这同时修掉了一个隐患：
+StagePost 录制现在落在 `Vendor` 之后，抓到的是真正发出的请求（此前 extras 跑在
+录制之后，录到的"最终请求"与实际出站不一致）。
 
 ---
 
@@ -144,17 +150,19 @@ func RuleFlagRegistry() []FlagSpec { … }
 ## 5. 五种 flag 注入手法
 
 ```
-Type 1b-pre  Request body, pre-Base Transform
-         作为 Transform 接口的实现 prepend 到 chain 最前（BaseTransform
+Type 1b-pre  Request body, INBOUND slot（pre-Base Transform）
+         作为 Transform 接口的实现装在 chain 最前（BaseTransform
          之前）运行；type-switch 决定是否对 inbound request 形态生效。
          例：OpenAICursorCompatTransform —— 在 Base 把 OpenAI Chat 转
          成其他形态之前 flatten 富文本内容。聚合点：
          `internal/server/rule_flags.go::rulePreBaseTransforms`。
 
-Type 1b-post Request body, post-Base Transform（推荐用于跨协议 rewrite）
-         作为 Transform 接口的实现 append 到 chain 末尾，在 BaseTransform
-         完成协议转换之后运行；type-switch 决定是否对目标 request 形态
-         生效。例：OpenAIMaxTokensRewriteTransform。聚合点：
+Type 1b-post Request body, TARGET slot（post-Base Transform，推荐用于跨协议 rewrite）
+         作为 Transform 接口的实现装在 `Consistency` 之后、`Vendor`
+         **之前**，在 BaseTransform 完成协议转换之后运行；type-switch
+         决定是否对目标 request 形态生效。**绝不在 Vendor 之后**——Vendor
+         是直面 provider 的最终步骤，不可逾越。例：
+         OpenAIMaxTokensRewriteTransform、RuleThinkingTransform。聚合点：
          `internal/server/rule_flags.go::ruleExtraTransforms`。
 
 Type 2   Per-request context hint
@@ -181,9 +189,13 @@ Type 5   Routing behavior (service selection)
 ```
 
 任何新 flag 都应归入这几类之一。pre-Base 和 post-Base Transform 都是同一
-个 `Transform` 接口的实现，区别只在 chain 中的位置：pre 在 BaseTransform
-之前（看见 inbound 形态），post 在之后（看见目标形态）。聚合点
-`rulePreBaseTransforms` / `ruleExtraTransforms` 决定 flag 装哪边。
+个 `Transform` 接口的实现，区别只在 chain 中的位置：pre 装在 INBOUND slot
+（BaseTransform 之前，看见 inbound 形态），post 装在 TARGET slot
+（Consistency 之后、Vendor 之前，看见目标形态）。聚合点
+`rulePreBaseTransforms` / `ruleExtraTransforms` 决定 flag 装哪边。两个 slot
+之外，chain 的骨架（StagePre 录制 → Base → MCP → Consistency → Vendor →
+StagePost 录制）由 `BuildTransformChain` 固定，**Vendor + 录制是不可逾越的
+尾段**。
 
 ---
 
@@ -235,32 +247,35 @@ handler                            transformXxxx                       chain
   │             flags)                  │                                │
   │  (e.g. [OpenAIMaxTokensRewrite])    │                                │
   ├──────── preBase, extras... ────────►│                                │
-  │                                     │  chain := BuildTransformChain  │
-  │                                     │           (...)                │
+  │                                     │  chain := BuildTransformChain( │
+  │                                     │      ..., preBase, extras)      │
   │                                     ├──────────────────────────────►│
-  │                                     │  prependPreBaseTransforms(     │
-  │                                     │      chain, preBase)           │
-  │                                     │  appendExtraTransforms(        │
-  │                                     │      chain, extraTransforms)   │
   │                                     │  chain.Execute(ctx)            │
   │                                     ├──────────────────────────────►│
 ```
 
 关键约束：
 
-- `BuildTransformChain` 不感知 rule flag。它的输入是 scenario / provider
-  / recording——把哪些 rule Transform 要 prepend / append 的决策留给
-  handler。
+- `BuildTransformChain` 是唯一的 chain 装配点。它接受 scenario / provider
+  / recording，外加 `preBase []transform.Transform` 与
+  `extras []transform.Transform` 两个 slot 入参，把它们插进固定骨架的对应
+  位置（preBase 在最前的 INBOUND slot，extras 在 Consistency 之后、Vendor
+  之前的 TARGET slot）。它自身不解析 rule flag——具体装哪些 Transform 仍由
+  handler 通过聚合点决定，但**插哪个位置由 builder 统一保证**，handler 不再
+  各自 prepend / append。
 - 所有 4 个 `transformXxxx`（`transformAnthropicV1`、
   `transformAnthropicBeta`、`transformOpenAIChat`、
   `transformOpenAIResponses`）都接受一个 `preBaseTransforms []transform.Transform`
-  位置参数 + variadic `extraTransforms ...transform.Transform`，分别用
-  `prependPreBaseTransforms(chain, preBase)` 和
-  `appendExtraTransforms(chain, extras)` 装到 chain 两端。
+  位置参数 + variadic `extraTransforms ...transform.Transform`，直接透传给
+  `BuildTransformChain`。（`smart_compact` 仍在 Anthropic V1 / Beta 两条
+  handler 内单独 prepend 到最前，行为不变。）
 - `rulePreBaseTransforms(flags)` 和 `ruleExtraTransforms(flags)`
   （`internal/server/rule_flags.go`）是 rule→Transform 的两个聚合点。
   新增 rule-driven Transform 时，按"作用于 inbound 形态" / "作用于目标
   形态"二选一，往对应聚合点追加 case；handler 端不需要改动。
+- chain 顺序的回归护栏在
+  `internal/server/protocol_chain_builder_test.go`：`extras` 必须落在
+  `consistency_normalize` 之后、`vendor_adjust` 之前。
 
 ---
 
@@ -479,9 +494,10 @@ Plugins Card 操作。
 | string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
 | UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约 |
 | 请求字段重写：handler pre-chain mutate vs post-base Transform | post-base Transform | handler 链外直改 | 链外直改在跨协议路径（Anthropic→OpenAI）失效；Transform 在 Base 之后看到的是最终形态，所有 inbound 类型都能命中 |
+| post-base extras 的 chain 位置 | Consistency 之后、**Vendor 之前** | append 到 chain 末尾（Vendor 之后） | Vendor 直面 provider 做不可逆改写，必须是最后一个 mutation；extras 跑在 Vendor 之后会破坏"vendor 最终态"且让 StagePost 录制抓不到真实出站请求 |
 | op vs Transform 是否合并 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（可独立测、可复用、可多端调用）；Transform 才感知 rule 与链路位置。合并会让原语难复用 |
 | Transform 放协议层包 vs server 包 | 视依赖而定 | 全部塞 server | 只依赖 SDK / 协议类型的放 `internal/protocol/transform/`；需要 server-domain 类型的放 `internal/server/`。避免反向依赖 |
-| `BuildTransformChain` 是否感知 rule | 否 | 把 ruleFlags 传入 | chain builder 只懂 scenario/provider/recording；rule 级关心点放在 handler，通过 `extraTransforms ...transform.Transform` variadic 注入 |
+| `BuildTransformChain` 是否感知 rule | 否（只收已构造好的 Transform） | 把 ruleFlags 传入 | chain builder 不解析 flag，但作为唯一装配点接收 `preBase` / `extras` 两个 slot 入参并保证插入位置（INBOUND / TARGET slot）；rule→Transform 的决策仍在 handler 聚合点。早期版本由各 handler 自行 prepend/append，导致插入位置分散且 extras 误落在 Vendor 之后 |
 | 取消路由图齿轮菜单中的 Cursor 专用项 | ✅ | 同时保留菜单项和 Plugins 卡片 | 两套入口对同一字段会引发混淆 |
 | 前端 registry-driven vs per-flag switch/case | registry-driven | 每个 flag 一个 case | registry-driven 消除 ~293 行重复代码；新增 flag 零前端 UI 改动。代价是需要 snakeToCamel 动态映射（类型不够严格），但 `TestRuleFlagRegistry_KeysMatchStructFields` 保证 key 与 struct 同步 |
 | `Shared` / `InheritanceMode` 嵌入 FlagSpec | ✅ | 前端单独维护共享清单 | 继承语义是 flag 固有属性，放在 registry 可信源里前端零维护 |

--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -269,7 +269,7 @@ handler                            transformXxxx                       chain
 - 所有 4 个 `transformXxxx`（`transformAnthropicV1`、
   `transformAnthropicBeta`、`transformOpenAIChat`、
   `transformOpenAIResponses`）都接受一个 `preBaseTransforms []transform.Transform`
-  位置参数 + variadic `preVendorTransforms ...transform.Transform`，直接透传给
+  位置参数 + 一个 `preVendorTransforms []transform.Transform`，直接透传给
   `BuildTransformChain`。（`smart_compact` 仍在 Anthropic V1 / Beta 两条
   handler 内单独 prepend 到最前，行为不变。）
 - `rulePreBaseTransforms(flags)` 和 `rulePreVendorTransforms(flags)`

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -96,7 +96,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	// (This also applies the custom User-Agent to the request context.)
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target, provider)
 
-	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
+	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -96,7 +96,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	// (This also applies the custom User-Agent to the request context.)
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target, provider)
 
-	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
+	reqCtx, err := s.transformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -92,7 +92,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	// (This also applies the custom User-Agent to the request context.)
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target, provider)
 
-	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
+	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -92,7 +92,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	// (This also applies the custom User-Agent to the request context.)
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target, provider)
 
-	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
+	reqCtx, err := s.transformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -233,7 +233,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target, provider)
 
 	// === Transform via pipeline ===
-	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
+	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -233,7 +233,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target, provider)
 
 	// === Transform via pipeline ===
-	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
+	reqCtx, err := s.transformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -230,7 +230,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	// handlers (this also applies the custom User-Agent to the request context).
 	scenarioConfig := s.config.GetScenarioConfig(scenarioType)
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target, provider)
-	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, rulePreBaseTransforms(ruleFlags), ruleExtraTransforms(ruleFlags)...)
+	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -230,7 +230,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 	// handlers (this also applies the custom User-Agent to the request context).
 	scenarioConfig := s.config.GetScenarioConfig(scenarioType)
 	ruleFlags := resolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target, provider)
-	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags)...)
+	reqCtx, err := s.transformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, rulePreBaseTransforms(ruleFlags), rulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/protocol_chain_builder.go
+++ b/internal/server/protocol_chain_builder.go
@@ -14,8 +14,23 @@ func (s *Server) ShouldRecording(recorder *ProtocolRecorder) bool {
 	return recorder != nil
 }
 
-// BuildTransformChain builds the appropriate transform chain based on recording configuration
-func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioType typ.RuleScenario, scenarioFlags *typ.ScenarioFlags, recorder *ProtocolRecorder) (*transform.TransformChain, error) {
+// BuildTransformChain assembles the canonical transform chain in a single place,
+// slotting the rule-driven transforms into well-defined positions:
+//
+//	INBOUND slot : preBase rule transforms (act on the client's original shape)
+//	StagePre-record (if enabled)
+//	Base         (protocol conversion)
+//	MCP          (inject / native-websearch-strip / strip-guard) [if mcpEnabled]
+//	Consistency  (cross-provider normalization, param clamping)
+//	TARGET slot  : extras rule transforms (act on the converted, upstream-bound shape)
+//	Vendor       (provider-specific finalize)
+//	StagePost-record (if enabled)
+//
+// Invariant: nothing runs after Vendor except recording. Vendor directly faces
+// the provider and must be the last mutation, so the rule extras are inserted
+// after Consistency but BEFORE Vendor — this also means the StagePost recording
+// captures the truly-final, dispatched request.
+func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioType typ.RuleScenario, scenarioFlags *typ.ScenarioFlags, recorder *ProtocolRecorder, preBase []transform.Transform, extras []transform.Transform) (*transform.TransformChain, error) {
 
 	recordMode := s.GetScenarioRecordMode(scenarioType)
 	shouldRecord := s.ShouldRecording(recorder)
@@ -27,6 +42,11 @@ func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType
 		recordMode == obs.RecordModeRequestOnly ||
 		recordMode == obs.RecordModeRequestResponse ||
 		recordMode == obs.RecordModeStagedRequestResponse
+
+	// INBOUND slot: rule transforms that act on the inbound request shape, before
+	// any protocol conversion (and before recording, so the type-switch in each
+	// transform sees what the client actually sent).
+	transforms = append(transforms, preBase...)
 
 	// 1. Pre-transform recording (if request recording is enabled)
 	if shouldRecord && requestRecordingEnabled {
@@ -42,9 +62,16 @@ func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType
 	}
 	// 3. Consistency transform (cross-provider normalization including message alignment)
 	transforms = append(transforms, transform.NewConsistencyTransform(targetType))
+
+	// TARGET slot: rule transforms that act on the converted, upstream-bound
+	// shape. Placed after Consistency (so its param clamping still applies) and
+	// before Vendor (so Vendor remains the final, immutable step).
+	transforms = append(transforms, extras...)
+
 	transforms = append(transforms, transform.NewVendorTransform(providerURL))
 
-	// 3. Post-transform recording (if request recording is enabled)
+	// 4. Post-transform recording (if request recording is enabled). Runs last so
+	// it snapshots the truly-final request dispatched to the provider.
 	if shouldRecord && requestRecordingEnabled {
 		transforms = append(transforms, NewTransformRecorder(c, recorder, StagePost))
 	}

--- a/internal/server/protocol_chain_builder.go
+++ b/internal/server/protocol_chain_builder.go
@@ -15,22 +15,23 @@ func (s *Server) ShouldRecording(recorder *ProtocolRecorder) bool {
 }
 
 // BuildTransformChain assembles the canonical transform chain in a single place,
-// slotting the rule-driven transforms into well-defined positions:
+// slotting the rule-driven transforms into the two named positions — preBase and
+// preVendor — that bracket the protocol conversion and the vendor finalize:
 //
-//	INBOUND slot : preBase rule transforms (act on the client's original shape)
+//	preBase slot   : preBase rule transforms (act on the client's original shape)
 //	StagePre-record (if enabled)
-//	Base         (protocol conversion)
-//	MCP          (inject / native-websearch-strip / strip-guard) [if mcpEnabled]
-//	Consistency  (cross-provider normalization, param clamping)
-//	TARGET slot  : extras rule transforms (act on the converted, upstream-bound shape)
-//	Vendor       (provider-specific finalize)
+//	Base           (protocol conversion)
+//	MCP            (inject / native-websearch-strip / strip-guard) [if mcpEnabled]
+//	Consistency    (cross-provider normalization, param clamping)
+//	preVendor slot : preVendor rule transforms (act on the converted, upstream-bound shape)
+//	Vendor         (provider-specific finalize)
 //	StagePost-record (if enabled)
 //
 // Invariant: nothing runs after Vendor except recording. Vendor directly faces
-// the provider and must be the last mutation, so the rule extras are inserted
-// after Consistency but BEFORE Vendor — this also means the StagePost recording
-// captures the truly-final, dispatched request.
-func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioType typ.RuleScenario, scenarioFlags *typ.ScenarioFlags, recorder *ProtocolRecorder, preBase []transform.Transform, extras []transform.Transform) (*transform.TransformChain, error) {
+// the provider and must be the last mutation, so the preVendor transforms are
+// inserted after Consistency but BEFORE Vendor — this also means the StagePost
+// recording captures the truly-final, dispatched request.
+func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioType typ.RuleScenario, scenarioFlags *typ.ScenarioFlags, recorder *ProtocolRecorder, preBase []transform.Transform, preVendor []transform.Transform) (*transform.TransformChain, error) {
 
 	recordMode := s.GetScenarioRecordMode(scenarioType)
 	shouldRecord := s.ShouldRecording(recorder)
@@ -43,7 +44,7 @@ func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType
 		recordMode == obs.RecordModeRequestResponse ||
 		recordMode == obs.RecordModeStagedRequestResponse
 
-	// INBOUND slot: rule transforms that act on the inbound request shape, before
+	// preBase slot: rule transforms that act on the inbound request shape, before
 	// any protocol conversion (and before recording, so the type-switch in each
 	// transform sees what the client actually sent).
 	transforms = append(transforms, preBase...)
@@ -63,10 +64,10 @@ func (s *Server) BuildTransformChain(c *gin.Context, targetType protocol.APIType
 	// 3. Consistency transform (cross-provider normalization including message alignment)
 	transforms = append(transforms, transform.NewConsistencyTransform(targetType))
 
-	// TARGET slot: rule transforms that act on the converted, upstream-bound
+	// preVendor slot: rule transforms that act on the converted, upstream-bound
 	// shape. Placed after Consistency (so its param clamping still applies) and
 	// before Vendor (so Vendor remains the final, immutable step).
-	transforms = append(transforms, extras...)
+	transforms = append(transforms, preVendor...)
 
 	transforms = append(transforms, transform.NewVendorTransform(providerURL))
 

--- a/internal/server/protocol_chain_builder_test.go
+++ b/internal/server/protocol_chain_builder_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,16 +11,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
-
-// indexOf returns the position of name in names, or -1 if absent.
-func indexOf(names []string, name string) int {
-	for i, n := range names {
-		if n == name {
-			return i
-		}
-	}
-	return -1
-}
 
 // chainNames runs the (zero-config) chain builder and returns the ordered
 // transform names. A zero Server has nil config, so recording and MCP are off —
@@ -64,17 +55,17 @@ func TestBuildTransformChain_PreVendorBeforeVendor(t *testing.T) {
 	}
 	names := chainNames(t, nil, preVendor)
 
-	consistency := indexOf(names, "consistency_normalize")
-	vendor := indexOf(names, "vendor_adjust")
-	thinking := indexOf(names, "rule_thinking")
-	maxTokens := indexOf(names, "openai_max_tokens_rewrite")
+	consistency := slices.Index(names, "consistency_normalize")
+	vendor := slices.Index(names, "vendor_adjust")
+	thinking := slices.Index(names, "rule_thinking")
+	maxTokens := slices.Index(names, "openai_max_tokens_rewrite")
 
 	require.NotEqual(t, -1, consistency)
 	require.NotEqual(t, -1, vendor)
 	require.NotEqual(t, -1, thinking)
 	require.NotEqual(t, -1, maxTokens)
 
-	// Extras sit after Consistency...
+	// preVendor transforms sit after Consistency...
 	assert.Greater(t, thinking, consistency, "rule_thinking must run after consistency_normalize")
 	assert.Greater(t, maxTokens, consistency, "openai_max_tokens_rewrite must run after consistency_normalize")
 	// ...and strictly before Vendor — nothing mutates the request after Vendor.
@@ -88,8 +79,8 @@ func TestBuildTransformChain_PreBaseBeforeBase(t *testing.T) {
 	preBase := []transform.Transform{transform.NewOpenAICursorCompatTransform()}
 	names := chainNames(t, preBase, nil)
 
-	cursor := indexOf(names, names[0]) // first slot is the pre-Base transform
-	base := indexOf(names, "base_convert")
+	cursor := slices.Index(names, "openai_cursor_compat")
+	base := slices.Index(names, "base_convert")
 
 	require.NotEqual(t, -1, base)
 	assert.Equal(t, 0, cursor, "pre-Base rule transform must be first in the chain")

--- a/internal/server/protocol_chain_builder_test.go
+++ b/internal/server/protocol_chain_builder_test.go
@@ -24,7 +24,7 @@ func indexOf(names []string, name string) int {
 // chainNames runs the (zero-config) chain builder and returns the ordered
 // transform names. A zero Server has nil config, so recording and MCP are off —
 // leaving the canonical base order plus whatever rule transforms are slotted in.
-func chainNames(t *testing.T, preBase, extras []transform.Transform) []string {
+func chainNames(t *testing.T, preBase, preVendor []transform.Transform) []string {
 	t.Helper()
 	s := &Server{}
 	chain, err := s.BuildTransformChain(
@@ -35,7 +35,7 @@ func chainNames(t *testing.T, preBase, extras []transform.Transform) []string {
 		nil,
 		nil, // no recorder
 		preBase,
-		extras,
+		preVendor,
 	)
 	require.NoError(t, err)
 
@@ -53,16 +53,16 @@ func TestBuildTransformChain_BaseOrder(t *testing.T) {
 	assert.Equal(t, []string{"base_convert", "consistency_normalize", "vendor_adjust"}, names)
 }
 
-// TestBuildTransformChain_ExtrasBeforeVendor is the regression guard for the
-// core fix: rule "extras" (target-shape transforms) must run after Consistency
-// and BEFORE Vendor, so Vendor remains the final, immutable step facing the
-// provider.
-func TestBuildTransformChain_ExtrasBeforeVendor(t *testing.T) {
-	extras := []transform.Transform{
+// TestBuildTransformChain_PreVendorBeforeVendor is the regression guard for the
+// core fix: rule preVendor transforms (target-shape transforms) must run after
+// Consistency and BEFORE Vendor, so Vendor remains the final, immutable step
+// facing the provider.
+func TestBuildTransformChain_PreVendorBeforeVendor(t *testing.T) {
+	preVendor := []transform.Transform{
 		transform.NewRuleThinkingTransform(typ.ThinkingEffortHigh),
 		transform.NewOpenAIMaxTokensRewriteTransform(true, false),
 	}
-	names := chainNames(t, nil, extras)
+	names := chainNames(t, nil, preVendor)
 
 	consistency := indexOf(names, "consistency_normalize")
 	vendor := indexOf(names, "vendor_adjust")

--- a/internal/server/protocol_chain_builder_test.go
+++ b/internal/server/protocol_chain_builder_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// indexOf returns the position of name in names, or -1 if absent.
+func indexOf(names []string, name string) int {
+	for i, n := range names {
+		if n == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// chainNames runs the (zero-config) chain builder and returns the ordered
+// transform names. A zero Server has nil config, so recording and MCP are off —
+// leaving the canonical base order plus whatever rule transforms are slotted in.
+func chainNames(t *testing.T, preBase, extras []transform.Transform) []string {
+	t.Helper()
+	s := &Server{}
+	chain, err := s.BuildTransformChain(
+		nil, // gin.Context only used by the (disabled) recorder
+		protocol.TypeOpenAIChat,
+		"https://api.example.com",
+		typ.ScenarioGlobal,
+		nil,
+		nil, // no recorder
+		preBase,
+		extras,
+	)
+	require.NoError(t, err)
+
+	var names []string
+	for _, tr := range chain.GetTransforms() {
+		names = append(names, tr.Name())
+	}
+	return names
+}
+
+// TestBuildTransformChain_BaseOrder pins the canonical base order with no rule
+// transforms: protocol convert → normalize → vendor finalize.
+func TestBuildTransformChain_BaseOrder(t *testing.T) {
+	names := chainNames(t, nil, nil)
+	assert.Equal(t, []string{"base_convert", "consistency_normalize", "vendor_adjust"}, names)
+}
+
+// TestBuildTransformChain_ExtrasBeforeVendor is the regression guard for the
+// core fix: rule "extras" (target-shape transforms) must run after Consistency
+// and BEFORE Vendor, so Vendor remains the final, immutable step facing the
+// provider.
+func TestBuildTransformChain_ExtrasBeforeVendor(t *testing.T) {
+	extras := []transform.Transform{
+		transform.NewRuleThinkingTransform(typ.ThinkingEffortHigh),
+		transform.NewOpenAIMaxTokensRewriteTransform(true, false),
+	}
+	names := chainNames(t, nil, extras)
+
+	consistency := indexOf(names, "consistency_normalize")
+	vendor := indexOf(names, "vendor_adjust")
+	thinking := indexOf(names, "rule_thinking")
+	maxTokens := indexOf(names, "openai_max_tokens_rewrite")
+
+	require.NotEqual(t, -1, consistency)
+	require.NotEqual(t, -1, vendor)
+	require.NotEqual(t, -1, thinking)
+	require.NotEqual(t, -1, maxTokens)
+
+	// Extras sit after Consistency...
+	assert.Greater(t, thinking, consistency, "rule_thinking must run after consistency_normalize")
+	assert.Greater(t, maxTokens, consistency, "openai_max_tokens_rewrite must run after consistency_normalize")
+	// ...and strictly before Vendor — nothing mutates the request after Vendor.
+	assert.Less(t, thinking, vendor, "rule_thinking must run before vendor_adjust")
+	assert.Less(t, maxTokens, vendor, "openai_max_tokens_rewrite must run before vendor_adjust")
+}
+
+// TestBuildTransformChain_PreBaseBeforeBase verifies the inbound slot: pre-Base
+// rule transforms run before protocol conversion so they see the client shape.
+func TestBuildTransformChain_PreBaseBeforeBase(t *testing.T) {
+	preBase := []transform.Transform{transform.NewOpenAICursorCompatTransform()}
+	names := chainNames(t, preBase, nil)
+
+	cursor := indexOf(names, names[0]) // first slot is the pre-Base transform
+	base := indexOf(names, "base_convert")
+
+	require.NotEqual(t, -1, base)
+	assert.Equal(t, 0, cursor, "pre-Base rule transform must be first in the chain")
+	assert.Less(t, cursor, base, "pre-Base rule transform must run before base_convert")
+}

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,11 +8,11 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support. The rule-driven pre-Base and
-	// extra transforms are slotted into their canonical positions by the builder.
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
+	// preVendor transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -75,10 +75,10 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	return finalCtx, nil
 }
 
-func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
-	// extra transforms are slotted into their canonical positions by the builder.
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
+	// preVendor transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -138,10 +138,10 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
-	// extra transforms are slotted into their canonical positions by the builder.
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
+	// preVendor transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -193,10 +193,10 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
-	// extra transforms are slotted into their canonical positions by the builder.
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
+	// preVendor transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,40 +8,14 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// appendExtraTransforms tacks rule-driven post-Base transforms onto a chain
-// built by BuildTransformChain. Kept rule-agnostic — the caller decides what
-// to append.
-func appendExtraTransforms(chain *transform.TransformChain, extras []transform.Transform) {
-	for _, t := range extras {
-		chain.Add(t)
-	}
-}
-
-// prependPreBaseTransforms prepends rule-driven pre-Base transforms onto a
-// chain built by BuildTransformChain. They run before any existing stage
-// (including StagePre recording) — same position smart_compact uses — so the
-// type-switch in each transform sees the inbound request shape exactly as the
-// client sent it.
-func prependPreBaseTransforms(chain *transform.TransformChain, preBase []transform.Transform) {
-	if len(preBase) == 0 {
-		return
-	}
-	existing := chain.GetTransforms()
-	merged := make([]transform.Transform, 0, len(preBase)+len(existing))
-	merged = append(merged, preBase...)
-	merged = append(merged, existing...)
-	chain.SetTransforms(merged)
-}
-
 func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
 
-	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
+	// Build transform chain with recording support. The rule-driven pre-Base and
+	// extra transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
 	if err != nil {
 		return nil, err
 	}
-	prependPreBaseTransforms(chain, preBaseTransforms)
-	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags
@@ -102,13 +76,12 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 }
 
 func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
-	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
+	// Build transform chain with recording support. The rule-driven pre-Base and
+	// extra transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
 	if err != nil {
 		return nil, err
 	}
-	prependPreBaseTransforms(chain, preBaseTransforms)
-	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags
@@ -166,13 +139,12 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 }
 
 func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
-	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
+	// Build transform chain with recording support. The rule-driven pre-Base and
+	// extra transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
 	if err != nil {
 		return nil, err
 	}
-	prependPreBaseTransforms(chain, preBaseTransforms)
-	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags
@@ -222,13 +194,12 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 }
 
 func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, extraTransforms ...transform.Transform) (*transform.TransformContext, error) {
-	// Build transform chain with recording support
-	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder)
+	// Build transform chain with recording support. The rule-driven pre-Base and
+	// extra transforms are slotted into their canonical positions by the builder.
+	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, extraTransforms)
 	if err != nil {
 		return nil, err
 	}
-	prependPreBaseTransforms(chain, preBaseTransforms)
-	appendExtraTransforms(chain, extraTransforms)
 
 	// Create transform context
 	var scenarioFlags *typ.ScenarioFlags

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
@@ -75,7 +75,7 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	return finalCtx, nil
 }
 
-func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
@@ -138,7 +138,7 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
@@ -193,7 +193,7 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms ...transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -10,7 +10,7 @@ import (
 )
 
 // rulePreBaseTransforms builds the per-rule list of pre-Base transforms for the
-// chain's INBOUND slot. Pre-Base transforms act on the *inbound* request shape —
+// chain's preBase slot. Pre-Base transforms act on the *inbound* request shape —
 // they run before BaseTransform's protocol conversion, so the type-switch inside
 // each transform sees what the client actually sent.
 //
@@ -49,30 +49,30 @@ func parseBlockTools(raw string) []string {
 	return names
 }
 
-// ruleExtraTransforms builds the per-rule list of post-Base transforms for the
-// chain's TARGET slot (after Consistency, before Vendor). Post-Base transforms
-// act on the *target* request shape — they run after BaseTransform's protocol
+// rulePreVendorTransforms builds the per-rule list of pre-Vendor transforms for
+// the chain's preVendor slot (after Consistency, before Vendor). These act on
+// the *target* request shape — they run after BaseTransform's protocol
 // conversion, so the type-switch inside each transform matches the
-// upstream-bound form.
+// upstream-bound form, but still before Vendor finalizes the request.
 //
 // Returns nil when no rule-level flag requires a chain stage so callers can
-// pass the result straight to a variadic `extraTransforms ...transform.Transform`
+// pass the result straight to a variadic `preVendorTransforms ...transform.Transform`
 // parameter.
 //
 // Takes already-resolved flags so callers that need other fields off
 // RuleFlags (CustomUserAgent, SkipUsage) can resolve once and share.
-func ruleExtraTransforms(flags typ.RuleFlags) []transform.Transform {
-	var extras []transform.Transform
+func rulePreVendorTransforms(flags typ.RuleFlags) []transform.Transform {
+	var preVendor []transform.Transform
 	if flags.UseMaxCompletionTokens || flags.UseMaxTokens {
-		extras = append(extras, transform.NewOpenAIMaxTokensRewriteTransform(
+		preVendor = append(preVendor, transform.NewOpenAIMaxTokensRewriteTransform(
 			flags.UseMaxCompletionTokens,
 			flags.UseMaxTokens,
 		))
 	}
 	if flags.ThinkingEffort != typ.ThinkingEffortDefault {
-		extras = append(extras, transform.NewRuleThinkingTransform(flags.ThinkingEffort))
+		preVendor = append(preVendor, transform.NewRuleThinkingTransform(flags.ThinkingEffort))
 	}
-	return extras
+	return preVendor
 }
 
 // resolveRuleFlags returns the effective flags for this request: a copy of

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -56,7 +56,7 @@ func parseBlockTools(raw string) []string {
 // upstream-bound form, but still before Vendor finalizes the request.
 //
 // Returns nil when no rule-level flag requires a chain stage so callers can
-// pass the result straight to a variadic `preVendorTransforms ...transform.Transform`
+// pass the result straight to a `preVendorTransforms []transform.Transform`
 // parameter.
 //
 // Takes already-resolved flags so callers that need other fields off

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -9,13 +9,13 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// rulePreBaseTransforms builds the per-rule list of pre-Base transforms to
-// prepend onto the protocol chain. Pre-Base transforms act on the *inbound*
-// request shape — they run before BaseTransform's protocol conversion, so the
-// type-switch inside each transform sees what the client actually sent.
+// rulePreBaseTransforms builds the per-rule list of pre-Base transforms for the
+// chain's INBOUND slot. Pre-Base transforms act on the *inbound* request shape —
+// they run before BaseTransform's protocol conversion, so the type-switch inside
+// each transform sees what the client actually sent.
 //
-// Returns nil when no rule-level flag requires a pre-Base stage so callers
-// can pass the result straight to prependPreBaseTransforms.
+// Returns nil when no rule-level flag requires a pre-Base stage so callers can
+// pass the result straight to BuildTransformChain's preBase parameter.
 func rulePreBaseTransforms(flags typ.RuleFlags) []transform.Transform {
 	var pre []transform.Transform
 	if flags.CursorCompat {
@@ -49,10 +49,11 @@ func parseBlockTools(raw string) []string {
 	return names
 }
 
-// ruleExtraTransforms builds the per-rule list of post-Base transforms to
-// append to the protocol chain. Post-Base transforms act on the *target*
-// request shape — they run after BaseTransform's protocol conversion, so the
-// type-switch inside each transform matches the upstream-bound form.
+// ruleExtraTransforms builds the per-rule list of post-Base transforms for the
+// chain's TARGET slot (after Consistency, before Vendor). Post-Base transforms
+// act on the *target* request shape — they run after BaseTransform's protocol
+// conversion, so the type-switch inside each transform matches the
+// upstream-bound form.
 //
 // Returns nil when no rule-level flag requires a chain stage so callers can
 // pass the result straight to a variadic `extraTransforms ...transform.Transform`

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -160,15 +160,15 @@ func TestRulePreBaseTransforms_OtherFlagsAlone_NoTransform(t *testing.T) {
 	}
 }
 
-func TestRuleExtraTransforms_NoFlags(t *testing.T) {
-	got := ruleExtraTransforms(typ.RuleFlags{})
+func TestRulePreVendorTransforms_NoFlags(t *testing.T) {
+	got := rulePreVendorTransforms(typ.RuleFlags{})
 	if got != nil {
 		t.Errorf("expected nil for zero-value flags, got %d transforms", len(got))
 	}
 }
 
-func TestRuleExtraTransforms_UseMaxCompletionTokens(t *testing.T) {
-	got := ruleExtraTransforms(typ.RuleFlags{UseMaxCompletionTokens: true})
+func TestRulePreVendorTransforms_UseMaxCompletionTokens(t *testing.T) {
+	got := rulePreVendorTransforms(typ.RuleFlags{UseMaxCompletionTokens: true})
 	if len(got) != 1 {
 		t.Fatalf("expected 1 transform, got %d", len(got))
 	}
@@ -181,8 +181,8 @@ func TestRuleExtraTransforms_UseMaxCompletionTokens(t *testing.T) {
 	}
 }
 
-func TestRuleExtraTransforms_UseMaxTokens(t *testing.T) {
-	got := ruleExtraTransforms(typ.RuleFlags{UseMaxTokens: true})
+func TestRulePreVendorTransforms_UseMaxTokens(t *testing.T) {
+	got := rulePreVendorTransforms(typ.RuleFlags{UseMaxTokens: true})
 	if len(got) != 1 {
 		t.Fatalf("expected 1 transform, got %d", len(got))
 	}
@@ -192,8 +192,8 @@ func TestRuleExtraTransforms_UseMaxTokens(t *testing.T) {
 	}
 }
 
-func TestRuleExtraTransforms_ThinkingEffort(t *testing.T) {
-	got := ruleExtraTransforms(typ.RuleFlags{ThinkingEffort: typ.ThinkingEffortHigh})
+func TestRulePreVendorTransforms_ThinkingEffort(t *testing.T) {
+	got := rulePreVendorTransforms(typ.RuleFlags{ThinkingEffort: typ.ThinkingEffortHigh})
 	if len(got) != 1 {
 		t.Fatalf("expected 1 transform, got %d", len(got))
 	}
@@ -206,19 +206,19 @@ func TestRuleExtraTransforms_ThinkingEffort(t *testing.T) {
 	}
 }
 
-func TestRuleExtraTransforms_ThinkingEffortEmpty_NoTransform(t *testing.T) {
-	got := ruleExtraTransforms(typ.RuleFlags{ThinkingEffort: typ.ThinkingEffortDefault})
+func TestRulePreVendorTransforms_ThinkingEffortEmpty_NoTransform(t *testing.T) {
+	got := rulePreVendorTransforms(typ.RuleFlags{ThinkingEffort: typ.ThinkingEffortDefault})
 	if got != nil {
 		t.Errorf("empty thinking effort should add no transform, got %d", len(got))
 	}
 }
 
-func TestRuleExtraTransforms_CursorCompatAlone_NoTransform(t *testing.T) {
-	// CursorCompat is a pre-Base flag — it must not surface in the post-Base
-	// extras list. This is the safety net for the rule-flag-to-transform
-	// migration: if anyone wires cursor_compat into ruleExtraTransforms by
-	// mistake, this test goes red.
-	got := ruleExtraTransforms(typ.RuleFlags{
+func TestRulePreVendorTransforms_CursorCompatAlone_NoTransform(t *testing.T) {
+	// CursorCompat is a preBase flag — it must not surface in the preVendor
+	// list. This is the safety net for the rule-flag-to-transform migration: if
+	// anyone wires cursor_compat into rulePreVendorTransforms by mistake, this
+	// test goes red.
+	got := rulePreVendorTransforms(typ.RuleFlags{
 		CursorCompat:    true,
 		SkipUsage:       true,
 		CustomUserAgent: "Foo/1.0",


### PR DESCRIPTION
## What & why

The transform chain appended rule-driven "extra" transforms (`OpenAIMaxTokensRewriteTransform`, `RuleThinkingTransform`) to the **tail of the chain — after `Vendor` and after StagePost recording**. That broke two invariants:

- **Vendor must be the final, immutable step.** It directly faces the provider and does irreversible work (model alias, metadata, billing headers, DeepSeek thinking patch). Nothing should mutate the request after it.
- **Recording fidelity.** StagePost recording ran *before* those extras, so the recorded "final upstream request" didn't match what was actually dispatched.

## Changes

- **Centralize chain assembly in `BuildTransformChain`.** It now takes `preBase []transform.Transform` and `preVendor []transform.Transform` and slots them into fixed positions, with `Vendor` + recording as a guaranteed tail:
  ```
  preBase → StagePre-record → Base → MCP → Consistency → preVendor → Vendor → StagePost-record
  ```
  `preVendor` now runs after Consistency (so its param clamping still applies) and **before** Vendor — verified orthogonal to Vendor's work, so the move is behavior-preserving aside from the corrected ordering.

- **Remove per-handler chain mutation.** Dropped `prependPreBaseTransforms` / `appendExtraTransforms`; the four `transformXxxx` handlers (`transformAnthropicV1/Beta`, `transformOpenAIChat`, `transformOpenAIResponses`) just pass the two slices through. The builder is the single source of truth for ordering.

- **Rename + symmetry.** `ruleExtraTransforms` → `rulePreVendorTransforms`. The two dynamic insertion points are now symmetric — `preBase` (before Base) and `preVendor` (before Vendor) — both passed as plain slices (not variadic).

- **Tests.** New `internal/server/protocol_chain_builder_test.go` pins the canonical base order and guards that `preVendor` runs after `consistency_normalize` and strictly before `vendor_adjust`; uses stdlib `slices.Index`.

- **Docs.** `.design/rule-flags.md` updated with the slot model (`preBase` / `preVendor`), the canonical order, and the invariant: nothing runs after `Vendor` except recording.

## Notes / out of scope

`smart_compact` is still prepended by the two Anthropic handlers post-build (it applies to Anthropic inbound only); folding it into the builder would change behavior, so it's intentionally left as-is. Full `internal/server` and `internal/protocol/transform` suites pass.

https://claude.ai/code/session_01R9Gy8npezszdCGAGKGo5NK