### PR TITLE
refactor(oauth): Refactor OAuth token request handling and metadata management

### DIFF
--- a/ai/oauth/config.go
+++ b/ai/oauth/config.go
@@ -27,8 +27,6 @@ func ParseProviderType(i ai.Issuer) (ai.Issuer, error) {
 	}
 }
 
-// String returns the string representation of ai.Issuer
-
 // Config holds the OAuth configuration
 type Config struct {
 	// BaseURL is the base URL of this server for callback generation
@@ -357,6 +355,41 @@ func (t *Token) ExpiredIn(within time.Duration) bool {
 	return time.Now().Add(within).After(t.Expiry)
 }
 
+// setExpiryFromExpiresIn derives the absolute Expiry from the ExpiresIn seconds
+// field returned by the provider. A non-positive ExpiresIn leaves Expiry unset
+// (treated as "no expiry").
+func (t *Token) setExpiryFromExpiresIn() {
+	if t.ExpiresIn > 0 {
+		t.Expiry = time.Now().Add(time.Duration(t.ExpiresIn) * time.Second)
+	}
+}
+
+// putMetadata stores a non-empty value under key, allocating the metadata map
+// on demand. Empty values are ignored so callers can pass optional fields
+// unconditionally.
+func (t *Token) putMetadata(key, value string) {
+	if value == "" {
+		return
+	}
+	if t.Metadata == nil {
+		t.Metadata = make(map[string]any)
+	}
+	t.Metadata[key] = value
+}
+
+// mergeMetadata merges src into the token metadata, allocating on demand.
+func (t *Token) mergeMetadata(src map[string]any) {
+	if len(src) == 0 {
+		return
+	}
+	if t.Metadata == nil {
+		t.Metadata = make(map[string]any)
+	}
+	for k, v := range src {
+		t.Metadata[k] = v
+	}
+}
+
 // DeviceCodeResponse represents the response from the device authorization endpoint
 // RFC 8628: OAuth 2.0 Device Authorization Grant
 type DeviceCodeResponse struct {
@@ -390,19 +423,4 @@ type DeviceCodeData struct {
 	ExpiresAt    time.Time
 	InitiatedAt  time.Time
 	CodeVerifier string // PKCE code verifier (for Device Code PKCE flow)
-}
-
-// DeviceTokenRequest represents the request to poll for token with device code
-type DeviceTokenRequest struct {
-	// GrantType is the grant type, must be "urn:ietf:params:oauth:grant-type:device_code"
-	GrantType string `json:"grant_type"`
-
-	// DeviceCode is the device code from the device authorization response
-	DeviceCode string `json:"device_code"`
-
-	// ClientID is the OAuth client ID
-	ClientID string `json:"client_id"`
-
-	// ClientSecret is the OAuth client secret (optional for public clients)
-	ClientSecret string `json:"client_secret,omitempty"`
 }

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -443,6 +443,20 @@ func (m *Manager) sendTokenRequest(ctx context.Context, config *ProviderConfig, 
 	return client.Do(req)
 }
 
+// populateAnthropicMetadata extracts organization / account identity from an
+// Anthropic (Claude) token response body into the token metadata. A response
+// body that does not decode is ignored — the token itself is still usable.
+func populateAnthropicMetadata(token *Token, rawBody []byte) {
+	var resp AnthropicTokenResponse
+	if json.Unmarshal(rawBody, &resp) != nil {
+		return
+	}
+	token.putMetadata("organization_id", resp.Organization.UUID)
+	token.putMetadata("organization_name", resp.Organization.Name)
+	token.putMetadata("account_id", resp.Account.UUID)
+	token.putMetadata("email", resp.Account.EmailAddress)
+}
+
 // populateCodexMetadata extracts email / account_id / name from a Codex ID
 // token (JWT) into the token metadata. Returns false if there is no ID token or
 // it could not be parsed.
@@ -593,14 +607,7 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 	switch config.Type {
 	case ai.IssuerClaudeCode, ai.IssuerAnthropic:
 		// Anthropic/Claude return organization/account info in the token response.
-		// Use the pre-defined types from hook.go for consistency.
-		var anthropicResp AnthropicTokenResponse
-		if json.Unmarshal(rawBody, &anthropicResp) == nil {
-			token.putMetadata("organization_id", anthropicResp.Organization.UUID)
-			token.putMetadata("organization_name", anthropicResp.Organization.Name)
-			token.putMetadata("account_id", anthropicResp.Account.UUID)
-			token.putMetadata("email", anthropicResp.Account.EmailAddress)
-		}
+		populateAnthropicMetadata(token, rawBody)
 	case ai.IssuerCodex:
 		// Codex carries user info in the ID token (JWT).
 		if token.IDToken != "" {

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -195,11 +195,6 @@ func (m *Manager) generateCodeChallenge(verifier string) string {
 	return challenge
 }
 
-// generateStateKey generates a key for storing state data
-func (m *Manager) stateKey(state string) string {
-	return state
-}
-
 // saveState saves state data with expiration
 func (m *Manager) saveState(data *StateData) error {
 	// Set expiration time based on config
@@ -396,6 +391,75 @@ func (m *Manager) getHTTPClient(opts *Options) *http.Client {
 	return m.config.GetHTTPClient()
 }
 
+// buildTokenRequest constructs a POST request to endpoint carrying params in the
+// provider's configured body format. It sets the default Content-Type/Accept
+// headers, runs the provider hook (which may mutate params and headers),
+// rebuilds the body if the hook changed params, and merges per-flow extra
+// headers. This is the single construction path shared by token exchange,
+// refresh, device-code initiation, and device-code polling.
+func (m *Manager) buildTokenRequest(ctx context.Context, config *ProviderConfig, endpoint string, params map[string]string, opts *Options) (*http.Request, error) {
+	reqBody, contentType, err := buildRequestBody(params, config.TokenRequestFormat)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+
+	// Call provider's token hook if present. It may mutate params and headers.
+	if config.Hook != nil {
+		if err := config.Hook.BeforeToken(params, req.Header); err != nil {
+			return nil, err
+		}
+		// Rebuild the body in case the hook mutated params.
+		reqBody, _, err = buildRequestBody(params, config.TokenRequestFormat)
+		if err != nil {
+			return nil, fmt.Errorf("failed to rebuild request body: %w", err)
+		}
+		req.Body = io.NopCloser(reqBody)
+	}
+
+	applyExtraHeaders(req.Header, opts.ExtraHeaders)
+	return req, nil
+}
+
+// sendTokenRequest builds and sends a token request, applying the debug hook and
+// the per-request timeout. Callers own response reading and status handling
+// because their success/error decoding differs.
+func (m *Manager) sendTokenRequest(ctx context.Context, config *ProviderConfig, endpoint string, params map[string]string, timeout time.Duration, opts *Options) (*http.Response, error) {
+	req, err := m.buildTokenRequest(ctx, config, endpoint, params, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	m.debugRequest(req, config.TokenRequestFormat)
+
+	client := m.getHTTPClient(opts)
+	client.Timeout = timeout
+	return client.Do(req)
+}
+
+// populateCodexMetadata extracts email / account_id / name from a Codex ID
+// token (JWT) into the token metadata. Returns false if there is no ID token or
+// it could not be parsed.
+func populateCodexMetadata(token *Token) bool {
+	if token.IDToken == "" {
+		return false
+	}
+	claims := parseIDToken(token.IDToken)
+	if claims == nil {
+		return false
+	}
+	token.putMetadata("email", claims.Email)
+	token.putMetadata("account_id", claims.GetAccountID())
+	token.putMetadata("name", claims.Name)
+	return true
+}
+
 // HandleCallback handles the OAuth callback request
 func (m *Manager) HandleCallback(ctx context.Context, r *http.Request, opts ...Option) (*Token, error) {
 	options := applyOptions(opts...)
@@ -491,40 +555,9 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 		"has_client_secret":    config.ClientSecret != "",
 		"token_url":            config.TokenURL,
 		"request_format":       map[TokenRequestFormat]string{TokenRequestFormatJSON: "JSON", TokenRequestFormatForm: "Form"}[config.TokenRequestFormat],
-	}).Info("[OAuth] PKCE code_verifier added to token request")
+	}).Info("[OAuth] Exchanging authorization code for token")
 
-	reqBody, contentType, err := buildRequestBody(params, config.TokenRequestFormat)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build request body: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", config.TokenURL, reqBody)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Accept", "application/json")
-
-	// Call provider's token hook if present
-	if config.Hook != nil {
-		if err := config.Hook.BeforeToken(params, req.Header); err != nil {
-			return nil, err
-		}
-		req.Body = io.NopCloser(reqBody)
-	}
-
-	applyExtraHeaders(req.Header, opts.ExtraHeaders)
-
-	// Debug: print request details
-	m.debugRequest(req, config.TokenRequestFormat)
-
-	// Send request with optional proxy support
-	// Uses OAUTH_PROXY_URL, HTTP_PROXY, or HTTPS_PROXY environment variables
-	client := m.getHTTPClient(opts)
-	client.Timeout = 60 * time.Second
-
-	resp, err := client.Do(req)
+	resp, err := m.sendTokenRequest(ctx, config, config.TokenURL, params, 60*time.Second, opts)
 	if err != nil {
 		return nil, fmt.Errorf("client error: %w: %v", ErrTokenExchangeFailed, err)
 	}
@@ -554,86 +587,52 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 	}
 
 	// Convert ExpiresIn to Expiry
-	if token.ExpiresIn > 0 {
-		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
-	}
+	token.setExpiryFromExpiresIn()
 
 	// For Anthropic/Claude providers, extract organization info from token response
 	// Use the pre-defined types from hook.go for consistency
 	if config.Type == ai.IssuerClaudeCode || config.Type == ai.IssuerAnthropic {
 		var anthropicResp AnthropicTokenResponse
 		if json.Unmarshal(rawBody, &anthropicResp) == nil {
-			// Extract metadata from token response
-			if token.Metadata == nil {
-				token.Metadata = make(map[string]any)
-			}
-			if anthropicResp.Organization.UUID != "" {
-				token.Metadata["organization_id"] = anthropicResp.Organization.UUID
-			}
-			if anthropicResp.Organization.Name != "" {
-				token.Metadata["organization_name"] = anthropicResp.Organization.Name
-			}
-			if anthropicResp.Account.UUID != "" {
-				token.Metadata["account_id"] = anthropicResp.Account.UUID
-			}
-			if anthropicResp.Account.EmailAddress != "" {
-				token.Metadata["email"] = anthropicResp.Account.EmailAddress
-			}
+			token.putMetadata("organization_id", anthropicResp.Organization.UUID)
+			token.putMetadata("organization_name", anthropicResp.Organization.Name)
+			token.putMetadata("account_id", anthropicResp.Account.UUID)
+			token.putMetadata("email", anthropicResp.Account.EmailAddress)
 		}
 	}
 
 	// For Codex provider, parse ID token to extract user info
-	if config.Type == ai.IssuerCodex && token.IDToken != "" {
-		if claims := parseIDToken(token.IDToken); claims != nil {
-			if token.Metadata == nil {
-				token.Metadata = make(map[string]any)
-			}
-			if claims.Email != "" {
-				token.Metadata["email"] = claims.Email
-			}
-			if accountID := claims.GetAccountID(); accountID != "" {
-				token.Metadata["account_id"] = accountID
-			}
-			if claims.Name != "" {
-				token.Metadata["name"] = claims.Name
+	if config.Type == ai.IssuerCodex {
+		if token.IDToken != "" {
+			if !populateCodexMetadata(token) {
+				logrus.Warnf("[OAuth] Failed to parse ID token for Codex provider")
 			}
 		} else {
-			logrus.Warnf("[OAuth] Failed to parse ID token for Codex provider")
-		}
-	} else if config.Type == ai.IssuerCodex {
-		// Log only the key set so we can tell whether OpenAI omitted id_token
-		// or returned it under a different key — never the values, which
-		// contain access_token / refresh_token.
-		var raw map[string]json.RawMessage
-		if jsonErr := json.Unmarshal(rawBody, &raw); jsonErr == nil {
-			keys := make([]string, 0, len(raw))
-			for k := range raw {
-				keys = append(keys, k)
+			// Log only the key set so we can tell whether OpenAI omitted id_token
+			// or returned it under a different key — never the values, which
+			// contain access_token / refresh_token.
+			var raw map[string]json.RawMessage
+			if jsonErr := json.Unmarshal(rawBody, &raw); jsonErr == nil {
+				keys := make([]string, 0, len(raw))
+				for k := range raw {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response field names: %v", keys)
+			} else {
+				logrus.Warnf("[OAuth] Codex token exchange returned no id_token; could not inspect response: %v", jsonErr)
 			}
-			sort.Strings(keys)
-			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; response field names: %v", keys)
-		} else {
-			logrus.Warnf("[OAuth] Codex token exchange returned no id_token; could not inspect response: %v", jsonErr)
 		}
 	}
 
 	// Call provider's after-token hook to fetch additional metadata
 	if config.Hook != nil && token.AccessToken != "" {
-		metadata, err := config.Hook.AfterToken(ctx, token.AccessToken, client)
+		metadata, err := config.Hook.AfterToken(ctx, token.AccessToken, m.getHTTPClient(opts))
 		if err != nil {
-			fmt.Printf("[OAuth] AfterToken hook failed: %v\n", err)
+			logrus.Warnf("[OAuth] AfterToken hook failed: %v", err)
 			// Continue even if AfterToken fails, as we already have the token
 		}
-		if metadata != nil {
-			if token.Metadata == nil {
-				token.Metadata = metadata
-			} else {
-				// Merge metadata
-				for k, v := range metadata {
-					token.Metadata[k] = v
-				}
-			}
-		}
+		token.mergeMetadata(metadata)
 	}
 
 	return token, nil
@@ -692,46 +691,7 @@ func (m *Manager) refreshToken(ctx context.Context, providerType ai.Issuer, refr
 		params["client_secret"] = config.ClientSecret
 	}
 
-	// Build request body first
-	reqBody, contentType, err := buildRequestBody(params, config.TokenRequestFormat)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build request body: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", config.TokenURL, reqBody)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Accept", "application/json")
-
-	// Call provider's token hook if present (may modify params and headers)
-	if config.Hook != nil {
-		if err := config.Hook.BeforeToken(params, req.Header); err != nil {
-			return nil, err
-		}
-		// Rebuild body in case hook modified params
-		reqBody, contentType, err = buildRequestBody(params, config.TokenRequestFormat)
-		if err != nil {
-			return nil, fmt.Errorf("failed to rebuild request body: %w", err)
-		}
-		req.Body = io.NopCloser(reqBody)
-	}
-
-	// Set Content-Type after hook (hook may have modified it)
-	req.Header.Set("Content-Type", contentType)
-
-	applyExtraHeaders(req.Header, opts.ExtraHeaders)
-
-	// Debug: print request details
-	m.debugRequest(req, config.TokenRequestFormat)
-
-	// Send request with optional proxy support
-	// Uses OAUTH_PROXY_URL, HTTP_PROXY, or HTTPS_PROXY environment variables
-	client := m.getHTTPClient(opts)
-	client.Timeout = 30 * time.Second
-
-	resp, err := client.Do(req)
+	resp, err := m.sendTokenRequest(ctx, config, config.TokenURL, params, 30*time.Second, opts)
 	if err != nil {
 		return nil, fmt.Errorf("refresh token: %w: %v", ErrTokenExchangeFailed, err)
 	}
@@ -749,26 +709,11 @@ func (m *Manager) refreshToken(ctx context.Context, providerType ai.Issuer, refr
 	}
 
 	// Convert ExpiresIn to Expiry
-	if token.ExpiresIn > 0 {
-		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
-	}
+	token.setExpiryFromExpiresIn()
 
 	// For Codex provider, parse ID token to extract user info
-	if providerType == ai.IssuerCodex && token.IDToken != "" {
-		if claims := parseIDToken(token.IDToken); claims != nil {
-			if token.Metadata == nil {
-				token.Metadata = make(map[string]any)
-			}
-			if claims.Email != "" {
-				token.Metadata["email"] = claims.Email
-			}
-			if accountID := claims.GetAccountID(); accountID != "" {
-				token.Metadata["account_id"] = accountID
-			}
-			if claims.Name != "" {
-				token.Metadata["name"] = claims.Name
-			}
-		}
+	if providerType == ai.IssuerCodex {
+		populateCodexMetadata(token)
 	}
 
 	return token, nil
@@ -885,38 +830,7 @@ func (m *Manager) InitiateDeviceCodeFlow(ctx context.Context, userID string, pro
 		params["code_challenge_method"] = "S256"
 	}
 
-	reqBody, contentType, err := buildRequestBody(params, config.TokenRequestFormat)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build request body: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", config.DeviceCodeURL, reqBody)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Accept", "application/json")
-
-	// Call provider's token hook if present
-	if config.Hook != nil {
-		if err := config.Hook.BeforeToken(params, req.Header); err != nil {
-			return nil, err
-		}
-		// Rebuild body in case hook modified params
-		reqBody, contentType, err = buildRequestBody(params, config.TokenRequestFormat)
-		if err != nil {
-			return nil, fmt.Errorf("failed to rebuild request body: %w", err)
-		}
-		req.Body = io.NopCloser(reqBody)
-		req.Header.Set("Content-Type", contentType)
-	}
-
-	applyExtraHeaders(req.Header, options.ExtraHeaders)
-
-	client := m.getHTTPClient(options)
-	client.Timeout = 30 * time.Second
-	resp, err := client.Do(req)
+	resp, err := m.sendTokenRequest(ctx, config, config.DeviceCodeURL, params, 30*time.Second, options)
 	if err != nil {
 		return nil, fmt.Errorf("device code request failed: %w", err)
 	}
@@ -1045,36 +959,7 @@ func (m *Manager) pollTokenRequest(ctx context.Context, config *ProviderConfig, 
 		params["code_verifier"] = codeVerifier
 	}
 
-	reqBody, contentType, err := buildRequestBody(params, config.TokenRequestFormat)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build request body: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", config.TokenURL, reqBody)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Accept", "application/json")
-
-	// Call provider's token hook if present
-	if config.Hook != nil {
-		if err := config.Hook.BeforeToken(params, req.Header); err != nil {
-			return nil, err
-		}
-		reqBody, _, err = buildRequestBody(params, config.TokenRequestFormat)
-		if err != nil {
-			return nil, fmt.Errorf("failed to rebuild request body: %w", err)
-		}
-		req.Body = io.NopCloser(reqBody)
-	}
-
-	applyExtraHeaders(req.Header, opts.ExtraHeaders)
-
-	client := m.getHTTPClient(opts)
-	client.Timeout = 30 * time.Second
-	resp, err := client.Do(req)
+	resp, err := m.sendTokenRequest(ctx, config, config.TokenURL, params, 30*time.Second, opts)
 	if err != nil {
 		return nil, fmt.Errorf("token poll request failed: %w", err)
 	}
@@ -1115,9 +1000,7 @@ func (m *Manager) pollTokenRequest(ctx context.Context, config *ProviderConfig, 
 	}
 
 	// Convert ExpiresIn to Expiry
-	if token.ExpiresIn > 0 {
-		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
-	}
+	token.setExpiryFromExpiresIn()
 
 	return token, nil
 }

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -589,9 +589,11 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 	// Convert ExpiresIn to Expiry
 	token.setExpiryFromExpiresIn()
 
-	// For Anthropic/Claude providers, extract organization info from token response
-	// Use the pre-defined types from hook.go for consistency
-	if config.Type == ai.IssuerClaudeCode || config.Type == ai.IssuerAnthropic {
+	// Extract provider-specific identity metadata from the token response.
+	switch config.Type {
+	case ai.IssuerClaudeCode, ai.IssuerAnthropic:
+		// Anthropic/Claude return organization/account info in the token response.
+		// Use the pre-defined types from hook.go for consistency.
 		var anthropicResp AnthropicTokenResponse
 		if json.Unmarshal(rawBody, &anthropicResp) == nil {
 			token.putMetadata("organization_id", anthropicResp.Organization.UUID)
@@ -599,10 +601,8 @@ func (m *Manager) exchangeCodeForToken(ctx context.Context, config *ProviderConf
 			token.putMetadata("account_id", anthropicResp.Account.UUID)
 			token.putMetadata("email", anthropicResp.Account.EmailAddress)
 		}
-	}
-
-	// For Codex provider, parse ID token to extract user info
-	if config.Type == ai.IssuerCodex {
+	case ai.IssuerCodex:
+		// Codex carries user info in the ID token (JWT).
 		if token.IDToken != "" {
 			if !populateCodexMetadata(token) {
 				logrus.Warnf("[OAuth] Failed to parse ID token for Codex provider")

--- a/ai/oauth/statestore.go
+++ b/ai/oauth/statestore.go
@@ -91,11 +91,6 @@ func (s *MemoryStateStorage) CleanupExpired() error {
 	return nil
 }
 
-// stateKey generates a key for storing state data (for compatibility with existing code)
-func (s *MemoryStateStorage) stateKey(state string) string {
-	return state
-}
-
 // Count returns the number of states currently stored (for testing)
 func (s *MemoryStateStorage) Count() int {
 	s.mu.RLock()

--- a/ai/oauth/store.go
+++ b/ai/oauth/store.go
@@ -120,26 +120,3 @@ func (s *MemoryTokenStorage) ListProviders(userID string) ([]ai.Issuer, error) {
 
 	return providers, nil
 }
-
-// TokenWithMetadata represents a token with additional metadata
-type TokenWithMetadata struct {
-	Token     *Token
-	UserID    string
-	Provider  ai.Issuer
-	CreatedAt time.Time
-	UpdatedAt time.Time
-}
-
-// MetadataTokenStorage extends TokenStorage with metadata support
-type MetadataTokenStorage interface {
-	TokenStorage
-
-	// SaveTokenWithMetadata saves a token with additional metadata
-	SaveTokenWithMetadata(userID string, provider ai.Issuer, token *Token, metadata map[string]string) error
-
-	// GetTokenWithMetadata retrieves a token with metadata
-	GetTokenWithMetadata(userID string, provider ai.Issuer) (*TokenWithMetadata, error)
-
-	// ListAllTokens returns all tokens with their metadata
-	ListAllTokens() ([]*TokenWithMetadata, error)
-}


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup of the `ai/oauth` package. Consolidates the token-request lifecycle that was open-coded across four flows (code exchange, refresh, device-code initiation, polling) into shared helpers, extracts per-provider metadata handling into dedicated helpers, and removes verified-dead code. Net ~120 fewer lines; no functional change.

## Key Changes

- **New request helpers on `Manager`:**
  - `buildTokenRequest()` — builds the POST request: encode body → set Content-Type/Accept → run provider hook (rebuilding the body if the hook mutated params) → merge per-flow extra headers
  - `sendTokenRequest()` — builds, debug-logs, and sends with a per-request timeout (callers keep their own response decoding, since success/error shapes differ)

- **New metadata helpers:**
  - `populateAnthropicMetadata(token, rawBody)` — organization/account identity from the Anthropic token response
  - `populateCodexMetadata(token)` — email/account_id/name from the Codex ID token (JWT)

- **New `Token` methods:**
  - `setExpiryFromExpiresIn()` — derive absolute `Expiry` from `ExpiresIn` seconds
  - `putMetadata()` — store a non-empty value, allocating the map lazily
  - `mergeMetadata()` — merge a metadata map, allocating lazily

- **Refactored flows** (each dropped ~35–40 lines of duplicated construction):
  - `exchangeCodeForToken()`, `refreshToken()`, `InitiateDeviceCodeFlow()`, `pollTokenRequest()` now call `sendTokenRequest()`
  - Provider metadata dispatch in `exchangeCodeForToken()` folded into a single `switch config.Type` (Anthropic/Claude vs Codex) — the two branches are mutually exclusive, so a switch makes that explicit; each branch is one named `populate…Metadata` call

- **Removed (verified unused repo-wide):**
  - `Manager.stateKey()` and `MemoryStateStorage.stateKey()`
  - `DeviceTokenRequest` struct
  - `TokenWithMetadata` struct + `MetadataTokenStorage` interface
  - A stray orphan comment in `config.go`

- **Logging:**
  - `fmt.Printf` → `logrus.Warnf` for the AfterToken hook failure
  - Corrected the always-logged, misleading `"PKCE code_verifier added to token request"` message to `"Exchanging authorization code for token"`

## Consistency notes

The unification is byte-identical on the wire for every registered provider:
- The `Content-Type` precedence in the shared path lets the hook override the encoded default; the only two `BeforeToken` hooks that set `Content-Type` (Anthropic→JSON, Codex→Form) set exactly the value `buildRequestBody` produces for their format.
- No hook mutates body params in `BeforeToken`, and form/JSON encoding sorts map keys deterministically, so rebuilding the body after the hook yields identical bytes.

## Testing

- `go test ./ai/oauth/...` — pass
- Consumers `internal/server/module/oauth` and `internal/server/module/tokenrefresh` — build + tests pass
- `go vet` / `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJ5KEG3LtethqdybnJ6T7B