### PR TITLE
refactor(quota): unify usage window structure across all providers

### DIFF
--- a/Taskfile.quota.yml
+++ b/Taskfile.quota.yml
@@ -9,13 +9,7 @@ tasks:
   anthropic:
     cmds:
       - |
-        curl https://api.anthropic.com/api/oauth/usage \
-        -H "Authorization: Bearer {{.ANTHROPIC_TOKEN}}" \
-        -H "Accept: application/json" \
-        -H "Content-Type: application/json" \
-        -H "anthropic-beta: oauth-2025-04-20" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
             "five_hour": {
@@ -42,28 +36,31 @@ tasks:
             }
         }
         EOF
+      - |
+        curl https://api.anthropic.com/api/oauth/usage \
+        -H "Authorization: Bearer {{.ANTHROPIC_TOKEN}}" \
+        -H "Accept: application/json" \
+        -H "Content-Type: application/json" \
+        -H "anthropic-beta: oauth-2025-04-20" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   openai:
     cmds:
       - |
-        curl https://api.openai.com/v1/usage \
-        -H "Authorization: Bearer {{.OPENAI_KEY}}" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         NOTE: OpenAI usage API often returns 404.
         Check https://platform.openai.com/usage for usage details.
         EOF
+      - |
+        curl https://api.openai.com/v1/usage \
+        -H "Authorization: Bearer {{.OPENAI_KEY}}" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   gemini:
     cmds:
       - |
-        curl -X POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota \
-        -H "Authorization: Bearer {{.GEMINI_TOKEN}}" \
-        -H "Content-Type: application/json" \
-        -d '{}' \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "buckets": [
@@ -80,17 +77,19 @@ tasks:
           ]
         }
         EOF
+      - |
+        curl -X POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota \
+        -H "Authorization: Bearer {{.GEMINI_TOKEN}}" \
+        -H "Content-Type: application/json" \
+        -d '{}' \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   openrouter:
     aliases:
       - cli:dev
     cmds:
       - |
-        curl https://openrouter.ai/api/v1/key \
-        -H "Authorization: Bearer {{.OPENROUTER_KEY}}" \
-        -H "Accept: application/json" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "data": {
@@ -120,17 +119,16 @@ tasks:
           }
         }
         EOF
+      - |
+        curl https://openrouter.ai/api/v1/key \
+        -H "Authorization: Bearer {{.OPENROUTER_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   codex:
     cmds:
       - |
-        curl https://chatgpt.com/backend-api/wham/usage \
-        -H "Authorization: Bearer {{.CODEX_KEY}}" \
-        -H "Accept: application/json" \
-        -H "User-Agent: codex-cli" \
-        {{ if .CODEX_ACCOUNT_ID }}-H "ChatGPT-Account-Id: {{.CODEX_ACCOUNT_ID}}"{{ end }} \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "user_id": "user-j5z",
@@ -199,6 +197,7 @@ tasks:
         }
         EOF
       - |
+        echo "example"
         cat << EOF
         {
           "user_id": "user-I9Ki---jrzi2",
@@ -241,30 +240,34 @@ tasks:
           "promo": null
         }
         EOF
+      - |
+        curl https://chatgpt.com/backend-api/wham/usage \
+        -H "Authorization: Bearer {{.CODEX_KEY}}" \
+        -H "Accept: application/json" \
+        -H "User-Agent: codex-cli" \
+        {{ if .CODEX_ACCOUNT_ID }}-H "ChatGPT-Account-Id: {{.CODEX_ACCOUNT_ID}}"{{ end }} \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   kimi-k2:
     cmds:
       - |
-        curl https://kimi-k2.ai/api/user/credits \
-        -H "Authorization: Bearer {{.KIMI_KEY}}" \
-        -H "Accept: application/json" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "consumed": 150,
           "remaining": 350
         }
         EOF
+      - |
+        curl https://kimi-k2.ai/api/user/credits \
+        -H "Authorization: Bearer {{.KIMI_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   minimax:
     cmds:
       - |
-        curl https://api.minimax.io/v1/api/openplatform/coding_plan/remains \
-        -H "Authorization: Bearer {{.MINIMAX_KEY}}" \
-        -H "Accept: application/json" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "model_remains": [
@@ -301,15 +304,16 @@ tasks:
           }
         }
         EOF
-        
+      - |
+        curl https://api.minimax.io/v1/api/openplatform/coding_plan/remains \
+        -H "Authorization: Bearer {{.MINIMAX_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
+
   minimax-cn:
     cmds:
       - |
-        curl https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains \
-        -H "Authorization: Bearer {{.MINIMAX_KEY}}" \
-        -H "Accept: application/json" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "model_remains": [
@@ -398,15 +402,16 @@ tasks:
           }
         }
         EOF
+      - |
+        curl https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains \
+        -H "Authorization: Bearer {{.MINIMAX_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   zai:
     cmds:
       - |
-        curl https://api.z.ai/api/monitor/usage/quota/limit \
-        -H "Authorization: Bearer {{.ZAI_KEY}}" \
-        -H "Accept: application/json" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
         {
           "code": 0,
@@ -431,6 +436,11 @@ tasks:
           }
         }
         EOF
+      - |
+        curl https://api.z.ai/api/monitor/usage/quota/limit \
+        -H "Authorization: Bearer {{.ZAI_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
   glm:
     cmds:
@@ -490,7 +500,7 @@ tasks:
         -H "Authorization: Bearer {{.GLM_KEY}}" \
         -H "Accept: application/json" \
         {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
-      
+
 
   # copilot, cursor, vertex_ai: no public quota API
   copilot:

--- a/Taskfile.quota.yml
+++ b/Taskfile.quota.yml
@@ -435,47 +435,49 @@ tasks:
   glm:
     cmds:
       - |
-        curl https://open.bigmodel.cn/api/monitor/usage/quota/limit \
-        -H "Authorization: Bearer {{.GLM_KEY}}" \
-        -H "Accept: application/json" \
-        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }}
-      - |
+        echo "example"
         cat << EOF
-        {
+         {
           "code": 200,
           "msg": "操作成功",
           "data": {
             "limits": [
               {
+                "type": "TOKENS_LIMIT",
+                "unit": 3,
+                "number": 5,
+                "percentage": 0
+              },
+              {
+                "type": "TOKENS_LIMIT",
+                "unit": 6,
+                "number": 1,
+                "percentage": 100,
+                "nextResetTime": 1782717116981
+              },
+              {
                 "type": "TIME_LIMIT",
                 "unit": 5,
                 "number": 1,
                 "usage": 4000,
-                "currentValue": 557,
-                "remaining": 3443,
-                "percentage": 13,
-                "nextResetTime": 1775309163998,
+                "currentValue": 63,
+                "remaining": 3937,
+                "percentage": 1,
+                "nextResetTime": 1784704316998,
                 "usageDetails": [
                   {
                     "modelCode": "search-prime",
-                    "usage": 426
+                    "usage": 71
                   },
                   {
                     "modelCode": "web-reader",
-                    "usage": 131
+                    "usage": 5
                   },
                   {
                     "modelCode": "zread",
                     "usage": 0
                   }
                 ]
-              },
-              {
-                "type": "TOKENS_LIMIT",
-                "unit": 3,
-                "number": 5,
-                "percentage": 2,
-                "nextResetTime": 1775126846418
               }
             ],
             "level": "max"
@@ -483,6 +485,12 @@ tasks:
           "success": true
         }
         EOF
+      - |
+        curl https://open.bigmodel.cn/api/monitor/usage/quota/limit \
+        -H "Authorization: Bearer {{.GLM_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
+      
 
   # copilot, cursor, vertex_ai: no public quota API
   copilot:

--- a/ai/quota/fetcher/anthropic.go
+++ b/ai/quota/fetcher/anthropic.go
@@ -126,46 +126,46 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 		FetchedAt:    now,
 		ExpiresAt:    now.Add(5 * time.Minute),
 		RawResponse:  rawResponse, // 存储原始响应
-
-		// Primary: 5-hour session quota (API returns utilization percentage only)
-		// Used/Limit normalized to 0-100 scale for unified frontend rendering
-		Primary: &quota.UsageWindow{
-			Type:          quota.WindowTypeSession,
-			Used:          apiResp.FiveHour.Utilization,
-			Limit:         100,
-			UsedPercent:   apiResp.FiveHour.Utilization,
-			Unit:          quota.UsageUnitPercent,
-			WindowMinutes: 300, // 5 hours
-			Label:         "5-Hour Window",
-			Description:   fmt.Sprintf("%.0f%% utilization", apiResp.FiveHour.Utilization),
-		},
-
-		// Secondary: 7-day weekly quota (API returns utilization percentage only)
-		// Used/Limit normalized to 0-100 scale for unified frontend rendering
-		Secondary: &quota.UsageWindow{
-			Type:        quota.WindowTypeWeekly,
-			Used:        apiResp.SevenDay.Utilization,
-			Limit:       100,
-			UsedPercent: apiResp.SevenDay.Utilization,
-			Unit:        quota.UsageUnitPercent,
-			Label:       "7-Day Window",
-			Description: fmt.Sprintf("%.0f%% utilization", apiResp.SevenDay.Utilization),
-		},
 	}
+
+	// 5-hour session quota (API returns utilization percentage only)
+	// Used/Limit normalized to 0-100 scale for unified frontend rendering
+	fiveHour := usage.AddWindow("five_hour", 0, &quota.UsageWindow{
+		Type:          quota.WindowTypeSession,
+		Used:          apiResp.FiveHour.Utilization,
+		Limit:         100,
+		UsedPercent:   apiResp.FiveHour.Utilization,
+		Unit:          quota.UsageUnitPercent,
+		WindowMinutes: 300, // 5 hours
+		Label:         "5-Hour Window",
+		Description:   fmt.Sprintf("%.0f%% utilization", apiResp.FiveHour.Utilization),
+	})
+
+	// 7-day weekly quota (API returns utilization percentage only)
+	// Used/Limit normalized to 0-100 scale for unified frontend rendering
+	sevenDay := usage.AddWindow("seven_day", 1, &quota.UsageWindow{
+		Type:        quota.WindowTypeWeekly,
+		Used:        apiResp.SevenDay.Utilization,
+		Limit:       100,
+		UsedPercent: apiResp.SevenDay.Utilization,
+		Unit:        quota.UsageUnitPercent,
+		Label:       "7-Day Window",
+		Description: fmt.Sprintf("%.0f%% utilization", apiResp.SevenDay.Utilization),
+	})
 
 	// 解析 resets_at 时间（API 返回带微秒的 ISO 8601，需用 RFC3339Nano）
 	if apiResp.FiveHour.ResetsAt != nil {
 		if t, err := time.Parse(time.RFC3339Nano, *apiResp.FiveHour.ResetsAt); err == nil {
-			usage.Primary.ResetsAt = &t
+			fiveHour.ResetsAt = &t
 		}
 	}
 	if apiResp.SevenDay.ResetsAt != nil {
 		if t, err := time.Parse(time.RFC3339Nano, *apiResp.SevenDay.ResetsAt); err == nil {
-			usage.Secondary.ResetsAt = &t
+			sevenDay.ResetsAt = &t
 		}
 	}
 
-	// Tertiary: Extra usage (Max plan add-on), only if enabled
+	// Extra usage (Max plan add-on), only if enabled
 	// API returns utilization percentage (nullable) and credit amounts
 	if apiResp.ExtraUsage.IsEnabled {
 		var utilPct float64
@@ -181,7 +181,7 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 			limit = 100
 			desc = "utilization unavailable"
 		}
-		usage.Tertiary = &quota.UsageWindow{
+		usage.AddWindow("extra_usage", 2, &quota.UsageWindow{
 			Type:        quota.WindowTypeMonthly,
 			Used:        used,
 			Limit:       limit,
@@ -189,7 +189,7 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 			Unit:        quota.UsageUnitPercent,
 			Label:       "Extra Usage",
 			Description: desc,
-		}
+		})
 
 		usage.Cost = &quota.UsageCost{
 			Used:         apiResp.ExtraUsage.UsedCredits / 100,  // cents → dollars

--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -185,7 +185,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 	if apiResp.RateLimit != nil {
 		if w := apiResp.RateLimit.PrimaryWindow; w != nil {
 			resetsAt := time.Unix(w.ResetAt, 0)
-			usage.Primary = &quota.UsageWindow{
+			usage.AddWindow("current", 0, &quota.UsageWindow{
 				Type:          quota.WindowTypeSession,
 				Used:          float64(w.UsedPercent), // Normalize to 0-100 scale
 				Limit:         100,                    // Normalize to 0-100 scale
@@ -195,11 +195,11 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 				WindowMinutes: w.LimitWindowSeconds / 60,
 				Label:         "Current Window",
 				Description:   fmt.Sprintf("%dh window, %.0f%% used", w.LimitWindowSeconds/3600, float64(w.UsedPercent)),
-			}
+			})
 		}
 		if w := apiResp.RateLimit.SecondaryWindow; w != nil {
 			resetsAt := time.Unix(w.ResetAt, 0)
-			usage.Secondary = &quota.UsageWindow{
+			usage.AddWindow("weekly", 1, &quota.UsageWindow{
 				Type:          quota.WindowTypeWeekly,
 				Used:          float64(w.UsedPercent), // Normalize to 0-100 scale
 				Limit:         100,                    // Normalize to 0-100 scale
@@ -209,12 +209,11 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 				WindowMinutes: w.LimitWindowSeconds / 60,
 				Label:         "Weekly",
 				Description:   fmt.Sprintf("%dd window, %.0f%% used", w.LimitWindowSeconds/86400, float64(w.UsedPercent)),
-			}
+			})
 		}
 	}
 
 	// Handle additional_rate_limits (model-specific quotas like GPT-5.3-Codex-Spark)
-	var extraWindows []*quota.UsageWindow
 	for _, arl := range apiResp.AdditionalRateLimits {
 		if arl.RateLimit.PrimaryWindow != nil {
 			w := arl.RateLimit.PrimaryWindow
@@ -223,7 +222,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 			if label == "" {
 				label = arl.MeteredFeature
 			}
-			extraWindows = append(extraWindows, &quota.UsageWindow{
+			usage.AddWindow(fmt.Sprintf("model_%d", len(usage.Windows)), len(usage.Windows), &quota.UsageWindow{
 				Type:          quota.WindowTypeModel,
 				Used:          float64(w.UsedPercent), // Normalize to 0-100 scale
 				Limit:         100,                    // Normalize to 0-100 scale
@@ -243,7 +242,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 	if apiResp.CodeReviewRateLimit != nil && apiResp.CodeReviewRateLimit.PrimaryWindow != nil {
 		w := apiResp.CodeReviewRateLimit.PrimaryWindow
 		resetsAt := time.Unix(w.ResetAt, 0)
-		codeReviewWindow := &quota.UsageWindow{
+		usage.AddWindow("code_review", len(usage.Windows), &quota.UsageWindow{
 			Type:          quota.WindowTypeCodeReview,
 			Used:          float64(w.UsedPercent), // Normalize to 0-100 scale
 			Limit:         100,                    // Normalize to 0-100 scale
@@ -255,13 +254,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 			Description:   fmt.Sprintf("Code Review: %.0f%% used", float64(w.UsedPercent)),
 			Allowed:       &apiResp.CodeReviewRateLimit.Allowed,
 			LimitReached:  &apiResp.CodeReviewRateLimit.LimitReached,
-		}
-		// Add to extra windows
-		extraWindows = append(extraWindows, codeReviewWindow)
-	}
-
-	if len(extraWindows) > 0 {
-		usage.ExtraWindows = extraWindows
+		})
 	}
 
 	// Handle credits (balance is now a pointer)

--- a/ai/quota/fetcher/codex_e2e_test.go
+++ b/ai/quota/fetcher/codex_e2e_test.go
@@ -50,13 +50,9 @@ func TestCodexE2E(t *testing.T) {
 	if usage.Account != nil {
 		fmt.Printf("Account: tier=%s\n", usage.Account.Tier)
 	}
-	if usage.Primary != nil {
-		fmt.Printf("Primary: %s — %.1f%% (resets at %v)\n",
-			usage.Primary.Label, usage.Primary.UsedPercent, usage.Primary.ResetsAt)
-	}
-	if usage.Secondary != nil {
-		fmt.Printf("Secondary: %s — %.1f%% (resets at %v)\n",
-			usage.Secondary.Label, usage.Secondary.UsedPercent, usage.Secondary.ResetsAt)
+	for _, window := range usage.Windows {
+		fmt.Printf("Window[%s]: %s — %.1f%% (resets at %v)\n",
+			window.Key, window.Label, window.UsedPercent, window.ResetsAt)
 	}
 	if usage.Cost != nil {
 		fmt.Printf("Credits: balance=$%.2f currency=%s\n",

--- a/ai/quota/fetcher/codex_test.go
+++ b/ai/quota/fetcher/codex_test.go
@@ -101,29 +101,28 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 		t.Errorf("Account.Tier = %q, want pro", usage.Account.Tier)
 	}
 
-	// Verify primary window (5h session)
-	if usage.Primary == nil {
-		t.Fatal("Primary is nil")
+	// Verify current window (5h session)
+	if len(usage.Windows) < 2 {
+		t.Fatalf("expected at least 2 windows, got %d", len(usage.Windows))
 	}
-	if usage.Primary.UsedPercent != 25 {
-		t.Errorf("Primary.UsedPercent = %f, want 25", usage.Primary.UsedPercent)
+	current := usage.Windows[0]
+	if current.UsedPercent != 25 {
+		t.Errorf("Current.UsedPercent = %f, want 25", current.UsedPercent)
 	}
-	if usage.Primary.WindowMinutes != 300 { // 18000s / 60
-		t.Errorf("Primary.WindowMinutes = %d, want 300", usage.Primary.WindowMinutes)
+	if current.WindowMinutes != 300 { // 18000s / 60
+		t.Errorf("Current.WindowMinutes = %d, want 300", current.WindowMinutes)
 	}
-	if usage.Primary.Label != "Current Window" {
-		t.Errorf("Primary.Label = %q, want 'Current Window'", usage.Primary.Label)
+	if current.Label != "Current Window" {
+		t.Errorf("Current.Label = %q, want 'Current Window'", current.Label)
 	}
 
-	// Verify secondary window (weekly)
-	if usage.Secondary == nil {
-		t.Fatal("Secondary is nil")
+	// Verify weekly window
+	weekly := usage.Windows[1]
+	if weekly.UsedPercent != 10 {
+		t.Errorf("Weekly.UsedPercent = %f, want 10", weekly.UsedPercent)
 	}
-	if usage.Secondary.UsedPercent != 10 {
-		t.Errorf("Secondary.UsedPercent = %f, want 10", usage.Secondary.UsedPercent)
-	}
-	if usage.Secondary.WindowMinutes != 10080 { // 604800s / 60
-		t.Errorf("Secondary.WindowMinutes = %d, want 10080", usage.Secondary.WindowMinutes)
+	if weekly.WindowMinutes != 10080 { // 604800s / 60
+		t.Errorf("Weekly.WindowMinutes = %d, want 10080", weekly.WindowMinutes)
 	}
 
 	// Verify credits
@@ -299,12 +298,12 @@ func TestCodexFetcher_Fetch_WithAdditionalLimits(t *testing.T) {
 		t.Fatalf("Fetch() error: %v", err)
 	}
 
-	// Verify extra windows
-	if len(usage.ExtraWindows) != 1 {
-		t.Fatalf("Expected 1 extra window, got %d", len(usage.ExtraWindows))
+	// Verify model window
+	if len(usage.Windows) != 3 {
+		t.Fatalf("Expected 3 windows, got %d", len(usage.Windows))
 	}
 
-	extra := usage.ExtraWindows[0]
+	extra := usage.Windows[2]
 	if extra.Label != "GPT-5.3-Codex-Spark" {
 		t.Errorf("Extra window label = %q, want 'GPT-5.3-Codex-Spark'", extra.Label)
 	}
@@ -378,12 +377,12 @@ func TestCodexFetcher_Fetch_WithCodeReviewLimit(t *testing.T) {
 		t.Fatalf("Fetch() error: %v", err)
 	}
 
-	// Verify extra windows includes code review
-	if len(usage.ExtraWindows) != 1 {
-		t.Fatalf("Expected 1 extra window (code review), got %d", len(usage.ExtraWindows))
+	// Verify windows include code review
+	if len(usage.Windows) != 2 {
+		t.Fatalf("Expected 2 windows, got %d", len(usage.Windows))
 	}
 
-	codeReview := usage.ExtraWindows[0]
+	codeReview := usage.Windows[1]
 	if codeReview.Label != "Code Review" {
 		t.Errorf("Code review window label = %q, want 'Code Review'", codeReview.Label)
 	}

--- a/ai/quota/fetcher/gemini.go
+++ b/ai/quota/fetcher/gemini.go
@@ -131,9 +131,9 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 
 	usage.Breakdowns = breakdowns
 
-	// Primary: overall average usage across all models
+	// Overall average usage across all models
 	avgUsedPercent := totalUsedPercent / float64(len(quotaResp.Buckets))
-	usage.Primary = &quota.UsageWindow{
+	overall := usage.AddWindow("average", 0, &quota.UsageWindow{
 		Type:        quota.WindowTypeDaily,
 		Used:        avgUsedPercent, // Normalize to 0-100 scale
 		Limit:       100,            // Normalize to 0-100 scale
@@ -141,14 +141,14 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 		Unit:        quota.UsageUnitPercent,
 		Label:       "Average Usage",
 		Description: fmt.Sprintf("%.0f%% across %d models", avgUsedPercent, len(quotaResp.Buckets)),
-	}
+	})
 
 	// Set reset time from first bucket
 	if len(quotaResp.Buckets) > 0 && quotaResp.Buckets[0].ResetTime != "" {
 		if t, err := time.Parse(time.RFC3339, quotaResp.Buckets[0].ResetTime); err == nil {
-			usage.Primary.ResetsAt = &t
+			overall.ResetsAt = &t
 		} else if t, err := time.Parse("2006-01-02T15:04:05.999Z", quotaResp.Buckets[0].ResetTime); err == nil {
-			usage.Primary.ResetsAt = &t
+			overall.ResetsAt = &t
 		}
 	}
 

--- a/ai/quota/fetcher/gemini.go
+++ b/ai/quota/fetcher/gemini.go
@@ -113,13 +113,7 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 			Description: fmt.Sprintf("%.0f%% used", usedPercent),
 		}
 
-		if bucket.ResetTime != "" {
-			if t, err := time.Parse(time.RFC3339, bucket.ResetTime); err == nil {
-				window.ResetsAt = &t
-			} else if t, err := time.Parse("2006-01-02T15:04:05.999Z", bucket.ResetTime); err == nil {
-				window.ResetsAt = &t
-			}
-		}
+		window.ResetsAt = parseGeminiResetTime(bucket.ResetTime)
 
 		breakdowns = append(breakdowns, &quota.UsageBreakdown{
 			Key:     bucket.ModelID,
@@ -144,15 +138,23 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 	})
 
 	// Set reset time from first bucket
-	if len(quotaResp.Buckets) > 0 && quotaResp.Buckets[0].ResetTime != "" {
-		if t, err := time.Parse(time.RFC3339, quotaResp.Buckets[0].ResetTime); err == nil {
-			overall.ResetsAt = &t
-		} else if t, err := time.Parse("2006-01-02T15:04:05.999Z", quotaResp.Buckets[0].ResetTime); err == nil {
-			overall.ResetsAt = &t
-		}
+	if len(quotaResp.Buckets) > 0 {
+		overall.ResetsAt = parseGeminiResetTime(quotaResp.Buckets[0].ResetTime)
 	}
 
 	return usage, nil
+}
+
+func parseGeminiResetTime(value string) *time.Time {
+	if value == "" {
+		return nil
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05.999Z"} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return &t
+		}
+	}
+	return nil
 }
 
 func (f *GeminiFetcher) fetchQuota(ctx context.Context, client *http.Client, token, projectID string) (*geminiQuotaResponse, string, error) {

--- a/ai/quota/fetcher/kimik2.go
+++ b/ai/quota/fetcher/kimik2.go
@@ -92,16 +92,16 @@ func (f *KimiK2Fetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 		ProviderType: quota.ProviderTypeKimiK2,
 		FetchedAt:    now,
 		ExpiresAt:    now.Add(5 * time.Minute),
-		Primary: &quota.UsageWindow{
-			Type:        quota.WindowTypeBalance,
-			Used:        consumed,
-			Limit:       total,
-			UsedPercent: usedPercent,
-			Unit:        quota.UsageUnitCredits,
-			Label:       "Credits",
-			Description: fmt.Sprintf("%.0f consumed, %.0f remaining", consumed, remaining),
-		},
 	}
+	usage.AddWindow("credits", 0, &quota.UsageWindow{
+		Type:        quota.WindowTypeBalance,
+		Used:        consumed,
+		Limit:       total,
+		UsedPercent: usedPercent,
+		Unit:        quota.UsageUnitCredits,
+		Label:       "Credits",
+		Description: fmt.Sprintf("%.0f consumed, %.0f remaining", consumed, remaining),
+	})
 
 	return usage, nil
 }

--- a/ai/quota/fetcher/minimax.go
+++ b/ai/quota/fetcher/minimax.go
@@ -175,8 +175,8 @@ func (f *MiniMaxFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quo
 
 	usage.Breakdowns = breakdowns
 
-	// Primary: aggregated daily quota
-	usage.Primary = &quota.UsageWindow{
+	// Aggregated daily quota
+	daily := usage.AddWindow("daily", 0, &quota.UsageWindow{
 		Type:        quota.WindowTypeDaily,
 		Used:        float64(totalUsed),
 		Limit:       float64(totalLimit),
@@ -184,17 +184,17 @@ func (f *MiniMaxFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quo
 		Unit:        quota.UsageUnitRequests,
 		Label:       "Daily Quota",
 		Description: fmt.Sprintf("%d / %d requests", totalUsed, totalLimit),
-	}
+	})
 
 	// Reset time from first model
 	if len(apiResp.ModelRemains) > 0 && apiResp.ModelRemains[0].EndTime > 0 {
 		t := time.UnixMilli(apiResp.ModelRemains[0].EndTime)
-		usage.Primary.ResetsAt = &t
+		daily.ResetsAt = &t
 	}
 
-	// Secondary: aggregated weekly quota
+	// Aggregated weekly quota
 	if weeklyLimit > 0 {
-		usage.Secondary = &quota.UsageWindow{
+		usage.AddWindow("weekly", 1, &quota.UsageWindow{
 			Type:        quota.WindowTypeWeekly,
 			Used:        float64(weeklyUsed),
 			Limit:       float64(weeklyLimit),
@@ -202,7 +202,7 @@ func (f *MiniMaxFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quo
 			Unit:        quota.UsageUnitRequests,
 			Label:       "Weekly Quota",
 			Description: fmt.Sprintf("%d / %d requests", weeklyUsed, weeklyLimit),
-		}
+		})
 	}
 
 	return usage, nil

--- a/ai/quota/fetcher/minimaxi.go
+++ b/ai/quota/fetcher/minimaxi.go
@@ -149,8 +149,8 @@ func (f *MiniMaxCNFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 
 	usage.Breakdowns = breakdowns
 
-	// Primary: aggregated daily quota
-	usage.Primary = &quota.UsageWindow{
+	// Aggregated daily quota
+	daily := usage.AddWindow("daily", 0, &quota.UsageWindow{
 		Type:        quota.WindowTypeDaily,
 		Used:        float64(totalUsed),
 		Limit:       float64(totalLimit),
@@ -158,17 +158,17 @@ func (f *MiniMaxCNFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 		Unit:        quota.UsageUnitRequests,
 		Label:       "Daily Quota",
 		Description: fmt.Sprintf("%d / %d requests", totalUsed, totalLimit),
-	}
+	})
 
 	// Reset time from first model
 	if len(apiResp.ModelRemains) > 0 && apiResp.ModelRemains[0].EndTime > 0 {
 		t := time.UnixMilli(apiResp.ModelRemains[0].EndTime)
-		usage.Primary.ResetsAt = &t
+		daily.ResetsAt = &t
 	}
 
-	// Secondary: aggregated weekly quota
+	// Aggregated weekly quota
 	if weeklyLimit > 0 {
-		usage.Secondary = &quota.UsageWindow{
+		usage.AddWindow("weekly", 1, &quota.UsageWindow{
 			Type:        quota.WindowTypeWeekly,
 			Used:        float64(weeklyUsed),
 			Limit:       float64(weeklyLimit),
@@ -176,7 +176,7 @@ func (f *MiniMaxCNFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 			Unit:        quota.UsageUnitRequests,
 			Label:       "Weekly Quota",
 			Description: fmt.Sprintf("%d / %d requests", weeklyUsed, weeklyLimit),
-		}
+		})
 	}
 
 	return usage, nil

--- a/ai/quota/fetcher/openrouter.go
+++ b/ai/quota/fetcher/openrouter.go
@@ -110,11 +110,11 @@ func (f *OpenRouterFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*
 		Tier: tier,
 	}
 
-	// Primary: usage vs limit (if limit is set)
+	// Usage vs limit (if limit is set)
 	if data.Limit != nil && *data.Limit > 0 {
 		used := data.Usage
 		limit := *data.Limit
-		usage.Primary = &quota.UsageWindow{
+		usage.AddWindow("key_limit", 0, &quota.UsageWindow{
 			Type:        quota.WindowTypeBalance,
 			Used:        used,
 			Limit:       limit,
@@ -122,10 +122,10 @@ func (f *OpenRouterFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*
 			Unit:        quota.UsageUnitCurrency,
 			Label:       "Key Limit",
 			Description: fmt.Sprintf("Balance: $%.2f / $%.2f", limit-used, limit),
-		}
+		})
 	} else {
-		// No limit set — show monthly usage as primary
-		usage.Primary = &quota.UsageWindow{
+		// No limit set — show monthly usage first
+		usage.AddWindow("monthly_usage", 0, &quota.UsageWindow{
 			Type:        quota.WindowTypeMonthly,
 			Used:        data.UsageMonthly,
 			Limit:       0,
@@ -133,11 +133,11 @@ func (f *OpenRouterFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*
 			Unit:        quota.UsageUnitCurrency,
 			Label:       "Monthly Usage",
 			Description: fmt.Sprintf("This month: $%.4f (no limit set)", data.UsageMonthly),
-		}
+		})
 	}
 
-	// Secondary: monthly usage breakdown
-	usage.Secondary = &quota.UsageWindow{
+	// Monthly usage breakdown
+	usage.AddWindow("monthly", 1, &quota.UsageWindow{
 		Type:        quota.WindowTypeMonthly,
 		Used:        data.UsageMonthly,
 		Limit:       0,
@@ -146,7 +146,7 @@ func (f *OpenRouterFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*
 		Label:       "Monthly",
 		Description: fmt.Sprintf("Daily: $%.4f | Weekly: $%.4f | Monthly: $%.4f | Total: $%.4f",
 			data.UsageDaily, data.UsageWeekly, data.UsageMonthly, data.Usage),
-	}
+	})
 
 	// Cost
 	usage.Cost = &quota.UsageCost{

--- a/ai/quota/fetcher/openrouter_e2e_test.go
+++ b/ai/quota/fetcher/openrouter_e2e_test.go
@@ -43,9 +43,9 @@ func TestOpenRouterE2E(t *testing.T) {
 	}
 
 	fmt.Printf("Provider: %s (%s)\n", usage.ProviderName, usage.ProviderType)
-	if usage.Primary != nil {
-		fmt.Printf("Primary: %s — used=%.2f limit=%.2f (%.1f%%)\n",
-			usage.Primary.Label, usage.Primary.Used, usage.Primary.Limit, usage.Primary.UsedPercent)
+	for _, window := range usage.Windows {
+		fmt.Printf("Window[%s]: %s — used=%.2f limit=%.2f (%.1f%%)\n",
+			window.Key, window.Label, window.Used, window.Limit, window.UsedPercent)
 	}
 	if usage.Cost != nil {
 		fmt.Printf("Cost: used=$%.2f limit=$%.2f currency=%s\n",

--- a/ai/quota/fetcher/openrouter_test.go
+++ b/ai/quota/fetcher/openrouter_test.go
@@ -63,32 +63,31 @@ func TestOpenRouterFetcher_Fetch(t *testing.T) {
 		t.Errorf("ProviderType = %q, want openrouter", usage.ProviderType)
 	}
 
-	// Primary window (key limit)
-	if usage.Primary == nil {
-		t.Fatal("Primary is nil")
+	// Key limit window
+	if len(usage.Windows) < 2 {
+		t.Fatalf("expected at least 2 windows, got %d", len(usage.Windows))
 	}
-	if usage.Primary.Type != quota.WindowTypeBalance {
-		t.Errorf("Primary.Type = %q, want balance", usage.Primary.Type)
+	keyLimit := usage.Windows[0]
+	if keyLimit.Type != quota.WindowTypeBalance {
+		t.Errorf("KeyLimit.Type = %q, want balance", keyLimit.Type)
 	}
-	if usage.Primary.Used != 35.50 {
-		t.Errorf("Primary.Used = %f, want 35.50", usage.Primary.Used)
+	if keyLimit.Used != 35.50 {
+		t.Errorf("KeyLimit.Used = %f, want 35.50", keyLimit.Used)
 	}
-	if usage.Primary.Limit != 100.0 {
-		t.Errorf("Primary.Limit = %f, want 100.0", usage.Primary.Limit)
+	if keyLimit.Limit != 100.0 {
+		t.Errorf("KeyLimit.Limit = %f, want 100.0", keyLimit.Limit)
 	}
-	if usage.Primary.Unit != quota.UsageUnitCurrency {
-		t.Errorf("Primary.Unit = %q, want currency", usage.Primary.Unit)
+	if keyLimit.Unit != quota.UsageUnitCurrency {
+		t.Errorf("KeyLimit.Unit = %q, want currency", keyLimit.Unit)
 	}
 
-	// Secondary window (monthly)
-	if usage.Secondary == nil {
-		t.Fatal("Secondary is nil")
+	// Monthly window
+	monthly := usage.Windows[1]
+	if monthly.Type != quota.WindowTypeMonthly {
+		t.Errorf("Monthly.Type = %q, want monthly", monthly.Type)
 	}
-	if usage.Secondary.Type != quota.WindowTypeMonthly {
-		t.Errorf("Secondary.Type = %q, want monthly", usage.Secondary.Type)
-	}
-	if usage.Secondary.Used != 30.00 {
-		t.Errorf("Secondary.Used = %f, want 30.00", usage.Secondary.Used)
+	if monthly.Used != 30.00 {
+		t.Errorf("Monthly.Used = %f, want 30.00", monthly.Used)
 	}
 
 	// Cost
@@ -148,9 +147,12 @@ func TestOpenRouterFetcher_FreeTier(t *testing.T) {
 		t.Fatalf("Fetch() error: %v", err)
 	}
 
-	// No limit → primary shows monthly usage
-	if usage.Primary.Type != quota.WindowTypeMonthly {
-		t.Errorf("Primary.Type = %q, want monthly (no limit)", usage.Primary.Type)
+	// No limit → first window shows monthly usage
+	if len(usage.Windows) == 0 {
+		t.Fatal("expected quota windows")
+	}
+	if usage.Windows[0].Type != quota.WindowTypeMonthly {
+		t.Errorf("First window Type = %q, want monthly (no limit)", usage.Windows[0].Type)
 	}
 	if usage.Account.Tier != "free" {
 		t.Errorf("Account.Tier = %q, want free", usage.Account.Tier)

--- a/ai/quota/fetcher/zai.go
+++ b/ai/quota/fetcher/zai.go
@@ -2,13 +2,13 @@ package fetcher
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/ai/quota"
 )
+
+const zaiQuotaLimitURL = "https://api.z.ai/api/monitor/usage/quota/limit"
 
 // ZaiFetcher z.ai 配额获取器
 // Uses: GET https://api.z.ai/api/monitor/usage/quota/limit (API key auth)
@@ -28,144 +28,12 @@ func (f *ZaiFetcher) Validate(provider *ai.Provider) error {
 	return validateAPIKeyProvider(provider)
 }
 
-// ── API response types ──────────────────────────────────
-
-// zaiQuotaLimitResponse from GET /api/monitor/usage/quota/limit
-type zaiQuotaLimitResponse struct {
-	Code int `json:"code"`
-	Data struct {
-		PlanName string     `json:"planName"` // or "plan", "plan_type", "packageName"
-		Limits   []zaiLimit `json:"limits"`
-	} `json:"data"`
-}
-
-type zaiLimit struct {
-	Type        string  `json:"type"` // e.g. "TOKENS_LIMIT", "TIME_LIMIT"
-	Used        float64 `json:"used"`
-	Total       float64 `json:"total"`
-	Unit        string  `json:"unit"`          // e.g. "minutes", "hours", "days"
-	NextResetMs int64   `json:"nextResetTime"` // epoch ms
-}
-
-// ── Fetch ──────────────────────────────────────────────
-
 func (f *ZaiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
-	var apiResp zaiQuotaLimitResponse
-	rawResponse, err := fetchBearerJSON(ctx, provider, "https://api.z.ai/api/monitor/usage/quota/limit", &apiResp)
+	var apiResp zaiQuotaResponse
+	rawResponse, err := fetchBearerJSON(ctx, provider, zaiQuotaLimitURL, &apiResp)
 	if err != nil {
 		return nil, err
 	}
 
-	now := time.Now()
-	usage := &quota.ProviderUsage{
-		ProviderUUID: provider.UUID,
-		ProviderName: provider.Name,
-		ProviderType: quota.ProviderTypeZai,
-		FetchedAt:    now,
-		ExpiresAt:    now.Add(5 * time.Minute),
-		RawResponse:  rawResponse,
-		Account: &quota.UsageAccount{
-			Tier: apiResp.Data.PlanName,
-		},
-	}
-
-	if len(apiResp.Data.Limits) == 0 {
-		return usage, nil
-	}
-
-	// Create breakdowns for each limit type
-	breakdowns := make([]*quota.UsageBreakdown, 0, len(apiResp.Data.Limits))
-
-	for _, lim := range apiResp.Data.Limits {
-		var windowType quota.WindowType
-		var label string
-		var unit quota.UsageUnit
-
-		switch lim.Type {
-		case "TOKENS_LIMIT":
-			windowType = quota.WindowTypeDaily
-			label = "Tokens"
-			unit = quota.UsageUnitTokens
-		case "TIME_LIMIT":
-			windowType = quota.WindowTypeCustom
-			label = "Time"
-			unit = quota.UsageUnitRequests
-		default:
-			windowType = quota.WindowTypeCustom
-			label = lim.Type
-			unit = quota.UsageUnitRequests
-		}
-
-		window := &quota.UsageWindow{
-			Type:        windowType,
-			Used:        lim.Used,
-			Limit:       lim.Total,
-			UsedPercent: calcPercent(lim.Used, lim.Total),
-			Unit:        unit,
-			Label:       label,
-			Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-		}
-
-		if lim.NextResetMs > 0 {
-			t := time.UnixMilli(lim.NextResetMs)
-			window.ResetsAt = &t
-		}
-
-		breakdowns = append(breakdowns, &quota.UsageBreakdown{
-			Key:     lim.Type,
-			Label:   label,
-			Group:   "type",
-			Windows: []*quota.UsageWindow{window},
-		})
-	}
-
-	usage.Breakdowns = breakdowns
-
-	// TOKENS_LIMIT first, if available
-	for _, lim := range apiResp.Data.Limits {
-		if lim.Type == "TOKENS_LIMIT" {
-			addTieredWindow(usage, "tokens", 0, &quota.UsageWindow{
-				Type:        quota.WindowTypeDaily,
-				Used:        lim.Used,
-				Limit:       lim.Total,
-				UsedPercent: calcPercent(lim.Used, lim.Total),
-				Unit:        quota.UsageUnitTokens,
-				Label:       "Token Limit",
-				Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-			}, lim.NextResetMs)
-			break
-		}
-	}
-
-	// TIME_LIMIT second, if available
-	for _, lim := range apiResp.Data.Limits {
-		if lim.Type == "TIME_LIMIT" {
-			addTieredWindow(usage, "time", 1, &quota.UsageWindow{
-				Type:        quota.WindowTypeCustom,
-				Used:        lim.Used,
-				Limit:       lim.Total,
-				UsedPercent: calcPercent(lim.Used, lim.Total),
-				Unit:        quota.UsageUnitRequests,
-				Label:       "Time Limit",
-				Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-			}, lim.NextResetMs)
-			break
-		}
-	}
-
-	// Fallback: use first limit when no aggregate window was selected
-	if len(usage.Windows) == 0 && len(apiResp.Data.Limits) > 0 {
-		lim := apiResp.Data.Limits[0]
-		addTieredWindow(usage, "limit", 0, &quota.UsageWindow{
-			Type:        quota.WindowTypeCustom,
-			Used:        lim.Used,
-			Limit:       lim.Total,
-			UsedPercent: calcPercent(lim.Used, lim.Total),
-			Unit:        quota.UsageUnitRequests,
-			Label:       lim.Type,
-			Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-		}, lim.NextResetMs)
-	}
-
-	return usage, nil
+	return buildZaiProviderUsage(provider, quota.ProviderTypeZai, rawResponse, &apiResp)
 }

--- a/ai/quota/fetcher/zai.go
+++ b/ai/quota/fetcher/zai.go
@@ -2,10 +2,7 @@ package fetcher
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -28,13 +25,7 @@ func (f *ZaiFetcher) ProviderType() quota.ProviderType { return quota.ProviderTy
 func (f *ZaiFetcher) RequiresAuth() ai.AuthType        { return ai.AuthTypeAPIKey }
 
 func (f *ZaiFetcher) Validate(provider *ai.Provider) error {
-	if provider == nil {
-		return fmt.Errorf("provider is nil")
-	}
-	if provider.GetAccessToken() == "" {
-		return fmt.Errorf("no API key available")
-	}
-	return nil
+	return validateAPIKeyProvider(provider)
 }
 
 // ── API response types ──────────────────────────────────
@@ -59,36 +50,10 @@ type zaiLimit struct {
 // ── Fetch ──────────────────────────────────────────────
 
 func (f *ZaiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
-	token := provider.GetAccessToken()
-	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.z.ai/api/monitor/usage/quota/limit", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-
-	// Read raw response
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-	rawResponse := string(bodyBytes)
-
 	var apiResp zaiQuotaLimitResponse
-	if err := json.Unmarshal(bodyBytes, &apiResp); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+	rawResponse, err := fetchBearerJSON(ctx, provider, "https://api.z.ai/api/monitor/usage/quota/limit", &apiResp)
+	if err != nil {
+		return nil, err
 	}
 
 	now := time.Now()
@@ -156,10 +121,10 @@ func (f *ZaiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 
 	usage.Breakdowns = breakdowns
 
-	// Primary: TOKENS_LIMIT if available, otherwise first limit
+	// TOKENS_LIMIT first, if available
 	for _, lim := range apiResp.Data.Limits {
 		if lim.Type == "TOKENS_LIMIT" {
-			usage.Primary = &quota.UsageWindow{
+			addTieredWindow(usage, "tokens", 0, &quota.UsageWindow{
 				Type:        quota.WindowTypeDaily,
 				Used:        lim.Used,
 				Limit:       lim.Total,
@@ -167,19 +132,15 @@ func (f *ZaiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 				Unit:        quota.UsageUnitTokens,
 				Label:       "Token Limit",
 				Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-			}
-			if lim.NextResetMs > 0 {
-				t := time.UnixMilli(lim.NextResetMs)
-				usage.Primary.ResetsAt = &t
-			}
+			}, lim.NextResetMs)
 			break
 		}
 	}
 
-	// Secondary: TIME_LIMIT if available
+	// TIME_LIMIT second, if available
 	for _, lim := range apiResp.Data.Limits {
 		if lim.Type == "TIME_LIMIT" {
-			usage.Secondary = &quota.UsageWindow{
+			addTieredWindow(usage, "time", 1, &quota.UsageWindow{
 				Type:        quota.WindowTypeCustom,
 				Used:        lim.Used,
 				Limit:       lim.Total,
@@ -187,19 +148,15 @@ func (f *ZaiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 				Unit:        quota.UsageUnitRequests,
 				Label:       "Time Limit",
 				Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-			}
-			if lim.NextResetMs > 0 {
-				t := time.UnixMilli(lim.NextResetMs)
-				usage.Secondary.ResetsAt = &t
-			}
+			}, lim.NextResetMs)
 			break
 		}
 	}
 
-	// Fallback: use first limit as primary if primary not set
-	if usage.Primary == nil && len(apiResp.Data.Limits) > 0 {
+	// Fallback: use first limit when no aggregate window was selected
+	if len(usage.Windows) == 0 && len(apiResp.Data.Limits) > 0 {
 		lim := apiResp.Data.Limits[0]
-		usage.Primary = &quota.UsageWindow{
+		addTieredWindow(usage, "limit", 0, &quota.UsageWindow{
 			Type:        quota.WindowTypeCustom,
 			Used:        lim.Used,
 			Limit:       lim.Total,
@@ -207,11 +164,7 @@ func (f *ZaiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 			Unit:        quota.UsageUnitRequests,
 			Label:       lim.Type,
 			Description: fmt.Sprintf("%.0f / %.0f", lim.Used, lim.Total),
-		}
-		if lim.NextResetMs > 0 {
-			t := time.UnixMilli(lim.NextResetMs)
-			usage.Primary.ResetsAt = &t
-		}
+		}, lim.NextResetMs)
 	}
 
 	return usage, nil

--- a/ai/quota/fetcher/zai_glm.go
+++ b/ai/quota/fetcher/zai_glm.go
@@ -2,13 +2,13 @@ package fetcher
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/ai/quota"
 )
+
+const glmQuotaLimitURL = "https://open.bigmodel.cn/api/monitor/usage/quota/limit"
 
 // GLMFetcher GLM (BigModel.cn) 配额获取器
 // Uses: GET https://open.bigmodel.cn/api/monitor/usage/quota/limit
@@ -28,224 +28,12 @@ func (f *GLMFetcher) Validate(provider *ai.Provider) error {
 	return validateAPIKeyProvider(provider)
 }
 
-// ── Unit mapping constants ─────────────────────────────────────
-
-// unitScopeMap maps GLM API unit values to their time scope
-var unitScopeMap = map[int]string{
-	3: "hour",  // unit 3 = hours
-	5: "month", // unit 5 = months
-	6: "week",  // unit 6 = weeks
-}
-
-// unitToWindowType maps GLM API unit values to quota window types
-var unitToWindowType = map[int]quota.WindowType{
-	3: quota.WindowTypeSession, // hours
-	5: quota.WindowTypeMonthly, // months
-	6: quota.WindowTypeWeekly,  // weeks
-}
-
-// ── API response types ──────────────────────────────────
-
-// glmQuotaLimitResponse from GET /api/monitor/usage/quota/limit
-type glmQuotaLimitResponse struct {
-	Code    int    `json:"code"`
-	Msg     string `json:"msg"`
-	Success bool   `json:"success"`
-	Data    struct {
-		Limits []glmLimit `json:"limits"`
-		Level  string     `json:"level"` // e.g. "max"
-	} `json:"data"`
-}
-
-type glmLimit struct {
-	Type          string           `json:"type"`         // TIME_LIMIT, TOKENS_LIMIT
-	Unit          int              `json:"unit"`         // unit multiplier
-	Number        int              `json:"number"`       // number of units
-	Usage         float64          `json:"usage"`        // total usage
-	CurrentValue  float64          `json:"currentValue"` // current value
-	Remaining     float64          `json:"remaining"`
-	Percentage    float64          `json:"percentage"`
-	NextResetTime int64            `json:"nextResetTime"` // epoch ms
-	UsageDetails  []glmUsageDetail `json:"usageDetails,omitempty"`
-}
-
-type glmUsageDetail struct {
-	ModelCode string  `json:"modelCode"`
-	Usage     float64 `json:"usage"`
-}
-
-// ── Fetch ──────────────────────────────────────────────
-
 func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
-	var apiResp glmQuotaLimitResponse
-	rawResponse, err := fetchBearerJSON(ctx, provider, "https://open.bigmodel.cn/api/monitor/usage/quota/limit", &apiResp)
+	var apiResp zaiQuotaResponse
+	rawResponse, err := fetchBearerJSON(ctx, provider, glmQuotaLimitURL, &apiResp)
 	if err != nil {
 		return nil, err
 	}
 
-	// Check for API error
-	if apiResp.Code != 200 || !apiResp.Success {
-		return nil, fmt.Errorf("API error: %s", apiResp.Msg)
-	}
-
-	now := time.Now()
-	usage := &quota.ProviderUsage{
-		ProviderUUID: provider.UUID,
-		ProviderName: provider.Name,
-		ProviderType: quota.ProviderTypeGLM,
-		FetchedAt:    now,
-		ExpiresAt:    now.Add(5 * time.Minute),
-		RawResponse:  rawResponse,
-		Account: &quota.UsageAccount{
-			Tier: apiResp.Data.Level,
-		},
-	}
-
-	if len(apiResp.Data.Limits) == 0 {
-		return usage, nil
-	}
-
-	// Process each limit type
-	for _, lim := range apiResp.Data.Limits {
-		// GLM API fields:
-		// - Usage: total quota allocation (may be absent for percentage-only quotas)
-		// - CurrentValue: amount currently used (may be absent)
-		// - Remaining: amount remaining (may be absent)
-		// - Percentage: utilization percentage (always present)
-		//
-		// Some quotas (like TOKENS_LIMIT) only provide percentage, not absolute values
-		total := lim.Usage
-		used := lim.CurrentValue
-		hasAbsoluteValues := total > 0 || used > 0
-
-		// Use percentage from API
-		usedPercent := lim.Percentage
-
-		var windowType quota.WindowType
-		var label string
-		var unit quota.UsageUnit
-		var tier = -1 // lower tier is more important; -1 means fallback only
-
-		switch lim.Type {
-		case "TOKENS_LIMIT":
-			// TOKENS_LIMIT uses unit to define time scope
-			// unit: 3 (hours), 6 (weeks), 5 (months)
-			if scope, ok := unitScopeMap[lim.Unit]; ok {
-				label = fmt.Sprintf("%d-%s Tokens", lim.Number, scope)
-				unit = quota.UsageUnitTokens
-				windowType = unitToWindowType[lim.Unit]
-				// Tier: hourly first, weekly second, monthly after MCP
-				switch lim.Unit {
-				case 3:
-					tier = 0 // 5-hour tokens
-				case 6:
-					tier = 1 // weekly tokens
-				case 5:
-					tier = 3 // monthly tokens, not commonly used
-				}
-			} else {
-				// Fallback for unknown TOKENS_LIMIT units
-				windowType = quota.WindowTypeCustom
-				label = fmt.Sprintf("Token Limit (unit:%d, num:%d)", lim.Unit, lim.Number)
-				unit = quota.UsageUnitTokens
-			}
-		case "TIME_LIMIT":
-			// TIME_LIMIT is MCP (Model Context Protocol) quota
-			// MCP always gets tertiary tier (level 2)
-			if scope, ok := unitScopeMap[lim.Unit]; ok {
-				label = fmt.Sprintf("%d-%s MCP", lim.Number, scope)
-				unit = quota.UsageUnitRequests
-				windowType = unitToWindowType[lim.Unit]
-				tier = 2 // MCP always tertiary
-			} else {
-				// Fallback for unknown TIME_LIMIT units
-				windowType = quota.WindowTypeCustom
-				label = fmt.Sprintf("MCP Limit (unit:%d, num:%d)", lim.Unit, lim.Number)
-				unit = quota.UsageUnitRequests
-				tier = 2 // MCP always tertiary
-			}
-		default:
-			windowType = quota.WindowTypeCustom
-			label = lim.Type
-			unit = quota.UsageUnitRequests
-		}
-
-		var window *quota.UsageWindow
-
-		if hasAbsoluteValues {
-			// Has absolute values (e.g., TIME_LIMIT)
-			window = &quota.UsageWindow{
-				Type:        windowType,
-				Used:        used,
-				Limit:       total,
-				UsedPercent: usedPercent,
-				Unit:        unit,
-				Label:       label,
-				Description: fmt.Sprintf("%.0f / %.0f", used, total),
-			}
-		} else {
-			// Percentage-only (e.g., some TOKENS_LIMIT)
-			window = &quota.UsageWindow{
-				Type:        windowType,
-				Used:        usedPercent, // No absolute values available
-				Limit:       100,         // No absolute values available
-				UsedPercent: usedPercent,
-				Unit:        unit,
-				Label:       label,
-				Description: fmt.Sprintf("%.0f%% utilization", usedPercent),
-			}
-		}
-
-		applyResetTime(window, lim.NextResetTime)
-
-		// Add aggregate window by tier. Lower tier means more important.
-		if tier < 0 {
-			tier = len(usage.Windows)
-		}
-		usage.AddWindow(fmt.Sprintf("%s_%d_%d", lim.Type, lim.Unit, lim.Number), tier, window)
-
-		// Create breakdowns for usageDetails (per-model breakdown)
-		if len(lim.UsageDetails) > 0 {
-			for _, detail := range lim.UsageDetails {
-				// Calculate this model's share of the total usage
-				modelPercent := float64(0)
-				if lim.CurrentValue > 0 {
-					modelPercent = (detail.Usage / lim.CurrentValue) * 100
-				}
-
-				modelWindow := &quota.UsageWindow{
-					Type:        windowType,
-					Used:        detail.Usage,
-					Limit:       total, // Use total as reference
-					UsedPercent: modelPercent,
-					Unit:        unit,
-					Label:       label,
-					Description: fmt.Sprintf("%.0f / %.0f", detail.Usage, total),
-				}
-
-				applyResetTime(modelWindow, lim.NextResetTime)
-
-				// Find existing breakdown for this model or create new one
-				found := false
-				for _, bd := range usage.Breakdowns {
-					if bd.Key == detail.ModelCode {
-						// Add window to existing breakdown
-						bd.Windows = append(bd.Windows, modelWindow)
-						found = true
-						break
-					}
-				}
-				if !found {
-					usage.Breakdowns = append(usage.Breakdowns, &quota.UsageBreakdown{
-						Key:     detail.ModelCode,
-						Label:   detail.ModelCode,
-						Group:   "model",
-						Windows: []*quota.UsageWindow{modelWindow},
-					})
-				}
-			}
-		}
-	}
-
-	return usage, nil
+	return buildZaiProviderUsage(provider, quota.ProviderTypeGLM, rawResponse, &apiResp)
 }

--- a/ai/quota/fetcher/zai_glm.go
+++ b/ai/quota/fetcher/zai_glm.go
@@ -2,10 +2,7 @@ package fetcher
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -28,13 +25,7 @@ func (f *GLMFetcher) ProviderType() quota.ProviderType { return quota.ProviderTy
 func (f *GLMFetcher) RequiresAuth() ai.AuthType        { return ai.AuthTypeAPIKey }
 
 func (f *GLMFetcher) Validate(provider *ai.Provider) error {
-	if provider == nil {
-		return fmt.Errorf("provider is nil")
-	}
-	if provider.GetAccessToken() == "" {
-		return fmt.Errorf("no API key available")
-	}
-	return nil
+	return validateAPIKeyProvider(provider)
 }
 
 // ── Unit mapping constants ─────────────────────────────────────
@@ -86,36 +77,10 @@ type glmUsageDetail struct {
 // ── Fetch ──────────────────────────────────────────────
 
 func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
-	token := provider.GetAccessToken()
-	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://open.bigmodel.cn/api/monitor/usage/quota/limit", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-
-	// Read raw response
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-	rawResponse := string(bodyBytes)
-
 	var apiResp glmQuotaLimitResponse
-	if err := json.Unmarshal(bodyBytes, &apiResp); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+	rawResponse, err := fetchBearerJSON(ctx, provider, "https://open.bigmodel.cn/api/monitor/usage/quota/limit", &apiResp)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check for API error
@@ -159,7 +124,7 @@ func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 		var windowType quota.WindowType
 		var label string
 		var unit quota.UsageUnit
-		var priority int // 0=primary, 1=secondary, 2=tertiary, -1=no assignment
+		var tier = -1 // lower tier is more important; -1 means fallback only
 
 		switch lim.Type {
 		case "TOKENS_LIMIT":
@@ -169,14 +134,14 @@ func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 				label = fmt.Sprintf("%d-%s Tokens", lim.Number, scope)
 				unit = quota.UsageUnitTokens
 				windowType = unitToWindowType[lim.Unit]
-				// Priority: hourly=primary, weekly=secondary, monthly=tertiary
+				// Tier: hourly first, weekly second, monthly after MCP
 				switch lim.Unit {
 				case 3:
-					priority = 0 // primary (5-hour tokens)
+					tier = 0 // 5-hour tokens
 				case 6:
-					priority = 1 // secondary (weekly tokens)
+					tier = 1 // weekly tokens
 				case 5:
-					priority = 3 // extra (monthly tokens, not commonly used)
+					tier = 3 // monthly tokens, not commonly used
 				}
 			} else {
 				// Fallback for unknown TOKENS_LIMIT units
@@ -186,18 +151,18 @@ func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 			}
 		case "TIME_LIMIT":
 			// TIME_LIMIT is MCP (Model Context Protocol) quota
-			// MCP always gets tertiary priority (level 2)
+			// MCP always gets tertiary tier (level 2)
 			if scope, ok := unitScopeMap[lim.Unit]; ok {
 				label = fmt.Sprintf("%d-%s MCP", lim.Number, scope)
 				unit = quota.UsageUnitRequests
 				windowType = unitToWindowType[lim.Unit]
-				priority = 2 // MCP always tertiary
+				tier = 2 // MCP always tertiary
 			} else {
 				// Fallback for unknown TIME_LIMIT units
 				windowType = quota.WindowTypeCustom
 				label = fmt.Sprintf("MCP Limit (unit:%d, num:%d)", lim.Unit, lim.Number)
 				unit = quota.UsageUnitRequests
-				priority = 2 // MCP always tertiary
+				tier = 2 // MCP always tertiary
 			}
 		default:
 			windowType = quota.WindowTypeCustom
@@ -231,32 +196,13 @@ func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 			}
 		}
 
-		if lim.NextResetTime > 0 {
-			t := time.UnixMilli(lim.NextResetTime)
-			window.ResetsAt = &t
-		}
+		applyResetTime(window, lim.NextResetTime)
 
-		// Assign to primary/secondary/tertiary/extra based on priority
-		switch priority {
-		case 0: // primary
-			if usage.Primary == nil {
-				usage.Primary = window
-			}
-		case 1: // secondary
-			if usage.Secondary == nil {
-				usage.Secondary = window
-			}
-		case 2: // tertiary
-			if usage.Tertiary == nil {
-				usage.Tertiary = window
-			}
-		case 3: // extra windows
-			usage.ExtraWindows = append(usage.ExtraWindows, window)
-		default: // no priority assigned, use as fallback
-			if usage.Primary == nil {
-				usage.Primary = window
-			}
+		// Add aggregate window by tier. Lower tier means more important.
+		if tier < 0 {
+			tier = len(usage.Windows)
 		}
+		usage.AddWindow(fmt.Sprintf("%s_%d_%d", lim.Type, lim.Unit, lim.Number), tier, window)
 
 		// Create breakdowns for usageDetails (per-model breakdown)
 		if len(lim.UsageDetails) > 0 {
@@ -277,10 +223,7 @@ func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 					Description: fmt.Sprintf("%.0f / %.0f", detail.Usage, total),
 				}
 
-				if lim.NextResetTime > 0 {
-					t := time.UnixMilli(lim.NextResetTime)
-					modelWindow.ResetsAt = &t
-				}
+				applyResetTime(modelWindow, lim.NextResetTime)
 
 				// Find existing breakdown for this model or create new one
 				found := false
@@ -301,77 +244,6 @@ func (f *GLMFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.P
 					})
 				}
 			}
-		}
-	}
-
-	// Fallback: use first limit as primary if primary not set
-	if usage.Primary == nil && len(apiResp.Data.Limits) > 0 {
-		lim := apiResp.Data.Limits[0]
-		total := lim.Usage
-		used := lim.CurrentValue
-		usedPercent := lim.Percentage
-		hasAbsoluteValues := total > 0 || used > 0
-
-		if hasAbsoluteValues && usedPercent == 0 {
-			usedPercent = (used / total) * 100
-		}
-
-		var label string
-		var unit quota.UsageUnit
-		var windowType quota.WindowType
-
-		switch lim.Type {
-		case "TOKENS_LIMIT":
-			if scope, ok := unitScopeMap[lim.Unit]; ok {
-				label = fmt.Sprintf("%d-%s Tokens", lim.Number, scope)
-				unit = quota.UsageUnitTokens
-				windowType = unitToWindowType[lim.Unit]
-			} else {
-				label = fmt.Sprintf("Token Limit (unit:%d, num:%d)", lim.Unit, lim.Number)
-				unit = quota.UsageUnitTokens
-				windowType = quota.WindowTypeCustom
-			}
-		case "TIME_LIMIT":
-			if scope, ok := unitScopeMap[lim.Unit]; ok {
-				label = fmt.Sprintf("%d-%s MCP", lim.Number, scope)
-				unit = quota.UsageUnitRequests
-				windowType = unitToWindowType[lim.Unit]
-			} else {
-				label = fmt.Sprintf("MCP Limit (unit:%d, num:%d)", lim.Unit, lim.Number)
-				unit = quota.UsageUnitRequests
-				windowType = quota.WindowTypeCustom
-			}
-		default:
-			label = lim.Type
-			unit = quota.UsageUnitRequests
-			windowType = quota.WindowTypeCustom
-		}
-
-		if hasAbsoluteValues {
-			usage.Primary = &quota.UsageWindow{
-				Type:        windowType,
-				Used:        used,
-				Limit:       total,
-				UsedPercent: usedPercent,
-				Unit:        unit,
-				Label:       label,
-				Description: fmt.Sprintf("%.0f / %.0f", used, total),
-			}
-		} else {
-			usage.Primary = &quota.UsageWindow{
-				Type:        windowType,
-				Used:        usedPercent, // Normalize to 0-100 scale
-				Limit:       100,         // Normalize to 0-100 scale
-				UsedPercent: usedPercent,
-				Unit:        unit,
-				Label:       label,
-				Description: fmt.Sprintf("%.0f%% utilization", usedPercent),
-			}
-		}
-
-		if lim.NextResetTime > 0 {
-			t := time.UnixMilli(lim.NextResetTime)
-			usage.Primary.ResetsAt = &t
 		}
 	}
 

--- a/ai/quota/fetcher/zai_shared.go
+++ b/ai/quota/fetcher/zai_shared.go
@@ -54,16 +54,234 @@ func fetchBearerJSON(ctx context.Context, provider *ai.Provider, url string, tar
 	return string(bodyBytes), nil
 }
 
+type zaiQuotaResponse struct {
+	Code    int    `json:"code"`
+	Msg     string `json:"msg"`
+	Success bool   `json:"success"`
+	Data    struct {
+		Limits   []zaiQuotaLimit `json:"limits"`
+		Level    string          `json:"level"`
+		PlanName string          `json:"planName"`
+	} `json:"data"`
+}
+
+type zaiQuotaLimit struct {
+	Type          string           `json:"type"`
+	Unit          zaiQuotaUnit     `json:"unit"`
+	Number        int              `json:"number"`
+	Usage         float64          `json:"usage"`
+	CurrentValue  float64          `json:"currentValue"`
+	Remaining     float64          `json:"remaining"`
+	Percentage    float64          `json:"percentage"`
+	Used          float64          `json:"used"`
+	Total         float64          `json:"total"`
+	NextResetTime int64            `json:"nextResetTime"`
+	UsageDetails  []zaiUsageDetail `json:"usageDetails,omitempty"`
+}
+
+type zaiQuotaUnit struct {
+	Int    int
+	String string
+}
+
+func (u *zaiQuotaUnit) UnmarshalJSON(data []byte) error {
+	var n int
+	if err := json.Unmarshal(data, &n); err == nil {
+		u.Int = n
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		u.String = s
+		return nil
+	}
+
+	return nil
+}
+
+type zaiUsageDetail struct {
+	ModelCode string  `json:"modelCode"`
+	Usage     float64 `json:"usage"`
+}
+
+func (r *zaiQuotaResponse) accountTier() string {
+	if r.Data.Level != "" {
+		return r.Data.Level
+	}
+	return r.Data.PlanName
+}
+
+func (r *zaiQuotaResponse) ok() bool {
+	return r.Code == 0 || r.Success || r.Code == 200
+}
+
+var zaiQuotaUnitScopeMap = map[int]string{
+	3: "hour",
+	5: "month",
+	6: "week",
+}
+
+var zaiQuotaUnitToWindowType = map[int]quota.WindowType{
+	3: quota.WindowTypeSession,
+	5: quota.WindowTypeMonthly,
+	6: quota.WindowTypeWeekly,
+}
+
+func buildZaiProviderUsage(provider *ai.Provider, providerType quota.ProviderType, rawResponse string, apiResp *zaiQuotaResponse) (*quota.ProviderUsage, error) {
+	if !apiResp.ok() {
+		return nil, fmt.Errorf("API error: %s", apiResp.Msg)
+	}
+
+	now := time.Now()
+	usage := &quota.ProviderUsage{
+		ProviderUUID: provider.UUID,
+		ProviderName: provider.Name,
+		ProviderType: providerType,
+		FetchedAt:    now,
+		ExpiresAt:    now.Add(5 * time.Minute),
+		RawResponse:  rawResponse,
+		Account: &quota.UsageAccount{
+			Tier: apiResp.accountTier(),
+		},
+	}
+
+	for _, lim := range apiResp.Data.Limits {
+		windowType, label, unit, tier := classifyZaiLimit(lim)
+		used, total, usedPercent, hasAbsoluteValues := zaiLimitValues(lim)
+
+		window := &quota.UsageWindow{
+			Type:        windowType,
+			Used:        used,
+			Limit:       total,
+			UsedPercent: usedPercent,
+			Unit:        unit,
+			Label:       label,
+		}
+		if hasAbsoluteValues {
+			window.Description = fmt.Sprintf("%.0f / %.0f", used, total)
+		} else {
+			window.Description = fmt.Sprintf("%.0f%% utilization", usedPercent)
+		}
+		applyResetTime(window, lim.NextResetTime)
+
+		if tier < 0 {
+			tier = len(usage.Windows)
+		}
+		usage.AddWindow(zaiLimitKey(lim), tier, window)
+
+		addZaiUsageDetails(usage, lim, windowType, label, unit, total)
+	}
+
+	return usage, nil
+}
+
+func classifyZaiLimit(lim zaiQuotaLimit) (quota.WindowType, string, quota.UsageUnit, int) {
+	scope, hasScope := zaiQuotaUnitScopeMap[lim.Unit.Int]
+	scopedLabel := func(name string) string {
+		if hasScope && lim.Number > 0 {
+			return fmt.Sprintf("%d-%s %s", lim.Number, scope, name)
+		}
+		return name
+	}
+
+	scopedWindowType := quota.WindowTypeCustom
+	if hasScope {
+		scopedWindowType = zaiQuotaUnitToWindowType[lim.Unit.Int]
+	}
+
+	switch lim.Type {
+	case "TOKENS_LIMIT":
+		tier := 0
+		switch lim.Unit.Int {
+		case 3:
+			tier = 0
+		case 6:
+			tier = 1
+		case 5:
+			tier = 3
+		}
+		return scopedWindowType, scopedLabel("Tokens"), quota.UsageUnitTokens, tier
+	case "TIME_LIMIT":
+		return scopedWindowType, scopedLabel("MCP"), quota.UsageUnitRequests, 2
+	default:
+		return quota.WindowTypeCustom, lim.Type, quota.UsageUnitRequests, -1
+	}
+}
+
+func zaiLimitValues(lim zaiQuotaLimit) (used, total, usedPercent float64, hasAbsoluteValues bool) {
+	total = lim.Usage
+	if total == 0 {
+		total = lim.Total
+	}
+	used = lim.CurrentValue
+	if used == 0 {
+		used = lim.Used
+	}
+	usedPercent = lim.Percentage
+	if usedPercent == 0 {
+		usedPercent = calcPercent(used, total)
+	}
+	hasAbsoluteValues = total > 0 || used > 0
+	if !hasAbsoluteValues {
+		used = usedPercent
+		total = 100
+	}
+	return used, total, usedPercent, hasAbsoluteValues
+}
+
+func zaiLimitKey(lim zaiQuotaLimit) string {
+	if lim.Unit.Int > 0 || lim.Number > 0 {
+		return fmt.Sprintf("%s_%d_%d", lim.Type, lim.Unit.Int, lim.Number)
+	}
+	return lim.Type
+}
+
+func addZaiUsageDetails(usage *quota.ProviderUsage, lim zaiQuotaLimit, windowType quota.WindowType, label string, unit quota.UsageUnit, total float64) {
+	if len(lim.UsageDetails) == 0 {
+		return
+	}
+
+	for _, detail := range lim.UsageDetails {
+		modelPercent := float64(0)
+		if lim.CurrentValue > 0 {
+			modelPercent = (detail.Usage / lim.CurrentValue) * 100
+		}
+
+		modelWindow := &quota.UsageWindow{
+			Type:        windowType,
+			Used:        detail.Usage,
+			Limit:       total,
+			UsedPercent: modelPercent,
+			Unit:        unit,
+			Label:       label,
+			Description: fmt.Sprintf("%.0f / %.0f", detail.Usage, total),
+		}
+		applyResetTime(modelWindow, lim.NextResetTime)
+
+		found := false
+		for _, bd := range usage.Breakdowns {
+			if bd.Key == detail.ModelCode {
+				bd.Windows = append(bd.Windows, modelWindow)
+				found = true
+				break
+			}
+		}
+		if !found {
+			usage.Breakdowns = append(usage.Breakdowns, &quota.UsageBreakdown{
+				Key:     detail.ModelCode,
+				Label:   detail.ModelCode,
+				Group:   "model",
+				Windows: []*quota.UsageWindow{modelWindow},
+			})
+		}
+	}
+}
+
 func applyResetTime(window *quota.UsageWindow, resetMs int64) {
 	if window == nil || resetMs <= 0 {
 		return
 	}
 	t := time.UnixMilli(resetMs)
 	window.ResetsAt = &t
-}
-
-func addTieredWindow(usage *quota.ProviderUsage, key string, tier int, window *quota.UsageWindow, resetMs int64) *quota.UsageWindow {
-	window = usage.AddWindow(key, tier, window)
-	applyResetTime(window, resetMs)
-	return window
 }

--- a/ai/quota/fetcher/zai_shared.go
+++ b/ai/quota/fetcher/zai_shared.go
@@ -1,0 +1,69 @@
+package fetcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/ai/quota"
+)
+
+func validateAPIKeyProvider(provider *ai.Provider) error {
+	if provider == nil {
+		return fmt.Errorf("provider is nil")
+	}
+	if provider.GetAccessToken() == "" {
+		return fmt.Errorf("no API key available")
+	}
+	return nil
+}
+
+func fetchBearerJSON(ctx context.Context, provider *ai.Provider, url string, target interface{}) (string, error) {
+	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+provider.GetAccessToken())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	if err := json.Unmarshal(bodyBytes, target); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+
+	return string(bodyBytes), nil
+}
+
+func applyResetTime(window *quota.UsageWindow, resetMs int64) {
+	if window == nil || resetMs <= 0 {
+		return
+	}
+	t := time.UnixMilli(resetMs)
+	window.ResetsAt = &t
+}
+
+func addTieredWindow(usage *quota.ProviderUsage, key string, tier int, window *quota.UsageWindow, resetMs int64) *quota.UsageWindow {
+	window = usage.AddWindow(key, tier, window)
+	applyResetTime(window, resetMs)
+	return window
+}

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -184,8 +184,12 @@ func (m *Manager) Summary(ctx context.Context) (*Summary, error) {
 		summary.ByType[usage.ProviderType]++
 
 		// 警告统计
-		if usage.Primary != nil && usage.Primary.UsedPercent >= 80 {
-			summary.WarningProviders++
+		usage.NormalizeWindows()
+		for _, window := range usage.Windows {
+			if window != nil && window.UsedPercent >= 80 {
+				summary.WarningProviders++
+				break
+			}
 		}
 	}
 

--- a/ai/quota/store.go
+++ b/ai/quota/store.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -71,6 +72,10 @@ type ProviderUsageRecord struct {
 	AccountTier  *string `gorm:"column:account_tier"`
 	AccountOrgID *string `gorm:"column:account_org_id"`
 
+	// Variable quota data
+	WindowsJSON    *string `gorm:"column:windows;type:text"`
+	BreakdownsJSON *string `gorm:"column:breakdowns;type:text"`
+
 	// Metadata
 	FetchedAt   time.Time  `gorm:"column:fetched_at;index:idx_provider_usage_fetched"`
 	ExpiresAt   time.Time  `gorm:"column:expires_at"`
@@ -101,51 +106,6 @@ func (r *ProviderUsageRecord) toProviderUsage() *ProviderUsage {
 		usage.LastErrorAt = r.LastErrorAt
 	}
 
-	// Primary window
-	if r.PrimaryType != nil {
-		usage.Primary = &UsageWindow{
-			Type:          WindowType(*r.PrimaryType),
-			Used:          getFloat64(r.PrimaryUsed),
-			Limit:         getFloat64(r.PrimaryLimit),
-			Unit:          UsageUnit(getString(r.PrimaryUnit)),
-			ResetsAt:      r.PrimaryResetsAt,
-			WindowMinutes: getInt(r.PrimaryWindowMins),
-			Label:         getString(r.PrimaryLabel),
-			Description:   getString(r.PrimaryDesc),
-		}
-		usage.Primary.UsedPercent = usage.Primary.CalculateUsedPercent()
-	}
-
-	// Secondary window
-	if r.SecondaryType != nil {
-		usage.Secondary = &UsageWindow{
-			Type:          WindowType(*r.SecondaryType),
-			Used:          getFloat64(r.SecondaryUsed),
-			Limit:         getFloat64(r.SecondaryLimit),
-			Unit:          UsageUnit(getString(r.SecondaryUnit)),
-			ResetsAt:      r.SecondaryResetsAt,
-			WindowMinutes: getInt(r.SecondaryWindowMins),
-			Label:         getString(r.SecondaryLabel),
-			Description:   getString(r.SecondaryDesc),
-		}
-		usage.Secondary.UsedPercent = usage.Secondary.CalculateUsedPercent()
-	}
-
-	// Tertiary window
-	if r.TertiaryType != nil {
-		usage.Tertiary = &UsageWindow{
-			Type:          WindowType(*r.TertiaryType),
-			Used:          getFloat64(r.TertiaryUsed),
-			Limit:         getFloat64(r.TertiaryLimit),
-			Unit:          UsageUnit(getString(r.TertiaryUnit)),
-			ResetsAt:      r.TertiaryResetsAt,
-			WindowMinutes: getInt(r.TertiaryWindowMins),
-			Label:         getString(r.TertiaryLabel),
-			Description:   getString(r.TertiaryDesc),
-		}
-		usage.Tertiary.UsedPercent = usage.Tertiary.CalculateUsedPercent()
-	}
-
 	// Cost
 	if r.CostUsed != nil || r.CostLimit != nil {
 		usage.Cost = &UsageCost{
@@ -167,6 +127,21 @@ func (r *ProviderUsageRecord) toProviderUsage() *ProviderUsage {
 			OrganizationID: getString(r.AccountOrgID),
 		}
 	}
+
+	// Variable quota data
+	if r.WindowsJSON != nil && *r.WindowsJSON != "" {
+		var windows []*UsageWindow
+		if err := json.Unmarshal([]byte(*r.WindowsJSON), &windows); err == nil {
+			usage.Windows = windows
+		}
+	}
+	if r.BreakdownsJSON != nil && *r.BreakdownsJSON != "" {
+		var breakdowns []*UsageBreakdown
+		if err := json.Unmarshal([]byte(*r.BreakdownsJSON), &breakdowns); err == nil {
+			usage.Breakdowns = breakdowns
+		}
+	}
+	usage.NormalizeWindows()
 
 	return usage
 }
@@ -191,54 +166,6 @@ func toRecord(usage *ProviderUsage) *ProviderUsageRecord {
 		record.RawResponse = &usage.RawResponse
 	}
 
-	// Primary window
-	if usage.Primary != nil {
-		record.PrimaryUsed = &usage.Primary.Used
-		record.PrimaryLimit = &usage.Primary.Limit
-		ptype := string(usage.Primary.Type)
-		record.PrimaryType = &ptype
-		unit := string(usage.Primary.Unit)
-		record.PrimaryUnit = &unit
-		record.PrimaryResetsAt = usage.Primary.ResetsAt
-		record.PrimaryWindowMins = &usage.Primary.WindowMinutes
-		record.PrimaryLabel = &usage.Primary.Label
-		if usage.Primary.Description != "" {
-			record.PrimaryDesc = &usage.Primary.Description
-		}
-	}
-
-	// Secondary window
-	if usage.Secondary != nil {
-		record.SecondaryUsed = &usage.Secondary.Used
-		record.SecondaryLimit = &usage.Secondary.Limit
-		stype := string(usage.Secondary.Type)
-		record.SecondaryType = &stype
-		unit := string(usage.Secondary.Unit)
-		record.SecondaryUnit = &unit
-		record.SecondaryResetsAt = usage.Secondary.ResetsAt
-		record.SecondaryWindowMins = &usage.Secondary.WindowMinutes
-		record.SecondaryLabel = &usage.Secondary.Label
-		if usage.Secondary.Description != "" {
-			record.SecondaryDesc = &usage.Secondary.Description
-		}
-	}
-
-	// Tertiary window
-	if usage.Tertiary != nil {
-		record.TertiaryUsed = &usage.Tertiary.Used
-		record.TertiaryLimit = &usage.Tertiary.Limit
-		ttype := string(usage.Tertiary.Type)
-		record.TertiaryType = &ttype
-		unit := string(usage.Tertiary.Unit)
-		record.TertiaryUnit = &unit
-		record.TertiaryResetsAt = usage.Tertiary.ResetsAt
-		record.TertiaryWindowMins = &usage.Tertiary.WindowMinutes
-		record.TertiaryLabel = &usage.Tertiary.Label
-		if usage.Tertiary.Description != "" {
-			record.TertiaryDesc = &usage.Tertiary.Description
-		}
-	}
-
 	// Cost
 	if usage.Cost != nil {
 		record.CostUsed = &usage.Cost.Used
@@ -260,6 +187,21 @@ func toRecord(usage *ProviderUsage) *ProviderUsageRecord {
 		}
 		if usage.Account.OrganizationID != "" {
 			record.AccountOrgID = &usage.Account.OrganizationID
+		}
+	}
+
+	// Variable quota data
+	usage.NormalizeWindows()
+	if len(usage.Windows) > 0 {
+		if data, err := json.Marshal(usage.Windows); err == nil {
+			windowsJSON := string(data)
+			record.WindowsJSON = &windowsJSON
+		}
+	}
+	if len(usage.Breakdowns) > 0 {
+		if data, err := json.Marshal(usage.Breakdowns); err == nil {
+			breakdownsJSON := string(data)
+			record.BreakdownsJSON = &breakdownsJSON
 		}
 	}
 

--- a/ai/quota/store.go
+++ b/ai/quota/store.go
@@ -129,18 +129,8 @@ func (r *ProviderUsageRecord) toProviderUsage() *ProviderUsage {
 	}
 
 	// Variable quota data
-	if r.WindowsJSON != nil && *r.WindowsJSON != "" {
-		var windows []*UsageWindow
-		if err := json.Unmarshal([]byte(*r.WindowsJSON), &windows); err == nil {
-			usage.Windows = windows
-		}
-	}
-	if r.BreakdownsJSON != nil && *r.BreakdownsJSON != "" {
-		var breakdowns []*UsageBreakdown
-		if err := json.Unmarshal([]byte(*r.BreakdownsJSON), &breakdowns); err == nil {
-			usage.Breakdowns = breakdowns
-		}
-	}
+	usage.Windows = decodeJSONField[[]*UsageWindow](r.WindowsJSON)
+	usage.Breakdowns = decodeJSONField[[]*UsageBreakdown](r.BreakdownsJSON)
 	usage.NormalizeWindows()
 
 	return usage
@@ -192,23 +182,33 @@ func toRecord(usage *ProviderUsage) *ProviderUsageRecord {
 
 	// Variable quota data
 	usage.NormalizeWindows()
-	if len(usage.Windows) > 0 {
-		if data, err := json.Marshal(usage.Windows); err == nil {
-			windowsJSON := string(data)
-			record.WindowsJSON = &windowsJSON
-		}
-	}
-	if len(usage.Breakdowns) > 0 {
-		if data, err := json.Marshal(usage.Breakdowns); err == nil {
-			breakdownsJSON := string(data)
-			record.BreakdownsJSON = &breakdownsJSON
-		}
-	}
+	record.WindowsJSON = encodeJSONField(usage.Windows)
+	record.BreakdownsJSON = encodeJSONField(usage.Breakdowns)
 
 	return record
 }
 
 // Helper functions
+func decodeJSONField[T any](value *string) T {
+	var zero T
+	if value == nil || *value == "" {
+		return zero
+	}
+	if err := json.Unmarshal([]byte(*value), &zero); err != nil {
+		return *new(T)
+	}
+	return zero
+}
+
+func encodeJSONField[T any](value T) *string {
+	data, err := json.Marshal(value)
+	if err != nil || string(data) == "null" || string(data) == "[]" {
+		return nil
+	}
+	encoded := string(data)
+	return &encoded
+}
+
 func getFloat64(f *float64) float64 {
 	if f == nil {
 		return 0

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// ProviderType 供应商类型枚举
+// ProviderType provider type enumeration
 type ProviderType string
 
 const (
@@ -28,126 +28,126 @@ const (
 	ProviderTypeCodex      ProviderType = "codex"
 )
 
-// WindowType 窗口类型枚举
+// WindowType window type enumeration
 type WindowType string
 
 const (
-	WindowTypeSession    WindowType = "session"     // 会话配额（小时级）
-	WindowTypeDaily      WindowType = "daily"       // 日配额
-	WindowTypeWeekly     WindowType = "weekly"      // 周配额
-	WindowTypeMonthly    WindowType = "monthly"     // 月配额
-	WindowTypeCustom     WindowType = "custom"      // 自定义窗口
-	WindowTypeBalance    WindowType = "balance"     // 余额/积分
-	WindowTypeModel      WindowType = "model"       // 模型特定配额
-	WindowTypeCodeReview WindowType = "code_review" // 代码审查配额
+	WindowTypeSession    WindowType = "session"     // session quota (hourly)
+	WindowTypeDaily      WindowType = "daily"       // daily quota
+	WindowTypeWeekly     WindowType = "weekly"      // weekly quota
+	WindowTypeMonthly    WindowType = "monthly"     // monthly quota
+	WindowTypeCustom     WindowType = "custom"      // custom window
+	WindowTypeBalance    WindowType = "balance"     // balance/credits
+	WindowTypeModel      WindowType = "model"       // model-specific quota
+	WindowTypeCodeReview WindowType = "code_review" // code review quota
 )
 
-// UsageUnit 用量单位枚举
+// UsageUnit usage unit enumeration
 type UsageUnit string
 
 const (
-	UsageUnitTokens   UsageUnit = "tokens"   // Token 数量
-	UsageUnitRequests UsageUnit = "requests" // 请求次数
-	UsageUnitCredits  UsageUnit = "credits"  // 积分
-	UsageUnitCurrency UsageUnit = "currency" // 货币
-	UsageUnitPercent  UsageUnit = "percent"  // 百分比 (0-100)
+	UsageUnitTokens   UsageUnit = "tokens"   // token count
+	UsageUnitRequests UsageUnit = "requests" // request count
+	UsageUnitCredits  UsageUnit = "credits"  // credits
+	UsageUnitCurrency UsageUnit = "currency" // currency
+	UsageUnitPercent  UsageUnit = "percent"  // percentage (0-100)
 )
 
-// ProviderUsage 表示供应商配额快照
+// ProviderUsage represents a provider quota snapshot
 type ProviderUsage struct {
-	// 基础信息
-	ProviderUUID string       `json:"provider_uuid"` // 关联的 Provider UUID
-	ProviderName string       `json:"provider_name"` // 供应商名称
-	ProviderType ProviderType `json:"provider_type"` // 供应商类型
-	FetchedAt    time.Time    `json:"fetched_at"`    // 获取时间
-	ExpiresAt    time.Time    `json:"expires_at"`    // 数据过期时间
+	// Basic information
+	ProviderUUID string       `json:"provider_uuid"` // associated provider UUID
+	ProviderName string       `json:"provider_name"` // provider name
+	ProviderType ProviderType `json:"provider_type"` // provider type
+	FetchedAt    time.Time    `json:"fetched_at"`    // fetch time
+	ExpiresAt    time.Time    `json:"expires_at"`    // data expiration time
 
-	// 前端展示用的规范化配额窗口。Tier 越低越重要，展示越靠前。
+	// Normalized quota windows for frontend display. Lower tier values are more important and displayed first.
 	Windows []*UsageWindow `json:"windows,omitempty"`
 
-	// 费用信息（如月度费用）
+	// Cost information (e.g., monthly costs)
 	Cost *UsageCost `json:"cost,omitempty"`
 
-	// 账户信息（可选，用于显示用户身份）
+	// Account information (optional, for displaying user identity)
 	Account *UsageAccount `json:"account,omitempty"`
 
-	// 分组明细（如按模型、按区域等）
+	// Group breakdowns (e.g., by model, by region)
 	Breakdowns []*UsageBreakdown `json:"breakdowns,omitempty"`
 
-	// 错误信息（如果获取失败）
+	// Error information (if fetch failed)
 	LastError   string     `json:"last_error,omitempty"`
 	LastErrorAt *time.Time `json:"last_error_at,omitempty"`
 
-	// 原始响应数据（用于调试和复查）
+	// Raw response data (for debugging and review)
 	RawResponse string `json:"raw_response,omitempty"`
 }
 
-// UsageBreakdown 表示配额的分组明细（如按模型、按区域）
+// UsageBreakdown represents grouped quota breakdowns (e.g., by model, by region)
 type UsageBreakdown struct {
-	// 分组标识
-	Key   string `json:"key"`   // 分组键，如模型名称 "gpt-4"、区域 "us-east-1"
-	Label string `json:"label"` // 显示标签
-	Group string `json:"group"` // 分组类型，如 "model", "region", "tier"
+	// Group identifiers
+	Key   string `json:"key"`   // group key, e.g., model name "gpt-4", region "us-east-1"
+	Label string `json:"label"` // display label
+	Group string `json:"group"` // group type, e.g., "model", "region", "tier"
 
-	// 配额数据
-	Windows []*UsageWindow `json:"windows"` // 该分组的多维度配额窗口
+	// Quota data
+	Windows []*UsageWindow `json:"windows"` // multi-dimensional quota windows for this group
 
-	// 可选的元数据
+	// Optional metadata
 	Description string `json:"description,omitempty"`
 }
 
-// UsageWindow 表示一个配额窗口
+// UsageWindow represents a single quota window
 type UsageWindow struct {
-	// 展示标识与层级。Tier 越低越重要，展示越靠前。
+	// Display key and priority tier. Lower tier values are more important and displayed first.
 	Key  string `json:"key,omitempty"`
 	Tier int    `json:"tier,omitempty"`
 
-	// 窗口类型标识
+	// Window type identifier
 	Type WindowType `json:"type"` // session, weekly, monthly, daily, custom, balance
 
-	// 配额数据
-	Used        float64 `json:"used"`         // 已使用量
-	Limit       float64 `json:"limit"`        // 配额限制（0 表示无限制）
-	UsedPercent float64 `json:"used_percent"` // 使用百分比 (0-100)
+	// Quota data
+	Used        float64 `json:"used"`         // used amount
+	Limit       float64 `json:"limit"`        // quota limit (0 means unlimited)
+	UsedPercent float64 `json:"used_percent"` // usage percentage (0-100)
 
-	// 时间窗口
-	ResetsAt      *time.Time `json:"resets_at,omitempty"`      // 重置时间（如果已知）
-	WindowMinutes int        `json:"window_minutes,omitempty"` // 时间窗口大小（分钟）
+	// Time window
+	ResetsAt      *time.Time `json:"resets_at,omitempty"`      // reset time (if known)
+	WindowMinutes int        `json:"window_minutes,omitempty"` // time window size (minutes)
 
-	// 单位信息
+	// Unit information
 	Unit UsageUnit `json:"unit"` // tokens, requests, credits, usd
 
-	// 元数据
-	Label       string `json:"label"`       // 显示标签，如 "Session Quota"
-	Description string `json:"description"` // 描述信息
+	// Metadata
+	Label       string `json:"label"`       // display label, e.g., "Session Quota"
+	Description string `json:"description"` // description
 
-	// 限制状态（可选）
-	Allowed      *bool `json:"allowed,omitempty"`       // 是否允许请求
-	LimitReached *bool `json:"limit_reached,omitempty"` // 是否达到限制
+	// Limit status (optional)
+	Allowed      *bool `json:"allowed,omitempty"`       // whether requests are allowed
+	LimitReached *bool `json:"limit_reached,omitempty"` // whether limit is reached
 }
 
-// UsageCost 表示费用信息
+// UsageCost represents cost information
 type UsageCost struct {
-	Used         float64    `json:"used"`          // 已使用金额
-	Limit        float64    `json:"limit"`         // 预算限制（0 表示无限制）
-	CurrencyCode string     `json:"currency_code"` // 货币代码，如 USD
+	Used         float64    `json:"used"`          // amount used
+	Limit        float64    `json:"limit"`         // budget limit (0 means unlimited)
+	CurrencyCode string     `json:"currency_code"` // currency code, e.g., USD
 	ResetsAt     *time.Time `json:"resets_at,omitempty"`
-	Label        string     `json:"label"` // 显示标签
+	Label        string     `json:"label"` // display label
 }
 
-// UsageAccount 表示账户信息
+// UsageAccount represents account information
 type UsageAccount struct {
-	ID             string `json:"id"`              // 账户 ID
-	Name           string `json:"name"`            // 账户名称
-	Email          string `json:"email,omitempty"` // 账户邮箱
-	Tier           string `json:"tier,omitempty"`  // 账户层级
+	ID             string `json:"id"`              // account ID
+	Name           string `json:"name"`            // account name
+	Email          string `json:"email,omitempty"` // account email
+	Tier           string `json:"tier,omitempty"`  // account tier
 	OrganizationID string `json:"organization_id,omitempty"`
 
-	// 费用控制状态（可选）
-	SpendControlReached bool `json:"spend_control_reached,omitempty"` // 是否达到费用控制限制
+	// Spend control status (optional)
+	SpendControlReached bool `json:"spend_control_reached,omitempty"` // whether spend control limit is reached
 }
 
-// CalculateUsedPercent 计算使用百分比
+// CalculateUsedPercent calculates usage percentage
 func (w *UsageWindow) CalculateUsedPercent() float64 {
 	if w.Limit <= 0 {
 		return 0
@@ -210,12 +210,12 @@ func (p *ProviderUsage) AddWindow(key string, tier int, window *UsageWindow) *Us
 	return window
 }
 
-// IsExpired 检查配额数据是否过期
+// IsExpired checks if quota data is expired
 func (p *ProviderUsage) IsExpired() bool {
 	return time.Now().After(p.ExpiresAt)
 }
 
-// GetErrorStatus 获取错误状态
+// GetErrorStatus gets error status
 func (p *ProviderUsage) GetErrorStatus() ErrorStatus {
 	if p.LastError == "" {
 		return ErrorStatusOK
@@ -223,7 +223,7 @@ func (p *ProviderUsage) GetErrorStatus() ErrorStatus {
 	return ErrorStatusError
 }
 
-// ErrorStatus 错误状态
+// ErrorStatus error status
 type ErrorStatus string
 
 const (
@@ -231,26 +231,26 @@ const (
 	ErrorStatusError ErrorStatus = "error"
 )
 
-// ProviderUsageConfig 单个供应商的配额配置
+// ProviderUsageConfig single provider quota configuration
 type ProviderUsageConfig struct {
-	Enabled        bool   `json:"enabled"`         // 是否启用此供应商
-	Priority       int    `json:"priority"`        // 优先级（用于排序）
-	CustomEndpoint string `json:"custom_endpoint"` // 自定义 API 端点
-	FetcherType    string `json:"fetcher_type"`    // Fetcher 类型
+	Enabled        bool   `json:"enabled"`         // whether this provider is enabled
+	Priority       int    `json:"priority"`        // priority (for sorting)
+	CustomEndpoint string `json:"custom_endpoint"` // custom API endpoint
+	FetcherType    string `json:"fetcher_type"`    // Fetcher type
 }
 
-// Config 配额获取配置
+// Config quota fetch configuration
 type Config struct {
-	// 全局设置
-	Enabled         bool                           `json:"enabled"`          // 是否启用配额追踪
-	RefreshInterval time.Duration                  `json:"refresh_interval"` // 刷新间隔（默认 5 分钟）
-	CacheTTL        time.Duration                  `json:"cache_ttl"`        // 缓存有效期（默认 10 分钟）
-	RetryOnFailure  bool                           `json:"retry_on_failure"` // 失败时是否重试
-	MaxRetries      int                            `json:"max_retries"`      // 最大重试次数
-	Providers       map[string]ProviderUsageConfig `json:"providers"`        // 供应商特定配置
+	// Global settings
+	Enabled         bool                           `json:"enabled"`          // whether quota tracking is enabled
+	RefreshInterval time.Duration                  `json:"refresh_interval"` // refresh interval (default 5 minutes)
+	CacheTTL        time.Duration                  `json:"cache_ttl"`        // cache validity period (default 10 minutes)
+	RetryOnFailure  bool                           `json:"retry_on_failure"` // whether to retry on failure
+	MaxRetries      int                            `json:"max_retries"`      // maximum retry attempts
+	Providers       map[string]ProviderUsageConfig `json:"providers"`        // provider-specific configuration
 }
 
-// DefaultConfig 返回默认配置
+// DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
 		Enabled:         true,
@@ -262,7 +262,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// NullableFloat64 用于 GORM 处理可为空的 float64
+// NullableFloat64 for GORM to handle nullable float64
 type NullableFloat64 struct {
 	Float64 float64
 	Valid   bool
@@ -320,7 +320,7 @@ func (n *NullableFloat64) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// NullableTime 用于 GORM 处理可为空的 time.Time
+// NullableTime for GORM to handle nullable time.Time
 type NullableTime struct {
 	Time  time.Time
 	Valid bool

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -170,7 +170,17 @@ func (p *ProviderUsage) NormalizeWindows() {
 	}
 
 	sort.SliceStable(p.Windows, func(i, j int) bool {
-		return p.Windows[i].Tier < p.Windows[j].Tier
+		left, right := p.Windows[i], p.Windows[j]
+		if left == nil && right == nil {
+			return false
+		}
+		if left == nil {
+			return false
+		}
+		if right == nil {
+			return true
+		}
+		return left.Tier < right.Tier
 	})
 }
 

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -61,13 +62,8 @@ type ProviderUsage struct {
 	FetchedAt    time.Time    `json:"fetched_at"`    // 获取时间
 	ExpiresAt    time.Time    `json:"expires_at"`    // 数据过期时间
 
-	// 配额窗口（最多支持 3 个级别：primary, secondary, tertiary）
-	Primary   *UsageWindow `json:"primary,omitempty"`
-	Secondary *UsageWindow `json:"secondary,omitempty"`
-	Tertiary  *UsageWindow `json:"tertiary,omitempty"`
-
-	// 额外配额窗口（用于模型特定配额、代码审查配额等）
-	ExtraWindows []*UsageWindow `json:"extra_windows,omitempty"`
+	// 前端展示用的规范化配额窗口。Tier 越低越重要，展示越靠前。
+	Windows []*UsageWindow `json:"windows,omitempty"`
 
 	// 费用信息（如月度费用）
 	Cost *UsageCost `json:"cost,omitempty"`
@@ -102,6 +98,10 @@ type UsageBreakdown struct {
 
 // UsageWindow 表示一个配额窗口
 type UsageWindow struct {
+	// 展示标识与层级。Tier 越低越重要，展示越靠前。
+	Key  string `json:"key,omitempty"`
+	Tier int    `json:"tier,omitempty"`
+
 	// 窗口类型标识
 	Type WindowType `json:"type"` // session, weekly, monthly, daily, custom, balance
 
@@ -156,6 +156,48 @@ func (w *UsageWindow) CalculateUsedPercent() float64 {
 		return 100
 	}
 	return (w.Used / w.Limit) * 100
+}
+
+// NormalizeWindows ensures Windows contains all aggregate quota windows in display order.
+// Lower tier means more important and is rendered first.
+func (p *ProviderUsage) NormalizeWindows() {
+	if p == nil {
+		return
+	}
+
+	for i, window := range p.Windows {
+		applyWindowDefaults(window, fmt.Sprintf("window_%d", i))
+	}
+
+	sort.SliceStable(p.Windows, func(i, j int) bool {
+		return p.Windows[i].Tier < p.Windows[j].Tier
+	})
+}
+
+func applyWindowDefaults(window *UsageWindow, key string) {
+	if window == nil {
+		return
+	}
+	if window.Key == "" {
+		window.Key = key
+	}
+	if window.UsedPercent == 0 {
+		window.UsedPercent = window.CalculateUsedPercent()
+	}
+}
+
+// AddWindow adds a quota window with canonical display metadata.
+func (p *ProviderUsage) AddWindow(key string, tier int, window *UsageWindow) *UsageWindow {
+	if p == nil || window == nil {
+		return nil
+	}
+	window.Key = key
+	window.Tier = tier
+	if window.UsedPercent == 0 {
+		window.UsedPercent = window.CalculateUsedPercent()
+	}
+	p.Windows = append(p.Windows, window)
+	return window
 }
 
 // IsExpired 检查配额数据是否过期

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -36,15 +36,18 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
 
   // Format detailed info for tooltip
   const formatDetailedInfo = () => {
-    if (window.used === 0 && window.limit === 0 && window.unit === 'percent') {
-      return `${window.used_percent.toFixed(0)}%`;
-    }
-
     const formatNumber = (num: number) => {
       if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
       if (num >= 1000) return `${(num / 1000).toFixed(0)}K`;
       return num.toString();
     };
+
+    if (window.unit === 'percent') {
+      if (window.used === 0 && window.limit === 0) {
+        return `${window.used_percent.toFixed(0)}%`;
+      }
+      return `${formatNumber(window.used)}% / ${formatNumber(window.limit)}%`;
+    }
 
     return `${formatNumber(window.used)} / ${formatNumber(window.limit)} ${window.unit}`;
   };

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Tooltip, Typography, tooltipClasses } from '@mui/material';
 import type { UsageWindow } from '@/types/quota';
+import { formatQuotaPercent, formatQuotaUsage } from '@/types/quota';
 import { QUOTA_COLORS } from '../dashboard/chartStyles';
 
 interface QuotaBarItemProps {
@@ -10,6 +11,12 @@ interface QuotaBarItemProps {
    * @default false
    */
   showDetails?: boolean;
+}
+
+function formatCompactNumber(num: number) {
+  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
+  if (num >= 1000) return `${(num / 1000).toFixed(0)}K`;
+  return num.toString();
 }
 
 /**
@@ -24,33 +31,6 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
   };
 
   const barColor = getColor(window.used_percent);
-
-  // Format usage display
-  const formatUsageDisplay = () => {
-    // For percentage-only quotas
-    if (window.used === 0 && window.limit === 0 && window.unit === 'percent') {
-      return `${window.used_percent.toFixed(0)}%`;
-    }
-    return `${window.used_percent.toFixed(0)}%`;
-  };
-
-  // Format detailed info for tooltip
-  const formatDetailedInfo = () => {
-    const formatNumber = (num: number) => {
-      if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-      if (num >= 1000) return `${(num / 1000).toFixed(0)}K`;
-      return num.toString();
-    };
-
-    if (window.unit === 'percent') {
-      if (window.used === 0 && window.limit === 0) {
-        return `${window.used_percent.toFixed(0)}%`;
-      }
-      return `${formatNumber(window.used)}% / ${formatNumber(window.limit)}%`;
-    }
-
-    return `${formatNumber(window.used)} / ${formatNumber(window.limit)} ${window.unit}`;
-  };
 
   // Format reset time
   const formatResetTime = () => {
@@ -71,7 +51,7 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
   };
 
   const resetTime = formatResetTime();
-  const detailedInfo = formatDetailedInfo();
+  const detailedInfo = formatQuotaUsage(window, { formatNumber: formatCompactNumber });
 
   const tooltipContent = (
     <Box
@@ -178,7 +158,7 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
             minWidth: 35,
           }}
         >
-          {formatUsageDisplay()}
+          {formatQuotaPercent(window)}
         </Typography>
 
         {/* Optional details inline */}

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -4,6 +4,7 @@ import { Refresh as RefreshIcon } from '@/components/icons';
 import { Info as InfoIcon } from '@/components/icons';
 import { QuotaBarItem } from './QuotaBarItem';
 import type { ProviderQuota } from '@/types/quota';
+import { quotaToWindows } from '@/types/quota';
 
 interface QuotaInlineDisplayProps {
   quota: ProviderQuota | undefined;
@@ -28,18 +29,7 @@ export function QuotaInlineDisplay({
   onRefresh,
   maxInlineItems = 3,
 }: QuotaInlineDisplayProps) {
-  // Collect all available windows
-  const windows: Array<{ key: string; window: any; label: string }> = [];
-
-  if (quota?.primary) {
-    windows.push({ key: 'primary', window: quota.primary, label: quota.primary.label });
-  }
-  if (quota?.secondary) {
-    windows.push({ key: 'secondary', window: quota.secondary, label: quota.secondary.label });
-  }
-  if (quota?.tertiary) {
-    windows.push({ key: 'tertiary', window: quota.tertiary, label: quota.tertiary.label });
-  }
+  const windows = quotaToWindows(quota);
 
   const hasQuota = windows.length > 0;
   const hasHiddenItems = windows.length > maxInlineItems;
@@ -72,8 +62,10 @@ export function QuotaInlineDisplay({
             {label}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            {window.used === 0 && window.limit === 0 && window.unit === 'percent'
-              ? `${window.used_percent.toFixed(0)}%`
+            {window.unit === 'percent'
+              ? window.used === 0 && window.limit === 0
+                ? `${window.used_percent.toFixed(0)}%`
+                : `${window.used}% / ${window.limit}% (${window.used_percent.toFixed(0)}%)`
               : `${window.used} / ${window.limit} ${window.unit} (${window.used_percent.toFixed(0)}%)`
             }
           </Typography>

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -4,7 +4,7 @@ import { Refresh as RefreshIcon } from '@/components/icons';
 import { Info as InfoIcon } from '@/components/icons';
 import { QuotaBarItem } from './QuotaBarItem';
 import type { ProviderQuota } from '@/types/quota';
-import { quotaToWindows } from '@/types/quota';
+import { formatQuotaUsage, quotaToWindows } from '@/types/quota';
 
 interface QuotaInlineDisplayProps {
   quota: ProviderQuota | undefined;
@@ -62,12 +62,7 @@ export function QuotaInlineDisplay({
             {label}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            {window.unit === 'percent'
-              ? window.used === 0 && window.limit === 0
-                ? `${window.used_percent.toFixed(0)}%`
-                : `${window.used}% / ${window.limit}% (${window.used_percent.toFixed(0)}%)`
-              : `${window.used} / ${window.limit} ${window.unit} (${window.used_percent.toFixed(0)}%)`
-            }
+            {formatQuotaUsage(window, { includePercent: true })}
           </Typography>
           {window.resets_at && (
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -118,12 +118,7 @@ export function ModelsPanel({
         );
     }, [providerModels, provider.uuid, provider.name, provider.api_style]);
 
-    // Prepare quota prop for ModelCard
-    const quotaProp = useMemo(() => {
-        return providerQuota;  // Pass full quota object, QuotaBar will handle breakdowns
-    }, [providerQuota]);
-
-    const quotaWindows = useMemo(() => quotaToWindows(quotaProp), [quotaProp]);
+    const quotaWindows = useMemo(() => quotaToWindows(providerQuota), [providerQuota]);
 
     // Re-fetch provider models when refresh trigger changes (e.g., after custom model deletion)
     useEffect(() => {
@@ -472,7 +467,7 @@ export function ModelsPanel({
                                 <Typography variant="caption" sx={{ mb: 0.5, display: 'block', color: '#64748b' }}>
                                     {label}
                                 </Typography>
-                                <QuotaBar quota={quotaProp!} window={window} />
+                                <QuotaBar quota={providerQuota!} window={window} />
                             </Box>
                         ))}
                     </Stack>

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -18,7 +18,8 @@ import {
 } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Provider } from '@/types/provider';
-import type { ProviderQuota, UsageWindow } from '@/types/quota';
+import type { ProviderQuota } from '@/types/quota';
+import { quotaToWindows } from '@/types/quota';
 import { getModelTypeInfo } from '@/utils/modelUtils';
 import { useCustomModels } from '@/hooks/useCustomModels';
 import { useProviderModels } from '@/hooks/useProviderModels';
@@ -57,27 +58,20 @@ async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> 
 
 // Convert ProviderModelData.quota to ProviderQuota type
 function convertToProviderQuota(
-    quota: { primary?: any; cost?: any } | undefined,
+    quota: Partial<ProviderQuota> | undefined,
     provider: Provider,
     lastUpdated?: string
 ): ProviderQuota | undefined {
     if (!quota) return undefined;
 
     return {
-        provider_uuid: provider.uuid,
-        provider_name: provider.name,
-        provider_type: provider.api_style,
-        fetched_at: lastUpdated || new Date().toISOString(),
-        expires_at: '',
-        primary: quota.primary as UsageWindow | undefined,
-        secondary: undefined,
-        tertiary: undefined,
-        cost: quota.cost,
-        account: undefined,
-        breakdowns: undefined,
-        last_error: undefined,
-        last_error_at: undefined,
-    };
+        ...quota,
+        provider_uuid: quota.provider_uuid ?? provider.uuid,
+        provider_name: quota.provider_name ?? provider.name,
+        provider_type: quota.provider_type ?? provider.api_style,
+        fetched_at: quota.fetched_at ?? lastUpdated ?? new Date().toISOString(),
+        expires_at: quota.expires_at ?? '',
+    } as ProviderQuota;
 }
 
 export interface ModelsPanelProps {
@@ -128,6 +122,8 @@ export function ModelsPanel({
     const quotaProp = useMemo(() => {
         return providerQuota;  // Pass full quota object, QuotaBar will handle breakdowns
     }, [providerQuota]);
+
+    const quotaWindows = useMemo(() => quotaToWindows(quotaProp), [quotaProp]);
 
     // Re-fetch provider models when refresh trigger changes (e.g., after custom model deletion)
     useEffect(() => {
@@ -437,7 +433,7 @@ export function ModelsPanel({
             </Box>
 
             {/* Provider Quota Bars - fixed at the bottom */}
-            {quotaProp && quotaProp.primary && (
+            {quotaWindows.length > 0 && (
                 <Box sx={{ p: 2, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
                     <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5 }}>
                         <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
@@ -471,33 +467,14 @@ export function ModelsPanel({
                         </IconButton>
                     </Stack>
                     <Stack spacing={1.5}>
-                        {/* Primary quota */}
-                        <Box>
-                            <Typography variant="caption" sx={{ mb: 0.5, display: 'block', color: '#64748b' }}>
-                                {quotaProp.primary.label}
-                            </Typography>
-                            <QuotaBar quota={quotaProp} windowIndex={0} />
-                        </Box>
-
-                        {/* Secondary quota */}
-                        {quotaProp.secondary && (
-                            <Box>
+                        {quotaWindows.map(({ key, label, window }) => (
+                            <Box key={key}>
                                 <Typography variant="caption" sx={{ mb: 0.5, display: 'block', color: '#64748b' }}>
-                                    {quotaProp.secondary.label}
+                                    {label}
                                 </Typography>
-                                <QuotaBar quota={quotaProp} windowIndex={1} />
+                                <QuotaBar quota={quotaProp!} window={window} />
                             </Box>
-                        )}
-
-                        {/* Tertiary quota */}
-                        {quotaProp.tertiary && (
-                            <Box>
-                                <Typography variant="caption" sx={{ mb: 0.5, display: 'block', color: '#64748b' }}>
-                                    {quotaProp.tertiary.label}
-                                </Typography>
-                                <QuotaBar quota={quotaProp} windowIndex={2} />
-                            </Box>
-                        )}
+                        ))}
                     </Stack>
                 </Box>
             )}

--- a/frontend/src/components/model-select/QuotaBar.tsx
+++ b/frontend/src/components/model-select/QuotaBar.tsx
@@ -2,7 +2,7 @@ import { Box, Tooltip } from '@mui/material';
 import { QuotaTooltipContent } from './QuotaTooltip';
 import type { QuotaTooltipData, QuotaWindowDisplay } from './QuotaTooltip';
 import { QUOTA_COLORS, formatNumber } from '../dashboard/chartStyles';
-import type { ProviderQuota } from '../../types/quota';
+import type { ProviderQuota, TieredUsageWindow } from '../../types/quota';
 
 interface UsageWindow {
   type: string;
@@ -24,16 +24,15 @@ interface UsageCost {
 
 interface QuotaBarProps {
   quota: ProviderQuota;
-  windowIndex?: 0 | 1 | 2;  // 0=primary, 1=secondary, 2=tertiary
+  window?: TieredUsageWindow;
+  windowIndex?: 0 | 1 | 2;  // Legacy fallback only
 }
 
-export function QuotaBar({ quota, windowIndex = 0 }: QuotaBarProps) {
-  // Get the window based on index
+export function QuotaBar({ quota, window: explicitWindow, windowIndex = 0 }: QuotaBarProps) {
+  // Get the canonical window when a direct window is not provided.
   const getWindow = (): UsageWindow | null => {
-    if (windowIndex === 0) return quota.primary || null;
-    if (windowIndex === 1) return quota.secondary || null;
-    if (windowIndex === 2) return quota.tertiary || null;
-    return quota.primary || null;
+    if (explicitWindow) return explicitWindow;
+    return quota.windows?.[windowIndex] || null;
   };
 
   const window = getWindow();
@@ -49,6 +48,7 @@ export function QuotaBar({ quota, windowIndex = 0 }: QuotaBarProps) {
         breakdownDisplays.push({
           label: bd.label,
           window: targetWindow,
+          group: bd.group,
           color: QUOTA_COLORS.secondary,
         });
       }

--- a/frontend/src/components/model-select/QuotaBar.tsx
+++ b/frontend/src/components/model-select/QuotaBar.tsx
@@ -1,26 +1,8 @@
 import { Box, Tooltip } from '@mui/material';
 import { QuotaTooltipContent } from './QuotaTooltip';
 import type { QuotaTooltipData, QuotaWindowDisplay } from './QuotaTooltip';
-import { QUOTA_COLORS, formatNumber } from '../dashboard/chartStyles';
+import { QUOTA_COLORS } from '../dashboard/chartStyles';
 import type { ProviderQuota, TieredUsageWindow } from '../../types/quota';
-
-interface UsageWindow {
-  type: string;
-  used: number;
-  limit: number;
-  used_percent: number;
-  resets_at?: string;
-  unit: string;
-  label: string;
-  description?: string;
-}
-
-interface UsageCost {
-  used: number;
-  limit: number;
-  currency_code: string;
-  label?: string;
-}
 
 interface QuotaBarProps {
   quota: ProviderQuota;
@@ -29,21 +11,16 @@ interface QuotaBarProps {
 }
 
 export function QuotaBar({ quota, window: explicitWindow, windowIndex = 0 }: QuotaBarProps) {
-  // Get the canonical window when a direct window is not provided.
-  const getWindow = (): UsageWindow | null => {
-    if (explicitWindow) return explicitWindow;
-    return quota.windows?.[windowIndex] || null;
-  };
-
-  const window = getWindow();
+  const window = explicitWindow ?? quota.windows?.[windowIndex] ?? null;
   if (!window) return null;
 
   // Get breakdown windows for tooltip
   const breakdownDisplays: QuotaWindowDisplay[] = [];
   if (quota.breakdowns && quota.breakdowns.length > 0) {
     for (const bd of quota.breakdowns) {
-      // Use the window matching current window type
-      const targetWindow = bd.windows.find(w => w.type === window.type) || bd.windows[0];
+      const targetWindow = bd.windows.find(w => window.key && w.key === window.key)
+        || bd.windows.find(w => w.type === window.type)
+        || bd.windows[0];
       if (targetWindow) {
         breakdownDisplays.push({
           label: bd.label,
@@ -134,136 +111,6 @@ export function QuotaBar({ quota, window: explicitWindow, windowIndex = 0 }: Quo
           sx={{
             position: 'absolute',
             left: `${Math.min(window.used_percent, 100)}%`,
-            top: '50%',
-            transform: 'translate(-50%, -50%)',
-            width: 0,
-            height: 0,
-            borderLeft: '6px solid transparent',
-            borderRight: '6px solid transparent',
-            borderTop: `10px solid ${barColor}`,
-            transition: 'left 0.3s ease',
-          }}
-        />
-      </Box>
-    </Tooltip>
-  );
-}
-
-// Legacy props interface for backward compatibility
-export interface QuotaBarLegacyProps {
-  used: number;
-  limit: number;
-  percent: number;
-  unit: string;
-  label: string;
-  resetsAt?: string;
-  secondary?: UsageWindow;
-  cost?: UsageCost;
-}
-
-export function QuotaBarLegacy({
-  used,
-  limit,
-  percent,
-  unit,
-  label,
-  resetsAt,
-  secondary,
-  cost,
-}: QuotaBarLegacyProps) {
-  const getColor = () => {
-    if (percent >= 80) return QUOTA_COLORS.error;
-    if (percent >= 50) return QUOTA_COLORS.warning;
-    return QUOTA_COLORS.success;
-  };
-
-  const barColor = getColor();
-
-  const primaryData: QuotaTooltipData = {
-    label,
-    used,
-    limit,
-    percent,
-    unit,
-    resetsAt: resetsAt,
-    color: barColor,
-  };
-
-  const secondaryData = secondary ? {
-    label: secondary.label,
-    used: secondary.used,
-    limit: secondary.limit,
-    percent: secondary.used_percent,
-    unit: secondary.unit,
-    color: QUOTA_COLORS.secondary,
-  } : undefined;
-
-  const costData = cost ? {
-    used: cost.used,
-    limit: cost.limit,
-    currency: cost.currency_code,
-  } : undefined;
-
-  const tooltipContent = (
-    <QuotaTooltipContent
-      title={label}
-      primary={primaryData}
-      secondary={secondaryData}
-      cost={costData}
-    />
-  );
-
-  return (
-    <Tooltip
-      title={tooltipContent}
-      arrow={false}
-      placement="top"
-      componentsProps={{
-        tooltip: {
-          sx: {
-            backgroundColor: 'transparent',
-            boxShadow: 'none',
-            padding: 0,
-            border: 'none',
-          },
-        },
-      }}
-    >
-      <Box
-        sx={{
-          position: 'relative',
-          width: '100%',
-          height: 8,
-          cursor: 'pointer',
-        }}
-      >
-        {/* Background */}
-        <Box
-          sx={{
-            height: '100%',
-            bgcolor: QUOTA_COLORS.background,
-            borderRadius: 1,
-            position: 'relative',
-            overflow: 'hidden',
-          }}
-        >
-          {/* Fill bar */}
-          <Box
-            sx={{
-              height: '100%',
-              width: `${Math.min(percent, 100)}%`,
-              bgcolor: barColor,
-              borderRadius: 1,
-              transition: 'width 0.3s ease',
-            }}
-          />
-        </Box>
-
-        {/* Current position indicator */}
-        <Box
-          sx={{
-            position: 'absolute',
-            left: `${Math.min(percent, 100)}%`,
             top: '50%',
             transform: 'translate(-50%, -50%)',
             width: 0,

--- a/frontend/src/components/model-select/QuotaTooltip.tsx
+++ b/frontend/src/components/model-select/QuotaTooltip.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography } from '@mui/material';
 import { tooltipStyle, tooltipTextStyles, formatNumber } from '../dashboard/chartStyles';
+import { formatQuotaUsage } from '../../types/quota';
 import type { UsageWindow } from '../../types/quota';
 
 export interface QuotaTooltipData {
@@ -33,15 +34,15 @@ export interface QuotaTooltipProps {
 
 export function QuotaTooltipContent({ title, primary, secondary, cost, breakdowns }: QuotaTooltipProps) {
   // Helper function to format usage display
-  const formatUsageDisplay = (data: QuotaTooltipData) => {
-    if (data.unit === 'percent') {
-      if (data.used === 0 && data.limit === 0) {
-        return `${data.percent.toFixed(0)}%`;
-      }
-      return `${formatNumber(data.used)}% / ${formatNumber(data.limit)}%`;
-    }
-    return `${formatNumber(data.used)} / ${formatNumber(data.limit)} ${data.unit}`;
-  };
+  const formatUsageDisplay = (data: QuotaTooltipData) => formatQuotaUsage(
+    {
+      used: data.used,
+      limit: data.limit,
+      used_percent: data.percent,
+      unit: data.unit,
+    },
+    { formatNumber }
+  );
 
   return (
     <Box sx={tooltipStyle}>
@@ -144,12 +145,7 @@ export function QuotaTooltipContent({ title, primary, secondary, cost, breakdown
                 }}
               />
               <Typography sx={{ ...tooltipTextStyles.caption, fontSize: '11px' }}>
-                {bd.label}: {bd.window.unit === 'percent'
-                  ? bd.window.used === 0 && bd.window.limit === 0
-                    ? `${bd.window.used_percent.toFixed(0)}%`
-                    : `${formatNumber(bd.window.used)}% / ${formatNumber(bd.window.limit)}% (${bd.window.used_percent.toFixed(0)}%)`
-                  : `${formatNumber(bd.window.used)} / ${formatNumber(bd.window.limit)} ${bd.window.unit} (${bd.window.used_percent.toFixed(0)}%)`
-                }
+                {bd.label}: {formatQuotaUsage(bd.window, { includePercent: true, formatNumber })}
               </Typography>
             </Box>
           ))}

--- a/frontend/src/components/model-select/QuotaTooltip.tsx
+++ b/frontend/src/components/model-select/QuotaTooltip.tsx
@@ -15,6 +15,7 @@ export interface QuotaTooltipData {
 export interface QuotaWindowDisplay {
   label: string;
   window: UsageWindow;
+  group?: string;
   color?: string;
 }
 
@@ -33,9 +34,11 @@ export interface QuotaTooltipProps {
 export function QuotaTooltipContent({ title, primary, secondary, cost, breakdowns }: QuotaTooltipProps) {
   // Helper function to format usage display
   const formatUsageDisplay = (data: QuotaTooltipData) => {
-    // For percentage-only quotas (used=0, limit=0, unit=percent)
-    if (data.used === 0 && data.limit === 0 && data.unit === 'percent') {
-      return `${data.percent.toFixed(0)}%`;
+    if (data.unit === 'percent') {
+      if (data.used === 0 && data.limit === 0) {
+        return `${data.percent.toFixed(0)}%`;
+      }
+      return `${formatNumber(data.used)}% / ${formatNumber(data.limit)}%`;
     }
     return `${formatNumber(data.used)} / ${formatNumber(data.limit)} ${data.unit}`;
   };
@@ -120,7 +123,7 @@ export function QuotaTooltipContent({ title, primary, secondary, cost, breakdown
           }}
         >
           <Typography sx={{ ...tooltipTextStyles.caption, fontWeight: 500, mb: 1 }}>
-            By {breakdowns[0]?.window?.type === 'daily' ? 'Model' : 'Type'}:
+            By {breakdowns[0]?.group || 'Item'}:
           </Typography>
           {breakdowns.map((bd, idx) => (
             <Box
@@ -141,9 +144,11 @@ export function QuotaTooltipContent({ title, primary, secondary, cost, breakdown
                 }}
               />
               <Typography sx={{ ...tooltipTextStyles.caption, fontSize: '11px' }}>
-                {bd.label}: {bd.window.used === 0 && bd.window.limit === 0 && bd.window.unit === 'percent'
-                  ? `${bd.window.used_percent.toFixed(0)}%`
-                  : `${formatNumber(bd.window.used)} / ${formatNumber(bd.window.limit)} (${bd.window.used_percent.toFixed(0)}%)`
+                {bd.label}: {bd.window.unit === 'percent'
+                  ? bd.window.used === 0 && bd.window.limit === 0
+                    ? `${bd.window.used_percent.toFixed(0)}%`
+                    : `${formatNumber(bd.window.used)}% / ${formatNumber(bd.window.limit)}% (${bd.window.used_percent.toFixed(0)}%)`
+                  : `${formatNumber(bd.window.used)} / ${formatNumber(bd.window.limit)} ${bd.window.unit} (${bd.window.used_percent.toFixed(0)}%)`
                 }
               </Typography>
             </Box>

--- a/frontend/src/types/quota.ts
+++ b/frontend/src/types/quota.ts
@@ -18,7 +18,7 @@ export type ProviderQuota = ProviderUsage & {
 };
 
 // Re-export for consumers
-export type { UsageWindow, UsageCost, UsageAccount, UsageBreakdown, ProviderUsage as ProviderUsage };
+export type { UsageWindow, UsageCost, UsageAccount, UsageBreakdown, ProviderUsage };
 
 // Quota types for provider usage/limit information
 // Note: Most types are now from codegen, see ../client/index.ts
@@ -95,4 +95,31 @@ export function quotaToDisplayItems(quota: ProviderQuota): QuotaDisplayItem[] {
     });
 
     return items;
+}
+
+interface FormatQuotaUsageOptions {
+    includePercent?: boolean;
+    formatNumber?: (value: number) => string;
+}
+
+type QuotaUsageValues = Pick<UsageWindow, 'used' | 'limit' | 'used_percent' | 'unit'>;
+
+export function formatQuotaPercent(window: QuotaUsageValues): string {
+    return `${window.used_percent.toFixed(0)}%`;
+}
+
+export function formatQuotaUsage(
+    window: QuotaUsageValues,
+    { includePercent = false, formatNumber = String }: FormatQuotaUsageOptions = {}
+): string {
+    if (window.unit === 'percent') {
+        if (window.used === 0 && window.limit === 0) {
+            return formatQuotaPercent(window);
+        }
+        const usage = `${formatNumber(window.used)}% / ${formatNumber(window.limit)}%`;
+        return includePercent ? `${usage} (${formatQuotaPercent(window)})` : usage;
+    }
+
+    const usage = `${formatNumber(window.used)} / ${formatNumber(window.limit)} ${window.unit}`;
+    return includePercent ? `${usage} (${formatQuotaPercent(window)})` : usage;
 }

--- a/frontend/src/types/quota.ts
+++ b/frontend/src/types/quota.ts
@@ -7,9 +7,15 @@ import type {
     ProviderUsage,
 } from '@/client';
 
+export type TieredUsageWindow = UsageWindow & {
+    key?: string;
+    tier?: number;
+};
+
 // Type aliases for convenience and backward compatibility
-// ProviderQuota is an alias for ProviderUsage from codegen
-export type ProviderQuota = ProviderUsage;
+export type ProviderQuota = ProviderUsage & {
+    windows?: TieredUsageWindow[];
+};
 
 // Re-export for consumers
 export type { UsageWindow, UsageCost, UsageAccount, UsageBreakdown, ProviderUsage as ProviderUsage };
@@ -17,16 +23,53 @@ export type { UsageWindow, UsageCost, UsageAccount, UsageBreakdown, ProviderUsag
 // Quota types for provider usage/limit information
 // Note: Most types are now from codegen, see ../client/index.ts
 
+export interface QuotaWindowDisplayItem {
+    key: string;
+    label: string;
+    window: TieredUsageWindow;
+}
+
+function windowPercent(window: TieredUsageWindow): number {
+    if (typeof window.used_percent === 'number') {
+        return window.used_percent;
+    }
+    if (window.limit > 0) {
+        return Math.min((window.used / window.limit) * 100, 100);
+    }
+    return 0;
+}
+
+function withWindowDefaults(
+    window: TieredUsageWindow,
+    key: string,
+    tier: number
+): QuotaWindowDisplayItem {
+    return {
+        key: window.key || key,
+        label: window.label || key,
+        window: {
+            ...window,
+            key: window.key || key,
+            tier: window.tier ?? tier,
+            used_percent: windowPercent(window),
+        },
+    };
+}
+
+export function quotaToWindows(quota?: ProviderQuota): QuotaWindowDisplayItem[] {
+    if (!quota || !quota.windows?.length) return [];
+
+    return quota.windows
+        .map((window, index) => withWindowDefaults(window, `window-${index}`, 100 + index))
+        .sort((a, b) => (a.window.tier ?? 999) - (b.window.tier ?? 999));
+}
+
 // Extended quota with breakdowns flattened for UI consumption
 export interface QuotaDisplayItem {
-    key: string;           // Unique identifier (e.g., model name or "primary")
+    key: string;           // Unique identifier (e.g., model name or "aggregate")
     label: string;         // Display label
     group?: string;        // Group type ("model", "type", or undefined for aggregate)
-    windows: {
-        primary?: UsageWindow;
-        secondary?: UsageWindow;
-        tertiary?: UsageWindow;
-    };
+    windows: UsageWindow[];
 }
 
 // Helper to convert ProviderQuota to display items
@@ -36,31 +79,19 @@ export function quotaToDisplayItems(quota: ProviderQuota): QuotaDisplayItem[] {
     // Add breakdowns first (per-model or per-type)
     if (quota.breakdowns && quota.breakdowns.length > 0) {
         for (const bd of quota.breakdowns) {
-            // Find daily and weekly windows for this breakdown
-            const daily = bd.windows.find(w => w.type === 'daily');
-            const weekly = bd.windows.find(w => w.type === 'weekly');
-
             items.push({
                 key: bd.key,
                 label: bd.label,
                 group: bd.group,
-                windows: {
-                    primary: daily,
-                    secondary: weekly,
-                },
+                windows: bd.windows,
             });
         }
     }
 
-    // Add aggregate item at the end
     items.push({
         key: 'aggregate',
         label: 'Total',
-        windows: {
-            primary: quota.primary,
-            secondary: quota.secondary,
-            tertiary: quota.tertiary,
-        },
+        windows: quotaToWindows(quota).map(item => item.window),
     });
 
     return items;

--- a/internal/command/quota.go
+++ b/internal/command/quota.go
@@ -251,20 +251,8 @@ func printQuotaDetails(usage *quota.ProviderUsage) {
 
 // displayWindowsWithProgress displays quota windows with visual progress bars
 func displayWindowsWithProgress(usage *quota.ProviderUsage) {
-	windows := make([]*quota.UsageWindow, 0)
-
-	// Collect main windows in priority order
-	if usage.Primary != nil {
-		windows = append(windows, usage.Primary)
-	}
-	if usage.Secondary != nil {
-		windows = append(windows, usage.Secondary)
-	}
-	if usage.Tertiary != nil {
-		windows = append(windows, usage.Tertiary)
-	}
-	// Add extra windows
-	windows = append(windows, usage.ExtraWindows...)
+	usage.NormalizeWindows()
+	windows := usage.Windows
 
 	if len(windows) == 0 {
 		fmt.Println("No quota data available")

--- a/internal/server/module/statusline/handler.go
+++ b/internal/server/module/statusline/handler.go
@@ -246,54 +246,20 @@ func (h *Handler) populateQuotaData(resp *CombinedStatusData, providerUUID strin
 	}
 }
 
-// selectBestQuotaWindow selects the most relevant quota window
-// Priority: session > daily > weekly > monthly > balance
-// Falls back to Primary if no matching type found
+// selectBestQuotaWindow selects the most relevant quota window.
+// Lower tier means more important, so the first meaningful window wins.
 func (h *Handler) selectBestQuotaWindow(usage *quota.ProviderUsage) *quota.UsageWindow {
 	if usage == nil {
 		return nil
 	}
 
-	priorityOrder := []quota.WindowType{
-		quota.WindowTypeSession,
-		quota.WindowTypeDaily,
-		quota.WindowTypeWeekly,
-		quota.WindowTypeMonthly,
-		quota.WindowTypeBalance,
-	}
-
-	// Check in priority order - look for windows with actual limit data
-	for _, windowType := range priorityOrder {
-		if w := getWindowByType(usage, windowType); w != nil {
-			// Accept if it has a meaningful limit OR if it has percentage data
-			if w.Limit > 0 || (w.Limit > 0 && w.UsedPercent > 0) {
-				return w
-			}
+	usage.NormalizeWindows()
+	for _, w := range usage.Windows {
+		if w != nil && (w.Limit > 0 || w.UsedPercent > 0) {
+			return w
 		}
 	}
 
-	// Fallback: try Primary window even if limit is 0 (might be percentage-based)
-	if usage.Primary != nil {
-		// For percentage-based quotas (like Gemini), Limit=100 means 100%
-		if usage.Primary.Limit > 0 || usage.Primary.UsedPercent > 0 {
-			return usage.Primary
-		}
-	}
-
-	return nil
-}
-
-// getWindowByType gets a window by type from ProviderUsage
-func getWindowByType(usage *quota.ProviderUsage, windowType quota.WindowType) *quota.UsageWindow {
-	if usage.Primary != nil && usage.Primary.Type == windowType {
-		return usage.Primary
-	}
-	if usage.Secondary != nil && usage.Secondary.Type == windowType {
-		return usage.Secondary
-	}
-	if usage.Tertiary != nil && usage.Tertiary.Type == windowType {
-		return usage.Tertiary
-	}
 	return nil
 }
 
@@ -314,15 +280,12 @@ func (h *Handler) buildQuotaInline(mapping *tbModelMappingResult) string {
 	}
 
 	// Collect all windows with meaningful data
-	var windows []*quota.UsageWindow
-	if usage.Primary != nil && usage.Primary.Limit > 0 {
-		windows = append(windows, usage.Primary)
-	}
-	if usage.Secondary != nil && usage.Secondary.Limit > 0 {
-		windows = append(windows, usage.Secondary)
-	}
-	if usage.Tertiary != nil && usage.Tertiary.Limit > 0 {
-		windows = append(windows, usage.Tertiary)
+	usage.NormalizeWindows()
+	windows := make([]*quota.UsageWindow, 0, len(usage.Windows))
+	for _, window := range usage.Windows {
+		if window != nil && window.Limit > 0 {
+			windows = append(windows, window)
+		}
 	}
 
 	if len(windows) == 0 {

--- a/internal/server/module/statusline/handler.go
+++ b/internal/server/module/statusline/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -306,11 +307,7 @@ func (h *Handler) buildQuotaInline(mapping *tbModelMappingResult) string {
 	}
 
 	// Join all quota parts
-	result := " | Quota:"
-	for _, p := range parts {
-		result += " " + p
-	}
-	return result
+	return " | Quota: " + strings.Join(parts, " ")
 }
 
 // formatQuotaWindow formats a single quota window


### PR DESCRIPTION
## Summary
The quota system previously used inconsistent data structures across providers (Primary/Secondary/Tertiary fields vs ExtraWindows array). 
This created maintenance burden and made frontend rendering complex. 
This refactor unifies all quota windows into a single ordered `Windows` array with explicit keys and priorities.

### Major
- All providers now use `usage.AddWindow(key, priority, window)` instead of setting `Primary`/`Secondary`/`Tertiary` fields directly
- Frontend components updated to iterate over `usage.Windows` instead of checking multiple fields
- Zai and GLM providers extracted 400+ lines of duplicate code into shared `zai_shared.go` 

### Minor
- Updated quota sample task to show example responses alongside live API calls
- Added `parseGeminiResetTime()` helper to reduce time parsing duplication
- Updated tests to verify window arrays instead of individual fields