### PR TITLE
feat(server): route profile endpoints by name alias, not just ID

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1558,12 +1558,6 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 		return fmt.Errorf("no profiles found for scenario '%s'", base)
 	}
 
-	// Same URL-friendly constraint as creation: a rename must not produce a
-	// name that can't be used in a route.
-	if err := typ.ValidateProfileName(name); err != nil {
-		return err
-	}
-
 	profiles := c.Profiles[base]
 	idx := -1
 	for i, p := range profiles {
@@ -1574,6 +1568,17 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 	}
 	if idx < 0 {
 		return fmt.Errorf("profile '%s' not found in scenario '%s'", profileID, base)
+	}
+
+	// Apply the URL-friendly constraint only when the name actually changes.
+	// Editing a legacy profile (e.g. changing nothing but the mode) replays its
+	// existing name through here; if that name predates the constraint we must
+	// not reject the edit. A genuine rename, on the other hand, is a fresh write
+	// and must not introduce a new non-routable name.
+	if name != profiles[idx].Name {
+		if err := typ.ValidateProfileName(name); err != nil {
+			return err
+		}
 	}
 
 	// Validate name uniqueness (excluding current profile)

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1493,6 +1493,12 @@ func (c *Config) CreateProfile(baseScenario typ.RuleScenario, name string, unifi
 
 	base := string(baseScenario)
 
+	// Constrain the name to a URL-friendly alias up front, so the profile is
+	// always addressable as "/tingly/<base>:<name>" — not just by its ID.
+	if err := typ.ValidateProfileName(name); err != nil {
+		return typ.ProfileMeta{}, err
+	}
+
 	if c.Profiles == nil {
 		c.Profiles = make(map[string][]typ.ProfileMeta)
 	}
@@ -1550,6 +1556,12 @@ func (c *Config) UpdateProfile(baseScenario typ.RuleScenario, profileID string, 
 	base := string(baseScenario)
 	if c.Profiles == nil {
 		return fmt.Errorf("no profiles found for scenario '%s'", base)
+	}
+
+	// Same URL-friendly constraint as creation: a rename must not produce a
+	// name that can't be used in a route.
+	if err := typ.ValidateProfileName(name); err != nil {
+		return err
 	}
 
 	profiles := c.Profiles[base]

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1689,22 +1689,26 @@ func (c *Config) ResolveProfileNameOrID(baseScenario typ.RuleScenario, input str
 // address those by ID. Returns ("", false) when the alias matches neither a
 // known ID nor a simple, unique profile name.
 func (c *Config) ResolveProfileAlias(baseScenario typ.RuleScenario, alias string) (string, bool) {
-	if alias == "" {
-		return "", false
-	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	profiles := c.Profiles[string(baseScenario)]
 
 	// Direct ID match — already canonical, nothing to rewrite.
-	if _, ok := c.GetProfile(baseScenario, alias); ok {
-		return alias, true
+	for _, p := range profiles {
+		if p.ID == alias {
+			return alias, true
+		}
 	}
 
-	// Only attempt name resolution for URL-friendly aliases.
+	// Otherwise resolve by name, but only for URL-friendly aliases (this also
+	// rejects "", which IsSimpleProfileAlias reports false for). A stored name
+	// equal to a simple alias is itself simple, so no per-name re-check needed.
 	if !typ.IsSimpleProfileAlias(alias) {
 		return "", false
 	}
-
-	for _, p := range c.GetProfiles(baseScenario) {
-		if p.Name == alias && typ.IsSimpleProfileAlias(p.Name) {
+	for _, p := range profiles {
+		if p.Name == alias {
 			return p.ID, true
 		}
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1660,6 +1660,40 @@ func (c *Config) ResolveProfileNameOrID(baseScenario typ.RuleScenario, input str
 
 	return "", fmt.Errorf("profile '%s' not found in scenario '%s'", input, baseScenario)
 }
+
+// ResolveProfileAlias resolves a URL-friendly profile alias to its canonical
+// profile ID. The alias may be:
+//   - the profile ID itself (e.g. "p1") — returned as-is, and
+//   - a profile's human-readable name (e.g. "mine") — but only when that name
+//     is a simple identifier safe to embed in a URL path segment.
+//
+// Profiles whose names contain spaces or other characters that don't parse
+// cleanly out of a URL are intentionally not routable by name; callers must
+// address those by ID. Returns ("", false) when the alias matches neither a
+// known ID nor a simple, unique profile name.
+func (c *Config) ResolveProfileAlias(baseScenario typ.RuleScenario, alias string) (string, bool) {
+	if alias == "" {
+		return "", false
+	}
+
+	// Direct ID match — already canonical, nothing to rewrite.
+	if _, ok := c.GetProfile(baseScenario, alias); ok {
+		return alias, true
+	}
+
+	// Only attempt name resolution for URL-friendly aliases.
+	if !typ.IsSimpleProfileAlias(alias) {
+		return "", false
+	}
+
+	for _, p := range c.GetProfiles(baseScenario) {
+		if p.Name == alias && typ.IsSimpleProfileAlias(p.Name) {
+			return p.ID, true
+		}
+	}
+
+	return "", false
+}
 func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -228,3 +228,44 @@ func TestSetServerHost_EmptyStringReturnsLocalhost(t *testing.T) {
 		t.Errorf("expected empty string to return 'localhost', got %q", host)
 	}
 }
+
+func TestResolveProfileAlias(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+	scenario := typ.RuleScenario("claude_code")
+
+	p1, err := cfg.CreateProfile(scenario, "mine", true)
+	if err != nil {
+		t.Fatalf("CreateProfile failed: %v", err)
+	}
+	if _, err := cfg.CreateProfile(scenario, "my work profile", true); err != nil {
+		t.Fatalf("CreateProfile failed: %v", err)
+	}
+
+	// Resolve by canonical ID.
+	if id, ok := cfg.ResolveProfileAlias(scenario, p1.ID); !ok || id != p1.ID {
+		t.Errorf("ResolveProfileAlias(%q) = (%q, %v), want (%q, true)", p1.ID, id, ok, p1.ID)
+	}
+
+	// Resolve by simple name.
+	if id, ok := cfg.ResolveProfileAlias(scenario, "mine"); !ok || id != p1.ID {
+		t.Errorf("ResolveProfileAlias(\"mine\") = (%q, %v), want (%q, true)", id, ok, p1.ID)
+	}
+
+	// Non-simple name is not routable by name.
+	if id, ok := cfg.ResolveProfileAlias(scenario, "my work profile"); ok {
+		t.Errorf("ResolveProfileAlias(\"my work profile\") = (%q, true), want not ok", id)
+	}
+
+	// Unknown alias.
+	if _, ok := cfg.ResolveProfileAlias(scenario, "nope"); ok {
+		t.Errorf("ResolveProfileAlias(\"nope\") = ok, want not ok")
+	}
+
+	// Empty alias.
+	if _, ok := cfg.ResolveProfileAlias(scenario, ""); ok {
+		t.Errorf("ResolveProfileAlias(\"\") = ok, want not ok")
+	}
+}

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -240,9 +240,13 @@ func TestResolveProfileAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateProfile failed: %v", err)
 	}
-	if _, err := cfg.CreateProfile(scenario, "my work profile", true); err != nil {
-		t.Fatalf("CreateProfile failed: %v", err)
-	}
+	// Simulate a legacy profile whose name predates the creation-time
+	// constraint (CreateProfile now rejects names with spaces). The routing
+	// path must still refuse to resolve it by name.
+	cfg.Profiles[string(scenario)] = append(cfg.Profiles[string(scenario)], typ.ProfileMeta{
+		ID:   "p99",
+		Name: "my work profile",
+	})
 
 	// Resolve by canonical ID.
 	if id, ok := cfg.ResolveProfileAlias(scenario, p1.ID); !ok || id != p1.ID {
@@ -267,5 +271,28 @@ func TestResolveProfileAlias(t *testing.T) {
 	// Empty alias.
 	if _, ok := cfg.ResolveProfileAlias(scenario, ""); ok {
 		t.Errorf("ResolveProfileAlias(\"\") = ok, want not ok")
+	}
+}
+
+func TestCreateProfile_RejectsNonURLFriendlyName(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+	scenario := typ.RuleScenario("claude_code")
+
+	for _, bad := range []string{"my profile", "a:b", "a/b", "", " mine"} {
+		if _, err := cfg.CreateProfile(scenario, bad, true); err == nil {
+			t.Errorf("CreateProfile(%q) = nil error, want rejection", bad)
+		}
+	}
+
+	// A valid name still works, and a rename to a bad name is rejected.
+	p, err := cfg.CreateProfile(scenario, "mine", true)
+	if err != nil {
+		t.Fatalf("CreateProfile(\"mine\") failed: %v", err)
+	}
+	if err := cfg.UpdateProfile(scenario, p.ID, "not ok", nil); err == nil {
+		t.Errorf("UpdateProfile to \"not ok\" = nil error, want rejection")
 	}
 }

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -287,12 +287,42 @@ func TestCreateProfile_RejectsNonURLFriendlyName(t *testing.T) {
 		}
 	}
 
-	// A valid name still works, and a rename to a bad name is rejected.
+	// A valid name still works; renaming it to a new bad name is rejected.
 	p, err := cfg.CreateProfile(scenario, "mine", true)
 	if err != nil {
 		t.Fatalf("CreateProfile(\"mine\") failed: %v", err)
 	}
 	if err := cfg.UpdateProfile(scenario, p.ID, "not ok", nil); err == nil {
 		t.Errorf("UpdateProfile to \"not ok\" = nil error, want rejection")
+	}
+}
+
+func TestUpdateProfile_AllowsEditingLegacyBadName(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+	scenario := typ.RuleScenario("claude_code")
+
+	// Simulate a legacy profile whose name predates the creation-time
+	// constraint (created directly, bypassing CreateProfile validation).
+	cfg.Profiles = map[string][]typ.ProfileMeta{
+		string(scenario): {{ID: "p1", Name: "my work profile"}},
+	}
+
+	// Editing the legacy profile while preserving its (bad) name must succeed —
+	// the handler replays the existing name when the caller doesn't rename.
+	if err := cfg.UpdateProfile(scenario, "p1", "my work profile", nil); err != nil {
+		t.Errorf("UpdateProfile preserving legacy name = %v, want nil", err)
+	}
+
+	// Cleaning it up to a valid name is allowed.
+	if err := cfg.UpdateProfile(scenario, "p1", "work", nil); err != nil {
+		t.Errorf("UpdateProfile to valid name = %v, want nil", err)
+	}
+
+	// But renaming to a different still-bad name is rejected.
+	if err := cfg.UpdateProfile(scenario, "p1", "still bad", nil); err == nil {
+		t.Errorf("UpdateProfile to \"still bad\" = nil error, want rejection")
 	}
 }

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -281,7 +281,7 @@ func TestCreateProfile_RejectsNonURLFriendlyName(t *testing.T) {
 	}
 	scenario := typ.RuleScenario("claude_code")
 
-	for _, bad := range []string{"my profile", "a:b", "a/b", "", " mine"} {
+	for _, bad := range []string{"my profile", "a:b", "a/b", "", " mine", "p1", "p07"} {
 		if _, err := cfg.CreateProfile(scenario, bad, true); err == nil {
 			t.Errorf("CreateProfile(%q) = nil error, want rejection", bad)
 		}

--- a/internal/server/profile_alias_middleware.go
+++ b/internal/server/profile_alias_middleware.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// profileAliasMiddleware rewrites a profile alias in the ":scenario" path
+// segment to its canonical "base:pN" form before contextMiddleware runs.
+//
+// Profile endpoints are addressed as "/tingly/claude_code:p1", but the "p1"
+// suffix has low recognizability. This middleware lets callers use the
+// profile's name instead — "/tingly/claude_code:mine" — by resolving the
+// suffix against the configured profiles and rewriting the path param to the
+// profile ID in place. Everything downstream (contextMiddleware, auth,
+// routing, usage records) only ever sees the canonical "base:pN", so no other
+// stage needs to learn about aliases.
+//
+// Resolution is best-effort and non-fatal: if the suffix is already a valid
+// ID, or cannot be resolved to a simple/URL-friendly profile name, the path is
+// left untouched and contextMiddleware performs validation (and error
+// reporting) exactly as before.
+func (s *Server) profileAliasMiddleware(c *gin.Context) {
+	rawScenario := c.Param("scenario")
+	base, suffix := typ.ParseScenarioProfile(typ.RuleScenario(rawScenario))
+	// Only profiled scenarios ("base:suffix") are eligible — a missing suffix
+	// is a plain scenario with nothing to resolve.
+	if base == "" || suffix == "" || s.config == nil {
+		c.Next()
+		return
+	}
+
+	id, ok := s.config.ResolveProfileAlias(base, suffix)
+	if !ok || id == suffix {
+		// Unknown alias, non-simple name, or already canonical — leave as-is.
+		c.Next()
+		return
+	}
+
+	rewritten := string(typ.ProfiledScenarioName(base, id))
+
+	// Rewrite the routed path param — covers every handler and the
+	// contextMiddleware that derives the request-context scenario from c.Param.
+	for i := range c.Params {
+		if c.Params[i].Key == "scenario" {
+			c.Params[i].Value = rewritten
+		}
+	}
+
+	// Also rewrite the URL path so consumers that re-derive the scenario from
+	// the raw path agree on the canonical form. The usage tracker
+	// (extractScenarioFromPath) is the one that matters: without this, requests
+	// via the alias would be recorded under "claude_code:mine" instead of
+	// "claude_code:p1", splitting analytics across the alias and the ID.
+	originalPath := c.Request.URL.Path
+	oldSeg := "/tingly/" + rawScenario
+	newSeg := "/tingly/" + rewritten
+	rewriteSeg := func(p string) string {
+		if rest, found := strings.CutPrefix(p, oldSeg); found {
+			return newSeg + rest
+		}
+		return p
+	}
+	c.Request.URL.Path = rewriteSeg(c.Request.URL.Path)
+	if c.Request.URL.RawPath != "" {
+		c.Request.URL.RawPath = rewriteSeg(c.Request.URL.RawPath)
+	}
+
+	// Record the mapping. After this point the original alias is gone from the
+	// path, usage records, and access logs — all of which now show the
+	// canonical ID. The before→after fields keep SRE able to correlate a client
+	// that called "/tingly/claude_code:mine/..." with records tagged
+	// "claude_code:p1".
+	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+		"profile_alias":  rawScenario,
+		"scenario":       rewritten,
+		"original_path":  originalPath,
+		"rewritten_path": c.Request.URL.Path,
+	}).Infof("[profile-alias] resolved %q -> %q", rawScenario, rewritten)
+
+	c.Next()
+}

--- a/internal/server/profile_alias_middleware_test.go
+++ b/internal/server/profile_alias_middleware_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// newAliasTestServer builds a Server whose config holds a single claude_code
+// profile (p1 named "mine"), enough to exercise profileAliasMiddleware.
+func newAliasTestServer() *Server {
+	return &Server{config: &config.Config{
+		Profiles: map[string][]typ.ProfileMeta{
+			"claude_code": {{ID: "p1", Name: "mine"}},
+		},
+	}}
+}
+
+// invokeAliasMiddleware runs profileAliasMiddleware over a request whose
+// :scenario param is rawScenario and whose path embeds it, returning the
+// resulting param value and rewritten URL path.
+func invokeAliasMiddleware(t *testing.T, s *Server, rawScenario string) (param, path string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/tingly/"+rawScenario+"/v1/messages", nil)
+	c.Params = gin.Params{{Key: "scenario", Value: rawScenario}}
+
+	s.profileAliasMiddleware(c)
+
+	return c.Param("scenario"), c.Request.URL.Path
+}
+
+func TestProfileAliasMiddleware_RewritesNameToID(t *testing.T) {
+	s := newAliasTestServer()
+
+	param, path := invokeAliasMiddleware(t, s, "claude_code:mine")
+
+	if param != "claude_code:p1" {
+		t.Errorf("param = %q, want %q", param, "claude_code:p1")
+	}
+	if path != "/tingly/claude_code:p1/v1/messages" {
+		t.Errorf("path = %q, want %q", path, "/tingly/claude_code:p1/v1/messages")
+	}
+	// The usage tracker derives the scenario from the (now rewritten) path.
+	if sc := extractScenarioFromPath(path); sc != "claude_code:p1" {
+		t.Errorf("extractScenarioFromPath = %q, want %q", sc, "claude_code:p1")
+	}
+}
+
+func TestProfileAliasMiddleware_LeavesCanonicalAndUnknownUntouched(t *testing.T) {
+	s := newAliasTestServer()
+
+	for _, raw := range []string{
+		"claude_code:p1", // already canonical
+		"claude_code:nope", // unknown alias
+		"claude_code",      // not profiled
+		"openai",           // not profiled
+	} {
+		param, path := invokeAliasMiddleware(t, s, raw)
+		if param != raw {
+			t.Errorf("param for %q = %q, want unchanged", raw, param)
+		}
+		if path != "/tingly/"+raw+"/v1/messages" {
+			t.Errorf("path for %q = %q, want unchanged", raw, path)
+		}
+	}
+}

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -75,8 +75,12 @@ func (s *Server) UseAIEndpoints() {
 	passthroughOpenaiV1 := s.engine.Group("/passthrough/openai/v1")
 	s.SetupPassthroughOpenAIEndpoints(passthroughOpenaiV1)
 
-	// scenario routes with middleware to inject scenario into context
+	// scenario routes with middleware to inject scenario into context.
+	// profileAliasMiddleware runs first so it can rewrite a profile name alias
+	// (e.g. "claude_code:mine") to its canonical ID form ("claude_code:p1")
+	// before contextMiddleware validates and downstream stages consume it.
 	scenario := s.engine.Group("/tingly/:scenario")
+	scenario.Use(s.profileAliasMiddleware)
 	scenario.Use(s.contextMiddleware)
 	s.SetupMixinEndpoints(scenario)
 	// Claude Code v2.1+ sends HEAD <ANTHROPIC_BASE_URL> as a connectivity
@@ -86,6 +90,7 @@ func (s *Server) UseAIEndpoints() {
 
 	// scenario v1 routes with middleware
 	scenarioV1 := s.engine.Group("/tingly/:scenario/v1")
+	scenarioV1.Use(s.profileAliasMiddleware)
 	scenarioV1.Use(s.contextMiddleware)
 	s.SetupMixinEndpoints(scenarioV1)
 	scenarioV1.HEAD("", func(c *gin.Context) { c.Status(http.StatusOK) })
@@ -147,6 +152,50 @@ func (s *Server) SetupPassthroughOpenAIEndpoints(group *gin.RouterGroup) {
 	group.GET("/responses/*path", s.getModelAuthMiddleware(), s.PassthroughOpenAI)
 	// Models endpoint returns tingly-box's model list (not passthrough)
 	group.GET("/models", s.getModelAuthMiddleware(), s.OpenAIListModels)
+}
+
+// profileAliasMiddleware rewrites a profile alias in the ":scenario" path
+// segment to its canonical "base:pN" form before contextMiddleware runs.
+//
+// Profile endpoints are addressed as "/tingly/claude_code:p1", but the "p1"
+// suffix has low recognizability. This middleware lets callers use the
+// profile's name instead — "/tingly/claude_code:mine" — by resolving the
+// suffix against the configured profiles and rewriting the path param to the
+// profile ID in place. Everything downstream (contextMiddleware, auth,
+// routing, usage records) only ever sees the canonical "base:pN", so no other
+// stage needs to learn about aliases.
+//
+// Resolution is best-effort and non-fatal: if the suffix is already a valid
+// ID, or cannot be resolved to a simple/URL-friendly profile name, the path is
+// left untouched and contextMiddleware performs validation (and error
+// reporting) exactly as before.
+func (s *Server) profileAliasMiddleware(c *gin.Context) {
+	rawScenario := c.Param("scenario")
+	if !typ.IsProfiledScenario(typ.RuleScenario(rawScenario)) {
+		c.Next()
+		return
+	}
+
+	base, suffix := typ.ParseScenarioProfile(typ.RuleScenario(rawScenario))
+	if base == "" || suffix == "" || s.config == nil {
+		c.Next()
+		return
+	}
+
+	id, ok := s.config.ResolveProfileAlias(base, suffix)
+	if !ok || id == suffix {
+		// Unknown alias, non-simple name, or already canonical — leave as-is.
+		c.Next()
+		return
+	}
+
+	rewritten := string(typ.ProfiledScenarioName(base, id))
+	for i := range c.Params {
+		if c.Params[i].Key == "scenario" {
+			c.Params[i].Value = rewritten
+		}
+	}
+	c.Next()
 }
 
 // contextMiddleware is a middleware that extracts the scenario parameter from the URL path

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tingly-dev/tingly-box/internal/client"
@@ -190,11 +191,31 @@ func (s *Server) profileAliasMiddleware(c *gin.Context) {
 	}
 
 	rewritten := string(typ.ProfiledScenarioName(base, id))
+
+	// Rewrite the routed path param — covers every handler and the
+	// contextMiddleware that derives the request-context scenario from c.Param.
 	for i := range c.Params {
 		if c.Params[i].Key == "scenario" {
 			c.Params[i].Value = rewritten
 		}
 	}
+
+	// Also rewrite the URL path so consumers that re-derive the scenario from
+	// the raw path agree on the canonical form. The usage tracker
+	// (extractScenarioFromPath) is the one that matters: without this, requests
+	// via the alias would be recorded under "claude_code:mine" instead of
+	// "claude_code:p1", splitting analytics across the alias and the ID.
+	oldSeg := "/tingly/" + rawScenario
+	newSeg := "/tingly/" + rewritten
+	if rest, found := strings.CutPrefix(c.Request.URL.Path, oldSeg); found {
+		c.Request.URL.Path = newSeg + rest
+	}
+	if c.Request.URL.RawPath != "" {
+		if rest, found := strings.CutPrefix(c.Request.URL.RawPath, oldSeg); found {
+			c.Request.URL.RawPath = newSeg + rest
+		}
+	}
+
 	c.Next()
 }
 

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -173,12 +173,9 @@ func (s *Server) SetupPassthroughOpenAIEndpoints(group *gin.RouterGroup) {
 // reporting) exactly as before.
 func (s *Server) profileAliasMiddleware(c *gin.Context) {
 	rawScenario := c.Param("scenario")
-	if !typ.IsProfiledScenario(typ.RuleScenario(rawScenario)) {
-		c.Next()
-		return
-	}
-
 	base, suffix := typ.ParseScenarioProfile(typ.RuleScenario(rawScenario))
+	// Only profiled scenarios ("base:suffix") are eligible — a missing suffix
+	// is a plain scenario with nothing to resolve.
 	if base == "" || suffix == "" || s.config == nil {
 		c.Next()
 		return
@@ -209,26 +206,28 @@ func (s *Server) profileAliasMiddleware(c *gin.Context) {
 	originalPath := c.Request.URL.Path
 	oldSeg := "/tingly/" + rawScenario
 	newSeg := "/tingly/" + rewritten
-	if rest, found := strings.CutPrefix(c.Request.URL.Path, oldSeg); found {
-		c.Request.URL.Path = newSeg + rest
-	}
-	if c.Request.URL.RawPath != "" {
-		if rest, found := strings.CutPrefix(c.Request.URL.RawPath, oldSeg); found {
-			c.Request.URL.RawPath = newSeg + rest
+	rewriteSeg := func(p string) string {
+		if rest, found := strings.CutPrefix(p, oldSeg); found {
+			return newSeg + rest
 		}
+		return p
+	}
+	c.Request.URL.Path = rewriteSeg(c.Request.URL.Path)
+	if c.Request.URL.RawPath != "" {
+		c.Request.URL.RawPath = rewriteSeg(c.Request.URL.RawPath)
 	}
 
 	// Record the mapping. After this point the original alias is gone from the
 	// path, usage records, and access logs — all of which now show the
-	// canonical ID. Logging both the scenario token and the full path
-	// before→after keeps SRE able to correlate a client that called
-	// "/tingly/claude_code:mine/..." with records tagged "claude_code:p1".
+	// canonical ID. The before→after fields keep SRE able to correlate a client
+	// that called "/tingly/claude_code:mine/..." with records tagged
+	// "claude_code:p1".
 	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
 		"profile_alias":  rawScenario,
 		"scenario":       rewritten,
 		"original_path":  originalPath,
 		"rewritten_path": c.Request.URL.Path,
-	}).Infof("[profile-alias] resolved %q -> %q (path %q -> %q)", rawScenario, rewritten, originalPath, c.Request.URL.Path)
+	}).Infof("[profile-alias] resolved %q -> %q", rawScenario, rewritten)
 
 	c.Next()
 }

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -206,6 +206,7 @@ func (s *Server) profileAliasMiddleware(c *gin.Context) {
 	// (extractScenarioFromPath) is the one that matters: without this, requests
 	// via the alias would be recorded under "claude_code:mine" instead of
 	// "claude_code:p1", splitting analytics across the alias and the ID.
+	originalPath := c.Request.URL.Path
 	oldSeg := "/tingly/" + rawScenario
 	newSeg := "/tingly/" + rewritten
 	if rest, found := strings.CutPrefix(c.Request.URL.Path, oldSeg); found {
@@ -219,13 +220,15 @@ func (s *Server) profileAliasMiddleware(c *gin.Context) {
 
 	// Record the mapping. After this point the original alias is gone from the
 	// path, usage records, and access logs — all of which now show the
-	// canonical ID. Logging the before→after here keeps SRE able to correlate a
-	// client that called "claude_code:mine" with records tagged
-	// "claude_code:p1".
+	// canonical ID. Logging both the scenario token and the full path
+	// before→after keeps SRE able to correlate a client that called
+	// "/tingly/claude_code:mine/..." with records tagged "claude_code:p1".
 	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-		"profile_alias": rawScenario,
-		"scenario":      rewritten,
-	}).Infof("[profile-alias] resolved %q -> %q", rawScenario, rewritten)
+		"profile_alias":  rawScenario,
+		"scenario":       rewritten,
+		"original_path":  originalPath,
+		"rewritten_path": c.Request.URL.Path,
+	}).Infof("[profile-alias] resolved %q -> %q (path %q -> %q)", rawScenario, rewritten, originalPath, c.Request.URL.Path)
 
 	c.Next()
 }

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/client"
 	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -215,6 +216,16 @@ func (s *Server) profileAliasMiddleware(c *gin.Context) {
 			c.Request.URL.RawPath = newSeg + rest
 		}
 	}
+
+	// Record the mapping. After this point the original alias is gone from the
+	// path, usage records, and access logs — all of which now show the
+	// canonical ID. Logging the before→after here keeps SRE able to correlate a
+	// client that called "claude_code:mine" with records tagged
+	// "claude_code:p1".
+	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+		"profile_alias": rawScenario,
+		"scenario":      rewritten,
+	}).Infof("[profile-alias] resolved %q -> %q", rawScenario, rewritten)
 
 	c.Next()
 }

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/client"
 	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -154,82 +152,6 @@ func (s *Server) SetupPassthroughOpenAIEndpoints(group *gin.RouterGroup) {
 	group.GET("/responses/*path", s.getModelAuthMiddleware(), s.PassthroughOpenAI)
 	// Models endpoint returns tingly-box's model list (not passthrough)
 	group.GET("/models", s.getModelAuthMiddleware(), s.OpenAIListModels)
-}
-
-// profileAliasMiddleware rewrites a profile alias in the ":scenario" path
-// segment to its canonical "base:pN" form before contextMiddleware runs.
-//
-// Profile endpoints are addressed as "/tingly/claude_code:p1", but the "p1"
-// suffix has low recognizability. This middleware lets callers use the
-// profile's name instead — "/tingly/claude_code:mine" — by resolving the
-// suffix against the configured profiles and rewriting the path param to the
-// profile ID in place. Everything downstream (contextMiddleware, auth,
-// routing, usage records) only ever sees the canonical "base:pN", so no other
-// stage needs to learn about aliases.
-//
-// Resolution is best-effort and non-fatal: if the suffix is already a valid
-// ID, or cannot be resolved to a simple/URL-friendly profile name, the path is
-// left untouched and contextMiddleware performs validation (and error
-// reporting) exactly as before.
-func (s *Server) profileAliasMiddleware(c *gin.Context) {
-	rawScenario := c.Param("scenario")
-	base, suffix := typ.ParseScenarioProfile(typ.RuleScenario(rawScenario))
-	// Only profiled scenarios ("base:suffix") are eligible — a missing suffix
-	// is a plain scenario with nothing to resolve.
-	if base == "" || suffix == "" || s.config == nil {
-		c.Next()
-		return
-	}
-
-	id, ok := s.config.ResolveProfileAlias(base, suffix)
-	if !ok || id == suffix {
-		// Unknown alias, non-simple name, or already canonical — leave as-is.
-		c.Next()
-		return
-	}
-
-	rewritten := string(typ.ProfiledScenarioName(base, id))
-
-	// Rewrite the routed path param — covers every handler and the
-	// contextMiddleware that derives the request-context scenario from c.Param.
-	for i := range c.Params {
-		if c.Params[i].Key == "scenario" {
-			c.Params[i].Value = rewritten
-		}
-	}
-
-	// Also rewrite the URL path so consumers that re-derive the scenario from
-	// the raw path agree on the canonical form. The usage tracker
-	// (extractScenarioFromPath) is the one that matters: without this, requests
-	// via the alias would be recorded under "claude_code:mine" instead of
-	// "claude_code:p1", splitting analytics across the alias and the ID.
-	originalPath := c.Request.URL.Path
-	oldSeg := "/tingly/" + rawScenario
-	newSeg := "/tingly/" + rewritten
-	rewriteSeg := func(p string) string {
-		if rest, found := strings.CutPrefix(p, oldSeg); found {
-			return newSeg + rest
-		}
-		return p
-	}
-	c.Request.URL.Path = rewriteSeg(c.Request.URL.Path)
-	if c.Request.URL.RawPath != "" {
-		c.Request.URL.RawPath = rewriteSeg(c.Request.URL.RawPath)
-	}
-
-	// Record the mapping. After this point the original alias is gone from the
-	// path, usage records, and access logs — all of which now show the
-	// canonical ID. The before→after fields keep SRE able to correlate a client
-	// that called "/tingly/claude_code:mine/..." with records tagged
-	// "claude_code:p1".
-	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-		"profile_alias":  rawScenario,
-		"scenario":       rewritten,
-		"original_path":  originalPath,
-		"rewritten_path": c.Request.URL.Path,
-	}).Infof("[profile-alias] resolved %q -> %q", rawScenario, rewritten)
-
-	c.Next()
 }
 
 // contextMiddleware is a middleware that extracts the scenario parameter from the URL path

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -247,6 +247,19 @@ func ProfiledScenarioName(base RuleScenario, profileID string) RuleScenario {
 	return RuleScenario(string(base) + ProfileSeparator + profileID)
 }
 
+// IsSimpleProfileAlias reports whether s is a URL-friendly profile alias that
+// the profile-alias middleware is allowed to resolve to a profile ID.
+//
+// A profile is addressed as the "<alias>" half of "/tingly/<base>:<alias>", so
+// the only thing that disqualifies a name is a character that doesn't survive
+// that round-trip: the profile separator ':' (would re-split), the path
+// separator '/' (would start a new path segment), or surrounding whitespace.
+// Anything else parses cleanly as a single segment. Names that fail this check
+// are not routable by name — callers must address those profiles by ID.
+func IsSimpleProfileAlias(s string) bool {
+	return s != "" && s == strings.TrimSpace(s) && !strings.ContainsAny(s, ":/ ")
+}
+
 // getBaseScenarioDescriptor resolves the descriptor for a plain (non-profiled) scenario.
 func getBaseScenarioDescriptor(base RuleScenario) (ScenarioDescriptor, bool) {
 	scenarioRegistryMu.RLock()

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -260,6 +260,21 @@ func IsSimpleProfileAlias(s string) bool {
 	return s != "" && s == strings.TrimSpace(s) && !strings.ContainsAny(s, ":/ ")
 }
 
+// ValidateProfileName enforces, at profile creation/rename time, that a name is
+// a simple alias usable directly in a route ("/tingly/<base>:<name>"). Pushing
+// the constraint to the write path is the primary defense: every stored
+// profile is then guaranteed routable by name, and IsSimpleProfileAlias on the
+// routing path only has to guard legacy data created before this check.
+func ValidateProfileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name must not be empty")
+	}
+	if !IsSimpleProfileAlias(name) {
+		return fmt.Errorf("profile name %q must be a single URL-friendly token (no spaces, '%s' or '/') so it can be used directly in a route like '/tingly/<scenario>:%s'", name, ProfileSeparator, name)
+	}
+	return nil
+}
+
 // getBaseScenarioDescriptor resolves the descriptor for a plain (non-profiled) scenario.
 func getBaseScenarioDescriptor(base RuleScenario) (ScenarioDescriptor, bool) {
 	scenarioRegistryMu.RLock()

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -3,6 +3,7 @@ package typ
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -272,17 +273,16 @@ func IsSimpleProfileAlias(s string) bool {
 
 // looksLikeProfileID reports whether name has the reserved auto-generated ID
 // shape "p"<digits> (e.g. "p1", "p07"). Allowing such a name would let it
-// shadow ID-based routing, since ResolveProfileAlias matches IDs first.
+// shadow ID-based routing, since ResolveProfileAlias matches IDs first. IDs are
+// minted as fmt.Sprintf("p%d", n), so a trailing unsigned integer is exactly
+// the shape to reserve.
 func looksLikeProfileID(name string) bool {
-	if len(name) < 2 || name[0] != 'p' {
+	rest, ok := strings.CutPrefix(name, "p")
+	if !ok {
 		return false
 	}
-	for i := 1; i < len(name); i++ {
-		if name[i] < '0' || name[i] > '9' {
-			return false
-		}
-	}
-	return true
+	_, err := strconv.ParseUint(rest, 10, 64)
+	return err == nil
 }
 
 // ValidateProfileName enforces, at profile creation/rename time, that a name is

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -251,26 +251,56 @@ func ProfiledScenarioName(base RuleScenario, profileID string) RuleScenario {
 // the profile-alias middleware is allowed to resolve to a profile ID.
 //
 // A profile is addressed as the "<alias>" half of "/tingly/<base>:<alias>", so
-// the only thing that disqualifies a name is a character that doesn't survive
-// that round-trip: the profile separator ':' (would re-split), the path
-// separator '/' (would start a new path segment), or surrounding whitespace.
-// Anything else parses cleanly as a single segment. Names that fail this check
-// are not routable by name — callers must address those profiles by ID.
+// the alias has to be a clean URL path token. We whitelist the RFC 3986
+// unreserved slug subset — ASCII letters, digits, '-' and '_' — which needs no
+// escaping and contains no path/profile separators. Names that fail this check
+// are not routable by name; callers must address those profiles by ID.
 func IsSimpleProfileAlias(s string) bool {
-	return s != "" && s == strings.TrimSpace(s) && !strings.ContainsAny(s, ":/ ")
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= 'a' && ch <= 'z', ch >= 'A' && ch <= 'Z', ch >= '0' && ch <= '9', ch == '_', ch == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// looksLikeProfileID reports whether name has the reserved auto-generated ID
+// shape "p"<digits> (e.g. "p1", "p07"). Allowing such a name would let it
+// shadow ID-based routing, since ResolveProfileAlias matches IDs first.
+func looksLikeProfileID(name string) bool {
+	if len(name) < 2 || name[0] != 'p' {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateProfileName enforces, at profile creation/rename time, that a name is
 // a simple alias usable directly in a route ("/tingly/<base>:<name>"). Pushing
 // the constraint to the write path is the primary defense: every stored
 // profile is then guaranteed routable by name, and IsSimpleProfileAlias on the
-// routing path only has to guard legacy data created before this check.
+// routing path only has to guard legacy data created before this check. The
+// "p"<digits> shape is additionally reserved here so a name can never collide
+// with the auto-generated ID namespace.
 func ValidateProfileName(name string) error {
 	if name == "" {
 		return fmt.Errorf("profile name must not be empty")
 	}
 	if !IsSimpleProfileAlias(name) {
-		return fmt.Errorf("profile name %q must be a single URL-friendly token (no spaces, '%s' or '/') so it can be used directly in a route like '/tingly/<scenario>:%s'", name, ProfileSeparator, name)
+		return fmt.Errorf("profile name %q must contain only letters, digits, '-' and '_' so it can be used directly in a route like '/tingly/<scenario>:%s'", name, name)
+	}
+	if looksLikeProfileID(name) {
+		return fmt.Errorf("profile name %q is reserved: it has the shape of an auto-generated profile ID — choose a different name", name)
 	}
 	return nil
 }

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -186,15 +186,39 @@ func TestIsSimpleProfileAlias(t *testing.T) {
 		{"my_profile", true},
 		{"work2", true},
 		{"", false},
-		{"my profile", false},  // interior space
-		{" mine", false},       // leading space
-		{"mine ", false},       // trailing space
+		{"my profile", false},     // interior space
+		{" mine", false},          // leading space
+		{"mine ", false},          // trailing space
 		{"claude_code:p1", false}, // contains separator
-		{"a/b", false},         // path separator
+		{"a/b", false},            // path separator
 	}
 	for _, tc := range cases {
 		if got := IsSimpleProfileAlias(tc.in); got != tc.want {
 			t.Errorf("IsSimpleProfileAlias(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateProfileName(t *testing.T) {
+	valid := []string{"cc", "mine", "profile-1", "team2", "my_cc", "p1x", "px"}
+	for _, name := range valid {
+		if err := ValidateProfileName(name); err != nil {
+			t.Errorf("ValidateProfileName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{
+		"",           // empty
+		"my profile", // space
+		"a:b",        // separator
+		"a/b",        // path separator
+		"café",       // non-ASCII
+		"p1",         // reserved ID shape
+		"p07",        // reserved ID shape
+	}
+	for _, name := range invalid {
+		if err := ValidateProfileName(name); err == nil {
+			t.Errorf("ValidateProfileName(%q) = nil, want error", name)
 		}
 	}
 }

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -173,3 +173,28 @@ func TestRegisterScenario_RejectsConflictingDescriptor(t *testing.T) {
 		t.Fatalf("expected conflicting descriptor registration to fail")
 	}
 }
+
+func TestIsSimpleProfileAlias(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"cc", true},
+		{"mine", true},
+		{"p1", true},
+		{"my-profile", true},
+		{"my_profile", true},
+		{"work2", true},
+		{"", false},
+		{"my profile", false},  // interior space
+		{" mine", false},       // leading space
+		{"mine ", false},       // trailing space
+		{"claude_code:p1", false}, // contains separator
+		{"a/b", false},         // path separator
+	}
+	for _, tc := range cases {
+		if got := IsSimpleProfileAlias(tc.in); got != tc.want {
+			t.Errorf("IsSimpleProfileAlias(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Profile endpoints are addressed as `/tingly/claude_code:p1`, but the `p1` suffix has poor recognizability. This lets callers use the **profile's name** instead — `/tingly/claude_code:mine` — while everything downstream still sees the canonical `claude_code:p1`.

## How

A new **`profileAliasMiddleware`** runs ahead of `contextMiddleware` on the `/tingly/:scenario` (and `/v1`) groups:

1. Parses the `:scenario` suffix; resolves a name alias → profile ID via `config.ResolveProfileAlias` (ID-first, then simple-name match).
2. Rewrites the gin `:scenario` param **and** `c.Request.URL.Path`/`RawPath` to the canonical `base:pN`, so every consumer agrees — handlers (`c.Param`), `contextMiddleware` (request-context scenario), and the usage tracker (which re-derives scenario from the raw path via `extractScenarioFromPath`). Without the path rewrite, usage would split between `claude_code:mine` and `claude_code:p1`.
3. Logs the alias→canonical mapping (with original/rewritten paths) so SRE can correlate a client that called `:mine` with records tagged `:p1`.

Resolution is best-effort and non-fatal: an already-canonical ID or an unresolvable suffix is left untouched for `contextMiddleware` to validate as before.

## Defense at write time

To keep routing-by-name reliable, profile names are constrained at the write path (`CreateProfile` / `UpdateProfile`):

- **Charset:** `ValidateProfileName` requires the RFC 3986 unreserved slug subset `[A-Za-z0-9_-]` — a clean URL path token (no `:` `/` whitespace, no escaping).
- **Reserved IDs:** names shaped like an auto-generated ID (`p<digits>`, e.g. `p1`, `p07`) are rejected so they can't shadow ID-based routing.
- **Legacy-safe:** `UpdateProfile` only validates when the name actually changes, so editing a pre-existing profile (e.g. changing only the mode) never gets blocked by a legacy name. The routing-side `IsSimpleProfileAlias` remains as defense-in-depth for legacy data (those profiles just aren't routable by name — use the ID).

## Files

- `internal/server/profile_alias_middleware.go` (+ test) — the middleware
- `internal/typ/scenario_registry.go` — `IsSimpleProfileAlias`, `ValidateProfileName`, reserved-`pN` check
- `internal/server/config/config.go` — `ResolveProfileAlias` + creation/rename constraint
- `internal/server/server_routes.go` — wires the middleware onto the scenario groups

## Tests

`internal/typ`, `internal/server`, `internal/server/config`, `internal/server/module/scenario` all pass. Coverage includes alias→ID rewrite + path rewrite (asserting `extractScenarioFromPath` sees the canonical ID), charset/`pN` validation, and the legacy-edit allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Xh2EaWusTeGThV1fgmAzZ