### PR TITLE
perf(vision): Parallelize vision proxy image descriptions with concurrency control

### DIFF
--- a/internal/visionproxy/README.md
+++ b/internal/visionproxy/README.md
@@ -61,6 +61,13 @@ responsibilities:
 
 ### Process pipeline
 
+Processing is two-phase: a **collect** walk that strips historical images
+in place and gathers the latest message's images as `imageRef`s (source +
+splice-back callback), then a **describe** fan-out that resolves each ref
+via the vision upstream — concurrently when there is more than one image,
+bounded by `describeConcurrency` (4). Each ref splices into its own
+distinct block slot, so the concurrent writes need no locking.
+
 ```
 req : *anthropic.BetaMessageNewParams (or v1 / OpenAI / Responses)
 
@@ -74,20 +81,22 @@ req : *anthropic.BetaMessageNewParams (or v1 / OpenAI / Responses)
         { OfImage: B }                                       ◄── latest target
       ] } ]
        │
-       │ pickUsableService(services)
+       │ Phase 1 — collect<Protocol>(req):
+       │   for each message i < lastIdx:
+       │     replace OfImage blocks with
+       │       { OfText: "[image: (omitted from history)]" }
+       │     (no Describe call — no upstream cost for historical images)
+       │   for each OfImage in messages[lastIdx]:
+       │     extractImageSource → (mediaType, b64Data, remoteURL)
+       │       - Beta:   img.Source.OfBase64 | img.Source.OfURL
+       │       - V1:     img.Source.OfBase64 | img.Source.OfURL
+       │       - OpenAI: ParseImageURLToAnthropicSource(image_url.url)
+       │     collect imageRef{source, splice}
+       │
+       │ pickUsableService(services)          (skipped when no refs)
        │   skip nil / inactive / unresolvable-provider svcs
        │
-       │ for each message i < lastIdx:
-       │   replace OfImage blocks with
-       │     { OfText: "[image: (omitted from history)]" }
-       │   (no Describe call — no upstream cost for historical images)
-       │
-       │ for each OfImage in messages[lastIdx]:
-       │   extractImageSource → (mediaType, b64Data, remoteURL)
-       │     - Beta:   img.Source.OfBase64 | img.Source.OfURL
-       │     - V1:     img.Source.OfBase64 | img.Source.OfURL
-       │     - OpenAI: ParseImageURLToAnthropicSource(image_url.url)
-       │
+       │ Phase 2 — describeAll(refs): concurrent, ≤ describeConcurrency
        │   describe(ctx, service, mediaType, b64, url):
        │     visionClient.Describe(...)
        │       poolVisionClient (production adapter)
@@ -172,5 +181,7 @@ deliver images this way. Unknown request shapes are left alone (no-op).
 
 ## Out of scope (today)
 
-- Concurrent image description (sequential, one call per image).
-- Caching describe results across requests.
+- Caching describe results across requests (each image is described once
+  per request, even if the identical image appears in multiple requests).
+- Deduplicating identical images within one request (each occurrence gets
+  its own describe call).

--- a/internal/visionproxy/README.md
+++ b/internal/visionproxy/README.md
@@ -64,9 +64,13 @@ responsibilities:
 Processing is two-phase: a **collect** walk that strips historical images
 in place and gathers the latest message's images as `imageRef`s (source +
 splice-back callback), then a **describe** fan-out that resolves each ref
-via the vision upstream — concurrently when there is more than one image,
-bounded by `describeConcurrency` (4). Each ref splices into its own
-distinct block slot, so the concurrent writes need no locking.
+via the vision upstream — concurrently, with `describeConcurrency` (4)
+bounding both live goroutines and in-flight upstream calls (the semaphore
+is acquired before each goroutine spawns). Each ref splices into its own
+distinct block slot, so the concurrent writes need no locking. A panic in
+the describe path is recovered per-image and collapses to the fail-strip
+marker — the goroutines run outside the HTTP handler's recovery
+middleware, so containment lives here.
 
 ```
 req : *anthropic.BetaMessageNewParams (or v1 / OpenAI / Responses)
@@ -148,6 +152,7 @@ fail-strip does not apply; they always receive the omitted marker.
   vision client nil       │ p.Client == nil                  │  unavail   │
   Describe() error        │ err != nil                       │  unavail   │
   empty response          │ strings.TrimSpace(desc) == ""    │  unavail   │
+  Describe() panics       │ recovered in safeDescribe        │  unavail   │
   success                 │ desc non-empty                   │  [image: …]│
                           ├──────────────────────────────────┴───────────┤
   historical image        │ messages[i] where i < lastIdx    │  historic │

--- a/internal/visionproxy/vision_proxy.go
+++ b/internal/visionproxy/vision_proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
@@ -44,6 +45,25 @@ const imageUnavailableText = "[image: (description unavailable)]"
 // message are sent through the vision upstream for description.
 const imageHistoricalText = "[image: (omitted from history)]"
 
+// describeConcurrency bounds how many vision upstream calls run in parallel
+// for a single request. The upstream round-trip dominates proxy latency, so
+// a latest message carrying several images (multi-screenshot tool results,
+// image comparisons) should not pay N sequential round-trips; the bound
+// keeps a pathological request from opening dozens of connections at once.
+const describeConcurrency = 4
+
+// imageRef is one image occurrence in the LATEST message, captured while
+// walking the request: the extracted source plus a splice callback that
+// writes the replacement text back into the exact block the image came
+// from. Every ref targets a distinct slice slot, so splice calls are safe
+// to run from concurrent goroutines without locking.
+type imageRef struct {
+	mediaType string
+	b64       string
+	remoteURL string
+	splice    func(text string)
+}
+
 // Process mutates req in place: every image block becomes a text block. On
 // any failure (no usable service, vision client error, empty upstream
 // response) the image is still removed so a downstream text-only model does
@@ -54,23 +74,34 @@ func (p *VisionProxyProcessor) Process(ctx context.Context, req any, services []
 	if req == nil {
 		return nil
 	}
-	usable := p.pickUsableService(services)
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
+	// Phase 1 — walk the request: historical images are replaced with the
+	// fixed marker immediately (no upstream cost); latest-message images
+	// are collected for the describe fan-out.
+	var refs []imageRef
 	switch req := req.(type) {
 	case *anthropic.BetaMessageNewParams:
-		p.processBeta(ctx, req, usable)
+		refs = collectBeta(req)
 	case *anthropic.MessageNewParams:
-		p.processV1(ctx, req, usable)
+		refs = collectV1(req)
 	case *openai.ChatCompletionNewParams:
-		p.processOpenAI(ctx, req, usable)
+		refs = collectOpenAI(req)
 	case *responses.ResponseNewParams:
-		p.processResponses(ctx, req, usable)
+		refs = collectResponses(req)
 	default:
 		// Unknown request shape — leave it alone.
+		return nil
 	}
+	if len(refs) == 0 {
+		return nil
+	}
+
+	// Phase 2 — describe the collected images (concurrently when there is
+	// more than one) and splice the text back in.
+	p.describeAll(ctx, p.pickUsableService(services), refs)
 	return nil
 }
 
@@ -87,6 +118,30 @@ func (p *VisionProxyProcessor) pickUsableService(services []*loadbalance.Service
 		return svc
 	}
 	return nil
+}
+
+// describeAll resolves every collected ref via the vision upstream and
+// splices the replacement text into the request. Calls run concurrently,
+// bounded by describeConcurrency; the single-image fast path skips the
+// goroutine machinery entirely.
+func (p *VisionProxyProcessor) describeAll(ctx context.Context, usable *loadbalance.Service, refs []imageRef) {
+	if len(refs) == 1 {
+		r := refs[0]
+		r.splice(p.describe(ctx, usable, r.mediaType, r.b64, r.remoteURL))
+		return
+	}
+	sem := make(chan struct{}, describeConcurrency)
+	var wg sync.WaitGroup
+	for _, r := range refs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			r.splice(p.describe(ctx, usable, r.mediaType, r.b64, r.remoteURL))
+		}()
+	}
+	wg.Wait()
 }
 
 // describe calls the vision client when available and returns the
@@ -131,129 +186,168 @@ func truncateForLog(s string, max int) string {
 	return s[:max] + fmt.Sprintf("…(+%d)", len(s)-max)
 }
 
-// processBeta replaces every image block in every message with a text
-// block: described via the vision upstream for the latest message,
-// stripped with imageHistoricalText for earlier ones. Image blocks
-// occur both at the top level and nested inside tool_result.Content
-// (see .design/vision-proxy-scenario.md §9.1) — walkBetaContent handles
-// both shapes.
-func (p *VisionProxyProcessor) processBeta(ctx context.Context, req *anthropic.BetaMessageNewParams, usable *loadbalance.Service) {
-	if len(req.Messages) == 0 {
-		return
+// spliceOrCollect is the single decision point for what happens to an image
+// block. Images outside the latest message get the fixed historical marker
+// spliced in immediately — no upstream call, no ref. Latest-message images
+// are appended to refs for the describe fan-out.
+func spliceOrCollect(refs []imageRef, isLast bool, mediaType, b64, remoteURL string, splice func(text string)) []imageRef {
+	if !isLast {
+		splice(imageHistoricalText)
+		return refs
 	}
+	return append(refs, imageRef{mediaType: mediaType, b64: b64, remoteURL: remoteURL, splice: splice})
+}
+
+// collectBeta walks every message of a Beta request. Image blocks occur both
+// at the top level and nested inside tool_result.Content (see
+// .design/vision-proxy-scenario.md §9.1) — both shapes are handled.
+func collectBeta(req *anthropic.BetaMessageNewParams) []imageRef {
+	var refs []imageRef
 	lastIdx := len(req.Messages) - 1
 	for mi := range req.Messages {
-		p.walkBetaContent(ctx, req.Messages[mi].Content, usable, mi == lastIdx)
-	}
-}
-
-func (p *VisionProxyProcessor) walkBetaContent(ctx context.Context, blocks []anthropic.BetaContentBlockParamUnion, usable *loadbalance.Service, isLast bool) {
-	for bi := range blocks {
-		if blocks[bi].OfImage != nil {
-			blocks[bi] = anthropic.BetaContentBlockParamUnion{
-				OfText: &anthropic.BetaTextBlockParam{Text: p.betaReplacementText(ctx, blocks[bi].OfImage, usable, isLast)},
+		isLast := mi == lastIdx
+		blocks := req.Messages[mi].Content
+		for bi := range blocks {
+			if img := blocks[bi].OfImage; img != nil {
+				mediaType, b64, remoteURL := extractBetaImageSource(img)
+				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
+					blocks[bi] = anthropic.BetaContentBlockParamUnion{
+						OfText: &anthropic.BetaTextBlockParam{Text: text},
+					}
+				})
+				continue
 			}
-			continue
-		}
-		if tr := blocks[bi].OfToolResult; tr != nil {
+			tr := blocks[bi].OfToolResult
+			if tr == nil {
+				continue
+			}
 			inner := tr.Content
 			for ii := range inner {
-				if inner[ii].OfImage == nil {
+				img := inner[ii].OfImage
+				if img == nil {
 					continue
 				}
-				inner[ii] = anthropic.BetaToolResultBlockParamContentUnion{
-					OfText: &anthropic.BetaTextBlockParam{Text: p.betaReplacementText(ctx, inner[ii].OfImage, usable, isLast)},
-				}
+				mediaType, b64, remoteURL := extractBetaImageSource(img)
+				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
+					inner[ii] = anthropic.BetaToolResultBlockParamContentUnion{
+						OfText: &anthropic.BetaTextBlockParam{Text: text},
+					}
+				})
 			}
 		}
 	}
+	return refs
 }
 
-func (p *VisionProxyProcessor) betaReplacementText(ctx context.Context, img *anthropic.BetaImageBlockParam, usable *loadbalance.Service, isLast bool) string {
-	if !isLast {
-		return imageHistoricalText
-	}
-	mediaType, b64, remoteURL := extractBetaImageSource(img)
-	return p.describe(ctx, usable, mediaType, b64, remoteURL)
-}
-
-func (p *VisionProxyProcessor) processV1(ctx context.Context, req *anthropic.MessageNewParams, usable *loadbalance.Service) {
-	if len(req.Messages) == 0 {
-		return
-	}
+// collectV1 mirrors collectBeta for the v1 Messages API types.
+func collectV1(req *anthropic.MessageNewParams) []imageRef {
+	var refs []imageRef
 	lastIdx := len(req.Messages) - 1
 	for mi := range req.Messages {
-		p.walkV1Content(ctx, req.Messages[mi].Content, usable, mi == lastIdx)
-	}
-}
-
-func (p *VisionProxyProcessor) walkV1Content(ctx context.Context, blocks []anthropic.ContentBlockParamUnion, usable *loadbalance.Service, isLast bool) {
-	for bi := range blocks {
-		if blocks[bi].OfImage != nil {
-			blocks[bi] = anthropic.ContentBlockParamUnion{
-				OfText: &anthropic.TextBlockParam{Text: p.v1ReplacementText(ctx, blocks[bi].OfImage, usable, isLast)},
+		isLast := mi == lastIdx
+		blocks := req.Messages[mi].Content
+		for bi := range blocks {
+			if img := blocks[bi].OfImage; img != nil {
+				mediaType, b64, remoteURL := extractV1ImageSource(img)
+				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
+					blocks[bi] = anthropic.ContentBlockParamUnion{
+						OfText: &anthropic.TextBlockParam{Text: text},
+					}
+				})
+				continue
 			}
-			continue
-		}
-		if tr := blocks[bi].OfToolResult; tr != nil {
+			tr := blocks[bi].OfToolResult
+			if tr == nil {
+				continue
+			}
 			inner := tr.Content
 			for ii := range inner {
-				if inner[ii].OfImage == nil {
+				img := inner[ii].OfImage
+				if img == nil {
 					continue
 				}
-				inner[ii] = anthropic.ToolResultBlockParamContentUnion{
-					OfText: &anthropic.TextBlockParam{Text: p.v1ReplacementText(ctx, inner[ii].OfImage, usable, isLast)},
-				}
+				mediaType, b64, remoteURL := extractV1ImageSource(img)
+				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
+					inner[ii] = anthropic.ToolResultBlockParamContentUnion{
+						OfText: &anthropic.TextBlockParam{Text: text},
+					}
+				})
 			}
 		}
 	}
+	return refs
 }
 
-func (p *VisionProxyProcessor) v1ReplacementText(ctx context.Context, img *anthropic.ImageBlockParam, usable *loadbalance.Service, isLast bool) string {
-	if !isLast {
-		return imageHistoricalText
-	}
-	mediaType, b64, remoteURL := extractV1ImageSource(img)
-	return p.describe(ctx, usable, mediaType, b64, remoteURL)
-}
-
-func (p *VisionProxyProcessor) processOpenAI(ctx context.Context, req *openai.ChatCompletionNewParams, usable *loadbalance.Service) {
-	if len(req.Messages) == 0 {
-		return
-	}
+// collectOpenAI walks a Chat Completions request. Only user messages can
+// carry image_url content parts in the current SDK union.
+func collectOpenAI(req *openai.ChatCompletionNewParams) []imageRef {
+	var refs []imageRef
 	lastIdx := len(req.Messages) - 1
-	historicalPart := openai.ChatCompletionContentPartUnionParam{
-		OfText: &openai.ChatCompletionContentPartTextParam{Text: imageHistoricalText},
-	}
-	for mi := 0; mi < lastIdx; mi++ {
+	for mi := range req.Messages {
 		um := req.Messages[mi].OfUser
 		if um == nil {
 			continue
 		}
+		isLast := mi == lastIdx
 		parts := um.Content.OfArrayOfContentParts
 		for pi := range parts {
-			if parts[pi].OfImageURL == nil {
+			ip := parts[pi].OfImageURL
+			if ip == nil {
 				continue
 			}
-			parts[pi] = historicalPart
+			mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(ip.ImageURL.URL)
+			refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
+				parts[pi] = openai.ChatCompletionContentPartUnionParam{
+					OfText: &openai.ChatCompletionContentPartTextParam{Text: text},
+				}
+			})
 		}
 	}
-	um := req.Messages[lastIdx].OfUser
-	if um == nil {
-		return
-	}
-	parts := um.Content.OfArrayOfContentParts
-	for pi := range parts {
-		ip := parts[pi].OfImageURL
-		if ip == nil {
+	return refs
+}
+
+// collectResponses mirrors collectBeta/collectV1 for the OpenAI Responses
+// API: it walks every input item's content list, replacing each
+// `input_image` part with a text part.
+//
+// Shapes handled: ResponseInputItemUnionParam.OfMessage (EasyInputMessageParam,
+// with EasyInputMessageContentUnionParam.OfInputItemContentList) and
+// ResponseInputItemUnionParam.OfInputMessage (ResponseInputItemMessageParam,
+// content list inline). Tool/function/output items don't carry
+// input_image parts in the current SDK union and are left alone.
+func collectResponses(req *responses.ResponseNewParams) []imageRef {
+	items := req.Input.OfInputItemList
+	var refs []imageRef
+	lastIdx := len(items) - 1
+	for mi := range items {
+		var list responses.ResponseInputMessageContentListParam
+		switch {
+		case items[mi].OfMessage != nil:
+			list = items[mi].OfMessage.Content.OfInputItemContentList
+		case items[mi].OfInputMessage != nil:
+			list = items[mi].OfInputMessage.Content
+		default:
 			continue
 		}
-		mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(ip.ImageURL.URL)
-		text := p.describe(ctx, usable, mediaType, b64, remoteURL)
-		parts[pi] = openai.ChatCompletionContentPartUnionParam{
-			OfText: &openai.ChatCompletionContentPartTextParam{Text: text},
+		isLast := mi == lastIdx
+		for ci := range list {
+			img := list[ci].OfInputImage
+			if img == nil {
+				continue
+			}
+			url := ""
+			if img.ImageURL.Valid() {
+				url = img.ImageURL.Value
+			}
+			mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(url)
+			refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
+				list[ci] = responses.ResponseInputContentUnionParam{
+					OfInputText: &responses.ResponseInputTextParam{Text: text},
+				}
+			})
 		}
 	}
+	return refs
 }
 
 func extractBetaImageSource(img *anthropic.BetaImageBlockParam) (mediaType, b64, remoteURL string) {
@@ -267,65 +361,6 @@ func extractBetaImageSource(img *anthropic.BetaImageBlockParam) (mediaType, b64,
 		return "", "", img.Source.OfURL.URL
 	}
 	return
-}
-
-// processResponses mirrors processBeta/processV1 for the OpenAI Responses
-// API: it walks every input item's content list, replacing each
-// `input_image` part with a text part. The latest item gets a real
-// description via the vision upstream; earlier items get the fixed
-// historical marker. Same rationale as processBeta — historical images
-// are too costly to describe and rarely needed for the current turn.
-//
-// Shapes handled: ResponseInputItemUnionParam.OfMessage (EasyInputMessageParam,
-// with EasyInputMessageContentUnionParam.OfInputItemContentList) and
-// ResponseInputItemUnionParam.OfInputMessage (ResponseInputItemMessageParam,
-// content list inline). Tool/function/output items don't carry
-// input_image parts in the current SDK union and are left alone.
-func (p *VisionProxyProcessor) processResponses(ctx context.Context, req *responses.ResponseNewParams, usable *loadbalance.Service) {
-	items := req.Input.OfInputItemList
-	if len(items) == 0 {
-		return
-	}
-	lastIdx := len(items) - 1
-	for mi := range items {
-		p.walkResponsesItem(ctx, &items[mi], usable, mi == lastIdx)
-	}
-}
-
-func (p *VisionProxyProcessor) walkResponsesItem(ctx context.Context, item *responses.ResponseInputItemUnionParam, usable *loadbalance.Service, isLast bool) {
-	if item.OfMessage != nil {
-		p.walkResponsesContentList(ctx, item.OfMessage.Content.OfInputItemContentList, usable, isLast)
-		return
-	}
-	if item.OfInputMessage != nil {
-		p.walkResponsesContentList(ctx, item.OfInputMessage.Content, usable, isLast)
-		return
-	}
-}
-
-func (p *VisionProxyProcessor) walkResponsesContentList(ctx context.Context, list responses.ResponseInputMessageContentListParam, usable *loadbalance.Service, isLast bool) {
-	for i := range list {
-		img := list[i].OfInputImage
-		if img == nil {
-			continue
-		}
-		text := p.responsesReplacementText(ctx, img, usable, isLast)
-		list[i] = responses.ResponseInputContentUnionParam{
-			OfInputText: &responses.ResponseInputTextParam{Text: text},
-		}
-	}
-}
-
-func (p *VisionProxyProcessor) responsesReplacementText(ctx context.Context, img *responses.ResponseInputImageParam, usable *loadbalance.Service, isLast bool) string {
-	if !isLast {
-		return imageHistoricalText
-	}
-	url := ""
-	if img.ImageURL.Valid() {
-		url = img.ImageURL.Value
-	}
-	mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(url)
-	return p.describe(ctx, usable, mediaType, b64, remoteURL)
 }
 
 func extractV1ImageSource(img *anthropic.ImageBlockParam) (mediaType, b64, remoteURL string) {

--- a/internal/visionproxy/vision_proxy.go
+++ b/internal/visionproxy/vision_proxy.go
@@ -121,27 +121,37 @@ func (p *VisionProxyProcessor) pickUsableService(services []*loadbalance.Service
 }
 
 // describeAll resolves every collected ref via the vision upstream and
-// splices the replacement text into the request. Calls run concurrently,
-// bounded by describeConcurrency; the single-image fast path skips the
-// goroutine machinery entirely.
+// splices the replacement text into the request. The semaphore is acquired
+// BEFORE each goroutine is spawned, so describeConcurrency bounds live
+// goroutines as well as in-flight upstream calls.
 func (p *VisionProxyProcessor) describeAll(ctx context.Context, usable *loadbalance.Service, refs []imageRef) {
-	if len(refs) == 1 {
-		r := refs[0]
-		r.splice(p.describe(ctx, usable, r.mediaType, r.b64, r.remoteURL))
-		return
-	}
 	sem := make(chan struct{}, describeConcurrency)
 	var wg sync.WaitGroup
 	for _, r := range refs {
+		sem <- struct{}{}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sem <- struct{}{}
 			defer func() { <-sem }()
-			r.splice(p.describe(ctx, usable, r.mediaType, r.b64, r.remoteURL))
+			r.splice(p.safeDescribe(ctx, usable, r))
 		}()
 	}
 	wg.Wait()
+}
+
+// safeDescribe is describe plus panic containment. It runs on goroutines
+// describeAll spawns, outside the HTTP handler's recovery middleware — a
+// panicking vision client (SDK edge case, malformed upstream stream) must
+// fail-strip one image, not crash the process.
+func (p *VisionProxyProcessor) safeDescribe(ctx context.Context, usable *loadbalance.Service, r imageRef) (text string) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			logrus.WithContext(ctx).WithField("component", "vision_proxy").
+				WithField("panic", rec).Error("vision proxy: describe panicked; stripping image")
+			text = imageUnavailableText
+		}
+	}()
+	return p.describe(ctx, usable, r.mediaType, r.b64, r.remoteURL)
 }
 
 // describe calls the vision client when available and returns the
@@ -152,7 +162,7 @@ func (p *VisionProxyProcessor) describeAll(ctx context.Context, usable *loadbala
 // Logging deliberately uses no "source" field — that would push the
 // entry down MultiLogger's explicit-source branch and skip the
 // request_id auto-injection that drives per-request log aggregation.
-// See .design/vision-proxy-scenario.md §9.3.
+// See .design/vision-proxy.md §6.3.
 func (p *VisionProxyProcessor) describe(ctx context.Context, usable *loadbalance.Service, mediaType, b64, remoteURL string) string {
 	base := logrus.WithContext(ctx).WithField("component", "vision_proxy")
 	if usable == nil || p.Client == nil {
@@ -190,17 +200,17 @@ func truncateForLog(s string, max int) string {
 // block. Images outside the latest message get the fixed historical marker
 // spliced in immediately — no upstream call, no ref. Latest-message images
 // are appended to refs for the describe fan-out.
-func spliceOrCollect(refs []imageRef, isLast bool, mediaType, b64, remoteURL string, splice func(text string)) []imageRef {
+func spliceOrCollect(refs []imageRef, isLast bool, ref imageRef) []imageRef {
 	if !isLast {
-		splice(imageHistoricalText)
+		ref.splice(imageHistoricalText)
 		return refs
 	}
-	return append(refs, imageRef{mediaType: mediaType, b64: b64, remoteURL: remoteURL, splice: splice})
+	return append(refs, ref)
 }
 
 // collectBeta walks every message of a Beta request. Image blocks occur both
 // at the top level and nested inside tool_result.Content (see
-// .design/vision-proxy-scenario.md §9.1) — both shapes are handled.
+// .design/vision-proxy.md §6.1) — both shapes are handled.
 func collectBeta(req *anthropic.BetaMessageNewParams) []imageRef {
 	var refs []imageRef
 	lastIdx := len(req.Messages) - 1
@@ -210,10 +220,13 @@ func collectBeta(req *anthropic.BetaMessageNewParams) []imageRef {
 		for bi := range blocks {
 			if img := blocks[bi].OfImage; img != nil {
 				mediaType, b64, remoteURL := extractBetaImageSource(img)
-				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
-					blocks[bi] = anthropic.BetaContentBlockParamUnion{
-						OfText: &anthropic.BetaTextBlockParam{Text: text},
-					}
+				refs = spliceOrCollect(refs, isLast, imageRef{
+					mediaType: mediaType, b64: b64, remoteURL: remoteURL,
+					splice: func(text string) {
+						blocks[bi] = anthropic.BetaContentBlockParamUnion{
+							OfText: &anthropic.BetaTextBlockParam{Text: text},
+						}
+					},
 				})
 				continue
 			}
@@ -228,10 +241,13 @@ func collectBeta(req *anthropic.BetaMessageNewParams) []imageRef {
 					continue
 				}
 				mediaType, b64, remoteURL := extractBetaImageSource(img)
-				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
-					inner[ii] = anthropic.BetaToolResultBlockParamContentUnion{
-						OfText: &anthropic.BetaTextBlockParam{Text: text},
-					}
+				refs = spliceOrCollect(refs, isLast, imageRef{
+					mediaType: mediaType, b64: b64, remoteURL: remoteURL,
+					splice: func(text string) {
+						inner[ii] = anthropic.BetaToolResultBlockParamContentUnion{
+							OfText: &anthropic.BetaTextBlockParam{Text: text},
+						}
+					},
 				})
 			}
 		}
@@ -249,10 +265,13 @@ func collectV1(req *anthropic.MessageNewParams) []imageRef {
 		for bi := range blocks {
 			if img := blocks[bi].OfImage; img != nil {
 				mediaType, b64, remoteURL := extractV1ImageSource(img)
-				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
-					blocks[bi] = anthropic.ContentBlockParamUnion{
-						OfText: &anthropic.TextBlockParam{Text: text},
-					}
+				refs = spliceOrCollect(refs, isLast, imageRef{
+					mediaType: mediaType, b64: b64, remoteURL: remoteURL,
+					splice: func(text string) {
+						blocks[bi] = anthropic.ContentBlockParamUnion{
+							OfText: &anthropic.TextBlockParam{Text: text},
+						}
+					},
 				})
 				continue
 			}
@@ -267,10 +286,13 @@ func collectV1(req *anthropic.MessageNewParams) []imageRef {
 					continue
 				}
 				mediaType, b64, remoteURL := extractV1ImageSource(img)
-				refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
-					inner[ii] = anthropic.ToolResultBlockParamContentUnion{
-						OfText: &anthropic.TextBlockParam{Text: text},
-					}
+				refs = spliceOrCollect(refs, isLast, imageRef{
+					mediaType: mediaType, b64: b64, remoteURL: remoteURL,
+					splice: func(text string) {
+						inner[ii] = anthropic.ToolResultBlockParamContentUnion{
+							OfText: &anthropic.TextBlockParam{Text: text},
+						}
+					},
 				})
 			}
 		}
@@ -296,10 +318,13 @@ func collectOpenAI(req *openai.ChatCompletionNewParams) []imageRef {
 				continue
 			}
 			mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(ip.ImageURL.URL)
-			refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
-				parts[pi] = openai.ChatCompletionContentPartUnionParam{
-					OfText: &openai.ChatCompletionContentPartTextParam{Text: text},
-				}
+			refs = spliceOrCollect(refs, isLast, imageRef{
+				mediaType: mediaType, b64: b64, remoteURL: remoteURL,
+				splice: func(text string) {
+					parts[pi] = openai.ChatCompletionContentPartUnionParam{
+						OfText: &openai.ChatCompletionContentPartTextParam{Text: text},
+					}
+				},
 			})
 		}
 	}
@@ -335,15 +360,14 @@ func collectResponses(req *responses.ResponseNewParams) []imageRef {
 			if img == nil {
 				continue
 			}
-			url := ""
-			if img.ImageURL.Valid() {
-				url = img.ImageURL.Value
-			}
-			mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(url)
-			refs = spliceOrCollect(refs, isLast, mediaType, b64, remoteURL, func(text string) {
-				list[ci] = responses.ResponseInputContentUnionParam{
-					OfInputText: &responses.ResponseInputTextParam{Text: text},
-				}
+			mediaType, b64, remoteURL := request.ParseImageURLToAnthropicSource(img.ImageURL.Or(""))
+			refs = spliceOrCollect(refs, isLast, imageRef{
+				mediaType: mediaType, b64: b64, remoteURL: remoteURL,
+				splice: func(text string) {
+					list[ci] = responses.ResponseInputContentUnionParam{
+						OfInputText: &responses.ResponseInputTextParam{Text: text},
+					}
+				},
 			})
 		}
 	}
@@ -351,9 +375,6 @@ func collectResponses(req *responses.ResponseNewParams) []imageRef {
 }
 
 func extractBetaImageSource(img *anthropic.BetaImageBlockParam) (mediaType, b64, remoteURL string) {
-	if img == nil {
-		return
-	}
 	if img.Source.OfBase64 != nil {
 		return string(img.Source.OfBase64.MediaType), img.Source.OfBase64.Data, ""
 	}
@@ -364,9 +385,6 @@ func extractBetaImageSource(img *anthropic.BetaImageBlockParam) (mediaType, b64,
 }
 
 func extractV1ImageSource(img *anthropic.ImageBlockParam) (mediaType, b64, remoteURL string) {
-	if img == nil {
-		return
-	}
 	if img.Source.OfBase64 != nil {
 		return string(img.Source.OfBase64.MediaType), img.Source.OfBase64.Data, ""
 	}

--- a/internal/visionproxy/vision_proxy_client.go
+++ b/internal/visionproxy/vision_proxy_client.go
@@ -28,6 +28,10 @@ import (
 //
 // Returning ("", nil) means "no description available" → fail-strip path.
 // Returning a non-nil error is also fail-strip.
+//
+// Describe may be called concurrently — the processor fans out up to
+// describeConcurrency goroutines per request — so implementations must be
+// safe for concurrent use.
 type VisionClient interface {
 	Describe(ctx context.Context, service *loadbalance.Service, mediaType, base64Data, remoteURL string) (string, error)
 }

--- a/internal/visionproxy/vision_proxy_test.go
+++ b/internal/visionproxy/vision_proxy_test.go
@@ -31,6 +31,12 @@ type describeCall struct {
 	URL       string
 }
 
+// fakeVisionClient keys canned responses and injected errors by call ARRIVAL
+// index. Describe calls for a multi-image message run concurrently, so the
+// arrival order — and therefore which image receives responses[i] or the
+// errAt[i] failure — is nondeterministic. Use it with single-image requests
+// (or order-insensitive assertions); use echoPayloadClient to assert the
+// image→description mapping.
 type fakeVisionClient struct {
 	mu        sync.Mutex
 	calls     []describeCall
@@ -490,7 +496,11 @@ func TestVisionProxy_VisionCallError_StripImageWithUnavailableMarker(t *testing.
 	require.Contains(t, collectText(req), "description unavailable", "fail-strip marker present")
 }
 
-func TestVisionProxy_MultipleImages_AllReplacedInOrder(t *testing.T) {
+// Every latest-message image gets its own describe call and is replaced.
+// Descriptions are assigned by fakeVisionClient arrival order, which is
+// nondeterministic under the concurrent fan-out — positional mapping is
+// covered by TestVisionProxy_ConcurrentDescribe_MappingPreserved instead.
+func TestVisionProxy_MultipleImages_AllReplaced(t *testing.T) {
 	prov := mkProvider("anthropic-vision")
 	fake := newFakeVisionClient("first description", "second description", "third description")
 	p := mkProcessor(t, fake, prov)
@@ -505,6 +515,29 @@ func TestVisionProxy_MultipleImages_AllReplacedInOrder(t *testing.T) {
 	require.Contains(t, text, "first description")
 	require.Contains(t, text, "second description")
 	require.Contains(t, text, "third description")
+}
+
+// panickyVisionClient panics on every Describe call.
+type panickyVisionClient struct{}
+
+func (panickyVisionClient) Describe(_ context.Context, _ *loadbalance.Service, _, _, _ string) (string, error) {
+	panic("vision client exploded")
+}
+
+// TestVisionProxy_DescribePanic_FailStrips pins the panic-containment
+// contract: describe runs on goroutines outside the HTTP handler's recovery
+// middleware, so a panicking vision client must collapse to the fail-strip
+// marker for that image — never crash the process.
+func TestVisionProxy_DescribePanic_FailStrips(t *testing.T) {
+	prov := mkProvider("anthropic-vision")
+	p := mkProcessor(t, panickyVisionClient{}, prov)
+
+	req := betaReqWithImages("describe", tinyPNGBase64, tinyPNGBase64)
+	svcs := []*loadbalance.Service{mkService(prov.UUID, true)}
+
+	require.NoError(t, p.Process(context.Background(), req, svcs))
+	require.Equal(t, 0, countImages(req), "images stripped despite panicking client")
+	require.Contains(t, collectText(req), "description unavailable", "fail-strip marker present")
 }
 
 // echoPayloadClient derives the description from the image payload itself,

--- a/internal/visionproxy/vision_proxy_test.go
+++ b/internal/visionproxy/vision_proxy_test.go
@@ -3,6 +3,8 @@ package visionproxy
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -503,6 +505,43 @@ func TestVisionProxy_MultipleImages_AllReplacedInOrder(t *testing.T) {
 	require.Contains(t, text, "first description")
 	require.Contains(t, text, "second description")
 	require.Contains(t, text, "third description")
+}
+
+// echoPayloadClient derives the description from the image payload itself,
+// so ordering assertions can catch any cross-wiring between the concurrent
+// describe goroutines and their splice targets.
+type echoPayloadClient struct{}
+
+func (echoPayloadClient) Describe(_ context.Context, _ *loadbalance.Service, _, b64, _ string) (string, error) {
+	return "desc-of-" + b64, nil
+}
+
+// TestVisionProxy_ConcurrentDescribe_MappingPreserved sends more images than
+// describeConcurrency and verifies each description lands in the slot its
+// image came from — the concurrent fan-out must not scramble the mapping.
+func TestVisionProxy_ConcurrentDescribe_MappingPreserved(t *testing.T) {
+	prov := mkProvider("anthropic-vision")
+	p := mkProcessor(t, echoPayloadClient{}, prov)
+
+	const n = describeConcurrency * 2
+	payloads := make([]string, n)
+	for i := range payloads {
+		payloads[i] = fmt.Sprintf("img-%02d", i)
+	}
+	req := betaReqWithImages("compare all of these", payloads...)
+	svcs := []*loadbalance.Service{mkService(prov.UUID, true)}
+
+	require.NoError(t, p.Process(context.Background(), req, svcs))
+	require.Equal(t, 0, countImages(req))
+
+	text := collectText(req)
+	prev := -1
+	for _, payload := range payloads {
+		pos := strings.Index(text, "desc-of-"+payload)
+		require.GreaterOrEqual(t, pos, 0, "description for %s missing", payload)
+		require.Greater(t, pos, prev, "description for %s spliced out of order", payload)
+		prev = pos
+	}
 }
 
 func TestVisionProxy_NoImages_NoOp(t *testing.T) {


### PR DESCRIPTION
## Summary

Refactors the vision proxy image processing pipeline to parallelize description calls for multiple images in the latest message, while maintaining strict ordering guarantees and panic containment. The change splits processing into two phases: a collect walk that gathers images and their splice targets, followed by a concurrent describe fan-out bounded by `describeConcurrency` (4).

## Key Changes

- **Two-phase processing pipeline**: 
  - Phase 1 (collect): Walk the request structure once, immediately strip historical images with the fixed marker, and gather latest-message images as `imageRef` structs (source + splice-back callback)
  - Phase 2 (describe): Fan out concurrent vision upstream calls, bounded by a semaphore to limit goroutines and in-flight requests

- **Concurrency control**: Introduced `describeConcurrency` constant (4) that bounds both live goroutines and in-flight upstream calls. The semaphore is acquired before each goroutine spawns, preventing pathological requests with many images from opening dozens of connections at once.

- **Panic containment**: Wrapped describe calls in `safeDescribe()` with per-image panic recovery. Since describe runs on goroutines outside the HTTP handler's recovery middleware, panicking vision clients now fail-strip individual images rather than crashing the process.

- **Refactored collection functions**: Replaced sequential `process*()` and `walk*()` methods with `collect*()` functions that return `[]imageRef` for the describe fan-out. Each ref captures its image source and a closure that splices the description back into the exact block slot it came from — no locking needed since each ref targets a distinct slice element.

- **Preserved ordering**: Despite concurrent execution, descriptions are spliced back into their original positions via per-ref callbacks, maintaining the request structure's integrity.

## Implementation Details

- `imageRef` struct encapsulates: media type, base64 data, remote URL, and a splice callback
- `spliceOrCollect()` is the single decision point: historical images get the marker immediately, latest-message images are collected for fan-out
- `describeAll()` manages the semaphore and wait group for concurrent execution
- Updated test suite with new tests for panic containment and concurrent mapping preservation (using `echoPayloadClient` to verify descriptions land in correct slots)
- Documentation updated in README.md to reflect the two-phase pipeline and concurrency model

## Testing

- Added `TestVisionProxy_DescribePanic_FailStrips` to verify panic recovery
- Added `TestVisionProxy_ConcurrentDescribe_MappingPreserved` to verify ordering is preserved under concurrent execution with more images than `describeConcurrency`
- Renamed `TestVisionProxy_MultipleImages_AllReplacedInOrder` to `TestVisionProxy_MultipleImages_AllReplaced` (ordering is now verified by the dedicated concurrent test)

https://claude.ai/code/session_014dpX9beMy91os2p5bzgDZQ