### PR TITLE
bugfix(protocol,ttft): record TTFT on first content token, not first byte

### DIFF
--- a/.design/ttft.md
+++ b/.design/ttft.md
@@ -1,0 +1,134 @@
+# TTFT（Time To First Token）记录
+
+> 适用对象：改 `internal/protocol/loop.go`（`MarkFirstToken` / `CommitFirstChunk`）、`internal/protocol/stream/`（各协议的 content gate）、`internal/server/module/mcp/generic_stream_interceptor.go`（MCP 流式拦截器）、或 `internal/server/usage_tracking.go`（TTFT 消费侧）的人。
+>
+> 这份文档只讲一件事：**TTFT 必须在「第一个内容 token」被记录，而不是「第一个字节」。**
+
+---
+
+## 0. 一句话
+
+`TTFT = 第一个 content token 的时间 − 请求开始时间`。第一个**字节**只是结构帧（`message_start` / role delta / `response.created`），不是 token——在那一瞬记 TTFT 会让 dashboard 显示的 TTFT 偏低到失真。
+
+所以每条流式输出路径都装一个 **content gate**：只放过「真正带模型生成内容」的事件去触发 `MarkFirstToken`，结构帧一律跳过。
+
+```mermaid
+flowchart LR
+    A["请求开始<br/>ContextKeyStartTime"] --> B["上游首字节<br/>(结构帧)"]
+    B -.跳过.-> C["第一个 content 事件<br/>text / tool / reasoning delta"]
+    C -->|MarkFirstToken| D["CtxKeyFirstTokenTime"]
+    A --> E["CalculateTTFT<br/>= firstToken − startTime"]
+    D --> E
+```
+
+---
+
+## 1. 核心 API
+
+| 名称 | 位置 | 作用 |
+|---|---|---|
+| `MarkFirstToken(c)` | `protocol/loop.go` | **唯一**记录 TTFT 的入口。幂等：已存在则直接 return（最早信号胜）。非流式 handler 从不调用它。 |
+| `CommitFirstChunk(c)` | `protocol/loop.go` | 只提交 failover gate（首个字节 = upstream 健康），**故意不记 TTFT**。 |
+| `CtxKeyFirstTokenTime` | `constant/tracking_ctx.go` | gin context key，存 `time.Time`。 |
+| `CalculateTTFT(c)` | `server/tracking_context.go` | `firstToken − startTime`，毫秒；无 token 时间则返回 0（**不回退成总 latency**）。 |
+
+> ⚠️ 关键区分：`CommitFirstChunk` 处理「上游已连上、可以开始 failover 提交」这件事；`MarkFirstToken` 处理「模型吐出了第一个字」。两者曾经合一，现已拆开——首字节 ≠ 首 token。
+
+---
+
+## 2. 为什么不能在首字节记
+
+各协议流式响应的第一个事件都是**结构帧**，不含模型内容：
+
+| 协议 | 首个事件 | 性质 |
+|---|---|---|
+| Anthropic | `message_start` → `content_block_start` | 结构帧 |
+| OpenAI Chat | `{delta:{role:"assistant"}}`（role-only） | 结构帧 |
+| OpenAI Responses | `response.created` → `response.in_progress` | 结构帧 |
+| Google | 无独立 message_start（首块即可能带内容） | — |
+
+模型真正开始「说话」是在第一个 **content delta**：文本、tool call 参数、reasoning、refusal。在结构帧那刻记 TTFT，等于把「网络 + 排队 + 模型预热」整段延迟砍掉，dashboard 的 TTFT 会系统性偏低、失去诊断意义。
+
+---
+
+## 3. 每条输出路径的 content gate
+
+每条流式输出路径在它的 **send funnel**（所有 chunk 必经的写出口）里判断「这一帧带不带内容」，带才 `MarkFirstToken`。因为 `MarkFirstToken` 幂等，重复内容帧是 no-op，无需额外去重标志位。
+
+### 3.1 Anthropic 出口（`stream/anthropic_helper.go`）
+
+`sendAnthropicStreamEvent` 是所有 Anthropic SSE 的唯一出口：
+
+```go
+func sendAnthropicStreamEvent(c, eventType, eventData, flusher) {
+    if isAnthropicContentDeltaEvent(eventType) {   // == "content_block_delta"
+        protocol.MarkFirstToken(c)
+    }
+    // ... marshal + write
+}
+```
+
+`isAnthropicContentDeltaEvent`（`anthropic_constant.go`）：只认 `content_block_delta`。`message_start` / `content_block_start` / `ping` / `*_stop` 都是结构帧，不算。
+
+### 3.2 OpenAI Responses 出口（`stream/openai_helper.go`）
+
+`OpenAIResponsesEvent` 是 Responses 输出（passthrough + 所有 converter）的唯一出口：
+
+```go
+func OpenAIResponsesEvent(c, event, v) {
+    if isOpenAIResponsesContentEvent(event) {       // strings.HasSuffix(event, ".delta")
+        protocol.MarkFirstToken(c)
+    }
+    // ... write
+}
+```
+
+Responses 的内容一律走 `*.delta` 事件（`response.output_text.delta`、`response.function_call_arguments.delta`、`response.reasoning.delta` …）。`response.created` / `response.in_progress` / `response.output_item.added` 是结构帧。
+
+### 3.3 OpenAI Chat 出口
+
+有两条 Chat 出口，对应两种 chunk 构造方式：
+
+| 出口 | chunk 类型 | gate |
+|---|---|---|
+| `openaiChatSSEWriter`（`openai_responses_to_chat.go`） | `wire.ChatStreamChunk`（typed） | `isOpenAIChatContentChunk` |
+| `sendOpenAIStreamChunkForce`（`anthropic_to_openai.go`） | `map[string]interface{}`（raw） | `isOpenAIChatChunkMapContent` |
+| `handleOpenAIStreamResponse`（`server/openai_chat.go`） | SDK `openai.ChatCompletionChunk`（inline） | 内联判断 |
+
+三个 gate 检查同一组字段：`content` / `tool_calls` / `reasoning_content`（/ `refusal` / `function_call`），任一非空即为内容帧。Chat 流的领头块是 `{role:"assistant"}` 的 role-only delta——不含上述任何字段，自然被跳过。
+
+> 三个 gate 为什么不合一？它们操作**不同类型**（`wire.ChatStreamChunk` / raw map / SDK 类型），合一需要类型适配器，得不偿失。`server` 侧用 SDK 类型，也无法复用 `stream` 包里 typed/raw 的实现。
+
+### 3.4 Google 出口（`stream/any_to_google.go`）
+
+`sendGoogleStreamChunk` + `isGoogleContentChunk`：遍历 `candidates[].content.parts`，任一 part 有 `Text` 或 `FunctionCall` 即为内容。Google wire 没有 `message_start` 帧，首块带内容就是首 token。
+
+### 3.5 MCP 流式拦截器（`server/module/mcp/generic_stream_interceptor.go`）
+
+MCP 拦截器**直接写 SSE**，不经 `sendAnthropicStreamEvent`，所以必须自己 mark。它在两个内容事件处调 `recordTTFT()`（内部即 `MarkFirstToken(i.c)`）：
+
+- `handleTextEvent`：文本 delta
+- `handleToolDeltaEvent`：tool input delta（纯 tool-call 响应的首 token）
+
+结构事件（`message_start` / `content_block_start`）走别的 handler，不触发 `recordTTFT`。幂等，故无需旧的 `ttftRecorded` bool（已删）。
+
+---
+
+## 4. 新增 / 修改流式输出路径时
+
+对照清单：
+
+1. **找到 send funnel**——所有 chunk 写向客户端必经的那个函数。content gate 装在这里，一处覆盖所有上游来源。
+2. **判断内容**——区分结构帧 vs 内容帧。常见信号：Anthropic 的 `content_block_delta`、Responses 的 `*.delta` 后缀、Chat 的非空 `content`/`tool_calls`/`reasoning`。
+3. **直接调 `MarkFirstToken(c)`**，不要自己加 bool 去重——它幂等。
+4. **不要在 `CommitFirstChunk` / `RunLoop` 里记 TTFT**——那是首字节，不是首 token。
+
+测试模板见 `stream/responses_to_anthropic_ttft_test.go`：对每个 gate 写一组「结构帧不 mark、内容帧 mark」的表驱动用例，并在真实 converter 路径上断言「TTFT 在 content delta 时才被设置、结构帧已先发出」。
+
+---
+
+## 5. 不变式
+
+- `CtxKeyFirstTokenTime` 一旦设置不再被覆盖（最早信号胜）。
+- 非流式请求从不设置它 → `CalculateTTFT` 返回 0，**不回退成总 latency**（否则 TTFT 与 latency 不可区分）。
+- TTFT 仅由 `MarkFirstToken` 写、由 `CalculateTTFT` 读，dashboard / `MetricsData.TTFTMs` / DB `usage_records.ttft_ms` 全部源自 `CalculateTTFT`。

--- a/.design/ttft.md
+++ b/.design/ttft.md
@@ -6,11 +6,11 @@
 
 ---
 
-## 0. 一句话
+## 0. 模型
 
-`TTFT = 第一个 content token 的时间 − 请求开始时间`。第一个**字节**只是结构帧（`message_start` / role delta / `response.created`），不是 token——在那一瞬记 TTFT 会让 dashboard 显示的 TTFT 偏低到失真。
+`TTFT = 第一个 content token 的时间 − 请求开始时间`。
 
-所以每条流式输出路径都装一个 **content gate**：只放过「真正带模型生成内容」的事件去触发 `MarkFirstToken`，结构帧一律跳过。
+每条流式响应都先发一堆**结构帧**（`message_start` / role delta / `response.created` …），模型真正开始「说话」是在第一个 **content delta**（文本 / tool 参数 / reasoning / refusal）。结构帧那刻记 TTFT 会把「网络 + 排队 + 模型预热」整段延迟砍掉，dashboard 的 TTFT 系统性偏低、失去诊断意义。所以 content gate 只放过内容帧去触发 `MarkFirstToken`，结构帧一律跳过。
 
 ```mermaid
 flowchart LR
@@ -28,107 +28,80 @@ flowchart LR
 | 名称 | 位置 | 作用 |
 |---|---|---|
 | `MarkFirstToken(c)` | `protocol/loop.go` | **唯一**记录 TTFT 的入口。幂等：已存在则直接 return（最早信号胜）。非流式 handler 从不调用它。 |
-| `CommitFirstChunk(c)` | `protocol/loop.go` | 只提交 failover gate（首个字节 = upstream 健康），**故意不记 TTFT**。 |
+| `CommitFirstChunk(c)` | `protocol/loop.go` | 只提交 failover gate（首字节 = upstream 健康），**故意不记 TTFT**。 |
 | `CtxKeyFirstTokenTime` | `constant/tracking_ctx.go` | gin context key，存 `time.Time`。 |
 | `CalculateTTFT(c)` | `server/tracking_context.go` | `firstToken − startTime`，毫秒；无 token 时间则返回 0（**不回退成总 latency**）。 |
 
-> ⚠️ 关键区分：`CommitFirstChunk` 处理「上游已连上、可以开始 failover 提交」这件事；`MarkFirstToken` 处理「模型吐出了第一个字」。两者曾经合一，现已拆开——首字节 ≠ 首 token。
+> 关键区分：`CommitFirstChunk` 处理「上游已连上、可以提交 failover」；`MarkFirstToken` 处理「模型吐出了第一个字」。两者曾经合一，现已拆开——首字节 ≠ 首 token。
 
 ---
 
-## 2. 为什么不能在首字节记
+## 2. content gate：识别内容帧
 
-各协议流式响应的第一个事件都是**结构帧**，不含模型内容：
+content gate 是「这一帧带不带模型内容」的判断，每条输出路径在写出口处调用它，命中才 `MarkFirstToken`。判断依据按协议：
 
-| 协议 | 首个事件 | 性质 |
+| 协议 | 结构帧（不算） | 内容帧（算） |
 |---|---|---|
-| Anthropic | `message_start` → `content_block_start` | 结构帧 |
-| OpenAI Chat | `{delta:{role:"assistant"}}`（role-only） | 结构帧 |
-| OpenAI Responses | `response.created` → `response.in_progress` | 结构帧 |
-| Google | 无独立 message_start（首块即可能带内容） | — |
+| Anthropic | `message_start` / `content_block_start` / `content_block_stop` / `ping` / `message_delta` / `message_stop` | `content_block_delta`（`text_delta` / `thinking_delta` / `input_json_delta` / `signature_delta`） |
+| OpenAI Chat | 领头 `{delta:{role:"assistant"}}`、纯 `finish_reason` 块 | `delta` 有非空 `content` / `tool_calls` / `reasoning_content` / `refusal` / `function_call` |
+| OpenAI Responses | `response.created` / `response.in_progress` / `response.output_item.added` / `response.completed` | 后缀为 `*.delta` 的事件（`output_text` / `function_call_arguments` / `reasoning` / `refusal` 等 delta） |
+| Google | 无独立 message_start 帧 | `candidates[].content.parts` 任一 part 有 `Text` 或 `FunctionCall` |
 
-模型真正开始「说话」是在第一个 **content delta**：文本、tool call 参数、reasoning、refusal。在结构帧那刻记 TTFT，等于把「网络 + 排队 + 模型预热」整段延迟砍掉，dashboard 的 TTFT 会系统性偏低、失去诊断意义。
+每个 gate 都是一个小函数，集中放可测：
+
+- `isAnthropicContentDeltaEvent` — `== "content_block_delta"`（`anthropic_constant.go`）
+- `isOpenAIChatContentChunk` / `isOpenAIChatChunkMapContent` — Chat 的 typed / raw-map 两版（`openai_helper.go`）
+- `isOpenAIResponsesContentEvent` — `strings.HasSuffix(event, ".delta")`（`openai_helper.go`）
+- `isGoogleContentChunk` — 遍历 parts（`any_to_google.go`）
 
 ---
 
-## 3. 每条输出路径的 content gate
+## 3. 覆盖矩阵：每条输出路径在哪 mark
 
-每条流式输出路径在它的 **send funnel**（所有 chunk 必经的写出口）里判断「这一帧带不带内容」，带才 `MarkFirstToken`。因为 `MarkFirstToken` 幂等，重复内容帧是 no-op，无需额外去重标志位。
+`MarkFirstToken` 幂等，所以每条路径只需在「内容帧即将写出」处调一次，重复内容帧是 no-op，不需要 bool 去重。
 
-### 3.1 Anthropic 出口（`stream/anthropic_helper.go`）
+### 3.1 共用 send funnel 的路径（gate 装在 funnel 里，一处覆盖所有上游来源）
 
-`sendAnthropicStreamEvent` 是所有 Anthropic SSE 的唯一出口：
-
-```go
-func sendAnthropicStreamEvent(c, eventType, eventData, flusher) {
-    if isAnthropicContentDeltaEvent(eventType) {   // == "content_block_delta"
-        protocol.MarkFirstToken(c)
-    }
-    // ... marshal + write
-}
-```
-
-`isAnthropicContentDeltaEvent`（`anthropic_constant.go`）：只认 `content_block_delta`。`message_start` / `content_block_start` / `ping` / `*_stop` 都是结构帧，不算。
-
-### 3.2 OpenAI Responses 出口（`stream/openai_helper.go`）
-
-`OpenAIResponsesEvent` 是 Responses 输出（passthrough + 所有 converter）的唯一出口：
-
-```go
-func OpenAIResponsesEvent(c, event, v) {
-    if isOpenAIResponsesContentEvent(event) {       // strings.HasSuffix(event, ".delta")
-        protocol.MarkFirstToken(c)
-    }
-    // ... write
-}
-```
-
-Responses 的内容一律走 `*.delta` 事件（`response.output_text.delta`、`response.function_call_arguments.delta`、`response.reasoning.delta` …）。`response.created` / `response.in_progress` / `response.output_item.added` 是结构帧。
-
-### 3.3 OpenAI Chat 出口
-
-有两条 Chat 出口，对应两种 chunk 构造方式：
-
-| 出口 | chunk 类型 | gate |
+| 出口 | gate | 谁用它（覆盖哪些 handler） |
 |---|---|---|
-| `openaiChatSSEWriter`（`openai_responses_to_chat.go`） | `wire.ChatStreamChunk`（typed） | `isOpenAIChatContentChunk` |
-| `sendOpenAIStreamChunkForce`（`anthropic_to_openai.go`） | `map[string]interface{}`（raw） | `isOpenAIChatChunkMapContent` |
-| `handleOpenAIStreamResponse`（`server/openai_chat.go`） | SDK `openai.ChatCompletionChunk`（inline） | 内联判断 |
+| `sendAnthropicStreamEvent`（`anthropic_helper.go`） | `isAnthropicContentDeltaEvent` | 所有 Anthropic converter（`google_to_any` 的 v1/beta、`openai_responses_to_anthropic*` 的 v1/beta、`sendAnthropicV1*` helpers），以及 guardrails rewrite 分支 |
+| `OpenAIResponsesEvent`（`openai_helper.go`） | `isOpenAIResponsesContentEvent` | Responses passthrough（`HandleOpenAIResponsesStream`）+ 所有 Responses converter |
+| `openaiChatSSEWriter`（`openai_responses_to_chat.go`） | `isOpenAIChatContentChunk` | Responses→Chat converter |
+| `sendOpenAIStreamChunkForce`（`anthropic_to_openai.go`） | `isOpenAIChatChunkMapContent` | Google→OpenAI converter |
+| `sendGoogleStreamChunk`（`any_to_google.go`） | `isGoogleContentChunk` | 任意→Google converter |
 
-三个 gate 检查同一组字段：`content` / `tool_calls` / `reasoning_content`（/ `refusal` / `function_call`），任一非空即为内容帧。Chat 流的领头块是 `{role:"assistant"}` 的 role-only delta——不含上述任何字段，自然被跳过。
+### 3.2 直接写 SSE、不经任何 funnel 的路径（必须自己 mark）
 
-> 三个 gate 为什么不合一？它们操作**不同类型**（`wire.ChatStreamChunk` / raw map / SDK 类型），合一需要类型适配器，得不偿失。`server` 侧用 SDK 类型，也无法复用 `stream` 包里 typed/raw 的实现。
+这些 handler 把上游原始字节直接 `c.SSEvent` / `OpenAISSE` / `c.Writer.Write` 转发，或自己拼 chunk 写出，funnel 不经过它们，所以 content gate 要落在事件循环里：
 
-### 3.4 Google 出口（`stream/any_to_google.go`）
+| 路径 | 写法 | mark 点 |
+|---|---|---|
+| `HandleAnthropic` / `HandleAnthropicBeta`（`anthropic_passthrough.go`） | `c.SSEvent(evt.Type, evt.RawJSON())` | 事件回调顶部，`isAnthropicContentDeltaEvent(evt.Type)` 命中时 mark |
+| `HandleOpenAIChatStream`（`openai_passthrough.go`） | `OpenAISSE(c, chunkMap)` | `OpenAISSE` 前，`delta` 有内容字段时 mark |
+| `handleOpenAIStreamResponse`（`server/openai_chat.go`） | 内联拼 map → `WriteString` | 内联 content 判断（SDK `openai.ChatCompletionChunk` 类型） |
+| `GenericStreamInterceptor`（`server/module/mcp/`） | `adapter.SendEvent` 直接写 | `recordTTFT()`（= `MarkFirstToken(i.c)`），仅在 `handleTextEvent` / `handleToolDeltaEvent` 调用 |
 
-`sendGoogleStreamChunk` + `isGoogleContentChunk`：遍历 `candidates[].content.parts`，任一 part 有 `Text` 或 `FunctionCall` 即为内容。Google wire 没有 `message_start` 帧，首块带内容就是首 token。
+> Chat 的内容判断有三处实现（typed / raw-map / SDK inline），操作不同类型，合一需要适配器、得不偿失，保持并列。
 
-### 3.5 MCP 流式拦截器（`server/module/mcp/generic_stream_interceptor.go`）
-
-MCP 拦截器**直接写 SSE**，不经 `sendAnthropicStreamEvent`，所以必须自己 mark。它在两个内容事件处调 `recordTTFT()`（内部即 `MarkFirstToken(i.c)`）：
-
-- `handleTextEvent`：文本 delta
-- `handleToolDeltaEvent`：tool input delta（纯 tool-call 响应的首 token）
-
-结构事件（`message_start` / `content_block_start`）走别的 handler，不触发 `recordTTFT`。幂等，故无需旧的 `ttftRecorded` bool（已删）。
-
----
-
-## 4. 新增 / 修改流式输出路径时
-
-对照清单：
-
-1. **找到 send funnel**——所有 chunk 写向客户端必经的那个函数。content gate 装在这里，一处覆盖所有上游来源。
-2. **判断内容**——区分结构帧 vs 内容帧。常见信号：Anthropic 的 `content_block_delta`、Responses 的 `*.delta` 后缀、Chat 的非空 `content`/`tool_calls`/`reasoning`。
-3. **直接调 `MarkFirstToken(c)`**，不要自己加 bool 去重——它幂等。
-4. **不要在 `CommitFirstChunk` / `RunLoop` 里记 TTFT**——那是首字节，不是首 token。
-
-测试模板见 `stream/responses_to_anthropic_ttft_test.go`：对每个 gate 写一组「结构帧不 mark、内容帧 mark」的表驱动用例，并在真实 converter 路径上断言「TTFT 在 content delta 时才被设置、结构帧已先发出」。
+**判据**：一条流式路径在循环里直接写原始字节（不经任何 `send*` funnel）→ 必须自己 mark；走某个 `send*` funnel → funnel 已覆盖。
 
 ---
 
-## 5. 不变式
+## 4. 不变式
 
 - `CtxKeyFirstTokenTime` 一旦设置不再被覆盖（最早信号胜）。
 - 非流式请求从不设置它 → `CalculateTTFT` 返回 0，**不回退成总 latency**（否则 TTFT 与 latency 不可区分）。
-- TTFT 仅由 `MarkFirstToken` 写、由 `CalculateTTFT` 读，dashboard / `MetricsData.TTFTMs` / DB `usage_records.ttft_ms` 全部源自 `CalculateTTFT`。
+- TTFT 仅由 `MarkFirstToken` 写、由 `CalculateTTFT` 读；dashboard / `MetricsData.TTFTMs` / DB `usage_records.ttft_ms` 全部源自 `CalculateTTFT`。
+
+---
+
+## 5. 新增 / 修改流式输出路径时
+
+1. **走 funnel 还是直接写？** 走 §3.1 的某个 `send*` funnel → gate 已装好，无需动。直接写原始字节 → 在事件循环里自己 mark（§3.2）。
+2. **判断内容帧**——按 §2 的协议信号区分结构帧 vs 内容帧。
+3. **直接调 `MarkFirstToken(c)`**，不要自己加 bool 去重——它幂等。
+4. **不要在 `CommitFirstChunk` / `RunLoop` 里记 TTFT**——那是首字节，不是首 token。
+
+测试模板：
+- converter gate：`stream/responses_to_anthropic_ttft_test.go`（表驱动，结构帧不 mark / 内容帧 mark）。
+- raw passthrough：`stream/passthrough_test.go`（`TestHandle*_Passthrough_*`，在真实 handler 上验证内容帧才 mark、结构帧不 mark）。

--- a/internal/protocol/loop.go
+++ b/internal/protocol/loop.go
@@ -52,11 +52,9 @@ func RunLoop(c *gin.Context, step func(w io.Writer) bool) bool {
 // CommitFirstChunk signals a failover gate wrapping c.Writer (if any) that
 // the first real stream chunk has been produced, so it flushes buffered
 // output and switches to pass-through. No-op when no gate is installed.
-//
-// As the "first chunk reached the client" moment for every committing
-// streaming path, it also records TTFT via MarkFirstToken.
+// It does NOT record TTFT: the first byte is a structural event, not a
+// content token. Each protocol marks the first content event itself.
 func CommitFirstChunk(c *gin.Context) {
-	MarkFirstToken(c)
 	if cm, ok := c.Writer.(interface{ CommitFirstChunk() }); ok {
 		cm.CommitFirstChunk()
 	}

--- a/internal/protocol/loop_test.go
+++ b/internal/protocol/loop_test.go
@@ -39,21 +39,20 @@ func TestMarkFirstToken_RecordsOnceEarliestWins(t *testing.T) {
 	assert.Equal(t, first, v2.(time.Time), "later mark must not overwrite earliest signal")
 }
 
-// TestCommitFirstChunk_RecordsFirstToken verifies the commit seam records TTFT
-// even when no failover gate is installed on the writer.
-func TestCommitFirstChunk_RecordsFirstToken(t *testing.T) {
+// TestCommitFirstChunk_DoesNotRecordFirstToken verifies the commit seam does not
+// record TTFT — only the first content token does, marked by each protocol.
+func TestCommitFirstChunk_DoesNotRecordFirstToken(t *testing.T) {
 	c := &gin.Context{}
 
 	CommitFirstChunk(c)
 
 	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
-	assert.True(t, ok, "CommitFirstChunk must record the first-token time")
+	assert.False(t, ok, "CommitFirstChunk must not record TTFT; only content events do")
 }
 
-// TestRunLoop_RecordsFirstTokenOnFirstChunk exercises the real streaming wiring:
-// RunLoop -> commitFirstChunk -> MarkFirstToken. Before any chunk the first-token
-// time is unset; once the first chunk is produced it is recorded.
-func TestRunLoop_RecordsFirstTokenOnFirstChunk(t *testing.T) {
+// TestRunLoop_DoesNotRecordFirstTokenOnFirstChunk verifies RunLoop does not
+// record TTFT on the first chunk; it sees raw bytes, not content events.
+func TestRunLoop_DoesNotRecordFirstTokenOnFirstChunk(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := &closeNotifyRecorder{httptest.NewRecorder()}
 	c, _ := gin.CreateTestContext(w)
@@ -72,5 +71,5 @@ func TestRunLoop_RecordsFirstTokenOnFirstChunk(t *testing.T) {
 	})
 
 	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
-	assert.True(t, ok, "RunLoop must record the first-token time after the first chunk")
+	assert.False(t, ok, "RunLoop must not record TTFT on the first byte; handlers mark content events")
 }

--- a/internal/protocol/stream/anthropic_constant.go
+++ b/internal/protocol/stream/anthropic_constant.go
@@ -28,3 +28,9 @@ const (
 	deltaTypeThinkingDelta  = "thinking_delta"
 	deltaTypeInputJSONDelta = "input_json_delta"
 )
+
+// isAnthropicContentDeltaEvent reports whether an Anthropic SSE event carries
+// model-generated content (a token) rather than structural framing.
+func isAnthropicContentDeltaEvent(eventType string) bool {
+	return eventType == eventTypeContentBlockDelta
+}

--- a/internal/protocol/stream/anthropic_helper.go
+++ b/internal/protocol/stream/anthropic_helper.go
@@ -146,7 +146,13 @@ func sendMessageStart(
 
 // sendAnthropicStreamEvent sends one Anthropic SSE event and optionally records it
 // via StreamEventRecorder if one is stored in the Gin context.
+// It also marks TTFT on the first content_block_delta event; MarkFirstToken is
+// idempotent.
 func sendAnthropicStreamEvent(c *gin.Context, eventType string, eventData map[string]interface{}, flusher http.Flusher) {
+	if isAnthropicContentDeltaEvent(eventType) {
+		protocol.MarkFirstToken(c)
+	}
+
 	eventJSON, err := json.Marshal(eventData)
 	if err != nil {
 		logrus.WithContext(c.Request.Context()).Errorf("Failed to marshal Anthropic stream event: %v", err)

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -50,6 +50,12 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 
 			acc.Consume(evt)
 
+			// This passthrough writes raw upstream bytes via c.SSEvent, bypassing
+			// sendAnthropicStreamEvent, so mark TTFT here on the first content delta.
+			if isAnthropicContentDeltaEvent(evt.Type) {
+				protocol.MarkFirstToken(hc.GinContext)
+			}
+
 			if hc.Guardrails != nil && hc.Guardrails.Enabled {
 				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
 					return err
@@ -150,6 +156,12 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 			}
 
 			acc.ConsumeBeta(evt)
+
+			// This passthrough writes raw upstream bytes via c.SSEvent, bypassing
+			// sendAnthropicStreamEvent, so mark TTFT here on the first content delta.
+			if isAnthropicContentDeltaEvent(evt.Type) {
+				protocol.MarkFirstToken(hc.GinContext)
+			}
 
 			if hc.Guardrails != nil && hc.Guardrails.Enabled {
 				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {

--- a/internal/protocol/stream/anthropic_to_openai.go
+++ b/internal/protocol/stream/anthropic_to_openai.go
@@ -105,8 +105,12 @@ func AnthropicToOpenAIStreamWithMCPHooks(hc *protocol.HandleContext, req *anthro
 	return usage, nil
 }
 
-// sendOpenAIStreamChunkForce helper function to send a chunk in OpenAI format
+// sendOpenAIStreamChunkForce sends a chunk in OpenAI format and marks TTFT on
+// the first content-bearing chunk. MarkFirstToken is idempotent.
 func sendOpenAIStreamChunkForce(c *gin.Context, chunk map[string]interface{}) {
+	if isOpenAIChatChunkMapContent(chunk) {
+		protocol.MarkFirstToken(c)
+	}
 	OpenAISSE(c, chunk)
 }
 

--- a/internal/protocol/stream/any_to_google.go
+++ b/internal/protocol/stream/any_to_google.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/genai"
 
+	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/nonstream"
 )
 
@@ -380,6 +381,10 @@ func HandleAnthropicToGoogleStreamResponse(c *gin.Context, stream *anthropicstre
 
 // sendGoogleStreamChunk sends a GenerateContentResponse as a JSON chunk
 func sendGoogleStreamChunk(c *gin.Context, resp *genai.GenerateContentResponse, flusher http.Flusher) {
+	// Mark TTFT on the first chunk with content; MarkFirstToken is idempotent.
+	if isGoogleContentChunk(resp) {
+		protocol.MarkFirstToken(c)
+	}
 	// Use the SDK's JSON marshal to ensure proper format
 	chunkJSON, err := json.Marshal(resp)
 	if err != nil {
@@ -388,4 +393,23 @@ func sendGoogleStreamChunk(c *gin.Context, resp *genai.GenerateContentResponse, 
 	}
 	c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", string(chunkJSON))))
 	flusher.Flush()
+}
+
+// isGoogleContentChunk reports whether a Google response carries content
+// (a text or function-call part).
+func isGoogleContentChunk(resp *genai.GenerateContentResponse) bool {
+	if resp == nil {
+		return false
+	}
+	for _, cand := range resp.Candidates {
+		if cand.Content == nil {
+			continue
+		}
+		for _, part := range cand.Content.Parts {
+			if part.Text != "" || part.FunctionCall != nil {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/protocol/stream/openai_helper.go
+++ b/internal/protocol/stream/openai_helper.go
@@ -6,13 +6,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
+// OpenAIResponsesEvent writes one Responses API SSE event, flushes, and marks
+// TTFT on the first content-bearing (*.delta) event. MarkFirstToken is idempotent.
 func OpenAIResponsesEvent(c *gin.Context, event string, v any) {
+	if isOpenAIResponsesContentEvent(event) {
+		protocol.MarkFirstToken(c)
+	}
 	switch vv := v.(type) {
 	case []byte:
 		c.Writer.WriteString(fmt.Sprintf("event: %s\ndata: %s\n\n", event, string(vv)))
@@ -26,6 +35,53 @@ func OpenAIResponsesEvent(c *gin.Context, event string, v any) {
 		}
 		c.Writer.WriteString(fmt.Sprintf("event: %s\ndata: %s\n\n", event, data))
 	}
+}
+
+// isOpenAIResponsesContentEvent reports whether a Responses API event carries
+// content, which always arrives as a *.delta event.
+func isOpenAIResponsesContentEvent(eventType string) bool {
+	return strings.HasSuffix(eventType, ".delta")
+}
+
+// isOpenAIChatContentChunk reports whether an OpenAI Chat chunk carries content
+// (text / tool calls / reasoning), skipping the leading role-only delta.
+func isOpenAIChatContentChunk(chunk wire.ChatStreamChunk) bool {
+	for _, choice := range chunk.Choices {
+		if choice.Delta.Content != "" ||
+			len(choice.Delta.ToolCalls) > 0 ||
+			choice.Delta.ReasoningContent != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// isOpenAIChatChunkMapContent is the raw-map variant of isOpenAIChatContentChunk
+// for handlers that build OpenAI Chat chunks directly as maps.
+func isOpenAIChatChunkMapContent(chunk map[string]interface{}) bool {
+	choices, ok := chunk["choices"].([]map[string]interface{})
+	if !ok {
+		return false
+	}
+	for _, choice := range choices {
+		delta, ok := choice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if c, _ := delta["content"].(string); c != "" {
+			return true
+		}
+		if tc, _ := delta["tool_calls"].([]map[string]interface{}); len(tc) > 0 {
+			return true
+		}
+		if rc, _ := delta["reasoning_content"].(string); rc != "" {
+			return true
+		}
+		if rf, _ := delta["refusal"].(string); rf != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // OpenAISSE marshals v to JSON and writes it as an OpenAI-style SSE data line, then flushes.
@@ -183,4 +239,24 @@ type pendingToolCall struct {
 	name  string
 	input string
 	emit  bool
+}
+
+// openaiChatSSEWriter returns a handleFunc that writes OpenAI Chat wire chunks
+// (both normal chunks and error chunks) as SSE, and marks TTFT on the first
+// content-bearing chunk.
+func openaiChatSSEWriter(c *gin.Context) func(event interface{}) error {
+	return func(event interface{}) error {
+		if chunk, ok := event.(wire.ChatStreamChunk); ok {
+			if isOpenAIChatContentChunk(chunk) {
+				protocol.MarkFirstToken(c)
+			}
+		}
+		OpenAISSE(c, event)
+		return nil
+	}
+}
+
+// writeSSEChunk writes a single SSE chunk — kept for callers in other files.
+func writeSSEChunk(c *gin.Context, _ interface{ Flush() }, chunk any) {
+	OpenAISSE(c, chunk)
 }

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -237,6 +237,10 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 			}
 
 			// Send the chunk
+			// Mark TTFT on the first content-bearing chunk; MarkFirstToken is idempotent.
+			if choice.Delta.Content != "" || choice.Delta.Refusal != "" || len(choice.Delta.ToolCalls) > 0 || choice.Delta.JSON.FunctionCall.Valid() {
+				protocol.MarkFirstToken(c)
+			}
 			OpenAISSE(c, chunkMap)
 			return nil
 		},

--- a/internal/protocol/stream/openai_responses_to_chat.go
+++ b/internal/protocol/stream/openai_responses_to_chat.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -42,18 +41,4 @@ func HandleResponsesToOpenAIChatStream(
 
 	OpenAISSEDone(c)
 	return usage, nil
-}
-
-// openaiChatSSEWriter returns a handleFunc that writes OpenAI Chat wire chunks
-// (both normal chunks and error chunks) as SSE.
-func openaiChatSSEWriter(c *gin.Context) func(event interface{}) error {
-	return func(event interface{}) error {
-		OpenAISSE(c, event)
-		return nil
-	}
-}
-
-// writeSSEChunk writes a single SSE chunk — kept for callers in other files.
-func writeSSEChunk(c *gin.Context, _ interface{ Flush() }, chunk any) {
-	OpenAISSE(c, chunk)
 }

--- a/internal/protocol/stream/passthrough_test.go
+++ b/internal/protocol/stream/passthrough_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
@@ -148,6 +149,67 @@ func buildAnthropicOutputOnlyDeltaJSON(t *testing.T, outputTokens int64) string 
 		},
 	}
 	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// buildAnthropicContentBlockDeltaJSON creates a content_block_delta event carrying
+// model text — the first content-bearing event that should trigger a TTFT mark.
+func buildAnthropicContentBlockDeltaJSON(t *testing.T, text string) string {
+	t.Helper()
+	event := map[string]interface{}{
+		"type":  "content_block_delta",
+		"index": 0,
+		"delta": map[string]interface{}{
+			"type": "text_delta",
+			"text": text,
+		},
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// buildChatContentChunkJSON builds an OpenAI Chat chunk with non-empty delta
+// content — the first content-bearing chunk that should trigger a TTFT mark.
+func buildChatContentChunkJSON(t *testing.T, content string) string {
+	t.Helper()
+	chunk := map[string]interface{}{
+		"id":      "chatcmpl-test",
+		"object":  "chat.completion.chunk",
+		"created": 1000,
+		"model":   "gpt-4o",
+		"choices": []interface{}{
+			map[string]interface{}{
+				"index":         0,
+				"delta":         map[string]interface{}{"content": content},
+				"finish_reason": nil,
+			},
+		},
+	}
+	data, err := json.Marshal(chunk)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// buildChatRoleOnlyChunkJSON builds an OpenAI Chat chunk with only the leading
+// role delta ({role:"assistant"}) — a structural frame that must NOT mark TTFT.
+func buildChatRoleOnlyChunkJSON(t *testing.T) string {
+	t.Helper()
+	chunk := map[string]interface{}{
+		"id":      "chatcmpl-test",
+		"object":  "chat.completion.chunk",
+		"created": 1000,
+		"model":   "gpt-4o",
+		"choices": []interface{}{
+			map[string]interface{}{
+				"index":         0,
+				"delta":         map[string]interface{}{"role": "assistant"},
+				"finish_reason": nil,
+			},
+		},
+	}
+	data, err := json.Marshal(chunk)
 	require.NoError(t, err)
 	return string(data)
 }
@@ -405,4 +467,117 @@ func TestHandleAnthropicBeta_RealStreamFormat(t *testing.T) {
 	assert.Equal(t, 40, usage.InputTokens, "input_tokens must come from message_start")
 	assert.Equal(t, 22, usage.OutputTokens)
 	assert.Equal(t, 8, usage.CacheInputTokens)
+}
+
+// ---------------------------------------------------------------------------
+// TTFT for passthrough handlers (which write raw upstream bytes, bypassing
+// the converter content gates, so they must mark TTFT themselves).
+// ---------------------------------------------------------------------------
+
+// TestHandleAnthropic_Passthrough_MarksTTFT verifies the Anthropic passthrough
+// records TTFT on the first content_block_delta, not the message_start frame.
+func TestHandleAnthropic_Passthrough_MarksTTFT(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 5, 0), // structural frame — must NOT mark
+		buildAnthropicContentBlockDeltaJSON(t, "hi"),
+	}
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](newFakeAnthropicDecoder(events), nil)
+
+	_, err := HandleAnthropic(newTestHandleContext(c), stream)
+	require.NoError(t, err)
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok, "Anthropic passthrough must mark TTFT on the content delta")
+}
+
+// TestHandleAnthropic_Passthrough_NoTTFTOnStructuralOnly verifies no TTFT is
+// recorded when the stream contains only structural events (no content).
+func TestHandleAnthropic_Passthrough_NoTTFTOnStructuralOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 5, 0), // structural only
+	}
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](newFakeAnthropicDecoder(events), nil)
+
+	_, err := HandleAnthropic(newTestHandleContext(c), stream)
+	require.NoError(t, err)
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.False(t, ok, "no content delta must not mark TTFT")
+}
+
+// TestHandleAnthropicBeta_Passthrough_MarksTTFT is the beta-passthrough variant.
+func TestHandleAnthropicBeta_Passthrough_MarksTTFT(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	events := []string{
+		buildAnthropicMessageStartJSON(t, 5, 0),
+		buildAnthropicContentBlockDeltaJSON(t, "hi"),
+	}
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](newFakeAnthropicDecoder(events), nil)
+
+	_, err := HandleAnthropicBeta(newTestHandleContext(c), stream)
+	require.NoError(t, err)
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok, "Anthropic beta passthrough must mark TTFT on the content delta")
+}
+
+// TestHandleOpenAIChatStream_Passthrough_MarksTTFT verifies the OpenAI Chat
+// passthrough records TTFT on the first content chunk, skipping the role-only delta.
+func TestHandleOpenAIChatStream_Passthrough_MarksTTFT(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	dec := &fakeChatDecoder{events: []string{
+		buildChatRoleOnlyChunkJSON(t), // structural frame — must NOT mark
+		buildChatContentChunkJSON(t, "hi"),
+	}, current: -1}
+	stream := openaistream.NewStream[openai.ChatCompletionChunk](dec, nil)
+
+	hc := newTestHandleContext(c)
+	hc.DisableStreamUsage = true
+	req := &openai.ChatCompletionNewParams{}
+	_, err := HandleOpenAIChatStream(hc, stream, req)
+	require.NoError(t, err)
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.True(t, ok, "OpenAI Chat passthrough must mark TTFT on the first content chunk")
+}
+
+// TestHandleOpenAIChatStream_Passthrough_NoTTFTOnRoleOnly verifies no TTFT is
+// recorded when the stream contains only the role-only delta.
+func TestHandleOpenAIChatStream_Passthrough_NoTTFTOnRoleOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	dec := &fakeChatDecoder{events: []string{
+		buildChatRoleOnlyChunkJSON(t),
+	}, current: -1}
+	stream := openaistream.NewStream[openai.ChatCompletionChunk](dec, nil)
+
+	hc := newTestHandleContext(c)
+	hc.DisableStreamUsage = true
+	req := &openai.ChatCompletionNewParams{}
+	_, err := HandleOpenAIChatStream(hc, stream, req)
+	require.NoError(t, err)
+
+	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+	assert.False(t, ok, "role-only delta must not mark TTFT")
 }

--- a/internal/protocol/stream/responses_to_anthropic_ttft_test.go
+++ b/internal/protocol/stream/responses_to_anthropic_ttft_test.go
@@ -10,15 +10,47 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genai"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
-// TestHandleResponsesToAnthropicV1Stream_RecordsTTFT verifies the streaming
-// Responses API → Anthropic conversion records the first-token time (TTFT)
-// through CommitFirstChunk, so the dashboard shows a real TTFT rather than "-".
-func TestHandleResponsesToAnthropicV1Stream_RecordsTTFT(t *testing.T) {
+// TestSendAnthropicStreamEvent_TTFTOnlyOnContentDelta verifies TTFT is marked
+// only on content_block_delta, not on structural events.
+func TestSendAnthropicStreamEvent_TTFTOnlyOnContentDelta(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+		marks     bool
+	}{
+		{"message_start is structural", "message_start", false},
+		{"content_block_start is structural", "content_block_start", false},
+		{"ping is structural", "ping", false},
+		{"content_block_stop is structural", "content_block_stop", false},
+		{"content_block_delta text marks TTFT", "content_block_delta", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+			sendAnthropicStreamEvent(c, tc.eventType, map[string]any{"type": tc.eventType}, w)
+
+			_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+			assert.Equal(t, tc.marks, ok, "TTFT mark expectation for %s", tc.eventType)
+		})
+	}
+}
+
+// TestHandleResponsesToAnthropicV1Stream_RecordsTTFTOnDelta verifies the
+// Responses→Anthropic conversion records TTFT at the first content delta, not
+// the leading response.created / message_start.
+func TestHandleResponsesToAnthropicV1Stream_RecordsTTFTOnDelta(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
 	c, _ := gin.CreateTestContext(w)
@@ -46,7 +78,137 @@ func TestHandleResponsesToAnthropicV1Stream_RecordsTTFT(t *testing.T) {
 	_, err := HandleResponsesToAnthropicV1Stream(protocol.NewHandleContext(c, "proxy-model"), stream, "proxy-model")
 	require.NoError(t, err)
 
-	// The first emitted event must have recorded the first-token time.
+	// TTFT must be recorded once content flowed.
 	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
-	assert.True(t, ok, "streaming Responses->Anthropic should record TTFT via CommitFirstChunk")
+	assert.True(t, ok, "streaming Responses->Anthropic should record TTFT on first content delta")
+
+	// message_start proves TTFT fired on the delta, not the first byte.
+	body := w.Body.String()
+	assert.Contains(t, body, "event:message_start", "converter emits message_start framing")
+	assert.Contains(t, body, "event:content_block_delta", "converter emits the content delta")
+}
+
+// TestIsAnthropicContentDeltaEvent verifies the gate used to mark TTFT.
+func TestIsAnthropicContentDeltaEvent(t *testing.T) {
+	assert.True(t, isAnthropicContentDeltaEvent("content_block_delta"))
+	assert.False(t, isAnthropicContentDeltaEvent("message_start"))
+	assert.False(t, isAnthropicContentDeltaEvent("content_block_start"))
+	assert.False(t, isAnthropicContentDeltaEvent("ping"))
+	assert.False(t, isAnthropicContentDeltaEvent(""))
+}
+
+// TestIsOpenAIResponsesContentEvent verifies the Responses gate: content
+// arrives as *.delta events, structural events do not count.
+func TestIsOpenAIResponsesContentEvent(t *testing.T) {
+	assert.True(t, isOpenAIResponsesContentEvent("response.output_text.delta"))
+	assert.True(t, isOpenAIResponsesContentEvent("response.function_call_arguments.delta"))
+	assert.True(t, isOpenAIResponsesContentEvent("response.reasoning.delta"))
+	assert.False(t, isOpenAIResponsesContentEvent("response.created"))
+	assert.False(t, isOpenAIResponsesContentEvent("response.in_progress"))
+	assert.False(t, isOpenAIResponsesContentEvent("response.output_item.added"))
+	assert.False(t, isOpenAIResponsesContentEvent("response.completed"))
+	assert.False(t, isOpenAIResponsesContentEvent(""))
+}
+
+// TestOpenAIResponsesEvent_TTFTOnlyOnContentDelta verifies the Responses funnel
+// marks TTFT only on content-bearing events.
+func TestOpenAIResponsesEvent_TTFTOnlyOnContentDelta(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		event string
+		marks bool
+	}{
+		{"created", "response.created", false},
+		{"in_progress", "response.in_progress", false},
+		{"output_item.added", "response.output_item.added", false},
+		{"output_text.delta", "response.output_text.delta", true},
+		{"function_call_arguments.delta", "response.function_call_arguments.delta", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+			OpenAIResponsesEvent(c, tc.event, map[string]any{"type": tc.event})
+
+			_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+			assert.Equal(t, tc.marks, ok, "TTFT for %s", tc.event)
+		})
+	}
+}
+
+// TestIsOpenAIChatContentChunk verifies the typed OpenAI-Chat content gate used
+// by the converter output funnel (openaiChatSSEWriter).
+func TestIsOpenAIChatContentChunk(t *testing.T) {
+	roleOnly := wire.ChatStreamChunk{Choices: []wire.ChatStreamChoice{{Delta: wire.ChatStreamDelta{Role: "assistant"}}}}
+	assert.False(t, isOpenAIChatContentChunk(roleOnly), "role-only delta is not content")
+
+	text := wire.ChatStreamChunk{Choices: []wire.ChatStreamChoice{{Delta: wire.ChatStreamDelta{Content: "hi"}}}}
+	assert.True(t, isOpenAIChatContentChunk(text), "text delta is content")
+
+	tool := wire.ChatStreamChunk{Choices: []wire.ChatStreamChoice{{Delta: wire.ChatStreamDelta{ToolCalls: []wire.ChatStreamToolCall{{Index: 0}}}}}}
+	assert.True(t, isOpenAIChatContentChunk(tool), "tool_calls delta is content")
+
+	reasoning := wire.ChatStreamChunk{Choices: []wire.ChatStreamChoice{{Delta: wire.ChatStreamDelta{ReasoningContent: "thinking"}}}}
+	assert.True(t, isOpenAIChatContentChunk(reasoning), "reasoning delta is content")
+}
+
+// TestIsOpenAIChatChunkMapContent verifies the raw-map variant used by handlers
+// that build OpenAI Chat chunks directly (e.g. Google→OpenAI).
+func TestIsOpenAIChatChunkMapContent(t *testing.T) {
+	assert.False(t, isOpenAIChatChunkMapContent(map[string]any{
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"role": "assistant"}}},
+	}), "role-only is not content")
+
+	assert.True(t, isOpenAIChatChunkMapContent(map[string]any{
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"content": "hi"}}},
+	}), "content text is content")
+
+	assert.True(t, isOpenAIChatChunkMapContent(map[string]any{
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"tool_calls": []map[string]any{{"index": 0}}}}},
+	}), "tool_calls is content")
+
+	assert.True(t, isOpenAIChatChunkMapContent(map[string]any{
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"reasoning_content": "thinking"}}},
+	}), "reasoning_content is content")
+
+	assert.True(t, isOpenAIChatChunkMapContent(map[string]any{
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"refusal": "I can't help with that"}}},
+	}), "refusal is content")
+
+	assert.False(t, isOpenAIChatChunkMapContent(map[string]any{
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"}},
+	}), "finish-only is not content")
+}
+
+// TestSendGoogleStreamChunk_TTFTOnlyOnContent verifies the Google-output funnel
+// marks TTFT only when a chunk carries text or function-call content.
+func TestSendGoogleStreamChunk_TTFTOnlyOnContent(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		resp  *genai.GenerateContentResponse
+		marks bool
+	}{
+		{"nil resp", nil, false},
+		{"empty candidates", &genai.GenerateContentResponse{}, false},
+		{"text content", &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []*genai.Part{{Text: "hi"}}}}},
+		}, true},
+		{"function call", &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: "f"}}}}}},
+		}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/models/x:streamGenerateContent", nil)
+
+			sendGoogleStreamChunk(c, tc.resp, w)
+
+			_, ok := c.Get(constant.CtxKeyFirstTokenTime)
+			assert.Equal(t, tc.marks, ok, "TTFT for %s", tc.name)
+		})
+	}
 }

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -11,8 +11,8 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/sirupsen/logrus"
 
-	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -34,7 +34,6 @@ type GenericStreamInterceptor struct {
 	config          InterceptorConfig
 
 	// Cross-round state (not reset)
-	ttftRecorded      bool
 	totalInputTokens  int64
 	totalOutputTokens int64
 	totalCacheTokens  int64
@@ -222,10 +221,6 @@ func (i *GenericStreamInterceptor) consumeRound(stream StreamHandle) (any, error
 			break
 		}
 		event := stream.Current()
-
-		// The interceptor never commits through CommitFirstChunk, so record
-		// TTFT here on the first upstream event.
-		protocol.MarkFirstToken(i.c)
 
 		i.accumulateRoundEvent(event)
 
@@ -446,11 +441,8 @@ func (i *GenericStreamInterceptor) handleTextEvent(event any) error {
 		return err
 	}
 
-	// Record TTFT
-	if !i.ttftRecorded {
-		i.recordTTFT()
-		i.ttftRecorded = true
-	}
+	// Mark TTFT on the first content token; MarkFirstToken is idempotent.
+	i.recordTTFT()
 
 	return i.adapter.SendEvent(i.c, "content_block_delta", payload)
 }
@@ -502,6 +494,8 @@ func (i *GenericStreamInterceptor) handleToolDeltaEvent(event any) error {
 	if err != nil {
 		return err
 	}
+	// A tool input delta is content; mark TTFT (idempotent).
+	i.recordTTFT()
 	return i.adapter.SendEvent(i.c, "content_block_delta", payload)
 }
 
@@ -685,10 +679,9 @@ func (i *GenericStreamInterceptor) resultsToAny(results []ToolExecutionResult) [
 }
 
 func (i *GenericStreamInterceptor) recordTTFT() {
-	// Time To First Token (TTFT) tracking is handled at the dispatch layer
-	// through HandleContext hooks. This method is called for consistency
-	// but the actual tracking is done in the dispatch functions.
-	// See: mcp_anthropic_v1_helper.go - dispatchGeneric*Stream functions
+	// The interceptor writes SSE directly, so it marks TTFT itself. Only reached
+	// for content events (text / tool-input deltas); MarkFirstToken is idempotent.
+	protocol.MarkFirstToken(i.c)
 }
 
 func (i *GenericStreamInterceptor) isSuppressedContentBlockEvent(event any) bool {

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -470,6 +470,12 @@ func (s *Server) handleOpenAIStreamResponse(c *gin.Context, streamResp *ssestrea
 			delta["tool_calls"] = choice.Delta.ToolCalls
 		}
 
+		// Mark TTFT on the first chunk carrying content (text / tool call /
+		// refusal), not the leading role-only delta. MarkFirstToken is idempotent.
+		if choice.Delta.Content != "" || choice.Delta.Refusal != "" || len(choice.Delta.ToolCalls) > 0 || choice.Delta.JSON.FunctionCall.Valid() {
+			protocol.MarkFirstToken(c)
+		}
+
 		finishReason := &choice.FinishReason
 		if finishReason != nil && *finishReason == "" {
 			finishReason = nil


### PR DESCRIPTION
## Summary
TTFT (Time To First Token) shown on the dashboard was systematically underestimated and often missing entirely. It was being recorded at the first stream **byte** — which is merely a structural frame (`message_start` / role delta / `response.created`), not a model-generated token.  

Recording at that point silently discards network latency, queue time, and model-warmup overhead, rendering the metric useless for diagnosis. Several output paths recorded nothing at all.

### Major
- **Redefine the TTFT mark point**: move it from the first byte to the first **content-bearing event**. `MarkFirstToken` now fires only on content deltas (e.g., Google text/function-call parts), never on structural frames. Structural-versus-content detection is centralized in per-protocol gate helpers.  
- **Cover every output path, including passthrough**: the raw passthrough handlers (`HandleAnthropic`/`HandleAnthropicBeta`, `HandleOpenAIChatStream`) and the server Chat streamer re-serialize upstream bytes directly and bypassed the converter content gates — they now mark TTFT in their own event loops. Previously these paths produced no TTFT at all.  
- **Decouple `CommitFirstChunk` from TTFT**: it now only commits the failover gate (first byte = upstream healthy) and no longer records TTFT. First-byte health and first-token timing are now correctly separate signals.  
- **MCP interceptor**: mark on first text/tool-input delta directly (drops the obsolete `ttftRecorded` bool since `MarkFirstToken` is idempotent).

### Minor
- Added `.design/ttft.md` documenting the model, per-protocol content gates, the full path coverage matrix, and invariants.  
- Tests: table-driven gate coverage (`responses_to_anthropic_ttft_test.go`) plus end-to-end passthrough tests asserting content frames mark TTFT and structural frames do not (`passthrough_test.go`).