### PR TITLE
Release stream and Anthropic SDK request state to prevent heap retention

### DIFF
--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -104,6 +104,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 	httpClient := &http.Client{
 		Transport: transport,
 	}
+	httpClient.Transport = wrapWithStreamRequestRelease(httpClient.Transport)
 	options = append(options, anthropicOption.WithHTTPClient(httpClient))
 
 	// MENTION: extra will be applied at last to confirm override

--- a/internal/client/stream_request_release.go
+++ b/internal/client/stream_request_release.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"net/http"
+	"strings"
+)
+
+// streamRequestReleaseTransport drops retry-body state from the response's
+// request once the outbound HTTP request has been accepted by the transport.
+//
+// The Anthropic SDK builds streaming requests by JSON-marshaling params into a
+// bytes.Buffer and then installing Request.GetBody closures over that byte
+// slice. The SDK's SSE decoder keeps the *http.Response reachable for rich
+// streaming errors, and http.Response.Request then keeps the request body bytes
+// reachable until the stream object is collected. Large beta requests therefore
+// show up in pprof under BetaMessagesNewStreaming -> BetaMessageNewParams.MarshalJSON.
+//
+// For successful SSE responses the request has already been accepted and there
+// will be no SDK retry, so retaining Body/GetBody on the response-side request
+// only increases heap retention. Headers, method and URL remain intact for
+// error reporting.
+type streamRequestReleaseTransport struct {
+	base http.RoundTripper
+}
+
+func (t *streamRequestReleaseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	resp, err := base.RoundTrip(req)
+	if isSuccessfulEventStreamResponse(resp) {
+		clearResponseRequestBody(resp)
+	}
+	return resp, err
+}
+
+func isSuccessfulEventStreamResponse(resp *http.Response) bool {
+	if resp == nil || resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return false
+	}
+	return strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/event-stream")
+}
+
+func clearResponseRequestBody(resp *http.Response) {
+	if resp == nil || resp.Request == nil {
+		return
+	}
+	resp.Request.Body = nil
+	resp.Request.GetBody = nil
+	resp.Request.ContentLength = 0
+}
+
+func wrapWithStreamRequestRelease(inner http.RoundTripper) http.RoundTripper {
+	return &streamRequestReleaseTransport{base: inner}
+}

--- a/internal/client/stream_request_release_test.go
+++ b/internal/client/stream_request_release_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type streamRequestReleaseRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f streamRequestReleaseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestStreamRequestReleaseTransportClearsResponseRequestBody(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("large marshaled request body"))
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/v1/messages", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("large marshaled request body")), nil
+	}
+	req.ContentLength = int64(len("large marshaled request body"))
+
+	wrapped := &streamRequestReleaseTransport{base: streamRequestReleaseRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader("event: message_stop\ndata: {}\n\n")),
+			Request:    req,
+		}, nil
+	})}
+
+	resp, err := wrapped.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Request == nil {
+		t.Fatal("expected response request metadata to remain available")
+	}
+	if resp.Request.Body != nil {
+		t.Fatal("expected response request body to be cleared")
+	}
+	if resp.Request.GetBody != nil {
+		t.Fatal("expected response request GetBody closure to be cleared")
+	}
+	if resp.Request.ContentLength != 0 {
+		t.Fatalf("expected response request content length to be reset, got %d", resp.Request.ContentLength)
+	}
+	if resp.Request.Method != http.MethodPost || resp.Request.URL.String() != "https://example.test/v1/messages" {
+		t.Fatalf("expected method and URL to remain for error reporting, got %s %s", resp.Request.Method, resp.Request.URL.String())
+	}
+}
+
+func TestStreamRequestReleaseTransportKeepsRetryableErrorBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/v1/messages", io.NopCloser(strings.NewReader("body")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("body")), nil }
+
+	wrapped := &streamRequestReleaseTransport{base: streamRequestReleaseRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+			Request:    req,
+		}, nil
+	})}
+
+	resp, err := wrapped.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Request.Body == nil {
+		t.Fatal("expected retryable non-SSE response request body to remain available")
+	}
+	if resp.Request.GetBody == nil {
+		t.Fatal("expected retryable non-SSE response request GetBody to remain available")
+	}
+}

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -259,3 +259,18 @@ func (a *AnthropicStreamAssembler) Finish(model string, inputTokens, outputToken
 		Usage:        *usage,
 	}
 }
+
+// Reset releases accumulated stream response state held by the assembler.
+func (a *AnthropicStreamAssembler) Reset() {
+	if a == nil {
+		return
+	}
+	a.msgID = ""
+	a.msgType = ""
+	a.msgRole = ""
+	a.stopReason = ""
+	a.stopSeq = ""
+	a.usageData = nil
+	a.blocks = nil
+	a.toolInputBuf = nil
+}

--- a/internal/protocol/context.go
+++ b/internal/protocol/context.go
@@ -134,6 +134,8 @@ func (hc *HandleContext) SetupSSEHeaders() {
 // or (false, err, nil) on error.
 // handleFunc is called for each event after OnStreamEventHooks are invoked.
 func (hc *HandleContext) ProcessStream(nextFunc func() (bool, error, interface{}), handleFunc func(interface{}) error) error {
+	defer hc.ReleaseStreamState()
+
 	c := hc.GinContext
 
 	if _, ok := c.Writer.(http.Flusher); !ok {
@@ -198,6 +200,23 @@ func (hc *HandleContext) ProcessStream(nextFunc func() (bool, error, interface{}
 }
 
 // DispatchStreamError calls all OnStreamError hooks.
+
+// ReleaseStreamState drops per-stream hooks and guardrail buffers after a stream
+// has completed or errored. Hook closures often capture assemblers/recorders that
+// aggregate response chunks; clearing them prevents protocol stream response
+// state from staying reachable through a HandleContext after request completion.
+func (hc *HandleContext) ReleaseStreamState() {
+	if hc == nil {
+		return
+	}
+	hc.OnStreamEventHooks = nil
+	hc.OnStreamCompleteHooks = nil
+	hc.OnStreamErrorHooks = nil
+	if hc.Guardrails != nil {
+		hc.Guardrails.Stream = nil
+	}
+}
+
 func (hc *HandleContext) DispatchStreamError(err error) {
 	for _, hook := range hc.OnStreamErrorHooks {
 		hook(err)

--- a/internal/protocol/context_test.go
+++ b/internal/protocol/context_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewHandleContext(t *testing.T) {
@@ -136,8 +137,8 @@ func TestHandleContext_Chaining(t *testing.T) {
 
 func TestSetupSSEHeaders(t *testing.T) {
 	tests := []struct {
-		name          string
-		checkHeader   func(*testing.T, http.Header)
+		name        string
+		checkHeader func(*testing.T, http.Header)
 	}{
 		{
 			name: "sets correct SSE headers",
@@ -279,25 +280,24 @@ func TestIsContextCanceled(t *testing.T) {
 	})
 }
 
-
 func TestErrorResponse(t *testing.T) {
 	tests := []struct {
-		name     string
-		message  string
+		name      string
+		message   string
 		errorType string
-		code     string
+		code      string
 	}{
 		{
-			name:     "basic error response",
-			message:  "Something went wrong",
+			name:      "basic error response",
+			message:   "Something went wrong",
 			errorType: "api_error",
-			code:     "invalid_request",
+			code:      "invalid_request",
 		},
 		{
-			name:     "error without code",
-			message:  "Another error",
+			name:      "error without code",
+			message:   "Another error",
 			errorType: "validation_error",
-			code:     "",
+			code:      "",
 		},
 	}
 
@@ -317,4 +317,20 @@ func TestErrorResponse(t *testing.T) {
 			assert.Equal(t, tt.code, resp.Error.Code)
 		})
 	}
+}
+
+func TestHandleContext_ReleaseStreamStateDropsResponseHooks(t *testing.T) {
+	hc := NewHandleContext(nil, "model")
+	hc.WithOnStreamEvent(func(event interface{}) error { return nil })
+	hc.WithOnStreamComplete(func() {})
+	hc.WithOnStreamError(func(err error) {})
+	hc.EnsureGuardrailsStream().AnthropicToolEvents[0] = []GuardrailsBufferedEvent{{EventType: "content_block_delta"}}
+
+	hc.ReleaseStreamState()
+
+	assert.Nil(t, hc.OnStreamEventHooks)
+	assert.Nil(t, hc.OnStreamCompleteHooks)
+	assert.Nil(t, hc.OnStreamErrorHooks)
+	require.NotNil(t, hc.Guardrails)
+	assert.Nil(t, hc.Guardrails.Stream)
 }

--- a/internal/protocol/gjson_retention_test.go
+++ b/internal/protocol/gjson_retention_test.go
@@ -210,3 +210,63 @@ func TestLargeRequestRetention(t *testing.T) {
 	t.Logf("single 512KB request retains %.2f MB while the parsed struct is held",
 		float64(after.HeapAlloc-before.HeapAlloc)/1024/1024)
 }
+
+// TestReleaseAnthropicBetaMessagesRequestReducesRetention is the regression
+// proof for request-end cleanup. It intentionally keeps the outer request
+// wrappers reachable after the simulated request has ended:
+//
+//   - unreleased wrappers retain the SDK params and therefore the gjson/apijson
+//     raw JSON metadata for each parsed request body;
+//   - released wrappers remain reachable, but their embedded SDK params are
+//     cleared, so the body-sized raw metadata can be collected.
+func TestReleaseAnthropicBetaMessagesRequestReducesRetention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heap-measurement regression in short mode")
+	}
+
+	const (
+		iterations  = 500
+		fillerBytes = 32 * 1024
+	)
+	body := buildAnthropicBetaBody(fillerBytes)
+
+	measure := func(release bool) float64 {
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		sink := make([]*AnthropicBetaMessagesRequest, 0, iterations)
+		for i := 0; i < iterations; i++ {
+			req := &AnthropicBetaMessagesRequest{}
+			if err := json.Unmarshal(body, req); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+			if release {
+				ReleaseAnthropicBetaMessagesRequest(req)
+			}
+			sink = append(sink, req)
+		}
+
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+		runtime.KeepAlive(sink)
+
+		growth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+		if growth < 0 {
+			growth = 0
+		}
+		return float64(growth) / 1024 / 1024
+	}
+
+	unreleased := measure(false)
+	released := measure(true)
+
+	t.Logf("retained after request end, unreleased wrappers: %.1f MB", unreleased)
+	t.Logf("retained after request end, released wrappers  : %.1f MB", released)
+
+	const minDropMB = 8.0
+	if unreleased-released < minDropMB {
+		t.Fatalf("release did not reduce retained heap enough: unreleased=%.1fMB released=%.1fMB", unreleased, released)
+	}
+}

--- a/internal/protocol/release.go
+++ b/internal/protocol/release.go
@@ -1,0 +1,25 @@
+package protocol
+
+import "github.com/anthropics/anthropic-sdk-go"
+
+// ReleaseAnthropicBetaMessageParams clears Anthropic beta SDK params once the
+// caller no longer needs the request. The SDK decoder stores gjson/apijson raw
+// JSON metadata inside these params; keeping them reachable after forwarding can
+// keep the original request-sized JSON alive after the HTTP request has ended.
+func ReleaseAnthropicBetaMessageParams(req *anthropic.BetaMessageNewParams) {
+	if req != nil {
+		*req = anthropic.BetaMessageNewParams{}
+	}
+}
+
+// ReleaseAnthropicBetaMessagesRequest clears the parsed beta request wrapper and
+// drops the embedded SDK params pointer, so request-end cleanup releases the raw
+// JSON metadata retained by the SDK decoder.
+func ReleaseAnthropicBetaMessagesRequest(req *AnthropicBetaMessagesRequest) {
+	if req == nil {
+		return
+	}
+	ReleaseAnthropicBetaMessageParams(req.BetaMessageNewParams)
+	req.BetaMessageNewParams = nil
+	req.Stream = false
+}

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -208,7 +208,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 
 	// Delegate to the appropriate implementation based on beta parameter
 	if beta {
-		s.AnthropicMessagesV1Beta(c, betaMessages, actualModel, requestModel, rule, provider)
+		s.AnthropicMessagesV1Beta(c, &betaMessages, actualModel, requestModel, rule, provider)
 
 	} else {
 		s.AnthropicMessagesV1(c, messages, actualModel, requestModel, rule, provider)

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -23,7 +23,9 @@ import (
 // Like AnthropicMessagesV1, the provider-independent prologue runs once and the
 // per-attempt callback re-runs the provider-dependent pipeline so failover can
 // rotate across heterogeneous API styles.
-func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, requestModel string, responseModel string, rule *typ.Rule, provider *typ.Provider) {
+func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, requestModel string, responseModel string, rule *typ.Rule, provider *typ.Provider) {
+	defer protocol.ReleaseAnthropicBetaMessagesRequest(req)
+
 	// ── One-time prologue (provider-independent) ──
 
 	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex.
@@ -74,7 +76,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 					s.failAttemptSetup(c, err)
 					return
 				}
-				areq = cloned
+				areq = &cloned
 			}
 			s.runAnthropicBetaAttempt(c, areq, responseModel, p, retryModel, rule, isStreaming, scenarioType, scenarioConfig, recorder)
 		})
@@ -82,7 +84,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 
 // runAnthropicBetaAttempt executes the provider-dependent half of an Anthropic
 // beta request for one failover attempt. See runAnthropicV1Attempt.
-func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *ProtocolRecorder) {
+func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *ProtocolRecorder) {
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)
@@ -158,11 +160,27 @@ func (s *Server) streamAnthropicBeta(c *gin.Context, req *anthropic.BetaMessageN
 	scenario := GetTrackingContextScenario(c)
 	if s.guardrailsEnabledForScenario(scenario) {
 		hc.EnsureGuardrails().Enabled = true
-		s.attachGuardrailsHooks(c, hc, actualModel, provider, guardrailsadapter.AdaptMessagesFromAnthropicV1Beta(req.System, req.Messages))
+		// Build the compact guardrail view before releasing the SDK request. The
+		// SDK request carries apijson/gjson raw metadata that pins the full request
+		// body; keeping it throughout a long stream is the pprof-visible leak
+		// catalyst on Anthropic beta passthrough traffic.
+		guardrailMessages := guardrailsadapter.AdaptMessagesFromAnthropicV1Beta(req.System, req.Messages)
+		s.attachGuardrailsHooks(c, hc, actualModel, provider, guardrailMessages)
 	}
+
+	releaseAnthropicBetaRequest(req)
 
 	usageStat, err := stream.HandleAnthropicBeta(hc, streamResp)
 	s.trackUsageWithTokenUsage(c, usageStat, err)
+}
+
+// releaseAnthropicBetaRequest drops the parsed SDK request immediately after
+// the upstream streaming request has been created and all local hooks have copied
+// the small data they still need. Anthropic SDK params retain gjson.Raw metadata
+// for the whole decoded JSON body; if the params remain reachable for the whole
+// stream, concurrent long streams accumulate body-sized live heap.
+func releaseAnthropicBetaRequest(req *anthropic.BetaMessageNewParams) {
+	protocol.ReleaseAnthropicBetaMessageParams(req)
 }
 
 // nonstreamResponsesToAnthropicBeta handles non-streaming Responses API request

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -318,6 +318,24 @@ func (sr *ProtocolRecorder) emit(err error) {
 	}
 
 	sr.sink.Emit(r)
+	sr.releaseAfterEmit()
+}
+
+// releaseAfterEmit drops per-request recorder state once the obs.Record has
+// been handed to the sink. This prevents completed protocol stream responses
+// from remaining reachable through gin.Context keys or recorder references; the
+// emitted record owns whatever payload the selected record mode intentionally
+// preserves.
+func (sr *ProtocolRecorder) releaseAfterEmit() {
+	if sr == nil {
+		return
+	}
+	sr.streamChunks = nil
+	sr.originalRequest = nil
+	sr.transformedRequest = nil
+	sr.finalResponse = nil
+	sr.transformSteps = nil
+	sr.c = nil
 }
 
 // resolveRequestID returns the request correlation id established by the

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicBeta(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
@@ -53,7 +53,7 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 		req.BetaMessageNewParams,
 		opts...,
 	)
-	transformCtx.HasNativeAdvisor = hasNativeAdvisorBeta(req)
+	transformCtx.HasNativeAdvisor = hasNativeAdvisorBeta(*req)
 	transformCtx.SourceAPI = protocol.TypeAnthropicBeta
 	transformCtx.TargetAPI = target
 

--- a/internal/server/recording_hooks.go
+++ b/internal/server/recording_hooks.go
@@ -172,6 +172,7 @@ func AttachRecorderHooks(hc *protocol.HandleContext, recorder *ProtocolRecorder,
 		return nil
 	})
 	hc.WithOnStreamComplete(func() {
+		defer asm.Reset()
 		if msg := asm.Finish(model, 0, 0); msg != nil {
 			recorder.SetAssembledResponse(msg)
 		}

--- a/internal/server/recording_hooks_test.go
+++ b/internal/server/recording_hooks_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -271,4 +272,36 @@ func ctxWithTimeout(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+func TestAttachRecorderHooks_ReleasesResponseSideStateAfterEmit(t *testing.T) {
+	const scenario = typ.RuleScenario("test")
+	s, mem := newRecordingTestServer(t, scenario, obs.RecordModeAll)
+	c, _ := newRecordingTestContext(t, []byte(`{}`))
+
+	provider := &typ.Provider{Name: "p"}
+	recorder := s.EnsureProtocolRecorder(c, string(scenario), provider, "m", obs.RecordModeAll, nil)
+	require.NotNil(t, recorder)
+
+	hc := protocol.NewHandleContext(c, "rm")
+	AttachRecorderHooks(hc, recorder, "m", provider)
+
+	largeDelta := strings.Repeat("x", 64*1024)
+	events := []*anthropic.BetaRawMessageStreamEventUnion{
+		{Type: "message_start", Message: anthropic.BetaMessage{ID: "msg_release"}},
+		{Type: "content_block_start", Index: 0, ContentBlock: anthropic.BetaRawContentBlockStartEventContentBlockUnion{Type: "text"}},
+		{Type: "content_block_delta", Index: 0, Delta: anthropic.BetaRawMessageStreamEventUnionDelta{Type: "text_delta", Text: largeDelta}},
+		{Type: "content_block_stop", Index: 0},
+		{Type: "message_stop"},
+	}
+	require.NoError(t, driveBetaStream(hc, events))
+
+	require.NoError(t, s.scenarioRecordSinks[scenario].ForceFlush(ctxWithTimeout(t)))
+	require.Len(t, mem.snapshot(), 1)
+
+	assert.Nil(t, recorder.streamChunks, "emitted recorder must not retain raw stream chunks")
+	assert.Nil(t, recorder.finalResponse, "emitted recorder must not retain assembled response")
+	assert.Nil(t, recorder.originalRequest, "emitted recorder must not retain request body")
+	assert.Nil(t, recorder.transformedRequest, "emitted recorder must not retain transformed request")
+	assert.Nil(t, recorder.c, "emitted recorder must not retain gin context")
 }


### PR DESCRIPTION
### Motivation

- Prevent long-lived retention of large request bodies and stream buffers caused by Anthropic SDK `gjson/apijson` raw metadata and assembler/recorder closures remaining reachable after a stream or request ends.
- Ensure per-stream hooks, guardrail buffers and recorder state are dropped promptly when streams complete or records are emitted to avoid accumulating live heap during long-running streams.

### Description

- Added `ReleaseAnthropicBetaMessageParams` and `ReleaseAnthropicBetaMessagesRequest` in `internal/protocol/release.go` to clear Anthropic SDK params that hold raw JSON metadata.
- Changed Anthropic beta request handling to use `*protocol.AnthropicBetaMessagesRequest` (pass `&betaMessages`) and `defer protocol.ReleaseAnthropicBetaMessagesRequest(req)` so parsed SDK params are released at request end; added an immediate `releaseAnthropicBetaRequest` call in `streamAnthropicBeta` after guardrail data is copied.
- Added `HandleContext.ReleaseStreamState()` and added `defer hc.ReleaseStreamState()` to `ProcessStream` to clear per-stream hooks and guardrail stream buffers after completion or error.
- Added `AnthropicStreamAssembler.Reset()` and invoke it when stream completion finalizes the recorder, and added `ProtocolRecorder.releaseAfterEmit()` to drop recorder internals after emitting a record (called from `emit`).
- Adjusted transform and handler signatures to accept pointer request types and updated `hasNativeAdvisorBeta` usage accordingly.
- Added/updated tests and small test cleanups, including `TestHandleContext_ReleaseStreamStateDropsResponseHooks`, `TestAttachRecorderHooks_ReleasesResponseSideStateAfterEmit`, and the heap-regression `TestReleaseAnthropicBetaMessagesRequestReducesRetention` (skips in `-short`).

### Testing

- Added unit tests `TestHandleContext_ReleaseStreamStateDropsResponseHooks` and `TestAttachRecorderHooks_ReleasesResponseSideStateAfterEmit`, both of which passed in CI runs.
- Added memory regression test `TestReleaseAnthropicBetaMessagesRequestReducesRetention` which is skipped in `-short` mode and was used to validate that `ReleaseAnthropicBetaMessagesRequest` reduces retained heap when executed.
- Existing recorder/stream tests were exercised and updated accordingly, and the updated test suite passed in automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7c79ede4832a9abd4e0030b9e36e)