### PR TITLE
refactor(protocol,server): pointer receivers and stream-state cleanup

### DIFF
--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -17,6 +17,9 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// guard
+var _ AnthropicClientInterface = (*ClaudeClient)(nil)
+
 // ClaudeClient wraps AnthropicClient with Claude Code OAuth-specific behaviors.
 // It creates an Anthropic SDK client directly with Claude Code headers and middleware,
 // then embeds it for delegation.

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -19,6 +19,9 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// guard
+var _ OpenAIClientInterface = (*CodexClient)(nil)
+
 // CodexClient wraps OpenAIClient with Codex-specific behaviors.
 // It embeds OpenAIClient to inherit standard OpenAI API functionality,
 // while overriding methods that require special handling for ChatGPT backend API.

--- a/internal/client/kimi_client.go
+++ b/internal/client/kimi_client.go
@@ -19,6 +19,9 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// guard
+var _ OpenAIClientInterface = (*KimiClient)(nil)
+
 // KimiClient wraps OpenAIClient with Kimi-specific behaviors.
 // It embeds OpenAIClient to inherit standard OpenAI API functionality,
 // while applying Kimi-specific normalization before requests.

--- a/internal/protocol/anthropic.go
+++ b/internal/protocol/anthropic.go
@@ -18,7 +18,7 @@ type (
 	}
 )
 
-func (r AnthropicMessagesRequest) MarshalJSON() ([]byte, error) {
+func (r *AnthropicMessagesRequest) MarshalJSON() ([]byte, error) {
 	var m map[string]any
 
 	if r.MessageNewParams != nil {
@@ -39,7 +39,7 @@ func (r AnthropicMessagesRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (r AnthropicBetaMessagesRequest) MarshalJSON() ([]byte, error) {
+func (r *AnthropicBetaMessagesRequest) MarshalJSON() ([]byte, error) {
 	var m map[string]any
 
 	if r.BetaMessageNewParams != nil {

--- a/internal/protocol/anthropic.go
+++ b/internal/protocol/anthropic.go
@@ -8,7 +8,6 @@ import (
 
 // Use official Anthropic SDK types directly
 type (
-	// Request types
 	AnthropicMessagesRequest struct {
 		Stream bool `json:"stream"`
 		*anthropic.MessageNewParams
@@ -20,65 +19,77 @@ type (
 )
 
 func (r AnthropicMessagesRequest) MarshalJSON() ([]byte, error) {
-	inner, err := json.Marshal(r.MessageNewParams)
-	if err != nil {
-		return nil, err
+	var m map[string]any
+
+	if r.MessageNewParams != nil {
+		b, err := json.Marshal(r.MessageNewParams)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+	} else {
+		m = make(map[string]any)
 	}
-	if !r.Stream {
-		return inner, nil
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(inner, &raw); err != nil {
-		return nil, err
-	}
-	raw["stream"] = json.RawMessage("true")
-	return json.Marshal(raw)
+
+	m["stream"] = r.Stream
+
+	return json.Marshal(m)
 }
 
 func (r AnthropicBetaMessagesRequest) MarshalJSON() ([]byte, error) {
-	inner, err := json.Marshal(r.BetaMessageNewParams)
-	if err != nil {
-		return nil, err
+	var m map[string]any
+
+	if r.BetaMessageNewParams != nil {
+		b, err := json.Marshal(r.BetaMessageNewParams)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+	} else {
+		m = make(map[string]any)
 	}
-	if !r.Stream {
-		return inner, nil
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(inner, &raw); err != nil {
-		return nil, err
-	}
-	raw["stream"] = json.RawMessage("true")
-	return json.Marshal(raw)
+
+	m["stream"] = r.Stream
+
+	return json.Marshal(m)
 }
 
 func (r *AnthropicBetaMessagesRequest) UnmarshalJSON(data []byte) error {
-	var inner = &anthropic.BetaMessageNewParams{}
 	aux := &struct {
 		Stream bool `json:"stream"`
 	}{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, inner); err != nil {
+
+	r.BetaMessageNewParams = new(anthropic.BetaMessageNewParams)
+	r.Stream = aux.Stream
+
+	if err := json.Unmarshal(data, r.BetaMessageNewParams); err != nil {
 		return err
 	}
-	r.Stream = aux.Stream
-	r.BetaMessageNewParams = inner
 	return nil
 }
 
 func (r *AnthropicMessagesRequest) UnmarshalJSON(data []byte) error {
-	var inner = &anthropic.MessageNewParams{}
 	aux := &struct {
 		Stream bool `json:"stream"`
 	}{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, inner); err != nil {
+
+	r.MessageNewParams = new(anthropic.MessageNewParams)
+	r.Stream = aux.Stream
+
+	if err := json.Unmarshal(data, r.MessageNewParams); err != nil {
 		return err
 	}
-	r.Stream = aux.Stream
-	r.MessageNewParams = inner
 	return nil
 }

--- a/internal/protocol/anthropic_test.go
+++ b/internal/protocol/anthropic_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -11,7 +12,7 @@ func Test_AnthropicUnMarshal(t *testing.T) {
 	for _, d := range testdata {
 		r := AnthropicBetaMessagesRequest{}
 
-		err := r.UnmarshalJSON([]byte(d))
+		err := json.Unmarshal([]byte(d), &r)
 		if err != nil {
 			t.Error(err)
 		}
@@ -22,9 +23,11 @@ func Test_AnthropicUnMarshal(t *testing.T) {
 				content = tb.OfText.Text
 			}
 		}
-		bs, err := r.MarshalJSON()
+
+		bs, err := json.MarshalIndent(r, "  ", "  ")
 		t.Log(string(bs))
 		assert.True(t, strings.Contains(content, "上海"))
+		assert.True(t, strings.Contains(string(bs), "stream\": true"))
 	}
 }
 
@@ -35,6 +38,7 @@ func init() {
 {
   "model": "claude-sonnet-4-20250514",
   "max_tokens": 1024,
+  "stream": true,
   "tools": [
     {
       "name": "get_weather",
@@ -101,6 +105,7 @@ func init() {
 {
   "model": "claude-sonnet-4-20250514",
   "max_tokens": 1024,
+  "stream": true,
   "tools": [
     {
       "name": "get_weather",

--- a/internal/protocol/context.go
+++ b/internal/protocol/context.go
@@ -134,6 +134,8 @@ func (hc *HandleContext) SetupSSEHeaders() {
 // or (false, err, nil) on error.
 // handleFunc is called for each event after OnStreamEventHooks are invoked.
 func (hc *HandleContext) ProcessStream(nextFunc func() (bool, error, interface{}), handleFunc func(interface{}) error) error {
+	defer hc.ReleaseStreamState()
+
 	c := hc.GinContext
 
 	if _, ok := c.Writer.(http.Flusher); !ok {
@@ -198,6 +200,23 @@ func (hc *HandleContext) ProcessStream(nextFunc func() (bool, error, interface{}
 }
 
 // DispatchStreamError calls all OnStreamError hooks.
+
+// ReleaseStreamState drops per-stream hooks and guardrail buffers after a stream
+// has completed or errored. Hook closures often capture assemblers/recorders that
+// aggregate response chunks; clearing them prevents protocol stream response
+// state from staying reachable through a HandleContext after request completion.
+func (hc *HandleContext) ReleaseStreamState() {
+	if hc == nil {
+		return
+	}
+	hc.OnStreamEventHooks = nil
+	hc.OnStreamCompleteHooks = nil
+	hc.OnStreamErrorHooks = nil
+	if hc.Guardrails != nil {
+		hc.Guardrails.Stream = nil
+	}
+}
+
 func (hc *HandleContext) DispatchStreamError(err error) {
 	for _, hook := range hc.OnStreamErrorHooks {
 		hook(err)

--- a/internal/protocol/context_test.go
+++ b/internal/protocol/context_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewHandleContext(t *testing.T) {
@@ -136,8 +137,8 @@ func TestHandleContext_Chaining(t *testing.T) {
 
 func TestSetupSSEHeaders(t *testing.T) {
 	tests := []struct {
-		name          string
-		checkHeader   func(*testing.T, http.Header)
+		name        string
+		checkHeader func(*testing.T, http.Header)
 	}{
 		{
 			name: "sets correct SSE headers",
@@ -279,25 +280,24 @@ func TestIsContextCanceled(t *testing.T) {
 	})
 }
 
-
 func TestErrorResponse(t *testing.T) {
 	tests := []struct {
-		name     string
-		message  string
+		name      string
+		message   string
 		errorType string
-		code     string
+		code      string
 	}{
 		{
-			name:     "basic error response",
-			message:  "Something went wrong",
+			name:      "basic error response",
+			message:   "Something went wrong",
 			errorType: "api_error",
-			code:     "invalid_request",
+			code:      "invalid_request",
 		},
 		{
-			name:     "error without code",
-			message:  "Another error",
+			name:      "error without code",
+			message:   "Another error",
 			errorType: "validation_error",
-			code:     "",
+			code:      "",
 		},
 	}
 
@@ -317,4 +317,20 @@ func TestErrorResponse(t *testing.T) {
 			assert.Equal(t, tt.code, resp.Error.Code)
 		})
 	}
+}
+
+func TestHandleContext_ReleaseStreamStateDropsResponseHooks(t *testing.T) {
+	hc := NewHandleContext(nil, "model")
+	hc.WithOnStreamEvent(func(event interface{}) error { return nil })
+	hc.WithOnStreamComplete(func() {})
+	hc.WithOnStreamError(func(err error) {})
+	hc.EnsureGuardrailsStream().AnthropicToolEvents[0] = []GuardrailsBufferedEvent{{EventType: "content_block_delta"}}
+
+	hc.ReleaseStreamState()
+
+	assert.Nil(t, hc.OnStreamEventHooks)
+	assert.Nil(t, hc.OnStreamCompleteHooks)
+	assert.Nil(t, hc.OnStreamErrorHooks)
+	require.NotNil(t, hc.Guardrails)
+	assert.Nil(t, hc.Guardrails.Stream)
 }

--- a/internal/protocol/openai.go
+++ b/internal/protocol/openai.go
@@ -19,7 +19,7 @@ type OpenAIChatCompletionRequest struct {
 	Stream bool `json:"stream"`
 }
 
-func (r OpenAIChatCompletionRequest) MarshalJSON() ([]byte, error) {
+func (r *OpenAIChatCompletionRequest) MarshalJSON() ([]byte, error) {
 	inner, err := json.Marshal(r.ChatCompletionNewParams)
 	if err != nil {
 		return nil, err

--- a/internal/protocol/openai.go
+++ b/internal/protocol/openai.go
@@ -36,18 +36,19 @@ func (r OpenAIChatCompletionRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (r *OpenAIChatCompletionRequest) UnmarshalJSON(data []byte) error {
-	var inner = &openai.ChatCompletionNewParams{}
 	aux := &struct {
 		Stream bool `json:"stream"`
 	}{}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, inner); err != nil {
+
+	r.ChatCompletionNewParams = new(openai.ChatCompletionNewParams)
+	r.Stream = aux.Stream
+
+	if err := json.Unmarshal(data, r.ChatCompletionNewParams); err != nil {
 		return err
 	}
-	r.Stream = aux.Stream
-	r.ChatCompletionNewParams = inner
 	return nil
 }
 
@@ -91,13 +92,12 @@ func (r *ResponseCreateRequest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Then, unmarshal into the embedded ResponseNewParams
-	var inner = &responses.ResponseNewParams{}
-	if err := json.Unmarshal(processedData, inner); err != nil {
+	r.ResponseNewParams = new(responses.ResponseNewParams)
+	r.Stream = aux.Stream
+
+	if err := json.Unmarshal(processedData, r.ResponseNewParams); err != nil {
 		return err
 	}
-
-	r.Stream = aux.Stream
-	r.ResponseNewParams = inner
 	return nil
 }
 

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -36,8 +36,7 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 				return false, streamResp.Err(), nil
 			}
 			// Current() returns a value, but we need a pointer for modification
-			evt := streamResp.Current()
-			return true, nil, &evt
+			return true, nil, new(streamResp.Current())
 		},
 		func(event interface{}) error {
 			evt := event.(*anthropic.MessageStreamEventUnion)
@@ -143,8 +142,7 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 				return false, streamResp.Err(), nil
 			}
 			// Current() returns a value, but we need a pointer for modification
-			evt := streamResp.Current()
-			return true, nil, &evt
+			return true, nil, new(streamResp.Current())
 		},
 		func(event interface{}) error {
 			evt := event.(*anthropic.BetaRawMessageStreamEventUnion)

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -67,8 +67,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 				// retryable status instead of a clean finish.
 				return false, streamResp.Err(), nil
 			}
-			chunk := streamResp.Current()
-			return true, nil, &chunk
+			return true, nil, new(streamResp.Current())
 		},
 		func(event interface{}) error {
 			chunk := event.(*openai.ChatCompletionChunk)

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -139,10 +139,10 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	var requestModel string
 	var reqParams interface{} // For smart routing context extraction
 
-	var betaMessages protocol.AnthropicBetaMessagesRequest
-	var messages protocol.AnthropicMessagesRequest
+	var betaMessages = &protocol.AnthropicBetaMessagesRequest{}
+	var messages = &protocol.AnthropicMessagesRequest{}
 	if beta {
-		if err := json.Unmarshal(bodyBytes, &betaMessages); err != nil {
+		if err := json.Unmarshal(bodyBytes, betaMessages); err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
 					Message: fmt.Sprintf("Message decode error: %s", err.Error()),
@@ -157,7 +157,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 		reqParams = betaMessages.BetaMessageNewParams
 
 	} else {
-		if err := json.Unmarshal(bodyBytes, &messages); err != nil {
+		if err := json.Unmarshal(bodyBytes, messages); err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
 					Message: fmt.Sprintf("Message decode error: %s", err.Error()),

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -23,7 +23,7 @@ import (
 // Like AnthropicMessagesV1, the provider-independent prologue runs once and the
 // per-attempt callback re-runs the provider-dependent pipeline so failover can
 // rotate across heterogeneous API styles.
-func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, requestModel string, responseModel string, rule *typ.Rule, provider *typ.Provider) {
+func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, requestModel string, responseModel string, rule *typ.Rule, provider *typ.Provider) {
 	// ── One-time prologue (provider-independent) ──
 
 	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex.
@@ -82,7 +82,7 @@ func (s *Server) AnthropicMessagesV1Beta(c *gin.Context, req protocol.AnthropicB
 
 // runAnthropicBetaAttempt executes the provider-dependent half of an Anthropic
 // beta request for one failover attempt. See runAnthropicV1Attempt.
-func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *ProtocolRecorder) {
+func (s *Server) runAnthropicBetaAttempt(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *ProtocolRecorder) {
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -23,7 +23,7 @@ import (
 // (pre-chain → guardrails → target resolution → transform → dispatch) against
 // the candidate selected for that attempt. Because the transform is re-run per
 // attempt, failover can rotate across heterogeneous API styles.
-func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessagesRequest, requestModel string, responseModel string, rule *typ.Rule, provider *typ.Provider) {
+func (s *Server) AnthropicMessagesV1(c *gin.Context, req *protocol.AnthropicMessagesRequest, requestModel string, responseModel string, rule *typ.Rule, provider *typ.Provider) {
 	// ── One-time prologue (provider-independent) ──
 
 	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex.
@@ -88,7 +88,7 @@ func (s *Server) AnthropicMessagesV1(c *gin.Context, req protocol.AnthropicMessa
 // pre-transform chain and guardrails, resolve the target API for this provider's
 // style, transform, and dispatch. Setup failures route through failAttemptSetup
 // so the orchestrator can advance to the next candidate.
-func (s *Server) runAnthropicV1Attempt(c *gin.Context, req protocol.AnthropicMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *ProtocolRecorder) {
+func (s *Server) runAnthropicV1Attempt(c *gin.Context, req *protocol.AnthropicMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *ProtocolRecorder) {
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleAnthropic)

--- a/internal/server/native_advisor_detection.go
+++ b/internal/server/native_advisor_detection.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
-func hasNativeAdvisorBeta(req protocol.AnthropicBetaMessagesRequest) bool {
+func hasNativeAdvisorBeta(req *protocol.AnthropicBetaMessagesRequest) bool {
 	return betaHistoryHasAdvisorBlocks(req.BetaMessageNewParams.Messages)
 }
 

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -32,8 +32,8 @@ func (s *Server) HandleOpenAIChatCompletions(c *gin.Context) {
 	}
 
 	// Parse OpenAI-style request
-	var req protocol.OpenAIChatCompletionRequest
-	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+	var req = &protocol.OpenAIChatCompletionRequest{}
+	if err := json.Unmarshal(bodyBytes, req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
 				Message: "Invalid request body: " + err.Error(),

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -20,7 +20,7 @@ import (
 // the failover loop whose per-attempt callback re-runs the provider-dependent
 // pipeline (align → cap → target resolution → transform → dispatch) so failover
 // can rotate across heterogeneous API styles.
-func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCompletionRequest, responseModel string, provider *typ.Provider, scenarioType typ.RuleScenario, rule *typ.Rule) {
+func (s *Server) OpenAIChatCompletion(c *gin.Context, req *protocol.OpenAIChatCompletionRequest, responseModel string, provider *typ.Provider, scenarioType typ.RuleScenario, rule *typ.Rule) {
 	// ── One-time prologue (provider-independent) ──
 
 	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex.
@@ -71,7 +71,7 @@ func (s *Server) OpenAIChatCompletion(c *gin.Context, req protocol.OpenAIChatCom
 // runOpenAIChatAttempt executes the provider-dependent half of an OpenAI chat
 // request for one failover attempt. Setup failures route through
 // failAttemptSetup so the orchestrator can advance to the next candidate.
-func (s *Server) runOpenAIChatAttempt(c *gin.Context, req protocol.OpenAIChatCompletionRequest, responseModel string, provider *typ.Provider, actualModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig) {
+func (s *Server) runOpenAIChatAttempt(c *gin.Context, req *protocol.OpenAIChatCompletionRequest, responseModel string, provider *typ.Provider, actualModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig) {
 	// Resolve dual endpoint: when the provider has an OpenAI-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleOpenAI)

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -32,7 +32,7 @@ func (s *Server) HandleResponsesCreate(c *gin.Context) {
 	}
 
 	// Parse request (minimal parsing for validation)
-	var req protocol.ResponseCreateRequest
+	var req = &protocol.ResponseCreateRequest{}
 	if err := json.Unmarshal(bodyBytes, &req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
@@ -155,7 +155,7 @@ func (s *Server) HandleResponsesCreate(c *gin.Context) {
 // failover loop whose per-attempt callback re-runs the provider-dependent
 // pipeline (target resolution → transform → dispatch) so failover can rotate
 // across heterogeneous API styles.
-func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, provider *typ.Provider, rule *typ.Rule, req protocol.ResponseCreateRequest, responseModel string, maxAllowed int) {
+func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, provider *typ.Provider, rule *typ.Rule, req *protocol.ResponseCreateRequest, responseModel string, maxAllowed int) {
 	// ── One-time prologue (provider-independent) ──
 
 	// Auto-detect context-1m from incoming beta header for Claude Code/Desktop/Codex.
@@ -189,7 +189,7 @@ func (s *Server) ResponsesCreate(c *gin.Context, scenarioType typ.RuleScenario, 
 // runOpenAIResponsesAttempt executes the provider-dependent half of an OpenAI
 // Responses request for one failover attempt. Setup failures route through
 // failAttemptSetup so the orchestrator can advance to the next candidate.
-func (s *Server) runOpenAIResponsesAttempt(c *gin.Context, req protocol.ResponseCreateRequest, provider *typ.Provider, actualModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig) {
+func (s *Server) runOpenAIResponsesAttempt(c *gin.Context, req *protocol.ResponseCreateRequest, provider *typ.Provider, actualModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig) {
 	// Resolve dual endpoint: when the provider has an OpenAI-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = s.resolveProviderForClient(provider, protocol.APIStyleOpenAI)

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -318,15 +318,15 @@ func (sr *ProtocolRecorder) emit(err error) {
 	}
 
 	sr.sink.Emit(r)
-	sr.releaseAfterEmit()
+	sr.release()
 }
 
-// releaseAfterEmit drops per-request recorder state once the obs.Record has
+// release drops per-request recorder state once the obs.Record has
 // been handed to the sink. This prevents completed protocol stream responses
 // from remaining reachable through gin.Context keys or recorder references; the
 // emitted record owns whatever payload the selected record mode intentionally
 // preserves.
-func (sr *ProtocolRecorder) releaseAfterEmit() {
+func (sr *ProtocolRecorder) release() {
 	if sr == nil {
 		return
 	}

--- a/internal/server/protocol_recording.go
+++ b/internal/server/protocol_recording.go
@@ -318,6 +318,24 @@ func (sr *ProtocolRecorder) emit(err error) {
 	}
 
 	sr.sink.Emit(r)
+	sr.releaseAfterEmit()
+}
+
+// releaseAfterEmit drops per-request recorder state once the obs.Record has
+// been handed to the sink. This prevents completed protocol stream responses
+// from remaining reachable through gin.Context keys or recorder references; the
+// emitted record owns whatever payload the selected record mode intentionally
+// preserves.
+func (sr *ProtocolRecorder) releaseAfterEmit() {
+	if sr == nil {
+		return
+	}
+	sr.streamChunks = nil
+	sr.originalRequest = nil
+	sr.transformedRequest = nil
+	sr.finalResponse = nil
+	sr.transformSteps = nil
+	sr.c = nil
 }
 
 // resolveRequestID returns the request correlation id established by the

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicBeta(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
@@ -71,7 +71,7 @@ func (s *Server) transformAnthropicBeta(c *gin.Context, req protocol.AnthropicBe
 	return finalCtx, nil
 }
 
-func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformAnthropicV1(c *gin.Context, req *protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
@@ -134,7 +134,7 @@ func (s *Server) transformAnthropicV1(c *gin.Context, req protocol.AnthropicMess
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIChat(c *gin.Context, req *protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
@@ -189,7 +189,7 @@ func (s *Server) transformOpenAIChat(c *gin.Context, req protocol.OpenAIChatComp
 	return finalCtx, nil
 }
 
-func (s *Server) transformOpenAIResponses(c *gin.Context, req protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+func (s *Server) transformOpenAIResponses(c *gin.Context, req *protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
 	chain, err := s.BuildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)

--- a/internal/server/request_clone.go
+++ b/internal/server/request_clone.go
@@ -23,24 +23,24 @@ import (
 
 // cloneAnthropicV1Request rebuilds an Anthropic v1 request from a marshalled
 // template (produced by AnthropicMessagesRequest.MarshalJSON).
-func cloneAnthropicV1Request(template []byte) (protocol.AnthropicMessagesRequest, error) {
-	var r protocol.AnthropicMessagesRequest
+func cloneAnthropicV1Request(template []byte) (*protocol.AnthropicMessagesRequest, error) {
+	var r = &protocol.AnthropicMessagesRequest{}
 	err := json.Unmarshal(template, &r)
 	return r, err
 }
 
 // cloneAnthropicBetaRequest rebuilds an Anthropic beta request from a marshalled
 // template (produced by AnthropicBetaMessagesRequest.MarshalJSON).
-func cloneAnthropicBetaRequest(template []byte) (protocol.AnthropicBetaMessagesRequest, error) {
-	var r protocol.AnthropicBetaMessagesRequest
+func cloneAnthropicBetaRequest(template []byte) (*protocol.AnthropicBetaMessagesRequest, error) {
+	var r = &protocol.AnthropicBetaMessagesRequest{}
 	err := json.Unmarshal(template, &r)
 	return r, err
 }
 
 // cloneOpenAIChatRequest rebuilds an OpenAI chat request from a marshalled
 // template (produced by OpenAIChatCompletionRequest.MarshalJSON).
-func cloneOpenAIChatRequest(template []byte) (protocol.OpenAIChatCompletionRequest, error) {
-	var r protocol.OpenAIChatCompletionRequest
+func cloneOpenAIChatRequest(template []byte) (*protocol.OpenAIChatCompletionRequest, error) {
+	var r = &protocol.OpenAIChatCompletionRequest{}
 	err := json.Unmarshal(template, &r)
 	return r, err
 }


### PR DESCRIPTION
## Summary
Protocol request types previously mixed value and pointer receivers, causing unnecessary copying of large embedded SDK structs and a receiver inconsistency between `MarshalJSON` and `UnmarshalJSON`. 

This change standardizes on pointer receivers, adds per-request stream-state cleanup to prevent memory leaks, and introduces compile-time interface guards for client wrappers.

### Major
- Protocol request types use pointer receivers consistently — no more copying embedded SDK structs on every marshal/unmarshal call
- Stream hooks and recorder state are released after request completion — closures capturing assemblers and response chunks no longer stay reachable, reducing GC pressure under load

### Minor
- Fixed `MarshalJSON`/`UnmarshalJSON` receiver inconsistency (both now pointer receivers)
- Added compile-time interface guards for `ClaudeClient`, `CodexClient`, and `KimiClient`
- Adopted `new(T)` for taking addresses of stream event values