### PR TITLE
feat(scenario,config): expose Claude Code defaultMode in auto-config

### DIFF
--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -3,6 +3,7 @@ import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModel
 import ClaudeCodeConfigModal from './components/ClaudeCodeConfigModal';
 import ConnectProviderFlow from '@/components/ConnectProviderFlow';
 import { derivePrefsFromRules } from './components/ClaudeCodeQuickConfig';
+import type { ClaudeCodeDefaultMode } from './components/ClaudeCodeQuickConfig';
 import PageLayout from '@/components/PageLayout';
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
 import TemplatePage from './components/TemplatePage.tsx';
@@ -176,10 +177,11 @@ const UseClaudeCodePageContent: React.FC = () => {
     const applyPrefs = async (
         prefs: Record<string, string>,
         installStatusLine: boolean,
+        defaultMode: ClaudeCodeDefaultMode = 'acceptEdits',
     ): Promise<AgentApplyResult> => {
         try {
             setIsApplyLoading(true);
-            const result = await api.applyClaudeConfig(prefs, installStatusLine);
+            const result = await api.applyClaudeConfig(prefs, installStatusLine, defaultMode);
             if (result?.success) {
                 const created = result.createdFiles || [];
                 const updated = result.updatedFiles || [];
@@ -323,8 +325,8 @@ const UseClaudeCodePageContent: React.FC = () => {
                     baseUrl={baseUrl}
                     rules={rules}
                     copyToClipboard={copyToClipboard}
-                    onApplyWithPrefs={(prefs, installStatusLine) =>
-                        applyPrefs(prefs as Record<string, string>, installStatusLine)
+                    onApplyWithPrefs={(prefs, installStatusLine, defaultMode) =>
+                        applyPrefs(prefs as Record<string, string>, installStatusLine, defaultMode)
                     }
                     isApplyLoading={isApplyLoading}
                     pendingContext1MChange={pendingContext1MChange}

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -2,6 +2,7 @@ import { Alert, AlertTitle, Box, Button, Checkbox, CircularProgress, Dialog, Dia
 import { Close as CloseIcon } from '@/components/icons';
 import { InfoOutlined as InfoOutlinedIcon } from '@/components/icons';
 import { VisibilityOutlined as VisibilityOutlinedIcon } from '@/components/icons';
+import { RestartAlt as RestartAltIcon } from '@/components/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import CodeBlock from '@/components/CodeBlock';
@@ -42,6 +43,7 @@ const MODAL_TEXT = {
         tabQuick: '自动配置',
         tabManual: '手动',
         previewButton: '预览生成的 env',
+        resetTooltip: '重置为 tb 推荐默认值',
         previewTitle: '预览 — 将写入 ~/.claude/settings.json 的 env 段',
         applySuccess: '配置已写入',
         applyFailure: '应用失败',
@@ -53,6 +55,7 @@ const MODAL_TEXT = {
         tabQuick: 'Auto Config',
         tabManual: 'Manual',
         previewButton: 'Preview generated env',
+        resetTooltip: 'Reset to tb-recommended defaults',
         previewTitle: 'Preview — env block written to ~/.claude/settings.json',
         applySuccess: 'Configuration applied',
         applyFailure: 'Apply failed',
@@ -289,6 +292,11 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
         setApplyResult(result);
     };
 
+    const handleResetDefaults = React.useCallback(() => {
+        setPrefsAndClearResult(derivePrefsFromRules({ rules, mode: configMode }));
+        setDefaultModeAndClearResult('acceptEdits');
+    }, [configMode, rules, setDefaultModeAndClearResult, setPrefsAndClearResult]);
+
     const canApply = isFullEdition && !!onApplyWithPrefs;
 
     return (
@@ -305,12 +313,21 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                 PaperProps={{ sx: { borderRadius: 3, maxHeight: '90vh' } }}
             >
                 <DialogTitle sx={{ pb: 1, borderBottom: 1, borderColor: 'divider' }}>
-                    <Typography variant="h6" fontWeight={600}>
-                        {t('claudeCode.modal.title')}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-                        {t('claudeCode.modal.subtitle')}
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2 }}>
+                        <Box sx={{ minWidth: 0 }}>
+                            <Typography variant="h6" fontWeight={600}>
+                                {t('claudeCode.modal.title')}
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                                {t('claudeCode.modal.subtitle')}
+                            </Typography>
+                        </Box>
+                        <Tooltip title={modalText.resetTooltip} arrow>
+                            <IconButton size="small" onClick={handleResetDefaults} sx={{ mt: 0.25 }}>
+                                <RestartAltIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
                     <Tabs
                         value={mainTab}
                         onChange={(_, v) => setMainTab(v)}
@@ -378,10 +395,6 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                             setPrefs={setPrefsAndClearResult}
                             defaultMode={defaultMode}
                             setDefaultMode={setDefaultModeAndClearResult}
-                            onResetDefaults={() => {
-                                setPrefsAndClearResult(derivePrefsFromRules({ rules, mode: configMode }));
-                                setDefaultModeAndClearResult('acceptEdits');
-                            }}
                         />
                     )}
 

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -8,7 +8,7 @@ import CodeBlock from '@/components/CodeBlock';
 import { isFullEdition } from '@/utils/edition';
 import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageContext';
 import ClaudeCodeQuickConfig, { derivePrefsFromRules, prefsToEnvPreview } from './ClaudeCodeQuickConfig';
-import type { ClaudeCodePrefs } from './ClaudeCodeQuickConfig';
+import type { ClaudeCodeDefaultMode, ClaudeCodePrefs } from './ClaudeCodeQuickConfig';
 import type { AgentApplyResult } from './AgentSetupCard';
 import Context1MChangeBanner from './Context1MChangeBanner';
 
@@ -25,7 +25,7 @@ interface ClaudeCodeConfigModalProps {
     // this callback is what writes them to ~/.claude/settings.json. The
     // returned AgentApplyResult is rendered in-modal so the user sees
     // which files were touched and where the backup landed.
-    onApplyWithPrefs?: (prefs: ClaudeCodePrefs, installStatusLine: boolean) => Promise<AgentApplyResult>;
+    onApplyWithPrefs?: (prefs: ClaudeCodePrefs, installStatusLine: boolean, defaultMode: ClaudeCodeDefaultMode) => Promise<AgentApplyResult>;
     isApplyLoading?: boolean;
     // Pending 1M context change (scoped to the toggled rule) to preview in the modal
     pendingContext1MChange?: { enabled: boolean; ruleUuid?: string } | null;
@@ -63,7 +63,7 @@ const MODAL_TEXT = {
 } as const;
 
 // Helper to generate common Node.js script for writing config files
-const generateNodeScript = (settingsPath: string, envConfig: Record<string, any>) => {
+const generateNodeScript = (settingsPath: string, configPayload: Record<string, any>) => {
     return `const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -77,7 +77,7 @@ if (!fs.existsSync(targetDir)) {
     fs.mkdirSync(targetDir, { recursive: true });
 }
 
-const config = ${JSON.stringify(envConfig, null, 4)};
+const config = ${JSON.stringify(configPayload, null, 4)};
 
 let existing = {};
 if (fs.existsSync(targetPath)) {
@@ -86,7 +86,7 @@ if (fs.existsSync(targetPath)) {
 }
 
 const merged = settingsPath.includes("settings.json")
-    ? { ...existing, env: config }
+    ? { ...existing, ...config }
     : { ...existing, ...config };
 
 fs.writeFileSync(targetPath, JSON.stringify(merged, null, 2));
@@ -114,6 +114,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     const [previewOpen, setPreviewOpen] = React.useState(false);
     const [applyResult, setApplyResult] = React.useState<AgentApplyResult | null>(null);
     const [installStatusLine, setInstallStatusLine] = React.useState(true);
+    const [defaultMode, setDefaultMode] = React.useState<ClaudeCodeDefaultMode>('acceptEdits');
 
     // Prefs is the single source of truth for both tabs. Re-seed when the
     // modal isn't open so we never clobber the user's unsaved edits.
@@ -123,6 +124,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     React.useEffect(() => {
         if (!open) {
             setPrefs(derivePrefsFromRules({ rules, mode: configMode }));
+            setDefaultMode('acceptEdits');
             setApplyResult(null);
         }
     }, [open, configMode, rules]);
@@ -155,6 +157,11 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
         setApplyResult(null);
     }, []);
 
+    const setDefaultModeAndClearResult = React.useCallback((next: ClaudeCodeDefaultMode) => {
+        setDefaultMode(next);
+        setApplyResult(null);
+    }, []);
+
     const claudeJsonConfig = { hasCompletedOnboarding: true };
 
     // Env map for both the manual tab (display/copy) and the preview dialog.
@@ -164,23 +171,28 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
         [prefs, baseUrl, token],
     );
 
+    const settingsConfig = React.useMemo(
+        () => ({ env: envConfig, defaultMode }),
+        [envConfig, defaultMode],
+    );
+
     const generateSettingsConfig = React.useCallback(() => {
-        return JSON.stringify({ env: envConfig }, null, 2);
-    }, [envConfig]);
+        return JSON.stringify(settingsConfig, null, 2);
+    }, [settingsConfig]);
 
     const generateSettingsScriptWindows = React.useCallback(() => {
-        const nodeCode = generateNodeScript('.claude/settings.json', envConfig);
+        const nodeCode = generateNodeScript('.claude/settings.json', settingsConfig);
         return `# PowerShell - Run in PowerShell
 @"
 ${nodeCode}
 "@ | node`;
-    }, [envConfig]);
+    }, [settingsConfig]);
 
     const generateSettingsScriptUnix = React.useCallback(() => {
-        const nodeCode = generateNodeScript('.claude/settings.json', envConfig);
+        const nodeCode = generateNodeScript('.claude/settings.json', settingsConfig);
         return `# Bash - Run in terminal
 node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
-    }, [envConfig]);
+    }, [settingsConfig]);
 
     const generateClaudeJsonConfig = React.useCallback(() => {
         return JSON.stringify(claudeJsonConfig, null, 2);
@@ -273,7 +285,7 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
 
     const handleApply = async (installStatusLine: boolean) => {
         if (!onApplyWithPrefs) return;
-        const result = await onApplyWithPrefs(prefs, installStatusLine);
+        const result = await onApplyWithPrefs(prefs, installStatusLine, defaultMode);
         setApplyResult(result);
     };
 
@@ -364,7 +376,12 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                         <ClaudeCodeQuickConfig
                             prefs={prefs}
                             setPrefs={setPrefsAndClearResult}
-                            onResetDefaults={() => setPrefsAndClearResult(derivePrefsFromRules({ rules, mode: configMode }))}
+                            defaultMode={defaultMode}
+                            setDefaultMode={setDefaultModeAndClearResult}
+                            onResetDefaults={() => {
+                                setPrefsAndClearResult(derivePrefsFromRules({ rules, mode: configMode }));
+                                setDefaultModeAndClearResult('acceptEdits');
+                            }}
                         />
                     )}
 

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -14,7 +14,6 @@ import {
     Typography,
 } from '@mui/material';
 import { InfoOutlined as InfoOutlinedIcon } from '@/components/icons';
-import { RestartAlt as RestartAltIcon } from '@/components/icons';
 import { ExpandMore as ExpandMoreIcon } from '@/components/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -477,19 +476,16 @@ const SECTION_TEXT_EN: SectionTextMap = {
 
 interface UIText {
     panelHeader: string;
-    resetTooltip: string;
     oneMTooltip: string;
 }
 
 const UI_TEXT_ZH: UIText = {
     panelHeader: '每行对应一个 Claude Code 环境变量。hover 信息图标查看含义；留空 / 关闭 = 不写入。',
-    resetTooltip: '重置为 tb 推荐默认值',
     oneMTooltip: '启用 1M 上下文窗口（在模型 ID 末尾追加 [1m]，需路由的目标模型支持）',
 };
 
 const UI_TEXT_EN: UIText = {
     panelHeader: 'Each row is one Claude Code env var. Hover the info icon for details. Blank / off = the env is not written.',
-    resetTooltip: 'Reset to tb-recommended defaults',
     oneMTooltip: 'Enable the 1M context window (appends [1m] to the model ID; the routed target model must support it).',
 };
 
@@ -782,7 +778,6 @@ interface QuickConfigPanelProps {
     setPrefs: (p: ClaudeCodePrefs) => void;
     defaultMode: ClaudeCodeDefaultMode;
     setDefaultMode: (mode: ClaudeCodeDefaultMode) => void;
-    onResetDefaults: () => void;
 }
 
 const DefaultModeSection: React.FC<{
@@ -792,7 +787,7 @@ const DefaultModeSection: React.FC<{
 }> = ({ lang, defaultMode, setDefaultMode }) => {
     const meta = DEFAULT_MODE_SECTION_TEXT[lang];
     const text = DEFAULT_MODE_TEXT[lang];
-    const selected = text[defaultMode];
+    const selectedText = text[defaultMode];
 
     return (
         <Box>
@@ -803,8 +798,8 @@ const DefaultModeSection: React.FC<{
             <Divider />
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1, minHeight: 52 }}>
                 <Box sx={{ flex: '0 0 180px', display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-                    <Typography variant="body2" fontWeight={500} noWrap>{selected.label}</Typography>
-                    <Tooltip placement="top" arrow title={selected.description}>
+                    <Typography variant="body2" fontWeight={500} noWrap>Default Mode</Typography>
+                    <Tooltip placement="top" arrow title={`${selectedText.label}: ${selectedText.description}`}>
                         <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
                     </Tooltip>
                 </Box>
@@ -875,21 +870,13 @@ const ClaudeCodeQuickConfig: React.FC<QuickConfigPanelProps> = ({
     setPrefs,
     defaultMode,
     setDefaultMode,
-    onResetDefaults,
 }) => {
     const lang = useLang();
     const uiText = UI_TEXT[lang];
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <Typography variant="body2" color="text.secondary">{uiText.panelHeader}</Typography>
-                <Tooltip title={uiText.resetTooltip} arrow>
-                    <IconButton size="small" onClick={onResetDefaults}>
-                        <RestartAltIcon fontSize="small" />
-                    </IconButton>
-                </Tooltip>
-            </Box>
+            <Typography variant="body2" color="text.secondary">{uiText.panelHeader}</Typography>
 
             <DefaultModeSection lang={lang} defaultMode={defaultMode} setDefaultMode={setDefaultMode} />
             <Section group="model" lang={lang} prefs={prefs} setPrefs={setPrefs} />

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -2,6 +2,9 @@ import {
     Box,
     Collapse,
     Divider,
+    FormControl,
+    MenuItem,
+    Select,
     IconButton,
     InputAdornment,
     Stack,
@@ -52,7 +55,8 @@ export interface ClaudeCodePrefs {
 }
 
 type PrefsKey = keyof ClaudeCodePrefs;
-type Group = 'model' | 'limits' | 'switches' | 'network';
+export type ClaudeCodeDefaultMode = 'acceptEdits' | 'bypassPermissions' | 'default' | 'delegate' | 'dontAsk' | 'plan' | 'auto';
+type Group = 'behavior' | 'model' | 'limits' | 'switches' | 'network';
 type Kind = 'model' | 'int' | 'text' | 'bool';
 type Lang = 'zh' | 'en';
 
@@ -388,7 +392,51 @@ const FIELDS_TEXT_EN: FieldTextMap = {
 interface SectionText { title: string; hint: string }
 type SectionTextMap = Record<Group, SectionText>;
 
+interface DefaultModeOptionText {
+    label: string;
+    description: string;
+}
+
+const DEFAULT_MODE_OPTIONS: ClaudeCodeDefaultMode[] = ['acceptEdits', 'default', 'plan', 'auto', 'delegate', 'dontAsk', 'bypassPermissions'];
+
+const DEFAULT_MODE_TEXT_ZH: Record<ClaudeCodeDefaultMode, DefaultModeOptionText> = {
+    acceptEdits: { label: '接受编辑（推荐）', description: '自动接受文件编辑，其他高风险操作仍按 Claude Code 规则处理。' },
+    default: { label: '默认', description: '使用 Claude Code 官方默认权限行为。' },
+    plan: { label: '计划模式', description: '默认进入 plan mode，先规划再执行。' },
+    auto: { label: '自动', description: '由 Claude Code 自动选择权限行为。' },
+    delegate: { label: '委托', description: '把权限决策委托给 Claude Code 支持的外部流程。' },
+    dontAsk: { label: '不询问', description: '避免交互式询问；适合无人值守场景。' },
+    bypassPermissions: { label: '绕过权限', description: '跳过权限检查；仅在完全可信环境中使用。' },
+};
+
+const DEFAULT_MODE_TEXT_EN: Record<ClaudeCodeDefaultMode, DefaultModeOptionText> = {
+    acceptEdits: { label: 'Accept edits (recommended)', description: 'Automatically accepts file edits while leaving riskier actions to Claude Code rules.' },
+    default: { label: 'Default', description: 'Use Claude Code\'s built-in default permission behavior.' },
+    plan: { label: 'Plan mode', description: 'Start in plan mode by default before implementation.' },
+    auto: { label: 'Auto', description: 'Let Claude Code choose the permission behavior automatically.' },
+    delegate: { label: 'Delegate', description: 'Delegate permission decisions to Claude Code\'s supported external flow.' },
+    dontAsk: { label: 'Don\'t ask', description: 'Avoid interactive prompts; useful for unattended setups.' },
+    bypassPermissions: { label: 'Bypass permissions', description: 'Skip permission checks; use only in fully trusted environments.' },
+};
+
+const DEFAULT_MODE_TEXT: Record<Lang, Record<ClaudeCodeDefaultMode, DefaultModeOptionText>> = {
+    zh: DEFAULT_MODE_TEXT_ZH,
+    en: DEFAULT_MODE_TEXT_EN,
+};
+
+const DEFAULT_MODE_SECTION_TEXT: Record<Lang, SectionText> = {
+    zh: {
+        title: '默认权限模式',
+        hint: '写入 settings.json 的 defaultMode；tb 推荐 acceptEdits。',
+    },
+    en: {
+        title: 'Default permission mode',
+        hint: 'Writes defaultMode in settings.json; tb recommends acceptEdits.',
+    },
+};
+
 const SECTION_TEXT_ZH: SectionTextMap = {
+    behavior: DEFAULT_MODE_SECTION_TEXT.zh,
     model: {
         title: '模型路由',
         hint: '每个槽位对应 Claude Code 内部一个用途。只用一个模型时把 5 个槽位填成同一个值即可。',
@@ -408,6 +456,7 @@ const SECTION_TEXT_ZH: SectionTextMap = {
 };
 
 const SECTION_TEXT_EN: SectionTextMap = {
+    behavior: DEFAULT_MODE_SECTION_TEXT.en,
     model: {
         title: 'Model routing',
         hint: 'Each slot maps to one of Claude Code\'s internal uses. To use a single model, fill all 5 slots with the same value.',
@@ -731,12 +780,101 @@ const Section: React.FC<SectionProps> = ({ group, lang, prefs, setPrefs }) => {
 interface QuickConfigPanelProps {
     prefs: ClaudeCodePrefs;
     setPrefs: (p: ClaudeCodePrefs) => void;
+    defaultMode: ClaudeCodeDefaultMode;
+    setDefaultMode: (mode: ClaudeCodeDefaultMode) => void;
     onResetDefaults: () => void;
 }
+
+const DefaultModeSection: React.FC<{
+    lang: Lang;
+    defaultMode: ClaudeCodeDefaultMode;
+    setDefaultMode: (mode: ClaudeCodeDefaultMode) => void;
+}> = ({ lang, defaultMode, setDefaultMode }) => {
+    const meta = DEFAULT_MODE_SECTION_TEXT[lang];
+    const text = DEFAULT_MODE_TEXT[lang];
+    const selected = text[defaultMode];
+
+    return (
+        <Box>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 0.5 }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{meta.title}</Typography>
+                <Typography variant="caption" color="text.secondary">{meta.hint}</Typography>
+            </Box>
+            <Divider />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1, minHeight: 52 }}>
+                <Box sx={{ flex: '0 0 180px', display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                    <Typography variant="body2" fontWeight={500} noWrap>{selected.label}</Typography>
+                    <Tooltip placement="top" arrow title={selected.description}>
+                        <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
+                    </Tooltip>
+                </Box>
+                <Box sx={{ flex: '0 0 320px', minWidth: 0 }}>
+                    <Box
+                        component="span"
+                        sx={{
+                            px: 0.75,
+                            py: 0.25,
+                            borderRadius: 0.75,
+                            bgcolor: 'action.hover',
+                            fontFamily: 'monospace',
+                            fontSize: '0.72rem',
+                            color: 'text.secondary',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        defaultMode
+                    </Box>
+                </Box>
+                <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+                    <FormControl size="small" sx={{ width: 360 }}>
+                        <Select
+                            value={defaultMode}
+                            onChange={(e) => setDefaultMode(e.target.value as ClaudeCodeDefaultMode)}
+                            renderValue={(value) => {
+                                const mode = value as ClaudeCodeDefaultMode;
+                                return (
+                                    <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 2, width: '100%' }}>
+                                        <Typography component="span" variant="body2">{text[mode].label}</Typography>
+                                        <Typography component="span" variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>{mode}</Typography>
+                                    </Box>
+                                );
+                            }}
+                            MenuProps={{
+                                PaperProps: { sx: { maxHeight: 320, width: 360 } },
+                                MenuListProps: { sx: { py: 0.5 } },
+                            }}
+                            sx={{
+                                height: 40,
+                                '& .MuiSelect-select': {
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    py: 1,
+                                },
+                            }}
+                        >
+                            {DEFAULT_MODE_OPTIONS.map((mode) => (
+                                <MenuItem key={mode} value={mode} sx={{ minHeight: 40, py: 1 }}>
+                                    <Tooltip title={text[mode].description} arrow placement="left">
+                                        <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 2, width: '100%' }}>
+                                            <Typography variant="body2">{text[mode].label}</Typography>
+                                            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>{mode}</Typography>
+                                        </Box>
+                                    </Tooltip>
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
 
 const ClaudeCodeQuickConfig: React.FC<QuickConfigPanelProps> = ({
     prefs,
     setPrefs,
+    defaultMode,
+    setDefaultMode,
     onResetDefaults,
 }) => {
     const lang = useLang();
@@ -753,6 +891,7 @@ const ClaudeCodeQuickConfig: React.FC<QuickConfigPanelProps> = ({
                 </Tooltip>
             </Box>
 
+            <DefaultModeSection lang={lang} defaultMode={defaultMode} setDefaultMode={setDefaultMode} />
             <Section group="model" lang={lang} prefs={prefs} setPrefs={setPrefs} />
             <Section group="limits" lang={lang} prefs={prefs} setPrefs={setPrefs} />
             <Section group="switches" lang={lang} prefs={prefs} setPrefs={setPrefs} />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1093,10 +1093,10 @@ export const api = {
     // `preferences` is the source of truth: each key is a Claude Code env
     // var name (e.g. ANTHROPIC_MODEL), and the backend writes them straight
     // into ~/.claude/settings.json under "env".
-    applyClaudeConfig: async (preferences: Record<string, string>, installStatusLine?: boolean): Promise<any> => {
+    applyClaudeConfig: async (preferences: Record<string, string>, installStatusLine?: boolean, defaultMode: string = 'acceptEdits'): Promise<any> => {
         return uiAPI('/config/apply/claude', {
             method: 'POST',
-            body: JSON.stringify({preferences, installStatusLine}),
+            body: JSON.stringify({preferences, installStatusLine, defaultMode}),
         });
     },
 

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -283,9 +283,10 @@ func ensureDir(path string) error {
 type ApplyOption func(*applyOptions)
 
 type applyOptions struct {
-	backup    bool
-	retention int
-	extras    map[string]any
+	backup      bool
+	retention   int
+	extras      map[string]any
+	defaultMode string
 }
 
 // WithBackup enables or disables backup when applying settings.
@@ -301,6 +302,13 @@ func WithBackup(enable bool) ApplyOption {
 func WithBackupRetention(n int) ApplyOption {
 	return func(opts *applyOptions) {
 		opts.retention = n
+	}
+}
+
+// WithDefaultMode sets the Claude Code defaultMode value in settings.json.
+func WithDefaultMode(mode string) ApplyOption {
+	return func(opts *applyOptions) {
+		opts.defaultMode = mode
 	}
 }
 
@@ -376,6 +384,9 @@ func ApplyClaudeSettingsToPath(targetPath string, env map[string]string, opts ..
 	}
 
 	existingConfig["env"] = envInterface
+	if applyOpts.defaultMode != "" {
+		existingConfig["defaultMode"] = applyOpts.defaultMode
+	}
 	// Apply extras from options
 	for k, v := range applyOpts.extras {
 		existingConfig[k] = v

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
+func TestApplyClaudeSettings_DefaultMode(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "settings.json")
+
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	}, WithDefaultMode("acceptEdits"), WithBackup(false))
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.Message)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	if settings["defaultMode"] != "acceptEdits" {
+		t.Fatalf("defaultMode = %v, want acceptEdits", settings["defaultMode"])
+	}
+}
+
 func TestApplyClaudeSettings_NewFile(t *testing.T) {
 	// Create a temporary directory
 	tempDir, err := os.MkdirTemp("", "tingly-test")

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -141,6 +141,14 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 		})
 		return
 	}
+	defaultMode, ok := normalizeClaudeCodeDefaultMode(req.DefaultMode)
+	if !ok {
+		c.JSON(http.StatusBadRequest, config.ApplyResult{
+			Success: false,
+			Message: "Invalid defaultMode: " + req.DefaultMode,
+		})
+		return
+	}
 
 	// Get base URL from the user's request (respects reverse proxy headers)
 	port := h.config.ServerPort
@@ -173,6 +181,7 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 	var statusLinePath string
 
 	var opts []config.ApplyOption
+	opts = append(opts, config.WithDefaultMode(defaultMode))
 	if req.InstallStatusLine {
 		var scriptCreated bool
 		statusLinePath, scriptCreated, err = config.InstallStatusLineScript()

--- a/internal/server/module/configapply/handler_test.go
+++ b/internal/server/module/configapply/handler_test.go
@@ -140,8 +140,9 @@ func TestApplyClaudeConfig_MalformedBodyReturns400(t *testing.T) {
 // JSON keys; the handler binds them into the typed struct.
 func TestApplyClaudeConfigRequest_JSONShape(t *testing.T) {
 	wire := []byte(`{
-		"installStatusLine": true,
-		"preferences": {
+			"installStatusLine": true,
+			"defaultMode": "delegate",
+			"preferences": {
 			"ANTHROPIC_MODEL": "tingly/cc-default",
 			"ANTHROPIC_DEFAULT_SONNET_MODEL": "tingly/cc-sonnet[1m]",
 			"API_TIMEOUT_MS": "3000000",
@@ -155,6 +156,9 @@ func TestApplyClaudeConfigRequest_JSONShape(t *testing.T) {
 	}
 	if !req.InstallStatusLine {
 		t.Error("InstallStatusLine = false, want true")
+	}
+	if req.DefaultMode != "delegate" {
+		t.Errorf("DefaultMode = %q", req.DefaultMode)
 	}
 	if req.Preferences == nil {
 		t.Fatal("Preferences = nil, want populated")

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -14,6 +14,27 @@ import (
 type ApplyClaudeConfigRequest struct {
 	InstallStatusLine bool                   `json:"installStatusLine"`
 	Preferences       *agent.ClaudeCodePrefs `json:"preferences"`
+	DefaultMode       string                 `json:"defaultMode,omitempty"`
+}
+
+const DefaultClaudeCodeDefaultMode = "acceptEdits"
+
+var validClaudeCodeDefaultModes = map[string]struct{}{
+	"acceptEdits":       {},
+	"bypassPermissions": {},
+	"default":           {},
+	"delegate":          {},
+	"dontAsk":           {},
+	"plan":              {},
+	"auto":              {},
+}
+
+func normalizeClaudeCodeDefaultMode(mode string) (string, bool) {
+	if mode == "" {
+		return DefaultClaudeCodeDefaultMode, true
+	}
+	_, ok := validClaudeCodeDefaultModes[mode]
+	return mode, ok
 }
 
 // ApplyConfigResponse is the response for ApplyClaudeConfig


### PR DESCRIPTION
## Summary

Claude Code supports a `defaultMode` setting in `settings.json` that controls its permission behavior, but TB's auto-config didn't expose this option — users had to edit the config file manually. Now they can pick a default mode directly from the UI.

### Major
- Users can choose from 7 permission modes (acceptEdits, plan, delegate, auto, default, dontAsk, bypassPermissions) via a dropdown in the auto-config modal — no manual `settings.json` edits required
- The selected mode is written to `~/.claude/settings.json` as `defaultMode` alongside the existing `env` block
- A reset button in the modal title bar restores both env prefs and default mode to tb-recommended values with one click

### Minor
- Backend validates the mode value server-side and normalizes empty values to `acceptEdits`
- Claude Code QuickConfig panel gains a `DefaultModeSection` component independent of the env-var fields
- Moved the reset button from inside the QuickConfig panel (which was cramped) to the modal dialog title bar (more discoverable)
- Updated generated setup scripts to include `defaultMode` in the merged config payload