### PR TITLE
refactor(cc): simplify Claude Code statusline apply path with cmp.Or

### DIFF
--- a/ai/agent/claude_code.go
+++ b/ai/agent/claude_code.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"cmp"
 	"fmt"
+	"strings"
 
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
 )
@@ -154,6 +155,16 @@ func applyClaudeOnboarding() (*serverconfig.ApplyResult, error) {
 	return serverconfig.ApplyClaudeOnboarding(payload)
 }
 
+// configFileStatusPrefixes maps the leading words of an ApplyResult.Message
+// (e.g. "Created /path/to/file") to the status shown alongside the path.
+var configFileStatusPrefixes = []struct {
+	prefix string
+	status string
+}{
+	{"Created ", "created"},
+	{"Updated ", "updated"},
+}
+
 // collectConfigFiles collects the config file paths from apply results
 func collectConfigFiles(results ...*serverconfig.ApplyResult) []string {
 	var files []string
@@ -161,18 +172,16 @@ func collectConfigFiles(results ...*serverconfig.ApplyResult) []string {
 		if r == nil {
 			continue
 		}
-		msg := r.Message
-		if len(msg) > 8 && containsPrefix(msg[8:], "Created ") {
-			// Find the file path after "Created "
-			file := extractFilePath(msg[8:])
-			if file != "" {
-				files = append(files, file+" (created)")
+		for _, p := range configFileStatusPrefixes {
+			rest, ok := strings.CutPrefix(r.Message, p.prefix)
+			if !ok {
+				continue
 			}
-		} else if len(msg) > 8 && containsPrefix(msg[8:], "Updated ") {
-			file := extractFilePath(msg[8:])
+			file, _, _ := strings.Cut(rest, " ")
 			if file != "" {
-				files = append(files, file+" (updated)")
+				files = append(files, fmt.Sprintf("%s (%s)", file, p.status))
 			}
+			break
 		}
 	}
 	return files
@@ -187,20 +196,4 @@ func collectBackupPaths(results ...*serverconfig.ApplyResult) []string {
 		}
 	}
 	return paths
-}
-
-// Helper functions to avoid importing strings package
-
-func containsPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
-}
-
-func extractFilePath(s string) string {
-	// Find the end of the file path (first space after prefix)
-	for i := 0; i < len(s); i++ {
-		if s[i] == ' ' || s[i] == '(' {
-			return s[:i]
-		}
-	}
-	return ""
 }

--- a/ai/agent/claude_code.go
+++ b/ai/agent/claude_code.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"cmp"
 	"fmt"
 
 	serverconfig "github.com/tingly-dev/tingly-box/internal/server/config"
@@ -62,36 +63,13 @@ func (p *ClaudeCodeParams) BuildEnv() map[string]string {
 	}
 
 	// Model configuration
-	defaultModel := p.ModelConfig.Default
-	if defaultModel == "" {
-		defaultModel = "tingly/cc"
-	}
+	defaultModel := cmp.Or(p.ModelConfig.Default, "tingly/cc")
 
 	env["ANTHROPIC_MODEL"] = defaultModel
-
-	if p.ModelConfig.Haiku != "" {
-		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = p.ModelConfig.Haiku
-	} else {
-		env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = defaultModel
-	}
-
-	if p.ModelConfig.Opus != "" {
-		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = p.ModelConfig.Opus
-	} else {
-		env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = defaultModel
-	}
-
-	if p.ModelConfig.Sonnet != "" {
-		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = p.ModelConfig.Sonnet
-	} else {
-		env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = defaultModel
-	}
-
-	if p.ModelConfig.SubAgent != "" {
-		env["CLAUDE_CODE_SUBAGENT_MODEL"] = p.ModelConfig.SubAgent
-	} else {
-		env["CLAUDE_CODE_SUBAGENT_MODEL"] = defaultModel
-	}
+	env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = cmp.Or(p.ModelConfig.Haiku, defaultModel)
+	env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = cmp.Or(p.ModelConfig.Opus, defaultModel)
+	env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = cmp.Or(p.ModelConfig.Sonnet, defaultModel)
+	env["CLAUDE_CODE_SUBAGENT_MODEL"] = cmp.Or(p.ModelConfig.SubAgent, defaultModel)
 
 	// Add extra env vars
 	for k, v := range p.ExtraEnv {

--- a/internal/agent/rule_bridge.go
+++ b/internal/agent/rule_bridge.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"cmp"
 	"fmt"
 	"strings"
 
@@ -195,10 +196,7 @@ func (aa *AgentApply) collectCodexRuleModels() []string {
 
 // getBaseURLAndToken returns the base URL and API token for configuration
 func (aa *AgentApply) getBaseURLAndToken() (string, string) {
-	port := aa.config.ServerPort
-	if port == 0 {
-		port = 12580
-	}
+	port := cmp.Or(aa.config.ServerPort, 12580)
 	baseURL := fmt.Sprintf("http://%s:%d", aa.host, port)
 	apiKey := aa.config.GetModelToken()
 	return baseURL, apiKey

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -1,6 +1,7 @@
 package configapply
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,6 +14,14 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
+
+// defaultServerPort is used when no server port is configured.
+const defaultServerPort = 12580
+
+// resolvedPort returns the configured server port, falling back to the default.
+func (h *Handler) resolvedPort() int {
+	return cmp.Or(h.config.ServerPort, defaultServerPort)
+}
 
 // Handler handles config apply HTTP requests
 type Handler struct {
@@ -151,10 +160,7 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 	}
 
 	// Get base URL from the user's request (respects reverse proxy headers)
-	port := h.config.ServerPort
-	if port == 0 {
-		port = 12580
-	}
+	port := h.resolvedPort()
 	baseURL := middleware.BaseURLFromRequest(c, port)
 	// Use the model token from config (tingly-box- prefixed JWT)
 	apiKey := h.config.GetModelToken()
@@ -285,10 +291,7 @@ func (h *Handler) ApplyOpenCodeConfigFromState(c *gin.Context) {
 	}
 
 	// Get base URL from the user's request (respects reverse proxy headers)
-	port := h.config.ServerPort
-	if port == 0 {
-		port = 12580
-	}
+	port := h.resolvedPort()
 	baseURL := middleware.BaseURLFromRequest(c, port)
 	configBaseURL := baseURL + "/tingly/opencode"
 
@@ -342,10 +345,7 @@ func (h *Handler) restoreAgent(c *gin.Context, agentType agent.AgentType) {
 		return
 	}
 
-	host := h.host
-	if host == "" {
-		host = "localhost"
-	}
+	host := cmp.Or(h.host, "localhost")
 	apply := agent.NewAgentApply(h.config, host)
 
 	result, err := apply.RestoreAgent(&agent.RestoreAgentRequest{
@@ -391,10 +391,7 @@ func (h *Handler) GetOpenCodeConfigPreview(c *gin.Context) {
 	}
 
 	// Get base URL from the user's request (respects reverse proxy headers)
-	port := h.config.ServerPort
-	if port == 0 {
-		port = 12580
-	}
+	port := h.resolvedPort()
 	baseURL := middleware.BaseURLFromRequest(c, port)
 	configBaseURL := baseURL + "/tingly/opencode"
 
@@ -546,10 +543,7 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 	// Build context windows map from rules for models with context_1m flag
 	contextWindows := config.BuildContextWindowsFromRules(cfg)
 
-	port := h.config.ServerPort
-	if port == 0 {
-		port = 12580
-	}
+	port := h.resolvedPort()
 	codexBaseURL := middleware.BaseURLFromRequest(c, port) + "/tingly/codex"
 	apiKey := h.config.GetModelToken()
 
@@ -677,10 +671,7 @@ func (h *Handler) GetCodexConfigPreview(c *gin.Context) {
 	// Build context windows map from rules for models with context_1m flag
 	contextWindows := config.BuildContextWindowsFromRules(cfg)
 
-	port := h.config.ServerPort
-	if port == 0 {
-		port = 12580
-	}
+	port := h.resolvedPort()
 	codexBaseURL := middleware.BaseURLFromRequest(c, port) + "/tingly/codex"
 	apiKey := h.config.GetModelToken()
 

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -554,8 +554,9 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 	// one (materialized into auth.json) but also works without (auth.json left
 	// untouched so an existing `codex login` survives).
 	var chatgptTokens *config.CodexChatGPTTokens
-	switch authMode {
-	case config.CodexAuthChatGPT:
+	needsTokens := authMode == config.CodexAuthChatGPT ||
+		(authMode == config.CodexAuthHybrid && req.OAuthProviderUUID != "")
+	if needsTokens {
 		tokens, err := h.loadCodexChatGPTTokens(req.OAuthProviderUUID)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, ApplyCodexConfigResponse{
@@ -565,18 +566,6 @@ func (h *Handler) ApplyCodexConfigFromState(c *gin.Context) {
 			return
 		}
 		chatgptTokens = tokens
-	case config.CodexAuthHybrid:
-		if req.OAuthProviderUUID != "" {
-			tokens, err := h.loadCodexChatGPTTokens(req.OAuthProviderUUID)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, ApplyCodexConfigResponse{
-					Success: false,
-					Message: err.Error(),
-				})
-				return
-			}
-			chatgptTokens = tokens
-		}
 	}
 
 	// ChatGPT mode: clear tingly gateway keys from config.toml so codex CLI

--- a/internal/server/module/statusline/cache.go
+++ b/internal/server/module/statusline/cache.go
@@ -1,6 +1,9 @@
 package statusline
 
-import "sync"
+import (
+	"cmp"
+	"sync"
+)
 
 const maxSize = 500
 
@@ -66,37 +69,23 @@ func (c *Cache) evict() {
 func mergeStatusInput(input, cached *StatusInput) *StatusInput {
 	merged := *input
 
-	merged.Model.DisplayName = mergeIfEmpty(merged.Model.DisplayName, cached.Model.DisplayName)
-	merged.Model.ID = mergeIfEmpty(merged.Model.ID, cached.Model.ID)
+	merged.Model.DisplayName = cmp.Or(merged.Model.DisplayName, cached.Model.DisplayName)
+	merged.Model.ID = cmp.Or(merged.Model.ID, cached.Model.ID)
 
-	merged.ContextWindow.UsedPercentage = mergeIfZero(merged.ContextWindow.UsedPercentage, cached.ContextWindow.UsedPercentage)
-	merged.ContextWindow.ContextWindowSize = mergeIfZero(merged.ContextWindow.ContextWindowSize, cached.ContextWindow.ContextWindowSize)
-	merged.ContextWindow.TotalInputTokens = mergeIfZero(merged.ContextWindow.TotalInputTokens, cached.ContextWindow.TotalInputTokens)
-	merged.ContextWindow.TotalOutputTokens = mergeIfZero(merged.ContextWindow.TotalOutputTokens, cached.ContextWindow.TotalOutputTokens)
-	merged.ContextWindow.CurrentUsage.InputTokens = mergeIfZero(merged.ContextWindow.CurrentUsage.InputTokens, cached.ContextWindow.CurrentUsage.InputTokens)
-	merged.ContextWindow.CurrentUsage.OutputTokens = mergeIfZero(merged.ContextWindow.CurrentUsage.OutputTokens, cached.ContextWindow.CurrentUsage.OutputTokens)
-	merged.ContextWindow.CurrentUsage.CacheRead = mergeIfZero(merged.ContextWindow.CurrentUsage.CacheRead, cached.ContextWindow.CurrentUsage.CacheRead)
-	merged.ContextWindow.CurrentUsage.CacheWrite = mergeIfZero(merged.ContextWindow.CurrentUsage.CacheWrite, cached.ContextWindow.CurrentUsage.CacheWrite)
+	merged.ContextWindow.UsedPercentage = cmp.Or(merged.ContextWindow.UsedPercentage, cached.ContextWindow.UsedPercentage)
+	merged.ContextWindow.ContextWindowSize = cmp.Or(merged.ContextWindow.ContextWindowSize, cached.ContextWindow.ContextWindowSize)
+	merged.ContextWindow.TotalInputTokens = cmp.Or(merged.ContextWindow.TotalInputTokens, cached.ContextWindow.TotalInputTokens)
+	merged.ContextWindow.TotalOutputTokens = cmp.Or(merged.ContextWindow.TotalOutputTokens, cached.ContextWindow.TotalOutputTokens)
+	merged.ContextWindow.CurrentUsage.InputTokens = cmp.Or(merged.ContextWindow.CurrentUsage.InputTokens, cached.ContextWindow.CurrentUsage.InputTokens)
+	merged.ContextWindow.CurrentUsage.OutputTokens = cmp.Or(merged.ContextWindow.CurrentUsage.OutputTokens, cached.ContextWindow.CurrentUsage.OutputTokens)
+	merged.ContextWindow.CurrentUsage.CacheRead = cmp.Or(merged.ContextWindow.CurrentUsage.CacheRead, cached.ContextWindow.CurrentUsage.CacheRead)
+	merged.ContextWindow.CurrentUsage.CacheWrite = cmp.Or(merged.ContextWindow.CurrentUsage.CacheWrite, cached.ContextWindow.CurrentUsage.CacheWrite)
 
-	merged.Cost.TotalCostUSD = mergeIfZero(merged.Cost.TotalCostUSD, cached.Cost.TotalCostUSD)
-	merged.Cost.TotalDurationMs = mergeIfZero(merged.Cost.TotalDurationMs, cached.Cost.TotalDurationMs)
-	merged.Cost.TotalAPIDurationMs = mergeIfZero(merged.Cost.TotalAPIDurationMs, cached.Cost.TotalAPIDurationMs)
-	merged.Cost.TotalLinesAdded = mergeIfZero(merged.Cost.TotalLinesAdded, cached.Cost.TotalLinesAdded)
-	merged.Cost.TotalLinesRemoved = mergeIfZero(merged.Cost.TotalLinesRemoved, cached.Cost.TotalLinesRemoved)
+	merged.Cost.TotalCostUSD = cmp.Or(merged.Cost.TotalCostUSD, cached.Cost.TotalCostUSD)
+	merged.Cost.TotalDurationMs = cmp.Or(merged.Cost.TotalDurationMs, cached.Cost.TotalDurationMs)
+	merged.Cost.TotalAPIDurationMs = cmp.Or(merged.Cost.TotalAPIDurationMs, cached.Cost.TotalAPIDurationMs)
+	merged.Cost.TotalLinesAdded = cmp.Or(merged.Cost.TotalLinesAdded, cached.Cost.TotalLinesAdded)
+	merged.Cost.TotalLinesRemoved = cmp.Or(merged.Cost.TotalLinesRemoved, cached.Cost.TotalLinesRemoved)
 
 	return &merged
-}
-
-func mergeIfEmpty(target, cached string) string {
-	if target == "" && cached != "" {
-		return cached
-	}
-	return target
-}
-
-func mergeIfZero[T int | int64 | float64](target, cached T) T {
-	if target == 0 && cached != 0 {
-		return cached
-	}
-	return target
 }

--- a/internal/server/module/statusline/handler.go
+++ b/internal/server/module/statusline/handler.go
@@ -126,15 +126,8 @@ func (h *Handler) GetClaudeCodeStatusLine(c *gin.Context) {
 
 	// Build context bar (8 characters wide)
 	barWidth := 8
-	filled := usedPct * barWidth / 100
-	empty := barWidth - filled
-	bar := ""
-	for i := 0; i < filled; i++ {
-		bar += "▓"
-	}
-	for i := 0; i < empty; i++ {
-		bar += "░"
-	}
+	filled := min(max(usedPct*barWidth/100, 0), barWidth)
+	bar := strings.Repeat("▓", filled) + strings.Repeat("░", barWidth-filled)
 
 	// Build profile label: "p1:name" or empty
 	profileLabel := ""
@@ -340,26 +333,18 @@ func (h *Handler) formatQuotaWindow(window *quota.UsageWindow) string {
 		return ""
 	}
 
-	// Format based on unit
-	switch window.Unit {
-	case quota.UsageUnitTokens:
-		if limit >= 1000000 {
-			return fmt.Sprintf("%.1fM/%.1fM", used/1000000, limit/1000000)
-		} else if limit >= 10000 {
-			return fmt.Sprintf("%.0fK/%.0fK", used/1000, limit/1000)
-		}
+	// Requests and credits always show actual numbers, never a K/M suffix.
+	if window.Unit == quota.UsageUnitRequests || window.Unit == quota.UsageUnitCredits {
 		return fmt.Sprintf("%.0f/%.0f", used, limit)
-	case quota.UsageUnitRequests:
-		// For requests, don't use K suffix - show actual numbers
-		return fmt.Sprintf("%.0f/%.0f", used, limit)
-	case quota.UsageUnitCredits:
-		return fmt.Sprintf("%.0f/%.0f", used, limit)
+	}
+
+	// Tokens (and any other unit) get a K/M suffix for large limits.
+	switch {
+	case limit >= 1000000:
+		return fmt.Sprintf("%.1fM/%.1fM", used/1000000, limit/1000000)
+	case limit >= 10000:
+		return fmt.Sprintf("%.0fK/%.0fK", used/1000, limit/1000)
 	default:
-		if limit >= 1000000 {
-			return fmt.Sprintf("%.1fM/%.1fM", used/1000000, limit/1000000)
-		} else if limit >= 10000 {
-			return fmt.Sprintf("%.0fK/%.0fK", used/1000, limit/1000)
-		}
 		return fmt.Sprintf("%.0f/%.0f", used, limit)
 	}
 }

--- a/internal/server/module/statusline/handler.go
+++ b/internal/server/module/statusline/handler.go
@@ -1,6 +1,7 @@
 package statusline
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/http"
@@ -118,10 +119,7 @@ func (h *Handler) GetClaudeCodeStatusLine(c *gin.Context) {
 
 	// Build status line
 	// Format: [CC Model] → TB Model@Provider | ▓▓▓░░░░░ 7% | $0.05
-	ccModel := merged.Model.DisplayName
-	if ccModel == "" {
-		ccModel = "unknown"
-	}
+	ccModel := cmp.Or(merged.Model.DisplayName, "unknown")
 
 	usedPct := int(merged.ContextWindow.UsedPercentage)
 	cost := merged.Cost.TotalCostUSD
@@ -153,10 +151,7 @@ func (h *Handler) GetClaudeCodeStatusLine(c *gin.Context) {
 	mapping := h.getTBModelMapping(merged.Model.ID, typ.RuleScenario(scenario))
 
 	// Build output: [ruleModel @ p1:name] -> realModel @ providerName | bar pct | cost
-	ruleModel := merged.Model.ID
-	if ruleModel == "" {
-		ruleModel = ccModel
-	}
+	ruleModel := cmp.Or(merged.Model.ID, ccModel)
 
 	output := fmt.Sprintf("[%s", ruleModel)
 	if profileLabel != "" {


### PR DESCRIPTION
## Summary

Replace hand-rolled "use this value if it's set, else fall back" conditionals with the standard library `cmp.Or` (Go 1.21+) across the code that builds and applies Claude Code's statusline, and clean up a few adjacent rough edges found while touching these files.

## Changes

- **`internal/server/module/statusline/cache.go`** — `mergeStatusInput` merges live statusline input with cached values field-by-field. Deleted the custom generic `mergeIfEmpty`/`mergeIfZero` helpers entirely and replaced all 15 call sites with `cmp.Or(target, cached)`.
- **`internal/server/module/statusline/handler.go`**:
  - `ccModel`/`ruleModel` fallback-to-default logic now uses `cmp.Or`.
  - Context-usage bar (`▓▓▓░░░░░`) built with `strings.Repeat` (clamped via `min`/`max`) instead of a byte-at-a-time loop — also fixes a latent malformed-bar case when `usedPct` exceeds 100.
  - Collapsed the duplicated `UsageUnitTokens`/`default` branches in `formatQuotaWindow`.
- **`ai/agent/claude_code.go`** — `ClaudeCodeParams.BuildEnv` (builds the env written into the statusline-invoking `settings.json`) had 4 near-identical if/else blocks falling back to `defaultModel`; collapsed to `cmp.Or` one-liners.
- **`internal/server/module/configapply/handler.go`**:
  - The statusline-install handler repeated `port := h.config.ServerPort; if port == 0 { port = 12580 }` 5 times; extracted a `resolvedPort()` helper using `cmp.Or`, plus the `host` fallback.
  - Collapsed the Codex ChatGPT/Hybrid auth branches, which called `loadCodexChatGPTTokens` with an identical 9-line error-response block twice, into one condition.
- **`internal/agent/rule_bridge.go`** — same port-fallback pattern in `AgentApply.getBaseURLAndToken`, used by the same statusline/config-apply flow.

## Bug fix

`collectConfigFiles` in `ai/agent/claude_code.go` checked the `"Created "`/`"Updated "` prefix against `msg[8:]` instead of `msg`, so it never matched a real message like `"Created /path/to/file"` — the `ConfigFiles` list reported after every Claude Code apply (including statusline installs) was silently always empty. Replaced the hand-rolled `containsPrefix`/`extractFilePath` with `strings.CutPrefix`/`strings.Cut` and verified with a standalone repro that it now returns the expected `["<path> (created)", ...]`.

## Verification

- Submodules initialized (`git submodule update --init --recursive`).
- `go build ./...` and `gofmt` clean across the whole repo.
- `go test` on all touched packages (`statusline`, `configapply`, `internal/agent`, `ai/agent`) — only 2 pre-existing failures in `statusline` (`TestGetClaudeCodeStatus_IncludesCacheUsage`, `TestGetClaudeCodeStatusLine_IncludesCacheUsage`), confirmed via `git stash` to already fail on the base branch and unrelated to this change.
- Standalone repro scripts for the context-bar clamping (0%/100%/150%/-5% inputs) and the `collectConfigFiles` fix, both showing correct output before merging into the tree.

---

https://claude.ai/code/session_016fcoX43aN5gomP5qnEmD5N