### PR TITLE
refactor(imbot) 2/3: neutral outbound actions, rendered per platform

### DIFF
--- a/imbot/core/action.go
+++ b/imbot/core/action.go
@@ -1,0 +1,153 @@
+package core
+
+// Actions are the platform-neutral way to attach interactive controls to an
+// outbound message. They replace the previous convention of pre-rendering a
+// platform payload and passing it through SendMessageOptions.Metadata, which
+// forced every caller to know which platform it was talking to — and silently
+// produced button-less messages when it guessed wrong.
+//
+// The division of labour is: the caller describes intent (a labelled action
+// that carries some callback data), the platform decides presentation
+// (Telegram inline keyboard, Feishu card buttons, numbered text, ...).
+//
+// Not every capability should be neutral. Three tiers:
+//
+//   - Tier 1, universal: a labelled action with callback data, or a link.
+//     Every platform can express it. That is Action's own fields.
+//   - Tier 2, capability-gated: something several platforms can do in
+//     different ways (opening a mini app). Expressed as an ActionKind; the
+//     platform picks the implementation, and Fallback says what happens where
+//     it does not exist.
+//   - Tier 3, platform-only: capabilities worth no abstraction at all
+//     (Telegram's pay or switch_inline_query). These do NOT get neutral
+//     fields; they travel in Ext, populated by constructors in the platform
+//     package, so the caller's import declares the intent and it stays
+//     greppable. See imbot/platform/telegram for examples.
+//
+// The rule that makes this work: a platform that cannot render an action must
+// apply Fallback rather than dropping it silently.
+
+// ActionKind is the neutral semantic of an action. The zero value is a plain
+// callback action, which is what nearly every action is.
+type ActionKind string
+
+const (
+	// ActionCallback emits a callback to the bot carrying CallbackData.
+	ActionCallback ActionKind = ""
+	// ActionOpenURL opens URL in the user's browser.
+	ActionOpenURL ActionKind = "open_url"
+	// ActionOpenMiniApp opens an embedded mini app at URL. Platforms without
+	// an embedded webview apply Fallback (FallbackAsURL is the sensible one).
+	ActionOpenMiniApp ActionKind = "open_mini_app"
+)
+
+// FallbackPolicy declares what a platform does with an action it cannot
+// render. Declaring this is mandatory in spirit: the zero value drops the
+// action, so a caller that cares must say so.
+type FallbackPolicy string
+
+const (
+	// FallbackDrop omits the action. The zero value, and correct for actions
+	// that are pure convenience.
+	FallbackDrop FallbackPolicy = ""
+	// FallbackAsURL degrades to a plain link action when URL is set.
+	FallbackAsURL FallbackPolicy = "as_url"
+)
+
+// Only the policies a platform actually honours are defined here. An
+// "append it to the body as numbered text" policy would be useful for
+// platforms with no interactive support, but nothing implements it yet — and a
+// policy that silently does nothing is precisely the failure this seam exists
+// to remove. Add it together with its first implementation.
+
+// Action is one message-scoped interactive control.
+//
+// "Message-scoped" is deliberate: Telegram also has a chat-scoped reply
+// keyboard, which is a different concept with a different lifetime. Do not
+// conflate the two under one name.
+type Action struct {
+	// ID is a stable identifier for the action, used for logging and for
+	// platforms whose button payloads carry a separate id field.
+	ID string
+	// Label is the user-visible button text.
+	Label string
+	// CallbackData is the opaque payload echoed back when the action fires.
+	//
+	// TODO(phase-2b): this is Telegram's wire format leaking into the neutral
+	// model — it forces a 64-byte budget on every platform, including those
+	// with no such limit. It is scheduled to become an arbitrary Payload with
+	// per-platform delivery.
+	CallbackData string
+	// URL is the link opened by ActionOpenURL / ActionOpenMiniApp.
+	URL string
+	// Kind is the neutral semantic; zero value means a callback action.
+	Kind ActionKind
+	// Ext carries Tier 3, platform-specific action data. Only the platform
+	// named by the key reads its entry; the others apply Fallback. Populate it
+	// through the platform package's constructors rather than by hand.
+	Ext map[Platform]any
+	// Fallback declares the behaviour on platforms that cannot render this
+	// action.
+	Fallback FallbackPolicy
+}
+
+// ExtFor returns this action's Tier 3 payload for a platform, if any.
+func (a Action) ExtFor(platform Platform) (any, bool) {
+	if a.Ext == nil {
+		return nil, false
+	}
+	v, ok := a.Ext[platform]
+	return v, ok
+}
+
+// IsLink reports whether the action should be rendered as a link rather than
+// as a callback control.
+func (a Action) IsLink() bool {
+	return a.URL != "" && (a.Kind == ActionOpenURL || a.CallbackData == "")
+}
+
+// ActionSet is a laid-out group of message-scoped actions. Rows are preserved
+// because layout is meaningful — the directory browser depends on it — and a
+// platform that has no notion of rows can always flatten.
+type ActionSet struct {
+	Rows [][]Action
+}
+
+// NewActionSet creates an empty action set.
+func NewActionSet() *ActionSet {
+	return &ActionSet{}
+}
+
+// AddRow appends a row of actions. Empty rows are ignored.
+func (s *ActionSet) AddRow(actions ...Action) *ActionSet {
+	if len(actions) == 0 {
+		return s
+	}
+	s.Rows = append(s.Rows, actions)
+	return s
+}
+
+// IsEmpty reports whether the set carries no actions at all.
+func (s *ActionSet) IsEmpty() bool {
+	if s == nil {
+		return true
+	}
+	for _, row := range s.Rows {
+		if len(row) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Flatten returns every action in row order, for platforms with no row concept.
+func (s *ActionSet) Flatten() []Action {
+	if s == nil {
+		return nil
+	}
+	var out []Action
+	for _, row := range s.Rows {
+		out = append(out, row...)
+	}
+	return out
+}

--- a/imbot/core/bot.go
+++ b/imbot/core/bot.go
@@ -51,14 +51,27 @@ type Bot interface {
 
 // SendMessageOptions represents options for sending a message
 type SendMessageOptions struct {
-	Text      string                 `json:"text,omitempty"`
-	Media     []MediaAttachment      `json:"media,omitempty"`
-	ReplyTo   string                 `json:"replyTo,omitempty"`
-	ThreadID  string                 `json:"threadId,omitempty"`
-	ParseMode ParseMode              `json:"parseMode,omitempty"`
-	Entities  []Entity               `json:"entities,omitempty"` // Telegram message entities (alternative to ParseMode)
-	Silent    bool                   `json:"silent,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	Text      string            `json:"text,omitempty"`
+	Media     []MediaAttachment `json:"media,omitempty"`
+	ReplyTo   string            `json:"replyTo,omitempty"`
+	ThreadID  string            `json:"threadId,omitempty"`
+	ParseMode ParseMode         `json:"parseMode,omitempty"`
+	Entities  []Entity          `json:"entities,omitempty"` // Telegram message entities (alternative to ParseMode)
+	Silent    bool              `json:"silent,omitempty"`
+
+	// Actions attaches message-scoped interactive controls in a
+	// platform-neutral form. Each platform renders it natively (Telegram
+	// inline keyboard, Feishu card buttons, ...) or degrades per each action's
+	// FallbackPolicy. See action.go.
+	//
+	// This supersedes Metadata["replyMarkup"], which required the caller to
+	// pre-render a platform payload. That path still works for one release and
+	// logs a deprecation warning.
+	Actions *ActionSet `json:"actions,omitempty"`
+
+	// Metadata carries platform-specific escape-hatch values. It is no longer
+	// the transport for interactive payloads — use Actions.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // SendResult represents the result of sending a message

--- a/imbot/imbot.go
+++ b/imbot/imbot.go
@@ -443,3 +443,36 @@ func NewCommandRegistry() *command.CommandRegistry {
 func NewHandlerContext(bot Bot, chatID, senderID string, platform Platform) *command.HandlerContext {
 	return command.NewHandlerContext(bot, chatID, senderID, core.Platform(platform))
 }
+
+// Message actions — the neutral outbound interactive payload.
+//
+// Callers build an ActionSet and hand it to SendMessageOptions.Actions; each
+// platform renders it natively. This replaces the old pattern of rendering a
+// Telegram payload at the call site and passing it through Metadata.
+// Platform-only capabilities do not appear here — they come from constructors
+// in the platform packages (see imbot/platform/telegram). Rationale in
+// imbot/core/action.go.
+type (
+	// Action is one message-scoped interactive control.
+	Action = core.Action
+	// ActionSet is a laid-out group of message-scoped actions.
+	ActionSet = core.ActionSet
+	// ActionKind is the neutral semantic of an action.
+	ActionKind = core.ActionKind
+	// FallbackPolicy declares what happens on platforms that cannot render an action.
+	FallbackPolicy = core.FallbackPolicy
+)
+
+const (
+	ActionCallback    = core.ActionCallback
+	ActionOpenURL     = core.ActionOpenURL
+	ActionOpenMiniApp = core.ActionOpenMiniApp
+
+	FallbackDrop  = core.FallbackDrop
+	FallbackAsURL = core.FallbackAsURL
+)
+
+// NewActionSet creates an empty action set.
+func NewActionSet() *core.ActionSet {
+	return core.NewActionSet()
+}

--- a/imbot/interaction/keyboard.go
+++ b/imbot/interaction/keyboard.go
@@ -3,6 +3,8 @@ package interaction
 import (
 	"fmt"
 	"strings"
+
+	"github.com/tingly-dev/tingly-box/imbot/core"
 )
 
 // InlineKeyboardButton represents a button in an inline keyboard
@@ -161,4 +163,31 @@ func FormatDirButton(name string, maxLen int) string {
 		return fmt.Sprintf("📁 %s", name)
 	}
 	return fmt.Sprintf("📁 %s...", name[:maxLen-3])
+}
+
+// ToActionSet converts a legacy inline-keyboard markup into the neutral
+// core.ActionSet that SendMessageOptions.Actions takes.
+//
+// This is the bridge that lets existing keyboard-building code migrate off
+// per-platform pre-rendering without being rewritten: build the keyboard as
+// before, then hand over an action set instead of a Telegram payload.
+func (m InlineKeyboardMarkup) ToActionSet() *core.ActionSet {
+	set := core.NewActionSet()
+	for _, row := range m.InlineKeyboard {
+		actions := make([]core.Action, 0, len(row))
+		for _, btn := range row {
+			actions = append(actions, core.Action{
+				Label:        btn.Text,
+				CallbackData: btn.CallbackData,
+				URL:          btn.URL,
+			})
+		}
+		set.AddRow(actions...)
+	}
+	return set
+}
+
+// BuildActions returns the built keyboard directly as a neutral action set.
+func (b *KeyboardBuilder) BuildActions() *core.ActionSet {
+	return b.Build().ToActionSet()
 }

--- a/imbot/platform/feishu/action_render.go
+++ b/imbot/platform/feishu/action_render.go
@@ -1,0 +1,168 @@
+package feishu
+
+import (
+	"context"
+	"fmt"
+
+	larkcard "github.com/larksuite/oapi-sdk-go/v3/card"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	"github.com/tingly-dev/tingly-box/imbot/core"
+	"github.com/tingly-dev/tingly-box/imbot/interaction"
+)
+
+// sendActionCard renders text plus a neutral action set as a Feishu
+// interactive card.
+//
+// This replaces the previous path, which type-switched on whatever the caller
+// had stuffed into Metadata["replyMarkup"]. Callers in practice supplied a
+// go-telegram models.InlineKeyboardMarkup, which matched none of the cases, so
+// every remote-control keyboard reached Feishu users as a card with no buttons.
+func (b *Bot) sendActionCard(ctx context.Context, target string, opts *core.SendMessageOptions, set *core.ActionSet) (*core.SendResult, error) {
+	if b.client == nil {
+		return nil, fmt.Errorf("bot client is nil")
+	}
+	if b.client.Im == nil {
+		return nil, fmt.Errorf("client.Im is nil")
+	}
+
+	card := buildActionCard(opts.Text, set)
+	cardJSON, err := card.String()
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize card: %w", err)
+	}
+
+	req := larkim.NewCreateMessageReqBuilder().
+		ReceiveIdType(getReceiveIdType(target)).
+		Body(larkim.NewCreateMessageReqBodyBuilder().
+			ReceiveId(target).
+			MsgType("interactive").
+			Content(cardJSON).
+			Build()).
+		Build()
+
+	resp, err := b.client.Im.Message.Create(ctx, req)
+	if err != nil {
+		return nil, core.WrapError(err, core.Platform(b.domain), core.ErrPlatformError)
+	}
+	if resp.Code != 0 {
+		return nil, core.NewBotError(core.ErrPlatformError, fmt.Sprintf("API error: %s", resp.Msg), false)
+	}
+
+	b.UpdateLastActivity()
+	return &core.SendResult{MessageID: b.extractMessageIDFromResponse(resp)}, nil
+}
+
+// buildActionCard builds a Lark interactive card from text and a neutral
+// action set.
+func buildActionCard(text string, set *core.ActionSet) *larkcard.MessageCard {
+	elements := []larkcard.MessageCardElement{
+		larkcard.NewMessageCardDiv().
+			Text(larkcard.NewMessageCardLarkMd().Content(text)),
+	}
+
+	// Feishu lays actions out itself, so rows are flattened.
+	var buttons []larkcard.MessageCardActionElement
+	for _, action := range set.Flatten() {
+		if btn, ok := buildActionButton(action); ok {
+			buttons = append(buttons, btn)
+		}
+	}
+
+	if len(buttons) > 0 {
+		layout := larkcard.MessageCardActionLayoutFlow
+		elements = append(elements, larkcard.NewMessageCardAction().
+			Layout(&layout).
+			Actions(buttons))
+	}
+
+	wideScreen := true
+	return larkcard.NewMessageCard().
+		Config(larkcard.NewMessageCardConfig().WideScreenMode(wideScreen)).
+		Elements(elements).
+		Build()
+}
+
+// buildActionButton renders one neutral action as a Feishu card button.
+//
+// Feishu has no Tier 3 extensions of its own yet; an action carrying another
+// platform's Ext is rendered from its neutral fields when it has them, and
+// otherwise honours its FallbackPolicy. FallbackAsText is handled by the
+// caller, not here, because it changes the message body rather than the
+// buttons.
+func buildActionButton(action core.Action) (larkcard.MessageCardActionElement, bool) {
+	if action.Label == "" {
+		return nil, false
+	}
+
+	// A link-only action with nothing to call back stays a link.
+	if action.IsLink() {
+		if action.Fallback == core.FallbackDrop && action.Kind == core.ActionOpenMiniApp {
+			return nil, false
+		}
+		return larkcard.NewMessageCardEmbedButton().
+			Text(larkcard.NewMessageCardPlainText().Content(action.Label)).
+			Type(larkcard.MessageCardButtonTypeDefault).
+			MultiUrl(larkcard.NewMessageCardURL().Url(action.URL)), true
+	}
+
+	if action.CallbackData == "" {
+		// Nothing to send back and nowhere to go.
+		return nil, false
+	}
+
+	return larkcard.NewMessageCardEmbedButton().
+		Text(larkcard.NewMessageCardPlainText().Content(action.Label)).
+		Type(larkcard.MessageCardButtonTypeDefault).
+		Value(map[string]interface{}{
+			"callback": action.CallbackData,
+			"actionId": action.ID,
+		}), true
+}
+
+// actionSetFromLegacyMarkup accepts the shapes that used to be pushed through
+// Metadata["replyMarkup"] and normalises them to an action set. Kept for one
+// release while call sites migrate to SendMessageOptions.Actions.
+func actionSetFromLegacyMarkup(raw any) *core.ActionSet {
+	switch m := raw.(type) {
+	case *core.ActionSet:
+		return m
+	case interaction.InlineKeyboardMarkup:
+		return m.ToActionSet()
+	case *interaction.InlineKeyboardMarkup:
+		if m == nil {
+			return nil
+		}
+		return m.ToActionSet()
+	case map[string]interface{}:
+		return actionSetFromMap(m)
+	}
+	return nil
+}
+
+// actionSetFromMap handles a keyboard that arrived as decoded JSON.
+func actionSetFromMap(m map[string]interface{}) *core.ActionSet {
+	rows, ok := m["inline_keyboard"].([]interface{})
+	if !ok {
+		return nil
+	}
+	set := core.NewActionSet()
+	for _, row := range rows {
+		rowArray, ok := row.([]interface{})
+		if !ok {
+			continue
+		}
+		actions := make([]core.Action, 0, len(rowArray))
+		for _, btn := range rowArray {
+			btnMap, ok := btn.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			label, _ := btnMap["text"].(string)
+			callback, _ := btnMap["callback_data"].(string)
+			url, _ := btnMap["url"].(string)
+			actions = append(actions, core.Action{Label: label, CallbackData: callback, URL: url})
+		}
+		set.AddRow(actions...)
+	}
+	return set
+}

--- a/imbot/platform/feishu/action_render_test.go
+++ b/imbot/platform/feishu/action_render_test.go
@@ -1,0 +1,118 @@
+package feishu
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/imbot/core"
+	"github.com/tingly-dev/tingly-box/imbot/interaction"
+)
+
+// TestBuildActionCardRendersButtons is the regression test for the defect this
+// seam exists to fix: remote_control's action menu reached Feishu users as a
+// card with no buttons, because the caller pre-rendered a go-telegram markup
+// that this package's type switch did not recognise.
+func TestBuildActionCardRendersButtons(t *testing.T) {
+	set := core.NewActionSet().
+		AddRow(
+			core.Action{ID: "clear", Label: "🗑 Clear", CallbackData: "action:clear"},
+			core.Action{ID: "bind", Label: "📁 CD", CallbackData: "action:bind"},
+		).
+		AddRow(core.Action{ID: "project", Label: "🔧 Project", CallbackData: "action:project"})
+
+	out, err := buildActionCard("Task done.", set).String()
+	if err != nil {
+		t.Fatalf("card serialize: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("card is not valid JSON: %v\n%s", err, out)
+	}
+
+	// Feishu flattens rows, but every action must survive with its callback.
+	for _, want := range []string{
+		"🗑 Clear", "📁 CD", "🔧 Project",
+		"action:clear", "action:bind", "action:project",
+		"Task done.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("card is missing %q\n%s", want, out)
+		}
+	}
+	if got := strings.Count(out, `"tag":"button"`); got != 3 {
+		t.Errorf("expected 3 buttons, got %d\n%s", got, out)
+	}
+}
+
+func TestBuildActionCardWithoutActions(t *testing.T) {
+	out, err := buildActionCard("just text", core.NewActionSet()).String()
+	if err != nil {
+		t.Fatalf("card serialize: %v", err)
+	}
+	if strings.Contains(out, `"tag":"button"`) {
+		t.Errorf("expected no buttons\n%s", out)
+	}
+	if !strings.Contains(out, "just text") {
+		t.Errorf("expected the text to survive\n%s", out)
+	}
+}
+
+// TestBuildActionCardTier3Fallback covers the escape-hatch contract: an action
+// carrying another platform's Tier 3 payload must degrade here per its
+// FallbackPolicy, not vanish and not leak the other platform's shape.
+func TestBuildActionCardTier3Fallback(t *testing.T) {
+	// FallbackAsURL: a Telegram mini-app button becomes a plain link.
+	asURL := core.Action{
+		Label:    "Open dashboard",
+		URL:      "https://example.test/dash",
+		Kind:     core.ActionOpenMiniApp,
+		Fallback: core.FallbackAsURL,
+		Ext:      map[core.Platform]any{core.PlatformTelegram: struct{ x int }{1}},
+	}
+	out, err := buildActionCard("hi", core.NewActionSet().AddRow(asURL)).String()
+	if err != nil {
+		t.Fatalf("card serialize: %v", err)
+	}
+	if !strings.Contains(out, "https://example.test/dash") {
+		t.Errorf("FallbackAsURL should keep the link\n%s", out)
+	}
+
+	// FallbackDrop: a capability with no Feishu equivalent is omitted.
+	dropped := core.Action{
+		Label:    "Switch inline",
+		Kind:     core.ActionOpenMiniApp,
+		URL:      "https://example.test/x",
+		Fallback: core.FallbackDrop,
+		Ext:      map[core.Platform]any{core.PlatformTelegram: struct{ x int }{1}},
+	}
+	out, err = buildActionCard("hi", core.NewActionSet().AddRow(dropped)).String()
+	if err != nil {
+		t.Fatalf("card serialize: %v", err)
+	}
+	if strings.Contains(out, `"tag":"button"`) {
+		t.Errorf("FallbackDrop should omit the action\n%s", out)
+	}
+}
+
+func TestActionSetFromLegacyMarkup(t *testing.T) {
+	kb := interaction.InlineKeyboardMarkup{
+		InlineKeyboard: [][]interaction.InlineKeyboardButton{
+			{{Text: "Yes", CallbackData: "yes"}},
+		},
+	}
+	set := actionSetFromLegacyMarkup(kb)
+	if set.IsEmpty() {
+		t.Fatal("expected the legacy generic markup to decode")
+	}
+	if got := set.Flatten()[0].Label; got != "Yes" {
+		t.Errorf("label = %q, want Yes", got)
+	}
+
+	// A shape nobody recognises must report as empty so the caller can warn,
+	// rather than silently shipping a button-less card.
+	if !actionSetFromLegacyMarkup(struct{ Nope bool }{}).IsEmpty() {
+		t.Error("expected an unknown markup shape to decode to nothing")
+	}
+}

--- a/imbot/platform/feishu/bot_sdk.go
+++ b/imbot/platform/feishu/bot_sdk.go
@@ -13,7 +13,6 @@ import (
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
-	"github.com/tingly-dev/tingly-box/imbot/interaction"
 
 	"github.com/tingly-dev/tingly-box/imbot/core"
 )
@@ -380,9 +379,19 @@ func (b *Bot) sendText(ctx context.Context, target string, opts *core.SendMessag
 		return nil, err
 	}
 
-	// Check for interactive card (keyboard)
+	// Interactive controls: prefer the neutral action set, fall back to the
+	// deprecated pre-rendered payload in Metadata["replyMarkup"].
+	if !opts.Actions.IsEmpty() {
+		return b.sendActionCard(ctx, target, opts, opts.Actions)
+	}
 	if replyMarkup, hasKeyboard := opts.Metadata["replyMarkup"]; hasKeyboard {
-		return b.sendInteractiveCard(ctx, target, opts, replyMarkup)
+		if set := actionSetFromLegacyMarkup(replyMarkup); !set.IsEmpty() {
+			b.Logger().Debug("sendText: metadata[\"replyMarkup\"] is deprecated, use SendMessageOptions.Actions")
+			return b.sendActionCard(ctx, target, opts, set)
+		}
+		// Unrecognised shape. Historically this produced a card with no
+		// buttons at all; say so rather than shipping a mutilated card.
+		b.Logger().Warn("sendText: metadata[\"replyMarkup\"] has an unsupported shape %T, actions dropped", replyMarkup)
 	}
 
 	// Regular text message using SDK builder
@@ -446,122 +455,6 @@ func (b *Bot) sendText(ctx context.Context, target string, opts *core.SendMessag
 		MessageID: messageID,
 		Timestamp: 0,
 	}, nil
-}
-
-// sendInteractiveCard sends an interactive card with buttons
-func (b *Bot) sendInteractiveCard(ctx context.Context, target string, opts *core.SendMessageOptions, replyMarkup interface{}) (*core.SendResult, error) {
-	b.Logger().Debug("sendInteractiveCard called: target=%s", target)
-
-	// Safety checks
-	if b.client == nil {
-		return nil, fmt.Errorf("bot client is nil")
-	}
-	if b.client.Im == nil {
-		return nil, fmt.Errorf("client.Im is nil")
-	}
-
-	card := b.buildInteractiveCard(opts.Text, replyMarkup)
-	cardJson, err := card.String()
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize card: %w", err)
-	}
-
-	msgType := "interactive"
-	b.Logger().Debug("Sending card: type=%s", msgType)
-
-	// Use SDK builder pattern
-	req := larkim.NewCreateMessageReqBuilder().
-		ReceiveIdType(getReceiveIdType(target)).
-		Body(larkim.NewCreateMessageReqBodyBuilder().
-			ReceiveId(target).
-			MsgType(msgType).
-			Content(cardJson).
-			Build()).
-		Build()
-
-	b.Logger().Debug("Sending card request: target=%s, receiveIdType=%s", target, getReceiveIdType(target))
-	resp, err := b.client.Im.Message.Create(ctx, req)
-	if err != nil {
-		b.Logger().Error("Failed to send card: %v", err)
-		return nil, core.WrapError(err, core.Platform(b.domain), core.ErrPlatformError)
-	}
-
-	// Check if the API call was successful (code 0)
-	if resp.Code != 0 {
-		b.Logger().Error("API returned error code: %d, msg: %s", resp.Code, resp.Msg)
-		return nil, core.NewBotError(core.ErrPlatformError, fmt.Sprintf("API error: %s", resp.Msg), false)
-	}
-
-	b.UpdateLastActivity()
-	messageID := b.extractMessageIDFromResponse(resp)
-	b.Logger().Info("Card sent successfully: ID=%s", messageID)
-	return &core.SendResult{
-		MessageID: messageID,
-		Timestamp: 0,
-	}, nil
-}
-
-// buildInteractiveCard builds a Lark interactive card from text and keyboard markup
-func (b *Bot) buildInteractiveCard(text string, replyMarkup interface{}) *larkcard.MessageCard {
-	elements := []larkcard.MessageCardElement{
-		larkcard.NewMessageCardDiv().
-			Text(larkcard.NewMessageCardLarkMd().Content(text)),
-	}
-
-	// Convert keyboard markup to action buttons
-	// Try to convert from InlineKeyboardMarkup or map format
-	var buttons []larkcard.MessageCardActionElement
-
-	// Handle InlineKeyboardMarkup type
-	if kb, ok := replyMarkup.(interaction.InlineKeyboardMarkup); ok {
-		for _, row := range kb.InlineKeyboard {
-			for _, btn := range row {
-				button := larkcard.NewMessageCardEmbedButton().
-					Text(larkcard.NewMessageCardPlainText().Content(btn.Text)).
-					Type(larkcard.MessageCardButtonTypeDefault).
-					Value(map[string]interface{}{
-						"callback": btn.CallbackData,
-					})
-				buttons = append(buttons, button)
-			}
-		}
-	} else if kbMap, ok := replyMarkup.(map[string]interface{}); ok {
-		// Handle map format (from JSON unmarshaling)
-		if inlineKeyboard, ok := kbMap["inline_keyboard"].([]interface{}); ok {
-			for _, row := range inlineKeyboard {
-				if rowArray, ok := row.([]interface{}); ok {
-					for _, btn := range rowArray {
-						if btnMap, ok := btn.(map[string]interface{}); ok {
-							buttonText, _ := btnMap["text"].(string)
-							callbackData, _ := btnMap["callback_data"].(string)
-
-							button := larkcard.NewMessageCardEmbedButton().
-								Text(larkcard.NewMessageCardPlainText().Content(buttonText)).
-								Type(larkcard.MessageCardButtonTypeDefault).
-								Value(map[string]interface{}{
-									"callback": callbackData,
-								})
-							buttons = append(buttons, button)
-						}
-					}
-				}
-			}
-		}
-	}
-
-	if len(buttons) > 0 {
-		layout := larkcard.MessageCardActionLayoutFlow
-		action := larkcard.NewMessageCardAction().
-			Layout(&layout).
-			Actions(buttons)
-		elements = append(elements, action)
-	}
-
-	wideScreen := true
-	return larkcard.NewMessageCard().
-		Config(larkcard.NewMessageCardConfig().WideScreenMode(wideScreen)).
-		Elements(elements).
-		Build()
 }
 
 // sendMedia sends media

--- a/imbot/platform/telegram/action_render.go
+++ b/imbot/platform/telegram/action_render.go
@@ -1,0 +1,130 @@
+package telegram
+
+import (
+	"github.com/go-telegram/bot/models"
+	"github.com/tingly-dev/tingly-box/imbot/core"
+	"github.com/tingly-dev/tingly-box/imbot/interaction"
+)
+
+// Tier 3 escape hatch for Telegram-only button capabilities.
+//
+// These are deliberately NOT neutral fields on core.Action. A caller that
+// wants a Telegram mini-app button imports this package and says so; the
+// import is the declaration, and it stays greppable. Other platforms see an
+// Ext entry they do not recognise and apply the action's FallbackPolicy.
+//
+// See imbot/core/action.go for the three-tier rationale.
+
+// telegramExt is the Telegram-specific payload carried in core.Action.Ext.
+type telegramExt struct {
+	// webAppURL renders the button as a Mini App launcher.
+	webAppURL string
+	// switchInlineQuery renders the button as an inline-query switch.
+	switchInlineQuery *string
+}
+
+// WebAppButton builds an action that opens a Telegram Mini App.
+//
+// On every other platform the action falls back to a plain URL button, since
+// a mini app is a web page underneath.
+func WebAppButton(label, url string) core.Action {
+	return core.Action{
+		Label:    label,
+		URL:      url,
+		Kind:     core.ActionOpenMiniApp,
+		Fallback: core.FallbackAsURL,
+		Ext:      map[core.Platform]any{core.PlatformTelegram: telegramExt{webAppURL: url}},
+	}
+}
+
+// SwitchInlineButton builds an action that switches the user into an inline
+// query in another chat. This has no equivalent elsewhere, so it drops by
+// default; pass a Fallback explicitly if the caller wants otherwise.
+func SwitchInlineButton(label, query string) core.Action {
+	q := query
+	return core.Action{
+		Label:    label,
+		Fallback: core.FallbackDrop,
+		Ext:      map[core.Platform]any{core.PlatformTelegram: telegramExt{switchInlineQuery: &q}},
+	}
+}
+
+// resolveReplyMarkup produces the Telegram inline keyboard for an outbound
+// message, preferring the neutral Actions field and falling back to the
+// deprecated Metadata["replyMarkup"] convention.
+func (b *Bot) resolveReplyMarkup(opts *core.SendMessageOptions) *models.InlineKeyboardMarkup {
+	if !opts.Actions.IsEmpty() {
+		markup := BuildInlineKeyboard(opts.Actions)
+		return &markup
+	}
+
+	// Deprecated path: a pre-rendered platform payload in the metadata bag.
+	// Kept for one release so call sites can migrate incrementally.
+	if opts.Metadata == nil {
+		return nil
+	}
+	raw, ok := opts.Metadata["replyMarkup"]
+	if !ok {
+		return nil
+	}
+	b.Logger().Debug("SendMessage: metadata[\"replyMarkup\"] is deprecated, use SendMessageOptions.Actions")
+
+	switch m := raw.(type) {
+	case models.InlineKeyboardMarkup:
+		return &m
+	case *models.InlineKeyboardMarkup:
+		return m
+	case interaction.InlineKeyboardMarkup:
+		markup := BuildInlineKeyboard(m.ToActionSet())
+		return &markup
+	}
+	return nil
+}
+
+// BuildInlineKeyboard renders a neutral action set as a Telegram inline
+// keyboard. Actions this platform cannot express are dropped here rather than
+// at the call site — that is the whole point of the seam.
+func BuildInlineKeyboard(set *core.ActionSet) models.InlineKeyboardMarkup {
+	var rows [][]models.InlineKeyboardButton
+	for _, row := range set.Rows {
+		var buttons []models.InlineKeyboardButton
+		for _, action := range row {
+			if btn, ok := buildButton(action); ok {
+				buttons = append(buttons, btn)
+			}
+		}
+		if len(buttons) > 0 {
+			rows = append(rows, buttons)
+		}
+	}
+	return models.InlineKeyboardMarkup{InlineKeyboard: rows}
+}
+
+func buildButton(action core.Action) (models.InlineKeyboardButton, bool) {
+	btn := models.InlineKeyboardButton{Text: action.Label}
+
+	// Tier 3 first: a Telegram-specific shape wins over the neutral fields.
+	if raw, ok := action.ExtFor(core.PlatformTelegram); ok {
+		if ext, ok := raw.(telegramExt); ok {
+			switch {
+			case ext.webAppURL != "":
+				btn.WebApp = &models.WebAppInfo{URL: ext.webAppURL}
+				return btn, true
+			case ext.switchInlineQuery != nil:
+				btn.SwitchInlineQuery = ext.switchInlineQuery
+				return btn, true
+			}
+		}
+	}
+
+	switch {
+	case action.CallbackData != "":
+		btn.CallbackData = action.CallbackData
+	case action.URL != "":
+		btn.URL = action.URL
+	default:
+		// A button with neither a callback nor a URL is rejected by Telegram.
+		return models.InlineKeyboardButton{}, false
+	}
+	return btn, true
+}

--- a/imbot/platform/telegram/action_render_test.go
+++ b/imbot/platform/telegram/action_render_test.go
@@ -1,0 +1,95 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/imbot/core"
+	"github.com/tingly-dev/tingly-box/imbot/interaction"
+)
+
+func TestBuildInlineKeyboardPreservesRows(t *testing.T) {
+	set := core.NewActionSet().
+		AddRow(core.Action{Label: "A", CallbackData: "a"}, core.Action{Label: "B", CallbackData: "b"}).
+		AddRow(core.Action{Label: "C", CallbackData: "c"})
+
+	kb := BuildInlineKeyboard(set)
+	if len(kb.InlineKeyboard) != 2 {
+		t.Fatalf("rows = %d, want 2", len(kb.InlineKeyboard))
+	}
+	if len(kb.InlineKeyboard[0]) != 2 || len(kb.InlineKeyboard[1]) != 1 {
+		t.Fatalf("row layout not preserved: %v", kb.InlineKeyboard)
+	}
+	if kb.InlineKeyboard[0][0].CallbackData != "a" {
+		t.Errorf("callback = %q, want a", kb.InlineKeyboard[0][0].CallbackData)
+	}
+}
+
+func TestBuildInlineKeyboardURLAction(t *testing.T) {
+	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(
+		core.Action{Label: "Docs", URL: "https://example.test", Kind: core.ActionOpenURL},
+	))
+	if got := kb.InlineKeyboard[0][0].URL; got != "https://example.test" {
+		t.Errorf("URL = %q", got)
+	}
+}
+
+// TestBuildInlineKeyboardDropsUnsendableAction guards against emitting a button
+// with neither callback data nor a URL, which Telegram rejects outright — and
+// a rejected button fails the whole send, not just the button.
+func TestBuildInlineKeyboardDropsUnsendableAction(t *testing.T) {
+	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(core.Action{Label: "orphan"}))
+	if len(kb.InlineKeyboard) != 0 {
+		t.Errorf("expected the unsendable action to be dropped, got %v", kb.InlineKeyboard)
+	}
+}
+
+// TestWebAppButton covers the Tier 3 escape hatch: Telegram-only capabilities
+// are reachable through this package's constructors, not through neutral
+// fields, and they still declare what other platforms should do instead.
+func TestWebAppButton(t *testing.T) {
+	action := WebAppButton("Dashboard", "https://example.test/app")
+
+	if action.Fallback != core.FallbackAsURL {
+		t.Errorf("Fallback = %q, want as_url — other platforms must degrade explicitly", action.Fallback)
+	}
+	if action.URL == "" {
+		t.Error("the neutral URL must be set so the fallback has something to use")
+	}
+
+	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(action))
+	btn := kb.InlineKeyboard[0][0]
+	if btn.WebApp == nil {
+		t.Fatal("expected a web_app button on Telegram")
+	}
+	if btn.WebApp.URL != "https://example.test/app" {
+		t.Errorf("web_app URL = %q", btn.WebApp.URL)
+	}
+	if btn.CallbackData != "" {
+		t.Error("a web_app button must not also carry callback data")
+	}
+}
+
+func TestSwitchInlineButton(t *testing.T) {
+	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(SwitchInlineButton("Share", "query")))
+	btn := kb.InlineKeyboard[0][0]
+	if btn.SwitchInlineQuery == nil || *btn.SwitchInlineQuery != "query" {
+		t.Errorf("expected switch_inline_query to be set, got %+v", btn)
+	}
+}
+
+func TestKeyboardToActionSetRoundTrip(t *testing.T) {
+	kb := interaction.NewKeyboardBuilder().
+		AddRow(interaction.CallbackButton("Yes", "yes"), interaction.CallbackButton("No", "no")).
+		AddRow(interaction.URLButton("Docs", "https://example.test"))
+
+	out := BuildInlineKeyboard(kb.BuildActions())
+	if len(out.InlineKeyboard) != 2 {
+		t.Fatalf("rows = %d, want 2", len(out.InlineKeyboard))
+	}
+	if out.InlineKeyboard[0][1].CallbackData != "no" {
+		t.Errorf("callback = %q, want no", out.InlineKeyboard[0][1].CallbackData)
+	}
+	if out.InlineKeyboard[1][0].URL != "https://example.test" {
+		t.Errorf("URL = %q", out.InlineKeyboard[1][0].URL)
+	}
+}

--- a/imbot/platform/telegram/telegram.go
+++ b/imbot/platform/telegram/telegram.go
@@ -458,11 +458,9 @@ func (b *Bot) sendText(ctx context.Context, chatID int64, opts *core.SendMessage
 		}
 
 		// Set reply markup (inline keyboard) only on last chunk
-		if opts.Metadata != nil && i == len(chunks)-1 {
-			if markup, ok := opts.Metadata["replyMarkup"]; ok {
-				if replyMarkup, ok := markup.(models.InlineKeyboardMarkup); ok {
-					params.ReplyMarkup = &replyMarkup
-				}
+		if i == len(chunks)-1 {
+			if markup := b.resolveReplyMarkup(opts); markup != nil {
+				params.ReplyMarkup = markup
 			}
 		}
 

--- a/imbot/platform/tingly/adapter.go
+++ b/imbot/platform/tingly/adapter.go
@@ -3,73 +3,56 @@ package tingly
 import (
 	"time"
 
-	tgmodels "github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 	itx "github.com/tingly-dev/tingly-box/imbot/interaction"
 )
 
-// decodeReplyMarkup extracts an inline keyboard from outbound message
-// metadata. Production callers stuff one of two shapes into
-// metadata["replyMarkup"]:
+// decodeActions extracts the outbound keyboard for the test harness.
 //
-//   - imbot.InlineKeyboardMarkup (from the generic interaction package), or
-//   - models.InlineKeyboardMarkup (Telegram-specific, returned by
-//     imbot.BuildTelegramActionKeyboard, used widely by remote_control/bot).
-//
-// We accept both shapes so tingly faithfully captures keyboards regardless
-// of which API the caller used.
-func decodeReplyMarkup(meta map[string]interface{}) *Keyboard {
-	if meta == nil {
+// It prefers the neutral SendMessageOptions.Actions and falls back to the
+// deprecated Metadata["replyMarkup"] convention while call sites migrate.
+// The previous version of this function accepted two shapes — the generic
+// interaction markup and the Telegram-specific one — because remote_control
+// pre-rendered a Telegram payload for every platform. That is exactly the
+// coupling the Actions field removes, so only the legacy generic shape is
+// still decoded here.
+func decodeActions(opts *core.SendMessageOptions) *Keyboard {
+	if !opts.Actions.IsEmpty() {
+		return convertActionSet(opts.Actions)
+	}
+	if opts.Metadata == nil {
 		return nil
 	}
-	raw, ok := meta["replyMarkup"]
+	raw, ok := opts.Metadata["replyMarkup"]
 	if !ok {
 		return nil
 	}
 	switch m := raw.(type) {
+	case *core.ActionSet:
+		return convertActionSet(m)
 	case itx.InlineKeyboardMarkup:
-		return convertGenericKeyboard(m)
+		return convertActionSet(m.ToActionSet())
 	case *itx.InlineKeyboardMarkup:
 		if m == nil {
 			return nil
 		}
-		return convertGenericKeyboard(*m)
-	case tgmodels.InlineKeyboardMarkup:
-		return convertTelegramKeyboard(m)
-	case *tgmodels.InlineKeyboardMarkup:
-		if m == nil {
-			return nil
-		}
-		return convertTelegramKeyboard(*m)
+		return convertActionSet(m.ToActionSet())
 	}
 	return nil
 }
 
-func convertGenericKeyboard(m itx.InlineKeyboardMarkup) *Keyboard {
-	out := &Keyboard{Rows: make([][]Button, 0, len(m.InlineKeyboard))}
-	for _, row := range m.InlineKeyboard {
-		buttons := make([]Button, 0, len(row))
-		for _, b := range row {
-			buttons = append(buttons, Button{
-				Label:        b.Text,
-				CallbackData: b.CallbackData,
-				URL:          b.URL,
-			})
-		}
-		out.Rows = append(out.Rows, buttons)
+func convertActionSet(set *core.ActionSet) *Keyboard {
+	if set.IsEmpty() {
+		return nil
 	}
-	return out
-}
-
-func convertTelegramKeyboard(m tgmodels.InlineKeyboardMarkup) *Keyboard {
-	out := &Keyboard{Rows: make([][]Button, 0, len(m.InlineKeyboard))}
-	for _, row := range m.InlineKeyboard {
+	out := &Keyboard{Rows: make([][]Button, 0, len(set.Rows))}
+	for _, row := range set.Rows {
 		buttons := make([]Button, 0, len(row))
-		for _, b := range row {
+		for _, a := range row {
 			buttons = append(buttons, Button{
-				Label:        b.Text,
-				CallbackData: b.CallbackData,
-				URL:          b.URL,
+				Label:        a.Label,
+				CallbackData: a.CallbackData,
+				URL:          a.URL,
 			})
 		}
 		out.Rows = append(out.Rows, buttons)

--- a/imbot/platform/tingly/tingly_test.go
+++ b/imbot/platform/tingly/tingly_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	tgmodels "github.com/go-telegram/bot/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tingly-dev/tingly-box/imbot/core"
@@ -71,15 +70,23 @@ func TestBot_SendWithGenericKeyboard(t *testing.T) {
 	assert.Equal(t, "ia:1:approve", events[0].Keyboard.Rows[0][0].CallbackData)
 }
 
-func TestBot_SendWithTelegramKeyboard(t *testing.T) {
+// TestBot_SendWithActions covers the current contract: callers hand over a
+// neutral action set and the platform renders it.
+//
+// This replaces TestBot_SendWithTelegramKeyboard, which asserted that tingly
+// could decode a go-telegram InlineKeyboardMarkup out of the metadata bag.
+// That decoding existed only because remote_control pre-rendered a Telegram
+// payload for every platform — the coupling SendMessageOptions.Actions
+// removes — so the behaviour it pinned is gone on purpose.
+func TestBot_SendWithActions(t *testing.T) {
 	bot, tr := newReadyBot(t)
 
-	tgKB := tgmodels.InlineKeyboardMarkup{InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
-		{{Text: "Yes", CallbackData: "yes"}, {Text: "No", CallbackData: "no"}},
-	}}
 	_, err := bot.SendMessage(context.Background(), "chat-1", &core.SendMessageOptions{
-		Text:     "ok?",
-		Metadata: map[string]any{"replyMarkup": tgKB},
+		Text: "ok?",
+		Actions: core.NewActionSet().AddRow(
+			core.Action{Label: "Yes", CallbackData: "yes"},
+			core.Action{Label: "No", CallbackData: "no"},
+		),
 	})
 	require.NoError(t, err)
 
@@ -91,6 +98,26 @@ func TestBot_SendWithTelegramKeyboard(t *testing.T) {
 		{Label: "Yes", CallbackData: "yes"},
 		{Label: "No", CallbackData: "no"},
 	}, events[0].Keyboard.Rows[0])
+}
+
+// TestBot_SendWithLegacyKeyboardMetadata pins the deprecated compatibility
+// path, which stays for one release while call sites migrate.
+func TestBot_SendWithLegacyKeyboardMetadata(t *testing.T) {
+	bot, tr := newReadyBot(t)
+
+	kb := itx.InlineKeyboardMarkup{InlineKeyboard: [][]itx.InlineKeyboardButton{
+		{{Text: "Yes", CallbackData: "yes"}},
+	}}
+	_, err := bot.SendMessage(context.Background(), "chat-1", &core.SendMessageOptions{
+		Text:     "ok?",
+		Metadata: map[string]any{"replyMarkup": kb},
+	})
+	require.NoError(t, err)
+
+	events := tr.EventsForChat("chat-1")
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].Keyboard)
+	assert.Equal(t, []Button{{Label: "Yes", CallbackData: "yes"}}, events[0].Keyboard.Rows[0])
 }
 
 func TestBot_EditDeleteReact(t *testing.T) {

--- a/imbot/platform/tingly/transport.go
+++ b/imbot/platform/tingly/transport.go
@@ -195,7 +195,7 @@ func (t *InProcessTransport) Send(ctx context.Context, target string, opts *core
 		if len(media) > 0 && text == "" {
 			kind = EventMedia
 		}
-		kb = decodeReplyMarkup(opts.Metadata)
+		kb = decodeActions(opts)
 	}
 	t.record(Event{
 		Kind:      kind,

--- a/imbot/tests/telegram_e2e_test.go
+++ b/imbot/tests/telegram_e2e_test.go
@@ -79,9 +79,7 @@ func TestE2E_TelegramBot_RealBot(t *testing.T) {
 		msg, err := bot.SendMessage(context.Background(), testChatID, &imbot.SendMessageOptions{
 			Text:      "🔐 *Tool Permission Request*\n\nTool: `Bash`\n\nArgs: \n\tcmd: `ls -la...`\n\nReason: test_permission",
 			ParseMode: imbot.ParseModeMarkdown,
-			Metadata: map[string]interface{}{
-				"replyMarkup": imbot.BuildTelegramActionKeyboard(kb.Build()),
-			},
+			Actions:   kb.BuildActions(),
 		})
 
 		if err != nil {

--- a/imbot/util.go
+++ b/imbot/util.go
@@ -2,7 +2,6 @@ package imbot
 
 import (
 	tgbot "github.com/go-telegram/bot"
-	"github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 )
 
@@ -17,28 +16,6 @@ import (
 //   - []string: Array of text chunks, each within the platform's limit
 func ChunkText(platform string, text string) []string {
 	return core.ChunkTextForPlatform(core.Platform(platform), text)
-}
-
-// BuildTelegramActionKeyboard converts imbot.InlineKeyboardMarkup to models.InlineKeyboardMarkup
-func BuildTelegramActionKeyboard(kb InlineKeyboardMarkup) models.InlineKeyboardMarkup {
-	var rows [][]models.InlineKeyboardButton
-	for _, row := range kb.InlineKeyboard {
-		var buttons []models.InlineKeyboardButton
-		for _, btn := range row {
-			tgBtn := models.InlineKeyboardButton{
-				Text: btn.Text,
-			}
-			if btn.CallbackData != "" {
-				tgBtn.CallbackData = btn.CallbackData
-			}
-			if btn.URL != "" {
-				tgBtn.URL = btn.URL
-			}
-			buttons = append(buttons, tgBtn)
-		}
-		rows = append(rows, buttons)
-	}
-	return models.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 // EscapeMarkdown escapes special characters for Telegram MarkdownV2

--- a/internal/remote_control/bot/agent_claude_code.go
+++ b/internal/remote_control/bot/agent_claude_code.go
@@ -245,13 +245,12 @@ func claudePermissionPolicy(sessionMode string) (string, bool) {
 // successful execution. Replaces the legacy CompletionCallback.OnComplete.
 func (e *ClaudeCodeExecutor) sendTaskDoneCard(hCtx HandlerContext, meta *ResponseMeta) {
 	kb := feature.BuildActionKeyboard()
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
-	actionCard := feature.BuildActionCard()
 
 	doneText := IconDone + " " + MsgTaskDone + ". " + MsgContinueOrHelp + BuildFooter(meta.AgentType, meta.ProjectPath)
 	if _, err := hCtx.Bot.SendMessage(context.Background(), hCtx.ChatID, &imbot.SendMessageOptions{
 		Text:     doneText,
-		Metadata: buildTrackedActionMenuMetadata(hCtx, tgKeyboard, actionCard),
+		Actions:  kb.BuildActions(),
+		Metadata: trackActionMenuMetadata(),
 	}); err != nil {
 		logrus.WithError(err).Warn("ClaudeCodeExecutor: failed to send Task done card")
 	}

--- a/internal/remote_control/bot/bot_agent.go
+++ b/internal/remote_control/bot/bot_agent.go
@@ -164,22 +164,15 @@ func (c *SmartGuideCompletionCallback) OnComplete(result *smart_guide.Completion
 
 	// Send action keyboard on completion
 	kb := feature.BuildActionKeyboard()
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
-	actionCard := feature.BuildActionCard()
-
-	metadata := buildTrackedActionMenuMetadata(c.hCtx, tgKeyboard, actionCard)
-	// Forward context_token from incoming message metadata (required by Weixin)
-	if c.hCtx.Message.Metadata != nil {
-		if ct, ok := c.hCtx.Message.Metadata["context_token"].(string); ok {
-			metadata["context_token"] = ct
-		}
-	}
 
 	sgDoneText := IconDone + " " + MsgTaskDone + ". " + MsgContinueOrHelp + BuildFooter(c.meta.AgentType, c.meta.ProjectPath)
-	_, err := c.hCtx.Bot.SendMessage(context.Background(), c.hCtx.ChatID, &imbot.SendMessageOptions{
+	opts := &imbot.SendMessageOptions{
 		Text:     sgDoneText,
-		Metadata: metadata,
-	})
+		Actions:  kb.BuildActions(),
+		Metadata: trackActionMenuMetadata(),
+	}
+	forwardReplyContext(opts, c.hCtx.Message)
+	_, err := c.hCtx.Bot.SendMessage(context.Background(), c.hCtx.ChatID, opts)
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to send action keyboard for SmartGuide")
 	}

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -218,11 +218,11 @@ func (h *BotHandler) handleBotProjectCommand(hCtx HandlerContext) {
 
 	text := buildProjectText(currentPath, projectPaths)
 	keyboard := buildProjectKeyboard(currentPath, projectPaths)
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
 
 	_, err := hCtx.Bot.SendMessage(context.Background(), hCtx.ChatID, &imbot.SendMessageOptions{
 		Text:     text,
-		Metadata: buildTrackedReplyMetadata(tgKeyboard),
+		Actions:  keyboard.ToActionSet(),
+		Metadata: trackActionMenuMetadata(),
 	})
 	if err != nil {
 		logrus.WithError(err).Error("Failed to send project list")

--- a/internal/remote_control/bot/bot_file_send.go
+++ b/internal/remote_control/bot/bot_file_send.go
@@ -53,15 +53,7 @@ func (h *BotHandler) SendFile(ctx context.Context, hCtx HandlerContext, filePath
 		Media: []imbot.MediaAttachment{attachment},
 	}
 
-	// Forward context_token from incoming message metadata (required by Weixin)
-	if hCtx.Message.Metadata != nil {
-		if ct, ok := hCtx.Message.Metadata["context_token"].(string); ok {
-			if opts.Metadata == nil {
-				opts.Metadata = make(map[string]interface{})
-			}
-			opts.Metadata["context_token"] = ct
-		}
-	}
+	forwardReplyContext(opts, hCtx.Message)
 
 	_, err = hCtx.Bot.SendMessage(ctx, hCtx.ChatID, opts)
 	if err != nil {

--- a/internal/remote_control/bot/card_metadata.go
+++ b/internal/remote_control/bot/card_metadata.go
@@ -1,57 +1,51 @@
 package bot
 
-import (
-	"github.com/tingly-dev/tingly-box/imbot"
-	imbotfeishu "github.com/tingly-dev/tingly-box/imbot/platform/feishu"
-)
+// Outbound interactive controls now travel as a neutral imbot.ActionSet on
+// SendMessageOptions.Actions, and each platform renders them itself.
+//
+// This file used to build three parallel renderings of the same buttons into
+// the metadata bag — a Telegram markup under "replyMarkup", a neutral card
+// under "card", and Feishu card JSON under "card_json" — and hope the right
+// one got picked up. Two of the three were never read on any send path, and
+// the one that was carried a go-telegram type that Feishu could not decode,
+// so Feishu users got messages with no buttons at all.
+//
+// What is left here is the one thing that genuinely is out-of-band metadata:
+// the flag asking the send path to remember this message's ID so the action
+// menu can be removed later.
+
+import "github.com/tingly-dev/tingly-box/imbot"
 
 const trackActionMenuIDKey = "_trackActionMenuID"
 
-func buildReplyMetadata(tgKeyboard interface{}) map[string]interface{} {
+// trackActionMenuMetadata marks an outbound message as the current action-menu
+// message, so its ID is recorded and the menu can be taken down later.
+func trackActionMenuMetadata() map[string]interface{} {
 	return map[string]interface{}{
-		"replyMarkup": tgKeyboard,
+		trackActionMenuIDKey: true,
 	}
 }
 
-func buildTrackedReplyMetadata(tgKeyboard interface{}) map[string]interface{} {
-	metadata := buildReplyMetadata(tgKeyboard)
-	metadata[trackActionMenuIDKey] = true
-	return metadata
-}
-
-// buildActionMenuMetadata builds metadata for action menu with platform-specific card rendering
-func buildActionCardMetadata(tgKeyboard interface{}, card imbot.Card) map[string]interface{} {
-	metadata := buildReplyMetadata(tgKeyboard)
-	metadata["card"] = card
-	return metadata
-}
-
-func buildActionMenuMetadata(hCtx HandlerContext, tgKeyboard interface{}, card imbot.Card) map[string]interface{} {
-	metadata := buildActionCardMetadata(tgKeyboard, card)
-
-	// For Feishu/Lark, add card_json.
-	//
-	// TODO(phase-2a): this whole branch goes away. The caller should not be
-	// rendering a platform's wire format at all — it should hand over a
-	// neutral Card and let the platform render it. Note that today nothing on
-	// the Feishu send path reads metadata["card_json"] (only feishu/menu.go
-	// does, and remote_control never goes through the menu adapter), so this
-	// is already inert; see .sdlc/research/arch-remote-control-platform-seams §3.1.
-	if hCtx.Platform == imbot.PlatformFeishu || hCtx.Platform == imbot.PlatformLark {
-		if cardJSON, err := imbotfeishu.RenderCard(card); err == nil {
-			metadata["card_json"] = cardJSON
-		}
+// forwardReplyContext copies the inbound message's reply-context token onto
+// outbound options. Weixin and WeCom tie each reply to the inbound message it
+// answers, and drop or misattribute a reply that arrives without the token.
+//
+// This was five copies of the same block across four files. Consolidating it
+// is also what makes Seam 2 a small change later: when the bot learns to carry
+// its own reply context, this is the single function that goes away.
+//
+// TODO(phase-4): this should not be the caller's job at all — the bot knows
+// which inbound message it is answering.
+func forwardReplyContext(opts *imbot.SendMessageOptions, inbound imbot.Message) {
+	if inbound.Metadata == nil {
+		return
 	}
-
-	return metadata
-}
-
-func (h *BotHandler) buildTrackedActionMenuMetadata(hCtx HandlerContext, tgKeyboard interface{}, card imbot.Card) map[string]interface{} {
-	return buildTrackedActionMenuMetadata(hCtx, tgKeyboard, card)
-}
-
-func buildTrackedActionMenuMetadata(hCtx HandlerContext, tgKeyboard interface{}, card imbot.Card) map[string]interface{} {
-	metadata := buildActionMenuMetadata(hCtx, tgKeyboard, card)
-	metadata[trackActionMenuIDKey] = true
-	return metadata
+	token, _ := inbound.Metadata["context_token"].(string)
+	if token == "" {
+		return
+	}
+	if opts.Metadata == nil {
+		opts.Metadata = make(map[string]interface{})
+	}
+	opts.Metadata["context_token"] = token
 }

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -352,10 +352,10 @@ func newProjectCommand(adapter BotHandlerAdapter) imbot.Command {
 
 			if interactive && len(projectPaths) > 0 {
 				keyboard := buildProjectKeyboard(currentPath, projectPaths)
-				tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
 				_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
 					Text:     text + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
-					Metadata: buildTrackedReplyMetadata(tgKeyboard),
+					Actions:  keyboard.ToActionSet(),
+					Metadata: trackActionMenuMetadata(),
 				})
 				if err != nil {
 					logrus.WithError(err).Error("Failed to send project list")
@@ -774,10 +774,10 @@ func newResumeCommand(adapter BotHandlerAdapter) imbot.Command {
 			caps := imbot.GetPlatformCapabilities(string(ctx.Platform))
 			if ctx.IsDirectMessage && caps != nil && caps.SupportsInteraction() {
 				keyboard := buildResumeKeyboard(sessions)
-				tgKeyboard := imbot.BuildTelegramActionKeyboard(keyboard)
 				_, err := ctx.Bot.SendMessage(context.Background(), ctx.ChatID, &imbot.SendMessageOptions{
 					Text:     text + adapter.BuildReplyFooter(ctx.ChatID, string(ctx.Platform)),
-					Metadata: buildTrackedReplyMetadata(tgKeyboard),
+					Actions:  keyboard.ToActionSet(),
+					Metadata: trackActionMenuMetadata(),
 				})
 				if err != nil {
 					logrus.WithError(err).Error("Failed to send resume list with keyboard")

--- a/internal/remote_control/bot/feature/action_menu.go
+++ b/internal/remote_control/bot/feature/action_menu.go
@@ -39,24 +39,6 @@ func BuildActionKeyboard() *imbot.KeyboardBuilder {
 		)
 }
 
-// BuildActionCard builds the generic action card for post-completion menu
-func BuildActionCard() imbot.Card {
-	return imbot.NewCard("remote_control_action_menu").
-		AddActions(
-			imbot.CallbackCardAction("clear", "🗑 Clear",
-				imbot.FormatCallbackData("action", "clear")).
-				WithStyle(imbot.CardActionStyleDanger).
-				Build(),
-			imbot.CallbackCardAction("bind", "📁 CD",
-				imbot.FormatCallbackData("action", "bind")).
-				Build(),
-			imbot.CallbackCardAction("project", "🔧 Project",
-				imbot.FormatCallbackData("action", "project")).
-				Build(),
-		).
-		Build()
-}
-
 // BuildCancelKeyboard builds a simple cancel keyboard
 func BuildCancelKeyboard() *imbot.KeyboardBuilder {
 	return imbot.NewKeyboardBuilder().

--- a/internal/remote_control/bot/feature/telegram_dir_browser.go
+++ b/internal/remote_control/bot/feature/telegram_dir_browser.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/imbot"
+	imbottelegram "github.com/tingly-dev/tingly-box/imbot/platform/telegram"
 )
 
 const (
@@ -379,11 +380,16 @@ func SendDirectoryBrowser(ctx context.Context, bot imbot.Bot, browser *Directory
 		return "", err
 	}
 
-	// Try to cast bot to TelegramBot for editing
+	// Try to cast bot to TelegramBot for editing.
+	//
+	// TODO(phase-3): this is the last place that still needs a Telegram
+	// payload, because in-place message editing has not been lifted to a
+	// capability interface yet. Seam 4 (MessageRestater) replaces it, at which
+	// point Feishu and tingly get editing too.
 	tgBot, ok := imbot.AsTelegramBot(bot)
 	if ok && editMessageID != "" && state.MessageID != "" {
 		// Edit existing message
-		tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
+		tgKeyboard := imbottelegram.BuildInlineKeyboard(kb.BuildActions())
 		if err := tgBot.EditMessageWithKeyboard(ctx, chatID, editMessageID, text, &tgKeyboard); err != nil {
 			logrus.WithError(err).Warn("Failed to edit message, sending new one")
 			// Fall through to send new message
@@ -392,16 +398,11 @@ func SendDirectoryBrowser(ctx context.Context, bot imbot.Bot, browser *Directory
 		}
 	}
 
-	// Convert keyboard for Telegram
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
-
-	// Send new message with keyboard
+	// Send new message with the action set; each platform renders it itself.
 	result, err := bot.SendMessage(ctx, chatID, &imbot.SendMessageOptions{
 		Text:      text,
 		ParseMode: imbot.ParseModeMarkdown,
-		Metadata: map[string]interface{}{
-			"replyMarkup": tgKeyboard,
-		},
+		Actions:   kb.BuildActions(),
 	})
 	if err != nil {
 		return "", err

--- a/internal/remote_control/bot/handler_send.go
+++ b/internal/remote_control/bot/handler_send.go
@@ -19,15 +19,7 @@ func (h *BotHandler) SendText(hCtx HandlerContext, text string) {
 		Text:      text,
 		ParseMode: imbot.ParseModeMarkdown,
 	}
-	// Forward context_token from incoming message metadata (required by Weixin)
-	if hCtx.Message.Metadata != nil {
-		if ct, ok := hCtx.Message.Metadata["context_token"].(string); ok {
-			if opts.Metadata == nil {
-				opts.Metadata = make(map[string]interface{})
-			}
-			opts.Metadata["context_token"] = ct
-		}
-	}
+	forwardReplyContext(opts, hCtx.Message)
 	resp, err := bot.SendMessage(context.Background(), hCtx.ChatID, opts)
 	_ = resp
 	if err != nil {
@@ -62,15 +54,7 @@ func (h *BotHandler) sendTextWithReply(hCtx HandlerContext, text string, replyTo
 		ParseMode: imbot.ParseModeMarkdown,
 		ReplyTo:   replyTo,
 	}
-	// Forward context_token from incoming message metadata (required by Weixin)
-	if hCtx.Message.Metadata != nil {
-		if ct, ok := hCtx.Message.Metadata["context_token"].(string); ok {
-			if opts.Metadata == nil {
-				opts.Metadata = make(map[string]interface{})
-			}
-			opts.Metadata["context_token"] = ct
-		}
-	}
+	forwardReplyContext(opts, hCtx.Message)
 	_, err := bot.SendMessage(context.Background(), hCtx.ChatID, opts)
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to send message")
@@ -88,17 +72,6 @@ func (h *BotHandler) sendTextWithActionKeyboard(hCtx HandlerContext, text string
 		return
 	}
 	kb := feature.BuildActionKeyboard()
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
-
-	// Extract context_token from incoming message metadata (required by Weixin)
-	var contextToken string
-	if hCtx.Message.Metadata != nil {
-		if ct, ok := hCtx.Message.Metadata["context_token"].(string); ok {
-			contextToken = ct
-		}
-	}
-
-	actionCard := feature.BuildActionCard()
 
 	bot := h.botFromCtx(hCtx)
 	if bot == nil {
@@ -115,17 +88,12 @@ func (h *BotHandler) sendTextWithActionKeyboard(hCtx HandlerContext, text string
 		if replyTo != "" {
 			opts.ReplyTo = replyTo
 		}
-		// Only attach keyboard to the last chunk
+		// Only attach the action menu to the last chunk
 		if i == len(chunks)-1 {
-			opts.Metadata = h.buildTrackedActionMenuMetadata(hCtx, tgKeyboard, actionCard)
+			opts.Actions = kb.BuildActions()
+			opts.Metadata = trackActionMenuMetadata()
 		}
-		// Forward context_token for Weixin
-		if contextToken != "" {
-			if opts.Metadata == nil {
-				opts.Metadata = make(map[string]interface{})
-			}
-			opts.Metadata["context_token"] = contextToken
-		}
+		forwardReplyContext(opts, hCtx.Message)
 
 		result, err := bot.SendMessage(context.Background(), hCtx.ChatID, opts)
 		if err != nil {

--- a/internal/remote_control/bot/prompt_reply.go
+++ b/internal/remote_control/bot/prompt_reply.go
@@ -32,13 +32,7 @@ func promptReplyRouter(mgr *imbot.Manager, prompter *imchannel.IMPrompter) OnMes
 				Text:      text,
 				ParseMode: imbot.ParseModeMarkdown,
 			}
-			// Forward context_token from the incoming message (required by
-			// Weixin), mirroring BotHandler.SendText.
-			if msg.Metadata != nil {
-				if ct, ok := msg.Metadata["context_token"].(string); ok {
-					opts.Metadata = map[string]interface{}{"context_token": ct}
-				}
-			}
+			forwardReplyContext(opts, msg)
 			_, _ = bot.SendMessage(context.Background(), chatID, opts)
 		}
 

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -231,12 +231,12 @@ func (h *BotHandler) handleCustomPathPrompt(hCtx HandlerContext) {
 
 	// Send prompt with cancel keyboard
 	kb := feature.BuildCancelKeyboard()
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
 
 	result, err := hCtx.Bot.SendMessage(context.Background(), hCtx.ChatID, &imbot.SendMessageOptions{
 		Text:      BuildCustomPathPrompt(),
 		ParseMode: imbot.ParseModeMarkdown,
-		Metadata:  buildTrackedReplyMetadata(tgKeyboard),
+		Actions:   kb.BuildActions(),
+		Metadata:  trackActionMenuMetadata(),
 	})
 	if err != nil {
 		logrus.WithError(err).Error("Failed to send custom path prompt")
@@ -262,12 +262,12 @@ func (h *BotHandler) handleCreateConfirm(hCtx HandlerContext, path string) {
 	h.directoryBrowser.SetWaitingInput(hCtx.ChatID, false, "")
 
 	kb, text := feature.BuildCreateConfirmKeyboard(path)
-	tgKeyboard := imbot.BuildTelegramActionKeyboard(kb.Build())
 
 	_, err := hCtx.Bot.SendMessage(context.Background(), hCtx.ChatID, &imbot.SendMessageOptions{
 		Text:      text,
 		ParseMode: imbot.ParseModeMarkdown,
-		Metadata:  buildTrackedReplyMetadata(tgKeyboard),
+		Actions:   kb.BuildActions(),
+		Metadata:  trackActionMenuMetadata(),
 	})
 	if err != nil {
 		logrus.WithError(err).Error("Failed to send create confirmation")

--- a/remote/channel/imchannel/imprompter.go
+++ b/remote/channel/imchannel/imprompter.go
@@ -172,9 +172,7 @@ func (p *IMPrompter) Prompt(ctx context.Context, req ask.Request) (ask.Result, e
 		ParseMode: imbot.ParseModeMarkdown,
 	}
 	if supportsKeyboard {
-		opts.Metadata = map[string]interface{}{
-			"replyMarkup": imbot.BuildTelegramActionKeyboard(keyboard),
-		}
+		opts.Actions = keyboard.ToActionSet()
 	}
 	msg, err := bot.SendMessage(context.Background(), chatID, opts)
 	if err != nil {


### PR DESCRIPTION
**Stack 2 of 3.**

1. ~~#1434 — ownership moves~~ ✅ merged
2. **this PR** — neutral outbound actions (now based on `main`)
3. #1436 — capability table and message restating (based on this PR)

## Root cause

> imbot abstracts **inbound** messages (`core.Message` normalisation) and the **send action** (`SendMessage`), but not the **outbound payload**. That travelled through an untyped `Metadata map[string]interface{}`, so every caller had to know which platform it was talking to.

The historical shape — three renderings of the same buttons at one call site, hoping the right one got picked up:

```go
metadata["replyMarkup"] = tgKeyboard                     // Telegram shape
metadata["card"]        = card                           // neutral shape
if platform == Feishu { metadata["card_json"] = ... }    // Feishu shape
```

The last two were never read on any send path. The first carried a go-telegram type Feishu could not decode.

## Defect fixed: inline buttons were invisible on Feishu/Lark

`remote_control` always sent a `models.InlineKeyboardMarkup`; Feishu's type switch accepted only `interaction.InlineKeyboardMarkup` and `map[string]interface{}`, matched neither, and produced a card with **no buttons at all**. Clear / CD / Project, the directory browser and the `/resume` picker were all unreachable for Feishu users.

Feishu now renders from the neutral set, and an unrecognised legacy shape logs a warning rather than silently shipping a mutilated card.

## Design

`SendMessageOptions.Actions *core.ActionSet` — the caller describes intent, the platform decides presentation. Rows are preserved because layout is meaningful (the directory browser depends on it); platforms with no row concept flatten.

**Tier 3 escape hatch ships in the same PR, deliberately.** Removing `Metadata["replyMarkup"]` closes the only existing route to a Telegram-specific button; closing it without opening another would be a capability regression. So `telegram.WebAppButton` / `SwitchInlineButton` populate `Action.Ext` instead — the caller's import is the declaration and stays greppable. The point was never to eliminate platform-specific code, only the *invisible* kind.

Only the fallback policies a platform actually honours are defined. An "append as numbered text" policy would suit platforms with no interactive support, but nothing implements it yet — and a policy that silently does nothing is precisely the failure this seam exists to remove.

13 call sites migrated, including `imchannel/imprompter.go`: the leak had already crossed out of `remote_control` into the shared prompter, so fixing only `remote_control` would not have been enough.

`BuildTelegramActionKeyboard` is gone from the public API. The deprecated metadata path still works for one release and logs on use. tingly's dual-shape decoder is gone — it existed only to absorb the Telegram payload callers used to send, which is the coupling this removes.

## Deliberately deferred

`SendMessageOptions.Card` — the Card type family has 48 external references and no send path consumes it yet; `Actions` alone is what the defect needed. `Action.Payload` replacing `CallbackData` touches the callback protocol and belongs in its own PR. Per-action `Style` is unrendered today and follows `Card`.

## Verification

Rebased onto `main` after #1434 merged (squash, so the branch's parent commit was dropped rather than replayed); tree content is byte-identical to what was reviewed before the rebase.

Build and `go vet` clean with and without `-tags e2e`; 92 packages pass, 0 failures.

New tests cover the Feishu regression (button count and callbacks must survive), row preservation and unsendable-button rejection on Telegram, Tier 3 round-trip and fallback on a foreign platform, and both the new contract and the compat path on tingly.

One test was deliberately replaced rather than fixed: `TestBot_SendWithTelegramKeyboard` asserted that tingly could decode a go-telegram markup out of the metadata bag. That decoding existed only because `remote_control` pre-rendered a Telegram payload for every platform, so the behaviour it pinned is gone on purpose.