### PR TITLE
fix(codex): drop empty-content messages in Responses API converters

### DIFF
--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -301,6 +301,18 @@ func sanitizeInputItemID(item *responses.ResponseInputItemUnionParam) bool {
 		logrus.Debugf("[Codex] Dropping item_reference input item with invalid id: %q", item.OfItemReference.ID)
 		return false
 	}
+
+	// Drop message items with empty string content.
+	// Codex rejects "content": "" as a missing required parameter.
+	if item.OfMessage != nil {
+		msg := item.OfMessage
+		if msg.Content.OfString.Valid() && msg.Content.OfString.Value == "" &&
+			len(msg.Content.OfInputItemContentList) == 0 {
+			logrus.Warnf("[Codex] Dropping message item (role=%s) with empty string content", msg.Role)
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/internal/client/codex_round_tripper.go
+++ b/internal/client/codex_round_tripper.go
@@ -112,6 +112,10 @@ func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
 	// scrub the marshaled JSON to catch every variant the SDK may emit.
 	bodyStr = sanitizeCodexInputIDsJSON(bodyStr)
 
+	// Drop message items whose content serialized as "" — Codex treats empty
+	// string content as a missing required parameter.
+	bodyStr = sanitizeCodexEmptyContentJSON(bodyStr)
+
 	return []byte(bodyStr), nil
 }
 
@@ -150,6 +154,31 @@ func sanitizeCodexInputIDsJSON(bodyStr string) string {
 			if updated, err := sjson.Delete(bodyStr, path+".id"); err == nil {
 				bodyStr = updated
 			}
+		}
+	}
+	return bodyStr
+}
+
+// sanitizeCodexEmptyContentJSON drops input items of type "message" whose content
+// field is an empty string. Codex treats "content": "" as a missing required
+// parameter, which results in an invalid_request_error.
+func sanitizeCodexEmptyContentJSON(bodyStr string) string {
+	input := gjson.Get(bodyStr, "input")
+	if !input.IsArray() {
+		return bodyStr
+	}
+
+	items := input.Array()
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		content := item.Get("content")
+		if !content.Exists() || content.Type != gjson.String || content.String() != "" {
+			continue
+		}
+		logrus.Warnf("[Codex] Dropping input[%d] (type=%q) with empty string content", i, item.Get("type").String())
+		path := fmt.Sprintf("input.%d", i)
+		if updated, err := sjson.Delete(bodyStr, path); err == nil {
+			bodyStr = updated
 		}
 	}
 	return bodyStr

--- a/internal/client/codex_round_tripper_test.go
+++ b/internal/client/codex_round_tripper_test.go
@@ -103,6 +103,55 @@ func TestSanitizeCodexInputIDsJSON_HighIndex(t *testing.T) {
 	assert.False(t, input[186].Get("id").Exists())
 }
 
+func TestSanitizeCodexEmptyContentJSON_DropsEmptyStringContent(t *testing.T) {
+	body := `{
+		"input": [
+			{"type": "message", "role": "user", "content": "hello"},
+			{"type": "message", "role": "assistant", "content": ""},
+			{"type": "message", "role": "user", "content": ""},
+			{"type": "function_call_output", "call_id": "c1", "output": ""}
+		]
+	}`
+
+	out := sanitizeCodexEmptyContentJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 2, "message items with empty string content must be dropped")
+	assert.Equal(t, "hello", input[0].Get("content").String())
+	assert.Equal(t, "function_call_output", input[1].Get("type").String(), "non-message items with empty content must be kept")
+}
+
+func TestSanitizeCodexEmptyContentJSON_KeepsNonEmptyContent(t *testing.T) {
+	body := `{"input":[{"type":"message","role":"user","content":"hi"},{"type":"message","role":"assistant","content":"hello"}]}`
+
+	out := sanitizeCodexEmptyContentJSON(body)
+
+	assert.Equal(t, body, out, "non-empty content must not be modified")
+}
+
+func TestSanitizeCodexEmptyContentJSON_NoInputArray(t *testing.T) {
+	body := `{"model":"gpt-5-codex","input":"hello"}`
+
+	out := sanitizeCodexEmptyContentJSON(body)
+
+	assert.Equal(t, body, out)
+}
+
+func TestSanitizeCodexEmptyContentJSON_HighIndex(t *testing.T) {
+	// Mirrors the production failure: input[1012].content == ""
+	var items []string
+	for i := 0; i < 1012; i++ {
+		items = append(items, `{"type":"message","role":"user","content":"x"}`)
+	}
+	items = append(items, `{"type":"message","role":"assistant","content":""}`)
+	body := `{"input":[` + strings.Join(items, ",") + `]}`
+
+	out := sanitizeCodexEmptyContentJSON(body)
+
+	input := gjson.Get(out, "input").Array()
+	assert.Len(t, input, 1012, "empty-content message at high index must be dropped")
+}
+
 func TestCodexInputItemIDRequired(t *testing.T) {
 	required := []string{
 		"reasoning", "code_interpreter_call", "computer_call", "file_search_call",

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -33,16 +33,9 @@ func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageN
 		}
 	}
 
-	// Set input - use list format if we have multiple items or complex content
-	if len(inputItems) > 0 {
-		params.Input = responses.ResponseNewParamsInputUnion{
-			OfInputItemList: inputItems,
-		}
-	} else {
-		// Fallback to simple string input
-		params.Input = responses.ResponseNewParamsInputUnion{
-			OfString: ParamOpt(""),
-		}
+	// Set input - always use list format so the field is well-typed.
+	params.Input = responses.ResponseNewParamsInputUnion{
+		OfInputItemList: inputItems,
 	}
 
 	// Convert MaxTokens to MaxOutputTokens
@@ -108,7 +101,7 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 				items = append(items, responses.ResponseInputItemUnionParam{
 					OfFunctionCallOutput: &outputItem,
 				})
-			} else if block.OfText != nil {
+			} else if block.OfText != nil && block.OfText.Text != "" {
 				// Text content alongside tool results
 				messageItem := responses.EasyInputMessageParam{
 					Type: responses.EasyInputMessageTypeMessage,
@@ -219,20 +212,7 @@ func convertBetaAssistantMessageToResponsesInput(msg anthropic.BetaMessageParam)
 		})
 	}
 
-	// If no items were created, create an empty assistant message
-	if len(items) == 0 {
-		messageItem := responses.EasyInputMessageParam{
-			Type: responses.EasyInputMessageTypeMessage,
-			Role: responses.EasyInputMessageRole("assistant"),
-			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: ParamOpt(""),
-			},
-		}
-		items = append(items, responses.ResponseInputItemUnionParam{
-			OfMessage: &messageItem,
-		})
-	}
-
+	// An assistant message with no text and no tool_use blocks is empty — skip it.
 	return items
 }
 

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -222,20 +222,7 @@ func convertV1AssistantMessageToResponsesInput(msg anthropic.MessageParam) []res
 		})
 	}
 
-	// If no items were created, create an empty assistant message
-	if len(items) == 0 {
-		messageItem := responses.EasyInputMessageParam{
-			Type: responses.EasyInputMessageTypeMessage,
-			Role: responses.EasyInputMessageRole("assistant"),
-			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(""),
-			},
-		}
-		items = append(items, responses.ResponseInputItemUnionParam{
-			OfMessage: &messageItem,
-		})
-	}
-
+	// An assistant message with no text and no tool_use blocks is empty — skip it.
 	return items
 }
 

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -81,7 +81,7 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 	for _, msg := range messages {
 		switch {
 		case !param.IsOmitted(msg.OfUser):
-			result = append(result, convertChatUserMessageToResponses(msg.OfUser))
+			result = append(result, convertChatUserMessageToResponses(msg.OfUser)...)
 
 		case !param.IsOmitted(msg.OfAssistant):
 			assistantMsg := msg.OfAssistant
@@ -101,8 +101,7 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 					}
 				}
 			} else {
-				// Regular assistant message
-				result = append(result, convertChatAssistantMessageToResponses(assistantMsg))
+				result = append(result, convertChatAssistantMessageToResponses(assistantMsg)...)
 			}
 
 		case !param.IsOmitted(msg.OfTool):
@@ -114,9 +113,10 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 }
 
 // convertChatUserMessageToResponses converts a Chat user message to Responses format.
-func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessageParam) responses.ResponseInputItemUnionParam {
-	if userMsg.Content.OfString.Valid() {
-		return responses.ResponseInputItemUnionParam{
+// Returns nil if the message has no usable content.
+func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessageParam) []responses.ResponseInputItemUnionParam {
+	if userMsg.Content.OfString.Valid() && userMsg.Content.OfString.Value != "" {
+		return []responses.ResponseInputItemUnionParam{{
 			OfMessage: &responses.EasyInputMessageParam{
 				Type: responses.EasyInputMessageTypeMessage,
 				Role: responses.EasyInputMessageRole("user"),
@@ -124,7 +124,7 @@ func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessage
 					OfString: param.NewOpt(userMsg.Content.OfString.Value),
 				},
 			},
-		}
+		}}
 	}
 
 	// Multipart content: forward text + image_url parts as input_text + input_image.
@@ -149,7 +149,7 @@ func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessage
 			}
 		}
 		if len(contentList) > 0 {
-			return responses.ResponseInputItemUnionParam{
+			return []responses.ResponseInputItemUnionParam{{
 				OfMessage: &responses.EasyInputMessageParam{
 					Type: responses.EasyInputMessageTypeMessage,
 					Role: responses.EasyInputMessageRole("user"),
@@ -157,38 +157,30 @@ func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessage
 						OfInputItemContentList: contentList,
 					},
 				},
-			}
+			}}
 		}
 	}
 
-	// Fall back to an empty user message to preserve prior behavior.
-	return responses.ResponseInputItemUnionParam{
-		OfMessage: &responses.EasyInputMessageParam{
-			Type: responses.EasyInputMessageTypeMessage,
-			Role: responses.EasyInputMessageRole("user"),
-			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(""),
-			},
-		},
-	}
+	// No usable content — skip rather than emit an empty message.
+	return nil
 }
 
 // convertChatAssistantMessageToResponses converts a Chat assistant message to Responses format.
-func convertChatAssistantMessageToResponses(assistantMsg *openai.ChatCompletionAssistantMessageParam) responses.ResponseInputItemUnionParam {
-	content := ""
-	if !param.IsOmitted(assistantMsg.Content.OfString) && assistantMsg.Content.OfString.Value != "" {
-		content = assistantMsg.Content.OfString.Value
+// Returns nil if the message has no usable text content.
+func convertChatAssistantMessageToResponses(assistantMsg *openai.ChatCompletionAssistantMessageParam) []responses.ResponseInputItemUnionParam {
+	if param.IsOmitted(assistantMsg.Content.OfString) || assistantMsg.Content.OfString.Value == "" {
+		return nil
 	}
 
-	return responses.ResponseInputItemUnionParam{
+	return []responses.ResponseInputItemUnionParam{{
 		OfMessage: &responses.EasyInputMessageParam{
 			Type: responses.EasyInputMessageTypeMessage,
 			Role: responses.EasyInputMessageRole("assistant"),
 			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(content),
+				OfString: param.NewOpt(assistantMsg.Content.OfString.Value),
 			},
 		},
-	}
+	}}
 }
 
 // convertChatToolMessageToResponses converts a Chat tool message to Responses function_call_output format.


### PR DESCRIPTION
## Summary

Fixes intermittent `invalid_request_error: Missing required parameter 'input[N].content'` from the Codex (ChatGPT backend) API.

**Root cause** — three converter functions had incomplete condition coverage: when no usable content was found they produced a placeholder `message` item with `"content": ""` instead of skipping the item. Codex treats empty-string content as a missing required parameter.

- `convertChatUserMessageToResponses` — fell through to `param.NewOpt("")` when `OfString` was invalid and all content parts were filtered out
- `convertChatAssistantMessageToResponses` — always emitted a message even when `content == ""`
- `convertV1AssistantMessageToResponsesInput` / `convertBetaAssistantMessageToResponsesInput` — explicit "create empty assistant message" fallback
- `ConvertAnthropicBetaToResponsesRequest` — top-level fallback to `OfString: ""` when no input items were produced

## Changes

### Source-level fix (3 converter files)

- `openai_chat_to_openai_responses.go`: changed `convertChatUserMessageToResponses` and `convertChatAssistantMessageToResponses` to return `[]item` (nil = skip); empty/missing content now returns nil instead of an empty message
- `anthropic_v1_to_responses.go`: removed empty-assistant fallback; an assistant turn with no text and no tool_use is skipped
- `anthropic_beta_to_responses.go`: same empty-assistant fallback removed; top-level input fallback replaced with always-use-`OfInputItemList`; text block in `hasToolResult` branch now guarded by `Text != ""`

### Defence-in-depth sanitizers (kept as safety net)

- `codex_client.go` / `sanitizeInputItemID`: drops `OfMessage` items with empty `OfString` before marshaling
- `codex_round_tripper.go` / `sanitizeCodexEmptyContentJSON`: drops `"content": ""` items from the serialized JSON body, with warn-level logging

## Test plan

- [x] `TestSanitizeCodexEmptyContentJSON_DropsEmptyStringContent` — message items with `""` content are dropped; non-message items with empty output are kept
- [x] `TestSanitizeCodexEmptyContentJSON_KeepsNonEmptyContent` — valid messages pass through unchanged
- [x] `TestSanitizeCodexEmptyContentJSON_HighIndex` — reproduces the production failure at `input[1012]`
- [x] All existing `TestSanitizeCodexInputIDsJSON_*` tests still pass
- [x] All `internal/protocol/request` tests pass