### PR TITLE
refactor(UI): System pages UX review: card boundaries, naming, inline descriptions

### DIFF
--- a/frontend/src/components/GlobalExperimentalFeatures.tsx
+++ b/frontend/src/components/GlobalExperimentalFeatures.tsx
@@ -1,6 +1,6 @@
 import {useFeatureFlags} from '@/contexts/FeatureFlagsContext';
 import { Psychology as IconBrain, Shield as IconShield, SettingsApplications } from '@/components/icons';
-import {Alert, Box, Chip, Tooltip, Typography,} from '@mui/material';
+import {Alert, Box, Chip, Typography,} from '@mui/material';
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {api} from '../services/api';
@@ -123,63 +123,56 @@ const GlobalExperimentalFeatures: React.FC = () => {
         },
     });
 
+    // One row per feature: name + always-visible description, with a plain
+    // On/Off chip on the right. The description used to live only in a hover
+    // tooltip (and the chip repeated the feature name).
+    const featureRow = (
+        icon: React.ReactNode,
+        name: string,
+        description: string,
+        enabled: boolean,
+        onToggle: () => void,
+    ) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', py: 2, gap: 3 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 180 }}>
+                {icon}
+                <Typography variant="subtitle2">{name}</Typography>
+            </Box>
+            <Typography variant="body2" sx={{ color: 'text.secondary', flex: 1 }}>
+                {description}
+            </Typography>
+            <Chip
+                label={enabled ? t('common.on') : t('common.off')}
+                onClick={onToggle}
+                size="small"
+                sx={{ ...chipStyle(enabled), minWidth: 52 }}
+            />
+        </Box>
+    );
+
     return (
         <Box sx={{display: 'flex', flexDirection: 'column', gap: 0}}>
             {/* Skill Features - Only in full edition */}
-            {isFullEdition && (
-                <Box sx={{display: 'flex', alignItems: 'center', py: 2, gap: 3}}>
-                    {/* Label */}
-                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1, minWidth: 180}}>
-                        <IconBrain sx={{ fontSize: 16, color: 'text.secondary' }} />
-                        <Typography variant="subtitle2" sx={{color: 'text.secondary'}}>
-                            {t('system.experimentalFeatures.skills')}
-                        </Typography>
-                        <Tooltip title={t('system.experimentalFeatures.enableIdeSkills')} arrow>
-                            <Box/>
-                        </Tooltip>
-                    </Box>
-
-                    {/* Skill feature toggles as clickable chips */}
-                    <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flex: 1}}>
-                        {SKILL_FEATURES.map((feature) => {
-                            const isEnabled = features[feature.key] || false;
-                            return (
-                                <Tooltip key={feature.key}
-                                         title={t(feature.descriptionKey) + (isEnabled ? ` (${t('system.experimentalFeatures.enabled')})` : ` (${t('system.experimentalFeatures.disabled')})`)}
-                                         arrow>
-                                    <Chip
-                                        label={`${t(feature.labelKey)} · ${isEnabled ? t('common.on') : t('common.off')}`}
-                                        onClick={() => toggleFeature(feature.key)}
-                                        size="small"
-                                        sx={chipStyle(isEnabled)}
-                                    />
-                                </Tooltip>
-                            );
-                        })}
-                    </Box>
-                </Box>)
-            }
+            {isFullEdition && SKILL_FEATURES.map((feature) =>
+                <React.Fragment key={feature.key}>
+                    {featureRow(
+                        <IconBrain sx={{ fontSize: 16, color: 'text.secondary' }} />,
+                        t(feature.labelKey),
+                        t(feature.descriptionKey),
+                        features[feature.key] || false,
+                        () => toggleFeature(feature.key),
+                    )}
+                </React.Fragment>
+            )}
 
             {/* Guardrails Section */}
-            <Box sx={{ display: 'flex', alignItems: 'center', py: 2, gap: 3 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 180 }}>
-                    <IconShield sx={{ fontSize: 16, color: 'text.secondary' }} />
-                    <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
-                        {t('system.experimentalFeatures.guardrails')}
-                    </Typography>
-                </Box>
-
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                    <Tooltip title={t('system.experimentalFeatures.enableGuardrails') + (guardrailsEnabled ? ` (${t('system.experimentalFeatures.enabled')})` : ` (${t('system.experimentalFeatures.disabled')})`)} arrow>
-                        <Chip
-                            label={`${t('system.experimentalFeatures.guardrails')} · ${guardrailsEnabled ? t('common.on') : t('common.off')}`}
-                            onClick={toggleGuardrails}
-                            size="small"
-                            sx={chipStyle(guardrailsEnabled)}
-                        />
-                    </Tooltip>
-                </Box>
-            </Box>
+            {featureRow(
+                <IconShield sx={{ fontSize: 16, color: 'text.secondary' }} />,
+                t('system.experimentalFeatures.guardrails'),
+                t('system.experimentalFeatures.enableGuardrails'),
+                guardrailsEnabled,
+                toggleGuardrails,
+            )}
 
             {guardrailsEnabled && (
                 <Alert severity="info" sx={{ mt: 1 }}>
@@ -190,25 +183,13 @@ const GlobalExperimentalFeatures: React.FC = () => {
             )}
 
             {/* MCP Section */}
-            <Box sx={{ display: 'flex', alignItems: 'center', py: 2, gap: 3 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 180 }}>
-                    <SettingsApplications sx={{ fontSize: '1rem', color: 'text.secondary' }} />
-                    <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
-                        {t('system.experimentalFeatures.mcp')}
-                    </Typography>
-                </Box>
-
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                    <Tooltip title={t('system.experimentalFeatures.enableMCP') + (mcpEnabled ? ` (${t('system.experimentalFeatures.enabled')})` : ` (${t('system.experimentalFeatures.disabled')})`)} arrow>
-                        <Chip
-                            label={`${t('system.experimentalFeatures.mcp')} Tools · ${mcpEnabled ? t('common.on') : t('common.off')}`}
-                            onClick={toggleMCP}
-                            size="small"
-                            sx={{ ...chipStyle(mcpEnabled), cursor: 'pointer', pointerEvents: 'auto' }}
-                        />
-                    </Tooltip>
-                </Box>
-            </Box>
+            {featureRow(
+                <SettingsApplications sx={{ fontSize: '1rem', color: 'text.secondary' }} />,
+                `${t('system.experimentalFeatures.mcp')} Tools`,
+                t('system.experimentalFeatures.enableMCP'),
+                mcpEnabled,
+                toggleMCP,
+            )}
 
             {mcpEnabled && (
                 <Alert severity="info" sx={{ mt: 1 }}>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -116,7 +116,7 @@ export default {
     "system": "System",
     "general": "General",
     "experimental": "Experimental",
-    "logs": "Troubleshoot",
+    "logs": "Logs",
     "userRequest": "User Request",
     "skills": "Skills",
     "addProfile": "Add Profile",
@@ -737,9 +737,9 @@ export default {
       "skills": "Skills",
       "guardrails": "Guardrails",
       "mcp": "MCP",
-      "enableIdeSkills": "Enable IDE Skills feature for managing code snippets and skills from IDEs",
-      "enableGuardrails": "Enable Guardrails - block risky tool calls and filter sensitive outputs",
-      "enableMCP": "Enable MCP Tools - Configure MCP (Model Context Protocol) tools like web search and web fetch",
+      "enableIdeSkills": "Manage code snippets and skills from your IDE",
+      "enableGuardrails": "Block risky tool calls and filter sensitive outputs",
+      "enableMCP": "MCP (Model Context Protocol) tools such as web search and web fetch",
       "on": "On",
       "off": "Off",
       "enabled": "enabled",
@@ -760,6 +760,9 @@ export default {
       "server": "Server",
       "forceLogout": "Force logout",
       "refreshStatus": "Refresh status"
+    },
+    "preferences": {
+      "title": "Appearance & Language"
     }
   },
   "serverInfo": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -117,7 +117,7 @@ export default {
     "system": "系统",
     "general": "通用",
     "experimental": "实验功能",
-    "logs": "错误检查",
+    "logs": "日志",
     "userRequest": "用户请求",
     "skills": "技能",
     "addProfile": "添加配置文件",
@@ -738,9 +738,9 @@ export default {
       "skills": "Skills",
       "guardrails": "Guardrails",
       "mcp": "MCP",
-      "enableIdeSkills": "启用 IDE Skills 功能，用于管理来自 IDE 的代码片段和技能",
-      "enableGuardrails": "启用 Guardrails - 阻止有风险的工具调用并过滤敏感输出",
-      "enableMCP": "启用 MCP Tools - 配置 MCP（Model Context Protocol）工具，如网页搜索和网页获取",
+      "enableIdeSkills": "管理来自 IDE 的代码片段和技能",
+      "enableGuardrails": "阻止有风险的工具调用并过滤敏感输出",
+      "enableMCP": "MCP（Model Context Protocol）工具，如网页搜索和网页获取",
       "on": "On",
       "off": "Off",
       "enabled": "已启用",
@@ -761,6 +761,9 @@ export default {
       "server": "服务器",
       "forceLogout": "强制登出",
       "refreshStatus": "刷新状态"
+    },
+    "preferences": {
+      "title": "外观与语言"
     }
   },
   "serverInfo": {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1421,8 +1421,29 @@ export const handlers = [
         return HttpResponse.json({ valid: true, user: { username: 'admin', role: 'admin' } })
     }),
 
+    http.get('/api/v1/auth/token', () => {
+        return HttpResponse.json({
+            success: true,
+            data: { token: 'mock-user-token-a1b2c3d4e5f6', is_default: false },
+        })
+    }),
+
+    http.post('/api/v1/auth/token/reset', () => {
+        return HttpResponse.json({
+            success: true,
+            data: { token: `mock-user-token-${Math.random().toString(36).slice(2, 14)}` },
+        })
+    }),
+
     http.get('/api/v1/token', () => {
         return HttpResponse.json({ token: 'mock-model-token', type: 'Bearer' })
+    }),
+
+    http.post('/api/v1/auth/model-token/reset', () => {
+        return HttpResponse.json({
+            success: true,
+            data: { token: `mock-model-token-${Math.random().toString(36).slice(2, 14)}` },
+        })
     }),
 
     http.get('/api/v1/rules', ({ request }) => {

--- a/frontend/src/pages/system/AccessControl.tsx
+++ b/frontend/src/pages/system/AccessControl.tsx
@@ -452,11 +452,6 @@ const AccessControl = () => {
                             </Box>
                         </Box>
 
-                        <Alert severity="info" sx={{ mt: 1 }}>
-                            <Typography variant="body2">
-                                {t('accessControl.modelToken.sharing')}
-                            </Typography>
-                        </Alert>
                     </Stack>
                 </UnifiedCard>
             </Stack>

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -223,87 +223,6 @@ const System = () => {
                             </Box>
                         </Box>
 
-                        {/* Language — merged from the standalone Language Settings card */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconLanguage sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.language.title')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
-                                <Chip
-                                    label={t('system.language.en')}
-                                    onClick={() => changeLanguage('en')}
-                                    size="small"
-                                    sx={{
-                                        bgcolor: i18n.language === 'en' ? 'primary.main' : 'action.hover',
-                                        color: i18n.language === 'en' ? 'primary.contrastText' : 'text.primary',
-                                        fontWeight: i18n.language === 'en' ? 600 : 400,
-                                        border: i18n.language === 'en' ? 'none' : '1px solid',
-                                        borderColor: 'divider',
-                                        cursor: 'pointer',
-                                        '&:hover': {
-                                            bgcolor: i18n.language === 'en' ? 'primary.dark' : 'action.selected',
-                                        },
-                                    }}
-                                />
-                                <Chip
-                                    label={t('system.language.zh')}
-                                    onClick={() => changeLanguage('zh')}
-                                    size="small"
-                                    sx={{
-                                        bgcolor: i18n.language === 'zh' ? 'primary.main' : 'action.hover',
-                                        color: i18n.language === 'zh' ? 'primary.contrastText' : 'text.primary',
-                                        fontWeight: i18n.language === 'zh' ? 600 : 400,
-                                        border: i18n.language === 'zh' ? 'none' : '1px solid',
-                                        borderColor: 'divider',
-                                        cursor: 'pointer',
-                                        '&:hover': {
-                                            bgcolor: i18n.language === 'zh' ? 'primary.dark' : 'action.selected',
-                                        },
-                                    }}
-                                />
-                            </Box>
-                        </Box>
-
-                        {/* Theme — moved from the activity bar */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconBrush sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('common.theme')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
-                                {themeOptions.map(({ value, label, renderIcon }) => {
-                                    const selected = themeMode === value;
-                                    return (
-                                        <Chip
-                                            key={value}
-                                            icon={renderIcon({ size: 14 })}
-                                            label={label}
-                                            onClick={() => setTheme(value)}
-                                            size="small"
-                                            sx={{
-                                                bgcolor: selected ? 'primary.main' : 'action.hover',
-                                                color: selected ? 'primary.contrastText' : 'text.primary',
-                                                fontWeight: selected ? 600 : 400,
-                                                border: selected ? 'none' : '1px solid',
-                                                borderColor: 'divider',
-                                                cursor: 'pointer',
-                                                '& .MuiChip-icon': {
-                                                    color: 'inherit',
-                                                },
-                                                '&:hover': {
-                                                    bgcolor: selected ? 'primary.dark' : 'action.selected',
-                                                },
-                                            }}
-                                        />
-                                    );
-                                })}
-                            </Box>
-                        </Box>
                     </Stack>
                 </UnifiedCard>
 
@@ -351,6 +270,98 @@ const System = () => {
                                 {proxyUrlSaving ? <CircularProgress size={14} color="inherit" /> : t('common.save')}
                             </Button>
                         </Stack>
+                    </Stack>
+                </UnifiedCard>
+
+                {/* Appearance & Language — user preferences, kept apart from
+                    server state so "Server Status" only answers "is the
+                    gateway healthy?" */}
+                <UnifiedCard
+                    title={t('system.preferences.title')}
+                    size="full"
+                >
+                    <Stack spacing={1.5}>
+                        {/* Language */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                <IconLanguage sx={{ fontSize: 14, color: 'text.secondary' }} />
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {t('system.language.title')}
+                                </Typography>
+                            </Box>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
+                                <Chip
+                                    label={t('system.language.en')}
+                                    onClick={() => changeLanguage('en')}
+                                    size="small"
+                                    sx={{
+                                        bgcolor: i18n.language === 'en' ? 'primary.main' : 'action.hover',
+                                        color: i18n.language === 'en' ? 'primary.contrastText' : 'text.primary',
+                                        fontWeight: i18n.language === 'en' ? 600 : 400,
+                                        border: i18n.language === 'en' ? 'none' : '1px solid',
+                                        borderColor: 'divider',
+                                        cursor: 'pointer',
+                                        '&:hover': {
+                                            bgcolor: i18n.language === 'en' ? 'primary.dark' : 'action.selected',
+                                        },
+                                    }}
+                                />
+                                <Chip
+                                    label={t('system.language.zh')}
+                                    onClick={() => changeLanguage('zh')}
+                                    size="small"
+                                    sx={{
+                                        bgcolor: i18n.language === 'zh' ? 'primary.main' : 'action.hover',
+                                        color: i18n.language === 'zh' ? 'primary.contrastText' : 'text.primary',
+                                        fontWeight: i18n.language === 'zh' ? 600 : 400,
+                                        border: i18n.language === 'zh' ? 'none' : '1px solid',
+                                        borderColor: 'divider',
+                                        cursor: 'pointer',
+                                        '&:hover': {
+                                            bgcolor: i18n.language === 'zh' ? 'primary.dark' : 'action.selected',
+                                        },
+                                    }}
+                                />
+                            </Box>
+                        </Box>
+
+                        {/* Theme */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                                <IconBrush sx={{ fontSize: 14, color: 'text.secondary' }} />
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    {t('common.theme')}
+                                </Typography>
+                            </Box>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
+                                {themeOptions.map(({ value, label, renderIcon }) => {
+                                    const selected = themeMode === value;
+                                    return (
+                                        <Chip
+                                            key={value}
+                                            icon={renderIcon({ size: 14 })}
+                                            label={label}
+                                            onClick={() => setTheme(value)}
+                                            size="small"
+                                            sx={{
+                                                bgcolor: selected ? 'primary.main' : 'action.hover',
+                                                color: selected ? 'primary.contrastText' : 'text.primary',
+                                                fontWeight: selected ? 600 : 400,
+                                                border: selected ? 'none' : '1px solid',
+                                                borderColor: 'divider',
+                                                cursor: 'pointer',
+                                                '& .MuiChip-icon': {
+                                                    color: 'inherit',
+                                                },
+                                                '&:hover': {
+                                                    bgcolor: selected ? 'primary.dark' : 'action.selected',
+                                                },
+                                            }}
+                                        />
+                                    );
+                                })}
+                            </Box>
+                        </Box>
                     </Stack>
                 </UnifiedCard>
 

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -1,7 +1,7 @@
 import CardGrid from '@/components/CardGrid.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
-import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, Star as IconStar, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Language as IconWorld, Check as IconCheck, AccessTime as IconClock } from '@/components/icons';
+import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, Star as IconStar, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock } from '@/components/icons';
 import { VersionDisplay } from '@/components/VersionDisplay';
 import { UpdatePanelDialog } from '@/components/UpdatePanelDialog';
 import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
@@ -228,14 +228,7 @@ const System = () => {
 
                 {/* Quick Proxy — dedicated card for the reusable proxy preset */}
                 <UnifiedCard
-                    title={
-                        <Stack direction="row" alignItems="center" spacing={1}>
-                            <IconWorld sx={{ fontSize: 18, color: 'text.secondary' }} />
-                            <Typography variant="subtitle1" fontWeight={600}>
-                                {t('system.proxy.globalProxyUrl.label')}
-                            </Typography>
-                        </Stack>
-                    }
+                    title={t('system.proxy.globalProxyUrl.label')}
                     size="full"
                 >
                     <Stack spacing={1.5}>


### PR DESCRIPTION
## Summary

Third-area UX pass (System: General / Access Control / Experimental / Logs), reviewed against `.design/ux-principles.md`.

- **General**: split the "Server Status" card so Language/Theme move into a new "Appearance & Language" card — Server Status now only answers "is the gateway healthy?" instead of mixing in user preferences.
- **General**: "Quick Proxy" card header now matches the plain-title style every other card on the page uses (it previously had a custom icon + lighter font weight that stood out).
- **Sidebar naming**: renamed "Troubleshoot" → "Logs" (en/zh) to match the page it opens, and frees up "Troubleshoot" for the scenario-level rule diagnostics feature that already uses that name elsewhere.
- **Experimental**: each feature row now shows an always-visible inline description instead of a hover-only tooltip; the chip is a plain On/Off instead of repeating the feature name. Removes a Skills tooltip that was wrapping an empty `<Box/>` and could never actually be hovered.
- **Access Control**: removed the Model Token card's bottom info alert, which duplicated the "Token Security" bullets already at the top of the page.

## Test plan
- [x] `tsc --noEmit` — 143 pre-existing errors, no new errors introduced
- [x] Verified all four System pages visually (light mode) via headless Chrome screenshots in mock mode

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VXeQZm4oTHpQPtTuGPAYdz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXeQZm4oTHpQPtTuGPAYdz)_