### PR TITLE
bugfix(protocol): Fix array-of-text content forwarding in protocol converters

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -426,9 +426,6 @@ Cases reuse `flagTB`/`flagRecorder`/`flagAbort` from `flags.go` so they run
 under both `*testing.T` (`TestContentShapes`) and the CLI
 (`--mode=content_shapes`) without duplicating that plumbing.
 
-Current coverage: tool/assistant/system array-of-text content and
-`reasoning_effort` forwarding, for `openai_chat → openai_responses` and
-`openai_chat → anthropic_beta` — the two converters #1427 touched
-(`ConvertChatToOpenAIResponses`, `ConvertOpenAIToAnthropicRequest`). Extend
-this list, not the matrix's `Scenario`/`buildRequest`, when a future bug is
+See `contentShapeCases()` in `content_shapes.go` for current coverage. Extend
+that list, not the matrix's `Scenario`/`buildRequest`, when a future bug is
 "the gateway dropped an unusual request shape while forwarding it."

--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -6,6 +6,13 @@
 > Related: per-rule **flag** behavior is tested by a separate, registry-driven
 > suite — see [`rule-flag-testing.md`](./rule-flag-testing.md). The matrix
 > itself stays flag-free (it exercises protocol conversion, not rule flags).
+>
+> Related: request **content-shape** regressions (a client sending array-of-
+> text-blocks content instead of a plain string on tool/system/assistant
+> messages) are covered by a separate suite in `content_shapes.go` — see
+> §9.1. The matrix itself always sends the same fixed single-turn prompt and
+> only varies the mocked *response* shape, so it cannot catch bugs in how
+> unusual *request* shapes are forwarded upstream.
 
 ---
 
@@ -97,6 +104,9 @@ go test -tags e2e ./internal/protocoltest/... -run TestHarness_Streaming
 
 # Idempotent round-trips
 go test -tags e2e ./internal/protocoltest/... -run TestIdempotent
+
+# Request content-shape regression suite (see §9.1)
+go test -tags e2e ./internal/protocoltest/... -run TestContentShapes
 ```
 
 ### CLI (`cli/harness`)
@@ -105,14 +115,15 @@ go test -tags e2e ./internal/protocoltest/... -run TestIdempotent
 executor (`ExecuteAll*`) so the CLI can run it directly — including idempotence
 and the rule-flag suite, which would otherwise be go-test-only.
 
-| `--mode` | single (A→B) | transitive (A→B→C) | idempotent (`g(f(A))==A`) | flags (per-rule) |
-|----------|:---:|:---:|:---:|:---:|
-| `default` *(no flag)* | ✅ | — | ✅ | — |
-| `all` | ✅ | ✅ | ✅ | ✅ |
-| `single` | ✅ | — | — | — |
-| `transitive` | — | ✅ | — | — |
-| `idempotent` | — | — | ✅ | — |
-| `flags` | — | — | — | ✅ |
+| `--mode` | single (A→B) | transitive (A→B→C) | idempotent (`g(f(A))==A`) | flags (per-rule) | content_shapes (§9.1) |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| `default` *(no flag)* | ✅ | — | ✅ | — | — |
+| `all` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `single` | ✅ | — | — | — | — |
+| `transitive` | — | ✅ | — | — | — |
+| `idempotent` | — | — | ✅ | — | — |
+| `flags` | — | — | — | ✅ | — |
+| `content_shapes` | — | — | — | — | ✅ |
 
 ```bash
 # Default: single-hop + idempotent round-trips. Two-hop and flags are OFF by
@@ -128,6 +139,7 @@ go run ./cli/harness matrix --mode=single
 go run ./cli/harness matrix --mode=transitive
 go run ./cli/harness matrix --mode=idempotent
 go run ./cli/harness matrix --mode=flags     # per-rule flag behavior
+go run ./cli/harness matrix --mode=content_shapes  # request content-shape regression
 
 # Filter by scenario / source / target
 go run ./cli/harness matrix --scenario text --source anthropic_v1
@@ -139,6 +151,9 @@ go run ./cli/harness matrix --json
 The `flags` section is documented in detail in
 [`rule-flag-testing.md`](./rule-flag-testing.md); `ExecuteAllFlags` reports one
 `TestResult` per flag (`Name: "flags/<key>"`, `Scenario: <key>`).
+
+The `content_shapes` section is documented in §9.1 below; `ExecuteAllContentShapes`
+reports one `TestResult` per case (`Name: "content_shapes/<case name>"`).
 
 ### Client drivers (`--client`)
 
@@ -377,3 +392,43 @@ the gateway actually forwarded upstream*. The `VirtualServer` mock records it:
 These power the per-rule **flag** behavior suite, which is documented
 separately: [`rule-flag-testing.md`](./rule-flag-testing.md). Keep the matrix
 itself flag-free — flags are an orthogonal axis and live in their own suite.
+
+### 9.1 Request content-shape regression suite (`content_shapes.go`)
+
+**Why this exists.** Every matrix request is built by `buildRequest`
+(`testenv.go`) from the fixed `harnessPrompt` — a single-turn plain-string user
+message, identical across every scenario and every client driver
+(`client.go`: "the request itself varies only by (Source, RequestModel,
+Streaming)"). `Scenario.MockResponses` only controls the mocked upstream
+*response* shape. That split means the matrix, by construction, cannot catch
+a bug in how the gateway forwards an unusual *request* content shape upstream
+— which is exactly how issue #1427 shipped: a `role: "tool"` message whose
+`content` was an array of text blocks (`[{"type":"text","text":"..."}]`,
+valid per the OpenAI spec and emitted by several agent frameworks instead of
+a plain string) was silently forwarded upstream as an empty string, and no
+scenario or assertion in the matrix could have caught it — the matrix never
+sends a tool/assistant/system message in that shape in the first place.
+
+Reworking `buildRequest` to vary per scenario would mean threading bespoke
+request bodies through every client driver, including the Python/Node/AI SDK
+subprocess drivers that wrap real vendor SDKs — those SDKs may not expose an
+array-of-text-blocks tool result through their high-level API at all, and the
+matrix's client-driver architecture deliberately assumes a shape-invariant
+request so results stay comparable across drivers. That redesign is out of
+proportion to the bug class.
+
+Instead, `content_shapes.go` follows the same "separate, registry-driven
+suite" pattern as `flags.go`: a `contentShapeCase{name, run}` list, driven
+through the real gateway with a bespoke JSON body per case (built directly,
+bypassing `buildRequest`), asserting on the request the gateway actually
+forwarded upstream via `VirtualServer.LastRequest` — not the parsed response.
+Cases reuse `flagTB`/`flagRecorder`/`flagAbort` from `flags.go` so they run
+under both `*testing.T` (`TestContentShapes`) and the CLI
+(`--mode=content_shapes`) without duplicating that plumbing.
+
+Current coverage: tool/assistant/system array-of-text content and
+`reasoning_effort` forwarding, for `openai_chat → openai_responses` and
+`openai_chat → anthropic_beta` — the two converters #1427 touched
+(`ConvertChatToOpenAIResponses`, `ConvertOpenAIToAnthropicRequest`). Extend
+this list, not the matrix's `Scenario`/`buildRequest`, when a future bug is
+"the gateway dropped an unusual request shape while forwarding it."

--- a/.github/workflows/harness-matrix.yml
+++ b/.github/workflows/harness-matrix.yml
@@ -31,6 +31,7 @@ on:
           - transitive
           - idempotent
           - flags
+          - content_shapes
           - gosdk
           - python
           - node
@@ -75,6 +76,10 @@ jobs:
             tier: matrix
             focus: flags
             cmd: matrix --mode=flags --json
+          - name: matrix-content-shapes
+            tier: matrix
+            focus: content_shapes
+            cmd: matrix --mode=content_shapes --json
           # One matrix leg per client driver: the same matrix driven through
           # real client stacks instead of raw HTTP. gosdk uses the official Go
           # SDKs in-process; python/node/aisdk run the real foreign SDKs via

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -25,7 +25,7 @@ type MatrixCmd struct {
 	Targets    []string `kong:"name='target',sep=',',help='Filter by target protocol (can repeat or comma-separate)'"`
 	Streaming  bool     `kong:"name='streaming',help='Run only streaming tests'"`
 	NonStream  bool     `kong:"name='non-streaming',help='Run only non-streaming tests'"`
-	Mode       string   `kong:"name='mode',default='default',enum='default,all,single,transitive,idempotent,flags',help='Section selection: default (single + idempotent round-trip; two-hop OFF), all (single + transitive + idempotent + flags), single (A→B only), transitive (A→B→C only), idempotent (round-trip g(f(A))==A only), flags (per-rule flag behavior only)'"`
+	Mode       string   `kong:"name='mode',default='default',enum='default,all,single,transitive,idempotent,flags,content_shapes',help='Section selection: default (single + idempotent round-trip; two-hop OFF), all (single + transitive + idempotent + flags + content_shapes), single (A→B only), transitive (A→B→C only), idempotent (round-trip g(f(A))==A only), flags (per-rule flag behavior only), content_shapes (request content-shape regression only)'"`
 	Client     string   `kong:"name='client',default='http',enum='http,gosdk,python,node,aisdk',help='Client driver: http (raw JSON over net/http, default), gosdk (official anthropic-sdk-go / openai-go), python (real Python SDKs via subprocess driver), node (real Node SDKs via subprocess driver), aisdk (AI SDK by Vercel via subprocess driver)'"`
 	JsonOutput bool     `kong:"name='json',help='Output results as JSON'"`
 	Verbose    int      `kong:"name='verbose',short='v',type='counter',help='Verbose output (repeat for more detail)'"`
@@ -52,6 +52,9 @@ func (*MatrixCmd) Help() string {
 
   # Run only per-rule flag behavior tests
   harness matrix --mode=flags
+
+  # Run only request content-shape regression tests
+  harness matrix --mode=content_shapes
 
   # Run only single-hop (A→B) tests
   harness matrix --mode=single
@@ -99,8 +102,8 @@ func (m *MatrixCmd) Run() error {
 	if m.Streaming && m.NonStream {
 		return fmt.Errorf("cannot specify both --streaming and --non-streaming")
 	}
-	if m.Client != "http" && m.Mode == "flags" {
-		return fmt.Errorf("--mode=flags only supports --client=http (the flags suite drives raw requests with custom headers)")
+	if m.Client != "http" && (m.Mode == "flags" || m.Mode == "content_shapes") {
+		return fmt.Errorf("--mode=%s only supports --client=http (this suite drives raw requests directly)", m.Mode)
 	}
 
 	client, err := resolveClient(m.Client)
@@ -141,12 +144,13 @@ func (m *MatrixCmd) Run() error {
 
 	// Collect results for the selected sections (--mode controls which).
 	//
-	//   single-hop (A→B)        runs unless mode is transitive/idempotent/flags
-	//   transitive (A→B→C)      runs only for all/transitive (OFF by default)
-	//   idempotent (g(f(A))==A) runs for default/all/idempotent
-	//   flags (per-rule flags)  runs for all/flags
+	//   single-hop (A→B)         runs unless mode is transitive/idempotent/flags/content_shapes
+	//   transitive (A→B→C)       runs only for all/transitive (OFF by default)
+	//   idempotent (g(f(A))==A)  runs for default/all/idempotent
+	//   flags (per-rule flags)   runs for all/flags
+	//   content_shapes (request content-shape regression) runs for all/content_shapes
 	var combined []protocoltest.TestResult
-	if m.Mode != "transitive" && m.Mode != "idempotent" && m.Mode != "flags" {
+	if m.Mode != "transitive" && m.Mode != "idempotent" && m.Mode != "flags" && m.Mode != "content_shapes" {
 		combined = append(combined, matrix.ExecuteAll()...)
 	}
 	if m.Mode == "all" || m.Mode == "transitive" {
@@ -159,6 +163,11 @@ func (m *MatrixCmd) Run() error {
 		combined = append(combined, matrix.ExecuteAllFlags()...)
 	} else if m.Mode == "all" {
 		logrus.Warnf("skipping flags section: only supported with --client=http")
+	}
+	if (m.Mode == "all" || m.Mode == "content_shapes") && m.Client == "http" {
+		combined = append(combined, matrix.ExecuteAllContentShapes()...)
+	} else if m.Mode == "all" {
+		logrus.Warnf("skipping content_shapes section: only supported with --client=http")
 	}
 	results := filterResults(combined, m)
 

--- a/internal/protocol/request/anthropic_v1_to_beta.go
+++ b/internal/protocol/request/anthropic_v1_to_beta.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"strings"
+
 	"github.com/anthropics/anthropic-sdk-go"
 )
 
@@ -75,10 +77,23 @@ func convertAnthropicV1ContentToBeta(blocks []anthropic.ContentBlockParamUnion) 
 		case b.OfToolResult != nil:
 			out = append(out, anthropic.NewBetaToolResultBlock(
 				b.OfToolResult.ToolUseID,
-				"",
+				joinV1ToolResultText(b.OfToolResult.Content),
 				false,
 			))
 		}
 	}
 	return out
+}
+
+// joinV1ToolResultText concatenates the text blocks of a v1 tool_result's
+// content into a single string, mirroring convertToolResultContent in
+// anthropic_v1_to_openai.go.
+func joinV1ToolResultText(content []anthropic.ToolResultBlockParamContentUnion) string {
+	var texts []string
+	for _, c := range content {
+		if c.OfText != nil && c.OfText.Text != "" {
+			texts = append(texts, c.OfText.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
 }

--- a/internal/protocol/request/anthropic_v1_to_beta.go
+++ b/internal/protocol/request/anthropic_v1_to_beta.go
@@ -1,99 +1,40 @@
 package request
 
 import (
-	"strings"
+	"encoding/json"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/sirupsen/logrus"
 )
 
 // ConvertAnthropicV1ToBetaRequest projects an Anthropic v1 MessageNewParams onto
-// the Beta MessageNewParams shape. Beta is a structural superset of v1 in the SDK,
-// so this is a field-by-field copy.
+// the Beta MessageNewParams shape. Beta's wire format is a strict structural
+// superset of v1's (same field names and shapes; Beta only adds optional
+// fields), so a v1 request's own JSON round-trips losslessly into the Beta
+// struct — every block type (text, image, tool_use, tool_result, documents,
+// cache_control, ...) survives without hand-maintained per-type conversion.
+// This previously did a field-by-field Go copy that silently dropped
+// tool_result content and image data; the round-trip has no such gaps and
+// needs no updates when the SDK adds new block types.
 //
-// Coverage is limited to the fields downstream consumers (currently smart-routing
-// context extraction) read: Model, MaxTokens, Thinking-enabled flag, System text,
-// Messages with text / image / tool_use / tool_result blocks. Extend as needed if
-// other call sites require additional fields.
+// Returns nil (rather than erroring) if req is nil or the round-trip fails,
+// so callers doing best-effort context extraction (smart-routing) degrade
+// gracefully instead of panicking.
 func ConvertAnthropicV1ToBetaRequest(req *anthropic.MessageNewParams) *anthropic.BetaMessageNewParams {
 	if req == nil {
 		return nil
 	}
 
-	beta := &anthropic.BetaMessageNewParams{
-		Model:     anthropic.Model(req.Model),
-		MaxTokens: req.MaxTokens,
-	}
-
-	if req.Thinking.OfEnabled != nil {
-		beta.Thinking = anthropic.BetaThinkingConfigParamUnion{
-			OfEnabled: &anthropic.BetaThinkingConfigEnabledParam{
-				BudgetTokens: req.Thinking.OfEnabled.BudgetTokens,
-			},
-		}
-	}
-
-	if len(req.System) > 0 {
-		beta.System = make([]anthropic.BetaTextBlockParam, 0, len(req.System))
-		for _, s := range req.System {
-			if s.Text == "" {
-				continue
-			}
-			beta.System = append(beta.System, anthropic.BetaTextBlockParam{Text: s.Text})
-		}
-	}
-
-	if len(req.Messages) > 0 {
-		beta.Messages = make([]anthropic.BetaMessageParam, 0, len(req.Messages))
-		for _, msg := range req.Messages {
-			beta.Messages = append(beta.Messages, anthropic.BetaMessageParam{
-				Role:    anthropic.BetaMessageParamRole(msg.Role),
-				Content: convertAnthropicV1ContentToBeta(msg.Content),
-			})
-		}
-	}
-
-	return beta
-}
-
-func convertAnthropicV1ContentToBeta(blocks []anthropic.ContentBlockParamUnion) []anthropic.BetaContentBlockParamUnion {
-	if len(blocks) == 0 {
+	b, err := json.Marshal(req)
+	if err != nil {
+		logrus.WithError(err).Warn("ConvertAnthropicV1ToBetaRequest: marshal v1 request failed")
 		return nil
 	}
-	out := make([]anthropic.BetaContentBlockParamUnion, 0, len(blocks))
-	for _, b := range blocks {
-		switch {
-		case b.OfText != nil:
-			out = append(out, anthropic.NewBetaTextBlock(b.OfText.Text))
-		case b.OfImage != nil:
-			out = append(out, anthropic.BetaContentBlockParamUnion{
-				OfImage: &anthropic.BetaImageBlockParam{},
-			})
-		case b.OfToolUse != nil:
-			out = append(out, anthropic.NewBetaToolUseBlock(
-				b.OfToolUse.ID,
-				b.OfToolUse.Input,
-				b.OfToolUse.Name,
-			))
-		case b.OfToolResult != nil:
-			out = append(out, anthropic.NewBetaToolResultBlock(
-				b.OfToolResult.ToolUseID,
-				joinV1ToolResultText(b.OfToolResult.Content),
-				false,
-			))
-		}
-	}
-	return out
-}
 
-// joinV1ToolResultText concatenates the text blocks of a v1 tool_result's
-// content into a single string, mirroring convertToolResultContent in
-// anthropic_v1_to_openai.go.
-func joinV1ToolResultText(content []anthropic.ToolResultBlockParamContentUnion) string {
-	var texts []string
-	for _, c := range content {
-		if c.OfText != nil && c.OfText.Text != "" {
-			texts = append(texts, c.OfText.Text)
-		}
+	var beta anthropic.BetaMessageNewParams
+	if err := json.Unmarshal(b, &beta); err != nil {
+		logrus.WithError(err).Warn("ConvertAnthropicV1ToBetaRequest: unmarshal into beta shape failed")
+		return nil
 	}
-	return strings.Join(texts, "\n")
+	return &beta
 }

--- a/internal/protocol/request/anthropic_v1_to_beta_test.go
+++ b/internal/protocol/request/anthropic_v1_to_beta_test.go
@@ -1,0 +1,63 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertAnthropicV1ToBetaRequest_ToolResultContent guards against the
+// tool_result content being silently dropped (hardcoded to "") when the v1
+// request is projected onto the Beta shape for smart-routing context
+// extraction — the same class of defect as issue #1427, found in a sibling
+// converter while fixing that issue.
+func TestConvertAnthropicV1ToBetaRequest_ToolResultContent(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewToolResultBlock("call_1", "The secret word is ZANZIBAR", false)),
+		},
+	}
+
+	result := ConvertAnthropicV1ToBetaRequest(req)
+
+	require.Len(t, result.Messages, 1)
+	require.Len(t, result.Messages[0].Content, 1)
+	toolResult := result.Messages[0].Content[0].OfToolResult
+	require.NotNil(t, toolResult)
+	require.Len(t, toolResult.Content, 1)
+	assert.Equal(t, "The secret word is ZANZIBAR", toolResult.Content[0].OfText.Text)
+}
+
+func TestConvertAnthropicV1ToBetaRequest_ToolResultMultipleBlocksJoined(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					{
+						OfToolResult: &anthropic.ToolResultBlockParam{
+							ToolUseID: "call_1",
+							Content: []anthropic.ToolResultBlockParamContentUnion{
+								{OfText: &anthropic.TextBlockParam{Text: "line one"}},
+								{OfText: &anthropic.TextBlockParam{Text: "line two"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := ConvertAnthropicV1ToBetaRequest(req)
+
+	toolResult := result.Messages[0].Content[0].OfToolResult
+	require.NotNil(t, toolResult)
+	require.Len(t, toolResult.Content, 1)
+	assert.Equal(t, "line one\nline two", toolResult.Content[0].OfText.Text)
+}

--- a/internal/protocol/request/anthropic_v1_to_beta_test.go
+++ b/internal/protocol/request/anthropic_v1_to_beta_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestConvertAnthropicV1ToBetaRequest_ToolResultContent guards against the
-// tool_result content being silently dropped (hardcoded to "") when the v1
-// request is projected onto the Beta shape for smart-routing context
-// extraction — the same class of defect as issue #1427, found in a sibling
-// converter while fixing that issue.
+// TestConvertAnthropicV1ToBetaRequest_ToolResultContent guards against
+// tool_result content being silently dropped when the v1 request is
+// projected onto the Beta shape for smart-routing context extraction — the
+// same class of defect as issue #1427, found in this sibling converter while
+// fixing that issue (a prior hand-written field-by-field copy hardcoded the
+// content to ""). The current implementation is a JSON round-trip, which is
+// lossless by construction.
 func TestConvertAnthropicV1ToBetaRequest_ToolResultContent(t *testing.T) {
 	req := &anthropic.MessageNewParams{
 		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
@@ -32,7 +34,11 @@ func TestConvertAnthropicV1ToBetaRequest_ToolResultContent(t *testing.T) {
 	assert.Equal(t, "The secret word is ZANZIBAR", toolResult.Content[0].OfText.Text)
 }
 
-func TestConvertAnthropicV1ToBetaRequest_ToolResultMultipleBlocksJoined(t *testing.T) {
+// TestConvertAnthropicV1ToBetaRequest_ToolResultMultipleBlocksPreserved checks
+// that a tool_result with several content blocks survives the round-trip as
+// distinct blocks (the JSON round-trip preserves structure exactly, unlike a
+// hand-written converter that might flatten/join them).
+func TestConvertAnthropicV1ToBetaRequest_ToolResultMultipleBlocksPreserved(t *testing.T) {
 	req := &anthropic.MessageNewParams{
 		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
 		MaxTokens: 1024,
@@ -58,6 +64,69 @@ func TestConvertAnthropicV1ToBetaRequest_ToolResultMultipleBlocksJoined(t *testi
 
 	toolResult := result.Messages[0].Content[0].OfToolResult
 	require.NotNil(t, toolResult)
-	require.Len(t, toolResult.Content, 1)
-	assert.Equal(t, "line one\nline two", toolResult.Content[0].OfText.Text)
+	require.Len(t, toolResult.Content, 2)
+	assert.Equal(t, "line one", toolResult.Content[0].OfText.Text)
+	assert.Equal(t, "line two", toolResult.Content[1].OfText.Text)
+}
+
+// TestConvertAnthropicV1ToBetaRequest_ImagePreserved guards against image
+// content being dropped — the prior field-by-field converter created an
+// empty BetaImageBlockParam with no Source at all, discarding the image
+// entirely. The round-trip carries the real source through.
+func TestConvertAnthropicV1ToBetaRequest_ImagePreserved(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					{
+						OfImage: &anthropic.ImageBlockParam{
+							Source: anthropic.ImageBlockParamSourceUnion{
+								OfBase64: &anthropic.Base64ImageSourceParam{
+									Data:      "AAAA",
+									MediaType: "image/png",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := ConvertAnthropicV1ToBetaRequest(req)
+
+	image := result.Messages[0].Content[0].OfImage
+	require.NotNil(t, image)
+	require.NotNil(t, image.Source.OfBase64)
+	assert.Equal(t, "AAAA", image.Source.OfBase64.Data)
+	assert.Equal(t, anthropic.BetaBase64ImageSourceMediaType("image/png"), image.Source.OfBase64.MediaType)
+}
+
+// TestConvertAnthropicV1ToBetaRequest_ModelAndThinking checks the scalar
+// fields smart-routing context extraction reads survive the round-trip.
+func TestConvertAnthropicV1ToBetaRequest_ModelAndThinking(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-3-5-sonnet-20241022"),
+		MaxTokens: 1024,
+		Thinking: anthropic.ThinkingConfigParamUnion{
+			OfEnabled: &anthropic.ThinkingConfigEnabledParam{BudgetTokens: 2048},
+		},
+		System: []anthropic.TextBlockParam{{Text: "You are a helpful assistant."}},
+	}
+
+	result := ConvertAnthropicV1ToBetaRequest(req)
+
+	assert.Equal(t, anthropic.Model("claude-3-5-sonnet-20241022"), result.Model)
+	assert.Equal(t, int64(1024), result.MaxTokens)
+	require.NotNil(t, result.Thinking.OfEnabled)
+	assert.Equal(t, int64(2048), result.Thinking.OfEnabled.BudgetTokens)
+	require.Len(t, result.System, 1)
+	assert.Equal(t, "You are a helpful assistant.", result.System[0].Text)
+}
+
+func TestConvertAnthropicV1ToBetaRequest_Nil(t *testing.T) {
+	assert.Nil(t, ConvertAnthropicV1ToBetaRequest(nil))
 }

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -7,7 +7,40 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
 )
+
+// joinTextContentParts concatenates the text fields of text-only content parts
+// (used by tool and system messages) into a single newline-separated string.
+// This mirrors the pattern in AlignToolMessagesForOpenAI and lets converters
+// handle the array-of-text-blocks content form allowed by the OpenAI spec.
+func joinTextContentParts(parts []openai.ChatCompletionContentPartTextParam) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	texts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.Text != "" {
+			texts = append(texts, part.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+// joinAssistantTextContentParts concatenates the text fields of assistant array
+// content parts into a single newline-separated string, ignoring refusal parts.
+func joinAssistantTextContentParts(parts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	texts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.OfText != nil && part.OfText.Text != "" {
+			texts = append(texts, part.OfText.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}
 
 // ConvertChatToOpenAIResponses converts OpenAI Chat Completions params to Responses API format.
 // This enables using Chat Completions format with Responses API providers.
@@ -23,9 +56,12 @@ func ConvertChatToOpenAIResponses(params *openai.ChatCompletionNewParams, defaul
 	for _, msg := range params.Messages {
 		switch {
 		case !param.IsOmitted(msg.OfSystem):
-			// Extract system message content
-			if sysMsg := msg.OfSystem; !param.IsOmitted(sysMsg.Content.OfString) && sysMsg.Content.OfString.Value != "" {
+			// Extract system message content (string or array-of-text form)
+			sysMsg := msg.OfSystem
+			if !param.IsOmitted(sysMsg.Content.OfString) && sysMsg.Content.OfString.Value != "" {
 				systemParts = append(systemParts, sysMsg.Content.OfString.Value)
+			} else if text := joinTextContentParts(sysMsg.Content.OfArrayOfContentParts); text != "" {
+				systemParts = append(systemParts, text)
 			}
 
 		default:
@@ -70,6 +106,13 @@ func ConvertChatToOpenAIResponses(params *openai.ChatCompletionNewParams, defaul
 
 	// Convert tool choice if present
 	result.ToolChoice = ConvertChatToolChoiceToResponsesToolChoice(&params.ToolChoice)
+
+	// Forward reasoning effort if the client supplied one
+	if params.ReasoningEffort != "" {
+		result.Reasoning = shared.ReasoningParam{
+			Effort: params.ReasoningEffort,
+		}
+	}
 
 	return result
 }
@@ -168,7 +211,11 @@ func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessage
 // convertChatAssistantMessageToResponses converts a Chat assistant message to Responses format.
 // Returns nil if the message has no usable text content.
 func convertChatAssistantMessageToResponses(assistantMsg *openai.ChatCompletionAssistantMessageParam) []responses.ResponseInputItemUnionParam {
-	if param.IsOmitted(assistantMsg.Content.OfString) || assistantMsg.Content.OfString.Value == "" {
+	content := assistantMsg.Content.OfString.Value
+	if content == "" {
+		content = joinAssistantTextContentParts(assistantMsg.Content.OfArrayOfContentParts)
+	}
+	if content == "" {
 		return nil
 	}
 
@@ -177,7 +224,7 @@ func convertChatAssistantMessageToResponses(assistantMsg *openai.ChatCompletionA
 			Type: responses.EasyInputMessageTypeMessage,
 			Role: responses.EasyInputMessageRole("assistant"),
 			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(assistantMsg.Content.OfString.Value),
+				OfString: param.NewOpt(content),
 			},
 		},
 	}}
@@ -185,9 +232,9 @@ func convertChatAssistantMessageToResponses(assistantMsg *openai.ChatCompletionA
 
 // convertChatToolMessageToResponses converts a Chat tool message to Responses function_call_output format.
 func convertChatToolMessageToResponses(toolMsg *openai.ChatCompletionToolMessageParam) responses.ResponseInputItemUnionParam {
-	content := ""
-	if !param.IsOmitted(toolMsg.Content.OfString) && toolMsg.Content.OfString.Value != "" {
-		content = toolMsg.Content.OfString.Value
+	content := toolMsg.Content.OfString.Value
+	if content == "" {
+		content = joinTextContentParts(toolMsg.Content.OfArrayOfContentParts)
 	}
 
 	return responses.ResponseInputItemUnionParam{

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -11,9 +11,9 @@ import (
 )
 
 // joinTextContentParts concatenates the text fields of text-only content parts
-// (used by tool and system messages) into a single newline-separated string.
-// This mirrors the pattern in AlignToolMessagesForOpenAI and lets converters
-// handle the array-of-text-blocks content form allowed by the OpenAI spec.
+// (used by tool and system messages) into a single newline-separated string,
+// letting converters handle the array-of-text-blocks content form allowed by
+// the OpenAI spec.
 func joinTextContentParts(parts []openai.ChatCompletionContentPartTextParam) string {
 	if len(parts) == 0 {
 		return ""
@@ -30,16 +30,13 @@ func joinTextContentParts(parts []openai.ChatCompletionContentPartTextParam) str
 // joinAssistantTextContentParts concatenates the text fields of assistant array
 // content parts into a single newline-separated string, ignoring refusal parts.
 func joinAssistantTextContentParts(parts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion) string {
-	if len(parts) == 0 {
-		return ""
-	}
-	texts := make([]string, 0, len(parts))
+	textParts := make([]openai.ChatCompletionContentPartTextParam, 0, len(parts))
 	for _, part := range parts {
-		if part.OfText != nil && part.OfText.Text != "" {
-			texts = append(texts, part.OfText.Text)
+		if part.OfText != nil {
+			textParts = append(textParts, *part.OfText)
 		}
 	}
-	return strings.Join(texts, "\n")
+	return joinTextContentParts(textParts)
 }
 
 // ConvertChatToOpenAIResponses converts OpenAI Chat Completions params to Responses API format.

--- a/internal/protocol/request/openai_chat_to_openai_responses_test.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses_test.go
@@ -351,6 +351,125 @@ func createToolResultMessage() openai.ChatCompletionMessageParamUnion {
 	}
 }
 
+// TestConvertChatToOpenAIResponsesArrayContent covers the array-of-text-blocks
+// content form (allowed by the OpenAI spec, emitted by several agent frameworks).
+// Previously these converters only read the string variant and dropped the array,
+// forwarding an empty string upstream (issue #1427).
+func TestConvertChatToOpenAIResponsesArrayContent(t *testing.T) {
+	t.Run("tool result with array-of-text content", func(t *testing.T) {
+		toolMsg := openai.ChatCompletionMessageParamUnion{
+			OfTool: &openai.ChatCompletionToolMessageParam{
+				ToolCallID: "call_1",
+				Content: openai.ChatCompletionToolMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{
+						{Text: "The secret word is ZANZIBAR"},
+					},
+				},
+			},
+		}
+		params := &openai.ChatCompletionNewParams{
+			Model:    openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi"), createAssistantWithToolCallsMessage(), toolMsg},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		require.Len(t, result.Input.OfInputItemList, 3)
+		fnOutput := result.Input.OfInputItemList[2].OfFunctionCallOutput
+		require.NotNil(t, fnOutput)
+		assert.Equal(t, "The secret word is ZANZIBAR", fnOutput.Output.OfString.Value)
+	})
+
+	t.Run("tool result joins multiple text parts", func(t *testing.T) {
+		toolMsg := openai.ChatCompletionMessageParamUnion{
+			OfTool: &openai.ChatCompletionToolMessageParam{
+				ToolCallID: "call_1",
+				Content: openai.ChatCompletionToolMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{
+						{Text: "line one"},
+						{Text: "line two"},
+					},
+				},
+			},
+		}
+		params := &openai.ChatCompletionNewParams{
+			Model:    openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{createAssistantWithToolCallsMessage(), toolMsg},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		fnOutput := result.Input.OfInputItemList[len(result.Input.OfInputItemList)-1].OfFunctionCallOutput
+		require.NotNil(t, fnOutput)
+		assert.Equal(t, "line one\nline two", fnOutput.Output.OfString.Value)
+	})
+
+	t.Run("system message with array-of-text content", func(t *testing.T) {
+		sysMsg := openai.ChatCompletionMessageParamUnion{
+			OfSystem: &openai.ChatCompletionSystemMessageParam{
+				Content: openai.ChatCompletionSystemMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{
+						{Text: "You are a helpful assistant."},
+					},
+				},
+			},
+		}
+		params := &openai.ChatCompletionNewParams{
+			Model:    openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{sysMsg, openai.UserMessage("hi")},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		assert.Equal(t, "You are a helpful assistant.", result.Instructions.Value)
+	})
+
+	t.Run("assistant message with array-of-text content", func(t *testing.T) {
+		asstMsg := openai.ChatCompletionMessageParamUnion{
+			OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+						{OfText: &openai.ChatCompletionContentPartTextParam{Text: "The capital of France is Paris."}},
+					},
+				},
+			},
+		}
+		params := &openai.ChatCompletionNewParams{
+			Model:    openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{asstMsg},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		require.Len(t, result.Input.OfInputItemList, 1)
+		assert.Equal(t, "assistant", string(result.Input.OfInputItemList[0].OfMessage.Role))
+		assert.Equal(t, "The capital of France is Paris.", result.Input.OfInputItemList[0].OfMessage.Content.OfString.Value)
+	})
+
+	t.Run("reasoning_effort forwarded", func(t *testing.T) {
+		params := &openai.ChatCompletionNewParams{
+			Model:           openai.ChatModel("gpt-4"),
+			Messages:        []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+			ReasoningEffort: shared.ReasoningEffortHigh,
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		assert.Equal(t, shared.ReasoningEffortHigh, result.Reasoning.Effort)
+	})
+
+	t.Run("no reasoning_effort leaves reasoning unset", func(t *testing.T) {
+		params := &openai.ChatCompletionNewParams{
+			Model:    openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		assert.Equal(t, shared.ReasoningEffort(""), result.Reasoning.Effort)
+	})
+}
+
 // createGetWeatherFunction creates a weather tool definition
 func createGetWeatherFunction() shared.FunctionDefinitionParam {
 	return shared.FunctionDefinitionParam{

--- a/internal/protocol/request/openai_to_anthropic.go
+++ b/internal/protocol/request/openai_to_anthropic.go
@@ -16,9 +16,11 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 		// Read the typed union fields directly — no JSON round-trip needed.
 		switch {
 		case msg.OfSystem != nil:
-			// System message → params.System
+			// System message → params.System (string or array-of-text form)
 			if content := msg.OfSystem.Content.OfString.Value; content != "" {
 				systemParts = append(systemParts, content)
+			} else if text := joinTextContentParts(msg.OfSystem.Content.OfArrayOfContentParts); text != "" {
+				systemParts = append(systemParts, text)
 			}
 
 		case msg.OfUser != nil:
@@ -52,9 +54,11 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			// Assistant message
 			var blocks []anthropic.BetaContentBlockParamUnion
 
-			// Add text content if present
+			// Add text content if present (string or array-of-text form)
 			if content := msg.OfAssistant.Content.OfString.Value; content != "" {
 				blocks = append(blocks, anthropic.NewBetaTextBlock(content))
+			} else if text := joinAssistantTextContentParts(msg.OfAssistant.Content.OfArrayOfContentParts); text != "" {
+				blocks = append(blocks, anthropic.NewBetaTextBlock(text))
 			}
 
 			// Convert tool calls to tool_use blocks
@@ -80,9 +84,14 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			}
 
 		case msg.OfTool != nil:
-			// Tool result message → tool_result block (must be USER role)
+			// Tool result message → tool_result block (must be USER role).
+			// Content may be a plain string or an array of text blocks.
+			content := msg.OfTool.Content.OfString.Value
+			if content == "" {
+				content = joinTextContentParts(msg.OfTool.Content.OfArrayOfContentParts)
+			}
 			blocks := []anthropic.BetaContentBlockParamUnion{
-				anthropic.NewBetaToolResultBlock(msg.OfTool.ToolCallID, msg.OfTool.Content.OfString.Value, false),
+				anthropic.NewBetaToolResultBlock(msg.OfTool.ToolCallID, content, false),
 			}
 			messages = append(messages, anthropic.NewBetaUserMessage(blocks...))
 		}

--- a/internal/protocol/request/request_conversion_test.go
+++ b/internal/protocol/request/request_conversion_test.go
@@ -196,6 +196,81 @@ func TestConvertOpenAIToAnthropicRequest(t *testing.T) {
 	}
 }
 
+// TestConvertOpenAIToAnthropicRequestArrayContent verifies that array-of-text
+// content forms (system, assistant, and tool messages) are forwarded rather than
+// dropped as empty strings (issue #1427).
+func TestConvertOpenAIToAnthropicRequestArrayContent(t *testing.T) {
+	t.Run("tool result with array-of-text content", func(t *testing.T) {
+		req := &openai.ChatCompletionNewParams{
+			Model: openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage("hi"),
+				{OfTool: &openai.ChatCompletionToolMessageParam{
+					ToolCallID: "call_1",
+					Content: openai.ChatCompletionToolMessageParamContentUnion{
+						OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{
+							{Text: "The secret word is ZANZIBAR"},
+						},
+					},
+				}},
+			},
+			MaxTokens: openai.Opt(int64(100)),
+		}
+
+		result := ConvertOpenAIToAnthropicRequest(req, 8192)
+
+		require.Len(t, result.Messages, 2)
+		toolResult := result.Messages[1].Content[0].OfToolResult
+		require.NotNil(t, toolResult)
+		require.Len(t, toolResult.Content, 1)
+		assert.Equal(t, "The secret word is ZANZIBAR", toolResult.Content[0].OfText.Text)
+	})
+
+	t.Run("system message with array-of-text content", func(t *testing.T) {
+		req := &openai.ChatCompletionNewParams{
+			Model: openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{OfSystem: &openai.ChatCompletionSystemMessageParam{
+					Content: openai.ChatCompletionSystemMessageParamContentUnion{
+						OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{
+							{Text: "You are a helpful assistant."},
+						},
+					},
+				}},
+				openai.UserMessage("hi"),
+			},
+			MaxTokens: openai.Opt(int64(100)),
+		}
+
+		result := ConvertOpenAIToAnthropicRequest(req, 8192)
+
+		require.Len(t, result.System, 1)
+		assert.Equal(t, "You are a helpful assistant.", result.System[0].Text)
+	})
+
+	t.Run("assistant message with array-of-text content", func(t *testing.T) {
+		req := &openai.ChatCompletionNewParams{
+			Model: openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+					Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+						OfArrayOfContentParts: []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+							{OfText: &openai.ChatCompletionContentPartTextParam{Text: "The capital of France is Paris."}},
+						},
+					},
+				}},
+			},
+			MaxTokens: openai.Opt(int64(100)),
+		}
+
+		result := ConvertOpenAIToAnthropicRequest(req, 8192)
+
+		require.Len(t, result.Messages, 1)
+		require.Len(t, result.Messages[0].Content, 1)
+		assert.Equal(t, "The capital of France is Paris.", result.Messages[0].Content[0].OfText.Text)
+	})
+}
+
 func TestConvertOpenAIToAnthropicTools(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/protocoltest/content_shapes.go
+++ b/internal/protocoltest/content_shapes.go
@@ -2,6 +2,7 @@ package protocoltest
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -66,6 +67,21 @@ func sendContentShape(t flagTB, env *TestEnv, source, target protocol.APIType, b
 	return res
 }
 
+// assertUpstreamText sends body through the gateway, extracts a field from
+// the captured upstream request via extract, and asserts it equals want.
+// CapturedRequest.JSON() is nil-safe (vmodel/benchmark/capture.go), so no
+// separate "was anything captured" check is needed — an absent request
+// simply makes every extractor return ok=false, which fails the assertion
+// with an informative message on its own.
+func assertUpstreamText(t flagTB, env *TestEnv, source, target protocol.APIType, endpoint EndpointKind, body map[string]any, extract func(map[string]any) (string, bool), want string) {
+	t.Helper()
+	sendContentShape(t, env, source, target, body)
+	out, ok := extract(env.virtual.LastRequest(endpoint).JSON())
+	if !ok || out != want {
+		t.Errorf("upstream %s text = %q (ok=%v), want %q", endpoint, out, ok, want)
+	}
+}
+
 // ─── OpenAI Responses body helpers ────────────────────────────────────────
 
 // responsesFunctionCallOutput returns the "output" string of the first
@@ -94,6 +110,14 @@ func responsesMessageContent(body map[string]any, role string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// responsesReasoningEffort returns the "reasoning.effort" string in a
+// captured OpenAI Responses request body.
+func responsesReasoningEffort(body map[string]any) (string, bool) {
+	reasoning, _ := body["reasoning"].(map[string]any)
+	effort, ok := reasoning["effort"].(string)
+	return effort, ok
 }
 
 // ─── Anthropic Beta body helpers ──────────────────────────────────────────
@@ -164,6 +188,8 @@ func anthropicSystemText(body map[string]any) (string, bool) {
 
 func contentShapeCases() []contentShapeCase {
 	const secretWord = "The secret word is ZANZIBAR"
+	const parisAnswer = "The capital of France is Paris."
+	const systemPrompt = "You are a helpful assistant."
 
 	toolCallTurns := []map[string]any{
 		{"role": "user", "content": "What's the secret word?"},
@@ -171,65 +197,60 @@ func contentShapeCases() []contentShapeCase {
 			{"id": "call_1", "type": "function", "function": map[string]any{"name": "get_secret", "arguments": "{}"}},
 		}},
 	}
+	// slices.Concat copies rather than mutating toolCallTurns' backing array,
+	// which matters because both cases below share it under t.Parallel().
+	toolResultBody := func() map[string]any {
+		return map[string]any{
+			"messages": slices.Concat(toolCallTurns, []map[string]any{
+				{"role": "tool", "tool_call_id": "call_1",
+					"content": []map[string]any{{"type": "text", "text": secretWord}}},
+			}),
+		}
+	}
+	// assistantArrayBody/systemArrayBody are funcs, not shared maps: each of
+	// the two cases below runs under t.Parallel() and sendContentShape
+	// mutates its body (stamps "model" on it), so a shared map instance would
+	// race between the Chat→Responses and Chat→Anthropic cases that both use
+	// this fixture.
+	assistantArrayBody := func() map[string]any {
+		return map[string]any{
+			"messages": []map[string]any{
+				{"role": "user", "content": "What is the capital of France?"},
+				{"role": "assistant", "content": []map[string]any{{"type": "text", "text": parisAnswer}}},
+			},
+		}
+	}
+	systemArrayBody := func() map[string]any {
+		return map[string]any{
+			"messages": []map[string]any{
+				{"role": "system", "content": []map[string]any{{"type": "text", "text": systemPrompt}}},
+				{"role": "user", "content": "Hello"},
+			},
+		}
+	}
+
+	assistantContent := func(body map[string]any) (string, bool) { return responsesMessageContent(body, "assistant") }
+	instructions := func(body map[string]any) (string, bool) {
+		v, ok := body["instructions"].(string)
+		return v, ok
+	}
+	anthropicAssistantText := func(body map[string]any) (string, bool) { return anthropicMessageText(body, "assistant") }
 
 	return []contentShapeCase{
 		// ── Chat → Responses ────────────────────────────────────────────
 		{name: "chat_to_responses/tool_array_content", run: func(t flagTB, env *TestEnv) {
-			body := map[string]any{
-				"messages": append(append([]map[string]any{}, toolCallTurns...), map[string]any{
-					"role": "tool", "tool_call_id": "call_1",
-					"content": []map[string]any{{"type": "text", "text": secretWord}},
-				}),
-			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
-			up := env.virtual.LastRequest(EndpointResponses)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			out, ok := responsesFunctionCallOutput(up.JSON())
-			if !ok || out != secretWord {
-				t.Errorf("function_call_output.output = %q (ok=%v), want %q", out, ok, secretWord)
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, EndpointResponses,
+				toolResultBody(), responsesFunctionCallOutput, secretWord)
 		}},
 
 		{name: "chat_to_responses/assistant_array_content", run: func(t flagTB, env *TestEnv) {
-			body := map[string]any{
-				"messages": []map[string]any{
-					{"role": "user", "content": "What is the capital of France?"},
-					{"role": "assistant", "content": []map[string]any{
-						{"type": "text", "text": "The capital of France is Paris."},
-					}},
-				},
-			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
-			up := env.virtual.LastRequest(EndpointResponses)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			out, ok := responsesMessageContent(up.JSON(), "assistant")
-			if !ok || out != "The capital of France is Paris." {
-				t.Errorf("assistant message content = %q (ok=%v), want %q", out, ok, "The capital of France is Paris.")
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, EndpointResponses,
+				assistantArrayBody(), assistantContent, parisAnswer)
 		}},
 
 		{name: "chat_to_responses/system_array_content", run: func(t flagTB, env *TestEnv) {
-			body := map[string]any{
-				"messages": []map[string]any{
-					{"role": "system", "content": []map[string]any{
-						{"type": "text", "text": "You are a helpful assistant."},
-					}},
-					{"role": "user", "content": "Hello"},
-				},
-			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
-			up := env.virtual.LastRequest(EndpointResponses)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			instructions, _ := up.JSON()["instructions"].(string)
-			if instructions != "You are a helpful assistant." {
-				t.Errorf("instructions = %q, want %q", instructions, "You are a helpful assistant.")
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, EndpointResponses,
+				systemArrayBody(), instructions, systemPrompt)
 		}},
 
 		{name: "chat_to_responses/reasoning_effort_forwarded", run: func(t flagTB, env *TestEnv) {
@@ -237,74 +258,24 @@ func contentShapeCases() []contentShapeCase {
 				"messages":         []map[string]any{{"role": "user", "content": "Hello"}},
 				"reasoning_effort": "high",
 			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
-			up := env.virtual.LastRequest(EndpointResponses)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			reasoning, _ := up.JSON()["reasoning"].(map[string]any)
-			if effort, _ := reasoning["effort"].(string); effort != "high" {
-				t.Errorf("reasoning.effort = %v, want %q; reasoning=%v", reasoning["effort"], "high", reasoning)
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, EndpointResponses,
+				body, responsesReasoningEffort, "high")
 		}},
 
 		// ── Chat → Anthropic Beta ───────────────────────────────────────
 		{name: "chat_to_anthropic/tool_array_content", run: func(t flagTB, env *TestEnv) {
-			body := map[string]any{
-				"messages": append(append([]map[string]any{}, toolCallTurns...), map[string]any{
-					"role": "tool", "tool_call_id": "call_1",
-					"content": []map[string]any{{"type": "text", "text": secretWord}},
-				}),
-			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, body)
-			up := env.virtual.LastRequest(EndpointAnthropic)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			out, ok := anthropicToolResultText(up.JSON())
-			if !ok || out != secretWord {
-				t.Errorf("tool_result content text = %q (ok=%v), want %q", out, ok, secretWord)
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, EndpointAnthropic,
+				toolResultBody(), anthropicToolResultText, secretWord)
 		}},
 
 		{name: "chat_to_anthropic/assistant_array_content", run: func(t flagTB, env *TestEnv) {
-			body := map[string]any{
-				"messages": []map[string]any{
-					{"role": "user", "content": "What is the capital of France?"},
-					{"role": "assistant", "content": []map[string]any{
-						{"type": "text", "text": "The capital of France is Paris."},
-					}},
-				},
-			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, body)
-			up := env.virtual.LastRequest(EndpointAnthropic)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			out, ok := anthropicMessageText(up.JSON(), "assistant")
-			if !ok || out != "The capital of France is Paris." {
-				t.Errorf("assistant message text = %q (ok=%v), want %q", out, ok, "The capital of France is Paris.")
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, EndpointAnthropic,
+				assistantArrayBody(), anthropicAssistantText, parisAnswer)
 		}},
 
 		{name: "chat_to_anthropic/system_array_content", run: func(t flagTB, env *TestEnv) {
-			body := map[string]any{
-				"messages": []map[string]any{
-					{"role": "system", "content": []map[string]any{
-						{"type": "text", "text": "You are a helpful assistant."},
-					}},
-					{"role": "user", "content": "Hello"},
-				},
-			}
-			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, body)
-			up := env.virtual.LastRequest(EndpointAnthropic)
-			if up == nil {
-				t.Fatal("no upstream request captured")
-			}
-			out, ok := anthropicSystemText(up.JSON())
-			if !ok || out != "You are a helpful assistant." {
-				t.Errorf("system text = %q (ok=%v), want %q", out, ok, "You are a helpful assistant.")
-			}
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, EndpointAnthropic,
+				systemArrayBody(), anthropicSystemText, systemPrompt)
 		}},
 	}
 }

--- a/internal/protocoltest/content_shapes.go
+++ b/internal/protocoltest/content_shapes.go
@@ -1,0 +1,355 @@
+package protocoltest
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// This file is the request-content-shape regression suite, shared by both the
+// go-test entry point (TestContentShapes) and the CLI
+// (`harness matrix --mode=content_shapes`). It is deliberately separate from
+// the protocol matrix: every matrix request carries the same fixed single-turn
+// prompt (see client.go's harnessPrompt) and the Scenario only controls the
+// mocked upstream *response* shape — so the matrix, by design, cannot catch
+// bugs in how the gateway forwards unusual *request* content shapes upstream.
+//
+// This suite closes that gap for the array-of-text-blocks content form
+// (`content: [{"type":"text","text":"..."}]` — valid per the OpenAI spec and
+// emitted by several agent frameworks instead of a plain string) on tool,
+// assistant, and system messages: the shape that shipped upstream as an empty
+// string in issue #1427. Each case drives one bespoke multi-turn request
+// through the real gateway and asserts on the request actually forwarded
+// upstream (VirtualServer.LastRequest) — not the parsed response — the same
+// technique the rule-flag suite (flags.go) uses. See
+// .design/harness-matrix.md section 9.
+
+// contentShapeScenario is the shared fixture every case routes through. Its
+// mock response is irrelevant to what these cases assert (the forwarded
+// *request*, not the response), so any text-capable scenario works; a
+// dedicated name just keeps its routes from colliding with other suites'.
+func contentShapeScenario() Scenario {
+	s := TextScenario()
+	s.Name = "content_shapes"
+	s.Description = "Shared fixture for request content-shape regression tests"
+	s.Assertions = nil
+	return s
+}
+
+// contentShapeCase is one request-content-shape regression case. It reuses
+// flagTB/flagRecorder/flagAbort from flags.go so cases run under both
+// *testing.T and the CLI without duplicating that plumbing.
+type contentShapeCase struct {
+	name string
+	run  func(t flagTB, env *TestEnv)
+}
+
+// sendContentShape wires a route for (source, target), stamps the resolved
+// request model onto body, and sends it through the gateway. body must not
+// already set "model". Fails the case on transport errors.
+func sendContentShape(t flagTB, env *TestEnv, source, target protocol.APIType, body map[string]any) *RoundTripResult {
+	t.Helper()
+	s := contentShapeScenario()
+	env.SetupRoute(source, target, s)
+	model := env.findRouteModel(source, target, s.Name)
+	if model == "" {
+		t.Fatalf("no route configured for source=%s target=%s", source, target)
+	}
+	body["model"] = model
+
+	path, _ := buildRequest(source, model, false) // only the path is reused; body is bespoke
+	res, err := env.dispatch(source, target, s.Name, path, mustMarshal(body), nil, false)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	return res
+}
+
+// ─── OpenAI Responses body helpers ────────────────────────────────────────
+
+// responsesFunctionCallOutput returns the "output" string of the first
+// function_call_output item in a captured OpenAI Responses request body.
+func responsesFunctionCallOutput(body map[string]any) (string, bool) {
+	input, _ := body["input"].([]any)
+	for _, raw := range input {
+		item, _ := raw.(map[string]any)
+		if item["type"] == "function_call_output" {
+			out, ok := item["output"].(string)
+			return out, ok
+		}
+	}
+	return "", false
+}
+
+// responsesMessageContent returns the "content" string of the first input
+// item with the given role in a captured OpenAI Responses request body.
+func responsesMessageContent(body map[string]any, role string) (string, bool) {
+	input, _ := body["input"].([]any)
+	for _, raw := range input {
+		item, _ := raw.(map[string]any)
+		if item["type"] == "message" && item["role"] == role {
+			content, ok := item["content"].(string)
+			return content, ok
+		}
+	}
+	return "", false
+}
+
+// ─── Anthropic Beta body helpers ──────────────────────────────────────────
+
+// anthropicToolResultText returns the text of the first tool_result block
+// found across a captured Anthropic Beta request body's messages.
+func anthropicToolResultText(body map[string]any) (string, bool) {
+	msgs, _ := body["messages"].([]any)
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		blocks, _ := msg["content"].([]any)
+		for _, rawBlock := range blocks {
+			block, _ := rawBlock.(map[string]any)
+			if block["type"] != "tool_result" {
+				continue
+			}
+			parts, _ := block["content"].([]any)
+			if len(parts) == 0 {
+				return "", false
+			}
+			first, _ := parts[0].(map[string]any)
+			text, ok := first["text"].(string)
+			return text, ok
+		}
+	}
+	return "", false
+}
+
+// anthropicMessageText returns the text of the first content block of the
+// first message with the given role in a captured Anthropic Beta request body.
+func anthropicMessageText(body map[string]any, role string) (string, bool) {
+	msgs, _ := body["messages"].([]any)
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		if msg["role"] != role {
+			continue
+		}
+		blocks, _ := msg["content"].([]any)
+		if len(blocks) == 0 {
+			return "", false
+		}
+		first, _ := blocks[0].(map[string]any)
+		text, ok := first["text"].(string)
+		return text, ok
+	}
+	return "", false
+}
+
+// anthropicSystemText returns the joined text of the "system" field in a
+// captured Anthropic Beta request body, whether it arrived as a plain string
+// or as an array of text blocks.
+func anthropicSystemText(body map[string]any) (string, bool) {
+	switch v := body["system"].(type) {
+	case string:
+		return v, v != ""
+	case []any:
+		if len(v) == 0 {
+			return "", false
+		}
+		first, _ := v[0].(map[string]any)
+		text, ok := first["text"].(string)
+		return text, ok
+	}
+	return "", false
+}
+
+// ─── Cases ─────────────────────────────────────────────────────────────────
+
+func contentShapeCases() []contentShapeCase {
+	const secretWord = "The secret word is ZANZIBAR"
+
+	toolCallTurns := []map[string]any{
+		{"role": "user", "content": "What's the secret word?"},
+		{"role": "assistant", "tool_calls": []map[string]any{
+			{"id": "call_1", "type": "function", "function": map[string]any{"name": "get_secret", "arguments": "{}"}},
+		}},
+	}
+
+	return []contentShapeCase{
+		// ── Chat → Responses ────────────────────────────────────────────
+		{name: "chat_to_responses/tool_array_content", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages": append(append([]map[string]any{}, toolCallTurns...), map[string]any{
+					"role": "tool", "tool_call_id": "call_1",
+					"content": []map[string]any{{"type": "text", "text": secretWord}},
+				}),
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
+			up := env.virtual.LastRequest(EndpointResponses)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			out, ok := responsesFunctionCallOutput(up.JSON())
+			if !ok || out != secretWord {
+				t.Errorf("function_call_output.output = %q (ok=%v), want %q", out, ok, secretWord)
+			}
+		}},
+
+		{name: "chat_to_responses/assistant_array_content", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages": []map[string]any{
+					{"role": "user", "content": "What is the capital of France?"},
+					{"role": "assistant", "content": []map[string]any{
+						{"type": "text", "text": "The capital of France is Paris."},
+					}},
+				},
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
+			up := env.virtual.LastRequest(EndpointResponses)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			out, ok := responsesMessageContent(up.JSON(), "assistant")
+			if !ok || out != "The capital of France is Paris." {
+				t.Errorf("assistant message content = %q (ok=%v), want %q", out, ok, "The capital of France is Paris.")
+			}
+		}},
+
+		{name: "chat_to_responses/system_array_content", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages": []map[string]any{
+					{"role": "system", "content": []map[string]any{
+						{"type": "text", "text": "You are a helpful assistant."},
+					}},
+					{"role": "user", "content": "Hello"},
+				},
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
+			up := env.virtual.LastRequest(EndpointResponses)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			instructions, _ := up.JSON()["instructions"].(string)
+			if instructions != "You are a helpful assistant." {
+				t.Errorf("instructions = %q, want %q", instructions, "You are a helpful assistant.")
+			}
+		}},
+
+		{name: "chat_to_responses/reasoning_effort_forwarded", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages":         []map[string]any{{"role": "user", "content": "Hello"}},
+				"reasoning_effort": "high",
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, body)
+			up := env.virtual.LastRequest(EndpointResponses)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			reasoning, _ := up.JSON()["reasoning"].(map[string]any)
+			if effort, _ := reasoning["effort"].(string); effort != "high" {
+				t.Errorf("reasoning.effort = %v, want %q; reasoning=%v", reasoning["effort"], "high", reasoning)
+			}
+		}},
+
+		// ── Chat → Anthropic Beta ───────────────────────────────────────
+		{name: "chat_to_anthropic/tool_array_content", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages": append(append([]map[string]any{}, toolCallTurns...), map[string]any{
+					"role": "tool", "tool_call_id": "call_1",
+					"content": []map[string]any{{"type": "text", "text": secretWord}},
+				}),
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, body)
+			up := env.virtual.LastRequest(EndpointAnthropic)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			out, ok := anthropicToolResultText(up.JSON())
+			if !ok || out != secretWord {
+				t.Errorf("tool_result content text = %q (ok=%v), want %q", out, ok, secretWord)
+			}
+		}},
+
+		{name: "chat_to_anthropic/assistant_array_content", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages": []map[string]any{
+					{"role": "user", "content": "What is the capital of France?"},
+					{"role": "assistant", "content": []map[string]any{
+						{"type": "text", "text": "The capital of France is Paris."},
+					}},
+				},
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, body)
+			up := env.virtual.LastRequest(EndpointAnthropic)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			out, ok := anthropicMessageText(up.JSON(), "assistant")
+			if !ok || out != "The capital of France is Paris." {
+				t.Errorf("assistant message text = %q (ok=%v), want %q", out, ok, "The capital of France is Paris.")
+			}
+		}},
+
+		{name: "chat_to_anthropic/system_array_content", run: func(t flagTB, env *TestEnv) {
+			body := map[string]any{
+				"messages": []map[string]any{
+					{"role": "system", "content": []map[string]any{
+						{"type": "text", "text": "You are a helpful assistant."},
+					}},
+					{"role": "user", "content": "Hello"},
+				},
+			}
+			sendContentShape(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, body)
+			up := env.virtual.LastRequest(EndpointAnthropic)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			out, ok := anthropicSystemText(up.JSON())
+			if !ok || out != "You are a helpful assistant." {
+				t.Errorf("system text = %q (ok=%v), want %q", out, ok, "You are a helpful assistant.")
+			}
+		}},
+	}
+}
+
+// ─── CLI execution (harness matrix --mode=content_shapes) ────────────────
+
+// ExecuteAllContentShapes runs the request-content-shape regression suite
+// without requiring testing.T. It is the CLI-compatible counterpart of
+// TestContentShapes, returning []TestResult. Name format:
+// "content_shapes/<case name>".
+func (m *Matrix) ExecuteAllContentShapes() []TestResult {
+	results := make([]TestResult, 0, len(contentShapeCases()))
+	for _, c := range contentShapeCases() {
+		results = append(results, runContentShapeCaseCLI(c))
+	}
+	return results
+}
+
+func runContentShapeCaseCLI(c contentShapeCase) TestResult {
+	res := TestResult{Name: "content_shapes/" + c.name, Scenario: c.name}
+	start := time.Now()
+
+	env, err := NewTestEnvForCLI()
+	if err != nil {
+		res.Errors = []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("create test env: %v", err)}}
+		res.Duration = time.Since(start)
+		return res
+	}
+	defer env.Close()
+
+	// Reuses flagRecorder/flagAbort from flags.go: same flagTB contract, same
+	// "run under a testing.T-free recorder" trick, no need to duplicate it.
+	rec := &flagRecorder{}
+	func() {
+		defer func() {
+			rec.runCleanups()
+			if r := recover(); r != nil && r != flagAbort {
+				panic(r)
+			}
+		}()
+		c.run(rec, env)
+	}()
+
+	res.Errors = rec.errs
+	res.Passed = len(rec.errs) == 0
+	res.Duration = time.Since(start)
+	return res
+}

--- a/internal/protocoltest/content_shapes_test.go
+++ b/internal/protocoltest/content_shapes_test.go
@@ -1,0 +1,22 @@
+package protocoltest
+
+import "testing"
+
+// The request-content-shape regression suite itself lives in content_shapes.go
+// (shared with the CLI `harness matrix --mode=content_shapes`). This file is
+// just the go-test entry point.
+
+// TestContentShapes drives every request content-shape regression case
+// through the real gateway and asserts on the request actually forwarded
+// upstream. *testing.T satisfies the flagTB the cases use.
+func TestContentShapes(t *testing.T) {
+	for _, c := range contentShapeCases() {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			env := NewTestEnv(t)
+			defer env.Close()
+			c.run(t, env)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1427: several OpenAI Chat Completions protocol converters read only the `OfString` variant of a content union and silently dropped the array-of-text-blocks form (`[{"type":"text","text":"..."}]` — valid per the OpenAI spec, emitted by several agent frameworks) on tool/system/assistant messages, forwarding empty strings upstream. The model then saw empty tool results, presenting as degraded agent performance.

## Changes (4 commits)

**1. Forward array-of-text content and `reasoning_effort`** (`2d2c227`)
- `openai_chat_to_openai_responses.go` (Chat → Responses): tool, assistant, and system messages now fall back to joining `OfArrayOfContentParts` when `OfString` is empty, via new `joinTextContentParts`/`joinAssistantTextContentParts` helpers.
- `openai_to_anthropic.go` (Chat → Anthropic Beta): same fallback for tool, assistant, and system messages.
- Forwards a client-supplied `reasoning_effort` into the Responses API's `reasoning.effort` field (previously dropped entirely).

**2. New end-to-end regression suite; fix a sibling defect found along the way** (`6167a0f`)
- The existing protocol matrix (`internal/protocoltest`) only varies the mocked upstream *response* shape per scenario — every request it sends is the same fixed single-turn prompt, so it structurally cannot catch this bug class. Reworking it to vary per scenario would mean threading bespoke bodies through every client driver, including subprocess drivers wrapping real vendor SDKs that may not expose this shape at all — disproportionate to the fix.
- Added `internal/protocoltest/content_shapes.go` instead: a separate suite (mirrors `flags.go`'s pattern) that drives real multi-turn requests through the gateway and asserts on the request actually forwarded upstream (`VirtualServer.LastRequest`), not the response. Verified the cases fail against the pre-fix converters and pass against the fix. Wired into `harness matrix --mode=content_shapes` and its own CI leg.
- While auditing sibling converters for the same defect class, found `ConvertAnthropicV1ToBetaRequest` (smart-routing context extraction) unconditionally hardcoded tool_result content to `""`. Fixed with a join, plus tests.

**3. Replace the v1→beta converter with a JSON round-trip** (`26d580f`)
- The hand-written field-by-field copy from the previous commit only covered known-read fields, which is exactly how it dropped tool_result content — and, as it turned out, image data too (empty image blocks with no source).
- Beta's wire format is a strict structural superset of v1's, so a v1 request's own JSON round-trips losslessly into the Beta struct. Replaced ~90 lines of hand-maintained per-block-type conversion with a marshal/unmarshal round-trip — less code, no more "forgot to copy this field" bugs, and no maintenance burden as the SDK adds new block types.

**4. Code-review cleanup** (`bd433ff`)
- Self-review pass (4 parallel angles: reuse, simplification, efficiency, altitude). Collapsed `content_shapes.go`'s repeated test-case boilerplate into a shared `assertUpstreamText` helper; caught and fixed a real data race the refactor would have introduced (shared body fixtures mutated by parallel subtests); deduplicated `joinAssistantTextContentParts`; trimmed a docs paragraph prone to drift.

## Verification

- `go build ./...`, `go vet`, `go test ./...` all clean.
- New unit tests for every touched converter; `content_shapes.go`'s 7 cases confirmed red against the pre-fix code, green against the fix.
- CLI: `go run ./cli/harness matrix --mode=content_shapes` passes all 7 cases; `--mode=all` still wires cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)