### PR TITLE
refactor(UA, flag, client): Refactor User-Agent handling: forward inbound client UA, pin vendor UA

### DIFF
--- a/.design/rule-flags.md
+++ b/.design/rule-flags.md
@@ -134,7 +134,7 @@ func RuleFlagRegistry() []FlagSpec { … }
 
 | Key | Type | 类别 | Shared | 继承 | 作用 | 注入点 |
 |-----|------|------|--------|------|------|--------|
-| `custom_user_agent` | string | request | **yes** | override | 覆盖出站 User-Agent header。registry 通过 `Suggestions`（`typ.DefaultUserAgents()`）透出几个常见 CLI/agent 的 UA 预设供快选。特殊值 `none`（`typ.UserAgentNone`）= 完全去掉 User-Agent header。| `customUserAgentTransport` + `applyCustomUserAgent(c, flags)` → `WithCustomUserAgent(ctx, ...)`（Type 2）|
+| `custom_user_agent` | string | request | **yes** | override | 覆盖出站 User-Agent header。registry 通过 `Suggestions`（`typ.DefaultUserAgents()`）透出几个常见 CLI/agent 的 UA 预设供快选。特殊值 `none`（`typ.UserAgentNone`）= 完全去掉 User-Agent header。| `userAgentTransport` + `applyCustomUserAgent(c, flags)` → `WithCustomUserAgent(ctx, ...)`（Type 2）|
 | `openai_endpoint_override` | enum (`auto`/`chat`/`responses`) | request | — | — | 强制单条 rule 的 OpenAI 出口走 Chat 或 Responses；与 provider 声明的 `OpenAIEndpointMode` 冲突时 provider 赢（见 `.design/openai-endpoint-routing.md`）| `ParseEndpointOverride` → `ResolveOpenAIEndpoint`（Type 4：路由层决策）|
 | `use_max_completion_tokens` | bool | request | — | — | 把 `max_tokens` 字段名重写为 `max_completion_tokens`（OpenAI o1/o3/gpt-5 系列必需） | `transform.OpenAIMaxTokensRewriteTransform` → `ops.ApplyMaxCompletionTokensRewrite`（Type 1b-post）|
 | `use_max_tokens` | bool | request | — | — | 反向：把 `max_completion_tokens` 写回旧字段 `max_tokens`（用于拒绝新字段的 provider/模型）| 同上 → `ops.ApplyMaxTokensRewrite`（Type 1b-post）|
@@ -284,50 +284,80 @@ handler                            transformXxxx                       chain
 
 ## 8. UA 链层 — 实操中最易踩坑的部分
 
-**UA 是请求链路的关注点,不是 provider 配置。** 没有 provider 级 UA 字段(历史上的
-`provider.UserAgent` 已彻底移除,理由见 §11 取舍表)。走哪条 client 实现决定适用哪套规则:
+> 出站 UA 的**权威说明**（含各 client 路径逐一对照的结果表）见
+> `.design/user-agent.md`。本节从 rule flag 视角给出链层与注入机制。
+
+**不存在一条统一线性优先级。** UA 是**请求链路**的关注点,不是 provider 配置——历史上
+的 `provider.UserAgent` 已彻底移除(理由见 §11 取舍表)。走哪条 client 实现决定适用哪一套
+规则,有两套(每层"set then delegate",**innermost wins**):
 
 **A. 通用 pass-through 链**（通用 OpenAI `openai.go`、通用非-OAuth Anthropic
-`anthropic.go` else 分支）——rule/scenario `custom_user_agent` 是唯一 UA override 层:
+`anthropic.go` else 分支）——client 入站 UA 会被**兜底转发**：
 
 ```
-   customUserAgentTransport          ← rule/scenario custom_user_agent（非空即赢）
-     base http.Transport → wire      ← 否则 SDK 默认 UA
+   userAgentTransport                  ← 一处解析优先级(不靠多层叠放)
+     base http.Transport → wire
 ```
 
-优先级：**rule/scenario custom_user_agent > SDK 默认 UA**（`none` 哨兵 = 完全去掉 UA）。
+优先级（在 `userAgentTransport` 一个 RoundTrip 内解析）：**rule/scenario custom_user_agent
+> 入站 client UA > SDK 默认**。它读 ctx 两个候选值显式取胜者,避免"包裹顺序 vs 执行顺序
+相反"的易错点。
 
-**B. 内建特种（vendor）链**（Claude Code OAuth / Codex / Kimi / Gemini / Antigravity）
-——vendor round-tripper 硬编码的**特种握手 UA 是决定性的**,`custom_user_agent` 完全不参与
-（这些链上没有 `customUserAgentTransport`）,也没有任何 provider 配置能覆盖它。
-`createSessionBoundTransport`(vendor 链底座)只做 session 绑定,不碰 UA。
+**B. 内建特种（vendor）链**（Claude Code OAuth / Codex / Kimi / Gemini /
+Antigravity）——**client UA 与 rule/scenario custom_user_agent 完全不参与,也没有任何
+provider 配置入口**：
 
-| 场景（通用链 A） | rule UA | 实际发出 |
-|------------------|---------|----------|
-| 默认 | 空 | SDK 默认 |
-| Rule 配了 | "Bench/1" | Bench/1 |
-| Rule = `none` | "none" | （无 UA，strip 生效）|
+```
+   vendorRoundTripper                  ← 设 vendor 特种 UA（Codex 例外：不设）
+     createSessionBoundTransport       ← 只做 session 绑定,不碰 UA
+       SessionBoundTransport → wire
+```
 
-| 场景（特种链 B） | 实际发出 |
-|------------------|----------|
-| 任意 rule/配置 | **vendor 特种 UA**（Codex：SDK 默认,round-tripper 不设 UA）|
+唯一 UA 来源:**vendor 特种 UA,决定性、不可被任何配置覆盖**。
 
-vendor-specialized 路径不接 rule UA：它们 UA 跟整个 OAuth/握手/指纹协议绑定,任何级别的
-覆盖都会破坏 vendor 校验,所以 vendor 特种 UA 对它是**决定性**的。这条边界写进了
-`flag_registry.go` 中 `custom_user_agent` 的 description 里。
+⚠️ **别把两套写成一条链。** vendor 链上没有 `userAgentTransport`（Gemini 更是
+`req.Header = http.Header{}` 清空整个 header），`createSessionBoundTransport` 也只做
+session 绑定不碰 UA——所以 client 发什么、rule 配
+什么,都**动不了 vendor 特种 UA**。边界靠"vendor 链自带 `WithHTTPClient` 在 SDK option
+末尾覆盖掉通用 httpClient / 自建不含 UA-transport 的链"保证(详见本节末尾的不变量)。
 
-⚠️ **重要不变量**：`applyCustomUserAgent`（由 `resolveRuleFlagsWithScenario`
-统一调用）把 UA 写进 `c.Request.Context()`（对**所有**请求，无论
-scenario/provider），但 UA 只在 transport 链里
-**有** `customUserAgentTransport` 的 client 上生效——它读 `req.Context()`。
-`customUserAgentTransport` 只在两处接入：通用 `NewOpenAIClient`（openai.go）
-与通用非-OAuth Anthropic 分支（anthropic.go else）。vendor 路径
-（Codex / Kimi 等）虽然内部复用 `NewOpenAIClient`，但用 `extraOptions` 里
-自带的 `WithHTTPClient`（含 `codexRoundTripper` / `kimiRoundTripper`，
-**不含** `customUserAgentTransport`）在 SDK option 末尾覆盖掉通用 httpClient
-（"extra 最后应用"）；Claude OAuth 走 `NewClaudeClient` 自建链。所以即便
-ctx 里带着 UA，vendor client 也没有任何 transport 去读它——握手 UA 不会被
-flag 污染。**给 vendor 链新增 transport 时切勿引入 `customUserAgentTransport`。**
+结果（**通用链 A**，client 入站发了 `cherry/1.2`）：
+
+| 场景 | rule UA | client 入站 UA | 实际发出 |
+|------|---------|----------------|----------|
+| 什么都没配 | 空 | 空 | SDK 默认 |
+| client 发了 UA | 空 | "cherry/1.2" | **cherry/1.2**（兜底转发）|
+| Rule 配了 | "Bench/1" | "cherry/1.2" | Bench/1 |
+| Rule = `none` | "none" | "cherry/1.2" | （无 UA，strip 生效）|
+
+结果（**特种链 B**）：任意 rule/client/配置 → **vendor 特种 UA**（Codex：SDK 默认）。
+
+并非所有 client 都接入这些层（`✅` = 该层生效；`❌` = 该链上没有对应 transport 去读，
+对该 client 完全不可见）：
+
+| Client | Rule/Scenario UA | Client 入站 UA |
+|--------|:----------------:|:--------------:|
+| 通用 OpenAI (`client/openai.go`) | ✅ | ✅ |
+| 通用 Anthropic 非-OAuth (`client/anthropic.go` else 分支) | ✅ | ✅ |
+| Claude Code OAuth (`claudeRoundTripper`) | ❌ | ❌ |
+| Codex / Kimi / Gemini / Antigravity | ❌ | ❌ |
+
+vendor-specialized 路径既不接 rule UA、也不接 client 入站 UA：它们的 UA 跟整个
+OAuth / 握手 / 指纹协议绑定，任何级别的覆盖都会破坏 vendor 校验，所以 vendor 特种 UA
+对它们是**决定性**的。这条边界写进了 `flag_registry.go` 中 `custom_user_agent` 的
+description 里，逐路径对照见 `.design/user-agent.md` §3。
+
+⚠️ **重要不变量**：`applyCustomUserAgent` 与 `applyClientUserAgent`（都由
+`resolveRuleFlagsWithScenario` 统一调用）把 UA 写进 `c.Request.Context()`（对**所有**
+请求，无论 scenario/provider），但这两个 UA 只在 transport 链里**有**
+`userAgentTransport` 的 client 上生效——它读 `req.Context()` 的两个候选值并按固定优先级
+取胜者。`userAgentTransport` 只在两处接入：通用 `NewOpenAIClient`（openai.go）与通用
+非-OAuth Anthropic 分支（anthropic.go else）。vendor 路径（Codex / Kimi 等）虽然内部复用
+`NewOpenAIClient`，但用 `extraOptions` 里自带的 `WithHTTPClient`（含 `codexRoundTripper` /
+`kimiRoundTripper`，**不含** `userAgentTransport`）在 SDK option 末尾覆盖掉通用 httpClient
+（"extra 最后应用"）；Gemini / Antigravity / Claude OAuth 自建 transport 链。所以即便 ctx
+里带着 UA，vendor client 也没有任何 transport 去读它——握手 / 特种 UA 不会被 flag 或
+client UA 污染。**给 vendor 链新增 transport 时切勿引入 `userAgentTransport`。**
 
 ---
 
@@ -483,7 +513,7 @@ Plugins Card 操作。
 | Registry 由后端 owner | ✅ | 前端硬编码 + 后端硬编码两边对 | 单一可信源，新 flag 只动一处元数据 |
 | 卡片放路由图内 vs 固定右侧 | 固定右侧 | 卡片随路由图滚动 | flag 是 rule 级而非 provider 级，常驻可见更符合心智模型 |
 | string flag 的"启用"语义 | 空 = 未启用 | 独立 enable Switch + 文本 | 一个字段一个状态，UI 更简单；权衡是无法区分"空字符串"和"未配置" |
-| UA 链 vendor pin 是否不可覆盖 | **是,vendor pin 决定性** | 保留 `provider.UserAgent` 调试 override | provider 是静态配置,不该耦合进请求链路去改写 vendor 握手/指纹 UA(footgun)。`provider.UserAgent` 字段已彻底移除;UA 只保留请求侧来源(rule custom_user_agent)与 vendor pin 两个正交轴 |
+| UA 链 vendor pin 是否不可覆盖 | **是,vendor pin 决定性** | 保留 `provider.UserAgent` 调试 override | provider 是静态配置,不该耦合进请求链路去改写 vendor 握手/指纹 UA(footgun)。`provider.UserAgent` 字段已彻底移除;UA 只保留请求侧来源(client 入站 / rule custom_user_agent)与 vendor pin 两个正交轴。详见 `.design/user-agent.md` §5 |
 | 请求字段重写：handler pre-chain mutate vs post-base Transform | post-base Transform | handler 链外直改 | 链外直改在跨协议路径（Anthropic→OpenAI）失效；Transform 在 Base 之后看到的是最终形态，所有 inbound 类型都能命中 |
 | preVendor transforms 的 chain 位置 | Consistency 之后、**Vendor 之前** | append 到 chain 末尾（Vendor 之后） | Vendor 直面 provider 做不可逆改写，必须是最后一个 mutation；preVendor 跑在 Vendor 之后会破坏"vendor 最终态"且让 StagePost 录制抓不到真实出站请求 |
 | op vs Transform 是否合并 | 分两层 | 把 op 直接做成 Transform | op 是纯函数原语（可独立测、可复用、可多端调用）；Transform 才感知 rule 与链路位置。合并会让原语难复用 |

--- a/.design/user-agent.md
+++ b/.design/user-agent.md
@@ -1,0 +1,204 @@
+# User-Agent 处理与优先级
+
+> 适用对象：tingly-box 后端贡献者。
+> 本文档是出站 `User-Agent` 行为的**权威说明**。rule flag 侧的注入机制见
+> `.design/rule-flags.md`（尤其 §8）；本文聚焦"最终 wire 上发出什么 UA"。
+
+---
+
+## 0. 一句话模型
+
+tingly-box **不是透明转发代理**：它解析入站请求体、经 transform chain、再用
+vendor SDK（openai-go / anthropic-sdk-go / go-genai）**重建**出站请求。出站
+`User-Agent` 是**合成**的，不是把 client 的头原样透传。
+
+**核心原则：UA 是请求链路的关注点,不是 provider 配置。** 没有任何 provider 级
+的 UA 字段(历史上的 `provider.UserAgent` 已彻底移除,理由见 §5)。走哪条 client
+实现决定适用哪一套规则,有两套,泾渭分明:
+
+- **A. 通用 pass-through client**（generic OpenAI、generic 非-OAuth Anthropic）——
+  UA 完全由**请求侧**决定:rule/scenario `custom_user_agent`,或兜底转发**入站 client UA**。
+- **B. 内建特种（vendor）client**（Claude Code OAuth / Kimi / Gemini / Antigravity /
+  Codex）——**vendor 特种握手 UA 是唯一且决定性的**。rule/scenario `custom_user_agent`
+  与入站 client UA **完全不参与**,也没有任何 provider 配置能覆盖它。
+
+> ⚠️ 别把两套写成一条链。vendor 特种 UA 不是"某条线性链的最弱兜底",而是特种链上
+> **决定性的、不可被配置覆盖**的值。
+
+---
+
+## 1. 两套链，分别看
+
+每层都是"set then delegate"，**innermost（最靠近 wire）wins**。
+
+### A. 通用 pass-through client
+
+链（自外向内）：
+
+```
+   wrapWithLogging                       ← 只记录，不改 UA
+     userAgentTransport                  ← 一处解析固定优先级
+       base transport → wire
+```
+
+**优先级(在 `userAgentTransport` 一个 RoundTrip 内解析,不靠多层叠放):**
+`rule/scenario custom_user_agent` > `入站 client UA` > `SDK 默认 UA`。
+
+- 只有这两条通用链接入 `userAgentTransport`。它读 ctx 里的两个候选值
+  (`GetCustomUserAgent` / `GetClientUserAgent`),显式按上面顺序取胜者——**不是**用两个
+  叠放的 transport(那样"包裹顺序"与"执行/优先级顺序"相反,极易读错)。
+- client 入站 UA 只在 rule/scenario override 为空时才用。
+- 两者都空且 client 也没发 UA → 保留 SDK 默认。
+
+### B. 内建特种（vendor）client
+
+链（自外向内）：
+
+```
+   vendorRoundTripper                    ← 设 vendor 特种 UA（Codex 例外：不设 UA）
+     createSessionBoundTransport         ← 只做 session 绑定,不碰 UA
+       SessionBoundTransport → wire
+```
+
+**唯一的 UA 来源:vendor 特种 UA(决定性)。**
+
+- `userAgentTransport` **不在这条链上**——没有任何 transport 去读 rule/scenario
+  custom_user_agent 或入站 client UA。Gemini 更是
+  `req.Header = http.Header{}` 把整个 header 清空后重设,client 的一切头都没了。
+- `createSessionBoundTransport` 现在**只做 session 绑定**,不再包 UA override。
+- 所以 client 发什么 UA、rule 配什么、任何 provider 配置,**都动不了 vendor 特种 UA**。
+- Codex 例外:其 round-tripper 不设 UA,所以发的是 **OpenAI SDK 默认 UA**(详见 §3)。
+
+---
+
+## 2. 通用链结果矩阵（A 类）
+
+以 client 入站发了 `cherry-studio/1.2` 为例（"SDK 默认"指 openai-go / anthropic-sdk-go 自带 UA）：
+
+| rule/scenario UA | client 入站 UA | 实际发出（wire） | 说明 |
+|------------------|----------------|------------------|------|
+| 空 | 空 | **SDK 默认** | 什么都没配、client 也没发 |
+| 空 | `cherry-studio/1.2` | **`cherry-studio/1.2`** | ⭐ 兜底转发:尊重真实 client |
+| `Bench/1` | `cherry-studio/1.2` | **`Bench/1`** | rule/scenario override 赢 client |
+| `none`（哨兵） | 任意 | **（无 UA 头）** | 显式 strip,见 §4 |
+
+> scenario `custom_user_agent` 与 rule `custom_user_agent` 合并进同一个 `CustomUserAgent`
+> 值(rule 非空时赢,否则继承 scenario),由 `userAgentTransport` 当作"rule/scenario
+> override"处理。因此**已配置的 scenario 默认 UA 仍会覆盖 client 入站 UA**——"显式配置
+> > 尊重 client > SDK 默认"。
+
+## 2b. 特种链结果（B 类）
+
+vendor 特种 client 恒定:
+
+| 场景 | 实际发出（wire） |
+|------|------------------|
+| 任意 rule/client/配置 | **vendor 特种 UA**(Claude Code OAuth / Kimi / Gemini / Antigravity);Codex → SDK 默认 |
+
+> 特种链没有任何可配置的 UA override 入口——这是**有意的**(见 §5)。
+
+---
+
+## 3. 各内建 client 路径一览
+
+| Client 路径 | 类型 | rule/scenario UA | client 入站 UA | wire 上的 UA | 代码 |
+|-------------|------|:---:|:---:|--------------|------|
+| 通用 OpenAI（`NewOpenAIClient`,无 vendor 覆盖) | A 通用 | ✅ | ✅ | rule/scenario > client 入站 > openai-go SDK 默认 | `internal/client/openai.go` |
+| 通用非-OAuth Anthropic（`NewAnthropicClient` else 分支) | A 通用 | ✅ | ✅ | rule/scenario > client 入站 > anthropic-sdk-go SDK 默认 | `internal/client/anthropic.go` |
+| Claude Code OAuth（`claudeRoundTripper`) | B 特种 | ❌ | ❌ | `claude-cli/2.1.86 (external, cli)`(决定性) | `internal/client/claude_round_tripper.go:135` |
+| Kimi（`NewKimiClient`) | B 特种 | ❌ | ❌ | `KimiCLI/1.10.6`(决定性) | `internal/client/kimi_round_tripper.go:13` |
+| Gemini（`NewGeminiClient`) | B 特种 | ❌ | ❌ | `GeminiCLI/0.1.0 (linux; amd64)`(决定性) | `internal/client/gemini_client.go:145` |
+| Antigravity（`NewAntigravityClient`) | B 特种 | ❌ | ❌ | `antigravity/1.11.5 windows/amd64`(决定性) | `internal/client/antigravity_client.go:146` |
+| Codex / ChatGPT backend（`codexRoundTripper`) | B 特种 | ❌ | ❌ | **openai-go SDK 默认**(round-tripper 不设 UA) | `internal/client/codex_round_tripper.go` |
+
+> "rule/scenario UA ❌"与"client 入站 UA ❌"表示这些链上**没有对应 transport 去读**,
+> 不是"读了但优先级低"——它们对 vendor 链完全不可见。
+
+**Codex 的特殊说明**：`codexRoundTripper` **不在 model 请求上设 User-Agent**。
+`codex_cli_rs` 只是 OAuth token 交换的 **body `originator` 参数**（`ai/oauth/hook.go`），
+`codex-cli` UA 只用于 quota 拉取（`ai/quota/fetcher/codex.go`）——都不是 model 请求的
+wire UA。ChatGPT backend 靠 OAuth token + `ChatGPT-Account-ID` 头 + `originator` body
+识别,而非 UA。
+
+> registry 预设（`internal/typ/flag_registry.go::DefaultUserAgents`）里列出的
+> `claude-cli/…`、`codex_cli_rs/0.20.0` 等是给 `custom_user_agent` flag 的**快选建议**
+> ——它们是"通用链上可选择去冒充的 UA",**不代表对应 vendor 链默认就发这个值**,也不代表
+> `custom_user_agent` 对 vendor 链有效(对 vendor 链无效,见 §5)。
+
+---
+
+## 4. `none` 哨兵 — 发送"无 User-Agent"（仅 A 类）
+
+`custom_user_agent = "none"`（`typ.UserAgentNone`）表示**完全去掉** User-Agent 头，
+仅对**通用链**有效(vendor 链不读 custom_user_agent)。
+
+实现细节（`custom_ua_transport.go`）：net/http 在头**缺失**时会注入默认
+`Go-http-client/<ver>`；只有把头设成**显式空串**才能让请求真正不带 UA。所以哨兵把
+`User-Agent` set 为 `""`（present-but-empty），而非删除。
+
+`none` 是 rule/scenario override 值,`userAgentTransport` 优先取它,所以即便 client 发了
+UA,`none` 依旧 strip 掉——显式 strip 是通用链里最高优先的意图。
+
+---
+
+## 5. 为什么没有 provider 级 UA / vendor 特种 UA 决定性（不变量）
+
+**历史包袱与移除**:早期有一个 `provider.UserAgent` 字段,作为"调试 override"被包成
+`wrapWithUserAgent` 塞进传输链,而且经由 `createSessionBoundTransport`(所有 vendor 链的
+公共底座)注入,能**盖过 vendor 特种握手 UA**。这是设计问题:
+
+- provider 是**静态配置**,和"请求在链路上如何呈现身份"是两个正交的轴;把 provider 配置
+  塞进请求传输链,就让它有了伸手改写 vendor 握手/指纹 UA 的能力——既是 footgun(Claude
+  OAuth 错配即被拒),又让 vendor 特种 UA 名不副实地"可被覆盖"。
+- UA 在请求链路上只该有两个合法来源:**调用方是谁**(client 入站 / rule-scenario
+  custom_user_agent)和 **vendor 协议要求什么**(vendor pin)。
+
+因此 `provider.UserAgent` 字段**已彻底移除**(struct 字段、`wrapWithUserAgent` /
+`userAgentRoundTripper`、DTO、handler、前端表单项全部删除),`createSessionBoundTransport`
+回归"只做 session 绑定"的单一职责。结果:
+
+- **vendor 特种 UA 现在是决定性的、不可被任何配置覆盖**(满足"内建特种 client 最高优")。
+- 通用链只剩纯请求侧来源(rule/scenario > client 入站 > SDK 默认)。
+
+**边界如何保证**(重要不变量):
+
+- `applyClientUserAgent` / `applyCustomUserAgent`(都由 `resolveRuleFlagsWithScenario`
+  统一调用)对**所有**请求都把 UA 写进 `c.Request.Context()`,但这两个 UA 只在传输链里
+  **有** `userAgentTransport` 的 client 上被读取。
+- `userAgentTransport` **只**接入通用 `NewOpenAIClient`(openai.go)与通用非-OAuth
+  Anthropic 分支(anthropic.go else)。
+- vendor 链虽内部复用 `NewOpenAIClient`(Kimi / Codex),但用 `extraOptions` 里自带的
+  `WithHTTPClient`(含 `kimiRoundTripper` / `codexRoundTripper`,**不含** `userAgentTransport`)
+  在 SDK option 末尾覆盖掉通用 httpClient("extra 最后应用");Gemini / Antigravity /
+  Claude OAuth 自建 transport 链。这些 vendor RT 都包在 `createSessionBoundTransport`
+  **外层**,而后者不碰 UA。
+- 所以即便 ctx 里带着 UA,vendor client 也没有任何 transport 去读它——vendor 特种 UA
+  岿然不动。
+
+> ⚠️ **给 vendor 链新增 transport 时,切勿引入 `userAgentTransport`;也不要恢复任何
+> provider 级 UA override。** 这些都会击穿 vendor 特种 UA 的决定性。若确需为某个 vendor
+> 端点冒充别的 UA,应改那条 vendor RT 里硬编码的特种 UA 常量,而不是从请求链路旁路注入。
+
+---
+
+## 6. 代码地图
+
+| 关注点 | 位置 |
+|--------|------|
+| client UA ctx helper | `internal/typ/id.go`（`WithClientUserAgent` / `GetClientUserAgent` / `ClientUserAgentKey`）|
+| rule/scenario UA ctx helper + `none` 哨兵 | `internal/typ/id.go`（`WithCustomUserAgent` / `GetCustomUserAgent` / `UserAgentNone`）|
+| UA 解析 transport（A 类,rule/scenario override + client 兜底转发,一处解析优先级）| `internal/client/custom_ua_transport.go`（`userAgentTransport`）|
+| session 绑定底座(A + B,不碰 UA) | `internal/client/http.go`（`createSessionBoundTransport` / `SessionBoundTransport`）|
+| 通用 OpenAI 链装配（A）| `internal/client/openai.go`（`NewOpenAIClient`）|
+| 通用 Anthropic 链装配（A）| `internal/client/anthropic.go`（`NewAnthropicClient` else 分支）|
+| vendor 特种 RT（B）| `claude_round_tripper.go` / `kimi_round_tripper.go` / `gemini_client.go` / `antigravity_client.go` / `codex_round_tripper.go` |
+| 解析合并 + 挂 ctx（唯一合并点） | `internal/server/rule_flags.go`（`ResolveRuleFlagsWithScenario` → `applyCustomUserAgent` / `applyClientUserAgent`）|
+| UA 预设快选(通用链 flag) | `internal/typ/flag_registry.go`（`DefaultUserAgents`）|
+| 入站 UA 仅做检测的地方 | `internal/server/user_agent.go`（Cursor 检测）；`internal/server/middleware/multi_mode_memory_log.go`（审计日志）|
+| 测试 | `internal/client/custom_ua_transport_test.go`；`internal/server/rule_flags_test.go` |
+
+---
+
+## 7. 相关文档
+
+- `.design/rule-flags.md` §8 — rule flag 视角下的 UA 链层与注入机制。

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -179,10 +179,10 @@ type Provider struct {
 	ProxyURL      string   `json:"proxy_url"` // HTTP or SOCKS proxy URL (e.g., "http://localhost:7890" or "socks5://localhost:1080")
 	// NOTE: there is deliberately no provider-level User-Agent override. The
 	// outbound User-Agent is a request-path concern, not provider config: it is
-	// decided by the request (rule/scenario custom_user_agent) on generic
-	// pass-through clients, and pinned by the vendor handshake on specialized
-	// clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity), where the
-	// pin is decisive.
+	// decided by the request (rule/scenario custom_user_agent > inbound client
+	// UA) on generic pass-through clients, and pinned by the vendor handshake on
+	// specialized clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity),
+	// where the pin is decisive. See .design/user-agent.md.
 	Timeout     int64    `json:"timeout,omitempty"`      // Request timeout in seconds (default: 1800 = 30 minutes)
 	Tags        []string `json:"tags,omitempty"`         // Provider tags for categorization
 	Models      []string `json:"models,omitempty"`       // Available models for this provider (cached)

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -85,19 +85,21 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 			transport = &context1mBetaTransport{base: createSessionBoundTransport(provider, sessionID)}
 		}
 	} else {
-		// Generic non-OAuth Anthropic provider. The rule/scenario
-		// custom_user_agent override (via customUserAgentTransport) is the only
-		// outbound-UA layer; there is deliberately no provider-level UA override
-		// (UA is a request-path concern, not provider config). OAuth issuers
-		// above keep their dedicated transport chain unchanged because
-		// vendor-specific round-trippers pin the handshake UA themselves.
+		// Generic non-OAuth Anthropic provider. A single userAgentTransport
+		// resolves the same fixed precedence as the generic OpenAI client
+		// (rule/scenario custom_user_agent > inbound client UA > SDK default) in
+		// one place. There is deliberately no provider-level UA layer
+		// (see .design/user-agent.md). OAuth issuers above keep their dedicated
+		// transport chain unchanged because vendor-specific round-trippers pin
+		// the handshake UA themselves — that pin is decisive and must not be
+		// overwritten by the rule or client UA.
 		//
 		// Use the transport pool instead of http.DefaultTransport so that env
 		// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
 		// proxy is explicitly configured for the provider.
 		base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
 		transport = &context1mBetaTransport{base: base}
-		transport = &customUserAgentTransport{base: transport}
+		transport = &userAgentTransport{base: transport}
 		transport = wrapWithLogging(transport, provider)
 	}
 

--- a/internal/client/context_1m_transport.go
+++ b/internal/client/context_1m_transport.go
@@ -11,7 +11,7 @@ import (
 // anthropic-beta header when the request context carries the 1M hint
 // (typ.WithContext1M, attached by the gateway when the matched rule has the
 // context_1m flag). This is the Type-2
-// (context-passed hint) injection point, mirroring customUserAgentTransport:
+// (context-passed hint) injection point, mirroring userAgentTransport:
 // upstream providers only honor 1M when this beta flag is present, so the
 // rule flag must reach the wire even for clients that don't send it.
 type context1mBetaTransport struct {

--- a/internal/client/custom_ua_transport.go
+++ b/internal/client/custom_ua_transport.go
@@ -7,20 +7,15 @@ import (
 )
 
 // userAgentTransport sets the outbound User-Agent for the generic pass-through
-// clients (generic OpenAI, generic non-OAuth Anthropic), resolving the fixed
-// precedence in ONE place:
+// clients, resolving the fixed precedence in one place:
 //
 //	rule/scenario custom_user_agent  >  inbound client UA  >  SDK default
 //
-// Both candidates are attached to the request context at the single resolve
-// merge point (typ.WithCustomUserAgent / typ.WithClientUserAgent). Keeping the
-// precedence inside one RoundTrip — instead of two stacked transports whose
-// wrapping order reads backwards from their execution order — makes the winner
-// obvious and clones the request at most once.
-//
-// Vendor-specialized clients (Claude Code OAuth, Codex, Kimi, Gemini,
-// Antigravity) deliberately do NOT carry this transport: their pinned handshake
-// UA is decisive, and neither the rule UA nor the inbound client UA may touch it.
+// Both candidates are attached to the request context at the resolve merge point
+// (typ.WithCustomUserAgent / typ.WithClientUserAgent). Vendor-specialized clients
+// (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) deliberately do NOT carry
+// this transport, so their pinned handshake UA stays decisive. See
+// .design/user-agent.md.
 type userAgentTransport struct {
 	base http.RoundTripper
 }
@@ -31,19 +26,19 @@ func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 		base = http.DefaultTransport
 	}
 
-	// Fixed precedence, resolved once: an explicit rule/scenario override wins;
-	// otherwise forward the inbound client's own UA; otherwise leave whatever the
-	// SDK stamped on the request (兜底).
-	ua := typ.GetCustomUserAgent(req.Context())
+	// An explicit rule/scenario override wins; otherwise forward the inbound
+	// client's own UA; otherwise leave whatever the SDK stamped (兜底).
+	ctx := req.Context()
+	ua := typ.GetCustomUserAgent(ctx)
 	if ua == "" {
-		ua = typ.GetClientUserAgent(req.Context())
+		ua = typ.GetClientUserAgent(ctx)
 	}
 	if ua == "" {
 		return base.RoundTrip(req)
 	}
 
 	// Clone before mutating so concurrent retries never race on shared headers.
-	req = req.Clone(req.Context())
+	req = req.Clone(ctx)
 	if ua == typ.UserAgentNone {
 		// Sentinel (rule/scenario only): strip the User-Agent entirely. net/http
 		// omits the header when it is present-but-empty, but injects the default

--- a/internal/client/custom_ua_transport.go
+++ b/internal/client/custom_ua_transport.go
@@ -6,30 +6,52 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// customUserAgentTransport applies a per-request User-Agent override when one
-// is attached to the request context via typ.WithCustomUserAgent. This lets
-// rule-level flags retarget upstream identification without rebuilding the
-// pooled OpenAI client.
-type customUserAgentTransport struct {
+// userAgentTransport sets the outbound User-Agent for the generic pass-through
+// clients (generic OpenAI, generic non-OAuth Anthropic), resolving the fixed
+// precedence in ONE place:
+//
+//	rule/scenario custom_user_agent  >  inbound client UA  >  SDK default
+//
+// Both candidates are attached to the request context at the single resolve
+// merge point (typ.WithCustomUserAgent / typ.WithClientUserAgent). Keeping the
+// precedence inside one RoundTrip — instead of two stacked transports whose
+// wrapping order reads backwards from their execution order — makes the winner
+// obvious and clones the request at most once.
+//
+// Vendor-specialized clients (Claude Code OAuth, Codex, Kimi, Gemini,
+// Antigravity) deliberately do NOT carry this transport: their pinned handshake
+// UA is decisive, and neither the rule UA nor the inbound client UA may touch it.
+type userAgentTransport struct {
 	base http.RoundTripper
 }
 
-func (t *customUserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	base := t.base
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	if ua := typ.GetCustomUserAgent(req.Context()); ua != "" {
-		req = req.Clone(req.Context())
-		if ua == typ.UserAgentNone {
-			// Sentinel: strip the User-Agent entirely. net/http omits the header
-			// when it is explicitly present but empty, whereas an absent header
-			// makes it inject the default Go-http-client/<ver> UA. Setting "" is
-			// the only way to send a request carrying no User-Agent at all.
-			req.Header.Set("User-Agent", "")
-		} else {
-			req.Header.Set("User-Agent", ua)
-		}
+
+	// Fixed precedence, resolved once: an explicit rule/scenario override wins;
+	// otherwise forward the inbound client's own UA; otherwise leave whatever the
+	// SDK stamped on the request (兜底).
+	ua := typ.GetCustomUserAgent(req.Context())
+	if ua == "" {
+		ua = typ.GetClientUserAgent(req.Context())
+	}
+	if ua == "" {
+		return base.RoundTrip(req)
+	}
+
+	// Clone before mutating so concurrent retries never race on shared headers.
+	req = req.Clone(req.Context())
+	if ua == typ.UserAgentNone {
+		// Sentinel (rule/scenario only): strip the User-Agent entirely. net/http
+		// omits the header when it is present-but-empty, but injects the default
+		// Go-http-client/<ver> when it is absent — so "" is the only way to send
+		// a request carrying no User-Agent at all.
+		req.Header.Set("User-Agent", "")
+	} else {
+		req.Header.Set("User-Agent", ua)
 	}
 	return base.RoundTrip(req)
 }

--- a/internal/client/custom_ua_transport_test.go
+++ b/internal/client/custom_ua_transport_test.go
@@ -39,85 +39,142 @@ func newReq(t *testing.T, ctx context.Context, ua string) *http.Request {
 	return req
 }
 
-func TestCustomUserAgentTransport_NoContextValue_PassesThrough(t *testing.T) {
+// userAgentTransport resolves a fixed precedence in one place:
+//
+//	rule/scenario custom_user_agent  >  inbound client UA  >  SDK default
+//
+// The tests below exercise every branch of that precedence plus the `none`
+// strip sentinel, clone-before-mutate, and the nil-base fallback.
+
+func TestUserAgentTransport_NoContextValue_PassesThrough(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := &customUserAgentTransport{base: cap}
-	req := newReq(t, context.Background(), "original/1.0")
+	wrapped := &userAgentTransport{base: cap}
+	// Simulate the SDK having already stamped its default UA on the request.
+	req := newReq(t, context.Background(), "sdk-default/1.0")
 
 	if _, err := wrapped.RoundTrip(req); err != nil {
 		t.Fatalf("RoundTrip: %v", err)
 	}
-	if cap.lastUA != "original/1.0" {
-		t.Errorf("UA = %q, want passthrough %q", cap.lastUA, "original/1.0")
+	if cap.lastUA != "sdk-default/1.0" {
+		t.Errorf("UA = %q, want SDK default passthrough %q", cap.lastUA, "sdk-default/1.0")
 	}
 }
 
-func TestCustomUserAgentTransport_OverridesWhenContextSet(t *testing.T) {
+func TestUserAgentTransport_RuleOverride(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := &customUserAgentTransport{base: cap}
-	ctx := typ.WithCustomUserAgent(context.Background(), "MyApp/1.0")
-	req := newReq(t, ctx, "original/1.0")
+	wrapped := &userAgentTransport{base: cap}
+	ctx := typ.WithCustomUserAgent(context.Background(), "RuleUA/1.0")
+	req := newReq(t, ctx, "sdk-default/1.0")
 
 	if _, err := wrapped.RoundTrip(req); err != nil {
 		t.Fatalf("RoundTrip: %v", err)
 	}
-	if cap.lastUA != "MyApp/1.0" {
-		t.Errorf("UA = %q, want override %q", cap.lastUA, "MyApp/1.0")
+	if cap.lastUA != "RuleUA/1.0" {
+		t.Errorf("UA = %q, want rule override %q", cap.lastUA, "RuleUA/1.0")
 	}
 }
 
-func TestCustomUserAgentTransport_NoneSentinelStripsHeader(t *testing.T) {
+func TestUserAgentTransport_ForwardsInboundClientUA(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := &customUserAgentTransport{base: cap}
-	ctx := typ.WithCustomUserAgent(context.Background(), typ.UserAgentNone)
-	req := newReq(t, ctx, "original/1.0")
+	wrapped := &userAgentTransport{base: cap}
+	// Client sent "cherry-studio/1.2"; SDK stamped its own default. With no rule
+	// override, the inbound client UA must be forwarded so upstream sees the real
+	// caller instead of the generic SDK UA.
+	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
+	req := newReq(t, ctx, "sdk-default/1.0")
 
 	if _, err := wrapped.RoundTrip(req); err != nil {
 		t.Fatalf("RoundTrip: %v", err)
 	}
-	// The sentinel must blank out the User-Agent so net/http sends no UA.
+	if cap.lastUA != "cherry-studio/1.2" {
+		t.Errorf("UA = %q, want inbound client UA %q", cap.lastUA, "cherry-studio/1.2")
+	}
+}
+
+func TestUserAgentTransport_RuleWinsOverClient(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &userAgentTransport{base: cap}
+	// Both present: the rule/scenario override wins over the inbound client UA.
+	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
+	ctx = typ.WithCustomUserAgent(ctx, "RuleUA/1.0")
+	req := newReq(t, ctx, "sdk-default/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if cap.lastUA != "RuleUA/1.0" {
+		t.Errorf("UA = %q, want rule wins over client %q", cap.lastUA, "RuleUA/1.0")
+	}
+}
+
+func TestUserAgentTransport_NoneSentinelStripsEvenWithClientUA(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &userAgentTransport{base: cap}
+	// The `none` sentinel is a rule/scenario value; it must strip the UA entirely
+	// and still win over a present inbound client UA.
+	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
+	ctx = typ.WithCustomUserAgent(ctx, typ.UserAgentNone)
+	req := newReq(t, ctx, "sdk-default/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
 	if cap.lastUA != "" {
 		t.Errorf("UA = %q, want stripped (empty)", cap.lastUA)
 	}
-	// The header must be present-but-empty (not absent), otherwise net/http
-	// would re-inject its default Go-http-client UA on the wire.
+	// The header must be present-but-empty (not absent), otherwise net/http would
+	// re-inject its default Go-http-client UA on the wire.
 	if _, ok := cap.lastReq.Header["User-Agent"]; !ok {
 		t.Error("expected User-Agent header present-but-empty, got absent")
 	}
 	// Caller's request must be untouched.
-	if req.Header.Get("User-Agent") != "original/1.0" {
+	if req.Header.Get("User-Agent") != "sdk-default/1.0" {
 		t.Errorf("original request mutated: UA = %q", req.Header.Get("User-Agent"))
 	}
 }
 
-func TestCustomUserAgentTransport_DoesNotMutateOriginalRequest(t *testing.T) {
+func TestUserAgentTransport_DoesNotMutateOriginalRequest(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := &customUserAgentTransport{base: cap}
-	ctx := typ.WithCustomUserAgent(context.Background(), "MyApp/1.0")
-	req := newReq(t, ctx, "original/1.0")
+	wrapped := &userAgentTransport{base: cap}
+	ctx := typ.WithCustomUserAgent(context.Background(), "RuleUA/1.0")
+	req := newReq(t, ctx, "sdk-default/1.0")
 
 	if _, err := wrapped.RoundTrip(req); err != nil {
 		t.Fatalf("RoundTrip: %v", err)
 	}
-	// The caller's request must still see the original UA header because
-	// the transport clones before mutating — otherwise concurrent retries
-	// would race on shared headers.
-	if got := req.Header.Get("User-Agent"); got != "original/1.0" {
-		t.Errorf("caller's req mutated: UA = %q, want %q", got, "original/1.0")
+	// Clone-before-mutate: the caller's request must keep its original header so
+	// concurrent retries don't race on shared headers.
+	if got := req.Header.Get("User-Agent"); got != "sdk-default/1.0" {
+		t.Errorf("caller's req mutated: UA = %q, want %q", got, "sdk-default/1.0")
 	}
 }
 
-func TestCustomUserAgentTransport_NilBaseFallsBackToDefault(t *testing.T) {
-	// When base is nil the wrapper must not panic; it falls back to
-	// http.DefaultTransport. We can't easily exercise the fallback without
-	// network access, so just verify the nil case doesn't crash before
-	// dispatching by hitting an httptest server.
+func TestUserAgentTransport_EmptyContextValuesAreNoOp(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &userAgentTransport{base: cap}
+	// WithCustomUserAgent("") / WithClientUserAgent("") explicitly skip attaching
+	// the value, so an existing SDK UA header is left untouched.
+	ctx := typ.WithCustomUserAgent(context.Background(), "")
+	ctx = typ.WithClientUserAgent(ctx, "")
+	req := newReq(t, ctx, "sdk-default/1.0")
+
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if cap.lastUA != "sdk-default/1.0" {
+		t.Errorf("UA = %q, want passthrough %q", cap.lastUA, "sdk-default/1.0")
+	}
+}
+
+func TestUserAgentTransport_NilBaseFallsBackToDefault(t *testing.T) {
+	// When base is nil the transport must not panic; it falls back to
+	// http.DefaultTransport. Exercise it against an httptest server.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
 
-	wrapped := &customUserAgentTransport{base: nil}
+	wrapped := &userAgentTransport{base: nil}
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	resp, err := wrapped.RoundTrip(req)
 	if err != nil {
@@ -128,21 +185,3 @@ func TestCustomUserAgentTransport_NilBaseFallsBackToDefault(t *testing.T) {
 		t.Errorf("status = %d, want 204", resp.StatusCode)
 	}
 }
-
-func TestCustomUserAgentTransport_EmptyContextValueIsNoOp(t *testing.T) {
-	cap := &captureTransport{}
-	wrapped := &customUserAgentTransport{base: cap}
-	// WithCustomUserAgent("") explicitly skips attaching the value, so this
-	// effectively tests that an empty rule flag does not blank out an
-	// existing UA header.
-	ctx := typ.WithCustomUserAgent(context.Background(), "")
-	req := newReq(t, ctx, "fallback/1.0")
-
-	if _, err := wrapped.RoundTrip(req); err != nil {
-		t.Fatalf("RoundTrip: %v", err)
-	}
-	if cap.lastUA != "fallback/1.0" {
-		t.Errorf("UA = %q, want passthrough %q", cap.lastUA, "fallback/1.0")
-	}
-}
-

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -248,7 +248,9 @@ func (t *SessionBoundTransport) RoundTrip(req *http.Request) (*http.Response, er
 // It deliberately does NOT touch the User-Agent: this transport underpins the
 // vendor-specialized clients (Claude Code OAuth, Codex, Kimi, Gemini,
 // Antigravity), whose round trippers pin the vendor handshake UA outside it.
-// Keeping UA out of here is what makes that vendor pin decisive.
+// Keeping UA out of here is what makes that vendor pin decisive — no
+// provider/request-path override can reach into the handshake. See
+// .design/user-agent.md.
 func createSessionBoundTransport(provider *typ.Provider, sessionID typ.SessionID) http.RoundTripper {
 	var issuer ai.Issuer
 	if provider.OAuthDetail != nil {

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -63,16 +63,17 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	// Create HTTP client with session-bound transport
 	var transport http.RoundTripper
 
-	// User-Agent: the rule/scenario custom_user_agent override (via
-	// customUserAgentTransport) is the only outbound-UA layer here. There is
-	// deliberately no provider-level UA override — UA is a request-path concern,
-	// not provider config.
+	// User-Agent: a single transport resolves the fixed precedence
+	// (rule/scenario custom_user_agent > inbound client UA > SDK default) in one
+	// place — see userAgentTransport. There is deliberately no provider-level UA
+	// layer; UA is a request-path concern, not provider config
+	// (see .design/user-agent.md).
 	//
 	// Use the transport pool instead of http.DefaultTransport so that env
 	// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
 	// proxy is explicitly configured for the provider.
 	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
-	transport = &customUserAgentTransport{base: base}
+	transport = &userAgentTransport{base: base}
 	transport = wrapWithLogging(transport, provider)
 
 	httpClient := &http.Client{

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -288,7 +288,7 @@ func ruleFlagCases() []flagCase {
 			const ua = "HarnessFlagUA/9.9"
 			model := env.SetupRouteWithFlags(protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, flagScenario(), typ.RuleFlags{CustomUserAgent: ua})
 			// Streaming path: the custom UA rides c.Request.Context() into the
-			// forward context, which the OpenAI client's customUserAgentTransport
+			// forward context, which the OpenAI client's userAgentTransport
 			// reads. (The non-streaming openai_chat path builds its forward
 			// context with a nil baseCtx, so the UA override does not propagate
 			// there — tracked separately.)

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -162,6 +162,15 @@ func ResolveRuleFlagsWithScenario(
 	// single merge point, so the chat / v1 / beta handlers don't each repeat it.
 	applyCustomUserAgent(c, flags)
 
+	// Attach the inbound client's own User-Agent as a lower-precedence fallback:
+	// the generic (non-vendor) transport forwards it upstream only when no
+	// rule/scenario custom_user_agent override is in effect, so we respect who
+	// the real caller is instead of leaking the SDK's generic default. Attached
+	// for every request; only clients whose transport chain includes
+	// userAgentTransport read it — vendor OAuth / specialized paths ignore
+	// it and keep their pinned, decisive UA.
+	applyClientUserAgent(c)
+
 	// Attach the 1M-context hint the same way: the outbound Anthropic transport
 	// (context1mBetaTransport) appends the context-1m beta flag at RoundTrip
 	// time.
@@ -183,7 +192,7 @@ func applyContext1M(c *gin.Context, flags typ.RuleFlags) {
 
 // applyCustomUserAgent attaches the effective custom User-Agent (already merged
 // across rule + scenario) to the request context, so the outbound transport
-// (customUserAgentTransport) can read it at RoundTrip time. This is the Type-2
+// (userAgentTransport) can read it at RoundTrip time. This is the Type-2
 // (context-passed hint) injection point: the dispatch path forwards
 // c.Request.Context() down to the SDK call, where the transport applies the
 // override. No-op when no override is configured, so the vendor/provider
@@ -196,6 +205,29 @@ func applyCustomUserAgent(c *gin.Context, flags typ.RuleFlags) {
 		return
 	}
 	c.Request = c.Request.WithContext(typ.WithCustomUserAgent(c.Request.Context(), flags.CustomUserAgent))
+}
+
+// applyClientUserAgent attaches the inbound client's own User-Agent header to
+// the request context so the generic outbound transport (userAgentTransport)
+// can forward it upstream as a fallback. It sits at a lower precedence than the
+// explicit rule/scenario custom_user_agent override, and above the vendor SDK's
+// default UA, so it only takes effect when no override is configured. No-op when
+// the client sent no User-Agent, so the SDK/vendor default is preserved
+// unchanged (兜底).
+//
+// Like applyCustomUserAgent this runs for every request, but only clients whose
+// transport chain carries userAgentTransport (the two generic
+// pass-through paths) actually read it. Vendor-specialized paths never wire that
+// transport, so their pinned UA stays decisive.
+func applyClientUserAgent(c *gin.Context) {
+	if c == nil || c.Request == nil {
+		return
+	}
+	ua := c.GetHeader("User-Agent")
+	if ua == "" {
+		return
+	}
+	c.Request = c.Request.WithContext(typ.WithClientUserAgent(c.Request.Context(), ua))
 }
 
 // ShouldStripUsage merges the cursor_compat and skip_usage hints carried in

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -162,14 +162,12 @@ func ResolveRuleFlagsWithScenario(
 	// single merge point, so the chat / v1 / beta handlers don't each repeat it.
 	applyCustomUserAgent(c, flags)
 
-	// Attach the inbound client's own User-Agent as a lower-precedence fallback:
-	// the generic (non-vendor) transport forwards it upstream only when no
-	// rule/scenario custom_user_agent override is in effect, so we respect who
-	// the real caller is instead of leaking the SDK's generic default. Attached
-	// for every request; only clients whose transport chain includes
-	// userAgentTransport read it — vendor OAuth / specialized paths ignore
-	// it and keep their pinned, decisive UA.
-	applyClientUserAgent(c)
+	// Inbound client UA is a lower-precedence fallback (see applyClientUserAgent).
+	// Skip it when an override is set: the transport would ignore the client UA
+	// anyway, so attaching it is pure allocation.
+	if flags.CustomUserAgent == "" {
+		applyClientUserAgent(c)
+	}
 
 	// Attach the 1M-context hint the same way: the outbound Anthropic transport
 	// (context1mBetaTransport) appends the context-1m beta flag at RoundTrip
@@ -209,16 +207,10 @@ func applyCustomUserAgent(c *gin.Context, flags typ.RuleFlags) {
 
 // applyClientUserAgent attaches the inbound client's own User-Agent header to
 // the request context so the generic outbound transport (userAgentTransport)
-// can forward it upstream as a fallback. It sits at a lower precedence than the
-// explicit rule/scenario custom_user_agent override, and above the vendor SDK's
-// default UA, so it only takes effect when no override is configured. No-op when
-// the client sent no User-Agent, so the SDK/vendor default is preserved
-// unchanged (兜底).
-//
-// Like applyCustomUserAgent this runs for every request, but only clients whose
-// transport chain carries userAgentTransport (the two generic
-// pass-through paths) actually read it. Vendor-specialized paths never wire that
-// transport, so their pinned UA stays decisive.
+// can forward it upstream. Only the two generic pass-through clients wire that
+// transport; vendor-specialized paths never read it, keeping their pinned UA
+// decisive. No-op when the client sent no User-Agent (SDK default stands).
+// The caller only invokes this when no custom_user_agent override is set.
 func applyClientUserAgent(c *gin.Context) {
 	if c == nil || c.Request == nil {
 		return

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -493,6 +493,71 @@ func TestResolveRuleFlagsWithScenario_CustomUserAgent(t *testing.T) {
 	}
 }
 
+func TestApplyClientUserAgent_AttachesInboundUA(t *testing.T) {
+	c := newGinContext(t)
+	c.Request.Header.Set("User-Agent", "cherry-studio/1.2")
+
+	applyClientUserAgent(c)
+
+	if got := typ.GetClientUserAgent(c.Request.Context()); got != "cherry-studio/1.2" {
+		t.Errorf("GetClientUserAgent = %q, want %q", got, "cherry-studio/1.2")
+	}
+}
+
+func TestApplyClientUserAgent_NoHeaderIsNoOp(t *testing.T) {
+	c := newGinContext(t)
+	// No User-Agent header set on the inbound request.
+
+	applyClientUserAgent(c)
+
+	if got := typ.GetClientUserAgent(c.Request.Context()); got != "" {
+		t.Errorf("GetClientUserAgent = %q, want empty (no inbound UA to forward)", got)
+	}
+}
+
+func TestApplyClientUserAgent_NilRequestIsNoOp(t *testing.T) {
+	// A gin.Context with a nil Request must not panic.
+	c, _ := gin.CreateTestContext(nil)
+	applyClientUserAgent(c) // must not panic
+}
+
+// TestResolveRuleFlagsWithScenario_AttachesClientUserAgent verifies the single
+// merge point forwards the inbound client UA into the request context (which the
+// generic transport later reads), alongside — and independent of — the explicit
+// custom_user_agent override. Precedence between the two is enforced in the
+// transport chain, not here: both hints coexist in the context.
+func TestResolveRuleFlagsWithScenario_AttachesClientUserAgent(t *testing.T) {
+	t.Run("inbound UA attached when no explicit override", func(t *testing.T) {
+		c := newGinContext(t)
+		c.Request.Header.Set("User-Agent", "cherry-studio/1.2")
+		rule := &typ.Rule{Flags: typ.RuleFlags{}}
+
+		ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioAnthropic, &typ.ScenarioConfig{},
+			protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+
+		if got := typ.GetClientUserAgent(c.Request.Context()); got != "cherry-studio/1.2" {
+			t.Errorf("client UA in ctx = %q, want %q", got, "cherry-studio/1.2")
+		}
+	})
+
+	t.Run("both explicit override and inbound UA coexist in ctx", func(t *testing.T) {
+		c := newGinContext(t)
+		c.Request.Header.Set("User-Agent", "cherry-studio/1.2")
+		rule := &typ.Rule{Flags: typ.RuleFlags{CustomUserAgent: "Rule/2.0"}}
+
+		ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioAnthropic, &typ.ScenarioConfig{},
+			protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+
+		ctx := c.Request.Context()
+		if got := typ.GetCustomUserAgent(ctx); got != "Rule/2.0" {
+			t.Errorf("custom UA in ctx = %q, want %q", got, "Rule/2.0")
+		}
+		if got := typ.GetClientUserAgent(ctx); got != "cherry-studio/1.2" {
+			t.Errorf("client UA in ctx = %q, want %q", got, "cherry-studio/1.2")
+		}
+	})
+}
+
 func TestResolveRuleFlagsWithScenario_CleanHeaderSuppressedForClaudeOAuth(t *testing.T) {
 	oauthProvider := &typ.Provider{
 		AuthType:    typ.AuthTypeOAuth,

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -523,9 +523,9 @@ func TestApplyClientUserAgent_NilRequestIsNoOp(t *testing.T) {
 
 // TestResolveRuleFlagsWithScenario_AttachesClientUserAgent verifies the single
 // merge point forwards the inbound client UA into the request context (which the
-// generic transport later reads), alongside — and independent of — the explicit
-// custom_user_agent override. Precedence between the two is enforced in the
-// transport chain, not here: both hints coexist in the context.
+// generic transport later reads) — but only as a fallback: when a
+// custom_user_agent override is set, the client UA is not attached, since the
+// transport would ignore it.
 func TestResolveRuleFlagsWithScenario_AttachesClientUserAgent(t *testing.T) {
 	t.Run("inbound UA attached when no explicit override", func(t *testing.T) {
 		c := newGinContext(t)
@@ -540,7 +540,7 @@ func TestResolveRuleFlagsWithScenario_AttachesClientUserAgent(t *testing.T) {
 		}
 	})
 
-	t.Run("both explicit override and inbound UA coexist in ctx", func(t *testing.T) {
+	t.Run("override wins and client UA is not attached", func(t *testing.T) {
 		c := newGinContext(t)
 		c.Request.Header.Set("User-Agent", "cherry-studio/1.2")
 		rule := &typ.Rule{Flags: typ.RuleFlags{CustomUserAgent: "Rule/2.0"}}
@@ -552,8 +552,9 @@ func TestResolveRuleFlagsWithScenario_AttachesClientUserAgent(t *testing.T) {
 		if got := typ.GetCustomUserAgent(ctx); got != "Rule/2.0" {
 			t.Errorf("custom UA in ctx = %q, want %q", got, "Rule/2.0")
 		}
-		if got := typ.GetClientUserAgent(ctx); got != "cherry-studio/1.2" {
-			t.Errorf("client UA in ctx = %q, want %q", got, "cherry-studio/1.2")
+		// The override wins, so the client UA is redundant and not attached.
+		if got := typ.GetClientUserAgent(ctx); got != "" {
+			t.Errorf("client UA in ctx = %q, want empty (override present)", got)
 		}
 	})
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -103,7 +103,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:             "custom_user_agent",
 			Label:           "Custom User-Agent",
-			Description:     "Override the outbound User-Agent header sent to the upstream provider, for generic OpenAI / Anthropic clients. Vendor-specific clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) keep their dedicated handshake User-Agent and ignore this. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
+			Description:     "Override the outbound User-Agent header sent to the upstream provider, for generic OpenAI / Anthropic clients. Takes precedence over the inbound client's own User-Agent; vendor-specific clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) keep their dedicated handshake User-Agent and ignore this. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
 			Type:            FlagTypeString,
 			Category:        FlagCategoryRequestOpenAI,
 			Placeholder:     "e.g. MyApp/1.0",

--- a/internal/typ/id.go
+++ b/internal/typ/id.go
@@ -163,10 +163,9 @@ func GetCustomUserAgent(ctx context.Context) string {
 }
 
 // ClientUserAgentKey carries the *inbound* client's User-Agent header down to
-// the outbound HTTP transport so it can be forwarded upstream. This is distinct
-// from CustomUserAgentKey (the explicit rule/scenario override): the client UA
-// is only a fallback, applied at a lower precedence than the rule/scenario
-// override, and above the vendor SDK's default UA.
+// the outbound HTTP transport so it can be forwarded upstream. Distinct from
+// CustomUserAgentKey (the explicit rule/scenario override); userAgentTransport
+// resolves the precedence between them.
 const ClientUserAgentKey contextKey = "client_user_agent"
 
 // WithClientUserAgent attaches the inbound client's User-Agent so an outbound

--- a/internal/typ/id.go
+++ b/internal/typ/id.go
@@ -162,6 +162,34 @@ func GetCustomUserAgent(ctx context.Context) string {
 	return ""
 }
 
+// ClientUserAgentKey carries the *inbound* client's User-Agent header down to
+// the outbound HTTP transport so it can be forwarded upstream. This is distinct
+// from CustomUserAgentKey (the explicit rule/scenario override): the client UA
+// is only a fallback, applied at a lower precedence than the rule/scenario
+// override, and above the vendor SDK's default UA.
+const ClientUserAgentKey contextKey = "client_user_agent"
+
+// WithClientUserAgent attaches the inbound client's User-Agent so an outbound
+// HTTP transport may forward it upstream when nothing else overrides the UA.
+// Empty values are not attached (no client UA to forward).
+func WithClientUserAgent(ctx context.Context, ua string) context.Context {
+	if ua == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ClientUserAgentKey, ua)
+}
+
+// GetClientUserAgent returns the inbound client's User-Agent, or "" if none.
+func GetClientUserAgent(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if ua, ok := ctx.Value(ClientUserAgentKey).(string); ok {
+		return ua
+	}
+	return ""
+}
+
 // Context1MKey carries the rule-level 1M-context hint down to the outbound
 // Anthropic transport, which appends the context-1m beta flag at request time.
 const Context1MKey contextKey = "context_1m"


### PR DESCRIPTION
## Summary

Restructure outbound User-Agent handling to respect the real caller's identity on generic clients while keeping vendor-specialized clients' pinned handshake UAs decisive and unconfigurable.

**Core change:** The generic pass-through clients (OpenAI, non-OAuth Anthropic) now resolve a **fixed three-tier precedence in one place** (`userAgentTransport`):
1. Explicit rule/scenario `custom_user_agent` override (highest)
2. Inbound client's own User-Agent (fallback — **new**)
3. SDK default UA (lowest)

Vendor-specialized clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) deliberately **do not** carry `userAgentTransport` and have no configuration entry for UA — their pinned handshake UA is now truly decisive.

## Key Changes

- **New context helper** (`internal/typ/id.go`): `WithClientUserAgent` / `GetClientUserAgent` to carry inbound client UA down to the transport layer
- **Renamed & refactored transport** (`internal/client/custom_ua_transport.go`): `customUserAgentTransport` → `userAgentTransport`; now resolves both rule override and client UA in a single `RoundTrip`, avoiding the "wrapping order reads backwards from execution order" pitfall
- **Single merge point** (`internal/server/rule_flags.go`): `applyClientUserAgent()` attaches inbound UA alongside `applyCustomUserAgent()` at the unified resolve point (`ResolveRuleFlagsWithScenario`)
- **Vendor chains unchanged**: `createSessionBoundTransport` remains session-binding-only; vendor round-trippers (Claude OAuth, Kimi, Gemini, Antigravity, Codex) keep their pinned UA constants and do not wire `userAgentTransport`
- **Comprehensive design doc** (`.design/user-agent.md`): Authority reference for UA behavior, precedence matrices per client type, code map, and the invariants that keep vendor UA decisive
- **Updated rule-flags design** (`.design/rule-flags.md` §8): Clarified two-chain model, linked to new user-agent.md, and emphasized the boundary that prevents rule/client UA from polluting vendor handshakes

## Implementation Details

- **Precedence resolved once**: Instead of stacking two transports (whose wrapping order confuses readers), `userAgentTransport.RoundTrip()` explicitly checks rule override first, then client UA, then passes through SDK default — all in one place
- **Clone-before-mutate**: Request is cloned only when a UA change is needed, avoiding races on concurrent retries
- **`none` sentinel preserved**: `custom_user_agent = "none"` still strips UA entirely (present-but-empty header to prevent net/http's default injection)
- **Vendor boundary enforced by architecture**: Vendor paths use `extraOptions` with `WithHTTPClient` (containing vendor RT, not `userAgentTransport`) to override the generic httpClient at SDK option application time; Gemini/Antigravity/Claude OAuth build their own chains — so even if ctx carries UA, vendor clients have no transport to read it
- **Tests expanded**: Added `TestApplyClientUserAgent_*` and `TestResolveRuleFlagsWithScenario_AttachesClientUserAgent` to verify inbound UA attachment; `userAgentTransport` tests now cover all three precedence tiers plus the `none` sentinel

## Rationale

**Why forward inbound client UA?** The generic clients are transparent pass-through proxies; respecting the real caller's identity (cherry-studio, Cursor, etc.) instead of leaking the SDK's generic default improves upstream observability and debugging.

**Why vendor UA is now truly decisive?** Vendor handshakes (OAuth tokens, session binding, fingerprinting) depend on a specific UA. The old `provider.UserAgent` field allowed provider config to override vendor UA, which was a footgun (Claude OAuth mismatches = rejection). Removing that field and keeping vendor UA out of the request chain ensures it cannot be accidentally polluted by rule flags or client UA.

**

https://claude.ai/code/session_01M2NSPuQE4UbyBFCHLuNY4n