### PR TITLE
bugfix(harness): surface truncated streams as failures

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -201,9 +201,16 @@ stdout; non-zero exit = broken driver, API errors go in-band:
 {"http_status":200,"role":"assistant","content":"...","model":"...",
  "finish_reason":"end_turn","thinking":"","tool_calls":[...],
  "usage":{"input_tokens":10,"output_tokens":8},
- "stream_event_count":7,"raw_body":"...",
+ "stream_event_count":7,"stream_completed":true,
+ "stream_error":null,"raw_body":"...",
  "error":{"status":429,"type":"...","message":"..."}}
 ```
+
+`stream_error` is distinct from `error`: the latter is an HTTP/API failure,
+while `stream_error` means headers were already committed (typically HTTP 200)
+but the turn did not reach a normal terminal event. Drivers must set
+`stream_completed` only after observing a real protocol completion marker; they
+must never synthesize completion for a truncated stream.
 
 The contract itself is covered on every PR by a stub shell driver
 (`client_subprocess_test.go` + `tests/clients/testdata/stub_driver.sh`), so

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
@@ -73,14 +73,8 @@ func (c *anthropicBetaToResponsesConverter) Next() (interface{}, bool, error) {
 			if err := c.stream.Err(); err != nil {
 				return nil, false, err
 			}
-			// Stream ended without message_stop — emit fallback completion
 			if !c.finished {
-				c.emitCompletionEvents()
-				if len(c.pending) > 0 {
-					evt := c.pending[0]
-					c.pending = c.pending[1:]
-					return evt, false, nil
-				}
+				return nil, false, fmt.Errorf("anthropic stream ended without message_stop")
 			}
 			return nil, true, nil
 		}

--- a/internal/protocol/stream/anthropic_to_openai_converter.go
+++ b/internal/protocol/stream/anthropic_to_openai_converter.go
@@ -41,6 +41,7 @@ type anthropicToOpenAIConverter struct {
 	// pending event queue
 	pending []interface{}
 	hookErr error
+	started bool
 	done    bool
 }
 
@@ -75,6 +76,12 @@ func (c *anthropicToOpenAIConverter) Next() (interface{}, bool, error) {
 
 	for {
 		if !c.stream.Next() {
+			if err := c.stream.Err(); err != nil {
+				return nil, false, err
+			}
+			if c.started && !c.done {
+				return nil, false, fmt.Errorf("anthropic stream ended without message_stop")
+			}
 			return nil, true, nil
 		}
 		event := c.stream.Current()
@@ -103,6 +110,7 @@ func (c *anthropicToOpenAIConverter) HookErr() error {
 func (c *anthropicToOpenAIConverter) processEvent(event *anthropic.BetaRawMessageStreamEventUnion) {
 	switch event.Type {
 	case "message_start":
+		c.started = true
 		c.emitChunk(wire.ChatStreamDelta{Role: "assistant"}, nil)
 		c.acc.ConsumeBeta(event)
 

--- a/internal/protocol/stream/openai_chat_to_responses_converter.go
+++ b/internal/protocol/stream/openai_chat_to_responses_converter.go
@@ -74,17 +74,11 @@ func (c *chatToResponsesConverter) Next() (interface{}, bool, error) {
 	// Read upstream chunks until we have at least one event to yield
 	for {
 		if !c.stream.Next() {
-			// Stream ended — emit completion events if not yet sent
 			if err := c.stream.Err(); err != nil {
 				return nil, false, err
 			}
 			if !c.completedSent {
-				c.emitCompletionEvents()
-				if len(c.pending) > 0 {
-					evt := c.pending[0]
-					c.pending = c.pending[1:]
-					return evt, false, nil
-				}
+				return nil, false, fmt.Errorf("chat stream ended without a finish reason")
 			}
 			return nil, true, nil
 		}

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -44,6 +44,7 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 	var hasUsage bool
 	var contentBuilder strings.Builder
 	var firstChunkID string
+	var sawFinish bool
 	// Obfuscation padding is cosmetic; generate at most one value per stream
 	// (lazily) instead of one crypto/rand read per chunk.
 	var obfuscationValue string
@@ -95,6 +96,9 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 			}
 
 			choice := chunk.Choices[0]
+			if choice.FinishReason != "" {
+				sawFinish = true
+			}
 
 			// Accumulate content for estimation
 			if choice.Delta.Content != "" {
@@ -250,6 +254,21 @@ func HandleOpenAIChatStream(hc *protocol.HandleContext, streamResp *openaistream
 		c.SSEvent("", string(errorJSON))
 		flusher.Flush()
 		return usage, err
+	}
+
+	if contentBuilder.Len() > 0 && !sawFinish && c.Request.Context().Err() == nil {
+		streamErr := fmt.Errorf("chat stream ended without a finish reason")
+		errorChunk := map[string]interface{}{
+			"error": map[string]interface{}{
+				"message": streamErr.Error(),
+				"type":    "stream_error",
+				"code":    "upstream_truncated",
+			},
+		}
+		errorJSON, _ := json.Marshal(errorChunk)
+		c.SSEvent("", string(errorJSON))
+		flusher.Flush()
+		return usage, streamErr
 	}
 
 	if !hasUsage {

--- a/internal/protocol/stream/openai_responses_to_chat.go
+++ b/internal/protocol/stream/openai_responses_to_chat.go
@@ -35,6 +35,8 @@ func HandleResponsesToOpenAIChatStream(
 		logrus.WithContext(c.Request.Context()).Errorf("Responses to Chat stream error: %v", err)
 		if !c.Writer.Written() {
 			SendStreamingError(c, err)
+		} else {
+			sendOpenAIStreamError(c, err.Error(), "stream_error")
 		}
 		return conv.Usage(), err
 	}

--- a/internal/protocol/stream/openai_responses_to_chat_converter.go
+++ b/internal/protocol/stream/openai_responses_to_chat_converter.go
@@ -70,14 +70,8 @@ func (c *responsesToChatConverter) Next() (interface{}, bool, error) {
 			if err := c.stream.Err(); err != nil {
 				return nil, false, err
 			}
-			// Stream ended without response.completed — emit fallback completion
 			if !c.completed {
-				c.emitFallbackCompletion()
-				if len(c.pending) > 0 {
-					evt := c.pending[0]
-					c.pending = c.pending[1:]
-					return evt, false, nil
-				}
+				return nil, false, fmt.Errorf("responses stream ended without a terminal event")
 			}
 			return nil, true, nil
 		}
@@ -242,23 +236,6 @@ func (c *responsesToChatConverter) emitCompletedOutput(output []responses.Respon
 			}
 		}
 	}
-}
-
-func (c *responsesToChatConverter) emitFallbackCompletion() {
-	// Mark completed first: this runs when the upstream stream ended without a
-	// response.completed event (e.g. a truncated / mid-stream-cut stream). The
-	// terminal chunk is emitted exactly once — without this flag the Next() loop
-	// would re-enter on the next exhausted stream.Next() and re-emit the
-	// fallback forever, flushing chunks unboundedly until the process OOMs.
-	c.completed = true
-	if !c.hasSentCreated {
-		c.pending = append(c.pending, c.roleChunk())
-	}
-	finishReason := "stop"
-	if c.hasToolCalls {
-		finishReason = openaiFinishReasonToolCalls
-	}
-	c.pending = append(c.pending, c.finalChunk(finishReason))
 }
 
 // responsesToChatFinishReason maps a terminal Responses API response to the

--- a/internal/protocol/stream/passthrough_test.go
+++ b/internal/protocol/stream/passthrough_test.go
@@ -214,6 +214,26 @@ func buildChatRoleOnlyChunkJSON(t *testing.T) string {
 	return string(data)
 }
 
+func buildChatFinishChunkJSON(t *testing.T) string {
+	t.Helper()
+	chunk := map[string]interface{}{
+		"id":      "chatcmpl-test",
+		"object":  "chat.completion.chunk",
+		"created": 1000,
+		"model":   "gpt-4o",
+		"choices": []interface{}{
+			map[string]interface{}{
+				"index":         0,
+				"delta":         map[string]interface{}{},
+				"finish_reason": "stop",
+			},
+		},
+	}
+	data, err := json.Marshal(chunk)
+	require.NoError(t, err)
+	return string(data)
+}
+
 // newTestHandleContext creates a minimal HandleContext wired to the given gin context.
 func newTestHandleContext(c *gin.Context) *protocol.HandleContext {
 	return protocol.NewHandleContext(c, "test-model")
@@ -594,6 +614,7 @@ func TestHandleOpenAIChatStream_Passthrough_MarksTTFT(t *testing.T) {
 	dec := &fakeChatDecoder{events: []string{
 		buildChatRoleOnlyChunkJSON(t), // structural frame — must NOT mark
 		buildChatContentChunkJSON(t, "hi"),
+		buildChatFinishChunkJSON(t),
 	}, current: -1}
 	stream := openaistream.NewStream[openai.ChatCompletionChunk](dec, nil)
 
@@ -604,6 +625,26 @@ func TestHandleOpenAIChatStream_Passthrough_MarksTTFT(t *testing.T) {
 
 	_, ok := c.Get(constant.CtxKeyFirstTokenTime)
 	assert.True(t, ok, "OpenAI Chat passthrough must mark TTFT on the first content chunk")
+}
+
+func TestHandleOpenAIChatStream_Passthrough_TruncatedStreamErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	dec := &fakeChatDecoder{events: []string{
+		buildChatRoleOnlyChunkJSON(t),
+		buildChatContentChunkJSON(t, "partial"),
+	}, current: -1}
+	stream := openaistream.NewStream[openai.ChatCompletionChunk](dec, nil)
+
+	hc := newTestHandleContext(c)
+	hc.DisableStreamUsage = true
+	_, err := HandleOpenAIChatStream(hc, stream)
+	require.ErrorContains(t, err, "without a finish reason")
+	assert.Contains(t, w.Body.String(), `"type":"stream_error"`)
+	assert.NotContains(t, w.Body.String(), "[DONE]")
 }
 
 // TestHandleOpenAIChatStream_Passthrough_NoTTFTOnRoleOnly verifies no TTFT is

--- a/internal/protocoltest/aliases.go
+++ b/internal/protocoltest/aliases.go
@@ -44,6 +44,8 @@ var (
 	AssertUsageNonZero         = check.AssertUsageNonZero
 	AssertHTTPStatus           = check.AssertHTTPStatus
 	AssertStreamEventCount     = check.AssertStreamEventCount
+	AssertStreamError          = check.AssertStreamError
+	AssertStreamNotCompleted   = check.AssertStreamNotCompleted
 	AssertHTTPStatusAtLeast    = check.AssertHTTPStatusAtLeast
 	AssertErrorMessageContains = check.AssertErrorMessageContains
 	AssertModelContains        = check.AssertModelContains

--- a/internal/protocoltest/client.go
+++ b/internal/protocoltest/client.go
@@ -1,7 +1,11 @@
 package protocoltest
 
 import (
+	"encoding/json"
+	"strings"
+
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/sse"
 )
 
 // harnessPrompt is the single user prompt every matrix request carries.
@@ -55,4 +59,72 @@ func newRoundTripResult(spec SendSpec) *RoundTripResult {
 func normalizeResultJSON(result *RoundTripResult, raw []byte, source protocol.APIType, streaming bool) {
 	parsed := parseFromJSON(raw, sourceToStyle(source))
 	fillFromParsedResult(result, parsed)
+}
+
+// classifyStreamEvents extracts the two outcome states that semantic response
+// assembly intentionally does not represent: an in-band stream error and a
+// normal completion marker. It accepts both raw SSE lines and SDK event JSON.
+func classifyStreamEvents(result *RoundTripResult) {
+	if !result.IsStreaming {
+		return
+	}
+	for _, line := range result.StreamEvents {
+		payload, ok := sse.ParseSSEDataPayload(line)
+		if !ok {
+			payload = line
+		}
+		if payload == "[DONE]" {
+			if result.SourceProtocol == protocol.TypeOpenAIChat {
+				result.StreamCompleted = true
+			}
+			continue
+		}
+
+		var event map[string]interface{}
+		if json.Unmarshal([]byte(payload), &event) != nil {
+			continue
+		}
+		eventType, _ := event["type"].(string)
+		switch result.SourceProtocol {
+		case protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta:
+			result.StreamCompleted = result.StreamCompleted || eventType == "message_stop"
+		case protocol.TypeOpenAIChat:
+			if choices, ok := event["choices"].([]interface{}); ok {
+				for _, rawChoice := range choices {
+					choice, _ := rawChoice.(map[string]interface{})
+					if finish, ok := choice["finish_reason"].(string); ok && finish != "" {
+						result.StreamCompleted = true
+					}
+				}
+			}
+		case protocol.TypeOpenAIResponses:
+			result.StreamCompleted = result.StreamCompleted || eventType == "response.completed"
+		}
+
+		if eventType == "error" || event["error"] != nil {
+			result.StreamError = streamErrorMessage(event)
+		}
+	}
+}
+
+func streamErrorMessage(event map[string]interface{}) string {
+	if envelope, ok := event["error"].(map[string]interface{}); ok {
+		if message, ok := envelope["message"].(string); ok && message != "" {
+			return message
+		}
+		if nested, ok := envelope["error"].(map[string]interface{}); ok {
+			if message, ok := nested["message"].(string); ok && message != "" {
+				return message
+			}
+		}
+	}
+	if message, ok := event["message"].(string); ok && message != "" {
+		return message
+	}
+	return strings.TrimSpace(string(mustJSON(event)))
+}
+
+func mustJSON(value interface{}) []byte {
+	data, _ := json.Marshal(value)
+	return data
 }

--- a/internal/protocoltest/client_gosdk.go
+++ b/internal/protocoltest/client_gosdk.go
@@ -102,11 +102,15 @@ func (c *goSDKClient) sendAnthropicV1(ctx context.Context, spec SendSpec) (*Roun
 	}
 	if err := stream.Err(); err != nil {
 		if res, rerr := anthropicErrorResult(result, err); rerr == nil {
+			if res.HTTPStatus == 200 {
+				res.StreamError = err.Error()
+			}
 			return res, nil
 		}
 		// Mid-stream error (e.g. an in-band error event for a truncated
 		// upstream): report it rather than presenting partial content as success.
 		result.HTTPStatus = 200
+		result.StreamError = err.Error()
 		result.RawBody = []byte(err.Error())
 		return result, nil
 	}
@@ -117,6 +121,7 @@ func (c *goSDKClient) sendAnthropicV1(ctx context.Context, spec SendSpec) (*Roun
 	}
 	result.RawBody = raw
 	normalizeResultJSON(result, raw, spec.Source, true)
+	classifyStreamEvents(result)
 	return result, nil
 }
 
@@ -153,9 +158,13 @@ func (c *goSDKClient) sendAnthropicBeta(ctx context.Context, spec SendSpec) (*Ro
 	}
 	if err := stream.Err(); err != nil {
 		if res, rerr := anthropicErrorResult(result, err); rerr == nil {
+			if res.HTTPStatus == 200 {
+				res.StreamError = err.Error()
+			}
 			return res, nil
 		}
 		result.HTTPStatus = 200
+		result.StreamError = err.Error()
 		result.RawBody = []byte(err.Error())
 		return result, nil
 	}
@@ -166,6 +175,7 @@ func (c *goSDKClient) sendAnthropicBeta(ctx context.Context, spec SendSpec) (*Ro
 	}
 	result.RawBody = raw
 	normalizeResultJSON(result, raw, spec.Source, true)
+	classifyStreamEvents(result)
 	return result, nil
 }
 
@@ -210,6 +220,7 @@ func (c *goSDKClient) sendOpenAIChat(ctx context.Context, spec SendSpec) (*Round
 			return res, nil
 		}
 		result.HTTPStatus = 200
+		result.StreamError = err.Error()
 		result.RawBody = []byte(err.Error())
 		return result, nil
 	}
@@ -220,6 +231,7 @@ func (c *goSDKClient) sendOpenAIChat(ctx context.Context, spec SendSpec) (*Round
 	}
 	result.RawBody = raw
 	normalizeResultJSON(result, raw, spec.Source, true)
+	classifyStreamEvents(result)
 	return result, nil
 }
 
@@ -256,6 +268,7 @@ func (c *goSDKClient) sendOpenAIResponses(ctx context.Context, spec SendSpec) (*
 		if len(result.StreamEvents) == 0 {
 			return nil, fmt.Errorf("openai responses SDK stream: %w", err)
 		}
+		result.StreamError = err.Error()
 	}
 	result.HTTPStatus = 200
 	// openai-go has no Responses stream accumulator; reuse the harness's SSE
@@ -265,6 +278,7 @@ func (c *goSDKClient) sendOpenAIResponses(ctx context.Context, spec SendSpec) (*
 	if len(sseLines) > 0 {
 		result.RawBody = []byte(sseLines[len(sseLines)-1])
 	}
+	classifyStreamEvents(result)
 	return result, nil
 }
 

--- a/internal/protocoltest/client_subprocess.go
+++ b/internal/protocoltest/client_subprocess.go
@@ -76,6 +76,8 @@ type driverResponse struct {
 	ToolCalls        []driverToolCall     `json:"tool_calls"`
 	Usage            *driverUsage         `json:"usage"`
 	StreamEventCount int                  `json:"stream_event_count"`
+	StreamCompleted  bool                 `json:"stream_completed"`
+	StreamError      *driverStreamError   `json:"stream_error"`
 	RawBody          string               `json:"raw_body"`
 	Error            *driverErrorEnvelope `json:"error"`
 }
@@ -89,6 +91,11 @@ type driverToolCall struct {
 type driverUsage struct {
 	InputTokens  int `json:"input_tokens"`
 	OutputTokens int `json:"output_tokens"`
+}
+
+type driverStreamError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
 }
 
 // driverErrorEnvelope carries an in-band gateway/API error.
@@ -152,6 +159,10 @@ func (c *subprocessClient) Send(env *TestEnv, spec SendSpec) (*RoundTripResult, 
 	result.FinishReason = resp.FinishReason
 	result.ThinkingContent = resp.Thinking
 	result.RawBody = []byte(resp.RawBody)
+	result.StreamCompleted = resp.StreamCompleted
+	if resp.StreamError != nil {
+		result.StreamError = resp.StreamError.Message
+	}
 	for _, tc := range resp.ToolCalls {
 		result.ToolCalls = append(result.ToolCalls, ToolCallResult{ID: tc.ID, Name: tc.Name, Arguments: tc.Arguments})
 	}
@@ -166,6 +177,9 @@ func (c *subprocessClient) Send(env *TestEnv, spec SendSpec) (*RoundTripResult, 
 	if resp.Error != nil {
 		if resp.Error.Status != 0 {
 			result.HTTPStatus = resp.Error.Status
+		}
+		if spec.Streaming && result.HTTPStatus == 200 && result.StreamError == "" {
+			result.StreamError = resp.Error.Message
 		}
 		if len(result.RawBody) == 0 {
 			result.RawBody = []byte(resp.Error.Message)

--- a/internal/protocoltest/client_subprocess_test.go
+++ b/internal/protocoltest/client_subprocess_test.go
@@ -72,6 +72,9 @@ func TestSubprocessClient_Contract(t *testing.T) {
 	if len(res.StreamEvents) != 4 {
 		t.Errorf("stream_event_count: got %d, want 4", len(res.StreamEvents))
 	}
+	if res.StreamError != "upstream truncated" || res.StreamCompleted {
+		t.Errorf("stream outcome: error=%q completed=%v", res.StreamError, res.StreamCompleted)
+	}
 	if string(res.RawBody) != "stub raw body" {
 		t.Errorf("raw_body: got %q", res.RawBody)
 	}

--- a/internal/protocoltest/matrix.go
+++ b/internal/protocoltest/matrix.go
@@ -352,7 +352,8 @@ func scenarioSupportsStreaming(s Scenario) bool {
 // scenarioRequiresStreaming returns true if the scenario has streaming-specific assertions.
 func scenarioRequiresStreaming(s Scenario) bool {
 	for _, a := range s.Assertions {
-		if strings.Contains(a.Name, "stream_event_count") {
+		if strings.Contains(a.Name, "stream_event_count") ||
+			a.Name == "stream_error" || a.Name == "stream_not_completed" {
 			return true
 		}
 	}

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -426,6 +426,7 @@ func (env *TestEnv) dispatch(source, target protocol.APIType, scenarioName, path
 		parsed = parseFromJSON(raw, sourceToStyle(source))
 	}
 	fillFromParsedResult(result, parsed)
+	classifyStreamEvents(result)
 
 	return result, nil
 }

--- a/internal/server/module/mcp/generic_stream_interceptor.go
+++ b/internal/server/module/mcp/generic_stream_interceptor.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -19,6 +20,8 @@ import (
 const (
 	defaultMaxRounds = 3
 )
+
+var errTruncatedStream = errors.New("upstream stream truncated")
 
 // GenericStreamInterceptor implements format-agnostic streaming MCP tool handling
 type GenericStreamInterceptor struct {
@@ -127,6 +130,17 @@ func (i *GenericStreamInterceptor) Run(req any) error {
 		response, err := i.consumeRound(stream)
 		stream.Close()
 		if err != nil {
+			if errors.Is(err, errTruncatedStream) {
+				payload, _ := json.Marshal(map[string]interface{}{
+					"type": "error",
+					"error": map[string]interface{}{
+						"type":    "stream_error",
+						"message": err.Error(),
+						"code":    "upstream_truncated",
+					},
+				})
+				return i.adapter.SendEvent(i.c, "error", payload)
+			}
 			return err
 		}
 
@@ -244,6 +258,13 @@ func (i *GenericStreamInterceptor) consumeRound(stream StreamHandle) (any, error
 	if err != nil {
 		return nil, fmt.Errorf("stream error: %w", err)
 	}
+	if i.seenMessageStart && i.roundMessageStop == nil {
+		return nil, fmt.Errorf("%w: anthropic stream ended without message_stop", errTruncatedStream)
+	}
+	if i.roundOpenAI != nil && len(i.roundOpenAI.Choices) > 0 &&
+		i.roundOpenAI.Choices[0].FinishReason == "" {
+		return nil, fmt.Errorf("%w: chat stream ended without a finish reason", errTruncatedStream)
+	}
 
 	// Build complete response from accumulated state
 	return i.roundResponse(), nil
@@ -282,21 +303,33 @@ func (i *GenericStreamInterceptor) roundResponse() any {
 func (i *GenericStreamInterceptor) accumulateRoundEvent(event any) {
 	switch e := event.(type) {
 	case anthropic.MessageStreamEventUnion:
+		if e.Type == "message_start" {
+			i.seenMessageStart = true
+		}
 		if i.roundAnthropicV1 == nil {
 			i.roundAnthropicV1 = &anthropic.Message{}
 		}
 		i.roundAnthropicV1.Accumulate(e)
 	case *anthropic.MessageStreamEventUnion:
+		if e != nil && e.Type == "message_start" {
+			i.seenMessageStart = true
+		}
 		if i.roundAnthropicV1 == nil {
 			i.roundAnthropicV1 = &anthropic.Message{}
 		}
 		i.roundAnthropicV1.Accumulate(*e)
 	case anthropic.BetaRawMessageStreamEventUnion:
+		if e.Type == "message_start" {
+			i.seenMessageStart = true
+		}
 		if i.roundAnthropicBeta == nil {
 			i.roundAnthropicBeta = &anthropic.BetaMessage{}
 		}
 		i.roundAnthropicBeta.Accumulate(e)
 	case *anthropic.BetaRawMessageStreamEventUnion:
+		if e != nil && e.Type == "message_start" {
+			i.seenMessageStart = true
+		}
 		if i.roundAnthropicBeta == nil {
 			i.roundAnthropicBeta = &anthropic.BetaMessage{}
 		}

--- a/tests/clients/aisdk/driver.mjs
+++ b/tests/clients/aisdk/driver.mjs
@@ -151,6 +151,9 @@ async function runStream(req, model) {
       case "finish":
         finishReason = part.finishReason ?? "";
         usage = mapUsage(part.totalUsage);
+        if ((finishReason === "error" || finishReason === "unknown") && streamError === null) {
+          streamError = new Error(`AI SDK reported ${finishReason} instead of a normal finish reason`);
+        }
         break;
       case "error":
         streamError = part.error;
@@ -180,6 +183,13 @@ async function runStream(req, model) {
     tool_calls: toolCalls,
     usage,
     stream_event_count: count,
+    stream_completed: streamError === null && finishReason !== "",
+    stream_error: streamError
+      ? {
+          type: unwrapError(streamError)?.name ?? "StreamError",
+          message: String(unwrapError(streamError)?.message ?? streamError),
+        }
+      : undefined,
     raw_body: content,
   };
 }

--- a/tests/clients/node/driver.mjs
+++ b/tests/clients/node/driver.mjs
@@ -17,6 +17,20 @@ function toolCall(id, name, args) {
   return { id, name, arguments: args };
 }
 
+function streamErrorResponse(count, content, error) {
+  return {
+    http_status: 200,
+    content,
+    stream_event_count: count,
+    stream_completed: false,
+    raw_body: String(error?.message ?? error),
+    stream_error: {
+      type: error?.name ?? "StreamError",
+      message: String(error?.message ?? error),
+    },
+  };
+}
+
 // ── Anthropic (v1 + beta) ────────────────────────────────────────────────────
 
 function normalizeAnthropicMessage(msg) {
@@ -71,6 +85,7 @@ async function runAnthropic(req, beta) {
     const msg = await stream.finalMessage();
     const resp = normalizeAnthropicMessage(msg);
     resp.stream_event_count = count;
+    resp.stream_completed = true;
     return resp;
   } catch (e) {
     if (isAPIError(e)) return apiErrorResponse(e);
@@ -120,22 +135,27 @@ async function runOpenAIChat(req, client) {
   let finish = "";
   let model = "";
   const tools = new Map();
-  for await (const chunk of stream) {
-    count++;
-    model = chunk.model || model;
-    const choice = chunk.choices?.[0];
-    if (!choice) continue;
-    const delta = choice.delta ?? {};
-    role = delta.role || role;
-    content += delta.content ?? "";
-    for (const tc of delta.tool_calls ?? []) {
-      const slot = tools.get(tc.index) ?? { id: "", name: "", arguments: "" };
-      if (tc.id) slot.id = tc.id;
-      if (tc.function?.name) slot.name = tc.function.name;
-      slot.arguments += tc.function?.arguments ?? "";
-      tools.set(tc.index, slot);
+  try {
+    for await (const chunk of stream) {
+      count++;
+      model = chunk.model || model;
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+      const delta = choice.delta ?? {};
+      role = delta.role || role;
+      content += delta.content ?? "";
+      for (const tc of delta.tool_calls ?? []) {
+        const slot = tools.get(tc.index) ?? { id: "", name: "", arguments: "" };
+        if (tc.id) slot.id = tc.id;
+        if (tc.function?.name) slot.name = tc.function.name;
+        slot.arguments += tc.function?.arguments ?? "";
+        tools.set(tc.index, slot);
+      }
+      finish = choice.finish_reason || finish;
     }
-    finish = choice.finish_reason || finish;
+  } catch (e) {
+    if (isAPIError(e) || count === 0) throw e;
+    return streamErrorResponse(count, content, e);
   }
   const toolCalls = [...tools.entries()]
     .sort((a, b) => a[0] - b[0])
@@ -150,6 +170,7 @@ async function runOpenAIChat(req, client) {
     tool_calls: toolCalls,
     usage: null,
     stream_event_count: count,
+    stream_completed: true,
     raw_body: content,
   };
 }
@@ -193,32 +214,31 @@ async function runOpenAIResponses(req, client) {
   let count = 0;
   let final = null;
   let deltaText = "";
-  for await (const event of stream) {
-    count++;
-    if (event.type === "response.completed" || event.type === "response.incomplete") {
-      final = event.response;
-    } else if (event.type === "response.output_text.delta") {
-      deltaText += event.delta ?? "";
+  try {
+    for await (const event of stream) {
+      count++;
+      if (event.type === "response.completed" || event.type === "response.incomplete") {
+        final = event.response;
+      } else if (event.type === "response.output_text.delta") {
+        deltaText += event.delta ?? "";
+      }
     }
+  } catch (e) {
+    if (isAPIError(e) || count === 0) throw e;
+    return streamErrorResponse(count, deltaText, e);
   }
   let resp;
   if (final) {
     resp = normalizeResponse(final);
   } else {
-    // Stream cut before a terminal event (midstream-close).
-    resp = {
-      http_status: 200,
-      role: "assistant",
-      content: deltaText,
-      model: "",
-      finish_reason: "",
-      thinking: "",
-      tool_calls: [],
-      usage: null,
-      raw_body: deltaText,
-    };
+    return streamErrorResponse(
+      count,
+      deltaText,
+      new Error("responses stream ended without a terminal event"),
+    );
   }
   resp.stream_event_count = count;
+  resp.stream_completed = true;
   return resp;
 }
 

--- a/tests/clients/python/driver.py
+++ b/tests/clients/python/driver.py
@@ -32,6 +32,21 @@ def tool_call(id_, name, arguments):
     return {"id": id_, "name": name, "arguments": arguments}
 
 
+def stream_error_response(count, content, error):
+    """Report an error after a stream started without breaking the driver."""
+    return {
+        "http_status": 200,
+        "content": content,
+        "stream_event_count": count,
+        "stream_completed": False,
+        "raw_body": str(error),
+        "stream_error": {
+            "type": type(error).__name__,
+            "message": str(error),
+        },
+    }
+
+
 # ── Anthropic (v1 + beta) ────────────────────────────────────────────────────
 
 
@@ -100,15 +115,14 @@ def run_anthropic(req, beta):
                 msg = stream.get_final_message()
             resp = normalize_anthropic_message(msg)
             resp["stream_event_count"] = count
+            resp["stream_completed"] = True
             return resp
         except anthropic.APIStatusError:
             raise
         except Exception as e:
             # Mid-stream error event (truncated upstream): the SDK raised; the
             # turn was not completed. Report it in-band rather than crashing.
-            return {"http_status": 200, "stream_event_count": count,
-                    "raw_body": str(e),
-                    "error": {"status": 0, "type": type(e).__name__, "message": str(e)}}
+            return stream_error_response(count, "", e)
     except anthropic.APIStatusError as e:
         return api_error_response(e)
 
@@ -159,25 +173,32 @@ def run_openai_chat(req, client):
         model = ""
         # tool calls accumulate by index, like the Go ChatCompletionAccumulator
         tools = {}
-        for chunk in client.chat.completions.create(stream=True, **kwargs):
-            count += 1
-            model = chunk.model or model
-            if not chunk.choices:
-                continue
-            choice = chunk.choices[0]
-            delta = choice.delta
-            if delta is not None:
-                role = delta.role or role
-                content += delta.content or ""
-                for tc in delta.tool_calls or []:
-                    slot = tools.setdefault(tc.index, {"id": "", "name": "", "arguments": ""})
-                    if tc.id:
-                        slot["id"] = tc.id
-                    if tc.function is not None:
-                        if tc.function.name:
-                            slot["name"] = tc.function.name
-                        slot["arguments"] += tc.function.arguments or ""
-            finish = choice.finish_reason or finish
+        try:
+            for chunk in client.chat.completions.create(stream=True, **kwargs):
+                count += 1
+                model = chunk.model or model
+                if not chunk.choices:
+                    continue
+                choice = chunk.choices[0]
+                delta = choice.delta
+                if delta is not None:
+                    role = delta.role or role
+                    content += delta.content or ""
+                    for tc in delta.tool_calls or []:
+                        slot = tools.setdefault(tc.index, {"id": "", "name": "", "arguments": ""})
+                        if tc.id:
+                            slot["id"] = tc.id
+                        if tc.function is not None:
+                            if tc.function.name:
+                                slot["name"] = tc.function.name
+                            slot["arguments"] += tc.function.arguments or ""
+                finish = choice.finish_reason or finish
+        except openai.APIStatusError:
+            raise
+        except Exception as e:
+            if count == 0:
+                raise
+            return stream_error_response(count, content, e)
         tool_calls = [
             tool_call(t["id"], t["name"], t["arguments"])
             for _, t in sorted(tools.items())
@@ -192,6 +213,7 @@ def run_openai_chat(req, client):
             "tool_calls": tool_calls,
             "usage": None,
             "stream_event_count": count,
+            "stream_completed": True,
             "raw_body": content,
         }
     except openai.APIStatusError as e:
@@ -244,30 +266,30 @@ def run_openai_responses(req, client):
         count = 0
         final = None
         delta_text = ""
-        for event in client.responses.create(stream=True, **kwargs):
-            count += 1
-            etype = getattr(event, "type", "")
-            if etype in ("response.completed", "response.incomplete"):
-                final = event.response
-            elif etype == "response.output_text.delta":
-                delta_text += event.delta or ""
+        try:
+            for event in client.responses.create(stream=True, **kwargs):
+                count += 1
+                etype = getattr(event, "type", "")
+                if etype in ("response.completed", "response.incomplete"):
+                    final = event.response
+                elif etype == "response.output_text.delta":
+                    delta_text += event.delta or ""
+        except openai.APIStatusError:
+            raise
+        except Exception as e:
+            if count == 0:
+                raise
+            return stream_error_response(count, delta_text, e)
         if final is not None:
             resp = normalize_response(final)
         else:
-            # Stream was cut before a terminal event (midstream-close):
-            # report what was accumulated from deltas.
-            resp = {
-                "http_status": 200,
-                "role": "assistant",
-                "content": delta_text,
-                "model": "",
-                "finish_reason": "",
-                "thinking": "",
-                "tool_calls": [],
-                "usage": None,
-                "raw_body": delta_text,
-            }
+            return stream_error_response(
+                count,
+                delta_text,
+                RuntimeError("responses stream ended without a terminal event"),
+            )
         resp["stream_event_count"] = count
+        resp["stream_completed"] = True
         return resp
     except openai.APIStatusError as e:
         return api_error_response(e)

--- a/tests/clients/testdata/stub_driver.sh
+++ b/tests/clients/testdata/stub_driver.sh
@@ -14,5 +14,7 @@ printf '%s\n' '{
   "tool_calls": [{"id": "call_1", "name": "get_weather", "arguments": "{\"location\":\"Paris\"}"}],
   "usage": {"input_tokens": 10, "output_tokens": 8},
   "stream_event_count": 4,
+  "stream_completed": false,
+  "stream_error": {"type": "StreamError", "message": "upstream truncated"},
   "raw_body": "stub raw body"
 }'

--- a/vmodel/benchmark/check/assert.go
+++ b/vmodel/benchmark/check/assert.go
@@ -212,6 +212,35 @@ func AssertStreamEventCount(min int) Assertion {
 	}
 }
 
+// AssertStreamError returns an Assertion that a streaming client explicitly
+// observed an error after the response had started.
+func AssertStreamError() Assertion {
+	return Assertion{
+		Name: "stream_error",
+		Check: func(r *RoundTripResult) error {
+			if r.StreamError == "" {
+				return fmt.Errorf("stream ended without a reported error")
+			}
+			return nil
+		},
+	}
+}
+
+// AssertStreamNotCompleted returns an Assertion that no normal completion
+// marker was observed. Error events and a clean terminal event are deliberately
+// separate states: a truncated turn must never be presented as completed.
+func AssertStreamNotCompleted() Assertion {
+	return Assertion{
+		Name: "stream_not_completed",
+		Check: func(r *RoundTripResult) error {
+			if r.StreamCompleted {
+				return fmt.Errorf("stream was marked completed despite the expected failure")
+			}
+			return nil
+		},
+	}
+}
+
 // AssertHTTPStatusAtLeast returns an Assertion that the HTTP status code is >= min.
 func AssertHTTPStatusAtLeast(min int) Assertion {
 	return Assertion{

--- a/vmodel/benchmark/check/assert_test.go
+++ b/vmodel/benchmark/check/assert_test.go
@@ -74,3 +74,21 @@ func TestAssertFinishReasonOneOf(t *testing.T) {
 		t.Fatal("expected failure for unaccepted finish reason")
 	}
 }
+
+func TestAssertStreamFailure(t *testing.T) {
+	truncated := &RoundTripResult{IsStreaming: true, StreamError: "upstream truncated"}
+	if err := AssertStreamError().Check(truncated); err != nil {
+		t.Fatalf("stream_error: %v", err)
+	}
+	if err := AssertStreamNotCompleted().Check(truncated); err != nil {
+		t.Fatalf("stream_not_completed: %v", err)
+	}
+
+	completed := &RoundTripResult{IsStreaming: true, StreamCompleted: true}
+	if err := AssertStreamError().Check(completed); err == nil {
+		t.Fatal("expected missing stream error to fail")
+	}
+	if err := AssertStreamNotCompleted().Check(completed); err == nil {
+		t.Fatal("expected completed stream to fail")
+	}
+}

--- a/vmodel/benchmark/check/result.go
+++ b/vmodel/benchmark/check/result.go
@@ -37,6 +37,11 @@ type RoundTripResult struct {
 	HTTPStatus   int
 	RawBody      []byte
 	StreamEvents []string // raw SSE event lines (streaming only)
+	// StreamError records a failure reported after streaming had already
+	// started. It is distinct from an HTTP/API error: headers may already have
+	// committed a 200 response while the turn still failed to complete.
+	StreamError     string
+	StreamCompleted bool // true only when a normal completion marker was observed
 
 	// Extracted semantics (populated by the framework after parsing)
 	Content         string

--- a/vmodel/benchmark/scenario/builtins.go
+++ b/vmodel/benchmark/scenario/builtins.go
@@ -690,11 +690,12 @@ func ErrorMidStreamCloseScenario() Scenario {
 		Assertions: []check.Assertion{
 			// A mid-stream cut must be handled gracefully: the response stays
 			// 200 (headers were already sent) and the stream terminates in a
-			// client-consumable way. Anthropic-target paths surface it as an
-			// in-band error event (real SDK clients raise — the turn was
-			// truncated, not completed); OpenAI-target paths end with the
-			// partial content. The gateway must not 5xx or hang either way.
+			// client-consumable way. The client must preserve the events it
+			// already received, report the stream error explicitly, and never
+			// present the truncated turn as normally completed.
 			check.AssertHTTPStatus(200),
+			check.AssertStreamError(),
+			check.AssertStreamNotCompleted(),
 		},
 		Structural: []check.Assertion{
 			check.AssertHTTPStatus(200),


### PR DESCRIPTION
## Summary

Streaming responses that ended without a protocol terminal marker could previously be presented as successful, allowing clients to accept partial text or tool calls. This change preserves the failure across passthrough and protocol-conversion paths and makes the harness verify the behavior using real SDK clients.

## Key Changes

- **Stream lifecycle integrity**: Treat EOF without `message_stop`, `finish_reason`, or a Responses terminal event as a failed turn instead of synthesizing a successful completion.
- **Client-visible failures**: Emit an in-band stream error when response headers have already committed, while withholding normal terminal markers such as `[DONE]`.
- **Protocol conversion safety**: Preserve truncation semantics across Anthropic, OpenAI Chat, and OpenAI Responses conversion paths so partial responses cannot become successful responses during translation.
- **MCP execution safety**: Reject truncated MCP stream rounds before assembling them into complete responses, reducing the risk of consuming incomplete tool calls.
- **Harness outcome model**: Track stream errors separately from HTTP/API errors and record completion only after observing a real protocol terminal marker.
- **SDK compatibility**: Normalize post-header failures from Go, Python, Node, and AI SDK clients without treating expected stream exceptions as broken harness drivers.

## Testing

- Full single-client matrix for raw, Go SDK, Python, Node, and AI SDK: `243 passed`, `45 skipped` per client.
- Verified `error-midstream-close` across all five clients.
- Passed protocol stream, MCP, protocol-test, and benchmark assertion Go tests.
- Passed Python compilation and Node/AI SDK syntax validation.
- Passed Git whitespace validation.

## Notes

- **Post-header status**: Mid-stream failures retain HTTP 200 because the response headers are already committed; callers must use the stream error and absence of a completion marker to determine the turn outcome.
- **Partial output**: Clients may have rendered partial text before receiving the error. They must not execute incomplete tool calls or treat the turn as successfully completed.