### PR TITLE
skill(ui-preview): drop in-process image compression; document as optional external step

### DIFF
--- a/.claude/skills/ui-preview/SKILL.md
+++ b/.claude/skills/ui-preview/SKILL.md
@@ -82,36 +82,27 @@ const { chromium } = createRequire('file://' + process.cwd() + '/')('playwright'
 
 Each script is self-documenting — see its file header for usage, outputs, and known issues.
 
-## Screenshot size policy
+## Shrinking screenshots (optional)
 
-Screenshots are product documentation artifacts, so keep visual quality high while
-avoiding oversized repo exports. All committed screenshot scripts must write images
-through `screenshotOptimized()` from `optimize-image.mjs` instead of calling
-`page.screenshot()` directly. The helper captures the PNG/JPEG, then replaces it
-only if a smaller optimized image is produced.
+Screenshots are captured with Playwright's plain `page.screenshot()` — the skill
+deliberately does **not** compress images internally, because optimizers depend on
+host tooling that is not guaranteed in the run environment. If a PNG is large and
+you want to trim it before committing, run any optimizer you have available on the
+captured file afterwards. None of these are required:
 
-Optimization is intentionally best-effort and non-blocking:
-- PNG: `pngquant --quality 80-95 --strip` when available, with an ImageMagick
-  lossless fallback/pass.
-- JPEG: ImageMagick `-strip -quality 82` when available.
-- If optimizers are absent or do not make the file smaller, the original capture
-  is kept.
+- `pngquant --quality 80-95 --strip --force --out foo.png foo.png` (lossy, smallest PNGs)
+- `oxipng -o 4 --strip safe foo.png` (lossless)
+- Node: `sharp(file).png({ quality: 80, palette: true }).toFile(out)`
+- Python: `Pillow` → `img.save(out, optimize=True)`
 
-For one-off scripts, import and use:
-
-```js
-import { screenshotOptimized } from '../.agents/skills/ui-preview/optimize-image.mjs';
-await screenshotOptimized(page, { path: '/tmp/page.png', fullPage: false });
-```
+Prefer keeping the original capture when quality matters more than size.
 
 ## After capturing
 
-1. Check the console for `optimized ...` lines; unexpectedly huge PNGs usually
-   mean the script bypassed `screenshotOptimized()`.
-2. `SendUserFile` the PNGs so the user can review them.
-3. For ad-hoc `screenshot.mjs`: delete it before committing — the stop hook will flag it.
-4. `docs/` is gitignored; force-add images: `git add -f docs/images/`.
-5. Free the port: `fuser -k 3000/tcp` or `pkill -f "vite --mode mock"`.
+1. `SendUserFile` the PNGs so the user can review them.
+2. For ad-hoc `screenshot.mjs`: delete it before committing — the stop hook will flag it.
+3. `docs/` is gitignored; force-add images: `git add -f docs/images/`.
+4. Free the port: `fuser -k 3000/tcp` or `pkill -f "vite --mode mock"`.
 
 ## Troubleshooting
 

--- a/.claude/skills/ui-preview/docs-screenshots.mjs
+++ b/.claude/skills/ui-preview/docs-screenshots.mjs
@@ -34,7 +34,6 @@
 // resolve from wherever the script is *run* from (i.e. frontend/).
 import { createRequire } from 'module';
 import path from 'path';
-import { screenshotOptimized } from './optimize-image.mjs';
 const { chromium } = createRequire('file://' + process.cwd() + '/')('playwright');
 
 const CHROME = '/tmp/chrome/chrome-linux64/chrome';
@@ -70,7 +69,7 @@ async function shoot(browser, route, filename, opts = {}) {
     try { await page.waitForSelector(waitFor, { timeout: 8000 }); } catch { /* ok */ }
     await page.waitForTimeout(settle);
     if (interact) await interact(page);
-    await screenshotOptimized(page, { path: path.join(OUTDIR, filename), fullPage: false });
+    await page.screenshot({ path: path.join(OUTDIR, filename), fullPage: false });
     console.log(`  ✓ [${VP.width}×${VP.height}] ${route} → ${filename}`);
     await page.close();
 }

--- a/.claude/skills/ui-preview/regression-credentials.mjs
+++ b/.claude/skills/ui-preview/regression-credentials.mjs
@@ -29,7 +29,6 @@ import { createRequire } from 'node:module';
 import { join } from 'node:path';
 const require = createRequire(join(process.cwd(), 'noop.js'));
 const { chromium } = require('playwright');
-import { screenshotOptimized } from './optimize-image.mjs';
 
 const CHROME_PATH = process.env.CHROME_PATH || '/tmp/chrome/chrome-linux64/chrome';
 const BASE = process.env.BASE_URL || 'http://localhost:3000';
@@ -97,7 +96,7 @@ const spinnerVisible = await page.evaluate(() => {
     const disabledNoText = submit.disabled && submit.innerText.trim() === '';
     return hasProgress || disabledNoText;
 });
-await screenshotOptimized(page, { path: '/tmp/regression-credentials.png' });
+await page.screenshot({ path: '/tmp/regression-credentials.png' });
 assert(spinnerVisible, 'submit button shows a spinner while the request is in flight');
 
 // Let the request settle (404 in mock) and the error toast appear.

--- a/.claude/skills/ui-preview/scenario-routing-graph.mjs
+++ b/.claude/skills/ui-preview/scenario-routing-graph.mjs
@@ -52,7 +52,6 @@
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { readFileSync } from 'fs';
-import { screenshotOptimized } from './optimize-image.mjs';
 const require = createRequire(join(process.cwd(), 'noop.js'));
 const { chromium } = require('playwright');
 
@@ -151,7 +150,7 @@ async function shoot(browser, mode) {
     // Allow extra time for the real API data to load and React to settle.
     await page.waitForTimeout(4000);
 
-    await screenshotOptimized(page, { path: `/tmp/scenario-routing-${mode}.png`, fullPage: true });
+    await page.screenshot({ path: `/tmp/scenario-routing-${mode}.png`, fullPage: true });
 
     // Tight crop of the smart-routing rule card (has both the model + "Add Smart Rule").
     const tagged = await page.evaluate(() => {
@@ -166,7 +165,7 @@ async function shoot(browser, mode) {
         return true;
     });
     if (tagged) {
-        await screenshotOptimized(page.locator('#__smartcard'), { path: `/tmp/scenario-routing-smart-${mode}.png` });
+        await page.locator('#__smartcard').screenshot({ path: `/tmp/scenario-routing-smart-${mode}.png` });
     } else {
         console.log(`[${mode}] smart card not found (is data seeded + separate mode active?)`);
     }

--- a/.claude/skills/ui-preview/screenshot.mjs
+++ b/.claude/skills/ui-preview/screenshot.mjs
@@ -11,7 +11,6 @@
 // Outputs go to /tmp/<name>.png. Use SendUserFile to surface them.
 
 import { chromium } from 'playwright';
-import { screenshotOptimized } from './optimize-image.mjs';
 
 const CHROME_PATH = '/tmp/chrome/chrome-linux64/chrome';
 const BASE = 'http://localhost:3000';
@@ -49,10 +48,10 @@ const bodyText = await page.evaluate(() => document.body.innerText.slice(0, 500)
 console.log('--- body text ---\n' + bodyText + '\n---');
 
 // Full viewport
-await screenshotOptimized(page, { path: '/tmp/page-full.png', fullPage: false });
+await page.screenshot({ path: '/tmp/page-full.png', fullPage: false });
 
 // Cropped: activity bar + secondary sidebar (top-left region)
-await screenshotOptimized(page, {
+await page.screenshot({
     path: '/tmp/page-sidebar.png',
     clip: { x: 0, y: 0, width: 420, height: 280 },
 });
@@ -63,7 +62,7 @@ try {
     const btn = page.getByRole('button', { name: /Zen Mode|禅模式/i }).first();
     await btn.click({ timeout: 5000 });
     await page.waitForTimeout(500);
-    await screenshotOptimized(page, {
+    await page.screenshot({
         path: '/tmp/page-menu.png',
         clip: { x: 0, y: 0, width: 600, height: 400 },
     });


### PR DESCRIPTION
## What

Reverts the in-process image compression that `85c0cb8fd` (#1355) baked into the Playwright screenshot helper, and instead documents compression as an optional post-capture step.

## Why

`optimize-image.mjs` coupled the screenshot capture toolchain to host-installed `pngquant` / ImageMagick, which is not guaranteed in the run environment (the skill explicitly targets a restricted container). The screenshot helper's job is to capture —
compression is an environment-dependent concern that belongs as a documented, opt-in external step, not as a hard dependency inside `screenshotOptimized()`.

## Changes

- **Removed** `optimize-image.mjs` (was untracked, never committed — deleted from disk).
- **`screenshot.mjs` / `docs-screenshots.mjs` / `regression-credentials.mjs` / `scenario-routing-graph.mjs`**: revert all `screenshotOptimized(x, opts)` calls back to plain `x.screenshot(opts)`; drop the import.
- **`SKILL.md`**: replace the mandatory "Screenshot size policy" section with a "Shrinking screenshots (optional)" section listing `pngquant` / `oxipng` / `sharp` / `Pillow` as available external optimizers, and restore the clean "After capturing" checklist.

## Verification

- `grep` confirms no `screenshotOptimized` / `optimize-image` / `optimizeImage` references remain.
- All 4 `.mjs` scripts pass `node --check`.