### PR TITLE
fix: cap OpenAI Chat/Responses max_tokens fields without forcing a default

### DIFF
--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -195,9 +195,14 @@ func (s *Server) runOpenAIChatAttempt(c *gin.Context, req *protocol.OpenAIChatCo
 
 	transform.AlignToolMessagesForOpenAI(req.ChatCompletionNewParams)
 
-	// === Cap max_tokens at model's maximum ===
-	if req.MaxTokens.Valid() && req.MaxTokens.Value > int64(maxAllowed) {
-		req.MaxTokens.Value = int64(maxAllowed)
+	// === Cap max_tokens / max_completion_tokens at model's maximum ===
+	// defaultMaxTokens is 0 (no fill) here: DefaultMaxTokens is an Anthropic-only
+	// setting (max_tokens is mandatory on that API); OpenAI callers that omit
+	// max_tokens get no field injected, same as before this cap existed, and the
+	// upstream provider applies its own default.
+	if err := executeOpenAIChatPreChain(req.ChatCompletionNewParams, 0, maxAllowed); err != nil {
+		s.failAttemptSetup(c, fmt.Errorf("max_tokens validation failed: %w", err))
+		return
 	}
 
 	// === Determine target API type ===

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -200,6 +200,17 @@ func (s *Server) runOpenAIResponsesAttempt(c *gin.Context, req *protocol.Respons
 	req.Model = responses.ResponsesModel(actualModel)
 	maxAllowed := s.templateManager.GetMaxTokensForModelByProvider(provider, actualModel)
 
+	// === Cap max_output_tokens at model's maximum ===
+	// defaultMaxTokens is 0 (no fill): DefaultMaxTokens is an Anthropic-only
+	// setting. Omitted max_output_tokens stays omitted; the upstream provider
+	// applies its own default (the WithMaxTokens(maxAllowed) option further
+	// below is unrelated — it only seeds a fallback for cross-protocol
+	// conversions that require a value, e.g. when the target is Anthropic).
+	if err := executeOpenAIResponsesPreChain(req.ResponseNewParams, 0, maxAllowed); err != nil {
+		s.failAttemptSetup(c, fmt.Errorf("max_output_tokens validation failed: %w", err))
+		return
+	}
+
 	// Determine target API type based on provider API style
 	target := protocol.TypeOpenAIResponses
 	switch provider.APIStyle {

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -3,6 +3,8 @@ package server
 import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
 
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -368,5 +370,26 @@ func executeAnthropicBetaPreChain(
 		return nil
 	}
 	_, err := transform.NewTransformChain(transforms).Execute(ctx)
+	return err
+}
+
+// executeOpenAIChatPreChain applies the same max_tokens fill/cap rules as the
+// Anthropic pre-chain (buildAnthropicPreChain) to an OpenAI Chat Completions
+// request, ahead of the transform chain / provider dispatch. Without this,
+// requests using max_completion_tokens (or a maxAllowed=0 "no cap" config)
+// would go upstream unbounded — the request-time cap in runOpenAIChatAttempt
+// only ever adjusted max_tokens.
+func executeOpenAIChatPreChain(req *openai.ChatCompletionNewParams, defaultMaxTokens, maxAllowed int) error {
+	mt := servertransform.NewMaxTokensTransform(defaultMaxTokens, maxAllowed)
+	_, err := transform.NewTransformChain([]transform.Transform{mt}).Execute(transform.NewTransformContext(req))
+	return err
+}
+
+// executeOpenAIResponsesPreChain is the Responses-API counterpart of
+// executeOpenAIChatPreChain — it caps/fills max_output_tokens, which
+// previously had no enforcement at all on the Responses path.
+func executeOpenAIResponsesPreChain(req *responses.ResponseNewParams, defaultMaxTokens, maxAllowed int) error {
+	mt := servertransform.NewMaxTokensTransform(defaultMaxTokens, maxAllowed)
+	_, err := transform.NewTransformChain([]transform.Transform{mt}).Execute(transform.NewTransformContext(req))
 	return err
 }


### PR DESCRIPTION
## Summary

Follow-up to #1287. `MaxTokensTransform` gained OpenAI Chat Completions / Responses support in that PR, but nothing actually wired it into the OpenAI request paths — `NewMaxTokensTransform` was only ever appended by `buildAnthropicPreChain`. As a result, OpenAI requests using `max_completion_tokens` or `max_output_tokens` above the model's cap still went upstream uncapped, and the pre-existing ad-hoc cap in `openai_chat.go` only ever looked at `max_tokens`.

## Changes

- Added `executeOpenAIChatPreChain` / `executeOpenAIResponsesPreChain` in `internal/server/protocol_transform.go` and call them from `runOpenAIChatAttempt` / `runOpenAIResponsesAttempt`.
- `defaultMaxTokens` is passed as `0` at both call sites (not `s.config.GetDefaultMaxTokens()`, which is documented as Anthropic-only and always non-zero) — this means **omitted fields stay omitted**; only present values above `maxAllowed` get capped. This avoids silently forcing a `max_tokens`/`max_output_tokens` value onto OpenAI-style requests that never set one, which would have been a real behavior change for clients relying on the upstream provider's own default.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/server/...`
- [x] `go test ./internal/server/...`

https://claude.ai/code/session_01MqN2PrHaQfhFyLNR2tf5Z2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqN2PrHaQfhFyLNR2tf5Z2)_