### PR TITLE
bugfix(UI): Fix tab label shift on selection by using text-shadow instead of font-weight

### DIFF
--- a/frontend/src/components/ConfigRow.tsx
+++ b/frontend/src/components/ConfigRow.tsx
@@ -40,7 +40,13 @@ const TabButton: React.FC<{
             px: 1.5,
             py: 0.5,
             fontSize: '0.8125rem',
-            fontWeight: isActive ? 700 : 500,
+            // Keep fontWeight fixed so the label's rendered width never
+            // changes on selection — toggling font-weight here shifts every
+            // tab/separator to its right. Fake the bold via text-shadow
+            // instead, which affects stroke, not glyph metrics.
+            fontWeight: 500,
+            color: isActive ? 'text.primary' : 'text.secondary',
+            textShadow: isActive ? '0 0 0.4px currentColor, 0 0 0.4px currentColor' : 'none',
             cursor: 'pointer',
             userSelect: 'none',
             transition: 'all 0.15s ease-in-out',


### PR DESCRIPTION
## Summary
Prevents visual layout shift in tab buttons when selected by replacing dynamic `fontWeight` toggling with a `textShadow` technique that simulates bold text without affecting glyph metrics.

## Changes
- **Fixed layout stability**: Changed `fontWeight` from dynamic (500/700) to fixed at 500 to prevent tab labels from shifting width on selection
- **Visual bold effect**: Applied `textShadow: '0 0 0.4px currentColor, 0 0 0.4px currentColor'` to simulate bold appearance when active, which affects stroke rendering rather than glyph dimensions
- **Color contrast**: Added explicit `color` property that switches between `text.primary` (active) and `text.secondary` (inactive) for clarity

## Implementation Details
The previous approach of toggling `fontWeight` between 500 and 700 caused every tab and separator to the right to shift horizontally when a tab was selected, creating a jarring visual effect. By keeping font-weight constant and using text-shadow to fake the bold effect, the label's rendered width remains stable while maintaining the visual distinction between active and inactive states.

https://claude.ai/code/session_01NUn3tNk2W8hzs5V8zEgvH9