### PR TITLE
fix(routing): run smart routing before affinity; scope pins per content partition (G3)

### DIFF
--- a/.design/loadbalance.pencil.md
+++ b/.design/loadbalance.pencil.md
@@ -29,22 +29,26 @@ funnels through the same path; there is exactly one production route.
   │  1 HealthStage        filter    drop 429/auth-unhealthy services                      │
   │       │               ┈┈► HealthMonitor        degrade: none healthy → keep all       │
   │       ▼                                                                               │
-  │  2 AffinityStage      terminal  honor session pin iff the strategy would pick it NOW  │
+  │  2 SmartRoutingStage  filter    first rule whose ops all match → narrow candidates    │
+  │       │               to the matched CONTENT PARTITION (runs before affinity so a     │
+  │       │               pin can never defeat content routing)                           │
+  │       │               ops read extracted RequestContext (model/tokens/agent-kind/…)   │
+  │       │               processor ops (proxy_vision) mutate req on EVERY request,       │
+  │       │               then bypass ↓ (candidates unchanged)                            │
+  │       ▼                                                                               │
+  │  3 AffinityStage      terminal  honor the PARTITION-SCOPED pin iff the strategy       │
+  │       │               would pick it now (key: session + matched partition idx)        │
   │       │               ┈┈► AffinityStore (strict TTL)                                  │
   │       │               ┈┈► typ.IsAffinityEligible: breaker walk + tier + PromotionHold │
   │       ▼                                                                               │
-  │  3 SmartRoutingStage  terminal  first rule whose ops all match → service subset       │
-  │       │               ops read extracted RequestContext (model/tokens/agent-kind/…)   │
-  │       │               processor ops (proxy_vision) mutate req, then BYPASS ↓ to 4     │
-  │       │               subset of >1 → LB *within* the subset (same engine as 4)        │
-  │       ▼                                                                               │
-  │  4 LoadBalancerStage  terminal  the global fallback — always selects (or errors)      │
+  │  4 LoadBalancerStage  terminal  always selects (or errors) within the narrowed set;   │
+  │       │               labeled smart_routing when a partition matched                  │
   │       └────────────► LoadBalancer.SelectService(rule│narrowed candidates)   see ②     │
   └───────────────────────────────────────────────────────────────────────────────────────┘
         │  validate pick: service active + provider resolvable + provider enabled
         │  (invalid → fall through to the next stage, not a hard error)
         ▼
-  postProcess: (re)pin session ━━► AffinityStore          (unless the pin itself won)
+  postProcess: (re)pin session in its partition ━━► AffinityStore   (unless the pin won)
         │
         ▼
   (provider, service) → prologue continues → dispatchWithPriorityFailover   see ③
@@ -112,13 +116,14 @@ Selection is stateless; all memory lives in three stores fed by dispatch outcome
   │        ┊                  │        ┊                   │        ┊                  │
   │        ┈┈► TierTactic     │        ┈┈► HealthStage (1) │        ┈┈► token/latency/ │
   │        ┈┈► IsAffinity-    │                            │            speed tactics  │
-  │            Eligible (2)   │                            │        ┈┈► smart ops      │
+  │            Eligible (3)   │                            │        ┈┈► smart ops      │
   │        ┈┈► horizontal     │                            │            (ttft/capacity)│
   │            pick (②)       │                            │                           │
   └───────────────────────────┴────────────────────────────┴───────────────────────────┘
 
-  AffinityStore (rule-scoped, session → service pin, strict TTL — no sliding renewal)
-     written by postProcess (①) · read by AffinityStage (2) · validity delegated to
+  AffinityStore (rule- and partition-scoped: session + matched smart partition →
+     service pin, strict TTL — no sliding renewal)
+     written by postProcess (①) · read by AffinityStage (3) · validity delegated to
      the breaker walk, so a pin never outlives what the strategy would pick.
 
   Failover (failover.pencil.md) closes the loop: a retryable attempt records ✗ for
@@ -155,8 +160,9 @@ Selection is stateless; all memory lives in three stores fed by dispatch outcome
   filter → pick → Allow-claim, degrade to unfiltered when nothing is available) for
   non-tier tactics; TierTactic shares the same helper per bucket. Regression:
   `TestLBScenario_B_Flat_DeadPeerExcludedAndSingleProbe`.
-- **G3 — affinity is global-scope**: pins are per rule, not per smart-routing subset
-  (`selector.go` TODO; the `smart_rule` scope plumbing exists but the store keying doesn't).
+- ~~**G3 — affinity is global-scope**~~ **RESOLVED**: smart routing runs before
+  affinity and pins are partition-scoped (`AffinitySessionKey`), so stickiness lives
+  inside the content decision. See tier-routing.md G3 for details.
 
 ## Map to code
 

--- a/.design/tier-routing.md
+++ b/.design/tier-routing.md
@@ -130,7 +130,7 @@ Notes:
 
 - `available` = breaker closed or half-open, read via the non-consuming `IsAvailable` (never steals the half-open probe).
 - On a drop, the strategy re-selects and `postProcess` re-pins — the failover layer is untouched.
-- The pipeline runs **health → affinity → strategy**. `HealthFilter` only sees 429/auth, so the 500 signal comes straight from the breaker.
+- The pipeline runs **health → smart → affinity → strategy** (smart routing decides the content partition first; affinity pins are scoped inside it). `HealthFilter` only sees 429/auth, so the 500 signal comes straight from the breaker.
 - The two "drop" cases (both are `P in T* and P available? → no`): **cross-tier demote** (a higher tier recovered, so P's tier is no longer T\*) and **within-tier dead peer** (P is in T\* but its own breaker is open while a peer is up).
 
 #### Two feedback channels, and the `lb` simulator
@@ -287,7 +287,7 @@ On a decline the pipeline falls through to the strategy, which re-selects a curr
 
 - **G1 — horizontal tactics are breaker-blind. RESOLVED.** `LoadBalancer.SelectService` now runs the same two-phase breaker walk for horizontal tactics (`typ.PickBreakerAvailable`): filter to breaker-available services (rule-scoped, non-consuming `IsAvailable`), pick within the subset, Allow-claim only the pick. A flat-shape dead peer is excluded at the selection layer and a recovering peer gets exactly one probe per open-window; when every healthy service is breaker-unavailable the pick degrades to the unfiltered set so the client sees the real upstream error. Pinned by `TestLBScenario_B_Flat_DeadPeerExcludedAndSingleProbe` (formerly the `t.Skip` known-gap marker).
 - **G2 — heterogeneous failover. RESOLVED.** Previously a fallback reused the already-transformed request body and was restricted to the same `Provider.APIStyle`. The transform is now re-run per attempt against a pristine request, so failover spans API styles and carries each tier's own model. See **Heterogeneous (cross-style) failover** below.
-- **G3 — affinity is global-scope.** Affinity runs before smart routing on the union of all the rule's services (`selector.go` TODO); per-smart-rule affinity scoping is not implemented.
+- **G3 — affinity is global-scope. RESOLVED.** The pipeline now runs smart routing BEFORE affinity: smart narrows the candidate set to the matched content partition, and pins are scoped per partition (`AffinitySessionKey`: session + matched smart-rule index). A first-request pin can no longer defeat content routing for the session TTL, and processor ops (proxy_vision) run on every request instead of being skipped for pinned sessions. Pinned by `TestSelect_ContentRoutingBeatsCrossPartitionPin` and `TestSelect_ProcessorRunsForPinnedSession`.
 
 ### Verifying shapes end-to-end
 

--- a/internal/constant/tracking_ctx.go
+++ b/internal/constant/tracking_ctx.go
@@ -14,6 +14,7 @@ const (
 	CtxKeyFirstTokenTime = "tracking_first_token_time" // time.Time (for TTFT calculation)
 	CtxKeyCacheHit       = "tracking_cache_hit"        // bool (cache hit status)
 	CtxKeySessionID      = "tracking_session_id"       // string (resolved session ID for affinity)
+	CtxKeyAffinityKey    = "tracking_affinity_key"     // string (scoped affinity store key: session + matched smart partition)
 	CtxKeyLBServiceID    = "tracking_lb_service_id"    // string (selected upstream, e.g. "provider-uuid:model")
 	CtxKeyLBTactic       = "tracking_lb_tactic"        // string (tactic name, e.g. "token_based")
 )

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -132,29 +132,36 @@ func NewServiceSelectorWithLogger(
 	}
 
 	newSmart := func() *SmartRoutingStage {
-		stage := NewSmartRoutingStage(lb, affinity)
+		stage := NewSmartRoutingStage(affinity)
 		if multiLogger != nil {
 			stage.SetMultiLogger(multiLogger)
 		}
 		return stage
 	}
 
-	// One pipeline serves every rule — order is health → affinity → strategy.
-	// Each stage self-guards, so there is no need for per-mode variants:
+	// One pipeline serves every rule — order is health → smart → affinity →
+	// strategy. Each stage self-guards, so there is no need for per-mode
+	// variants:
 	//   - Health  narrows the candidate set by 429/auth health; passes through
 	//     when no filter is set or filtering would empty the set (degrade).
+	//   - Smart   runs BEFORE affinity: it decides the content partition (and
+	//     always runs processor ops, which mutate the request) by narrowing
+	//     the candidate set to the matched subset. Running it after affinity
+	//     let a first-request pin defeat content routing for the whole
+	//     session TTL — and skip processor ops entirely for pinned sessions.
+	//     Passes through when smart routing is off or unmatched.
 	//   - Affinity returns nothing when affinity is disabled or there's no
-	//     session, so it is a no-op for non-affinity rules. It uses the global
-	//     (ruleUUID:sessionID) scope because it runs before smart routing, so
-	//     the matched-smart-rule index isn't available yet. The breaker-driven
-	//     (500) signal is consulted inside the affinity tier check and the
-	//     tier tactic; Health feeds it the 429/auth signal.
-	//   - Smart   passes through when smart routing is off or unmatched.
-	//   - LB      always selects (the terminal fallback).
+	//     session. Pins are scoped per matched partition (AffinitySessionKey),
+	//     so stickiness lives INSIDE the content decision, never above it.
+	//     The breaker-driven (500) signal is consulted inside the affinity
+	//     tier check and the tier tactic; Health feeds it the 429/auth signal.
+	//   - LB      always selects (the terminal fallback) within the narrowed
+	//     candidate set, labeling the result smart_routing when a partition
+	//     matched.
 	s.pipeline = []SelectionStage{
 		NewHealthStage(healthFilter),
-		NewAffinityStage(affinity, "global"),
 		newSmart(),
+		NewAffinityStage(affinity),
 		NewLoadBalancerStage(lb),
 	}
 
@@ -240,11 +247,14 @@ func (s *ServiceSelector) postProcess(ctx *SelectionContext, result *SelectionRe
 		// Affinity disabled (no rule value, no scenario value, no legacy bool)
 		return
 	}
-	s.affinityStore.Set(ctx.Rule.UUID, ctx.SessionID.String(), &AffinityEntry{
+	// Pin inside the partition this request was routed by, so one session can
+	// hold independent pins per request kind (see AffinitySessionKey).
+	affinityKey := AffinitySessionKey(ctx.SessionID.String(), ctx.MatchedSmartRuleIndex)
+	s.affinityStore.Set(ctx.Rule.UUID, affinityKey, &AffinityEntry{
 		Service:   result.Service,
 		LockedAt:  clock.Now(),
 		ExpiresAt: clock.Now().Add(ttl),
 	})
-	logrus.Infof("[affinity] locked service %s -> %s for session %s",
-		result.Provider.Name, result.Service.Model, ctx.SessionID.String())
+	logrus.Infof("[affinity] locked service %s -> %s for session key %s",
+		result.Provider.Name, result.Service.Model, affinityKey)
 }

--- a/internal/server/routing/selector_test.go
+++ b/internal/server/routing/selector_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
+
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
 )
 
 func TestSelect_NoAffinity_FallsToLoadBalancer(t *testing.T) {
@@ -173,7 +175,9 @@ func TestSelect_PostProcess_LocksAffinity(t *testing.T) {
 	require.Equal(t, "smart_routing", result.Source)
 	require.Len(t, store.sets, 1, "affinity should be locked after smart routing")
 	require.Equal(t, "rule-1", store.sets[0].ruleUUID)
-	require.Equal(t, testSessionKey("session-1"), store.sets[0].sessionID)
+	// The pin is scoped to the matched smart partition (index 0), so a
+	// request routed by a different partition cannot inherit it.
+	require.Equal(t, AffinitySessionKey(testSessionKey("session-1"), 0), store.sets[0].sessionID)
 }
 
 func TestSelect_PostProcess_LocksOnLoadBalancer(t *testing.T) {
@@ -261,13 +265,15 @@ func TestSelect_PipelineCaching(t *testing.T) {
 }
 
 func TestNewServiceSelector_PipelineOrder(t *testing.T) {
-	// One pipeline serves every rule: health → affinity → smart → load_balancer.
+	// One pipeline serves every rule: health → smart → affinity → load_balancer.
+	// Smart runs BEFORE affinity so content routing decides the partition and
+	// stickiness lives inside it (and processor ops always run).
 	sel := NewServiceSelector(&mockConfig{}, newMockAffinityStore(), &mockLoadBalancer{})
 
 	require.Len(t, sel.pipeline, 4)
-	require.Equal(t, "health", sel.pipeline[0].Name(), "health must run before affinity")
-	require.Equal(t, "affinity", sel.pipeline[1].Name())
-	require.Equal(t, "smart_routing", sel.pipeline[2].Name())
+	require.Equal(t, "health", sel.pipeline[0].Name(), "health must run first")
+	require.Equal(t, "smart_routing", sel.pipeline[1].Name(), "smart must run before affinity")
+	require.Equal(t, "affinity", sel.pipeline[2].Name())
 	require.Equal(t, "load_balancer", sel.pipeline[3].Name())
 }
 
@@ -304,3 +310,107 @@ func TestSelect_TierAffinity_RepinsToPrimaryAfterRecovery(t *testing.T) {
 
 // ErrNoService is a sentinel error for tests
 var ErrNoService = errors.New("no service available")
+
+// pickFirstLB is a LoadBalancer stub that picks the first active candidate —
+// it makes candidate-set narrowing observable end-to-end.
+type pickFirstLB struct{}
+
+func (p *pickFirstLB) SelectService(rule *typ.Rule) (*loadbalance.Service, error) {
+	active := rule.GetActiveServices()
+	if len(active) == 0 {
+		return nil, nil
+	}
+	return active[0], nil
+}
+
+// TestSelect_ProcessorRunsForPinnedSession pins the ordering fix: processor
+// ops (e.g. proxy_vision) mutate the request and MUST run on every request —
+// under the old affinity-before-smart order, a pinned session skipped the
+// smart stage entirely, so the mutation silently stopped happening after the
+// first request.
+func TestSelect_ProcessorRunsForPinnedSession(t *testing.T) {
+	called := 0
+	smartrouting.RegisterProcessor(bypassOpPosition, bypassOpEnabled,
+		processorFunc(func(_ *smartrouting.ProcessorContext) error {
+			called++
+			return nil
+		}))
+	t.Cleanup(func() { smartrouting.UnregisterProcessor(bypassOpPosition, bypassOpEnabled) })
+
+	svcTop := testService("provider-top", "gpt-4", true)
+	store := newMockAffinityStore()
+	cfg := &mockConfig{providers: map[string]*typ.Provider{
+		"provider-top": testProvider("provider-top", "Top", true),
+	}}
+	rule := testSmartRule("rule-pin-proc", "any-model", []*loadbalance.Service{svcTop}, bypassOp())
+	rule.Services = []*loadbalance.Service{svcTop}
+	rule.Flags.SessionAffinity = 3600
+
+	// The session is already pinned (bypass routes pin in the top-level
+	// partition, index -1).
+	store.Set("rule-pin-proc", AffinitySessionKey(testSessionKey("s1"), -1), testAffinityEntry(svcTop))
+
+	sel := NewServiceSelector(cfg, store, &pickFirstLB{})
+	ctx := testContext(rule, "s1")
+	ctx.Request = betaReqWithImage("describe")
+
+	result, err := sel.Select(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, called, "processor must run even though the session is pinned")
+	require.Equal(t, svcTop.ServiceID(), result.Service.ServiceID(), "pin still honored after processing")
+	require.Equal(t, SourceAffinity, result.Source)
+}
+
+// TestSelect_ContentRoutingBeatsCrossPartitionPin pins the other half of the
+// ordering fix: a pin created in one content partition must not capture
+// requests that match a different partition — under the old order the first
+// request's pin defeated content routing for the whole session TTL.
+func TestSelect_ContentRoutingBeatsCrossPartitionPin(t *testing.T) {
+	svcTop := testService("provider-top", "normal-model", true)
+	svcSub := testService("provider-sub", "special-model", true)
+	store := newMockAffinityStore()
+	cfg := &mockConfig{providers: map[string]*typ.Provider{
+		"provider-top": testProvider("provider-top", "Top", true),
+		"provider-sub": testProvider("provider-sub", "Sub", true),
+	}}
+
+	rule := testSmartRule("rule-partition", "any", []*loadbalance.Service{svcSub},
+		testModelContainsOp("special"))
+	rule.Services = []*loadbalance.Service{svcTop}
+	rule.Flags.SessionAffinity = 3600
+
+	sel := NewServiceSelector(cfg, store, &pickFirstLB{})
+
+	// Request 1: no smart match → top-level pool → pinned to svcTop (partition -1).
+	ctx := testContext(rule, "s1")
+	ctx.Request = testOpenAIRequest("normal-model")
+	result, err := sel.Select(ctx)
+	require.NoError(t, err)
+	require.Equal(t, svcTop.ServiceID(), result.Service.ServiceID())
+
+	// Request 2: matches the smart partition → MUST route to the subset, not
+	// the session's top-level pin.
+	ctx = testContext(rule, "s1")
+	ctx.Request = testOpenAIRequest("special-model")
+	result, err = sel.Select(ctx)
+	require.NoError(t, err)
+	require.Equal(t, svcSub.ServiceID(), result.Service.ServiceID(),
+		"content routing must beat the cross-partition pin")
+	require.Equal(t, SourceSmartRouting, result.Source)
+
+	// Request 3: same content → now sticks via the partition-scoped pin.
+	ctx = testContext(rule, "s1")
+	ctx.Request = testOpenAIRequest("special-model")
+	result, err = sel.Select(ctx)
+	require.NoError(t, err)
+	require.Equal(t, svcSub.ServiceID(), result.Service.ServiceID())
+	require.Equal(t, SourceAffinity, result.Source, "second matching request sticks within the partition")
+
+	// Request 4: non-matching content again → the top-level pin still holds.
+	ctx = testContext(rule, "s1")
+	ctx.Request = testOpenAIRequest("normal-model")
+	result, err = sel.Select(ctx)
+	require.NoError(t, err)
+	require.Equal(t, svcTop.ServiceID(), result.Service.ServiceID())
+	require.Equal(t, SourceAffinity, result.Source)
+}

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -70,6 +70,10 @@ func (s *SimpleSelector) SelectService(
 
 	// Automatically store sessionID in gin context for downstream handlers
 	c.Set(constant.CtxKeySessionID, ctx.SessionID.String())
+	// The scoped affinity key (session + matched smart partition) — consumers
+	// that write back to the affinity entry (e.g. message-id updates) must use
+	// this, not the bare session, or they'll miss partition-scoped pins.
+	c.Set(constant.CtxKeyAffinityKey, AffinitySessionKey(ctx.SessionID.String(), result.MatchedSmartRuleIndex))
 
 	// Store result metadata for observability
 	c.Set("routing_source", result.Source)

--- a/internal/server/routing/stage_affinity.go
+++ b/internal/server/routing/stage_affinity.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"strconv"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/clock"
@@ -9,17 +11,36 @@ import (
 
 // AffinityStage checks if a session has a locked service from previous requests.
 // If found and valid, returns the locked service; otherwise passes to next stage.
+//
+// It runs AFTER SmartRoutingStage, so pins are scoped to the content partition
+// smart routing matched (see AffinitySessionKey): a session pinned inside one
+// smart subset cannot drag requests that match a different subset — content
+// routing decides the partition, affinity provides stickiness within it.
 type AffinityStage struct {
 	store AffinityStore
-	scope string // "global" or "smart_rule"
 }
 
-// NewAffinityStage creates a new affinity stage with the given store and scope
-func NewAffinityStage(store AffinityStore, scope string) *AffinityStage {
-	return &AffinityStage{
-		store: store,
-		scope: scope,
+// NewAffinityStage creates a new affinity stage backed by the given store
+func NewAffinityStage(store AffinityStore) *AffinityStage {
+	return &AffinityStage{store: store}
+}
+
+// AffinitySessionKey returns the affinity-store session key scoped to the
+// content partition smart routing matched: the bare session for the rule's
+// top-level pool (no match, index -1), or session + "#sr<idx>" inside a smart
+// subset. Partition-scoping is what lets one session hold independent pins
+// per request kind (e.g. a Claude Code main pin and a subagent pin), each
+// with its own prompt-cache continuity.
+//
+// The partition identity is the smart rule's index, the only stable handle
+// the config offers. Editing the rule list can renumber partitions and
+// mis-bucket existing pins; pins are in-memory with short TTLs, so this
+// self-heals within one TTL.
+func AffinitySessionKey(sessionID string, matchedSmartRuleIndex int) string {
+	if matchedSmartRuleIndex < 0 {
+		return sessionID
 	}
+	return sessionID + "#sr" + strconv.Itoa(matchedSmartRuleIndex)
 }
 
 // Name returns the stage identifier
@@ -38,17 +59,9 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 		return nil, false
 	}
 
-	// For smart_rule scope, we need the matched rule index
-	// If we're evaluating affinity BEFORE smart routing, we can't use smart_rule scope
-	if s.scope == "smart_rule" && ctx.MatchedSmartRuleIndex < 0 {
-		// Smart routing hasn't run yet, can't check smart_rule-scoped affinity
-		return nil, false
-	}
-
-	// Check affinity store
-	// Currently AffinityStore only supports global scope (ruleUUID:sessionID)
-	// TODO: Extend AffinityStore to support smart_rule scope keys
-	entry, ok := s.store.Get(rule.UUID, ctx.SessionID.String())
+	// Look up the pin in the partition smart routing just matched (or the
+	// top-level partition when nothing matched).
+	entry, ok := s.store.Get(rule.UUID, AffinitySessionKey(ctx.SessionID.String(), ctx.MatchedSmartRuleIndex))
 	if !ok {
 		return nil, false
 	}

--- a/internal/server/routing/stage_affinity_test.go
+++ b/internal/server/routing/stage_affinity_test.go
@@ -34,7 +34,7 @@ func TestAffinity_LockedSession(t *testing.T) {
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -51,7 +51,7 @@ func TestAffinity_NoLock(t *testing.T) {
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -68,7 +68,7 @@ func TestAffinity_AffinityDisabled(t *testing.T) {
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 0 // disabled
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -86,7 +86,7 @@ func TestAffinity_SmartDisabled(t *testing.T) {
 	rule.SmartEnabled = false
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -103,28 +103,50 @@ func TestAffinity_EmptySession(t *testing.T) {
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "") // empty session
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled, "should pass when session is empty")
 }
 
-func TestAffinity_SmartRuleScope_NoIndex(t *testing.T) {
+// Pins are partition-scoped: a pin created in the top-level partition must
+// not be honored for a request that matched a smart subset (and vice versa) —
+// content routing decides the partition, affinity sticks within it.
+func TestAffinity_PartitionScoping(t *testing.T) {
 	store := newMockAffinityStore()
-	svc := testService("provider-a", "gpt-4", true)
-	store.Set("rule-1", testSessionKey("session-1"), testAffinityEntry(svc))
+	topSvc := testService("provider-top", "gpt-4", true)
+	subSvc := testService("provider-sub", "gpt-4", true)
 
 	rule := testRule("rule-1", "gpt-4", nil)
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "smart_rule")
-	ctx := testContext(rule, "session-1")
-	ctx.MatchedSmartRuleIndex = -1 // smart routing hasn't run yet
+	// Pin in the top-level partition (no smart match).
+	store.Set("rule-1", AffinitySessionKey(testSessionKey("session-1"), -1), testAffinityEntry(topSvc))
+	// Independent pin inside smart partition 1.
+	store.Set("rule-1", AffinitySessionKey(testSessionKey("session-1"), 1), testAffinityEntry(subSvc))
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when smart_rule scope but no index")
+	stage := NewAffinityStage(store)
+
+	// A request routed by smart partition 1 must see the subset pin.
+	ctx := testContext(rule, "session-1")
+	ctx.MatchedSmartRuleIndex = 1
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled)
+	require.Equal(t, "provider-sub", result.Service.Provider)
+
+	// A request with no smart match must see the top-level pin.
+	ctx = testContext(rule, "session-1")
+	result, handled = stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.True(t, handled)
+	require.Equal(t, "provider-top", result.Service.Provider)
+
+	// A request routed by a DIFFERENT partition must find no pin at all.
+	ctx = testContext(rule, "session-1")
+	ctx.MatchedSmartRuleIndex = 2
+	_, handled = stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled, "a pin must never leak across partitions")
 }
 
 // --- Tier-scoped affinity (breaker-aware) ---
@@ -139,7 +161,7 @@ func TestAffinity_TierScope_DeclinesStalePinWhenPrimaryHealthy(t *testing.T) {
 	store.Set("rule-tier-a", testSessionKey("s1"), testAffinityEntry(t1))
 
 	rule := tierRule("rule-tier-a", "m", []*loadbalance.Service{t0, t1})
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -163,7 +185,7 @@ func TestAffinity_TierScope_HonorsPinWhilePrimaryDown(t *testing.T) {
 	}
 	defer bs.RecordSuccess("rule-tier-b", t0.ServiceID())
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -187,7 +209,7 @@ func TestAffinity_TierScope_DeclinesWhenPinnedBreakerOpen(t *testing.T) {
 	}
 	defer bs.RecordSuccess("rule-tier-c", t1.ServiceID())
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -204,7 +226,7 @@ func TestAffinity_TierScope_WithinTierStickinessPreserved(t *testing.T) {
 	store.Set("rule-tier-d", testSessionKey("s1"), testAffinityEntry(b))
 
 	rule := tierRule("rule-tier-d", "m", []*loadbalance.Service{a, b})
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -232,7 +254,7 @@ func TestAffinity_HorizontalRule_DropsPinToDeadPeer(t *testing.T) {
 	}
 	defer bs.RecordSuccess("rule-horiz", a.ServiceID())
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -241,20 +263,22 @@ func TestAffinity_HorizontalRule_DropsPinToDeadPeer(t *testing.T) {
 }
 
 func TestAffinity_Name(t *testing.T) {
-	stage := NewAffinityStage(newMockAffinityStore(), "global")
+	stage := NewAffinityStage(newMockAffinityStore())
 	require.Equal(t, "affinity", stage.Name())
 }
 
 func TestAffinity_MatchedSmartRuleIndex_Propagated(t *testing.T) {
 	store := newMockAffinityStore()
 	svc := testService("provider-a", "gpt-4", true)
-	store.Set("rule-1", testSessionKey("session-1"), testAffinityEntry(svc))
 
 	rule := testRule("rule-1", "gpt-4", nil)
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "smart_rule")
+	// The pin lives in partition 2's bucket, matching the request's route.
+	store.Set("rule-1", AffinitySessionKey(testSessionKey("session-1"), 2), testAffinityEntry(svc))
+
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 	ctx.MatchedSmartRuleIndex = 2
 
@@ -292,7 +316,7 @@ func TestAffinity_MultipleSessions(t *testing.T) {
 	rule.SmartEnabled = true
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 
 	// Session A should get provider A
 	ctxA := testContext(rule, "session-a")
@@ -326,7 +350,7 @@ func TestAffinity_StrictTTL_Expired(t *testing.T) {
 	rule := testRule("rule-ttl", "gpt-4", nil)
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
@@ -350,7 +374,7 @@ func TestAffinity_StrictTTL_NotExpired(t *testing.T) {
 	rule := testRule("rule-ttl", "gpt-4", nil)
 	rule.Flags.SessionAffinity = 3600
 
-	stage := NewAffinityStage(store, "global")
+	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))

--- a/internal/server/routing/stage_load_balancer.go
+++ b/internal/server/routing/stage_load_balancer.go
@@ -43,7 +43,15 @@ func (s *LoadBalancerStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		return nil, false
 	}
 
-	result := NewResult(service, SourceLoadBalancer)
+	// When a smart partition matched, the candidate set IS that partition, so
+	// label the pick smart_routing — preserving the pre-reorder observability
+	// contract (source=smart_routing ⇒ picked from a smart-matched subset).
+	source := SourceLoadBalancer
+	if ctx.MatchedSmartRuleIndex >= 0 {
+		source = SourceSmartRouting
+	}
+	result := NewResult(service, source)
+	result.MatchedSmartRuleIndex = ctx.MatchedSmartRuleIndex
 	return result, true
 }
 

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -15,17 +15,13 @@ import (
 // SmartRoutingStage evaluates smart routing rules and returns matched services.
 // If multiple services match, applies load balancing within the matched set.
 type SmartRoutingStage struct {
-	loadBalancer  LoadBalancer
 	affinityStore AffinityStore
 	multiLogger   *pkgobs.MultiLogger // optional; used to emit structured smart-routing logs
 }
 
 // NewSmartRoutingStage creates a new smart routing stage
-func NewSmartRoutingStage(lb LoadBalancer, affinity AffinityStore) *SmartRoutingStage {
-	return &SmartRoutingStage{
-		loadBalancer:  lb,
-		affinityStore: affinity,
-	}
+func NewSmartRoutingStage(affinity AffinityStore) *SmartRoutingStage {
+	return &SmartRoutingStage{affinityStore: affinity}
 }
 
 // SetMultiLogger attaches the multi-logger so the stage can emit structured
@@ -218,11 +214,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		return nil, false
 	}
 
-	ctx.MatchedSmartRuleIndex = matchedRuleIndex
-
-	logrus.Debugf("[smart_routing] rule %d matched, selecting from %d services",
-		matchedRuleIndex, len(matchedServices))
-
 	// Filter active services
 	activeServices := FilterActiveServices(matchedServices)
 	if len(activeServices) == 0 {
@@ -232,28 +223,18 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		return nil, false
 	}
 
-	// Single service? Return it directly
-	if len(activeServices) == 1 {
-		result := NewResult(activeServices[0], SourceSmartRouting)
-		result.MatchedSmartRuleIndex = matchedRuleIndex
-		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
-			activeServices[0], "selected", "single active service in matched set")
-		return result, true
-	}
-
-	// Multiple services: apply load balancing within matched set
-	service := s.selectFromServices(activeServices, rule)
-	if service == nil {
-		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
-			nil, "lb_failed", "load balancer returned no service")
-		return nil, false
-	}
-
-	result := NewResult(service, SourceSmartRouting)
-	result.MatchedSmartRuleIndex = matchedRuleIndex
+	// Narrow the candidate set to the matched partition — this stage decides
+	// WHERE to route (the content partition); AffinityStage then applies
+	// per-partition stickiness and LoadBalancerStage picks WITHIN it. Smart
+	// routing used to terminal-select here, but that ran after affinity, so a
+	// first-request pin could defeat content routing for the whole session
+	// TTL and skip processor ops entirely for pinned sessions.
+	ctx.MatchedSmartRuleIndex = matchedRuleIndex
+	logrus.Debugf("[smart_routing] rule %d matched, narrowing candidates to %d services",
+		matchedRuleIndex, len(activeServices))
 	s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
-		service, "selected", "load balanced within matched set")
-	return result, true
+		nil, "matched", "candidates narrowed to the matched subset")
+	return NewFilterResult(SourceSmartRouting, activeServices), false
 }
 
 // runOpProcessors runs the registered op-level processors of the matched rule
@@ -304,28 +285,6 @@ func (s *SmartRoutingStage) runOpProcessors(
 	}
 	ctx.BypassedSmartRules[matchedRuleIndex] = struct{}{}
 	return true
-}
-
-// selectFromServices applies load balancing to select one service from the matched set
-func (s *SmartRoutingStage) selectFromServices(services []*loadbalance.Service, rule *typ.Rule) *loadbalance.Service {
-	if len(services) == 0 {
-		return nil
-	}
-
-	if len(services) == 1 {
-		return services[0]
-	}
-
-	// Create a temporary rule with only the matched services for load balancing
-	tempRule := *rule // Copy the rule
-	tempRule.Services = services
-
-	service, err := s.loadBalancer.SelectService(&tempRule)
-	if err != nil {
-		logrus.Debugf("[smart_routing] load balancer selection failed: %v", err)
-		return nil
-	}
-	return service
 }
 
 // collectAllCapacityInfo collects seat-capacity info for all services across all smart routing rules.

--- a/internal/server/routing/stage_smart_routing_processor_test.go
+++ b/internal/server/routing/stage_smart_routing_processor_test.go
@@ -118,26 +118,29 @@ func TestSmartRoutingStage_ProcessorBypass_RunsProcessorAndContinues(t *testing.
 	ctx := testContext(rule, "")
 	ctx.Request = betaReqWithImage("describe")
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{service: services[0]}, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 
 	require.False(t, handled, "stage must not terminate when a processor is present (implicit bypass)")
 	require.Equal(t, 1, called, "registered processor must be invoked")
 }
 
-func TestSmartRoutingStage_NoProcessor_TerminalSelectionUnchanged(t *testing.T) {
-	// Rules without processor-bearing ops keep current terminal behavior.
+func TestSmartRoutingStage_NoProcessor_NarrowsCandidates(t *testing.T) {
+	// Rules without processor-bearing ops narrow the candidate set to the
+	// matched subset (a filter — affinity/LB then run within it).
 	services := []*loadbalance.Service{testService("provider-a", "gpt-4", true)}
 	rule := testSmartRule("rule-1", "gpt-4", services, testModelContainsOp("gpt"))
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{service: services[0]}, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 
-	require.True(t, handled, "no processor → terminal selection")
+	require.False(t, handled, "no processor → narrow, never terminate")
 	require.NotNil(t, result)
-	require.Equal(t, "gpt-4", result.Service.Model)
+	require.Len(t, result.FilteredServices, 1)
+	require.Equal(t, "gpt-4", result.FilteredServices[0].Model)
+	require.Equal(t, 0, ctx.MatchedSmartRuleIndex)
 }
 
 func TestSmartRoutingStage_BypassedRule_NotReentered(t *testing.T) {
@@ -158,7 +161,7 @@ func TestSmartRoutingStage_BypassedRule_NotReentered(t *testing.T) {
 	// Pre-mark rule 0 as already bypassed.
 	ctx.BypassedSmartRules = map[int]struct{}{0: {}}
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{service: services[0]}, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 
 	require.False(t, handled, "stage must not terminate; pipeline continues")
@@ -193,7 +196,7 @@ func TestSmartRoutingStage_ProcessorMutatesRequest_LoadBalancerSeesMutation(t *t
 	ctx := testContext(rule, "")
 	ctx.Request = betaReqWithImage("describe")
 
-	smart := NewSmartRoutingStage(&mockLoadBalancer{service: services[0]}, newMockAffinityStore())
+	smart := NewSmartRoutingStage(newMockAffinityStore())
 	rec := &recordingStage{name: "recording", result: NewResult(services[0], "recording"), handled: true}
 
 	_, idx, evaluated := runStagePipeline(t, []SelectionStage{smart, rec}, ctx, newSelectionState(ctx.Rule))

--- a/internal/server/routing/stage_smart_routing_test.go
+++ b/internal/server/routing/stage_smart_routing_test.go
@@ -46,53 +46,54 @@ func betaRequestWithToolResult(keyword string) *anthropic.BetaMessageNewParams {
 }
 
 func TestSmartRouting_RuleMatch(t *testing.T) {
-	lb := &mockLoadBalancer{service: testService("provider-a", "gpt-4", true)}
 	services := []*loadbalance.Service{testService("provider-a", "gpt-4", true)}
 
 	rule := testSmartRule("rule-1", "gpt-4", services, testModelContainsOp("gpt"))
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	// A match is a FILTER, not a terminal selection: the stage narrows the
+	// candidate set to the matched subset so affinity/LB run within it.
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
+	require.False(t, handled, "smart routing narrows candidates; it does not select")
 	require.NotNil(t, result)
-	require.Equal(t, "gpt-4", result.Service.Model)
 	require.Equal(t, "smart_routing", result.Source)
-	require.Equal(t, 0, result.MatchedSmartRuleIndex)
+	require.Len(t, result.FilteredServices, 1)
+	require.Equal(t, "gpt-4", result.FilteredServices[0].Model)
+	require.Equal(t, 0, ctx.MatchedSmartRuleIndex)
 }
 
 func TestSmartRouting_NoMatch(t *testing.T) {
-	lb := &mockLoadBalancer{}
 	services := []*loadbalance.Service{testService("provider-a", "gpt-4", true)}
 
 	rule := testSmartRule("rule-1", "gpt-4", services, testModelContainsOp("claude"))
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled, "should pass when rule doesn't match")
+	require.Nil(t, result, "no match must not narrow the candidate set")
+	require.Equal(t, -1, ctx.MatchedSmartRuleIndex)
 }
 
 func TestSmartRouting_Disabled(t *testing.T) {
-	lb := &mockLoadBalancer{}
 	rule := testRule("rule-1", "gpt-4", nil)
 	// SmartEnabled is false by default
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	ctx := testContext(rule, "")
 	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
 	require.False(t, handled)
 }
 
 func TestSmartRouting_EmptyRules(t *testing.T) {
-	lb := &mockLoadBalancer{}
 	rule := testRule("rule-1", "gpt-4", nil)
 	rule.SmartEnabled = true
 	rule.SmartRouting = []smartrouting.SmartRouting{} // empty
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4")
 
@@ -101,11 +102,10 @@ func TestSmartRouting_EmptyRules(t *testing.T) {
 }
 
 func TestSmartRouting_NilRequest(t *testing.T) {
-	lb := &mockLoadBalancer{}
 	rule := testRule("rule-1", "gpt-4", nil)
 	rule.SmartEnabled = true
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	ctx := testContext(rule, "")
 	ctx.Request = nil
 
@@ -114,34 +114,19 @@ func TestSmartRouting_NilRequest(t *testing.T) {
 }
 
 func TestSmartRouting_InactiveServiceFiltered(t *testing.T) {
-	lb := &mockLoadBalancer{}
 	services := []*loadbalance.Service{testService("provider-a", "gpt-4", false)} // inactive
 
 	rule := testSmartRule("rule-1", "gpt-4", services, testModelContainsOp("gpt"))
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when matched service is inactive")
-}
-
-func TestSmartRouting_SingleService(t *testing.T) {
-	lb := &mockLoadBalancer{} // should NOT be called for single service
-	services := []*loadbalance.Service{testService("provider-a", "gpt-4", true)}
-
-	rule := testSmartRule("rule-1", "gpt-4", services, testModelContainsOp("gpt"))
-	ctx := testContext(rule, "")
-	ctx.Request = testOpenAIRequest("gpt-4o")
-
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
-	require.Equal(t, "provider-a", result.Service.Provider)
+	require.False(t, handled, "should pass when matched service is inactive")
+	require.Nil(t, result, "an all-inactive subset must not narrow the candidate set")
 }
 
-func TestSmartRouting_MultipleServices_LB(t *testing.T) {
-	lb := &mockLoadBalancer{service: testService("provider-b", "gpt-4", true)}
+func TestSmartRouting_MultipleServices_Narrowed(t *testing.T) {
 	services := []*loadbalance.Service{
 		testService("provider-a", "gpt-4", true),
 		testService("provider-b", "gpt-4", true),
@@ -151,15 +136,14 @@ func TestSmartRouting_MultipleServices_LB(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	// The full matched subset is handed downstream; the LB stage picks within it.
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
-	require.Equal(t, "provider-b", result.Service.Provider, "should use LB-selected service")
+	require.False(t, handled)
+	require.Len(t, result.FilteredServices, 2)
 }
 
 func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
-	lb := &mockLoadBalancer{}
-
 	// Rule 0: matches claude, Rule 1: matches gpt
 	servicesA := []*loadbalance.Service{testService("provider-a", "claude-3", true)}
 	servicesB := []*loadbalance.Service{testService("provider-b", "gpt-4", true)}
@@ -174,15 +158,16 @@ func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	stage := NewSmartRoutingStage(lb, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
-	require.Equal(t, "provider-b", result.Service.Provider)
-	require.Equal(t, 1, result.MatchedSmartRuleIndex, "second rule should match")
+	require.False(t, handled)
+	require.Len(t, result.FilteredServices, 1)
+	require.Equal(t, "provider-b", result.FilteredServices[0].Provider)
+	require.Equal(t, 1, ctx.MatchedSmartRuleIndex, "second rule should match")
 }
 
 func TestSmartRouting_Name(t *testing.T) {
-	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	require.Equal(t, "smart_routing", stage.Name())
 }
 
@@ -223,10 +208,12 @@ func TestSmartRouting_AgentClaudeCode_SubagentRoutesToCheapPool(t *testing.T) {
 	ctx.Scenario = typ.ScenarioClaudeCode
 	ctx.Request = subagentReq
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "subagent request should match")
-	require.Equal(t, "provider-cheap", result.Service.Provider)
+	require.False(t, handled)
+	require.NotNil(t, result, "subagent request should match and narrow candidates")
+	require.Len(t, result.FilteredServices, 1)
+	require.Equal(t, "provider-cheap", result.FilteredServices[0].Provider)
 }
 
 func TestSmartRouting_AgentClaudeCode_MainDoesNotMatchSubagentRule(t *testing.T) {
@@ -264,9 +251,10 @@ func TestSmartRouting_AgentClaudeCode_MainDoesNotMatchSubagentRule(t *testing.T)
 	ctx.Scenario = typ.ScenarioClaudeCode
 	ctx.Request = mainReq
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "main-agent request should not match subagent-only rule")
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled)
+	require.Nil(t, result, "main-agent request should not match subagent-only rule")
 }
 
 // TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch is the stage-level
@@ -290,9 +278,10 @@ func TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = betaRequestWithToolResult("keyword")
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled,
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled)
+	require.Nil(t, result,
 		"tool_result as last user message must not match latest_user contains rule")
 }
 
@@ -339,10 +328,11 @@ func TestSmartRouting_LatestUser_TextMatchesAfterToolResult(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = req
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
+	stage := NewSmartRoutingStage(newMockAffinityStore())
 	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "real user text with keyword must match")
-	require.Equal(t, "provider-special", result.Service.Provider)
+	require.False(t, handled)
+	require.NotNil(t, result, "real user text with keyword must match")
+	require.Equal(t, "provider-special", result.FilteredServices[0].Provider)
 }
 
 func TestSmartRouting_AgentClaudeCode_NonClaudeCodeScenarioDoesNotMatch(t *testing.T) {
@@ -371,7 +361,8 @@ func TestSmartRouting_AgentClaudeCode_NonClaudeCodeScenarioDoesNotMatch(t *testi
 	ctx.Scenario = typ.ScenarioOpenAI
 	ctx.Request = testOpenAIRequest("gpt-4")
 
-	stage := NewSmartRoutingStage(&mockLoadBalancer{}, newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "non-claude_code scenarios should not satisfy agent.claude_code ops")
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	require.False(t, handled)
+	require.Nil(t, result, "non-claude_code scenarios should not satisfy agent.claude_code ops")
 }

--- a/internal/server/server_affinity.go
+++ b/internal/server/server_affinity.go
@@ -13,11 +13,16 @@ func (s *Server) updateAffinityMessageID(c *gin.Context, rule *typ.Rule, message
 		return
 	}
 
-	sessionID, exists := c.Get(ContextKeySessionID)
+	// Use the partition-scoped affinity key set at selection time; fall back
+	// to the bare session for callers that predate the scoped keys.
+	key, exists := c.Get(ContextKeyAffinityKey)
 	if !exists {
-		return
+		key, exists = c.Get(ContextKeySessionID)
+		if !exists {
+			return
+		}
 	}
 
-	s.affinityStore.UpdateMessageID(rule.UUID, sessionID.(string), messageID)
-	logrus.Debugf("[affinity] updated message ID %s for session %s, rule %s", messageID, sessionID.(string), rule.UUID)
+	s.affinityStore.UpdateMessageID(rule.UUID, key.(string), messageID)
+	logrus.Debugf("[affinity] updated message ID %s for affinity key %s, rule %s", messageID, key.(string), rule.UUID)
 }

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -24,6 +24,7 @@ const (
 	ContextKeyFirstTokenTime = constant.CtxKeyFirstTokenTime
 	ContextKeyCacheHit       = constant.CtxKeyCacheHit
 	ContextKeySessionID      = constant.CtxKeySessionID
+	ContextKeyAffinityKey    = constant.CtxKeyAffinityKey
 	ContextKeyLBServiceID    = constant.CtxKeyLBServiceID
 	ContextKeyLBTactic       = constant.CtxKeyLBTactic
 )


### PR DESCRIPTION
## Summary

Third of three follow-up PRs (stacked on the cleanup/refactor PR).

Resolves known gap G3 and a correctness bug it was hiding. The pipeline ran health → affinity → smart → LB, so a session pin — checked only for candidate membership and breaker eligibility, never against content — terminated selection before smart routing could run. Two consequences:

- Processor ops were silently skipped for pinned sessions: a `proxy_vision` smart op mutates image blocks into text descriptions, but once the first request pinned the session, the smart stage never ran again and raw image blocks reached text-only upstreams (a non-retryable 400 failover cannot mask).
- Content routing was defeated by the first request's pin for the whole session TTL, in both directions: a main-agent request dragged onto the subagent subset's cheap provider, or a ≥1M-token request held on a small-context provider (upstream 400/413).

**New order: health → smart → affinity → LB.**

- `SmartRoutingStage` becomes a **filter**: it narrows the candidate set to the matched content partition (and always runs processor ops); the LB stage picks within the subset, labeled `smart_routing` when a partition matched — preserving the observability contract. The stage's own LB-within-subset duplicate is gone.
- Affinity pins are **partition-scoped** (`AffinitySessionKey`: session + matched smart-rule index, -1 = top-level pool). One session now holds independent pins per request kind — a Claude Code main pin and a subagent pin each keep their own prompt-cache continuity, which is strictly better than the old single cross-kind pin (different request kinds never shared cache prefixes anyway). The half-built `smart_rule` scope parameter on `AffinityStage` is replaced by this.
- The scoped key is exposed via gin context (`CtxKeyAffinityKey`) so the message-id write-back finds partition-scoped entries.

Partition identity is the smart rule's index (the only stable handle in config); editing the rule list can renumber partitions and mis-bucket in-memory pins, which self-heals within one TTL.

## Testing

Pinned by `TestSelect_ProcessorRunsForPinnedSession` and `TestSelect_ContentRoutingBeatsCrossPartitionPin` (end-to-end through the pipeline), plus `TestAffinity_PartitionScoping`; stage tests rewritten to the filter contract. Design docs updated (G3 marked resolved, pipeline diagrams reordered).

Full suites (`server`/`servertest` incl. e2e/`typ`/`loadbalance`/`routing`/`config`/`protocoltest`/`visionproxy`) and all 13 `harness lb` scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ES9RicqC6J8GXJ91NVcFuA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ES9RicqC6J8GXJ91NVcFuA)_