### PR TITLE
refactor(client, provider): remove provider-level User-Agent override

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -284,48 +284,36 @@ handler                            transformXxxx                       chain
 
 ## 8. UA 链层 — 实操中最易踩坑的部分
 
-User-Agent 优先级（每一层都是"set then delegate"，**innermost wins**）：
+**UA 是请求链路的关注点,不是 provider 配置。** 没有 provider 级 UA 字段(历史上的
+`provider.UserAgent` 已彻底移除,理由见 §11 取舍表)。走哪条 client 实现决定适用哪套规则:
+
+**A. 通用 pass-through 链**（通用 OpenAI `openai.go`、通用非-OAuth Anthropic
+`anthropic.go` else 分支）——rule/scenario `custom_user_agent` 是唯一 UA override 层:
 
 ```
-   ┌────────────────────────────────────┐
-   │  outer adapter (e.g. claudeRT)     │ ← vendor 硬编码 UA，先 set
-   │     │  set "claude-cli/2.1.86"     │
-   │     ▼ delegates to                 │
-   │  wrapWithUserAgent(provider)       │ ← provider.UserAgent（调试 override）
-   │     │  if non-empty: set provider  │   非空时覆盖 vendor 硬编码
-   │     ▼                              │
-   │  customUserAgentTransport          │ ← rule-level custom_user_agent
-   │     │  if ctx has UA: set rule UA  │   非空时覆盖一切（innermost wins）
-   │     ▼                              │
-   │  base http.Transport (sends wire)  │
-   └────────────────────────────────────┘
+   customUserAgentTransport          ← rule/scenario custom_user_agent（非空即赢）
+     base http.Transport → wire      ← 否则 SDK 默认 UA
 ```
 
-最终结果：
+优先级：**rule/scenario custom_user_agent > SDK 默认 UA**（`none` 哨兵 = 完全去掉 UA）。
 
-| 场景 | rule UA | provider UA | vendor 硬编码 | 实际发出 |
-|------|---------|-------------|--------------|---------|
-| 默认 | 空 | 空 | claude-cli/… | claude-cli/… |
-| Provider 配了 | 空 | "MyOrg/1.0" | claude-cli/… | MyOrg/1.0 |
-| Rule 配了 | "Bench/1" | "MyOrg/1.0" | claude-cli/… | Bench/1 |
-| Rule 配了 | "Bench/1" | 空 | — | Bench/1 |
+**B. 内建特种（vendor）链**（Claude Code OAuth / Codex / Kimi / Gemini / Antigravity）
+——vendor round-tripper 硬编码的**特种握手 UA 是决定性的**,`custom_user_agent` 完全不参与
+（这些链上没有 `customUserAgentTransport`）,也没有任何 provider 配置能覆盖它。
+`createSessionBoundTransport`(vendor 链底座)只做 session 绑定,不碰 UA。
 
-⚠️ `provider.UserAgent` 一旦设置就会覆盖 vendor 硬编码——这是**有意为之**
-的调试通道（见 `ai/provider.go` 该字段的 doc comment）。Claude Code OAuth
-等端点对 UA 有真实校验，错配会让 OAuth 直接被拒；设置该字段时要清楚自己
-在干嘛。
+| 场景（通用链 A） | rule UA | 实际发出 |
+|------------------|---------|----------|
+| 默认 | 空 | SDK 默认 |
+| Rule 配了 | "Bench/1" | Bench/1 |
+| Rule = `none` | "none" | （无 UA，strip 生效）|
 
-并非所有 client 都接入这条链：
+| 场景（特种链 B） | 实际发出 |
+|------------------|----------|
+| 任意 rule/配置 | **vendor 特种 UA**（Codex：SDK 默认,round-tripper 不设 UA）|
 
-| Client | Provider UA | Rule UA |
-|--------|-------------|---------|
-| 通用 OpenAI (`client/openai.go`) | ✅ | ✅ |
-| 通用 Anthropic 非-OAuth (`client/anthropic.go` else 分支) | ✅ | ✅ |
-| Claude Code OAuth (`claudeRoundTripper`) | ✅ | ❌ |
-| Codex / Kimi / Gemini / Google | ✅ | ❌ |
-
-vendor-specialized 路径不接 rule UA：它们 UA 跟整个 OAuth/握手协议绑
-定，rule 级覆盖反而会破坏 vendor 校验。这条边界写进了
+vendor-specialized 路径不接 rule UA：它们 UA 跟整个 OAuth/握手/指纹协议绑定,任何级别的
+覆盖都会破坏 vendor 校验,所以 vendor 特种 UA 对它是**决定性**的。这条边界写进了
 `flag_registry.go` 中 `custom_user_agent` 的 description 里。
 
 ⚠️ **重要不变量**：`applyCustomUserAgent`（由 `resolveRuleFlagsWithScenario`
@@ -495,7 +483,7 @@ Plugins Card 操作。
 | Registry 由后端 owner | ✅ | 前端硬编码 + 后端硬编码两边对 | 单一可信源，新 flag 只动一处元数据 |
 | 卡片放路由图内 vs 固定右侧 | 固定右侧 | 卡片随路由图滚动 | flag 是 rule 级而非 provider 级，常驻可见更符合心智模型 |
 | string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
-| UA 链 vendor pin 是否不可覆盖 | 否，可被 provider/rule 覆盖 | vendor pin 强制 | 把 `provider.UserAgent` 当调试 override 更灵活；用 doc comment 规约 |
+| UA 链 vendor pin 是否不可覆盖 | **是,vendor pin 决定性** | 保留 `provider.UserAgent` 调试 override | provider 是静态配置,不该耦合进请求链路去改写 vendor 握手/指纹 UA(footgun)。`provider.UserAgent` 字段已彻底移除;UA 只保留请求侧来源(rule custom_user_agent)与 vendor pin 两个正交轴 |
 | 请求字段重写：handler pre-chain mutate vs post-base Transform | post-base Transform | handler 链外直改 | 链外直改在跨协议路径（Anthropic→OpenAI）失效；Transform 在 Base 之后看到的是最终形态，所有 inbound 类型都能命中 |
 | preVendor transforms 的 chain 位置 | Consistency 之后、**Vendor 之前** | append 到 chain 末尾（Vendor 之后） | Vendor 直面 provider 做不可逆改写，必须是最后一个 mutation；preVendor 跑在 Vendor 之后会破坏"vendor 最终态"且让 StagePost 录制抓不到真实出站请求 |
 | op vs Transform 是否合并 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（可独立测、可复用、可多端调用）；Transform 才感知 rule 与链路位置。合并会让原语难复用 |

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -177,15 +177,12 @@ type Provider struct {
 	NoKeyRequired bool     `json:"no_key_required"`
 	Enabled       bool     `json:"enabled"`
 	ProxyURL      string   `json:"proxy_url"` // HTTP or SOCKS proxy URL (e.g., "http://localhost:7890" or "socks5://localhost:1080")
-	// UserAgent is treated as a deliberate debug / override knob. Empty means
-	// "use the vendor-appropriate default", which for generic OpenAI / Anthropic
-	// is the SDK default and for specialized clients (Claude Code OAuth,
-	// Codex, Gemini, Google) is the hardcoded vendor UA those round trippers
-	// pin. Setting a non-empty value here will overwrite even those vendor
-	// pins — that is intentional for debugging and bug-reproduction scenarios,
-	// but be aware that some upstreams (notably Claude Code OAuth) verify the
-	// CLI UA and may reject requests with a different value.
-	UserAgent   string   `json:"user_agent,omitempty"`
+	// NOTE: there is deliberately no provider-level User-Agent override. The
+	// outbound User-Agent is a request-path concern, not provider config: it is
+	// decided by the request (rule/scenario custom_user_agent) on generic
+	// pass-through clients, and pinned by the vendor handshake on specialized
+	// clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity), where the
+	// pin is decisive.
 	Timeout     int64    `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
 	Tags        []string `json:"tags,omitempty"`         // Provider tags for categorization
 	Models      []string `json:"models,omitempty"`       // Available models for this provider (cached)

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -42,7 +42,6 @@ export interface EnhancedProviderFormData {
     noKeyRequired?: boolean;
     enabled?: boolean;
     proxyUrl?: string;
-    userAgent?: string;
     authType?: 'api_key' | 'oauth';
     protocols?: ('openai' | 'anthropic')[];
     providerBaseUrls?: { openai?: string; anthropic?: string };
@@ -703,14 +702,6 @@ const ProviderFormDialog = ({
                                             onChange('name', value);
                                             setNameIsAutoFilled(false);
                                         }}
-                                    />
-                                    <TextField
-                                        size="small" fullWidth
-                                        label={t('providerDialog.advanced.userAgent.label', {defaultValue: 'User-Agent'})}
-                                        placeholder={t('providerDialog.advanced.userAgent.placeholder', {defaultValue: 'Leave empty to use built-in default'})}
-                                        value={data.userAgent || ''}
-                                        onChange={(e) => onChange('userAgent', e.target.value)}
-                                        helperText={t('providerDialog.advanced.userAgent.help', {defaultValue: 'Custom outbound HTTP User-Agent. Empty falls back to the provider\'s built-in UA.'})}
                                     />
                                     {mode === 'edit' && (
                                         <FormControlLabel

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -59,7 +59,6 @@ export function buildProviderFormData(selection: ConnectSelection): ConnectFormR
             enabled: true,
             noKeyRequired: isLocal ? !((p as any).defaultApiKey) : false,
             proxyUrl: '',
-            userAgent: '',
             providerBaseUrls: { openai: p.baseUrlOpenAI, anthropic: p.baseUrlAnthropic },
             selectedProviderId: p.id,
         },
@@ -144,7 +143,6 @@ export const useProviderDialog = (
             token: fd.token,
             no_key_required: fd.noKeyRequired,
             proxy_url: fd.proxyUrl,
-            user_agent: fd.userAgent ?? '',
         };
 
         const result = await api.addProvider(providerData);

--- a/frontend/src/hooks/useProviderEditDialog.tsx
+++ b/frontend/src/hooks/useProviderEditDialog.tsx
@@ -48,7 +48,6 @@ export function useProviderEditDialog({ onUpdated, showNotification }: UseProvid
             no_key_required: fd.noKeyRequired || false,
             enabled: fd.enabled,
             proxy_url: fd.proxyUrl ?? '',
-            user_agent: fd.userAgent ?? '',
             api_base_openai: fd.apiBaseOpenAI ?? '',
             api_base_anthropic: fd.apiBaseAnthropic ?? '',
         };
@@ -83,7 +82,6 @@ export function useProviderEditDialog({ onUpdated, showNotification }: UseProvid
                     enabled: provider.enabled,
                     noKeyRequired: provider.no_key_required || false,
                     proxyUrl: provider.proxy_url || '',
-                    userAgent: (provider as any).user_agent || '',
                     authType: provider.auth_type || 'api_key',
                 } as any);
                 setApiKeyDialogOpen(true);

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -85,11 +85,12 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 			transport = &context1mBetaTransport{base: createSessionBoundTransport(provider, sessionID)}
 		}
 	} else {
-		// Generic non-OAuth Anthropic provider. Apply the same User-Agent
-		// layering as the generic OpenAI client (rule > provider): rule-UA
-		// wraps innermost so it overwrites the header last, provider-UA sits
-		// outside. OAuth issuers above keep their dedicated transport chain
-		// unchanged because vendor-specific round-trippers manage UA themselves.
+		// Generic non-OAuth Anthropic provider. The rule/scenario
+		// custom_user_agent override (via customUserAgentTransport) is the only
+		// outbound-UA layer; there is deliberately no provider-level UA override
+		// (UA is a request-path concern, not provider config). OAuth issuers
+		// above keep their dedicated transport chain unchanged because
+		// vendor-specific round-trippers pin the handshake UA themselves.
 		//
 		// Use the transport pool instead of http.DefaultTransport so that env
 		// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
@@ -97,7 +98,6 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 		base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
 		transport = &context1mBetaTransport{base: base}
 		transport = &customUserAgentTransport{base: transport}
-		transport = wrapWithUserAgent(transport, provider)
 		transport = wrapWithLogging(transport, provider)
 	}
 

--- a/internal/client/custom_ua_transport_test.go
+++ b/internal/client/custom_ua_transport_test.go
@@ -146,37 +146,3 @@ func TestCustomUserAgentTransport_EmptyContextValueIsNoOp(t *testing.T) {
 	}
 }
 
-func TestWrapWithUserAgent_RuleAndProviderLayering(t *testing.T) {
-	// Simulate the full chain used by client/openai.go and client/anthropic.go:
-	//   wrapWithUserAgent(provider)  -> outer
-	//     customUserAgentTransport   -> rule UA, innermost
-	//       captureTransport         -> wire
-	// Rule UA should win when both are present.
-	cap := &captureTransport{}
-	prov := &typ.Provider{UserAgent: "ProviderUA/1.0"}
-
-	var transport http.RoundTripper = cap
-	transport = &customUserAgentTransport{base: transport}
-	transport = wrapWithUserAgent(transport, prov)
-
-	t.Run("rule overrides provider", func(t *testing.T) {
-		ctx := typ.WithCustomUserAgent(context.Background(), "RuleUA/1.0")
-		req := newReq(t, ctx, "")
-		if _, err := transport.RoundTrip(req); err != nil {
-			t.Fatalf("RoundTrip: %v", err)
-		}
-		if cap.lastUA != "RuleUA/1.0" {
-			t.Errorf("UA = %q, want rule wins (%q)", cap.lastUA, "RuleUA/1.0")
-		}
-	})
-
-	t.Run("provider wins when rule absent", func(t *testing.T) {
-		req := newReq(t, context.Background(), "")
-		if _, err := transport.RoundTrip(req); err != nil {
-			t.Fatalf("RoundTrip: %v", err)
-		}
-		if cap.lastUA != "ProviderUA/1.0" {
-			t.Errorf("UA = %q, want provider fallback (%q)", cap.lastUA, "ProviderUA/1.0")
-		}
-	})
-}

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -14,40 +14,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// userAgentRoundTripper forces the outbound User-Agent header to a fixed
-// value. It is layered as the INNERMOST wrapper (closer to the network) so it
-// takes precedence over any provider-specific UA set by outer round trippers
-// (claudeRoundTripper, antigravityRoundTripper, codexRoundTripper, etc.) that
-// rewrite headers before delegating downstream.
-type userAgentRoundTripper struct {
-	http.RoundTripper
-	userAgent string
-}
-
-func (t *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.userAgent != "" {
-		req.Header.Set("User-Agent", t.userAgent)
-	}
-	return t.RoundTripper.RoundTrip(req)
-}
-
-// wrapWithUserAgent wraps a transport with a User-Agent override when the
-// provider has a custom UA configured. Returns the original transport unchanged
-// when no override is set.
-//
-// Design note: provider.UserAgent is treated as a deliberate debug knob — when
-// non-empty it intentionally overrides even vendor-pinned UAs (claude-cli,
-// GeminiCLI, codex, …) because we don't want to hide the configured value
-// behind silent precedence rules. Operators who set this should know what
-// they're doing; the catch lives in ai/provider.go's UserAgent doc comment.
-// Rule-level custom_user_agent layers innermost so it still wins over both.
-func wrapWithUserAgent(inner http.RoundTripper, provider *typ.Provider) http.RoundTripper {
-	if provider == nil || provider.UserAgent == "" {
-		return inner
-	}
-	return &userAgentRoundTripper{RoundTripper: inner, userAgent: provider.UserAgent}
-}
-
 // CreateHTTPClientWithProxy creates an HTTP client with proxy support.
 // Supports http(s) and socks5 proxy URLs; falls back to http.DefaultClient
 // for any parse/scheme failure (logged).
@@ -279,9 +245,10 @@ func (t *SessionBoundTransport) RoundTrip(req *http.Request) (*http.Response, er
 // their dedicated xxx_client.go files and layer their RoundTripper on top of
 // what this returns.
 //
-// A custom User-Agent override (provider.UserAgent) is layered here at the
-// innermost position so it wins against any outer adapter that rewrites
-// headers before delegating downstream.
+// It deliberately does NOT touch the User-Agent: this transport underpins the
+// vendor-specialized clients (Claude Code OAuth, Codex, Kimi, Gemini,
+// Antigravity), whose round trippers pin the vendor handshake UA outside it.
+// Keeping UA out of here is what makes that vendor pin decisive.
 func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID) http.RoundTripper {
 	var issuer ai.Issuer
 	if provider.OAuthDetail != nil {
@@ -292,13 +259,11 @@ func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID
 		logrus.Debugf("Using proxy for provider %s: %s", provider.UUID, provider.ProxyURL)
 	}
 
-	base := &SessionBoundTransport{
+	return &SessionBoundTransport{
 		transportPool: GetGlobalTransportPool(),
 		providerUUID:  provider.UUID,
 		proxyURL:      provider.ProxyURL,
 		issuer:        issuer,
 		sessionID:     sessionID,
 	}
-
-	return wrapWithUserAgent(base, provider)
 }

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -63,17 +63,16 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	// Create HTTP client with session-bound transport
 	var transport http.RoundTripper
 
-	// User-Agent layering (rule > provider): rule-UA wraps the base transport
-	// innermost so it overwrites the header last (closest to the wire), then
-	// the provider-UA wrapper sits outside. When the rule flag is absent the
-	// rule-UA wrapper is a no-op, leaving provider-UA in effect.
+	// User-Agent: the rule/scenario custom_user_agent override (via
+	// customUserAgentTransport) is the only outbound-UA layer here. There is
+	// deliberately no provider-level UA override — UA is a request-path concern,
+	// not provider config.
 	//
 	// Use the transport pool instead of http.DefaultTransport so that env
 	// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
 	// proxy is explicitly configured for the provider.
 	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
 	transport = &customUserAgentTransport{base: base}
-	transport = wrapWithUserAgent(transport, provider)
 	transport = wrapWithLogging(transport, provider)
 
 	httpClient := &http.Client{

--- a/internal/dataio/integration_test.go
+++ b/internal/dataio/integration_test.go
@@ -200,7 +200,6 @@ func TestProviderRoundTripByAuthType(t *testing.T) {
 				NoKeyRequired:      false,
 				Enabled:            true,
 				ProxyURL:           "http://localhost:7890",
-				UserAgent:          "custom-agent/1.0",
 				Timeout:            45,
 				Tags:               []string{"prod", "fast"},
 				Models:             []string{"gpt-4", "gpt-4o"},
@@ -310,7 +309,7 @@ func TestProviderRoundTripByAuthType(t *testing.T) {
 			// owns — this isolates the export/import fix from the separate
 			// DB persistence layer (internal/data/db), which has its own,
 			// independent field-mapping gaps (e.g. Models isn't a column at
-			// all, UserAgent/DeviceID aren't copied in toRecord/toProvider)
+			// all, DeviceID isn't copied in toRecord/toProvider)
 			// that are out of scope for this change.
 			decodedProvider := decodeExportedProvider(t, exportResult.Content, tt.provider.UUID)
 
@@ -505,9 +504,6 @@ func assertProviderFieldsEqual(t *testing.T, want, got *typ.Provider) {
 	}
 	if want.ProxyURL != got.ProxyURL {
 		t.Errorf("ProxyURL = %q, want %q", got.ProxyURL, want.ProxyURL)
-	}
-	if want.UserAgent != got.UserAgent {
-		t.Errorf("UserAgent = %q, want %q", got.UserAgent, want.UserAgent)
 	}
 	if want.Timeout != got.Timeout {
 		t.Errorf("Timeout = %d, want %d", got.Timeout, want.Timeout)

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -47,7 +47,6 @@ func maskForResponse(p *typ.Provider) ProviderResponse {
 		NoKeyRequired:    p.NoKeyRequired,
 		Enabled:          p.Enabled,
 		ProxyURL:         p.ProxyURL,
-		UserAgent:        p.UserAgent,
 		AuthType:         string(p.AuthType),
 		Source:           string(p.Source),
 	}
@@ -175,7 +174,6 @@ func (h *Handler) CreateProvider(c *gin.Context) {
 		NoKeyRequired:    req.NoKeyRequired,
 		Enabled:          true, // always make new provider enabled
 		ProxyURL:         req.ProxyURL,
-		UserAgent:        req.UserAgent,
 		AuthType:         typ.AuthType(req.AuthType),
 		Timeout:          constant.DefaultRequestTimeout,
 	}
@@ -300,9 +298,6 @@ func (h *Handler) UpdateProvider(c *gin.Context) {
 	}
 	if req.ProxyURL != nil {
 		p.ProxyURL = *req.ProxyURL
-	}
-	if req.UserAgent != nil {
-		p.UserAgent = *req.UserAgent
 	}
 
 	// Dual-mode constraints: validate post-merge so we catch combinations

--- a/internal/server/module/provider/types.go
+++ b/internal/server/module/provider/types.go
@@ -19,7 +19,6 @@ type ProviderResponse struct {
 	NoKeyRequired    bool              `json:"no_key_required" example:"false"`
 	Enabled          bool              `json:"enabled" example:"true"`
 	ProxyURL         string            `json:"proxy_url,omitempty" example:"http://localhost:7890"`
-	UserAgent        string            `json:"user_agent,omitempty" example:"my-gateway/1.0"`
 	AuthType         string            `json:"auth_type,omitempty" example:"api_key"` // api_key, oauth, or vmodel
 	OAuthDetail      *typ.OAuthDetail  `json:"oauth_detail,omitempty"`                // OAuth credentials (only for oauth auth type)
 	VModelDetail     *typ.VModelDetail `json:"vmodel_detail,omitempty"`               // Virtual-model config (only for vmodel auth type)
@@ -43,7 +42,6 @@ type CreateProviderRequest struct {
 	NoKeyRequired    bool   `json:"no_key_required" description:"Whether provider requires no API key" example:"false"`
 	Enabled          bool   `json:"enabled" description:"Whether provider is enabled" example:"true"`
 	ProxyURL         string `json:"proxy_url,omitempty" description:"HTTP or SOCKS proxy URL (e.g., http://localhost:7890 or socks5://localhost:1080)" example:"http://localhost:7890"`
-	UserAgent        string `json:"user_agent,omitempty" description:"Custom outbound HTTP User-Agent; empty uses the built-in/default for this provider" example:"my-gateway/1.0"`
 	AuthType         string `json:"auth_type,omitempty" description:"Auth type: api_key or oauth (default: api_key)" example:"api_key"`
 }
 
@@ -65,7 +63,6 @@ type UpdateProviderRequest struct {
 	NoKeyRequired    *bool   `json:"no_key_required,omitempty" description:"Whether provider requires no API key"`
 	Enabled          *bool   `json:"enabled,omitempty" description:"New enabled status"`
 	ProxyURL         *string `json:"proxy_url,omitempty" description:"HTTP or SOCKS proxy URL"`
-	UserAgent        *string `json:"user_agent,omitempty" description:"Custom outbound HTTP User-Agent (empty string clears it and reverts to default)"`
 }
 
 // UpdateProviderResponse represents the response for updating a provider.

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -103,7 +103,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:             "custom_user_agent",
 			Label:           "Custom User-Agent",
-			Description:     "Override the outbound User-Agent header sent to the upstream provider. Takes precedence over the provider-level User-Agent for generic OpenAI / Anthropic clients; vendor-specific clients (Claude Code OAuth, Codex, Gemini, Google) keep their dedicated User-Agent. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
+			Description:     "Override the outbound User-Agent header sent to the upstream provider, for generic OpenAI / Anthropic clients. Vendor-specific clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) keep their dedicated handshake User-Agent and ignore this. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
 			Type:            FlagTypeString,
 			Category:        FlagCategoryRequestOpenAI,
 			Placeholder:     "e.g. MyApp/1.0",

--- a/openapi.json
+++ b/openapi.json
@@ -6348,11 +6348,6 @@
             "type": "string",
             "description": "API token",
             "example": "sk-..."
-          },
-          "user_agent": {
-            "type": "string",
-            "description": "Custom outbound HTTP User-Agent; empty uses the built-in/default for this provider",
-            "example": "my-gateway/1.0"
           }
         },
         "required": [
@@ -9630,11 +9625,6 @@
             "description": "Field token",
             "example": "sk-***...***"
           },
-          "user_agent": {
-            "type": "string",
-            "description": "Field user_agent",
-            "example": "my-gateway/1.0"
-          },
           "uuid": {
             "type": "string",
             "description": "Field uuid",
@@ -11602,10 +11592,6 @@
           "token": {
             "type": "string",
             "description": "New API token"
-          },
-          "user_agent": {
-            "type": "string",
-            "description": "Custom outbound HTTP User-Agent (empty string clears it and reverts to default)"
           }
         }
       },
@@ -11784,6 +11770,9 @@
                 "type": "string",
                 "description": "Field description",
                 "example": "My rule description"
+              },
+              "flags": {
+                "$ref": "#/components/schemas/RuleFlags"
               },
               "provider": {
                 "type": "string",


### PR DESCRIPTION
Removes the `provider.UserAgent` field and its plumbing. Outbound User-Agent is a request-path concern, not provider config.

**Why:** `provider.UserAgent` was injected into the transport chain (via `wrapWithUserAgent`, incl. `createSessionBoundTransport` — the base of every vendor/OAuth client), letting a provider knob overwrite the vendor handshake/fingerprint UA (`claude-cli`, `KimiCLI`, …). Footgun for Claude Code OAuth, and it made the vendor pin only nominally decisive.

**After:** generic clients carry only the rule/scenario `custom_user_agent` override; vendor pins are decisive.

**Changes:** drop the field + `wrapWithUserAgent`/`userAgentRoundTripper`; `createSessionBoundTransport` only binds the session now; remove `user_agent` from provider DTOs/handler, frontend dialog/hooks, and `openapi.json` (regenerated); update tests and `.design/rule-flags.md` §8/§11.

**Compat:** providers are JSON with no `user_agent` DB column — a stale key is ignored on load, no migration needed.