### PR TITLE
bugfix(server): make ClearServiceStats actually clear persisted and in-memory stats

### DIFF
--- a/internal/data/db/service_stat.go
+++ b/internal/data/db/service_stat.go
@@ -306,6 +306,16 @@ func (ss *StatsStore) ClearAll() error {
 	return ss.db.Exec("DELETE FROM service_stats").Error
 }
 
+// ClearService removes persisted stats for a single provider:model. No error
+// if no rows matched (the service simply had no recorded stats).
+func (ss *StatsStore) ClearService(provider, model string) error {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	return ss.db.Where("provider = ? AND model = ?", provider, model).
+		Delete(&ServiceStatsRecord{}).Error
+}
+
 // toServiceStats converts a ServiceStatsRecord to ServiceStats.
 func (r *ServiceStatsRecord) toServiceStats() loadbalance.ServiceStats {
 	return loadbalance.ServiceStats{

--- a/internal/data/db/service_stat_test.go
+++ b/internal/data/db/service_stat_test.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// newTestStatsStore creates a stats store backed by a temp database.
+func newTestStatsStore(t *testing.T) *StatsStore {
+	t.Helper()
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager error: %v", err)
+	}
+	t.Cleanup(func() { sm.Close() })
+	return sm.Stats()
+}
+
+// TestStatsStore_ClearService verifies ClearService removes only the targeted
+// provider:model, leaving other services' persisted stats intact. It fills the
+// store with a couple of services, clears one, and asserts the survivor stays.
+func TestStatsStore_ClearService(t *testing.T) {
+	store := newTestStatsStore(t)
+
+	// Seed two services.
+	svcA := &loadbalance.Service{Provider: "prov-a", Model: "m"}
+	svcB := &loadbalance.Service{Provider: "prov-b", Model: "m"}
+	if _, err := store.RecordUsage(svcA, 10, 20); err != nil {
+		t.Fatalf("RecordUsage A: %v", err)
+	}
+	if _, err := store.RecordUsage(svcB, 30, 40); err != nil {
+		t.Fatalf("RecordUsage B: %v", err)
+	}
+
+	// Clear only A.
+	if err := store.ClearService("prov-a", "m"); err != nil {
+		t.Fatalf("ClearService: %v", err)
+	}
+
+	// A is gone.
+	if _, ok := store.Get("prov-a", "m"); ok {
+		t.Fatal("prov-a/m should be cleared")
+	}
+	// B survives.
+	gotB, ok := store.Get("prov-b", "m")
+	if !ok {
+		t.Fatal("prov-b/m should still exist (ClearService must be scoped)")
+	}
+	if gotB.RequestCount != 1 {
+		t.Errorf("prov-b/m RequestCount = %d, want 1 (untouched)", gotB.RequestCount)
+	}
+
+	// Clearing a non-existent service is a no-op (no error).
+	if err := store.ClearService("never", "existed"); err != nil {
+		t.Fatalf("ClearService on missing row should be a no-op, got: %v", err)
+	}
+}

--- a/internal/server/load_balance.go
+++ b/internal/server/load_balance.go
@@ -220,12 +220,47 @@ func (lb *LoadBalancer) GetAllServiceStats() map[string]*loadbalance.ServiceStat
 	return result
 }
 
-// ClearServiceStats clears statistics for a specific service
+// ClearServiceStats clears statistics for a specific provider:model — both
+// the persisted stats store and the in-memory ServiceStats on every active
+// rule service that matches (stats are global per provider:model, shared
+// across rules). The previous implementation only touched an internal map
+// that was never populated, so the clear was a no-op.
 func (lb *LoadBalancer) ClearServiceStats(provider, model string) {
-	// Clear from internal stats map
-	serviceID := fmt.Sprintf("%s:%s", provider, model)
-	if stats, exists := lb.stats[serviceID]; exists {
-		stats.ResetWindow()
+	// 1. Persisted stats store.
+	if lb.config != nil {
+		if sm := lb.config.StoreManager(); sm != nil {
+			if store := sm.Stats(); store != nil {
+				if err := store.ClearService(provider, model); err != nil {
+					logrus.Warnf("[load_balancer] failed to clear persisted stats for %s/%s: %v", provider, model, err)
+				}
+			}
+		}
+	}
+
+	// 2. In-memory ServiceStats on matching active services across all rules.
+	// Reset the same field set as ClearAllStats (cumulative + window), so a
+	// single-service clear matches the all-clear scope service-by-service.
+	if lb.config != nil {
+		rules := lb.config.GetRequestConfigs()
+		for ruleIdx, rule := range rules {
+			if !rule.Active {
+				continue
+			}
+			for i := range rule.Services {
+				svc := rule.Services[i]
+				if svc.Active && svc.Provider == provider && svc.Model == model {
+					stats := &svc.Stats
+					stats.RequestCount = 0
+					stats.WindowRequestCount = 0
+					stats.WindowTokensConsumed = 0
+					stats.WindowInputTokens = 0
+					stats.WindowOutputTokens = 0
+					stats.WindowStart = time.Now()
+					stats.LastUsed = time.Time{}
+				}
+			}
+			rules[ruleIdx] = rule
+		}
 	}
 }
 


### PR DESCRIPTION
ClearServiceStats only touched an internal lb.stats map that is never populated, so the "clear stats for one service" endpoint was a silent no-op — neither the SQLite stats store nor the in-memory ServiceStats were cleared. Only ClearAllStats worked end-to-end.

Add StatsStore.ClearService(provider, model) (DELETE WHERE provider/model, the table's primary key) and rewrite LoadBalancer.ClearServiceStats to clear both the persisted store and the in-memory ServiceStats on every active rule service matching that provider:model (stats are global per provider:model, shared across rules). The in-memory reset matches ClearAllStats's field scope (cumulative + window), so single-service and all-service clear behave consistently service-by-service.