### PR TITLE
ui: add cache hit ratio into dashboard table view.

### DIFF
--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -313,6 +313,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                             <TableCell>Provider / Model</TableCell>
                             <TableCell>Scenario</TableCell>
                             <TableCell align="right">Cache</TableCell>
+                            <TableCell align="right">Cache Hit</TableCell>
                             <TableCell align="right">Input</TableCell>
                             <TableCell align="right">Output</TableCell>
                             <TableCell align="right">Latency</TableCell>
@@ -324,7 +325,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                     <TableBody>
                         {records.length === 0 && !loading ? (
                             <TableRow>
-                                <TableCell colSpan={10} align="center" sx={{ py: 5 }}>
+                                <TableCell colSpan={11} align="center" sx={{ py: 5 }}>
                                     <Typography variant="body2" color="text.secondary">No requests found</Typography>
                                     <Typography variant="caption" color="text.disabled">Try changing the status filter</Typography>
                                 </TableCell>
@@ -363,6 +364,18 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                                 <TableCell align="right">
                                     <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.cache.main }}>
                                         {r.cache_input_tokens > 0 ? fmtTokens(r.cache_input_tokens) : '-'}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'text.secondary' }}>
+                                        {(() => {
+                                            const cacheTokens = r.cache_input_tokens || 0;
+                                            const inputTokens = r.input_tokens || 0;
+                                            const total = cacheTokens + inputTokens;
+                                            if (total === 0) return '-';
+                                            const ratio = (cacheTokens / total) * 100;
+                                            return `${ratio.toFixed(1)}%`;
+                                        })()}
                                     </Typography>
                                 </TableCell>
                                 <TableCell align="right">

--- a/frontend/src/components/dashboard/ServiceStatsTable.tsx
+++ b/frontend/src/components/dashboard/ServiceStatsTable.tsx
@@ -125,6 +125,9 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
                                 Cache Tokens
                             </TableCell>
                             <TableCell align="right" sx={{ fontWeight: 600 }}>
+                                Cache Hit
+                            </TableCell>
+                            <TableCell align="right" sx={{ fontWeight: 600 }}>
                                 Input Tokens
                             </TableCell>
                             <TableCell align="right" sx={{ fontWeight: 600 }}>
@@ -139,7 +142,7 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
                     <TableBody>
                         {stats.length === 0 ? (
                             <TableRow>
-                                <TableCell colSpan={7} align="center" sx={{ py: 8 }}>
+                                <TableCell colSpan={8} align="center" sx={{ py: 8 }}>
                                     <Box sx={{ textAlign: 'center' }}>
                                         <Box
                                             sx={{
@@ -208,6 +211,23 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
                                         </TableCell>
                                         <TableCell align="right">{formatRequests(stat.request_count)}</TableCell>
                                         <TableCell align="right">{formatTokens(stat.cache_input_tokens || 0)}</TableCell>
+                                        <TableCell align="right">
+                                            <Typography
+                                                variant="body2"
+                                                sx={{
+                                                    color: 'text.secondary',
+                                                }}
+                                            >
+                                                {(() => {
+                                                    const cacheTokens = stat.cache_input_tokens || 0;
+                                                    const inputTokens = stat.total_input_tokens || 0;
+                                                    const ratio = (cacheTokens + inputTokens) > 0
+                                                        ? (cacheTokens / (cacheTokens + inputTokens)) * 100
+                                                        : 0;
+                                                    return `${ratio.toFixed(2)}%`;
+                                                })()}
+                                            </Typography>
+                                        </TableCell>
                                         <TableCell align="right">{formatTokens(stat.total_input_tokens)}</TableCell>
                                         <TableCell align="right">{formatTokens(stat.total_output_tokens)}</TableCell>
                                         {/* <TableCell align="right">
@@ -227,7 +247,7 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
                                 ))}
                                 {emptyRows > 0 && (
                                     <TableRow style={{ height: 53 * emptyRows }}>
-                                        <TableCell colSpan={7} />
+                                        <TableCell colSpan={8} />
                                     </TableRow>
                                 )}
                             </>


### PR DESCRIPTION
<img width="1071" height="419" alt="image" src="https://github.com/user-attachments/assets/25f11272-d528-4458-9830-cd4c8cbbe9c5" />
