### PR TITLE
feat(codex) :fast model suffix support for Codex priority service tier

### DIFF
--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -133,8 +133,19 @@ func (c *CodexClient) ImagesGenerate(ctx context.Context, req openai.ImageGenera
 	return c.parseImageGenerationStream(ctx, stream)
 }
 
+// fastModelSuffix marks a virtual Codex catalog model id (e.g. "gpt-5.6-sol:fast")
+// that requests OpenAI's priority service tier at higher cost. It is stripped
+// before the request reaches the ChatGPT backend API, which knows nothing about it.
+const fastModelSuffix = ":fast"
+
 // applyCodexDefaultsToParams applies Codex-specific defaults to a ResponseNewParams struct.
 func applyCodexDefaultsToParams(req *responses.ResponseNewParams) {
+	// Resolve the ":fast" virtual model suffix into the real model id + priority service tier.
+	if strings.HasSuffix(req.Model, fastModelSuffix) {
+		req.Model = strings.TrimSuffix(req.Model, fastModelSuffix)
+		req.ServiceTier = responses.ResponseNewParamsServiceTierPriority
+	}
+
 	// Set default instructions if not provided
 	if !req.Instructions.Valid() {
 		req.Instructions = param.NewOpt(defaultInstructions)

--- a/internal/client/codex_client_test.go
+++ b/internal/client/codex_client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/openai/openai-go/v3/responses"
@@ -29,5 +30,37 @@ func TestApplyCodexDefaultsToParams_NoFastSuffix(t *testing.T) {
 	}
 	if req.ServiceTier != "" {
 		t.Fatalf("expected empty service tier, got %q", req.ServiceTier)
+	}
+}
+
+// TestApplyCodexDefaultsToParams_ServiceTierSurvivesWireBody guards against the
+// request body being silently stripped of "service_tier" by the second body-shaping
+// pass in codexRoundTripper.filterField (a deny-list JSON filter applied to the
+// already-marshaled body, separate from the SDK struct marshaling).
+func TestApplyCodexDefaultsToParams_ServiceTierSurvivesWireBody(t *testing.T) {
+	req := responses.ResponseNewParams{Model: "gpt-5.6-sol:fast"}
+	applyCodexDefaultsToParams(&req)
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	rt := &codexRoundTripper{}
+	filtered, err := rt.filterField(raw)
+	if err != nil {
+		t.Fatalf("filterField failed: %v", err)
+	}
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(filtered, &out); err != nil {
+		t.Fatalf("unmarshal filtered body: %v", err)
+	}
+
+	if out["service_tier"] != "priority" {
+		t.Fatalf("expected service_tier=priority in final wire body, got %v (full body: %s)", out["service_tier"], filtered)
+	}
+	if out["model"] != "gpt-5.6-sol" {
+		t.Fatalf("expected model=gpt-5.6-sol in final wire body, got %v", out["model"])
 	}
 }

--- a/internal/client/codex_client_test.go
+++ b/internal/client/codex_client_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestApplyCodexDefaultsToParams_FastSuffix(t *testing.T) {
+	req := responses.ResponseNewParams{Model: "gpt-5.6-sol:fast"}
+
+	applyCodexDefaultsToParams(&req)
+
+	if req.Model != "gpt-5.6-sol" {
+		t.Fatalf("expected model to be stripped to %q, got %q", "gpt-5.6-sol", req.Model)
+	}
+	if req.ServiceTier != responses.ResponseNewParamsServiceTierPriority {
+		t.Fatalf("expected service tier %q, got %q", responses.ResponseNewParamsServiceTierPriority, req.ServiceTier)
+	}
+}
+
+func TestApplyCodexDefaultsToParams_NoFastSuffix(t *testing.T) {
+	req := responses.ResponseNewParams{Model: "gpt-5.6-sol"}
+
+	applyCodexDefaultsToParams(&req)
+
+	if req.Model != "gpt-5.6-sol" {
+		t.Fatalf("expected model to remain %q, got %q", "gpt-5.6-sol", req.Model)
+	}
+	if req.ServiceTier != "" {
+		t.Fatalf("expected empty service tier, got %q", req.ServiceTier)
+	}
+}

--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -358,11 +358,25 @@
           "note": "旗舰模型，能力最强，适合复杂编码、长程 Agent 和高难度推理"
         },
         {
+          "id": "gpt-5.6-sol:fast",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-07-09",
+          "note": "旗舰模型 · Fast 模式，请求 OpenAI 优先算力通道，速度更快但消耗更高，仅 Codex 订阅支持"
+        },
+        {
           "id": "gpt-5.6-terra",
           "context": 1050000,
           "max_output": 128000,
           "created": "2026-07-09",
           "note": "平衡能力与成本，适合常规开发任务"
+        },
+        {
+          "id": "gpt-5.6-terra:fast",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-07-09",
+          "note": "平衡模型 · Fast 模式，请求 OpenAI 优先算力通道，速度更快但消耗更高，仅 Codex 订阅支持"
         },
         {
           "id": "gpt-5.6-luna",


### PR DESCRIPTION
## Summary
Adds support for virtual `:fast` model suffixes in the Codex catalog that transparently map to OpenAI's priority service tier. This allows users to request faster inference at higher cost through intuitive model IDs like `gpt-5.6-sol:fast` without exposing the underlying `service_tier` API parameter.

## Changes
- **Model parameter transformation**: Implemented `applyCodexDefaultsToParams()` logic to strip the `:fast` suffix from model IDs and set `ServiceTier` to `priority` before sending requests to the ChatGPT backend
- **Catalog entries**: Added `:fast` variants for `gpt-5.6-sol` and `gpt-5.6-terra` models in `providers.json` with appropriate descriptions noting Codex-only availability
- **Wire format preservation**: Added test guard (`TestApplyCodexDefaultsToParams_ServiceTierSurvivesWireBody`) to ensure the `service_tier` field survives the `codexRoundTripper.filterField()` JSON filtering pass and reaches the wire body intact
- **Test coverage**: Added comprehensive unit tests covering fast suffix stripping, model preservation when no suffix is present, and end-to-end wire body validation

## Implementation Details
The `:fast` suffix is a virtual catalog convention that exists only in Tingly-Box's model listing. It is resolved early in the request pipeline (`applyCodexDefaultsToParams`) before reaching the OpenAI backend, which has no knowledge of this suffix. The implementation guards against accidental field stripping by the deny-list JSON filter applied during request marshaling.

https://claude.ai/code/session_01UBeV5ystTsr2bVTQbFnosU