### PR TITLE
feat(cli): Runtime port file - CLI auto-detects the live server port, and a real restart

### DIFF
--- a/.design/runtime-port-file.md
+++ b/.design/runtime-port-file.md
@@ -1,0 +1,41 @@
+# Runtime Port File
+
+## Problem
+
+The server port is intentionally **not persisted** in the config file
+(`Config.ServerPort` is `json:"-"`): starting with `--port 9000` must not
+silently rewrite the user's long-term configuration. The flip side is that
+other CLI processes (`cc`, `profile`, `log`, `status`, `open`) resolve the
+port from config and get the default (12580) — so after
+`tingly-box start --port 9000`, `tingly-box profile p1` connects to the wrong
+port unless the user remembers to repeat `--port 9000` every time.
+
+## Decision
+
+Treat the live port as a **runtime artifact, not configuration** — exactly
+like the PID lock file:
+
+- On startup, right after acquiring the PID lock, the server writes
+  `<configDir>/tingly-server.port` containing the actual listening port
+  (`pkg/lock.PortFile`, atomic temp-file + rename write).
+- On every shutdown path (signal, web-UI stop, server error, hook failure,
+  daemonize failure) the file is removed alongside the lock release.
+- Readers go through `AppManager.GetRuntimeServerPort()`:
+  1. explicit `--port` flag always wins (handled at each call site);
+  2. if the PID lock is held (server running) and the port file is readable,
+     use the recorded port;
+  3. otherwise fall back to `GetServerPort()` (config / 12580 default).
+
+## Staleness
+
+A crashed server (SIGKILL) leaves the port file behind, but the flock is
+always released by the OS. Readers therefore **must gate on
+`FileLock.IsLocked()`** before trusting the port file; a stale file with no
+lock held is ignored. The next successful start overwrites it.
+
+## Scope
+
+Only cross-process CLI readers use the runtime port. In-process consumers
+(the server itself, TUI quickstart that starts the server in-process, GUI
+wails service) already hold the correct port in the in-memory config and are
+unchanged.

--- a/.design/runtime-port-file.md
+++ b/.design/runtime-port-file.md
@@ -42,6 +42,34 @@ Binding a port and reading the runtime port are kept separate:
   override it, so the otherwise-invisible sticky port is surfaced. To return
   to the default, `stop` then `start`.
 
+### Daemon mode
+
+`Daemonize()` backgrounds the server by re-exec'ing the process with its own
+`os.Args`. A port the parent *resolved* (a preserved `restart` port, or a
+config port) is not on that command line, so the detached child would
+re-resolve and drift back to the default. The parent therefore pins the
+resolved port by appending `--port <n>` to the child's args; the CLI parser
+takes the last occurrence, so it wins without stripping any earlier value.
+
+## Behavior matrix
+
+| Command | Server state | Resulting port | Reads port file |
+| --- | --- | --- | :---: |
+| `start` | stopped | config → 12580 | no |
+| `start --port N` | stopped | **N** | no |
+| `start` | running | reports "already running" (shows live port) | display only |
+| `restart` | running on X | **continues on X** | yes (before stop) |
+| `restart --port N` | running on X | **N** | no |
+| `restart` | stopped | config → 12580 | no |
+| `restart --daemon` (bare) | running on X | **continues on X** | yes |
+| `stop` + `start` | — | config → 12580 | no |
+| `cc` / `profile` / `log` / `status` / `open` | running on X | **X** while lock held, else config | yes |
+| any | stale file, not running | config → 12580 | ignored |
+
+Invariant: an explicit `--port` always wins; binding never reads the port
+file; only readers and `restart` continuation do, and only while the lock is
+held.
+
 ## Staleness
 
 A crashed server (SIGKILL) leaves the port file behind, but the flock is

--- a/.design/runtime-port-file.md
+++ b/.design/runtime-port-file.md
@@ -26,6 +26,22 @@ like the PID lock file:
      use the recorded port;
   3. otherwise fall back to `GetServerPort()` (config / 12580 default).
 
+## Start vs. restart
+
+Binding a port and reading the runtime port are kept separate:
+
+- **`start` (and a `start` on a stopped box)** resolves its port purely from
+  `--port` → config → 12580. It never consults the port file, so a fresh
+  start is predictable and a stale file from a crash can't resurrect an old
+  port.
+- **`restart`** is a *real* restart: a bare `restart` continues on the port
+  the server is actually running on (read from the port file **before**
+  stopping, since stop removes it), instead of silently relocating to the
+  config default and breaking clients pointed at the live port. An explicit
+  `--port` still wins. Restart prints the port it continues on and how to
+  override it, so the otherwise-invisible sticky port is surfaced. To return
+  to the default, `stop` then `start`.
+
 ## Staleness
 
 A crashed server (SIGKILL) leaves the port file behind, but the flock is

--- a/internal/command/app_manager.go
+++ b/internal/command/app_manager.go
@@ -232,9 +232,9 @@ func (am *AppManager) GetServerPort() int {
 // file is readable, that port wins; otherwise this falls back to the
 // configured port.
 func (am *AppManager) GetRuntimeServerPort() int {
-	configDir := am.appConfig.ConfigDir()
-	if lock.NewFileLock(configDir).IsLocked() {
-		if port, err := lock.NewPortFile(configDir).Read(); err == nil {
+	fileLock := lock.NewFileLock(am.appConfig.ConfigDir())
+	if fileLock.IsLocked() {
+		if port, err := fileLock.ReadPort(); err == nil {
 			return port
 		}
 	}

--- a/internal/command/app_manager.go
+++ b/internal/command/app_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/server"
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
+	"github.com/tingly-dev/tingly-box/pkg/lock"
 )
 
 // AppManager manages all application state and operations.
@@ -220,6 +221,23 @@ func (am *AppManager) GetRuleByUUID(uuid string) *typ.Rule {
 
 // GetServerPort returns the configured server port.
 func (am *AppManager) GetServerPort() int {
+	return am.appConfig.GetServerPort()
+}
+
+// GetRuntimeServerPort returns the port the running server is actually
+// listening on. The server port is intentionally not persisted in the config
+// file, so a server started with --port would be invisible to other CLI
+// processes; the server therefore records its port in a runtime port file
+// next to the PID lock. When the server is running (lock held) and the port
+// file is readable, that port wins; otherwise this falls back to the
+// configured port.
+func (am *AppManager) GetRuntimeServerPort() int {
+	configDir := am.appConfig.ConfigDir()
+	if lock.NewFileLock(configDir).IsLocked() {
+		if port, err := lock.NewPortFile(configDir).Read(); err == nil {
+			return port
+		}
+	}
 	return am.appConfig.GetServerPort()
 }
 

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -20,7 +20,7 @@ import (
 // to Claude Code so users do not need to insert a literal '--'.
 type CCmdKong struct {
 	Profile string   `kong:"flag,name='profile',help='Claude Code profile to use'"`
-	Port    int      `kong:"flag,name='port',help='Tingly-Box server port (default: from config or 12580)'"`
+	Port    int      `kong:"flag,name='port',help='Tingly-Box server port (default: detected from running server, else config or 12580)'"`
 	Args    []string `kong:"arg,optional,passthrough='all',help='Additional arguments to pass to Claude Code (e.g., --model opus)'"`
 }
 
@@ -72,10 +72,12 @@ func runCC(appManager *AppManager, profile string, portOverride int, claudeArgs 
 		scenarioPath = string(typ.ProfiledScenarioName(scenario, profileID))
 	}
 
-	// Build base URL and token
+	// Build base URL and token. Without an explicit --port, prefer the port
+	// the running server actually listens on (runtime port file) over the
+	// configured default, so `--port` at server start doesn't need repeating.
 	port := portOverride
 	if port == 0 {
-		port = appManager.GetServerPort()
+		port = appManager.GetRuntimeServerPort()
 	}
 	if port == 0 {
 		port = 12580

--- a/internal/command/log.go
+++ b/internal/command/log.go
@@ -49,7 +49,7 @@ func (l *LogCmdKong) Run(appManager *AppManager) error {
 
 	port := l.Port
 	if port == 0 {
-		port = appConfig.GetServerPort()
+		port = appManager.GetRuntimeServerPort()
 	}
 	host := l.Host
 	if host == "" {

--- a/internal/command/profile_command.go
+++ b/internal/command/profile_command.go
@@ -30,7 +30,7 @@ import (
 type ProfileCmdKong struct {
 	List      bool     `kong:"flag,name='list',help='List all profiles (non-interactive)'"`
 	Show      bool     `kong:"flag,name='show',help='Show profile details instead of launching'"`
-	Port      int      `kong:"flag,name='port',help='Connect to tingly-box on the specified port (default: from config)'"`
+	Port      int      `kong:"flag,name='port',help='Connect to tingly-box on the specified port (default: detected from running server, else config)'"`
 	ProfileID string   `kong:"arg,optional,help='Profile name or ID to launch Claude Code with'"`
 	Args      []string `kong:"arg,optional,passthrough='all',help='Additional arguments to pass to Claude Code (e.g., --model opus)'"`
 }

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -123,7 +124,7 @@ func (o *OpenCmdKong) Run(appManager *AppManager) error {
 	fileLock := lock.NewFileLock(appConfig.ConfigDir())
 
 	if fileLock.IsLocked() {
-		port := appConfig.GetServerPort()
+		port := appManager.GetRuntimeServerPort()
 		globalConfig := appManager.GetGlobalConfig()
 
 		host := opts.Host
@@ -203,7 +204,7 @@ func runStatusCmd(appManager *AppManager) error {
 	fmt.Printf("Server Status: ")
 	if serverRunning {
 		fmt.Printf("Running\n")
-		port := appConfig.GetServerPort()
+		port := appManager.GetRuntimeServerPort()
 		fmt.Printf("Port: %d\n", port)
 		fmt.Printf("OpenAI Style API Endpoint: http://localhost:%d/tingly/openai/v1/chat/completions\n", port)
 		fmt.Printf("Anthropic Style API Endpoint: http://localhost:%d/tingly/anthropic/v1/messages\n", port)
@@ -491,7 +492,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 
 	// Check if server is already running using file lock (BEFORE port check)
 	if fileLock.IsLocked() {
-		fmt.Printf("Server is already running on port %d\n", port)
+		fmt.Printf("Server is already running on port %d\n", appManager.GetRuntimeServerPort())
 		fmt.Println("Use 'tingly-box restart' to restart the server")
 		fmt.Println("Use 'tingly-box stop' to stop it")
 
@@ -531,6 +532,14 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 	}
 	fmt.Printf("Lock acquired: %s\n", fileLock.GetLockFilePath())
 
+	// Record the actual listening port next to the PID lock so other CLI
+	// processes (cc/profile/log/status/open) can discover it — the port is
+	// intentionally not persisted in the config file.
+	portFile := lock.NewPortFile(appConfig.ConfigDir())
+	if err := portFile.Write(port); err != nil {
+		logrus.Warnf("Failed to record server port: %v", err)
+	}
+
 	serverManager := NewServerManager(
 		appConfig,
 		server.WithDebug(opts.EnableDebug),
@@ -547,6 +556,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 			continue
 		}
 		if err := hook(serverManager); err != nil {
+			_ = portFile.Remove()
 			fileLock.Unlock()
 			return err
 		}
@@ -572,6 +582,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 		if !daemon.IsDaemonProcess() {
 			// Fork and detach - this call exits the parent process
 			if err := daemon.Daemonize(); err != nil {
+				_ = portFile.Remove()
 				fileLock.Unlock()
 				return fmt.Errorf("failed to daemonize: %w", err)
 			}
@@ -591,16 +602,19 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 	select {
 	case err := <-serverErr:
 		// Release lock on error
+		_ = portFile.Remove()
 		fileLock.Unlock()
 		return fmt.Errorf("server stopped unexpectedly: %w", err)
 	case <-sigChan:
 		fmt.Println("\nReceived shutdown signal, stopping server...")
 		// Release lock on shutdown
+		_ = portFile.Remove()
 		fileLock.Unlock()
 		return serverManager.Stop()
 	case <-server.GetShutdownChannel():
 		fmt.Println("\nReceived stop request from web UI, stopping server...")
 		// Release lock on shutdown
+		_ = portFile.Remove()
 		fileLock.Unlock()
 		return serverManager.Stop()
 	}
@@ -615,6 +629,13 @@ func CreateAppManagerForDir(configDir string) (*AppManager, error) {
 		return nil, fmt.Errorf("failed to create app config for directory %s: %w", configDir, err)
 	}
 	return NewAppManagerWithConfig(appConfig), nil
+}
+
+// removeRuntimePortFile removes the runtime port file that lives next to the
+// given PID lock. Used by the stopping process after the lock is released,
+// when the server was killed without a chance to clean up itself.
+func removeRuntimePortFile(fileLock *lock.FileLock) {
+	_ = lock.NewPortFile(filepath.Dir(fileLock.GetLockFilePath())).Remove()
 }
 
 // doStopServerWithFileLock stops the server using the provided file lock

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -534,9 +533,10 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 
 	// Record the actual listening port next to the PID lock so other CLI
 	// processes (cc/profile/log/status/open) can discover it — the port is
-	// intentionally not persisted in the config file.
-	portFile := lock.NewPortFile(appConfig.ConfigDir())
-	if err := portFile.Write(port); err != nil {
+	// intentionally not persisted in the config file. The lock owns this
+	// runtime artifact and removes it on Unlock, so no per-exit-path cleanup
+	// is needed here.
+	if err := fileLock.WritePort(port); err != nil {
 		logrus.Warnf("Failed to record server port: %v", err)
 	}
 
@@ -556,7 +556,6 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 			continue
 		}
 		if err := hook(serverManager); err != nil {
-			_ = portFile.Remove()
 			fileLock.Unlock()
 			return err
 		}
@@ -582,7 +581,6 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 		if !daemon.IsDaemonProcess() {
 			// Fork and detach - this call exits the parent process
 			if err := daemon.Daemonize(); err != nil {
-				_ = portFile.Remove()
 				fileLock.Unlock()
 				return fmt.Errorf("failed to daemonize: %w", err)
 			}
@@ -601,20 +599,17 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 	// Wait for either server error, shutdown signal, or web UI stop request
 	select {
 	case err := <-serverErr:
-		// Release lock on error
-		_ = portFile.Remove()
+		// Release lock on error (also removes the runtime port file)
 		fileLock.Unlock()
 		return fmt.Errorf("server stopped unexpectedly: %w", err)
 	case <-sigChan:
 		fmt.Println("\nReceived shutdown signal, stopping server...")
-		// Release lock on shutdown
-		_ = portFile.Remove()
+		// Release lock on shutdown (also removes the runtime port file)
 		fileLock.Unlock()
 		return serverManager.Stop()
 	case <-server.GetShutdownChannel():
 		fmt.Println("\nReceived stop request from web UI, stopping server...")
-		// Release lock on shutdown
-		_ = portFile.Remove()
+		// Release lock on shutdown (also removes the runtime port file)
 		fileLock.Unlock()
 		return serverManager.Stop()
 	}
@@ -629,13 +624,6 @@ func CreateAppManagerForDir(configDir string) (*AppManager, error) {
 		return nil, fmt.Errorf("failed to create app config for directory %s: %w", configDir, err)
 	}
 	return NewAppManagerWithConfig(appConfig), nil
-}
-
-// removeRuntimePortFile removes the runtime port file that lives next to the
-// given PID lock. Used by the stopping process after the lock is released,
-// when the server was killed without a chance to clean up itself.
-func removeRuntimePortFile(fileLock *lock.FileLock) {
-	_ = lock.NewPortFile(filepath.Dir(fileLock.GetLockFilePath())).Remove()
 }
 
 // doStopServerWithFileLock stops the server using the provided file lock

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -84,6 +85,19 @@ func (r *RestartCmdKong) Run(appManager *AppManager) error {
 	fileLock := lock.NewFileLock(appConfig.ConfigDir())
 	wasRunning := fileLock.IsLocked()
 
+	// A real restart continues on the port the server is actually running on,
+	// not the config default. That port may have come from `--port` at start
+	// time and is intentionally never persisted, so without this a bare
+	// `restart` would silently relocate the server and break clients (cc /
+	// profile / an open web UI) pointed at the live port. An explicit `--port`
+	// still wins. The live port must be read BEFORE stopping, since stopping
+	// removes the runtime port file.
+	restartPort := r.Port
+	preservedPort := restartPort == 0 && wasRunning
+	if preservedPort {
+		restartPort = appManager.GetRuntimeServerPort()
+	}
+
 	if wasRunning {
 		fmt.Println("Stopping current server...")
 		if err := stopServerWithFileLock(fileLock); err != nil {
@@ -94,8 +108,14 @@ func (r *RestartCmdKong) Run(appManager *AppManager) error {
 		fmt.Println("Server was not running, starting it...")
 	}
 
+	// Make the preserved port and how to override it visible, so the "sticky"
+	// port is never invisible state (see .design/runtime-port-file.md).
+	if preservedPort {
+		fmt.Printf("Continuing on the running port %d (pass --port to change it; run 'stop' then 'start' for the default).\n", restartPort)
+	}
+
 	flags := options.StartFlags{
-		Port:                 r.Port,
+		Port:                 restartPort,
 		Host:                 r.Host,
 		EnableUI:             r.EnableUI,
 		EnableDebug:          r.EnableDebug,
@@ -579,8 +599,11 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 	// Handle daemon mode - fork and detach after all messages are printed
 	if opts.Daemon {
 		if !daemon.IsDaemonProcess() {
-			// Fork and detach - this call exits the parent process
-			if err := daemon.Daemonize(); err != nil {
+			// Fork and detach - this call exits the parent process. Pin the
+			// resolved port so the re-exec'd child binds the same port instead
+			// of re-resolving from its own args (which omit a preserved/config
+			// port and would drift to the default).
+			if err := daemon.Daemonize("--port", strconv.Itoa(port)); err != nil {
 				fileLock.Unlock()
 				return fmt.Errorf("failed to daemonize: %w", err)
 			}

--- a/internal/command/server_test.go
+++ b/internal/command/server_test.go
@@ -110,6 +110,44 @@ func TestServerPortConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("Runtime port prefers port file while server is running", func(t *testing.T) {
+		appManager, err := NewAppManager(tempDir)
+		if err != nil {
+			t.Fatalf("Failed to create app manager: %v", err)
+		}
+
+		configPort := appManager.GetServerPort()
+
+		// No server running: falls back to the configured port even if a
+		// stale port file exists.
+		portFile := lock.NewPortFile(tempDir)
+		if err := portFile.Write(23456); err != nil {
+			t.Fatalf("Failed to write port file: %v", err)
+		}
+		if got := appManager.GetRuntimeServerPort(); got != configPort {
+			t.Errorf("Expected configured port %d when server is not running, got %d", configPort, got)
+		}
+
+		// Server running (lock held): the port file wins.
+		fileLock := lock.NewFileLock(tempDir)
+		if err := fileLock.TryLock(); err != nil {
+			t.Fatalf("Failed to acquire lock: %v", err)
+		}
+		defer fileLock.Unlock()
+
+		if got := appManager.GetRuntimeServerPort(); got != 23456 {
+			t.Errorf("Expected runtime port 23456, got %d", got)
+		}
+
+		// Port file gone while running: falls back to configured port.
+		if err := portFile.Remove(); err != nil {
+			t.Fatalf("Failed to remove port file: %v", err)
+		}
+		if got := appManager.GetRuntimeServerPort(); got != configPort {
+			t.Errorf("Expected configured port %d after port file removal, got %d", configPort, got)
+		}
+	})
+
 	t.Run("Port persists when explicitly saved", func(t *testing.T) {
 		// First instance: set port
 		appManager1, err := NewAppManager(tempDir)

--- a/internal/command/server_unix.go
+++ b/internal/command/server_unix.go
@@ -51,7 +51,7 @@ func stopServerWithFileLock(fileLock *lock.FileLock) error {
 	// Wait for process to exit
 	for i := 0; i < 5; i++ { // Wait up to 5 seconds
 		if !fileLock.IsLocked() {
-			removeRuntimePortFile(fileLock)
+			_ = fileLock.RemovePort()
 			return nil
 		}
 		time.Sleep(1 * time.Second)
@@ -63,6 +63,6 @@ func stopServerWithFileLock(fileLock *lock.FileLock) error {
 		return fmt.Errorf("failed to force kill process: %w", err)
 	}
 
-	removeRuntimePortFile(fileLock)
+	_ = fileLock.RemovePort()
 	return nil
 }

--- a/internal/command/server_unix.go
+++ b/internal/command/server_unix.go
@@ -51,6 +51,7 @@ func stopServerWithFileLock(fileLock *lock.FileLock) error {
 	// Wait for process to exit
 	for i := 0; i < 5; i++ { // Wait up to 5 seconds
 		if !fileLock.IsLocked() {
+			removeRuntimePortFile(fileLock)
 			return nil
 		}
 		time.Sleep(1 * time.Second)
@@ -62,5 +63,6 @@ func stopServerWithFileLock(fileLock *lock.FileLock) error {
 		return fmt.Errorf("failed to force kill process: %w", err)
 	}
 
+	removeRuntimePortFile(fileLock)
 	return nil
 }

--- a/internal/command/server_windows.go
+++ b/internal/command/server_windows.go
@@ -45,7 +45,7 @@ func stopServerWithFileLock(fileLock *lock.FileLock) error {
 		if !fileLock.IsLocked() {
 			// TerminateProcess gives the server no chance to clean up its
 			// runtime port file, so remove it from the stopping side.
-			removeRuntimePortFile(fileLock)
+			_ = fileLock.RemovePort()
 			return nil
 		}
 		time.Sleep(1 * time.Second)

--- a/internal/command/server_windows.go
+++ b/internal/command/server_windows.go
@@ -43,6 +43,9 @@ func stopServerWithFileLock(fileLock *lock.FileLock) error {
 	// Wait for process to exit and lock to be released
 	for i := 0; i < 5; i++ { // Wait up to 5 seconds
 		if !fileLock.IsLocked() {
+			// TerminateProcess gives the server no chance to clean up its
+			// runtime port file, so remove it from the stopping side.
+			removeRuntimePortFile(fileLock)
 			return nil
 		}
 		time.Sleep(1 * time.Second)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"os"
+	"strings"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -40,4 +41,45 @@ func NewLogger(cfg *LogRotationConfig) *lumberjack.Logger {
 // IsDaemonProcess checks if the current process is running as a daemon
 func IsDaemonProcess() bool {
 	return os.Getenv("_TINGLY_BOX_DAEMON") == "1"
+}
+
+// buildDaemonArgs computes the argv for the re-exec'd daemon child. Daemonize
+// re-runs the current command, so any value the parent *resolved* (rather than
+// received on the command line) would be re-resolved by the child and could
+// drift — e.g. a `restart` that preserves the running port, or a port that came
+// from config. overrideArgs pins those resolved flags: the matching flags are
+// stripped from the original args and replaced, so the child binds exactly what
+// the parent decided. With no overrides the original args pass through unchanged.
+func buildDaemonArgs(args, overrideArgs []string) []string {
+	if len(overrideArgs) == 0 {
+		return args
+	}
+	// Only --port is overridden today; strip both spellings and short form.
+	filtered := stripFlag(args, "--port", "-p")
+	return append(filtered, overrideArgs...)
+}
+
+// stripFlag removes the named flags and their values from args, handling both
+// "--flag value" and "--flag=value" (and the same for short forms).
+func stripFlag(args []string, names ...string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		drop := false
+		for _, name := range names {
+			if arg == name {
+				drop = true
+				i++ // also skip the following value token
+				break
+			}
+			if strings.HasPrefix(arg, name+"=") {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, arg)
+		}
+	}
+	return out
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"os"
-	"strings"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -44,42 +43,17 @@ func IsDaemonProcess() bool {
 }
 
 // buildDaemonArgs computes the argv for the re-exec'd daemon child. Daemonize
-// re-runs the current command, so any value the parent *resolved* (rather than
-// received on the command line) would be re-resolved by the child and could
-// drift — e.g. a `restart` that preserves the running port, or a port that came
-// from config. overrideArgs pins those resolved flags: the matching flags are
-// stripped from the original args and replaced, so the child binds exactly what
-// the parent decided. With no overrides the original args pass through unchanged.
+// re-runs the current command, so a value the parent *resolved* rather than
+// received on the command line (e.g. a `restart` preserving the running port)
+// would be re-resolved by the child and drift back to the default. overrideArgs
+// is appended so the child sees the pinned flag; the CLI parser takes the last
+// occurrence, so this wins over any earlier value without needing to strip it.
 func buildDaemonArgs(args, overrideArgs []string) []string {
 	if len(overrideArgs) == 0 {
 		return args
 	}
-	// Only --port is overridden today; strip both spellings and short form.
-	filtered := stripFlag(args, "--port", "-p")
-	return append(filtered, overrideArgs...)
-}
-
-// stripFlag removes the named flags and their values from args, handling both
-// "--flag value" and "--flag=value" (and the same for short forms).
-func stripFlag(args []string, names ...string) []string {
-	out := make([]string, 0, len(args))
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		drop := false
-		for _, name := range names {
-			if arg == name {
-				drop = true
-				i++ // also skip the following value token
-				break
-			}
-			if strings.HasPrefix(arg, name+"=") {
-				drop = true
-				break
-			}
-		}
-		if !drop {
-			out = append(out, arg)
-		}
-	}
+	out := make([]string, 0, len(args)+len(overrideArgs))
+	out = append(out, args...)
+	out = append(out, overrideArgs...)
 	return out
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -19,28 +19,18 @@ func TestBuildDaemonArgs(t *testing.T) {
 			want:     []string{"restart", "--daemon"},
 		},
 		{
-			name:     "appends port when absent",
+			name:     "appends pinned port (restart preserve case)",
 			args:     []string{"restart", "--daemon"},
 			override: []string{"--port", "9000"},
 			want:     []string{"restart", "--daemon", "--port", "9000"},
 		},
 		{
-			name:     "replaces existing --port value form",
+			// An earlier --port is left in place; the CLI parser takes the last
+			// occurrence, so the appended value wins without stripping.
+			name:     "appends after an existing --port (last wins)",
 			args:     []string{"start", "--port", "8080", "--daemon"},
 			override: []string{"--port", "9000"},
-			want:     []string{"start", "--daemon", "--port", "9000"},
-		},
-		{
-			name:     "replaces existing --port=value form",
-			args:     []string{"start", "--port=8080", "--daemon"},
-			override: []string{"--port", "9000"},
-			want:     []string{"start", "--daemon", "--port", "9000"},
-		},
-		{
-			name:     "replaces short -p form",
-			args:     []string{"start", "-p", "8080", "--daemon"},
-			override: []string{"--port", "9000"},
-			want:     []string{"start", "--daemon", "--port", "9000"},
+			want:     []string{"start", "--port", "8080", "--daemon", "--port", "9000"},
 		},
 	}
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildDaemonArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		override []string
+		want     []string
+	}{
+		{
+			name:     "no override passes through unchanged",
+			args:     []string{"restart", "--daemon"},
+			override: nil,
+			want:     []string{"restart", "--daemon"},
+		},
+		{
+			name:     "appends port when absent",
+			args:     []string{"restart", "--daemon"},
+			override: []string{"--port", "9000"},
+			want:     []string{"restart", "--daemon", "--port", "9000"},
+		},
+		{
+			name:     "replaces existing --port value form",
+			args:     []string{"start", "--port", "8080", "--daemon"},
+			override: []string{"--port", "9000"},
+			want:     []string{"start", "--daemon", "--port", "9000"},
+		},
+		{
+			name:     "replaces existing --port=value form",
+			args:     []string{"start", "--port=8080", "--daemon"},
+			override: []string{"--port", "9000"},
+			want:     []string{"start", "--daemon", "--port", "9000"},
+		},
+		{
+			name:     "replaces short -p form",
+			args:     []string{"start", "-p", "8080", "--daemon"},
+			override: []string{"--port", "9000"},
+			want:     []string{"start", "--daemon", "--port", "9000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildDaemonArgs(tt.args, tt.override)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildDaemonArgs(%v, %v) = %v, want %v", tt.args, tt.override, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/daemon/daemon_unix.go
+++ b/pkg/daemon/daemon_unix.go
@@ -10,8 +10,12 @@ import (
 )
 
 // Daemonize detaches the process from the terminal and runs in the background
-// This works on Unix-like systems (Linux, macOS)
-func Daemonize() error {
+// This works on Unix-like systems (Linux, macOS).
+//
+// overrideArgs pins flags the parent resolved (e.g. "--port", "9000") so the
+// detached child binds exactly what the parent decided instead of re-resolving
+// its own command line. See buildDaemonArgs.
+func Daemonize(overrideArgs ...string) error {
 	// Check if we're already the child process
 	if IsDaemonProcess() {
 		return nil
@@ -23,8 +27,8 @@ func Daemonize() error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	// Get original arguments
-	args := os.Args[1:]
+	// Get original arguments, pinning any resolved flags for the child
+	args := buildDaemonArgs(os.Args[1:], overrideArgs)
 
 	// Set environment variable to mark the child as daemon
 	cmd := exec.Command(execPath, args...)

--- a/pkg/daemon/daemon_windows.go
+++ b/pkg/daemon/daemon_windows.go
@@ -10,8 +10,12 @@ import (
 )
 
 // Daemonize detaches the process from the terminal and runs in the background
-// This works on Windows by creating a detached process
-func Daemonize() error {
+// This works on Windows by creating a detached process.
+//
+// overrideArgs pins flags the parent resolved (e.g. "--port", "9000") so the
+// detached child binds exactly what the parent decided instead of re-resolving
+// its own command line. See buildDaemonArgs.
+func Daemonize(overrideArgs ...string) error {
 	// Check if we're already the child process
 	if IsDaemonProcess() {
 		return nil
@@ -23,8 +27,8 @@ func Daemonize() error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	// Get original arguments
-	args := os.Args[1:]
+	// Get original arguments, pinning any resolved flags for the child
+	args := buildDaemonArgs(os.Args[1:], overrideArgs)
 
 	// Set environment variable to mark the child as daemon
 	cmd := exec.Command(execPath, args...)

--- a/pkg/lock/filelock_unix.go
+++ b/pkg/lock/filelock_unix.go
@@ -23,6 +23,7 @@ type FileLock struct {
 	lockFile string
 	file     *os.File
 	pid      int
+	portFile *PortFile
 }
 
 // NewFileLock creates a new file lock instance.
@@ -30,6 +31,7 @@ type FileLock struct {
 func NewFileLock(configDir string) *FileLock {
 	return &FileLock{
 		lockFile: filepath.Join(configDir, "tingly-server.lock"),
+		portFile: NewPortFile(configDir),
 	}
 }
 
@@ -85,8 +87,10 @@ func (fl *FileLock) Unlock() error {
 	closeErr := fl.file.Close()
 	fl.file = nil
 
-	// Remove the lock file (optional, keeps directory clean)
+	// Remove the lock file and the associated runtime port file (both are
+	// runtime artifacts of this lock; keeps the config directory clean).
 	_ = os.Remove(fl.lockFile)
+	_ = fl.portFile.Remove()
 
 	if closeErr != nil {
 		return fmt.Errorf("failed to close lock file: %w", closeErr)
@@ -146,4 +150,24 @@ func (fl *FileLock) GetPID() (int, error) {
 	}
 
 	return pid, nil
+}
+
+// WritePort records the port the running server is listening on. It is a
+// runtime artifact tied to this lock's lifetime: written after TryLock and
+// removed by Unlock (or RemovePort for a crashed server the stopper cleans up).
+func (fl *FileLock) WritePort(port int) error {
+	return fl.portFile.Write(port)
+}
+
+// ReadPort returns the port recorded by the running server. Callers must gate
+// on IsLocked() and treat any error as "port unknown" (fall back to config).
+func (fl *FileLock) ReadPort() (int, error) {
+	return fl.portFile.Read()
+}
+
+// RemovePort deletes the runtime port file. Unlock already does this for the
+// lock holder; the stop command uses it to clean up after a server that was
+// killed without releasing the lock itself.
+func (fl *FileLock) RemovePort() error {
+	return fl.portFile.Remove()
 }

--- a/pkg/lock/filelock_windows.go
+++ b/pkg/lock/filelock_windows.go
@@ -19,6 +19,7 @@ type FileLock struct {
 	pidFile  string // Separate PID file for Windows (can be read while lock is held)
 	file     *os.File
 	pid      int
+	portFile *PortFile
 }
 
 // NewFileLock creates a new file lock instance.
@@ -27,6 +28,7 @@ func NewFileLock(configDir string) *FileLock {
 	return &FileLock{
 		lockFile: filepath.Join(configDir, "tingly-server.lock"),
 		pidFile:  filepath.Join(configDir, "tingly-server.pid"), // Separate PID file
+		portFile: NewPortFile(configDir),
 	}
 }
 
@@ -89,9 +91,11 @@ func (fl *FileLock) Unlock() error {
 	closeErr := fl.file.Close()
 	fl.file = nil
 
-	// Remove the lock file and PID file (optional, keeps directory clean)
+	// Remove the lock file, PID file, and the associated runtime port file
+	// (all runtime artifacts of this lock; keeps the config directory clean).
 	_ = os.Remove(fl.lockFile)
 	_ = os.Remove(fl.pidFile)
+	_ = fl.portFile.Remove()
 
 	if closeErr != nil {
 		return fmt.Errorf("failed to close lock file: %w", closeErr)
@@ -162,4 +166,24 @@ func (fl *FileLock) GetPID() (int, error) {
 	}
 
 	return pid, nil
+}
+
+// WritePort records the port the running server is listening on. It is a
+// runtime artifact tied to this lock's lifetime: written after TryLock and
+// removed by Unlock (or RemovePort for a crashed server the stopper cleans up).
+func (fl *FileLock) WritePort(port int) error {
+	return fl.portFile.Write(port)
+}
+
+// ReadPort returns the port recorded by the running server. Callers must gate
+// on IsLocked() and treat any error as "port unknown" (fall back to config).
+func (fl *FileLock) ReadPort() (int, error) {
+	return fl.portFile.Read()
+}
+
+// RemovePort deletes the runtime port file. Unlock already does this for the
+// lock holder; the stop command uses it to clean up after a server that was
+// killed without releasing the lock itself.
+func (fl *FileLock) RemovePort() error {
+	return fl.portFile.Remove()
 }

--- a/pkg/lock/portfile.go
+++ b/pkg/lock/portfile.go
@@ -67,8 +67,3 @@ func (pf *PortFile) Remove() error {
 	}
 	return nil
 }
-
-// Path returns the port file path for debugging purposes.
-func (pf *PortFile) Path() string {
-	return pf.path
-}

--- a/pkg/lock/portfile.go
+++ b/pkg/lock/portfile.go
@@ -1,0 +1,74 @@
+package lock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const portFileName = "tingly-server.port"
+
+// PortFile records the port the running server is actually listening on.
+// Like the PID lock file, it is a runtime artifact in the config directory,
+// not configuration: the server writes it right after acquiring the file
+// lock and removes it on shutdown. Other CLI processes (cc/profile/log/
+// status/open) read it to discover the live port, since the server port is
+// intentionally not persisted in the config file.
+//
+// Readers must gate on FileLock.IsLocked(): a stale port file can survive a
+// crashed server, but the flock is always released by the OS.
+type PortFile struct {
+	path string
+}
+
+// NewPortFile creates a port file handle for the given config directory.
+func NewPortFile(configDir string) *PortFile {
+	return &PortFile{path: filepath.Join(configDir, portFileName)}
+}
+
+// Write records the listening port. The write is atomic (temp file + rename)
+// so a concurrent reader never observes a partial value.
+func (pf *PortFile) Write(port int) error {
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid port %d", port)
+	}
+	tmp := pf.path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(port)+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write port file: %w", err)
+	}
+	if err := os.Rename(tmp, pf.path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to publish port file: %w", err)
+	}
+	return nil
+}
+
+// Read returns the recorded port. Callers should treat any error as
+// "port unknown" and fall back to the configured port.
+func (pf *PortFile) Read() (int, error) {
+	data, err := os.ReadFile(pf.path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read port file: %w", err)
+	}
+	s := strings.TrimSpace(string(data))
+	port, err := strconv.Atoi(s)
+	if err != nil || port <= 0 || port > 65535 {
+		return 0, fmt.Errorf("invalid port %q in %s", s, pf.path)
+	}
+	return port, nil
+}
+
+// Remove deletes the port file. A missing file is not an error.
+func (pf *PortFile) Remove() error {
+	if err := os.Remove(pf.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove port file: %w", err)
+	}
+	return nil
+}
+
+// Path returns the port file path for debugging purposes.
+func (pf *PortFile) Path() string {
+	return pf.path
+}

--- a/pkg/lock/portfile_test.go
+++ b/pkg/lock/portfile_test.go
@@ -1,0 +1,72 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortFile_WriteReadRemove(t *testing.T) {
+	dir := t.TempDir()
+	pf := NewPortFile(dir)
+
+	if _, err := pf.Read(); err == nil {
+		t.Error("Read should fail when port file does not exist")
+	}
+
+	if err := pf.Write(19999); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	port, err := pf.Read()
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if port != 19999 {
+		t.Errorf("Expected port 19999, got %d", port)
+	}
+
+	// Overwrite with a new port
+	if err := pf.Write(12580); err != nil {
+		t.Fatalf("Write (overwrite) failed: %v", err)
+	}
+	port, err = pf.Read()
+	if err != nil {
+		t.Fatalf("Read after overwrite failed: %v", err)
+	}
+	if port != 12580 {
+		t.Errorf("Expected port 12580, got %d", port)
+	}
+
+	if err := pf.Remove(); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if _, err := pf.Read(); err == nil {
+		t.Error("Read should fail after Remove")
+	}
+
+	// Removing a missing file is not an error
+	if err := pf.Remove(); err != nil {
+		t.Errorf("Remove on missing file should not fail, got: %v", err)
+	}
+}
+
+func TestPortFile_WriteInvalidPort(t *testing.T) {
+	pf := NewPortFile(t.TempDir())
+	for _, p := range []int{0, -1, 65536} {
+		if err := pf.Write(p); err == nil {
+			t.Errorf("Write(%d) should fail", p)
+		}
+	}
+}
+
+func TestPortFile_ReadInvalidContent(t *testing.T) {
+	dir := t.TempDir()
+	pf := NewPortFile(dir)
+	if err := os.WriteFile(filepath.Join(dir, portFileName), []byte("not-a-port\n"), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if _, err := pf.Read(); err == nil {
+		t.Error("Read should fail on non-numeric content")
+	}
+}


### PR DESCRIPTION
## Problem

The server port is intentionally **not persisted** in config (`ServerPort` is `json:"-"`), so `start --port 9000` doesn't silently rewrite long-term config. The downside: other CLI commands resolve the port from config and get the default (12580), so users had to repeat `--port` everywhere — and a bare `restart` would silently relocate a server off its live port.

## Solution

Treat the live port as a **runtime artifact, like the PID lock**: the server writes `<configDir>/tingly-server.port` after acquiring the lock and removes it on shutdown. Readers discover the live port from it; a real `restart` continues on it.

- **`PortFile`** (`pkg/lock/portfile.go`) — atomic write (temp+rename), range validation, tolerant remove.
- **`FileLock` owns it** — `WritePort`/`ReadPort`/`RemovePort`; `Unlock()` removes it on every exit path (one owner, no scattered cleanup).
- **`GetRuntimeServerPort()`** — port file wins **only while the lock is held**; stale files from a crash are ignored (flock is always released by the OS); otherwise falls back to config/12580.
- **Readers updated** — `cc` / `profile` / `log` / `status` / `open` auto-detect the live port when no `--port` is given.
- **Real restart** — a bare `restart` reads the live port *before* stopping and continues on it, prints the port + how to override, and `stop`+`start` returns to the default. Explicit `--port` always wins.
- **Daemon mode** — `Daemonize()` re-execs `os.Args`, so the parent pins the resolved port via an appended `--port` (CLI takes last-wins) to keep the detached child deterministic.

## Behavior

| Command | State | Port | Reads file |
| --- | --- | --- | :---: |
| `start` / `start --port N` | stopped | config→12580 / **N** | no |
| `restart` | running on X | **continues on X** | yes (pre-stop) |
| `restart --port N` | running on X | **N** | no |
| `restart --daemon` (bare) | running on X | **continues on X** | yes |
| `stop` + `start` | — | config→12580 | no |
| `cc`/`profile`/`log`/`status`/`open` | running on X | **X** (lock held) | yes |
| any | stale file, not running | config→12580 | ignored |

**Invariant:** explicit `--port` always wins; binding never reads the port file; only readers and `restart` continuation do, and only while the lock is held.

Rationale, staleness handling, and scope in `.design/runtime-port-file.md`.

## Verification

- unix + windows build/vet; `pkg/lock` + `pkg/daemon` + `internal/command` tests green (port file R/W, `GetRuntimeServerPort` three-state, daemon arg-pinning).
- Real start + curl: server genuinely listens on the chosen/continued port across all restart cases including `--daemon`.

https://claude.ai/code/session_014hHGMrviDyKVFUQKq6mr3n