### PR TITLE
feat(remote): Add Claude Code profile selection for remote @cc execution

### DIFF
--- a/.design/remote-cc-profile.md
+++ b/.design/remote-cc-profile.md
@@ -40,22 +40,44 @@ on the @tb branch.
 
 ## 3. Execution path (reuse, not reimplementation)
 
+**Why env vars alone don't work.** The main scenario's routing has always
+been injected as process env vars (`ExecutionOptions.Env`) because Claude
+Code CLI, given no `--settings` flag, reads `~/.claude/settings.json` and
+those values happen to match (both derived from the same rules via Quick
+Config). A profile is different: its routing/models/overrides live in a
+*separate* derived file (`~/.tingly-box/claude/<id>--<name>/settings.json`),
+and the CLI's `--settings <path>` flag **replaces** `~/.claude/settings.json`
+rather than merging with it. So a profile selection only takes effect if that
+file is materialized and referenced via `--settings` — injecting its values
+as process env instead is silently ignored, because with no `--settings`
+flag the CLI still reads the main settings file, whose values win. (This is
+also why `BuildCCProfileSettings` copies the user's main settings.json as a
+base before layering the profile's deltas on top — nothing else backs it.)
+
 `ClaudeCodeExecutor.Execute`:
 
 1. Reads the bot setting via `deps.GetBotSetting()` (dynamic, straight from the
    store) and extracts the profile with `BotSetting.CCProfileID()` — so a
    profile switch in the web UI applies from the next message, no bot restart.
-2. Calls `TBClient.GetClaudeCodeEnvForProfile(ctx, profileID)`:
-   - `profileID == ""` → the existing `GetClaudeCodeEnv` (main scenario).
-   - otherwise → `agent.ResolveCCProfileSettings(...)` with the profiled
-     scenario path — the **same** resolution `tingly-box cc --profile` uses, so
-     remote and local launches produce identical env: `ANTHROPIC_BASE_URL`
-     pointing at `/tingly/claude_code:<id>`, tier models from the profile's
-     builtin rules, the profile's unified/separate mode, and its persisted env
-     overrides.
-3. If the profile cannot be resolved (deleted after selection), the executor
+2. If a profile is selected, calls
+   `TBClient.GetClaudeCodeSettingsPathForProfile(ctx, profileID)`, which
+   materializes the profile's settings.json via
+   `agent.MaterializeCCProfileSettings(...)` — the **same** on-disk artifact
+   and resolution `tingly-box cc --profile` produces — and returns its path.
+   That path is passed as `ExecutionOptions.SettingsPath`, which
+   `agentboot/claude`'s CLI builder turns into `--settings <path>` — the exact
+   mechanism the local launch uses.
+3. If no profile is selected (or profile materialization fails), falls back to
+   `TBClient.GetClaudeCodeEnv(ctx)` → `ExecutionOptions.Env` (the pre-existing
+   main-scenario mechanism, unchanged).
+4. If the profile cannot be resolved (deleted after selection), the executor
    warns in-chat and falls back to the main scenario for that run instead of
    failing or silently rerouting.
+
+`Env` and `SettingsPath` are mutually exclusive per run: a resolved profile
+sets only `SettingsPath` (mirroring the local CLI's `os.Environ()` passthrough
++ `--settings`, no extra env injected); the main-scenario fallback sets only
+`Env`.
 
 The status line ("⏳ CC: Processing new session... (profile: p1)") and the
 execution log both carry the profile so runs are attributable.

--- a/.design/remote-cc-profile.md
+++ b/.design/remote-cc-profile.md
@@ -6,137 +6,119 @@
 
 ---
 
-## 1. Problem
+## 1. The selection: `default_agent`
 
-Claude Code supports named profiles ("claude_code:p1" scenarios with their own
-routing rules, unified/separate mode, and settings-env overrides), and the
-local launcher already honors them (`tingly-box cc --profile p1`). The remote
-agent, however, was hard-wired to the main `claude_code` scenario:
-`ClaudeCodeExecutor` always called `TBClient.GetClaudeCodeEnv`, so a user could
-not pick a profile to serve @cc duty for a bot.
-
-## 2. The selection: `default_agent`
-
-Bot settings already carried a dormant `default_agent` column (DB → API →
-generated frontend types) from the retired RemoteGraph design. It is now the
-single field that answers "which agent configuration serves @cc for this bot":
+Each bot's `default_agent` setting answers "which Claude Code configuration
+serves @cc for this bot":
 
 | value                  | meaning                                   |
 |------------------------|-------------------------------------------|
 | `""` / `claude_code`   | main claude_code scenario (default)       |
 | `claude_code:<id>`     | the Claude Code profile `<id>`            |
 
-- The value reuses the backend's profiled-scenario naming
+- The value is the backend's standard profiled-scenario naming
   (`typ.ProfiledScenarioName` / `typ.ParseScenarioProfile`) — no new grammar.
-- `internal/server/module/imbot` validates it on create/update: unknown bases
-  and non-existent profiles are rejected with 400, so a typo cannot silently
-  fall back at execution time.
-- Clearing = writing the explicit base value `claude_code` (the settings store
-  skips empty strings on partial update, so "" cannot be persisted back).
+- `internal/server/module/imbot`'s `validateDefaultAgent` rejects unknown
+  bases and non-existent profile IDs on create/update (400), so a typo cannot
+  silently no-op at execution time.
+- Clearing writes the explicit base value `claude_code`, not `""` — a
+  concrete value reads clearly in raw settings/logs (ux-principles.md §5,
+  "show the concrete value, not the alias").
 
 Selection is **per bot**, matching where the @cc branch is configured (the
-Remote page's per-bot card), and mirroring the per-bot SmartGuide model config
-on the @tb branch.
+Remote page's per-bot card), mirroring the per-bot SmartGuide model config on
+the @tb branch. There is no per-chat override — one bot routes @cc through
+one profile.
 
-## 3. Execution path (reuse, not reimplementation)
+## 2. Execution: `ClaudeCodeExecutor.Execute`
 
-**Why env vars alone don't work.** The main scenario's routing has always
-been injected as process env vars (`ExecutionOptions.Env`) because Claude
-Code CLI, given no `--settings` flag, reads `~/.claude/settings.json` and
-those values happen to match (both derived from the same rules via Quick
-Config). A profile is different: its routing/models/overrides live in a
-*separate* derived file (`~/.tingly-box/claude/<id>--<name>/settings.json`),
-and the CLI's `--settings <path>` flag **replaces** `~/.claude/settings.json`
-rather than merging with it. So a profile selection only takes effect if that
-file is materialized and referenced via `--settings` — injecting its values
-as process env instead is silently ignored, because with no `--settings`
-flag the CLI still reads the main settings file, whose values win. (This is
-also why `BuildCCProfileSettings` copies the user's main settings.json as a
-base before layering the profile's deltas on top — nothing else backs it.)
-
-`ClaudeCodeExecutor.Execute`:
-
-1. Reads the bot setting via `deps.GetBotSetting()` (dynamic, straight from the
-   store) and extracts the profile with `BotSetting.CCProfileID()` — so a
-   profile switch in the web UI applies from the next message, no bot restart.
+1. Reads the bot setting via `deps.GetBotSetting()` (a live store read on
+   every message, not a cached value) and extracts the profile with
+   `BotSetting.CCProfileID()` — a profile switch in the web UI applies from
+   the chat's next message, no bot restart needed.
 2. If a profile is selected, calls
    `TBClient.GetClaudeCodeSettingsPathForProfile(ctx, profileID)`, which
    materializes the profile's settings.json via
-   `agent.MaterializeCCProfileSettings(...)` — the **same** on-disk artifact
-   and resolution `tingly-box cc --profile` produces — and returns its path.
-   That path is passed as `ExecutionOptions.SettingsPath`, which
-   `agentboot/claude`'s CLI builder turns into `--settings <path>` — the exact
-   mechanism the local launch uses.
-3. If no profile is selected (or profile materialization fails), falls back to
-   `TBClient.GetClaudeCodeEnv(ctx)` → `ExecutionOptions.Env` (the pre-existing
-   main-scenario mechanism, unchanged).
-4. If the profile cannot be resolved (deleted after selection), the executor
-   warns in-chat and falls back to the main scenario for that run instead of
-   failing or silently rerouting.
+   `agent.MaterializeCCProfileSettings(...)` — the same on-disk artifact and
+   resolution `tingly-box cc --profile <id>` produces — and returns its path.
+   That path becomes `ExecutionOptions.SettingsPath`, which
+   `agentboot/claude`'s CLI builder turns into a `--settings <path>` flag —
+   the same mechanism the local launch uses.
+3. With no profile selected (or if materialization fails), falls back to
+   `TBClient.GetClaudeCodeEnv(ctx)` → `ExecutionOptions.Env` (the main
+   scenario's routing, injected as process env vars).
+4. If the selected profile can no longer be resolved (e.g. deleted after
+   selection), the executor warns in-chat and runs that message against the
+   main scenario instead of failing or silently misrouting.
 
 `Env` and `SettingsPath` are mutually exclusive per run: a resolved profile
-sets only `SettingsPath` (mirroring the local CLI's `os.Environ()` passthrough
-+ `--settings`, no extra env injected); the main-scenario fallback sets only
-`Env`.
+sets only `SettingsPath` (mirroring the local CLI's plain `os.Environ()`
+passthrough + `--settings`, no extra env injected); the main-scenario path
+sets only `Env`.
+
+**Why a profile needs `--settings` rather than env vars.** Claude Code's
+`--settings <path>` flag *replaces* `~/.claude/settings.json` rather than
+merging with it. The main scenario's routing works as plain env vars because,
+with no `--settings` flag, the CLI reads `~/.claude/settings.json` and those
+values already match (both derived from the same rules via Quick Config). A
+profile's routing/models/overrides live in a separate derived file
+(`~/.tingly-box/claude/<id>--<name>/settings.json`); injecting them as env
+vars instead of referencing that file has no effect, because the CLI still
+loads the main settings file, whose values win. This is also why
+`BuildCCProfileSettings` copies the user's main settings.json as a base
+before layering the profile's deltas on top — nothing else backs it.
 
 The status line ("⏳ CC: Processing new session... (profile: p1)") and the
-execution log both carry the profile so runs are attributable.
+execution log both carry the profile ID so runs are attributable.
 
-## 4. Frontend surface
+## 3. Frontend surface
 
-The Remote page's per-bot graph grows a node on the @cc branch:
+The Remote page's per-bot graph carries a node on the @cc branch:
 
 ```
 @cc → [Agent: Claude Code] → [Profile: Default | <name>]
 ```
 
 - `CCProfileNode` shows the resolved profile name ("Default" when none;
-  warning styling when the selected profile no longer exists).
-- Clicking the Profile node opens `CCProfileDialog`: Default + all profiles
-  from `ProfileContext` (`GET /scenario/claude_code/profiles`), one tap to
-  switch — writes `default_agent` via the existing imbot update API.
-- No codegen was needed: `default_agent` was already in the OpenAPI schema.
-- The Claude Code `AgentNode` itself is **not** clickable (matches the
-  SmartGuide agent node). It used to navigate to `/agent/claude_code`, but
-  now that the adjacent Profile node is the actual next action for this
-  branch, a second competing click target on the agent node itself would
-  fight the same UX principle that motivated the Profile node in the first
-  place — so it was removed, and the node's hover tooltip points at the
-  Profile node instead of the stale "click to configure" copy.
+  warning styling when the selected profile no longer exists). It is the only
+  clickable target on this branch — clicking it opens `CCProfileDialog`
+  (Default + all profiles from `ProfileContext`,
+  `GET /scenario/claude_code/profiles`), one tap to switch, writing
+  `default_agent` via the existing imbot update API.
+- The Claude Code `AgentNode` itself is informational, not clickable — same
+  as the SmartGuide agent node on the @tb branch. The Profile node is the
+  branch's one actionable next step; a second click target on the agent node
+  would compete with it.
+- `default_agent` was already present in the OpenAPI schema, so no codegen
+  was needed for this feature.
 
-### 4.1 AgentNode hover tooltip: hysteresis over hand-rolled timers
+### 3.1 AgentNode's hover tooltip
 
-`AgentNode` (both the @tb/SmartGuide and @cc/Claude Code nodes) originally
-built its own hover popover: a manual `open` boolean, a `setTimeout`-based
-enter delay, and separate `onMouseEnter`/`onMouseLeave` handlers on both the
-anchor and the popover's `Paper` (so moving the pointer from one to the other
-didn't close it). Two problems surfaced once the content grew long enough to
-occasionally collide with the viewport edge:
+`AgentNode` (both the @tb/SmartGuide and @cc/Claude Code nodes) uses
+`NodeTooltip` — the shared MUI `Tooltip` wrapper also used by
+`BotModelNode`/`CCProfileNode` — rather than a custom hover popover. Two
+properties of this specific component matter here:
 
-1. **Flicker.** MUI's `Popover` repositions itself to stay on-screen; when
-   that shift happened under the cursor, the close was instant (no leave
-   delay) while re-open waited out the enter timer again, so the popover
-   visibly opened/closed in a loop.
-2. **Washed-out text.** The popover's `Typography` used the `body2`/`caption`
-   variants, whose colors (`text.secondary` / `text.disabled`) are baked into
-   this app's theme (`theme/base.ts`) for normal page backgrounds — not for
-   sitting on the popover's own dark surface, where they read as
-   unintentionally dim.
+- **Hysteresis, not hand-rolled timers.** `NodeTooltip` has built-in
+  enter/leave delays and never repositions itself under the pointer, so
+  passing quickly over a node or across its edge doesn't cause the tooltip to
+  flicker open/closed.
+- **Inherited text color.** Every line inside the tooltip content sets
+  `color: 'inherit'` explicitly. This app's theme (`theme/base.ts`) bakes a
+  fixed color into the `body2`/`caption` typography variants
+  (`text.secondary` / `text.disabled`) for normal page backgrounds; left at
+  their variant default inside the tooltip's own (differently-colored)
+  surface, that reads as unintentionally washed-out. `color: 'inherit'` makes
+  every line take the tooltip's own text color instead.
 
-Fix: replace the hand-rolled popover with `NodeTooltip` (the shared MUI
-`Tooltip` wrapper `BotModelNode`/`CCProfileNode` already use), which has
-built-in enter/leave hysteresis and doesn't reposition under the pointer, so
-it structurally can't fall into that loop. Every line of tooltip content now
-sets `color: 'inherit'` so it takes the tooltip's own text color rather than
-a page-tuned theme variant color. The copy itself was also trimmed (5 feature
-bullets → 3, shorter description) so the tooltip rarely needs to reposition
-in the first place.
+Tooltip copy is kept short (3 feature bullets, one description line, one
+config hint) so it fits without needing to reposition.
 
-## 5. Non-goals / future
+## 4. Non-goals / future
 
 - Per-chat override (e.g. a `/profile` bot command) is deliberately out of
   scope; the bot-level selection covers the "one bot = one working set" model.
   If needed later, a chat-level field can shadow the bot default.
-- Other agents in `default_agent` (codex etc.) — the validation currently
-  whitelists only `claude_code[.:<profile>]`; extend `validateDefaultAgent`
-  and the executor routing when a second remote agent lands.
+- Other agents in `default_agent` (codex etc.) — `validateDefaultAgent`
+  currently whitelists only `claude_code[.:<profile>]`; extend it and the
+  executor routing when a second remote agent lands.

--- a/.design/remote-cc-profile.md
+++ b/.design/remote-cc-profile.md
@@ -1,0 +1,85 @@
+# Remote @cc Profile Selection
+
+> Audience: contributors touching the remote-control bot (@cc execution) or
+> Claude Code profiles. Records how a bot's @cc branch is pointed at a Claude
+> Code profile and how remote execution reuses the profile launch logic.
+
+---
+
+## 1. Problem
+
+Claude Code supports named profiles ("claude_code:p1" scenarios with their own
+routing rules, unified/separate mode, and settings-env overrides), and the
+local launcher already honors them (`tingly-box cc --profile p1`). The remote
+agent, however, was hard-wired to the main `claude_code` scenario:
+`ClaudeCodeExecutor` always called `TBClient.GetClaudeCodeEnv`, so a user could
+not pick a profile to serve @cc duty for a bot.
+
+## 2. The selection: `default_agent`
+
+Bot settings already carried a dormant `default_agent` column (DB → API →
+generated frontend types) from the retired RemoteGraph design. It is now the
+single field that answers "which agent configuration serves @cc for this bot":
+
+| value                  | meaning                                   |
+|------------------------|-------------------------------------------|
+| `""` / `claude_code`   | main claude_code scenario (default)       |
+| `claude_code:<id>`     | the Claude Code profile `<id>`            |
+
+- The value reuses the backend's profiled-scenario naming
+  (`typ.ProfiledScenarioName` / `typ.ParseScenarioProfile`) — no new grammar.
+- `internal/server/module/imbot` validates it on create/update: unknown bases
+  and non-existent profiles are rejected with 400, so a typo cannot silently
+  fall back at execution time.
+- Clearing = writing the explicit base value `claude_code` (the settings store
+  skips empty strings on partial update, so "" cannot be persisted back).
+
+Selection is **per bot**, matching where the @cc branch is configured (the
+Remote page's per-bot card), and mirroring the per-bot SmartGuide model config
+on the @tb branch.
+
+## 3. Execution path (reuse, not reimplementation)
+
+`ClaudeCodeExecutor.Execute`:
+
+1. Reads the bot setting via `deps.GetBotSetting()` (dynamic, straight from the
+   store) and extracts the profile with `BotSetting.CCProfileID()` — so a
+   profile switch in the web UI applies from the next message, no bot restart.
+2. Calls `TBClient.GetClaudeCodeEnvForProfile(ctx, profileID)`:
+   - `profileID == ""` → the existing `GetClaudeCodeEnv` (main scenario).
+   - otherwise → `agent.ResolveCCProfileSettings(...)` with the profiled
+     scenario path — the **same** resolution `tingly-box cc --profile` uses, so
+     remote and local launches produce identical env: `ANTHROPIC_BASE_URL`
+     pointing at `/tingly/claude_code:<id>`, tier models from the profile's
+     builtin rules, the profile's unified/separate mode, and its persisted env
+     overrides.
+3. If the profile cannot be resolved (deleted after selection), the executor
+   warns in-chat and falls back to the main scenario for that run instead of
+   failing or silently rerouting.
+
+The status line ("⏳ CC: Processing new session... (profile: p1)") and the
+execution log both carry the profile so runs are attributable.
+
+## 4. Frontend surface
+
+The Remote page's per-bot graph grows a node on the @cc branch:
+
+```
+@cc → [Agent: Claude Code] → [Profile: Default | <name>]
+```
+
+- `CCProfileNode` shows the resolved profile name ("Default" when none;
+  warning styling when the selected profile no longer exists).
+- Clicking opens `CCProfileDialog`: Default + all profiles from
+  `ProfileContext` (`GET /scenario/claude_code/profiles`), one tap to switch —
+  writes `default_agent` via the existing imbot update API.
+- No codegen was needed: `default_agent` was already in the OpenAPI schema.
+
+## 5. Non-goals / future
+
+- Per-chat override (e.g. a `/profile` bot command) is deliberately out of
+  scope; the bot-level selection covers the "one bot = one working set" model.
+  If needed later, a chat-level field can shadow the bot default.
+- Other agents in `default_agent` (codex etc.) — the validation currently
+  whitelists only `claude_code[.:<profile>]`; extend `validateDefaultAgent`
+  and the executor routing when a second remote agent lands.

--- a/.design/remote-cc-profile.md
+++ b/.design/remote-cc-profile.md
@@ -92,10 +92,45 @@ The Remote page's per-bot graph grows a node on the @cc branch:
 
 - `CCProfileNode` shows the resolved profile name ("Default" when none;
   warning styling when the selected profile no longer exists).
-- Clicking opens `CCProfileDialog`: Default + all profiles from
-  `ProfileContext` (`GET /scenario/claude_code/profiles`), one tap to switch —
-  writes `default_agent` via the existing imbot update API.
+- Clicking the Profile node opens `CCProfileDialog`: Default + all profiles
+  from `ProfileContext` (`GET /scenario/claude_code/profiles`), one tap to
+  switch — writes `default_agent` via the existing imbot update API.
 - No codegen was needed: `default_agent` was already in the OpenAPI schema.
+- The Claude Code `AgentNode` itself is **not** clickable (matches the
+  SmartGuide agent node). It used to navigate to `/agent/claude_code`, but
+  now that the adjacent Profile node is the actual next action for this
+  branch, a second competing click target on the agent node itself would
+  fight the same UX principle that motivated the Profile node in the first
+  place — so it was removed, and the node's hover tooltip points at the
+  Profile node instead of the stale "click to configure" copy.
+
+### 4.1 AgentNode hover tooltip: hysteresis over hand-rolled timers
+
+`AgentNode` (both the @tb/SmartGuide and @cc/Claude Code nodes) originally
+built its own hover popover: a manual `open` boolean, a `setTimeout`-based
+enter delay, and separate `onMouseEnter`/`onMouseLeave` handlers on both the
+anchor and the popover's `Paper` (so moving the pointer from one to the other
+didn't close it). Two problems surfaced once the content grew long enough to
+occasionally collide with the viewport edge:
+
+1. **Flicker.** MUI's `Popover` repositions itself to stay on-screen; when
+   that shift happened under the cursor, the close was instant (no leave
+   delay) while re-open waited out the enter timer again, so the popover
+   visibly opened/closed in a loop.
+2. **Washed-out text.** The popover's `Typography` used the `body2`/`caption`
+   variants, whose colors (`text.secondary` / `text.disabled`) are baked into
+   this app's theme (`theme/base.ts`) for normal page backgrounds — not for
+   sitting on the popover's own dark surface, where they read as
+   unintentionally dim.
+
+Fix: replace the hand-rolled popover with `NodeTooltip` (the shared MUI
+`Tooltip` wrapper `BotModelNode`/`CCProfileNode` already use), which has
+built-in enter/leave hysteresis and doesn't reposition under the pointer, so
+it structurally can't fall into that loop. Every line of tooltip content now
+sets `color: 'inherit'` so it takes the tooltip's own text color rather than
+a page-tuned theme variant color. The copy itself was also trimmed (5 feature
+bullets → 3, shorter description) so the tooltip rarely needs to reposition
+in the first place.
 
 ## 5. Non-goals / future
 

--- a/frontend/src/components/bot/CCProfileDialog.tsx
+++ b/frontend/src/components/bot/CCProfileDialog.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useState } from 'react';
+import {
+    Chip,
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Radio,
+    Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import type { BotSettings } from '@/types/bot';
+import { ccProfileIdFromDefaultAgent } from '@/types/bot';
+import type { ProfileInfo } from '@/contexts/ProfileContext';
+
+interface CCProfileDialogProps {
+    open: boolean;
+    bot: BotSettings | null;
+    profiles: ProfileInfo[];
+    /** Persists the selection; profileId '' = default (main claude_code scenario). */
+    onSelect: (uuid: string, profileId: string) => Promise<void>;
+    onClose: () => void;
+}
+
+// CCProfileDialog picks which Claude Code configuration serves @cc for a bot:
+// the default claude_code scenario or one of the configured profiles. The
+// selection routes remote @cc executions through the profiled scenario with
+// the profile's models and env overrides — same as `tingly-box cc --profile`.
+const CCProfileDialog: React.FC<CCProfileDialogProps> = ({
+    open,
+    bot,
+    profiles,
+    onSelect,
+    onClose,
+}) => {
+    const { t } = useTranslation();
+    const [saving, setSaving] = useState(false);
+
+    const currentId = ccProfileIdFromDefaultAgent(bot?.default_agent);
+
+    const handlePick = useCallback(async (profileId: string) => {
+        if (!bot?.uuid || saving) return;
+        setSaving(true);
+        try {
+            await onSelect(bot.uuid, profileId);
+            onClose();
+        } finally {
+            setSaving(false);
+        }
+    }, [bot, saving, onSelect, onClose]);
+
+    if (!open) return null;
+
+    return (
+        <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+            <DialogTitle sx={{ textAlign: 'center' }}>
+                <Typography variant="h6">
+                    {t('remoteAgent.ccProfile.dialogTitle', { defaultValue: 'Claude Code Profile for @cc' })}
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                    {t('remoteAgent.ccProfile.dialogSubtitle', {
+                        defaultValue: 'Remote @cc sessions route through the selected profile — its rules, model mapping, and settings overrides.',
+                    })}
+                </Typography>
+            </DialogTitle>
+            <DialogContent>
+                <List dense disablePadding>
+                    <ListItemButton
+                        selected={currentId === ''}
+                        disabled={saving}
+                        onClick={() => handlePick('')}
+                    >
+                        <ListItemIcon sx={{ minWidth: 36 }}>
+                            <Radio edge="start" checked={currentId === ''} tabIndex={-1} disableRipple size="small" />
+                        </ListItemIcon>
+                        <ListItemText
+                            primary={t('remoteAgent.ccProfile.default', { defaultValue: 'Default' })}
+                            secondary={t('remoteAgent.ccProfile.defaultSecondary', { defaultValue: 'Main claude_code scenario' })}
+                        />
+                    </ListItemButton>
+                    {profiles.map((p) => (
+                        <ListItemButton
+                            key={p.id}
+                            selected={currentId === p.id}
+                            disabled={saving}
+                            onClick={() => handlePick(p.id)}
+                        >
+                            <ListItemIcon sx={{ minWidth: 36 }}>
+                                <Radio edge="start" checked={currentId === p.id} tabIndex={-1} disableRipple size="small" />
+                            </ListItemIcon>
+                            <ListItemText
+                                primary={p.name}
+                                secondary={`claude_code:${p.id}`}
+                            />
+                            <Chip
+                                label={p.unified
+                                    ? t('remoteAgent.ccProfile.unified', { defaultValue: 'unified' })
+                                    : t('remoteAgent.ccProfile.separate', { defaultValue: 'separate' })}
+                                size="small"
+                                variant="outlined"
+                                sx={{ height: 20, fontSize: '0.65rem' }}
+                            />
+                        </ListItemButton>
+                    ))}
+                </List>
+                {profiles.length === 0 && (
+                    <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1, textAlign: 'center' }}>
+                        {t('remoteAgent.ccProfile.empty', {
+                            defaultValue: 'No Claude Code profiles yet. Create one on the Claude Code scenario page first.',
+                        })}
+                    </Typography>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default CCProfileDialog;

--- a/frontend/src/components/bot/RemoteAgentBotCard.tsx
+++ b/frontend/src/components/bot/RemoteAgentBotCard.tsx
@@ -27,6 +27,7 @@ import {styled} from '@mui/material/styles';
 import type {BotSettings} from '@/types/bot';
 import {isRemoteAgentMounted} from '@/types/bot';
 import type {Provider} from '@/types/provider';
+import type {ProfileInfo} from '@/contexts/ProfileContext';
 import PairingCodePanel from './PairingCodePanel';
 import RemoteControlGraph from './RemoteControlGraph';
 import {useEffect, useState} from 'react';
@@ -72,6 +73,10 @@ interface RemoteAgentBotCardProps {
     providers: Provider[];
     onMountToggle: (mounted: boolean) => void;
     onModelClick: () => void;
+    /** Configured Claude Code profiles (resolves the @cc profile node label). */
+    ccProfiles?: ProfileInfo[];
+    /** Opens the Claude Code profile picker for this bot. */
+    onCCProfileClick?: () => void;
     onAgentSettingsSave: (settings: { chat_id: string; bash_allowlist: string[] }) => Promise<void>;
     /** Opens the shared BotConfigDialog in edit mode (bot resource fields). */
     onEdit: () => void;
@@ -96,6 +101,8 @@ const RemoteAgentBotCard: React.FC<RemoteAgentBotCardProps> = ({
     providers,
     onMountToggle,
     onModelClick,
+    ccProfiles,
+    onCCProfileClick,
     onAgentSettingsSave,
     onEdit,
     onRestart,
@@ -208,6 +215,8 @@ const RemoteAgentBotCard: React.FC<RemoteAgentBotCardProps> = ({
                         isBotEnabled={isEnabled}
                         readOnly={isToggling}
                         onModelClick={onModelClick}
+                        ccProfiles={ccProfiles}
+                        onCCProfileClick={onCCProfileClick}
                     />
                 </GraphContainer>
                 <Stack spacing={1.5} sx={{px: 2, py: 1.5}}>

--- a/frontend/src/components/bot/RemoteControlGraph.tsx
+++ b/frontend/src/components/bot/RemoteControlGraph.tsx
@@ -1,11 +1,14 @@
 import { Box } from '@mui/material';
 import type { BotSettings } from '@/types/bot.ts';
+import { ccProfileIdFromDefaultAgent } from '@/types/bot.ts';
 import type { Provider } from '@/types/provider.ts';
+import type { ProfileInfo } from '@/contexts/ProfileContext';
 import { ArrowNode, NodeContainer } from '../nodes';
 import ImBotNode from '../nodes/ImBotNode.tsx';
 import BotModelNode from '../nodes/BotModelNode.tsx';
 import AgentNode from '../nodes/AgentNode.tsx';
 import AtNode from '../nodes/AtNode.tsx';
+import CCProfileNode from '../nodes/CCProfileNode.tsx';
 import { useNavigate } from 'react-router-dom';
 import { useCallback } from 'react';
 
@@ -43,6 +46,10 @@ export interface RemoteControlGraphProps {
     readOnly?: boolean;
     onModelClick?: () => void;
     onBotClick?: () => void;
+    /** Configured Claude Code profiles (to resolve the selected profile name). */
+    ccProfiles?: ProfileInfo[];
+    /** Opens the Claude Code profile picker for this bot's @cc branch. */
+    onCCProfileClick?: () => void;
 }
 
 const getProviderName = (providerUuid: string | undefined, providersData: Provider[]): string => {
@@ -58,9 +65,16 @@ const RemoteControlGraph: React.FC<RemoteControlGraphProps> = ({
     readOnly = false,
     onModelClick,
     onBotClick,
+    ccProfiles = [],
+    onCCProfileClick,
 }) => {
     const navigate = useNavigate();
     const providerName = getProviderName(imbot.smartguide_provider, providers);
+
+    // Which Claude Code configuration serves @cc: '' = main claude_code
+    // scenario, otherwise a profile ID from default_agent ("claude_code:<id>").
+    const ccProfileId = ccProfileIdFromDefaultAgent(imbot.default_agent);
+    const ccProfileName = ccProfiles.find(p => p.id === ccProfileId)?.name;
 
     const handleAgentClick = useCallback(() => {
         navigate('/agent/claude_code');
@@ -114,7 +128,7 @@ const RemoteControlGraph: React.FC<RemoteControlGraphProps> = ({
                     </NodeContainer>
                 </Box>
 
-                {/* @cc: Claude Code agent only */}
+                {/* @cc: Claude Code agent → profile (default or a claude_code profile) */}
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                     <NodeContainer>
                         <AtNode type="cc" />
@@ -127,6 +141,17 @@ const RemoteControlGraph: React.FC<RemoteControlGraphProps> = ({
                             agentType="claude-code"
                             active={isBotEnabled}
                             onClick={readOnly ? undefined : handleAgentClick}
+                        />
+                    </NodeContainer>
+
+                    <ArrowNode direction="forward" />
+
+                    <NodeContainer>
+                        <CCProfileNode
+                            profileId={ccProfileId}
+                            profileName={ccProfileName}
+                            active={isBotEnabled}
+                            onClick={readOnly ? undefined : onCCProfileClick}
                         />
                     </NodeContainer>
                 </Box>

--- a/frontend/src/components/bot/RemoteControlGraph.tsx
+++ b/frontend/src/components/bot/RemoteControlGraph.tsx
@@ -9,8 +9,6 @@ import BotModelNode from '../nodes/BotModelNode.tsx';
 import AgentNode from '../nodes/AgentNode.tsx';
 import AtNode from '../nodes/AtNode.tsx';
 import CCProfileNode from '../nodes/CCProfileNode.tsx';
-import { useNavigate } from 'react-router-dom';
-import { useCallback } from 'react';
 
 const graphRowStyles = (theme: any) => ({
     display: 'flex',
@@ -68,17 +66,12 @@ const RemoteControlGraph: React.FC<RemoteControlGraphProps> = ({
     ccProfiles = [],
     onCCProfileClick,
 }) => {
-    const navigate = useNavigate();
     const providerName = getProviderName(imbot.smartguide_provider, providers);
 
     // Which Claude Code configuration serves @cc: '' = main claude_code
     // scenario, otherwise a profile ID from default_agent ("claude_code:<id>").
     const ccProfileId = ccProfileIdFromDefaultAgent(imbot.default_agent);
     const ccProfileName = ccProfiles.find(p => p.id === ccProfileId)?.name;
-
-    const handleAgentClick = useCallback(() => {
-        navigate('/agent/claude_code');
-    }, [navigate]);
 
     return (
         <Box sx={graphRowStyles}>
@@ -140,7 +133,6 @@ const RemoteControlGraph: React.FC<RemoteControlGraphProps> = ({
                         <AgentNode
                             agentType="claude-code"
                             active={isBotEnabled}
-                            onClick={readOnly ? undefined : handleAgentClick}
                         />
                     </NodeContainer>
 

--- a/frontend/src/components/nodes/AgentNode.tsx
+++ b/frontend/src/components/nodes/AgentNode.tsx
@@ -1,6 +1,6 @@
-import { Box, Chip, Divider, Paper, Popover, Typography, styled } from '@mui/material';
+import { Box, Chip, Divider, Typography, styled } from '@mui/material';
 import { NODE_LAYER_STYLES } from './styles';
-import { useCallback, useRef, useState } from 'react';
+import NodeTooltip from './NodeTooltip';
 import { useTranslation } from 'react-i18next';
 
 type AgentType = 'claude-code' | 'smart-guide' | 'custom' | 'mock';
@@ -29,26 +29,22 @@ const AGENT_TYPE_CONFIG: Record<AgentType, {
         color: 'info',
         info: {
             en: {
-                description: 'A full-spectrum development agent powered by Claude Code CLI. Handles implementation, refactoring, testing, builds, and git operations — anything that requires deep code execution in your local environment.',
+                description: 'A full-spectrum development agent (Claude Code CLI) — implementation, refactors, tests, builds, and git operations in your local environment.',
                 features: [
-                    'Implement features, algorithms, and multi-file refactors',
-                    'Run tests, builds, and debug sessions',
-                    'Execute git operations: commits, pushes, rebases',
-                    'Manage dependencies and complex package changes',
-                    'Triggered via IM — type @cc to hand off from SmartGuide',
+                    'Multi-file implementation & refactors',
+                    'Run tests, builds, and debug',
+                    'Git operations: commit, push, rebase',
                 ],
-                config: 'Click this node to open the Claude Code scene and configure profiles.',
+                config: 'Click to open Claude Code and configure profiles.',
             },
             zh: {
-                description: '由 Claude Code CLI 驱动的全栈开发代理，负责功能实现、重构、测试、构建和 Git 操作——所有需要在本地环境深度执行的任务。',
+                description: '由 Claude Code CLI 驱动的全栈开发代理——功能实现、重构、测试、构建和 Git 操作。',
                 features: [
-                    '实现功能、算法及跨文件重构',
+                    '跨文件实现与重构',
                     '运行测试、构建与调试',
-                    '执行 Git 操作：提交、推送、变基',
-                    '管理依赖和复杂包变更',
-                    '通过 IM 触发——在 SmartGuide 中输入 @cc 即可切换',
+                    'Git 操作：提交、推送、变基',
                 ],
-                config: '点击此节点跳转到 Claude Code 场景页，配置 Profile 和运行参数。',
+                config: '点击跳转到 Claude Code 场景页配置 Profile。',
             },
         },
     },
@@ -57,26 +53,22 @@ const AGENT_TYPE_CONFIG: Record<AgentType, {
         color: 'success',
         info: {
             en: {
-                description: 'A navigation and coordination assistant (@tb). Understands your intent, explores the project, answers questions, handles small edits and workspace setup — then hands off heavy implementation to @cc.',
+                description: 'A navigation and coordination assistant (@tb) — explores the project, answers questions, and handles small edits, then hands off heavy implementation to @cc.',
                 features: [
-                    'Project exploration: read files, explain structure and architecture',
-                    'Answer questions about dependencies and configuration',
-                    'Small precise edits: config values, env vars, templates',
-                    'Workspace setup: clone repos, set working directory',
-                    'Persistent memory across sessions (MEMORY.md)',
+                    'Explore files & explain architecture',
+                    'Small precise edits: config, env vars',
+                    'Persistent memory (MEMORY.md)',
                 ],
-                config: 'Click the Model node to the right to select the provider and model for this agent.',
+                config: 'Click the Model node to select provider and model.',
             },
             zh: {
-                description: '导航与协调助手（@tb）。理解用户意图、探索项目、回答问题、处理小改动和工作区配置，重度实现任务交由 @cc 处理。',
+                description: '导航与协调助手（@tb）——探索项目、回答问题、处理小改动，重度实现交由 @cc。',
                 features: [
-                    '项目探索：读取文件，解释结构和架构',
-                    '回答依赖与配置相关问题',
-                    '精准小改动：配置值、环境变量、模板',
-                    '工作区配置：克隆仓库、设置工作目录',
+                    '探索文件并讲解架构',
+                    '精准小改动：配置、环境变量',
                     '跨会话持久记忆（MEMORY.md）',
                 ],
-                config: '点击右侧 Model 节点，为此代理选择服务商和模型。',
+                config: '点击右侧 Model 节点选择服务商和模型。',
             },
         },
     },
@@ -162,29 +154,33 @@ const AgentNode: React.FC<AgentNodeProps> = ({
     const displayLabel = label || config.label;
     const clickable = !!onClick;
 
-    const anchorEl = useRef<HTMLDivElement | null>(null);
-    const [open, setOpen] = useState(false);
-    const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const handleMouseEnter = useCallback(() => {
-        enterTimer.current = setTimeout(() => setOpen(true), 400);
-    }, []);
-
-    const handleMouseLeave = useCallback(() => {
-        if (enterTimer.current) clearTimeout(enterTimer.current);
-        setOpen(false);
-    }, []);
+    // NodeTooltip (MUI Tooltip) rather than a hand-rolled hover Popover: it
+    // has built-in enter/leave hysteresis and never needs to reposition
+    // itself under the cursor, so it can't fall into the open/close flicker
+    // loop a manually-timed Popover does when its content is tall enough to
+    // collide with the viewport edge.
+    const tooltipContent = (
+        <Box sx={{ maxWidth: 260 }}>
+            <Typography variant="body2" sx={{ mb: 1, lineHeight: 1.5 }}>
+                {info.description}
+            </Typography>
+            <Box component="ul" sx={{ m: 0, pl: 2.25, mb: 1 }}>
+                {info.features.map((f) => (
+                    <Box component="li" key={f} sx={{ '&:not(:last-of-type)': { mb: 0.25 } }}>
+                        <Typography variant="caption">{f}</Typography>
+                    </Box>
+                ))}
+            </Box>
+            <Divider sx={{ my: 0.75, borderColor: 'rgba(255,255,255,0.2)' }} />
+            <Typography variant="caption" sx={{ display: 'block', fontStyle: 'italic', opacity: 0.85 }}>
+                {info.config}
+            </Typography>
+        </Box>
+    );
 
     return (
-        <>
-            <StyledAgentNode
-                ref={anchorEl}
-                active={active}
-                clickable={clickable}
-                onClick={onClick}
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
-            >
+        <NodeTooltip title={tooltipContent} placement="top">
+            <StyledAgentNode active={active} clickable={clickable} onClick={onClick}>
                 <Box sx={NODE_LAYER_STYLES.topLayer}>
                     <Typography variant="body2" sx={NODE_LAYER_STYLES.typography}>Agent</Typography>
                 </Box>
@@ -200,70 +196,7 @@ const AgentNode: React.FC<AgentNodeProps> = ({
                     />
                 </Box>
             </StyledAgentNode>
-            <Popover
-                open={open}
-                anchorEl={anchorEl.current}
-                onClose={() => setOpen(false)}
-                anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-                transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-                disableRestoreFocus
-                slotProps={{ paper: { onMouseEnter: handleMouseEnter, onMouseLeave: handleMouseLeave } }}
-                sx={{ pointerEvents: 'none' }}
-            >
-                <Paper sx={{ p: 2, maxWidth: 300, pointerEvents: 'auto' }}>
-                    {/* Header */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <Chip
-                            label={config.label}
-                            size="small"
-                            color={config.color as any}
-                            sx={{ fontWeight: 700, fontSize: '0.75rem' }}
-                        />
-                        <Typography variant="caption" sx={{
-                            color: "text.secondary"
-                        }}>Agent</Typography>
-                    </Box>
-
-                    {/* Description */}
-                    <Typography variant="body2" sx={{ mb: 1.5, lineHeight: 1.55, color: 'text.primary' }}>
-                        {info.description}
-                    </Typography>
-
-                    <Divider sx={{ mb: 1.5 }} />
-
-                    {/* Features */}
-                    <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                        {lang === 'zh' ? '功能' : 'Features'}
-                    </Typography>
-                    <Box component="ul" sx={{ m: 0, mt: 0.5, pl: 2.5, mb: 1.5 }}>
-                        {info.features.map((f) => (
-                            <Box component="li" key={f} sx={{ mb: 0.25 }}>
-                                <Typography variant="caption" sx={{
-                                    color: "text.secondary"
-                                }}>{f}</Typography>
-                            </Box>
-                        ))}
-                    </Box>
-
-                    <Divider sx={{ mb: 1.5 }} />
-
-                    {/* Config hint */}
-                    <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                        {lang === 'zh' ? '配置' : 'Configuration'}
-                    </Typography>
-                    <Typography
-                        variant="caption"
-                        sx={{
-                            display: "block",
-                            mt: 0.5,
-                            color: 'text.secondary',
-                            lineHeight: 1.5
-                        }}>
-                        {info.config}
-                    </Typography>
-                </Paper>
-            </Popover>
-        </>
+        </NodeTooltip>
     );
 };
 

--- a/frontend/src/components/nodes/AgentNode.tsx
+++ b/frontend/src/components/nodes/AgentNode.tsx
@@ -35,7 +35,7 @@ const AGENT_TYPE_CONFIG: Record<AgentType, {
                     'Run tests, builds, and debug',
                     'Git operations: commit, push, rebase',
                 ],
-                config: 'Click to open Claude Code and configure profiles.',
+                config: 'Click the Profile node to the right to route @cc through a Claude Code profile.',
             },
             zh: {
                 description: '由 Claude Code CLI 驱动的全栈开发代理——功能实现、重构、测试、构建和 Git 操作。',
@@ -44,7 +44,7 @@ const AGENT_TYPE_CONFIG: Record<AgentType, {
                     '运行测试、构建与调试',
                     'Git 操作：提交、推送、变基',
                 ],
-                config: '点击跳转到 Claude Code 场景页配置 Profile。',
+                config: '点击右侧 Profile 节点，为 @cc 选择 Claude Code Profile。',
             },
         },
     },
@@ -159,20 +159,25 @@ const AgentNode: React.FC<AgentNodeProps> = ({
     // itself under the cursor, so it can't fall into the open/close flicker
     // loop a manually-timed Popover does when its content is tall enough to
     // collide with the viewport edge.
+    // Typography variants in this app's theme carry a fixed color (body2 →
+    // text.secondary, caption → text.disabled) meant for normal page
+    // backgrounds. Left alone inside the Tooltip's own dark bubble, that
+    // reads as an unintentionally washed-out grey, so every line here
+    // explicitly inherits the Tooltip's own text color instead.
     const tooltipContent = (
         <Box sx={{ maxWidth: 260 }}>
-            <Typography variant="body2" sx={{ mb: 1, lineHeight: 1.5 }}>
+            <Typography variant="body2" sx={{ mb: 1, lineHeight: 1.5, color: 'inherit' }}>
                 {info.description}
             </Typography>
             <Box component="ul" sx={{ m: 0, pl: 2.25, mb: 1 }}>
                 {info.features.map((f) => (
                     <Box component="li" key={f} sx={{ '&:not(:last-of-type)': { mb: 0.25 } }}>
-                        <Typography variant="caption">{f}</Typography>
+                        <Typography variant="caption" sx={{ color: 'inherit' }}>{f}</Typography>
                     </Box>
                 ))}
             </Box>
-            <Divider sx={{ my: 0.75, borderColor: 'rgba(255,255,255,0.2)' }} />
-            <Typography variant="caption" sx={{ display: 'block', fontStyle: 'italic', opacity: 0.85 }}>
+            <Divider sx={{ my: 0.75, borderColor: 'rgba(255,255,255,0.24)' }} />
+            <Typography variant="caption" sx={{ display: 'block', fontStyle: 'italic', color: 'inherit' }}>
                 {info.config}
             </Typography>
         </Box>

--- a/frontend/src/components/nodes/CCProfileNode.tsx
+++ b/frontend/src/components/nodes/CCProfileNode.tsx
@@ -1,0 +1,114 @@
+import { Box, Chip, Divider, Typography, styled } from '@mui/material';
+import { Warning as WarningIcon } from '@/components/icons';
+import { NODE_LAYER_STYLES } from './styles';
+import NodeTooltip from './NodeTooltip';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const StyledCCProfileNode = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'active' && prop !== 'clickable' && prop !== 'missing',
+})<{ active: boolean; clickable: boolean; missing: boolean }>(({ active, clickable, missing, theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 12,
+    borderRadius: theme.shape.borderRadius,
+    border: '1px solid',
+    borderColor: missing ? 'warning.main' : (active ? 'info.main' : 'divider'),
+    backgroundColor: missing ? 'warning.50' : (active ? 'info.50' : 'background.paper'),
+    textAlign: 'center',
+    width: 220,
+    height: 90,
+    boxShadow: theme.shadows[2],
+    transition: 'all 0.2s ease-in-out',
+    position: 'relative',
+    opacity: active ? 1 : 0.6,
+    cursor: clickable ? 'pointer' : 'default',
+    '&:hover': clickable ? {
+        borderColor: 'info.main',
+        boxShadow: theme.shadows[4],
+        transform: 'translateY(-2px)',
+    } : {},
+}));
+
+interface CCProfileNodeProps {
+    /** Selected Claude Code profile ID ("" = default / main scenario). */
+    profileId?: string;
+    /** Resolved display name of the selected profile (if it still exists). */
+    profileName?: string;
+    active?: boolean;
+    onClick?: () => void;
+}
+
+// CCProfileNode shows which Claude Code profile serves @cc for this bot:
+// "Default" (main claude_code scenario) or a named profile
+// ("claude_code:<id>" scenario). Click to switch.
+const CCProfileNode: React.FC<CCProfileNodeProps> = ({
+    profileId,
+    profileName,
+    active = true,
+    onClick,
+}) => {
+    const { t } = useTranslation();
+    const clickable = !!onClick;
+    const hasProfile = !!profileId;
+    // Selected profile no longer exists — surface it instead of hiding it;
+    // execution falls back to the default scenario until re-picked.
+    const missing = hasProfile && !profileName;
+
+    const handleClick = useCallback((event: React.MouseEvent) => {
+        event.stopPropagation();
+        if (onClick) onClick();
+    }, [onClick]);
+
+    const label = hasProfile
+        ? (profileName || profileId)
+        : t('remoteAgent.ccProfile.default', { defaultValue: 'Default' });
+
+    const tooltip = missing
+        ? t('remoteAgent.ccProfile.missingTooltip', {
+            defaultValue: 'Profile "{{id}}" no longer exists — @cc falls back to the default claude_code scenario. Click to pick another.',
+            id: profileId,
+        })
+        : hasProfile
+            ? <>{t('remoteAgent.ccProfile.profileTooltip', { defaultValue: 'Claude Code profile' })}: {profileName} ({profileId})<br/>{t('remoteAgent.ccProfile.scenario', { defaultValue: 'Scenario' })}: claude_code:{profileId}</>
+            : t('remoteAgent.ccProfile.defaultTooltip', { defaultValue: 'Uses the main claude_code scenario. Click to route @cc through a Claude Code profile.' });
+
+    return (
+        <StyledCCProfileNode active={active} clickable={clickable} missing={missing} onClick={handleClick}>
+            <Box sx={NODE_LAYER_STYLES.topLayer}>
+                <NodeTooltip title={tooltip} placement="top">
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
+                        {active && missing && (
+                            <WarningIcon sx={{ fontSize: '1rem', color: 'warning.main' }} />
+                        )}
+                        <Typography
+                            variant="body2"
+                            noWrap
+                            sx={{
+                                color: 'text.primary',
+                                ...NODE_LAYER_STYLES.typography,
+                                fontStyle: hasProfile ? 'normal' : 'italic',
+                                maxWidth: '180px',
+                                textAlign: 'center',
+                            }}>
+                            {label}
+                        </Typography>
+                    </Box>
+                </NodeTooltip>
+            </Box>
+            <Divider sx={NODE_LAYER_STYLES.divider} />
+            <Box sx={NODE_LAYER_STYLES.bottomLayer}>
+                <Chip
+                    label={t('remoteAgent.ccProfile.chip', { defaultValue: 'Profile' })}
+                    size="small"
+                    color={missing ? 'warning' : (hasProfile ? 'info' : 'default')}
+                    sx={{ height: 24, fontSize: '0.7rem', fontWeight: 500 }}
+                />
+            </Box>
+        </StyledCCProfileNode>
+    );
+};
+
+export default CCProfileNode;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2438,7 +2438,8 @@ export const handlers = [
                     enabled: true,
                     auth_type: 'token',
                     default_cwd: '/home/user/projects',
-                    default_agent: 'claude_code',
+                    // @cc routes through the "ds" Claude Code profile (claude_code:p1)
+                    default_agent: 'claude_code:p1',
                     smartguide_provider: 'mock-provider-anthropic',
                     smartguide_model: 'claude-sonnet-5',
                     chat_id: '123456789',

--- a/frontend/src/pages/remote-agent/PlatformRemoteAgentPage.tsx
+++ b/frontend/src/pages/remote-agent/PlatformRemoteAgentPage.tsx
@@ -1,11 +1,14 @@
 import { BotConfigDialog, RemoteAgentBotCard, useBotModelDialog } from '@/components/bot';
+import CCProfileDialog from '@/components/bot/CCProfileDialog';
 import EmptyStateGuide from '@/components/EmptyStateGuide';
 import { PageLayout } from '@/components/PageLayout';
 import CollapsibleGuide from '@/components/remote-control/CollapsibleGuide';
 import UnifiedCard from '@/components/UnifiedCard';
 import { api } from '@/services/api';
 import { usePlatformGuide } from '@/constants/platformGuides';
+import { useProfileContext } from '@/contexts/ProfileContext';
 import type { BotSettings } from '@/types/bot';
+import { defaultAgentForCCProfile } from '@/types/bot';
 import type { Provider } from '@/types/provider';
 import { Add } from '@/components/icons';
 import { Alert, Box, Button, CircularProgress, Snackbar } from '@mui/material';
@@ -193,6 +196,26 @@ const PlatformRemoteAgentPage = ({ platformId, platformName }: PlatformRemoteAge
         openBotModelDialog();
     }, [openBotModelDialog]);
 
+    // Claude Code profiles for the @cc branch — the selected profile decides
+    // which claude_code scenario remote @cc executions route through.
+    const { getProfiles: getScenarioProfiles } = useProfileContext();
+    const ccProfiles = getScenarioProfiles('claude_code');
+    const [profileDialogBot, setProfileDialogBot] = useState<BotSettings | null>(null);
+
+    const handleCCProfileSelect = useCallback(async (uuid: string, profileId: string) => {
+        const response = await api.updateImBotSetting(uuid, {
+            default_agent: defaultAgentForCCProfile(profileId),
+        });
+        if (response?.success) {
+            showNotification(t('remoteAgent.notify.ccProfileUpdated', { defaultValue: 'Claude Code profile updated' }), 'success');
+            await loadBots();
+        } else {
+            const message = response?.error || t('remoteAgent.notify.ccProfileUpdateFailed', { defaultValue: 'Failed to update Claude Code profile' });
+            showNotification(message, 'error');
+            throw new Error(message);
+        }
+    }, [loadBots, showNotification, t]);
+
     return (
         <PageLayout loading={false}>
             {/* Same platform setup guide as the Bots page — mirrored sections
@@ -242,6 +265,8 @@ const PlatformRemoteAgentPage = ({ platformId, platformName }: PlatformRemoteAge
                                 providers={providers}
                                 onMountToggle={(mounted) => handleMountToggle(bot.uuid!, mounted)}
                                 onModelClick={() => handleModelClick(bot)}
+                                ccProfiles={ccProfiles}
+                                onCCProfileClick={() => setProfileDialogBot(bot)}
                                 onAgentSettingsSave={(settings) => handleAgentSettingsSave(bot.uuid!, settings)}
                                 onEdit={() => openEditDialog(bot.uuid!)}
                                 onRestart={() => handleBotRestart(bot.uuid!)}
@@ -265,6 +290,13 @@ const PlatformRemoteAgentPage = ({ platformId, platformName }: PlatformRemoteAge
                 notify={showNotification}
             />
             <BotModelDialog open={botModelDialogOpen} />
+            <CCProfileDialog
+                open={Boolean(profileDialogBot)}
+                bot={profileDialogBot}
+                profiles={ccProfiles}
+                onSelect={handleCCProfileSelect}
+                onClose={() => setProfileDialogBot(null)}
+            />
             <Snackbar
                 open={snackbar.open}
                 autoHideDuration={snackbar.severity === 'error' ? null : 4000}

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -94,8 +94,9 @@ export function ccProfileIdFromDefaultAgent(defaultAgent?: string): string {
 }
 
 // defaultAgentForCCProfile builds the default_agent value for a profile
-// selection ('' → "claude_code", i.e. back to the main scenario — the update
-// API skips empty strings, so the explicit base value is used to clear).
+// selection ('' → the explicit base "claude_code", not an empty string — a
+// concrete value reads clearly in raw settings/logs, per the "show the
+// concrete value, not the alias" principle in .design/ux-principles.md).
 export function defaultAgentForCCProfile(profileId: string): string {
     return profileId ? `${CLAUDE_CODE_AGENT}:${profileId}` : CLAUDE_CODE_AGENT;
 }

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -80,6 +80,26 @@ export function getAuthDisplayValue(settings: BotSettings, config: BotPlatformCo
     return 'Configured';
 }
 
+// CLAUDE_CODE_AGENT is the base agent identifier stored in default_agent when
+// @cc uses the main claude_code scenario. A profiled selection is stored as
+// "claude_code:<profileId>" — mirrors the backend scenario naming.
+export const CLAUDE_CODE_AGENT = 'claude_code';
+
+// ccProfileIdFromDefaultAgent extracts the Claude Code profile ID from a bot's
+// default_agent value. Returns '' for unset / "claude_code" / non-claude_code.
+export function ccProfileIdFromDefaultAgent(defaultAgent?: string): string {
+    const v = (defaultAgent || '').trim();
+    if (!v.startsWith(CLAUDE_CODE_AGENT + ':')) return '';
+    return v.slice(CLAUDE_CODE_AGENT.length + 1);
+}
+
+// defaultAgentForCCProfile builds the default_agent value for a profile
+// selection ('' → "claude_code", i.e. back to the main scenario — the update
+// API skips empty strings, so the explicit base value is used to clear).
+export function defaultAgentForCCProfile(profileId: string): string {
+    return profileId ? `${CLAUDE_CODE_AGENT}:${profileId}` : CLAUDE_CODE_AGENT;
+}
+
 // REMOTE_AGENT_SCENARIO is the mount name for the remote-agent purpose
 // (control Claude Code / SmartGuide from chat). Mirrors the backend constant.
 export const REMOTE_AGENT_SCENARIO = 'remote_agent';

--- a/internal/remote_control/bot/agent_claude_code.go
+++ b/internal/remote_control/bot/agent_claude_code.go
@@ -75,9 +75,18 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 		Timestamp: time.Now(),
 	})
 
+	// The bot's default_agent setting decides which Claude Code configuration
+	// serves @cc: the main claude_code scenario or a profile
+	// ("claude_code:<id>"). Read dynamically so a profile switch in the web UI
+	// applies from the next message without a bot restart.
+	profileID := e.deps.GetBotSettingOrCache().CCProfileID()
+
 	statusMsg := "⏳ CC: Processing new session..."
 	if !req.IsNewSession {
 		statusMsg = "⏳ CC: Resuming session..."
+	}
+	if profileID != "" {
+		statusMsg += fmt.Sprintf(" (profile: %s)", profileID)
 	}
 	e.deps.SendTextWithReply(req.HCtx, e.deps.FormatResponseWithFooter(*meta, statusMsg), req.ReplyTo)
 
@@ -94,6 +103,7 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 		"projectPath":    projectPath,
 		"shouldResume":   shouldResume,
 		"permissionMode": permissionMode,
+		"ccProfile":      profileID,
 	}).Info("Starting Claude Code execution")
 
 	streamWriter := e.deps.NewStreamingMessageHandler(req.HCtx, meta)
@@ -101,10 +111,19 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 	// Route the Claude Code CLI through the tingly-box gateway so it uses the
 	// configured provider (including third-party model services) instead of
 	// talking to the Anthropic API directly. Without this, @cc fails whenever
-	// no direct Anthropic credentials are present on the host.
+	// no direct Anthropic credentials are present on the host. With a profile
+	// selected, the env routes through the profiled scenario instead; if the
+	// profile can no longer be resolved (e.g. deleted in the UI), fall back to
+	// the main scenario and tell the user rather than silently running with
+	// different routing than they selected.
 	var execEnv []string
 	if e.deps.TBClient != nil {
-		ccEnv, eerr := e.deps.TBClient.GetClaudeCodeEnv(ctx)
+		ccEnv, eerr := e.deps.TBClient.GetClaudeCodeEnvForProfile(ctx, profileID)
+		if eerr != nil && profileID != "" {
+			logrus.WithError(eerr).WithField("ccProfile", profileID).Warn("ClaudeCodeExecutor: failed to resolve profile env; falling back to main claude_code scenario")
+			e.deps.SendText(req.HCtx, fmt.Sprintf("⚠️ Claude Code profile '%s' could not be resolved (%v).\nRunning with the default claude_code scenario instead. Pick another profile in the tingly-box web UI (Remote → this bot).", profileID, eerr))
+			ccEnv, eerr = e.deps.TBClient.GetClaudeCodeEnv(ctx)
+		}
 		if eerr != nil {
 			logrus.WithError(eerr).Warn("ClaudeCodeExecutor: failed to resolve gateway env; @cc may not reach the configured provider")
 		} else {

--- a/internal/remote_control/bot/agent_claude_code.go
+++ b/internal/remote_control/bot/agent_claude_code.go
@@ -108,26 +108,43 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 
 	streamWriter := e.deps.NewStreamingMessageHandler(req.HCtx, meta)
 
-	// Route the Claude Code CLI through the tingly-box gateway so it uses the
-	// configured provider (including third-party model services) instead of
-	// talking to the Anthropic API directly. Without this, @cc fails whenever
-	// no direct Anthropic credentials are present on the host. With a profile
-	// selected, the env routes through the profiled scenario instead; if the
-	// profile can no longer be resolved (e.g. deleted in the UI), fall back to
-	// the main scenario and tell the user rather than silently running with
-	// different routing than they selected.
+	// Route the Claude Code CLI through the tingly-box gateway. Two distinct
+	// mechanisms, matching what a local launch does for each case:
+	//
+	//   - Main scenario (no profile): process env vars (ANTHROPIC_BASE_URL,
+	//     etc.). Without this, @cc fails whenever no direct Anthropic
+	//     credentials are present on the host.
+	//   - A selected profile: the CLI's --settings flag REPLACES
+	//     ~/.claude/settings.json rather than merging with it, so a profile's
+	//     routing/models/overrides only take effect when its materialized
+	//     settings.json is referenced via --settings — exactly what
+	//     `tingly-box cc --profile <id>` does locally. Injecting the
+	//     profile's values as process env instead is not enough: with no
+	//     --settings flag the CLI still reads ~/.claude/settings.json, whose
+	//     main-scenario values would silently win.
+	//
+	// If the profile can no longer be resolved (e.g. deleted in the UI), fall
+	// back to the main scenario and tell the user rather than silently
+	// running with different routing than they selected.
 	var execEnv []string
+	var settingsPath string
 	if e.deps.TBClient != nil {
-		ccEnv, eerr := e.deps.TBClient.GetClaudeCodeEnvForProfile(ctx, profileID)
-		if eerr != nil && profileID != "" {
-			logrus.WithError(eerr).WithField("ccProfile", profileID).Warn("ClaudeCodeExecutor: failed to resolve profile env; falling back to main claude_code scenario")
-			e.deps.SendText(req.HCtx, fmt.Sprintf("⚠️ Claude Code profile '%s' could not be resolved (%v).\nRunning with the default claude_code scenario instead. Pick another profile in the tingly-box web UI (Remote → this bot).", profileID, eerr))
-			ccEnv, eerr = e.deps.TBClient.GetClaudeCodeEnv(ctx)
+		if profileID != "" {
+			path, perr := e.deps.TBClient.GetClaudeCodeSettingsPathForProfile(ctx, profileID)
+			if perr != nil {
+				logrus.WithError(perr).WithField("ccProfile", profileID).Warn("ClaudeCodeExecutor: failed to materialize profile settings; falling back to main claude_code scenario")
+				e.deps.SendText(req.HCtx, fmt.Sprintf("⚠️ Claude Code profile '%s' could not be resolved (%v).\nRunning with the default claude_code scenario instead. Pick another profile in the tingly-box web UI (Remote → this bot).", profileID, perr))
+			} else {
+				settingsPath = path
+			}
 		}
-		if eerr != nil {
-			logrus.WithError(eerr).Warn("ClaudeCodeExecutor: failed to resolve gateway env; @cc may not reach the configured provider")
-		} else {
-			execEnv = ccEnv
+		if settingsPath == "" {
+			ccEnv, eerr := e.deps.TBClient.GetClaudeCodeEnv(ctx)
+			if eerr != nil {
+				logrus.WithError(eerr).Warn("ClaudeCodeExecutor: failed to resolve gateway env; @cc may not reach the configured provider")
+			} else {
+				execEnv = ccEnv
+			}
 		}
 	}
 
@@ -165,6 +182,7 @@ func (e *ClaudeCodeExecutor) Execute(ctx context.Context, req PreparedRequest) (
 			PermissionPromptTool: "stdio",
 			PermissionMode:       permissionMode,
 			Env:                  execEnv,
+			SettingsPath:         settingsPath,
 			Store:                e.deps.SessionMgr,
 		},
 	}, prompter, sink)

--- a/internal/remote_control/bot/chat_store.go
+++ b/internal/remote_control/bot/chat_store.go
@@ -3,9 +3,11 @@ package bot
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/jsonstore"
 )
 
@@ -30,6 +32,13 @@ type BotSetting struct {
 	Enabled       bool              `json:"enabled"`                  // Whether this bot is enabled
 	Scenarios     string            `json:"scenarios,omitempty"`      // Raw scenario/mount list (JSON, see remote/binding)
 
+	// DefaultAgent selects which agent configuration serves @cc for this bot:
+	// ""/"claude_code" = the main claude_code scenario, "claude_code:<id>" = a
+	// Claude Code profile — @cc then routes through the profiled scenario with
+	// the profile's unified/separate mode and env overrides, exactly like a
+	// local `tingly-box cc --profile <id>` launch.
+	DefaultAgent string `json:"default_agent,omitempty"`
+
 	// Output behavior settings
 	Verbose *bool `json:"verbose,omitempty"` // Send intermediate messages (nil = true default)
 
@@ -46,6 +55,21 @@ type BotSetting struct {
 
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// CCProfileID extracts the Claude Code profile ID from DefaultAgent.
+// Returns "" for the main claude_code scenario (unset, "claude_code", or a
+// value whose base scenario isn't claude_code).
+func (b BotSetting) CCProfileID() string {
+	raw := strings.TrimSpace(b.DefaultAgent)
+	if raw == "" {
+		return ""
+	}
+	base, profileID := typ.ParseScenarioProfile(typ.RuleScenario(raw))
+	if base != typ.ScenarioClaudeCode {
+		return ""
+	}
+	return profileID
 }
 
 // IsRequirePairing reports whether this bot requires per-chat pairing.

--- a/internal/remote_control/bot/handler_constructor.go
+++ b/internal/remote_control/bot/handler_constructor.go
@@ -162,6 +162,7 @@ func NewBotHandler(
 					ChatIDLock:         record.ChatIDLock,
 					BashAllowlist:      record.BashAllowlist,
 					DefaultCwd:         record.DefaultCwd,
+					DefaultAgent:       record.DefaultAgent,
 					Enabled:            record.Enabled,
 					Scenarios:          record.Scenarios,
 					SmartGuideProvider: record.SmartGuideProvider,

--- a/internal/remote_control/bot/manager.go
+++ b/internal/remote_control/bot/manager.go
@@ -379,6 +379,7 @@ func (m *Manager) Start(parentCtx context.Context, uuid string) error {
 		ChatIDLock:         record.ChatIDLock,
 		BashAllowlist:      record.BashAllowlist,
 		DefaultCwd:         record.DefaultCwd,
+		DefaultAgent:       record.DefaultAgent,
 		Enabled:            record.Enabled,
 		Scenarios:          record.Scenarios,
 		SmartGuideProvider: record.SmartGuideProvider,

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tingly-dev/tingly-box/imbot"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/remote/binding"
 	"github.com/tingly-dev/tingly-box/remote/channel"
 )
@@ -145,6 +146,11 @@ func (h *Handler) CreateSettings(c *gin.Context) {
 	}
 	if req.Token != "" && authType == "token" {
 		authMap["token"] = strings.TrimSpace(req.Token)
+	}
+
+	if err := h.validateDefaultAgent(strings.TrimSpace(req.DefaultAgent)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid default_agent", "details": err.Error()})
+		return
 	}
 
 	settings := db.Settings{
@@ -314,7 +320,12 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 
 	// Handle default_agent config (partial update)
 	if req.DefaultAgent != nil {
-		settings.DefaultAgent = strings.TrimSpace(*req.DefaultAgent)
+		trimmed := strings.TrimSpace(*req.DefaultAgent)
+		if err := h.validateDefaultAgent(trimmed); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid default_agent", "details": err.Error()})
+			return
+		}
+		settings.DefaultAgent = trimmed
 	} else {
 		settings.DefaultAgent = currentSettings.DefaultAgent
 	}
@@ -553,6 +564,30 @@ func (h *Handler) GetPlatformConfig(c *gin.Context) {
 }
 
 // Helper function to normalize allowlist
+// validateDefaultAgent checks a default_agent value: "" and "claude_code"
+// select the main scenario; "claude_code:<profileID>" must reference an
+// existing Claude Code profile. Anything else is rejected so a typo can't
+// silently fall back to the default at execution time.
+func (h *Handler) validateDefaultAgent(value string) error {
+	if value == "" {
+		return nil
+	}
+	base, profileID := typ.ParseScenarioProfile(typ.RuleScenario(value))
+	if base != typ.ScenarioClaudeCode {
+		return fmt.Errorf("unsupported default_agent %q: only claude_code (optionally with a profile, e.g. claude_code:p1) is supported", value)
+	}
+	if profileID == "" {
+		return nil
+	}
+	if h.config == nil {
+		return nil
+	}
+	if _, found := h.config.GetProfile(typ.ScenarioClaudeCode, profileID); !found {
+		return fmt.Errorf("claude code profile %q not found", profileID)
+	}
+	return nil
+}
+
 func normalizeAllowlist(values []string) []string {
 	seen := make(map[string]struct{})
 	var out []string

--- a/internal/tbclient/mock.go
+++ b/internal/tbclient/mock.go
@@ -58,6 +58,15 @@ func (m *MockTBClient) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
+// GetClaudeCodeEnvForProfile mocks the GetClaudeCodeEnvForProfile method
+func (m *MockTBClient) GetClaudeCodeEnvForProfile(ctx context.Context, profileID string) ([]string, error) {
+	args := m.Called(ctx, profileID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 // GetDefaultRuleForScenario mocks the GetDefaultRuleForScenario method
 func (m *MockTBClient) GetDefaultRuleForScenario(ctx context.Context, scenario typ.RuleScenario) (*typ.Rule, error) {
 	args := m.Called(ctx, scenario)

--- a/internal/tbclient/mock.go
+++ b/internal/tbclient/mock.go
@@ -58,13 +58,10 @@ func (m *MockTBClient) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-// GetClaudeCodeEnvForProfile mocks the GetClaudeCodeEnvForProfile method
-func (m *MockTBClient) GetClaudeCodeEnvForProfile(ctx context.Context, profileID string) ([]string, error) {
+// GetClaudeCodeSettingsPathForProfile mocks the GetClaudeCodeSettingsPathForProfile method
+func (m *MockTBClient) GetClaudeCodeSettingsPathForProfile(ctx context.Context, profileID string) (string, error) {
 	args := m.Called(ctx, profileID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]string), args.Error(1)
+	return args.String(0), args.Error(1)
 }
 
 // GetDefaultRuleForScenario mocks the GetDefaultRuleForScenario method

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -44,13 +44,17 @@ type TBClient interface {
 	// (including third-party model services) instead of the Anthropic API.
 	GetClaudeCodeEnv(ctx context.Context) ([]string, error)
 
-	// GetClaudeCodeEnvForProfile is the profile-aware variant of
-	// GetClaudeCodeEnv. An empty profileID behaves exactly like
-	// GetClaudeCodeEnv (main claude_code scenario); a non-empty profileID
-	// routes through the profiled scenario ("claude_code:<id>") and applies
-	// the profile's unified/separate mode and persisted env overrides — the
-	// same resolution the local `tingly-box cc --profile` launch uses.
-	GetClaudeCodeEnvForProfile(ctx context.Context, profileID string) ([]string, error)
+	// GetClaudeCodeSettingsPathForProfile materializes the Claude Code
+	// profile's derived settings.json — the same on-disk artifact and
+	// resolution `tingly-box cc --profile <id>` uses — and returns its path.
+	// Claude Code's --settings flag REPLACES ~/.claude/settings.json rather
+	// than merging with it, so a profile selection only takes effect when its
+	// full settings file is referenced this way; env vars alone are not
+	// enough (they lose to whatever ~/.claude/settings.json already sets,
+	// since no --settings flag means the CLI falls back to that file).
+	// Returns ("", nil) for an empty profileID — the main scenario needs no
+	// settings file, only GetClaudeCodeEnv.
+	GetClaudeCodeSettingsPathForProfile(ctx context.Context, profileID string) (string, error)
 
 	// GetHTTPEndpointForScenario returns HTTP endpoint configuration for a scenario
 	GetHTTPEndpointForScenario(ctx context.Context, scenario typ.RuleScenario) (*HTTPEndpointConfig, error)
@@ -180,19 +184,22 @@ func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 	return env, nil
 }
 
-// GetClaudeCodeEnvForProfile builds the gateway env for a specific Claude Code
-// profile. It resolves the profiled scenario ("claude_code:<id>") through the
-// same ResolveCCProfileSettings path the local `tingly-box cc --profile` launch
-// uses, so remote @cc sessions get identical routing, tier models, and profile
-// env overrides. An empty profileID falls back to the main-scenario env.
-func (c *TBClientImpl) GetClaudeCodeEnvForProfile(ctx context.Context, profileID string) ([]string, error) {
+// GetClaudeCodeSettingsPathForProfile materializes the profiled scenario
+// ("claude_code:<id>") settings file via the same MaterializeCCProfileSettings
+// path the local `tingly-box cc --profile` launch uses, and returns its path
+// for the caller to pass to the claude CLI via --settings. Writing to disk
+// (rather than just resolving env in memory) matters: --settings is how the
+// CLI is told to use this profile's routing/models/overrides AT ALL — without
+// it the CLI reads ~/.claude/settings.json as usual, and the main scenario's
+// values there would silently win over anything we injected as process env.
+func (c *TBClientImpl) GetClaudeCodeSettingsPathForProfile(ctx context.Context, profileID string) (string, error) {
 	if profileID == "" {
-		return c.GetClaudeCodeEnv(ctx)
+		return "", nil
 	}
 
 	meta, found := c.config.GetProfile(typ.ScenarioClaudeCode, profileID)
 	if !found {
-		return nil, fmt.Errorf("claude code profile %q not found", profileID)
+		return "", fmt.Errorf("claude code profile %q not found", profileID)
 	}
 
 	port := c.config.GetServerPort()
@@ -204,16 +211,11 @@ func (c *TBClientImpl) GetClaudeCodeEnvForProfile(ctx context.Context, profileID
 	apiKey := c.config.GetModelToken()
 	scenarioPath := string(typ.ProfiledScenarioName(typ.ScenarioClaudeCode, meta.ID))
 
-	resolved, err := tbagent.ResolveCCProfileSettings(c.config, baseURL, apiKey, scenarioPath, meta)
+	settingsPath, err := tbagent.MaterializeCCProfileSettings(c.config, baseURL, apiKey, scenarioPath, meta)
 	if err != nil {
-		return nil, fmt.Errorf("resolve claude code profile %q env: %w", profileID, err)
+		return "", fmt.Errorf("materialize claude code profile %q settings: %w", profileID, err)
 	}
-
-	env := make([]string, 0, len(resolved.Env))
-	for k, v := range resolved.Env {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
-	return env, nil
+	return settingsPath, nil
 }
 
 // claudeCodeModels holds the request-model name for each Claude Code model tier.

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -44,6 +44,14 @@ type TBClient interface {
 	// (including third-party model services) instead of the Anthropic API.
 	GetClaudeCodeEnv(ctx context.Context) ([]string, error)
 
+	// GetClaudeCodeEnvForProfile is the profile-aware variant of
+	// GetClaudeCodeEnv. An empty profileID behaves exactly like
+	// GetClaudeCodeEnv (main claude_code scenario); a non-empty profileID
+	// routes through the profiled scenario ("claude_code:<id>") and applies
+	// the profile's unified/separate mode and persisted env overrides — the
+	// same resolution the local `tingly-box cc --profile` launch uses.
+	GetClaudeCodeEnvForProfile(ctx context.Context, profileID string) ([]string, error)
+
 	// GetHTTPEndpointForScenario returns HTTP endpoint configuration for a scenario
 	GetHTTPEndpointForScenario(ctx context.Context, scenario typ.RuleScenario) (*HTTPEndpointConfig, error)
 
@@ -167,6 +175,42 @@ func (c *TBClientImpl) GetClaudeCodeEnv(ctx context.Context) ([]string, error) {
 
 	env := make([]string, 0, len(envMap))
 	for k, v := range envMap {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env, nil
+}
+
+// GetClaudeCodeEnvForProfile builds the gateway env for a specific Claude Code
+// profile. It resolves the profiled scenario ("claude_code:<id>") through the
+// same ResolveCCProfileSettings path the local `tingly-box cc --profile` launch
+// uses, so remote @cc sessions get identical routing, tier models, and profile
+// env overrides. An empty profileID falls back to the main-scenario env.
+func (c *TBClientImpl) GetClaudeCodeEnvForProfile(ctx context.Context, profileID string) ([]string, error) {
+	if profileID == "" {
+		return c.GetClaudeCodeEnv(ctx)
+	}
+
+	meta, found := c.config.GetProfile(typ.ScenarioClaudeCode, profileID)
+	if !found {
+		return nil, fmt.Errorf("claude code profile %q not found", profileID)
+	}
+
+	port := c.config.GetServerPort()
+	if port == 0 {
+		port = 12580
+	}
+	host := c.config.GetServerHost()
+	baseURL := fmt.Sprintf("http://%s:%d", host, port)
+	apiKey := c.config.GetModelToken()
+	scenarioPath := string(typ.ProfiledScenarioName(typ.ScenarioClaudeCode, meta.ID))
+
+	resolved, err := tbagent.ResolveCCProfileSettings(c.config, baseURL, apiKey, scenarioPath, meta)
+	if err != nil {
+		return nil, fmt.Errorf("resolve claude code profile %q env: %w", profileID, err)
+	}
+
+	env := make([]string, 0, len(resolved.Env))
+	for k, v := range resolved.Env {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	return env, nil

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -316,6 +316,66 @@ func TestGetClaudeCodeEnv_RoutesThroughGateway(t *testing.T) {
 	assert.True(t, hasToken)
 }
 
+func TestGetClaudeCodeEnvForProfile_EmptyIDFallsBackToMain(t *testing.T) {
+	cfg := &serverconfig.Config{
+		ServerPort: 9000,
+		Rules:      []typ.Rule{ccRule("built-in-cc", "tingly/cc")},
+	}
+	client := NewTBClient(cfg, nil)
+
+	env, err := client.GetClaudeCodeEnvForProfile(context.Background(), "")
+	require.NoError(t, err)
+
+	kv := envToMap(env)
+	assert.Equal(t, "http://localhost:9000/tingly/claude_code", kv["ANTHROPIC_BASE_URL"])
+}
+
+func TestGetClaudeCodeEnvForProfile_UnknownProfile(t *testing.T) {
+	cfg := &serverconfig.Config{ServerPort: 9000}
+	client := NewTBClient(cfg, nil)
+
+	_, err := client.GetClaudeCodeEnvForProfile(context.Background(), "ghost")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+func TestGetClaudeCodeEnvForProfile_RoutesThroughProfiledScenario(t *testing.T) {
+	profiledRule := ccRule(serverconfig.BuiltinRuleUUID(typ.RuleScenario("claude_code:p1"), "cc"), "team/coder")
+	profiledRule.Scenario = "claude_code:p1"
+	cfg := &serverconfig.Config{
+		ServerPort: 9000,
+		Profiles: map[string][]typ.ProfileMeta{
+			string(typ.ScenarioClaudeCode): {{ID: "p1", Name: "work", Unified: true}},
+		},
+		Rules: []typ.Rule{profiledRule},
+	}
+	client := NewTBClient(cfg, nil)
+
+	env, err := client.GetClaudeCodeEnvForProfile(context.Background(), "p1")
+	require.NoError(t, err)
+
+	kv := envToMap(env)
+	// The base URL must point at the PROFILED scenario endpoint so requests
+	// route through the profile's rules, and the unified model comes from the
+	// profile's builtin rule.
+	assert.Equal(t, "http://localhost:9000/tingly/claude_code:p1", kv["ANTHROPIC_BASE_URL"])
+	assert.Equal(t, "team/coder", kv["ANTHROPIC_MODEL"])
+	assert.Equal(t, "team/coder", kv["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+}
+
+func envToMap(env []string) map[string]string {
+	kv := map[string]string{}
+	for _, e := range env {
+		for i := 0; i < len(e); i++ {
+			if e[i] == '=' {
+				kv[e[:i]] = e[i+1:]
+				break
+			}
+		}
+	}
+	return kv
+}
+
 func TestGetScenarioEndpointPath(t *testing.T) {
 	client := NewTBClient(&serverconfig.Config{}, nil)
 	tests := []struct {

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -2,6 +2,8 @@ package tbclient
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -316,30 +318,31 @@ func TestGetClaudeCodeEnv_RoutesThroughGateway(t *testing.T) {
 	assert.True(t, hasToken)
 }
 
-func TestGetClaudeCodeEnvForProfile_EmptyIDFallsBackToMain(t *testing.T) {
-	cfg := &serverconfig.Config{
-		ServerPort: 9000,
-		Rules:      []typ.Rule{ccRule("built-in-cc", "tingly/cc")},
-	}
-	client := NewTBClient(cfg, nil)
-
-	env, err := client.GetClaudeCodeEnvForProfile(context.Background(), "")
-	require.NoError(t, err)
-
-	kv := envToMap(env)
-	assert.Equal(t, "http://localhost:9000/tingly/claude_code", kv["ANTHROPIC_BASE_URL"])
-}
-
-func TestGetClaudeCodeEnvForProfile_UnknownProfile(t *testing.T) {
+func TestGetClaudeCodeSettingsPathForProfile_EmptyIDReturnsNoPath(t *testing.T) {
+	// The main scenario needs no materialized settings file — the caller
+	// falls back to GetClaudeCodeEnv (process env) in that case.
 	cfg := &serverconfig.Config{ServerPort: 9000}
 	client := NewTBClient(cfg, nil)
 
-	_, err := client.GetClaudeCodeEnvForProfile(context.Background(), "ghost")
+	path, err := client.GetClaudeCodeSettingsPathForProfile(context.Background(), "")
+	require.NoError(t, err)
+	assert.Empty(t, path)
+}
+
+func TestGetClaudeCodeSettingsPathForProfile_UnknownProfile(t *testing.T) {
+	cfg := &serverconfig.Config{ServerPort: 9000}
+	client := NewTBClient(cfg, nil)
+
+	_, err := client.GetClaudeCodeSettingsPathForProfile(context.Background(), "ghost")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ghost")
 }
 
-func TestGetClaudeCodeEnvForProfile_RoutesThroughProfiledScenario(t *testing.T) {
+func TestGetClaudeCodeSettingsPathForProfile_MaterializesProfileSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
 	profiledRule := ccRule(serverconfig.BuiltinRuleUUID(typ.RuleScenario("claude_code:p1"), "cc"), "team/coder")
 	profiledRule.Scenario = "claude_code:p1"
 	cfg := &serverconfig.Config{
@@ -351,16 +354,23 @@ func TestGetClaudeCodeEnvForProfile_RoutesThroughProfiledScenario(t *testing.T) 
 	}
 	client := NewTBClient(cfg, nil)
 
-	env, err := client.GetClaudeCodeEnvForProfile(context.Background(), "p1")
+	path, err := client.GetClaudeCodeSettingsPathForProfile(context.Background(), "p1")
+	require.NoError(t, err)
+	require.NotEmpty(t, path)
+
+	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 
-	kv := envToMap(env)
-	// The base URL must point at the PROFILED scenario endpoint so requests
-	// route through the profile's rules, and the unified model comes from the
-	// profile's builtin rule.
-	assert.Equal(t, "http://localhost:9000/tingly/claude_code:p1", kv["ANTHROPIC_BASE_URL"])
-	assert.Equal(t, "team/coder", kv["ANTHROPIC_MODEL"])
-	assert.Equal(t, "team/coder", kv["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+	var written struct {
+		Env map[string]string `json:"env"`
+	}
+	require.NoError(t, json.Unmarshal(data, &written))
+
+	// The materialized file — the one --settings will point the CLI at —
+	// must carry the PROFILED scenario endpoint and the profile's resolved
+	// model, not the main scenario's.
+	assert.Equal(t, "http://localhost:9000/tingly/claude_code:p1", written.Env["ANTHROPIC_BASE_URL"])
+	assert.Equal(t, "team/coder", written.Env["ANTHROPIC_MODEL"])
 }
 
 func envToMap(env []string) map[string]string {

--- a/internal/tbclient/tb_client_test.go
+++ b/internal/tbclient/tb_client_test.go
@@ -373,19 +373,6 @@ func TestGetClaudeCodeSettingsPathForProfile_MaterializesProfileSettings(t *test
 	assert.Equal(t, "team/coder", written.Env["ANTHROPIC_MODEL"])
 }
 
-func envToMap(env []string) map[string]string {
-	kv := map[string]string{}
-	for _, e := range env {
-		for i := 0; i < len(e); i++ {
-			if e[i] == '=' {
-				kv[e[:i]] = e[i+1:]
-				break
-			}
-		}
-	}
-	return kv
-}
-
 func TestGetScenarioEndpointPath(t *testing.T) {
 	client := NewTBClient(&serverconfig.Config{}, nil)
 	tests := []struct {


### PR DESCRIPTION
## Summary

Extends the remote @cc agent to support Claude Code profiles, allowing users to route remote executions through a named profile (with its own routing rules, unified/separate mode, and env overrides) instead of always using the main `claude_code` scenario. This mirrors the local `tingly-box cc --profile <id>` behavior.

## Key Changes

**Backend**
- Added `default_agent` field to `BotSetting` to store which Claude Code configuration serves @cc for a bot (`""` / `"claude_code"` = main scenario, `"claude_code:<id>"` = a profile)
- Implemented `GetClaudeCodeSettingsPathForProfile()` in `TBClient` to materialize profile settings files (same artifact as local launch) and pass them via `--settings` flag to the Claude Code CLI
- Updated `ClaudeCodeExecutor.Execute()` to read `default_agent` dynamically and route through the selected profile's settings file or fall back to main scenario env vars
- Added validation in `imbot/handler.go` to reject invalid `default_agent` values on create/update (only `claude_code` base + optional profile ID allowed)
- Updated bot handler/manager to propagate `DefaultAgent` from DB records

**Frontend**
- Created `CCProfileNode` component to display the selected profile ("Default" or profile name) on the @cc branch of the Remote Control graph
- Created `CCProfileDialog` to pick a profile (Default + all configured Claude Code profiles from `ProfileContext`)
- Updated `RemoteControlGraph` to include the profile node and wire click handlers
- Added `ccProfileIdFromDefaultAgent()` and `defaultAgentForCCProfile()` helpers in `bot.ts` to parse/build the `default_agent` value
- Simplified `AgentNode` tooltip from hand-rolled Popover to `NodeTooltip` (MUI Tooltip) to avoid flicker on tall content
- Updated agent descriptions to be more concise and reflect the new profile routing model

**Documentation**
- Added `.design/remote-cc-profile.md` explaining the selection mechanism, execution path reuse, and why settings files (not env vars alone) are needed for profiles to work

## Notable Implementation Details

- **Settings file materialization**: Profiles require their full settings.json to be written to disk and referenced via `--settings` because the Claude Code CLI's `--settings` flag *replaces* `~/.claude/settings.json` rather than merging with it. Injecting profile values as process env alone is insufficient — the CLI would still read the main settings file and use its values.
- **Dynamic profile resolution**: `default_agent` is read on each message, so a profile switch in the web UI applies immediately without restarting the bot.
- **Graceful fallback**: If a selected profile is deleted, execution falls back to the main scenario and warns the user in-chat rather than failing silently.
- **Tooltip refactor**: Replaced the custom Popover hover logic in `AgentNode` with MUI's `Tooltip` component, which has built-in hysteresis and avoids the flicker loop that occurred when tall content collided with viewport edges.

https://claude.ai/code/session_012ohyr8RK6FUTYBCcp5UPez