### PR TITLE
bugfix(protocol): Fix assembly response handling to prevent malformed JSON errors

### DIFF
--- a/internal/protocol/stream/openai_responses_to_anthropic_assembly.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_assembly.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -123,15 +124,14 @@ func (a *responsesToAnthropicAssembly) run(c *gin.Context, stream ResponsesStrea
 	return conv.Usage(), stream.Err()
 }
 
-// setAssemblyHeadersAndRecover mirrors the header and panic behavior of the
-// previous assembly implementation: SSE headers are set up-front (gin's JSON
-// render preserves an already-set Content-Type, so responses keep the
-// historical text/event-stream header), and a panic surfaces as an SSE error
-// frame.
+// setAssemblyHeaders sets the response headers for the assembly path. The
+// assembled response is a single JSON message, so the Content-Type is left to
+// gin's JSON render (application/json). A historical implementation forced
+// text/event-stream here, which made strict SDK clients (e.g. Claude Code's
+// non-streaming fallback) skip JSON parsing and treat the body as opaque text,
+// surfacing as "API returned an empty or malformed response (HTTP 200)" (#1316).
 func setAssemblyHeaders(c *gin.Context) {
-	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
-	c.Header("Connection", "keep-alive")
 	c.Header("Access-Control-Allow-Origin", "*")
 	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 }
@@ -139,13 +139,48 @@ func setAssemblyHeaders(c *gin.Context) {
 func recoverAssemblyPanic(c *gin.Context) {
 	if r := recover(); r != nil {
 		logrus.WithContext(c.Request.Context()).Errorf("Panic in Responses API to Anthropic assembly handler: %v", r)
-		if c.Writer != nil {
-			c.SSEvent("error", "{\"error\":{\"message\":\"Internal streaming error\",\"type\":\"internal_error\"}}")
-			if flusher, ok := c.Writer.(http.Flusher); ok {
-				flusher.Flush()
-			}
+		if c.Writer != nil && !c.Writer.Written() {
+			c.JSON(http.StatusInternalServerError, protocol.ErrorResponse{
+				Error: protocol.ErrorDetail{
+					Message: "Internal assembly error",
+					Type:    "internal_error",
+				},
+			})
 		}
 	}
+}
+
+// failEmptyAssembly reports an upstream stream that produced no usable content
+// blocks. Responding with an error status (propagating the upstream status
+// when known, 502 otherwise) instead of a 200 message with `content: null`
+// keeps strict clients from choking on a malformed message and lets priority
+// failover retry another candidate (both statuses are retryable).
+func failEmptyAssembly(c *gin.Context, err error, stopReason string) error {
+	if err == nil {
+		err = fmt.Errorf("upstream responses stream produced no content blocks (stop_reason=%q)", stopReason)
+	}
+	c.JSON(protocol.UpstreamStatus(err, http.StatusBadGateway), protocol.ErrorResponse{
+		Error: protocol.ErrorDetail{
+			Message: "Upstream returned an empty response: " + err.Error(),
+			Type:    "api_error",
+		},
+	})
+	return err
+}
+
+// normalizeAssemblyStopReason fills in a stop reason for a stream that was cut
+// before its terminal Responses event: tool_use if a tool call completed,
+// end_turn otherwise. Only called when at least one content block assembled.
+func normalizeAssemblyStopReason(asm *responsesToAnthropicAssembly) string {
+	if asm.stopReason != "" {
+		return asm.stopReason
+	}
+	for _, block := range asm.content {
+		if block.blockType == blockTypeToolUse {
+			return anthropicStopReasonToolUse
+		}
+	}
+	return anthropicStopReasonEndTurn
 }
 
 func closeResponsesStream(c *gin.Context, stream ResponsesStreamIter) {
@@ -167,12 +202,19 @@ func HandleResponsesToAnthropicV1Assembly(c *gin.Context, stream ResponsesStream
 	asm := newResponsesToAnthropicAssembly()
 	usage, err := asm.run(c, stream, responseModel)
 
+	// A stream that produced no content blocks (upstream failure, or cut
+	// before any block completed) must not be folded into a 200 message with
+	// null content — fail so failover can retry (#1316).
+	if len(asm.content) == 0 {
+		return usage, failEmptyAssembly(c, err, asm.stopReason)
+	}
+
 	msg := anthropic.Message{
 		ID:         asm.id,
 		Type:       constant.Message("message"),
 		Role:       constant.Assistant("assistant"),
 		Model:      anthropic.Model(asm.model),
-		StopReason: anthropic.StopReason(asm.stopReason),
+		StopReason: anthropic.StopReason(normalizeAssemblyStopReason(asm)),
 	}
 	for _, block := range asm.content {
 		union := anthropic.ContentBlockUnion{
@@ -211,12 +253,18 @@ func HandleResponsesToAnthropicBetaAssembly(c *gin.Context, stream ResponsesStre
 	asm := newResponsesToAnthropicAssembly()
 	usage, err := asm.run(c, stream, responseModel)
 
+	// See HandleResponsesToAnthropicV1Assembly: never fold a content-less
+	// stream into a 200 message with null content (#1316).
+	if len(asm.content) == 0 {
+		return usage, failEmptyAssembly(c, err, asm.stopReason)
+	}
+
 	msg := anthropic.BetaMessage{
 		ID:         asm.id,
 		Type:       constant.Message("message"),
 		Role:       constant.Assistant("assistant"),
 		Model:      anthropic.Model(asm.model),
-		StopReason: anthropic.BetaStopReason(asm.stopReason),
+		StopReason: anthropic.BetaStopReason(normalizeAssemblyStopReason(asm)),
 	}
 	for _, block := range asm.content {
 		union := anthropic.BetaContentBlockUnion{

--- a/internal/protocol/stream/openai_responses_to_anthropic_assembly_test.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_assembly_test.go
@@ -80,6 +80,9 @@ func TestHandleResponsesToAnthropicV1Assembly_Golden(t *testing.T) {
 	assert.Equal(t, 2, usage.CacheInputTokens)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
+	// JSON body must be labeled application/json — a text/event-stream label
+	// makes SDK clients skip JSON parsing entirely (#1316).
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 
 	var msg map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
@@ -133,10 +136,12 @@ func TestHandleResponsesToAnthropicBetaAssembly_Golden(t *testing.T) {
 	assert.Equal(t, "get_weather", content[1].(map[string]any)["name"])
 }
 
-// TestHandleResponsesToAnthropicV1Assembly_Truncated: a stream that ends
-// without a terminal Responses event must still respond with the partial
-// assembled message (the old implementation returned an empty body).
-func TestHandleResponsesToAnthropicV1Assembly_Truncated(t *testing.T) {
+// TestHandleResponsesToAnthropicV1Assembly_TruncatedNoContent: a stream cut
+// before any content block completes must fail with a retryable error status.
+// The old behavior responded 200 with `content: null`, which strict clients
+// (Claude Code's non-streaming fallback) reject as a malformed message (#1316),
+// and which the failover orchestrator treated as success.
+func TestHandleResponsesToAnthropicV1Assembly_TruncatedNoContent(t *testing.T) {
 	c, rec := newAssemblyTestContext(t)
 
 	events := []map[string]any{
@@ -144,12 +149,55 @@ func TestHandleResponsesToAnthropicV1Assembly_Truncated(t *testing.T) {
 		{"type": "response.output_text.delta", "item_id": "item_1", "output_index": 0, "delta": "partial"},
 	}
 	_, err := HandleResponsesToAnthropicV1Assembly(c, newAssemblyTestStream(events), "claude-proxy")
+	require.Error(t, err)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj, ok := resp["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+// TestHandleResponsesToAnthropicV1Assembly_TruncatedPartialContent: a stream
+// cut after a content block completed still responds best-effort with the
+// assembled blocks, and fills in a stop_reason so the message is well-formed.
+func TestHandleResponsesToAnthropicV1Assembly_TruncatedPartialContent(t *testing.T) {
+	c, rec := newAssemblyTestContext(t)
+
+	events := []map[string]any{
+		{"type": "response.created", "response": map[string]any{"id": "resp_1"}},
+		{"type": "response.output_text.delta", "item_id": "item_1", "output_index": 0, "delta": "partial"},
+		{"type": "response.output_text.done", "item_id": "item_1", "output_index": 0, "text": "partial"},
+	}
+	_, err := HandleResponsesToAnthropicV1Assembly(c, newAssemblyTestStream(events), "claude-proxy")
 	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var msg map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
-	// The text block never received content_block_stop, so content stays
-	// empty — but the response is a well-formed message, not an empty body.
 	assert.Equal(t, "message", msg["type"])
 	assert.Equal(t, "assistant", msg["role"])
+	assert.Equal(t, "end_turn", msg["stop_reason"])
+	content, ok := msg["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	assert.Equal(t, "partial", content[0].(map[string]any)["text"])
+}
+
+// TestHandleResponsesToAnthropicBetaAssembly_EmptyContent mirrors the V1 empty
+// case for the beta handler.
+func TestHandleResponsesToAnthropicBetaAssembly_EmptyContent(t *testing.T) {
+	c, rec := newAssemblyTestContext(t)
+
+	events := []map[string]any{
+		{"type": "response.created", "response": map[string]any{"id": "resp_1"}},
+	}
+	_, err := HandleResponsesToAnthropicBetaAssembly(c, newAssemblyTestStream(events), "claude-proxy")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 }


### PR DESCRIPTION
## Summary
Fixes issue #1316 where the Responses API to Anthropic assembly handler was returning responses with `text/event-stream` Content-Type headers, causing strict SDK clients (like Claude Code's non-streaming fallback) to skip JSON parsing and treat the body as opaque text, resulting in "API returned an empty or malformed response (HTTP 200)" errors.

## Key Changes

- **Removed `text/event-stream` Content-Type header** from assembly responses. The assembled response is a single JSON message, so gin's JSON render now correctly sets `application/json`, allowing SDK clients to parse the response properly.

- **Changed empty content handling** to fail with HTTP 502 (Bad Gateway) instead of returning HTTP 200 with `content: null`. This prevents strict clients from rejecting the malformed message and allows the failover orchestrator to retry another candidate.

- **Added `failEmptyAssembly()` function** to report upstream streams that produced no usable content blocks with appropriate error details and retryable status codes.

- **Added `normalizeAssemblyStopReason()` function** to fill in a stop reason for streams cut before their terminal event: `tool_use` if a tool call completed, `end_turn` otherwise. This ensures assembled messages are well-formed even when truncated after partial content.

- **Updated panic recovery** in `recoverAssemblyPanic()` to return a proper JSON error response instead of an SSE error frame, and only respond if headers haven't been written yet.

- **Simplified assembly headers** by removing `Connection: keep-alive` (not needed for non-streaming responses) and the problematic `text/event-stream` Content-Type.

- **Updated test cases** to verify correct Content-Type headers and distinguish between two truncation scenarios:
  - `TruncatedNoContent`: Stream cut before any content block completes → HTTP 502 error
  - `TruncatedPartialContent`: Stream cut after content blocks completed → HTTP 200 with normalized stop_reason

## Implementation Details

The fix addresses a fundamental mismatch: the assembly path produces a single JSON response, not a stream of SSE events. The historical `text/event-stream` header was a copy-paste artifact from the streaming implementation that broke strict JSON parsing in downstream clients. By removing it and properly handling edge cases (empty content, truncation), the response now works correctly with all client types while maintaining proper error semantics for failover retry logic.

