### PR TITLE
feat(config): support order by ":free" for openrouter provider.

### DIFF
--- a/frontend/src/components/model-select/CustomModelCard.tsx
+++ b/frontend/src/components/model-select/CustomModelCard.tsx
@@ -103,21 +103,26 @@ export default function CustomModelCard({
                     {loading ? (
                         <CircularProgress size={20} />
                     ) : (
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                fontWeight: 500,
-                                fontSize: '0.8rem',
-                                lineHeight: 1.2,
-                                wordBreak: 'break-word',
-                                textAlign: 'center',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                            }}
-                        >
-                            {model}
-                        </Typography>
+                        <Tooltip title={model} arrow disableInteractive>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    fontWeight: 500,
+                                    fontSize: '0.8rem',
+                                    lineHeight: 1.2,
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: 3,
+                                    WebkitBoxOrient: 'vertical',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    wordBreak: 'break-word',
+                                    textAlign: 'center',
+                                    maxWidth: '100%',
+                                }}
+                            >
+                                {model}
+                            </Typography>
+                        </Tooltip>
                     )}
                 </Box>
 

--- a/frontend/src/components/model-select/ModelCard.tsx
+++ b/frontend/src/components/model-select/ModelCard.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle } from '@/components/icons';
-import { Box, Card, CardContent, CircularProgress, Typography } from '@mui/material';
+import { Box, Card, CardContent, CircularProgress, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 import { getModelCardActiveColor, getModelCardStateStyles, modelCardTransition } from './cardStyles';
@@ -92,22 +92,26 @@ export default function ModelCard({
                     <CircularProgress size={20} />
                 ) : (
                     <>
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                fontWeight: 500,
-                                fontSize: '0.8rem',
-                                lineHeight: 1.2,
-                                wordBreak: 'break-word',
-                                textAlign: 'center',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                width: '100%',
-                            }}
-                        >
-                            {model}
-                        </Typography>
+                        <Tooltip title={model} arrow disableInteractive>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    fontWeight: 500,
+                                    fontSize: '0.8rem',
+                                    lineHeight: 1.2,
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: 3,
+                                    WebkitBoxOrient: 'vertical',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    wordBreak: 'break-word',
+                                    textAlign: 'center',
+                                    width: '100%',
+                                }}
+                            >
+                                {model}
+                            </Typography>
+                        </Tooltip>
                         {description && (
                             <Typography
                                 variant="caption"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -216,12 +216,8 @@ export const api = {
                 params: {path: {uuid}}
             });
             const body = response.data;
-            if (body?.success && body?.data) {
-                // Sort models alphabetically by model name to reduce UI changes
-                body.data.models.sort((a: any, b: any) =>
-                    a.localeCompare(b)
-                );
-            }
+            // Model ordering is authoritative from the backend
+            // (config.SortProviderModels); do not re-sort here.
             return body;
         } catch (error: any) {
             return {success: false, error: error.message};
@@ -237,12 +233,8 @@ export const api = {
                 params: {path: {uuid}}
             });
             const body = response.data;
-            if (body?.success && body?.data) {
-                // Sort models alphabetically by model name to reduce UI changes
-                body.data.models.sort((a: any, b: any) =>
-                    a.localeCompare(b)
-                );
-            }
+            // Model ordering is authoritative from the backend
+            // (config.SortProviderModels); do not re-sort here.
             return body;
         } catch (error: any) {
             return {success: false, error: error.message};

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2032,11 +2032,9 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 	if lister != nil {
 		models, apiErr = lister.ListModels(ctx)
 		if apiErr == nil && len(models) > 0 {
-			// OpenRouter tags free models with a ":free" suffix. Promote them to
-			// the front of the list so they surface first in the model picker.
-			if isOpenRouterProvider(provider) {
-				sortOpenRouterFreeModelsFirst(models)
-			}
+			// Apply canonical ordering before persisting; the same sort is
+			// reapplied at the serving boundary so cached order is irrelevant.
+			SortProviderModels(provider, models)
 			return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
 		}
 		if client.IsModelsEndpointNotSupported(apiErr) {
@@ -2111,6 +2109,34 @@ func (c *Config) newModelLister(provider *typ.Provider) (client.ModelLister, fun
 	}
 }
 
+// SortProviderModels applies the canonical display ordering to a provider's
+// model list in place. It is the single source of truth for model ordering
+// served to clients — callers (fetch + serving boundaries) invoke it instead
+// of relying on the frontend to sort.
+//
+// Default: alphabetical by model id. OpenRouter additionally tags free models
+// with a ":free" suffix; those are promoted to the front, sorted alphabetically
+// among themselves and ahead of the paid models (which are also alphabetical).
+func SortProviderModels(provider *typ.Provider, models []string) {
+	if provider == nil || len(models) < 2 {
+		return
+	}
+	promoteFree := isOpenRouterProvider(provider)
+	slices.SortStableFunc(models, func(a, b string) int {
+		if promoteFree {
+			aFree := strings.HasSuffix(a, ":free")
+			bFree := strings.HasSuffix(b, ":free")
+			if aFree != bFree {
+				if aFree {
+					return -1
+				}
+				return 1
+			}
+		}
+		return strings.Compare(a, b)
+	})
+}
+
 // isOpenRouterProvider reports whether the provider routes to OpenRouter.
 // OpenRouter's canonical host is openrouter.ai; the base_url templates embed it
 // as https://openrouter.ai/api/v1 (OpenAI) and https://openrouter.ai/api (Anthropic).
@@ -2121,24 +2147,6 @@ func isOpenRouterProvider(provider *typ.Provider) bool {
 		}
 	}
 	return false
-}
-
-// sortOpenRouterFreeModelsFirst reorders models in place so that any id ending
-// in ":free" sorts before non-free ids, preserving the relative order within
-// each group (stable sort).
-func sortOpenRouterFreeModelsFirst(models []string) {
-	slices.SortStableFunc(models, func(a, b string) int {
-		aFree := strings.HasSuffix(a, ":free")
-		bFree := strings.HasSuffix(b, ":free")
-		switch {
-		case aFree && !bFree:
-			return -1
-		case !aFree && bFree:
-			return 1
-		default:
-			return 0
-		}
-	})
 }
 
 func (c *Config) GetModelManager() *data.ModelListManager {

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2021,47 +2021,22 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 	var models []string
 	var apiErr error
 
-	var lister client.ModelLister
-	if strings.Contains(strings.ToLower(strings.TrimSpace(provider.APIBase)), "api.deepseek.com") {
-		providerForModels := *provider
-		providerForModels.APIBase = "https://api.deepseek.com"
-		oClient, err := client.NewOpenAIClient(&providerForModels, "", typ.SessionID{})
-		if err == nil {
-			defer oClient.Close()
-			lister = oClient
-		}
+	lister, closer, err := c.newModelLister(provider)
+	if err != nil {
 		apiErr = err
-	} else {
-		switch provider.APIStyle {
-		case protocol.APIStyleAnthropic:
-			aClient, err := client.NewAnthropicClient(provider, "", typ.SessionID{})
-			if err == nil {
-				defer aClient.Close()
-				lister = aClient
-			}
-			apiErr = err
-		case protocol.APIStyleGoogle:
-			gClient, err := client.NewGoogleClient(provider, "", typ.SessionID{})
-			if err == nil {
-				defer gClient.Close()
-				lister = gClient
-			}
-			apiErr = err
-		case protocol.APIStyleOpenAI:
-			fallthrough
-		default:
-			oClient, err := client.NewOpenAIClient(provider, "", typ.SessionID{})
-			if err == nil {
-				defer oClient.Close()
-				lister = oClient
-			}
-			apiErr = err
-		}
+	}
+	if closer != nil {
+		defer closer()
 	}
 
 	if lister != nil {
 		models, apiErr = lister.ListModels(ctx)
 		if apiErr == nil && len(models) > 0 {
+			// OpenRouter tags free models with a ":free" suffix. Promote them to
+			// the front of the list so they surface first in the model picker.
+			if isOpenRouterProvider(provider) {
+				sortOpenRouterFreeModelsFirst(models)
+			}
 			return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
 		}
 		if client.IsModelsEndpointNotSupported(apiErr) {
@@ -2087,6 +2062,83 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 		return fmt.Errorf("failed to fetch models (API: %v, template fallback: not available)", apiErr)
 	}
 	return fmt.Errorf("failed to fetch models (template fallback: not available)")
+}
+
+// newModelLister builds the client used to list models for a provider.
+//
+// It returns a ModelLister, an optional closer the caller must defer, and any
+// construction error. Two special cases sit alongside the default APIStyle
+// dispatch:
+//
+//   - DeepSeek exposes its model list only on the bare host (no /v1 path), so
+//     we override APIBase to https://api.deepseek.com before constructing the
+//     OpenAI client.
+//
+// The closer is non-nil whenever the lister is, so the caller can defer it
+// without checking the lister separately.
+func (c *Config) newModelLister(provider *typ.Provider) (client.ModelLister, func() error, error) {
+	if strings.Contains(strings.ToLower(strings.TrimSpace(provider.APIBase)), "api.deepseek.com") {
+		providerForModels := *provider
+		providerForModels.APIBase = "https://api.deepseek.com"
+		oClient, err := client.NewOpenAIClient(&providerForModels, "", typ.SessionID{})
+		if err != nil {
+			return nil, nil, err
+		}
+		return oClient, oClient.Close, nil
+	}
+
+	switch provider.APIStyle {
+	case protocol.APIStyleAnthropic:
+		aClient, err := client.NewAnthropicClient(provider, "", typ.SessionID{})
+		if err != nil {
+			return nil, nil, err
+		}
+		return aClient, aClient.Close, nil
+	case protocol.APIStyleGoogle:
+		gClient, err := client.NewGoogleClient(provider, "", typ.SessionID{})
+		if err != nil {
+			return nil, nil, err
+		}
+		return gClient, gClient.Close, nil
+	case protocol.APIStyleOpenAI:
+		fallthrough
+	default:
+		oClient, err := client.NewOpenAIClient(provider, "", typ.SessionID{})
+		if err != nil {
+			return nil, nil, err
+		}
+		return oClient, oClient.Close, nil
+	}
+}
+
+// isOpenRouterProvider reports whether the provider routes to OpenRouter.
+// OpenRouter's canonical host is openrouter.ai; the base_url templates embed it
+// as https://openrouter.ai/api/v1 (OpenAI) and https://openrouter.ai/api (Anthropic).
+func isOpenRouterProvider(provider *typ.Provider) bool {
+	for _, base := range []string{provider.APIBase, provider.APIBaseOpenAI, provider.APIBaseAnthropic} {
+		if strings.Contains(strings.ToLower(base), "openrouter.ai") {
+			return true
+		}
+	}
+	return false
+}
+
+// sortOpenRouterFreeModelsFirst reorders models in place so that any id ending
+// in ":free" sorts before non-free ids, preserving the relative order within
+// each group (stable sort).
+func sortOpenRouterFreeModelsFirst(models []string) {
+	slices.SortStableFunc(models, func(a, b string) int {
+		aFree := strings.HasSuffix(a, ":free")
+		bFree := strings.HasSuffix(b, ":free")
+		switch {
+		case aFree && !bFree:
+			return -1
+		case !aFree && bFree:
+			return 1
+		default:
+			return 0
+		}
+	})
 }
 
 func (c *Config) GetModelManager() *data.ModelListManager {

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -419,6 +419,11 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 	modelManager := h.config.GetModelManager()
 	models := modelManager.GetModels(uid)
 
+	// Apply canonical ordering at the serving boundary (see GetProviderModelsByUUID).
+	if p, err := h.config.GetProviderByUUID(uid); err == nil {
+		config.SortProviderModels(p, models)
+	}
+
 	logrus.WithFields(logrus.Fields{
 		"action":       obs.ActionFetchModels,
 		"success":      true,
@@ -504,6 +509,13 @@ func (h *Handler) GetProviderModelsByUUID(c *gin.Context) {
 				}
 			}
 		}
+	}
+
+	// Apply canonical ordering at the serving boundary so the response order
+	// is authoritative regardless of cache source. The frontend relies on this
+	// order and no longer sorts client-side.
+	if p, err := h.config.GetProviderByUUID(uid); err == nil {
+		config.SortProviderModels(p, models)
 	}
 
 	providerModels := ProviderModelInfo{


### PR DESCRIPTION
- Backend: add sort for model list, and specially sort for openrouter ":free"
- Frontend: optimize model card for long model name (via ellipsis)
