### PR TITLE
feat(quota,frontend): surface Codex reset credits and unify quota bar display

### DIFF
--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -123,6 +123,28 @@ type codexAdditionalRateLimit struct {
 	RateLimit      codexRateLimit `json:"rate_limit"`
 }
 
+// ── Reset credits detail endpoint ─────────────────────────
+
+// codexResetCreditsResponse from GET /backend-api/wham/rate-limit-reset-credits
+type codexResetCreditsResponse struct {
+	Credits        []codexResetCredit `json:"credits"`
+	AvailableCount int                `json:"available_count,omitempty"`
+}
+
+type codexResetCredit struct {
+	ID              string  `json:"id"`
+	ResetType       string  `json:"reset_type"`
+	Status          string  `json:"status"`
+	GrantedAt       string  `json:"granted_at"`        // ISO8601时间字符串
+	ExpiresAt       string  `json:"expires_at"`        // ISO8601时间字符串
+	RedeemStartedAt *string `json:"redeem_started_at"` // 可能为null
+	RedeemedAt      *string `json:"redeemed_at"`       // 可能为null
+	ProfileImageURL string  `json:"profile_image_url"`
+	ProfileUserID   string  `json:"profile_user_id"`
+	Title           string  `json:"title"`
+	Description     string  `json:"description"`
+}
+
 // ── Fetch ──────────────────────────────────────────────
 
 func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
@@ -259,6 +281,43 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 		})
 	}
 
+	// Handle reset credits — show each credit as a resource in breakdowns
+	if apiResp.RateLimitResetCredits != nil {
+		detail, err := f.fetchResetCreditsDetail(ctx, client, token, accountID)
+		if err == nil && detail != nil && len(detail.Credits) > 0 {
+			for _, c := range detail.Credits {
+				var usedVal float64
+				if c.Status != "available" {
+					usedVal = 1
+				}
+
+				expiresAt, err := time.Parse(time.RFC3339, c.ExpiresAt)
+				if err != nil {
+					logrus.Error(err)
+				}
+				grantedAt, err := time.Parse(time.RFC3339, c.GrantedAt)
+				if err != nil {
+					logrus.Error(err)
+				}
+
+				usage.Breakdowns = append(usage.Breakdowns, &quota.UsageBreakdown{
+					Key:   c.ID,
+					Label: fmt.Sprintf("Credit %s", c.ID),
+					Group: "reset_credit",
+					Windows: []*quota.UsageWindow{{
+						Type:        quota.WindowTypeBalance,
+						Used:        usedVal,
+						Limit:       1,
+						Unit:        quota.UsageUnitCredits,
+						ResetsAt:    &expiresAt,
+						Label:       c.Status,
+						Description: fmt.Sprintf("%s · Acquired %s", c.Status, grantedAt.Format("2006-01-02")),
+					}},
+				})
+			}
+		}
+	}
+
 	// Handle credits (balance is now a pointer)
 	if apiResp.Credits != nil && apiResp.Credits.HasCredits && !apiResp.Credits.Unlimited && apiResp.Credits.Balance != nil {
 		usage.Cost = &quota.UsageCost{
@@ -278,4 +337,46 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 	}
 
 	return usage, nil
+}
+
+// fetchResetCreditsDetail calls the detail endpoint for per-credit reset info.
+// GET /backend-api/wham/rate-limit-reset-credits
+func (f *CodexFetcher) fetchResetCreditsDetail(ctx context.Context, client *http.Client, token, accountID string) (*codexResetCreditsResponse, error) {
+	apiBase := "https://chatgpt.com"
+	if f.baseURL != "" {
+		apiBase = f.baseURL
+	}
+	url := apiBase + "/backend-api/wham/rate-limit-reset-credits"
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "codex-cli")
+	if accountID != "" {
+		req.Header.Set("ChatGPT-Account-Id", accountID)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var result codexResetCreditsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &result, nil
 }

--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -302,7 +302,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 
 				usage.Breakdowns = append(usage.Breakdowns, &quota.UsageBreakdown{
 					Key:   c.ID,
-					Label: fmt.Sprintf("Credit %s", c.ID),
+					Label: fmt.Sprintf("Reset Credit"),
 					Group: "resource",
 					Windows: []*quota.UsageWindow{{
 						Type:        quota.WindowTypeBalance,
@@ -311,7 +311,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 						Unit:        quota.UsageUnitCredits,
 						ResetsAt:    &expiresAt,
 						Label:       c.Status,
-						Description: fmt.Sprintf("%s · Acquired %s", c.Status, grantedAt.Format("2006-01-02")),
+						Description: fmt.Sprintf("Granted %s · Expire %s", grantedAt.Format("2006-01-02"), expiresAt.Format("2006-01-02")),
 					}},
 				})
 			}

--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -303,7 +303,7 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 				usage.Breakdowns = append(usage.Breakdowns, &quota.UsageBreakdown{
 					Key:   c.ID,
 					Label: fmt.Sprintf("Credit %s", c.ID),
-					Group: "reset_credit",
+					Group: "resource",
 					Windows: []*quota.UsageWindow{{
 						Type:        quota.WindowTypeBalance,
 						Used:        usedVal,

--- a/ai/quota/fetcher/codex_test.go
+++ b/ai/quota/fetcher/codex_test.go
@@ -150,8 +150,8 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 	if len(usage.Breakdowns) != 3 {
 		t.Fatalf("Expected 3 reset credit breakdowns, got %d", len(usage.Breakdowns))
 	}
-	if usage.Breakdowns[0].Group != "reset_credit" {
-		t.Errorf("Breakdown[0].Group = %q, want 'reset_credit'", usage.Breakdowns[0].Group)
+	if usage.Breakdowns[0].Group != "resource" {
+		t.Errorf("Breakdown[0].Group = %q, want 'resource'", usage.Breakdowns[0].Group)
 	}
 	if usage.Breakdowns[0].Windows[0].Label != "available" {
 		t.Errorf("Breakdown[0] status = %q, want 'available'", usage.Breakdowns[0].Windows[0].Label)

--- a/ai/quota/fetcher/codex_test.go
+++ b/ai/quota/fetcher/codex_test.go
@@ -52,27 +52,27 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 			json.NewEncoder(w).Encode(resp)
 
 		case "/backend-api/wham/rate-limit-reset-credits":
-			createdAt := time.Now().Add(-30 * 24 * time.Hour).Unix()
+			grantedAt := time.Now().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
 			resp := map[string]interface{}{
 				"available_count": 1,
 				"credits": []interface{}{
 					map[string]interface{}{
 						"id":         "credit-001",
 						"status":     "available",
-						"created_at": createdAt,
-						"expires_at": resetAt,
+						"granted_at": grantedAt,
+						"expires_at": time.Unix(resetAt, 0).Format(time.RFC3339),
 					},
 					map[string]interface{}{
 						"id":         "credit-002",
 						"status":     "used",
-						"created_at": createdAt,
-						"expires_at": time.Now().Add(-24 * time.Hour).Unix(),
+						"granted_at": grantedAt,
+						"expires_at": time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
 					},
 					map[string]interface{}{
 						"id":         "credit-003",
 						"status":     "used",
-						"created_at": createdAt,
-						"expires_at": time.Now().Add(-48 * time.Hour).Unix(),
+						"granted_at": grantedAt,
+						"expires_at": time.Now().Add(-48 * time.Hour).Format(time.RFC3339),
 					},
 				},
 			}

--- a/ai/quota/fetcher/codex_test.go
+++ b/ai/quota/fetcher/codex_test.go
@@ -23,45 +23,66 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 
 	// Mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify request path
-		if r.URL.Path != "/backend-api/wham/usage" {
-			t.Errorf("expected path /backend-api/wham/usage, got %s", r.URL.Path)
-		}
-		// Verify auth header
-		if r.Header.Get("Authorization") != "Bearer test-token" {
-			t.Errorf("expected Bearer test-token, got %s", r.Header.Get("Authorization"))
-		}
-		// Verify account ID header
-		if r.Header.Get("ChatGPT-Account-Id") != "acct-123" {
-			t.Errorf("expected ChatGPT-Account-Id acct-123, got %s", r.Header.Get("ChatGPT-Account-Id"))
-		}
-		// Verify user agent
-		if r.Header.Get("User-Agent") != "codex-cli" {
-			t.Errorf("expected User-Agent codex-cli, got %s", r.Header.Get("User-Agent"))
-		}
+		switch r.URL.Path {
+		case "/backend-api/wham/usage":
+			resp := map[string]interface{}{
+				"plan_type": "pro",
+				"rate_limit": map[string]interface{}{
+					"primary_window": map[string]interface{}{
+						"used_percent":         25,
+						"reset_at":             resetAt,
+						"limit_window_seconds": 18000, // 5 hours
+					},
+					"secondary_window": map[string]interface{}{
+						"used_percent":         10,
+						"reset_at":             weeklyResetAt,
+						"limit_window_seconds": 604800, // 7 days
+					},
+				},
+				"credits": map[string]interface{}{
+					"has_credits": true,
+					"unlimited":   false,
+					"balance":     150.0,
+				},
+				"rate_limit_reset_credits": map[string]interface{}{
+					"available_count": 3,
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
 
-		resp := map[string]interface{}{
-			"plan_type": "pro",
-			"rate_limit": map[string]interface{}{
-				"primary_window": map[string]interface{}{
-					"used_percent":         25,
-					"reset_at":             resetAt,
-					"limit_window_seconds": 18000, // 5 hours
+		case "/backend-api/wham/rate-limit-reset-credits":
+			createdAt := time.Now().Add(-30 * 24 * time.Hour).Unix()
+			resp := map[string]interface{}{
+				"available_count": 1,
+				"credits": []interface{}{
+					map[string]interface{}{
+						"id":         "credit-001",
+						"status":     "available",
+						"created_at": createdAt,
+						"expires_at": resetAt,
+					},
+					map[string]interface{}{
+						"id":         "credit-002",
+						"status":     "used",
+						"created_at": createdAt,
+						"expires_at": time.Now().Add(-24 * time.Hour).Unix(),
+					},
+					map[string]interface{}{
+						"id":         "credit-003",
+						"status":     "used",
+						"created_at": createdAt,
+						"expires_at": time.Now().Add(-48 * time.Hour).Unix(),
+					},
 				},
-				"secondary_window": map[string]interface{}{
-					"used_percent":         10,
-					"reset_at":             weeklyResetAt,
-					"limit_window_seconds": 604800, // 7 days
-				},
-			},
-			"credits": map[string]interface{}{
-				"has_credits": true,
-				"unlimited":   false,
-				"balance":     150.0,
-			},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -102,8 +123,8 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 	}
 
 	// Verify current window (5h session)
-	if len(usage.Windows) < 2 {
-		t.Fatalf("expected at least 2 windows, got %d", len(usage.Windows))
+	if len(usage.Windows) != 2 {
+		t.Fatalf("expected 2 windows (current + weekly), got %d", len(usage.Windows))
 	}
 	current := usage.Windows[0]
 	if current.UsedPercent != 25 {
@@ -123,6 +144,33 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 	}
 	if weekly.WindowMinutes != 10080 { // 604800s / 60
 		t.Errorf("Weekly.WindowMinutes = %d, want 10080", weekly.WindowMinutes)
+	}
+
+	// Verify reset credits breakdowns (as resources, not windows)
+	if len(usage.Breakdowns) != 3 {
+		t.Fatalf("Expected 3 reset credit breakdowns, got %d", len(usage.Breakdowns))
+	}
+	if usage.Breakdowns[0].Group != "reset_credit" {
+		t.Errorf("Breakdown[0].Group = %q, want 'reset_credit'", usage.Breakdowns[0].Group)
+	}
+	if usage.Breakdowns[0].Windows[0].Label != "available" {
+		t.Errorf("Breakdown[0] status = %q, want 'available'", usage.Breakdowns[0].Windows[0].Label)
+	}
+	if usage.Breakdowns[0].Windows[0].Used != 0 {
+		t.Errorf("Breakdown[0] Used = %f, want 0 (available)", usage.Breakdowns[0].Windows[0].Used)
+	}
+	if usage.Breakdowns[1].Windows[0].Label != "used" {
+		t.Errorf("Breakdown[1] status = %q, want 'used'", usage.Breakdowns[1].Windows[0].Label)
+	}
+	if usage.Breakdowns[1].Windows[0].Used != 1 {
+		t.Errorf("Breakdown[1] Used = %f, want 1 (used)", usage.Breakdowns[1].Windows[0].Used)
+	}
+
+	// Verify no reset credits window in Windows
+	for _, w := range usage.Windows {
+		if w.Key == "reset_credits" {
+			t.Errorf("reset_credits should not appear in Windows, found key=%s", w.Key)
+		}
 	}
 
 	// Verify credits
@@ -180,6 +228,100 @@ func TestCodexFetcher_Fetch_NoCredits(t *testing.T) {
 	}
 	if usage.Account.Tier != "free" {
 		t.Errorf("Account.Tier = %q, want free", usage.Account.Tier)
+	}
+	if len(usage.Windows) != 1 {
+		t.Fatalf("Expected 1 window, got %d", len(usage.Windows))
+	}
+}
+
+func TestCodexFetcher_Fetch_WithResetCreditsOnly(t *testing.T) {
+	logger := logrus.New()
+	resetAt := time.Now().Add(2 * time.Hour).Unix()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"plan_type": "plus",
+			"rate_limit": map[string]interface{}{
+				"primary_window": map[string]interface{}{
+					"used_percent":         40,
+					"reset_at":             resetAt,
+					"limit_window_seconds": 18000,
+				},
+			},
+			"rate_limit_reset_credits": map[string]interface{}{
+				"available_count": 2,
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	fetcher := &CodexFetcher{logger: logger, baseURL: server.URL}
+	provider := &ai.Provider{
+		UUID:     "codex-plus",
+		Name:     "Codex Plus",
+		AuthType: ai.AuthTypeOAuth,
+		OAuthDetail: &ai.OAuthDetail{
+			AccessToken: "test-token",
+		},
+	}
+
+	usage, err := fetcher.Fetch(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+
+	// No detail endpoint → no windows or breakdowns for reset credits
+	if len(usage.Windows) != 1 {
+		t.Fatalf("Expected 1 window, got %d", len(usage.Windows))
+	}
+	if len(usage.Breakdowns) != 0 {
+		t.Fatalf("Expected 0 breakdowns (no detail endpoint), got %d", len(usage.Breakdowns))
+	}
+}
+
+func TestCodexFetcher_Fetch_WithZeroResetCredits(t *testing.T) {
+	logger := logrus.New()
+	resetAt := time.Now().Add(2 * time.Hour).Unix()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"plan_type": "plus",
+			"rate_limit": map[string]interface{}{
+				"primary_window": map[string]interface{}{
+					"used_percent":         20,
+					"reset_at":             resetAt,
+					"limit_window_seconds": 18000,
+				},
+			},
+			"rate_limit_reset_credits": map[string]interface{}{
+				"available_count": 0,
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	fetcher := &CodexFetcher{logger: logger, baseURL: server.URL}
+	provider := &ai.Provider{
+		UUID:     "codex-zero-reset",
+		Name:     "Codex Zero Reset",
+		AuthType: ai.AuthTypeOAuth,
+		OAuthDetail: &ai.OAuthDetail{
+			AccessToken: "test-token",
+		},
+	}
+
+	usage, err := fetcher.Fetch(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+
+	if len(usage.Windows) != 1 {
+		t.Fatalf("Expected 1 window, got %d", len(usage.Windows))
+	}
+	if len(usage.Breakdowns) != 0 {
+		t.Fatalf("Expected 0 breakdowns, got %d", len(usage.Breakdowns))
 	}
 }
 

--- a/ai/quota/fetcher/gemini.go
+++ b/ai/quota/fetcher/gemini.go
@@ -118,7 +118,7 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 		breakdowns = append(breakdowns, &quota.UsageBreakdown{
 			Key:     bucket.ModelID,
 			Label:   bucket.ModelID,
-			Group:   "model",
+			Group:   "resource",
 			Windows: []*quota.UsageWindow{window},
 		})
 	}

--- a/ai/quota/fetcher/minimax.go
+++ b/ai/quota/fetcher/minimax.go
@@ -168,7 +168,7 @@ func (f *MiniMaxFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quo
 		breakdowns = append(breakdowns, &quota.UsageBreakdown{
 			Key:     m.ModelName,
 			Label:   m.ModelName,
-			Group:   "model",
+			Group:   "resource",
 			Windows: modelWindows,
 		})
 	}

--- a/ai/quota/fetcher/minimaxi.go
+++ b/ai/quota/fetcher/minimaxi.go
@@ -142,7 +142,7 @@ func (f *MiniMaxCNFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 		breakdowns = append(breakdowns, &quota.UsageBreakdown{
 			Key:     m.ModelName,
 			Label:   m.ModelName,
-			Group:   "model",
+			Group:   "resource",
 			Windows: modelWindows,
 		})
 	}

--- a/ai/quota/fetcher/zai_shared.go
+++ b/ai/quota/fetcher/zai_shared.go
@@ -271,7 +271,7 @@ func addZaiUsageDetails(usage *quota.ProviderUsage, lim zaiQuotaLimit, windowTyp
 			usage.Breakdowns = append(usage.Breakdowns, &quota.UsageBreakdown{
 				Key:     detail.ModelCode,
 				Label:   detail.ModelCode,
-				Group:   "model",
+				Group:   "resource",
 				Windows: []*quota.UsageWindow{modelWindow},
 			})
 		}

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Box, Stack, Tooltip, Typography, tooltipClasses } from '@mui/material';
 import type { UsageWindow } from '@/types/quota';
 import { formatQuotaPercent, formatQuotaUsage } from '@/types/quota';
@@ -11,6 +12,21 @@ interface QuotaBarItemProps {
    * @default false
    */
   showDetails?: boolean;
+  /**
+   * Override the percentage text (e.g., "1/3" for resource items)
+   * When set, the percent text is replaced by this value.
+   */
+  percentLabel?: string;
+  /**
+   * Force a specific bar color. When set, bypasses the default percent-based color logic.
+   */
+  barColor?: string;
+  /**
+   * Custom tooltip content. When set, replaces the default tooltip entirely.
+   * Used for resource-type items (e.g., reset credits) that need per-item detail in hover.
+   * The default tooltip shows usage stats and reset time.
+   */
+  tooltipContent?: React.ReactNode;
 }
 
 function formatCompactNumber(num: number) {
@@ -23,14 +39,14 @@ function formatCompactNumber(num: number) {
  * Compact inline display of a single quota window.
  * Shows: Label + Bar + Percent, with details in tooltip.
  */
-export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps) {
+export function QuotaBarItem({ window, showDetails = false, percentLabel, barColor: forcedBarColor, tooltipContent: customTooltip }: QuotaBarItemProps) {
   const getColor = (percent: number) => {
     if (percent >= 80) return QUOTA_COLORS.error;
     if (percent >= 50) return QUOTA_COLORS.warning;
     return QUOTA_COLORS.success;
   };
 
-  const barColor = getColor(window.used_percent);
+  const barColor = forcedBarColor ?? getColor(window.used_percent);
 
   // Format reset time
   const formatResetTime = () => {
@@ -85,7 +101,7 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
 
   return (
     <Tooltip
-      title={tooltipContent}
+      title={customTooltip ?? tooltipContent}
       arrow
       disableInteractive
       componentsProps={{
@@ -104,7 +120,7 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
       <Stack
         direction="row"
         alignItems="center"
-        spacing={1}
+        spacing={0.5}
         sx={{
           flexShrink: 0,
         }}
@@ -113,7 +129,7 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
         <Typography
           variant="body2"
           color="text.secondary"
-          sx={{ minWidth: 45 }}
+          sx={{ fontSize: '12px', whiteSpace: 'nowrap' }}
         >
           {window.label}:
         </Typography>
@@ -122,7 +138,7 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
         <Box
           sx={{
             position: 'relative',
-            width: 60,
+            width: 40,
             height: 8,
             cursor: 'pointer',
           }}
@@ -150,15 +166,16 @@ export function QuotaBarItem({ window, showDetails = false }: QuotaBarItemProps)
           </Box>
         </Box>
 
-        {/* Percent */}
+        {/* Percent / count label */}
         <Typography
           variant="body2"
           sx={{
-            color: barColor,
-            minWidth: 35,
+            color: percentLabel ? 'text.secondary' : barColor,
+            fontSize: '12px',
+            whiteSpace: 'nowrap',
           }}
         >
-          {formatQuotaPercent(window)}
+          {percentLabel ?? formatQuotaPercent(window)}
         </Typography>
 
         {/* Optional details inline */}

--- a/frontend/src/components/credential/QuotaBarRow.tsx
+++ b/frontend/src/components/credential/QuotaBarRow.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Box, Stack, Typography } from '@mui/material';
+import type { ProviderQuota, UsageWindow } from '@/types/quota';
+import { quotaToWindows } from '@/types/quota';
+import { QuotaBarItem } from './QuotaBarItem';
+
+interface QuotaBarRowProps {
+  quota: ProviderQuota | undefined;
+}
+
+interface ResourceItem {
+  key: string;
+  window: UsageWindow;
+  countLabel: string;
+  tooltipContent: React.ReactNode;
+}
+
+/**
+ * Hook: computes windows + resource items from a ProviderQuota in one pass.
+ * Returns the windows list, resource items, and whether there's anything to show.
+ */
+export function useQuotaBars(quota: ProviderQuota | undefined): {
+  windows: ReturnType<typeof quotaToWindows>;
+  resourceItems: ResourceItem[];
+  hasAny: boolean;
+} {
+  const windows = React.useMemo(() => quotaToWindows(quota), [quota]);
+
+  const resourceItems: ResourceItem[] = React.useMemo(() => {
+    if (!quota) return [];
+    const breakdowns = quota.breakdowns;
+    if (!breakdowns?.length) return [];
+
+    const groups = new Map<string, typeof breakdowns>();
+    for (const bd of breakdowns) {
+      const list = groups.get(bd.group) ?? [];
+      list.push(bd);
+      groups.set(bd.group, list);
+    }
+
+    return Array.from(groups.entries()).map(([group, items]) => {
+      const total = items.length;
+      const label = group
+        .split('_')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+
+      const tooltipContent = (
+        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
+            {label} ({total})
+          </Typography>
+          {items.map((bd: any) => {
+            const win = bd.windows?.[0];
+            return win ? (
+              <Typography key={bd.key} variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.3, lineHeight: 1.4 }}>
+                {(bd.label || bd.key)}{win.description ? `: ${win.description}` : ''}
+              </Typography>
+            ) : null;
+          })}
+        </Box>
+      );
+
+      return {
+        key: group,
+        window: {
+          label,
+          used: 0,
+          limit: total,
+          used_percent: 100,
+          unit: 'percent' as const,
+        } as UsageWindow,
+        countLabel: `${total}`,
+        tooltipContent,
+      };
+    });
+  }, [quota]);
+
+  const hasAny = windows.length > 0 || resourceItems.length > 0;
+
+  return { windows, resourceItems, hasAny };
+}
+
+/**
+ * Horizontal row of quota bar items — percentage windows + resource items.
+ * Shared between credential detail rows and model-select panels.
+ */
+export function QuotaBarRow({ quota }: QuotaBarRowProps) {
+  const { windows, resourceItems, hasAny } = useQuotaBars(quota);
+
+  if (!hasAny) return null;
+
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      alignItems="center"
+      sx={{
+        overflowX: 'auto',
+        '&::-webkit-scrollbar': { display: 'none' },
+        msOverflowStyle: 'none',
+        scrollbarWidth: 'none',
+      }}
+    >
+      {windows.map(({ key, window }) => (
+        <QuotaBarItem key={key} window={window} />
+      ))}
+      {resourceItems.map(item => (
+        <QuotaBarItem
+          key={item.key}
+          window={item.window}
+          percentLabel={item.countLabel}
+          barColor="#22c55e"
+          tooltipContent={item.tooltipContent}
+        />
+      ))}
+    </Stack>
+  );
+}

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -37,62 +37,78 @@ export function QuotaInlineDisplay({
   const visibleWindows = windows.slice(0, maxInlineItems);
   const hiddenWindows = windows.slice(maxInlineItems);
 
-  // Compute reset credits synthetic window from breakdowns
-  const resetCreditsWindow: { key: string; window: UsageWindow; countLabel: string; tooltipContent: React.ReactNode } | null = (() => {
-    if (!quota) return null;
-    const credits = (quota.breakdowns ?? []).filter(bd => bd.group === 'reset_credit');
-    if (credits.length === 0) return null;
-    const available = credits.filter(bd => bd.windows[0]?.label === 'available').length;
-    const total = credits.length;
-    const used = total - available;
+  // Compute resource-type items from breakdowns (e.g., reset credits, entitlements)
+  // Each breakdown group becomes a synthetic bar with per-item hover detail.
+  const resourceItems: Array<{ key: string; window: UsageWindow; countLabel: string; tooltipContent: React.ReactNode }> = (() => {
+    if (!quota) return [];
+    const groups = new Map<string, typeof quota.breakdowns>();
+    for (const bd of quota.breakdowns ?? []) {
+      // Skip standard breakdown groups rendered elsewhere (e.g., per-model)
+      if (bd.group === 'model') continue;
+      const list = groups.get(bd.group) ?? [];
+      list.push(bd);
+      groups.set(bd.group, list);
+    }
 
-    // Build per-credit detail tooltip
     const STATUS_COLORS: Record<string, string> = {
       available: '#22c55e',
       used: '#94a3b8',
       expired: '#ef4444',
     };
-    const tooltipContent = (
-      <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
-        <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
-          Reset Credits ({available} / {total} available)
-        </Typography>
-        {credits.map((bd) => {
-          const win = bd.windows[0];
-          if (!win) return null;
-          const status = win.label || 'unknown';
-          const color = STATUS_COLORS[status] || STATUS_COLORS.used;
-          const expiresAt = win.resets_at ? new Date(win.resets_at) : null;
-          return (
-            <Stack key={bd.key} direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
-              <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
-              <Typography variant="caption" sx={{ color: 'text.secondary', lineHeight: 1.3 }}>
-                {status === 'available' ? 'Available' : status.charAt(0).toUpperCase() + status.slice(1)}
-                {expiresAt && ` · Expires ${expiresAt.toLocaleDateString()}`}
-              </Typography>
-            </Stack>
-          );
-        })}
-      </Box>
-    );
 
-    return {
-      window: {
-        label: 'Reset Credits',
-        used: used,
-        limit: total,
-        used_percent: 100,
-        unit: 'percent' as const,
-        description: `${available} available, ${total} total`,
-      } as UsageWindow,
-      key: 'reset_credits',
-      countLabel: `${available}/${total}`,
-      tooltipContent,
-    };
+    return Array.from(groups.entries())
+      .filter((entry): entry is [string, NonNullable<typeof quota.breakdowns>] => entry[1] !== undefined)
+      .map(([group, items]) => {
+      const available = items.filter(bd => bd.windows[0]?.label === 'available').length;
+      const total = items.length;
+      // Derive display label from group name: "reset_credit" → "Reset Credits"
+      const label = group
+        .split('_')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+
+      const tooltipContent = (
+        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
+            {label} ({available} / {total} available)
+          </Typography>
+          {items.map((bd) => {
+            const win = bd.windows[0];
+            if (!win) return null;
+            const status = win.label || 'unknown';
+            const color = STATUS_COLORS[status] || STATUS_COLORS.used;
+            const expiresAt = win.resets_at ? new Date(win.resets_at) : null;
+            return (
+              <Stack key={bd.key} direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+                <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
+                <Typography variant="caption" sx={{ color: 'text.secondary', lineHeight: 1.3 }}>
+                  {status === 'available' ? 'Available' : status.charAt(0).toUpperCase() + status.slice(1)}
+                  {expiresAt && ` · Expires ${expiresAt.toLocaleDateString()}`}
+                </Typography>
+              </Stack>
+            );
+          })}
+        </Box>
+      );
+
+      return {
+        key: group,
+        window: {
+          label,
+          used: total - available,
+          limit: total,
+          used_percent: 100,
+          unit: 'percent' as const,
+          description: `${available} available, ${total} total`,
+        } as UsageWindow,
+        countLabel: `${available}/${total}`,
+        tooltipContent,
+      };
+    });
   })();
 
   // Show nothing if there's no data at all
-  if (!hasQuota && !resetCreditsWindow) {
+  if (!hasQuota && resourceItems.length === 0) {
     return null;
   }
 
@@ -234,9 +250,9 @@ export function QuotaInlineDisplay({
         {visibleWindows.map(({ key, window }) => (
           <QuotaBarItem key={key} window={window} />
         ))}
-        {resetCreditsWindow && (
-          <QuotaBarItem key={resetCreditsWindow.key} window={resetCreditsWindow.window} percentLabel={resetCreditsWindow.countLabel} barColor="#22c55e" tooltipContent={resetCreditsWindow.tooltipContent} />
-        )}
+        {resourceItems.map(item => (
+          <QuotaBarItem key={item.key} window={item.window} percentLabel={item.countLabel} barColor="#22c55e" tooltipContent={item.tooltipContent} />
+        ))}
       </Stack>
     </Box>
   );

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -4,8 +4,9 @@ import { AccessTime as AccessTimeIcon } from '@/components/icons';
 import { Refresh as RefreshIcon } from '@/components/icons';
 import { Info as InfoIcon } from '@/components/icons';
 import { QuotaBarItem } from './QuotaBarItem';
-import type { ProviderQuota, UsageWindow } from '@/types/quota';
-import { formatQuotaUsage, quotaToWindows } from '@/types/quota';
+import { QuotaBarRow, useQuotaBars } from './QuotaBarRow';
+import type { ProviderQuota } from '@/types/quota';
+import { formatQuotaUsage } from '@/types/quota';
 
 interface QuotaInlineDisplayProps {
   quota: ProviderQuota | undefined;
@@ -21,7 +22,7 @@ interface QuotaInlineDisplayProps {
 
 /**
  * Horizontal inline display of quota information.
- * Shows quota items side by side with refresh button.
+ * Shows quota bars with refresh/info actions.
  * Hidden items accessible via info icon tooltip.
  */
 export function QuotaInlineDisplay({
@@ -30,69 +31,14 @@ export function QuotaInlineDisplay({
   onRefresh,
   maxInlineItems = 3,
 }: QuotaInlineDisplayProps) {
-  const windows = quotaToWindows(quota);
+  const { windows, resourceItems, hasAny } = useQuotaBars(quota);
 
-  const hasQuota = windows.length > 0;
   const hasHiddenItems = windows.length > maxInlineItems;
   const visibleWindows = windows.slice(0, maxInlineItems);
   const hiddenWindows = windows.slice(maxInlineItems);
 
-  // Compute resource-type items from breakdowns (e.g., reset credits, entitlements)
-  // Each non-"model" breakdown group is aggregated into one compact bar with count.
-  const resourceItems: Array<{ key: string; window: UsageWindow; countLabel: string; tooltipContent: React.ReactNode }> = (() => {
-    if (!quota) return [];
-
-    // Group all breakdowns by group name
-    const groups = new Map<string, typeof quota.breakdowns>();
-    for (const bd of quota.breakdowns ?? []) {
-      const list = groups.get(bd.group) ?? [];
-      list.push(bd);
-      groups.set(bd.group, list);
-    }
-
-    return Array.from(groups.entries())
-      .filter((entry): entry is [string, NonNullable<typeof quota.breakdowns>] => entry[1] !== undefined)
-      .map(([group, items]) => {
-        const total = items.length;
-        const label = group
-          .split('_')
-          .map(w => w.charAt(0).toUpperCase() + w.slice(1))
-          .join(' ');
-
-        const tooltipContent = (
-          <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
-            <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
-              {label} ({total})
-            </Typography>
-            {items.map((bd) => {
-              const win = bd.windows[0];
-              if (!win) return null;
-              return (
-                <Typography key={bd.key} variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.3, lineHeight: 1.4 }}>
-                  {(bd.label || bd.key)}{win.description ? `: ${win.description}` : ''}
-                </Typography>
-              );
-            })}
-          </Box>
-        );
-
-        return {
-          key: group,
-          window: {
-            label,
-            used: 0,
-            limit: total,
-            used_percent: 100,
-            unit: 'percent' as const,
-          } as UsageWindow,
-          countLabel: `${total}`,
-          tooltipContent,
-        };
-      });
-  })();
-
   // Show nothing if there's no data at all
-  if (!hasQuota && resourceItems.length === 0) {
+  if (!hasAny) {
     return null;
   }
 
@@ -217,20 +163,8 @@ export function QuotaInlineDisplay({
         )}
       </Stack>
 
-      {/* Quota items */}
-      <Stack
-        direction="row"
-        spacing={2}
-        sx={{
-          overflowX: 'auto',
-          // Hide scrollbar but keep functionality
-          '&::-webkit-scrollbar': {
-            display: 'none',
-          },
-          msOverflowStyle: 'none',
-          scrollbarWidth: 'none',
-        }}
-      >
+      {/* Quota bar row — visible windows + resource items */}
+      <Stack direction="row" spacing={2} sx={{ overflowX: 'auto', '&::-webkit-scrollbar': { display: 'none' }, msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
         {visibleWindows.map(({ key, window }) => (
           <QuotaBarItem key={key} window={window} />
         ))}

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
 import { Box, Stack, IconButton, Typography, CircularProgress, Tooltip } from '@mui/material';
 import { AccessTime as AccessTimeIcon } from '@/components/icons';
 import { Refresh as RefreshIcon } from '@/components/icons';
 import { Info as InfoIcon } from '@/components/icons';
 import { QuotaBarItem } from './QuotaBarItem';
-import type { ProviderQuota } from '@/types/quota';
+import type { ProviderQuota, UsageWindow } from '@/types/quota';
 import { formatQuotaUsage, quotaToWindows } from '@/types/quota';
 
 interface QuotaInlineDisplayProps {
@@ -36,8 +37,62 @@ export function QuotaInlineDisplay({
   const visibleWindows = windows.slice(0, maxInlineItems);
   const hiddenWindows = windows.slice(maxInlineItems);
 
-  // No quota available - don't show anything
-  if (!hasQuota) {
+  // Compute reset credits synthetic window from breakdowns
+  const resetCreditsWindow: { key: string; window: UsageWindow; countLabel: string; tooltipContent: React.ReactNode } | null = (() => {
+    if (!quota) return null;
+    const credits = (quota.breakdowns ?? []).filter(bd => bd.group === 'reset_credit');
+    if (credits.length === 0) return null;
+    const available = credits.filter(bd => bd.windows[0]?.label === 'available').length;
+    const total = credits.length;
+    const used = total - available;
+
+    // Build per-credit detail tooltip
+    const STATUS_COLORS: Record<string, string> = {
+      available: '#22c55e',
+      used: '#94a3b8',
+      expired: '#ef4444',
+    };
+    const tooltipContent = (
+      <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
+        <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
+          Reset Credits ({available} / {total} available)
+        </Typography>
+        {credits.map((bd) => {
+          const win = bd.windows[0];
+          if (!win) return null;
+          const status = win.label || 'unknown';
+          const color = STATUS_COLORS[status] || STATUS_COLORS.used;
+          const expiresAt = win.resets_at ? new Date(win.resets_at) : null;
+          return (
+            <Stack key={bd.key} direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+              <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
+              <Typography variant="caption" sx={{ color: 'text.secondary', lineHeight: 1.3 }}>
+                {status === 'available' ? 'Available' : status.charAt(0).toUpperCase() + status.slice(1)}
+                {expiresAt && ` · Expires ${expiresAt.toLocaleDateString()}`}
+              </Typography>
+            </Stack>
+          );
+        })}
+      </Box>
+    );
+
+    return {
+      window: {
+        label: 'Reset Credits',
+        used: used,
+        limit: total,
+        used_percent: 100,
+        unit: 'percent' as const,
+        description: `${available} available, ${total} total`,
+      } as UsageWindow,
+      key: 'reset_credits',
+      countLabel: `${available}/${total}`,
+      tooltipContent,
+    };
+  })();
+
+  // Show nothing if there's no data at all
+  if (!hasQuota && !resetCreditsWindow) {
     return null;
   }
 
@@ -179,6 +234,9 @@ export function QuotaInlineDisplay({
         {visibleWindows.map(({ key, window }) => (
           <QuotaBarItem key={key} window={window} />
         ))}
+        {resetCreditsWindow && (
+          <QuotaBarItem key={resetCreditsWindow.key} window={resetCreditsWindow.window} percentLabel={resetCreditsWindow.countLabel} barColor="#22c55e" tooltipContent={resetCreditsWindow.tooltipContent} />
+        )}
       </Stack>
     </Box>
   );

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -38,73 +38,57 @@ export function QuotaInlineDisplay({
   const hiddenWindows = windows.slice(maxInlineItems);
 
   // Compute resource-type items from breakdowns (e.g., reset credits, entitlements)
-  // Each breakdown group becomes a synthetic bar with per-item hover detail.
+  // Each non-"model" breakdown group is aggregated into one compact bar with count.
   const resourceItems: Array<{ key: string; window: UsageWindow; countLabel: string; tooltipContent: React.ReactNode }> = (() => {
     if (!quota) return [];
+
+    // Group all breakdowns by group name
     const groups = new Map<string, typeof quota.breakdowns>();
     for (const bd of quota.breakdowns ?? []) {
-      // Skip standard breakdown groups rendered elsewhere (e.g., per-model)
-      if (bd.group === 'model') continue;
       const list = groups.get(bd.group) ?? [];
       list.push(bd);
       groups.set(bd.group, list);
     }
 
-    const STATUS_COLORS: Record<string, string> = {
-      available: '#22c55e',
-      used: '#94a3b8',
-      expired: '#ef4444',
-    };
-
     return Array.from(groups.entries())
       .filter((entry): entry is [string, NonNullable<typeof quota.breakdowns>] => entry[1] !== undefined)
       .map(([group, items]) => {
-      const available = items.filter(bd => bd.windows[0]?.label === 'available').length;
-      const total = items.length;
-      // Derive display label from group name: "reset_credit" → "Reset Credits"
-      const label = group
-        .split('_')
-        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
-        .join(' ');
+        const total = items.length;
+        const label = group
+          .split('_')
+          .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(' ');
 
-      const tooltipContent = (
-        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
-          <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
-            {label} ({available} / {total} available)
-          </Typography>
-          {items.map((bd) => {
-            const win = bd.windows[0];
-            if (!win) return null;
-            const status = win.label || 'unknown';
-            const color = STATUS_COLORS[status] || STATUS_COLORS.used;
-            const expiresAt = win.resets_at ? new Date(win.resets_at) : null;
-            return (
-              <Stack key={bd.key} direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
-                <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
-                <Typography variant="caption" sx={{ color: 'text.secondary', lineHeight: 1.3 }}>
-                  {status === 'available' ? 'Available' : status.charAt(0).toUpperCase() + status.slice(1)}
-                  {expiresAt && ` · Expires ${expiresAt.toLocaleDateString()}`}
+        const tooltipContent = (
+          <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
+            <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>
+              {label} ({total})
+            </Typography>
+            {items.map((bd) => {
+              const win = bd.windows[0];
+              if (!win) return null;
+              return (
+                <Typography key={bd.key} variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.3, lineHeight: 1.4 }}>
+                  {(bd.label || bd.key)}{win.description ? `: ${win.description}` : ''}
                 </Typography>
-              </Stack>
-            );
-          })}
-        </Box>
-      );
+              );
+            })}
+          </Box>
+        );
 
-      return {
-        key: group,
-        window: {
-          label,
-          used: total - available,
-          limit: total,
-          used_percent: 100,
-          unit: 'percent' as const,
-          description: `${available} available, ${total} total`,
-        } as UsageWindow,
-        countLabel: `${available}/${total}`,
-        tooltipContent,
-      };
-    });
+        return {
+          key: group,
+          window: {
+            label,
+            used: 0,
+            limit: total,
+            used_percent: 100,
+            unit: 'percent' as const,
+          } as UsageWindow,
+          countLabel: `${total}`,
+          tooltipContent,
+        };
+      });
   })();
 
   // Show nothing if there's no data at all

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -18,8 +18,9 @@ import {
 } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Provider } from '@/types/provider';
-import type { ProviderQuota } from '@/types/quota';
 import { quotaToWindows } from '@/types/quota';
+import type { ProviderQuota, UsageWindow } from '@/types/quota';
+import { QuotaBarItem } from '@/components/credential/QuotaBarItem';
 import { getModelTypeInfo } from '@/utils/modelUtils';
 import { useCustomModels } from '@/hooks/useCustomModels';
 import { useProviderModels } from '@/hooks/useProviderModels';
@@ -32,7 +33,6 @@ import CustomModelCard from './CustomModelCard';
 import ModelCard from './ModelCard';
 import RecentModelsSection from './RecentModelsSection';
 import NewModelsSection from './NewModelsSection';
-import { QuotaBar } from './QuotaBar';
 
 async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> {
     const basePath = window.location.origin;
@@ -119,6 +119,41 @@ export function ModelsPanel({
     }, [providerModels, provider.uuid, provider.name, provider.api_style]);
 
     const quotaWindows = useMemo(() => quotaToWindows(providerQuota), [providerQuota]);
+
+    // Compute resource items from breakdowns (unified resource display)
+    const resourceItems = useMemo(() => {
+        const breakdowns = providerQuota?.breakdowns;
+        if (!breakdowns?.length) return [];
+        const groups = new Map<string, typeof breakdowns>();
+        for (const bd of breakdowns) {
+            const list = groups.get(bd.group) ?? [];
+            list.push(bd);
+            groups.set(bd.group, list);
+        }
+        return Array.from(groups.entries()).map(([group, items]) => {
+            const total = items.length;
+            const label = group.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+            const tooltipContent = (
+                <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
+                    <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>{label} ({total})</Typography>
+                    {items.map((bd: any) => {
+                        const win = bd.windows?.[0];
+                        return win ? (
+                            <Typography key={bd.key} variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.3, lineHeight: 1.4 }}>
+                                {(bd.label || bd.key)}{win.description ? `: ${win.description}` : ''}
+                            </Typography>
+                        ) : null;
+                    })}
+                </Box>
+            );
+            return {
+                key: group,
+                window: { label, used: 0, limit: total, used_percent: 100, unit: 'percent' as const } as UsageWindow,
+                countLabel: `${total}`,
+                tooltipContent,
+            };
+        });
+    }, [providerQuota]);
 
     // Re-fetch provider models when refresh trigger changes (e.g., after custom model deletion)
     useEffect(() => {
@@ -461,14 +496,12 @@ export function ModelsPanel({
                             />
                         </IconButton>
                     </Stack>
-                    <Stack spacing={1.5}>
-                        {quotaWindows.map(({ key, label, window }) => (
-                            <Box key={key}>
-                                <Typography variant="caption" sx={{ mb: 0.5, display: 'block', color: '#64748b' }}>
-                                    {label}
-                                </Typography>
-                                <QuotaBar quota={providerQuota!} window={window} />
-                            </Box>
+                    <Stack direction="row" spacing={2} sx={{ overflowX: 'auto', '&::-webkit-scrollbar': { display: 'none' }, msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
+                        {quotaWindows.map(({ key, window }) => (
+                            <QuotaBarItem key={key} window={window} />
+                        ))}
+                        {resourceItems.map(item => (
+                            <QuotaBarItem key={item.key} window={item.window} percentLabel={item.countLabel} barColor="#22c55e" tooltipContent={item.tooltipContent} />
                         ))}
                     </Stack>
                 </Box>

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -18,9 +18,9 @@ import {
 } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Provider } from '@/types/provider';
-import { quotaToWindows } from '@/types/quota';
-import type { ProviderQuota, UsageWindow } from '@/types/quota';
+import type { ProviderQuota } from '@/types/quota';
 import { QuotaBarItem } from '@/components/credential/QuotaBarItem';
+import { useQuotaBars } from '@/components/credential/QuotaBarRow';
 import { getModelTypeInfo } from '@/utils/modelUtils';
 import { useCustomModels } from '@/hooks/useCustomModels';
 import { useProviderModels } from '@/hooks/useProviderModels';
@@ -118,42 +118,7 @@ export function ModelsPanel({
         );
     }, [providerModels, provider.uuid, provider.name, provider.api_style]);
 
-    const quotaWindows = useMemo(() => quotaToWindows(providerQuota), [providerQuota]);
-
-    // Compute resource items from breakdowns (unified resource display)
-    const resourceItems = useMemo(() => {
-        const breakdowns = providerQuota?.breakdowns;
-        if (!breakdowns?.length) return [];
-        const groups = new Map<string, typeof breakdowns>();
-        for (const bd of breakdowns) {
-            const list = groups.get(bd.group) ?? [];
-            list.push(bd);
-            groups.set(bd.group, list);
-        }
-        return Array.from(groups.entries()).map(([group, items]) => {
-            const total = items.length;
-            const label = group.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
-            const tooltipContent = (
-                <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5, maxWidth: 250 }}>
-                    <Typography variant="caption" sx={{ fontWeight: 600, display: 'block', mb: 1 }}>{label} ({total})</Typography>
-                    {items.map((bd: any) => {
-                        const win = bd.windows?.[0];
-                        return win ? (
-                            <Typography key={bd.key} variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.3, lineHeight: 1.4 }}>
-                                {(bd.label || bd.key)}{win.description ? `: ${win.description}` : ''}
-                            </Typography>
-                        ) : null;
-                    })}
-                </Box>
-            );
-            return {
-                key: group,
-                window: { label, used: 0, limit: total, used_percent: 100, unit: 'percent' as const } as UsageWindow,
-                countLabel: `${total}`,
-                tooltipContent,
-            };
-        });
-    }, [providerQuota]);
+    const { windows: quotaWindows, resourceItems } = useQuotaBars(providerQuota);
 
     // Re-fetch provider models when refresh trigger changes (e.g., after custom model deletion)
     useEffect(() => {


### PR DESCRIPTION
## Summary
Codex (ChatGPT) accounts with reset credits previously had no visibility into how many credits remained or their status. Now each reset credit appears inline in the quota bar, and the frontend display is unified across credential rows and model-select panels.

<img width="1730" height="170" alt="image" src="https://github.com/user-attachments/assets/030d3f64-b318-45da-a71b-5a514941944e" />

### Major
- Codex reset credits are now fetched via the detail endpoint and surfaced as individual breakdown items, each showing status (available/used),
- Quota bars in credential rows and model-select panels now use a shared `QuotaBarRow` component with a `useQuotaBars` hook, eliminating duplicate display logic
- Resource-type items (like reset credits) render with a count label ("3") and a detail tooltip instead of a percentage bar

### Minor
- Breakdown group renamed from `"model"` to `"resource"` across Gemini, MiniMax, MiniMax-CN, and Z.ai fetchers for consistency with Codex
- `QuotaBarItem` gains optional `percentLabel`, `barColor`, and `tooltipContent` props for flexible reuse
- `QuotaInlineDisplay` and `ModelsPanel` both delegate bar rendering to the shared hook
- Codex test server updated to route on path, with new test cases for reset-credits-only and zero-reset-credits scenarios
