### PR TITLE
fix(agent): set CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000 for 1M context profiles

### DIFF
--- a/internal/agent/cc_settings.go
+++ b/internal/agent/cc_settings.go
@@ -32,6 +32,10 @@ func GenerateCCEnv(cfg *serverconfig.Config, baseURL, apiKey, scenarioPath strin
 		"TINGLY_API_URL":                           baseURL,
 	}
 
+	// Track whether any resolved rule has the 1M context flag so we can
+	// mirror the frontend quick-config's auto-compact window adjustment.
+	context1M := false
+
 	ruleModel := func(fallback string, uuids ...string) string {
 		if cfg != nil {
 			for _, uuid := range uuids {
@@ -40,8 +44,11 @@ func GenerateCCEnv(cfg *serverconfig.Config, baseURL, apiKey, scenarioPath strin
 						// Mirror the frontend quick-config: a rule with the 1M context
 						// flag advertises itself to Claude Code via the [1m] suffix (the
 						// client strips it back and sends the context-1m beta header).
-						if r.Flags.Context1M && !strings.HasSuffix(m, serverconfig.Context1MSuffix) {
-							m += serverconfig.Context1MSuffix
+						if r.Flags.Context1M {
+							context1M = true
+							if !strings.HasSuffix(m, serverconfig.Context1MSuffix) {
+								m += serverconfig.Context1MSuffix
+							}
 						}
 						return m
 					}
@@ -75,6 +82,13 @@ func GenerateCCEnv(cfg *serverconfig.Config, baseURL, apiKey, scenarioPath strin
 		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = tierModel("opus", serverconfig.RuleUUIDBuiltinCCOpus, "tingly/cc-opus")
 		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = tierModel("sonnet", serverconfig.RuleUUIDBuiltinCCSonnet, "tingly/cc-sonnet")
 		env["CLAUDE_CODE_SUBAGENT_MODEL"] = tierModel("subagent", serverconfig.RuleUUIDBuiltinCCSubagent, "tingly/cc-subagent")
+	}
+
+	// Mirror the frontend quick-config: when any resolved model rule has the
+	// 1M context flag, adjust the auto-compact window to match so Claude Code
+	// doesn't compact prematurely.
+	if context1M {
+		env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = "1000000"
 	}
 
 	return env

--- a/internal/agent/cc_settings_test.go
+++ b/internal/agent/cc_settings_test.go
@@ -80,6 +80,36 @@ func TestGenerateCCEnv_ProfileUnified_ResolvesCCRule(t *testing.T) {
 	}
 }
 
+func TestGenerateCCEnv_Profile_Context1MAutoCompactWindow(t *testing.T) {
+	// When any rule in the profile has Context1M=true, the auto-compact
+	// window must be adjusted to 1M so Claude Code doesn't compact prematurely.
+	cfg := &serverconfig.Config{Rules: []typ.Rule{
+		{UUID: "builtin:claude_code:p1:haiku", Scenario: "claude_code:p1", RequestModel: "haiku",
+			Flags: typ.RuleFlags{Context1M: true}, Active: true},
+	}}
+
+	env := GenerateCCEnv(cfg, "http://localhost:12580", "tok", "claude_code:p1", false, true)
+
+	if got := env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]; got != "1000000" {
+		t.Errorf("CLAUDE_CODE_AUTO_COMPACT_WINDOW = %q, want %q", got, "1000000")
+	}
+}
+
+func TestGenerateCCEnv_Profile_No1M_NoAutoCompactWindow(t *testing.T) {
+	// Without the 1M flag, the env should NOT include the auto-compact
+	// window override — let Claude Code use its own default.
+	cfg := &serverconfig.Config{Rules: []typ.Rule{
+		{UUID: "builtin:claude_code:p1:haiku", Scenario: "claude_code:p1", RequestModel: "haiku",
+			Flags: typ.RuleFlags{Context1M: false}, Active: true},
+	}}
+
+	env := GenerateCCEnv(cfg, "http://localhost:12580", "tok", "claude_code:p1", false, true)
+
+	if _, ok := env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]; ok {
+		t.Errorf("CLAUDE_CODE_AUTO_COMPACT_WINDOW should not be set without Context1M, got %q", env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
+	}
+}
+
 func TestGenerateCCEnv_MainScenario_ResolvesModernBuiltins(t *testing.T) {
 	cfg := &serverconfig.Config{Rules: []typ.Rule{
 		{UUID: serverconfig.RuleUUIDCCHaiku, Scenario: typ.ScenarioClaudeCode, RequestModel: "vendor/fast", Active: true},


### PR DESCRIPTION
GenerateCCEnv already detected rules with Context1M flag to append the [1m] suffix to model names, but never propagated that to the CLAUDE_CODE_AUTO_COMPACT_WINDOW env var.  This caused premature context compaction when launching Claude Code with a 1M-context profile via the CLI (tingly-box cc --profile / profile <name>).

Now context1M detection sets the auto-compact window to 1000000, matching the frontend quick-config behavior in derivePrefsFromRules.