### PR TITLE
feat(claude-code): make profile artifacts readable and safe

### DIFF
--- a/.design/claude-code-config.md
+++ b/.design/claude-code-config.md
@@ -276,16 +276,70 @@ target a model name routed by a different gateway on the same proxy
 URL — without forcing the form to surface concepts ("rule", "service",
 "provider") that are normally hidden one level below.
 
-### 5.6 Profiles (out of scope for the form)
+### 5.6 Profile settings are derived artifacts
 
-The profile system at `/agent/claude_code/profile/:profileId` uses
+The profile system at `/agent/claude_code/profile/:profileId` uses the
 scenario string `claude_code:<profileId>` and its **own** set of rules
-(short names like `default`/`haiku` instead of `tingly/cc-*`). Profile
-launches go through `tingly-box cc --profile <id>`, which has a separate
-env-generation path in `internal/command/cc_command.go:generateCCEnv`.
-The Quick Config modal is intentionally only mounted on the default
-(non-profile) page; profile env is materialized by the CLI subcommand at
-launch time, not written to global `~/.claude/settings.json`.
+(short names like `default`/`haiku` instead of `tingly/cc-*`). The Quick
+Config modal remains scoped to the default page; profile env is generated
+by `GenerateCCEnv` and materialized by `BuildCCProfileSettings`.
+
+There is deliberately no second profile manifest under the Claude
+directory. The sources of truth are:
+
+- global config for profile ID, name, mode, rules, and routing flags;
+- `~/.claude/settings.json` for the user's current local Claude settings.
+
+Everything under `~/.tingly-box/claude/` is a deterministic runtime
+artifact that can be rebuilt from those sources. Code must only derive a
+path from config; it must never scan or parse directory names to reconstruct
+profile metadata.
+
+The materialized layout keeps the stable ID and human name visible without
+symlinks or another `profiles/` nesting layer:
+
+```text
+~/.tingly-box/claude/
+├── default/
+│   ├── settings.json
+│   └── statusline.sh
+├── p1--work/
+│   ├── settings.json
+│   └── statusline.sh
+└── p2--deepseek/
+    ├── settings.json
+    └── statusline.sh
+```
+
+`default/` is a synthetic local profile. It maps the current
+`~/.claude/settings.json` into a Tingly-specific launch artifact; it is not a
+link to, and never modifies, the user's original file. A named profile uses
+`<profileID>--<profileName>/`. Legacy names that are not filesystem-safe fall
+back to the stable ID-only directory until renamed.
+
+On every materialization, `settings.json` is rebuilt from the current local
+settings (or `{}` if the local file no longer exists), then receives the
+generated env and profile-local `statusline.sh` command. This reset is
+important: a previously generated artifact must never become an accidental
+second source of truth.
+
+Profile CRUD follows the same derived-artifact rule:
+
+- **Create/run:** materialize the current config into its computed directory.
+- **Rename:** materialize the new directory first; only after success remove
+  the old generated files. A case-only rename is guarded with `os.SameFile`
+  for case-insensitive filesystems.
+- **Delete:** remove only the known generated files (`settings.json` and
+  `statusline.sh`), then remove the directory if empty. User-added files are
+  preserved; cleanup never uses recursive deletion.
+- **Migration:** after a successful build, remove the old flat
+  `<profileID>.json`, `statusline-<profileID>.sh`, and an owned legacy name
+  symlink. No new links are created, so the layout works consistently across
+  macOS, Linux, and Windows.
+
+Artifact directories themselves must be real directories, not symlinks. Both
+write and cleanup paths reject a symlink at the computed profile directory so
+profile operations cannot escape `~/.tingly-box/claude/`.
 
 ---
 

--- a/internal/agent/cc_settings.go
+++ b/internal/agent/cc_settings.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -96,21 +94,22 @@ func GenerateCCEnv(cfg *serverconfig.Config, baseURL, apiKey, scenarioPath strin
 	return env
 }
 
-// BuildCCProfileSettings creates or updates the Claude Code profile settings
-// file at ~/.tingly-box/claude/<profileID>.json. It copies ~/.claude/settings.json
-// as a base (if it exists), installs the shared status line script, generates a
-// per-profile wrapper script, and merges the tingly env vars.
+// BuildCCProfileSettings materializes one derived Claude Code profile under
+// ~/.tingly-box/claude/. The local/default profile lives at default/, while a
+// named profile lives at <profileID>--<profileName>/ so both its stable identity
+// and human name are visible without aliases or platform-specific links.
 //
-// profileName, if non-empty and different from profileID, also gets a
-// human-readable symlink (e.g. ds.json -> p1.json) so the profile is
-// browsable by name, not just by its opaque ID. Pass "" to skip.
-//
-// Returns the path to the written file.
+// Config remains the source of truth. The directory contains only rebuildable
+// runtime artifacts: settings.json and its statusline.sh wrapper.
 func BuildCCProfileSettings(profileID, scenarioPath, profileName string, env map[string]string) (string, error) {
-	profileDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
-	destPath := filepath.Join(profileDir, profileID+".json")
+	rootDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
+	artifactDir, err := ccProfileArtifactDir(rootDir, profileID, profileName)
+	if err != nil {
+		return "", err
+	}
+	destPath := filepath.Join(artifactDir, "settings.json")
 
-	if err := os.MkdirAll(profileDir, 0755); err != nil {
+	if err := ensureCCProfileArtifactDir(artifactDir); err != nil {
 		return "", fmt.Errorf("failed to create profile directory: %w", err)
 	}
 
@@ -120,12 +119,17 @@ func BuildCCProfileSettings(profileID, scenarioPath, profileName string, env map
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
 	srcPath := filepath.Join(homeDir, ".claude", "settings.json")
-	if data, err := os.ReadFile(srcPath); err == nil {
-		if err := os.WriteFile(destPath, data, 0644); err != nil {
-			return "", fmt.Errorf("failed to copy user settings: %w", err)
-		}
-	} else if !os.IsNotExist(err) {
-		return "", fmt.Errorf("failed to read user settings: %w", err)
+	baseSettings := []byte("{}")
+	if data, readErr := os.ReadFile(srcPath); readErr == nil {
+		baseSettings = data
+	} else if !os.IsNotExist(readErr) {
+		return "", fmt.Errorf("failed to read user settings: %w", readErr)
+	}
+	// Always reset the derived file to the current local source (or an empty
+	// object when that source no longer exists) before applying profile values.
+	// This prevents generated artifacts from becoming a second source of truth.
+	if err := os.WriteFile(destPath, baseSettings, 0644); err != nil {
+		return "", fmt.Errorf("failed to copy user settings: %w", err)
 	}
 
 	// Install the base status line script (shared across profiles).
@@ -134,7 +138,7 @@ func BuildCCProfileSettings(profileID, scenarioPath, profileName string, env map
 	}
 
 	// Generate per-profile wrapper script that sets TINGLY_SCENARIO.
-	wrapperPath, err := buildCCProfileStatusLineScript(profileDir, profileID, scenarioPath)
+	wrapperPath, err := buildCCProfileStatusLineScript(artifactDir, profileID, scenarioPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create status line wrapper: %w", err)
 	}
@@ -152,90 +156,113 @@ func BuildCCProfileSettings(profileID, scenarioPath, profileName string, env map
 		return "", fmt.Errorf("failed to apply settings: %s", result.Message)
 	}
 
-	if err := syncProfileNameSymlink(profileDir, profileID, profileName, ""); err != nil {
-		// Non-fatal: the ID-named settings file is already usable; the alias is
-		// a convenience for browsing ~/.tingly-box/claude/.
-		logrus.WithError(err).Warn("failed to sync profile name symlink")
-	}
+	removeLegacyCCProfileArtifacts(rootDir, profileID, profileName)
 
 	return destPath, nil
 }
 
-// SyncProfileNameSymlink (re)points a human-readable symlink at the profile's
-// ID-named settings file, e.g. ~/.tingly-box/claude/ds.json -> p1.json, so the
-// profile is browsable by name instead of only by its opaque "p1" ID.
-//
-// name may be empty (unnamed/default profile) or equal to profileID (nothing
-// to alias) — both are no-ops. oldName, if non-empty and different from name,
-// has its stale symlink removed first (rename case).
-func SyncProfileNameSymlink(profileID, name, oldName string) error {
-	profileDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
-	return syncProfileNameSymlink(profileDir, profileID, name, oldName)
+func ccProfileArtifactDir(rootDir, profileID, profileName string) (string, error) {
+	if profileID == "default" {
+		return filepath.Join(rootDir, "default"), nil
+	}
+	if !typ.IsSimpleProfileAlias(profileID) {
+		return "", fmt.Errorf("invalid Claude Code profile ID %q", profileID)
+	}
+	if err := typ.ValidateProfileName(profileName); err != nil {
+		// Legacy names created before validation remain runnable from config, but
+		// use the stable ID-only directory until the user gives them a safe name.
+		return filepath.Join(rootDir, profileID), nil
+	}
+	return filepath.Join(rootDir, profileID+"--"+profileName), nil
 }
 
-func syncProfileNameSymlink(profileDir, profileID, name, oldName string) error {
-	target := profileID + ".json"
-
-	if oldName != "" && oldName != name {
-		removeProfileNameSymlink(profileDir, profileID, oldName)
+func ensureCCProfileArtifactDir(artifactDir string) error {
+	info, err := os.Lstat(artifactDir)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(artifactDir, 0755)
 	}
-
-	if name == "" || name == profileID {
-		return nil
+	if err != nil {
+		return err
 	}
-
-	linkPath := filepath.Join(profileDir, name+".json")
-
-	// If something already occupies linkPath and it isn't our symlink, leave it
-	// alone rather than clobbering an unrelated file.
-	if info, err := os.Lstat(linkPath); err == nil {
-		if info.Mode()&os.ModeSymlink == 0 {
-			return fmt.Errorf("cannot create profile symlink: %s already exists and is not a symlink", linkPath)
-		}
-		if existing, err := os.Readlink(linkPath); err == nil && existing == target {
-			return nil // already correct
-		}
-		if err := os.Remove(linkPath); err != nil {
-			return fmt.Errorf("failed to replace stale profile symlink: %w", err)
-		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to stat profile symlink: %w", err)
-	}
-
-	if err := os.Symlink(target, linkPath); err != nil {
-		return fmt.Errorf("failed to create profile symlink: %w", err)
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("profile artifact path is not a managed directory: %s", artifactDir)
 	}
 	return nil
 }
 
-// RemoveProfileNameSymlink removes the name-based symlink for a profile, if any.
-func RemoveProfileNameSymlink(profileID, name string) {
-	profileDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
-	removeProfileNameSymlink(profileDir, profileID, name)
+// RemoveCCProfileArtifacts removes only files generated by Tingly-Box for the
+// selected profile. If users added anything else to the directory, it is left
+// in place rather than recursively deleted.
+func RemoveCCProfileArtifacts(profileID, profileName string) error {
+	rootDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
+	return removeCCProfileArtifacts(rootDir, profileID, profileName)
 }
 
-func removeProfileNameSymlink(profileDir, profileID, name string) {
-	if name == "" || name == profileID {
+// RemoveRenamedCCProfileArtifacts removes the old derived directory after the
+// new one has been materialized. os.SameFile protects case-only renames on
+// case-insensitive filesystems, where both spellings identify the same path.
+func RemoveRenamedCCProfileArtifacts(profileID, oldName, newName string) error {
+	rootDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
+	return removeRenamedCCProfileArtifacts(rootDir, profileID, oldName, newName)
+}
+
+func removeRenamedCCProfileArtifacts(rootDir, profileID, oldName, newName string) error {
+	oldDir, oldErr := ccProfileArtifactDir(rootDir, profileID, oldName)
+	newDir, newErr := ccProfileArtifactDir(rootDir, profileID, newName)
+	if oldErr == nil && newErr == nil {
+		oldInfo, oldStatErr := os.Stat(oldDir)
+		newInfo, newStatErr := os.Stat(newDir)
+		if oldStatErr == nil && newStatErr == nil && os.SameFile(oldInfo, newInfo) {
+			return nil
+		}
+	}
+	return removeCCProfileArtifacts(rootDir, profileID, oldName)
+}
+
+func removeCCProfileArtifacts(rootDir, profileID, profileName string) error {
+	artifactDir, err := ccProfileArtifactDir(rootDir, profileID, profileName)
+	if err == nil {
+		if info, statErr := os.Lstat(artifactDir); statErr == nil && (info.Mode()&os.ModeSymlink != 0 || !info.IsDir()) {
+			return fmt.Errorf("refusing to clean unmanaged Claude Code profile path: %s", artifactDir)
+		} else if statErr != nil && !os.IsNotExist(statErr) {
+			return fmt.Errorf("failed to inspect Claude Code profile directory: %w", statErr)
+		}
+		for _, name := range []string{"settings.json", "statusline.sh"} {
+			if removeErr := os.Remove(filepath.Join(artifactDir, name)); removeErr != nil && !os.IsNotExist(removeErr) {
+				return fmt.Errorf("failed to remove Claude Code profile artifact %s: %w", name, removeErr)
+			}
+		}
+		if removeErr := os.Remove(artifactDir); removeErr != nil && !os.IsNotExist(removeErr) {
+			// A non-empty directory contains user files; preserving it is expected.
+			if entries, readErr := os.ReadDir(artifactDir); readErr != nil || len(entries) == 0 {
+				return fmt.Errorf("failed to remove Claude Code profile directory: %w", removeErr)
+			}
+		}
+	}
+
+	removeLegacyCCProfileArtifacts(rootDir, profileID, profileName)
+	return nil
+}
+
+func removeLegacyCCProfileArtifacts(rootDir, profileID, profileName string) {
+	_ = os.Remove(filepath.Join(rootDir, profileID+".json"))
+	_ = os.Remove(filepath.Join(rootDir, "statusline-"+profileID+".sh"))
+
+	if profileName == "" || !typ.IsSimpleProfileAlias(profileName) {
 		return
 	}
-	linkPath := filepath.Join(profileDir, name+".json")
-	info, err := os.Lstat(linkPath)
-	if err != nil {
-		return // nothing to remove
-	}
-	// Only remove it if it's actually a symlink pointing at this profile's
-	// settings file — never touch a real file that happens to share the name.
-	if info.Mode()&os.ModeSymlink == 0 {
+	aliasPath := filepath.Join(rootDir, profileName+".json")
+	info, err := os.Lstat(aliasPath)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
 		return
 	}
-	if target, err := os.Readlink(linkPath); err != nil || target != profileID+".json" {
-		return
+	if target, readErr := os.Readlink(aliasPath); readErr == nil && target == profileID+".json" {
+		_ = os.Remove(aliasPath)
 	}
-	_ = os.Remove(linkPath)
 }
 
 func buildCCProfileStatusLineScript(profileDir, profileID, scenarioPath string) (string, error) {
-	wrapperPath := filepath.Join(profileDir, fmt.Sprintf("statusline-%s.sh", profileID))
+	wrapperPath := filepath.Join(profileDir, "statusline.sh")
 
 	content := fmt.Sprintf("#!/bin/bash\n"+
 		"# Per-profile status line wrapper for Claude Code\n"+

--- a/internal/agent/cc_settings.go
+++ b/internal/agent/cc_settings.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -98,8 +100,13 @@ func GenerateCCEnv(cfg *serverconfig.Config, baseURL, apiKey, scenarioPath strin
 // file at ~/.tingly-box/claude/<profileID>.json. It copies ~/.claude/settings.json
 // as a base (if it exists), installs the shared status line script, generates a
 // per-profile wrapper script, and merges the tingly env vars.
+//
+// profileName, if non-empty and different from profileID, also gets a
+// human-readable symlink (e.g. ds.json -> p1.json) so the profile is
+// browsable by name, not just by its opaque ID. Pass "" to skip.
+//
 // Returns the path to the written file.
-func BuildCCProfileSettings(profileID, scenarioPath string, env map[string]string) (string, error) {
+func BuildCCProfileSettings(profileID, scenarioPath, profileName string, env map[string]string) (string, error) {
 	profileDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
 	destPath := filepath.Join(profileDir, profileID+".json")
 
@@ -145,7 +152,86 @@ func BuildCCProfileSettings(profileID, scenarioPath string, env map[string]strin
 		return "", fmt.Errorf("failed to apply settings: %s", result.Message)
 	}
 
+	if err := syncProfileNameSymlink(profileDir, profileID, profileName, ""); err != nil {
+		// Non-fatal: the ID-named settings file is already usable; the alias is
+		// a convenience for browsing ~/.tingly-box/claude/.
+		logrus.WithError(err).Warn("failed to sync profile name symlink")
+	}
+
 	return destPath, nil
+}
+
+// SyncProfileNameSymlink (re)points a human-readable symlink at the profile's
+// ID-named settings file, e.g. ~/.tingly-box/claude/ds.json -> p1.json, so the
+// profile is browsable by name instead of only by its opaque "p1" ID.
+//
+// name may be empty (unnamed/default profile) or equal to profileID (nothing
+// to alias) — both are no-ops. oldName, if non-empty and different from name,
+// has its stale symlink removed first (rename case).
+func SyncProfileNameSymlink(profileID, name, oldName string) error {
+	profileDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
+	return syncProfileNameSymlink(profileDir, profileID, name, oldName)
+}
+
+func syncProfileNameSymlink(profileDir, profileID, name, oldName string) error {
+	target := profileID + ".json"
+
+	if oldName != "" && oldName != name {
+		removeProfileNameSymlink(profileDir, profileID, oldName)
+	}
+
+	if name == "" || name == profileID {
+		return nil
+	}
+
+	linkPath := filepath.Join(profileDir, name+".json")
+
+	// If something already occupies linkPath and it isn't our symlink, leave it
+	// alone rather than clobbering an unrelated file.
+	if info, err := os.Lstat(linkPath); err == nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("cannot create profile symlink: %s already exists and is not a symlink", linkPath)
+		}
+		if existing, err := os.Readlink(linkPath); err == nil && existing == target {
+			return nil // already correct
+		}
+		if err := os.Remove(linkPath); err != nil {
+			return fmt.Errorf("failed to replace stale profile symlink: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat profile symlink: %w", err)
+	}
+
+	if err := os.Symlink(target, linkPath); err != nil {
+		return fmt.Errorf("failed to create profile symlink: %w", err)
+	}
+	return nil
+}
+
+// RemoveProfileNameSymlink removes the name-based symlink for a profile, if any.
+func RemoveProfileNameSymlink(profileID, name string) {
+	profileDir := filepath.Join(constant.GetTinglyConfDir(), "claude")
+	removeProfileNameSymlink(profileDir, profileID, name)
+}
+
+func removeProfileNameSymlink(profileDir, profileID, name string) {
+	if name == "" || name == profileID {
+		return
+	}
+	linkPath := filepath.Join(profileDir, name+".json")
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		return // nothing to remove
+	}
+	// Only remove it if it's actually a symlink pointing at this profile's
+	// settings file — never touch a real file that happens to share the name.
+	if info.Mode()&os.ModeSymlink == 0 {
+		return
+	}
+	if target, err := os.Readlink(linkPath); err != nil || target != profileID+".json" {
+		return
+	}
+	_ = os.Remove(linkPath)
 }
 
 func buildCCProfileStatusLineScript(profileDir, profileID, scenarioPath string) (string, error) {

--- a/internal/agent/cc_settings_test.go
+++ b/internal/agent/cc_settings_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
@@ -136,5 +138,140 @@ func TestGenerateCCEnv_MainScenario_ResolvesLegacyBuiltins(t *testing.T) {
 	// Missing rules keep the canonical tingly/* fallbacks.
 	if got := env["ANTHROPIC_MODEL"]; got != "tingly/cc-default" {
 		t.Errorf("default model = %q, want %q", got, "tingly/cc-default")
+	}
+}
+
+func TestSyncProfileNameSymlink_CreatesLink(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
+		t.Fatalf("syncProfileNameSymlink: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(dir, "ds.json"))
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != "p1.json" {
+		t.Errorf("ds.json -> %q, want %q", target, "p1.json")
+	}
+}
+
+func TestSyncProfileNameSymlink_NoOpWhenNameEmptyOrEqualsID(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := syncProfileNameSymlink(dir, "p1", "", ""); err != nil {
+		t.Fatalf("empty name: %v", err)
+	}
+	if err := syncProfileNameSymlink(dir, "p1", "p1", ""); err != nil {
+		t.Fatalf("name == id: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no files created, got %v", entries)
+	}
+}
+
+func TestSyncProfileNameSymlink_RenameRemovesOldLink(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := syncProfileNameSymlink(dir, "p1", "newname", "ds"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(dir, "ds.json")); !os.IsNotExist(err) {
+		t.Errorf("expected ds.json to be removed after rename, lstat err = %v", err)
+	}
+	target, err := os.Readlink(filepath.Join(dir, "newname.json"))
+	if err != nil {
+		t.Fatalf("readlink newname.json: %v", err)
+	}
+	if target != "p1.json" {
+		t.Errorf("newname.json -> %q, want %q", target, "p1.json")
+	}
+}
+
+func TestSyncProfileNameSymlink_DoesNotClobberRealFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// A real (non-symlink) file happens to occupy the alias name.
+	if err := os.WriteFile(filepath.Join(dir, "ds.json"), []byte(`{"real":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := syncProfileNameSymlink(dir, "p1", "ds", "")
+	if err == nil {
+		t.Fatal("expected error when alias name collides with a real file")
+	}
+
+	data, readErr := os.ReadFile(filepath.Join(dir, "ds.json"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != `{"real":true}` {
+		t.Errorf("real file content was modified: %s", data)
+	}
+}
+
+func TestSyncProfileNameSymlink_IdempotentWhenAlreadyCorrect(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
+		t.Fatalf("second sync (idempotent): %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(dir, "ds.json"))
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != "p1.json" {
+		t.Errorf("ds.json -> %q, want %q", target, "p1.json")
+	}
+}
+
+func TestRemoveProfileNameSymlink_OnlyRemovesOwnSymlink(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	removeProfileNameSymlink(dir, "p1", "ds")
+
+	if _, err := os.Lstat(filepath.Join(dir, "ds.json")); !os.IsNotExist(err) {
+		t.Errorf("expected ds.json removed, lstat err = %v", err)
+	}
+
+	// Removing again (already gone) and removing a name that maps to a real
+	// file must not error or delete unrelated files.
+	if err := os.WriteFile(filepath.Join(dir, "other.json"), []byte(`{"real":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	removeProfileNameSymlink(dir, "p1", "other")
+	if _, err := os.Lstat(filepath.Join(dir, "other.json")); err != nil {
+		t.Errorf("real file should not have been removed: %v", err)
 	}
 }

--- a/internal/agent/cc_settings_test.go
+++ b/internal/agent/cc_settings_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,42 @@ import (
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readJSONMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func requirePathMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected path to be absent: %s (err = %v)", path, err)
+	}
+}
+
+func writeGeneratedArtifacts(t *testing.T, dir string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(dir, "settings.json"), "generated")
+	writeTestFile(t, filepath.Join(dir, "statusline.sh"), "generated")
+}
 
 func TestGenerateCCEnv_ProfileSeparate_ResolvesModelsFromCanonicalRules(t *testing.T) {
 	cfg := &serverconfig.Config{Rules: []typ.Rule{
@@ -141,137 +178,185 @@ func TestGenerateCCEnv_MainScenario_ResolvesLegacyBuiltins(t *testing.T) {
 	}
 }
 
-func TestSyncProfileNameSymlink_CreatesLink(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
+func TestCCProfileArtifactDir(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name        string
+		profileID   string
+		profileName string
+		want        string
+		wantErr     bool
+	}{
+		{name: "local default", profileID: "default", want: filepath.Join(root, "default")},
+		{name: "named profile", profileID: "p1", profileName: "work", want: filepath.Join(root, "p1--work")},
+		{name: "unsafe legacy name falls back to ID", profileID: "p1", profileName: "../legacy", want: filepath.Join(root, "p1")},
+		{name: "unsafe ID rejected", profileID: "../p1", profileName: "work", wantErr: true},
 	}
 
-	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
-		t.Fatalf("syncProfileNameSymlink: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ccProfileArtifactDir(root, tt.profileID, tt.profileName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("artifact dir = %q, want %q", got, tt.want)
+			}
+		})
 	}
+}
 
-	target, err := os.Readlink(filepath.Join(dir, "ds.json"))
+func TestBuildCCProfileSettings_MaterializesReadableDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	localClaudeDir := filepath.Join(home, ".claude")
+	writeTestFile(t, filepath.Join(localClaudeDir, "settings.json"), `{"theme":"dark"}`)
+
+	root := filepath.Join(home, ".tingly-box", "claude")
+	for _, path := range []string{filepath.Join(root, "p1.json"), filepath.Join(root, "statusline-p1.sh")} {
+		writeTestFile(t, path, "legacy")
+	}
+	legacyAliasPath := filepath.Join(root, "work.json")
+	legacyAliasCreated := os.Symlink("p1.json", legacyAliasPath) == nil
+
+	settingsPath, err := BuildCCProfileSettings("p1", "claude_code:p1", "work", map[string]string{"TINGLY_TEST": "yes"})
 	if err != nil {
-		t.Fatalf("readlink: %v", err)
+		t.Fatal(err)
 	}
-	if target != "p1.json" {
-		t.Errorf("ds.json -> %q, want %q", target, "p1.json")
-	}
-}
-
-func TestSyncProfileNameSymlink_NoOpWhenNameEmptyOrEqualsID(t *testing.T) {
-	dir := t.TempDir()
-
-	if err := syncProfileNameSymlink(dir, "p1", "", ""); err != nil {
-		t.Fatalf("empty name: %v", err)
-	}
-	if err := syncProfileNameSymlink(dir, "p1", "p1", ""); err != nil {
-		t.Fatalf("name == id: %v", err)
+	wantPath := filepath.Join(root, "p1--work", "settings.json")
+	if settingsPath != wantPath {
+		t.Fatalf("settings path = %q, want %q", settingsPath, wantPath)
 	}
 
-	entries, err := os.ReadDir(dir)
+	settings := readJSONMap(t, settingsPath)
+	if settings["theme"] != "dark" {
+		t.Errorf("local setting was not preserved: %#v", settings)
+	}
+	env, ok := settings["env"].(map[string]any)
+	if !ok || env["TINGLY_TEST"] != "yes" {
+		t.Errorf("generated env missing: %#v", settings["env"])
+	}
+	statusLine, ok := settings["statusLine"].(map[string]any)
+	if !ok || statusLine["command"] != filepath.Join(root, "p1--work", "statusline.sh") {
+		t.Errorf("status line does not point inside profile directory: %#v", settings["statusLine"])
+	}
+	for _, legacyPath := range []string{filepath.Join(root, "p1.json"), filepath.Join(root, "statusline-p1.sh")} {
+		requirePathMissing(t, legacyPath)
+	}
+	if legacyAliasCreated {
+		requirePathMissing(t, legacyAliasPath)
+	}
+
+	defaultPath, err := BuildCCProfileSettings("default", "claude_code", "", map[string]string{"TINGLY_DEFAULT": "yes"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 0 {
-		t.Errorf("expected no files created, got %v", entries)
+	if want := filepath.Join(root, "default", "settings.json"); defaultPath != want {
+		t.Errorf("default settings path = %q, want %q", defaultPath, want)
+	}
+
+	if err := os.Remove(filepath.Join(localClaudeDir, "settings.json")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildCCProfileSettings("default", "claude_code", "", map[string]string{"TINGLY_DEFAULT": "refreshed"}); err != nil {
+		t.Fatal(err)
+	}
+	settings = readJSONMap(t, defaultPath)
+	if _, exists := settings["theme"]; exists {
+		t.Errorf("removed local settings leaked from an older generated artifact: %#v", settings)
 	}
 }
 
-func TestSyncProfileNameSymlink_RenameRemovesOldLink(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+func TestRemoveCCProfileArtifacts_PreservesUserFiles(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := filepath.Join(root, "p1--work")
+	writeGeneratedArtifacts(t, artifactDir)
+	writeTestFile(t, filepath.Join(artifactDir, "notes.txt"), "user-owned")
+	for _, path := range []string{filepath.Join(root, "p1.json"), filepath.Join(root, "statusline-p1.sh")} {
+		writeTestFile(t, path, "legacy")
+	}
+
+	if err := removeCCProfileArtifacts(root, "p1", "work"); err != nil {
 		t.Fatal(err)
 	}
-
-	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
-		t.Fatalf("create: %v", err)
+	for _, name := range []string{"settings.json", "statusline.sh"} {
+		requirePathMissing(t, filepath.Join(artifactDir, name))
 	}
-	if err := syncProfileNameSymlink(dir, "p1", "newname", "ds"); err != nil {
-		t.Fatalf("rename: %v", err)
+	if _, err := os.Stat(filepath.Join(artifactDir, "notes.txt")); err != nil {
+		t.Errorf("user file should be preserved: %v", err)
 	}
-
-	if _, err := os.Lstat(filepath.Join(dir, "ds.json")); !os.IsNotExist(err) {
-		t.Errorf("expected ds.json to be removed after rename, lstat err = %v", err)
-	}
-	target, err := os.Readlink(filepath.Join(dir, "newname.json"))
-	if err != nil {
-		t.Fatalf("readlink newname.json: %v", err)
-	}
-	if target != "p1.json" {
-		t.Errorf("newname.json -> %q, want %q", target, "p1.json")
+	for _, legacyPath := range []string{filepath.Join(root, "p1.json"), filepath.Join(root, "statusline-p1.sh")} {
+		requirePathMissing(t, legacyPath)
 	}
 }
 
-func TestSyncProfileNameSymlink_DoesNotClobberRealFile(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+func TestRemoveCCProfileArtifacts_RemovesEmptyDirectory(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := filepath.Join(root, "p1--work")
+	writeGeneratedArtifacts(t, artifactDir)
+
+	if err := removeCCProfileArtifacts(root, "p1", "work"); err != nil {
 		t.Fatal(err)
 	}
-	// A real (non-symlink) file happens to occupy the alias name.
-	if err := os.WriteFile(filepath.Join(dir, "ds.json"), []byte(`{"real":true}`), 0644); err != nil {
-		t.Fatal(err)
-	}
+	requirePathMissing(t, artifactDir)
+}
 
-	err := syncProfileNameSymlink(dir, "p1", "ds", "")
-	if err == nil {
-		t.Fatal("expected error when alias name collides with a real file")
+func TestProfileArtifactOperations_RejectSymlinkDirectory(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	artifactDir := filepath.Join(root, "p1--work")
+	if err := os.Symlink(outside, artifactDir); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
 	}
+	outsideSettings := filepath.Join(outside, "settings.json")
+	writeTestFile(t, outsideSettings, "outside")
 
-	data, readErr := os.ReadFile(filepath.Join(dir, "ds.json"))
-	if readErr != nil {
-		t.Fatal(readErr)
+	if err := ensureCCProfileArtifactDir(artifactDir); err == nil {
+		t.Fatal("expected symlink artifact directory to be rejected for writes")
 	}
-	if string(data) != `{"real":true}` {
-		t.Errorf("real file content was modified: %s", data)
+	if err := removeCCProfileArtifacts(root, "p1", "work"); err == nil {
+		t.Fatal("expected symlink artifact directory to be rejected for cleanup")
+	}
+	if data, err := os.ReadFile(outsideSettings); err != nil || string(data) != "outside" {
+		t.Fatalf("outside file was changed: data = %q, err = %v", data, err)
 	}
 }
 
-func TestSyncProfileNameSymlink_IdempotentWhenAlreadyCorrect(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+func TestRemoveRenamedCCProfileArtifacts_PreservesSameDirectory(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := filepath.Join(root, "p1--work")
+	settingsPath := filepath.Join(artifactDir, "settings.json")
+	writeTestFile(t, settingsPath, "generated")
+
+	if err := removeRenamedCCProfileArtifacts(root, "p1", "work", "work"); err != nil {
 		t.Fatal(err)
 	}
-
-	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
-		t.Fatalf("first sync: %v", err)
-	}
-	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
-		t.Fatalf("second sync (idempotent): %v", err)
-	}
-
-	target, err := os.Readlink(filepath.Join(dir, "ds.json"))
-	if err != nil {
-		t.Fatalf("readlink: %v", err)
-	}
-	if target != "p1.json" {
-		t.Errorf("ds.json -> %q, want %q", target, "p1.json")
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Fatalf("same artifact directory should be preserved: %v", err)
 	}
 }
 
-func TestRemoveProfileNameSymlink_OnlyRemovesOwnSymlink(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "p1.json"), []byte("{}"), 0644); err != nil {
+func TestRemoveRenamedCCProfileArtifacts_RemovesOnlyOldDirectory(t *testing.T) {
+	root := t.TempDir()
+	oldDir := filepath.Join(root, "p1--old")
+	newDir := filepath.Join(root, "p1--new")
+	for _, dir := range []string{oldDir, newDir} {
+		writeGeneratedArtifacts(t, dir)
+	}
+
+	if err := removeRenamedCCProfileArtifacts(root, "p1", "old", "new"); err != nil {
 		t.Fatal(err)
 	}
-	if err := syncProfileNameSymlink(dir, "p1", "ds", ""); err != nil {
-		t.Fatalf("create: %v", err)
-	}
-
-	removeProfileNameSymlink(dir, "p1", "ds")
-
-	if _, err := os.Lstat(filepath.Join(dir, "ds.json")); !os.IsNotExist(err) {
-		t.Errorf("expected ds.json removed, lstat err = %v", err)
-	}
-
-	// Removing again (already gone) and removing a name that maps to a real
-	// file must not error or delete unrelated files.
-	if err := os.WriteFile(filepath.Join(dir, "other.json"), []byte(`{"real":true}`), 0644); err != nil {
-		t.Fatal(err)
-	}
-	removeProfileNameSymlink(dir, "p1", "other")
-	if _, err := os.Lstat(filepath.Join(dir, "other.json")); err != nil {
-		t.Errorf("real file should not have been removed: %v", err)
+	requirePathMissing(t, oldDir)
+	if _, err := os.Stat(filepath.Join(newDir, "settings.json")); err != nil {
+		t.Fatalf("new directory should be preserved: %v", err)
 	}
 }

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -104,7 +104,11 @@ func runCC(appManager *AppManager, profile string, portOverride int, claudeArgs 
 	if settingsID == "" {
 		settingsID = "default"
 	}
-	settingsPath, err := agent.BuildCCProfileSettings(settingsID, scenarioPath, env)
+	profileName := ""
+	if profileMeta != nil {
+		profileName = profileMeta.Name
+	}
+	settingsPath, err := agent.BuildCCProfileSettings(settingsID, scenarioPath, profileName, env)
 	if err != nil {
 		return err
 	}

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -281,7 +281,7 @@ func TestCreateProfile_RejectsNonURLFriendlyName(t *testing.T) {
 	}
 	scenario := typ.RuleScenario("claude_code")
 
-	for _, bad := range []string{"my profile", "a:b", "a/b", "", " mine", "p1", "p07"} {
+	for _, bad := range []string{"my profile", "a:b", "a/b", "", " mine", "default", "DEFAULT", "p1", "p07"} {
 		if _, err := cfg.CreateProfile(scenario, bad, true); err == nil {
 			t.Errorf("CreateProfile(%q) = nil error, want rejection", bad)
 		}

--- a/internal/server/module/scenario/handler.go
+++ b/internal/server/module/scenario/handler.go
@@ -527,13 +527,21 @@ func (h *Handler) UpdateProfile(c *gin.Context) {
 		return
 	}
 
-	// Repoint the name-based symlink to match the new name; harmless no-op if
-	// the name didn't change.
-	if err := agent.SyncProfileNameSymlink(profileID, req.Name, oldName); err != nil {
-		logrus.WithError(err).Warn("failed to sync profile name symlink after rename")
+	updated, _ := h.config.GetProfile(scenario, profileID)
+	if req.Name != oldName {
+		// Profile directories are derived from config, so materialize the new
+		// canonical path first and only then remove the old generated artifacts.
+		profiledScenario := string(typ.ProfiledScenarioName(scenario, profileID))
+		baseURL := middleware.BaseURLFromRequest(c, h.config.GetServerPort())
+		apiKey := h.config.GetModelToken()
+		env := agent.GenerateCCEnv(h.config, baseURL, apiKey, profiledScenario, updated.Unified, true)
+		if _, settingsErr := agent.BuildCCProfileSettings(profileID, profiledScenario, updated.Name, env); settingsErr != nil {
+			logrus.WithError(settingsErr).Warn("failed to rebuild Claude Code settings after profile rename")
+		} else if cleanupErr := agent.RemoveRenamedCCProfileArtifacts(profileID, oldName, updated.Name); cleanupErr != nil {
+			logrus.WithError(cleanupErr).Warn("failed to clean old Claude Code profile artifacts after rename")
+		}
 	}
 
-	updated, _ := h.config.GetProfile(scenario, profileID)
 	c.JSON(http.StatusOK, gin.H{"success": true, "message": "profile updated", "data": updated})
 }
 
@@ -554,7 +562,8 @@ func (h *Handler) DeleteProfile(c *gin.Context) {
 		return
 	}
 
-	// Capture the name before deletion so we can clean up its symlink.
+	// Capture the name before deletion so the derived runtime artifacts can be
+	// removed after their source-of-truth config is deleted.
 	profileName := ""
 	if existing, ok := h.config.GetProfile(scenario, profileID); ok {
 		profileName = existing.Name
@@ -565,7 +574,9 @@ func (h *Handler) DeleteProfile(c *gin.Context) {
 		return
 	}
 
-	agent.RemoveProfileNameSymlink(profileID, profileName)
+	if cleanupErr := agent.RemoveCCProfileArtifacts(profileID, profileName); cleanupErr != nil {
+		logrus.WithError(cleanupErr).Warn("failed to clean Claude Code profile artifacts after delete")
+	}
 
 	c.JSON(http.StatusOK, gin.H{"success": true, "message": "profile deleted"})
 }

--- a/internal/server/module/scenario/handler.go
+++ b/internal/server/module/scenario/handler.go
@@ -481,7 +481,7 @@ func (h *Handler) CreateProfile(c *gin.Context) {
 	baseURL := middleware.BaseURLFromRequest(c, h.config.GetServerPort())
 	apiKey := h.config.GetModelToken()
 	env := agent.GenerateCCEnv(h.config, baseURL, apiKey, profiledScenario, meta.Unified, true)
-	if _, settingsErr := agent.BuildCCProfileSettings(meta.ID, profiledScenario, env); settingsErr != nil {
+	if _, settingsErr := agent.BuildCCProfileSettings(meta.ID, profiledScenario, meta.Name, env); settingsErr != nil {
 		logrus.WithError(settingsErr).Warn("failed to create Claude Code settings for new profile")
 	}
 
@@ -512,18 +512,25 @@ func (h *Handler) UpdateProfile(c *gin.Context) {
 	}
 
 	// If name is not provided, preserve existing profile name
+	existing, ok := h.config.GetProfile(scenario, profileID)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "profile not found"})
+		return
+	}
+	oldName := existing.Name
 	if req.Name == "" {
-		existing, ok := h.config.GetProfile(scenario, profileID)
-		if !ok {
-			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "profile not found"})
-			return
-		}
 		req.Name = existing.Name
 	}
 
 	if err := h.config.UpdateProfile(scenario, profileID, req.Name, req.Unified); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
 		return
+	}
+
+	// Repoint the name-based symlink to match the new name; harmless no-op if
+	// the name didn't change.
+	if err := agent.SyncProfileNameSymlink(profileID, req.Name, oldName); err != nil {
+		logrus.WithError(err).Warn("failed to sync profile name symlink after rename")
 	}
 
 	updated, _ := h.config.GetProfile(scenario, profileID)
@@ -547,10 +554,18 @@ func (h *Handler) DeleteProfile(c *gin.Context) {
 		return
 	}
 
+	// Capture the name before deletion so we can clean up its symlink.
+	profileName := ""
+	if existing, ok := h.config.GetProfile(scenario, profileID); ok {
+		profileName = existing.Name
+	}
+
 	if err := h.config.DeleteProfile(scenario, profileID); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
 		return
 	}
+
+	agent.RemoveProfileNameSymlink(profileID, profileName)
 
 	c.JSON(http.StatusOK, gin.H{"success": true, "message": "profile deleted"})
 }

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -290,14 +290,17 @@ func looksLikeProfileID(name string) bool {
 // the constraint to the write path is the primary defense: every stored
 // profile is then guaranteed routable by name, and IsSimpleProfileAlias on the
 // routing path only has to guard legacy data created before this check. The
-// "p"<digits> shape is additionally reserved here so a name can never collide
-// with the auto-generated ID namespace.
+// "default" and the "p"<digits> ID shape are additionally reserved so user
+// names cannot collide with system-managed profile identities.
 func ValidateProfileName(name string) error {
 	if name == "" {
 		return fmt.Errorf("profile name must not be empty")
 	}
 	if !IsSimpleProfileAlias(name) {
 		return fmt.Errorf("profile name %q must contain only letters, digits, '-' and '_' so it can be used directly in a route like '/tingly/<scenario>:%s'", name, name)
+	}
+	if strings.EqualFold(name, "default") {
+		return fmt.Errorf("profile name %q is reserved for the local default profile", name)
 	}
 	if looksLikeProfileID(name) {
 		return fmt.Errorf("profile name %q is reserved: it has the shape of an auto-generated profile ID — choose a different name", name)

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -209,6 +209,8 @@ func TestValidateProfileName(t *testing.T) {
 
 	invalid := []string{
 		"",           // empty
+		"default",    // reserved settings filename
+		"DEFAULT",    // reserved on case-insensitive filesystems
 		"my profile", // space
 		"a:b",        // separator
 		"a/b",        // path separator


### PR DESCRIPTION
## Summary

Claude Code profile artifacts previously exposed only internal profile IDs, making configurations difficult to identify and leaving generated files inconsistent after profile renames or deletion. Profiles are now materialized as readable, safely managed runtime artifacts derived from the current configuration.

## Key Changes

- **Readable profile directories**: Profile artifacts use `<profile-id>--<profile-name>` directories such as `p1--deepseek`, preserving both stable identity and a recognizable name.

- **Complete profile lifecycle**: Creating a profile materializes its settings, renaming builds the new directory before cleaning the old one, and deletion removes the corresponding managed artifacts.

- **Deterministic configuration**: Every materialization starts from the current `~/.claude/settings.json`, preventing stale generated files from becoming a second source of truth.

- **Safe cleanup and migration**: Legacy flat files are migrated automatically, user-added files are preserved, and symlinked artifact directories are rejected to prevent writes or cleanup outside the managed location.

- **Collision-free naming**: `default`, including case-insensitive variants, is reserved for the local default profile so named profiles cannot conflict with system-managed artifacts.

## Testing

- **Artifact lifecycle coverage**: Tests cover readable directory generation, local-setting refresh, legacy migration, rename and deletion behavior, user-file preservation, reserved names, and symlink escape protection.
