### PR TITLE
fix(config): scenario modals preserve applied settings across reopen and 1M toggle

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2668,6 +2668,15 @@ export const handlers = [
         })
     }),
 
+    http.get('/api/v1/config/codex', () => {
+        return HttpResponse.json({
+            success: true,
+            exists: true,
+            preferences: { model_reasoning_effort: 'high' },
+            writeCatalog: true,
+        })
+    }),
+
     http.get('/api/v1/scenario/:scenario/profiles', ({ params }) => {
         const { scenario } = params as { scenario: string }
         if (scenario === 'claude_code') {

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -138,33 +138,32 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
             return;
         }
 
-        // A pending routing 1M change must preview the rule's new generated
-        // values. It intentionally takes precedence over the persisted model
-        // slots for this apply operation.
-        if (pendingContext1MChange != null) {
-            const tempRules = rules.map(rule => {
-                if (pendingContext1MChange.ruleUuid && rule.uuid !== pendingContext1MChange.ruleUuid) {
-                    return rule;
-                }
-                return {
-                    ...rule,
-                    flags: {
-                        ...rule.flags,
-                        context1m: pendingContext1MChange.enabled,
-                    },
-                };
-            });
-            setPrefs(derivePrefsFromRules({ rules: tempRules, mode: configMode }));
-            setIsConfigLoading(false);
-            return;
-        }
+        // A pending routing 1M change previews the rule's new model slots
+        // (with the [1m] suffix applied). It must NOT discard the user's other
+        // applied prefs (max tokens, timeout, privacy switches): those are
+        // restored exactly as on a normal open, then the model slots + the
+        // 1M-driven auto-compact window are overlaid from the rule-derived
+        // generated prefs. So we still fetch the applied config here and merge
+        // via restoreAppliedClaudeCodePrefs — only the `generated` input differs.
+        const tempRules = pendingContext1MChange == null ? rules : rules.map(rule => {
+            if (pendingContext1MChange.ruleUuid && rule.uuid !== pendingContext1MChange.ruleUuid) {
+                return rule;
+            }
+            return {
+                ...rule,
+                flags: {
+                    ...rule.flags,
+                    context1m: pendingContext1MChange.enabled,
+                },
+            };
+        });
+        const generated = derivePrefsFromRules({ rules: tempRules, mode: configMode });
 
         let active = true;
         setIsConfigLoading(true);
         void api.getAppliedClaudeConfig().then(result => {
             if (!active) return;
             if (result?.success && result.exists) {
-                const generated = derivePrefsFromRules({ rules, mode: configMode });
                 setPrefs(restoreAppliedClaudeCodePrefs({
                     generated,
                     applied: result.preferences || {},
@@ -172,7 +171,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
                 setDefaultMode((result.defaultMode || 'acceptEdits') as ClaudeCodeDefaultMode);
                 setInstallStatusLine(!!result.installStatusLine);
             } else {
-                setPrefs(derivePrefsFromRules({ rules, mode: configMode }));
+                setPrefs(generated);
                 setDefaultMode('acceptEdits');
                 setInstallStatusLine(true);
                 if (result?.success === false) {

--- a/frontend/src/pages/scenario/components/CodexConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/CodexConfigModal.tsx
@@ -87,6 +87,12 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     // ~/.codex/config.toml; first-time users (nothing applied yet) fall back to
     // defaults. Mirrors ClaudeCodeConfigModal's open-effect hydration so the
     // form no longer resets the user's last applied values on every open.
+    //
+    // pendingContext1MChange is in the deps so reopening after a 1M toggle
+    // re-hydrates fresh state, but it does NOT branch the body: Codex's 1M
+    // setting only affects the catalog's context window (generated at preview
+    // time), never the reasoning prefs edited here — so a 1M toggle must not
+    // skip the applied-config readback the way it used to.
     React.useEffect(() => {
         if (!open) {
             setPrefs(defaultCodexPrefs());
@@ -114,7 +120,7 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
         return () => {
             active = false;
         };
-    }, [open]);
+    }, [open, pendingContext1MChange]);
 
     // Fetch Codex OAuth providers only when the picker is actually shown (direct
     // or hybrid) — no network cost for the default gateway path. Direct mode

--- a/frontend/src/pages/scenario/components/CodexConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/CodexConfigModal.tsx
@@ -2,7 +2,7 @@ import { Alert, Box, Button, Checkbox, CircularProgress, Dialog, DialogActions, 
 import React from 'react';
 import { InfoOutlined, RestartAlt } from '@/components/icons';
 import CodeBlock from '@/components/CodeBlock';
-import CodexQuickConfig, { type CodexPrefs, defaultCodexPrefs } from './CodexQuickConfig';
+import CodexQuickConfig, { type CodexPrefs, defaultCodexPrefs, mergeSavedCodexPrefs } from './CodexQuickConfig';
 import Context1MChangeBanner from './Context1MChangeBanner';
 import { shouldIgnoreDialogClose } from '@/components/dialogClose';
 import { api } from '@/services/api';
@@ -75,16 +75,45 @@ const CodexConfigModal: React.FC<CodexConfigModalProps> = ({
     const [catalogJson, setCatalogJson] = React.useState<string>('');
     const [previewModels, setPreviewModels] = React.useState<string[]>([]);
 
+    // True while the applied-config readback is in flight, so the Quick tab
+    // can show a spinner instead of flashing the defaults before the saved
+    // values land. Mirrors ClaudeCodeConfigModal's isConfigLoading.
+    const [isConfigLoading, setIsConfigLoading] = React.useState(false);
+
     // Apply configuration state
     const [isApplying, setIsApplying] = React.useState(false);
 
-    // Seed defaults on open.
+    // On open, restore the prefs/writeCatalog previously applied to
+    // ~/.codex/config.toml; first-time users (nothing applied yet) fall back to
+    // defaults. Mirrors ClaudeCodeConfigModal's open-effect hydration so the
+    // form no longer resets the user's last applied values on every open.
     React.useEffect(() => {
-        if (!open) return;
-        setPrefs(defaultCodexPrefs());
-        setAuthMode('apikey');
-        setSelectedOAuthProvider('');
-        setCodexOAuthProviders([]);
+        if (!open) {
+            setPrefs(defaultCodexPrefs());
+            setWriteCatalog(true);
+            setAuthMode('apikey');
+            setSelectedOAuthProvider('');
+            setCodexOAuthProviders([]);
+            setIsConfigLoading(false);
+            return;
+        }
+        let active = true;
+        setIsConfigLoading(true);
+        void api.getAppliedCodexConfig().then(result => {
+            if (!active) return;
+            if (result?.success && result.exists) {
+                setPrefs(mergeSavedCodexPrefs(result.preferences || {}));
+                setWriteCatalog(result.writeCatalog !== false);
+            } else {
+                setPrefs(defaultCodexPrefs());
+                setWriteCatalog(true);
+            }
+        }).finally(() => {
+            if (active) setIsConfigLoading(false);
+        });
+        return () => {
+            active = false;
+        };
     }, [open]);
 
     // Fetch Codex OAuth providers only when the picker is actually shown (direct
@@ -417,7 +446,13 @@ EOF`;
                         </FormControl>
                     </Box>
                 )}
-                {authMode !== 'chatgpt' && mainTab === 'quick' && (
+                {authMode !== 'chatgpt' && mainTab === 'quick' && isConfigLoading && (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+                        <CircularProgress size={28} />
+                    </Box>
+                )}
+
+                {authMode !== 'chatgpt' && mainTab === 'quick' && !isConfigLoading && (
                     <CodexQuickConfig
                         prefs={prefs}
                         setPrefs={setPrefs}

--- a/frontend/src/pages/scenario/components/CodexQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/CodexQuickConfig.tsx
@@ -29,22 +29,32 @@ export function defaultCodexPrefs(): CodexPrefs {
     return { model_reasoning_effort: 'medium' };
 }
 
+// CODEX_PREF_KEYS is the single source of truth for the durable Codex pref
+// keys on the frontend (mirrors MODEL_SLOT_KEYS in claudeCodePrefsState.ts and
+// the backend CodexPrefs struct). Adding a key is one entry here, typed against
+// keyof CodexPrefs so an omission or typo is a compile error.
+const CODEX_PREF_KEYS = [
+    'model_reasoning_effort',
+    'model_reasoning_summary',
+    'model_verbosity',
+    'model_supports_reasoning_summaries',
+] as const satisfies readonly (keyof CodexPrefs)[];
+
 // Merge a previously-applied prefs object over the current defaults so
 // reopening the Codex config modal restores durable user choices rather than
-// resetting to defaults every time. Only the four whitelisted keys are
-// considered; anything else on `applied` is ignored. Undefined fields on
-// `applied` defer to `defaults`, matching the backend's "empty = omit" stance.
+// resetting to defaults every time. Empty values on `applied` defer to the
+// default (Codex treats "" as "omit, use built-in default").
 //
 // Unlike Claude Code (where model slots must always come from routing rules),
 // Codex has no routing-derived prefs, so a plain shallow merge is correct.
 export function mergeSavedCodexPrefs(applied: CodexPrefs = {}): CodexPrefs {
     const merged: CodexPrefs = { ...defaultCodexPrefs() };
-    (['model_reasoning_effort', 'model_reasoning_summary', 'model_verbosity', 'model_supports_reasoning_summaries'] as const).forEach((key) => {
+    for (const key of CODEX_PREF_KEYS) {
         const v = applied[key];
         if (v !== undefined && v !== '') {
             merged[key] = v;
         }
-    });
+    }
     return merged;
 }
 

--- a/frontend/src/pages/scenario/components/CodexQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/CodexQuickConfig.tsx
@@ -29,6 +29,25 @@ export function defaultCodexPrefs(): CodexPrefs {
     return { model_reasoning_effort: 'medium' };
 }
 
+// Merge a previously-applied prefs object over the current defaults so
+// reopening the Codex config modal restores durable user choices rather than
+// resetting to defaults every time. Only the four whitelisted keys are
+// considered; anything else on `applied` is ignored. Undefined fields on
+// `applied` defer to `defaults`, matching the backend's "empty = omit" stance.
+//
+// Unlike Claude Code (where model slots must always come from routing rules),
+// Codex has no routing-derived prefs, so a plain shallow merge is correct.
+export function mergeSavedCodexPrefs(applied: CodexPrefs = {}): CodexPrefs {
+    const merged: CodexPrefs = { ...defaultCodexPrefs() };
+    (['model_reasoning_effort', 'model_reasoning_summary', 'model_verbosity', 'model_supports_reasoning_summaries'] as const).forEach((key) => {
+        const v = applied[key];
+        if (v !== undefined && v !== '') {
+            merged[key] = v;
+        }
+    });
+    return merged;
+}
+
 type PrefsKey = keyof CodexPrefs;
 type Kind = 'enum' | 'bool';
 type Lang = 'zh' | 'en';

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -502,6 +502,13 @@ export const api = {
         return controlApi((client, headers) => (client as any).GET('/api/v1/config/claude', {headers}));
     },
 
+    // Placeholder for the Codex applied-config endpoint. Uses the generated
+    // client's runtime transport; remove the casts after the next OpenAPI
+    // client regeneration includes this route.
+    getAppliedCodexConfig: async (): Promise<any> => {
+        return controlApi((client, headers) => (client as any).GET('/api/v1/config/codex', {headers}));
+    },
+
     getProfiles: async (scenario: string): Promise<any> => {
         return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}/profiles', {
             headers,

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1019,25 +1019,36 @@ func (p *CodexPrefs) toConfig() map[string]interface{} {
 	if p == nil {
 		return out
 	}
-	addEnum := func(key, val string) {
-		val = strings.TrimSpace(val)
-		if val == "" {
-			return
-		}
-		for _, allowed := range codexEnumValues[key] {
-			if val == allowed {
-				out[key] = val
-				return
-			}
+	setEnum := func(key, val string) {
+		if v, ok := codexEnumValue(key, val); ok {
+			out[key] = v
 		}
 	}
-	addEnum("model_reasoning_effort", p.ModelReasoningEffort)
-	addEnum("model_reasoning_summary", p.ModelReasoningSummary)
-	addEnum("model_verbosity", p.ModelVerbosity)
+	setEnum("model_reasoning_effort", p.ModelReasoningEffort)
+	setEnum("model_reasoning_summary", p.ModelReasoningSummary)
+	setEnum("model_verbosity", p.ModelVerbosity)
 	if strings.TrimSpace(p.ModelSupportsReasoningSummaries) == "true" {
 		out["model_supports_reasoning_summaries"] = true
 	}
 	return out
+}
+
+// codexEnumValue validates a value against the allowed set for an enum-typed
+// CodexPrefs key (see codexEnumValues). It returns the trimmed value and true
+// when it is a member, or ""/false otherwise (empty input also yields false).
+// Shared by toConfig (write) and CodexPrefsFromConfig (read) so the two stay
+// in lockstep — there is one definition of "what is a valid enum value".
+func codexEnumValue(key, val string) (string, bool) {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return "", false
+	}
+	for _, allowed := range codexEnumValues[key] {
+		if val == allowed {
+			return val, true
+		}
+	}
+	return "", false
 }
 
 // CodexPrefsFromConfig is the inverse of (*CodexPrefs).toConfig: it extracts
@@ -1049,45 +1060,27 @@ func (p *CodexPrefs) toConfig() map[string]interface{} {
 // fields into the prefs surface.
 func CodexPrefsFromConfig(cfg map[string]interface{}) *CodexPrefs {
 	prefs := &CodexPrefs{}
-	strVal := func(key string) (string, bool) {
-		v, ok := cfg[key]
-		if !ok {
-			return "", false
-		}
-		switch t := v.(type) {
-		case string:
-			return t, true
-		case bool:
-			if t {
-				return "true", true
-			}
-			return "", true
-		default:
-			// go-toml unmarshals integers/floats as int64/float64; reasoning
-			// keys are all string-valued, so non-string scalars are dropped.
-			return "", true
+	// Enum-typed keys: validate against codexEnumValues (shared with toConfig)
+	// so an out-of-set value is dropped rather than surfaced in the form.
+	if v, ok := cfg["model_reasoning_effort"].(string); ok {
+		if val, ok := codexEnumValue("model_reasoning_effort", v); ok {
+			prefs.ModelReasoningEffort = val
 		}
 	}
-	// Reuse codexEnumValues to validate the three enum-typed keys. A value
-	// outside the allowed set is dropped so a stale/mistyped config.toml
-	// cannot surface an invalid option in the form.
-	for _, key := range []string{
-		"model_reasoning_effort",
-		"model_reasoning_summary",
-		"model_verbosity",
-	} {
-		if val, ok := strVal(key); ok && val != "" {
-			for _, allowed := range codexEnumValues[key] {
-				if strings.TrimSpace(val) == allowed {
-					setCodexPrefField(prefs, key, allowed)
-					break
-				}
-			}
+	if v, ok := cfg["model_reasoning_summary"].(string); ok {
+		if val, ok := codexEnumValue("model_reasoning_summary", v); ok {
+			prefs.ModelReasoningSummary = val
+		}
+	}
+	if v, ok := cfg["model_verbosity"].(string); ok {
+		if val, ok := codexEnumValue("model_verbosity", v); ok {
+			prefs.ModelVerbosity = val
 		}
 	}
 	// model_supports_reasoning_summaries maps true -> "true"; anything else
 	// (false, missing, non-bool) leaves it unset, matching toConfig's stance
-	// that only an explicit "true" opts in.
+	// that only an explicit "true" opts in. Accept both a native TOML bool and
+	// the string form (older files / hand-edits).
 	if v, ok := cfg["model_supports_reasoning_summaries"]; ok {
 		if b, ok := v.(bool); ok && b {
 			prefs.ModelSupportsReasoningSummaries = "true"
@@ -1098,26 +1091,33 @@ func CodexPrefsFromConfig(cfg map[string]interface{}) *CodexPrefs {
 	return prefs
 }
 
-// setCodexPrefField assigns a validated enum value to the matching CodexPrefs
-// field by config.toml key name. It mirrors the key→field mapping in toConfig.
-func setCodexPrefField(p *CodexPrefs, key, val string) {
-	switch key {
-	case "model_reasoning_effort":
-		p.ModelReasoningEffort = val
-	case "model_reasoning_summary":
-		p.ModelReasoningSummary = val
-	case "model_verbosity":
-		p.ModelVerbosity = val
+// isTinglyManagedCodexConfig reports whether a parsed config.toml was written
+// by tingly-box. The reliable signals are an explicit
+// `model_provider = "tingly-box"` or a `[model_providers.tingly-box]` stanza.
+// The generic `model`/`model_catalog_json` keys are deliberately NOT signals —
+// a stock codex install always has `model`, so flagging on it would mark every
+// codex config as tingly-owned. Both ReadCodexConfig (read) and
+// ClearCodexGatewayConfig (mutate) route through this so the read/clear pair
+// cannot drift on what "tingly owns" means.
+func isTinglyManagedCodexConfig(cfg map[string]interface{}) bool {
+	if provider, ok := cfg["model_provider"].(string); ok && provider == codexGatewayProviderName {
+		return true
 	}
+	if providers, ok := cfg["model_providers"].(map[string]interface{}); ok {
+		if _, ok := providers[codexGatewayProviderName]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ReadCodexConfig reads ~/.codex/config.toml and returns the typed prefs, the
 // inferred writeCatalog state (true when model_catalog_json is set), and
 // whether a tingly-managed config exists. A missing or unparseable file yields
 // empty prefs, writeCatalog=false, exists=false. exists is true only when the
-// file carries the tingly provider name or any managed top-level key — the same
-// detection ClearCodexGatewayConfig uses — so a never-configured machine reads
-// as "not applied" and the form falls back to defaults.
+// file is tingly-managed (see isTinglyManagedCodexConfig) so a
+// never-configured machine reads as "not applied" and the form falls back to
+// defaults.
 func ReadCodexConfig() (prefs *CodexPrefs, writeCatalog bool, exists bool, err error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -1138,25 +1138,8 @@ func ReadCodexConfig() (prefs *CodexPrefs, writeCatalog bool, exists bool, err e
 		return DefaultCodexPrefs(), false, false, nil
 	}
 
-	// Detect tingly ownership. The reliable signals are an explicit
-	// `model_provider = "tingly-box"` or a `[model_providers.tingly-box]` stanza;
-	// either proves tingly-box wrote this config. The other managed top-level
-	// keys (model, model_catalog_json) are NOT tingly-specific on their own — a
-	// stock codex config always has `model`, so flagging on it would mark every
-	// codex install as tingly-managed and restore stale prefs into it.
-	owned := false
-	if provider, ok := cfg["model_provider"].(string); ok && provider == codexGatewayProviderName {
-		owned = true
-	}
-	if !owned {
-		if providers, ok := cfg["model_providers"].(map[string]interface{}); ok {
-			if _, ok := providers[codexGatewayProviderName]; ok {
-				owned = true
-			}
-		}
-	}
 	_, hasCatalog := cfg["model_catalog_json"]
-	return CodexPrefsFromConfig(cfg), hasCatalog, owned, nil
+	return CodexPrefsFromConfig(cfg), hasCatalog, isTinglyManagedCodexConfig(cfg), nil
 }
 
 // ApplyCodexConfig merges tingly-box Codex settings into ~/.codex/config.toml
@@ -1546,10 +1529,11 @@ func ClearCodexGatewayConfig() (*ApplyResult, error) {
 		return result, nil
 	}
 
-	// Fast path: if the file mentions neither the tingly provider name nor any
-	// managed top-level key, skip the unmarshal/marshal round-trip entirely.
-	// Re-marshaling user TOML loses comments and reorders keys, so avoiding it
-	// in the common no-op case is also a correctness win.
+	// Fast path: if the file does not even mention the tingly provider name,
+	// skip the unmarshal/marshal round-trip entirely. Re-marshaling user TOML
+	// loses comments and reorders keys, so avoiding it in the common no-op case
+	// is also a correctness win. isTinglyManagedCodexConfig below is the real
+	// authority on whether to act; this is just a cheap bytes-level pre-filter.
 	if !bytes.Contains(data, []byte(codexGatewayProviderName)) {
 		result.Success = true
 		result.Message = "config.toml has no tingly gateway keys, nothing to clear"
@@ -1559,6 +1543,15 @@ func ClearCodexGatewayConfig() (*ApplyResult, error) {
 	cfg := map[string]interface{}{}
 	if err := tomlpkg.Unmarshal(data, &cfg); err != nil {
 		result.Message = fmt.Sprintf("Failed to parse config.toml: %v", err)
+		return result, nil
+	}
+
+	// Only a tingly-managed config has anything to clear. This shares the exact
+	// ownership definition with ReadCodexConfig so the read/clear pair cannot
+	// disagree on what "tingly owns".
+	if !isTinglyManagedCodexConfig(cfg) {
+		result.Success = true
+		result.Message = "config.toml has no tingly gateway keys, nothing to clear"
 		return result, nil
 	}
 

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -1040,6 +1040,125 @@ func (p *CodexPrefs) toConfig() map[string]interface{} {
 	return out
 }
 
+// CodexPrefsFromConfig is the inverse of (*CodexPrefs).toConfig: it extracts
+// the typed, whitelisted CodexPrefs keys from a parsed config.toml top-level
+// map. Only the four managed keys are read; enum values are validated (invalid
+// values dropped) and the bool field is normalized back to "true"/"" so it
+// round-trips through the same JSON shape the frontend edits. Keys outside the
+// whitelist are ignored — a hand-edited config.toml can never smuggle extra
+// fields into the prefs surface.
+func CodexPrefsFromConfig(cfg map[string]interface{}) *CodexPrefs {
+	prefs := &CodexPrefs{}
+	strVal := func(key string) (string, bool) {
+		v, ok := cfg[key]
+		if !ok {
+			return "", false
+		}
+		switch t := v.(type) {
+		case string:
+			return t, true
+		case bool:
+			if t {
+				return "true", true
+			}
+			return "", true
+		default:
+			// go-toml unmarshals integers/floats as int64/float64; reasoning
+			// keys are all string-valued, so non-string scalars are dropped.
+			return "", true
+		}
+	}
+	// Reuse codexEnumValues to validate the three enum-typed keys. A value
+	// outside the allowed set is dropped so a stale/mistyped config.toml
+	// cannot surface an invalid option in the form.
+	for _, key := range []string{
+		"model_reasoning_effort",
+		"model_reasoning_summary",
+		"model_verbosity",
+	} {
+		if val, ok := strVal(key); ok && val != "" {
+			for _, allowed := range codexEnumValues[key] {
+				if strings.TrimSpace(val) == allowed {
+					setCodexPrefField(prefs, key, allowed)
+					break
+				}
+			}
+		}
+	}
+	// model_supports_reasoning_summaries maps true -> "true"; anything else
+	// (false, missing, non-bool) leaves it unset, matching toConfig's stance
+	// that only an explicit "true" opts in.
+	if v, ok := cfg["model_supports_reasoning_summaries"]; ok {
+		if b, ok := v.(bool); ok && b {
+			prefs.ModelSupportsReasoningSummaries = "true"
+		} else if s, ok := v.(string); ok && strings.TrimSpace(s) == "true" {
+			prefs.ModelSupportsReasoningSummaries = "true"
+		}
+	}
+	return prefs
+}
+
+// setCodexPrefField assigns a validated enum value to the matching CodexPrefs
+// field by config.toml key name. It mirrors the key→field mapping in toConfig.
+func setCodexPrefField(p *CodexPrefs, key, val string) {
+	switch key {
+	case "model_reasoning_effort":
+		p.ModelReasoningEffort = val
+	case "model_reasoning_summary":
+		p.ModelReasoningSummary = val
+	case "model_verbosity":
+		p.ModelVerbosity = val
+	}
+}
+
+// ReadCodexConfig reads ~/.codex/config.toml and returns the typed prefs, the
+// inferred writeCatalog state (true when model_catalog_json is set), and
+// whether a tingly-managed config exists. A missing or unparseable file yields
+// empty prefs, writeCatalog=false, exists=false. exists is true only when the
+// file carries the tingly provider name or any managed top-level key — the same
+// detection ClearCodexGatewayConfig uses — so a never-configured machine reads
+// as "not applied" and the form falls back to defaults.
+func ReadCodexConfig() (prefs *CodexPrefs, writeCatalog bool, exists bool, err error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, false, false, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	targetPath := filepath.Join(homeDir, ".codex", "config.toml")
+
+	data, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		// Missing file is not an error — first-time setup, no applied state.
+		return DefaultCodexPrefs(), false, false, nil
+	}
+
+	cfg := map[string]interface{}{}
+	if err := tomlpkg.Unmarshal(data, &cfg); err != nil {
+		// Unparseable file: surface the error but still report non-existence so
+		// the form falls back to defaults rather than showing a blank state.
+		return DefaultCodexPrefs(), false, false, nil
+	}
+
+	// Detect tingly ownership. The reliable signals are an explicit
+	// `model_provider = "tingly-box"` or a `[model_providers.tingly-box]` stanza;
+	// either proves tingly-box wrote this config. The other managed top-level
+	// keys (model, model_catalog_json) are NOT tingly-specific on their own — a
+	// stock codex config always has `model`, so flagging on it would mark every
+	// codex install as tingly-managed and restore stale prefs into it.
+	owned := false
+	if provider, ok := cfg["model_provider"].(string); ok && provider == codexGatewayProviderName {
+		owned = true
+	}
+	if !owned {
+		if providers, ok := cfg["model_providers"].(map[string]interface{}); ok {
+			if _, ok := providers[codexGatewayProviderName]; ok {
+				owned = true
+			}
+		}
+	}
+	_, hasCatalog := cfg["model_catalog_json"]
+	return CodexPrefsFromConfig(cfg), hasCatalog, owned, nil
+}
+
 // ApplyCodexConfig merges tingly-box Codex settings into ~/.codex/config.toml
 // and writes ~/.codex/tingly-model-catalog.json with one entry per supplied
 // model so Codex's `/model` picker can see them.

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyClaudeSettings_DefaultMode(t *testing.T) {
@@ -1416,16 +1418,16 @@ func TestCodexPrefsFromConfig(t *testing.T) {
 		"model_verbosity":                   "low",
 		"model_supports_reasoning_summaries": true,
 		// Unrelated keys are ignored — they must not leak into prefs.
-		"model":              "tingly/codex",
-		"model_provider":     "tingly-box",
-		"approval_policy":    "on-request",
-		"unknown_user_key":   "whatever",
+		"model":            "tingly/codex",
+		"model_provider":   "tingly-box",
+		"approval_policy":  "on-request",
+		"unknown_user_key": "whatever",
 	}
 	prefs := CodexPrefsFromConfig(cfg)
-	assertEqual(t, "high", prefs.ModelReasoningEffort)
-	assertEqual(t, "detailed", prefs.ModelReasoningSummary)
-	assertEqual(t, "low", prefs.ModelVerbosity)
-	assertEqual(t, "true", prefs.ModelSupportsReasoningSummaries)
+	assert.Equal(t, "high", prefs.ModelReasoningEffort)
+	assert.Equal(t, "detailed", prefs.ModelReasoningSummary)
+	assert.Equal(t, "low", prefs.ModelVerbosity)
+	assert.Equal(t, "true", prefs.ModelSupportsReasoningSummaries)
 }
 
 // Enum values outside the allowed set are dropped (forward-compatible,
@@ -1439,18 +1441,32 @@ func TestCodexPrefsFromConfig_DropsInvalidEnum(t *testing.T) {
 		"model_supports_reasoning_summaries": false,
 	}
 	prefs := CodexPrefsFromConfig(cfg)
-	assertEqual(t, "", prefs.ModelReasoningEffort)
-	assertEqual(t, "concise", prefs.ModelReasoningSummary)
-	assertEqual(t, "", prefs.ModelVerbosity)
-	assertEqual(t, "", prefs.ModelSupportsReasoningSummaries)
+	assert.Empty(t, prefs.ModelReasoningEffort)
+	assert.Equal(t, "concise", prefs.ModelReasoningSummary)
+	assert.Empty(t, prefs.ModelVerbosity)
+	assert.Empty(t, prefs.ModelSupportsReasoningSummaries)
 }
 
 func TestCodexPrefsFromConfig_Empty(t *testing.T) {
 	prefs := CodexPrefsFromConfig(map[string]interface{}{})
-	if prefs == nil {
-		t.Fatal("expected non-nil prefs")
+	require.NotNil(t, prefs)
+	assert.Empty(t, prefs.ModelReasoningEffort)
+}
+
+// toConfig and CodexPrefsFromConfig must round-trip: any prefs we can write
+// must read back identical. Pins the forward/inverse pair against drift.
+func TestCodexPrefs_RoundTrip(t *testing.T) {
+	cases := []*CodexPrefs{
+		{},
+		DefaultCodexPrefs(),
+		{ModelReasoningEffort: "high", ModelReasoningSummary: "detailed", ModelVerbosity: "low", ModelSupportsReasoningSummaries: "true"},
+		{ModelReasoningEffort: "none", ModelReasoningSummary: "none"},
+		{ModelSupportsReasoningSummaries: "true"},
 	}
-	assertEqual(t, "", prefs.ModelReasoningEffort)
+	for i, original := range cases {
+		out := CodexPrefsFromConfig(original.toConfig())
+		assert.Equal(t, original, out, "round-trip mismatch at case %d", i)
+	}
 }
 
 // ReadCodexConfig reports the tingly-managed state and infers writeCatalog from
@@ -1460,25 +1476,18 @@ func TestReadCodexConfig_AppliedConfig(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	codexDir := filepath.Join(home, ".codex")
-	require := requireNoError(t)
-	require(os.MkdirAll(codexDir, 0755))
-	require(os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
+	require.NoError(t, os.MkdirAll(codexDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
 model_provider = "tingly-box"
 model_catalog_json = "/x/tingly-model-catalog.json"
 model_reasoning_effort = "high"
 `), 0644))
 
 	prefs, writeCatalog, exists, err := ReadCodexConfig()
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if !exists {
-		t.Error("expected exists=true for tingly-managed config")
-	}
-	if !writeCatalog {
-		t.Error("expected writeCatalog=true when model_catalog_json is set")
-	}
-	assertEqual(t, "high", prefs.ModelReasoningEffort)
+	require.NoError(t, err)
+	assert.True(t, exists, "tingly-managed config should report exists=true")
+	assert.True(t, writeCatalog, "model_catalog_json present → writeCatalog=true")
+	assert.Equal(t, "high", prefs.ModelReasoningEffort)
 }
 
 // A config.toml with no tingly footprint reads as not-applied, even if it has
@@ -1488,23 +1497,16 @@ func TestReadCodexConfig_NonTinglyNotApplied(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	codexDir := filepath.Join(home, ".codex")
-	require := requireNoError(t)
-	require(os.MkdirAll(codexDir, 0755))
-	require(os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
+	require.NoError(t, os.MkdirAll(codexDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
 model = "gpt-5"
 model_reasoning_effort = "high"
 `), 0644))
 
 	_, writeCatalog, exists, err := ReadCodexConfig()
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if exists {
-		t.Error("expected exists=false for a non-tingly config")
-	}
-	if writeCatalog {
-		t.Error("expected writeCatalog=false when no model_catalog_json")
-	}
+	require.NoError(t, err)
+	assert.False(t, exists, "expected exists=false for a non-tingly config")
+	assert.False(t, writeCatalog, "expected writeCatalog=false when no model_catalog_json")
 }
 
 // Missing file is not an error — first-time setup returns defaults + not-applied.
@@ -1514,33 +1516,9 @@ func TestReadCodexConfig_MissingFile(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 
 	prefs, writeCatalog, exists, err := ReadCodexConfig()
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if exists {
-		t.Error("expected exists=false when no config.toml")
-	}
-	if writeCatalog {
-		t.Error("expected writeCatalog=false when no config.toml")
-	}
+	require.NoError(t, err)
+	assert.False(t, exists, "expected exists=false when no config.toml")
+	assert.False(t, writeCatalog, "expected writeCatalog=false when no config.toml")
 	// Defaults returned so the form has a starting value.
-	assertEqual(t, "medium", prefs.ModelReasoningEffort)
-}
-
-func assertEqual(t *testing.T, want, got string) {
-	t.Helper()
-	if want != got {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
-// requireNoError returns a helper that fails the test on error, keeping these
-// table-ish tests terse without pulling testify into this file's style.
-func requireNoError(t *testing.T) func(error) {
-	t.Helper()
-	return func(err error) {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	}
+	assert.Equal(t, "medium", prefs.ModelReasoningEffort)
 }

--- a/internal/server/config/apply_config_test.go
+++ b/internal/server/config/apply_config_test.go
@@ -1406,3 +1406,141 @@ func TestApplyCodexConfig_PrefsRejectInvalidEnumAndCannotClobberManaged(t *testi
 		t.Errorf("model = %v, want m1", cfg["model"])
 	}
 }
+
+// CodexPrefsFromConfig is the inverse of toConfig: only whitelisted keys are
+// read, enum values validated, and the bool normalized to "true"/"".
+func TestCodexPrefsFromConfig(t *testing.T) {
+	cfg := map[string]interface{}{
+		"model_reasoning_effort":            "high",
+		"model_reasoning_summary":           "detailed",
+		"model_verbosity":                   "low",
+		"model_supports_reasoning_summaries": true,
+		// Unrelated keys are ignored — they must not leak into prefs.
+		"model":              "tingly/codex",
+		"model_provider":     "tingly-box",
+		"approval_policy":    "on-request",
+		"unknown_user_key":   "whatever",
+	}
+	prefs := CodexPrefsFromConfig(cfg)
+	assertEqual(t, "high", prefs.ModelReasoningEffort)
+	assertEqual(t, "detailed", prefs.ModelReasoningSummary)
+	assertEqual(t, "low", prefs.ModelVerbosity)
+	assertEqual(t, "true", prefs.ModelSupportsReasoningSummaries)
+}
+
+// Enum values outside the allowed set are dropped (forward-compatible,
+// injection-safe) — they do not surface as an invalid option in the form.
+func TestCodexPrefsFromConfig_DropsInvalidEnum(t *testing.T) {
+	cfg := map[string]interface{}{
+		"model_reasoning_effort":  "ultra", // not a valid effort
+		"model_reasoning_summary": "concise",
+		"model_verbosity":         7, // wrong type
+		// false / non-"true" → empty (not opted in)
+		"model_supports_reasoning_summaries": false,
+	}
+	prefs := CodexPrefsFromConfig(cfg)
+	assertEqual(t, "", prefs.ModelReasoningEffort)
+	assertEqual(t, "concise", prefs.ModelReasoningSummary)
+	assertEqual(t, "", prefs.ModelVerbosity)
+	assertEqual(t, "", prefs.ModelSupportsReasoningSummaries)
+}
+
+func TestCodexPrefsFromConfig_Empty(t *testing.T) {
+	prefs := CodexPrefsFromConfig(map[string]interface{}{})
+	if prefs == nil {
+		t.Fatal("expected non-nil prefs")
+	}
+	assertEqual(t, "", prefs.ModelReasoningEffort)
+}
+
+// ReadCodexConfig reports the tingly-managed state and infers writeCatalog from
+// the presence of model_catalog_json.
+func TestReadCodexConfig_AppliedConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	codexDir := filepath.Join(home, ".codex")
+	require := requireNoError(t)
+	require(os.MkdirAll(codexDir, 0755))
+	require(os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
+model_provider = "tingly-box"
+model_catalog_json = "/x/tingly-model-catalog.json"
+model_reasoning_effort = "high"
+`), 0644))
+
+	prefs, writeCatalog, exists, err := ReadCodexConfig()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !exists {
+		t.Error("expected exists=true for tingly-managed config")
+	}
+	if !writeCatalog {
+		t.Error("expected writeCatalog=true when model_catalog_json is set")
+	}
+	assertEqual(t, "high", prefs.ModelReasoningEffort)
+}
+
+// A config.toml with no tingly footprint reads as not-applied, even if it has
+// reasoning prefs from some other setup — those are not tingly-owned state.
+func TestReadCodexConfig_NonTinglyNotApplied(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	codexDir := filepath.Join(home, ".codex")
+	require := requireNoError(t)
+	require(os.MkdirAll(codexDir, 0755))
+	require(os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
+model = "gpt-5"
+model_reasoning_effort = "high"
+`), 0644))
+
+	_, writeCatalog, exists, err := ReadCodexConfig()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if exists {
+		t.Error("expected exists=false for a non-tingly config")
+	}
+	if writeCatalog {
+		t.Error("expected writeCatalog=false when no model_catalog_json")
+	}
+}
+
+// Missing file is not an error — first-time setup returns defaults + not-applied.
+func TestReadCodexConfig_MissingFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	prefs, writeCatalog, exists, err := ReadCodexConfig()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if exists {
+		t.Error("expected exists=false when no config.toml")
+	}
+	if writeCatalog {
+		t.Error("expected writeCatalog=false when no config.toml")
+	}
+	// Defaults returned so the form has a starting value.
+	assertEqual(t, "medium", prefs.ModelReasoningEffort)
+}
+
+func assertEqual(t *testing.T, want, got string) {
+	t.Helper()
+	if want != got {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// requireNoError returns a helper that fails the test on error, keeping these
+// table-ish tests terse without pulling testify into this file's style.
+func requireNoError(t *testing.T) func(error) {
+	t.Helper()
+	return func(err error) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}

--- a/internal/server/config/main_test.go
+++ b/internal/server/config/main_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates every test in this package from the user's real home
+// directory. Several functions under test resolve their target path from
+// os.UserHomeDir() (e.g. ~/.codex/config.toml, ~/.claude/settings.json). Tests
+// that exercise the full apply/read path must never write into the developer's
+// real config files, so the whole binary is redirected to a throwaway HOME
+// before any test runs. Individual tests may still point HOME at their own
+// t.TempDir() for finer-grained isolation; this is the safety net that catches
+// any test that forgets to.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "tb-config-test-home-")
+	if err != nil {
+		panic("failed to create isolated test home: " + err.Error())
+	}
+	defer os.RemoveAll(tmp)
+	os.Setenv("HOME", tmp)
+	os.Setenv("USERPROFILE", tmp)
+	os.Exit(m.Run())
+}

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -63,6 +63,26 @@ func (h *Handler) GetClaudeConfig(c *gin.Context) {
 	})
 }
 
+// GetCodexConfig reads the values previously applied to the user's
+// ~/.codex/config.toml so reopening the editor restores durable state.
+// Routing/auth fields are not returned (see CodexConfigResponse).
+func (h *Handler) GetCodexConfig(c *gin.Context) {
+	prefs, writeCatalog, exists, err := config.ReadCodexConfig()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+	if prefs == nil {
+		prefs = config.DefaultCodexPrefs()
+	}
+	c.JSON(http.StatusOK, CodexConfigResponse{
+		Success:      true,
+		Exists:       exists,
+		Preferences:  *prefs,
+		WriteCatalog: writeCatalog,
+	})
+}
+
 // HTTPTransportConfigUpdate represents the update request for HTTP transport settings
 type HTTPTransportConfigUpdate struct {
 	RespectEnvProxy *bool   `json:"respect_env_proxy"` // nil = no change

--- a/internal/server/module/configapply/handler_test.go
+++ b/internal/server/module/configapply/handler_test.go
@@ -68,6 +68,72 @@ func TestGetClaudeConfig_RestoresAppliedPreferences(t *testing.T) {
 	assert.Equal(t, "64000", response.Preferences.ClaudeCodeMaxOutputTokens)
 }
 
+func TestGetCodexConfig_RestoresAppliedPreferences(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	codexDir := filepath.Join(home, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0755))
+	// A tingly-managed config.toml carrying the four prefs keys plus the
+	// catalog reference and the tingly provider stanza.
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(`
+model = "tingly/codex"
+model_provider = "tingly-box"
+model_catalog_json = "/home/user/.codex/tingly-model-catalog.json"
+model_reasoning_effort = "high"
+model_reasoning_summary = "detailed"
+model_verbosity = "low"
+model_supports_reasoning_summaries = true
+
+[model_providers.tingly-box]
+name = "Tingly Box"
+base_url = "http://localhost:12580/tingly/codex"
+wire_api = "responses"
+`), 0644))
+
+	handler := NewHandler(nil, "localhost")
+	router := gin.New()
+	router.GET("/config/codex", handler.GetCodexConfig)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/codex", nil)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var response CodexConfigResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.True(t, response.Success)
+	assert.True(t, response.Exists, "tingly-managed config should report exists=true")
+	assert.True(t, response.WriteCatalog, "model_catalog_json present → writeCatalog=true")
+	assert.Equal(t, "high", response.Preferences.ModelReasoningEffort)
+	assert.Equal(t, "detailed", response.Preferences.ModelReasoningSummary)
+	assert.Equal(t, "low", response.Preferences.ModelVerbosity)
+	assert.Equal(t, "true", response.Preferences.ModelSupportsReasoningSummaries)
+}
+
+// A config.toml with no tingly footprint reads as not-applied: the form falls
+// back to defaults rather than restoring stale values.
+func TestGetCodexConfig_NotAppliedFallsBackToDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// No ~/.codex/config.toml at all.
+	handler := NewHandler(nil, "localhost")
+	router := gin.New()
+	router.GET("/config/codex", handler.GetCodexConfig)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/codex", nil)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var response CodexConfigResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.True(t, response.Success)
+	assert.False(t, response.Exists)
+	assert.False(t, response.WriteCatalog)
+	// Defaults are still returned so the form has sensible starting values.
+	assert.Equal(t, "medium", response.Preferences.ModelReasoningEffort)
+}
+
 func TestApplyClaudeConfig_NilConfig(t *testing.T) {
 	handler := NewHandler(nil, "localhost")
 

--- a/internal/server/module/configapply/main_test.go
+++ b/internal/server/module/configapply/main_test.go
@@ -1,0 +1,23 @@
+package configapply
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates every test in this package from the user's real home
+// directory. The apply handlers resolve their target paths from
+// os.UserHomeDir() (e.g. ~/.claude/settings.json via ApplyClaudeSettings*,
+// ~/.codex/config.toml via ReadCodexConfig). A test that drives the full
+// handler path must never mutate the developer's real config files, so the
+// whole binary is redirected to a throwaway HOME before any test runs.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "tb-configapply-test-home-")
+	if err != nil {
+		panic("failed to create isolated test home: " + err.Error())
+	}
+	defer os.RemoveAll(tmp)
+	os.Setenv("HOME", tmp)
+	os.Setenv("USERPROFILE", tmp)
+	os.Exit(m.Run())
+}

--- a/internal/server/module/configapply/routes.go
+++ b/internal/server/module/configapply/routes.go
@@ -23,6 +23,12 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithResponseModel(ClaudeConfigResponse{}),
 	)
 
+	router.GET("/config/codex", handler.GetCodexConfig,
+		swagger.WithDescription("Get the currently applied Codex preferences"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(CodexConfigResponse{}),
+	)
+
 	// Config apply endpoints - requires authentication (applied by caller)
 	router.POST("/config/apply/claude", handler.ApplyClaudeConfig,
 		swagger.WithDescription("Generate and apply Claude Code configuration from system state"),

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -39,6 +39,18 @@ type ClaudeConfigResponse struct {
 	InstallStatusLine bool                  `json:"installStatusLine"`
 }
 
+// CodexConfigResponse returns the typed values currently persisted in the
+// user's ~/.codex/config.toml so the frontend can restore Apply state on reopen.
+// Routing/auth-owned fields (model, model_provider, the gateway token) are NOT
+// returned — same safety stance as ClaudeConfigResponse. writeCatalog is inferred
+// from the presence of model_catalog_json in config.toml.
+type CodexConfigResponse struct {
+	Success      bool               `json:"success"`
+	Exists       bool               `json:"exists"`
+	Preferences  config.CodexPrefs  `json:"preferences"`
+	WriteCatalog bool               `json:"writeCatalog"`
+}
+
 // ApplyOpenCodeConfigResponse is the response for ApplyOpenCodeConfigFromState
 type ApplyOpenCodeConfigResponse struct {
 	config.ApplyResult


### PR DESCRIPTION
## Summary

In two cases, the Codex and Claude Code config modals silently discarded the user's applied settings: the Codex modal reset to defaults every time it opened (it had no way to read back the applied settings), and toggling 1M context on a rule reopened the modal showing defaults instead of the user's last applied values. Re-applying after either action would revert settings such as max output tokens, timeout, privacy switches, reasoning effort, and others. This brings Codex to parity with Claude Code's readback and fixes the 1M-preview path on both surfaces.

## Key Changes

- **Codex modal restores applied values on open**: the Codex Quick Config now reads back the reasoning preferences and catalog-write state that were previously applied to `~/.codex/config.toml`, instead of resetting to defaults every time it opens. A user who tuned reasoning effort and reopens the dialog sees their choice, not `medium`.

- **1M toggle no longer drops applied settings (both clients)**: toggling 1M context opens the modal to apply the renamed models, but both surfaces used to show defaults because the 1M-preview path skipped the applied-config read. Both now restore the user's non-routing preferences and overlay only the 1M-driven changes (for Claude: model slots and auto-compact window; for Codex: nothing in preferences, since 1M only affects the model catalog).

- **Don't misread foreign codex configs as tingly-managed**: a config is treated as tingly-applied only when it actually points to the tingly-box provider, not merely because it has a `model` key (which every codex install has). Without this fix, any stock codex config would have stale preferences restored into it.

## Notes

- **Codegen follow-up**: the new `getAppliedCodexConfig` call uses a placeholder type cast until the next swagger/client regeneration; drop it then. No behavior impact in the meantime.
- **Auth mode is intentionally not read back**: the Codex modal still defaults to the gateway auth path on open. Inferring chatgpt/hybrid would require parsing the provider stanza and `auth.json`, which is error-prone and offers no clear payoff; users can reselect it if needed.

## Testing

Backend unit and handler tests (including a round-trip test that pins the preference read/write pair against drift), frontend build and lint clean, and the test suites verified to leave the developer's actual `~/.claude` and `~/.codex` files untouched.