### PR TITLE
fix(usage): correct TTFT so it no longer mirrors total latency

### DIFF
--- a/internal/protocol/loop.go
+++ b/internal/protocol/loop.go
@@ -53,10 +53,8 @@ func RunLoop(c *gin.Context, step func(w io.Writer) bool) bool {
 // the first real stream chunk has been produced, so it flushes buffered
 // output and switches to pass-through. No-op when no gate is installed.
 //
-// It is the centralized "first chunk reached the client" moment for every
-// committing streaming path (RunLoop-based producers commit here once,
-// hand-rolled producers call it explicitly), so it also records the Time To
-// First Token via MarkFirstToken.
+// As the "first chunk reached the client" moment for every committing
+// streaming path, it also records TTFT via MarkFirstToken.
 func CommitFirstChunk(c *gin.Context) {
 	MarkFirstToken(c)
 	if cm, ok := c.Writer.(interface{ CommitFirstChunk() }); ok {
@@ -64,14 +62,9 @@ func CommitFirstChunk(c *gin.Context) {
 	}
 }
 
-// MarkFirstToken stamps the first-token time used for TTFT metrics. It is the
-// single source of truth for recording TTFT: it records only on the first call
-// for a request (earliest signal wins) and is safe to call repeatedly.
-//
-// Streaming producers reach it through CommitFirstChunk on their first chunk;
-// the MCP interceptor (which does not commit) calls it directly on its first
-// event. Non-streaming handlers never call it, so their TTFT stays unset and
-// the dashboard renders "-" instead of a value identical to total latency.
+// MarkFirstToken is the single source of truth for recording the first-token
+// time used for TTFT: idempotent (earliest signal wins), safe to call
+// repeatedly. Non-streaming handlers never call it, so their TTFT stays unset.
 func MarkFirstToken(c *gin.Context) {
 	if c == nil {
 		return

--- a/internal/protocol/loop.go
+++ b/internal/protocol/loop.go
@@ -3,8 +3,11 @@ package protocol
 import (
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
 )
 
 // RunLoop drives a streaming response, handling client-disconnect detection,
@@ -49,10 +52,29 @@ func RunLoop(c *gin.Context, step func(w io.Writer) bool) bool {
 // CommitFirstChunk signals a failover gate wrapping c.Writer (if any) that
 // the first real stream chunk has been produced, so it flushes buffered
 // output and switches to pass-through. No-op when no gate is installed.
+//
+// This is also the single, centralized "first chunk reached the client"
+// moment for every streaming path (RunLoop-based producers commit here once,
+// hand-rolled producers call it explicitly), so it is where we record the
+// Time To First Token for TTFT metrics. Non-streaming handlers never reach
+// here, so their TTFT correctly stays unset.
 func CommitFirstChunk(c *gin.Context) {
+	recordFirstTokenTime(c)
 	if cm, ok := c.Writer.(interface{ CommitFirstChunk() }); ok {
 		cm.CommitFirstChunk()
 	}
+}
+
+// recordFirstTokenTime stamps the first-token time used for TTFT, only on the
+// first call for a request (earliest signal wins). Safe to call repeatedly.
+func recordFirstTokenTime(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	if _, exists := c.Get(constant.CtxKeyFirstTokenTime); exists {
+		return
+	}
+	c.Set(constant.CtxKeyFirstTokenTime, time.Now())
 }
 
 func commitFirstChunk(c *gin.Context) { CommitFirstChunk(c) }

--- a/internal/protocol/loop.go
+++ b/internal/protocol/loop.go
@@ -53,21 +53,26 @@ func RunLoop(c *gin.Context, step func(w io.Writer) bool) bool {
 // the first real stream chunk has been produced, so it flushes buffered
 // output and switches to pass-through. No-op when no gate is installed.
 //
-// This is also the single, centralized "first chunk reached the client"
-// moment for every streaming path (RunLoop-based producers commit here once,
-// hand-rolled producers call it explicitly), so it is where we record the
-// Time To First Token for TTFT metrics. Non-streaming handlers never reach
-// here, so their TTFT correctly stays unset.
+// It is the centralized "first chunk reached the client" moment for every
+// committing streaming path (RunLoop-based producers commit here once,
+// hand-rolled producers call it explicitly), so it also records the Time To
+// First Token via MarkFirstToken.
 func CommitFirstChunk(c *gin.Context) {
-	recordFirstTokenTime(c)
+	MarkFirstToken(c)
 	if cm, ok := c.Writer.(interface{ CommitFirstChunk() }); ok {
 		cm.CommitFirstChunk()
 	}
 }
 
-// recordFirstTokenTime stamps the first-token time used for TTFT, only on the
-// first call for a request (earliest signal wins). Safe to call repeatedly.
-func recordFirstTokenTime(c *gin.Context) {
+// MarkFirstToken stamps the first-token time used for TTFT metrics. It is the
+// single source of truth for recording TTFT: it records only on the first call
+// for a request (earliest signal wins) and is safe to call repeatedly.
+//
+// Streaming producers reach it through CommitFirstChunk on their first chunk;
+// the MCP interceptor (which does not commit) calls it directly on its first
+// event. Non-streaming handlers never call it, so their TTFT stays unset and
+// the dashboard renders "-" instead of a value identical to total latency.
+func MarkFirstToken(c *gin.Context) {
 	if c == nil {
 		return
 	}

--- a/internal/protocol/loop_test.go
+++ b/internal/protocol/loop_test.go
@@ -1,0 +1,76 @@
+package protocol
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+)
+
+// closeNotifyRecorder adds CloseNotify to httptest.ResponseRecorder so it can
+// back a gin.ResponseWriter driven by RunLoop.
+type closeNotifyRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (r *closeNotifyRecorder) CloseNotify() <-chan bool { return make(chan bool) }
+
+// TestMarkFirstToken_RecordsOnceEarliestWins verifies the single source of
+// truth is idempotent: the first signal wins and later calls never overwrite.
+func TestMarkFirstToken_RecordsOnceEarliestWins(t *testing.T) {
+	c := &gin.Context{}
+
+	_, exists := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.False(t, exists)
+
+	MarkFirstToken(c)
+	v, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok)
+	first := v.(time.Time)
+
+	time.Sleep(5 * time.Millisecond)
+	MarkFirstToken(c)
+	v2, _ := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.Equal(t, first, v2.(time.Time), "later mark must not overwrite earliest signal")
+}
+
+// TestCommitFirstChunk_RecordsFirstToken verifies the commit seam records TTFT
+// even when no failover gate is installed on the writer.
+func TestCommitFirstChunk_RecordsFirstToken(t *testing.T) {
+	c := &gin.Context{}
+
+	CommitFirstChunk(c)
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok, "CommitFirstChunk must record the first-token time")
+}
+
+// TestRunLoop_RecordsFirstTokenOnFirstChunk exercises the real streaming wiring:
+// RunLoop -> commitFirstChunk -> MarkFirstToken. Before any chunk the first-token
+// time is unset; once the first chunk is produced it is recorded.
+func TestRunLoop_RecordsFirstTokenOnFirstChunk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+
+	_, exists := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.False(t, exists, "no first-token time before streaming starts")
+
+	calls := 0
+	RunLoop(c, func(wr io.Writer) bool {
+		calls++
+		if calls == 1 {
+			_, _ = wr.Write([]byte("data: hi\n\n"))
+			return true // first chunk produced
+		}
+		return false // stop
+	})
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok, "RunLoop must record the first-token time after the first chunk")
+}

--- a/internal/protocol/stream/responses_to_anthropic_ttft_test.go
+++ b/internal/protocol/stream/responses_to_anthropic_ttft_test.go
@@ -1,0 +1,52 @@
+package stream
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// TestHandleResponsesToAnthropicV1Stream_RecordsTTFT verifies the streaming
+// Responses API → Anthropic conversion records the first-token time (TTFT)
+// through CommitFirstChunk, so the dashboard shows a real TTFT rather than "-".
+func TestHandleResponsesToAnthropicV1Stream_RecordsTTFT(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	// No first-token time before streaming starts.
+	_, exists := c.Get(constant.CtxKeyFirstTokenTime)
+	require.False(t, exists)
+
+	events := eventsToStrings([]map[string]any{
+		{"type": "response.created", "response": map[string]any{"id": "resp_1"}},
+		{"type": "response.output_text.delta", "item_id": "item_1", "output_index": 0, "delta": "hi"},
+		{"type": "response.completed", "response": map[string]any{
+			"id":     "resp_1",
+			"status": "completed",
+			"usage": map[string]any{
+				"input_tokens": 5, "output_tokens": 2, "total_tokens": 7,
+			},
+		}},
+	})
+	stream := openaistream.NewStream[responses.ResponseStreamEventUnion](
+		newFakeResponsesDecoder(events), nil,
+	)
+
+	_, err := HandleResponsesToAnthropicV1Stream(protocol.NewHandleContext(c, "proxy-model"), stream, "proxy-model")
+	require.NoError(t, err)
+
+	// The first emitted event must have recorded the first-token time.
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok, "streaming Responses->Anthropic should record TTFT via CommitFirstChunk")
+}

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -117,8 +117,6 @@ func (s *Server) handleAnthropicStreamResponseV1Beta(c *gin.Context, req *anthro
 	hc := protocol.NewHandleContext(c, respModel)
 	actualModel := string(req.Model)
 
-	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
-
 	// Add recorder hooks if recorder is available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)
 

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -117,15 +117,7 @@ func (s *Server) handleAnthropicStreamResponseV1Beta(c *gin.Context, req *anthro
 	hc := protocol.NewHandleContext(c, respModel)
 	actualModel := string(req.Model)
 
-	// Record TTFT when the first streaming chunk arrives
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 
 	// Add recorder hooks if recorder is available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)

--- a/internal/server/mcp_anthropic_v1_helper.go
+++ b/internal/server/mcp_anthropic_v1_helper.go
@@ -375,15 +375,8 @@ func (s *Server) dispatchGenericAnthropicV1Stream(
 	// Create HandleContext for streaming
 	hc := protocol.NewHandleContext(c, responseModel)
 
-	// Add TTFT tracking
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally by the MCP interceptor via
+	// protocol.MarkFirstToken on its first upstream event.
 
 	// Add recorder hooks if available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)
@@ -486,15 +479,8 @@ func (s *Server) dispatchGenericOpenAIChatStream(
 	// Create HandleContext for streaming
 	hc := protocol.NewHandleContext(c, responseModel)
 
-	// Add TTFT tracking
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally by the MCP interceptor via
+	// protocol.MarkFirstToken on its first upstream event.
 
 	// Add recorder hooks if available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)
@@ -587,15 +573,8 @@ func (s *Server) dispatchGenericAnthropicBetaStream(
 	// Create HandleContext for streaming
 	hc := protocol.NewHandleContext(c, responseModel)
 
-	// Add TTFT tracking
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally by the MCP interceptor via
+	// protocol.MarkFirstToken on its first upstream event.
 
 	// Add recorder hooks if available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)

--- a/internal/server/mcp_anthropic_v1_helper.go
+++ b/internal/server/mcp_anthropic_v1_helper.go
@@ -375,9 +375,6 @@ func (s *Server) dispatchGenericAnthropicV1Stream(
 	// Create HandleContext for streaming
 	hc := protocol.NewHandleContext(c, responseModel)
 
-	// TTFT is recorded centrally by the MCP interceptor via
-	// protocol.MarkFirstToken on its first upstream event.
-
 	// Add recorder hooks if available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)
 
@@ -479,9 +476,6 @@ func (s *Server) dispatchGenericOpenAIChatStream(
 	// Create HandleContext for streaming
 	hc := protocol.NewHandleContext(c, responseModel)
 
-	// TTFT is recorded centrally by the MCP interceptor via
-	// protocol.MarkFirstToken on its first upstream event.
-
 	// Add recorder hooks if available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)
 
@@ -572,9 +566,6 @@ func (s *Server) dispatchGenericAnthropicBetaStream(
 
 	// Create HandleContext for streaming
 	hc := protocol.NewHandleContext(c, responseModel)
-
-	// TTFT is recorded centrally by the MCP interceptor via
-	// protocol.MarkFirstToken on its first upstream event.
 
 	// Add recorder hooks if available
 	AttachRecorderHooks(hc, recorder, actualModel, provider)

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -223,9 +223,8 @@ func (i *GenericStreamInterceptor) consumeRound(stream StreamHandle) (any, error
 		}
 		event := stream.Current()
 
-		// Record TTFT on the first upstream event. The interceptor does not
-		// commit through CommitFirstChunk, so it records here directly (and
-		// unconditionally — independent of guardrails). Idempotent.
+		// The interceptor never commits through CommitFirstChunk, so record
+		// TTFT here on the first upstream event.
 		protocol.MarkFirstToken(i.c)
 
 		i.accumulateRoundEvent(event)

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -222,6 +222,12 @@ func (i *GenericStreamInterceptor) consumeRound(stream StreamHandle) (any, error
 			break
 		}
 		event := stream.Current()
+
+		// Record TTFT on the first upstream event. The interceptor does not
+		// commit through CommitFirstChunk, so it records here directly (and
+		// unconditionally — independent of guardrails). Idempotent.
+		protocol.MarkFirstToken(i.c)
+
 		i.accumulateRoundEvent(event)
 
 		// Call guardrails hooks if enabled

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -363,16 +363,7 @@ func (s *Server) streamOpenAIChat(c *gin.Context, provider *typ.Provider, origin
 	hc := protocol.NewHandleContext(c, responseModel)
 	hc.DisableStreamUsage = disableStreamUsage
 
-	// Record TTFT when the first streaming chunk arrives
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
-
+	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleOpenAIChatStream(hc, streamResp, req)
 
 	// Track usage from stream handler

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -363,7 +363,6 @@ func (s *Server) streamOpenAIChat(c *gin.Context, provider *typ.Provider, origin
 	hc := protocol.NewHandleContext(c, responseModel)
 	hc.DisableStreamUsage = disableStreamUsage
 
-	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleOpenAIChatStream(hc, streamResp, req)
 
 	// Track usage from stream handler

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -846,14 +846,7 @@ func (s *Server) streamResponsesToChat(c *gin.Context, reqCtx *transform.Transfo
 	}
 
 	hc := protocol.NewHandleContext(c, responseModel)
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleResponsesToOpenAIChatStream(hc, primedStream, responseModel)
 	s.trackUsageWithTokenUsage(c, usage, err)
 	if recorder != nil {
@@ -944,14 +937,7 @@ func (s *Server) streamOpenAIResponses(c *gin.Context, reqCtx *transform.Transfo
 
 	// Handle the streaming response
 	hc := protocol.NewHandleContext(c, responseModel)
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleOpenAIResponsesStream(hc, primedStream, responseModel)
 
 	// Track usage from stream handler
@@ -1056,14 +1042,7 @@ func (s *Server) streamAnthropicBetaFromResponses(c *gin.Context, reqCtx *transf
 	}
 
 	hc := protocol.NewHandleContext(c, responseModel)
-	firstTokenRecorded := false
-	hc.WithOnStreamEvent(func(_ interface{}) error {
-		if !firstTokenRecorded {
-			SetFirstTokenTime(c)
-			firstTokenRecorded = true
-		}
-		return nil
-	})
+	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleAnthropicBetaToOpenAIResponsesStream(hc, anthropicStream, responseModel)
 	s.trackUsageWithTokenUsage(c, usage, err)
 }

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -846,7 +846,6 @@ func (s *Server) streamResponsesToChat(c *gin.Context, reqCtx *transform.Transfo
 	}
 
 	hc := protocol.NewHandleContext(c, responseModel)
-	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleResponsesToOpenAIChatStream(hc, primedStream, responseModel)
 	s.trackUsageWithTokenUsage(c, usage, err)
 	if recorder != nil {
@@ -937,7 +936,6 @@ func (s *Server) streamOpenAIResponses(c *gin.Context, reqCtx *transform.Transfo
 
 	// Handle the streaming response
 	hc := protocol.NewHandleContext(c, responseModel)
-	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleOpenAIResponsesStream(hc, primedStream, responseModel)
 
 	// Track usage from stream handler
@@ -1042,7 +1040,6 @@ func (s *Server) streamAnthropicBetaFromResponses(c *gin.Context, reqCtx *transf
 	}
 
 	hc := protocol.NewHandleContext(c, responseModel)
-	// TTFT is recorded centrally via protocol.MarkFirstToken (CommitFirstChunk).
 	usage, err := stream.HandleAnthropicBetaToOpenAIResponsesStream(hc, anthropicStream, responseModel)
 	s.trackUsageWithTokenUsage(c, usage, err)
 }

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -93,12 +93,6 @@ func calculateLatencyFromStart(startTime time.Time) int {
 	return int(elapsed.Milliseconds())
 }
 
-// SetFirstTokenTime records when the first token was received (for TTFT calculation).
-// This should be called when the first chunk is received in streaming requests.
-func SetFirstTokenTime(c *gin.Context) {
-	c.Set(ContextKeyFirstTokenTime, time.Now())
-}
-
 // GetFirstTokenTime retrieves the first token time from the context.
 // Returns the timestamp and true if it exists, zero time and false otherwise.
 func GetFirstTokenTime(c *gin.Context) (time.Time, bool) {
@@ -112,9 +106,9 @@ func GetFirstTokenTime(c *gin.Context) (time.Time, bool) {
 
 // CalculateTTFT calculates Time To First Token in milliseconds.
 //
-// TTFT only has meaning for streaming requests, where SetFirstTokenTime is
-// called when the first chunk arrives. When the first token time is recorded,
-// TTFT = firstTokenTime - startTime.
+// TTFT only has meaning for streaming requests, where protocol.MarkFirstToken
+// records the first-token time when the first chunk arrives. When that time is
+// recorded, TTFT = firstTokenTime - startTime.
 //
 // For non-streaming requests (or when the first token time was never recorded)
 // there is no distinct "first token" moment, so TTFT is not applicable and we

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -104,16 +104,9 @@ func GetFirstTokenTime(c *gin.Context) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// CalculateTTFT calculates Time To First Token in milliseconds.
-//
-// TTFT only has meaning for streaming requests, where protocol.MarkFirstToken
-// records the first-token time when the first chunk arrives. When that time is
-// recorded, TTFT = firstTokenTime - startTime.
-//
-// For non-streaming requests (or when the first token time was never recorded)
-// there is no distinct "first token" moment, so TTFT is not applicable and we
-// return 0. Returning 0 lets the dashboard render "-" instead of mistakenly
-// showing a value identical to the total latency.
+// CalculateTTFT returns Time To First Token in milliseconds, or 0 when no
+// first-token time was recorded (e.g. non-streaming requests). It must not
+// fall back to total latency, which would make TTFT indistinguishable from it.
 func CalculateTTFT(c *gin.Context) int64 {
 	startTime := time.Time{}
 	if t, exists := c.Get(ContextKeyStartTime); exists {
@@ -126,8 +119,6 @@ func CalculateTTFT(c *gin.Context) int64 {
 		return 0
 	}
 
-	// Only report TTFT when the first token time was actually recorded
-	// (streaming requests). Otherwise TTFT is not applicable.
 	if firstTokenTime, hasTTFT := GetFirstTokenTime(c); hasTTFT {
 		return firstTokenTime.Sub(startTime).Milliseconds()
 	}

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -111,7 +111,15 @@ func GetFirstTokenTime(c *gin.Context) (time.Time, bool) {
 }
 
 // CalculateTTFT calculates Time To First Token in milliseconds.
-// Returns TTFT if firstTokenTime is set, otherwise returns total latency.
+//
+// TTFT only has meaning for streaming requests, where SetFirstTokenTime is
+// called when the first chunk arrives. When the first token time is recorded,
+// TTFT = firstTokenTime - startTime.
+//
+// For non-streaming requests (or when the first token time was never recorded)
+// there is no distinct "first token" moment, so TTFT is not applicable and we
+// return 0. Returning 0 lets the dashboard render "-" instead of mistakenly
+// showing a value identical to the total latency.
 func CalculateTTFT(c *gin.Context) int64 {
 	startTime := time.Time{}
 	if t, exists := c.Get(ContextKeyStartTime); exists {
@@ -124,13 +132,13 @@ func CalculateTTFT(c *gin.Context) int64 {
 		return 0
 	}
 
-	// Try to get first token time
+	// Only report TTFT when the first token time was actually recorded
+	// (streaming requests). Otherwise TTFT is not applicable.
 	if firstTokenTime, hasTTFT := GetFirstTokenTime(c); hasTTFT {
 		return firstTokenTime.Sub(startTime).Milliseconds()
 	}
 
-	// Fallback: TTFT = total latency for non-streaming or if first token time not set
-	return time.Since(startTime).Milliseconds()
+	return 0
 }
 
 // SetCacheHit records whether this request was a cache hit.

--- a/internal/server/tracking_context_test.go
+++ b/internal/server/tracking_context_test.go
@@ -244,19 +244,20 @@ func TestCalculateTTFT(t *testing.T) {
 		assert.LessOrEqual(t, ttft, int64(350))
 	})
 
-	t.Run("non-streaming fallback to total latency", func(t *testing.T) {
+	t.Run("no first token time is not applicable", func(t *testing.T) {
 		c := &gin.Context{}
 
 		startTime := time.Now().Add(-500 * time.Millisecond)
 		c.Set(ContextKeyStartTime, startTime)
-		// No first token time set
+		// No first token time set (e.g. non-streaming request)
 
 		ttft := CalculateTTFT(c)
 
-		// Should fallback to total latency (~500ms)
-		// Allow tolerance (450-550ms)
-		assert.GreaterOrEqual(t, ttft, int64(450))
-		assert.LessOrEqual(t, ttft, int64(550))
+		// TTFT only has meaning once a first token time was recorded.
+		// Without it we must NOT fall back to the total latency, otherwise
+		// the dashboard would show TTFT identical to latency. Return 0 so the
+		// frontend renders "-".
+		assert.Equal(t, int64(0), ttft)
 	})
 
 	t.Run("no start time", func(t *testing.T) {

--- a/internal/server/tracking_context_test.go
+++ b/internal/server/tracking_context_test.go
@@ -270,23 +270,31 @@ func TestCalculateTTFT(t *testing.T) {
 	})
 }
 
-// TestSetGetFirstTokenTime tests first token time tracking
-func TestSetGetFirstTokenTime(t *testing.T) {
+// TestMarkAndGetFirstTokenTime tests first token time tracking. TTFT is
+// recorded by the single source of truth, protocol.MarkFirstToken, and read
+// back through GetFirstTokenTime.
+func TestMarkAndGetFirstTokenTime(t *testing.T) {
 	c := &gin.Context{}
 
 	// Initially should not exist
 	_, exists := GetFirstTokenTime(c)
 	assert.False(t, exists)
 
-	// Set first token time
+	// Mark first token time
 	now := time.Now()
-	SetFirstTokenTime(c)
+	protocol.MarkFirstToken(c)
 
 	// Should exist now
 	firstTokenTime, exists := GetFirstTokenTime(c)
 	assert.True(t, exists)
 	assert.False(t, firstTokenTime.IsZero())
 	assert.WithinDuration(t, now, firstTokenTime, 100*time.Millisecond)
+
+	// Idempotent: a later mark must not overwrite the earliest signal.
+	time.Sleep(5 * time.Millisecond)
+	protocol.MarkFirstToken(c)
+	again, _ := GetFirstTokenTime(c)
+	assert.Equal(t, firstTokenTime, again)
 }
 
 // TestSetGetCacheHit tests cache hit tracking


### PR DESCRIPTION
## Problem

On the dashboard Requests view, `latency` and `ttft` showed identical values, which is wrong — TTFT (time to first token) should be well below total latency for streaming.

## Root cause (two layers)

1. **Non-streaming:** `CalculateTTFT` fell back to `time.Since(startTime)` (≈ total latency) when no first-token time was recorded. Non-streaming requests never record one, so TTFT == latency.
2. **Streaming:** the first-token time was only recorded by a per-handler `WithOnStreamEvent(SetFirstTokenTime)` hook, which is **only dispatched by `ProcessStream`**. Handlers driving the stream through `RunLoop` directly (e.g. the OpenAI Responses passthrough) or via raw loops never fired it, and the MCP interceptor only dispatched hooks when guardrails were on — so those paths fell back to total latency too.

The frontend and the API/DB serialization were both correct (`latency_ms` / `ttft_ms` are distinct, no field swap); the bug was entirely in backend computation/recording.

## Fix

- `CalculateTTFT` returns `0` (not total latency) when no first-token time was recorded. The frontend already renders `0` as `-`, which is the correct semantics for "no distinct first token" (non-streaming).
- Consolidate first-token recording to a single idempotent source of truth, `protocol.MarkFirstToken` (earliest signal wins), invoked at the two genuine seams:
  - `CommitFirstChunk` — the centralized "first chunk reached the client" signal, hit by every committing `RunLoop`/`ProcessStream` path.
  - the MCP interceptor's consume loop — which never commits, so it records directly and unconditionally (also fixing the guardrails-off gap).
- Remove the 8 now-redundant per-handler `SetFirstTokenTime` hooks and the unused `SetFirstTokenTime`. Reading still goes through `GetFirstTokenTime`.

Each removed hook's path was verified to retain coverage (ProcessStream/RunLoop → CommitFirstChunk; MCP → MarkFirstToken in the consume loop) before deletion.

## Coverage notes

- **Streaming Responses→Anthropic (v1 & beta) is covered**: it goes through `RunConverter` + `anthropicSSEWriterWithFirstChunk`, both of which call `CommitFirstChunk`, so TTFT is recorded. Proven by `TestHandleResponsesToAnthropicV1Stream_RecordsTTFT`.
- **Not covered (by design):** the non-streaming **assembly** path (used when the client requests a non-streaming response) buffers the upstream stream and emits once — there is no incremental first token, so TTFT correctly shows `-`. The `→Google` output conversions also use raw loops without `CommitFirstChunk` and show `-`; left as-is.

## Tests

- `TestCalculateTTFT` updated: no first-token time → `0` (was: total latency).
- `TestMarkAndGetFirstTokenTime`: records + earliest-wins idempotency.
- `internal/protocol/loop_test.go`:
  - `TestMarkFirstToken_RecordsOnceEarliestWins`
  - `TestCommitFirstChunk_RecordsFirstToken`
  - `TestRunLoop_RecordsFirstTokenOnFirstChunk` — exercises the real wiring `RunLoop → commitFirstChunk → MarkFirstToken`.
- `TestHandleResponsesToAnthropicV1Stream_RecordsTTFT` — proves the streaming Responses→Anthropic path records TTFT end-to-end.

All of `internal/server`, `internal/protocol/...`, `internal/server/module/mcp`, and `internal/protocoltest` (failover) pass.

https://claude.ai/code/session_01PHLySu7uJAfX44k81o7UVS