### PR TITLE
refactor(agentboot): isolate Claude executions and harden lifecycle

### DIFF
--- a/.design/agentboot-refactor.md
+++ b/.design/agentboot-refactor.md
@@ -406,9 +406,40 @@ not pursued: it would create an `agentboot → ask → agentboot` import cycle (
 `Prompter` interface lives in `agentboot`), and the single `event → ask.Request →
 ask.Result → response` hop in `imprompter.go` is already minimal.
 
-Net: the refactor stops after P1.5. The earlier P0/P1/P1.5 deletions removed a
-genuinely redundant *parallel paradigm*; this PR removes only the
-misleading/orphan accessors and keeps one coherent query + scalar surface.
+Net through P2: the earlier P0/P1/P1.5 deletions removed a genuinely redundant
+*parallel paradigm*; P2 removed only misleading/orphan accessors and kept one
+coherent query + scalar surface.
+
+### P3 — per-query state and lifecycle isolation — DONE
+
+Reference implementation: the locally installed Python `claude-agent-sdk`
+0.2.126. Its one-shot `query()` creates a fresh transport and query controller
+per call, treats decode/process failures as terminal, and closes stdin before
+terminate/kill escalation. Agentboot now adopts those lifecycle properties:
+
+1. `Runner` stores an `AgentTransportFactory`, not an `AgentTransport`.
+   `Execute` calls the factory once, so Claude's mutable message accumulator and
+   routing context cannot leak across concurrent bot chats. `Agent` and
+   `Launcher` no longer cache a transport.
+2. `RunnerConfig` makes the existing `StreamBufferSize` and
+   `DefaultExecutionTimeout` settings effective. A per-call zero timeout uses
+   the default; a negative timeout explicitly disables it.
+3. Terminal results close the protocol encoder/stdin first. A bounded grace
+   period lets Claude flush its session file before the runner escalates to
+   `Kill`.
+4. `ResultError`, `ProcessError`, and `ProtocolError` preserve the actual
+   failure class, CLI subtype/details, exit code, and wrapped cause.
+   `Result.ExitCode` and `Result.Error` now agree with `Wait`.
+5. Fatal decoder errors stop the process instead of waiting forever, and a
+   stream-json EOF without a result returns `ErrNoTerminalResult`.
+
+Deliberately not copied from the SDK: persistent bidirectional clients, hooks,
+in-process MCP servers, rewind/task controls, and dynamic model/permission
+mutation. None is required by the current remote-control product path.
+
+Regression coverage includes two overlapping runs on one Agent (routing
+isolation), configured buffer/timeout, non-zero process exit, malformed JSON,
+missing terminal result, structured result errors, and encoder-close behavior.
 
 ### Verification per phase
 

--- a/agentboot/README.md
+++ b/agentboot/README.md
@@ -57,7 +57,7 @@ func main() {
         case agentboot.AskRequestEvent:
             _ = handle.Respond(e.ID, agentboot.AskResponse{Approved: true})
         case agentboot.ErrorEvent:
-            log.Printf("non-fatal: %v", e.Err)
+            log.Printf("stream error: %v", e.Err)
         }
     }
 
@@ -69,48 +69,50 @@ func main() {
 }
 ```
 
-### Through the AgentBoot registry
+### Through AgentService
 
 ```go
-ab, err := agentboot.New(agentboot.Config{
+config := agentboot.Config{
     DefaultAgent:     agentboot.AgentTypeClaude,
     DefaultFormat:    agentboot.OutputFormatStreamJSON,
     EnableStreamJSON: true,
-})
+}
+service, err := agentboot.NewAgentService(config)
 if err != nil {
     log.Fatal(err)
 }
 
-ab.RegisterAgent(agentboot.AgentTypeClaude, claude.NewAgent(ab.GetConfig()))
+service.RegisterAgent(agentboot.AgentTypeClaude, claude.NewAgent(config))
 
-agent, err := ab.GetDefaultAgent()
-if err != nil {
-    log.Fatal(err)
-}
-
-handle, err := agent.Execute(ctx, "List files", agentboot.ExecutionOptions{
-    ProjectPath: "/tmp",
-})
+handle, err := service.Execute(
+    ctx,
+    agentboot.AgentTypeClaude,
+    "/tmp",
+    "List files",
+    agentboot.ExecutionOptions{},
+)
 // ...consume handle.Events(), then handle.Wait()
 ```
 
 ### Resuming a Claude session
 
 ```go
-ab, _ := agentboot.New(agentboot.Config{
+service, _ := agentboot.NewAgentService(agentboot.Config{
     DefaultAgent:      agentboot.AgentTypeClaude,
     ClaudeProjectsDir: "", // empty = ~/.claude/projects
 })
 
-sessions, err := ab.ListRecentSessions(ctx, "/abs/project/path", 10)
+sessions, err := service.ListSessions(ctx, "/abs/project/path", 10)
 if err != nil {
     log.Fatal(err)
 }
 
-opts := ab.ResumeSession(sessions[0].SessionID)
-opts.ProjectPath = "/abs/project/path"
-
-handle, err := agent.Execute(ctx, "Continue", opts)
+handle, err := service.ExecuteSession(
+    ctx,
+    sessions[0].SessionID,
+    "Continue",
+    agentboot.ExecutionOptions{},
+)
 ```
 
 ## Execution Lifecycle
@@ -135,9 +137,11 @@ protocol state is isolated.
 | `MessageEvent`          | Agent message (assistant text, tool use, tool result, etc.) |
 | `ApprovalRequestEvent`  | Tool permission request — caller must `Respond`              |
 | `AskRequestEvent`       | Interactive question (e.g. AskUserQuestion)                  |
-| `ErrorEvent`            | Non-fatal error — execution continues                         |
+| `ErrorEvent`            | Stream error; may mirror the fatal error returned by `Wait`   |
 
 Fatal errors are surfaced via the error returned from `handle.Wait()`.
+Use `errors.As` with `*ResultError`, `*ProcessError`, or `*ProtocolError`
+when callers need structured handling.
 
 ## Output Formats
 
@@ -167,7 +171,7 @@ Set per-execution via `ExecutionOptions.PermissionMode`, or globally on the Clau
 | `EnableStreamJSON`          | `true`                           |
 | `StreamBufferSize`          | `100`                            |
 | `DefaultExecutionTimeout`   | `0` (no timeout)                 |
-| `ClaudeProjectsDir`         | `""` (session store disabled)    |
+| `ClaudeProjectsDir`         | `""` (`~/.claude/projects`)      |
 
 `ExecutionOptions` carries per-call overrides: project path, output format, timeout, env, session ID + resume flag, model and fallback model, max turns, allowed/disallowed tools, MCP servers, custom/append system prompts, permission mode, settings path, permission prompt tool, and a session store sink. A zero timeout uses the configured default; a negative timeout explicitly disables it.
 
@@ -175,23 +179,20 @@ Set per-execution via `ExecutionOptions.PermissionMode`, or globally on the Clau
 
 ```
 agentboot/
-├── agentboot.go          # AgentBoot registry + session helpers
+├── agentboot.go          # Internal agent registry
 ├── config.go             # DefaultConfig / DefaultPermissionConfig
 ├── types.go              # Agent interface, ExecutionOptions, Result, ...
+├── errors.go             # Structured result/process/protocol errors
 ├── handle.go             # ExecutionHandle + ControlResponse types
 ├── events.go             # StreamEvent sum type (Message/Approval/Ask/Error)
-├── handler.go            # CompositeHandler for streamer/approval/ask/completion
-├── builder.go            # Function-typed handler adapters
 ├── driver.go             # AgentDriver interface + LaunchSpec
-├── transport.go          # AgentTransport interface
-├── runner.go             # Generic Runner wiring driver+transport+process
-├── run.go                # Run loop / event pump
-├── message.go            # Internal message routing
-├── session_bridge.go     # Session lifecycle bridging
+├── transport.go          # AgentTransport + per-execution factory
+├── runner.go             # Generic per-execution lifecycle engine
+├── run.go                # High-level Prompter/MessageSink consumer
+├── service.go            # Public AgentService façade
 ├── ask/                  # Ask/permission prompter implementations
 ├── common/               # Shared event + session metadata types
 ├── process/              # Process abstraction (osexec + fake for tests)
-├── prompt/               # Prompt utilities
 ├── protocol/             # Stream-JSON encoder / decoder
 ├── session/              # Generic session store interface
 └── claude/               # Claude Code agent implementation
@@ -236,7 +237,10 @@ The fastest path is to reuse the generic `Runner` by implementing `AgentDriver` 
    func (a *Agent) SetDefaultFormat(f agentboot.OutputFormat)      { a.runner.SetDefaultFormat(f) }
    func (a *Agent) GetDefaultFormat() agentboot.OutputFormat       { return a.runner.GetDefaultFormat() }
    ```
-3. Add the constant to `types.go` and register the agent on an `AgentBoot` with `RegisterAgent`.
+   The factory must return a fresh transport; transports may own mutable
+   per-run state.
+3. Add the constant to `types.go` and register the agent on an `AgentService`
+   with `RegisterAgent`.
 
 For agents that don't fit the process+protocol pipeline (in-process mocks, remote services), use `agentboot.NewControlledHandle` to drive an `ExecutionHandle` directly.
 

--- a/agentboot/README.md
+++ b/agentboot/README.md
@@ -6,6 +6,7 @@ AgentBoot is a unified bootstrapping and runtime layer for AI coding agents. It 
 
 - **Unified Agent interface** — one `Execute` entry point for every agent type.
 - **Streaming execution handle** — consume a totally-ordered event channel and respond to permission / ask requests inline.
+- **Per-execution protocol isolation** — every run owns its transport, accumulator, routing context, process, and control state.
 - **Driver + Transport + Runner split** — process setup, protocol parsing, and execution are independent and individually testable.
 - **Pluggable process factory** — swap real `os/exec` for a scripted fake in tests without touching the driver or transport.
 - **Session store integration** — list and resume Claude Code sessions read from `~/.claude/projects`.
@@ -118,11 +119,14 @@ handle, err := agent.Execute(ctx, "Continue", opts)
 
 1. Iterate `handle.Events()` from a single goroutine. Events are delivered in totally-ordered form.
 2. For `ApprovalRequestEvent` and `AskRequestEvent`, call `handle.Respond(req.ID, response)` with the matching `ControlResponse` — `ApprovalResponse` or `AskResponse`. The response is forwarded to the agent process's stdin.
-3. The events channel closes after the process has exited *and* every decoded event has been delivered.
-4. After the channel closes, `handle.Wait()` returns the aggregated `*Result`.
-5. `handle.Cancel()` requests cooperative shutdown; the underlying context can be cancelled to the same effect.
+3. On a terminal result, the runner closes stdin so the CLI can flush session state; it escalates to `Kill` only after a bounded grace period.
+4. The events channel closes after the process has exited *and* every decoded event has been delivered.
+5. After the channel closes, `handle.Wait()` returns the aggregated `*Result` and the authoritative terminal error.
+6. `handle.Cancel()` requests cooperative shutdown; the underlying context can be cancelled to the same effect.
 
 `Respond`, `Cancel`, and `Wait` are safe to call from any goroutine.
+Different handles from the same Agent may run concurrently; their mutable
+protocol state is isolated.
 
 ## Stream Events
 
@@ -165,7 +169,7 @@ Set per-execution via `ExecutionOptions.PermissionMode`, or globally on the Clau
 | `DefaultExecutionTimeout`   | `0` (no timeout)                 |
 | `ClaudeProjectsDir`         | `""` (session store disabled)    |
 
-`ExecutionOptions` carries per-call overrides: project path, output format, timeout, env, session ID + resume flag, model and fallback model, max turns, allowed/disallowed tools, MCP servers, custom/append system prompts, permission mode, settings path, permission prompt tool, and a session store sink.
+`ExecutionOptions` carries per-call overrides: project path, output format, timeout, env, session ID + resume flag, model and fallback model, max turns, allowed/disallowed tools, MCP servers, custom/append system prompts, permission mode, settings path, permission prompt tool, and a session store sink. A zero timeout uses the configured default; a negative timeout explicitly disables it.
 
 ## Package Structure
 
@@ -218,8 +222,10 @@ The fastest path is to reuse the generic `Runner` by implementing `AgentDriver` 
    ```go
    func NewAgent(cfg agentboot.Config) *Agent {
        d := NewDriver(cfg)
-       t := NewTransport()
-       return &Agent{runner: agentboot.NewRunner(d, t), driver: d}
+       newTransport := func() agentboot.AgentTransport {
+           return NewTransport()
+       }
+       return &Agent{runner: agentboot.NewRunner(d, newTransport), driver: d}
    }
 
    func (a *Agent) Execute(ctx context.Context, prompt string, opts agentboot.ExecutionOptions) (agentboot.ExecutionHandle, error) {
@@ -240,7 +246,9 @@ For agents that don't fit the process+protocol pipeline (in-process mocks, remot
 - `claude.NewAgentWithFactory` wires a fake factory into the real Claude driver/transport so end-to-end stream-JSON parsing is exercised without spawning `claude`.
 - `NewControlledHandle` lets tests build an `ExecutionHandle` from closures.
 
-See `agentboot/claude/*_e2e_test.go` and `agentboot/handle_test.go` for the patterns.
+See `agentboot/claude/fixture/fixture_test.go`,
+`agentboot/claude/agent_concurrency_test.go`, and
+`agentboot/handle_test.go` for the patterns.
 
 ## License
 

--- a/agentboot/claude/agent.go
+++ b/agentboot/claude/agent.go
@@ -10,9 +10,8 @@ import (
 // Agent implements the agentboot.Agent interface for Claude Code.
 // Internally it uses Driver (process setup) + Transport (protocol) + agentboot.Runner (execution).
 type Agent struct {
-	runner    *agentboot.Runner
-	driver    *Driver
-	transport *Transport
+	runner *agentboot.Runner
+	driver *Driver
 }
 
 // NewAgent creates a new Claude agent.
@@ -22,18 +21,24 @@ func NewAgent(config agentboot.Config) *Agent {
 		StreamBufferSize:        config.StreamBufferSize,
 		DefaultExecutionTimeout: config.DefaultExecutionTimeout,
 	}
-	return NewAgentWithConfig(claudeConfig)
+	agent := NewAgentWithConfig(claudeConfig)
+	if config.DefaultFormat != "" {
+		agent.SetDefaultFormat(config.DefaultFormat)
+	}
+	return agent
 }
 
 // NewAgentWithConfig creates a Claude agent with full Claude-specific config.
 func NewAgentWithConfig(config Config) *Agent {
 	driver := NewDriver(config)
-	transport := NewTransport()
-	runner := agentboot.NewRunner(driver, transport)
+	runner := agentboot.NewRunnerWithConfig(
+		driver,
+		func() agentboot.AgentTransport { return NewTransport() },
+		runnerConfig(config),
+	)
 	return &Agent{
-		runner:    runner,
-		driver:    driver,
-		transport: transport,
+		runner: runner,
+		driver: driver,
 	}
 }
 
@@ -49,12 +54,23 @@ func NewAgentWithFactory(config Config, factory process.Factory) *Agent {
 	driver := NewDriver(config)
 	driver.SetForceAvailable(true)
 	driver.SetCLIPath("claude-fixture-binary") // sentinel; resolveBinary returns it as-is
-	transport := NewTransport()
-	runner := agentboot.NewRunnerWithFactory(driver, transport, factory)
+	runner := agentboot.NewRunnerWithFactoryAndConfig(
+		driver,
+		func() agentboot.AgentTransport { return NewTransport() },
+		factory,
+		runnerConfig(config),
+	)
 	return &Agent{
-		runner:    runner,
-		driver:    driver,
-		transport: transport,
+		runner: runner,
+		driver: driver,
+	}
+}
+
+func runnerConfig(config Config) agentboot.RunnerConfig {
+	return agentboot.RunnerConfig{
+		DefaultFormat:           agentboot.OutputFormatStreamJSON,
+		EventBufferSize:         config.StreamBufferSize,
+		DefaultExecutionTimeout: config.DefaultExecutionTimeout,
 	}
 }
 

--- a/agentboot/claude/agent_concurrency_test.go
+++ b/agentboot/claude/agent_concurrency_test.go
@@ -1,0 +1,127 @@
+package claude_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+	"github.com/tingly-dev/tingly-box/agentboot/claude"
+	"github.com/tingly-dev/tingly-box/agentboot/process"
+)
+
+// TestAgent_OverlappingExecutionsIsolateTransportContext reproduces the
+// production shape where one registered Agent serves multiple chats. The
+// first permission event is emitted only after the second Execute has begun;
+// a shared transport would stamp both events with chat-2's routing context.
+func TestAgent_OverlappingExecutionsIsolateTransportContext(t *testing.T) {
+	factory := process.NewFakeFactory()
+	factory.OnStart = func(_ context.Context, _ process.LaunchSpec, h *process.FakeHandle) {
+		go func() {
+			_, _ = io.Copy(io.Discard, h.StdinR)
+		}()
+	}
+	agent := claude.NewAgentWithFactory(claude.Config{}, factory)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first, err := agent.Execute(ctx, "first", agentboot.ExecutionOptions{
+		SessionID: "session-1",
+		ChatID:    "chat-1",
+		Platform:  "telegram",
+		BotUUID:   "bot-1",
+	})
+	require.NoError(t, err)
+	second, err := agent.Execute(ctx, "second", agentboot.ExecutionOptions{
+		SessionID: "session-2",
+		ChatID:    "chat-2",
+		Platform:  "discord",
+		BotUUID:   "bot-2",
+	})
+	require.NoError(t, err)
+
+	handles := factory.Handles()
+	require.Len(t, handles, 2)
+	writeFakeEvent(t, handles[0], map[string]any{
+		"type":       claude.SDKControlRequestMessage,
+		"request_id": "request-1",
+		"request": map[string]any{
+			"subtype":   claude.ControlRequestSubtypeCanUseTool,
+			"tool_name": "Bash",
+			"input":     map[string]any{"command": "pwd"},
+		},
+	})
+	writeFakeEvent(t, handles[1], map[string]any{
+		"type":       claude.SDKControlRequestMessage,
+		"request_id": "request-2",
+		"request": map[string]any{
+			"subtype":   claude.ControlRequestSubtypeCanUseTool,
+			"tool_name": "Read",
+			"input":     map[string]any{"file_path": "README.md"},
+		},
+	})
+
+	firstApproval := receiveApproval(t, first)
+	secondApproval := receiveApproval(t, second)
+	assert.Equal(t, "session-1", firstApproval.SessionID)
+	assert.Equal(t, "chat-1", firstApproval.ChatID)
+	assert.Equal(t, "telegram", firstApproval.Platform)
+	assert.Equal(t, "bot-1", firstApproval.BotUUID)
+	assert.Equal(t, "session-2", secondApproval.SessionID)
+	assert.Equal(t, "chat-2", secondApproval.ChatID)
+	assert.Equal(t, "discord", secondApproval.Platform)
+	assert.Equal(t, "bot-2", secondApproval.BotUUID)
+
+	require.NoError(t, first.Respond(firstApproval.ID, agentboot.ApprovalResponse{Approved: true}))
+	require.NoError(t, second.Respond(secondApproval.ID, agentboot.ApprovalResponse{Approved: true}))
+
+	finishSuccessfulRun(t, handles[0])
+	finishSuccessfulRun(t, handles[1])
+	for range first.Events() {
+	}
+	for range second.Events() {
+	}
+	_, err = first.Wait()
+	require.NoError(t, err)
+	_, err = second.Wait()
+	require.NoError(t, err)
+}
+
+func receiveApproval(t *testing.T, handle agentboot.ExecutionHandle) agentboot.ApprovalRequestEvent {
+	t.Helper()
+	select {
+	case event := <-handle.Events():
+		approval, ok := event.(agentboot.ApprovalRequestEvent)
+		require.True(t, ok, "event type = %T, want ApprovalRequestEvent", event)
+		return approval
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for approval event")
+		return agentboot.ApprovalRequestEvent{}
+	}
+}
+
+func finishSuccessfulRun(t *testing.T, handle *process.FakeHandle) {
+	t.Helper()
+	writeFakeEvent(t, handle, map[string]any{
+		"type":     claude.SDKResultMessage,
+		"subtype":  claude.ResultSubtypeSuccess,
+		"is_error": false,
+	})
+	handle.FinishOutput()
+	handle.SignalExit(nil)
+}
+
+func writeFakeEvent(t *testing.T, handle *process.FakeHandle, event map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	data = append(data, '\n')
+	_, err = handle.WriteOutput(data)
+	require.NoError(t, err)
+}

--- a/agentboot/claude/cli_discovery.go
+++ b/agentboot/claude/cli_discovery.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -23,25 +24,32 @@ const (
 	EnvUseBundled  = "CLAUDE_USE_BUNDLED"
 	EnvUseGlobal   = "CLAUDE_USE_GLOBAL"
 	EnvClaudeHome  = "CLAUDE_HOME"
-	EnvBunEnv      = "BUN_INSTALL"
 	EnvNodePath    = "NODE_PATH"
 	EnvBunVersions = "BUN_VERSIONS"
 	EnvBunInstall  = "BUN_INSTALL"
 
-	// Default paths
-	DefaultBundledPathLinux   = "/opt/claude-code/dist/claude"
-	DefaultBundledPathDarwin  = "/Applications/Claude.app/Contents/MacOS/claude"
-	DefaultBundledPathWindows = `C:\Program Files\Claude\claude.exe`
+	// EnvBunEnv is retained for source compatibility.
+	// Deprecated: use EnvBunInstall.
+	EnvBunEnv = EnvBunInstall
 
-	// Claude version for bundled fallback
-	DefaultBundledVersion = "1.0.0"
+	claudeCLIProbeTimeout = 5 * time.Second
+)
+
+// Deprecated bundled fallback constants retained so existing agentboot
+// consumers continue to compile. Packaged Claude Code paths are installation
+// relative and are now discovered dynamically; no fixed path/version is safe.
+const (
+	DefaultBundledPathLinux   = ""
+	DefaultBundledPathDarwin  = ""
+	DefaultBundledPathWindows = ""
+	DefaultBundledVersion     = ""
 )
 
 // CLIVariant represents a discovered Claude CLI installation
 type CLIVariant struct {
 	Path    string
 	Version string
-	Source  string // "global", "bundled", "custom", "env"
+	Source  string // "global", "bundled", "native", "custom"
 }
 
 // CLIDiscovery handles Claude CLI path discovery and version checking
@@ -50,11 +58,26 @@ type CLIDiscovery struct {
 	cachedVariant   *CLIVariant
 	cachedEnv       []string
 	forceRediscover bool
+	forceBundled    bool
+	forceGlobal     bool
 }
 
 // NewCLIDiscovery creates a new CLI discovery instance
 func NewCLIDiscovery() *CLIDiscovery {
 	return &CLIDiscovery{}
+}
+
+// SetPreference configures a discovery source preference. A bundled CLI means
+// a Claude Code executable packaged alongside Tingly-Box; it never means the
+// Claude Desktop application.
+func (d *CLIDiscovery) SetPreference(useBundled, useGlobal bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.forceBundled = useBundled
+	d.forceGlobal = useGlobal
+	d.cachedVariant = nil
+	d.forceRediscover = true
 }
 
 // FindClaudeCLI finds the best available Claude CLI installation
@@ -110,60 +133,60 @@ func (d *CLIDiscovery) GetCleanEnv(ctx context.Context) ([]string, error) {
 func (d *CLIDiscovery) discoverCLI(ctx context.Context) (*CLIVariant, error) {
 	// 1. Check explicit override via environment variable
 	if path := os.Getenv(EnvClaudePath); path != "" {
-		if d.isExecutable(path) {
-			variant := &CLIVariant{
-				Path:   path,
-				Source: "custom",
-			}
-			// Try to get version
-			if version, err := d.getClaudeVersion(ctx, path); err == nil {
-				variant.Version = version
-			}
-			return variant, nil
+		variant, err := d.validateVariant(ctx, path, "custom")
+		if err != nil {
+			return nil, fmt.Errorf("%s does not point to a usable Claude Code CLI: %w", EnvClaudePath, err)
 		}
-		return nil, fmt.Errorf("CLAUDE_CLI_PATH set but not executable: %s", path)
+		return variant, nil
 	}
 
 	// 2. Check forced flags
-	if os.Getenv(EnvUseBundled) == "1" {
-		bundled := d.getBundledVariant()
-		if bundled != nil {
+	forceBundled := d.forceBundled || os.Getenv(EnvUseBundled) == "1"
+	forceGlobal := d.forceGlobal || os.Getenv(EnvUseGlobal) == "1"
+	if forceBundled && forceGlobal {
+		return nil, fmt.Errorf("%s and %s cannot both be enabled", EnvUseBundled, EnvUseGlobal)
+	}
+	if forceBundled {
+		bundled, err := d.findBundledVariant(ctx)
+		if err == nil {
 			return bundled, nil
 		}
-		return nil, fmt.Errorf("CLAUDE_USE_BUNDLED set but no bundled CLI found")
+		return nil, fmt.Errorf("%s set but no packaged Claude Code CLI found: %w", EnvUseBundled, err)
 	}
 
-	if os.Getenv(EnvUseGlobal) == "1" {
+	if forceGlobal {
 		global, err := d.findGlobalVariant(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("CLAUDE_USE_GLOBAL set but global CLI not found: %w", err)
+			return nil, fmt.Errorf("%s set but Claude Code CLI was not found in PATH: %w", EnvUseGlobal, err)
 		}
 		return global, nil
 	}
 
-	// 3. Find global variant
-	global, err := d.findGlobalVariant(ctx)
-	if err == nil && global != nil {
-		// Compare with bundled if available
-		bundled := d.getBundledVariant()
-		if bundled != nil && global.Version != "" && bundled.Version != "" {
-			// Use newer version
-			if compareVersions(global.Version, bundled.Version) < 0 {
-				logrus.Debugf("Using bundled CLI (newer): %s vs %s", bundled.Version, global.Version)
-				return bundled, nil
-			}
-			logrus.Debugf("Using global CLI (newer): %s vs %s", global.Version, bundled.Version)
+	// 3. Probe every supported Claude Code installation source and choose the
+	// newest verified CLI. PATH wins ties because it reflects the user's
+	// explicit shell selection.
+	var variants []*CLIVariant
+	if global, err := d.findGlobalVariant(ctx); err == nil {
+		variants = append(variants, global)
+	}
+	if bundled, err := d.findBundledVariant(ctx); err == nil {
+		variants = append(variants, bundled)
+	}
+	if native, err := d.findKnownVariant(ctx); err == nil {
+		variants = append(variants, native)
+	}
+
+	if len(variants) == 0 {
+		return nil, fmt.Errorf("no verified Claude Code CLI installation found")
+	}
+	best := variants[0]
+	for _, candidate := range variants[1:] {
+		if candidate.Path != best.Path && compareVersions(candidate.Version, best.Version) > 0 {
+			best = candidate
 		}
-		return global, nil
 	}
-
-	// 4. Fallback to bundled
-	bundled := d.getBundledVariant()
-	if bundled != nil {
-		return bundled, nil
-	}
-
-	return nil, fmt.Errorf("no Claude CLI installation found")
+	logrus.Debugf("Using Claude Code CLI %s from %s: %s", best.Version, best.Source, best.Path)
+	return best, nil
 }
 
 // findGlobalVariant searches for globally installed Claude CLI
@@ -177,53 +200,116 @@ func (d *CLIDiscovery) findGlobalVariant(ctx context.Context) (*CLIVariant, erro
 			continue
 		}
 
-		// Verify it's actually Claude CLI
-		if !d.verifyClaudeCLI(ctx, path) {
+		variant, err := d.validateVariant(ctx, path, "global")
+		if err != nil {
 			continue
 		}
-
-		variant := &CLIVariant{
-			Path:   path,
-			Source: "global",
-		}
-
-		// Get version
-		if version, err := d.getClaudeVersion(ctx, path); err == nil {
-			variant.Version = version
-		}
-
 		return variant, nil
 	}
 
-	return nil, fmt.Errorf("global Claude CLI not found in PATH")
+	return nil, fmt.Errorf("verified Claude Code CLI not found in PATH")
 }
 
-// getBundledVariant returns the bundled Claude CLI if available
-func (d *CLIDiscovery) getBundledVariant() *CLIVariant {
-	path := d.getBundledPath()
-	if path == "" || !d.isExecutable(path) {
+// findBundledVariant returns a verified Claude Code CLI packaged alongside
+// Tingly-Box. Claude Desktop is intentionally not a candidate.
+func (d *CLIDiscovery) findBundledVariant(ctx context.Context) (*CLIVariant, error) {
+	var variants []*CLIVariant
+	for _, path := range d.bundledCandidatePaths() {
+		variant, err := d.validateVariant(ctx, path, "bundled")
+		if err == nil {
+			variants = append(variants, variant)
+		}
+	}
+	if len(variants) > 0 {
+		return newestVariant(variants), nil
+	}
+	return nil, fmt.Errorf("no verified application-local Claude Code CLI")
+}
+
+func (d *CLIDiscovery) bundledCandidatePaths() []string {
+	executable, err := os.Executable()
+	if err != nil {
 		return nil
 	}
-
-	return &CLIVariant{
-		Path:    path,
-		Version: DefaultBundledVersion,
-		Source:  "bundled",
-	}
+	dir := filepath.Dir(executable)
+	name := claudeExecutableName()
+	return uniquePaths([]string{
+		filepath.Join(dir, name),
+		filepath.Clean(filepath.Join(dir, "..", "Resources", name)),
+		filepath.Join(dir, "claude-code", name),
+		filepath.Clean(filepath.Join(dir, "..", "Resources", "claude-code", name)),
+	})
 }
 
-// getBundledPath returns the bundled CLI path for the current platform
-func (d *CLIDiscovery) getBundledPath() string {
-	switch runtime.GOOS {
-	case "darwin":
-		return DefaultBundledPathDarwin
-	case "linux":
-		return DefaultBundledPathLinux
-	case "windows":
-		return DefaultBundledPathWindows
-	default:
-		return ""
+// findKnownVariant searches the install locations used by Claude Code's
+// native/npm installers when shell PATH setup is unavailable.
+func (d *CLIDiscovery) findKnownVariant(ctx context.Context) (*CLIVariant, error) {
+	var variants []*CLIVariant
+	for _, path := range d.knownCandidatePaths() {
+		variant, err := d.validateVariant(ctx, path, "native")
+		if err == nil {
+			variants = append(variants, variant)
+		}
 	}
+	if len(variants) > 0 {
+		return newestVariant(variants), nil
+	}
+	return nil, fmt.Errorf("Claude Code CLI not found in standard install locations")
+}
+
+func (d *CLIDiscovery) knownCandidatePaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	name := claudeExecutableName()
+	paths := []string{
+		filepath.Join(home, ".local", "bin", name),
+		filepath.Join(home, ".npm-global", "bin", name),
+		filepath.Join(home, ".claude", "local", name),
+		filepath.Join(home, "node_modules", ".bin", name),
+		filepath.Join(home, ".yarn", "bin", name),
+	}
+	if runtime.GOOS != "windows" {
+		paths = append(paths,
+			filepath.Join("/usr", "local", "bin", name),
+			filepath.Join("/opt", "homebrew", "bin", name),
+		)
+	}
+	return uniquePaths(paths)
+}
+
+func claudeExecutableName() string {
+	if runtime.GOOS == "windows" {
+		return "claude.exe"
+	}
+	return "claude"
+}
+
+func uniquePaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	unique := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		unique = append(unique, path)
+	}
+	return unique
+}
+
+func newestVariant(variants []*CLIVariant) *CLIVariant {
+	best := variants[0]
+	for _, candidate := range variants[1:] {
+		if compareVersions(candidate.Version, best.Version) > 0 {
+			best = candidate
+		}
+	}
+	return best
 }
 
 // whichCommand finds a command in PATH
@@ -254,40 +340,64 @@ func (d *CLIDiscovery) isExecutable(path string) bool {
 		return false
 	}
 
-	// Check executable bit
+	if runtime.GOOS == "windows" {
+		return true
+	}
+
+	// Check executable bit on Unix-like platforms.
 	return info.Mode().Perm()&0111 != 0
 }
 
-// verifyClaudeCLI verifies that a binary is actually Claude CLI
-func (d *CLIDiscovery) verifyClaudeCLI(ctx context.Context, path string) bool {
-	// Run with --version flag to verify
-	cleanEnv, _ := d.buildCleanEnv(ctx)
-	cmd := exec.CommandContext(ctx, path, "--version")
-	cmd.Env = cleanEnv
-
-	output, err := cmd.CombinedOutput()
+func (d *CLIDiscovery) validateVariant(ctx context.Context, path, source string) (*CLIVariant, error) {
+	version, err := d.ValidateClaudeCodeCLI(ctx, path)
 	if err != nil {
-		return false
+		return nil, err
 	}
-
-	// Check if output looks like Claude version
-	outputStr := string(output)
-	return strings.Contains(outputStr, "Claude") ||
-		strings.Contains(outputStr, "Anthropic")
+	return &CLIVariant{
+		Path:    path,
+		Version: version,
+		Source:  source,
+	}, nil
 }
 
-// getClaudeVersion gets the version string from Claude CLI
-func (d *CLIDiscovery) getClaudeVersion(ctx context.Context, path string) (string, error) {
-	cleanEnv, _ := d.buildCleanEnv(ctx)
-	cmd := exec.CommandContext(ctx, path, "--version")
-	cmd.Env = cleanEnv
-
-	output, err := cmd.Output()
+// ValidateClaudeCodeCLI verifies executable identity and returns its real
+// version. Generic Claude/Anthropic desktop binaries are rejected: the version
+// banner must identify Claude Code or the legacy Claude CLI name.
+func (d *CLIDiscovery) ValidateClaudeCodeCLI(ctx context.Context, path string) (string, error) {
+	if !d.isExecutable(path) {
+		return "", fmt.Errorf("not an executable file: %s", path)
+	}
+	output, err := d.runVersionProbe(ctx, path)
 	if err != nil {
 		return "", err
 	}
+	banner := strings.TrimSpace(output)
+	lower := strings.ToLower(banner)
+	if !strings.Contains(lower, "claude code") && !strings.Contains(lower, "claude cli") {
+		return "", fmt.Errorf("unexpected --version banner %q", banner)
+	}
+	version := parseVersion(banner)
+	if version == "" || version == "unknown" || version[0] < '0' || version[0] > '9' {
+		return "", fmt.Errorf("Claude Code version missing from banner %q", banner)
+	}
+	return version, nil
+}
 
-	return parseVersion(string(output)), nil
+func (d *CLIDiscovery) runVersionProbe(ctx context.Context, path string) (string, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, claudeCLIProbeTimeout)
+	defer cancel()
+
+	cleanEnv, _ := d.buildCleanEnv(probeCtx)
+	cmd := exec.CommandContext(probeCtx, path, "--version")
+	cmd.Env = cleanEnv
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if probeCtx.Err() != nil {
+			return "", fmt.Errorf("Claude Code version probe timed out: %w", probeCtx.Err())
+		}
+		return "", fmt.Errorf("Claude Code version probe failed: %w", err)
+	}
+	return string(output), nil
 }
 
 // buildCleanEnv creates a clean environment for running Claude CLI
@@ -299,13 +409,13 @@ func (d *CLIDiscovery) buildCleanEnv(ctx context.Context) ([]string, error) {
 
 	for _, e := range env {
 		// Skip local node_modules paths
-		if strings.HasPrefix(e, "NODE_PATH=") {
+		if strings.HasPrefix(e, EnvNodePath+"=") {
 			continue
 		}
 
 		// Skip Bun-specific paths that might interfere
-		if strings.HasPrefix(e, "BUN_VERSIONS=") ||
-			strings.HasPrefix(e, "BUN_INSTALL=") {
+		if strings.HasPrefix(e, EnvBunVersions+"=") ||
+			strings.HasPrefix(e, EnvBunInstall+"=") {
 			continue
 		}
 

--- a/agentboot/claude/cli_discovery_test.go
+++ b/agentboot/claude/cli_discovery_test.go
@@ -1,0 +1,90 @@
+package claude
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateClaudeCodeCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper uses a POSIX executable script")
+	}
+
+	discovery := NewCLIDiscovery()
+	valid := writeVersionCLI(t, "2.1.218 (Claude Code)")
+	version, err := discovery.ValidateClaudeCodeCLI(context.Background(), valid)
+	if err != nil {
+		t.Fatalf("ValidateClaudeCodeCLI() error = %v", err)
+	}
+	if version != "2.1.218" {
+		t.Fatalf("version = %q, want 2.1.218", version)
+	}
+
+	legacy := writeVersionCLI(t, "Claude CLI v1.0.0")
+	if _, err := discovery.ValidateClaudeCodeCLI(context.Background(), legacy); err != nil {
+		t.Fatalf("legacy Claude CLI banner should remain compatible: %v", err)
+	}
+
+	desktop := writeVersionCLI(t, "1.0.0 (Claude)")
+	if _, err := discovery.ValidateClaudeCodeCLI(context.Background(), desktop); err == nil {
+		t.Fatal("generic Claude desktop banner was accepted as Claude Code CLI")
+	}
+}
+
+func TestBundledCandidatesExcludeClaudeDesktop(t *testing.T) {
+	for _, path := range NewCLIDiscovery().bundledCandidatePaths() {
+		if strings.Contains(path, "/Applications/Claude.app/") {
+			t.Fatalf("Claude Desktop must not be a CLI candidate: %s", path)
+		}
+	}
+}
+
+func TestDriverHonorsAndValidatesConfiguredCLIPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper uses a POSIX executable script")
+	}
+
+	valid := writeVersionCLI(t, "2.1.218 (Claude Code)")
+	driver := NewDriver(Config{CLIPath: valid})
+	if driver.cliPath != valid {
+		t.Fatalf("driver CLI path = %q, want %q", driver.cliPath, valid)
+	}
+	if !driver.IsAvailable() {
+		t.Fatal("verified configured Claude Code CLI should be available")
+	}
+
+	desktop := writeVersionCLI(t, "1.0.0 (Claude)")
+	if NewDriver(Config{CLIPath: desktop}).IsAvailable() {
+		t.Fatal("configured Claude Desktop executable should be rejected")
+	}
+}
+
+func TestPermissionModesMatchClaudeCodeCLI(t *testing.T) {
+	for _, mode := range []PermissionMode{
+		PermissionModeDefault,
+		PermissionModeAcceptEdits,
+		PermissionModeAuto,
+		PermissionModeBypassPermissions,
+		PermissionModeManual,
+		PermissionModeDontAsk,
+		PermissionModePlan,
+	} {
+		if !IsValidPermissionMode(string(mode)) {
+			t.Errorf("permission mode %q should be valid", mode)
+		}
+	}
+}
+
+func writeVersionCLI(t *testing.T, banner string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "claude")
+	script := "#!/bin/sh\nprintf '%s\\n' '" + banner + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/agentboot/claude/config.go
+++ b/agentboot/claude/config.go
@@ -9,8 +9,11 @@ type PermissionMode string
 const (
 	// PermissionModeDefault uses the default permission behavior (asks for permissions)
 	PermissionModeDefault PermissionMode = "default"
-	// PermissionModeAuto auto-approves permissions (equivalent to bypassPermissions)
+	// PermissionModeAuto delegates permission decisions to Claude Code's
+	// configurable rule classifier. It is not an unconditional bypass.
 	PermissionModeAuto PermissionMode = "auto"
+	// PermissionModeManual requires interactive approval for permission requests.
+	PermissionModeManual PermissionMode = "manual"
 	// PermissionModeDontAsk doesn't ask for permissions
 	PermissionModeDontAsk PermissionMode = "dontAsk"
 	// PermissionModeBypassPermissions bypasses all permission checks
@@ -110,7 +113,7 @@ func (c *Config) WithContinue() *Config {
 // IsValidPermissionMode checks if a permission mode is valid for Claude CLI
 func IsValidPermissionMode(mode string) bool {
 	switch PermissionMode(mode) {
-	case PermissionModeDefault, PermissionModeAuto, PermissionModeDontAsk,
+	case PermissionModeDefault, PermissionModeAuto, PermissionModeManual, PermissionModeDontAsk,
 		PermissionModeBypassPermissions, PermissionModeAcceptEdits, PermissionModePlan:
 		return true
 	default:

--- a/agentboot/claude/constant.go
+++ b/agentboot/claude/constant.go
@@ -19,13 +19,13 @@ package claude
 //	| SDKHookResponseMessage
 //	| SDKToolProgressMessage
 //	| SDKAuthStatusMessage
-//	| SDKTaskNotificationMessage
-//	| SDKTaskStartedMessage
-//	| SDKTaskProgressMessage
 //	| SDKFilesPersistedEvent
 //	| SDKToolUseSummaryMessage
 //	| SDKRateLimitEvent
 //	| SDKPromptSuggestionMessage;
+//
+// Task lifecycle wire values are system-message subtypes in current Claude
+// Code. Deprecated SDKTask* aliases are retained below for source compatibility.
 const (
 	SDKTextMessage               = "text"
 	SDKSystemMessage             = "system"
@@ -46,9 +46,6 @@ const (
 	SDKHookResponseMessage       = "hook_response"
 	SDKToolProgressMessage       = "tool_progress"
 	SDKAuthStatusMessage         = "auth_status"
-	SDKTaskNotificationMessage   = "task_notification"
-	SDKTaskStartedMessage        = "task_started"
-	SDKTaskProgressMessage       = "task_progress"
 	SDKFilesPersistedMessage     = "files_persisted"
 	SDKToolUseSummaryMessage     = "tool_use_summary"
 	// SDKRateLimitEvent is the top-level type emitted by CC v2.1+ when the
@@ -63,7 +60,12 @@ const SDKControlPrefix = "control_"
 
 // System message subtypes
 const (
-	SystemSubtypeInit          = "init"
+	SystemSubtypeInit             = "init"
+	SystemSubtypeTaskStarted      = "task_started"
+	SystemSubtypeTaskProgress     = "task_progress"
+	SystemSubtypeTaskNotification = "task_notification"
+	SystemSubtypeTaskUpdated      = "task_updated"
+	// SystemSubtypeTaskCompleted is emitted by older Claude Code versions.
 	SystemSubtypeTaskCompleted = "task_completed"
 	// SystemSubtypeAPIRetry is emitted by the Claude Code CLI when an upstream
 	// API call fails with a retryable error (overload, rate limit, transient
@@ -72,6 +74,14 @@ const (
 	SystemSubtypeAPIRetry = "api_retry"
 	// SystemSubtypeRateLimit is emitted when the CLI is rate limited upstream.
 	SystemSubtypeRateLimit = "rate_limit"
+)
+
+// Deprecated task names retained as aliases for callers that used them before
+// these wire values were correctly classified as system-message subtypes.
+const (
+	SDKTaskStartedMessage      = SystemSubtypeTaskStarted
+	SDKTaskProgressMessage     = SystemSubtypeTaskProgress
+	SDKTaskNotificationMessage = SystemSubtypeTaskNotification
 )
 
 // assistant message error
@@ -105,16 +115,39 @@ const (
 	ControlRequestTypeCancel     = "cancel"
 )
 
-// Result subtypes
+// Control-response subtypes
 const (
-	ResultSubtypeSuccess = "success"
-	ResultSubtypeError   = "error"
+	ControlResponseSubtypeSuccess = "success"
+	ControlResponseSubtypeError   = "error"
+)
+
+// Terminal result subtypes
+const (
+	ResultSubtypeSuccess                         = "success"
+	ResultSubtypeErrorMaxTurns                   = "error_max_turns"
+	ResultSubtypeErrorDuringExecution            = "error_during_execution"
+	ResultSubtypeErrorMaxBudgetUSD               = "error_max_budget_usd"
+	ResultSubtypeErrorMaxStructuredOutputRetries = "error_max_structured_output_retries"
+
+	// ResultSubtypeError was historically used for control responses. Terminal
+	// result errors use the error_* constants above.
+	// Deprecated: use ControlResponseSubtypeError.
+	ResultSubtypeError = ControlResponseSubtypeError
 )
 
 // Content block types
 const (
-	ContentBlockTypeText       = "text"
-	ContentBlockTypeToolUse    = "tool_use"
-	ContentBlockTypeThinking   = "thinking"
-	ContentBlockTypeToolResult = "tool_result"
+	ContentBlockTypeText                          = "text"
+	ContentBlockTypeToolUse                       = "tool_use"
+	ContentBlockTypeThinking                      = "thinking"
+	ContentBlockTypeRedactedThinking              = "redacted_thinking"
+	ContentBlockTypeToolResult                    = "tool_result"
+	ContentBlockTypeServerToolUse                 = "server_tool_use"
+	ContentBlockTypeWebSearchToolResult           = "web_search_tool_result"
+	ContentBlockTypeWebFetchToolResult            = "web_fetch_tool_result"
+	ContentBlockTypeCodeExecutionToolResult       = "code_execution_tool_result"
+	ContentBlockTypeBashCodeExecutionToolResult   = "bash_code_execution_tool_result"
+	ContentBlockTypeTextEditorExecutionToolResult = "text_editor_code_execution_tool_result"
+	ContentBlockTypeToolSearchToolResult          = "tool_search_tool_result"
+	ContentBlockTypeContainerUpload               = "container_upload"
 )

--- a/agentboot/claude/driver.go
+++ b/agentboot/claude/driver.go
@@ -25,10 +25,16 @@ type Driver struct {
 
 // NewDriver creates a new Claude Driver.
 func NewDriver(config Config) *Driver {
+	cliPath := strings.TrimSpace(config.CLIPath)
+	if cliPath == "" {
+		cliPath = "claude"
+	}
+	discovery := NewCLIDiscovery()
+	discovery.SetPreference(config.UseBundled, config.UseGlobal)
 	return &Driver{
 		config:    config,
-		cliPath:   "claude",
-		discovery: NewCLIDiscovery(),
+		cliPath:   cliPath,
+		discovery: discovery,
 	}
 }
 
@@ -58,7 +64,7 @@ func (d *Driver) IsAvailable() bool {
 	d.mu.RUnlock()
 
 	if cliPath != "" && cliPath != "claude" && cliPath != "anthropic" {
-		_, err := os.Stat(cliPath)
+		_, err := discovery.ValidateClaudeCodeCLI(context.Background(), cliPath)
 		return err == nil
 	}
 
@@ -171,9 +177,16 @@ func (d *Driver) resolveBinary(ctx context.Context) (string, error) {
 	d.mu.RLock()
 	cliPath := d.cliPath
 	discovery := d.discovery
+	forceAvailable := d.forceAvailable
 	d.mu.RUnlock()
 
 	if cliPath != "" && cliPath != "claude" && cliPath != "anthropic" {
+		if forceAvailable {
+			return cliPath, nil
+		}
+		if _, err := discovery.ValidateClaudeCodeCLI(ctx, cliPath); err != nil {
+			return "", fmt.Errorf("invalid Claude Code CLI path %q: %w", cliPath, err)
+		}
 		return cliPath, nil
 	}
 

--- a/agentboot/claude/formatter.go
+++ b/agentboot/claude/formatter.go
@@ -119,12 +119,17 @@ func (f *TextFormatter) Format(msg Message) string {
 
 func (f *TextFormatter) formatSystem(m *SystemMessage) string {
 	switch m.SubType {
-	case SDKTaskStartedMessage:
+	case SystemSubtypeTaskStarted:
 		return f.formatTaskStarted(m)
 	case SystemSubtypeTaskCompleted:
 		return f.formatTaskCompleted(m)
-	case SDKTaskNotificationMessage:
+	case SystemSubtypeTaskNotification:
 		return f.formatTaskNotification(m)
+	case SystemSubtypeTaskProgress, SystemSubtypeTaskUpdated:
+		// Claude Code emits these frequently while a subagent is running. The
+		// raw message remains available to consumers; suppressing incremental
+		// patches here avoids flooding chat surfaces.
+		return ""
 	case SystemSubtypeInit:
 		var b strings.Builder
 		b.WriteString("[SYSTEM] ")
@@ -236,7 +241,7 @@ func (f *TextFormatter) formatAssistant(m *AssistantMessage) string {
 			if content.Text != "" {
 				sections = append(sections, strings.TrimRight(content.Text, "\n"))
 			}
-		case ContentBlockTypeToolUse:
+		case ContentBlockTypeToolUse, ContentBlockTypeServerToolUse:
 			f.rememberToolName(content.ID, content.Name)
 			f.markAssistantToolID(content.ID)
 			tools = append(tools, ToolUseRef{
@@ -249,6 +254,19 @@ func (f *TextFormatter) formatAssistant(m *AssistantMessage) string {
 			if f.Verbose && content.Thinking != "" {
 				sections = append(sections, "[THINKING] "+content.Thinking)
 			}
+		case ContentBlockTypeRedactedThinking:
+			// Redacted reasoning is intentionally never rendered.
+		case ContentBlockTypeWebSearchToolResult,
+			ContentBlockTypeWebFetchToolResult,
+			ContentBlockTypeCodeExecutionToolResult,
+			ContentBlockTypeBashCodeExecutionToolResult,
+			ContentBlockTypeTextEditorExecutionToolResult,
+			ContentBlockTypeToolSearchToolResult:
+			flushTools()
+			sections = append(sections, f.formatServerToolResult(content.Type, content.ToolUseID))
+		case ContentBlockTypeContainerUpload:
+			flushTools()
+			sections = append(sections, "Container upload ready")
 		}
 	}
 	flushTools()
@@ -261,6 +279,28 @@ func (f *TextFormatter) formatAssistant(m *AssistantMessage) string {
 		return ""
 	}
 	return strings.Join(sections, "\n")
+}
+
+func (f *TextFormatter) formatServerToolResult(blockType, toolUseID string) string {
+	if name := f.consumeToolName(toolUseID); name != "" {
+		return name + " result"
+	}
+	switch blockType {
+	case ContentBlockTypeWebSearchToolResult:
+		return "Web search result"
+	case ContentBlockTypeWebFetchToolResult:
+		return "Web fetch result"
+	case ContentBlockTypeCodeExecutionToolResult:
+		return "Code execution result"
+	case ContentBlockTypeBashCodeExecutionToolResult:
+		return "Bash execution result"
+	case ContentBlockTypeTextEditorExecutionToolResult:
+		return "Text editor execution result"
+	case ContentBlockTypeToolSearchToolResult:
+		return "Tool search result"
+	default:
+		return "Server tool result"
+	}
 }
 
 func (f *TextFormatter) formatUser(m *UserMessage) string {

--- a/agentboot/claude/formatter_test.go
+++ b/agentboot/claude/formatter_test.go
@@ -47,6 +47,34 @@ func TestTextFormatter_FormatSystemMessage(t *testing.T) {
 	}
 }
 
+func TestTextFormatter_TaskSubtypePolicy(t *testing.T) {
+	formatter := NewTextFormatter()
+
+	started := formatter.Format(&SystemMessage{
+		Type:        SDKSystemMessage,
+		SubType:     SystemSubtypeTaskStarted,
+		Description: "Inspect constants",
+	})
+	if !contains(started, "Inspect constants") {
+		t.Fatalf("task_started output = %q", started)
+	}
+
+	notification := formatter.Format(&SystemMessage{
+		Type:        SDKSystemMessage,
+		SubType:     SystemSubtypeTaskNotification,
+		Description: "Inspection complete",
+	})
+	if !contains(notification, "Inspection complete") {
+		t.Fatalf("task_notification output = %q", notification)
+	}
+
+	for _, subtype := range []string{SystemSubtypeTaskProgress, SystemSubtypeTaskUpdated} {
+		if output := formatter.Format(&SystemMessage{Type: SDKSystemMessage, SubType: subtype}); output != "" {
+			t.Errorf("%s should be retained as raw data but hidden from text output, got %q", subtype, output)
+		}
+	}
+}
+
 func TestTextFormatter_FormatAPIRetry(t *testing.T) {
 	formatter := NewTextFormatter()
 
@@ -115,6 +143,52 @@ func TestTextFormatter_FormatAssistantMessage(t *testing.T) {
 
 	if !contains(output, "Hello, world!") {
 		t.Errorf("Expected text content in output: %s", output)
+	}
+}
+
+func TestTextFormatter_FormatServerToolBlocks(t *testing.T) {
+	formatter := NewTextFormatter()
+	msg := &AssistantMessage{
+		Type: SDKAssistantMessage,
+		Message: anthropic.Message{
+			Content: []anthropic.ContentBlockUnion{
+				{
+					Type:  ContentBlockTypeServerToolUse,
+					ID:    "srv-1",
+					Name:  "web_search",
+					Input: json.RawMessage(`{"query":"Claude Code"}`),
+				},
+				{
+					Type:      ContentBlockTypeWebSearchToolResult,
+					ToolUseID: "srv-1",
+				},
+			},
+		},
+	}
+
+	output := formatter.Format(msg)
+	if !contains(output, "web_search") {
+		t.Fatalf("server tool invocation missing from output: %q", output)
+	}
+	if !contains(output, "result") {
+		t.Fatalf("server tool result missing from output: %q", output)
+	}
+}
+
+func TestUnmarshalCurrentContentBlockVariants(t *testing.T) {
+	for _, raw := range []string{
+		`{"type":"server_tool_use","id":"srv-1","name":"web_search","input":{"query":"test"}}`,
+		`{"type":"redacted_thinking","data":"opaque"}`,
+		`{"type":"web_search_tool_result","tool_use_id":"srv-1","content":[]}`,
+		`{"type":"container_upload","file_id":"file-1"}`,
+	} {
+		block, err := UnmarshalContentBlock([]byte(raw))
+		if err != nil {
+			t.Fatalf("UnmarshalContentBlock(%s): %v", raw, err)
+		}
+		if _, unknown := block.(*UnknownBlock); unknown {
+			t.Errorf("current content block decoded as unknown: %s", raw)
+		}
 	}
 }
 

--- a/agentboot/claude/launcher.go
+++ b/agentboot/claude/launcher.go
@@ -15,21 +15,22 @@ import (
 // Prefer using NewAgentWithConfig for new code. Launcher is retained for
 // backward compatibility with existing callers (examples, integration tests).
 type Launcher struct {
-	mu      sync.RWMutex
-	driver  *Driver
-	runner  *agentboot.Runner
-	transport *Transport
+	mu     sync.RWMutex
+	driver *Driver
+	runner *agentboot.Runner
 }
 
 // NewLauncher creates a new Claude launcher.
 func NewLauncher(config Config) *Launcher {
 	driver := NewDriver(config)
-	transport := NewTransport()
-	runner := agentboot.NewRunner(driver, transport)
+	runner := agentboot.NewRunnerWithConfig(
+		driver,
+		func() agentboot.AgentTransport { return NewTransport() },
+		runnerConfig(config),
+	)
 	return &Launcher{
-		driver:    driver,
-		transport: transport,
-		runner:    runner,
+		driver: driver,
+		runner: runner,
 	}
 }
 
@@ -98,4 +99,3 @@ func (l *Launcher) Interrupt(ctx context.Context, stdin io.WriteCloser, reason s
 	builder := NewCancelRequestBuilder().WithCancel("execution").WithReason(reason)
 	return controlMgr.SendRequestAsync(builder.Build(), stdin)
 }
-

--- a/agentboot/claude/messages.go
+++ b/agentboot/claude/messages.go
@@ -27,7 +27,7 @@ type SystemMessage struct {
 	SessionID string    `json:"session_id"`
 	Timestamp time.Time `json:"timestamp"`
 
-	// Subagent task fields (populated when SubType is task_started/task_notification/task_completed)
+	// Subagent task fields (populated for task lifecycle subtypes).
 	Description string `json:"description,omitempty"`
 	Prompt      string `json:"prompt,omitempty"`
 	TaskID      string `json:"task_id,omitempty"`
@@ -183,6 +183,42 @@ func (b *ThinkingBlock) GetContentType() string {
 	return b.Type
 }
 
+// RedactedThinkingBlock represents reasoning withheld by the API.
+type RedactedThinkingBlock struct {
+	Type string `json:"type"`
+	Data string `json:"data"`
+}
+
+// GetContentType implements ContentBlock.
+func (b *RedactedThinkingBlock) GetContentType() string {
+	return b.Type
+}
+
+// ServerToolResultContentBlock preserves the common envelope shared by
+// Claude's server-side tool result variants.
+type ServerToolResultContentBlock struct {
+	Type      string          `json:"type"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content,omitempty"`
+}
+
+// GetContentType implements ContentBlock.
+func (b *ServerToolResultContentBlock) GetContentType() string {
+	return b.Type
+}
+
+// ContainerUploadContentBlock represents a file uploaded to Claude's
+// server-side execution container.
+type ContainerUploadContentBlock struct {
+	Type   string `json:"type"`
+	FileID string `json:"file_id"`
+}
+
+// GetContentType implements ContentBlock.
+func (b *ContainerUploadContentBlock) GetContentType() string {
+	return b.Type
+}
+
 // ToolResultContentBlock represents tool result content (within message content array)
 type ToolResultContentBlock struct {
 	Type      string `json:"type"`
@@ -212,7 +248,7 @@ func UnmarshalContentBlock(data []byte) (ContentBlock, error) {
 			return nil, err
 		}
 		return &block, nil
-	case ContentBlockTypeToolUse:
+	case ContentBlockTypeToolUse, ContentBlockTypeServerToolUse:
 		var block ToolUseBlock
 		if err := json.Unmarshal(data, &block); err != nil {
 			return nil, err
@@ -224,8 +260,31 @@ func UnmarshalContentBlock(data []byte) (ContentBlock, error) {
 			return nil, err
 		}
 		return &block, nil
+	case ContentBlockTypeRedactedThinking:
+		var block RedactedThinkingBlock
+		if err := json.Unmarshal(data, &block); err != nil {
+			return nil, err
+		}
+		return &block, nil
 	case ContentBlockTypeToolResult:
 		var block ToolResultContentBlock
+		if err := json.Unmarshal(data, &block); err != nil {
+			return nil, err
+		}
+		return &block, nil
+	case ContentBlockTypeWebSearchToolResult,
+		ContentBlockTypeWebFetchToolResult,
+		ContentBlockTypeCodeExecutionToolResult,
+		ContentBlockTypeBashCodeExecutionToolResult,
+		ContentBlockTypeTextEditorExecutionToolResult,
+		ContentBlockTypeToolSearchToolResult:
+		var block ServerToolResultContentBlock
+		if err := json.Unmarshal(data, &block); err != nil {
+			return nil, err
+		}
+		return &block, nil
+	case ContentBlockTypeContainerUpload:
+		var block ContainerUploadContentBlock
 		if err := json.Unmarshal(data, &block); err != nil {
 			return nil, err
 		}

--- a/agentboot/claude/ref/stream-json.schema.json
+++ b/agentboot/claude/ref/stream-json.schema.json
@@ -19,7 +19,7 @@
         "type": { "const": "system" },
         "subtype": {
           "type": "string",
-          "enum": ["init", "shutdown", "error"]
+          "description": "Forward-compatible system subtype. Known values include init, api_retry, rate_limit, task_started, task_progress, task_notification, task_updated, and legacy task_completed."
         },
         "session_id": { "type": "string", "format": "uuid" },
         "timestamp": { "type": "string", "format": "date-time" }
@@ -61,12 +61,30 @@
       "required": ["model", "id", "type", "role", "content"]
     },
     "ContentBlock": {
-      "oneOf": [
-        { "$ref": "#/$defs/TextBlock" },
-        { "$ref": "#/$defs/ToolUseBlock" },
-        { "$ref": "#/$defs/ThinkingBlock" },
-        { "$ref": "#/$defs/ToolResultContentBlock" }
-      ]
+      "type": "object",
+      "description": "Forward-compatible Anthropic content block union.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "examples": [
+            "text",
+            "thinking",
+            "redacted_thinking",
+            "tool_use",
+            "server_tool_use",
+            "tool_result",
+            "web_search_tool_result",
+            "web_fetch_tool_result",
+            "code_execution_tool_result",
+            "bash_code_execution_tool_result",
+            "text_editor_code_execution_tool_result",
+            "tool_search_tool_result",
+            "container_upload"
+          ]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": true
     },
     "TextBlock": {
       "type": "object",
@@ -149,7 +167,7 @@
         "type": { "const": "result" },
         "subtype": {
           "type": "string",
-          "enum": ["success", "error"]
+          "description": "Forward-compatible terminal subtype. Known values include success, error_max_turns, error_during_execution, error_max_budget_usd, and error_max_structured_output_retries."
         },
         "result": { "type": "string" },
         "total_cost_usd": { "type": "number" },

--- a/agentboot/claude/transport.go
+++ b/agentboot/claude/transport.go
@@ -174,7 +174,7 @@ func (t *Transport) buildAskResponse(requestID string, result agentboot.AskRespo
 	innerResponse := map[string]interface{}{"request_id": requestID}
 
 	if result.Approved {
-		innerResponse["subtype"] = ResultSubtypeSuccess
+		innerResponse["subtype"] = ControlResponseSubtypeSuccess
 		if result.UpdatedInput != nil {
 			innerResponse["response"] = map[string]interface{}{
 				"behavior":     "allow",
@@ -184,7 +184,7 @@ func (t *Transport) buildAskResponse(requestID string, result agentboot.AskRespo
 			innerResponse["response"] = map[string]interface{}{"behavior": "allow"}
 		}
 	} else {
-		innerResponse["subtype"] = ResultSubtypeError
+		innerResponse["subtype"] = ControlResponseSubtypeError
 		reason := result.Reason
 		if reason == "" {
 			reason = "User denied this request"
@@ -201,7 +201,7 @@ func (t *Transport) buildAskResponse(requestID string, result agentboot.AskRespo
 
 func (t *Transport) buildPermissionResponse(requestID string, result agentboot.ApprovalResponse, originalInput map[string]interface{}) map[string]any {
 	innerResponse := map[string]interface{}{
-		"subtype":    ResultSubtypeSuccess,
+		"subtype":    ControlResponseSubtypeSuccess,
 		"request_id": requestID,
 	}
 

--- a/agentboot/errors.go
+++ b/agentboot/errors.go
@@ -1,0 +1,72 @@
+package agentboot
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrNoTerminalResult means a stream-json process ended cleanly without the
+// result event that defines the outcome of an agent turn.
+var ErrNoTerminalResult = errors.New("agentboot: stream ended without a terminal result")
+
+// ProcessError reports an unsuccessful agent subprocess exit.
+type ProcessError struct {
+	AgentType AgentType
+	ExitCode  int
+	Err       error
+}
+
+func (e *ProcessError) Error() string {
+	agent := e.AgentType.String()
+	if agent == "" {
+		agent = "agent"
+	}
+	if e.ExitCode >= 0 {
+		return fmt.Sprintf("agentboot: %s process exited with code %d: %v", agent, e.ExitCode, e.Err)
+	}
+	return fmt.Sprintf("agentboot: %s process failed: %v", agent, e.Err)
+}
+
+// Unwrap exposes the underlying process error.
+func (e *ProcessError) Unwrap() error { return e.Err }
+
+// ProtocolError reports a fatal stream protocol failure.
+type ProtocolError struct {
+	AgentType AgentType
+	Err       error
+}
+
+func (e *ProtocolError) Error() string {
+	agent := e.AgentType.String()
+	if agent == "" {
+		agent = "agent"
+	}
+	return fmt.Sprintf("agentboot: %s protocol error: %v", agent, e.Err)
+}
+
+// Unwrap exposes the decoder or protocol error. In particular,
+// errors.Is(err, ErrNoTerminalResult) remains supported.
+func (e *ProtocolError) Unwrap() error { return e.Err }
+
+// ResultError reports a structured terminal error emitted by the agent.
+type ResultError struct {
+	AgentType AgentType
+	Subtype   string
+	Details   []string
+}
+
+func (e *ResultError) Error() string {
+	agent := e.AgentType.String()
+	if agent == "" {
+		agent = "agent"
+	}
+	message := fmt.Sprintf("agentboot: %s returned an error result", agent)
+	if e.Subtype != "" {
+		message += " (" + e.Subtype + ")"
+	}
+	if len(e.Details) > 0 {
+		message += ": " + strings.Join(e.Details, "; ")
+	}
+	return message
+}

--- a/agentboot/events.go
+++ b/agentboot/events.go
@@ -61,9 +61,9 @@ type AskRequestEvent struct {
 
 func (AskRequestEvent) isStreamEvent() {}
 
-// ErrorEvent reports a non-fatal error noticed during execution. The
-// runner continues processing after emitting an ErrorEvent. Fatal errors
-// are surfaced via [ExecutionHandle.Wait]'s returned error instead.
+// ErrorEvent reports an error noticed while consuming the execution stream.
+// It may be recoverable, or it may be a tail notification of the fatal error
+// that [ExecutionHandle.Wait] returns. Wait is the authoritative outcome.
 type ErrorEvent struct {
 	Err error
 }

--- a/agentboot/protocol/decoder_test.go
+++ b/agentboot/protocol/decoder_test.go
@@ -145,3 +145,33 @@ func TestEncoder_WritesNewlineDelimited(t *testing.T) {
 		t.Fatalf("encoder output = %q, want %q", got, want)
 	}
 }
+
+func TestEncoder_CloseIsIdempotentAndRejectsFurtherWrites(t *testing.T) {
+	dst := &closeBuffer{}
+	encoder := NewEncoder(dst)
+	if err := encoder.Encode(map[string]any{"a": 1}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if dst.closeCalls != 1 {
+		t.Fatalf("close calls = %d, want 1", dst.closeCalls)
+	}
+	if err := encoder.Encode(map[string]any{"b": 2}); !errors.Is(err, ErrEncoderClosed) {
+		t.Fatalf("Encode after Close error = %v, want ErrEncoderClosed", err)
+	}
+}
+
+type closeBuffer struct {
+	bytes.Buffer
+	closeCalls int
+}
+
+func (b *closeBuffer) Close() error {
+	b.closeCalls++
+	return nil
+}

--- a/agentboot/protocol/encoder.go
+++ b/agentboot/protocol/encoder.go
@@ -2,18 +2,23 @@ package protocol
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 )
 
+// ErrEncoderClosed is returned when Encode is called after Close.
+var ErrEncoderClosed = errors.New("protocol: encoder closed")
+
 // Encoder writes control responses (and other outbound messages) as
 // newline-delimited JSON to a destination io.Writer. It is safe for
-// concurrent use; concurrent Encode calls are serialized so that no two
-// JSON values interleave on the wire.
+// concurrent use; Encode and Close are serialized so that no JSON value is
+// truncated by a concurrent stdin shutdown.
 type Encoder struct {
-	mu  sync.Mutex
-	dst io.Writer
+	mu     sync.Mutex
+	dst    io.Writer
+	closed bool
 }
 
 // NewEncoder constructs an Encoder targeting w.
@@ -24,9 +29,27 @@ func NewEncoder(w io.Writer) *Encoder { return &Encoder{dst: w} }
 func (e *Encoder) Encode(v any) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if e.closed {
+		return ErrEncoderClosed
+	}
 	enc := json.NewEncoder(e.dst)
 	if err := enc.Encode(v); err != nil {
 		return fmt.Errorf("encode: %w", err)
+	}
+	return nil
+}
+
+// Close closes the destination when it implements io.Closer. It is
+// idempotent and waits for an in-flight Encode to finish first.
+func (e *Encoder) Close() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return nil
+	}
+	e.closed = true
+	if closer, ok := e.dst.(io.Closer); ok {
+		return closer.Close()
 	}
 	return nil
 }

--- a/agentboot/run.go
+++ b/agentboot/run.go
@@ -39,10 +39,10 @@ type Prompter interface {
 }
 
 // MessageSink receives, in order, the [MessageEvent.Raw] value of each
-// message event and any terminal [ErrorEvent] the agent emits (passed as the
-// ErrorEvent value itself, so consumers can surface non-fatal errors that do
-// not fail handle.Wait()). Pass nil to drop these (e.g. when only completion
-// matters).
+// message event and any [ErrorEvent] the agent emits (passed as the ErrorEvent
+// value itself). An ErrorEvent may be recoverable or may mirror the fatal error
+// later returned by handle.Wait. Pass nil to drop these when only completion
+// matters.
 type MessageSink func(any)
 
 // RunWithPrompter is the convenience consumer of an [ExecutionHandle].

--- a/agentboot/runner.go
+++ b/agentboot/runner.go
@@ -329,27 +329,59 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 			case EventKindTerminalSuccess:
 				state.mu.Lock()
 				state.terminalSeen = true
-				state.terminalSuccess = true
 				state.mu.Unlock()
 				shutdownGracefully()
 
 			case EventKindTerminalError:
 				state.mu.Lock()
 				state.terminalSeen = true
-				state.terminalSuccess = false
+				state.terminalErr = resultErrorFromEvent(r.driver.Type(), ev)
 				state.mu.Unlock()
 				shutdownGracefully()
 			}
 		}
 
-		// Decoder closed (EOF, ctx, or error). Wait for the process to actually
-		// exit before considering execution done — this enforces the
-		// OnComplete-after-exit invariant the old runner violated.
-		_ = proc.Wait()
+		dErr := decoderErr()
+		state.mu.Lock()
+		terminalSeen := state.terminalSeen
+		state.mu.Unlock()
 
-		// Surface any decoder-level error as a tail ErrorEvent (non-fatal).
-		if dErr := decoderErr(); dErr != nil && !errors.Is(dErr, context.Canceled) {
-			handle.emit(runCtx, ErrorEvent{Err: dErr})
+		// A fatal decoder error means the read side can no longer make
+		// progress. Likewise, stream-json EOF without a result has no valid
+		// completion to wait for. Stop the process before joining it so a
+		// malformed or truncated stream cannot leave Wait blocked forever.
+		fatalDecode := dErr != nil &&
+			!errors.Is(dErr, context.Canceled) &&
+			!errors.Is(dErr, context.DeadlineExceeded)
+		if fatalDecode || (opts.OutputFormat == OutputFormatStreamJSON && !terminalSeen) {
+			_ = proc.Kill()
+		}
+
+		// Wait for the process to actually exit before considering execution
+		// done — this enforces the OnComplete-after-exit invariant.
+		processWaitErr := proc.Wait()
+		shutdownWG.Wait()
+
+		state.mu.Lock()
+		if processWaitErr != nil {
+			state.processErr = newProcessError(r.driver.Type(), processWaitErr)
+			state.exitCode = state.processErr.ExitCode
+		}
+		if dErr != nil && !errors.Is(dErr, context.Canceled) && !errors.Is(dErr, context.DeadlineExceeded) {
+			state.protocolErr = &ProtocolError{AgentType: r.driver.Type(), Err: dErr}
+		}
+		processErr := state.processErr
+		protocolErr := state.protocolErr
+		terminalErr := state.terminalErr
+		state.mu.Unlock()
+
+		// Match the SDK's error-in-stream behavior while keeping Wait as the
+		// authoritative terminal outcome.
+		switch {
+		case protocolErr != nil:
+			handle.emit(runCtx, ErrorEvent{Err: protocolErr})
+		case terminalErr == nil && processErr != nil:
+			handle.emit(runCtx, ErrorEvent{Err: processErr})
 		}
 	}()
 
@@ -361,6 +393,7 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 		waitOnce.Do(func() {
 			pumpWG.Wait()
 			feederWG.Wait()
+			runCtxErr := runCtx.Err()
 			cancel()
 
 			// Compute result under state lock, then release before calling store
@@ -372,6 +405,7 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 				defer state.mu.Unlock()
 
 				waitResult = &Result{
+					ExitCode: state.exitCode,
 					Format:   opts.OutputFormat,
 					Events:   append([]common.Event(nil), state.events...),
 					Duration: time.Since(state.startTime),
@@ -380,17 +414,23 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 				if state.opts.SessionID != "" {
 					waitResult.Metadata["session_id"] = state.opts.SessionID
 				}
-				if state.terminalSeen && !state.terminalSuccess {
-					waitResult.Error = "agent reported error result"
-					waitErr = errors.New(waitResult.Error)
-				}
-				if rctxErr := runCtx.Err(); rctxErr != nil && !state.terminalSeen {
-					if errors.Is(rctxErr, context.DeadlineExceeded) {
-						waitResult.Error = "agent execution timed out"
-						waitErr = context.DeadlineExceeded
-					} else if errors.Is(rctxErr, context.Canceled) && ctx.Err() != nil {
-						waitErr = ctx.Err()
+				switch {
+				case state.terminalErr != nil:
+					waitErr = state.terminalErr
+				case runCtxErr != nil:
+					waitErr = runCtxErr
+				case state.protocolErr != nil:
+					waitErr = state.protocolErr
+				case state.processErr != nil:
+					waitErr = state.processErr
+				case opts.OutputFormat == OutputFormatStreamJSON && !state.terminalSeen:
+					waitErr = &ProtocolError{
+						AgentType: r.driver.Type(),
+						Err:       ErrNoTerminalResult,
 					}
+				}
+				if waitErr != nil {
+					waitResult.Error = waitErr.Error()
 				}
 				sessID = state.opts.SessionID
 			}()
@@ -415,10 +455,57 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 type runState struct {
 	mu sync.Mutex
 
-	opts            ExecutionOptions
-	startTime       time.Time
-	events          []common.Event
-	pendingInput    map[string]map[string]any
-	terminalSeen    bool
-	terminalSuccess bool
+	opts         ExecutionOptions
+	startTime    time.Time
+	events       []common.Event
+	pendingInput map[string]map[string]any
+	terminalSeen bool
+	terminalErr  *ResultError
+	processErr   *ProcessError
+	protocolErr  *ProtocolError
+	exitCode     int
+}
+
+func newProcessError(agentType AgentType, err error) *ProcessError {
+	exitCode := -1
+	type exitCoder interface {
+		ExitCode() int
+	}
+	var withExitCode exitCoder
+	if errors.As(err, &withExitCode) {
+		exitCode = withExitCode.ExitCode()
+	}
+	return &ProcessError{
+		AgentType: agentType,
+		ExitCode:  exitCode,
+		Err:       err,
+	}
+}
+
+func resultErrorFromEvent(agentType AgentType, event common.Event) *ResultError {
+	resultErr := &ResultError{
+		AgentType: agentType,
+		Subtype:   stringValue(event.Data["subtype"]),
+	}
+	if values, ok := event.Data["errors"].([]any); ok {
+		for _, value := range values {
+			if detail := stringValue(value); detail != "" {
+				resultErr.Details = append(resultErr.Details, detail)
+			}
+		}
+	}
+	if len(resultErr.Details) == 0 {
+		for _, key := range []string{"error", "result"} {
+			if detail := stringValue(event.Data[key]); detail != "" {
+				resultErr.Details = append(resultErr.Details, detail)
+				break
+			}
+		}
+	}
+	return resultErr
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
 }

--- a/agentboot/runner.go
+++ b/agentboot/runner.go
@@ -21,26 +21,74 @@ import (
 // Tests inject [process.NewFakeFactory] via [NewRunnerWithFactory] to
 // substitute the binary while exercising the same driver and transport.
 type Runner struct {
-	mu            sync.RWMutex
-	driver        AgentDriver
-	transport     AgentTransport
-	procFactory   process.Factory
-	defaultFormat OutputFormat
+	mu                  sync.RWMutex
+	driver              AgentDriver
+	transportFactory    AgentTransportFactory
+	procFactory         process.Factory
+	defaultFormat       OutputFormat
+	eventBufferSize     int
+	defaultTimeout      time.Duration
+	shutdownGracePeriod time.Duration
+}
+
+const (
+	defaultEventBufferSize     = 100
+	defaultShutdownGracePeriod = 5 * time.Second
+)
+
+// RunnerConfig controls execution defaults owned by a Runner. Per-call values
+// in [ExecutionOptions] still take precedence.
+type RunnerConfig struct {
+	DefaultFormat           OutputFormat
+	EventBufferSize         int
+	DefaultExecutionTimeout time.Duration
+	ShutdownGracePeriod     time.Duration
+}
+
+func normalizeRunnerConfig(config RunnerConfig) RunnerConfig {
+	if config.DefaultFormat == "" {
+		config.DefaultFormat = OutputFormatStreamJSON
+	}
+	if config.EventBufferSize <= 0 {
+		config.EventBufferSize = defaultEventBufferSize
+	}
+	if config.ShutdownGracePeriod <= 0 {
+		config.ShutdownGracePeriod = defaultShutdownGracePeriod
+	}
+	return config
 }
 
 // NewRunner creates a Runner backed by [process.NewOSExecFactory].
-func NewRunner(driver AgentDriver, transport AgentTransport) *Runner {
-	return NewRunnerWithFactory(driver, transport, process.NewOSExecFactory())
+//
+// transportFactory is called once per Execute so mutable protocol state is
+// never shared by concurrent runs.
+func NewRunner(driver AgentDriver, transportFactory AgentTransportFactory) *Runner {
+	return NewRunnerWithConfig(driver, transportFactory, RunnerConfig{})
 }
 
-// NewRunnerWithFactory creates a Runner with a custom process factory. Use
-// [process.NewFakeFactory] in tests.
-func NewRunnerWithFactory(driver AgentDriver, transport AgentTransport, factory process.Factory) *Runner {
+// NewRunnerWithConfig creates an OS-backed Runner with explicit defaults.
+func NewRunnerWithConfig(driver AgentDriver, transportFactory AgentTransportFactory, config RunnerConfig) *Runner {
+	return NewRunnerWithFactoryAndConfig(driver, transportFactory, process.NewOSExecFactory(), config)
+}
+
+// NewRunnerWithFactory creates a Runner with a custom process factory and
+// default RunnerConfig. Use [process.NewFakeFactory] in tests.
+func NewRunnerWithFactory(driver AgentDriver, transportFactory AgentTransportFactory, factory process.Factory) *Runner {
+	return NewRunnerWithFactoryAndConfig(driver, transportFactory, factory, RunnerConfig{})
+}
+
+// NewRunnerWithFactoryAndConfig creates a Runner with both a custom process
+// factory and explicit execution defaults.
+func NewRunnerWithFactoryAndConfig(driver AgentDriver, transportFactory AgentTransportFactory, factory process.Factory, config RunnerConfig) *Runner {
+	config = normalizeRunnerConfig(config)
 	return &Runner{
-		driver:        driver,
-		transport:     transport,
-		procFactory:   factory,
-		defaultFormat: OutputFormatStreamJSON,
+		driver:              driver,
+		transportFactory:    transportFactory,
+		procFactory:         factory,
+		defaultFormat:       config.DefaultFormat,
+		eventBufferSize:     config.EventBufferSize,
+		defaultTimeout:      config.DefaultExecutionTimeout,
+		shutdownGracePeriod: config.ShutdownGracePeriod,
 	}
 }
 
@@ -71,12 +119,18 @@ func (r *Runner) GetDefaultFormat() OutputFormat {
 func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptions) (ExecutionHandle, error) {
 	r.mu.RLock()
 	defaultFormat := r.defaultFormat
+	eventBufferSize := r.eventBufferSize
+	defaultTimeout := r.defaultTimeout
+	shutdownGracePeriod := r.shutdownGracePeriod
 	r.mu.RUnlock()
 	if opts.OutputFormat == "" {
 		opts.OutputFormat = defaultFormat
 	}
 	if opts.OutputFormat == "" {
 		opts.OutputFormat = OutputFormatStreamJSON
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = defaultTimeout
 	}
 
 	if !r.driver.IsAvailable() {
@@ -91,7 +145,14 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 		return nil, errors.New("empty launch command")
 	}
 
-	r.transport.SetExecutionContext(opts.SessionID, opts.ChatID, opts.Platform, opts.BotUUID)
+	if r.transportFactory == nil {
+		return nil, errors.New("agentboot: transport factory is nil")
+	}
+	transport := r.transportFactory()
+	if transport == nil {
+		return nil, errors.New("agentboot: transport factory returned nil")
+	}
+	transport.SetExecutionContext(opts.SessionID, opts.ChatID, opts.Platform, opts.BotUUID)
 
 	runCtx, cancel := context.WithCancel(ctx)
 	if opts.Timeout > 0 {
@@ -122,6 +183,43 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 	encoder := protocol.NewEncoder(proc.Stdin())
 	decoderEvents, decoderErr := decoder.Stream(runCtx)
 
+	// process.Factory implementations must observe cancellation consistently,
+	// including test/custom factories that do not use exec.CommandContext.
+	go func() {
+		select {
+		case <-runCtx.Done():
+			_ = proc.Kill()
+		case <-proc.Done():
+		}
+	}()
+
+	// A result is terminal, but Claude Code may still need to flush its session
+	// file. End stdin first, then escalate to Kill only if it does not exit
+	// within the grace period.
+	var shutdownOnce sync.Once
+	var shutdownWG sync.WaitGroup
+	shutdownGracefully := func() {
+		shutdownOnce.Do(func() {
+			// Close may briefly wait for an in-flight encoder write. Keep the
+			// pump draining stdout while shutdown proceeds.
+			shutdownWG.Add(2)
+			go func() {
+				defer shutdownWG.Done()
+				_ = encoder.Close()
+			}()
+			go func() {
+				defer shutdownWG.Done()
+				timer := time.NewTimer(shutdownGracePeriod)
+				defer timer.Stop()
+				select {
+				case <-proc.Done():
+				case <-timer.C:
+					_ = proc.Kill()
+				}
+			}()
+		})
+	}
+
 	startTime := time.Now()
 
 	state := &runState{
@@ -132,7 +230,7 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 
 	var handle *runnerHandle
 	handle = newRunnerHandle(
-		16,
+		eventBufferSize,
 		// responseFn: encode and write the control response.
 		func(reqID string, resp ControlResponse) error {
 			state.mu.Lock()
@@ -142,7 +240,7 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 			}
 			state.mu.Unlock()
 
-			wire := r.transport.EncodeControlResponse(reqID, resp, input)
+			wire := transport.EncodeControlResponse(reqID, resp, input)
 			if wire == nil {
 				return errors.New("transport produced nil control response")
 			}
@@ -192,14 +290,14 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 			state.events = append(state.events, ev)
 			state.mu.Unlock()
 
-			kind, parsed := r.transport.Classify(ev)
+			kind, parsed := transport.Classify(ev)
 
 			switch kind {
 			case EventKindIgnore:
 				// Drop.
 
 			case EventKindMessage:
-				msgs := r.transport.AccumulateMessage(ev)
+				msgs := transport.AccumulateMessage(ev)
 				for _, m := range msgs {
 					handle.emit(runCtx, MessageEvent{Raw: m})
 				}
@@ -233,15 +331,14 @@ func (r *Runner) Execute(ctx context.Context, prompt string, opts ExecutionOptio
 				state.terminalSeen = true
 				state.terminalSuccess = true
 				state.mu.Unlock()
-				_ = proc.Kill()
-				// Continue draining; decoder loop ends after EOF.
+				shutdownGracefully()
 
 			case EventKindTerminalError:
 				state.mu.Lock()
 				state.terminalSeen = true
 				state.terminalSuccess = false
 				state.mu.Unlock()
-				_ = proc.Kill()
+				shutdownGracefully()
 			}
 		}
 

--- a/agentboot/runner_config_test.go
+++ b/agentboot/runner_config_test.go
@@ -43,6 +43,6 @@ func TestRunner_AppliesConfiguredBufferAndDefaultTimeout(t *testing.T) {
 	result, waitErr := handle.Wait()
 	require.ErrorIs(t, waitErr, context.DeadlineExceeded)
 	require.NotNil(t, result)
-	assert.NotEmpty(t, result.Error)
+	assert.Equal(t, waitErr.Error(), result.Error)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
 }

--- a/agentboot/runner_config_test.go
+++ b/agentboot/runner_config_test.go
@@ -1,0 +1,48 @@
+package agentboot_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+	"github.com/tingly-dev/tingly-box/agentboot/claude"
+	"github.com/tingly-dev/tingly-box/agentboot/process"
+)
+
+func TestRunner_AppliesConfiguredBufferAndDefaultTimeout(t *testing.T) {
+	factory := process.NewFakeFactory()
+	factory.OnStart = func(ctx context.Context, _ process.LaunchSpec, h *process.FakeHandle) {
+		go func() {
+			_, _ = io.Copy(io.Discard, h.StdinR)
+		}()
+		go func() {
+			<-ctx.Done()
+			h.FinishOutput()
+			h.SignalExit(nil)
+		}()
+	}
+	agent := claude.NewAgentWithFactory(claude.Config{
+		StreamBufferSize:        3,
+		DefaultExecutionTimeout: 40 * time.Millisecond,
+	}, factory)
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	started := time.Now()
+	handle, err := agent.Execute(parentCtx, "timeout", agentboot.ExecutionOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 3, cap(handle.Events()))
+
+	for range handle.Events() {
+	}
+	result, waitErr := handle.Wait()
+	require.ErrorIs(t, waitErr, context.DeadlineExceeded)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Error)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+}

--- a/agentboot/runner_lifecycle_test.go
+++ b/agentboot/runner_lifecycle_test.go
@@ -1,0 +1,129 @@
+package agentboot_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+	"github.com/tingly-dev/tingly-box/agentboot/claude"
+	"github.com/tingly-dev/tingly-box/agentboot/claude/fixture"
+	"github.com/tingly-dev/tingly-box/agentboot/process"
+)
+
+func TestRunner_PropagatesProcessExitError(t *testing.T) {
+	factory := process.NewFakeFactory()
+	factory.OnStart = func(_ context.Context, _ process.LaunchSpec, h *process.FakeHandle) {
+		go func() {
+			_, _ = io.Copy(io.Discard, h.StdinR)
+		}()
+		go func() {
+			h.FinishOutput()
+			h.SignalExit(testExitError{code: 23})
+			_ = h.Kill()
+		}()
+	}
+	agent := claude.NewAgentWithFactory(claude.Config{}, factory)
+
+	handle, err := agent.Execute(context.Background(), "fail", agentboot.ExecutionOptions{})
+	require.NoError(t, err)
+	var streamedError error
+	for event := range handle.Events() {
+		if errorEvent, ok := event.(agentboot.ErrorEvent); ok {
+			streamedError = errorEvent.Err
+		}
+	}
+	result, waitErr := handle.Wait()
+
+	var processErr *agentboot.ProcessError
+	require.ErrorAs(t, waitErr, &processErr)
+	assert.Equal(t, 23, processErr.ExitCode)
+	assert.Equal(t, 23, result.ExitCode)
+	assert.Equal(t, waitErr.Error(), result.Error)
+	require.ErrorAs(t, streamedError, &processErr)
+}
+
+func TestRunner_PropagatesProtocolDecodeError(t *testing.T) {
+	factory := process.NewFakeFactory()
+	factory.OnStart = func(_ context.Context, _ process.LaunchSpec, h *process.FakeHandle) {
+		go func() {
+			_, _ = io.Copy(io.Discard, h.StdinR)
+		}()
+		go func() {
+			_, _ = h.WriteOutput([]byte("{not-json}\n"))
+			h.FinishOutput()
+			h.SignalExit(nil)
+			_ = h.Kill()
+		}()
+	}
+	agent := claude.NewAgentWithFactory(claude.Config{}, factory)
+
+	handle, err := agent.Execute(context.Background(), "decode", agentboot.ExecutionOptions{})
+	require.NoError(t, err)
+	var streamedError error
+	for event := range handle.Events() {
+		if errorEvent, ok := event.(agentboot.ErrorEvent); ok {
+			streamedError = errorEvent.Err
+		}
+	}
+	result, waitErr := handle.Wait()
+
+	var protocolErr *agentboot.ProtocolError
+	require.ErrorAs(t, waitErr, &protocolErr)
+	assert.False(t, errors.Is(waitErr, agentboot.ErrNoTerminalResult))
+	assert.Equal(t, waitErr.Error(), result.Error)
+	require.ErrorAs(t, streamedError, &protocolErr)
+}
+
+func TestRunner_RejectsStreamWithoutTerminalResult(t *testing.T) {
+	agent := claude.NewAgentWithFactory(claude.Config{}, fixture.Factory(fixture.Script{
+		fixture.AssistantText("partial"),
+	}))
+
+	handle, err := agent.Execute(context.Background(), "missing result", agentboot.ExecutionOptions{})
+	require.NoError(t, err)
+	for range handle.Events() {
+	}
+	result, waitErr := handle.Wait()
+
+	require.ErrorIs(t, waitErr, agentboot.ErrNoTerminalResult)
+	var protocolErr *agentboot.ProtocolError
+	require.ErrorAs(t, waitErr, &protocolErr)
+	assert.Equal(t, waitErr.Error(), result.Error)
+}
+
+func TestRunner_PreservesStructuredResultError(t *testing.T) {
+	agent := claude.NewAgentWithFactory(claude.Config{}, fixture.Factory(fixture.Script{
+		fixture.Raw(map[string]any{
+			"type":     claude.SDKResultMessage,
+			"subtype":  "error_max_turns",
+			"is_error": true,
+			"errors":   []string{"maximum turns reached", "raise max_turns"},
+		}),
+	}))
+
+	handle, err := agent.Execute(context.Background(), "run", agentboot.ExecutionOptions{})
+	require.NoError(t, err)
+	for range handle.Events() {
+	}
+	result, waitErr := handle.Wait()
+
+	var resultErr *agentboot.ResultError
+	require.ErrorAs(t, waitErr, &resultErr)
+	assert.Equal(t, "error_max_turns", resultErr.Subtype)
+	assert.Equal(t, []string{"maximum turns reached", "raise max_turns"}, resultErr.Details)
+	assert.True(t, strings.Contains(result.Error, "maximum turns reached"))
+	assert.False(t, result.IsSuccess())
+}
+
+type testExitError struct {
+	code int
+}
+
+func (e testExitError) Error() string { return "test process failed" }
+func (e testExitError) ExitCode() int { return e.code }

--- a/agentboot/runner_lifecycle_test.go
+++ b/agentboot/runner_lifecycle_test.go
@@ -101,7 +101,7 @@ func TestRunner_PreservesStructuredResultError(t *testing.T) {
 	agent := claude.NewAgentWithFactory(claude.Config{}, fixture.Factory(fixture.Script{
 		fixture.Raw(map[string]any{
 			"type":     claude.SDKResultMessage,
-			"subtype":  "error_max_turns",
+			"subtype":  claude.ResultSubtypeErrorMaxTurns,
 			"is_error": true,
 			"errors":   []string{"maximum turns reached", "raise max_turns"},
 		}),
@@ -115,7 +115,7 @@ func TestRunner_PreservesStructuredResultError(t *testing.T) {
 
 	var resultErr *agentboot.ResultError
 	require.ErrorAs(t, waitErr, &resultErr)
-	assert.Equal(t, "error_max_turns", resultErr.Subtype)
+	assert.Equal(t, claude.ResultSubtypeErrorMaxTurns, resultErr.Subtype)
 	assert.Equal(t, []string{"maximum turns reached", "raise max_turns"}, resultErr.Details)
 	assert.True(t, strings.Contains(result.Error, "maximum turns reached"))
 	assert.False(t, result.IsSuccess())

--- a/agentboot/runner_shutdown_test.go
+++ b/agentboot/runner_shutdown_test.go
@@ -1,0 +1,64 @@
+package agentboot_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/agentboot"
+	"github.com/tingly-dev/tingly-box/agentboot/claude"
+	"github.com/tingly-dev/tingly-box/agentboot/process"
+)
+
+func TestRunner_ClosesInputForGracefulExitAfterResult(t *testing.T) {
+	factory := process.NewFakeFactory()
+	sawInputEOF := make(chan struct{})
+	factory.OnStart = func(_ context.Context, _ process.LaunchSpec, h *process.FakeHandle) {
+		go func() {
+			decoder := json.NewDecoder(h.StdinR)
+			var initial map[string]any
+			if err := decoder.Decode(&initial); err != nil {
+				h.FinishOutput()
+				h.SignalExit(err)
+				return
+			}
+
+			result, _ := json.Marshal(map[string]any{
+				"type":     claude.SDKResultMessage,
+				"subtype":  claude.ResultSubtypeSuccess,
+				"is_error": false,
+			})
+			_, _ = h.WriteOutput(append(result, '\n'))
+
+			var next map[string]any
+			if err := decoder.Decode(&next); errors.Is(err, io.EOF) {
+				close(sawInputEOF)
+			}
+			h.FinishOutput()
+			h.SignalExit(nil)
+		}()
+	}
+	agent := claude.NewAgentWithFactory(claude.Config{}, factory)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	handle, err := agent.Execute(ctx, "flush", agentboot.ExecutionOptions{})
+	require.NoError(t, err)
+	for range handle.Events() {
+	}
+	result, waitErr := handle.Wait()
+
+	require.NoError(t, waitErr)
+	assert.True(t, result.IsSuccess())
+	select {
+	case <-sawInputEOF:
+	default:
+		t.Fatal("agent process did not observe stdin EOF before completion")
+	}
+}

--- a/agentboot/transport.go
+++ b/agentboot/transport.go
@@ -2,6 +2,13 @@ package agentboot
 
 import "github.com/tingly-dev/tingly-box/agentboot/common"
 
+// AgentTransportFactory creates the protocol state for one execution.
+//
+// A transport may contain mutable, execution-scoped state such as message
+// accumulators and routing metadata. Runner therefore calls the factory once
+// per Execute instead of sharing a transport across concurrent executions.
+type AgentTransportFactory func() AgentTransport
+
 // EventKind is the classification result returned by [AgentTransport.Classify].
 type EventKind int
 

--- a/agentboot/types.go
+++ b/agentboot/types.go
@@ -57,8 +57,10 @@ func (m PermissionMode) String() string {
 type ExecutionOptions struct {
 	ProjectPath  string
 	OutputFormat OutputFormat
-	Timeout      time.Duration
-	Env          []string
+	// Timeout overrides the Runner default. Zero uses the configured default;
+	// a negative value explicitly disables the default timeout.
+	Timeout time.Duration
+	Env     []string
 	// SessionID is the session ID to use or resume
 	// If Resume is true, --resume <session_id> is used to continue an existing session
 	// If Resume is false, --session-id <session_id> is used to create a new session with specific ID

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -54,7 +54,7 @@ export interface ClaudeCodePrefs {
 }
 
 export type PrefsKey = keyof ClaudeCodePrefs;
-export type ClaudeCodeDefaultMode = 'acceptEdits' | 'bypassPermissions' | 'default' | 'delegate' | 'dontAsk' | 'plan' | 'auto';
+export type ClaudeCodeDefaultMode = 'acceptEdits' | 'bypassPermissions' | 'default' | 'delegate' | 'dontAsk' | 'manual' | 'plan' | 'auto';
 export type Group = 'behavior' | 'model' | 'limits' | 'switches' | 'network';
 export type Kind = 'model' | 'int' | 'text' | 'bool';
 export type Lang = 'zh' | 'en';
@@ -420,13 +420,14 @@ interface DefaultModeOptionText {
     description: string;
 }
 
-export const CLAUDE_CODE_DEFAULT_MODE_OPTIONS: ClaudeCodeDefaultMode[] = ['acceptEdits', 'default', 'plan', 'auto', 'delegate', 'dontAsk', 'bypassPermissions'];
+export const CLAUDE_CODE_DEFAULT_MODE_OPTIONS: ClaudeCodeDefaultMode[] = ['acceptEdits', 'default', 'manual', 'plan', 'auto', 'delegate', 'dontAsk', 'bypassPermissions'];
 
 const DEFAULT_MODE_TEXT_ZH: Record<ClaudeCodeDefaultMode, DefaultModeOptionText> = {
     acceptEdits: { label: '接受编辑（推荐）', description: '自动接受文件编辑，其他高风险操作仍按 Claude Code 规则处理。' },
     default: { label: '默认', description: '使用 Claude Code 官方默认权限行为。' },
+    manual: { label: '手动确认', description: '工具权限请求需要交互确认。' },
     plan: { label: '计划模式', description: '默认进入 plan mode，先规划再执行。' },
-    auto: { label: '自动', description: '由 Claude Code 自动选择权限行为。' },
+    auto: { label: '自动规则', description: '由 Claude Code 的规则分类器允许、软拒绝或硬拒绝工具调用。' },
     delegate: { label: '委托', description: '把权限决策委托给 Claude Code 支持的外部流程。' },
     dontAsk: { label: '不询问', description: '避免交互式询问；适合无人值守场景。' },
     bypassPermissions: { label: '绕过权限', description: '跳过权限检查；仅在完全可信环境中使用。' },
@@ -435,8 +436,9 @@ const DEFAULT_MODE_TEXT_ZH: Record<ClaudeCodeDefaultMode, DefaultModeOptionText>
 const DEFAULT_MODE_TEXT_EN: Record<ClaudeCodeDefaultMode, DefaultModeOptionText> = {
     acceptEdits: { label: 'Accept edits (recommended)', description: 'Automatically accepts file edits while leaving riskier actions to Claude Code rules.' },
     default: { label: 'Default', description: 'Use Claude Code\'s built-in default permission behavior.' },
+    manual: { label: 'Manual approval', description: 'Require interactive approval for tool permission requests.' },
     plan: { label: 'Plan mode', description: 'Start in plan mode by default before implementation.' },
-    auto: { label: 'Auto', description: 'Let Claude Code choose the permission behavior automatically.' },
+    auto: { label: 'Auto rules', description: 'Use Claude Code\'s rule classifier to allow, soft-deny, or hard-deny tool calls.' },
     delegate: { label: 'Delegate', description: 'Delegate permission decisions to Claude Code\'s supported external flow.' },
     dontAsk: { label: 'Don\'t ask', description: 'Avoid interactive prompts; useful for unattended setups.' },
     bypassPermissions: { label: 'Bypass permissions', description: 'Skip permission checks; use only in fully trusted environments.' },

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -13,6 +13,7 @@ var validClaudeCodeDefaultModes = map[string]struct{}{
 	"default":           {},
 	"delegate":          {},
 	"dontAsk":           {},
+	"manual":            {},
 	"plan":              {},
 	"auto":              {},
 }

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -7,6 +7,13 @@ import (
 	"testing"
 )
 
+func TestNormalizeClaudeCodeDefaultModeAcceptsManual(t *testing.T) {
+	mode, ok := NormalizeClaudeCodeDefaultMode("manual")
+	if !ok || mode != "manual" {
+		t.Fatalf("manual mode = %q, %v; want manual, true", mode, ok)
+	}
+}
+
 func TestClaudeCodePrefs_ToEnv_OmitsEmpty(t *testing.T) {
 	// Sparse prefs: only one model + one limit, everything else empty.
 	p := ClaudeCodePrefs{

--- a/internal/remote_control/bot/agent_claude_code.go
+++ b/internal/remote_control/bot/agent_claude_code.go
@@ -33,18 +33,16 @@ func (e *ClaudeCodeExecutor) GetAgentType() agentboot.AgentType {
 	return agentClaudeCode
 }
 
-// noApprovalModes are permission modes that auto-approve every tool request
-// without going through IMPrompter.
+// noApprovalModes contains only modes whose contract is unconditional
+// approval. Other modes must preserve Claude Code's own deny/plan/classifier
+// semantics if a permission callback reaches the host.
 var noApprovalModes = map[string]bool{
-	string(claude.PermissionModeAuto):              true,
 	string(claude.PermissionModeBypassPermissions): true,
-	string(claude.PermissionModeDontAsk):           true,
-	string(claude.PermissionModePlan):              true,
 }
 
 // autoApprovePrompter wraps a Prompter to auto-approve every tool permission
-// request (for permission modes like plan/bypass) while still deferring
-// AskUserQuestion prompts to the underlying prompter.
+// request in bypass mode while still deferring AskUserQuestion prompts to the
+// underlying prompter.
 type autoApprovePrompter struct{ inner agentboot.Prompter }
 
 func (p autoApprovePrompter) OnApproval(context.Context, agentboot.ApprovalRequestEvent) (agentboot.ApprovalResponse, error) {

--- a/internal/remote_control/bot/agent_claude_code_permission_test.go
+++ b/internal/remote_control/bot/agent_claude_code_permission_test.go
@@ -1,0 +1,25 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/agentboot/claude"
+)
+
+func TestNoApprovalModesPreserveClaudeAutoSemantics(t *testing.T) {
+	if noApprovalModes[string(claude.PermissionModeAuto)] {
+		t.Fatal("auto mode must use Claude Code's rule classifier, not unconditional approval")
+	}
+	for _, mode := range []claude.PermissionMode{
+		claude.PermissionModeManual,
+		claude.PermissionModeDontAsk,
+		claude.PermissionModePlan,
+	} {
+		if noApprovalModes[string(mode)] {
+			t.Fatalf("%s mode must preserve Claude Code's permission semantics", mode)
+		}
+	}
+	if !noApprovalModes[string(claude.PermissionModeBypassPermissions)] {
+		t.Fatal("bypassPermissions should remain non-interactive")
+	}
+}

--- a/internal/remote_control/bot/command_integration.go
+++ b/internal/remote_control/bot/command_integration.go
@@ -95,7 +95,7 @@ func (a *botHandlerAdapter) FindOrCreateSession(chatID, agentType, projectPath s
 // UpdatePermissionMode updates the permission mode for a session.
 func (a *botHandlerAdapter) UpdatePermissionMode(sessionID, mode string) error {
 	if !claude.IsValidPermissionMode(mode) {
-		return fmt.Errorf("invalid permission mode: %q, must be one of: default, plan, auto, acceptEdits, dontAsk, bypassPermissions", mode)
+		return fmt.Errorf("invalid permission mode: %q, must be one of: default, manual, plan, auto, acceptEdits, dontAsk, bypassPermissions", mode)
 	}
 	a.handler.sessionMgr.Update(sessionID, func(s *session.Session) {
 		s.PermissionMode = mode


### PR DESCRIPTION
## Summary

Claude Code executions now keep mutable protocol state isolated per run and handle terminal, process, and protocol failures predictably. This prevents overlapping bot chats from influencing each other while making CLI discovery and permission behavior match the real Claude Code contract.

## Key Changes

- **Concurrent Claude sessions**: Each execution receives its own transport, message accumulator, routing context, and process lifecycle, so simultaneous chats through one agent cannot leak state or responses across conversations.
- **Reliable execution completion**: Terminal results now close stdin before escalation, configured timeouts and stream buffers take effect, and malformed/truncated streams stop cleanly rather than leaving callers waiting indefinitely.
- **Actionable failures**: Result, process, and protocol failures retain structured details, exit codes, and underlying causes so callers can distinguish agent errors from runtime or decoding failures.
- **CLI installation discovery**: Claude Code candidates are verified before use, packaged/global/native installations are compared safely, and forced source choices now fail with clear diagnostics.
- **Permission semantics**: Remote control preserves Claude Code’s `manual`, `plan`, `auto`, and `dontAsk` behavior instead of auto-approving them; only bypass mode bypasses host approval.
- **Regression coverage**: New tests cover concurrent runs, lifecycle shutdown, timeouts, decoder failures, CLI discovery, and permission-mode handling.

## Notes

- **Working tree artifacts**: Local untracked files are intentionally excluded from this branch comparison and PR scope.