### PR TITLE
feat(ui, routing): support to edit providers from service graphs

### DIFF
--- a/frontend/src/components/ModelListDialog.tsx
+++ b/frontend/src/components/ModelListDialog.tsx
@@ -87,6 +87,7 @@ const ModelListDialog = ({ open, onClose, provider }: ModelListDialogProps) => {
                         <ModelSelectDialog
                             providers={provider ? [provider] : []}
                             selectedProvider={provider?.uuid}
+                            activeTab={provider?.uuid}
                             selectedModel={selectedModel}
                             onSelected={(option) => setSelectedModel(option.model || '')}
                             onSelectionClear={() => setSelectedModel('')}

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -18,6 +18,7 @@ import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
 import { formatRuleFlags, parseRuleFlags } from '@/components/rule-card/utils';
 import { getFlagValue, setFlagValue } from '@/components/rule-card/flagHelpers';
 import { formatModelNameWithContext1M } from '@/components/rule-card/modelNameUtils';
+import { useProviderEditDialog } from '@/hooks/useProviderEditDialog';
 
 // Module-level cache so we only fetch the flag catalog once per session.
 // `undefined` = never fetched; `[]` = fetched but empty (don't re-fetch).
@@ -108,6 +109,11 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         ruleUuid: rule.uuid,
         onModelSelectOpen,
         showNotification,
+    });
+
+    const { editProvider, providerEditDialogs } = useProviderEditDialog({
+        showNotification,
+        onUpdated: (providerUuid) => onRefreshProvider?.(providerUuid),
     });
 
     // Delete confirmation state
@@ -314,6 +320,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 extensionsCard={extensionsCard}
                 onUpdateRecord={(field, value) => updateField(configRecord, setConfigRecord, field, value)}
                 onProviderNodeClick={handleProviderNodeClick}
+                onEditProvider={editProvider}
                 onTierChange={handleProviderTierChange}
                 onDeleteProvider={(providerUuid) => handleDeleteProvider(configRecord.uuid, providerUuid)}
                 onAddService={handleAddServiceButtonClick}
@@ -361,6 +368,8 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 onClose={smartHandlers.handleCancelSmartRuleEdit}
                 onSave={smartHandlers.handleSaveSmartRule}
             />
+
+            {providerEditDialogs}
         </>
     );
 };

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -53,6 +53,7 @@ export interface RuleCardProps {
     onRuleChange?: (updatedRule: Rule) => void;
     onProviderModelsChange?: (providerUuid: string, models: ProviderModelData) => void;
     onRefreshProvider?: (providerUuid: string) => void;
+    onProviderUpdated?: (providerUuid: string) => void | Promise<void>;
     onModelSelectOpen: (ruleUuid: string, configRecord: ConfigRecord, mode: 'edit' | 'add', providerUuid?: string, addTier?: number) => void;
     collapsible?: boolean;
     initiallyExpanded?: boolean;
@@ -72,6 +73,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     onRuleChange,
     onProviderModelsChange,
     onRefreshProvider,
+    onProviderUpdated,
     onModelSelectOpen,
     collapsible = false,
     initiallyExpanded = !collapsible,
@@ -113,7 +115,10 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 
     const { editProvider, providerEditDialogs } = useProviderEditDialog({
         showNotification,
-        onUpdated: (providerUuid) => onRefreshProvider?.(providerUuid),
+        onUpdated: async (providerUuid) => {
+            await onProviderUpdated?.(providerUuid);
+            await onRefreshProvider?.(providerUuid);
+        },
     });
 
     // Delete confirmation state

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -85,6 +85,7 @@ export interface UnifiedRoutingGraphProps {
     // Callbacks
     onUpdateRecord?: (field: keyof ConfigRecord, value: any) => void;
     onProviderNodeClick?: (providerUuid: string) => void;
+    onEditProvider?: (providerUuid: string) => void;
     onTierChange?: (providerUuid: string, tier: number) => void;
     onDeleteProvider?: (providerUuid: string) => void;
     onAddService?: (tier?: number) => void;
@@ -175,6 +176,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                                             guideMode = false,
                                                                             onUpdateRecord,
                                                                             onProviderNodeClick,
+                                                                            onEditProvider,
                                                                             onTierChange,
                                                                             onDeleteProvider,
                                                                             onAddService,
@@ -315,6 +317,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                 active={active && p.active !== false}
                                 onDelete={() => onDeleteProvider?.(p.uuid)}
                                 onNodeClick={() => onProviderNodeClick?.(p.uuid)}
+                                onEditProvider={onEditProvider}
                                 showTier={false}
                                 forceShowActions={shouldShowActions ?? (hoveredTier === group.tier)}
                                 onMoveTierUp={group.tier > 0 && onTierChange ? () => onTierChange(p.uuid, group.tier - 1) : undefined}
@@ -335,7 +338,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 ))}
             </Box>
         );
-    }, [t, tierGroups, active, saving, record.providers.length, getApiStyle, providers, onDeleteProvider, onProviderNodeClick, onTierChange, onAddService, hoveredTier, guideMode, handleShowGuide]);
+    }, [t, tierGroups, active, saving, record.providers.length, getApiStyle, providers, onDeleteProvider, onProviderNodeClick, onEditProvider, onTierChange, onAddService, hoveredTier, guideMode, handleShowGuide]);
 
     // Render smart rules section
     const renderSmartRules = () => {
@@ -380,6 +383,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                 active={active && service.active !== false}
                                                 onDelete={() => onDeleteServiceFromSmartRule?.(rule.uuid, service.uuid)}
                                                 onNodeClick={() => onProviderNodeClick?.(service.provider)}
+                                                onEditProvider={onEditProvider}
                                             />
                                         ))}
                                         <ActionAddNode

--- a/frontend/src/components/nodes/ServiceNode.tsx
+++ b/frontend/src/components/nodes/ServiceNode.tsx
@@ -18,7 +18,6 @@ import {
 } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { Provider } from '@/types/provider.ts';
 import { ApiStyleBadge } from '../ApiStyleBadge.tsx';
@@ -82,6 +81,7 @@ export interface ServiceNodeProps {
     showTier?: boolean;
     onMoveTierUp?: () => void;
     onMoveTierDown?: () => void;
+    onEditProvider?: (providerUuid: string) => void;
     forceShowActions?: boolean;
 }
 
@@ -195,10 +195,10 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
     showTier = true,
     onMoveTierUp,
     onMoveTierDown,
+    onEditProvider,
     forceShowActions = false,
 }) => {
     const { t } = useTranslation();
-    const navigate = useNavigate();
     const theme = useTheme();
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const [probeAnchorEl, setProbeAnchorEl] = useState<null | HTMLElement>(null);
@@ -228,10 +228,10 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
     const handleMenuClick = (e: React.MouseEvent<HTMLElement>) => { e.stopPropagation(); setMenuAnchorEl(e.currentTarget); };
     const handleMenuClose = () => setMenuAnchorEl(null);
     const handleDelete = () => { handleMenuClose(); onDelete(); };
-    const handleEditProvider = provider.provider && providerInfo.exists
+    const handleEditProvider = provider.provider && providerInfo.exists && onEditProvider
         ? () => {
             handleMenuClose();
-            navigate(`/credentials?editProvider=${encodeURIComponent(provider.provider)}`);
+            onEditProvider(provider.provider);
         }
         : undefined;
     const handleProbeClick = (e: React.MouseEvent<HTMLElement>) => { e.stopPropagation(); setProbeAnchorEl(e.currentTarget); };
@@ -246,7 +246,6 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
                 menuOpen={menuOpen}
                 onMenuClose={handleMenuClose}
                 onDelete={handleDelete}
-                onEditProvider={handleEditProvider}
             />
 
             {provider.provider && providerInfo.exists && (

--- a/frontend/src/components/nodes/ServiceNode.tsx
+++ b/frontend/src/components/nodes/ServiceNode.tsx
@@ -2,6 +2,7 @@ import {
     Delete as DeleteIcon,
     Warning as WarningIcon,
     PlayArrow as PlayIcon,
+    Edit as EditIcon,
     KeyboardArrowUp,
     KeyboardArrowDown,
 } from '@/components/icons';
@@ -17,6 +18,7 @@ import {
 } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { Provider } from '@/types/provider.ts';
 import { ApiStyleBadge } from '../ApiStyleBadge.tsx';
@@ -196,6 +198,7 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
     forceShowActions = false,
 }) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
     const theme = useTheme();
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const [probeAnchorEl, setProbeAnchorEl] = useState<null | HTMLElement>(null);
@@ -225,6 +228,12 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
     const handleMenuClick = (e: React.MouseEvent<HTMLElement>) => { e.stopPropagation(); setMenuAnchorEl(e.currentTarget); };
     const handleMenuClose = () => setMenuAnchorEl(null);
     const handleDelete = () => { handleMenuClose(); onDelete(); };
+    const handleEditProvider = provider.provider && providerInfo.exists
+        ? () => {
+            handleMenuClose();
+            navigate(`/credentials?editProvider=${encodeURIComponent(provider.provider)}`);
+        }
+        : undefined;
     const handleProbeClick = (e: React.MouseEvent<HTMLElement>) => { e.stopPropagation(); setProbeAnchorEl(e.currentTarget); };
     const handleProbeClose = () => setProbeAnchorEl(null);
 
@@ -237,6 +246,7 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
                 menuOpen={menuOpen}
                 onMenuClose={handleMenuClose}
                 onDelete={handleDelete}
+                onEditProvider={handleEditProvider}
             />
 
             {provider.provider && providerInfo.exists && (
@@ -350,6 +360,17 @@ export const ServiceNode: React.FC<ServiceNodeProps> = ({
                                 sx={{ p: 0.5 }}
                             >
                                 <PlayIcon sx={{ fontSize: '1rem' }} />
+                            </IconButton>
+                        </NodeTooltip>
+                    )}
+                    {handleEditProvider && (
+                        <NodeTooltip title={t('rule.service.editProvider')} placement="bottom">
+                            <IconButton
+                                size="small"
+                                onClick={(e) => { e.stopPropagation(); handleEditProvider(); }}
+                                sx={{ p: 0.5 }}
+                            >
+                                <EditIcon sx={{ fontSize: '1rem' }} />
                             </IconButton>
                         </NodeTooltip>
                     )}

--- a/frontend/src/components/nodes/ServiceNodeContent.tsx
+++ b/frontend/src/components/nodes/ServiceNodeContent.tsx
@@ -8,7 +8,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import {
     Delete as DeleteIcon,
-    Edit as EditIcon,
 } from '@/components/icons';
 
 interface ServiceNodeContentProps {
@@ -16,7 +15,6 @@ interface ServiceNodeContentProps {
     menuOpen: boolean;
     onMenuClose: () => void;
     onDelete: () => void;
-    onEditProvider?: () => void;
 }
 
 const ServiceNodeContent: React.FC<ServiceNodeContentProps> = ({
@@ -24,7 +22,6 @@ const ServiceNodeContent: React.FC<ServiceNodeContentProps> = ({
     menuOpen,
     onMenuClose,
     onDelete,
-    onEditProvider,
 }) => {
     const { t } = useTranslation();
 
@@ -37,14 +34,6 @@ const ServiceNodeContent: React.FC<ServiceNodeContentProps> = ({
             transformOrigin={{ horizontal: 'right', vertical: 'top' }}
             anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
         >
-            {onEditProvider && (
-                <MenuItem onClick={onEditProvider}>
-                    <ListItemIcon>
-                        <EditIcon />
-                    </ListItemIcon>
-                    <ListItemText>{t('rule.service.editProvider')}</ListItemText>
-                </MenuItem>
-            )}
             <MenuItem onClick={onDelete}>
                 <ListItemIcon>
                     <DeleteIcon />

--- a/frontend/src/components/nodes/ServiceNodeContent.tsx
+++ b/frontend/src/components/nodes/ServiceNodeContent.tsx
@@ -8,6 +8,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import {
     Delete as DeleteIcon,
+    Edit as EditIcon,
 } from '@/components/icons';
 
 interface ServiceNodeContentProps {
@@ -15,6 +16,7 @@ interface ServiceNodeContentProps {
     menuOpen: boolean;
     onMenuClose: () => void;
     onDelete: () => void;
+    onEditProvider?: () => void;
 }
 
 const ServiceNodeContent: React.FC<ServiceNodeContentProps> = ({
@@ -22,6 +24,7 @@ const ServiceNodeContent: React.FC<ServiceNodeContentProps> = ({
     menuOpen,
     onMenuClose,
     onDelete,
+    onEditProvider,
 }) => {
     const { t } = useTranslation();
 
@@ -34,6 +37,14 @@ const ServiceNodeContent: React.FC<ServiceNodeContentProps> = ({
             transformOrigin={{ horizontal: 'right', vertical: 'top' }}
             anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
         >
+            {onEditProvider && (
+                <MenuItem onClick={onEditProvider}>
+                    <ListItemIcon>
+                        <EditIcon />
+                    </ListItemIcon>
+                    <ListItemText>{t('rule.service.editProvider')}</ListItemText>
+                </MenuItem>
+            )}
             <MenuItem onClick={onDelete}>
                 <ListItemIcon>
                     <DeleteIcon />

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -78,8 +78,6 @@ interface UseProviderDialogReturn {
     handleConnectAIClick: () => void;
     handleConnectSelect: (selection: ConnectSelection) => void;
     handleCloseConnect: () => void;
-    customMode: boolean;
-    dualMode: boolean;
     fromConnectPicker: boolean;
 }
 
@@ -91,15 +89,11 @@ export const useProviderDialog = (
 
     const [providerDialogOpen, setProviderDialogOpen] = useState(false);
     const [connectDialogOpen, setConnectDialogOpen] = useState(false);
-    const [customMode, setCustomMode] = useState(false);
-    const [dualMode, setDualMode] = useState(false);
     const [fromConnectPicker, setFromConnectPicker] = useState(false);
     const [providerFormData, setProviderFormData] = useState<EnhancedProviderFormData>(emptyForm(defaultApiStyle));
 
     const handleAddProviderClick = () => {
         setProviderFormData(emptyForm(defaultApiStyle));
-        setCustomMode(false);
-        setDualMode(false);
         setFromConnectPicker(false);
         setProviderDialogOpen(true);
     };
@@ -123,7 +117,6 @@ export const useProviderDialog = (
             return;
         }
 
-        setCustomMode(selection.kind === 'custom');
         setProviderFormData(built.formData);
         setProviderDialogOpen(true);
     }, [defaultApiStyle, onImport]);
@@ -183,8 +176,6 @@ export const useProviderDialog = (
 
     const handleCloseDialog = () => {
         setProviderDialogOpen(false);
-        setCustomMode(false);
-        setDualMode(false);
         setFromConnectPicker(false);
     };
 
@@ -204,8 +195,6 @@ export const useProviderDialog = (
         handleConnectAIClick,
         handleConnectSelect,
         handleCloseConnect,
-        customMode,
-        dualMode,
         fromConnectPicker,
     };
 };

--- a/frontend/src/hooks/useProviderEditDialog.tsx
+++ b/frontend/src/hooks/useProviderEditDialog.tsx
@@ -1,0 +1,147 @@
+import OAuthDetailDialog from '@/components/OAuthDetailDialog';
+import ProviderFormDialog, { type EnhancedProviderFormData } from '@/components/ProviderFormDialog';
+import { api } from '@/services/api';
+import type { Provider } from '@/types/provider';
+import { type FormEvent, useCallback, useMemo, useState } from 'react';
+
+type ProviderFormData = EnhancedProviderFormData;
+
+interface OAuthEditFormData {
+    name: string;
+    apiBase: string;
+    apiStyle: string;
+    enabled: boolean;
+    proxyUrl?: string;
+}
+
+interface UseProviderEditDialogOptions {
+    onUpdated?: (providerUuid: string) => void | Promise<void>;
+    showNotification?: (message: string, severity: 'success' | 'error') => void;
+}
+
+const emptyProviderFormData: ProviderFormData = {
+    uuid: undefined,
+    name: '',
+    apiBase: '',
+    apiStyle: undefined,
+    token: '',
+    enabled: true,
+};
+
+export function useProviderEditDialog({ onUpdated, showNotification }: UseProviderEditDialogOptions = {}) {
+    const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
+    const [providerFormData, setProviderFormData] = useState<ProviderFormData>(emptyProviderFormData);
+    const [oauthDetailProvider, setOAuthDetailProvider] = useState<Provider | null>(null);
+    const [oauthDetailDialogOpen, setOAuthDetailDialogOpen] = useState(false);
+
+    const handleProviderFormChange = useCallback((field: keyof ProviderFormData, value: any) => {
+        setProviderFormData(prev => ({ ...prev, [field]: value }));
+    }, []);
+
+    const buildEditProviderPayload = useCallback((override?: Partial<ProviderFormData>) => {
+        const fd: any = { ...providerFormData, ...(override || {}) };
+        return {
+            name: fd.name,
+            api_base: fd.apiBase,
+            api_style: fd.apiStyle,
+            token: fd.token || undefined,
+            no_key_required: fd.noKeyRequired || false,
+            enabled: fd.enabled,
+            proxy_url: fd.proxyUrl ?? '',
+            user_agent: fd.userAgent ?? '',
+            api_base_openai: fd.apiBaseOpenAI ?? '',
+            api_base_anthropic: fd.apiBaseAnthropic ?? '',
+        };
+    }, [providerFormData]);
+
+    const closeApiKeyDialog = useCallback(() => {
+        setApiKeyDialogOpen(false);
+        setProviderFormData(emptyProviderFormData);
+    }, []);
+
+    const closeOAuthDetailDialog = useCallback(() => {
+        setOAuthDetailDialogOpen(false);
+        setOAuthDetailProvider(null);
+    }, []);
+
+    const editProvider = useCallback(async (uuid: string) => {
+        const result = await api.getProvider(uuid);
+        if (result.success) {
+            const provider = result.data as Provider;
+            if (provider.auth_type === 'oauth') {
+                setOAuthDetailProvider(provider);
+                setOAuthDetailDialogOpen(true);
+            } else {
+                setProviderFormData({
+                    uuid: provider.uuid,
+                    name: provider.name,
+                    apiBase: provider.api_base,
+                    apiStyle: provider.api_style || 'openai',
+                    apiBaseOpenAI: provider.api_base_openai || '',
+                    apiBaseAnthropic: provider.api_base_anthropic || '',
+                    token: provider.token || '',
+                    enabled: provider.enabled,
+                    noKeyRequired: provider.no_key_required || false,
+                    proxyUrl: provider.proxy_url || '',
+                    userAgent: (provider as any).user_agent || '',
+                    authType: provider.auth_type || 'api_key',
+                } as any);
+                setApiKeyDialogOpen(true);
+            }
+        } else {
+            showNotification?.(`Failed to load provider details: ${result.error}`, 'error');
+        }
+    }, [showNotification]);
+
+    const handleProviderSubmit = useCallback(async (e: FormEvent, resolved?: Partial<ProviderFormData>) => {
+        e.preventDefault();
+        if (!providerFormData.uuid) return;
+
+        const result = await api.updateProvider(providerFormData.uuid, buildEditProviderPayload(resolved));
+        if (result.success) {
+            showNotification?.('Provider updated successfully!', 'success');
+            closeApiKeyDialog();
+            await onUpdated?.(providerFormData.uuid);
+        } else {
+            showNotification?.(`Failed to update provider: ${result.error}`, 'error');
+        }
+    }, [buildEditProviderPayload, closeApiKeyDialog, onUpdated, providerFormData.uuid, showNotification]);
+
+    const handleOAuthSubmit = useCallback(async (data: OAuthEditFormData) => {
+        if (!oauthDetailProvider?.uuid) return;
+        const result = await api.updateProvider(oauthDetailProvider.uuid, {
+            name: data.name,
+            api_base: data.apiBase,
+            api_style: data.apiStyle,
+            enabled: data.enabled,
+            proxy_url: data.proxyUrl ?? '',
+        });
+        if (!result.success) throw new Error(result.error || 'Failed to update provider');
+        showNotification?.('Provider updated successfully!', 'success');
+        await onUpdated?.(oauthDetailProvider.uuid);
+    }, [oauthDetailProvider?.uuid, onUpdated, showNotification]);
+
+    const providerEditDialogs = useMemo(() => (
+        <>
+            <ProviderFormDialog
+                open={apiKeyDialogOpen}
+                onClose={closeApiKeyDialog}
+                onSubmit={handleProviderSubmit}
+                data={providerFormData}
+                onChange={handleProviderFormChange}
+                mode="edit"
+            />
+            <OAuthDetailDialog
+                open={oauthDetailDialogOpen}
+                provider={oauthDetailProvider}
+                onClose={closeOAuthDetailDialog}
+                onSubmit={handleOAuthSubmit}
+            />
+        </>
+    ), [apiKeyDialogOpen, closeApiKeyDialog, closeOAuthDetailDialog, handleOAuthSubmit, handleProviderFormChange, handleProviderSubmit, oauthDetailDialogOpen, oauthDetailProvider, providerFormData]);
+
+    return {
+        editProvider,
+        providerEditDialogs,
+    };
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -416,6 +416,7 @@ export default {
       "selectProvider": "Select Provider",
       "selectModel": "Select Model",
       "testService": "Test Service",
+      "editProvider": "Edit Provider",
       "deleteService": "Delete Service"
     },
     "tier": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -417,7 +417,7 @@ export default {
       "selectProvider": "选择提供商",
       "selectModel": "选择模型",
       "testService": "测试服务",
-      "editProvider": "编辑提供商",
+      "editProvider": "编辑服务商凭证",
       "deleteService": "删除服务"
     },
     "tier": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -417,6 +417,7 @@ export default {
       "selectProvider": "选择提供商",
       "selectModel": "选择模型",
       "testService": "测试服务",
+      "editProvider": "编辑提供商",
       "deleteService": "删除服务"
     },
     "tier": {

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -33,7 +33,7 @@ type ProviderFormData = EnhancedProviderFormData;
 interface OAuthEditFormData {
     name: string;
     apiBase: string;
-    apiStyle: 'openai' | 'anthropic';
+    apiStyle: string;
     enabled: boolean;
     proxyUrl?: string;
 }
@@ -73,26 +73,6 @@ const CredentialPage = () => {
     // Import Dialog state
     const [showImportModal, setShowImportModal] = useState(false);
     const [importing, setImporting] = useState(false);
-
-    // URL param handling for auto-opening dialogs
-    useEffect(() => {
-        const dialog = searchParams.get('dialog');
-        const style = searchParams.get('style') as 'openai' | 'anthropic' | null;
-        if (dialog === 'add') {
-            setSearchParams({});
-            if (style === 'oauth') {
-                setOAuthDialogOpen(true);
-            } else {
-                const apiStyle = style === 'openai' || style === 'anthropic' ? style : undefined;
-                setApiKeyDialogMode('add');
-                setProviderFormData({
-                    uuid: undefined, name: '', apiBase: '', apiStyle: apiStyle, token: '',
-                    enabled: true, noKeyRequired: false, proxyUrl: '', userAgent: '',
-                } as any);
-                setApiKeyDialogOpen(true);
-            }
-        }
-    }, [searchParams, setSearchParams]);
 
     useEffect(() => { loadProviders(); }, []);
 
@@ -268,6 +248,38 @@ const CredentialPage = () => {
             showNotification(`Failed to load provider details: ${result.error}`, 'error');
         }
     };
+
+    // URL param handling for auto-opening dialogs
+    useEffect(() => {
+        const editProvider = searchParams.get('editProvider');
+        if (editProvider) {
+            const nextParams = new URLSearchParams(searchParams);
+            nextParams.delete('editProvider');
+            setSearchParams(nextParams, { replace: true });
+            handleEditProvider(editProvider);
+            return;
+        }
+
+        const dialog = searchParams.get('dialog');
+        const style = searchParams.get('style') as 'openai' | 'anthropic' | 'oauth' | null;
+        if (dialog === 'add') {
+            const nextParams = new URLSearchParams(searchParams);
+            nextParams.delete('dialog');
+            nextParams.delete('style');
+            setSearchParams(nextParams, { replace: true });
+            if (style === 'oauth') {
+                setOAuthDialogOpen(true);
+            } else {
+                const apiStyle = style === 'openai' || style === 'anthropic' ? style : undefined;
+                setApiKeyDialogMode('add');
+                setProviderFormData({
+                    uuid: undefined, name: '', apiBase: '', apiStyle: apiStyle, token: '',
+                    enabled: true, noKeyRequired: false, proxyUrl: '', userAgent: '',
+                } as any);
+                setApiKeyDialogOpen(true);
+            }
+        }
+    }, [searchParams, setSearchParams]);
 
     // OAuth handlers
     const handleOAuthSuccess = () => {

--- a/frontend/src/pages/CredentialPage.tsx
+++ b/frontend/src/pages/CredentialPage.tsx
@@ -2,7 +2,6 @@ import ApiKeyTable from '@/components/ApiKeyTable.tsx';
 import ConnectProviderDialog, { type ConnectSelection } from '@/components/ConnectProviderDialog';
 import EmptyStateGuide from '@/components/EmptyStateGuide';
 import ImportModal from '@/components/ImportModal';
-import OAuthDetailDialog from '@/components/OAuthDetailDialog.tsx';
 import OAuthDialog from '@/components/OAuthDialog.tsx';
 import OAuthTable from '@/components/OAuthTable.tsx';
 import PageHeader from '@/components/PageHeader';
@@ -10,6 +9,7 @@ import { PageLayout } from '@/components/PageLayout';
 import ProviderFormDialog, { type EnhancedProviderFormData } from '@/components/ProviderFormDialog.tsx';
 import Surface from '@/components/Surface';
 import { useProviderQuota } from '@/hooks/useProviderQuota';
+import { useProviderEditDialog } from '@/hooks/useProviderEditDialog';
 import { buildProviderFormData } from '@/hooks/useProviderDialog';
 import { Add, ListAlt, Upload, VpnKey } from '@/components/icons';
 import {
@@ -29,14 +29,6 @@ import { api } from '../services/api';
 import { useNotify } from '@/hooks/useNotify';
 
 type ProviderFormData = EnhancedProviderFormData;
-
-interface OAuthEditFormData {
-    name: string;
-    apiBase: string;
-    apiStyle: string;
-    enabled: boolean;
-    proxyUrl?: string;
-}
 
 const CredentialPage = () => {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -67,8 +59,6 @@ const CredentialPage = () => {
         providerName: string;
         reason: string;
     }>({ open: false, providerUuid: '', providerName: '', reason: '' });
-    const [oauthDetailProvider, setOAuthDetailProvider] = useState<any | null>(null);
-    const [oauthDetailDialogOpen, setOAuthDetailDialogOpen] = useState(false);
 
     // Import Dialog state
     const [showImportModal, setShowImportModal] = useState(false);
@@ -124,6 +114,11 @@ const CredentialPage = () => {
         else { showNotification(`Failed to load providers: ${result.error}`, 'error'); }
         setLoading(false);
     };
+
+    const { editProvider: handleEditProvider, providerEditDialogs } = useProviderEditDialog({
+        showNotification,
+        onUpdated: loadProviders,
+    });
 
     // Build the body for an add request. Always produces exactly 1 provider record.
     const buildAddProviderPayload = (override?: Partial<ProviderFormData>): any => {
@@ -218,36 +213,6 @@ const CredentialPage = () => {
         else { showNotification(`Failed to toggle provider: ${result.error}`, 'error'); }
     };
 
-    const handleEditProvider = async (uuid: string) => {
-        const result = await api.getProvider(uuid);
-        if (result.success) {
-            const provider = result.data;
-            if (provider.auth_type === 'oauth') {
-                setOAuthDetailProvider(result.data);
-                setOAuthDetailDialogOpen(true);
-            } else {
-                setIsLocalProvider(false);
-                setApiKeyDialogMode('edit');
-                setProviderFormData({
-                    uuid: provider.uuid,
-                    name: provider.name,
-                    apiBase: provider.api_base,
-                    apiStyle: provider.api_style || 'openai',
-                    apiBaseOpenAI: provider.api_base_openai || '',
-                    apiBaseAnthropic: provider.api_base_anthropic || '',
-                    token: provider.token || '',
-                    enabled: provider.enabled,
-                    noKeyRequired: provider.no_key_required || false,
-                    proxyUrl: provider.proxy_url || '',
-                    userAgent: (provider as any).user_agent || '',
-                    authType: provider.auth_type || 'api_key',
-                } as any);
-                setApiKeyDialogOpen(true);
-            }
-        } else {
-            showNotification(`Failed to load provider details: ${result.error}`, 'error');
-        }
-    };
 
     // URL param handling for auto-opening dialogs
     useEffect(() => {
@@ -424,14 +389,7 @@ const CredentialPage = () => {
                 </DialogActions>
             </Dialog>
 
-            {/* OAuth Detail/Edit Dialog */}
-            <OAuthDetailDialog open={oauthDetailDialogOpen} provider={oauthDetailProvider} onClose={() => setOAuthDetailDialogOpen(false)} onSubmit={async (data: OAuthEditFormData) => {
-                if (!oauthDetailProvider?.uuid) return;
-                const result = await api.updateProvider(oauthDetailProvider.uuid, { name: data.name, api_base: data.apiBase, api_style: data.apiStyle, enabled: data.enabled, proxy_url: data.proxyUrl ?? '' });
-                if (!result.success) throw new Error(result.error || 'Failed to update provider');
-                showNotification('Provider updated successfully!', 'success');
-                loadProviders();
-            }}/>
+            {providerEditDialogs}
 
             {/* Import Modal */}
             <ImportModal open={showImportModal} onClose={() => setShowImportModal(false)} onImport={handleImportData} loading={importing}/>

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -53,8 +53,6 @@ const Onboarding: React.FC = () => {
     const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
     const [providerFormData, setProviderFormData] = useState<ProviderFormData>(emptyForm());
     const [isLocalProvider, setIsLocalProvider] = useState(false);
-    const [isCustomMode, setIsCustomMode] = useState(false);
-    const [isDualMode, setIsDualMode] = useState(false);
 
     // OAuth Dialog state
     const [oauthDialogOpen, setOAuthDialogOpen] = useState(false);
@@ -92,13 +90,11 @@ const Onboarding: React.FC = () => {
         const built = buildProviderFormData(selection)!;
 
         if (selection.kind === 'custom') {
-            setIsCustomMode(true);
             setIsLocalProvider(false);
             openDialogWith(built.formData);
             return;
         }
 
-        setIsCustomMode(false);
         setIsLocalProvider(selection.kind === 'local');
         openDialogWith(built.formData);
     };
@@ -210,8 +206,6 @@ const Onboarding: React.FC = () => {
                 onClose={() => {
                     setApiKeyDialogOpen(false);
                     setIsLocalProvider(false);
-                    setIsCustomMode(false);
-                    setIsDualMode(false);
                 }}
                 onSubmit={handleSubmit}
                 onForceAdd={handleForceAdd}
@@ -220,8 +214,6 @@ const Onboarding: React.FC = () => {
                 mode="add"
                 isFirstProvider
                 optionalEditableToken={isLocalProvider}
-                customMode={isCustomMode}
-                dualMode={isDualMode}
             />
 
             {/* OAuth Add Dialog - now functional in onboarding */}

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -193,8 +193,6 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
         handleConnectAIClick,
         handleConnectSelect,
         handleCloseConnect,
-        customMode,
-        dualMode,
         fromConnectPicker,
     } = useProviderDialog(showNotification, {
         onProviderAdded: () => {
@@ -210,6 +208,10 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
     const handleCreateRule = useCallback(() => {
         openModelSelectForCreate();
     }, [openModelSelectForCreate]);
+
+    const handleProviderUpdated = useCallback(async (_providerUuid: string) => {
+        await onProvidersLoad?.();
+    }, [onProvidersLoad]);
 
     // Handle expand/collapse all
     const handleToggleExpandAll = useCallback(() => {
@@ -432,6 +434,7 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
                                             onRuleChange={handleRuleChange}
                                             onProviderModelsChange={handleProviderModelsChange}
                                             onRefreshProvider={handleRefreshModels}
+                                            onProviderUpdated={handleProviderUpdated}
                                             collapsible={collapsible}
                                             initiallyExpanded={expandedStates[rule.uuid] ?? collapsible}
                                             onModelSelectOpen={openModelSelectDialog}
@@ -484,8 +487,6 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
                 data={providerFormData}
                 onChange={handleFieldChange}
                 mode="add"
-                customMode={customMode}
-                dualMode={dualMode}
             />
 
             {showScrollTop && (


### PR DESCRIPTION
## Summary
Provider configuration was separated from the routing surfaces where users discover issues, forcing them to leave the current flow before fixing a service. 
This lets users edit a provider directly from routing/service graphs and return to an up-to-date view afterward.

### Major
- Users can now edit an existing provider from service node actions instead of navigating back to the credential page first.
- Provider edits are reused across credential and routing flows, so API-key and OAuth providers behave consistently wherever editing starts.
- Single-provider model selection now opens on the relevant provider tab immediately, avoiding an empty or mismatched tab state.

### Minor
- Provider edit success refreshes the affected provider/model state so routing cards reflect the latest configuration.
- Credential page deep links can open provider edit dialogs via URL parameters.
- Removed legacy provider form mode flags that are no longer needed by the consolidated provider form flow.
