### PR TITLE
bugfix(failover, tier): missing model info while failover

### DIFF
--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -106,7 +106,8 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	reqCtx.ResponseModel = proxyModel
 
 	s.dispatchWithPriorityFailover(c, rule, provider, actualModel,
-		func(p *typ.Provider, _ string) {
+		func(p *typ.Provider, retryModel string) {
+			reqCtx.RequestModel = retryModel
 			retryProvider := s.resolveProviderForClient(p, protocol.APIStyleAnthropic)
 			s.dispatchChainResult(c, reqCtx, rule, retryProvider, isStreaming, recorder)
 		})

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -102,7 +102,8 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	reqCtx.ResponseModel = proxyModel
 
 	s.dispatchWithPriorityFailover(c, rule, provider, actualModel,
-		func(p *typ.Provider, _ string) {
+		func(p *typ.Provider, retryModel string) {
+			reqCtx.RequestModel = retryModel
 			retryProvider := s.resolveProviderForClient(p, protocol.APIStyleAnthropic)
 			s.dispatchChainResult(c, reqCtx, rule, retryProvider, isStreaming, recorder)
 		})

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -343,6 +343,17 @@ func (s *Server) dispatchWithPriorityFailover(
 	for i := 0; i < len(activeServices); i++ {
 		serviceID := loadbalance.FormatServiceID(provider.UUID, model)
 		tried[serviceID] = true
+
+		// Log each attempt with clear numbering
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"stage":          "failover_attempt",
+			"attempt":        i + 1,
+			"total_attempts": len(activeServices),
+			"service":        serviceID,
+			"provider":       provider.Name,
+			"model":          model,
+		}).Infof("[failover] attempt %d/%d: trying: %s/%s", i+1, len(activeServices), provider.UUID, model)
+
 		if rec != nil {
 			rec.SetActiveService(provider, model)
 		}
@@ -352,39 +363,63 @@ func (s *Server) dispatchWithPriorityFailover(
 		// A committed gate means the stream's first real chunk reached
 		// the wire — bytes have left the process, retry is impossible.
 		if gate.Committed() {
+			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+				"stage":          "failover_success",
+				"attempt":        i + 1,
+				"total_attempts": len(activeServices),
+				"service":        serviceID,
+				"provider":       provider.Name,
+				"model":          model,
+			}).Infof("[failover] succeeded on attempt %d with %s/%s", i+1, provider.UUID, model)
 			return
 		}
 		status := gate.Status()
 		if !isRetryableStatus(status) {
+			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+				"stage":          "failover_terminal",
+				"attempt":        i + 1,
+				"total_attempts": len(activeServices),
+				"service":        serviceID,
+				"provider":       provider.Name,
+				"model":          model,
+				"status":         status,
+			}).Warnf("[failover] attempt %d returned status %d with %s/%s", i+1, status, provider.UUID, model)
 			return
 		}
 
 		nextProvider, nextService, err := s.selectFallbackService(rule, tried, initialProvider.APIStyle)
 		if err != nil {
 			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-				"stage":   "failover",
-				"attempt": i + 1,
-				"status":  status,
-				"error":   err.Error(),
+				"stage":          "failover_error",
+				"attempt":        i + 1,
+				"total_attempts": len(activeServices),
+				"status":         status,
+				"error":          err.Error(),
 			}).Warnf("[failover] load balancer failed selecting fallback after %d attempt(s) status=%d: %v", i+1, status, err)
 			return
 		}
 		if nextProvider == nil || nextService == nil {
 			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-				"stage":   "failover",
-				"attempt": i + 1,
-				"status":  status,
+				"stage":          "failover_exhausted",
+				"attempt":        i + 1,
+				"total_attempts": len(activeServices),
+				"status":         status,
 			}).Warnf("[failover] giving up after %d attempt(s) status=%d (no more services)", i+1, status)
 			return
 		}
+
+		nextServiceID := loadbalance.FormatServiceID(nextProvider.UUID, nextService.Model)
 		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-			"stage":        "failover",
-			"attempt":      i + 1,
-			"status":       status,
-			"from_service": serviceID,
-			"to_provider":  nextProvider.Name,
-			"to_model":     nextService.Model,
-		}).Infof("[failover] status=%d → retrying with %s/%s", status, nextProvider.Name, nextService.Model)
+			"stage":          "failover_retry",
+			"attempt":        i + 1,
+			"total_attempts": len(activeServices),
+			"status":         status,
+			"from_service":   serviceID,
+			"to_service":     nextServiceID,
+			"to_provider":    nextProvider.Name,
+			"to_model":       nextService.Model,
+		}).Warnf("[failover] attempt %d failed with %d, retrying with %s/%s",
+			i+1, status, nextProvider.UUID, nextService.Model)
 
 		gate.Discard()
 		provider = nextProvider

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -354,6 +354,9 @@ func (s *Server) dispatchWithPriorityFailover(
 			"model":          model,
 		}).Infof("[failover] attempt %d/%d: trying: %s/%s", i+1, len(activeServices), provider.UUID, model)
 
+		// Update context for logging/middleware to show current attempt
+		UpdateTrackingForFailover(c, provider, model)
+
 		if rec != nil {
 			rec.SetActiveService(provider, model)
 		}

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -223,7 +223,8 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 	reqCtx.RequestModel = actualModel
 	reqCtx.ResponseModel = responseModel
 	s.dispatchWithPriorityFailover(c, rule, provider, actualModel,
-		func(p *typ.Provider, _ string) {
+		func(p *typ.Provider, retryModel string) {
+			reqCtx.RequestModel = retryModel
 			s.dispatchChainResult(c, reqCtx, rule, p, isStreaming, nil)
 		})
 }

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -229,7 +229,8 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 
 	// Use unified dispatch with mid-request failover (non-streaming only).
 	s.dispatchWithPriorityFailover(c, rule, provider, string(req.Model),
-		func(p *typ.Provider, _ string) {
+		func(p *typ.Provider, retryModel string) {
+			reqCtx.RequestModel = retryModel
 			s.dispatchChainResult(c, reqCtx, rule, p, isStreaming, nil)
 		})
 }

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -131,6 +131,20 @@ func SetCacheHit(c *gin.Context, isHit bool) {
 	c.Set(ContextKeyCacheHit, isHit)
 }
 
+// UpdateTrackingForFailover updates provider and model tracking during failover retry.
+// This ensures that logging/middleware shows the final successful service after failover,
+// not the initially-selected failed service.
+//
+// Parameters:
+//   - c: Gin context
+//   - provider: The new provider being tried in this failover attempt
+//   - model: The new model being tried in this failover attempt
+func UpdateTrackingForFailover(c *gin.Context, provider *typ.Provider, model string) {
+	c.Set(ContextKeyProvider, provider)
+	c.Set(ContextKeyModel, model)
+	c.Set(ContextKeyLBServiceID, provider.UUID+"/"+model)
+}
+
 // GetCacheHit retrieves the cache hit status from the context.
 // Returns the cache hit status and true if it exists, false and false otherwise.
 func GetCacheHit(c *gin.Context) (bool, bool) {


### PR DESCRIPTION
Our failover logic lost the model information, causing the retry logic to continuously fail (incorrect model ID). 

This PR fixes the related issue and adds failover-related logs on the request path.