### PR TITLE
config: add gpt-5.6 variants to ChatGPT Code (codex) provider

### DIFF
--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -351,6 +351,27 @@
       "base_url_anthropic": null,
       "models": [
         {
+          "id": "gpt-5.6-sol",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-07-09",
+          "note": "旗舰模型，能力最强，适合复杂编码、长程 Agent 和高难度推理"
+        },
+        {
+          "id": "gpt-5.6-terra",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-07-09",
+          "note": "平衡能力与成本，适合常规开发任务"
+        },
+        {
+          "id": "gpt-5.6-luna",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-07-09",
+          "note": "延迟和成本最低，适合高频、相对简单的任务"
+        },
+        {
           "id": "gpt-5.4",
           "context": 272000
         },


### PR DESCRIPTION
### Motivation

- Add new high-capacity `gpt-5.6` model variants to the ChatGPT Code (`codex`) provider to support more complex coding, long-running agents, and cost/performance tradeoffs.
- Include model metadata (context windows and max output) so clients can select appropriate models for large-context and high-throughput tasks.
- Ensure file formatting ends with a newline for consistency.

### Description

- Added three new models under the `codex` provider: `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, each with `context: 1050000` and `max_output: 128000` and `created: "2026-07-09"` and descriptive `note` fields.
- Kept existing `codex` provider fields (endpoints, auth, and other models) unchanged and only extended the `models` list.
- Added a trailing newline to the end of `internal/data/providers.json` for consistent file termination.

### Testing

- Validated the updated JSON file structure using a JSON linter (`jq`) and confirmed it parses successfully.
- Ran the repository's automated test suite (`go test ./...`), and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a505847fe74832aa8677ce20120ac77)