### PR TITLE
fix(frontend): stop preset selection from overwriting provider name in edit mode

### DIFF
--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -165,7 +165,9 @@ const ProviderFormDialog = ({
             anthropic: provider.baseUrlAnthropic,
         });
         onChangeRef.current('selectedProviderId', provider.id);
-        if (nameIsAutoFilled || !data.name) {
+        // In edit mode the provider name already belongs to the user — selecting a
+        // preset must never overwrite it. Auto-fill only applies in add mode.
+        if (mode === 'add' && (nameIsAutoFilled || !data.name)) {
             onChangeRef.current('name', provider.alias || provider.name);
             setNameIsAutoFilled(true);
         }


### PR DESCRIPTION
In the provider edit dialog, clicking a preset chip would replace the provider's name with the preset's alias/name. The name autofill gate (nameIsAutoFilled) starts true on open, so in edit mode — where the name already belongs to the user — selecting a preset silently overwrote it.

Restrict name auto-fill to add mode; in edit mode a preset selection only affects the URL/protocol configuration and leaves the name untouched.