### PR TITLE
refactor(profile): update to suggest new `profile` command to replace `cc` command

### DIFF
--- a/cli/tingly-box/main.go
+++ b/cli/tingly-box/main.go
@@ -5,10 +5,8 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"os"
-	"strings"
-
 	_ "net/http/pprof"
+	"os"
 	_ "time/tzdata" // Embed timezone data for static builds
 
 	"github.com/alecthomas/kong"
@@ -100,14 +98,6 @@ func main() {
 			// Print default Kong help
 			if err := kong.DefaultHelpPrinter(options, ctx); err != nil {
 				return err
-			}
-			// Append passthrough help for cc and profile commands
-			c := ctx.Command()
-			switch {
-			case strings.HasPrefix(c, "cc"):
-				command.PrintCCPassthroughHelp("cc")
-			case strings.HasPrefix(c, "profile"):
-				command.PrintCCPassthroughHelp("profile")
 			}
 			return nil
 		}),

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -122,12 +122,13 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
         }
     };
 
-    // Load rules for this profile
+    // Profile quick start command. Keep the old `cc --profile` form compatible
+    // in the CLI, but surface the new direct `profile <name>` form in the UI.
     const ccCommand = React.useMemo(() => {
         if (commandMode === 'npx' && appVersion) {
-            return `npx -y tingly-box@${appVersion} cc --profile ${profileId}`;
+            return `npx -y tingly-box@${appVersion} profile ${profileId}`;
         }
-        return `tingly-box cc --profile ${profileId}`;
+        return `tingly-box profile ${profileId}`;
     }, [commandMode, appVersion, profileId]);
 
     return (

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -15,13 +15,13 @@ import (
 
 // ============== Kong Command Structures ==============
 
-// CCmdKong launches Claude Code with tingly-box-specific flags
-// Accepts --profile, --port/--tingly-port, and --help flags.
-// All other arguments are passed to Claude Code.
+// CCmdKong launches Claude Code with tingly-box-specific flags.
+// Put tingly-box flags before Claude Code args; unknown flags are passed through
+// to Claude Code so users do not need to insert a literal '--'.
 type CCmdKong struct {
 	Profile string   `kong:"flag,name='profile',help='Claude Code profile to use'"`
 	Port    int      `kong:"flag,name='port',help='Tingly-Box server port (default: from config or 12580)'"`
-	Args    []string `kong:"arg,optional"`
+	Args    []string `kong:"arg,optional,passthrough='all',help='Additional arguments to pass to Claude Code (e.g., --model opus)'"`
 }
 
 func (c *CCmdKong) Run(appManager *AppManager) error {

--- a/internal/command/profile_command.go
+++ b/internal/command/profile_command.go
@@ -21,18 +21,18 @@ import (
 //
 //	tingly-box profile                    → list profiles (interactive on TTY, select to launch)
 //	tingly-box profile p1                 → launch Claude Code with profile p1
-//	tingly-box profile p1 --port 12580    → launch Claude Code with profile p1 on port 12580
-//	tingly-box profile p1 -- --model opus → launch with profile p1, passing --model opus to Claude
-//	tingly-box profile p1 -- -p hi        → launch with profile p1, using Claude's print mode
+//	tingly-box profile --port 12580 p1    → launch Claude Code with profile p1 on port 12580
+//	tingly-box profile p1 --model opus    → launch with profile p1, passing --model opus to Claude
+//	tingly-box profile p1 -p hi           → launch with profile p1, using Claude's print mode
 //
-// Note: Use '--' to separate tingly-box options from Claude arguments, especially
-// when passing flags that might conflict (e.g., -p for Claude's print mode).
+// Put tingly-box flags before the profile name; after the profile name, flags are
+// treated as Claude Code arguments. A literal '--' still works for compatibility.
 type ProfileCmdKong struct {
 	List      bool     `kong:"flag,name='list',help='List all profiles (non-interactive)'"`
 	Show      bool     `kong:"flag,name='show',help='Show profile details instead of launching'"`
 	Port      int      `kong:"flag,name='port',help='Connect to tingly-box on the specified port (default: from config)'"`
 	ProfileID string   `kong:"arg,optional,help='Profile name or ID to launch Claude Code with'"`
-	Args      []string `kong:"arg,optional,help='Additional arguments to pass to Claude Code (e.g., --model opus)'"`
+	Args      []string `kong:"arg,optional,passthrough='all',help='Additional arguments to pass to Claude Code (e.g., --model opus)'"`
 }
 
 func (p *ProfileCmdKong) Run(appManager *AppManager) error {


### PR DESCRIPTION
Now we suggest to use `profile` command for claude code profile, and all claude code options and arguments are passthrough.