### PR TITLE
feat: new smart routing op - timerange.

### DIFF
--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -18,12 +18,12 @@ export interface ConfigProvider {
 
 export interface SmartOp {
     uuid: string;
-    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'tool_use' | 'token' | 'service_ttft' | 'service_capacity' | 'agent.claude_code';
+    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'tool_use' | 'token' | 'service_ttft' | 'service_capacity' | 'agent.claude_code' | 'time';
     operation: string;
     value: string;
     meta?: {
         description?: string;
-        type?: 'string' | 'int' | 'bool' | 'float';
+        type?: 'string' | 'int' | 'bool' | 'float' | 'time_range';
     };
 }
 

--- a/frontend/src/components/nodes/SmartOpNode.tsx
+++ b/frontend/src/components/nodes/SmartOpNode.tsx
@@ -15,6 +15,7 @@ import { alpha } from '@mui/material/styles';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { SmartRouting, SmartOp } from '../RoutingGraphTypes.ts';
+import { formatTimeRange } from '../rule-card/timeRange.ts';
 import {
     ActionButtonsBox,
     getRouteGraphActiveColor,
@@ -32,9 +33,13 @@ export interface SmartNodeProps {
     onMoveDown?: () => void;
 }
 
+const opValue = (op: SmartOp): string =>
+    op.meta?.type === 'time_range' ? formatTimeRange(op.value) || op.value : op.value;
+
 // Full tooltip text for a single op.
 const opTooltip = (op: SmartOp): string => {
-    const val = op.value ? `: ${op.value}` : '';
+    const value = opValue(op);
+    const val = value ? `: ${value}` : '';
     return `${op.position} · ${op.operation}${val}`;
 };
 
@@ -228,7 +233,6 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                                         · {op.operation}
                                     </Typography>
 
-                                    {/* value — primary, truncated */}
                                     {op.value && (
                                         <Typography
                                             component="span"
@@ -243,7 +247,7 @@ export const SmartOpNode: React.FC<SmartNodeProps> = ({
                                                 lineHeight: 1,
                                             }}
                                         >
-                                            : {op.value}
+                                            : {opValue(op)}
                                         </Typography>
                                     )}
                                 </Box>

--- a/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
@@ -24,11 +24,20 @@ import {
     Article as ArticleIcon,
     Speed as SpeedIcon,
     Bolt as BoltIcon,
+    Schedule as ScheduleIcon,
     HelpOutline as HelpOutlineIcon,
 } from '@/components/icons';
 import React, { useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type { SmartOp, SmartRouting } from '@/components/RoutingGraphTypes';
+import {
+    DEFAULT_TIME_RANGE,
+    formatTimeRange,
+    isValidTimeRange,
+    parseTimeRange,
+    serializeTimeRange,
+    timezoneOptions,
+} from './timeRange';
 
 interface PositionMeta {
     value: SmartOp['position'];
@@ -41,6 +50,7 @@ const POSITION_OPTIONS: PositionMeta[] = [
     { value: 'agent.claude_code', label: 'Agent: Claude Code', description: 'Claude Code request kind (main / subagent / compact)', category: 'agent' },
     { value: 'context_system', label: 'System Prompt', description: 'System prompt message in context', category: 'context' },
     { value: 'latest_user', label: 'Latest User Message', description: 'Latest user message', category: 'context' },
+    { value: 'time', label: 'Time range', description: 'Route requests during or outside a daily time range in the selected timezone.', category: 'time' },
     { value: 'thinking', label: 'Thinking', description: 'Thinking mode enabled / disable', category: 'request' },
     { value: 'token', label: 'Token Count', description: 'Token count', category: 'request' },
     { value: 'service_ttft', label: 'Service TTFT', description: 'Time to first token across services (ms)', category: 'service' },
@@ -55,7 +65,10 @@ const VALUE_OPTIONS: Record<string, Array<{ value: string; label: string }> | un
     ],
 };
 
-const OPERATION_OPTIONS: Record<string, Array<{ value: string; label: string; description: string; valueType: 'string' | 'int' | 'bool' }>> = {
+const OPERATION_OPTIONS: Record<string, Array<{ value: string; label: string; description: string; valueType: 'string' | 'int' | 'bool' | 'time_range' }>> = {
+    time: [
+        { value: 'time_range', label: 'Time range', description: 'Match requests during or outside a daily time range.', valueType: 'time_range' },
+    ],
     model: [
         { value: 'contains', label: 'Contains', description: 'Model name contains the value', valueType: 'string' },
         { value: 'equals', label: 'Equals', description: 'Model name equals the value', valueType: 'string' },
@@ -106,10 +119,11 @@ const CATEGORY_META: Record<string, CategoryMeta> = {
     agent: { label: 'Agent', icon: <AutoAwesomeIcon fontSize="small" /> },
     context: { label: 'Context', icon: <ArticleIcon fontSize="small" /> },
     request: { label: 'Request', icon: <BoltIcon fontSize="small" /> },
+    time: { label: 'Time', icon: <ScheduleIcon fontSize="small" /> },
     service: { label: 'Service', icon: <SpeedIcon fontSize="small" /> },
 };
 
-const CATEGORY_ORDER = ['agent', 'context', 'request', 'service'];
+const CATEGORY_ORDER = ['agent', 'context', 'request', 'time', 'service'];
 
 const positionMeta = (value: string): PositionMeta | undefined =>
     POSITION_OPTIONS.find((p) => p.value === value);
@@ -129,6 +143,7 @@ const formatNumberWithCommas = (value: string): string => {
 const isOpValid = (op: SmartOp): boolean => {
     if (!op.position || !op.operation) return false;
     if (op.meta?.type === 'bool') return true;
+    if (op.meta?.type === 'time_range') return isValidTimeRange(parseTimeRange(op.value));
     return !!op.value && op.value.trim() !== '';
 };
 
@@ -138,7 +153,8 @@ const opSummary = (op: SmartOp): string => {
     const posLabel = pos?.label || op.position;
     if (!op.operation) return posLabel;
     if (op.meta?.type === 'bool') return `${posLabel} · ${op.operation}`;
-    return `${posLabel} · ${op.operation}${op.value ? ` · ${op.value}` : ''}`;
+    const value = op.meta?.type === 'time_range' ? formatTimeRange(op.value) || 'Invalid schedule' : op.value;
+    return `${posLabel} · ${op.operation}${value ? ` · ${value}` : ''}`;
 };
 
 export interface SmartRuleCatalogDialogProps {
@@ -183,6 +199,9 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
         if (opOpts?.length === 1) {
             newOp.operation = opOpts[0].value;
             newOp.meta = { description: opOpts[0].description, type: opOpts[0].valueType };
+            if (opOpts[0].valueType === 'time_range') {
+                newOp.value = serializeTimeRange(DEFAULT_TIME_RANGE);
+            }
         }
         setOps((prev) => [...prev, newOp]);
     };
@@ -200,7 +219,7 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                     const opDef = OPERATION_OPTIONS[op.position]?.find((o) => o.value === updates.operation);
                     if (opDef) {
                         updated.meta = { description: opDef.description, type: opDef.valueType };
-                        updated.value = '';
+                        updated.value = opDef.valueType === 'time_range' ? serializeTimeRange(DEFAULT_TIME_RANGE) : '';
                     }
                 }
                 return updated;
@@ -225,6 +244,12 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
     };
 
     const allValid = ops.every(isOpValid);
+    const timezones = useMemo(timezoneOptions, []);
+
+    const updateTimeRange = (op: SmartOp, updates: Partial<typeof DEFAULT_TIME_RANGE>) => {
+        const range = parseTimeRange(op.value) || DEFAULT_TIME_RANGE;
+        updateOp(op.uuid, { value: serializeTimeRange({ ...range, ...updates }) });
+    };
 
     const countByCategory = useMemo(() => {
         const counts: Record<string, number> = {};
@@ -489,7 +514,38 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                                                                 )}
 
                                                                 {/* Value input */}
-                                                                {op.meta?.type !== 'bool' && op.operation && (
+                                                                {op.meta?.type === 'time_range' && op.operation && (() => {
+                                                                    const range = parseTimeRange(op.value) || DEFAULT_TIME_RANGE;
+                                                                    return (
+                                                                        <Stack spacing={1} sx={{ maxWidth: 440 }}>
+                                                                            <Stack direction="row" spacing={1}>
+                                                                                <FormControl size="small" fullWidth>
+                                                                                    <InputLabel>Apply</InputLabel>
+                                                                                    <Select
+                                                                                        value={range.outside ? 'outside' : 'during'}
+                                                                                        label="Apply"
+                                                                                        onChange={(e) => updateTimeRange(op, { outside: e.target.value === 'outside' })}
+                                                                                    >
+                                                                                        <MenuItem value="during">During this window</MenuItem>
+                                                                                        <MenuItem value="outside">Outside this window</MenuItem>
+                                                                                    </Select>
+                                                                                </FormControl>
+                                                                                <TextField size="small" label="Start" type="time" value={range.start} onChange={(e) => updateTimeRange(op, { start: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
+                                                                                <TextField size="small" label="End" type="time" value={range.end} onChange={(e) => updateTimeRange(op, { end: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
+                                                                            </Stack>
+                                                                            <FormControl size="small" fullWidth>
+                                                                                <InputLabel>Timezone</InputLabel>
+                                                                                <Select value={range.timezone} label="Timezone" onChange={(e) => updateTimeRange(op, { timezone: e.target.value })}>
+                                                                                    {timezones.map((timezone) => <MenuItem key={timezone} value={timezone}>{timezone}</MenuItem>)}
+                                                                                </Select>
+                                                                            </FormControl>
+                                                                            <Typography variant="caption" color="text.secondary">
+                                                                                Routing converts the current UTC time into this timezone. Start is included, end is excluded; overnight windows work.
+                                                                            </Typography>
+                                                                        </Stack>
+                                                                    );
+                                                                })()}
+                                                                {op.meta?.type !== 'bool' && op.meta?.type !== 'time_range' && op.operation && (
                                                                     VALUE_OPTIONS[op.position] ? (
                                                                         <FormControl size="small" sx={{ minWidth: 160 }}>
                                                                             <InputLabel>Value</InputLabel>

--- a/frontend/src/components/rule-card/timeRange.ts
+++ b/frontend/src/components/rule-card/timeRange.ts
@@ -1,0 +1,56 @@
+export interface TimeRangeValue {
+    start: string;
+    end: string;
+    timezone: string;
+    outside: boolean;
+}
+
+export const DEFAULT_TIME_RANGE: TimeRangeValue = {
+    start: '09:00',
+    end: '17:00',
+    timezone: 'UTC',
+    outside: false,
+};
+
+const isTimeOfDay = (value: string): boolean => /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+
+export const parseTimeRange = (value: string): TimeRangeValue | null => {
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (!parsed || typeof parsed !== 'object') return null;
+        const candidate = parsed as Partial<TimeRangeValue>;
+        if (
+            !isTimeOfDay(candidate.start ?? '') ||
+            !isTimeOfDay(candidate.end ?? '') ||
+            !candidate.timezone ||
+            typeof candidate.outside !== 'boolean'
+        ) {
+            return null;
+        }
+        return {
+            start: candidate.start!,
+            end: candidate.end!,
+            timezone: candidate.timezone!,
+            outside: candidate.outside,
+        };
+    } catch {
+        return null;
+    }
+};
+
+export const serializeTimeRange = (value: TimeRangeValue): string => JSON.stringify(value);
+
+export const isValidTimeRange = (value: TimeRangeValue | null): value is TimeRangeValue =>
+    value !== null && isTimeOfDay(value.start) && isTimeOfDay(value.end) && value.start !== value.end && !!value.timezone;
+
+export const formatTimeRange = (value: string): string | null => {
+    const range = parseTimeRange(value);
+    if (!range) return null;
+    return `${range.outside ? 'Outside' : 'During'} ${range.start}–${range.end} · ${range.timezone}`;
+};
+
+export const timezoneOptions = (): string[] => {
+    const supportedValuesOf = Intl.supportedValuesOf;
+    if (typeof supportedValuesOf !== 'function') return ['UTC'];
+    return ['UTC', ...supportedValuesOf('timeZone').filter((timezone) => timezone !== 'UTC')];
+};

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/auth"
 )
@@ -582,6 +583,9 @@ func (c *Config) AddRule(rule typ.Rule) error {
 	if err := c.validateRuleServices(rule); err != nil {
 		return err
 	}
+	if err := validateSmartRoutingRules(rule); err != nil {
+		return err
+	}
 
 	// Guard name unique within same scenario
 	for _, rc := range c.Rules {
@@ -610,6 +614,9 @@ func (c *Config) UpdateRule(uid string, rule typ.Rule) error {
 
 	// Validate that all service provider UUIDs exist
 	if err := c.validateRuleServices(rule); err != nil {
+		return err
+	}
+	if err := validateSmartRoutingRules(rule); err != nil {
 		return err
 	}
 
@@ -2309,6 +2316,24 @@ func (c *Config) hasMigrationCompleted(name string) bool {
 // markMigrationCompleted records a one-time migration as done so it is skipped on future startups.
 func (c *Config) markMigrationCompleted(name string) {
 	c.MigrationsCompleted = append(c.MigrationsCompleted, name)
+}
+
+// validateSmartRoutingRules rejects invalid configured predicates before saving a rule.
+// Empty smart-routing blocks are editor drafts: the frontend creates one before
+// the user adds conditions and services, so full rule validation remains in
+// Router construction when the rule can actually be evaluated.
+func validateSmartRoutingRules(rule typ.Rule) error {
+	if !rule.SmartEnabled {
+		return nil
+	}
+	for i := range rule.SmartRouting {
+		for j := range rule.SmartRouting[i].Ops {
+			if err := smartrouting.ValidateSmartOp(&rule.SmartRouting[i].Ops[j]); err != nil {
+				return fmt.Errorf("invalid smart routing rule[%d] op[%d]: %w", i, j, err)
+			}
+		}
+	}
+	return nil
 }
 
 // validateRuleServices checks that all provider UUIDs referenced by services exist

--- a/internal/smart_routing/op.go
+++ b/internal/smart_routing/op.go
@@ -4,6 +4,16 @@ package smartrouting
 // This registry defines all operations across all positions for documentation,
 // UI rendering, and future API integrations.
 var Operations = []SmartOp{
+	// Time operations
+	{
+		Position:  PositionTime,
+		Operation: OpTimeRange,
+		Meta: SmartOpMeta{
+			Description: "Current time is within a daily wall-clock interval",
+			Type:        ValueTypeTimeRange,
+		},
+	},
+
 	// Model operations
 	{
 		Position:  PositionModel,
@@ -245,9 +255,13 @@ const (
 	PositionServiceTTFT     SmartOpPosition = "service_ttft"      // Service TTFT characteristics
 	PositionServiceCapacity SmartOpPosition = "service_capacity"  // Service seat capacity (affinity utilization)
 	PositionAgentClaudeCode SmartOpPosition = "agent.claude_code" // Claude Code agent request kind (main / subagent / compact)
+	PositionTime            SmartOpPosition = "time"              // Current time in a configured timezone
 )
 
 const (
+	// Time operations
+	OpTimeRange SmartOpOperation = "time_range" // Daily wall-clock interval
+
 	// Model operations
 	OpModelContains SmartOpOperation = "contains" // Model name contains the value
 	OpModelGlob     SmartOpOperation = "glob"     // Model name matches glob pattern

--- a/internal/smart_routing/op.go
+++ b/internal/smart_routing/op.go
@@ -9,7 +9,7 @@ var Operations = []SmartOp{
 		Position:  PositionTime,
 		Operation: OpTimeRange,
 		Meta: SmartOpMeta{
-			Description: "Current time is within a daily wall-clock interval",
+			Description: "Current time is within a daily wall-clock interval [start, end) in a timezone (minute granularity)",
 			Type:        ValueTypeTimeRange,
 		},
 	},

--- a/internal/smart_routing/routing.go
+++ b/internal/smart_routing/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/gobwas/glob"
 
@@ -116,6 +117,8 @@ func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
 		return r.evaluateServiceCapacityOp(ctx, op)
 	case PositionAgentClaudeCode:
 		return r.evaluateAgentClaudeCodeOp(ctx, op)
+	case PositionTime:
+		return r.evaluateTimeRangeOp(op)
 	default:
 		res := newOpResult(op)
 		res.Reason = fmt.Sprintf("unknown position %q", op.Position)
@@ -132,6 +135,31 @@ func newOpResult(op *SmartOp) OpEvalResult {
 		Operation: string(op.Operation),
 		Value:     op.Value,
 	}
+}
+
+func (r *Router) evaluateTimeRangeOp(op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	if op.Operation != OpTimeRange {
+		res.Reason = fmt.Sprintf("unsupported time op %q", op.Operation)
+		return res
+	}
+
+	tr, err := parseTimeRange(op.Value)
+	if err != nil {
+		res.Reason = fmt.Sprintf("invalid time range: %v", err)
+		return res
+	}
+	utc := utcNow().UTC()
+	local := utc.In(tr.location)
+	inWindow := tr.includes(utc)
+	res.Matched = inWindow != tr.Outside
+	comparator := "during"
+	if tr.Outside {
+		comparator = "outside"
+	}
+	res.Actual = fmt.Sprintf("utc=%s local=%s timezone=%s", utc.Format(time.RFC3339), local.Format(time.RFC3339), tr.Timezone)
+	res.Reason = fmt.Sprintf("%s [%s, %s) in %s: %t", comparator, tr.Start, tr.End, tr.Timezone, res.Matched)
+	return res
 }
 
 // ValidateSmartRouting checks if the smart routing rule is valid
@@ -196,6 +224,9 @@ func validateOpValueType(op *SmartOp) error {
 		return err
 	case ValueTypeBool:
 		_, err := op.Bool()
+		return err
+	case ValueTypeTimeRange:
+		_, err := parseTimeRange(op.Value)
 		return err
 	default:
 		return fmt.Errorf("unknown type: %s", expectedType)

--- a/internal/smart_routing/time_range.go
+++ b/internal/smart_routing/time_range.go
@@ -1,0 +1,79 @@
+package smartrouting
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// utcNow is the router's sole clock source. Tests may replace it temporarily.
+var utcNow = func() time.Time { return time.Now().UTC() }
+
+type timeRange struct {
+	Start    string `json:"start"`
+	End      string `json:"end"`
+	Timezone string `json:"timezone"`
+	Outside  bool   `json:"outside"`
+
+	startMinute int
+	endMinute   int
+	location    *time.Location
+}
+
+func parseTimeRange(value string) (timeRange, error) {
+	decoder := json.NewDecoder(bytes.NewBufferString(value))
+	decoder.DisallowUnknownFields()
+
+	var tr timeRange
+	if err := decoder.Decode(&tr); err != nil {
+		return timeRange{}, fmt.Errorf("invalid time range JSON: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return timeRange{}, fmt.Errorf("invalid time range JSON: multiple values")
+		}
+		return timeRange{}, fmt.Errorf("invalid time range JSON: %w", err)
+	}
+	if tr.Start == "" || tr.End == "" || tr.Timezone == "" {
+		return timeRange{}, fmt.Errorf("start, end, and timezone are required")
+	}
+
+	var err error
+	if tr.startMinute, err = parseTimeOfDay(tr.Start); err != nil {
+		return timeRange{}, fmt.Errorf("invalid start: %w", err)
+	}
+	if tr.endMinute, err = parseTimeOfDay(tr.End); err != nil {
+		return timeRange{}, fmt.Errorf("invalid end: %w", err)
+	}
+	if tr.startMinute == tr.endMinute {
+		return timeRange{}, fmt.Errorf("start and end must differ")
+	}
+	tr.location, err = time.LoadLocation(tr.Timezone)
+	if err != nil {
+		return timeRange{}, fmt.Errorf("invalid timezone %q: %w", tr.Timezone, err)
+	}
+	return tr, nil
+}
+
+func parseTimeOfDay(value string) (int, error) {
+	if len(value) != len("00:00") || value[2] != ':' || value[0] < '0' || value[0] > '2' || value[1] < '0' || value[1] > '9' || value[3] < '0' || value[3] > '5' || value[4] < '0' || value[4] > '9' {
+		return 0, fmt.Errorf("must be strict HH:mm")
+	}
+	hour := int(value[0]-'0')*10 + int(value[1]-'0')
+	minute := int(value[3]-'0')*10 + int(value[4]-'0')
+	if hour > 23 {
+		return 0, fmt.Errorf("must be between 00:00 and 23:59")
+	}
+	return hour*60 + minute, nil
+}
+
+func (tr timeRange) includes(now time.Time) bool {
+	local := now.In(tr.location)
+	minute := local.Hour()*60 + local.Minute()
+	if tr.startMinute < tr.endMinute {
+		return minute >= tr.startMinute && minute < tr.endMinute
+	}
+	return minute >= tr.startMinute || minute < tr.endMinute
+}

--- a/internal/smart_routing/time_range_test.go
+++ b/internal/smart_routing/time_range_test.go
@@ -61,10 +61,14 @@ func TestEvaluateTimeRangeOp(t *testing.T) {
 	shanghai := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"09:00","end":"10:00","timezone":"Asia/Shanghai","outside":false}`}
 	require.True(t, r.evaluateTimeRangeOp(&shanghai).Matched)
 
-	// On DST fall-back, both 01:30 occurrences compare as the same wall-clock minute.
-	utcNow = func() time.Time { return time.Date(2026, 11, 1, 6, 30, 0, 0, time.UTC) }
+	// DST fall-back (US 2026-11-01): 02:00 EDT -> 01:00 EST at 06:00 UTC, so the
+	// wall-clock hour 01:00-02:00 occurs twice. 05:30 UTC is the first 01:30 (EDT),
+	// 06:30 UTC the second 01:30 (EST); wall-clock-minute comparison must match both.
 	newYork := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"01:00","end":"02:00","timezone":"America/New_York","outside":false}`}
-	require.True(t, r.evaluateTimeRangeOp(&newYork).Matched)
+	utcNow = func() time.Time { return time.Date(2026, 11, 1, 5, 30, 0, 0, time.UTC) }
+	require.True(t, r.evaluateTimeRangeOp(&newYork).Matched, "first 01:30 (EDT)")
+	utcNow = func() time.Time { return time.Date(2026, 11, 1, 6, 30, 0, 0, time.UTC) }
+	require.True(t, r.evaluateTimeRangeOp(&newYork).Matched, "second 01:30 (EST)")
 
 	invalid := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{}`}
 	res = r.evaluateTimeRangeOp(&invalid)

--- a/internal/smart_routing/time_range_test.go
+++ b/internal/smart_routing/time_range_test.go
@@ -1,0 +1,99 @@
+package smartrouting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func TestParseTimeRange(t *testing.T) {
+	valid := `{"start":"09:00","end":"17:00","timezone":"Asia/Shanghai","outside":false}`
+	tr, err := parseTimeRange(valid)
+	require.NoError(t, err)
+	require.Equal(t, 9*60, tr.startMinute)
+	require.Equal(t, 17*60, tr.endMinute)
+	require.Equal(t, "Asia/Shanghai", tr.location.String())
+
+	for _, value := range []string{
+		``, `[]`, `{"start":"9:00","end":"17:00","timezone":"UTC"}`,
+		`{"start":"24:00","end":"17:00","timezone":"UTC"}`,
+		`{"start":"09:00","end":"09:00","timezone":"UTC"}`,
+		`{"start":"09:00","end":"17:00","timezone":"Not/AZone"}`,
+		`{"start":"09:00","end":"17:00","timezone":"UTC","extra":true}`,
+		`{"start":"09:00","end":"17:00","timezone":"UTC"} {}`,
+	} {
+		_, err := parseTimeRange(value)
+		require.Error(t, err, value)
+	}
+
+	// outside is deliberately optional for manually-authored forward-compatible rules.
+	_, err = parseTimeRange(`{"start":"09:00","end":"17:00","timezone":"UTC"}`)
+	require.NoError(t, err)
+}
+
+func TestEvaluateTimeRangeOp(t *testing.T) {
+	original := utcNow
+	t.Cleanup(func() { utcNow = original })
+	utcNow = func() time.Time { return time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC) }
+
+	r := &Router{}
+	standard := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"09:00","end":"17:00","timezone":"UTC","outside":false}`}
+	res := r.evaluateTimeRangeOp(&standard)
+	require.True(t, res.Matched, res.Reason)
+	require.Contains(t, res.Actual, "utc=2026-07-10T09:00:00Z")
+	require.Contains(t, res.Actual, "timezone=UTC")
+
+	utcNow = func() time.Time { return time.Date(2026, 7, 10, 17, 0, 0, 0, time.UTC) }
+	require.False(t, r.evaluateTimeRangeOp(&standard).Matched, "end is exclusive")
+
+	outside := standard
+	outside.Value = `{"start":"09:00","end":"17:00","timezone":"UTC","outside":true}`
+	require.True(t, r.evaluateTimeRangeOp(&outside).Matched)
+
+	utcNow = func() time.Time { return time.Date(2026, 7, 10, 23, 0, 0, 0, time.UTC) }
+	overnight := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"22:00","end":"06:00","timezone":"UTC","outside":false}`}
+	require.True(t, r.evaluateTimeRangeOp(&overnight).Matched)
+
+	utcNow = func() time.Time { return time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC) }
+	shanghai := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"09:00","end":"10:00","timezone":"Asia/Shanghai","outside":false}`}
+	require.True(t, r.evaluateTimeRangeOp(&shanghai).Matched)
+
+	// On DST fall-back, both 01:30 occurrences compare as the same wall-clock minute.
+	utcNow = func() time.Time { return time.Date(2026, 11, 1, 6, 30, 0, 0, time.UTC) }
+	newYork := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"01:00","end":"02:00","timezone":"America/New_York","outside":false}`}
+	require.True(t, r.evaluateTimeRangeOp(&newYork).Matched)
+
+	invalid := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{}`}
+	res = r.evaluateTimeRangeOp(&invalid)
+	require.False(t, res.Matched)
+	require.Contains(t, res.Reason, "invalid time range")
+}
+
+func TestTimeRangeValidationAndRouting(t *testing.T) {
+	op := SmartOp{Position: PositionTime, Operation: OpTimeRange, Value: `{"start":"22:00","end":"06:00","timezone":"America/Los_Angeles","outside":false}`, Meta: SmartOpMeta{Type: ValueTypeString}}
+	require.NoError(t, ValidateSmartOp(&op), "metadata must not override catalog value type")
+
+	invalid := op
+	invalid.Value = `{"start":"22:00","end":"22:00","timezone":"UTC"}`
+	require.Error(t, ValidateSmartOp(&invalid))
+
+	original := utcNow
+	t.Cleanup(func() { utcNow = original })
+	utcNow = func() time.Time { return time.Date(2026, 7, 10, 6, 30, 0, 0, time.UTC) } // 23:30 PDT
+	router, err := NewRouter([]SmartRouting{{
+		Description: "night service",
+		Ops:         []SmartOp{op},
+		Services:    testServices(),
+	}})
+	require.NoError(t, err)
+	services, matched := router.EvaluateRequest(&RequestContext{})
+	require.True(t, matched)
+	require.Len(t, services, 1)
+}
+
+func testServices() []*loadbalance.Service {
+	return []*loadbalance.Service{{Provider: "night", Model: "model", Active: true}}
+}

--- a/internal/smart_routing/type.go
+++ b/internal/smart_routing/type.go
@@ -17,10 +17,11 @@ type SmartOpOperation string
 type SmartOpValueType string
 
 const (
-	ValueTypeString SmartOpValueType = "string" // String value
-	ValueTypeInt    SmartOpValueType = "int"    // Integer value
-	ValueTypeBool   SmartOpValueType = "bool"   // Boolean value
-	ValueTypeFloat  SmartOpValueType = "float"  // Float value
+	ValueTypeString    SmartOpValueType = "string"     // String value
+	ValueTypeInt       SmartOpValueType = "int"        // Integer value
+	ValueTypeBool      SmartOpValueType = "bool"       // Boolean value
+	ValueTypeFloat     SmartOpValueType = "float"      // Float value
+	ValueTypeTimeRange SmartOpValueType = "time_range" // Daily wall-clock interval in an IANA timezone
 )
 
 // SmartOpMeta contains metadata for a smart routing operation
@@ -73,7 +74,7 @@ type SmartRouting struct {
 func (p SmartOpPosition) IsValid() bool {
 	switch p {
 	case PositionModel, PositionThinking, PositionContextSystem, PositionContextUser, PositionLatestUser, PositionToolUse, PositionToken,
-		PositionServiceTTFT, PositionServiceCapacity, PositionAgentClaudeCode:
+		PositionServiceTTFT, PositionServiceCapacity, PositionAgentClaudeCode, PositionTime:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
Smart routing could match on request content (model, tokens, tools, agent kind) but had no way to
steer traffic by the clock — e.g. "use the daytime pool during business hours, fall back at night."

This adds a `time` position with a `time_range` op so operators can route by the current wall-clock
time in an IANA timezone, including overnight windows and DST transitions.

## Note
feature request from #1266 