### PR TITLE
harness(routing): verify production pipeline order end to end

### DIFF
--- a/.design/harness-duo.md
+++ b/.design/harness-duo.md
@@ -202,10 +202,14 @@ Mechanics:
   (`outcome`, `matched_rule_description`) plus the summary's `routed_model`.
   This keeps the user-facing explain surface itself under test (the reason
   duo children boot `WithMultiLogger`, matching production).
+- **Pipeline assertion**: requests opt in to routing diagnostics and assert
+  `routing_source`, the pre-dispatch selected model, and the exact cumulative
+  evaluated-stage path. The wire marker remains independent, so failover can
+  prove both which service selection chose and which service finally answered.
 - **Scenarios are declarative** (`DuoRoutingScenario`): built-in catalog in
   `duo_routing_scenarios.go` (one per position category + first-match
-  ordering + the G3 partition-scoped-affinity regression), user files via
-  `harness routing --file`.
+  ordering + four pipeline boundaries: health→smart, smart→affinity,
+  affinity→LB, and smart→LB), user files via `harness routing --file`.
 
 Semantics the scenarios encode (learned the hard way, keep in mind when
 authoring):

--- a/cli/harness/README.md
+++ b/cli/harness/README.md
@@ -491,22 +491,29 @@ independent surfaces:
 ```bash
 ./harness routing                      # all built-in scenarios
 ./harness routing --list               # catalog with descriptions
-./harness routing --scenarios token-threshold,affinity-partition
+./harness routing --scenarios pipeline-health-before-smart-routing,pipeline-smart-routing-before-affinity,pipeline-affinity-before-load-balancer,pipeline-smart-routing-before-load-balancer
 ./harness routing --file my-rules.yaml # user-defined scenarios (see testdata/routing/example.yaml)
 ./harness routing --json               # machine-readable report
 ```
 
 Built-ins cover the smart-routing position catalog (token, thinking,
-context_user, model, time_range, agent.claude_code) plus two
-behavioral regressions: **first-match ordering** and **G3** (session pins
-scoped per content partition). Time-range windows are built relative to the
-wall clock — hours-wide margins, no clock seam needed.
+context_user, model, time_range, agent.claude_code), **first-match ordering**,
+and four explicit pipeline invariants: **health before smart-routing**,
+**smart-routing before affinity**, **affinity before load-balancer**, and
+**smart-routing before load-balancer**. Each pipeline scenario asserts the
+opt-in debug routing source and exact evaluated-stage path in addition to the
+wire responder and smart-routing timeline. Time-range windows are built
+relative to the wall clock — hours-wide margins, no clock seam needed.
 
 Semantics worth knowing when authoring scenarios:
 
 - When **no partition matches**, the LB falls back to the **union** of base
   + partition services, so `expect.svc` is only deterministic for matched
   requests; miss requests assert `outcome: no_match` on the trace instead.
+- Pipeline expectations can assert `source`, `selected_model`, and the exact
+  ordered `stages`. `svc` remains the independent final wire responder, so a
+  failover scenario can distinguish the initially selected service from the
+  service that ultimately answered.
 - `service_ttft` / `service_capacity` (stats-driven, pass on empty data)
   and `proxy_vision` (processor-bearing bypass op) are not covered yet.
 

--- a/cli/harness/testdata/routing/example.yaml
+++ b/cli/harness/testdata/routing/example.yaml
@@ -3,8 +3,11 @@
 # Services reference tb1's service-identity pool ("a".."f"); each identity
 # answers with its own marker so `expect.svc` is verified from the response
 # body. `target` picks the provider protocol (chat | responses | anthropic).
-# Trace expectations (`outcome`, `matched`) are checked against tb2's
-# /api/v1/requests smart_routing trace.
+# Rules may set `lb_tactic` / `within_tier_tactic`; services may set `tier`
+# and `weight`, allowing SmartRouting-before-LB precedence checks.
+# Pipeline expectations (`source`, `selected_model`, `stages`) are checked
+# against opt-in routing diagnostics. Trace expectations (`outcome`, `matched`)
+# are checked against tb2's /api/v1/requests smart_routing trace.
 #
 # NOTE: when no partition matches (outcome: no_match), the load balancer
 # picks from the UNION of base + partition services, so `expect.svc` is only

--- a/internal/protocoltest/duo_routing.go
+++ b/internal/protocoltest/duo_routing.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -44,6 +45,15 @@ type DuoRoutingService struct {
 	// Target is the provider protocol: "chat" (default), "responses", or
 	// "anthropic".
 	Target string `yaml:"target,omitempty" json:"target,omitempty"`
+	// Model overrides the service-identity model derived from Svc. It is used
+	// for production mock models such as virtual-fail-429 in pipeline setup
+	// requests. Normal wire-identity services should use Svc.
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
+	// Tier is the service priority for the tier tactic (lower is preferred).
+	Tier int `yaml:"tier,omitempty" json:"tier,omitempty"`
+	// Weight controls selection within tactics that support weighting. Zero
+	// keeps the harness default of 1.
+	Weight int `yaml:"weight,omitempty" json:"weight,omitempty"`
 }
 
 // DuoSmartOpSpec is one smart-routing condition in scenario form; it maps
@@ -69,6 +79,12 @@ type DuoRoutingRule struct {
 	Scenario string `yaml:"scenario,omitempty" json:"scenario,omitempty"`
 	// AffinitySecs enables session affinity (Flags.SessionAffinity).
 	AffinitySecs int `yaml:"affinity_secs,omitempty" json:"affinity_secs,omitempty"`
+	// LBTactic selects the terminal load-balancing strategy. Empty means the
+	// harness default (random).
+	LBTactic string `yaml:"lb_tactic,omitempty" json:"lb_tactic,omitempty"`
+	// WithinTierTactic selects among services in the same tier. Empty means
+	// random. It is only meaningful when LBTactic is tier.
+	WithinTierTactic string `yaml:"within_tier_tactic,omitempty" json:"within_tier_tactic,omitempty"`
 	// Services is the base pool the LB falls back to when no partition
 	// matches.
 	Services []DuoRoutingService `yaml:"services" json:"services"`
@@ -99,6 +115,14 @@ type DuoRoutingExpect struct {
 	Outcome string `yaml:"outcome,omitempty" json:"outcome,omitempty"`
 	// Matched asserts the matched partition's description.
 	Matched string `yaml:"matched,omitempty" json:"matched,omitempty"`
+	// Source asserts the production routing source response header
+	// (smart_routing, affinity, or load_balancer).
+	Source string `yaml:"source,omitempty" json:"source,omitempty"`
+	// SelectedModel asserts the service selected before dispatch/failover. Use
+	// Svc for the independent final wire responder assertion.
+	SelectedModel string `yaml:"selected_model,omitempty" json:"selected_model,omitempty"`
+	// Stages asserts the exact cumulative ServiceSelector path.
+	Stages []string `yaml:"stages,omitempty" json:"stages,omitempty"`
 }
 
 // DuoRoutingRequest is one request in a scenario's program.
@@ -155,7 +179,19 @@ func duoRoutingServices(specs []DuoRoutingService) ([]*loadbalance.Service, erro
 		if err != nil {
 			return nil, err
 		}
-		services = append(services, harnessService(provider, DuoServiceModel(s.Svc)))
+		model := s.Model
+		if model == "" {
+			if s.Svc == "" {
+				return nil, fmt.Errorf("service requires svc or model")
+			}
+			model = DuoServiceModel(s.Svc)
+		}
+		svc := harnessService(provider, model)
+		svc.Tier = s.Tier
+		if s.Weight > 0 {
+			svc.Weight = s.Weight
+		}
+		services = append(services, svc)
 	}
 	return services, nil
 }
@@ -191,6 +227,23 @@ func (sc *DuoRoutingScenario) toRule() (*typ.Rule, error) {
 	rule.SmartEnabled = len(smart) > 0
 	rule.SmartRouting = smart
 	rule.Flags.SessionAffinity = sc.Rule.AffinitySecs
+	if sc.Rule.LBTactic != "" {
+		tactic, ok := loadbalance.ParseTacticTypeStrict(sc.Rule.LBTactic)
+		if !ok {
+			return nil, fmt.Errorf("scenario %s: unknown lb_tactic %q", sc.Name, sc.Rule.LBTactic)
+		}
+		rule.LBTactic = typ.NewDefaultTactic(tactic)
+	}
+	if sc.Rule.WithinTierTactic != "" {
+		if rule.GetTacticType() != loadbalance.TacticTier {
+			return nil, fmt.Errorf("scenario %s: within_tier_tactic requires lb_tactic tier", sc.Name)
+		}
+		within, ok := loadbalance.ParseTacticTypeStrict(sc.Rule.WithinTierTactic)
+		if !ok || within == loadbalance.TacticTier {
+			return nil, fmt.Errorf("scenario %s: invalid within_tier_tactic %q", sc.Name, sc.Rule.WithinTierTactic)
+		}
+		rule.LBTactic.Params = &typ.TierParams{WithinTierTactic: within}
+	}
 	return &rule, nil
 }
 
@@ -267,47 +320,36 @@ func buildRoutingBody(sc *DuoRoutingScenario, r DuoRoutingRequest) ([]byte, erro
 
 // duoRequestDetail mirrors the /api/v1/requests/:id response shape the
 // engine consumes.
+type duoRequestEvent struct {
+	Source string         `json:"source"`
+	Fields map[string]any `json:"fields"`
+}
+
 type duoRequestDetail struct {
-	RequestID   string `json:"request_id"`
-	RoutedModel string `json:"routed_model"`
-	Events      []struct {
-		Source string         `json:"source"`
-		Fields map[string]any `json:"fields"`
-	} `json:"events"`
+	RequestID   string            `json:"request_id"`
+	RoutedModel string            `json:"routed_model"`
+	Events      []duoRequestEvent `json:"events"`
 }
 
 // smartRoutingTrace fetches the request's timeline from the instance and
 // returns the smart_routing event's fields plus the summary's routed_model
 // (the model the LB ultimately dispatched, folded from the access log).
 // Sink writes race the response, so it retries briefly.
-func (inst *DuoInstance) smartRoutingTrace(requestID string) (fields map[string]any, routedModel string, err error) {
+func (inst *DuoInstance) routingRequestDetail(requestID string) (detail duoRequestDetail, err error) {
 	deadline := time.Now().Add(3 * time.Second)
 	for {
-		fields, routedModel, err = inst.smartRoutingTraceOnce(requestID)
-		if err == nil && routedModel != "" {
-			return fields, routedModel, nil
+		err = inst.getJSON("/api/v1/requests/"+requestID, &detail)
+		if err == nil && detail.RoutedModel != "" {
+			return detail, nil
 		}
 		if time.Now().After(deadline) {
 			if err == nil {
 				err = fmt.Errorf("request %s: routed_model not recorded", requestID)
 			}
-			return nil, "", err
+			return duoRequestDetail{}, err
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-}
-
-func (inst *DuoInstance) smartRoutingTraceOnce(requestID string) (map[string]any, string, error) {
-	var detail duoRequestDetail
-	if err := inst.getJSON("/api/v1/requests/"+requestID, &detail); err != nil {
-		return nil, "", err
-	}
-	for _, ev := range detail.Events {
-		if ev.Source == "smart_routing" {
-			return ev.Fields, detail.RoutedModel, nil
-		}
-	}
-	return nil, "", fmt.Errorf("request %s: no smart_routing event in timeline (%d events)", requestID, len(detail.Events))
 }
 
 // ─── Scenario execution ───────────────────────────────────────────────────────
@@ -359,6 +401,7 @@ func (env *DuoEnv) runRoutingRequest(sc *DuoRoutingScenario, r DuoRoutingRequest
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+env.TB2.ModelToken)
 	req.Header.Set("X-Request-Id", requestID)
+	req.Header.Set("X-Tingly-Debug-Routing", "1")
 	if r.Session != "" {
 		req.Header.Set("X-Tingly-Session-ID", r.Session)
 	}
@@ -374,6 +417,22 @@ func (env *DuoEnv) runRoutingRequest(sc *DuoRoutingScenario, r DuoRoutingRequest
 		return
 	}
 	add("http", true, "200")
+	if r.Expect.Source != "" {
+		got := resp.Header.Get("X-Tingly-Routing-Source")
+		add("routing/source", got == r.Expect.Source, fmt.Sprintf("want %s, got %s", r.Expect.Source, got))
+	}
+	if r.Expect.SelectedModel != "" {
+		got := resp.Header.Get("X-Tingly-Selected-Model")
+		add("routing/selected_model", got == r.Expect.SelectedModel,
+			fmt.Sprintf("want %s, got %s", r.Expect.SelectedModel, got))
+	}
+	if len(r.Expect.Stages) > 0 {
+		got := strings.Split(resp.Header.Get("X-Tingly-Evaluated-Stages"), ",")
+		if len(got) == 1 && got[0] == "" {
+			got = nil
+		}
+		add("routing/stages", slices.Equal(got, r.Expect.Stages), fmt.Sprintf("want %v, got %v", r.Expect.Stages, got))
+	}
 
 	// Wire-level: which service identity answered.
 	if r.Expect.Svc != "" {
@@ -393,10 +452,17 @@ func (env *DuoEnv) runRoutingRequest(sc *DuoRoutingScenario, r DuoRoutingRequest
 	if r.Expect.Outcome == "" && r.Expect.Matched == "" && r.Expect.Svc == "" {
 		return
 	}
-	fields, routedModel, err := env.TB2.smartRoutingTrace(requestID)
+	detail, err := env.TB2.routingRequestDetail(requestID)
 	if err != nil {
 		add("trace", false, err.Error())
 		return
+	}
+	var fields map[string]any
+	for _, ev := range detail.Events {
+		if ev.Source == "smart_routing" {
+			fields = ev.Fields
+			break
+		}
 	}
 	if r.Expect.Outcome != "" {
 		got, _ := fields["outcome"].(string)
@@ -409,6 +475,6 @@ func (env *DuoEnv) runRoutingRequest(sc *DuoRoutingScenario, r DuoRoutingRequest
 	}
 	if r.Expect.Svc != "" {
 		want := DuoServiceModel(r.Expect.Svc)
-		add("trace/routed_model", routedModel == want, fmt.Sprintf("want %s, got %s", want, routedModel))
+		add("trace/routed_model", detail.RoutedModel == want, fmt.Sprintf("want %s, got %s", want, detail.RoutedModel))
 	}
 }

--- a/internal/protocoltest/duo_routing_config_test.go
+++ b/internal/protocoltest/duo_routing_config_test.go
@@ -1,0 +1,37 @@
+package protocoltest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestRoutingPipelineSmartBeforeLoadBalancerRuleShape(t *testing.T) {
+	sc := routingPipelineSmartBeforeLoadBalancer()
+	rule, err := sc.toRule()
+	require.NoError(t, err)
+	require.Equal(t, loadbalance.TacticTier, rule.GetTacticType())
+
+	params, ok := rule.LBTactic.Params.(*typ.TierParams)
+	require.True(t, ok)
+	require.Equal(t, loadbalance.TacticRandom, params.WithinTierTactic)
+	require.Equal(t, 0, rule.Services[0].Tier)
+	require.Equal(t, 1, rule.SmartRouting[0].Services[0].Tier)
+	require.Equal(t, 2, rule.SmartRouting[0].Services[1].Tier)
+}
+
+func TestRoutingRuleRejectsInvalidTactics(t *testing.T) {
+	sc := routingPipelineSmartBeforeLoadBalancer()
+	sc.Rule.LBTactic = "typo"
+	_, err := sc.toRule()
+	require.ErrorContains(t, err, "unknown lb_tactic")
+
+	sc = routingPipelineSmartBeforeLoadBalancer()
+	sc.Rule.LBTactic = "random"
+	sc.Rule.WithinTierTactic = "random"
+	_, err = sc.toRule()
+	require.ErrorContains(t, err, "requires lb_tactic tier")
+}

--- a/internal/protocoltest/duo_routing_scenarios.go
+++ b/internal/protocoltest/duo_routing_scenarios.go
@@ -60,6 +60,10 @@ func LoadRoutingScenarios(path string) ([]*DuoRoutingScenario, error) {
 // clock (the smart-routing clock is not injectable across processes).
 func BuiltinRoutingScenarios() []*DuoRoutingScenario {
 	return []*DuoRoutingScenario{
+		routingPipelineHealthBeforeSmart(),
+		routingPipelineSmartBeforeLoadBalancer(),
+		routingPipelineAffinityBeforeLoadBalancer(),
+		routingPipelineSmartBeforeAffinity(),
 		routingTokenThreshold(),
 		routingThinking(),
 		routingContextKeyword(),
@@ -67,7 +71,124 @@ func BuiltinRoutingScenarios() []*DuoRoutingScenario {
 		routingTimeRange(),
 		routingFirstMatchOrder(),
 		routingClaudeCodeKind(),
-		routingAffinityPartition(),
+	}
+}
+
+var fullSelectionPipeline = []string{"health", "smart_routing", "affinity", "load_balancer"}
+
+func routingPipelineHealthBeforeSmart() *DuoRoutingScenario {
+	return &DuoRoutingScenario{
+		Name:        "pipeline-health-before-smart-routing",
+		Description: "health removes a rate-limited service before smart routing intersects the matched partition",
+		Rule: DuoRoutingRule{
+			LBTactic:         "tier",
+			WithinTierTactic: "random",
+			Services: []DuoRoutingService{
+				{Svc: "b", Tier: 1},
+				{Svc: "c", Tier: 2},
+			},
+			Smart: []DuoSmartPartition{{
+				Description: "health-sensitive partition",
+				Ops:         []DuoSmartOpSpec{{Position: "context_user", Operation: "contains", Value: "ROUTE-HEALTH"}},
+				Services: []DuoRoutingService{
+					{Model: FailMockPreContent429, Tier: 0},
+					{Svc: "b", Tier: 1},
+				},
+			}},
+		},
+		Requests: []DuoRoutingRequest{
+			{
+				Name: "mark-primary-unhealthy", Body: DuoRoutingBody{UserText: "ROUTE-HEALTH setup"},
+				Expect: DuoRoutingExpect{
+					Svc: "b", Outcome: "matched", Matched: "health-sensitive partition",
+					Source: "smart_routing", SelectedModel: FailMockPreContent429, Stages: fullSelectionPipeline,
+				},
+			},
+			{
+				Name: "health-filtered-before-smart", Body: DuoRoutingBody{UserText: "ROUTE-HEALTH verify"},
+				Expect: DuoRoutingExpect{
+					Svc: "b", Outcome: "matched", Matched: "health-sensitive partition",
+					Source: "smart_routing", SelectedModel: DuoServiceModel("b"), Stages: fullSelectionPipeline,
+				},
+			},
+		},
+	}
+}
+
+// routingPipelineSmartBeforeLoadBalancer deliberately makes the global LB preference conflict
+// with the smart partition. If LB ran first it would choose base tier-0 A;
+// the expected tier-1 B proves SmartRouting narrowed the candidates before
+// the terminal tier tactic selected within that subset. The no-match request
+// is the control and must return to A under the same rule.
+func routingPipelineSmartBeforeLoadBalancer() *DuoRoutingScenario {
+	return &DuoRoutingScenario{
+		Name:        "pipeline-smart-routing-before-load-balancer",
+		Description: "smart routing narrows candidates before the tier load balancer selects",
+		Rule: DuoRoutingRule{
+			LBTactic:         "tier",
+			WithinTierTactic: "random",
+			Services:         []DuoRoutingService{{Svc: "a", Tier: 0}},
+			Smart: []DuoSmartPartition{{
+				Description: "smart partition",
+				Ops:         []DuoSmartOpSpec{{Position: "context_user", Operation: "contains", Value: "ROUTE-SMART"}},
+				Services: []DuoRoutingService{
+					{Svc: "b", Tier: 1},
+					{Svc: "c", Tier: 2},
+				},
+			}},
+		},
+		Requests: []DuoRoutingRequest{
+			{
+				Name: "match", Body: DuoRoutingBody{UserText: "please ROUTE-SMART now"},
+				Expect: DuoRoutingExpect{
+					Svc: "b", Outcome: "matched", Matched: "smart partition",
+					Source: "smart_routing", Stages: fullSelectionPipeline,
+				},
+			},
+			{
+				Name: "no-match", Body: DuoRoutingBody{UserText: "ordinary request"},
+				Expect: DuoRoutingExpect{
+					Svc: "a", Outcome: "no_match", Source: "load_balancer", Stages: fullSelectionPipeline,
+				},
+			},
+		},
+	}
+}
+
+func routingPipelineAffinityBeforeLoadBalancer() *DuoRoutingScenario {
+	const session = "duo-affinity-before-lb"
+	return &DuoRoutingScenario{
+		Name:        "pipeline-affinity-before-load-balancer",
+		Description: "the first request creates a partition pin; the second terminates at affinity without evaluating load balancing",
+		Rule: DuoRoutingRule{
+			AffinitySecs: 300,
+			LBTactic:     "tier",
+			Services:     []DuoRoutingService{{Svc: "c", Tier: 2}},
+			Smart: []DuoSmartPartition{{
+				Description: "sticky partition",
+				Ops:         []DuoSmartOpSpec{{Position: "context_user", Operation: "contains", Value: "ROUTE-STICKY"}},
+				Services: []DuoRoutingService{
+					{Svc: "a", Tier: 0},
+					{Svc: "b", Tier: 1},
+				},
+			}},
+		},
+		Requests: []DuoRoutingRequest{
+			{
+				Name: "create-pin", Session: session, Body: DuoRoutingBody{UserText: "ROUTE-STICKY first"},
+				Expect: DuoRoutingExpect{
+					Svc: "a", Outcome: "matched", Matched: "sticky partition",
+					Source: "smart_routing", Stages: fullSelectionPipeline,
+				},
+			},
+			{
+				Name: "affinity-short-circuit", Session: session, Body: DuoRoutingBody{UserText: "ROUTE-STICKY second"},
+				Expect: DuoRoutingExpect{
+					Svc: "a", Outcome: "matched", Matched: "sticky partition",
+					Source: "affinity", Stages: []string{"health", "smart_routing", "affinity"},
+				},
+			},
+		},
 	}
 }
 
@@ -309,15 +430,15 @@ func routingClaudeCodeKind() *DuoRoutingScenario {
 	}
 }
 
-// routingAffinityPartition is the G3 regression: with session affinity on,
+// routingPipelineSmartBeforeAffinity is the G3 regression: with session affinity on,
 // a pin acquired in one content partition must not drag requests of the
 // other partition — content routing wins, pins are scoped per partition.
-func routingAffinityPartition() *DuoRoutingScenario {
+func routingPipelineSmartBeforeAffinity() *DuoRoutingScenario {
 	const session = "duo-g3-session"
 	big := DuoRoutingBody{SizeKB: 256}
 	small := DuoRoutingBody{SizeKB: 4}
 	return &DuoRoutingScenario{
-		Name:        "affinity-partition",
+		Name:        "pipeline-smart-routing-before-affinity",
 		Description: "G3: session pins are scoped per smart partition; content routing beats a cross-partition pin",
 		Rule: DuoRoutingRule{
 			AffinitySecs: 300,
@@ -338,15 +459,24 @@ func routingAffinityPartition() *DuoRoutingScenario {
 		Requests: []DuoRoutingRequest{
 			{
 				Name: "big-1", Session: session, Body: big,
-				Expect: DuoRoutingExpect{Svc: "a", Outcome: "matched", Matched: "big"},
+				Expect: DuoRoutingExpect{
+					Svc: "a", Outcome: "matched", Matched: "big",
+					Source: "smart_routing", Stages: fullSelectionPipeline,
+				},
 			},
 			{
 				Name: "small-after-pin", Session: session, Body: small,
-				Expect: DuoRoutingExpect{Svc: "b", Outcome: "matched", Matched: "small"},
+				Expect: DuoRoutingExpect{
+					Svc: "b", Outcome: "matched", Matched: "small",
+					Source: "smart_routing", Stages: fullSelectionPipeline,
+				},
 			},
 			{
 				Name: "big-2", Session: session, Body: big,
-				Expect: DuoRoutingExpect{Svc: "a", Outcome: "matched", Matched: "big"},
+				Expect: DuoRoutingExpect{
+					Svc: "a", Outcome: "matched", Matched: "big",
+					Source: "affinity", Stages: []string{"health", "smart_routing", "affinity"},
+				},
 			},
 		},
 	}

--- a/internal/protocoltest/duo_serve.go
+++ b/internal/protocoltest/duo_serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/config"
 	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/server"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -102,6 +103,11 @@ func runDuoServe() error {
 		if err := seedDuoGateway(appCfg, os.Getenv(duoEnvUpstreamURL), os.Getenv(duoEnvUpstreamToken)); err != nil {
 			return fmt.Errorf("seed gateway wiring: %w", err)
 		}
+		// Pipeline health scenarios need a non-zero recovery window so a 429
+		// remains observable by the next request. State still comes exclusively
+		// from real gateway traffic; this only makes the duo config explicit and
+		// deterministic instead of inheriting a zero-value immediate recovery.
+		appCfg.GetGlobalConfig().HealthMonitor = loadbalance.DefaultHealthMonitorConfig()
 	}
 
 	// Production boots with a MultiLogger; without it the smart-routing and

--- a/internal/server/failover_dispatch.go
+++ b/internal/server/failover_dispatch.go
@@ -419,6 +419,15 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 			return
 		}
 
+		// Health owns rate-limit/auth availability across requests, while the
+		// breaker owns transient 5xx failures within a rule. A successful
+		// fallback means final usage tracking only sees the fallback's success,
+		// so record a failed 429 attempt here or the next request would select
+		// the rate-limited service again before SmartRouting/LB evaluation.
+		if status == http.StatusTooManyRequests && ph.deps.HealthMonitor != nil {
+			ph.deps.HealthMonitor.ReportRateLimit(serviceID)
+		}
+
 		loadbalance.RecordServiceFailure(rule.UUID, serviceID)
 		state := loadbalance.DefaultBreakerStore().Get(rule.UUID, serviceID).State()
 		fields = failoverLogFields(c, rule, provider, model, serviceID)

--- a/internal/server/failover_logging_test.go
+++ b/internal/server/failover_logging_test.go
@@ -132,6 +132,9 @@ func TestFailoverLogging_RetryAndGiveUp(t *testing.T) {
 		}
 
 		h.DispatchWithPriorityFailover(c, rule, providerT0, "gpt-4o", attempt)
+		if hm.IsHealthy(loadbalance.FormatServiceID(providerT0.UUID, "gpt-4o")) {
+			t.Fatal("retryable 429 attempt must mark the failed service unhealthy even when fallback succeeds")
+		}
 
 		printCapturedLog(t, hook.entries)
 

--- a/internal/server/load_balance_simulator.go
+++ b/internal/server/load_balance_simulator.go
@@ -19,7 +19,7 @@ import (
 )
 
 // LBSimulator drives the real load-balancing path — routing.ServiceSelector.Select
-// (health → affinity → smart → strategy) followed by dispatchWithPriorityFailover —
+// (health → smart → affinity → strategy) followed by dispatchWithPriorityFailover —
 // against programmable fake upstreams over a request sequence, with a deterministic
 // breaker clock.
 //

--- a/internal/server/protocol_handler.go
+++ b/internal/server/protocol_handler.go
@@ -61,8 +61,8 @@ type ProtocolHandlerDeps struct {
 	// description, context window) from the provider template catalog.
 	TemplateManager *data.TemplateManager
 
-	// RoutingSelector runs the full selection pipeline (health → affinity →
-	// smart → strategy) for a scenario/rule/request, used by the top-level
+	// RoutingSelector runs the full selection pipeline (health → smart →
+	// affinity → strategy) for a scenario/rule/request, used by the top-level
 	// OpenAI/Anthropic entry handlers (Step 10).
 	RoutingSelector *routing.SimpleSelector
 

--- a/internal/server/routing/pipeline_scenarios_test.go
+++ b/internal/server/routing/pipeline_scenarios_test.go
@@ -1,0 +1,131 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// pipelineScenarioLB makes the candidate set handed to the terminal load
+// balancer observable. Returning the first candidate also creates deliberate
+// conflicts with upstream stages: without the expected narrowing or affinity
+// short-circuit, a different service wins.
+type pipelineScenarioLB struct {
+	health *typ.HealthFilter
+	calls  int
+	seen   []string
+}
+
+func (l *pipelineScenarioLB) HealthFilter() *typ.HealthFilter { return l.health }
+
+func (l *pipelineScenarioLB) SelectService(rule *typ.Rule) (*loadbalance.Service, error) {
+	l.calls++
+	l.seen = l.seen[:0]
+	for _, svc := range rule.GetActiveServices() {
+		l.seen = append(l.seen, svc.ServiceID())
+	}
+	if len(rule.GetActiveServices()) == 0 {
+		return nil, nil
+	}
+	return rule.GetActiveServices()[0], nil
+}
+
+func pipelineScenarioConfig(services ...*loadbalance.Service) *mockConfig {
+	providers := make(map[string]*typ.Provider, len(services))
+	for _, svc := range services {
+		providers[svc.Provider] = testProvider(svc.Provider, svc.Provider, true)
+	}
+	return &mockConfig{providers: providers}
+}
+
+func pipelineSmartRule(base []*loadbalance.Service, partition []*loadbalance.Service) *typ.Rule {
+	rule := testRule("pipeline-rule", "request-model", base)
+	rule.SmartEnabled = true
+	rule.SmartRouting = []smartrouting.SmartRouting{{
+		Description: "matched partition",
+		Ops:         []smartrouting.SmartOp{testModelContainsOp("smart")},
+		Services:    partition,
+	}}
+	return rule
+}
+
+func TestServiceSelectorPipelineScenarios(t *testing.T) {
+	t.Run("pipeline-health-before-smart-routing", func(t *testing.T) {
+		base := testService("base", "base-model", true)
+		unhealthy := testService("unhealthy", "smart-unhealthy", true)
+		healthy := testService("healthy", "smart-healthy", true)
+		rule := pipelineSmartRule([]*loadbalance.Service{base}, []*loadbalance.Service{unhealthy, healthy})
+
+		monitor := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+		monitor.ReportRateLimit(unhealthy.ServiceID())
+		lb := &pipelineScenarioLB{health: typ.NewHealthFilter(monitor)}
+		sel := NewServiceSelector(pipelineScenarioConfig(base, unhealthy, healthy), newMockAffinityStore(), lb)
+		ctx := testContext(rule, "")
+		ctx.Request = testOpenAIRequest("smart-request")
+
+		result, err := sel.Select(ctx)
+		require.NoError(t, err)
+		require.Equal(t, healthy.ServiceID(), result.Service.ServiceID())
+		require.Equal(t, []string{healthy.ServiceID()}, lb.seen,
+			"health must remove the unhealthy service before smart routing intersects its partition")
+	})
+
+	t.Run("pipeline-smart-routing-before-affinity", func(t *testing.T) {
+		base := testService("base", "base-model", true)
+		smart := testService("smart", "smart-model", true)
+		rule := pipelineSmartRule([]*loadbalance.Service{base}, []*loadbalance.Service{smart})
+		rule.Flags.SessionAffinity = 300
+		store := newMockAffinityStore()
+		store.Set(rule.UUID, AffinitySessionKey(testSessionKey("session"), -1), testAffinityEntry(base))
+		lb := &pipelineScenarioLB{}
+		sel := NewServiceSelector(pipelineScenarioConfig(base, smart), store, lb)
+		ctx := testContext(rule, "session")
+		ctx.Request = testOpenAIRequest("smart-request")
+
+		result, err := sel.Select(ctx)
+		require.NoError(t, err)
+		require.Equal(t, smart.ServiceID(), result.Service.ServiceID(),
+			"the global affinity pin must not capture a request that first enters a smart partition")
+		require.Equal(t, 0, ctx.MatchedSmartRuleIndex)
+	})
+
+	t.Run("pipeline-affinity-before-load-balancer", func(t *testing.T) {
+		first := testService("first", "smart-first", true)
+		pinned := testService("pinned", "smart-pinned", true)
+		rule := pipelineSmartRule(nil, []*loadbalance.Service{first, pinned})
+		rule.Flags.SessionAffinity = 300
+		store := newMockAffinityStore()
+		store.Set(rule.UUID, AffinitySessionKey(testSessionKey("session"), 0), testAffinityEntry(pinned))
+		lb := &pipelineScenarioLB{}
+		sel := NewServiceSelector(pipelineScenarioConfig(first, pinned), store, lb)
+		ctx := testContext(rule, "session")
+		ctx.Request = testOpenAIRequest("smart-request")
+
+		result, err := sel.Select(ctx)
+		require.NoError(t, err)
+		require.Equal(t, SourceAffinity, result.Source)
+		require.Equal(t, pinned.ServiceID(), result.Service.ServiceID())
+		require.Zero(t, lb.calls, "an eligible affinity hit must terminate before load balancing")
+	})
+
+	t.Run("pipeline-smart-routing-before-load-balancer", func(t *testing.T) {
+		base := testService("base", "base-model", true)
+		firstSmart := testService("smart-a", "smart-a-model", true)
+		secondSmart := testService("smart-b", "smart-b-model", true)
+		rule := pipelineSmartRule([]*loadbalance.Service{base}, []*loadbalance.Service{firstSmart, secondSmart})
+		lb := &pipelineScenarioLB{}
+		sel := NewServiceSelector(pipelineScenarioConfig(base, firstSmart, secondSmart), newMockAffinityStore(), lb)
+		ctx := testContext(rule, "")
+		ctx.Request = testOpenAIRequest("smart-request")
+
+		result, err := sel.Select(ctx)
+		require.NoError(t, err)
+		require.Equal(t, firstSmart.ServiceID(), result.Service.ServiceID())
+		require.Equal(t, []string{firstSmart.ServiceID(), secondSmart.ServiceID()}, lb.seen,
+			"load balancing must receive the smart partition, not the global candidate pool")
+	})
+}

--- a/internal/server/routing/result.go
+++ b/internal/server/routing/result.go
@@ -61,8 +61,3 @@ func NewFilterResult(source string, services []*loadbalance.Service) *SelectionR
 		MatchedSmartRuleIndex: -1,
 	}
 }
-
-// AddEvaluatedStage records that a stage was evaluated
-func (r *SelectionResult) AddEvaluatedStage(stageName string) {
-	r.EvaluatedStages = append(r.EvaluatedStages, stageName)
-}

--- a/internal/server/routing/selector.go
+++ b/internal/server/routing/selector.go
@@ -172,6 +172,7 @@ func NewServiceSelectorWithLogger(
 // It picks a pre-built pipeline based on rule configuration and executes it.
 func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error) {
 	state := newSelectionState(ctx.Rule)
+	evaluatedStages := make([]string, 0, len(s.pipeline))
 
 	logrus.Debugf("[selector] executing pipeline with %d stages for rule %s",
 		len(s.pipeline), ctx.Rule.UUID)
@@ -179,19 +180,25 @@ func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error
 	// Execute pipeline stages in order
 	for _, stage := range s.pipeline {
 		stageName := stage.Name()
+		evaluatedStages = append(evaluatedStages, stageName)
 		logrus.Debugf("[selector] evaluating stage: %s", stageName)
 
 		result, handled := stage.Evaluate(ctx, state)
 
-		// Track that this stage was evaluated
 		if result != nil {
-			result.AddEvaluatedStage(stageName)
 			if result.FilteredServices != nil {
 				state.candidateServices = result.FilteredServices
 			}
 		}
 
 		if handled {
+			if result != nil {
+				// A filter stage's result is intentionally replaced as the
+				// pipeline advances. Attach the cumulative path at the terminal
+				// boundary so observability reports every stage that actually ran,
+				// including pass-through stages that returned nil.
+				result.EvaluatedStages = append([]string(nil), evaluatedStages...)
+			}
 			// Stage produced a result, validate and return
 			if result == nil || result.Service == nil {
 				logrus.Warnf("[selector] stage %s returned handled=true but nil result", stageName)

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -50,7 +50,7 @@ func (s *SimpleSelector) SelectService(
 			}
 			svc := &loadbalance.Service{Provider: providerUUID, Model: model, Active: true}
 			logrus.Debugf("[routing] probe service pin: provider=%s model=%s", provider.Name, model)
-			setRoutingDebugHeaders(c, provider.Name, provider.UUID, model, SourceProbePin, -1)
+			setRoutingDebugHeaders(c, provider.Name, provider.UUID, model, SourceProbePin, -1, nil)
 			return provider, svc, nil
 		}
 	}
@@ -105,7 +105,7 @@ func (s *SimpleSelector) SelectService(
 		"evaluated_stages": result.EvaluatedStages,
 	}).Infof("[routing] selected %s/%s via %s", result.Provider.UUID, result.Service.Model, result.Source)
 
-	setRoutingDebugHeaders(c, result.Provider.Name, result.Provider.UUID, result.Service.Model, result.Source, result.MatchedSmartRuleIndex)
+	setRoutingDebugHeaders(c, result.Provider.Name, result.Provider.UUID, result.Service.Model, result.Source, result.MatchedSmartRuleIndex, result.EvaluatedStages)
 
 	return result.Provider, result.Service, nil
 }
@@ -113,7 +113,7 @@ func (s *SimpleSelector) SelectService(
 // setRoutingDebugHeaders emits X-Tingly-Selected-* response headers describing
 // the routing decision, but only when the request opted in via
 // X-Tingly-Debug-Routing: 1 (set by probes). matchedSmartRule < 0 means none.
-func setRoutingDebugHeaders(c *gin.Context, providerName, providerUUID, model, source string, matchedSmartRule int) {
+func setRoutingDebugHeaders(c *gin.Context, providerName, providerUUID, model, source string, matchedSmartRule int, evaluatedStages []string) {
 	if c.GetHeader("X-Tingly-Debug-Routing") != "1" {
 		return
 	}
@@ -121,6 +121,9 @@ func setRoutingDebugHeaders(c *gin.Context, providerName, providerUUID, model, s
 	c.Header("X-Tingly-Selected-Provider-UUID", providerUUID)
 	c.Header("X-Tingly-Selected-Model", model)
 	c.Header("X-Tingly-Routing-Source", source)
+	if len(evaluatedStages) > 0 {
+		c.Header("X-Tingly-Evaluated-Stages", strings.Join(evaluatedStages, ","))
+	}
 	if matchedSmartRule >= 0 {
 		c.Header("X-Tingly-Matched-Smart-Rule", fmt.Sprintf("%d", matchedSmartRule))
 	}


### PR DESCRIPTION
## Why

SmartRouting and load balancing had separate harness coverage, but we lacked an end-to-end guarantee that production requests actually follow:

```text
Health → SmartRouting → Affinity → LoadBalancer
```

A correct final provider alone cannot prove this order—it may be accidental or only reflect the final routing label.

## Implementation

harness routing now includes four adversarial scenarios, one for each important stage boundary. They intentionally create conflicting Health, SmartRouting, Affinity, and LB decisions, then verify:

- the actual evaluated stage path;
- which stage completed selection;
- the service selected before failover;
- the upstream that ultimately answered.

The harness continues through the production Rule API and two-process gateway path.

This also fixes retryable 429 feedback during failover: a rate-limited primary is now reported to HealthMonitor even when a fallback succeeds, preventing the next request from immediately selecting it again.

## Verification

`go run ./cli/harness routing`

All 11 scenarios and 123 checks pass.

`go test ./internal/server/routing ./internal/loadbalance`
`go test ./internal/protocoltest`

All pass.