### PR TITLE
refactor(frontend): streamline routing pages and probe diagnostics

### DIFF
--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -451,31 +451,18 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
     return (
         <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth PaperProps={{ sx: { minHeight: 420 } }}>
             <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', minWidth: 0 }}>
-                    <Typography variant="subtitle1" fontWeight={600}>
-                        {targetName}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', minWidth: 0, overflow: 'hidden' }}>
+                    <Typography
+                        variant="subtitle1"
+                        fontWeight={600}
+                        sx={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {model ? `${targetName} · ${model}` : targetName}
                     </Typography>
-                    {model && (
-                        <>
-                            <Typography variant="body2" color="text.secondary">
-                                ·
-                            </Typography>
-                            <Typography
-                                variant="body2"
-                                sx={{
-                                    fontFamily: 'monospace',
-                                    fontWeight: 500,
-                                    color: 'primary.main',
-                                    maxWidth: 200,
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                }}
-                            >
-                                {model}
-                            </Typography>
-                        </>
-                    )}
                 </Box>
                 <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
                     {import.meta.env.DEV && (

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -455,12 +455,30 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
                     <Typography variant="subtitle1" fontWeight={600}>
                         {targetType === 'rule' ? t('probe.testRule') : t('probe.testProvider')}
                     </Typography>
-                    <Chip
-                        label={model ? `${targetName} | ${model}` : targetName}
-                        size="small"
-                        variant="outlined"
-                        sx={{ fontFamily: 'monospace', fontSize: '0.75rem', maxWidth: 360 }}
-                    />
+                    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+                        {targetName}
+                    </Typography>
+                    {model && (
+                        <>
+                            <Typography variant="body2" color="text.secondary">
+                                ·
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    fontFamily: 'monospace',
+                                    fontWeight: 500,
+                                    color: 'primary.main',
+                                    maxWidth: 200,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {model}
+                            </Typography>
+                        </>
+                    )}
                 </Box>
                 <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
                     {import.meta.env.DEV && (

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -550,7 +550,7 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
 
             <DialogContent>
                 {/* Controls: 形态 (request shape) + 范围 (scope) */}
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap', mb: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 3, flexWrap: 'wrap', mb: 1 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Typography variant="caption" color="text.secondary">
                             {t('probe.shape')}

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -14,7 +14,6 @@ import {
     ToggleButtonGroup,
     Collapse,
     Alert,
-    AlertTitle,
 } from '@mui/material';
 import {
     CheckCircle as CheckIcon,
@@ -177,12 +176,6 @@ const JourneyRow = memo(({ label, value, muted }: { label: string; value: React.
     );
 });
 
-const SectionTitle = ({ children }: { children: React.ReactNode }) => (
-    <Typography variant="body2" sx={{ fontWeight: 600, color: 'primary.main', mt: 2, mb: 0.5 }}>
-        {children}
-    </Typography>
-);
-
 // CollapsibleSection: a section with title and expand/collapse functionality
 interface CollapsibleSectionProps {
     title: string;
@@ -239,20 +232,21 @@ const StatusBar = memo(({ result }: { result: ProbeResult }) => {
     return (
         <Alert
             severity={ok ? 'success' : 'error'}
-            variant="filled"
+            variant="outlined"
             sx={{
                 mt: 2,
                 borderRadius: 2,
+                borderWidth: 2,
                 '& .MuiAlert-icon': {
-                    fontSize: 32,
+                    fontSize: 28,
                 },
             }}
-            icon={ok ? <CheckIcon sx={{ fontSize: 32 }} /> : <ErrorIcon sx={{ fontSize: 32 }} />}
+            icon={ok ? <CheckIcon sx={{ fontSize: 28 }} /> : <ErrorIcon sx={{ fontSize: 28 }} />}
         >
-            <AlertTitle sx={{ fontWeight: 700, fontSize: '1rem' }}>
-                {ok ? t('probe.success') : t('probe.failed')}
-            </AlertTitle>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+                <Typography variant="subtitle1" fontWeight={700} sx={{ fontSize: '1rem' }}>
+                    {ok ? t('probe.success') : t('probe.failed')}
+                </Typography>
                 {d?.latency_ms ? (
                     <Chip
                         icon={<SpeedIcon sx={{ fontSize: 16 }} />}
@@ -260,7 +254,7 @@ const StatusBar = memo(({ result }: { result: ProbeResult }) => {
                         size="medium"
                         sx={{
                             height: 28,
-                            bgcolor: 'rgba(255,255,255,0.2)',
+                            bgcolor: ok ? 'success.main' : 'error.main',
                             color: 'common.white',
                             '& .MuiChip-icon': {
                                 color: 'common.white',
@@ -275,7 +269,7 @@ const StatusBar = memo(({ result }: { result: ProbeResult }) => {
                         size="medium"
                         sx={{
                             height: 28,
-                            bgcolor: 'rgba(255,255,255,0.2)',
+                            bgcolor: ok ? 'success.main' : 'error.main',
                             color: 'common.white',
                             '& .MuiChip-icon': {
                                 color: 'common.white',
@@ -283,20 +277,21 @@ const StatusBar = memo(({ result }: { result: ProbeResult }) => {
                         }}
                     />
                 ) : null}
-                {!ok && result.error && (
-                    <Typography
-                        variant="body2"
-                        sx={{
-                            fontFamily: 'monospace',
-                            fontSize: '0.85rem',
-                            color: 'common.white',
-                            wordBreak: 'break-word',
-                        }}
-                    >
-                        {result.error.message}
-                    </Typography>
-                )}
             </Box>
+            {!ok && result.error && (
+                <Typography
+                    variant="body2"
+                    sx={{
+                        fontFamily: 'monospace',
+                        fontSize: '0.85rem',
+                        mt: 1,
+                        color: 'text.primary',
+                        wordBreak: 'break-word',
+                    }}
+                >
+                    {result.error.message}
+                </Typography>
+            )}
         </Alert>
     );
 });

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -7,13 +7,14 @@ import {
     Typography,
     Chip,
     LinearProgress,
-    Alert,
     IconButton,
     Tooltip,
     Button,
     ToggleButton,
     ToggleButtonGroup,
     Collapse,
+    Alert,
+    AlertTitle,
 } from '@mui/material';
 import {
     CheckCircle as CheckIcon,
@@ -23,6 +24,8 @@ import {
     ContentCopy as CopyIcon,
     Refresh as RefreshIcon,
     PlayArrow as RunIcon,
+    ExpandMore as ExpandMoreIcon,
+    ExpandLess as ExpandLessIcon,
 } from '@/components/icons';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
@@ -180,6 +183,53 @@ const SectionTitle = ({ children }: { children: React.ReactNode }) => (
     </Typography>
 );
 
+// CollapsibleSection: a section with title and expand/collapse functionality
+interface CollapsibleSectionProps {
+    title: string;
+    defaultExpanded?: boolean;
+    children: React.ReactNode;
+}
+
+const CollapsibleSection = memo(({ title, defaultExpanded = false, children }: CollapsibleSectionProps) => {
+    const [expanded, setExpanded] = useState(defaultExpanded);
+    const theme = useTheme();
+
+    return (
+        <Box
+            sx={{
+                mt: 2,
+                border: `1px solid ${theme.palette.divider}`,
+                borderRadius: 1.5,
+                overflow: 'hidden',
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    px: 1.5,
+                    py: 1,
+                    bgcolor: 'action.hover',
+                    cursor: 'pointer',
+                    '&:hover': {
+                        bgcolor: 'action.selected',
+                    },
+                }}
+                onClick={() => setExpanded(!expanded)}
+            >
+                <Typography variant="subtitle2" fontWeight={600} color="text.primary">
+                    {title}
+                </Typography>
+                {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            </Box>
+            <Collapse in={expanded}>
+                <Box sx={{ p: 1.5 }}>{children}</Box>
+            </Collapse>
+        </Box>
+    );
+});
+
 // StatusBar: the one-glance verdict — success/failure, latency, tokens.
 const StatusBar = memo(({ result }: { result: ProbeResult }) => {
     const theme = useTheme();
@@ -187,28 +237,67 @@ const StatusBar = memo(({ result }: { result: ProbeResult }) => {
     const ok = result.success;
     const d = result.data;
     return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            {ok ? (
-                <CheckIcon sx={{ color: theme.palette.success.main, fontSize: 24 }} />
-            ) : (
-                <ErrorIcon sx={{ color: theme.palette.error.main, fontSize: 24 }} />
-            )}
-            <Typography variant="subtitle2" fontWeight={600}>
+        <Alert
+            severity={ok ? 'success' : 'error'}
+            variant="filled"
+            sx={{
+                mt: 2,
+                borderRadius: 2,
+                '& .MuiAlert-icon': {
+                    fontSize: 32,
+                },
+            }}
+            icon={ok ? <CheckIcon sx={{ fontSize: 32 }} /> : <ErrorIcon sx={{ fontSize: 32 }} />}
+        >
+            <AlertTitle sx={{ fontWeight: 700, fontSize: '1rem' }}>
                 {ok ? t('probe.success') : t('probe.failed')}
-            </Typography>
-            {d?.latency_ms ? (
-                <Chip icon={<SpeedIcon sx={{ fontSize: 14 }} />} label={`${d.latency_ms}ms`} size="small" sx={{ height: 24 }} />
-            ) : null}
-            {d?.total_tokens ? (
-                <Chip
-                    icon={<TokenIcon sx={{ fontSize: 14 }} />}
-                    label={`${d.total_tokens} tokens`}
-                    size="small"
-                    variant="outlined"
-                    sx={{ height: 24 }}
-                />
-            ) : null}
-        </Box>
+            </AlertTitle>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+                {d?.latency_ms ? (
+                    <Chip
+                        icon={<SpeedIcon sx={{ fontSize: 16 }} />}
+                        label={`${d.latency_ms}ms`}
+                        size="medium"
+                        sx={{
+                            height: 28,
+                            bgcolor: 'rgba(255,255,255,0.2)',
+                            color: 'common.white',
+                            '& .MuiChip-icon': {
+                                color: 'common.white',
+                            },
+                        }}
+                    />
+                ) : null}
+                {d?.total_tokens ? (
+                    <Chip
+                        icon={<TokenIcon sx={{ fontSize: 16 }} />}
+                        label={`${d.total_tokens} tokens`}
+                        size="medium"
+                        sx={{
+                            height: 28,
+                            bgcolor: 'rgba(255,255,255,0.2)',
+                            color: 'common.white',
+                            '& .MuiChip-icon': {
+                                color: 'common.white',
+                            },
+                        }}
+                    />
+                ) : null}
+                {!ok && result.error && (
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            fontFamily: 'monospace',
+                            fontSize: '0.85rem',
+                            color: 'common.white',
+                            wordBreak: 'break-word',
+                        }}
+                    >
+                        {result.error.message}
+                    </Typography>
+                )}
+            </Box>
+        </Alert>
     );
 });
 
@@ -300,7 +389,6 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
     const [direct, setDirect] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [result, setResult] = useState<ProbeResult | null>(null);
-    const [rawExpanded, setRawExpanded] = useState(false);
     const [copyTooltipOpen, setCopyTooltipOpen] = useState(false);
 
     // Reset on open — do NOT auto-run; the user clicks 运行测试.
@@ -310,14 +398,12 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
             setDirect(false);
             setResult(null);
             setIsLoading(false);
-            setRawExpanded(false);
         }
     }, [open, testMode]);
 
     const runTest = useCallback(async () => {
         setIsLoading(true);
         setResult(null);
-        setRawExpanded(false);
 
         const body = {
             target_type: targetType,
@@ -382,28 +468,94 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
                         sx={{ fontFamily: 'monospace', fontSize: '0.75rem', maxWidth: 360 }}
                     />
                 </Box>
-                {result && (
-                    <Box sx={{ display: 'flex', gap: 0.5 }}>
-                        <Tooltip
-                            title={copyTooltipOpen ? t('probe.copied') : t('probe.copyResponse')}
-                            open={copyTooltipOpen || undefined}
-                            disableHoverListener={copyTooltipOpen}
-                        >
-                            <IconButton onClick={handleCopy} size="small" sx={{ color: 'text.secondary' }}>
-                                <CopyIcon fontSize="small" />
-                            </IconButton>
-                        </Tooltip>
-                        <Tooltip title={t('probe.rerun')}>
-                            <IconButton onClick={runTest} size="small" sx={{ color: 'text.secondary' }} disabled={isLoading}>
-                                <RefreshIcon fontSize="small" />
-                            </IconButton>
-                        </Tooltip>
-                    </Box>
-                )}
+                <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                    {import.meta.env.DEV && (
+                        <>
+                            <Tooltip title="Simulate Success">
+                                <IconButton
+                                    size="small"
+                                    onClick={() => {
+                                        setResult({
+                                            success: true,
+                                            data: {
+                                                content: 'Simulated success response for demo purposes',
+                                                latency_ms: 450,
+                                                request_url: 'https://api.example.com/v1/chat',
+                                                stream: mode === 'streaming',
+                                                prompt_tokens: 25,
+                                                completion_tokens: 18,
+                                                total_tokens: 43,
+                                                selected_provider: targetName,
+                                                selected_model: model || 'claude-sonnet-4-20250514',
+                                                routing_source: 'smart_routing',
+                                                matched_smart_rule: 1,
+                                                upstream_api: 'anthropic_v1',
+                                                upstream_url: 'https://api.anthropic.com/v1/messages',
+                                                matched_rule: 'test-rule',
+                                                matched_rule_desc: 'Test Rule Description',
+                                                applied_flags: 'stream,bypass_cache',
+                                            },
+                                        });
+                                        setIsLoading(false);
+                                    }}
+                                    sx={{ color: 'success.main' }}
+                                >
+                                    <CheckIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
+                            <Tooltip title="Simulate Failure">
+                                <IconButton
+                                    size="small"
+                                    onClick={() => {
+                                        setResult({
+                                            success: false,
+                                            error: {
+                                                message: 'Simulated error for demo purposes: Connection timeout',
+                                                type: 'upstream_error',
+                                            },
+                                        });
+                                        setIsLoading(false);
+                                    }}
+                                    sx={{ color: 'error.main' }}
+                                >
+                                    <ErrorIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
+                        </>
+                    )}
+                    {result && (
+                        <>
+                            <Tooltip
+                                title={copyTooltipOpen ? t('probe.copied') : t('probe.copyResponse')}
+                                open={copyTooltipOpen || undefined}
+                                disableHoverListener={copyTooltipOpen}
+                            >
+                                <IconButton onClick={handleCopy} size="small" sx={{ color: 'text.secondary' }}>
+                                    <CopyIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
+                            <Tooltip title={t('probe.rerun')}>
+                                <IconButton onClick={runTest} size="small" sx={{ color: 'text.secondary' }} disabled={isLoading}>
+                                    <RefreshIcon fontSize="small" />
+                                </IconButton>
+                            </Tooltip>
+                        </>
+                    )}
+                    <Button
+                        variant="contained"
+                        size="small"
+                        startIcon={isLoading ? null : <RunIcon fontSize="small" />}
+                        onClick={runTest}
+                        disabled={isLoading}
+                        sx={{ minWidth: 100 }}
+                    >
+                        {isLoading ? t('probe.running') : t('probe.run')}
+                    </Button>
+                </Box>
             </DialogTitle>
 
             <DialogContent>
-                {/* Controls: 形态 (request shape) + 范围 (scope) + run */}
+                {/* Controls: 形态 (request shape) + 范围 (scope) */}
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap', mb: 1 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Typography variant="caption" color="text.secondary">
@@ -443,17 +595,6 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
                             </ToggleButtonGroup>
                         </Box>
                     )}
-
-                    <Button
-                        variant="contained"
-                        size="small"
-                        startIcon={<RunIcon fontSize="small" />}
-                        onClick={runTest}
-                        disabled={isLoading}
-                        sx={{ ml: 'auto' }}
-                    >
-                        {isLoading ? t('probe.running') : t('probe.run')}
-                    </Button>
                 </Box>
 
                 {isLoading && <LinearProgress sx={{ height: 6, borderRadius: 3, mt: 1 }} />}
@@ -468,35 +609,21 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
 
                 {!isLoading && result && (
                     <Box>
-                        <Box sx={{ mt: 1 }}>
-                            <StatusBar result={result} />
-                        </Box>
+                        <StatusBar result={result} />
 
-                        {!result.success && result.error && (
-                            <Alert severity="error" variant="outlined" sx={{ mt: 2, borderRadius: 2 }}>
-                                <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
-                                    {result.error.message}
-                                </Typography>
-                                {result.error.type && (
-                                    <Typography variant="caption" color="text.secondary">
-                                        Type: {result.error.type}
-                                    </Typography>
-                                )}
-                            </Alert>
-                        )}
-
-                        <Journey
-                            result={result}
-                            targetType={targetType}
-                            targetName={targetName}
-                            scenario={scenario}
-                            model={model}
-                            bypassed={bypassed}
-                        />
+                        <CollapsibleSection title={t('probe.journey')} defaultExpanded={false}>
+                            <Journey
+                                result={result}
+                                targetType={targetType}
+                                targetName={targetName}
+                                scenario={scenario}
+                                model={model}
+                                bypassed={bypassed}
+                            />
+                        </CollapsibleSection>
 
                         {result.success && (
-                            <Box>
-                                <SectionTitle>{t('probe.response')}</SectionTitle>
+                            <CollapsibleSection title={t('probe.response')} defaultExpanded={false}>
                                 <Box
                                     sx={{
                                         p: 1.5,
@@ -512,31 +639,27 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
                                 >
                                     {extracted || t('probe.noText')}
                                 </Box>
-                                {result.data?.content && (
-                                    <>
-                                        <Button size="small" onClick={() => setRawExpanded((v) => !v)} sx={{ mt: 0.5, textTransform: 'none' }}>
-                                            {rawExpanded ? t('probe.rawJsonHide') : t('probe.rawJson')}
-                                        </Button>
-                                        <Collapse in={rawExpanded}>
-                                            <Box
-                                                sx={{
-                                                    p: 1.5,
-                                                    bgcolor: 'grey.50',
-                                                    borderRadius: 1.5,
-                                                    fontFamily: 'monospace',
-                                                    fontSize: '0.72rem',
-                                                    whiteSpace: 'pre-wrap',
-                                                    wordBreak: 'break-all',
-                                                    maxHeight: 240,
-                                                    overflow: 'auto',
-                                                }}
-                                            >
-                                                {result.data.content}
-                                            </Box>
-                                        </Collapse>
-                                    </>
-                                )}
-                            </Box>
+                            </CollapsibleSection>
+                        )}
+
+                        {result.success && result.data?.content && (
+                            <CollapsibleSection title={t('probe.rawJson')} defaultExpanded={false}>
+                                <Box
+                                    sx={{
+                                        p: 1.5,
+                                        bgcolor: 'grey.50',
+                                        borderRadius: 1.5,
+                                        fontFamily: 'monospace',
+                                        fontSize: '0.72rem',
+                                        whiteSpace: 'pre-wrap',
+                                        wordBreak: 'break-all',
+                                        maxHeight: 240,
+                                        overflow: 'auto',
+                                    }}
+                                >
+                                    {result.data.content}
+                                </Box>
+                            </CollapsibleSection>
                         )}
                     </Box>
                 )}

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -453,9 +453,6 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
             <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', minWidth: 0 }}>
                     <Typography variant="subtitle1" fontWeight={600}>
-                        {targetType === 'rule' ? t('probe.testRule') : t('probe.testProvider')}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
                         {targetName}
                     </Typography>
                     {model && (

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -555,7 +555,7 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 3, flexWrap: 'wrap', mb: 1 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Typography variant="caption" color="text.secondary">
-                            {t('probe.request')}
+                            {t('probe.shape')}
                         </Typography>
                         <ToggleButtonGroup
                             size="small"

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -325,7 +325,6 @@ const Journey = memo(
 
         return (
             <Box>
-                <SectionTitle>{t('probe.journey')}</SectionTitle>
                 {isRule && (
                     <JourneyRow label={t('probe.row.rule')} value={`${ruleLabel}${scenario ? `  ·  ${scenario}` : ''}`} />
                 )}

--- a/frontend/src/components/probe/ProbeV2Dialog.tsx
+++ b/frontend/src/components/probe/ProbeV2Dialog.tsx
@@ -551,11 +551,11 @@ export const ProbeV2Dialog: React.FC<ProbeV2DialogProps> = ({
             </DialogTitle>
 
             <DialogContent>
-                {/* Controls: 形态 (request shape) + 范围 (scope) */}
+                {/* Controls: request type + scope */}
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 3, flexWrap: 'wrap', mb: 1 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Typography variant="caption" color="text.secondary">
-                            {t('probe.shape')}
+                            {t('probe.request')}
                         </Typography>
                         <ToggleButtonGroup
                             size="small"

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -873,11 +873,7 @@ export default {
       "deleteFailed": "Failed to delete profile",
       "mode": "Mode",
       "unified": "Unified",
-      "separate": "Separate",
-      "unifiedDescription": "All models use the same routing rule",
-      "separateDescription": "Each model uses its own routing rule",
-      "modeUpdated": "Profile mode updated to {{mode}}",
-      "modeUpdateFailed": "Failed to update profile mode"
+      "separate": "Separate"
     }
   },
   "prompt": {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -386,7 +386,7 @@ export default {
   "probe": {
     "testRule": "Test Rule",
     "testProvider": "Test Service",
-    "shape": "Shape",
+    "shape": "Request",
     "nonstream": "Nonstream",
     "stream": "Stream",
     "scope": "Scope",
@@ -395,7 +395,7 @@ export default {
     "scopeHint": "Direct skips Tingly-Box's routing & middleware, to tell whether a failure is upstream or inside TB.",
     "run": "Run Test",
     "running": "Testing…",
-    "runHint": "Pick a shape, then click Run Test",
+    "runHint": "Pick a request type, then click Run Test",
     "rerun": "Re-run",
     "copyResponse": "Copy response",
     "copied": "Copied!",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -874,11 +874,7 @@ export default {
       "deleteFailed": "删除配置文件失败",
       "mode": "模式",
       "unified": "统一",
-      "separate": "分离",
-      "unifiedDescription": "所有模型使用相同的路由规则",
-      "separateDescription": "每个模型使用自己的路由规则",
-      "modeUpdated": "配置文件模式已更新为 {{mode}}",
-      "modeUpdateFailed": "配置文件模式更新失败"
+      "separate": "分离"
     }
   },
   "prompt": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -387,7 +387,7 @@ export default {
   "probe": {
     "testRule": "测试规则",
     "testProvider": "测试服务",
-    "shape": "形态",
+    "shape": "请求",
     "nonstream": "非流式",
     "stream": "流式",
     "scope": "范围",
@@ -396,7 +396,7 @@ export default {
     "scopeHint": "直连上游会绕过 Tingly-Box 的路由与中间件,用于判断故障在上游还是 TB 内部。",
     "run": "运行测试",
     "running": "测试中…",
-    "runHint": "选择形态后点击「运行测试」",
+    "runHint": "选择请求类型后点击「运行测试」",
     "rerun": "重新测试",
     "copyResponse": "复制响应",
     "copied": "已复制!",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1380,7 +1380,6 @@ export const handlers = [
     http.get('/api/v1/rules', ({ request }) => {
         const url = new URL(request.url)
         const scenario = url.searchParams.get('scenario')
-        const profileId = url.searchParams.get('profile_id')
 
         if (scenario === 'imagegen') {
             return HttpResponse.json({
@@ -1404,8 +1403,9 @@ export const handlers = [
             })
         }
 
-        // Handle profile-specific rules
-        if (scenario === 'claude_code' && profileId) {
+        // Handle profile-specific rules (e.g., claude_code:p1)
+        if (scenario?.startsWith('claude_code:')) {
+            const profileId = scenario.split(':')[1];
             // Return mock rules for the specific profile
             return HttpResponse.json({
                 success: true,

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -663,6 +663,36 @@ const mockRemoteGraphs: any[] = [
     }
 ]
 
+// ============================================
+// Mock Claude Code Profiles
+// ============================================
+const mockClaudeCodeProfiles = [
+    {
+        id: 'p1',
+        name: 'ds',
+        description: 'DeepSeek profile for cost-effective development',
+        unified: true,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+        id: 'p2',
+        name: 'sonnet',
+        description: 'Claude Sonnet profile for balanced performance',
+        unified: false,
+        created_at: '2024-01-15T00:00:00Z',
+        updated_at: '2024-01-15T00:00:00Z',
+    },
+    {
+        id: 'p3',
+        name: 'codex',
+        description: 'Codex profile for code generation tasks',
+        unified: true,
+        created_at: '2024-02-01T00:00:00Z',
+        updated_at: '2024-02-01T00:00:00Z',
+    },
+]
+
 const mockRules = {
     tingly: {
         provider: "openai",
@@ -1350,6 +1380,8 @@ export const handlers = [
     http.get('/api/v1/rules', ({ request }) => {
         const url = new URL(request.url)
         const scenario = url.searchParams.get('scenario')
+        const profileId = url.searchParams.get('profile_id')
+
         if (scenario === 'imagegen') {
             return HttpResponse.json({
                 success: true,
@@ -1371,6 +1403,29 @@ export const handlers = [
                 ],
             })
         }
+
+        // Handle profile-specific rules
+        if (scenario === 'claude_code' && profileId) {
+            // Return mock rules for the specific profile
+            return HttpResponse.json({
+                success: true,
+                data: [
+                    {
+                        uuid: `mock-rule-cc-${profileId}-1`,
+                        scenario: `claude_code:${profileId}`,
+                        request_model: 'claude-sonnet-4-6',
+                        response_model: '',
+                        active: true,
+                        description: `Profile ${profileId} - Smart routing rule`,
+                        flags: { claude_code_compat: true, clean_header: true },
+                        services: [
+                            { uuid: `svc-cc-${profileId}-1`, provider: 'mock-provider-anthropic', model: 'claude-sonnet-4-6', weight: 1, active: true },
+                        ],
+                    },
+                ],
+            })
+        }
+
         const rules = scenario ? (mockV1Rules[scenario] ?? []) : []
         return HttpResponse.json({ success: true, data: rules })
     }),
@@ -1887,6 +1942,22 @@ export const handlers = [
         return HttpResponse.json({ total: logs.length, logs })
     }),
 
+    // ============================================
+    // Scenario Descriptors API
+    // ============================================
+    http.get('/api/v1/scenario-descriptors', () => {
+        return HttpResponse.json({
+            success: true,
+            data: [
+                { id: 'claude_code', supports_profiles: true },
+                { id: 'claude_desktop', supports_profiles: false },
+                { id: 'openai', supports_profiles: false },
+                { id: 'anthropic', supports_profiles: false },
+                { id: 'codex', supports_profiles: false },
+            ],
+        })
+    }),
+
     http.get('/api/v1/requests', ({ request }) => {
         const url = new URL(request.url)
         const scenario = url.searchParams.get('scenario')
@@ -1922,5 +1993,95 @@ export const handlers = [
                 time: new Date(base + i * 120).toISOString(),
             })),
         })
+    }),
+
+    // ============================================
+    // Claude Code Profiles API (v1)
+    // ============================================
+    http.get('/api/v1/scenario/:scenario/profiles', ({ params }) => {
+        const { scenario } = params as { scenario: string }
+        if (scenario === 'claude_code') {
+            return HttpResponse.json({
+                success: true,
+                data: mockClaudeCodeProfiles,
+            })
+        }
+        return HttpResponse.json({
+            success: true,
+            data: [],
+        })
+    }),
+
+    http.post('/api/v1/scenario/:scenario/profiles', async ({ params, request }) => {
+        const { scenario } = params as { scenario: string }
+        const body = await request.json() as any
+        const newProfile = {
+            id: `profile-${Date.now()}`,
+            name: body.name,
+            description: body.description || '',
+            unified: body.unified ?? true,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        }
+        mockClaudeCodeProfiles.push(newProfile)
+        return HttpResponse.json({
+            success: true,
+            data: newProfile,
+        })
+    }),
+
+    http.put('/api/v1/scenario/:scenario/profiles/:profileId', async ({ params, request }) => {
+        const { scenario, profileId } = params as { scenario: string; profileId: string }
+        const body = await request.json() as any
+
+        if (scenario !== 'claude_code') {
+            return HttpResponse.json({
+                success: false,
+                error: 'Scenario not supported',
+            }, { status: 400 })
+        }
+
+        const profile = mockClaudeCodeProfiles.find(p => p.id === profileId)
+        if (!profile) {
+            return HttpResponse.json({
+                success: false,
+                error: 'Profile not found',
+            }, { status: 404 })
+        }
+
+        if (body.name !== undefined) profile.name = body.name
+        if (body.description !== undefined) profile.description = body.description
+        if (body.unified !== undefined) profile.unified = body.unified
+        profile.updated_at = new Date().toISOString()
+
+        return HttpResponse.json({
+            success: true,
+            data: profile,
+        })
+    }),
+
+    http.delete('/api/v1/scenario/:scenario/profiles/:profileId', ({ params }) => {
+        const { scenario, profileId } = params as { scenario: string; profileId: string }
+
+        if (scenario !== 'claude_code') {
+            return HttpResponse.json({
+                success: false,
+                error: 'Scenario not supported',
+            }, { status: 400 })
+        }
+
+        const index = mockClaudeCodeProfiles.findIndex(p => p.id === profileId)
+        if (index >= 0) {
+            mockClaudeCodeProfiles.splice(index, 1)
+            return HttpResponse.json({
+                success: true,
+                message: 'Profile deleted successfully',
+            })
+        }
+
+        return HttpResponse.json({
+            success: false,
+            error: 'Profile not found',
+        }, { status: 404 })
     }),
 ]

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -67,7 +67,6 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
     const [isProfileMutating, setIsProfileMutating] = useState(false);
     const [appVersion, setAppVersion] = useState('');
     const [unifiedMode, setUnifiedMode] = useState(currentProfile?.unified || false);
-    const [isUpdatingMode, setIsUpdatingMode] = useState(false);
     const [commandMode, setCommandMode] = useState<'npx' | 'global'>('npx');
 
     // Update unified mode when profile changes
@@ -140,30 +139,7 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
         }
     };
 
-    // Handle mode toggle
-    const handleModeToggle = async () => {
-        if (!profileId) return;
-        const newMode = !unifiedMode;
-        try {
-            setIsUpdatingMode(true);
-            // Only pass unified mode, let backend use existing name
-            const result = await api.updateProfile(BASE_SCENARIO, profileId, '', newMode);
-            if (result.success) {
-                setUnifiedMode(newMode);
-                showNotification(t('claudeCode.profile.modeUpdated', { mode: newMode ? t('claudeCode.profile.unified') : t('claudeCode.profile.separate') }), 'success');
-                refreshProfiles();
-                // Reload rules after mode change
-                await loadRules();
-            } else {
-                showNotification(`${t('claudeCode.profile.modeUpdateFailed')}: ${result.error || 'Unknown error'}`, 'error');
-            }
-        } catch {
-            showNotification(t('claudeCode.profile.modeUpdateFailed'), 'error');
-        } finally {
-            setIsUpdatingMode(false);
-        }
-    };
-
+    // Load rules for this profile
     const ccCommand = React.useMemo(() => {
         if (commandMode === 'npx' && appVersion) {
             return `npx -y tingly-box@${appVersion} cc --profile ${profileId}`;
@@ -280,40 +256,6 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                                 },
                             ]}
                             activeTab="quickstart"
-                            onTabChange={() => {}}
-                        />
-                    </Box>
-                    <Box sx={{ px: 2, py: 0.5 }}>
-                        <ConfigRow
-                            tabs={[
-                                {
-                                    key: 'mode',
-                                    label: t('claudeCode.profile.mode'),
-                                    content: (
-                                        <Typography
-                                            variant="subtitle2"
-                                            color="text.secondary"
-                                            sx={{
-                                                fontFamily: 'monospace',
-                                                fontSize: '0.75rem',
-                                                cursor: 'pointer',
-                                                '&:hover': {
-                                                    textDecoration: 'underline',
-                                                    backgroundColor: 'action.hover'
-                                                },
-                                                padding: 1,
-                                                borderRadius: 1,
-                                                transition: 'all 0.2s ease-in-out'
-                                            }}
-                                        >
-                                            {unifiedMode
-                                                ? t('claudeCode.profile.unifiedDescription')
-                                                : t('claudeCode.profile.separateDescription')}
-                                        </Typography>
-                                    ),
-                                },
-                            ]}
-                            activeTab="mode"
                             onTabChange={() => {}}
                         />
                     </Box>

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -29,7 +29,7 @@ import {
     Tooltip,
     Typography
 } from '@mui/material';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import TemplatePage from './components/TemplatePage.tsx';
@@ -52,11 +52,8 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
         notification,
         copyToClipboard,
         baseUrl,
+        isLoading,
     } = useScenarioPageInternal(scenario);
-
-    // Rules state
-    const [rules, setRules] = useState<any[]>([]);
-    const [loadingRule, setLoadingRule] = useState(true);
 
     // Profile state
     const { getProfiles, refresh: refreshProfiles } = useProfileContext();
@@ -73,20 +70,6 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
     useEffect(() => {
         setUnifiedMode(currentProfile?.unified || false);
     }, [currentProfile]);
-
-    // Load rules for this profile
-    const loadRules = useCallback(async () => {
-        setLoadingRule(true);
-        // Profile rules have their own scenario (e.g., claude_code:p1)
-        // Just load all rules for this profile scenario
-        const result = await api.getRules(scenario);
-        setRules(result.success ? result.data : []);
-        setLoadingRule(false);
-    }, [scenario]);
-
-    useEffect(() => {
-        loadRules();
-    }, [loadRules]);
 
     // Load app version for npm command
     useEffect(() => {
@@ -148,7 +131,7 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
     }, [commandMode, appVersion, profileId]);
 
     return (
-        <PageLayout loading={loadingRule} notification={notification}>
+        <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
                 <UnifiedCard
                     size="full"
@@ -272,8 +255,7 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                 </UnifiedCard>
 
                 <TemplatePage
-                    rules={rules}
-                    onRulesChange={setRules}
+                    scenario={scenario}
                     collapsible={true}
                     allowToggleRule={false}
                     allowAddRule={false}

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -330,8 +330,6 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                 </UnifiedCard>
 
                 <TemplatePage
-                    title="Models and Forwarding Rules"
-                    scenario={scenario}
                     rules={rules}
                     onRulesChange={setRules}
                     collapsible={true}

--- a/frontend/src/pages/scenario/UseAgentPage.tsx
+++ b/frontend/src/pages/scenario/UseAgentPage.tsx
@@ -40,7 +40,6 @@ const UseAgentPageContent: React.FC = () => {
 
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />

--- a/frontend/src/pages/scenario/UseAnthropicPage.tsx
+++ b/frontend/src/pages/scenario/UseAnthropicPage.tsx
@@ -6,9 +6,7 @@ import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "anthropic";
-
 const UseAnthropicPageContent: React.FC = () => {
     const {
         isLoading,
@@ -16,7 +14,6 @@ const UseAnthropicPageContent: React.FC = () => {
         copyToClipboard,
         baseUrl,
     } = useScenarioPageInternal(scenario);
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -38,7 +35,6 @@ const UseAnthropicPageContent: React.FC = () => {
                 </UnifiedCard>
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />
@@ -46,7 +42,6 @@ const UseAnthropicPageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseAnthropicPage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -54,5 +49,4 @@ const UseAnthropicPage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseAnthropicPage;

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -279,7 +279,6 @@ const UseClaudeCodePageContent: React.FC = () => {
                 />
 
                 <TemplatePage
-                    title="Models and Forwarding Rules"
                     scenario={SCENARIO}
                     rules={rules}
                     onRulesChange={setRules}

--- a/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeDesktopPage.tsx
@@ -9,9 +9,7 @@ import TemplatePage from './components/TemplatePage.tsx';
 import ClaudeDesktopConfigModal from './components/ClaudeDesktopConfigModal';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "claude_desktop";
-
 const UseClaudeDesktopPageContent: React.FC = () => {
     const {
         isLoading,
@@ -22,20 +20,16 @@ const UseClaudeDesktopPageContent: React.FC = () => {
         loadRules,
         showNotification,
     } = useScenarioPageInternal(scenario);
-
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
-
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
     };
-
     const handleContext1MToggle = (newState: boolean) => {
         // Store the pending change and directly open config panel
         setPendingContext1MChange(newState);
         setConfigModalOpen(true);
     };
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -72,15 +66,12 @@ const UseClaudeDesktopPageContent: React.FC = () => {
                         compact={true}
                     />
                 </UnifiedCard>
-
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                     onContext1MToggle={handleContext1MToggle}
                 />
-
                 <ClaudeDesktopConfigModal
                     open={configModalOpen}
                     onClose={() => {
@@ -97,7 +88,6 @@ const UseClaudeDesktopPageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseClaudeDesktopPage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -105,5 +95,4 @@ const UseClaudeDesktopPage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseClaudeDesktopPage;

--- a/frontend/src/pages/scenario/UseCodexPage.tsx
+++ b/frontend/src/pages/scenario/UseCodexPage.tsx
@@ -13,9 +13,7 @@ import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "codex";
-
 const UseCodexPageContent: React.FC = () => {
     const {
         isLoading,
@@ -25,12 +23,10 @@ const UseCodexPageContent: React.FC = () => {
         baseUrl,
         rules,
     } = useScenarioPageInternal(scenario);
-
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
     const [pendingContext1MChange, setPendingContext1MChange] = useState<boolean | null>(null);
-
     const handleApply = async (): Promise<AgentApplyResult> => {
         try {
             setIsApplyLoading(true);
@@ -57,13 +53,11 @@ const UseCodexPageContent: React.FC = () => {
             setIsApplyLoading(false);
         }
     };
-
     const handleContext1MToggle = (newState: boolean) => {
         // Store the pending change and directly open config panel
         setPendingContext1MChange(newState);
         setConfigModalOpen(true);
     };
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -98,7 +92,6 @@ const UseCodexPageContent: React.FC = () => {
                         compact={true}
                     />
                 </UnifiedCard>
-
                 <AgentSetupCard
                     agentKey={scenario}
                     agentName="Codex"
@@ -111,15 +104,12 @@ const UseCodexPageContent: React.FC = () => {
                     onSelectModel={scrollToModelsCard}
                     onConnectProvider={() => setConnectProviderOpen(true)}
                 />
-
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                     onContext1MToggle={handleContext1MToggle}
                 />
-
                 <CodexConfigModal
                     open={configModalOpen}
                     onClose={() => {
@@ -129,7 +119,6 @@ const UseCodexPageContent: React.FC = () => {
                     copyToClipboard={copyToClipboard}
                     pendingContext1MChange={pendingContext1MChange}
                 />
-
                 <ConnectProviderFlow
                     open={connectProviderOpen}
                     onClose={() => setConnectProviderOpen(false)}
@@ -140,7 +129,6 @@ const UseCodexPageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseCodexPage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -148,5 +136,4 @@ const UseCodexPage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseCodexPage;

--- a/frontend/src/pages/scenario/UseEmbedPage.tsx
+++ b/frontend/src/pages/scenario/UseEmbedPage.tsx
@@ -38,7 +38,7 @@ const UseEmbedPageContent: React.FC = () => {
                 </UnifiedCard>
                 <TemplatePage
                     scenario={scenario}
-                    title="Embedding Models and Forwarding Rules"
+                    title="Embedding Model Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />

--- a/frontend/src/pages/scenario/UseImageGenPage.tsx
+++ b/frontend/src/pages/scenario/UseImageGenPage.tsx
@@ -65,7 +65,7 @@ const UseImageGenPageContent: React.FC = () => {
                 />
                 <TemplatePage
                     scenario={scenario}
-                    title="Image Generation Models and Forwarding Rules"
+                    title="Image Generation Model Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />

--- a/frontend/src/pages/scenario/UseOpenAIPage.tsx
+++ b/frontend/src/pages/scenario/UseOpenAIPage.tsx
@@ -38,7 +38,6 @@ const UseOpenAIPageContent: React.FC = () => {
                 </UnifiedCard>
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />

--- a/frontend/src/pages/scenario/UseOpenCodePage.tsx
+++ b/frontend/src/pages/scenario/UseOpenCodePage.tsx
@@ -12,9 +12,7 @@ import TemplatePage from './components/TemplatePage.tsx';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { api } from '@/services/api';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "opencode";
-
 const UseOpenCodePageContent: React.FC = () => {
     const {
         isLoading,
@@ -24,7 +22,6 @@ const UseOpenCodePageContent: React.FC = () => {
         baseUrl,
         rules,
     } = useScenarioPageInternal(scenario);
-
     const [isApplyLoading, setIsApplyLoading] = useState(false);
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
@@ -32,7 +29,6 @@ const UseOpenCodePageContent: React.FC = () => {
     const [scriptWindows, setScriptWindows] = useState('');
     const [scriptUnix, setScriptUnix] = useState('');
     const [isConfigLoading, setIsConfigLoading] = useState(false);
-
     const fetchConfigPreview = async () => {
         setIsConfigLoading(true);
         try {
@@ -57,7 +53,6 @@ const UseOpenCodePageContent: React.FC = () => {
             setIsConfigLoading(false);
         }
     };
-
     const handleOpenConfigModal = async () => {
         setConfigJson('// Loading...');
         setScriptWindows('// Loading...');
@@ -65,7 +60,6 @@ const UseOpenCodePageContent: React.FC = () => {
         await fetchConfigPreview();
         setConfigModalOpen(true);
     };
-
     const handleApply = async (): Promise<AgentApplyResult> => {
         try {
             setIsApplyLoading(true);
@@ -83,7 +77,6 @@ const UseOpenCodePageContent: React.FC = () => {
             setIsApplyLoading(false);
         }
     };
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -119,7 +112,6 @@ const UseOpenCodePageContent: React.FC = () => {
                         compact={true}
                     />
                 </UnifiedCard>
-
                 <AgentSetupCard
                     agentKey={scenario}
                     agentName="OpenCode"
@@ -132,14 +124,11 @@ const UseOpenCodePageContent: React.FC = () => {
                     onSelectModel={scrollToModelsCard}
                     onConnectProvider={() => setConnectProviderOpen(true)}
                 />
-
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />
-
                 <OpenCodeConfigModal
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
@@ -151,7 +140,6 @@ const UseOpenCodePageContent: React.FC = () => {
                     isApplyLoading={isApplyLoading}
                     isLoading={isConfigLoading}
                 />
-
                 <ConnectProviderFlow
                     open={connectProviderOpen}
                     onClose={() => setConnectProviderOpen(false)}
@@ -162,7 +150,6 @@ const UseOpenCodePageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseOpenCodePage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -170,5 +157,4 @@ const UseOpenCodePage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseOpenCodePage;

--- a/frontend/src/pages/scenario/UseTeamPage.tsx
+++ b/frontend/src/pages/scenario/UseTeamPage.tsx
@@ -6,9 +6,7 @@ import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "team";
-
 const UseTeamPageContent: React.FC = () => {
     const {
         isLoading,
@@ -16,7 +14,6 @@ const UseTeamPageContent: React.FC = () => {
         copyToClipboard,
         baseUrl,
     } = useScenarioPageInternal(scenario);
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -37,10 +34,8 @@ const UseTeamPageContent: React.FC = () => {
                         scenario={scenario}
                     />
                 </UnifiedCard>
-
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />
@@ -48,7 +43,6 @@ const UseTeamPageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseTeamPage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -56,5 +50,4 @@ const UseTeamPage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseTeamPage;

--- a/frontend/src/pages/scenario/UseVSCodePage.tsx
+++ b/frontend/src/pages/scenario/UseVSCodePage.tsx
@@ -11,12 +11,9 @@ import TemplatePage from './components/TemplatePage.tsx';
 import VSCodeConfigModal from './components/VSCodeConfigModal';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "vscode";
-
 const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=Tingly-Dev.vscode-tingly-box';
 const VSCODE_INSTALL_URL = 'vscode:extension/Tingly-Dev.vscode-tingly-box';
-
 const UseVSCodePageContent: React.FC = () => {
     const {
         isLoading,
@@ -26,14 +23,11 @@ const UseVSCodePageContent: React.FC = () => {
         baseUrl,
         rules,
     } = useScenarioPageInternal(scenario);
-
     const [configModalOpen, setConfigModalOpen] = useState(false);
     const [connectProviderOpen, setConnectProviderOpen] = useState(false);
-
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
     };
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -70,7 +64,6 @@ const UseVSCodePageContent: React.FC = () => {
                         compact={true}
                     />
                 </UnifiedCard>
-
                 <AgentSetupCard
                     agentKey={scenario}
                     agentName="VS Code"
@@ -88,19 +81,15 @@ const UseVSCodePageContent: React.FC = () => {
                     onSelectModel={scrollToModelsCard}
                     onConnectProvider={() => setConnectProviderOpen(true)}
                 />
-
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />
-
                 <VSCodeConfigModal
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
                 />
-
                 <ConnectProviderFlow
                     open={connectProviderOpen}
                     onClose={() => setConnectProviderOpen(false)}
@@ -111,7 +100,6 @@ const UseVSCodePageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseVSCodePage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -119,5 +107,4 @@ const UseVSCodePage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseVSCodePage;

--- a/frontend/src/pages/scenario/UseXcodePage.tsx
+++ b/frontend/src/pages/scenario/UseXcodePage.tsx
@@ -9,9 +9,7 @@ import TemplatePage from './components/TemplatePage.tsx';
 import XcodeConfigModal from './components/XcodeConfigModal';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
-
 const scenario = "xcode";
-
 const UseXcodePageContent: React.FC = () => {
     const {
         isLoading,
@@ -19,13 +17,10 @@ const UseXcodePageContent: React.FC = () => {
         copyToClipboard,
         baseUrl,
     } = useScenarioPageInternal(scenario);
-
     const [configModalOpen, setConfigModalOpen] = useState(false);
-
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
     };
-
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -62,14 +57,11 @@ const UseXcodePageContent: React.FC = () => {
                         compact={true}
                     />
                 </UnifiedCard>
-
                 <TemplatePage
                     scenario={scenario}
-                    title="Models and Forwarding Rules"
                     collapsible={true}
                     allowDeleteRule={true}
                 />
-
                 <XcodeConfigModal
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
@@ -80,7 +72,6 @@ const UseXcodePageContent: React.FC = () => {
         </PageLayout>
     );
 };
-
 const UseXcodePage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -88,5 +79,4 @@ const UseXcodePage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
-
 export default UseXcodePage;

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -68,7 +68,7 @@ export const hasModelOnAnyRule = (rules: any[] | null | undefined): boolean =>
     rules.some(r => Array.isArray(r?.services) && r.services.some((s: any) => s?.provider && s?.model));
 
 /**
- * Smoothly scroll the "Models and Forwarding Rules" card into view, then
+ * Smoothly scroll the "Model Rules" card into view, then
  * spotlight the "+ Add model" target so "Select a Model" actually points the
  * user at where to click — not just near it. The pulse is fired after the
  * scroll settles so it lands in view.
@@ -340,7 +340,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                         <Collapse in={(!modelDone && firstIncomplete === 1) || expandedDoneSteps.has(1)}>
                             <Stack spacing={0.75} sx={{ mt: 0.75, pl: 4.25 }}>
                                 <Typography variant="body2" color="text.secondary">
-                                    Choose which model {agentName} will use in the <em>Models and Forwarding Rules</em> section below.
+                                    Choose which model {agentName} will use in the <em>Model Rules</em> section below.
                                 </Typography>
                                 {onSelectModel && (
                                     <Box>

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -13,6 +13,7 @@ import UnifiedCard from '@/components/UnifiedCard';
 import { EntryGuideDialog } from '@/components/tier/EntryGuideDialog';
 import type {TabTemplatePageProps} from './TemplatePage.types';
 import {TemplatePageActions} from './TemplatePageActions';
+import {TitleIconButtons} from './TitleIconButtons';
 import {useTemplatePageRules} from '@/pages/scenario/hooks/useTemplatePageRules';
 import {useScrollToNewRule} from '@/components/hooks/useScrollToNewRule';
 import {useModelSelectDialog} from '@/hooks/useModelSelectDialog';
@@ -66,7 +67,7 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         onRulesChange = internalData.handleRulesChange,
         onProvidersLoad = internalData.loadProviders,
         loadRules = internalData.loadRules,
-        title = "",
+        title = "Model Rules",
         collapsible = false,
         allowDeleteRule = false,
         onRuleDelete = internalData.handleRuleDelete,
@@ -401,6 +402,15 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
                 id="models-and-forwarding-rules"
                 size="full"
                 title={title}
+                leftAction={
+                    <TitleIconButtons
+                        collapsible={collapsible}
+                        allExpanded={allExpanded}
+                        onToggleExpandAll={handleToggleExpandAll}
+                        showExpandCollapseButton={showExpandCollapseButton}
+                        onShowGuide={() => setShowGuide(true)}
+                    />
+                }
                 rightAction={rightAction}
                 sx={{ scrollMarginTop: 16 }}
             >

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -11,7 +11,7 @@ import ProviderFormDialog from '@/components/ProviderFormDialog';
 import ConnectProviderDialog from '@/components/ConnectProviderDialog';
 import UnifiedCard from '@/components/UnifiedCard';
 import { EntryGuideDialog } from '@/components/tier/EntryGuideDialog';
-import type {TabTemplatePageProps} from './TemplatePage.types';
+import type {TemplatePageProps} from './TemplatePage.types';
 import {TemplatePageActions} from './TemplatePageActions';
 import {TitleIconButtons} from './TitleIconButtons';
 import {useTemplatePageRules} from '@/pages/scenario/hooks/useTemplatePageRules';
@@ -30,47 +30,29 @@ const ROUTING_GUIDE_SEEN_KEY = 'tb.routingGuideAutoShown';
 let routingGuideAutoOpenedThisSession = false;
 
 /**
- * TemplatePage component that supports two modes:
+ * TemplatePage component with internally-managed state and optional overrides.
  *
  * INTERNAL MODE (recommended):
- * Only provide `scenario` prop - TemplatePage fetches all data internally.
+ * Just provide `scenario` prop - TemplatePage fetches all data internally.
  * <TemplatePage scenario="agent" />
  *
- * EXTERNAL MODE (legacy):
- * Provide all props - for backward compatibility with existing code.
- * <TemplatePage rules={rules} providers={providers} scenario="agent" ... />
+ * HYBRID MODE (for custom logic):
+ * Provide `scenario` plus override specific data props for custom behavior.
+ * <TemplatePage scenario="custom" rules={customRules} onRulesChange={customHandler} />
  *
- * MODAL STATE (shared via context):
- * The ApiKeyModal state is shared via ScenarioPageModalProvider context.
- * This ensures that ProviderConfigCard (in the parent page) and TemplatePage
- * show the same modal when "View Token" is clicked.
+ * Modal state (ApiKeyModal) is shared via ScenarioPageModalProvider context.
  */
-const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
+const TemplatePage: React.FC<TemplatePageProps> = (props) => {
     // Get modal state from context (shared with ProviderConfigCard)
     const { showTokenModal, setShowTokenModal, token, copyToClipboard } = useScenarioPageModal();
 
-    // Determine which mode we're in
-    // If `rules` is provided, use external mode (legacy)
-    // If only `scenario` is provided, use internal mode (recommended)
-    const isInternalMode = !props.rules && Boolean(props.scenario);
-
     // Internal mode: fetch all data internally (excluding modal - that's from context)
-    const internalData = useScenarioPageInternal(
-        isInternalMode ? (props.scenario as string) : ''
-    );
+    const internalData = useScenarioPageInternal(props.scenario);
 
-    // External mode: use props directly
     const {
-        rules = internalData.rules,
-        showNotification = internalData.showNotification,
-        providers = internalData.providers,
-        onRulesChange = internalData.handleRulesChange,
-        onProvidersLoad = internalData.loadProviders,
-        loadRules = internalData.loadRules,
         title = "Model Rules",
         collapsible = false,
         allowDeleteRule = false,
-        onRuleDelete = internalData.handleRuleDelete,
         allowToggleRule = true,
         allowAddRule = true,
         scenario,
@@ -81,11 +63,19 @@ const TemplatePage: React.FC<TabTemplatePageProps> = (props) => {
         showEmptyState = true,
         rightAction: customRightAction,
         onAddApiKeyClick,
-        newlyCreatedRuleUuids = internalData.newlyCreatedRuleUuids,
         onContext1MToggle,
     } = props;
 
-    const isLoading = isInternalMode ? internalData.isLoading : false;
+    // Use provided props or fallback to internal data
+    const rules = props.rules ?? internalData.rules;
+    const showNotification = props.showNotification ?? internalData.showNotification;
+    const providers = props.providers ?? internalData.providers;
+    const onRulesChange = props.onRulesChange ?? internalData.handleRulesChange;
+    const onProvidersLoad = props.onProvidersLoad ?? internalData.loadProviders;
+    const loadRules = props.loadRules ?? internalData.loadRules;
+    const onRuleDelete = props.onRuleDelete ?? internalData.handleRuleDelete;
+    const newlyCreatedRuleUuids = internalData.newlyCreatedRuleUuids;
+    const isLoading = internalData.isLoading;
 
     const navigate = useNavigate();
     const [allExpanded, setAllExpanded] = useState<boolean>(true);

--- a/frontend/src/pages/scenario/components/TemplatePage.types.ts
+++ b/frontend/src/pages/scenario/components/TemplatePage.types.ts
@@ -8,6 +8,10 @@ import type { Provider } from '@/types/provider';
  * Just provide `scenario` and TemplatePage will handle all data fetching internally.
  * <TemplatePage scenario="agent" />
  *
+ * PROFILE MODE:
+ * For profile-specific rules, provide the suffixed scenario.
+ * <TemplatePage scenario="claude_code:p1" />
+ *
  * HYBRID MODE (for custom logic):
  * Provide `scenario` plus override specific data props for custom behavior.
  * <TemplatePage scenario="custom" rules={customRules} onRulesChange={customHandler} />

--- a/frontend/src/pages/scenario/components/TemplatePage.types.ts
+++ b/frontend/src/pages/scenario/components/TemplatePage.types.ts
@@ -2,10 +2,17 @@ import type { Rule } from '@/components/RoutingGraphTypes.ts';
 import type { Provider } from '@/types/provider';
 
 /**
- * Props for using TemplatePage with internally-managed state (recommended).
- * Only provide `scenario` and TemplatePage will handle all data fetching internally.
+ * Props for TemplatePage component.
+ *
+ * INTERNAL MODE (recommended):
+ * Just provide `scenario` and TemplatePage will handle all data fetching internally.
+ * <TemplatePage scenario="agent" />
+ *
+ * HYBRID MODE (for custom logic):
+ * Provide `scenario` plus override specific data props for custom behavior.
+ * <TemplatePage scenario="custom" rules={customRules} onRulesChange={customHandler} />
  */
-export interface TemplatePageInternalProps {
+export interface TemplatePageProps {
     scenario: string;
     title?: string | React.ReactNode;
     collapsible?: boolean;
@@ -21,48 +28,14 @@ export interface TemplatePageInternalProps {
     emptyStateTitle?: string;
     emptyStateDescription?: string;
     onAddApiKeyClick?: () => void;
-}
+    onContext1MToggle?: (newState: boolean, ruleUuid?: string) => void;
 
-/**
- * Props for using TemplatePage with externally-managed state (legacy pattern).
- * All state must be provided by the parent component.
- *
- * @deprecated Use TemplatePageInternalProps instead (just pass `scenario`)
- */
-export interface TemplatePageExternalProps {
-    title?: string | React.ReactNode;
-    rules: Rule[];
-    showTokenModal: boolean;
-    setShowTokenModal: (show: boolean) => void;
-    token: string;
-    showNotification: (message: string, severity: 'success' | 'info' | 'warning' | 'error') => void;
-    providers: Provider[];
+    // Optional overrides for custom logic (hybrid mode)
+    rules?: Rule[];
+    showNotification?: (message: string, severity: 'success' | 'info' | 'warning' | 'error') => void;
+    providers?: Provider[];
     onRulesChange?: (updatedRules: Rule[]) => void;
     onProvidersLoad?: () => Promise<void>;
-    collapsible?: boolean;
-    allowDeleteRule?: boolean;
     onRuleDelete?: (ruleUuid: string) => void;
-    allowToggleRule?: boolean;
-    allowAddRule?: boolean;
-    newlyCreatedRuleUuids?: Set<string>; // @deprecated - not used, kept for API compatibility
-    scenario?: string;
-    showAddApiKeyButton?: boolean;
-    showCreateRuleButton?: boolean;
-    showExpandCollapseButton?: boolean;
-    showImportButton?: boolean;
-    rightAction?: React.ReactNode;
-    headerHeight?: number;
     loadRules?: (scenario: string) => Promise<void>;
-    showEmptyState?: boolean;
-    emptyStateTitle?: string;
-    emptyStateDescription?: string;
-    onAddApiKeyClick?: () => void;
-    onContext1MToggle?: (newState: boolean, ruleUuid?: string) => void;
 }
-
-/**
- * Union type discriminated by whether `rules` is provided.
- * - If `rules` is provided → external mode (legacy)
- * - If `scenario` is provided (and `rules` is not) → internal mode (recommended)
- */
-export type TabTemplatePageProps = TemplatePageInternalProps & Partial<TemplatePageExternalProps>;

--- a/frontend/src/pages/scenario/components/TemplatePageActions.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePageActions.tsx
@@ -3,13 +3,9 @@ import { useTranslation } from 'react-i18next';
 import {
     Add as AddIcon,
     BugReport as TroubleshootIcon,
-    FoldUp as FoldUpIcon,
-    FoldDown as FoldDownIcon,
     Key as KeyIcon,
-    Speed as SpeedIcon,
-    HelpOutline as HelpOutlineIcon,
 } from '@/components/icons';
-import { Button, IconButton, Stack, Tooltip } from '@mui/material';
+import { Button, Stack, Tooltip } from '@mui/material';
 import { ProbeMenu } from '@/components/probe';
 
 export interface TemplatePageActionsProps {
@@ -22,9 +18,7 @@ export interface TemplatePageActionsProps {
     onCreateRule: () => void;
     showExpandCollapseButton?: boolean;
     onViewLogs?: () => void;
-    // Opens the routing walkthrough. Rendered as a "?" at the end of the toolbar
-    // so it's a single, page-level entry point (and a persistent hint that the
-    // guide can be reopened here later).
+    // Icon button actions - these will be rendered next to the title instead
     onShowGuide?: () => void;
     // Probe V2 props
     scenario?: string;
@@ -57,7 +51,7 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
     };
 
     return (
-        <Stack direction="row" spacing={1} alignItems="center">
+        <Stack direction="row" spacing={1.5} alignItems="center">
             {onViewLogs && (
                 <Button
                     variant="outlined"
@@ -90,25 +84,6 @@ export const TemplatePageActions: React.FC<TemplatePageActionsProps> = ({
                     >
                         {t('templateActions.newRule')}
                     </Button>
-                </Tooltip>
-            )}
-            {showExpandCollapseButton && collapsible && (
-                <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
-                    <IconButton size="small" onClick={onToggleExpandAll}>
-                        {allExpanded ? <FoldUpIcon fontSize="small" /> : <FoldDownIcon fontSize="small" />}
-                    </IconButton>
-                </Tooltip>
-            )}
-            {onShowGuide && (
-                <Tooltip title={t('templateActions.howRoutingWorks', { defaultValue: 'How routing works' })}>
-                    <IconButton
-                        size="small"
-                        aria-label={t('templateActions.howRoutingWorks', { defaultValue: 'How routing works' })}
-                        onClick={onShowGuide}
-                        sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
-                    >
-                        <HelpOutlineIcon fontSize="small" />
-                    </IconButton>
                 </Tooltip>
             )}
         </Stack>

--- a/frontend/src/pages/scenario/components/TitleIconButtons.tsx
+++ b/frontend/src/pages/scenario/components/TitleIconButtons.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+    FoldUp as FoldUpIcon,
+    FoldDown as FoldDownIcon,
+    HelpOutline as HelpOutlineIcon,
+} from '@/components/icons';
+import { IconButton, Stack, Tooltip } from '@mui/material';
+
+export interface TitleIconButtonsProps {
+    collapsible: boolean;
+    allExpanded: boolean;
+    onToggleExpandAll: () => void;
+    showExpandCollapseButton?: boolean;
+    onShowGuide?: () => void;
+}
+
+export const TitleIconButtons: React.FC<TitleIconButtonsProps> = ({
+    collapsible,
+    allExpanded,
+    onToggleExpandAll,
+    showExpandCollapseButton = true,
+    onShowGuide,
+}) => {
+    const { t } = useTranslation();
+
+    // Don't render if no icon buttons to show
+    if (!showExpandCollapseButton || !collapsible) {
+        if (!onShowGuide) return null;
+    }
+
+    return (
+        <Stack direction="row" spacing={0.5} alignItems="center">
+            {showExpandCollapseButton && collapsible && (
+                <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
+                    <IconButton size="small" onClick={onToggleExpandAll}>
+                        {allExpanded ? <FoldUpIcon fontSize="small" /> : <FoldDownIcon fontSize="small" />}
+                    </IconButton>
+                </Tooltip>
+            )}
+            {onShowGuide && (
+                <Tooltip title={t('templateActions.howRoutingWorks', { defaultValue: 'How routing works' })}>
+                    <IconButton
+                        size="small"
+                        aria-label={t('templateActions.howRoutingWorks', { defaultValue: 'How routing works' })}
+                        onClick={onShowGuide}
+                        sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+                    >
+                        <HelpOutlineIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+            )}
+        </Stack>
+    );
+};


### PR DESCRIPTION
## Summary

The scenario routing pages had accumulated repetitive copy, inconsistent rule-section naming, and extra UI chrome that made setup and troubleshooting feel more cumbersome than needed. 

This PR simplifies these flows so users can quickly scan model-routing pages, easily interpret probe results, and manage Claude Code profiles with reduced friction.

## Major

- Simplified routing-rule surfaces across scenario pages by adopting clearer, consistent "Model Rules" naming and reducing repeated page-level boilerplate
- Improved the probe dialog so test outcomes can be interpreted at a glance, with detailed journey/response data moved into collapsible sections that reduce noise without hiding diagnostics
- Cleaned up Claude Code profile handling and mock support so profile-specific routing remains consistent during development and review flows

## Minor

- Moved title-adjacent utility actions into a dedicated component to reduce toolbar clutter and make rule-card headers more consistent
- Updated onboarding/setup copy so model-selection guidance matches the renamed rule sections
- Refined probe terminology from "Shape" to "Request" in localized UI text for better clarity