### PR TITLE
bugfix(server): fix stale content-length on gzipped UI responses

### DIFF
--- a/internal/server/middleware/gzip.go
+++ b/internal/server/middleware/gzip.go
@@ -25,13 +25,36 @@ type gzipResponseWriter struct {
 	wrote bool
 }
 
-func (g *gzipResponseWriter) Write(data []byte) (int, error) {
+func (g *gzipResponseWriter) clearContentLength() {
+	// A handler may have set Content-Length for the uncompressed body (Gin's
+	// render.Data does this). Gzip changes the representation length, so the
+	// stale value would make clients and reverse proxies treat the response as
+	// truncated. Let net/http select the correct framing for the encoded body.
+	g.Header().Del("Content-Length")
+}
+
+func (g *gzipResponseWriter) WriteHeader(code int) {
+	g.clearContentLength()
+	g.ResponseWriter.WriteHeader(code)
+}
+
+func (g *gzipResponseWriter) WriteHeaderNow() {
+	g.clearContentLength()
+	g.ResponseWriter.WriteHeaderNow()
+}
+
+func (g *gzipResponseWriter) prepareWrite() {
+	g.clearContentLength()
 	g.wrote = true
+}
+
+func (g *gzipResponseWriter) Write(data []byte) (int, error) {
+	g.prepareWrite()
 	return g.gz.Write(data)
 }
 
 func (g *gzipResponseWriter) WriteString(s string) (int, error) {
-	g.wrote = true
+	g.prepareWrite()
 	return g.gz.Write([]byte(s))
 }
 

--- a/internal/server/middleware/gzip_test.go
+++ b/internal/server/middleware/gzip_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -51,6 +52,61 @@ func TestGzipHandlerCompressesWhenAccepted(t *testing.T) {
 	}
 	if body.Data != payload {
 		t.Fatal("decompressed payload does not match original")
+	}
+}
+
+func TestGzipHandlerRemovesUncompressedContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	payload := []byte(strings.Repeat("cloudflare origin response ", 200))
+	engine.GET("/data", Gzip(), func(c *gin.Context) {
+		// render.Data sets Content-Length before writing. Once Gzip transforms
+		// the body, that uncompressed length must not reach the network.
+		c.Data(http.StatusOK, "text/plain; charset=utf-8", payload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	req.Header.Set("Accept-Encoding", "br, gzip")
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Content-Length"); got != "" {
+		t.Fatalf("Content-Length = %q, want empty for a streamed gzip response", got)
+	}
+	if got := w.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+
+	gz, err := gzip.NewReader(w.Body)
+	if err != nil {
+		t.Fatalf("gzip.NewReader failed: %v", err)
+	}
+	decoded, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("decompression failed: %v", err)
+	}
+	if string(decoded) != string(payload) {
+		t.Fatal("decompressed payload does not match original")
+	}
+}
+
+func TestGzipHandlerRemovesContentLengthBeforeExplicitHeaderCommit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	payload := strings.Repeat("explicit header commit ", 100)
+	engine.GET("/data", Gzip(), func(c *gin.Context) {
+		c.Header("Content-Length", fmt.Sprintf("%d", len(payload)))
+		c.Writer.WriteHeaderNow()
+		_, _ = c.Writer.WriteString(payload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	if got := w.Result().Header.Get("Content-Length"); got != "" {
+		t.Fatalf("committed Content-Length = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Cloudflare Tunnel and other gzip-aware reverse proxies could not serve the Tingly Box UI because the origin advertised the uncompressed `Content-Length` while sending a shorter gzip body.

This restores valid HTTP response framing so the embedded UI loads correctly through reverse proxies.

Fixes #1379

## Key Changes

- **Reverse-proxy compatibility**: Remove stale uncompressed `Content-Length` values before writing gzip responses, preventing proxies from treating the origin response as truncated.
- **Response framing safety**: Cover normal writes, string writes, and explicitly committed headers so compressed responses consistently use valid HTTP framing.
- **Regression protection**: Add coverage for Gin's fixed-length `c.Data` rendering with Cloudflare-style `Accept-Encoding: br, gzip`, including early header commits.

## Testing

- `go test ./internal/server/middleware -count=1`
- `go test ./internal/server ./internal/server/middleware ./internal/server/module/usage -count=1`
- `go vet ./internal/server/middleware`
- `git diff --check`

### Real Caddy reverse-proxy validation

Two complete Tingly Box binaries were built with the same embedded production UI:

- Clean `HEAD` baseline
- Fixed working-tree version

Both were started with isolated configuration directories and proxied through separate Caddy listeners.

- Baseline direct: declared `Content-Length: 1220`, sent 493 bytes; curl exited with code 18.
- Baseline through Caddy: empty response; Caddy logged `reading: unexpected EOF`.
- Fixed direct: HTTP 200 with a complete 493-byte gzip response.
- Fixed through Caddy: HTTP 200 with `Content-Length: 493`.
- The fixed HTML decompressed successfully and its referenced JS/CSS assets also loaded through Caddy.
- Baseline static JS returned 200, isolating the failure to the gzip-compressed SPA fallback.

## Notes

The broader `go test ./internal/server/...` suite still contains unrelated failures in two existing `statusline` cache-usage tests. All packages related to this change pass.