### PR TITLE
perf: reduce memory pressure on streaming requests

### DIFF
--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -272,7 +272,7 @@ func (c *OpenAIClient) ListModels(ctx context.Context) ([]string, error) {
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		return nil, fmt.Errorf("provider returned status %d (len=%d)", resp.StatusCode, len(bodyBytes))
 	}
 
 	// Parse response body

--- a/internal/protocol/anthropic.go
+++ b/internal/protocol/anthropic.go
@@ -11,11 +11,11 @@ type (
 	// Request types
 	AnthropicMessagesRequest struct {
 		Stream bool `json:"stream"`
-		anthropic.MessageNewParams
+		*anthropic.MessageNewParams
 	}
 	AnthropicBetaMessagesRequest struct {
 		Stream bool `json:"stream"`
-		anthropic.BetaMessageNewParams
+		*anthropic.BetaMessageNewParams
 	}
 )
 
@@ -52,14 +52,14 @@ func (r AnthropicBetaMessagesRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (r *AnthropicBetaMessagesRequest) UnmarshalJSON(data []byte) error {
-	var inner anthropic.BetaMessageNewParams
+	var inner = &anthropic.BetaMessageNewParams{}
 	aux := &struct {
 		Stream bool `json:"stream"`
 	}{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, &inner); err != nil {
+	if err := json.Unmarshal(data, inner); err != nil {
 		return err
 	}
 	r.Stream = aux.Stream
@@ -68,14 +68,14 @@ func (r *AnthropicBetaMessagesRequest) UnmarshalJSON(data []byte) error {
 }
 
 func (r *AnthropicMessagesRequest) UnmarshalJSON(data []byte) error {
-	var inner anthropic.MessageNewParams
+	var inner = &anthropic.MessageNewParams{}
 	aux := &struct {
 		Stream bool `json:"stream"`
 	}{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, &inner); err != nil {
+	if err := json.Unmarshal(data, inner); err != nil {
 		return err
 	}
 	r.Stream = aux.Stream

--- a/internal/protocol/openai.go
+++ b/internal/protocol/openai.go
@@ -15,7 +15,7 @@ import (
 
 // OpenAIChatCompletionRequest is a type alias for OpenAI chat completion request with extra fields.
 type OpenAIChatCompletionRequest struct {
-	openai.ChatCompletionNewParams
+	*openai.ChatCompletionNewParams
 	Stream bool `json:"stream"`
 }
 
@@ -36,14 +36,14 @@ func (r OpenAIChatCompletionRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (r *OpenAIChatCompletionRequest) UnmarshalJSON(data []byte) error {
-	var inner openai.ChatCompletionNewParams
+	var inner = &openai.ChatCompletionNewParams{}
 	aux := &struct {
 		Stream bool `json:"stream"`
 	}{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, &inner); err != nil {
+	if err := json.Unmarshal(data, inner); err != nil {
 		return err
 	}
 	r.Stream = aux.Stream
@@ -69,7 +69,7 @@ type ResponseCreateRequest struct {
 	Stream bool `json:"stream"`
 
 	// Embed the native SDK type for all other fields
-	responses.ResponseNewParams
+	*responses.ResponseNewParams
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for ResponseCreateRequest
@@ -91,8 +91,8 @@ func (r *ResponseCreateRequest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Then, unmarshal into the embedded ResponseNewParams
-	var inner responses.ResponseNewParams
-	if err := json.Unmarshal(processedData, &inner); err != nil {
+	var inner = &responses.ResponseNewParams{}
+	if err := json.Unmarshal(processedData, inner); err != nil {
 		return err
 	}
 

--- a/internal/protocol/transform/chain.go
+++ b/internal/protocol/transform/chain.go
@@ -204,6 +204,8 @@ func (ctx *TransformContext) configExtraForMetadata() map[string]any {
 func (ctx *TransformContext) Release() {
 	ctx.Request = nil
 	ctx.OriginalRequest = nil
+	ctx.TransformSteps = nil
+	ctx.Extra = nil
 }
 
 // TransformChain manages an ordered sequence of transforms

--- a/internal/protocol/transform/chain.go
+++ b/internal/protocol/transform/chain.go
@@ -201,6 +201,11 @@ func (ctx *TransformContext) configExtraForMetadata() map[string]any {
 	return extra
 }
 
+func (ctx *TransformContext) Release() {
+	ctx.Request = nil
+	ctx.OriginalRequest = nil
+}
+
 // TransformChain manages an ordered sequence of transforms
 type TransformChain struct {
 	// transforms are the ordered transformation steps

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -156,7 +156,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 			return
 		}
 		requestModel = string(betaMessages.Model)
-		reqParams = &betaMessages.BetaMessageNewParams
+		reqParams = betaMessages.BetaMessageNewParams
 
 	} else {
 		if err := json.Unmarshal(bodyBytes, &messages); err != nil {
@@ -172,7 +172,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 		}
 
 		requestModel = string(messages.Model)
-		reqParams = &messages.MessageNewParams
+		reqParams = messages.MessageNewParams
 	}
 
 	// Check if this is the request requestModel name first

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -147,11 +147,11 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 		if err := json.Unmarshal(bodyBytes, &betaMessages); err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
-					Message: fmt.Sprintf("Message error: %s", string(bodyBytes)),
+					Message: fmt.Sprintf("Message decode error: %s", err.Error()),
 					Type:    "invalid_request_error",
 				},
 			})
-			logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic beta decode error")
+			logrus.WithError(err).Errorf("Anthropic beta decode error")
 			c.Abort()
 			return
 		}
@@ -162,11 +162,11 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 		if err := json.Unmarshal(bodyBytes, &messages); err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
-					Message: fmt.Sprintf("Message error: %s", string(bodyBytes)),
+					Message: fmt.Sprintf("Message decode error: %s", err.Error()),
 					Type:    "invalid_request_error",
 				},
 			})
-			logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic decode error")
+			logrus.WithError(err).Errorf("Anthropic decode error")
 			c.Abort()
 			return
 		}

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -119,8 +119,6 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	//	return
 	//}
 
-	c.Set("server_instance", s)
-
 	// Read the raw request body first for debugging purposes
 	bodyBytes, err := c.GetRawData()
 	if err != nil {
@@ -205,11 +203,6 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	if provider.Timeout <= 0 {
 		provider.Timeout = constant.DefaultRequestTimeout
 	}
-
-	// Set the rule and provider in context
-	c.Set("rule", rule)
-
-	// sessionID is automatically stored by SelectService
 
 	actualModel := selectedService.Model
 

--- a/internal/server/anthropic_count_tokens.go
+++ b/internal/server/anthropic_count_tokens.go
@@ -47,7 +47,6 @@ func (s *Server) AnthropicCountTokens(c *gin.Context) {
 	}
 
 	var requestModel string
-	var reqParams interface{} // For smart routing context extraction
 
 	// always use beta for token count
 	var params anthropic.BetaMessageCountTokensParams
@@ -86,7 +85,7 @@ func (s *Server) AnthropicCountTokens(c *gin.Context) {
 		return
 	}
 
-	provider, selectedService, err := s.routingSelector.SelectService(c, scenarioType, rule, reqParams)
+	provider, selectedService, err := s.routingSelector.SelectService(c, scenarioType, rule, nil)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/server/anthropic_count_tokens.go
+++ b/internal/server/anthropic_count_tokens.go
@@ -53,11 +53,11 @@ func (s *Server) AnthropicCountTokens(c *gin.Context) {
 	if err := json.Unmarshal(bodyBytes, &params); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
-				Message: fmt.Sprintf("Message error: %s", string(bodyBytes)),
+				Message: fmt.Sprintf("Message error: %s", err.Error()),
 				Type:    "invalid_request_error",
 			},
 		})
-		logrus.WithError(err).WithField("body", string(bodyBytes)).Errorf("Anthropic beta decode error")
+		logrus.WithError(err).Errorf("Anthropic beta decode error")
 		c.Abort()
 		return
 	}

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -35,7 +35,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 	scenarioConfig := s.config.GetScenarioConfig(scenarioType)
 
 	// Inject session ID into request context so all downstream code can access it
-	sessionID := resolveSessionID(c, &req.BetaMessageNewParams)
+	sessionID := resolveSessionID(c, req.BetaMessageNewParams)
 	c.Request = c.Request.WithContext(typ.WithSessionID(c.Request.Context(), sessionID))
 
 	// Set tracking context with all metadata. Provider/model are refreshed per
@@ -99,7 +99,7 @@ func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req protocol.AnthropicB
 	// Build and run server-side pre-transform chain (scenario-driven flags)
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, requestModel)
 	if err := executeAnthropicBetaPreChain(
-		&req.BetaMessageNewParams, scenarioConfig,
+		req.BetaMessageNewParams, scenarioConfig,
 		s.config.GetDefaultMaxTokens(), maxAllowed, isStreaming,
 	); err != nil {
 		s.failAttemptSetup(c, err)
@@ -109,7 +109,7 @@ func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req protocol.AnthropicB
 	// request guardrails
 	scenario := GetTrackingContextScenario(c)
 	if s.guardrailsEnabledForScenario(scenario) {
-		s.applyGuardrailsToAnthropicV1BetaRequest(c, &req.BetaMessageNewParams, requestModel, provider)
+		s.applyGuardrailsToAnthropicV1BetaRequest(c, req.BetaMessageNewParams, requestModel, provider)
 	}
 
 	// Determine target API type for protocol transformation detection

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -137,6 +137,7 @@ func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req protocol.AnthropicB
 		s.failAttemptSetup(c, err)
 		return
 	}
+	defer reqCtx.Release()
 
 	reqCtx.RequestModel = requestModel
 	reqCtx.ResponseModel = responseModel

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -35,7 +35,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 	scenarioConfig := s.config.GetScenarioConfig(scenarioType)
 
 	// Inject session ID into request context so all downstream code can access it
-	sessionID := resolveSessionID(c, &req.MessageNewParams)
+	sessionID := resolveSessionID(c, req.MessageNewParams)
 	c.Request = c.Request.WithContext(typ.WithSessionID(c.Request.Context(), sessionID))
 
 	// Set tracking context with all metadata. Provider/model are refreshed per
@@ -105,7 +105,7 @@ func (s *Server) runAnthropicV1Attempt(c *gin.Context, req protocol.AnthropicMes
 	// Build and run server-side pre-transform chain (scenario-driven flags)
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, requestModel)
 	if err := executeAnthropicV1PreChain(
-		&req.MessageNewParams, scenarioConfig,
+		req.MessageNewParams, scenarioConfig,
 		s.config.GetDefaultMaxTokens(), maxAllowed, isStreaming,
 	); err != nil {
 		s.failAttemptSetup(c, err)
@@ -114,7 +114,7 @@ func (s *Server) runAnthropicV1Attempt(c *gin.Context, req protocol.AnthropicMes
 
 	scenario := GetTrackingContextScenario(c)
 	if s.guardrailsEnabledForScenario(scenario) {
-		s.applyGuardrailsToAnthropicV1Request(c, &req.MessageNewParams, requestModel, provider)
+		s.applyGuardrailsToAnthropicV1Request(c, req.MessageNewParams, requestModel, provider)
 	}
 
 	// Determine target API type for protocol transformation detection

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -142,6 +142,7 @@ func (s *Server) runAnthropicV1Attempt(c *gin.Context, req protocol.AnthropicMes
 		s.failAttemptSetup(c, err)
 		return
 	}
+	defer reqCtx.Release()
 
 	reqCtx.RequestModel = requestModel
 	reqCtx.ResponseModel = responseModel

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -61,7 +61,6 @@ func NewMultiModeMemoryLogMiddleware(multiLogger *obs.MultiLogger) *MultiModeMem
 // It logs all HTTP requests to both the multi-mode logger and memory
 func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		start := time.Now()
 		path := c.Request.URL.Path
 		raw := c.Request.URL.RawQuery
 
@@ -77,8 +76,6 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 
 		c.Next()
 
-		// Build log entry manually for more control
-		latency := time.Since(start)
 		clientIP := c.ClientIP()
 		method := c.Request.Method
 		statusCode := c.Writer.Status()
@@ -114,7 +111,6 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 			"type":       "http_request",
 			"request_id": requestID,
 			"status":     statusCode,
-			"latency":    latency,
 			"client_ip":  clientIP,
 			"method":     method,
 			"path":       path,
@@ -155,11 +151,10 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		}
 
 		// Log with structured fields including error details
-		m.logger.WithFields(fields).Log(getLogLevel(statusCode), fmt.Sprintf("%s %s %d %v %s %d",
+		m.logger.WithFields(fields).Log(getLogLevel(statusCode), fmt.Sprintf("%s %s %d %s %d",
 			method,
 			path,
 			statusCode,
-			latency,
 			clientIP,
 			bodySize,
 		))

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -75,12 +75,6 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		}
 		c.Set(GinRequestIDKey, requestID)
 
-		// Carry the id on the request context so request-scoped code (protocol
-		// conversion, upstream client calls) can log via logrus.WithContext(ctx);
-		// the MultiLogger hook routes those entries to the model_request source.
-		c.Request = c.Request.WithContext(obs.ContextWithRequestID(c.Request.Context(), requestID))
-
-		// Process request
 		c.Next()
 
 		// Build log entry manually for more control

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -82,7 +82,7 @@ func (s *Server) runOpenAIChatAttempt(c *gin.Context, req protocol.OpenAIChatCom
 	req.Model = actualModel
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
 
-	transform.AlignToolMessagesForOpenAI(&req.ChatCompletionNewParams)
+	transform.AlignToolMessagesForOpenAI(req.ChatCompletionNewParams)
 
 	// === Cap max_tokens at model's maximum ===
 	if req.MaxTokens.Valid() && req.MaxTokens.Value > int64(maxAllowed) {

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -122,6 +122,8 @@ func (s *Server) runOpenAIChatAttempt(c *gin.Context, req protocol.OpenAIChatCom
 		s.failAttemptSetup(c, fmt.Errorf("Transform failed: %w", err))
 		return
 	}
+	defer reqCtx.Release()
+
 	reqCtx.Extra["cursor_compat"] = ruleFlags.CursorCompat
 	reqCtx.Extra["skip_usage"] = ruleFlags.SkipUsage
 

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -250,17 +250,17 @@ func (s *Server) runOpenAIResponsesAttempt(c *gin.Context, req protocol.Response
 
 // convertToResponsesParams converts raw JSON to OpenAI SDK params format
 // This handles the model override and forwards the rest as-is
-func (s *Server) convertToResponsesParams(bodyBytes []byte, actualModel string) (responses.ResponseNewParams, error) {
+func (s *Server) convertToResponsesParams(bodyBytes []byte, actualModel string) (*responses.ResponseNewParams, error) {
 	// Preprocess to add type fields to input items (needed for union deserialization)
 	// and flatten output_text content blocks
 	processedData, err := protocol.PreprocessInputData(bodyBytes)
 	if err != nil {
-		return responses.ResponseNewParams{}, err
+		return nil, err
 	}
 
 	var raw map[string]any
 	if err := json.Unmarshal(processedData, &raw); err != nil {
-		return responses.ResponseNewParams{}, err
+		return nil, err
 	}
 
 	// Override the model
@@ -269,12 +269,12 @@ func (s *Server) convertToResponsesParams(bodyBytes []byte, actualModel string) 
 	// Marshal back to JSON and unmarshal into ResponseNewParams
 	modifiedJSON, err := json.Marshal(raw)
 	if err != nil {
-		return responses.ResponseNewParams{}, err
+		return nil, err
 	}
 
-	var params responses.ResponseNewParams
-	if err := json.Unmarshal(modifiedJSON, &params); err != nil {
-		return responses.ResponseNewParams{}, err
+	var params = &responses.ResponseNewParams{}
+	if err := json.Unmarshal(modifiedJSON, params); err != nil {
+		return nil, err
 	}
 
 	return params, nil

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -239,6 +239,8 @@ func (s *Server) runOpenAIResponsesAttempt(c *gin.Context, req protocol.Response
 		s.failAttemptSetup(c, fmt.Errorf("Transform failed: %w", err))
 		return
 	}
+	defer reqCtx.Release()
+
 	// Carry the response-shaping hints for downstream dispatch, matching the
 	// chat handler (consumed by shouldStripUsage on the conversion sub-paths).
 	reqCtx.Extra["cursor_compat"] = ruleFlags.CursorCompat

--- a/internal/server/openai_responses_vision_test.go
+++ b/internal/server/openai_responses_vision_test.go
@@ -66,11 +66,11 @@ func TestHandleResponsesCreate_VisionProxyAppliesBeforeChatConversion(t *testing
 	req.ResponseNewParams = params
 	req.Model = "downstream-text-only-model"
 	// Vision proxy MUST run after the assignment above — that is the fix.
-	s.applyVisionProxy(newVisionTestGinCtx(), "claude_code", &typ.Rule{}, &req.ResponseNewParams)
+	s.applyVisionProxy(newVisionTestGinCtx(), "claude_code", &typ.Rule{}, req.ResponseNewParams)
 
 	// The conversion step is what DeepSeek receives; assert no image_url
 	// or input_image survives on the wire-level shape.
-	chatParams := request.ConvertOpenAIResponsesToChat(&req.ResponseNewParams, 4096)
+	chatParams := request.ConvertOpenAIResponsesToChat(req.ResponseNewParams, 4096)
 	chatJSON, err := json.Marshal(chatParams)
 	if err != nil {
 		t.Fatalf("marshal chat: %v", err)
@@ -116,7 +116,7 @@ func TestHandleResponsesCreate_VisionProxyBeforeReparseIsIneffective(t *testing.
 		t.Fatalf("unmarshal: %v", err)
 	}
 	// Wrong order: apply BEFORE the re-parse.
-	s.applyVisionProxy(newVisionTestGinCtx(), "claude_code", &typ.Rule{}, &req.ResponseNewParams)
+	s.applyVisionProxy(newVisionTestGinCtx(), "claude_code", &typ.Rule{}, req.ResponseNewParams)
 	params, err := s.convertToResponsesParams(bodyBytes, "downstream-text-only-model")
 	if err != nil {
 		t.Fatalf("convertToResponsesParams: %v", err)
@@ -125,7 +125,7 @@ func TestHandleResponsesCreate_VisionProxyBeforeReparseIsIneffective(t *testing.
 	req.Model = "downstream-text-only-model"
 	// (no second applyVisionProxy — this is what the bug looked like)
 
-	chatParams := request.ConvertOpenAIResponsesToChat(&req.ResponseNewParams, 4096)
+	chatParams := request.ConvertOpenAIResponsesToChat(req.ResponseNewParams, 4096)
 	chatJSON, err := json.Marshal(chatParams)
 	if err != nil {
 		t.Fatalf("marshal chat: %v", err)

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -81,6 +81,10 @@ func (s *Server) dispatchChainResult(
 	rule *typ.Rule, provider *typ.Provider,
 	isStreaming bool, recorder *ProtocolRecorder,
 ) {
+	defer func() {
+		reqCtx.Release()
+	}()
+
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 
 	// Bubble up the execution-level routing decision for probes. This is the

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -50,7 +50,7 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	}
 
 	transformCtx := transform.NewTransformContext(
-		&req.BetaMessageNewParams,
+		req.BetaMessageNewParams,
 		opts...,
 	)
 	transformCtx.HasNativeAdvisor = hasNativeAdvisorBeta(req)
@@ -115,7 +115,7 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	}
 
 	transformCtx := transform.NewTransformContext(
-		&req.MessageNewParams,
+		req.MessageNewParams,
 		opts...,
 	)
 	transformCtx.SourceAPI = protocol.TypeAnthropicV1
@@ -170,7 +170,7 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	}
 
 	transformCtx := transform.NewTransformContext(
-		&req.ChatCompletionNewParams,
+		req.ChatCompletionNewParams,
 		opts...,
 	)
 	transformCtx.SourceAPI = protocol.TypeOpenAIChat
@@ -220,7 +220,7 @@ func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseC
 	}
 
 	transformCtx := transform.NewTransformContext(
-		&req.ResponseNewParams,
+		req.ResponseNewParams,
 		opts...,
 	)
 	transformCtx.SourceAPI = protocol.TypeOpenAIResponses

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -60,10 +60,6 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	// Execute transform chain
 	finalCtx, err := chain.Execute(transformCtx)
 	if err != nil {
-		if protocolRecorder != nil {
-			protocolRecorder.SetTransformSteps(finalCtx.TransformSteps)
-			protocolRecorder.RecordError(err)
-		}
 		return nil, err
 	}
 

--- a/internal/server/request_clone.go
+++ b/internal/server/request_clone.go
@@ -49,12 +49,12 @@ func cloneOpenAIChatRequest(template []byte) (protocol.OpenAIChatCompletionReque
 // and unmarshals the SDK struct directly — NOT through ResponseCreateRequest,
 // whose UnmarshalJSON re-runs PreprocessInputData (input-item type injection)
 // that has already been applied to the template.
-func cloneResponsesParams(template responses.ResponseNewParams) (responses.ResponseNewParams, error) {
+func cloneResponsesParams(template *responses.ResponseNewParams) (*responses.ResponseNewParams, error) {
 	b, err := json.Marshal(template)
 	if err != nil {
-		return responses.ResponseNewParams{}, err
+		return nil, err
 	}
 	var out responses.ResponseNewParams
 	err = json.Unmarshal(b, &out)
-	return out, err
+	return &out, err
 }

--- a/internal/server/system_log_handler.go
+++ b/internal/server/system_log_handler.go
@@ -88,7 +88,7 @@ func (s *Server) GetSystemLogStats(c *gin.Context) {
 	logPath := s.multiLogger.GetJSONLogPath()
 
 	// Read all logs to calculate stats (with a reasonable limit, system source only)
-	entries, err := s.multiLogger.ReadJSONLogs(10000)
+	entries, err := s.multiLogger.ReadJSONLogs(500)
 	if err != nil {
 		logrus.Errorf("Failed to read system logs for stats: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/pkg/obs/multi_logger.go
+++ b/pkg/obs/multi_logger.go
@@ -126,13 +126,13 @@ func DefaultMultiLoggerConfig(configDir string) *MultiLoggerConfig {
 		JSONMaxBackups: 3,
 		JSONMaxAge:     7,
 
-		// Default memory sink sizes
+		// Default memory sink sizes - reduced to limit memory usage
 		MemorySinkConfig: map[LogSource]MemorySinkConfig{
-			LogSourceHTTP:         {MaxEntries: 1000}, // HTTP requests: high volume
-			LogSourceSystem:       {MaxEntries: 500},  // System logs: medium volume
-			LogSourceAction:       {MaxEntries: 100},  // User actions: low volume, important
-			LogSourceSmartRouting: {MaxEntries: 500},  // Smart routing evaluations: per-request
-			LogSourceModelRequest: {MaxEntries: 1000}, // Model request stages: aligned with HTTP envelope
+			LogSourceHTTP:         {MaxEntries: 50}, // HTTP requests: high volume, reduced from 1000
+			LogSourceSystem:       {MaxEntries: 50}, // System logs: medium volume, reduced from 500
+			LogSourceAction:       {MaxEntries: 50}, // User actions: low volume, reduced from 100
+			LogSourceSmartRouting: {MaxEntries: 50}, // Smart routing evaluations: per-request, reduced from 500
+			LogSourceModelRequest: {MaxEntries: 50}, // Model request stages: reduced from 1000
 		},
 	}
 }

--- a/vmodel/anthropic/transform_model.go
+++ b/vmodel/anthropic/transform_model.go
@@ -50,7 +50,7 @@ func (m *TransformModel) HandleAnthropicStream(req *protocol.AnthropicBetaMessag
 
 // HandleAnthropic applies Chain then Transformer to req in-place and returns the response.
 func (m *TransformModel) HandleAnthropic(req *protocol.AnthropicBetaMessagesRequest) (VModelResponse, error) {
-	ctx := transform.NewTransformContext(&req.BetaMessageNewParams)
+	ctx := transform.NewTransformContext(req.BetaMessageNewParams)
 
 	if m.cfg.Chain != nil {
 		if _, err := m.cfg.Chain.Execute(ctx); err != nil {

--- a/vmodel/client/anthropic.go
+++ b/vmodel/client/anthropic.go
@@ -28,11 +28,11 @@ func NewAnthropicClient(reg *anthropicvm.Registry, provider *typ.Provider) *Anth
 	return &AnthropicClient{reg: reg, provider: provider}
 }
 
-func (c *AnthropicClient) GetProvider() *typ.Provider        { return c.provider }
-func (c *AnthropicClient) APIStyle() protocol.APIStyle       { return protocol.APIStyleAnthropic }
-func (c *AnthropicClient) SetRecordSink(_ *obs.Sink)         {}
-func (c *AnthropicClient) Client() *anthropic.Client         { return nil }
-func (c *AnthropicClient) Close() error                      { return nil }
+func (c *AnthropicClient) GetProvider() *typ.Provider  { return c.provider }
+func (c *AnthropicClient) APIStyle() protocol.APIStyle { return protocol.APIStyleAnthropic }
+func (c *AnthropicClient) SetRecordSink(_ *obs.Sink)   {}
+func (c *AnthropicClient) Client() *anthropic.Client   { return nil }
+func (c *AnthropicClient) Close() error                { return nil }
 
 func (c *AnthropicClient) ListModels(_ context.Context) ([]string, error) {
 	models := c.reg.ListModels()
@@ -55,7 +55,7 @@ func (c *AnthropicClient) BetaMessagesNew(_ context.Context, req *anthropic.Beta
 	}
 
 	vmReq := &protocol.AnthropicBetaMessagesRequest{
-		BetaMessageNewParams: *req,
+		BetaMessageNewParams: req,
 	}
 
 	resp, err := vm.HandleAnthropic(vmReq)
@@ -147,7 +147,7 @@ func (c *AnthropicClient) betaStreamDecoder(req *anthropic.BetaMessageNewParams)
 	if err := injectedPreContentError(vm); err != nil {
 		return nil, err
 	}
-	return newAnthropicVModelDecoder(vm, &protocol.AnthropicBetaMessagesRequest{BetaMessageNewParams: *req}), nil
+	return newAnthropicVModelDecoder(vm, &protocol.AnthropicBetaMessagesRequest{BetaMessageNewParams: req}), nil
 }
 
 // v1ToBetaParams converts MessageNewParams → BetaMessageNewParams via JSON
@@ -369,10 +369,10 @@ func (d *anthropicVModelDecoder) Err() error   { return d.err }
 // anthropicErrDecoder is a no-op decoder that immediately returns an error.
 type anthropicErrDecoder struct{ err error }
 
-func (e anthropicErrDecoder) Next() bool                    { return false }
-func (e anthropicErrDecoder) Event() anthropicstream.Event  { return anthropicstream.Event{} }
-func (e anthropicErrDecoder) Close() error                  { return nil }
-func (e anthropicErrDecoder) Err() error                    { return e.err }
+func (e anthropicErrDecoder) Next() bool                   { return false }
+func (e anthropicErrDecoder) Event() anthropicstream.Event { return anthropicstream.Event{} }
+func (e anthropicErrDecoder) Close() error                 { return nil }
+func (e anthropicErrDecoder) Err() error                   { return e.err }
 
 // ── content conversion helpers ────────────────────────────────────────────────
 

--- a/vmodel/client/openai.go
+++ b/vmodel/client/openai.go
@@ -33,11 +33,11 @@ func NewOpenAIClient(reg *openaivm.Registry, provider *typ.Provider) *OpenAIClie
 	return &OpenAIClient{reg: reg, provider: provider}
 }
 
-func (c *OpenAIClient) GetProvider() *typ.Provider          { return c.provider }
-func (c *OpenAIClient) APIStyle() protocol.APIStyle         { return protocol.APIStyleOpenAI }
-func (c *OpenAIClient) SetRecordSink(_ *obs.Sink)           {}
-func (c *OpenAIClient) Client() *openai.Client              { return nil }
-func (c *OpenAIClient) Close() error                        { return nil }
+func (c *OpenAIClient) GetProvider() *typ.Provider  { return c.provider }
+func (c *OpenAIClient) APIStyle() protocol.APIStyle { return protocol.APIStyleOpenAI }
+func (c *OpenAIClient) SetRecordSink(_ *obs.Sink)   {}
+func (c *OpenAIClient) Client() *openai.Client      { return nil }
+func (c *OpenAIClient) Close() error                { return nil }
 
 func (c *OpenAIClient) ListModels(_ context.Context) ([]string, error) {
 	models := c.reg.ListModels()
@@ -60,7 +60,7 @@ func (c *OpenAIClient) ChatCompletionsNew(_ context.Context, req openai.ChatComp
 	}
 
 	vmReq := &protocol.OpenAIChatCompletionRequest{
-		ChatCompletionNewParams: req,
+		ChatCompletionNewParams: &req,
 	}
 
 	resp, err := vm.HandleOpenAIChat(vmReq)
@@ -75,8 +75,8 @@ func (c *OpenAIClient) ChatCompletionsNew(_ context.Context, req openai.ChatComp
 	var toolCalls []map[string]interface{}
 	for i, tc := range resp.ToolCalls {
 		toolCalls = append(toolCalls, map[string]interface{}{
-			"id":   tc.ID,
-			"type": "function",
+			"id":    tc.ID,
+			"type":  "function",
 			"index": i,
 			"function": map[string]interface{}{
 				"name":      tc.Name,
@@ -135,7 +135,7 @@ func (c *OpenAIClient) ChatCompletionsNewStreaming(_ context.Context, req openai
 	}
 
 	vmReq := &protocol.OpenAIChatCompletionRequest{
-		ChatCompletionNewParams: req,
+		ChatCompletionNewParams: &req,
 	}
 
 	dec := newOpenAIVModelDecoder(vm, vmReq)
@@ -328,7 +328,7 @@ func (d *openAIVModelDecoder) Err() error   { return d.err }
 // errDecoder is a no-op decoder that immediately returns an error from Err().
 type errDecoder struct{ err error }
 
-func (e errDecoder) Next() bool               { return false }
+func (e errDecoder) Next() bool                { return false }
 func (e errDecoder) Event() openaistream.Event { return openaistream.Event{} }
-func (e errDecoder) Close() error             { return nil }
-func (e errDecoder) Err() error               { return e.err }
+func (e errDecoder) Close() error              { return nil }
+func (e errDecoder) Err() error                { return e.err }


### PR DESCRIPTION
## Problem

Go pprof heap profiles showed ~250 MB (~86% of live heap) pinned by gjson/apijson decoders — the parsed request body was held alive for the entire duration of each streaming response. Under concurrent streams this becomes: memory ≈ streams × request body size.

## Changes

### Request lifecycle
- `TransformContext.Release()`: nils the request pointer after dispatch, releasing the parsed body for GC. Called via `defer` at the end of each attempt in both the v1 and beta handlers.
- Remove unnecessary request copies that added allocation overhead with no benefit.
- Remove useless context `Set` calls that kept extra references alive.

### Logging
- Strip full request body logging from AI model requests (was retaining the body in log buffers).
- Cap in-memory log entries to 50 per source (`multi_mode_memory_log`).
- Reduce log read count in middleware.

### Submodules
- Update `libs/anthropic-sdk-go` and `libs/openai-go` with patches that avoid internal OOM in the SDK decoders.

### Refactor
- Unify protocol request/response types to use pointers consistently.

---

may help to resolve #1255 