### PR TITLE
refactor(harness, duo): Replace duo env-var scatter with typed duoInstanceSpec contract

### DIFF
--- a/.design/harness-duo.md
+++ b/.design/harness-duo.md
@@ -62,7 +62,7 @@ Design decisions, and why:
   the CLI binary *and* the `go test` binary — CI needs no extra build step.
 
 - **A typed boot spec, not an env-var scatter.** `TINGLY_DUO_SPEC` carries a
-  JSON-encoded `duoInstanceSpec` (`duo_serve.go`): explicit `role`
+  JSON-encoded `duoInstanceSpec` (`duo_spec.go`): explicit `role`
   (`gateway` / `upstream`), config dir, port, and the role's wiring fields —
   the duo analogue of the CLI's `options.StartServerOptions`, so tb boot
   parameters stay consistent with how every other server boot is expressed.
@@ -273,7 +273,8 @@ go test ./internal/protocoltest/ -run 'TestDuoFunctional|TestDuoMemoryRegression
 ```
 
 Code map: `internal/protocoltest/duo.go` (parent: routes, spawning, request
-driving) · `duo_serve.go` (child: boot + seeding, spec contract) ·
+driving) · `duo_spec.go` (parent↔child boot contract) · `duo_serve.go`
+(child: boot + seeding) ·
 `duo_checks.go` (functional phase — parses responses into the shared
 `RoundTripResult` and runs the `vmodel/benchmark/check` assertion library,
 same vocabulary as matrix/replay) · `duo_memory.go` (per-instance memory

--- a/.design/harness-duo.md
+++ b/.design/harness-duo.md
@@ -55,14 +55,23 @@ Design decisions, and why:
   or interacting with those components are on the measured path.
 
 - **Re-execution instead of a separate server binary.** The parent spawns
-  `os.Executable()` with the `TINGLY_DUO_*` env contract;
-  `MaybeRunDuoServe()` (called first thing in `cli/harness` `main()` and in
-  `duo_test.go`'s `TestMain`) intercepts and runs the server, never
-  returning. The same mechanism therefore works for the CLI binary *and* the
-  `go test` binary — CI needs no extra build step.
+  `os.Executable()` with the boot contract in a single `TINGLY_DUO_SPEC`
+  environment variable; `MaybeRunDuoServe()` (called first thing in
+  `cli/harness` `main()` and in `duo_test.go`'s `TestMain`) intercepts and
+  runs the server, never returning. The same mechanism therefore works for
+  the CLI binary *and* the `go test` binary — CI needs no extra build step.
+
+- **A typed boot spec, not an env-var scatter.** `TINGLY_DUO_SPEC` carries a
+  JSON-encoded `duoInstanceSpec` (`duo_serve.go`): explicit `role`
+  (`gateway` / `upstream`), config dir, port, and the role's wiring fields —
+  the duo analogue of the CLI's `options.StartServerOptions`, so tb boot
+  parameters stay consistent with how every other server boot is expressed.
+  The spec is validated on both sides (parent fails fast before spawning;
+  child rejects a malformed spec with the offending field named) and the
+  role is stated, never inferred from which fields happen to be set.
 
 - **Children self-seed their own config dirs.** tb2 receives tb1's URL/token
-  via env and writes its own providers + rules at boot. The parent never
+  in its spec and writes its own providers + rules at boot. The parent never
   opens an instance's SQLite store (no cross-process DB access); its only
   reads are each child's `config.json` (tokens) and HTTP.
 
@@ -264,7 +273,7 @@ go test ./internal/protocoltest/ -run 'TestDuoFunctional|TestDuoMemoryRegression
 ```
 
 Code map: `internal/protocoltest/duo.go` (parent: routes, spawning, request
-driving) · `duo_serve.go` (child: boot + seeding, env contract) ·
+driving) · `duo_serve.go` (child: boot + seeding, spec contract) ·
 `duo_checks.go` (functional phase — parses responses into the shared
 `RoundTripResult` and runs the `vmodel/benchmark/check` assertion library,
 same vocabulary as matrix/replay) · `duo_memory.go` (per-instance memory

--- a/cli/harness/duo.go
+++ b/cli/harness/duo.go
@@ -86,9 +86,11 @@ func (cmd *DuoCmd) Run() error {
 	}
 
 	env, err := bootDuoEnv("duo", cmd.JSON, cmd.Verbose,
-		protocoltest.DuoEnvConfig{Stream: protocoltest.DuoStreamShape{
-			SizeKB: cmd.StreamKB,
-			Delay:  time.Duration(cmd.StreamMS) * time.Millisecond,
+		protocoltest.DuoEnvConfig{Upstream: protocoltest.DuoUpstreamConfig{
+			Stream: protocoltest.DuoStreamShape{
+				SizeKB: cmd.StreamKB,
+				Delay:  time.Duration(cmd.StreamMS) * time.Millisecond,
+			},
 		}})
 	if err != nil {
 		return err

--- a/cli/harness/duo.go
+++ b/cli/harness/duo.go
@@ -86,7 +86,10 @@ func (cmd *DuoCmd) Run() error {
 	}
 
 	env, err := bootDuoEnv("duo", cmd.JSON, cmd.Verbose,
-		protocoltest.DuoEnvConfig{StreamKB: cmd.StreamKB, StreamMS: cmd.StreamMS})
+		protocoltest.DuoEnvConfig{Stream: protocoltest.DuoStreamShape{
+			SizeKB: cmd.StreamKB,
+			Delay:  time.Duration(cmd.StreamMS) * time.Millisecond,
+		}})
 	if err != nil {
 		return err
 	}

--- a/cli/harness/main.go
+++ b/cli/harness/main.go
@@ -40,7 +40,7 @@ type CLI struct {
 
 func main() {
 	// Duo child mode: when the parent (harness duo) re-executes this binary
-	// under the TINGLY_DUO_* env contract, run a full server instance instead
+	// under the TINGLY_DUO_SPEC contract, run a full server instance instead
 	// of the CLI. Never returns in that case.
 	protocoltest.MaybeRunDuoServe()
 

--- a/internal/protocoltest/agent_real_test.go
+++ b/internal/protocoltest/agent_real_test.go
@@ -42,10 +42,10 @@ func TestSetupRealProfile_ClaudeCode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build a minimal Anthropic v1 messages request (same format claude CLI sends)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"model":      "tingly/cc", // must match built-in-cc RequestModel
 		"max_tokens": 256,
-		"messages": []map[string]interface{}{
+		"messages": []map[string]any{
 			{"role": "user", "content": "Hello"},
 		},
 		"stream": false,
@@ -68,11 +68,11 @@ func TestSetupRealProfile_ClaudeCode(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status: %s", string(respBody))
 
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	require.NoError(t, json.Unmarshal(respBody, &parsed), "response must be valid JSON: %s", string(respBody))
 
 	assert.Equal(t, "message", parsed["type"], "response type should be message")
-	content, ok := parsed["content"].([]interface{})
+	content, ok := parsed["content"].([]any)
 	require.True(t, ok && len(content) > 0, "response must have content blocks")
 }
 

--- a/internal/protocoltest/aliases.go
+++ b/internal/protocoltest/aliases.go
@@ -95,7 +95,7 @@ var (
 // mustMarshal is retained as a protocoltest-local helper because it is used by
 // testenv.go and flags.go to build request bodies. The scenario package has its
 // own unexported copy.
-func mustMarshal(v interface{}) []byte {
+func mustMarshal(v any) []byte {
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic(fmt.Sprintf("mustMarshal: %v", err))

--- a/internal/protocoltest/duo.go
+++ b/internal/protocoltest/duo.go
@@ -10,7 +10,7 @@ package protocoltest
 // tb1 and tb2 are SEPARATE PROCESSES, each a full production server booted
 // through server.Start (background refreshers, config watcher, production
 // http.Server timeouts) — the parent re-executes its own binary via the
-// TINGLY_DUO_* env contract in duo_serve.go. Because each instance has its
+// typed duoInstanceSpec contract in duo_serve.go. Because each instance has its
 // own Go runtime, memory is observed PER INSTANCE over the production
 // /api/v1/debug/{memstats,pprof/heap} endpoints: a leak attributes directly
 // to tb2 (gateway/conversion path) or tb1 (vmodel serving path) instead of
@@ -47,7 +47,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -308,24 +307,25 @@ func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
 	cfg.withDefaults()
 	env := &DuoEnv{client: &http.Client{Timeout: 120 * time.Second}}
 
-	tb1, err := env.startInstance("tb1", cfg, map[string]string{
-		duoEnvStreamKB: strconv.Itoa(cfg.StreamKB),
-		duoEnvStreamMS: strconv.Itoa(cfg.StreamMS),
-	})
+	tb1, err := env.startInstance(duoInstanceSpec{
+		Name:     "tb1",
+		Role:     duoRoleUpstream,
+		StreamKB: cfg.StreamKB,
+		StreamMS: cfg.StreamMS,
+	}, cfg)
 	if err != nil {
 		env.Close()
 		return nil, fmt.Errorf("boot tb1: %w", err)
 	}
 	env.TB1 = tb1
 
-	tb2Env := map[string]string{
-		duoEnvUpstreamURL:   tb1.BaseURL,
-		duoEnvUpstreamToken: tb1.ModelToken,
-	}
-	if cfg.TB2WriteTimeoutMS > 0 {
-		tb2Env[duoEnvWriteTimeoutMS] = strconv.Itoa(cfg.TB2WriteTimeoutMS)
-	}
-	tb2, err := env.startInstance("tb2", cfg, tb2Env)
+	tb2, err := env.startInstance(duoInstanceSpec{
+		Name:           "tb2",
+		Role:           duoRoleGateway,
+		UpstreamURL:    tb1.BaseURL,
+		UpstreamToken:  tb1.ModelToken,
+		WriteTimeoutMS: cfg.TB2WriteTimeoutMS,
+	}, cfg)
 	if err != nil {
 		env.Close()
 		return nil, fmt.Errorf("boot tb2: %w", err)
@@ -335,16 +335,28 @@ func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
 }
 
 // startInstance spawns one child instance (re-executing this binary under
-// the duo env contract), waits for it to become healthy, and reads its
-// tokens from the child's config.json.
-func (env *DuoEnv) startInstance(name string, cfg DuoEnvConfig, extra map[string]string) (*DuoInstance, error) {
-	dir, err := os.MkdirTemp("", "duo-"+name+"-*")
+// the duo spec contract), waits for it to become healthy, and reads its
+// tokens from the child's config.json. The caller fills the role-specific
+// spec fields; config dir and port are allocated here.
+func (env *DuoEnv) startInstance(spec duoInstanceSpec, cfg DuoEnvConfig) (*DuoInstance, error) {
+	dir, err := os.MkdirTemp("", "duo-"+spec.Name+"-*")
 	if err != nil {
 		return nil, err
 	}
 	env.dirs = append(env.dirs, dir)
+	spec.ConfigDir = dir
 
-	port, err := pickFreePort()
+	spec.Port, err = pickFreePort()
+	if err != nil {
+		return nil, err
+	}
+
+	// Fail fast on a malformed spec here, in-process — a child boot failure
+	// would surface the same error, but only after a spawn and as a tail dump.
+	if err := spec.validate(); err != nil {
+		return nil, err
+	}
+	specEnv, err := spec.encode()
 	if err != nil {
 		return nil, err
 	}
@@ -355,25 +367,17 @@ func (env *DuoEnv) startInstance(name string, cfg DuoEnvConfig, extra map[string
 	}
 
 	inst := &DuoInstance{
-		Name:      name,
+		Name:      spec.Name,
 		ConfigDir: dir,
-		Port:      port,
-		BaseURL:   fmt.Sprintf("http://127.0.0.1:%d", port),
+		Port:      spec.Port,
+		BaseURL:   fmt.Sprintf("http://127.0.0.1:%d", spec.Port),
 		out:       newTailBuffer(64 * 1024),
 		done:      make(chan struct{}),
 		hc:        &http.Client{Timeout: 60 * time.Second},
 	}
 
 	cmd := exec.Command(exe)
-	cmd.Env = append(os.Environ(),
-		duoEnvRole+"="+duoRoleServe,
-		duoEnvName+"="+name,
-		duoEnvConfigDir+"="+dir,
-		duoEnvPort+"="+strconv.Itoa(port),
-	)
-	for k, v := range extra {
-		cmd.Env = append(cmd.Env, k+"="+v)
-	}
+	cmd.Env = append(os.Environ(), specEnv)
 	var sink io.Writer = inst.out
 	if cfg.ChildLog != nil {
 		sink = io.MultiWriter(inst.out, cfg.ChildLog)
@@ -381,7 +385,7 @@ func (env *DuoEnv) startInstance(name string, cfg DuoEnvConfig, extra map[string
 	cmd.Stdout = sink
 	cmd.Stderr = sink
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("spawn %s: %w", name, err)
+		return nil, fmt.Errorf("spawn %s: %w", spec.Name, err)
 	}
 	inst.cmd = cmd
 	go func() {
@@ -390,10 +394,10 @@ func (env *DuoEnv) startInstance(name string, cfg DuoEnvConfig, extra map[string
 	}()
 
 	if err := inst.waitReady(cfg.BootTimeout); err != nil {
-		return inst, fmt.Errorf("%s not ready: %w\n--- %s output tail ---\n%s", name, err, name, inst.OutputTail())
+		return inst, fmt.Errorf("%s not ready: %w\n--- %s output tail ---\n%s", spec.Name, err, spec.Name, inst.OutputTail())
 	}
 	if err := inst.readTokens(); err != nil {
-		return inst, fmt.Errorf("%s tokens: %w", name, err)
+		return inst, fmt.Errorf("%s tokens: %w", spec.Name, err)
 	}
 	return inst, nil
 }

--- a/internal/protocoltest/duo.go
+++ b/internal/protocoltest/duo.go
@@ -10,7 +10,7 @@ package protocoltest
 // tb1 and tb2 are SEPARATE PROCESSES, each a full production server booted
 // through server.Start (background refreshers, config watcher, production
 // http.Server timeouts) — the parent re-executes its own binary via the
-// typed duoInstanceSpec contract in duo_serve.go. Because each instance has its
+// typed duoInstanceSpec contract in duo_spec.go. Because each instance has its
 // own Go runtime, memory is observed PER INSTANCE over the production
 // /api/v1/debug/{memstats,pprof/heap} endpoints: a leak attributes directly
 // to tb2 (gateway/conversion path) or tb1 (vmodel serving path) instead of
@@ -258,32 +258,47 @@ func (inst *DuoInstance) WriteHeapProfile(dir, name string) (string, error) {
 
 // ─── Environment ──────────────────────────────────────────────────────────────
 
-// DuoEnvConfig parameterizes NewDuoEnv.
+// DuoEnvConfig parameterizes NewDuoEnv. Role-specific knobs live in the
+// Upstream / Gateway sections — mirroring the child-side spec's role split —
+// so an instance-specific parameter has a structural home instead of a
+// name-prefixed field; top-level fields apply to the environment as a whole.
 type DuoEnvConfig struct {
-	// Stream shapes tb1's slow backpressure vmodels (see DuoStreamShape).
-	// Defaults: 256 KB over ~1 s of wall time (Delay 500ms, applied twice).
-	Stream DuoStreamShape
+	// Upstream configures tb1, the vmodel upstream.
+	Upstream DuoUpstreamConfig
+	// Gateway configures tb2, the gateway under test.
+	Gateway DuoGatewayConfig
 	// ChildLog, when non-nil, receives both children's stdout/stderr live
 	// (in addition to the per-instance tail buffer used for diagnostics).
 	ChildLog io.Writer
 	// BootTimeout caps how long each instance may take to become healthy
 	// (default 90s — first boot may attempt a provider-template fetch).
 	BootTimeout time.Duration
-	// TB2HTTPTimeouts overrides tb2's real http.Server timeouts — the
-	// server's own packaged type (server.WithHTTPTimeouts), all four
-	// deadlines configurable; zero fields keep Start()'s defaults. Lets a
-	// test arm a short WriteTimeout and prove ClearServerIOTimeouts still
-	// lets a slower stream complete under the full two-process production
-	// stack (#1384) — not just the isolated middleware unit test.
-	TB2HTTPTimeouts server.HTTPTimeouts
+}
+
+// DuoUpstreamConfig is the tb1 section of DuoEnvConfig.
+type DuoUpstreamConfig struct {
+	// Stream shapes tb1's slow backpressure vmodels (see DuoStreamShape).
+	// Defaults: 256 KB over ~1 s of wall time (Delay 500ms, applied twice).
+	Stream DuoStreamShape
+}
+
+// DuoGatewayConfig is the tb2 section of DuoEnvConfig.
+type DuoGatewayConfig struct {
+	// HTTPTimeouts overrides tb2's real http.Server timeouts — the server's
+	// own packaged type (server.WithHTTPTimeouts), all four deadlines
+	// configurable; zero fields keep Start()'s defaults. Lets a test arm a
+	// short WriteTimeout and prove ClearServerIOTimeouts still lets a slower
+	// stream complete under the full two-process production stack (#1384) —
+	// not just the isolated middleware unit test.
+	HTTPTimeouts server.HTTPTimeouts
 }
 
 func (c *DuoEnvConfig) withDefaults() {
-	if c.Stream.SizeKB <= 0 {
-		c.Stream.SizeKB = 256
+	if c.Upstream.Stream.SizeKB <= 0 {
+		c.Upstream.Stream.SizeKB = 256
 	}
-	if c.Stream.Delay <= 0 {
-		c.Stream.Delay = 500 * time.Millisecond
+	if c.Upstream.Stream.Delay <= 0 {
+		c.Upstream.Stream.Delay = 500 * time.Millisecond
 	}
 	if c.BootTimeout <= 0 {
 		c.BootTimeout = 90 * time.Second
@@ -310,7 +325,7 @@ func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
 	tb1, err := env.startInstance(duoInstanceSpec{
 		Name:   "tb1",
 		Role:   duoRoleUpstream,
-		Stream: cfg.Stream,
+		Stream: cfg.Upstream.Stream,
 	}, cfg)
 	if err != nil {
 		env.Close()
@@ -323,7 +338,7 @@ func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
 		Role:          duoRoleGateway,
 		UpstreamURL:   tb1.BaseURL,
 		UpstreamToken: tb1.ModelToken,
-		HTTPTimeouts:  cfg.TB2HTTPTimeouts,
+		HTTPTimeouts:  cfg.Gateway.HTTPTimeouts,
 	}, cfg)
 	if err != nil {
 		env.Close()

--- a/internal/protocoltest/duo.go
+++ b/internal/protocoltest/duo.go
@@ -52,6 +52,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tingly-dev/tingly-box/internal/server"
 	debugmodule "github.com/tingly-dev/tingly-box/internal/server/module/debug"
 )
 
@@ -259,31 +260,30 @@ func (inst *DuoInstance) WriteHeapProfile(dir, name string) (string, error) {
 
 // DuoEnvConfig parameterizes NewDuoEnv.
 type DuoEnvConfig struct {
-	// StreamKB / StreamMS shape tb1's slow backpressure vmodels: an
-	// approximately StreamKB-sized response streamed over roughly 2×StreamMS
-	// wall time. Defaults: 256 KB over ~1 s.
-	StreamKB int
-	StreamMS int
+	// Stream shapes tb1's slow backpressure vmodels (see DuoStreamShape).
+	// Defaults: 256 KB over ~1 s of wall time (Delay 500ms, applied twice).
+	Stream DuoStreamShape
 	// ChildLog, when non-nil, receives both children's stdout/stderr live
 	// (in addition to the per-instance tail buffer used for diagnostics).
 	ChildLog io.Writer
 	// BootTimeout caps how long each instance may take to become healthy
 	// (default 90s — first boot may attempt a provider-template fetch).
 	BootTimeout time.Duration
-	// TB2WriteTimeoutMS, when > 0, overrides tb2's real http.Server.WriteTimeout
-	// (server.WithHTTPTimeouts) instead of Start()'s 10-minute default. Lets a
-	// test arm a short deadline and prove ClearServerIOTimeouts still lets a
-	// slower stream complete under the full two-process production stack
-	// (#1384) — not just the isolated middleware unit test.
-	TB2WriteTimeoutMS int
+	// TB2HTTPTimeouts overrides tb2's real http.Server timeouts — the
+	// server's own packaged type (server.WithHTTPTimeouts), all four
+	// deadlines configurable; zero fields keep Start()'s defaults. Lets a
+	// test arm a short WriteTimeout and prove ClearServerIOTimeouts still
+	// lets a slower stream complete under the full two-process production
+	// stack (#1384) — not just the isolated middleware unit test.
+	TB2HTTPTimeouts server.HTTPTimeouts
 }
 
 func (c *DuoEnvConfig) withDefaults() {
-	if c.StreamKB <= 0 {
-		c.StreamKB = 256
+	if c.Stream.SizeKB <= 0 {
+		c.Stream.SizeKB = 256
 	}
-	if c.StreamMS <= 0 {
-		c.StreamMS = 500
+	if c.Stream.Delay <= 0 {
+		c.Stream.Delay = 500 * time.Millisecond
 	}
 	if c.BootTimeout <= 0 {
 		c.BootTimeout = 90 * time.Second
@@ -308,10 +308,9 @@ func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
 	env := &DuoEnv{client: &http.Client{Timeout: 120 * time.Second}}
 
 	tb1, err := env.startInstance(duoInstanceSpec{
-		Name:     "tb1",
-		Role:     duoRoleUpstream,
-		StreamKB: cfg.StreamKB,
-		StreamMS: cfg.StreamMS,
+		Name:   "tb1",
+		Role:   duoRoleUpstream,
+		Stream: cfg.Stream,
 	}, cfg)
 	if err != nil {
 		env.Close()
@@ -320,11 +319,11 @@ func NewDuoEnv(cfg DuoEnvConfig) (*DuoEnv, error) {
 	env.TB1 = tb1
 
 	tb2, err := env.startInstance(duoInstanceSpec{
-		Name:           "tb2",
-		Role:           duoRoleGateway,
-		UpstreamURL:    tb1.BaseURL,
-		UpstreamToken:  tb1.ModelToken,
-		WriteTimeoutMS: cfg.TB2WriteTimeoutMS,
+		Name:          "tb2",
+		Role:          duoRoleGateway,
+		UpstreamURL:   tb1.BaseURL,
+		UpstreamToken: tb1.ModelToken,
+		HTTPTimeouts:  cfg.TB2HTTPTimeouts,
 	}, cfg)
 	if err != nil {
 		env.Close()

--- a/internal/protocoltest/duo_serve.go
+++ b/internal/protocoltest/duo_serve.go
@@ -4,20 +4,18 @@ package protocoltest
 // production tingly-box instance booted via server.Start (background
 // refreshers, config watcher, real http.Server timeouts — everything a real
 // deployment runs). The parent (NewDuoEnv) re-executes its own binary with
-// the typed duoInstanceSpec contract below (one JSON document in the
-// TINGLY_DUO_SPEC environment variable); MaybeRunDuoServe intercepts that
-// re-execution before normal CLI/test execution begins and never returns.
+// the typed duoInstanceSpec contract (duo_spec.go); MaybeRunDuoServe
+// intercepts that re-execution before normal CLI/test execution begins and
+// never returns.
 //
 // The child self-seeds its own config dir, so the parent never opens the
 // instance's SQLite store — the only cross-process contract is the spec
 // plus reading the child's config.json for tokens.
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/config"
@@ -31,114 +29,6 @@ import (
 	openaivm "github.com/tingly-dev/tingly-box/vmodel/openai"
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
-
-// duoEnvSpec is the single environment variable of the parent→child boot
-// contract: a JSON-encoded duoInstanceSpec. Its presence marks the process
-// as a duo child.
-const duoEnvSpec = "TINGLY_DUO_SPEC"
-
-// duoRole selects which of the two duo roles a child instance plays. The
-// role is explicit in the spec rather than inferred from which wiring
-// fields happen to be set.
-type duoRole string
-
-const (
-	// duoRoleGateway is tb2: the gateway under test — converts client
-	// requests and proxies them to the upstream instance.
-	duoRoleGateway duoRole = "gateway"
-	// duoRoleUpstream is tb1: serves the /virtual vmodel endpoints the
-	// gateway's providers point at.
-	duoRoleUpstream duoRole = "upstream"
-)
-
-// duoInstanceSpec is the typed boot contract between the duo parent and one
-// child instance — the duo analogue of the CLI's options.StartServerOptions,
-// so tb boot parameters read like every other server boot in the codebase
-// instead of a stringly env map. The parent fills it in NewDuoEnv /
-// startInstance; the child decodes and validates it once in MaybeRunDuoServe.
-type duoInstanceSpec struct {
-	Name      string  `json:"name"`
-	Role      duoRole `json:"role"`
-	ConfigDir string  `json:"config_dir"`
-	Port      int     `json:"port"`
-
-	// Gateway (tb2) wiring: where the upstream instance (tb1) lives.
-	UpstreamURL   string `json:"upstream_url,omitempty"`
-	UpstreamToken string `json:"upstream_token,omitempty"`
-
-	// HTTPTimeouts overrides the child's real http.Server timeouts — the
-	// server's own packaged type (server.WithHTTPTimeouts), so all four
-	// deadlines are configurable here exactly as they are on a production
-	// boot; zero fields keep Start()'s defaults. Currently only wired to the
-	// gateway role (NewDuoEnv): #1384 is about the gateway's own outbound
-	// write to the client, not tb1's.
-	HTTPTimeouts server.HTTPTimeouts `json:"http_timeouts"`
-
-	// Stream shapes the slow/large backpressure vmodels (upstream role).
-	Stream DuoStreamShape `json:"stream"`
-}
-
-// DuoStreamShape parameterizes tb1's slow backpressure vmodels: an
-// approximately SizeKB-sized response whose Delay is applied once as TTFT by
-// the virtualserver handler and spread again across chunks by the mock's
-// stream loop, so a request's wall time is roughly 2×Delay.
-type DuoStreamShape struct {
-	SizeKB int           `json:"size_kb,omitempty"`
-	Delay  time.Duration `json:"delay,omitempty"`
-}
-
-// validate rejects a spec that cannot boot, with the field name in the
-// error — the earlier env-map contract silently defaulted malformed values.
-func (s *duoInstanceSpec) validate() error {
-	var missing []string
-	if s.Name == "" {
-		missing = append(missing, "name")
-	}
-	if s.ConfigDir == "" {
-		missing = append(missing, "config_dir")
-	}
-	if s.Port <= 0 {
-		missing = append(missing, "port")
-	}
-	switch s.Role {
-	case duoRoleGateway:
-		if s.UpstreamURL == "" {
-			missing = append(missing, "upstream_url")
-		}
-		if s.UpstreamToken == "" {
-			missing = append(missing, "upstream_token")
-		}
-	case duoRoleUpstream:
-	default:
-		return fmt.Errorf("unknown duo role %q (want %q or %q)", s.Role, duoRoleGateway, duoRoleUpstream)
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("duo spec for role %q missing/invalid: %s", s.Role, strings.Join(missing, ", "))
-	}
-	return nil
-}
-
-// encode serializes the spec into the env entry startInstance hands to the
-// child process.
-func (s *duoInstanceSpec) encode() (string, error) {
-	raw, err := json.Marshal(s)
-	if err != nil {
-		return "", fmt.Errorf("encode duo spec: %w", err)
-	}
-	return duoEnvSpec + "=" + string(raw), nil
-}
-
-// decodeDuoSpec parses and validates the child-side spec.
-func decodeDuoSpec(raw string) (duoInstanceSpec, error) {
-	var spec duoInstanceSpec
-	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
-		return spec, fmt.Errorf("decode %s: %w", duoEnvSpec, err)
-	}
-	if err := spec.validate(); err != nil {
-		return spec, err
-	}
-	return spec, nil
-}
 
 // tb2 provider UUIDs wired by seedDuoGateway; duo_routing.go's scenario
 // services reference the same IDs, so they live in one place.

--- a/internal/protocoltest/duo_serve.go
+++ b/internal/protocoltest/duo_serve.go
@@ -4,18 +4,18 @@ package protocoltest
 // production tingly-box instance booted via server.Start (background
 // refreshers, config watcher, real http.Server timeouts — everything a real
 // deployment runs). The parent (NewDuoEnv) re-executes its own binary with
-// the TINGLY_DUO_* environment variables below; MaybeRunDuoServe intercepts
-// that re-execution before normal CLI/test execution begins and never
-// returns.
+// the typed duoInstanceSpec contract below (one JSON document in the
+// TINGLY_DUO_SPEC environment variable); MaybeRunDuoServe intercepts that
+// re-execution before normal CLI/test execution begins and never returns.
 //
 // The child self-seeds its own config dir, so the parent never opens the
-// instance's SQLite store — the only cross-process contract is this env
-// block plus reading the child's config.json for tokens.
+// instance's SQLite store — the only cross-process contract is the spec
+// plus reading the child's config.json for tokens.
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -32,29 +32,103 @@ import (
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
 )
 
-// Environment variable contract between the duo parent and child.
+// duoEnvSpec is the single environment variable of the parent→child boot
+// contract: a JSON-encoded duoInstanceSpec. Its presence marks the process
+// as a duo child.
+const duoEnvSpec = "TINGLY_DUO_SPEC"
+
+// duoRole selects which of the two duo roles a child instance plays. The
+// role is explicit in the spec rather than inferred from which wiring
+// fields happen to be set.
+type duoRole string
+
 const (
-	duoEnvRole      = "TINGLY_DUO_ROLE"
-	duoEnvName      = "TINGLY_DUO_NAME"
-	duoEnvConfigDir = "TINGLY_DUO_CONFIG_DIR"
-	duoEnvPort      = "TINGLY_DUO_PORT"
+	// duoRoleGateway is tb2: the gateway under test — converts client
+	// requests and proxies them to the upstream instance.
+	duoRoleGateway duoRole = "gateway"
+	// duoRoleUpstream is tb1: serves the /virtual vmodel endpoints the
+	// gateway's providers point at.
+	duoRoleUpstream duoRole = "upstream"
+)
+
+// duoInstanceSpec is the typed boot contract between the duo parent and one
+// child instance — the duo analogue of the CLI's options.StartServerOptions,
+// so tb boot parameters read like every other server boot in the codebase
+// instead of a stringly env map. The parent fills it in NewDuoEnv /
+// startInstance; the child decodes and validates it once in MaybeRunDuoServe.
+type duoInstanceSpec struct {
+	Name      string  `json:"name"`
+	Role      duoRole `json:"role"`
+	ConfigDir string  `json:"config_dir"`
+	Port      int     `json:"port"`
 
 	// Gateway (tb2) wiring: where the upstream instance (tb1) lives.
-	duoEnvUpstreamURL   = "TINGLY_DUO_UPSTREAM_URL"
-	duoEnvUpstreamToken = "TINGLY_DUO_UPSTREAM_TOKEN"
+	UpstreamURL   string `json:"upstream_url,omitempty"`
+	UpstreamToken string `json:"upstream_token,omitempty"`
+	// WriteTimeoutMS, when > 0, overrides the real http.Server.WriteTimeout
+	// (server.WithHTTPTimeouts) instead of Start()'s 10-minute default.
+	// Only wired to the gateway role: #1384 is about the gateway's own
+	// outbound write to the client, not tb1's, so only the gateway under
+	// test needs a short armed deadline.
+	WriteTimeoutMS int `json:"write_timeout_ms,omitempty"`
 
-	// Upstream (tb1) wiring: shape of the slow/large "backpressure" vmodels.
-	duoEnvStreamKB = "TINGLY_DUO_STREAM_KB"
-	duoEnvStreamMS = "TINGLY_DUO_STREAM_MS"
+	// Upstream (tb1) wiring: shape of the slow/large backpressure vmodels.
+	StreamKB int `json:"stream_kb,omitempty"`
+	StreamMS int `json:"stream_ms,omitempty"`
+}
 
-	// Overrides Start()'s hardcoded http.Server.WriteTimeout via
-	// server.WithHTTPTimeouts. Currently only wired to tb2 in NewDuoEnv:
-	// #1384 is about the gateway's own outbound write to the client, not
-	// tb1's, so only the gateway under test needs a short armed deadline.
-	duoEnvWriteTimeoutMS = "TINGLY_DUO_WRITE_TIMEOUT_MS"
+// validate rejects a spec that cannot boot, with the field name in the
+// error — the earlier env-map contract silently defaulted malformed values.
+func (s *duoInstanceSpec) validate() error {
+	var missing []string
+	if s.Name == "" {
+		missing = append(missing, "name")
+	}
+	if s.ConfigDir == "" {
+		missing = append(missing, "config_dir")
+	}
+	if s.Port <= 0 {
+		missing = append(missing, "port")
+	}
+	switch s.Role {
+	case duoRoleGateway:
+		if s.UpstreamURL == "" {
+			missing = append(missing, "upstream_url")
+		}
+		if s.UpstreamToken == "" {
+			missing = append(missing, "upstream_token")
+		}
+	case duoRoleUpstream:
+	default:
+		return fmt.Errorf("unknown duo role %q (want %q or %q)", s.Role, duoRoleGateway, duoRoleUpstream)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("duo spec for role %q missing/invalid: %s", s.Role, strings.Join(missing, ", "))
+	}
+	return nil
+}
 
-	duoRoleServe = "serve"
-)
+// encode serializes the spec into the env entry startInstance hands to the
+// child process.
+func (s *duoInstanceSpec) encode() (string, error) {
+	raw, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("encode duo spec: %w", err)
+	}
+	return duoEnvSpec + "=" + string(raw), nil
+}
+
+// decodeDuoSpec parses and validates the child-side spec.
+func decodeDuoSpec(raw string) (duoInstanceSpec, error) {
+	var spec duoInstanceSpec
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		return spec, fmt.Errorf("decode %s: %w", duoEnvSpec, err)
+	}
+	if err := spec.validate(); err != nil {
+		return spec, err
+	}
+	return spec, nil
+}
 
 // tb2 provider UUIDs wired by seedDuoGateway; duo_routing.go's scenario
 // services reference the same IDs, so they live in one place.
@@ -73,40 +147,35 @@ const (
 )
 
 // MaybeRunDuoServe runs a duo child instance and exits the process when the
-// duo env contract is present; otherwise it returns immediately. Call it
-// first thing in main() (cli/harness) and TestMain (duo_test.go) so the
-// parent can re-execute the same binary as a server.
+// duo spec is present in the environment; otherwise it returns immediately.
+// Call it first thing in main() (cli/harness) and TestMain (duo_test.go) so
+// the parent can re-execute the same binary as a server.
 func MaybeRunDuoServe() {
-	if os.Getenv(duoEnvRole) != duoRoleServe {
+	raw := os.Getenv(duoEnvSpec)
+	if raw == "" {
 		return
 	}
-	if err := runDuoServe(); err != nil {
-		fmt.Fprintf(os.Stderr, "duo-serve[%s]: %v\n", os.Getenv(duoEnvName), err)
+	spec, err := decodeDuoSpec(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "duo-serve: %v\n", err)
+		os.Exit(1)
+	}
+	if err := runDuoServe(spec); err != nil {
+		fmt.Fprintf(os.Stderr, "duo-serve[%s]: %v\n", spec.Name, err)
 		os.Exit(1)
 	}
 	os.Exit(0)
 }
 
-func runDuoServe() error {
-	dir := os.Getenv(duoEnvConfigDir)
-	if dir == "" {
-		return fmt.Errorf("%s not set", duoEnvConfigDir)
-	}
-	port, err := strconv.Atoi(os.Getenv(duoEnvPort))
-	if err != nil || port <= 0 {
-		return fmt.Errorf("invalid %s: %q", duoEnvPort, os.Getenv(duoEnvPort))
-	}
-
-	appCfg, err := config.NewAppConfig(config.WithConfigDir(dir))
+func runDuoServe(spec duoInstanceSpec) error {
+	appCfg, err := config.NewAppConfig(config.WithConfigDir(spec.ConfigDir))
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	isGateway := os.Getenv(duoEnvUpstreamURL) != ""
-
-	// tb2 role: wire providers + one rule per duo route to the upstream (tb1).
-	if isGateway {
-		if err := seedDuoGateway(appCfg, os.Getenv(duoEnvUpstreamURL), os.Getenv(duoEnvUpstreamToken)); err != nil {
+	// Gateway role: wire providers + one rule per duo route to the upstream.
+	if spec.Role == duoRoleGateway {
+		if err := seedDuoGateway(appCfg, spec.UpstreamURL, spec.UpstreamToken); err != nil {
 			return fmt.Errorf("seed gateway wiring: %w", err)
 		}
 		// Pipeline health scenarios need a non-zero recovery window so a 429
@@ -119,28 +188,31 @@ func runDuoServe() error {
 	// Production boots with a MultiLogger; without it the smart-routing and
 	// model-request memory sinks don't exist and /api/v1/requests has nothing
 	// to join, so the child would be less observable than a real deployment.
-	multiLogger, err := obs.NewMultiLogger(obs.DefaultMultiLoggerConfig(dir))
+	multiLogger, err := obs.NewMultiLogger(obs.DefaultMultiLoggerConfig(spec.ConfigDir))
 	if err != nil {
 		return fmt.Errorf("init multi logger: %w", err)
 	}
 
+	// Option assembly mirrors the CLI's startServer (command/server.go): the
+	// same server.ServerOption vocabulary, minus interactive concerns
+	// (browser, banner, file lock) that have no place in a child process.
 	opts := []server.ServerOption{
 		server.WithOpenBrowser(false),
 		server.WithMultiLogger(multiLogger),
 	}
-	if ms := duoEnvInt(duoEnvWriteTimeoutMS); ms > 0 {
+	if spec.WriteTimeoutMS > 0 {
 		opts = append(opts, server.WithHTTPTimeouts(server.HTTPTimeouts{
-			WriteTimeout: time.Duration(ms) * time.Millisecond,
+			WriteTimeout: time.Duration(spec.WriteTimeoutMS) * time.Millisecond,
 		}))
 	}
 	srv := server.NewServer(appCfg.GetGlobalConfig(), opts...)
 
-	if !isGateway {
-		// tb1 role: register the duo-only vmodels before serving — the
+	if spec.Role == duoRoleUpstream {
+		// Upstream role: register the duo-only vmodels before serving — the
 		// slow/large backpressure models and the service-identity pool the
 		// routing scenarios address.
-		if kb := duoEnvInt(duoEnvStreamKB); kb > 0 {
-			if err := registerDuoStreamModels(srv.GetVirtualModelService(), kb, duoEnvInt(duoEnvStreamMS)); err != nil {
+		if spec.StreamKB > 0 {
+			if err := registerDuoStreamModels(srv.GetVirtualModelService(), spec.StreamKB, spec.StreamMS); err != nil {
 				return fmt.Errorf("register duo stream models: %w", err)
 			}
 		}
@@ -149,12 +221,7 @@ func runDuoServe() error {
 		}
 	}
 
-	return srv.Start(port)
-}
-
-func duoEnvInt(key string) int {
-	n, _ := strconv.Atoi(os.Getenv(key))
-	return n
+	return srv.Start(spec.Port)
 }
 
 // seedDuoGateway persists the tb2 wiring into the child's own config dir:

--- a/internal/protocoltest/duo_serve.go
+++ b/internal/protocoltest/duo_serve.go
@@ -65,16 +65,26 @@ type duoInstanceSpec struct {
 	// Gateway (tb2) wiring: where the upstream instance (tb1) lives.
 	UpstreamURL   string `json:"upstream_url,omitempty"`
 	UpstreamToken string `json:"upstream_token,omitempty"`
-	// WriteTimeoutMS, when > 0, overrides the real http.Server.WriteTimeout
-	// (server.WithHTTPTimeouts) instead of Start()'s 10-minute default.
-	// Only wired to the gateway role: #1384 is about the gateway's own
-	// outbound write to the client, not tb1's, so only the gateway under
-	// test needs a short armed deadline.
-	WriteTimeoutMS int `json:"write_timeout_ms,omitempty"`
 
-	// Upstream (tb1) wiring: shape of the slow/large backpressure vmodels.
-	StreamKB int `json:"stream_kb,omitempty"`
-	StreamMS int `json:"stream_ms,omitempty"`
+	// HTTPTimeouts overrides the child's real http.Server timeouts — the
+	// server's own packaged type (server.WithHTTPTimeouts), so all four
+	// deadlines are configurable here exactly as they are on a production
+	// boot; zero fields keep Start()'s defaults. Currently only wired to the
+	// gateway role (NewDuoEnv): #1384 is about the gateway's own outbound
+	// write to the client, not tb1's.
+	HTTPTimeouts server.HTTPTimeouts `json:"http_timeouts"`
+
+	// Stream shapes the slow/large backpressure vmodels (upstream role).
+	Stream DuoStreamShape `json:"stream"`
+}
+
+// DuoStreamShape parameterizes tb1's slow backpressure vmodels: an
+// approximately SizeKB-sized response whose Delay is applied once as TTFT by
+// the virtualserver handler and spread again across chunks by the mock's
+// stream loop, so a request's wall time is roughly 2×Delay.
+type DuoStreamShape struct {
+	SizeKB int           `json:"size_kb,omitempty"`
+	Delay  time.Duration `json:"delay,omitempty"`
 }
 
 // validate rejects a spec that cannot boot, with the field name in the
@@ -196,23 +206,20 @@ func runDuoServe(spec duoInstanceSpec) error {
 	// Option assembly mirrors the CLI's startServer (command/server.go): the
 	// same server.ServerOption vocabulary, minus interactive concerns
 	// (browser, banner, file lock) that have no place in a child process.
-	opts := []server.ServerOption{
+	// HTTPTimeouts is passed through unconditionally — zero fields keep
+	// Start()'s defaults by WithHTTPTimeouts's own contract.
+	srv := server.NewServer(appCfg.GetGlobalConfig(),
 		server.WithOpenBrowser(false),
 		server.WithMultiLogger(multiLogger),
-	}
-	if spec.WriteTimeoutMS > 0 {
-		opts = append(opts, server.WithHTTPTimeouts(server.HTTPTimeouts{
-			WriteTimeout: time.Duration(spec.WriteTimeoutMS) * time.Millisecond,
-		}))
-	}
-	srv := server.NewServer(appCfg.GetGlobalConfig(), opts...)
+		server.WithHTTPTimeouts(spec.HTTPTimeouts),
+	)
 
 	if spec.Role == duoRoleUpstream {
 		// Upstream role: register the duo-only vmodels before serving — the
 		// slow/large backpressure models and the service-identity pool the
 		// routing scenarios address.
-		if spec.StreamKB > 0 {
-			if err := registerDuoStreamModels(srv.GetVirtualModelService(), spec.StreamKB, spec.StreamMS); err != nil {
+		if spec.Stream.SizeKB > 0 {
+			if err := registerDuoStreamModels(srv.GetVirtualModelService(), spec.Stream); err != nil {
 				return fmt.Errorf("register duo stream models: %w", err)
 			}
 		}
@@ -271,34 +278,32 @@ func seedDuoGateway(appCfg *config.AppConfig, tb1URL, tb1Token string) error {
 
 // registerDuoStreamModels registers the slow/large vmodels into tb1's
 // registries. The response streams len(chunks) deltas of ~2 KB each; the
-// Delay parameter is applied by the virtualserver handler once up front
-// (TTFT) and spread again across chunks by the mock's stream loop, so a
-// request's wall time is roughly 2×delay.
-func registerDuoStreamModels(svc *virtualserver.Service, kb, ms int) error {
+// shape's Delay semantics are documented on DuoStreamShape.
+func registerDuoStreamModels(svc *virtualserver.Service, shape DuoStreamShape) error {
 	if svc == nil {
 		return fmt.Errorf("virtual model service unavailable")
 	}
-	chunks := duoStreamChunks(kb)
-	delay := time.Duration(ms) * time.Millisecond
+	chunks := duoStreamChunks(shape.SizeKB)
 	content := strings.Join(chunks, "")
+	description := fmt.Sprintf("duo backpressure model: ~%d KB streamed over ~%s", shape.SizeKB, 2*shape.Delay)
 
 	if err := svc.GetOpenAIRegistry().Register(openaivm.NewMockModel(&openaivm.MockModelConfig{
 		ID:           DuoSlowOpenAIModel,
 		Name:         "Duo slow GPT",
-		Description:  fmt.Sprintf("duo backpressure model: ~%d KB streamed over ~%d ms", kb, 2*ms),
+		Description:  description,
 		Content:      content,
 		StreamChunks: chunks,
-		Delay:        delay,
+		Delay:        shape.Delay,
 	})); err != nil {
 		return err
 	}
 	return svc.GetAnthropicRegistry().Register(anthropicvm.NewMockModel(&anthropicvm.MockModelConfig{
 		ID:           DuoSlowAnthropicModel,
 		Name:         "Duo slow Claude",
-		Description:  fmt.Sprintf("duo backpressure model: ~%d KB streamed over ~%d ms", kb, 2*ms),
+		Description:  description,
 		Content:      content,
 		StreamChunks: chunks,
-		Delay:        delay,
+		Delay:        shape.Delay,
 	}))
 }
 

--- a/internal/protocoltest/duo_spec.go
+++ b/internal/protocoltest/duo_spec.go
@@ -1,0 +1,123 @@
+package protocoltest
+
+// duo_spec.go defines the typed boot contract between the duo parent
+// (NewDuoEnv, duo.go) and a child instance (MaybeRunDuoServe, duo_serve.go):
+// one JSON-encoded duoInstanceSpec carried in a single environment variable.
+// Behaviour is pinned by duo_spec_test.go without booting any process.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/server"
+)
+
+// duoEnvSpec is the single environment variable of the parent→child boot
+// contract: a JSON-encoded duoInstanceSpec. Its presence marks the process
+// as a duo child.
+const duoEnvSpec = "TINGLY_DUO_SPEC"
+
+// duoRole selects which of the two duo roles a child instance plays. The
+// role is explicit in the spec rather than inferred from which wiring
+// fields happen to be set.
+type duoRole string
+
+const (
+	// duoRoleGateway is tb2: the gateway under test — converts client
+	// requests and proxies them to the upstream instance.
+	duoRoleGateway duoRole = "gateway"
+	// duoRoleUpstream is tb1: serves the /virtual vmodel endpoints the
+	// gateway's providers point at.
+	duoRoleUpstream duoRole = "upstream"
+)
+
+// duoInstanceSpec is the typed boot contract between the duo parent and one
+// child instance — the duo analogue of the CLI's options.StartServerOptions,
+// so tb boot parameters read like every other server boot in the codebase
+// instead of a stringly env map. The parent fills it in NewDuoEnv /
+// startInstance; the child decodes and validates it once in MaybeRunDuoServe.
+type duoInstanceSpec struct {
+	Name      string  `json:"name"`
+	Role      duoRole `json:"role"`
+	ConfigDir string  `json:"config_dir"`
+	Port      int     `json:"port"`
+
+	// Gateway (tb2) wiring: where the upstream instance (tb1) lives.
+	UpstreamURL   string `json:"upstream_url,omitempty"`
+	UpstreamToken string `json:"upstream_token,omitempty"`
+
+	// HTTPTimeouts overrides the child's real http.Server timeouts — the
+	// server's own packaged type (server.WithHTTPTimeouts), so all four
+	// deadlines are configurable here exactly as they are on a production
+	// boot; zero fields keep Start()'s defaults. Currently only wired to the
+	// gateway role (NewDuoEnv): #1384 is about the gateway's own outbound
+	// write to the client, not tb1's.
+	HTTPTimeouts server.HTTPTimeouts `json:"http_timeouts"`
+
+	// Stream shapes the slow/large backpressure vmodels (upstream role).
+	Stream DuoStreamShape `json:"stream"`
+}
+
+// DuoStreamShape parameterizes tb1's slow backpressure vmodels: an
+// approximately SizeKB-sized response whose Delay is applied once as TTFT by
+// the virtualserver handler and spread again across chunks by the mock's
+// stream loop, so a request's wall time is roughly 2×Delay.
+type DuoStreamShape struct {
+	SizeKB int           `json:"size_kb,omitempty"`
+	Delay  time.Duration `json:"delay,omitempty"`
+}
+
+// validate rejects a spec that cannot boot, with the field name in the
+// error — the earlier env-map contract silently defaulted malformed values.
+func (s *duoInstanceSpec) validate() error {
+	var missing []string
+	if s.Name == "" {
+		missing = append(missing, "name")
+	}
+	if s.ConfigDir == "" {
+		missing = append(missing, "config_dir")
+	}
+	if s.Port <= 0 {
+		missing = append(missing, "port")
+	}
+	switch s.Role {
+	case duoRoleGateway:
+		if s.UpstreamURL == "" {
+			missing = append(missing, "upstream_url")
+		}
+		if s.UpstreamToken == "" {
+			missing = append(missing, "upstream_token")
+		}
+	case duoRoleUpstream:
+	default:
+		return fmt.Errorf("unknown duo role %q (want %q or %q)", s.Role, duoRoleGateway, duoRoleUpstream)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("duo spec for role %q missing/invalid: %s", s.Role, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// encode serializes the spec into the env entry startInstance hands to the
+// child process.
+func (s *duoInstanceSpec) encode() (string, error) {
+	raw, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("encode duo spec: %w", err)
+	}
+	return duoEnvSpec + "=" + string(raw), nil
+}
+
+// decodeDuoSpec parses and validates the child-side spec.
+func decodeDuoSpec(raw string) (duoInstanceSpec, error) {
+	var spec duoInstanceSpec
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		return spec, fmt.Errorf("decode %s: %w", duoEnvSpec, err)
+	}
+	if err := spec.validate(); err != nil {
+		return spec, err
+	}
+	return spec, nil
+}

--- a/internal/protocoltest/duo_spec_test.go
+++ b/internal/protocoltest/duo_spec_test.go
@@ -1,0 +1,77 @@
+package protocoltest
+
+import (
+	"strings"
+	"testing"
+)
+
+// The duoInstanceSpec is a cross-process contract (parent env → child boot),
+// so its round-trip and validation behaviour are pinned here without booting
+// any child process.
+
+func TestDuoSpecRoundTrip(t *testing.T) {
+	spec := duoInstanceSpec{
+		Name:           "tb2",
+		Role:           duoRoleGateway,
+		ConfigDir:      "/tmp/duo-tb2",
+		Port:           4242,
+		UpstreamURL:    "http://127.0.0.1:4141",
+		UpstreamToken:  "sk-tingly-upstream",
+		WriteTimeoutMS: 300,
+	}
+	entry, err := spec.encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	raw, ok := strings.CutPrefix(entry, duoEnvSpec+"=")
+	if !ok {
+		t.Fatalf("env entry %q not prefixed with %s=", entry, duoEnvSpec)
+	}
+	got, err := decodeDuoSpec(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != spec {
+		t.Errorf("round trip mismatch:\n got  %+v\n want %+v", got, spec)
+	}
+}
+
+func TestDuoSpecValidate(t *testing.T) {
+	upstream := duoInstanceSpec{Name: "tb1", Role: duoRoleUpstream, ConfigDir: "/tmp/duo-tb1", Port: 4141}
+	gateway := duoInstanceSpec{
+		Name: "tb2", Role: duoRoleGateway, ConfigDir: "/tmp/duo-tb2", Port: 4242,
+		UpstreamURL: "http://127.0.0.1:4141", UpstreamToken: "sk-tingly-upstream",
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*duoInstanceSpec)
+		spec    duoInstanceSpec
+		wantErr string // "" = valid
+	}{
+		{name: "upstream ok", spec: upstream},
+		{name: "gateway ok", spec: gateway},
+		{name: "unknown role", spec: upstream, mutate: func(s *duoInstanceSpec) { s.Role = "sidecar" }, wantErr: "unknown duo role"},
+		{name: "missing config dir", spec: upstream, mutate: func(s *duoInstanceSpec) { s.ConfigDir = "" }, wantErr: "config_dir"},
+		{name: "missing port", spec: gateway, mutate: func(s *duoInstanceSpec) { s.Port = 0 }, wantErr: "port"},
+		{name: "gateway without upstream", spec: gateway, mutate: func(s *duoInstanceSpec) { s.UpstreamURL = ""; s.UpstreamToken = "" }, wantErr: "upstream_url, upstream_token"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := tc.spec
+			if tc.mutate != nil {
+				tc.mutate(&spec)
+			}
+			err := spec.validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate: unexpected error %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validate: got %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/protocoltest/duo_spec_test.go
+++ b/internal/protocoltest/duo_spec_test.go
@@ -3,6 +3,9 @@ package protocoltest
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/server"
 )
 
 // The duoInstanceSpec is a cross-process contract (parent env → child boot),
@@ -11,13 +14,14 @@ import (
 
 func TestDuoSpecRoundTrip(t *testing.T) {
 	spec := duoInstanceSpec{
-		Name:           "tb2",
-		Role:           duoRoleGateway,
-		ConfigDir:      "/tmp/duo-tb2",
-		Port:           4242,
-		UpstreamURL:    "http://127.0.0.1:4141",
-		UpstreamToken:  "sk-tingly-upstream",
-		WriteTimeoutMS: 300,
+		Name:          "tb2",
+		Role:          duoRoleGateway,
+		ConfigDir:     "/tmp/duo-tb2",
+		Port:          4242,
+		UpstreamURL:   "http://127.0.0.1:4141",
+		UpstreamToken: "sk-tingly-upstream",
+		HTTPTimeouts:  server.HTTPTimeouts{WriteTimeout: 300 * time.Millisecond},
+		Stream:        DuoStreamShape{SizeKB: 64, Delay: 150 * time.Millisecond},
 	}
 	entry, err := spec.encode()
 	if err != nil {

--- a/internal/protocoltest/duo_test.go
+++ b/internal/protocoltest/duo_test.go
@@ -136,7 +136,9 @@ func TestDuoBackpressure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("duo e2e is not a -short test")
 	}
-	env, err := NewDuoEnv(DuoEnvConfig{Stream: DuoStreamShape{SizeKB: 64, Delay: 150 * time.Millisecond}})
+	env, err := NewDuoEnv(DuoEnvConfig{
+		Upstream: DuoUpstreamConfig{Stream: DuoStreamShape{SizeKB: 64, Delay: 150 * time.Millisecond}},
+	})
 	if err != nil {
 		t.Fatalf("boot duo env: %v", err)
 	}
@@ -172,8 +174,8 @@ func TestDuoWriteTimeoutSurvivesClearedDeadline(t *testing.T) {
 		t.Skip("duo e2e is not a -short test")
 	}
 	env, err := NewDuoEnv(DuoEnvConfig{
-		Stream:          DuoStreamShape{SizeKB: 64, Delay: 600 * time.Millisecond},
-		TB2HTTPTimeouts: server.HTTPTimeouts{WriteTimeout: 300 * time.Millisecond},
+		Upstream: DuoUpstreamConfig{Stream: DuoStreamShape{SizeKB: 64, Delay: 600 * time.Millisecond}},
+		Gateway:  DuoGatewayConfig{HTTPTimeouts: server.HTTPTimeouts{WriteTimeout: 300 * time.Millisecond}},
 	})
 	if err != nil {
 		t.Fatalf("boot duo env: %v", err)

--- a/internal/protocoltest/duo_test.go
+++ b/internal/protocoltest/duo_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/server"
 )
 
 func TestMain(m *testing.M) {
@@ -134,7 +136,7 @@ func TestDuoBackpressure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("duo e2e is not a -short test")
 	}
-	env, err := NewDuoEnv(DuoEnvConfig{StreamKB: 64, StreamMS: 150})
+	env, err := NewDuoEnv(DuoEnvConfig{Stream: DuoStreamShape{SizeKB: 64, Delay: 150 * time.Millisecond}})
 	if err != nil {
 		t.Fatalf("boot duo env: %v", err)
 	}
@@ -169,7 +171,10 @@ func TestDuoWriteTimeoutSurvivesClearedDeadline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("duo e2e is not a -short test")
 	}
-	env, err := NewDuoEnv(DuoEnvConfig{StreamKB: 64, StreamMS: 600, TB2WriteTimeoutMS: 300})
+	env, err := NewDuoEnv(DuoEnvConfig{
+		Stream:          DuoStreamShape{SizeKB: 64, Delay: 600 * time.Millisecond},
+		TB2HTTPTimeouts: server.HTTPTimeouts{WriteTimeout: 300 * time.Millisecond},
+	})
 	if err != nil {
 		t.Fatalf("boot duo env: %v", err)
 	}

--- a/internal/protocoltest/failover.go
+++ b/internal/protocoltest/failover.go
@@ -337,8 +337,8 @@ func (env *TestEnv) SendWithModel(t *testing.T, source protocol.APIType, modelNa
 
 // failoverJSONBody is a convenience helper for tests that need to peek at the
 // JSON error body returned by the gateway after all tiers fail.
-func failoverJSONBody(b []byte) map[string]interface{} {
-	var m map[string]interface{}
+func failoverJSONBody(b []byte) map[string]any {
+	var m map[string]any
 	_ = json.Unmarshal(b, &m)
 	return m
 }

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -446,47 +446,47 @@ func (env *TestEnv) findRouteModel(source, target protocol.APIType, scenarioName
 func buildRequest(source protocol.APIType, model string, streaming bool) (path string, body []byte) {
 	switch source {
 	case protocol.TypeAnthropicV1:
-		return "/tingly/anthropic/v1/messages", mustMarshal(map[string]interface{}{
+		return "/tingly/anthropic/v1/messages", mustMarshal(map[string]any{
 			"model":      model,
 			"max_tokens": 1024,
-			"messages": []map[string]interface{}{
+			"messages": []map[string]any{
 				{"role": "user", "content": "What is the capital of France?"},
 			},
 			"stream": streaming,
 		})
 	case protocol.TypeAnthropicBeta:
-		return "/tingly/anthropic/v1/messages?beta=true", mustMarshal(map[string]interface{}{
+		return "/tingly/anthropic/v1/messages?beta=true", mustMarshal(map[string]any{
 			"model":      model,
 			"max_tokens": 1024,
-			"messages": []map[string]interface{}{
-				{"role": "user", "content": []map[string]interface{}{
+			"messages": []map[string]any{
+				{"role": "user", "content": []map[string]any{
 					{"type": "text", "text": "What is the capital of France?"},
 				}},
 			},
 			"stream": streaming,
 		})
 	case protocol.TypeOpenAIChat:
-		return "/tingly/openai/v1/chat/completions", mustMarshal(map[string]interface{}{
+		return "/tingly/openai/v1/chat/completions", mustMarshal(map[string]any{
 			"model": model,
-			"messages": []map[string]interface{}{
+			"messages": []map[string]any{
 				{"role": "user", "content": "What is the capital of France?"},
 			},
 			"stream": streaming,
 		})
 	case protocol.TypeOpenAIResponses:
-		return "/tingly/openai/v1/responses", mustMarshal(map[string]interface{}{
+		return "/tingly/openai/v1/responses", mustMarshal(map[string]any{
 			"model": model,
-			"input": []map[string]interface{}{
-				{"type": "message", "role": "user", "content": []map[string]interface{}{
+			"input": []map[string]any{
+				{"type": "message", "role": "user", "content": []map[string]any{
 					{"type": "input_text", "text": "What is the capital of France?"},
 				}},
 			},
 			"stream": streaming,
 		})
 	default:
-		return "/tingly/openai/v1/chat/completions", mustMarshal(map[string]interface{}{
+		return "/tingly/openai/v1/chat/completions", mustMarshal(map[string]any{
 			"model":    model,
-			"messages": []map[string]interface{}{{"role": "user", "content": "What is the capital of France?"}},
+			"messages": []map[string]any{{"role": "user", "content": "What is the capital of France?"}},
 			"stream":   streaming,
 		})
 	}
@@ -543,7 +543,7 @@ func sourceToStyle(source protocol.APIType) protocol.APIStyle {
 }
 
 func parseFromJSON(raw []byte, style protocol.APIStyle) sse.ParsedResult {
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return sse.ParsedResult{}
 	}

--- a/internal/protocoltest/virtual_client.go
+++ b/internal/protocoltest/virtual_client.go
@@ -42,7 +42,7 @@ func (vs *VirtualServer) Client() *VirtualClient {
 func (vc *VirtualClient) SendOpenAIChat(t *testing.T, s Scenario, streaming bool) *ParsedResponse {
 	t.Helper()
 	vc.maybeRegister(s)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"model":    "gpt-4o",
 		"messages": []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
 		"stream":   streaming,
@@ -54,7 +54,7 @@ func (vc *VirtualClient) SendOpenAIChat(t *testing.T, s Scenario, streaming bool
 func (vc *VirtualClient) SendOpenAIResponses(t *testing.T, s Scenario, streaming bool) *ParsedResponse {
 	t.Helper()
 	vc.maybeRegister(s)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"model":  "gpt-4o",
 		"input":  "What is the capital of France?",
 		"stream": streaming,
@@ -66,7 +66,7 @@ func (vc *VirtualClient) SendOpenAIResponses(t *testing.T, s Scenario, streaming
 func (vc *VirtualClient) SendAnthropicV1(t *testing.T, s Scenario, streaming bool) *ParsedResponse {
 	t.Helper()
 	vc.maybeRegister(s)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"model":      "claude-3-5-sonnet-20241022",
 		"max_tokens": 1024,
 		"messages":   []map[string]string{{"role": "user", "content": "What is the capital of France?"}},
@@ -79,8 +79,8 @@ func (vc *VirtualClient) SendAnthropicV1(t *testing.T, s Scenario, streaming boo
 func (vc *VirtualClient) SendGoogle(t *testing.T, s Scenario, streaming bool) *ParsedResponse {
 	t.Helper()
 	vc.maybeRegister(s)
-	body := map[string]interface{}{
-		"contents": []map[string]interface{}{
+	body := map[string]any{
+		"contents": []map[string]any{
 			{"role": "user", "parts": []map[string]string{{"text": "What is the capital of France?"}}},
 		},
 	}


### PR DESCRIPTION
## Summary

Refactors the parent↔child boot contract for duo test instances from a scatter of `TINGLY_DUO_*` environment variables to a single JSON-encoded `duoInstanceSpec` carried in `TINGLY_DUO_SPEC`. This makes the duo boot parameters explicit and type-safe, mirroring how the CLI's `options.StartServerOptions` structures server configuration.

## Key Changes

- **New `duo_spec.go`**: Defines `duoInstanceSpec` (the typed boot contract), `duoRole` enum (`gateway` / `upstream`), and `DuoStreamShape` for backpressure model parameters. Includes `encode()` / `decodeDuoSpec()` for serialization and `validate()` for fail-fast validation with field-level error messages.

- **New `duo_spec_test.go`**: Unit tests for spec round-trip serialization and validation, pinning behavior without spawning child processes.

- **`duo_serve.go` refactored**: Removed all `TINGLY_DUO_*` env-var constants and parsing logic. `MaybeRunDuoServe()` now decodes the spec once and passes it to `runDuoServe(spec)`. Removed `duoEnvInt()` helper and `strconv` / `time` imports no longer needed.

- **`duo.go` refactored**: 
  - `DuoEnvConfig` now has `Upstream` / `Gateway` sub-structs (mirroring the role split), replacing flat `StreamKB` / `StreamMS` / `TB2WriteTimeoutMS` fields.
  - `startInstance()` now takes a `duoInstanceSpec` template (caller fills role-specific fields), allocates config dir and port, validates the spec in-process before spawning, and encodes it into the single env entry.
  - Removed all manual env-var assembly; spec is validated on both sides (parent fails fast; child rejects malformed specs with field names).

- **`duo_test.go` updated**: Test calls now use the structured `DuoEnvConfig{Upstream: ..., Gateway: ...}` API instead of flat fields.

- **`cli/harness/duo.go` updated**: Converts CLI flags (`StreamKB`, `StreamMS`) to the new `DuoStreamShape` struct.

- **Minor cleanups**: Replaced `map[string]interface{}` with `map[string]any` in `testenv.go`, `virtual_client.go`, `agent_real_test.go`, and `failover.go` (Go 1.18+ idiom).

## Implementation Details

- The spec is JSON-encoded and passed as a single env var, making the contract explicit and self-documenting (no scattered magic strings).
- Role is stated in the spec (`duoRoleGateway` / `duoRoleUpstream`), never inferred from which fields happen to be set.
- Validation happens on both sides: parent validates before spawning (fail-fast, no child boot overhead); child validates on decode and reports the offending field name.
- `HTTPTimeouts` and `DuoStreamShape` are reused from their respective packages, keeping the spec consistent with production server boot patterns.
- Updated `.design/harness-duo.md` to document the new typed contract and its benefits.

https://claude.ai/code/session_01GMkUmjGr8FkKMUKcKX9nff