### PR TITLE
bugfix(ui): Fix API badge layout in ApiKeyTable

### DIFF
--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -304,11 +304,11 @@ const ApiKeyTable = ({
                                         >
                                             <ApiStyleBadge
                                                 apiStyle="openai"
-                                                sx={{width: "100%", justifyContent: "center"}}
+                                                sx={{minWidth: "110px", justifyContent: "center"}}
                                             />
                                             <ApiStyleBadge
                                                 apiStyle="anthropic"
-                                                sx={{width: "100%", justifyContent: "center"}}
+                                                sx={{minWidth: "110px", justifyContent: "center"}}
                                             />
                                         </Stack>
                                     ) : (

--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -297,25 +297,12 @@ const ApiKeyTable = ({
                                 {/* API Style */}
                                 <TableCell>
                                     {provider.api_base_openai && provider.api_base_anthropic ? (
-                                        <Stack
-                                            direction="column"
-                                            spacing={0.5}
-                                            alignItems="stretch"
-                                        >
-                                            <ApiStyleBadge
-                                                apiStyle="openai"
-                                                sx={{minWidth: "110px", justifyContent: "center"}}
-                                            />
-                                            <ApiStyleBadge
-                                                apiStyle="anthropic"
-                                                sx={{minWidth: "110px", justifyContent: "center"}}
-                                            />
+                                        <Stack direction="row" spacing={0.5} alignItems="center">
+                                            <ApiStyleBadge apiStyle="openai" compact />
+                                            <ApiStyleBadge apiStyle="anthropic" compact />
                                         </Stack>
                                     ) : (
-                                        <ApiStyleBadge
-                                            sx={{minWidth: "110px"}}
-                                            apiStyle={provider.api_style}
-                                        />
+                                        <ApiStyleBadge apiStyle={provider.api_style} compact />
                                     )}
                                 </TableCell>
                                 {/* API Base URL */}

--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -300,7 +300,7 @@ const ApiKeyTable = ({
                                         <Stack
                                             direction="column"
                                             spacing={0.5}
-                                            alignItems="stretch"
+                                            alignItems="flex-start"
                                         >
                                             <ApiStyleBadge
                                                 apiStyle="openai"

--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -297,12 +297,25 @@ const ApiKeyTable = ({
                                 {/* API Style */}
                                 <TableCell>
                                     {provider.api_base_openai && provider.api_base_anthropic ? (
-                                        <Stack direction="row" spacing={0.5} alignItems="center">
-                                            <ApiStyleBadge apiStyle="openai" compact />
-                                            <ApiStyleBadge apiStyle="anthropic" compact />
+                                        <Stack
+                                            direction="column"
+                                            spacing={0.5}
+                                            alignItems="stretch"
+                                        >
+                                            <ApiStyleBadge
+                                                apiStyle="openai"
+                                                sx={{minWidth: "110px", justifyContent: "center"}}
+                                            />
+                                            <ApiStyleBadge
+                                                apiStyle="anthropic"
+                                                sx={{minWidth: "110px", justifyContent: "center"}}
+                                            />
                                         </Stack>
                                     ) : (
-                                        <ApiStyleBadge apiStyle={provider.api_style} compact />
+                                        <ApiStyleBadge
+                                            sx={{minWidth: "110px"}}
+                                            apiStyle={provider.api_style}
+                                        />
                                     )}
                                 </TableCell>
                                 {/* API Base URL */}


### PR DESCRIPTION
## Summary
Adjusted the layout of API style badges in the ApiKeyTable to prevent them from stretching to full width and instead use a fixed minimum width.

## Changes
- Changed Stack `alignItems` from `"stretch"` to `"flex-start"` to allow badges to size naturally
- Updated ApiStyleBadge `width` from `"100%"` to `minWidth: "110px"` for both OpenAI and Anthropic badges to maintain consistent badge sizing without forcing full-width expansion

## Details
This change improves the visual layout by preventing the badges from unnecessarily expanding to fill the container width. The badges now maintain a reasonable minimum width while respecting the natural size of their content, resulting in a cleaner and more compact appearance in the table.

https://claude.ai/code/session_01K2WB7XD6Ye2c6goHdivRHK