### PR TITLE
feat(usage): normalize token accounting across providers

### DIFF
--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -63,7 +63,7 @@ flowchart TD
 type TokenUsage struct {
     InputTokens      int `json:"input_tokens"`                 // 输入/prompt，已扣除 cache
     OutputTokens     int `json:"output_tokens"`                // 输出/completion
-    CacheInputTokens int `json:"cache_input_tokens,omitempty"` // cache creation + cache read 合并
+    CacheInputTokens int `json:"cache_input_tokens,omitempty"` // cache read 命中（不含 write）
     ReasoningTokens  int `json:"reasoning_tokens,omitempty"`   // o1/o3 reasoning，是 OutputTokens 的子集
     SystemTokens     int `json:"system_tokens,omitempty"`      // 模板/系统指令/框架开销
 }
@@ -83,7 +83,7 @@ type TokenUsage struct {
 | `ToAnthropicUsageMap()` / `ToAnthropicMessageDeltaUsageMap()` | 从 canonical usage 生成 Anthropic wire usage map |
 | `ToOpenAIChatUsageMap()` / `ToOpenAIResponsesUsageMap()` | 从 canonical usage 还原 OpenAI wire usage map（input/prompt 含 cache） |
 
-> ⚠️ 注意 `CacheInputTokens` 是 **creation + read 合并**后的单字段（见 §2 归一化）。早期版本曾分 `cache_creation` / `cache_read` 两列，已合并（DB 迁移见 §6.2）。
+> ⚠️ `CacheInputTokens` 仅代表 **cache read 命中**。Write（`cache_creation`）已并入 `InputTokens`（Anthropic 归一化）；OpenAI 无 write 概念。`CacheReadTokens` / `CacheWriteTokens` 为详情字段，两者之和 = 旧版 `CacheInputTokens`（合并期已过去，现以详情为准）。
 
 ---
 

--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -80,6 +80,8 @@ type TokenUsage struct {
 | `NewTokenUsageWithCache(in, out, cache)` | + cache |
 | `NewTokenUsageFull(in, out, cache, reasoning)` | + reasoning（OpenAI 路径用） |
 | `ZeroTokenUsage()` | 零值，用于「无 usage」回退 |
+| `ToAnthropicUsageMap()` / `ToAnthropicMessageDeltaUsageMap()` | 从 canonical usage 生成 Anthropic wire usage map |
+| `ToOpenAIChatUsageMap()` / `ToOpenAIResponsesUsageMap()` | 从 canonical usage 还原 OpenAI wire usage map（input/prompt 含 cache） |
 
 > ⚠️ 注意 `CacheInputTokens` 是 **creation + read 合并**后的单字段（见 §2 归一化）。早期版本曾分 `cache_creation` / `cache_read` 两列，已合并（DB 迁移见 §6.2）。
 
@@ -199,6 +201,7 @@ Anthropic 把 usage 拆在两个事件里：
 
 - `message_start` → `input_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens`
 - `message_delta` → `output_tokens`（个别非标准 provider 也在这里塞 `input_tokens`）
+- **协议转换特例**：OpenAI → Anthropic 这类转换在流开始时拿不到权威 input usage，只能在上游终态事件拿到完整 usage；因此终态 `message_delta.usage` 可以携带完整 normalized usage（`input_tokens` / `output_tokens` / `cache_read_input_tokens`），这是为了保持对外 SSE、录制与计费同源一致。
 
 ```go
 acc := usage.NewAnthropicAccumulator()

--- a/ai/protocol.go
+++ b/ai/protocol.go
@@ -98,6 +98,78 @@ func (u *TokenUsage) HasCacheUsage() bool {
 	return u.CacheInputTokens > 0
 }
 
+// ToAnthropicUsageMap converts canonical usage into Anthropic message usage shape.
+func (u *TokenUsage) ToAnthropicUsageMap() map[string]interface{} {
+	usage := map[string]interface{}{
+		"input_tokens":  u.InputTokens,
+		"output_tokens": u.OutputTokens,
+	}
+	if u.CacheInputTokens > 0 {
+		usage["cache_read_input_tokens"] = u.CacheInputTokens
+	}
+	return usage
+}
+
+// ToAnthropicMessageDeltaUsageMap converts canonical usage into Anthropic stream
+// message_delta usage shape for protocol conversion. Native Anthropic streams put
+// input usage on message_start, but converters such as OpenAI→Anthropic only get
+// authoritative input usage at the terminal upstream event, so the final
+// message_delta carries the complete normalized usage.
+func (u *TokenUsage) ToAnthropicMessageDeltaUsageMap() map[string]interface{} {
+	usage := map[string]interface{}{
+		"input_tokens":  u.InputTokens,
+		"output_tokens": u.OutputTokens,
+	}
+	if u.CacheInputTokens > 0 {
+		usage["cache_read_input_tokens"] = u.CacheInputTokens
+	}
+	return usage
+}
+
+// ToOpenAIChatUsageMap converts canonical usage into OpenAI Chat Completions
+// usage shape. Prompt/input tokens on the wire include cached tokens.
+func (u *TokenUsage) ToOpenAIChatUsageMap() map[string]interface{} {
+	inputTokens := u.InputTokens + u.CacheInputTokens
+	usage := map[string]interface{}{
+		"prompt_tokens":     inputTokens,
+		"completion_tokens": u.OutputTokens,
+		"total_tokens":      inputTokens + u.OutputTokens,
+	}
+	if u.CacheInputTokens > 0 {
+		usage["prompt_tokens_details"] = map[string]interface{}{
+			"cached_tokens": u.CacheInputTokens,
+		}
+	}
+	if u.ReasoningTokens > 0 {
+		usage["completion_tokens_details"] = map[string]interface{}{
+			"reasoning_tokens": u.ReasoningTokens,
+		}
+	}
+	return usage
+}
+
+// ToOpenAIResponsesUsageMap converts canonical usage into OpenAI Responses API
+// usage shape. Input tokens on the wire include cached tokens.
+func (u *TokenUsage) ToOpenAIResponsesUsageMap() map[string]interface{} {
+	inputTokens := u.InputTokens + u.CacheInputTokens
+	usage := map[string]interface{}{
+		"input_tokens":  inputTokens,
+		"output_tokens": u.OutputTokens,
+		"total_tokens":  inputTokens + u.OutputTokens,
+	}
+	if u.CacheInputTokens > 0 {
+		usage["input_tokens_details"] = map[string]interface{}{
+			"cached_tokens": u.CacheInputTokens,
+		}
+	}
+	if u.ReasoningTokens > 0 {
+		usage["output_tokens_details"] = map[string]interface{}{
+			"reasoning_tokens": u.ReasoningTokens,
+		}
+	}
+	return usage
+}
+
 // NewTokenUsage creates a new TokenUsage with the given token counts.
 func NewTokenUsage(inputTokens, outputTokens int) *TokenUsage {
 	return &TokenUsage{

--- a/ai/protocol.go
+++ b/ai/protocol.go
@@ -68,13 +68,17 @@ type TokenUsage struct {
 	// OutputTokens is the number of output/completion tokens consumed
 	OutputTokens int `json:"output_tokens"`
 
-	// CacheInputTokens is the number of cache-related tokens consumed
-	// (includes both cache creation and cache read operations)
+	// CacheInputTokens is the number of cache-read-hit tokens consumed.
+	// Cache-write cost is tracked separately in CacheWriteTokens.
+	// Note: Anthropic normalization folds CacheWriteTokens into InputTokens
+	// (InputTokens += cache_creation), so InputTokens already covers write cost.
+	// Total prompt cost = InputTokens + CacheInputTokens.
 	CacheInputTokens int `json:"cache_input_tokens,omitempty"`
 
-	// Both cache read and write are part of cache input, but write means an extra cost than general read
-	// for all cases, prompt = input + cache_input
-	// and we just store the read and write for details
+	// CacheReadTokens and CacheWriteTokens provide detail for billing.
+	// CacheReadTokens  = cache-read hits (same as CacheInputTokens).
+	// CacheWriteTokens = cache writes; folded into InputTokens in Anthropic
+	// normalization; zero for OpenAI (no wire-level write concept).
 	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
 	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
 

--- a/ai/protocol.go
+++ b/ai/protocol.go
@@ -72,6 +72,12 @@ type TokenUsage struct {
 	// (includes both cache creation and cache read operations)
 	CacheInputTokens int `json:"cache_input_tokens,omitempty"`
 
+	// Both cache read and write are part of cache input, but write means an extra cost than general read
+	// for all cases, prompt = input + cache_input
+	// and we just store the read and write for details
+	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+
 	// ReasoningTokens is the number of tokens used for internal reasoning
 	// (e.g. o1/o3 reasoning models). These are a subset of OutputTokens.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
@@ -104,8 +110,11 @@ func (u *TokenUsage) ToAnthropicUsageMap() map[string]interface{} {
 		"input_tokens":  u.InputTokens,
 		"output_tokens": u.OutputTokens,
 	}
-	if u.CacheInputTokens > 0 {
-		usage["cache_read_input_tokens"] = u.CacheInputTokens
+	if u.CacheReadTokens > 0 {
+		usage["cache_read_input_tokens"] = u.CacheReadTokens
+	}
+	if u.CacheWriteTokens > 0 {
+		usage["cache_creation_input_tokens"] = u.CacheWriteTokens
 	}
 	return usage
 }
@@ -116,14 +125,7 @@ func (u *TokenUsage) ToAnthropicUsageMap() map[string]interface{} {
 // authoritative input usage at the terminal upstream event, so the final
 // message_delta carries the complete normalized usage.
 func (u *TokenUsage) ToAnthropicMessageDeltaUsageMap() map[string]interface{} {
-	usage := map[string]interface{}{
-		"input_tokens":  u.InputTokens,
-		"output_tokens": u.OutputTokens,
-	}
-	if u.CacheInputTokens > 0 {
-		usage["cache_read_input_tokens"] = u.CacheInputTokens
-	}
-	return usage
+	return u.ToAnthropicUsageMap()
 }
 
 // ToOpenAIChatUsageMap converts canonical usage into OpenAI Chat Completions
@@ -180,21 +182,25 @@ func NewTokenUsage(inputTokens, outputTokens int) *TokenUsage {
 
 // NewTokenUsageWithCache creates a new TokenUsage with cache token count.
 func NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens int) *TokenUsage {
+	return NewTokenUsageWithCacheDetails(inputTokens, outputTokens, cacheTokens, 0)
+}
+
+// NewTokenUsageWithCacheDetails creates a TokenUsage with cache read/write detail counts.
+func NewTokenUsageWithCacheDetails(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int) *TokenUsage {
 	return &TokenUsage{
 		InputTokens:      inputTokens,
 		OutputTokens:     outputTokens,
-		CacheInputTokens: cacheTokens,
+		CacheInputTokens: cacheReadTokens,
+		CacheReadTokens:  cacheReadTokens,
+		CacheWriteTokens: cacheWriteTokens,
 	}
 }
 
 // NewTokenUsageFull creates a TokenUsage with cache and reasoning token counts.
 func NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens int) *TokenUsage {
-	return &TokenUsage{
-		InputTokens:      inputTokens,
-		OutputTokens:     outputTokens,
-		CacheInputTokens: cacheTokens,
-		ReasoningTokens:  reasoningTokens,
-	}
+	usage := NewTokenUsageWithCache(inputTokens, outputTokens, cacheTokens)
+	usage.ReasoningTokens = reasoningTokens
+	return usage
 }
 
 // ZeroTokenUsage returns a TokenUsage with zero values.

--- a/build/Taskfile.curl.yml
+++ b/build/Taskfile.curl.yml
@@ -152,7 +152,7 @@ tasks:
   anthropic-stream:
     cmds:
       - |
-        curl -X POST http://localhost:12580/tingly/openai/v1/messages \
+        curl -X POST http://localhost:12580/tingly/claude_code/v1/messages \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer {{.TINGLY_BOX_KEY}}" \
         -d '{
@@ -160,7 +160,7 @@ tasks:
         			"role": "user",
         			"content": "请帮我计算 3+5，并告诉我北京天气"
         		}],
-        		"model": "tingly-qwen",
+        		"model": "cc",
         		"stream": true,
         		"tools": [{
                   "name": "add_numbers",

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -93,12 +93,6 @@ func responsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
 	}
 }
 
-// toResponsesUsageWire converts normalized TokenUsage to the Responses API wire
-// usage struct. InputTokens on the wire = total (uncached + cached).
-func toResponsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
-	return responsesUsageWire(u)
-}
-
 // responsesConverterState and newResponsesWireResponseFromState are kept for
 // any callers outside this file that still use them.
 type responsesConverterState struct {
@@ -181,7 +175,7 @@ func sendCompletionEvent(c *gin.Context, state *responsesConverterState, flusher
 			Status:      "completed",
 			CompletedAt: state.createdAt,
 			Output:      output,
-			Usage:       toResponsesUsageWire(u),
+			Usage:       responsesUsageWire(u),
 		},
 	}
 	sendResponsesEvent(c, doneEvent, flusher)

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -78,9 +78,7 @@ func sendResponsesErrorEvent(c *gin.Context, message string, errorType string, _
 	OpenAIResponsesEvent(c, errorEvent.EventType(), errorEvent)
 }
 
-// toResponsesUsageWire converts normalized TokenUsage to the Responses API wire
-// usage struct. InputTokens on the wire = total (uncached + cached).
-func toResponsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
+func responsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
 	totalInput := int64(u.InputTokens + u.CacheInputTokens)
 	return &wire.ResponsesUsageWire{
 		InputTokens:  totalInput,
@@ -89,7 +87,16 @@ func toResponsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
 		InputTokensDetails: wire.ResponsesInputTokensDetailsWire{
 			CachedTokens: int64(u.CacheInputTokens),
 		},
+		OutputTokensDetails: wire.ResponsesOutputTokensDetailsWire{
+			ReasoningTokens: int64(u.ReasoningTokens),
+		},
 	}
+}
+
+// toResponsesUsageWire converts normalized TokenUsage to the Responses API wire
+// usage struct. InputTokens on the wire = total (uncached + cached).
+func toResponsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
+	return responsesUsageWire(u)
 }
 
 // responsesConverterState and newResponsesWireResponseFromState are kept for

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
@@ -342,7 +342,7 @@ func (c *anthropicBetaToResponsesConverter) emitCompletionEvents() {
 		CreatedAt:   c.createdAt,
 		CompletedAt: c.createdAt,
 		Output:      output,
-		Usage:       toResponsesUsageWire(u),
+		Usage:       responsesUsageWire(u),
 	}
 
 	if isIncomplete {

--- a/internal/protocol/stream/anthropic_helper.go
+++ b/internal/protocol/stream/anthropic_helper.go
@@ -378,8 +378,21 @@ func sendAnthropicV1ContentBlockStop(c *gin.Context, flusher http.Flusher) {
 	sendAnthropicStreamEvent(c, eventTypeContentBlockStop, event, flusher)
 }
 
-// sendAnthropicV1MessageStop sends a message_stop event.
-func sendAnthropicV1MessageStop(c *gin.Context, inputTokens, outputTokens int, flusher http.Flusher) {
+// sendAnthropicV1MessageStop sends a message_delta usage event followed by message_stop.
+func sendAnthropicV1MessageStop(c *gin.Context, usage *protocol.TokenUsage, flusher http.Flusher) {
+	if usage == nil {
+		usage = protocol.ZeroTokenUsage()
+	}
+	deltaEvent := map[string]interface{}{
+		"type": eventTypeMessageDelta,
+		"delta": map[string]interface{}{
+			"stop_reason":   anthropicStopReasonEndTurn,
+			"stop_sequence": nil,
+		},
+		"usage": usage.ToAnthropicMessageDeltaUsageMap(),
+	}
+	sendAnthropicStreamEvent(c, eventTypeMessageDelta, deltaEvent, flusher)
+
 	event := map[string]interface{}{
 		"type": eventTypeMessageStop,
 	}

--- a/internal/protocol/stream/google_to_any.go
+++ b/internal/protocol/stream/google_to_any.go
@@ -237,9 +237,7 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 	var (
 		textBlockIndex = -1
 		toolBlockIndex = -1
-		inputTokens    int64
-		outputTokens   int64
-		cacheTokens    int64
+		usage          = protocol.ZeroTokenUsage()
 	)
 
 	// Send message_start event first
@@ -270,7 +268,7 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 		select {
 		case <-c.Request.Context().Done():
 			logrus.WithContext(c.Request.Context()).Debug("Client disconnected, stopping Google to Anthropic stream")
-			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+			return usage, nil
 		default:
 		}
 
@@ -278,7 +276,7 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 			// Check if it was a client cancellation
 			if errors.Is(err, context.Canceled) {
 				logrus.WithContext(c.Request.Context()).Debug("Google stream canceled by client")
-				return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+				return usage, nil
 			}
 			logrus.WithContext(c.Request.Context()).Errorf("Google stream error: %v", err)
 			errorEvent := map[string]interface{}{
@@ -290,7 +288,7 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 				},
 			}
 			sendAnthropicStreamEvent(c, "error", errorEvent, flusher)
-			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
+			return usage, err
 		}
 
 		// Process candidates
@@ -369,9 +367,11 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 
 				// Collect usage info
 				if googleResp.UsageMetadata != nil {
-					inputTokens = int64(googleResp.UsageMetadata.PromptTokenCount)
-					outputTokens = int64(googleResp.UsageMetadata.CandidatesTokenCount)
-					cacheTokens = int64(googleResp.UsageMetadata.CachedContentTokenCount)
+					usage = protocol.NewTokenUsageWithCache(
+						int(googleResp.UsageMetadata.PromptTokenCount),
+						int(googleResp.UsageMetadata.CandidatesTokenCount),
+						int(googleResp.UsageMetadata.CachedContentTokenCount),
+					)
 				}
 
 				// Send message_delta with stop reason and usage
@@ -381,9 +381,7 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 						"stop_reason":   stopReason,
 						"stop_sequence": nil,
 					},
-					"usage": map[string]interface{}{
-						"output_tokens": outputTokens,
-					},
+					"usage": usage.ToAnthropicMessageDeltaUsageMap(),
 				}
 				sendAnthropicStreamEvent(c, "message_delta", messageDeltaEvent, flusher)
 
@@ -392,19 +390,21 @@ func HandleGoogleToAnthropicStreamResponse(c *gin.Context, stream iter.Seq2[*gen
 					"type": "message_stop",
 				}
 				sendAnthropicStreamEvent(c, "message_stop", messageStopEvent, flusher)
-				return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+				return usage, nil
 			}
 		}
 
 		// Track usage
 		if googleResp.UsageMetadata != nil {
-			inputTokens = int64(googleResp.UsageMetadata.PromptTokenCount)
-			outputTokens = int64(googleResp.UsageMetadata.CandidatesTokenCount)
-			cacheTokens = int64(googleResp.UsageMetadata.CachedContentTokenCount)
+			usage = protocol.NewTokenUsageWithCache(
+				int(googleResp.UsageMetadata.PromptTokenCount),
+				int(googleResp.UsageMetadata.CandidatesTokenCount),
+				int(googleResp.UsageMetadata.CachedContentTokenCount),
+			)
 		}
 	}
 
-	return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+	return usage, nil
 }
 
 // HandleGoogleToAnthropicBetaStreamResponse processes Google streaming events and converts them to Anthropic beta format.
@@ -443,9 +443,7 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 	var (
 		textBlockIndex = -1
 		toolBlockIndex = -1
-		inputTokens    int64
-		outputTokens   int64
-		cacheTokens    int64
+		usage          = protocol.ZeroTokenUsage()
 	)
 
 	// Send message_start event first
@@ -476,7 +474,7 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 		select {
 		case <-c.Request.Context().Done():
 			logrus.WithContext(c.Request.Context()).Debug("Client disconnected, stopping Google to Anthropic beta stream")
-			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+			return usage, nil
 		default:
 		}
 
@@ -484,7 +482,7 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 			// Check if it was a client cancellation
 			if errors.Is(err, context.Canceled) {
 				logrus.WithContext(c.Request.Context()).Debug("Google stream canceled by client")
-				return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+				return usage, nil
 			}
 			logrus.WithContext(c.Request.Context()).Errorf("Google stream error: %v", err)
 			errorEvent := map[string]interface{}{
@@ -496,7 +494,7 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 				},
 			}
 			sendAnthropicStreamEvent(c, "error", errorEvent, flusher)
-			return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), err
+			return usage, err
 		}
 
 		// Process candidates
@@ -575,9 +573,11 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 
 				// Collect usage info
 				if googleResp.UsageMetadata != nil {
-					inputTokens = int64(googleResp.UsageMetadata.PromptTokenCount)
-					outputTokens = int64(googleResp.UsageMetadata.CandidatesTokenCount)
-					cacheTokens = int64(googleResp.UsageMetadata.CachedContentTokenCount)
+					usage = protocol.NewTokenUsageWithCache(
+						int(googleResp.UsageMetadata.PromptTokenCount),
+						int(googleResp.UsageMetadata.CandidatesTokenCount),
+						int(googleResp.UsageMetadata.CachedContentTokenCount),
+					)
 				}
 
 				// Send message_delta with stop reason and usage
@@ -587,9 +587,7 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 						"stop_reason":   string(stopReason),
 						"stop_sequence": "",
 					},
-					"usage": map[string]interface{}{
-						"output_tokens": outputTokens,
-					},
+					"usage": usage.ToAnthropicMessageDeltaUsageMap(),
 				}
 				sendAnthropicStreamEvent(c, eventTypeMessageDelta, messageDeltaEvent, flusher)
 
@@ -604,9 +602,7 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 						"model":         responseModel,
 						"stop_reason":   string(stopReason),
 						"stop_sequence": "",
-						"usage": map[string]interface{}{
-							"output_tokens": outputTokens,
-						},
+						"usage":         usage.ToAnthropicMessageDeltaUsageMap(),
 					},
 				}
 				sendAnthropicStreamEvent(c, eventTypeMessageStop, messageStopEvent, flusher)
@@ -614,17 +610,19 @@ func HandleGoogleToAnthropicBetaStreamResponse(c *gin.Context, stream iter.Seq2[
 				// Send final simple data with type (without event, aka empty)
 				c.SSEvent("", map[string]interface{}{"type": eventTypeMessageStop})
 				flusher.Flush()
-				return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+				return usage, nil
 			}
 		}
 
 		// Track usage
 		if googleResp.UsageMetadata != nil {
-			inputTokens = int64(googleResp.UsageMetadata.PromptTokenCount)
-			outputTokens = int64(googleResp.UsageMetadata.CandidatesTokenCount)
-			cacheTokens = int64(googleResp.UsageMetadata.CachedContentTokenCount)
+			usage = protocol.NewTokenUsageWithCache(
+				int(googleResp.UsageMetadata.PromptTokenCount),
+				int(googleResp.UsageMetadata.CandidatesTokenCount),
+				int(googleResp.UsageMetadata.CachedContentTokenCount),
+			)
 		}
 	}
 
-	return protocol.NewTokenUsageWithCache(int(inputTokens), int(outputTokens), int(cacheTokens)), nil
+	return usage, nil
 }

--- a/internal/protocol/stream/openai_chat_to_responses_converter.go
+++ b/internal/protocol/stream/openai_chat_to_responses_converter.go
@@ -10,6 +10,7 @@ import (
 	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	protocolusage "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
@@ -29,10 +30,7 @@ type chatToResponsesConverter struct {
 	pendingToolCalls  map[int]*pendingToolCallResponse
 	accumulatedText   strings.Builder
 	promptTokensTotal int64
-	inputTokens       int64
-	outputTokens      int64
-	cacheTokens       int64
-	reasoningTokens   int64
+	usage             *protocol.TokenUsage
 	hasSentCreated    bool
 	hasUsage          bool
 	completedSent     bool
@@ -60,6 +58,7 @@ func NewChatToResponsesConverter(stream *openaistream.Stream[openai.ChatCompleti
 		responseID:       fmt.Sprintf("resp_%d", time.Now().Unix()),
 		createdAt:        time.Now().Unix(),
 		textItemID:       fmt.Sprintf("msg_%d", time.Now().UnixNano()),
+		usage:            protocol.ZeroTokenUsage(),
 		pendingToolCalls: make(map[int]*pendingToolCallResponse),
 	}
 }
@@ -102,7 +101,7 @@ func (c *chatToResponsesConverter) Next() (interface{}, bool, error) {
 }
 
 func (c *chatToResponsesConverter) Usage() *protocol.TokenUsage {
-	return protocol.NewTokenUsageFull(int(c.inputTokens), int(c.outputTokens), int(c.cacheTokens), int(c.reasoningTokens))
+	return c.usage
 }
 
 // processChunk handles a single upstream ChatCompletionChunk and appends
@@ -119,24 +118,12 @@ func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChun
 	}
 
 	// Track usage
-	if chunk.Usage.PromptTokens != 0 {
-		c.promptTokensTotal = int64(chunk.Usage.PromptTokens)
+	if chunk.Usage.PromptTokens != 0 || chunk.Usage.CompletionTokens != 0 ||
+		chunk.Usage.PromptTokensDetails.CachedTokens != 0 ||
+		chunk.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
+		c.usage = protocolusage.FromOpenAIChatCompletion(chunk.Usage)
+		c.promptTokensTotal = int64(c.usage.InputTokens + c.usage.CacheInputTokens)
 		c.hasUsage = true
-	}
-	if chunk.Usage.CompletionTokens != 0 {
-		c.outputTokens = int64(chunk.Usage.CompletionTokens)
-		c.hasUsage = true
-	}
-	if chunk.Usage.PromptTokensDetails.CachedTokens != 0 {
-		c.cacheTokens = int64(chunk.Usage.PromptTokensDetails.CachedTokens)
-		c.hasUsage = true
-	}
-	if chunk.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
-		c.reasoningTokens = int64(chunk.Usage.CompletionTokensDetails.ReasoningTokens)
-		c.hasUsage = true
-	}
-	if c.promptTokensTotal > 0 {
-		c.inputTokens = c.promptTokensTotal - c.cacheTokens
 	}
 
 	if len(chunk.Choices) == 0 {
@@ -216,11 +203,12 @@ func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChun
 	if choice.FinishReason != "" {
 		c.finishReason = string(choice.FinishReason)
 
-		if !c.hasUsage && c.outputTokens == 0 {
-			c.outputTokens = int64(c.accumulatedText.Len() / 4)
+		if !c.hasUsage && c.usage.OutputTokens == 0 {
+			outputTokens := int64(c.accumulatedText.Len() / 4)
 			for _, ptc := range c.pendingToolCalls {
-				c.outputTokens += int64(ptc.arguments.Len() / 4)
+				outputTokens += int64(ptc.arguments.Len() / 4)
 			}
+			c.usage = protocol.NewTokenUsageFull(c.usage.InputTokens, int(outputTokens), c.usage.CacheInputTokens, c.usage.ReasoningTokens)
 		}
 
 		c.emitCompletionEvents()
@@ -374,18 +362,8 @@ func (c *chatToResponsesConverter) wireResponse(status string, output []wire.Res
 		CreatedAt: c.createdAt,
 		Status:    status,
 		Output:    output,
-		Usage: &wire.ResponsesUsageWire{
-			InputTokens:  c.inputTokens,
-			OutputTokens: c.outputTokens,
-			TotalTokens:  c.inputTokens + c.outputTokens,
-			InputTokensDetails: wire.ResponsesInputTokensDetailsWire{
-				CachedTokens: c.cacheTokens,
-			},
-			OutputTokensDetails: wire.ResponsesOutputTokensDetailsWire{
-				ReasoningTokens: c.reasoningTokens,
-			},
-		},
-		Model: c.responseModel,
+		Usage:     responsesUsageWire(c.Usage()),
+		Model:     c.responseModel,
 	}
 }
 

--- a/internal/protocol/stream/openai_chat_to_responses_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_test.go
@@ -246,8 +246,7 @@ func TestChatToResponsesConverter_ToolCall(t *testing.T) {
 func TestChatToResponsesConverter_CompletedEvent(t *testing.T) {
 	conv := NewChatToResponsesConverter(nil, "gpt-4o-mini")
 	conv.hasSentCreated = true
-	conv.inputTokens = 10
-	conv.outputTokens = 20
+	conv.usage = protocol.NewTokenUsage(10, 20)
 	conv.hasUsage = true
 
 	conv.processChunk(&openai.ChatCompletionChunk{
@@ -274,10 +273,7 @@ func TestChatToResponsesConverter_CompletedEvent(t *testing.T) {
 func TestChatToResponsesConverter_WithReasoningTokens(t *testing.T) {
 	conv := NewChatToResponsesConverter(nil, "o3-mini")
 	conv.hasSentCreated = true
-	conv.inputTokens = 50
-	conv.outputTokens = 30
-	conv.cacheTokens = 5
-	conv.reasoningTokens = 12
+	conv.usage = protocol.NewTokenUsageFull(45, 30, 5, 12)
 	conv.hasUsage = true
 
 	conv.processChunk(&openai.ChatCompletionChunk{

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tidwall/sjson"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
+	protocolusage "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // ===================================================================
@@ -39,7 +40,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
 
-	var promptTokensTotal, inputTokens, outputTokens, cacheTokens, reasoningTokens int
+	usage := protocol.ZeroTokenUsage()
 	var hasUsage bool
 	var contentBuilder strings.Builder
 	var firstChunkID string
@@ -77,23 +78,11 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 				firstChunkID = chunk.ID
 			}
 
-			// Accumulate usage from chunks (if present)
-			if chunk.Usage.PromptTokens != 0 {
-				promptTokensTotal = int(chunk.Usage.PromptTokens)
-				hasUsage = true
-			}
-			if chunk.Usage.CompletionTokens != 0 {
-				outputTokens = int(chunk.Usage.CompletionTokens)
-				hasUsage = true
-			}
-			// Track cache tokens from prompt tokens details if available
-			if chunk.Usage.PromptTokensDetails.CachedTokens != 0 {
-				cacheTokens = int(chunk.Usage.PromptTokensDetails.CachedTokens)
-				hasUsage = true
-			}
-			// Track reasoning tokens from completion tokens details if available
-			if chunk.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
-				reasoningTokens = int(chunk.Usage.CompletionTokensDetails.ReasoningTokens)
+			// Accumulate usage from chunks (if present).
+			if chunk.Usage.PromptTokens != 0 || chunk.Usage.CompletionTokens != 0 ||
+				chunk.Usage.PromptTokensDetails.CachedTokens != 0 ||
+				chunk.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
+				usage = protocolusage.FromOpenAIChatCompletion(chunk.Usage)
 				hasUsage = true
 			}
 
@@ -246,16 +235,9 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 		},
 	)
 
-	// Normalize: OpenAI prompt_tokens = total (cached + uncached); subtract cache
-	// so inputTokens represents uncached-only, matching Anthropic semantics.
-	if promptTokensTotal > 0 {
-		inputTokens = promptTokensTotal - cacheTokens
-	}
-
 	if err != nil && !errors.Is(err, context.Canceled) {
 		if !hasUsage {
-			inputTokens = hc.EstimatedInputTokens
-			outputTokens = token.EstimateOutputTokens(contentBuilder.String())
+			usage = protocol.NewTokenUsage(hc.EstimatedInputTokens, token.EstimateOutputTokens(contentBuilder.String()))
 		}
 
 		// Stream failed before any content reached the client: surface a
@@ -263,7 +245,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 		// instead of a 200 SSE error event.
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
-			return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), err
+			return usage, err
 		}
 
 		errorChunk := map[string]interface{}{
@@ -277,12 +259,11 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 		errorJSON, _ := json.Marshal(errorChunk)
 		c.SSEvent("", string(errorJSON))
 		flusher.Flush()
-		return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), err
+		return usage, err
 	}
 
 	if !hasUsage {
-		inputTokens = hc.EstimatedInputTokens
-		outputTokens = token.EstimateOutputTokens(contentBuilder.String())
+		usage = protocol.NewTokenUsage(hc.EstimatedInputTokens, token.EstimateOutputTokens(contentBuilder.String()))
 
 		// Use the first chunk ID, or generate one if not available
 		chunkID := firstChunkID
@@ -291,7 +272,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 		}
 
 		// Send estimated usage as final chunk (only if not disabled and we have actual usage)
-		if !hc.DisableStreamUsage && (inputTokens > 0 || outputTokens > 0) {
+		if !hc.DisableStreamUsage && usage.HasUsage() {
 			usageChunk := map[string]interface{}{
 				"id":      chunkID,
 				"object":  "chat.completion.chunk",
@@ -304,11 +285,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 						"finish_reason": nil,
 					},
 				},
-				"usage": map[string]interface{}{
-					"prompt_tokens":     inputTokens,
-					"completion_tokens": outputTokens,
-					"total_tokens":      inputTokens + outputTokens,
-				},
+				"usage": usage.ToOpenAIChatUsageMap(),
 			}
 
 			usageChunkJSON, err := json.Marshal(usageChunk)
@@ -324,7 +301,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 	c.SSEvent("", " [DONE]")
 	flusher.Flush()
 
-	return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), nil
+	return usage, nil
 }
 
 // HandleOpenAIResponsesStream handles OpenAI Responses API streaming response.
@@ -340,8 +317,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 	c.Header("Access-Control-Allow-Origin", "*")
 	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
-	var promptTokensTotal, inputTokens, outputTokens, cacheTokens, reasoningTokens int64
-	var hasUsage bool
+	usage := protocol.ZeroTokenUsage()
 
 	protocol.RunLoop(c, func(w io.Writer) bool {
 		select {
@@ -364,9 +340,12 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 
 		// Accumulate usage from the raw JSON (SDK struct fields may be zero for
 		// providers that use custom serialisation or in unit-test fake decoders).
+		promptTokensTotal := int64(0)
+		outputTokens := int64(0)
+		cacheTokens := int64(0)
+		reasoningTokens := int64(0)
 		if it := gjson.Get(eventRaw, "response.usage.input_tokens"); it.Exists() && it.Int() > 0 {
 			promptTokensTotal = it.Int()
-			hasUsage = true
 		}
 		if ot := gjson.Get(eventRaw, "response.usage.output_tokens"); ot.Exists() && ot.Int() > 0 {
 			outputTokens = ot.Int()
@@ -403,6 +382,10 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 			}
 		}
 
+		if promptTokensTotal > 0 || outputTokens > 0 || cacheTokens > 0 || reasoningTokens > 0 {
+			usage = protocol.NewTokenUsageFull(int(promptTokensTotal-cacheTokens), int(outputTokens), int(cacheTokens), int(reasoningTokens))
+		}
+
 		if len(eventRaw) > 0 {
 			if model := gjson.Get(eventRaw, "response.model"); model.Exists() && model.String() != "" {
 				if modified, err := sjson.Set(eventRaw, "response.model", responseModel); err == nil {
@@ -415,15 +398,10 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 		return true
 	})
 
-	// Normalize: OpenAI input_tokens = total; subtract cache for uncached-only semantics.
-	if promptTokensTotal > 0 {
-		inputTokens = promptTokensTotal - cacheTokens
-	}
-
 	if err := stream.Err(); err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.WithContext(c.Request.Context()).Debug("Responses stream canceled by client")
-			return protocol.NewTokenUsageFull(int(inputTokens), int(outputTokens), int(cacheTokens), int(reasoningTokens)), nil
+			return usage, nil
 		}
 
 		logrus.WithContext(c.Request.Context()).Errorf("Responses stream error: %v", err)
@@ -432,7 +410,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 		// instead of a 200 SSE error event.
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
-			return protocol.NewTokenUsageFull(int(inputTokens), int(outputTokens), int(cacheTokens), int(reasoningTokens)), err
+			return usage, err
 		}
 		errorChunk := map[string]interface{}{
 			"error": map[string]interface{}{
@@ -442,11 +420,10 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 			},
 		}
 		OpenAIResponsesEvent(c, "error", errorChunk)
-		return protocol.NewTokenUsageFull(int(inputTokens), int(outputTokens), int(cacheTokens), int(reasoningTokens)), err
+		return usage, err
 	}
 
-	_ = hasUsage
-	return protocol.NewTokenUsageFull(int(inputTokens), int(outputTokens), int(cacheTokens), int(reasoningTokens)), nil
+	return usage, nil
 }
 
 // ===================================================================
@@ -497,7 +474,7 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream ResponsesStre
 		return protocol.ZeroTokenUsage(), fmt.Errorf("streaming not supported by this connection")
 	}
 
-	var promptTokensTotal, inputTokens, outputTokens, cacheTokens, reasoningTokens int
+	usage := protocol.ZeroTokenUsage()
 
 	// Generate message ID for Anthropic format
 	messageID := fmt.Sprintf("msg_%d", time.Now().Unix())
@@ -515,7 +492,7 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream ResponsesStre
 		select {
 		case <-c.Request.Context().Done():
 			logrus.WithContext(c.Request.Context()).Debug("[ChatGPT] Client disconnected, stopping stream")
-			return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), c.Request.Context().Err()
+			return usage, c.Request.Context().Err()
 		default:
 		}
 
@@ -538,47 +515,35 @@ func HandleOpenAIResponsesStreamToAnthropic(c *gin.Context, stream ResponsesStre
 			}
 		}
 
-		// Extract usage from the event
-		if evt.Response.Usage.InputTokens > 0 {
-			promptTokensTotal = int(evt.Response.Usage.InputTokens)
+		// Extract usage from the event.
+		if evt.Response.Usage.InputTokens > 0 || evt.Response.Usage.OutputTokens > 0 ||
+			evt.Response.Usage.InputTokensDetails.CachedTokens > 0 ||
+			evt.Response.Usage.OutputTokensDetails.ReasoningTokens > 0 {
+			usage = protocolusage.FromOpenAIResponses(evt.Response.Usage)
 		}
-		if evt.Response.Usage.OutputTokens > 0 {
-			outputTokens = int(evt.Response.Usage.OutputTokens)
-		}
-		if evt.Response.Usage.InputTokensDetails.CachedTokens > 0 {
-			cacheTokens = int(evt.Response.Usage.InputTokensDetails.CachedTokens)
-		}
-		if evt.Response.Usage.OutputTokensDetails.ReasoningTokens > 0 {
-			reasoningTokens = int(evt.Response.Usage.OutputTokensDetails.ReasoningTokens)
-		}
-	}
-
-	// Normalize: OpenAI input_tokens = total; subtract cache for uncached-only semantics.
-	if promptTokensTotal > 0 {
-		inputTokens = promptTokensTotal - cacheTokens
 	}
 
 	// Check for stream errors
 	if err := stream.Err(); err != nil {
 		if errors.Is(err, context.Canceled) || protocol.IsContextCanceled(err) {
 			logrus.WithContext(c.Request.Context()).Debug("[ChatGPT] Stream canceled by client")
-			return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), nil
+			return usage, nil
 		}
 		// Stream failed before any content reached the client: surface a
 		// retryable 5xx so mid-request failover can try the next tier.
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
 		}
-		return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), fmt.Errorf("stream error: %w", err)
+		return usage, fmt.Errorf("stream error: %w", err)
 	}
 
-	logrus.WithContext(c.Request.Context()).Infof("[ChatGPT] Finished reading SSE stream: %d chunks, tokens: %d in, %d out", chunkCount, inputTokens, outputTokens)
+	logrus.WithContext(c.Request.Context()).Infof("[ChatGPT] Finished reading SSE stream: %d chunks, tokens: %d in, %d out", chunkCount, usage.InputTokens, usage.OutputTokens)
 
 	// Send content_block_stop event
 	sendAnthropicV1ContentBlockStop(c, flusher)
 
 	// Send message_stop event with usage
-	sendAnthropicV1MessageStop(c, inputTokens, outputTokens, flusher)
+	sendAnthropicV1MessageStop(c, usage, flusher)
 
-	return protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens), nil
+	return usage, nil
 }

--- a/internal/protocol/stream/openai_responses_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_converter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // responsesToAnthropicToolCall tracks a Responses API tool call being assembled from stream events.
@@ -139,6 +140,7 @@ func (r *responsesToAnthropicConverter) emitMessageStart() {
 			"model":         r.responseModel,
 			"stop_reason":   nil,
 			"stop_sequence": nil,
+			// MENTION: placeholder only
 			"usage": map[string]interface{}{
 				"input_tokens":  0,
 				"output_tokens": 0,
@@ -218,12 +220,7 @@ func (r *responsesToAnthropicConverter) emitMessageDelta(stopReason string) {
 	for k, v := range r.state.deltaExtras {
 		deltaMap[k] = v
 	}
-	usageMap := map[string]interface{}{
-		"output_tokens": r.state.outputTokens,
-	}
-	if r.state.cacheTokens > 0 {
-		usageMap["cache_read_input_tokens"] = r.state.cacheTokens
-	}
+	usageMap := r.Usage().ToAnthropicMessageDeltaUsageMap()
 	r.emitAnthropic(eventTypeMessageDelta, map[string]interface{}{
 		"type":  eventTypeMessageDelta,
 		"delta": deltaMap,
@@ -591,13 +588,9 @@ func (r *responsesToAnthropicConverter) processEvent(currentEvent responses.Resp
 // from the streamed content (tool_use vs end_turn); otherwise the override is
 // used (e.g. max_tokens for an incomplete response).
 func (r *responsesToAnthropicConverter) finalize(resp *responses.Response, stopReasonOverride string) {
-	r.state.cacheTokens = resp.Usage.InputTokensDetails.CachedTokens
-	r.state.inputTokens = resp.Usage.InputTokens - r.state.cacheTokens
-	r.state.outputTokens = resp.Usage.OutputTokens
-	r.state.reasoningTokens = resp.Usage.OutputTokensDetails.ReasoningTokens
-	r.usage = protocol.NewTokenUsageFull(int(r.state.inputTokens), int(r.state.outputTokens), int(r.state.cacheTokens), int(r.state.reasoningTokens))
+	r.usage = usage.FromOpenAIResponses(resp.Usage)
 
-	logrus.WithContext(r.ctx).Debugf("[ResponsesAPI] Finalize: input_tokens=%d, output_tokens=%d", r.state.inputTokens, r.state.outputTokens)
+	logrus.WithContext(r.ctx).Debugf("[ResponsesAPI] Finalize: input_tokens=%d, output_tokens=%d", r.usage.InputTokens, r.usage.OutputTokens)
 
 	// Handle non-streamed tool calls from the final output array.
 	for _, outputItem := range resp.Output {

--- a/internal/protocol/stream/openai_responses_to_chat_converter.go
+++ b/internal/protocol/stream/openai_responses_to_chat_converter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	protocolusage "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
@@ -22,10 +23,7 @@ type responsesToChatConverter struct {
 	chatID          string
 	createdAt       int64
 	accumulated     strings.Builder
-	inputTokens     int64
-	outputTokens    int64
-	cacheTokens     int64
-	reasoningTokens int64
+	usage           *protocol.TokenUsage
 	totalTokens     int64
 	hasSentCreated  bool
 	hasToolCalls    bool
@@ -53,6 +51,7 @@ func NewResponsesToChatConverter(stream ResponsesStreamIter, responseModel strin
 		disableUsage:    disableUsage,
 		chatID:          fmt.Sprintf("chatcmpl-%d", time.Now().Unix()),
 		createdAt:       time.Now().Unix(),
+		usage:           protocol.ZeroTokenUsage(),
 		toolCallIndexes: make(map[string]int),
 		toolCalls:       make(map[int]*responsesToChatToolCall),
 	}
@@ -95,7 +94,7 @@ func (c *responsesToChatConverter) Next() (interface{}, bool, error) {
 }
 
 func (c *responsesToChatConverter) Usage() *protocol.TokenUsage {
-	return protocol.NewTokenUsageFull(int(c.inputTokens), int(c.outputTokens), int(c.cacheTokens), int(c.reasoningTokens))
+	return c.usage
 }
 
 // processEvent handles a single upstream event and appends resulting chunks to c.pending.
@@ -187,14 +186,11 @@ func (c *responsesToChatConverter) processEvent(evt *responses.ResponseStreamEve
 		// assistant output and final usage. Treat it identically to
 		// response.completed so the terminal chunk preserves output + usage
 		// rather than falling through to the post-loop usage=0 fallback.
-		c.cacheTokens = evt.Response.Usage.InputTokensDetails.CachedTokens
-		c.inputTokens = evt.Response.Usage.InputTokens - c.cacheTokens
-		c.outputTokens = evt.Response.Usage.OutputTokens
-		c.reasoningTokens = evt.Response.Usage.OutputTokensDetails.ReasoningTokens
+		c.usage = protocolusage.FromOpenAIResponses(evt.Response.Usage)
 		if evt.Response.Usage.TotalTokens != 0 {
 			c.totalTokens = evt.Response.Usage.TotalTokens
 		} else {
-			c.totalTokens = c.inputTokens + c.outputTokens
+			c.totalTokens = int64(c.usage.InputTokens + c.usage.CacheInputTokens + c.usage.OutputTokens)
 		}
 		c.emitCompletedOutput(evt.Response.Output)
 		finishReason := responsesToChatFinishReason(&evt.Response, c.hasToolCalls)
@@ -314,21 +310,22 @@ func (c *responsesToChatConverter) toolCallDeltaChunk(index int, delta string) w
 func (c *responsesToChatConverter) finalChunk(finishReason string) wire.ChatStreamChunk {
 	chunk := c.newChunk(wire.ChatStreamDelta{}, &finishReason)
 	if !c.disableUsage {
-		totalInput := c.inputTokens + c.cacheTokens
+		u := c.Usage()
+		totalInput := int64(u.InputTokens + u.CacheInputTokens)
 		total := c.totalTokens
 		if total == 0 {
-			total = totalInput + c.outputTokens
+			total = totalInput + int64(u.OutputTokens)
 		}
 		usage := &wire.ChatStreamUsage{
 			PromptTokens:     totalInput,
-			CompletionTokens: c.outputTokens,
+			CompletionTokens: int64(u.OutputTokens),
 			TotalTokens:      total,
 		}
-		if c.cacheTokens != 0 {
-			usage.PromptTokensDetails = &wire.ChatStreamPromptTokenDetails{CachedTokens: c.cacheTokens}
+		if u.CacheInputTokens != 0 {
+			usage.PromptTokensDetails = &wire.ChatStreamPromptTokenDetails{CachedTokens: int64(u.CacheInputTokens)}
 		}
-		if c.reasoningTokens != 0 {
-			usage.CompletionTokensDetails = &wire.ChatStreamOutputTokenDetails{ReasoningTokens: c.reasoningTokens}
+		if u.ReasoningTokens != 0 {
+			usage.CompletionTokensDetails = &wire.ChatStreamOutputTokenDetails{ReasoningTokens: int64(u.ReasoningTokens)}
 		}
 		chunk.Usage = usage
 	}

--- a/internal/protocol/stream/openai_responses_type_test.go
+++ b/internal/protocol/stream/openai_responses_type_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
@@ -14,10 +15,7 @@ func TestResponsesWireResponseJSONIsMinimalComparedToSDKResponse(t *testing.T) {
 	conv := NewChatToResponsesConverter(nil, "")
 	conv.responseID = "resp_test"
 	conv.createdAt = 123
-	conv.inputTokens = 10
-	conv.outputTokens = 5
-	conv.cacheTokens = 3
-	conv.reasoningTokens = 2
+	conv.usage = protocol.NewTokenUsageFull(10, 5, 3, 2)
 
 	wireEvent := wire.ResponsesCreatedEvent{
 		Type:           "response.created",

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	protocolusage "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // handleResponsesToAnthropicStream is the shared implementation for both v1 and beta
@@ -103,6 +104,16 @@ type OpenAIToAnthropicMCPHooks struct {
 }
 
 var ErrMCPStreamContinue = errors.New("mcp stream should continue")
+
+func applyTokenUsageToStreamState(state *streamState, usage *protocol.TokenUsage) {
+	if state == nil || usage == nil {
+		return
+	}
+	state.inputTokens = int64(usage.InputTokens)
+	state.outputTokens = int64(usage.OutputTokens)
+	state.cacheTokens = int64(usage.CacheInputTokens)
+	state.reasoningTokens = int64(usage.ReasoningTokens)
+}
 
 // HandleOpenAIToAnthropicStreamResponse processes OpenAI streaming events and converts them to Anthropic format.
 // Returns UsageStat containing token usage information for tracking.
@@ -249,6 +260,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 
 	// Initialize streaming state
 	state := newStreamState()
+	usage := protocol.ZeroTokenUsage()
 
 	// Track tool calls by item ID for Responses API
 	type pendingToolCall struct {
@@ -519,10 +531,8 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 
 		case "response.completed":
 			completed := currentEvent.AsResponseCompleted()
-			state.cacheTokens = completed.Response.Usage.InputTokensDetails.CachedTokens
-			state.inputTokens = completed.Response.Usage.InputTokens - state.cacheTokens
-			state.outputTokens = completed.Response.Usage.OutputTokens
-			state.reasoningTokens = completed.Response.Usage.OutputTokensDetails.ReasoningTokens
+			usage = protocolusage.FromOpenAIResponses(completed.Response.Usage)
+			applyTokenUsageToStreamState(state, usage)
 
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Response completed: input_tokens=%d, output_tokens=%d", state.inputTokens, state.outputTokens)
 
@@ -596,7 +606,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 			senders.SendMessageStop(messageID, responseModel, state, stopReason, flusher)
 
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Sent message_stop event with stop_reason=%s, finishing stream", stopReason)
-			return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
+			return usage, nil
 
 		case "response.output_text.annotation.added":
 			// Per-annotation event; pass through silently.
@@ -707,10 +717,8 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 			// content_filter), not a transport error. Preserve the partial output
 			// and map to Anthropic's max_tokens stop reason.
 			incomplete := currentEvent.AsResponseIncomplete()
-			state.cacheTokens = incomplete.Response.Usage.InputTokensDetails.CachedTokens
-			state.inputTokens = incomplete.Response.Usage.InputTokens - state.cacheTokens
-			state.outputTokens = incomplete.Response.Usage.OutputTokens
-			state.reasoningTokens = incomplete.Response.Usage.OutputTokensDetails.ReasoningTokens
+			usage = protocolusage.FromOpenAIResponses(incomplete.Response.Usage)
+			applyTokenUsageToStreamState(state, usage)
 
 			senders.SendStopEvents(state, flusher)
 
@@ -723,7 +731,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 			senders.SendMessageStop(messageID, responseModel, state, stopReason, flusher)
 
 			logrus.WithContext(c.Request.Context()).Debugf("[ResponsesAPI] Incomplete response: reason=%s, stop_reason=%s", incomplete.Response.IncompleteDetails.Reason, stopReason)
-			return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
+			return usage, nil
 
 		case "error", "response.failed":
 			logrus.WithContext(c.Request.Context()).Errorf("Responses API error event: %v", currentEvent)
@@ -735,7 +743,7 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 				},
 			}
 			senders.SendErrorEvent(errorEvent, flusher)
-			return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), fmt.Errorf("Responses API error: %v", currentEvent)
+			return usage, fmt.Errorf("Responses API error: %v", currentEvent)
 
 		default:
 			logrus.WithContext(c.Request.Context()).Debugf("Unhandled Responses API event type: %s", currentEvent.Type)
@@ -753,10 +761,10 @@ func handlerResponsesToAnthropicStream(c *gin.Context, stream ResponsesStreamIte
 			},
 		}
 		senders.SendErrorEvent(errorEvent, flusher)
-		return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), err
+		return usage, err
 	}
 
-	return protocol.NewTokenUsageFull(int(state.inputTokens), int(state.outputTokens), int(state.cacheTokens), int(state.reasoningTokens)), nil
+	return usage, nil
 }
 
 func HandleResponsesToAnthropicV1Assembly(c *gin.Context, stream ResponsesStreamIter, responseModel string) (*protocol.TokenUsage, error) {

--- a/internal/protocol/stream/openai_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_to_anthropic_converter.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
+	protocolusage "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 )
 
 // anthropicStreamEvent wraps a single Anthropic SSE event for the converter pipeline.
@@ -276,16 +277,25 @@ func (c *openAIToAnthropicConverter) processChunk(chunk *openai.ChatCompletionCh
 }
 
 func (c *openAIToAnthropicConverter) consumeTokenCounter(chunk *openai.ChatCompletionChunk) {
-	if c.tokenCounter == nil {
+	if c.tokenCounter != nil {
+		_, _, _ = c.tokenCounter.ConsumeOpenAIChunk(chunk)
+		inputTokens, outputTokens := c.tokenCounter.GetCounts()
+		if inputTokens > 0 {
+			c.state.inputTokens = int64(inputTokens)
+		}
+		if outputTokens > 0 {
+			c.state.outputTokens = int64(outputTokens)
+		}
 		return
 	}
-	_, _, _ = c.tokenCounter.ConsumeOpenAIChunk(chunk)
-	inputTokens, outputTokens := c.tokenCounter.GetCounts()
-	if inputTokens > 0 {
-		c.state.inputTokens = int64(inputTokens)
-	}
-	if outputTokens > 0 {
-		c.state.outputTokens = int64(outputTokens)
+
+	// Fallback: extract usage directly from the chunk when token counter is
+	// unavailable (e.g. constructor failure).  This mirrors the approach used
+	// in openai_passthrough.go for the terminal usage-only chunk.
+	if chunk.Usage.PromptTokens != 0 || chunk.Usage.CompletionTokens != 0 ||
+		chunk.Usage.PromptTokensDetails.CachedTokens != 0 ||
+		chunk.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
+		c.usage = protocolusage.FromOpenAIChatCompletion(chunk.Usage)
 	}
 }
 

--- a/internal/protocol/stream/openai_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_to_anthropic_converter.go
@@ -35,6 +35,7 @@ type openAIToAnthropicConverter struct {
 	messageStarted       bool
 	tokenCounter         *token.StreamTokenCounter
 	state                *streamState
+	usage                *protocol.TokenUsage
 	pendingFinishReason  string
 	finishSeen           bool
 	hookErr              error
@@ -57,6 +58,7 @@ func newOpenAIToAnthropicConverter(
 		mapFinishReason: mapFinishReason,
 		messageID:       fmt.Sprintf("msg_%d", time.Now().Unix()),
 		state:           newStreamState(),
+		usage:           protocol.ZeroTokenUsage(),
 	}
 	// Initialize token counter; continue without it on error
 	if tc, err := token.NewStreamTokenCounter(); err == nil {
@@ -116,12 +118,7 @@ func (c *openAIToAnthropicConverter) Next() (interface{}, bool, error) {
 }
 
 func (c *openAIToAnthropicConverter) Usage() *protocol.TokenUsage {
-	return protocol.NewTokenUsageFull(
-		int(c.state.inputTokens),
-		int(c.state.outputTokens),
-		int(c.state.cacheTokens),
-		int(c.state.reasoningTokens),
-	)
+	return c.usage
 }
 
 func (c *openAIToAnthropicConverter) HookErr() error {
@@ -295,19 +292,13 @@ func (c *openAIToAnthropicConverter) consumeTokenCounter(chunk *openai.ChatCompl
 func (c *openAIToAnthropicConverter) emitTerminalEvents() {
 	if c.tokenCounter != nil {
 		inputTokens, outputTokens := c.tokenCounter.GetCounts()
-		c.state.inputTokens = int64(inputTokens)
-		c.state.outputTokens = int64(outputTokens)
 		cacheTokens, reasoningTokens := c.tokenCounter.GetUpstreamDetails()
-		if cacheTokens > 0 {
-			c.state.cacheTokens = int64(cacheTokens)
-		}
-		if reasoningTokens > 0 {
-			c.state.reasoningTokens = int64(reasoningTokens)
-		}
+		c.usage = protocol.NewTokenUsageFull(inputTokens, outputTokens, cacheTokens, reasoningTokens)
 	}
+	usage := c.Usage()
 	logrus.Debugf("OpenAI->Anthropic stream usage: model=%s in=%d out=%d cache=%d reasoning=%d stop=%s",
-		c.responseModel, c.state.inputTokens, c.state.outputTokens,
-		c.state.cacheTokens, c.state.reasoningTokens, c.pendingFinishReason)
+		c.responseModel, usage.InputTokens, usage.OutputTokens,
+		usage.CacheInputTokens, usage.ReasoningTokens, c.pendingFinishReason)
 	c.emitEnsureMessageStart()
 	c.emitStopEvents()
 	stopReason := c.mapFinishReason(c.pendingFinishReason)
@@ -452,12 +443,7 @@ func (c *openAIToAnthropicConverter) emitMessageDelta(stopReason string) {
 	for k, v := range c.state.deltaExtras {
 		deltaMap[k] = v
 	}
-	usageMap := map[string]interface{}{
-		"output_tokens": c.state.outputTokens,
-	}
-	if c.state.cacheTokens > 0 {
-		usageMap["cache_read_input_tokens"] = c.state.cacheTokens
-	}
+	usageMap := c.Usage().ToAnthropicMessageDeltaUsageMap()
 	c.emitAnthropic(eventTypeMessageDelta, map[string]interface{}{
 		"type":  eventTypeMessageDelta,
 		"delta": deltaMap,

--- a/internal/protocol/usage/accumulator.go
+++ b/internal/protocol/usage/accumulator.go
@@ -18,15 +18,13 @@ import (
 // (BetaRawMessageStreamEventUnion) streams are supported via Consume and
 // ConsumeBeta respectively.
 type AnthropicAccumulator struct {
-	inputTokens  int
-	outputTokens int
-	cacheTokens  int
-	hasUsage     bool
+	usage    *protocol.TokenUsage
+	hasUsage bool
 }
 
 // NewAnthropicAccumulator returns a zeroed accumulator ready to consume events.
 func NewAnthropicAccumulator() *AnthropicAccumulator {
-	return &AnthropicAccumulator{}
+	return &AnthropicAccumulator{usage: protocol.ZeroTokenUsage()}
 }
 
 // Consume updates the accumulator from a non-beta streaming event.
@@ -85,61 +83,72 @@ func (a *AnthropicAccumulator) consumeRaw(
 	msgStartCacheReadRaw, deltaCacheReadRaw int64,
 	msgStartCacheCreation, deltaCacheCreation int64,
 ) {
+	if a.usage == nil {
+		a.usage = protocol.ZeroTokenUsage()
+	}
+
 	// Input tokens — prefer message_start, fall back to message_delta
 	switch {
 	case msgStartInput > 0:
-		a.inputTokens = int(msgStartInput)
+		a.usage.InputTokens = int(msgStartInput)
 		a.hasUsage = true
 	case msgStartInputRaw > 0:
-		a.inputTokens = int(msgStartInputRaw)
+		a.usage.InputTokens = int(msgStartInputRaw)
 		a.hasUsage = true
 	case deltaInput > 0:
-		a.inputTokens = int(deltaInput)
+		a.usage.InputTokens = int(deltaInput)
 		a.hasUsage = true
 	case deltaInputRaw > 0:
-		a.inputTokens = int(deltaInputRaw)
+		a.usage.InputTokens = int(deltaInputRaw)
 		a.hasUsage = true
 	}
 
 	// Output tokens
 	switch {
 	case deltaOutput > 0:
-		a.outputTokens = int(deltaOutput)
+		a.usage.OutputTokens = int(deltaOutput)
 		a.hasUsage = true
 	case deltaOutputRaw > 0:
-		a.outputTokens = int(deltaOutputRaw)
+		a.usage.OutputTokens = int(deltaOutputRaw)
 		a.hasUsage = true
 	}
 
-	// Cache read tokens — stored separately as cacheTokens
+	// Cache read tokens — stored separately as cache read details
 	switch {
 	case msgStartCacheRead > 0:
-		a.cacheTokens = int(msgStartCacheRead)
+		a.usage.CacheReadTokens = int(msgStartCacheRead)
 		a.hasUsage = true
 	case deltaCacheRead > 0:
-		a.cacheTokens = int(deltaCacheRead)
+		a.usage.CacheReadTokens = int(deltaCacheRead)
 		a.hasUsage = true
 	case msgStartCacheReadRaw > 0:
-		a.cacheTokens = int(msgStartCacheReadRaw)
+		a.usage.CacheReadTokens = int(msgStartCacheReadRaw)
 		a.hasUsage = true
 	case deltaCacheReadRaw > 0:
-		a.cacheTokens = int(deltaCacheReadRaw)
+		a.usage.CacheReadTokens = int(deltaCacheReadRaw)
 		a.hasUsage = true
 	}
 
 	// Normalize: add cache_creation to inputTokens so denominator =
-	// input (uncached) + creation (write cost). Cache reads stay in cacheTokens.
+	// input (uncached) + creation (write cost). Cache reads stay in cache details.
 	switch {
 	case msgStartCacheCreation > 0:
-		a.inputTokens += int(msgStartCacheCreation)
+		a.usage.CacheWriteTokens = int(msgStartCacheCreation)
+		a.usage.InputTokens += int(msgStartCacheCreation)
 	case deltaCacheCreation > 0:
-		a.inputTokens += int(deltaCacheCreation)
+		a.usage.CacheWriteTokens = int(deltaCacheCreation)
+		a.usage.InputTokens += int(deltaCacheCreation)
 	}
 }
 
 // Result returns the normalized TokenUsage built from accumulated events.
 func (a *AnthropicAccumulator) Result() *protocol.TokenUsage {
-	return protocol.NewTokenUsageWithCache(a.inputTokens, a.outputTokens, a.cacheTokens)
+	if a.usage == nil {
+		return protocol.ZeroTokenUsage()
+	}
+	result := *a.usage
+	result.CacheInputTokens = result.CacheReadTokens
+	return &result
 }
 
 // HasUsage reports whether any non-zero usage was observed.

--- a/internal/protocol/usage/extract.go
+++ b/internal/protocol/usage/extract.go
@@ -51,20 +51,22 @@ func FromOpenAIResponses(u responses.ResponseUsage) *protocol.TokenUsage {
 // (non-beta) Message usage block. CacheCreationInputTokens is added to
 // InputTokens so the denominator covers all non-cache-read prompt cost.
 func FromAnthropicMessage(u anthropic.Usage) *protocol.TokenUsage {
-	return protocol.NewTokenUsageWithCache(
+	return protocol.NewTokenUsageWithCacheDetails(
 		int(u.InputTokens)+int(u.CacheCreationInputTokens),
 		int(u.OutputTokens),
 		int(u.CacheReadInputTokens),
+		int(u.CacheCreationInputTokens),
 	)
 }
 
 // FromAnthropicBetaMessage extracts normalized TokenUsage from an Anthropic
 // beta BetaMessage usage block. Same normalization as the non-beta path.
 func FromAnthropicBetaMessage(u anthropic.BetaUsage) *protocol.TokenUsage {
-	return protocol.NewTokenUsageWithCache(
+	return protocol.NewTokenUsageWithCacheDetails(
 		int(u.InputTokens)+int(u.CacheCreationInputTokens),
 		int(u.OutputTokens),
 		int(u.CacheReadInputTokens),
+		int(u.CacheCreationInputTokens),
 	)
 }
 


### PR DESCRIPTION
## Summary
Provider usage fields had different meanings across OpenAI, Anthropic, and Google, making cache-hit rates, reasoning tokens, and stream usage easy to miscount. 

This PR makes `TokenUsage` the shared source of truth so streaming converters, protocol bridges, and billing paths preserve the same normalized usage semantics. 

### Major
- Usage reporting now distinguishes uncached input, cache-read hits, cache writes, output, and reasoning tokens consistently across OpenAI Chat, OpenAI Responses, Anthropic, Anthropic beta, and Google streams.
- Cache-hit ratios and billing inputs can now be calculated from the same canonical usage model instead of provider-specific ad hoc token fields.
- Stream protocol conversions now carry complete usage details through terminal events, including cache and reasoning metadata where supported.

### Minor
- Adds canonical helpers for converting normalized usage back into OpenAI Chat, OpenAI Responses, and Anthropic wire usage shapes.
- Centralizes OpenAI and Anthropic extraction rules in `internal/protocol/usage` to avoid repeated subtraction/addition logic in stream handlers.
- Updates stream usage design documentation to clarify cache-read vs cache-write semantics.
- Updates stream tests to assert usage via the shared `TokenUsage` model.
- Refreshes curl task URLs used by local task automation.