### PR TITLE
bugfix(frontend, config): unify provider search logic and fix name error.

### DIFF
--- a/frontend/src/components/ConnectProviderDialog.tsx
+++ b/frontend/src/components/ConnectProviderDialog.tsx
@@ -15,7 +15,7 @@ import {
     alpha,
 } from '@mui/material';
 import React, {useMemo, useState} from 'react';
-import {type UniqueProvider, useProviderTemplates} from '../services/serviceProviders';
+import {type UniqueProvider, useProviderTemplates, searchProviders} from '../services/serviceProviders';
 import ProviderIcon from './ProviderIcon';
 import {FALLBACK_OAUTH_PROVIDERS, type OAuthProvider} from './OAuthDialog';
 
@@ -233,12 +233,12 @@ export const ProviderListContent: React.FC<ProviderListContentProps> = ({
         []
     );
 
-    const needle = query.trim().toLowerCase();
+    const needle = query.trim();
     const filteredKey = needle
-        ? keyProviders.filter((p) => (p.alias || p.name).toLowerCase().includes(needle))
+        ? searchProviders(keyProviders, needle)
         : keyProviders;
     const filteredOAuth = needle
-        ? oauthProviders.filter((p) => `${p.name} ${p.displayName}`.toLowerCase().includes(needle))
+        ? oauthProviders.filter((p) => `${p.name} ${p.displayName} ${p.id}`.toLowerCase().includes(needle.toLowerCase()))
         : oauthProviders;
     const showCustom = !needle || 'custom endpoint dual import'.includes(needle);
 

--- a/frontend/src/components/RegionBadge.tsx
+++ b/frontend/src/components/RegionBadge.tsx
@@ -3,16 +3,23 @@ import { Chip } from '@mui/material';
 import { LocationOn as LocationOnIcon } from '@/components/icons';
 
 export interface RegionBadgeProps {
-  region: 'cn' | 'global';
+  region: 'cn' | 'global' | 'self-hosted';
   size?: 'small' | 'medium';
   sx?: SxProps;
 }
 
-const getRegionColor = (region: 'cn' | 'global'): { bg: string; text: string; icon: React.ReactNode } => {
+const getRegionColor = (region: 'cn' | 'global' | 'self-hosted'): { bg: string; text: string; icon: React.ReactNode } => {
   if (region === 'cn') {
     return {
       bg: 'error.50',
       text: 'error.main',
+      icon: <LocationOnIcon sx={{ fontSize: 12 }} />,
+    };
+  }
+  if (region === 'self-hosted') {
+    return {
+      bg: 'warning.50',
+      text: 'warning.main',
       icon: <LocationOnIcon sx={{ fontSize: 12 }} />,
     };
   }
@@ -41,7 +48,7 @@ const RegionBadge: React.FC<RegionBadgeProps> = ({ region, size = 'small', sx = 
   return (
     <Chip
       icon={colors.icon as React.ReactElement}
-      label={region === 'cn' ? 'CN' : 'Global'}
+      label={region === 'cn' ? 'CN' : region === 'self-hosted' ? 'Self-hosted' : 'Global'}
       sx={{
         height: sizeStyle.height,
         fontSize: sizeStyle.fontSize,

--- a/frontend/src/components/providerFormDialog/ProviderAutocomplete.tsx
+++ b/frontend/src/components/providerFormDialog/ProviderAutocomplete.tsx
@@ -2,6 +2,7 @@ import {Autocomplete, Box, TextField, Typography, Stack} from '@mui/material';
 import React from 'react';
 import {useTranslation} from 'react-i18next';
 import type {UniqueProvider} from '../../services/serviceProviders';
+import {searchProviders} from '../../services/serviceProviders';
 import ProviderIcon from '../ProviderIcon';
 import RegionBadge from '../RegionBadge';
 
@@ -60,16 +61,7 @@ const ProviderAutocomplete: React.FC<ProviderAutocompleteProps> = ({
             size="small"
             options={groupedOptions}
             filterOptions={(opts, state) => {
-                const needle = state.inputValue.trim().toLowerCase();
-                if (!needle) return opts;
-                return opts.filter(option => {
-                    const displayName = (option.alias || option.name).toLowerCase();
-                    return (
-                        displayName.includes(needle) ||
-                        (option.baseUrlOpenAI || '').toLowerCase().includes(needle) ||
-                        (option.baseUrlAnthropic || '').toLowerCase().includes(needle)
-                    );
-                });
+                return searchProviders(opts, state.inputValue);
             }}
             getOptionLabel={(option) => {
                 if (typeof option === 'string') return option;

--- a/frontend/src/services/serviceProviders.ts
+++ b/frontend/src/services/serviceProviders.ts
@@ -214,6 +214,27 @@ export function getAllUniqueProviders(): UniqueProvider[] {
     return providers;
 }
 
+// Unified search function for provider templates
+// Searches across: display name (alias/name), base URLs, website, and ID
+// This ensures consistent search behavior across all UI components
+export function searchProviders(providers: UniqueProvider[], query: string): UniqueProvider[] {
+    const needle = query.trim().toLowerCase();
+    if (!needle) {
+        return providers;
+    }
+
+    return providers.filter(provider => {
+        const displayName = (provider.alias || provider.name).toLowerCase();
+        return (
+            displayName.includes(needle) ||
+            (provider.id || '').toLowerCase().includes(needle) ||
+            (provider.baseUrlOpenAI || '').toLowerCase().includes(needle) ||
+            (provider.baseUrlAnthropic || '').toLowerCase().includes(needle) ||
+            (provider.website || '').toLowerCase().includes(needle)
+        );
+    });
+}
+
 // React hook for provider templates
 // This ensures components re-render when providers are loaded
 export function useProviderTemplates(): UniqueProvider[] {

--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -1289,8 +1289,8 @@
     },
     "volces-com-coding": {
       "id": "volces-com-coding",
-      "name": "Volcengine Coding Plan (CN)",
-      "alias": "Volcengine Coding Plan (CN) | 火山方舟 Coding Plan（中国）",
+      "name": "Volcengine Ark Coding Plan (CN)",
+      "alias": "Volcengine Ark Coding Plan (CN) | 火山方舟 Coding Plan（中国）",
       "status": "active",
       "valid": true,
       "canonical_domain": "ark.cn-beijing.volces.com",


### PR DESCRIPTION
Unify provider search algorithm across Connect AI and provider form, and fix name error for `Volcengine Ark Coding Plan (CN)`.

Fix https://github.com/tingly-dev/tingly-box/issues/1230