### PR TITLE
config: Update Anthropic models to use stable model IDs

### DIFF
--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -208,32 +208,17 @@
       "base_url_anthropic": "https://api.anthropic.com",
       "models": [
         {
-          "id": "claude-sonnet-4-20250514",
-          "context": 200000,
-          "max_output": 64000
-        },
-        {
-          "id": "claude-opus-4-20250514",
-          "context": 200000,
-          "max_output": 32000
-        },
-        {
-          "id": "claude-opus-4-1-20250805",
-          "context": 200000,
-          "max_output": 32000
-        },
-        {
-          "id": "claude-sonnet-4-5-20250929",
+          "id": "claude-sonnet-4-5",
           "context": 1000000,
           "max_output": 64000
         },
         {
-          "id": "claude-haiku-4-5-20251001",
+          "id": "claude-haiku-4-5",
           "context": 200000,
           "max_output": 64000
         },
         {
-          "id": "claude-opus-4-5-20251101",
+          "id": "claude-opus-4-5",
           "context": 1000000,
           "max_output": 64000
         },
@@ -259,6 +244,11 @@
         },
         {
           "id": "claude-sonnet-5",
+          "context": 1000000,
+          "max_output": 128000
+        },
+        {
+          "id": "claude-fable-5",
           "context": 1000000,
           "max_output": 128000
         }


### PR DESCRIPTION
## Summary
Consolidates Anthropic model configurations to use stable model identifiers without date suffixes, removing outdated model versions and adding the new Claude Fable 5 model.

## Key Changes
- **Removed dated model versions**: Eliminated `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, `claude-opus-4-1-20250805`, and their dated variants
- **Standardized model IDs**: Migrated to stable identifiers:
  - `claude-sonnet-4-5-20250929` → `claude-sonnet-4-5`
  - `claude-haiku-4-5-20251001` → `claude-haiku-4-5`
  - `claude-opus-4-5-20251101` → `claude-opus-4-5`
- **Added Claude Fable 5**: New model with 1M context window and 128K max output tokens
- **Preserved capabilities**: Maintained context windows and max output specifications for all retained models

## Implementation Details
This change aligns the provider configuration with Anthropic's stable model naming convention, reducing maintenance burden from date-based versioning while ensuring users have access to the latest stable model variants.

https://claude.ai/code/session_012nVvFwuY3EmK2KMP3iPBDz