### PR TITLE
bugfix(codex): fail over on malformed streaming responses

### DIFF
--- a/internal/client/codex_round_tripper.go
+++ b/internal/client/codex_round_tripper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -84,10 +85,43 @@ func (t *codexRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		return nil, fmt.Errorf("request failed with status %s: %s", resp.Status, string(errorBody))
 	}
 
+	if err := validateCodexStreamResponse(resp); err != nil {
+		return nil, err
+	}
+
 	resp.Header.Set("Content-Type", "text/event-stream")
 	logrus.WithContext(req.Context()).Debugf("[Codex] Must use stream: %s", resp.Status)
 
 	return resp, nil
+}
+
+func validateCodexStreamResponse(resp *http.Response) error {
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		return nil
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.ToLower(strings.Split(contentType, ";")[0]))
+	}
+	if mediaType == "" || mediaType == "text/event-stream" {
+		return nil
+	}
+	if !isClearlyNonSSEMediaType(mediaType) {
+		return nil
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	return fmt.Errorf("codex returned non-SSE 200 response content-type %q: %s", contentType, strings.TrimSpace(string(body)))
+}
+
+func isClearlyNonSSEMediaType(mediaType string) bool {
+	if mediaType == "application/json" || mediaType == "application/problem+json" || mediaType == "text/html" {
+		return true
+	}
+	return strings.HasSuffix(mediaType, "+json")
 }
 
 func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {

--- a/internal/client/codex_round_tripper_test.go
+++ b/internal/client/codex_round_tripper_test.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -171,4 +174,43 @@ func TestCodexInputItemIDRequired(t *testing.T) {
 	for _, typ := range optional {
 		assert.False(t, codexInputItemIDRequired(typ), "type %q should not require id", typ)
 	}
+}
+
+func TestValidateCodexStreamResponse_AllowsSSE(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+		Body:   io.NopCloser(strings.NewReader("data: {}\n\n")),
+	}
+
+	require.NoError(t, validateCodexStreamResponse(resp))
+}
+
+func TestValidateCodexStreamResponse_AllowsMissingContentType(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("data: {}\n\n")),
+	}
+
+	require.NoError(t, validateCodexStreamResponse(resp))
+}
+
+func TestValidateCodexStreamResponse_RejectsJSON200(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   io.NopCloser(strings.NewReader(`{"error":"maintenance"}`)),
+	}
+
+	err := validateCodexStreamResponse(resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-SSE 200 response")
+	assert.Contains(t, err.Error(), "maintenance")
+}
+
+func TestValidateCodexStreamResponse_AllowsAmbiguousNonSSEContentType(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/plain"}},
+		Body:   io.NopCloser(strings.NewReader("data: {}\n\n")),
+	}
+
+	require.NoError(t, validateCodexStreamResponse(resp))
 }

--- a/internal/protocol/stream/prime.go
+++ b/internal/protocol/stream/prime.go
@@ -15,6 +15,8 @@
 package stream
 
 import (
+	"fmt"
+
 	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -61,19 +63,19 @@ func (p *firstEventReplayStream) Close() error { return p.inner.Close() }
 // lazy HTTP request and surface pre-stream upstream errors. Returns:
 //
 //   - (iter, nil)   primed; iter replays the read event first, then
-//                   delegates to the SDK stream.
-//   - (iter, nil)   degenerate "no events, no error" — iter is the SDK
-//                   stream itself (which immediately reports Next()=false).
-//   - (nil, err)    pre-stream failure — caller retries next priority tier.
+//     delegates to the SDK stream.
+//   - (nil, err)    pre-stream failure, including a degenerate stream with
+//     zero events and no SDK error — caller retries next
+//     priority tier before any Anthropic SSE bytes are written.
 func PrimeResponsesStream(stream *openaistream.Stream[responses.ResponseStreamEventUnion]) (ResponsesStreamIter, error) {
 	if stream == nil {
-		return nil, nil
+		return nil, fmt.Errorf("upstream returned nil responses stream")
 	}
 	if !stream.Next() {
 		if err := stream.Err(); err != nil {
 			return nil, err
 		}
-		return stream, nil
+		return nil, fmt.Errorf("upstream returned empty responses stream")
 	}
 	return &firstEventReplayStream{
 		first: stream.Current(),

--- a/internal/protocol/stream/prime_test.go
+++ b/internal/protocol/stream/prime_test.go
@@ -9,7 +9,10 @@ package stream
 import (
 	"testing"
 
+	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stubStream mimics the small slice of *openaistream.Stream that
@@ -55,4 +58,28 @@ func TestFirstEventReplayStream_CurrentBeforeNextIsZero(t *testing.T) {
 	if p.nextCount != 0 {
 		t.Fatalf("fresh wrapper nextCount = %d, want 0", p.nextCount)
 	}
+}
+
+func TestPrimeResponsesStream_EmptyStreamReturnsError(t *testing.T) {
+	stream := openaistream.NewStream[responses.ResponseStreamEventUnion](newFakeResponsesDecoder(nil), nil)
+
+	primed, err := PrimeResponsesStream(stream)
+
+	require.Error(t, err)
+	assert.Nil(t, primed)
+	assert.Contains(t, err.Error(), "empty responses stream")
+}
+
+func TestPrimeResponsesStream_ReplaysFirstEvent(t *testing.T) {
+	stream := openaistream.NewStream[responses.ResponseStreamEventUnion](newFakeResponsesDecoder([]string{
+		buildResponsesCompletedJSON(t, 3, 5, 0, 0),
+	}), nil)
+
+	primed, err := PrimeResponsesStream(stream)
+	require.NoError(t, err)
+	require.NotNil(t, primed)
+
+	require.True(t, primed.Next())
+	assert.Equal(t, "response.completed", primed.Current().Type)
+	assert.False(t, primed.Next())
 }


### PR DESCRIPTION
## Summary
Codex streaming could occasionally surface to Claude Code as an empty or malformed HTTP 200 response when the upstream Responses stream produced no usable SSE events.  ( report in #1316 )
This PR makes invalid Codex streams fail before Anthropic-formatted bytes are committed, allowing priority failover to retry another candidate.

### Major
- Claude Code requests through Codex now fail over when the Responses API stream is empty before any events are emitted.
- Codex 200 responses that are clearly JSON/HTML error payloads are rejected instead of being forced into `text/event-stream`.

### Minor
- Ambiguous content types are still allowed to avoid rejecting non-standard but stream-compatible upstream responses.
- Added regression coverage for empty Responses stream priming and Codex non-SSE 200 response handling.