### PR TITLE
bugfix(frontend): model select infinite loop and stale provider-models API paths

### DIFF
--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -41,13 +41,15 @@ export function useLocalStorage<T extends Record<string, any>>(
   const [version, setVersion] = useState(0);
 
   // Load data from localStorage
+  // Always returns a fresh object so callers can safely mutate it (e.g. saveData/removeKey)
+  // without corrupting the shared `defaultValue` reference.
   const loadData = useCallback((): T => {
     try {
       const stored = localStorage.getItem(storageKey);
-      return stored ? deserializer(stored) : defaultValue;
+      return stored ? deserializer(stored) : {...defaultValue};
     } catch (error) {
       console.error(`Failed to load ${storageKey} from storage:`, error);
-      return defaultValue;
+      return {...defaultValue};
     }
   }, [storageKey, deserializer, defaultValue]);
 

--- a/frontend/src/hooks/useRecentModels.ts
+++ b/frontend/src/hooks/useRecentModels.ts
@@ -7,7 +7,7 @@ const RECENT_MODELS_STORAGE_KEY = 'tingly_recent_models';
 const LAST_PROVIDER_STORAGE_KEY = 'tingly_last_provider';
 const MAX_RECENT_MODELS = 3;
 const DEFAULT_RECENT_MODELS = {};
-const DEFAULT_LAST_PROVIDER = '';
+const DEFAULT_LAST_PROVIDER_DATA: Record<string, string> = {};
 
 // Type for recent models data
 export type RecentModelsData = { [providerUuid: string]: string[] };
@@ -25,7 +25,7 @@ export const useRecentModels = () => {
     const { data: recentModels, version, saveData, removeKey, setData, refetch, loadData } =
         useLocalStorage<RecentModelsData>(RECENT_MODELS_STORAGE_KEY, DEFAULT_RECENT_MODELS);
     const { data: lastProvider, saveData: saveLastProvider } =
-        useLocalStorage<Record<string, string>>(LAST_PROVIDER_STORAGE_KEY, {});
+        useLocalStorage<Record<string, string>>(LAST_PROVIDER_STORAGE_KEY, DEFAULT_LAST_PROVIDER_DATA);
 
     // Listen for recent models updates from other components and reload
     useEffect(() => {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1045,8 +1045,8 @@ export const handlers = [
         })
     }),
 
-    // ── v1 provider models by UUID (used by ModelSelectDialog) ───────────────
-    http.get('/api/v1/provider-models/:uuid', ({ params }) => {
+    // ── v2 provider models by UUID (used by ModelSelectDialog) ───────────────
+    http.get('/api/v2/provider-models/:uuid', ({ params }) => {
         const { uuid } = params as { uuid: string }
         const modelMap: Record<string, string[]> = {
             'mock-provider-anthropic': [

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -211,7 +211,7 @@ export const api = {
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await client.POST('/api/v1/provider-models/{uuid}', {
+            const response = await client.POST('/api/v2/provider-models/{uuid}', {
                 headers,
                 params: {path: {uuid}}
             });
@@ -232,7 +232,7 @@ export const api = {
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await client.GET('/api/v1/provider-models/{uuid}', {
+            const response = await client.GET('/api/v2/provider-models/{uuid}', {
                 headers,
                 params: {path: {uuid}}
             });

--- a/internal/servertest/server_test.go
+++ b/internal/servertest/server_test.go
@@ -93,7 +93,7 @@ func runModelsEndpoint(t *testing.T, ts *TestServer, isRealConfig bool) {
 	globalConfig := ts.appConfig.GetGlobalConfig()
 	userToken := globalConfig.GetUserToken()
 	// Use "glm" provider UUID to test provider models endpoint
-	req, _ := http.NewRequest("GET", "/api/v1/provider-models/glm", nil)
+	req, _ := http.NewRequest("GET", "/api/v2/provider-models/glm", nil)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+userToken)
 	w := httptest.NewRecorder()
@@ -234,7 +234,7 @@ func runProviderModelsEndpointWithAuth(t *testing.T, ts *TestServer, isRealConfi
 
 	for _, providerName := range []string{"anthropic", "glm"} {
 		t.Run(providerName, func(t *testing.T) {
-			req, _ := http.NewRequest("POST", "/api/v1/provider-models/"+providerName, nil)
+			req, _ := http.NewRequest("POST", "/api/v2/provider-models/"+providerName, nil)
 			req.Header.Set("Authorization", "Bearer "+userToken)
 			w := httptest.NewRecorder()
 			ts.ginEngine.ServeHTTP(w, req)
@@ -255,7 +255,7 @@ func runProviderModelsEndpointWithAuth(t *testing.T, ts *TestServer, isRealConfi
 
 func runProviderModelsEndpointWithoutAuth(t *testing.T, ts *TestServer) {
 	// Use "glm" provider UUID to test provider models endpoint
-	req, _ := http.NewRequest("GET", "/api/v1/provider-models/glm", nil)
+	req, _ := http.NewRequest("GET", "/api/v2/provider-models/glm", nil)
 	w := httptest.NewRecorder()
 	ts.ginEngine.ServeHTTP(w, req)
 

--- a/openapi.json
+++ b/openapi.json
@@ -2604,72 +2604,6 @@
         }
       }
     },
-    "/api/v1/provider-models/{uuid}": {
-      "get": {
-        "tags": [
-          "models"
-        ],
-        "summary": "Get all provider models",
-        "description": "Get all provider models",
-        "operationId": "apiV1Provider-modelsUuidGet",
-        "parameters": [
-          {
-            "name": "uuid",
-            "in": "path",
-            "description": "Unique identifier (UUID)",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderModelsResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "models"
-        ],
-        "summary": "Fetch models for a specific provider",
-        "description": "Fetch models for a specific provider",
-        "operationId": "apiV1Provider-modelsUuidPost",
-        "parameters": [
-          {
-            "name": "uuid",
-            "in": "path",
-            "description": "Unique identifier (UUID)",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderModelsResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/requests": {
       "get": {
         "tags": [
@@ -4236,6 +4170,72 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LightweightResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/provider-models/{uuid}": {
+      "get": {
+        "tags": [
+          "models"
+        ],
+        "summary": "Get all provider models",
+        "description": "Get all provider models",
+        "operationId": "apiV2Provider-modelsUuidGet",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "Unique identifier (UUID)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderModelsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "models"
+        ],
+        "summary": "Fetch models for a specific provider",
+        "description": "Fetch models for a specific provider",
+        "operationId": "apiV2Provider-modelsUuidPost",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "Unique identifier (UUID)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderModelsResponse"
                 }
               }
             }
@@ -6244,7 +6244,7 @@
           "health": {
             "type": "boolean",
             "description": "Field health",
-            "example": false
+            "example": true
           },
           "service": {
             "type": "string",
@@ -6570,7 +6570,7 @@
           "release_url": {
             "type": "string",
             "description": "Field release_url",
-            "example": "https://github.com/tingly-dev/tingly-box/releases/tag/v0.260130.1200"
+            "example": "https://github.com/tingly-dev/tingly-box/releases"
           },
           "should_notify": {
             "type": "boolean",
@@ -10793,8 +10793,7 @@
           },
           "message": {
             "type": "string",
-            "description": "Field message",
-            "example": "Provider models successfully"
+            "description": "Field message"
           },
           "success": {
             "type": "boolean",
@@ -10804,7 +10803,6 @@
         },
         "required": [
           "success",
-          "message",
           "data"
         ]
       },
@@ -10863,8 +10861,16 @@
       "description": "Operations related to token"
     },
     {
-      "name": "system-logs",
-      "description": "Operations related to system-logs"
+      "name": "codex",
+      "description": "Operations related to codex"
+    },
+    {
+      "name": "auth",
+      "description": "Operations related to auth"
+    },
+    {
+      "name": "actions",
+      "description": "Operations related to actions"
     },
     {
       "name": "rules",
@@ -10875,6 +10881,54 @@
       "description": "Operations related to scenarios"
     },
     {
+      "name": "guardrails",
+      "description": "Operations related to guardrails"
+    },
+    {
+      "name": "oauth",
+      "description": "Operations related to oauth"
+    },
+    {
+      "name": "weixin",
+      "description": "Operations related to weixin"
+    },
+    {
+      "name": "requests",
+      "description": "Operations related to requests"
+    },
+    {
+      "name": "server",
+      "description": "Operations related to server"
+    },
+    {
+      "name": "onboarding",
+      "description": "Operations related to onboarding"
+    },
+    {
+      "name": "testing",
+      "description": "Operations related to testing"
+    },
+    {
+      "name": "models",
+      "description": "Operations related to models"
+    },
+    {
+      "name": "usage",
+      "description": "Operations related to usage"
+    },
+    {
+      "name": "imbot-settings",
+      "description": "Operations related to imbot-settings"
+    },
+    {
+      "name": "feishu",
+      "description": "Operations related to feishu"
+    },
+    {
+      "name": "system-logs",
+      "description": "Operations related to system-logs"
+    },
+    {
       "name": "history",
       "description": "Operations related to history"
     },
@@ -10883,88 +10937,32 @@
       "description": "Operations related to skills"
     },
     {
-      "name": "oauth",
-      "description": "Operations related to oauth"
-    },
-    {
-      "name": "mcp",
-      "description": "Operations related to mcp"
-    },
-    {
-      "name": "info",
-      "description": "Operations related to info"
-    },
-    {
-      "name": "guardrails",
-      "description": "Operations related to guardrails"
-    },
-    {
       "name": "providers",
       "description": "Operations related to providers"
-    },
-    {
-      "name": "feishu",
-      "description": "Operations related to feishu"
-    },
-    {
-      "name": "config",
-      "description": "Operations related to config"
-    },
-    {
-      "name": "codex",
-      "description": "Operations related to codex"
-    },
-    {
-      "name": "models",
-      "description": "Operations related to models"
-    },
-    {
-      "name": "onboarding",
-      "description": "Operations related to onboarding"
-    },
-    {
-      "name": "auth",
-      "description": "Operations related to auth"
-    },
-    {
-      "name": "logs",
-      "description": "Operations related to logs"
-    },
-    {
-      "name": "actions",
-      "description": "Operations related to actions"
-    },
-    {
-      "name": "server",
-      "description": "Operations related to server"
-    },
-    {
-      "name": "testing",
-      "description": "Operations related to testing"
-    },
-    {
-      "name": "usage",
-      "description": "Operations related to usage"
-    },
-    {
-      "name": "requests",
-      "description": "Operations related to requests"
-    },
-    {
-      "name": "imbot-settings",
-      "description": "Operations related to imbot-settings"
     },
     {
       "name": "imbot-admin",
       "description": "Operations related to imbot-admin"
     },
     {
-      "name": "weixin",
-      "description": "Operations related to weixin"
+      "name": "config",
+      "description": "Operations related to config"
+    },
+    {
+      "name": "mcp",
+      "description": "Operations related to mcp"
     },
     {
       "name": "mcp-transport",
       "description": "Operations related to mcp-transport"
+    },
+    {
+      "name": "info",
+      "description": "Operations related to info"
+    },
+    {
+      "name": "logs",
+      "description": "Operations related to logs"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix an infinite render loop that occurred when opening the model select dialog
- Fix all `provider-models` API calls returning 404 due to stale `/api/v1` codegen after a backend route migration to `/api/v2`
- Fix `useLocalStorage` mutating its shared default object on first write

## Changes

### 1. Infinite update loop in model select (`useRecentModels`)
`useLocalStorage` was called with an inline `{}` object literal as `defaultValue`. Since a fresh object is created every render, and `useLocalStorage`'s mount `useEffect` depends (transitively via `loadData`/`refetch`) on `defaultValue`, the effect re-fired every render, calling `setData`/`setVersion` in a loop → `Maximum update depth exceeded`. Replaced the inline literal with a stable, correctly-typed module-level constant (`DEFAULT_LAST_PROVIDER_DATA: Record<string, string>`).

### 2. Stale `/api/v1/provider-models` codegen → all provider model fetches 404
Backend commit `8d7f6248` ("refactor: extract provider handler as module") moved `GET/POST /provider-models/:uuid` from the `apiV1` group into `apiV2` alongside the rest of the provider module, but three call sites were never updated and kept hitting the now-removed `/api/v1` path:
- `openapi.json` — regenerated via `go run ./cli/tingly-box swagger`
- `frontend/src/services/api.ts` (`getProviderModelsByUUID`, `updateProviderModelsByUUID`) — updated to `/api/v2`
- `frontend/src/mocks/handlers.ts` mock handler — updated to `/api/v2`
- `internal/servertest/server_test.go` — 3 test call sites were silently 404ing against the real route; updated to `/api/v2` and now pass

### 3. `useLocalStorage` mutating its shared default object (found in review)
`loadData()` returned the caller-supplied `defaultValue` **by reference** when storage was empty. `saveData()`/`removeKey()` then mutate that returned object in place before persisting. Once fix #1 introduced a module-level default constant shared by every `useRecentModels()` instance, the very first write would silently mutate that shared default in place — any later hook instance (or a `refetch()` after the key is cleared) could read back the stale mutated object instead of a true empty default. `loadData()` now returns a shallow copy whenever it falls back to `defaultValue`, so mutation is always safe.

## Verification
- Built and ran the server locally; confirmed `GET/POST /api/v2/provider-models/{uuid}` returns 200 with real model data (curl with a real auth token)
- `go build ./...` clean
- `go test -tags=e2e ./internal/servertest/... -run TestSystem/Provider_Models_Endpoint` — mock variants pass; the `_Real` variant requires a locally-configured real provider and is unaffected by this fix
- `tsc --noEmit` shows no new errors introduced by these changes (pre-existing unrelated errors in the repo are untouched)

https://claude.ai/code/session_01HcHGUVQxdceSZH8nnvATFY