### PR TITLE
feat(cli): Make bot reload event-driven: CLI pokes server instead of polling

### DIFF
--- a/.design/imbot-sync.md
+++ b/.design/imbot-sync.md
@@ -34,11 +34,14 @@ correctness.**
    "run `remote start …`".
 
 2. **The polling loop stays, but as a backstop** (`background.go`):
-   one immediate sync at startup, then a 5-minute reconcile. It is no longer
+   one immediate sync at startup, then a 1-minute reconcile. It is no longer
    the propagation path; it exists for self-healing — `Sync()` restarts
    enabled-but-not-running bots, which is also the crash-recovery mechanism —
    and for direct store edits that bypass both the API and the CLI helper.
-   Removing it entirely would silently lose crash recovery.
+   Removing it entirely would silently lose crash recovery. The interval
+   bounds worst-case crash recovery at ~1 minute; a no-op pass is one SQLite
+   read plus an in-memory compare and logs nothing, so the frequency itself
+   is essentially free.
 
 3. **Silence when idle**: the loop no longer logs successful no-op passes;
    `bot.Manager.Sync` already logs each bot it actually starts or stops.

--- a/.design/imbot-sync.md
+++ b/.design/imbot-sync.md
@@ -27,9 +27,11 @@ correctness.**
    The live port is discovered through the runtime port file gated on the
    PID lock (see `runtime-port-file.md`) — this is exactly why the port file
    exists. The call is best-effort: server not running → nothing to notify,
-   the initial sync at next startup picks the change up. The caller gets a
-   bool so UX can say what actually happened ("bot started automatically"
-   vs. "run `remote start …`").
+   the initial sync at next startup picks the change up. The reload response
+   carries per-bot running status (`Sync()` swallows individual start
+   failures by design), so UX reports what actually happened: "started
+   automatically" / "server notified but bot not running, check logs" /
+   "run `remote start …`".
 
 2. **The polling loop stays, but as a backstop** (`background.go`):
    one immediate sync at startup, then a 5-minute reconcile. It is no longer

--- a/.design/imbot-sync.md
+++ b/.design/imbot-sync.md
@@ -1,0 +1,52 @@
+# ImBot State Sync: Event-Driven with a Reconcile Backstop
+
+## Problem
+
+Bot settings live in a shared SQLite store written by two kinds of actors:
+
+- **The server itself** (web UI API handlers) — in-process, so handlers
+  already start/stop bots inline right after mutating settings.
+- **CLI commands** (`remote add`, `remote pair`, …) — a *separate process*
+  opening the same SQLite file directly. The running server has no way to
+  observe those writes (SQLite update hooks are per-connection; watching the
+  WAL file is unreliable).
+
+Historically the server papered over this with a 30-second polling loop
+(`periodicBotSync`) that called `Sync()` unconditionally — a bot added via
+CLI took up to 30s to start, and the loop logged
+"Periodic bot sync completed" forever.
+
+## Decision
+
+Kubernetes-style split: **edge-triggered for latency, level-triggered for
+correctness.**
+
+1. **CLI pokes the server after writing** (`internal/command/remote_notify.go`).
+   After a CLI mutation, `notifyServerBotReload()` calls the pre-existing
+   `POST /api/v1/imbot-admin/reload` endpoint, which runs the same `Sync()`.
+   The live port is discovered through the runtime port file gated on the
+   PID lock (see `runtime-port-file.md`) — this is exactly why the port file
+   exists. The call is best-effort: server not running → nothing to notify,
+   the initial sync at next startup picks the change up. The caller gets a
+   bool so UX can say what actually happened ("bot started automatically"
+   vs. "run `remote start …`").
+
+2. **The polling loop stays, but as a backstop** (`background.go`):
+   one immediate sync at startup, then a 5-minute reconcile. It is no longer
+   the propagation path; it exists for self-healing — `Sync()` restarts
+   enabled-but-not-running bots, which is also the crash-recovery mechanism —
+   and for direct store edits that bypass both the API and the CLI helper.
+   Removing it entirely would silently lose crash recovery.
+
+3. **Silence when idle**: the loop no longer logs successful no-op passes;
+   `bot.Manager.Sync` already logs each bot it actually starts or stops.
+
+## Non-goals
+
+- `Sync()` reconciles *running state vs. enabled flag* only. Config changes
+  to an already-running bot (SmartGuide model, pairing) still require a
+  restart (`POST /imbot-admin/restart/:uuid`); CLI paths that only change
+  config intentionally do not poke reload.
+- The standalone-bot path (`tingly-box remote start`) running alongside a
+  server that also starts the same bot is a pre-existing hazard, unchanged
+  here.

--- a/internal/command/remote_add.go
+++ b/internal/command/remote_add.go
@@ -128,8 +128,12 @@ func runRemoteAddInteractive(reader *bufio.Reader, appManager *AppManager) error
 	fmt.Println()
 	// The bot is saved with Enabled: true. If the server is running, poke it
 	// so the bot starts right away; otherwise tell the user how to run it.
-	if notifyServerBotReload(appManager) {
-		fmt.Println("Server is running — the bot has been started automatically.")
+	if bots, ok := notifyServerBotReload(appManager); ok {
+		if botRunningAfterReload(bots, created.UUID) {
+			fmt.Println("Server is running — the bot has been started automatically.")
+		} else {
+			fmt.Println("Server was notified, but the bot is not running — check `tingly-box log` for startup errors.")
+		}
 	} else {
 		fmt.Println("To start this bot, run:")
 		fmt.Printf("  tingly-box remote start %s\n", created.UUID)

--- a/internal/command/remote_add.go
+++ b/internal/command/remote_add.go
@@ -126,8 +126,14 @@ func runRemoteAddInteractive(reader *bufio.Reader, appManager *AppManager) error
 	PrintSuccess("Bot configuration saved successfully!")
 	fmt.Printf("UUID: %s\n", created.UUID)
 	fmt.Println()
-	fmt.Println("To start this bot, run:")
-	fmt.Printf("  tingly-box remote start %s\n", created.UUID)
+	// The bot is saved with Enabled: true. If the server is running, poke it
+	// so the bot starts right away; otherwise tell the user how to run it.
+	if notifyServerBotReload(appManager) {
+		fmt.Println("Server is running — the bot has been started automatically.")
+	} else {
+		fmt.Println("To start this bot, run:")
+		fmt.Printf("  tingly-box remote start %s\n", created.UUID)
+	}
 	fmt.Println()
 
 	return nil

--- a/internal/command/remote_notify.go
+++ b/internal/command/remote_notify.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -9,6 +10,12 @@ import (
 
 	"github.com/tingly-dev/tingly-box/pkg/lock"
 )
+
+// reloadedBot is the per-bot status returned by the server's reload endpoint.
+type reloadedBot struct {
+	UUID    string `json:"uuid"`
+	Running bool   `json:"running"`
+}
 
 // notifyServerBotReload pokes the running server's bot-reload endpoint
 // (POST /api/v1/imbot-admin/reload) so bot settings written by this CLI
@@ -19,22 +26,22 @@ import (
 // Best-effort by design: when the server is not running there is nothing to
 // notify, and the initial sync on next startup picks the change up. The live
 // port is discovered via the runtime port file (gated on the PID lock, see
-// .design/runtime-port-file.md). Returns true only when the server
-// acknowledged the reload.
-func notifyServerBotReload(appManager *AppManager) bool {
+// .design/runtime-port-file.md). On acknowledgment it returns the per-bot
+// statuses reported by the server, so callers can tell whether a specific
+// bot actually came up — Sync swallows individual start failures by design.
+func notifyServerBotReload(appManager *AppManager) ([]reloadedBot, bool) {
 	if appManager == nil || appManager.AppConfig() == nil {
-		return false
+		return nil, false
 	}
 
-	fileLock := lock.NewFileLock(appManager.AppConfig().ConfigDir())
-	if !fileLock.IsLocked() {
-		return false
+	if !lock.NewFileLock(appManager.AppConfig().ConfigDir()).IsLocked() {
+		return nil, false
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/api/v1/imbot-admin/reload", appManager.GetRuntimeServerPort())
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		return false
+		return nil, false
 	}
 	if token := appManager.GetUserToken(); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -44,13 +51,32 @@ func notifyServerBotReload(appManager *AppManager) bool {
 	resp, err := client.Do(req)
 	if err != nil {
 		logrus.WithError(err).Debug("Failed to notify running server to reload bots")
-		return false
+		return nil, false
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		logrus.WithField("status", resp.StatusCode).Debug("Server rejected bot reload notification")
-		return false
+		return nil, false
 	}
-	return true
+
+	var parsed struct {
+		Success bool          `json:"success"`
+		Bots    []reloadedBot `json:"bots"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil || !parsed.Success {
+		return nil, false
+	}
+	return parsed.Bots, true
+}
+
+// botRunningAfterReload reports whether the given bot came up in a reload
+// response.
+func botRunningAfterReload(bots []reloadedBot, uuid string) bool {
+	for _, b := range bots {
+		if b.UUID == uuid {
+			return b.Running
+		}
+	}
+	return false
 }

--- a/internal/command/remote_notify.go
+++ b/internal/command/remote_notify.go
@@ -1,0 +1,56 @@
+package command
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/pkg/lock"
+)
+
+// notifyServerBotReload pokes the running server's bot-reload endpoint
+// (POST /api/v1/imbot-admin/reload) so bot settings written by this CLI
+// process — a separate process sharing the SQLite store — take effect
+// immediately instead of waiting for the server's low-frequency reconcile
+// loop.
+//
+// Best-effort by design: when the server is not running there is nothing to
+// notify, and the initial sync on next startup picks the change up. The live
+// port is discovered via the runtime port file (gated on the PID lock, see
+// .design/runtime-port-file.md). Returns true only when the server
+// acknowledged the reload.
+func notifyServerBotReload(appManager *AppManager) bool {
+	if appManager == nil || appManager.AppConfig() == nil {
+		return false
+	}
+
+	fileLock := lock.NewFileLock(appManager.AppConfig().ConfigDir())
+	if !fileLock.IsLocked() {
+		return false
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/api/v1/imbot-admin/reload", appManager.GetRuntimeServerPort())
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return false
+	}
+	if token := appManager.GetUserToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		logrus.WithError(err).Debug("Failed to notify running server to reload bots")
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logrus.WithField("status", resp.StatusCode).Debug("Server rejected bot reload notification")
+		return false
+	}
+	return true
+}

--- a/internal/server/module/imbot/background.go
+++ b/internal/server/module/imbot/background.go
@@ -7,31 +7,38 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// periodicBotSync periodically syncs bot states with database settings.
-// This ensures that bots created via CLI (with Enabled: true) are automatically started
-// without requiring web UI interaction.
+// reconcileInterval is deliberately low-frequency: state changes are applied
+// at their source (web API handlers start/stop bots inline; the CLI pokes
+// POST /api/v1/imbot-admin/reload after writing the shared settings store),
+// so this loop is only a safety net for crashed bots and direct store edits
+// that bypassed both paths.
+const reconcileInterval = 5 * time.Minute
+
+// periodicBotSync reconciles bot runtime state with stored settings.
+//
+// It runs one immediate sync at startup (so bots enabled while the server
+// was down come up without any UI interaction), then keeps a low-frequency
+// reconcile loop as a self-healing backstop. It is intentionally NOT the
+// primary propagation path — see reconcileInterval.
 func (m *BotManager) periodicBotSync(ctx context.Context) {
 	// Initial sync immediately after startup
 	if err := m.Sync(ctx); err != nil {
 		logrus.WithError(err).Warn("Initial bot sync failed")
-	} else {
-		logrus.Debug("Initial bot sync completed")
 	}
 
-	// Periodic sync every 30 seconds
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
+			// Sync itself logs every bot it actually starts or stops, so a
+			// no-op reconcile stays completely silent.
 			if err := m.Sync(ctx); err != nil {
-				logrus.WithError(err).Debug("Periodic bot sync failed")
-			} else {
-				logrus.Debug("Periodic bot sync completed")
+				logrus.WithError(err).Warn("Bot reconcile failed")
 			}
 		case <-ctx.Done():
-			logrus.Debug("Periodic bot sync stopped")
+			logrus.Debug("Bot reconcile loop stopped")
 			return
 		}
 	}

--- a/internal/server/module/imbot/background.go
+++ b/internal/server/module/imbot/background.go
@@ -7,12 +7,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// reconcileInterval is deliberately low-frequency: state changes are applied
-// at their source (web API handlers start/stop bots inline; the CLI pokes
+// reconcileInterval paces the safety-net loop. State changes are applied at
+// their source (web API handlers start/stop bots inline; the CLI pokes
 // POST /api/v1/imbot-admin/reload after writing the shared settings store),
-// so this loop is only a safety net for crashed bots and direct store edits
-// that bypassed both paths.
-const reconcileInterval = 5 * time.Minute
+// so this loop only covers crashed bots and direct store edits that bypassed
+// both paths. One minute keeps that worst-case recovery delay short; a no-op
+// pass is one SQLite read plus an in-memory compare and stays silent, so the
+// frequency is essentially free.
+const reconcileInterval = time.Minute
 
 // periodicBotSync reconciles bot runtime state with stored settings.
 //

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -603,7 +603,10 @@ func (h *Handler) Reload(c *gin.Context) {
 	}
 
 	logrus.Info("Bot configuration reloaded via admin API")
-	c.JSON(http.StatusOK, gin.H{"success": true})
+	// Include per-bot status so callers (e.g. the CLI poke after `remote add`)
+	// can report what actually happened: Sync swallows individual start
+	// failures by design, so success alone doesn't mean every bot is up.
+	c.JSON(http.StatusOK, gin.H{"success": true, "bots": h.botMgr.GetStatus()})
 }
 
 // StopAll stops all running bots (delegates to BotManager)


### PR DESCRIPTION
## Summary

Replaces the 30-second polling loop with an event-driven architecture where the CLI immediately notifies the server after writing bot settings, while keeping a low-frequency (1-minute) reconcile loop as a self-healing backstop. This reduces latency for bots added via CLI from ~30s to immediate, and eliminates noisy "sync completed" logs during idle periods.

## Changes

- **New `internal/command/remote_notify.go`**: Implements `notifyServerBotReload()` to POST to the server's reload endpoint after CLI mutations. Discovers the live server port via the runtime port file (gated on PID lock). Returns per-bot running status so UX can report what actually happened (e.g., "started automatically" vs. "server notified but bot not running").

- **Updated `internal/server/module/imbot/background.go`**: 
  - Renamed `periodicBotSync` loop from 30s to 5-minute reconcile interval (`reconcileInterval`)
  - Keeps one immediate sync at startup (for bots enabled while server was down)
  - Reframed as a safety net for crashed bots and direct store edits, not the primary propagation path
  - Removed "sync completed" logs on no-op passes; `Sync()` already logs each bot it actually starts/stops

- **Updated `internal/command/remote_add.go`**: After saving a new bot, calls `notifyServerBotReload()` and reports contextual feedback: "started automatically" if server is running and bot came up, "check logs" if server was notified but bot failed to start, or "run `remote start`" if server is not running.

- **Updated `internal/server/module/imbot/handler.go`**: The `Reload` endpoint now includes per-bot status in its response (`h.botMgr.GetStatus()`), enabling the CLI to report accurate feedback about which bots actually started.

- **New `.design/imbot-sync.md`**: Documents the rationale (Kubernetes-style split: edge-triggered for latency, level-triggered for correctness), the three-part design, and non-goals (config-only changes still require explicit restart; standalone-bot hazard unchanged).

## Implementation Details

- The notification is best-effort: if the server is not running, the initial sync at next startup picks up the change. No silent failures.
- The reload response carries per-bot running status because `Sync()` swallows individual start failures by design — success alone doesn't mean every bot is up.
- The reconcile loop is intentionally silent on no-op passes, reducing log noise while preserving visibility into actual state changes.

https://claude.ai/code/session_01Xk4Jnhb2ETLPtX7tYrgjLz