### PR TITLE
fix & refactor: consolidate model-list fallback into ResolveProviderModels (fixes codex empty list)

### DIFF
--- a/.design/model-list.md
+++ b/.design/model-list.md
@@ -56,7 +56,11 @@ Step 3 的三条硬性约束（`handler.go` 内注释同步）：
 
 ---
 
-## 4. 两个历史 Bug 与教训
+> **读路径与刷新路径共用同一个兜底**：模板兜底逻辑收敛在 `Handler.templateFallbackModels`（`handler.go`），`GetProviderModelsByUUID`（读）和 `UpdateProviderModelsByUUID`（手动刷新）都调用它。见 Bug #3。
+
+---
+
+## 4. 历史 Bug 与教训
 
 ### 4.1 Bug #1：兜底列表无法快速生效
 
@@ -82,6 +86,21 @@ Step 3 的三条硬性约束（`handler.go` 内注释同步）：
 **结论**：**模板绝不并入非空真实列表；上游非空即视为对增删都权威，原样透传。** 相关 helper、`merged` 来源常量、合并测试全部移除（PR 净删 111 行）。
 
 **安全边界由测试钉死**：`TestGetProviderModelsByUUID_ClaudeCode_NonEmptyCache_NotPollutedByTemplate` —— 缓存里一份缺了 `claude-opus-4-5` 的上游列表，接口原样返回，**不会**把模板里的该模型补回来。
+
+### 4.3 Bug #3：Codex 手动刷新返回空列表
+
+**现象**：Codex（issuer `codex`）provider 点"刷新模型列表"后返回 0 个模型，把原本能正常展示的列表清空。
+
+**根因**：`UpdateProviderModelsByUUID`（刷新端点）只做两件事——`FetchAndSaveProviderModels` + `GetModels`（读 DB）。对 Codex：
+- Codex 的 `/models` 端点不支持，`OpenAIClient.ListModels` 直接短路返回 `ErrModelsEndpointNotSupported`（`internal/client/openai.go`，守卫用 `GetIssuer()` 且额外判 `APIBase == CodexAPIBase`）；
+- `FetchAndSaveProviderModels` 清掉该错误、命中模板后 `return nil`（成功）**但不落库**；
+- 于是 `GetModels` 读 DB 得到空 → 刷新端点返回 `models_count: 0`。
+
+读路径（GET）没这个问题，因为它的 Step 3 会**实时**读模板兜底；但刷新路径当初漏了这一步。
+
+> 排查中一个被证伪的岔路：曾怀疑是"旧 provider 记录只设了 `OAuthDetail.ProviderType`、`Issuer` 为空"导致模板匹配（用裸 `.Issuer`）失败。但 provider store 存/取时会用 `GetIssuer()` 归一化（`provider_store.go` 存 `OAuthProviderType = GetIssuer()`、取时写回 `Issuer`），任何经过存储的记录 `Issuer` 都已补齐，所以这条不成立。**先复现再修**避免了误修。
+
+**修复**：把模板兜底抽成 `Handler.templateFallbackModels`，读路径和刷新路径共用；刷新端点在 `GetModels` 为空时也调用它。回归测试 `TestUpdateProviderModelsByUUID_Codex_ReturnsTemplateModels`（修复前失败、修复后通过）。
 
 ---
 

--- a/.design/model-list.md
+++ b/.design/model-list.md
@@ -24,39 +24,39 @@
 
 | 职责 | 位置 |
 |---|---|
-| 服务端点（读路径） | `GetProviderModelsByUUID` — `internal/server/module/provider/handler.go:454` |
-| 刷新端点（写路径） | `UpdateProviderModelsByUUID` — `handler.go:398` |
-| Fetch + 持久化逻辑 | `Config.FetchAndSaveProviderModels` — `internal/server/config/config.go:2006` |
-| 排序（serving 边界唯一真源） | `SortProviderModels` — `config.go:2126` |
+| **兜底链唯一真源（resolver）** | `Config.ResolveProviderModels(forceRefresh, uid)` — `internal/server/config/config.go` |
+| 上游 API fetch + 持久化（内部） | `Config.fetchAndSaveAPIModels` — `config.go` |
+| 缓存预热薄封装（不返回列表） | `Config.FetchAndSaveProviderModels` — `config.go` |
+| 服务端点（读路径） | `GetProviderModelsByUUID` — `internal/server/module/provider/handler.go` |
+| 刷新端点（写路径） | `UpdateProviderModelsByUUID` — `handler.go` |
+| 排序（serving 边界唯一真源） | `SortProviderModels` — `config.go` |
 | 缓存 manager（TTL=1h） | `ModelListManager` / `ModelCacheTTL` — `internal/data/model_list.go:14` |
 | 存储后端（SQLite/GORM） | `ModelStore` — `internal/data/db/provider_model.go`（PK 仅 `provider_uuid`） |
-| 内嵌模板兜底 | `TemplateManager.GetEmbeddedModelsForProvider` — `internal/data/provider_template.go:686` |
+| 内嵌模板兜底 | `TemplateManager.GetEmbeddedModelsForProvider` — `internal/data/provider_template.go` |
 | 响应里的来源标记 | `ModelCacheSource*` — `internal/server/module/provider/types.go` |
 
 ---
 
-## 3. 读路径最终设计（`GetProviderModelsByUUID`）
+## 3. 兜底链最终设计（`ResolveProviderModels`）
 
-分四步，逐级兜底。**模板只在前三步全部拿不到东西（列表为空）时才用。**
+**整条兜底链收敛在一个函数里**：`Config.ResolveProviderModels(forceRefresh bool, uid string) (ResolvedModels, error)`，返回 `{Models, Source, LastUpdated}`。所有调用方（HTTP 读、HTTP 刷新、CLI、OAuth 完成）都走它，行为完全一致。
 
 ```
-Step 1  DB 缓存（api 来源，1h TTL）           非空 → 直接返回，source=db
-Step 2a VModel 静态列表（虚拟 provider）       非空 → 返回，source=vmodel（永不过期）
-Step 2b 上游 API 实时 fetch（非虚拟）          成功非空 → 返回，source=api
-Step 3  内嵌模板兜底（仅当以上全空）           非空 → 返回，source=template
+Step 1  DB 缓存（1h TTL；forceRefresh=true 时跳过）   非空 → 返回，source=db
+Step 2  VModel 静态列表（虚拟 provider）              → 返回，source=vmodel（永不过期）
+Step 3  上游 API fetch（fetchAndSaveAPIModels，持久化） 成功非空 → 返回，source=api
+Step 4  内嵌模板兜底（live，不落库）                  非空 → 返回，source=template
 ```
 
-Step 3 的三条硬性约束（`handler.go` 内注释同步）：
+- **`forceRefresh` 是读路径与刷新路径的唯一区别**：读传 `false`（缓存优先），手动刷新传 `true`（跳过缓存、强制重查上游）。**只差一个 bool，两条路径再也无法漂移**（Bug #3 类问题从结构上消除）。
+- Step 4 三条硬约束：①仅当前面全空才用；②绝不并入非空列表（模板是会过期的编译期快照，并入会复活已淘汰模型）；③live 读取不落库（改进内嵌列表立即生效）。
+- 两个 HTTP handler 因此变得很薄——一行 `ResolveProviderModels(...)` + 组装响应。`expiresAt`（仅响应元数据）由 handler 的 `modelListExpiry(source)` 从 source 推导。
 
-1. **仅当 `len(models) == 0` 时才用模板** —— 绝不并入非空列表。
-2. **实时读取，不持久化** —— 不写回 DB。
-3. 命中模板时 `expiresAt` 设为 1h 后（仅用于响应元数据，不代表落库）。
+`ModelCacheSource` / `ModelListSource` 只有四个取值：`db` / `api` / `vmodel` / `template`。**没有 `merged`。**
 
-`ModelCacheSource` 只有四个取值：`db` / `api` / `vmodel` / `template`。**没有 `merged`。**
-
----
-
-> **读路径与刷新路径共用同一个兜底**：模板兜底逻辑收敛在 `Handler.templateFallbackModels`（`handler.go`），`GetProviderModelsByUUID`（读）和 `UpdateProviderModelsByUUID`（手动刷新）都调用它。见 Bug #3。
+> **`FetchAndSaveProviderModels` 仍保留**，但降级为"只预热缓存、不返回列表"的薄封装，供纯触发抓取的调用点使用（TUI 缓存预热、OAuth 重认证）。需要"生效列表"的调用点一律用 `ResolveProviderModels`。
+>
+> **TUI `availableModels`（`rule_mode.go`）刻意不并入 resolver**：它是渲染期"只读缓存+模板、绝不发网络"的语义，与 resolver"缓存缺失即抓取"不同。
 
 ---
 
@@ -100,7 +100,9 @@ Step 3 的三条硬性约束（`handler.go` 内注释同步）：
 
 > 排查中一个被证伪的岔路：曾怀疑是"旧 provider 记录只设了 `OAuthDetail.ProviderType`、`Issuer` 为空"导致模板匹配（用裸 `.Issuer`）失败。但 provider store 存/取时会用 `GetIssuer()` 归一化（`provider_store.go` 存 `OAuthProviderType = GetIssuer()`、取时写回 `Issuer`），任何经过存储的记录 `Issuer` 都已补齐，所以这条不成立。**先复现再修**避免了误修。
 
-**修复**：把模板兜底抽成 `Handler.templateFallbackModels`，读路径和刷新路径共用；刷新端点在 `GetModels` 为空时也调用它。回归测试 `TestUpdateProviderModelsByUUID_Codex_ReturnsTemplateModels`（修复前失败、修复后通过）。
+**修复**：最初把模板兜底抽成 `Handler.templateFallbackModels` 让两个 handler 共用（PR #1364）；随后**全面重构**把整条兜底链收敛进 `Config.ResolveProviderModels`（见 §3），两个 handler 只差一个 `forceRefresh` bool，`templateFallbackModels` 被移除。回归测试 `TestUpdateProviderModelsByUUID_Codex_ReturnsTemplateModels`。
+
+> 重构同时修掉了 **3 个潜伏的同类 bug**：`agent_command.go`、`remote.go`、`oauth/handler.go` 当初都是 `FetchAndSave` + `GetModels` 且没补模板兜底，codex 场景同样会拿到空列表；迁到 `ResolveProviderModels` 后一并修复。
 
 ---
 

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -255,15 +255,16 @@ func promptForAgentConfig(reader *bufio.Reader, appManager *AppManager, req *age
 		req.Provider = provider.UUID
 	}
 
-	// Fetch models for the provider
-	if err := appManager.FetchAndSaveProviderModels(req.Provider); err != nil {
+	// Fetch models for the provider. ResolveProviderModels walks the full
+	// fallback chain, so providers whose /models endpoint is unsupported
+	// (e.g. Codex) still yield their embedded template catalog.
+	globalConfig := appManager.GetGlobalConfig()
+	resolved, err := globalConfig.ResolveProviderModels(true, req.Provider)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to fetch models from provider: %v\n", err)
 		fmt.Fprintln(os.Stderr, "Using cached model list...")
 	}
-
-	// Get models from provider
-	globalConfig := appManager.GetGlobalConfig()
-	models := globalConfig.GetModelManager().GetModels(req.Provider)
+	models := resolved.Models
 
 	// Prompt for model if not specified
 	if req.Model == "" {

--- a/internal/command/remote.go
+++ b/internal/command/remote.go
@@ -198,17 +198,19 @@ func promptForSmartGuideModel(reader *bufio.Reader, appManager *AppManager) (str
 	}
 
 	// Fetch models for the provider
-	modelManager := appManager.AppConfig().GetGlobalConfig().GetModelManager()
-	if modelManager == nil {
+	globalCfg := appManager.AppConfig().GetGlobalConfig()
+	if globalCfg.GetModelManager() == nil {
 		return "", "", fmt.Errorf("model manager not available")
 	}
 
-	// Try to fetch models from provider
-	if err := appManager.AppConfig().FetchAndSaveProviderModels(provider.UUID); err != nil {
+	// ResolveProviderModels walks the full fallback chain, so providers whose
+	// /models endpoint is unsupported (e.g. Codex) still return their catalog.
+	resolved, err := globalCfg.ResolveProviderModels(true, provider.UUID)
+	if err != nil {
 		logrus.WithError(err).Warn("Failed to fetch models from provider, using cached list")
 	}
 
-	models := modelManager.GetModels(provider.UUID)
+	models := resolved.Models
 	if len(models) == 0 {
 		// If no models found, let user enter manually
 		fmt.Println()

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2002,7 +2002,138 @@ func (c *Config) IsScenarioRecordingEnabled(scenario typ.RuleScenario) bool {
 	return c.GetScenarioRecordingMode(scenario) != typ.RecordingModeDisabled
 }
 
-// FetchAndSaveProviderModels fetches models from a provider with fallback hierarchy
+// ModelListSource identifies where a resolved model list came from. Its string
+// values match provider.ModelCacheSource so the HTTP layer can map directly.
+type ModelListSource string
+
+const (
+	ModelListSourceCache    ModelListSource = "db"       // served from the DB cache
+	ModelListSourceAPI      ModelListSource = "api"      // freshly fetched from upstream
+	ModelListSourceVModel   ModelListSource = "vmodel"   // virtual provider's static list
+	ModelListSourceTemplate ModelListSource = "template" // compile-time embedded fallback
+)
+
+// ResolvedModels is the effective model list for a provider plus provenance.
+type ResolvedModels struct {
+	Models      []string
+	Source      ModelListSource
+	LastUpdated string // formatted timestamp of the cached record; empty if unknown
+}
+
+// ResolveProviderModels returns the effective model list for a provider,
+// walking the full fallback chain in ONE place so every caller (HTTP read,
+// HTTP refresh, CLI, OAuth completion) sees identical behavior:
+//
+//	cache (DB) → VModel (virtual) → upstream API → embedded template
+//
+// When forceRefresh is false, a fresh-enough DB cache short-circuits the
+// chain; when true the cache is bypassed and upstream is re-queried (the
+// manual "refresh models" action). The returned list is canonically sorted.
+//
+// Template results are never persisted, so an improved embedded list takes
+// effect immediately and a template snapshot never pollutes a real cached
+// list. This method always fetches on a cache miss — callers that must not
+// touch the network (e.g. TUI render) should read the cache/template directly.
+func (c *Config) ResolveProviderModels(forceRefresh bool, uid string) (ResolvedModels, error) {
+	provider, provErr := c.GetProviderByUUID(uid)
+
+	finalize := func(models []string, src ModelListSource) ResolvedModels {
+		if provErr == nil {
+			SortProviderModels(provider, models)
+		}
+		lastUpdated := ""
+		if _, updated, exists := c.modelManager.GetProviderInfo(uid); exists {
+			lastUpdated = updated
+		}
+		return ResolvedModels{Models: models, Source: src, LastUpdated: lastUpdated}
+	}
+
+	// Step 1: DB cache (unless forcing a refresh).
+	if !forceRefresh {
+		if cached := c.modelManager.GetModels(uid); len(cached) > 0 {
+			return finalize(cached, ModelListSourceCache), nil
+		}
+	}
+
+	if provErr != nil {
+		return ResolvedModels{}, fmt.Errorf("provider with UUID %s not found: %w", uid, provErr)
+	}
+
+	// Step 2: VModel static list (virtual providers).
+	if provider.IsVirtual() {
+		var models []string
+		if provider.VModelDetail != nil {
+			models = provider.VModelDetail.Models
+		}
+		return finalize(models, ModelListSourceVModel), nil
+	}
+
+	// Step 3: Upstream API (persisted on success).
+	if err := c.fetchAndSaveAPIModels(provider); err == nil {
+		if fresh := c.modelManager.GetModels(uid); len(fresh) > 0 {
+			return finalize(fresh, ModelListSourceAPI), nil
+		}
+	}
+
+	// Step 4: Embedded template fallback (live, never persisted). It is a
+	// last resort only — never merged into a non-empty real list, since the
+	// snapshot can still name models the upstream has retired.
+	if c.templateManager != nil {
+		if tmpl, err := c.templateManager.GetEmbeddedModelsForProvider(provider); err == nil && len(tmpl) > 0 {
+			return finalize(tmpl, ModelListSourceTemplate), nil
+		}
+	}
+
+	return finalize(nil, ModelListSourceTemplate), nil
+}
+
+// fetchAndSaveAPIModels queries the provider's upstream /models endpoint and,
+// on success, persists the sorted list (ModelSourceAPI). It returns an error
+// when the endpoint is unsupported or the call fails; the caller falls back to
+// the template. It never persists template data.
+func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lister, closer, err := c.newModelLister(provider)
+	if closer != nil {
+		defer closer()
+	}
+	if err != nil || lister == nil {
+		logrus.Errorf("Failed to create client for provider %s: %v", provider.Name, err)
+		return fmt.Errorf("failed to create client for provider %s: %w", provider.Name, err)
+	}
+
+	models, apiErr := lister.ListModels(ctx)
+	if apiErr != nil {
+		if client.IsModelsEndpointNotSupported(apiErr) {
+			logrus.Infof("Provider %s does not support models endpoint, using template fallback", provider.Name)
+		} else {
+			logrus.Errorf("Failed to fetch models from API: %v", apiErr)
+		}
+		return apiErr
+	}
+	if len(models) == 0 {
+		return fmt.Errorf("provider %s returned no models", provider.Name)
+	}
+
+	// Persist the upstream list verbatim. It is authoritative for both
+	// additions and removals, so the embedded template snapshot must not be
+	// merged in here — that would resurrect retired models. Apply canonical
+	// ordering before persisting; the same sort is reapplied at the serving
+	// boundary so cached order is irrelevant.
+	SortProviderModels(provider, models)
+	return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
+}
+
+// FetchAndSaveProviderModels fetches a provider's models and persists API
+// results, warming the DB cache. It is retained for callers that only need to
+// trigger a fetch (e.g. TUI cache-warming); callers that need the effective
+// list should use ResolveProviderModels instead.
+//
+// Contract: returns nil when a real API list was persisted OR when the API is
+// unavailable but an embedded template exists to fall back on; returns an
+// error only when neither a real nor a template list can be produced.
 func (c *Config) FetchAndSaveProviderModels(uid string) error {
 	provider, err := c.GetProviderByUUID(uid)
 	if err != nil {
@@ -2018,54 +2149,18 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 		return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	var models []string
-	var apiErr error
-
-	lister, closer, err := c.newModelLister(provider)
-	if err != nil {
-		apiErr = err
-	}
-	if closer != nil {
-		defer closer()
+	apiErr := c.fetchAndSaveAPIModels(provider)
+	if apiErr == nil {
+		return nil
 	}
 
-	if lister != nil {
-		models, apiErr = lister.ListModels(ctx)
-		if apiErr == nil && len(models) > 0 {
-			// Persist the upstream list verbatim. It is authoritative for both
-			// additions and removals, so the embedded template snapshot must
-			// not be merged in here — that would resurrect retired models.
-			// Apply canonical ordering before persisting; the same sort is
-			// reapplied at the serving boundary so cached order is irrelevant.
-			SortProviderModels(provider, models)
-			return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
-		}
-		if client.IsModelsEndpointNotSupported(apiErr) {
-			logrus.Infof("Provider %s does not support models endpoint, using template fallback", provider.Name)
-			apiErr = nil // Clear error to proceed to template fallback
-		} else {
-			logrus.Errorf("Failed to fetch models from API: %v", apiErr)
-		}
-	} else {
-		logrus.Errorf("Failed to create client for provider %s: %v", provider.Name, apiErr)
-	}
-
-	// API failed or not supported, fall back to compile-time embedded providers.json.
-	// Do not persist template data to DB — callers should use it directly without caching.
+	// API failed or not supported — success only if a template can cover it.
 	if c.templateManager != nil {
-		tmplModels, tmplErr := c.templateManager.GetEmbeddedModelsForProvider(provider)
-		if tmplErr == nil && len(tmplModels) > 0 {
-			return nil // signal success; caller uses GetEmbeddedModelsForProvider directly
+		if tmpl, tErr := c.templateManager.GetEmbeddedModelsForProvider(provider); tErr == nil && len(tmpl) > 0 {
+			return nil
 		}
 	}
-
-	if apiErr != nil {
-		return fmt.Errorf("failed to fetch models (API: %v, template fallback: not available)", apiErr)
-	}
-	return fmt.Errorf("failed to fetch models (template fallback: not available)")
+	return fmt.Errorf("failed to fetch models (API: %v, template fallback: not available)", apiErr)
 }
 
 // newModelLister builds the client used to list models for a provider.

--- a/internal/server/config/model_resolve_test.go
+++ b/internal/server/config/model_resolve_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/data"
+	"github.com/tingly-dev/tingly-box/internal/data/db"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func newResolveTestConfig(t *testing.T) *Config {
+	t.Helper()
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+	tm := data.NewEmbeddedOnlyTemplateManager()
+	require.NoError(t, tm.Initialize(context.Background()))
+	cfg.SetTemplateManager(tm)
+	return cfg
+}
+
+func codexResolveProvider() *typ.Provider {
+	return &typ.Provider{
+		Name:     "Codex OAuth",
+		APIBase:  protocol.CodexAPIBase,
+		APIStyle: protocol.APIStyleOpenAI,
+		AuthType: typ.AuthTypeOAuth,
+		Enabled:  true,
+		OAuthDetail: &typ.OAuthDetail{
+			AccessToken: "test-codex-token",
+			Issuer:      ai.IssuerCodex,
+		},
+	}
+}
+
+// Codex's /models endpoint is unsupported, so the resolver must fall through
+// to the embedded template (never persisted) and report source=template.
+func TestResolveProviderModels_Codex_TemplateFallback(t *testing.T) {
+	cfg := newResolveTestConfig(t)
+	p := codexResolveProvider()
+	require.NoError(t, cfg.AddProvider(p))
+
+	got, err := cfg.ResolveProviderModels(true, p.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, ModelListSourceTemplate, got.Source)
+	assert.Contains(t, got.Models, "gpt-5.5")
+}
+
+// A non-empty DB cache is served verbatim (source=db) and the upstream API is
+// NOT re-queried when forceRefresh is false.
+func TestResolveProviderModels_CacheHit_NotRefetched(t *testing.T) {
+	cfg := newResolveTestConfig(t)
+	p := codexResolveProvider()
+	require.NoError(t, cfg.AddProvider(p))
+	require.NoError(t, cfg.GetModelManager().SaveModels(p, []string{"cached-only"}, db.ModelSourceAPI))
+
+	got, err := cfg.ResolveProviderModels(false, p.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, ModelListSourceCache, got.Source)
+	assert.Equal(t, []string{"cached-only"}, got.Models)
+}
+
+// forceRefresh bypasses the cache: even with a cached list present, codex
+// re-resolves to the template (its /models endpoint is unsupported, so no real
+// network call happens, but the cache is intentionally skipped).
+func TestResolveProviderModels_ForceRefresh_BypassesCache(t *testing.T) {
+	cfg := newResolveTestConfig(t)
+	p := codexResolveProvider()
+	require.NoError(t, cfg.AddProvider(p))
+	require.NoError(t, cfg.GetModelManager().SaveModels(p, []string{"stale-cached"}, db.ModelSourceAPI))
+
+	got, err := cfg.ResolveProviderModels(true, p.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, ModelListSourceTemplate, got.Source)
+	assert.NotContains(t, got.Models, "stale-cached")
+	assert.Contains(t, got.Models, "gpt-5.5")
+}
+
+// A provider that does not exist yields an error (used by the refresh path to
+// surface a 500) rather than silently resolving to an empty list.
+func TestResolveProviderModels_UnknownProvider_Errors(t *testing.T) {
+	cfg := newResolveTestConfig(t)
+
+	_, err := cfg.ResolveProviderModels(true, "does-not-exist")
+	require.Error(t, err)
+}

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -1146,14 +1146,14 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 		return "", fmt.Errorf("failed to save provider: %w", err)
 	}
 
-	// Fetch models for the newly created OAuth provider
+	// Fetch models for the newly created OAuth provider. ResolveProviderModels
+	// falls back to the embedded template for issuers whose /models endpoint is
+	// unsupported (e.g. Codex), so the log reflects the real catalog size.
 	log.Printf("[OAuth] Fetching models for OAuth provider %s (%s)", providerName, providerUUID.String())
-	if err := h.config.FetchAndSaveProviderModels(providerUUID.String()); err != nil {
+	if resolved, err := h.config.ResolveProviderModels(true, providerUUID.String()); err != nil {
 		log.Printf("[OAuth] Warning: Failed to fetch models for OAuth provider %s: %v", providerName, err)
 	} else {
-		modelManager := h.config.GetModelManager()
-		models := modelManager.GetModels(providerUUID.String())
-		log.Printf("[OAuth] Successfully fetched %d models for OAuth provider %s", len(models), providerName)
+		log.Printf("[OAuth] Successfully fetched %d models for OAuth provider %s", len(resolved.Models), providerName)
 	}
 
 	// Log the successful provider creation

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -394,6 +394,29 @@ func (h *Handler) ToggleProvider(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// templateFallbackModels returns the embedded template model list for a
+// non-virtual provider, or nil when unavailable. It is the last-resort
+// fallback shared by the read (GetProviderModelsByUUID) and refresh
+// (UpdateProviderModelsByUUID) endpoints: for providers whose /models
+// endpoint is unsupported (e.g. Codex), FetchAndSaveProviderModels resolves
+// to the embedded template without persisting it, so a plain DB read yields
+// nothing and both endpoints must consult the template live to avoid
+// surfacing an empty list.
+func (h *Handler) templateFallbackModels(p *typ.Provider) []string {
+	if p == nil || p.IsVirtual() {
+		return nil
+	}
+	tm := h.config.GetTemplateManager()
+	if tm == nil {
+		return nil
+	}
+	models, err := tm.GetEmbeddedModelsForProvider(p)
+	if err != nil {
+		return nil
+	}
+	return models
+}
+
 // UpdateProviderModelsByUUID fetches and caches models for the given provider.
 func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 	uid := c.Param("uuid")
@@ -418,8 +441,22 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 	modelManager := h.config.GetModelManager()
 	models := modelManager.GetModels(uid)
 
+	p, provErr := h.config.GetProviderByUUID(uid)
+
+	// FetchAndSaveProviderModels does not persist template-only results (e.g.
+	// Codex, whose /models endpoint is unsupported), so a DB read can be empty
+	// even on success. Fall back to the embedded template just like the GET
+	// path, otherwise a manual refresh would wipe the list to zero models.
+	source := ModelCacheSourceAPI
+	if len(models) == 0 && provErr == nil {
+		if tmpl := h.templateFallbackModels(p); len(tmpl) > 0 {
+			models = tmpl
+			source = ModelCacheSourceTemplate
+		}
+	}
+
 	// Apply canonical ordering at the serving boundary (see GetProviderModelsByUUID).
-	if p, err := h.config.GetProviderByUUID(uid); err == nil {
+	if provErr == nil {
 		config.SortProviderModels(p, models)
 	}
 
@@ -430,7 +467,7 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 		"models_count": len(models),
 	}).Info(fmt.Sprintf("Successfully fetched %d models for provider %s", len(models), uid))
 
-	providerModels := ProviderModelInfo{Models: models}
+	providerModels := ProviderModelInfo{Models: models, Source: source}
 
 	if h.quotaManager != nil {
 		ctx := c.Request.Context()
@@ -510,12 +547,10 @@ func (h *Handler) GetProviderModelsByUUID(c *gin.Context) {
 	// embedded list takes effect immediately instead of waiting out a cached
 	// entry's TTL.
 	if provErr == nil && !isVirtual && len(models) == 0 {
-		if tm := h.config.GetTemplateManager(); tm != nil {
-			if templateModels, err := tm.GetEmbeddedModelsForProvider(p); err == nil && len(templateModels) > 0 {
-				models = templateModels
-				source = ModelCacheSourceTemplate
-				expiresAt = time.Now().Add(1 * time.Hour)
-			}
+		if templateModels := h.templateFallbackModels(p); len(templateModels) > 0 {
+			models = templateModels
+			source = ModelCacheSourceTemplate
+			expiresAt = time.Now().Add(1 * time.Hour)
 		}
 	}
 

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -394,30 +394,22 @@ func (h *Handler) ToggleProvider(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// templateFallbackModels returns the embedded template model list for a
-// non-virtual provider, or nil when unavailable. It is the last-resort
-// fallback shared by the read (GetProviderModelsByUUID) and refresh
-// (UpdateProviderModelsByUUID) endpoints: for providers whose /models
-// endpoint is unsupported (e.g. Codex), FetchAndSaveProviderModels resolves
-// to the embedded template without persisting it, so a plain DB read yields
-// nothing and both endpoints must consult the template live to avoid
-// surfacing an empty list.
-func (h *Handler) templateFallbackModels(p *typ.Provider) []string {
-	if p == nil || p.IsVirtual() {
-		return nil
+// modelListExpiry returns the response expiry for a resolved source. VModel
+// lists are static (far future, avoiding a serialised zero time); every other
+// source uses a 1h TTL matching the DB cache.
+func modelListExpiry(source config.ModelListSource) time.Time {
+	if source == config.ModelListSourceVModel {
+		const neverExpires = 20 * 365 * 24 * time.Hour
+		return time.Now().Add(neverExpires)
 	}
-	tm := h.config.GetTemplateManager()
-	if tm == nil {
-		return nil
-	}
-	models, err := tm.GetEmbeddedModelsForProvider(p)
-	if err != nil {
-		return nil
-	}
-	return models
+	return time.Now().Add(1 * time.Hour)
 }
 
-// UpdateProviderModelsByUUID fetches and caches models for the given provider.
+// UpdateProviderModelsByUUID force-refreshes and returns the model list for the
+// given provider (the manual "refresh models" action). It re-queries upstream,
+// falling back to the embedded template just like the read path — so providers
+// whose /models endpoint is unsupported (e.g. Codex) still return their catalog
+// instead of an empty list.
 func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 	uid := c.Param("uuid")
 	if uid == "" {
@@ -425,7 +417,13 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 		return
 	}
 
-	if err := h.config.FetchAndSaveProviderModels(uid); err != nil {
+	resolved, err := h.config.ResolveProviderModels(true, uid)
+	if err == nil && len(resolved.Models) == 0 {
+		// A manual refresh that surfaces nothing is a failure worth reporting,
+		// unlike the display path which tolerates an empty list.
+		err = fmt.Errorf("no models available for provider %s", uid)
+	}
+	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"action":   obs.ActionFetchModels,
 			"success":  false,
@@ -438,36 +436,14 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 		return
 	}
 
-	modelManager := h.config.GetModelManager()
-	models := modelManager.GetModels(uid)
-
-	p, provErr := h.config.GetProviderByUUID(uid)
-
-	// FetchAndSaveProviderModels does not persist template-only results (e.g.
-	// Codex, whose /models endpoint is unsupported), so a DB read can be empty
-	// even on success. Fall back to the embedded template just like the GET
-	// path, otherwise a manual refresh would wipe the list to zero models.
-	source := ModelCacheSourceAPI
-	if len(models) == 0 && provErr == nil {
-		if tmpl := h.templateFallbackModels(p); len(tmpl) > 0 {
-			models = tmpl
-			source = ModelCacheSourceTemplate
-		}
-	}
-
-	// Apply canonical ordering at the serving boundary (see GetProviderModelsByUUID).
-	if provErr == nil {
-		config.SortProviderModels(p, models)
-	}
-
 	logrus.WithFields(logrus.Fields{
 		"action":       obs.ActionFetchModels,
 		"success":      true,
 		"provider":     uid,
-		"models_count": len(models),
-	}).Info(fmt.Sprintf("Successfully fetched %d models for provider %s", len(models), uid))
+		"models_count": len(resolved.Models),
+	}).Info(fmt.Sprintf("Successfully fetched %d models for provider %s", len(resolved.Models), uid))
 
-	providerModels := ProviderModelInfo{Models: models, Source: source}
+	providerModels := ProviderModelInfo{Models: resolved.Models, Source: ModelCacheSource(resolved.Source)}
 
 	if h.quotaManager != nil {
 		ctx := c.Request.Context()
@@ -478,7 +454,7 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 
 	c.JSON(http.StatusOK, ProviderModelsResponse{
 		Success: true,
-		Message: fmt.Sprintf("Successfully fetched %d models for provider %s", len(models), uid),
+		Message: fmt.Sprintf("Successfully fetched %d models for provider %s", len(resolved.Models), uid),
 		Data:    providerModels,
 	})
 }
@@ -491,8 +467,7 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 func (h *Handler) GetProviderModelsByUUID(c *gin.Context) {
 	uid := c.Param("uuid")
 
-	providerModelManager := h.config.GetModelManager()
-	if providerModelManager == nil {
+	if h.config.GetModelManager() == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"success": false,
 			"error":   "Provider model manager not available",
@@ -500,72 +475,16 @@ func (h *Handler) GetProviderModelsByUUID(c *gin.Context) {
 		return
 	}
 
-	// Step 1: Try DB cache (API-sourced, 1h TTL).
-	models := providerModelManager.GetModels(uid)
-	source := ModelCacheSourceDB
-	// Default to far-future for sources that never expire (VModel); other
-	// sources override this below with their own TTL. Avoids serialising a
-	// zero time.Time ("0001-01-01T00:00:00Z") in the response.
-	const neverExpires = 20 * 365 * 24 * time.Hour
-	expiresAt := time.Now().Add(neverExpires)
-	lastUpdated := ""
-
-	p, provErr := h.config.GetProviderByUUID(uid)
-	isVirtual := provErr == nil && p.IsVirtual()
-
-	if len(models) > 0 {
-		if _, updated, exists := providerModelManager.GetProviderInfo(uid); exists {
-			lastUpdated = updated
-		}
-		expiresAt = time.Now().Add(1 * time.Hour)
-	} else if provErr == nil {
-		if isVirtual {
-			// Step 2a: VModel fallback (static, no cache).
-			if p.VModelDetail != nil {
-				models = p.VModelDetail.Models
-				source = ModelCacheSourceVModel
-			}
-			// VModel lists are static — never expire.
-		} else {
-			// Step 2b: Try Provider API.
-			if apiErr := h.config.FetchAndSaveProviderModels(uid); apiErr == nil {
-				models = providerModelManager.GetModels(uid)
-				if len(models) > 0 {
-					source = ModelCacheSourceAPI
-					expiresAt = time.Now().Add(1 * time.Hour)
-				}
-			}
-		}
-	}
-
-	// Step 3: Template fallback — used only when we still have no models at
-	// all (API failed, unsupported, or returned nothing). The embedded
-	// template is a compile-time snapshot that can still list models the
-	// upstream has since retired, so it must never be merged into a non-empty
-	// real list — doing so would resurrect deprecated models. It is a pure
-	// last-resort fallback. Read live (never persisted) so an improved
-	// embedded list takes effect immediately instead of waiting out a cached
-	// entry's TTL.
-	if provErr == nil && !isVirtual && len(models) == 0 {
-		if templateModels := h.templateFallbackModels(p); len(templateModels) > 0 {
-			models = templateModels
-			source = ModelCacheSourceTemplate
-			expiresAt = time.Now().Add(1 * time.Hour)
-		}
-	}
-
-	// Apply canonical ordering at the serving boundary so the response order
-	// is authoritative regardless of cache source. The frontend relies on this
-	// order and no longer sorts client-side.
-	if provErr == nil {
-		config.SortProviderModels(p, models)
-	}
+	// Resolve through the shared fallback chain (cache → vmodel → api →
+	// template). A resolve error (e.g. provider not found) is non-fatal for the
+	// display path: serve an empty list rather than an error.
+	resolved, _ := h.config.ResolveProviderModels(false, uid)
 
 	providerModels := ProviderModelInfo{
-		Models:      models,
-		Source:      source,
-		ExpiresAt:   expiresAt,
-		LastUpdated: lastUpdated,
+		Models:      resolved.Models,
+		Source:      ModelCacheSource(resolved.Source),
+		ExpiresAt:   modelListExpiry(resolved.Source),
+		LastUpdated: resolved.LastUpdated,
 	}
 
 	// Attach quota only when the provider type is supported; skip silently

--- a/internal/server/module/provider/model_list_test.go
+++ b/internal/server/module/provider/model_list_test.go
@@ -97,6 +97,35 @@ func TestGetProviderModelsByUUID_Codex_EmptyCache_UsesTemplate(t *testing.T) {
 	assert.Contains(t, resp.Data.Models, "gpt-5.5")
 }
 
+// TestUpdateProviderModelsByUUID_Codex_ReturnsTemplateModels is a regression
+// test for codex model-list refresh returning an empty list. The refresh
+// endpoint calls FetchAndSaveProviderModels (which, for codex, short-circuits
+// the unsupported /models endpoint and resolves to the embedded template
+// without persisting it) and then reads back from the DB cache. Since the
+// template is never persisted, a naive DB read yields zero models — the
+// endpoint must apply the same template fallback the GET path does.
+func TestUpdateProviderModelsByUUID_Codex_ReturnsTemplateModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := newTestConfigWithTemplates(t)
+	provider := newCodexOAuthProvider()
+	require.NoError(t, cfg.AddProvider(provider))
+
+	handler := NewHandler(cfg, nil)
+	router := gin.New()
+	router.POST("/provider-models/:uuid", handler.UpdateProviderModelsByUUID)
+
+	req, _ := http.NewRequest("POST", "/provider-models/"+provider.UUID, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp ProviderModelsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.True(t, resp.Success)
+	assert.NotEmpty(t, resp.Data.Models, "codex refresh must fall back to template models, not return an empty list")
+	assert.Contains(t, resp.Data.Models, "gpt-5.5")
+}
+
 // TestGetProviderModelsByUUID_ClaudeCode_NonEmptyCache_NotPollutedByTemplate
 // pins the deprecation-safety guarantee: the embedded template is a
 // compile-time snapshot that can still list models the upstream has retired,


### PR DESCRIPTION
## What & why

Started as a fix for **Codex model-list refresh returning an empty list**, then consolidated the whole fallback subsystem, which had accumulated into several hand-maintained copies.

### The bug (commit 1)

`UpdateProviderModelsByUUID` (manual "refresh models") only did `FetchAndSaveProviderModels` + a DB read. For providers whose `/models` endpoint is unsupported (Codex), the fetch resolves to the embedded template **without persisting it**, so the DB read returned zero models and the refresh wiped the list.

> An earlier suspicion — legacy records with only `OAuthDetail.ProviderType` set — was reproduced and **disproven**: the provider store normalizes `Issuer` via `GetIssuer()` on save/load. Reproducing first avoided a misdirected fix.

### The refactor (commit 2)

Root structural cause: `FetchAndSaveProviderModels` returned `nil` both when it persisted a real API list AND when it resolved to a template without saving anything — so every caller had to re-read the cache and separately re-derive the template fallback. That produced **3+ copies** of the fallback chain and left `agent_command`, `remote`, and `oauth` carrying the same latent codex-empty bug.

Introduce **`Config.ResolveProviderModels(forceRefresh, uid) → {Models, Source, LastUpdated}`** as the single place that walks `cache → VModel → API → template`:

- Both HTTP handlers collapse to one call — GET passes `false`, refresh passes `true`. They **can no longer drift** (structurally prevents the bug class).
- `agent_command`, `remote`, `oauth` migrated to it → their latent codex bug fixed for free.
- `FetchAndSaveProviderModels` kept as a thin cache-warming wrapper for callers that only trigger a fetch (TUI, oauth re-auth).
- TUI `availableModels` left as-is (render-time, must **not** fetch — different semantics).

Invariant preserved: the embedded template is a pure last-resort fallback, **never merged** into a non-empty real list (would resurrect upstream-retired models).

## Tests

- `TestUpdateProviderModelsByUUID_Codex_ReturnsTemplateModels` (regression, fails before commit 1).
- `ResolveProviderModels` unit tests: cache-hit-not-refetched, force-refresh-bypasses-cache, codex template fallback, unknown-provider errors.
- Existing model-list handler tests still pass.
- `go build ./...`, `go vet`, and tests for provider / config / data / command / oauth all green.

Design notes: `.design/model-list.md` updated (§3 rewritten around the resolver; Bug #3 documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)