### PR TITLE
refactor(UI, UX): Improve timezone selector UX with common zones and offset labels

### DIFF
--- a/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
@@ -516,32 +516,33 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                                                                 {op.meta?.type === 'time_range' && op.operation && (() => {
                                                                     const range = parseTimeRange(op.value) || DEFAULT_TIME_RANGE;
                                                                     return (
-                                                                        <Stack spacing={1} sx={{ maxWidth: 440 }}>
+                                                                        <Stack spacing={1} sx={{ maxWidth: 560 }}>
+                                                                            <FormControl size="small" fullWidth>
+                                                                                <InputLabel>Apply</InputLabel>
+                                                                                <Select
+                                                                                    value={range.outside ? 'outside' : 'during'}
+                                                                                    label="Apply"
+                                                                                    onChange={(e) => updateTimeRange(op, { outside: e.target.value === 'outside' })}
+                                                                                >
+                                                                                    <MenuItem value="during">During this window</MenuItem>
+                                                                                    <MenuItem value="outside">Outside this window</MenuItem>
+                                                                                </Select>
+                                                                            </FormControl>
                                                                             <Stack direction="row" spacing={1}>
-                                                                                <FormControl size="small" fullWidth>
-                                                                                    <InputLabel>Apply</InputLabel>
-                                                                                    <Select
-                                                                                        value={range.outside ? 'outside' : 'during'}
-                                                                                        label="Apply"
-                                                                                        onChange={(e) => updateTimeRange(op, { outside: e.target.value === 'outside' })}
-                                                                                    >
-                                                                                        <MenuItem value="during">During this window</MenuItem>
-                                                                                        <MenuItem value="outside">Outside this window</MenuItem>
-                                                                                    </Select>
-                                                                                </FormControl>
                                                                                 <TextField size="small" label="Start" type="time" value={range.start} onChange={(e) => updateTimeRange(op, { start: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
                                                                                 <TextField size="small" label="End" type="time" value={range.end} onChange={(e) => updateTimeRange(op, { end: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
+                                                                                <Autocomplete
+                                                                                    size="small"
+                                                                                    fullWidth
+                                                                                    disableClearable
+                                                                                    options={timezones.includes(range.timezone) ? timezones : [range.timezone, ...timezones]}
+                                                                                    getOptionLabel={timezoneLabel}
+                                                                                    value={range.timezone}
+                                                                                    onChange={(_e, value) => value && updateTimeRange(op, { timezone: value })}
+                                                                                    renderInput={(params) => <TextField {...params} label="Timezone" />}
+                                                                                    sx={{ minWidth: 200 }}
+                                                                                />
                                                                             </Stack>
-                                                                            <Autocomplete
-                                                                                size="small"
-                                                                                fullWidth
-                                                                                disableClearable
-                                                                                options={timezones.includes(range.timezone) ? timezones : [range.timezone, ...timezones]}
-                                                                                getOptionLabel={timezoneLabel}
-                                                                                value={range.timezone}
-                                                                                onChange={(_e, value) => value && updateTimeRange(op, { timezone: value })}
-                                                                                renderInput={(params) => <TextField {...params} label="Timezone" />}
-                                                                            />
                                                                             <Typography variant="caption" color="text.secondary">
                                                                                 Routing converts the current UTC time into this timezone. Start is included, end is excluded; overnight windows work.
                                                                             </Typography>

--- a/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
@@ -1,4 +1,5 @@
 import {
+    Autocomplete,
     Box,
     Button,
     Chip,
@@ -36,6 +37,7 @@ import {
     isValidTimeRange,
     parseTimeRange,
     serializeTimeRange,
+    timezoneLabel,
     timezoneOptions,
 } from './timeRange';
 
@@ -530,12 +532,16 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                                                                                 <TextField size="small" label="Start" type="time" value={range.start} onChange={(e) => updateTimeRange(op, { start: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
                                                                                 <TextField size="small" label="End" type="time" value={range.end} onChange={(e) => updateTimeRange(op, { end: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
                                                                             </Stack>
-                                                                            <FormControl size="small" fullWidth>
-                                                                                <InputLabel>Timezone</InputLabel>
-                                                                                <Select value={range.timezone} label="Timezone" onChange={(e) => updateTimeRange(op, { timezone: e.target.value })}>
-                                                                                    {timezones.map((timezone) => <MenuItem key={timezone} value={timezone}>{timezone}</MenuItem>)}
-                                                                                </Select>
-                                                                            </FormControl>
+                                                                            <Autocomplete
+                                                                                size="small"
+                                                                                fullWidth
+                                                                                disableClearable
+                                                                                options={timezones.includes(range.timezone) ? timezones : [range.timezone, ...timezones]}
+                                                                                getOptionLabel={timezoneLabel}
+                                                                                value={range.timezone}
+                                                                                onChange={(_e, value) => value && updateTimeRange(op, { timezone: value })}
+                                                                                renderInput={(params) => <TextField {...params} label="Timezone" />}
+                                                                            />
                                                                             <Typography variant="caption" color="text.secondary">
                                                                                 Routing converts the current UTC time into this timezone. Start is included, end is excluded; overnight windows work.
                                                                             </Typography>

--- a/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
@@ -529,8 +529,6 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                                                                                 </Select>
                                                                             </FormControl>
                                                                             <Stack direction="row" spacing={1}>
-                                                                                <TextField size="small" label="Start" type="time" value={range.start} onChange={(e) => updateTimeRange(op, { start: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
-                                                                                <TextField size="small" label="End" type="time" value={range.end} onChange={(e) => updateTimeRange(op, { end: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
                                                                                 <Autocomplete
                                                                                     size="small"
                                                                                     fullWidth
@@ -542,6 +540,8 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                                                                                     renderInput={(params) => <TextField {...params} label="Timezone" />}
                                                                                     sx={{ minWidth: 200 }}
                                                                                 />
+                                                                                <TextField size="small" label="Start" type="time" value={range.start} onChange={(e) => updateTimeRange(op, { start: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
+                                                                                <TextField size="small" label="End" type="time" value={range.end} onChange={(e) => updateTimeRange(op, { end: e.target.value })} InputLabelProps={{ shrink: true }} fullWidth />
                                                                             </Stack>
                                                                             <Typography variant="caption" color="text.secondary">
                                                                                 Routing converts the current UTC time into this timezone. Start is included, end is excluded; overnight windows work.

--- a/frontend/src/components/rule-card/timeRange.ts
+++ b/frontend/src/components/rule-card/timeRange.ts
@@ -46,11 +46,60 @@ export const isValidTimeRange = (value: TimeRangeValue | null): value is TimeRan
 export const formatTimeRange = (value: string): string | null => {
     const range = parseTimeRange(value);
     if (!range) return null;
-    return `${range.outside ? 'Outside' : 'During'} ${range.start}–${range.end} · ${range.timezone}`;
+    return `${range.outside ? 'Outside' : 'During'} ${range.start}–${range.end} · ${timezoneLabel(range.timezone)}`;
 };
 
-export const timezoneOptions = (): string[] => {
-    const supportedValuesOf = Intl.supportedValuesOf;
-    if (typeof supportedValuesOf !== 'function') return ['UTC'];
-    return ['UTC', ...supportedValuesOf('timeZone').filter((timezone) => timezone !== 'UTC')];
+// A curated set of common IANA zones — one representative city per UTC offset,
+// matching the convention used by most scheduling UIs (Google Calendar, GitHub
+// Actions cron, etc.) instead of the full ~400-entry IANA database.
+const COMMON_TIMEZONES: string[] = [
+    'UTC',
+    'Pacific/Midway',
+    'Pacific/Honolulu',
+    'America/Anchorage',
+    'America/Los_Angeles',
+    'America/Denver',
+    'America/Chicago',
+    'America/New_York',
+    'America/Sao_Paulo',
+    'Atlantic/Azores',
+    'Europe/London',
+    'Europe/Paris',
+    'Europe/Berlin',
+    'Europe/Athens',
+    'Europe/Moscow',
+    'Asia/Dubai',
+    'Asia/Karachi',
+    'Asia/Kolkata',
+    'Asia/Dhaka',
+    'Asia/Bangkok',
+    'Asia/Shanghai',
+    'Asia/Tokyo',
+    'Australia/Sydney',
+    'Pacific/Auckland',
+];
+
+const zoneCity = (timezone: string): string => timezone.split('/').pop()?.replace(/_/g, ' ') ?? timezone;
+
+const zoneOffsetMinutes = (timezone: string): number => {
+    try {
+        const parts = new Intl.DateTimeFormat('en-US', { timeZone: timezone, timeZoneName: 'longOffset' }).formatToParts(new Date());
+        const offset = parts.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT+0';
+        const match = /GMT([+-])(\d{1,2})(?::?(\d{2}))?/.exec(offset);
+        if (!match) return 0;
+        const sign = match[1] === '-' ? -1 : 1;
+        return sign * (Number(match[2]) * 60 + Number(match[3] ?? 0));
+    } catch {
+        return 0;
+    }
 };
+
+export const timezoneLabel = (timezone: string): string => {
+    const minutes = zoneOffsetMinutes(timezone);
+    const sign = minutes < 0 ? '-' : '+';
+    const abs = Math.abs(minutes);
+    const offset = `UTC${sign}${String(Math.floor(abs / 60)).padStart(2, '0')}:${String(abs % 60).padStart(2, '0')}`;
+    return timezone === 'UTC' ? offset : `${offset} ${zoneCity(timezone)}`;
+};
+
+export const timezoneOptions = (): string[] => COMMON_TIMEZONES.slice().sort((a, b) => zoneOffsetMinutes(a) - zoneOffsetMinutes(b));


### PR DESCRIPTION
## Summary
Replaces the exhaustive IANA timezone list with a curated set of ~24 common timezones (one representative city per UTC offset), matching the convention used by Google Calendar and GitHub Actions. Adds UTC offset labels to timezone display and switches the selector from a dropdown to an autocomplete field for better discoverability.

## Changes
- **Timezone list**: Replaced `Intl.supportedValuesOf('timeZone')` with a hand-curated `COMMON_TIMEZONES` array covering major UTC offsets
- **Timezone display**: Added `timezoneLabel()` function that formats timezones as `UTC±HH:MM CityName` (e.g., `UTC-05:00 New_York`), making offsets immediately visible
- **Timezone selector**: Changed from `Select` dropdown to `Autocomplete` component, allowing users to search/filter timezones while maintaining the curated list as defaults
- **UI layout**: Reorganized time range controls—moved "Apply" (during/outside) to its own row, timezone selector now sits alongside start/end time fields
- **Sorting**: Timezone options are now sorted by UTC offset for logical grouping

## Implementation Details
- `zoneOffsetMinutes()` uses `Intl.DateTimeFormat` with `timeZoneName: 'longOffset'` to dynamically calculate current UTC offsets (handles DST correctly)
- `zoneCity()` extracts the city name from IANA zone identifiers (e.g., `Asia/Tokyo` → `Tokyo`)
- Autocomplete includes fallback support: if a previously-saved timezone isn't in the common list, it's prepended to options
- All timezone operations remain backward-compatible with existing serialized values

This aligns with UX principles of showing concrete values (UTC offsets) instead of aliases, reducing cognitive load when selecting timezones across different regions.

https://claude.ai/code/session_01DhnK8meE8iCDHp9XJWWDyg