### PR TITLE
bugfix: in codex hybrid, should set `requires_openai_auth = true`.

### DIFF
--- a/.design/codex-auth.md
+++ b/.design/codex-auth.md
@@ -46,10 +46,10 @@ name = "OpenAI using Tingly Box"
 base_url = "http://127.0.0.1:12580/tingly/codex"
 wire_api = "responses"
 experimental_bearer_token = "tingly-box-…"   # gateway token, provider-scoped
-requires_openai_auth = false                  # tingly token isn't sk-shaped
+requires_openai_auth = true                   # provider still uses the OpenAI auth path
 ```
 
-> Gateway (`apikey`) mode instead emits `requires_openai_auth = true` (no bearer
+> Gateway (`apikey`) mode also emits `requires_openai_auth = true` (no bearer
 > token) so Codex sources the provider credential from `auth.json`'s
 > `OPENAI_API_KEY`. Neither mode writes `preferred_auth_method` — it is **not** in
 > Codex's `config-schema.json` (which is `additionalProperties: false`), so
@@ -60,12 +60,12 @@ Result: **Codex App still sees the official account; `codex` requests still
 route through tingly-box.** This mirrors `cc-switch`'s "Codex App Enhancements /
 keep official login" toggle (v3.16.1).
 
-### `requires_openai_auth = false`
+### `requires_openai_auth = true`
 
-`experimental_bearer_token` is an OpenAI-labeled *experimental* field, and Codex
-otherwise assumes an `sk-`-shaped key for a provider. `requires_openai_auth =
-false` drops that assumption so the `tingly-box-`-prefixed JWT is accepted. Both
-keys are written together and only when a bearer token is supplied.
+`experimental_bearer_token` is an OpenAI-labeled *experimental* field.
+`requires_openai_auth = true` keeps this provider on the OpenAI auth path so the
+provider-scoped bearer token is honored. Both keys are written together and only
+when a bearer token is supplied.
 
 ### auth.json: materialize vs leave untouched
 
@@ -170,9 +170,9 @@ Facts that constrain our output (JSON Schema draft-07):
   ("Additional properties are not allowed"). It is gone from both the provider
   object and the root.
 - `requires_openai_auth` defaults to **`false`** = *"key comes from the `env_key`
-  env var"*; **`true`** = *"key/token comes from `auth.json`"*. Gateway (apikey)
-  mode sets `true` (sources `OPENAI_API_KEY` from `auth.json`); hybrid sets
-  `false` (uses the provider-scoped `experimental_bearer_token`).
+  env var"*; **`true`** = *"provider uses the OpenAI auth path"*. Gateway (apikey)
+  mode sets `true` (sources `OPENAI_API_KEY` from `auth.json`); hybrid also sets
+  `true` while supplying the provider-scoped `experimental_bearer_token`.
 - `model_reasoning_effort` is schema-typed as any non-empty string
   (`ReasoningEffort`, `minLength: 1`) — values are model-advertised, so our
   whitelist stays a superset rather than a fixed enum.

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2285,7 +2285,7 @@ export const handlers = [
             // Hybrid keeps the gateway token in config.toml so auth.json can hold
             // a native ChatGPT login.
             lines.push(`experimental_bearer_token = "${token}"`)
-            lines.push('requires_openai_auth = false')
+            lines.push('requires_openai_auth = true')
         } else {
             // Gateway: Codex sources the key from auth.json's OPENAI_API_KEY.
             lines.push('requires_openai_auth = true')

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1137,11 +1137,11 @@ func RenderCodexConfigTOML(baseURL string, models []string, prefs *CodexPrefs, w
 // don't want to point Codex at a file we never wrote).
 //
 // bearerToken, when non-empty, is written into the tingly-box provider stanza
-// as `experimental_bearer_token` (with `requires_openai_auth = false` so Codex
-// doesn't reject the non-`sk-` tingly token). This is the hybrid-mode path: it
-// keeps the gateway credential provider-scoped inside config.toml so
-// ~/.codex/auth.json can retain a native ChatGPT login instead. Pass "" for the
-// classic gateway path where the key lives in auth.json's OPENAI_API_KEY.
+// as `experimental_bearer_token` (with `requires_openai_auth = true`). This is
+// the hybrid-mode path: it keeps the gateway credential provider-scoped inside
+// config.toml so ~/.codex/auth.json can retain a native ChatGPT login instead.
+// Pass "" for the classic gateway path where the key lives in auth.json's
+// OPENAI_API_KEY.
 func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []string, catalogPath string, prefs *CodexPrefs, bearerToken string) {
 	// User-tunable, whitelist-validated keys. Applied at the top level (global
 	// default) and stamped into each generated profile so profiles are
@@ -1173,10 +1173,10 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	if bearerToken != "" {
 		// Hybrid: provider-scoped credential keeps the gateway token out of
 		// auth.json so a native ChatGPT login can coexist there.
-		// requires_openai_auth=false tells Codex not to source this provider's
-		// credential from auth.json (it comes from the bearer token instead).
+		// requires_openai_auth=true tells Codex this provider still requires the
+		// OpenAI auth path (the credential arrives via the bearer token above).
 		providerStanza["experimental_bearer_token"] = bearerToken
-		providerStanza["requires_openai_auth"] = false
+		providerStanza["requires_openai_auth"] = true
 	} else {
 		// Gateway (apikey): the token lives in ~/.codex/auth.json's
 		// OPENAI_API_KEY. requires_openai_auth=true is the schema-documented way

--- a/internal/server/config/apply_config_hybrid_test.go
+++ b/internal/server/config/apply_config_hybrid_test.go
@@ -12,7 +12,7 @@ import (
 // Hybrid mode keeps requests on the tingly-box gateway while leaving
 // ~/.codex/auth.json free to hold a native ChatGPT login. The gateway token
 // therefore rides in config.toml's provider stanza as experimental_bearer_token
-// (with requires_openai_auth=false) rather than in auth.json.
+// (with requires_openai_auth=true) rather than in auth.json.
 
 func TestRenderCodexConfigTOML_HybridEmbedsBearerToken(t *testing.T) {
 	tomlBytes, err := RenderCodexConfigTOML("http://h/tingly/codex", []string{"tingly-codex"}, DefaultCodexPrefs(), false, "tingly-box-secret")
@@ -28,8 +28,8 @@ func TestRenderCodexConfigTOML_HybridEmbedsBearerToken(t *testing.T) {
 	if tb["experimental_bearer_token"] != "tingly-box-secret" {
 		t.Errorf("experimental_bearer_token = %v, want tingly-box-secret", tb["experimental_bearer_token"])
 	}
-	if tb["requires_openai_auth"] != false {
-		t.Errorf("requires_openai_auth = %v, want false", tb["requires_openai_auth"])
+	if tb["requires_openai_auth"] != true {
+		t.Errorf("requires_openai_auth = %v, want true", tb["requires_openai_auth"])
 	}
 	// Managed routing fields are still present so requests go through tingly.
 	if cfg["model_provider"] != "tingly-box" {


### PR DESCRIPTION
<img width="2382" height="1470" alt="image" src="https://github.com/user-attachments/assets/43a56cb0-69d8-4efc-aaac-837b70c9718e" />
