### PR TITLE
perf: Use platform-specific exec to avoid parent process leaks

### DIFF
--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -120,8 +120,8 @@ func runCC(appManager *AppManager, profile string, portOverride int, claudeArgs 
 	execArgs = append(execArgs, claudeArgs...)
 
 	// Exec replaces current process (on Windows, which has no true exec(),
-	// this instead runs the child and exits once it finishes) so the
-	// tingly-box process does not remain resident for the claude session.
+	// this instead starts the child detached and exits immediately) so
+	// tingly-box does not remain resident for the claude session.
 	binPath := variant.Path
 	//nolint:gosec // intentional exec of user-installed CLI
 	if err := execReplace(binPath, execArgs, os.Environ()); err != nil {

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -120,16 +119,12 @@ func runCC(appManager *AppManager, profile string, portOverride int, claudeArgs 
 	execArgs := []string{"--settings", settingsPath}
 	execArgs = append(execArgs, claudeArgs...)
 
-	// Exec replaces current process
+	// Exec replaces current process (on Windows, which has no true exec(),
+	// this instead runs the child and exits once it finishes) so the
+	// tingly-box process does not remain resident for the claude session.
 	binPath := variant.Path
 	//nolint:gosec // intentional exec of user-installed CLI
-	execCmd := exec.Command(binPath, execArgs...)
-	execCmd.Stdin = os.Stdin
-	execCmd.Stdout = os.Stdout
-	execCmd.Stderr = os.Stderr
-	execCmd.Env = os.Environ()
-
-	if err := execCmd.Run(); err != nil {
+	if err := execReplace(binPath, execArgs, os.Environ()); err != nil {
 		return fmt.Errorf("failed to run claude CLI: %w", err)
 	}
 	return nil

--- a/internal/command/exec_unix.go
+++ b/internal/command/exec_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package command
+
+import (
+	"syscall"
+)
+
+// execReplace replaces the current process image with binPath, so the
+// tingly-box process does not remain resident for the lifetime of the
+// child (avoids accumulating leaked parent processes).
+func execReplace(binPath string, args []string, env []string) error {
+	argv := append([]string{binPath}, args...)
+	return syscall.Exec(binPath, argv, env)
+}

--- a/internal/command/exec_windows.go
+++ b/internal/command/exec_windows.go
@@ -8,21 +8,27 @@ import (
 )
 
 // execReplace approximates process replacement on Windows, which has no
-// true exec(). The child's stdio handles are inherited independently of
-// the parent, so it starts binPath as a child and exits tingly-box
-// immediately without waiting — the child stays attached to the same
-// console (Ctrl+C still reaches it) and keeps running on its own, while
-// tingly-box does not remain resident for the claude session.
+// true exec(). It starts binPath as a child process with the same stdio
+// handles, then exits tingly-box immediately without waiting.
+//
+// In a normal console session, the child remains attached to the same
+// console, so Ctrl+C should continue to reach it. This is not identical
+// to POSIX exec(), and behavior may differ under job objects, IDEs,
+// services, CI, or custom console/process-group setups.
 func execReplace(binPath string, args []string, env []string) error {
 	cmd := exec.Command(binPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = env
+
+	if env != nil {
+		cmd.Env = env
+	}
 
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+
 	os.Exit(0)
 	return nil
 }

--- a/internal/command/exec_windows.go
+++ b/internal/command/exec_windows.go
@@ -8,9 +8,11 @@ import (
 )
 
 // execReplace approximates process replacement on Windows, which has no
-// true exec(). It starts binPath as a child, waits for it to finish, and
-// exits the current process with the child's exit code so tingly-box does
-// not remain resident once the child is running.
+// true exec(). The child's stdio handles are inherited independently of
+// the parent, so it starts binPath as a child and exits tingly-box
+// immediately without waiting — the child stays attached to the same
+// console (Ctrl+C still reaches it) and keeps running on its own, while
+// tingly-box does not remain resident for the claude session.
 func execReplace(binPath string, args []string, env []string) error {
 	cmd := exec.Command(binPath, args...)
 	cmd.Stdin = os.Stdin
@@ -19,13 +21,6 @@ func execReplace(binPath string, args []string, env []string) error {
 	cmd.Env = env
 
 	if err := cmd.Start(); err != nil {
-		return err
-	}
-	err := cmd.Wait()
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		os.Exit(exitErr.ExitCode())
-	}
-	if err != nil {
 		return err
 	}
 	os.Exit(0)

--- a/internal/command/exec_windows.go
+++ b/internal/command/exec_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package command
+
+import (
+	"os"
+	"os/exec"
+)
+
+// execReplace approximates process replacement on Windows, which has no
+// true exec(). It starts binPath as a child, waits for it to finish, and
+// exits the current process with the child's exit code so tingly-box does
+// not remain resident once the child is running.
+func execReplace(binPath string, args []string, env []string) error {
+	cmd := exec.Command(binPath, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	err := cmd.Wait()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		os.Exit(exitErr.ExitCode())
+	}
+	if err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil
+}


### PR DESCRIPTION
## Summary
Refactors process execution to use platform-specific implementations that prevent the tingly-box parent process from remaining resident after spawning the Claude CLI.

## Key Changes
- **New `exec_unix.go`**: Uses `syscall.Exec()` on Unix-like systems to replace the current process image with the child process, ensuring the parent doesn't remain in memory.
- **New `exec_windows.go`**: Implements process replacement on Windows (which lacks true `exec()`) by starting the child detached with inherited stdio handles, then immediately exiting the parent. The child remains attached to the same console for signal handling (Ctrl+C).
- **Updated `cc_command.go`**: Replaces inline `exec.Command()` logic with a call to the new `execReplace()` function, reducing code duplication and improving maintainability.

## Implementation Details
- Uses build tags (`//go:build windows` and `//go:build !windows`) to conditionally compile the appropriate implementation.
- On Unix: Leverages `syscall.Exec()` for true process replacement with no parent overhead.
- On Windows: Uses `cmd.Start()` (non-blocking) followed by immediate `os.Exit(0)` to detach the parent while keeping the child running in the same console session.
- Both implementations preserve stdin/stdout/stderr and environment variables for the child process.

https://claude.ai/code/session_01VSKaY6V4JAbJeNcGuztEG4