### PR TITLE
chore(servertest): remove dead code, quiet debug output, harden LB e2e assertions

### DIFF
--- a/internal/servertest/health_filter_test.go
+++ b/internal/servertest/health_filter_test.go
@@ -171,8 +171,10 @@ func TestHealthFilter_Recovery(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
 
-	// Wait for recovery timeout
-	time.Sleep(1100 * time.Millisecond)
+	// Poll until the service actually recovers (asserts the unhealthy→healthy
+	// transition directly), instead of a fixed sleep that over/under-waits.
+	require.Eventually(t, func() bool { return healthMonitor.IsHealthy(serviceID) },
+		3*time.Second, 50*time.Millisecond, "service should recover to healthy")
 
 	// Service should be healthy again
 	service, err = lb.SelectService(rule)

--- a/internal/servertest/lb_virtual_validation_test.go
+++ b/internal/servertest/lb_virtual_validation_test.go
@@ -4,7 +4,6 @@
 package servertest
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -131,18 +130,19 @@ func TestLB_VirtualValidation_EqualProviders(t *testing.T) {
 		}
 	}
 
-	// Print a verdict table. A healthy balancer keeps the dominant provider
-	// well under ~70% for equal providers. Flag anything that concentrates.
-	fmt.Println("\n================ LOAD BALANCING VIRTUAL VALIDATION ================")
-	fmt.Printf("%-30s %8s %8s %14s\n", "TACTIC", "prov1", "prov2", "max-share")
+	// Log a verdict table (visible under `go test -v`). A healthy balancer keeps
+	// the dominant provider well under ~70% for equal providers; flag anything
+	// that concentrates.
+	t.Logf("================ LOAD BALANCING VIRTUAL VALIDATION ================")
+	t.Logf("%-30s %8s %8s %14s", "TACTIC", "prov1", "prov2", "max-share")
 	for _, r := range results {
 		verdict := "OK"
 		if r.maxSharePct >= 70.0 {
 			verdict = "BAD (concentrated)"
 		}
-		fmt.Printf("%-30s %8d %8d %12.1f%%  %s\n", r.name, r.p1, r.p2, r.maxSharePct, verdict)
+		t.Logf("%-30s %8d %8d %12.1f%%  %s", r.name, r.p1, r.p2, r.maxSharePct, verdict)
 	}
-	fmt.Println("==================================================================")
+	t.Logf("==================================================================")
 }
 
 func max(a, b int) int {

--- a/internal/servertest/load_balancing_test.go
+++ b/internal/servertest/load_balancing_test.go
@@ -864,10 +864,12 @@ func TestLoadBalancer_WeightedRandom(t *testing.T) {
 		Active: true,
 	}
 
-	// Test weighted selection (run multiple times to see distribution)
+	// Test weighted selection (run multiple times to see distribution).
+	// Large sample size: the random tactic has no seedable RNG, so a big N is what
+	// keeps the observed 3:1 ratio inside the tolerance band reliably.
 	provider1Count := 0
 	provider2Count := 0
-	total := 400
+	total := 2000
 
 	for i := 0; i < total; i++ {
 		service, err := lb.SelectService(rule)
@@ -1082,9 +1084,11 @@ func TestLoadBalancer_TokenBasedThreshold2(t *testing.T) {
 			providerCounts["provider-A"], providerCounts["provider-B"], providerCounts["provider-C"])
 	}
 
-	// Test that the CurrentServiceID is correctly maintained
-	// After 6 requests with threshold 2, the ID should be "provider-C:model-C"
-	expectedFinalServiceID := "provider-C:model-C"
+	// Test that the CurrentServiceID is correctly maintained. After 6 round-robin
+	// requests the final selection is provider-C; derive the expected ID from the
+	// product's own formatter (Service.ServiceID() → "provider/model") rather than
+	// hardcoding the separator.
+	expectedFinalServiceID := rule.Services[2].ServiceID() // provider-C
 	if rule.CurrentServiceID != expectedFinalServiceID {
 		t.Errorf("Expected CurrentServiceID = %s, got %s", expectedFinalServiceID, rule.CurrentServiceID)
 	}

--- a/internal/servertest/mock_provider.go
+++ b/internal/servertest/mock_provider.go
@@ -7,17 +7,16 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
-	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/tingly-dev/tingly-box/internal/server"
-
-	"github.com/tingly-dev/tingly-box/internal/constant"
-	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// MockProviderServer represents a mock AI provider server
+// MockProviderServer is a minimal, endpoint-keyed mock AI provider: callers set
+// an exact response (or error / streaming events) per endpoint and assert on
+// call counts and the last forwarded request. It is intentionally a "dumb echo"
+// — gateway-level tests (load balancing, auth, concurrency) want byte-exact
+// control over upstream responses, not protocol-correct generated ones. For
+// wire-format-correct fixtures use the vmodel benchmark instead
+// (see .design/vmodel-benchmark.md, "Phase 3 — servertest").
 type MockProviderServer struct {
 	server             *httptest.Server
 	responses          map[string]MockResponse
@@ -48,37 +47,6 @@ func CreateMockChatCompletionResponse(id, model, content string) map[string]inte
 			"prompt_tokens":     10,
 			"completion_tokens": 5,
 			"total_tokens":      15,
-		},
-	}
-}
-
-// CreateMockChatCompletionResponseWithToolCalls creates a mock response with function/tool calls
-func CreateMockChatCompletionResponseWithToolCalls(id, model, content string, toolCalls []map[string]interface{}) map[string]interface{} {
-	message := map[string]interface{}{
-		"role":    "assistant",
-		"content": content,
-	}
-
-	if len(toolCalls) > 0 {
-		message["tool_calls"] = toolCalls
-	}
-
-	return map[string]interface{}{
-		"id":      id,
-		"object":  "chat.completion",
-		"created": time.Now().Unix(),
-		"model":   model,
-		"choices": []map[string]interface{}{
-			{
-				"index":         0,
-				"message":       message,
-				"finish_reason": "tool_calls",
-			},
-		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     15,
-			"completion_tokens": 10,
-			"total_tokens":      25,
 		},
 	}
 }
@@ -119,14 +87,12 @@ func NewMockProviderServer() *MockProviderServer {
 // SetResponse configures a mock response for a specific endpoint
 func (m *MockProviderServer) SetResponse(endpoint string, response MockResponse) {
 	key := strings.TrimPrefix(endpoint, "/")
-	fmt.Printf("Setting response for endpoint: %s (key: %s)\n", endpoint, key)
 	m.responses[key] = response
 }
 
 // SetStreamingResponse configures a mock streaming response for a specific endpoint
 func (m *MockProviderServer) SetStreamingResponse(endpoint string, response MockStreamingResponse) {
 	key := strings.TrimPrefix(endpoint, "/")
-	fmt.Printf("Setting streaming response for endpoint: %s (key: %s)\n", endpoint, key)
 	m.streamingResponses = make(map[string]MockStreamingResponse)
 	m.streamingResponses[key] = response
 }
@@ -139,17 +105,13 @@ func (m *MockProviderServer) handleChatCompletions(w http.ResponseWriter, r *htt
 	m.callCount[endpoint]++
 	m.mutex.Unlock()
 
-	// Parse request for debugging
+	// Parse request to record it and detect streaming.
 	var reqBody map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err == nil {
 		m.mutex.Lock()
 		m.lastRequest[endpoint] = reqBody
 		m.mutex.Unlock()
 
-		// Debug: log the received request
-		fmt.Printf("Mock server received request for %s: %+v\n", endpoint, reqBody)
-
-		// Check if this is a streaming request
 		if stream, ok := reqBody["stream"].(bool); ok && stream {
 			m.handleStreamingRequest(w, r, endpoint, reqBody)
 			return
@@ -159,13 +121,10 @@ func (m *MockProviderServer) handleChatCompletions(w http.ResponseWriter, r *htt
 	response, exists := m.responses[endpoint]
 	if !exists {
 		// Default successful response
-		fmt.Printf("No configured response for %s, using default\n", endpoint)
 		response = MockResponse{
 			StatusCode: 200,
 			Body:       CreateMockChatCompletionResponse("chatcmpl-mock", "gpt-3.5-turbo", "Mock response from provider"),
 		}
-	} else {
-		fmt.Printf("Found configured response for %s\n", endpoint)
 	}
 
 	// Apply delay if configured
@@ -198,29 +157,16 @@ func (m *MockProviderServer) handleMessages(w http.ResponseWriter, r *http.Reque
 	m.callCount[endpoint]++
 	m.mutex.Unlock()
 
-	// Debug: log the endpoint
-	fmt.Printf("handleMessages called for endpoint: %s (URL: %s)\n", endpoint, r.URL.Path)
-
-	// Parse request for debugging
+	// Parse request to record it and detect streaming.
 	var reqBody map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err == nil {
 		m.mutex.Lock()
 		m.lastRequest[endpoint] = reqBody
 		m.mutex.Unlock()
 
-		// Debug: log the received request body
-		fmt.Printf("Mock server received request for %s: %+v\n", endpoint, reqBody)
-
-		// Check if this is a streaming request
-		if stream, ok := reqBody["stream"].(bool); ok {
-			fmt.Printf("Stream flag detected: %v\n", stream)
-			if stream {
-				fmt.Printf("Handling streaming request for %s\n", endpoint)
-				m.handleStreamingRequest(w, r, endpoint, reqBody)
-				return
-			}
-		} else {
-			fmt.Printf("No stream flag in request\n")
+		if stream, ok := reqBody["stream"].(bool); ok && stream {
+			m.handleStreamingRequest(w, r, endpoint, reqBody)
+			return
 		}
 	}
 
@@ -284,7 +230,6 @@ func (m *MockProviderServer) handleStreamingRequest(w http.ResponseWriter, r *ht
 	// Get streaming response configuration
 	streamingResp, exists := m.streamingResponses[endpoint]
 	if !exists {
-		fmt.Printf("No configured streaming response for %s, using default\n", endpoint)
 		// Default streaming response
 		streamingResp = MockStreamingResponse{
 			Events: []string{
@@ -294,13 +239,10 @@ func (m *MockProviderServer) handleStreamingRequest(w http.ResponseWriter, r *ht
 				`data: [DONE]`,
 			},
 		}
-	} else {
-		fmt.Printf("Found configured streaming response for %s with %d events\n", endpoint, len(streamingResp.Events))
 	}
 
 	// Send streaming events
 	for _, event := range streamingResp.Events {
-		fmt.Printf("Sending event: %s\n", event)
 		fmt.Fprintf(w, "%s\n\n", event)
 		flusher.Flush()
 		// Small delay to simulate real streaming
@@ -346,262 +288,4 @@ func (m *MockProviderServer) Reset() {
 	defer m.mutex.Unlock()
 	m.callCount = make(map[string]int)
 	m.lastRequest = make(map[string]interface{})
-}
-
-// MockProviderTestSuite provides a comprehensive test suite for provider testing
-type MockProviderTestSuite struct {
-	t            *testing.T
-	mockServer   *MockProviderServer
-	testServer   *TestServer
-	originalBase string
-}
-
-// NewMockProviderTestSuite creates a new test suite
-func NewMockProviderTestSuite(t *testing.T) *MockProviderTestSuite {
-	suite := &MockProviderTestSuite{
-		t:          t,
-		mockServer: NewMockProviderServer(),
-	}
-
-	// Setup test server
-	suite.testServer = NewTestServer(t)
-
-	// Add mock provider
-	providerName := "mock-provider"
-
-	// Add provider through the config
-	provider := &typ.Provider{
-		UUID:    providerName,
-		Name:    providerName,
-		APIBase: suite.mockServer.GetURL(),
-		Token:   "mock-token",
-		Enabled: true,
-		Timeout: int64(constant.DefaultRequestTimeout),
-	}
-	err := suite.testServer.appConfig.AddProvider(provider)
-	if err != nil {
-		suite.t.Fatalf("Failed to add mock provider: %v", err)
-	}
-
-	return suite
-}
-
-// TestSuccessfulRequest tests a successful chat completion request
-func (suite *MockProviderTestSuite) TestSuccessfulRequest() {
-	// Configure mock response
-	mockResponse := map[string]interface{}{
-		"id":      "chatcmpl-test123",
-		"object":  "chat.completion",
-		"created": time.Now().Unix(),
-		"model":   "gpt-3.5-turbo",
-		"choices": []map[string]interface{}{
-			{
-				"index": 0,
-				"message": map[string]interface{}{
-					"role":    "assistant",
-					"content": "Hello! This is a test response.",
-				},
-				"finish_reason": "stop",
-			},
-		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     12,
-			"completion_tokens": 8,
-			"total_tokens":      20,
-		},
-	}
-
-	suite.mockServer.SetResponse("/v1/chat/completions", MockResponse{
-		StatusCode: 200,
-		Body:       mockResponse,
-	})
-
-	// Create test request
-	requestBody := CreateTestChatRequest("gpt-3.5-turbo", []map[string]string{
-		{"role": "user", "content": "Hello, test!"},
-	})
-
-	// Make request
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/v1/chat/completions", CreateJSONBody(requestBody))
-	req.Header.Set("Authorization", "Bearer valid-test-token")
-
-	suite.testServer.ginEngine.ServeHTTP(w, req)
-
-	// Assertions
-	assert.Equal(suite.t, 200, w.Code)
-	assert.Equal(suite.t, 1, suite.mockServer.GetCallCount("/v1/chat/completions"))
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(suite.t, err)
-	assert.Equal(suite.t, "chatcmpl-test123", response["id"])
-
-	choices, ok := response["choices"].([]interface{})
-	assert.True(suite.t, ok)
-	assert.Len(suite.t, choices, 1)
-
-	firstChoice, ok := choices[0].(map[string]interface{})
-	assert.True(suite.t, ok)
-
-	message, ok := firstChoice["message"].(map[string]interface{})
-	assert.True(suite.t, ok)
-	assert.Equal(suite.t, "Hello! This is a test response.", message["content"])
-
-	usage, ok := response["usage"].(map[string]interface{})
-	assert.True(suite.t, ok)
-	assert.Equal(suite.t, float64(20), usage["total_tokens"]) // JSON numbers are float64
-}
-
-// TestProviderError tests error handling from provider
-func (suite *MockProviderTestSuite) TestProviderError() {
-	// Configure mock error response
-	suite.mockServer.SetResponse("/v1/chat/completions", MockResponse{
-		StatusCode: 401,
-		Error:      "Invalid API key",
-	})
-
-	// Create test request
-	requestBody := CreateTestChatRequest("gpt-3.5-turbo", []map[string]string{
-		{"role": "user", "content": "Hello, test!"},
-	})
-
-	// Make request
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/v1/chat/completions", CreateJSONBody(requestBody))
-	req.Header.Set("Authorization", "Bearer valid-test-token")
-
-	suite.testServer.ginEngine.ServeHTTP(w, req)
-
-	// Assertions
-	assert.Equal(suite.t, 500, w.Code) // Internal server error due to provider error
-
-	var errorResp server.ErrorResponse
-	err := json.Unmarshal(w.Body.Bytes(), &errorResp)
-	assert.NoError(suite.t, err)
-	assert.Contains(suite.t, errorResp.Error.Message, "provider error")
-}
-
-// TestNetworkTimeout tests timeout handling
-func (suite *MockProviderTestSuite) TestNetworkTimeout() {
-	// Configure mock response with delay
-	suite.mockServer.SetResponse("/v1/chat/completions", MockResponse{
-		StatusCode: 200,
-		Delay:      2 * time.Second, // Longer than client timeout
-		Body:       CreateMockChatCompletionResponse("chatcmpl-timeout", "gpt-3.5-turbo", "Delayed response"),
-	})
-
-	// Create test request
-	requestBody := CreateTestChatRequest("gpt-3.5-turbo", []map[string]string{
-		{"role": "user", "content": "Hello, test!"},
-	})
-
-	// Make request
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/v1/chat/completions", CreateJSONBody(requestBody))
-	req.Header.Set("Authorization", "Bearer valid-test-token")
-
-	suite.testServer.ginEngine.ServeHTTP(w, req)
-
-	// Assertions - should fail due to timeout (client timeout is 30s in the actual implementation)
-	// For testing purposes, we'll just verify the call was made
-	assert.Equal(suite.t, 1, suite.mockServer.GetCallCount("/v1/chat/completions"))
-}
-
-// TestInvalidRequest tests handling of invalid requests
-func (suite *MockProviderTestSuite) TestInvalidRequest() {
-	// Test with missing model
-	requestBody := map[string]interface{}{
-		"messages": []map[string]string{
-			{"role": "user", "content": "Hello, test!"},
-		},
-	}
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/v1/chat/completions", CreateJSONBody(requestBody))
-	req.Header.Set("Authorization", "Bearer valid-test-token")
-
-	suite.testServer.ginEngine.ServeHTTP(w, req)
-
-	// Assertions
-	assert.Equal(suite.t, 400, w.Code)
-
-	var errorResp server.ErrorResponse
-	err := json.Unmarshal(w.Body.Bytes(), &errorResp)
-	assert.NoError(suite.t, err)
-	assert.Contains(suite.t, errorResp.Error.Message, "Model is required")
-}
-
-// TestRequestForwarding verifies correct request forwarding to provider
-func (suite *MockProviderTestSuite) TestRequestForwarding() {
-	// Configure mock response
-	suite.mockServer.SetResponse("/v1/chat/completions", MockResponse{
-		StatusCode: 200,
-		Body:       CreateMockChatCompletionResponse("chatcmpl-forward-test", "gpt-3.5-turbo", "Forwarded request response"),
-	})
-
-	// Create test request with specific parameters
-	requestBody := map[string]interface{}{
-		"model": "gpt-3.5-turbo",
-		"messages": []map[string]string{
-			{"role": "system", "content": "You are a helpful assistant."},
-			{"role": "user", "content": "Hello!"},
-		},
-		"stream":      false,
-		"temperature": 0.7,
-	}
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/v1/chat/completions", CreateJSONBody(requestBody))
-	req.Header.Set("Authorization", "Bearer valid-test-token")
-
-	suite.testServer.ginEngine.ServeHTTP(w, req)
-
-	// Verify request was forwarded correctly
-	assert.Equal(suite.t, 1, suite.mockServer.GetCallCount("/v1/chat/completions"))
-
-	lastRequest := suite.mockServer.GetLastRequest("/v1/chat/completions")
-	assert.NotNil(suite.t, lastRequest)
-	assert.Equal(suite.t, "gpt-3.5-turbo", lastRequest["model"])
-	assert.Equal(suite.t, false, lastRequest["stream"])
-	assert.Equal(suite.t, 0.7, lastRequest["temperature"])
-}
-
-// Cleanup cleans up the test suite
-func (suite *MockProviderTestSuite) Cleanup() {
-	suite.mockServer.Close()
-	Cleanup()
-}
-
-// RunMockProviderTests runs all mock provider tests
-func RunMockProviderTests(t *testing.T) {
-	t.Run("MockProvider_SuccessfulRequest", func(t *testing.T) {
-		suite := NewMockProviderTestSuite(t)
-		defer suite.Cleanup()
-		suite.TestSuccessfulRequest()
-	})
-
-	t.Run("MockProvider_ProviderError", func(t *testing.T) {
-		suite := NewMockProviderTestSuite(t)
-		defer suite.Cleanup()
-		suite.TestProviderError()
-	})
-
-	t.Run("MockProvider_NetworkTimeout", func(t *testing.T) {
-		suite := NewMockProviderTestSuite(t)
-		defer suite.Cleanup()
-		suite.TestNetworkTimeout()
-	})
-
-	t.Run("MockProvider_InvalidRequest", func(t *testing.T) {
-		suite := NewMockProviderTestSuite(t)
-		defer suite.Cleanup()
-		suite.TestInvalidRequest()
-	})
-
-	t.Run("MockProvider_RequestForwarding", func(t *testing.T) {
-		suite := NewMockProviderTestSuite(t)
-		defer suite.Cleanup()
-		suite.TestRequestForwarding()
-	})
 }

--- a/internal/servertest/server_test.go
+++ b/internal/servertest/server_test.go
@@ -382,10 +382,12 @@ func runLoadBalancingOpenAI(t *testing.T, ts *TestServer) {
 
 	t.Logf("Second load balance request status: %d", w2.Code)
 
-	// Both requests should be handled (may fail at provider level but routing works)
-	// Include 422 for cases where the model rule is not properly configured
-	assert.True(t, containsStatus(w1.Code, []int{200, 400, 422, 500}))
-	assert.True(t, containsStatus(w2.Code, []int{200, 400, 422, 500}))
+	// Both requests should be handled (may fail at provider level but routing works).
+	// Accept 401 (fake-token test providers legitimately return Unauthorized),
+	// 422 (model rule not fully configured), and other forwarding outcomes — the
+	// point is that routing reached a provider, not the upstream's verdict.
+	assert.True(t, containsStatus(w1.Code, []int{200, 400, 401, 422, 500}))
+	assert.True(t, containsStatus(w2.Code, []int{200, 400, 401, 422, 500}))
 }
 
 func runLoadBalancingAnthropic(t *testing.T, ts *TestServer) {
@@ -437,10 +439,12 @@ func runLoadBalancingAnthropic(t *testing.T, ts *TestServer) {
 
 	t.Logf("Second Anthropic load balance request status: %d", w2.Code)
 
-	// Both requests should be handled (may fail at provider level but routing works)
-	// Include 422 for cases where the model rule is not properly configured
-	assert.True(t, containsStatus(w1.Code, []int{200, 400, 422, 500}))
-	assert.True(t, containsStatus(w2.Code, []int{200, 400, 422, 500}))
+	// Both requests should be handled (may fail at provider level but routing works).
+	// Accept 401 (fake-token test providers legitimately return Unauthorized),
+	// 422 (model rule not fully configured), and other forwarding outcomes — the
+	// point is that routing reached a provider, not the upstream's verdict.
+	assert.True(t, containsStatus(w1.Code, []int{200, 400, 401, 422, 500}))
+	assert.True(t, containsStatus(w2.Code, []int{200, 400, 401, 422, 500}))
 }
 
 func runDirectMockServerTest(t *testing.T) {

--- a/internal/servertest/utils.go
+++ b/internal/servertest/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/config"
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
-	"github.com/tingly-dev/tingly-box/internal/protocol"
 	typ "github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -193,101 +191,6 @@ func AssertJSONResponse(t *testing.T, resp *http.Response, expectedStatus int, c
 
 	if checkFields != nil {
 		checkFields(data)
-	}
-}
-
-// CreateTestProvider creates a test provider configuration
-func CreateTestProvider(name, apiBase, token string) *typ.Provider {
-	return &typ.Provider{
-		Name:    name,
-		APIBase: apiBase,
-		Token:   token,
-		Enabled: true,
-		Timeout: int64(constant.DefaultRequestTimeout),
-	}
-}
-
-// CaptureRequest captures HTTP request details
-func CaptureRequest(handler gin.HandlerFunc) (*http.Request, map[string]interface{}, error) {
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-
-	// Create a test request
-	reqBody, _ := json.Marshal(map[string]interface{}{
-		"model":    "test-model",
-		"messages": []map[string]string{{"role": "user", "content": "test"}},
-	})
-
-	req, _ := http.NewRequest("POST", "/test", bytes.NewBuffer(reqBody))
-	req.Header.Set("Content-Type", "application/json")
-	c.Request = req
-
-	handler(c)
-
-	var requestData map[string]interface{}
-	json.NewDecoder(c.Request.Body).Decode(&requestData)
-
-	return req, requestData, nil
-}
-
-// AddTestProvider adds a single test provider
-func (ts *TestServer) AddTestProvider(t *testing.T, name, apiBase, apiStyle string, enabled bool) {
-	provider := &typ.Provider{
-		UUID:     name, // for test, use name as uuid for convenience
-		Name:     name,
-		APIBase:  apiBase,
-		APIStyle: protocol.APIStyle(apiStyle),
-		Token:    "test-token",
-		Enabled:  enabled,
-		Timeout:  int64(constant.DefaultRequestTimeout),
-	}
-	if err := ts.appConfig.AddProvider(provider); err != nil {
-		t.Fatalf("Failed to add provider %s: %v", name, err)
-	}
-}
-
-// AddTestProviderWithURL adds a provider with a specific URL
-func (ts *TestServer) AddTestProviderWithURL(t *testing.T, name, url, apiStyle string, enabled bool) {
-	provider := &typ.Provider{
-		UUID:     name, // use name as uuid for convenience
-		Name:     name,
-		APIBase:  url,
-		APIStyle: protocol.APIStyle(apiStyle),
-		Token:    "test-token",
-		Enabled:  enabled,
-		Timeout:  int64(constant.DefaultRequestTimeout),
-	}
-	if err := ts.appConfig.AddProvider(provider); err != nil {
-		t.Fatalf("Failed to add provider %s: %v", name, err)
-	}
-}
-
-// AddTestRule adds a test rule that routes to a specific provider
-func (ts *TestServer) AddTestRule(t *testing.T, requestModel, providerName, model string) {
-	// Create a simple rule with proper LBTactic
-	rule := typ.Rule{
-		UUID:          requestModel,
-		Scenario:      typ.ScenarioOpenAI,
-		RequestModel:  requestModel,
-		ResponseModel: model,
-		Services: []*loadbalance.Service{
-			{
-				Provider:   providerName,
-				Model:      model,
-				Weight:     1,
-				Active:     true,
-				TimeWindow: 300,
-			},
-		},
-		LBTactic: typ.Tactic{
-			Type:   loadbalance.TacticAdaptive,
-			Params: typ.DefaultAdaptiveParams(),
-		},
-		Active: true,
-	}
-
-	if err := ts.appConfig.GetGlobalConfig().AddRequestConfig(rule); err != nil {
-		t.Fatalf("Failed to add rule %s: %v", requestModel, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Hygiene + reliability pass over `internal/servertest` — the follow-up deferred from the benchmark-foundation PR (#1218), kept separate so that PR stayed scoped. **No production code changes.** After this, the **full `-tags e2e` servertest suite is green** (it had a long-standing failure on `main`).

## Changes

### `mock_provider.go` — remove dead scaffolding + debug spam
- Delete dead `MockProviderTestSuite` + `RunMockProviderTests` + `Test*` methods (~250 lines, never invoked) and the dead `CreateMockChatCompletionResponseWithToolCalls` helper.
- Strip 13 `fmt.Printf`/`Println` debug lines; collapse the now-empty stream-flag branches. 607 → 291 lines. **Public API unchanged.**

### `utils.go` — remove dead exported helpers
- Delete 5 helpers with verified zero callers (`CreateTestProvider`, `CaptureRequest`, `AddTestProvider`, `AddTestProviderWithURL`, `AddTestRule`) + the now-unused `net/http/httptest` and `internal/protocol` imports.

### `lb_virtual_validation_test.go` — quiet the diagnostic table
- Convert the 4 `fmt.Println/Printf` table lines to `t.Logf` (shown only under `-v`); drop the now-unused `fmt` import. Last `fmt.Print*` in the package.

### `server_test.go` — accept 401 in the LB-mock e2e assertions
- The two LB-mock tests forward to fake-token test providers that legitimately return **401**. Widen the accepted status set to `{200,400,401,422,500}` with a clarifying comment. Widening a `containsStatus` set can't turn a passing assertion into a failure.

### Reliability hardening (bucket D)
- **`TestLoadBalancer_TokenBasedThreshold2`** — was failing on `main`. The round-robin logic is correct; the assertion just hardcoded `provider-C:model-C` (colon) while the canonical `Service.ServiceID()` is `provider-C/model-C` (slash). Now derives the expected ID from `rule.Services[2].ServiceID()`. **This was the last failing e2e test.**
- **`TestHealthFilter_Recovery`** — replace `time.Sleep(1100ms)` with `require.Eventually(healthMonitor.IsHealthy(serviceID), 3s, 50ms)`; waits exactly as long as recovery needs and asserts the unhealthy→healthy transition directly.
- **`TestLoadBalancer_WeightedRandom`** — bump sample size 400 → 2000 (the random tactic has no seedable RNG) so the 3:1 ratio stays inside the `[2.2,4.2]` tolerance reliably.

## Validation

- `go build`, `go vet` (plain **and** `-tags e2e`), `gofmt` on `./internal/servertest/...` — clean.
- `go test ./internal/servertest/...` (plain) — green.
- `go test -tags e2e ./internal/servertest/` (full suite) — **green** (previously failed on `TestLoadBalancer_TokenBasedThreshold2`).
- Removed helpers: confirmed zero references repo-wide.

## Deliberately left alone
`TestLB_VirtualValidation_EqualProviders` (1000 samples vs a 65% threshold for equal providers is a robust regression guard) and `concurrency_test.go`'s 10ms orchestration sleeps — neither is a real flake source.

https://claude.ai/code/session_01M9hBJiyVdNroKVPRn7MMTW