### PR TITLE
bugfix(ai-log): restore request correlation and simplify troubleshoot filter UX

### DIFF
--- a/frontend/src/components/AILogViewer.tsx
+++ b/frontend/src/components/AILogViewer.tsx
@@ -12,7 +12,6 @@ import {
     TableContainer,
     TableHead,
     TableRow,
-    TextField,
     Typography,
     TableSortLabel,
 } from '@mui/material';
@@ -136,21 +135,13 @@ const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: Request
     const [expandedId, setExpandedId] = useState<string | null>(null);
     const [details, setDetails] = useState<Record<string, ModelRequestDetail>>({});
     const [error, setError] = useState<string | null>(null);
-    // Initialize scenario filter from initialScenario prop on mount
-    const [scenario, setScenario] = useState(initialScenario ?? '');
-    const [provider, setProvider] = useState('');
-    const [status, setStatus] = useState('');
+    // Always start unfiltered so the user sees the full picture.
+    // initialScenario is kept as a prop only to power the quick-filter chip.
+    const [scenario, setScenario] = useState('');
     const tableContainerRef = useRef<HTMLDivElement>(null);
     // Sorting state
     const [sortField, setSortField] = useState<SortField>('time');
     const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
-
-    // Initialize scenario from initialScenario when prop changes
-    useEffect(() => {
-        if (initialScenario !== undefined) {
-            setScenario(initialScenario);
-        }
-    }, [initialScenario]);
 
     const loadRequests = async () => {
         setLoading(true);
@@ -159,8 +150,6 @@ const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: Request
             const response = await getRequests({
                 limit: 200,
                 scenario: scenario || undefined,
-                provider: provider || undefined,
-                status: status || undefined,
             });
             if (response && response.requests) {
                 const sorted = [...response.requests].sort((a, b) => {
@@ -200,7 +189,7 @@ const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: Request
     useEffect(() => {
         loadRequests();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scenario, provider, status, sortField, sortOrder]);
+    }, [scenario, sortField, sortOrder]);
 
     useEffect(() => {
         if (autoRefresh) {
@@ -208,7 +197,7 @@ const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: Request
             return () => clearInterval(id);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [autoRefresh, scenario, provider, status]);
+    }, [autoRefresh, scenario]);
 
     const handleSort = (field: SortField) => {
         if (sortField === field) {
@@ -378,36 +367,17 @@ const AILogViewer = ({ getRequests, getRequestDetail, initialScenario }: Request
                     </Typography>
                 </Stack>
                 <Stack direction="row" spacing={1} alignItems="center">
-                    <TextField
-                        size="small"
-                        label="Scenario"
-                        value={scenario}
-                        onChange={(e) => setScenario(e.target.value.trim())}
-                        sx={{ width: 130 }}
-                    />
-                    <TextField
-                        size="small"
-                        label="Provider"
-                        value={provider}
-                        onChange={(e) => setProvider(e.target.value.trim())}
-                        sx={{ width: 130 }}
-                    />
-                    <TextField
-                        size="small"
-                        label="Status"
-                        value={status}
-                        onChange={(e) => setStatus(e.target.value.trim())}
-                        sx={{ width: 90 }}
-                    />
-                    {(scenario || provider || status) && (
-                        <Button
+                    {/* Quick-filter chip: one click to apply/remove the context scenario */}
+                    {initialScenario && (
+                        <Chip
+                            label={`filter: ${initialScenario}`}
                             size="small"
-                            variant="outlined"
-                            onClick={() => { setScenario(''); setProvider(''); setStatus(''); }}
-                            sx={{ fontSize: '0.7rem', py: 0.5, px: 1 }}
-                        >
-                            Clear
-                        </Button>
+                            color={scenario === initialScenario ? 'primary' : 'default'}
+                            variant={scenario === initialScenario ? 'filled' : 'outlined'}
+                            onClick={() => setScenario(prev => prev === initialScenario ? '' : initialScenario)}
+                            onDelete={scenario === initialScenario ? () => setScenario('') : undefined}
+                            sx={{ fontFamily: 'monospace', fontSize: '0.72rem' }}
+                        />
                     )}
                 </Stack>
                 <Box sx={{ flex: 1 }} />

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -72,7 +72,18 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 		if requestID == "" {
 			requestID = uuid.NewString()
 		}
+		// Store on gin context so Gin middleware/handlers that hold *gin.Context
+		// can read it via c.GetString(GinRequestIDKey) — e.g. the access log
+		// fields below and stage_smart_routing's emitTrace.
 		c.Set(GinRequestIDKey, requestID)
+
+		// Also carry the id on the Go request context so code that only has
+		// context.Context (protocol converters, upstream client calls) can log
+		// via logrus.WithContext(ctx). The MultiLogger hook reads it back with
+		// RequestIDFromContext and routes those entries to LogSourceModelRequest,
+		// stamping them with the id for correlation. This is NOT a body copy —
+		// WithContext only swaps the context pointer.
+		c.Request = c.Request.WithContext(obs.ContextWithRequestID(c.Request.Context(), requestID))
 
 		c.Next()
 


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where the AI Log (Troubleshoot view) was returning empty data. A performance-related commit unintentionally broke `request_id` propagation into Go's `context.Context`, causing all model-request log entries to be misrouted and never correlated. 

This PR restores proper correlation and improves the filter UX, which was previously pre-filtering results in a way that obscured the full data set.

## Changes

### Major
- **Restores AI Log functionality** – model request and smart routing log entries are now correctly correlated by `request_id`, matching the original design.
- **Improves Troubleshoot dialog UX** – the dialog now opens unfiltered, showing all requests by default. Users can narrow results by clicking the single `filter: <scenario>` chip when needed.

### Minor
- **Removes redundant filter inputs** – the Scenario, Provider, and Status text-field filters, along with the Clear button, have been removed from the AI log toolbar. These added clutter without providing significant value, as the chip-based interaction covers the primary use case.
- **Adds explanatory comments** – clarifies the distinction between `c.Set()` (gin context, for middleware/handlers) and `c.Request.WithContext()` (Go context, for protocol/client code that only has access to `context.Context`), improving code maintainability.