### PR TITLE
refactor(ui): Improve model chip layout with fixed-width grid and truncation

### DIFF
--- a/frontend/src/components/VirtualModelsTable.tsx
+++ b/frontend/src/components/VirtualModelsTable.tsx
@@ -36,8 +36,8 @@ const VirtualModelsTable = ({ providers, onToggle }: VirtualModelsTableProps) =>
             <Table size="small">
                 <TableHead>
                     <TableRow>
-                        <TableCell sx={{ width: '30%' }}>Name</TableCell>
-                        <TableCell sx={{ width: '15%' }}>Protocol</TableCell>
+                        <TableCell sx={{ width: '18%' }}>Name</TableCell>
+                        <TableCell sx={{ width: '10%' }}>API Style</TableCell>
                         <TableCell>Models</TableCell>
                         <TableCell sx={{ width: '12%' }} align="center">Enabled</TableCell>
                     </TableRow>

--- a/frontend/src/components/VirtualModelsTable.tsx
+++ b/frontend/src/components/VirtualModelsTable.tsx
@@ -16,6 +16,10 @@ import {
 } from '@mui/material';
 import type { Provider } from '../types/provider';
 
+// Cap visible model chips per row so wrapping doesn't produce uneven row
+// heights across providers with different model counts.
+const MAX_VISIBLE_MODELS = 4;
+
 interface VirtualModelsTableProps {
     providers: Provider[];
     onToggle?: (providerUuid: string) => void;
@@ -65,16 +69,26 @@ const VirtualModelsTable = ({ providers, onToggle }: VirtualModelsTableProps) =>
                                             none registered
                                         </Typography>
                                     ) : (
-                                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                                            {models.map((m) => (
+                                        <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 0.5, overflow: 'hidden' }}>
+                                            {models.slice(0, MAX_VISIBLE_MODELS).map((m: string) => (
                                                 <Chip
                                                     key={m}
                                                     label={m}
                                                     size="small"
                                                     variant="outlined"
-                                                    sx={{ height: 20 }}
+                                                    sx={{ height: 20, flexShrink: 0 }}
                                                 />
                                             ))}
+                                            {models.length > MAX_VISIBLE_MODELS && (
+                                                <Tooltip title={models.slice(MAX_VISIBLE_MODELS).join(', ')}>
+                                                    <Chip
+                                                        label={`+${models.length - MAX_VISIBLE_MODELS}`}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        sx={{ height: 20, flexShrink: 0, color: 'text.secondary' }}
+                                                    />
+                                                </Tooltip>
+                                            )}
                                         </Box>
                                     )}
                                 </TableCell>

--- a/frontend/src/components/VirtualModelsTable.tsx
+++ b/frontend/src/components/VirtualModelsTable.tsx
@@ -16,9 +16,9 @@ import {
 } from '@mui/material';
 import type { Provider } from '../types/provider';
 
-// Cap visible model chips per row so wrapping doesn't produce uneven row
-// heights across providers with different model counts.
-const MAX_VISIBLE_MODELS = 4;
+// Fixed chip width so rows form an aligned grid instead of ragged
+// flex-wrap lines whose chip widths vary with label length.
+const MODEL_CHIP_WIDTH = 132;
 
 interface VirtualModelsTableProps {
     providers: Provider[];
@@ -69,26 +69,30 @@ const VirtualModelsTable = ({ providers, onToggle }: VirtualModelsTableProps) =>
                                             none registered
                                         </Typography>
                                     ) : (
-                                        <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 0.5, overflow: 'hidden' }}>
-                                            {models.slice(0, MAX_VISIBLE_MODELS).map((m: string) => (
-                                                <Chip
-                                                    key={m}
-                                                    label={m}
-                                                    size="small"
-                                                    variant="outlined"
-                                                    sx={{ height: 20, flexShrink: 0 }}
-                                                />
-                                            ))}
-                                            {models.length > MAX_VISIBLE_MODELS && (
-                                                <Tooltip title={models.slice(MAX_VISIBLE_MODELS).join(', ')}>
+                                        <Box
+                                            sx={{
+                                                display: 'grid',
+                                                gridTemplateColumns: `repeat(auto-fill, ${MODEL_CHIP_WIDTH}px)`,
+                                                gap: 0.5,
+                                            }}
+                                        >
+                                            {models.map((m: string) => (
+                                                <Tooltip key={m} title={m}>
                                                     <Chip
-                                                        label={`+${models.length - MAX_VISIBLE_MODELS}`}
+                                                        label={m}
                                                         size="small"
                                                         variant="outlined"
-                                                        sx={{ height: 20, flexShrink: 0, color: 'text.secondary' }}
+                                                        sx={{
+                                                            height: 20,
+                                                            width: MODEL_CHIP_WIDTH,
+                                                            '& .MuiChip-label': {
+                                                                overflow: 'hidden',
+                                                                textOverflow: 'ellipsis',
+                                                            },
+                                                        }}
                                                     />
                                                 </Tooltip>
-                                            )}
+                                            ))}
                                         </Box>
                                     )}
                                 </TableCell>


### PR DESCRIPTION
## Summary
Refactored the models display in VirtualModelsTable to use a fixed-width grid layout instead of flex-wrap, improving visual alignment and handling long model names gracefully.

## Key Changes
- Introduced `MODEL_CHIP_WIDTH` constant (132px) for consistent chip sizing across all rows
- Changed models container from `display: flex` with `flexWrap` to `display: grid` with `gridTemplateColumns: repeat(auto-fill, 132px)` for aligned grid layout
- Added text truncation with ellipsis for model names that exceed chip width
- Wrapped chips in `Tooltip` component to show full model name on hover
- Updated table column widths: "Name" from 30% to 18%, "Protocol" renamed to "API Style" with width reduced from 15% to 10%

## Implementation Details
- Fixed chip width prevents ragged row alignment caused by variable label lengths
- Grid layout with `auto-fill` allows responsive wrapping while maintaining alignment
- Tooltip provides UX affordance for truncated text, allowing users to see full model names without cluttering the interface
- Chip label styling includes `overflow: hidden` and `textOverflow: ellipsis` for proper truncation behavior

https://claude.ai/code/session_01NqVeoyemJCcHJfrH4gRG7G