### PR TITLE
fix(ui): add language toggle and adjacent nav buttons to routing guides

### DIFF
--- a/frontend/src/components/tier/EntryGuideDialog.tsx
+++ b/frontend/src/components/tier/EntryGuideDialog.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { ROUTING_GUIDE_STEPS } from './diagrams';
 import { StaticGraphViewer } from './StaticGraphViewer';
 import { GuideToolbarPreview } from './GuideToolbarPreview';
+import { GuideLanguageToggle } from './GuideLanguageToggle';
 
 export interface EntryGuideDialogProps {
     open: boolean;
@@ -128,13 +129,18 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                 }
             }}
         >
-            <DialogTitle id="entry-guide-dialog-title" sx={{ pr: 8 }}>
-                <Typography variant="h6" component="div">
-                    {guideTitle}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                    {t('rule.routing.guide.subtitle', { defaultValue: 'Step {{current}} of {{total}}', current: safeActiveStep + 1, total: totalSteps })}
-                </Typography>
+            <DialogTitle id="entry-guide-dialog-title" sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, pr: 8 }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="h6" component="div">
+                        {guideTitle}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                        {t('rule.routing.guide.subtitle', { defaultValue: 'Step {{current}} of {{total}}', current: safeActiveStep + 1, total: totalSteps })}
+                    </Typography>
+                </Box>
+                <Box sx={{ pt: 0.5 }}>
+                    <GuideLanguageToggle />
+                </Box>
             </DialogTitle>
             <IconButton
                 aria-label={t('common.close', { defaultValue: 'Close' })}
@@ -266,7 +272,7 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                     </Box>
                 </Box>
             </DialogContent>
-            <DialogActions sx={{ justifyContent: 'space-between', px: { xs: 2, sm: 3 }, py: 2 }}>
+            <DialogActions sx={{ justifyContent: 'flex-end', gap: 1.5, px: { xs: 2, sm: 3 }, py: 2 }}>
                 <Button
                     disabled={safeActiveStep === 0}
                     onClick={handleBack}

--- a/frontend/src/components/tier/GuideLanguageToggle.tsx
+++ b/frontend/src/components/tier/GuideLanguageToggle.tsx
@@ -1,0 +1,63 @@
+import { Box, Chip, Tooltip } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Compact language switcher for guide dialogs (EntryGuideDialog, TierGuideDialog).
+ *
+ * These dialogs are modal (fullScreen on mobile) and sit on top of the
+ * ActivityBar's language button, so users can get stuck mid-guide with the
+ * wrong language and no way to switch without closing the dialog. This gives
+ * the guide its own always-visible toggle, reusing the same
+ * i18n.changeLanguage + localStorage persistence as ActivityBar.
+ */
+export const GuideLanguageToggle: React.FC = () => {
+    const { t, i18n } = useTranslation();
+
+    const changeLanguage = (lng: string) => {
+        if (i18n.language === lng) return;
+        i18n.changeLanguage(lng);
+        localStorage.setItem('i18nextLng', lng);
+    };
+
+    return (
+        <Tooltip title={t('system.language.title')}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Chip
+                    label={t('system.language.en')}
+                    onClick={() => changeLanguage('en')}
+                    size="small"
+                    sx={{
+                        bgcolor: i18n.language === 'en' ? 'primary.main' : 'action.hover',
+                        color: i18n.language === 'en' ? 'primary.contrastText' : 'text.primary',
+                        fontWeight: i18n.language === 'en' ? 600 : 400,
+                        border: i18n.language === 'en' ? 'none' : '1px solid',
+                        borderColor: 'divider',
+                        cursor: 'pointer',
+                        '&:hover': {
+                            bgcolor: i18n.language === 'en' ? 'primary.dark' : 'action.selected',
+                        },
+                    }}
+                />
+                <Chip
+                    label={t('system.language.zh')}
+                    onClick={() => changeLanguage('zh')}
+                    size="small"
+                    sx={{
+                        bgcolor: i18n.language === 'zh' ? 'primary.main' : 'action.hover',
+                        color: i18n.language === 'zh' ? 'primary.contrastText' : 'text.primary',
+                        fontWeight: i18n.language === 'zh' ? 600 : 400,
+                        border: i18n.language === 'zh' ? 'none' : '1px solid',
+                        borderColor: 'divider',
+                        cursor: 'pointer',
+                        '&:hover': {
+                            bgcolor: i18n.language === 'zh' ? 'primary.dark' : 'action.selected',
+                        },
+                    }}
+                />
+            </Box>
+        </Tooltip>
+    );
+};
+
+export default GuideLanguageToggle;

--- a/frontend/src/components/tier/TierGuideDialog.tsx
+++ b/frontend/src/components/tier/TierGuideDialog.tsx
@@ -19,6 +19,7 @@ import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TIER_GUIDE_STEPS, type GuideStep } from './diagrams';
 import { StaticGraphViewer } from './StaticGraphViewer';
+import { GuideLanguageToggle } from './GuideLanguageToggle';
 
 export interface TierGuideDialogProps {
     open: boolean;
@@ -110,13 +111,18 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                 }
             }}
         >
-            <DialogTitle id="tier-guide-dialog-title" sx={{ pr: 8 }}>
-                <Typography variant="h6" component="div">
-                    {t(`rule.tier.guide.steps.${activeStep + 1}.title`)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                    {t('rule.tier.guide.subtitle', { defaultValue: 'Step {{current}} of {{total}}', current: activeStep + 1, total: maxSteps })}
-                </Typography>
+            <DialogTitle id="tier-guide-dialog-title" sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, pr: 8 }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="h6" component="div">
+                        {t(`rule.tier.guide.steps.${activeStep + 1}.title`)}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                        {t('rule.tier.guide.subtitle', { defaultValue: 'Step {{current}} of {{total}}', current: activeStep + 1, total: maxSteps })}
+                    </Typography>
+                </Box>
+                <Box sx={{ pt: 0.5 }}>
+                    <GuideLanguageToggle />
+                </Box>
             </DialogTitle>
             <IconButton
                 aria-label={t('common.close', { defaultValue: 'Close' })}
@@ -245,7 +251,7 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                     </Box>
                 </Box>
             </DialogContent>
-            <DialogActions sx={{ justifyContent: 'space-between', px: { xs: 2, sm: 3 }, py: 2 }}>
+            <DialogActions sx={{ justifyContent: 'flex-end', gap: 1.5, px: { xs: 2, sm: 3 }, py: 2 }}>
                 <Button
                     disabled={activeStep === 0}
                     onClick={handleBack}


### PR DESCRIPTION
## Summary

The Direct/Smart Routing Guide (`EntryGuideDialog`) and Tier Guide (`TierGuideDialog`) are near-mandatory onboarding dialogs new users go through — but had two UX issues:

1. **No in-dialog language switch.** The dialogs are modal (fullScreen on mobile), covering the app's persistent language toggle in `ActivityBar`. Users stuck in the wrong language couldn't switch without closing the guide first.
2. **Previous/Next split to opposite ends of the footer.** `justifyContent: 'space-between'` pushed the two nav buttons to the far left/right of the footer bar, making sequential "next, next, next" clicks span the full dialog width.

## Changes

- New `GuideLanguageToggle` component (`frontend/src/components/tier/GuideLanguageToggle.tsx`): a compact EN/中文 segmented-chip toggle, reusing the same `i18n.changeLanguage` + `localStorage` persistence already used in `ActivityBar` — no new i18n keys needed.
- Rendered it in the `DialogTitle` of both guides, next to the close button — always visible, no extra click/menu needed.
- Changed `DialogActions` from `justifyContent: 'space-between'` to `flex-end` + `gap`, so Previous/Next sit adjacent on the right instead of at opposite corners.
- Applied identically to both `EntryGuideDialog` and `TierGuideDialog` for consistency. 

## Verification

- `pnpm build` passes with no type errors.
- Manually verified via headless screenshot (Playwright, mock mode): language toggle switches all dialog copy (title, steps, buttons, hints) without closing the dialog or resetting the active step; nav buttons render adjacent in both light layouts.
- `TierGuideDialog` shares the exact same code pattern/component but wasn't separately screenshotted (harder to trigger via automation — requires Separate Model mode + node hover); risk is low given the identical change.