### PR TITLE
bugfix(server): profile scenario flag writes no longer orphan inherited base config

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1752,30 +1752,44 @@ func (c *Config) GetScenarioFlag(scenario typ.RuleScenario, flagName string) boo
 	}
 }
 
+// findOrCreateScenarioConfigLocked returns the scenario config to mutate for a
+// Set*Flag call. If an exact-match entry doesn't exist yet, seeds a new one:
+// for a profiled scenario (e.g. "claude_code:p1") it copies Flags/Extensions
+// from the resolved base config (via scenarioConfigLocked's fallback) so the
+// profile starts as a fork of its base rather than silently losing flags that
+// were previously inherited from the base scenario on first write. For a
+// non-profiled (or otherwise unresolvable) scenario it creates a blank entry
+// as before. Callers must hold the write lock.
+func (c *Config) findOrCreateScenarioConfigLocked(scenario typ.RuleScenario) *typ.ScenarioConfig {
+	for i := range c.Scenarios {
+		if c.Scenarios[i].Scenario == scenario {
+			return &c.Scenarios[i]
+		}
+	}
+
+	newConfig := typ.ScenarioConfig{
+		Scenario:   scenario,
+		Flags:      typ.ScenarioFlags{},
+		Extensions: make(map[string]interface{}),
+	}
+	if seed := c.scenarioConfigLocked(scenario); seed != nil {
+		newConfig.Flags = seed.Flags
+		newConfig.Extensions = make(map[string]interface{}, len(seed.Extensions))
+		for k, v := range seed.Extensions {
+			newConfig.Extensions[k] = v
+		}
+	}
+	c.Scenarios = append(c.Scenarios, newConfig)
+	return &c.Scenarios[len(c.Scenarios)-1]
+}
+
 // SetScenarioFlag sets a specific flag value for a scenario
 func (c *Config) SetScenarioFlag(scenario typ.RuleScenario, flagName string, value bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Find or create scenario config
-	var config *typ.ScenarioConfig
-	for i := range c.Scenarios {
-		if c.Scenarios[i].Scenario == scenario {
-			config = &c.Scenarios[i]
-			break
-		}
-	}
-
-	if config == nil {
-		// Create new scenario config
-		newConfig := typ.ScenarioConfig{
-			Scenario:   scenario,
-			Flags:      typ.ScenarioFlags{},
-			Extensions: make(map[string]interface{}),
-		}
-		c.Scenarios = append(c.Scenarios, newConfig)
-		config = &c.Scenarios[len(c.Scenarios)-1]
-	}
+	// Find or create scenario config (seeded from base config for profiles)
+	config := c.findOrCreateScenarioConfigLocked(scenario)
 
 	// Set the specific flag
 	switch flagName {
@@ -1848,25 +1862,8 @@ func (c *Config) SetScenarioStringFlag(scenario typ.RuleScenario, flagName strin
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Find or create scenario config
-	var config *typ.ScenarioConfig
-	for i := range c.Scenarios {
-		if c.Scenarios[i].Scenario == scenario {
-			config = &c.Scenarios[i]
-			break
-		}
-	}
-
-	if config == nil {
-		// Create new scenario config
-		newConfig := typ.ScenarioConfig{
-			Scenario:   scenario,
-			Flags:      typ.ScenarioFlags{},
-			Extensions: make(map[string]interface{}),
-		}
-		c.Scenarios = append(c.Scenarios, newConfig)
-		config = &c.Scenarios[len(c.Scenarios)-1]
-	}
+	// Find or create scenario config (seeded from base config for profiles)
+	config := c.findOrCreateScenarioConfigLocked(scenario)
 
 	// Set the specific flag
 	switch flagName {
@@ -1914,28 +1911,10 @@ func (c *Config) SetScenarioIntFlag(scenario typ.RuleScenario, flagName string, 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Find or create scenario config
-	var config *typ.ScenarioConfig
-	for i := range c.Scenarios {
-		if c.Scenarios[i].Scenario == scenario {
-			config = &c.Scenarios[i]
-			break
-		}
-	}
-
-	if config == nil {
-		newConfig := typ.ScenarioConfig{
-			Scenario:   scenario,
-			Flags:      typ.ScenarioFlags{},
-			Extensions: make(map[string]interface{}),
-		}
-		c.Scenarios = append(c.Scenarios, newConfig)
-		config = &c.Scenarios[len(c.Scenarios)-1]
-	}
-
 	switch flagName {
 	// No scenario-level int flags currently registered; add cases here, e.g.
 	//   case FlagFoo:
+	//       config := c.findOrCreateScenarioConfigLocked(scenario)
 	//       config.Flags.Foo = value
 	//       return c.Save()
 	default:
@@ -1978,23 +1957,8 @@ func (c *Config) SetScenarioExtensions(scenario typ.RuleScenario, values map[str
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var config *typ.ScenarioConfig
-	for i := range c.Scenarios {
-		if c.Scenarios[i].Scenario == scenario {
-			config = &c.Scenarios[i]
-			break
-		}
-	}
-
-	if config == nil {
-		newConfig := typ.ScenarioConfig{
-			Scenario:   scenario,
-			Flags:      typ.ScenarioFlags{},
-			Extensions: make(map[string]interface{}),
-		}
-		c.Scenarios = append(c.Scenarios, newConfig)
-		config = &c.Scenarios[len(c.Scenarios)-1]
-	}
+	// Find or create scenario config (seeded from base config for profiles)
+	config := c.findOrCreateScenarioConfigLocked(scenario)
 
 	if config.Extensions == nil {
 		config.Extensions = make(map[string]interface{})

--- a/internal/server/config/flag_test.go
+++ b/internal/server/config/flag_test.go
@@ -77,6 +77,80 @@ func TestScenarioAffinityDoesNotLeakIntoRules(t *testing.T) {
 	}
 }
 
+// TestProfileScenarioFlagWriteInheritsBaseConfig verifies that writing a flag
+// to a profiled scenario (e.g. "claude_code:p1") for the first time seeds the
+// new profile-scoped ScenarioConfig from the resolved base scenario config,
+// rather than a blank one. Before the fix, SetScenarioFlag/SetScenarioStringFlag/
+// SetScenarioIntFlag/SetScenarioExtensions did an exact-match-only lookup and
+// created an empty entry on miss, silently orphaning the profile from every
+// flag it previously inherited from the base scenario via scenarioConfigLocked's
+// fallback (used by the Get* counterparts). See .claude/plans -
+// "Fix: Claude Code profile page top flag panel doesn't read/write flags
+// correctly".
+func TestProfileScenarioFlagWriteInheritsBaseConfig(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	base := typ.ScenarioClaudeCode
+	profile := typ.RuleScenario("claude_code:p1")
+
+	// Base scenario is switched to separate mode.
+	if err := cfg.SetScenarioFlag(base, FlagSeparate, true); err != nil {
+		t.Fatalf("SetScenarioFlag(base, separate) error: %v", err)
+	}
+
+	// Sanity: before any profile-local write, the profile reads through to
+	// base via scenarioConfigLocked's fallback.
+	if v := cfg.GetScenarioFlag(profile, FlagSeparate); !v {
+		t.Fatalf("expected profile to inherit base separate=true via fallback before any profile write, got false")
+	}
+
+	// Writing an unrelated flag on the profile (e.g. toggling Smart Compact
+	// from the profile page's plugin panel) must not orphan the profile from
+	// the base scenario's already-set flags.
+	if err := cfg.SetScenarioFlag(profile, FlagSmartCompact, true); err != nil {
+		t.Fatalf("SetScenarioFlag(profile, smart_compact) error: %v", err)
+	}
+
+	if v := cfg.GetScenarioFlag(profile, FlagSeparate); !v {
+		t.Errorf("profile lost inherited separate=true after an unrelated profile-local flag write")
+	}
+	if v := cfg.GetScenarioFlag(profile, FlagSmartCompact); !v {
+		t.Errorf("profile-local smart_compact write did not persist")
+	}
+	// Base scenario itself must be unaffected by the profile write.
+	if v := cfg.GetScenarioFlag(base, FlagSmartCompact); v {
+		t.Errorf("smart_compact leaked into the base scenario config")
+	}
+
+	// Same guarantee for the string-flag setter (e.g. thinking_effort set on
+	// base, then a different flag toggled on the profile).
+	profile2 := typ.RuleScenario("claude_code:p2")
+	if err := cfg.SetScenarioStringFlag(base, FlagThinkingEffort, "high"); err != nil {
+		t.Fatalf("SetScenarioStringFlag(base, thinking_effort) error: %v", err)
+	}
+	if err := cfg.SetScenarioStringFlag(profile2, FlagRecordingV2, string(typ.RecordingModeRequestOnly)); err != nil {
+		t.Fatalf("SetScenarioStringFlag(profile2, recording_v2) error: %v", err)
+	}
+	if got := cfg.GetScenarioStringFlag(profile2, FlagThinkingEffort); got != "high" {
+		t.Errorf("profile2 lost inherited thinking_effort=high after an unrelated profile-local string flag write, got %q", got)
+	}
+
+	// Same guarantee for SetScenarioExtensions.
+	profile3 := typ.RuleScenario("claude_code:p3")
+	if err := cfg.SetScenarioFlag(base, FlagSkipUsage, true); err != nil {
+		t.Fatalf("SetScenarioFlag(base, skip_usage) error: %v", err)
+	}
+	if err := cfg.SetScenarioExtensions(profile3, map[string]interface{}{"some_extension": "x"}); err != nil {
+		t.Fatalf("SetScenarioExtensions(profile3) error: %v", err)
+	}
+	if v := cfg.GetScenarioFlag(profile3, FlagSkipUsage); !v {
+		t.Errorf("profile3 lost inherited skip_usage=true after an unrelated SetScenarioExtensions write")
+	}
+}
+
 // TestBuiltInRulesSessionAffinity verifies the built-in Claude Code / Desktop /
 // Codex rules seed session_affinity to the 30-min default, while other built-in
 // rules leave it disabled.


### PR DESCRIPTION
SetScenarioFlag/SetScenarioStringFlag/SetScenarioIntFlag/SetScenarioExtensions did an exact-match-only lookup and created a blank ScenarioConfig on miss, while the Get* counterparts fall back to the base scenario's config via scenarioConfigLocked. 

The first flag write from a Claude Code profile page (e.g. toggling Smart Compact) created an isolated claude_code:p1 entry that became the exact match for all future reads, silently reverting every other flag that was previously inherited from the base scenario (routing mode, thinking_effort, recording_v2, skip_usage, ...) to zero-values.

Add findOrCreateScenarioConfigLocked, which seeds a new profile-scoped entry by copying the resolved base config instead of a blank one, and use it in all four setters.

Add TestProfileScenarioFlagWriteInheritsBaseConfig covering the bool/string setters and SetScenarioExtensions.