### PR TITLE
perf(protocol): reduce memory retention in protocol especially Anthropic passthrough

### DIFF
--- a/internal/guardrails/mutate/anthropic_stream.go
+++ b/internal/guardrails/mutate/anthropic_stream.go
@@ -2,6 +2,7 @@ package mutate
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	guardrailscore "github.com/tingly-dev/tingly-box/internal/guardrails/core"
@@ -64,7 +65,7 @@ func RewriteAnthropicToolUseEvent(
 		eventType = evt.Type
 		index = int(evt.Index)
 		block = evt.ContentBlock
-		rawJSON = evt.RawJSON()
+		rawJSON = strings.Clone(evt.RawJSON())
 	case *anthropic.BetaRawMessageStreamEventUnion:
 		if evt == nil {
 			return false, nil, nil
@@ -72,7 +73,7 @@ func RewriteAnthropicToolUseEvent(
 		eventType = evt.Type
 		index = int(evt.Index)
 		block = evt.ContentBlock
-		rawJSON = evt.RawJSON()
+		rawJSON = strings.Clone(evt.RawJSON())
 	default:
 		return false, nil, nil
 	}

--- a/internal/protocol/anthropic.go
+++ b/internal/protocol/anthropic.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/tidwall/gjson"
 )
 
 // Use official Anthropic SDK types directly
@@ -61,35 +62,15 @@ func (r *AnthropicBetaMessagesRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (r *AnthropicBetaMessagesRequest) UnmarshalJSON(data []byte) error {
-	aux := &struct {
-		Stream bool `json:"stream"`
-	}{}
-	if err := json.Unmarshal(data, aux); err != nil {
-		return err
-	}
-
 	r.BetaMessageNewParams = new(anthropic.BetaMessageNewParams)
-	r.Stream = aux.Stream
+	r.Stream = gjson.GetBytes(data, "stream").Bool()
 
-	if err := json.Unmarshal(data, r.BetaMessageNewParams); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(data, r.BetaMessageNewParams)
 }
 
 func (r *AnthropicMessagesRequest) UnmarshalJSON(data []byte) error {
-	aux := &struct {
-		Stream bool `json:"stream"`
-	}{}
-	if err := json.Unmarshal(data, aux); err != nil {
-		return err
-	}
-
 	r.MessageNewParams = new(anthropic.MessageNewParams)
-	r.Stream = aux.Stream
+	r.Stream = gjson.GetBytes(data, "stream").Bool()
 
-	if err := json.Unmarshal(data, r.MessageNewParams); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(data, r.MessageNewParams)
 }

--- a/internal/protocol/assembler/streamemit/emitter_v1.go
+++ b/internal/protocol/assembler/streamemit/emitter_v1.go
@@ -1,6 +1,8 @@
 package streamemit
 
 import (
+	"strings"
+
 	"github.com/anthropics/anthropic-sdk-go"
 )
 
@@ -20,7 +22,7 @@ func (e *StreamEmitter) FeedV1(evt *anthropic.MessageStreamEventUnion) ([]Buffer
 	// stay accurate regardless of buffering decisions.
 	e.msg.RecordV1Event(evt)
 
-	payload, err := payloadFromRaw(evt.RawJSON(), evt.Type)
+	payload, err := payloadFromRaw(strings.Clone(evt.RawJSON()), evt.Type)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/protocol/assembler/streamemit/emitter_v1beta.go
+++ b/internal/protocol/assembler/streamemit/emitter_v1beta.go
@@ -1,6 +1,8 @@
 package streamemit
 
 import (
+	"strings"
+
 	"github.com/anthropics/anthropic-sdk-go"
 )
 
@@ -18,7 +20,7 @@ func (e *StreamEmitter) FeedV1Beta(evt *anthropic.BetaRawMessageStreamEventUnion
 
 	e.msg.RecordV1BetaEvent(evt)
 
-	payload, err := payloadFromRaw(evt.RawJSON(), evt.Type)
+	payload, err := payloadFromRaw(strings.Clone(evt.RawJSON()), evt.Type)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/protocol/nonstream/anthropic_write.go
+++ b/internal/protocol/nonstream/anthropic_write.go
@@ -2,6 +2,7 @@ package nonstream
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -20,7 +21,7 @@ import (
 // be stale. They marshal the struct directly so the wire reflects the mutation.
 func WriteAnthropicMessage(c *gin.Context, msg any) {
 	if r, ok := msg.(interface{ RawJSON() string }); ok {
-		if raw := r.RawJSON(); raw != "" {
+		if raw := strings.Clone(r.RawJSON()); raw != "" {
 			c.Data(http.StatusOK, "application/json; charset=utf-8", []byte(raw))
 			return
 		}

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -17,95 +18,121 @@ import (
 // HandleAnthropic handles Anthropic v1 streaming response.
 // Returns (UsageStat, error)
 func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Stream[anthropic.MessageStreamEventUnion]) (*protocol.TokenUsage, error) {
-	defer streamResp.Close()
+	streamClosed := false
+	defer func() {
+		if !streamClosed {
+			streamResp.Close()
+		}
+	}()
+	defer hc.ReleaseStreamState()
 
 	hc.SetupSSEHeaders()
 
 	acc := usage.NewAnthropicAccumulator()
 	var sawMessageStart, sawMessageStop bool
+	var processErr error
 
-	err := hc.ProcessStream(
-		func() (bool, error, interface{}) {
-			if streamResp.Err() != nil {
-				return false, streamResp.Err(), nil
-			}
-			if !streamResp.Next() {
-				// Surface an error that the SDK only set during this Next()
-				// (e.g. an in-band SSE error event or a pre-content upstream
-				// failure) so the handler can emit a retryable status instead
-				// of a clean finish.
-				return false, streamResp.Err(), nil
-			}
-			// Current() returns a value, but we need a pointer for modification
-			return true, nil, new(streamResp.Current())
-		},
-		func(event interface{}) error {
-			evt := event.(*anthropic.MessageStreamEventUnion)
-			switch evt.Type {
-			case "message_start":
-				sawMessageStart = true
-			case "message_stop":
-				sawMessageStop = true
-			}
+	protocol.RunLoop(hc.GinContext, func(_ io.Writer) bool {
+		select {
+		case <-hc.GinContext.Request.Context().Done():
+			return false
+		default:
+		}
 
-			acc.Consume(evt)
+		// Pre-check: surface an error the SDK set before the current call
+		// (e.g. from a previous Close or an in-band SSE error event).
+		if streamResp.Err() != nil {
+			processErr = streamResp.Err()
+			return false
+		}
 
-			// This passthrough writes raw upstream bytes via c.SSEvent, bypassing
-			// sendAnthropicStreamEvent, so mark TTFT here on the first content delta.
-			if isAnthropicContentDeltaEvent(evt.Type) {
-				protocol.MarkFirstToken(hc.GinContext)
+		if !streamResp.Next() {
+			// Explicit close on stream end matches the original nextFunc
+			// behavior: Close() before returning to surface transport errors.
+			streamClosed = true
+			if err := streamResp.Close(); err != nil {
+				processErr = err
+			} else if streamResp.Err() != nil {
+				processErr = streamResp.Err()
 			}
+			return false
+		}
 
-			if hc.Guardrails != nil && hc.Guardrails.Enabled {
-				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
-					return err
-				} else if handled {
-					for _, rewrittenEvent := range rewritten {
-						sendAnthropicStreamEvent(hc.GinContext, rewrittenEvent.EventType, rewrittenEvent.Payload, hc.GinContext.Writer)
-					}
-					return nil
+		event := streamResp.Current()
+		evt := &event
+
+		// Call stream event hooks (recorder, guardrails)
+		for _, hook := range hc.OnStreamEventHooks {
+			if hookErr := hook(evt); hookErr != nil {
+				processErr = hookErr
+				return false
+			}
+		}
+
+		switch evt.Type {
+		case "message_start":
+			sawMessageStart = true
+		case "message_stop":
+			sawMessageStop = true
+		}
+
+		acc.Consume(evt)
+
+		// This passthrough writes raw upstream bytes via c.SSEvent, bypassing
+		// sendAnthropicStreamEvent, so mark TTFT here on the first content delta.
+		if isAnthropicContentDeltaEvent(evt.Type) {
+			protocol.MarkFirstToken(hc.GinContext)
+		}
+
+		if hc.Guardrails != nil && hc.Guardrails.Enabled {
+			if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
+				processErr = err
+				return false
+			} else if handled {
+				for _, rewrittenEvent := range rewritten {
+					sendAnthropicStreamEvent(hc.GinContext, rewrittenEvent.EventType, rewrittenEvent.Payload, hc.GinContext.Writer)
 				}
+				hc.GinContext.Writer.Flush()
+				return true
 			}
+		}
 
-			// For message_start events, modify the model in the raw JSON
-			// to preserve the original API response structure
-			if evt.Type == "message_start" {
-				var eventMap map[string]json.RawMessage
-				if err := json.Unmarshal([]byte(evt.RawJSON()), &eventMap); err == nil {
-					var msgMap map[string]json.RawMessage
-					if err := json.Unmarshal(eventMap["message"], &msgMap); err == nil {
-						msgMap["model"] = json.RawMessage(`"` + hc.ResponseModel + `"`)
-						eventMap["message"], _ = json.Marshal(msgMap)
-					}
-					modified, _ := json.Marshal(eventMap)
-					hc.GinContext.SSEvent(evt.Type, string(modified))
-				} else {
-					hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
+		// For message_start events, modify the model in the raw JSON
+		// to preserve the original API response structure
+		if evt.Type == "message_start" {
+			var eventMap map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(evt.RawJSON()), &eventMap); err == nil {
+				var msgMap map[string]json.RawMessage
+				if err := json.Unmarshal(eventMap["message"], &msgMap); err == nil {
+					msgMap["model"] = json.RawMessage(`"` + hc.ResponseModel + `"`)
+					eventMap["message"], _ = json.Marshal(msgMap)
 				}
+				modified, _ := json.Marshal(eventMap)
+				hc.GinContext.SSEvent(evt.Type, string(modified))
 			} else {
 				hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
 			}
-			hc.GinContext.Writer.Flush()
-			return nil
-		},
-	)
+		} else {
+			hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
+		}
+		hc.GinContext.Writer.Flush()
+		return true
+	})
 
-	// Handle errors
-	if err != nil {
-		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
+	if processErr != nil {
+		for _, hook := range hc.OnStreamErrorHooks {
+			hook(processErr)
+		}
+		if errors.Is(processErr, context.Canceled) || protocol.IsContextCanceled(processErr) {
 			logrus.WithContext(hc.GinContext.Request.Context()).Debug("Anthropic v1 stream canceled by client")
 			return acc.Result(), nil
 		}
-
-		// Stream failed before any content reached the client: surface a
-		// retryable 5xx so mid-request failover can try the next tier,
-		// instead of a 200 SSE error event.
 		if !hc.GinContext.Writer.Written() {
-			SendStreamingError(hc.GinContext, err)
-			return acc.Result(), err
+			SendStreamingError(hc.GinContext, processErr)
+			return acc.Result(), processErr
 		}
-		MarshalAndSendErrorEvent(hc.GinContext, err.Error(), "stream_error", "stream_failed")
-		return acc.Result(), err
+		MarshalAndSendErrorEvent(hc.GinContext, processErr.Error(), "stream_error", "stream_failed")
+		return acc.Result(), processErr
 	}
 
 	// Upstream cut mid-stream (content started but never terminated): surface
@@ -117,107 +144,142 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 		MarshalAndSendErrorEvent(hc.GinContext, "upstream stream ended before completion", "stream_error", "incomplete_stream")
 	}
 
+	for _, hook := range hc.OnStreamCompleteHooks {
+		hook()
+	}
+
 	return acc.Result(), nil
 }
 
 // HandleAnthropicBeta handles Anthropic v1 beta streaming response.
 // Returns (UsageStat, error)
 func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion]) (*protocol.TokenUsage, error) {
-	defer streamResp.Close()
+	streamClosed := false
+	defer func() {
+		if !streamClosed {
+			streamResp.Close()
+		}
+	}()
+	defer hc.ReleaseStreamState()
 
 	hc.SetupSSEHeaders()
 
 	acc := usage.NewAnthropicAccumulator()
 	var sawMessageStart, sawMessageStop bool
 
-	err := hc.ProcessStream(
-		func() (bool, error, interface{}) {
-			if streamResp.Err() != nil {
-				return false, streamResp.Err(), nil
-			}
-			if !streamResp.Next() {
-				// Surface an error that the SDK only set during this Next()
-				// (e.g. an in-band SSE error event or a pre-content upstream
-				// failure) so the handler can emit a retryable status instead
-				// of a clean finish.
-				return false, streamResp.Err(), nil
-			}
-			// Current() returns a value, but we need a pointer for modification
-			return true, nil, new(streamResp.Current())
-		},
-		func(event interface{}) error {
-			evt := event.(*anthropic.BetaRawMessageStreamEventUnion)
-			switch evt.Type {
-			case "message_start":
-				sawMessageStart = true
-			case "message_stop":
-				sawMessageStop = true
-			}
+	var processErr error
 
-			acc.ConsumeBeta(evt)
+	protocol.RunLoop(hc.GinContext, func(_ io.Writer) bool {
+		select {
+		case <-hc.GinContext.Request.Context().Done():
+			return false
+		default:
+		}
 
-			// This passthrough writes raw upstream bytes via c.SSEvent, bypassing
-			// sendAnthropicStreamEvent, so mark TTFT here on the first content delta.
-			if isAnthropicContentDeltaEvent(evt.Type) {
-				protocol.MarkFirstToken(hc.GinContext)
+		// Pre-check: surface an error the SDK set before the current call
+		// (e.g. from a previous Close or an in-band SSE error event).
+		if streamResp.Err() != nil {
+			processErr = streamResp.Err()
+			return false
+		}
+
+		if !streamResp.Next() {
+			// Explicit close on stream end matches the original nextFunc
+			// behavior: Close() before returning to surface transport errors.
+			streamClosed = true
+			if err := streamResp.Close(); err != nil {
+				processErr = err
+			} else if streamResp.Err() != nil {
+				processErr = streamResp.Err()
 			}
+			return false
+		}
 
-			if hc.Guardrails != nil && hc.Guardrails.Enabled {
-				if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
-					return err
-				} else if handled {
-					for _, rewrittenEvent := range rewritten {
-						sendAnthropicStreamEvent(hc.GinContext, rewrittenEvent.EventType, rewrittenEvent.Payload, hc.GinContext.Writer)
-					}
-					return nil
+		event := streamResp.Current()
+		evt := &event
+
+		// Call stream event hooks (recorder, guardrails)
+		for _, hook := range hc.OnStreamEventHooks {
+			if hookErr := hook(evt); hookErr != nil {
+				processErr = hookErr
+				return false
+			}
+		}
+
+		switch evt.Type {
+		case "message_start":
+			sawMessageStart = true
+		case "message_stop":
+			sawMessageStop = true
+		}
+
+		acc.ConsumeBeta(evt)
+
+		// This passthrough writes raw upstream bytes via c.SSEvent, bypassing
+		// sendAnthropicStreamEvent, so mark TTFT here on the first content delta.
+		if isAnthropicContentDeltaEvent(evt.Type) {
+			protocol.MarkFirstToken(hc.GinContext)
+		}
+
+		if hc.Guardrails != nil && hc.Guardrails.Enabled {
+			if handled, rewritten, err := guardrailsmutate.RewriteAnthropicToolUseEvent(hc.Guardrails.CredentialMask, hc.Guardrails.Stream, evt); err != nil {
+				processErr = err
+				return false
+			} else if handled {
+				for _, rewrittenEvent := range rewritten {
+					sendAnthropicStreamEvent(hc.GinContext, rewrittenEvent.EventType, rewrittenEvent.Payload, hc.GinContext.Writer)
 				}
+				hc.GinContext.Writer.Flush()
+				return true
 			}
+		}
 
-			// For message_start events, modify the model in the raw JSON
-			// to preserve the original API response structure
-			if evt.Type == "message_start" {
-				var eventMap map[string]json.RawMessage
-				if err := json.Unmarshal([]byte(evt.RawJSON()), &eventMap); err == nil {
-					var msgMap map[string]json.RawMessage
-					if err := json.Unmarshal(eventMap["message"], &msgMap); err == nil {
-						msgMap["model"] = json.RawMessage(`"` + hc.ResponseModel + `"`)
-						eventMap["message"], _ = json.Marshal(msgMap)
-					}
-					modified, _ := json.Marshal(eventMap)
-					hc.GinContext.SSEvent(evt.Type, string(modified))
-				} else {
-					hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
+		// For message_start events, modify the model in the raw JSON
+		// to preserve the original API response structure
+		if evt.Type == "message_start" {
+			var eventMap map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(evt.RawJSON()), &eventMap); err == nil {
+				var msgMap map[string]json.RawMessage
+				if err := json.Unmarshal(eventMap["message"], &msgMap); err == nil {
+					msgMap["model"] = json.RawMessage(`"` + hc.ResponseModel + `"`)
+					eventMap["message"], _ = json.Marshal(msgMap)
 				}
+				modified, _ := json.Marshal(eventMap)
+				hc.GinContext.SSEvent(evt.Type, string(modified))
 			} else {
 				hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
 			}
-			hc.GinContext.Writer.Flush()
-			return nil
-		},
-	)
+		} else {
+			hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
+		}
+		hc.GinContext.Writer.Flush()
+		return true
+	})
 
-	// Handle errors
-	if err != nil {
-		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
+	if processErr != nil {
+		for _, hook := range hc.OnStreamErrorHooks {
+			hook(processErr)
+		}
+		if errors.Is(processErr, context.Canceled) || protocol.IsContextCanceled(processErr) {
 			logrus.WithContext(hc.GinContext.Request.Context()).Debug("Anthropic v1 beta stream canceled by client")
 			return acc.Result(), nil
 		}
-
-		// Stream failed before any content reached the client: surface a
-		// retryable 5xx so mid-request failover can try the next tier,
-		// instead of a 200 SSE error event.
 		if !hc.GinContext.Writer.Written() {
-			SendStreamingError(hc.GinContext, err)
-			return acc.Result(), err
+			SendStreamingError(hc.GinContext, processErr)
+			return acc.Result(), processErr
 		}
-		MarshalAndSendErrorEvent(hc.GinContext, err.Error(), "stream_error", "stream_failed")
-		return acc.Result(), err
+		MarshalAndSendErrorEvent(hc.GinContext, processErr.Error(), "stream_error", "stream_failed")
+		return acc.Result(), processErr
 	}
 
 	// See HandleAnthropic: surface an honest error event when the upstream was
 	// cut after content started.
 	if sawMessageStart && !sawMessageStop {
 		MarshalAndSendErrorEvent(hc.GinContext, "upstream stream ended before completion", "stream_error", "incomplete_stream")
+	}
+
+	for _, hook := range hc.OnStreamCompleteHooks {
+		hook()
 	}
 
 	return acc.Result(), nil

--- a/internal/protocol/stream/anthropic_passthrough.go
+++ b/internal/protocol/stream/anthropic_passthrough.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
@@ -79,10 +80,10 @@ func HandleAnthropic(hc *protocol.HandleContext, streamResp *anthropicstream.Str
 					modified, _ := json.Marshal(eventMap)
 					hc.GinContext.SSEvent(evt.Type, string(modified))
 				} else {
-					hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+					hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
 				}
 			} else {
-				hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+				hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
 			}
 			hc.GinContext.Writer.Flush()
 			return nil
@@ -185,10 +186,10 @@ func HandleAnthropicBeta(hc *protocol.HandleContext, streamResp *anthropicstream
 					modified, _ := json.Marshal(eventMap)
 					hc.GinContext.SSEvent(evt.Type, string(modified))
 				} else {
-					hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+					hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
 				}
 			} else {
-				hc.GinContext.SSEvent(evt.Type, evt.RawJSON())
+				hc.GinContext.SSEvent(evt.Type, strings.Clone(evt.RawJSON()))
 			}
 			hc.GinContext.Writer.Flush()
 			return nil

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -357,8 +357,9 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 
 		evt := stream.Current()
 
-		// Marshal event using RawJSON() to avoid serializing empty union fields
-		eventRaw := evt.RawJSON()
+		// Marshal event using RawJSON() to avoid serializing empty union fields.
+		// strings.Clone breaks the gjson backing reference to the SSE buffer.
+		eventRaw := strings.Clone(evt.RawJSON())
 		eventType := evt.Type
 
 		// Accumulate usage from the raw JSON (SDK struct fields may be zero for

--- a/internal/protocol/usage/accumulator.go
+++ b/internal/protocol/usage/accumulator.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"strings"
+
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/tidwall/gjson"
 
@@ -31,7 +33,7 @@ func NewAnthropicAccumulator() *AnthropicAccumulator {
 // It is safe to call on every event in the stream; only usage-carrying
 // events (message_start, message_delta) have any effect.
 func (a *AnthropicAccumulator) Consume(evt *anthropic.MessageStreamEventUnion) {
-	raw := evt.RawJSON()
+	raw := strings.Clone(evt.RawJSON())
 	a.consumeRaw(
 		evt.Message.Usage.InputTokens,
 		gjson.Get(raw, "message.usage.input_tokens").Int(),

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -100,7 +100,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 
 	// Validate scenario
 	if !isValidRuleScenario(scenarioType) {
-		c.JSON(http.StatusBadRequest, ErrorResponse{
+		c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
 				Message: fmt.Sprintf("invalid scenario: %s", scenario),
 				Type:    "invalid_request_error",
@@ -122,7 +122,7 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	// Read the raw request body first for debugging purposes
 	bodyBytes, err := c.GetRawData()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
+		c.AbortWithStatusJSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{
 				Message: err.Error(),
 			},
@@ -143,14 +143,13 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	var messages = &protocol.AnthropicMessagesRequest{}
 	if beta {
 		if err := json.Unmarshal(bodyBytes, betaMessages); err != nil {
-			c.JSON(http.StatusBadRequest, ErrorResponse{
+			logrus.WithError(err).Errorf("Anthropic beta decode error")
+			c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
 					Message: fmt.Sprintf("Message decode error: %s", err.Error()),
 					Type:    "invalid_request_error",
 				},
 			})
-			logrus.WithError(err).Errorf("Anthropic beta decode error")
-			c.Abort()
 			return
 		}
 		requestModel = string(betaMessages.Model)
@@ -158,14 +157,13 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 
 	} else {
 		if err := json.Unmarshal(bodyBytes, messages); err != nil {
-			c.JSON(http.StatusBadRequest, ErrorResponse{
+			logrus.WithError(err).Errorf("Anthropic decode error")
+			c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{
 				Error: ErrorDetail{
 					Message: fmt.Sprintf("Message decode error: %s", err.Error()),
 					Type:    "invalid_request_error",
 				},
 			})
-			logrus.WithError(err).Errorf("Anthropic decode error")
-			c.Abort()
 			return
 		}
 
@@ -175,10 +173,19 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 
 	// Check if this is the request requestModel name first
 	rule, err = s.determineRuleWithScenario(c, scenarioType, requestModel)
-	if rule == nil || err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
 				Message: err.Error(),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+	if rule == nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{
+			Error: ErrorDetail{
+				Message: "no such rule",
 				Type:    "invalid_request_error",
 			},
 		})
@@ -190,13 +197,13 @@ func (s *Server) HandleAnthropicMessages(c *gin.Context) {
 	// Select service using routing pipeline
 	provider, selectedService, err = s.routingSelector.SelectService(c, scenarioType, rule, reqParams)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{
+		logrus.WithError(err).Errorf("Select service error")
+		c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{
 				Message: err.Error(),
 				Type:    "invalid_request_error",
 			},
 		})
-		logrus.WithError(err).Errorf("Select service error")
 		return
 	}
 
@@ -228,7 +235,7 @@ func (s *Server) AnthropicListModelsForScenario(c *gin.Context, scenario typ.Rul
 func (s *Server) anthropicListModelsWithScenario(c *gin.Context, scenario *typ.RuleScenario) {
 	cfg := s.config
 	if cfg == nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
+		c.AbortWithStatusJSON(http.StatusInternalServerError, ErrorResponse{
 			Error: ErrorDetail{
 				Message: "Config not available",
 				Type:    "internal_error",

--- a/internal/server/anthropic_message_beta.go
+++ b/internal/server/anthropic_message_beta.go
@@ -185,7 +185,7 @@ func (s *Server) nonstreamResponsesToAnthropicBeta(c *gin.Context, proxyModel st
 
 	// Use standard OpenAI Responses API (session ID already in c.Request.Context)
 	wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, responsesReq.Model)
-	fc := forwarding.NewForwardContext(nil, provider)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 
 	response, cancel, err = forwarding.ForwardOpenAIResponses(fc, wrapper, responsesReq)
 	if cancel != nil {

--- a/internal/server/anthropic_message_v1.go
+++ b/internal/server/anthropic_message_v1.go
@@ -165,7 +165,7 @@ func (s *Server) nonstreamResponsesToAnthropic(c *gin.Context, proxyModel string
 
 	// Use standard OpenAI Responses API (session ID already in c.Request.Context)
 	wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, responsesReq.Model)
-	fc := forwarding.NewForwardContext(nil, provider)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 
 	response, cancel, err = forwarding.ForwardOpenAIResponses(fc, wrapper, responsesReq)
 	if cancel != nil {

--- a/internal/server/forwarding/context.go
+++ b/internal/server/forwarding/context.go
@@ -30,9 +30,6 @@ type ForwardContext struct {
 //   - Use context.Background() for non-streaming requests
 //   - Use c.Request.Context() for streaming requests to support client cancellation
 func NewForwardContext(baseCtx context.Context, provider *typ.Provider) *ForwardContext {
-	if baseCtx == nil {
-		baseCtx = context.Background()
-	}
 	timeout := time.Duration(provider.Timeout) * time.Second
 	if timeout <= 0 {
 		timeout = time.Duration(constant.DefaultRequestTimeout) * time.Second
@@ -80,9 +77,6 @@ func (fc *ForwardContext) WithAfterRequest(hook func(context.Context, interface{
 // 2. Add timeout
 func (fc *ForwardContext) PrepareContext(req interface{}) (context.Context, context.CancelFunc) {
 	ctx := fc.BaseCtx
-	if ctx == nil {
-		ctx = context.Background()
-	}
 
 	// Apply BeforeRequest hooks in order
 	for _, hook := range fc.BeforeRequestHooks {

--- a/internal/server/module/mcp/anthropic_beta_adapter.go
+++ b/internal/server/module/mcp/anthropic_beta_adapter.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
@@ -421,7 +422,7 @@ func (a *AnthropicBetaAdapter) RewriteEventIndex(event any, offset int) ([]byte,
 		return nil, fmt.Errorf("expected *BetaRawMessageStreamEventUnion, got %T", event)
 	}
 
-	rawJSON := e.RawJSON() // This returns string
+	rawJSON := strings.Clone(e.RawJSON()) // This returns string
 	// Parse and rewrite index
 	var parsed map[string]interface{}
 	if err := json.Unmarshal([]byte(rawJSON), &parsed); err != nil {

--- a/internal/server/module/mcp/anthropic_v1_adapter.go
+++ b/internal/server/module/mcp/anthropic_v1_adapter.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
@@ -416,7 +417,7 @@ func (a *AnthropicV1Adapter) RewriteEventIndex(event any, offset int) ([]byte, e
 		return nil, fmt.Errorf("expected *MessageStreamEventUnion, got %T", event)
 	}
 
-	rawJSON := e.RawJSON() // This returns string
+	rawJSON := strings.Clone(e.RawJSON()) // This returns string
 	// Parse and rewrite index
 	var parsed map[string]interface{}
 	if err := json.Unmarshal([]byte(rawJSON), &parsed); err != nil {

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -139,7 +139,7 @@ func (s *Server) nonstreamOpenAIChat(c *gin.Context, provider *typ.Provider, ori
 
 	// Forward request to provider
 	wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, req.Model)
-	fc := forwarding.NewForwardContext(nil, provider)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 	response, _, err := forwarding.ForwardOpenAIChat(fc, wrapper, req)
 	if err != nil {
 		// Track error with no usage

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -397,82 +397,77 @@ func (s *Server) passthroughAnthropicBeta(
 
 	ctx := c.Request.Context()
 
-	switch reqCtx.SourceAPI {
-	case protocol.TypeOpenAIChat:
-		s.dispatchAnthropicBetaToOpenAIChat(c, reqCtx, rule, provider, isStreaming, recorder)
-	default:
-		if isStreaming {
-			if declaredMCP && s.mcpEnabled() {
-				s.dispatchGenericAnthropicBetaStream(c, reqCtx, rule, provider, recorder)
-				return
-			}
-
-			wrapper := s.clientPool.GetAnthropicClient(ctx, provider, actualModel)
-			fc := forwarding.NewForwardContext(ctx, provider)
-			streamResp, cancel, err := forwarding.ForwardAnthropicV1BetaStream(fc, wrapper, req)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				s.trackUsageFromContext(c, 0, 0, err)
-				stream.SendStreamingError(c, err)
-				if recorder != nil {
-					recorder.RecordError(err)
-				}
-				return
-			}
-
-			s.streamAnthropicBeta(c, req, streamResp, actualModel, responseModel, provider, recorder)
+	if isStreaming {
+		if declaredMCP && s.mcpEnabled() {
+			s.dispatchGenericAnthropicBetaStream(c, reqCtx, rule, provider, recorder)
 			return
 		}
 
-		var anthropicResp *anthropic.BetaMessage
-		var err error
-		if declaredMCP && s.mcpEnabled() {
-			var usage *mcp.TokenUsage
-			anthropicResp, usage, err = s.runGenericAnthropicBetaNonStream(ctx, provider, req, recorder)
-			if err != nil {
-				recordMCPForwardingError(s, c, err, recorder)
-				return
+		wrapper := s.clientPool.GetAnthropicClient(ctx, provider, actualModel)
+		fc := forwarding.NewForwardContext(ctx, provider)
+		streamResp, cancel, err := forwarding.ForwardAnthropicV1BetaStream(fc, wrapper, req)
+		if cancel != nil {
+			defer cancel()
+		}
+		if err != nil {
+			s.trackUsageFromContext(c, 0, 0, err)
+			stream.SendStreamingError(c, err)
+			if recorder != nil {
+				recorder.RecordError(err)
 			}
-			if usage != nil {
-				tokenUsage := protocol.NewTokenUsageWithCache(usage.InputTokens, usage.OutputTokens, usage.CacheTokens)
-				s.trackUsageWithTokenUsage(c, tokenUsage, nil)
-			}
-		} else {
-			wrapper := s.clientPool.GetAnthropicClient(ctx, provider, actualModel)
-			fc := forwarding.NewForwardContext(ctx, provider)
-			var cancel context.CancelFunc
-			anthropicResp, cancel, err = forwarding.ForwardAnthropicV1Beta(fc, wrapper, req)
-			if cancel != nil {
-				defer cancel()
-			}
-			if err != nil {
-				s.trackUsageFromContext(c, 0, 0, err)
-				stream.SendForwardingError(c, err)
-				if recorder != nil {
-					recorder.RecordError(err)
-				}
-				return
-			}
-
-			s.trackUsageWithTokenUsage(c, usagepkg.FromAnthropicBetaMessage(anthropicResp.Usage), nil)
+			return
 		}
 
-		s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
-		anthropicResp.Model = anthropic.Model(responseModel)
-
-		scenario := GetTrackingContextScenario(c)
-		if s.guardrailsEnabledForScenario(scenario) {
-			s.applyGuardrailsToAnthropicV1BetaNonStreamResponse(c, req, actualModel, provider, anthropicResp)
-		}
-
-		if recorder != nil {
-			recorder.SetAssembledResponse(anthropicResp)
-			recorder.RecordResponse(provider, reqCtx.RequestModel)
-		}
-		nonstream.WriteAnthropicMessage(c, anthropicResp)
+		s.streamAnthropicBeta(c, req, streamResp, actualModel, responseModel, provider, recorder)
+		return
 	}
+
+	var anthropicResp *anthropic.BetaMessage
+	var err error
+	if declaredMCP && s.mcpEnabled() {
+		var usage *mcp.TokenUsage
+		anthropicResp, usage, err = s.runGenericAnthropicBetaNonStream(ctx, provider, req, recorder)
+		if err != nil {
+			recordMCPForwardingError(s, c, err, recorder)
+			return
+		}
+		if usage != nil {
+			tokenUsage := protocol.NewTokenUsageWithCache(usage.InputTokens, usage.OutputTokens, usage.CacheTokens)
+			s.trackUsageWithTokenUsage(c, tokenUsage, nil)
+		}
+	} else {
+		wrapper := s.clientPool.GetAnthropicClient(ctx, provider, actualModel)
+		fc := forwarding.NewForwardContext(ctx, provider)
+		var cancel context.CancelFunc
+		anthropicResp, cancel, err = forwarding.ForwardAnthropicV1Beta(fc, wrapper, req)
+		if cancel != nil {
+			defer cancel()
+		}
+		if err != nil {
+			s.trackUsageFromContext(c, 0, 0, err)
+			stream.SendForwardingError(c, err)
+			if recorder != nil {
+				recorder.RecordError(err)
+			}
+			return
+		}
+
+		s.trackUsageWithTokenUsage(c, usagepkg.FromAnthropicBetaMessage(anthropicResp.Usage), nil)
+	}
+
+	s.updateAffinityMessageID(c, rule, string(anthropicResp.ID))
+	anthropicResp.Model = anthropic.Model(responseModel)
+
+	scenario := GetTrackingContextScenario(c)
+	if s.guardrailsEnabledForScenario(scenario) {
+		s.applyGuardrailsToAnthropicV1BetaNonStreamResponse(c, req, actualModel, provider, anthropicResp)
+	}
+
+	if recorder != nil {
+		recorder.SetAssembledResponse(anthropicResp)
+		recorder.RecordResponse(provider, reqCtx.RequestModel)
+	}
+	nonstream.WriteAnthropicMessage(c, anthropicResp)
 }
 
 func hasDeclaredMCPAnthropicV1Tools(req *anthropic.MessageNewParams) bool {

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -300,11 +300,13 @@ func (s *Server) dispatchAnthropicBetaToOpenAIChat(
 		hc := protocol.NewHandleContext(c, responseModel)
 		tokenUsage, err := stream.AnthropicToOpenAIStream(hc, req, streamResp, responseModel, disableStreamUsage)
 		if err != nil {
-			if tokenUsage.InputTokens > 0 || tokenUsage.OutputTokens > 0 {
-				s.trackUsageWithTokenUsage(c, tokenUsage, err)
-			} else {
-				// Track error even when no tokens were received (e.g., early 1302 rate limit)
-				s.trackUsageFromContext(c, 0, 0, err)
+			if tokenUsage != nil {
+				if tokenUsage.InputTokens > 0 || tokenUsage.OutputTokens > 0 {
+					s.trackUsageWithTokenUsage(c, tokenUsage, err)
+				} else {
+					// Track error even when no tokens were received (e.g., early 1302 rate limit)
+					s.trackUsageFromContext(c, 0, 0, err)
+				}
 			}
 			SendErrorResponse(c, upstreamForwardStatus(err), fmt.Errorf("Failed to create streaming request: : %w", err), "api_error")
 			if recorder != nil {

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -661,7 +661,7 @@ func (s *Server) dispatchGoogle(
 		s.trackUsageWithTokenUsage(c, usage, nil)
 	} else {
 		wrapper := s.clientPool.GetGoogleClient(c.Request.Context(), provider, model)
-		fc := forwarding.NewForwardContext(nil, provider)
+		fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 		resp, _, err := forwarding.ForwardGoogle(fc, wrapper, model, req, cfg)
 		if err != nil {
 			stream.SendForwardingError(c, err)
@@ -789,7 +789,7 @@ func (s *Server) dispatchOpenAIChat(
 			}
 		} else {
 			wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, req.Model)
-			fc := forwarding.NewForwardContext(nil, provider)
+			fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 			resp, _, err = forwarding.ForwardOpenAIChat(fc, wrapper, req)
 			if err != nil {
 				stream.SendForwardingError(c, err)
@@ -896,7 +896,7 @@ func (s *Server) nonstreamOpenAIResponses(c *gin.Context, reqCtx *transform.Tran
 	params := reqCtx.Request.(*responses.ResponseNewParams)
 
 	wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, string(params.Model))
-	fc := forwarding.NewForwardContext(nil, provider)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 	response, cancel, err := forwarding.ForwardOpenAIResponses(fc, wrapper, *params)
 	if cancel != nil {
 		defer cancel()
@@ -956,7 +956,7 @@ func (s *Server) nonstreamOpenAIChatToResponses(c *gin.Context, reqCtx *transfor
 	chatReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
 
 	wrapper := s.clientPool.GetOpenAIClient(c.Request.Context(), provider, string(chatReq.Model))
-	fc := forwarding.NewForwardContext(nil, provider)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 	chatResp, _, err := forwarding.ForwardOpenAIChat(fc, wrapper, chatReq)
 	if err != nil {
 		s.trackUsageWithTokenUsage(c, protocol.NewTokenUsageWithCache(0, 0, 0), err)
@@ -1005,7 +1005,7 @@ func (s *Server) nonstreamAnthropicBetaFromResponses(c *gin.Context, reqCtx *tra
 
 	ctx := c.Request.Context()
 	wrapper := s.clientPool.GetAnthropicClient(ctx, provider, string(anthropicReq.Model))
-	fc := forwarding.NewForwardContext(nil, provider)
+	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 	anthropicResp, cancel, err := forwarding.ForwardAnthropicV1Beta(fc, wrapper, anthropicReq)
 	if cancel != nil {
 		defer cancel()


### PR DESCRIPTION
## Summary
Streaming passthrough could keep large upstream buffers alive longer than necessary and some forwarding paths were not tied to the incoming request context. 

This change reduces memory retention in stream handling while making cancellation, error reporting, and usage accounting more consistent.

### Major
- Anthropic and OpenAI streaming paths now avoid holding references to raw SSE backing buffers, reducing memory pressure during long or high-volume streams.
- Anthropic passthrough now follows the shared streaming loop behavior, preserving hooks, cancellation handling, completion callbacks, and honest mid-stream error reporting.
- Non-stream forwarding now carries the request context, so client cancellation and context-scoped behavior propagate consistently across providers.

### Minor
- Anthropic request stream detection avoids an extra full decode pass.
- Error handling is safer around nil token usage, missing rules, and Gin abort responses.