### PR TITLE
feat(team): Seed default flags for team scenario rules on creation

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -575,10 +575,33 @@ func (c *Config) GetEffectiveAffinity(rule *typ.Rule) time.Duration {
 	return 0
 }
 
+// applyScenarioCreateDefaults seeds sensible per-scenario flag defaults on a
+// rule at creation time. It lives here, in the AddRule choke point, so every
+// creation path benefits — HTTP, CLI, TUI, agent, and import all funnel through
+// AddRule. Loading an existing config never calls AddRule, so a user who later
+// turns a default off is never re-seeded.
+//
+// Team: rules under the team scenario are almost always fronted by Claude Code
+// clients pointed at /tingly/team, so they hit the same third-party-provider
+// incompatibilities the built-in Claude Code rules already default around —
+// mid-conversation system-role messages that strict Anthropic-compatible
+// providers reject (ClaudeCodeCompat) and Claude Code's injected billing header
+// that must not leak upstream (CleanHeader). Default both on so team rules work
+// out of the box. Only seed when the caller sent no flags at all, so an explicit
+// payload that sets any flag is left untouched.
+func applyScenarioCreateDefaults(rule *typ.Rule) {
+	if rule.Scenario.Is(typ.ScenarioTeam) && rule.Flags == (typ.RuleFlags{}) {
+		rule.Flags.ClaudeCodeCompat = true
+		rule.Flags.CleanHeader = true
+	}
+}
+
 // AddRule updates the default Rule
 func (c *Config) AddRule(rule typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	applyScenarioCreateDefaults(&rule)
 
 	// Validate that all service provider UUIDs exist
 	if err := c.validateRuleServices(rule); err != nil {

--- a/internal/server/config/rule_test.go
+++ b/internal/server/config/rule_test.go
@@ -62,6 +62,50 @@ func TestAddRule_DuplicateNameDifferentScenario(t *testing.T) {
 	}
 }
 
+func TestAddRule_TeamSeedsCreateDefaults(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	// A bare team rule (no flags) — as any non-HTTP path (CLI/TUI/import) would
+	// build it — must come out with the team creation defaults seeded on.
+	if err := cfg.AddRule(typ.Rule{UUID: "team-1", Scenario: typ.ScenarioTeam, RequestModel: "m"}); err != nil {
+		t.Fatalf("AddRule failed: %v", err)
+	}
+	seeded := cfg.GetRuleByUUID("team-1")
+	if seeded == nil {
+		t.Fatal("team rule not found after AddRule")
+	}
+	if !seeded.Flags.ClaudeCodeCompat || !seeded.Flags.CleanHeader {
+		t.Errorf("expected team defaults seeded, got %+v", seeded.Flags)
+	}
+
+	// An explicit flag set is left untouched — the defaults are not layered on.
+	if err := cfg.AddRule(typ.Rule{UUID: "team-2", Scenario: typ.ScenarioTeam, RequestModel: "m2", Flags: typ.RuleFlags{SkipUsage: true}}); err != nil {
+		t.Fatalf("AddRule failed: %v", err)
+	}
+	explicit := cfg.GetRuleByUUID("team-2")
+	if explicit == nil {
+		t.Fatal("explicit team rule not found after AddRule")
+	}
+	if !explicit.Flags.SkipUsage || explicit.Flags.ClaudeCodeCompat || explicit.Flags.CleanHeader {
+		t.Errorf("explicit flags must not be overridden, got %+v", explicit.Flags)
+	}
+
+	// A non-team rule keeps its empty flag set.
+	if err := cfg.AddRule(typ.Rule{UUID: "oai-1", Scenario: typ.ScenarioOpenAI, RequestModel: "m3"}); err != nil {
+		t.Fatalf("AddRule failed: %v", err)
+	}
+	other := cfg.GetRuleByUUID("oai-1")
+	if other == nil {
+		t.Fatal("openai rule not found after AddRule")
+	}
+	if other.Flags != (typ.RuleFlags{}) {
+		t.Errorf("non-team rule should keep empty flags, got %+v", other.Flags)
+	}
+}
+
 func TestAddRule_DuplicateUUID(t *testing.T) {
 	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
 	if err != nil {

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -162,6 +162,7 @@ func (h *Handler) CreateRule(c *gin.Context) {
 	response.Data.Active = rule.Active
 	response.Data.SmartEnabled = rule.SmartEnabled
 	response.Data.SmartRouting = rule.SmartRouting
+	response.Data.Flags = rule.Flags
 
 	c.JSON(http.StatusOK, response)
 }
@@ -239,6 +240,7 @@ func (h *Handler) UpdateRule(c *gin.Context) {
 	response.Data.Active = rule.Active
 	response.Data.SmartEnabled = rule.SmartEnabled
 	response.Data.SmartRouting = rule.SmartRouting
+	response.Data.Flags = rule.Flags
 
 	c.JSON(http.StatusOK, response)
 }

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -122,6 +122,7 @@ func (h *Handler) CreateRule(c *gin.Context) {
 		})
 		return
 	}
+	applyScenarioCreateDefaults(&rule)
 	rule.UUID = uuid.NewString()
 
 	if h.config == nil {
@@ -276,6 +277,29 @@ func (h *Handler) DeleteRule(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// applyScenarioCreateDefaults seeds sensible per-scenario flag defaults on a
+// freshly created rule. It runs only at creation time (not on update), so users
+// remain free to toggle any of these off afterwards without a later save
+// re-enabling them.
+//
+// Team: rules under the team scenario are almost always fronted by Claude Code
+// clients pointed at /tingly/team, so they hit the same third-party-provider
+// incompatibilities the built-in Claude Code rules already default around —
+// mid-conversation system-role messages that strict Anthropic-compatible
+// providers reject (ClaudeCodeCompat) and Claude Code's injected billing header
+// that must not leak upstream (CleanHeader). Default both on so team rules work
+// out of the box. Only seed when the client sent no flags, so an explicit
+// create payload that sets flags is left untouched.
+func applyScenarioCreateDefaults(rule *typ.Rule) {
+	if rule == nil {
+		return
+	}
+	if rule.Scenario.Is(typ.ScenarioTeam) && rule.Flags == (typ.RuleFlags{}) {
+		rule.Flags.ClaudeCodeCompat = true
+		rule.Flags.CleanHeader = true
+	}
 }
 
 // GetFlagRegistry returns the catalog of supported rule-level flags.

--- a/internal/server/module/rule/handler.go
+++ b/internal/server/module/rule/handler.go
@@ -122,7 +122,6 @@ func (h *Handler) CreateRule(c *gin.Context) {
 		})
 		return
 	}
-	applyScenarioCreateDefaults(&rule)
 	rule.UUID = uuid.NewString()
 
 	if h.config == nil {
@@ -139,6 +138,13 @@ func (h *Handler) CreateRule(c *gin.Context) {
 			"error":   "Failed to save rule: " + err.Error(),
 		})
 		return
+	}
+
+	// Echo what was actually persisted: AddRule seeds per-scenario creation
+	// defaults (e.g. team rules get claude_code_compat + clean_header), so the
+	// client refreshes its local state from the stored rule, not the raw payload.
+	if saved := h.config.GetRuleByUUID(rule.UUID); saved != nil {
+		rule = *saved
 	}
 
 	// Log the action
@@ -279,29 +285,6 @@ func (h *Handler) DeleteRule(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
-}
-
-// applyScenarioCreateDefaults seeds sensible per-scenario flag defaults on a
-// freshly created rule. It runs only at creation time (not on update), so users
-// remain free to toggle any of these off afterwards without a later save
-// re-enabling them.
-//
-// Team: rules under the team scenario are almost always fronted by Claude Code
-// clients pointed at /tingly/team, so they hit the same third-party-provider
-// incompatibilities the built-in Claude Code rules already default around —
-// mid-conversation system-role messages that strict Anthropic-compatible
-// providers reject (ClaudeCodeCompat) and Claude Code's injected billing header
-// that must not leak upstream (CleanHeader). Default both on so team rules work
-// out of the box. Only seed when the client sent no flags, so an explicit
-// create payload that sets flags is left untouched.
-func applyScenarioCreateDefaults(rule *typ.Rule) {
-	if rule == nil {
-		return
-	}
-	if rule.Scenario.Is(typ.ScenarioTeam) && rule.Flags == (typ.RuleFlags{}) {
-		rule.Flags.ClaudeCodeCompat = true
-		rule.Flags.CleanHeader = true
-	}
 }
 
 // GetFlagRegistry returns the catalog of supported rule-level flags.

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -270,6 +270,12 @@ func TestCreateRule_TeamSeedsDefaultFlags(t *testing.T) {
 	if !saved.Flags.CleanHeader {
 		t.Error("expected CleanHeader seeded on for a new team rule")
 	}
+	// The response body must echo the seeded flags so a client that reads
+	// result.data directly (without a follow-up refresh) reflects the true
+	// stored state.
+	if !response.Data.Flags.ClaudeCodeCompat || !response.Data.Flags.CleanHeader {
+		t.Errorf("create response did not echo seeded flags: %+v", response.Data.Flags)
+	}
 }
 
 // TestCreateRule_TeamRespectsExplicitFlags verifies the seeding only fills an

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -229,6 +229,132 @@ func TestCreateRule_Success(t *testing.T) {
 	assert.Contains(t, bodyResp, `"uuid"`)
 }
 
+// TestCreateRule_TeamSeedsDefaultFlags locks the team-scenario default: a new
+// team rule created without flags gets ClaudeCodeCompat + CleanHeader seeded on,
+// since team rules are almost always fronted by Claude Code clients that hit the
+// same third-party-provider incompatibilities the built-in Claude Code rules
+// already default around.
+func TestCreateRule_TeamSeedsDefaultFlags(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg)
+	router.POST("/rules", handler.CreateRule)
+
+	rule := typ.Rule{
+		RequestModel: "team-model",
+		Scenario:     typ.ScenarioTeam,
+		Active:       true,
+	}
+	body, _ := json.Marshal(rule)
+	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("create failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var response UpdateRuleResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	saved := cfg.GetRuleByUUID(response.Data.UUID)
+	if saved == nil {
+		t.Fatal("rule not found after create")
+	}
+	if !saved.Flags.ClaudeCodeCompat {
+		t.Error("expected ClaudeCodeCompat seeded on for a new team rule")
+	}
+	if !saved.Flags.CleanHeader {
+		t.Error("expected CleanHeader seeded on for a new team rule")
+	}
+}
+
+// TestCreateRule_TeamRespectsExplicitFlags verifies the seeding only fills an
+// empty flag set: a create payload that already carries flags is left untouched,
+// so an operator who deliberately turns the defaults off is not overridden.
+func TestCreateRule_TeamRespectsExplicitFlags(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg)
+	router.POST("/rules", handler.CreateRule)
+
+	// Explicitly set a single, unrelated flag. The flag set is non-empty, so the
+	// team defaults must NOT be layered on top.
+	rule := typ.Rule{
+		RequestModel: "team-model",
+		Scenario:     typ.ScenarioTeam,
+		Active:       true,
+		Flags:        typ.RuleFlags{SkipUsage: true},
+	}
+	body, _ := json.Marshal(rule)
+	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("create failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var response UpdateRuleResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	saved := cfg.GetRuleByUUID(response.Data.UUID)
+	if saved == nil {
+		t.Fatal("rule not found after create")
+	}
+	if !saved.Flags.SkipUsage {
+		t.Error("explicit SkipUsage flag was lost")
+	}
+	if saved.Flags.ClaudeCodeCompat || saved.Flags.CleanHeader {
+		t.Error("team defaults must not override an explicit flag set")
+	}
+}
+
+// TestCreateRule_NonTeamNoDefaultFlags guards the scope: seeding is team-only,
+// so a rule created under any other scenario keeps its empty flag set.
+func TestCreateRule_NonTeamNoDefaultFlags(t *testing.T) {
+	registerTestRuleScenario(t, typ.RuleScenario("test-scenario"))
+
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg)
+	router.POST("/rules", handler.CreateRule)
+
+	rule := typ.Rule{
+		RequestModel: "gpt-4",
+		Scenario:     "test-scenario",
+		Active:       true,
+	}
+	body, _ := json.Marshal(rule)
+	req, _ := http.NewRequest("POST", "/rules", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("create failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var response UpdateRuleResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	saved := cfg.GetRuleByUUID(response.Data.UUID)
+	if saved == nil {
+		t.Fatal("rule not found after create")
+	}
+	if saved.Flags != (typ.RuleFlags{}) {
+		t.Errorf("non-team rule should keep empty flags, got %+v", saved.Flags)
+	}
+}
+
 func TestCreateRule_DuplicateNameSameScenario(t *testing.T) {
 	registerTestRuleScenario(t, typ.RuleScenario("test-scenario"))
 

--- a/internal/server/module/rule/types.go
+++ b/internal/server/module/rule/types.go
@@ -42,6 +42,11 @@ type UpdateRuleResponse struct {
 		Active        bool                        `json:"active" example:"true"`
 		SmartEnabled  bool                        `json:"smart_enabled" example:"false"`
 		SmartRouting  []smartrouting.SmartRouting `json:"smart_routing,omitempty"`
+		// Flags echoes the rule's persisted feature flags. Creation seeds
+		// per-scenario defaults (e.g. team rules get claude_code_compat +
+		// clean_header), so the client must read them back from here to reflect
+		// the true stored state without a follow-up refresh.
+		Flags typ.RuleFlags `json:"flags,omitempty"`
 	} `json:"data"`
 }
 


### PR DESCRIPTION
## Summary
Team rules created without explicit flags now automatically seed `ClaudeCodeCompat` (Claude Code compatibility) and `CleanHeader` (remove header) enabled. Team rules are almost always fronted by Claude Code clients pointed at `/tingly/team`, so they hit the same third-party-provider incompatibilities the built-in Claude Code rules already default around — mid-conversation system-role messages that strict Anthropic-compatible providers reject, and Claude Code's injected billing header that must not leak upstream.

## Key Changes
- **config.go** — the seeding lives at the `AddRule` choke point, so **every** creation path benefits (HTTP, CLI, TUI, agent, import), not just the API handler. `applyScenarioCreateDefaults()` seeds the two flags for the `team` scenario only when the caller sent no flags at all. Config load never calls `AddRule`, so a user who later turns a default off is never re-seeded.

- **handler.go** — `CreateRule()` re-reads the persisted rule (via `GetRuleByUUID`) before building its response, mirroring `UpdateRule()`, so the echoed flags reflect the seeded/stored state rather than the raw request payload.

- **types.go** — added a `Flags` field to `UpdateRuleResponse.Data` so a client reading `result.data` directly sees the authoritative stored flags without a follow-up refresh.

## Behavior
- **Creation-only**: defaults are seeded when a rule is first added, never re-applied on update or config load — users stay free to toggle them off.
- **Explicit payload wins**: if a client sends any flags at all, the team defaults are not layered on top.
- **Scoped to `team`**: any other scenario keeps its empty flag set.

## Tests
- `config.TestAddRule_TeamSeedsCreateDefaults` — locks the choke-point behavior directly (non-HTTP paths): seed-on-empty, respect-explicit, non-team-untouched.
- `rule.TestCreateRule_TeamSeedsDefaultFlags` — team rule gets both flags seeded and echoed in the HTTP response.
- `rule.TestCreateRule_TeamRespectsExplicitFlags` — explicit flags are never overridden.
- `rule.TestCreateRule_NonTeamNoDefaultFlags` — non-team scenarios keep empty flags.

## Follow-up
The response model gained a `flags` field, so run `task codegen` before merge to refresh `openapi.json` + the frontend client SDK types. Runtime already works (the client reads `result.data` loosely); this only keeps the generated TypeScript types in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MurBgG3Q9rBuzd9tg3Uacm