### PR TITLE
fix(loadbalance): stabilize tier failover recovery

### DIFF
--- a/.design/tier-routing.md
+++ b/.design/tier-routing.md
@@ -1,6 +1,6 @@
 # Tier-Based Service Routing
 
-Status: shipped (v1) on branch `claude/priority-service-routing-dIQfX`. Tracking commits: `a362ca3`, `5221109`. UX redesign on PR #1096 (`claude/dreamy-hawking-DQaYY`).
+Status: shipped (v1) on branch `claude/priority-service-routing-dIQfX`. Tracking commits: `a362ca3`, `5221109`. UX redesign on PR #1096 (`claude/dreamy-hawking-DQaYY`). Oscillation hardening (recovery hysteresis, PromotionHold, rule-scoped breaker) on branch `bugfix/tier` — commits `58508a25` (hysteresis), `9fe19215` (PromotionHold), `483aec74` (rule-scoped breaker); see "Recovery" below.
 
 ## Why
 
@@ -23,7 +23,7 @@ A second, related gap: when an upstream service starts failing, nothing in the b
 
 - **Not** a cross-request load balancer rebalance — existing tactics stay intact and remain the default.
 - **Not** a request-level retry loop. When a request fails mid-flight, the client still sees the error. Failover happens on the **next** request after the breaker trips. (Mid-request retry is parked as v2 — see "Future work".)
-- **Not** a global health system. The breaker is process-local and rule- scoped through the service-id key; we deliberately avoided Redis-level shared state to keep the deployment story simple.
+- **Not** a global health system. The breaker is process-local and **rule-scoped**: keyed by `(ruleUUID, provider:model)` so each rule owns independent breaker state per service (a service failing under one rule does not fail it for another). We deliberately avoided Redis-level shared state to keep the deployment story simple.
 
 ## How
 
@@ -59,9 +59,17 @@ The breaker is a three-state machine (`Closed → Open → HalfOpen`):
 
 - **Closed** — normal. `Allow()` returns true, failures are counted.
 - **Open** — too many consecutive failures (`FailureThreshold`, default 3). `Allow()` returns false. After `OpenDuration` (default 30 s) the next `Allow()` call lazily flips to HalfOpen.
-- **HalfOpen** — exactly one probe is permitted. Success → Closed, failure → Open with a fresh timer.
+- **HalfOpen** — exactly one probe is permitted at a time. Recovery requires **`RecoveryThreshold` (default 3) consecutive probe successes** to close; a single success just releases the probe slot so the next probe can go through. Any probe failure re-opens with a fresh timer.
 
 Recovery requires **no separate scheduler**. Selection re-evaluates the tier list every request, and the breaker's lazy state transition admits one probe naturally. Active probing was considered and rejected for v1 — for hot rules it's redundant, and for cold rules there is no one to serve anyway.
+
+#### Hysteresis on recovery (why `RecoveryThreshold = 3`)
+
+Recovery is deliberately **harder than tripping** (`down = 3`, `up = 3`, symmetric). A single lucky probe no longer promotes a still-flaky primary: a half-sick T0 that trips → fails over to T1 → recovers on one probe → takes full traffic → trips again would oscillate on a ~30 s loop. Requiring a streak means a flapping upstream has to prove itself across multiple probes before it reclaims traffic. See `internal/loadbalance/breaker.go` (`RecordSuccess` accumulates `halfOpenSuccess`).
+
+#### PromotionHold — gradual return-to-primary
+
+Even with hysteresis, the instant T0 closes, every session pinned to T1 becomes affinity-ineligible at once and migrates back — a batch flip that can re-trip T0 under full load. **PromotionHold** (default 60 s) de-jitters this: a freshly-recovered primary only takes **new** sessions during the hold; sessions already pinned to a lower tier stay there until the primary has stayed recovered past the hold. The breaker stamps `closedSince` on recovery; `IsAffinityEligible` keeps a low-tier pin valid while a higher-priority tier is within its hold. Set `PromotionHold <= 0` to disable.
 
 ### Breaker threshold — why 3
 
@@ -92,11 +100,11 @@ Session affinity (`Flags.SessionAffinity`) pins a session to the service it firs
 
 For tier rules this was buggy: `AffinityStage` ran **before** the tier strategy and honored the pin **without consulting the breaker**. So a session pinned to a fallback tier during a brief primary outage stuck there forever — the primary could recover and the session never came back ("configured t1 but auto-jumps to t2"; or a pinned-but-failing t2 that keeps 500ing instead of failing over).
 
-Fix: the pin is honored only while the pinned service is one the strategy would pick *right now* — `typ.IsAffinityEligible`. It keys off **config shape, not tactic label** ("tier" is just the emergent shape of a multi-layer rule), so one check covers every shape:
+Fix: the pin is honored only while the pinned service is one the strategy would pick *right now* — `typ.IsAffinityEligible(ruleUUID, services, target)`. It is rule-scoped (the breaker read keys on `ruleUUID`) and keys off **config shape, not tactic label** ("tier" is just the emergent shape of a multi-layer rule), so one check covers every shape:
 
 - **one service** — always eligible (nothing else to pick).
 - **one layer, many services** — eligible iff the pinned service's own breaker is available; a pin to a *dead peer* is dropped while healthy peers exist.
-- **many layers** — eligible iff the pinned service is breaker-available *and* in the highest-priority tier that currently has any available service; a pin to a fallback tier is dropped once the primary recovers.
+- **many layers** — eligible iff the pinned service is breaker-available *and* in the highest-priority tier that currently has any available service; a pin to a fallback tier is dropped once the primary recovers — **unless** the primary just recovered and is still within `PromotionHold` (see Recovery), in which case the low-tier pin is kept a little longer to avoid a batch flip-flop.
 
 Decision flow (pinned service = `P`):
 
@@ -186,11 +194,12 @@ The "user moves a service card to a different tier" event has to cross five laye
 └──────────────────────────────────────────────────────────────────────┘
                                   ↓
 ┌─ Per-request feedback into the breaker ──────────────────────────────┐
-│  Dispatch finishes → ProtocolRecorder:                                │
-│       RecordResponse → loadbalance.RecordServiceSuccess(serviceID)    │
-│       RecordError    → loadbalance.RecordServiceFailure(serviceID)    │
+│  Dispatch finishes → ProtocolRecorder (bound to ruleUUID):            │
+│       RecordResponse → loadbalance.RecordServiceSuccess(ruleUUID, sid)│
+│       RecordError    → loadbalance.RecordServiceFailure(ruleUUID, sid)│
 │  Same DefaultBreakerStore the selection logic consulted, so the next  │
-│  request's TierTactic sees the updated state.                         │
+│  request's TierTactic sees the updated state. State is keyed per rule │
+│  — other rules using the same provider:model are unaffected.          │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -201,18 +210,18 @@ This is pinned down by `TestTierRouting_EndToEnd` in `internal/server/priority_r
 1. Unmarshals a Rule JSON with `lb_tactic.type = "tier"`,
 2. Asserts `LBTactic.Params` is a `*TierParams` after decode,
 3. Calls `LoadBalancer.SelectService` and asserts the T0 service is picked,
-4. Trips the breaker via `DefaultBreakerStore.RecordFailure` exactly as the recorder does,
+4. Trips the breaker via `DefaultBreakerStore.RecordFailure(ruleUUID, …)` exactly as the recorder does,
 5. Asserts the next pick falls back to T1,
 6. Records a success and asserts the pick returns to T0.
 
 ### Wiring failures to the breaker
 
-`ProtocolRecorder` already sees every success and failure of every upstream call. We added two lines:
+`ProtocolRecorder` already sees every success and failure of every upstream call. We added the bridge:
 
-- `RecordResponse(provider, model)` → `RecordServiceSuccess(serviceID)`
-- `RecordError(err)` → `RecordServiceFailure(serviceID)`
+- `RecordResponse(provider, model)` → `RecordServiceSuccess(ruleUUID, serviceID)`
+- `RecordError(err)` → `RecordServiceFailure(ruleUUID, serviceID)`
 
-The `serviceID` is computed from `provider.UUID + ":" + model`, matching the format `Service.ServiceID()` produces, so the breaker registry's keys line up exactly with the selection pool. **Zero changes** to the dispatch hot path were required.
+The recorder binds `ruleUUID` once at creation (`EnsureProtocolRecorder` reads the rule already on the gin context via `ContextKeyRule`); the rule is fixed across failover attempts so per-attempt `SetActiveService` doesn't touch it. The `serviceID` is `FormatServiceID(provider.UUID, model)` = `"provider/model"`, and the breaker key is `FormatBreakerKey(ruleUUID, serviceID)` = `"ruleUUID/provider/model"` — matching `Service.ServiceID()` for the service half, so the breaker registry's keys line up exactly with the selection pool. **Zero changes** to the dispatch hot path were required.
 
 ### Frontend UX
 
@@ -253,13 +262,13 @@ There is **no independent "tier mode"** in tingly-box — every routing behavior
 
 Config shape sets the *space* of choices; runtime state picks within it:
 
-- **Breaker** per service (closed / open / half-open, process-wide `DefaultBreakerStore`) — drives tier demotion, the half-open recovery probe, and affinity eligibility. It is the authoritative signal for 5xx failures.
+- **Breaker** per (rule, service) (closed / open / half-open, process-wide `DefaultBreakerStore` keyed by `(ruleUUID, provider:model)`) — drives tier demotion, the half-open recovery probe, and affinity eligibility. It is the authoritative signal for 5xx failures. Each rule has independent state per service, so traffic under one rule cannot trip another rule's primary.
 - **Active** flag — inactive services are excluded everywhere (`GetActiveServices`); `IsAffinityEligible` mirrors this (an inactive service must not make its tier look "available").
 - **Health** (429 / auth) via `HealthFilter`/`HealthMonitor` — a *separate* signal from the breaker (5xx feed only the breaker), applied by the `HealthStage` filter.
 
 ### Affinity-eligibility truth table
 
-What `typ.IsAffinityEligible(activeServices, P)` encodes for a pinned service `P` (it mirrors `TierTactic`'s bucket walk using the non-consuming `BreakerStore.IsAvailable`, so it never steals the half-open probe):
+What `typ.IsAffinityEligible(ruleUUID, activeServices, P)` encodes for a pinned service `P` (it mirrors `TierTactic`'s bucket walk using the non-consuming `BreakerStore.IsAvailable`, so it never steals the half-open probe; the breaker read is rule-scoped via `ruleUUID`):
 
 | Situation | Honor pin to P? |
 |---|---|
@@ -267,7 +276,8 @@ What `typ.IsAffinityEligible(activeServices, P)` encodes for a pinned service `P
 | Flat, P breaker available | yes |
 | Flat, P breaker open, a peer available | no → re-pin to a healthy peer |
 | Cascade/Grid, P available **and** P.tier == top available tier | yes |
-| Cascade/Grid, a higher tier has recovered (P sits below it) | no → re-pin up to the recovered tier |
+| Cascade/Grid, a higher tier recovered **and** still within `PromotionHold` | yes (keep low-tier pin — gradual return) |
+| Cascade/Grid, a higher tier has recovered (P sits below it, past hold) | no → re-pin up to the recovered tier |
 | Every breaker open | yes iff P is in the lowest tier (degrade-don't-disappear) |
 | P inactive | no (declined) |
 
@@ -290,7 +300,7 @@ On a decline the pipeline falls through to the strategy, which re-selects a curr
 | Users with multiple equivalent accounts | First-class failover. Put the main account at T0, the backup at T1, walk away. |
 | Users running cost-tiered providers | Same model with a cheap-then-expensive cascade. |
 | Operators of any production rule | Free circuit breaking. Even users on the existing tactics get failure isolation as soon as they assign a single tier. |
-| Anyone debugging | The recorder now reports per-service success/failure into the breaker, and the breaker state is exposed via `BreakerStore.Snapshot()` for future surfacing. |
+| Anyone debugging | The recorder now reports per-service success/failure into the (rule-scoped) breaker, so a flapping service's state is visible per rule without cross-rule confusion. |
 
 The feature is **additive**: rules without explicit tiers behave exactly as before; the new tactic is opt-in via the UI.
 
@@ -368,7 +378,7 @@ Verified by: cross-style e2e tests in `internal/protocoltest/failover_test.go` (
 1. **Mid-stream failover (v4)** — pre-content retry is in place on every streaming path; the remaining gap is reconnecting to the next tier after content has already started flowing. Needs response reassembly or protocol-aware "rewind" semantics; out of scope until users actually hit it.
 2. ~~**Heterogeneous fallback**~~ — **Done (v3).** The transform chain re-runs per attempt, lifting the "same-style only" v2 constraint and carrying each tier's own model. See "Heterogeneous (cross-style) failover" above.
 3. **Active half-open probing** — opt-in goroutine that probes Open breakers on a cadence, useful for cold rules.
-4. **Per-rule breaker thresholds** — currently process-wide defaults. Could be surfaced as a Rule-level config block.
+4. **Per-rule breaker thresholds** — breaker *state* is already rule-scoped (each rule has independent state per service), but the tunables (`FailureThreshold`, `OpenDuration`, `RecoveryThreshold`, `PromotionHold`) are still process-wide defaults. Could be surfaced as a Rule-level config block.
 5. **Failover decision log + UI** — the recorder already sees every success/failure attribution; surface "request X went to service A → fell back to B" in the system log page.
 6. **Dispatch simulator** — read-only "explain plan" that shows which service a hypothetical request would land on. Particularly useful in combination with smart routing.
 
@@ -376,11 +386,13 @@ Verified by: cross-style e2e tests in `internal/protocoltest/failover_test.go` (
 
 Backend
 - `internal/loadbalance/load_balancing.go` — `Service.Tier`, `TacticTier` enum.
-- `internal/loadbalance/breaker.go` — three-state breaker + store.
+- `internal/loadbalance/breaker.go` — three-state breaker + rule-scoped store (keyed `(ruleUUID, serviceID)`), recovery hysteresis (`RecoveryThreshold`), PromotionHold (`closedSince`).
+- `internal/loadbalance/service_id.go` — `FormatServiceID`, `FormatBreakerKey`.
 - `internal/loadbalance/breaker_test.go`
-- `internal/typ/tactics.go` — `TierParams`, `TierTactic`, `groupServicesByTier`.
+- `internal/typ/tactics.go` — `TierParams`, `TierTactic`, `groupServicesByTier`, `IsAffinityEligible` (rule-scoped, PromotionHold-aware).
 - `internal/typ/priority_tactic_test.go`
-- `internal/server/protocol_recording.go` — recorder → breaker bridge.
+- `internal/server/recording/recorder.go` — recorder → (rule-scoped) breaker bridge (`BindRule`, `RecordResponse`/`RecordError`).
+- `internal/server/protocol_handler.go` — `EnsureProtocolRecorder` binds `ruleUUID` from the gin context.
 
 Frontend
 - `frontend/src/components/RoutingGraphTypes.ts` — `ConfigProvider.tier`, `ConfigRecord.lbTactic`.

--- a/.design/tier-routing.pencil.md
+++ b/.design/tier-routing.pencil.md
@@ -75,10 +75,10 @@ groupServicesByTier(active)         ← ascending; tier 0 is highest priority, t
 
 ## Cross-request — circuit breaker state machine
 
-Per-service three-state breaker (`internal/loadbalance/breaker.go`), keyed by `serviceID = provider.UUID + ":" + model`. No scheduler — the Open→HalfOpen flip is lazy, evaluated on the next `Allow()`.
+Three-state breaker (`internal/loadbalance/breaker.go`), **rule-scoped**: keyed by `FormatBreakerKey(ruleUUID, serviceID)` = `"ruleUUID/provider/model"` (serviceID = `FormatServiceID(provider.UUID, model)` = `"provider/model"`). Each rule owns independent state per service — a service failing under one rule does not trip another. No scheduler — the Open→HalfOpen flip is lazy, evaluated on the next `Allow()`. Recovery uses **hysteresis**: `RecoveryThreshold` (default 3) consecutive probe successes are required to close (a single success just frees the probe slot).
 
 ```
-                         RecordSuccess()
+                         RecordSuccess() × RecoveryThreshold (default 3)
             ┌──────────────────────────────────────────┐
             │                                           │
             ▼                                           │
@@ -86,22 +86,25 @@ Per-service three-state breaker (`internal/loadbalance/breaker.go`), keyed by `s
    │     CLOSED      │  (default 3)                     │
    │ Allow() = true  │ ───────────────────────────────►│
    │ count failures  │                                  ▼
-   └─────────────────┘                        ┌──────────────────┐
-            ▲                                  │      OPEN        │
-            │ RecordSuccess()                  │ Allow() = false  │
-            │ (probe ok)                       │ openedAt = now   │
-            │                                  └────────┬─────────┘
+   │ closedSince=now │                        ┌──────────────────┐
+   └─────────────────┘                        │      OPEN        │
+            ▲                                  │ Allow() = false  │
+            │ 3 consecutive                    │ openedAt = now   │
+            │ probe successes                  └────────┬─────────┘
+            │ (each frees slot)                         │
    ┌─────────────────┐                                  │
    │    HALF-OPEN    │  time.Since(openedAt) ≥           │
    │ Allow():        │  OpenDuration (default 30s)      │
    │  1st caller=true│ ◄────────────────────────────────┘
    │  others = false │      (lazy flip on next Allow())
+   │ halfOpenSuccess │
    └────────┬────────┘
             │ RecordFailure()  → back to OPEN, openedAt reset, probe slot freed
             └────────────────────────────────────────────────────────┘
 
-State() applies the same lazy Open→HalfOpen flip for read-consistent
-introspection (BreakerStore.Snapshot() for future UI surfacing).
+closedSince drives PromotionHold (default 60s): a freshly-recovered primary
+only takes NEW sessions; existing low-tier pins stay until the primary has
+stayed recovered past the hold (de-jitters batch return-to-primary).
 ```
 
 ## Cross-request — recorder → breaker feedback loop
@@ -115,12 +118,12 @@ The dispatch hot path needs **zero** changes: `ProtocolRecorder` already observe
   dispatch attempt on serviceID                       │
        │                                              │
        ├─ success → recorder.RecordResponse           │
-       │              └─ RecordServiceSuccess(id) ──┐  │
-       │                                            ▼  │
+       │              └─ RecordServiceSuccess(ruleUUID, id) ──┐  │
+       │                                            ▼           │
        └─ failure → recorder.RecordError            DefaultBreakerStore
-                      └─ RecordServiceFailure(id) ─►  (same keys: UUID:model)
+                      └─ RecordServiceFailure(ruleUUID, id) ─►  (key: ruleUUID/provider/model)
                                                      │
-                                                     └─ store.Allow(id) consulted
+                                                     └─ store.Allow(ruleUUID, id) consulted
                                                         by TierTactic above
    In-request failover re-binds the recorder per attempt
    (rec.SetActiveService) so a 2nd-attempt failure trips the

--- a/cli/harness/testdata/lb/cascade.yaml
+++ b/cli/harness/testdata/lb/cascade.yaml
@@ -1,5 +1,7 @@
-# cascade — primary fails 3x then recovers; watch the pin move to the fallback
-# tier and snap back to the primary after the breaker's open window elapses.
+# cascade — primary fails 3x then admits recovery probes; watch the pin move to
+# the fallback tier and snap back to the primary after the breaker's open window
+# elapses. Recovery hysteresis keeps the breaker half-open until enough
+# consecutive probes succeed.
 rule_uuid: cascade
 tactic: tier
 affinity_secs: 1800
@@ -14,7 +16,7 @@ expect:
   attempts: [openai/gpt-5.4]
   pin: openai/gpt-5.4
   breaker:
-    openai/gpt-5.4: closed
+    openai/gpt-5.4: half_open
     openai/gpt-5.5: closed
 program:
   - { request: session1 }
@@ -22,5 +24,5 @@ program:
   - { request: session1 }     # gpt-5.4 breaker opens here
   - { request: session1 }     # pin moves to gpt-5.5
   - { advance: 31s }          # past the breaker's 30s open window
-  - { request: session1 }     # half-open probe → gpt-5.4 recovers → pin snaps back
-  - { request: session1 }
+  - { request: session1 }     # half-open probe → gpt-5.4 success 1/3 → pin snaps back
+  - { request: session1 }     # second probe succeeds; breaker remains half-open

--- a/cli/harness/testdata/lb/halfopen.yaml
+++ b/cli/harness/testdata/lb/halfopen.yaml
@@ -1,8 +1,8 @@
-# halfopen — half-open recovery probe. Cascade shape; the primary trips after
-# 3 failures, stays open, then after an advance past OpenDuration (30s → 31s)
-# the breaker admits ONE half-open probe, which succeeds → breaker closed. The
-# half-open state is transient, so only final breaker states are asserted (not
-# the transient half_open, which has flipped to closed by the final snapshot).
+# halfopen — half-open recovery probes. Cascade shape; the primary trips after
+# 3 failures, stays open, then after an advance past OpenDuration (30s -> 31s)
+# the breaker admits one probe at a time. Recovery hysteresis requires three
+# consecutive successful probes before closing, so this shorter scenario ends
+# with the breaker still half_open.
 rule_uuid: halfopen
 tactic: tier
 affinity_secs: 1800
@@ -15,7 +15,7 @@ faults:
 expect:
   final_status: 200
   breaker:
-    openai/gpt-5.4: closed
+    openai/gpt-5.4: half_open
     openai/gpt-5.5: closed
 program:
   - { request: session1 }   # gpt-5.4 500 → gpt-5.5 (strike 1)
@@ -23,5 +23,5 @@ program:
   - { request: session1 }   # gpt-5.4 500 → gpt-5.5 (strike 3 → gpt-5.4 breaker OPEN)
   - { request: session1 }   # gpt-5.4 open → straight to gpt-5.5
   - { advance: 31s }        # past OpenDuration → gpt-5.4 half-open probe allowed
-  - { request: session1 }   # half-open probe to gpt-5.4 → 200 → breaker CLOSED
-  - { request: session1 }   # gpt-5.4 closed → gpt-5.4 directly
+  - { request: session1 }   # half-open probe to gpt-5.4 -> 200, success 1/3
+  - { request: session1 }   # second probe succeeds; breaker remains half_open

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -194,12 +194,15 @@ func (s BreakerState) String() string {
 	return "unknown"
 }
 
-// BreakerStore is a concurrent-safe registry of breakers keyed by service
-// identifier. Breakers are created lazily on first access.
+// BreakerStore is a concurrent-safe registry of breakers keyed by
+// (ruleUUID, serviceID). Breakers are created lazily on first access.
 //
-// The store is process-wide: two rules that reference the same
-// provider:model share breaker state. This is intentional — if a service
-// is failing, it is generally failing for every rule that uses it.
+// Breakers are rule-scoped: each rule owns independent breaker state per
+// service. A service failing for one rule does NOT fail it for another rule
+// that uses the same provider:model — each rule's failover decisions are
+// driven only by the traffic it observes. This mirrors the rule-scoped
+// affinity store (internal/server/affinity/affinity.go). Key composition lives
+// in FormatBreakerKey.
 type BreakerStore struct {
 	mu       sync.RWMutex
 	breakers map[string]*Breaker
@@ -223,11 +226,12 @@ func NewBreakerStore(failureThreshold int, openDuration time.Duration) *BreakerS
 	}
 }
 
-// Get returns the breaker for the given serviceID, creating one with the
-// store's default thresholds if needed.
-func (s *BreakerStore) Get(serviceID string) *Breaker {
+// Get returns the breaker for the given (ruleUUID, serviceID), creating one
+// with the store's default thresholds if needed.
+func (s *BreakerStore) Get(ruleUUID, serviceID string) *Breaker {
+	key := FormatBreakerKey(ruleUUID, serviceID)
 	s.mu.RLock()
-	if b, ok := s.breakers[serviceID]; ok {
+	if b, ok := s.breakers[key]; ok {
 		s.mu.RUnlock()
 		return b
 	}
@@ -235,17 +239,17 @@ func (s *BreakerStore) Get(serviceID string) *Breaker {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if b, ok := s.breakers[serviceID]; ok {
+	if b, ok := s.breakers[key]; ok {
 		return b
 	}
 	b := NewBreaker(s.failures, s.openFor)
-	s.breakers[serviceID] = b
+	s.breakers[key] = b
 	return b
 }
 
-// Allow is a convenience over Get(serviceID).Allow().
-func (s *BreakerStore) Allow(serviceID string) bool {
-	return s.Get(serviceID).Allow()
+// Allow is a convenience over Get(ruleUUID, serviceID).Allow().
+func (s *BreakerStore) Allow(ruleUUID, serviceID string) bool {
+	return s.Get(ruleUUID, serviceID).Allow()
 }
 
 // IsAvailable reports whether the service's breaker currently permits traffic,
@@ -254,8 +258,8 @@ func (s *BreakerStore) Allow(serviceID string) bool {
 // only need to know "is this service usable right now" (e.g. affinity scoping)
 // should use it so they don't steal the single half-open probe from the
 // selection path.
-func (s *BreakerStore) IsAvailable(serviceID string) bool {
-	return s.Get(serviceID).State() != BreakerOpen
+func (s *BreakerStore) IsAvailable(ruleUUID, serviceID string) bool {
+	return s.Get(ruleUUID, serviceID).State() != BreakerOpen
 }
 
 // WithinPromotionHold reports whether the service recovered (entered Closed
@@ -264,11 +268,11 @@ func (s *BreakerStore) IsAvailable(serviceID string) bool {
 // freshly-recovered primary until it has proven stable for the hold. A service
 // that is Open, HalfOpen, never-tripped, or recovered longer ago than hold is
 // NOT within the hold. hold <= 0 disables the check (always false).
-func (s *BreakerStore) WithinPromotionHold(serviceID string, hold time.Duration) bool {
+func (s *BreakerStore) WithinPromotionHold(ruleUUID, serviceID string, hold time.Duration) bool {
 	if hold <= 0 {
 		return false
 	}
-	b := s.Get(serviceID)
+	b := s.Get(ruleUUID, serviceID)
 	since := b.ClosedSince()
 	if since.IsZero() {
 		return false
@@ -276,25 +280,14 @@ func (s *BreakerStore) WithinPromotionHold(serviceID string, hold time.Duration)
 	return clock.Now().Sub(since) < hold
 }
 
-// RecordSuccess is a convenience over Get(serviceID).RecordSuccess().
-func (s *BreakerStore) RecordSuccess(serviceID string) {
-	s.Get(serviceID).RecordSuccess()
+// RecordSuccess is a convenience over Get(ruleUUID, serviceID).RecordSuccess().
+func (s *BreakerStore) RecordSuccess(ruleUUID, serviceID string) {
+	s.Get(ruleUUID, serviceID).RecordSuccess()
 }
 
-// RecordFailure is a convenience over Get(serviceID).RecordFailure().
-func (s *BreakerStore) RecordFailure(serviceID string) {
-	s.Get(serviceID).RecordFailure()
-}
-
-// Snapshot returns a copy of current breaker states for introspection.
-func (s *BreakerStore) Snapshot() map[string]BreakerState {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	out := make(map[string]BreakerState, len(s.breakers))
-	for id, b := range s.breakers {
-		out[id] = b.State()
-	}
-	return out
+// RecordFailure is a convenience over Get(ruleUUID, serviceID).RecordFailure().
+func (s *BreakerStore) RecordFailure(ruleUUID, serviceID string) {
+	s.Get(ruleUUID, serviceID).RecordFailure()
 }
 
 // Reset clears all breaker entries. Useful for tests/harness to avoid state leakage
@@ -316,16 +309,16 @@ func DefaultBreakerStore() *BreakerStore {
 }
 
 // AllowService is a package-level convenience used by selection logic.
-func AllowService(serviceID string) bool {
-	return defaultStore.Allow(serviceID)
+func AllowService(ruleUUID, serviceID string) bool {
+	return defaultStore.Allow(ruleUUID, serviceID)
 }
 
 // RecordServiceSuccess is a package-level convenience used by dispatch.
-func RecordServiceSuccess(serviceID string) {
-	defaultStore.RecordSuccess(serviceID)
+func RecordServiceSuccess(ruleUUID, serviceID string) {
+	defaultStore.RecordSuccess(ruleUUID, serviceID)
 }
 
 // RecordServiceFailure is a package-level convenience used by dispatch.
-func RecordServiceFailure(serviceID string) {
-	defaultStore.RecordFailure(serviceID)
+func RecordServiceFailure(ruleUUID, serviceID string) {
+	defaultStore.RecordFailure(ruleUUID, serviceID)
 }

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -21,6 +21,13 @@ const (
 	DefaultBreakerFailureThreshold  = 3
 	DefaultBreakerOpenDuration      = 30 * time.Second
 	DefaultBreakerRecoveryThreshold = 3 // consecutive half-open successes required to close
+
+	// DefaultPromotionHold is how long a recovered (Closed) primary tier must
+	// stay recovered before it can reclaim sessions pinned to a lower tier.
+	// It de-jitters batch return-to-primary: a freshly-recovered primary only
+	// takes NEW sessions during the hold; existing fallback-tier pins migrate
+	// back once the primary has proven stable. Zero disables the hold.
+	DefaultPromotionHold = 60 * time.Second
 )
 
 // Breaker is a three-state circuit breaker for a single service, with
@@ -42,6 +49,7 @@ type Breaker struct {
 	openedAt         time.Time
 	halfOpenInFlight bool
 	halfOpenSuccess  int // consecutive successes in the current HalfOpen run
+	closedSince      time.Time // when recovery completed (HalfOpen→Closed); zero while never recovered or currently open
 
 	FailureThreshold  int
 	OpenDuration      time.Duration
@@ -117,6 +125,7 @@ func (b *Breaker) RecordSuccess() {
 			b.state = BreakerClosed
 			b.consecFails = 0
 			b.halfOpenSuccess = 0
+			b.closedSince = clock.Now()
 		}
 		return
 	}
@@ -146,6 +155,19 @@ func (b *Breaker) openLocked() {
 	b.state = BreakerOpen
 	b.openedAt = clock.Now()
 	b.halfOpenSuccess = 0
+	b.closedSince = time.Time{}
+}
+
+// ClosedSince returns when recovery last completed (the HalfOpen→Closed
+// transition after RecoveryThreshold successes). It is zero while the service
+// has never recovered or is currently open/tripping. Tier affinity uses it for
+// PromotionHold: a primary tier must stay recovered for a hold period before
+// it can reclaim sessions pinned to a lower tier, so a freshly-recovered
+// primary doesn't vacuum all fallback-tier sessions back at once.
+func (b *Breaker) ClosedSince() time.Time {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closedSince
 }
 
 // State returns the current breaker state. Intended for introspection / UI.
@@ -234,6 +256,24 @@ func (s *BreakerStore) Allow(serviceID string) bool {
 // selection path.
 func (s *BreakerStore) IsAvailable(serviceID string) bool {
 	return s.Get(serviceID).State() != BreakerOpen
+}
+
+// WithinPromotionHold reports whether the service recovered (entered Closed
+// from a HalfOpen recovery) within the given hold window. Tier affinity uses
+// this to keep sessions pinned to a lower tier from being vacuumed back to a
+// freshly-recovered primary until it has proven stable for the hold. A service
+// that is Open, HalfOpen, never-tripped, or recovered longer ago than hold is
+// NOT within the hold. hold <= 0 disables the check (always false).
+func (s *BreakerStore) WithinPromotionHold(serviceID string, hold time.Duration) bool {
+	if hold <= 0 {
+		return false
+	}
+	b := s.Get(serviceID)
+	since := b.ClosedSince()
+	if since.IsZero() {
+		return false
+	}
+	return clock.Now().Sub(since) < hold
 }
 
 // RecordSuccess is a convenience over Get(serviceID).RecordSuccess().

--- a/internal/loadbalance/breaker.go
+++ b/internal/loadbalance/breaker.go
@@ -18,34 +18,39 @@ const (
 
 // Default circuit breaker tunables.
 const (
-	DefaultBreakerFailureThreshold = 3
-	DefaultBreakerOpenDuration     = 30 * time.Second
+	DefaultBreakerFailureThreshold  = 3
+	DefaultBreakerOpenDuration      = 30 * time.Second
+	DefaultBreakerRecoveryThreshold = 3 // consecutive half-open successes required to close
 )
 
-// Breaker is a simple three-state circuit breaker for a single service.
+// Breaker is a three-state circuit breaker for a single service, with
+// hysteresis on recovery to avoid tier oscillation.
 //
-// State transitions:
 //   - Closed → Open when consecutive failures hit FailureThreshold.
 //   - Open → HalfOpen lazily, once OpenDuration has elapsed since the trip.
-//     The next Allow() call observes the elapsed time and flips state.
-//   - HalfOpen → Closed on RecordSuccess.
-//   - HalfOpen → Open on RecordFailure (open timer restarts).
+//   - HalfOpen → Closed only after RecoveryThreshold consecutive probe
+//     successes. A single success is not enough — it just releases the probe
+//     slot so the next probe can go through.
+//   - HalfOpen → Open on any probe failure (timer restarts from scratch).
 //
-// While HalfOpen, Allow() returns true for the first caller and false for
-// concurrent callers, so exactly one probe request goes through at a time.
+// While HalfOpen, Allow() returns true for at most one caller at a time, so
+// exactly one probe request goes through per probe round.
 type Breaker struct {
 	mu               sync.Mutex
 	state            BreakerState
 	consecFails      int
 	openedAt         time.Time
 	halfOpenInFlight bool
+	halfOpenSuccess  int // consecutive successes in the current HalfOpen run
 
-	FailureThreshold int
-	OpenDuration     time.Duration
+	FailureThreshold  int
+	OpenDuration      time.Duration
+	RecoveryThreshold int // N_up: consecutive successes to recover
 }
 
 // NewBreaker creates a breaker with the supplied thresholds. Zero values
-// fall back to defaults.
+// fall back to defaults. RecoveryThreshold defaults to
+// DefaultBreakerRecoveryThreshold.
 func NewBreaker(failureThreshold int, openDuration time.Duration) *Breaker {
 	if failureThreshold <= 0 {
 		failureThreshold = DefaultBreakerFailureThreshold
@@ -54,9 +59,10 @@ func NewBreaker(failureThreshold int, openDuration time.Duration) *Breaker {
 		openDuration = DefaultBreakerOpenDuration
 	}
 	return &Breaker{
-		state:            BreakerClosed,
-		FailureThreshold: failureThreshold,
-		OpenDuration:     openDuration,
+		state:             BreakerClosed,
+		FailureThreshold:  failureThreshold,
+		OpenDuration:      openDuration,
+		RecoveryThreshold: DefaultBreakerRecoveryThreshold,
 	}
 }
 
@@ -74,6 +80,7 @@ func (b *Breaker) Allow() bool {
 		if clock.Now().Sub(b.openedAt) >= b.OpenDuration {
 			b.state = BreakerHalfOpen
 			b.halfOpenInFlight = true
+			b.halfOpenSuccess = 0
 			return true
 		}
 		return false
@@ -87,32 +94,58 @@ func (b *Breaker) Allow() bool {
 	return true
 }
 
-// RecordSuccess closes the breaker and resets failure tracking.
+// recoveryThreshold guards against a misconfigured zero value.
+func (b *Breaker) recoveryThreshold() int {
+	if b.RecoveryThreshold <= 0 {
+		return DefaultBreakerRecoveryThreshold
+	}
+	return b.RecoveryThreshold
+}
+
+// RecordSuccess closes the breaker once RecoveryThreshold consecutive probe
+// successes have been observed in HalfOpen. Before the threshold is reached it
+// merely releases the probe slot so the next probe can go through. A success
+// from a Closed breaker resets failure tracking.
 func (b *Breaker) RecordSuccess() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.state = BreakerClosed
+
+	if b.state == BreakerHalfOpen {
+		b.halfOpenSuccess++
+		b.halfOpenInFlight = false
+		if b.halfOpenSuccess >= b.recoveryThreshold() {
+			b.state = BreakerClosed
+			b.consecFails = 0
+			b.halfOpenSuccess = 0
+		}
+		return
+	}
 	b.consecFails = 0
-	b.halfOpenInFlight = false
 }
 
-// RecordFailure increments failure tracking and trips the breaker when
-// the threshold is reached. A failure during HalfOpen immediately re-opens.
+// RecordFailure increments failure tracking and trips the breaker when the
+// threshold is reached. A failure during HalfOpen immediately re-opens and
+// restarts the open timer from scratch.
 func (b *Breaker) RecordFailure() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	if b.state == BreakerHalfOpen {
-		b.state = BreakerOpen
-		b.openedAt = clock.Now()
+		b.openLocked()
 		b.halfOpenInFlight = false
 		return
 	}
 	b.consecFails++
-	if b.consecFails >= b.FailureThreshold {
-		b.state = BreakerOpen
-		b.openedAt = clock.Now()
+	if b.state == BreakerClosed && b.consecFails >= b.FailureThreshold {
+		b.openLocked()
 	}
+}
+
+// openLocked transitions to Open and stamps the open time. Caller holds b.mu.
+func (b *Breaker) openLocked() {
+	b.state = BreakerOpen
+	b.openedAt = clock.Now()
+	b.halfOpenSuccess = 0
 }
 
 // State returns the current breaker state. Intended for introspection / UI.

--- a/internal/loadbalance/breaker_test.go
+++ b/internal/loadbalance/breaker_test.go
@@ -234,3 +234,79 @@ func TestBreakerHysteresisResetsOnFailure(t *testing.T) {
 		t.Fatalf("state = %v, want half_open (streak was reset)", b.State())
 	}
 }
+
+// TestBreakerClosedSince verifies the recovery timestamp that drives tier
+// affinity's PromotionHold: it is stamped when recovery completes and cleared
+// on any subsequent open.
+func TestBreakerClosedSince(t *testing.T) {
+	fc, restore := withFakeClock(t)
+	defer restore()
+
+	b := NewBreaker(2, time.Second)
+	b.RecoveryThreshold = 1
+
+	if !b.ClosedSince().IsZero() {
+		t.Fatal("ClosedSince should be zero on a fresh breaker")
+	}
+
+	// Trip, then recover.
+	b.RecordFailure()
+	b.RecordFailure() // → Open
+	if !b.ClosedSince().IsZero() {
+		t.Fatal("ClosedSince should be zero while open")
+	}
+	fc.advance(time.Second)
+	b.Allow() // Open → HalfOpen
+	recoverAt := fc.now
+	b.RecordSuccess() // HalfOpen → Closed
+	if got := b.ClosedSince(); !got.Equal(recoverAt) {
+		t.Fatalf("ClosedSince = %v, want %v", got, recoverAt)
+	}
+
+	// A new failure trips again and clears ClosedSince.
+	b.RecordFailure()
+	b.RecordFailure() // → Open
+	if !b.ClosedSince().IsZero() {
+		t.Fatalf("ClosedSince = %v, want zero after re-open", b.ClosedSince())
+	}
+}
+
+// TestBreakerStoreWithinPromotionHold verifies the store helper that tier
+// affinity reads: a freshly-recovered service is within the hold, and leaves
+// it once the hold window elapses (or if it never tripped / re-opened).
+func TestBreakerStoreWithinPromotionHold(t *testing.T) {
+	fc, restore := withFakeClock(t)
+	defer restore()
+
+	store := NewBreakerStore(1, time.Second)
+	id := "svc:hold"
+
+	// Never tripped → not within hold (no recovery happened).
+	if store.WithinPromotionHold(id, 60*time.Second) {
+		t.Fatal("never-tripped service should not be within promotion hold")
+	}
+
+	// Trip and recover. RecoveryThreshold defaults to 3, so drive a full
+	// 3-probe success streak to close the breaker.
+	store.RecordFailure(id) // → Open
+	fc.advance(time.Second)
+	for i := 0; i < 3; i++ {
+		store.Allow(id)         // first: Open → HalfOpen; later: next probe slot
+		store.RecordSuccess(id) // accumulate; 3rd closes the breaker
+	}
+
+	// Right after recovery: within a 60s hold.
+	if !store.WithinPromotionHold(id, 60*time.Second) {
+		t.Fatal("freshly recovered service should be within 60s promotion hold")
+	}
+	// hold <= 0 disables the check entirely.
+	if store.WithinPromotionHold(id, 0) {
+		t.Fatal("hold<=0 should disable the check (always false)")
+	}
+
+	// 60s+ later: out of the hold.
+	fc.advance(61 * time.Second)
+	if store.WithinPromotionHold(id, 60*time.Second) {
+		t.Fatal("service recovered >60s ago should be out of the hold")
+	}
+}

--- a/internal/loadbalance/breaker_test.go
+++ b/internal/loadbalance/breaker_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/clock"
 )
 
+// testRule is the ruleUUID used by store-level tests. The store is rule-scoped,
+// so every call needs a ruleUUID; a single constant keeps these tests isolated
+// (their serviceIDs are already unique per test).
+const testRule = "breaker-test-rule"
+
 func TestBreakerOpensAfterThreshold(t *testing.T) {
 	b := NewBreaker(3, time.Second)
 	if !b.Allow() {
@@ -79,12 +84,12 @@ func TestBreakerSuccessResetsCounter(t *testing.T) {
 
 func TestBreakerStoreLazyCreation(t *testing.T) {
 	store := NewBreakerStore(2, time.Second)
-	b1 := store.Get("svc:a")
-	b2 := store.Get("svc:a")
+	b1 := store.Get(testRule, "svc:a")
+	b2 := store.Get(testRule, "svc:a")
 	if b1 != b2 {
 		t.Fatal("store should return the same breaker for the same key")
 	}
-	if store.Get("svc:b") == b1 {
+	if store.Get(testRule, "svc:b") == b1 {
 		t.Fatal("store should return different breakers for different keys")
 	}
 }
@@ -93,28 +98,28 @@ func TestBreakerStoreIsAvailable(t *testing.T) {
 	store := NewBreakerStore(2, 20*time.Millisecond)
 
 	// Closed → available.
-	if !store.IsAvailable("svc:avail") {
+	if !store.IsAvailable(testRule, "svc:avail") {
 		t.Fatal("fresh (closed) breaker should be available")
 	}
 
 	// Open → not available.
-	store.RecordFailure("svc:avail")
-	store.RecordFailure("svc:avail")
-	if store.IsAvailable("svc:avail") {
+	store.RecordFailure(testRule, "svc:avail")
+	store.RecordFailure(testRule, "svc:avail")
+	if store.IsAvailable(testRule, "svc:avail") {
 		t.Fatal("open breaker should not be available")
 	}
 
 	// After the open window, HalfOpen → available, and the read must NOT
 	// consume the half-open probe: a following Allow() must still succeed.
 	time.Sleep(30 * time.Millisecond)
-	if !store.IsAvailable("svc:avail") {
+	if !store.IsAvailable(testRule, "svc:avail") {
 		t.Fatal("half-open breaker should report available")
 	}
-	if !store.Allow("svc:avail") {
+	if !store.Allow(testRule, "svc:avail") {
 		t.Fatal("IsAvailable must not consume the half-open probe; Allow() should still pass")
 	}
 	// The probe is now claimed, so a concurrent Allow() is rejected.
-	if store.Allow("svc:avail") {
+	if store.Allow(testRule, "svc:avail") {
 		t.Fatal("half-open should only admit a single probe")
 	}
 }
@@ -126,13 +131,13 @@ func TestBreakerStoreConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			store.Allow("svc:concurrent")
-			store.RecordFailure("svc:concurrent")
+			store.Allow(testRule, "svc:concurrent")
+			store.RecordFailure(testRule, "svc:concurrent")
 		}()
 	}
 	wg.Wait()
 	// Just need to ensure no panic / race; state is now Open.
-	if store.Get("svc:concurrent").State() != BreakerOpen {
+	if store.Get(testRule, "svc:concurrent").State() != BreakerOpen {
 		t.Fatal("after many failures the breaker should be open")
 	}
 }
@@ -282,31 +287,64 @@ func TestBreakerStoreWithinPromotionHold(t *testing.T) {
 	id := "svc:hold"
 
 	// Never tripped → not within hold (no recovery happened).
-	if store.WithinPromotionHold(id, 60*time.Second) {
+	if store.WithinPromotionHold(testRule, id, 60*time.Second) {
 		t.Fatal("never-tripped service should not be within promotion hold")
 	}
 
 	// Trip and recover. RecoveryThreshold defaults to 3, so drive a full
 	// 3-probe success streak to close the breaker.
-	store.RecordFailure(id) // → Open
+	store.RecordFailure(testRule, id) // → Open
 	fc.advance(time.Second)
 	for i := 0; i < 3; i++ {
-		store.Allow(id)         // first: Open → HalfOpen; later: next probe slot
-		store.RecordSuccess(id) // accumulate; 3rd closes the breaker
+		store.Allow(testRule, id)         // first: Open → HalfOpen; later: next probe slot
+		store.RecordSuccess(testRule, id) // accumulate; 3rd closes the breaker
 	}
 
 	// Right after recovery: within a 60s hold.
-	if !store.WithinPromotionHold(id, 60*time.Second) {
+	if !store.WithinPromotionHold(testRule, id, 60*time.Second) {
 		t.Fatal("freshly recovered service should be within 60s promotion hold")
 	}
 	// hold <= 0 disables the check entirely.
-	if store.WithinPromotionHold(id, 0) {
+	if store.WithinPromotionHold(testRule, id, 0) {
 		t.Fatal("hold<=0 should disable the check (always false)")
 	}
 
 	// 60s+ later: out of the hold.
 	fc.advance(61 * time.Second)
-	if store.WithinPromotionHold(id, 60*time.Second) {
+	if store.WithinPromotionHold(testRule, id, 60*time.Second) {
 		t.Fatal("service recovered >60s ago should be out of the hold")
+	}
+}
+
+// TestBreakerStoreIsRuleScoped is the regression guard for rule-scoped breakers:
+// tripping a service under one rule must NOT trip the same serviceID under
+// another rule. This is the whole point of the re-keying — a busy rule's
+// failing traffic cannot fail over a different rule that uses the same
+// provider:model as its primary.
+func TestBreakerStoreIsRuleScoped(t *testing.T) {
+	store := NewBreakerStore(3, time.Second)
+	const (
+		ruleA = "rule-a"
+		ruleB = "rule-b"
+		sid   = "provider-x/model-y"
+	)
+
+	// Trip the service under ruleA only.
+	for i := 0; i < DefaultBreakerFailureThreshold; i++ {
+		store.RecordFailure(ruleA, sid)
+	}
+
+	if store.Get(ruleA, sid).State() != BreakerOpen {
+		t.Fatal("ruleA's breaker for the shared service should be open after tripping")
+	}
+	if store.Get(ruleB, sid).State() != BreakerClosed {
+		t.Fatal("ruleB's breaker for the SAME service must stay closed (rule-scoped isolation)")
+	}
+	// Concretely: ruleB still admits the service, ruleA does not.
+	if !store.Allow(ruleB, sid) {
+		t.Fatal("ruleB should still allow the service")
+	}
+	if store.Allow(ruleA, sid) {
+		t.Fatal("ruleA should reject the service while its breaker is open")
 	}
 }

--- a/internal/loadbalance/breaker_test.go
+++ b/internal/loadbalance/breaker_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/clock"
 )
 
 func TestBreakerOpensAfterThreshold(t *testing.T) {
@@ -24,6 +26,7 @@ func TestBreakerOpensAfterThreshold(t *testing.T) {
 
 func TestBreakerHalfOpenAfterDuration(t *testing.T) {
 	b := NewBreaker(2, 20*time.Millisecond)
+	b.RecoveryThreshold = 1 // keep this test focused on the open/half-open path, not hysteresis
 	b.RecordFailure()
 	b.RecordFailure()
 	if b.Allow() {
@@ -52,6 +55,7 @@ func TestBreakerHalfOpenAfterDuration(t *testing.T) {
 
 func TestBreakerHalfOpenFailureReopens(t *testing.T) {
 	b := NewBreaker(1, 10*time.Millisecond)
+	b.RecoveryThreshold = 1
 	b.RecordFailure() // → open
 	time.Sleep(15 * time.Millisecond)
 	b.Allow() // → half-open
@@ -130,5 +134,103 @@ func TestBreakerStoreConcurrent(t *testing.T) {
 	// Just need to ensure no panic / race; state is now Open.
 	if store.Get("svc:concurrent").State() != BreakerOpen {
 		t.Fatal("after many failures the breaker should be open")
+	}
+}
+
+// fakeClock is a controllable time source for deterministic breaker tests.
+type fakeClock struct {
+	now time.Time
+}
+
+func (f *fakeClock) advance(d time.Duration) { f.now = f.now.Add(d) }
+
+// withFakeClock installs a controllable clock and returns the clock, a restore
+// function, and a helper to advance it. The breaker reads time via clock.Now.
+func withFakeClock(t *testing.T) (*fakeClock, func()) {
+	t.Helper()
+	fc := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	restore := clock.SetClock(func() time.Time { return fc.now })
+	return fc, restore
+}
+
+// TestBreakerHysteresisRequiresConsecutiveSuccesses verifies that a single
+// half-open probe success no longer closes the breaker — the core anti-
+// oscillation change. RecoveryThreshold (default 3) consecutive successes
+// are required.
+func TestBreakerHysteresisRequiresConsecutiveSuccesses(t *testing.T) {
+	fc, restore := withFakeClock(t)
+	defer restore()
+
+	b := NewBreaker(3, time.Second)
+	b.RecordFailure()
+	b.RecordFailure()
+	b.RecordFailure() // → Open
+	if b.State() != BreakerOpen {
+		t.Fatalf("state = %v, want open", b.State())
+	}
+
+	// Open window elapses → HalfOpen. First probe succeeds but must NOT close.
+	fc.advance(time.Second)
+	if !b.Allow() {
+		t.Fatal("first probe after open window should be allowed")
+	}
+	b.RecordSuccess()
+	if b.State() != BreakerHalfOpen {
+		t.Fatalf("after 1 success state = %v, want half_open (not closed)", b.State())
+	}
+
+	// Second probe: Allow again (previous success released the slot), succeed, still not closed.
+	if !b.Allow() {
+		t.Fatal("second probe should be allowed")
+	}
+	b.RecordSuccess()
+	if b.State() != BreakerHalfOpen {
+		t.Fatalf("after 2 successes state = %v, want half_open", b.State())
+	}
+
+	// Third consecutive success → Closed.
+	if !b.Allow() {
+		t.Fatal("third probe should be allowed")
+	}
+	b.RecordSuccess()
+	if b.State() != BreakerClosed {
+		t.Fatalf("after 3 successes state = %v, want closed", b.State())
+	}
+}
+
+// TestBreakerHysteresisResetsOnFailure verifies that a probe failure during
+// the recovery streak resets the success counter and re-opens, requiring a
+// fresh full streak afterwards.
+func TestBreakerHysteresisResetsOnFailure(t *testing.T) {
+	fc, restore := withFakeClock(t)
+	defer restore()
+
+	b := NewBreaker(2, time.Second)
+	b.RecordFailure()
+	b.RecordFailure() // → Open
+
+	// Two successes (below the default threshold of 3).
+	fc.advance(time.Second)
+	b.Allow()
+	b.RecordSuccess()
+	b.Allow()
+	b.RecordSuccess()
+	if b.State() != BreakerHalfOpen {
+		t.Fatalf("state = %v, want half_open after 2 successes", b.State())
+	}
+
+	// A failure now resets the streak and re-opens, restarting the open timer.
+	b.Allow()
+	b.RecordFailure()
+	if b.State() != BreakerOpen {
+		t.Fatalf("state = %v, want open after failure reset the streak", b.State())
+	}
+
+	// After the open window (base duration), a single success is not enough.
+	fc.advance(time.Second)
+	b.Allow()
+	b.RecordSuccess()
+	if b.State() != BreakerHalfOpen {
+		t.Fatalf("state = %v, want half_open (streak was reset)", b.State())
 	}
 }

--- a/internal/loadbalance/load_balancing.go
+++ b/internal/loadbalance/load_balancing.go
@@ -527,8 +527,8 @@ func ParseTacticType(s string) TacticType {
 		return TacticLatencyBased
 	case "speed_based":
 		return TacticSpeedBased
-	case "adaptive":
-		return TacticAdaptive
+	case "adaptive": // legacy, map to random
+		return TacticRandom
 	case "capacity_based":
 		return TacticCapacityBased
 	case "tier":
@@ -536,6 +536,6 @@ func ParseTacticType(s string) TacticType {
 	case "priority": // backward-compat alias
 		return TacticTier
 	default:
-		return TacticAdaptive // default to adaptive
+		return TacticRandom // default to random
 	}
 }

--- a/internal/loadbalance/load_balancing_test.go
+++ b/internal/loadbalance/load_balancing_test.go
@@ -141,8 +141,8 @@ func TestParseTacticType(t *testing.T) {
 		{"token_based", TacticTokenBased},
 		{"hybrid", TacticTokenBased}, // deprecated → token_based
 		{"random", TacticRandom},
-		{"invalid", TacticAdaptive}, // Default fallback
-		{"", TacticAdaptive},        // Empty string fallback
+		{"invalid", TacticRandom}, // Default fallback
+		{"", TacticRandom},        // Empty string fallback
 	}
 
 	for _, test := range tests {
@@ -264,8 +264,8 @@ func TestParseTacticType_LatencyBased(t *testing.T) {
 		expected TacticType
 	}{
 		{"latency_based", TacticLatencyBased},
-		{"LATENCY_BASED", TacticAdaptive}, // Case sensitive, falls back to default
-		{"invalid", TacticAdaptive},       // Default fallback
+		{"LATENCY_BASED", TacticRandom}, // Case sensitive, falls back to default
+		{"invalid", TacticRandom},       // Default fallback
 	}
 
 	for _, test := range tests {
@@ -357,8 +357,8 @@ func TestParseTacticType_SpeedBased(t *testing.T) {
 		expected TacticType
 	}{
 		{"speed_based", TacticSpeedBased},
-		{"SPEED_BASED", TacticAdaptive}, // Case sensitive, falls back to default
-		{"invalid", TacticAdaptive},     // Default fallback
+		{"SPEED_BASED", TacticRandom}, // Case sensitive, falls back to default
+		{"invalid", TacticRandom},     // Default fallback
 	}
 
 	for _, test := range tests {
@@ -374,14 +374,14 @@ func TestTacticType_String_SpeedBased(t *testing.T) {
 	}
 }
 
-func TestParseTacticType_Adaptive(t *testing.T) {
+func TestParseTacticType_AdaptiveLegacyMapsToRandom(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected TacticType
 	}{
-		{"adaptive", TacticAdaptive},
-		{"ADAPTIVE", TacticAdaptive}, // Case sensitive, falls back to default
-		{"invalid", TacticAdaptive},  // Default fallback
+		{"adaptive", TacticRandom},
+		{"ADAPTIVE", TacticRandom}, // Case sensitive, falls back to default
+		{"invalid", TacticRandom},  // Default fallback
 	}
 
 	for _, test := range tests {

--- a/internal/loadbalance/service_id.go
+++ b/internal/loadbalance/service_id.go
@@ -19,10 +19,21 @@ func (id ServiceID) String() string {
 }
 
 // FormatServiceID formats a (providerUUID, model) pair into the canonical
-// "provider:model" string used as the breaker key and exclusion map key
-// throughout the gateway. Sites that don't have a full *Service in hand
-// (the failover orchestrator, the recorder, usage tracking) call this
-// directly so all paths agree on the same key shape.
+// "provider/model" string used as the exclusion map key and as the
+// service-scoped half of the breaker key. Sites that don't have a full
+// *Service in hand (the failover orchestrator, the recorder, usage tracking)
+// call this directly so all paths agree on the same key shape.
 func FormatServiceID(providerUUID, model string) string {
 	return fmt.Sprintf("%s/%s", providerUUID, model)
+}
+
+// FormatBreakerKey formats a (ruleUUID, serviceID) pair into the canonical
+// "ruleUUID/serviceID" string used as the breaker-store key. The breaker is
+// rule-scoped: each rule owns independent breaker state per service so a busy
+// rule's failing traffic cannot trip another rule's primary. The serviceID
+// half is FormatServiceID's "provider/model"; rule UUIDs are slash-free, so
+// the composite is unambiguous. Mirrors the affinity store's rule-scoped key
+// (internal/server/affinity/affinity.go makeKey).
+func FormatBreakerKey(ruleUUID, serviceID string) string {
+	return fmt.Sprintf("%s/%s", ruleUUID, serviceID)
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1470,8 +1470,8 @@ func newCCProfileRules(profiledScenario typ.RuleScenario, unified bool) []typ.Ru
 			RequestModel: requestModel,
 			Description:  description,
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			// Claude Code profiles inherit the built-in CC defaults: normalize the
 			// mid-conversation system role (ClaudeCodeCompat) so third-party
@@ -2177,9 +2177,17 @@ func IsTacticValid(tactic *typ.Tactic) bool {
 	switch p := tactic.Params.(type) {
 	case *typ.TokenBasedParams:
 		return p.TokenThreshold > 0
+	case typ.TokenBasedParams:
+		return p.TokenThreshold > 0
 	case *typ.RandomParams:
 		// Random params has no fields, always valid if not nil
 		return true
+	case typ.RandomParams:
+		return true
+	case *typ.TierParams:
+		return tactic.Type == loadbalance.TacticTier && p.WithinTierTactic != loadbalance.TacticTier
+	case typ.TierParams:
+		return tactic.Type == loadbalance.TacticTier && p.WithinTierTactic != loadbalance.TacticTier
 	default:
 		// Unknown params type, treat as invalid
 		return false

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -23,8 +23,8 @@ func init() {
 			Description:   "Default proxy rule in tingly-box for general use with Anthropic",
 			Services:      []*loadbalance.Service{},
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			Active: true,
 		},
@@ -36,8 +36,8 @@ func init() {
 			Description:   "Default proxy rule in tingly-box for agent",
 			Services:      []*loadbalance.Service{},
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			Active: true,
 		},
@@ -49,8 +49,8 @@ func init() {
 			Description:   "Built in model rule for agent - claw",
 			Services:      []*loadbalance.Service{},
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			Active: true,
 		},
@@ -62,8 +62,8 @@ func init() {
 			Description:   "Default proxy rule in tingly-box for general use with OpenAI",
 			Services:      []*loadbalance.Service{},
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			Active: true,
 		},
@@ -75,8 +75,8 @@ func init() {
 			Description:   "Default proxy rule for Codex",
 			Services:      []*loadbalance.Service{},
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			// 30-min session affinity improves cache hit rate for Codex sessions.
 			Flags:  typ.RuleFlags{SessionAffinity: defaultSessionAffinitySeconds},
@@ -96,8 +96,8 @@ func init() {
 			Description:   "Default proxy rule for OpenCode - AI coding assistant",
 			Services:      []*loadbalance.Service{},
 			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			Active: true,
 		},
@@ -109,7 +109,7 @@ func init() {
 }
 
 // cdRule builds a built-in Claude Desktop rule with the shared defaults: an empty
-// service list, the default adaptive load-balancing tactic, Active, and the
+// service list, the default random load-balancing tactic, Active, and the
 // clean_header + claude_code_compat + session_affinity flags on. Claude Desktop
 // injects x-anthropic-billing-header blocks into system messages (CleanHeader)
 // and sends mid-conversation system-role messages that third-party
@@ -123,8 +123,8 @@ func cdRule(uuid, requestModel, description string) typ.Rule {
 		Description:  description,
 		Services:     []*loadbalance.Service{},
 		LBTactic: typ.Tactic{
-			Type:   loadbalance.TacticAdaptive,
-			Params: typ.DefaultAdaptiveParams(),
+			Type:   loadbalance.TacticRandom,
+			Params: typ.DefaultRandomParams(),
 		},
 		Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true, SessionAffinity: defaultSessionAffinitySeconds},
 		Active: true,
@@ -132,7 +132,7 @@ func cdRule(uuid, requestModel, description string) typ.Rule {
 }
 
 // ccRule builds a built-in Claude Code rule with the shared defaults: an empty
-// service list, the default adaptive load-balancing tactic, and the
+// service list, the default random load-balancing tactic, and the
 // claude_code_compat + clean_header + session_affinity flags on. Claude Code
 // emits mid-conversation system-role messages that third-party
 // Anthropic-compatible providers reject (ClaudeCodeCompat), and injects
@@ -147,8 +147,8 @@ func ccRule(uuid, requestModel, description string, active bool) typ.Rule {
 		Description:  description,
 		Services:     []*loadbalance.Service{},
 		LBTactic: typ.Tactic{
-			Type:   loadbalance.TacticAdaptive,
-			Params: typ.DefaultAdaptiveParams(),
+			Type:   loadbalance.TacticRandom,
+			Params: typ.DefaultRandomParams(),
 		},
 		Flags:  typ.RuleFlags{ClaudeCodeCompat: true, CleanHeader: true, SessionAffinity: defaultSessionAffinitySeconds},
 		Active: active,

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -225,11 +225,9 @@ func normalizeRuleBasics(c *Config) bool {
 				needsSave = true
 			}
 		}
-		if !IsTacticValid(&rule.LBTactic) {
-			rule.LBTactic = typ.Tactic{
-				Type:   loadbalance.TacticAdaptive,
-				Params: typ.DefaultAdaptiveParams(),
-			}
+		normalizedTactic := normalizeRuleTactic(rule)
+		if rule.LBTactic.Type != normalizedTactic.Type || !IsTacticValid(&rule.LBTactic) {
+			rule.LBTactic = normalizedTactic
 			needsSave = true
 		}
 		valid = append(valid, rule)
@@ -239,6 +237,36 @@ func normalizeRuleBasics(c *Config) bool {
 	}
 	c.Rules = valid
 	return needsSave
+}
+
+func normalizeRuleTactic(rule typ.Rule) typ.Tactic {
+	if hasMultipleServiceTiers(rule.Services) {
+		return typ.Tactic{
+			Type:   loadbalance.TacticTier,
+			Params: typ.DefaultTierParams(),
+		}
+	}
+	if rule.LBTactic.Type == loadbalance.TacticTier && IsTacticValid(&rule.LBTactic) {
+		return rule.LBTactic
+	}
+	return typ.Tactic{
+		Type:   loadbalance.TacticRandom,
+		Params: typ.DefaultRandomParams(),
+	}
+}
+
+func hasMultipleServiceTiers(services []*loadbalance.Service) bool {
+	seen := make(map[int]struct{})
+	for _, svc := range services {
+		if svc == nil || !svc.Active {
+			continue
+		}
+		seen[svc.Tier] = struct{}{}
+		if len(seen) > 1 {
+			return true
+		}
+	}
+	return false
 }
 
 func legacyRuleScenario(uuid string) (typ.RuleScenario, bool) {

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -31,12 +31,45 @@ func TestNormalizeLegacyConfigBaseline_RuleBasics(t *testing.T) {
 		t.Error("missing rule UUID should be generated")
 	}
 	for _, r := range c.Rules {
-		if r.LBTactic.Type != loadbalance.TacticAdaptive {
-			t.Errorf("rule %q tactic type = %q, want %q", r.UUID, r.LBTactic.Type, loadbalance.TacticAdaptive)
+		if r.LBTactic.Type != loadbalance.TacticRandom {
+			t.Errorf("rule %q tactic type = %q, want %q", r.UUID, r.LBTactic.Type, loadbalance.TacticRandom)
 		}
-		if _, ok := typ.AsAdaptiveParams(r.LBTactic.Params); !ok {
-			t.Errorf("rule %q tactic params should be adaptive: %+v", r.UUID, r.LBTactic.Params)
+		if _, ok := typ.AsRandomParams(r.LBTactic.Params); !ok {
+			t.Errorf("rule %q tactic params should be random: %+v", r.UUID, r.LBTactic.Params)
 		}
+	}
+}
+
+func TestNormalizeLegacyConfigBaseline_MultiTierRulesBecomeTierWithRandomWithinTier(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{
+				UUID:     "tier-rule",
+				Scenario: typ.ScenarioClaudeCode,
+				Services: []*loadbalance.Service{
+					{Provider: "p0", Model: "high", Active: true, Tier: 0},
+					{Provider: "p1", Model: "low", Active: true, Tier: 1},
+				},
+				LBTactic: typ.Tactic{
+					Type:   loadbalance.TacticAdaptive,
+					Params: typ.DefaultAdaptiveParams(),
+				},
+			},
+		},
+	}
+
+	normalizeLegacyConfigBaseline(c)
+
+	got := c.Rules[0].LBTactic
+	if got.Type != loadbalance.TacticTier {
+		t.Fatalf("multi-tier rule tactic = %q, want %q", got.Type, loadbalance.TacticTier)
+	}
+	params, ok := got.Params.(*typ.TierParams)
+	if !ok {
+		t.Fatalf("multi-tier params = %T, want *typ.TierParams", got.Params)
+	}
+	if params.WithinTierTactic != loadbalance.TacticRandom {
+		t.Fatalf("within tier tactic = %q, want random", params.WithinTierTactic)
 	}
 }
 

--- a/internal/server/config/rule.go
+++ b/internal/server/config/rule.go
@@ -80,7 +80,8 @@ func (c *Config) EnsureSmartGuideRuleForBot(botUUID, botName, providerUUID, mode
 				},
 			},
 			LBTactic: typ.Tactic{
-				Type: loadbalance.TacticAdaptive,
+				Type:   loadbalance.TacticRandom,
+				Params: typ.DefaultRandomParams(),
 			},
 			Active:       true,
 			SmartEnabled: false,

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -401,6 +401,7 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		// A committed gate means the stream's first real chunk reached
 		// the wire — bytes have left the process, retry is impossible.
 		if gate.Committed() {
+			loadbalance.RecordServiceSuccess(rule.UUID, serviceID)
 			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
 				"stage":          "failover_success",
 				"attempt":        i + 1,
@@ -424,6 +425,18 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 			}).Warnf("[failover] attempt %d returned status %d with %s/%s", i+1, status, provider.UUID, model)
 			return
 		}
+
+		loadbalance.RecordServiceFailure(rule.UUID, serviceID)
+		state := loadbalance.DefaultBreakerStore().Get(rule.UUID, serviceID).State()
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"stage":         "breaker_failure_recorded",
+			"rule_uuid":     rule.UUID,
+			"service":       serviceID,
+			"provider":      provider.Name,
+			"model":         model,
+			"status":        status,
+			"breaker_state": state.String(),
+		}).Warnf("[breaker] recorded failure for %s; state=%s", serviceID, state.String())
 
 		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
 			"stage":          "failover_attempt_failed",

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -379,18 +379,16 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		serviceID := loadbalance.FormatServiceID(provider.UUID, model)
 		tried[serviceID] = true
 
-		// Log each attempt with clear numbering
-		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-			"stage":          "failover_attempt",
-			"attempt":        i + 1,
-			"total_attempts": len(activeServices),
-			"service":        serviceID,
-			"provider":       provider.Name,
-			"model":          model,
-		}).Infof("[failover] attempt %d/%d: trying: %s/%s", i+1, len(activeServices), provider.UUID, model)
-
-		// Update context for logging/middleware to show current attempt
+		// Update context before logging/dispatch so request-scoped observability
+		// reflects the service currently being tried, and ultimately the last
+		// successful service when failover succeeds.
 		UpdateTrackingForFailover(c, provider, model)
+
+		fields := failoverLogFields(c, rule, provider, model, serviceID)
+		fields["stage"] = "failover_attempt"
+		fields["attempt"] = i + 1
+		fields["active_services"] = len(activeServices)
+		logrus.WithContext(c.Request.Context()).WithFields(fields).Infof("[failover] attempt %d: trying: %s/%s", i+1, provider.UUID, model)
 
 		if rec != nil {
 			rec.SetActiveService(provider, model)
@@ -402,52 +400,42 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		// the wire — bytes have left the process, retry is impossible.
 		if gate.Committed() {
 			loadbalance.RecordServiceSuccess(rule.UUID, serviceID)
-			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-				"stage":          "failover_success",
-				"attempt":        i + 1,
-				"total_attempts": len(activeServices),
-				"service":        serviceID,
-				"provider":       provider.Name,
-				"model":          model,
-			}).Infof("[failover] succeeded on attempt %d with %s/%s", i+1, provider.UUID, model)
+			fields := failoverLogFields(c, rule, provider, model, serviceID)
+			fields["stage"] = "failover_success"
+			fields["attempt"] = i + 1
+			fields["active_services"] = len(activeServices)
+			fields["routed_model"] = model
+			fields["routed_provider"] = provider.Name
+			logrus.WithContext(c.Request.Context()).WithFields(fields).Infof("[failover] succeeded on attempt %d with %s/%s", i+1, provider.UUID, model)
 			return
 		}
 		status := gate.Status()
 		if !isRetryableStatus(status) {
-			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-				"stage":          "failover_terminal",
-				"attempt":        i + 1,
-				"total_attempts": len(activeServices),
-				"service":        serviceID,
-				"provider":       provider.Name,
-				"model":          model,
-				"status":         status,
-			}).Warnf("[failover] attempt %d returned status %d with %s/%s", i+1, status, provider.UUID, model)
+			fields := failoverLogFields(c, rule, provider, model, serviceID)
+			fields["stage"] = "failover_terminal"
+			fields["attempt"] = i + 1
+			fields["active_services"] = len(activeServices)
+			fields["status"] = status
+			logrus.WithContext(c.Request.Context()).WithFields(fields).Warnf("[failover] attempt %d returned status %d with %s/%s", i+1, status, provider.UUID, model)
 			return
 		}
 
 		loadbalance.RecordServiceFailure(rule.UUID, serviceID)
 		state := loadbalance.DefaultBreakerStore().Get(rule.UUID, serviceID).State()
-		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-			"stage":         "breaker_failure_recorded",
-			"rule_uuid":     rule.UUID,
-			"service":       serviceID,
-			"provider":      provider.Name,
-			"model":         model,
-			"status":        status,
-			"breaker_state": state.String(),
-		}).Warnf("[breaker] recorded failure for %s; state=%s", serviceID, state.String())
+		fields = failoverLogFields(c, rule, provider, model, serviceID)
+		fields["stage"] = "breaker_failure_recorded"
+		fields["rule_uuid"] = rule.UUID
+		fields["status"] = status
+		fields["breaker_state"] = state.String()
+		logrus.WithContext(c.Request.Context()).WithFields(fields).Warnf("[breaker] recorded failure for %s; state=%s", serviceID, state.String())
 
-		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-			"stage":          "failover_attempt_failed",
-			"attempt":        i + 1,
-			"total_attempts": len(activeServices),
-			"service":        serviceID,
-			"provider":       provider.Name,
-			"model":          model,
-			"status":         status,
-			"retryable":      true,
-		}).Warnf("[failover] attempt %d failed with retryable status %d on %s/%s",
+		fields = failoverLogFields(c, rule, provider, model, serviceID)
+		fields["stage"] = "failover_attempt_failed"
+		fields["attempt"] = i + 1
+		fields["active_services"] = len(activeServices)
+		fields["status"] = status
+		fields["retryable"] = true
+		logrus.WithContext(c.Request.Context()).WithFields(fields).Warnf("[failover] attempt %d failed with retryable status %d on %s/%s",
 			i+1, status, provider.UUID, model)
 
 		// Pass "" so the candidate pool spans all API styles: each attempt
@@ -455,40 +443,69 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		// heterogeneous failover (e.g. Anthropic → OpenAI) is supported.
 		nextProvider, nextService, err := ph.selectFallbackService(rule, tried, "")
 		if err != nil {
-			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-				"stage":          "failover_error",
-				"attempt":        i + 1,
-				"total_attempts": len(activeServices),
-				"status":         status,
-				"error":          err.Error(),
-			}).Warnf("[failover] load balancer failed selecting fallback after %d attempt(s) status=%d: %v", i+1, status, err)
+			fields := failoverLogFields(c, rule, provider, model, serviceID)
+			fields["stage"] = "failover_error"
+			fields["attempt"] = i + 1
+			fields["active_services"] = len(activeServices)
+			fields["status"] = status
+			fields["error"] = err.Error()
+			logrus.WithContext(c.Request.Context()).WithFields(fields).Warnf("[failover] load balancer failed selecting fallback after %d attempt(s) status=%d: %v", i+1, status, err)
 			return
 		}
 		if nextProvider == nil || nextService == nil {
-			logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-				"stage":          "failover_exhausted",
-				"attempt":        i + 1,
-				"total_attempts": len(activeServices),
-				"status":         status,
-			}).Warnf("[failover] giving up after %d attempt(s) status=%d (no more services)", i+1, status)
+			fields := failoverLogFields(c, rule, provider, model, serviceID)
+			fields["stage"] = "failover_exhausted"
+			fields["attempt"] = i + 1
+			fields["active_services"] = len(activeServices)
+			fields["status"] = status
+			logrus.WithContext(c.Request.Context()).WithFields(fields).Warnf("[failover] giving up after %d attempt(s) status=%d (no more services)", i+1, status)
 			return
 		}
 
 		nextServiceID := loadbalance.FormatServiceID(nextProvider.UUID, nextService.Model)
-		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-			"stage":          "failover_retry",
-			"attempt":        i + 1,
-			"total_attempts": len(activeServices),
-			"status":         status,
-			"from_service":   serviceID,
-			"to_service":     nextServiceID,
-			"to_provider":    nextProvider.Name,
-			"to_model":       nextService.Model,
-		}).Warnf("[failover] attempt %d failed with %d, retrying with %s/%s",
+		fields = failoverLogFields(c, rule, provider, model, serviceID)
+		fields["stage"] = "failover_retry"
+		fields["attempt"] = i + 1
+		fields["active_services"] = len(activeServices)
+		fields["status"] = status
+		fields["from_service"] = serviceID
+		fields["to_service"] = nextServiceID
+		fields["to_provider"] = nextProvider.Name
+		fields["to_model"] = nextService.Model
+		logrus.WithContext(c.Request.Context()).WithFields(fields).Warnf("[failover] attempt %d failed with %d, retrying with %s/%s",
 			i+1, status, nextProvider.UUID, nextService.Model)
 
 		gate.Discard()
 		provider = nextProvider
 		model = nextService.Model
 	}
+}
+
+func failoverLogFields(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, serviceID string) logrus.Fields {
+	fields := logrus.Fields{
+		"service":       serviceID,
+		"attempt_model": model,
+	}
+	if provider != nil {
+		fields["provider"] = provider.Name
+		fields["provider_uuid"] = provider.UUID
+	}
+	if rule != nil {
+		fields["rule_uuid"] = rule.UUID
+		fields["request_model"] = rule.RequestModel
+		fields["scenario"] = string(rule.GetScenario())
+		fields["lb_tactic"] = rule.GetTacticType().String()
+	}
+	if c != nil {
+		if requestModel := c.GetString(ContextKeyRequestModel); requestModel != "" {
+			fields["request_model"] = requestModel
+		}
+		if scenario := c.GetString(ContextKeyScenario); scenario != "" {
+			fields["scenario"] = scenario
+		}
+		if tactic := c.GetString(ContextKeyLBTactic); tactic != "" {
+			fields["lb_tactic"] = tactic
+		}
+	}
+	return fields
 }

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -425,6 +425,18 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 			return
 		}
 
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"stage":          "failover_attempt_failed",
+			"attempt":        i + 1,
+			"total_attempts": len(activeServices),
+			"service":        serviceID,
+			"provider":       provider.Name,
+			"model":          model,
+			"status":         status,
+			"retryable":      true,
+		}).Warnf("[failover] attempt %d failed with retryable status %d on %s/%s",
+			i+1, status, provider.UUID, model)
+
 		// Pass "" so the candidate pool spans all API styles: each attempt
 		// re-transforms the request for the selected provider's style, so
 		// heterogeneous failover (e.g. Anthropic → OpenAI) is supported.

--- a/internal/server/failover_logging_test.go
+++ b/internal/server/failover_logging_test.go
@@ -79,7 +79,9 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 	}
 
 	rule := &typ.Rule{
-		UUID: "test-rule",
+		UUID:         "test-rule",
+		Scenario:     typ.ScenarioClaudeCode,
+		RequestModel: "cc",
 		LBTactic: typ.Tactic{
 			Type: loadbalance.TacticTier,
 			Params: &typ.TierParams{
@@ -133,8 +135,19 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 
 		printCapturedLog(t, hook.entries)
 
-		var sawRetry bool
+		var sawRetry, sawSuccess bool
 		for _, e := range hook.entries {
+			if stage, _ := e.Data["stage"].(string); strings.HasPrefix(stage, "failover_") {
+				if e.Data["scenario"] != string(typ.ScenarioClaudeCode) {
+					t.Errorf("%s log scenario = %v, want %s", stage, e.Data["scenario"], typ.ScenarioClaudeCode)
+				}
+				if e.Data["request_model"] != "cc" {
+					t.Errorf("%s log request_model = %v, want cc", stage, e.Data["request_model"])
+				}
+				if e.Data["attempt_model"] == nil {
+					t.Errorf("%s log missing attempt_model", stage)
+				}
+			}
 			if e.Data["stage"] == "failover_retry" && e.Data["to_provider"] != nil {
 				sawRetry = true
 				for _, field := range []string{"attempt", "status", "from_service", "to_provider", "to_model"} {
@@ -143,9 +156,21 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 					}
 				}
 			}
+			if e.Data["stage"] == "failover_success" {
+				sawSuccess = true
+				if e.Data["routed_model"] != "gpt-4o-mini" {
+					t.Errorf("success routed_model = %v, want gpt-4o-mini", e.Data["routed_model"])
+				}
+			}
 		}
 		if !sawRetry {
 			t.Error("expected a failover retry log entry with to_provider field, got none")
+		}
+		if !sawSuccess {
+			t.Error("expected a failover success log entry, got none")
+		}
+		if got := c.GetString(ContextKeyModel); got != "gpt-4o-mini" {
+			t.Errorf("final tracking model = %q, want gpt-4o-mini", got)
 		}
 	})
 

--- a/internal/server/failover_logging_test.go
+++ b/internal/server/failover_logging_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	internalobs "github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/server/recording"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/obs"
 )
@@ -179,4 +182,94 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 			t.Error("expected a failover give-up log entry, got none")
 		}
 	})
+}
+
+func TestFailoverRecordsBreakerFailureIndependentlyOfRecorder(t *testing.T) {
+	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	providerT0 := &typ.Provider{UUID: "breaker-prov-t0", Name: "ProviderAlpha", Enabled: true, APIStyle: "openai", APIBase: "https://api.example-alpha.com/v1"}
+	providerT1 := &typ.Provider{UUID: "breaker-prov-t1", Name: "ProviderBeta", Enabled: true, APIStyle: "openai", APIBase: "https://api.example-beta.com/v1"}
+	if err := cfg.AddProvider(providerT0); err != nil {
+		t.Fatalf("AddProvider T0: %v", err)
+	}
+	if err := cfg.AddProvider(providerT1); err != nil {
+		t.Fatalf("AddProvider T1: %v", err)
+	}
+
+	rule := &typ.Rule{
+		UUID: "breaker-recording-disabled-rule",
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticTier,
+			Params: typ.DefaultTierParams(),
+		},
+		Services: []*loadbalance.Service{
+			{Provider: providerT0.UUID, Model: "primary", Active: true, Tier: 0},
+			{Provider: providerT1.UUID, Model: "fallback", Active: true, Tier: 1},
+		},
+	}
+
+	hm := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+	hf := typ.NewHealthFilter(hm)
+	h := NewHandler(ProtocolHandlerDeps{
+		Config:        cfg,
+		LoadBalancer:  NewLoadBalancer(cfg, hf),
+		HealthMonitor: hm,
+	})
+
+	for _, tc := range []struct {
+		name           string
+		attachRecorder bool
+	}{
+		{name: "recorder_disabled"},
+		{name: "recorder_attached", attachRecorder: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			loadbalance.DefaultBreakerStore().Reset()
+			defer loadbalance.DefaultBreakerStore().Reset()
+
+			for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+				rec := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(rec)
+				c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", nil)
+				var protocolRecorder *recording.ProtocolRecorder
+				if tc.attachRecorder {
+					protocolRecorder, err = recording.NewProtocolRecorder(c, nil, "test", internalobs.RecordModeStagedRequestResponse, []byte(`{}`))
+					if err != nil {
+						t.Fatalf("NewProtocolRecorder: %v", err)
+					}
+					c.Set(recording.RecorderContextKey, protocolRecorder)
+				}
+
+				attempt := func(provider *typ.Provider, model string) {
+					if provider.UUID == providerT0.UUID {
+						c.Writer.WriteHeader(http.StatusTooManyRequests)
+						if protocolRecorder != nil {
+							protocolRecorder.RecordError(errors.New("upstream 429"))
+						}
+						return
+					}
+					c.Writer.WriteHeader(http.StatusOK)
+					if gate, ok := c.Writer.(*firstChunkGate); ok {
+						gate.CommitFirstChunk()
+					}
+				}
+
+				h.DispatchWithPriorityFailover(c, rule, providerT0, "primary", attempt)
+
+				id := loadbalance.FormatServiceID(providerT0.UUID, "primary")
+				state := loadbalance.DefaultBreakerStore().Get(rule.UUID, id).State()
+				if i < loadbalance.DefaultBreakerFailureThreshold-1 && state != loadbalance.BreakerClosed {
+					t.Fatalf("after %d failure(s), breaker state for %s = %s, want closed", i+1, id, state)
+				}
+			}
+
+			id := loadbalance.FormatServiceID(providerT0.UUID, "primary")
+			if got := loadbalance.DefaultBreakerStore().Get(rule.UUID, id).State(); got != loadbalance.BreakerOpen {
+				t.Fatalf("breaker state for %s = %s, want open", id, got)
+			}
+		})
+	}
 }

--- a/internal/server/load_balance.go
+++ b/internal/server/load_balance.go
@@ -98,6 +98,7 @@ func (lb *LoadBalancer) SelectService(rule *typ.Rule) (*loadbalance.Service, err
 	// Always instantiate tactic from rule's params to ensure correct parameters
 	// State is now stored globally (globalRoundRobinStreaks) so this is safe
 	actualTactic := rule.LBTactic.Instantiate()
+	logTierConfigIgnored(rule, activeServices, actualTactic.GetType())
 
 	// Create a temporary rule with only healthy services for the tactic
 	tempRule := &typ.Rule{
@@ -123,6 +124,28 @@ func (lb *LoadBalancer) SelectService(rule *typ.Rule) (*loadbalance.Service, err
 	}
 
 	return selectedService, nil
+}
+
+func logTierConfigIgnored(rule *typ.Rule, services []*loadbalance.Service, tacticType loadbalance.TacticType) {
+	if rule == nil || tacticType == loadbalance.TacticTier {
+		return
+	}
+	tiers := make(map[int]struct{})
+	for _, svc := range services {
+		if svc == nil || !svc.Active {
+			continue
+		}
+		tiers[svc.Tier] = struct{}{}
+		if len(tiers) > 1 {
+			logrus.WithFields(logrus.Fields{
+				"stage":     "tier_config_ignored",
+				"rule_uuid": rule.UUID,
+				"tactic":    tacticType.String(),
+			}).Warnf("[load_balancer] rule %s has multiple service tiers but lb_tactic=%s; tier priority is ignored",
+				rule.UUID, tacticType.String())
+			return
+		}
+	}
 }
 
 // getTactic retrieves a tactic by type

--- a/internal/server/load_balance_simulator.go
+++ b/internal/server/load_balance_simulator.go
@@ -233,11 +233,11 @@ func (s *LBSimulator) Request(session string) (LBTrace, error) {
 		if status == http.StatusOK {
 			c.Writer.WriteHeader(http.StatusOK)
 			CommitFirstChunkIfGate(c.Writer) // simulate the stream's first real chunk
-			loadbalance.RecordServiceSuccess(sid)
+			loadbalance.RecordServiceSuccess(s.rule.UUID, sid)
 			s.server.reportHealthStatus(provider, model, nil, "")
 		} else {
 			c.Writer.WriteHeader(status)
-			loadbalance.RecordServiceFailure(sid)
+			loadbalance.RecordServiceFailure(s.rule.UUID, sid)
 			s.server.reportHealthStatus(provider, model,
 				fmt.Errorf("upstream returned HTTP %d", status), "")
 		}
@@ -308,13 +308,16 @@ func (s *LBSimulator) SeedPin(session, provider, model string) {
 }
 
 // BreakerStates returns a snapshot of every rule service's breaker state, keyed
-// by serviceID (values: "closed" / "open" / "half_open").
+// by serviceID (values: "closed" / "open" / "half_open"). The breaker store is
+// rule-scoped, so reads key on s.rule.UUID; the returned map stays
+// serviceID-keyed (a consumer-facing contract used by scenario tests + the
+// harness CLI).
 func (s *LBSimulator) BreakerStates() map[string]string {
 	store := loadbalance.DefaultBreakerStore()
 	out := make(map[string]string, len(s.rule.Services))
 	for _, svc := range s.rule.Services {
 		id := svc.ServiceID()
-		out[id] = store.Get(id).State().String()
+		out[id] = store.Get(s.rule.UUID, id).State().String()
 	}
 	return out
 }

--- a/internal/server/load_balance_simulator.go
+++ b/internal/server/load_balance_simulator.go
@@ -224,20 +224,15 @@ func (s *LBSimulator) Request(session string) (LBTrace, error) {
 		tr.Statuses = append(tr.Statuses, status)
 		tr.FinalStatus = status
 
-		// Feed BOTH production feedback channels exactly as a real request would:
-		//   - breaker: binary success/failure (mirrors the recorder).
-		//   - health monitor: status-classified, via the production classifier
-		//     reportHealthStatus (429→rate-limit, 401/403→auth, 5xx/4xx/other→
-		//     error, 2xx→success). The synthesized message routes through its
-		//     substring matcher exactly.
+		// Feed the health-monitor production channel. Breaker feedback is now
+		// owned by the failover gate itself, matching real requests when scenario
+		// recording is disabled.
 		if status == http.StatusOK {
 			c.Writer.WriteHeader(http.StatusOK)
 			CommitFirstChunkIfGate(c.Writer) // simulate the stream's first real chunk
-			loadbalance.RecordServiceSuccess(s.rule.UUID, sid)
 			s.server.reportHealthStatus(provider, model, nil, "")
 		} else {
 			c.Writer.WriteHeader(status)
-			loadbalance.RecordServiceFailure(s.rule.UUID, sid)
 			s.server.reportHealthStatus(provider, model,
 				fmt.Errorf("upstream returned HTTP %d", status), "")
 		}

--- a/internal/server/load_balance_test.go
+++ b/internal/server/load_balance_test.go
@@ -438,6 +438,66 @@ func TestLBScenario_HalfOpenProbeRecovery(t *testing.T) {
 	require.Equal(t, 200, tr.FinalStatus)
 }
 
+// ============ PromotionHold: de-jitter batch return-to-primary ============
+//
+// Plan B. When t0 recovers, a freshly-Closed primary is within PromotionHold.
+// During the hold it takes NEW sessions but does NOT reclaim sessions already
+// pinned to the fallback tier — so the whole fallback population isn't vacuumed
+// back at once (which would re-trip t0 under full load). Once t0 has stayed
+// healthy past the hold, fallback pins migrate back.
+func TestLBScenario_PromotionHoldBatchDeJitter(t *testing.T) {
+	t0 := svc("openai", "gpt-5.4", 0, true)
+	t1 := svc("openai", "gpt-5.5", 1, true)
+	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	// t0: 3 failures trip; 3 successes recover (driven by a NEW session's
+	// probes); then more 200s for the post-hold return of the original session.
+	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-promo", 1800, t0, t1), map[string][]int{
+		id0: {500, 500, 500, 200, 200, 200, 200, 200},
+		id1: {200},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	const orig = "sess-orig" // lands on t1 while t0 is tripped
+
+	// 3 failures trip t0; orig failovers to t1 and pins there.
+	for i := 0; i < 3; i++ {
+		_, err := sim.Request(orig)
+		require.NoError(t, err)
+	}
+	require.Equal(t, "open", sim.BreakerStates()[id0])
+	_, err = sim.Request(orig)
+	require.NoError(t, err)
+	require.Equal(t, id1, sim.Pin(orig), "orig should be pinned to t1 while t0 is open")
+
+	// Advance past OpenDuration; drive t0's recovery with a NEW session so orig
+	// (pinned to t1) is not the one probing t0.
+	sim.Advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
+	const fresh = "sess-fresh"
+	for probe := 0; probe < 3; probe++ {
+		tr, err := sim.Request(fresh)
+		require.NoError(t, err)
+		require.Equal(t, []string{id0}, tr.Attempts, "fresh session probes recovered t0")
+		require.Equal(t, 200, tr.FinalStatus)
+	}
+	require.Equal(t, "closed", sim.BreakerStates()[id0], "t0 should be closed after 3 successful probes")
+
+	// t0 just recovered — within PromotionHold. The fresh session adopted t0,
+	// but orig STAYS on t1 (the recovered primary hasn't proven stable yet).
+	require.Equal(t, id0, sim.Pin(fresh), "fresh session adopts recovered t0 during hold")
+	tr, err := sim.Request(orig)
+	require.NoError(t, err)
+	require.Equal(t, []string{id1}, tr.Attempts, "orig stays on t1 while t0 is within PromotionHold")
+	require.Equal(t, id1, sim.Pin(orig), "orig remains pinned to t1 during the hold")
+
+	// Advance past PromotionHold. t0 has now proven stable → orig migrates back.
+	sim.Advance(loadbalance.DefaultPromotionHold + time.Second)
+	tr, err = sim.Request(orig)
+	require.NoError(t, err)
+	require.Equal(t, []string{id0}, tr.Attempts, "orig returns to t0 after PromotionHold elapses")
+	require.Equal(t, id0, sim.Pin(orig), "orig re-pins to t0 after the hold")
+}
+
 // ============ All tiers tripped: degrade to T0 ============
 //
 // When every tier's breaker is open, TierTactic falls back to the highest-

--- a/internal/server/load_balance_test.go
+++ b/internal/server/load_balance_test.go
@@ -106,7 +106,7 @@ func TestLBScenario_C_CascadeFailoverAndRecovery(t *testing.T) {
 	t1 := svc("openai", "gpt-5.5", 1, true)
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-C", 1800, t0, t1), map[string][]int{
-		id0: {500, 500, 500, 200},
+		id0: {500, 500, 500, 200, 200, 200},
 		id1: {200},
 	})
 	require.NoError(t, err)
@@ -130,9 +130,15 @@ func TestLBScenario_C_CascadeFailoverAndRecovery(t *testing.T) {
 	// Enough time passes for the breaker to admit a probe; t0 recovers upstream.
 	sim.Advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
 
-	tr, err = sim.Request(sess)
-	require.NoError(t, err)
-	require.Equal(t, []string{id0}, tr.Attempts, "after recovery the session should return to t0")
+	// Recovery requires RecoveryThreshold (3) consecutive successful probes
+	// (hysteresis). Each probe returns to t0 while still HalfOpen; only the
+	// 3rd closes the breaker and re-pins the session.
+	for probe := 1; probe <= 3; probe++ {
+		tr, err = sim.Request(sess)
+		require.NoError(t, err)
+		require.Equal(t, []string{id0}, tr.Attempts, "recovery probe %d should land on t0", probe)
+		require.Equal(t, 200, tr.FinalStatus)
+	}
 	require.Equal(t, id0, sim.Pin(sess), "session should be re-pinned to the recovered primary t0")
 	require.Equal(t, "closed", sim.BreakerStates()[id0])
 }
@@ -379,8 +385,11 @@ func TestLBScenario_HalfOpenProbeRecovery(t *testing.T) {
 	t0 := svc("openai", "gpt-5.4", 0, true)
 	t1 := svc("openai", "gpt-5.5", 1, true)
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
+	// 3 failures trip t0; then RecoveryThreshold (3) consecutive successful
+	// probes are required to close it (hysteresis: a single success no longer
+	// closes). We feed 3 successes so the breaker fully recovers.
 	sim, cleanup, err := NewLBSimulator(tierTacticRule("rule-hop", 1800, t0, t1), map[string][]int{
-		id0: {500, 500, 500, 200, 200}, // 3 failures trip, 4th is the probe (succeeds), 5th is closed
+		id0: {500, 500, 500, 200, 200, 200},
 		id1: {200},
 	})
 	require.NoError(t, err)
@@ -406,15 +415,23 @@ func TestLBScenario_HalfOpenProbeRecovery(t *testing.T) {
 	// Advance past OpenDuration (30s + 1s)
 	sim.Advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
 
-	// 5th request: half-open probe to t0 → 200 → breaker closes
-	tr, err = sim.Request(sess)
-	require.NoError(t, err)
-	require.Equal(t, []string{id0}, tr.Attempts, "after OpenDuration, half-open probe lands on t0")
-	require.Equal(t, 200, tr.FinalStatus)
-	require.Equal(t, "closed", sim.BreakerStates()[id0], "successful probe closes the breaker")
+	// Recovery takes RecoveryThreshold (3) consecutive successful probes.
+	// Each successful probe while still HalfOpen admits t0 but does not yet
+	// close the breaker; only the 3rd consecutive success closes it.
+	for probe := 0; probe < 3; probe++ {
+		tr, err = sim.Request(sess)
+		require.NoError(t, err)
+		require.Equal(t, []string{id0}, tr.Attempts, "half-open probe should land on t0")
+		require.Equal(t, 200, tr.FinalStatus)
+		want := "half_open"
+		if probe == 2 {
+			want = "closed"
+		}
+		require.Equal(t, want, sim.BreakerStates()[id0], "probe %d: breaker state", probe+1)
+	}
 	require.Equal(t, id0, sim.Pin(sess), "session should be re-pinned to t0 after recovery")
 
-	// 6th request: t0 closed → t0 directly
+	// Next request: t0 closed → t0 directly
 	tr, err = sim.Request(sess)
 	require.NoError(t, err)
 	require.Equal(t, []string{id0}, tr.Attempts, "after recovery, requests land on t0")

--- a/internal/server/load_balance_tier_e2e_test.go
+++ b/internal/server/load_balance_tier_e2e_test.go
@@ -83,10 +83,10 @@ func TestTierRouting_EndToEnd(t *testing.T) {
 	defer restoreClock()
 
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		store.RecordFailure(primaryID)
+		store.RecordFailure(rule.UUID, primaryID)
 	}
-	defer store.RecordSuccess(primaryID)
-	defer store.RecordSuccess(fallbackID)
+	defer store.RecordSuccess(rule.UUID, primaryID)
+	defer store.RecordSuccess(rule.UUID, fallbackID)
 
 	got, err = lb.SelectService(&rule)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestTierRouting_EndToEnd(t *testing.T) {
 	//    RecordServiceSuccess on a good request). RecoveryThreshold is set
 	//    to 1 so this test stays focused on the tier-return contract; the
 	//    multi-success streak is covered in breaker_test.go.
-	pb := store.Get(primaryID)
+	pb := store.Get(rule.UUID, primaryID)
 	prevThreshold := pb.RecoveryThreshold
 	pb.RecoveryThreshold = 1
 	defer func() { pb.RecoveryThreshold = prevThreshold }()
@@ -117,7 +117,7 @@ func TestTierRouting_EndToEnd(t *testing.T) {
 	if got.ServiceID() != primaryID {
 		t.Fatalf("half-open pick = %s, want primary %s", got.ServiceID(), primaryID)
 	}
-	store.RecordSuccess(primaryID) // HalfOpen → Closed
+	store.RecordSuccess(rule.UUID, primaryID) // HalfOpen → Closed
 
 	got, err = lb.SelectService(&rule)
 	if err != nil {

--- a/internal/server/load_balance_tier_e2e_test.go
+++ b/internal/server/load_balance_tier_e2e_test.go
@@ -3,7 +3,9 @@ package server
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/tingly-dev/tingly-box/internal/clock"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -76,6 +78,10 @@ func TestTierRouting_EndToEnd(t *testing.T) {
 	// 2. Trip the primary's breaker via the package-level store — this
 	//    is the same store the recorder writes into on real failures.
 	store := loadbalance.DefaultBreakerStore()
+	base := time.Unix(2_000_000_000, 0)
+	restoreClock := clock.SetClock(func() time.Time { return base })
+	defer restoreClock()
+
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
 		store.RecordFailure(primaryID)
 	}
@@ -90,9 +96,28 @@ func TestTierRouting_EndToEnd(t *testing.T) {
 		t.Fatalf("after-trip pick = %s, want fallback %s", got.ServiceID(), fallbackID)
 	}
 
-	// 3. Mark the primary healthy again (mirrors what RecordResponse →
-	//    RecordServiceSuccess does at the end of a good request).
-	store.RecordSuccess(primaryID)
+	// 3. Recovery now requires consecutive probe successes (hysteresis).
+	//    Advance past the open window so SelectService's internal Allow()
+	//    flips the breaker Open → HalfOpen and re-admits the primary, then
+	//    mark the probe successful so it closes (mirrors RecordResponse →
+	//    RecordServiceSuccess on a good request). RecoveryThreshold is set
+	//    to 1 so this test stays focused on the tier-return contract; the
+	//    multi-success streak is covered in breaker_test.go.
+	pb := store.Get(primaryID)
+	prevThreshold := pb.RecoveryThreshold
+	pb.RecoveryThreshold = 1
+	defer func() { pb.RecoveryThreshold = prevThreshold }()
+
+	clock.SetClock(func() time.Time { return base.Add(loadbalance.DefaultBreakerOpenDuration + time.Second) })
+
+	got, err = lb.SelectService(&rule)
+	if err != nil {
+		t.Fatalf("half-open SelectService: %v", err)
+	}
+	if got.ServiceID() != primaryID {
+		t.Fatalf("half-open pick = %s, want primary %s", got.ServiceID(), primaryID)
+	}
+	store.RecordSuccess(primaryID) // HalfOpen → Closed
 
 	got, err = lb.SelectService(&rule)
 	if err != nil {

--- a/internal/server/load_balance_tier_e2e_test.go
+++ b/internal/server/load_balance_tier_e2e_test.go
@@ -99,10 +99,10 @@ func TestTierRouting_EndToEnd(t *testing.T) {
 	// 3. Recovery now requires consecutive probe successes (hysteresis).
 	//    Advance past the open window so SelectService's internal Allow()
 	//    flips the breaker Open → HalfOpen and re-admits the primary, then
-	//    mark the probe successful so it closes (mirrors RecordResponse →
-	//    RecordServiceSuccess on a good request). RecoveryThreshold is set
-	//    to 1 so this test stays focused on the tier-return contract; the
-	//    multi-success streak is covered in breaker_test.go.
+	//    mark the probe successful so it closes (mirrors failover's success
+	//    feedback on a good request). RecoveryThreshold is set to 1 so this
+	//    test stays focused on the tier-return contract; the multi-success
+	//    streak is covered in breaker_test.go.
 	pb := store.Get(rule.UUID, primaryID)
 	prevThreshold := pb.RecoveryThreshold
 	pb.RecoveryThreshold = 1

--- a/internal/server/openai_mcp.go
+++ b/internal/server/openai_mcp.go
@@ -48,7 +48,9 @@ func (ph *ProtocolHandler) StreamOpenAIChatToAnthropicV1WithMCP(
 		}
 		if err != nil {
 			ph.trackUsageWithTokenUsage(c, usage, err)
-			stream.SendInternalError(c, err.Error())
+			if !c.Writer.Written() {
+				stream.SendStreamingError(c, err)
+			}
 			if recorder != nil {
 				recorder.RecordError(err)
 			}
@@ -102,7 +104,9 @@ func (ph *ProtocolHandler) StreamOpenAIChatToAnthropicBetaWithMCP(
 		}
 		if err != nil {
 			ph.trackUsageWithTokenUsage(c, usage, err)
-			stream.SendInternalError(c, err.Error())
+			if !c.Writer.Written() {
+				stream.SendStreamingError(c, err)
+			}
 			if streamRec != nil {
 				streamRec.RecordError(err)
 			}

--- a/internal/server/protocol_handler.go
+++ b/internal/server/protocol_handler.go
@@ -276,8 +276,16 @@ func (ph *ProtocolHandler) determineRuleWithScenario(ctx *gin.Context, scenario 
 // because scenario sink lifecycle (creation, mutex, recordDir) still lives on
 // root *Server — see ProtocolHandlerDeps.
 func (ph *ProtocolHandler) EnsureProtocolRecorder(c *gin.Context, scenario string, provider *typ.Provider, model string, mode obs.RecordMode, bs []byte) *recording.ProtocolRecorder {
+	bindRule := func(rec *recording.ProtocolRecorder) {
+		if r, ok := c.Get(ContextKeyRule); ok {
+			if rule, ok := r.(*typ.Rule); ok {
+				rec.BindRule(rule.UUID)
+			}
+		}
+	}
 	if rec, ok := recording.GetRecorderFromContext(c); ok {
 		rec.BindProvider(provider, model, mode)
+		bindRule(rec)
 		return rec
 	}
 
@@ -296,6 +304,7 @@ func (ph *ProtocolHandler) EnsureProtocolRecorder(c *gin.Context, scenario strin
 		return nil
 	}
 	rec.BindProvider(provider, model, mode)
+	bindRule(rec)
 	c.Set(recording.RecorderContextKey, rec)
 	return rec
 }

--- a/internal/server/protocol_handler.go
+++ b/internal/server/protocol_handler.go
@@ -276,16 +276,8 @@ func (ph *ProtocolHandler) determineRuleWithScenario(ctx *gin.Context, scenario 
 // because scenario sink lifecycle (creation, mutex, recordDir) still lives on
 // root *Server — see ProtocolHandlerDeps.
 func (ph *ProtocolHandler) EnsureProtocolRecorder(c *gin.Context, scenario string, provider *typ.Provider, model string, mode obs.RecordMode, bs []byte) *recording.ProtocolRecorder {
-	bindRule := func(rec *recording.ProtocolRecorder) {
-		if r, ok := c.Get(ContextKeyRule); ok {
-			if rule, ok := r.(*typ.Rule); ok {
-				rec.BindRule(rule.UUID)
-			}
-		}
-	}
 	if rec, ok := recording.GetRecorderFromContext(c); ok {
 		rec.BindProvider(provider, model, mode)
-		bindRule(rec)
 		return rec
 	}
 
@@ -304,7 +296,6 @@ func (ph *ProtocolHandler) EnsureProtocolRecorder(c *gin.Context, scenario strin
 		return nil
 	}
 	rec.BindProvider(provider, model, mode)
-	bindRule(rec)
 	c.Set(recording.RecorderContextKey, rec)
 	return rec
 }

--- a/internal/server/recording/recorder.go
+++ b/internal/server/recording/recorder.go
@@ -58,6 +58,7 @@ type ProtocolRecorder struct {
 	providerBase  string // Base URL
 	model         string
 	mode          obs.RecordMode
+	ruleUUID      string // rule whose breaker to attribute success/failure to (rule-scoped breaker)
 }
 
 func NewProtocolRecorder(c *gin.Context, sink *obs.Sink, scenario string, mode obs.RecordMode, body []byte) (*ProtocolRecorder, error) {
@@ -92,12 +93,24 @@ func NewProtocolRecorder(c *gin.Context, sink *obs.Sink, scenario string, mode o
 // SetActiveService re-binds the recorder to a new provider/model. The
 // failover orchestrator calls this between attempts so a subsequent
 // RecordError attributes the failure to the right service rather than
-// to whichever service the recorder was last bound to.
+// to whichever service the recorder was last bound to. The rule does not
+// change across failover attempts, so SetActiveService does not touch ruleUUID.
 func (sr *ProtocolRecorder) SetActiveService(provider *typ.Provider, model string) {
 	if sr == nil {
 		return
 	}
 	sr.BindProvider(provider, model, "")
+}
+
+// BindRule binds the rule whose breaker should receive this recorder's
+// success/failure attributions. Called once at recorder creation
+// (EnsureProtocolRecorder); the rule is fixed for the whole request, including
+// across failover attempts.
+func (sr *ProtocolRecorder) BindRule(ruleUUID string) {
+	if sr == nil {
+		return
+	}
+	sr.ruleUUID = ruleUUID
 }
 
 // breakerServiceID returns the loadbalance service identifier for the
@@ -247,8 +260,8 @@ func (sr *ProtocolRecorder) RecordResponse(provider *typ.Provider, model string)
 	if sr.finalResponse == nil {
 		sr.finalResponse = sr.synthesizeFinalResponse()
 	}
-	if id := sr.breakerServiceID(); id != "" {
-		loadbalance.RecordServiceSuccess(id)
+	if id := sr.breakerServiceID(); id != "" && sr.ruleUUID != "" {
+		loadbalance.RecordServiceSuccess(sr.ruleUUID, id)
 	}
 	sr.emit(nil)
 }
@@ -259,8 +272,8 @@ func (sr *ProtocolRecorder) RecordError(err error) {
 		return
 	}
 	if err != nil {
-		if id := sr.breakerServiceID(); id != "" {
-			loadbalance.RecordServiceFailure(id)
+		if id := sr.breakerServiceID(); id != "" && sr.ruleUUID != "" {
+			loadbalance.RecordServiceFailure(sr.ruleUUID, id)
 		}
 	}
 	sr.emit(err)

--- a/internal/server/recording/recorder.go
+++ b/internal/server/recording/recorder.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
-	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -58,7 +57,6 @@ type ProtocolRecorder struct {
 	providerBase  string // Base URL
 	model         string
 	mode          obs.RecordMode
-	ruleUUID      string // rule whose breaker to attribute success/failure to (rule-scoped breaker)
 }
 
 func NewProtocolRecorder(c *gin.Context, sink *obs.Sink, scenario string, mode obs.RecordMode, body []byte) (*ProtocolRecorder, error) {
@@ -91,35 +89,14 @@ func NewProtocolRecorder(c *gin.Context, sink *obs.Sink, scenario string, mode o
 }
 
 // SetActiveService re-binds the recorder to a new provider/model. The
-// failover orchestrator calls this between attempts so a subsequent
-// RecordError attributes the failure to the right service rather than
-// to whichever service the recorder was last bound to. The rule does not
-// change across failover attempts, so SetActiveService does not touch ruleUUID.
+// failover orchestrator calls this between attempts so records reflect the
+// service currently being attempted. Breaker accounting is owned by the
+// failover loop, not by recording.
 func (sr *ProtocolRecorder) SetActiveService(provider *typ.Provider, model string) {
 	if sr == nil {
 		return
 	}
 	sr.BindProvider(provider, model, "")
-}
-
-// BindRule binds the rule whose breaker should receive this recorder's
-// success/failure attributions. Called once at recorder creation
-// (EnsureProtocolRecorder); the rule is fixed for the whole request, including
-// across failover attempts.
-func (sr *ProtocolRecorder) BindRule(ruleUUID string) {
-	if sr == nil {
-		return
-	}
-	sr.ruleUUID = ruleUUID
-}
-
-// breakerServiceID returns the loadbalance service identifier for the
-// active provider+model, or "" if either is unknown.
-func (sr *ProtocolRecorder) breakerServiceID() string {
-	if sr == nil || sr.providerUUID == "" || sr.model == "" {
-		return ""
-	}
-	return loadbalance.FormatServiceID(sr.providerUUID, sr.model)
 }
 
 // GetRecorderFromContext returns the ProtocolRecorder stashed in c by
@@ -260,9 +237,6 @@ func (sr *ProtocolRecorder) RecordResponse(provider *typ.Provider, model string)
 	if sr.finalResponse == nil {
 		sr.finalResponse = sr.synthesizeFinalResponse()
 	}
-	if id := sr.breakerServiceID(); id != "" && sr.ruleUUID != "" {
-		loadbalance.RecordServiceSuccess(sr.ruleUUID, id)
-	}
 	sr.emit(nil)
 }
 
@@ -270,11 +244,6 @@ func (sr *ProtocolRecorder) RecordResponse(provider *typ.Provider, model string)
 func (sr *ProtocolRecorder) RecordError(err error) {
 	if sr == nil {
 		return
-	}
-	if err != nil {
-		if id := sr.breakerServiceID(); id != "" && sr.ruleUUID != "" {
-			loadbalance.RecordServiceFailure(sr.ruleUUID, id)
-		}
 	}
 	sr.emit(err)
 }

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -92,19 +92,22 @@ func (s *SimpleSelector) SelectService(
 	}
 	c.Set(constant.CtxKeyLBTactic, tacticName)
 
-	fields := selectionRuleLogFields(ctx)
-	fields["stage"] = "routing_selected"
-	fields["source"] = result.Source
-	fields["lb_tactic"] = tacticName
-	fields["service"] = result.Service.ServiceID()
-	fields["provider"] = result.Provider.Name
-	fields["provider_uuid"] = result.Provider.UUID
-	fields["model"] = result.Service.Model
-	fields["routed_model"] = result.Service.Model
-	fields["routed_provider"] = result.Provider.Name
-	fields["candidate_count"] = len(ctx.Rule.GetActiveServices())
-	fields["evaluated_stages"] = result.EvaluatedStages
-	logrus.WithContext(c.Request.Context()).WithFields(fields).Infof("[routing] selected %s/%s via %s", result.Provider.UUID, result.Service.Model, result.Source)
+	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+		"stage":            "routing_selected",
+		"rule_uuid":        rule.UUID,
+		"scenario":         string(scenario),
+		"request_model":    rule.RequestModel,
+		"source":           result.Source,
+		"lb_tactic":        tacticName,
+		"service":          result.Service.ServiceID(),
+		"provider":         result.Provider.Name,
+		"provider_uuid":    result.Provider.UUID,
+		"model":            result.Service.Model,
+		"routed_model":     result.Service.Model,
+		"routed_provider":  result.Provider.Name,
+		"candidate_count":  len(ctx.Rule.GetActiveServices()),
+		"evaluated_stages": result.EvaluatedStages,
+	}).Infof("[routing] selected %s/%s via %s", result.Provider.UUID, result.Service.Model, result.Source)
 
 	setRoutingDebugHeaders(c, result.Provider.Name, result.Provider.UUID, result.Service.Model, result.Source, result.MatchedSmartRuleIndex)
 

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -92,18 +92,19 @@ func (s *SimpleSelector) SelectService(
 	}
 	c.Set(constant.CtxKeyLBTactic, tacticName)
 
-	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-		"stage":            "routing_selected",
-		"rule_uuid":        rule.UUID,
-		"source":           result.Source,
-		"lb_tactic":        tacticName,
-		"service":          result.Service.ServiceID(),
-		"provider":         result.Provider.Name,
-		"provider_uuid":    result.Provider.UUID,
-		"model":            result.Service.Model,
-		"candidate_count":  len(ctx.Rule.GetActiveServices()),
-		"evaluated_stages": result.EvaluatedStages,
-	}).Infof("[routing] selected %s/%s via %s", result.Provider.UUID, result.Service.Model, result.Source)
+	fields := selectionRuleLogFields(ctx)
+	fields["stage"] = "routing_selected"
+	fields["source"] = result.Source
+	fields["lb_tactic"] = tacticName
+	fields["service"] = result.Service.ServiceID()
+	fields["provider"] = result.Provider.Name
+	fields["provider_uuid"] = result.Provider.UUID
+	fields["model"] = result.Service.Model
+	fields["routed_model"] = result.Service.Model
+	fields["routed_provider"] = result.Provider.Name
+	fields["candidate_count"] = len(ctx.Rule.GetActiveServices())
+	fields["evaluated_stages"] = result.EvaluatedStages
+	logrus.WithContext(c.Request.Context()).WithFields(fields).Infof("[routing] selected %s/%s via %s", result.Provider.UUID, result.Service.Model, result.Source)
 
 	setRoutingDebugHeaders(c, result.Provider.Name, result.Provider.UUID, result.Service.Model, result.Source, result.MatchedSmartRuleIndex)
 

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -92,6 +92,19 @@ func (s *SimpleSelector) SelectService(
 	}
 	c.Set(constant.CtxKeyLBTactic, tacticName)
 
+	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+		"stage":            "routing_selected",
+		"rule_uuid":        rule.UUID,
+		"source":           result.Source,
+		"lb_tactic":        tacticName,
+		"service":          result.Service.ServiceID(),
+		"provider":         result.Provider.Name,
+		"provider_uuid":    result.Provider.UUID,
+		"model":            result.Service.Model,
+		"candidate_count":  len(ctx.Rule.GetActiveServices()),
+		"evaluated_stages": result.EvaluatedStages,
+	}).Infof("[routing] selected %s/%s via %s", result.Provider.UUID, result.Service.Model, result.Source)
+
 	setRoutingDebugHeaders(c, result.Provider.Name, result.Provider.UUID, result.Service.Model, result.Source, result.MatchedSmartRuleIndex)
 
 	return result.Provider, result.Service, nil

--- a/internal/server/routing/stage_affinity.go
+++ b/internal/server/routing/stage_affinity.go
@@ -82,7 +82,7 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 	// On decline the pipeline falls through to the strategy, which re-selects a
 	// currently-valid service, and postProcess re-pins the session there.
 	if state != nil && len(state.candidateServices) > 0 &&
-		!typ.IsAffinityEligible(state.candidateServices, entry.Service) {
+		!typ.IsAffinityEligible(rule.UUID, state.candidateServices, entry.Service) {
 		logrus.Infof("[affinity] locked service %s is not currently selectable for session %s; dropping pin so strategy re-selects",
 			entry.Service.ServiceID(), ctx.SessionID.String())
 		return nil, false

--- a/internal/server/routing/stage_affinity_test.go
+++ b/internal/server/routing/stage_affinity_test.go
@@ -159,9 +159,9 @@ func TestAffinity_TierScope_HonorsPinWhilePrimaryDown(t *testing.T) {
 
 	bs := loadbalance.DefaultBreakerStore()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		bs.RecordFailure(t0.ServiceID())
+		bs.RecordFailure("rule-tier-b", t0.ServiceID())
 	}
-	defer bs.RecordSuccess(t0.ServiceID())
+	defer bs.RecordSuccess("rule-tier-b", t0.ServiceID())
 
 	stage := NewAffinityStage(store, "global")
 	ctx := testContext(rule, "s1")
@@ -183,9 +183,9 @@ func TestAffinity_TierScope_DeclinesWhenPinnedBreakerOpen(t *testing.T) {
 
 	bs := loadbalance.DefaultBreakerStore()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		bs.RecordFailure(t1.ServiceID())
+		bs.RecordFailure("rule-tier-c", t1.ServiceID())
 	}
-	defer bs.RecordSuccess(t1.ServiceID())
+	defer bs.RecordSuccess("rule-tier-c", t1.ServiceID())
 
 	stage := NewAffinityStage(store, "global")
 	ctx := testContext(rule, "s1")
@@ -228,9 +228,9 @@ func TestAffinity_HorizontalRule_DropsPinToDeadPeer(t *testing.T) {
 
 	bs := loadbalance.DefaultBreakerStore()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		bs.RecordFailure(a.ServiceID())
+		bs.RecordFailure("rule-horiz", a.ServiceID())
 	}
-	defer bs.RecordSuccess(a.ServiceID())
+	defer bs.RecordSuccess("rule-horiz", a.ServiceID())
 
 	stage := NewAffinityStage(store, "global")
 	ctx := testContext(rule, "s1")

--- a/internal/server/routing/stage_health.go
+++ b/internal/server/routing/stage_health.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -21,7 +23,7 @@ func (s *HealthStage) Name() string {
 	return "health"
 }
 
-func (s *HealthStage) Evaluate(_ *SelectionContext, state *selectionState) (*SelectionResult, bool) {
+func (s *HealthStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
 	if state == nil || state.candidateServices == nil {
 		return nil, false
 	}
@@ -39,19 +41,36 @@ func (s *HealthStage) Evaluate(_ *SelectionContext, state *selectionState) (*Sel
 	// caller still gets a service (and the real upstream 429/auth) instead of a
 	// "no service available" routing error.
 	if before > 0 && len(healthy) == 0 {
-		logrus.Warnf("[health] all %d candidates unhealthy; keeping the full set (degrade)", before)
+		logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
+			"stage":      "routing_health_degrade",
+			"rule_uuid":  selectionRuleUUID(ctx),
+			"candidates": before,
+		}).Warnf("[health] all %d candidates unhealthy; keeping the full set (degrade)", before)
 		return NewFilterResult("health", state.candidateServices), false
 	}
 
 	filteredCount := before - len(healthy)
 
 	if filteredCount > 0 {
-		logrus.Warnf("[health] Filtered %d unhealthy services, %d remaining (of %d total)",
+		logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
+			"stage":           "routing_health_filtered",
+			"rule_uuid":       selectionRuleUUID(ctx),
+			"filtered_count":  filteredCount,
+			"remaining_count": len(healthy),
+			"candidate_count": before,
+		}).Warnf("[health] Filtered %d unhealthy services, %d remaining (of %d total)",
 			filteredCount, len(healthy), before)
 		// Log each filtered service for debugging
 		for _, svc := range state.candidateServices {
 			if !s.filter.IsHealthy(svc.ServiceID()) {
-				logrus.Warnf("[health] Service %s:%s is unhealthy (rate limited/auth error)",
+				logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
+					"stage":         "routing_health_filtered_service",
+					"rule_uuid":     selectionRuleUUID(ctx),
+					"service":       svc.ServiceID(),
+					"provider_uuid": svc.Provider,
+					"model":         svc.Model,
+					"reason":        "rate_limited_or_auth_error",
+				}).Warnf("[health] Service %s:%s is unhealthy (rate limited/auth error)",
 					svc.Provider, svc.Model)
 			}
 		}
@@ -59,4 +78,18 @@ func (s *HealthStage) Evaluate(_ *SelectionContext, state *selectionState) (*Sel
 
 	// Continue pipeline (don't select, just filter)
 	return NewFilterResult("health", healthy), false
+}
+
+func selectionLogContext(ctx *SelectionContext) context.Context {
+	if ctx != nil && ctx.GinContext != nil && ctx.GinContext.Request != nil {
+		return ctx.GinContext.Request.Context()
+	}
+	return context.Background()
+}
+
+func selectionRuleUUID(ctx *SelectionContext) string {
+	if ctx != nil && ctx.Rule != nil {
+		return ctx.Rule.UUID
+	}
+	return ""
 }

--- a/internal/server/routing/stage_load_balancer.go
+++ b/internal/server/routing/stage_load_balancer.go
@@ -63,14 +63,13 @@ func logOpenBreakerSkips(ctx *SelectionContext, rule interface {
 		if state != loadbalance.BreakerOpen {
 			continue
 		}
-		logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
-			"stage":         "routing_breaker_skipped",
-			"rule_uuid":     ctx.Rule.UUID,
-			"service":       svc.ServiceID(),
-			"provider_uuid": svc.Provider,
-			"model":         svc.Model,
-			"tier":          svc.Tier,
-			"breaker_state": state.String(),
-		}).Warnf("[routing] skipped %s because breaker is %s", svc.ServiceID(), state.String())
+		fields := selectionRuleLogFields(ctx)
+		fields["stage"] = "routing_breaker_skipped"
+		fields["service"] = svc.ServiceID()
+		fields["provider_uuid"] = svc.Provider
+		fields["attempt_model"] = svc.Model
+		fields["tier"] = svc.Tier
+		fields["breaker_state"] = state.String()
+		logrus.WithContext(selectionLogContext(ctx)).WithFields(fields).Warnf("[routing] skipped %s because breaker is %s", svc.ServiceID(), state.String())
 	}
 }

--- a/internal/server/routing/stage_load_balancer.go
+++ b/internal/server/routing/stage_load_balancer.go
@@ -63,13 +63,17 @@ func logOpenBreakerSkips(ctx *SelectionContext, rule interface {
 		if state != loadbalance.BreakerOpen {
 			continue
 		}
-		fields := selectionRuleLogFields(ctx)
-		fields["stage"] = "routing_breaker_skipped"
-		fields["service"] = svc.ServiceID()
-		fields["provider_uuid"] = svc.Provider
-		fields["attempt_model"] = svc.Model
-		fields["tier"] = svc.Tier
-		fields["breaker_state"] = state.String()
-		logrus.WithContext(selectionLogContext(ctx)).WithFields(fields).Warnf("[routing] skipped %s because breaker is %s", svc.ServiceID(), state.String())
+		logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
+			"stage":         "routing_breaker_skipped",
+			"rule_uuid":     ctx.Rule.UUID,
+			"scenario":      string(ctx.Scenario),
+			"request_model": ctx.Rule.RequestModel,
+			"lb_tactic":     ctx.Rule.GetTacticType().String(),
+			"service":       svc.ServiceID(),
+			"provider_uuid": svc.Provider,
+			"attempt_model": svc.Model,
+			"tier":          svc.Tier,
+			"breaker_state": state.String(),
+		}).Warnf("[routing] skipped %s because breaker is %s", svc.ServiceID(), state.String())
 	}
 }

--- a/internal/server/routing/stage_load_balancer.go
+++ b/internal/server/routing/stage_load_balancer.go
@@ -2,6 +2,8 @@ package routing
 
 import (
 	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
 // LoadBalancerStage performs standard load balancing across all rule services.
@@ -28,6 +30,7 @@ func (s *LoadBalancerStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if state != nil {
 		tempRule.Services = state.candidateServices
 	}
+	logOpenBreakerSkips(ctx, &tempRule)
 
 	service, err := s.loadBalancer.SelectService(&tempRule)
 	if err != nil {
@@ -42,4 +45,32 @@ func (s *LoadBalancerStage) Evaluate(ctx *SelectionContext, state *selectionStat
 
 	result := NewResult(service, "load_balancer")
 	return result, true
+}
+
+func logOpenBreakerSkips(ctx *SelectionContext, rule interface {
+	GetTacticType() loadbalance.TacticType
+	GetActiveServices() []*loadbalance.Service
+}) {
+	if ctx == nil || ctx.Rule == nil || rule == nil || rule.GetTacticType() != loadbalance.TacticTier {
+		return
+	}
+	store := loadbalance.DefaultBreakerStore()
+	for _, svc := range rule.GetActiveServices() {
+		if svc == nil {
+			continue
+		}
+		state := store.Get(ctx.Rule.UUID, svc.ServiceID()).State()
+		if state != loadbalance.BreakerOpen {
+			continue
+		}
+		logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
+			"stage":         "routing_breaker_skipped",
+			"rule_uuid":     ctx.Rule.UUID,
+			"service":       svc.ServiceID(),
+			"provider_uuid": svc.Provider,
+			"model":         svc.Model,
+			"tier":          svc.Tier,
+			"breaker_state": state.String(),
+		}).Warnf("[routing] skipped %s because breaker is %s", svc.ServiceID(), state.String())
+	}
 }

--- a/internal/typ/priority_tactic_test.go
+++ b/internal/typ/priority_tactic_test.go
@@ -160,3 +160,93 @@ func TestTierAllBreakersOpenReturnsLowestTier(t *testing.T) {
 		t.Fatalf("want T0 fallback when all open, got tier=%d", got.Tier)
 	}
 }
+
+// recoverPrimary trips the primary's breaker, then drives a full
+// RecoveryThreshold-probe success streak to close it. The fake clock is
+// advanced past OpenDuration between trips and probes. It returns the time
+// recovery completed (ClosedSince) for hold assertions.
+func recoverPrimary(t *testing.T, store *loadbalance.BreakerStore, id string, now func() time.Time, advance func(time.Duration)) time.Time {
+	t.Helper()
+	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
+		store.RecordFailure(id)
+	}
+	advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
+	for i := 0; i < loadbalance.DefaultBreakerRecoveryThreshold; i++ {
+		store.Allow(id)         // first: Open → HalfOpen; later: next probe slot
+		store.RecordSuccess(id) // 3rd closes the breaker
+	}
+	since := store.Get(id).ClosedSince()
+	if since.IsZero() {
+		t.Fatal("expected primary to have recovered (ClosedSince set)")
+	}
+	return since
+}
+
+// TestPromotionHoldKeepsFallbackPin verifies the core of plan B: a session
+// pinned to a fallback tier (T1) is NOT vacuumed back to a freshly-recovered
+// primary (T0) while T0 is within its PromotionHold. Only NEW sessions adopt
+// T0 during the hold. After the hold elapses, the T1 pin becomes ineligible
+// and the session migrates back.
+func TestPromotionHoldKeepsFallbackPin(t *testing.T) {
+	base := time.Unix(2_000_000_000, 0)
+	now := base
+	restore := clock.SetClock(func() time.Time { return now })
+	defer restore()
+	advance := func(d time.Duration) { now = now.Add(d) }
+
+	primary := mkService("hold-p1", "m1", 0)
+	backup := mkService("hold-p2", "m1", 1)
+	rule := mkTierRule(primary, backup)
+	store := loadbalance.DefaultBreakerStore()
+	defer func() {
+		// Reset primary for other tests sharing the global store.
+		for i := 0; i < loadbalance.DefaultBreakerRecoveryThreshold; i++ {
+			store.RecordSuccess(primary.ServiceID())
+		}
+	}()
+
+	// T0 trips, T1 takes over; the session is pinned to T1.
+	recoverAt := recoverPrimary(t, store, primary.ServiceID(), func() time.Time { return now }, advance)
+
+	// T0 just recovered — within PromotionHold. A pin to T1 stays eligible.
+	if !IsAffinityEligible(rule.GetActiveServices(), backup) {
+		t.Fatal("T1 pin should stay eligible while T0 is within PromotionHold")
+	}
+	// A pin to T0 is of course still eligible (it's the top tier).
+	if !IsAffinityEligible(rule.GetActiveServices(), primary) {
+		t.Fatal("T0 pin should always be eligible when T0 is available")
+	}
+
+	// Advance past PromotionHold. Now the recovered primary has proven stable
+	// and reclaims fallback-tier sessions.
+	now = recoverAt.Add(loadbalance.DefaultPromotionHold + time.Second)
+	if IsAffinityEligible(rule.GetActiveServices(), backup) {
+		t.Fatal("T1 pin should become ineligible after PromotionHold elapses (return to T0)")
+	}
+}
+
+// TestPromotionHoldNewSessionGoesToPrimary verifies the other half: during the
+// hold, NEW sessions (no pin) still adopt the recovered primary — the hold
+// only retains EXISTING fallback pins, it never blocks new traffic from T0.
+func TestPromotionHoldNewSessionGoesToPrimary(t *testing.T) {
+	base := time.Unix(2_000_000_000, 0)
+	now := base
+	restore := clock.SetClock(func() time.Time { return now })
+	defer restore()
+	advance := func(d time.Duration) { now = now.Add(d) }
+
+	primary := mkService("new-p1", "m1", 0)
+	backup := mkService("new-p2", "m1", 1)
+	rule := mkTierRule(primary, backup)
+	tactic := NewTierTactic(loadbalance.TacticRandom)
+	store := loadbalance.DefaultBreakerStore()
+
+	recoverPrimary(t, store, primary.ServiceID(), func() time.Time { return now }, advance)
+
+	// New session: SelectService (no pin consulted) picks the recovered T0
+	// even though we are inside PromotionHold.
+	got := tactic.SelectService(rule)
+	if got != primary {
+		t.Fatalf("new session should adopt recovered T0 during hold, got %v", got)
+	}
+}

--- a/internal/typ/priority_tactic_test.go
+++ b/internal/typ/priority_tactic_test.go
@@ -50,9 +50,9 @@ func TestTierFallsBackWhenBreakerOpen(t *testing.T) {
 	// Trip the primary's breaker.
 	store := loadbalance.DefaultBreakerStore()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		store.RecordFailure(primary.ServiceID())
+		store.RecordFailure(rule.UUID, primary.ServiceID())
 	}
-	defer store.RecordSuccess(primary.ServiceID()) // clean up for other tests
+	defer store.RecordSuccess(rule.UUID, primary.ServiceID()) // clean up for other tests
 
 	got := tactic.SelectService(rule)
 	if got != backup {
@@ -71,7 +71,7 @@ func TestTierReturnsToHigherWhenBreakerCloses(t *testing.T) {
 
 	store := loadbalance.DefaultBreakerStore()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		store.RecordFailure(primary.ServiceID())
+		store.RecordFailure(rule.UUID, primary.ServiceID())
 	}
 	if got := tactic.SelectService(rule); got != backup {
 		t.Fatalf("expected fallback to T1 backup, got %v", got)
@@ -81,7 +81,7 @@ func TestTierReturnsToHigherWhenBreakerCloses(t *testing.T) {
 	// success no longer closes the breaker). Keep this test focused on tier
 	// return by requiring just one successful probe; the streak itself is
 	// covered in breaker_test.go.
-	b := store.Get(primary.ServiceID())
+	b := store.Get(rule.UUID, primary.ServiceID())
 	prevThreshold := b.RecoveryThreshold
 	b.RecoveryThreshold = 1
 	defer func() { b.RecoveryThreshold = prevThreshold }()
@@ -95,7 +95,7 @@ func TestTierReturnsToHigherWhenBreakerCloses(t *testing.T) {
 		t.Fatalf("expected half-open probe to pick T0 primary, got %v", got)
 	}
 	// The probe succeeded → mark it so the breaker closes for good.
-	store.RecordSuccess(primary.ServiceID())
+	store.RecordSuccess(rule.UUID, primary.ServiceID())
 	if got := tactic.SelectService(rule); got != primary {
 		t.Fatalf("expected return to T0 primary after recovery, got %v", got)
 	}
@@ -144,12 +144,12 @@ func TestTierAllBreakersOpenReturnsLowestTier(t *testing.T) {
 	store := loadbalance.DefaultBreakerStore()
 	for _, svc := range []*loadbalance.Service{high, low} {
 		for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-			store.RecordFailure(svc.ServiceID())
+			store.RecordFailure(rule.UUID, svc.ServiceID())
 		}
 	}
 	defer func() {
-		store.RecordSuccess(high.ServiceID())
-		store.RecordSuccess(low.ServiceID())
+		store.RecordSuccess(rule.UUID, high.ServiceID())
+		store.RecordSuccess(rule.UUID, low.ServiceID())
 	}()
 
 	got := tactic.SelectService(rule)
@@ -165,17 +165,17 @@ func TestTierAllBreakersOpenReturnsLowestTier(t *testing.T) {
 // RecoveryThreshold-probe success streak to close it. The fake clock is
 // advanced past OpenDuration between trips and probes. It returns the time
 // recovery completed (ClosedSince) for hold assertions.
-func recoverPrimary(t *testing.T, store *loadbalance.BreakerStore, id string, now func() time.Time, advance func(time.Duration)) time.Time {
+func recoverPrimary(t *testing.T, store *loadbalance.BreakerStore, ruleUUID, id string, now func() time.Time, advance func(time.Duration)) time.Time {
 	t.Helper()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		store.RecordFailure(id)
+		store.RecordFailure(ruleUUID, id)
 	}
 	advance(loadbalance.DefaultBreakerOpenDuration + time.Second)
 	for i := 0; i < loadbalance.DefaultBreakerRecoveryThreshold; i++ {
-		store.Allow(id)         // first: Open → HalfOpen; later: next probe slot
-		store.RecordSuccess(id) // 3rd closes the breaker
+		store.Allow(ruleUUID, id)         // first: Open → HalfOpen; later: next probe slot
+		store.RecordSuccess(ruleUUID, id) // 3rd closes the breaker
 	}
-	since := store.Get(id).ClosedSince()
+	since := store.Get(ruleUUID, id).ClosedSince()
 	if since.IsZero() {
 		t.Fatal("expected primary to have recovered (ClosedSince set)")
 	}
@@ -201,26 +201,26 @@ func TestPromotionHoldKeepsFallbackPin(t *testing.T) {
 	defer func() {
 		// Reset primary for other tests sharing the global store.
 		for i := 0; i < loadbalance.DefaultBreakerRecoveryThreshold; i++ {
-			store.RecordSuccess(primary.ServiceID())
+			store.RecordSuccess(rule.UUID, primary.ServiceID())
 		}
 	}()
 
 	// T0 trips, T1 takes over; the session is pinned to T1.
-	recoverAt := recoverPrimary(t, store, primary.ServiceID(), func() time.Time { return now }, advance)
+	recoverAt := recoverPrimary(t, store, rule.UUID, primary.ServiceID(), func() time.Time { return now }, advance)
 
 	// T0 just recovered — within PromotionHold. A pin to T1 stays eligible.
-	if !IsAffinityEligible(rule.GetActiveServices(), backup) {
+	if !IsAffinityEligible(rule.UUID, rule.GetActiveServices(), backup) {
 		t.Fatal("T1 pin should stay eligible while T0 is within PromotionHold")
 	}
 	// A pin to T0 is of course still eligible (it's the top tier).
-	if !IsAffinityEligible(rule.GetActiveServices(), primary) {
+	if !IsAffinityEligible(rule.UUID, rule.GetActiveServices(), primary) {
 		t.Fatal("T0 pin should always be eligible when T0 is available")
 	}
 
 	// Advance past PromotionHold. Now the recovered primary has proven stable
 	// and reclaims fallback-tier sessions.
 	now = recoverAt.Add(loadbalance.DefaultPromotionHold + time.Second)
-	if IsAffinityEligible(rule.GetActiveServices(), backup) {
+	if IsAffinityEligible(rule.UUID, rule.GetActiveServices(), backup) {
 		t.Fatal("T1 pin should become ineligible after PromotionHold elapses (return to T0)")
 	}
 }
@@ -241,7 +241,7 @@ func TestPromotionHoldNewSessionGoesToPrimary(t *testing.T) {
 	tactic := NewTierTactic(loadbalance.TacticRandom)
 	store := loadbalance.DefaultBreakerStore()
 
-	recoverPrimary(t, store, primary.ServiceID(), func() time.Time { return now }, advance)
+	recoverPrimary(t, store, rule.UUID, primary.ServiceID(), func() time.Time { return now }, advance)
 
 	// New session: SelectService (no pin consulted) picks the recovered T0
 	// even though we are inside PromotionHold.

--- a/internal/typ/priority_tactic_test.go
+++ b/internal/typ/priority_tactic_test.go
@@ -2,7 +2,9 @@ package typ
 
 import (
 	"testing"
+	"time"
 
+	"github.com/tingly-dev/tingly-box/internal/clock"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
@@ -59,6 +61,9 @@ func TestTierFallsBackWhenBreakerOpen(t *testing.T) {
 }
 
 func TestTierReturnsToHigherWhenBreakerCloses(t *testing.T) {
+	restore := clock.SetClock(func() time.Time { return time.Unix(2_000_000_000, 0) })
+	defer restore()
+
 	primary := mkService("recover-p1", "recover-m1", 0)
 	backup := mkService("recover-p2", "recover-m1", 1)
 	rule := mkTierRule(primary, backup)
@@ -71,6 +76,25 @@ func TestTierReturnsToHigherWhenBreakerCloses(t *testing.T) {
 	if got := tactic.SelectService(rule); got != backup {
 		t.Fatalf("expected fallback to T1 backup, got %v", got)
 	}
+
+	// Recovery now requires consecutive probe successes (hysteresis: a single
+	// success no longer closes the breaker). Keep this test focused on tier
+	// return by requiring just one successful probe; the streak itself is
+	// covered in breaker_test.go.
+	b := store.Get(primary.ServiceID())
+	prevThreshold := b.RecoveryThreshold
+	b.RecoveryThreshold = 1
+	defer func() { b.RecoveryThreshold = prevThreshold }()
+
+	// Advance past the open window so SelectService's internal Allow() flips
+	// the breaker Open → HalfOpen and admits the primary again.
+	now := func() time.Time { return time.Unix(2_000_000_000, 0).Add(loadbalance.DefaultBreakerOpenDuration + time.Second) }
+	clock.SetClock(now)
+	got := tactic.SelectService(rule)
+	if got != primary {
+		t.Fatalf("expected half-open probe to pick T0 primary, got %v", got)
+	}
+	// The probe succeeded → mark it so the breaker closes for good.
 	store.RecordSuccess(primary.ServiceID())
 	if got := tactic.SelectService(rule); got != primary {
 		t.Fatalf("expected return to T0 primary after recovery, got %v", got)

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -1169,7 +1169,7 @@ func (pt *TierTactic) SelectService(rule *Rule) *loadbalance.Service {
 		}
 		allowed := make([]*loadbalance.Service, 0, len(group.services))
 		for _, svc := range group.services {
-			if store.Allow(svc.ServiceID()) {
+			if store.Allow(rule.UUID, svc.ServiceID()) {
 				allowed = append(allowed, svc)
 			}
 		}
@@ -1247,7 +1247,10 @@ func groupServicesByTier(services []*loadbalance.Service) []tierBucket {
 
 // IsAffinityEligible reports whether target is a service the routing strategy
 // would actually select right now, so session affinity can decide whether a
-// pin is still valid. It is config-shape driven rather than tactic-label
+// pin is still valid. ruleUUID scopes the breaker store: each rule has
+// independent breaker state per service, so eligibility reflects only the
+// traffic this rule observes (a service failing under another rule does not
+// demote a pin here). It is config-shape driven rather than tactic-label
 // driven — "tier" is just the emergent shape of a multi-layer rule, so this
 // answers the same question for every shape:
 //
@@ -1271,7 +1274,7 @@ func groupServicesByTier(services []*loadbalance.Service) []tierBucket {
 // every service is tripped it falls back to "target is in the lowest-numbered
 // tier" (matching TierTactic's degrade-don't-disappear behavior) so a pin is
 // honored rather than wedging.
-func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Service) bool {
+func IsAffinityEligible(ruleUUID string, services []*loadbalance.Service, target *loadbalance.Service) bool {
 	if target == nil || !target.Active {
 		return false
 	}
@@ -1296,7 +1299,7 @@ func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Ser
 		available := false
 		targetAvailableHere := false
 		for _, svc := range group.services {
-			if store.IsAvailable(svc.ServiceID()) {
+			if store.IsAvailable(ruleUUID, svc.ServiceID()) {
 				available = true
 				if svc.ServiceID() == target.ServiceID() {
 					targetAvailableHere = true
@@ -1315,7 +1318,7 @@ func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Ser
 		// available. Default to returning to the primary, UNLESS the primary
 		// just recovered and is still within PromotionHold — then keep the
 		// low-tier pin a little longer to avoid a batch flip-flop.
-		if tierWithinPromotionHold(store, group.services, hold) {
+		if tierWithinPromotionHold(ruleUUID, store, group.services, hold) {
 			return true
 		}
 		return false
@@ -1330,9 +1333,9 @@ func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Ser
 // recovered within the hold window. A tier counts as "freshly recovered" if at
 // least one of its available services is within PromotionHold; services that
 // never tripped or recovered long ago do not trigger the hold.
-func tierWithinPromotionHold(store *loadbalance.BreakerStore, services []*loadbalance.Service, hold time.Duration) bool {
+func tierWithinPromotionHold(ruleUUID string, store *loadbalance.BreakerStore, services []*loadbalance.Service, hold time.Duration) bool {
 	for _, svc := range services {
-		if store.WithinPromotionHold(svc.ServiceID(), hold) {
+		if store.WithinPromotionHold(ruleUUID, svc.ServiceID(), hold) {
 			return true
 		}
 	}

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -1257,6 +1258,14 @@ func groupServicesByTier(services []*loadbalance.Service) []tierBucket {
 //     tier is the highest-priority tier that currently has any available
 //     service (don't stay on a fallback tier after the primary recovers).
 //
+// PromotionHold de-jitters batch return-to-primary: when a higher-priority tier
+// has just recovered (within DefaultPromotionHold), it only takes NEW sessions.
+// A session already pinned to a lower tier is kept there until the recovered
+// primary has stayed healthy past the hold — so a freshly-recovered primary
+// doesn't vacuum all fallback-tier sessions back at once and re-trip under
+// full load. This mirrors the "low tier has an inherent, lower-priority
+// stickiness" intent: the primary must prove stable to outweigh it.
+//
 // It mirrors TierTactic.SelectService's bucket walk but uses the non-consuming
 // breaker read (IsAvailable) so it never steals the half-open probe. When
 // every service is tripped it falls back to "target is in the lowest-numbered
@@ -1282,6 +1291,7 @@ func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Ser
 	}
 
 	store := loadbalance.DefaultBreakerStore()
+	hold := loadbalance.DefaultPromotionHold
 	for _, group := range buckets {
 		available := false
 		targetAvailableHere := false
@@ -1293,16 +1303,40 @@ func IsAffinityEligible(services []*loadbalance.Service, target *loadbalance.Ser
 				}
 			}
 		}
-		if available {
-			// This is the top available tier. The pin is valid only if the
-			// target itself is the (or an) available service in it.
-			return targetAvailableHere
+		if !available {
+			continue
 		}
+		// This is the top available tier.
+		if targetAvailableHere {
+			// The pin is already on the best tier — always eligible.
+			return true
+		}
+		// The pin is on a lower tier while a higher-priority tier is
+		// available. Default to returning to the primary, UNLESS the primary
+		// just recovered and is still within PromotionHold — then keep the
+		// low-tier pin a little longer to avoid a batch flip-flop.
+		if tierWithinPromotionHold(store, group.services, hold) {
+			return true
+		}
+		return false
 	}
 	// Every service is tripped — honor a pin to the lowest-numbered (highest
 	// priority) tier, which groupServicesByTier returns first, so the request
 	// still surfaces a real upstream error instead of wedging.
 	return target.Tier == buckets[0].tier
+}
+
+// tierWithinPromotionHold reports whether any available service in the tier
+// recovered within the hold window. A tier counts as "freshly recovered" if at
+// least one of its available services is within PromotionHold; services that
+// never tripped or recovered long ago do not trigger the hold.
+func tierWithinPromotionHold(store *loadbalance.BreakerStore, services []*loadbalance.Service, hold time.Duration) bool {
+	for _, svc := range services {
+		if store.WithinPromotionHold(svc.ServiceID(), hold) {
+			return true
+		}
+	}
+	return false
 }
 
 // Pre-created singleton priority tactic for the default-tactic registry.

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -131,7 +131,8 @@ func ParseTacticFromMap(tacticType loadbalance.TacticType, params map[string]int
 			tacticParams = DefaultTierParams()
 		}
 	default:
-		tacticParams = DefaultAdaptiveParams()
+		tacticType = loadbalance.TacticRandom
+		tacticParams = DefaultRandomParams()
 	}
 
 	return Tactic{
@@ -338,6 +339,9 @@ func AsTokenBasedParams(p TacticParams) (TokenBasedParams, bool) {
 }
 
 func AsRandomParams(p TacticParams) (RandomParams, bool) {
+	if rp, ok := p.(*RandomParams); ok {
+		return *rp, true
+	}
 	rp, ok := p.(RandomParams)
 	return rp, ok
 }

--- a/internal/typ/tier_availability_test.go
+++ b/internal/typ/tier_availability_test.go
@@ -6,11 +6,17 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
+// tierTestRule is the ruleUUID for IsAffinityEligible shape tests. The breaker
+// store is rule-scoped; these tests exercise tier-shape logic (not rule
+// isolation), and their serviceIDs are already unique per test, so one shared
+// ruleUUID keeps them isolated.
+const tierTestRule = "tier-test-rule"
+
 // tripBreaker opens a service's breaker by recording the failure threshold.
-func tripBreaker(svc *loadbalance.Service) {
+func tripBreaker(ruleUUID string, svc *loadbalance.Service) {
 	store := loadbalance.DefaultBreakerStore()
 	for i := 0; i < loadbalance.DefaultBreakerFailureThreshold; i++ {
-		store.RecordFailure(svc.ServiceID())
+		store.RecordFailure(ruleUUID, svc.ServiceID())
 	}
 }
 
@@ -20,10 +26,10 @@ func TestIsAffinityEligible_TopTierAvailable(t *testing.T) {
 	t1 := mkService("ita-a-p1", "m", 1)
 	svcs := []*loadbalance.Service{t0, t1}
 
-	if !IsAffinityEligible(svcs, t0) {
+	if !IsAffinityEligible(tierTestRule, svcs,t0) {
 		t.Fatal("t0 should be eligible when its breaker is closed")
 	}
-	if IsAffinityEligible(svcs, t1) {
+	if IsAffinityEligible(tierTestRule, svcs,t1) {
 		t.Fatal("t1 must NOT be eligible while t0 (higher priority) is available")
 	}
 }
@@ -33,13 +39,13 @@ func TestIsAffinityEligible_TopTierOpen_NextBecomesTop(t *testing.T) {
 	t1 := mkService("ita-b-p1", "m", 1)
 	svcs := []*loadbalance.Service{t0, t1}
 
-	tripBreaker(t0)
-	defer loadbalance.DefaultBreakerStore().RecordSuccess(t0.ServiceID())
+	tripBreaker(tierTestRule, t0)
+	defer loadbalance.DefaultBreakerStore().RecordSuccess(tierTestRule, t0.ServiceID())
 
-	if IsAffinityEligible(svcs, t0) {
+	if IsAffinityEligible(tierTestRule, svcs,t0) {
 		t.Fatal("t0 is open; it should not be eligible")
 	}
-	if !IsAffinityEligible(svcs, t1) {
+	if !IsAffinityEligible(tierTestRule, svcs,t1) {
 		t.Fatal("t1 should become eligible while t0 is open")
 	}
 }
@@ -51,13 +57,13 @@ func TestIsAffinityEligible_SameTierDeadPeerDropped(t *testing.T) {
 	b := mkService("ita-peer-b", "m", 0)
 	svcs := []*loadbalance.Service{a, b}
 
-	tripBreaker(a)
-	defer loadbalance.DefaultBreakerStore().RecordSuccess(a.ServiceID())
+	tripBreaker(tierTestRule, a)
+	defer loadbalance.DefaultBreakerStore().RecordSuccess(tierTestRule, a.ServiceID())
 
-	if IsAffinityEligible(svcs, a) {
+	if IsAffinityEligible(tierTestRule, svcs,a) {
 		t.Fatal("pin to a dead same-tier peer must be dropped when a healthy peer exists")
 	}
-	if !IsAffinityEligible(svcs, b) {
+	if !IsAffinityEligible(tierTestRule, svcs,b) {
 		t.Fatal("pin to a healthy same-tier peer must be honored")
 	}
 }
@@ -67,19 +73,19 @@ func TestIsAffinityEligible_AllOpen_FallsBackToLowestTier(t *testing.T) {
 	t1 := mkService("ita-c-p1", "m", 1)
 	svcs := []*loadbalance.Service{t0, t1}
 
-	tripBreaker(t0)
-	tripBreaker(t1)
+	tripBreaker(tierTestRule, t0)
+	tripBreaker(tierTestRule, t1)
 	defer func() {
 		store := loadbalance.DefaultBreakerStore()
-		store.RecordSuccess(t0.ServiceID())
-		store.RecordSuccess(t1.ServiceID())
+		store.RecordSuccess(tierTestRule, t0.ServiceID())
+		store.RecordSuccess(tierTestRule, t1.ServiceID())
 	}()
 
 	// Degrade-don't-disappear: the lowest-numbered tier is the fallback.
-	if !IsAffinityEligible(svcs, t0) {
+	if !IsAffinityEligible(tierTestRule, svcs,t0) {
 		t.Fatal("when everything is open, a pin to the lowest tier (t0) is honored")
 	}
-	if IsAffinityEligible(svcs, t1) {
+	if IsAffinityEligible(tierTestRule, svcs,t1) {
 		t.Fatal("t1 is not the fallback when everything is open")
 	}
 }
@@ -90,13 +96,13 @@ func TestIsAffinityEligible_SingleService(t *testing.T) {
 	only := mkService("ita-solo", "m", 0)
 	svcs := []*loadbalance.Service{only}
 
-	if !IsAffinityEligible(svcs, only) {
+	if !IsAffinityEligible(tierTestRule, svcs,only) {
 		t.Fatal("single healthy service must be eligible")
 	}
 
-	tripBreaker(only)
-	defer loadbalance.DefaultBreakerStore().RecordSuccess(only.ServiceID())
-	if !IsAffinityEligible(svcs, only) {
+	tripBreaker(tierTestRule, only)
+	defer loadbalance.DefaultBreakerStore().RecordSuccess(tierTestRule, only.ServiceID())
+	if !IsAffinityEligible(tierTestRule, svcs,only) {
 		t.Fatal("single service must stay eligible even when its breaker is open")
 	}
 }
@@ -110,7 +116,7 @@ func TestIsAffinityEligible_InactiveDoesNotMaskLowerTier(t *testing.T) {
 	svcs := []*loadbalance.Service{t0, t1}
 
 	// t0 is inactive → top active tier is t1 → a pin to t1 is eligible.
-	if !IsAffinityEligible(svcs, t1) {
+	if !IsAffinityEligible(tierTestRule, svcs,t1) {
 		t.Fatal("t1 should be eligible when the only higher tier is inactive")
 	}
 }
@@ -121,20 +127,20 @@ func TestIsAffinityEligible_InactiveTargetDeclined(t *testing.T) {
 	b := mkService("ita-inact-target-b", "m", 0)
 	svcs := []*loadbalance.Service{a, b}
 
-	if IsAffinityEligible(svcs, a) {
+	if IsAffinityEligible(tierTestRule, svcs,a) {
 		t.Fatal("an inactive pinned service must never be eligible")
 	}
-	if !IsAffinityEligible(svcs, b) {
+	if !IsAffinityEligible(tierTestRule, svcs,b) {
 		t.Fatal("the active peer should still be eligible")
 	}
 }
 
 func TestIsAffinityEligible_NilAndEmpty(t *testing.T) {
 	t0 := mkService("ita-d-p0", "m", 0)
-	if IsAffinityEligible([]*loadbalance.Service{t0}, nil) {
+	if IsAffinityEligible(tierTestRule, []*loadbalance.Service{t0}, nil) {
 		t.Fatal("nil target should be false")
 	}
-	if IsAffinityEligible(nil, t0) {
+	if IsAffinityEligible(tierTestRule, nil, t0) {
 		t.Fatal("empty service set should be false")
 	}
 }


### PR DESCRIPTION
## Summary

Stabilizes tier-based failover by making circuit breaker state rule-scoped, adding recovery hysteresis, and keeping fallback-pinned sessions from rushing back to a freshly recovered primary tier. Failover now owns breaker success/failure accounting directly, so breaker updates happen even when request recording is disabled and logs consistently describe the rule, scenario, attempted service, routed service, and breaker state.

## Key Changes

- Scope breaker keys by `(rule_uuid, service_id)` so one rule's failing traffic does not trip the same provider/model for another rule.
- Require multiple consecutive half-open successes before closing a breaker, and track `ClosedSince` for recovered services.
- Add `DefaultPromotionHold` so existing sessions pinned to a lower tier remain there briefly after the primary recovers, while new sessions can still use the recovered primary.
- Move breaker accounting out of the recorder and into the failover loop, then enrich failover/routing logs for attempts, retries, terminal failures, skipped open breakers, and health filtering.
- Default generated Claude Code profile rules to random load balancing and broaden tactic validation/parsing for value and pointer param shapes, including tier params.
- Refresh tier-routing design docs to describe recovery hysteresis, promotion hold, and rule-scoped breakers.

## Impact

Tier routing should be less prone to oscillation during upstream recovery and less likely to spread breaker state across unrelated rules. Operators also get clearer logs for why a service was skipped, retried, or promoted back into traffic.

## Validation

```
go test ./internal/loadbalance ./internal/typ ./internal/server
go test ./cli/...
go run ./cli/harness lb --all --table
```

