### PR TITLE
refactor+perf(harness): dedupe CLI matrix sections, parallelize, cut env-boot cost

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -83,6 +83,23 @@ Assertions + SemanticEquivalence checks
 | `semanticEquivalenceErrors(label, r1, r2)` | Compares two results field-by-field, returns `[]AssertionError` |
 | `assertSemanticEquivalence(t, label, r1, r2)` | Delegates to above, calls `t.Errorf` per error |
 
+### Section drivers (`section.go`)
+
+Every section contributes only its combos and per-combo execution; the shared
+lifecycle lives once in `internal/protocoltest/section.go`:
+
+| Driver | Used by | Purpose |
+|--------|---------|---------|
+| `Matrix.executePerScenario(skip, combosFor)` | `ExecuteAll` / `ExecuteAllTransitive` / `ExecuteAllIdempotent` | CLI-side: one env per scenario, setup-failure fan-out (env boot failure is reported per-combination), sequential combo execution, env close |
+| `Matrix.runPerScenario(t, skip, run)` | `RunTransitive` / `RunIdempotent` | testing.T-side: one env per scenario subtest, scenarios in parallel, combos sequential |
+| `runRecorderCase(name, scenario, run)` | `ExecuteAllFlags` / `ExecuteAllContentShapes` | Runs one `flagTB`-style case body under the recording shim, returns a `TestResult` |
+
+A `scenarioCombo` is `{meta TestResult, run func(*TestEnv) TestResult}` — the
+`meta` doubles as the setup-failure result when the scenario's env cannot be
+created. (Single-hop `Matrix.Run(t)` keeps its own deeper subtest nesting —
+`scenario/source/target/mode` with one env per leaf — because its test-name
+contract and per-leaf parallelism differ from the per-scenario sections.)
+
 ---
 
 ## 3. How to run
@@ -124,6 +141,13 @@ and the rule-flag suite, which would otherwise be go-test-only.
 | `idempotent` | — | — | ✅ | — | — |
 | `flags` | — | — | — | ✅ | — |
 | `content_shapes` | — | — | — | — | ✅ |
+
+This mode → section mapping is declared in one place: the `matrixSections`
+registry in `cli/harness/matrix.go`. Each entry names the section, lists the
+`--mode` values that include it, marks whether it is http-only (`flags` /
+`content_shapes` drive raw requests directly), and points at its
+`ExecuteAll*` executor. Adding a section = one registry entry + extending the
+`--mode` enum.
 
 ```bash
 # Default: single-hop + idempotent round-trips. Two-hop and flags are OFF by

--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -100,6 +100,29 @@ created. (Single-hop `Matrix.Run(t)` keeps its own deeper subtest nesting —
 `scenario/source/target/mode` with one env per leaf — because its test-name
 contract and per-leaf parallelism differ from the per-scenario sections.)
 
+### CLI parallelism & env-boot cost
+
+The CLI drivers run their independent units — scenarios in
+`executePerScenario`, cases in `runRecorderCases` — concurrently up to
+`GOMAXPROCS`, mirroring the `t.Parallel()` the go-test entry points always
+had. Combos *within* a scenario still run sequentially against the shared
+env. Results are written into index-addressed slots, so output order (and
+therefore `--json` output) is identical to a sequential run. Two run modes
+force sequential execution (`sectionParallelism()`): `--batch` measures
+per-request timing that parallel load would skew, and `--record-dir`
+captures traffic for replay that concurrent runs would interleave.
+
+Env boots themselves are also cheap now: the single most expensive step of a
+config boot was generating the enterprise-context RSA-2048 key pair
+(~100-600ms of prime search) into every fresh temp config dir. The harness
+pre-seeds each env's key slots from a process-level cached pair
+(`serverconfig.PreseedEnterpriseContextKeys`), generated once per process —
+sharing one throwaway key across harness envs is deliberate, and production
+configs are untouched (they generate once and reuse from disk). Together
+these took the default CLI run from ~15s to ~4s and `--mode=all` from ~41s
+to ~10s on a 4-core machine; the e2e go-test path (already parallel, so
+keygen CPU was its bottleneck) dropped from ~60s to ~17s.
+
 ---
 
 ## 3. How to run

--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -10,7 +10,7 @@
 > Related: request **content-shape** regressions (a client sending array-of-
 > text-blocks content instead of a plain string on tool/system/assistant
 > messages) are covered by a separate suite in `content_shapes.go` — see
-> §9.1. The matrix itself always sends the same fixed single-turn prompt and
+> §10.1. The matrix itself always sends the same fixed single-turn prompt and
 > only varies the mocked *response* shape, so it cannot catch bugs in how
 > unusual *request* shapes are forwarded upstream.
 
@@ -38,6 +38,11 @@ original (A→B→A with `g(f(A)) == A` assertions). The transitive run does emi
 some chains where C happens to equal A, but those only run the scenario's
 normal assertions after two hops — they do **not** assert idempotence. True
 idempotence lives in its own path (`idempotent.go`).
+
+Two further suites round out coverage on orthogonal axes and are documented
+in their own sections below: per-rule **flag** behavior (§10, detailed in
+[`rule-flag-testing.md`](./rule-flag-testing.md)) and request **content-shape**
+regressions (§10.1).
 
 ---
 
@@ -69,10 +74,18 @@ Assertions + SemanticEquivalence checks
   `First.Target == Second.Source`. Built automatically from `DefaultPairs()`.
 
 - **`Matrix`** — the orchestrator. Holds `Pairs`, `Scenarios`, `Streaming`
-  modes, and filter/config methods (`OnlyScenarios`, `OnlySources`, etc.).
+  modes, and filter/config methods (`OnlyScenarios`, `OnlySources`, etc.),
+  plus CLI-only knobs (`BatchCount`, `RecordDir`, `Client`) set via `With*`
+  methods.
 
 - **`RoundTripResult`** — normalized output: `Content`, `Role`,
   `FinishReason`, `ToolCalls`, `Usage`, `StreamEvents`, etc.
+
+- **`TestResult`** — the outcome of one combination (`Passed`, `Skipped`,
+  `Errors`, `Duration`, plus `Batch*` fields when `BatchCount > 1`). Every
+  `Execute*` entry point returns `[]TestResult` uniformly, so the CLI's
+  table/JSON printer and the `testing.T` bridge (`reportTestResult`) share
+  one shape instead of each section inventing its own.
 
 ### Shared helpers
 
@@ -85,62 +98,87 @@ Assertions + SemanticEquivalence checks
 
 ### Section drivers (`section.go`)
 
-Every section contributes only its combos and per-combo execution; the shared
-lifecycle lives once in `internal/protocoltest/section.go`:
+Every section (single-hop, transitive, idempotent, flags, content_shapes)
+contributes only its combos and per-combo execution; the env-per-scenario
+lifecycle, setup-failure fan-out, and `testing.T` scaffolding live once in
+`internal/protocoltest/section.go`:
 
 | Driver | Used by | Purpose |
 |--------|---------|---------|
-| `Matrix.executePerScenario(skip, combosFor)` | `ExecuteAll` / `ExecuteAllTransitive` / `ExecuteAllIdempotent` | CLI-side: one env per scenario, setup-failure fan-out (env boot failure is reported per-combination), sequential combo execution, env close |
-| `Matrix.runPerScenario(t, skip, run)` | `RunTransitive` / `RunIdempotent` | testing.T-side: one env per scenario subtest, scenarios in parallel, combos sequential |
-| `runRecorderCase(name, scenario, run)` | `ExecuteAllFlags` / `ExecuteAllContentShapes` | Runs one `flagTB`-style case body under the recording shim, returns a `TestResult` |
+| `Matrix.executePerScenario(skip, combosFor)` | `ExecuteAll` / `ExecuteAllTransitive` / `ExecuteAllIdempotent` | CLI-side: one env per scenario, scenarios run concurrently (§3.1), combos within a scenario run sequentially against the shared env |
+| `Matrix.runPerScenario(t, skip, run)` | `RunTransitive` / `RunIdempotent` | `testing.T` counterpart: one env per scenario subtest, `t.Parallel()` scenarios, combos sequential |
+| `Matrix.runRecorderCases(cases)` | `ExecuteAllFlags` / `ExecuteAllContentShapes` | CLI-side: one env per case, cases run concurrently (§3.1) |
+| `runRecorderCase(name, scenario, run)` | `runRecorderCases` | Runs one `flagTB`-style case body under the recording shim (`flagRecorder`), returns its `TestResult` |
+| `setupFailureResult(base, err)` | `executeScenarioCombos` / `runRecorderCase` | Shared "env failed to boot" `TestResult` construction |
 
 A `scenarioCombo` is `{meta TestResult, run func(*TestEnv) TestResult}` — the
 `meta` doubles as the setup-failure result when the scenario's env cannot be
-created. (Single-hop `Matrix.Run(t)` keeps its own deeper subtest nesting —
+created. A `recorderCase` is the equivalent for the flags/content_shapes
+suites: `{name, scenario string, run func(flagTB, *TestEnv)}`. (Single-hop
+`Matrix.Run(t)` keeps its own deeper subtest nesting —
 `scenario/source/target/mode` with one env per leaf — because its test-name
 contract and per-leaf parallelism differ from the per-scenario sections.)
 
-### CLI parallelism & env-boot cost
+---
 
-The CLI drivers run their independent units — scenarios in
-`executePerScenario`, cases in `runRecorderCases` — concurrently via
-`runIndexed` (an `errgroup.Group` with `SetLimit`), mirroring the
-`t.Parallel()` the go-test entry points always had. The cap
-(`sectionParallelism()`) is `min(GOMAXPROCS, maxSectionParallelism)`, not raw
-core count: each unit boots a full `httptest.Server` + SQLite-backed
-`AppConfig`, an I/O/fd/memory cost that core count doesn't bound, so an
-unlimited-up-to-GOMAXPROCS cap would over-commit fd/memory on high-core CI
-runners for no throughput benefit. Combos *within* a scenario still run
-sequentially against the shared env. Results are written into
-index-addressed slots, so output order (and therefore `--json` output) is
-identical to a sequential run. Two run modes force sequential execution
-(`sectionParallelism()` returns 1): `--batch` measures per-request timing
-that parallel load would skew, and `--record-dir` captures traffic for
+## 3. CLI execution model
+
+Two runtime properties of `cli/harness matrix` sit outside the test
+*definitions* above but matter for anyone running or profiling it.
+
+### 3.1 Parallelism
+
+Independent env-backed units — scenarios in `executePerScenario`, cases in
+`runRecorderCases` — run concurrently via `runIndexed` (an
+`golang.org/x/sync/errgroup.Group` with `SetLimit`), mirroring the
+`t.Parallel()` the go-test entry points always had. Combos *within* a
+scenario still run sequentially against the shared env — routes are keyed by
+`(source, target, scenario)`, so this is purely about overlapping I/O wait,
+not a correctness requirement. Results land in index-addressed slots, so
+output order — and therefore `--json` output — is identical to a sequential
+run regardless of goroutine completion order.
+
+The concurrency cap (`Matrix.sectionParallelism()`) is
+`min(GOMAXPROCS, maxSectionParallelism)` — currently 8 — not raw core count
+(see §8 for why). It drops to 1 (fully sequential) whenever `--batch` or
+`--record-dir` is set: `--batch` measures per-request timing that parallel
+load would skew, and `--record-dir` captures request/response traffic for
 replay that concurrent runs would interleave.
 
-Env boots themselves are also cheap now: the single most expensive step of a
-config boot was generating the enterprise-context RSA-2048 key pair
-(~100-600ms of prime search) into every fresh temp config dir. The harness
-pre-seeds each env's key slots from a process-cached pair
-(`internal/protocoltest`'s `preseedEnterpriseContextKeys`, generated once per
-process via `sync.OnceValues`) — sharing one throwaway key across harness
-envs is deliberate. This lives in the harness, not
-`internal/server/config`: `internal/server/config/enterprise.go` only
-exports the generic primitives (`GenerateEnterpriseContextPEMs`,
-`WriteEnterpriseContextKeys`, `EnterpriseContextKeyPaths`) that
-`ensureEnterpriseContextRS256KeyPair` already used internally; the
-process-cache-and-reuse *policy* is harness-only knowledge with zero
-production callers, so it belongs in `internal/protocoltest` (structurally a
-test/harness package) rather than in a package that ships in the real server
-binary. Production configs are untouched — they still generate once per
-config dir and reuse the key from disk. Together these took the default CLI
-run from ~15s to ~3s and `--mode=all` from ~41s to ~8s on a 4-core machine;
-the e2e go-test path (already parallel, so keygen CPU was its bottleneck)
-dropped from ~60s to ~17s.
+### 3.2 Env-boot cost
+
+Each env boots a full `httptest.Server` + SQLite-backed `AppConfig` in a
+fresh temp dir. The single most expensive step of that boot is
+`internal/server/config`'s enterprise-context RSA-2048 key generation
+(~100-600ms of prime search) — a one-time cost for a real install, but every
+harness env is a fresh install by construction, and one CLI run boots dozens
+of them.
+
+`internal/protocoltest/testenv.go`'s `preseedEnterpriseContextKeys` amortizes
+this: one key pair is generated per process (`sync.OnceValues`) and written
+into every env's key slots before `config.NewAppConfig` runs, so
+`ensureEnterpriseContextRS256KeyPair` finds the files already present and
+skips generating its own. `internal/server/config/enterprise.go` only
+exports the generic primitives this uses — `GenerateEnterpriseContextPEMs`,
+`WriteEnterpriseContextKeys`, `EnterpriseContextKeyPaths` — the same ones
+`ensureEnterpriseContextRS256KeyPair` already used internally; see §8 for why
+the caching *policy* itself lives in the harness, not the production config
+package.
+
+Together, §3.1 and §3.2 took (4-core machine):
+
+| | before | after |
+|---|---|---|
+| `matrix` (default) | ~15s | ~3s |
+| `matrix --mode=all` | ~41s | ~8s |
+| e2e go test (`TestHarness` + idempotent/flags/content_shapes) | ~60s | ~17s |
+
+The e2e path was already parallel via `t.Parallel()`, so keygen CPU was its
+only bottleneck — it benefits from §3.2 alone.
 
 ---
 
-## 3. How to run
+## 4. How to run
 
 ### go test (requires `-tags e2e`)
 
@@ -160,7 +198,7 @@ go test -tags e2e ./internal/protocoltest/... -run TestHarness_Streaming
 # Idempotent round-trips
 go test -tags e2e ./internal/protocoltest/... -run TestIdempotent
 
-# Request content-shape regression suite (see §9.1)
+# Request content-shape regression suite (see §10.1)
 go test -tags e2e ./internal/protocoltest/... -run TestContentShapes
 ```
 
@@ -170,7 +208,7 @@ go test -tags e2e ./internal/protocoltest/... -run TestContentShapes
 executor (`ExecuteAll*`) so the CLI can run it directly — including idempotence
 and the rule-flag suite, which would otherwise be go-test-only.
 
-| `--mode` | single (A→B) | transitive (A→B→C) | idempotent (`g(f(A))==A`) | flags (per-rule) | content_shapes (§9.1) |
+| `--mode` | single (A→B) | transitive (A→B→C) | idempotent (`g(f(A))==A`) | flags (per-rule) | content_shapes (§10.1) |
 |----------|:---:|:---:|:---:|:---:|:---:|
 | `default` *(no flag)* | ✅ | — | ✅ | — | — |
 | `all` | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -185,7 +223,7 @@ registry in `cli/harness/matrix.go`. Each entry names the section, lists the
 `--mode` values that include it, marks whether it is http-only (`flags` /
 `content_shapes` drive raw requests directly), and points at its
 `ExecuteAll*` executor. Adding a section = one registry entry + extending the
-`--mode` enum.
+`--mode` enum (see §8 for why this replaced a hand-maintained if-chain).
 
 ```bash
 # Default: single-hop + idempotent round-trips. Two-hop and flags are OFF by
@@ -214,8 +252,13 @@ The `flags` section is documented in detail in
 [`rule-flag-testing.md`](./rule-flag-testing.md); `ExecuteAllFlags` reports one
 `TestResult` per flag (`Name: "flags/<key>"`, `Scenario: <key>`).
 
-The `content_shapes` section is documented in §9.1 below; `ExecuteAllContentShapes`
+The `content_shapes` section is documented in §10.1 below; `ExecuteAllContentShapes`
 reports one `TestResult` per case (`Name: "content_shapes/<case name>"`).
+
+Other CLI flags (`--batch`, `--record-dir`, `--mcp`, `-v`) are documented in
+[`cli/harness/README.md`](../cli/harness/README.md); `--batch` and
+`--record-dir` additionally force the sections above to run sequentially
+(§3.1).
 
 ### Client drivers (`--client`)
 
@@ -303,7 +346,7 @@ and Responses string-`input` dropped in responses→chat conversion).
 
 ---
 
-## 4. Adding a new scenario
+## 5. Adding a new scenario
 
 1. Define a `FooScenario() Scenario` function in
    `vmodel/benchmark/scenario/builtins.go` with `MockResponses` for all 4
@@ -347,7 +390,7 @@ func IncompleteScenario() Scenario {
 
 ---
 
-## 5. Adding a new protocol pair
+## 6. Adding a new protocol pair
 
 1. Add the pair to `DefaultPairs()` in `matrix.go`.
 
@@ -361,7 +404,7 @@ func IncompleteScenario() Scenario {
 
 ---
 
-## 6. Test naming conventions
+## 7. Test naming conventions
 
 Tests are structured as nested subtests for `-run` filtering:
 
@@ -383,7 +426,7 @@ CLI `TestResult.Name` follows the same `scenario/path/mode` pattern.
 
 ---
 
-## 7. Design decisions
+## 8. Design decisions
 
 **Why explicit pairs, not Cartesian product?**
 Many cells of the full product map to the same dispatch handler (e.g.
@@ -407,9 +450,34 @@ This is the shared core used by both the `testing.T` path
 (`executeTransitiveChain`). The `testing.T` version just loops and
 calls `t.Errorf` per entry — no duplicated field checks.
 
+**Why a `matrixSections` registry instead of an if-chain on `--mode`?**
+Before, CLI dispatch was five near-identical `if m.Mode == ...` blocks
+plus a hand-maintained comment describing the same mapping — the two
+routinely drifted. A data table is the mapping: adding a section is one
+entry, and this doc's mode table (§4) can point straight at the source
+of truth instead of re-deriving it.
+
+**Why does the harness cap concurrency at `min(GOMAXPROCS, 8)` instead of raw `GOMAXPROCS`?**
+Each concurrent unit boots a full `httptest.Server` + SQLite-backed
+config — an I/O/fd/memory cost, not a CPU one. Core count doesn't bound
+that cost, so scaling purely with `GOMAXPROCS` would over-commit fd and
+memory limits on high-core CI runners for no throughput benefit; a small
+fixed ceiling caps it regardless of machine size.
+
+**Why does the RSA key pre-seed (§3.2) live in `internal/protocoltest`, not `internal/server/config`?**
+`internal/server/config` ships in the production server binary; the
+process-cache-and-reuse *policy* has zero production callers and exists
+purely to amortize a cost the harness's "fresh config dir per env"
+pattern creates. `enterprise.go` only exports the generic
+generate/write/path primitives `ensureEnterpriseContextRS256KeyPair`
+already used internally — the caching decision is harness-only
+knowledge and belongs in the package that's structurally a test
+harness. Production configs are unaffected: they still generate once
+per install and reuse the key from disk.
+
 ---
 
-## 8. Error scenarios (pre-content vs mid-stream)
+## 9. Error scenarios (pre-content vs mid-stream)
 
 Error scenarios are modeled by `ErrorInjection.Stage`, and the two stages have
 very different observable shapes — conflating them hides real gateway bugs.
@@ -440,7 +508,7 @@ worth comparing across hops (and idempotence skips `error` for the same reason).
 
 ---
 
-## 9. Inspecting the forwarded request (capture & flags)
+## 10. Inspecting the forwarded request (capture & flags)
 
 The matrix asserts on the parsed *response*, but some checks need the *request
 the gateway actually forwarded upstream*. The `VirtualServer` mock records it:
@@ -455,7 +523,7 @@ These power the per-rule **flag** behavior suite, which is documented
 separately: [`rule-flag-testing.md`](./rule-flag-testing.md). Keep the matrix
 itself flag-free — flags are an orthogonal axis and live in their own suite.
 
-### 9.1 Request content-shape regression suite (`content_shapes.go`)
+### 10.1 Request content-shape regression suite (`content_shapes.go`)
 
 **Why this exists.** Every matrix request is built by `buildRequest`
 (`testenv.go`) from the fixed `harnessPrompt` — a single-turn plain-string user

--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -103,25 +103,40 @@ contract and per-leaf parallelism differ from the per-scenario sections.)
 ### CLI parallelism & env-boot cost
 
 The CLI drivers run their independent units — scenarios in
-`executePerScenario`, cases in `runRecorderCases` — concurrently up to
-`GOMAXPROCS`, mirroring the `t.Parallel()` the go-test entry points always
-had. Combos *within* a scenario still run sequentially against the shared
-env. Results are written into index-addressed slots, so output order (and
-therefore `--json` output) is identical to a sequential run. Two run modes
-force sequential execution (`sectionParallelism()`): `--batch` measures
-per-request timing that parallel load would skew, and `--record-dir`
-captures traffic for replay that concurrent runs would interleave.
+`executePerScenario`, cases in `runRecorderCases` — concurrently via
+`runIndexed` (an `errgroup.Group` with `SetLimit`), mirroring the
+`t.Parallel()` the go-test entry points always had. The cap
+(`sectionParallelism()`) is `min(GOMAXPROCS, maxSectionParallelism)`, not raw
+core count: each unit boots a full `httptest.Server` + SQLite-backed
+`AppConfig`, an I/O/fd/memory cost that core count doesn't bound, so an
+unlimited-up-to-GOMAXPROCS cap would over-commit fd/memory on high-core CI
+runners for no throughput benefit. Combos *within* a scenario still run
+sequentially against the shared env. Results are written into
+index-addressed slots, so output order (and therefore `--json` output) is
+identical to a sequential run. Two run modes force sequential execution
+(`sectionParallelism()` returns 1): `--batch` measures per-request timing
+that parallel load would skew, and `--record-dir` captures traffic for
+replay that concurrent runs would interleave.
 
 Env boots themselves are also cheap now: the single most expensive step of a
 config boot was generating the enterprise-context RSA-2048 key pair
 (~100-600ms of prime search) into every fresh temp config dir. The harness
-pre-seeds each env's key slots from a process-level cached pair
-(`serverconfig.PreseedEnterpriseContextKeys`), generated once per process —
-sharing one throwaway key across harness envs is deliberate, and production
-configs are untouched (they generate once and reuse from disk). Together
-these took the default CLI run from ~15s to ~4s and `--mode=all` from ~41s
-to ~10s on a 4-core machine; the e2e go-test path (already parallel, so
-keygen CPU was its bottleneck) dropped from ~60s to ~17s.
+pre-seeds each env's key slots from a process-cached pair
+(`internal/protocoltest`'s `preseedEnterpriseContextKeys`, generated once per
+process via `sync.OnceValues`) — sharing one throwaway key across harness
+envs is deliberate. This lives in the harness, not
+`internal/server/config`: `internal/server/config/enterprise.go` only
+exports the generic primitives (`GenerateEnterpriseContextPEMs`,
+`WriteEnterpriseContextKeys`, `EnterpriseContextKeyPaths`) that
+`ensureEnterpriseContextRS256KeyPair` already used internally; the
+process-cache-and-reuse *policy* is harness-only knowledge with zero
+production callers, so it belongs in `internal/protocoltest` (structurally a
+test/harness package) rather than in a package that ships in the real server
+binary. Production configs are untouched — they still generate once per
+config dir and reuse the key from disk. Together these took the default CLI
+run from ~15s to ~3s and `--mode=all` from ~41s to ~8s on a 4-core machine;
+the e2e go-test path (already parallel, so keygen CPU was its bottleneck)
+dropped from ~60s to ~17s.
 
 ---
 

--- a/.design/rule-flag-testing.md
+++ b/.design/rule-flag-testing.md
@@ -12,7 +12,7 @@
 > It is wired into the harness as the **`flags`** section: run it via
 > `harness matrix --mode=flags` (also included in `--mode=all`), or as
 > `go test -run TestRuleFlags`. See the mode table in
-> [`harness-matrix.md`](./harness-matrix.md#3-how-to-run).
+> [`harness-matrix.md`](./harness-matrix.md#4-how-to-run).
 
 ---
 

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/protocoltest"
@@ -32,6 +33,27 @@ type MatrixCmd struct {
 	RecordDir  string   `kong:"name='record-dir',env='HARNESS_RECORD_DIR',help='Directory for recording requests/responses (default: disabled)'"`
 	BatchCount int      `kong:"name='batch',default='1',help='Number of times to run each test (for stability/performance testing)'"`
 	MCPEnabled bool     `kong:"name='mcp',help='Enable MCP feature flag in test env'"`
+}
+
+// matrixSection describes one runnable section of the validation matrix and
+// which --mode values include it. Adding a section means adding one entry
+// here (plus its ExecuteAll* executor in internal/protocoltest) and extending
+// the --mode enum on MatrixCmd.
+type matrixSection struct {
+	name     string
+	modes    []string // --mode values that include this section
+	httpOnly bool     // drives raw requests directly; requires --client=http
+	exec     func(*protocoltest.Matrix) []protocoltest.TestResult
+}
+
+// matrixSections is the section registry: the single source of truth for what
+// each --mode runs. Section order here is output order.
+var matrixSections = []matrixSection{
+	{name: "single", modes: []string{"default", "all", "single"}, exec: (*protocoltest.Matrix).ExecuteAll},
+	{name: "transitive", modes: []string{"all", "transitive"}, exec: (*protocoltest.Matrix).ExecuteAllTransitive},
+	{name: "idempotent", modes: []string{"default", "all", "idempotent"}, exec: (*protocoltest.Matrix).ExecuteAllIdempotent},
+	{name: "flags", modes: []string{"all", "flags"}, httpOnly: true, exec: (*protocoltest.Matrix).ExecuteAllFlags},
+	{name: "content_shapes", modes: []string{"all", "content_shapes"}, httpOnly: true, exec: (*protocoltest.Matrix).ExecuteAllContentShapes},
 }
 
 // Help returns extended help text shown by `harness matrix --help`.
@@ -102,8 +124,12 @@ func (m *MatrixCmd) Run() error {
 	if m.Streaming && m.NonStream {
 		return fmt.Errorf("cannot specify both --streaming and --non-streaming")
 	}
-	if m.Client != "http" && (m.Mode == "flags" || m.Mode == "content_shapes") {
-		return fmt.Errorf("--mode=%s only supports --client=http (this suite drives raw requests directly)", m.Mode)
+	if m.Client != "http" {
+		for _, sec := range matrixSections {
+			if sec.httpOnly && m.Mode == sec.name {
+				return fmt.Errorf("--mode=%s only supports --client=http (this suite drives raw requests directly)", m.Mode)
+			}
+		}
 	}
 
 	client, err := resolveClient(m.Client)
@@ -142,32 +168,20 @@ func (m *MatrixCmd) Run() error {
 		matrix = matrix.WithMCPEnabled()
 	}
 
-	// Collect results for the selected sections (--mode controls which).
-	//
-	//   single-hop (A→B)         runs unless mode is transitive/idempotent/flags/content_shapes
-	//   transitive (A→B→C)       runs only for all/transitive (OFF by default)
-	//   idempotent (g(f(A))==A)  runs for default/all/idempotent
-	//   flags (per-rule flags)   runs for all/flags
-	//   content_shapes (request content-shape regression) runs for all/content_shapes
+	// Collect results for the sections the selected --mode includes (see
+	// matrixSections for the mode → section mapping).
 	var combined []protocoltest.TestResult
-	if m.Mode != "transitive" && m.Mode != "idempotent" && m.Mode != "flags" && m.Mode != "content_shapes" {
-		combined = append(combined, matrix.ExecuteAll()...)
-	}
-	if m.Mode == "all" || m.Mode == "transitive" {
-		combined = append(combined, matrix.ExecuteAllTransitive()...)
-	}
-	if m.Mode == "default" || m.Mode == "all" || m.Mode == "idempotent" {
-		combined = append(combined, matrix.ExecuteAllIdempotent()...)
-	}
-	if (m.Mode == "all" || m.Mode == "flags") && m.Client == "http" {
-		combined = append(combined, matrix.ExecuteAllFlags()...)
-	} else if m.Mode == "all" {
-		logrus.Warnf("skipping flags section: only supported with --client=http")
-	}
-	if (m.Mode == "all" || m.Mode == "content_shapes") && m.Client == "http" {
-		combined = append(combined, matrix.ExecuteAllContentShapes()...)
-	} else if m.Mode == "all" {
-		logrus.Warnf("skipping content_shapes section: only supported with --client=http")
+	for _, sec := range matrixSections {
+		if !slices.Contains(sec.modes, m.Mode) {
+			continue
+		}
+		if sec.httpOnly && m.Client != "http" {
+			// Only reachable with --mode=all: selecting an http-only section
+			// directly with another client is rejected up front.
+			logrus.Warnf("skipping %s section: only supported with --client=http", sec.name)
+			continue
+		}
+		combined = append(combined, sec.exec(matrix)...)
 	}
 	results := filterResults(combined, m)
 
@@ -260,15 +274,18 @@ func driverDir() (string, error) {
 	return dir, nil
 }
 
-// filterResults filters test results based on command options.
+// filterResults applies the command's source/target/streaming filters to the
+// combined results. The matrix filters its own pairs, but sections whose cases
+// are not pair-derived (idempotent, flags, content_shapes) only honor these
+// flags through this post-filter.
 func filterResults(results []protocoltest.TestResult, m *MatrixCmd) []protocoltest.TestResult {
 	var filtered []protocoltest.TestResult
 
 	for _, r := range results {
-		if len(m.Sources) > 0 && !contains(m.Sources, string(r.Source)) {
+		if len(m.Sources) > 0 && !slices.Contains(m.Sources, string(r.Source)) {
 			continue
 		}
-		if len(m.Targets) > 0 && !contains(m.Targets, string(r.Target)) {
+		if len(m.Targets) > 0 && !slices.Contains(m.Targets, string(r.Target)) {
 			continue
 		}
 		if m.Streaming && !r.Streaming {
@@ -281,14 +298,4 @@ func filterResults(results []protocoltest.TestResult, m *MatrixCmd) []protocolte
 	}
 
 	return filtered
-}
-
-// contains checks if a string slice contains a specific value.
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -144,7 +145,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1 // indirect
-	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
@@ -177,7 +177,6 @@ require (
 	golang.org/x/arch v0.25.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,6 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1 h1:Lb/Uzkiw2Ugt2Xf03J5wmv81PdkYOiWbI8CNBi1boC8=
 github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1/go.mod h1:ln3IqPYYocZbYvl9TAOrG/cxGR9xcn4pnZRLdCTEGEU=
-github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=
-github.com/otiai10/mint v1.6.3/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=

--- a/internal/protocoltest/content_shapes.go
+++ b/internal/protocoltest/content_shapes.go
@@ -1,9 +1,7 @@
 package protocoltest
 
 import (
-	"fmt"
 	"slices"
-	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
@@ -287,40 +285,10 @@ func contentShapeCases() []contentShapeCase {
 // TestContentShapes, returning []TestResult. Name format:
 // "content_shapes/<case name>".
 func (m *Matrix) ExecuteAllContentShapes() []TestResult {
-	results := make([]TestResult, 0, len(contentShapeCases()))
-	for _, c := range contentShapeCases() {
-		results = append(results, runContentShapeCaseCLI(c))
+	cases := contentShapeCases()
+	results := make([]TestResult, 0, len(cases))
+	for _, c := range cases {
+		results = append(results, runRecorderCase("content_shapes/"+c.name, c.name, c.run))
 	}
 	return results
-}
-
-func runContentShapeCaseCLI(c contentShapeCase) TestResult {
-	res := TestResult{Name: "content_shapes/" + c.name, Scenario: c.name}
-	start := time.Now()
-
-	env, err := NewTestEnvForCLI()
-	if err != nil {
-		res.Errors = []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("create test env: %v", err)}}
-		res.Duration = time.Since(start)
-		return res
-	}
-	defer env.Close()
-
-	// Reuses flagRecorder/flagAbort from flags.go: same flagTB contract, same
-	// "run under a testing.T-free recorder" trick, no need to duplicate it.
-	rec := &flagRecorder{}
-	func() {
-		defer func() {
-			rec.runCleanups()
-			if r := recover(); r != nil && r != flagAbort {
-				panic(r)
-			}
-		}()
-		c.run(rec, env)
-	}()
-
-	res.Errors = rec.errs
-	res.Passed = len(rec.errs) == 0
-	res.Duration = time.Since(start)
-	return res
 }

--- a/internal/protocoltest/content_shapes.go
+++ b/internal/protocoltest/content_shapes.go
@@ -285,10 +285,9 @@ func contentShapeCases() []contentShapeCase {
 // TestContentShapes, returning []TestResult. Name format:
 // "content_shapes/<case name>".
 func (m *Matrix) ExecuteAllContentShapes() []TestResult {
-	cases := contentShapeCases()
-	results := make([]TestResult, 0, len(cases))
-	for _, c := range cases {
-		results = append(results, runRecorderCase("content_shapes/"+c.name, c.name, c.run))
+	var cases []recorderCase
+	for _, c := range contentShapeCases() {
+		cases = append(cases, recorderCase{name: "content_shapes/" + c.name, scenario: c.name, run: c.run})
 	}
-	return results
+	return m.runRecorderCases(cases)
 }

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/constant"
@@ -578,40 +577,10 @@ func (r *flagRecorder) runCleanups() {
 // It is the CLI-compatible counterpart of TestRuleFlags, returning []TestResult.
 // Name format: "flags/<flag key>".
 func (m *Matrix) ExecuteAllFlags() []TestResult {
-	results := make([]TestResult, 0, len(ruleFlagCases()))
-	for _, fc := range ruleFlagCases() {
-		results = append(results, runFlagCaseCLI(fc))
+	cases := ruleFlagCases()
+	results := make([]TestResult, 0, len(cases))
+	for _, fc := range cases {
+		results = append(results, runRecorderCase("flags/"+fc.key, fc.key, fc.run))
 	}
 	return results
-}
-
-func runFlagCaseCLI(fc flagCase) TestResult {
-	// Scenario carries the flag key so the CLI table (which shows the Scenario
-	// column, not Name) distinguishes the 13 rows; Name keeps the flags/ prefix.
-	res := TestResult{Name: "flags/" + fc.key, Scenario: fc.key}
-	start := time.Now()
-
-	env, err := NewTestEnvForCLI()
-	if err != nil {
-		res.Errors = []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("create test env: %v", err)}}
-		res.Duration = time.Since(start)
-		return res
-	}
-	defer env.Close()
-
-	rec := &flagRecorder{}
-	func() {
-		defer func() {
-			rec.runCleanups()
-			if r := recover(); r != nil && r != flagAbort {
-				panic(r)
-			}
-		}()
-		fc.run(rec, env)
-	}()
-
-	res.Errors = rec.errs
-	res.Passed = len(rec.errs) == 0
-	res.Duration = time.Since(start)
-	return res
 }

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -577,10 +577,9 @@ func (r *flagRecorder) runCleanups() {
 // It is the CLI-compatible counterpart of TestRuleFlags, returning []TestResult.
 // Name format: "flags/<flag key>".
 func (m *Matrix) ExecuteAllFlags() []TestResult {
-	cases := ruleFlagCases()
-	results := make([]TestResult, 0, len(cases))
-	for _, fc := range cases {
-		results = append(results, runRecorderCase("flags/"+fc.key, fc.key, fc.run))
+	var cases []recorderCase
+	for _, fc := range ruleFlagCases() {
+		cases = append(cases, recorderCase{name: "flags/" + fc.key, scenario: fc.key, run: fc.run})
 	}
-	return results
+	return m.runRecorderCases(cases)
 }

--- a/internal/protocoltest/idempotent.go
+++ b/internal/protocoltest/idempotent.go
@@ -133,40 +133,27 @@ func (env *TestEnv) setupChainHopRoute(source, target protocol.APIType, s Scenar
 // RunIdempotent executes round-trip idempotency tests for all cases ×
 // scenarios as subtests under t. Each case runs the same
 // executeIdempotentCase implementation the CLI path uses; the testing.T
-// layer only provisions one env per scenario and reports the TestResult.
+// layer (runPerScenario) only provisions one env per scenario and reports
+// the TestResult.
+//
+// Error / truncation scenarios are not round-trippable: the inner gateway
+// wraps upstream errors and a mid-stream cut surfaces as an error on one hop
+// but partial content on another, so the two paths legitimately diverge.
+// SkipTransitive marks exactly these.
 func (m *Matrix) RunIdempotent(t *testing.T) {
 	t.Helper()
 
 	cases := DefaultIdempotentCases()
-
-	for _, scenario := range m.Scenarios {
-		// Error / truncation scenarios are not round-trippable: the inner
-		// gateway wraps upstream errors and a mid-stream cut surfaces as an
-		// error on one hop but partial content on another, so the two paths
-		// legitimately diverge. SkipTransitive marks exactly these.
-		if scenario.SkipTransitive {
-			continue
+	m.runPerScenario(t, skipTransitiveScenario, func(t *testing.T, env *TestEnv, scenario Scenario) {
+		for _, ic := range cases {
+			for _, streaming := range m.Streaming {
+				t.Run(fmt.Sprintf("%s/%s", ic.Name, streamMode(streaming)), func(t *testing.T) {
+					result := m.executeIdempotentCase(env, scenario, ic, streaming)
+					reportTestResult(t, &result)
+				})
+			}
 		}
-
-		t.Run(scenario.Name, func(t *testing.T) {
-			t.Parallel()
-
-			env, err := NewTestEnvForCLI(m.testEnvOpts()...)
-			if err != nil {
-				t.Fatalf("create test env: %v", err)
-			}
-			defer env.Close()
-
-			for _, ic := range cases {
-				for _, streaming := range m.Streaming {
-					t.Run(fmt.Sprintf("%s/%s", ic.Name, streamMode(streaming)), func(t *testing.T) {
-						result := m.executeIdempotentCase(env, scenario, ic, streaming)
-						reportTestResult(t, &result)
-					})
-				}
-			}
-		})
-	}
+	})
 }
 
 // ExecuteAllIdempotent runs round-trip idempotency tests without requiring
@@ -177,57 +164,39 @@ func (m *Matrix) RunIdempotent(t *testing.T) {
 //
 // Name format: "scenario/<case>/mode" (e.g. "text/openai_chat_via_anthropic/stream").
 func (m *Matrix) ExecuteAllIdempotent() []TestResult {
-	var results []TestResult
 	cases := DefaultIdempotentCases()
-
-	for _, scenario := range m.Scenarios {
-		// Error / truncation scenarios are not round-trippable (see RunIdempotent).
-		if scenario.SkipTransitive {
-			continue
-		}
-
-		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
-		if err != nil {
-			for _, ic := range cases {
-				for _, streaming := range m.Streaming {
-					results = append(results, TestResult{
-						Name:      idempotentTestName(scenario.Name, ic, streaming),
-						Scenario:  scenario.Name,
-						Source:    ic.Source,
-						Target:    ic.Mid,
-						Streaming: streaming,
-						Passed:    false,
-						Errors:    []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("failed to create test env: %v", err)}},
-					})
-				}
-			}
-			continue
-		}
-
+	return m.executePerScenario(skipTransitiveScenario, func(s Scenario) []scenarioCombo {
+		var combos []scenarioCombo
 		for _, ic := range cases {
 			for _, streaming := range m.Streaming {
-				results = append(results, m.executeIdempotentCase(env, scenario, ic, streaming))
+				combos = append(combos, scenarioCombo{
+					meta: ic.baseResult(s.Name, streaming),
+					run: func(env *TestEnv) TestResult {
+						return m.executeIdempotentCase(env, s, ic, streaming)
+					},
+				})
 			}
 		}
-		env.Close()
-	}
-	return results
+		return combos
+	})
 }
 
-func idempotentTestName(scenarioName string, ic IdempotentCase, streaming bool) string {
-	return fmt.Sprintf("%s/%s/%s", scenarioName, ic.Name, streamMode(streaming))
+// baseResult returns a TestResult pre-filled with the fields that identify
+// this case in a given scenario/mode.
+func (ic IdempotentCase) baseResult(scenarioName string, streaming bool) TestResult {
+	return TestResult{
+		Name:      fmt.Sprintf("%s/%s/%s", scenarioName, ic.Name, streamMode(streaming)),
+		Scenario:  scenarioName,
+		Source:    ic.Source,
+		Target:    ic.Mid,
+		Streaming: streaming,
+	}
 }
 
 // executeIdempotentCase runs a single baseline-vs-round-trip comparison and
 // returns its TestResult.
 func (m *Matrix) executeIdempotentCase(env *TestEnv, scenario Scenario, ic IdempotentCase, streaming bool) TestResult {
-	base := TestResult{
-		Name:      idempotentTestName(scenario.Name, ic, streaming),
-		Scenario:  scenario.Name,
-		Source:    ic.Source,
-		Target:    ic.Mid,
-		Streaming: streaming,
-	}
+	base := ic.baseResult(scenario.Name, streaming)
 
 	if reason, skip := skipIdempotentScenario(ic, scenario.Name); skip {
 		base.Skipped = true
@@ -298,13 +267,10 @@ func (m *Matrix) executeIdempotentCase(env *TestEnv, scenario Scenario, ic Idemp
 }
 
 // skipIdempotentScenario reports whether a case+scenario should be skipped
-// because one of its hops is in the single-hop skip list.
+// because one of its hops is in the single-hop known-defect list.
 func skipIdempotentScenario(ic IdempotentCase, scenarioName string) (string, bool) {
-	for _, src := range []protocol.APIType{ic.Source, ic.Mid} {
-		key := fmt.Sprintf("%s|%s", src, scenarioName)
-		if reason, skip := skipSourceScenarios[key]; skip {
-			return reason, true
-		}
+	if reason, skip := KnownDefectReason(ic.Source, scenarioName); skip {
+		return reason, true
 	}
-	return "", false
+	return KnownDefectReason(ic.Mid, scenarioName)
 }

--- a/internal/protocoltest/matrix.go
+++ b/internal/protocoltest/matrix.go
@@ -289,7 +289,8 @@ func (m *Matrix) Run(t *testing.T) {
 								}
 								defer env.Close()
 
-								reportTestResult(t, m.executeTest(env, scenario, pair.Source, pair.Target, streaming))
+								result := m.executeTest(env, scenario, pair.Source, pair.Target, streaming)
+								reportTestResult(t, &result)
 							})
 						}
 					})
@@ -372,125 +373,80 @@ func truncate(s string, max int) string {
 // It does not use testing.T, making it suitable for standalone execution.
 //
 // One TestEnv is created per scenario and reused for all of its combinations
-// — routes are keyed by (source, target, scenario), so combinations within a
-// scenario cannot interfere, and env boots stay off the hot path.
+// (see executePerScenario).
 func (m *Matrix) ExecuteAll() []TestResult {
-	var results []TestResult
-
-	// For each scenario, create one TestEnv and reuse it for all combinations
-	for _, scenario := range m.Scenarios {
-		scenario := scenario
-
-		// Create TestEnv for this scenario
-		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
-		if err != nil {
-			// All tests for this scenario fail with setup error
-			for _, pair := range m.Pairs {
-				for _, streaming := range m.Streaming {
-					results = append(results, TestResult{
-						Name:      m.buildTestName(scenario.Name, pair.Source, pair.Target, streaming),
-						Scenario:  scenario.Name,
-						Source:    pair.Source,
-						Target:    pair.Target,
-						Streaming: streaming,
-						Passed:    false,
-						Errors: []AssertionError{{
-							Assertion: "setup",
-							Error:     fmt.Sprintf("failed to create test env: %v", err),
-						}},
-					})
-				}
-			}
-			continue
-		}
-		defer env.Close()
-
-		// Run all combinations for this scenario
+	return m.executePerScenario(nil, func(s Scenario) []scenarioCombo {
+		var combos []scenarioCombo
 		for _, pair := range m.Pairs {
 			for _, streaming := range m.Streaming {
-				if result := m.executeTest(env, scenario, pair.Source, pair.Target, streaming); result != nil {
-					results = append(results, *result)
-				}
+				combos = append(combos, scenarioCombo{
+					meta: m.newBaseResult(s.Name, pair.Source, pair.Target, streaming),
+					run: func(env *TestEnv) TestResult {
+						return m.executeTest(env, s, pair.Source, pair.Target, streaming)
+					},
+				})
 			}
 		}
-
-		// Close env explicitly after processing all combinations for this scenario
-		env.Close()
-	}
-
-	return results
+		return combos
+	})
 }
 
-// executeTest executes a single test with the given environment.
-// Returns nil if the test should be skipped.
-func (m *Matrix) executeTest(env *TestEnv, scenario Scenario, source, target protocol.APIType, streaming bool) *TestResult {
-	srcScenarioKey := fmt.Sprintf("%s|%s", source, scenario.Name)
-	if reason, skip := skipSourceScenarios[srcScenarioKey]; skip {
-		return &TestResult{
-			Name:       m.buildTestName(scenario.Name, source, target, streaming),
-			Scenario:   scenario.Name,
-			Source:     source,
-			Target:     target,
-			Streaming:  streaming,
-			Skipped:    true,
-			SkipReason: reason,
-		}
+// newBaseResult returns a TestResult pre-filled with the fields that identify
+// a single-hop combination.
+func (m *Matrix) newBaseResult(scenarioName string, source, target protocol.APIType, streaming bool) TestResult {
+	return TestResult{
+		Name:      m.buildTestName(scenarioName, source, target, streaming),
+		Scenario:  scenarioName,
+		Source:    source,
+		Target:    target,
+		Streaming: streaming,
 	}
+}
 
+// skipReason chains every skip check that applies to a single-hop
+// combination: known gateway defects, client-driver incompatibilities, and
+// streaming-mode mismatches.
+func (m *Matrix) skipReason(scenario Scenario, source protocol.APIType, streaming bool) (string, bool) {
+	if reason, skip := KnownDefectReason(source, scenario.Name); skip {
+		return reason, true
+	}
 	if reason, skip := m.clientSkipReason(source, scenario.Name); skip {
-		return &TestResult{
-			Name:       m.buildTestName(scenario.Name, source, target, streaming),
-			Scenario:   scenario.Name,
-			Source:     source,
-			Target:     target,
-			Streaming:  streaming,
-			Skipped:    true,
-			SkipReason: reason,
-		}
+		return reason, true
+	}
+	return streamingSkipReason(scenario, streaming)
+}
+
+// executeTest executes a single test combination with the given environment,
+// resolving skips first and batching when requested.
+func (m *Matrix) executeTest(env *TestEnv, scenario Scenario, source, target protocol.APIType, streaming bool) TestResult {
+	if reason, skip := m.skipReason(scenario, source, streaming); skip {
+		r := m.newBaseResult(scenario.Name, source, target, streaming)
+		r.Skipped = true
+		r.SkipReason = reason
+		return r
 	}
 
-	if reason, skip := streamingSkipReason(scenario, streaming); skip {
-		return &TestResult{
-			Name:       m.buildTestName(scenario.Name, source, target, streaming),
-			Scenario:   scenario.Name,
-			Source:     source,
-			Target:     target,
-			Streaming:  streaming,
-			Skipped:    true,
-			SkipReason: reason,
-		}
-	}
-
-	// Execute test (with batch if requested)
 	if m.BatchCount > 1 {
 		return m.executeBatch(env, scenario, source, target, streaming)
 	}
-
-	result := m.executeOneWithEnv(env, scenario, source, target, streaming)
-	return &result
+	return m.executeOneWithEnv(env, scenario, source, target, streaming)
 }
 
 // executeOneWithEnv runs a single test combination using the provided TestEnv.
 // Used by ExecuteAll for optimized batch testing.
 func (m *Matrix) executeOneWithEnv(env *TestEnv, s Scenario, source, target protocol.APIType, streaming bool) TestResult {
 	start := time.Now()
+	base := m.newBaseResult(s.Name, source, target, streaming)
 
 	env.SetupRoute(source, target, s)
 	result, err := env.SendAsCLI(source, target, s, streaming)
 	if err != nil {
-		return TestResult{
-			Name:      m.buildTestName(s.Name, source, target, streaming),
-			Scenario:  s.Name,
-			Source:    source,
-			Target:    target,
-			Streaming: streaming,
-			Passed:    false,
-			Errors: []AssertionError{{
-				Assertion: "send",
-				Error:     fmt.Sprintf("failed to send request: %v", err),
-			}},
-			Duration: time.Since(start),
-		}
+		base.Errors = []AssertionError{{
+			Assertion: "send",
+			Error:     fmt.Sprintf("failed to send request: %v", err),
+		}}
+		base.Duration = time.Since(start)
+		return base
 	}
 
 	// Check assertions
@@ -507,18 +463,12 @@ func (m *Matrix) executeOneWithEnv(env *TestEnv, s Scenario, source, target prot
 		}
 	}
 
-	return TestResult{
-		Name:       m.buildTestName(s.Name, source, target, streaming),
-		Scenario:   s.Name,
-		Source:     source,
-		Target:     target,
-		Streaming:  streaming,
-		Passed:     passed,
-		Errors:     errors,
-		Duration:   time.Since(start),
-		HTTPStatus: result.HTTPStatus,
-		Response:   result,
-	}
+	base.Passed = passed
+	base.Errors = errors
+	base.Duration = time.Since(start)
+	base.HTTPStatus = result.HTTPStatus
+	base.Response = result
+	return base
 }
 
 // buildTestName constructs a test name from its components.
@@ -527,7 +477,7 @@ func (m *Matrix) buildTestName(scenario string, source, target protocol.APIType,
 }
 
 // executeBatch runs a test multiple times and aggregates the results.
-func (m *Matrix) executeBatch(env *TestEnv, scenario Scenario, source, target protocol.APIType, streaming bool) *TestResult {
+func (m *Matrix) executeBatch(env *TestEnv, scenario Scenario, source, target protocol.APIType, streaming bool) TestResult {
 	name := m.buildTestName(scenario.Name, source, target, streaming)
 
 	var results []TestResult
@@ -573,7 +523,7 @@ func (m *Matrix) executeBatch(env *TestEnv, scenario Scenario, source, target pr
 		response = results[len(results)-1].Response
 	}
 
-	return &TestResult{
+	return TestResult{
 		Name:        name,
 		Scenario:    scenario.Name,
 		Source:      source,

--- a/internal/protocoltest/section.go
+++ b/internal/protocoltest/section.go
@@ -1,0 +1,114 @@
+package protocoltest
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// This file holds the shared drivers behind the matrix's sections
+// (single-hop, transitive, idempotent, flags, content_shapes). Each section
+// contributes only its combos and per-combo execution; the env-per-scenario
+// lifecycle, setup-failure fan-out, and testing.T scaffolding live here once.
+
+// scenarioCombo is one runnable cell within a per-scenario section: the
+// TestResult metadata that identifies it plus the function that executes it
+// against a live env. meta doubles as the setup-failure result when the
+// scenario's env cannot be created.
+type scenarioCombo struct {
+	meta TestResult
+	run  func(env *TestEnv) TestResult
+}
+
+// executePerScenario is the shared CLI-side driver for sections that provision
+// one TestEnv per scenario (single-hop, transitive, idempotent). Routes are
+// keyed by (source, target, scenario), so combos within a scenario cannot
+// interfere and env boots stay off the hot path. When env creation fails,
+// every combo is reported as a setup failure so a broken environment surfaces
+// per-combination in the results table.
+func (m *Matrix) executePerScenario(skipScenario func(Scenario) bool, combosFor func(Scenario) []scenarioCombo) []TestResult {
+	var results []TestResult
+	for _, scenario := range m.Scenarios {
+		if skipScenario != nil && skipScenario(scenario) {
+			continue
+		}
+		combos := combosFor(scenario)
+
+		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
+		if err != nil {
+			for _, c := range combos {
+				r := c.meta
+				r.Errors = []AssertionError{{
+					Assertion: "setup",
+					Error:     fmt.Sprintf("failed to create test env: %v", err),
+				}}
+				results = append(results, r)
+			}
+			continue
+		}
+
+		for _, c := range combos {
+			results = append(results, c.run(env))
+		}
+		env.Close()
+	}
+	return results
+}
+
+// runPerScenario is the testing.T counterpart of executePerScenario: one env
+// per scenario subtest (scenarios run in parallel, combos sequentially within
+// each — limiting file-descriptor usage), with run receiving the live env.
+func (m *Matrix) runPerScenario(t *testing.T, skipScenario func(Scenario) bool, run func(t *testing.T, env *TestEnv, s Scenario)) {
+	t.Helper()
+
+	for _, scenario := range m.Scenarios {
+		if skipScenario != nil && skipScenario(scenario) {
+			continue
+		}
+		t.Run(scenario.Name, func(t *testing.T) {
+			t.Parallel()
+
+			env, err := NewTestEnvForCLI(m.testEnvOpts()...)
+			if err != nil {
+				t.Fatalf("create test env: %v", err)
+			}
+			defer env.Close()
+
+			run(t, env, scenario)
+		})
+	}
+}
+
+// runRecorderCase executes one flagTB-style case body (flags, content_shapes)
+// against a fresh env, converting recorded failures into a CLI TestResult.
+// Scenario carries the case's short name so the CLI table (which shows the
+// Scenario column, not Name) distinguishes the rows; Name keeps the section
+// prefix.
+func runRecorderCase(name, scenario string, run func(flagTB, *TestEnv)) TestResult {
+	res := TestResult{Name: name, Scenario: scenario}
+	start := time.Now()
+
+	env, err := NewTestEnvForCLI()
+	if err != nil {
+		res.Errors = []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("create test env: %v", err)}}
+		res.Duration = time.Since(start)
+		return res
+	}
+	defer env.Close()
+
+	rec := &flagRecorder{}
+	func() {
+		defer func() {
+			rec.runCleanups()
+			if r := recover(); r != nil && r != flagAbort {
+				panic(r)
+			}
+		}()
+		run(rec, env)
+	}()
+
+	res.Errors = rec.errs
+	res.Passed = len(rec.errs) == 0
+	res.Duration = time.Since(start)
+	return res
+}

--- a/internal/protocoltest/section.go
+++ b/internal/protocoltest/section.go
@@ -3,9 +3,10 @@ package protocoltest
 import (
 	"fmt"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // This file holds the shared drivers behind the matrix's sections
@@ -23,6 +24,15 @@ type scenarioCombo struct {
 	run  func(env *TestEnv) TestResult
 }
 
+// maxSectionParallelism bounds how many env-backed units (scenarios, recorder
+// cases) run concurrently, regardless of core count. Each unit boots a full
+// httptest.Server plus a SQLite-backed AppConfig (temp dir, listening socket,
+// several sqlite/WAL file descriptors) — that cost is I/O/fd/memory-bound,
+// not CPU-bound, so letting core count alone dictate how many run at once
+// would over-commit fd and memory limits on high-core machines (common on CI
+// runners) for no throughput benefit.
+const maxSectionParallelism = 8
+
 // sectionParallelism returns how many independent env-backed units (scenarios,
 // recorder cases) a CLI section may run concurrently. Two run modes force
 // sequential execution: --batch measures per-request timing (parallel load
@@ -32,32 +42,25 @@ func (m *Matrix) sectionParallelism() int {
 	if m.BatchCount > 1 || m.RecordDir != "" {
 		return 1
 	}
-	return runtime.GOMAXPROCS(0)
+	if procs := runtime.GOMAXPROCS(0); procs < maxSectionParallelism {
+		return procs
+	}
+	return maxSectionParallelism
 }
 
-// runIndexed runs fn(0..n-1) with at most parallelism concurrent calls,
-// sequentially when parallelism <= 1. Callers write results into
-// index-addressed slots, so output order stays deterministic regardless of
-// completion order.
+// runIndexed runs fn(0..n-1) with at most parallelism concurrent calls.
+// Callers write results into index-addressed slots, so output order stays
+// deterministic regardless of completion order or scheduling.
 func runIndexed(n, parallelism int, fn func(i int)) {
-	if parallelism <= 1 {
-		for i := 0; i < n; i++ {
-			fn(i)
-		}
-		return
-	}
-	sem := make(chan struct{}, parallelism)
-	var wg sync.WaitGroup
+	var g errgroup.Group
+	g.SetLimit(parallelism)
 	for i := 0; i < n; i++ {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
-			defer func() { <-sem }()
+		g.Go(func() error {
 			fn(i)
-		}()
+			return nil
+		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 }
 
 // executePerScenario is the shared CLI-side driver for sections that provision
@@ -99,12 +102,7 @@ func (m *Matrix) executeScenarioCombos(scenario Scenario, combosFor func(Scenari
 	env, err := NewTestEnvForCLI(m.testEnvOpts()...)
 	if err != nil {
 		for _, c := range combos {
-			r := c.meta
-			r.Errors = []AssertionError{{
-				Assertion: "setup",
-				Error:     fmt.Sprintf("failed to create test env: %v", err),
-			}}
-			results = append(results, r)
+			results = append(results, setupFailureResult(c.meta, err))
 		}
 		return results
 	}
@@ -114,6 +112,17 @@ func (m *Matrix) executeScenarioCombos(scenario Scenario, combosFor func(Scenari
 		results = append(results, c.run(env))
 	}
 	return results
+}
+
+// setupFailureResult returns base with its Errors set to a single "setup"
+// AssertionError wrapping err — the result reported when the env itself
+// fails to boot, shared by the scenario-combo and recorder-case drivers.
+func setupFailureResult(base TestResult, err error) TestResult {
+	base.Errors = []AssertionError{{
+		Assertion: "setup",
+		Error:     fmt.Sprintf("failed to create test env: %v", err),
+	}}
+	return base
 }
 
 // runPerScenario is the testing.T counterpart of executePerScenario: one env
@@ -168,7 +177,7 @@ func runRecorderCase(name, scenario string, run func(flagTB, *TestEnv)) TestResu
 
 	env, err := NewTestEnvForCLI()
 	if err != nil {
-		res.Errors = []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("create test env: %v", err)}}
+		res = setupFailureResult(res, err)
 		res.Duration = time.Since(start)
 		return res
 	}

--- a/internal/protocoltest/section.go
+++ b/internal/protocoltest/section.go
@@ -2,6 +2,8 @@ package protocoltest
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 )
@@ -9,7 +11,8 @@ import (
 // This file holds the shared drivers behind the matrix's sections
 // (single-hop, transitive, idempotent, flags, content_shapes). Each section
 // contributes only its combos and per-combo execution; the env-per-scenario
-// lifecycle, setup-failure fan-out, and testing.T scaffolding live here once.
+// lifecycle, setup-failure fan-out, parallelism, and testing.T scaffolding
+// live here once.
 
 // scenarioCombo is one runnable cell within a per-scenario section: the
 // TestResult metadata that identifies it plus the function that executes it
@@ -20,37 +23,95 @@ type scenarioCombo struct {
 	run  func(env *TestEnv) TestResult
 }
 
+// sectionParallelism returns how many independent env-backed units (scenarios,
+// recorder cases) a CLI section may run concurrently. Two run modes force
+// sequential execution: --batch measures per-request timing (parallel load
+// would skew min/avg/max), and --record-dir captures request/response traffic
+// for replay (concurrent runs would interleave recordings).
+func (m *Matrix) sectionParallelism() int {
+	if m.BatchCount > 1 || m.RecordDir != "" {
+		return 1
+	}
+	return runtime.GOMAXPROCS(0)
+}
+
+// runIndexed runs fn(0..n-1) with at most parallelism concurrent calls,
+// sequentially when parallelism <= 1. Callers write results into
+// index-addressed slots, so output order stays deterministic regardless of
+// completion order.
+func runIndexed(n, parallelism int, fn func(i int)) {
+	if parallelism <= 1 {
+		for i := 0; i < n; i++ {
+			fn(i)
+		}
+		return
+	}
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fn(i)
+		}()
+	}
+	wg.Wait()
+}
+
 // executePerScenario is the shared CLI-side driver for sections that provision
-// one TestEnv per scenario (single-hop, transitive, idempotent). Routes are
-// keyed by (source, target, scenario), so combos within a scenario cannot
-// interfere and env boots stay off the hot path. When env creation fails,
-// every combo is reported as a setup failure so a broken environment surfaces
-// per-combination in the results table.
+// one TestEnv per scenario (single-hop, transitive, idempotent). Scenarios are
+// fully independent (each gets its own env), so they run concurrently up to
+// sectionParallelism; combos within a scenario share the env and run
+// sequentially. Results are assembled in scenario order, so the output is
+// identical to a sequential run (modulo durations).
 func (m *Matrix) executePerScenario(skipScenario func(Scenario) bool, combosFor func(Scenario) []scenarioCombo) []TestResult {
+	var scenarios []Scenario
+	for _, s := range m.Scenarios {
+		if skipScenario != nil && skipScenario(s) {
+			continue
+		}
+		scenarios = append(scenarios, s)
+	}
+
+	perScenario := make([][]TestResult, len(scenarios))
+	runIndexed(len(scenarios), m.sectionParallelism(), func(i int) {
+		perScenario[i] = m.executeScenarioCombos(scenarios[i], combosFor)
+	})
+
 	var results []TestResult
-	for _, scenario := range m.Scenarios {
-		if skipScenario != nil && skipScenario(scenario) {
-			continue
-		}
-		combos := combosFor(scenario)
+	for _, rs := range perScenario {
+		results = append(results, rs...)
+	}
+	return results
+}
 
-		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
-		if err != nil {
-			for _, c := range combos {
-				r := c.meta
-				r.Errors = []AssertionError{{
-					Assertion: "setup",
-					Error:     fmt.Sprintf("failed to create test env: %v", err),
-				}}
-				results = append(results, r)
-			}
-			continue
-		}
+// executeScenarioCombos runs one scenario's combos against a fresh env.
+// Routes are keyed by (source, target, scenario), so combos within a scenario
+// cannot interfere and env boots stay off the hot path. When env creation
+// fails, every combo is reported as a setup failure so a broken environment
+// surfaces per-combination in the results table.
+func (m *Matrix) executeScenarioCombos(scenario Scenario, combosFor func(Scenario) []scenarioCombo) []TestResult {
+	combos := combosFor(scenario)
+	results := make([]TestResult, 0, len(combos))
 
+	env, err := NewTestEnvForCLI(m.testEnvOpts()...)
+	if err != nil {
 		for _, c := range combos {
-			results = append(results, c.run(env))
+			r := c.meta
+			r.Errors = []AssertionError{{
+				Assertion: "setup",
+				Error:     fmt.Sprintf("failed to create test env: %v", err),
+			}}
+			results = append(results, r)
 		}
-		env.Close()
+		return results
+	}
+	defer env.Close()
+
+	for _, c := range combos {
+		results = append(results, c.run(env))
 	}
 	return results
 }
@@ -79,11 +140,28 @@ func (m *Matrix) runPerScenario(t *testing.T, skipScenario func(Scenario) bool, 
 	}
 }
 
-// runRecorderCase executes one flagTB-style case body (flags, content_shapes)
-// against a fresh env, converting recorded failures into a CLI TestResult.
-// Scenario carries the case's short name so the CLI table (which shows the
-// Scenario column, not Name) distinguishes the rows; Name keeps the section
-// prefix.
+// recorderCase is one flagTB-style case body (flags, content_shapes): a
+// section-prefixed result name, the short case name shown in the CLI table's
+// Scenario column, and the case body itself.
+type recorderCase struct {
+	name     string
+	scenario string
+	run      func(flagTB, *TestEnv)
+}
+
+// runRecorderCases executes recorder cases with bounded parallelism — each
+// case boots its own env, so cases are fully independent — assembling results
+// in case order.
+func (m *Matrix) runRecorderCases(cases []recorderCase) []TestResult {
+	results := make([]TestResult, len(cases))
+	runIndexed(len(cases), m.sectionParallelism(), func(i int) {
+		results[i] = runRecorderCase(cases[i].name, cases[i].scenario, cases[i].run)
+	})
+	return results
+}
+
+// runRecorderCase executes one flagTB-style case body against a fresh env,
+// converting recorded failures into a CLI TestResult.
 func runRecorderCase(name, scenario string, run func(flagTB, *TestEnv)) TestResult {
 	res := TestResult{Name: name, Scenario: scenario}
 	start := time.Now()

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -80,6 +80,46 @@ func NewTestEnvOptionWithClient(c Client) TestEnvOption {
 	}
 }
 
+// enterpriseKeyPair holds a generated key pair's PEM encoding.
+// sync.OnceValues only returns two values, so the pair rides in one struct
+// alongside the error.
+type enterpriseKeyPair struct {
+	private, public []byte
+}
+
+// preseedKeys generates one RSA-2048 enterprise-context key pair per process
+// and reuses it for every harness env. Generation is the expensive part
+// (~100-600ms of prime search); the harness boots one env per scenario per
+// section, so paying that cost once instead of per-env is the whole point.
+// Deliberately process-cached and shared: the key never leaves the process's
+// own temp dirs, and no harness assertion depends on envs having distinct
+// keys.
+var preseedKeys = sync.OnceValues(func() (enterpriseKeyPair, error) {
+	private, public, err := serverconfig.GenerateEnterpriseContextPEMs()
+	return enterpriseKeyPair{private, public}, err
+})
+
+// preseedEnterpriseContextKeys writes the process-cached key pair into
+// configDir's enterprise-context key slots, so config creation
+// (ensureEnterpriseContextRS256KeyPair) finds them already on disk and skips
+// generating its own. configDir is always a just-created os.MkdirTemp result
+// here, so the slots are never already populated — no existence check needed.
+//
+// This lives in the harness, not internal/server/config: it exists purely to
+// amortize a cost the harness's "one fresh config dir per env" pattern
+// creates, and production configs never call it (they generate once and
+// reuse the key from disk). internal/server/config only exports the generic
+// generate/write/path primitives; the caching policy is harness-only
+// knowledge.
+func preseedEnterpriseContextKeys(configDir string) error {
+	keys, err := preseedKeys()
+	if err != nil {
+		return err
+	}
+	privatePath, publicPath := serverconfig.EnterpriseContextKeyPaths(configDir)
+	return serverconfig.WriteEnterpriseContextKeys(privatePath, publicPath, keys.private, keys.public)
+}
+
 // gatewayCore is the shared skeleton every single-process harness env builds
 // on: a temp config dir, an app config, a real gateway httptest.Server, and a
 // VirtualServer mock provider. TestEnv (matrix/flags) and AgentTestEnv
@@ -105,7 +145,7 @@ func newGatewayCore(dirPattern string, configure func(*config.AppConfig), server
 	// key generation is the single most expensive step of a config boot
 	// (~100-600ms of prime search), and the harness boots one env per scenario
 	// per section. Sharing one throwaway key across harness envs is deliberate.
-	if err := serverconfig.PreseedEnterpriseContextKeys(configDir); err != nil {
+	if err := preseedEnterpriseContextKeys(configDir); err != nil {
 		os.RemoveAll(configDir)
 		return nil, fmt.Errorf("preseed enterprise keys: %w", err)
 	}

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -94,6 +94,13 @@ type enterpriseKeyPair struct {
 // Deliberately process-cached and shared: the key never leaves the process's
 // own temp dirs, and no harness assertion depends on envs having distinct
 // keys.
+//
+// sync.OnceValues caches a generation failure permanently, not just the
+// success value — a transient rand.Reader/OS failure on the first call would
+// poison every env for the rest of the process, where previously each env
+// generated (and could fail) independently. Accepted: the only realistic
+// failure mode is entropy-source exhaustion, which isn't something a retry
+// would recover from either.
 var preseedKeys = sync.OnceValues(func() (enterpriseKeyPair, error) {
 	private, public, err := serverconfig.GenerateEnterpriseContextPEMs()
 	return enterpriseKeyPair{private, public}, err

--- a/internal/protocoltest/testenv.go
+++ b/internal/protocoltest/testenv.go
@@ -101,6 +101,15 @@ func newGatewayCore(dirPattern string, configure func(*config.AppConfig), server
 		return nil, fmt.Errorf("create temp config dir: %w", err)
 	}
 
+	// Pre-seed the enterprise-context RSA key pair from a process-level cache:
+	// key generation is the single most expensive step of a config boot
+	// (~100-600ms of prime search), and the harness boots one env per scenario
+	// per section. Sharing one throwaway key across harness envs is deliberate.
+	if err := serverconfig.PreseedEnterpriseContextKeys(configDir); err != nil {
+		os.RemoveAll(configDir)
+		return nil, fmt.Errorf("preseed enterprise keys: %w", err)
+	}
+
 	appConfig, err := config.NewAppConfig(config.WithConfigDir(configDir))
 	if err != nil {
 		os.RemoveAll(configDir)

--- a/internal/protocoltest/transitive.go
+++ b/internal/protocoltest/transitive.go
@@ -42,19 +42,13 @@ func (m *Matrix) DefaultChains() []TransitiveChain {
 	return chains
 }
 
-// skipTransitiveScenarios lists source+scenario combinations where the second
-// hop is known to fail (inherits from single-hop skip list).
+// skipTransitiveKey reports whether either hop of a chain is in the
+// single-hop known-defect list for the scenario.
 func skipTransitiveKey(chain TransitiveChain, scenarioName string) (string, bool) {
-	// Check both hops against the single-hop skip list
-	firstKey := fmt.Sprintf("%s|%s", chain.First.Source, scenarioName)
-	if reason, skip := skipSourceScenarios[firstKey]; skip {
+	if reason, skip := KnownDefectReason(chain.First.Source, scenarioName); skip {
 		return reason, true
 	}
-	secondKey := fmt.Sprintf("%s|%s", chain.Second.Source, scenarioName)
-	if reason, skip := skipSourceScenarios[secondKey]; skip {
-		return reason, true
-	}
-	return "", false
+	return KnownDefectReason(chain.Second.Source, scenarioName)
 }
 
 // RunTransitive executes two-hop transitive tests for all chains × scenarios
@@ -67,9 +61,8 @@ func skipTransitiveKey(chain TransitiveChain, scenarioName string) (string, bool
 // field that B→C needs, the results will diverge.
 //
 // Each chain runs the same executeTransitiveChain implementation the CLI
-// path uses; the testing.T layer only provisions one env per scenario (to
-// limit file descriptor usage — chains run sequentially within a scenario)
-// and reports the TestResult.
+// path uses; the testing.T layer (runPerScenario) only provisions one env per
+// scenario and reports the TestResult.
 func (m *Matrix) RunTransitive(t *testing.T) {
 	t.Helper()
 
@@ -78,30 +71,23 @@ func (m *Matrix) RunTransitive(t *testing.T) {
 		t.Skip("no transitive chains to test")
 	}
 
-	for _, scenario := range m.Scenarios {
-		if scenario.SkipTransitive {
-			continue
+	m.runPerScenario(t, skipTransitiveScenario, func(t *testing.T, env *TestEnv, scenario Scenario) {
+		for _, chain := range chains {
+			for _, streaming := range m.Streaming {
+				t.Run(fmt.Sprintf("%s/%s", chain, streamMode(streaming)), func(t *testing.T) {
+					result := m.executeTransitiveChain(env, scenario, chain, streaming)
+					reportTestResult(t, &result)
+				})
+			}
 		}
+	})
+}
 
-		t.Run(scenario.Name, func(t *testing.T) {
-			t.Parallel()
-
-			env, err := NewTestEnvForCLI(m.testEnvOpts()...)
-			if err != nil {
-				t.Fatalf("create test env: %v", err)
-			}
-			defer env.Close()
-
-			for _, chain := range chains {
-				for _, streaming := range m.Streaming {
-					t.Run(fmt.Sprintf("%s/%s", chain, streamMode(streaming)), func(t *testing.T) {
-						result := m.executeTransitiveChain(env, scenario, chain, streaming)
-						reportTestResult(t, &result)
-					})
-				}
-			}
-		})
-	}
+// skipTransitiveScenario is the scenario-level opt-out shared by the
+// transitive and idempotent sections: error / truncation scenarios produce no
+// comparable output across hops.
+func skipTransitiveScenario(s Scenario) bool {
+	return s.SkipTransitive
 }
 
 // normalizeJSON strips whitespace from a JSON string for comparison.
@@ -114,53 +100,38 @@ func normalizeJSON(s string) string {
 // It is the CLI-compatible counterpart of RunTransitive, returning []TestResult.
 // Name format: "scenario/A→B→C/mode".
 func (m *Matrix) ExecuteAllTransitive() []TestResult {
-	var results []TestResult
 	chains := m.DefaultChains()
-
-	for _, scenario := range m.Scenarios {
-		if scenario.SkipTransitive {
-			continue
-		}
-
-		env, err := NewTestEnvForCLI(m.testEnvOpts()...)
-		if err != nil {
-			for _, chain := range chains {
-				for _, streaming := range m.Streaming {
-					results = append(results, TestResult{
-						Name:      chain.TestName(scenario.Name, streaming),
-						Scenario:  scenario.Name,
-						Source:    chain.First.Source,
-						Target:    chain.Second.Target,
-						Streaming: streaming,
-						Passed:    false,
-						Errors:    []AssertionError{{Assertion: "setup", Error: fmt.Sprintf("failed to create test env: %v", err)}},
-					})
-				}
-			}
-			continue
-		}
-
+	return m.executePerScenario(skipTransitiveScenario, func(s Scenario) []scenarioCombo {
+		var combos []scenarioCombo
 		for _, chain := range chains {
 			for _, streaming := range m.Streaming {
-				result := m.executeTransitiveChain(env, scenario, chain, streaming)
-				results = append(results, result)
+				combos = append(combos, scenarioCombo{
+					meta: chain.baseResult(s.Name, streaming),
+					run: func(env *TestEnv) TestResult {
+						return m.executeTransitiveChain(env, s, chain, streaming)
+					},
+				})
 			}
 		}
-		env.Close()
+		return combos
+	})
+}
+
+// baseResult returns a TestResult pre-filled with the fields that identify
+// this chain in a given scenario/mode.
+func (c TransitiveChain) baseResult(scenarioName string, streaming bool) TestResult {
+	return TestResult{
+		Name:      c.TestName(scenarioName, streaming),
+		Scenario:  scenarioName,
+		Source:    c.First.Source,
+		Target:    c.Second.Target,
+		Streaming: streaming,
 	}
-	return results
 }
 
 // executeTransitiveChain runs a single two-hop chain for a given scenario/mode.
 func (m *Matrix) executeTransitiveChain(env *TestEnv, scenario Scenario, chain TransitiveChain, streaming bool) TestResult {
-	name := chain.TestName(scenario.Name, streaming)
-	base := TestResult{
-		Name:      name,
-		Scenario:  scenario.Name,
-		Source:    chain.First.Source,
-		Target:    chain.Second.Target,
-		Streaming: streaming,
-	}
+	base := chain.baseResult(scenario.Name, streaming)
 
 	if reason, skip := skipTransitiveKey(chain, scenario.Name); skip {
 		base.Skipped = true

--- a/internal/server/config/enterprise.go
+++ b/internal/server/config/enterprise.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 )
 
 type EnterpriseContextPublicKey struct {
@@ -29,14 +28,19 @@ type EnterpriseContextJWTConfig struct {
 	RequireJTI        bool                         `json:"require_jti" yaml:"require_jti"`
 }
 
-func enterpriseContextKeyPaths(configDir string) (string, string) {
+// EnterpriseContextKeyPaths returns the on-disk paths for a config dir's
+// enterprise-context RS256 key pair. Exported so callers that need to
+// provision or inspect the key slots directly (e.g. a harness pre-seeding
+// key material — see internal/protocoltest) don't have to reimplement the
+// layout.
+func EnterpriseContextKeyPaths(configDir string) (string, string) {
 	keyDir := filepath.Join(configDir, "keys")
 	return filepath.Join(keyDir, "enterprise_context_rs256_private.pem"),
 		filepath.Join(keyDir, "enterprise_context_rs256_public.pem")
 }
 
 func ensureEnterpriseContextRS256KeyPair(configDir string) (string, string, error) {
-	privatePath, publicPath := enterpriseContextKeyPaths(configDir)
+	privatePath, publicPath := EnterpriseContextKeyPaths(configDir)
 	privateOK := false
 	publicOK := false
 	if st, err := os.Stat(privatePath); err == nil && !st.IsDir() {
@@ -49,19 +53,23 @@ func ensureEnterpriseContextRS256KeyPair(configDir string) (string, string, erro
 		return "file:" + privatePath, "file:" + publicPath, nil
 	}
 
-	privatePEM, publicPEM, err := generateEnterpriseContextPEMs()
+	privatePEM, publicPEM, err := GenerateEnterpriseContextPEMs()
 	if err != nil {
 		return "", "", err
 	}
-	if err := writeEnterpriseContextKeys(privatePath, publicPath, privatePEM, publicPEM); err != nil {
+	if err := WriteEnterpriseContextKeys(privatePath, publicPath, privatePEM, publicPEM); err != nil {
 		return "", "", err
 	}
 	return "file:" + privatePath, "file:" + publicPath, nil
 }
 
-// generateEnterpriseContextPEMs generates a fresh RSA-2048 key pair and
-// returns it PEM-encoded (private PKCS1, public PKIX).
-func generateEnterpriseContextPEMs() (privatePEM, publicPEM []byte, err error) {
+// GenerateEnterpriseContextPEMs generates a fresh RSA-2048 key pair and
+// returns it PEM-encoded (private PKCS1, public PKIX). Exported alongside
+// WriteEnterpriseContextKeys so a caller that needs to provision key material
+// ahead of config creation (e.g. a harness pre-seeding many config dirs from
+// one generated pair — see internal/protocoltest) can reuse the exact same
+// generation/encoding logic ensureEnterpriseContextRS256KeyPair uses.
+func GenerateEnterpriseContextPEMs() (privatePEM, publicPEM []byte, err error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate rsa key failed: %w", err)
@@ -81,8 +89,9 @@ func generateEnterpriseContextPEMs() (privatePEM, publicPEM []byte, err error) {
 	return privatePEM, publicPEM, nil
 }
 
-// writeEnterpriseContextKeys writes a PEM key pair into configDir's key slots.
-func writeEnterpriseContextKeys(privatePath, publicPath string, privatePEM, publicPEM []byte) error {
+// WriteEnterpriseContextKeys writes a PEM key pair into configDir's key slots
+// (see EnterpriseContextKeyPaths).
+func WriteEnterpriseContextKeys(privatePath, publicPath string, privatePEM, publicPEM []byte) error {
 	if err := os.MkdirAll(filepath.Dir(privatePath), 0700); err != nil {
 		return fmt.Errorf("create enterprise key dir failed: %w", err)
 	}
@@ -93,34 +102,4 @@ func writeEnterpriseContextKeys(privatePath, publicPath string, privatePEM, publ
 		return fmt.Errorf("write enterprise public key failed: %w", err)
 	}
 	return nil
-}
-
-var (
-	preseedKeyOnce sync.Once
-	preseedPrivate []byte
-	preseedPublic  []byte
-	preseedErr     error
-)
-
-// PreseedEnterpriseContextKeys writes a process-cached RSA-2048 key pair into
-// configDir's enterprise-context key slots, so that config creation skips the
-// expensive per-directory key generation (~100-600ms of prime search).
-//
-// Intended for test harnesses that boot many fresh config dirs in one process
-// — the generated key never leaves the process's temp dirs and every harness
-// env sharing one throwaway key is deliberate. A no-op if the slots already
-// hold keys. Production configs never call this: they generate once and reuse
-// the key from disk.
-func PreseedEnterpriseContextKeys(configDir string) error {
-	privatePath, publicPath := enterpriseContextKeyPaths(configDir)
-	if _, err := os.Stat(privatePath); err == nil {
-		return nil
-	}
-	preseedKeyOnce.Do(func() {
-		preseedPrivate, preseedPublic, preseedErr = generateEnterpriseContextPEMs()
-	})
-	if preseedErr != nil {
-		return preseedErr
-	}
-	return writeEnterpriseContextKeys(privatePath, publicPath, preseedPrivate, preseedPublic)
 }

--- a/internal/server/config/enterprise.go
+++ b/internal/server/config/enterprise.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 type EnterpriseContextPublicKey struct {
@@ -48,30 +49,78 @@ func ensureEnterpriseContextRS256KeyPair(configDir string) (string, string, erro
 		return "file:" + privatePath, "file:" + publicPath, nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(privatePath), 0700); err != nil {
-		return "", "", fmt.Errorf("create enterprise key dir failed: %w", err)
+	privatePEM, publicPEM, err := generateEnterpriseContextPEMs()
+	if err != nil {
+		return "", "", err
 	}
+	if err := writeEnterpriseContextKeys(privatePath, publicPath, privatePEM, publicPEM); err != nil {
+		return "", "", err
+	}
+	return "file:" + privatePath, "file:" + publicPath, nil
+}
+
+// generateEnterpriseContextPEMs generates a fresh RSA-2048 key pair and
+// returns it PEM-encoded (private PKCS1, public PKIX).
+func generateEnterpriseContextPEMs() (privatePEM, publicPEM []byte, err error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return "", "", fmt.Errorf("generate rsa key failed: %w", err)
+		return nil, nil, fmt.Errorf("generate rsa key failed: %w", err)
 	}
-	privatePEM := pem.EncodeToMemory(&pem.Block{
+	privatePEM = pem.EncodeToMemory(&pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 	pubDer, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 	if err != nil {
-		return "", "", fmt.Errorf("marshal rsa public key failed: %w", err)
+		return nil, nil, fmt.Errorf("marshal rsa public key failed: %w", err)
 	}
-	publicPEM := pem.EncodeToMemory(&pem.Block{
+	publicPEM = pem.EncodeToMemory(&pem.Block{
 		Type:  "PUBLIC KEY",
 		Bytes: pubDer,
 	})
+	return privatePEM, publicPEM, nil
+}
+
+// writeEnterpriseContextKeys writes a PEM key pair into configDir's key slots.
+func writeEnterpriseContextKeys(privatePath, publicPath string, privatePEM, publicPEM []byte) error {
+	if err := os.MkdirAll(filepath.Dir(privatePath), 0700); err != nil {
+		return fmt.Errorf("create enterprise key dir failed: %w", err)
+	}
 	if err := os.WriteFile(privatePath, privatePEM, 0600); err != nil {
-		return "", "", fmt.Errorf("write enterprise private key failed: %w", err)
+		return fmt.Errorf("write enterprise private key failed: %w", err)
 	}
 	if err := os.WriteFile(publicPath, publicPEM, 0644); err != nil {
-		return "", "", fmt.Errorf("write enterprise public key failed: %w", err)
+		return fmt.Errorf("write enterprise public key failed: %w", err)
 	}
-	return "file:" + privatePath, "file:" + publicPath, nil
+	return nil
+}
+
+var (
+	preseedKeyOnce sync.Once
+	preseedPrivate []byte
+	preseedPublic  []byte
+	preseedErr     error
+)
+
+// PreseedEnterpriseContextKeys writes a process-cached RSA-2048 key pair into
+// configDir's enterprise-context key slots, so that config creation skips the
+// expensive per-directory key generation (~100-600ms of prime search).
+//
+// Intended for test harnesses that boot many fresh config dirs in one process
+// — the generated key never leaves the process's temp dirs and every harness
+// env sharing one throwaway key is deliberate. A no-op if the slots already
+// hold keys. Production configs never call this: they generate once and reuse
+// the key from disk.
+func PreseedEnterpriseContextKeys(configDir string) error {
+	privatePath, publicPath := enterpriseContextKeyPaths(configDir)
+	if _, err := os.Stat(privatePath); err == nil {
+		return nil
+	}
+	preseedKeyOnce.Do(func() {
+		preseedPrivate, preseedPublic, preseedErr = generateEnterpriseContextPEMs()
+	})
+	if preseedErr != nil {
+		return preseedErr
+	}
+	return writeEnterpriseContextKeys(privatePath, publicPath, preseedPrivate, preseedPublic)
 }


### PR DESCRIPTION
## Summary

`internal/protocoltest`'s CLI matrix (`cli/harness matrix`) had five sections — single-hop, transitive, idempotent, flags, content_shapes — each re-implementing the same env-per-scenario/case scaffolding, and the CLI's `--mode` dispatch was a manually-maintained if-chain. On top of that, the CLI path was slow: ~15s for a default run, ~41s for `--mode=all`.

- **Extract shared section drivers** (`internal/protocoltest/section.go`): `executePerScenario`/`runPerScenario` own the env-per-scenario lifecycle (setup-failure fan-out, parallelism, testing.T scaffolding) once; each section now only declares its combos. `cli/harness/matrix.go`'s `--mode` dispatch becomes a data-driven `matrixSections` registry (name, modes, http-only constraint, executor) instead of a hand-maintained if-chain.
- **Perf**: profiling showed most CLI wall time was outside test execution — env boot, not request handling. Two fixes:
  - Pre-seed a process-cached RSA-2048 key pair into every harness env instead of paying `crypto/rsa.GenerateKey`'s ~100-600ms prime search per env (harness boots ~20 envs per run). Kept out of `internal/server/config` (ships in the production binary) — that package only exports the generic generate/write/path primitives it already used internally; the harness-only caching policy lives in `internal/protocoltest`.
  - Parallelize independent scenarios/cases up to `min(GOMAXPROCS, 8)` via `golang.org/x/sync/errgroup`, mirroring the `t.Parallel()` the go-test entry points already had. Capped rather than raw `GOMAXPROCS` since each unit boots a full `httptest.Server` + SQLite-backed config — an fd/memory cost, not a CPU one.
- **Review pass**: ran `/simplify` (reuse/simplification/efficiency/altitude, 4 parallel passes) plus an independent correctness review over the above; applied every finding worth fixing (see commit messages for the reasoning on each) and documented one accepted trade-off (`sync.OnceValues` caches a keygen failure permanently for the process — acceptable since the only realistic failure mode, entropy exhaustion, isn't retry-recoverable anyway).

## Results (4-core machine)

| | before | after |
|---|---|---|
| `matrix` (default) | ~15s | ~3s |
| `matrix --mode=all` | ~41s | ~8s |
| `matrix --mode=flags` | ~5s | ~1s |
| e2e go test (`TestHarness` + idempotent/flags/content_shapes) | ~60s | ~17s |

Behavior is unchanged throughout: normalized `--json` output is byte-identical to pre-refactor across all seven `--mode` values (verified by diffing before/after runs), and `-race` is clean on `--mode=all`.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/protocoltest/... ./internal/server/config/... ./cli/harness/...`
- [x] `go test -tags e2e ./internal/protocoltest/... -run 'TestHarness$|TestIdempotent$|TestContentShapes|TestRuleFlags'`
- [x] `--json` output diffed byte-for-byte (name/scenario/source/target/streaming/status) against pre-refactor across `--mode={default,all,single,transitive,idempotent,flags,content_shapes}`
- [x] `go build -race` + `matrix --mode=all` run clean, zero data races
- [x] `.design/harness-matrix.md` updated to document the section-driver architecture and the perf changes

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01H5tX87SHvPT1y1D2MWjg5U