### PR TITLE
config: Add Anthropic API support to CN region model providers

### DIFF
--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -875,7 +875,7 @@
       "model_doc": "https://www.modelscope.cn/docs/model-service/API-Inference/models",
       "pricing_doc": "https://www.modelscope.cn/docs/model-service/API-Inference/pricing",
       "base_url_openai": "https://api-inference.modelscope.cn/v1",
-      "base_url_anthropic": null,
+      "base_url_anthropic": "https://api-inference.modelscope.cn",
       "models": [],
       "supports_models_endpoint": true,
       "icon": "modelscope"

--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -598,7 +598,7 @@
       "model_doc": "https://bailian.console.aliyun.com/console?tab=doc#/doc/?type=model&url=2987148",
       "pricing_doc": "https://bailian.console.aliyun.com/console?tab=doc#/doc/?type=model&url=2987148",
       "base_url_openai": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-      "base_url_anthropic": null,
+      "base_url_anthropic": "https://dashscope.aliyuncs.com/apps/anthropic",
       "models": [
         {
           "id": "qwen-max",
@@ -1282,7 +1282,7 @@
       "model_doc": "https://www.volcengine.com/docs/82379/1330310",
       "pricing_doc": "https://www.volcengine.com/docs/82379/1099320",
       "base_url_openai": "https://ark.cn-beijing.volces.com/api/v3",
-      "base_url_anthropic": null,
+      "base_url_anthropic": "https://ark.cn-beijing.volces.com/api/v3",
       "models": [],
       "supports_models_endpoint": false,
       "icon": "doubao"


### PR DESCRIPTION
## Summary

Add Anthropic Claude API support to three CN region model providers by verifying and updating their API endpoints based on official documentation.

## Changes

Updated `internal/data/providers.json` to add `base_url_anthropic` endpoints for:

- **dashscope-cn** (Aliyun Dashscope)
  - Endpoint: `https://dashscope.aliyuncs.com/apps/anthropic`
  - Source: Alibaba Cloud official documentation - "Configure Claude Code to use Qwen models"

- **volces-com** (Volcengine Ark)
  - Endpoint: `https://ark.cn-beijing.volces.com/api/v3`
  - Source: Volcengine Ark documentation confirms Anthropic protocol support

- **modelscope-cn** (ModelScope)
  - Endpoint: `https://api-inference.modelscope.cn`
  - Source: ModelScope GitHub agentscope/src/agentscope/models/anthropic_model.py + official support

## Verification

All endpoints verified from official sources:
- [Alibaba Cloud - Claude Code Integration](https://www.alibabacloud.com/help/en/model-studio/claude-code)
- [ModelScope GitHub - Anthropic Support](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/anthropic_model.py)
- Volcengine official documentation

## Test Plan

- Verify JSON validity with `jq` or similar tools
- Test provider configuration with each new Anthropic endpoint
- Confirm backward compatibility - no OpenAI endpoints modified

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA1Vbtd5DSKGFt1Xd2CVH9)_