### PR TITLE
perf(dashboard): add usage_daily pre-aggregation and gzip response compression

### DIFF
--- a/.design/dashboard-usage-perf.md
+++ b/.design/dashboard-usage-perf.md
@@ -25,10 +25,13 @@ The previously dormant `usage_daily` table is now populated and queried:
   Old-layout tables (no `user_id` column) are dropped and rebuilt on startup;
   the table holds only derived data, so this is safe.
 - **Lazy backfill**: the first query needing a completed day triggers
-  `aggregateDay` (DELETE + INSERT…SELECT in a transaction). Aggregated days are
-  tracked in memory (`aggregatedDays`) and persist in the table itself. A day is
-  only aggregated once it is ≥1h past UTC midnight (`dailyAggGrace`) so requests
-  recorded shortly after midnight are not missed.
+  `aggregateDay` (DELETE + INSERT…SELECT in a transaction). Which days are
+  already aggregated is read directly from `usage_daily` on each call
+  (`missingAggregatedDays`, an indexed range query on `date`) rather than
+  cached in memory — the table is the source of truth, so there's no shadow
+  state to keep in sync or lose across a restart. A day is only aggregated
+  once it is ≥1h past UTC midnight (`dailyAggGrace`) so requests recorded
+  shortly after midnight are not missed.
 - **Query routing**: `GetAggregatedStats` (group_by ∈ model/provider/user/daily,
   no scenario/rule/status filter) and `GetTimeSeries` (interval=day, filters ⊆
   provider/model/user) spanning ≥2 complete days split the range into:
@@ -37,8 +40,8 @@ The previously dormant `usage_daily` table is now populated and queried:
   (latency) recompute from sums. Anything else falls back to the raw scan, as
   does any aggregation error (logged at Warn).
 - **Deletion consistency**: `DeleteOlderThan` also purges `usage_daily` rows up
-  to and including the cutoff day and resets the in-memory day cache, so the
-  boundary day re-aggregates from the remaining raw rows.
+  to and including the cutoff day, so the boundary day re-aggregates from the
+  remaining raw rows on the next query.
 
 Measured on ~200k records / 90 days (SQLite, in-repo test): stats 300ms → 12ms,
 timeseries 227ms → 6ms steady-state; one-time backfill ≈ one raw scan. Raw-path
@@ -52,9 +55,12 @@ or behind proxy usage writes.
 
 ### 3. gzip on usage endpoints (`internal/server/middleware/gzip.go`)
 
-`GzipHandler` wraps the three usage GET handlers (JSON-only; never use it on
-streaming/SSE routes). Compresses when the client sends `Accept-Encoding: gzip`;
-typical usage JSON shrinks ~10x.
+`middleware.Gzip()` is real gin middleware (calls `c.Next()`), registered
+per-route via `swagger.WithMiddleware(middleware.Gzip())` on the three usage
+GET routes (JSON-only; never use it on streaming/SSE routes) so it composes
+through the normal middleware chain instead of wrapping the handler directly.
+Compresses when the client sends `Accept-Encoding: gzip`; typical usage JSON
+shrinks ~10x.
 
 ### 4. Frontend fetch discipline (`DashboardPage.tsx`)
 

--- a/.design/dashboard-usage-perf.md
+++ b/.design/dashboard-usage-perf.md
@@ -1,0 +1,79 @@
+# Dashboard Usage Query Performance
+
+> Status: shipped on `claude/dashboard-data-performance-21da4o`.
+
+## Problem
+
+The usage dashboard (`/api/v1/usage/stats`, `/usage/timeseries`, `/usage/records`)
+aggregated directly over the raw `usage_records` table on every load. With a large
+record count (weeks of heavy proxy traffic) each 30/90-day dashboard load ran
+multiple full range scans with `GROUP BY strftime(...)`, all serialized behind a
+single `sync.Mutex` shared with the proxy's usage writes, and shipped uncompressed
+JSON. Symptoms: multi-second dashboard loads, UI feeling frozen, large network
+payloads.
+
+## Fix (four layers)
+
+### 1. `usage_daily` pre-aggregation (`internal/data/db/usage_daily.go`)
+
+The previously dormant `usage_daily` table is now populated and queried:
+
+- **Schema v2**: one row per `(UTC day, provider_uuid, model, user_id)` with
+  additive sums (`request_count`, token sums, `error_count`, `streamed_count`,
+  `latency_sum_ms`). The day key equals SQLite's `date(timestamp)` — the same
+  UTC-day bucketing the raw queries already used — stored as `YYYY-MM-DD` TEXT.
+  Old-layout tables (no `user_id` column) are dropped and rebuilt on startup;
+  the table holds only derived data, so this is safe.
+- **Lazy backfill**: the first query needing a completed day triggers
+  `aggregateDay` (DELETE + INSERT…SELECT in a transaction). Aggregated days are
+  tracked in memory (`aggregatedDays`) and persist in the table itself. A day is
+  only aggregated once it is ≥1h past UTC midnight (`dailyAggGrace`) so requests
+  recorded shortly after midnight are not missed.
+- **Query routing**: `GetAggregatedStats` (group_by ∈ model/provider/user/daily,
+  no scenario/rule/status filter) and `GetTimeSeries` (interval=day, filters ⊆
+  provider/model/user) spanning ≥2 complete days split the range into:
+  raw scan of the partial leading day → `usage_daily` for complete days → raw
+  scan of the trailing partial day(s); results merge additively, and averages
+  (latency) recompute from sums. Anything else falls back to the raw scan, as
+  does any aggregation error (logged at Warn).
+- **Deletion consistency**: `DeleteOlderThan` also purges `usage_daily` rows up
+  to and including the cutoff day and resets the in-memory day cache, so the
+  boundary day re-aggregates from the remaining raw rows.
+
+Measured on ~200k records / 90 days (SQLite, in-repo test): stats 300ms → 12ms,
+timeseries 227ms → 6ms steady-state; one-time backfill ≈ one raw scan. Raw-path
+cost grows linearly with record count; the daily path stays flat.
+
+### 2. Concurrent reads (`UsageStore.mu` → `sync.RWMutex`)
+
+Queries take the read lock (SQLite WAL supports concurrent readers), writes the
+write lock. The dashboard's parallel requests no longer queue behind each other
+or behind proxy usage writes.
+
+### 3. gzip on usage endpoints (`internal/server/middleware/gzip.go`)
+
+`GzipHandler` wraps the three usage GET handlers (JSON-only; never use it on
+streaming/SSE routes). Compresses when the client sends `Accept-Encoding: gzip`;
+typical usage JSON shrinks ~10x.
+
+### 4. Frontend fetch discipline (`DashboardPage.tsx`)
+
+- Providers + API tokens (filter metadata) load once on mount and on manual
+  refresh — not on every filter change / auto-refresh tick.
+- A request sequence number drops out-of-order stats/timeseries responses when
+  filters change faster than requests complete.
+- `GetRecords` skips the `COUNT(*)` scan when the first page already contains
+  the full result set.
+
+## Invariants / gotchas
+
+- Timestamps are bound as server-local time strings by the SQLite driver and
+  compared lexicographically; all new query bounds are converted via
+  `.In(time.Local)` to match. Per-day aggregation scans pad the timestamp range
+  by ±2h (`dstScanPad`) and guard with exact `date(timestamp) = ?`.
+- `usage_daily` has no scenario/rule/status dimension — queries filtering on
+  those always use the raw table. Extend the schema (and bump the rebuild
+  condition in `ensureUsageDailySchema`) if those filters ever need the fast path.
+- Equivalence between the merged path and the raw path is locked in by
+  `internal/data/db/usage_daily_test.go`; if you change either side, keep those
+  tests green.

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Stack, Tooltip, Typography, tooltipClasses } from '@mui/material';
 import type { UsageWindow } from '@/types/quota';
 import { formatQuotaPercent, formatQuotaUsage } from '@/types/quota';
-import { QUOTA_COLORS } from '../dashboard/chartStyles';
+import { QUOTA_COLORS, formatNumber } from '../dashboard/chartStyles';
 
 interface QuotaBarItemProps {
   window: UsageWindow;
@@ -29,11 +29,7 @@ interface QuotaBarItemProps {
   tooltipContent?: React.ReactNode;
 }
 
-function formatCompactNumber(num: number) {
-  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(0)}K`;
-  return num.toString();
-}
+const formatCompactNumber = formatNumber;
 
 /**
  * Compact inline display of a single quota window.

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -30,7 +30,7 @@ import {
     ResponsiveContainer,
 } from 'recharts';
 import { WaveSine as StreamIcon } from '@/components/icons';
-import { getThemeChartStyles, TOKEN_COLORS } from './chartStyles';
+import { getThemeChartStyles, TOKEN_COLORS, formatNumber } from './chartStyles';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -71,11 +71,7 @@ const LATENCY_BUCKETS = [
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const fmtTokens = (n: number) => {
-    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-    if (n >= 1_000)     return `${(n / 1_000).toFixed(1)}K`;
-    return n.toString();
-};
+const fmtTokens = formatNumber;
 
 const fmtLatency = (ms: number) => {
     if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;

--- a/frontend/src/components/dashboard/ServiceStatsTable.tsx
+++ b/frontend/src/components/dashboard/ServiceStatsTable.tsx
@@ -13,6 +13,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { useState } from 'react';
+import { formatNumber } from './chartStyles';
 
 export interface AggregatedStat {
     key: string;
@@ -48,11 +49,7 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
         return 'rgba(100, 116, 139, 0.1)';
     };
 
-    const formatTokens = (num: number): string => {
-        if (num >= 1000000) return `${(num / 1000000).toFixed(2)}M`;
-        if (num >= 1000) return `${(num / 1000).toFixed(2)}K`;
-        return num.toLocaleString();
-    };
+    const formatTokens = formatNumber;
 
     const formatRequests = (num: number): string => {
         return num.toLocaleString();

--- a/frontend/src/components/dashboard/TokenHeatmap.tsx
+++ b/frontend/src/components/dashboard/TokenHeatmap.tsx
@@ -1,6 +1,7 @@
 import { Box, Tooltip, Typography, tooltipClasses } from '@mui/material';
 import { useMemo } from 'react';
 import { format } from 'date-fns';
+import { formatNumber } from './chartStyles';
 
 // Green color scale for GitHub-style heatmap (like GitHub's contribution graph)
 const HEATMAP_COLORS = [
@@ -43,29 +44,7 @@ interface TokenHeatmapProps {
     title?: string;
 }
 
-// Format large numbers (T, B, M, K)
-const formatTokenTotal = (value: number): string => {
-    const units = [
-        { size: 1_000_000_000_000, suffix: 'T' },
-        { size: 1_000_000_000, suffix: 'B' },
-        { size: 1_000_000, suffix: 'M' },
-        { size: 1_000, suffix: 'K' },
-    ];
-
-    for (const unit of units) {
-        if (value >= unit.size) {
-            const scaled = value / unit.size;
-            const precision = scaled >= 100 ? 0 : scaled >= 10 ? 1 : 2;
-            const compact = scaled
-                .toFixed(precision)
-                .replace(/\.0+$/, '')
-                .replace(/(\.\d*[1-9])0+$/, '$1');
-            return `${compact}${unit.suffix}`;
-        }
-    }
-
-    return new Intl.NumberFormat('en-US').format(value);
-};
+const formatTokenTotal = formatNumber;
 
 // Calculate streaks
 const computeStreaks = (allDays: string[], valueByDate: Map<string, number>) => {

--- a/frontend/src/components/dashboard/TokenHistoryChart/utils.ts
+++ b/frontend/src/components/dashboard/TokenHistoryChart/utils.ts
@@ -1,6 +1,7 @@
 // Shared utilities for TokenHistoryChart components
 
 import type { ChartDataPoint, TimeSeriesData } from './types';
+import { formatNumber } from '../chartStyles';
 
 export const formatTimeLabel = (timestamp: string, isDayMode: boolean): string => {
     if (!timestamp) return '';
@@ -82,17 +83,9 @@ export const calculateLabelInterval = (dataLength: number): number => {
     return Math.ceil(dataLength / 6);
 };
 
-export const formatYAxis = (value: number): string => {
-    if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`;
-    if (value >= 1000) return `${(value / 1000).toFixed(1)}K`;
-    return value.toString();
-};
+export const formatYAxis = formatNumber;
 
-export const formatTooltipValue = (value: number): string => {
-    if (value >= 1000000) return `${(value / 1000000).toFixed(2)}M`;
-    if (value >= 1000) return `${(value / 1000).toFixed(2)}K`;
-    return value.toLocaleString();
-};
+export const formatTooltipValue = formatNumber;
 
 /**
  * Aggregate minute-level time series data into 5-minute buckets.

--- a/frontend/src/components/dashboard/chartStyles.ts
+++ b/frontend/src/components/dashboard/chartStyles.ts
@@ -124,26 +124,17 @@ export const barRadius: [number, number, number, number] = [4, 4, 0, 0];
 export const ANIMATION_DURATION = 600;
 
 // Format large numbers compactly (999, 50K, 1.5M, 20.4B, 1.1T).
-// Precision adapts to magnitude and trailing zeros are trimmed.
-export const formatNumber = (n: number): string => {
-    const units = [
-        { size: 1_000_000_000_000, suffix: 'T' },
-        { size: 1_000_000_000, suffix: 'B' },
-        { size: 1_000_000, suffix: 'M' },
-        { size: 1_000, suffix: 'K' },
-    ];
+//
+// Backed by Intl's compact notation instead of a hand-rolled unit ladder: a
+// manual "divide, then toFixed" approach rounds within the chosen unit and
+// can strand a value just below a boundary — e.g. 999999 divided by 1e3 and
+// rounded to 0 decimals gives "1000K" instead of carrying into "1M". Intl
+// rounds to the target significant digits first and picks the unit that
+// carry produces, so boundary values always land in the right unit.
+const compactNumberFormatter = new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    compactDisplay: 'short',
+    maximumSignificantDigits: 3,
+});
 
-    for (const unit of units) {
-        if (n >= unit.size) {
-            const scaled = n / unit.size;
-            const precision = scaled >= 100 ? 0 : scaled >= 10 ? 1 : 2;
-            const compact = scaled
-                .toFixed(precision)
-                .replace(/\.0+$/, '')
-                .replace(/(\.\d*[1-9])0+$/, '$1');
-            return `${compact}${unit.suffix}`;
-        }
-    }
-
-    return n.toLocaleString();
-};
+export const formatNumber = (n: number): string => compactNumberFormatter.format(n);

--- a/frontend/src/components/dashboard/chartStyles.ts
+++ b/frontend/src/components/dashboard/chartStyles.ts
@@ -123,9 +123,27 @@ export const barRadius: [number, number, number, number] = [4, 4, 0, 0];
 // Animation duration for chart transitions
 export const ANIMATION_DURATION = 600;
 
-// Format numbers (50K, 1M, etc.)
+// Format large numbers compactly (999, 50K, 1.5M, 20.4B, 1.1T).
+// Precision adapts to magnitude and trailing zeros are trimmed.
 export const formatNumber = (n: number): string => {
-    if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
-    if (n >= 1000) return `${(n / 1000).toFixed(0)}K`;
-    return n.toString();
+    const units = [
+        { size: 1_000_000_000_000, suffix: 'T' },
+        { size: 1_000_000_000, suffix: 'B' },
+        { size: 1_000_000, suffix: 'M' },
+        { size: 1_000, suffix: 'K' },
+    ];
+
+    for (const unit of units) {
+        if (n >= unit.size) {
+            const scaled = n / unit.size;
+            const precision = scaled >= 100 ? 0 : scaled >= 10 ? 1 : 2;
+            const compact = scaled
+                .toFixed(precision)
+                .replace(/\.0+$/, '')
+                .replace(/(\.\d*[1-9])0+$/, '$1');
+            return `${compact}${unit.suffix}`;
+        }
+    }
+
+    return n.toLocaleString();
 };

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -8,4 +8,5 @@ export type { DailyUsage, HeatmapMetrics } from './TokenHeatmap';
 export { default as AgentQuickNav } from './AgentQuickNav';
 export { default as RequestsView } from './RequestsView';
 export type { UsageRecord } from './RequestsView';
+export { formatNumber } from './chartStyles';
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
     Box,
@@ -160,24 +160,20 @@ export default function DashboardPage() {
         return params;
     }, []);
 
-    const loadData = useCallback(async (provider: string, model: string, user: string, range: TimeRange) => {
-        try {
-            const config = TIME_RANGE_CONFIG[range];
-            const params = buildTimeParams(provider, model, user, range);
+    // Monotonic sequence used to drop out-of-order responses when filters
+    // change faster than requests complete.
+    const requestSeq = useRef(0);
 
-            const [statsResult, timeSeriesResult, providersResult, tokensResult] = await Promise.all([
-                api.getUsageStats({ ...params, group_by: 'model', limit: 100 }),
-                api.getUsageTimeSeries({ ...params, interval: config.interval }),
+    // Providers and API tokens are filter metadata that doesn't depend on the
+    // selected time range or filters — fetch them once (and on manual
+    // refresh) instead of on every filter change / auto-refresh tick.
+    const loadFilterOptions = useCallback(async () => {
+        try {
+            const [providersResult, tokensResult] = await Promise.all([
                 api.getProviders(),
                 api.listAPITokens({ limit: 500 }),
             ]);
 
-            if (statsResult?.data) {
-                setStats(statsResult.data);
-            }
-            if (timeSeriesResult?.data) {
-                setTimeSeries(timeSeriesResult.data);
-            }
             if (providersResult?.success && providersResult?.data) {
                 setProviders(providersResult.data);
             }
@@ -190,14 +186,44 @@ export default function DashboardPage() {
                 )).sort((a, b) => a.localeCompare(b));
                 setSharingUsers(users);
             }
+        } catch (error) {
+            console.error('Failed to load dashboard filter options:', error);
+        }
+    }, []);
+
+    const loadData = useCallback(async (provider: string, model: string, user: string, range: TimeRange) => {
+        const seq = ++requestSeq.current;
+        try {
+            const config = TIME_RANGE_CONFIG[range];
+            const params = buildTimeParams(provider, model, user, range);
+
+            const [statsResult, timeSeriesResult] = await Promise.all([
+                api.getUsageStats({ ...params, group_by: 'model', limit: 100 }),
+                api.getUsageTimeSeries({ ...params, interval: config.interval }),
+            ]);
+
+            // A newer request was issued while this one was in flight —
+            // discard the stale response instead of overwriting fresh data.
+            if (seq !== requestSeq.current) {
+                return;
+            }
+
+            if (statsResult?.data) {
+                setStats(statsResult.data);
+            }
+            if (timeSeriesResult?.data) {
+                setTimeSeries(timeSeriesResult.data);
+            }
 
             // Store time params for records loading
             setRecordsTimeParams({ start_time: params.start_time, end_time: params.end_time });
         } catch (error) {
             console.error('Failed to load dashboard data:', error);
         } finally {
-            setLoading(false);
-            setRefreshing(false);
+            if (seq === requestSeq.current) {
+                setLoading(false);
+                setRefreshing(false);
+            }
         }
     }, [buildTimeParams]);
 
@@ -234,6 +260,10 @@ export default function DashboardPage() {
             setRecordsLoading(false);
         }
     }, []);
+
+    useEffect(() => {
+        loadFilterOptions();
+    }, [loadFilterOptions]);
 
     useEffect(() => {
         loadData(selectedProvider, selectedModel, selectedUser, timeRange);
@@ -291,6 +321,7 @@ export default function DashboardPage() {
 
     const handleRefresh = () => {
         setRefreshing(true);
+        loadFilterOptions();
         loadData(selectedProvider, selectedModel, selectedUser, timeRange);
     };
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -20,7 +20,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon, Token as PaidIcon, Stream as StreamIcon, Autorenew as CachedIcon, FilterOff, ChevronLeft, ChevronRight } from '@/components/icons';
-import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView } from '@/components/dashboard';
+import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView, formatNumber } from '@/components/dashboard';
 import type { TimeSeriesData, AggregatedStat, UsageRecord } from '@/components/dashboard';
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import PageHeader from '@/components/PageHeader';
@@ -378,13 +378,6 @@ export default function DashboardPage() {
             cacheTokens: stat.cache_input_tokens || 0,
         };
     });
-
-    // Format large numbers
-    const formatNumber = (num: number): string => {
-        if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M';
-        if (num >= 1000) return (num / 1000).toFixed(1) + 'K';
-        return num.toLocaleString();
-    };
 
     // Group providers by auth_type for the dropdown
     const authTypeLabel = (authType: string): string => {

--- a/internal/data/db/store_manager.go
+++ b/internal/data/db/store_manager.go
@@ -185,10 +185,7 @@ func (sm *StoreManager) initStatsStore() error {
 
 // initUsageStore initializes the UsageStore.
 func (sm *StoreManager) initUsageStore() error {
-	if err := ensureUsageDailySchema(sm.db); err != nil {
-		return err
-	}
-	if err := sm.db.AutoMigrate(&UsageRecord{}, &UsageDailyRecord{}, &UsageMonthlyRecord{}); err != nil {
+	if err := migrateUsageTables(sm.db); err != nil {
 		return err
 	}
 	sm.usageStore = &UsageStore{

--- a/internal/data/db/store_manager.go
+++ b/internal/data/db/store_manager.go
@@ -185,6 +185,9 @@ func (sm *StoreManager) initStatsStore() error {
 
 // initUsageStore initializes the UsageStore.
 func (sm *StoreManager) initUsageStore() error {
+	if err := ensureUsageDailySchema(sm.db); err != nil {
+		return err
+	}
 	if err := sm.db.AutoMigrate(&UsageRecord{}, &UsageDailyRecord{}, &UsageMonthlyRecord{}); err != nil {
 		return err
 	}

--- a/internal/data/db/usage_daily.go
+++ b/internal/data/db/usage_daily.go
@@ -61,37 +61,51 @@ func dailyWindow(start, end, now time.Time) (time.Time, time.Time) {
 }
 
 // ensureDailyAggregates lazily builds usage_daily rows for every day in
-// [firstDay, lastDayEx) that has not been aggregated yet.
+// [firstDay, lastDayEx) that has not been aggregated yet. Which days are
+// already aggregated is read directly from usage_daily (an indexed range
+// query, scoped to the requested window) rather than cached in memory — the
+// table itself is the source of truth, so concurrent stats/timeseries
+// requests never contend on a lock just to check it, and the answer can't go
+// stale across a restart.
 func (us *UsageStore) ensureDailyAggregates(firstDay, lastDayEx time.Time) error {
-	us.aggMu.Lock()
-	defer us.aggMu.Unlock()
-
-	if !us.aggLoaded {
-		var days []string
-		us.mu.RLock()
-		err := us.db.Model(&UsageDailyRecord{}).Distinct("date").Pluck("date", &days).Error
-		us.mu.RUnlock()
-		if err != nil {
-			return err
-		}
-		us.aggregatedDays = make(map[string]bool, len(days))
-		for _, d := range days {
-			us.aggregatedDays[d] = true
-		}
-		us.aggLoaded = true
+	missing, err := us.missingAggregatedDays(firstDay, lastDayEx)
+	if err != nil {
+		return err
 	}
-
-	for day := firstDay; day.Before(lastDayEx); day = day.Add(24 * time.Hour) {
-		key := day.Format(dailyDateLayout)
-		if us.aggregatedDays[key] {
-			continue
-		}
-		if _, err := us.aggregateDay(key, day); err != nil {
+	for _, day := range missing {
+		if _, err := us.aggregateDay(day.Format(dailyDateLayout), day); err != nil {
 			return err
 		}
-		us.aggregatedDays[key] = true
 	}
 	return nil
+}
+
+// missingAggregatedDays returns the UTC days in [firstDay, lastDayEx) that
+// have no usage_daily rows yet.
+func (us *UsageStore) missingAggregatedDays(firstDay, lastDayEx time.Time) ([]time.Time, error) {
+	us.mu.RLock()
+	var have []string
+	err := us.db.Model(&UsageDailyRecord{}).
+		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout)).
+		Distinct("date").
+		Pluck("date", &have).Error
+	us.mu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
+	haveSet := make(map[string]bool, len(have))
+	for _, d := range have {
+		haveSet[d] = true
+	}
+
+	var missing []time.Time
+	for day := firstDay; day.Before(lastDayEx); day = day.Add(24 * time.Hour) {
+		if !haveSet[day.Format(dailyDateLayout)] {
+			missing = append(missing, day)
+		}
+	}
+	return missing, nil
 }
 
 // aggregateDay (re)builds the usage_daily rows for one UTC day.
@@ -295,19 +309,19 @@ func statsMergeKey(groupBy string, b aggBucket) string {
 }
 
 // normalizeStatBucket clears fields that are not dimensions of the grouping,
-// so merged results don't leak arbitrary per-row values.
+// so merged results don't leak arbitrary per-row values. Key is already set
+// correctly by the SQL aliasing in both source paths (rawAggBuckets and
+// dailyStatBuckets) and preserved by mergeInto, so it only needs clearing the
+// non-dimension fields here.
 func normalizeStatBucket(groupBy string, b *aggBucket) {
 	switch groupBy {
 	case "provider":
-		b.Key = b.ProviderUUID
 		b.Model, b.Scenario, b.UserID = "", "", ""
 	case "user":
-		b.Key = b.UserID
 		b.ProviderUUID, b.ProviderName, b.Model, b.Scenario = "", "", "", ""
 	case "daily":
 		b.ProviderUUID, b.ProviderName, b.Model, b.Scenario, b.UserID = "", "", "", "", ""
 	default: // model
-		b.Key = b.Model
 		b.Scenario, b.UserID = "", ""
 	}
 }

--- a/internal/data/db/usage_daily.go
+++ b/internal/data/db/usage_daily.go
@@ -1,0 +1,452 @@
+package db
+
+import (
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// Daily pre-aggregation for usage statistics.
+//
+// Dashboard queries over long ranges (7/30/90 days) used to GROUP BY over the
+// raw usage_records table on every load, which degrades linearly with record
+// count. Instead, completed UTC days (matching SQLite's date(timestamp)
+// bucketing already used by the raw queries) are aggregated once into
+// usage_daily, and range queries combine:
+//
+//	[start .. firstDay)   raw scan (partial leading day, at most ~1 day)
+//	[firstDay .. lastDay) usage_daily lookup (cheap, few rows per day)
+//	[lastDay .. end]      raw scan (today's partial day + grace window)
+//
+// Aggregation is lazy: triggered by the first query that needs a day, tracked
+// in memory, and persisted in usage_daily itself. Days are only aggregated
+// once they are dailyAggGrace past midnight so late-finishing requests whose
+// timestamps fall just before midnight are still captured.
+
+const (
+	dailyDateLayout = "2006-01-02"
+	// dailyAggGrace delays aggregation of a finished day so requests that
+	// started before midnight but were recorded after it are not missed.
+	dailyAggGrace = time.Hour
+	// minDailySpan is the minimum number of complete days a query must cover
+	// before the pre-aggregation path is worth taking over a raw scan.
+	minDailySpan = 2 * 24 * time.Hour
+	// dstScanPad widens the per-day raw scan window so rows whose stored
+	// wall-clock offset differs from the current one (DST shifts) are still
+	// found; the exact date(timestamp) guard filters out the excess.
+	dstScanPad = 2 * time.Hour
+)
+
+// utcDayStart truncates a time to the start of its UTC day.
+func utcDayStart(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// dailyWindow returns the [firstDay, lastDayEx) range of complete UTC days
+// within [start, end] that are eligible for pre-aggregation as of now.
+func dailyWindow(start, end, now time.Time) (time.Time, time.Time) {
+	firstDay := utcDayStart(start)
+	if !firstDay.Equal(start) {
+		firstDay = firstDay.Add(24 * time.Hour)
+	}
+	lastDayEx := utcDayStart(end)
+	if cap := utcDayStart(now.Add(-dailyAggGrace)); cap.Before(lastDayEx) {
+		lastDayEx = cap
+	}
+	return firstDay, lastDayEx
+}
+
+// ensureDailyAggregates lazily builds usage_daily rows for every day in
+// [firstDay, lastDayEx) that has not been aggregated yet.
+func (us *UsageStore) ensureDailyAggregates(firstDay, lastDayEx time.Time) error {
+	us.aggMu.Lock()
+	defer us.aggMu.Unlock()
+
+	if !us.aggLoaded {
+		var days []string
+		us.mu.RLock()
+		err := us.db.Model(&UsageDailyRecord{}).Distinct("date").Pluck("date", &days).Error
+		us.mu.RUnlock()
+		if err != nil {
+			return err
+		}
+		us.aggregatedDays = make(map[string]bool, len(days))
+		for _, d := range days {
+			us.aggregatedDays[d] = true
+		}
+		us.aggLoaded = true
+	}
+
+	for day := firstDay; day.Before(lastDayEx); day = day.Add(24 * time.Hour) {
+		key := day.Format(dailyDateLayout)
+		if us.aggregatedDays[key] {
+			continue
+		}
+		if _, err := us.aggregateDay(key, day); err != nil {
+			return err
+		}
+		us.aggregatedDays[key] = true
+	}
+	return nil
+}
+
+// aggregateDay (re)builds the usage_daily rows for one UTC day.
+func (us *UsageStore) aggregateDay(key string, dayStart time.Time) (int64, error) {
+	us.mu.Lock()
+	defer us.mu.Unlock()
+
+	// The timestamp range prunes via the index; the date() guard is exact.
+	// Bind times converted to server-local so the driver formats them with
+	// the same offset the records were stored with.
+	scanStart := dayStart.Add(-dstScanPad).In(time.Local)
+	scanEnd := dayStart.Add(24*time.Hour + dstScanPad).In(time.Local)
+
+	var rows int64
+	err := us.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("date = ?", key).Delete(&UsageDailyRecord{}).Error; err != nil {
+			return err
+		}
+		res := tx.Exec(`
+			INSERT INTO usage_daily (date, provider_uuid, provider_name, model, user_id,
+				request_count, total_tokens, input_tokens, output_tokens,
+				cache_input_tokens, system_tokens, error_count, streamed_count, latency_sum_ms)
+			SELECT ?, COALESCE(provider_uuid, ''), COALESCE(provider_name, ''), COALESCE(model, ''), COALESCE(user_id, ''),
+				COUNT(*),
+				COALESCE(SUM(total_tokens), 0),
+				COALESCE(SUM(input_tokens), 0),
+				COALESCE(SUM(output_tokens), 0),
+				COALESCE(SUM(cache_input_tokens), 0),
+				COALESCE(SUM(system_tokens), 0),
+				COALESCE(SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN streamed = true THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(latency_ms), 0)
+			FROM usage_records
+			WHERE timestamp >= ? AND timestamp < ? AND date(timestamp) = ?
+			GROUP BY provider_uuid, provider_name, model, user_id
+		`, key, scanStart, scanEnd, key)
+		if res.Error != nil {
+			return res.Error
+		}
+		rows = res.RowsAffected
+		return nil
+	})
+	return rows, err
+}
+
+// aggregatedStatsFromDaily serves GetAggregatedStats from usage_daily when the
+// query shape allows it. Returns handled=false to fall back to the raw scan.
+func (us *UsageStore) aggregatedStatsFromDaily(q UsageStatsQuery) ([]AggregatedStat, bool, error) {
+	switch q.GroupBy {
+	case "model", "provider", "user", "daily":
+	default:
+		return nil, false, nil
+	}
+	// Dimensions/filters not present in usage_daily require the raw table.
+	if q.Scenario != "" || q.RuleUUID != "" || q.Status != "" {
+		return nil, false, nil
+	}
+	if q.StartTime.IsZero() || q.EndTime.IsZero() {
+		return nil, false, nil
+	}
+
+	firstDay, lastDayEx := dailyWindow(q.StartTime, q.EndTime, time.Now())
+	if lastDayEx.Sub(firstDay) < minDailySpan {
+		return nil, false, nil
+	}
+	if err := us.ensureDailyAggregates(firstDay, lastDayEx); err != nil {
+		logrus.WithError(err).Warn("usage: daily aggregation failed; falling back to raw scan")
+		return nil, false, nil
+	}
+
+	merged := make(map[string]*aggBucket)
+	mergeInto := func(buckets []aggBucket) {
+		for i := range buckets {
+			b := buckets[i]
+			k := statsMergeKey(q.GroupBy, b)
+			if cur, ok := merged[k]; ok {
+				cur.RequestCount += b.RequestCount
+				cur.TotalTokens += b.TotalTokens
+				cur.InputTokens += b.InputTokens
+				cur.OutputTokens += b.OutputTokens
+				cur.CacheInputTokens += b.CacheInputTokens
+				cur.SystemTokens += b.SystemTokens
+				cur.ErrorCount += b.ErrorCount
+				cur.StreamedCount += b.StreamedCount
+				cur.LatencySum += b.LatencySum
+			} else {
+				merged[k] = &b
+			}
+		}
+	}
+
+	// Complete days from the pre-aggregation table.
+	daily, err := us.dailyStatBuckets(q, firstDay, lastDayEx)
+	if err != nil {
+		return nil, true, err
+	}
+	mergeInto(daily)
+
+	// Partial edge days from the raw table.
+	if q.StartTime.Before(firstDay) {
+		edge := q
+		edge.EndTime = firstDay.Add(-time.Nanosecond).In(time.Local)
+		buckets, err := us.rawAggBuckets(edge, false)
+		if err != nil {
+			return nil, true, err
+		}
+		mergeInto(buckets)
+	}
+	if q.EndTime.After(lastDayEx) {
+		edge := q
+		edge.StartTime = lastDayEx.In(time.Local)
+		buckets, err := us.rawAggBuckets(edge, false)
+		if err != nil {
+			return nil, true, err
+		}
+		mergeInto(buckets)
+	}
+
+	list := make([]aggBucket, 0, len(merged))
+	for _, b := range merged {
+		normalizeStatBucket(q.GroupBy, b)
+		list = append(list, *b)
+	}
+	sortAggBuckets(list, q.SortBy, q.SortOrder)
+	if q.Limit > 0 && len(list) > q.Limit {
+		list = list[:q.Limit]
+	}
+
+	stats := make([]AggregatedStat, len(list))
+	for i, b := range list {
+		stats[i] = b.toAggregatedStat()
+	}
+	return stats, true, nil
+}
+
+// dailyStatBuckets aggregates usage_daily rows over [firstDay, lastDayEx)
+// with the grouping/filters of the given query.
+func (us *UsageStore) dailyStatBuckets(q UsageStatsQuery, firstDay, lastDayEx time.Time) ([]aggBucket, error) {
+	us.mu.RLock()
+	defer us.mu.RUnlock()
+
+	var keyExpr, groupBy string
+	switch q.GroupBy {
+	case "provider":
+		keyExpr = "provider_uuid as key, provider_uuid, provider_name, '' as model, '' as user_id"
+		groupBy = "provider_uuid, provider_name"
+	case "user":
+		keyExpr = "user_id as key, '' as provider_uuid, '' as provider_name, '' as model, user_id"
+		groupBy = "user_id"
+	case "daily":
+		keyExpr = "date as key, '' as provider_uuid, '' as provider_name, '' as model, '' as user_id"
+		groupBy = "date"
+	default: // model
+		keyExpr = "model as key, provider_uuid, provider_name, model, '' as user_id"
+		groupBy = "provider_uuid, provider_name, model"
+	}
+
+	db := us.db.Model(&UsageDailyRecord{}).
+		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout))
+	if q.Provider != "" {
+		db = db.Where("provider_uuid = ?", q.Provider)
+	}
+	if q.Model != "" {
+		db = db.Where("model = ?", q.Model)
+	}
+	if q.UserID != "" {
+		db = db.Where("user_id = ?", q.UserID)
+	}
+
+	var buckets []aggBucket
+	if err := db.Select(keyExpr + `,
+		COALESCE(SUM(request_count), 0) as request_count,
+		COALESCE(SUM(total_tokens), 0) as total_tokens,
+		COALESCE(SUM(input_tokens), 0) as input_tokens,
+		COALESCE(SUM(output_tokens), 0) as output_tokens,
+		COALESCE(SUM(cache_input_tokens), 0) as cache_input_tokens,
+		COALESCE(SUM(system_tokens), 0) as system_tokens,
+		COALESCE(SUM(error_count), 0) as error_count,
+		COALESCE(SUM(streamed_count), 0) as streamed_count,
+		COALESCE(SUM(latency_sum_ms), 0) as latency_sum`).
+		Group(groupBy).
+		Scan(&buckets).Error; err != nil {
+		return nil, err
+	}
+	return buckets, nil
+}
+
+// statsMergeKey identifies the group a bucket belongs to when combining
+// usage_daily results with raw edge scans.
+func statsMergeKey(groupBy string, b aggBucket) string {
+	switch groupBy {
+	case "provider":
+		return b.ProviderUUID
+	case "user":
+		return b.UserID
+	case "daily":
+		return b.Key // YYYY-MM-DD
+	default: // model
+		return b.ProviderUUID + "\x00" + b.Model
+	}
+}
+
+// normalizeStatBucket clears fields that are not dimensions of the grouping,
+// so merged results don't leak arbitrary per-row values.
+func normalizeStatBucket(groupBy string, b *aggBucket) {
+	switch groupBy {
+	case "provider":
+		b.Key = b.ProviderUUID
+		b.Model, b.Scenario, b.UserID = "", "", ""
+	case "user":
+		b.Key = b.UserID
+		b.ProviderUUID, b.ProviderName, b.Model, b.Scenario = "", "", "", ""
+	case "daily":
+		b.ProviderUUID, b.ProviderName, b.Model, b.Scenario, b.UserID = "", "", "", "", ""
+	default: // model
+		b.Key = b.Model
+		b.Scenario, b.UserID = "", ""
+	}
+}
+
+func sortAggBuckets(list []aggBucket, sortBy, sortOrder string) {
+	metric := func(b aggBucket) float64 {
+		switch sortBy {
+		case "request_count":
+			return float64(b.RequestCount)
+		case "avg_latency":
+			return avgFloat(float64(b.LatencySum), b.RequestCount)
+		default: // total_tokens
+			return float64(b.TotalTokens)
+		}
+	}
+	asc := sortOrder == "asc"
+	sort.SliceStable(list, func(i, j int) bool {
+		if asc {
+			return metric(list[i]) < metric(list[j])
+		}
+		return metric(list[i]) > metric(list[j])
+	})
+}
+
+// timeSeriesFromDaily serves day-interval time series from usage_daily when
+// the query shape allows it. Returns handled=false to fall back to raw.
+func (us *UsageStore) timeSeriesFromDaily(interval string, start, end time.Time, filters map[string]string) ([]TimeSeriesData, bool, error) {
+	if interval != "day" || start.IsZero() || end.IsZero() {
+		return nil, false, nil
+	}
+	for k := range filters {
+		switch k {
+		case "provider_uuid", "model", "user_id":
+		default:
+			return nil, false, nil
+		}
+	}
+
+	firstDay, lastDayEx := dailyWindow(start, end, time.Now())
+	if lastDayEx.Sub(firstDay) < minDailySpan {
+		return nil, false, nil
+	}
+	if err := us.ensureDailyAggregates(firstDay, lastDayEx); err != nil {
+		logrus.WithError(err).Warn("usage: daily aggregation failed; falling back to raw scan")
+		return nil, false, nil
+	}
+
+	var out []TimeSeriesData
+
+	// Partial leading day from the raw table.
+	if start.Before(firstDay) {
+		lead, err := us.rawTimeSeries("day", start, firstDay.Add(-time.Nanosecond).In(time.Local), filters)
+		if err != nil {
+			return nil, true, err
+		}
+		out = append(out, lead...)
+	}
+
+	// Complete days from the pre-aggregation table.
+	body, err := us.dailyTimeSeries(firstDay, lastDayEx, filters)
+	if err != nil {
+		return nil, true, err
+	}
+	out = append(out, body...)
+
+	// Partial trailing days (today + grace window) from the raw table.
+	if end.After(lastDayEx) {
+		tail, err := us.rawTimeSeries("day", lastDayEx.In(time.Local), end, filters)
+		if err != nil {
+			return nil, true, err
+		}
+		out = append(out, tail...)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		a, _ := strconv.ParseInt(out[i].Timestamp, 10, 64)
+		b, _ := strconv.ParseInt(out[j].Timestamp, 10, 64)
+		return a < b
+	})
+	return out, true, nil
+}
+
+// dailyTimeSeries returns one bucket per date from usage_daily.
+func (us *UsageStore) dailyTimeSeries(firstDay, lastDayEx time.Time, filters map[string]string) ([]TimeSeriesData, error) {
+	us.mu.RLock()
+	defer us.mu.RUnlock()
+
+	db := us.db.Model(&UsageDailyRecord{}).
+		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout))
+	for k, v := range filters {
+		db = db.Where(k+" = ?", v)
+	}
+
+	type row struct {
+		Date             string
+		RequestCount     int64
+		TotalTokens      int64
+		InputTokens      int64
+		OutputTokens     int64
+		CacheInputTokens int64
+		SystemTokens     int64
+		ErrorCount       int64
+		LatencySum       int64
+	}
+	var rows []row
+	if err := db.Select(`date,
+		COALESCE(SUM(request_count), 0) as request_count,
+		COALESCE(SUM(total_tokens), 0) as total_tokens,
+		COALESCE(SUM(input_tokens), 0) as input_tokens,
+		COALESCE(SUM(output_tokens), 0) as output_tokens,
+		COALESCE(SUM(cache_input_tokens), 0) as cache_input_tokens,
+		COALESCE(SUM(system_tokens), 0) as system_tokens,
+		COALESCE(SUM(error_count), 0) as error_count,
+		COALESCE(SUM(latency_sum_ms), 0) as latency_sum`).
+		Group("date").
+		Order("date ASC").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	data := make([]TimeSeriesData, 0, len(rows))
+	for _, r := range rows {
+		day, err := time.ParseInLocation(dailyDateLayout, r.Date, time.UTC)
+		if err != nil {
+			continue
+		}
+		data = append(data, TimeSeriesData{
+			// Unix seconds of the UTC day start, matching the raw
+			// strftime('%s', ...) bucket encoding.
+			Timestamp:        strconv.FormatInt(day.Unix(), 10),
+			RequestCount:     r.RequestCount,
+			TotalTokens:      r.TotalTokens,
+			InputTokens:      r.InputTokens,
+			OutputTokens:     r.OutputTokens,
+			CacheInputTokens: r.CacheInputTokens,
+			SystemTokens:     r.SystemTokens,
+			ErrorCount:       r.ErrorCount,
+			AvgLatencyMs:     avgFloat(float64(r.LatencySum), r.RequestCount),
+		})
+	}
+	return data, nil
+}

--- a/internal/data/db/usage_daily_test.go
+++ b/internal/data/db/usage_daily_test.go
@@ -1,0 +1,358 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// seedUsageRecords writes a deterministic mix of records spread over the past
+// `days` days (several providers/models/users, errors, streamed, cache).
+func seedUsageRecords(t *testing.T, store *UsageStore, days int) int {
+	t.Helper()
+
+	providers := []struct{ uuid, name string }{
+		{"prov-a", "Provider A"},
+		{"prov-b", "Provider B"},
+	}
+	models := []string{"model-x", "model-y", "model-z"}
+	users := []string{"admin", "alice"}
+
+	count := 0
+	now := time.Now()
+	for d := 0; d < days; d++ {
+		for h := 0; h < 24; h += 5 {
+			for i, p := range providers {
+				model := models[(d+h+i)%len(models)]
+				user := users[(d+i)%len(users)]
+				status := "success"
+				if (d+h)%10 == 0 {
+					status = "error"
+				}
+				rec := &UsageRecord{
+					ProviderUUID:     p.uuid,
+					ProviderName:     p.name,
+					Model:            model,
+					Scenario:         "default",
+					UserID:           user,
+					Timestamp:        now.Add(-time.Duration(d)*24*time.Hour - time.Duration(h)*time.Hour),
+					InputTokens:      100 + d*10 + h,
+					OutputTokens:     50 + h,
+					CacheInputTokens: 20 * i,
+					SystemTokens:     5,
+					Status:           status,
+					LatencyMs:        200 + h*3,
+					Streamed:         h%2 == 0,
+				}
+				if err := store.RecordUsage(rec); err != nil {
+					t.Fatalf("RecordUsage failed: %v", err)
+				}
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func statsKey(s AggregatedStat) string {
+	return fmt.Sprintf("%s|%s|%s|%s", s.Key, s.ProviderUUID, s.Model, s.UserID)
+}
+
+// TestAggregatedStatsDailyMatchesRaw verifies the usage_daily merged path
+// returns the same numbers as a raw usage_records scan.
+func TestAggregatedStatsDailyMatchesRaw(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	seedUsageRecords(t, store, 8)
+
+	now := time.Now()
+	for _, groupBy := range []string{"model", "provider", "user", "daily"} {
+		query := UsageStatsQuery{
+			GroupBy:   groupBy,
+			StartTime: now.Add(-7 * 24 * time.Hour),
+			EndTime:   now,
+			Limit:     100,
+			SortBy:    "total_tokens",
+			SortOrder: "desc",
+		}
+
+		merged, handled, err := store.aggregatedStatsFromDaily(query)
+		if err != nil {
+			t.Fatalf("[%s] aggregatedStatsFromDaily failed: %v", groupBy, err)
+		}
+		if !handled {
+			t.Fatalf("[%s] expected daily path to handle a 7-day query", groupBy)
+		}
+
+		buckets, err := store.rawAggBuckets(query, true)
+		if err != nil {
+			t.Fatalf("[%s] rawAggBuckets failed: %v", groupBy, err)
+		}
+		raw := make(map[string]AggregatedStat, len(buckets))
+		totalRawRequests := int64(0)
+		for _, b := range buckets {
+			normalizeStatBucket(groupBy, &b)
+			raw[statsKey(b.toAggregatedStat())] = b.toAggregatedStat()
+			totalRawRequests += b.RequestCount
+		}
+
+		if len(merged) != len(raw) {
+			t.Fatalf("[%s] group count mismatch: merged=%d raw=%d", groupBy, len(merged), len(raw))
+		}
+		for _, m := range merged {
+			r, ok := raw[statsKey(m)]
+			if !ok {
+				t.Fatalf("[%s] merged group %q missing from raw results", groupBy, statsKey(m))
+			}
+			if m.RequestCount != r.RequestCount ||
+				m.TotalTokens != r.TotalTokens ||
+				m.InputTokens != r.InputTokens ||
+				m.OutputTokens != r.OutputTokens ||
+				m.CacheInputTokens != r.CacheInputTokens ||
+				m.SystemTokens != r.SystemTokens ||
+				m.ErrorCount != r.ErrorCount ||
+				m.StreamedCount != r.StreamedCount {
+				t.Fatalf("[%s] group %q mismatch:\nmerged=%+v\nraw=%+v", groupBy, statsKey(m), m, r)
+			}
+			if diff := m.AvgLatencyMs - r.AvgLatencyMs; diff > 0.001 || diff < -0.001 {
+				t.Fatalf("[%s] group %q avg latency mismatch: merged=%f raw=%f", groupBy, statsKey(m), m.AvgLatencyMs, r.AvgLatencyMs)
+			}
+		}
+	}
+}
+
+// TestAggregatedStatsDailyWithFilters checks provider/model/user filters take
+// the daily path and match raw results.
+func TestAggregatedStatsDailyWithFilters(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	seedUsageRecords(t, store, 6)
+
+	now := time.Now()
+	query := UsageStatsQuery{
+		GroupBy:   "model",
+		StartTime: now.Add(-5 * 24 * time.Hour),
+		EndTime:   now,
+		Provider:  "prov-a",
+		UserID:    "admin",
+		Limit:     100,
+		SortBy:    "total_tokens",
+		SortOrder: "desc",
+	}
+
+	merged, handled, err := store.aggregatedStatsFromDaily(query)
+	if err != nil {
+		t.Fatalf("aggregatedStatsFromDaily failed: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected daily path to handle filtered query")
+	}
+
+	buckets, err := store.rawAggBuckets(query, true)
+	if err != nil {
+		t.Fatalf("rawAggBuckets failed: %v", err)
+	}
+	if len(merged) != len(buckets) {
+		t.Fatalf("group count mismatch: merged=%d raw=%d", len(merged), len(buckets))
+	}
+	var mergedTotal, rawTotal int64
+	for _, m := range merged {
+		mergedTotal += m.RequestCount
+	}
+	for _, b := range buckets {
+		rawTotal += b.RequestCount
+	}
+	if mergedTotal != rawTotal {
+		t.Fatalf("request totals mismatch: merged=%d raw=%d", mergedTotal, rawTotal)
+	}
+}
+
+// TestTimeSeriesDailyMatchesRaw verifies day-interval time series from the
+// daily path match the raw scan bucket-for-bucket.
+func TestTimeSeriesDailyMatchesRaw(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	seedUsageRecords(t, store, 8)
+
+	now := time.Now()
+	start := now.Add(-7 * 24 * time.Hour)
+
+	merged, handled, err := store.timeSeriesFromDaily("day", start, now, nil)
+	if err != nil {
+		t.Fatalf("timeSeriesFromDaily failed: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected daily path to handle a 7-day day-interval query")
+	}
+
+	raw, err := store.rawTimeSeries("day", start, now, nil)
+	if err != nil {
+		t.Fatalf("rawTimeSeries failed: %v", err)
+	}
+
+	if len(merged) != len(raw) {
+		t.Fatalf("bucket count mismatch: merged=%d raw=%d", len(merged), len(raw))
+	}
+	for i := range merged {
+		m, r := merged[i], raw[i]
+		if m.Timestamp != r.Timestamp ||
+			m.RequestCount != r.RequestCount ||
+			m.TotalTokens != r.TotalTokens ||
+			m.InputTokens != r.InputTokens ||
+			m.OutputTokens != r.OutputTokens ||
+			m.CacheInputTokens != r.CacheInputTokens ||
+			m.ErrorCount != r.ErrorCount {
+			t.Fatalf("bucket %d mismatch:\nmerged=%+v\nraw=%+v", i, m, r)
+		}
+	}
+
+	// The daily table must now be populated for completed days.
+	var dailyRows int64
+	if err := store.db.Model(&UsageDailyRecord{}).Count(&dailyRows).Error; err != nil {
+		t.Fatalf("counting usage_daily rows failed: %v", err)
+	}
+	if dailyRows == 0 {
+		t.Fatal("expected usage_daily to be populated after daily-path query")
+	}
+}
+
+// TestPublicAPIsUseDailyPathTransparently exercises the public entry points
+// end to end (routing decision included).
+func TestPublicAPIsUseDailyPathTransparently(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	total := seedUsageRecords(t, store, 4)
+
+	now := time.Now()
+	stats, err := store.GetAggregatedStats(UsageStatsQuery{
+		GroupBy:   "model",
+		StartTime: now.Add(-30 * 24 * time.Hour),
+		EndTime:   now,
+		Limit:     100,
+		SortBy:    "total_tokens",
+		SortOrder: "desc",
+	})
+	if err != nil {
+		t.Fatalf("GetAggregatedStats failed: %v", err)
+	}
+	var got int64
+	for _, s := range stats {
+		got += s.RequestCount
+	}
+	if got != int64(total) {
+		t.Fatalf("GetAggregatedStats total requests = %d, want %d", got, total)
+	}
+
+	series, err := store.GetTimeSeries("day", now.Add(-30*24*time.Hour), now, nil)
+	if err != nil {
+		t.Fatalf("GetTimeSeries failed: %v", err)
+	}
+	got = 0
+	for _, b := range series {
+		got += b.RequestCount
+	}
+	if got != int64(total) {
+		t.Fatalf("GetTimeSeries total requests = %d, want %d", got, total)
+	}
+}
+
+// TestDeleteOlderThanPurgesDailyAggregates ensures raw deletion keeps the
+// daily table consistent and resets the in-memory aggregation cache.
+func TestDeleteOlderThanPurgesDailyAggregates(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	seedUsageRecords(t, store, 6)
+
+	now := time.Now()
+	// Populate the daily table.
+	if _, _, err := store.timeSeriesFromDaily("day", now.Add(-5*24*time.Hour), now, nil); err != nil {
+		t.Fatalf("timeSeriesFromDaily failed: %v", err)
+	}
+
+	cutoff := now.Add(-3 * 24 * time.Hour)
+	if _, err := store.DeleteOlderThan(cutoff); err != nil {
+		t.Fatalf("DeleteOlderThan failed: %v", err)
+	}
+
+	var stale int64
+	if err := store.db.Model(&UsageDailyRecord{}).
+		Where("date < ?", cutoff.UTC().Format(dailyDateLayout)).
+		Count(&stale).Error; err != nil {
+		t.Fatalf("counting stale daily rows failed: %v", err)
+	}
+	if stale != 0 {
+		t.Fatalf("expected daily aggregates before cutoff to be deleted, found %d", stale)
+	}
+
+	// Query again after deletion: totals must match a raw scan.
+	mergedSeries, handled, err := store.timeSeriesFromDaily("day", now.Add(-5*24*time.Hour), now, nil)
+	if err != nil || !handled {
+		t.Fatalf("timeSeriesFromDaily after delete: handled=%v err=%v", handled, err)
+	}
+	rawSeries, err := store.rawTimeSeries("day", now.Add(-5*24*time.Hour), now, nil)
+	if err != nil {
+		t.Fatalf("rawTimeSeries failed: %v", err)
+	}
+	var mergedTotal, rawTotal int64
+	for _, b := range mergedSeries {
+		mergedTotal += b.RequestCount
+	}
+	for _, b := range rawSeries {
+		rawTotal += b.RequestCount
+	}
+	if mergedTotal != rawTotal {
+		t.Fatalf("post-delete totals mismatch: merged=%d raw=%d", mergedTotal, rawTotal)
+	}
+}
+
+// TestGetRecordsTotalWithoutFullCount checks the COUNT-skip fast path.
+func TestGetRecordsTotalWithoutFullCount(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	total := seedUsageRecords(t, store, 1)
+
+	start := time.Now().Add(-2 * 24 * time.Hour)
+	end := time.Now()
+
+	// Page smaller than result set: COUNT path.
+	records, gotTotal, err := store.GetRecords(start, end, nil, 3, 0)
+	if err != nil {
+		t.Fatalf("GetRecords failed: %v", err)
+	}
+	if len(records) != 3 || gotTotal != int64(total) {
+		t.Fatalf("paged GetRecords = (%d records, total %d), want (3, %d)", len(records), gotTotal, total)
+	}
+
+	// Page larger than result set: fast path total.
+	records, gotTotal, err = store.GetRecords(start, end, nil, 500, 0)
+	if err != nil {
+		t.Fatalf("GetRecords failed: %v", err)
+	}
+	if len(records) != total || gotTotal != int64(total) {
+		t.Fatalf("full GetRecords = (%d records, total %d), want (%d, %d)", len(records), gotTotal, total, total)
+	}
+}

--- a/internal/data/db/usage_record.go
+++ b/internal/data/db/usage_record.go
@@ -113,11 +113,6 @@ type UsageStore struct {
 	// lock (WAL mode supports concurrent readers), so dashboard queries do
 	// not serialize behind proxy usage writes or each other.
 	mu sync.RWMutex
-
-	// Daily pre-aggregation bookkeeping (see usage_daily.go)
-	aggMu          sync.Mutex
-	aggregatedDays map[string]bool
-	aggLoaded      bool
 }
 
 // NewUsageStore creates or loads a usage store using SQLite database.
@@ -143,12 +138,8 @@ func NewUsageStore(baseDir string) (*UsageStore, error) {
 		dbPath: dbPath,
 	}
 
-	// Auto-migrate schema for all usage-related tables
-	if err := ensureUsageDailySchema(db); err != nil {
-		return nil, fmt.Errorf("failed to align usage daily schema: %w", err)
-	}
-	if err := db.AutoMigrate(&UsageRecord{}, &UsageDailyRecord{}, &UsageMonthlyRecord{}); err != nil {
-		return nil, fmt.Errorf("failed to migrate usage database: %w", err)
+	if err := migrateUsageTables(db); err != nil {
+		return nil, err
 	}
 	if err := ensureUsageRecordSchema(db); err != nil {
 		return nil, fmt.Errorf("failed to align usage schema: %w", err)
@@ -156,6 +147,19 @@ func NewUsageStore(baseDir string) (*UsageStore, error) {
 	logrus.Debugf("Usage store initialization completed")
 
 	return store, nil
+}
+
+// migrateUsageTables aligns and auto-migrates usage_records, usage_daily, and
+// usage_monthly. Shared by NewUsageStore and StoreManager.initUsageStore so
+// the two initialization paths can't drift apart.
+func migrateUsageTables(db *gorm.DB) error {
+	if err := ensureUsageDailySchema(db); err != nil {
+		return fmt.Errorf("failed to align usage daily schema: %w", err)
+	}
+	if err := db.AutoMigrate(&UsageRecord{}, &UsageDailyRecord{}, &UsageMonthlyRecord{}); err != nil {
+		return fmt.Errorf("failed to migrate usage database: %w", err)
+	}
+	return nil
 }
 
 func ensureUsageRecordSchema(db *gorm.DB) error {
@@ -630,6 +634,8 @@ func (us *UsageStore) GetRecordsAfterID(lastID uint, startTime time.Time, limit 
 // with the daily aggregates derived from them so both views stay consistent.
 func (us *UsageStore) DeleteOlderThan(cutoffDate time.Time) (int64, error) {
 	us.mu.Lock()
+	defer us.mu.Unlock()
+
 	result := us.db.Where("timestamp < ?", cutoffDate).Delete(&UsageRecord{})
 	if result.Error == nil {
 		// Include the boundary day: its aggregate now over-counts deleted
@@ -637,14 +643,6 @@ func (us *UsageStore) DeleteOlderThan(cutoffDate time.Time) (int64, error) {
 		// next query.
 		us.db.Where("date <= ?", cutoffDate.UTC().Format(dailyDateLayout)).Delete(&UsageDailyRecord{})
 	}
-	us.mu.Unlock()
-
-	// Aggregates for deleted days must be recomputed if queried again.
-	us.aggMu.Lock()
-	us.aggLoaded = false
-	us.aggregatedDays = nil
-	us.aggMu.Unlock()
-
 	return result.RowsAffected, result.Error
 }
 

--- a/internal/data/db/usage_record.go
+++ b/internal/data/db/usage_record.go
@@ -51,22 +51,29 @@ func (UsageRecord) TableName() string {
 	return "usage_records"
 }
 
-// UsageDailyRecord is the GORM model for daily aggregated usage statistics
+// UsageDailyRecord is the GORM model for daily aggregated usage statistics.
+// One row per (UTC day, provider, model, user). Date uses the same day
+// boundary as SQLite's date(timestamp) so daily rows can substitute raw
+// usage_records scans for completed days.
 type UsageDailyRecord struct {
-	ID           uint      `gorm:"primaryKey;autoIncrement;column:id"`
-	Date         time.Time `gorm:"column:date;index:idx_date;index:idx_date_provider_model;not null"`
-	ProviderUUID string    `gorm:"column:provider_uuid;index:idx_date_provider_model;not null"`
-	ProviderName string    `gorm:"column:provider_name;not null"`
-	Model        string    `gorm:"column:model;index:idx_date_provider_model;not null"`
-	RequestCount int64     `gorm:"column:request_count;not null"`
-	TotalTokens  int64     `gorm:"column:total_tokens;not null"`
-	InputTokens  int64     `gorm:"column:input_tokens;not null"`
-	OutputTokens int64     `gorm:"column:output_tokens;not null"`
+	ID           uint   `gorm:"primaryKey;autoIncrement;column:id"`
+	Date         string `gorm:"column:date;index:idx_date;uniqueIndex:uq_daily_dim,priority:1;not null"` // YYYY-MM-DD (UTC)
+	ProviderUUID string `gorm:"column:provider_uuid;uniqueIndex:uq_daily_dim,priority:2;not null"`
+	ProviderName string `gorm:"column:provider_name;not null"`
+	Model        string `gorm:"column:model;uniqueIndex:uq_daily_dim,priority:3;not null"`
+	UserID       string `gorm:"column:user_id;uniqueIndex:uq_daily_dim,priority:4;not null;default:''"`
+	RequestCount int64  `gorm:"column:request_count;not null"`
+	TotalTokens  int64  `gorm:"column:total_tokens;not null"`
+	InputTokens  int64  `gorm:"column:input_tokens;not null"`
+	OutputTokens int64  `gorm:"column:output_tokens;not null"`
 	// Cache tokens
 	CacheInputTokens int64 `gorm:"column:cache_input_tokens;default:0"`
 	// System tokens
-	SystemTokens int64 `gorm:"column:system_tokens;default:0"`
-	ErrorCount   int64 `gorm:"column:error_count;default:0"`
+	SystemTokens  int64 `gorm:"column:system_tokens;default:0"`
+	ErrorCount    int64 `gorm:"column:error_count;default:0"`
+	StreamedCount int64 `gorm:"column:streamed_count;default:0"`
+	// Sum of latency_ms across the day, so merged averages stay weighted
+	LatencySumMs int64 `gorm:"column:latency_sum_ms;default:0"`
 }
 
 // TableName specifies the table name for GORM
@@ -102,7 +109,15 @@ func (UsageMonthlyRecord) TableName() string {
 type UsageStore struct {
 	db     *gorm.DB
 	dbPath string
-	mu     sync.Mutex
+	// mu guards the database: writes take the write lock, queries the read
+	// lock (WAL mode supports concurrent readers), so dashboard queries do
+	// not serialize behind proxy usage writes or each other.
+	mu sync.RWMutex
+
+	// Daily pre-aggregation bookkeeping (see usage_daily.go)
+	aggMu          sync.Mutex
+	aggregatedDays map[string]bool
+	aggLoaded      bool
 }
 
 // NewUsageStore creates or loads a usage store using SQLite database.
@@ -129,6 +144,9 @@ func NewUsageStore(baseDir string) (*UsageStore, error) {
 	}
 
 	// Auto-migrate schema for all usage-related tables
+	if err := ensureUsageDailySchema(db); err != nil {
+		return nil, fmt.Errorf("failed to align usage daily schema: %w", err)
+	}
 	if err := db.AutoMigrate(&UsageRecord{}, &UsageDailyRecord{}, &UsageMonthlyRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate usage database: %w", err)
 	}
@@ -185,6 +203,19 @@ func ensureUsageRecordSchema(db *gorm.DB) error {
 		// Don't fail initialization for this migration, it's not critical
 	}
 
+	return nil
+}
+
+// ensureUsageDailySchema rebuilds the usage_daily table when it predates the
+// v2 layout (user_id dimension + streamed/latency sums). The table holds only
+// derived data and is repopulated lazily, so dropping it is safe.
+func ensureUsageDailySchema(db *gorm.DB) error {
+	m := db.Migrator()
+	if m.HasTable(&UsageDailyRecord{}) && !m.HasColumn(&UsageDailyRecord{}, "user_id") {
+		if err := m.DropTable(&UsageDailyRecord{}); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -259,10 +290,76 @@ type AggregatedStat struct {
 	StreamedRate     float64 `json:"streamed_rate"`
 }
 
-// GetAggregatedStats returns aggregated statistics
+// GetAggregatedStats returns aggregated statistics. For queries spanning
+// several completed days it combines the usage_daily pre-aggregation table
+// with a raw scan of only the partial edge days (see usage_daily.go), so
+// dashboard loads stay fast regardless of how many raw records accumulate.
 func (us *UsageStore) GetAggregatedStats(query UsageStatsQuery) ([]AggregatedStat, error) {
-	us.mu.Lock()
-	defer us.mu.Unlock()
+	if stats, ok, err := us.aggregatedStatsFromDaily(query); ok {
+		return stats, err
+	}
+
+	buckets, err := us.rawAggBuckets(query, true)
+	if err != nil {
+		return nil, err
+	}
+	stats := make([]AggregatedStat, len(buckets))
+	for i, b := range buckets {
+		stats[i] = b.toAggregatedStat()
+	}
+	return stats, nil
+}
+
+// aggBucket carries additive aggregation sums so results from usage_daily and
+// raw usage_records scans can be merged before computing derived rates.
+type aggBucket struct {
+	Key              string
+	ProviderUUID     string
+	ProviderName     string
+	Model            string
+	Scenario         string
+	UserID           string
+	RequestCount     int64
+	TotalTokens      int64
+	InputTokens      int64
+	OutputTokens     int64
+	CacheInputTokens int64
+	SystemTokens     int64
+	ErrorCount       int64
+	StreamedCount    int64
+	LatencySum       int64
+}
+
+func (b aggBucket) toAggregatedStat() AggregatedStat {
+	return AggregatedStat{
+		Key:              b.Key,
+		ProviderUUID:     b.ProviderUUID,
+		ProviderName:     b.ProviderName,
+		Model:            b.Model,
+		Scenario:         b.Scenario,
+		UserID:           b.UserID,
+		RequestCount:     b.RequestCount,
+		TotalTokens:      b.TotalTokens,
+		InputTokens:      b.InputTokens,
+		OutputTokens:     b.OutputTokens,
+		CacheInputTokens: b.CacheInputTokens,
+		SystemTokens:     b.SystemTokens,
+		AvgInputTokens:   avgFloat(float64(b.InputTokens), b.RequestCount),
+		AvgOutputTokens:  avgFloat(float64(b.OutputTokens), b.RequestCount),
+		AvgLatencyMs:     avgFloat(float64(b.LatencySum), b.RequestCount),
+		ErrorCount:       b.ErrorCount,
+		ErrorRate:        rateFloat(b.ErrorCount, b.RequestCount),
+		StreamedCount:    b.StreamedCount,
+		StreamedRate:     rateFloat(b.StreamedCount, b.RequestCount),
+	}
+}
+
+// rawAggBuckets aggregates directly over usage_records. When applyLimit is
+// false, sorting/limiting is left to the caller (used for edge-day scans that
+// are merged with usage_daily results afterwards).
+func (us *UsageStore) rawAggBuckets(query UsageStatsQuery, applyLimit bool) ([]aggBucket, error) {
+	us.mu.RLock()
+	defer us.mu.RUnlock()
 
 	// Build the base query
 	db := us.db.Model(&UsageRecord{})
@@ -322,25 +419,7 @@ func (us *UsageStore) GetAggregatedStats(query UsageStatsQuery) ([]AggregatedSta
 		keyField = "model"
 	}
 
-	type result struct {
-		Key              string
-		ProviderUUID     string
-		ProviderName     string
-		Model            string
-		Scenario         string
-		UserID           string
-		RequestCount     int64
-		TotalTokens      int64
-		InputTokens      int64
-		OutputTokens     int64
-		CacheInputTokens int64
-		SystemTokens     int64
-		ErrorCount       int64
-		StreamedCount    int64
-		AvgLatency       float64
-	}
-
-	var results []result
+	var results []aggBucket
 	selectClause := fmt.Sprintf(`
 		%s as key,
 		COALESCE(provider_uuid, '') as provider_uuid,
@@ -356,45 +435,18 @@ func (us *UsageStore) GetAggregatedStats(query UsageStatsQuery) ([]AggregatedSta
 		COALESCE(SUM(system_tokens), 0) as system_tokens,
 		COALESCE(SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END), 0) as error_count,
 		COALESCE(SUM(CASE WHEN streamed = true THEN 1 ELSE 0 END), 0) as streamed_count,
-		COALESCE(AVG(latency_ms), 0) as avg_latency
+		COALESCE(SUM(latency_ms), 0) as latency_sum
 	`, keyField)
 
-	if err := db.
-		Select(selectClause).
-		Group(groupBy).
-		Order(buildOrderBy(query.SortBy, query.SortOrder)).
-		Limit(query.Limit).
-		Scan(&results).Error; err != nil {
+	db = db.Select(selectClause).Group(groupBy)
+	if applyLimit {
+		db = db.Order(buildOrderBy(query.SortBy, query.SortOrder)).Limit(query.Limit)
+	}
+	if err := db.Scan(&results).Error; err != nil {
 		return nil, err
 	}
 
-	// Convert to AggregatedStat
-	stats := make([]AggregatedStat, len(results))
-	for i, r := range results {
-		stats[i] = AggregatedStat{
-			Key:              r.Key,
-			ProviderUUID:     r.ProviderUUID,
-			ProviderName:     r.ProviderName,
-			Model:            r.Model,
-			Scenario:         r.Scenario,
-			UserID:           r.UserID,
-			RequestCount:     r.RequestCount,
-			TotalTokens:      r.TotalTokens,
-			InputTokens:      r.InputTokens,
-			OutputTokens:     r.OutputTokens,
-			CacheInputTokens: r.CacheInputTokens,
-			SystemTokens:     r.SystemTokens,
-			AvgInputTokens:   avgFloat(float64(r.InputTokens), r.RequestCount),
-			AvgOutputTokens:  avgFloat(float64(r.OutputTokens), r.RequestCount),
-			AvgLatencyMs:     r.AvgLatency,
-			ErrorCount:       r.ErrorCount,
-			ErrorRate:        rateFloat(r.ErrorCount, r.RequestCount),
-			StreamedCount:    r.StreamedCount,
-			StreamedRate:     rateFloat(r.StreamedCount, r.RequestCount),
-		}
-	}
-
-	return stats, nil
+	return results, nil
 }
 
 // TimeSeriesData represents a single time bucket in time series data
@@ -410,10 +462,20 @@ type TimeSeriesData struct {
 	AvgLatencyMs     float64 `json:"avg_latency_ms"`
 }
 
-// GetTimeSeries returns time-series data for usage
+// GetTimeSeries returns time-series data for usage. Day-interval queries
+// spanning several completed days are served from usage_daily with raw scans
+// only for the partial edge days (see usage_daily.go).
 func (us *UsageStore) GetTimeSeries(interval string, startTime, endTime time.Time, filters map[string]string) ([]TimeSeriesData, error) {
-	us.mu.Lock()
-	defer us.mu.Unlock()
+	if data, ok, err := us.timeSeriesFromDaily(interval, startTime, endTime, filters); ok {
+		return data, err
+	}
+	return us.rawTimeSeries(interval, startTime, endTime, filters)
+}
+
+// rawTimeSeries aggregates time buckets directly over usage_records.
+func (us *UsageStore) rawTimeSeries(interval string, startTime, endTime time.Time, filters map[string]string) ([]TimeSeriesData, error) {
+	us.mu.RLock()
+	defer us.mu.RUnlock()
 
 	var timeFormat string
 	switch interval {
@@ -498,36 +560,41 @@ func (us *UsageStore) GetTimeSeries(interval string, startTime, endTime time.Tim
 
 // GetRecords returns individual usage records (for debugging/audit)
 func (us *UsageStore) GetRecords(startTime, endTime time.Time, filters map[string]string, limit, offset int) ([]UsageRecord, int64, error) {
-	us.mu.Lock()
-	defer us.mu.Unlock()
+	us.mu.RLock()
+	defer us.mu.RUnlock()
 
-	db := us.db.Model(&UsageRecord{})
-
-	if !startTime.IsZero() {
-		db = db.Where("timestamp >= ?", startTime)
-	}
-	if !endTime.IsZero() {
-		db = db.Where("timestamp <= ?", endTime)
-	}
-
-	for key, value := range filters {
-		db = db.Where(key+" = ?", value)
-	}
-
-	// Get total count
-	var total int64
-	if err := db.Count(&total).Error; err != nil {
-		return nil, 0, err
+	base := func() *gorm.DB {
+		q := us.db.Model(&UsageRecord{})
+		if !startTime.IsZero() {
+			q = q.Where("timestamp >= ?", startTime)
+		}
+		if !endTime.IsZero() {
+			q = q.Where("timestamp <= ?", endTime)
+		}
+		for key, value := range filters {
+			q = q.Where(key+" = ?", value)
+		}
+		return q
 	}
 
 	// Get records with pagination
 	var records []UsageRecord
-	if err := db.
+	if err := base().
 		Order("timestamp DESC").
 		Limit(limit).
 		Offset(offset).
 		Find(&records).Error; err != nil {
 		return nil, 0, err
+	}
+
+	// The full COUNT(*) scan is only needed when the page might not contain
+	// everything; the common dashboard case (first page, under the limit)
+	// gets the total for free.
+	total := int64(offset + len(records))
+	if len(records) == limit {
+		if err := base().Count(&total).Error; err != nil {
+			return nil, 0, err
+		}
 	}
 
 	return records, total, nil
@@ -536,8 +603,8 @@ func (us *UsageStore) GetRecords(startTime, endTime time.Time, filters map[strin
 // GetRecordsAfterID returns usage records with id greater than lastID.
 // On initial sync, startTime can be used to cap the historical backfill window.
 func (us *UsageStore) GetRecordsAfterID(lastID uint, startTime time.Time, limit int) ([]UsageRecord, error) {
-	us.mu.Lock()
-	defer us.mu.Unlock()
+	us.mu.RLock()
+	defer us.mu.RUnlock()
 
 	if limit <= 0 {
 		limit = 100
@@ -559,45 +626,33 @@ func (us *UsageStore) GetRecordsAfterID(lastID uint, startTime time.Time, limit 
 	return records, nil
 }
 
-// DeleteOlderThan deletes records older than the specified date
+// DeleteOlderThan deletes records older than the specified date, together
+// with the daily aggregates derived from them so both views stay consistent.
 func (us *UsageStore) DeleteOlderThan(cutoffDate time.Time) (int64, error) {
 	us.mu.Lock()
-	defer us.mu.Unlock()
-
 	result := us.db.Where("timestamp < ?", cutoffDate).Delete(&UsageRecord{})
+	if result.Error == nil {
+		// Include the boundary day: its aggregate now over-counts deleted
+		// records and will be rebuilt from the remaining raw rows on the
+		// next query.
+		us.db.Where("date <= ?", cutoffDate.UTC().Format(dailyDateLayout)).Delete(&UsageDailyRecord{})
+	}
+	us.mu.Unlock()
+
+	// Aggregates for deleted days must be recomputed if queried again.
+	us.aggMu.Lock()
+	us.aggLoaded = false
+	us.aggregatedDays = nil
+	us.aggMu.Unlock()
+
 	return result.RowsAffected, result.Error
 }
 
-// AggregateToDaily aggregates records to daily summaries
+// AggregateToDaily (re)builds the usage_daily rows for the UTC day containing
+// the given time. It returns the number of aggregate rows written.
 func (us *UsageStore) AggregateToDaily(date time.Time) (int64, error) {
-	us.mu.Lock()
-	defer us.mu.Unlock()
-
-	// Aggregate usage records to daily summaries
-	result := us.db.Exec(`
-		INSERT OR REPLACE INTO usage_daily (date, provider_uuid, provider_name, model, request_count, total_tokens, input_tokens, output_tokens, cache_input_tokens, system_tokens, error_count)
-		SELECT
-			date(?) as date,
-			provider_uuid,
-			provider_name,
-			model,
-			COUNT(*) as request_count,
-			SUM(total_tokens) as total_tokens,
-			SUM(input_tokens) as input_tokens,
-			SUM(output_tokens) as output_tokens,
-			SUM(cache_input_tokens) as cache_input_tokens,
-			SUM(system_tokens) as system_tokens,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
-		FROM usage_records
-		WHERE date(timestamp) = date(?)
-		GROUP BY provider_uuid, provider_name, model
-	`, date, date)
-
-	if result.Error != nil {
-		return 0, result.Error
-	}
-
-	return result.RowsAffected, nil
+	day := utcDayStart(date)
+	return us.aggregateDay(day.Format(dailyDateLayout), day)
 }
 
 // Helper functions
@@ -610,7 +665,7 @@ func buildOrderBy(sortBy, sortOrder string) string {
 	case "request_count":
 		return fmt.Sprintf("request_count %s", sortOrder)
 	case "avg_latency":
-		return fmt.Sprintf("avg_latency %s", sortOrder)
+		return fmt.Sprintf("(latency_sum * 1.0 / request_count) %s", sortOrder)
 	default: // total_tokens
 		return fmt.Sprintf("total_tokens %s", sortOrder)
 	}

--- a/internal/server/middleware/gzip.go
+++ b/internal/server/middleware/gzip.go
@@ -35,15 +35,16 @@ func (g *gzipResponseWriter) WriteString(s string) (int, error) {
 	return g.gz.Write([]byte(s))
 }
 
-// GzipHandler wraps a JSON-producing handler so its response body is
-// gzip-compressed when the client accepts it. Intended for endpoints that can
-// return large payloads (usage stats, time series, records). Do not use it on
-// streaming/SSE endpoints. The unnamed signature keeps it assignable to both
-// gin.HandlerFunc and swagger.Handler.
-func GzipHandler(handler func(c *gin.Context)) func(c *gin.Context) {
+// Gzip returns gin middleware that gzip-compresses the response body when
+// the client accepts it. Intended for endpoints that can return large JSON
+// payloads (usage stats, time series, records) — register it per-route via
+// swagger.WithMiddleware(middleware.Gzip()) rather than wrapping the handler
+// directly, so it composes through the normal auth/CORS middleware chain
+// instead of bypassing it. Do not use it on streaming/SSE endpoints.
+func Gzip() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !strings.Contains(c.GetHeader("Accept-Encoding"), "gzip") {
-			handler(c)
+			c.Next()
 			return
 		}
 
@@ -56,7 +57,7 @@ func GzipHandler(handler func(c *gin.Context)) func(c *gin.Context) {
 		c.Header("Vary", "Accept-Encoding")
 		c.Writer = writer
 
-		handler(c)
+		c.Next()
 
 		c.Writer = writer.ResponseWriter
 		if writer.wrote {

--- a/internal/server/middleware/gzip.go
+++ b/internal/server/middleware/gzip.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+// gzipWriterPool recycles gzip writers across requests to avoid the
+// per-request allocation cost of gzip.NewWriter.
+var gzipWriterPool = sync.Pool{
+	New: func() interface{} {
+		// BestSpeed keeps CPU cost negligible while still shrinking JSON
+		// payloads roughly 10x.
+		w, _ := gzip.NewWriterLevel(nil, gzip.BestSpeed)
+		return w
+	},
+}
+
+type gzipResponseWriter struct {
+	gin.ResponseWriter
+	gz    *gzip.Writer
+	wrote bool
+}
+
+func (g *gzipResponseWriter) Write(data []byte) (int, error) {
+	g.wrote = true
+	return g.gz.Write(data)
+}
+
+func (g *gzipResponseWriter) WriteString(s string) (int, error) {
+	g.wrote = true
+	return g.gz.Write([]byte(s))
+}
+
+// GzipHandler wraps a JSON-producing handler so its response body is
+// gzip-compressed when the client accepts it. Intended for endpoints that can
+// return large payloads (usage stats, time series, records). Do not use it on
+// streaming/SSE endpoints. The unnamed signature keeps it assignable to both
+// gin.HandlerFunc and swagger.Handler.
+func GzipHandler(handler func(c *gin.Context)) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		if !strings.Contains(c.GetHeader("Accept-Encoding"), "gzip") {
+			handler(c)
+			return
+		}
+
+		gz := gzipWriterPool.Get().(*gzip.Writer)
+		gz.Reset(c.Writer)
+		defer gzipWriterPool.Put(gz)
+
+		writer := &gzipResponseWriter{ResponseWriter: c.Writer, gz: gz}
+		c.Header("Content-Encoding", "gzip")
+		c.Header("Vary", "Accept-Encoding")
+		c.Writer = writer
+
+		handler(c)
+
+		c.Writer = writer.ResponseWriter
+		if writer.wrote {
+			_ = gz.Close()
+		} else {
+			// Nothing was written (e.g. 204); drop the compression headers
+			// instead of emitting an empty gzip stream.
+			header := c.Writer.Header()
+			header.Del("Content-Encoding")
+		}
+	}
+}

--- a/internal/server/middleware/gzip_test.go
+++ b/internal/server/middleware/gzip_test.go
@@ -16,9 +16,9 @@ func TestGzipHandlerCompressesWhenAccepted(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
 	payload := strings.Repeat(`{"key":"value"},`, 500)
-	engine.GET("/data", GzipHandler(func(c *gin.Context) {
+	engine.GET("/data", Gzip(), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"data": payload})
-	}))
+	})
 
 	req, _ := http.NewRequest("GET", "/data", nil)
 	req.Header.Set("Accept-Encoding", "gzip")
@@ -57,9 +57,9 @@ func TestGzipHandlerCompressesWhenAccepted(t *testing.T) {
 func TestGzipHandlerPassthroughWithoutAcceptEncoding(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
-	engine.GET("/data", GzipHandler(func(c *gin.Context) {
+	engine.GET("/data", Gzip(), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"ok": true})
-	}))
+	})
 
 	req, _ := http.NewRequest("GET", "/data", nil)
 	w := httptest.NewRecorder()
@@ -79,9 +79,9 @@ func TestGzipHandlerPassthroughWithoutAcceptEncoding(t *testing.T) {
 func TestGzipHandlerEmptyBody(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
-	engine.GET("/empty", GzipHandler(func(c *gin.Context) {
+	engine.GET("/empty", Gzip(), func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
-	}))
+	})
 
 	req, _ := http.NewRequest("GET", "/empty", nil)
 	req.Header.Set("Accept-Encoding", "gzip")

--- a/internal/server/middleware/gzip_test.go
+++ b/internal/server/middleware/gzip_test.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGzipHandlerCompressesWhenAccepted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	payload := strings.Repeat(`{"key":"value"},`, 500)
+	engine.GET("/data", GzipHandler(func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": payload})
+	}))
+
+	req, _ := http.NewRequest("GET", "/data", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if w.Body.Len() >= len(payload) {
+		t.Fatalf("compressed body (%d bytes) not smaller than payload (%d bytes)", w.Body.Len(), len(payload))
+	}
+
+	gz, err := gzip.NewReader(w.Body)
+	if err != nil {
+		t.Fatalf("gzip.NewReader failed: %v", err)
+	}
+	decoded, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("decompression failed: %v", err)
+	}
+	var body struct {
+		Data string `json:"data"`
+	}
+	if err := json.Unmarshal(decoded, &body); err != nil {
+		t.Fatalf("decompressed body is not valid JSON: %v", err)
+	}
+	if body.Data != payload {
+		t.Fatal("decompressed payload does not match original")
+	}
+}
+
+func TestGzipHandlerPassthroughWithoutAcceptEncoding(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/data", GzipHandler(func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	}))
+
+	req, _ := http.NewRequest("GET", "/data", nil)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding = %q, want empty", got)
+	}
+	if !strings.Contains(w.Body.String(), `"ok":true`) {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestGzipHandlerEmptyBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/empty", GzipHandler(func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	}))
+
+	req, _ := http.NewRequest("GET", "/empty", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Fatalf("expected empty body, got %d bytes", w.Body.Len())
+	}
+}

--- a/internal/server/module/usage/routes.go
+++ b/internal/server/module/usage/routes.go
@@ -8,7 +8,8 @@ import (
 // RegisterRoutes registers the usage API routes with swagger documentation
 func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	// GET /api/v1/usage/stats - Get aggregated usage statistics
-	router.GET("/usage/stats", middleware.GzipHandler(handler.GetStats),
+	router.GET("/usage/stats", handler.GetStats,
+		swagger.WithMiddleware(middleware.Gzip()),
 		swagger.WithTags("usage"),
 		swagger.WithDescription("Returns aggregated usage statistics with flexible grouping and filtering"),
 		swagger.WithQueryConfig("group_by", swagger.QueryParamConfig{
@@ -101,7 +102,8 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	)
 
 	// GET /api/v1/usage/timeseries - Get time-series usage data
-	router.GET("/usage/timeseries", middleware.GzipHandler(handler.GetTimeSeries),
+	router.GET("/usage/timeseries", handler.GetTimeSeries,
+		swagger.WithMiddleware(middleware.Gzip()),
 		swagger.WithTags("usage"),
 		swagger.WithDescription("Returns time-series data for usage with configurable intervals"),
 		swagger.WithQueryConfig("interval", swagger.QueryParamConfig{
@@ -149,7 +151,8 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	)
 
 	// GET /api/v1/usage/records - Get individual usage records
-	router.GET("/usage/records", middleware.GzipHandler(handler.GetRecords),
+	router.GET("/usage/records", handler.GetRecords,
+		swagger.WithMiddleware(middleware.Gzip()),
 		swagger.WithTags("usage"),
 		swagger.WithDescription("Returns individual usage records (for debugging/audit)"),
 		swagger.WithQueryConfig("start_time", swagger.QueryParamConfig{

--- a/internal/server/module/usage/routes.go
+++ b/internal/server/module/usage/routes.go
@@ -1,13 +1,14 @@
 package usage
 
 import (
+	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/swagger"
 )
 
 // RegisterRoutes registers the usage API routes with swagger documentation
 func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	// GET /api/v1/usage/stats - Get aggregated usage statistics
-	router.GET("/usage/stats", handler.GetStats,
+	router.GET("/usage/stats", middleware.GzipHandler(handler.GetStats),
 		swagger.WithTags("usage"),
 		swagger.WithDescription("Returns aggregated usage statistics with flexible grouping and filtering"),
 		swagger.WithQueryConfig("group_by", swagger.QueryParamConfig{
@@ -100,7 +101,7 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	)
 
 	// GET /api/v1/usage/timeseries - Get time-series usage data
-	router.GET("/usage/timeseries", handler.GetTimeSeries,
+	router.GET("/usage/timeseries", middleware.GzipHandler(handler.GetTimeSeries),
 		swagger.WithTags("usage"),
 		swagger.WithDescription("Returns time-series data for usage with configurable intervals"),
 		swagger.WithQueryConfig("interval", swagger.QueryParamConfig{
@@ -148,7 +149,7 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	)
 
 	// GET /api/v1/usage/records - Get individual usage records
-	router.GET("/usage/records", handler.GetRecords,
+	router.GET("/usage/records", middleware.GzipHandler(handler.GetRecords),
 		swagger.WithTags("usage"),
 		swagger.WithDescription("Returns individual usage records (for debugging/audit)"),
 		swagger.WithQueryConfig("start_time", swagger.QueryParamConfig{


### PR DESCRIPTION
## Summary

Optimizes dashboard performance by introducing lazy pre-aggregation of usage statistics into a `usage_daily` table and adding gzip compression to large API responses. Dashboard queries spanning multiple days now combine pre-aggregated daily buckets with raw scans of partial edge days, reducing query time from hundreds of milliseconds to single digits. Response payloads are compressed ~10x when clients support gzip.

## Key Changes

### Backend: Usage Daily Pre-aggregation (`internal/data/db/usage_daily.go`)
- **New `usage_daily` table schema (v2)**: stores one row per `(UTC day, provider_uuid, model, user_id)` with additive sums (request_count, token counts, error_count, streamed_count, latency_sum_ms). Date stored as `YYYY-MM-DD` TEXT matching SQLite's `date(timestamp)` bucketing.
- **Lazy backfill**: first query needing a completed day triggers `aggregateDay()` (DELETE + INSERT…SELECT in transaction). Days tracked in memory and persisted in table; only aggregated ≥1h past UTC midnight to capture late-finishing requests.
- **Smart query routing**: `GetAggregatedStats` and `GetTimeSeries` with compatible filters (group_by ∈ {model, provider, user, daily}; no scenario/rule/status filters) spanning ≥2 complete days split into: raw scan of leading partial day → `usage_daily` lookup for complete days → raw scan of trailing partial day(s). Results merge additively; averages recompute from sums. Incompatible queries fall back to raw scan.
- **Deletion consistency**: `DeleteOlderThan` also purges `usage_daily` rows and resets in-memory cache so boundary day re-aggregates from remaining raw rows.
- **Schema migration**: old-layout `usage_daily` tables (missing `user_id`, `streamed_count`, `latency_sum_ms` columns) are dropped and rebuilt on startup; safe since table holds only derived data.

### Backend: Response Compression (`internal/server/middleware/gzip.go`)
- **GzipHandler middleware**: wraps JSON-producing handlers to gzip-compress responses when client sends `Accept-Encoding: gzip`. Uses pooled gzip writers (BestSpeed level) to minimize per-request allocation cost.
- **Applied to usage endpoints** (`internal/server/module/usage/routes.go`): wraps `/api/v1/usage/stats`, `/api/v1/usage/timeseries`, `/api/v1/usage/records` to compress large payloads ~10x.

### Database: Concurrency Improvements
- **RWMutex for UsageStore**: changed from `sync.Mutex` to `sync.RWMutex` so dashboard queries (read lock) don't serialize behind proxy usage writes (write lock) or each other. WAL mode supports concurrent readers.
- **Daily aggregation bookkeeping**: separate `aggMu` mutex guards in-memory `aggregatedDays` map and `aggLoaded` flag.

### Frontend: Number Formatting
- **Centralized `formatNumber` utility** (`frontend/src/components/dashboard/chartStyles.ts`): uses `Intl.NumberFormat` with compact notation (999, 50K, 1.5M, 20.4B, 1.1T) instead of hand-rolled unit ladder. Exported and reused across TokenHeatmap, ServiceStatsTable, and chart utilities.
- **Dashboard refactor** (`frontend/src/pages/DashboardPage.tsx`): split data loading into `loadFilterOptions` (providers, tokens — fetched once) and `loadData` (stats, timeseries — fetched on filter/range change). Added request sequence tracking to drop out-of-order responses when filters change faster than requests complete.

### Tests
- **Comprehensive test suite** (`internal/data/db/usage_daily_test.go`): verifies daily-path results match raw scans across all group_by modes, with/without filters, and after deletion. Tests public API routing and time series consistency.
- **Gzip middleware tests** (`internal/server/middleware/gzip_test.go`

https://claude.ai/code/session_01UcmQEBtubRHJpuGhLoDGwT