### PR TITLE
refactor(swagger): Refactor schema generation for deterministic, version-aware output

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4956,10 +4956,6 @@
       "AdvisorConfig": {
         "type": "object",
         "properties": {
-          "ProviderResolver": {
-            "type": "object",
-            "description": "Field ProviderResolver"
-          },
           "max_tokens": {
             "type": "integer",
             "format": "int64",
@@ -4983,10 +4979,7 @@
             "format": "int64",
             "description": "Field timeout_seconds"
           }
-        },
-        "required": [
-          "ProviderResolver"
-        ]
+        }
       },
       "AggregatedStat": {
         "type": "object",
@@ -5113,6 +5106,10 @@
       "ApplyClaudeConfigRequest": {
         "type": "object",
         "properties": {
+          "defaultMode": {
+            "type": "string",
+            "description": "Field defaultMode"
+          },
           "installStatusLine": {
             "type": "boolean",
             "description": "Field installStatusLine"
@@ -5234,12 +5231,30 @@
       "ApplyOpenCodeConfigResponse": {
         "type": "object",
         "properties": {
-          "ApplyResult": {
-            "$ref": "#/components/schemas/ApplyResult"
+          "backupPath": {
+            "type": "string",
+            "description": "Field backupPath"
+          },
+          "created": {
+            "type": "boolean",
+            "description": "Field created"
+          },
+          "message": {
+            "type": "string",
+            "description": "Field message"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          },
+          "updated": {
+            "type": "boolean",
+            "description": "Field updated"
           }
         },
         "required": [
-          "ApplyResult"
+          "success",
+          "message"
         ]
       },
       "ApplyResult": {
@@ -5334,13 +5349,6 @@
             "type": "string",
             "description": "Field DISABLE_TELEMETRY"
           },
-          "Extra": {
-            "type": "object",
-            "description": "Field Extra",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
           "HTTPS_PROXY": {
             "type": "string",
             "description": "Field HTTPS_PROXY"
@@ -5373,10 +5381,7 @@
             "type": "string",
             "description": "Field USE_BUILTIN_RIPGREP"
           }
-        },
-        "required": [
-          "Extra"
-        ]
+        }
       },
       "CodexConfigPreviewResponse": {
         "type": "object",
@@ -5645,10 +5650,6 @@
       "CreateRuleRequest": {
         "type": "object",
         "properties": {
-          "CurrentServiceID": {
-            "type": "string",
-            "description": "Field CurrentServiceID"
-          },
           "active": {
             "type": "boolean",
             "description": "Field active"
@@ -5709,7 +5710,6 @@
           "response_model",
           "description",
           "services",
-          "CurrentServiceID",
           "lb_tactic",
           "active",
           "smart_enabled"
@@ -5966,11 +5966,13 @@
             "properties": {
               "data": {
                 "type": "string",
-                "description": "Base64 or JSONL encoded provider export data"
+                "description": "Base64 or JSONL encoded provider export data",
+                "example": "TGB64:1.0:..."
               },
               "format": {
                 "type": "string",
-                "description": "Field format"
+                "description": "Field format",
+                "example": "base64"
               }
             },
             "required": [
@@ -6536,18 +6538,20 @@
                 "type": "array",
                 "description": "Field providers",
                 "items": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ProviderImportInfo"
                 }
               },
               "providers_created": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field providers_created"
+                "description": "Field providers_created",
+                "example": 1
               },
               "providers_used": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field providers_used"
+                "description": "Field providers_used",
+                "example": 0
               }
             },
             "required": [
@@ -7171,8 +7175,10 @@
       "ModelRequestDetail": {
         "type": "object",
         "properties": {
-          "ModelRequestSummary": {
-            "$ref": "#/components/schemas/ModelRequestSummary"
+          "event_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field event_count"
           },
           "events": {
             "type": "array",
@@ -7180,10 +7186,64 @@
             "items": {
               "$ref": "#/components/schemas/ModelRequestEvent"
             }
+          },
+          "has_error": {
+            "type": "boolean",
+            "description": "Field has_error"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field latency_ms"
+          },
+          "max_level": {
+            "type": "string",
+            "description": "Field max_level"
+          },
+          "method": {
+            "type": "string",
+            "description": "Field method"
+          },
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "provider": {
+            "type": "string",
+            "description": "Field provider"
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Field request_id"
+          },
+          "request_model": {
+            "type": "string",
+            "description": "Field request_model"
+          },
+          "routed_model": {
+            "type": "string",
+            "description": "Field routed_model"
+          },
+          "scenario": {
+            "type": "string",
+            "description": "Field scenario"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field status"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Field time"
           }
         },
         "required": [
-          "ModelRequestSummary",
+          "request_id",
+          "time",
+          "has_error",
+          "event_count",
           "events"
         ]
       },
@@ -7370,45 +7430,55 @@
             "properties": {
               "auth_url": {
                 "type": "string",
-                "description": "Field auth_url"
+                "description": "Field auth_url",
+                "example": "https://claude.ai/oauth/authorize?..."
               },
               "device_code": {
                 "type": "string",
-                "description": "Field device_code"
+                "description": "Field device_code",
+                "example": "MN-12345678-abcdef"
               },
               "expires_in": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field expires_in"
+                "description": "Field expires_in",
+                "example": 1800
               },
               "interval": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field interval"
+                "description": "Field interval",
+                "example": 5
               },
               "provider": {
                 "type": "string",
-                "description": "Field provider"
+                "description": "Field provider",
+                "example": "qwen_code"
               },
               "session_id": {
                 "type": "string",
-                "description": "Field session_id"
+                "description": "Field session_id",
+                "example": "abc123def456"
               },
               "state": {
                 "type": "string",
-                "description": "Field state"
+                "description": "Field state",
+                "example": "random_state_string"
               },
               "user_code": {
                 "type": "string",
-                "description": "Field user_code"
+                "description": "Field user_code",
+                "example": "ABCD-EFGH"
               },
               "verification_uri": {
                 "type": "string",
-                "description": "Field verification_uri"
+                "description": "Field verification_uri",
+                "example": "https://chat.qwen.ai/activate"
               },
               "verification_uri_complete": {
                 "type": "string",
-                "description": "Field verification_uri_complete"
+                "description": "Field verification_uri_complete",
+                "example": "https://chat.qwen.ai/activate?user_code=ABCD-EFGH"
               }
             }
           },
@@ -7608,27 +7678,33 @@
             "properties": {
               "access_token": {
                 "type": "string",
-                "description": "Field access_token"
+                "description": "Field access_token",
+                "example": "sk-ant-..."
               },
               "expires_at": {
                 "type": "string",
-                "description": "Field expires_at"
+                "description": "Field expires_at",
+                "example": "2024-01-01T12:00:00Z"
               },
               "provider_type": {
                 "type": "string",
-                "description": "Field provider_type"
+                "description": "Field provider_type",
+                "example": "claude_code"
               },
               "provider_uuid": {
                 "type": "string",
-                "description": "Field provider_uuid"
+                "description": "Field provider_uuid",
+                "example": "550e8400-e29b-41d4-a716-446655440000"
               },
               "refresh_token": {
                 "type": "string",
-                "description": "Field refresh_token"
+                "description": "Field refresh_token",
+                "example": "refresh_..."
               },
               "token_type": {
                 "type": "string",
-                "description": "Field token_type"
+                "description": "Field token_type",
+                "example": "Bearer"
               }
             },
             "required": [
@@ -7663,19 +7739,23 @@
             "properties": {
               "error": {
                 "type": "string",
-                "description": "Field error"
+                "description": "Field error",
+                "example": "Authorization failed"
               },
               "provider_uuid": {
                 "type": "string",
-                "description": "Field provider_uuid"
+                "description": "Field provider_uuid",
+                "example": "550e8400-e29b-41d4-a716-446655440000"
               },
               "session_id": {
                 "type": "string",
-                "description": "Field session_id"
+                "description": "Field session_id",
+                "example": "abc123def456"
               },
               "status": {
                 "type": "string",
-                "description": "Field status"
+                "description": "Field status",
+                "example": "success"
               }
             },
             "required": [
@@ -7703,27 +7783,33 @@
             "properties": {
               "access_token": {
                 "type": "string",
-                "description": "Field access_token"
+                "description": "Field access_token",
+                "example": "sk-ant-..."
               },
               "expires_at": {
                 "type": "string",
-                "description": "Field expires_at"
+                "description": "Field expires_at",
+                "example": "2024-01-01T12:00:00Z"
               },
               "provider": {
                 "type": "string",
-                "description": "Field provider"
+                "description": "Field provider",
+                "example": "anthropic"
               },
               "refresh_token": {
                 "type": "string",
-                "description": "Field refresh_token"
+                "description": "Field refresh_token",
+                "example": "refresh_..."
               },
               "token_type": {
                 "type": "string",
-                "description": "Field token_type"
+                "description": "Field token_type",
+                "example": "Bearer"
               },
               "valid": {
                 "type": "boolean",
-                "description": "Field valid"
+                "description": "Field valid",
+                "example": true
               }
             },
             "required": [
@@ -8116,6 +8202,31 @@
         "required": [
           "name",
           "unified"
+        ]
+      },
+      "ProviderImportInfo": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Field action",
+            "example": "created"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name",
+            "example": "openai"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Field uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "required": [
+          "uuid",
+          "name",
+          "action"
         ]
       },
       "ProviderModelInfo": {
@@ -8706,10 +8817,6 @@
       "Rule": {
         "type": "object",
         "properties": {
-          "CurrentServiceID": {
-            "type": "string",
-            "description": "Field CurrentServiceID"
-          },
           "active": {
             "type": "boolean",
             "description": "Field active"
@@ -8770,7 +8877,6 @@
           "response_model",
           "description",
           "services",
-          "CurrentServiceID",
           "lb_tactic",
           "active",
           "smart_enabled"
@@ -9000,15 +9106,18 @@
             "properties": {
               "flag": {
                 "type": "string",
-                "description": "Field flag"
+                "description": "Field flag",
+                "example": "unified"
               },
               "scenario": {
                 "type": "string",
-                "description": "Field scenario"
+                "description": "Field scenario",
+                "example": "claude_code"
               },
               "value": {
                 "type": "boolean",
-                "description": "Field value"
+                "description": "Field value",
+                "example": true
               }
             },
             "required": [
@@ -9206,9 +9315,6 @@
       "Service": {
         "type": "object",
         "properties": {
-          "Stats": {
-            "$ref": "#/components/schemas/ServiceStats"
-          },
           "active": {
             "type": "boolean",
             "description": "Field active"
@@ -9247,191 +9353,7 @@
           "model",
           "weight",
           "active",
-          "time_window",
-          "Stats"
-        ]
-      },
-      "ServiceStats": {
-        "type": "object",
-        "properties": {
-          "LatencySamples": {
-            "type": "array",
-            "description": "Field LatencySamples",
-            "items": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          "SpeedSamples": {
-            "type": "array",
-            "description": "Field SpeedSamples",
-            "items": {
-              "type": "number",
-              "format": "double"
-            }
-          },
-          "TTFTSamples": {
-            "type": "array",
-            "description": "Field TTFTSamples",
-            "items": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          "avg_latency_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field avg_latency_ms"
-          },
-          "avg_token_speed": {
-            "type": "number",
-            "format": "double",
-            "description": "Field avg_token_speed"
-          },
-          "avg_ttft_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field avg_ttft_ms"
-          },
-          "cache_hit_rate": {
-            "type": "number",
-            "format": "double",
-            "description": "Field cache_hit_rate"
-          },
-          "last_latency_update": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Field last_latency_update"
-          },
-          "last_speed_update": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Field last_speed_update"
-          },
-          "last_ttft_update": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Field last_ttft_update"
-          },
-          "last_used": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Field last_used"
-          },
-          "p50_latency_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field p50_latency_ms"
-          },
-          "p50_ttft_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field p50_ttft_ms"
-          },
-          "p95_latency_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field p95_latency_ms"
-          },
-          "p95_ttft_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field p95_ttft_ms"
-          },
-          "p99_latency_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field p99_latency_ms"
-          },
-          "p99_ttft_ms": {
-            "type": "number",
-            "format": "double",
-            "description": "Field p99_ttft_ms"
-          },
-          "request_count": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field request_count"
-          },
-          "service_id": {
-            "type": "string",
-            "description": "Field service_id"
-          },
-          "time_window": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field time_window"
-          },
-          "window_cache_hits": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_cache_hits"
-          },
-          "window_cache_misses": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_cache_misses"
-          },
-          "window_cost_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_cost_tokens"
-          },
-          "window_input_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_input_tokens"
-          },
-          "window_output_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_output_tokens"
-          },
-          "window_request_count": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_request_count"
-          },
-          "window_start": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Field window_start"
-          },
-          "window_tokens_consumed": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field window_tokens_consumed"
-          }
-        },
-        "required": [
-          "service_id",
-          "request_count",
-          "last_used",
-          "window_start",
-          "window_request_count",
-          "window_tokens_consumed",
-          "window_input_tokens",
-          "window_output_tokens",
-          "time_window",
-          "LatencySamples",
-          "avg_latency_ms",
-          "p50_latency_ms",
-          "p95_latency_ms",
-          "p99_latency_ms",
-          "last_latency_update",
-          "SpeedSamples",
-          "avg_token_speed",
-          "last_speed_update",
-          "TTFTSamples",
-          "avg_ttft_ms",
-          "p50_ttft_ms",
-          "p95_ttft_ms",
-          "p99_ttft_ms",
-          "last_ttft_update",
-          "window_cache_hits",
-          "window_cache_misses",
-          "cache_hit_rate",
-          "window_cost_tokens"
+          "time_window"
         ]
       },
       "Settings": {
@@ -9786,26 +9708,31 @@
               "port": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field port"
+                "description": "Field port",
+                "example": 12580
               },
               "providers_enabled": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field providers_enabled"
+                "description": "Field providers_enabled",
+                "example": 2
               },
               "providers_total": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field providers_total"
+                "description": "Field providers_total",
+                "example": 3
               },
               "request_count": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Field request_count"
+                "description": "Field request_count",
+                "example": 100
               },
               "server_running": {
                 "type": "boolean",
-                "description": "Field server_running"
+                "description": "Field server_running",
+                "example": true
               }
             },
             "required": [
@@ -10038,7 +9965,8 @@
             "properties": {
               "enabled": {
                 "type": "boolean",
-                "description": "Field enabled"
+                "description": "Field enabled",
+                "example": true
               }
             },
             "required": [
@@ -10282,10 +10210,6 @@
       "UpdateRuleRequest": {
         "type": "object",
         "properties": {
-          "CurrentServiceID": {
-            "type": "string",
-            "description": "Field CurrentServiceID"
-          },
           "active": {
             "type": "boolean",
             "description": "Field active"
@@ -10346,7 +10270,6 @@
           "response_model",
           "description",
           "services",
-          "CurrentServiceID",
           "lb_tactic",
           "active",
           "smart_enabled"
@@ -10361,41 +10284,49 @@
             "properties": {
               "active": {
                 "type": "boolean",
-                "description": "Field active"
+                "description": "Field active",
+                "example": true
               },
               "default_model": {
                 "type": "string",
-                "description": "Field default_model"
+                "description": "Field default_model",
+                "example": "gpt-3.5-turbo"
               },
               "description": {
                 "type": "string",
-                "description": "Field description"
+                "description": "Field description",
+                "example": "My rule description"
               },
               "provider": {
                 "type": "string",
-                "description": "Field provider"
+                "description": "Field provider",
+                "example": "openai"
               },
               "request_model": {
                 "type": "string",
-                "description": "Field request_model"
+                "description": "Field request_model",
+                "example": "gpt-3.5-turbo"
               },
               "response_model": {
                 "type": "string",
-                "description": "Field response_model"
+                "description": "Field response_model",
+                "example": "gpt-3.5-turbo"
               },
               "scenario": {
                 "type": "string",
-                "description": "Field scenario"
+                "description": "Field scenario",
+                "example": "openai"
               },
               "smart_enabled": {
                 "type": "boolean",
-                "description": "Field smart_enabled"
+                "description": "Field smart_enabled",
+                "example": false
               },
               "smart_routing": {
                 "type": "array",
                 "description": "Field smart_routing",
                 "items": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SmartRouting"
                 }
               },
               "uuid": {
@@ -10921,36 +10852,24 @@
   },
   "tags": [
     {
-      "name": "logs",
-      "description": "Operations related to logs"
-    },
-    {
       "name": "actions",
       "description": "Operations related to actions"
     },
     {
-      "name": "rules",
-      "description": "Operations related to rules"
-    },
-    {
-      "name": "testing",
-      "description": "Operations related to testing"
-    },
-    {
-      "name": "oauth",
-      "description": "Operations related to oauth"
+      "name": "auth",
+      "description": "Operations related to auth"
     },
     {
       "name": "codex",
       "description": "Operations related to codex"
     },
     {
-      "name": "mcp-transport",
-      "description": "Operations related to mcp-transport"
+      "name": "config",
+      "description": "Operations related to config"
     },
     {
-      "name": "requests",
-      "description": "Operations related to requests"
+      "name": "feishu",
+      "description": "Operations related to feishu"
     },
     {
       "name": "guardrails",
@@ -10961,72 +10880,84 @@
       "description": "Operations related to history"
     },
     {
-      "name": "skills",
-      "description": "Operations related to skills"
-    },
-    {
-      "name": "providers",
-      "description": "Operations related to providers"
-    },
-    {
-      "name": "models",
-      "description": "Operations related to models"
-    },
-    {
-      "name": "feishu",
-      "description": "Operations related to feishu"
-    },
-    {
-      "name": "config",
-      "description": "Operations related to config"
-    },
-    {
-      "name": "server",
-      "description": "Operations related to server"
-    },
-    {
-      "name": "onboarding",
-      "description": "Operations related to onboarding"
-    },
-    {
-      "name": "usage",
-      "description": "Operations related to usage"
+      "name": "imbot-admin",
+      "description": "Operations related to imbot-admin"
     },
     {
       "name": "imbot-settings",
       "description": "Operations related to imbot-settings"
     },
     {
-      "name": "imbot-admin",
-      "description": "Operations related to imbot-admin"
+      "name": "info",
+      "description": "Operations related to info"
     },
     {
-      "name": "weixin",
-      "description": "Operations related to weixin"
+      "name": "logs",
+      "description": "Operations related to logs"
     },
     {
       "name": "mcp",
       "description": "Operations related to mcp"
     },
     {
-      "name": "info",
-      "description": "Operations related to info"
+      "name": "mcp-transport",
+      "description": "Operations related to mcp-transport"
     },
     {
-      "name": "system-logs",
-      "description": "Operations related to system-logs"
+      "name": "models",
+      "description": "Operations related to models"
+    },
+    {
+      "name": "oauth",
+      "description": "Operations related to oauth"
+    },
+    {
+      "name": "onboarding",
+      "description": "Operations related to onboarding"
+    },
+    {
+      "name": "providers",
+      "description": "Operations related to providers"
+    },
+    {
+      "name": "requests",
+      "description": "Operations related to requests"
+    },
+    {
+      "name": "rules",
+      "description": "Operations related to rules"
     },
     {
       "name": "scenarios",
       "description": "Operations related to scenarios"
     },
     {
+      "name": "server",
+      "description": "Operations related to server"
+    },
+    {
+      "name": "skills",
+      "description": "Operations related to skills"
+    },
+    {
+      "name": "system-logs",
+      "description": "Operations related to system-logs"
+    },
+    {
+      "name": "testing",
+      "description": "Operations related to testing"
+    },
+    {
       "name": "token",
       "description": "Operations related to token"
     },
     {
-      "name": "auth",
-      "description": "Operations related to auth"
+      "name": "usage",
+      "description": "Operations related to usage"
+    },
+    {
+      "name": "weixin",
+      "description": "Operations related to weixin"
     }
   ]
 }

--- a/swagger/convert.go
+++ b/swagger/convert.go
@@ -1,131 +1,79 @@
 package swagger
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 )
 
-// getSwaggerTypeWithDetails converts Go type to Swagger schema with additional details
-func (rm *RouteManager) getSwaggerTypeWithDetails(goType reflect.Type, bindingTag, formatTag, enumTag string) Schema {
-	schema := rm.getSwaggerType(goType)
-
-	// Override format if explicitly specified
-	if formatTag != "" {
-		schema.Format = formatTag
-	}
-
-	// Handle enum values
-	if enumTag != "" {
-		enumValues := strings.Split(enumTag, ",")
-		schema.Enum = make([]interface{}, len(enumValues))
-		for i, val := range enumValues {
-			schema.Enum[i] = rm.parseEnumValue(val, goType)
-		}
-	}
-
-	return schema
-}
-
-// parseValidationRules extracts validation constraints from binding tag
-func (rm *RouteManager) parseValidationRules(schema *Schema, bindingTag string, goType reflect.Type) {
+// parseValidationRules extracts validation constraints from a binding tag and
+// applies them to the schema. goType must already be pointer-dereferenced.
+func parseValidationRules(schema *Schema, bindingTag string, goType reflect.Type) {
 	if bindingTag == "" {
 		return
 	}
 
-	rules := strings.Split(bindingTag, ",")
-	for _, rule := range rules {
+	isString := goType.Kind() == reflect.String
+	isSequence := goType.Kind() == reflect.Slice || goType.Kind() == reflect.Array
+
+	setMinimum := func(value string, exclusive bool) {
+		switch {
+		case isString:
+			if v, err := strconv.Atoi(value); err == nil {
+				schema.MinLength = &v
+			}
+		case isSequence:
+			if v, err := strconv.Atoi(value); err == nil {
+				schema.MinItems = &v
+			}
+		default:
+			if v, err := strconv.ParseFloat(value, 64); err == nil {
+				schema.Minimum = &v
+				schema.ExclusiveMinimum = exclusive
+			}
+		}
+	}
+	setMaximum := func(value string, exclusive bool) {
+		switch {
+		case isString:
+			if v, err := strconv.Atoi(value); err == nil {
+				schema.MaxLength = &v
+			}
+		case isSequence:
+			if v, err := strconv.Atoi(value); err == nil {
+				schema.MaxItems = &v
+			}
+		default:
+			if v, err := strconv.ParseFloat(value, 64); err == nil {
+				schema.Maximum = &v
+				schema.ExclusiveMaximum = exclusive
+			}
+		}
+	}
+
+	for _, rule := range strings.Split(bindingTag, ",") {
 		rule = strings.TrimSpace(rule)
 
 		switch {
 		case strings.HasPrefix(rule, "min="):
-			if minVal := rm.parseNumericValue(strings.TrimPrefix(rule, "min="), goType); minVal != nil {
-				if goType.Kind() == reflect.String {
-					if iv, ok := minVal.(*int64); ok {
-						intVal := int(*iv)
-						schema.MinLength = &intVal
-					}
-				} else if fv, ok := minVal.(*float64); ok {
-					schema.Minimum = fv
-				} else if iv, ok := minVal.(*int64); ok {
-					minVal := float64(*iv)
-					schema.Minimum = &minVal
-				}
-			}
+			setMinimum(strings.TrimPrefix(rule, "min="), false)
 		case strings.HasPrefix(rule, "max="):
-			if maxVal := rm.parseNumericValue(strings.TrimPrefix(rule, "max="), goType); maxVal != nil {
-				if goType.Kind() == reflect.String {
-					if iv, ok := maxVal.(*int64); ok {
-						intVal := int(*iv)
-						schema.MaxLength = &intVal
-					}
-				} else if fv, ok := maxVal.(*float64); ok {
-					schema.Maximum = fv
-				} else if iv, ok := maxVal.(*int64); ok {
-					maxVal := float64(*iv)
-					schema.Maximum = &maxVal
-				}
-			}
+			setMaximum(strings.TrimPrefix(rule, "max="), false)
 		case strings.HasPrefix(rule, "len="):
-			if lenVal := rm.parseNumericValue(strings.TrimPrefix(rule, "len="), goType); lenVal != nil {
-				if goType.Kind() == reflect.String || goType.Kind() == reflect.Slice || goType.Kind() == reflect.Array {
-					if iv, ok := lenVal.(*int64); ok {
-						intVal := int(*iv)
-						schema.MinLength = &intVal
-						schema.MaxLength = &intVal
-					}
-				}
-			}
-		case strings.HasPrefix(rule, "gt="):
-			if gtVal := rm.parseNumericValue(strings.TrimPrefix(rule, "gt="), goType); gtVal != nil {
-				if goType.Kind() == reflect.Float32 || goType.Kind() == reflect.Float64 {
-					minVal := float64(*gtVal.(*float64)) + 0.000001
-					schema.Minimum = &minVal
-					schema.ExclusiveMinimum = true
-				} else {
-					minVal := float64(*gtVal.(*int64)) + 1
-					schema.Minimum = &minVal
-					schema.ExclusiveMinimum = true
-				}
-			}
+			value := strings.TrimPrefix(rule, "len=")
+			setMinimum(value, false)
+			setMaximum(value, false)
 		case strings.HasPrefix(rule, "gte="):
-			if gteVal := rm.parseNumericValue(strings.TrimPrefix(rule, "gte="), goType); gteVal != nil {
-				if goType.Kind() == reflect.Float32 || goType.Kind() == reflect.Float64 {
-					minVal := float64(*gteVal.(*float64))
-					schema.Minimum = &minVal
-				} else {
-					minVal := float64(*gteVal.(*int64))
-					schema.Minimum = &minVal
-				}
-			}
-		case strings.HasPrefix(rule, "lt="):
-			if ltVal := rm.parseNumericValue(strings.TrimPrefix(rule, "lt="), goType); ltVal != nil {
-				if goType.Kind() == reflect.Float32 || goType.Kind() == reflect.Float64 {
-					maxVal := float64(*ltVal.(*float64)) - 0.000001
-					schema.Maximum = &maxVal
-					schema.ExclusiveMaximum = true
-				} else {
-					maxVal := float64(*ltVal.(*int64)) - 1
-					schema.Maximum = &maxVal
-					schema.ExclusiveMaximum = true
-				}
-			}
+			setMinimum(strings.TrimPrefix(rule, "gte="), false)
 		case strings.HasPrefix(rule, "lte="):
-			if lteVal := rm.parseNumericValue(strings.TrimPrefix(rule, "lte="), goType); lteVal != nil {
-				if goType.Kind() == reflect.Float32 || goType.Kind() == reflect.Float64 {
-					maxVal := float64(*lteVal.(*float64))
-					schema.Maximum = &maxVal
-				} else {
-					maxVal := float64(*lteVal.(*int64))
-					schema.Maximum = &maxVal
-				}
-			}
+			setMaximum(strings.TrimPrefix(rule, "lte="), false)
+		case strings.HasPrefix(rule, "gt="):
+			setMinimum(strings.TrimPrefix(rule, "gt="), true)
+		case strings.HasPrefix(rule, "lt="):
+			setMaximum(strings.TrimPrefix(rule, "lt="), true)
 		case rule == "email":
 			schema.Format = "email"
-		case rule == "url":
-			schema.Format = "uri"
-		case rule == "uri":
+		case rule == "url", rule == "uri":
 			schema.Format = "uri"
 		case rule == "uuid":
 			schema.Format = "uuid"
@@ -137,54 +85,36 @@ func (rm *RouteManager) parseValidationRules(schema *Schema, bindingTag string, 
 			enumValues := strings.Split(strings.TrimPrefix(rule, "oneof="), " ")
 			schema.Enum = make([]interface{}, len(enumValues))
 			for i, val := range enumValues {
-				schema.Enum[i] = rm.parseEnumValue(val, goType)
+				schema.Enum[i] = parseTaggedValue(val, goType)
 			}
-		case strings.HasPrefix(rule, "alpha"):
-			schema.Pattern = "^[a-zA-Z]+$"
-		case strings.HasPrefix(rule, "alphanum"):
+		case rule == "alphanum":
 			schema.Pattern = "^[a-zA-Z0-9]+$"
-		case strings.HasPrefix(rule, "numeric"):
+		case rule == "alpha":
+			schema.Pattern = "^[a-zA-Z]+$"
+		case rule == "numeric":
 			schema.Pattern = "^[0-9]+$"
-		case strings.HasPrefix(rule, "hexadecimal"):
+		case rule == "hexadecimal":
 			schema.Pattern = "^[0-9a-fA-F]+$"
 		case strings.HasPrefix(rule, "contains="):
-			value := strings.TrimPrefix(rule, "contains=")
-			if goType.Kind() == reflect.String {
-				schema.Pattern = ".*" + value + ".*"
+			if isString {
+				schema.Pattern = ".*" + strings.TrimPrefix(rule, "contains=") + ".*"
 			}
 		case strings.HasPrefix(rule, "startswith="):
-			value := strings.TrimPrefix(rule, "startswith=")
-			if goType.Kind() == reflect.String {
-				schema.Pattern = "^" + value + ".*"
+			if isString {
+				schema.Pattern = "^" + strings.TrimPrefix(rule, "startswith=") + ".*"
 			}
 		case strings.HasPrefix(rule, "endswith="):
-			value := strings.TrimPrefix(rule, "endswith=")
-			if goType.Kind() == reflect.String {
-				schema.Pattern = ".*" + value + "$"
+			if isString {
+				schema.Pattern = ".*" + strings.TrimPrefix(rule, "endswith=") + "$"
 			}
 		}
 	}
 }
 
-// parseNumericValue parses numeric values from string tags
-func (rm *RouteManager) parseNumericValue(value string, goType reflect.Type) interface{} {
-	if goType.Kind() == reflect.Float32 || goType.Kind() == reflect.Float64 {
-		if val, err := strconv.ParseFloat(value, 64); err == nil {
-			return &val
-		}
-	} else {
-		if val, err := strconv.ParseInt(value, 10, 64); err == nil {
-			return &val
-		}
-	}
-	return nil
-}
-
-// parseExampleValue parses example value based on field type
-func (rm *RouteManager) parseExampleValue(value string, goType reflect.Type) interface{} {
-	if goType.Kind() == reflect.Ptr {
-		goType = goType.Elem()
-	}
+// parseTaggedValue parses a tag-provided literal (example, default, enum
+// entry) into a value matching the field type.
+func parseTaggedValue(value string, goType reflect.Type) interface{} {
+	goType = derefType(goType)
 
 	switch goType.Kind() {
 	case reflect.String:
@@ -219,135 +149,30 @@ func (rm *RouteManager) parseExampleValue(value string, goType reflect.Type) int
 	}
 }
 
-// parseDefaultValue parses default value based on field type
-func (rm *RouteManager) parseDefaultValue(value string, goType reflect.Type) interface{} {
-	return rm.parseExampleValue(value, goType)
-}
+// queryParamType maps a Go type to the (type, format) pair used for query
+// parameters. Query parameters are always primitive-ish; struct and map types
+// degrade to "object" as before.
+func queryParamType(goType reflect.Type) (string, string) {
+	goType = derefType(goType)
 
-// parseEnumValue parses enum value based on field type
-func (rm *RouteManager) parseEnumValue(value string, goType reflect.Type) interface{} {
-	return rm.parseExampleValue(value, goType)
-}
-
-// getSwaggerType converts Go type to Swagger schema
-func (rm *RouteManager) getSwaggerType(goType reflect.Type) Schema {
 	switch goType.Kind() {
 	case reflect.String:
-		return Schema{Type: "string"}
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return Schema{Type: "integer", Format: "int64"}
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return Schema{Type: "integer", Format: "int64"}
+		return "string", ""
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "integer", "int64"
 	case reflect.Float32, reflect.Float64:
-		return Schema{Type: "number", Format: "double"}
+		return "number", "double"
 	case reflect.Bool:
-		return Schema{Type: "boolean"}
+		return "boolean", ""
 	case reflect.Slice, reflect.Array:
-		elemType := goType.Elem()
-		if elemType.Kind() == reflect.Ptr {
-			elemType = elemType.Elem()
-		}
-		// Get the proper schema for the element type
-		// This handles type aliases correctly (e.g., IDESource which is "type IDESource string")
-		elemSchema := rm.getSwaggerType(elemType)
-		return Schema{
-			Type:  "array",
-			Items: &elemSchema,
-		}
-	case reflect.Map:
-		// Get key and value types
-		valueType := goType.Elem()
-
-		if valueType.Kind() == reflect.Ptr {
-			valueType = valueType.Elem()
-		}
-
-		// Generate schema for map with additionalProperties
-		schema := Schema{Type: "object"}
-
-		// Set value type in additionalProperties
-		if valueType.Kind() == reflect.Struct && valueType.String() != "time.Time" {
-			// For struct values, use reference
-			schema.AdditionalProperties = &Schema{
-				Ref: fmt.Sprintf("#/definitions/%s", valueType.Name()),
-			}
-		} else {
-			// For primitive types, get the swagger type
-			valueSchema := rm.getSwaggerType(valueType)
-			schema.AdditionalProperties = &valueSchema
-		}
-
-		return schema
+		return "array", ""
 	case reflect.Struct:
-		// Handle time.Time specially
-		if goType.String() == "time.Time" {
-			return Schema{Type: "string", Format: "date-time"}
+		if goType == timeType {
+			return "string", "date-time"
 		}
-		// For nested structs, check if it's a known model type
-		// If it's a primitive wrapper or basic type, return object
-		// Otherwise, we'll handle it in generateSchemaFromModel
-		return Schema{Type: "object"}
-	case reflect.Ptr:
-		return rm.getSwaggerType(goType.Elem())
-	case reflect.Interface:
-		return Schema{Type: "object"}
+		return "object", ""
 	default:
-		return Schema{Type: "object"}
-	}
-}
-
-// getSwaggerTypeVersion converts Go type to Swagger schema with version-specific refs
-func (rm *RouteManager) getSwaggerTypeVersion(goType reflect.Type, version Version) Schema {
-	switch goType.Kind() {
-	case reflect.String:
-		return Schema{Type: "string"}
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return Schema{Type: "integer", Format: "int64"}
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return Schema{Type: "integer", Format: "int64"}
-	case reflect.Float32, reflect.Float64:
-		return Schema{Type: "number", Format: "double"}
-	case reflect.Bool:
-		return Schema{Type: "boolean"}
-	case reflect.Slice, reflect.Array:
-		elemType := goType.Elem()
-		if elemType.Kind() == reflect.Ptr {
-			elemType = elemType.Elem()
-		}
-		elemSchema := rm.getSwaggerTypeVersion(elemType, version)
-		return Schema{
-			Type:  "array",
-			Items: &elemSchema,
-		}
-	case reflect.Map:
-		valueType := goType.Elem()
-		if valueType.Kind() == reflect.Ptr {
-			valueType = valueType.Elem()
-		}
-
-		schema := Schema{Type: "object"}
-		refPrefix := getRefPrefix(version)
-
-		if valueType.Kind() == reflect.Struct && valueType.String() != "time.Time" {
-			schema.AdditionalProperties = &Schema{
-				Ref: refPrefix + valueType.Name(),
-			}
-		} else {
-			valueSchema := rm.getSwaggerTypeVersion(valueType, version)
-			schema.AdditionalProperties = &valueSchema
-		}
-
-		return schema
-	case reflect.Struct:
-		if goType.String() == "time.Time" {
-			return Schema{Type: "string", Format: "date-time"}
-		}
-		return Schema{Type: "object"}
-	case reflect.Ptr:
-		return rm.getSwaggerTypeVersion(goType.Elem(), version)
-	case reflect.Interface:
-		return Schema{Type: "object"}
-	default:
-		return Schema{Type: "object"}
+		return "object", ""
 	}
 }

--- a/swagger/model.go
+++ b/swagger/model.go
@@ -5,96 +5,6 @@ import (
 	"strings"
 )
 
-// collectNestedModels recursively collects all nested struct models
-func (rm *RouteManager) collectNestedModels(model interface{}, allModels map[string]interface{}, processedModels map[string]bool) {
-	modelType := reflect.TypeOf(model)
-
-	// Handle pointer types
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	// Only process struct types (except time.Time)
-	if modelType.Kind() != reflect.Struct || modelType.String() == "time.Time" {
-		return
-	}
-
-	modelName := modelType.Name()
-
-	// Skip anonymous structs (they don't have name)
-	if modelName == "" {
-		return
-	}
-
-	// If already processed, skip
-	if processed, exists := processedModels[modelName]; exists && processed {
-		return
-	}
-
-	// Mark as being processed to avoid infinite recursion
-	processedModels[modelName] = true
-
-	// Add to allModels if not already there
-	if _, exists := allModels[modelName]; !exists {
-		allModels[modelName] = reflect.Zero(modelType).Interface()
-	}
-
-	// Recursively process all fields
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
-
-		// Skip non-exported fields
-		if field.PkgPath != "" {
-			continue
-		}
-
-		// Process field type
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-
-		// If field is a struct, recursively collect its nested models
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			nestedModel := reflect.Zero(fieldType).Interface()
-			rm.collectNestedModels(nestedModel, allModels, processedModels)
-		}
-
-		// If field is a slice/array of structs, process the element type
-		if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			elemType := field.Type.Elem()
-			if elemType.Kind() == reflect.Ptr {
-				elemType = elemType.Elem()
-			}
-			if elemType.Kind() == reflect.Struct && elemType.String() != "time.Time" {
-				nestedModel := reflect.Zero(elemType).Interface()
-				rm.collectNestedModels(nestedModel, allModels, processedModels)
-			}
-		}
-
-		// If field is a map with struct values, process the value type
-		if field.Type.Kind() == reflect.Map {
-			valueType := field.Type.Elem()
-			if valueType.Kind() == reflect.Ptr {
-				valueType = valueType.Elem()
-			}
-			if valueType.Kind() == reflect.Struct && valueType.String() != "time.Time" {
-				nestedModel := reflect.Zero(valueType).Interface()
-				rm.collectNestedModels(nestedModel, allModels, processedModels)
-			}
-		}
-	}
-}
-
-// getModelName extracts the model name from the struct type
-func getModelName(model interface{}) string {
-	t := reflect.TypeOf(model)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	return t.Name()
-}
-
 // getModelNameWithFallback extracts model name with fallback to auto-generation for anonymous structs
 // Priority: explicitName > struct name > auto-generated from route
 func (rm *RouteManager) getModelNameWithFallback(model interface{}, explicitName, method, path, modelType string) string {
@@ -104,75 +14,54 @@ func (rm *RouteManager) getModelNameWithFallback(model interface{}, explicitName
 	}
 
 	// 2. Try struct name
-	t := reflect.TypeOf(model)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	if name := t.Name(); name != "" {
+	if name := derefType(reflect.TypeOf(model)).Name(); name != "" {
 		return name
 	}
 
 	// 3. Auto-generate from route
-	return rm.generateAutoModelName(method, path, modelType)
+	return generateAutoModelName(method, path, modelType)
 }
 
 // generateAutoModelName generates a model name from method, path, and model type
 // Example: POST /api/v1/users -> PostApiV1UsersRequest or PostApiV1UsersResponse
-func (rm *RouteManager) generateAutoModelName(method, path, modelType string) string {
-	// Clean path and convert to PascalCase
-	// /api/v1/users/:id -> ApiV1UsersId
-	parts := strings.Split(path, "/")
+func generateAutoModelName(method, path, modelType string) string {
+	// Clean path and convert to PascalCase: /api/v1/users/:id -> ApiV1UsersId
 	var nameParts []string
-	for _, part := range parts {
+	for _, part := range strings.Split(path, "/") {
+		part = strings.TrimPrefix(part, ":")
 		if part == "" {
 			continue
 		}
-		// Convert :param to Param
-		if strings.HasPrefix(part, ":") {
-			part = strings.TrimPrefix(part, ":")
-		}
-		// Convert to PascalCase (first letter uppercase)
-		if len(part) > 0 {
-			nameParts = append(nameParts, strings.ToUpper(part[:1])+part[1:])
-		}
+		nameParts = append(nameParts, strings.ToUpper(part[:1])+part[1:])
 	}
 
 	// Combine: Method + PathParts + ModelType
 	// e.g., Post + ApiV1Users + Request -> PostApiV1UsersRequest
 	methodName := strings.ToUpper(method[:1]) + strings.ToLower(method[1:])
-	pathName := strings.Join(nameParts, "")
 
-	return methodName + pathName + modelType
+	return methodName + strings.Join(nameParts, "") + modelType
 }
 
 // generateOperationID generates an operation ID from method and swagger path
 // Example: GET /api/v1/auth/validate -> apiV1AuthValidateGet
-func (rm *RouteManager) generateOperationID(method, swaggerPath string) string {
-	// Convert path to camelCase
-	// /api/v1/auth/validate -> apiV1AuthValidate
-	parts := strings.Split(swaggerPath, "/")
+func generateOperationID(method, swaggerPath string) string {
+	// Convert path to camelCase: /api/v1/auth/validate -> apiV1AuthValidate
 	var nameParts []string
-	for i, part := range parts {
+	for _, part := range strings.Split(swaggerPath, "/") {
+		// Remove braces from path params: {id} -> Id
+		part = strings.Trim(part, "{}")
 		if part == "" {
 			continue
 		}
-		// Remove braces from path params: {id} -> Id
-		part = strings.Trim(part, "{}")
-		if len(part) == 0 {
-			continue
-		}
 		// First part lowercase, rest PascalCase
-		if i == 1 { // First non-empty part after leading /
+		if len(nameParts) == 0 {
 			nameParts = append(nameParts, strings.ToLower(part[:1])+part[1:])
 		} else {
 			nameParts = append(nameParts, strings.ToUpper(part[:1])+part[1:])
 		}
 	}
 
-	// Combine: pathName + Method (lowercase)
-	// e.g., apiV1AuthValidate + get -> apiV1AuthValidateGet
-	pathName := strings.Join(nameParts, "")
+	// Combine: pathName + Method: apiV1AuthValidate + get -> apiV1AuthValidateGet
 	methodLower := strings.ToLower(method)
-
-	return pathName + strings.ToUpper(methodLower[:1]) + methodLower[1:]
+	return strings.Join(nameParts, "") + strings.ToUpper(methodLower[:1]) + methodLower[1:]
 }

--- a/swagger/openapi_20260608_test.go
+++ b/swagger/openapi_20260608_test.go
@@ -269,11 +269,8 @@ func TestRefSchemaHandling(t *testing.T) {
 		Nested *NestedModel `json:"nested"`
 	}
 
-	rm := &RouteManager{}
-	version := VersionV3
-
 	// Generate schema for the model
-	schema := rm.generateSchemaWithReferencesVersion(TestModel{}, version)
+	schema := newSchemaGen(VersionV3).modelSchema(TestModel{})
 
 	// Check that the nested property uses $ref
 	nestedSchema, exists := schema.Properties["nested"]
@@ -329,11 +326,9 @@ func TestMarshalSchemaWithRef(t *testing.T) {
 
 // TestBooleanTypeMapping tests that bool types are mapped to boolean
 func TestBooleanTypeMapping(t *testing.T) {
-	rm := &RouteManager{}
-
 	// Test direct bool type
 	boolType := reflect.TypeOf(false)
-	schema := rm.getSwaggerType(boolType)
+	schema := newSchemaGen(VersionV3).typeSchema(boolType)
 
 	if schema.Type != "boolean" {
 		t.Errorf("Expected type 'boolean' for bool, got '%s'", schema.Type)
@@ -353,10 +348,7 @@ func TestGenerateSchemaWithRefNoSiblings(t *testing.T) {
 		Active  bool     `json:"active" description:"Is user active"`
 	}
 
-	rm := &RouteManager{}
-	version := VersionV3
-
-	schema := rm.generateSchemaWithReferencesVersion(User{}, version)
+	schema := newSchemaGen(VersionV3).modelSchema(User{})
 
 	// Check address property (should be $ref)
 	addrSchema, exists := schema.Properties["address"]

--- a/swagger/openapi_v3.go
+++ b/swagger/openapi_v3.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -31,12 +30,11 @@ func (rm *RouteManager) buildV3Spec() (string, error) {
 		},
 		Servers:    rm.buildV3Servers(),
 		Paths:      make(map[string]PathItemV3),
-		Components: rm.buildV3Components(),
-		Tags:       []Tag{},
+		Components: buildV3Components(),
 	}
 
 	// Add contact info if available
-	if rm.swaggerInfo.Contact.Name != "" || rm.swaggerInfo.Contact.Email != "" || rm.swaggerInfo.Contact.URL != "" {
+	if rm.swaggerInfo.Contact != (SwaggerContact{}) {
 		openapi.Info.Contact = &OpenAPIContactObject{
 			Name:  rm.swaggerInfo.Contact.Name,
 			Email: rm.swaggerInfo.Contact.Email,
@@ -45,7 +43,7 @@ func (rm *RouteManager) buildV3Spec() (string, error) {
 	}
 
 	// Add license info if available
-	if rm.swaggerInfo.License.Name != "" || rm.swaggerInfo.License.URL != "" {
+	if rm.swaggerInfo.License != (SwaggerLicense{}) {
 		openapi.Info.License = &OpenAPILicenseObject{
 			Name: rm.swaggerInfo.License.Name,
 			URL:  rm.swaggerInfo.License.URL,
@@ -59,81 +57,50 @@ func (rm *RouteManager) buildV3Spec() (string, error) {
 	for _, group := range rm.groups {
 		for _, route := range group.routes {
 			fullPath := group.prefix + route.Path
-			openapiPath := rm.convertPathFormat(fullPath)
-			method := strings.ToLower(route.Method)
+			openapiPath := convertPathFormat(fullPath)
 
-			// Create path item if not exists
-			if _, exists := openapi.Paths[openapiPath]; !exists {
-				openapi.Paths[openapiPath] = PathItemV3{}
+			operation := rm.buildV3Operation(group, route, fullPath, modelSet)
+			for _, tag := range operation.Tags {
+				tagSet[tag] = true
 			}
 
-			// Build operation
-			operation := rm.buildV3Operation(route, fullPath, modelSet)
-
-			// Add tags
-			if len(operation.Tags) > 0 {
-				for _, tag := range operation.Tags {
-					tagSet[tag] = true
-				}
-			}
-
-			// Add operation to path item
 			pathItem := openapi.Paths[openapiPath]
-			switch method {
-			case "get":
-				pathItem.Get = operation
-			case "post":
-				pathItem.Post = operation
-			case "put":
-				pathItem.Put = operation
-			case "delete":
-				pathItem.Delete = operation
-			case "patch":
-				pathItem.Patch = operation
-			case "options":
-				pathItem.Options = operation
-			case "head":
-				pathItem.Head = operation
-			}
+			setV3Operation(&pathItem, route.Method, operation)
 			openapi.Paths[openapiPath] = pathItem
 		}
 	}
 
-	// Generate tags
-	for tagName := range tagSet {
-		openapi.Tags = append(openapi.Tags, Tag{
-			Name:        tagName,
-			Description: fmt.Sprintf("Operations related to %s", tagName),
-		})
-	}
+	openapi.Tags = sortedTags(tagSet)
 
-	// Generate all model schemas with proper handling of nested models
-	processedModels := make(map[string]bool)
-	allModels := make(map[string]interface{})
+	// Generate schemas for registered models and all nested models
+	openapi.Components.Schemas = newSchemaGen(VersionV3).buildDefinitions(modelSet)
 
-	// First, collect all initial models
-	for modelName, model := range modelSet {
-		allModels[modelName] = model
-		processedModels[modelName] = false
-	}
-
-	// Then recursively collect all nested models
-	for _, model := range modelSet {
-		rm.collectNestedModels(model, allModels, processedModels)
-	}
-
-	// Finally, generate schemas for all collected models
-	for modelName, model := range allModels {
-		openapi.Components.Schemas[modelName] = rm.generateSchemaFromModelWithCacheVersion(model, allModels, VersionV3)
-	}
-
-	// Convert to JSON
 	jsonData, err := json.MarshalIndent(openapi, "", "  ")
 	if err != nil {
 		return "", err
 	}
 
 	return string(jsonData), nil
+}
+
+// setV3Operation assigns an operation to the method slot of a path item
+func setV3Operation(pathItem *PathItemV3, method string, operation *OperationV3) {
+	switch strings.ToLower(method) {
+	case "get":
+		pathItem.Get = operation
+	case "post":
+		pathItem.Post = operation
+	case "put":
+		pathItem.Put = operation
+	case "delete":
+		pathItem.Delete = operation
+	case "patch":
+		pathItem.Patch = operation
+	case "options":
+		pathItem.Options = operation
+	case "head":
+		pathItem.Head = operation
+	}
 }
 
 // buildV3Servers builds server list from swagger info
@@ -148,9 +115,8 @@ func (rm *RouteManager) buildV3Servers() []Server {
 			scheme = rm.swaggerInfo.Schemes[0]
 		}
 
-		url := fmt.Sprintf("%s://%s%s", scheme, rm.swaggerInfo.Host, rm.swaggerInfo.BasePath)
 		servers = append(servers, Server{
-			URL: url,
+			URL: fmt.Sprintf("%s://%s%s", scheme, rm.swaggerInfo.Host, rm.swaggerInfo.BasePath),
 		})
 	}
 
@@ -158,27 +124,23 @@ func (rm *RouteManager) buildV3Servers() []Server {
 }
 
 // buildV3Components builds the components object
-func (rm *RouteManager) buildV3Components() Components {
-	components := Components{
-		Schemas:         make(map[string]Schema),
-		SecuritySchemes: make(map[string]SecuritySchemeV3),
+func buildV3Components() Components {
+	return Components{
+		SecuritySchemes: map[string]SecuritySchemeV3{
+			"ApiKeyAuth": {
+				Type:        "apiKey",
+				Name:        "Authorization",
+				In:          "header",
+				Description: "API key authorization header",
+			},
+		},
 	}
-
-	// Add security schemes
-	components.SecuritySchemes["ApiKeyAuth"] = SecuritySchemeV3{
-		Type:        "apiKey",
-		Name:        "Authorization",
-		In:          "header",
-		Description: "API key authorization header",
-	}
-
-	return components
 }
 
 // buildV3Operation builds an OpenAPI 3.0 operation from route config
-func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, modelSet map[string]interface{}) *OperationV3 {
+func (rm *RouteManager) buildV3Operation(group *RouteGroup, route RouteConfig, fullPath string, modelSet map[string]interface{}) *OperationV3 {
 	operation := &OperationV3{
-		OperationID: rm.generateOperationID(route.Method, rm.convertPathFormat(fullPath)),
+		OperationID: generateOperationID(route.Method, convertPathFormat(fullPath)),
 		Summary:     route.Description,
 		Description: route.Description,
 		Responses:   make(map[string]ResponseV3),
@@ -186,9 +148,9 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 		Parameters:  []ParameterV3{},
 	}
 
-	// Set tags (fallback to group name if not specified)
-	if len(operation.Tags) == 0 && len(route.Tags) == 0 {
-		// Tags will be set by the caller from the group
+	// Fallback to group name when the route has no tags
+	if len(operation.Tags) == 0 {
+		operation.Tags = []string{group.name}
 	}
 
 	// Handle deprecated
@@ -206,38 +168,19 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 		}
 	}
 
-	// Handle path parameters
-	var pathParams []ParameterV3
-	if len(route.PathParams) > 0 {
-		for _, pathParam := range route.PathParams {
-			pathParams = append(pathParams, ParameterV3{
-				Name:        pathParam.Name,
-				In:          "path",
-				Description: pathParam.Description,
-				Required:    true,
-				Schema: &Schema{
-					Type:   pathParam.Type,
-					Format: pathParam.Format,
-				},
-			})
-		}
-	} else {
-		// Auto-detect path params
-		v2PathParams := rm.extractPathParams(route.Path)
-		for _, p := range v2PathParams {
-			pathParams = append(pathParams, ParameterV3{
-				Name:        p.Name,
-				In:          "path",
-				Description: p.Description,
-				Required:    true,
-				Schema: &Schema{
-					Type:   p.Type,
-					Format: p.Format,
-				},
-			})
-		}
+	// Path parameters first so they appear before query params
+	for _, p := range resolvePathParams(route) {
+		operation.Parameters = append(operation.Parameters, ParameterV3{
+			Name:        p.Name,
+			In:          "path",
+			Description: p.Description,
+			Required:    true,
+			Schema: &Schema{
+				Type:   p.Type,
+				Format: p.Format,
+			},
+		})
 	}
-	operation.Parameters = append(operation.Parameters, pathParams...)
 
 	// Handle query parameters from QueryParams
 	for _, param := range route.QueryParams {
@@ -247,11 +190,9 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 			Description: param.Description,
 			Required:    param.Required,
 			Schema: &Schema{
-				Type: normalizeSchemaType(param.Type),
+				Type:    normalizeSchemaType(param.Type),
+				Default: param.Default,
 			},
-		}
-		if param.Default != nil {
-			v3Param.Schema.Default = param.Default
 		}
 		if param.Minimum != nil {
 			minVal := float64(*param.Minimum)
@@ -271,8 +212,9 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 	if route.QueryModel != nil {
 		modelName := rm.getModelNameWithFallback(route.QueryModel, route.QueryModelName, route.Method, fullPath, "Query")
 		modelSet[modelName] = route.QueryModel
-		queryParams := rm.generateQueryParametersV3(route.QueryModel)
-		operation.Parameters = append(operation.Parameters, queryParams...)
+		for _, qp := range modelQueryParams(route.QueryModel) {
+			operation.Parameters = append(operation.Parameters, qp.toV3())
+		}
 	}
 
 	// Handle request model
@@ -281,11 +223,11 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 		modelSet[modelName] = route.RequestModel
 
 		if route.Method == http.MethodGet {
-			// For GET requests, add query parameters
-			queryParams := rm.generateQueryParametersV3(route.RequestModel)
-			operation.Parameters = append(operation.Parameters, queryParams...)
+			// For GET requests, document the model as query parameters
+			for _, qp := range modelQueryParams(route.RequestModel) {
+				operation.Parameters = append(operation.Parameters, qp.toV3())
+			}
 		} else {
-			// For POST/PUT/DELETE requests, add request body
 			operation.RequestBody = &RequestBody{
 				Description: "Request body",
 				Required:    true,
@@ -300,7 +242,7 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 		}
 	}
 
-	// Handle response models
+	// Handle response model
 	if route.ResponseModel != nil {
 		modelName := rm.getModelNameWithFallback(route.ResponseModel, route.ResponseModelName, route.Method, fullPath, "Response")
 		modelSet[modelName] = route.ResponseModel
@@ -319,9 +261,7 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 			Description: "Successful response",
 			Content: map[string]MediaType{
 				"application/json": {
-					Schema: &Schema{
-						Type: "object",
-					},
+					Schema: &Schema{Type: "object"},
 				},
 			},
 		}
@@ -329,18 +269,14 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 
 	// Handle error responses
 	for _, errorResp := range route.ErrorResponses {
-		statusCode := fmt.Sprintf("%d", errorResp.Code)
 		response := ResponseV3{
 			Description: errorResp.Message,
 			Content: map[string]MediaType{
 				"application/json": {
-					Schema: &Schema{
-						Type: "object",
-					},
+					Schema: &Schema{Type: "object"},
 				},
 			},
 		}
-
 		if errorResp.Model != nil {
 			modelName := rm.getModelNameWithFallback(errorResp.Model, "", route.Method, fullPath, fmt.Sprintf("Error%d", errorResp.Code))
 			modelSet[modelName] = errorResp.Model
@@ -350,66 +286,10 @@ func (rm *RouteManager) buildV3Operation(route RouteConfig, fullPath string, mod
 				},
 			}
 		}
-
-		operation.Responses[statusCode] = response
+		operation.Responses[fmt.Sprintf("%d", errorResp.Code)] = response
 	}
 
 	return operation
-}
-
-// generateQueryParametersV3 generates v3 query parameters from a model
-func (rm *RouteManager) generateQueryParametersV3(model interface{}) []ParameterV3 {
-	var parameters []ParameterV3
-	modelType := reflect.TypeOf(model)
-
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	if modelType.Kind() != reflect.Struct {
-		return parameters
-	}
-
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
-		fieldName := field.Name
-		jsonTag := field.Tag.Get("json")
-		formTag := field.Tag.Get("form")
-
-		// Determine the parameter name
-		paramName := fieldName
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				paramName = parts[0]
-			}
-		} else if formTag != "" && formTag != "-" {
-			parts := strings.Split(formTag, ",")
-			if parts[0] != "" {
-				paramName = parts[0]
-			}
-		}
-
-		// Check if field is required
-		bindingTag := field.Tag.Get("binding")
-		required := strings.Contains(bindingTag, "required")
-
-		// Determine parameter type
-		paramType := rm.getSwaggerType(field.Type)
-
-		parameters = append(parameters, ParameterV3{
-			Name:        paramName,
-			In:          "query",
-			Description: fmt.Sprintf("Query parameter %s", paramName),
-			Required:    required,
-			Schema: &Schema{
-				Type:   paramType.Type,
-				Format: paramType.Format,
-			},
-		})
-	}
-
-	return parameters
 }
 
 // SetupOpenAPIEndpoints configures both Swagger v2 and OpenAPI v3 documentation endpoints

--- a/swagger/router.go
+++ b/swagger/router.go
@@ -141,9 +141,7 @@ func (rm *RouteManager) NewGroup(name, version, prefix string, opts ...RouteGrou
 // AddMiddleware adds middleware to the route group
 func (rg *RouteGroup) AddMiddleware(middleware ...gin.HandlerFunc) {
 	rg.middleware = append(rg.middleware, middleware...)
-	for _, mw := range rg.middleware {
-		rg.Router.Use(mw)
-	}
+	rg.Router.Use(middleware...)
 }
 
 // RegisterRoute registers a single route
@@ -162,13 +160,9 @@ func (rg *RouteGroup) RegisterRoute(config RouteConfig) {
 		middleware = append(middleware, rg.authMiddleware())
 	}
 
-	// Add route-specific middleware
+	// Add route-specific middleware, then the handler itself
 	middleware = append(middleware, config.Middleware...)
-
-	// Register route with gin and add the handler
-	middleware = append(middleware, func(c *gin.Context) {
-		config.Handler(c)
-	})
+	middleware = append(middleware, gin.HandlerFunc(config.Handler))
 
 	rg.Router.Handle(config.Method, config.Path, middleware...)
 
@@ -431,137 +425,4 @@ func (rm *RouteManager) GetRouteGroups() []*RouteGroup {
 
 func (rm *RouteManager) GetEngine() *gin.Engine {
 	return rm.engine
-}
-
-// GenerateSwaggerAnnotations generates swagger annotations for all routes
-func (rm *RouteManager) GenerateSwaggerAnnotations() string {
-	var annotations strings.Builder
-
-	// Add main swagger annotation
-	annotations.WriteString(`// @title ` + rm.swaggerInfo.Title + "\n")
-	annotations.WriteString(`// @version ` + rm.swaggerInfo.Version + "\n")
-	annotations.WriteString(`// @description ` + rm.swaggerInfo.Description + "\n")
-
-	if rm.swaggerInfo.Host != "" {
-		annotations.WriteString(`// @host ` + rm.swaggerInfo.Host + "\n")
-	}
-
-	if rm.swaggerInfo.BasePath != "" {
-		annotations.WriteString(`// @BasePath ` + rm.swaggerInfo.BasePath + "\n")
-	}
-
-	annotations.WriteString("\n")
-
-	// Add contact and license if available
-	if rm.swaggerInfo.Contact.Name != "" {
-		annotations.WriteString(`// @contact.name ` + rm.swaggerInfo.Contact.Name + "\n")
-		if rm.swaggerInfo.Contact.Email != "" {
-			annotations.WriteString(`// @contact.email ` + rm.swaggerInfo.Contact.Email + "\n")
-		}
-		if rm.swaggerInfo.Contact.URL != "" {
-			annotations.WriteString(`// @contact.url ` + rm.swaggerInfo.Contact.URL + "\n")
-		}
-	}
-
-	if rm.swaggerInfo.License.Name != "" {
-		annotations.WriteString(`// @license.name ` + rm.swaggerInfo.License.Name + "\n")
-		if rm.swaggerInfo.License.URL != "" {
-			annotations.WriteString(`// @license.url ` + rm.swaggerInfo.License.URL + "\n")
-		}
-	}
-
-	annotations.WriteString("\n")
-
-	// Generate annotations for each route
-	for _, group := range rm.groups {
-		for _, route := range group.routes {
-			annotations.WriteString(rm.generateRouteAnnotations(group, route))
-			annotations.WriteString("\n")
-		}
-	}
-
-	return annotations.String()
-}
-
-// generateRouteAnnotations generates swagger annotations for a specific route
-func (rm *RouteManager) generateRouteAnnotations(group *RouteGroup, route RouteConfig) string {
-	var annotations strings.Builder
-
-	// Add basic route information
-	annotations.WriteString("// @Summary " + route.Description + "\n")
-	annotations.WriteString("// @Description " + route.Description + "\n")
-
-	// Add tags
-	if len(route.Tags) > 0 {
-		for _, tag := range route.Tags {
-			annotations.WriteString("// @Tags " + tag + "\n")
-		}
-	} else {
-		annotations.WriteString("// @Tags " + group.name + "\n")
-	}
-
-	// Add HTTP method and path
-	fullPath := group.prefix + route.Path
-	swaggerPath := rm.convertPathFormat(fullPath)
-	methodLower := strings.ToLower(route.Method)
-	annotations.WriteString("// @Router " + swaggerPath + "[" + methodLower + "]\n")
-
-	// Add query parameters from QueryParams
-	for _, param := range route.QueryParams {
-		required := "false"
-		if param.Required {
-			required = "true"
-		}
-		annotations.WriteString("// @Param " + param.Name + " query " + param.Type + " " + required + " \"" + param.Description + "\"\n")
-	}
-
-	// Add query model if specified
-	if route.QueryModel != nil {
-		modelName := rm.getModelNameWithFallback(route.QueryModel, route.QueryModelName, route.Method, fullPath, "Query")
-		annotations.WriteString("// @Param " + modelName + " query " + modelName + " true \"Query parameters\"\n")
-	}
-
-	// Add request model if specified
-	if route.RequestModel != nil {
-		modelName := rm.getModelNameWithFallback(route.RequestModel, route.RequestModelName, route.Method, fullPath, "Request")
-		if route.Method == http.MethodGet {
-			annotations.WriteString("// @Param " + modelName + " query " + modelName + " true \"Request parameters\"\n")
-		} else {
-			annotations.WriteString("// @Param request body " + modelName + " true \"Request body\"\n")
-		}
-	}
-
-	// Add response model if specified
-	if route.ResponseModel != nil {
-		modelName := rm.getModelNameWithFallback(route.ResponseModel, route.ResponseModelName, route.Method, fullPath, "Response")
-		annotations.WriteString("// @Success 200 {object} " + modelName + "\n")
-	} else {
-		annotations.WriteString("// @Success 200 {object} map[string]interface{}\n")
-	}
-
-	// Add error responses
-	for _, errorResp := range route.ErrorResponses {
-		if errorResp.Model != nil {
-			modelName := rm.getModelNameWithFallback(errorResp.Model, "", route.Method, fullPath, fmt.Sprintf("Error%d", errorResp.Code))
-			annotations.WriteString("// @Failure " + string(rune(errorResp.Code)) + " {object} " + modelName + "\n")
-		} else {
-			annotations.WriteString("// @Failure " + string(rune(errorResp.Code)) + " {object} map[string]interface{}\n")
-		}
-	}
-
-	// Add security if auth required
-	if route.AuthRequired {
-		annotations.WriteString("// @Security ApiKeyAuth\n")
-	}
-
-	// Add deprecated if specified
-	if route.Deprecated {
-		if route.DeprecatedMsg != "" {
-			annotations.WriteString("// @Deprecated " + route.DeprecatedMsg + "\n")
-		} else {
-			annotations.WriteString("// @Deprecated\n")
-		}
-	}
-
-	return annotations.String()
 }

--- a/swagger/schema.go
+++ b/swagger/schema.go
@@ -1,418 +1,17 @@
 package swagger
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 )
 
-// generateSchemaFromModel generates Swagger schema from a Go struct
-func (rm *RouteManager) generateSchemaFromModel(model interface{}) Schema {
-	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	// Check if this is a primitive type
-	if modelType.Kind() != reflect.Struct {
-		return rm.getSwaggerType(modelType)
-	}
-
-	// For struct, generate schema with references to nested models
-	return rm.generateSchemaWithReferences(model)
-}
-
-// generateSchemaWithReferences generates schema using $ref for known nested models
-func (rm *RouteManager) generateSchemaWithReferences(model interface{}) Schema {
-	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	schema := Schema{
-		Type:       "object",
-		Properties: make(map[string]Schema),
-		Required:   []string{},
-	}
-
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
-		fieldName := field.Name
-
-		// Get all relevant tags
-		jsonTag := field.Tag.Get("json")
-		bindingTag := field.Tag.Get("binding")
-		exampleTag := field.Tag.Get("example")
-		defaultTag := field.Tag.Get("default")
-		docTag := field.Tag.Get("doc")
-		descriptionTag := field.Tag.Get("description")
-		formatTag := field.Tag.Get("format")
-		enumTag := field.Tag.Get("enum")
-
-		// Skip non-exported fields
-		if field.PkgPath != "" {
-			continue
-		}
-
-		// Determine the property name and json options
-		propName := fieldName
-		isOptional := false
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				propName = parts[0]
-			}
-			// Check for omitempty and other options
-			for _, part := range parts[1:] {
-				switch part {
-				case "omitempty":
-					isOptional = true
-				case "stringize":
-					// Handle string conversion
-				case "omitempty,stringize":
-					isOptional = true
-				}
-			}
-		}
-
-		// Generate property schema with type-specific details
-		var propSchema Schema
-		// Check if this is a nested struct (including pointers to structs)
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			// For nested structs, create a reference
-			nestedModelName := fieldType.Name()
-			if nestedModelName == "" {
-				// For anonymous structs, generate inline schema
-				collectedModels := make(map[string]interface{})
-				propSchema = rm.generateAnonymousStructSchema(fieldType, collectedModels)
-			} else {
-				// For named structs, use $ref
-				propSchema = Schema{
-					Ref: fmt.Sprintf("#/definitions/%s", nestedModelName),
-				}
-			}
-		} else if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			// Handle slices/arrays
-			elemType := field.Type.Elem()
-			// Check if element is a pointer to struct
-			if elemType.Kind() == reflect.Ptr {
-				elemType = elemType.Elem()
-			}
-			if elemType.Kind() == reflect.Struct && elemType.String() != "time.Time" {
-				nestedModelName := elemType.Name()
-				if nestedModelName == "" {
-					// For anonymous struct elements in array
-					collectedModels := make(map[string]interface{})
-					itemSchema := rm.generateAnonymousStructSchema(elemType, collectedModels)
-					propSchema = Schema{
-						Type:  "array",
-						Items: &itemSchema,
-					}
-				} else {
-					// For named struct elements in array
-					propSchema = Schema{
-						Type:  "array",
-						Items: &Schema{Ref: fmt.Sprintf("#/definitions/%s", nestedModelName)},
-					}
-				}
-			} else {
-				propSchema = rm.getSwaggerTypeWithDetails(field.Type, bindingTag, formatTag, enumTag)
-			}
-		} else {
-			propSchema = rm.getSwaggerTypeWithDetails(field.Type, bindingTag, formatTag, enumTag)
-		}
-
-		// Set description with priority (only if not a $ref)
-		if propSchema.Ref == "" {
-			if descriptionTag != "" {
-				propSchema.Description = descriptionTag
-			} else if docTag != "" {
-				propSchema.Description = docTag
-			} else {
-				propSchema.Description = fmt.Sprintf("Field %s", propName)
-			}
-		}
-
-		// Set example value (only if not a $ref)
-		if propSchema.Ref == "" && exampleTag != "" {
-			propSchema.Example = rm.parseExampleValue(exampleTag, field.Type)
-		}
-
-		// Set default value (only if not a $ref)
-		if propSchema.Ref == "" && defaultTag != "" {
-			propSchema.Default = rm.parseDefaultValue(defaultTag, field.Type)
-		}
-
-		// Parse binding validation rules
-		rm.parseValidationRules(&propSchema, bindingTag, field.Type)
-
-		// Check if field is required (binding tag takes precedence over omitempty)
-		if strings.Contains(bindingTag, "required") {
-			schema.Required = append(schema.Required, propName)
-		} else if !isOptional {
-			// Add to required if not explicitly optional
-			schema.Required = append(schema.Required, propName)
-		}
-
-		schema.Properties[propName] = propSchema
-	}
-
-	return schema
-}
-
-// generateSchemaFromModelWithDefinitions generates Swagger schema and collects nested models
-func (rm *RouteManager) generateSchemaFromModelWithDefinitions(model interface{}, collectedModels map[string]interface{}) Schema {
-	modelType := reflect.TypeOf(model)
-
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	schema := Schema{
-		Type:       "object",
-		Properties: make(map[string]Schema),
-		Required:   []string{},
-	}
-
-	if modelType.Kind() != reflect.Struct {
-		// Handle primitive types
-		return rm.getSwaggerType(modelType)
-	}
-
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
-		fieldName := field.Name
-
-		// Get all relevant tags
-		jsonTag := field.Tag.Get("json")
-		bindingTag := field.Tag.Get("binding")
-		exampleTag := field.Tag.Get("example")
-		defaultTag := field.Tag.Get("default")
-		docTag := field.Tag.Get("doc")
-		descriptionTag := field.Tag.Get("description")
-		formatTag := field.Tag.Get("format")
-		enumTag := field.Tag.Get("enum")
-
-		// Skip non-exported fields
-		if field.PkgPath != "" {
-			continue
-		}
-
-		// Determine the property name and json options
-		propName := fieldName
-		isOptional := false
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				propName = parts[0]
-			}
-			// Check for omitempty and other options
-			for _, part := range parts[1:] {
-				switch part {
-				case "omitempty":
-					isOptional = true
-				case "stringize":
-					// Handle string conversion
-				case "omitempty,stringize":
-					isOptional = true
-				}
-			}
-		}
-
-		// Generate property schema with type-specific details
-		var propSchema Schema
-		// Check if this is a nested struct (including pointers to structs)
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			// For nested structs, create a reference
-			nestedModelName := fieldType.Name()
-			if nestedModelName == "" {
-				// For anonymous structs, generate inline schema
-				propSchema = rm.generateAnonymousStructSchema(fieldType, collectedModels)
-			} else {
-				// For named structs, collect them and use $ref
-				if _, exists := collectedModels[nestedModelName]; !exists {
-					// Create a zero value of the struct to collect it
-					nestedModel := reflect.Zero(fieldType).Interface()
-					collectedModels[nestedModelName] = nestedModel
-				}
-				propSchema = Schema{
-					Ref: fmt.Sprintf("#/definitions/%s", nestedModelName),
-				}
-			}
-		} else if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			// Handle slices/arrays
-			elemType := field.Type.Elem()
-			// Check if element is a pointer to struct
-			if elemType.Kind() == reflect.Ptr {
-				elemType = elemType.Elem()
-			}
-			if elemType.Kind() == reflect.Struct && elemType.String() != "time.Time" {
-				nestedModelName := elemType.Name()
-				if nestedModelName == "" {
-					// For anonymous struct elements in array
-					itemSchema := rm.generateAnonymousStructSchema(elemType, collectedModels)
-					propSchema = Schema{
-						Type:  "array",
-						Items: &itemSchema,
-					}
-				} else {
-					// For named struct elements in array
-					if _, exists := collectedModels[nestedModelName]; !exists {
-						nestedModel := reflect.Zero(elemType).Interface()
-						collectedModels[nestedModelName] = nestedModel
-					}
-					propSchema = Schema{
-						Type:  "array",
-						Items: &Schema{Ref: fmt.Sprintf("#/definitions/%s", nestedModelName)},
-					}
-				}
-			} else {
-				propSchema = rm.getSwaggerTypeWithDetails(field.Type, bindingTag, formatTag, enumTag)
-			}
-		} else {
-			propSchema = rm.getSwaggerTypeWithDetails(field.Type, bindingTag, formatTag, enumTag)
-		}
-
-		// Set description with priority (only if not a $ref)
-		if propSchema.Ref == "" {
-			if descriptionTag != "" {
-				propSchema.Description = descriptionTag
-			} else if docTag != "" {
-				propSchema.Description = docTag
-			} else {
-				propSchema.Description = fmt.Sprintf("Field %s", propName)
-			}
-		}
-
-		// Set example value (only if not a $ref)
-		if propSchema.Ref == "" && exampleTag != "" {
-			propSchema.Example = rm.parseExampleValue(exampleTag, field.Type)
-		}
-
-		// Set default value (only if not a $ref)
-		if propSchema.Ref == "" && defaultTag != "" {
-			propSchema.Default = rm.parseDefaultValue(defaultTag, field.Type)
-		}
-
-		// Parse binding validation rules
-		rm.parseValidationRules(&propSchema, bindingTag, field.Type)
-
-		// Check if field is required (binding tag takes precedence over omitempty)
-		if strings.Contains(bindingTag, "required") {
-			schema.Required = append(schema.Required, propName)
-		} else if !isOptional {
-			// Add to required if not explicitly optional
-			schema.Required = append(schema.Required, propName)
-		}
-
-		schema.Properties[propName] = propSchema
-	}
-
-	return schema
-}
-
-// generateAnonymousStructSchema generates schema for an anonymous struct
-func (rm *RouteManager) generateAnonymousStructSchema(structType reflect.Type, collectedModels map[string]interface{}) Schema {
-	schema := Schema{
-		Type:       "object",
-		Properties: make(map[string]Schema),
-		Required:   []string{},
-	}
-
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-
-		// Skip non-exported fields
-		if field.PkgPath != "" {
-			continue
-		}
-
-		// Get field name from json tag
-		propName := field.Name
-		jsonTag := field.Tag.Get("json")
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				propName = parts[0]
-			}
-		}
-
-		// Generate schema for this field
-		var fieldSchema Schema
-		// Check if this is a nested struct (including pointers to structs)
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			nestedModelName := fieldType.Name()
-			if nestedModelName == "" {
-				// Anonymous struct inside anonymous struct
-				fieldSchema = rm.generateAnonymousStructSchema(fieldType, collectedModels)
-			} else {
-				// Named struct inside anonymous struct
-				if _, exists := collectedModels[nestedModelName]; !exists {
-					nestedModel := reflect.Zero(fieldType).Interface()
-					collectedModels[nestedModelName] = nestedModel
-				}
-				fieldSchema = Schema{
-					Ref: fmt.Sprintf("#/definitions/%s", nestedModelName),
-				}
-			}
-		} else {
-			fieldSchema = rm.getSwaggerType(field.Type)
-		}
-
-		// Add description (only if not a $ref)
-		descriptionTag := field.Tag.Get("description")
-		docTag := field.Tag.Get("doc")
-		if fieldSchema.Ref == "" {
-			if descriptionTag != "" {
-				fieldSchema.Description = descriptionTag
-			} else if docTag != "" {
-				fieldSchema.Description = docTag
-			} else {
-				fieldSchema.Description = fmt.Sprintf("Field %s", propName)
-			}
-		}
-
-		schema.Properties[propName] = fieldSchema
-
-		// Check if field is required
-		if !strings.Contains(jsonTag, "omitempty") {
-			schema.Required = append(schema.Required, propName)
-		}
-	}
-
-	return schema
-}
-
-// generateSchemaFromModelWithCache generates schema using cached models to avoid duplication
-func (rm *RouteManager) generateSchemaFromModelWithCache(model interface{}, allModels map[string]interface{}) Schema {
-	// Get the actual type (handle pointers)
-	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	// If not a struct, use getSwaggerType (handles gin.H and other non-struct types)
-	if modelType.Kind() != reflect.Struct {
-		return rm.getSwaggerType(modelType)
-	}
-
-	// Otherwise, generate the schema normally
-	return rm.generateSchemaWithReferences(model)
-}
-
-// Version-aware schema generation functions for OpenAPI v3
+var (
+	timeType       = reflect.TypeOf(time.Time{})
+	rawMessageType = reflect.TypeOf(json.RawMessage{})
+)
 
 // getRefPrefix returns the reference prefix based on version
 func getRefPrefix(version Version) string {
@@ -424,350 +23,243 @@ func getRefPrefix(version Version) string {
 	}
 }
 
-// generateSchemaWithReferencesVersion generates schema using $ref with version-specific prefix
-func (rm *RouteManager) generateSchemaWithReferencesVersion(model interface{}, version Version) Schema {
-	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
+// schemaGen generates version-aware schemas from Go types.
+// Named struct types encountered while generating are recorded in collected so
+// the spec builders can emit a definition for every referenced model.
+type schemaGen struct {
+	refPrefix string
+	collected map[string]reflect.Type
+}
+
+func newSchemaGen(version Version) *schemaGen {
+	return &schemaGen{
+		refPrefix: getRefPrefix(version),
+		collected: make(map[string]reflect.Type),
+	}
+}
+
+// buildDefinitions generates schemas for every registered model plus all
+// named struct types reachable from them (nested structs, slice elements,
+// map values, embedded fields).
+func (g *schemaGen) buildDefinitions(modelSet map[string]interface{}) map[string]Schema {
+	definitions := make(map[string]Schema, len(modelSet))
+	for name, model := range modelSet {
+		definitions[name] = g.modelSchema(model)
 	}
 
-	refPrefix := getRefPrefix(version)
+	// Generating a schema may discover new nested models; iterate until no
+	// undiscovered model remains. Registration into collected happens at most
+	// once per name, so this terminates even with cyclic models.
+	for {
+		var pending []string
+		for name := range g.collected {
+			if _, done := definitions[name]; !done {
+				pending = append(pending, name)
+			}
+		}
+		if len(pending) == 0 {
+			return definitions
+		}
+		for _, name := range pending {
+			definitions[name] = g.structSchema(g.collected[name])
+		}
+	}
+}
 
+// modelSchema builds the expanded schema for a model that is emitted as a
+// definition. Unlike typeSchema, a named struct is expanded here rather than
+// turned into a $ref.
+func (g *schemaGen) modelSchema(model interface{}) Schema {
+	t := derefType(reflect.TypeOf(model))
+	if t.Kind() != reflect.Struct || t == timeType {
+		return g.typeSchema(t)
+	}
+	return g.structSchema(t)
+}
+
+// structSchema builds an object schema from the exported fields of a struct.
+func (g *schemaGen) structSchema(t reflect.Type) Schema {
 	schema := Schema{
 		Type:       "object",
 		Properties: make(map[string]Schema),
 		Required:   []string{},
 	}
-
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
-		fieldName := field.Name
-
-		// Get all relevant tags
-		jsonTag := field.Tag.Get("json")
-		bindingTag := field.Tag.Get("binding")
-		exampleTag := field.Tag.Get("example")
-		defaultTag := field.Tag.Get("default")
-		docTag := field.Tag.Get("doc")
-		descriptionTag := field.Tag.Get("description")
-		formatTag := field.Tag.Get("format")
-		enumTag := field.Tag.Get("enum")
-
-		// Skip non-exported fields
-		if field.PkgPath != "" {
-			continue
-		}
-
-		// Determine the property name and json options
-		propName := fieldName
-		isOptional := false
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				propName = parts[0]
-			}
-			for _, part := range parts[1:] {
-				if part == "omitempty" || part == "omitempty,stringize" {
-					isOptional = true
-				}
-			}
-		}
-
-		// Generate property schema
-		var propSchema Schema
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			nestedModelName := fieldType.Name()
-			if nestedModelName == "" {
-				collectedModels := make(map[string]interface{})
-				propSchema = rm.generateAnonymousStructSchemaVersion(fieldType, collectedModels, version)
-			} else {
-				propSchema = Schema{Ref: refPrefix + nestedModelName}
-			}
-		} else if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			elemType := field.Type.Elem()
-			if elemType.Kind() == reflect.Ptr {
-				elemType = elemType.Elem()
-			}
-			if elemType.Kind() == reflect.Struct && elemType.String() != "time.Time" {
-				nestedModelName := elemType.Name()
-				if nestedModelName == "" {
-					collectedModels := make(map[string]interface{})
-					itemSchema := rm.generateAnonymousStructSchemaVersion(elemType, collectedModels, version)
-					propSchema = Schema{Type: "array", Items: &itemSchema}
-				} else {
-					propSchema = Schema{Type: "array", Items: &Schema{Ref: refPrefix + nestedModelName}}
-				}
-			} else {
-				propSchema = rm.getSwaggerTypeWithDetailsVersion(field.Type, bindingTag, formatTag, enumTag, version)
-			}
-		} else if field.Type.Kind() == reflect.Map {
-			// Handle maps with version-aware type conversion
-			propSchema = rm.getSwaggerTypeWithDetailsVersion(field.Type, bindingTag, formatTag, enumTag, version)
-		} else {
-			propSchema = rm.getSwaggerTypeWithDetailsVersion(field.Type, bindingTag, formatTag, enumTag, version)
-		}
-
-		// Set description (only if not a $ref - OpenAPI 3.0 doesn't allow siblings with $ref)
-		if propSchema.Ref == "" {
-			if descriptionTag != "" {
-				propSchema.Description = descriptionTag
-			} else if docTag != "" {
-				propSchema.Description = docTag
-			} else {
-				propSchema.Description = fmt.Sprintf("Field %s", propName)
-			}
-		}
-
-		// Set example (only if not a $ref)
-		if propSchema.Ref == "" && exampleTag != "" {
-			propSchema.Example = rm.parseExampleValue(exampleTag, field.Type)
-		}
-
-		// Set default (only if not a $ref)
-		if propSchema.Ref == "" && defaultTag != "" {
-			propSchema.Default = rm.parseDefaultValue(defaultTag, field.Type)
-		}
-
-		// Parse validation
-		rm.parseValidationRules(&propSchema, bindingTag, field.Type)
-
-		// Check required
-		if strings.Contains(bindingTag, "required") {
-			schema.Required = append(schema.Required, propName)
-		} else if !isOptional {
-			schema.Required = append(schema.Required, propName)
-		}
-
-		schema.Properties[propName] = propSchema
-	}
-
+	g.addStructFields(&schema, t)
 	return schema
 }
 
-// generateAnonymousStructSchemaVersion generates schema for anonymous struct with version
-func (rm *RouteManager) generateAnonymousStructSchemaVersion(structType reflect.Type, collectedModels map[string]interface{}, version Version) Schema {
-	refPrefix := getRefPrefix(version)
+// addStructFields adds property schemas for the fields of t to schema.
+// Embedded structs without an explicit json name are flattened, matching
+// encoding/json marshaling behavior.
+func (g *schemaGen) addStructFields(schema *Schema, t reflect.Type) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
 
-	schema := Schema{
-		Type:       "object",
-		Properties: make(map[string]Schema),
-		Required:   []string{},
-	}
-
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
+		// Skip non-exported fields (embedded types are exported when the type
+		// name is; PkgPath is empty for them)
 		if field.PkgPath != "" {
 			continue
+		}
+
+		jsonTag := field.Tag.Get("json")
+		if tagName(jsonTag) == "-" {
+			continue
+		}
+
+		if field.Anonymous && tagName(jsonTag) == "" {
+			embeddedType := derefType(field.Type)
+			if embeddedType.Kind() == reflect.Struct && embeddedType != timeType {
+				g.addStructFields(schema, embeddedType)
+				continue
+			}
 		}
 
 		propName := field.Name
-		jsonTag := field.Tag.Get("json")
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				propName = parts[0]
-			}
+		if name := tagName(jsonTag); name != "" {
+			propName = name
 		}
 
-		var fieldSchema Schema
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
+		schema.Properties[propName] = g.fieldSchema(field, propName)
 
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			nestedModelName := fieldType.Name()
-			if nestedModelName == "" {
-				fieldSchema = rm.generateAnonymousStructSchemaVersion(fieldType, collectedModels, version)
-			} else {
-				if _, exists := collectedModels[nestedModelName]; !exists {
-					nestedModel := reflect.Zero(fieldType).Interface()
-					collectedModels[nestedModelName] = nestedModel
-				}
-				fieldSchema = Schema{Ref: refPrefix + nestedModelName}
-			}
-		} else if field.Type.Kind() == reflect.Map {
-			// Handle maps with version-aware type conversion
-			fieldSchema = rm.getSwaggerTypeVersion(field.Type, version)
-		} else if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			// Handle arrays with version-aware type conversion
-			fieldSchema = rm.getSwaggerTypeVersion(field.Type, version)
-		} else {
-			fieldSchema = rm.getSwaggerType(field.Type)
-		}
-
-		descriptionTag := field.Tag.Get("description")
-		docTag := field.Tag.Get("doc")
-		if fieldSchema.Ref == "" {
-			if descriptionTag != "" {
-				fieldSchema.Description = descriptionTag
-			} else if docTag != "" {
-				fieldSchema.Description = docTag
-			} else {
-				fieldSchema.Description = fmt.Sprintf("Field %s", propName)
-			}
-		}
-
-		schema.Properties[propName] = fieldSchema
-
-		if !strings.Contains(jsonTag, "omitempty") {
-			schema.Required = append(schema.Required, propName)
-		}
-	}
-
-	return schema
-}
-
-// generateSchemaFromModelWithDefinitionsVersion generates schema with definitions and version
-func (rm *RouteManager) generateSchemaFromModelWithDefinitionsVersion(model interface{}, collectedModels map[string]interface{}, version Version) Schema {
-	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
-	}
-
-	refPrefix := getRefPrefix(version)
-
-	schema := Schema{
-		Type:       "object",
-		Properties: make(map[string]Schema),
-		Required:   []string{},
-	}
-
-	if modelType.Kind() != reflect.Struct {
-		return rm.getSwaggerType(modelType)
-	}
-
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
-		fieldName := field.Name
-
-		jsonTag := field.Tag.Get("json")
+		// A field is required when binding says so, or when it is not marked
+		// omitempty (it always appears in the marshaled JSON).
 		bindingTag := field.Tag.Get("binding")
-		exampleTag := field.Tag.Get("example")
-		defaultTag := field.Tag.Get("default")
-		docTag := field.Tag.Get("doc")
-		descriptionTag := field.Tag.Get("description")
-		formatTag := field.Tag.Get("format")
-		enumTag := field.Tag.Get("enum")
-
-		if field.PkgPath != "" {
-			continue
-		}
-
-		propName := fieldName
-		isOptional := false
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				propName = parts[0]
-			}
-			for _, part := range parts[1:] {
-				if part == "omitempty" || part == "omitempty,stringize" {
-					isOptional = true
-				}
-			}
-		}
-
-		var propSchema Schema
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-
-		if fieldType.Kind() == reflect.Struct && fieldType.String() != "time.Time" {
-			nestedModelName := fieldType.Name()
-			if nestedModelName == "" {
-				propSchema = rm.generateAnonymousStructSchemaVersion(fieldType, collectedModels, version)
-			} else {
-				if _, exists := collectedModels[nestedModelName]; !exists {
-					nestedModel := reflect.Zero(fieldType).Interface()
-					collectedModels[nestedModelName] = nestedModel
-				}
-				propSchema = Schema{Ref: refPrefix + nestedModelName}
-			}
-		} else if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			elemType := field.Type.Elem()
-			if elemType.Kind() == reflect.Ptr {
-				elemType = elemType.Elem()
-			}
-			if elemType.Kind() == reflect.Struct && elemType.String() != "time.Time" {
-				nestedModelName := elemType.Name()
-				if nestedModelName == "" {
-					itemSchema := rm.generateAnonymousStructSchemaVersion(elemType, collectedModels, version)
-					propSchema = Schema{Type: "array", Items: &itemSchema}
-				} else {
-					if _, exists := collectedModels[nestedModelName]; !exists {
-						nestedModel := reflect.Zero(elemType).Interface()
-						collectedModels[nestedModelName] = nestedModel
-					}
-					propSchema = Schema{Type: "array", Items: &Schema{Ref: refPrefix + nestedModelName}}
-				}
-			} else {
-				propSchema = rm.getSwaggerTypeWithDetailsVersion(field.Type, bindingTag, formatTag, enumTag, version)
-			}
-		} else if field.Type.Kind() == reflect.Map {
-			// Handle maps with version-aware type conversion
-			propSchema = rm.getSwaggerTypeWithDetailsVersion(field.Type, bindingTag, formatTag, enumTag, version)
-		} else {
-			propSchema = rm.getSwaggerTypeWithDetailsVersion(field.Type, bindingTag, formatTag, enumTag, version)
-		}
-
-		if descriptionTag != "" {
-			propSchema.Description = descriptionTag
-		} else if docTag != "" {
-			propSchema.Description = docTag
-		} else {
-			propSchema.Description = fmt.Sprintf("Field %s", propName)
-		}
-
-		// Only set example if not a $ref
-		if propSchema.Ref == "" && exampleTag != "" {
-			propSchema.Example = rm.parseExampleValue(exampleTag, field.Type)
-		}
-
-		if defaultTag != "" {
-			propSchema.Default = rm.parseDefaultValue(defaultTag, field.Type)
-		}
-
-		rm.parseValidationRules(&propSchema, bindingTag, field.Type)
-
-		if strings.Contains(bindingTag, "required") {
-			schema.Required = append(schema.Required, propName)
-		} else if !isOptional {
+		if strings.Contains(bindingTag, "required") || !hasJSONOption(jsonTag, "omitempty") {
 			schema.Required = append(schema.Required, propName)
 		}
-
-		schema.Properties[propName] = propSchema
 	}
-
-	return schema
 }
 
-// generateSchemaFromModelWithCacheVersion generates schema with cache and version
-func (rm *RouteManager) generateSchemaFromModelWithCacheVersion(model interface{}, allModels map[string]interface{}, version Version) Schema {
-	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
+// fieldSchema builds the property schema for a single struct field, applying
+// tag-driven details (description, example, default, format, enum, binding
+// validation rules).
+func (g *schemaGen) fieldSchema(field reflect.StructField, propName string) Schema {
+	propSchema := g.typeSchema(field.Type)
+
+	// $ref must not carry sibling properties (OpenAPI 3.0 forbids them)
+	if propSchema.Ref != "" {
+		return propSchema
 	}
 
-	if modelType.Kind() != reflect.Struct {
-		return rm.getSwaggerType(modelType)
+	if format := field.Tag.Get("format"); format != "" {
+		propSchema.Format = format
 	}
 
-	return rm.generateSchemaWithReferencesVersion(model, version)
+	if enumTag := field.Tag.Get("enum"); enumTag != "" {
+		enumValues := strings.Split(enumTag, ",")
+		propSchema.Enum = make([]interface{}, len(enumValues))
+		for i, val := range enumValues {
+			propSchema.Enum[i] = parseTaggedValue(val, field.Type)
+		}
+	}
+
+	// Description priority: description > doc > generated fallback
+	if desc := field.Tag.Get("description"); desc != "" {
+		propSchema.Description = desc
+	} else if doc := field.Tag.Get("doc"); doc != "" {
+		propSchema.Description = doc
+	} else {
+		propSchema.Description = fmt.Sprintf("Field %s", propName)
+	}
+
+	if example := field.Tag.Get("example"); example != "" {
+		propSchema.Example = parseTaggedValue(example, field.Type)
+	}
+
+	if defaultTag := field.Tag.Get("default"); defaultTag != "" {
+		propSchema.Default = parseTaggedValue(defaultTag, field.Type)
+	}
+
+	parseValidationRules(&propSchema, field.Tag.Get("binding"), derefType(field.Type))
+
+	return propSchema
 }
 
-// getSwaggerTypeWithDetailsVersion converts Go type to Swagger schema with additional details and version
-func (rm *RouteManager) getSwaggerTypeWithDetailsVersion(goType reflect.Type, bindingTag, formatTag, enumTag string, version Version) Schema {
-	// For maps and other complex types, use the version-aware function
-	if goType.Kind() == reflect.Map {
-		return rm.getSwaggerTypeVersion(goType, version)
+// typeSchema returns the schema for a Go type as it appears inside another
+// schema. Named structs become a $ref and are queued for definition emission;
+// anonymous structs are inlined.
+func (g *schemaGen) typeSchema(t reflect.Type) Schema {
+	t = derefType(t)
+
+	switch t.Kind() {
+	case reflect.String:
+		return Schema{Type: "string"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return Schema{Type: "integer", Format: "int64"}
+	case reflect.Float32, reflect.Float64:
+		return Schema{Type: "number", Format: "double"}
+	case reflect.Bool:
+		return Schema{Type: "boolean"}
+	case reflect.Slice, reflect.Array:
+		// json.RawMessage marshals as arbitrary JSON: any-typed schema
+		if t == rawMessageType {
+			return Schema{}
+		}
+		// []byte marshals as a base64 string
+		if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8 {
+			return Schema{Type: "string", Format: "byte"}
+		}
+		elemSchema := g.typeSchema(t.Elem())
+		return Schema{Type: "array", Items: &elemSchema}
+	case reflect.Map:
+		valueSchema := g.typeSchema(t.Elem())
+		return Schema{Type: "object", AdditionalProperties: &valueSchema}
+	case reflect.Struct:
+		if t == timeType {
+			return Schema{Type: "string", Format: "date-time"}
+		}
+		if t.Name() == "" {
+			// Anonymous struct: inline the schema
+			return g.structSchema(t)
+		}
+		g.collect(t)
+		return Schema{Ref: g.refPrefix + t.Name()}
+	case reflect.Interface:
+		return Schema{Type: "object"}
+	default:
+		return Schema{Type: "object"}
 	}
-	// For other types, use the original function (version doesn't affect primitives)
-	return rm.getSwaggerTypeWithDetails(goType, bindingTag, formatTag, enumTag)
+}
+
+// collect records a named struct type so buildDefinitions emits it.
+func (g *schemaGen) collect(t reflect.Type) {
+	name := t.Name()
+	if name == "" {
+		return
+	}
+	if _, exists := g.collected[name]; !exists {
+		g.collected[name] = t
+	}
+}
+
+// derefType unwraps pointer types.
+func derefType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// tagName returns the name part of a json/form struct tag ("-" included).
+func tagName(tag string) string {
+	if tag == "" {
+		return ""
+	}
+	if idx := strings.Index(tag, ","); idx >= 0 {
+		return tag[:idx]
+	}
+	return tag
+}
+
+// hasJSONOption reports whether a struct tag carries the given option
+// (e.g. "omitempty" in `json:"name,omitempty"`).
+func hasJSONOption(tag, option string) bool {
+	parts := strings.Split(tag, ",")
+	for _, part := range parts[1:] {
+		if part == option {
+			return true
+		}
+	}
+	return false
 }

--- a/swagger/schema_test.go
+++ b/swagger/schema_test.go
@@ -1,0 +1,272 @@
+package swagger
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestManager(t *testing.T) *RouteManager {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rm := NewRouteManager(gin.New())
+	rm.SetSwaggerInfo(SwaggerInfo{
+		Title:   "Test API",
+		Version: "1.0.0",
+	})
+	return rm
+}
+
+// Generation must be deterministic: repeated generation of the same routes
+// (including the tags section) yields byte-identical output.
+func TestGenerateOpenAPIDeterministic(t *testing.T) {
+	rm := newTestManager(t)
+	group := rm.NewGroup("api", "v1", "")
+
+	handler := func(c *gin.Context) {}
+	tags := []string{"zeta", "alpha", "mid", "beta", "omega", "kappa", "iota"}
+	for _, tag := range tags {
+		group.GET("/"+tag, handler, WithDescription(tag), WithTags(tag))
+	}
+
+	first, err := rm.GenerateOpenAPI(VersionV3)
+	assert.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		next, err := rm.GenerateOpenAPI(VersionV3)
+		assert.NoError(t, err)
+		assert.Equal(t, first, next, "generation %d differs", i)
+	}
+
+	// Tags must be sorted by name
+	var spec OpenAPI
+	assert.NoError(t, json.Unmarshal([]byte(first), &spec))
+	for i := 1; i < len(spec.Tags); i++ {
+		assert.LessOrEqual(t, spec.Tags[i-1].Name, spec.Tags[i].Name)
+	}
+}
+
+// Fields tagged json:"-" never appear in marshaled JSON and must not appear
+// in the schema either.
+func TestSchemaSkipsJSONDashFields(t *testing.T) {
+	type Model struct {
+		Visible string `json:"visible"`
+		Hidden  string `json:"-"`
+		secret  string //lint:ignore U1000 unexported fields must be skipped
+	}
+	_ = Model{}.secret
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+	assert.Contains(t, schema.Properties, "visible")
+	assert.NotContains(t, schema.Properties, "Hidden")
+	assert.NotContains(t, schema.Properties, "secret")
+	assert.NotContains(t, schema.Required, "Hidden")
+}
+
+// Embedded structs without a json name are flattened into the parent,
+// matching encoding/json marshaling.
+func TestSchemaFlattensEmbeddedStructs(t *testing.T) {
+	type Base struct {
+		ID        string `json:"id"`
+		CreatedAt string `json:"created_at,omitempty"`
+	}
+	type PtrBase struct {
+		Extra string `json:"extra"`
+	}
+	type Model struct {
+		Base
+		*PtrBase
+		Name string `json:"name"`
+	}
+
+	gen := newSchemaGen(VersionV3)
+	schema := gen.modelSchema(Model{})
+
+	assert.Contains(t, schema.Properties, "id")
+	assert.Contains(t, schema.Properties, "created_at")
+	assert.Contains(t, schema.Properties, "extra")
+	assert.Contains(t, schema.Properties, "name")
+	assert.NotContains(t, schema.Properties, "Base")
+	assert.NotContains(t, schema.Properties, "PtrBase")
+	// Flattened required semantics carry over
+	assert.Contains(t, schema.Required, "id")
+	assert.NotContains(t, schema.Required, "created_at")
+	// The embedded types are not emitted as standalone definitions
+	assert.NotContains(t, gen.collected, "Base")
+	assert.NotContains(t, gen.collected, "PtrBase")
+}
+
+// []byte marshals as a base64 string; json.RawMessage is arbitrary JSON.
+func TestSchemaByteSliceAndRawMessage(t *testing.T) {
+	type Model struct {
+		Blob []byte          `json:"blob"`
+		Raw  json.RawMessage `json:"raw"`
+	}
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+
+	blob := schema.Properties["blob"]
+	assert.Equal(t, "string", blob.Type)
+	assert.Equal(t, "byte", blob.Format)
+
+	raw := schema.Properties["raw"]
+	assert.Empty(t, raw.Type)
+	assert.Empty(t, raw.Ref)
+	assert.Nil(t, raw.Items)
+}
+
+// Map values that are anonymous structs must be inlined, not emitted as a
+// dangling empty $ref.
+func TestSchemaMapOfAnonymousStruct(t *testing.T) {
+	type Model struct {
+		Data map[string]struct {
+			Value string `json:"value"`
+		} `json:"data"`
+	}
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+	data := schema.Properties["data"]
+	assert.Equal(t, "object", data.Type)
+	if assert.NotNil(t, data.AdditionalProperties) {
+		assert.Empty(t, data.AdditionalProperties.Ref)
+		assert.Contains(t, data.AdditionalProperties.Properties, "value")
+	}
+}
+
+// Named structs reachable only through maps, slices, or deep nesting must all
+// end up in the definitions.
+func TestBuildDefinitionsCollectsDeepModels(t *testing.T) {
+	type Leaf struct {
+		Value string `json:"value"`
+	}
+	type Mid struct {
+		Leaves map[string]Leaf `json:"leaves"`
+	}
+	type Root struct {
+		Mids []*Mid `json:"mids"`
+	}
+
+	defs := newSchemaGen(VersionV3).buildDefinitions(map[string]interface{}{"Root": Root{}})
+	assert.Contains(t, defs, "Root")
+	assert.Contains(t, defs, "Mid")
+	assert.Contains(t, defs, "Leaf")
+}
+
+// Self-referencing models must not hang generation.
+func TestBuildDefinitionsHandlesRecursiveModels(t *testing.T) {
+	type Node struct {
+		Name     string  `json:"name"`
+		Children []*Node `json:"children,omitempty"`
+	}
+
+	defs := newSchemaGen(VersionV3).buildDefinitions(map[string]interface{}{"Node": Node{}})
+	assert.Contains(t, defs, "Node")
+	children := defs["Node"].Properties["children"]
+	assert.Equal(t, "array", children.Type)
+	assert.Equal(t, "#/components/schemas/Node", children.Items.Ref)
+}
+
+// Binding tags on a nested-struct field must not attach validation keywords
+// as $ref siblings (forbidden in OpenAPI 3.0).
+func TestRefFieldsCarryNoValidationSiblings(t *testing.T) {
+	type Inner struct {
+		Value string `json:"value"`
+	}
+	type Model struct {
+		Inner Inner `json:"inner" binding:"required" description:"should not appear"`
+	}
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+	inner := schema.Properties["inner"]
+	assert.NotEmpty(t, inner.Ref)
+	assert.Empty(t, inner.Description)
+	assert.Empty(t, inner.Type)
+	assert.Nil(t, inner.Minimum)
+	assert.Contains(t, schema.Required, "inner")
+}
+
+// len= on strings constrains length; on slices it constrains item count.
+func TestValidationRulesLenAndBounds(t *testing.T) {
+	type Model struct {
+		Code  string   `json:"code" binding:"len=6"`
+		Items []string `json:"items" binding:"min=1,max=5"`
+		Score float64  `json:"score" binding:"gt=0,lte=100"`
+	}
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+
+	code := schema.Properties["code"]
+	if assert.NotNil(t, code.MinLength) && assert.NotNil(t, code.MaxLength) {
+		assert.Equal(t, 6, *code.MinLength)
+		assert.Equal(t, 6, *code.MaxLength)
+	}
+
+	items := schema.Properties["items"]
+	if assert.NotNil(t, items.MinItems) && assert.NotNil(t, items.MaxItems) {
+		assert.Equal(t, 1, *items.MinItems)
+		assert.Equal(t, 5, *items.MaxItems)
+	}
+
+	score := schema.Properties["score"]
+	if assert.NotNil(t, score.Minimum) && assert.NotNil(t, score.Maximum) {
+		assert.Equal(t, 0.0, *score.Minimum)
+		assert.True(t, score.ExclusiveMinimum)
+		assert.Equal(t, 100.0, *score.Maximum)
+		assert.False(t, score.ExclusiveMaximum)
+	}
+}
+
+// Query parameter names follow gin's binding: form tag wins over json tag,
+// and "-" opts the field out.
+func TestModelQueryParams(t *testing.T) {
+	type Query struct {
+		Page     int    `form:"page" json:"page_json" binding:"required"`
+		Name     string `json:"name"`
+		Ignored  string `form:"-"`
+		Excluded string `json:"-"`
+	}
+
+	params := modelQueryParams(Query{})
+	names := make(map[string]queryParamSpec, len(params))
+	for _, p := range params {
+		names[p.Name] = p
+	}
+
+	assert.Contains(t, names, "page")
+	assert.True(t, names["page"].Required)
+	assert.Equal(t, "integer", names["page"].Type)
+	assert.Contains(t, names, "name")
+	assert.NotContains(t, names, "page_json")
+	assert.NotContains(t, names, "Ignored")
+	assert.NotContains(t, names, "Excluded")
+}
+
+// AddMiddleware must register each middleware exactly once, even when called
+// multiple times.
+func TestAddMiddlewareRegistersOnce(t *testing.T) {
+	rm := newTestManager(t)
+	group := rm.NewGroup("api", "v1", "")
+
+	calls := map[string]int{}
+	counter := func(name string) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			calls[name]++
+			c.Next()
+		}
+	}
+	group.AddMiddleware(counter("first"))
+	group.AddMiddleware(counter("second"))
+
+	group.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	rm.GetEngine().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, calls["first"], "first middleware ran %d times", calls["first"])
+	assert.Equal(t, 1, calls["second"], "second middleware ran %d times", calls["second"])
+}

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -5,13 +5,19 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 )
 
-// GenerateSwaggerJSON generates the complete Swagger JSON specification
+// GenerateSwaggerJSON generates the complete Swagger 2.0 JSON specification
 func (rm *RouteManager) GenerateSwaggerJSON() (string, error) {
+	schemes := rm.swaggerInfo.Schemes
+	if len(schemes) == 0 {
+		schemes = []string{"http", "https"}
+	}
+
 	swagger := &Swagger{
 		Swagger: "2.0",
 		Info: SwaggerInfoObject{
@@ -19,11 +25,10 @@ func (rm *RouteManager) GenerateSwaggerJSON() (string, error) {
 			Description: rm.swaggerInfo.Description,
 			Version:     rm.swaggerInfo.Version,
 		},
-		Host:        rm.swaggerInfo.Host,
-		BasePath:    rm.swaggerInfo.BasePath,
-		Schemes:     []string{"http", "https"},
-		Paths:       make(map[string]PathItem),
-		Definitions: make(map[string]Schema),
+		Host:     rm.swaggerInfo.Host,
+		BasePath: rm.swaggerInfo.BasePath,
+		Schemes:  schemes,
+		Paths:    make(map[string]PathItem),
 		SecurityDefinitions: map[string]SecurityScheme{
 			"ApiKeyAuth": {
 				Type:        "apiKey",
@@ -32,11 +37,10 @@ func (rm *RouteManager) GenerateSwaggerJSON() (string, error) {
 				Description: "API key authorization header",
 			},
 		},
-		Tags: []Tag{},
 	}
 
 	// Add contact info if available
-	if rm.swaggerInfo.Contact.Name != "" || rm.swaggerInfo.Contact.Email != "" || rm.swaggerInfo.Contact.URL != "" {
+	if rm.swaggerInfo.Contact != (SwaggerContact{}) {
 		swagger.Info.Contact = &SwaggerContactObject{
 			Name:  rm.swaggerInfo.Contact.Name,
 			Email: rm.swaggerInfo.Contact.Email,
@@ -45,7 +49,7 @@ func (rm *RouteManager) GenerateSwaggerJSON() (string, error) {
 	}
 
 	// Add license info if available
-	if rm.swaggerInfo.License.Name != "" || rm.swaggerInfo.License.URL != "" {
+	if rm.swaggerInfo.License != (SwaggerLicense{}) {
 		swagger.Info.License = &SwaggerLicenseObject{
 			Name: rm.swaggerInfo.License.Name,
 			URL:  rm.swaggerInfo.License.URL,
@@ -59,219 +63,24 @@ func (rm *RouteManager) GenerateSwaggerJSON() (string, error) {
 	for _, group := range rm.groups {
 		for _, route := range group.routes {
 			fullPath := group.prefix + route.Path
-			swaggerPath := rm.convertPathFormat(fullPath)
-			method := strings.ToLower(route.Method)
+			swaggerPath := convertPathFormat(fullPath)
 
-			// Create path item if not exists
-			if _, exists := swagger.Paths[swaggerPath]; !exists {
-				swagger.Paths[swaggerPath] = PathItem{}
+			operation := rm.buildV2Operation(group, route, fullPath, swaggerPath, modelSet)
+			for _, tag := range operation.Tags {
+				tagSet[tag] = true
 			}
 
-			// Create operation
-			operation := &Operation{
-				OperationID: rm.generateOperationID(route.Method, swaggerPath),
-				Summary:     route.Description,
-				Description: route.Description,
-				Responses:   make(map[string]Response),
-				Consumes:    []string{"application/json"},
-				Produces:    []string{"application/json"},
-			}
-
-			// Set tags
-			if len(route.Tags) > 0 {
-				operation.Tags = route.Tags
-				for _, tag := range route.Tags {
-					tagSet[tag] = true
-				}
-			} else {
-				operation.Tags = []string{group.name}
-				tagSet[group.name] = true
-			}
-
-			// Handle deprecated
-			if route.Deprecated {
-				operation.Deprecated = true
-				if route.DeprecatedMsg != "" {
-					operation.Description = fmt.Sprintf("%s\n\nDEPRECATED: %s", route.Description, route.DeprecatedMsg)
-				}
-			}
-
-			// Handle authentication
-			if route.AuthRequired {
-				operation.Security = []map[string][]string{
-					{"ApiKeyAuth": {}},
-				}
-			}
-
-			// Handle path parameters (add them first so they appear before query/body params)
-			// Use explicit path params if provided, otherwise auto-detect from path
-			var pathParams []Parameter
-			if len(route.PathParams) > 0 {
-				// Use explicitly defined path params
-				for _, pathParam := range route.PathParams {
-					swaggerParam := Parameter{
-						Name:        pathParam.Name,
-						In:          "path",
-						Description: pathParam.Description,
-						Required:    true,
-						Type:        pathParam.Type,
-						Format:      pathParam.Format,
-					}
-					pathParams = append(pathParams, swaggerParam)
-				}
-			} else {
-				// Auto-detect path params from the route path
-				pathParams = rm.extractPathParams(route.Path)
-			}
-			operation.Parameters = append(operation.Parameters, pathParams...)
-
-			// Handle query parameters from QueryParams
-			for _, param := range route.QueryParams {
-				swaggerParam := Parameter{
-					Name:        param.Name,
-					In:          "query",
-					Description: param.Description,
-					Required:    param.Required,
-					Type:        param.Type,
-				}
-				if param.Default != nil {
-					swaggerParam.Default = param.Default
-				}
-				if param.Minimum != nil {
-					minVal := float64(*param.Minimum)
-					swaggerParam.Minimum = &minVal
-				}
-				if param.Maximum != nil {
-					maxVal := float64(*param.Maximum)
-					swaggerParam.Maximum = &maxVal
-				}
-				if len(param.Enum) > 0 {
-					swaggerParam.Enum = param.Enum
-				}
-				operation.Parameters = append(operation.Parameters, swaggerParam)
-			}
-
-			// Handle query model
-			if route.QueryModel != nil {
-				modelName := rm.getModelNameWithFallback(route.QueryModel, route.QueryModelName, route.Method, fullPath, "Query")
-				modelSet[modelName] = route.QueryModel
-				operation.Parameters = append(operation.Parameters, rm.generateQueryParameters(route.QueryModel)...)
-			}
-
-			// Handle request model
-			if route.RequestModel != nil {
-				modelName := rm.getModelNameWithFallback(route.RequestModel, route.RequestModelName, route.Method, fullPath, "Request")
-				modelSet[modelName] = route.RequestModel
-
-				if route.Method == http.MethodGet {
-					// For GET requests, add query parameters
-					operation.Parameters = append(operation.Parameters, rm.generateQueryParameters(route.RequestModel)...)
-				} else {
-					// For POST/PUT/DELETE requests, add body parameter
-					operation.Parameters = append(operation.Parameters, Parameter{
-						Name:        "request",
-						In:          "body",
-						Description: "Request body",
-						Required:    true,
-						Schema: &Schema{
-							Ref: fmt.Sprintf("#/definitions/%s", modelName),
-						},
-					})
-				}
-			}
-
-			// Handle response models
-			if route.ResponseModel != nil {
-				modelName := rm.getModelNameWithFallback(route.ResponseModel, route.ResponseModelName, route.Method, fullPath, "Response")
-				modelSet[modelName] = route.ResponseModel
-				operation.Responses["200"] = Response{
-					Description: "Successful response",
-					Schema: &Schema{
-						Ref: fmt.Sprintf("#/definitions/%s", modelName),
-					},
-				}
-			} else {
-				operation.Responses["200"] = Response{
-					Description: "Successful response",
-					Schema: &Schema{
-						Type: "object",
-					},
-				}
-			}
-
-			// Handle error responses
-			for _, errorResp := range route.ErrorResponses {
-				statusCode := fmt.Sprintf("%d", errorResp.Code)
-				response := Response{
-					Description: errorResp.Message,
-					Schema: &Schema{
-						Type: "object",
-					},
-				}
-
-				if errorResp.Model != nil {
-					modelName := rm.getModelNameWithFallback(errorResp.Model, "", route.Method, fullPath, fmt.Sprintf("Error%d", errorResp.Code))
-					modelSet[modelName] = errorResp.Model
-					response.Schema = &Schema{
-						Ref: fmt.Sprintf("#/definitions/%s", modelName),
-					}
-				}
-
-				operation.Responses[statusCode] = response
-			}
-
-			// Add operation to path item based on method
 			pathItem := swagger.Paths[swaggerPath]
-			switch method {
-			case "get":
-				pathItem.Get = operation
-			case "post":
-				pathItem.Post = operation
-			case "put":
-				pathItem.Put = operation
-			case "delete":
-				pathItem.Delete = operation
-			case "patch":
-				pathItem.Patch = operation
-			case "options":
-				pathItem.Options = operation
-			case "head":
-				pathItem.Head = operation
-			}
+			setV2Operation(&pathItem, route.Method, operation)
 			swagger.Paths[swaggerPath] = pathItem
 		}
 	}
 
-	// Generate tags
-	for tagName := range tagSet {
-		swagger.Tags = append(swagger.Tags, Tag{
-			Name:        tagName,
-			Description: fmt.Sprintf("Operations related to %s", tagName),
-		})
-	}
+	swagger.Tags = sortedTags(tagSet)
 
-	// Generate model definitions with proper handling of nested models
-	// Use a map to track which models have been processed to avoid duplication
-	processedModels := make(map[string]bool)
-	allModels := make(map[string]interface{})
+	// Generate definitions for registered models and all nested models
+	swagger.Definitions = newSchemaGen(VersionV2).buildDefinitions(modelSet)
 
-	// First, collect all initial models
-	for modelName, model := range modelSet {
-		allModels[modelName] = model
-		processedModels[modelName] = false // Mark as collected but not processed
-	}
-
-	// Then recursively collect all nested models
-	for _, model := range modelSet {
-		rm.collectNestedModels(model, allModels, processedModels)
-	}
-
-	// Finally, generate schemas for all collected models
-	for modelName, model := range allModels {
-		swagger.Definitions[modelName] = rm.generateSchemaFromModelWithCache(model, allModels)
-	}
-
-	// Convert to JSON
 	jsonData, err := json.MarshalIndent(swagger, "", "  ")
 	if err != nil {
 		return "", err
@@ -280,157 +89,371 @@ func (rm *RouteManager) GenerateSwaggerJSON() (string, error) {
 	return string(jsonData), nil
 }
 
-// convertPathFormat converts path parameters from :param to {param} format
-func (rm *RouteManager) convertPathFormat(path string) string {
-	result := path
-	parts := strings.Split(path, "/")
+// buildV2Operation builds a Swagger 2.0 operation from route config
+func (rm *RouteManager) buildV2Operation(group *RouteGroup, route RouteConfig, fullPath, swaggerPath string, modelSet map[string]interface{}) *Operation {
+	operation := &Operation{
+		OperationID: generateOperationID(route.Method, swaggerPath),
+		Summary:     route.Description,
+		Description: route.Description,
+		Responses:   make(map[string]Response),
+		Consumes:    []string{"application/json"},
+		Produces:    []string{"application/json"},
+	}
 
-	for _, part := range parts {
-		if strings.HasPrefix(part, ":") {
-			paramName := strings.TrimPrefix(part, ":")
-			result = strings.Replace(result, part, "{"+paramName+"}", 1)
+	// Set tags (fallback to group name)
+	if len(route.Tags) > 0 {
+		operation.Tags = route.Tags
+	} else {
+		operation.Tags = []string{group.name}
+	}
+
+	// Handle deprecated
+	if route.Deprecated {
+		operation.Deprecated = true
+		if route.DeprecatedMsg != "" {
+			operation.Description = fmt.Sprintf("%s\n\nDEPRECATED: %s", route.Description, route.DeprecatedMsg)
 		}
 	}
 
-	return result
+	// Handle authentication
+	if route.AuthRequired {
+		operation.Security = []map[string][]string{
+			{"ApiKeyAuth": {}},
+		}
+	}
+
+	// Path parameters first so they appear before query/body params.
+	// Explicit path params override auto-detection from the route path.
+	operation.Parameters = append(operation.Parameters, resolvePathParams(route)...)
+
+	// Handle query parameters from QueryParams
+	for _, param := range route.QueryParams {
+		swaggerParam := Parameter{
+			Name:        param.Name,
+			In:          "query",
+			Description: param.Description,
+			Required:    param.Required,
+			Type:        normalizeSchemaType(param.Type),
+			Default:     param.Default,
+		}
+		if param.Minimum != nil {
+			minVal := float64(*param.Minimum)
+			swaggerParam.Minimum = &minVal
+		}
+		if param.Maximum != nil {
+			maxVal := float64(*param.Maximum)
+			swaggerParam.Maximum = &maxVal
+		}
+		if len(param.Enum) > 0 {
+			swaggerParam.Enum = param.Enum
+		}
+		operation.Parameters = append(operation.Parameters, swaggerParam)
+	}
+
+	// Handle query model
+	if route.QueryModel != nil {
+		modelName := rm.getModelNameWithFallback(route.QueryModel, route.QueryModelName, route.Method, fullPath, "Query")
+		modelSet[modelName] = route.QueryModel
+		for _, qp := range modelQueryParams(route.QueryModel) {
+			operation.Parameters = append(operation.Parameters, qp.toV2())
+		}
+	}
+
+	// Handle request model
+	if route.RequestModel != nil {
+		modelName := rm.getModelNameWithFallback(route.RequestModel, route.RequestModelName, route.Method, fullPath, "Request")
+		modelSet[modelName] = route.RequestModel
+
+		if route.Method == http.MethodGet {
+			// For GET requests, document the model as query parameters
+			for _, qp := range modelQueryParams(route.RequestModel) {
+				operation.Parameters = append(operation.Parameters, qp.toV2())
+			}
+		} else {
+			operation.Parameters = append(operation.Parameters, Parameter{
+				Name:        "request",
+				In:          "body",
+				Description: "Request body",
+				Required:    true,
+				Schema: &Schema{
+					Ref: fmt.Sprintf("#/definitions/%s", modelName),
+				},
+			})
+		}
+	}
+
+	// Handle response model
+	if route.ResponseModel != nil {
+		modelName := rm.getModelNameWithFallback(route.ResponseModel, route.ResponseModelName, route.Method, fullPath, "Response")
+		modelSet[modelName] = route.ResponseModel
+		operation.Responses["200"] = Response{
+			Description: "Successful response",
+			Schema: &Schema{
+				Ref: fmt.Sprintf("#/definitions/%s", modelName),
+			},
+		}
+	} else {
+		operation.Responses["200"] = Response{
+			Description: "Successful response",
+			Schema:      &Schema{Type: "object"},
+		}
+	}
+
+	// Handle error responses
+	for _, errorResp := range route.ErrorResponses {
+		response := Response{
+			Description: errorResp.Message,
+			Schema:      &Schema{Type: "object"},
+		}
+		if errorResp.Model != nil {
+			modelName := rm.getModelNameWithFallback(errorResp.Model, "", route.Method, fullPath, fmt.Sprintf("Error%d", errorResp.Code))
+			modelSet[modelName] = errorResp.Model
+			response.Schema = &Schema{
+				Ref: fmt.Sprintf("#/definitions/%s", modelName),
+			}
+		}
+		operation.Responses[fmt.Sprintf("%d", errorResp.Code)] = response
+	}
+
+	return operation
+}
+
+// setV2Operation assigns an operation to the method slot of a path item
+func setV2Operation(pathItem *PathItem, method string, operation *Operation) {
+	switch strings.ToLower(method) {
+	case "get":
+		pathItem.Get = operation
+	case "post":
+		pathItem.Post = operation
+	case "put":
+		pathItem.Put = operation
+	case "delete":
+		pathItem.Delete = operation
+	case "patch":
+		pathItem.Patch = operation
+	case "options":
+		pathItem.Options = operation
+	case "head":
+		pathItem.Head = operation
+	}
+}
+
+// sortedTags converts a tag name set into a deterministic, sorted tag list.
+// Map iteration order is random; without sorting, every generation shuffles
+// the tags section and produces spurious diffs in committed specs.
+func sortedTags(tagSet map[string]bool) []Tag {
+	names := make([]string, 0, len(tagSet))
+	for name := range tagSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	tags := make([]Tag, 0, len(names))
+	for _, name := range names {
+		tags = append(tags, Tag{
+			Name:        name,
+			Description: fmt.Sprintf("Operations related to %s", name),
+		})
+	}
+	return tags
+}
+
+// resolvePathParams returns the path parameters for a route: explicitly
+// configured ones if present, otherwise auto-detected from the route path.
+func resolvePathParams(route RouteConfig) []Parameter {
+	if len(route.PathParams) == 0 {
+		return extractPathParams(route.Path)
+	}
+
+	params := make([]Parameter, 0, len(route.PathParams))
+	for _, pathParam := range route.PathParams {
+		params = append(params, Parameter{
+			Name:        pathParam.Name,
+			In:          "path",
+			Description: pathParam.Description,
+			Required:    true,
+			Type:        pathParam.Type,
+			Format:      pathParam.Format,
+		})
+	}
+	return params
+}
+
+// convertPathFormat converts path parameters from :param to {param} format
+func convertPathFormat(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if strings.HasPrefix(part, ":") {
+			parts[i] = "{" + strings.TrimPrefix(part, ":") + "}"
+		}
+	}
+	return strings.Join(parts, "/")
 }
 
 // extractPathParams extracts path parameters from the URL path with intelligent type detection
-func (rm *RouteManager) extractPathParams(path string) []Parameter {
+func extractPathParams(path string) []Parameter {
 	var params []Parameter
 
 	// Find all path parameters like :name, :uuid, etc.
-	parts := strings.Split(path, "/")
-	for _, part := range parts {
-		if strings.HasPrefix(part, ":") {
-			paramName := strings.TrimPrefix(part, ":")
-			param := Parameter{
-				Name:     paramName,
-				In:       "path",
-				Required: true,
-				Type:     "string", // Default type
-			}
-
-			// Smart type and description inference based on parameter name
-			paramLower := strings.ToLower(paramName)
-
-			switch {
-			case strings.Contains(paramLower, "uuid"):
-				param.Type = "string"
-				param.Format = "uuid"
-				param.Description = "Unique identifier (UUID)"
-
-			case strings.Contains(paramLower, "id") && !strings.Contains(paramLower, "providerid"):
-				param.Type = "string"
-				if strings.Contains(paramLower, "userid") {
-					param.Description = "User ID"
-				} else if strings.Contains(paramLower, "ruleid") {
-					param.Description = "Rule ID"
-				} else {
-					param.Description = "Resource ID"
-				}
-
-			case paramLower == "name" || strings.Contains(paramLower, "provider"):
-				param.Type = "string"
-				param.Description = "Resource name"
-
-			case strings.Contains(paramLower, "num") || strings.Contains(paramLower, "count"):
-				param.Type = "integer"
-				param.Format = "int64"
-				param.Description = "Numeric count"
-
-			case paramLower == "page":
-				param.Type = "integer"
-				param.Format = "int32"
-				param.Description = "Page number"
-
-			case paramLower == "size" || paramLower == "limit":
-				param.Type = "integer"
-				param.Format = "int32"
-				param.Description = "Page size limit"
-
-			case strings.Contains(paramLower, "timestamp") || strings.Contains(paramLower, "time"):
-				param.Type = "string"
-				param.Format = "date-time"
-				param.Description = "Timestamp"
-
-			case strings.Contains(paramLower, "date"):
-				param.Type = "string"
-				param.Format = "date"
-				param.Description = "Date"
-
-			case strings.Contains(paramLower, "email"):
-				param.Type = "string"
-				param.Format = "email"
-				param.Description = "Email address"
-
-			case strings.Contains(paramLower, "url") || strings.Contains(paramLower, "uri"):
-				param.Type = "string"
-				param.Format = "uri"
-				param.Description = "URL/URI"
-
-			default:
-				param.Description = fmt.Sprintf("Path parameter '%s'", paramName)
-			}
-
-			params = append(params, param)
+	for _, part := range strings.Split(path, "/") {
+		if !strings.HasPrefix(part, ":") {
+			continue
 		}
+		paramName := strings.TrimPrefix(part, ":")
+		param := Parameter{
+			Name:     paramName,
+			In:       "path",
+			Required: true,
+			Type:     "string", // Default type
+		}
+
+		// Smart type and description inference based on parameter name
+		paramLower := strings.ToLower(paramName)
+
+		switch {
+		case strings.Contains(paramLower, "uuid"):
+			param.Format = "uuid"
+			param.Description = "Unique identifier (UUID)"
+
+		case strings.Contains(paramLower, "id") && !strings.Contains(paramLower, "providerid"):
+			if strings.Contains(paramLower, "userid") {
+				param.Description = "User ID"
+			} else if strings.Contains(paramLower, "ruleid") {
+				param.Description = "Rule ID"
+			} else {
+				param.Description = "Resource ID"
+			}
+
+		case paramLower == "name" || strings.Contains(paramLower, "provider"):
+			param.Description = "Resource name"
+
+		case strings.Contains(paramLower, "num") || strings.Contains(paramLower, "count"):
+			param.Type = "integer"
+			param.Format = "int64"
+			param.Description = "Numeric count"
+
+		case paramLower == "page":
+			param.Type = "integer"
+			param.Format = "int32"
+			param.Description = "Page number"
+
+		case paramLower == "size" || paramLower == "limit":
+			param.Type = "integer"
+			param.Format = "int32"
+			param.Description = "Page size limit"
+
+		case strings.Contains(paramLower, "timestamp") || strings.Contains(paramLower, "time"):
+			param.Format = "date-time"
+			param.Description = "Timestamp"
+
+		case strings.Contains(paramLower, "date"):
+			param.Format = "date"
+			param.Description = "Date"
+
+		case strings.Contains(paramLower, "email"):
+			param.Format = "email"
+			param.Description = "Email address"
+
+		case strings.Contains(paramLower, "url") || strings.Contains(paramLower, "uri"):
+			param.Format = "uri"
+			param.Description = "URL/URI"
+
+		default:
+			param.Description = fmt.Sprintf("Path parameter '%s'", paramName)
+		}
+
+		params = append(params, param)
 	}
 
 	return params
 }
 
-// generateQueryParameters generates query parameters from a model
-func (rm *RouteManager) generateQueryParameters(model interface{}) []Parameter {
-	var parameters []Parameter
-	modelType := reflect.TypeOf(model)
+// queryParamSpec is a version-neutral description of a query parameter
+// derived from a model field.
+type queryParamSpec struct {
+	Name        string
+	Description string
+	Required    bool
+	Type        string
+	Format      string
+}
 
-	if modelType.Kind() == reflect.Ptr {
-		modelType = modelType.Elem()
+func (q queryParamSpec) toV2() Parameter {
+	return Parameter{
+		Name:        q.Name,
+		In:          "query",
+		Description: q.Description,
+		Required:    q.Required,
+		Type:        q.Type,
+		Format:      q.Format,
 	}
+}
 
+func (q queryParamSpec) toV3() ParameterV3 {
+	return ParameterV3{
+		Name:        q.Name,
+		In:          "query",
+		Description: q.Description,
+		Required:    q.Required,
+		Schema: &Schema{
+			Type:   q.Type,
+			Format: q.Format,
+		},
+	}
+}
+
+// modelQueryParams derives query parameters from a model's exported fields.
+// The parameter name follows gin's query binding: form tag first, then json
+// tag as documentation fallback, then the field name. Fields opting out with
+// "-" are skipped. Embedded structs are flattened.
+func modelQueryParams(model interface{}) []queryParamSpec {
+	modelType := derefType(reflect.TypeOf(model))
 	if modelType.Kind() != reflect.Struct {
-		return parameters
+		return nil
 	}
+	return structQueryParams(modelType)
+}
+
+func structQueryParams(modelType reflect.Type) []queryParamSpec {
+	var parameters []queryParamSpec
 
 	for i := 0; i < modelType.NumField(); i++ {
 		field := modelType.Field(i)
-		fieldName := field.Name
-		jsonTag := field.Tag.Get("json")
-		formTag := field.Tag.Get("form")
+		if field.PkgPath != "" {
+			continue
+		}
 
-		// Determine the parameter name
-		paramName := fieldName
-		if jsonTag != "" && jsonTag != "-" {
-			parts := strings.Split(jsonTag, ",")
-			if parts[0] != "" {
-				paramName = parts[0]
-			}
-		} else if formTag != "" && formTag != "-" {
-			parts := strings.Split(formTag, ",")
-			if parts[0] != "" {
-				paramName = parts[0]
+		formName := tagName(field.Tag.Get("form"))
+		jsonName := tagName(field.Tag.Get("json"))
+		if formName == "-" || (formName == "" && jsonName == "-") {
+			continue
+		}
+
+		// Flatten embedded structs the same way gin's form binding does
+		if field.Anonymous && formName == "" && jsonName == "" {
+			embeddedType := derefType(field.Type)
+			if embeddedType.Kind() == reflect.Struct && embeddedType != timeType {
+				parameters = append(parameters, structQueryParams(embeddedType)...)
+				continue
 			}
 		}
 
-		// Check if field is required
-		bindingTag := field.Tag.Get("binding")
-		required := strings.Contains(bindingTag, "required")
+		paramName := field.Name
+		if formName != "" {
+			paramName = formName
+		} else if jsonName != "" {
+			paramName = jsonName
+		}
 
-		// Determine parameter type
-		paramType := rm.getSwaggerType(field.Type)
+		paramType, paramFormat := queryParamType(field.Type)
 
-		// Create parameter
-		param := Parameter{
+		parameters = append(parameters, queryParamSpec{
 			Name:        paramName,
-			In:          "query",
 			Description: fmt.Sprintf("Query parameter %s", paramName),
-			Required:    required,
-			Type:        paramType.Type,
-			Format:      paramType.Format,
-		}
-
-		parameters = append(parameters, param)
+			Required:    strings.Contains(field.Tag.Get("binding"), "required"),
+			Type:        paramType,
+			Format:      paramFormat,
+		})
 	}
 
 	return parameters


### PR DESCRIPTION
## Summary
Refactored the Swagger/OpenAPI schema generation system to be deterministic, version-aware, and more maintainable. The core change replaces ad-hoc schema building with a structured `schemaGen` type that handles both Swagger 2.0 and OpenAPI 3.0 specifications consistently.

## Key Changes

### Schema Generation (`swagger/schema.go`)
- **New `schemaGen` type**: Encapsulates version-aware schema generation with a reference prefix and collected model tracking
- **Deterministic output**: Replaced recursive model collection with an iterative approach that processes models in a stable order
- **Simplified API**: Consolidated multiple schema generation methods into `modelSchema()`, `structSchema()`, and `typeSchema()` with clear responsibilities
- **Proper type handling**: 
  - Correctly handles `time.Time` and `json.RawMessage` as special cases
  - Flattens embedded structs without explicit json names (matching `encoding/json` behavior)
  - Properly inlines anonymous struct types in maps/slices instead of creating dangling `$ref`s
  - Handles `[]byte` as base64-encoded strings

### Swagger 2.0 Generation (`swagger/swagger.go`)
- Extracted operation building into `buildV2Operation()` for clarity
- Replaced inline path/operation assignment with helper `setV2Operation()`
- Uses new `schemaGen` for consistent definition generation
- Improved scheme handling with sensible defaults

### OpenAPI 3.0 Generation (`swagger/openapi_v3.go`)
- Aligned with Swagger 2.0 refactoring for consistency
- Extracted `setV3Operation()` helper
- Removed redundant nested model collection logic
- Uses shared `schemaGen` for definition generation

### Validation & Conversion (`swagger/convert.go`)
- Refactored `parseValidationRules()` to be a standalone function (not a method)
- Simplified validation rule parsing with helper closures
- Cleaner handling of min/max constraints across different types

### Router Improvements (`swagger/router.go`)
- Fixed middleware registration to avoid redundant wrapping
- Simplified handler registration in `RegisterRoute()`

### Testing (`swagger/schema_test.go`)
- Added comprehensive tests for deterministic generation
- Tests for JSON dash field skipping
- Tests for embedded struct flattening
- Tests for special type handling (`[]byte`, `json.RawMessage`, maps of anonymous structs)

## Notable Implementation Details

- **Deterministic tag ordering**: Tags are now sorted alphabetically before emission, ensuring byte-identical output across multiple generations
- **Cyclic model safety**: The iterative definition building approach handles cyclic struct references without infinite loops
- **Version abstraction**: Reference prefix (`#/definitions/` vs `#/components/schemas/`) is abstracted via `getRefPrefix()`
- **Embedded struct semantics**: Properly implements Go's `encoding/json` flattening behavior for embedded types without explicit json names
- **Backward compatibility**: All existing route registration and swagger info APIs remain unchanged

The refactoring improves code maintainability while fixing subtle bugs in nested model handling and ensuring deterministic, reproducible spec generation.

https://claude.ai/code/session_01NJu1KVa6DP1DM9XcKPinhS