### PR TITLE
bugfix(smart-guide, protocol): fix zero-argument tool schema forwarding

### DIFF
--- a/internal/protocol/request/anthropic_to_openai_test.go
+++ b/internal/protocol/request/anthropic_to_openai_test.go
@@ -16,19 +16,22 @@ import (
 // were being incorrectly handled.
 func TestConvertAnthropicInputSchemaToOpenAIParameters(t *testing.T) {
 	tests := []struct {
-		name      string
+		name       string
 		properties any
 		required   []string
-		want      shared.FunctionParameters
+		want       shared.FunctionParameters
 	}{
 		{
-			name:      "nil properties and empty required",
+			name:       "nil properties and empty required",
 			properties: nil,
 			required:   []string{},
-			want:      nil,
+			want: shared.FunctionParameters{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
 		},
 		{
-			name:      "nil properties with required",
+			name:       "nil properties with required",
 			properties: nil,
 			required:   []string{"path"},
 			want: shared.FunctionParameters{
@@ -119,6 +122,27 @@ func TestConvertAnthropicInputSchemaToOpenAIParameters(t *testing.T) {
 	}
 }
 
+func TestConvertAnthropicBetaToolsToOpenAI_ZeroArgumentSchema(t *testing.T) {
+	tools := []anthropic.BetaToolUnionParam{
+		anthropic.BetaToolUnionParamOfTool(
+			anthropic.BetaToolInputSchemaParam{},
+			"get_status",
+		),
+	}
+
+	result := ConvertAnthropicBetaToolsToOpenAI(tools)
+	require.Len(t, result, 1)
+
+	parameters := result[0].OfFunction.Function.Parameters
+	assert.Equal(t, "object", parameters["type"])
+	assert.Equal(t, map[string]any{}, parameters["properties"])
+
+	wireJSON, err := json.Marshal(result[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(wireJSON), `"parameters":{"properties":{},"type":"object"}`)
+	assert.NotContains(t, string(wireJSON), `"parameters":null`)
+}
+
 // TestConvertAnthropicToolsToOpenAI_DoubleEscapingFix tests the fix for
 // the double-escaping bug where tool schemas were incorrectly marshaled.
 func TestConvertAnthropicToolsToOpenAI_DoubleEscapingFix(t *testing.T) {
@@ -129,7 +153,7 @@ func TestConvertAnthropicToolsToOpenAI_DoubleEscapingFix(t *testing.T) {
 		InputSchema: anthropic.ToolInputSchemaParam{
 			Type: "object",
 			Properties: map[string]any{
-				"type":       "object",
+				"type": "object",
 				"properties": map[string]any{
 					"path": map[string]any{
 						"type":        "string",

--- a/internal/protocol/request/anthropic_v1_to_openai.go
+++ b/internal/protocol/request/anthropic_v1_to_openai.go
@@ -28,7 +28,10 @@ func ConvertAnthropicToolsToOpenAI(tools []anthropic.ToolUnionParam) []openai.Ch
 
 func convertAnthropicInputSchemaToOpenAIParameters(properties any, required []string) shared.FunctionParameters {
 	if properties == nil && len(required) == 0 {
-		return nil
+		return shared.FunctionParameters{
+			"type":       "object",
+			"properties": map[string]any{},
+		}
 	}
 
 	if schema, ok := properties.(map[string]any); ok {

--- a/internal/protocol/transform/consistency.go
+++ b/internal/protocol/transform/consistency.go
@@ -88,8 +88,8 @@ func (t *ConsistencyTransform) normalizeChatCompletion(ctx *TransformContext) er
 //
 // Normalization rules:
 //   - Ensure parameters type is "object"
-//   - Ensure properties exist if parameters are present
-//   - Normalize empty parameters to nil (avoids sending empty objects)
+//   - Ensure object schemas include properties
+//   - Represent zero-argument tools as a valid empty object schema
 func (t *ConsistencyTransform) normalizeToolSchemas(req *openai.ChatCompletionNewParams) {
 	if len(req.Tools) == 0 {
 		return
@@ -102,28 +102,19 @@ func (t *ConsistencyTransform) normalizeToolSchemas(req *openai.ChatCompletionNe
 
 		fn := toolUnion.OfFunction.Function
 
-		// Normalize tool parameters schema
-		if len(fn.Parameters) > 0 {
-			// Ensure type is "object" if not specified
-			if _, hasType := fn.Parameters["type"]; !hasType {
-				fn.Parameters["type"] = "object"
-			}
-
-			// If type is "object" but properties is missing/empty, normalize
-			if fn.Parameters["type"] == "object" {
-				if props, hasProps := fn.Parameters["properties"]; !hasProps || props == nil {
-					// Add empty properties to ensure valid schema
-					fn.Parameters["properties"] = map[string]interface{}{}
-				}
-			}
-
-			// Normalize: remove empty parameters map to avoid sending empty objects
-			if len(fn.Parameters) == 1 && fn.Parameters["type"] == "object" {
-				props, hasProps := fn.Parameters["properties"]
-				if !hasProps || (len(props.(map[string]interface{})) == 0) {
-					// Empty parameters, set to nil to avoid sending empty object
-					req.Tools[i].OfFunction.Function.Parameters = nil
-				}
+		// Some OpenAI-compatible providers validate an omitted schema as null,
+		// even though OpenAI permits omitting parameters for zero-argument
+		// functions. Always send a concrete empty object schema instead.
+		if fn.Parameters == nil {
+			fn.Parameters = map[string]interface{}{}
+			req.Tools[i].OfFunction.Function.Parameters = fn.Parameters
+		}
+		if _, hasType := fn.Parameters["type"]; !hasType {
+			fn.Parameters["type"] = "object"
+		}
+		if fn.Parameters["type"] == "object" {
+			if props, hasProps := fn.Parameters["properties"]; !hasProps || props == nil {
+				fn.Parameters["properties"] = map[string]interface{}{}
 			}
 		}
 	}
@@ -298,8 +289,8 @@ func (t *ConsistencyTransform) normalizeResponses(ctx *TransformContext) error {
 //
 // Normalization rules:
 //   - Ensure parameters type is "object"
-//   - Ensure properties exist if parameters are present
-//   - Normalize empty parameters to nil (avoids sending empty objects)
+//   - Ensure object schemas include properties
+//   - Represent zero-argument tools as a valid empty object schema
 func (t *ConsistencyTransform) normalizeResponseToolSchemas(req *responses.ResponseNewParams) {
 	if len(req.Tools) == 0 {
 		return
@@ -312,28 +303,16 @@ func (t *ConsistencyTransform) normalizeResponseToolSchemas(req *responses.Respo
 
 		fn := toolUnion.OfFunction
 
-		// Normalize tool parameters schema
-		if len(fn.Parameters) > 0 {
-			// Ensure type is "object" if not specified
-			if _, hasType := fn.Parameters["type"]; !hasType {
-				fn.Parameters["type"] = "object"
-			}
-
-			// If type is "object" but properties is missing/empty, normalize
-			if fn.Parameters["type"] == "object" {
-				if props, hasProps := fn.Parameters["properties"]; !hasProps || props == nil {
-					// Add empty properties to ensure valid schema
-					fn.Parameters["properties"] = map[string]interface{}{}
-				}
-			}
-
-			// Normalize: remove empty parameters map to avoid sending empty objects
-			if len(fn.Parameters) == 1 && fn.Parameters["type"] == "object" {
-				props, hasProps := fn.Parameters["properties"]
-				if !hasProps || (len(props.(map[string]interface{})) == 0) {
-					// Empty parameters, set to nil to avoid sending empty object
-					req.Tools[i].OfFunction.Parameters = nil
-				}
+		if fn.Parameters == nil {
+			fn.Parameters = map[string]interface{}{}
+			req.Tools[i].OfFunction.Parameters = fn.Parameters
+		}
+		if _, hasType := fn.Parameters["type"]; !hasType {
+			fn.Parameters["type"] = "object"
+		}
+		if fn.Parameters["type"] == "object" {
+			if props, hasProps := fn.Parameters["properties"]; !hasProps || props == nil {
+				fn.Parameters["properties"] = map[string]interface{}{}
 			}
 		}
 	}

--- a/internal/protocol/transform/consistency_test.go
+++ b/internal/protocol/transform/consistency_test.go
@@ -49,6 +49,7 @@ func TestConsistencyTransform_normalizeToolSchemas(t *testing.T) {
 		wantTools bool
 		checkType bool
 		wantType  string
+		wantEmpty bool
 	}{
 		{
 			name:      "no tools",
@@ -82,6 +83,9 @@ func TestConsistencyTransform_normalizeToolSchemas(t *testing.T) {
 				}),
 			},
 			wantTools: true,
+			checkType: true,
+			wantType:  "object",
+			wantEmpty: true,
 		},
 	}
 
@@ -98,11 +102,33 @@ func TestConsistencyTransform_normalizeToolSchemas(t *testing.T) {
 			if tt.wantTools {
 				assert.NotNil(t, req.Tools)
 				if tt.checkType {
-					assert.Equal(t, tt.wantType, req.Tools[0].OfFunction.Function.Parameters["type"])
+					parameters := req.Tools[0].OfFunction.Function.Parameters
+					assert.Equal(t, tt.wantType, parameters["type"])
+					if tt.wantEmpty {
+						assert.Equal(t, map[string]interface{}{}, parameters["properties"])
+					}
 				}
 			}
 		})
 	}
+}
+
+func TestConsistencyTransform_normalizeResponseToolSchemas_EmptyParameters(t *testing.T) {
+	ct := NewConsistencyTransform(protocol.TypeOpenAIResponses)
+	req := &responses.ResponseNewParams{
+		Model: "gpt-4o",
+		Tools: []responses.ToolUnionParam{
+			{OfFunction: &responses.FunctionToolParam{Name: "get_status"}},
+		},
+	}
+	ctx := &TransformContext{Request: req}
+
+	err := ct.Apply(ctx)
+	require.NoError(t, err)
+
+	parameters := req.Tools[0].OfFunction.Parameters
+	assert.Equal(t, "object", parameters["type"])
+	assert.Equal(t, map[string]interface{}{}, parameters["properties"])
 }
 
 func TestConsistencyTransform_normalizeToolSchemas_MultipleTools(t *testing.T) {

--- a/internal/remote_control/smart_guide/agent_integration_test.go
+++ b/internal/remote_control/smart_guide/agent_integration_test.go
@@ -83,7 +83,7 @@ func (m *scriptedModel) HandleAnthropic(req *protocol.AnthropicBetaMessagesReque
 	}, nil
 }
 
-func (m *scriptedModel) HandleAnthropicStream(req *protocol.AnthropicBetaMessagesRequest, emit func(any)) error {
+func (m *scriptedModel) HandleAnthropicStream(_ context.Context, req *protocol.AnthropicBetaMessagesRequest, emit func(any)) error {
 	resp, err := m.HandleAnthropic(req)
 	if err != nil {
 		return err
@@ -425,7 +425,7 @@ func (m *multiTurnModel) HandleAnthropic(req *protocol.AnthropicBetaMessagesRequ
 	return anthropicvm.VModelResponse{Content: content, StopReason: stop}, nil
 }
 
-func (m *multiTurnModel) HandleAnthropicStream(req *protocol.AnthropicBetaMessagesRequest, emit func(any)) error {
+func (m *multiTurnModel) HandleAnthropicStream(_ context.Context, req *protocol.AnthropicBetaMessagesRequest, emit func(any)) error {
 	resp, err := m.HandleAnthropic(req)
 	if err != nil {
 		return err

--- a/internal/remote_control/smart_guide/tools_bash.go
+++ b/internal/remote_control/smart_guide/tools_bash.go
@@ -239,7 +239,10 @@ func (t *GetStatusTool) Param() anthropic.BetaToolParam {
 	return anthropic.BetaToolParam{
 		Name:        "get_status",
 		Description: anthropic.String("Get the current bot status including agent, session, project path, and working directory."),
-		InputSchema: anthropic.BetaToolInputSchemaParam{},
+		InputSchema: anthropic.BetaToolInputSchemaParam{
+			Type:       "object",
+			Properties: map[string]interface{}{},
+		},
 	}
 }
 

--- a/internal/remote_control/smart_guide/tools_test.go
+++ b/internal/remote_control/smart_guide/tools_test.go
@@ -102,6 +102,8 @@ func TestNewGetStatusTool(t *testing.T) {
 	assert.NotNil(t, getStatusTool)
 	assert.Equal(t, "get_status", getStatusTool.Param().Name)
 	assert.Contains(t, getStatusTool.Param().Description.Value, "Get the current bot status")
+	assert.Equal(t, "object", string(getStatusTool.Param().InputSchema.Type))
+	assert.Equal(t, map[string]interface{}{}, getStatusTool.Param().InputSchema.Properties)
 }
 
 func TestGetStatusTool_Call(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix Smart Guide requests failing with an invalid schema error when forwarding zero-argument tools such as `get_status` through an OpenAI-compatible provider.

## Root Cause

Smart Guide defines `get_status` as a zero-argument Anthropic tool. During Anthropic → OpenAI conversion, the empty input schema was converted to `nil`, causing some upstream providers to receive `parameters: null`.

These providers require the function schema to be a JSON object or boolean and reject the request with:

```text
Invalid schema for function 'get_status': null is not of types "boolean", "object"