### PR TITLE
refactor(api): adopt generated control API client

### DIFF
--- a/frontend/src/components/LogExplorer.tsx
+++ b/frontend/src/components/LogExplorer.tsx
@@ -6,6 +6,7 @@ import AILogViewer, {
     type ModelRequestSummary,
     type RequestFilters,
 } from '@/components/AILogViewer.tsx';
+import { getControlApiClient, getControlApiHeaders } from '@/services/openapi';
 
 interface LogExplorerProps {
     // When set, the scenario filter is initialized to this value but can be changed/cleared by the user.
@@ -13,45 +14,47 @@ interface LogExplorerProps {
     initialScenario?: string;
 }
 
-const getAuthHeader = () => ({
-    Authorization: `Bearer ${localStorage.getItem('user_auth_token') || ''}`,
-});
-
 const LogExplorer = ({ initialScenario }: LogExplorerProps) => {
     const [tab, setTab] = useState(0);
 
     const getRequests = useCallback(async (params?: RequestFilters) => {
-        const q = new URLSearchParams();
-        if (params?.limit) q.append('limit', String(params.limit));
-        if (params?.scenario) q.append('scenario', params.scenario);
-        if (params?.provider) q.append('provider', params.provider);
-        if (params?.status) q.append('status', params.status);
-
-        const res = await fetch(`/api/v1/requests?${q}`, { headers: getAuthHeader() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const [client, headers] = await Promise.all([getControlApiClient(), getControlApiHeaders()]);
+        const result = await client.GET('/api/v1/requests', {
+            headers,
+            params: {query: {
+                limit: params?.limit,
+                scenario: params?.scenario,
+                provider: params?.provider,
+                status: params?.status,
+            }},
+        });
+        if (!result.response.ok) throw new Error(`HTTP ${result.response.status}`);
+        const data = result.data!;
         return { total: data.total || 0, requests: (data.requests || []) as ModelRequestSummary[] };
     }, []);
 
     const getRequestDetail = useCallback(async (id: string): Promise<ModelRequestDetail | null> => {
-        const res = await fetch(`/api/v1/requests/${encodeURIComponent(id)}`, { headers: getAuthHeader() });
-        if (!res.ok) {
-            if (res.status === 404) return null;
-            throw new Error(`HTTP ${res.status}`);
+        const [client, headers] = await Promise.all([getControlApiClient(), getControlApiHeaders()]);
+        const result = await client.GET('/api/v1/requests/{id}', {
+            headers,
+            params: {path: {id}},
+        });
+        if (!result.response.ok) {
+            if (result.response.status === 404) return null;
+            throw new Error(`HTTP ${result.response.status}`);
         }
-        return (await res.json()) as ModelRequestDetail;
+        return result.data as ModelRequestDetail;
     }, []);
 
     const getSystemLogs = useCallback(
         async (params?: { limit?: number; level?: string; since?: string }) => {
-            const q = new URLSearchParams();
-            if (params?.limit) q.append('limit', String(params.limit));
-            if (params?.level) q.append('level', params.level);
-            if (params?.since) q.append('since', params.since);
-
-            const res = await fetch(`/api/v1/system/logs?${q}`, { headers: getAuthHeader() });
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            const data = await res.json();
+            const [client, headers] = await Promise.all([getControlApiClient(), getControlApiHeaders()]);
+            const result = await client.GET('/api/v1/system/logs', {
+                headers,
+                params: {query: {limit: params?.limit}},
+            });
+            if (!result.response.ok) throw new Error(`HTTP ${result.response.status}`);
+            const data = result.data!;
             return { total: data.total || 0, logs: data.logs || [] };
         },
         [],

--- a/frontend/src/components/probe/runProbe.ts
+++ b/frontend/src/components/probe/runProbe.ts
@@ -1,34 +1,23 @@
 import type { ProbeRequest, ProbeResult } from '@/types/probe';
-
-const getUserAuthToken = (): string | null => localStorage.getItem('user_auth_token');
+import { controlApi } from '@/services/openapi';
 
 // runProbe posts to /api/v2/probe and normalizes transport/HTTP failures into
 // the same envelope shape the backend returns, so callers only handle one type.
 export async function runProbe(body: ProbeRequest): Promise<ProbeResult> {
-    const token = getUserAuthToken();
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-
-    try {
-        const response = await fetch('/api/v2/probe', {
-            method: 'POST',
+    const response = await controlApi((client, headers) => client.POST('/api/v2/probe', {
             headers,
-            body: JSON.stringify(body),
-        });
-        if (!response.ok) {
-            let message = `HTTP ${response.status}`;
-            try {
-                const e = await response.json();
-                message = e.error?.message || message;
-            } catch {
-                /* ignore */
-            }
-            return { success: false, error: { message, type: 'http_error' } };
-        }
-        return await response.json();
-    } catch (err: any) {
-        return { success: false, error: { message: err?.message || 'Probe failed', type: 'client_error' } };
+            body,
+        }));
+    if (!response?.success) {
+        return {
+            success: false,
+            error: {
+                message: response?.error?.message || response?.error || 'Probe failed',
+                type: response?.error?.type || 'client_error',
+            },
+        };
     }
+    return response as ProbeResult;
 }
 
 // formatLatency renders a millisecond latency compactly: "850ms" / "1.8s".

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, useRef, type ReactNode } from 'react';
 import { api } from '../services/api';
 import { authEvents } from '../services/authState';
+import { getControlApiClient } from '../services/openapi';
 import {
     Dialog,
     DialogTitle,
@@ -143,14 +144,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Validate token by making a test API call to the validate endpoint
                 if (finalToken && finalToken.trim() !== '') {
                     try {
-                        const response = await fetch('/api/v1/auth/validate', {
+                        const client = await getControlApiClient();
+                        const result = await client.GET('/api/v1/auth/validate', {
                             headers: {
                                 'Authorization': `Bearer ${finalToken}`,
-                                'Content-Type': 'application/json',
                             },
                         });
 
-                        if (response.ok) {
+                        if (result.response.ok) {
                             // Token is valid
                             setToken(finalToken);
                             await api.initialize();

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -84,6 +84,15 @@ const mockSystemLogs = [
     { time: '', level: 'error', message: 'background quota refresh failed: context deadline exceeded', fields: { component: 'quota' } },
 ]
 
+const mockGuardrailsGroups: Array<{
+    id: string
+    name: string
+    enabled: boolean
+    severity: string
+}> = [
+    { id: 'default', name: 'Default', enabled: true, severity: 'high' },
+]
+
 // ============================================
 // Mock Providers (v2 API with uuid)
 // ============================================
@@ -1479,6 +1488,7 @@ export const handlers = [
         return HttpResponse.json({
             success: true,
             config: {
+                groups: mockGuardrailsGroups,
                 policies: [
                     {
                         id: 'policy-001',
@@ -1519,6 +1529,52 @@ export const handlers = [
                 { path: '/etc/tingly/guardrails/enterprise.yml', name: 'Enterprise Rules', policy_count: 8 },
             ],
         })
+    }),
+
+    http.post('/api/v1/guardrails/group', async ({ request }) => {
+        const group = await request.json() as { id?: string; name?: string; enabled?: boolean; severity?: string }
+        if (!group.id) {
+            return HttpResponse.json({ success: false, error: 'Group ID is required' }, { status: 400 })
+        }
+        const nextGroup = {
+            id: group.id,
+            name: group.name || group.id,
+            enabled: group.enabled ?? true,
+            severity: group.severity || 'medium',
+        }
+        const existingIndex = mockGuardrailsGroups.findIndex((item) => item.id === group.id)
+        if (existingIndex >= 0) {
+            mockGuardrailsGroups[existingIndex] = nextGroup
+        } else {
+            mockGuardrailsGroups.push(nextGroup)
+        }
+        return HttpResponse.json({ success: true, group: nextGroup })
+    }),
+
+    http.put('/api/v1/guardrails/group/:id', async ({ params, request }) => {
+        const group = await request.json() as { id?: string; name?: string; enabled?: boolean; severity?: string }
+        const groupID = String(params.id)
+        const existingIndex = mockGuardrailsGroups.findIndex((item) => item.id === groupID)
+        if (existingIndex < 0) {
+            return HttpResponse.json({ success: false, error: 'Group not found' }, { status: 404 })
+        }
+        const nextGroup = {
+            ...mockGuardrailsGroups[existingIndex],
+            ...group,
+            id: group.id || groupID,
+        }
+        mockGuardrailsGroups[existingIndex] = nextGroup
+        return HttpResponse.json({ success: true, group: nextGroup })
+    }),
+
+    http.delete('/api/v1/guardrails/group/:id', ({ params }) => {
+        const groupID = String(params.id)
+        const existingIndex = mockGuardrailsGroups.findIndex((item) => item.id === groupID)
+        if (existingIndex < 0) {
+            return HttpResponse.json({ success: false, error: 'Group not found' }, { status: 404 })
+        }
+        mockGuardrailsGroups.splice(existingIndex, 1)
+        return HttpResponse.json({ success: true })
     }),
 
     http.get('/api/v1/guardrails/history', () => {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { Alert, Box, Button, Container, Paper, TextField, Typography } from '@mu
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
+import { getControlApiClient } from '../services/openapi';
 
 const Login: React.FC = () => {
     const { t } = useTranslation();
@@ -24,14 +25,14 @@ const Login: React.FC = () => {
         setError('');
 
         try {
-            const response = await fetch('/api/v1/auth/validate', {
+            const client = await getControlApiClient();
+            const result = await client.GET('/api/v1/auth/validate', {
                 headers: {
                     'Authorization': `Bearer ${urlToken}`,
-                    'Content-Type': 'application/json',
                 },
             });
 
-            if (response.ok) {
+            if (result.response.ok) {
                 await login(urlToken);
                 sessionStorage.removeItem('redirectAfterLogin');
                 // Use window.location.href to trigger a full page reload
@@ -66,14 +67,14 @@ const Login: React.FC = () => {
 
         try {
             // Validate the token by making a test API call to the validate endpoint
-            const response = await fetch('/api/v1/auth/validate', {
+            const client = await getControlApiClient();
+            const result = await client.GET('/api/v1/auth/validate', {
                 headers: {
                     'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
                 },
             });
 
-            if (response.ok) {
+            if (result.response.ok) {
                 await login(token);
                 // Clear the saved redirect path
                 sessionStorage.removeItem('redirectAfterLogin');

--- a/frontend/src/pages/system/LogsPage.tsx
+++ b/frontend/src/pages/system/LogsPage.tsx
@@ -2,6 +2,7 @@ import { Stack, Switch, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import LogExplorer from '@/components/LogExplorer';
 import UnifiedCard from '@/components/UnifiedCard';
+import { controlApi } from '@/services/openapi';
 
 const LogsPage = () => {
     const [debugMode, setDebugMode] = useState(false);
@@ -13,13 +14,8 @@ const LogsPage = () => {
 
     const fetchDebugMode = async () => {
         try {
-            const response = await fetch('/api/v1/system/logs/level', {
-                headers: {
-                    'Authorization': `Bearer ${localStorage.getItem('user_auth_token') || ''}`,
-                },
-            });
-            if (response.ok) {
-                const data = await response.json();
+            const data = await controlApi((client, headers) => client.GET('/api/v1/system/logs/level', {headers}));
+            if (data?.success !== false) {
                 setDebugMode(data.level === 'debug');
             }
         } catch (error) {
@@ -31,15 +27,11 @@ const LogsPage = () => {
         const newDebugMode = event.target.checked;
         setLoadingDebug(true);
         try {
-            const response = await fetch('/api/v1/system/logs/level', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('user_auth_token') || ''}`,
-                },
-                body: JSON.stringify({ level: newDebugMode ? 'debug' : 'info' }),
-            });
-            if (response.ok) {
+            const data = await controlApi((client, headers) => client.POST('/api/v1/system/logs/level', {
+                headers,
+                body: {level: newDebugMode ? 'debug' : 'info'},
+            }));
+            if (data?.success !== false) {
                 setDebugMode(newDebugMode);
             }
         } catch (error) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,14 @@
 // API service layer for communicating with the backend
 
 import TinglyService from "@/bindings";
-import type {paths} from '@/client';
+import type {components} from '@/client';
 import {getApiBaseUrl} from '../utils/protocol';
-// Import openapi-fetch
-import createClient from 'openapi-fetch';
+import {
+    controlApi,
+    getControlApiClient as getClient,
+    getControlApiHeaders as getAuthHeaders,
+    resetControlApiClient as resetClient,
+} from './openapi';
 
 // Get user auth token for UI and control API from localStorage
 const getUserAuthToken = (): string | null => {
@@ -34,94 +38,6 @@ const getRemoteCCAuthToken = async (): Promise<string | null> => {
 const getModelToken = (): string | null => {
     return localStorage.getItem('model_token');
 };
-
-// Create the typed client with base URL
-const createApiClient = async () => {
-    const basePath = await getApiBaseUrl();
-    return createClient<paths>({baseUrl: basePath});
-};
-
-// Global client instance (lazily initialized)
-let client: ReturnType<typeof createClient<paths>> | null = null;
-let clientInitPromise: Promise<ReturnType<typeof createClient<paths>>> | null = null;
-
-// Get the client singleton
-const getClient = async () => {
-    if (!clientInitPromise) {
-        clientInitPromise = createApiClient().then((c) => {
-            client = c;
-            return c;
-        });
-    }
-    return clientInitPromise;
-};
-
-// Reset client (e.g., when token changes)
-const resetClient = () => {
-    client = null;
-    clientInitPromise = null;
-};
-
-// Helper to get auth headers
-const getAuthHeaders = async (): Promise<Record<string, string>> => {
-    const token = getUserAuthToken();
-
-    // Try to get token from GUI if available
-    if (!token && import.meta.env.VITE_PKG_MODE === "gui") {
-        const svc = TinglyService;
-        if (svc) {
-            try {
-                const guiToken = await svc.GetUserAuthToken();
-                if (guiToken) {
-                    return {'Authorization': `Bearer ${guiToken}`};
-                }
-            } catch (err) {
-                console.error('Failed to get GUI token:', err);
-            }
-        }
-    }
-
-    if (token) {
-        return {'Authorization': `Bearer ${token}`};
-    }
-    return {};
-};
-
-// Lightweight fetch helper for endpoints not covered by codegen
-async function uiAPI(path: string, options: RequestInit = {}): Promise<any> {
-    const fullUrl = path.startsWith('/api/v1') ? path : `/api/v1${path}`;
-
-    // Use the same auth logic as getAuthHeaders for consistency
-    let token = getUserAuthToken();
-
-    // Try to get token from GUI if available
-    if (!token && import.meta.env.VITE_PKG_MODE === "gui") {
-        const svc = TinglyService;
-        if (svc) {
-            try {
-                const guiToken = await svc.GetUserAuthToken();
-                if (guiToken) {
-                    token = guiToken;
-                }
-            } catch (err) {
-                console.error('Failed to get GUI token for uiAPI:', err);
-            }
-        }
-    }
-
-    const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        ...options.headers as Record<string, string>,
-    };
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-
-    try {
-        const response = await fetch(fullUrl, {headers, ...options});
-        return await response.json();
-    } catch (error) {
-        return {success: false, error: (error as Error).message};
-    }
-}
 
 // Fetch helper for model API endpoints (OpenAI/Anthropic compatible)
 async function modelAPI(url: string, options: RequestInit = {}): Promise<any> {
@@ -326,21 +242,8 @@ export const api = {
     },
 
     // List virtual models registered in the in-process registries.
-    // NOTE: /api/v1/vmodel/available-models is not yet in the OpenAPI spec; raw fetch is intentional.
     getAvailableVirtualModels: async (): Promise<any> => {
-        try {
-            const headers = await getAuthHeaders();
-            const response = await fetch(`${await getApiBaseUrl()}/api/v1/vmodel/available-models`, {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...headers,
-                },
-            });
-            return await response.json();
-        } catch (error: any) {
-            return {success: false, error: error.message};
-        }
+        return controlApi((client, headers) => client.GET('/api/v1/vmodel/available-models', {headers}));
     },
 
     // Server control
@@ -447,10 +350,6 @@ export const api = {
                 headers,
                 body: data
             });
-            if (response.error) {
-                const errBody = response.error as any;
-                return {success: false, error: errBody?.error || 'Request failed'};
-            }
             return response.data;
         } catch (error: any) {
             return {success: false, error: error.message};
@@ -486,10 +385,8 @@ export const api = {
         }
     },
 
-    // PLACEHOLDER: replace with codegen client once openapi schema is regenerated.
-    // Backend: GET /api/v1/rule/flags/registry returns { success, data: FlagSpec[] }
     getRuleFlagRegistry: async (): Promise<any> => {
-        return uiAPI('/rule/flags/registry', {method: 'GET'});
+        return controlApi((client, headers) => client.GET('/api/v1/rule/flags/registry', {headers}));
     },
 
     // Imports providers from a base64/JSONL export bundle.
@@ -528,68 +425,88 @@ export const api = {
 
     // Scenario API
     getScenarios: async (): Promise<any> => {
-        return uiAPI('/scenarios');
+        return controlApi((client, headers) => client.GET('/api/v1/scenarios', {headers}));
     },
 
     getScenarioConfig: async (scenario: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}`);
+        return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}', {
+            headers,
+            params: {path: {scenario}},
+        }));
     },
 
     setScenarioConfig: async (scenario: string, config: any): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}`, {
-            method: 'POST',
-            body: JSON.stringify(config),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/scenario/{scenario}', {
+            headers,
+            params: {path: {scenario}},
+            body: config,
+        }));
     },
 
     getScenarioFlag: async (scenario: string, flag: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/flag/${flag}`);
+        return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}/flag/{flag}', {
+            headers,
+            params: {path: {scenario, flag}},
+        }));
     },
 
     setScenarioFlag: async (scenario: string, flag: string, value: boolean): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/flag/${flag}`, {
-            method: 'PUT',
-            body: JSON.stringify({value}),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/scenario/{scenario}/flag/{flag}', {
+            headers,
+            params: {path: {scenario, flag}},
+            body: {value},
+        }));
     },
 
     getScenarioStringFlag: async (scenario: string, flag: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/string-flag/${flag}`);
+        return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}/string-flag/{flag}', {
+            headers,
+            params: {path: {scenario, flag}},
+        }));
     },
 
     setScenarioStringFlag: async (scenario: string, flag: string, value: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/string-flag/${flag}`, {
-            method: 'PUT',
-            body: JSON.stringify({value}),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/scenario/{scenario}/string-flag/{flag}', {
+            headers,
+            params: {path: {scenario, flag}},
+            body: {value},
+        }));
     },
 
     getScenarioIntFlag: async (scenario: string, flag: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/int-flag/${flag}`);
+        return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}/int-flag/{flag}', {
+            headers,
+            params: {path: {scenario, flag}},
+        }));
     },
 
     setScenarioIntFlag: async (scenario: string, flag: string, value: number): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/int-flag/${flag}`, {
-            method: 'PUT',
-            body: JSON.stringify({value}),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/scenario/{scenario}/int-flag/{flag}', {
+            headers,
+            params: {path: {scenario, flag}},
+            body: {value},
+        }));
     },
 
     // Scenario descriptors (includes supports_profiles flag)
     getScenarioDescriptors: async (): Promise<any> => {
-        return uiAPI('/scenario-descriptors');
+        return controlApi((client, headers) => client.GET('/api/v1/scenario-descriptors', {headers}));
     },
 
     // Profile API
     getProfiles: async (scenario: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/profiles`);
+        return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}/profiles', {
+            headers,
+            params: {path: {scenario}},
+        }));
     },
 
     createProfile: async (scenario: string, name: string, unified?: boolean): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/profiles`, {
-            method: 'POST',
-            body: JSON.stringify({name, unified}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/scenario/{scenario}/profiles', {
+            headers,
+            params: {path: {scenario}},
+            body: {name, unified},
+        }));
     },
 
     updateProfile: async (scenario: string, id: string, name: string, unified?: boolean): Promise<any> => {
@@ -600,124 +517,133 @@ export const api = {
         if (unified !== undefined) {
             body.unified = unified;
         }
-        return uiAPI(`/scenario/${scenario}/profiles/${id}`, {
-            method: 'PUT',
-            body: JSON.stringify(body),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/scenario/{scenario}/profiles/{id}', {
+            headers,
+            params: {path: {scenario, id}},
+            body,
+        }));
     },
 
     deleteProfile: async (scenario: string, id: string): Promise<any> => {
-        return uiAPI(`/scenario/${scenario}/profiles/${id}`, {
-            method: 'DELETE',
-        });
+        return controlApi((client, headers) => client.DELETE('/api/v1/scenario/{scenario}/profiles/{id}', {
+            headers,
+            params: {path: {scenario, id}},
+        }));
     },
 
     // Guardrails API
     getGuardrailsConfig: async (): Promise<any> => {
-        return uiAPI('/guardrails/config');
+        return controlApi((client, headers) => client.GET('/api/v1/guardrails/config', {headers}));
     },
     getGuardrailsBuiltins: async (): Promise<any> => {
-        return uiAPI('/guardrails/builtins');
+        return controlApi((client, headers) => client.GET('/api/v1/guardrails/builtins', {headers}));
     },
     getGuardrailsRegistry: async (forceRefresh = false): Promise<any> => {
-        const query = forceRefresh ? '?refresh=1' : '';
-        return uiAPI(`/guardrails/registry${query}`);
+        return controlApi((client, headers) => client.GET('/api/v1/guardrails/registry', {
+            headers,
+            params: {query: {refresh: forceRefresh ? '1' : undefined}},
+        }));
     },
     installGuardrailsRegistryPolicy: async (id: string): Promise<any> => {
-        return uiAPI('/guardrails/registry/install', {
-            method: 'POST',
-            body: JSON.stringify({id}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/registry/install', {
+            headers,
+            body: {id},
+        }));
     },
     getGuardrailsCredentials: async (): Promise<any> => {
-        return uiAPI('/guardrails/credentials');
+        return controlApi((client, headers) => client.GET('/api/v1/guardrails/credentials', {headers}));
     },
     getGuardrailsCredential: async (credentialId: string): Promise<any> => {
-        return uiAPI(`/guardrails/credential/${encodeURIComponent(credentialId)}`);
+        return controlApi((client, headers) => client.GET('/api/v1/guardrails/credential/{id}', {
+            headers,
+            params: {path: {id: credentialId}},
+        }));
     },
     createGuardrailsCredential: async (payload: any): Promise<any> => {
-        return uiAPI('/guardrails/credential', {
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/credential', {
+            headers,
+            body: payload,
+        }));
     },
     updateGuardrailsCredential: async (credentialId: string, payload: any): Promise<any> => {
-        return uiAPI(`/guardrails/credential/${encodeURIComponent(credentialId)}`, {
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/guardrails/credential/{id}', {
+            headers,
+            params: {path: {id: credentialId}},
+            body: payload,
+        }));
     },
     deleteGuardrailsCredential: async (credentialId: string): Promise<any> => {
-        return uiAPI(`/guardrails/credential/${encodeURIComponent(credentialId)}`, {
-            method: 'DELETE',
-        });
+        return controlApi((client, headers) => client.DELETE('/api/v1/guardrails/credential/{id}', {
+            headers,
+            params: {path: {id: credentialId}},
+        }));
     },
     getGuardrailsHistory: async (): Promise<any> => {
-        return uiAPI('/guardrails/history');
+        return controlApi((client, headers) => client.GET('/api/v1/guardrails/history', {headers}));
     },
     clearGuardrailsHistory: async (): Promise<any> => {
-        return uiAPI('/guardrails/history', {
-            method: 'DELETE',
-        });
+        return controlApi((client, headers) => client.DELETE('/api/v1/guardrails/history', {headers}));
     },
     createGuardrailsPolicy: async (payload: any): Promise<any> => {
-        return uiAPI('/guardrails/policy', {
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/policy', {
+            headers,
+            body: payload,
+        }));
     },
     updateGuardrailsPolicy: async (policyId: string, payload: any): Promise<any> => {
-        return uiAPI(`/guardrails/policy/${encodeURIComponent(policyId)}`, {
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/guardrails/policy/{id}', {
+            headers,
+            params: {path: {id: policyId}},
+            body: payload,
+        }));
     },
     deleteGuardrailsPolicy: async (policyId: string): Promise<any> => {
-        return uiAPI(`/guardrails/policy/${encodeURIComponent(policyId)}`, {
-            method: 'DELETE',
-        });
+        return controlApi((client, headers) => client.DELETE('/api/v1/guardrails/policy/{id}', {
+            headers,
+            params: {path: {id: policyId}},
+        }));
     },
     createGuardrailsGroup: async (payload: any): Promise<any> => {
-        return uiAPI('/guardrails/group', {
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/group', {
+            headers,
+            body: payload,
+        }));
     },
     updateGuardrailsGroup: async (groupId: string, payload: any): Promise<any> => {
-        return uiAPI(`/guardrails/group/${encodeURIComponent(groupId)}`, {
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/guardrails/group/{id}', {
+            headers,
+            params: {path: {id: groupId}},
+            body: payload,
+        }));
     },
     deleteGuardrailsGroup: async (groupId: string): Promise<any> => {
-        return uiAPI(`/guardrails/group/${encodeURIComponent(groupId)}`, {
-            method: 'DELETE',
-        });
+        return controlApi((client, headers) => client.DELETE('/api/v1/guardrails/group/{id}', {
+            headers,
+            params: {path: {id: groupId}},
+        }));
     },
 
     updateGuardrailsConfig: async (content: string): Promise<any> => {
-        return uiAPI('/guardrails/config', {
-            method: 'PUT',
-            body: JSON.stringify({content}),
-        });
+        return controlApi((client, headers) => client.PUT('/api/v1/guardrails/config', {
+            headers,
+            body: {content},
+        }));
     },
     importGuardrailsFragment: async (content: string, fileName?: string): Promise<any> => {
-        return uiAPI('/guardrails/fragment/import', {
-            method: 'POST',
-            body: JSON.stringify({content, file_name: fileName}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/fragment/import', {
+            headers,
+            body: {content, file_name: fileName},
+        }));
     },
     exportGuardrailsFragments: async (paths: string[]): Promise<any> => {
-        return uiAPI('/guardrails/fragment/export', {
-            method: 'POST',
-            body: JSON.stringify({paths}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/fragment/export', {
+            headers,
+            body: {paths},
+        }));
     },
 
     reloadGuardrailsConfig: async (): Promise<any> => {
-        return uiAPI('/guardrails/reload', {
-            method: 'POST',
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/guardrails/reload', {headers}));
     },
 
     probeModel: async (uuid: string, model: string): Promise<any> => {
@@ -838,20 +764,6 @@ export const api = {
     }),
     listOpenAIModels: (): Promise<any> => modelAPI('/openai/v1/models'),
     listAnthropicModels: (): Promise<any> => modelAPI('/anthropic/v1/models'),
-
-
-    // Service management within rules
-    addServiceToRule: (ruleName: string, serviceData: any): Promise<any> => uiAPI(`/rule/${ruleName}/services`, {
-        method: 'POST',
-        body: JSON.stringify(serviceData),
-    }),
-    updateServiceInRule: (ruleName: string, serviceIndex: number, serviceData: any): Promise<any> => uiAPI(`/rule/${ruleName}/services/${serviceIndex}`, {
-        method: 'PUT',
-        body: JSON.stringify(serviceData),
-    }),
-    deleteServiceFromRule: (ruleName: string, serviceIndex: number): Promise<any> => uiAPI(`/rule/${ruleName}/services/${serviceIndex}`, {
-        method: 'DELETE',
-    }),
     // Token management
     setUserToken: (token: string): void => {
         localStorage.setItem('user_auth_token', token);
@@ -993,9 +905,6 @@ export const api = {
                 headers,
                 body: data as any
             });
-            if (response.error) {
-                return {success: false, error: 'Request failed', data: response.error};
-            }
             return response.data;
         } catch (error: any) {
             return {success: false, error: error.message};
@@ -1086,23 +995,18 @@ export const api = {
     // var name (e.g. ANTHROPIC_MODEL), and the backend writes them straight
     // into ~/.claude/settings.json under "env".
     applyClaudeConfig: async (preferences: Record<string, string>, installStatusLine?: boolean, defaultMode: string = 'acceptEdits'): Promise<any> => {
-        return uiAPI('/config/apply/claude', {
-            method: 'POST',
-            body: JSON.stringify({preferences, installStatusLine, defaultMode}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/config/apply/claude', {
+            headers,
+            body: {preferences, installStatusLine, defaultMode},
+        }));
     },
 
     applyOpenCodeConfig: async (): Promise<any> => {
-        return uiAPI('/config/apply/opencode', {
-            method: 'POST',
-            body: JSON.stringify({}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/config/apply/opencode', {headers}));
     },
 
     getOpenCodeConfigPreview: async (): Promise<any> => {
-        return uiAPI('/config/preview/opencode', {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/config/preview/opencode', {headers}));
     },
 
     applyCodexConfig: async (
@@ -1111,9 +1015,6 @@ export const api = {
         authMode?: 'apikey' | 'chatgpt' | 'hybrid',
         oauthProviderUuid?: string,
     ): Promise<any> => {
-        // Uses the typed codegen client (openapi-fetch) rather than uiAPI, which
-        // is being retired. The endpoint is swagger-registered as
-        // POST /api/v1/config/apply/codex (ApplyCodexConfigRequest).
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();
@@ -1172,10 +1073,10 @@ export const api = {
         createBackup?: boolean;
         dryRun?: boolean;
     } = {}): Promise<any> => {
-        return uiAPI('/codex/import/openai', {
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/codex/import/openai', {
+            headers,
+            body: payload,
+        }));
     },
 
     // ============================================
@@ -1663,7 +1564,7 @@ export const api = {
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await client.POST('/api/v1/imbot-admin/restart/{uuid}' as any, {
+            const response = await client.POST('/api/v1/imbot-admin/restart/{uuid}', {
                 headers,
                 params: {path: {uuid}}
             });
@@ -1794,48 +1695,54 @@ export const api = {
 
     // Start Weixin QR login flow
     weixinQRStart: async (botUUID: string, platform?: string, botName?: string): Promise<any> => {
-        return uiAPI(`/imbot-settings/${botUUID}/weixin/qr-start`, {
-            method: 'POST',
-            body: JSON.stringify({bot_uuid: botUUID, bot_platform: platform, bot_name: botName}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/imbot-settings/{uuid}/weixin/qr-start', {
+            headers,
+            params: {path: {uuid: botUUID}},
+            body: {bot_uuid: botUUID, bot_platform: platform, bot_name: botName},
+        }));
     },
 
     // Poll Weixin QR login status
     weixinQRStatus: async (botUUID: string, qrCodeId: string): Promise<any> => {
-        return uiAPI(`/imbot-settings/${botUUID}/weixin/qr-status?qrcode_id=${qrCodeId}`, {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/imbot-settings/{uuid}/weixin/qr-status', {
+            headers,
+            params: {path: {uuid: botUUID}, query: {qrcode_id: qrCodeId}},
+        }));
     },
 
     // Cancel Weixin QR login flow
     weixinQRCancel: async (botUUID: string): Promise<any> => {
-        return uiAPI(`/imbot-settings/${botUUID}/weixin/qr-cancel`, {
-            method: 'POST',
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/imbot-settings/{uuid}/weixin/qr-cancel', {
+            headers,
+            params: {path: {uuid: botUUID}},
+        }));
     },
 
     // ========== Feishu/Lark One-Click Registration API ==========
 
     // Start Feishu/Lark one-click app registration; returns a QR verification link
     feishuRegStart: async (botUUID: string, platform?: string, botName?: string): Promise<any> => {
-        return uiAPI(`/imbot-settings/${botUUID}/feishu/qr-start`, {
-            method: 'POST',
-            body: JSON.stringify({bot_uuid: botUUID, bot_platform: platform, bot_name: botName}),
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/imbot-settings/{uuid}/feishu/qr-start', {
+            headers,
+            params: {path: {uuid: botUUID}},
+            body: {bot_uuid: botUUID, bot_platform: platform, bot_name: botName},
+        }));
     },
 
     // Poll Feishu/Lark one-click registration status
     feishuRegStatus: async (botUUID: string): Promise<any> => {
-        return uiAPI(`/imbot-settings/${botUUID}/feishu/qr-status`, {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/imbot-settings/{uuid}/feishu/qr-status', {
+            headers,
+            params: {path: {uuid: botUUID}},
+        }));
     },
 
     // Cancel a pending Feishu/Lark one-click registration
     feishuRegCancel: async (botUUID: string): Promise<any> => {
-        return uiAPI(`/imbot-settings/${botUUID}/feishu/qr-cancel`, {
-            method: 'POST',
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/imbot-settings/{uuid}/feishu/qr-cancel', {
+            headers,
+            params: {path: {uuid: botUUID}},
+        }));
     },
 
     // ========== System Configuration API ==========
@@ -1871,150 +1778,69 @@ export const api = {
 
     // Get MCP runtime config
     getMCPConfig: async (): Promise<any> => {
-        return uiAPI('/mcp/config', {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/mcp/config', {headers}));
     },
 
     // Set MCP runtime config
-    setMCPConfig: async (config: {
-        sources?: Array<{
-            id?: string;
-            enabled?: boolean;
-            transport?: string;
-            endpoint?: string;
-            headers?: Record<string, string>;
-            tools?: string[];
-            command?: string;
-            args?: string[];
-            cwd?: string;
-            env?: Record<string, string>;
-            proxy_url?: string;
-            visibility?: 'client' | 'server';
-            advisor?: {
-                base_url?: string;
-                model?: string;
-                api_key?: string;
-                max_uses_per_request?: number;
-                max_tokens?: number;
-            };
-        }>;
-        request_timeout?: number;
-        strip_disabled_mcp_tools?: boolean;
-    }): Promise<any> => {
-        return uiAPI('/mcp/config', {
-            method: 'PUT',
-            body: JSON.stringify(config),
-        });
-    },
-
-    // Probe models from an arbitrary OpenAI-compatible endpoint
-    probeModels: async (baseUrl: string, apiKey?: string): Promise<{ success: boolean; models?: string[]; error?: string }> => {
-        return uiAPI('/probe-models', {
-            method: 'POST',
-            body: JSON.stringify({ base_url: baseUrl, api_key: apiKey || '' }),
-        });
+    setMCPConfig: async (config: components['schemas']['MCPRuntimeConfigRequest']): Promise<any> => {
+        return controlApi((client, headers) => client.PUT('/api/v1/mcp/config', {
+            headers,
+            body: config,
+        }));
     },
 
     // List all registered MCP clients
     listMCPClients: async (): Promise<any> => {
-        return uiAPI('/mcp/clients', {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/mcp/clients', {headers}));
     },
 
     // Get a specific MCP client by ID
     getMCPClient: async (id: string): Promise<any> => {
-        return uiAPI(`/mcp/client/${id}`, {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/mcp/client/{id}', {
+            headers,
+            params: {path: {id}},
+        }));
     },
 
     // Create a new MCP client
-    createMCPClient: async (data: {
-        name: string;
-        connection_type: 'stdio' | 'http' | 'sse';
-        enabled?: boolean;
-        stdio_config?: {
-            command: string;
-            args?: string[];
-            cwd?: string;
-            env?: string[];
-        };
-        connection_string?: string;
-        auth_type?: 'none' | 'headers' | 'oauth';
-        headers?: Record<string, string>;
-        oauth_config?: {
-            client_id: string;
-            client_secret?: string;
-            authorize_url: string;
-            token_url: string;
-            scopes?: string[];
-        };
-        tools_to_execute?: string[];
-        tools_to_auto_execute?: string[];
-        allowed_extra_headers?: string[];
-        proxy_url?: string;
-        env?: Record<string, string>;
-    }): Promise<any> => {
-        return uiAPI('/mcp/client', {
-            method: 'POST',
-            body: JSON.stringify(data),
-        });
+    createMCPClient: async (data: components['schemas']['CreateClientRequest']): Promise<any> => {
+        return controlApi((client, headers) => client.POST('/api/v1/mcp/client', {
+            headers,
+            body: data,
+        }));
     },
 
     // Update an MCP client
-    updateMCPClient: async (id: string, data: {
-        name?: string;
-        connection_type?: 'stdio' | 'http' | 'sse';
-        enabled?: boolean;
-        stdio_config?: {
-            command?: string;
-            args?: string[];
-            cwd?: string;
-            env?: string[];
-        };
-        connection_string?: string;
-        auth_type?: 'none' | 'headers' | 'oauth';
-        headers?: Record<string, string>;
-        oauth_config?: {
-            client_id?: string;
-            client_secret?: string;
-            authorize_url?: string;
-            token_url?: string;
-            scopes?: string[];
-        };
-        tools_to_execute?: string[];
-        tools_to_auto_execute?: string[];
-        allowed_extra_headers?: string[];
-        proxy_url?: string;
-        env?: Record<string, string>;
-    }): Promise<any> => {
-        return uiAPI(`/mcp/client/${id}`, {
-            method: 'PUT',
-            body: JSON.stringify(data),
-        });
+    updateMCPClient: async (id: string, data: components['schemas']['UpdateClientRequest']): Promise<any> => {
+        return controlApi((client, headers) => client.PUT('/api/v1/mcp/client/{id}', {
+            headers,
+            params: {path: {id}},
+            body: data,
+        }));
     },
 
     // Delete an MCP client
     deleteMCPClient: async (id: string): Promise<any> => {
-        return uiAPI(`/mcp/client/${id}`, {
-            method: 'DELETE',
-        });
+        return controlApi((client, headers) => client.DELETE('/api/v1/mcp/client/{id}', {
+            headers,
+            params: {path: {id}},
+        }));
     },
 
     // Reconnect an MCP client
     reconnectMCPClient: async (id: string): Promise<any> => {
-        return uiAPI(`/mcp/client/${id}/reconnect`, {
-            method: 'POST',
-        });
+        return controlApi((client, headers) => client.POST('/api/v1/mcp/client/{id}/reconnect', {
+            headers,
+            params: {path: {id}},
+        }));
     },
 
     // Get install command for an MCP client
     getMCPInstallCommand: async (name: string): Promise<any> => {
-        return uiAPI(`/mcp/install/${name}`, {
-            method: 'GET',
-        });
+        return controlApi((client, headers) => client.GET('/api/v1/mcp/install/{name}', {
+            headers,
+            params: {path: {name}},
+        }));
     },
 
     // ========== MCP Tool Testing API ==========
@@ -2031,14 +1857,14 @@ export const api = {
         executionTime?: number;
     }> => {
         try {
-            return uiAPI('/mcp/execute', {
-                method: 'POST',
-                body: JSON.stringify({
+            return controlApi((client, headers) => client.POST('/api/v1/mcp/execute', {
+                headers,
+                body: {
                     client_id: clientId,
                     tool_name: toolName,
                     arguments: args,
-                }),
-            });
+                },
+            }));
         } catch (error: any) {
             return {
                 success: false,
@@ -2058,99 +1884,67 @@ export const api = {
         limit?: number;
         offset?: number;
     }): Promise<any> => {
-        try {
-            const client = await getClient();
-            const headers = await getAuthHeaders();
-            const response = await client.GET('/api/v1/tokens', {
+        const data = await controlApi((client, headers) => client.GET('/api/v1/tokens', {
                 headers,
-                params: {query: params as any}
-            });
-            // openapi-fetch returns { data, error, response }
-            if (response.error) {
-                return {success: false, error: response.error};
-            }
-            return {success: true, data: response.data};
-        } catch (error: any) {
-            return {success: false, error: error.message};
+                params: {query: params}
+            }));
+        if (data?.success === false) {
+            return data;
         }
+        return {success: true, data};
     },
 
     // Get a specific API token
     getAPIToken: async (tokenId: string): Promise<any> => {
-        try {
-            const client = await getClient();
-            const headers = await getAuthHeaders();
-            const response = await client.GET('/api/v1/tokens/{token_id}', {
+        const data = await controlApi((client, headers) => client.GET('/api/v1/tokens/{token_id}', {
                 headers,
                 params: {path: {token_id: tokenId}}
-            });
-            if (response.error) {
-                return {success: false, error: response.error};
-            }
-            return {success: true, data: response.data};
-        } catch (error: any) {
-            return {success: false, error: error.message};
+            }));
+        if (data?.success === false) {
+            return data;
         }
+        return {success: true, data};
     },
 
     // Create a new API token
     createAPIToken: async (data: {
         display_name: string;
-        expires_in_days?: number;
     }): Promise<any> => {
-        try {
-            const client = await getClient();
-            const headers = await getAuthHeaders();
-            const response = await client.POST('/api/v1/tokens', {
+        const response = await controlApi((client, headers) => client.POST('/api/v1/tokens', {
                 headers,
                 body: data
-            });
-            if (response.error) {
-                return {success: false, error: response.error};
-            }
-            return {success: true, data: response.data};
-        } catch (error: any) {
-            return {success: false, error: error.message};
+            }));
+        if (response?.success === false) {
+            return response;
         }
+        return {success: true, data: response};
     },
 
     // Delete an API token
     deleteAPIToken: async (tokenId: string): Promise<any> => {
-        try {
-            const client = await getClient();
-            const headers = await getAuthHeaders();
-            const response = await client.DELETE('/api/v1/tokens/{token_id}', {
+        const data = await controlApi((client, headers) => client.DELETE('/api/v1/tokens/{token_id}', {
                 headers,
                 params: {path: {token_id: tokenId}}
-            });
-            if (response.error) {
-                return {success: false, error: response.error};
-            }
-            return {success: true, data: response.data};
-        } catch (error: any) {
-            return {success: false, error: error.message};
+            }));
+        if (data?.success === false) {
+            return data;
         }
+        return {success: true, data};
     },
 
     // Enable an API token
     setAPITokenEnabled: async (tokenId: string, enabled: boolean): Promise<any> => {
-        try {
-            const client = await getClient();
-            const headers = await getAuthHeaders();
-            const endpoint = enabled
+        const endpoint = enabled
                 ? '/api/v1/tokens/{token_id}/enable'
                 : '/api/v1/tokens/{token_id}/disable';
-            const response = await client.PUT(endpoint, {
+        const data = await controlApi((client, headers) => client.PUT(endpoint, {
                 headers,
                 params: {path: {token_id: tokenId}}
-            });
-            if (response.error) {
-                return {success: false, error: response.error};
-            }
-            return {success: true, data: response.data};
-        } catch (error: any) {
-            return {success: false, error: error.message};
+            }));
+        if (data?.success === false) {
+            return data;
         }
+        return {success: true, data};
     },
 };
 

--- a/frontend/src/services/onboardingExtract.ts
+++ b/frontend/src/services/onboardingExtract.ts
@@ -1,4 +1,4 @@
-import TinglyService from "@/bindings";
+import { controlApi } from './openapi';
 
 export interface OnboardingTokenCandidate {
     value: string;
@@ -13,59 +13,22 @@ export interface OnboardingExtractResult {
     error?: string;
 }
 
-const getUserAuthToken = (): string | null => {
-    return localStorage.getItem('user_auth_token');
-};
-
-const getAuthBearer = async (): Promise<string | null> => {
-    let token = getUserAuthToken();
-    if (!token && import.meta.env.VITE_PKG_MODE === "gui") {
-        const svc = TinglyService;
-        if (svc) {
-            try {
-                const guiToken = await svc.GetUserAuthToken();
-                if (guiToken) token = guiToken;
-            } catch (err) {
-                console.error('Failed to get GUI token for onboarding extract:', err);
-            }
-        }
-    }
-    return token;
-};
-
 export async function extractOnboardingCandidates(input: string): Promise<OnboardingExtractResult> {
-    const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-    };
-    const token = await getAuthBearer();
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-
-    try {
-        const resp = await fetch('/api/v1/onboarding/extract', {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({input}),
-        });
-        const body = await resp.json();
-        if (!body?.success) {
-            return {
-                success: false,
-                urls: [],
-                tokens: [],
-                error: body?.error?.message || 'Extraction failed',
-            };
-        }
-        return {
-            success: true,
-            urls: body?.data?.urls ?? [],
-            tokens: body?.data?.tokens ?? [],
-        };
-    } catch (err) {
+    const body = await controlApi((client, headers) => client.POST('/api/v1/onboarding/extract', {
+        headers,
+        body: {input},
+    }));
+    if (!body?.success) {
         return {
             success: false,
             urls: [],
             tokens: [],
-            error: (err as Error).message,
+            error: body?.error?.message || body?.error || 'Extraction failed',
         };
     }
+    return {
+        success: true,
+        urls: body?.data?.urls ?? [],
+        tokens: body?.data?.tokens ?? [],
+    };
 }

--- a/frontend/src/services/openapi.ts
+++ b/frontend/src/services/openapi.ts
@@ -1,0 +1,68 @@
+import TinglyService from '@/bindings';
+import type { paths } from '@/client';
+import { getApiBaseUrl } from '@/utils/protocol';
+import createClient from 'openapi-fetch';
+
+export type ApiClient = ReturnType<typeof createClient<paths>>;
+
+let clientPromise: Promise<ApiClient> | null = null;
+
+export const getControlApiClient = async (): Promise<ApiClient> => {
+    if (!clientPromise) {
+        clientPromise = getApiBaseUrl().then((baseUrl) => createClient<paths>({ baseUrl }));
+    }
+    return clientPromise;
+};
+
+export const resetControlApiClient = (): void => {
+    clientPromise = null;
+};
+
+export const getControlApiHeaders = async (): Promise<Record<string, string>> => {
+    const token = localStorage.getItem('user_auth_token');
+    if (token) {
+        return { Authorization: `Bearer ${token}` };
+    }
+
+    if (import.meta.env.VITE_PKG_MODE === 'gui' && TinglyService) {
+        try {
+            const guiToken = await TinglyService.GetUserAuthToken();
+            if (guiToken) {
+                return { Authorization: `Bearer ${guiToken}` };
+            }
+        } catch (error) {
+            console.error('Failed to get GUI token:', error);
+        }
+    }
+
+    return {};
+};
+
+const errorMessage = (error: unknown): string => {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === 'object' && error !== null) {
+        const value = error as { error?: string; message?: string };
+        return value.error || value.message || 'Request failed';
+    }
+    return 'Request failed';
+};
+
+export const controlApi = async (
+    request: (client: ApiClient, headers: Record<string, string>) => Promise<any>,
+): Promise<any> => {
+    try {
+        const [client, headers] = await Promise.all([
+            getControlApiClient(),
+            getControlApiHeaders(),
+        ]);
+        const response = await request(client, headers);
+        if (response.error) {
+            return { success: false, error: errorMessage(response.error) };
+        }
+        return response.data;
+    } catch (error) {
+        return { success: false, error: errorMessage(error) };
+    }
+};

--- a/internal/server/guardrails_handler.go
+++ b/internal/server/guardrails_handler.go
@@ -260,6 +260,25 @@ type protectedCredentialMutationResponse struct {
 	Credential protectedCredentialResponse `json:"credential"`
 }
 
+type protectedCredentialDetailEnvelope struct {
+	Success bool                              `json:"success"`
+	Data    protectedCredentialDetailResponse `json:"data"`
+}
+
+type protectedCredentialDeleteResponse struct {
+	Success      bool   `json:"success"`
+	CredentialID string `json:"credential_id"`
+}
+
+type guardrailsHistoryResponse struct {
+	Success bool                    `json:"success"`
+	Data    []guardrailsutils.Entry `json:"data"`
+}
+
+type guardrailsSuccessResponse struct {
+	Success bool `json:"success"`
+}
+
 // Leave the remote registry unset until the dedicated policy repository is
 // ready. The API will surface this as an unavailable registry instead of
 // coupling guardrails downloads to the main code repository.

--- a/internal/server/log_handler.go
+++ b/internal/server/log_handler.go
@@ -293,6 +293,11 @@ type SystemLogLevelRequest struct {
 	Level string `json:"level" binding:"required"`
 }
 
+type SystemLogLevelResponse struct {
+	Message string `json:"message,omitempty"`
+	Level   string `json:"level"`
+}
+
 // SetSystemLogLevel sets the minimum log level for system logs
 func (h *WebHandler) SetSystemLogLevel(c *gin.Context) {
 	if h.deps.MultiLogger == nil {

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -12,7 +12,7 @@ import (
 // written under "env" in ~/.claude/settings.json. `installStatusLine`
 // is orthogonal — it just toggles the statusLine stanza in settings.json.
 type ApplyClaudeConfigRequest struct {
-	InstallStatusLine bool                   `json:"installStatusLine"`
+	InstallStatusLine bool                   `json:"installStatusLine,omitempty"`
 	Preferences       *agent.ClaudeCodePrefs `json:"preferences"`
 	DefaultMode       string                 `json:"defaultMode,omitempty"`
 }

--- a/internal/server/module/imbot/routes.go
+++ b/internal/server/module/imbot/routes.go
@@ -189,6 +189,7 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 	router.GET("/imbot-settings/:uuid/weixin/qr-status", qrHandler.QRStatus,
 		swagger.WithTags("imbot-settings", "weixin"),
 		swagger.WithDescription("Polls Weixin QR code login status"),
+		swagger.WithQueryRequired("qrcode_id", "string", "QR code session identifier"),
 		swagger.WithResponseModel(QRStatusResponse{}),
 	)
 

--- a/internal/server/module/mcp/routes.go
+++ b/internal/server/module/mcp/routes.go
@@ -16,48 +16,60 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler, localHandler *
 	router.PUT("/mcp/config", handler.SetMCPRuntimeConfig,
 		swagger.WithDescription("Set global MCP runtime configuration"),
 		swagger.WithTags("mcp"),
+		swagger.WithRequestModel(MCPRuntimeConfigRequest{}),
 		swagger.WithResponseModel(MCPRuntimeConfigResponse{}),
 	)
 
 	router.GET("/mcp/clients", localHandler.ListClients,
 		swagger.WithDescription("List all registered MCP clients"),
 		swagger.WithTags("mcp"),
+		swagger.WithResponseModel(local.ClientListResponse{}),
 	)
 
 	router.POST("/mcp/client", localHandler.CreateClient,
 		swagger.WithDescription("Register a new MCP client"),
 		swagger.WithTags("mcp"),
+		swagger.WithRequestModel(local.CreateClientRequest{}),
+		swagger.WithResponseModel(local.ClientResponse{}),
 	)
 
 	router.GET("/mcp/client/:id", localHandler.GetClient,
 		swagger.WithDescription("Get a specific MCP client by ID"),
 		swagger.WithTags("mcp"),
+		swagger.WithResponseModel(local.ClientResponse{}),
 	)
 
 	router.PUT("/mcp/client/:id", localHandler.UpdateClient,
 		swagger.WithDescription("Update an MCP client configuration"),
 		swagger.WithTags("mcp"),
+		swagger.WithRequestModel(local.UpdateClientRequest{}),
+		swagger.WithResponseModel(local.ClientResponse{}),
 	)
 
 	router.DELETE("/mcp/client/:id", localHandler.DeleteClient,
 		swagger.WithDescription("Remove an MCP client"),
 		swagger.WithTags("mcp"),
+		swagger.WithResponseModel(local.ClientResponse{}),
 	)
 
 	router.POST("/mcp/client/:id/reconnect", localHandler.ReconnectClient,
 		swagger.WithDescription("Reconnect an MCP client"),
 		swagger.WithTags("mcp"),
+		swagger.WithResponseModel(local.ClientResponse{}),
 	)
 
 	router.GET("/mcp/install/:name", localHandler.GetInstallCommand,
 		swagger.WithDescription("Get MCP install command for a client"),
 		swagger.WithTags("mcp"),
+		swagger.WithResponseModel(local.InstallCommandResponse{}),
 	)
 
 	// Tool execution endpoint for testing
 	router.POST("/mcp/execute", localHandler.ExecuteTool,
 		swagger.WithDescription("Execute an MCP tool for testing"),
 		swagger.WithTags("mcp"),
+		swagger.WithRequestModel(local.ExecuteToolRequest{}),
+		swagger.WithResponseModel(local.ExecuteToolResponse{}),
 	)
 
 	// MCP Transport endpoints for local mode

--- a/internal/server/module/scenario/types.go
+++ b/internal/server/module/scenario/types.go
@@ -26,13 +26,13 @@ type ScenarioUpdateRequest struct {
 // ProfileCreateRequest represents the request to create or rename a profile
 type ProfileCreateRequest struct {
 	Name    string `json:"name" binding:"required"`
-	Unified bool   `json:"unified"` // Optional, defaults to false (separate mode)
+	Unified bool   `json:"unified,omitempty"` // Optional, defaults to false (separate mode)
 }
 
 // ProfileUpdateRequest represents the request to update a profile
 type ProfileUpdateRequest struct {
-	Name    string `json:"name"`
-	Unified *bool  `json:"unified"` // Pointer to distinguish zero from unset; nil = no change
+	Name    string `json:"name,omitempty"`
+	Unified *bool  `json:"unified,omitempty"` // Pointer to distinguish zero from unset; nil = no change
 }
 
 // ScenariosResponse represents the response for getting all scenarios
@@ -66,6 +66,6 @@ type ScenarioUpdateResponse struct {
 
 // ScenarioDescriptorsResponse represents the response for listing scenario descriptors
 type ScenarioDescriptorsResponse struct {
-	Success bool                      `json:"success" example:"true"`
-	Data    []typ.ScenarioDescriptor  `json:"data"`
+	Success bool                     `json:"success" example:"true"`
+	Data    []typ.ScenarioDescriptor `json:"data"`
 }

--- a/internal/server/module/sharing/routes.go
+++ b/internal/server/module/sharing/routes.go
@@ -1,16 +1,41 @@
 package sharing
 
-import "github.com/gin-gonic/gin"
+import "github.com/tingly-dev/tingly-box/swagger"
 
 // RegisterRoutes wires all token management endpoints onto the given group.
-func RegisterRoutes(group *gin.RouterGroup, h *Handler) {
-	tokens := group.Group("/tokens")
-
-	tokens.POST("", h.Create)
-	tokens.GET("", h.List)
-	tokens.GET("/:token_id", h.Get)
-	tokens.DELETE("/:token_id", h.Delete)
-	tokens.PUT("/:token_id/enable", h.Enable)
-	tokens.PUT("/:token_id/disable", h.Disable)
-	tokens.POST("/:token_id/regenerate", h.Regenerate)
+func RegisterRoutes(group *swagger.RouteGroup, h *Handler) {
+	group.POST("/tokens", h.Create,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("Create a shared API token"),
+		swagger.WithRequestModel(TokenCreateRequest{}),
+		swagger.WithResponseModel(TokenCreateResponse{}),
+	)
+	group.GET("/tokens", h.List,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("List shared API tokens"),
+		swagger.WithQueryModel(TokenListQuery{}),
+		swagger.WithResponseModel(TokenListResponse{}),
+	)
+	group.GET("/tokens/:token_id", h.Get,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("Get a shared API token"),
+		swagger.WithResponseModel(APITokenInfo{}),
+	)
+	group.DELETE("/tokens/:token_id", h.Delete,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("Delete a shared API token"),
+	)
+	group.PUT("/tokens/:token_id/enable", h.Enable,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("Enable a shared API token"),
+	)
+	group.PUT("/tokens/:token_id/disable", h.Disable,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("Disable a shared API token"),
+	)
+	group.POST("/tokens/:token_id/regenerate", h.Regenerate,
+		swagger.WithTags("tokens"),
+		swagger.WithDescription("Regenerate a shared API token"),
+		swagger.WithResponseModel(TokenCreateResponse{}),
+	)
 }

--- a/internal/server/module/sharing/types.go
+++ b/internal/server/module/sharing/types.go
@@ -9,6 +9,14 @@ type TokenCreateRequest struct {
 	DisplayName string `json:"display_name" binding:"required"`
 }
 
+// TokenListQuery describes the optional filters accepted by GET /tokens.
+type TokenListQuery struct {
+	UserID  string `form:"user_id" json:"user_id,omitempty"`
+	Enabled *bool  `form:"enabled" json:"enabled,omitempty"`
+	Limit   int    `form:"limit" json:"limit,omitempty"`
+	Offset  int    `form:"offset" json:"offset,omitempty"`
+}
+
 // TokenCreateResponse is returned after a token is created or regenerated.
 type TokenCreateResponse struct {
 	Token       string    `json:"token"`

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	sharing "github.com/tingly-dev/tingly-box/internal/server/module/sharing"
+	"github.com/tingly-dev/tingly-box/swagger"
 )
 
 // setupMiddleware configures server middleware
@@ -161,7 +162,8 @@ func (s *Server) UseTokenManagementEndpoints() {
 		return
 	}
 
-	api := s.engine.Group("/api/v1")
-	api.Use(s.getUserAuthMiddleware())
+	manager := swagger.NewRouteManager(s.engine)
+	api := manager.NewGroup("api", "v1", "")
+	api.Router.Use(s.getUserAuthMiddleware())
 	sharing.RegisterRoutes(api, sharing.NewHandler(store))
 }

--- a/internal/server/server_webui_api.go
+++ b/internal/server/server_webui_api.go
@@ -110,6 +110,7 @@ func (s *Server) UseWebAPIEndpoints(manager *swagger.RouteManager) {
 	apiV1.GET("/system/logs", s.webHandler.GetSystemLogs,
 		swagger.WithDescription("Get recent system logs with optional filtering (from JSON log file). Use 'limit' parameter to control how many recent entries to return."),
 		swagger.WithTags("system-logs"),
+		swagger.WithQuery("limit", "integer", "Maximum number of recent entries (default 100, max 1000)"),
 		swagger.WithResponseModel(SystemLogsResponse{}),
 	)
 	apiV1.GET("/system/logs/stats", s.webHandler.GetSystemLogStats,
@@ -119,16 +120,23 @@ func (s *Server) UseWebAPIEndpoints(manager *swagger.RouteManager) {
 	apiV1.GET("/system/logs/level", s.webHandler.GetSystemLogLevel,
 		swagger.WithDescription("Get the current system log level"),
 		swagger.WithTags("system-logs"),
+		swagger.WithResponseModel(SystemLogLevelResponse{}),
 	)
 	apiV1.POST("/system/logs/level", s.webHandler.SetSystemLogLevel,
 		swagger.WithDescription("Set the minimum log level for system logs"),
 		swagger.WithTags("system-logs"),
+		swagger.WithRequestModel(SystemLogLevelRequest{}),
+		swagger.WithResponseModel(SystemLogLevelResponse{}),
 	)
 
 	// Model Request routes (correlated per-request traces across pipeline stages)
 	apiV1.GET("/requests", s.webHandler.GetModelRequests,
 		swagger.WithDescription("List recent model requests, one row per correlation id, joining the HTTP access log, model-request stage logs and smart-routing traces. Supports 'limit', 'scenario', 'provider' and 'status' filters."),
 		swagger.WithTags("requests"),
+		swagger.WithQuery("limit", "integer", "Maximum number of requests (default 100, max 1000)"),
+		swagger.WithQuery("scenario", "string", "Exact scenario filter"),
+		swagger.WithQuery("provider", "string", "Exact provider filter"),
+		swagger.WithQuery("status", "string", "Exact HTTP status filter"),
 		swagger.WithResponseModel(ModelRequestsResponse{}),
 	)
 	apiV1.GET("/requests/:id", s.webHandler.GetModelRequestDetail,
@@ -231,86 +239,118 @@ func (s *Server) UseWebAPIEndpoints(manager *swagger.RouteManager) {
 	apiV1.GET("/guardrails/config", s.guardrailsHandler.GetGuardrailsConfig,
 		swagger.WithDescription("Get guardrails config content and parsed config"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsConfigResponse{}),
 	)
 	apiV1.GET("/guardrails/builtins", s.guardrailsHandler.GetGuardrailsBuiltins,
 		swagger.WithDescription("Get curated builtin guardrails policies"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsBuiltinsResponse{}),
 	)
 	apiV1.GET("/guardrails/registry", s.guardrailsHandler.GetGuardrailsRegistry,
 		swagger.WithDescription("List downloadable guardrails policies from a remote registry"),
 		swagger.WithTags("guardrails"),
+		swagger.WithQuery("refresh", "string", "Set to 1 to refresh the registry cache"),
+		swagger.WithResponseModel(guardrailsRegistryResponse{}),
 	)
 	apiV1.POST("/guardrails/registry/install", s.guardrailsHandler.InstallGuardrailsRegistryPolicy,
 		swagger.WithDescription("Download a guardrails policy from a remote registry into the local guardrails directory"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsRegistryInstallRequest{}),
+		swagger.WithResponseModel(guardrailsRegistryInstallResponse{}),
 	)
 	apiV1.GET("/guardrails/credentials", s.guardrailsHandler.GetGuardrailsCredentials,
 		swagger.WithDescription("List protected credentials used by guardrails pseudonymization"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(protectedCredentialsListResponse{}),
 	)
 	apiV1.GET("/guardrails/credential/:id", s.guardrailsHandler.GetGuardrailsCredential,
 		swagger.WithDescription("Get a protected credential for the local editor dialog"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(protectedCredentialDetailEnvelope{}),
 	)
 	apiV1.POST("/guardrails/credential", s.guardrailsHandler.CreateGuardrailsCredential,
 		swagger.WithDescription("Create a protected credential for guardrails pseudonymization"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(protectedCredentialCreateRequest{}),
+		swagger.WithResponseModel(protectedCredentialMutationResponse{}),
 	)
 	apiV1.PUT("/guardrails/credential/:id", s.guardrailsHandler.UpdateGuardrailsCredential,
 		swagger.WithDescription("Update a protected credential for guardrails pseudonymization"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(protectedCredentialUpdateRequest{}),
+		swagger.WithResponseModel(protectedCredentialMutationResponse{}),
 	)
 	apiV1.DELETE("/guardrails/credential/:id", s.guardrailsHandler.DeleteGuardrailsCredential,
 		swagger.WithDescription("Delete a protected credential for guardrails pseudonymization"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(protectedCredentialDeleteResponse{}),
 	)
 	apiV1.PUT("/guardrails/config", s.guardrailsHandler.UpdateGuardrailsConfig,
 		swagger.WithDescription("Update guardrails config and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsConfigUpdateRequest{}),
+		swagger.WithResponseModel(guardrailsConfigUpdateResponse{}),
 	)
 	apiV1.POST("/guardrails/fragment/import", s.guardrailsHandler.ImportGuardrailsFragment,
 		swagger.WithDescription("Import one or more guardrails policies into the shared custom fragment"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsFragmentImportRequest{}),
+		swagger.WithResponseModel(guardrailsFragmentImportResponse{}),
 	)
 	apiV1.POST("/guardrails/fragment/export", s.guardrailsHandler.ExportGuardrailsFragments,
 		swagger.WithDescription("Export one or more imported guardrails policy fragments"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsFragmentExportRequest{}),
+		swagger.WithResponseModel(guardrailsFragmentExportResponse{}),
 	)
 	apiV1.PUT("/guardrails/policy/:id", s.guardrailsHandler.UpdateGuardrailsPolicy,
 		swagger.WithDescription("Update a guardrails policy and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsPolicyUpdateRequest{}),
+		swagger.WithResponseModel(guardrailsPolicyUpdateResponse{}),
 	)
 	apiV1.DELETE("/guardrails/policy/:id", s.guardrailsHandler.DeleteGuardrailsPolicy,
 		swagger.WithDescription("Delete a guardrails policy and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsPolicyUpdateResponse{}),
 	)
 	apiV1.POST("/guardrails/policy", s.guardrailsHandler.CreateGuardrailsPolicy,
 		swagger.WithDescription("Create a new guardrails policy and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsPolicyCreateRequest{}),
+		swagger.WithResponseModel(guardrailsPolicyUpdateResponse{}),
 	)
 	apiV1.PUT("/guardrails/group/:id", s.guardrailsHandler.UpdateGuardrailsGroup,
 		swagger.WithDescription("Update a guardrails group and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsGroupUpdateRequest{}),
+		swagger.WithResponseModel(guardrailsGroupUpdateResponse{}),
 	)
 	apiV1.DELETE("/guardrails/group/:id", s.guardrailsHandler.DeleteGuardrailsGroup,
 		swagger.WithDescription("Delete a guardrails group and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsGroupUpdateResponse{}),
 	)
 	apiV1.POST("/guardrails/group", s.guardrailsHandler.CreateGuardrailsGroup,
 		swagger.WithDescription("Create a new guardrails group and reload engine"),
 		swagger.WithTags("guardrails"),
+		swagger.WithRequestModel(guardrailsGroupCreateRequest{}),
+		swagger.WithResponseModel(guardrailsGroupUpdateResponse{}),
 	)
 	apiV1.POST("/guardrails/reload", s.guardrailsHandler.ReloadGuardrailsConfig,
 		swagger.WithDescription("Reload guardrails config from disk"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsReloadResponse{}),
 	)
 	apiV1.GET("/guardrails/history", s.guardrailsHandler.GetGuardrailsHistory,
 		swagger.WithDescription("Get recent guardrails interception history"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsHistoryResponse{}),
 	)
 	apiV1.DELETE("/guardrails/history", s.guardrailsHandler.ClearGuardrailsHistory,
 		swagger.WithDescription("Clear guardrails interception history"),
 		swagger.WithTags("guardrails"),
+		swagger.WithResponseModel(guardrailsSuccessResponse{}),
 	)
 
 	// History

--- a/internal/server/swagger.go
+++ b/internal/server/swagger.go
@@ -13,8 +13,10 @@ import (
 	mcpmodule "github.com/tingly-dev/tingly-box/internal/server/module/mcp"
 	notifymodule "github.com/tingly-dev/tingly-box/internal/server/module/notify"
 	oauthmodule "github.com/tingly-dev/tingly-box/internal/server/module/oauth"
+	"github.com/tingly-dev/tingly-box/internal/server/module/sharing"
 	"github.com/tingly-dev/tingly-box/internal/server/module/statusline"
 	usagemodule "github.com/tingly-dev/tingly-box/internal/server/module/usage"
+	virtualmodelmodule "github.com/tingly-dev/tingly-box/internal/server/module/virtualmodel"
 	"github.com/tingly-dev/tingly-box/swagger"
 )
 
@@ -70,6 +72,11 @@ func registerAllAPIRoutes(engine *gin.Engine, manager *swagger.RouteManager, s *
 	apiV1 := manager.NewGroup("api", "v1", "")
 	apiV1.Router.Use(s.getUserAuthMiddleware())
 	oauthmodule.RegisterRoutes(apiV1, s.getUserAuthMiddleware(), s.oauthHandler)
+	virtualmodelmodule.RegisterRoutes(
+		apiV1,
+		s.getUserAuthMiddleware(),
+		virtualmodelmodule.NewHandler(s.virtualModelService),
+	)
 	// Register callback routes (unauthenticated)
 	oauthmodule.RegisterCallbackRoutes(manager, s.oauthHandler)
 
@@ -102,6 +109,10 @@ func registerAllAPIRoutes(engine *gin.Engine, manager *swagger.RouteManager, s *
 	// MCP runtime API routes
 	mcpHandler := mcpmodule.NewHandler(cfg)
 	mcpmodule.RegisterRoutes(apiV1, mcpHandler, mcpHandler.GetLocalHandler(), mcpHandler.GetTransportHandler())
+
+	// Schema generation only references these handlers, so no live token store
+	// is required here.
+	sharing.RegisterRoutes(apiV1, sharing.NewHandler(nil))
 
 	// Provider quota API routes
 	// Note: skipped for OpenAPI generation as quotaManager is not available

--- a/openapi.json
+++ b/openapi.json
@@ -493,7 +493,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsBuiltinsResponse"
                 }
               }
             }
@@ -515,7 +515,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsConfigResponse"
                 }
               }
             }
@@ -529,13 +529,24 @@
         "summary": "Update guardrails config and reload engine",
         "description": "Update guardrails config and reload engine",
         "operationId": "apiV1GuardrailsConfigPut",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsConfigUpdateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsConfigUpdateResponse"
                 }
               }
             }
@@ -551,13 +562,24 @@
         "summary": "Create a protected credential for guardrails pseudonymization",
         "description": "Create a protected credential for guardrails pseudonymization",
         "operationId": "apiV1GuardrailsCredentialPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/protectedCredentialCreateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/protectedCredentialMutationResponse"
                 }
               }
             }
@@ -590,7 +612,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/protectedCredentialDetailEnvelope"
                 }
               }
             }
@@ -615,13 +637,24 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/protectedCredentialUpdateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/protectedCredentialMutationResponse"
                 }
               }
             }
@@ -652,7 +685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/protectedCredentialDeleteResponse"
                 }
               }
             }
@@ -674,7 +707,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/protectedCredentialsListResponse"
                 }
               }
             }
@@ -690,13 +723,24 @@
         "summary": "Export one or more imported guardrails policy fragments",
         "description": "Export one or more imported guardrails policy fragments",
         "operationId": "apiV1GuardrailsFragmentExportPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsFragmentExportRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsFragmentExportResponse"
                 }
               }
             }
@@ -712,13 +756,24 @@
         "summary": "Import one or more guardrails policies into the shared custom fragment",
         "description": "Import one or more guardrails policies into the shared custom fragment",
         "operationId": "apiV1GuardrailsFragmentImportPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsFragmentImportRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsFragmentImportResponse"
                 }
               }
             }
@@ -734,13 +789,24 @@
         "summary": "Create a new guardrails group and reload engine",
         "description": "Create a new guardrails group and reload engine",
         "operationId": "apiV1GuardrailsGroupPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsGroupCreateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsGroupUpdateResponse"
                 }
               }
             }
@@ -767,13 +833,24 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsGroupUpdateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsGroupUpdateResponse"
                 }
               }
             }
@@ -804,7 +881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsGroupUpdateResponse"
                 }
               }
             }
@@ -826,7 +903,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsHistoryResponse"
                 }
               }
             }
@@ -846,7 +923,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsSuccessResponse"
                 }
               }
             }
@@ -862,13 +939,24 @@
         "summary": "Create a new guardrails policy and reload engine",
         "description": "Create a new guardrails policy and reload engine",
         "operationId": "apiV1GuardrailsPolicyPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsPolicyCreateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsPolicyUpdateResponse"
                 }
               }
             }
@@ -895,13 +983,24 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsPolicyUpdateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsPolicyUpdateResponse"
                 }
               }
             }
@@ -932,7 +1031,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsPolicyUpdateResponse"
                 }
               }
             }
@@ -948,13 +1047,24 @@
         "summary": "List downloadable guardrails policies from a remote registry",
         "description": "List downloadable guardrails policies from a remote registry",
         "operationId": "apiV1GuardrailsRegistryGet",
+        "parameters": [
+          {
+            "name": "refresh",
+            "in": "query",
+            "description": "Set to 1 to refresh the registry cache",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsRegistryResponse"
                 }
               }
             }
@@ -970,13 +1080,24 @@
         "summary": "Download a guardrails policy from a remote registry into the local guardrails directory",
         "description": "Download a guardrails policy from a remote registry into the local guardrails directory",
         "operationId": "apiV1GuardrailsRegistryInstallPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/guardrailsRegistryInstallRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsRegistryInstallResponse"
                 }
               }
             }
@@ -998,7 +1119,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/guardrailsReloadResponse"
                 }
               }
             }
@@ -1759,6 +1880,15 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "qrcode_id",
+            "in": "query",
+            "description": "QR code session identifier",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1933,13 +2063,24 @@
         "summary": "Register a new MCP client",
         "description": "Register a new MCP client",
         "operationId": "apiV1McpClientPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClientRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ClientResponse"
                 }
               }
             }
@@ -1972,7 +2113,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ClientResponse"
                 }
               }
             }
@@ -1997,13 +2138,24 @@
             }
           }
         ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClientRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ClientResponse"
                 }
               }
             }
@@ -2034,7 +2186,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ClientResponse"
                 }
               }
             }
@@ -2067,7 +2219,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ClientResponse"
                 }
               }
             }
@@ -2089,7 +2241,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ClientListResponse"
                 }
               }
             }
@@ -2125,6 +2277,17 @@
         "summary": "Set global MCP runtime configuration",
         "description": "Set global MCP runtime configuration",
         "operationId": "apiV1McpConfigPut",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MCPRuntimeConfigRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
@@ -2147,13 +2310,24 @@
         "summary": "Execute an MCP tool for testing",
         "description": "Execute an MCP tool for testing",
         "operationId": "apiV1McpExecutePost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteToolRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ExecuteToolResponse"
                 }
               }
             }
@@ -2186,7 +2360,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/InstallCommandResponse"
                 }
               }
             }
@@ -2656,6 +2830,44 @@
         "summary": "List recent model requests, one row per correlation id, joining the HTTP access log, model-request stage logs and smart-routing traces. Supports 'limit', 'scenario', 'provider' and 'status' filters.",
         "description": "List recent model requests, one row per correlation id, joining the HTTP access log, model-request stage logs and smart-routing traces. Supports 'limit', 'scenario', 'provider' and 'status' filters.",
         "operationId": "apiV1RequestsGet",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of requests (default 100, max 1000)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "scenario",
+            "in": "query",
+            "description": "Exact scenario filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Exact provider filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Exact HTTP status filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -3562,6 +3774,17 @@
         "summary": "Get recent system logs with optional filtering (from JSON log file). Use 'limit' parameter to control how many recent entries to return.",
         "description": "Get recent system logs with optional filtering (from JSON log file). Use 'limit' parameter to control how many recent entries to return.",
         "operationId": "apiV1SystemLogsGet",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of recent entries (default 100, max 1000)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -3590,7 +3813,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SystemLogLevelResponse"
                 }
               }
             }
@@ -3604,13 +3827,24 @@
         "summary": "Set the minimum log level for system logs",
         "description": "Set the minimum log level for system logs",
         "operationId": "apiV1SystemLogsLevelPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemLogLevelRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SystemLogLevelResponse"
                 }
               }
             }
@@ -3686,6 +3920,262 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tokens": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "List shared API tokens",
+        "description": "List shared API tokens",
+        "operationId": "apiV1TokensGet",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Query parameter user_id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "enabled",
+            "in": "query",
+            "description": "Query parameter enabled",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Query parameter limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Query parameter offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenListResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Create a shared API token",
+        "description": "Create a shared API token",
+        "operationId": "apiV1TokensPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenCreateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tokens/{token_id}": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Get a shared API token",
+        "description": "Get a shared API token",
+        "operationId": "apiV1TokensToken_idGet",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APITokenInfo"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Delete a shared API token",
+        "description": "Delete a shared API token",
+        "operationId": "apiV1TokensToken_idDelete",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tokens/{token_id}/disable": {
+      "put": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Disable a shared API token",
+        "description": "Disable a shared API token",
+        "operationId": "apiV1TokensToken_idDisablePut",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tokens/{token_id}/enable": {
+      "put": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Enable a shared API token",
+        "description": "Enable a shared API token",
+        "operationId": "apiV1TokensToken_idEnablePut",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tokens/{token_id}/regenerate": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Regenerate a shared API token",
+        "description": "Regenerate a shared API token",
+        "operationId": "apiV1TokensToken_idRegeneratePost",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "Resource ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenCreateResponse"
                 }
               }
             }
@@ -4115,6 +4605,28 @@
               "application/json": {
                 "schema": {
                   "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/vmodel/available-models": {
+      "get": {
+        "tags": [
+          "vmodel"
+        ],
+        "summary": "List virtual models registered in the in-process registries, grouped by protocol",
+        "description": "List virtual models registered in the in-process registries, grouped by protocol",
+        "operationId": "apiV1VmodelAvailable-modelsGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailableModelsResponse"
                 }
               }
             }
@@ -4887,6 +5399,48 @@
   },
   "components": {
     "schemas": {
+      "APITokenInfo": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Field created_at"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "Field created_by"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Field display_name"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "last_used_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Field last_used_at"
+          },
+          "token_id": {
+            "type": "string",
+            "description": "Field token_id"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Field user_id"
+          }
+        },
+        "required": [
+          "token_id",
+          "user_id",
+          "display_name",
+          "enabled",
+          "created_at"
+        ]
+      },
       "ActionHistoryEntry": {
         "type": "object",
         "properties": {
@@ -4895,15 +5449,12 @@
             "description": "Field action"
           },
           "details": {
-            "type": "object",
             "description": "Field details"
           },
           "fields": {
             "type": "object",
             "description": "Field fields",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "level": {
             "type": "string",
@@ -4949,6 +5500,25 @@
           "total",
           "actions"
         ]
+      },
+      "ActionSelector": {
+        "type": "object",
+        "properties": {
+          "exclude": {
+            "type": "array",
+            "description": "Field exclude",
+            "items": {
+              "type": "string"
+            }
+          },
+          "include": {
+            "type": "array",
+            "description": "Field include",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       },
       "AddSkillLocationRequest": {
         "type": "object",
@@ -5163,7 +5733,6 @@
           }
         },
         "required": [
-          "installStatusLine",
           "preferences"
         ]
       },
@@ -5330,6 +5899,46 @@
           "message"
         ]
       },
+      "AvailableModelEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Field id",
+            "example": "vm-claude-haiku"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Field protocol",
+            "example": "anthropic"
+          }
+        },
+        "required": [
+          "id",
+          "protocol"
+        ]
+      },
+      "AvailableModelsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Field data",
+            "items": {
+              "$ref": "#/components/schemas/AvailableModelEntry"
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success",
+            "example": true
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ]
+      },
       "ClaudeCodePrefs": {
         "type": "object",
         "properties": {
@@ -5427,6 +6036,48 @@
           }
         }
       },
+      "ClientListResponse": {
+        "type": "object",
+        "properties": {
+          "clients": {
+            "type": "array",
+            "description": "Field clients",
+            "items": {
+              "$ref": "#/components/schemas/MCPClient"
+            }
+          },
+          "error": {
+            "type": "string",
+            "description": "Field error"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "ClientResponse": {
+        "type": "object",
+        "properties": {
+          "client": {
+            "$ref": "#/components/schemas/MCPClient"
+          },
+          "error": {
+            "type": "string",
+            "description": "Field error"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
       "CodexConfigPreviewResponse": {
         "type": "object",
         "properties": {
@@ -5486,6 +6137,40 @@
           }
         }
       },
+      "Config": {
+        "type": "object",
+        "properties": {
+          "error_strategy": {
+            "type": "string",
+            "description": "Field error_strategy"
+          },
+          "groups": {
+            "type": "array",
+            "description": "Field groups",
+            "items": {
+              "$ref": "#/components/schemas/PolicyGroup"
+            }
+          },
+          "imports": {
+            "type": "array",
+            "description": "Field imports",
+            "items": {
+              "type": "string"
+            }
+          },
+          "policies": {
+            "type": "array",
+            "description": "Field policies",
+            "items": {
+              "$ref": "#/components/schemas/Policy"
+            }
+          },
+          "strategy": {
+            "type": "string",
+            "description": "Field strategy"
+          }
+        }
+      },
       "ConfigInfo": {
         "type": "object",
         "properties": {
@@ -5520,6 +6205,95 @@
         "required": [
           "success",
           "data"
+        ]
+      },
+      "CreateClientRequest": {
+        "type": "object",
+        "properties": {
+          "allowed_extra_headers": {
+            "type": "array",
+            "description": "Field allowed_extra_headers",
+            "items": {
+              "type": "string"
+            }
+          },
+          "args": {
+            "type": "array",
+            "description": "Field args",
+            "items": {
+              "type": "string"
+            }
+          },
+          "auth_type": {
+            "type": "string",
+            "description": "Field auth_type"
+          },
+          "connection_string": {
+            "type": "string",
+            "description": "Field connection_string"
+          },
+          "connection_type": {
+            "type": "string",
+            "description": "Field connection_type"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Field cwd"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "env": {
+            "type": "object",
+            "description": "Field env",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "headers": {
+            "type": "object",
+            "description": "Field headers",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "is_ping_available": {
+            "type": "boolean",
+            "description": "Field is_ping_available"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "oauth_config": {
+            "$ref": "#/components/schemas/MCPOAuthConfig"
+          },
+          "proxy_url": {
+            "type": "string",
+            "description": "Field proxy_url"
+          },
+          "stdio_config": {
+            "$ref": "#/components/schemas/MCPStdioConfig"
+          },
+          "tools_to_auto_execute": {
+            "type": "array",
+            "description": "Field tools_to_auto_execute",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tools_to_execute": {
+            "type": "array",
+            "description": "Field tools_to_execute",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "connection_type"
         ]
       },
       "CreateProviderRequest": {
@@ -5594,7 +6368,6 @@
         "type": "object",
         "properties": {
           "data": {
-            "type": "object",
             "description": "Field data"
           },
           "message": {
@@ -5957,9 +6730,6 @@
         },
         "required": [
           "target_type",
-          "rule_uuid",
-          "provider_uuid",
-          "model",
           "test_mode"
         ]
       },
@@ -5981,6 +6751,89 @@
           "success"
         ]
       },
+      "Entry": {
+        "type": "object",
+        "properties": {
+          "alias_hits": {
+            "type": "array",
+            "description": "Field alias_hits",
+            "items": {
+              "type": "string"
+            }
+          },
+          "block_message": {
+            "type": "string",
+            "description": "Field block_message"
+          },
+          "command_name": {
+            "type": "string",
+            "description": "Field command_name"
+          },
+          "credential_names": {
+            "type": "array",
+            "description": "Field credential_names",
+            "items": {
+              "type": "string"
+            }
+          },
+          "credential_refs": {
+            "type": "array",
+            "description": "Field credential_refs",
+            "items": {
+              "type": "string"
+            }
+          },
+          "direction": {
+            "type": "string",
+            "description": "Field direction"
+          },
+          "model": {
+            "type": "string",
+            "description": "Field model"
+          },
+          "phase": {
+            "type": "string",
+            "description": "Field phase"
+          },
+          "preview": {
+            "type": "string",
+            "description": "Field preview"
+          },
+          "provider": {
+            "type": "string",
+            "description": "Field provider"
+          },
+          "reasons": {
+            "type": "array",
+            "description": "Field reasons",
+            "items": {
+              "$ref": "#/components/schemas/PolicyResult"
+            }
+          },
+          "scenario": {
+            "type": "string",
+            "description": "Field scenario"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Field time"
+          },
+          "verdict": {
+            "type": "string",
+            "description": "Field verdict"
+          }
+        },
+        "required": [
+          "time",
+          "scenario",
+          "model",
+          "provider",
+          "direction",
+          "phase",
+          "verdict"
+        ]
+      },
       "ErrorDetail": {
         "type": "object",
         "properties": {
@@ -5995,6 +6848,53 @@
         },
         "required": [
           "message"
+        ]
+      },
+      "ExecuteToolRequest": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "type": "object",
+            "description": "Field arguments",
+            "additionalProperties": {}
+          },
+          "client_id": {
+            "type": "string",
+            "description": "Field client_id"
+          },
+          "tool_name": {
+            "type": "string",
+            "description": "Field tool_name"
+          }
+        },
+        "required": [
+          "client_id",
+          "tool_name"
+        ]
+      },
+      "ExecuteToolResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Field error"
+          },
+          "execution_time": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field execution_time"
+          },
+          "result": {
+            "type": "string",
+            "description": "Field result"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success"
         ]
       },
       "ExportProviderResponse": {
@@ -6356,9 +7256,7 @@
       },
       "H": {
         "type": "object",
-        "additionalProperties": {
-          "type": "object"
-        }
+        "additionalProperties": {}
       },
       "HealthInfoResponse": {
         "type": "object",
@@ -6389,7 +7287,6 @@
         "type": "object",
         "properties": {
           "data": {
-            "type": "object",
             "description": "Field data"
           },
           "success": {
@@ -6657,6 +7554,26 @@
           "message"
         ]
       },
+      "InstallCommandResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Field error"
+          },
+          "install_command": {
+            "type": "string",
+            "description": "Field install_command"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
       "LatestVersionInfo": {
         "type": "object",
         "properties": {
@@ -6912,16 +7829,12 @@
           "data": {
             "type": "object",
             "description": "Field data",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "fields": {
             "type": "object",
             "description": "Field fields",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "level": {
             "type": "string",
@@ -6964,6 +7877,35 @@
           "logs"
         ]
       },
+      "MCPClient": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/MCPSourceConfig"
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "state": {
+            "type": "string",
+            "description": "Field state"
+          },
+          "tools": {
+            "type": "array",
+            "description": "Field tools",
+            "items": {
+              "$ref": "#/components/schemas/MCPTool"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "config",
+          "tools",
+          "state"
+        ]
+      },
       "MCPOAuthConfig": {
         "type": "object",
         "properties": {
@@ -7004,6 +7946,27 @@
             "type": "string",
             "description": "Field mode"
           },
+          "request_timeout": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field request_timeout"
+          },
+          "sources": {
+            "type": "array",
+            "description": "Field sources",
+            "items": {
+              "$ref": "#/components/schemas/MCPSourceConfig"
+            }
+          },
+          "strip_disabled_mcp_tools": {
+            "type": "boolean",
+            "description": "Field strip_disabled_mcp_tools"
+          }
+        }
+      },
+      "MCPRuntimeConfigRequest": {
+        "type": "object",
+        "properties": {
           "request_timeout": {
             "type": "integer",
             "format": "int64",
@@ -7186,6 +8149,22 @@
           "command"
         ]
       },
+      "MCPTool": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Field description"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
       "MemStatsResponse": {
         "type": "object",
         "properties": {
@@ -7364,9 +8343,7 @@
           "fields": {
             "type": "object",
             "description": "Field fields",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "level": {
             "type": "string",
@@ -7649,9 +8626,7 @@
           "extra_fields": {
             "type": "object",
             "description": "Field extra_fields",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "issuer": {
             "type": "string",
@@ -8137,9 +9112,7 @@
           "categories": {
             "type": "object",
             "description": "Field categories",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "platforms": {
             "type": "array",
@@ -8157,6 +9130,171 @@
           "success",
           "platforms",
           "categories"
+        ]
+      },
+      "Policy": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "groups": {
+            "type": "array",
+            "description": "Field groups",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "kind": {
+            "type": "string",
+            "description": "Field kind"
+          },
+          "match": {
+            "$ref": "#/components/schemas/PolicyMatch"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Field reason"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/Scope"
+          },
+          "verdict": {
+            "type": "string",
+            "description": "Field verdict"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "enabled",
+          "match"
+        ]
+      },
+      "PolicyGroup": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "severity": {
+            "type": "string",
+            "description": "Field severity"
+          }
+        },
+        "required": [
+          "id",
+          "enabled"
+        ]
+      },
+      "PolicyMatch": {
+        "type": "object",
+        "properties": {
+          "actions": {
+            "$ref": "#/components/schemas/ActionSelector"
+          },
+          "case_sensitive": {
+            "type": "boolean",
+            "description": "Field case_sensitive"
+          },
+          "credential_refs": {
+            "type": "array",
+            "description": "Field credential_refs",
+            "items": {
+              "type": "string"
+            }
+          },
+          "match_mode": {
+            "type": "string",
+            "description": "Field match_mode"
+          },
+          "min_matches": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field min_matches"
+          },
+          "pattern_mode": {
+            "type": "string",
+            "description": "Field pattern_mode"
+          },
+          "patterns": {
+            "type": "array",
+            "description": "Field patterns",
+            "items": {
+              "type": "string"
+            }
+          },
+          "resources": {
+            "$ref": "#/components/schemas/ResourceMatcher"
+          },
+          "terms": {
+            "type": "array",
+            "description": "Field terms",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tool_names": {
+            "type": "array",
+            "description": "Field tool_names",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PolicyResult": {
+        "type": "object",
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "description": "Field evidence",
+            "additionalProperties": {}
+          },
+          "policy_id": {
+            "type": "string",
+            "description": "Field policy_id"
+          },
+          "policy_name": {
+            "type": "string",
+            "description": "Field policy_name"
+          },
+          "policy_type": {
+            "type": "string",
+            "description": "Field policy_type"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Field reason"
+          },
+          "verdict": {
+            "type": "string",
+            "description": "Field verdict"
+          }
+        },
+        "required": [
+          "policy_id",
+          "policy_name",
+          "policy_type",
+          "verdict"
         ]
       },
       "ProbeResult": {
@@ -8275,9 +9413,7 @@
           "input": {
             "type": "object",
             "description": "Field input",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "name": {
             "type": "string",
@@ -8303,8 +9439,7 @@
           }
         },
         "required": [
-          "name",
-          "unified"
+          "name"
         ]
       },
       "ProfileUpdateRequest": {
@@ -8318,11 +9453,7 @@
             "type": "boolean",
             "description": "Field unified"
           }
-        },
-        "required": [
-          "name",
-          "unified"
-        ]
+        }
       },
       "ProviderImportInfo": {
         "type": "object",
@@ -8889,6 +10020,26 @@
           "message"
         ]
       },
+      "ResourceMatcher": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "Field mode"
+          },
+          "type": {
+            "type": "string",
+            "description": "Field type"
+          },
+          "values": {
+            "type": "array",
+            "description": "Field values",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "RestoreConfigResponse": {
         "type": "object",
         "properties": {
@@ -9080,7 +10231,6 @@
         "type": "object",
         "properties": {
           "data": {
-            "type": "object",
             "description": "Field data"
           },
           "success": {
@@ -9140,9 +10290,7 @@
           "extensions": {
             "type": "object",
             "description": "Field extensions",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "flags": {
             "$ref": "#/components/schemas/ScenarioFlags"
@@ -9408,6 +10556,46 @@
           "success",
           "data"
         ]
+      },
+      "Scope": {
+        "type": "object",
+        "properties": {
+          "content_types": {
+            "type": "array",
+            "description": "Field content_types",
+            "items": {
+              "type": "string"
+            }
+          },
+          "directions": {
+            "type": "array",
+            "description": "Field directions",
+            "items": {
+              "type": "string"
+            }
+          },
+          "models": {
+            "type": "array",
+            "description": "Field models",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scenarios": {
+            "type": "array",
+            "description": "Field scenarios",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "description": "Field tags",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       },
       "ServerActionResponse": {
         "type": "object",
@@ -9876,9 +11064,7 @@
           "fields": {
             "type": "object",
             "description": "Field fields",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "additionalProperties": {}
           },
           "level": {
             "type": "string",
@@ -9898,6 +11084,34 @@
           "time",
           "level",
           "message"
+        ]
+      },
+      "SystemLogLevelRequest": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "string",
+            "description": "Field level"
+          }
+        },
+        "required": [
+          "level"
+        ]
+      },
+      "SystemLogLevelResponse": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "string",
+            "description": "Field level"
+          },
+          "message": {
+            "type": "string",
+            "description": "Field message"
+          }
+        },
+        "required": [
+          "level"
         ]
       },
       "SystemLogsResponse": {
@@ -9925,7 +11139,6 @@
         "type": "object",
         "properties": {
           "params": {
-            "type": "object",
             "description": "Field params"
           },
           "type": {
@@ -10145,6 +11358,51 @@
           "source"
         ]
       },
+      "TokenCreateRequest": {
+        "type": "object",
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "description": "Field display_name"
+          }
+        },
+        "required": [
+          "display_name"
+        ]
+      },
+      "TokenCreateResponse": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Field created_at"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Field display_name"
+          },
+          "token": {
+            "type": "string",
+            "description": "Field token"
+          },
+          "token_id": {
+            "type": "string",
+            "description": "Field token_id"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Field user_id"
+          }
+        },
+        "required": [
+          "token",
+          "token_id",
+          "user_id",
+          "display_name",
+          "created_at"
+        ]
+      },
       "TokenInfo": {
         "type": "object",
         "properties": {
@@ -10169,6 +11427,50 @@
           "valid"
         ]
       },
+      "TokenListQuery": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field limit"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field offset"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Field user_id"
+          }
+        }
+      },
+      "TokenListResponse": {
+        "type": "object",
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "description": "Field tokens",
+            "items": {
+              "$ref": "#/components/schemas/APITokenInfo"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field total"
+          }
+        },
+        "required": [
+          "tokens",
+          "total"
+        ]
+      },
       "TokenResponse": {
         "type": "object",
         "properties": {
@@ -10187,6 +11489,80 @@
           "token",
           "type"
         ]
+      },
+      "UpdateClientRequest": {
+        "type": "object",
+        "properties": {
+          "allowed_extra_headers": {
+            "type": "array",
+            "description": "Field allowed_extra_headers",
+            "items": {
+              "type": "string"
+            }
+          },
+          "auth_type": {
+            "type": "string",
+            "description": "Field auth_type"
+          },
+          "connection_string": {
+            "type": "string",
+            "description": "Field connection_string"
+          },
+          "connection_type": {
+            "type": "string",
+            "description": "Field connection_type"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "env": {
+            "type": "object",
+            "description": "Field env",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "headers": {
+            "type": "object",
+            "description": "Field headers",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "is_ping_available": {
+            "type": "boolean",
+            "description": "Field is_ping_available"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "oauth_config": {
+            "$ref": "#/components/schemas/MCPOAuthConfig"
+          },
+          "proxy_url": {
+            "type": "string",
+            "description": "Field proxy_url"
+          },
+          "stdio_config": {
+            "$ref": "#/components/schemas/MCPStdioConfig"
+          },
+          "tools_to_auto_execute": {
+            "type": "array",
+            "description": "Field tools_to_auto_execute",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tools_to_execute": {
+            "type": "array",
+            "description": "Field tools_to_execute",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       },
       "UpdateProviderRequest": {
         "type": "object",
@@ -10950,6 +12326,798 @@
           "message",
           "type"
         ]
+      },
+      "guardrailsBuiltinsResponse": {
+        "type": "object",
+        "properties": {
+          "policies": {
+            "type": "array",
+            "description": "Field policies",
+            "items": {
+              "$ref": "#/components/schemas/Policy"
+            }
+          }
+        },
+        "required": [
+          "policies"
+        ]
+      },
+      "guardrailsConfigResponse": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/Config"
+          },
+          "content": {
+            "type": "string",
+            "description": "Field content"
+          },
+          "exists": {
+            "type": "boolean",
+            "description": "Field exists"
+          },
+          "imports": {
+            "type": "array",
+            "description": "Field imports",
+            "items": {
+              "$ref": "#/components/schemas/guardrailsImportRef"
+            }
+          },
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "supported_scenarios": {
+            "type": "array",
+            "description": "Field supported_scenarios",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "path",
+          "exists",
+          "content",
+          "config",
+          "supported_scenarios"
+        ]
+      },
+      "guardrailsConfigUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Field content"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "guardrailsConfigUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "rule_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field rule_count"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "path",
+          "rule_count"
+        ]
+      },
+      "guardrailsFragmentExportFile": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Field content"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "policy_ids": {
+            "type": "array",
+            "description": "Field policy_ids",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "content"
+        ]
+      },
+      "guardrailsFragmentExportRequest": {
+        "type": "object",
+        "properties": {
+          "paths": {
+            "type": "array",
+            "description": "Field paths",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "paths"
+        ]
+      },
+      "guardrailsFragmentExportResponse": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": "array",
+            "description": "Field files",
+            "items": {
+              "$ref": "#/components/schemas/guardrailsFragmentExportFile"
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "files"
+        ]
+      },
+      "guardrailsFragmentImportRequest": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Field content"
+          },
+          "file_name": {
+            "type": "string",
+            "description": "Field file_name"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "guardrailsFragmentImportResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "policy_ids": {
+            "type": "array",
+            "description": "Field policy_ids",
+            "items": {
+              "type": "string"
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "path",
+          "policy_ids"
+        ]
+      },
+      "guardrailsGroupCreateRequest": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "severity": {
+            "type": "string",
+            "description": "Field severity"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "guardrailsGroupUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "severity": {
+            "type": "string",
+            "description": "Field severity"
+          }
+        }
+      },
+      "guardrailsGroupUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "group_id": {
+            "type": "string",
+            "description": "Field group_id"
+          },
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "path",
+          "group_id"
+        ]
+      },
+      "guardrailsHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Field data",
+            "items": {
+              "$ref": "#/components/schemas/Entry"
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ]
+      },
+      "guardrailsImportRef": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "policy_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field policy_count"
+          },
+          "policy_ids": {
+            "type": "array",
+            "description": "Field policy_ids",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "policy_count"
+        ]
+      },
+      "guardrailsPolicyCreateRequest": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "groups": {
+            "type": "array",
+            "description": "Field groups",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "kind": {
+            "type": "string",
+            "description": "Field kind"
+          },
+          "match": {
+            "$ref": "#/components/schemas/PolicyMatch"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Field reason"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/Scope"
+          },
+          "verdict": {
+            "type": "string",
+            "description": "Field verdict"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "match"
+        ]
+      },
+      "guardrailsPolicyUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "groups": {
+            "type": "array",
+            "description": "Field groups",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "kind": {
+            "type": "string",
+            "description": "Field kind"
+          },
+          "match": {
+            "$ref": "#/components/schemas/PolicyMatch"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Field reason"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/Scope"
+          },
+          "verdict": {
+            "type": "string",
+            "description": "Field verdict"
+          }
+        }
+      },
+      "guardrailsPolicyUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "policy_id": {
+            "type": "string",
+            "description": "Field policy_id"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "path",
+          "policy_id"
+        ]
+      },
+      "guardrailsRegistryEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Field reason"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ]
+      },
+      "guardrailsRegistryInstallRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "guardrailsRegistryInstallResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "policy_id": {
+            "type": "string",
+            "description": "Field policy_id"
+          },
+          "registry_url": {
+            "type": "string",
+            "description": "Field registry_url"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "registry_url",
+          "path",
+          "policy_id"
+        ]
+      },
+      "guardrailsRegistryResponse": {
+        "type": "object",
+        "properties": {
+          "policies": {
+            "type": "array",
+            "description": "Field policies",
+            "items": {
+              "$ref": "#/components/schemas/guardrailsRegistryEntry"
+            }
+          },
+          "url": {
+            "type": "string",
+            "description": "Field url"
+          }
+        },
+        "required": [
+          "url",
+          "policies"
+        ]
+      },
+      "guardrailsReloadResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Field path"
+          },
+          "rule_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field rule_count"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "path",
+          "rule_count"
+        ]
+      },
+      "guardrailsSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "protectedCredentialCreateRequest": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Field description"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "secret": {
+            "type": "string",
+            "description": "Field secret"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Field tags",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "Field type"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "secret"
+        ]
+      },
+      "protectedCredentialDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "credential_id": {
+            "type": "string",
+            "description": "Field credential_id"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "credential_id"
+        ]
+      },
+      "protectedCredentialDetailEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/protectedCredentialDetailResponse"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ]
+      },
+      "protectedCredentialDetailResponse": {
+        "type": "object",
+        "properties": {
+          "alias_token": {
+            "type": "string",
+            "description": "Field alias_token"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Field created_at"
+          },
+          "description": {
+            "type": "string",
+            "description": "Field description"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "secret": {
+            "type": "string",
+            "description": "Field secret"
+          },
+          "secret_mask": {
+            "type": "string",
+            "description": "Field secret_mask"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Field tags",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "Field type"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Field updated_at"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "alias_token",
+          "enabled",
+          "secret_mask"
+        ]
+      },
+      "protectedCredentialMutationResponse": {
+        "type": "object",
+        "properties": {
+          "credential": {
+            "$ref": "#/components/schemas/protectedCredentialResponse"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "credential"
+        ]
+      },
+      "protectedCredentialResponse": {
+        "type": "object",
+        "properties": {
+          "alias_token": {
+            "type": "string",
+            "description": "Field alias_token"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Field created_at"
+          },
+          "description": {
+            "type": "string",
+            "description": "Field description"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "secret_mask": {
+            "type": "string",
+            "description": "Field secret_mask"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Field tags",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "Field type"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Field updated_at"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "alias_token",
+          "enabled",
+          "secret_mask"
+        ]
+      },
+      "protectedCredentialUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Field description"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "secret": {
+            "type": "string",
+            "description": "Field secret"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Field tags",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "Field type"
+          }
+        }
+      },
+      "protectedCredentialsListResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Field data",
+            "items": {
+              "$ref": "#/components/schemas/protectedCredentialResponse"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
       }
     },
     "securitySchemes": {
@@ -11068,8 +13236,16 @@
       "description": "Operations related to token"
     },
     {
+      "name": "tokens",
+      "description": "Operations related to tokens"
+    },
+    {
       "name": "usage",
       "description": "Operations related to usage"
+    },
+    {
+      "name": "vmodel",
+      "description": "Operations related to vmodel"
     },
     {
       "name": "weixin",

--- a/swagger/schema.go
+++ b/swagger/schema.go
@@ -95,9 +95,9 @@ func (g *schemaGen) addStructFields(schema *Schema, t reflect.Type) {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 
-		// Skip non-exported fields (embedded types are exported when the type
-		// name is; PkgPath is empty for them)
-		if field.PkgPath != "" {
+		// encoding/json promotes exported fields from anonymous embedded structs,
+		// including unexported helper types used for response composition.
+		if field.PkgPath != "" && !field.Anonymous {
 			continue
 		}
 
@@ -124,7 +124,7 @@ func (g *schemaGen) addStructFields(schema *Schema, t reflect.Type) {
 		// A field is required when binding says so, or when it is not marked
 		// omitempty (it always appears in the marshaled JSON).
 		bindingTag := field.Tag.Get("binding")
-		if strings.Contains(bindingTag, "required") || !hasJSONOption(jsonTag, "omitempty") {
+		if hasValidationRule(bindingTag, "required") || !hasJSONOption(jsonTag, "omitempty") {
 			schema.Required = append(schema.Required, propName)
 		}
 	}
@@ -216,10 +216,21 @@ func (g *schemaGen) typeSchema(t reflect.Type) Schema {
 		g.collect(t)
 		return Schema{Ref: g.refPrefix + t.Name()}
 	case reflect.Interface:
-		return Schema{Type: "object"}
+		// An interface value may contain any valid JSON value. Leaving the schema
+		// empty keeps generated clients from narrowing it to an empty object.
+		return Schema{}
 	default:
 		return Schema{Type: "object"}
 	}
+}
+
+func hasValidationRule(tag, rule string) bool {
+	for _, item := range strings.Split(tag, ",") {
+		if strings.TrimSpace(item) == rule {
+			return true
+		}
+	}
+	return false
 }
 
 // collect records a named struct type so buildDefinitions emits it.

--- a/swagger/schema_test.go
+++ b/swagger/schema_test.go
@@ -99,6 +99,18 @@ func TestSchemaFlattensEmbeddedStructs(t *testing.T) {
 	assert.NotContains(t, gen.collected, "PtrBase")
 }
 
+func TestSchemaFlattensUnexportedEmbeddedStruct(t *testing.T) {
+	type embedded struct {
+		Value string `json:"value"`
+	}
+	type Model struct {
+		embedded
+	}
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+	assert.Contains(t, schema.Properties, "value")
+}
+
 // []byte marshals as a base64 string; json.RawMessage is arbitrary JSON.
 func TestSchemaByteSliceAndRawMessage(t *testing.T) {
 	type Model struct {
@@ -116,6 +128,22 @@ func TestSchemaByteSliceAndRawMessage(t *testing.T) {
 	assert.Empty(t, raw.Type)
 	assert.Empty(t, raw.Ref)
 	assert.Nil(t, raw.Items)
+}
+
+func TestSchemaRequiredIfIsNotUnconditionallyRequired(t *testing.T) {
+	type Model struct {
+		Conditional string         `json:"conditional,omitempty" binding:"required_if=Kind special"`
+		Required    string         `json:"required,omitempty" binding:"required"`
+		Metadata    map[string]any `json:"metadata,omitempty"`
+	}
+
+	schema := newSchemaGen(VersionV3).modelSchema(Model{})
+	assert.NotContains(t, schema.Required, "conditional")
+	assert.Contains(t, schema.Required, "required")
+	metadata := schema.Properties["metadata"]
+	if assert.NotNil(t, metadata.AdditionalProperties) {
+		assert.Empty(t, metadata.AdditionalProperties.Type)
+	}
 }
 
 // Map values that are anonymous structs must be inlined, not emitted as a

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -450,7 +450,7 @@ func structQueryParams(modelType reflect.Type) []queryParamSpec {
 		parameters = append(parameters, queryParamSpec{
 			Name:        paramName,
 			Description: fmt.Sprintf("Query parameter %s", paramName),
-			Required:    strings.Contains(field.Tag.Get("binding"), "required"),
+			Required:    hasValidationRule(field.Tag.Get("binding"), "required"),
 			Type:        paramType,
 			Format:      paramFormat,
 		})


### PR DESCRIPTION
## Summary

Moves the Web UI control surface onto the generated OpenAPI client so the frontend, backend, and API contract stay aligned as the product evolves.

## Key Changes

- **Control API compatibility**: Registers the missing control endpoints and schemas in Swagger, then regenerates the contract so supported UI workflows have a single authoritative definition.
- **Frontend request safety**: Routes login, logs, probes, onboarding, sharing, Guardrails, MCP, and scenario configuration through the generated client, preserving shared authentication and response handling.
- **Mock workflow reliability**: Completes the Guardrails group mock lifecycle so group pages and create/edit/delete flows work without retrying missing endpoints.

## Testing

- Targeted Go tests for Swagger and affected server modules.
- Mock-mode browser smoke tests across 53 direct routes, including login, onboarding, model testing, Guardrails, and MCP.
- Verified Guardrails group creation in the UI.