### PR TITLE
ux(frontend): improve model select dialog with search and provider memory

### DIFF
--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -227,6 +227,19 @@ func (m *Manager) isProviderEnabled(provider *typ.Provider) bool {
 	return true
 }
 
+// IsProviderSupported reports whether the provider has a registered quota
+// fetcher. When false, the caller should skip quota fetching rather than
+// emitting a misleading "unsupported provider type" error for the response.
+func (m *Manager) IsProviderSupported(providerUUID string) bool {
+	provider, err := m.providerMgr.GetProviderByUUID(providerUUID)
+	if err != nil || provider == nil {
+		return false
+	}
+	providerType := inferProviderType(provider)
+	_, ok := m.registry.Get(providerType)
+	return ok
+}
+
 // fetchProviderQuota 获取单个供应商的配额
 // 总是返回一个 ProviderUsage（成功或包含错误信息），并保存到 store。
 func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider) (*ProviderUsage, error) {

--- a/frontend/src/components/ModelSelectDialog.tsx
+++ b/frontend/src/components/ModelSelectDialog.tsx
@@ -5,6 +5,7 @@ import { useProviderModels } from '@/hooks/useProviderModels';
 import { useGridLayout } from '@/hooks/useGridLayout';
 import { useProviderGroups } from '@/hooks/useProviderGroups';
 import { useModelSelection } from '@/hooks/useModelSelection';
+import { useRecentModels } from '@/hooks/useRecentModels';
 import { ModelSelectProvider, useModelSelectContext } from '@/contexts/ModelSelectContext';
 import type { Provider } from '@/types/provider';
 import { getModelTypeInfo } from '@/utils/modelUtils';
@@ -58,15 +59,25 @@ function ModelSelectTabInner({
     } = useModelSelectContext();
 
     const { handleModelSelect } = useModelSelection({ onSelected });
+    const { recentModels, lastProvider } = useRecentModels();
 
     const {
         groupedProviders,
         flattenedProviders,
     } = useProviderGroups(providers, singleProvider);
 
-    // Use external activeTab if provided, otherwise use internal state
-    // Add fallback to prevent flickering: use selectedProvider or first available provider
-    const currentTab = externalActiveTab ?? internalCurrentTab ?? selectedProvider ?? flattenedProviders[0]?.uuid;
+    // Use external activeTab if provided, otherwise use internal state.
+    // Fallback chain to prevent flickering:
+    //   1. externalActiveTab — parent-controlled tab
+    //   2. internalCurrentTab — user's in-session tab switch
+    //   3. selectedProvider — lock onto the selected provider if a model is chosen
+    //   4. lastProvider — remember the last chosen provider when nothing is selected
+    //   5. first available provider — final default
+    const currentTab = externalActiveTab
+        ?? internalCurrentTab
+        ?? (selectedProvider && selectedModel ? selectedProvider : undefined)
+        ?? lastProvider
+        ?? flattenedProviders[0]?.uuid;
 
     const handleTabChange = useCallback(async (providerUuid: string) => {
         if (externalActiveTab === undefined) {
@@ -157,8 +168,20 @@ function ModelSelectTabInner({
                 // Mark this provider as initialized
                 initializedProviderRef.current = selectedProvider;
             }
+        } else if (lastProvider) {
+            // No selection yet: open on the most recently used provider.
+            // Fetch its models so the right panel is populated on first open.
+            if (externalActiveTab === undefined) {
+                setInternalCurrentTab(lastProvider);
+            }
+            fetchModels(lastProvider);
+            const targetProvider = flattenedProviders.find(p => p.uuid === lastProvider);
+            if (targetProvider && onProviderChange) {
+                onProviderChange(targetProvider);
+            }
+            initializedProviderRef.current = lastProvider;
         }
-    }, [selectedProvider, flattenedProviders, externalActiveTab, onProviderChange, setInternalCurrentTab, fetchModels]);
+    }, [selectedProvider, lastProvider, flattenedProviders, externalActiveTab, onProviderChange, setInternalCurrentTab, fetchModels]);
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%', width: '100%' }}>

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -243,31 +243,16 @@ export function ModelsPanel({
             <Box sx={{ flex: 1, overflowY: 'auto', p: 2 }}>
                 <Stack spacing={2}>
                 {/* Controls */}
-                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Stack direction="row" justifyContent="flex-end" alignItems="center" spacing={2}>
+                    {/* Action buttons */}
                     <Stack direction="row" alignItems="center" spacing={1}>
-                        <TextField
-                            size="small"
-                            placeholder="Search models..."
-                            value={searchTerms[provider.uuid] || ''}
-                            onChange={(e) => handleSearchChange(provider.uuid, e.target.value)}
-                            slotProps={{
-                                input: {
-                                    startAdornment: (
-                                        <InputAdornment position="start">
-                                            <SearchIcon />
-                                        </InputAdornment>
-                                    ),
-                                },
-                            }}
-                            sx={{ width: 200 }}
-                        />
                         <Button
                             variant="outlined"
                             startIcon={<AddCircleOutlineIcon />}
                             onClick={() => onCustomModelEdit(provider)}
                             sx={{ height: 40, minWidth: 100 }}
                         >
-                            Customize
+                            Custom Model
                         </Button>
                         <Button
                             variant="outlined"
@@ -302,10 +287,30 @@ export function ModelsPanel({
                             </Button>
                         )}
                     </Stack>
-                    <Typography variant="caption" color="text.secondary">
-                        {pagination.totalItems} models
-                    </Typography>
+
+                    {/* Search box */}
+                    <TextField
+                        size="small"
+                        placeholder="Search models..."
+                        value={searchTerms[provider.uuid] || ''}
+                        onChange={(e) => handleSearchChange(provider.uuid, e.target.value)}
+                        slotProps={{
+                            input: {
+                                startAdornment: (
+                                    <InputAdornment position="start">
+                                        <SearchIcon />
+                                    </InputAdornment>
+                                ),
+                            },
+                        }}
+                        sx={{ width: 200 }}
+                    />
                 </Stack>
+
+                {/* Model count */}
+                <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>
+                    {pagination.totalItems} models
+                </Typography>
 
                 {/* New Models Section */}
                 {newModels[provider.uuid]?.newModels && newModels[provider.uuid].newModels.length > 0 && (

--- a/frontend/src/components/model-select/ProviderSidebar.tsx
+++ b/frontend/src/components/model-select/ProviderSidebar.tsx
@@ -1,6 +1,6 @@
-import { CheckCircle } from '@/components/icons';
-import { Box, Stack, Typography } from '@mui/material';
-import React from 'react';
+import { CheckCircle, Search } from '@/components/icons';
+import { Box, Stack, Typography, TextField, InputAdornment } from '@mui/material';
+import React, { useState, useMemo } from 'react';
 import type { Provider } from '../../types/provider';
 import { AuthTypeBadge } from '../AuthTypeBadge';
 import { ApiStyleBadge } from '../ApiStyleBadge';
@@ -18,6 +18,25 @@ export function ProviderSidebar({
     selectedProvider,
     onTabChange,
 }: ProviderSidebarProps) {
+    const [providerSearchTerm, setProviderSearchTerm] = useState('');
+
+    // Filter providers based on search term
+    const filteredGroupedProviders = useMemo(() => {
+        if (!providerSearchTerm.trim()) {
+            return groupedProviders;
+        }
+
+        const searchLower = providerSearchTerm.toLowerCase();
+        return groupedProviders
+            .map(group => ({
+                authType: group.authType,
+                providers: group.providers.filter(provider =>
+                    provider.name.toLowerCase().includes(searchLower) ||
+                    provider.uuid.toLowerCase().includes(searchLower)
+                ),
+            }))
+            .filter(group => group.providers.length > 0);
+    }, [groupedProviders, providerSearchTerm]);
     return (
         <Box sx={{
             width: 300,
@@ -29,9 +48,22 @@ export function ProviderSidebar({
         }}>
             {/* Header */}
             <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                    Credentials ({groupedProviders.flatMap(g => g.providers).length})
-                </Typography>
+                <TextField
+                    size="small"
+                    placeholder="Search credentials..."
+                    value={providerSearchTerm}
+                    onChange={(e) => setProviderSearchTerm(e.target.value)}
+                    slotProps={{
+                        input: {
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <Search />
+                                </InputAdornment>
+                            ),
+                        },
+                    }}
+                    sx={{ width: 200 }}
+                />
             </Box>
 
             {/* Vertical Navigation with Auth Type Grouping */}
@@ -48,7 +80,7 @@ export function ProviderSidebar({
                     },
                 }}
             >
-                {groupedProviders.map((group) => {
+                {filteredGroupedProviders.map((group) => {
                     return (
                         <Box key={`group-${group.authType}`}>
                             {/* Auth Type Header */}

--- a/frontend/src/hooks/useRecentModels.ts
+++ b/frontend/src/hooks/useRecentModels.ts
@@ -4,8 +4,10 @@ import { createEventSystem } from '../utils/eventSystem';
 
 // Local storage key for recent models
 const RECENT_MODELS_STORAGE_KEY = 'tingly_recent_models';
+const LAST_PROVIDER_STORAGE_KEY = 'tingly_last_provider';
 const MAX_RECENT_MODELS = 3;
 const DEFAULT_RECENT_MODELS = {};
+const DEFAULT_LAST_PROVIDER = '';
 
 // Type for recent models data
 export type RecentModelsData = { [providerUuid: string]: string[] };
@@ -20,8 +22,10 @@ export const RECENT_MODELS_UPDATE_EVENT = recentModelsEvent.eventName;
 
 // Custom hook to manage recent models
 export const useRecentModels = () => {
-    const { data: recentModels, version, saveData, removeKey, setData, refetch } =
+    const { data: recentModels, version, saveData, removeKey, setData, refetch, loadData } =
         useLocalStorage<RecentModelsData>(RECENT_MODELS_STORAGE_KEY, DEFAULT_RECENT_MODELS);
+    const { data: lastProvider, saveData: saveLastProvider } =
+        useLocalStorage<Record<string, string>>(LAST_PROVIDER_STORAGE_KEY, {});
 
     // Listen for recent models updates from other components and reload
     useEffect(() => {
@@ -42,10 +46,14 @@ export const useRecentModels = () => {
         const newModels = [model, ...filtered].slice(0, MAX_RECENT_MODELS);
 
         if (saveData(providerUuid, newModels)) {
-            setData(prev => ({ ...prev, [providerUuid]: newModels }));
+            const currentData = loadData();
+            setData({ ...currentData, [providerUuid]: newModels });
             recentModelsEvent.dispatch({ providerUuid, modelName: model });
         }
-    }, [recentModels, saveData, setData]);
+
+        // Also update last used provider
+        saveLastProvider('default', providerUuid);
+    }, [recentModels, saveData, setData, saveLastProvider, loadData]);
 
     // Get recent models for a specific provider
     const getRecentModels = useCallback((providerUuid: string): string[] => {
@@ -55,14 +63,13 @@ export const useRecentModels = () => {
     // Clear recent models for a specific provider
     const clearRecentModels = useCallback((providerUuid: string) => {
         if (removeKey(providerUuid)) {
-            setData(prev => {
-                const newModels = { ...prev };
-                delete newModels[providerUuid];
-                return newModels;
-            });
+            const currentData = loadData();
+            const newModels = { ...currentData };
+            delete newModels[providerUuid];
+            setData(newModels);
             recentModelsEvent.dispatch({ providerUuid, modelName: '' });
         }
-    }, [removeKey, setData]);
+    }, [removeKey, setData, loadData]);
 
     // Helper functions for backward compatibility
     const loadRecentModelsFromStorage = useCallback(() => {
@@ -85,8 +92,10 @@ export const useRecentModels = () => {
 
     // Helper to listen for recent models updates (backward compatibility)
     const listenForRecentModelsUpdates = (callback: (providerUuid: string, modelName: string) => void) => {
-        return recentModelsEvent.listen(({ providerUuid, modelName }) => {
-            callback(providerUuid, modelName);
+        return recentModelsEvent.listen((payload) => {
+            if (payload) {
+                callback(payload.providerUuid, payload.modelName);
+            }
         });
     };
 
@@ -102,5 +111,6 @@ export const useRecentModels = () => {
         removeRecentModelsFromStorage,
         dispatchRecentModelsUpdate,
         listenForRecentModelsUpdates,
+        lastProvider: lastProvider['default'] || '',
     };
 };

--- a/internal/server/module/provider_quota/handler.go
+++ b/internal/server/module/provider_quota/handler.go
@@ -26,6 +26,9 @@ type Manager interface {
 	RefreshProvider(ctx context.Context, providerUUID string) (*quota.ProviderUsage, error)
 	// Summary 获取配额汇总
 	Summary(ctx context.Context) (*quota.Summary, error)
+	// IsProviderSupported reports whether the provider has a registered quota
+	// fetcher. Callers should skip quota fetching when this returns false.
+	IsProviderSupported(providerUUID string) bool
 	// StartAutoRefresh 启动自动刷新
 	StartAutoRefresh(ctx context.Context)
 	// StopAutoRefresh 停止自动刷新

--- a/internal/server/provider_handler.go
+++ b/internal/server/provider_handler.go
@@ -548,13 +548,19 @@ func (s *Server) GetProviderModelsByUUID(c *gin.Context) {
 	// Step 1: Try DB cache (API-sourced, 1h TTL)
 	models := providerModelManager.GetModels(uid)
 	source := ModelCacheSourceDB
-	expiresAt := time.Now().Add(1 * time.Hour)
+	// Default to far-future for sources that never expire (VModel); other
+	// sources override this below with their own TTL. Avoids serializing a
+	// zero time.Time ("0001-01-01T00:00:00Z") in the response.
+	const neverExpires = 20 * 365 * 24 * time.Hour
+	expiresAt := time.Now().Add(neverExpires)
 	lastUpdated := ""
 
 	if len(models) > 0 {
 		if _, updated, exists := providerModelManager.GetProviderInfo(uid); exists {
 			lastUpdated = updated
 		}
+		// DB cache has a 1h TTL (see data.ModelCacheTTL).
+		expiresAt = time.Now().Add(1 * time.Hour)
 	} else {
 		// Cache miss or stale — proceed to fallback
 		p, provErr := s.config.GetProviderByUUID(uid)
@@ -565,6 +571,7 @@ func (s *Server) GetProviderModelsByUUID(c *gin.Context) {
 					models = p.VModelDetail.Models
 					source = ModelCacheSourceVModel
 				}
+				// VModel lists are static — never expire.
 			} else {
 				// Step 2b: Try Provider API
 				apiErr := s.config.FetchAndSaveProviderModels(uid)
@@ -572,6 +579,8 @@ func (s *Server) GetProviderModelsByUUID(c *gin.Context) {
 					models = providerModelManager.GetModels(uid)
 					if len(models) > 0 {
 						source = ModelCacheSourceAPI
+						// Freshly fetched API models follow the DB cache TTL.
+						expiresAt = time.Now().Add(1 * time.Hour)
 					}
 				}
 
@@ -583,6 +592,7 @@ func (s *Server) GetProviderModelsByUUID(c *gin.Context) {
 						_ = providerModelManager.SaveModels(p, templateModels, db.ModelSourceTemplate)
 						models = templateModels
 						source = ModelCacheSourceTemplate
+						expiresAt = time.Now().Add(1 * time.Hour)
 					}
 				}
 			}
@@ -597,9 +607,11 @@ func (s *Server) GetProviderModelsByUUID(c *gin.Context) {
 		LastUpdated: lastUpdated,
 	}
 
-	// Attach quota information if quota manager is available
-	// Use GetQuotaNoCache to always get fresh data from DB (bypasses cache/expiration logic)
-	if s.quotaManager != nil {
+	// Attach quota information if quota manager is available AND the provider
+	// type is supported. Unsupported providers (e.g. unknown API base domains)
+	// would otherwise surface a misleading "unsupported provider type" error
+	// in the response — skip quota entirely in that case.
+	if s.quotaManager != nil && s.quotaManager.IsProviderSupported(uid) {
 		var ctx context.Context = c.Request.Context()
 		quotaData, err := s.quotaManager.GetQuotaNoCache(ctx, uid)
 		if err == nil && quotaData != nil {


### PR DESCRIPTION
Model selection UX was cumbersome for users managing multiple providers. 
Added search functionality and provider memory to streamline the workflow.

### Major
- Added provider search to filter credentials by name or UUID
- Added model search with repositioned UI for better accessibility
- Dialog now remembers and opens on the last-used provider
- Fixed misleading quota errors for unsupported provider types

### Minor
- Improved model cache expiration handling (VModel never expires, API 1h TTL)
- Fixed `useRecentModels` hook to properly update storage state
- Renamed "Customize" button to "Custom Model" for clarity