### PR TITLE
ci: replace issue template system field with OS & arch dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug in Tingly-Box
+title: "[BUG] "
 labels: ["bug"]
 body:
   - type: input
@@ -11,12 +12,19 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: system
+  - type: dropdown
+    id: os
     attributes:
-      label: System Information
-      description: OS, architecture, and any relevant environment details
-      placeholder: "e.g. macOS 14.0 arm64 / Ubuntu 22.04 x86_64"
+      label: OS & Architecture
+      description: Which operating system and CPU architecture are you running Tingly-Box on?
+      options:
+        - macOS Apple Silicon (M-chip)
+        - macOS Intel
+        - Windows x86_64
+        - Windows ARM64
+        - Linux x86_64
+        - Linux ARM64
+        - Other
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or improvement
+title: "[Feature] "
 labels: ["enhancement"]
 body:
   - type: input
@@ -11,12 +12,19 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: system
+  - type: dropdown
+    id: os
     attributes:
-      label: System Information
-      description: OS, architecture, and any relevant environment details
-      placeholder: "e.g. macOS 14.0 arm64 / Ubuntu 22.04 x86_64"
+      label: OS & Architecture
+      description: Which operating system and CPU architecture are you running Tingly-Box on?
+      options:
+        - macOS Apple Silicon (M-chip)
+        - macOS Intel
+        - Windows x86_64
+        - Windows ARM64
+        - Linux x86_64
+        - Linux ARM64
+        - Other
     validations:
       required: true
 


### PR DESCRIPTION
Convert the free-text System Information input into a single dropdown combining OS and CPU architecture (macOS Apple Silicon/Intel, Windows x86_64/ARM64, Linux x86_64/ARM64, Other) in bug_report.yml and feature_request.yml for easier, more consistent selection.