### PR TITLE
bugfix(routing): implement strict affinity TTL and tier-aware session pinning

### DIFF
--- a/.design/affinity.pencil.md
+++ b/.design/affinity.pencil.md
@@ -1,0 +1,272 @@
+# Affinity Flow Design
+
+## Overview
+
+Session affinity pins a client session to the service it first landed on. This document describes the complete flow of how affinity works in tingly-box, including the strict TTL behavior.
+
+## Configuration
+
+`rule.Flags.SessionAffinity` - TTL in seconds (e.g., 3600 = 1 hour)
+
+When affinity is enabled:
+
+- First request: locks to selected service, sets TTL
+- TTL expires: session re-enters selection, may get different service
+- Within TTL: session stays pinned to the same service
+
+## Complete Request Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         REQUEST FLOW (完整版)                                │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+Request 1 at T=0 (第一次请求, 无锁)
+─────────────────────────────────────┘
+
+1. SELECTOR.SELECT(ctx)
+   │
+   ▼
+2. AffinityStage.Evaluate()
+   │
+   ├── store.Get(ruleUUID, sessionID) → nil (无锁)
+   │
+   ▼
+3. → 返回 nil, false (pass through)
+   │
+   ▼
+4. LoadBalancerStage
+   │
+   ├── 选择 service: svc-a
+   │
+   ▼
+5. result = Result(svc-a, "load_balancer")
+   │
+   ▼
+6. postProcess(result, ctx)
+   │
+   ├── 检查: result.Source == "affinity"? → NO (是 "load_balancer")
+   │
+   ├── 检查: ttl := GetEffectiveAffinity(rule) → 3600 秒
+   │
+   ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  ⭐ 第一次锁定                                                  │
+   │  affinityStore.Set(..., AffinityEntry{                         │
+   │      Service: svc-a,                                            │
+   │      LockedAt: T=0,                                             │
+   │      ExpiresAt: T=0 + 3600 = T=3600                            │
+   │  })                                                             │
+   └─────────────────────────────────────────────────────────────────┘
+   │
+   ▼
+7. Response to client (使用 svc-a)
+
+
+Request 2 at T=1800 (TTL 内, 有锁)
+─────────────────────────────────────┘
+
+1. SELECTOR.SELECT(ctx)
+   │
+   ▼
+2. AffinityStage.Evaluate()
+   │
+   ├── store.Get(ruleUUID, sessionID) → entry (ExpiresAt: T=3600)
+   │
+   ├── ⭐ 检查: time.Now().After(entry.ExpiresAt)?
+   │   └── T=1800 > T=3600? → NO (未过期)
+   │
+   ├── ⭐ 检查: IsAffinityEligible(services, entry.Service)?
+   │   └── YES (假设 service 仍然可用)
+   │
+   ▼
+3. → 返回 Result(svc-a, "affinity")
+   │
+   ▼
+4. postProcess(result, ctx)
+   │
+   ├── ⭐ 检查: result.Source == "affinity"? → YES
+   │
+   ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  ⭐ 跳过锁定 (已锁定, 不刷新 TTL)                                │
+   │  return (不执行 Set)                                            │
+   └─────────────────────────────────────────────────────────────────┘
+   │
+   ▼
+5. Response to client (使用 svc-a, 锁的 TTL 仍是 T=3600)
+
+
+Request 3 at T=3601 (TTL 过期后, 有锁但过期)
+─────────────────────────────────────┘
+
+1. SELECTOR.SELECT(ctx)
+   │
+   ▼
+2. AffinityStage.Evaluate()
+   │
+   ├── store.Get(ruleUUID, sessionID) → entry (ExpiresAt: T=3600)
+   │
+   ├── ⭐ 检查: time.Now().After(entry.ExpiresAt)?
+   │   └── T=3601 > T=3600? → YES (已过期!)
+   │
+   ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  ⭐ 严格 TTL: 丢弃过期锁                                        │
+   │  logrus.Info("affinity entry expired...; dropping pin")       │
+   │  return nil, false (pass through to strategy)                  │
+   └─────────────────────────────────────────────────────────────────┘
+   │
+   ▼
+3. → 返回 nil, false (pass through)
+   │
+   ▼
+4. LoadBalancerStage
+   │
+   ├── 重新选择 service:
+   │   - 如果 svc-a 仍可用 → 可能选择 svc-a
+   │   - 如果 svc-a 不可用 → 选择其他 service
+   │   - 如果 tier 恢复 → 选择更高 tier 的 service
+   │
+   ▼
+5. 假设选择: svc-b (可能和之前相同, 也可能不同)
+   │
+   ▼
+6. result = Result(svc-b, "load_balancer")
+   │
+   ▼
+7. postProcess(result, ctx)
+   │
+   ├── 检查: result.Source == "affinity"? → NO (是 "load_balancer")
+   │
+   ├── 检查: ttl := GetEffectiveAffinity(rule) → 3600 秒
+   │
+   ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  ⭐ 重新锁定 (新锁, 新 TTL)                                     │
+   │  affinityStore.Set(..., AffinityEntry{                         │
+   │      Service: svc-b,                                            │
+   │      LockedAt: T=3601,                                         │
+   │      ExpiresAt: T=3601 + 3600 = T=7201                         │
+   │  })                                                             │
+   └─────────────────────────────────────────────────────────────────┘
+   │
+   ▼
+8. Response to client (使用 svc-b, 新的 TTL 到 T=7201)
+```
+
+## Key Design Decisions
+
+### 1. Strict TTL (not sliding)
+
+**Behavior**: Lock expires exactly at `LockedAt + SessionAffinity` seconds
+
+**Why**:
+
+- Honors the configured TTL value
+- Allows operational control (draining, rebalancing)
+- Predictable session lifecycle
+
+**Alternative (Sliding TTL)**: Each request refreshes the TTL
+
+- Pro: Active sessions never interrupted
+- Con: Configuration becomes meaningless
+
+### 2. No TTL Refresh in postProcess
+
+**Code**:
+
+```go
+if result.Source == "affinity" || ctx.SessionID.IsEmpty() {
+return // Don't re-lock, don't refresh TTL
+}
+```
+
+**Why**: This is critical for strict TTL. If we refreshed TTL here, it would become sliding TTL.
+
+### 3. Tier-Scoped Affinity
+
+**Behavior**: Even within TTL, a pin can be dropped if:
+
+- Pinned service's breaker is open (dead peer)
+- A higher-tier service has recovered (cross-tier demotion)
+
+**Why**: Ensures affinity respects tier priority and health, not just time.
+
+## AffinityEntry Structure
+
+```go
+type AffinityEntry struct {
+Service   *loadbalance.Service // The pinned service
+MessageID string               // For tracing
+LockedAt  time.Time // When the lock was created
+ExpiresAt time.Time // When the lock expires (strict TTL)
+}
+```
+
+## Pipeline Integration
+
+```
+Pipeline: Health → Affinity → Smart → LoadBalancer
+
+AffinityStage.Evaluate():
+    1. Check if affinity enabled (rule.Flags.SessionAffinity > 0)
+    2. Check if session exists (!SessionID.IsEmpty())
+    3. Get affinity entry (store.Get)
+    4. ⭐ Check if expired (time.Now().After(entry.ExpiresAt))
+    5. ⭐ Check if still eligible (typ.IsAffinityEligible)
+    6. Return Result(service, "affinity") or pass through
+
+postProcess():
+    1. Check if result.Source == "affinity" → skip (don't refresh TTL)
+    2. Get TTL (GetEffectiveAffinity)
+    3. Set new lock (affinityStore.Set)
+```
+
+## Time-Based Scenarios
+
+| Time   | Action        | State        | Result                                           |
+|--------|---------------|--------------|--------------------------------------------------|
+| T=0    | First request | No lock      | Create lock, ExpiresAt=T=3600                    |
+| T=1800 | Request       | Lock valid   | Use lock, NO refresh                             |
+| T=3601 | Request       | Lock expired | Drop lock, re-select, create new lock to T=7201  |
+| T=5400 | Request       | Lock valid   | Use lock, NO refresh                             |
+| T=7202 | Request       | Lock expired | Drop lock, re-select, create new lock to T=10802 |
+
+## Edge Cases
+
+### 1. Service Becomes Unavailable (Breaker Open)
+
+Even if lock is valid (not expired), `IsAffinityEligible` drops the pin:
+
+- Dead peer in same tier → drop, pick healthy peer
+- Higher tier recovers → drop, promote to recovered tier
+
+### 2. All Services Down
+
+When every breaker is open, affinity degrades:
+
+- Still honors pin to lowest tier (don't disappear)
+- Request surfaces real upstream error instead of "no service"
+
+### 3. Inactive Service
+
+Inactive services never make tiers look "available":
+
+- Inactive service's breaker state is ignored
+- Prevents false tier availability
+
+## Files
+
+- `internal/server/routing/stage_affinity.go` - AffinityStage with strict TTL
+- `internal/server/routing/selector.go` - postProcess with no-refresh logic
+- `internal/typ/tactics.go` - IsAffinityEligible (tier-scoped affinity)
+- `internal/server/routing/stage_affinity_test.go` - Tests including strict TTL
+
+## Testing
+
+See `internal/server/routing/stage_affinity_test.go`:
+
+- `TestAffinity_StrictTTL_Expired` - Expired lock is dropped
+- `TestAffinity_StrictTTL_NotExpired` - Valid lock is honored
+- `TestAffinity_TierScope_*` - Tier-scoped affinity scenarios

--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -108,32 +108,24 @@ Fix: `AffinityStage` honors a pin only while the pinned service is one the strat
 
 Decision flow (pinned service = `P`):
 
+```mermaid
+flowchart TD
+    P{"P == nil or inactive?"} -- yes --> DROP["NO — drop pin"]
+    P -- no --> W["active services → buckets by Tier (asc)<br/>find top tier T* with a breaker-available svc"]
+    W --> AV{"any tier available?"}
+    AV -- "yes (T*)" --> IN{"P in T* and P available?"}
+    AV -- "no (all open)" --> LOW{"P in lowest tier?"}
+    IN -- yes --> HON["YES — honor pin"]
+    IN -- no --> DROP
+    LOW -- yes --> HON2["YES — degrade (honor, surface real error)"]
+    LOW -- no --> DROP
 ```
-IsAffinityEligible(services, P)  — "is P a service the strategy would pick right now?"
 
-  P == nil  OR  P inactive ? ───────────────────────────────────────▶ NO (drop pin)
-        │ no
-        ▼
-  active  = services with Active==true      (inactive can't make a tier look "available")
-  buckets = group by Tier, ascending        (T0 = highest priority, first)
-        │
-        ▼
-  walk tiers top→down; the FIRST tier with any breaker-available service = top tier T*
-        │            (available = closed OR half-open; read via IsAvailable —
-        │             non-consuming, never steals the half-open probe)
-        ├──────────────────────────────┬───────────────────────────────────────
-        ▼ found T*                      ▼ no tier available (every breaker open)
-   P in T*  AND  P available ?     P in the lowest-numbered tier ?
-        ├─ yes ─▶ YES (honor)           ├─ yes ─▶ YES (degrade: honor, surface
-        └─ no  ─▶ NO  (drop)            │                real upstream error)
-                                        └─ no  ─▶ NO
-
-  the two "drop" cases:
-    cross-tier demote                     within-tier dead peer
-    T0: t0 (recovered) ◀ T*               T0: a (available) ◀ T*   b (open)
-    T1: P=t2 (available)                      P=b ∈ T* but not available
-    → P ∉ T* → drop → re-pick t0          → drop → re-pick a
-```
+`available` = breaker closed or half-open (read via the non-consuming `IsAvailable`, so it never steals the
+half-open probe). A drop falls through to the strategy, which re-selects a currently-valid service, and
+`postProcess` re-pins there. The two ways `P in T* and P available?` fails are the only "drop" cases:
+**cross-tier demote** (a higher tier recovered, so `P`'s lower tier is no longer `T*`) and **within-tier
+dead peer** (`P` is in `T*` but its own breaker is open while a peer is up).
 
 `IsAffinityEligible` mirrors `TierTactic`'s bucket walk but uses the non-consuming `BreakerStore.IsAvailable` so it never steals the half-open probe; when every service is tripped it degrades to "honor a pin to the lowest tier" rather than wedging. On decline, the pipeline falls through to the strategy, which re-selects a currently-valid service, and the existing `ServiceSelector.postProcess` automatically **re-pins** the session there — no change to the failover layer. The global-affinity pipeline is ordered **health → affinity → strategy** (`pipelineModeGlobalAffinity`). Note `typ.HealthFilter` only tracks 429/auth; the 500-driven signal lives in the breaker, which is why the affinity scoping consults the breaker directly rather than relying on the health stage.
 

--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -63,44 +63,35 @@ The breaker is a three-state machine (`Closed → Open → HalfOpen`):
 
 Recovery requires **no separate scheduler**. Selection re-evaluates the tier list every request, and the breaker's lazy state transition admits one probe naturally. Active probing was considered and rejected for v1 — for hot rules it's redundant, and for cold rules there is no one to serve anyway.
 
-### Breaker threshold — why 3, and when to revisit it
+### Breaker threshold — why 3
 
-`FailureThreshold = 3` means **3 *consecutive* failures**, and **any success resets the count to 0**
-(`Breaker.RecordSuccess`). Because a request attempts each service at most once (the in-request `tried`
-map), one request contributes **at most one** failure to a given service — so for a tier primary that is
-tried first on every request, "3 strikes" means *3 consecutive requests routed to it failed*, and it trips
-on the 3rd.
+`FailureThreshold = 3` = **3 consecutive failures**; any success resets the count. A request hits each
+service at most once (the `tried` map), so for a tier primary "3 strikes" = 3 consecutive requests to it
+failed.
 
-Picking the number is a sensitivity/stability trade-off, and the key fact is that **failover masks the
-client impact**: while a service accrues strikes the client still gets a 200 from the next tier, so an early
-trip is never a correctness problem — it only costs "a wasted primary attempt + one extra hop per request"
-until it trips, and a *premature* trip only costs "tier preference lost for `OpenDuration`." That asymmetry
-means we can lean slightly sensitive:
+Why 3? Failover hides the failure from the client (they still get a 200 from the next tier), so an early
+trip is never a correctness problem — at worst a wasted hop until it trips, or 30 s of lost tier preference
+if it trips too eagerly. So we can lean sensitive:
 
-- **Lower (→1)** trips on a single 500 → fastest protection, but a lone transient blip evicts the service
-  for the whole `OpenDuration` (30 s) — too twitchy for a "primary account that occasionally 500s".
-- **Higher (→8)** tolerates blips but drags a genuinely-dead service through many wasted primary attempts
-  before evicting it.
-- **3** tolerates 1–2 blips and still trips within 3 requests on sustained failure — a reasonable middle.
+- **1** — trips on a single 500; one blip evicts the service for 30 s. Too twitchy.
+- **8** — drags a dead service through many wasted attempts before evicting it.
+- **3** — tolerates a blip or two, trips within 3 requests on sustained failure. A good middle.
 
-**The real limitation is the *consecutive-reset* condition, not the number.** A service that fails
-*intermittently* (e.g. 500s ~30 % of the time) keeps getting its counter reset by the interleaved
-successes, so it may **never** trip — the breaker gives it no protection and every blip pays a failover hop
-forever. The original report ("one 500 then *sustained* 500s") is the consecutive case, which 3 handles
-well; the intermittent case is the gap. Closing it needs a **rolling-window / error-rate** trip condition
-(e.g. "≥ N failures in the last M outcomes"), at which point the exact threshold matters much less.
+The bigger limitation is the **consecutive-reset**, not the number. A service that fails *intermittently*
+(say 30 % of the time) keeps getting reset by the successes in between, so it may never trip. The original
+"sustained 500s" bug is the consecutive case (3 handles it); flapping is the gap — catching it needs a
+rolling-window / error-rate trigger, at which point the exact number barely matters.
 
-Tuning notes for whoever revisits this:
-- `FailureThreshold` and `OpenDuration` must be tuned **together** — an aggressive threshold with a long
-  open window causes frequent mis-evictions; pair a lower threshold with a shorter open window.
-- The right value depends on the upstream's transient-error profile, so this is a natural **per-rule /
-  per-scenario config** (tracked as Future work #4) rather than a single global constant.
+Tuning: move `FailureThreshold` and `OpenDuration` together (aggressive threshold + long open = frequent
+mis-evictions). The right value depends on the upstream, so it's a natural per-rule config (Future work #4).
 
 ### Session affinity must respect tier priority
 
-Session affinity (`Flags.SessionAffinity`) pins a session to whichever service first served it, so a conversation keeps hitting the same backend (prompt-cache continuity, etc.). For tier rules this created a sharp bug: the `AffinityStage` ran **before** the tier strategy and short-circuited to the pinned service *without consulting the breaker*. So if a session got pinned to a fallback tier during a brief primary-tier outage, it stuck there indefinitely — the primary tier could recover and the session would never return ("configured t1 but long-term auto-jumps to t2"; and a pinned-but-failing t2 would keep 500ing instead of failing over).
+Session affinity (`Flags.SessionAffinity`) pins a session to the service it first landed on (prompt-cache continuity, etc.).
 
-Fix: `AffinityStage` honors a pin only while the pinned service is one the strategy would actually pick right now — `typ.IsAffinityEligible`. This is **driven by the rule's config shape, not its tactic label** (there is no independent "tier mode"; "tier" is just the emergent shape of a multi-layer rule), so one rule covers every shape:
+For tier rules this was buggy: `AffinityStage` ran **before** the tier strategy and honored the pin **without consulting the breaker**. So a session pinned to a fallback tier during a brief primary outage stuck there forever — the primary could recover and the session never came back ("configured t1 but auto-jumps to t2"; or a pinned-but-failing t2 that keeps 500ing instead of failing over).
+
+Fix: the pin is honored only while the pinned service is one the strategy would pick *right now* — `typ.IsAffinityEligible`. It keys off **config shape, not tactic label** ("tier" is just the emergent shape of a multi-layer rule), so one check covers every shape:
 
 - **one service** — always eligible (nothing else to pick).
 - **one layer, many services** — eligible iff the pinned service's own breaker is available; a pin to a *dead peer* is dropped while healthy peers exist.
@@ -121,13 +112,12 @@ flowchart TD
     LOW -- no --> DROP
 ```
 
-`available` = breaker closed or half-open (read via the non-consuming `IsAvailable`, so it never steals the
-half-open probe). A drop falls through to the strategy, which re-selects a currently-valid service, and
-`postProcess` re-pins there. The two ways `P in T* and P available?` fails are the only "drop" cases:
-**cross-tier demote** (a higher tier recovered, so `P`'s lower tier is no longer `T*`) and **within-tier
-dead peer** (`P` is in `T*` but its own breaker is open while a peer is up).
+Notes:
 
-`IsAffinityEligible` mirrors `TierTactic`'s bucket walk but uses the non-consuming `BreakerStore.IsAvailable` so it never steals the half-open probe; when every service is tripped it degrades to "honor a pin to the lowest tier" rather than wedging. On decline, the pipeline falls through to the strategy, which re-selects a currently-valid service, and the existing `ServiceSelector.postProcess` automatically **re-pins** the session there — no change to the failover layer. The global-affinity pipeline is ordered **health → affinity → strategy** (`pipelineModeGlobalAffinity`). Note `typ.HealthFilter` only tracks 429/auth; the 500-driven signal lives in the breaker, which is why the affinity scoping consults the breaker directly rather than relying on the health stage.
+- `available` = breaker closed or half-open, read via the non-consuming `IsAvailable` (never steals the half-open probe).
+- On a drop, the strategy re-selects and `postProcess` re-pins — the failover layer is untouched.
+- The pipeline runs **health → affinity → strategy**. `HealthFilter` only sees 429/auth, so the 500 signal comes straight from the breaker.
+- The two "drop" cases (both are `P in T* and P available? → no`): **cross-tier demote** (a higher tier recovered, so P's tier is no longer T\*) and **within-tier dead peer** (P is in T\* but its own breaker is open while a peer is up).
 
 ### End-to-end flow: how the tactic switch actually takes effect
 

--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -106,6 +106,35 @@ Fix: `AffinityStage` honors a pin only while the pinned service is one the strat
 - **one layer, many services** — eligible iff the pinned service's own breaker is available; a pin to a *dead peer* is dropped while healthy peers exist.
 - **many layers** — eligible iff the pinned service is breaker-available *and* in the highest-priority tier that currently has any available service; a pin to a fallback tier is dropped once the primary recovers.
 
+Decision flow (pinned service = `P`):
+
+```
+IsAffinityEligible(services, P)  — "is P a service the strategy would pick right now?"
+
+  P == nil  OR  P inactive ? ───────────────────────────────────────▶ NO (drop pin)
+        │ no
+        ▼
+  active  = services with Active==true      (inactive can't make a tier look "available")
+  buckets = group by Tier, ascending        (T0 = highest priority, first)
+        │
+        ▼
+  walk tiers top→down; the FIRST tier with any breaker-available service = top tier T*
+        │            (available = closed OR half-open; read via IsAvailable —
+        │             non-consuming, never steals the half-open probe)
+        ├──────────────────────────────┬───────────────────────────────────────
+        ▼ found T*                      ▼ no tier available (every breaker open)
+   P in T*  AND  P available ?     P in the lowest-numbered tier ?
+        ├─ yes ─▶ YES (honor)           ├─ yes ─▶ YES (degrade: honor, surface
+        └─ no  ─▶ NO  (drop)            │                real upstream error)
+                                        └─ no  ─▶ NO
+
+  the two "drop" cases:
+    cross-tier demote                     within-tier dead peer
+    T0: t0 (recovered) ◀ T*               T0: a (available) ◀ T*   b (open)
+    T1: P=t2 (available)                      P=b ∈ T* but not available
+    → P ∉ T* → drop → re-pick t0          → drop → re-pick a
+```
+
 `IsAffinityEligible` mirrors `TierTactic`'s bucket walk but uses the non-consuming `BreakerStore.IsAvailable` so it never steals the half-open probe; when every service is tripped it degrades to "honor a pin to the lowest tier" rather than wedging. On decline, the pipeline falls through to the strategy, which re-selects a currently-valid service, and the existing `ServiceSelector.postProcess` automatically **re-pins** the session there — no change to the failover layer. The global-affinity pipeline is ordered **health → affinity → strategy** (`pipelineModeGlobalAffinity`). Note `typ.HealthFilter` only tracks 429/auth; the 500-driven signal lives in the breaker, which is why the affinity scoping consults the breaker directly rather than relying on the health stage.
 
 ### End-to-end flow: how the tactic switch actually takes effect

--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -63,6 +63,51 @@ The breaker is a three-state machine (`Closed → Open → HalfOpen`):
 
 Recovery requires **no separate scheduler**. Selection re-evaluates the tier list every request, and the breaker's lazy state transition admits one probe naturally. Active probing was considered and rejected for v1 — for hot rules it's redundant, and for cold rules there is no one to serve anyway.
 
+### Breaker threshold — why 3, and when to revisit it
+
+`FailureThreshold = 3` means **3 *consecutive* failures**, and **any success resets the count to 0**
+(`Breaker.RecordSuccess`). Because a request attempts each service at most once (the in-request `tried`
+map), one request contributes **at most one** failure to a given service — so for a tier primary that is
+tried first on every request, "3 strikes" means *3 consecutive requests routed to it failed*, and it trips
+on the 3rd.
+
+Picking the number is a sensitivity/stability trade-off, and the key fact is that **failover masks the
+client impact**: while a service accrues strikes the client still gets a 200 from the next tier, so an early
+trip is never a correctness problem — it only costs "a wasted primary attempt + one extra hop per request"
+until it trips, and a *premature* trip only costs "tier preference lost for `OpenDuration`." That asymmetry
+means we can lean slightly sensitive:
+
+- **Lower (→1)** trips on a single 500 → fastest protection, but a lone transient blip evicts the service
+  for the whole `OpenDuration` (30 s) — too twitchy for a "primary account that occasionally 500s".
+- **Higher (→8)** tolerates blips but drags a genuinely-dead service through many wasted primary attempts
+  before evicting it.
+- **3** tolerates 1–2 blips and still trips within 3 requests on sustained failure — a reasonable middle.
+
+**The real limitation is the *consecutive-reset* condition, not the number.** A service that fails
+*intermittently* (e.g. 500s ~30 % of the time) keeps getting its counter reset by the interleaved
+successes, so it may **never** trip — the breaker gives it no protection and every blip pays a failover hop
+forever. The original report ("one 500 then *sustained* 500s") is the consecutive case, which 3 handles
+well; the intermittent case is the gap. Closing it needs a **rolling-window / error-rate** trip condition
+(e.g. "≥ N failures in the last M outcomes"), at which point the exact threshold matters much less.
+
+Tuning notes for whoever revisits this:
+- `FailureThreshold` and `OpenDuration` must be tuned **together** — an aggressive threshold with a long
+  open window causes frequent mis-evictions; pair a lower threshold with a shorter open window.
+- The right value depends on the upstream's transient-error profile, so this is a natural **per-rule /
+  per-scenario config** (tracked as Future work #4) rather than a single global constant.
+
+### Session affinity must respect tier priority
+
+Session affinity (`Flags.SessionAffinity`) pins a session to whichever service first served it, so a conversation keeps hitting the same backend (prompt-cache continuity, etc.). For tier rules this created a sharp bug: the `AffinityStage` ran **before** the tier strategy and short-circuited to the pinned service *without consulting the breaker*. So if a session got pinned to a fallback tier during a brief primary-tier outage, it stuck there indefinitely — the primary tier could recover and the session would never return ("configured t1 but long-term auto-jumps to t2"; and a pinned-but-failing t2 would keep 500ing instead of failing over).
+
+Fix: `AffinityStage` honors a pin only while the pinned service is one the strategy would actually pick right now — `typ.IsAffinityEligible`. This is **driven by the rule's config shape, not its tactic label** (there is no independent "tier mode"; "tier" is just the emergent shape of a multi-layer rule), so one rule covers every shape:
+
+- **one service** — always eligible (nothing else to pick).
+- **one layer, many services** — eligible iff the pinned service's own breaker is available; a pin to a *dead peer* is dropped while healthy peers exist.
+- **many layers** — eligible iff the pinned service is breaker-available *and* in the highest-priority tier that currently has any available service; a pin to a fallback tier is dropped once the primary recovers.
+
+`IsAffinityEligible` mirrors `TierTactic`'s bucket walk but uses the non-consuming `BreakerStore.IsAvailable` so it never steals the half-open probe; when every service is tripped it degrades to "honor a pin to the lowest tier" rather than wedging. On decline, the pipeline falls through to the strategy, which re-selects a currently-valid service, and the existing `ServiceSelector.postProcess` automatically **re-pins** the session there — no change to the failover layer. The global-affinity pipeline is ordered **health → affinity → strategy** (`pipelineModeGlobalAffinity`). Note `typ.HealthFilter` only tracks 429/auth; the 500-driven signal lives in the breaker, which is why the affinity scoping consults the breaker directly rather than relying on the health stage.
+
 ### End-to-end flow: how the tactic switch actually takes effect
 
 The "user moves a service card to a different tier" event has to cross five layers before it changes how the next API request is routed. Each layer is wired explicitly:
@@ -157,6 +202,63 @@ The routing graph always renders tier rows, even when only one tier exists (T0 i
 The design choice here is **implicit mode activation**: assigning any service a tier flips the rule's `lb_tactic` to `tier` on save. No separate tactic-selector UI is exposed. Moving all services back to a single tier leaves the tactic as `tier` (consistent; the round-trip is safe).
 
 Why implicit: tactic concepts are jargon for most users. "Move this service to a fallback tier" is concrete and matches a real intent ("I want this one only when the first fails"). The tactic switch is plumbing — it shouldn't be a separate question.
+
+## Rule config shapes (taxonomy)
+
+There is **no independent "tier mode"** in tingly-box — every routing behavior is emergent from the rule's config *shape*. A user assembles a rule out of services; the shape that assembly takes determines the strategy, the failover, and how affinity behaves. The frontend flips `lb_tactic=tier` purely as a consequence of shape (any `Service.Tier > 0`, see `frontend/src/components/rule-card/utils.ts` `pickLbTactic`/`hasTierAssigned`); routing code should reason about the shape and runtime state, not the tactic label.
+
+### Primary structural grid — tiers × services-per-tier
+
+`Service.Tier` (default `0`) groups services into layers; lower number = higher priority.
+
+| Shape | Config | Strategy | Failover | Affinity (when enabled) |
+|---|---|---|---|---|
+| **A. Single** | 1 tier, 1 svc | none (direct) | none — single-svc bypass in `dispatchWithPriorityFailover` | trivial: always the one service |
+| **B. Flat** | 1 tier, N svc | horizontal (`random`/`token_based`/`latency`/…) | among peers in the tier | honor pin iff the pinned peer's breaker is available; drop to a healthy peer if it is open |
+| **C. Cascade** | M tiers, 1 svc each | `tier` (direct + fallback) | next tier down | follow the top available tier; return to the primary on recovery |
+| **D. Grid** | M tiers, N svc each | `tier` + within-tier sub-tactic | within the tier, then the next tier down | top available tier; within it, per-peer stickiness |
+
+### Orthogonal modifiers (multiply onto A–D)
+
+- **Within-tier sub-tactic** (`TierParams.WithinTierTactic`) — only matters when a tier holds > 1 service.
+- **Multi-model across services** (`Service.Model` is per-service) — valid; a cross-tier failover changes the model (the already-transformed body is reused, see **G2**).
+- **Multi-API-style** (`Provider.APIStyle`) — failover is **same-API-style only** (`selectFallbackService` filters on `requireAPIStyle`).
+- **Smart routing** (`SmartEnabled` / `SmartRouting[].Services`) — selects a service *subset* by request content; each subset is itself one of shapes A–D (with its own tiers).
+- **Affinity** (`Flags.SessionAffinity`, seconds) — session stickiness, governed by `typ.IsAffinityEligible`.
+
+### Runtime state that determines the actual pick
+
+Config shape sets the *space* of choices; runtime state picks within it:
+
+- **Breaker** per service (closed / open / half-open, process-wide `DefaultBreakerStore`) — drives tier demotion, the half-open recovery probe, and affinity eligibility. It is the authoritative signal for 5xx failures.
+- **Active** flag — inactive services are excluded everywhere (`GetActiveServices`); `IsAffinityEligible` mirrors this (an inactive service must not make its tier look "available").
+- **Health** (429 / auth) via `HealthFilter`/`HealthMonitor` — a *separate* signal from the breaker (5xx feed only the breaker), applied by the `HealthStage` filter.
+
+### Affinity-eligibility truth table
+
+What `typ.IsAffinityEligible(activeServices, P)` encodes for a pinned service `P` (it mirrors `TierTactic`'s bucket walk using the non-consuming `BreakerStore.IsAvailable`, so it never steals the half-open probe):
+
+| Situation | Honor pin to P? |
+|---|---|
+| Single service | yes (always) |
+| Flat, P breaker available | yes |
+| Flat, P breaker open, a peer available | no → re-pin to a healthy peer |
+| Cascade/Grid, P available **and** P.tier == top available tier | yes |
+| Cascade/Grid, a higher tier has recovered (P sits below it) | no → re-pin up to the recovered tier |
+| Every breaker open | yes iff P is in the lowest tier (degrade-don't-disappear) |
+| P inactive | no (declined) |
+
+On a decline the pipeline falls through to the strategy, which re-selects a currently-valid service, and `ServiceSelector.postProcess` re-pins the session there automatically.
+
+### Known gaps (explicit)
+
+- **G1 — horizontal tactics are breaker-blind.** Only `TierTactic` consults `DefaultBreakerStore`. `random`/`token_based`/`latency`/… select across the health-filtered set *ignoring the breaker*, so in the **Flat** shape a dead peer can still be re-selected at the selection layer (per-request failover still masks it from the client; affinity already drops the *pin* to a dead peer). *Deferred.* Surfaced as a `t.Skip` in `internal/server/lb_scenario_test.go` (`TestLBScenario_B_Flat_DeadPeerSelection_KnownGap`).
+- **G2 — heterogeneous failover.** A fallback reuses the already-transformed request body and is restricted to the same `Provider.APIStyle`; mixing API styles (and, in practice, models) across tiers within one failover is constrained.
+- **G3 — affinity is global-scope.** Affinity runs before smart routing on the union of all the rule's services (`selector.go` TODO); per-smart-rule affinity scoping is not implemented.
+
+### Verifying shapes end-to-end
+
+`internal/server/lb_scenario_test.go` is the scenario harness that drives the **full** path (selection → failover dispatch) against programmable fake upstreams over a request sequence, with a deterministic breaker clock (`loadbalance.SetClockForTest`). It covers each shape above plus the original sticky-affinity regression (trip → open → drop pin → recover → re-pin). Prefer extending it (rather than stage-level units alone) when changing routing/affinity/breaker behavior.
 
 ## Value
 

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -191,6 +191,16 @@ func (s *BreakerStore) Allow(serviceID string) bool {
 	return s.Get(serviceID).Allow()
 }
 
+// IsAvailable reports whether the service's breaker currently permits traffic,
+// without consuming a half-open probe slot. Closed and HalfOpen are available;
+// Open is not. Unlike Allow(), this is a side-effect-free read — callers that
+// only need to know "is this service usable right now" (e.g. affinity scoping)
+// should use it so they don't steal the single half-open probe from the
+// selection path.
+func (s *BreakerStore) IsAvailable(serviceID string) bool {
+	return s.Get(serviceID).State() != BreakerOpen
+}
+
 // RecordSuccess is a convenience over Get(serviceID).RecordSuccess().
 func (s *BreakerStore) RecordSuccess(serviceID string) {
 	s.Get(serviceID).RecordSuccess()

--- a/internal/loadbalance/breaker_test.go
+++ b/internal/loadbalance/breaker_test.go
@@ -85,6 +85,36 @@ func TestBreakerStoreLazyCreation(t *testing.T) {
 	}
 }
 
+func TestBreakerStoreIsAvailable(t *testing.T) {
+	store := NewBreakerStore(2, 20*time.Millisecond)
+
+	// Closed → available.
+	if !store.IsAvailable("svc:avail") {
+		t.Fatal("fresh (closed) breaker should be available")
+	}
+
+	// Open → not available.
+	store.RecordFailure("svc:avail")
+	store.RecordFailure("svc:avail")
+	if store.IsAvailable("svc:avail") {
+		t.Fatal("open breaker should not be available")
+	}
+
+	// After the open window, HalfOpen → available, and the read must NOT
+	// consume the half-open probe: a following Allow() must still succeed.
+	time.Sleep(30 * time.Millisecond)
+	if !store.IsAvailable("svc:avail") {
+		t.Fatal("half-open breaker should report available")
+	}
+	if !store.Allow("svc:avail") {
+		t.Fatal("IsAvailable must not consume the half-open probe; Allow() should still pass")
+	}
+	// The probe is now claimed, so a concurrent Allow() is rejected.
+	if store.Allow("svc:avail") {
+		t.Fatal("half-open should only admit a single probe")
+	}
+}
+
 func TestBreakerStoreConcurrent(t *testing.T) {
 	store := NewBreakerStore(5, time.Second)
 	var wg sync.WaitGroup

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -42,15 +42,6 @@ type AffinityEntry struct {
 	ExpiresAt time.Time
 }
 
-// pipelineMode determines which pipeline configuration to use.
-type pipelineMode int
-
-const (
-	pipelineModeNoAffinity     pipelineMode = iota // Smart Routing -> Load Balancer
-	pipelineModeGlobalAffinity                     // Affinity -> Smart Routing -> Load Balancer
-	pipelineModeSmartAffinity                      // Smart Routing -> Affinity -> Load Balancer
-)
-
 // ServiceSelector is the main entry point for service selection.
 // It orchestrates a pipeline of selection stages and validates the final result.
 type ServiceSelector struct {
@@ -58,8 +49,9 @@ type ServiceSelector struct {
 	affinityStore AffinityStore
 	loadBalancer  LoadBalancer
 
-	// Pre-built pipelines keyed by mode, built once at construction
-	pipelines map[pipelineMode][]SelectionStage
+	// One pipeline serves every rule — each stage self-guards (see the comment
+	// in NewServiceSelectorWithLogger). Built once at construction.
+	pipeline []SelectionStage
 }
 
 type healthFilterProvider interface {
@@ -133,7 +125,6 @@ func NewServiceSelectorWithLogger(
 		config:        cfg,
 		affinityStore: affinity,
 		loadBalancer:  lb,
-		pipelines:     make(map[pipelineMode][]SelectionStage),
 	}
 
 	var healthFilter *typ.HealthFilter
@@ -149,24 +140,21 @@ func NewServiceSelectorWithLogger(
 		return stage
 	}
 
-	// Pre-build all pipeline variants
-	s.pipelines[pipelineModeNoAffinity] = []SelectionStage{
-		newSmart(),
-		NewLoadBalancerStage(lb),
-	}
-	s.pipelines[pipelineModeGlobalAffinity] = []SelectionStage{
-		// Health first, then affinity, then strategy. HealthStage narrows the
-		// candidate set (429/auth-driven health) before affinity scoping runs;
-		// the breaker-driven (500) signal is consulted inside AffinityStage's
-		// tier check and the load-balancer/tier tactic itself.
+	// One pipeline serves every rule — order is health → affinity → strategy.
+	// Each stage self-guards, so there is no need for per-mode variants:
+	//   - Health  narrows the candidate set by 429/auth health; passes through
+	//     when no filter is set or filtering would empty the set (degrade).
+	//   - Affinity returns nothing when affinity is disabled or there's no
+	//     session, so it is a no-op for non-affinity rules. It uses the global
+	//     (ruleUUID:sessionID) scope because it runs before smart routing, so
+	//     the matched-smart-rule index isn't available yet. The breaker-driven
+	//     (500) signal is consulted inside the affinity tier check and the
+	//     tier tactic; Health feeds it the 429/auth signal.
+	//   - Smart   passes through when smart routing is off or unmatched.
+	//   - LB      always selects (the terminal fallback).
+	s.pipeline = []SelectionStage{
 		NewHealthStage(healthFilter),
 		NewAffinityStage(affinity, "global"),
-		newSmart(),
-		NewLoadBalancerStage(lb),
-	}
-	s.pipelines[pipelineModeSmartAffinity] = []SelectionStage{
-		NewHealthStage(healthFilter),
-		NewAffinityStage(affinity, "smart_rule"),
 		newSmart(),
 		NewLoadBalancerStage(lb),
 	}
@@ -177,14 +165,13 @@ func NewServiceSelectorWithLogger(
 // Select is the main entry point for service selection.
 // It picks a pre-built pipeline based on rule configuration and executes it.
 func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error) {
-	pipeline := s.selectPipeline(ctx.Rule)
 	state := newSelectionState(ctx.Rule)
 
 	logrus.Debugf("[selector] executing pipeline with %d stages for rule %s",
-		len(pipeline), ctx.Rule.UUID)
+		len(s.pipeline), ctx.Rule.UUID)
 
 	// Execute pipeline stages in order
-	for _, stage := range pipeline {
+	for _, stage := range s.pipeline {
 		stageName := stage.Name()
 		logrus.Debugf("[selector] evaluating stage: %s", stageName)
 
@@ -239,30 +226,6 @@ func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error
 
 	return nil, fmt.Errorf("no service available for rule %s (model: %s)",
 		ctx.Rule.UUID, ctx.Rule.RequestModel)
-}
-
-// selectPipeline picks the appropriate pre-built pipeline based on rule configuration.
-func (s *ServiceSelector) selectPipeline(rule *typ.Rule) []SelectionStage {
-	logrus.Debugf("[selector] selectPipeline for rule %s: AffinityEnabled=%v, SmartEnabled=%v, SmartRouting count=%d",
-		rule.RequestModel, rule.AffinityEnabled(), rule.SmartEnabled, len(rule.SmartRouting))
-	if !rule.AffinityEnabled() {
-		return s.pipelines[pipelineModeNoAffinity]
-	}
-
-	// Use global affinity scope: the affinity stage runs first and reads the
-	// ruleUUID:sessionID key that postProcess writes. The smart_rule-scoped
-	// pipeline can't read here because affinity is evaluated before smart
-	// routing (MatchedSmartRuleIndex is still unset), so it would never pin.
-	// TODO: Read from rule.AffinityScope when per-smart-rule scoping lands.
-	return s.pipelines[pipelineModeGlobalAffinity]
-}
-
-// getHealthFilter returns the health filter from the load balancer
-func (s *ServiceSelector) getHealthFilter() *typ.HealthFilter {
-	if p, ok := s.loadBalancer.(healthFilterProvider); ok {
-		return p.HealthFilter()
-	}
-	return nil
 }
 
 // postProcess handles post-selection logic like affinity locking.

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -155,6 +155,11 @@ func NewServiceSelectorWithLogger(
 		NewLoadBalancerStage(lb),
 	}
 	s.pipelines[pipelineModeGlobalAffinity] = []SelectionStage{
+		// Health first, then affinity, then strategy. HealthStage narrows the
+		// candidate set (429/auth-driven health) before affinity scoping runs;
+		// the breaker-driven (500) signal is consulted inside AffinityStage's
+		// tier check and the load-balancer/tier tactic itself.
+		NewHealthStage(healthFilter),
 		NewAffinityStage(affinity, "global"),
 		newSmart(),
 		NewLoadBalancerStage(lb),

--- a/internal/server/routing/selector_test.go
+++ b/internal/server/routing/selector_test.go
@@ -286,5 +286,47 @@ func TestNewServiceSelector_SmartAffinityPipelineOrder(t *testing.T) {
 	require.Equal(t, "load_balancer", pipeline[3].Name())
 }
 
+func TestNewServiceSelector_GlobalAffinityPipelineOrder(t *testing.T) {
+	sel := NewServiceSelector(&mockConfig{}, newMockAffinityStore(), &mockLoadBalancer{})
+
+	pipeline := sel.pipelines[pipelineModeGlobalAffinity]
+	require.Len(t, pipeline, 4)
+	require.Equal(t, "health", pipeline[0].Name(), "health must run before affinity")
+	require.Equal(t, "affinity", pipeline[1].Name())
+	require.Equal(t, "smart_routing", pipeline[2].Name())
+	require.Equal(t, "load_balancer", pipeline[3].Name())
+}
+
+// End-to-end fix for "configured t1 but long-term auto-jumps to t2": a session
+// pinned to a lower tier must return to the primary tier once it is healthy,
+// and the affinity pin must be rewritten to the primary (automatic re-pin via
+// postProcess — no failover-layer change needed).
+func TestSelect_TierAffinity_RepinsToPrimaryAfterRecovery(t *testing.T) {
+	t0 := tierService("e2e-t0", "m", 0)
+	t1 := tierService("e2e-t1", "m", 1)
+	lb := &mockLoadBalancer{service: t0} // strategy selects the primary tier
+	store := newMockAffinityStore()
+	store.Set("rule-e2e", testSessionKey("s1"), testAffinityEntry(t1)) // stale pin to t1
+	cfg := &mockConfig{
+		providers: map[string]*typ.Provider{
+			"e2e-t0": testProvider("e2e-t0", "T0", true),
+			"e2e-t1": testProvider("e2e-t1", "T1", true),
+		},
+	}
+
+	rule := tierRule("rule-e2e", "m", []*loadbalance.Service{t0, t1})
+
+	sel := NewServiceSelector(cfg, store, lb)
+	result, err := sel.Select(testContext(rule, "s1"))
+	require.NoError(t, err)
+	require.Equal(t, "load_balancer", result.Source, "stale lower-tier pin should be declined")
+	require.Equal(t, t0.ServiceID(), result.Service.ServiceID())
+
+	entry, ok := store.Get("rule-e2e", testSessionKey("s1"))
+	require.True(t, ok)
+	require.Equal(t, t0.ServiceID(), entry.Service.ServiceID(),
+		"affinity must be re-pinned to the recovered primary tier")
+}
+
 // ErrNoService is a sentinel error for tests
 var ErrNoService = errors.New("no service available")

--- a/internal/server/routing/selector_test.go
+++ b/internal/server/routing/selector_test.go
@@ -31,9 +31,9 @@ func TestSelect_NoAffinity_FallsToLoadBalancer(t *testing.T) {
 }
 
 func TestSelect_GlobalAffinity_Hit(t *testing.T) {
-	// With affinity enabled, selectPipeline picks the global-affinity pipeline
-	// whose AffinityStage reads the ruleUUID:sessionID key written on lock.
-	// A locked session must short-circuit to the locked service.
+	// With affinity enabled, the AffinityStage (global scope) reads the
+	// ruleUUID:sessionID key written on lock. A locked session must
+	// short-circuit to the locked service.
 	lockedSvc := testService("provider-a", "gpt-4", true)
 	otherSvc := testService("provider-b", "claude-3", true)
 	lb := &mockLoadBalancer{service: otherSvc} // LB would pick a different service
@@ -273,28 +273,15 @@ func TestUpdateServiceIndex(t *testing.T) {
 	require.True(t, lb.updateIndexCalled, "UpdateServiceIndex should call LB")
 }
 
-func TestNewServiceSelector_SmartAffinityPipelineOrder(t *testing.T) {
-	lb := &mockLoadBalancer{}
-	store := newMockAffinityStore()
-	sel := NewServiceSelector(&mockConfig{}, store, lb)
-
-	pipeline := sel.pipelines[pipelineModeSmartAffinity]
-	require.Len(t, pipeline, 4)
-	require.Equal(t, "health", pipeline[0].Name())
-	require.Equal(t, "affinity", pipeline[1].Name())
-	require.Equal(t, "smart_routing", pipeline[2].Name())
-	require.Equal(t, "load_balancer", pipeline[3].Name())
-}
-
-func TestNewServiceSelector_GlobalAffinityPipelineOrder(t *testing.T) {
+func TestNewServiceSelector_PipelineOrder(t *testing.T) {
+	// One pipeline serves every rule: health → affinity → smart → load_balancer.
 	sel := NewServiceSelector(&mockConfig{}, newMockAffinityStore(), &mockLoadBalancer{})
 
-	pipeline := sel.pipelines[pipelineModeGlobalAffinity]
-	require.Len(t, pipeline, 4)
-	require.Equal(t, "health", pipeline[0].Name(), "health must run before affinity")
-	require.Equal(t, "affinity", pipeline[1].Name())
-	require.Equal(t, "smart_routing", pipeline[2].Name())
-	require.Equal(t, "load_balancer", pipeline[3].Name())
+	require.Len(t, sel.pipeline, 4)
+	require.Equal(t, "health", sel.pipeline[0].Name(), "health must run before affinity")
+	require.Equal(t, "affinity", sel.pipeline[1].Name())
+	require.Equal(t, "smart_routing", sel.pipeline[2].Name())
+	require.Equal(t, "load_balancer", sel.pipeline[3].Name())
 }
 
 // End-to-end fix for "configured t1 but long-term auto-jumps to t2": a session

--- a/internal/server/routing/stage_affinity.go
+++ b/internal/server/routing/stage_affinity.go
@@ -2,6 +2,8 @@ package routing
 
 import (
 	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // AffinityStage checks if a session has a locked service from previous requests.
@@ -56,6 +58,23 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 	if state != nil && len(state.candidateServices) > 0 && !ContainsService(state.candidateServices, entry.Service) {
 		logrus.Debugf("[affinity] locked service %s not in candidate set, skipping",
 			entry.Service.ServiceID())
+		return nil, false
+	}
+
+	// Health scoping (breaker-aware): only honor a pin while the locked service
+	// is one the strategy would actually pick right now. This is driven by the
+	// rule's config shape, not its tactic label — "tier" is just the emergent
+	// shape of a multi-layer rule:
+	//   - many layers: drop a pin to a fallback tier once the primary recovers.
+	//   - one layer, many services: drop a pin to a dead peer when healthy
+	//     peers exist.
+	//   - one service: always honored (nothing else to pick).
+	// On decline the pipeline falls through to the strategy, which re-selects a
+	// currently-valid service, and postProcess re-pins the session there.
+	if state != nil && len(state.candidateServices) > 0 &&
+		!typ.IsAffinityEligible(state.candidateServices, entry.Service) {
+		logrus.Infof("[affinity] locked service %s is not currently selectable for session %s; dropping pin so strategy re-selects",
+			entry.Service.ServiceID(), ctx.SessionID.String())
 		return nil, false
 	}
 

--- a/internal/server/routing/stage_affinity.go
+++ b/internal/server/routing/stage_affinity.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"time"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -49,6 +51,15 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 	// TODO: Extend AffinityStore to support smart_rule scope keys
 	entry, ok := s.store.Get(rule.UUID, ctx.SessionID.String())
 	if !ok {
+		return nil, false
+	}
+
+	// Strict TTL: honor the pin only while the entry has not expired.
+	// Once the lock expires, the session must re-enter the selection pipeline
+	// and postProcess will create a new lock with a fresh TTL.
+	if time.Now().After(entry.ExpiresAt) {
+		logrus.Infof("[affinity] affinity entry for session %s expired at %s; dropping pin so strategy re-selects",
+			ctx.SessionID.String(), entry.ExpiresAt)
 		return nil, false
 	}
 

--- a/internal/server/routing/stage_affinity_test.go
+++ b/internal/server/routing/stage_affinity_test.go
@@ -7,7 +7,23 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
+
+// tierService builds an active service at the given tier for affinity tests.
+func tierService(provider, model string, tier int) *loadbalance.Service {
+	svc := testService(provider, model, true)
+	svc.Tier = tier
+	return svc
+}
+
+// tierRule builds a tier-tactic rule with affinity enabled.
+func tierRule(uuid, model string, services []*loadbalance.Service) *typ.Rule {
+	rule := testRule(uuid, model, services)
+	rule.Flags.SessionAffinity = 3600
+	rule.LBTactic = typ.Tactic{Type: loadbalance.TacticTier, Params: typ.DefaultTierParams()}
+	return rule
+}
 
 func TestAffinity_LockedSession(t *testing.T) {
 	store := newMockAffinityStore()
@@ -109,6 +125,119 @@ func TestAffinity_SmartRuleScope_NoIndex(t *testing.T) {
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled, "should pass when smart_rule scope but no index")
+}
+
+// --- Tier-scoped affinity (breaker-aware) ---
+
+// When the primary tier (t0) is healthy, a stale pin to a lower tier (t1) must
+// be declined so the strategy re-selects the primary. This is the fix for
+// "configured t1 but long-term auto-jumps to t2".
+func TestAffinity_TierScope_DeclinesStalePinWhenPrimaryHealthy(t *testing.T) {
+	store := newMockAffinityStore()
+	t0 := tierService("aff-tier-a-p0", "m", 0)
+	t1 := tierService("aff-tier-a-p1", "m", 1)
+	store.Set("rule-tier-a", testSessionKey("s1"), testAffinityEntry(t1))
+
+	rule := tierRule("rule-tier-a", "m", []*loadbalance.Service{t0, t1})
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled,
+		"stale pin to a lower tier must be declined while the primary tier is healthy")
+}
+
+// While the primary tier (t0) is down (breaker open), the pin to the now-top
+// available tier (t1) must be honored — within-failover stickiness.
+func TestAffinity_TierScope_HonorsPinWhilePrimaryDown(t *testing.T) {
+	store := newMockAffinityStore()
+	t0 := tierService("aff-tier-b-p0", "m", 0)
+	t1 := tierService("aff-tier-b-p1", "m", 1)
+	store.Set("rule-tier-b", testSessionKey("s1"), testAffinityEntry(t1))
+
+	rule := tierRule("rule-tier-b", "m", []*loadbalance.Service{t0, t1})
+
+	bs := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		bs.RecordFailure(t0.ServiceID())
+	}
+	defer bs.RecordSuccess(t0.ServiceID())
+
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled, "pin must be honored while the primary tier breaker is open")
+	require.Equal(t, t1.ServiceID(), result.Service.ServiceID())
+}
+
+// When the pinned service's own breaker is open and a higher tier is available,
+// the pin must be declined (subsumed by the top-available-tier check).
+func TestAffinity_TierScope_DeclinesWhenPinnedBreakerOpen(t *testing.T) {
+	store := newMockAffinityStore()
+	t0 := tierService("aff-tier-c-p0", "m", 0)
+	t1 := tierService("aff-tier-c-p1", "m", 1)
+	store.Set("rule-tier-c", testSessionKey("s1"), testAffinityEntry(t1))
+
+	rule := tierRule("rule-tier-c", "m", []*loadbalance.Service{t0, t1})
+
+	bs := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		bs.RecordFailure(t1.ServiceID())
+	}
+	defer bs.RecordSuccess(t1.ServiceID())
+
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled,
+		"pin to an open lower-tier service must be declined when a higher tier is available")
+}
+
+// Two services sharing one tier: the pin is honored regardless of which one,
+// preserving within-tier stickiness.
+func TestAffinity_TierScope_WithinTierStickinessPreserved(t *testing.T) {
+	store := newMockAffinityStore()
+	a := tierService("aff-tier-d-pa", "m", 0)
+	b := tierService("aff-tier-d-pb", "m", 0)
+	store.Set("rule-tier-d", testSessionKey("s1"), testAffinityEntry(b))
+
+	rule := tierRule("rule-tier-d", "m", []*loadbalance.Service{a, b})
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled, "within-tier pin must be honored")
+	require.Equal(t, b.ServiceID(), result.Service.ServiceID())
+}
+
+// Shape 2: one layer, many services, NO tier tactic label (plain horizontal
+// rule). A pin to a service whose breaker is open must still be dropped when a
+// healthy peer exists — the scoping is config-shape driven, not gated on the
+// tactic label.
+func TestAffinity_HorizontalRule_DropsPinToDeadPeer(t *testing.T) {
+	store := newMockAffinityStore()
+	a := testService("aff-horiz-a", "m", true) // tier 0 (default)
+	b := testService("aff-horiz-b", "m", true) // tier 0 (default)
+	store.Set("rule-horiz", testSessionKey("s1"), testAffinityEntry(a))
+
+	// Plain rule: testRule leaves LBTactic unset (defaults to random).
+	rule := testRule("rule-horiz", "m", []*loadbalance.Service{a, b})
+	rule.Flags.SessionAffinity = 3600
+
+	bs := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		bs.RecordFailure(a.ServiceID())
+	}
+	defer bs.RecordSuccess(a.ServiceID())
+
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled,
+		"pin to a dead same-tier peer must be dropped even without a tier tactic label")
 }
 
 func TestAffinity_Name(t *testing.T) {

--- a/internal/server/routing/stage_affinity_test.go
+++ b/internal/server/routing/stage_affinity_test.go
@@ -306,3 +306,54 @@ func TestAffinity_MultipleSessions(t *testing.T) {
 	require.True(t, handledB)
 	require.Equal(t, "provider-b", resultB.Service.Provider)
 }
+
+// --- Strict TTL tests ---
+
+// TestAffinity_StrictTTL_Expired verifies that an expired affinity entry is
+// dropped and the session passes through to the strategy for re-selection.
+func TestAffinity_StrictTTL_Expired(t *testing.T) {
+	store := newMockAffinityStore()
+	svc := testService("provider-a", "gpt-4", true)
+
+	// Create an already-expired entry
+	entry := &AffinityEntry{
+		Service:   svc,
+		LockedAt:  time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour), // expired 1 hour ago
+	}
+	store.Set("rule-ttl", testSessionKey("s1"), entry)
+
+	rule := testRule("rule-ttl", "gpt-4", nil)
+	rule.Flags.SessionAffinity = 3600
+
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled, "expired affinity entry must be dropped")
+}
+
+// TestAffinity_StrictTTL_NotExpired verifies that a valid (unexpired) affinity
+// entry is honored normally.
+func TestAffinity_StrictTTL_NotExpired(t *testing.T) {
+	store := newMockAffinityStore()
+	svc := testService("provider-a", "gpt-4", true)
+
+	// Create a still-valid entry (expires in the future)
+	entry := &AffinityEntry{
+		Service:   svc,
+		LockedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(1 * time.Hour), // expires in 1 hour
+	}
+	store.Set("rule-ttl", testSessionKey("s1"), entry)
+
+	rule := testRule("rule-ttl", "gpt-4", nil)
+	rule.Flags.SessionAffinity = 3600
+
+	stage := NewAffinityStage(store, "global")
+	ctx := testContext(rule, "s1")
+
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled, "valid affinity entry must be honored")
+	require.Equal(t, "provider-a", result.Service.Provider)
+}

--- a/internal/server/routing/stage_health.go
+++ b/internal/server/routing/stage_health.go
@@ -33,6 +33,16 @@ func (s *HealthStage) Evaluate(_ *SelectionContext, state *selectionState) (*Sel
 
 	before := len(state.candidateServices)
 	healthy := s.filter.Filter(state.candidateServices)
+
+	// Degrade, don't disappear: if every candidate is unhealthy, keep the full
+	// set rather than emptying it — mirrors LoadBalancer.SelectService, so the
+	// caller still gets a service (and the real upstream 429/auth) instead of a
+	// "no service available" routing error.
+	if before > 0 && len(healthy) == 0 {
+		logrus.Warnf("[health] all %d candidates unhealthy; keeping the full set (degrade)", before)
+		return NewFilterResult("health", state.candidateServices), false
+	}
+
 	filteredCount := before - len(healthy)
 
 	if filteredCount > 0 {

--- a/internal/server/routing/stage_health_test.go
+++ b/internal/server/routing/stage_health_test.go
@@ -73,11 +73,13 @@ func TestHealthStage_AllUnhealthy(t *testing.T) {
 	ctx := testContext(rule, "")
 	state := newSelectionState(ctx.Rule)
 
+	// Degrade, don't disappear: when every candidate is unhealthy, keep the full
+	// set so a service (and the real upstream 429/auth) still reaches the client.
 	result, handled := stage.Evaluate(ctx, state)
 	require.False(t, handled, "should continue even when all unhealthy")
 	require.NotNil(t, result)
 	state.candidateServices = result.FilteredServices
-	require.Len(t, state.candidateServices, 0, "all services should be filtered out")
+	require.Len(t, state.candidateServices, 2, "all-unhealthy degrades to the full set, not empty")
 }
 
 func TestHealthStage_NilServices(t *testing.T) {

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -1244,5 +1244,66 @@ func groupServicesByTier(services []*loadbalance.Service) []tierBucket {
 	return out
 }
 
+// IsAffinityEligible reports whether target is a service the routing strategy
+// would actually select right now, so session affinity can decide whether a
+// pin is still valid. It is config-shape driven rather than tactic-label
+// driven — "tier" is just the emergent shape of a multi-layer rule, so this
+// answers the same question for every shape:
+//
+//   - one service           → the only service; eligible whenever present.
+//   - one tier, many services → eligible iff target's own breaker is available
+//     (don't stick a session to a dead peer when healthy peers exist).
+//   - many tiers             → eligible iff target is breaker-available AND its
+//     tier is the highest-priority tier that currently has any available
+//     service (don't stay on a fallback tier after the primary recovers).
+//
+// It mirrors TierTactic.SelectService's bucket walk but uses the non-consuming
+// breaker read (IsAvailable) so it never steals the half-open probe. When
+// every service is tripped it falls back to "target is in the lowest-numbered
+// tier" (matching TierTactic's degrade-don't-disappear behavior) so a pin is
+// honored rather than wedging.
+func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Service) bool {
+	if target == nil || !target.Active {
+		return false
+	}
+	// Mirror GetActiveServices: inactive services are not selectable, so they
+	// must not influence the tier-availability computation (e.g. an inactive
+	// service whose breaker happens to be closed must not make its tier look
+	// "available" and wrongly demote a healthy pin in a lower tier).
+	active := make([]*loadbalance.Service, 0, len(services))
+	for _, svc := range services {
+		if svc != nil && svc.Active {
+			active = append(active, svc)
+		}
+	}
+	buckets := groupServicesByTier(active)
+	if len(buckets) == 0 {
+		return false
+	}
+
+	store := loadbalance.DefaultBreakerStore()
+	for _, group := range buckets {
+		available := false
+		targetAvailableHere := false
+		for _, svc := range group.services {
+			if store.IsAvailable(svc.ServiceID()) {
+				available = true
+				if svc.ServiceID() == target.ServiceID() {
+					targetAvailableHere = true
+				}
+			}
+		}
+		if available {
+			// This is the top available tier. The pin is valid only if the
+			// target itself is the (or an) available service in it.
+			return targetAvailableHere
+		}
+	}
+	// Every service is tripped — honor a pin to the lowest-numbered (highest
+	// priority) tier, which groupServicesByTier returns first, so the request
+	// still surfaces a real upstream error instead of wedging.
+	return target.Tier == buckets[0].tier
+}
+
 // Pre-created singleton priority tactic for the default-tactic registry.
 var defaultTierTactic = NewTierTactic(loadbalance.TacticRandom)

--- a/internal/typ/tier_availability_test.go
+++ b/internal/typ/tier_availability_test.go
@@ -1,0 +1,140 @@
+package typ
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// tripBreaker opens a service's breaker by recording the failure threshold.
+func tripBreaker(svc *loadbalance.Service) {
+	store := loadbalance.DefaultBreakerStore()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		store.RecordFailure(svc.ServiceID())
+	}
+}
+
+// Shape 3 (many tiers): the pin is eligible only in the top available tier.
+func TestIsAffinityEligible_TopTierAvailable(t *testing.T) {
+	t0 := mkService("ita-a-p0", "m", 0)
+	t1 := mkService("ita-a-p1", "m", 1)
+	svcs := []*loadbalance.Service{t0, t1}
+
+	if !IsAffinityEligible(svcs, t0) {
+		t.Fatal("t0 should be eligible when its breaker is closed")
+	}
+	if IsAffinityEligible(svcs, t1) {
+		t.Fatal("t1 must NOT be eligible while t0 (higher priority) is available")
+	}
+}
+
+func TestIsAffinityEligible_TopTierOpen_NextBecomesTop(t *testing.T) {
+	t0 := mkService("ita-b-p0", "m", 0)
+	t1 := mkService("ita-b-p1", "m", 1)
+	svcs := []*loadbalance.Service{t0, t1}
+
+	tripBreaker(t0)
+	defer loadbalance.DefaultBreakerStore().RecordSuccess(t0.ServiceID())
+
+	if IsAffinityEligible(svcs, t0) {
+		t.Fatal("t0 is open; it should not be eligible")
+	}
+	if !IsAffinityEligible(svcs, t1) {
+		t.Fatal("t1 should become eligible while t0 is open")
+	}
+}
+
+// Shape 2 (one tier, many services): a pin to a dead peer must be dropped while
+// healthy peers exist; a pin to a healthy peer is honored (stickiness).
+func TestIsAffinityEligible_SameTierDeadPeerDropped(t *testing.T) {
+	a := mkService("ita-peer-a", "m", 0)
+	b := mkService("ita-peer-b", "m", 0)
+	svcs := []*loadbalance.Service{a, b}
+
+	tripBreaker(a)
+	defer loadbalance.DefaultBreakerStore().RecordSuccess(a.ServiceID())
+
+	if IsAffinityEligible(svcs, a) {
+		t.Fatal("pin to a dead same-tier peer must be dropped when a healthy peer exists")
+	}
+	if !IsAffinityEligible(svcs, b) {
+		t.Fatal("pin to a healthy same-tier peer must be honored")
+	}
+}
+
+func TestIsAffinityEligible_AllOpen_FallsBackToLowestTier(t *testing.T) {
+	t0 := mkService("ita-c-p0", "m", 0)
+	t1 := mkService("ita-c-p1", "m", 1)
+	svcs := []*loadbalance.Service{t0, t1}
+
+	tripBreaker(t0)
+	tripBreaker(t1)
+	defer func() {
+		store := loadbalance.DefaultBreakerStore()
+		store.RecordSuccess(t0.ServiceID())
+		store.RecordSuccess(t1.ServiceID())
+	}()
+
+	// Degrade-don't-disappear: the lowest-numbered tier is the fallback.
+	if !IsAffinityEligible(svcs, t0) {
+		t.Fatal("when everything is open, a pin to the lowest tier (t0) is honored")
+	}
+	if IsAffinityEligible(svcs, t1) {
+		t.Fatal("t1 is not the fallback when everything is open")
+	}
+}
+
+// Shape 1 (single service): always eligible, even while its breaker is open
+// (nothing else to pick — failover/upstream-error path handles it).
+func TestIsAffinityEligible_SingleService(t *testing.T) {
+	only := mkService("ita-solo", "m", 0)
+	svcs := []*loadbalance.Service{only}
+
+	if !IsAffinityEligible(svcs, only) {
+		t.Fatal("single healthy service must be eligible")
+	}
+
+	tripBreaker(only)
+	defer loadbalance.DefaultBreakerStore().RecordSuccess(only.ServiceID())
+	if !IsAffinityEligible(svcs, only) {
+		t.Fatal("single service must stay eligible even when its breaker is open")
+	}
+}
+
+// An inactive service whose breaker is closed must not make its tier look
+// "available" and demote a healthy pin in a lower tier.
+func TestIsAffinityEligible_InactiveDoesNotMaskLowerTier(t *testing.T) {
+	t0 := mkService("ita-inact-p0", "m", 0)
+	t0.Active = false // configured but disabled; breaker untouched (closed)
+	t1 := mkService("ita-inact-p1", "m", 1)
+	svcs := []*loadbalance.Service{t0, t1}
+
+	// t0 is inactive → top active tier is t1 → a pin to t1 is eligible.
+	if !IsAffinityEligible(svcs, t1) {
+		t.Fatal("t1 should be eligible when the only higher tier is inactive")
+	}
+}
+
+func TestIsAffinityEligible_InactiveTargetDeclined(t *testing.T) {
+	a := mkService("ita-inact-target-a", "m", 0)
+	a.Active = false
+	b := mkService("ita-inact-target-b", "m", 0)
+	svcs := []*loadbalance.Service{a, b}
+
+	if IsAffinityEligible(svcs, a) {
+		t.Fatal("an inactive pinned service must never be eligible")
+	}
+	if !IsAffinityEligible(svcs, b) {
+		t.Fatal("the active peer should still be eligible")
+	}
+}
+
+func TestIsAffinityEligible_NilAndEmpty(t *testing.T) {
+	t0 := mkService("ita-d-p0", "m", 0)
+	if IsAffinityEligible([]*loadbalance.Service{t0}, nil) {
+		t.Fatal("nil target should be false")
+	}
+	if IsAffinityEligible(nil, t0) {
+		t.Fatal("empty service set should be false")
+	}
+}


### PR DESCRIPTION
## Summary

Session affinity had two critical bugs:  
(1) the configured TTL never expired because each request refreshed it, making the setting meaningless, and  
(2) sessions pinned to fallback tiers never returned to the primary tier after recovery.  

This PR implements strict TTL expiration and tier-aware affinity that respects both time-based expiration and runtime service health.

## Major

- **Strict TTL implementation**: Affinity locks now expire exactly at `LockedAt + SessionAffinity` seconds. Once expired, sessions re-enter the selection pipeline and receive a fresh lock with a new TTL. The previous behavior (sliding TTL) meant active sessions never expired, rendering the configuration ineffective.  
- **Tier-scoped affinity**: Session pins now respect tier priority and breaker state. A pinned service is only honored while it remains in the highest available tier. When a higher tier recovers, sessions automatically promote back to it. When a pinned service's breaker opens, sessions fail over to healthy peers within the same tier.  
- **Unified pipeline**: Collapsed three separate selection pipelines (no-affinity, global-affinity, smart-affinity) into a single self-guarding pipeline (health → affinity → smart → load_balancer). Each stage now handles its own enablement logic, eliminating mode-switching complexity.

## Minor

- Added `BreakerStore.IsAvailable()` for side-effect-free breaker reads (prevents stealing half-open probe slots during eligibility checks).  
- Health stage now degrades gracefully: when all candidates are unhealthy, it returns the full set instead of emptying it, ensuring clients receive real upstream errors rather than "no service available".  
- Comprehensive test coverage for strict TTL scenarios and tier-aware affinity behavior.  
- Design documentation updated with breaker threshold rationale, affinity decision flow diagrams, and complete affinity lifecycle documentation.