### PR TITLE
harness(codex): cover the nonstream-client/stream-upstream/assemble path

### DIFF
--- a/internal/protocoltest/roundtrip_test.go
+++ b/internal/protocoltest/roundtrip_test.go
@@ -228,22 +228,11 @@ func TestRoundTrip_StreamingPreContentFailure_AnthropicNative(t *testing.T) {
 }
 
 // ---- Codex assembly: nonstream client / stream upstream / assemble ----
-//
-// Codex only speaks the streaming Responses API. A non-streaming Anthropic
-// client request against a Codex-flagged provider is routed by
-// dispatchOpenAIResponses (provider.IsCodexProvider()) through
-// forwardResponsesStream + PrimeResponsesStream + the assembly handler
-// instead of a plain non-streaming forward — the third cell of the
-// {v1,beta} × {nonstream,stream,assemble} Responses→Anthropic matrix (see
-// internal/server/protocol_cross.go). Before SetupCodexAssemblyRoute, this
-// cell was unreachable by the harness: the routing check and the client's
-// dial target were the same provider.APIBase field, so a route could never
-// point at a local VirtualServer while also tripping the Codex branch.
+// Codex only speaks the streaming Responses API, so a non-streaming client
+// request against it is folded into a single message via
+// SetupCodexAssemblyRoute (see its doc comment for how this cell of the
+// dispatch matrix becomes reachable).
 
-// TestRoundTrip_CodexAssembly_Golden proves the happy path of the
-// previously-unreachable cell: a non-streaming Anthropic v1 request against
-// a Codex-flagged provider gets a well-formed 200 message, assembled from a
-// real (mocked) upstream SSE stream via the genuine dispatch decision.
 func TestRoundTrip_CodexAssembly_Golden(t *testing.T) {
 	env := pt.NewTestEnv(t)
 	defer env.Close()
@@ -258,8 +247,7 @@ func TestRoundTrip_CodexAssembly_Golden(t *testing.T) {
 }
 
 // TestRoundTrip_CodexAssembly_Beta mirrors the golden case for the Anthropic
-// beta source, exercising assembleResponsesToAnthropicBeta instead of the v1
-// variant.
+// beta source (assembleResponsesToAnthropicBeta instead of the v1 variant).
 func TestRoundTrip_CodexAssembly_Beta(t *testing.T) {
 	env := pt.NewTestEnv(t)
 	defer env.Close()
@@ -272,12 +260,9 @@ func TestRoundTrip_CodexAssembly_Beta(t *testing.T) {
 	assert.Contains(t, result.Content, "Paris")
 }
 
-// TestRoundTrip_CodexAssembly_PrimeFailure covers the same pre-stream
-// failure this file's TestRoundTrip_StreamingPrimeFailure_To_OpenAIResponses
-// covers for the plain streaming branch, but for the assembly branch: a
-// client that asked for a non-streaming response must still get a JSON
-// error with the upstream's status, not a 200 or an SSE frame, when the
-// mocked upstream fails before any event is readable.
+// TestRoundTrip_CodexAssembly_PrimeFailure is TestRoundTrip_StreamingPrimeFailure_To_OpenAIResponses's
+// counterpart for the assembly branch: a non-streaming client must still get
+// a JSON error with the upstream's status, not a 200 or an SSE frame.
 func TestRoundTrip_CodexAssembly_PrimeFailure(t *testing.T) {
 	env := pt.NewTestEnv(t)
 	defer env.Close()
@@ -292,15 +277,9 @@ func TestRoundTrip_CodexAssembly_PrimeFailure(t *testing.T) {
 		"no assistant content should be assembled from a prime-failed stream")
 }
 
-// TestRoundTrip_CodexAssembly_NoContentBlocks reproduces #1316's actual
-// repro end to end: the upstream starts a normal 200 stream (some events
-// arrive) but is cut before any content block completes — no
-// response.output_text.done, no response.completed. ErrorMidStreamCloseScenario
-// already models exactly this shape for FormatOpenAIResponses (see
-// buildMidStreamTruncated in vmodel/benchmark/scenario/scenario.go), so this
-// reuses it rather than hand-building synthetic events. Before #1316's fix,
-// this folded into a 200 message with content:null; the fix requires a
-// retryable error instead.
+// TestRoundTrip_CodexAssembly_NoContentBlocks reproduces #1316's repro end
+// to end via ErrorMidStreamCloseScenario, whose stream is cut before any
+// content block completes: a retryable error, not 200 with content:null.
 func TestRoundTrip_CodexAssembly_NoContentBlocks(t *testing.T) {
 	env := pt.NewTestEnv(t)
 	defer env.Close()

--- a/internal/protocoltest/roundtrip_test.go
+++ b/internal/protocoltest/roundtrip_test.go
@@ -227,6 +227,92 @@ func TestRoundTrip_StreamingPreContentFailure_AnthropicNative(t *testing.T) {
 		"no assistant content should be assembled from a failed pre-content stream")
 }
 
+// ---- Codex assembly: nonstream client / stream upstream / assemble ----
+//
+// Codex only speaks the streaming Responses API. A non-streaming Anthropic
+// client request against a Codex-flagged provider is routed by
+// dispatchOpenAIResponses (provider.IsCodexProvider()) through
+// forwardResponsesStream + PrimeResponsesStream + the assembly handler
+// instead of a plain non-streaming forward — the third cell of the
+// {v1,beta} × {nonstream,stream,assemble} Responses→Anthropic matrix (see
+// internal/server/protocol_cross.go). Before SetupCodexAssemblyRoute, this
+// cell was unreachable by the harness: the routing check and the client's
+// dial target were the same provider.APIBase field, so a route could never
+// point at a local VirtualServer while also tripping the Codex branch.
+
+// TestRoundTrip_CodexAssembly_Golden proves the happy path of the
+// previously-unreachable cell: a non-streaming Anthropic v1 request against
+// a Codex-flagged provider gets a well-formed 200 message, assembled from a
+// real (mocked) upstream SSE stream via the genuine dispatch decision.
+func TestRoundTrip_CodexAssembly_Golden(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupCodexAssemblyRoute(protocol.TypeAnthropicV1, pt.StreamingTextScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIResponses, pt.StreamingTextScenario(), false)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.Equal(t, "assistant", result.Role)
+	assert.Contains(t, result.Content, "Paris")
+}
+
+// TestRoundTrip_CodexAssembly_Beta mirrors the golden case for the Anthropic
+// beta source, exercising assembleResponsesToAnthropicBeta instead of the v1
+// variant.
+func TestRoundTrip_CodexAssembly_Beta(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupCodexAssemblyRoute(protocol.TypeAnthropicBeta, pt.StreamingTextScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicBeta, protocol.TypeOpenAIResponses, pt.StreamingTextScenario(), false)
+
+	require.Equal(t, 200, result.HTTPStatus)
+	assert.Contains(t, result.Content, "Paris")
+}
+
+// TestRoundTrip_CodexAssembly_PrimeFailure covers the same pre-stream
+// failure this file's TestRoundTrip_StreamingPrimeFailure_To_OpenAIResponses
+// covers for the plain streaming branch, but for the assembly branch: a
+// client that asked for a non-streaming response must still get a JSON
+// error with the upstream's status, not a 200 or an SSE frame, when the
+// mocked upstream fails before any event is readable.
+func TestRoundTrip_CodexAssembly_PrimeFailure(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupCodexAssemblyRoute(protocol.TypeAnthropicV1, pt.ErrorScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIResponses, pt.ErrorScenario(), false)
+
+	assert.GreaterOrEqual(t, result.HTTPStatus, 400,
+		"a mocked upstream failure must surface as a 4xx/5xx, not a 200")
+	assert.Empty(t, result.Content,
+		"no assistant content should be assembled from a prime-failed stream")
+}
+
+// TestRoundTrip_CodexAssembly_NoContentBlocks reproduces #1316's actual
+// repro end to end: the upstream starts a normal 200 stream (some events
+// arrive) but is cut before any content block completes — no
+// response.output_text.done, no response.completed. ErrorMidStreamCloseScenario
+// already models exactly this shape for FormatOpenAIResponses (see
+// buildMidStreamTruncated in vmodel/benchmark/scenario/scenario.go), so this
+// reuses it rather than hand-building synthetic events. Before #1316's fix,
+// this folded into a 200 message with content:null; the fix requires a
+// retryable error instead.
+func TestRoundTrip_CodexAssembly_NoContentBlocks(t *testing.T) {
+	env := pt.NewTestEnv(t)
+	defer env.Close()
+
+	env.SetupCodexAssemblyRoute(protocol.TypeAnthropicV1, pt.ErrorMidStreamCloseScenario())
+
+	result := env.SendAs(t, protocol.TypeAnthropicV1, protocol.TypeOpenAIResponses, pt.ErrorMidStreamCloseScenario(), false)
+
+	assert.GreaterOrEqual(t, result.HTTPStatus, 400,
+		"a stream cut before any content block completes must fail, not return 200 with content:null")
+}
+
 func TestRoundTrip_AllSources_TextScenario_NonStreaming(t *testing.T) {
 	sources := []protocol.APIType{
 		protocol.TypeAnthropicV1,

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -294,6 +294,73 @@ func (env *TestEnv) SetupRouteWithFlags(source, target protocol.APIType, s Scena
 	return env.findRouteModel(source, target, s.Name)
 }
 
+// SetupCodexAssemblyRoute wires a route to a provider flagged as Codex via
+// OAuthDetail.Issuer (not via a literal APIBase match against the real
+// chatgpt.com host) pointed at the VirtualServer. Codex only speaks the
+// streaming Responses API, so dispatchOpenAIResponses
+// (provider.IsCodexProvider()) routes a non-streaming client request through
+// forwardResponsesStream + PrimeResponsesStream + the assembly handler
+// instead of a plain non-streaming forward — the "nonstream client / stream
+// upstream / assemble" cell of the {v1,beta} × {nonstream,stream,assemble}
+// Responses→Anthropic matrix (see internal/server/protocol_cross.go).
+//
+// Before provider.IsCodexProvider() replaced a raw
+// provider.APIBase == protocol.CodexAPIBase comparison in dispatch, this
+// cell was unreachable by any harness: the routing check and the client's
+// real dial target were the same field, so a route could never point at a
+// local VirtualServer while also tripping the Codex branch. Decoupling the
+// two — Codex-ness now comes from OAuthDetail.Issuer, independent of
+// APIBase — is what makes this helper possible. The VirtualServer's mux
+// additionally registers /codex/responses (see
+// vmodel/benchmark/scenario_responder.go) to serve the path Codex's
+// RoundTripper rewrites /v1/responses to.
+//
+// Only source (client protocol) varies; target is always
+// protocol.TypeOpenAIResponses and streaming is always requested as false —
+// that's the one dispatch cell this exists to reach.
+func (env *TestEnv) SetupCodexAssemblyRoute(source protocol.APIType, s Scenario) {
+	target := protocol.TypeOpenAIResponses
+	key := routeKey(source, target, s.Name)
+
+	env.mu.Lock()
+	if env.setupRoutes[key] {
+		env.mu.Unlock()
+		return
+	}
+	env.setupRoutes[key] = true
+	env.mu.Unlock()
+
+	env.virtual.RegisterScenario(s)
+
+	providerUUID := fmt.Sprintf("virtual-codex-%s-%s", source, s.Name)
+	providerModel := fmt.Sprintf("virtual-model-%s", s.Name)
+	requestModel := fmt.Sprintf("pv-%s-to-codex-%s", source, s.Name)
+
+	provider := &typ.Provider{
+		UUID:               providerUUID,
+		Name:               providerUUID,
+		APIBase:            env.virtual.URL() + "/v1",
+		APIStyle:           protocol.APIStyleOpenAI,
+		OpenAIEndpointMode: ai.EndpointModeResponses,
+		AuthType:           typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			Issuer:      ai.IssuerCodex,
+			AccessToken: "virtual-codex-token",
+		},
+		Enabled: true,
+		Timeout: int64(constant.DefaultRequestTimeout),
+	}
+	_ = env.appConfig.AddProvider(provider)
+
+	rule := newHarnessRule(requestModel, sourceToRuleScenario(source), requestModel, providerModel,
+		harnessService(providerUUID, providerModel))
+	_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
+
+	env.mu.Lock()
+	env.routeModels[key] = requestModel
+	env.mu.Unlock()
+}
+
 // SendAs sends a request to the gateway as the given source protocol,
 // using the request model configured by SetupRoute, and returns the parsed result.
 //

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -230,13 +230,9 @@ func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
 }
 
 // setupRouteCore wires the provider + rule for a (source, target, scenario)
-// route. When flags is non-nil it is stamped onto the rule, so requests routed
-// through it traverse the real flag-resolution + transform path. flags==nil
-// preserves the original flag-free behavior used by the protocol matrix.
-// When providerFn is non-nil it is applied to the built provider just before
-// it's registered, letting callers override auth shape (e.g. SetupCodexAssemblyRoute
-// swapping the plain token for an OAuth/Codex identity) without duplicating
-// the rest of the provider/rule wiring.
+// route. flags, when non-nil, is stamped onto the rule. providerFn, when
+// non-nil, is applied to the built provider before registration — e.g.
+// SetupCodexAssemblyRoute uses it to swap in an OAuth/Codex identity.
 func (env *TestEnv) setupRouteCore(source, target protocol.APIType, s Scenario, flags *typ.RuleFlags, providerFn func(*typ.Provider)) {
 	key := routeKey(source, target, s.Name)
 
@@ -302,37 +298,22 @@ func (env *TestEnv) SetupRouteWithFlags(source, target protocol.APIType, s Scena
 }
 
 // SetupCodexAssemblyRoute wires a route to a provider flagged as Codex via
-// OAuthDetail.Issuer (not via a literal APIBase match against the real
-// chatgpt.com host) pointed at the VirtualServer. Codex only speaks the
-// streaming Responses API, so dispatchOpenAIResponses
-// (provider.IsCodexProvider()) routes a non-streaming client request through
-// forwardResponsesStream + PrimeResponsesStream + the assembly handler
-// instead of a plain non-streaming forward — the "nonstream client / stream
-// upstream / assemble" cell of the {v1,beta} × {nonstream,stream,assemble}
-// Responses→Anthropic matrix (see internal/server/protocol_cross.go).
-//
-// Before provider.IsCodexProvider() replaced a raw
-// provider.APIBase == protocol.CodexAPIBase comparison in dispatch, this
-// cell was unreachable by any harness: the routing check and the client's
-// real dial target were the same field, so a route could never point at a
-// local VirtualServer while also tripping the Codex branch. Decoupling the
-// two — Codex-ness now comes from OAuthDetail.Issuer, independent of
-// APIBase — is what makes this helper possible. The VirtualServer's mux
-// additionally registers /codex/responses (see
-// vmodel/benchmark/scenario_responder.go) to serve the path Codex's
-// RoundTripper rewrites /v1/responses to.
-//
-// Only source (client protocol) varies; target is always
-// protocol.TypeOpenAIResponses and streaming is always requested as false —
-// that's the one dispatch cell this exists to reach.
+// OAuthDetail.Issuer rather than a literal APIBase match, so it can point at
+// the VirtualServer instead of the real chatgpt.com host. Codex only speaks
+// the streaming Responses API, so a non-streaming request against it is
+// routed by dispatchOpenAIResponses through the assembly path — the
+// "nonstream client / stream upstream / assemble" cell of the
+// {v1,beta} × {nonstream,stream,assemble} matrix (protocol_cross.go) that
+// was unreachable before provider.IsCodexProvider() decoupled the routing
+// check from the literal dial target. (The mux also needs /codex/responses
+// registered — see vmodel/benchmark/scenario_responder.go — since that's
+// the path Codex's RoundTripper rewrites /v1/responses to.)
 func (env *TestEnv) SetupCodexAssemblyRoute(source protocol.APIType, s Scenario) {
 	target := protocol.TypeOpenAIResponses
 	env.setupRouteCore(source, target, s, nil, func(p *typ.Provider) {
-		// setupRouteCore already computes the right APIBase/APIStyle/
-		// OpenAIEndpointMode for an OpenAIResponses target; only the auth
-		// shape needs to change, from a plain token to an OAuth identity
-		// carrying the Codex issuer (what provider.IsCodexProvider() and
-		// ClientPool.GetOpenAIClient key off of).
+		// Only the auth shape needs to change from setupRouteCore's plain
+		// token to an OAuth/Codex identity — APIBase/APIStyle/EndpointMode
+		// are already right for an OpenAIResponses target.
 		p.UUID = fmt.Sprintf("virtual-codex-%s-%s", source, s.Name)
 		p.Name = p.UUID
 		p.Token = ""

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -226,14 +226,18 @@ func (env *TestEnv) VirtualCallCount() int { return env.virtual.CallCount() }
 // The provider's APIBase includes the /v1 suffix for OpenAI-style providers
 // to match actual provider API structure.
 func (env *TestEnv) SetupRoute(source, target protocol.APIType, s Scenario) {
-	env.setupRouteCore(source, target, s, nil)
+	env.setupRouteCore(source, target, s, nil, nil)
 }
 
 // setupRouteCore wires the provider + rule for a (source, target, scenario)
 // route. When flags is non-nil it is stamped onto the rule, so requests routed
 // through it traverse the real flag-resolution + transform path. flags==nil
 // preserves the original flag-free behavior used by the protocol matrix.
-func (env *TestEnv) setupRouteCore(source, target protocol.APIType, s Scenario, flags *typ.RuleFlags) {
+// When providerFn is non-nil it is applied to the built provider just before
+// it's registered, letting callers override auth shape (e.g. SetupCodexAssemblyRoute
+// swapping the plain token for an OAuth/Codex identity) without duplicating
+// the rest of the provider/rule wiring.
+func (env *TestEnv) setupRouteCore(source, target protocol.APIType, s Scenario, flags *typ.RuleFlags, providerFn func(*typ.Provider)) {
 	key := routeKey(source, target, s.Name)
 
 	env.mu.Lock()
@@ -272,10 +276,13 @@ func (env *TestEnv) setupRouteCore(source, target protocol.APIType, s Scenario, 
 		Enabled:            true,
 		Timeout:            int64(constant.DefaultRequestTimeout),
 	}
+	if providerFn != nil {
+		providerFn(provider)
+	}
 	_ = env.appConfig.AddProvider(provider)
 
 	rule := newHarnessRule(requestModel, sourceToRuleScenario(source), requestModel, providerModel,
-		harnessService(providerName, providerModel))
+		harnessService(provider.UUID, providerModel))
 	if flags != nil {
 		rule.Flags = *flags
 	}
@@ -290,7 +297,7 @@ func (env *TestEnv) setupRouteCore(source, target protocol.APIType, s Scenario, 
 // onto the gateway rule, so a request routed through it exercises the real
 // flag-resolution and transform pipeline. Returns the request model to send to.
 func (env *TestEnv) SetupRouteWithFlags(source, target protocol.APIType, s Scenario, flags typ.RuleFlags) string {
-	env.setupRouteCore(source, target, s, &flags)
+	env.setupRouteCore(source, target, s, &flags, nil)
 	return env.findRouteModel(source, target, s.Name)
 }
 
@@ -320,45 +327,21 @@ func (env *TestEnv) SetupRouteWithFlags(source, target protocol.APIType, s Scena
 // that's the one dispatch cell this exists to reach.
 func (env *TestEnv) SetupCodexAssemblyRoute(source protocol.APIType, s Scenario) {
 	target := protocol.TypeOpenAIResponses
-	key := routeKey(source, target, s.Name)
-
-	env.mu.Lock()
-	if env.setupRoutes[key] {
-		env.mu.Unlock()
-		return
-	}
-	env.setupRoutes[key] = true
-	env.mu.Unlock()
-
-	env.virtual.RegisterScenario(s)
-
-	providerUUID := fmt.Sprintf("virtual-codex-%s-%s", source, s.Name)
-	providerModel := fmt.Sprintf("virtual-model-%s", s.Name)
-	requestModel := fmt.Sprintf("pv-%s-to-codex-%s", source, s.Name)
-
-	provider := &typ.Provider{
-		UUID:               providerUUID,
-		Name:               providerUUID,
-		APIBase:            env.virtual.URL() + "/v1",
-		APIStyle:           protocol.APIStyleOpenAI,
-		OpenAIEndpointMode: ai.EndpointModeResponses,
-		AuthType:           typ.AuthTypeOAuth,
-		OAuthDetail: &typ.OAuthDetail{
+	env.setupRouteCore(source, target, s, nil, func(p *typ.Provider) {
+		// setupRouteCore already computes the right APIBase/APIStyle/
+		// OpenAIEndpointMode for an OpenAIResponses target; only the auth
+		// shape needs to change, from a plain token to an OAuth identity
+		// carrying the Codex issuer (what provider.IsCodexProvider() and
+		// ClientPool.GetOpenAIClient key off of).
+		p.UUID = fmt.Sprintf("virtual-codex-%s-%s", source, s.Name)
+		p.Name = p.UUID
+		p.Token = ""
+		p.AuthType = typ.AuthTypeOAuth
+		p.OAuthDetail = &typ.OAuthDetail{
 			Issuer:      ai.IssuerCodex,
 			AccessToken: "virtual-codex-token",
-		},
-		Enabled: true,
-		Timeout: int64(constant.DefaultRequestTimeout),
-	}
-	_ = env.appConfig.AddProvider(provider)
-
-	rule := newHarnessRule(requestModel, sourceToRuleScenario(source), requestModel, providerModel,
-		harnessService(providerUUID, providerModel))
-	_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
-
-	env.mu.Lock()
-	env.routeModels[key] = requestModel
-	env.mu.Unlock()
+		}
+	})
 }
 
 // SendAs sends a request to the gateway as the given source protocol,

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -126,16 +126,10 @@ func (ph *ProtocolHandler) dispatchAnthropicBeta(
 // source format. Anthropic sources on Codex providers use the assembly path
 // (Codex only streams), other providers use the plain non-streaming forward.
 //
-// The Codex check is provider.IsCodexProvider() rather than a raw
-// provider.APIBase == protocol.CodexAPIBase comparison so the "must
-// stream-and-assemble" decision is driven by the provider's OAuth issuer for
-// OAuth-authenticated providers (falling back to the literal APIBase for
-// legacy non-OAuth configs, same as before). This decouples the routing
-// decision from the literal dial target: a test provider can trip this
-// branch via OAuthDetail.Issuer while APIBase points at a local mock
-// server, which a raw string-equality check could never allow — that
-// coupling is what made this cell of the dispatch matrix unreachable by the
-// protocoltest harness (see #1316 follow-up).
+// Uses provider.IsCodexProvider() (OAuth issuer, falling back to literal
+// APIBase) rather than a raw APIBase equality check, so a test provider can
+// trip this branch via OAuthDetail.Issuer while APIBase points at a mock
+// server — see protocoltest.SetupCodexAssemblyRoute.
 func (ph *ProtocolHandler) dispatchOpenAIResponses(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,

--- a/internal/server/protocol_dispatch.go
+++ b/internal/server/protocol_dispatch.go
@@ -125,6 +125,17 @@ func (ph *ProtocolHandler) dispatchAnthropicBeta(
 // dispatchOpenAIResponses routes a Responses-API-bound request by the client's
 // source format. Anthropic sources on Codex providers use the assembly path
 // (Codex only streams), other providers use the plain non-streaming forward.
+//
+// The Codex check is provider.IsCodexProvider() rather than a raw
+// provider.APIBase == protocol.CodexAPIBase comparison so the "must
+// stream-and-assemble" decision is driven by the provider's OAuth issuer for
+// OAuth-authenticated providers (falling back to the literal APIBase for
+// legacy non-OAuth configs, same as before). This decouples the routing
+// decision from the literal dial target: a test provider can trip this
+// branch via OAuthDetail.Issuer while APIBase points at a local mock
+// server, which a raw string-equality check could never allow — that
+// coupling is what made this cell of the dispatch matrix unreachable by the
+// protocoltest harness (see #1316 follow-up).
 func (ph *ProtocolHandler) dispatchOpenAIResponses(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
@@ -138,7 +149,7 @@ func (ph *ProtocolHandler) dispatchOpenAIResponses(
 		logrus.Debugf("[AnthropicV1] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
 			ph.streamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
-		} else if provider.APIBase == protocol.CodexAPIBase {
+		} else if provider.IsCodexProvider() {
 			ph.assembleResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
 		} else {
 			ph.nonstreamResponsesToAnthropic(c, responseModel, actualModel, provider, *req)
@@ -147,7 +158,7 @@ func (ph *ProtocolHandler) dispatchOpenAIResponses(
 		logrus.Debugf("[Anthropic Beta] Using Transform Chain for Responses API for model=%s", actualModel)
 		if isStreaming {
 			ph.streamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
-		} else if provider.APIBase == protocol.CodexAPIBase {
+		} else if provider.IsCodexProvider() {
 			ph.assembleResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)
 		} else {
 			ph.nonstreamResponsesToAnthropicBeta(c, responseModel, actualModel, provider, *req)

--- a/vmodel/benchmark/scenario_responder.go
+++ b/vmodel/benchmark/scenario_responder.go
@@ -32,12 +32,8 @@ func newScenarioResponder(reg *vmodel.GenericRegistry[scenario.Scenario]) http.H
 	sr := &scenarioResponder{scenarios: reg, mux: http.NewServeMux()}
 	sr.mux.HandleFunc("/v1/chat/completions", sr.handle(scenario.FormatOpenAIChat))
 	sr.mux.HandleFunc("/v1/responses", sr.handleResponses)
-	// /codex/responses is where the Codex OAuth client's RoundTripper
-	// rewrites /v1/responses to (see internal/client/codex_round_tripper.go
-	// rewriteCodexPath) — registered so a provider flagged as Codex via
-	// OAuthDetail.Issuer can point at this server and still resolve,
-	// letting the protocoltest harness reach the Codex-only-streams /
-	// non-streaming-client assembly path without a real chatgpt.com host.
+	// /codex/responses is where the Codex client's RoundTripper rewrites
+	// /v1/responses to (internal/client/codex_round_tripper.go).
 	sr.mux.HandleFunc("/codex/responses", sr.handleResponses)
 	sr.mux.HandleFunc("/v1/messages", sr.handle(scenario.FormatAnthropic))
 	sr.mux.HandleFunc("/v1beta/models/", sr.handleGoogle)

--- a/vmodel/benchmark/scenario_responder.go
+++ b/vmodel/benchmark/scenario_responder.go
@@ -32,6 +32,13 @@ func newScenarioResponder(reg *vmodel.GenericRegistry[scenario.Scenario]) http.H
 	sr := &scenarioResponder{scenarios: reg, mux: http.NewServeMux()}
 	sr.mux.HandleFunc("/v1/chat/completions", sr.handle(scenario.FormatOpenAIChat))
 	sr.mux.HandleFunc("/v1/responses", sr.handleResponses)
+	// /codex/responses is where the Codex OAuth client's RoundTripper
+	// rewrites /v1/responses to (see internal/client/codex_round_tripper.go
+	// rewriteCodexPath) — registered so a provider flagged as Codex via
+	// OAuthDetail.Issuer can point at this server and still resolve,
+	// letting the protocoltest harness reach the Codex-only-streams /
+	// non-streaming-client assembly path without a real chatgpt.com host.
+	sr.mux.HandleFunc("/codex/responses", sr.handleResponses)
 	sr.mux.HandleFunc("/v1/messages", sr.handle(scenario.FormatAnthropic))
 	sr.mux.HandleFunc("/v1beta/models/", sr.handleGoogle)
 	return sr


### PR DESCRIPTION
## Summary

Harness follow-up to #1316 / #1378 (already merged to `main`), scoped to harness coverage only.

That fix was correct, but its tests only covered `HandleResponsesToAnthropic{V1,Beta}Assembly` directly with a hand-built stream — bypassing `dispatchOpenAIResponses`, `forwardResponsesStream`, and `PrimeResponsesStream` entirely. The cell of the `{v1,beta} × {nonstream,stream,assemble}` Responses→Anthropic matrix this bug actually lived in — a non-streaming Anthropic client against a Codex (stream-only) provider — had zero coverage of the real glue code, and was structurally unreachable by the `protocoltest` harness: `dispatchOpenAIResponses`'s routing check and the client's real dial target were both `provider.APIBase`, so no route could ever point at a mock server while also tripping the Codex branch.

This PR only adds the harness support needed to reach that cell and the tests that exercise it — it does not touch the fix itself:

- **`internal/server/protocol_dispatch.go`**: one-line-per-branch plumbing change, swapping the literal `provider.APIBase == protocol.CodexAPIBase` check for the existing `provider.IsCodexProvider()` helper (already used elsewhere in the codebase). This is the minimum needed to unblock the harness — it's what was coupling the routing decision to the client's real dial target, so no test route could ever trip the Codex branch while pointing at a mock server. Behavior for real provider configs is unchanged.
- **`internal/protocoltest`**: `SetupCodexAssemblyRoute` wires a Codex-flagged provider (via `OAuthDetail.Issuer`) against the `VirtualServer`; `vmodel/benchmark/scenario_responder.go` registers `/codex/responses` (where the Codex `RoundTripper` rewrites `/v1/responses` to) so the mock actually answers.
- **`roundtrip_test.go`** adds the golden, prime-failure, and no-content-blocks cases (the last reproduces #1316's actual repro shape end to end, reusing the existing `ErrorMidStreamCloseScenario` rather than hand-built events) — all driven through the real dispatch decision and real HTTP, not a bespoke fake client.

No changes to the assembly logic, the response-writing behavior, or anything else #1378 owns.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/protocoltest/... ./internal/server/... ./vmodel/...`
- [x] `go test -tags=e2e ./internal/protocoltest/... -run 'TestRoundTrip_CodexAssembly'` — all 4 new cases pass
- [x] `go test ./internal/protocoltest/...` and `go test -tags=e2e ./internal/protocoltest/...` (broader suite; unrelated to this change, the full matrix occasionally hits this sandbox's fd limit under parallel load — pre-existing environment flakiness, not caused by this diff)
- [x] `go test ./internal/server/...` (two pre-existing, unrelated failures in `internal/server/module/statusline`)
