### PR TITLE
feat(dashboard): filter usage by shared user

### DIFF
--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -306,14 +306,13 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                         <CircularProgress size={28} />
                     </Box>
                 )}
-                <Table stickyHeader size="small">
+                <Table stickyHeader size="small" sx={{ minWidth: 980 }}>
                     <TableHead>
                         <TableRow sx={{ '& .MuiTableCell-root': { fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary', py: 1, borderBottom: '1px solid', borderColor: 'divider', backgroundColor: 'background.paper', whiteSpace: 'nowrap' } }}>
                             <TableCell>Time</TableCell>
-                            <TableCell>Provider / Model</TableCell>
+                            <TableCell>Model</TableCell>
                             <TableCell>Scenario</TableCell>
-                            <TableCell align="right">Cache</TableCell>
-                            <TableCell align="right">Cache Hit</TableCell>
+                            <TableCell align="right" sx={{ minWidth: 96 }}>Cache</TableCell>
                             <TableCell align="right">Input</TableCell>
                             <TableCell align="right">Output</TableCell>
                             <TableCell align="right">Latency</TableCell>
@@ -325,7 +324,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                     <TableBody>
                         {records.length === 0 && !loading ? (
                             <TableRow>
-                                <TableCell colSpan={11} align="center" sx={{ py: 5 }}>
+                                <TableCell colSpan={10} align="center" sx={{ py: 5 }}>
                                     <Typography variant="body2" color="text.secondary">No requests found</Typography>
                                     <Typography variant="caption" color="text.disabled">Try changing the status filter</Typography>
                                 </TableCell>
@@ -341,7 +340,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                                     </Tooltip>
                                 </TableCell>
 
-                                {/* Provider / Model */}
+                                {/* Model */}
                                 <TableCell>
                                     <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled', lineHeight: 1.2 }}>
                                         {r.provider_name || '-'}
@@ -362,21 +361,24 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
 
                                 {/* Tokens */}
                                 <TableCell align="right">
-                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.cache.main }}>
-                                        {r.cache_input_tokens > 0 ? fmtTokens(r.cache_input_tokens) : '-'}
-                                    </Typography>
-                                </TableCell>
-                                <TableCell align="right">
-                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'text.secondary' }}>
-                                        {(() => {
-                                            const cacheTokens = r.cache_input_tokens || 0;
-                                            const inputTokens = r.input_tokens || 0;
-                                            const total = cacheTokens + inputTokens;
-                                            if (total === 0) return '-';
-                                            const ratio = (cacheTokens / total) * 100;
-                                            return `${ratio.toFixed(1)}%`;
-                                        })()}
-                                    </Typography>
+                                    {(() => {
+                                        const cacheTokens = r.cache_input_tokens || 0;
+                                        const inputTokens = r.input_tokens || 0;
+                                        const total = cacheTokens + inputTokens;
+                                        const ratio = total > 0 ? (cacheTokens / total) * 100 : 0;
+                                        return (
+                                            <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 0.5, lineHeight: 1.2, whiteSpace: 'nowrap' }}>
+                                                <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: cacheTokens > 0 ? 'text.primary' : 'text.disabled' }}>
+                                                    {cacheTokens > 0 ? fmtTokens(cacheTokens) : '-'}
+                                                </Typography>
+                                                {cacheTokens > 0 && total > 0 && (
+                                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.65rem', color: 'text.secondary' }}>
+                                                        | {ratio.toFixed(1)}%
+                                                    </Typography>
+                                                )}
+                                            </Box>
+                                        );
+                                    })()}
                                 </TableCell>
                                 <TableCell align="right">
                                     <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.input.main }}>

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -279,7 +279,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
     const theme = useTheme();
 
     return (
-        <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden', backgroundColor: 'background.paper', boxShadow: 'none' }}>
+        <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden', backgroundColor: 'background.paper', boxShadow: 'none', width: '100%', minWidth: 0 }}>
             {/* Header */}
             <Box sx={{ px: 2.5, py: 1.5, borderBottom: '1px solid', borderColor: 'divider', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 1.5 }}>
                 <Typography sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
@@ -300,13 +300,13 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
             </Box>
 
             {/* Table */}
-            <TableContainer sx={{ maxHeight: 420, position: 'relative' }}>
+            <TableContainer sx={{ maxHeight: 420, maxWidth: '100%', overflow: 'auto', position: 'relative' }}>
                 {loading && (
                     <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.6)' }}>
                         <CircularProgress size={28} />
                     </Box>
                 )}
-                <Table stickyHeader size="small" sx={{ minWidth: 980 }}>
+                <Table stickyHeader size="small" sx={{ tableLayout: 'auto' }}>
                     <TableHead>
                         <TableRow sx={{ '& .MuiTableCell-root': { fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary', py: 1, borderBottom: '1px solid', borderColor: 'divider', backgroundColor: 'background.paper', whiteSpace: 'nowrap' } }}>
                             <TableCell>Time</TableCell>

--- a/frontend/src/pages/APITokensPage.tsx
+++ b/frontend/src/pages/APITokensPage.tsx
@@ -1,11 +1,10 @@
 import { PageLayout } from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
 import { api } from '@/services/api';
-import { Key as IconKey, Add as IconPlus, Delete as IconTrash, ContentCopy as IconCopy, Check as IconCheck, AccessTime as IconClock, Person as IconUser, Shield as IconShield, Visibility as IconEye, VisibilityOff as IconEyeOff } from '@/components/icons';
+import { Key as IconKey, Add as IconPlus, Delete as IconTrash, DeleteOutline as IconDeleteOutline, ContentCopy as IconCopy, AccessTime as IconClock, Person as IconUser, Visibility as IconEye, VisibilityOff as IconEyeOff } from '@/components/icons';
 import {
     Box,
     Button,
-    Chip,
     CircularProgress,
     Dialog,
     DialogActions,
@@ -22,6 +21,7 @@ import {
     Typography,
     IconButton,
     Tooltip,
+    Switch,
 } from '@mui/material';
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -139,14 +139,8 @@ const APITokensPage = () => {
     };
 
     const formatDate = (dateStr?: string) => {
+        if (!dateStr) return '-';
         return new Date(dateStr).toLocaleString();
-    };
-
-    const getStatusChip = (token: APIToken) => {
-        if (!token.enabled) {
-            return <Chip label="Disabled" color="default" size="small" />;
-        }
-        return <Chip label="Active" color="success" size="small" icon={<IconCheck sx={{ fontSize: 14 }} />} />;
     };
 
     return (
@@ -186,8 +180,8 @@ const APITokensPage = () => {
                                         },
                                     }}
                                 >
-                                    <TableCell>Name</TableCell>
                                     <TableCell>UUID</TableCell>
+                                    <TableCell>Name</TableCell>
                                     <TableCell>Token</TableCell>
                                     <TableCell>Status</TableCell>
                                     <TableCell>Created</TableCell>
@@ -235,6 +229,19 @@ const APITokensPage = () => {
                                             }}
                                         >
                                             <TableCell>
+                                                <Tooltip title={token.user_id} placement="top">
+                                                    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ width: 'fit-content', cursor: 'default' }}>
+                                                        <IconUser sx={{ fontSize: 13, opacity: 0.4, flexShrink: 0 }} />
+                                                        <Typography
+                                                            variant="caption"
+                                                            sx={{ fontFamily: 'monospace', color: 'text.secondary' }}
+                                                        >
+                                                            {token.user_id.slice(0, 8)}…
+                                                        </Typography>
+                                                    </Stack>
+                                                </Tooltip>
+                                            </TableCell>
+                                            <TableCell>
                                                 <Stack direction="row" spacing={1} alignItems="center">
                                                     <Box
                                                         sx={{
@@ -249,19 +256,6 @@ const APITokensPage = () => {
                                                         {token.display_name}
                                                     </Typography>
                                                 </Stack>
-                                            </TableCell>
-                                            <TableCell>
-                                                <Tooltip title={token.user_id} placement="top">
-                                                    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ width: 'fit-content', cursor: 'default' }}>
-                                                        <IconUser sx={{ fontSize: 13, opacity: 0.4, flexShrink: 0 }} />
-                                                        <Typography
-                                                            variant="caption"
-                                                            sx={{ fontFamily: 'monospace', color: 'text.secondary' }}
-                                                        >
-                                                            {token.user_id.slice(0, 8)}…
-                                                        </Typography>
-                                                    </Stack>
-                                                </Tooltip>
                                             </TableCell>
                                             <TableCell sx={{ maxWidth: 260 }}>
                                                 <Box
@@ -316,7 +310,17 @@ const APITokensPage = () => {
                                                     </Box>
                                                 </Box>
                                             </TableCell>
-                                            <TableCell>{getStatusChip(token)}</TableCell>
+                                            <TableCell>
+                                                <Tooltip title={token.enabled ? 'Active' : 'Disabled'} placement="top">
+                                                    <Switch
+                                                        size="small"
+                                                        checked={token.enabled}
+                                                        onChange={() => handleToggleTokenEnabled(token)}
+                                                        color="success"
+                                                        inputProps={{ 'aria-label': `${token.enabled ? 'Disable' : 'Enable'} ${token.display_name}` }}
+                                                    />
+                                                </Tooltip>
+                                            </TableCell>
                                             <TableCell>
                                                 <Stack direction="row" spacing={0.5} alignItems="center">
                                                     <IconClock sx={{ fontSize: 13, opacity: 0.4, flexShrink: 0 }} />
@@ -331,31 +335,19 @@ const APITokensPage = () => {
                                                 </Typography>
                                             </TableCell>
                                             <TableCell align="right">
-                                                <Stack direction="row" spacing={0.25} justifyContent="flex-end">
-                                                    <Tooltip title={token.enabled ? 'Disable token' : 'Enable token'}>
-                                                        <IconButton
-                                                            size="small"
-                                                            color={token.enabled ? 'warning' : 'success'}
-                                                            onClick={() => handleToggleTokenEnabled(token)}
-                                                            sx={{ opacity: 0.75, '&:hover': { opacity: 1 } }}
-                                                        >
-                                                            {token.enabled ? <IconShield sx={{ fontSize: 15 }} /> : <IconCheck sx={{ fontSize: 15 }} />}
-                                                        </IconButton>
-                                                    </Tooltip>
-                                                    <Tooltip title="Delete token">
-                                                        <IconButton
-                                                            size="small"
-                                                            color="error"
-                                                            onClick={() => {
-                                                                setTokenToDelete(token);
-                                                                setDeleteDialogOpen(true);
-                                                            }}
-                                                            sx={{ opacity: 0.75, '&:hover': { opacity: 1 } }}
-                                                        >
-                                                            <IconTrash sx={{ fontSize: 15 }} />
-                                                        </IconButton>
-                                                    </Tooltip>
-                                                </Stack>
+                                                <Tooltip title="Delete token">
+                                                    <IconButton
+                                                        size="small"
+                                                        color="error"
+                                                        onClick={() => {
+                                                            setTokenToDelete(token);
+                                                            setDeleteDialogOpen(true);
+                                                        }}
+                                                        sx={{ opacity: 0.75, '&:hover': { opacity: 1 } }}
+                                                    >
+                                                        <IconDeleteOutline sx={{ fontSize: 16 }} />
+                                                    </IconButton>
+                                                </Tooltip>
                                             </TableCell>
                                         </TableRow>
                                     ))

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -33,6 +33,10 @@ interface Provider {
     auth_type?: string;
 }
 
+interface APIToken {
+    user_id?: string;
+}
+
 type TimeRange = 'today' | 'yesterday' | '3d' | '7d' | '30d' | '90d';
 
 const TIME_RANGE_CONFIG: Record<TimeRange, { label: string; days: number; interval: string }> = {
@@ -109,8 +113,10 @@ export default function DashboardPage() {
     const [stats, setStats] = useState<AggregatedStat[]>([]);
     const [timeSeries, setTimeSeries] = useState<TimeSeriesData[]>([]);
     const [providers, setProviders] = useState<Provider[]>([]);
+    const [sharingUsers, setSharingUsers] = useState<string[]>([]);
     const [selectedProvider, setSelectedProvider] = useState<string>('all');
     const [selectedModel, setSelectedModel] = useState<string>('all');
+    const [selectedUser, setSelectedUser] = useState<string>('all');
     const [modelsPage, setModelsPage] = useState(0);
     const [modelsPerPage] = useState(10);
 
@@ -120,7 +126,7 @@ export default function DashboardPage() {
     const [recordsLoading, setRecordsLoading] = useState(false);
     const [recordsTimeParams, setRecordsTimeParams] = useState<{ start_time: string; end_time: string } | null>(null);
 
-    const buildTimeParams = useCallback((provider: string, model: string, range: TimeRange) => {
+    const buildTimeParams = useCallback((provider: string, model: string, user: string, range: TimeRange) => {
         const now = new Date();
         const config = TIME_RANGE_CONFIG[range];
         const todayStart = getLocalMidnight(now);
@@ -148,18 +154,22 @@ export default function DashboardPage() {
         if (model && model !== 'all') {
             params.model = model;
         }
+        if (user && user !== 'all') {
+            params.user_id = user;
+        }
         return params;
     }, []);
 
-    const loadData = useCallback(async (provider: string, model: string, range: TimeRange) => {
+    const loadData = useCallback(async (provider: string, model: string, user: string, range: TimeRange) => {
         try {
             const config = TIME_RANGE_CONFIG[range];
-            const params = buildTimeParams(provider, model, range);
+            const params = buildTimeParams(provider, model, user, range);
 
-            const [statsResult, timeSeriesResult, providersResult] = await Promise.all([
+            const [statsResult, timeSeriesResult, providersResult, tokensResult] = await Promise.all([
                 api.getUsageStats({ ...params, group_by: 'model', limit: 100 }),
                 api.getUsageTimeSeries({ ...params, interval: config.interval }),
                 api.getProviders(),
+                api.listAPITokens({ limit: 500 }),
             ]);
 
             if (statsResult?.data) {
@@ -170,6 +180,15 @@ export default function DashboardPage() {
             }
             if (providersResult?.success && providersResult?.data) {
                 setProviders(providersResult.data);
+            }
+            if (tokensResult?.success && tokensResult?.data) {
+                const tokens: APIToken[] = Array.isArray(tokensResult.data) ? tokensResult.data : tokensResult.data.tokens || [];
+                const users = Array.from(new Set<string>(
+                    tokens
+                        .map((token) => token.user_id)
+                        .filter((userId): userId is string => Boolean(userId))
+                )).sort((a, b) => a.localeCompare(b));
+                setSharingUsers(users);
             }
 
             // Store time params for records loading
@@ -186,6 +205,7 @@ export default function DashboardPage() {
         timeParams: { start_time: string; end_time: string } | null,
         provider: string,
         model: string,
+        user: string,
     ) => {
         if (!timeParams) return;
         setRecordsLoading(true);
@@ -201,6 +221,9 @@ export default function DashboardPage() {
             if (model !== 'all') {
                 filters.model = model;
             }
+            if (user !== 'all') {
+                filters.user_id = user;
+            }
             const result = await api.getUsageRecords(filters);
             if (result?.data) {
                 setRecords(result.data);
@@ -213,8 +236,8 @@ export default function DashboardPage() {
     }, []);
 
     useEffect(() => {
-        loadData(selectedProvider, selectedModel, timeRange);
-    }, [loadData, selectedProvider, selectedModel, timeRange]);
+        loadData(selectedProvider, selectedModel, selectedUser, timeRange);
+    }, [loadData, selectedProvider, selectedModel, selectedUser, timeRange]);
 
     // Reset view mode when switching away from hourly ranges
     useEffect(() => {
@@ -226,14 +249,14 @@ export default function DashboardPage() {
     // Load records when entering requests view or time/provider/model changes
     useEffect(() => {
         if (viewMode === 'requests') {
-            loadRecords(recordsTimeParams, selectedProvider, selectedModel);
+            loadRecords(recordsTimeParams, selectedProvider, selectedModel, selectedUser);
         }
-    }, [viewMode, recordsTimeParams, selectedProvider, selectedModel, loadRecords]);
+    }, [viewMode, recordsTimeParams, selectedProvider, selectedModel, selectedUser, loadRecords]);
 
     // Reset model pagination when filters or data change
     useEffect(() => {
         setModelsPage(0);
-    }, [stats, selectedProvider, selectedModel]);
+    }, [stats, selectedProvider, selectedModel, selectedUser]);
 
     // Reset filters if selected provider/model no longer exists in current data
     useEffect(() => {
@@ -249,23 +272,26 @@ export default function DashboardPage() {
                 setSelectedModel('all');
             }
         }
-    }, [stats, selectedProvider, selectedModel]);
+        if (selectedUser !== 'all' && !sharingUsers.includes(selectedUser)) {
+            setSelectedUser('all');
+        }
+    }, [stats, sharingUsers, selectedProvider, selectedModel, selectedUser]);
 
     useEffect(() => {
         if (autoRefresh) {
             const interval = setInterval(() => {
-                loadData(selectedProvider, selectedModel, timeRange);
+                loadData(selectedProvider, selectedModel, selectedUser, timeRange);
                 if (viewMode === 'requests') {
-                    loadRecords(recordsTimeParams, selectedProvider, selectedModel);
+                    loadRecords(recordsTimeParams, selectedProvider, selectedModel, selectedUser);
                 }
             }, 60000);
             return () => clearInterval(interval);
         }
-    }, [autoRefresh, loadData, selectedProvider, selectedModel, timeRange, viewMode, loadRecords, recordsTimeParams]);
+    }, [autoRefresh, loadData, selectedProvider, selectedModel, selectedUser, timeRange, viewMode, loadRecords, recordsTimeParams]);
 
     const handleRefresh = () => {
         setRefreshing(true);
-        loadData(selectedProvider, selectedModel, timeRange);
+        loadData(selectedProvider, selectedModel, selectedUser, timeRange);
     };
 
     // Calculate totals from stats
@@ -392,11 +418,12 @@ export default function DashboardPage() {
             .map((m) => m.model);
     }, [stats]);
 
-    const hasActiveFilters = selectedProvider !== 'all' || selectedModel !== 'all';
+    const hasActiveFilters = selectedProvider !== 'all' || selectedModel !== 'all' || selectedUser !== 'all';
 
     const handleClearFilters = () => {
         setSelectedProvider('all');
         setSelectedModel('all');
+        setSelectedUser('all');
     };
 
     if (loading) {
@@ -460,6 +487,27 @@ export default function DashboardPage() {
                     {modelOptions.map((model) => (
                         <MenuItem key={model} value={model}>
                             {model}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: { xs: 140, sm: 180 } }}>
+                <InputLabel sx={{ fontWeight: 500, fontSize: '0.875rem' }}>User</InputLabel>
+                <Select
+                    value={selectedUser}
+                    label="User"
+                    onChange={(e) => setSelectedUser(e.target.value)}
+                    disabled={!sharingUsers.length}
+                    sx={{
+                        borderRadius: 2,
+                        '& .MuiOutlinedInput-input': { py: 1 },
+                    }}
+                >
+                    <MenuItem value="all">All Users</MenuItem>
+                    {sharingUsers.map((userId) => (
+                        <MenuItem key={userId} value={userId}>
+                            {userId}
                         </MenuItem>
                     ))}
                 </Select>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -873,6 +873,7 @@ export const api = {
         provider?: string;
         model?: string;
         scenario?: string;
+        user_id?: string;
         limit?: number;
     } = {}): Promise<any> => {
         try {
@@ -888,6 +889,7 @@ export const api = {
                         provider: params.provider,
                         model: params.model,
                         scenario: params.scenario,
+                        user_id: params.user_id,
                         limit: params.limit,
                     }
                 }
@@ -905,6 +907,7 @@ export const api = {
         provider?: string;
         model?: string;
         scenario?: string;
+        user_id?: string;
     } = {}): Promise<any> => {
         try {
             const client = await getClient();
@@ -919,7 +922,8 @@ export const api = {
                         provider: params.provider,
                         model: params.model,
                         scenario: params.scenario,
-                    }
+                        user_id: params.user_id,
+                    } as any
                 }
             });
             return response.data;
@@ -934,6 +938,7 @@ export const api = {
         provider?: string;
         model?: string;
         scenario?: string;
+        user_id?: string;
         status?: string;
         limit?: number;
         offset?: number;
@@ -950,10 +955,11 @@ export const api = {
                         provider: params.provider,
                         model: params.model,
                         scenario: params.scenario,
+                        user_id: params.user_id,
                         status: params.status as any,
                         limit: params.limit,
                         offset: params.offset,
-                    }
+                    } as any
                 }
             });
             return response.data;


### PR DESCRIPTION
## Summary
Dashboard usage analysis could only be narrowed by provider and model, which made shared-token activity harder to inspect. 

This lets users isolate usage by user and makes the surrounding dashboard tables easier to scan while investigating request volume and token behavior.

### Major
- Users can now filter dashboard stats, time series, and request records by shared user instead of manually inferring ownership from mixed usage data.
- API token status can be toggled directly from the token list, making enable/disable state clearer and faster to manage.

### Minor
- Request records are more compact and readable, with cache token count and hit ratio shown together.
- Dashboard and token tables have small layout refinements to reduce overflow and visual noise.
- Frontend API usage helpers now pass `user_id` through usage stats, time series, and records requests.