### PR TITLE
feat(team): manage sharing keys directly from Team page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import createAppTheme from './theme';
 import Login from './pages/Login';
 import Onboarding from './pages/Onboarding';
 import { api } from './services/api';
-import APITokensPage from './pages/APITokensPage';
+import SharingKeysPage from './pages/SharingKeysPage.tsx';
 import VirtualModelsPage from './pages/VirtualModelsPage';
 import UseOpenAIPage from './pages/scenario/UseOpenAIPage';
 import UseAnthropicPage from './pages/scenario/UseAnthropicPage';
@@ -213,7 +213,7 @@ function AppContent() {
                     {/* Other routes */}
                     <Route path="/system" element={<System />} />
                     <Route path="/access-control" element={<AccessControl />} />
-                    <Route path="/tingly-box-token" element={<APITokensPage />} />
+                    <Route path="/tingly-box-token" element={<SharingKeysPage />} />
                     <Route path="/system/logs" element={<LogsPage />} />
                     <Route path="/system/experimental" element={<ExperimentalPage />} />
                     {/* Dashboard routes with time range */}

--- a/frontend/src/components/SharingKeysTable.tsx
+++ b/frontend/src/components/SharingKeysTable.tsx
@@ -1,0 +1,255 @@
+import { Key as IconKey, DeleteOutline as IconDeleteOutline, ContentCopy as IconCopy, AccessTime as IconClock, Person as IconUser, Visibility as IconEye, VisibilityOff as IconEyeOff } from '@/components/icons';
+import {
+    Box,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography,
+    IconButton,
+    Tooltip,
+    Switch,
+    CircularProgress,
+} from '@mui/material';
+
+export interface SharingKey {
+    token_id: string;
+    user_id: string;
+    display_name: string;
+    enabled: boolean;
+    last_used_at?: string;
+    created_at: string;
+    created_by?: string;
+}
+
+export const maskToken = (token: string): string => {
+    if (!token) return '';
+    if (token.length <= 16) return `${token.slice(0, 8)}...${token.slice(-4)}`;
+    return `${token.slice(0, 12)}...${token.slice(-4)}`;
+};
+
+export const formatDate = (dateStr?: string) => {
+    if (!dateStr) return '-';
+    return new Date(dateStr).toLocaleString();
+};
+
+interface SharingKeysTableProps {
+    tokens: SharingKey[];
+    loading?: boolean;
+    visibleTokens: Record<string, boolean>;
+    onToggleVisibility: (tokenId: string) => void;
+    onCopy: (tokenId: string) => void;
+    onToggleEnabled: (token: SharingKey) => void;
+    onDelete: (token: SharingKey) => void;
+    /** Show the user_id column (default: true) */
+    showUserColumn?: boolean;
+    /** Show the last_used_at column (default: true) */
+    showLastUsedColumn?: boolean;
+    /** Label for the user column */
+    userColumnLabel?: string;
+}
+
+const SharingKeysTable: React.FC<SharingKeysTableProps> = ({
+    tokens,
+    loading = false,
+    visibleTokens,
+    onToggleVisibility,
+    onCopy,
+    onToggleEnabled,
+    onDelete,
+    showUserColumn = true,
+    showLastUsedColumn = true,
+    userColumnLabel = 'User',
+}) => {
+    const colSpan = 2 + (showUserColumn ? 1 : 0) + (showLastUsedColumn ? 1 : 0) + 1; // Name + Token + Status + Created + Actions + optional cols
+
+    return (
+        <TableContainer>
+            <Table>
+                <TableHead>
+                    <TableRow
+                        sx={{
+                            bgcolor: 'action.hover',
+                            '& th': {
+                                fontWeight: 700,
+                                fontSize: '0.75rem',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                                color: 'text.secondary',
+                                borderBottom: '2px solid',
+                                borderColor: 'divider',
+                                py: 1.5,
+                            },
+                        }}
+                    >
+                        <TableCell>Name</TableCell>
+                        {showUserColumn && <TableCell>{userColumnLabel}</TableCell>}
+                        <TableCell>Token</TableCell>
+                        <TableCell>Status</TableCell>
+                        <TableCell>Created</TableCell>
+                        {showLastUsedColumn && <TableCell>Last Used</TableCell>}
+                        <TableCell align="right">Actions</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {loading ? (
+                        <TableRow>
+                            <TableCell colSpan={colSpan} align="center" sx={{ border: 0 }}>
+                                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                                    <CircularProgress />
+                                </Box>
+                            </TableCell>
+                        </TableRow>
+                    ) : tokens.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={colSpan} align="center" sx={{ border: 0 }}>
+                                <Stack alignItems="center" spacing={1.5} sx={{ py: 4 }}>
+                                    <Box
+                                        sx={{
+                                            width: 40,
+                                            height: 40,
+                                            borderRadius: '50%',
+                                            bgcolor: 'action.hover',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'center',
+                                            color: 'text.disabled',
+                                        }}
+                                    >
+                                        <IconKey sx={{ fontSize: 20 }} />
+                                    </Box>
+                                    <Typography variant="body2" color="text.secondary">
+                                        No sharing keys yet. Create one to share model access with your team.
+                                    </Typography>
+                                </Stack>
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        tokens.map((key) => (
+                            <TableRow
+                                key={key.token_id}
+                                sx={{
+                                    '&:last-child td': { border: 0 },
+                                    opacity: !key.enabled ? 0.55 : 1,
+                                    '&:hover': { bgcolor: 'action.hover' },
+                                    '& td': { py: 1.5 },
+                                }}
+                            >
+                                <TableCell>
+                                    <Stack direction="row" spacing={1} alignItems="center">
+                                        <Box sx={{ color: key.enabled ? 'primary.main' : 'text.disabled', display: 'flex', flexShrink: 0 }}>
+                                            <IconKey sx={{ fontSize: 15 }} />
+                                        </Box>
+                                        <Typography variant="body2" fontWeight={600}>
+                                            {key.display_name}
+                                        </Typography>
+                                    </Stack>
+                                </TableCell>
+                                {showUserColumn && (
+                                    <TableCell>
+                                        <Tooltip title={key.user_id} placement="top">
+                                            <Stack direction="row" spacing={0.5} alignItems="center" sx={{ width: 'fit-content', cursor: 'default' }}>
+                                                <IconUser sx={{ fontSize: 13, opacity: 0.4, flexShrink: 0 }} />
+                                                <Typography variant="caption" sx={{ fontFamily: 'monospace', color: 'text.secondary' }}>
+                                                    {key.user_id.slice(0, 8)}…
+                                                </Typography>
+                                            </Stack>
+                                        </Tooltip>
+                                    </TableCell>
+                                )}
+                                <TableCell sx={{ maxWidth: 240 }}>
+                                    <Box
+                                        sx={{
+                                            px: 1, py: 0.5,
+                                            bgcolor: 'action.selected',
+                                            borderRadius: 1,
+                                            border: '1px solid',
+                                            borderColor: 'divider',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: 0.5,
+                                        }}
+                                    >
+                                        <Typography
+                                            variant="caption"
+                                            sx={{
+                                                fontFamily: 'monospace',
+                                                flex: 1,
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                                color: 'text.secondary',
+                                            }}
+                                        >
+                                            {visibleTokens[key.token_id] ? key.token_id : maskToken(key.token_id)}
+                                        </Typography>
+                                        <Tooltip title={visibleTokens[key.token_id] ? 'Hide' : 'Show'}>
+                                            <IconButton
+                                                size="small"
+                                                sx={{ p: 0.25, color: 'text.disabled', '&:hover': { color: 'text.primary' } }}
+                                                onClick={() => onToggleVisibility(key.token_id)}
+                                            >
+                                                {visibleTokens[key.token_id] ? <IconEyeOff sx={{ fontSize: 13 }} /> : <IconEye sx={{ fontSize: 13 }} />}
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Copy">
+                                            <IconButton
+                                                size="small"
+                                                sx={{ p: 0.25, color: 'text.disabled', '&:hover': { color: 'text.primary' } }}
+                                                onClick={() => onCopy(key.token_id)}
+                                            >
+                                                <IconCopy sx={{ fontSize: 13 }} />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </Box>
+                                </TableCell>
+                                <TableCell>
+                                    <Tooltip title={key.enabled ? 'Active' : 'Disabled'} placement="top">
+                                        <Switch
+                                            size="small"
+                                            checked={key.enabled}
+                                            onChange={() => onToggleEnabled(key)}
+                                            color="success"
+                                        />
+                                    </Tooltip>
+                                </TableCell>
+                                <TableCell>
+                                    <Stack direction="row" spacing={0.5} alignItems="center">
+                                        <IconClock sx={{ fontSize: 13, opacity: 0.4, flexShrink: 0 }} />
+                                        <Typography variant="caption" color="text.secondary">
+                                            {formatDate(key.created_at)}
+                                        </Typography>
+                                    </Stack>
+                                </TableCell>
+                                {showLastUsedColumn && (
+                                    <TableCell>
+                                        <Typography variant="caption" color="text.secondary">
+                                            {formatDate(key.last_used_at)}
+                                        </Typography>
+                                    </TableCell>
+                                )}
+                                <TableCell align="right">
+                                    <Tooltip title="Delete token">
+                                        <IconButton
+                                            size="small"
+                                            color="error"
+                                            onClick={() => onDelete(key)}
+                                            sx={{ opacity: 0.75, '&:hover': { opacity: 1 } }}
+                                        >
+                                            <IconDeleteOutline sx={{ fontSize: 16 }} />
+                                        </IconButton>
+                                    </Tooltip>
+                                </TableCell>
+                            </TableRow>
+                        ))
+                    )}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    );
+};
+
+export default SharingKeysTable;

--- a/frontend/src/pages/SharingKeysPage.tsx
+++ b/frontend/src/pages/SharingKeysPage.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useNotify } from '@/hooks/useNotify';
 import SharingKeysTable, { type SharingKey } from '@/components/SharingKeysTable';
 
-const APITokensPage = () => {
+const SharingKeysPage = () => {
     const { t } = useTranslation();
     const notify = useNotify();
     const [tokens, setTokens] = useState<SharingKey[]>([]);
@@ -203,4 +203,4 @@ const APITokensPage = () => {
     );
 };
 
-export default APITokensPage;
+export default SharingKeysPage;

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -306,10 +306,10 @@ const UseClaudeCodePageContent: React.FC = () => {
                         </Typography>
                     </DialogContent>
                     <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
-                        <Button onClick={cancelModeChange} color="inherit">
+                        <Button onClick={cancelModeChange} color="inherit" size="small">
                             Cancel
                         </Button>
-                        <Button onClick={confirmModeChange} variant="contained">
+                        <Button onClick={confirmModeChange} variant="contained" size="small">
                             Confirm
                         </Button>
                     </DialogActions>

--- a/frontend/src/pages/scenario/UseTeamPage.tsx
+++ b/frontend/src/pages/scenario/UseTeamPage.tsx
@@ -34,7 +34,8 @@ const UseTeamPageContent: React.FC = () => {
                     size="full"
                     rightAction={
                         <Button
-                            variant="outlined"
+                            variant="contained"
+                            size="small"
                             startIcon={<IconKey sx={{ fontSize: 18 }} />}
                             onClick={() => setSharingKeysOpen(true)}
                         >

--- a/frontend/src/pages/scenario/UseTeamPage.tsx
+++ b/frontend/src/pages/scenario/UseTeamPage.tsx
@@ -1,12 +1,17 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
+import { Key as IconKey } from '@/components/icons';
+import { useState } from 'react';
 import PageLayout from '@/components/PageLayout';
 import TemplatePage from './components/TemplatePage.tsx';
+import SharingKeysDialog from './components/SharingKeysDialog.tsx';
 import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
+
 const scenario = "team";
+
 const UseTeamPageContent: React.FC = () => {
     const {
         isLoading,
@@ -14,6 +19,9 @@ const UseTeamPageContent: React.FC = () => {
         copyToClipboard,
         baseUrl,
     } = useScenarioPageInternal(scenario);
+
+    const [sharingKeysOpen, setSharingKeysOpen] = useState(false);
+
     return (
         <PageLayout loading={isLoading} notification={notification}>
             <CardGrid>
@@ -24,6 +32,15 @@ const UseTeamPageContent: React.FC = () => {
                         </Box>
                     }
                     size="full"
+                    rightAction={
+                        <Button
+                            variant="outlined"
+                            startIcon={<IconKey sx={{ fontSize: 18 }} />}
+                            onClick={() => setSharingKeysOpen(true)}
+                        >
+                            Sharing Keys
+                        </Button>
+                    }
                 >
                     <ProviderConfigCard
                         title="Team"
@@ -40,9 +57,15 @@ const UseTeamPageContent: React.FC = () => {
                     allowDeleteRule={true}
                 />
             </CardGrid>
+
+            <SharingKeysDialog
+                open={sharingKeysOpen}
+                onClose={() => setSharingKeysOpen(false)}
+            />
         </PageLayout>
     );
 };
+
 const UseTeamPage: React.FC = () => {
     return (
         <ScenarioPageModalProvider>
@@ -50,4 +73,5 @@ const UseTeamPage: React.FC = () => {
         </ScenarioPageModalProvider>
     );
 };
+
 export default UseTeamPage;

--- a/frontend/src/pages/scenario/components/SharingKeysDialog.tsx
+++ b/frontend/src/pages/scenario/components/SharingKeysDialog.tsx
@@ -1,7 +1,4 @@
-import { PageLayout } from '@/components/PageLayout';
-import UnifiedCard from '@/components/UnifiedCard';
-import { api } from '@/services/api';
-import { Add as IconPlus, Delete as IconTrash } from '@/components/icons';
+import { Key as IconKey, Add as IconPlus, Delete as IconTrash } from '@/components/icons';
 import {
     Button,
     CircularProgress,
@@ -14,62 +11,56 @@ import {
     Typography,
 } from '@mui/material';
 import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { api } from '@/services/api';
 import { useNotify } from '@/hooks/useNotify';
 import SharingKeysTable, { type SharingKey } from '@/components/SharingKeysTable';
 
-const APITokensPage = () => {
-    const { t } = useTranslation();
+interface SharingKeysDialogProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+const SharingKeysDialog: React.FC<SharingKeysDialogProps> = ({ open, onClose }) => {
     const notify = useNotify();
-    const [tokens, setTokens] = useState<SharingKey[]>([]);
-    const [loading, setLoading] = useState(true);
 
-    // Create token dialog state
+    const [sharingKeys, setSharingKeys] = useState<SharingKey[]>([]);
+    const [keysLoading, setKeysLoading] = useState(true);
+    const [visibleTokens, setVisibleTokens] = useState<Record<string, boolean>>({});
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [newTokenDisplayName, setNewTokenDisplayName] = useState('');
+    const [newTokenName, setNewTokenName] = useState('');
     const [creatingToken, setCreatingToken] = useState(false);
-
-    // Delete confirm dialog
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [tokenToDelete, setTokenToDelete] = useState<SharingKey | null>(null);
     const [deletingToken, setDeletingToken] = useState(false);
 
-    // Token visibility state - map of token_id -> boolean
-    const [visibleTokens, setVisibleTokens] = useState<Record<string, boolean>>({});
-
-    useEffect(() => {
-        loadTokens();
-    }, []);
-
-    const loadTokens = async () => {
-        setLoading(true);
+    const loadSharingKeys = async () => {
+        setKeysLoading(true);
         const result = await api.listAPITokens();
         if (result.success && result.data) {
-            setTokens(result.data.tokens || []);
+            setSharingKeys(result.data.tokens || []);
         }
-        setLoading(false);
+        setKeysLoading(false);
     };
 
+    useEffect(() => {
+        if (open) {
+            loadSharingKeys();
+        }
+    }, [open]);
+
     const handleCreateToken = async () => {
-        if (!newTokenDisplayName) {
+        if (!newTokenName.trim()) {
             notify.error('Display Name is required');
             return;
         }
-
         setCreatingToken(true);
-        const result = await api.createAPIToken({
-            display_name: newTokenDisplayName,
-        });
-
+        const result = await api.createAPIToken({ display_name: newTokenName.trim() });
         setCreatingToken(false);
-        setCreateDialogOpen(false);
-
-        if (result.success && result.data) {
+        if (result.success) {
             notify.success('Token created successfully');
-            loadTokens();
-
-            // Reset form
-            setNewTokenDisplayName('');
+            setCreateDialogOpen(false);
+            setNewTokenName('');
+            loadSharingKeys();
         } else {
             notify.error(result.error?.message || 'Failed to create token');
         }
@@ -77,82 +68,76 @@ const APITokensPage = () => {
 
     const handleDeleteToken = async () => {
         if (!tokenToDelete) return;
-
         setDeletingToken(true);
         const result = await api.deleteAPIToken(tokenToDelete.token_id);
-
         setDeletingToken(false);
-        setDeleteDialogOpen(false);
-        setTokenToDelete(null);
-
         if (result.success) {
             notify.success('Token deleted successfully');
-            loadTokens();
+            setDeleteDialogOpen(false);
+            setTokenToDelete(null);
+            loadSharingKeys();
         } else {
             notify.error(result.error?.message || 'Failed to delete token');
         }
     };
 
     return (
-        <PageLayout loading={loading}>
-            <Stack spacing={3}>
-                {/* Tokens Table — the page-level explanation now lives as a hover tooltip
-                    on the Sharing sidebar item (see useActivityItems.tsx). */}
-                <UnifiedCard
-                    title="Tingly Box Share Model Tokens"
-                    subtitle="Manage API tokens for sharing model access with clients and environments."
-                    size="full"
-                    rightAction={
-                        <Button
-                            variant="contained"
-                            startIcon={<IconPlus sx={{ fontSize: 18 }} />}
-                            onClick={() => setCreateDialogOpen(true)}
-                        >
-                            Create Token
-                        </Button>
-                    }
-                >
+        <>
+            <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+                <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                        <IconKey />
+                        <span>Sharing Keys</span>
+                    </Stack>
+                    <Button
+                        variant="contained"
+                        startIcon={<IconPlus sx={{ fontSize: 18 }} />}
+                        onClick={() => setCreateDialogOpen(true)}
+                    >
+                        Create Token
+                    </Button>
+                </DialogTitle>
+                <DialogContent>
                     <SharingKeysTable
-                        tokens={tokens}
-                        loading={loading}
+                        tokens={sharingKeys}
+                        loading={keysLoading}
                         visibleTokens={visibleTokens}
                         onToggleVisibility={(tokenId) => setVisibleTokens(prev => ({ ...prev, [tokenId]: !prev[tokenId] }))}
                         onCopy={(tokenId) => {
                             navigator.clipboard.writeText(tokenId);
                             notify.success('Token copied to clipboard');
                         }}
-                        onToggleEnabled={async (token) => {
-                            const result = await api.setAPITokenEnabled(token.token_id, !token.enabled);
+                        onToggleEnabled={async (key) => {
+                            const result = await api.setAPITokenEnabled(key.token_id, !key.enabled);
                             if (result.success) {
-                                notify.success(token.enabled ? 'Token disabled' : 'Token enabled');
-                                loadTokens();
+                                notify.success(key.enabled ? 'Token disabled' : 'Token enabled');
+                                loadSharingKeys();
                             } else {
                                 notify.error(result.error?.message || 'Failed to update token');
                             }
                         }}
-                        onDelete={(token) => {
-                            setTokenToDelete(token);
+                        onDelete={(key) => {
+                            setTokenToDelete(key);
                             setDeleteDialogOpen(true);
                         }}
                         showUserColumn={true}
-                        showLastUsedColumn={true}
-                        userColumnLabel="UUID"
+                        showLastUsedColumn={false}
                     />
-                </UnifiedCard>
-            </Stack>
+                </DialogContent>
+            </Dialog>
 
             {/* Create Token Dialog */}
             <Dialog open={createDialogOpen} onClose={() => setCreateDialogOpen(false)} maxWidth="sm" fullWidth>
-                <DialogTitle>Create API Token</DialogTitle>
+                <DialogTitle>Create Sharing Key</DialogTitle>
                 <DialogContent>
                     <Stack spacing={3} sx={{ mt: 1 }}>
                         <TextField
                             label="Display Name"
                             fullWidth
-                            value={newTokenDisplayName}
-                            onChange={(e) => setNewTokenDisplayName(e.target.value)}
-                            placeholder="e.g., Production API Token"
-                            helperText="A descriptive name for this token"
+                            value={newTokenName}
+                            onChange={(e) => setNewTokenName(e.target.value)}
+                            placeholder="e.g., Team Alpha Key"
+                            helperText="A descriptive name for this sharing key"
                             autoFocus
                         />
                     </Stack>
@@ -162,7 +147,7 @@ const APITokensPage = () => {
                     <Button
                         variant="contained"
                         onClick={handleCreateToken}
-                        disabled={creatingToken || !newTokenDisplayName}
+                        disabled={creatingToken || !newTokenName.trim()}
                         startIcon={creatingToken ? <CircularProgress size={16} /> : <IconPlus sx={{ fontSize: 18 }} />}
                     >
                         Create Token
@@ -185,9 +170,7 @@ const APITokensPage = () => {
                     </Typography>
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={() => setDeleteDialogOpen(false)} disabled={deletingToken}>
-                        Cancel
-                    </Button>
+                    <Button onClick={() => setDeleteDialogOpen(false)} disabled={deletingToken}>Cancel</Button>
                     <Button
                         variant="contained"
                         color="error"
@@ -199,8 +182,8 @@ const APITokensPage = () => {
                     </Button>
                 </DialogActions>
             </Dialog>
-        </PageLayout>
+        </>
     );
 };
 
-export default APITokensPage;
+export default SharingKeysDialog;


### PR DESCRIPTION
## Summary
Team admins previously had to navigate to a separate page to manage sharing keys. Now they can view, create, enable/disable, and delete sharing keys inline from the Team configuration page via a dialog — no context switch required.

### Major
- Team page now has a "Sharing Keys" button that opens a full management dialog with create, toggle, copy, and delete actions
- Sharing keys table extracted as a reusable `SharingKeysTable` component with configurable columns and callback-driven events
- Standalone sharing keys page (`/tingly-box-token`) now uses the same reusable table component

### Minor
- Renamed `APITokensPage` → `SharingKeysPage` for consistent "Sharing Keys" terminology
- Fixed dialog action button sizes (`size='small'`) on Claude Code page for visual consistency
