### PR TITLE
Config: Add Anthropic API support to international providers

### DIFF
--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -1711,7 +1711,7 @@
       "model_doc": "https://deepinfra.com/models",
       "pricing_doc": "https://deepinfra.com/pricing",
       "base_url_openai": "https://api.deepinfra.com/v1/openai",
-      "base_url_anthropic": null,
+      "base_url_anthropic": "https://api.deepinfra.com/anthropic",
       "models": [],
       "supports_models_endpoint": true,
       "icon": "deepinfra"


### PR DESCRIPTION
## Summary

Add Anthropic Claude API support to international region model providers by verifying official documentation and endpoints.

## Changes

Updated `internal/data/providers.json` to add `base_url_anthropic` endpoint for:

- **deepinfra-com** (DeepInfra)
  - Endpoint: `https://api.deepinfra.com/anthropic`
  - Source: DeepInfra official documentation - "Anthropic SDK & Claude Code" integration guide

## Research Results

Investigated 11 international providers for Anthropic support. Only DeepInfra had official, verified support:

**Verified No Official Support:**
- Mistral AI - supports Anthropic MCP but no API endpoint
- Groq - no official Anthropic endpoint (community proxy solutions only)
- Together AI - no verified Anthropic endpoint
- Cerebras - community third-party gateway only, not official
- Perplexity - accesses Claude via Bedrock, not Perplexity's own endpoint
- Hyperbolic - OpenAI-compatible only
- OpenCode Zen - supports user-provided Anthropic keys but no own endpoint
- NVIDIA NIM - OpenAI-compatible only
- Stepfun - compatibility issues with Anthropic's protocol

## Verification

- [DeepInfra Anthropic Integration](https://docs.deepinfra.com/integrations/anthropic)
- [DeepInfra Claude Code Setup](https://docs.deepinfra.com/integrations/anthropic)

## Test Plan

- Verify JSON validity
- Test DeepInfra endpoint with Anthropic SDK
- Confirm backward compatibility

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA1Vbtd5DSKGFt1Xd2CVH9)_