### PR TITLE
perf(codex): let codex client own responses adaptation

### DIFF
--- a/internal/protocol/ops/request_openai_codex.go
+++ b/internal/protocol/ops/request_openai_codex.go
@@ -12,13 +12,6 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// ApplyCodexTransform applies Codex-specific transformations to a Responses API request.
-// This is a backward-compatible wrapper for the server-level call.
-// Deprecated: Use ApplyCodexResponsesTransform with TransformContext instead.
-func ApplyCodexTransform(anthropicReq *anthropic.BetaMessageNewParams, responsesReq *responses.ResponseNewParams) *responses.ResponseNewParams {
-	return ApplyCodexResponsesTransform(responsesReq, anthropicReq)
-}
-
 // ApplyCodexResponsesTransform applies Codex-specific transformations to a Responses API request.
 // This is called from VendorTransform for Codex backend providers.
 //

--- a/internal/protocol/test/provider_model_e2e_test.go
+++ b/internal/protocol/test/provider_model_e2e_test.go
@@ -27,7 +27,7 @@ func TestProviderModels_DeepSeek_AnthropicV1(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicV1),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-		transform.NewVendorTransform("api.deepseek.com"),
+		transform.NewVendorTransform(),
 	})
 
 	tests := []struct {
@@ -75,7 +75,7 @@ func TestProviderModels_DeepSeek_AnthropicV1_WithThinking(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicV1),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-		transform.NewVendorTransform("api.deepseek.com"),
+		transform.NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -108,7 +108,7 @@ func TestProviderModels_DeepSeek_AnthropicV1_WithThinking_Disable(t *testing.T) 
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicV1),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-		transform.NewVendorTransform("api.deepseek.com"),
+		transform.NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -147,7 +147,7 @@ func TestProviderModels_DeepSeek_OpenAIChat(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeOpenAIChat),
 		transform.NewConsistencyTransform(protocol.TypeOpenAIChat),
-		transform.NewVendorTransform("api.deepseek.com"),
+		transform.NewVendorTransform(),
 	})
 
 	tests := []struct {
@@ -189,7 +189,7 @@ func TestProviderModels_Anthropic_Official(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicV1),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-		transform.NewVendorTransform("api.anthropic.com"),
+		transform.NewVendorTransform(),
 	})
 
 	tests := []struct {
@@ -254,7 +254,7 @@ func TestProviderModels_Anthropic_Beta(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicBeta),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicBeta),
-		transform.NewVendorTransform("api.anthropic.com"),
+		transform.NewVendorTransform(),
 	})
 
 	tests := []struct {
@@ -303,7 +303,7 @@ func TestProviderModels_OpenAI_Official(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeOpenAIChat),
 		transform.NewConsistencyTransform(protocol.TypeOpenAIChat),
-		transform.NewVendorTransform("api.openai.com"),
+		transform.NewVendorTransform(),
 	})
 
 	tests := []struct {
@@ -349,7 +349,7 @@ func TestProviderModels_CrossProtocol_OpenAI_To_Anthropic(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicBeta),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicBeta),
-		transform.NewVendorTransform("api.anthropic.com"),
+		transform.NewVendorTransform(),
 	})
 
 	req := &openai.ChatCompletionNewParams{
@@ -379,7 +379,7 @@ func TestProviderModels_CrossProtocol_Anthropic_To_OpenAI(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeOpenAIChat),
 		transform.NewConsistencyTransform(protocol.TypeOpenAIChat),
-		transform.NewVendorTransform("api.openai.com"),
+		transform.NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -424,7 +424,7 @@ func TestProviderModels_StreamingBehavior(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			var req interface{}
@@ -479,7 +479,7 @@ func TestProviderModels_ErrorMessageHandling(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			var req interface{}
@@ -516,7 +516,7 @@ func TestProviderModels_MultiTurnConversation(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicV1),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-		transform.NewVendorTransform("api.anthropic.com"),
+		transform.NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -582,7 +582,7 @@ func TestProviderModels_ToolUseSupport(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			var req interface{}
@@ -638,7 +638,7 @@ func TestProviderModels_MaxTokensHandling(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			var req interface{}
@@ -698,7 +698,7 @@ func TestProviderModels_SystemPromptHandling(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			var req interface{}
@@ -768,7 +768,7 @@ func TestProviderModels_ReasoningModels(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			req := &openai.ChatCompletionNewParams{
@@ -813,7 +813,7 @@ func TestProviderModels_AdaptiveThinkingModels(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(protocol.TypeAnthropicV1),
 				transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-				transform.NewVendorTransform("api.anthropic.com"),
+				transform.NewVendorTransform(),
 			})
 
 			req := &anthropic.MessageNewParams{
@@ -863,7 +863,7 @@ func TestProviderModels_EnabledThinkingModels(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(protocol.TypeAnthropicV1),
 				transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-				transform.NewVendorTransform("api.anthropic.com"),
+				transform.NewVendorTransform(),
 			})
 
 			req := &anthropic.MessageNewParams{
@@ -914,7 +914,7 @@ func TestProviderModels_TransformChainOrdering(t *testing.T) {
 			chain := transform.NewTransformChain([]transform.Transform{
 				transform.NewBaseTransform(tt.targetType),
 				transform.NewConsistencyTransform(tt.targetType),
-				transform.NewVendorTransform(tt.provider),
+				transform.NewVendorTransform(),
 			})
 
 			var req interface{}
@@ -954,7 +954,7 @@ func TestProviderModels_ContextPreservation(t *testing.T) {
 	chain := transform.NewTransformChain([]transform.Transform{
 		transform.NewBaseTransform(protocol.TypeAnthropicV1),
 		transform.NewConsistencyTransform(protocol.TypeAnthropicV1),
-		transform.NewVendorTransform("api.anthropic.com"),
+		transform.NewVendorTransform(),
 	})
 
 	originalReq := &anthropic.MessageNewParams{
@@ -973,8 +973,9 @@ func TestProviderModels_ContextPreservation(t *testing.T) {
 	// Original request should be preserved
 	assert.Equal(t, originalReq, result.OriginalRequest, "original request should be preserved in context")
 
-	// Provider URL should be preserved
-	assert.Equal(t, "api.anthropic.com", result.ProviderURL, "provider URL should be preserved")
+	// Provider should be preserved
+	require.NotNil(t, result.Provider, "provider should be preserved")
+	assert.Equal(t, "api.anthropic.com", result.Provider.APIBase, "provider API base should be preserved")
 
 	// Streaming flag should be preserved
 	assert.True(t, result.IsStreaming, "streaming flag should be preserved")
@@ -992,7 +993,7 @@ func newFullChainContext(request interface{}, providerURL string, extra map[stri
 	return &transform.TransformContext{
 		Request:         request,
 		OriginalRequest: request,
-		ProviderURL:     providerURL,
+		Provider:        &typ.Provider{APIBase: providerURL},
 		IsStreaming:     true,
 		ScenarioFlags:   &typ.ScenarioFlags{},
 		TransformSteps:  []string{},

--- a/internal/protocol/transform/chain.go
+++ b/internal/protocol/transform/chain.go
@@ -48,6 +48,22 @@ func WithProviderURL(url string) TransformOption {
 	return func(ctx *TransformContext) { ctx.ProviderURL = url }
 }
 
+// WithProvider sets the provider as the canonical upstream/provider context and
+// fills legacy derived fields used by older transforms.
+func WithProvider(provider *typ.Provider) TransformOption {
+	return func(ctx *TransformContext) {
+		ctx.Provider = provider
+		if provider == nil {
+			return
+		}
+		ctx.ProviderURL = provider.APIBase
+		if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
+			ctx.ProviderType = string(provider.OAuthDetail.GetIssuer())
+			ctx.Config.UserID = provider.OAuthDetail.UserID
+		}
+	}
+}
+
 // WithIssuer sets the provider type (e.g., "claude_code", "codex") in the transform context.
 func WithIssuer(issuer string) TransformOption {
 	return func(ctx *TransformContext) { ctx.ProviderType = issuer }
@@ -150,6 +166,11 @@ type TransformContext struct {
 	// Config holds structured, type-safe configuration for the transform chain.
 	Config TransformConfig
 
+	// Provider is the canonical provider configuration for transforms that need
+	// provider-aware behavior. ProviderURL and ProviderType are legacy derived
+	// fields kept for compatibility with existing transforms and tests.
+	Provider *typ.Provider
+
 	// Extra allows transforms to pass arbitrary data through the chain
 	Extra map[string]interface{}
 }
@@ -205,6 +226,7 @@ func (ctx *TransformContext) Release() {
 	ctx.Request = nil
 	ctx.OriginalRequest = nil
 	ctx.TransformSteps = nil
+	ctx.Provider = nil
 	ctx.Extra = nil
 }
 

--- a/internal/protocol/transform/chain.go
+++ b/internal/protocol/transform/chain.go
@@ -43,30 +43,17 @@ type TransformConfig struct {
 // TransformOption configures a TransformContext
 type TransformOption func(*TransformContext)
 
-// WithProviderURL sets the provider URL in the transform context.
-func WithProviderURL(url string) TransformOption {
-	return func(ctx *TransformContext) { ctx.ProviderURL = url }
-}
-
-// WithProvider sets the provider as the canonical upstream/provider context and
-// fills legacy derived fields used by older transforms.
+// WithProvider sets the provider as the canonical upstream/provider context.
 func WithProvider(provider *typ.Provider) TransformOption {
 	return func(ctx *TransformContext) {
 		ctx.Provider = provider
 		if provider == nil {
 			return
 		}
-		ctx.ProviderURL = provider.APIBase
 		if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
-			ctx.ProviderType = string(provider.OAuthDetail.GetIssuer())
 			ctx.Config.UserID = provider.OAuthDetail.UserID
 		}
 	}
-}
-
-// WithIssuer sets the provider type (e.g., "claude_code", "codex") in the transform context.
-func WithIssuer(issuer string) TransformOption {
-	return func(ctx *TransformContext) { ctx.ProviderType = issuer }
 }
 
 // WithScenarioFlags sets the scenario flags in the transform context.
@@ -136,13 +123,6 @@ type TransformContext struct {
 	// Use SetRequest[T]() to update — only types satisfying RequestUnionConstraint are accepted.
 	Request interface{}
 
-	// ProviderURL identifies the provider (e.g., "api.deepseek.com")
-	ProviderURL string
-
-	// ProviderType identifies the OAuth provider type (e.g., "claude_code", "codex")
-	// This is used for provider-specific model filtering
-	ProviderType string
-
 	// ScenarioFlags contains configuration flags for the scenario
 	ScenarioFlags *typ.ScenarioFlags
 
@@ -167,8 +147,7 @@ type TransformContext struct {
 	Config TransformConfig
 
 	// Provider is the canonical provider configuration for transforms that need
-	// provider-aware behavior. ProviderURL and ProviderType are legacy derived
-	// fields kept for compatibility with existing transforms and tests.
+	// provider-aware behavior.
 	Provider *typ.Provider
 
 	// Extra allows transforms to pass arbitrary data through the chain
@@ -182,7 +161,7 @@ type TransformContext struct {
 // Example:
 //
 //	ctx := transform.NewTransformContext(&anthropicReq,
-//	    transform.WithProviderURL("api.deepseek.com"),
+//	    transform.WithProvider(provider),
 //	    transform.WithStreaming(true),
 //	)
 func NewTransformContext[T RequestUnionConstraint](request T, opts ...TransformOption) *TransformContext {

--- a/internal/protocol/transform/chain_test.go
+++ b/internal/protocol/transform/chain_test.go
@@ -167,19 +167,7 @@ func TestTransformChain_ContextPreservation(t *testing.T) {
 		wantEmptySteps bool
 	}{
 		{
-			name: "ProviderURL preserved",
-			setupCtx: func() *TransformContext {
-				return &TransformContext{
-					Request:     &openai.ChatCompletionNewParams{},
-					ProviderURL: "api.deepseek.com",
-				}
-			},
-			verifyCtx: func(t *testing.T, result *TransformContext) {
-				assert.Equal(t, "api.deepseek.com", result.ProviderURL)
-			},
-		},
-		{
-			name: "Provider option populates canonical and derived provider context",
+			name: "Provider option preserves canonical provider context",
 			setupCtx: func() *TransformContext {
 				return NewTransformContext(
 					&openai.ChatCompletionNewParams{},
@@ -195,8 +183,8 @@ func TestTransformChain_ContextPreservation(t *testing.T) {
 			},
 			verifyCtx: func(t *testing.T, result *TransformContext) {
 				require.NotNil(t, result.Provider)
-				assert.Equal(t, "https://chatgpt.com/backend-api", result.ProviderURL)
-				assert.Equal(t, string(ai.IssuerCodex), result.ProviderType)
+				assert.Equal(t, "https://chatgpt.com/backend-api", result.Provider.APIBase)
+				assert.True(t, result.Provider.IsCodexProvider())
 				assert.Equal(t, "user-123", result.Config.UserID)
 			},
 		},
@@ -303,13 +291,12 @@ func TestTransformChain_Length(t *testing.T) {
 // Integration tests with real transforms
 func TestTransformChain_Integration_RealTransforms(t *testing.T) {
 	baseTransform := NewBaseTransform(protocol.TypeOpenAIChat)
-	vendorTransform := NewVendorTransform("api.openai.com")
+	vendorTransform := NewVendorTransform()
 
 	chain := NewTransformChain([]Transform{baseTransform, vendorTransform})
 
 	ctx := &TransformContext{
 		Request:        newOpenAIRequest("gpt-4", 1024),
-		ProviderURL:    "api.openai.com",
 		ScenarioFlags:  &typ.ScenarioFlags{},
 		IsStreaming:    false,
 		TransformSteps: []string{},
@@ -356,7 +343,7 @@ func TestTransformChain_Integration_WithScenarioFlags(t *testing.T) {
 func TestTransformChain_Integration_FullChain(t *testing.T) {
 	baseTransform := NewBaseTransform(protocol.TypeOpenAIChat)
 	consistencyTransform := NewConsistencyTransform(protocol.TypeOpenAIChat)
-	vendorTransform := NewVendorTransform("api.openai.com")
+	vendorTransform := NewVendorTransform()
 
 	chain := NewTransformChain([]Transform{
 		baseTransform,
@@ -369,7 +356,6 @@ func TestTransformChain_Integration_FullChain(t *testing.T) {
 
 	ctx := &TransformContext{
 		Request:        req,
-		ProviderURL:    "api.openai.com",
 		IsStreaming:    false,
 		ScenarioFlags:  &typ.ScenarioFlags{},
 		TransformSteps: []string{},
@@ -388,7 +374,7 @@ func TestTransformChain_Integration_FullChain(t *testing.T) {
 func TestTransformChain_Integration_WithTools(t *testing.T) {
 	baseTransform := NewBaseTransform(protocol.TypeOpenAIChat)
 	consistencyTransform := NewConsistencyTransform(protocol.TypeOpenAIChat)
-	vendorTransform := NewVendorTransform("api.openai.com")
+	vendorTransform := NewVendorTransform()
 
 	chain := NewTransformChain([]Transform{baseTransform, consistencyTransform, vendorTransform})
 
@@ -408,7 +394,6 @@ func TestTransformChain_Integration_WithTools(t *testing.T) {
 
 	ctx := &TransformContext{
 		Request:        req,
-		ProviderURL:    "api.openai.com",
 		IsStreaming:    false,
 		ScenarioFlags:  &typ.ScenarioFlags{},
 		TransformSteps: []string{},
@@ -425,7 +410,7 @@ func TestTransformChain_Integration_WithTools(t *testing.T) {
 
 func TestTransformChain_Integration_ResponsesAPI(t *testing.T) {
 	baseTransform := NewBaseTransform(protocol.TypeOpenAIResponses)
-	vendorTransform := NewVendorTransform("api.openai.com")
+	vendorTransform := NewVendorTransform()
 
 	chain := NewTransformChain([]Transform{baseTransform, vendorTransform})
 
@@ -437,7 +422,6 @@ func TestTransformChain_Integration_ResponsesAPI(t *testing.T) {
 
 	ctx := &TransformContext{
 		Request:        &responsesReq,
-		ProviderURL:    "api.openai.com",
 		IsStreaming:    false,
 		ScenarioFlags:  &typ.ScenarioFlags{},
 		TransformSteps: []string{},

--- a/internal/protocol/transform/chain_test.go
+++ b/internal/protocol/transform/chain_test.go
@@ -11,6 +11,7 @@ import (
 	shared "github.com/openai/openai-go/v3/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -175,6 +176,28 @@ func TestTransformChain_ContextPreservation(t *testing.T) {
 			},
 			verifyCtx: func(t *testing.T, result *TransformContext) {
 				assert.Equal(t, "api.deepseek.com", result.ProviderURL)
+			},
+		},
+		{
+			name: "Provider option populates canonical and derived provider context",
+			setupCtx: func() *TransformContext {
+				return NewTransformContext(
+					&openai.ChatCompletionNewParams{},
+					WithProvider(&typ.Provider{
+						APIBase:  "https://chatgpt.com/backend-api",
+						AuthType: typ.AuthTypeOAuth,
+						OAuthDetail: &typ.OAuthDetail{
+							Issuer: ai.IssuerCodex,
+							UserID: "user-123",
+						},
+					}),
+				)
+			},
+			verifyCtx: func(t *testing.T, result *TransformContext) {
+				require.NotNil(t, result.Provider)
+				assert.Equal(t, "https://chatgpt.com/backend-api", result.ProviderURL)
+				assert.Equal(t, string(ai.IssuerCodex), result.ProviderType)
+				assert.Equal(t, "user-123", result.Config.UserID)
 			},
 		},
 		{

--- a/internal/protocol/transform/e2e_test.go
+++ b/internal/protocol/transform/e2e_test.go
@@ -81,7 +81,6 @@ func TestE2E_ProtocolConversions(t *testing.T) {
 
 				ctx := &TransformContext{
 					Request:     sourceReq.request,
-					ProviderURL: "api.example.com",
 					IsStreaming: false,
 				}
 
@@ -149,12 +148,11 @@ func TestE2E_FullChain(t *testing.T) {
 		chain := NewTransformChain([]Transform{
 			NewBaseTransform(protocol.TypeOpenAIChat),
 			NewConsistencyTransform(protocol.TypeOpenAIChat),
-			NewVendorTransform("api.openai.com"),
+			NewVendorTransform(),
 		})
 
 		ctx := &TransformContext{
 			Request:     sourceReq,
-			ProviderURL: "api.openai.com",
 			IsStreaming: false,
 		}
 
@@ -190,7 +188,6 @@ func TestE2E_FullChain(t *testing.T) {
 
 		ctx := &TransformContext{
 			Request:     sourceReq,
-			ProviderURL: "generativelanguage.googleapis.com",
 			IsStreaming: false,
 		}
 
@@ -226,12 +223,11 @@ func TestE2E_FullChain(t *testing.T) {
 		chain := NewTransformChain([]Transform{
 			NewBaseTransform(protocol.TypeOpenAIResponses),
 			NewConsistencyTransform(protocol.TypeOpenAIResponses),
-			NewVendorTransform("api.openai.com"),
+			NewVendorTransform(),
 		})
 
 		ctx := &TransformContext{
 			Request:     sourceReq,
-			ProviderURL: "api.openai.com",
 			IsStreaming: false,
 		}
 
@@ -267,7 +263,6 @@ func TestE2E_PointerTypeValidation(t *testing.T) {
 
 	ctx := &TransformContext{
 		Request:     valueReq, // Value type, not pointer
-		ProviderURL: "api.anthropic.com",
 		IsStreaming: false,
 	}
 
@@ -289,12 +284,11 @@ func TestE2E_TransformStepsRecorded(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeOpenAIChat),
 		NewConsistencyTransform(protocol.TypeOpenAIChat),
-		NewVendorTransform("api.openai.com"),
+		NewVendorTransform(),
 	})
 
 	ctx := &TransformContext{
 		Request:     sourceReq,
-		ProviderURL: "api.openai.com",
 		IsStreaming: false,
 	}
 

--- a/internal/protocol/transform/fullchain_test.go
+++ b/internal/protocol/transform/fullchain_test.go
@@ -17,7 +17,7 @@ func newFullChainContext(request interface{}, providerURL string, extra map[stri
 	return &TransformContext{
 		Request:         request,
 		OriginalRequest: request,
-		ProviderURL:     providerURL,
+		Provider:        &typ.Provider{APIBase: providerURL},
 		IsStreaming:     true,
 		ScenarioFlags:   &typ.ScenarioFlags{},
 		TransformSteps:  []string{},
@@ -41,7 +41,7 @@ func TestFullChain_AnthropicV1_To_AnthropicV1_Passthrough(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -95,7 +95,7 @@ func TestFullChain_AnthropicV1_Haiku_AdaptiveStripped(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -135,7 +135,7 @@ func TestFullChain_AnthropicBeta_To_AnthropicBeta_Passthrough(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicBeta),
 		NewConsistencyTransform(protocol.TypeAnthropicBeta),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := newBetaRequest("claude-sonnet-4-6-20250514", anthropic.BetaThinkingConfigParamUnion{
@@ -172,7 +172,7 @@ func TestFullChain_AnthropicBeta_To_Codex_AdaptiveThinking(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeOpenAIResponses),
 		NewConsistencyTransform(protocol.TypeOpenAIResponses),
-		NewVendorTransform(protocol.CodexAPIBase),
+		NewVendorTransform(),
 	})
 
 	req := newBetaRequest("claude-sonnet-4-6-20250514", anthropic.BetaThinkingConfigParamUnion{
@@ -199,7 +199,7 @@ func TestFullChain_AnthropicBeta_To_Codex_EnabledThinking(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeOpenAIResponses),
 		NewConsistencyTransform(protocol.TypeOpenAIResponses),
-		NewVendorTransform(protocol.CodexAPIBase),
+		NewVendorTransform(),
 	})
 
 	req := newBetaRequest("claude-sonnet-4-6-20250514", anthropic.BetaThinkingConfigParamUnion{
@@ -235,7 +235,7 @@ func TestFullChain_AnthropicV1_To_Responses_ProtocolConversion(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeOpenAIResponses),
 		NewConsistencyTransform(protocol.TypeOpenAIResponses),
-		NewVendorTransform(protocol.CodexAPIBase),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -273,7 +273,7 @@ func TestFullChain_AnthropicV1_NonAnthropicProvider_NoVendorTransform(t *testing
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.openai.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -311,7 +311,7 @@ func TestFullChain_AnthropicV1_MultiTurn_ThinkingBlocksFiltered(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -365,14 +365,14 @@ func TestFullChain_AnthropicV1_MultiTurn_ThinkingBlocksFiltered(t *testing.T) {
 }
 
 // =============================================
-// Full Chain: Anthropic v1 → Anthropic v1 (Claude AI provider URL)
+// Full Chain: Anthropic v1 → Anthropic v1 (Claude AI provider)
 // =============================================
 
-func TestFullChain_AnthropicV1_ClaudeAI_ProviderURL(t *testing.T) {
+func TestFullChain_AnthropicV1_ClaudeAI_Provider(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("https://claude.ai/api/v1/messages"),
+		NewVendorTransform(),
 	})
 
 	req := newAnthropicV1Request("claude-opus-4-6-20250514", 16384)
@@ -399,7 +399,7 @@ func TestFullChain_AnthropicV1_EmptyModel_ValidationFails(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -426,7 +426,7 @@ func TestFullChain_AnthropicV1_ExistingBillingHeader_Replaced(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -466,7 +466,7 @@ func TestFullChain_AnthropicV1_Haiku_ExplicitThinkingPreserved(t *testing.T) {
 	chain := NewTransformChain([]Transform{
 		NewBaseTransform(protocol.TypeAnthropicV1),
 		NewConsistencyTransform(protocol.TypeAnthropicV1),
-		NewVendorTransform("api.anthropic.com"),
+		NewVendorTransform(),
 	})
 
 	req := &anthropic.MessageNewParams{
@@ -511,7 +511,7 @@ func TestFullChain_AnthropicV1_SupportedModels(t *testing.T) {
 			chain := NewTransformChain([]Transform{
 				NewBaseTransform(protocol.TypeAnthropicV1),
 				NewConsistencyTransform(protocol.TypeAnthropicV1),
-				NewVendorTransform("api.anthropic.com"),
+				NewVendorTransform(),
 			})
 
 			req := &anthropic.MessageNewParams{
@@ -560,7 +560,7 @@ func TestFullChain_AnthropicV1_UnsupportedModels(t *testing.T) {
 			chain := NewTransformChain([]Transform{
 				NewBaseTransform(protocol.TypeAnthropicV1),
 				NewConsistencyTransform(protocol.TypeAnthropicV1),
-				NewVendorTransform("api.anthropic.com"),
+				NewVendorTransform(),
 			})
 
 			req := &anthropic.MessageNewParams{
@@ -630,7 +630,7 @@ func TestFullChain_Steps_Order(t *testing.T) {
 			chain := NewTransformChain([]Transform{
 				NewBaseTransform(tt.targetType),
 				NewConsistencyTransform(tt.targetType),
-				NewVendorTransform(tt.provider),
+				NewVendorTransform(),
 			})
 
 			var req interface{}

--- a/internal/protocol/transform/fullchain_test.go
+++ b/internal/protocol/transform/fullchain_test.go
@@ -189,10 +189,9 @@ func TestFullChain_AnthropicBeta_To_Codex_AdaptiveThinking(t *testing.T) {
 	resp, ok := result.Request.(*responses.ResponseNewParams)
 	require.True(t, ok, "expected *responses.ResponseNewParams, got %T", result.Request)
 
-	// Codex sets store=false and includes reasoning.encrypted_content
-	require.Len(t, resp.Include, 1)
-	assert.Equal(t, responses.ResponseIncludable("reasoning.encrypted_content"), resp.Include[0],
-		"Codex must include reasoning.encrypted_content")
+	// Codex backend defaults are applied by the Codex client, not by the
+	// protocol transform chain.
+	assert.Empty(t, resp.Include)
 }
 
 func TestFullChain_AnthropicBeta_To_Codex_EnabledThinking(t *testing.T) {
@@ -216,10 +215,9 @@ func TestFullChain_AnthropicBeta_To_Codex_EnabledThinking(t *testing.T) {
 	resp, ok := result.Request.(*responses.ResponseNewParams)
 	require.True(t, ok)
 
-	// Budget 10000 → effort "medium" per convertBudgetToEffort
-	// Reasoning config should be set
-	require.Len(t, resp.Include, 1)
-	assert.Equal(t, responses.ResponseIncludable("reasoning.encrypted_content"), resp.Include[0])
+	// Codex backend defaults are applied by the Codex client, not by the
+	// protocol transform chain.
+	assert.Empty(t, resp.Include)
 
 	// Model preserved through the chain
 	assert.Contains(t, string(resp.Model), "claude-sonnet-4-6")

--- a/internal/protocol/transform/vendor.go
+++ b/internal/protocol/transform/vendor.go
@@ -12,24 +12,24 @@ import (
 
 // VendorTransform applies provider-specific request adjustments. Per-shape
 // dispatch is a flat strings.Contains chain — uniform across all request
-// shapes so new vendors land in one place per shape.
-type VendorTransform struct {
-	ProviderURL string
-}
+// shapes so new vendors land in one place per shape. Provider data is read from
+// TransformContext so this transform remains stateless and reusable.
+type VendorTransform struct{}
 
-// NewVendorTransform creates a new vendor transform for the given provider URL.
-func NewVendorTransform(providerURL string) *VendorTransform {
-	return &VendorTransform{ProviderURL: providerURL}
+// NewVendorTransform creates a new vendor transform.
+func NewVendorTransform() *VendorTransform {
+	return &VendorTransform{}
 }
 
 func (t *VendorTransform) Name() string { return "vendor_adjust" }
 
 // Apply dispatches to the per-shape vendor logic. Unknown shapes are a no-op.
 func (t *VendorTransform) Apply(ctx *TransformContext) error {
-	url := strings.ToLower(t.ProviderURL)
+	providerURL := t.providerURL(ctx)
+	url := strings.ToLower(providerURL)
 	switch req := ctx.Request.(type) {
 	case *openai.ChatCompletionNewParams:
-		ctx.Request = t.applyChat(ctx, req)
+		ctx.Request = t.applyChat(ctx, req, providerURL)
 	case *responses.ResponseNewParams:
 		ctx.Request = t.applyResponses(ctx, req)
 	case *anthropic.MessageNewParams:
@@ -40,12 +40,19 @@ func (t *VendorTransform) Apply(ctx *TransformContext) error {
 	return nil
 }
 
-func (t *VendorTransform) applyChat(ctx *TransformContext, req *openai.ChatCompletionNewParams) *openai.ChatCompletionNewParams {
+func (t *VendorTransform) providerURL(ctx *TransformContext) string {
+	if ctx != nil && ctx.Provider != nil {
+		return ctx.Provider.APIBase
+	}
+	return ""
+}
+
+func (t *VendorTransform) applyChat(ctx *TransformContext, req *openai.ChatCompletionNewParams, providerURL string) *openai.ChatCompletionNewParams {
 	config := ctx.Config.OpenAIConfig
 	if config == nil {
 		config = &protocol.OpenAIConfig{}
 	}
-	return ops.ApplyProviderTransforms(req, t.ProviderURL, string(req.Model), config)
+	return ops.ApplyProviderTransforms(req, providerURL, string(req.Model), config)
 }
 
 func (t *VendorTransform) applyResponses(ctx *TransformContext, req *responses.ResponseNewParams) *responses.ResponseNewParams {
@@ -53,7 +60,7 @@ func (t *VendorTransform) applyResponses(ctx *TransformContext, req *responses.R
 		return req
 	}
 	// MENTION: no need to do transform here, the codex client will handle this
-	//if t.ProviderURL == protocol.CodexAPIBase {
+	//if t.providerURL(ctx) == protocol.CodexAPIBase {
 	//	return ops.ApplyCodexResponsesTransform(req, ctx.OriginalRequest)
 	//}
 	return req

--- a/internal/protocol/transform/vendor.go
+++ b/internal/protocol/transform/vendor.go
@@ -52,9 +52,10 @@ func (t *VendorTransform) applyResponses(ctx *TransformContext, req *responses.R
 	if req == nil || req.Model == "" {
 		return req
 	}
-	if t.ProviderURL == protocol.CodexAPIBase {
-		return ops.ApplyCodexResponsesTransform(req, ctx.OriginalRequest)
-	}
+	// MENTION: no need to do transform here, the codex client will handle this
+	//if t.ProviderURL == protocol.CodexAPIBase {
+	//	return ops.ApplyCodexResponsesTransform(req, ctx.OriginalRequest)
+	//}
 	return req
 }
 

--- a/internal/protocol/transform/vendor_test.go
+++ b/internal/protocol/transform/vendor_test.go
@@ -10,20 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/ops"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+func withProvider(ctx *TransformContext, providerURL string) *TransformContext {
+	ctx.Provider = &typ.Provider{APIBase: providerURL}
+	return ctx
+}
+
 func TestNewVendorTransform(t *testing.T) {
-	vt := NewVendorTransform("api.openai.com")
+	vt := NewVendorTransform()
 	assert.Equal(t, "vendor_adjust", vt.Name())
-	assert.Equal(t, "api.openai.com", vt.ProviderURL)
 }
 
 func TestVendorTransform_Apply_Success(t *testing.T) {
-	vt := NewVendorTransform("api.openai.com")
+	vt := NewVendorTransform()
 
 	ctx := &TransformContext{
-		Request:     newOpenAIRequest("gpt-4", 1024),
-		ProviderURL: "api.openai.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  newOpenAIRequest("gpt-4", 1024),
 		Extra: map[string]interface{}{
 			"openaiConfig": &protocol.OpenAIConfig{HasThinking: false, ReasoningEffort: "none"},
 		},
@@ -36,12 +41,12 @@ func TestVendorTransform_Apply_Success(t *testing.T) {
 }
 
 func TestVendorTransform_Apply_MissingOpenAIConfig(t *testing.T) {
-	vt := NewVendorTransform("api.openai.com")
+	vt := NewVendorTransform()
 
 	ctx := &TransformContext{
-		Request:     newOpenAIRequest("gpt-4", 1024),
-		ProviderURL: "api.openai.com",
-		Extra:       map[string]interface{}{},
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  newOpenAIRequest("gpt-4", 1024),
+		Extra:    map[string]interface{}{},
 	}
 
 	err := vt.Apply(ctx)
@@ -53,12 +58,12 @@ func TestVendorTransform_Apply_MissingOpenAIConfig(t *testing.T) {
 // Transform in the chain) rather than returning a ValidationError.
 
 func TestVendorTransform_Apply_NilRequest(t *testing.T) {
-	vt := NewVendorTransform("api.openai.com")
+	vt := NewVendorTransform()
 
 	ctx := &TransformContext{
-		Request:     nil,
-		ProviderURL: "api.openai.com",
-		Extra:       map[string]interface{}{},
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  nil,
+		Extra:    map[string]interface{}{},
 	}
 
 	// Nil request is a silent no-op now (same contract as every other
@@ -82,12 +87,12 @@ func TestVendorTransform_Protocols(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform(tt.providerURL)
+			vt := NewVendorTransform()
 
 			ctx := &TransformContext{
-				Request:     newOpenAIRequest(tt.model, tt.maxTokens),
-				ProviderURL: tt.providerURL,
-				Extra:       map[string]interface{}{"openaiConfig": &protocol.OpenAIConfig{}},
+				Provider: &typ.Provider{APIBase: tt.providerURL},
+				Request:  newOpenAIRequest(tt.model, tt.maxTokens),
+				Extra:    map[string]interface{}{"openaiConfig": &protocol.OpenAIConfig{}},
 			}
 
 			err := vt.Apply(ctx)
@@ -96,7 +101,7 @@ func TestVendorTransform_Protocols(t *testing.T) {
 	}
 }
 
-// TestNormalizeProviderURL removed alongside the helper itself: vendor
+// TestNormalizeProvider removed alongside the helper itself: vendor
 // dispatch now uses strings.Contains on the raw lowercased URL, no
 // separate parse step.
 
@@ -111,11 +116,11 @@ func TestVendorTransform_TransformerIntegration(t *testing.T) {
 	assert.NotNil(t, transformed)
 
 	// Through VendorTransform
-	vt := NewVendorTransform(providerURL)
+	vt := NewVendorTransform()
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: providerURL,
-		Extra:       map[string]interface{}{"openaiConfig": config},
+		Provider: &typ.Provider{APIBase: providerURL},
+		Request:  req,
+		Extra:    map[string]interface{}{"openaiConfig": config},
 	}
 
 	err := vt.Apply(ctx)
@@ -155,7 +160,7 @@ func assertBetaMetadata(t *testing.T, result *anthropic.BetaMessageNewParams, de
 	assert.Contains(t, uid, "session_id", "user_id should contain session_id")
 }
 
-func TestVendorTransform_AnthropicV1_ProviderURLMatching(t *testing.T) {
+func TestVendorTransform_AnthropicV1_ProviderMatching(t *testing.T) {
 	tests := []struct {
 		name        string
 		providerURL string
@@ -172,7 +177,7 @@ func TestVendorTransform_AnthropicV1_ProviderURLMatching(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform(tt.providerURL)
+			vt := NewVendorTransform()
 			req := &anthropic.MessageNewParams{
 				Model:     anthropic.Model("claude-3-5-haiku-20241022"),
 				MaxTokens: 4096,
@@ -188,9 +193,9 @@ func TestVendorTransform_AnthropicV1_ProviderURLMatching(t *testing.T) {
 			extra := map[string]interface{}{"device": "test-device", "user_id": "test-account"}
 
 			ctx := &TransformContext{
-				Request:     req,
-				ProviderURL: tt.providerURL,
-				Extra:       extra,
+				Provider: &typ.Provider{APIBase: tt.providerURL},
+				Request:  req,
+				Extra:    extra,
 			}
 
 			err := vt.Apply(ctx)
@@ -213,7 +218,7 @@ func TestVendorTransform_AnthropicV1_ProviderURLMatching(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicV1_EmptyModel(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 	req := &anthropic.MessageNewParams{
 		Model:     "",
 		MaxTokens: 4096,
@@ -223,9 +228,9 @@ func TestVendorTransform_AnthropicV1_EmptyModel(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
-		Extra:       map[string]interface{}{"device": "test-device", "user_id": "test-account"},
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
+		Extra:    map[string]interface{}{"device": "test-device", "user_id": "test-account"},
 	}
 
 	err := vt.Apply(ctx)
@@ -248,7 +253,7 @@ func TestVendorTransform_AnthropicV1_SupportedModel_AdaptivePreserved(t *testing
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform("api.anthropic.com")
+			vt := NewVendorTransform()
 			req := &anthropic.MessageNewParams{
 				Model:     anthropic.Model(tt.model),
 				MaxTokens: 4096,
@@ -261,8 +266,8 @@ func TestVendorTransform_AnthropicV1_SupportedModel_AdaptivePreserved(t *testing
 			}
 
 			ctx := &TransformContext{
-				Request:     req,
-				ProviderURL: "api.anthropic.com",
+				Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+				Request:  req,
 				Extra: map[string]interface{}{
 					"device":  "test-device-id",
 					"user_id": "test-account-uuid",
@@ -304,7 +309,7 @@ func TestVendorTransform_AnthropicV1_UnsupportedModel_AdaptiveDisabled(t *testin
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform("api.anthropic.com")
+			vt := NewVendorTransform()
 			req := &anthropic.MessageNewParams{
 				Model:     anthropic.Model(tt.model),
 				MaxTokens: 4096,
@@ -317,8 +322,8 @@ func TestVendorTransform_AnthropicV1_UnsupportedModel_AdaptiveDisabled(t *testin
 			}
 
 			ctx := &TransformContext{
-				Request:     req,
-				ProviderURL: "api.anthropic.com",
+				Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+				Request:  req,
 				Extra: map[string]interface{}{
 					"device":  "test-device-id",
 					"user_id": "test-account-uuid",
@@ -349,7 +354,7 @@ func TestVendorTransform_AnthropicV1_UnsupportedModel_AdaptiveDisabled(t *testin
 }
 
 func TestVendorTransform_AnthropicV1_BillingHeaderPrepend(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	// Request with existing system prompt (no billing header)
 	req := &anthropic.MessageNewParams{
@@ -364,8 +369,8 @@ func TestVendorTransform_AnthropicV1_BillingHeaderPrepend(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -387,7 +392,7 @@ func TestVendorTransform_AnthropicV1_BillingHeaderPrepend(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicV1_BillingHeaderReplace(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	// Request with existing billing header in system prompt
 	req := &anthropic.MessageNewParams{
@@ -403,8 +408,8 @@ func TestVendorTransform_AnthropicV1_BillingHeaderReplace(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -425,7 +430,7 @@ func TestVendorTransform_AnthropicV1_BillingHeaderReplace(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicV1_NoSystemPrompt(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := &anthropic.MessageNewParams{
 		Model:     anthropic.Model("claude-3-5-haiku-20241022"),
@@ -437,8 +442,8 @@ func TestVendorTransform_AnthropicV1_NoSystemPrompt(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -457,7 +462,7 @@ func TestVendorTransform_AnthropicV1_NoSystemPrompt(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicV1_EnabledThinkingPreserved(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	// Enabled thinking should be preserved even on unsupported models
 	req := &anthropic.MessageNewParams{
@@ -472,8 +477,8 @@ func TestVendorTransform_AnthropicV1_EnabledThinkingPreserved(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -506,7 +511,7 @@ func newBetaRequest(model string, thinking anthropic.BetaThinkingConfigParamUnio
 	}
 }
 
-func TestVendorTransform_AnthropicBeta_ProviderURLMatching(t *testing.T) {
+func TestVendorTransform_AnthropicBeta_ProviderMatching(t *testing.T) {
 	tests := []struct {
 		name        string
 		providerURL string
@@ -519,7 +524,7 @@ func TestVendorTransform_AnthropicBeta_ProviderURLMatching(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform(tt.providerURL)
+			vt := NewVendorTransform()
 			req := newBetaRequest("claude-3-5-haiku-20241022", anthropic.BetaThinkingConfigParamUnion{
 				OfAdaptive: &anthropic.BetaThinkingConfigAdaptiveParam{},
 			})
@@ -528,9 +533,9 @@ func TestVendorTransform_AnthropicBeta_ProviderURLMatching(t *testing.T) {
 			extra := map[string]interface{}{"device": "test-device", "user_id": "test-account"}
 
 			ctx := &TransformContext{
-				Request:     req,
-				ProviderURL: tt.providerURL,
-				Extra:       extra,
+				Provider: &typ.Provider{APIBase: tt.providerURL},
+				Request:  req,
+				Extra:    extra,
 			}
 
 			err := vt.Apply(ctx)
@@ -551,7 +556,7 @@ func TestVendorTransform_AnthropicBeta_ProviderURLMatching(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicBeta_EmptyModel(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 	req := &anthropic.BetaMessageNewParams{
 		Model:     "",
 		MaxTokens: 4096,
@@ -561,9 +566,9 @@ func TestVendorTransform_AnthropicBeta_EmptyModel(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
-		Extra:       map[string]interface{}{"device": "test-device", "user_id": "test-account"},
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
+		Extra:    map[string]interface{}{"device": "test-device", "user_id": "test-account"},
 	}
 
 	err := vt.Apply(ctx)
@@ -585,14 +590,14 @@ func TestVendorTransform_AnthropicBeta_SupportedModel_AdaptivePreserved(t *testi
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform("api.anthropic.com")
+			vt := NewVendorTransform()
 			req := newBetaRequest(tt.model, anthropic.BetaThinkingConfigParamUnion{
 				OfAdaptive: &anthropic.BetaThinkingConfigAdaptiveParam{},
 			})
 
 			ctx := &TransformContext{
-				Request:     req,
-				ProviderURL: "api.anthropic.com",
+				Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+				Request:  req,
 				Extra: map[string]interface{}{
 					"device":  "test-device-id",
 					"user_id": "test-account-uuid",
@@ -632,14 +637,14 @@ func TestVendorTransform_AnthropicBeta_UnsupportedModel_AdaptiveDisabled(t *test
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vt := NewVendorTransform("api.anthropic.com")
+			vt := NewVendorTransform()
 			req := newBetaRequest(tt.model, anthropic.BetaThinkingConfigParamUnion{
 				OfAdaptive: &anthropic.BetaThinkingConfigAdaptiveParam{},
 			})
 
 			ctx := &TransformContext{
-				Request:     req,
-				ProviderURL: "api.anthropic.com",
+				Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+				Request:  req,
 				Extra: map[string]interface{}{
 					"device":  "test-device-id",
 					"user_id": "test-account-uuid",
@@ -662,7 +667,7 @@ func TestVendorTransform_AnthropicBeta_UnsupportedModel_AdaptiveDisabled(t *test
 }
 
 func TestVendorTransform_AnthropicBeta_BillingHeaderPrepend(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := &anthropic.BetaMessageNewParams{
 		Model:     anthropic.Model("claude-3-5-haiku-20241022"),
@@ -676,8 +681,8 @@ func TestVendorTransform_AnthropicBeta_BillingHeaderPrepend(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -696,7 +701,7 @@ func TestVendorTransform_AnthropicBeta_BillingHeaderPrepend(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicBeta_BillingHeaderReplace(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := &anthropic.BetaMessageNewParams{
 		Model:     anthropic.Model("claude-3-5-haiku-20241022"),
@@ -711,8 +716,8 @@ func TestVendorTransform_AnthropicBeta_BillingHeaderReplace(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -732,7 +737,7 @@ func TestVendorTransform_AnthropicBeta_BillingHeaderReplace(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicBeta_NoSystemPrompt(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := &anthropic.BetaMessageNewParams{
 		Model:     anthropic.Model("claude-3-5-haiku-20241022"),
@@ -743,8 +748,8 @@ func TestVendorTransform_AnthropicBeta_NoSystemPrompt(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -762,15 +767,15 @@ func TestVendorTransform_AnthropicBeta_NoSystemPrompt(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicBeta_EnabledThinkingPreserved(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := newBetaRequest("claude-3-5-haiku-20241022", anthropic.BetaThinkingConfigParamUnion{
 		OfEnabled: &anthropic.BetaThinkingConfigEnabledParam{},
 	})
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -788,7 +793,7 @@ func TestVendorTransform_AnthropicBeta_EnabledThinkingPreserved(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicBeta_ThinkingBlocksFiltered(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	// Assistant message with thinking + text blocks
 	req := &anthropic.BetaMessageNewParams{
@@ -808,8 +813,8 @@ func TestVendorTransform_AnthropicBeta_ThinkingBlocksFiltered(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",
@@ -846,15 +851,15 @@ func TestVendorTransform_AnthropicBeta_ThinkingBlocksFiltered(t *testing.T) {
 
 func TestVendorTransform_AnthropicBeta_FullChain(t *testing.T) {
 	// End-to-end test: model transform + metadata transform together
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := newBetaRequest("claude-3-5-haiku-20241022", anthropic.BetaThinkingConfigParamUnion{
 		OfAdaptive: &anthropic.BetaThinkingConfigAdaptiveParam{},
 	})
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":   "my-device-abc",
 			"user_id":  "my-account-uuid",
@@ -888,7 +893,7 @@ func TestVendorTransform_AnthropicBeta_FullChain(t *testing.T) {
 }
 
 func TestVendorTransform_AnthropicV1_ThinkingBlocksFiltered(t *testing.T) {
-	vt := NewVendorTransform("api.anthropic.com")
+	vt := NewVendorTransform()
 
 	req := &anthropic.MessageNewParams{
 		Model:     anthropic.Model("claude-3-5-haiku-20241022"),
@@ -907,8 +912,8 @@ func TestVendorTransform_AnthropicV1_ThinkingBlocksFiltered(t *testing.T) {
 	}
 
 	ctx := &TransformContext{
-		Request:     req,
-		ProviderURL: "api.anthropic.com",
+		Provider: &typ.Provider{APIBase: "api.anthropic.com"},
+		Request:  req,
 		Extra: map[string]interface{}{
 			"device":  "device-id",
 			"user_id": "account-uuid",

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -17,7 +17,7 @@ func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.
 
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
-	chain, err := ph.buildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
+	chain, err := ph.buildTransformChain(c, target, scenarioType, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.
 func (ph *ProtocolHandler) TransformAnthropicV1(c *gin.Context, req *protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
-	chain, err := ph.buildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
+	chain, err := ph.buildTransformChain(c, target, scenarioType, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (ph *ProtocolHandler) TransformAnthropicV1(c *gin.Context, req *protocol.An
 func (ph *ProtocolHandler) TransformOpenAIChat(c *gin.Context, req *protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
-	chain, err := ph.buildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
+	chain, err := ph.buildTransformChain(c, target, scenarioType, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (ph *ProtocolHandler) TransformOpenAIChat(c *gin.Context, req *protocol.Ope
 func (ph *ProtocolHandler) TransformOpenAIResponses(c *gin.Context, req *protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
-	chain, err := ph.buildTransformChain(c, target, provider.APIBase, scenarioType, nil, protocolRecorder, preBaseTransforms, preVendorTransforms)
+	chain, err := ph.buildTransformChain(c, target, scenarioType, protocolRecorder, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (ph *ProtocolHandler) TransformOpenAIResponses(c *gin.Context, req *protoco
 // the provider and must be the last mutation, so the preVendor transforms are
 // inserted after Consistency but BEFORE Vendor — this also means the StagePost
 // recording captures the truly-final, dispatched request.
-func (ph *ProtocolHandler) buildTransformChain(c *gin.Context, targetType protocol.APIType, providerURL string, scenarioType typ.RuleScenario, scenarioFlags *typ.ScenarioFlags, recorder *recording.ProtocolRecorder, preBase []transform.Transform, preVendor []transform.Transform) (*transform.TransformChain, error) {
+func (ph *ProtocolHandler) buildTransformChain(c *gin.Context, targetType protocol.APIType, scenarioType typ.RuleScenario, recorder *recording.ProtocolRecorder, preBase []transform.Transform, preVendor []transform.Transform) (*transform.TransformChain, error) {
 
 	recordMode := ph.getScenarioRecordMode(scenarioType)
 	shouldRecord := recorder != nil
@@ -278,7 +278,7 @@ func (ph *ProtocolHandler) buildTransformChain(c *gin.Context, targetType protoc
 	// before Vendor (so Vendor remains the final, immutable step).
 	transforms = append(transforms, preVendor...)
 
-	transforms = append(transforms, transform.NewVendorTransform(providerURL))
+	transforms = append(transforms, transform.NewVendorTransform())
 
 	// 4. Post-transform recording (if request recording is enabled). Runs last so
 	// it snapshots the truly-final request dispatched to the provider.

--- a/internal/server/protocol_transform.go
+++ b/internal/server/protocol_transform.go
@@ -38,7 +38,7 @@ func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.
 
 	opts := []transform.TransformOption{
 		transform.WithContext(c.Request.Context()),
-		transform.WithProviderURL(provider.APIBase),
+		transform.WithProvider(provider),
 		transform.WithScenarioFlags(scenarioFlags),
 		transform.WithStreaming(isStreaming),
 		transform.WithDevice(ph.deps.Config.ClaudeCodeDeviceID),
@@ -47,11 +47,6 @@ func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.
 	// Advisor loopback requests carry X-Tingly-Advisor-Depth >= 1; skip MCP tool injection for them
 	if c.GetHeader("X-Tingly-Advisor-Depth") != "" {
 		opts = append(opts, transform.WithIsAdvisorRequest(true))
-	}
-
-	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
-		opts = append(opts, transform.WithUserID(provider.OAuthDetail.UserID))
-		opts = append(opts, transform.WithIssuer(provider.OAuthDetail.ProviderType))
 	}
 
 	transformCtx := transform.NewTransformContext(
@@ -99,7 +94,7 @@ func (ph *ProtocolHandler) TransformAnthropicV1(c *gin.Context, req *protocol.An
 	}
 
 	opts := []transform.TransformOption{
-		transform.WithProviderURL(provider.APIBase),
+		transform.WithProvider(provider),
 		transform.WithScenarioFlags(scenarioFlags),
 		transform.WithStreaming(isStreaming),
 		transform.WithDevice(ph.deps.Config.ClaudeCodeDeviceID),
@@ -108,11 +103,6 @@ func (ph *ProtocolHandler) TransformAnthropicV1(c *gin.Context, req *protocol.An
 	// Check if this is an advisor request
 	if c.GetHeader("X-Tingly-Advisor-Depth") != "" {
 		opts = append(opts, transform.WithIsAdvisorRequest(true))
-	}
-
-	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
-		opts = append(opts, transform.WithUserID(provider.OAuthDetail.UserID))
-		opts = append(opts, transform.WithIssuer(provider.OAuthDetail.ProviderType))
 	}
 
 	transformCtx := transform.NewTransformContext(
@@ -154,7 +144,7 @@ func (ph *ProtocolHandler) TransformOpenAIChat(c *gin.Context, req *protocol.Ope
 	}
 
 	opts := []transform.TransformOption{
-		transform.WithProviderURL(provider.APIBase),
+		transform.WithProvider(provider),
 		transform.WithScenarioFlags(scenarioFlags),
 		transform.WithStreaming(isStreaming),
 		transform.WithDevice(ph.deps.Config.ClaudeCodeDeviceID),
@@ -163,11 +153,6 @@ func (ph *ProtocolHandler) TransformOpenAIChat(c *gin.Context, req *protocol.Ope
 	// Check if this is an advisor request
 	if c.GetHeader("X-Tingly-Advisor-Depth") != "" {
 		opts = append(opts, transform.WithIsAdvisorRequest(true))
-	}
-
-	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
-		opts = append(opts, transform.WithUserID(provider.OAuthDetail.UserID))
-		opts = append(opts, transform.WithIssuer(provider.OAuthDetail.ProviderType))
 	}
 
 	transformCtx := transform.NewTransformContext(
@@ -209,15 +194,11 @@ func (ph *ProtocolHandler) TransformOpenAIResponses(c *gin.Context, req *protoco
 	}
 
 	opts := []transform.TransformOption{
-		transform.WithProviderURL(provider.APIBase),
+		transform.WithProvider(provider),
 		transform.WithScenarioFlags(scenarioFlags),
 		transform.WithStreaming(isStreaming),
 		transform.WithDevice(ph.deps.Config.ClaudeCodeDeviceID),
 		transform.WithMaxTokens(int64(maxAllowed)),
-	}
-	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil {
-		opts = append(opts, transform.WithUserID(provider.OAuthDetail.UserID))
-		opts = append(opts, transform.WithIssuer(provider.OAuthDetail.ProviderType))
 	}
 
 	transformCtx := transform.NewTransformContext(

--- a/internal/server/protocol_transform_test.go
+++ b/internal/server/protocol_transform_test.go
@@ -18,16 +18,7 @@ import (
 func chainNames(t *testing.T, preBase, preVendor []transform.Transform) []string {
 	t.Helper()
 	h := &ProtocolHandler{}
-	chain, err := h.buildTransformChain(
-		nil, // gin.Context only used by the (disabled) recorder
-		protocol.TypeOpenAIChat,
-		"https://api.example.com",
-		typ.ScenarioGlobal,
-		nil,
-		nil, // no recorder
-		preBase,
-		preVendor,
-	)
+	chain, err := h.buildTransformChain(nil, protocol.TypeOpenAIChat, typ.ScenarioGlobal, nil, preBase, preVendor)
 	require.NoError(t, err)
 
 	var names []string

--- a/internal/server/transform/transform_clean_header.go
+++ b/internal/server/transform/transform_clean_header.go
@@ -14,6 +14,8 @@ import (
 //     user geolocation (look-alike Unicode apostrophes and date separators),
 //     both in the system field and inside <system-reminder> blocks in the
 //     first message of the messages array.
+//  3. For Anthropic-to-Codex Responses conversion only, stripping Claude Code
+//     identity/capability preambles that otherwise pollute Codex instructions.
 //
 // Used by Claude Code scenarios to ensure system text is clean before forwarding
 // to third-party providers. Only added to the chain when CleanHeader flag is true.
@@ -27,15 +29,20 @@ func NewCleanHeaderTransform() *CleanHeaderTransform {
 func (t *CleanHeaderTransform) Name() string { return "clean_header" }
 
 func (t *CleanHeaderTransform) Apply(ctx *protocoltransform.TransformContext) error {
+	stripClaudeCodePreamble := shouldStripClaudeCodeSystemPreamble(ctx)
 	switch req := ctx.Request.(type) {
 	case *anthropic.MessageNewParams:
-		req.System = CleanSystemMessages(req.System)
+		req.System = cleanSystemMessages(req.System, stripClaudeCodePreamble)
 		req.Messages = CleanMessages(req.Messages)
 	case *anthropic.BetaMessageNewParams:
-		req.System = CleanBetaSystemMessages(req.System)
+		req.System = cleanBetaSystemMessages(req.System, stripClaudeCodePreamble)
 		req.Messages = CleanBetaMessages(req.Messages)
 	}
 	return nil
+}
+
+func shouldStripClaudeCodeSystemPreamble(ctx *protocoltransform.TransformContext) bool {
+	return ctx != nil && ctx.Provider != nil && ctx.Provider.IsCodexProvider()
 }
 
 // dateSlashRe matches date patterns like "2026/06/30" for steganography countermeasures.
@@ -50,6 +57,11 @@ var dateSlashRe = regexp.MustCompile(`(\d{4})/(\d{2})/(\d{2})`)
 //   - U+02BC MODIFIER LETTER APOSTROPHE
 //   - U+2018 LEFT SINGLE QUOTATION MARK
 var todayApostropheRe = regexp.MustCompile(`Today[’ʼ‘]s`)
+
+var claudeCodeSystemPreambles = []string{
+	"You are Claude Code, Anthropic's official CLI for Claude.",
+	"You are a file search specialist for Claude Code, Anthropic's official CLI for Claude. You excel at thoroughly navigating and exploring codebases.",
+}
 
 // NormalizeSteganographyText removes Anthropic's steganographic markers embedded
 // in system prompt text that silently encode user geolocation.
@@ -85,10 +97,27 @@ func NormalizeSteganographyText(text string) string {
 	return text
 }
 
+func StripClaudeCodeSystemPreamble(text string) string {
+	trimmed := strings.TrimLeft(text, " \t\r\n")
+	for _, preamble := range claudeCodeSystemPreambles {
+		if !strings.HasPrefix(trimmed, preamble) {
+			continue
+		}
+		trimmed = strings.TrimLeft(trimmed[len(preamble):], " \t\r\n")
+		text = trimmed
+		break
+	}
+	return text
+}
+
 // CleanSystemMessages removes billing header messages from system blocks
 // and normalizes steganographic markers in surviving blocks.
 // This is used for Claude Code scenario to filter out injected billing headers.
 func CleanSystemMessages(blocks []anthropic.TextBlockParam) []anthropic.TextBlockParam {
+	return cleanSystemMessages(blocks, false)
+}
+
+func cleanSystemMessages(blocks []anthropic.TextBlockParam, stripClaudeCodePreamble bool) []anthropic.TextBlockParam {
 	if len(blocks) == 0 {
 		return blocks
 	}
@@ -98,6 +127,14 @@ func CleanSystemMessages(blocks []anthropic.TextBlockParam) []anthropic.TextBloc
 		if strings.HasPrefix(strings.TrimSpace(block.Text), "x-anthropic-billing-header:") {
 			continue
 		}
+
+		if stripClaudeCodePreamble {
+			block.Text = StripClaudeCodeSystemPreamble(block.Text)
+			if strings.TrimSpace(block.Text) == "" {
+				continue
+			}
+		}
+
 		// Normalize steganographic markers in all surviving blocks
 		block.Text = NormalizeSteganographyText(block.Text)
 		result = append(result, block)
@@ -108,6 +145,10 @@ func CleanSystemMessages(blocks []anthropic.TextBlockParam) []anthropic.TextBloc
 // CleanBetaSystemMessages removes billing header messages from beta system blocks
 // and normalizes steganographic markers in surviving blocks.
 func CleanBetaSystemMessages(blocks []anthropic.BetaTextBlockParam) []anthropic.BetaTextBlockParam {
+	return cleanBetaSystemMessages(blocks, false)
+}
+
+func cleanBetaSystemMessages(blocks []anthropic.BetaTextBlockParam, stripClaudeCodePreamble bool) []anthropic.BetaTextBlockParam {
 	if len(blocks) == 0 {
 		return blocks
 	}
@@ -117,6 +158,14 @@ func CleanBetaSystemMessages(blocks []anthropic.BetaTextBlockParam) []anthropic.
 		if strings.HasPrefix(strings.TrimSpace(block.Text), "x-anthropic-billing-header:") {
 			continue
 		}
+
+		if stripClaudeCodePreamble {
+			block.Text = StripClaudeCodeSystemPreamble(block.Text)
+			if strings.TrimSpace(block.Text) == "" {
+				continue
+			}
+		}
+
 		// Normalize steganographic markers in all surviving blocks
 		block.Text = NormalizeSteganographyText(block.Text)
 		result = append(result, block)

--- a/internal/server/transform/transform_clean_header_test.go
+++ b/internal/server/transform/transform_clean_header_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
 	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // =============================================
@@ -199,6 +202,46 @@ func TestCleanSystemMessages_NormalTextPreserved(t *testing.T) {
 	}
 }
 
+func TestCleanSystemMessages_PreservesClaudeCodePreambleByDefault(t *testing.T) {
+	blocks := []anthropic.TextBlockParam{
+		{Text: "You are Claude Code, Anthropic's official CLI for Claude."},
+		{Text: "Project instructions must be preserved."},
+	}
+	result := CleanSystemMessages(blocks)
+	if len(result) != 2 {
+		t.Fatalf("CleanSystemMessages() returned %d blocks, want 2", len(result))
+	}
+	if result[0].Text != "You are Claude Code, Anthropic's official CLI for Claude." {
+		t.Errorf("CleanSystemMessages()[0] = %q, want %q", result[0].Text, "You are Claude Code, Anthropic's official CLI for Claude.")
+	}
+}
+
+func TestCleanSystemMessages_CodexModeStripsClaudeCodePreamblePrefix(t *testing.T) {
+	blocks := []anthropic.TextBlockParam{
+		{Text: "You are Claude Code, Anthropic's official CLI for Claude.\n\nFollow the repository conventions."},
+	}
+	result := cleanSystemMessages(blocks, true)
+	if len(result) != 1 {
+		t.Fatalf("CleanSystemMessages() returned %d blocks, want 1", len(result))
+	}
+	if result[0].Text != "Follow the repository conventions." {
+		t.Errorf("CleanSystemMessages()[0] = %q, want %q", result[0].Text, "Follow the repository conventions.")
+	}
+}
+
+func TestCleanSystemMessages_CodexModeRemovesClaudeCodeFileSearchPreamble(t *testing.T) {
+	blocks := []anthropic.TextBlockParam{
+		{Text: "You are a file search specialist for Claude Code, Anthropic's official CLI for Claude. You excel at thoroughly navigating and exploring codebases.\n\nUse ripgrep first."},
+	}
+	result := cleanSystemMessages(blocks, true)
+	if len(result) != 1 {
+		t.Fatalf("CleanSystemMessages() returned %d blocks, want 1", len(result))
+	}
+	if result[0].Text != "Use ripgrep first." {
+		t.Errorf("CleanSystemMessages()[0] = %q, want %q", result[0].Text, "Use ripgrep first.")
+	}
+}
+
 // =============================================
 // CleanBetaSystemMessages tests
 // =============================================
@@ -240,6 +283,20 @@ func TestCleanBetaSystemMessages_EmptyBlocks(t *testing.T) {
 	result = CleanBetaSystemMessages([]anthropic.BetaTextBlockParam{})
 	if len(result) != 0 {
 		t.Errorf("CleanBetaSystemMessages(empty) = %v, want empty", result)
+	}
+}
+
+func TestCleanBetaSystemMessages_PreservesClaudeCodePreambleByDefault(t *testing.T) {
+	blocks := []anthropic.BetaTextBlockParam{
+		{Text: "You are Claude Code, Anthropic's official CLI for Claude."},
+		{Text: "Project instructions must be preserved."},
+	}
+	result := CleanBetaSystemMessages(blocks)
+	if len(result) != 2 {
+		t.Fatalf("CleanBetaSystemMessages() returned %d blocks, want 2", len(result))
+	}
+	if result[0].Text != "You are Claude Code, Anthropic's official CLI for Claude." {
+		t.Errorf("CleanBetaSystemMessages()[0] = %q, want %q", result[0].Text, "You are Claude Code, Anthropic's official CLI for Claude.")
 	}
 }
 
@@ -468,6 +525,59 @@ func TestCleanHeaderTransform_Apply_AnthropicV1(t *testing.T) {
 	wantMsg := "<system-reminder>\nToday's date is 2026-06-30.\n</system-reminder>"
 	if req.Messages[0].Content[0].OfText.Text != wantMsg {
 		t.Errorf("CleanHeaderTransform.Apply() Messages = %q, want %q", req.Messages[0].Content[0].OfText.Text, wantMsg)
+	}
+}
+
+func TestCleanHeaderTransform_Apply_AnthropicV1CodexResponsesStripsClaudeCodePreamble(t *testing.T) {
+	tr := NewCleanHeaderTransform()
+	req := &anthropic.MessageNewParams{
+		System: []anthropic.TextBlockParam{
+			{Text: "You are Claude Code, Anthropic's official CLI for Claude."},
+			{Text: "You are Claude Code, Anthropic's official CLI for Claude.\n\nFollow the repository conventions."},
+		},
+	}
+	ctx := &protocoltransform.TransformContext{
+		Request:   req,
+		TargetAPI: protocol.TypeOpenAIResponses,
+		Provider: &typ.Provider{
+			AuthType:    typ.AuthTypeOAuth,
+			OAuthDetail: &typ.OAuthDetail{Issuer: ai.IssuerCodex},
+		},
+	}
+	if err := tr.Apply(ctx); err != nil {
+		t.Fatalf("CleanHeaderTransform.Apply() error = %v", err)
+	}
+	if len(req.System) != 1 {
+		t.Fatalf("CleanHeaderTransform.Apply() System returned %d blocks, want 1", len(req.System))
+	}
+	if req.System[0].Text != "Follow the repository conventions." {
+		t.Errorf("CleanHeaderTransform.Apply() System = %q, want %q", req.System[0].Text, "Follow the repository conventions.")
+	}
+}
+
+func TestCleanHeaderTransform_Apply_AnthropicV1NonCodexPreservesClaudeCodePreamble(t *testing.T) {
+	tr := NewCleanHeaderTransform()
+	req := &anthropic.MessageNewParams{
+		System: []anthropic.TextBlockParam{
+			{Text: "You are Claude Code, Anthropic's official CLI for Claude."},
+		},
+	}
+	ctx := &protocoltransform.TransformContext{
+		Request:   req,
+		TargetAPI: protocol.TypeOpenAIResponses,
+		Provider: &typ.Provider{
+			AuthType:    typ.AuthTypeOAuth,
+			OAuthDetail: &typ.OAuthDetail{Issuer: ai.IssuerOpenAI},
+		},
+	}
+	if err := tr.Apply(ctx); err != nil {
+		t.Fatalf("CleanHeaderTransform.Apply() error = %v", err)
+	}
+	if len(req.System) != 1 {
+		t.Fatalf("CleanHeaderTransform.Apply() System returned %d blocks, want 1", len(req.System))
+	}
+	if req.System[0].Text != "You are Claude Code, Anthropic's official CLI for Claude." {
+		t.Errorf("CleanHeaderTransform.Apply() System = %q, want %q", req.System[0].Text, "You are Claude Code, Anthropic's official CLI for Claude.")
 	}
 }
 

--- a/internal/server/transform/transform_mcp_tool_injection_test.go
+++ b/internal/server/transform/transform_mcp_tool_injection_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/openai/openai-go/v3"
 	"github.com/tingly-dev/tingly-box/internal/mcp/runtime"
-	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 	protocoltransform "github.com/tingly-dev/tingly-box/internal/protocol/transform"
+	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -44,7 +44,6 @@ func TestMCPToolInjectionTransform_AdvisorNativeGuard(t *testing.T) {
 		ctx := &protocoltransform.TransformContext{
 			Context:          context.Background(),
 			Request:          req,
-			ProviderType:     "claude_code",
 			HasNativeAdvisor: true,
 		}
 
@@ -67,9 +66,8 @@ func TestMCPToolInjectionTransform_AdvisorNativeGuard(t *testing.T) {
 			},
 		}
 		ctx := &protocoltransform.TransformContext{
-			Context:      context.Background(),
-			Request:      req,
-			ProviderType: "claude_code",
+			Context: context.Background(),
+			Request: req,
 		}
 
 		if err := tr.Apply(ctx); err != nil {


### PR DESCRIPTION
## Summary
Codex Responses requests were being adjusted in the generic transform chain even though the Codex client now owns that adaptation path. 
This PR removes the duplicate transform responsibility and keeps provider-specific cleanup focused on the user-visible prompt quality that Codex receives.

### Major
- perf: Codex Responses traffic now avoids proxy-side request rewrites that are already handled by the Codex
client, reducing duplicate behavior and making the dispatch path easier to reason about.
- pref: Claude Code identity preambles are stripped only for Codex providers, so Codex receives cleaner
instructions without weakening header cleanup behavior for other providers.

### Minor
- refactor: Provider-aware transforms now read the canonical provider from transform context instead of passing separate provider URL/type fields through the chain.
- refactor: OAuth info is populated from the provider context in one place.
- test: Tests were updated around Codex cleanup, vendor transforms, and transform-chain provider context behavior.
 