### PR TITLE
feat(harness): dual-process duo — per-instance memory observation + backpressure routes

### DIFF
--- a/.design/harness-duo.md
+++ b/.design/harness-duo.md
@@ -1,0 +1,159 @@
+# Harness Duo — two-process memory & protocol verification
+
+> For contributors working with `internal/protocoltest/duo*.go`,
+> `cli/harness/duo.go`, the `/api/v1/debug` diagnostics module, or anyone
+> investigating a gateway memory leak / OOM report.
+>
+> Related: the protocol-transform matrix (Tier A) lives in
+> [`harness-matrix.md`](./harness-matrix.md); the load-balancing simulator
+> (Tier LB) in [`tier-routing.md`](./tier-routing.md).
+
+---
+
+## 1. Why duo exists
+
+Duo was born from the #1255 OOM investigation: Claude-Code-shaped traffic
+(multi-MB conversation per turn, streaming) leaked ~823 KB **per request**
+inside the gateway's conversion path. Reproducing that class of bug needs
+three things a unit test doesn't give you:
+
+1. **The real pipeline end-to-end** — routing, transform, client pool,
+   transports, real HTTP between gateway and upstream.
+2. **A leak signal that separates retention from churn** — allocation volume
+   is huge and healthy; what matters is the **post-GC retention slope**
+   across request batches.
+3. **Attribution** — tingly-box appears on *both* sides of a deployment
+   (gateway, and upstream-ish serving surfaces). "The process grew" is not a
+   diagnosis; *which role leaked* is.
+
+## 2. Topology
+
+```
+                 harness (parent process — drives requests, never measured)
+                    │
+                    │ Anthropic v1/beta stream          per-instance sampling
+                    ▼                                   /api/v1/debug/{memstats,pprof/heap}
+   ┌──────────────────────────────┐    real HTTP    ┌──────────────────────────────┐
+   │  tb2  (gateway under test)   ├────────────────▶│  tb1  (vmodel upstream)      │
+   │  own process, server.Start() │                 │  own process, server.Start() │
+   └──────────────────────────────┘                 └──────────────────────────────┘
+```
+
+Design decisions, and why:
+
+- **Two real processes, not two in-process httptest servers.** A shared Go
+  heap makes per-instance attribution impossible (both instances run the same
+  code, so even heap-profile stacks can't always tell them apart) and lets
+  the harness client's own allocations pollute the numbers. Separate
+  processes give each instance its own runtime: tb2's slope is the
+  gateway/conversion verdict, tb1's slope is the vmodel-serving verdict, and
+  the parent is never measured.
+
+- **Full `server.Start()`, not `GetRouter()` + httptest.** Children boot the
+  production lifecycle: token refreshers, quota auto-refresh, config watcher,
+  remote-coder autostart, and the production `http.Server` timeouts. Leaks in
+  or interacting with those components are on the measured path.
+
+- **Re-execution instead of a separate server binary.** The parent spawns
+  `os.Executable()` with the `TINGLY_DUO_*` env contract;
+  `MaybeRunDuoServe()` (called first thing in `cli/harness` `main()` and in
+  `duo_test.go`'s `TestMain`) intercepts and runs the server, never
+  returning. The same mechanism therefore works for the CLI binary *and* the
+  `go test` binary — CI needs no extra build step.
+
+- **Children self-seed their own config dirs.** tb2 receives tb1's URL/token
+  via env and writes its own providers + rules at boot. The parent never
+  opens an instance's SQLite store (no cross-process DB access); its only
+  reads are each child's `config.json` (tokens) and HTTP.
+
+## 3. Observation: the `/api/v1/debug` module
+
+`internal/server/module/debug` is a **production management API**, not test
+scaffolding (UX principle: *diagnostics must traverse the real path*). The
+duo harness and a live incident use the same two endpoints (user-token auth):
+
+| Endpoint | Semantics |
+|----------|-----------|
+| `GET /api/v1/debug/memstats?gc=true` | `runtime.MemStats` snapshot; `gc=true` forces a double GC first so `heap_alloc_bytes` is the post-GC **retained set**. Also reports goroutine count (a second leak axis). |
+| `GET /api/v1/debug/pprof/heap?gc=true` | pprof heap profile (gzipped protobuf for `go tool pprof`), post-GC when `gc=true`. |
+
+These complement the CLI-level `--pprof` flag (side server on `:6060`,
+unauthenticated, opt-in at start): the debug module is on the main port,
+authenticated, and available on any running instance without a restart.
+
+Registration note: routes are registered in `server_control.go`
+(`UseUIEndpoints`) **and** in `swagger.go` (`registerAllAPIRoutes`) — the
+offline OpenAPI generator does not execute `UseUIEndpoints`, so a module
+registered in only one place either misses the running server or misses
+`openapi.json`. (Known drift: the `virtualmodel` module is currently
+runtime-only.)
+
+## 4. The memory phase
+
+Per route, per instance (`DuoMemoryReport{TB1, TB2}`):
+
+- **Retention slope** — warmup, baseline (post-GC), two sequential batches of
+  N requests, post-GC sample after each. Slope = (after2 − after1) / N. A
+  per-request pin shows as a positive slope; transient spikes and warm-up
+  growth (caches, pools) land in batch 1's delta and cancel out of the slope.
+  Threshold: 32 KB/request per instance (`duo_test.go`; #1255 measured 823,
+  healthy tb2 measures ~0.5).
+- **Allocation churn** — `total_alloc` delta per request; context for slope,
+  not a failure signal.
+- **Concurrent burst peak** — workers×per-worker requests while a sampler
+  polls both instances' live heap (no GC) every 100 ms; catches
+  amplification that sequential batches hide.
+- **Goroutine counts** — baseline vs final, both instances; a goroutine leak
+  is a memory leak with a different unit.
+- **Heap profiles** — `duo-<route>-<tb>-{baseline,final}.pb.gz` fetched per
+  instance when `--profile-dir` is set.
+
+## 5. Backpressure (`-slow` routes)
+
+The builtin vmodels answer instantly with ~130 bytes, which hides every
+buffering behaviour that only appears when data is in flight. Each duo route
+has a `-slow` variant that changes both ends:
+
+- **tb1 side** — `duo-serve` registers `duo-slow-gpt` / `duo-slow-claude`
+  (see `registerDuoStreamModels`): `--stream-kb` of content in ~2 KB chunks,
+  streamed over roughly 2×`--stream-ms` (the vmodel `Delay` is applied once
+  as TTFT by the virtualserver handler and spread again across chunks by the
+  mock's stream loop).
+- **client side** — the harness reads the SSE body through a `slowReader`
+  (8 KB read window + `--read-delay-ms` pause), building real TCP
+  backpressure against tb2 the way a slow consumer does.
+
+Default memory routes are `beta-chat,beta-chat-slow`: the Claude Code hot
+path fast *and* under backpressure, in one run.
+
+## 6. Fidelity ledger
+
+What matches production, and what still doesn't:
+
+| Aspect | Status |
+|--------|--------|
+| Request pipeline (routing → transform → client pool → HTTP) | ✅ identical code path; `/tingly/anthropic/v1/messages` shares the `/tingly/:scenario/v1` handler with `claude_code` |
+| Server lifecycle & background components | ✅ full `server.Start()` |
+| Process isolation / per-role memory | ✅ separate processes |
+| Slow upstream / slow client | ✅ `-slow` routes |
+| TLS to upstream | ❌ loopback HTTP (production upstreams are HTTPS; TLS record buffers not exercised) |
+| Request shape variety | ⚠️ alternating text messages only — no tool_use/thinking/image blocks in the conversation body |
+| Real provider latency/response distribution | ❌ vmodel responses are deterministic |
+
+Extend the request-shape axis in `BuildConversationBody` if a leak is ever
+suspected in a block-type-specific conversion branch.
+
+## 7. Entry points
+
+```bash
+./harness duo                          # functional all routes; memory fast + backpressure
+./harness duo --mem-routes all         # slope on every fast route
+./harness duo --skip-func --profile-dir /tmp -v
+go test ./internal/protocoltest/ -run 'TestDuoFunctional|TestDuoMemoryRegression|TestDuoBackpressure' -v
+```
+
+Code map: `internal/protocoltest/duo.go` (parent: routes, spawning, request
+driving) · `duo_serve.go` (child: boot + seeding, env contract) ·
+`duo_checks.go` (functional phase) · `duo_memory.go` (per-instance memory
+phase) · `internal/server/module/debug/` (observation endpoints) ·
+`cli/harness/duo.go` (CLI + side-by-side report).

--- a/.design/harness-duo.md
+++ b/.design/harness-duo.md
@@ -81,17 +81,34 @@ These complement the CLI-level `--pprof` flag (side server on `:6060`,
 unauthenticated, opt-in at start): the debug module is on the main port,
 authenticated, and available on any running instance without a restart.
 
-**Cost & control.** Mounting the routes costs nothing at runtime; the only
-expensive operation is the opt-in forced GC (stop-the-world on the live
-heap), which is throttled to at most one per second per instance — a polling
-client degrades to un-forced snapshots (`gc_forced: false`) instead of
-inducing a GC storm. The endpoints stay mounted by default rather than being
-gated behind a debug flag deliberately: their primary use is incident
-diagnosis on an already-running instance, and restarting with a flag to
-enable them would destroy the leaked heap being diagnosed. Content-wise they
-expose statistics and allocation stacks, never heap contents. The duo
-harness's `MemStats(gc=true)` retries past the throttle window so slope
-samples are always genuinely post-GC.
+**Cost & control.** Mounting the routes costs nothing at runtime. The two
+expensive operations are both throttled to one per second per instance: the
+opt-in forced GC (stop-the-world on the live heap; a throttled call degrades
+to an un-forced snapshot, `gc_forced: false`) and heap-profile serialization
+(CPU proportional to live objects; a throttled call gets a 429 with
+Retry-After, since a profile has no cheap degraded form). Plain memstats
+reads are microsecond-scale and unthrottled. The endpoints stay mounted by
+default rather than being gated behind a debug flag deliberately: their
+primary use is incident diagnosis on an already-running instance, and
+restarting with a flag to enable them would destroy the leaked heap being
+diagnosed. The duo harness retries `MemStats(gc=true)` and profile fetches
+past the throttle windows so slope samples are always genuinely post-GC.
+
+**Relation to pprof.** The heap endpoint is deliberately a *narrowed*
+re-exposure of `runtime/pprof` (the same `Lookup("heap").WriteTo` primitive
+`net/http/pprof` wraps), not a reimplementation of the suite. Mounting
+`net/http/pprof` wholesale was rejected: its import registers unauthenticated
+handlers on `http.DefaultServeMux` as a side effect (a footgun for every
+binary embedding the server), it exposes strictly more than needed
+(`cmdline` leaks argv, goroutine dumps can leak pprof labels, CPU profiling
+is a compute lever), and its `?gc=1` cannot be throttled without forking the
+handler. Information-wise these endpoints expose allocation-site stacks and
+counters, never heap contents — strictly less than pprof — behind the same
+user token that already guards far more valuable targets (provider keys,
+config apply). The full pprof suite remains available via the CLI's
+explicit `--pprof` side server on `:6060`; the split is intentional: main
+port = narrow, contract-shaped memory observation; `:6060` = full pprof,
+opt-in at start.
 
 Registration note: routes are registered in `server_control.go`
 (`UseUIEndpoints`) **and** in `swagger.go` (`registerAllAPIRoutes`) — the

--- a/.design/harness-duo.md
+++ b/.design/harness-duo.md
@@ -75,11 +75,23 @@ duo harness and a live incident use the same two endpoints (user-token auth):
 | Endpoint | Semantics |
 |----------|-----------|
 | `GET /api/v1/debug/memstats?gc=true` | `runtime.MemStats` snapshot; `gc=true` forces a double GC first so `heap_alloc_bytes` is the post-GC **retained set**. Also reports goroutine count (a second leak axis). |
-| `GET /api/v1/debug/pprof/heap?gc=true` | pprof heap profile (gzipped protobuf for `go tool pprof`), post-GC when `gc=true`. |
+| `GET /api/v1/debug/pprof/heap?gc=true` | pprof heap profile (gzipped protobuf for `go tool pprof`), post-GC when `gc=true` (`X-Debug-GC-Forced` header reports whether it ran). |
 
 These complement the CLI-level `--pprof` flag (side server on `:6060`,
 unauthenticated, opt-in at start): the debug module is on the main port,
 authenticated, and available on any running instance without a restart.
+
+**Cost & control.** Mounting the routes costs nothing at runtime; the only
+expensive operation is the opt-in forced GC (stop-the-world on the live
+heap), which is throttled to at most one per second per instance — a polling
+client degrades to un-forced snapshots (`gc_forced: false`) instead of
+inducing a GC storm. The endpoints stay mounted by default rather than being
+gated behind a debug flag deliberately: their primary use is incident
+diagnosis on an already-running instance, and restarting with a flag to
+enable them would destroy the leaked heap being diagnosed. Content-wise they
+expose statistics and allocation stacks, never heap contents. The duo
+harness's `MemStats(gc=true)` retries past the throttle window so slope
+samples are always genuinely post-GC.
 
 Registration note: routes are registered in `server_control.go`
 (`UseUIEndpoints`) **and** in `swagger.go` (`registerAllAPIRoutes`) — the

--- a/cli/harness/README.md
+++ b/cli/harness/README.md
@@ -354,6 +354,9 @@ exactly how routing, failover, the breaker, and affinity behave over a sequence.
 
 ## Tier Duo — `duo`
 
+> Design rationale, fidelity ledger, and observation contract:
+> [`.design/harness-duo.md`](../../.design/harness-duo.md)
+
 Two full tingly-box instances as **separate server processes**, verified
 end-to-end over **real HTTP**: `tb2` (the gateway under test) routes
 anthropic-scenario rules to `tb1`'s production vmodel endpoints, and the

--- a/cli/harness/README.md
+++ b/cli/harness/README.md
@@ -354,15 +354,31 @@ exactly how routing, failover, the breaker, and affinity behave over a sequence.
 
 ## Tier Duo — `duo`
 
-Two full tingly-box instances in one process, verified end-to-end over **real
-HTTP**: `tb2` (the gateway under test) routes anthropic-scenario rules to
-`tb1`'s production vmodel endpoints, and the harness drives Claude-Code-shaped
-conversations (megabytes of context per turn) through tb2's
-protocol-conversion paths.
+Two full tingly-box instances as **separate server processes**, verified
+end-to-end over **real HTTP**: `tb2` (the gateway under test) routes
+anthropic-scenario rules to `tb1`'s production vmodel endpoints, and the
+harness drives Claude-Code-shaped conversations (megabytes of context per
+turn) through tb2's protocol-conversion paths.
 
 ```
-client ──(Anthropic v1/beta stream)──▶ tb2 ──(real HTTP)──▶ tb1 /virtual/{openai,anthropic}/... (vmodel)
+                 harness (parent process — drives requests, never measured)
+                    │
+                    │ Anthropic v1/beta stream          per-instance sampling
+                    ▼                                   /api/v1/debug/{memstats,pprof/heap}
+   ┌──────────────────────────────┐    real HTTP    ┌──────────────────────────────┐
+   │  tb2  (gateway under test)   ├────────────────▶│  tb1  (vmodel upstream)      │
+   │  own process, server.Start() │                 │  own process, server.Start() │
+   └──────────────────────────────┘                 └──────────────────────────────┘
 ```
+
+Each instance is booted through the full production path (`server.Start`:
+background refreshers, config watcher, production `http.Server` timeouts) by
+re-executing the harness binary itself, and — because each has its own Go
+runtime — memory is observed **per instance** over the production
+`/api/v1/debug/memstats` + `/api/v1/debug/pprof/heap` endpoints. A retention
+slope therefore attributes directly: tb2 slope → gateway/conversion path,
+tb1 slope → vmodel serving path. (The same endpoints work against any live
+deployment for incident diagnosis.)
 
 Every anthropic-source route the vmodel can back is wired:
 
@@ -378,31 +394,43 @@ Every anthropic-source route the vmodel can back is wired:
 (The Google target is deliberately not covered — the vmodel surface skips it
 for now.)
 
+Every route also has a **`-slow` backpressure variant** (e.g.
+`beta-chat-slow`): tb1 answers from a slow/large stream vmodel
+(`--stream-kb` KB over roughly 2×`--stream-ms` wall time) while the harness
+reads the SSE body slowly (`--read-delay-ms` between reads), so buffering
+and pinning under real TCP backpressure — invisible with instant mock
+responses — are on the measured path.
+
 Two phases, both on by default:
 
 - **Functional** — SSE event shape (`message_start` … `message_stop`),
   assembled content, `stop_reason`, usage propagation, and the non-streaming
   response body.
-- **Memory** — allocation churn per request, **post-GC retention slope**
-  across two sequential batches (a leak shows as a positive slope; transient
-  spikes do not), and peak live heap under a concurrent burst. This is the
-  setup that pinned down #1255: 823 KB/request retained before the fix,
-  ~0.5 KB after. The run fails if the slope exceeds `--max-slope-kb`
-  (default 32).
+- **Memory** — per instance: allocation churn per request, **post-GC
+  retention slope** across two sequential batches (a leak shows as a
+  positive slope; transient spikes do not), peak live heap under a
+  concurrent burst, and goroutine counts. This is the setup that pinned down
+  #1255: 823 KB/request retained on the gateway before the fix, ~0.5 KB
+  after. The run fails if **either instance's** slope exceeds
+  `--max-slope-kb` (default 32). Default routes: `beta-chat` (fast) +
+  `beta-chat-slow` (backpressure).
 
 ```bash
-./harness duo                                   # functional: all routes; memory: beta-chat hot path
-./harness duo --mem-routes all                  # memory slope on every route
+./harness duo                                   # functional: all routes; memory: beta-chat fast + backpressure
+./harness duo --mem-routes all                  # memory slope on every fast route
+./harness duo --mem-routes beta-chat-slow --stream-kb 1024 --stream-ms 2000 --read-delay-ms 50   # heavy backpressure
 ./harness duo --routes beta-responses,v1-responses --skip-memory
 ./harness duo --body-mb 4 --batch 30            # heavier sweep
-./harness duo --skip-func --profile-dir /tmp    # memory only, write pprof heap profiles
-go tool pprof -top -inuse_space /tmp/duo-beta-chat-final.pb.gz
+./harness duo --skip-func --profile-dir /tmp    # memory only, write per-instance pprof heap profiles
+go tool pprof -top -inuse_space /tmp/duo-beta-chat-tb2-final.pb.gz
 ./harness duo --json                            # machine-readable report
+./harness duo -v                                # relay both children's server logs
 ```
 
-The engine lives in `internal/protocoltest/duo.go` and is shared with the
-`TestDuoFunctional` / `TestDuoMemoryRegression` Go tests, so CI guards the
-same slope threshold.
+The engine lives in `internal/protocoltest/duo*.go` and is shared with the
+`TestDuoFunctional` / `TestDuoMemoryRegression` / `TestDuoBackpressure` Go
+tests (whose `TestMain` re-executes the test binary as the child servers), so
+CI guards the same per-instance slope threshold.
 
 ## Agent reference
 
@@ -422,7 +450,8 @@ cli/harness/
                      provider / init-config
   matrix.go          Tier A command — wraps protocoltest.Matrix
   replay.go          Tier B command — fixture replay, upstreams, skip list
-  duo.go             Tier Duo command — wraps protocoltest.DuoEnv (function + memory)
+  duo.go             Tier Duo command — wraps protocoltest.DuoEnv (function +
+                     per-instance memory); child mode via MaybeRunDuoServe in main.go
   agent.go           Tier C command — agent CLI subprocess driver (+ env wiring)
   agent_real.go      Tier C real-provider mode: config iteration, per-entry runs
   lb.go              Tier LB command — load-balancing scenario simulator
@@ -446,6 +475,10 @@ internal/protocoltest/   shared engine used by all tiers
   replay.go          SetupVirtualAgentScenario, ReplayFixture, repointBuiltinRule
   assertions.go      reusable Assertion constructors
   real_model.go      providers.yaml parsing for --upstream=real / --config
+  duo.go             Tier Duo parent: routes, child spawning, request driving
+  duo_serve.go       Tier Duo child: full server boot + gateway/vmodel seeding
+  duo_checks.go      Tier Duo functional phase
+  duo_memory.go      Tier Duo memory phase (per-instance sampling over HTTP)
 ```
 
 ---

--- a/cli/harness/duo.go
+++ b/cli/harness/duo.go
@@ -5,29 +5,32 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
+	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
-// DuoCmd is Tier "Duo": two-instance e2e verification (function + memory)
-// over every anthropic-source conversion route. The topology, route matrix,
-// and #1255 background live on the engine — see internal/protocoltest/duo.go.
+// DuoCmd is Tier "Duo": two-process e2e verification (function + memory)
+// over every anthropic-source conversion route. tb1 and tb2 each run as a
+// full server child process and are observed separately over their
+// /api/v1/debug endpoints — the topology, route matrix, and #1255 background
+// live on the engine, see internal/protocoltest/duo.go.
 type DuoCmd struct {
-	Routes     string  `kong:"name='routes',default='all',help='Comma-separated route names for the functional phase, or \"all\" (routes: beta-chat, beta-responses, beta-anthropic, v1-chat, v1-responses, v1-anthropic)'"`
-	MemRoutes  string  `kong:"name='mem-routes',default='beta-chat',help='Comma-separated route names for the memory phase, or \"all\" (default: the Claude Code hot path)'"`
-	BodyMB     float64 `kong:"name='body-mb',default='2',help='Conversation size per request in MB (mimics agentic full-context turns)'"`
-	Batch      int     `kong:"name='batch',default='15',help='Requests per sequential batch (two batches measure the retention slope)'"`
-	Workers    int     `kong:"name='workers',default='4',help='Concurrent workers in the burst phase'"`
-	PerWorker  int     `kong:"name='per-worker',default='5',help='Requests per worker in the burst phase'"`
-	MaxSlopeKB float64 `kong:"name='max-slope-kb',default='32',help='Fail if post-GC retention exceeds this many KB/request'"`
-	SkipMemory bool    `kong:"name='skip-memory',help='Run only the functional checks'"`
-	SkipFunc   bool    `kong:"name='skip-func',help='Run only the memory phase'"`
-	ProfileDir string  `kong:"name='profile-dir',help='Write pprof heap profiles (duo-<route>-{baseline,final}.pb.gz) to this directory'"`
-	JSON       bool    `kong:"name='json',help='Emit results as JSON'"`
-	Verbose    bool    `kong:"name='verbose',short='v',help='Show gateway logs (default: quiet)'"`
+	Routes      string  `kong:"name='routes',default='all',help='Comma-separated route names for the functional phase, or \"all\" (routes: beta-chat, beta-responses, beta-anthropic, v1-chat, v1-responses, v1-anthropic)'"`
+	MemRoutes   string  `kong:"name='mem-routes',default='beta-chat,beta-chat-slow',help='Comma-separated route names for the memory phase, or \"all\" (any route also has a \"-slow\" backpressure variant; default: the Claude Code hot path, fast + backpressure)'"`
+	BodyMB      float64 `kong:"name='body-mb',default='2',help='Conversation size per request in MB (mimics agentic full-context turns)'"`
+	Batch       int     `kong:"name='batch',default='15',help='Requests per sequential batch (two batches measure the retention slope)'"`
+	Workers     int     `kong:"name='workers',default='4',help='Concurrent workers in the burst phase'"`
+	PerWorker   int     `kong:"name='per-worker',default='5',help='Requests per worker in the burst phase'"`
+	MaxSlopeKB  float64 `kong:"name='max-slope-kb',default='32',help='Fail if either instance retains more than this many KB/request post-GC'"`
+	StreamKB    int     `kong:"name='stream-kb',default='256',help='Backpressure (-slow) routes: tb1 vmodel response size in KB'"`
+	StreamMS    int     `kong:"name='stream-ms',default='500',help='Backpressure (-slow) routes: tb1 vmodel delay parameter in ms (stream wall time is roughly 2x)'"`
+	ReadDelayMS int     `kong:"name='read-delay-ms',default='15',help='Backpressure (-slow) routes: client-side pause between SSE reads in ms'"`
+	SkipMemory  bool    `kong:"name='skip-memory',help='Run only the functional checks'"`
+	SkipFunc    bool    `kong:"name='skip-func',help='Run only the memory phase'"`
+	ProfileDir  string  `kong:"name='profile-dir',help='Write per-instance pprof heap profiles (duo-<route>-<tb>-{baseline,final}.pb.gz) to this directory'"`
+	JSON        bool    `kong:"name='json',help='Emit results as JSON'"`
+	Verbose     bool    `kong:"name='verbose',short='v',help='Relay child instance logs (default: quiet)'"`
 }
 
 // duoResult is the JSON output shape.
@@ -39,7 +42,7 @@ type duoResult struct {
 	Pass       bool                            `json:"pass"`
 }
 
-// resolveRoutes parses a comma-separated route list ("all" = every route).
+// resolveRoutes parses a comma-separated route list ("all" = every fast route).
 func resolveRoutes(spec string) ([]protocoltest.DuoRoute, error) {
 	if strings.TrimSpace(spec) == "all" {
 		return protocoltest.AllDuoRoutes(), nil
@@ -52,7 +55,7 @@ func resolveRoutes(spec string) ([]protocoltest.DuoRoute, error) {
 		}
 		r, ok := protocoltest.FindDuoRoute(name)
 		if !ok {
-			return nil, fmt.Errorf("unknown route %q (known: %s)", name, duoRouteNames())
+			return nil, fmt.Errorf("unknown route %q (known: %s, each also as <name>-slow)", name, duoRouteNames())
 		}
 		routes = append(routes, r)
 	}
@@ -71,14 +74,6 @@ func duoRouteNames() string {
 }
 
 func (cmd *DuoCmd) Run() error {
-	if !cmd.Verbose {
-		// TestMode (not ReleaseMode): without a MultiLogger the access-log
-		// middleware falls back to a plain logrus logger and only discards
-		// its output under gin.TestMode.
-		gin.SetMode(gin.TestMode)
-		logrus.SetLevel(logrus.ErrorLevel)
-	}
-
 	funcRoutes, err := resolveRoutes(cmd.Routes)
 	if err != nil {
 		return err
@@ -88,14 +83,21 @@ func (cmd *DuoCmd) Run() error {
 		return err
 	}
 
-	env, err := protocoltest.NewDuoEnv()
+	envCfg := protocoltest.DuoEnvConfig{StreamKB: cmd.StreamKB, StreamMS: cmd.StreamMS}
+	if cmd.Verbose {
+		envCfg.ChildLog = os.Stderr
+	}
+	if !cmd.JSON {
+		fmt.Println("duo: booting tb1 (vmodel upstream) and tb2 (gateway) as server processes...")
+	}
+	env, err := protocoltest.NewDuoEnv(envCfg)
 	if err != nil {
 		return fmt.Errorf("boot duo environment: %w", err)
 	}
 	defer env.Close()
 
 	bodyBytes := int(cmd.BodyMB * 1024 * 1024)
-	result := duoResult{TB1URL: env.TB1URL(), TB2URL: env.TB2URL(), Pass: true}
+	result := duoResult{TB1URL: env.TB1.BaseURL, TB2URL: env.TB2.BaseURL, Pass: true}
 
 	progress := func(format string, args ...any) {
 		if !cmd.JSON {
@@ -105,7 +107,7 @@ func (cmd *DuoCmd) Run() error {
 
 	if !cmd.SkipFunc {
 		if !cmd.JSON {
-			fmt.Printf("duo: functional checks (tb2 %s → tb1 %s, body %.1f MB)\n", env.TB2URL(), env.TB1URL(), cmd.BodyMB)
+			fmt.Printf("duo: functional checks (tb2 %s → tb1 %s, body %.1f MB)\n", env.TB2.BaseURL, env.TB1.BaseURL, cmd.BodyMB)
 		}
 		for _, route := range funcRoutes {
 			checks := env.RunFunctionalChecks(route, bodyBytes)
@@ -135,16 +137,21 @@ func (cmd *DuoCmd) Run() error {
 
 	if !cmd.SkipMemory {
 		if !cmd.JSON {
-			fmt.Println("duo: memory phase")
+			fmt.Println("duo: memory phase (tb1 and tb2 observed separately)")
 		}
 		for i := range memRoutes {
 			route := memRoutes[i]
+			var readDelay time.Duration
+			if route.Slow {
+				readDelay = time.Duration(cmd.ReadDelayMS) * time.Millisecond
+			}
 			report, err := env.RunMemoryPhase(protocoltest.DuoMemoryConfig{
 				Route:      &route,
 				BodyBytes:  bodyBytes,
 				Batch:      cmd.Batch,
 				Workers:    cmd.Workers,
 				PerWorker:  cmd.PerWorker,
+				ReadDelay:  readDelay,
 				ProfileDir: cmd.ProfileDir,
 				Progress:   progress,
 			})
@@ -153,27 +160,11 @@ func (cmd *DuoCmd) Run() error {
 			}
 			result.Memory = append(result.Memory, report)
 
-			slopeOK := report.SlopeKBPerRequest <= cmd.MaxSlopeKB
-			if !slopeOK {
+			if report.MaxSlopeKB() > cmd.MaxSlopeKB {
 				result.Pass = false
 			}
 			if !cmd.JSON {
-				verdict := "OK"
-				if !slopeOK {
-					verdict = fmt.Sprintf("LEAK (limit %.1f)", cmd.MaxSlopeKB)
-				}
-				fmt.Printf("  %s:\n", route.Name)
-				fmt.Printf("    baseline post-GC heap      %8.2f MB\n", report.BaselineHeapMB)
-				fmt.Printf("    retained after %3d reqs    %+8.2f MB\n", report.Batch, report.AfterBatch1MB)
-				fmt.Printf("    retained after %3d reqs    %+8.2f MB\n", 2*report.Batch, report.AfterBatch2MB)
-				fmt.Printf("    retention slope            %8.1f KB/request   %s\n", report.SlopeKBPerRequest, verdict)
-				fmt.Printf("    allocation churn           %8.2f MB/request\n", report.ChurnMBPerRequest)
-				fmt.Printf("    burst peak heap (%d×%d)     %8.2f MB (post-GC %+.2f MB)\n",
-					report.ConcurrentWorkers, report.ConcurrentTotal/report.ConcurrentWorkers, report.PeakHeapMB, report.PostBurstDeltaMB)
-				if report.FinalProfile != "" {
-					fmt.Printf("    heap profiles: %s , %s\n", report.BaselineProfile, report.FinalProfile)
-					fmt.Printf("    inspect: go tool pprof -top -inuse_space %s\n", report.FinalProfile)
-				}
+				printMemoryReport(report, cmd.MaxSlopeKB)
 			}
 		}
 	}
@@ -192,4 +183,42 @@ func (cmd *DuoCmd) Run() error {
 		fmt.Println("duo: PASS")
 	}
 	return nil
+}
+
+// printMemoryReport renders one route's memory outcome, tb1 and tb2 side by
+// side so a leak reads directly as "which instance".
+func printMemoryReport(report *protocoltest.DuoMemoryReport, maxSlopeKB float64) {
+	fmt.Printf("  %s:\n", report.Route)
+	if report.ReadDelayMS > 0 {
+		fmt.Printf("    backpressure: slow reader %d ms between reads\n", report.ReadDelayMS)
+	}
+	fmt.Printf("    %-26s %14s %14s\n", "", "tb1 (vmodel)", "tb2 (gateway)")
+	row := func(label, format string, v1, v2 float64) {
+		fmt.Printf("    %-26s %14s %14s\n", label, fmt.Sprintf(format, v1), fmt.Sprintf(format, v2))
+	}
+	tb1, tb2 := report.TB1, report.TB2
+	row("baseline post-GC heap", "%.2f MB", tb1.BaselineHeapMB, tb2.BaselineHeapMB)
+	row(fmt.Sprintf("retained after %3d reqs", report.Batch), "%+.2f MB", tb1.AfterBatch1MB, tb2.AfterBatch1MB)
+	row(fmt.Sprintf("retained after %3d reqs", 2*report.Batch), "%+.2f MB", tb1.AfterBatch2MB, tb2.AfterBatch2MB)
+	verdict := func(slope float64) string {
+		if slope > maxSlopeKB {
+			return fmt.Sprintf("LEAK (limit %.1f)", maxSlopeKB)
+		}
+		return "OK"
+	}
+	fmt.Printf("    %-26s %14s %14s   tb1 %s / tb2 %s\n", "retention slope",
+		fmt.Sprintf("%.1f KB/req", tb1.SlopeKBPerRequest),
+		fmt.Sprintf("%.1f KB/req", tb2.SlopeKBPerRequest),
+		verdict(tb1.SlopeKBPerRequest), verdict(tb2.SlopeKBPerRequest))
+	row("allocation churn", "%.2f MB/req", tb1.ChurnMBPerRequest, tb2.ChurnMBPerRequest)
+	fmt.Printf("    %-26s %14s %14s\n", fmt.Sprintf("burst peak heap (%d×%d)", report.ConcurrentWorkers, report.ConcurrentTotal/report.ConcurrentWorkers),
+		fmt.Sprintf("%.2f MB", tb1.PeakHeapMB), fmt.Sprintf("%.2f MB", tb2.PeakHeapMB))
+	row("post-burst delta", "%+.2f MB", tb1.PostBurstDeltaMB, tb2.PostBurstDeltaMB)
+	fmt.Printf("    %-26s %14s %14s\n", "goroutines (base→final)",
+		fmt.Sprintf("%d→%d", tb1.BaselineGoroutines, tb1.FinalGoroutines),
+		fmt.Sprintf("%d→%d", tb2.BaselineGoroutines, tb2.FinalGoroutines))
+	if tb2.FinalProfile != "" {
+		fmt.Printf("    heap profiles: %s , %s (and tb1 counterparts)\n", tb2.BaselineProfile, tb2.FinalProfile)
+		fmt.Printf("    inspect: go tool pprof -top -inuse_space %s\n", tb2.FinalProfile)
+	}
 }

--- a/cli/harness/main.go
+++ b/cli/harness/main.go
@@ -14,6 +14,8 @@ import (
 	"os"
 
 	"github.com/alecthomas/kong"
+
+	"github.com/tingly-dev/tingly-box/internal/protocoltest"
 )
 
 // Build information variables (set via ldflags).
@@ -36,6 +38,11 @@ type CLI struct {
 }
 
 func main() {
+	// Duo child mode: when the parent (harness duo) re-executes this binary
+	// under the TINGLY_DUO_* env contract, run a full server instance instead
+	// of the CLI. Never returns in that case.
+	protocoltest.MaybeRunDuoServe()
+
 	var cli CLI
 	ctx := kong.Parse(&cli,
 		kong.Name("harness"),

--- a/gui/wails3/services/tingly_service.go
+++ b/gui/wails3/services/tingly_service.go
@@ -45,7 +45,6 @@ func NewTinglyService(configDir string, port int, debug bool) (*TinglyService, e
 		appManager.AppConfig(),
 		server.WithDebug(debug),
 		server.WithUI(true),
-		server.WithAdaptor(true),
 		server.WithOpenBrowser(false), // GUI doesn't need browser auto-open
 	)
 

--- a/internal/protocoltest/agent_env.go
+++ b/internal/protocoltest/agent_env.go
@@ -141,7 +141,7 @@ func NewAgentTestEnv(AgentType AgentType) (*AgentTestEnv, error) {
 	}
 
 	// Create gateway server with real routing
-	gatewayServer := server.NewServer(appConfig.GetGlobalConfig(), server.WithAdaptor(false))
+	gatewayServer := server.NewServer(appConfig.GetGlobalConfig())
 	router := gatewayServer.GetRouter()
 	ts := httptest.NewServer(router)
 

--- a/internal/protocoltest/duo.go
+++ b/internal/protocoltest/duo.go
@@ -7,24 +7,31 @@ package protocoltest
 //	   tb2 ──(converted provider request over real HTTP)──────────▶ tb1 /virtual/...
 //	   tb1 ──(vmodel SSE stream)───────────────────────────────────▶ tb2 ──▶ client
 //
-// Both instances are full production servers (server.NewServer) running in
-// one process on real HTTP listeners, so the whole gateway stack is
-// exercised — routing, transform pipeline, client pool, transports, usage
-// tracking — and a post-GC heap profile attributes retained bytes to real
-// call stacks.
+// tb1 and tb2 are SEPARATE PROCESSES, each a full production server booted
+// through server.Start (background refreshers, config watcher, production
+// http.Server timeouts) — the parent re-executes its own binary via the
+// TINGLY_DUO_* env contract in duo_serve.go. Because each instance has its
+// own Go runtime, memory is observed PER INSTANCE over the production
+// /api/v1/debug/{memstats,pprof/heap} endpoints: a leak attributes directly
+// to tb2 (gateway/conversion path) or tb1 (vmodel serving path) instead of
+// disappearing into a shared heap.
 //
 // Every anthropic-source conversion route the production vmodel endpoint can
 // back is wired (see AllDuoRoutes): {v1, beta} × {anthropic passthrough,
-// OpenAI Chat, OpenAI Responses}. The Google target is not covered — the
-// vmodel surface deliberately skips it for now.
+// OpenAI Chat, OpenAI Responses}. Each route also has a "-slow" backpressure
+// variant where tb1 streams a large response slowly (see DuoSlowOpenAIModel)
+// and the client can read slowly (DuoMemoryConfig.ReadDelay), exercising the
+// buffering/pinning behaviour that instant mock responses hide. The Google
+// target is not covered — the vmodel surface deliberately skips it for now.
 //
 // Two verification phases are provided:
 //
 //   - RunFunctionalChecks: protocol correctness through a conversion route
 //     (streaming SSE shape + assembled content + usage; non-streaming body).
-//   - RunMemoryPhase: allocation churn, post-GC retention slope across
-//     request batches (a leak shows up as a positive slope; transient spikes
-//     do not), concurrent-burst peak heap, and optional pprof heap profiles.
+//   - RunMemoryPhase: per-instance allocation churn, post-GC retention slope
+//     across request batches (a leak shows up as a positive slope; transient
+//     spikes do not), concurrent-burst peak heap, goroutine counts, and
+//     optional pprof heap profiles fetched from each instance.
 //
 // Consumed by `harness duo` (cli/harness) and by duo_test.go as functional +
 // memory regression tests.
@@ -35,42 +42,47 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"runtime"
-	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/ai"
-	"github.com/tingly-dev/tingly-box/internal/config"
-	"github.com/tingly-dev/tingly-box/internal/constant"
-	"github.com/tingly-dev/tingly-box/internal/loadbalance"
-	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
-	"github.com/tingly-dev/tingly-box/internal/server"
-	"github.com/tingly-dev/tingly-box/internal/typ"
+	debugmodule "github.com/tingly-dev/tingly-box/internal/server/module/debug"
 )
 
 // DuoRoute is one anthropic-source conversion route through tb2.
 type DuoRoute struct {
 	// Name identifies the route in flags, check names, and reports,
-	// e.g. "beta-chat", "v1-responses", "beta-anthropic".
+	// e.g. "beta-chat", "v1-responses", "beta-chat-slow".
 	Name string
 	// Beta selects the Anthropic beta source surface (?beta=true) over v1.
 	Beta bool
 	// Target is the provider protocol tb2 converts to: "chat", "responses",
 	// or "anthropic" (passthrough).
 	Target string
+	// Slow selects the backpressure variant: tb1 answers with the slow/large
+	// duo stream vmodel instead of the tiny instant builtin.
+	Slow bool
 }
 
 // RequestModel returns the tb2 request model wired for this route.
 func (r DuoRoute) RequestModel() string { return "duo-e2e-" + r.Name }
 
-// AllDuoRoutes lists every anthropic-source route the production vmodel
+// SlowVariant returns the backpressure variant of the route.
+func (r DuoRoute) SlowVariant() DuoRoute {
+	if r.Slow {
+		return r
+	}
+	return DuoRoute{Name: r.Name + "-slow", Beta: r.Beta, Target: r.Target, Slow: true}
+}
+
+// AllDuoRoutes lists every fast anthropic-source route the production vmodel
 // endpoint can back: {v1, beta} × {anthropic, openai chat, openai responses}.
 func AllDuoRoutes() []DuoRoute {
 	var routes []DuoRoute
@@ -85,9 +97,21 @@ func AllDuoRoutes() []DuoRoute {
 	return routes
 }
 
-// FindDuoRoute resolves a route by name.
+// allDuoRoutesWithSlow returns the fast routes plus their slow variants —
+// the full rule set seeded on tb2.
+func allDuoRoutesWithSlow() []DuoRoute {
+	fast := AllDuoRoutes()
+	all := make([]DuoRoute, 0, 2*len(fast))
+	all = append(all, fast...)
+	for _, r := range fast {
+		all = append(all, r.SlowVariant())
+	}
+	return all
+}
+
+// FindDuoRoute resolves a route by name, including "-slow" variants.
 func FindDuoRoute(name string) (DuoRoute, bool) {
-	for _, r := range AllDuoRoutes() {
+	for _, r := range allDuoRoutesWithSlow() {
 		if r.Name == name {
 			return r, true
 		}
@@ -99,131 +123,345 @@ func FindDuoRoute(name string) (DuoRoute, bool) {
 // (Anthropic beta client → OpenAI Chat provider) where #1255 was reported.
 var DuoDefaultRoute = DuoRoute{Name: "beta-chat", Beta: true, Target: "chat"}
 
-// duoTargetVModel maps a route target to the tb1 vmodel that serves it.
-func duoTargetVModel(target string) string {
-	if target == "anthropic" {
+// duoTargetVModel maps a route to the tb1 vmodel that serves it.
+func duoTargetVModel(route DuoRoute) string {
+	switch {
+	case route.Slow && route.Target == "anthropic":
+		return DuoSlowAnthropicModel
+	case route.Slow:
+		return DuoSlowOpenAIModel
+	case route.Target == "anthropic":
 		return "virtual-claude-3" // anthropic registry
+	default:
+		return "virtual-gpt-4" // openai registry (chat + responses surfaces)
 	}
-	return "virtual-gpt-4" // openai registry (chat + responses surfaces)
 }
 
-// DuoEnv holds the two running instances and the wiring between them.
+// ─── Instances ────────────────────────────────────────────────────────────────
+
+// DuoInstance is one child tingly-box process.
+type DuoInstance struct {
+	Name       string
+	ConfigDir  string
+	Port       int
+	BaseURL    string
+	UserToken  string
+	ModelToken string
+
+	cmd     *exec.Cmd
+	out     *tailBuffer
+	done    chan struct{}
+	exitErr error
+	hc      *http.Client
+}
+
+// OutputTail returns the last captured child stdout/stderr output.
+func (inst *DuoInstance) OutputTail() string { return inst.out.String() }
+
+// exited reports whether the child process has terminated.
+func (inst *DuoInstance) exited() bool {
+	select {
+	case <-inst.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// MemStats fetches a runtime memory snapshot from the instance's debug
+// endpoint. With gc=true the instance forces a full GC first, so
+// HeapAllocBytes is its post-GC retained set.
+func (inst *DuoInstance) MemStats(gc bool) (*debugmodule.MemStatsResponse, error) {
+	url := inst.BaseURL + "/api/v1/debug/memstats"
+	if gc {
+		url += "?gc=true"
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+inst.UserToken)
+	resp, err := inst.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s memstats: %w", inst.Name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("%s memstats: status %d: %s", inst.Name, resp.StatusCode, b)
+	}
+	var m debugmodule.MemStatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, fmt.Errorf("%s memstats: %w", inst.Name, err)
+	}
+	return &m, nil
+}
+
+// WriteHeapProfile fetches a post-GC pprof heap profile from the instance
+// and writes it under dir, returning the file path.
+func (inst *DuoInstance) WriteHeapProfile(dir, name string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, inst.BaseURL+"/api/v1/debug/pprof/heap?gc=true", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+inst.UserToken)
+	resp, err := inst.hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s heap profile: %w", inst.Name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return "", fmt.Errorf("%s heap profile: status %d: %s", inst.Name, resp.StatusCode, b)
+	}
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// ─── Environment ──────────────────────────────────────────────────────────────
+
+// DuoEnvConfig parameterizes NewDuoEnv.
+type DuoEnvConfig struct {
+	// StreamKB / StreamMS shape tb1's slow backpressure vmodels: an
+	// approximately StreamKB-sized response streamed over roughly 2×StreamMS
+	// wall time. Defaults: 256 KB over ~1 s.
+	StreamKB int
+	StreamMS int
+	// ChildLog, when non-nil, receives both children's stdout/stderr live
+	// (in addition to the per-instance tail buffer used for diagnostics).
+	ChildLog io.Writer
+	// BootTimeout caps how long each instance may take to become healthy
+	// (default 90s — first boot may attempt a provider-template fetch).
+	BootTimeout time.Duration
+}
+
+func (c *DuoEnvConfig) withDefaults() {
+	if c.StreamKB <= 0 {
+		c.StreamKB = 256
+	}
+	if c.StreamMS <= 0 {
+		c.StreamMS = 500
+	}
+	if c.BootTimeout <= 0 {
+		c.BootTimeout = 90 * time.Second
+	}
+}
+
+// DuoEnv holds the two running child instances and the wiring between them.
 type DuoEnv struct {
-	tb1Cfg *config.AppConfig
-	tb2Cfg *config.AppConfig
-	tb1    *httptest.Server
-	tb2    *httptest.Server
-	client *http.Client
+	TB1 *DuoInstance // upstream: serves /virtual vmodel endpoints
+	TB2 *DuoInstance // gateway under test: converts + proxies to tb1
 
-	tb2Token string
-	dirs     []string
+	client *http.Client
+	dirs   []string
 }
 
-// NewDuoEnv boots tb1 (vmodel provider) and tb2 (gateway under test) and
-// wires one tb2 rule per route in AllDuoRoutes to tb1's virtual endpoints.
-// Callers must Close() the returned env.
-func NewDuoEnv() (*DuoEnv, error) {
+// NewDuoEnv boots tb1 (vmodel upstream) and tb2 (gateway under test) as two
+// full server processes and wires one tb2 rule per route in
+// allDuoRoutesWithSlow to tb1's virtual endpoints. Callers must Close() the
+// returned env.
+func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
+	cfg.withDefaults()
 	env := &DuoEnv{client: &http.Client{Timeout: 120 * time.Second}}
 
-	boot := func(name string) (*config.AppConfig, *httptest.Server, error) {
-		dir, err := os.MkdirTemp("", "duo-"+name+"-*")
-		if err != nil {
-			return nil, nil, err
-		}
-		env.dirs = append(env.dirs, dir)
-		appCfg, err := config.NewAppConfig(config.WithConfigDir(dir))
-		if err != nil {
-			return nil, nil, err
-		}
-		srv := server.NewServer(appCfg.GetGlobalConfig(), server.WithAdaptor(false))
-		return appCfg, httptest.NewServer(srv.GetRouter()), nil
-	}
-
-	var err error
-	if env.tb1Cfg, env.tb1, err = boot("tb1"); err != nil {
+	tb1, err := env.startInstance("tb1", cfg, map[string]string{
+		duoEnvStreamKB: strconv.Itoa(cfg.StreamKB),
+		duoEnvStreamMS: strconv.Itoa(cfg.StreamMS),
+	})
+	if err != nil {
 		env.Close()
 		return nil, fmt.Errorf("boot tb1: %w", err)
 	}
-	if env.tb2Cfg, env.tb2, err = boot("tb2"); err != nil {
+	env.TB1 = tb1
+
+	tb2, err := env.startInstance("tb2", cfg, map[string]string{
+		duoEnvUpstreamURL:   tb1.BaseURL,
+		duoEnvUpstreamToken: tb1.ModelToken,
+	})
+	if err != nil {
 		env.Close()
 		return nil, fmt.Errorf("boot tb2: %w", err)
 	}
-	env.tb2Token = env.tb2Cfg.GetGlobalConfig().GetModelToken()
-	tb1Token := env.tb1Cfg.GetGlobalConfig().GetModelToken()
-
-	// One provider per target protocol; routes of both source surfaces share it.
-	providers := map[string]*typ.Provider{
-		"chat": {
-			UUID:               "tb1-openai-chat",
-			Name:               "tb1-openai-chat",
-			APIBase:            env.tb1.URL + "/virtual/openai/v1",
-			APIStyle:           protocol.APIStyleOpenAI,
-			OpenAIEndpointMode: ai.EndpointModeChat,
-		},
-		"responses": {
-			UUID:               "tb1-openai-responses",
-			Name:               "tb1-openai-responses",
-			APIBase:            env.tb1.URL + "/virtual/openai/v1",
-			APIStyle:           protocol.APIStyleOpenAI,
-			OpenAIEndpointMode: ai.EndpointModeResponses,
-		},
-		"anthropic": {
-			UUID:     "tb1-anthropic",
-			Name:     "tb1-anthropic",
-			APIBase:  env.tb1.URL + "/virtual/anthropic", // SDK appends /v1/messages
-			APIStyle: protocol.APIStyleAnthropic,
-		},
-	}
-	for _, p := range providers {
-		p.Token = tb1Token
-		p.Enabled = true
-		p.Timeout = int64(constant.DefaultRequestTimeout)
-		if err := env.tb2Cfg.AddProvider(p); err != nil {
-			env.Close()
-			return nil, fmt.Errorf("add provider %s: %w", p.Name, err)
-		}
-	}
-
-	for _, route := range AllDuoRoutes() {
-		rule := typ.Rule{
-			UUID:          route.RequestModel(),
-			Scenario:      typ.ScenarioAnthropic,
-			RequestModel:  route.RequestModel(),
-			ResponseModel: duoTargetVModel(route.Target),
-			Services: []*loadbalance.Service{{
-				Provider:   providers[route.Target].UUID,
-				Model:      duoTargetVModel(route.Target),
-				Weight:     1,
-				Active:     true,
-				TimeWindow: 300,
-			}},
-			LBTactic: typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.NewRandomParams()},
-			Active:   true,
-		}
-		if err := env.tb2Cfg.GetGlobalConfig().AddRequestConfig(rule); err != nil {
-			env.Close()
-			return nil, fmt.Errorf("add rule %s: %w", route.Name, err)
-		}
-	}
+	env.TB2 = tb2
 	return env, nil
 }
 
-// Close shuts down both instances and removes their config dirs.
-func (env *DuoEnv) Close() {
-	if env.tb1 != nil {
-		env.tb1.Close()
+// startInstance spawns one child instance (re-executing this binary under
+// the duo env contract), waits for it to become healthy, and reads its
+// tokens from the child's config.json.
+func (env *DuoEnv) startInstance(name string, cfg DuoEnvConfig, extra map[string]string) (*DuoInstance, error) {
+	dir, err := os.MkdirTemp("", "duo-"+name+"-*")
+	if err != nil {
+		return nil, err
 	}
-	if env.tb2 != nil {
-		env.tb2.Close()
+	env.dirs = append(env.dirs, dir)
+
+	port, err := pickFreePort()
+	if err != nil {
+		return nil, err
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	inst := &DuoInstance{
+		Name:      name,
+		ConfigDir: dir,
+		Port:      port,
+		BaseURL:   fmt.Sprintf("http://127.0.0.1:%d", port),
+		out:       newTailBuffer(64 * 1024),
+		done:      make(chan struct{}),
+		hc:        &http.Client{Timeout: 60 * time.Second},
+	}
+
+	cmd := exec.Command(exe)
+	cmd.Env = append(os.Environ(),
+		duoEnvRole+"="+duoRoleServe,
+		duoEnvName+"="+name,
+		duoEnvConfigDir+"="+dir,
+		duoEnvPort+"="+strconv.Itoa(port),
+	)
+	for k, v := range extra {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var sink io.Writer = inst.out
+	if cfg.ChildLog != nil {
+		sink = io.MultiWriter(inst.out, cfg.ChildLog)
+	}
+	cmd.Stdout = sink
+	cmd.Stderr = sink
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("spawn %s: %w", name, err)
+	}
+	inst.cmd = cmd
+	go func() {
+		inst.exitErr = cmd.Wait()
+		close(inst.done)
+	}()
+
+	if err := inst.waitReady(cfg.BootTimeout); err != nil {
+		return inst, fmt.Errorf("%s not ready: %w\n--- %s output tail ---\n%s", name, err, name, inst.OutputTail())
+	}
+	if err := inst.readTokens(); err != nil {
+		return inst, fmt.Errorf("%s tokens: %w", name, err)
+	}
+	return inst, nil
+}
+
+// waitReady polls the unauthenticated health endpoint until the instance
+// answers 200 or the deadline passes.
+func (inst *DuoInstance) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	url := inst.BaseURL + "/api/v1/info/health"
+	for time.Now().Before(deadline) {
+		if inst.exited() {
+			return fmt.Errorf("process exited during boot: %v", inst.exitErr)
+		}
+		resp, err := inst.hc.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("health check timed out after %s", timeout)
+}
+
+// readTokens reads the child-generated user/model tokens from its
+// config.json (written before the server starts listening).
+func (inst *DuoInstance) readTokens() error {
+	raw, err := os.ReadFile(filepath.Join(inst.ConfigDir, "config.json"))
+	if err != nil {
+		return err
+	}
+	var c struct {
+		UserToken  string `json:"user_token"`
+		ModelToken string `json:"model_token"`
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return err
+	}
+	if c.UserToken == "" || c.ModelToken == "" {
+		return fmt.Errorf("config.json missing tokens")
+	}
+	inst.UserToken = c.UserToken
+	inst.ModelToken = c.ModelToken
+	return nil
+}
+
+// Close terminates both instances and removes their config dirs.
+func (env *DuoEnv) Close() {
+	for _, inst := range []*DuoInstance{env.TB1, env.TB2} {
+		if inst == nil || inst.cmd == nil || inst.cmd.Process == nil {
+			continue
+		}
+		if !inst.exited() {
+			_ = inst.cmd.Process.Signal(syscall.SIGTERM)
+			select {
+			case <-inst.done:
+			case <-time.After(5 * time.Second):
+				_ = inst.cmd.Process.Kill()
+				select {
+				case <-inst.done:
+				case <-time.After(5 * time.Second):
+				}
+			}
+		}
 	}
 	for _, d := range env.dirs {
 		os.RemoveAll(d)
 	}
 }
 
-// TB1URL and TB2URL expose the instance endpoints (diagnostics/logging).
-func (env *DuoEnv) TB1URL() string { return env.tb1.URL }
-func (env *DuoEnv) TB2URL() string { return env.tb2.URL }
+// pickFreePort reserves an ephemeral localhost port and releases it for the
+// child to bind. (Small race window; boot failure surfaces via waitReady.)
+func pickFreePort() (int, error) {
+	l, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// tailBuffer is a concurrency-safe writer that keeps the last max bytes.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	max int
+}
+
+func newTailBuffer(max int) *tailBuffer { return &tailBuffer{max: max} }
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > t.max {
+		t.buf = t.buf[len(t.buf)-t.max:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.buf)
+}
+
+// ─── Request driving ─────────────────────────────────────────────────────────
 
 // BuildConversationBody builds a Claude-Code-shaped Anthropic request of
 // approximately totalBytes for the given route: alternating user/assistant
@@ -261,18 +499,39 @@ func (env *DuoEnv) post(route DuoRoute, body []byte) (*http.Response, error) {
 	if route.Beta {
 		path += "?beta=true"
 	}
-	req, err := http.NewRequest(http.MethodPost, env.tb2.URL+path, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, env.TB2.BaseURL+path, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+env.tb2Token)
+	req.Header.Set("Authorization", "Bearer "+env.TB2.ModelToken)
 	return env.client.Do(req)
+}
+
+// slowReader throttles SSE consumption to simulate a slow client: each Read
+// is capped to a small window and followed by a pause, so TCP backpressure
+// builds up against the gateway the way a slow real consumer causes it to.
+type slowReader struct {
+	r     io.Reader
+	delay time.Duration
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	const window = 8 * 1024
+	if len(p) > window {
+		p = p[:window]
+	}
+	n, err := s.r.Read(p)
+	if n > 0 && s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	return n, err
 }
 
 // DrainStreaming drives one streaming request over the route and fully
 // drains the SSE body, returning the number of `event:` lines seen.
-func (env *DuoEnv) DrainStreaming(route DuoRoute, body []byte) (int, error) {
+// A non-zero readDelay reads the body slowly (see slowReader).
+func (env *DuoEnv) DrainStreaming(route DuoRoute, body []byte, readDelay time.Duration) (int, error) {
 	resp, err := env.post(route, body)
 	if err != nil {
 		return 0, err
@@ -282,7 +541,11 @@ func (env *DuoEnv) DrainStreaming(route DuoRoute, body []byte) (int, error) {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		return 0, fmt.Errorf("status %d: %s", resp.StatusCode, b)
 	}
-	sc := bufio.NewScanner(resp.Body)
+	var r io.Reader = resp.Body
+	if readDelay > 0 {
+		r = &slowReader{r: resp.Body, delay: readDelay}
+	}
+	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	events := 0
 	for sc.Scan() {
@@ -294,287 +557,4 @@ func (env *DuoEnv) DrainStreaming(route DuoRoute, body []byte) (int, error) {
 		return 0, fmt.Errorf("no SSE events received")
 	}
 	return events, sc.Err()
-}
-
-// ─── Functional phase ─────────────────────────────────────────────────────────
-
-// DuoCheck is one functional verification result.
-type DuoCheck struct {
-	Route  string `json:"route"`
-	Name   string `json:"name"`
-	Pass   bool   `json:"pass"`
-	Detail string `json:"detail,omitempty"`
-}
-
-// RunFunctionalChecks verifies protocol correctness of one conversion route
-// with a bodyBytes-sized conversation: streaming SSE shape, assembled
-// content, usage propagation, and the non-streaming response body.
-func (env *DuoEnv) RunFunctionalChecks(route DuoRoute, bodyBytes int) []DuoCheck {
-	var checks []DuoCheck
-	add := func(name string, pass bool, detail string) {
-		checks = append(checks, DuoCheck{Route: route.Name, Name: name, Pass: pass, Detail: detail})
-	}
-	env.streamingChecks(route, bodyBytes, add)
-	env.nonStreamingChecks(route, bodyBytes, add)
-	return checks
-}
-
-// streamingChecks verifies SSE event shape and the assembled streaming result.
-func (env *DuoEnv) streamingChecks(route DuoRoute, bodyBytes int, add func(name string, pass bool, detail string)) {
-	resp, err := env.post(route, BuildConversationBody(route, bodyBytes, true))
-	if err != nil {
-		add("stream/http", false, err.Error())
-		return
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		add("stream/http", false, fmt.Sprintf("status %d: %s", resp.StatusCode, b))
-		return
-	}
-	add("stream/http", true, "200")
-
-	events, _ := sse.ReadSSELines(resp.Body)
-	joined := strings.Join(events, "\n")
-	for _, evt := range []string{"message_start", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop"} {
-		add("stream/event/"+evt, strings.Contains(joined, evt), "")
-	}
-
-	parsed := sse.AssembleAnthropicStream(events)
-	if parsed == nil {
-		add("stream/assemble", false, "assembler returned nil")
-		return
-	}
-	add("stream/assemble", parsed.Content != "", fmt.Sprintf("content=%dB", len(parsed.Content)))
-	add("stream/finish_reason", parsed.FinishReason != "", parsed.FinishReason)
-	if parsed.Usage == nil {
-		add("stream/usage", false, "no usage in stream")
-	} else {
-		add("stream/usage", parsed.Usage.InputTokens > 0 && parsed.Usage.OutputTokens > 0,
-			fmt.Sprintf("in=%d out=%d", parsed.Usage.InputTokens, parsed.Usage.OutputTokens))
-	}
-}
-
-// nonStreamingChecks verifies the non-streaming response body shape.
-func (env *DuoEnv) nonStreamingChecks(route DuoRoute, bodyBytes int, add func(name string, pass bool, detail string)) {
-	resp, err := env.post(route, BuildConversationBody(route, bodyBytes, false))
-	if err != nil {
-		add("nonstream/http", false, err.Error())
-		return
-	}
-	defer resp.Body.Close()
-	raw, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		add("nonstream/http", false, fmt.Sprintf("status %d: %s", resp.StatusCode, raw[:min(len(raw), 2048)]))
-		return
-	}
-	add("nonstream/http", true, "200")
-	var m map[string]interface{}
-	if err := json.Unmarshal(raw, &m); err != nil {
-		add("nonstream/body", false, "invalid JSON: "+err.Error())
-		return
-	}
-	parsed := sse.ParseAnthropicResult(m)
-	if parsed == nil {
-		add("nonstream/body", false, "unparseable anthropic body")
-		return
-	}
-	add("nonstream/content", parsed.Content != "", fmt.Sprintf("content=%dB", len(parsed.Content)))
-	add("nonstream/usage", parsed.Usage != nil && parsed.Usage.InputTokens > 0, "")
-}
-
-// ─── Memory phase ─────────────────────────────────────────────────────────────
-
-// DuoMemoryConfig parameterizes RunMemoryPhase.
-type DuoMemoryConfig struct {
-	Route      *DuoRoute // conversion route to drive (default DuoDefaultRoute)
-	BodyBytes  int       // conversation size per request (default 2MB)
-	Warmup     int       // warmup requests before the baseline (default 3)
-	Batch      int       // requests per sequential batch, two batches are run (default 15)
-	Workers    int       // concurrent workers in the burst phase (default 4)
-	PerWorker  int       // requests per worker in the burst phase (default 5)
-	ProfileDir string    // write pprof heap profiles here ("" = skip)
-	Progress   func(format string, args ...any)
-}
-
-func (c *DuoMemoryConfig) withDefaults() {
-	if c.Route == nil {
-		r := DuoDefaultRoute
-		c.Route = &r
-	}
-	if c.BodyBytes <= 0 {
-		c.BodyBytes = 2 * 1024 * 1024
-	}
-	if c.Warmup <= 0 {
-		c.Warmup = 3
-	}
-	if c.Batch <= 0 {
-		c.Batch = 15
-	}
-	if c.Workers <= 0 {
-		c.Workers = 4
-	}
-	if c.PerWorker <= 0 {
-		c.PerWorker = 5
-	}
-	if c.Progress == nil {
-		c.Progress = func(string, ...any) {}
-	}
-}
-
-// DuoMemoryReport is the outcome of RunMemoryPhase.
-type DuoMemoryReport struct {
-	Route             string  `json:"route"`
-	BodyBytes         int     `json:"body_bytes"`
-	Batch             int     `json:"batch_requests"` // two sequential batches of this size are run
-	BaselineHeapMB    float64 `json:"baseline_heap_mb"`
-	AfterBatch1MB     float64 `json:"after_batch1_delta_mb"`
-	AfterBatch2MB     float64 `json:"after_batch2_delta_mb"`
-	SlopeKBPerRequest float64 `json:"retention_slope_kb_per_request"`
-	ChurnMBPerRequest float64 `json:"alloc_churn_mb_per_request"`
-	ConcurrentWorkers int     `json:"concurrent_workers"`
-	ConcurrentTotal   int     `json:"concurrent_requests"`
-	PeakHeapMB        float64 `json:"concurrent_peak_heap_mb"`
-	PostBurstDeltaMB  float64 `json:"post_burst_delta_mb"`
-	BaselineProfile   string  `json:"baseline_profile,omitempty"`
-	FinalProfile      string  `json:"final_profile,omitempty"`
-}
-
-func duoHeapAfterGC() uint64 {
-	runtime.GC()
-	runtime.GC()
-	var m runtime.MemStats
-	runtime.ReadMemStats(&m)
-	return m.HeapAlloc
-}
-
-func duoWriteHeapProfile(dir, name string) (string, error) {
-	runtime.GC()
-	path := filepath.Join(dir, name)
-	f, err := os.Create(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
-		return "", err
-	}
-	return path, nil
-}
-
-// RunMemoryPhase measures allocation churn, post-GC retention slope, and
-// concurrent-burst peak heap on one conversion route. A near-zero slope means
-// no per-request leak (reference numbers live with duo_test.go's threshold).
-func (env *DuoEnv) RunMemoryPhase(cfg DuoMemoryConfig) (*DuoMemoryReport, error) {
-	cfg.withDefaults()
-	route := *cfg.Route
-	body := BuildConversationBody(route, cfg.BodyBytes, true)
-	report := &DuoMemoryReport{
-		Route:             route.Name,
-		BodyBytes:         len(body),
-		Batch:             cfg.Batch,
-		ConcurrentWorkers: cfg.Workers,
-		ConcurrentTotal:   cfg.Workers * cfg.PerWorker,
-	}
-
-	cfg.Progress("route %s: warmup %d requests, body %.2f MB", route.Name, cfg.Warmup, float64(len(body))/1024/1024)
-	for i := 0; i < cfg.Warmup; i++ {
-		if _, err := env.DrainStreaming(route, body); err != nil {
-			return nil, fmt.Errorf("warmup request %d: %w", i, err)
-		}
-	}
-
-	baseline := duoHeapAfterGC()
-	report.BaselineHeapMB = float64(baseline) / 1024 / 1024
-	if cfg.ProfileDir != "" {
-		p, err := duoWriteHeapProfile(cfg.ProfileDir, "duo-"+route.Name+"-baseline.pb.gz")
-		if err != nil {
-			return nil, err
-		}
-		report.BaselineProfile = p
-	}
-	var m0 runtime.MemStats
-	runtime.ReadMemStats(&m0)
-
-	runBatch := func() error {
-		for i := 0; i < cfg.Batch; i++ {
-			if _, err := env.DrainStreaming(route, body); err != nil {
-				return fmt.Errorf("sequential request: %w", err)
-			}
-		}
-		return nil
-	}
-	cfg.Progress("route %s: sequential 2 batches × %d requests", route.Name, cfg.Batch)
-	if err := runBatch(); err != nil {
-		return nil, err
-	}
-	after1 := duoHeapAfterGC()
-	if err := runBatch(); err != nil {
-		return nil, err
-	}
-	after2 := duoHeapAfterGC()
-
-	var m1 runtime.MemStats
-	runtime.ReadMemStats(&m1)
-	report.AfterBatch1MB = float64(int64(after1)-int64(baseline)) / 1024 / 1024
-	report.AfterBatch2MB = float64(int64(after2)-int64(baseline)) / 1024 / 1024
-	report.SlopeKBPerRequest = (float64(int64(after2)) - float64(int64(after1))) / float64(cfg.Batch) / 1024
-	report.ChurnMBPerRequest = float64(m1.TotalAlloc-m0.TotalAlloc) / float64(2*cfg.Batch) / 1024 / 1024
-
-	// Concurrent burst with live-heap sampling.
-	cfg.Progress("route %s: concurrent burst %d workers × %d requests", route.Name, cfg.Workers, cfg.PerWorker)
-	peakCh := make(chan uint64, 1)
-	stop := make(chan struct{})
-	go func() {
-		var peak uint64
-		// ReadMemStats is a stop-the-world operation; 50ms still catches a
-		// burst peak without perturbing the workload being measured.
-		tick := time.NewTicker(50 * time.Millisecond)
-		defer tick.Stop()
-		for {
-			select {
-			case <-stop:
-				peakCh <- peak
-				return
-			case <-tick.C:
-				var m runtime.MemStats
-				runtime.ReadMemStats(&m)
-				if m.HeapAlloc > peak {
-					peak = m.HeapAlloc
-				}
-			}
-		}
-	}()
-	var wg sync.WaitGroup
-	errCh := make(chan error, cfg.Workers)
-	for g := 0; g < cfg.Workers; g++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := 0; i < cfg.PerWorker; i++ {
-				if _, err := env.DrainStreaming(route, body); err != nil {
-					errCh <- err
-					return
-				}
-			}
-		}()
-	}
-	wg.Wait()
-	close(stop)
-	report.PeakHeapMB = float64(<-peakCh) / 1024 / 1024
-	select {
-	case err := <-errCh:
-		return nil, fmt.Errorf("concurrent request: %w", err)
-	default:
-	}
-	report.PostBurstDeltaMB = float64(int64(duoHeapAfterGC())-int64(baseline)) / 1024 / 1024
-
-	if cfg.ProfileDir != "" {
-		p, err := duoWriteHeapProfile(cfg.ProfileDir, "duo-"+route.Name+"-final.pb.gz")
-		if err != nil {
-			return nil, err
-		}
-		report.FinalProfile = p
-	}
-	return report, nil
 }

--- a/internal/protocoltest/duo.go
+++ b/internal/protocoltest/duo.go
@@ -170,8 +170,23 @@ func (inst *DuoInstance) exited() bool {
 
 // MemStats fetches a runtime memory snapshot from the instance's debug
 // endpoint. With gc=true the instance forces a full GC first, so
-// HeapAllocBytes is its post-GC retained set.
+// HeapAllocBytes is its post-GC retained set; the endpoint throttles forced
+// GCs, so a throttled sample is retried until the GC actually ran.
 func (inst *DuoInstance) MemStats(gc bool) (*debugmodule.MemStatsResponse, error) {
+	const gcRetries = 3
+	for attempt := 0; ; attempt++ {
+		m, err := inst.memStatsOnce(gc)
+		if err != nil {
+			return nil, err
+		}
+		if !gc || m.GCForced || attempt >= gcRetries {
+			return m, nil
+		}
+		time.Sleep(1100 * time.Millisecond) // just past the endpoint's forced-GC throttle window
+	}
+}
+
+func (inst *DuoInstance) memStatsOnce(gc bool) (*debugmodule.MemStatsResponse, error) {
 	url := inst.BaseURL + "/api/v1/debug/memstats"
 	if gc {
 		url += "?gc=true"

--- a/internal/protocoltest/duo.go
+++ b/internal/protocoltest/duo.go
@@ -213,16 +213,25 @@ func (inst *DuoInstance) memStatsOnce(gc bool) (*debugmodule.MemStatsResponse, e
 }
 
 // WriteHeapProfile fetches a post-GC pprof heap profile from the instance
-// and writes it under dir, returning the file path.
+// and writes it under dir, returning the file path. The endpoint throttles
+// profile serialization, so a 429 is retried past the throttle window.
 func (inst *DuoInstance) WriteHeapProfile(dir, name string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, inst.BaseURL+"/api/v1/debug/pprof/heap?gc=true", nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+inst.UserToken)
-	resp, err := inst.hc.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("%s heap profile: %w", inst.Name, err)
+	var resp *http.Response
+	for attempt := 0; ; attempt++ {
+		resp, err = inst.hc.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("%s heap profile: %w", inst.Name, err)
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= 3 {
+			break
+		}
+		resp.Body.Close()
+		time.Sleep(1100 * time.Millisecond) // just past the endpoint's profile throttle window
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/internal/protocoltest/duo_checks.go
+++ b/internal/protocoltest/duo_checks.go
@@ -1,0 +1,99 @@
+package protocoltest
+
+// Functional phase of the duo environment: protocol correctness of one
+// conversion route, driven end-to-end over real HTTP through both processes.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
+)
+
+// DuoCheck is one functional verification result.
+type DuoCheck struct {
+	Route  string `json:"route"`
+	Name   string `json:"name"`
+	Pass   bool   `json:"pass"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// RunFunctionalChecks verifies protocol correctness of one conversion route
+// with a bodyBytes-sized conversation: streaming SSE shape, assembled
+// content, usage propagation, and the non-streaming response body.
+func (env *DuoEnv) RunFunctionalChecks(route DuoRoute, bodyBytes int) []DuoCheck {
+	var checks []DuoCheck
+	add := func(name string, pass bool, detail string) {
+		checks = append(checks, DuoCheck{Route: route.Name, Name: name, Pass: pass, Detail: detail})
+	}
+	env.streamingChecks(route, bodyBytes, add)
+	env.nonStreamingChecks(route, bodyBytes, add)
+	return checks
+}
+
+// streamingChecks verifies SSE event shape and the assembled streaming result.
+func (env *DuoEnv) streamingChecks(route DuoRoute, bodyBytes int, add func(name string, pass bool, detail string)) {
+	resp, err := env.post(route, BuildConversationBody(route, bodyBytes, true))
+	if err != nil {
+		add("stream/http", false, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		add("stream/http", false, fmt.Sprintf("status %d: %s", resp.StatusCode, b))
+		return
+	}
+	add("stream/http", true, "200")
+
+	events, _ := sse.ReadSSELines(resp.Body)
+	joined := strings.Join(events, "\n")
+	for _, evt := range []string{"message_start", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop"} {
+		add("stream/event/"+evt, strings.Contains(joined, evt), "")
+	}
+
+	parsed := sse.AssembleAnthropicStream(events)
+	if parsed == nil {
+		add("stream/assemble", false, "assembler returned nil")
+		return
+	}
+	add("stream/assemble", parsed.Content != "", fmt.Sprintf("content=%dB", len(parsed.Content)))
+	add("stream/finish_reason", parsed.FinishReason != "", parsed.FinishReason)
+	if parsed.Usage == nil {
+		add("stream/usage", false, "no usage in stream")
+	} else {
+		add("stream/usage", parsed.Usage.InputTokens > 0 && parsed.Usage.OutputTokens > 0,
+			fmt.Sprintf("in=%d out=%d", parsed.Usage.InputTokens, parsed.Usage.OutputTokens))
+	}
+}
+
+// nonStreamingChecks verifies the non-streaming response body shape.
+func (env *DuoEnv) nonStreamingChecks(route DuoRoute, bodyBytes int, add func(name string, pass bool, detail string)) {
+	resp, err := env.post(route, BuildConversationBody(route, bodyBytes, false))
+	if err != nil {
+		add("nonstream/http", false, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		add("nonstream/http", false, fmt.Sprintf("status %d: %s", resp.StatusCode, raw[:min(len(raw), 2048)]))
+		return
+	}
+	add("nonstream/http", true, "200")
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		add("nonstream/body", false, "invalid JSON: "+err.Error())
+		return
+	}
+	parsed := sse.ParseAnthropicResult(m)
+	if parsed == nil {
+		add("nonstream/body", false, "unparseable anthropic body")
+		return
+	}
+	add("nonstream/content", parsed.Content != "", fmt.Sprintf("content=%dB", len(parsed.Content)))
+	add("nonstream/usage", parsed.Usage != nil && parsed.Usage.InputTokens > 0, "")
+}

--- a/internal/protocoltest/duo_memory.go
+++ b/internal/protocoltest/duo_memory.go
@@ -1,0 +1,264 @@
+package protocoltest
+
+// Memory phase of the duo environment. Both instances are observed
+// SEPARATELY over their /api/v1/debug endpoints, so a retention slope
+// attributes directly: tb2 slope → gateway/conversion path (the #1255
+// class), tb1 slope → vmodel serving path. The parent process drives
+// requests but is never measured — its own allocations cannot pollute the
+// numbers the way a shared-heap setup would.
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// DuoMemoryConfig parameterizes RunMemoryPhase.
+type DuoMemoryConfig struct {
+	Route     *DuoRoute // conversion route to drive (default DuoDefaultRoute)
+	BodyBytes int       // conversation size per request (default 2MB)
+	Warmup    int       // warmup requests before the baseline (default 3)
+	Batch     int       // requests per sequential batch, two batches are run (default 15)
+	Workers   int       // concurrent workers in the burst phase (default 4)
+	PerWorker int       // requests per worker in the burst phase (default 5)
+	// ReadDelay throttles client-side SSE consumption (see slowReader),
+	// building real TCP backpressure against tb2. 0 = read at full speed.
+	ReadDelay  time.Duration
+	ProfileDir string // write pprof heap profiles here ("" = skip)
+	Progress   func(format string, args ...any)
+}
+
+func (c *DuoMemoryConfig) withDefaults() {
+	if c.Route == nil {
+		r := DuoDefaultRoute
+		c.Route = &r
+	}
+	if c.BodyBytes <= 0 {
+		c.BodyBytes = 2 * 1024 * 1024
+	}
+	if c.Warmup <= 0 {
+		c.Warmup = 3
+	}
+	if c.Batch <= 0 {
+		c.Batch = 15
+	}
+	if c.Workers <= 0 {
+		c.Workers = 4
+	}
+	if c.PerWorker <= 0 {
+		c.PerWorker = 5
+	}
+	if c.Progress == nil {
+		c.Progress = func(string, ...any) {}
+	}
+}
+
+// DuoInstanceMemory is the memory outcome for ONE instance.
+type DuoInstanceMemory struct {
+	Instance           string  `json:"instance"` // "tb1" (vmodel upstream) or "tb2" (gateway)
+	BaselineHeapMB     float64 `json:"baseline_heap_mb"`
+	AfterBatch1MB      float64 `json:"after_batch1_delta_mb"`
+	AfterBatch2MB      float64 `json:"after_batch2_delta_mb"`
+	SlopeKBPerRequest  float64 `json:"retention_slope_kb_per_request"`
+	ChurnMBPerRequest  float64 `json:"alloc_churn_mb_per_request"`
+	PeakHeapMB         float64 `json:"concurrent_peak_heap_mb"`
+	PostBurstDeltaMB   float64 `json:"post_burst_delta_mb"`
+	BaselineGoroutines int     `json:"baseline_goroutines"`
+	FinalGoroutines    int     `json:"final_goroutines"`
+	BaselineProfile    string  `json:"baseline_profile,omitempty"`
+	FinalProfile       string  `json:"final_profile,omitempty"`
+}
+
+// DuoMemoryReport is the outcome of RunMemoryPhase across both instances.
+type DuoMemoryReport struct {
+	Route             string            `json:"route"`
+	BodyBytes         int               `json:"body_bytes"`
+	Batch             int               `json:"batch_requests"` // two sequential batches of this size are run
+	ReadDelayMS       int               `json:"read_delay_ms"`  // client-side slow-reader pause (0 = full speed)
+	ConcurrentWorkers int               `json:"concurrent_workers"`
+	ConcurrentTotal   int               `json:"concurrent_requests"`
+	TB1               DuoInstanceMemory `json:"tb1"`
+	TB2               DuoInstanceMemory `json:"tb2"`
+}
+
+// Instances returns both per-instance results, tb1 first.
+func (r *DuoMemoryReport) Instances() []*DuoInstanceMemory {
+	return []*DuoInstanceMemory{&r.TB1, &r.TB2}
+}
+
+// MaxSlopeKB returns the larger of the two instances' retention slopes.
+func (r *DuoMemoryReport) MaxSlopeKB() float64 {
+	if r.TB1.SlopeKBPerRequest > r.TB2.SlopeKBPerRequest {
+		return r.TB1.SlopeKBPerRequest
+	}
+	return r.TB2.SlopeKBPerRequest
+}
+
+// duoMemProbe accumulates the per-instance samples during a memory phase run.
+type duoMemProbe struct {
+	inst        *DuoInstance
+	result      DuoInstanceMemory
+	baseline    uint64
+	totalAlloc0 uint64
+}
+
+// sampleGC takes a post-GC snapshot from the probe's instance.
+func (p *duoMemProbe) sampleGC() (heapAlloc, totalAlloc uint64, goroutines int, err error) {
+	m, err := p.inst.MemStats(true)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return m.HeapAllocBytes, m.TotalAllocBytes, m.NumGoroutine, nil
+}
+
+// RunMemoryPhase measures allocation churn, post-GC retention slope, and
+// concurrent-burst peak heap on one conversion route — separately for tb1
+// and tb2. A near-zero slope means no per-request leak on that instance
+// (reference numbers live with duo_test.go's threshold).
+func (env *DuoEnv) RunMemoryPhase(cfg DuoMemoryConfig) (*DuoMemoryReport, error) {
+	cfg.withDefaults()
+	route := *cfg.Route
+	body := BuildConversationBody(route, cfg.BodyBytes, true)
+	report := &DuoMemoryReport{
+		Route:             route.Name,
+		BodyBytes:         len(body),
+		Batch:             cfg.Batch,
+		ReadDelayMS:       int(cfg.ReadDelay / time.Millisecond),
+		ConcurrentWorkers: cfg.Workers,
+		ConcurrentTotal:   cfg.Workers * cfg.PerWorker,
+	}
+	probes := []*duoMemProbe{
+		{inst: env.TB1, result: DuoInstanceMemory{Instance: "tb1"}},
+		{inst: env.TB2, result: DuoInstanceMemory{Instance: "tb2"}},
+	}
+
+	cfg.Progress("route %s: warmup %d requests, body %.2f MB, read delay %s",
+		route.Name, cfg.Warmup, float64(len(body))/1024/1024, cfg.ReadDelay)
+	for i := 0; i < cfg.Warmup; i++ {
+		if _, err := env.DrainStreaming(route, body, cfg.ReadDelay); err != nil {
+			return nil, fmt.Errorf("warmup request %d: %w", i, err)
+		}
+	}
+
+	for _, p := range probes {
+		heap, total, goroutines, err := p.sampleGC()
+		if err != nil {
+			return nil, err
+		}
+		p.baseline = heap
+		p.totalAlloc0 = total
+		p.result.BaselineHeapMB = float64(heap) / 1024 / 1024
+		p.result.BaselineGoroutines = goroutines
+		if cfg.ProfileDir != "" {
+			path, err := p.inst.WriteHeapProfile(cfg.ProfileDir,
+				fmt.Sprintf("duo-%s-%s-baseline.pb.gz", route.Name, p.inst.Name))
+			if err != nil {
+				return nil, err
+			}
+			p.result.BaselineProfile = path
+		}
+	}
+
+	runBatch := func() error {
+		for i := 0; i < cfg.Batch; i++ {
+			if _, err := env.DrainStreaming(route, body, cfg.ReadDelay); err != nil {
+				return fmt.Errorf("sequential request: %w", err)
+			}
+		}
+		return nil
+	}
+	cfg.Progress("route %s: sequential 2 batches × %d requests", route.Name, cfg.Batch)
+	if err := runBatch(); err != nil {
+		return nil, err
+	}
+	after1 := make([]uint64, len(probes))
+	for i, p := range probes {
+		heap, _, _, err := p.sampleGC()
+		if err != nil {
+			return nil, err
+		}
+		after1[i] = heap
+		p.result.AfterBatch1MB = float64(int64(heap)-int64(p.baseline)) / 1024 / 1024
+	}
+	if err := runBatch(); err != nil {
+		return nil, err
+	}
+	for i, p := range probes {
+		heap, total, _, err := p.sampleGC()
+		if err != nil {
+			return nil, err
+		}
+		p.result.AfterBatch2MB = float64(int64(heap)-int64(p.baseline)) / 1024 / 1024
+		p.result.SlopeKBPerRequest = (float64(int64(heap)) - float64(int64(after1[i]))) / float64(cfg.Batch) / 1024
+		p.result.ChurnMBPerRequest = float64(total-p.totalAlloc0) / float64(2*cfg.Batch) / 1024 / 1024
+	}
+
+	// Concurrent burst with per-instance live-heap sampling over HTTP.
+	cfg.Progress("route %s: concurrent burst %d workers × %d requests", route.Name, cfg.Workers, cfg.PerWorker)
+	peaks := make([]uint64, len(probes))
+	stop := make(chan struct{})
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		// ReadMemStats on the target is a stop-the-world operation; 100ms
+		// still catches a burst peak without perturbing the workload.
+		tick := time.NewTicker(100 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				for i, p := range probes {
+					if m, err := p.inst.MemStats(false); err == nil && m.HeapAllocBytes > peaks[i] {
+						peaks[i] = m.HeapAllocBytes
+					}
+				}
+			}
+		}
+	}()
+	var wg sync.WaitGroup
+	errCh := make(chan error, cfg.Workers)
+	for g := 0; g < cfg.Workers; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < cfg.PerWorker; i++ {
+				if _, err := env.DrainStreaming(route, body, cfg.ReadDelay); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	<-samplerDone
+	select {
+	case err := <-errCh:
+		return nil, fmt.Errorf("concurrent request: %w", err)
+	default:
+	}
+
+	for i, p := range probes {
+		p.result.PeakHeapMB = float64(peaks[i]) / 1024 / 1024
+		heap, _, goroutines, err := p.sampleGC()
+		if err != nil {
+			return nil, err
+		}
+		p.result.PostBurstDeltaMB = float64(int64(heap)-int64(p.baseline)) / 1024 / 1024
+		p.result.FinalGoroutines = goroutines
+		if cfg.ProfileDir != "" {
+			path, err := p.inst.WriteHeapProfile(cfg.ProfileDir,
+				fmt.Sprintf("duo-%s-%s-final.pb.gz", route.Name, p.inst.Name))
+			if err != nil {
+				return nil, err
+			}
+			p.result.FinalProfile = path
+		}
+	}
+
+	report.TB1 = probes[0].result
+	report.TB2 = probes[1].result
+	return report, nil
+}

--- a/internal/protocoltest/duo_memory.go
+++ b/internal/protocoltest/duo_memory.go
@@ -8,6 +8,7 @@ package protocoltest
 // numbers the way a shared-heap setup would.
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -88,10 +89,7 @@ func (r *DuoMemoryReport) Instances() []*DuoInstanceMemory {
 
 // MaxSlopeKB returns the larger of the two instances' retention slopes.
 func (r *DuoMemoryReport) MaxSlopeKB() float64 {
-	if r.TB1.SlopeKBPerRequest > r.TB2.SlopeKBPerRequest {
-		return r.TB1.SlopeKBPerRequest
-	}
-	return r.TB2.SlopeKBPerRequest
+	return max(r.TB1.SlopeKBPerRequest, r.TB2.SlopeKBPerRequest)
 }
 
 // duoMemProbe accumulates the per-instance samples during a memory phase run.
@@ -99,16 +97,27 @@ type duoMemProbe struct {
 	inst        *DuoInstance
 	result      DuoInstanceMemory
 	baseline    uint64
+	after1      uint64
 	totalAlloc0 uint64
+	peak        uint64
 }
 
-// sampleGC takes a post-GC snapshot from the probe's instance.
-func (p *duoMemProbe) sampleGC() (heapAlloc, totalAlloc uint64, goroutines int, err error) {
-	m, err := p.inst.MemStats(true)
-	if err != nil {
-		return 0, 0, 0, err
+// forEachProbe runs fn against both probes concurrently. The instances are
+// independent processes, so their forced-GC pauses (the expensive part of a
+// checkpoint) need not be paid back-to-back; the parent is never measured, so
+// the extra goroutine is free.
+func forEachProbe(probes []*duoMemProbe, fn func(p *duoMemProbe) error) error {
+	errs := make([]error, len(probes))
+	var wg sync.WaitGroup
+	for i, p := range probes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = fn(p)
+		}()
 	}
-	return m.HeapAllocBytes, m.TotalAllocBytes, m.NumGoroutine, nil
+	wg.Wait()
+	return errors.Join(errs...)
 }
 
 // RunMemoryPhase measures allocation churn, post-GC retention slope, and
@@ -140,23 +149,26 @@ func (env *DuoEnv) RunMemoryPhase(cfg DuoMemoryConfig) (*DuoMemoryReport, error)
 		}
 	}
 
-	for _, p := range probes {
-		heap, total, goroutines, err := p.sampleGC()
+	if err := forEachProbe(probes, func(p *duoMemProbe) error {
+		m, err := p.inst.MemStats(true)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		p.baseline = heap
-		p.totalAlloc0 = total
-		p.result.BaselineHeapMB = float64(heap) / 1024 / 1024
-		p.result.BaselineGoroutines = goroutines
+		p.baseline = m.HeapAllocBytes
+		p.totalAlloc0 = m.TotalAllocBytes
+		p.result.BaselineHeapMB = float64(m.HeapAllocBytes) / 1024 / 1024
+		p.result.BaselineGoroutines = m.NumGoroutine
 		if cfg.ProfileDir != "" {
 			path, err := p.inst.WriteHeapProfile(cfg.ProfileDir,
 				fmt.Sprintf("duo-%s-%s-baseline.pb.gz", route.Name, p.inst.Name))
 			if err != nil {
-				return nil, err
+				return err
 			}
 			p.result.BaselineProfile = path
 		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	runBatch := func() error {
@@ -171,31 +183,35 @@ func (env *DuoEnv) RunMemoryPhase(cfg DuoMemoryConfig) (*DuoMemoryReport, error)
 	if err := runBatch(); err != nil {
 		return nil, err
 	}
-	after1 := make([]uint64, len(probes))
-	for i, p := range probes {
-		heap, _, _, err := p.sampleGC()
+	if err := forEachProbe(probes, func(p *duoMemProbe) error {
+		m, err := p.inst.MemStats(true)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		after1[i] = heap
-		p.result.AfterBatch1MB = float64(int64(heap)-int64(p.baseline)) / 1024 / 1024
+		p.after1 = m.HeapAllocBytes
+		p.result.AfterBatch1MB = float64(int64(m.HeapAllocBytes)-int64(p.baseline)) / 1024 / 1024
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	if err := runBatch(); err != nil {
 		return nil, err
 	}
-	for i, p := range probes {
-		heap, total, _, err := p.sampleGC()
+	if err := forEachProbe(probes, func(p *duoMemProbe) error {
+		m, err := p.inst.MemStats(true)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		p.result.AfterBatch2MB = float64(int64(heap)-int64(p.baseline)) / 1024 / 1024
-		p.result.SlopeKBPerRequest = (float64(int64(heap)) - float64(int64(after1[i]))) / float64(cfg.Batch) / 1024
-		p.result.ChurnMBPerRequest = float64(total-p.totalAlloc0) / float64(2*cfg.Batch) / 1024 / 1024
+		p.result.AfterBatch2MB = float64(int64(m.HeapAllocBytes)-int64(p.baseline)) / 1024 / 1024
+		p.result.SlopeKBPerRequest = (float64(int64(m.HeapAllocBytes)) - float64(int64(p.after1))) / float64(cfg.Batch) / 1024
+		p.result.ChurnMBPerRequest = float64(m.TotalAllocBytes-p.totalAlloc0) / float64(2*cfg.Batch) / 1024 / 1024
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	// Concurrent burst with per-instance live-heap sampling over HTTP.
 	cfg.Progress("route %s: concurrent burst %d workers × %d requests", route.Name, cfg.Workers, cfg.PerWorker)
-	peaks := make([]uint64, len(probes))
 	stop := make(chan struct{})
 	samplerDone := make(chan struct{})
 	go func() {
@@ -209,9 +225,9 @@ func (env *DuoEnv) RunMemoryPhase(cfg DuoMemoryConfig) (*DuoMemoryReport, error)
 			case <-stop:
 				return
 			case <-tick.C:
-				for i, p := range probes {
-					if m, err := p.inst.MemStats(false); err == nil && m.HeapAllocBytes > peaks[i] {
-						peaks[i] = m.HeapAllocBytes
+				for _, p := range probes {
+					if m, err := p.inst.MemStats(false); err == nil && m.HeapAllocBytes > p.peak {
+						p.peak = m.HeapAllocBytes
 					}
 				}
 			}
@@ -240,22 +256,25 @@ func (env *DuoEnv) RunMemoryPhase(cfg DuoMemoryConfig) (*DuoMemoryReport, error)
 	default:
 	}
 
-	for i, p := range probes {
-		p.result.PeakHeapMB = float64(peaks[i]) / 1024 / 1024
-		heap, _, goroutines, err := p.sampleGC()
+	if err := forEachProbe(probes, func(p *duoMemProbe) error {
+		p.result.PeakHeapMB = float64(p.peak) / 1024 / 1024
+		m, err := p.inst.MemStats(true)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		p.result.PostBurstDeltaMB = float64(int64(heap)-int64(p.baseline)) / 1024 / 1024
-		p.result.FinalGoroutines = goroutines
+		p.result.PostBurstDeltaMB = float64(int64(m.HeapAllocBytes)-int64(p.baseline)) / 1024 / 1024
+		p.result.FinalGoroutines = m.NumGoroutine
 		if cfg.ProfileDir != "" {
 			path, err := p.inst.WriteHeapProfile(cfg.ProfileDir,
 				fmt.Sprintf("duo-%s-%s-final.pb.gz", route.Name, p.inst.Name))
 			if err != nil {
-				return nil, err
+				return err
 			}
 			p.result.FinalProfile = path
 		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	report.TB1 = probes[0].result

--- a/internal/protocoltest/duo_serve.go
+++ b/internal/protocoltest/duo_serve.go
@@ -1,0 +1,219 @@
+package protocoltest
+
+// duo_serve.go is the CHILD side of the duo two-process environment: a full
+// production tingly-box instance booted via server.Start (background
+// refreshers, config watcher, real http.Server timeouts — everything a real
+// deployment runs). The parent (NewDuoEnv) re-executes its own binary with
+// the TINGLY_DUO_* environment variables below; MaybeRunDuoServe intercepts
+// that re-execution before normal CLI/test execution begins and never
+// returns.
+//
+// The child self-seeds its own config dir, so the parent never opens the
+// instance's SQLite store — the only cross-process contract is this env
+// block plus reading the child's config.json for tokens.
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/server"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+	anthropicvm "github.com/tingly-dev/tingly-box/vmodel/anthropic"
+	openaivm "github.com/tingly-dev/tingly-box/vmodel/openai"
+	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
+)
+
+// Environment variable contract between the duo parent and child.
+const (
+	duoEnvRole      = "TINGLY_DUO_ROLE"
+	duoEnvName      = "TINGLY_DUO_NAME"
+	duoEnvConfigDir = "TINGLY_DUO_CONFIG_DIR"
+	duoEnvPort      = "TINGLY_DUO_PORT"
+
+	// Gateway (tb2) wiring: where the upstream instance (tb1) lives.
+	duoEnvUpstreamURL   = "TINGLY_DUO_UPSTREAM_URL"
+	duoEnvUpstreamToken = "TINGLY_DUO_UPSTREAM_TOKEN"
+
+	// Upstream (tb1) wiring: shape of the slow/large "backpressure" vmodels.
+	duoEnvStreamKB = "TINGLY_DUO_STREAM_KB"
+	duoEnvStreamMS = "TINGLY_DUO_STREAM_MS"
+
+	duoRoleServe = "serve"
+)
+
+// Slow-stream vmodel IDs registered on tb1 for the backpressure routes.
+// Unlike the builtin virtual-gpt-4/virtual-claude-3 (tiny instant response),
+// these stream a configurably large response over a configurable duration.
+const (
+	DuoSlowOpenAIModel    = "duo-slow-gpt"
+	DuoSlowAnthropicModel = "duo-slow-claude"
+)
+
+// MaybeRunDuoServe runs a duo child instance and exits the process when the
+// duo env contract is present; otherwise it returns immediately. Call it
+// first thing in main() (cli/harness) and TestMain (duo_test.go) so the
+// parent can re-execute the same binary as a server.
+func MaybeRunDuoServe() {
+	if os.Getenv(duoEnvRole) != duoRoleServe {
+		return
+	}
+	if err := runDuoServe(); err != nil {
+		fmt.Fprintf(os.Stderr, "duo-serve[%s]: %v\n", os.Getenv(duoEnvName), err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func runDuoServe() error {
+	dir := os.Getenv(duoEnvConfigDir)
+	if dir == "" {
+		return fmt.Errorf("%s not set", duoEnvConfigDir)
+	}
+	port, err := strconv.Atoi(os.Getenv(duoEnvPort))
+	if err != nil || port <= 0 {
+		return fmt.Errorf("invalid %s: %q", duoEnvPort, os.Getenv(duoEnvPort))
+	}
+
+	appCfg, err := config.NewAppConfig(config.WithConfigDir(dir))
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	// tb2 role: wire providers + one rule per duo route to the upstream (tb1).
+	if upstreamURL := os.Getenv(duoEnvUpstreamURL); upstreamURL != "" {
+		if err := seedDuoGateway(appCfg, upstreamURL, os.Getenv(duoEnvUpstreamToken)); err != nil {
+			return fmt.Errorf("seed gateway wiring: %w", err)
+		}
+	}
+
+	srv := server.NewServer(appCfg.GetGlobalConfig(), server.WithOpenBrowser(false))
+
+	// tb1 role: register the slow/large backpressure vmodels before serving.
+	if kb := duoEnvInt(duoEnvStreamKB); kb > 0 {
+		if err := registerDuoStreamModels(srv.GetVirtualModelService(), kb, duoEnvInt(duoEnvStreamMS)); err != nil {
+			return fmt.Errorf("register duo stream models: %w", err)
+		}
+	}
+
+	return srv.Start(port)
+}
+
+func duoEnvInt(key string) int {
+	n, _ := strconv.Atoi(os.Getenv(key))
+	return n
+}
+
+// seedDuoGateway persists the tb2 wiring into the child's own config dir:
+// one provider per target protocol pointing at tb1's /virtual endpoints, and
+// one anthropic-scenario rule per duo route (fast and slow variants).
+func seedDuoGateway(appCfg *config.AppConfig, tb1URL, tb1Token string) error {
+	providers := map[string]*typ.Provider{
+		"chat": {
+			UUID:               "tb1-openai-chat",
+			Name:               "tb1-openai-chat",
+			APIBase:            tb1URL + "/virtual/openai/v1",
+			APIStyle:           protocol.APIStyleOpenAI,
+			OpenAIEndpointMode: ai.EndpointModeChat,
+		},
+		"responses": {
+			UUID:               "tb1-openai-responses",
+			Name:               "tb1-openai-responses",
+			APIBase:            tb1URL + "/virtual/openai/v1",
+			APIStyle:           protocol.APIStyleOpenAI,
+			OpenAIEndpointMode: ai.EndpointModeResponses,
+		},
+		"anthropic": {
+			UUID:     "tb1-anthropic",
+			Name:     "tb1-anthropic",
+			APIBase:  tb1URL + "/virtual/anthropic", // SDK appends /v1/messages
+			APIStyle: protocol.APIStyleAnthropic,
+		},
+	}
+	for _, p := range providers {
+		p.Token = tb1Token
+		p.Enabled = true
+		p.Timeout = int64(constant.DefaultRequestTimeout)
+		if err := appCfg.AddProvider(p); err != nil {
+			return fmt.Errorf("add provider %s: %w", p.Name, err)
+		}
+	}
+
+	for _, route := range allDuoRoutesWithSlow() {
+		rule := typ.Rule{
+			UUID:          route.RequestModel(),
+			Scenario:      typ.ScenarioAnthropic,
+			RequestModel:  route.RequestModel(),
+			ResponseModel: duoTargetVModel(route),
+			Services: []*loadbalance.Service{{
+				Provider:   providers[route.Target].UUID,
+				Model:      duoTargetVModel(route),
+				Weight:     1,
+				Active:     true,
+				TimeWindow: 300,
+			}},
+			LBTactic: typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.NewRandomParams()},
+			Active:   true,
+		}
+		if err := appCfg.GetGlobalConfig().AddRequestConfig(rule); err != nil {
+			return fmt.Errorf("add rule %s: %w", route.Name, err)
+		}
+	}
+	return nil
+}
+
+// registerDuoStreamModels registers the slow/large vmodels into tb1's
+// registries. The response streams len(chunks) deltas of ~2 KB each; the
+// Delay parameter is applied by the virtualserver handler once up front
+// (TTFT) and spread again across chunks by the mock's stream loop, so a
+// request's wall time is roughly 2×delay.
+func registerDuoStreamModels(svc *virtualserver.Service, kb, ms int) error {
+	if svc == nil {
+		return fmt.Errorf("virtual model service unavailable")
+	}
+	chunks := duoStreamChunks(kb)
+	delay := time.Duration(ms) * time.Millisecond
+	content := strings.Join(chunks, "")
+
+	if err := svc.GetOpenAIRegistry().Register(openaivm.NewMockModel(&openaivm.MockModelConfig{
+		ID:           DuoSlowOpenAIModel,
+		Name:         "Duo slow GPT",
+		Description:  fmt.Sprintf("duo backpressure model: ~%d KB streamed over ~%d ms", kb, 2*ms),
+		Content:      content,
+		StreamChunks: chunks,
+		Delay:        delay,
+	})); err != nil {
+		return err
+	}
+	return svc.GetAnthropicRegistry().Register(anthropicvm.NewMockModel(&anthropicvm.MockModelConfig{
+		ID:           DuoSlowAnthropicModel,
+		Name:         "Duo slow Claude",
+		Description:  fmt.Sprintf("duo backpressure model: ~%d KB streamed over ~%d ms", kb, 2*ms),
+		Content:      content,
+		StreamChunks: chunks,
+		Delay:        delay,
+	}))
+}
+
+// duoStreamChunks builds ~2 KB filler chunks totalling approximately kb KB.
+func duoStreamChunks(kb int) []string {
+	const chunkBytes = 2 * 1024
+	n := kb * 1024 / chunkBytes
+	if n < 1 {
+		n = 1
+	}
+	const filler = "streamed backpressure payload "
+	chunk := strings.Repeat(filler, chunkBytes/len(filler)+1)[:chunkBytes]
+	chunks := make([]string, n)
+	for i := range chunks {
+		chunks[i] = chunk
+	}
+	return chunks
+}

--- a/internal/protocoltest/duo_test.go
+++ b/internal/protocoltest/duo_test.go
@@ -1,23 +1,58 @@
 package protocoltest
 
-// Regression tests over the Duo two-instance environment — topology and
+// Regression tests over the Duo two-process environment — topology and
 // route matrix are documented on the engine in duo.go. TestDuoFunctional
 // covers every route; TestDuoMemoryRegression guards the #1255 class of leak
-// (numbers with the threshold below). Heap profiles are written when
+// per instance (numbers with the threshold below); TestDuoBackpressure runs
+// the slow-stream + slow-reader variant. Heap profiles are written when
 // OOM_PROFILE_DIR is set:
 //
 //	OOM_PROFILE_DIR=/tmp go test ./internal/protocoltest/ -run TestDuo -v
+//
+// TestMain re-executes this test binary as the duo child servers (see
+// MaybeRunDuoServe), so each tb runs as a real, separately-observable
+// process booted through server.Start.
 
 import (
 	"os"
 	"testing"
+	"time"
 )
+
+func TestMain(m *testing.M) {
+	MaybeRunDuoServe()
+	os.Exit(m.Run())
+}
+
+// The #1255 leak measured 823 KB/request on the gateway instance. Healthy
+// builds measure ~0.5 KB/request; 32 KB leaves generous headroom against GC
+// noise while still catching any per-request pin of a request-body-sized
+// buffer. Applied to each instance separately: tb2 guards the
+// gateway/conversion path, tb1 the vmodel serving path.
+const duoMaxSlopeKB = 32.0
+
+func assertDuoSlopes(t *testing.T, report *DuoMemoryReport) {
+	t.Helper()
+	for _, im := range report.Instances() {
+		t.Logf("%s | route %s | baseline %.2f MB | slope %.1f KB/request | churn %.2f MB/request | burst peak %.2f MB (post-GC %+.2f MB) | goroutines %d→%d",
+			im.Instance, report.Route, im.BaselineHeapMB, im.SlopeKBPerRequest,
+			im.ChurnMBPerRequest, im.PeakHeapMB, im.PostBurstDeltaMB,
+			im.BaselineGoroutines, im.FinalGoroutines)
+		if im.BaselineProfile != "" {
+			t.Logf("%s profiles: %s %s", im.Instance, im.BaselineProfile, im.FinalProfile)
+		}
+		if im.SlopeKBPerRequest > duoMaxSlopeKB {
+			t.Errorf("%s post-GC retention slope %.1f KB/request exceeds %.0f KB/request — a per-request memory pin (see #1255)",
+				im.Instance, im.SlopeKBPerRequest, duoMaxSlopeKB)
+		}
+	}
+}
 
 func TestDuoFunctional(t *testing.T) {
 	if testing.Short() {
 		t.Skip("duo e2e is not a -short test")
 	}
-	env, err := NewDuoEnv()
+	env, err := NewDuoEnv(DuoEnvConfig{})
 	if err != nil {
 		t.Fatalf("boot duo env: %v", err)
 	}
@@ -45,7 +80,7 @@ func TestDuoMemoryRegression(t *testing.T) {
 	if testing.Short() {
 		t.Skip("duo e2e is not a -short test")
 	}
-	env, err := NewDuoEnv()
+	env, err := NewDuoEnv(DuoEnvConfig{})
 	if err != nil {
 		t.Fatalf("boot duo env: %v", err)
 	}
@@ -58,20 +93,36 @@ func TestDuoMemoryRegression(t *testing.T) {
 	if err != nil {
 		t.Fatalf("memory phase: %v", err)
 	}
+	assertDuoSlopes(t, report)
+}
 
-	t.Logf("route %s | body %.2f MB | slope %.1f KB/request | churn %.2f MB/request | burst peak %.2f MB (post-GC %+.2f MB)",
-		report.Route, float64(report.BodyBytes)/1024/1024, report.SlopeKBPerRequest,
-		report.ChurnMBPerRequest, report.PeakHeapMB, report.PostBurstDeltaMB)
-	if report.BaselineProfile != "" {
-		t.Logf("profiles: %s %s", report.BaselineProfile, report.FinalProfile)
+// TestDuoBackpressure runs the slow-stream + slow-reader variant of the
+// Claude Code hot path: tb1 streams a large response slowly while the client
+// reads slowly, so buffering under real TCP backpressure is on the measured
+// path. Parameters are kept small to bound test wall time.
+func TestDuoBackpressure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("duo e2e is not a -short test")
 	}
+	env, err := NewDuoEnv(DuoEnvConfig{StreamKB: 64, StreamMS: 150})
+	if err != nil {
+		t.Fatalf("boot duo env: %v", err)
+	}
+	defer env.Close()
 
-	// The #1255 leak measured 823 KB/request here. Healthy builds measure
-	// ~0.5 KB/request; 32 KB leaves generous headroom against GC noise while
-	// still catching any per-request pin of a request-body-sized buffer.
-	const maxSlopeKB = 32.0
-	if report.SlopeKBPerRequest > maxSlopeKB {
-		t.Errorf("post-GC retention slope %.1f KB/request exceeds %.0f KB/request — a per-request memory pin (see #1255)",
-			report.SlopeKBPerRequest, maxSlopeKB)
+	route := DuoDefaultRoute.SlowVariant()
+	report, err := env.RunMemoryPhase(DuoMemoryConfig{
+		Route:      &route,
+		BodyBytes:  512 * 1024,
+		Batch:      6,
+		Workers:    3,
+		PerWorker:  3,
+		ReadDelay:  10 * time.Millisecond,
+		ProfileDir: os.Getenv("OOM_PROFILE_DIR"),
+		Progress:   t.Logf,
+	})
+	if err != nil {
+		t.Fatalf("memory phase: %v", err)
 	}
+	assertDuoSlopes(t, report)
 }

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -105,7 +105,7 @@ func NewTestEnv(t *testing.T, opts ...TestEnvOption) *TestEnv {
 		t.Fatalf("create app config: %v", err)
 	}
 
-	gatewayServer := server.NewServer(appConfig.GetGlobalConfig(), server.WithAdaptor(false))
+	gatewayServer := server.NewServer(appConfig.GetGlobalConfig())
 	router := gatewayServer.GetRouter()
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
@@ -168,7 +168,7 @@ func NewTestEnvForCLI(opts ...TestEnvOption) (*TestEnv, error) {
 	}
 
 	// Build server options
-	serverOpts := []server.ServerOption{server.WithAdaptor(false)}
+	var serverOpts []server.ServerOption
 	if cfg.recordDir != "" {
 		serverOpts = append(serverOpts, server.WithRecordDir(cfg.recordDir))
 	}

--- a/internal/server/module/debug/handler.go
+++ b/internal/server/module/debug/handler.go
@@ -1,0 +1,71 @@
+// Package debug exposes runtime memory diagnostics for a running instance:
+// a memstats snapshot and a pprof heap profile. They exist so memory can be
+// observed per process over the same HTTP surface real deployments run —
+// the duo harness samples both of its tingly-box instances through these
+// endpoints, and the same endpoints serve live incident diagnosis.
+package debug
+
+import (
+	"net/http"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler serves the runtime memory diagnostics endpoints.
+type Handler struct{}
+
+// NewHandler returns a Handler.
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+// forceGC runs two GC cycles so finalizer-revived objects are collected too,
+// giving a stable post-GC retained set (the same double-GC that in-process
+// retention measurements use).
+func forceGC() {
+	runtime.GC()
+	runtime.GC()
+}
+
+// GetMemStats returns a runtime.MemStats snapshot. With ?gc=true it forces
+// a full GC first, so heap_alloc_bytes is the post-GC retained set.
+func (h *Handler) GetMemStats(c *gin.Context) {
+	gcForced := c.Query("gc") == "true"
+	if gcForced {
+		forceGC()
+	}
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	c.JSON(http.StatusOK, MemStatsResponse{
+		HeapAllocBytes:  m.HeapAlloc,
+		HeapInuseBytes:  m.HeapInuse,
+		HeapSysBytes:    m.HeapSys,
+		HeapObjects:     m.HeapObjects,
+		TotalAllocBytes: m.TotalAlloc,
+		NumGC:           m.NumGC,
+		NumGoroutine:    runtime.NumGoroutine(),
+		GCForced:        gcForced,
+	})
+}
+
+// GetHeapProfile streams a pprof heap profile (gzipped protobuf, the format
+// `go tool pprof` reads). With ?gc=true it forces a full GC first so the
+// profile reflects retained memory rather than garbage awaiting collection.
+func (h *Handler) GetHeapProfile(c *gin.Context) {
+	if c.Query("gc") == "true" {
+		forceGC()
+	}
+	profile := pprof.Lookup("heap")
+	if profile == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "heap profile unavailable"})
+		return
+	}
+	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Disposition", `attachment; filename="heap.pb.gz"`)
+	if err := profile.WriteTo(c.Writer, 0); err != nil {
+		// Headers are already sent; nothing better to do than log via gin.
+		_ = c.Error(err)
+	}
+}

--- a/internal/server/module/debug/handler.go
+++ b/internal/server/module/debug/handler.go
@@ -16,18 +16,24 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// minForcedGCInterval caps how often callers can force a full GC. A forced
-// double GC is the one genuinely expensive operation here (stop-the-world on
-// the live heap), and it is exposed to whoever holds the user token — the
-// throttle bounds the worst case (a polling client) to one extra GC per
-// second instead of a GC storm, while leaving normal diagnostic cadence
-// (samples seconds apart) untouched.
-const minForcedGCInterval = time.Second
+// The two genuinely expensive operations on this surface — a forced double
+// GC (stop-the-world on the live heap) and heap-profile serialization (CPU
+// proportional to live objects) — are exposed to whoever holds the user
+// token, so both are throttled. The bounds turn a polling client into a
+// degraded one (un-forced snapshots / 429) instead of a load lever, while
+// leaving normal diagnostic cadence (operations seconds apart) untouched.
+// Cheap operations (plain memstats reads, microsecond-scale) are not
+// limited.
+const (
+	minForcedGCInterval    = time.Second
+	minHeapProfileInterval = time.Second
+)
 
 // Handler serves the runtime memory diagnostics endpoints.
 type Handler struct {
 	mu          sync.Mutex
 	lastForceGC time.Time
+	lastProfile time.Time
 }
 
 // NewHandler returns a Handler.
@@ -77,6 +83,19 @@ func (h *Handler) GetMemStats(c *gin.Context) {
 // the profile reflects retained memory rather than garbage awaiting
 // collection.
 func (h *Handler) GetHeapProfile(c *gin.Context) {
+	h.mu.Lock()
+	throttled := time.Since(h.lastProfile) < minHeapProfileInterval
+	if !throttled {
+		h.lastProfile = time.Now()
+	}
+	h.mu.Unlock()
+	if throttled {
+		// Unlike memstats, a profile has no cheap degraded form — serving it
+		// IS the cost — so a throttled request is rejected outright.
+		c.Header("Retry-After", "1")
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "heap profile throttled; retry after 1s"})
+		return
+	}
 	if c.Query("gc") == "true" {
 		c.Header("X-Debug-GC-Forced", strconv.FormatBool(h.tryForceGC()))
 	}

--- a/internal/server/module/debug/handler.go
+++ b/internal/server/module/debug/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"sync"
 	"time"
 
@@ -77,7 +78,7 @@ func (h *Handler) GetMemStats(c *gin.Context) {
 // collection.
 func (h *Handler) GetHeapProfile(c *gin.Context) {
 	if c.Query("gc") == "true" {
-		c.Header("X-Debug-GC-Forced", boolStr(h.tryForceGC()))
+		c.Header("X-Debug-GC-Forced", strconv.FormatBool(h.tryForceGC()))
 	}
 	profile := pprof.Lookup("heap")
 	if profile == nil {
@@ -90,11 +91,4 @@ func (h *Handler) GetHeapProfile(c *gin.Context) {
 		// Headers are already sent; nothing better to do than log via gin.
 		_ = c.Error(err)
 	}
-}
-
-func boolStr(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
 }

--- a/internal/server/module/debug/handler.go
+++ b/internal/server/module/debug/handler.go
@@ -9,33 +9,53 @@ import (
 	"net/http"
 	"runtime"
 	"runtime/pprof"
+	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
+// minForcedGCInterval caps how often callers can force a full GC. A forced
+// double GC is the one genuinely expensive operation here (stop-the-world on
+// the live heap), and it is exposed to whoever holds the user token — the
+// throttle bounds the worst case (a polling client) to one extra GC per
+// second instead of a GC storm, while leaving normal diagnostic cadence
+// (samples seconds apart) untouched.
+const minForcedGCInterval = time.Second
+
 // Handler serves the runtime memory diagnostics endpoints.
-type Handler struct{}
+type Handler struct {
+	mu          sync.Mutex
+	lastForceGC time.Time
+}
 
 // NewHandler returns a Handler.
 func NewHandler() *Handler {
 	return &Handler{}
 }
 
-// forceGC runs two GC cycles so finalizer-revived objects are collected too,
-// giving a stable post-GC retained set (the same double-GC that in-process
-// retention measurements use).
-func forceGC() {
+// tryForceGC runs two GC cycles (so finalizer-revived objects are collected
+// too, giving a stable post-GC retained set) unless a forced GC ran within
+// minForcedGCInterval. Returns whether the GC actually ran; a throttled call
+// still serves its snapshot, just without forcing.
+func (h *Handler) tryForceGC() bool {
+	h.mu.Lock()
+	if time.Since(h.lastForceGC) < minForcedGCInterval {
+		h.mu.Unlock()
+		return false
+	}
+	h.lastForceGC = time.Now()
+	h.mu.Unlock()
 	runtime.GC()
 	runtime.GC()
+	return true
 }
 
 // GetMemStats returns a runtime.MemStats snapshot. With ?gc=true it forces
-// a full GC first, so heap_alloc_bytes is the post-GC retained set.
+// a full GC first (subject to the throttle), so heap_alloc_bytes is the
+// post-GC retained set; gc_forced reports whether the GC actually ran.
 func (h *Handler) GetMemStats(c *gin.Context) {
-	gcForced := c.Query("gc") == "true"
-	if gcForced {
-		forceGC()
-	}
+	gcForced := c.Query("gc") == "true" && h.tryForceGC()
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	c.JSON(http.StatusOK, MemStatsResponse{
@@ -51,11 +71,13 @@ func (h *Handler) GetMemStats(c *gin.Context) {
 }
 
 // GetHeapProfile streams a pprof heap profile (gzipped protobuf, the format
-// `go tool pprof` reads). With ?gc=true it forces a full GC first so the
-// profile reflects retained memory rather than garbage awaiting collection.
+// `go tool pprof` reads). With ?gc=true it forces a full GC first (subject
+// to the throttle; the X-Debug-GC-Forced header reports whether it ran) so
+// the profile reflects retained memory rather than garbage awaiting
+// collection.
 func (h *Handler) GetHeapProfile(c *gin.Context) {
 	if c.Query("gc") == "true" {
-		forceGC()
+		c.Header("X-Debug-GC-Forced", boolStr(h.tryForceGC()))
 	}
 	profile := pprof.Lookup("heap")
 	if profile == nil {
@@ -68,4 +90,11 @@ func (h *Handler) GetHeapProfile(c *gin.Context) {
 		// Headers are already sent; nothing better to do than log via gin.
 		_ = c.Error(err)
 	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }

--- a/internal/server/module/debug/handler_test.go
+++ b/internal/server/module/debug/handler_test.go
@@ -73,7 +73,9 @@ func TestForcedGCThrottle(t *testing.T) {
 		t.Error("immediate second gc=true call should be throttled (gc_forced=false)")
 	}
 
-	// The throttled heap-profile path reports the same via header.
+	// The heap-profile path shares the GC throttle (reported via header) and
+	// additionally throttles profile serialization itself: a first profile
+	// serves (with the GC skipped), an immediate second one is rejected.
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap?gc=true", nil))
 	if w.Code != http.StatusOK {
@@ -81,6 +83,11 @@ func TestForcedGCThrottle(t *testing.T) {
 	}
 	if got := w.Header().Get("X-Debug-GC-Forced"); got != "false" {
 		t.Errorf("X-Debug-GC-Forced = %q, want \"false\" within throttle window", got)
+	}
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap", nil))
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("immediate second profile: status %d, want 429", w.Code)
 	}
 }
 

--- a/internal/server/module/debug/handler_test.go
+++ b/internal/server/module/debug/handler_test.go
@@ -1,0 +1,67 @@
+package debug
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewHandler()
+	r.GET("/debug/memstats", h.GetMemStats)
+	r.GET("/debug/pprof/heap", h.GetHeapProfile)
+	return r
+}
+
+func TestGetMemStats(t *testing.T) {
+	r := newTestRouter()
+
+	for _, gc := range []bool{false, true} {
+		url := "/debug/memstats"
+		if gc {
+			url += "?gc=true"
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("gc=%v: status %d", gc, w.Code)
+		}
+		var resp MemStatsResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("gc=%v: invalid JSON: %v", gc, err)
+		}
+		if resp.HeapAllocBytes == 0 || resp.TotalAllocBytes == 0 {
+			t.Errorf("gc=%v: zero heap/total alloc: %+v", gc, resp)
+		}
+		if resp.NumGoroutine <= 0 {
+			t.Errorf("gc=%v: NumGoroutine = %d", gc, resp.NumGoroutine)
+		}
+		if resp.GCForced != gc {
+			t.Errorf("gc=%v: GCForced = %v", gc, resp.GCForced)
+		}
+	}
+}
+
+func TestGetHeapProfile(t *testing.T) {
+	r := newTestRouter()
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap?gc=true", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	body := w.Body.Bytes()
+	if len(body) == 0 {
+		t.Fatal("empty profile body")
+	}
+	// pprof.WriteTo(w, 0) emits gzipped protobuf — check the gzip magic so a
+	// silent format change (e.g. debug>0 text output) fails loudly.
+	if body[0] != 0x1f || body[1] != 0x8b {
+		t.Errorf("profile is not gzip data (first bytes: %x %x)", body[0], body[1])
+	}
+}

--- a/internal/server/module/debug/handler_test.go
+++ b/internal/server/module/debug/handler_test.go
@@ -47,6 +47,43 @@ func TestGetMemStats(t *testing.T) {
 	}
 }
 
+// TestForcedGCThrottle verifies that back-to-back gc=true calls do not force
+// repeated GCs: the second call inside the throttle window still serves a
+// snapshot but reports gc_forced=false.
+func TestForcedGCThrottle(t *testing.T) {
+	r := newTestRouter()
+
+	sample := func() MemStatsResponse {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/debug/memstats?gc=true", nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status %d", w.Code)
+		}
+		var resp MemStatsResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		return resp
+	}
+
+	if first := sample(); !first.GCForced {
+		t.Error("first gc=true call should force a GC")
+	}
+	if second := sample(); second.GCForced {
+		t.Error("immediate second gc=true call should be throttled (gc_forced=false)")
+	}
+
+	// The throttled heap-profile path reports the same via header.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap?gc=true", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("profile status %d", w.Code)
+	}
+	if got := w.Header().Get("X-Debug-GC-Forced"); got != "false" {
+		t.Errorf("X-Debug-GC-Forced = %q, want \"false\" within throttle window", got)
+	}
+}
+
 func TestGetHeapProfile(t *testing.T) {
 	r := newTestRouter()
 

--- a/internal/server/module/debug/routes.go
+++ b/internal/server/module/debug/routes.go
@@ -19,7 +19,7 @@ func RegisterRoutes(router *swagger.RouteGroup, authMiddleware gin.HandlerFunc, 
 	)
 	router.GET("/debug/pprof/heap", handler.GetHeapProfile,
 		swagger.WithTags("debug"),
-		swagger.WithDescription("pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header."),
+		swagger.WithDescription("pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header. Profile serialization itself is also throttled (min 1s apart, 429 with Retry-After when exceeded)."),
 		swagger.WithMiddleware(authMiddleware),
 	)
 }

--- a/internal/server/module/debug/routes.go
+++ b/internal/server/module/debug/routes.go
@@ -13,13 +13,13 @@ import (
 func RegisterRoutes(router *swagger.RouteGroup, authMiddleware gin.HandlerFunc, handler *Handler) {
 	router.GET("/debug/memstats", handler.GetMemStats,
 		swagger.WithTags("debug"),
-		swagger.WithDescription("Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set."),
+		swagger.WithDescription("Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set; forced GCs are throttled (min 1s apart) and gc_forced reports whether one actually ran."),
 		swagger.WithResponseModel(MemStatsResponse{}),
 		swagger.WithMiddleware(authMiddleware),
 	)
 	router.GET("/debug/pprof/heap", handler.GetHeapProfile,
 		swagger.WithTags("debug"),
-		swagger.WithDescription("pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory."),
+		swagger.WithDescription("pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header."),
 		swagger.WithMiddleware(authMiddleware),
 	)
 }

--- a/internal/server/module/debug/routes.go
+++ b/internal/server/module/debug/routes.go
@@ -1,0 +1,25 @@
+package debug
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/swagger"
+)
+
+// RegisterRoutes registers the runtime memory diagnostics routes under the
+// given /api/v1 group. Auth middleware is attached per-route via
+// WithMiddleware so this registration does not mutate the parent group's
+// middleware chain.
+func RegisterRoutes(router *swagger.RouteGroup, authMiddleware gin.HandlerFunc, handler *Handler) {
+	router.GET("/debug/memstats", handler.GetMemStats,
+		swagger.WithTags("debug"),
+		swagger.WithDescription("Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set."),
+		swagger.WithResponseModel(MemStatsResponse{}),
+		swagger.WithMiddleware(authMiddleware),
+	)
+	router.GET("/debug/pprof/heap", handler.GetHeapProfile,
+		swagger.WithTags("debug"),
+		swagger.WithDescription("pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory."),
+		swagger.WithMiddleware(authMiddleware),
+	)
+}

--- a/internal/server/module/debug/types.go
+++ b/internal/server/module/debug/types.go
@@ -1,0 +1,22 @@
+package debug
+
+// MemStatsResponse is the response body of GET /debug/memstats. Byte fields
+// come straight from runtime.MemStats so external observers (the duo memory
+// harness, incident diagnosis against a live instance) read the same numbers
+// an in-process runtime.ReadMemStats would.
+type MemStatsResponse struct {
+	// HeapAllocBytes is the live heap (bytes of allocated, not yet freed
+	// objects). Sampled after a forced GC (gc=true) it is the post-GC
+	// retained set — the number retention-slope measurements diff.
+	HeapAllocBytes uint64 `json:"heap_alloc_bytes" example:"10485760"`
+	HeapInuseBytes uint64 `json:"heap_inuse_bytes" example:"12582912"`
+	HeapSysBytes   uint64 `json:"heap_sys_bytes" example:"16777216"`
+	HeapObjects    uint64 `json:"heap_objects" example:"52000"`
+	// TotalAllocBytes is cumulative bytes allocated since process start
+	// (monotonic); diffs of it measure allocation churn.
+	TotalAllocBytes uint64 `json:"total_alloc_bytes" example:"104857600"`
+	NumGC           uint32 `json:"num_gc" example:"12"`
+	NumGoroutine    int    `json:"num_goroutine" example:"42"`
+	// GCForced reports whether this sample ran a forced GC first (gc=true).
+	GCForced bool `json:"gc_forced" example:"true"`
+}

--- a/internal/server/routing/integration_test.go
+++ b/internal/server/routing/integration_test.go
@@ -42,7 +42,7 @@ func newRoutingTestServer(t *testing.T) *routingTestServer {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(configDir))
 	require.NoError(t, err)
 
-	httpServer := server.NewServer(appConfig.GetGlobalConfig(), server.WithAdaptor(false))
+	httpServer := server.NewServer(appConfig.GetGlobalConfig())
 	ts := &routingTestServer{
 		appConfig:  appConfig,
 		httpServer: httptest.NewServer(httpServer.GetRouter()),
@@ -99,7 +99,7 @@ func newRoutingTestServerWithCapacity(t *testing.T, capacities map[string]struct
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(configDir))
 	require.NoError(t, err)
 
-	httpServer := server.NewServer(appConfig.GetGlobalConfig(), server.WithAdaptor(false))
+	httpServer := server.NewServer(appConfig.GetGlobalConfig())
 	ts := &routingTestServer{
 		appConfig:  appConfig,
 		httpServer: httptest.NewServer(httpServer.GetRouter()),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,11 +148,10 @@ type Server struct {
 	quotaManager providerQuotaModule.Manager
 
 	// options
-	enableUI      bool
-	enableAdaptor bool
-	openBrowser   bool
-	host          string
-	debug         bool
+	enableUI    bool
+	openBrowser bool
+	host        string
+	debug       bool
 
 	// record options
 	recordMode obs.RecordMode

--- a/internal/server/server_control.go
+++ b/internal/server/server_control.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/server/module/codeximport"
 	"github.com/tingly-dev/tingly-box/internal/server/module/configapply"
+	debugmodule "github.com/tingly-dev/tingly-box/internal/server/module/debug"
 	"github.com/tingly-dev/tingly-box/internal/server/module/imbot"
 	mcpmodule "github.com/tingly-dev/tingly-box/internal/server/module/mcp"
 	notifymodule "github.com/tingly-dev/tingly-box/internal/server/module/notify"
@@ -163,6 +164,15 @@ func (s *Server) UseUIEndpoints(ctx context.Context) {
 		apiV1,
 		s.getUserAuthMiddleware(),
 		virtualmodelmodule.NewHandler(s.virtualModelService),
+	)
+
+	// Runtime memory diagnostics — per-instance memstats + heap profile over
+	// the production HTTP surface. Consumed by the duo harness (per-instance
+	// leak attribution) and by live incident diagnosis.
+	debugmodule.RegisterRoutes(
+		apiV1,
+		s.getUserAuthMiddleware(),
+		debugmodule.NewHandler(),
 	)
 
 	// Usage API routes - register from usage module

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/server/module/codeximport"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/network"
+	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
 
 // Start starts the HTTP server
@@ -155,6 +156,13 @@ func (s *Server) GetRouter() *gin.Engine {
 // GetLoadBalancer returns the load balancer instance
 func (s *Server) GetLoadBalancer() *LoadBalancer {
 	return s.loadBalancer
+}
+
+// GetVirtualModelService returns the in-process virtual-model service, so
+// embedding callers (e.g. the duo harness child) can register additional
+// virtual models before Start.
+func (s *Server) GetVirtualModelService() *virtualserver.Service {
+	return s.virtualModelService
 }
 
 // HealthMonitor returns the server's health monitor

--- a/internal/server/server_options.go
+++ b/internal/server/server_options.go
@@ -17,10 +17,9 @@ type ServerOption func(*Server)
 // WithDefault applies all default server options
 func WithDefault() ServerOption {
 	return func(s *Server) {
-		s.enableUI = true      // Default: UI enabled
-		s.enableAdaptor = true // Default: adapter enabled
-		s.openBrowser = true   // Default: open browser enabled
-		s.host = ""            // Default: empty host (resolves to localhost)
+		s.enableUI = true    // Default: UI enabled
+		s.openBrowser = true // Default: open browser enabled
+		s.host = ""          // Default: empty host (resolves to localhost)
 	}
 }
 
@@ -40,13 +39,6 @@ func WithUI(enabled bool) ServerOption {
 func WithHost(host string) ServerOption {
 	return func(s *Server) {
 		s.host = host
-	}
-}
-
-// WithAdaptor enables or disables the adaptor for the server
-func WithAdaptor(enabled bool) ServerOption {
-	return func(s *Server) {
-		s.enableAdaptor = enabled
 	}
 }
 

--- a/internal/server/swagger.go
+++ b/internal/server/swagger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/server/module/codeximport"
 	"github.com/tingly-dev/tingly-box/internal/server/module/configapply"
+	debugmodule "github.com/tingly-dev/tingly-box/internal/server/module/debug"
 	"github.com/tingly-dev/tingly-box/internal/server/module/imbot"
 	mcpmodule "github.com/tingly-dev/tingly-box/internal/server/module/mcp"
 	notifymodule "github.com/tingly-dev/tingly-box/internal/server/module/notify"
@@ -71,6 +72,9 @@ func registerAllAPIRoutes(engine *gin.Engine, manager *swagger.RouteManager, s *
 	oauthmodule.RegisterRoutes(apiV1, s.getUserAuthMiddleware(), s.oauthHandler)
 	// Register callback routes (unauthenticated)
 	oauthmodule.RegisterCallbackRoutes(manager, s.oauthHandler)
+
+	// Runtime memory diagnostics routes
+	debugmodule.RegisterRoutes(apiV1, s.getUserAuthMiddleware(), debugmodule.NewHandler())
 
 	// Usage API routes - register from usage module
 	sm := cfg.StoreManager()

--- a/internal/servertest/adaptor_test.go
+++ b/internal/servertest/adaptor_test.go
@@ -20,7 +20,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		ts := NewTestServerWithConfigDir(t, testConfig.Path())
 
 		// Use the existing server with adaptor enabled
-		tsWithAdaptor := NewTestServerWithAdaptorFromConfig(ts.appConfig)
+		tsConverter := NewTestServerFromConfig(ts.appConfig)
 
 		// Add a rule that routes to Anthropic-style provider (glm)
 		rule := map[string]interface{}{
@@ -69,7 +69,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		w = httptest.NewRecorder()
 		// Use the server with adaptor for the actual request
-		tsWithAdaptor.ginEngine.ServeHTTP(w, req)
+		tsConverter.ginEngine.ServeHTTP(w, req)
 
 		t.Logf("Response code: %d", w.Code)
 		t.Logf("Response body: %s", w.Body.String())
@@ -92,7 +92,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		ts := NewTestServerWithConfigDir(t, testConfig.Path())
 
 		// Use the existing server with adaptor enabled
-		tsWithAdaptor := NewTestServerWithAdaptorFromConfig(ts.appConfig)
+		tsConverter := NewTestServerFromConfig(ts.appConfig)
 
 		// Add a rule that routes to OpenAI-style provider (qwen)
 		rule := map[string]interface{}{
@@ -142,7 +142,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		w = httptest.NewRecorder()
 		// Use the server with adaptor for the actual request
-		tsWithAdaptor.ginEngine.ServeHTTP(w, req)
+		tsConverter.ginEngine.ServeHTTP(w, req)
 
 		t.Logf("Response code: %d", w.Code)
 		t.Logf("Response body: %s", w.Body.String())
@@ -165,7 +165,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		ts := NewTestServerWithConfigDir(t, testConfig.Path())
 
 		// Use the existing server with adaptor enabled
-		tsWithAdaptor := NewTestServerWithAdaptorFromConfig(ts.appConfig)
+		tsConverter := NewTestServerFromConfig(ts.appConfig)
 
 		// Add a rule that routes to Anthropic-style provider (glm)
 		rule := map[string]interface{}{
@@ -234,7 +234,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		w = httptest.NewRecorder()
 		// Use the server with adaptor for the actual request
-		tsWithAdaptor.ginEngine.ServeHTTP(w, req)
+		tsConverter.ginEngine.ServeHTTP(w, req)
 
 		t.Logf("Response code: %d", w.Code)
 		if w.Code != 200 {
@@ -270,7 +270,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		ts := NewTestServerWithConfigDir(t, testConfig.Path())
 
 		// Use the existing server with adaptor enabled
-		tsWithAdaptor := NewTestServerWithAdaptorFromConfig(ts.appConfig)
+		tsConverter := NewTestServerFromConfig(ts.appConfig)
 
 		// Use existing rule for qwen-plus (which routes to qwen - OpenAI style)
 		// We'll send an Anthropic request to test the adaptor
@@ -292,7 +292,7 @@ func TestAdaptorFeatureWithRealConfig(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer "+modelToken)
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
-		tsWithAdaptor.ginEngine.ServeHTTP(w, req)
+		tsConverter.ginEngine.ServeHTTP(w, req)
 
 		t.Logf("Response code: %d", w.Code)
 		t.Logf("Response Content-Type: %s", w.Header().Get("Content-Type"))

--- a/internal/servertest/utils.go
+++ b/internal/servertest/utils.go
@@ -74,35 +74,6 @@ func NewTestServer(t *testing.T) *TestServer {
 // createTestServer creates a test server with the given appConfig
 func createTestServer(t *testing.T, appConfig *config.AppConfig) *TestServer {
 	// Create server instance but don't start it
-	// Note: adapter is disabled by default in tests to test the fallback behavior
-	httpServer := server2.NewServer(appConfig.GetGlobalConfig(), server2.WithAdaptor(false))
-
-	return &TestServer{
-		appConfig: appConfig,
-		server:    httpServer,
-		ginEngine: httpServer.GetRouter(), // Use the server's router
-	}
-}
-
-// NewTestServerWithAdaptor creates a new test server with adaptor flag
-func NewTestServerWithAdaptor(t *testing.T) *TestServer {
-	// Create temp config directory
-	configDir, err := os.MkdirTemp("", "tingly-box-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp config directory: %v", err)
-	}
-
-	// Register cleanup
-	t.Cleanup(func() {
-		os.RemoveAll(configDir)
-	})
-
-	appConfig, err := config.NewAppConfig(config.WithConfigDir(configDir))
-	if err != nil {
-		t.Fatalf("Failed to create app config: %v", err)
-	}
-
-	// Create server instance with adaptor flag
 	httpServer := server2.NewServer(appConfig.GetGlobalConfig())
 
 	return &TestServer{
@@ -230,9 +201,8 @@ func (ts *TestServer) EnsureLoadBalancingRule(t *testing.T, requestModel, model 
 	}
 }
 
-// NewTestServerWithAdaptorFromConfig creates a new test server with adaptor flag using existing app config
-func NewTestServerWithAdaptorFromConfig(appConfig *config.AppConfig) *TestServer {
-	// Create server instance with adaptor flag
+// NewTestServerFromConfig creates a new test server sharing an existing app config
+func NewTestServerFromConfig(appConfig *config.AppConfig) *TestServer {
 	httpServer := server2.NewServer(appConfig.GetGlobalConfig())
 
 	return &TestServer{

--- a/openapi.json
+++ b/openapi.json
@@ -462,8 +462,8 @@
         "tags": [
           "debug"
         ],
-        "summary": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header.",
-        "description": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header.",
+        "summary": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header. Profile serialization itself is also throttled (min 1s apart, 429 with Retry-After when exceeded).",
+        "description": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header. Profile serialization itself is also throttled (min 1s apart, 429 with Retry-After when exceeded).",
         "operationId": "apiV1DebugPprofHeapGet",
         "responses": {
           "200": {

--- a/openapi.json
+++ b/openapi.json
@@ -435,6 +435,50 @@
         }
       }
     },
+    "/api/v1/debug/memstats": {
+      "get": {
+        "tags": [
+          "debug"
+        ],
+        "summary": "Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set.",
+        "description": "Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set.",
+        "operationId": "apiV1DebugMemstatsGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemStatsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/debug/pprof/heap": {
+      "get": {
+        "tags": [
+          "debug"
+        ],
+        "summary": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory.",
+        "description": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory.",
+        "operationId": "apiV1DebugPprofHeapGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/guardrails/builtins": {
       "get": {
         "tags": [
@@ -7146,6 +7190,68 @@
           "command"
         ]
       },
+      "MemStatsResponse": {
+        "type": "object",
+        "properties": {
+          "gc_forced": {
+            "type": "boolean",
+            "description": "Field gc_forced",
+            "example": true
+          },
+          "heap_alloc_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field heap_alloc_bytes",
+            "example": 10485760
+          },
+          "heap_inuse_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field heap_inuse_bytes",
+            "example": 12582912
+          },
+          "heap_objects": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field heap_objects",
+            "example": 52000
+          },
+          "heap_sys_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field heap_sys_bytes",
+            "example": 16777216
+          },
+          "num_gc": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field num_gc",
+            "example": 12
+          },
+          "num_goroutine": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field num_goroutine",
+            "example": 42
+          },
+          "total_alloc_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field total_alloc_bytes",
+            "example": 104857600
+          }
+        },
+        "required": [
+          "heap_alloc_bytes",
+          "heap_inuse_bytes",
+          "heap_sys_bytes",
+          "heap_objects",
+          "total_alloc_bytes",
+          "num_gc",
+          "num_goroutine",
+          "gc_forced"
+        ]
+      },
       "ModelInfo": {
         "type": "object",
         "properties": {
@@ -7186,6 +7292,15 @@
             "items": {
               "$ref": "#/components/schemas/ModelRequestEvent"
             }
+          },
+          "failover_hops": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field failover_hops"
+          },
+          "failover_path": {
+            "type": "string",
+            "description": "Field failover_path"
           },
           "has_error": {
             "type": "boolean",
@@ -7293,6 +7408,15 @@
             "type": "integer",
             "format": "int64",
             "description": "Field event_count"
+          },
+          "failover_hops": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field failover_hops"
+          },
+          "failover_path": {
+            "type": "string",
+            "description": "Field failover_path"
           },
           "has_error": {
             "type": "boolean",
@@ -10866,6 +10990,10 @@
     {
       "name": "config",
       "description": "Operations related to config"
+    },
+    {
+      "name": "debug",
+      "description": "Operations related to debug"
     },
     {
       "name": "feishu",

--- a/openapi.json
+++ b/openapi.json
@@ -440,8 +440,8 @@
         "tags": [
           "debug"
         ],
-        "summary": "Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set.",
-        "description": "Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set.",
+        "summary": "Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set; forced GCs are throttled (min 1s apart) and gc_forced reports whether one actually ran.",
+        "description": "Runtime memory statistics snapshot. Pass gc=true to force a full GC first so heap_alloc_bytes is the post-GC retained set; forced GCs are throttled (min 1s apart) and gc_forced reports whether one actually ran.",
         "operationId": "apiV1DebugMemstatsGet",
         "responses": {
           "200": {
@@ -462,8 +462,8 @@
         "tags": [
           "debug"
         ],
-        "summary": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory.",
-        "description": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory.",
+        "summary": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header.",
+        "description": "pprof heap profile (gzipped protobuf for `go tool pprof`). Pass gc=true to force a full GC first so the profile reflects retained memory; forced GCs are throttled (min 1s apart), reported via the X-Debug-GC-Forced header.",
         "operationId": "apiV1DebugPprofHeapGet",
         "responses": {
           "200": {

--- a/vmodel/openai/delay_test.go
+++ b/vmodel/openai/delay_test.go
@@ -36,7 +36,7 @@ func newMetricsTestServer(t *testing.T) *metricsTestServer {
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(configDir))
 	require.NoError(t, err)
 
-	httpServer := server.NewServer(appConfig.GetGlobalConfig(), server.WithAdaptor(false))
+	httpServer := server.NewServer(appConfig.GetGlobalConfig())
 	return &metricsTestServer{
 		appConfig: appConfig,
 		ginEngine: httpServer.GetRouter(),


### PR DESCRIPTION
## What

Rework Tier Duo from two in-process `httptest` servers sharing one Go heap into **two real tingly-box processes**, each booted through the full production path (`server.Start`: background refreshers, config watcher, production `http.Server` timeouts) and **observed separately** — so a memory regression attributes directly to the gateway/conversion path (tb2) or the vmodel serving path (tb1) instead of disappearing into a shared heap.

```
                 harness (parent — drives requests, never measured)
                    │
                    │ Anthropic v1/beta stream          per-instance sampling
                    ▼                                   /api/v1/debug/{memstats,pprof/heap}
   ┌──────────────────────────────┐    real HTTP    ┌──────────────────────────────┐
   │  tb2  (gateway under test)   ├────────────────▶│  tb1  (vmodel upstream)      │
   │  own process, server.Start() │                 │  own process, server.Start() │
   └──────────────────────────────┘                 └──────────────────────────────┘
```

## How

- **Child processes via self re-execution.** The parent spawns `os.Executable()` under the `TINGLY_DUO_*` env contract; `MaybeRunDuoServe()` intercepts in both `cli/harness` `main()` and `duo_test.go`'s `TestMain`, so the CLI and `go test` share one mechanism with no extra build step. Children self-seed their own config dirs (providers/rules from env) — the parent never opens an instance's SQLite store.
- **Production observation endpoints.** New `/api/v1/debug/memstats` (optional forced GC → post-GC retained set, goroutine count) and `/api/v1/debug/pprof/heap` (gzipped pprof), user-token auth, swagger-defined. Deliberately a *narrowed* re-exposure of `runtime/pprof` rather than mounting `net/http/pprof` wholesale (DefaultServeMux side effect, wider surface, unthrottleable `gc=1`); the full pprof suite stays on the explicit `--pprof` side server. Both expensive operations are throttled to 1/s per instance: forced GC degrades to an un-forced snapshot (`gc_forced: false`), profile serialization rejects with 429 + Retry-After. The same endpoints work against any live deployment.
- **Per-instance memory phase.** Baseline / post-GC retention slope across two batches / allocation churn / concurrent-burst peak / goroutine counts, reported tb1 and tb2 side by side; the slope threshold applies to each instance. Checkpoints for the two independent processes are sampled concurrently.
- **Backpressure (`-slow`) route variants.** tb1 registers slow/large stream vmodels (`--stream-kb` over ~2×`--stream-ms`) and the client reads the SSE body slowly (`--read-delay-ms`, 8 KB window), putting buffering under real TCP backpressure on the measured path. Default memory routes: `beta-chat,beta-chat-slow`.
- **Cleanup.** Removed the dead `WithAdaptor` server option (set but never read) and its call sites.

## Docs & tests

- `.design/harness-duo.md`: topology rationale, env contract, observation/cost-control semantics, relation to pprof, and a fidelity ledger of remaining gaps (loopback HTTP vs TLS, text-only conversation bodies, deterministic vmodel latency).
- `cli/harness/README.md` Tier Duo section rewritten; `openapi.json` regenerated.
- Tests: `TestDuoFunctional` (all 6 routes), `TestDuoMemoryRegression` (per-instance slope guard), `TestDuoBackpressure` (slow stream + slow reader), debug-module unit tests incl. both throttles.

## Verification

- Full-default `./harness duo`: 6 routes × 13 functional checks pass; healthy slopes (tb1 ~0.1, tb2 ~0.2–0.5 KB/request) on fast and backpressure routes; per-instance heap profiles parse with `go tool pprof`.
- `go build ./...` (incl. the separate `gui/wails3` module), `go vet` (incl. `-tags e2e`), full `internal/protocoltest` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERy2KB6rj2q1EfBqBn6PHb