### PR TITLE
feat(statusline): two-row layout with cwd, session title, and model split

### DIFF
--- a/internal/server/module/statusline/cache.go
+++ b/internal/server/module/statusline/cache.go
@@ -87,5 +87,8 @@ func mergeStatusInput(input, cached *StatusInput) *StatusInput {
 	merged.Cost.TotalLinesAdded = cmp.Or(merged.Cost.TotalLinesAdded, cached.Cost.TotalLinesAdded)
 	merged.Cost.TotalLinesRemoved = cmp.Or(merged.Cost.TotalLinesRemoved, cached.Cost.TotalLinesRemoved)
 
+	merged.CWD = cmp.Or(merged.CWD, cached.CWD)
+	merged.SessionName = cmp.Or(merged.SessionName, cached.SessionName)
+
 	return &merged
 }

--- a/internal/server/module/statusline/handler.go
+++ b/internal/server/module/statusline/handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -117,8 +118,9 @@ func (h *Handler) GetClaudeCodeStatusLine(c *gin.Context) {
 	// Update cache with new input (even if partial)
 	h.cache.Update(&input)
 
-	// Build status line
-	// Format: [CC Model] → TB Model@Provider | ▓▓▓░░░░░ 7% | $0.05
+	// Build status line as two rows, split by semantic dimension:
+	//   row 1 (session + requested routing): ruleModel @ profile  📁 <cwd>  <session>
+	//   row 2 (real model + consumption):     realModel @ provider | ▓▓░░░░░░ 7% | $0.05 | Cache: 87% | Usage: 40K/100K
 	ccModel := cmp.Or(merged.Model.DisplayName, "unknown")
 
 	usedPct := int(merged.ContextWindow.UsedPercentage)
@@ -129,8 +131,8 @@ func (h *Handler) GetClaudeCodeStatusLine(c *gin.Context) {
 	filled := min(max(usedPct*barWidth/100, 0), barWidth)
 	bar := strings.Repeat("▓", filled) + strings.Repeat("░", barWidth-filled)
 
-	// Build profile label: "p1:name" or empty
-	profileLabel := ""
+	// Build profile label: "p1:name" or "default" when none configured.
+	profileLabel := "default"
 	base, profileID := typ.ParseScenarioProfile(typ.RuleScenario(scenario))
 	if profileID != "" {
 		profileName := profileID
@@ -142,28 +144,27 @@ func (h *Handler) GetClaudeCodeStatusLine(c *gin.Context) {
 
 	// Query Tingly Box model mapping
 	mapping := h.getTBModelMapping(merged.Model.ID, typ.RuleScenario(scenario))
-
-	// Build output: [ruleModel @ p1:name] -> realModel @ providerName | bar pct | cost
 	ruleModel := cmp.Or(merged.Model.ID, ccModel)
 
-	output := fmt.Sprintf("[%s", ruleModel)
-	if profileLabel != "" {
-		output += fmt.Sprintf(" @ %s", profileLabel)
-	}
-	output += "]"
-	if mapping != nil && mapping.model != "" {
-		output += fmt.Sprintf(" → %s @ %s", mapping.model, mapping.providerName)
-	}
-	output += fmt.Sprintf(" | %s %d%% | $%.2f", bar, usedPct, cost)
-	output += buildCacheInline(merged.ContextWindow.CurrentUsage)
+	// Row 1: requested routing first, then session identity.
+	// @ reads as "belongs to / via" (profile, provider).
+	row1 := fmt.Sprintf("%s @ %s  📁 %s%s", ruleModel, profileLabel, shortenPath(merged.CWD), sessionLabel(merged.SessionName, merged.SessionID))
 
-	// Add quota info to the same line if available
+	// Row 2: real model + consumption.
+	row2 := ""
+	if mapping != nil && mapping.model != "" {
+		row2 = fmt.Sprintf("%s @ %s | ", mapping.model, mapping.providerName)
+	}
+	row2 += fmt.Sprintf("%s %d%% | $%.2f", bar, usedPct, cost)
+	row2 += buildCacheInline(merged.ContextWindow.CurrentUsage)
+
+	// Add usage info to the same line if available
 	quotaInfo := h.buildQuotaInline(mapping)
 	if quotaInfo != "" {
-		output += quotaInfo
+		row2 += quotaInfo
 	}
 
-	c.String(http.StatusOK, output)
+	c.String(http.StatusOK, row1+"\n"+row2)
 }
 
 func cacheHitPct(usage CurrentUsage) int {
@@ -186,6 +187,82 @@ func buildCacheInline(usage CurrentUsage) string {
 	}
 
 	return fmt.Sprintf(" | Cache: %d%%", pct)
+}
+
+// shortenPath collapses a long absolute path for compact statusline display.
+// The home directory prefix becomes ~; long middles collapse to ... while the
+// first segment and the last two segments (parent/basename) are kept.
+// Examples:
+//
+//	/Users/yz/Project/101-project/tingly-box → ~/.../101-project/tingly-box
+//	/Users/xyz/tmp            → ~/tmp
+//	""                        → ~
+func shortenPath(path string) string {
+	if path == "" {
+		return "~"
+	}
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" && strings.HasPrefix(path, home) {
+		path = "~" + strings.TrimPrefix(path, home)
+	}
+
+	// Clean slashes so splitting is predictable, but keep the leading ~.
+	segments := strings.Split(strings.TrimPrefix(path, "~"), "/")
+	// Drop empty segments (leading slash, doubled slashes).
+	cleaned := segments[:0]
+	for _, s := range segments {
+		if s != "" {
+			cleaned = append(cleaned, s)
+		}
+	}
+
+	const maxLen = 40
+	if path == "~" || len(cleaned) == 0 {
+		return "~"
+	}
+
+	short := "~/" + strings.Join(cleaned, "/")
+
+	// Collapse the middle when there are more than 2 path segments (keeps
+	// home ~ prefix + last two), or when even a short segment count blows past
+	// the width budget. So /h/Project/101-project/tingly-box (3 segments) →
+	// ~/.../101-project/tingly-box, while /h/repo stays ~/repo.
+	if len(cleaned) > 2 || len(short) > maxLen {
+		if len(cleaned) <= 2 {
+			return short
+		}
+		tail := cleaned[len(cleaned)-2:]
+		return "~/.../" + strings.Join(tail, "/")
+	}
+
+	return short
+}
+
+// firstN returns the first n bytes of s (or all of it if shorter), safe for
+// short/empty input.
+func firstN(s string, n int) string {
+	if n < 0 {
+		n = 0
+	}
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// sessionLabel renders a compact, resumeable session identifier for row 1.
+// Prefers the human-readable title (quoted — literally copy-resumeable via
+// `claude --resume <title>`); falls back to #<first8> of the id when no title
+// exists (early / `claude -p` sessions). Returns "" when neither is available.
+// The result always carries a leading space when non-empty.
+func sessionLabel(name, id string) string {
+	if name != "" {
+		return fmt.Sprintf(" %q", name)
+	}
+	if id != "" {
+		return " #" + firstN(id, 8)
+	}
+	return ""
 }
 
 // tbModelMappingResult contains the result of model mapping lookup
@@ -278,8 +355,8 @@ func (h *Handler) selectBestQuotaWindow(usage *quota.ProviderUsage) *quota.Usage
 	return nil
 }
 
-// buildQuotaInline builds quota information for inline display in statusline
-// Format: " | Quota: 40/100 tokens" or " | Quota: 40K/100K tokens | 100/500 req"
+// buildQuotaInline builds quota (used/limit) information for inline display in statusline
+// Format: " | Usage: 40/100 tokens" or " | Usage: 40K/100K tokens | 100/500 req"
 func (h *Handler) buildQuotaInline(mapping *tbModelMappingResult) string {
 	if h.quotaMgr == nil || mapping == nil {
 		return ""
@@ -320,8 +397,9 @@ func (h *Handler) buildQuotaInline(mapping *tbModelMappingResult) string {
 		return ""
 	}
 
-	// Join all quota parts
-	return " | Quota: " + strings.Join(parts, " ")
+	// Join all quota parts. Label is "Usage" (not "Quota"): the values are
+	// used/limit (consumption), and "Usage" is unambiguous next to the usage %.
+	return " | Usage: " + strings.Join(parts, " ")
 }
 
 // formatQuotaWindow formats a single quota window

--- a/internal/server/module/statusline/handler_test.go
+++ b/internal/server/module/statusline/handler_test.go
@@ -3,6 +3,7 @@ package statusline
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -535,4 +536,146 @@ func TestAgentStructure(t *testing.T) {
 	if agent.Name != "claude-opus-4-6" {
 		t.Errorf("expected Name 'claude-opus-4-6', got %q", agent.Name)
 	}
+}
+
+// --- new two-row statusline tests ---
+
+func TestGetClaudeCodeStatusLine_TwoRowsWithTitle(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	router := setupTestRouter(cfg)
+
+	body := `{
+		"model": {"id": "cc[1m]", "display_name": "cc[1m]"},
+		"cwd": "/Users/yz/Project/101-project/tingly-box",
+		"session_id": "a3f9b2c1-1234-5678",
+		"session_name": "fix-login-bug",
+		"context_window": {"used_percentage": 7},
+		"cost": {"total_cost_usd": 0.05}
+	}`
+
+	req, _ := http.NewRequest("POST", "/statusline/claude_code", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	out := w.Body.String()
+	lines := strings.Split(out, "\n")
+	assert.Len(t, lines, 2, "statusline should be exactly two rows; got: %q", out)
+
+	// Row 1: requested routing FIRST (ruleModel @ default), then cwd + title.
+	assert.True(t, strings.HasPrefix(lines[0], "cc[1m] @ default"),
+		"row 1 should start with the routing block; got: %q", lines[0])
+	assert.Contains(t, lines[0], "tingly-box")
+	assert.Contains(t, lines[0], `"fix-login-bug"`)
+	// No wrapping [...] around the routing block, no consumption % on row 1.
+	assert.NotContains(t, lines[0], "7%", "consumption % belongs on row 2")
+
+	// Row 2: consumption only (no routing block on this row when no mapping
+	// resolves in the test config — just bar, %, cost).
+	assert.Contains(t, lines[1], "7%")
+	assert.Contains(t, lines[1], "$0.05")
+}
+
+func TestGetClaudeCodeStatusLine_FallbackToShortID(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	router := setupTestRouter(cfg)
+
+	// No session_name → must fall back to #<first8> of session_id.
+	body := `{
+		"model": {"id": "cc[1m]", "display_name": "cc[1m]"},
+		"cwd": "/tmp/repo",
+		"session_id": "a3f9b2c1-1234-5678"
+	}`
+
+	req, _ := http.NewRequest("POST", "/statusline/claude_code", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	out := w.Body.String()
+	row1 := strings.Split(out, "\n")[0]
+	assert.Contains(t, row1, "#a3f9b2c1")
+	assert.NotContains(t, row1, "#a3f9b2c1-") // only first 8 chars
+	assert.NotContains(t, row1, `"`, "no quoted title when session_name absent")
+}
+
+func TestGetClaudeCodeStatusLine_UsageLabelNotQuota(t *testing.T) {
+	// Sanity: the inline quota label is "Usage:", never "Quota:". This test
+	// passes even without a quota manager (no segment rendered), but guards
+	// against accidental regression of the label string.
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	router := setupTestRouter(cfg)
+
+	body := `{"model":{"id":"cc[1m]"},"session_id":"s1"}`
+	req, _ := http.NewRequest("POST", "/statusline/claude_code", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	out := w.Body.String()
+	assert.NotContains(t, out, "Quota:")
+}
+
+// --- pure helper tests ---
+
+func TestShortenPath(t *testing.T) {
+	// Non-home paths: ~ substitution is a no-op, so the leading segment becomes
+	// the first kept segment. Collapse kicks in at >2 segments (tail = last 2).
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "~"},
+		{"two segments absolute", "/tmp/repo", "~/tmp/repo"},
+		{"three segments collapse", "/a/b/repo", "~/.../b/repo"},
+		{"six segments collapse middle", "/a/b/c/d/e/repo", "~/.../e/repo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shortenPath(tc.in))
+		})
+	}
+}
+
+func TestShortenPath_HomePrefix(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no home dir available")
+	}
+	// Three segments under home → middle collapses, parent+basename kept.
+	got := shortenPath(home + "/Project/101-project/tingly-box")
+	assert.Equal(t, "~/.../101-project/tingly-box", got)
+
+	// One segment under home → shown whole.
+	gotShort := shortenPath(home + "/repo")
+	assert.Equal(t, "~/repo", gotShort)
+}
+
+func TestSessionLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		n, i string
+		want string
+	}{
+		{"title wins", "fix-login-bug", "a3f9b2c1-dead", ` "fix-login-bug"`},
+		{"id fallback", "", "a3f9b2c1-dead", " #a3f9b2c1"},
+		{"both empty", "", "", ""},
+		{"id truncated to 8", "", "1234567890abcdef", " #12345678"},
+		{"short id kept whole", "", "abc", " #abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sessionLabel(tc.n, tc.i))
+		})
+	}
+}
+
+func TestFirstN(t *testing.T) {
+	assert.Equal(t, "abc", firstN("abcdef", 3))
+	assert.Equal(t, "abcdef", firstN("abcdef", 10))
+	assert.Equal(t, "", firstN("abcdef", 0))
+	assert.Equal(t, "", firstN("", 5))
 }

--- a/internal/server/module/statusline/types.go
+++ b/internal/server/module/statusline/types.go
@@ -15,6 +15,7 @@ type StatusInput struct {
 	// Additional fields
 	Exceeds200kTokens bool        `json:"exceeds_200k_tokens"`
 	SessionID         string      `json:"session_id"`
+	SessionName       string      `json:"session_name"` // human-readable session title; resumeable via `claude --resume <title>`
 	TranscriptPath    string      `json:"transcript_path"`
 	Version           string      `json:"version"`
 	OutputStyle       OutputStyle `json:"output_style"`


### PR DESCRIPTION
## Summary
Split the Claude Code statusline into two semantic rows:
- Row 1 (routing + session): ruleModel @ profile, cwd (middle-collapsed), session title
- Row 2 (real model + consumption): realModel @ provider | context bar | cost | cache | usage

## Changes
- Capture session_name in StatusInput; show the resumeable session title, falling back to #<first8> of session_id when no title exists (raw id prefix can't be resumed via `claude --resume`, which is exact-match only).
- Cache-merge CWD and SessionName so they survive partial payloads.
- shortenPath collapses long paths (home -> ~, >2 segments keep last two).
- Drop redundant [...] brackets; unify connectors (@ = belongs/via, routed model on its own row). Default profile shown explicitly as @ default.
- Rename inline "Quota:" to "Usage:" since it renders used/limit (consumption), consistent with the frontend quota bars.

## Preview
```
  cc[1m] @ default  📁 ~/.../tingly-box "statusline-two-row-layout"                    125522 tokens
  glm-5.2 @ GLM | ▓░░░░░░░ 13% | $6.23 | Cache: 99% | Usage: 15/100 9/100 33/4000
```