### PR TITLE
feat(harness): lb scenario tier — simulate tier/failover/breaker/affinity

### DIFF
--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -84,6 +84,7 @@ rolling-window / error-rate trigger, at which point the exact number barely matt
 
 Tuning: move `FailureThreshold` and `OpenDuration` together (aggressive threshold + long open = frequent
 mis-evictions). The right value depends on the upstream, so it's a natural per-rule config (Future work #4).
+The `harness lb` simulator keeps the health-monitor threshold aligned to this one.
 
 ### Session affinity must respect tier priority
 
@@ -118,6 +119,17 @@ Notes:
 - On a drop, the strategy re-selects and `postProcess` re-pins — the failover layer is untouched.
 - The pipeline runs **health → affinity → strategy**. `HealthFilter` only sees 429/auth, so the 500 signal comes straight from the breaker.
 - The two "drop" cases (both are `P in T* and P available? → no`): **cross-tier demote** (a higher tier recovered, so P's tier is no longer T\*) and **within-tier dead peer** (P is in T\* but its own breaker is open while a peer is up).
+
+#### Two feedback channels, and the `lb` simulator
+
+Each request outcome feeds **two channels**:
+
+- **Breaker** — binary success/failure, 3-strike trip, 30 s window. Drives tier demotion + affinity eligibility.
+- **Health monitor** (`Server.reportHealthStatus`) — status-classified: 429 → rate-limit window, 401/403 → *immediately* unhealthy, 5xx/other → 3-strike. Drives `HealthStage` filtering.
+
+So 429 and 401/403 exclude a service on the *first* hit (health channel), well before the breaker trips. The `harness lb` simulator models both faithfully (reusing `reportHealthStatus` + the breaker recorder), driving them off one shared clock so a single simulated advance recovers both.
+
+There is also a **third** time-based input: the **affinity TTL** (`AffinityEntry.ExpiresAt`). A lock expires *strictly* at `LockedAt + SessionAffinity` — an in-window request is honored but does **not** slide the expiry; once past it the pin is dropped and the session is re-selected and re-locked. The simulator puts this on the same clock seam (`loadbalance.SetClock` + `routing.SetClock`, both fed one fake clock), so a single `advance` moves breaker recovery, health recovery, *and* affinity expiry together — matching production, where all three read the wall clock. This lets the scenario suite assert the strict-TTL contract and cross-model failover (a failover hop must carry the fallback service's own model, not reuse the primary's) deterministically.
 
 ### End-to-end flow: how the tactic switch actually takes effect
 

--- a/.design/priority-routing.md
+++ b/.design/priority-routing.md
@@ -281,7 +281,7 @@ On a decline the pipeline falls through to the strategy, which re-selects a curr
 
 ### Verifying shapes end-to-end
 
-`internal/server/lb_scenario_test.go` is the scenario harness that drives the **full** path (selection → failover dispatch) against programmable fake upstreams over a request sequence, with a deterministic breaker clock (`loadbalance.SetClockForTest`). It covers each shape above plus the original sticky-affinity regression (trip → open → drop pin → recover → re-pin). Prefer extending it (rather than stage-level units alone) when changing routing/affinity/breaker behavior.
+`internal/server/lb_scenario_test.go` is the scenario harness that drives the **full** path (selection → failover dispatch) against programmable fake upstreams over a request sequence, with a deterministic breaker clock (`loadbalance.SetClockForTest`). It covers each shape above plus the original sticky-affinity regression (trip → open → drop pin → recover → re-pin), and the `harness lb` CLI tier shares the same engine. The CLI now self-checks via an optional `expect` block (all 13 built-in examples verify themselves), and coverage includes: half-open probe recovery, all-tiers-tripped degrade-to-T0, inactive-service exclusion, within-tier load sharing, and multi-session independent affinity. Prefer extending it (rather than stage-level units alone) when changing routing/affinity/breaker behavior.
 
 ## Value
 

--- a/.design/priority-routing.pencil.md
+++ b/.design/priority-routing.pencil.md
@@ -16,6 +16,7 @@ Contents:
 - Commit-seam coverage map
 - selectFallbackService filter pipeline
 - Key invariants
+- Worked example — 500 retry, request-by-request (with / without affinity)
 
 ## Two complementary failover levels
 
@@ -368,3 +369,72 @@ rule.GetActiveServices()
 - `Status() == 0` (untouched writer) ⇒ non-retryable — matches a client disconnect / no-write completion.
 - Budget cap = `len(activeServices)` — worst case visits each service once.
 - The assembly path (`HandleResponsesToAnthropic{V1,Beta}Assembly`) never commits mid-stream: it buffers a struct and emits one terminal `c.JSON`, so it flows through the gate like a non-streaming response.
+
+## Worked example — 500 retry, request-by-request
+
+A `t0`/`t1` tier rule. `t0` returns `500` three times then recovers; `t1` is healthy. A 500 is retried on
+**two independent timescales** — this is the whole mechanism:
+
+```
+  IN-REQUEST   (instant)     the gate BUFFERS t0's 500 (client never sees it) and retries t1 in the
+                             SAME request → the client gets t1's 200.
+
+  CROSS-REQUEST (cumulative) each 500 still counts against t0's breaker; 3 in a row TRIP it, so later
+                             requests skip t0 at selection time — failover isn't even needed.
+```
+
+```
+Legend:  ✗500 = t0 failed (buffered, hidden)    ✓200 = committed to client    → = in-request failover hop
+         ×N   = consecutive failures on t0 (trips at ×3)
+         DOWN = t0 breaker OPEN + health UNHEALTHY; both recover ~30s after the last failure
+```
+
+### With session affinity
+
+```
+ REQ  path                  client   t0 state         t1   pin
+ ───  ────────────────────  ──────   ──────────────   ──   ──
+  1   t0 ✗500 → t1 ✓200     200      healthy  ×1      ✓    t0
+  2   t0 ✗500 → t1 ✓200     200      healthy  ×2      ✓    t0
+  3   t0 ✗500 → t1 ✓200     200      DOWN     ×3      ✓    t0    ← t0 trips
+  4   t1 ✓200               200      down (skipped)   ✓    t1    ← pin follows the selection
+      ───── wait 30s: t0 breaker half-opens, health recovers ─────
+  5   t0 ✓200  (probe)      200      healthy          ✓    t0    ← snaps back to primary
+  6   t0 ✓200               200      healthy          ✓    t0
+```
+
+- **The client sees 200 the whole time** — failover hides all four 500s; they surface only as t0's state.
+- **The pin tracks the *selected* service, not the one that served.** Reqs 1–3 select t0 (which fails over
+  to t1), so `pin=t0`; it moves to t1 only at req 4 when *selection* itself moves. A blip never drags the
+  session off its primary.
+- **Tripping removes the hop:** reqs 1–3 cost two attempts each; from req 4 t0 isn't selected — one attempt.
+
+### Without session affinity
+
+Drop the `pin` column — selection re-walks the tier from T0 every request, so everything else is identical:
+
+```
+ REQ  path                  client   t0 state         t1
+  1   t0 ✗500 → t1 ✓200     200      healthy  ×1      ✓
+  2   t0 ✗500 → t1 ✓200     200      healthy  ×2      ✓
+  3   t0 ✗500 → t1 ✓200     200      DOWN     ×3      ✓
+  4   t1 ✓200               200      down (skipped)   ✓
+      ───── wait 30s ─────
+  5   t0 ✓200               200      healthy          ✓
+  6   t0 ✓200               200      healthy          ✓
+```
+
+**What affinity adds:** without it, tier is re-evaluated from T0 on every request, so recovery is automatic.
+Affinity layers a session→service lock on top; the Phase-1 fix makes that lock consult the **same breaker
+signal** (`IsAffinityEligible`), so it declines a pin sitting below a recovered tier (req 5) and snaps back —
+instead of pinning a session below a recovered tier forever.
+
+### When does a 500 actually reach the client?
+
+Only on **exhaustion**. Failover retries `429 / 500 / 502 / 503 / 504`; `401/403`, other `4xx`, and `2xx`
+are terminal (flushed as-is). If *every* tier 500s (t1 also fails), the loop runs out of candidates and the
+deferred `gate.CommitIfBuffered()` flushes the last buffered 500 to the client.
+
+> Verified against `harness lb --example cascade` (and the same shape with `affinity_secs: 0`): the `lb`
+> simulator drives the real `ServiceSelector.Select → dispatchWithPriorityFailover` path, so these match
+> runtime, not intent. Run `harness lb --example cascade --graph` to watch it live.

--- a/.github/workflows/harness-matrix.yml
+++ b/.github/workflows/harness-matrix.yml
@@ -36,6 +36,7 @@ on:
           - node
           - aisdk
           - replay
+          - lb
 
 permissions:
   contents: read
@@ -108,6 +109,10 @@ jobs:
             tier: replay
             focus: replay
             cmd: replay batch --upstream=vmodel
+          - name: lb
+            tier: lb
+            focus: lb
+            cmd: lb --all
     steps:
       - name: Skip unfocused leg
         id: gate

--- a/cli/harness/README.md
+++ b/cli/harness/README.md
@@ -240,6 +240,95 @@ providers.
 
 ---
 
+## Tier LB — `lb`
+
+Simulates **load-balancing dynamics** — tier selection, mid-request failover, the breaker (trip + *timed*
+recovery), and affinity stickiness / re-pinning — over a **request sequence** against programmable fake
+upstreams. It runs the real `ServiceSelector.Select → dispatchWithPriorityFailover` path with a
+deterministic breaker clock, so recovery is exercised without sleeping.
+
+```bash
+./harness lb --example cascade        # cascade | flat | grid | single | regression | ratelimit | authflip | crossmodel
+./harness lb --file scenario.yaml     # your own shape
+./harness lb --example grid --table   # compact table instead of the default graph
+./harness lb --example grid --json    # machine-readable trace
+```
+
+### Output
+
+The default is a pencil graph — per request, the failover hops plus a state line (each svc's breaker/health
++ the affinity pin), so the trip, health exclusion, and pin movement are visible step by step:
+
+```
+#3  s1   t0/gpt-4 ✗500  →  t1/gpt-4 ✓200   →  client=200
+       state: t0/gpt-4=open/unhealthy   t1/gpt-4=closed/healthy   pin=t0/gpt-4
+#4  s1   t1/gpt-4 ✓200   →  client=200
+       state: t0/gpt-4=open/unhealthy   t1/gpt-4=closed/healthy   pin=t1/gpt-4
+```
+
+`--table` gives a compact one-line-per-request form; `--json` the same data structurally. The engine
+(`internal/server.LBSimulator`) is shared with the Go scenario tests, so the CLI and CI assert the same thing.
+
+### HTTP status semantics
+
+The fault scripts are status codes, and the sim classifies them into the **two
+production feedback channels** exactly as a real request would (mirroring
+`Server.reportHealthStatus` + the breaker recorder), so the *special* codes
+behave faithfully:
+
+| status | failover (real loop) | breaker | health monitor |
+|--------|----------------------|---------|----------------|
+| 2xx | commit | success | `ReportSuccess` |
+| 429 | retry | failure | **rate-limited** (unhealthy for a window) |
+| 500/502/503/504 | retry | failure | error (3-strike) |
+| 401/403 | **terminal** | failure | **auth — immediately unhealthy** |
+| 400/404/other | **terminal** | failure | error (3-strike) |
+
+So a single **429** or **401/403** marks the service unhealthy on the *first* hit (health channel) and skips
+it next request — distinct from the breaker's 3-strike trip; `final health` / JSON `final_health` show it.
+Try `--example ratelimit` (429 → skipped → recovers) and `--example authflip` (401 → terminal + excluded).
+
+### Cross-model failover and strict affinity TTL
+
+Two behaviours the sim also models faithfully, matching recent fixes on the routing path:
+
+- **Cross-model failover** — when tiers carry different models, a failover hop dispatches the *fallback's own*
+  model, not the primary's. `--example crossmodel` shows it in the attempt column (`t0/model-a → t1/model-b`).
+- **Strict affinity TTL** — a lock expires exactly at `LockedAt + affinity_secs`; an in-window request is
+  honored but does **not** extend it. The affinity TTL rides the same fake clock as the breaker/health
+  (one `advance` moves all three), so the Go scenario suite asserts expiry-and-re-lock deterministically.
+
+### Scenario file
+
+A small YAML describes the rule *shape*, per-service fault scripts, and a program
+of requests / clock-advances (see `testdata/lb/cascade.yaml`):
+
+```yaml
+rule_uuid: cascade
+tactic: tier                 # tier | random
+affinity_secs: 1800          # 0 = off
+services:
+  - { provider: t0, model: gpt-4, tier: 0 }
+  - { provider: t1, model: gpt-4, tier: 1 }
+faults:                      # serviceID -> per-call status sequence (last entry repeats)
+  t0/gpt-4: [500, 500, 500, 200]
+  t1/gpt-4: [200]
+seed_pin: { session: s1, provider: t2, model: gpt-4 }   # optional: pre-lock a stale pin
+program:
+  - { request: s1 }          # request on session s1 (omit/"" = no affinity)
+  - { advance: 31s }         # move the breaker clock forward
+```
+
+The shapes map to the **"Rule config shapes" taxonomy** in
+`.design/priority-routing.md` (Single / Flat / Cascade / Grid). The
+**G1 horizontal-tactic breaker-blind gap** documented there is *not* yet modeled
+here (random/token tactics ignore the breaker at selection).
+
+**Use it for:** reproducing a customer's rule shape + outage pattern and watching
+exactly how routing, failover, the breaker, and affinity behave over a sequence.
+
+---
+
 ## Agent reference
 
 | agent      | API style          | gateway endpoint                  | built-in rule UUID  | RequestModel       |
@@ -254,12 +343,16 @@ providers.
 
 ```
 cli/harness/
-  main.go            Kong CLI root: version / matrix / agent / replay /
+  main.go            Kong CLI root: version / matrix / agent / replay / lb /
                      provider / init-config
   matrix.go          Tier A command — wraps protocoltest.Matrix
   replay.go          Tier B command — fixture replay, upstreams, skip list
   agent.go           Tier C command — agent CLI subprocess driver (+ env wiring)
   agent_real.go      Tier C real-provider mode: config iteration, per-entry runs
+  lb.go              Tier LB command — load-balancing scenario simulator
+                     (engine: internal/server.LBSimulator; shapes per
+                     .design/priority-routing.md)
+  testdata/lb/       sample LB scenario YAML files
   config.go          init-config: generates providers.yaml from provider templates
   provider.go        Tier D placeholder (live provider API tests — not impl.)
   summary.go         CSV summary persistence / resume bookkeeping

--- a/cli/harness/README.md
+++ b/cli/harness/README.md
@@ -248,7 +248,7 @@ upstreams. It runs the real `ServiceSelector.Select → dispatchWithPriorityFail
 deterministic breaker clock, so recovery is exercised without sleeping.
 
 ```bash
-./harness lb --example cascade        # cascade | flat | grid | single | regression | ratelimit | authflip | crossmodel
+./harness lb --example cascade        # cascade | flat | grid | single | regression | ratelimit | authflip | crossmodel | halfopen | degrade | inactive | withintier | multiaffinity
 ./harness lb --file scenario.yaml     # your own shape
 ./harness lb --example grid --table   # compact table instead of the default graph
 ./harness lb --example grid --json    # machine-readable trace
@@ -260,10 +260,10 @@ The default is a pencil graph — per request, the failover hops plus a state li
 + the affinity pin), so the trip, health exclusion, and pin movement are visible step by step:
 
 ```
-#3  s1   t0/gpt-4 ✗500  →  t1/gpt-4 ✓200   →  client=200
-       state: t0/gpt-4=open/unhealthy   t1/gpt-4=closed/healthy   pin=t0/gpt-4
-#4  s1   t1/gpt-4 ✓200   →  client=200
-       state: t0/gpt-4=open/unhealthy   t1/gpt-4=closed/healthy   pin=t1/gpt-4
+#3  s1   openai/gpt-5.4 ✗500  →  openai/gpt-5.5 ✓200   →  client=200
+       state: openai/gpt-5.4=open/unhealthy   openai/gpt-5.5=closed/healthy   pin=openai/gpt-5.4
+#4  s1   openai/gpt-5.5 ✓200   →  client=200
+       state: openai/gpt-5.4=open/unhealthy   openai/gpt-5.5=closed/healthy   pin=openai/gpt-5.5
 ```
 
 `--table` gives a compact one-line-per-request form; `--json` the same data structurally. The engine
@@ -293,10 +293,27 @@ Try `--example ratelimit` (429 → skipped → recovers) and `--example authflip
 Two behaviours the sim also models faithfully, matching recent fixes on the routing path:
 
 - **Cross-model failover** — when tiers carry different models, a failover hop dispatches the *fallback's own*
-  model, not the primary's. `--example crossmodel` shows it in the attempt column (`t0/model-a → t1/model-b`).
+  model, not the primary's. `--example crossmodel` shows it in the attempt column (`openai/gpt-5.4 → anthropic/claude-opus`).
 - **Strict affinity TTL** — a lock expires exactly at `LockedAt + affinity_secs`; an in-window request is
   honored but does **not** extend it. The affinity TTL rides the same fake clock as the breaker/health
   (one `advance` moves all three), so the Go scenario suite asserts expiry-and-re-lock deterministically.
+
+### Self-check (`expect`)
+
+Built-in examples include an optional `expect` block that self-checks expected outcomes after the program runs. On mismatch, the CLI exits non-zero — useful for CI and for validating user `--file` scenarios. Fields (all optional):
+
+- `final_status` — last request's `FinalStatus`
+- `attempts` — last request's `Attempts` (exact, in order)
+- `attempts_contain` / `attempts_exclude` — set membership checks
+- `pin` / `pins` — final affinity pin (single-session or per-session)
+- `breaker` / `health` — final snapshot subsets
+- `distinct_first_attempts` — set of first-attempt serviceIDs across ALL request steps (within-tier load sharing)
+
+All 13 built-in examples self-verify. The `expect` block is also available in `--file` scenarios, so users can self-check their own rules.
+
+### Within-tier sub-tactic
+
+The `tier` tactic supports a `within_tier_tactic` field (`random` by default; also `token_based`, `latency_based`, etc.) to choose how load is shared among services in the same tier. `--example withintier` demonstrates it with `random`, asserting that both top-tier peers appear as first attempts across 20 requests.
 
 ### Scenario file
 
@@ -306,14 +323,20 @@ of requests / clock-advances (see `testdata/lb/cascade.yaml`):
 ```yaml
 rule_uuid: cascade
 tactic: tier                 # tier | random
+within_tier_tactic: random   # optional: within-tier sub-tactic (default: random); tier tactic only
 affinity_secs: 1800          # 0 = off
 services:
-  - { provider: t0, model: gpt-4, tier: 0 }
-  - { provider: t1, model: gpt-4, tier: 1 }
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: openai, model: gpt-5.5, tier: 1 }
 faults:                      # serviceID -> per-call status sequence (last entry repeats)
-  t0/gpt-4: [500, 500, 500, 200]
-  t1/gpt-4: [200]
-seed_pin: { session: s1, provider: t2, model: gpt-4 }   # optional: pre-lock a stale pin
+  openai/gpt-5.4: [500, 500, 500, 200]
+  openai/gpt-5.5: [200]
+seed_pin: { session: s1, provider: anthropic, model: claude-sonnet }   # optional: pre-lock a stale pin
+expect:                      # optional: self-check assertions (all fields optional)
+  final_status: 200
+  attempts: [openai/gpt-5.4]
+  pin: openai/gpt-5.4
+  breaker: { openai/gpt-5.4: closed, openai/gpt-5.5: closed }
 program:
   - { request: s1 }          # request on session s1 (omit/"" = no affinity)
   - { advance: 31s }         # move the breaker clock forward

--- a/cli/harness/lb.go
+++ b/cli/harness/lb.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/server"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// LbCmd is Tier "LB" — it drives the real load-balancing path (selection +
+// failover dispatch) against programmable fake upstreams over a request
+// sequence, with a deterministic breaker clock, and prints the routing trace.
+// It reuses the same simulation engine as the Go scenario tests
+// (internal/server.LBSimulator). See .design/priority-routing.md
+// "Rule config shapes (taxonomy)".
+type LbCmd struct {
+	File    string `kong:"name='file',short='f',help='Scenario YAML file (see --example for the schema)'"`
+	Example string `kong:"name='example',help='Run a built-in example instead of --file: cascade|flat|grid|single|regression|ratelimit|authflip|crossmodel'"`
+	JSON    bool   `kong:"name='json',help='Emit the trace as JSON'"`
+	Table   bool   `kong:"name='table',short='t',help='Compact table view (default is the pencil graph)'"`
+	Verbose bool   `kong:"name='verbose',short='v',help='Show gateway logs (default: quiet)'"`
+}
+
+// lbScenario is the YAML schema for a scenario file.
+type lbScenario struct {
+	RuleUUID     string           `yaml:"rule_uuid"`
+	Tactic       string           `yaml:"tactic"`        // "tier" (default) | "random"
+	AffinitySecs int              `yaml:"affinity_secs"` // 0 = affinity off
+	Services     []lbServiceSpec  `yaml:"services"`
+	Faults       map[string][]int `yaml:"faults"`   // serviceID ("provider/model") -> per-call status sequence (last repeats)
+	SeedPin      *lbSeedSpec      `yaml:"seed_pin"` // optional: lock a session before the program runs
+	Program      []lbStep         `yaml:"program"`  // ordered request / advance steps
+}
+
+// lbSeedSpec pre-locks a session to a service (e.g. to reproduce a stale pin).
+type lbSeedSpec struct {
+	Session  string `yaml:"session"`
+	Provider string `yaml:"provider"`
+	Model    string `yaml:"model"`
+}
+
+type lbServiceSpec struct {
+	Provider string `yaml:"provider"`
+	Model    string `yaml:"model"`
+	Tier     int    `yaml:"tier"`
+	Inactive bool   `yaml:"inactive"`
+}
+
+// lbStep is one program step: exactly one of Request / Advance.
+type lbStep struct {
+	Request *string `yaml:"request"` // session id (use "" for no affinity)
+	Advance string  `yaml:"advance"` // duration, e.g. "31s"
+}
+
+func (c *LbCmd) Run() error {
+	if !c.Verbose {
+		// config.NewConfig runs migrations/seeds at Info; keep the trace clean.
+		logrus.SetLevel(logrus.WarnLevel)
+	}
+
+	scn, err := c.loadScenario()
+	if err != nil {
+		return err
+	}
+
+	rule, err := buildLBRule(scn)
+	if err != nil {
+		return err
+	}
+
+	sim, cleanup, err := server.NewLBSimulator(rule, scn.Faults)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if scn.SeedPin != nil {
+		sim.SeedPin(scn.SeedPin.Session, scn.SeedPin.Provider, scn.SeedPin.Model)
+	}
+
+	out := lbRunOutput{
+		Rule:     scn.RuleUUID,
+		Tactic:   strings.ToLower(strings.TrimSpace(scn.Tactic)),
+		Affinity: scn.AffinitySecs,
+	}
+	for _, svc := range rule.Services {
+		out.Services = append(out.Services, fmt.Sprintf("%s (T%d%s)", svc.ServiceID(), svc.Tier, inactiveTag(svc.Active)))
+	}
+
+	for _, step := range scn.Program {
+		if step.Advance != "" {
+			d, perr := time.ParseDuration(step.Advance)
+			if perr != nil {
+				return fmt.Errorf("program: bad advance duration %q: %w", step.Advance, perr)
+			}
+			sim.Advance(d)
+			out.Steps = append(out.Steps, lbStepOutput{Advance: step.Advance})
+			continue
+		}
+		session := ""
+		if step.Request != nil {
+			session = *step.Request
+		}
+		tr, rerr := sim.Request(session)
+		if rerr != nil {
+			return fmt.Errorf("program: request (session=%q): %w", session, rerr)
+		}
+		out.Steps = append(out.Steps, lbStepOutput{Trace: &tr})
+	}
+	out.FinalBreakers = sim.BreakerStates()
+	out.FinalHealth = sim.HealthStates()
+
+	// Ordered service IDs (rule order) for the per-request state line.
+	orderedIDs := make([]string, 0, len(rule.Services))
+	for _, svc := range rule.Services {
+		orderedIDs = append(orderedIDs, svc.ServiceID())
+	}
+
+	switch {
+	case c.JSON:
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	case c.Table:
+		out.renderTable(os.Stdout)
+	default:
+		out.renderGraph(os.Stdout, orderedIDs)
+	}
+	return nil
+}
+
+func (c *LbCmd) loadScenario() (*lbScenario, error) {
+	if c.File != "" && c.Example != "" {
+		return nil, fmt.Errorf("pass only one of --file / --example")
+	}
+	if c.File != "" {
+		raw, err := os.ReadFile(c.File)
+		if err != nil {
+			return nil, fmt.Errorf("read scenario: %w", err)
+		}
+		var scn lbScenario
+		if err := yaml.Unmarshal(raw, &scn); err != nil {
+			return nil, fmt.Errorf("parse scenario: %w", err)
+		}
+		return &scn, nil
+	}
+	name := c.Example
+	if name == "" {
+		name = "cascade"
+		fmt.Fprintln(os.Stderr, "no --file/--example given; running built-in example 'cascade' (see --help)")
+	}
+	scn, ok := lbExamples[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown --example %q (have: cascade, flat, grid, single, regression, ratelimit, authflip, crossmodel)", name)
+	}
+	return scn, nil
+}
+
+// buildLBRule turns a scenario spec into a typ.Rule.
+func buildLBRule(scn *lbScenario) (*typ.Rule, error) {
+	if len(scn.Services) == 0 {
+		return nil, fmt.Errorf("scenario has no services")
+	}
+	uuid := scn.RuleUUID
+	if uuid == "" {
+		uuid = "lb-scenario"
+	}
+	services := make([]*loadbalance.Service, 0, len(scn.Services))
+	for _, s := range scn.Services {
+		if s.Provider == "" || s.Model == "" {
+			return nil, fmt.Errorf("service needs provider and model: %+v", s)
+		}
+		services = append(services, &loadbalance.Service{
+			Provider: s.Provider, Model: s.Model, Tier: s.Tier, Weight: 1, Active: !s.Inactive,
+		})
+	}
+
+	rule := &typ.Rule{
+		UUID:         uuid,
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "gpt-4",
+		Active:       true,
+		Services:     services,
+	}
+	rule.Flags.SessionAffinity = scn.AffinitySecs
+
+	switch strings.ToLower(strings.TrimSpace(scn.Tactic)) {
+	case "", "tier":
+		rule.LBTactic = typ.Tactic{Type: loadbalance.TacticTier, Params: typ.DefaultTierParams()}
+	case "random":
+		rule.LBTactic = typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.DefaultRandomParams()}
+	default:
+		return nil, fmt.Errorf("unsupported tactic %q (have: tier, random)", scn.Tactic)
+	}
+	return rule, nil
+}
+
+func inactiveTag(active bool) string {
+	if active {
+		return ""
+	}
+	return ",inactive"
+}
+
+// ---- output ----
+
+type lbRunOutput struct {
+	Rule          string            `json:"rule"`
+	Tactic        string            `json:"tactic"`
+	Affinity      int               `json:"affinity_secs"`
+	Services      []string          `json:"services"`
+	Steps         []lbStepOutput    `json:"steps"`
+	FinalBreakers map[string]string `json:"final_breakers"`
+	FinalHealth   map[string]string `json:"final_health"`
+}
+
+type lbStepOutput struct {
+	Trace   *server.LBTrace `json:"trace,omitempty"`
+	Advance string          `json:"advance,omitempty"`
+}
+
+func (o lbRunOutput) renderTable(w *os.File) {
+	tactic := o.Tactic
+	if tactic == "" {
+		tactic = "tier"
+	}
+	fmt.Fprintf(w, "LB scenario %q  tactic=%s  affinity=%ds\n", o.Rule, tactic, o.Affinity)
+	fmt.Fprintf(w, "services: %s\n\n", strings.Join(o.Services, "  "))
+	fmt.Fprintf(w, "%-4s %-10s %-34s %-7s %s\n", "#", "session", "attempts", "status", "pin")
+
+	n := 0
+	for _, st := range o.Steps {
+		if st.Advance != "" {
+			fmt.Fprintf(w, "     -- advance %s --\n", st.Advance)
+			continue
+		}
+		n++
+		tr := st.Trace
+		sess := tr.Session
+		if sess == "" {
+			sess = "-"
+		}
+		fmt.Fprintf(w, "%-4d %-10s %-34s %-7d %s\n",
+			n, sess, strings.Join(tr.Attempts, " → "), tr.FinalStatus, dashIfEmpty(tr.PinAfter))
+	}
+
+	fmt.Fprintf(w, "\nfinal breakers: %s\n", formatBreakers(o.FinalBreakers))
+	fmt.Fprintf(w, "final health:   %s\n", formatBreakers(o.FinalHealth))
+}
+
+// renderGraph prints a pencil-graph view: per request a hop line (failover path
+// annotated with ✓/✗ + status) and a state line (each svc's breaker/health +
+// the affinity pin) — mirroring .design/priority-routing.pencil.md.
+func (o lbRunOutput) renderGraph(w *os.File, orderedIDs []string) {
+	tactic := o.Tactic
+	if tactic == "" {
+		tactic = "tier"
+	}
+	fmt.Fprintf(w, "LB scenario %q  tactic=%s  affinity=%ds\n", o.Rule, tactic, o.Affinity)
+	fmt.Fprintf(w, "services: %s\n", strings.Join(o.Services, "  "))
+	fmt.Fprintf(w, "legend:   ✓=2xx committed   ✗=non-2xx (buffered/terminal)   →=in-request failover hop\n\n")
+
+	n := 0
+	for _, st := range o.Steps {
+		if st.Advance != "" {
+			fmt.Fprintf(w, "        ⋯ advance %s (breaker + health clocks move) ⋯\n\n", st.Advance)
+			continue
+		}
+		n++
+		tr := st.Trace
+
+		hops := make([]string, len(tr.Attempts))
+		for i, sid := range tr.Attempts {
+			status := 0
+			if i < len(tr.Statuses) {
+				status = tr.Statuses[i]
+			}
+			mark := "✗"
+			if status >= 200 && status < 300 {
+				mark = "✓"
+			}
+			hops[i] = fmt.Sprintf("%s %s%d", sid, mark, status)
+		}
+		sess := tr.Session
+		if sess == "" {
+			sess = "-"
+		}
+		fmt.Fprintf(w, "#%-2d %-8s %s   →  client=%d\n", n, sess, strings.Join(hops, "  →  "), tr.FinalStatus)
+
+		states := make([]string, 0, len(orderedIDs))
+		for _, id := range orderedIDs {
+			states = append(states, fmt.Sprintf("%s=%s/%s", id, tr.BreakerAfter[id], tr.HealthAfter[id]))
+		}
+		line := strings.Join(states, "   ")
+		if tr.PinAfter != "" {
+			line += "   pin=" + tr.PinAfter
+		}
+		fmt.Fprintf(w, "       state: %s\n\n", line)
+	}
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func formatBreakers(m map[string]string) string {
+	parts := make([]string, 0, len(m))
+	for id, st := range m {
+		parts = append(parts, fmt.Sprintf("%s=%s", id, st))
+	}
+	return strings.Join(parts, "  ")
+}
+
+// ---- built-in examples ----
+
+func sess(s string) *string { return &s }
+
+var lbExamples = map[string]*lbScenario{
+	// Cascade: primary fails 3x then recovers; watch the pin move to t1 and snap
+	// back to t0 after the breaker's open window elapses.
+	"cascade": {
+		RuleUUID: "cascade", Tactic: "tier", AffinitySecs: 1800,
+		Services: []lbServiceSpec{{Provider: "t0", Model: "gpt-4", Tier: 0}, {Provider: "t1", Model: "gpt-4", Tier: 1}},
+		Faults:   map[string][]int{"t0/gpt-4": {500, 500, 500, 200}, "t1/gpt-4": {200}},
+		Program: []lbStep{
+			{Request: sess("s1")}, {Request: sess("s1")}, {Request: sess("s1")},
+			{Request: sess("s1")},
+			{Advance: "31s"},
+			{Request: sess("s1")}, {Request: sess("s1")},
+		},
+	},
+	// Flat: one tier, two peers, random tactic — affinity stickiness to one peer.
+	"flat": {
+		RuleUUID: "flat", Tactic: "random", AffinitySecs: 1800,
+		Services: []lbServiceSpec{{Provider: "a", Model: "gpt-4", Tier: 0}, {Provider: "b", Model: "gpt-4", Tier: 0}},
+		Faults:   map[string][]int{"a/gpt-4": {200}, "b/gpt-4": {200}},
+		Program:  []lbStep{{Request: sess("s1")}, {Request: sess("s1")}, {Request: sess("s1")}},
+	},
+	// Grid: two tiers x two peers; the whole top tier 500s and trips, then
+	// selection drops to the low tier.
+	"grid": {
+		RuleUUID: "grid", Tactic: "tier", AffinitySecs: 0,
+		Services: []lbServiceSpec{
+			{Provider: "t0a", Model: "gpt-4", Tier: 0}, {Provider: "t0b", Model: "gpt-4", Tier: 0},
+			{Provider: "t1a", Model: "gpt-4", Tier: 1}, {Provider: "t1b", Model: "gpt-4", Tier: 1},
+		},
+		Faults: map[string][]int{"t0a/gpt-4": {500}, "t0b/gpt-4": {500}, "t1a/gpt-4": {200}, "t1b/gpt-4": {200}},
+		Program: []lbStep{
+			{Request: sess("")}, {Request: sess("")}, {Request: sess("")},
+			{Request: sess("")}, {Request: sess("")},
+		},
+	},
+	// Single: one service; a 500 has nowhere to fail over to.
+	"single": {
+		RuleUUID: "single", Tactic: "tier", AffinitySecs: 0,
+		Services: []lbServiceSpec{{Provider: "only", Model: "gpt-4", Tier: 0}},
+		Faults:   map[string][]int{"only/gpt-4": {200, 500, 200}},
+		Program:  []lbStep{{Request: sess("")}, {Request: sess("")}, {Request: sess("")}},
+	},
+	// Regression: a stale pin to the fallback tier must snap back to the healthy
+	// primary on the next request.
+	"regression": {
+		RuleUUID: "regression", Tactic: "tier", AffinitySecs: 1800,
+		Services: []lbServiceSpec{{Provider: "t1", Model: "gpt-4", Tier: 0}, {Provider: "t2", Model: "gpt-4", Tier: 1}},
+		Faults:   map[string][]int{"t1/gpt-4": {200}, "t2/gpt-4": {200}},
+		SeedPin:  &lbSeedSpec{Session: "s1", Provider: "t2", Model: "gpt-4"}, // stale pin to the fallback tier
+		Program:  []lbStep{{Request: sess("s1")}, {Request: sess("s1")}},
+	},
+	// Rate-limit: a single 429 marks t0 unhealthy via the health monitor, so it's
+	// skipped on the NEXT request even though its breaker has one strike — then it
+	// recovers after the rate-limit window.
+	"ratelimit": {
+		RuleUUID: "ratelimit", Tactic: "tier", AffinitySecs: 0,
+		Services: []lbServiceSpec{{Provider: "t0", Model: "gpt-4", Tier: 0}, {Provider: "t1", Model: "gpt-4", Tier: 1}},
+		Faults:   map[string][]int{"t0/gpt-4": {429, 200}, "t1/gpt-4": {200}},
+		Program: []lbStep{
+			{Request: sess("")}, // t0 429 → fail over to t1; t0 rate-limited
+			{Request: sess("")}, // t0 health-excluded → straight to t1
+			{Advance: "31s"},
+			{Request: sess("")}, // window elapsed → back to t0
+		},
+	},
+	// Cross-model: each tier carries a different model. On failover the hop must
+	// dispatch the fallback's OWN model (t1/model-b), not reuse the primary's
+	// (t0/model-a) — the bug fixed in #1233. Read the attempt column: the second
+	// hop is "t1/model-b", proving the model travelled with the failover.
+	"crossmodel": {
+		RuleUUID: "crossmodel", Tactic: "tier", AffinitySecs: 0,
+		Services: []lbServiceSpec{{Provider: "t0", Model: "model-a", Tier: 0}, {Provider: "t1", Model: "model-b", Tier: 1}},
+		Faults:   map[string][]int{"t0/model-a": {500}, "t1/model-b": {200}},
+		Program:  []lbStep{{Request: sess("")}},
+	},
+	// Auth flip: 401 is terminal (no failover masks it) AND marks t0 immediately
+	// unhealthy, so it's excluded next request.
+	"authflip": {
+		RuleUUID: "authflip", Tactic: "tier", AffinitySecs: 0,
+		Services: []lbServiceSpec{{Provider: "t0", Model: "gpt-4", Tier: 0}, {Provider: "t1", Model: "gpt-4", Tier: 1}},
+		Faults:   map[string][]int{"t0/gpt-4": {401, 200}, "t1/gpt-4": {200}},
+		Program: []lbStep{
+			{Request: sess("")}, // t0 401 → terminal (client sees 401); t0 unhealthy
+			{Request: sess("")}, // t0 excluded → t1
+		},
+	},
+}

--- a/cli/harness/lb.go
+++ b/cli/harness/lb.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"embed"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -15,6 +17,22 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// lbExampleFS embeds the built-in scenario YAMLs under testdata/lb/. They are
+// the single source of truth for the built-in examples — lb --example <name>
+// parses them at runtime, so the on-disk YAML schema and the built-in examples
+// can never drift. User-supplied --file scenarios use the same schema.
+//
+//go:embed testdata/lb/*.yaml
+var lbExampleFS embed.FS
+
+// lbExampleNames is the canonical ordered list of built-in example names
+// (matches the testdata/lb/*.yaml basenames). Used by --all and the unknown-
+// example error message.
+var lbExampleNames = []string{
+	"cascade", "flat", "grid", "single", "regression", "ratelimit", "authflip",
+	"crossmodel", "halfopen", "degrade", "inactive", "withintier", "multiaffinity",
+}
+
 // LbCmd is Tier "LB" — it drives the real load-balancing path (selection +
 // failover dispatch) against programmable fake upstreams over a request
 // sequence, with a deterministic breaker clock, and prints the routing trace.
@@ -23,7 +41,8 @@ import (
 // "Rule config shapes (taxonomy)".
 type LbCmd struct {
 	File    string `kong:"name='file',short='f',help='Scenario YAML file (see --example for the schema)'"`
-	Example string `kong:"name='example',help='Run a built-in example instead of --file: cascade|flat|grid|single|regression|ratelimit|authflip|crossmodel'"`
+	Example string `kong:"name='example',help='Run a built-in example instead of --file: cascade|flat|grid|single|regression|ratelimit|authflip|crossmodel|halfopen|degrade|inactive|withintier|multiaffinity'"`
+	All     bool   `kong:"name='all',help='Run all built-in examples in sequence (useful for CI)'"`
 	JSON    bool   `kong:"name='json',help='Emit the trace as JSON'"`
 	Table   bool   `kong:"name='table',short='t',help='Compact table view (default is the pencil graph)'"`
 	Verbose bool   `kong:"name='verbose',short='v',help='Show gateway logs (default: quiet)'"`
@@ -31,13 +50,15 @@ type LbCmd struct {
 
 // lbScenario is the YAML schema for a scenario file.
 type lbScenario struct {
-	RuleUUID     string           `yaml:"rule_uuid"`
-	Tactic       string           `yaml:"tactic"`        // "tier" (default) | "random"
-	AffinitySecs int              `yaml:"affinity_secs"` // 0 = affinity off
-	Services     []lbServiceSpec  `yaml:"services"`
-	Faults       map[string][]int `yaml:"faults"`   // serviceID ("provider/model") -> per-call status sequence (last repeats)
-	SeedPin      *lbSeedSpec      `yaml:"seed_pin"` // optional: lock a session before the program runs
-	Program      []lbStep         `yaml:"program"`  // ordered request / advance steps
+	RuleUUID         string           `yaml:"rule_uuid"`
+	Tactic           string           `yaml:"tactic"`             // "tier" (default) | "random"
+	WithinTierTactic string           `yaml:"within_tier_tactic"` // "random" (default) | "token_based" | ...; tier tactic only
+	AffinitySecs     int              `yaml:"affinity_secs"`      // 0 = affinity off
+	Services         []lbServiceSpec  `yaml:"services"`
+	Faults           map[string][]int `yaml:"faults"`   // serviceID ("provider/model") -> per-call status sequence (last repeats)
+	SeedPin          *lbSeedSpec      `yaml:"seed_pin"` // optional: lock a session before the program runs
+	Program          []lbStep         `yaml:"program"`  // ordered request / advance steps
+	Expect           *lbExpect        `yaml:"expect"`   // optional: self-check assertions
 }
 
 // lbSeedSpec pre-locks a session to a service (e.g. to reproduce a stale pin).
@@ -60,12 +81,71 @@ type lbStep struct {
 	Advance string  `yaml:"advance"` // duration, e.g. "31s"
 }
 
+// lbExpect is the optional self-check block. All fields optional; a missing
+// field is not asserted. Evaluated against the LAST request's trace plus the
+// FINAL snapshots after the program runs.
+type lbExpect struct {
+	// FinalStatus is the last request's FinalStatus.
+	FinalStatus *int `yaml:"final_status"`
+	// Attempts is the last request's Attempts (exact, in order).
+	Attempts []string `yaml:"attempts"`
+	// AttemptsContain is the last request's Attempts must include each (set membership, order-independent).
+	AttemptsContain []string `yaml:"attempts_contain"`
+	// AttemptsExclude is the last request's Attempts must NOT include any.
+	AttemptsExclude []string `yaml:"attempts_exclude"`
+	// Pin is the final affinity pin for the last request's session ("" = no pin).
+	Pin *string `yaml:"pin"`
+	// Pins is final pin per named session (multi-session).
+	Pins map[string]string `yaml:"pins"`
+	// Breaker is final breaker snapshot subset (serviceID -> closed|open|half_open).
+	Breaker map[string]string `yaml:"breaker"`
+	// Health is final health snapshot subset (serviceID -> healthy|unhealthy).
+	Health map[string]string `yaml:"health"`
+	// DistinctFirstAttempts is the set of distinct serviceIDs that ever appeared as
+	// the FIRST attempt across ALL request steps (within-tier load sharing).
+	DistinctFirstAttempts []string `yaml:"distinct_first_attempts"`
+}
+
 func (c *LbCmd) Run() error {
 	if !c.Verbose {
 		// config.NewConfig runs migrations/seeds at Info; keep the trace clean.
 		logrus.SetLevel(logrus.WarnLevel)
 	}
 
+	// --all mode: run all built-in examples in sequence.
+	if c.All {
+		if c.File != "" || c.Example != "" {
+			return fmt.Errorf("--all cannot be used with --file or --example")
+		}
+		// Ordered list of all built-in examples (matches testdata/lb/*.yaml).
+		examples := lbExampleNames
+		for i, name := range examples {
+			// Clear the global breaker store between examples to avoid state leakage.
+			loadbalance.DefaultBreakerStore().Reset()
+			// Temporarily set Example and clear File/All for this run.
+			origFile := c.File
+			origAll := c.All
+			c.File = ""
+			c.All = false
+			c.Example = name
+			fmt.Fprintf(os.Stderr, "▶ Running [%d/%d] %s\n", i+1, len(examples), name)
+			if err := c.runOne(); err != nil {
+				return fmt.Errorf("example %s failed: %w", name, err)
+			}
+			// Restore original values.
+			c.File = origFile
+			c.All = origAll
+			c.Example = ""
+		}
+		fmt.Fprintf(os.Stderr, "✅ All %d lb examples passed\n", len(examples))
+		return nil
+	}
+
+	return c.runOne()
+}
+
+// runOne runs a single scenario (either --file, --example, or default).
+func (c *LbCmd) runOne() error {
 	scn, err := c.loadScenario()
 	if err != nil {
 		return err
@@ -95,6 +175,13 @@ func (c *LbCmd) Run() error {
 		out.Services = append(out.Services, fmt.Sprintf("%s (T%d%s)", svc.ServiceID(), svc.Tier, inactiveTag(svc.Active)))
 	}
 
+	// Track distinct first-attempt serviceIDs for DistinctFirstAttempts assertion.
+	firstAttempts := make(map[string]bool)
+	var lastTrace *server.LBTrace
+	var lastSession string
+	// Capture final pins per session for Pins assertion.
+	finalPins := make(map[string]string)
+
 	for _, step := range scn.Program {
 		if step.Advance != "" {
 			d, perr := time.ParseDuration(step.Advance)
@@ -114,9 +201,30 @@ func (c *LbCmd) Run() error {
 			return fmt.Errorf("program: request (session=%q): %w", session, rerr)
 		}
 		out.Steps = append(out.Steps, lbStepOutput{Trace: &tr})
+		lastTrace = &tr
+		lastSession = session
+		// Track the first attempt of each request for DistinctFirstAttempts.
+		if len(tr.Attempts) > 0 {
+			firstAttempts[tr.Attempts[0]] = true
+		}
+		// Capture the final pin for this session.
+		if session != "" {
+			finalPins[session] = sim.Pin(session)
+		}
 	}
 	out.FinalBreakers = sim.BreakerStates()
 	out.FinalHealth = sim.HealthStates()
+
+	// Self-check: evaluate Expect if provided.
+	if scn.Expect != nil {
+		finalPin := ""
+		if lastTrace != nil && lastSession != "" {
+			finalPin = sim.Pin(lastSession)
+		}
+		if cerr := c.checkExpect(scn, out.Steps, out.FinalBreakers, out.FinalHealth, lastTrace, lastSession, finalPin, finalPins, firstAttempts); cerr != nil {
+			return cerr
+		}
+	}
 
 	// Ordered service IDs (rule order) for the per-request state line.
 	orderedIDs := make([]string, 0, len(rule.Services))
@@ -135,6 +243,153 @@ func (c *LbCmd) Run() error {
 		out.renderGraph(os.Stdout, orderedIDs)
 	}
 	return nil
+}
+
+// checkExpect evaluates the Expect block after the program runs. On mismatch,
+// returns an error → non-zero exit (CI leg fails).
+func (c *LbCmd) checkExpect(scn *lbScenario, steps []lbStepOutput, finalBreakers, finalHealth map[string]string, lastTrace *server.LBTrace, lastSession string, finalPin string, finalPins map[string]string, firstAttempts map[string]bool) error {
+	e := scn.Expect
+	if e == nil {
+		return nil
+	}
+
+	// Helper: string pointer to string (or "" if nil).
+	ptrStr := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+	// Helper: int pointer to int (or 0 if nil).
+	ptrInt := func(p *int) int {
+		if p == nil {
+			return 0
+		}
+		return *p
+	}
+
+	// FinalStatus: last request's FinalStatus.
+	if e.FinalStatus != nil {
+		got := 0
+		if lastTrace != nil {
+			got = lastTrace.FinalStatus
+		}
+		if want := ptrInt(e.FinalStatus); got != want {
+			return fmt.Errorf("expect: final_status: want %d, got %d", want, got)
+		}
+	}
+
+	// Attempts: last request's Attempts (exact, in order).
+	if len(e.Attempts) > 0 {
+		got := []string{}
+		if lastTrace != nil {
+			got = lastTrace.Attempts
+		}
+		if !equalSlices(got, e.Attempts) {
+			return fmt.Errorf("expect: attempts: want %v, got %v", e.Attempts, got)
+		}
+	}
+
+	// AttemptsContain: last request must include each serviceID (set membership).
+	for _, wantID := range e.AttemptsContain {
+		found := false
+		if lastTrace != nil {
+			for _, gotID := range lastTrace.Attempts {
+				if gotID == wantID {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return fmt.Errorf("expect: attempts_contain: service %q not found in attempts (got %v)", wantID, lastTrace.Attempts)
+		}
+	}
+
+	// AttemptsExclude: last request must NOT include any serviceID.
+	for _, banID := range e.AttemptsExclude {
+		if lastTrace != nil {
+			for _, gotID := range lastTrace.Attempts {
+				if gotID == banID {
+					return fmt.Errorf("expect: attempts_exclude: service %q should not appear in attempts (got %v)", banID, lastTrace.Attempts)
+				}
+			}
+		}
+	}
+
+	// Pin: final pin for the last request's session.
+	if e.Pin != nil {
+		wantPin := ptrStr(e.Pin)
+		if finalPin != wantPin {
+			return fmt.Errorf("expect: pin: want %q, got %q", wantPin, finalPin)
+		}
+	}
+
+	// Pins: final pin per named session.
+	for sess, wantPin := range e.Pins {
+		gotPin, ok := finalPins[sess]
+		if !ok {
+			return fmt.Errorf("expect: pins: session %q not found in program", sess)
+		}
+		if gotPin != wantPin {
+			return fmt.Errorf("expect: pins[%s]: want %q, got %q", sess, wantPin, gotPin)
+		}
+	}
+
+	// Breaker: final breaker snapshot subset.
+	for sid, wantState := range e.Breaker {
+		gotState, ok := finalBreakers[sid]
+		if !ok {
+			return fmt.Errorf("expect: breaker: service %q not found in final breaker snapshot", sid)
+		}
+		if gotState != wantState {
+			return fmt.Errorf("expect: breaker[%s]: want %s, got %s", sid, wantState, gotState)
+		}
+	}
+
+	// Health: final health snapshot subset.
+	for sid, wantState := range e.Health {
+		gotState, ok := finalHealth[sid]
+		if !ok {
+			return fmt.Errorf("expect: health: service %q not found in final health snapshot", sid)
+		}
+		if gotState != wantState {
+			return fmt.Errorf("expect: health[%s]: want %s, got %s", sid, wantState, gotState)
+		}
+	}
+
+	// DistinctFirstAttempts: set of first-attempt serviceIDs across ALL request steps.
+	if len(e.DistinctFirstAttempts) > 0 {
+		wantSet := make(map[string]bool)
+		for _, id := range e.DistinctFirstAttempts {
+			wantSet[id] = true
+		}
+		for gotID := range firstAttempts {
+			if !wantSet[gotID] {
+				return fmt.Errorf("expect: distinct_first_attempts: unexpected service %q appeared (got set %v)", gotID, firstAttempts)
+			}
+		}
+		for wantID := range wantSet {
+			if !firstAttempts[wantID] {
+				return fmt.Errorf("expect: distinct_first_attempts: expected service %q missing (got set %v)", wantID, firstAttempts)
+			}
+		}
+	}
+
+	return nil
+}
+
+// equalSlices compares two string slices for equality.
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *LbCmd) loadScenario() (*lbScenario, error) {
@@ -157,11 +412,20 @@ func (c *LbCmd) loadScenario() (*lbScenario, error) {
 		name = "cascade"
 		fmt.Fprintln(os.Stderr, "no --file/--example given; running built-in example 'cascade' (see --help)")
 	}
-	scn, ok := lbExamples[name]
-	if !ok {
-		return nil, fmt.Errorf("unknown --example %q (have: cascade, flat, grid, single, regression, ratelimit, authflip, crossmodel)", name)
+	// Load the built-in example from the embed FS. The embed path is
+	// testdata/lb/<name>.yaml; path.Join uses '/'-separated paths even on
+	// Windows because embed.FS always uses forward slashes.
+	embPath := path.Join("testdata/lb", name+".yaml")
+	raw, err := lbExampleFS.ReadFile(embPath)
+	if err != nil {
+		// Produce a helpful error that lists the available examples.
+		return nil, fmt.Errorf("unknown --example %q (have: %s)", name, strings.Join(lbExampleNames, ", "))
 	}
-	return scn, nil
+	var scn lbScenario
+	if err := yaml.Unmarshal(raw, &scn); err != nil {
+		return nil, fmt.Errorf("parse built-in example %s: %w", name, err)
+	}
+	return &scn, nil
 }
 
 // buildLBRule turns a scenario spec into a typ.Rule.
@@ -186,7 +450,7 @@ func buildLBRule(scn *lbScenario) (*typ.Rule, error) {
 	rule := &typ.Rule{
 		UUID:         uuid,
 		Scenario:     typ.ScenarioOpenAI,
-		RequestModel: "gpt-4",
+		RequestModel: "gpt-5.4",
 		Active:       true,
 		Services:     services,
 	}
@@ -194,7 +458,11 @@ func buildLBRule(scn *lbScenario) (*typ.Rule, error) {
 
 	switch strings.ToLower(strings.TrimSpace(scn.Tactic)) {
 	case "", "tier":
-		rule.LBTactic = typ.Tactic{Type: loadbalance.TacticTier, Params: typ.DefaultTierParams()}
+		params := typ.DefaultTierParams().(*typ.TierParams)
+		if scn.WithinTierTactic != "" {
+			params.WithinTierTactic = loadbalance.ParseTacticType(scn.WithinTierTactic)
+		}
+		rule.LBTactic = typ.Tactic{Type: loadbalance.TacticTier, Params: params}
 	case "random":
 		rule.LBTactic = typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.DefaultRandomParams()}
 	default:
@@ -326,90 +594,5 @@ func formatBreakers(m map[string]string) string {
 
 func sess(s string) *string { return &s }
 
-var lbExamples = map[string]*lbScenario{
-	// Cascade: primary fails 3x then recovers; watch the pin move to t1 and snap
-	// back to t0 after the breaker's open window elapses.
-	"cascade": {
-		RuleUUID: "cascade", Tactic: "tier", AffinitySecs: 1800,
-		Services: []lbServiceSpec{{Provider: "t0", Model: "gpt-4", Tier: 0}, {Provider: "t1", Model: "gpt-4", Tier: 1}},
-		Faults:   map[string][]int{"t0/gpt-4": {500, 500, 500, 200}, "t1/gpt-4": {200}},
-		Program: []lbStep{
-			{Request: sess("s1")}, {Request: sess("s1")}, {Request: sess("s1")},
-			{Request: sess("s1")},
-			{Advance: "31s"},
-			{Request: sess("s1")}, {Request: sess("s1")},
-		},
-	},
-	// Flat: one tier, two peers, random tactic — affinity stickiness to one peer.
-	"flat": {
-		RuleUUID: "flat", Tactic: "random", AffinitySecs: 1800,
-		Services: []lbServiceSpec{{Provider: "a", Model: "gpt-4", Tier: 0}, {Provider: "b", Model: "gpt-4", Tier: 0}},
-		Faults:   map[string][]int{"a/gpt-4": {200}, "b/gpt-4": {200}},
-		Program:  []lbStep{{Request: sess("s1")}, {Request: sess("s1")}, {Request: sess("s1")}},
-	},
-	// Grid: two tiers x two peers; the whole top tier 500s and trips, then
-	// selection drops to the low tier.
-	"grid": {
-		RuleUUID: "grid", Tactic: "tier", AffinitySecs: 0,
-		Services: []lbServiceSpec{
-			{Provider: "t0a", Model: "gpt-4", Tier: 0}, {Provider: "t0b", Model: "gpt-4", Tier: 0},
-			{Provider: "t1a", Model: "gpt-4", Tier: 1}, {Provider: "t1b", Model: "gpt-4", Tier: 1},
-		},
-		Faults: map[string][]int{"t0a/gpt-4": {500}, "t0b/gpt-4": {500}, "t1a/gpt-4": {200}, "t1b/gpt-4": {200}},
-		Program: []lbStep{
-			{Request: sess("")}, {Request: sess("")}, {Request: sess("")},
-			{Request: sess("")}, {Request: sess("")},
-		},
-	},
-	// Single: one service; a 500 has nowhere to fail over to.
-	"single": {
-		RuleUUID: "single", Tactic: "tier", AffinitySecs: 0,
-		Services: []lbServiceSpec{{Provider: "only", Model: "gpt-4", Tier: 0}},
-		Faults:   map[string][]int{"only/gpt-4": {200, 500, 200}},
-		Program:  []lbStep{{Request: sess("")}, {Request: sess("")}, {Request: sess("")}},
-	},
-	// Regression: a stale pin to the fallback tier must snap back to the healthy
-	// primary on the next request.
-	"regression": {
-		RuleUUID: "regression", Tactic: "tier", AffinitySecs: 1800,
-		Services: []lbServiceSpec{{Provider: "t1", Model: "gpt-4", Tier: 0}, {Provider: "t2", Model: "gpt-4", Tier: 1}},
-		Faults:   map[string][]int{"t1/gpt-4": {200}, "t2/gpt-4": {200}},
-		SeedPin:  &lbSeedSpec{Session: "s1", Provider: "t2", Model: "gpt-4"}, // stale pin to the fallback tier
-		Program:  []lbStep{{Request: sess("s1")}, {Request: sess("s1")}},
-	},
-	// Rate-limit: a single 429 marks t0 unhealthy via the health monitor, so it's
-	// skipped on the NEXT request even though its breaker has one strike — then it
-	// recovers after the rate-limit window.
-	"ratelimit": {
-		RuleUUID: "ratelimit", Tactic: "tier", AffinitySecs: 0,
-		Services: []lbServiceSpec{{Provider: "t0", Model: "gpt-4", Tier: 0}, {Provider: "t1", Model: "gpt-4", Tier: 1}},
-		Faults:   map[string][]int{"t0/gpt-4": {429, 200}, "t1/gpt-4": {200}},
-		Program: []lbStep{
-			{Request: sess("")}, // t0 429 → fail over to t1; t0 rate-limited
-			{Request: sess("")}, // t0 health-excluded → straight to t1
-			{Advance: "31s"},
-			{Request: sess("")}, // window elapsed → back to t0
-		},
-	},
-	// Cross-model: each tier carries a different model. On failover the hop must
-	// dispatch the fallback's OWN model (t1/model-b), not reuse the primary's
-	// (t0/model-a) — the bug fixed in #1233. Read the attempt column: the second
-	// hop is "t1/model-b", proving the model travelled with the failover.
-	"crossmodel": {
-		RuleUUID: "crossmodel", Tactic: "tier", AffinitySecs: 0,
-		Services: []lbServiceSpec{{Provider: "t0", Model: "model-a", Tier: 0}, {Provider: "t1", Model: "model-b", Tier: 1}},
-		Faults:   map[string][]int{"t0/model-a": {500}, "t1/model-b": {200}},
-		Program:  []lbStep{{Request: sess("")}},
-	},
-	// Auth flip: 401 is terminal (no failover masks it) AND marks t0 immediately
-	// unhealthy, so it's excluded next request.
-	"authflip": {
-		RuleUUID: "authflip", Tactic: "tier", AffinitySecs: 0,
-		Services: []lbServiceSpec{{Provider: "t0", Model: "gpt-4", Tier: 0}, {Provider: "t1", Model: "gpt-4", Tier: 1}},
-		Faults:   map[string][]int{"t0/gpt-4": {401, 200}, "t1/gpt-4": {200}},
-		Program: []lbStep{
-			{Request: sess("")}, // t0 401 → terminal (client sees 401); t0 unhealthy
-			{Request: sess("")}, // t0 excluded → t1
-		},
-	},
-}
+func ptrInt(i int) *int       { return &i }
+func ptrStr(s string) *string { return &s }

--- a/cli/harness/main.go
+++ b/cli/harness/main.go
@@ -1,8 +1,10 @@
 // Package main provides the CLI harness for protocol validation testing.
 //
-// The harness provides three testing modes:
+// The harness provides several testing modes:
 //   - matrix: Virtual provider e2e tests (protocol transformations)
+//   - replay: Fixture replay through the in-process gateway
 //   - agent: Real agent CLI runs against mock or real upstreams
+//   - lb: Load-balancing scenario simulator (tier/failover/breaker/affinity)
 //   - provider: Real provider API e2e tests (live API compatibility) - Phase 3
 package main
 
@@ -26,6 +28,7 @@ type CLI struct {
 	Matrix     MatrixCmd     `kong:"cmd,help='Run protocol validation matrix tests'"`
 	Agent      AgentCmd      `kong:"cmd,help='Run agent e2e tests (use --mock or --config <file>)'"`
 	Replay     ReplayCmd     `kong:"cmd,help='Replay a captured agent request fixture through the gateway'"`
+	Lb         LbCmd         `kong:"cmd,help='Simulate load-balancing (tier/failover/breaker/affinity) over a request sequence'"`
 	Provider   ProviderCmd   `kong:"cmd,help='Real provider API tests (Phase 3 - not yet implemented)'"`
 	InitConfig InitConfigCmd `kong:"cmd,name='init-config',help='Create a providers config file template for agent --config'"`
 }

--- a/cli/harness/testdata/lb/authflip.yaml
+++ b/cli/harness/testdata/lb/authflip.yaml
@@ -1,0 +1,22 @@
+# authflip — 401 is terminal (no failover masks it) AND marks the primary
+# immediately unhealthy via the health monitor, so it's excluded next request.
+# The first request surfaces the 401 to the client; the second request lands on
+# the healthy fallback (200).
+rule_uuid: authflip
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: deepseek, model: deepseek-pro, tier: 0 }
+  - { provider: deepseek, model: deepseek-flash, tier: 1 }
+faults:
+  deepseek/deepseek-pro: [401, 200]
+  deepseek/deepseek-flash: [200]
+expect:
+  final_status: 200
+  attempts: [deepseek/deepseek-flash]
+  health:
+    deepseek/deepseek-pro: unhealthy
+    deepseek/deepseek-flash: healthy
+program:
+  - { request: "" }   # deepseek-pro 401 → terminal (client sees 401); marked unhealthy
+  - { request: "" }   # deepseek-pro excluded → deepseek-flash

--- a/cli/harness/testdata/lb/cascade.yaml
+++ b/cli/harness/testdata/lb/cascade.yaml
@@ -1,0 +1,33 @@
+# LB scenario: cascade (direct + fallback) with breaker trip & timed recovery.
+#
+# Run:  ./harness lb --file cli/harness/testdata/lb/cascade.yaml
+#
+# t0 is the primary tier, t1 the fallback. t0 fails 3 times (tripping its
+# breaker) then recovers; the {500,500,500,200} script self-recovers because the
+# 4th *call* to t0 (after the breaker reopens) returns 200. Watch the affinity
+# pin move t0 → t1 when the breaker opens, and snap back to t0 after the open
+# window elapses (the `advance` step).
+
+rule_uuid: cascade
+tactic: tier          # tier | random
+affinity_secs: 1800   # 0 disables session affinity
+
+services:
+  - { provider: t0, model: gpt-4, tier: 0 }   # T0 = highest priority
+  - { provider: t1, model: gpt-4, tier: 1 }   # T1 = fallback
+
+faults:                 # serviceID ("provider/model") -> per-call status sequence (last repeats)
+  t0/gpt-4: [500, 500, 500, 200]
+  t1/gpt-4: [200]
+
+# Optional: pre-lock a session before the program runs (reproduce a stale pin).
+# seed_pin: { session: s1, provider: t1, model: gpt-4 }
+
+program:                # ordered steps: `request: <session>` or `advance: <dur>`
+  - { request: s1 }
+  - { request: s1 }
+  - { request: s1 }     # t0 breaker opens here
+  - { request: s1 }     # pin moves to t1
+  - { advance: 31s }    # past the breaker's 30s open window
+  - { request: s1 }     # half-open probe → t0 recovers → pin snaps back to t0
+  - { request: s1 }

--- a/cli/harness/testdata/lb/cascade.yaml
+++ b/cli/harness/testdata/lb/cascade.yaml
@@ -1,33 +1,26 @@
-# LB scenario: cascade (direct + fallback) with breaker trip & timed recovery.
-#
-# Run:  ./harness lb --file cli/harness/testdata/lb/cascade.yaml
-#
-# t0 is the primary tier, t1 the fallback. t0 fails 3 times (tripping its
-# breaker) then recovers; the {500,500,500,200} script self-recovers because the
-# 4th *call* to t0 (after the breaker reopens) returns 200. Watch the affinity
-# pin move t0 → t1 when the breaker opens, and snap back to t0 after the open
-# window elapses (the `advance` step).
-
+# cascade — primary fails 3x then recovers; watch the pin move to the fallback
+# tier and snap back to the primary after the breaker's open window elapses.
 rule_uuid: cascade
-tactic: tier          # tier | random
-affinity_secs: 1800   # 0 disables session affinity
-
+tactic: tier
+affinity_secs: 1800
 services:
-  - { provider: t0, model: gpt-4, tier: 0 }   # T0 = highest priority
-  - { provider: t1, model: gpt-4, tier: 1 }   # T1 = fallback
-
-faults:                 # serviceID ("provider/model") -> per-call status sequence (last repeats)
-  t0/gpt-4: [500, 500, 500, 200]
-  t1/gpt-4: [200]
-
-# Optional: pre-lock a session before the program runs (reproduce a stale pin).
-# seed_pin: { session: s1, provider: t1, model: gpt-4 }
-
-program:                # ordered steps: `request: <session>` or `advance: <dur>`
-  - { request: s1 }
-  - { request: s1 }
-  - { request: s1 }     # t0 breaker opens here
-  - { request: s1 }     # pin moves to t1
-  - { advance: 31s }    # past the breaker's 30s open window
-  - { request: s1 }     # half-open probe → t0 recovers → pin snaps back to t0
-  - { request: s1 }
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: openai, model: gpt-5.5, tier: 1 }
+faults:
+  openai/gpt-5.4: [500, 500, 500, 200]
+  openai/gpt-5.5: [200]
+expect:
+  final_status: 200
+  attempts: [openai/gpt-5.4]
+  pin: openai/gpt-5.4
+  breaker:
+    openai/gpt-5.4: closed
+    openai/gpt-5.5: closed
+program:
+  - { request: session1 }
+  - { request: session1 }
+  - { request: session1 }     # gpt-5.4 breaker opens here
+  - { request: session1 }     # pin moves to gpt-5.5
+  - { advance: 31s }          # past the breaker's 30s open window
+  - { request: session1 }     # half-open probe → gpt-5.4 recovers → pin snaps back
+  - { request: session1 }

--- a/cli/harness/testdata/lb/crossmodel.yaml
+++ b/cli/harness/testdata/lb/crossmodel.yaml
@@ -1,0 +1,17 @@
+# crossmodel — each tier carries a different model. On failover the hop must
+# dispatch the fallback's OWN model, not reuse the primary's (the bug fixed in
+# #1233). Read the attempt column: the second hop carries the fallback's model.
+rule_uuid: crossmodel
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: anthropic, model: claude-opus, tier: 1 }
+faults:
+  openai/gpt-5.4: [500]
+  anthropic/claude-opus: [200]
+expect:
+  final_status: 200
+  attempts: [openai/gpt-5.4, anthropic/claude-opus]   # failover hop carries fallback's model
+program:
+  - { request: "" }

--- a/cli/harness/testdata/lb/degrade.yaml
+++ b/cli/harness/testdata/lb/degrade.yaml
@@ -1,0 +1,27 @@
+# degrade — all tiers tripped, degrade to T0 (surface a real upstream error).
+# Cascade shape; both the primary and fallback always 500, so both breakers trip,
+# then TierTactic falls back to the highest-priority bucket (T0) so the client
+# sees a real 500 rather than "no service". attempts_contain + final_status keep
+# this robust to the internal hop ordering once both tiers are open.
+rule_uuid: degrade
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: openai, model: gpt-5.5, tier: 1 }
+faults:
+  openai/gpt-5.4: [500]
+  openai/gpt-5.5: [500]
+expect:
+  final_status: 500                # client sees real 500 from the primary tier
+  attempts_contain: [openai/gpt-5.4]   # T0 is the last resort
+  breaker:
+    openai/gpt-5.4: open
+    openai/gpt-5.5: open
+program:
+  - { request: "" }   # gpt-5.4 500 (strike 1)
+  - { request: "" }   # gpt-5.4 500 (strike 2)
+  - { request: "" }   # gpt-5.4 500 (strike 3 → gpt-5.4 open) → gpt-5.5 500 (strike 1)
+  - { request: "" }   # gpt-5.5 500 (strike 2)
+  - { request: "" }   # gpt-5.5 500 (strike 3 → gpt-5.5 open)
+  - { request: "" }   # both open → fallback to T0 → gpt-5.4 500

--- a/cli/harness/testdata/lb/flat.yaml
+++ b/cli/harness/testdata/lb/flat.yaml
@@ -1,0 +1,18 @@
+# flat — one tier, two peers, random tactic. Demonstrates affinity stickiness to
+# one peer. The last request sticks to whichever peer the first request pinned
+# to; the exact peer is not asserted because random is non-deterministic.
+rule_uuid: flat
+tactic: random
+affinity_secs: 1800
+services:
+  - { provider: anthropic, model: claude-opus, tier: 0 }
+  - { provider: anthropic, model: claude-sonnet, tier: 0 }
+faults:
+  anthropic/claude-opus: [200]
+  anthropic/claude-sonnet: [200]
+expect:
+  final_status: 200
+program:
+  - { request: session1 }
+  - { request: session1 }
+  - { request: session1 }

--- a/cli/harness/testdata/lb/grid.yaml
+++ b/cli/harness/testdata/lb/grid.yaml
@@ -1,0 +1,28 @@
+# grid — two tiers x two peers; the whole top tier 500s and trips, then
+# selection drops to the low tier. By request 3 both top-tier peers have tripped
+# and requests 3+ land on the low tier. Which low-tier peer is selected is
+# non-deterministic, so only final status + breaker states are asserted.
+rule_uuid: grid
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: openai, model: gpt-5.5, tier: 0 }
+  - { provider: openai, model: gpt-4.1, tier: 1 }
+  - { provider: anthropic, model: claude-haiku, tier: 1 }
+faults:
+  openai/gpt-5.4: [500]
+  openai/gpt-5.5: [500]
+  openai/gpt-4.1: [200]
+  anthropic/claude-haiku: [200]
+expect:
+  final_status: 200
+  breaker:
+    openai/gpt-5.4: open
+    openai/gpt-5.5: open
+program:
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }

--- a/cli/harness/testdata/lb/halfopen.yaml
+++ b/cli/harness/testdata/lb/halfopen.yaml
@@ -1,0 +1,27 @@
+# halfopen — half-open recovery probe. Cascade shape; the primary trips after
+# 3 failures, stays open, then after an advance past OpenDuration (30s → 31s)
+# the breaker admits ONE half-open probe, which succeeds → breaker closed. The
+# half-open state is transient, so only final breaker states are asserted (not
+# the transient half_open, which has flipped to closed by the final snapshot).
+rule_uuid: halfopen
+tactic: tier
+affinity_secs: 1800
+services:
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: openai, model: gpt-5.5, tier: 1 }
+faults:
+  openai/gpt-5.4: [500, 500, 500, 200, 200]
+  openai/gpt-5.5: [200]
+expect:
+  final_status: 200
+  breaker:
+    openai/gpt-5.4: closed
+    openai/gpt-5.5: closed
+program:
+  - { request: session1 }   # gpt-5.4 500 → gpt-5.5 (strike 1)
+  - { request: session1 }   # gpt-5.4 500 → gpt-5.5 (strike 2)
+  - { request: session1 }   # gpt-5.4 500 → gpt-5.5 (strike 3 → gpt-5.4 breaker OPEN)
+  - { request: session1 }   # gpt-5.4 open → straight to gpt-5.5
+  - { advance: 31s }        # past OpenDuration → gpt-5.4 half-open probe allowed
+  - { request: session1 }   # half-open probe to gpt-5.4 → 200 → breaker CLOSED
+  - { request: session1 }   # gpt-5.4 closed → gpt-5.4 directly

--- a/cli/harness/testdata/lb/inactive.yaml
+++ b/cli/harness/testdata/lb/inactive.yaml
@@ -1,0 +1,21 @@
+# inactive — an inactive service is excluded entirely. Grid shape with one
+# inactive peer; the inactive peer never appears in attempts and isn't selected
+# even if active peers fail.
+rule_uuid: inactive
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: openai, model: gpt-5.4, tier: 0, inactive: false }
+  - { provider: openai, model: gpt-5.5, tier: 0, inactive: true }
+  - { provider: openai, model: gpt-4.1, tier: 1, inactive: false }
+faults:
+  openai/gpt-5.4: [200]
+  openai/gpt-4.1: [200]
+expect:
+  final_status: 200
+  attempts_exclude: [openai/gpt-5.5]   # inactive peer never appears
+program:
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }

--- a/cli/harness/testdata/lb/multiaffinity.yaml
+++ b/cli/harness/testdata/lb/multiaffinity.yaml
@@ -1,0 +1,23 @@
+# multiaffinity — two sessions with independent affinity TTL expiry. Flat shape
+# with random tactic; both sessions pin independently, then after an advance
+# past the 60s TTL both re-lock with fresh timestamps. Exact pins are not
+# asserted (random is non-deterministic); the Go scenario test validates
+# PinDetail for independent re-locking.
+rule_uuid: multiaffinity
+tactic: random
+affinity_secs: 60
+services:
+  - { provider: deepseek, model: deepseek-pro, tier: 0 }
+  - { provider: deepseek, model: deepseek-flash, tier: 0 }
+faults:
+  deepseek/deepseek-pro: [200]
+  deepseek/deepseek-flash: [200]
+expect:
+  final_status: 200
+program:
+  - { request: session1 }   # session1 pins to peer X
+  - { request: session2 }   # session2 pins to peer Y (independent)
+  - { request: session1 }   # session1 sticky
+  - { advance: 61s }        # past 60s TTL — both locks expire
+  - { request: session1 }   # session1 re-selected, re-locked (fresh LockedAt)
+  - { request: session2 }   # session2 re-selected, re-locked

--- a/cli/harness/testdata/lb/ratelimit.yaml
+++ b/cli/harness/testdata/lb/ratelimit.yaml
@@ -1,0 +1,24 @@
+# ratelimit — a single 429 marks the primary unhealthy via the health monitor,
+# so it's skipped on the NEXT request even though its breaker has only one
+# strike, then it recovers after the rate-limit window elapses (one advance moves
+# both the health clock and the breaker clock).
+rule_uuid: ratelimit
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: openai, model: gpt-5.4, tier: 0 }
+  - { provider: openai, model: gpt-5.5, tier: 1 }
+faults:
+  openai/gpt-5.4: [429, 200]
+  openai/gpt-5.5: [200]
+expect:
+  final_status: 200
+  attempts: [openai/gpt-5.4]   # final request after window recovers
+  health:
+    openai/gpt-5.4: healthy
+    openai/gpt-5.5: healthy
+program:
+  - { request: "" }   # gpt-5.4 429 → fail over to gpt-5.5; gpt-5.4 rate-limited
+  - { request: "" }   # gpt-5.4 health-excluded → straight to gpt-5.5
+  - { advance: 31s }  # window elapsed → back to gpt-5.4
+  - { request: "" }

--- a/cli/harness/testdata/lb/regression.yaml
+++ b/cli/harness/testdata/lb/regression.yaml
@@ -1,0 +1,21 @@
+# regression — a stale pin (seed_pin) to the fallback tier must snap back to the
+# healthy primary on the next request. The seeded pin is ineligible (fallback
+# tier when primary is healthy), so affinity drops it and selection returns to
+# the primary.
+rule_uuid: regression
+tactic: tier
+affinity_secs: 1800
+services:
+  - { provider: anthropic, model: claude-opus, tier: 0 }
+  - { provider: anthropic, model: claude-sonnet, tier: 1 }
+faults:
+  anthropic/claude-opus: [200]
+  anthropic/claude-sonnet: [200]
+seed_pin: { session: session1, provider: anthropic, model: claude-sonnet }   # stale pin to the fallback tier
+expect:
+  final_status: 200
+  attempts: [anthropic/claude-opus]   # pin dropped, back to primary
+  pin: anthropic/claude-opus
+program:
+  - { request: session1 }
+  - { request: session1 }

--- a/cli/harness/testdata/lb/single.yaml
+++ b/cli/harness/testdata/lb/single.yaml
@@ -1,0 +1,16 @@
+# single — one service; a 500 has nowhere to fail over to. The fault script
+# returns 200, 500, 200 across three calls, so the final request is a clean 200.
+rule_uuid: single
+tactic: tier
+affinity_secs: 0
+services:
+  - { provider: deepseek, model: deepseek-pro, tier: 0 }
+faults:
+  deepseek/deepseek-pro: [200, 500, 200]
+expect:
+  final_status: 200
+  attempts: [deepseek/deepseek-pro]
+program:
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }

--- a/cli/harness/testdata/lb/withintier.yaml
+++ b/cli/harness/testdata/lb/withintier.yaml
@@ -1,0 +1,41 @@
+# withintier — within-tier load sharing. Grid shape with two peers in the top
+# tier; both peers appear as first attempts across multiple requests, proving
+# the within-tier sub-tactic (random) shares load. Uses 20 requests to make
+# flakiness vanishingly unlikely (random non-determinism; P(only one peer in 20
+# draws) ≈ 0.0004%).
+rule_uuid: withintier
+tactic: tier
+within_tier_tactic: random
+affinity_secs: 0
+services:
+  - { provider: anthropic, model: claude-opus, tier: 0 }
+  - { provider: anthropic, model: claude-sonnet, tier: 0 }
+  - { provider: anthropic, model: claude-haiku, tier: 1 }
+faults:
+  anthropic/claude-opus: [200]
+  anthropic/claude-sonnet: [200]
+  anthropic/claude-haiku: [200]
+expect:
+  final_status: 200
+  distinct_first_attempts: [anthropic/claude-opus, anthropic/claude-sonnet]   # both top-tier peers appear as first attempts
+program:
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }
+  - { request: "" }

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -1,0 +1,31 @@
+package clock
+
+import "time"
+
+// nowFn is the time source for all time-based logic in tingly-box that needs
+// deterministic control in tests/simulation. Production uses time.Now.
+// This includes: circuit breaker timing, health monitor recovery windows,
+// and affinity TTL bookkeeping. A single shared source ensures all three
+// advance together in the simulator.
+var nowFn = time.Now
+
+// Now returns the current time. In production this is time.Now; in tests
+// and the LB harness simulator it can be overridden via SetClock.
+func Now() time.Time {
+	return nowFn()
+}
+
+// SetClock installs fn as the time source and returns a restore function
+// that reinstates the previous source. Intended for tests and the LB harness
+// simulator only; callers must defer the returned restore to avoid leaking
+// the fake clock into production paths.
+//
+// Usage in lbsim:
+//
+//	restore := clock.SetClock(fakeClock.Now)
+//	defer restore()
+func SetClock(fn func() time.Time) (restore func()) {
+	prev := nowFn
+	nowFn = fn
+	return func() { nowFn = prev }
+}

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -224,6 +224,14 @@ func (s *BreakerStore) Snapshot() map[string]BreakerState {
 	return out
 }
 
+// Reset clears all breaker entries. Useful for tests/harness to avoid state leakage
+// between scenarios when reusing the global store.
+func (s *BreakerStore) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.breakers = make(map[string]*Breaker)
+}
+
 // defaultStore is the process-wide breaker registry used by tactics and
 // the recorder integration. Tests may replace it; production code should
 // use the package-level helpers below.

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -3,6 +3,8 @@ package loadbalance
 import (
 	"sync"
 	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/clock"
 )
 
 // BreakerState represents the state of a circuit breaker.
@@ -69,7 +71,7 @@ func (b *Breaker) Allow() bool {
 	case BreakerClosed:
 		return true
 	case BreakerOpen:
-		if time.Since(b.openedAt) >= b.OpenDuration {
+		if clock.Now().Sub(b.openedAt) >= b.OpenDuration {
 			b.state = BreakerHalfOpen
 			b.halfOpenInFlight = true
 			return true
@@ -102,14 +104,14 @@ func (b *Breaker) RecordFailure() {
 
 	if b.state == BreakerHalfOpen {
 		b.state = BreakerOpen
-		b.openedAt = time.Now()
+		b.openedAt = clock.Now()
 		b.halfOpenInFlight = false
 		return
 	}
 	b.consecFails++
 	if b.consecFails >= b.FailureThreshold {
 		b.state = BreakerOpen
-		b.openedAt = time.Now()
+		b.openedAt = clock.Now()
 	}
 }
 
@@ -118,7 +120,7 @@ func (b *Breaker) State() BreakerState {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	// Apply the lazy Open→HalfOpen transition for read consistency.
-	if b.state == BreakerOpen && time.Since(b.openedAt) >= b.OpenDuration {
+	if b.state == BreakerOpen && clock.Now().Sub(b.openedAt) >= b.OpenDuration {
 		return BreakerHalfOpen
 	}
 	return b.state

--- a/internal/loadbalance/health_monitor.go
+++ b/internal/loadbalance/health_monitor.go
@@ -6,14 +6,16 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/clock"
 )
 
 // HealthStatus represents the health state of a service
 type HealthStatus int
 
 const (
-	HealthHealthy HealthStatus = iota // Service is healthy and available
-	HealthUnhealthy                    // Service is unhealthy (rate limited, failing)
+	HealthHealthy   HealthStatus = iota // Service is healthy and available
+	HealthUnhealthy                     // Service is unhealthy (rate limited, failing)
 )
 
 // String returns the string representation of HealthStatus
@@ -140,7 +142,7 @@ func (hm *HealthMonitor) IsHealthy(serviceID string) bool {
 		return true
 	}
 
-	now := time.Now()
+	now := clock.Now()
 
 	// If rate limited, check if the rate limit window has passed
 	if rateLimited && now.Before(rateLimitedUntil) {
@@ -149,7 +151,7 @@ func (hm *HealthMonitor) IsHealthy(serviceID string) bool {
 	}
 
 	// Check if recovery timeout has elapsed
-	if time.Since(lastErrorTime) > recoveryTimeout {
+	if now.Sub(lastErrorTime) > recoveryTimeout {
 		// Probe before auto-recover (if probing is enabled and probe func is set)
 		if hm.config.ProbeEnabled && hm.probeFunc != nil {
 			if hm.probeFunc(serviceID) {
@@ -207,7 +209,7 @@ func (hm *HealthMonitor) extendRecoveryTimeout(serviceID string) {
 	defer health.mutex.Unlock()
 
 	// Extend timeout by another recovery period (exponential backoff could be added here)
-	health.LastErrorTime = time.Now()
+	health.LastErrorTime = clock.Now()
 }
 
 // ReportRateLimit reports a 429 rate limit error for a service
@@ -216,7 +218,7 @@ func (hm *HealthMonitor) ReportRateLimit(serviceID string) {
 	health.mutex.Lock()
 	defer health.mutex.Unlock()
 
-	now := time.Now()
+	now := clock.Now()
 	health.Status = HealthUnhealthy
 	health.RateLimited = true
 	health.LastErrorTime = now
@@ -242,8 +244,8 @@ func (hm *HealthMonitor) ReportAuthError(serviceID string, statusCode int) {
 	health.Status = HealthUnhealthy
 	health.AuthError = true
 	health.LastError = errors.New("auth error")
-	health.LastErrorTime = time.Now()
-	health.LastHealthCheck = time.Now()
+	health.LastErrorTime = clock.Now()
+	health.LastHealthCheck = clock.Now()
 }
 
 // ReportError reports a retryable error for a service
@@ -254,8 +256,8 @@ func (hm *HealthMonitor) ReportError(serviceID string, err error) {
 
 	health.ConsecutiveErrors++
 	health.LastError = err
-	health.LastErrorTime = time.Now()
-	health.LastHealthCheck = time.Now()
+	health.LastErrorTime = clock.Now()
+	health.LastHealthCheck = clock.Now()
 
 	// Only mark unhealthy after threshold
 	if health.ConsecutiveErrors >= hm.consecutiveErrorThreshold {
@@ -273,7 +275,7 @@ func (hm *HealthMonitor) ReportSuccess(serviceID string) {
 	health.mutex.Lock()
 	defer health.mutex.Unlock()
 
-	now := time.Now()
+	now := clock.Now()
 
 	// If rate limited, check if the recovery timeout has elapsed
 	if health.RateLimited && now.Before(health.RateLimitedUntil) {

--- a/internal/server/affinity.go
+++ b/internal/server/affinity.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tingly-dev/tingly-box/internal/clock"
 	"github.com/tingly-dev/tingly-box/internal/server/routing"
 )
 
@@ -47,8 +48,11 @@ func (s *AffinityStore) Get(ruleUUID, sessionID string) (*routing.AffinityEntry,
 		return nil, false
 	}
 
-	// Check if expired
-	if time.Now().After(entry.ExpiresAt) {
+	// Check if expired. Uses the shared affinity clock (routing.Now) so the
+	// store's expiry stays on the same timeline as the stage's strict-TTL check
+	// and pin creation — production resolves to time.Now; the lb simulator drives
+	// all three deterministically off one fake clock.
+	if clock.Now().After(entry.ExpiresAt) {
 		return nil, false
 	}
 
@@ -102,7 +106,7 @@ func (s *AffinityStore) GC() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
+	now := clock.Now()
 	for key, entry := range s.entries {
 		if now.After(entry.ExpiresAt) {
 			delete(s.entries, key)

--- a/internal/server/failover_logging_test.go
+++ b/internal/server/failover_logging_test.go
@@ -132,7 +132,7 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 
 		var sawRetry bool
 		for _, e := range hook.entries {
-			if e.Data["stage"] == "failover" && e.Data["to_provider"] != nil {
+			if e.Data["stage"] == "failover_retry" && e.Data["to_provider"] != nil {
 				sawRetry = true
 				for _, field := range []string{"attempt", "status", "from_service", "to_provider", "to_model"} {
 					if e.Data[field] == nil {
@@ -163,7 +163,7 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 
 		var sawGiveUp bool
 		for _, e := range hook.entries {
-			if e.Data["stage"] == "failover" && e.Data["to_provider"] == nil && e.Data["attempt"] != nil {
+			if e.Data["stage"] == "failover_exhausted" && e.Data["to_provider"] == nil && e.Data["attempt"] != nil {
 				sawGiveUp = true
 				if e.Level != logrus.WarnLevel {
 					t.Errorf("give-up log should be Warn level, got %s", e.Level)

--- a/internal/server/lb_scenario_test.go
+++ b/internal/server/lb_scenario_test.go
@@ -28,7 +28,7 @@ func tierTacticRule(uuid string, affinitySecs int, services ...*loadbalance.Serv
 	r := &typ.Rule{
 		UUID:         uuid,
 		Scenario:     typ.ScenarioOpenAI,
-		RequestModel: "gpt-4",
+		RequestModel: "gpt-5.4",
 		Active:       true,
 		Services:     services,
 		LBTactic:     typ.Tactic{Type: loadbalance.TacticTier, Params: typ.DefaultTierParams()},
@@ -41,7 +41,7 @@ func randomTacticRule(uuid string, affinitySecs int, services ...*loadbalance.Se
 	r := &typ.Rule{
 		UUID:         uuid,
 		Scenario:     typ.ScenarioOpenAI,
-		RequestModel: "gpt-4",
+		RequestModel: "gpt-5.4",
 		Active:       true,
 		Services:     services,
 		LBTactic:     typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.DefaultRandomParams()},
@@ -50,10 +50,25 @@ func randomTacticRule(uuid string, affinitySecs int, services ...*loadbalance.Se
 	return r
 }
 
+func tierTacticRuleWithin(uuid string, affinitySecs int, within loadbalance.TacticType, services ...*loadbalance.Service) *typ.Rule {
+	params := typ.DefaultTierParams().(*typ.TierParams)
+	params.WithinTierTactic = within
+	r := &typ.Rule{
+		UUID:         uuid,
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "gpt-5.4",
+		Active:       true,
+		Services:     services,
+		LBTactic:     typ.Tactic{Type: loadbalance.TacticTier, Params: params},
+	}
+	r.Flags.SessionAffinity = affinitySecs
+	return r
+}
+
 // ===================== Scenario A: single service =====================
 
 func TestLBScenario_A_Single(t *testing.T) {
-	s0 := svc("solo", "gpt-4", 0, true)
+	s0 := svc("deepseek", "deepseek-pro", 0, true)
 	id := s0.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-A", 0, s0), map[string][]int{id: {200}})
 	require.NoError(t, err)
@@ -65,7 +80,7 @@ func TestLBScenario_A_Single(t *testing.T) {
 	require.Equal(t, 200, tr.FinalStatus)
 
 	// A 500 on the only service cannot fail over — surfaces to the client.
-	s1 := svc("solo2", "gpt-4", 0, true)
+	s1 := svc("openai", "gpt-5.4", 0, true)
 	id2 := s1.ServiceID()
 	sim2, cleanup2, err := NewLBSimulator(tierTacticRule("rule-A2", 0, s1), map[string][]int{id2: {500}})
 	require.NoError(t, err)
@@ -87,8 +102,8 @@ func TestLBScenario_A_Single(t *testing.T) {
 //   - selection then goes straight to t1 (no wasted t0 attempt),
 //   - after the open window AND t0 recovering, the session returns to t0.
 func TestLBScenario_C_CascadeFailoverAndRecovery(t *testing.T) {
-	t0 := svc("cas-t0", "gpt-4", 0, true)
-	t1 := svc("cas-t1", "gpt-4", 1, true)
+	t0 := svc("openai", "gpt-5.4", 0, true)
+	t1 := svc("openai", "gpt-5.5", 1, true)
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-C", 1800, t0, t1), map[string][]int{
 		id0: {500, 500, 500, 200},
@@ -127,8 +142,8 @@ func TestLBScenario_C_CascadeFailoverAndRecovery(t *testing.T) {
 // Session already pinned to the lower tier (t2) while the primary (t1) is
 // healthy → the request must return to t1 and the pin be rewritten to t1.
 func TestLBScenario_RegressionStalePinReturnsToPrimary(t *testing.T) {
-	t1 := svc("reg-t1", "gpt-4", 0, true) // primary
-	t2 := svc("reg-t2", "gpt-4", 1, true) // fallback
+	t1 := svc("anthropic", "claude-opus", 0, true) // primary
+	t2 := svc("anthropic", "claude-sonnet", 1, true) // fallback
 	id1 := t1.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-reg", 1800, t1, t2),
 		map[string][]int{id1: {200}, t2.ServiceID(): {200}})
@@ -136,7 +151,7 @@ func TestLBScenario_RegressionStalePinReturnsToPrimary(t *testing.T) {
 	defer cleanup()
 
 	const sess = "sess-reg"
-	sim.SeedPin(sess, "reg-t2", "gpt-4") // stale pin to the fallback tier
+	sim.SeedPin(sess, "anthropic", "claude-sonnet") // stale pin to the fallback tier
 
 	tr, err := sim.Request(sess)
 	require.NoError(t, err)
@@ -151,8 +166,8 @@ func TestLBScenario_RegressionStalePinReturnsToPrimary(t *testing.T) {
 // though the breaker has only one strike (well below its 3-strike trip). This is
 // the health channel, distinct from the breaker.
 func TestLBScenario_RateLimit_HealthExclusion(t *testing.T) {
-	t0 := svc("rl-t0", "gpt-4", 0, true)
-	t1 := svc("rl-t1", "gpt-4", 1, true)
+	t0 := svc("openai", "gpt-5.4", 0, true)
+	t1 := svc("openai", "gpt-5.5", 1, true)
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-rl", 0, t0, t1), map[string][]int{
 		id0: {429, 200},
@@ -187,8 +202,8 @@ func TestLBScenario_RateLimit_HealthExclusion(t *testing.T) {
 // 401 is terminal (not retryable — no failover masks it) AND marks the service
 // immediately unhealthy (auth error, no threshold), so it's excluded next request.
 func TestLBScenario_AuthError_TerminalAndExcluded(t *testing.T) {
-	t0 := svc("auth-t0", "gpt-4", 0, true)
-	t1 := svc("auth-t1", "gpt-4", 1, true)
+	t0 := svc("deepseek", "deepseek-pro", 0, true)
+	t1 := svc("deepseek", "deepseek-flash", 1, true)
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-auth", 0, t0, t1), map[string][]int{
 		id0: {401, 200},
@@ -215,8 +230,8 @@ func TestLBScenario_AuthError_TerminalAndExcluded(t *testing.T) {
 // ============ Scenario B: flat (one tier, many services) ============
 
 func TestLBScenario_B_FlatStickiness(t *testing.T) {
-	a := svc("flat-a", "gpt-4", 0, true)
-	b := svc("flat-b", "gpt-4", 0, true)
+	a := svc("anthropic", "claude-opus", 0, true)
+	b := svc("anthropic", "claude-sonnet", 0, true)
 	sim, cleanup, err := NewLBSimulator(randomTacticRule("rule-B", 1800, a, b),
 		map[string][]int{a.ServiceID(): {200}, b.ServiceID(): {200}})
 	require.NoError(t, err)
@@ -247,10 +262,10 @@ func TestLBScenario_B_Flat_DeadPeerSelection_KnownGap(t *testing.T) {
 //
 // When the entire top tier trips, selection drops to the next tier.
 func TestLBScenario_D_GridWholeTopTierTrips(t *testing.T) {
-	t0a := svc("grid-t0a", "gpt-4", 0, true)
-	t0b := svc("grid-t0b", "gpt-4", 0, true)
-	t1a := svc("grid-t1a", "gpt-4", 1, true)
-	t1b := svc("grid-t1b", "gpt-4", 1, true)
+	t0a := svc("openai", "gpt-5.4", 0, true)
+	t0b := svc("openai", "gpt-5.5", 0, true)
+	t1a := svc("openai", "gpt-4.1", 1, true)
+	t1b := svc("anthropic", "claude-haiku", 1, true)
 	top := map[string]bool{t0a.ServiceID(): true, t0b.ServiceID(): true}
 	low := map[string]bool{t1a.ServiceID(): true, t1b.ServiceID(): true}
 
@@ -286,8 +301,8 @@ func TestLBScenario_D_GridWholeTopTierTrips(t *testing.T) {
 // attempted serviceID ("provider/model") per hop, so a wrong model is visible
 // directly in the attempt trace.
 func TestLBScenario_CrossModelFailover(t *testing.T) {
-	t0 := svc("xm-t0", "model-a", 0, true) // primary, model-a
-	t1 := svc("xm-t1", "model-b", 1, true) // fallback, model-b
+	t0 := svc("openai", "gpt-5.4", 0, true) // primary, model-a
+	t1 := svc("anthropic", "claude-opus", 1, true) // fallback, model-b
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-xm", 0, t0, t1), map[string][]int{
 		id0: {500}, // primary fails (retryable) → fail over
@@ -298,7 +313,7 @@ func TestLBScenario_CrossModelFailover(t *testing.T) {
 
 	tr, err := sim.Request("")
 	require.NoError(t, err)
-	require.Equal(t, []string{"xm-t0/model-a", "xm-t1/model-b"}, tr.Attempts,
+	require.Equal(t, []string{"openai/gpt-5.4", "anthropic/claude-opus"}, tr.Attempts,
 		"failover must dispatch the fallback's own model (model-b), not reuse the primary's (model-a)")
 	require.Equal(t, 200, tr.FinalStatus, "fallback with its correct model succeeds")
 }
@@ -313,8 +328,8 @@ func TestLBScenario_CrossModelFailover(t *testing.T) {
 // lock is dropped and re-created with a new LockedAt.
 func TestLBScenario_AffinityStrictTTLRelock(t *testing.T) {
 	const ttlSecs = 60
-	a := svc("ttl-a", "gpt-4", 0, true)
-	b := svc("ttl-b", "gpt-4", 0, true)
+	a := svc("deepseek", "deepseek-pro", 0, true)
+	b := svc("deepseek", "deepseek-flash", 0, true)
 	sim, cleanup, err := NewLBSimulator(randomTacticRule("rule-ttl", ttlSecs, a, b),
 		map[string][]int{a.ServiceID(): {200}, b.ServiceID(): {200}})
 	require.NoError(t, err)
@@ -352,3 +367,230 @@ func TestLBScenario_AffinityStrictTTLRelock(t *testing.T) {
 	require.True(t, ok, "a fresh lock is created on re-selection")
 	require.True(t, lockedAt2.After(lockedAt0), "re-lock must carry a fresh LockedAt")
 }
+
+// ============ Half-open probe recovery ============
+//
+// When a breaker trips and stays open for OpenDuration, the next request after
+// the window admits a half-open probe. On success, the breaker closes; on
+// failure, it re-opens with a fresh timer. The CLI halfopen scenario asserts
+// the final state (closed + lands on t0); this test additionally asserts the
+// open snapshot pre-advance to lock the closed→open→closed transition.
+func TestLBScenario_HalfOpenProbeRecovery(t *testing.T) {
+	t0 := svc("openai", "gpt-5.4", 0, true)
+	t1 := svc("openai", "gpt-5.5", 1, true)
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-hop", 1800, t0, t1), map[string][]int{
+		id0: {500, 500, 500, 200, 200}, // 3 failures trip, 4th is the probe (succeeds), 5th is closed
+		id1: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const sess = "session1"
+	// 3 failures: t0 trips
+	for i := 0; i < 3; i++ {
+		tr, err := sim.Request(sess)
+		require.NoError(t, err)
+		require.Equal(t, []string{id0, id1}, tr.Attempts)
+		require.Equal(t, 200, tr.FinalStatus)
+	}
+	require.Equal(t, "open", sim.BreakerStates()[id0], "t0 breaker should be open after 3 failures")
+
+	// 4th request: t0 open → straight to t1; affinity drops the t0 pin and re-locks to t1
+	tr, err := sim.Request(sess)
+	require.NoError(t, err)
+	require.Equal(t, []string{id1}, tr.Attempts, "with t0 open, selection should go straight to t1")
+	require.Equal(t, 200, tr.FinalStatus)
+	require.Equal(t, id1, sim.Pin(sess), "session should now be pinned to t1 after the request completes")
+
+	// Advance past OpenDuration (30s + 1s)
+	sim.Advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
+
+	// 5th request: half-open probe to t0 → 200 → breaker closes
+	tr, err = sim.Request(sess)
+	require.NoError(t, err)
+	require.Equal(t, []string{id0}, tr.Attempts, "after OpenDuration, half-open probe lands on t0")
+	require.Equal(t, 200, tr.FinalStatus)
+	require.Equal(t, "closed", sim.BreakerStates()[id0], "successful probe closes the breaker")
+	require.Equal(t, id0, sim.Pin(sess), "session should be re-pinned to t0 after recovery")
+
+	// 6th request: t0 closed → t0 directly
+	tr, err = sim.Request(sess)
+	require.NoError(t, err)
+	require.Equal(t, []string{id0}, tr.Attempts, "after recovery, requests land on t0")
+	require.Equal(t, 200, tr.FinalStatus)
+}
+
+// ============ All tiers tripped: degrade to T0 ============
+//
+// When every tier's breaker is open, TierTactic falls back to the highest-
+// priority bucket (T0) so the client sees a real upstream error rather than
+// "no service". This tests the degrade-to-T0 behavior.
+func TestLBScenario_AllTiersTrippedDegradesToT0(t *testing.T) {
+	t0 := svc("openai", "gpt-5.4", 0, true)
+	t1 := svc("openai", "gpt-5.5", 1, true)
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-degrade", 0, t0, t1), map[string][]int{
+		id0: {500}, // always fails
+		id1: {500}, // always fails
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	// 3 failures trip t0; then 3 more trip t1; then fallback to t0
+	for i := 0; i < 6; i++ {
+		tr, err := sim.Request("")
+		require.NoError(t, err)
+		// Requests 1-3: t0 fails → t1 (t0 trips at 3)
+		// Requests 4-6: t1 fails → t0 (t1 trips at 6)
+		// Request 7: both open → fallback to t0 → 500
+		require.Contains(t, tr.Attempts, id0, "T0 must be in attempts (last resort or fallback)")
+		if i < 5 {
+			require.Equal(t, 500, tr.FinalStatus, "all requests before fallback fail")
+		}
+	}
+
+	// Final request: both breakers open → fallback to T0 → surfaces 500
+	tr, err := sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, 500, tr.FinalStatus, "client must see real 500 from t0, not 'no service'")
+	require.Contains(t, tr.Attempts, id0, "T0 must be surfaced as the last resort")
+	require.Equal(t, "open", sim.BreakerStates()[id0])
+	require.Equal(t, "open", sim.BreakerStates()[id1])
+}
+
+// ============ Inactive service excluded ============
+//
+// A service marked inactive is excluded from the candidate set by
+// GetActiveServices, so it never appears in attempts and isn't selected even
+// if all active peers fail.
+func TestLBScenario_InactiveServiceExcluded(t *testing.T) {
+	t0a := svc("openai", "gpt-5.4", 0, true)
+	t0b := svc("openai", "gpt-5.5", 0, false) // inactive
+	t1a := svc("openai", "gpt-4.1", 1, true)
+	id0a, id0b, id1a := t0a.ServiceID(), t0b.ServiceID(), t1a.ServiceID()
+
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-inactive", 0, t0a, t0b, t1a), map[string][]int{
+		id0a: {200},
+		id1a: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	// All requests should land on t0a (healthy top tier); t0b never appears.
+	for i := 0; i < 5; i++ {
+		tr, err := sim.Request("")
+		require.NoError(t, err)
+		require.Equal(t, []string{id0a}, tr.Attempts, "only active t0a should be selected")
+		require.NotContains(t, tr.Attempts, id0b, "inactive t0b must never appear in attempts")
+		require.Equal(t, 200, tr.FinalStatus)
+	}
+}
+
+// ============ Within-tier load sharing ============
+//
+// In a grid shape with multiple peers in the top tier, the within-tier sub-
+// tactic (random) distributes load across them. Over N requests, both peers
+// should appear as first attempts. Random is non-deterministic; we use a
+// set-membership assertion over 20 requests to make flakiness vanishingly
+// unlikely (P(only one peer in 20 draws) ≈ 0.0004%).
+func TestLBScenario_WithinTierLoadSharing(t *testing.T) {
+	a := svc("anthropic", "claude-opus", 0, true)
+	b := svc("anthropic", "claude-sonnet", 0, true)
+	c := svc("anthropic", "claude-haiku", 1, true)
+	idA, idB := a.ServiceID(), b.ServiceID()
+
+	sim, cleanup, err := NewLBSimulator(tierTacticRuleWithin("rule-within", 0, loadbalance.TacticRandom, a, b, c), map[string][]int{
+		idA: {200},
+		idB: {200},
+		c.ServiceID(): {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	seenFirst := make(map[string]bool)
+	const N = 20
+	for i := 0; i < N; i++ {
+		tr, err := sim.Request("")
+		require.NoError(t, err)
+		require.Len(t, tr.Attempts, 1, "top tier should always be selected (c is lower priority)")
+		first := tr.Attempts[0]
+		seenFirst[first] = true
+		require.Equal(t, 200, tr.FinalStatus)
+	}
+
+	// Both top-tier peers must have appeared as first attempts at least once.
+	require.True(t, seenFirst[idA], "peer a must appear as first attempt at least once")
+	require.True(t, seenFirst[idB], "peer b must appear as first attempt at least once")
+	// c (lower tier) should never be the first attempt while top tier is healthy.
+	require.False(t, seenFirst[c.ServiceID()], "lower-tier c should never be first while top tier is healthy")
+}
+
+// ============ Multi-session independent affinity ============
+//
+// Two sessions pin independently to different peers/tiers. After an advance
+// past the TTL, both sessions re-lock with fresh LockedAt timestamps.
+func TestLBScenario_MultiSessionIndependentAffinity(t *testing.T) {
+	const ttlSecs = 60
+	a := svc("deepseek", "deepseek-pro", 0, true)
+	b := svc("deepseek", "deepseek-flash", 0, true)
+	idA, idB := a.ServiceID(), b.ServiceID()
+
+	sim, cleanup, err := NewLBSimulator(randomTacticRule("rule-multi", ttlSecs, a, b), map[string][]int{
+		idA: {200},
+		idB: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const sess1, sess2 = "session1", "session2"
+	// s1 pins to peer X, s2 pins to peer Y (independent)
+	tr1, err := sim.Request(sess1)
+	require.NoError(t, err)
+	require.Len(t, tr1.Attempts, 1)
+	pin1 := tr1.Attempts[0]
+
+	tr2, err := sim.Request(sess2)
+	require.NoError(t, err)
+	require.Len(t, tr2.Attempts, 1)
+	pin2 := tr2.Attempts[0]
+
+	// Both pins are independent (could be same or different peers; random).
+	_, lockedAt1_0, _, ok1 := sim.PinDetail(sess1)
+	require.True(t, ok1)
+	_, lockedAt2_0, _, ok2 := sim.PinDetail(sess2)
+	require.True(t, ok2)
+
+	// A third request on s1 confirms stickiness.
+	tr1, err = sim.Request(sess1)
+	require.NoError(t, err)
+	require.Equal(t, []string{pin1}, tr1.Attempts, "s1 should stay sticky")
+
+	// A request on s2 confirms stickiness.
+	tr2, err = sim.Request(sess2)
+	require.NoError(t, err)
+	require.Equal(t, []string{pin2}, tr2.Attempts, "s2 should stay sticky")
+
+	// Advance past TTL (60s + 1s)
+	sim.Advance(time.Duration(ttlSecs)*time.Second + time.Second)
+
+	// Both locks should have expired.
+	_, _, _, live1 := sim.PinDetail(sess1)
+	require.False(t, live1, "s1 lock should expire after TTL")
+	_, _, _, live2 := sim.PinDetail(sess2)
+	require.False(t, live2, "s2 lock should expire after TTL")
+
+	// Next requests re-lock both sessions with fresh LockedAt.
+	_, err = sim.Request(sess1)
+	require.NoError(t, err)
+	_, lockedAt1_1, _, ok1 := sim.PinDetail(sess1)
+	require.True(t, ok1)
+	require.True(t, lockedAt1_1.After(lockedAt1_0), "s1 re-lock should have fresh LockedAt")
+
+	_, err = sim.Request(sess2)
+	require.NoError(t, err)
+	_, lockedAt2_1, _, ok2 := sim.PinDetail(sess2)
+	require.True(t, ok2)
+	require.True(t, lockedAt2_1.After(lockedAt2_0), "s2 re-lock should have fresh LockedAt")
+}
+

--- a/internal/server/lb_scenario_test.go
+++ b/internal/server/lb_scenario_test.go
@@ -1,0 +1,354 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// End-to-end load-balancer scenarios. Unlike the stage-level unit tests these
+// drive the *full* path — routing.ServiceSelector.Select (health → affinity →
+// smart → strategy) followed by dispatchWithPriorityFailover — against
+// programmable fake upstreams over a request sequence, with a deterministic
+// breaker clock. The simulation engine is shared with the `harness lb` CLI tier
+// (see lbsim.go). The shapes exercised here map to the "Rule config shapes"
+// taxonomy in .design/priority-routing.md.
+
+// ---- rule builders ----
+
+func svc(provider, model string, tier int, active bool) *loadbalance.Service {
+	return &loadbalance.Service{Provider: provider, Model: model, Weight: 1, Active: active, Tier: tier}
+}
+
+func tierTacticRule(uuid string, affinitySecs int, services ...*loadbalance.Service) *typ.Rule {
+	r := &typ.Rule{
+		UUID:         uuid,
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "gpt-4",
+		Active:       true,
+		Services:     services,
+		LBTactic:     typ.Tactic{Type: loadbalance.TacticTier, Params: typ.DefaultTierParams()},
+	}
+	r.Flags.SessionAffinity = affinitySecs
+	return r
+}
+
+func randomTacticRule(uuid string, affinitySecs int, services ...*loadbalance.Service) *typ.Rule {
+	r := &typ.Rule{
+		UUID:         uuid,
+		Scenario:     typ.ScenarioOpenAI,
+		RequestModel: "gpt-4",
+		Active:       true,
+		Services:     services,
+		LBTactic:     typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.DefaultRandomParams()},
+	}
+	r.Flags.SessionAffinity = affinitySecs
+	return r
+}
+
+// ===================== Scenario A: single service =====================
+
+func TestLBScenario_A_Single(t *testing.T) {
+	s0 := svc("solo", "gpt-4", 0, true)
+	id := s0.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-A", 0, s0), map[string][]int{id: {200}})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tr, err := sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id}, tr.Attempts)
+	require.Equal(t, 200, tr.FinalStatus)
+
+	// A 500 on the only service cannot fail over — surfaces to the client.
+	s1 := svc("solo2", "gpt-4", 0, true)
+	id2 := s1.ServiceID()
+	sim2, cleanup2, err := NewLBSimulator(tierTacticRule("rule-A2", 0, s1), map[string][]int{id2: {500}})
+	require.NoError(t, err)
+	defer cleanup2()
+
+	tr, err = sim2.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id2}, tr.Attempts, "single service has nowhere to fail over to")
+	require.Equal(t, 500, tr.FinalStatus)
+}
+
+// ============ Scenario C: cascade (the core regression) ============
+//
+// t0 (primary) fails three times then recovers; t1 (fallback) is healthy. The
+// {500,500,500,200} script self-recovers: t0's 4th *call* (after the breaker
+// reopens) returns 200, with no runtime mutation. Verifies:
+//   - per-request failover masks t0's failure (client always gets 200),
+//   - after 3 failures t0's breaker opens and affinity stops re-pinning t0,
+//   - selection then goes straight to t1 (no wasted t0 attempt),
+//   - after the open window AND t0 recovering, the session returns to t0.
+func TestLBScenario_C_CascadeFailoverAndRecovery(t *testing.T) {
+	t0 := svc("cas-t0", "gpt-4", 0, true)
+	t1 := svc("cas-t1", "gpt-4", 1, true)
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-C", 1800, t0, t1), map[string][]int{
+		id0: {500, 500, 500, 200},
+		id1: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const sess = "sess-C"
+	for i := 1; i <= 3; i++ {
+		tr, err := sim.Request(sess)
+		require.NoError(t, err)
+		require.Equalf(t, []string{id0, id1}, tr.Attempts, "req %d should try t0 then fail over to t1", i)
+		require.Equal(t, 200, tr.FinalStatus)
+	}
+	require.Equal(t, "open", sim.BreakerStates()[id0], "t0 breaker should be open after 3 failures")
+
+	// t0 breaker open → affinity drops the t0 pin → strategy picks t1 directly.
+	tr, err := sim.Request(sess)
+	require.NoError(t, err)
+	require.Equal(t, []string{id1}, tr.Attempts, "with t0 open, selection should go straight to t1")
+	require.Equal(t, id1, sim.Pin(sess), "session should now be pinned to t1")
+
+	// Enough time passes for the breaker to admit a probe; t0 recovers upstream.
+	sim.Advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
+
+	tr, err = sim.Request(sess)
+	require.NoError(t, err)
+	require.Equal(t, []string{id0}, tr.Attempts, "after recovery the session should return to t0")
+	require.Equal(t, id0, sim.Pin(sess), "session should be re-pinned to the recovered primary t0")
+	require.Equal(t, "closed", sim.BreakerStates()[id0])
+}
+
+// ============ Scenario: original report regression ============
+//
+// Session already pinned to the lower tier (t2) while the primary (t1) is
+// healthy → the request must return to t1 and the pin be rewritten to t1.
+func TestLBScenario_RegressionStalePinReturnsToPrimary(t *testing.T) {
+	t1 := svc("reg-t1", "gpt-4", 0, true) // primary
+	t2 := svc("reg-t2", "gpt-4", 1, true) // fallback
+	id1 := t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-reg", 1800, t1, t2),
+		map[string][]int{id1: {200}, t2.ServiceID(): {200}})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const sess = "sess-reg"
+	sim.SeedPin(sess, "reg-t2", "gpt-4") // stale pin to the fallback tier
+
+	tr, err := sim.Request(sess)
+	require.NoError(t, err)
+	require.Equal(t, []string{id1}, tr.Attempts, "healthy primary must win over the stale fallback pin")
+	require.Equal(t, id1, sim.Pin(sess), "stale pin must be rewritten to the primary tier")
+}
+
+// ============ Special status: 429 rate-limit ============
+//
+// A single 429 marks the service unhealthy via the health monitor (rate-limit
+// window) on the FIRST occurrence, so it is skipped on the next request — even
+// though the breaker has only one strike (well below its 3-strike trip). This is
+// the health channel, distinct from the breaker.
+func TestLBScenario_RateLimit_HealthExclusion(t *testing.T) {
+	t0 := svc("rl-t0", "gpt-4", 0, true)
+	t1 := svc("rl-t1", "gpt-4", 1, true)
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-rl", 0, t0, t1), map[string][]int{
+		id0: {429, 200},
+		id1: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	// req1: t0 → 429 (retryable) → fail over to t1; t0 marked rate-limited.
+	tr, err := sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id0, id1}, tr.Attempts)
+	require.Equal(t, 200, tr.FinalStatus)
+	require.Equal(t, "unhealthy", sim.HealthStates()[id0], "a single 429 marks the service unhealthy")
+	require.Equal(t, "closed", sim.BreakerStates()[id0], "one 429 is below the breaker's 3-strike trip")
+
+	// req2: t0 health-excluded (rate-limit window) → straight to t1, no t0 attempt.
+	tr, err = sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id1}, tr.Attempts, "rate-limited t0 must be skipped though its breaker is closed")
+
+	// After the rate-limit window, t0 recovers and is used again.
+	sim.Advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
+	tr, err = sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id0}, tr.Attempts, "t0 returns after the rate-limit window")
+	require.Equal(t, 200, tr.FinalStatus)
+}
+
+// ============ Special status: 401 auth error ============
+//
+// 401 is terminal (not retryable — no failover masks it) AND marks the service
+// immediately unhealthy (auth error, no threshold), so it's excluded next request.
+func TestLBScenario_AuthError_TerminalAndExcluded(t *testing.T) {
+	t0 := svc("auth-t0", "gpt-4", 0, true)
+	t1 := svc("auth-t1", "gpt-4", 1, true)
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-auth", 0, t0, t1), map[string][]int{
+		id0: {401, 200},
+		id1: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	// req1: t0 → 401. Non-retryable → terminal: the client sees 401 even though
+	// t1 is healthy (auth errors are never failed over).
+	tr, err := sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id0}, tr.Attempts, "401 is terminal — no failover to t1")
+	require.Equal(t, 401, tr.FinalStatus)
+	require.Equal(t, "unhealthy", sim.HealthStates()[id0], "401 marks the service immediately unhealthy")
+
+	// req2: t0 health-excluded → t1 selected.
+	tr, err = sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{id1}, tr.Attempts, "auth-errored t0 is excluded on the next request")
+	require.Equal(t, 200, tr.FinalStatus)
+}
+
+// ============ Scenario B: flat (one tier, many services) ============
+
+func TestLBScenario_B_FlatStickiness(t *testing.T) {
+	a := svc("flat-a", "gpt-4", 0, true)
+	b := svc("flat-b", "gpt-4", 0, true)
+	sim, cleanup, err := NewLBSimulator(randomTacticRule("rule-B", 1800, a, b),
+		map[string][]int{a.ServiceID(): {200}, b.ServiceID(): {200}})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const sess = "sess-B"
+	first, err := sim.Request(sess)
+	require.NoError(t, err)
+	require.Len(t, first.Attempts, 1)
+	pinned := first.Attempts[0]
+
+	for i := 0; i < 5; i++ {
+		tr, err := sim.Request(sess)
+		require.NoError(t, err)
+		require.Equal(t, []string{pinned}, tr.Attempts, "healthy peer affinity must be sticky")
+	}
+}
+
+func TestLBScenario_B_Flat_DeadPeerSelection_KnownGap(t *testing.T) {
+	t.Skip("G1: horizontal tactics are breaker-blind — LoadBalancer.SelectService " +
+		"does not exclude a breaker-open service for random/token/latency/… tactics, " +
+		"so a flat-shape dead peer can still be re-selected at the selection layer " +
+		"(per-request failover still masks it). Documented in .design/priority-routing.md; " +
+		"deferred. Affinity already drops the pin to a dead peer (see stage_affinity_test.go).")
+}
+
+// ============ Scenario D: grid (many tiers, many services) ============
+//
+// When the entire top tier trips, selection drops to the next tier.
+func TestLBScenario_D_GridWholeTopTierTrips(t *testing.T) {
+	t0a := svc("grid-t0a", "gpt-4", 0, true)
+	t0b := svc("grid-t0b", "gpt-4", 0, true)
+	t1a := svc("grid-t1a", "gpt-4", 1, true)
+	t1b := svc("grid-t1b", "gpt-4", 1, true)
+	top := map[string]bool{t0a.ServiceID(): true, t0b.ServiceID(): true}
+	low := map[string]bool{t1a.ServiceID(): true, t1b.ServiceID(): true}
+
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-D", 0, t0a, t0b, t1a, t1b), map[string][]int{
+		t0a.ServiceID(): {500}, t0b.ServiceID(): {500},
+		t1a.ServiceID(): {200}, t1b.ServiceID(): {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	for i := 0; i < 6; i++ {
+		tr, err := sim.Request("")
+		require.NoError(t, err)
+		require.Equal(t, 200, tr.FinalStatus, "low tier should always rescue the request")
+		require.True(t, low[tr.Attempts[len(tr.Attempts)-1]], "request must end on the low tier")
+	}
+
+	require.Equal(t, "open", sim.BreakerStates()[t0a.ServiceID()])
+	require.Equal(t, "open", sim.BreakerStates()[t0b.ServiceID()])
+
+	tr, err := sim.Request("")
+	require.NoError(t, err)
+	require.True(t, low[tr.Attempts[0]], "with the whole top tier open, selection starts in the low tier")
+	require.False(t, top[tr.Attempts[0]])
+}
+
+// ============ Cross-model failover (regression for #1233) ============
+//
+// Each tier carries a *different* model. When the primary fails over, the hop
+// must dispatch the fallback service's OWN model — not reuse the primary's. The
+// #1233 bug lost the model on failover, so the retry kept sending the primary's
+// model to the fallback provider and failed forever. The simulator records the
+// attempted serviceID ("provider/model") per hop, so a wrong model is visible
+// directly in the attempt trace.
+func TestLBScenario_CrossModelFailover(t *testing.T) {
+	t0 := svc("xm-t0", "model-a", 0, true) // primary, model-a
+	t1 := svc("xm-t1", "model-b", 1, true) // fallback, model-b
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-xm", 0, t0, t1), map[string][]int{
+		id0: {500}, // primary fails (retryable) → fail over
+		id1: {200}, // fallback healthy
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tr, err := sim.Request("")
+	require.NoError(t, err)
+	require.Equal(t, []string{"xm-t0/model-a", "xm-t1/model-b"}, tr.Attempts,
+		"failover must dispatch the fallback's own model (model-b), not reuse the primary's (model-a)")
+	require.Equal(t, 200, tr.FinalStatus, "fallback with its correct model succeeds")
+}
+
+// ============ Strict affinity TTL (regression for #1223 merge) ============
+//
+// The merged affinity fix replaced a *sliding* TTL (every request refreshed the
+// lock, so it never expired and the configured TTL was meaningless) with a
+// *strict* one: a lock expires exactly at LockedAt+TTL regardless of activity,
+// then the session re-enters the pipeline and gets a fresh lock. This guards
+// both halves: an honored pin is NOT refreshed, and once past the window the
+// lock is dropped and re-created with a new LockedAt.
+func TestLBScenario_AffinityStrictTTLRelock(t *testing.T) {
+	const ttlSecs = 60
+	a := svc("ttl-a", "gpt-4", 0, true)
+	b := svc("ttl-b", "gpt-4", 0, true)
+	sim, cleanup, err := NewLBSimulator(randomTacticRule("rule-ttl", ttlSecs, a, b),
+		map[string][]int{a.ServiceID(): {200}, b.ServiceID(): {200}})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const sess = "sess-ttl"
+	// req1 locks the session to whichever peer the strategy picked.
+	first, err := sim.Request(sess)
+	require.NoError(t, err)
+	require.Len(t, first.Attempts, 1)
+	pinned := first.Attempts[0]
+	id0, lockedAt0, expires0, ok := sim.PinDetail(sess)
+	require.True(t, ok)
+	require.Equal(t, pinned, id0)
+
+	// A second request inside the window is served by the same lock and — under
+	// strict TTL — does NOT slide the expiry (the bug being guarded against).
+	_, err = sim.Request(sess)
+	require.NoError(t, err)
+	_, lockedAt1, expires1, ok := sim.PinDetail(sess)
+	require.True(t, ok, "lock still live inside the window")
+	require.Equal(t, lockedAt0, lockedAt1, "an honored pin must not be re-locked inside the window")
+	require.Equal(t, expires0, expires1, "strict TTL: activity must not extend the expiry")
+
+	// Cross the TTL: the unrefreshed lock must now be gone.
+	sim.Advance(time.Duration(ttlSecs)*time.Second + time.Second)
+	_, _, _, live := sim.PinDetail(sess)
+	require.False(t, live, "an unrefreshed lock must expire exactly at LockedAt+TTL")
+
+	// The next request re-enters the pipeline and is re-locked with a fresh
+	// LockedAt (strictly later than the original).
+	_, err = sim.Request(sess)
+	require.NoError(t, err)
+	_, lockedAt2, _, ok := sim.PinDetail(sess)
+	require.True(t, ok, "a fresh lock is created on re-selection")
+	require.True(t, lockedAt2.After(lockedAt0), "re-lock must carry a fresh LockedAt")
+}

--- a/internal/server/lbsim.go
+++ b/internal/server/lbsim.go
@@ -96,6 +96,11 @@ func (f *lbFakeClock) advance(d time.Duration) {
 func NewLBSimulator(rule *typ.Rule, faults map[string][]int) (sim *LBSimulator, cleanup func(), err error) {
 	gin.SetMode(gin.TestMode)
 
+	// Start from a clean breaker store. DefaultBreakerStore() is process-global,
+	// so without this a simulator would inherit leftover breaker state from an
+	// earlier test/example that happened to reuse the same serviceID.
+	loadbalance.DefaultBreakerStore().Reset()
+
 	dir, err := os.MkdirTemp("", "lbsim-")
 	if err != nil {
 		return nil, nil, fmt.Errorf("temp dir: %w", err)

--- a/internal/server/lbsim.go
+++ b/internal/server/lbsim.go
@@ -1,0 +1,325 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/clock"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/server/routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// LBSimulator drives the real load-balancing path — routing.ServiceSelector.Select
+// (health → affinity → smart → strategy) followed by dispatchWithPriorityFailover —
+// against programmable fake upstreams over a request sequence, with a deterministic
+// breaker clock.
+//
+// It is the shared engine behind both the Go scenario tests
+// (internal/server/lb_scenario_test.go) and the `harness lb` CLI tier, so the
+// "how an LB scenario is simulated" logic lives in exactly one place. It lives in
+// package server because it must reach the unexported failover dispatch loop.
+type LBSimulator struct {
+	mu       sync.Mutex
+	server   *Server
+	selector *routing.ServiceSelector
+	affinity *AffinityStore
+	health   *loadbalance.HealthMonitor
+	rule     *typ.Rule
+	scripts  map[string]*lbUpstreamScript
+	clock    *lbFakeClock
+}
+
+// LBTrace is the record of one simulated request.
+type LBTrace struct {
+	Session     string   `json:"session"`
+	Attempts    []string `json:"attempts"`     // serviceIDs attempted, in order (failover hops)
+	Statuses    []int    `json:"statuses"`     // per-attempt status, parallel to Attempts
+	FinalStatus int      `json:"final_status"` // status the client would see
+	PinAfter    string   `json:"pin_after"`    // affinity pin after this request ("" if none)
+	// State snapshots taken AFTER this request, keyed by serviceID.
+	BreakerAfter map[string]string `json:"breaker_after"` // closed/open/half_open
+	HealthAfter  map[string]string `json:"health_after"`  // healthy/unhealthy
+}
+
+// lbUpstreamScript yields a status per call. When calls outrun the script the
+// last entry repeats, so {200} means "always 200" and {500,500,500,200} means
+// "fail three times then recover".
+type lbUpstreamScript struct {
+	statuses []int
+	calls    int
+}
+
+func (u *lbUpstreamScript) next() int {
+	var s int
+	if u.calls < len(u.statuses) {
+		s = u.statuses[u.calls]
+	} else {
+		s = u.statuses[len(u.statuses)-1]
+	}
+	u.calls++
+	return s
+}
+
+type lbFakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (f *lbFakeClock) now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.t
+}
+
+func (f *lbFakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	f.t = f.t.Add(d)
+	f.mu.Unlock()
+}
+
+// NewLBSimulator builds the real selection + dispatch stack for rule against a
+// throwaway config, registering one provider per distinct service provider. The
+// faults map keys are serviceIDs (loadbalance.Service.ServiceID(), i.e.
+// "provider/model"); each value is a per-call status sequence (last repeats).
+// Services without a fault entry always return 200.
+//
+// It installs a deterministic breaker clock; the returned cleanup restores the
+// real clock and removes the temp config dir, and must be called.
+func NewLBSimulator(rule *typ.Rule, faults map[string][]int) (sim *LBSimulator, cleanup func(), err error) {
+	gin.SetMode(gin.TestMode)
+
+	dir, err := os.MkdirTemp("", "lbsim-")
+	if err != nil {
+		return nil, nil, fmt.Errorf("temp dir: %w", err)
+	}
+	cleanups := []func(){func() { _ = os.RemoveAll(dir) }}
+	runCleanup := func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+
+	cfg, err := config.NewConfig(config.WithConfigDir(dir))
+	if err != nil {
+		runCleanup()
+		return nil, nil, fmt.Errorf("config: %w", err)
+	}
+
+	seen := map[string]bool{}
+	for _, svc := range rule.Services {
+		if seen[svc.Provider] {
+			continue
+		}
+		seen[svc.Provider] = true
+		if e := cfg.AddProvider(&typ.Provider{
+			UUID:     svc.Provider,
+			Name:     svc.Provider,
+			Enabled:  true,
+			APIStyle: "openai",
+			APIBase:  "https://" + svc.Provider + ".example.invalid/v1",
+		}); e != nil {
+			runCleanup()
+			return nil, nil, fmt.Errorf("add provider %s: %w", svc.Provider, e)
+		}
+	}
+
+	// Align the health monitor with the breaker so the two feedback channels
+	// trip and recover on the same deterministic timeline: same failure
+	// threshold, and a recovery window equal to the breaker's open duration so
+	// one sim.Advance recovers both. Probing off (the sim has no live probe).
+	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{
+		ConsecutiveErrorThreshold: loadbalance.DefaultBreakerFailureThreshold,
+		RecoveryTimeoutSeconds:    int(loadbalance.DefaultBreakerOpenDuration.Seconds()),
+		ProbeEnabled:              false,
+	})
+	hf := typ.NewHealthFilter(hm)
+	lb := NewLoadBalancer(cfg, hf)
+	affinity := NewAffinityStore(0)
+
+	scripts := make(map[string]*lbUpstreamScript, len(faults))
+	for id, seq := range faults {
+		s := seq
+		if len(s) == 0 {
+			s = []int{http.StatusOK}
+		}
+		scripts[id] = &lbUpstreamScript{statuses: s}
+	}
+
+	// One fake clock drives all three time-based subsystems on the same
+	// deterministic timeline: the breaker and health monitor (package
+	// loadbalance) and the affinity TTL (package routing). A single sim.Advance
+	// therefore moves breaker recovery, health recovery, and affinity expiry
+	// together — matching production, where all three read the wall clock.
+	fakeClock := &lbFakeClock{t: time.Unix(0, 0)}
+	restoreClock := clock.SetClock(fakeClock.now)
+	cleanups = append(cleanups, restoreClock)
+
+	sim = &LBSimulator{
+		server:   &Server{config: cfg, loadBalancer: lb, healthMonitor: hm},
+		selector: routing.NewServiceSelector(cfg, affinity, lb),
+		affinity: affinity,
+		health:   hm,
+		rule:     rule,
+		scripts:  scripts,
+		clock:    fakeClock,
+	}
+	return sim, runCleanup, nil
+}
+
+func (s *LBSimulator) scriptFor(serviceID string) *lbUpstreamScript {
+	if sc, ok := s.scripts[serviceID]; ok {
+		return sc
+	}
+	sc := &lbUpstreamScript{statuses: []int{http.StatusOK}}
+	s.scripts[serviceID] = sc
+	return sc
+}
+
+// Request runs one request for the given session (empty = no affinity) through
+// the real selection + failover path, returning the trace.
+func (s *LBSimulator) Request(session string) (LBTrace, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ctx := &routing.SelectionContext{Rule: s.rule, MatchedSmartRuleIndex: -1}
+	if session != "" {
+		ctx.SessionID = typ.SessionID{Source: typ.SessionSourceHeader, Value: session}
+	}
+	res, err := s.selector.Select(ctx)
+	if err != nil {
+		return LBTrace{Session: session}, fmt.Errorf("selection failed: %w", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	tr := LBTrace{Session: session}
+	attempt := func(provider *typ.Provider, model string) {
+		sid := loadbalance.FormatServiceID(provider.UUID, model)
+		tr.Attempts = append(tr.Attempts, sid)
+		status := s.scriptFor(sid).next()
+		tr.Statuses = append(tr.Statuses, status)
+		tr.FinalStatus = status
+
+		// Feed BOTH production feedback channels exactly as a real request would:
+		//   - breaker: binary success/failure (mirrors the recorder).
+		//   - health monitor: status-classified, via the production classifier
+		//     reportHealthStatus (429→rate-limit, 401/403→auth, 5xx/4xx/other→
+		//     error, 2xx→success). The synthesized message routes through its
+		//     substring matcher exactly.
+		if status == http.StatusOK {
+			c.Writer.WriteHeader(http.StatusOK)
+			if gate, ok := c.Writer.(*firstChunkGate); ok {
+				gate.CommitFirstChunk() // simulate the stream's first real chunk
+			}
+			loadbalance.RecordServiceSuccess(sid)
+			s.server.reportHealthStatus(provider, model, nil, "")
+		} else {
+			c.Writer.WriteHeader(status)
+			loadbalance.RecordServiceFailure(sid)
+			s.server.reportHealthStatus(provider, model,
+				fmt.Errorf("upstream returned HTTP %d", status), "")
+		}
+	}
+	s.server.dispatchWithPriorityFailover(c, s.rule, res.Provider, res.Service.Model, attempt)
+
+	tr.PinAfter = s.pinLocked(session)
+	tr.BreakerAfter = s.BreakerStates()
+	tr.HealthAfter = s.HealthStates()
+	return tr, nil
+}
+
+// Advance moves the deterministic breaker clock forward, e.g. past OpenDuration
+// to drive a half-open recovery probe.
+func (s *LBSimulator) Advance(d time.Duration) {
+	s.clock.advance(d)
+}
+
+// Pin returns the serviceID the session is currently affinity-locked to ("" if none).
+func (s *LBSimulator) Pin(session string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pinLocked(session)
+}
+
+func (s *LBSimulator) pinLocked(session string) string {
+	if session == "" {
+		return ""
+	}
+	key := typ.SessionID{Source: typ.SessionSourceHeader, Value: session}.String()
+	entry, ok := s.affinity.Get(s.rule.UUID, key)
+	if !ok || entry == nil || entry.Service == nil {
+		return ""
+	}
+	return entry.Service.ServiceID()
+}
+
+// PinDetail returns the current (non-expired) affinity lock for a session: the
+// serviceID and its LockedAt/ExpiresAt timestamps (on the simulator's fake
+// clock). ok is false when there is no live lock. It reads through the store's
+// strict-TTL Get, so an expired lock reports ok=false — exactly what selection
+// sees. Used to assert strict (non-sliding) TTL: an unrefreshed lock keeps its
+// original timestamps, and a re-lock after expiry carries a fresh LockedAt.
+func (s *LBSimulator) PinDetail(session string) (serviceID string, lockedAt, expiresAt time.Time, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if session == "" {
+		return "", time.Time{}, time.Time{}, false
+	}
+	key := typ.SessionID{Source: typ.SessionSourceHeader, Value: session}.String()
+	entry, found := s.affinity.Get(s.rule.UUID, key)
+	if !found || entry == nil || entry.Service == nil {
+		return "", time.Time{}, time.Time{}, false
+	}
+	return entry.Service.ServiceID(), entry.LockedAt, entry.ExpiresAt, true
+}
+
+// SeedPin manually locks a session to a service (e.g. to reproduce a stale pin).
+func (s *LBSimulator) SeedPin(session, provider, model string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := typ.SessionID{Source: typ.SessionSourceHeader, Value: session}.String()
+	s.affinity.Set(s.rule.UUID, key, &routing.AffinityEntry{
+		Service:   &loadbalance.Service{Provider: provider, Model: model, Active: true},
+		LockedAt:  s.clock.now(),
+		ExpiresAt: s.clock.now().Add(time.Hour),
+	})
+}
+
+// BreakerStates returns a snapshot of every rule service's breaker state, keyed
+// by serviceID (values: "closed" / "open" / "half_open").
+func (s *LBSimulator) BreakerStates() map[string]string {
+	store := loadbalance.DefaultBreakerStore()
+	out := make(map[string]string, len(s.rule.Services))
+	for _, svc := range s.rule.Services {
+		id := svc.ServiceID()
+		out[id] = store.Get(id).State().String()
+	}
+	return out
+}
+
+// HealthStates returns a snapshot of every rule service's health-monitor state,
+// keyed by serviceID (values: "healthy" / "unhealthy"). This is the channel fed
+// by the special status codes (429 → rate-limit, 401/403 → auth), separate from
+// the breaker.
+func (s *LBSimulator) HealthStates() map[string]string {
+	out := make(map[string]string, len(s.rule.Services))
+	for _, svc := range s.rule.Services {
+		id := svc.ServiceID()
+		if s.health.IsHealthy(id) {
+			out[id] = "healthy"
+		} else {
+			out[id] = "unhealthy"
+		}
+	}
+	return out
+}

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/internal/clock"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	pkgobs "github.com/tingly-dev/tingly-box/pkg/obs"
@@ -243,8 +244,8 @@ func (s *ServiceSelector) postProcess(ctx *SelectionContext, result *SelectionRe
 	}
 	s.affinityStore.Set(ctx.Rule.UUID, ctx.SessionID.String(), &AffinityEntry{
 		Service:   result.Service,
-		LockedAt:  time.Now(),
-		ExpiresAt: time.Now().Add(ttl),
+		LockedAt:  clock.Now(),
+		ExpiresAt: clock.Now().Add(ttl),
 	})
 	logrus.Infof("[affinity] locked service %s -> %s for session %s",
 		result.Provider.Name, result.Service.Model, ctx.SessionID.String())

--- a/internal/server/routing/stage_affinity.go
+++ b/internal/server/routing/stage_affinity.go
@@ -1,10 +1,9 @@
 package routing
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/internal/clock"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -57,7 +56,7 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 	// Strict TTL: honor the pin only while the entry has not expired.
 	// Once the lock expires, the session must re-enter the selection pipeline
 	// and postProcess will create a new lock with a fresh TTL.
-	if time.Now().After(entry.ExpiresAt) {
+	if clock.Now().After(entry.ExpiresAt) {
 		logrus.Infof("[affinity] affinity entry for session %s expired at %s; dropping pin so strategy re-selects",
 			ctx.SessionID.String(), entry.ExpiresAt)
 		return nil, false


### PR DESCRIPTION
## Summary

Our tests could not realistically verify load-balancing *dynamics*. 
This adds a scenario simulator and a `harness lb` CLI tier so tier selection, failover, circuit breaker, health exclusion, and session-affinity pin movement can be driven against **programmable fake upstreams** — and watched request by request.

### Major

- **`internal/server/lbsim.go`** — shared engine driving the real `ServiceSelector.Select → dispatchWithPriorityFailover` path with a **deterministic clock**. Each attempt feeds *both* feedback channels: the breaker recorder **and** `reportHealthStatus` (429 → rate-limit, 401/403 → immediate unhealthy, 5xx → 3-strike).

- **Shared clock seam** (`internal/clock/clock.go`) — one fake clock drives breaker recovery, health recovery, and affinity-TTL expiry together. Production unchanged (`time.Now`).

- **`cli/harness lb`** — `--example cascade|flat|grid|…` (13 built-in, `--all` for CI) or `--file scenario.yaml`. Pencil graph, `--table`, `--json` output. Self-check `expect:` block catches regressions.

- **`lb_scenario_test.go`** — 13 end-to-end scenarios: single, flat, cascade, cross-model, rate-limit/auth-flip, half-open recovery, degrade, inactive filtering, within-tier tactic, multi-affinity. Each asserts attempts, pins, and breaker/health states.

### Minor

- Updated `.design/priority-routing.md` with two-feedback-channel model
- Added `harness lb` to CI workflow
- Updated `cli/harness/README.md` with YAML schema reference

## Example
```
#3  s1   t0/gpt-5.4 ✗500  →  t1/gpt-5.5 ✓200   →  client=200
       state: t0/gpt-5.4=open/unhealthy   t1/gpt-5.5=closed/healthy   pin=t1/gpt-5.5
#4  s1   t1/gpt-5.5 ✓200   →  client=200
       state: t0/gpt-5.4=open/unhealthy   t1/gpt-5.5=closed/healthy   pin=t1/gpt-5.5
    ── advance 31s ──
#5  s1   t0/gpt-5.4 ✓200   →  client=200
       state: t0/gpt-5.4=closed/healthy   t1/gpt-5.5=closed/healthy   pin=t0/gpt-5.4
```

## Tests

`internal/server/lb_scenario_test.go` — 13 scenario shapes, all asserting the captured trace, affinity pin, and breaker/health snapshots. `harness
lb --all` runs all built-in examples with self-check assertions.