### PR TITLE
refactor(imbot) 3/3: capability table and message restating

### DIFF
--- a/.design/imbot-platform-seams.md
+++ b/.design/imbot-platform-seams.md
@@ -249,9 +249,6 @@ Telegram 在**每一列**都是最紧的。它的约束已经泄漏成全平台�
 
 ## 6. 阶段与落地状态
 
-阶段 1 / 2a / 3 以**三个 stacked PR** 交付（依赖关系是真实的：2a 依赖 1 的归属搬迁，
-3 依赖 2a 的 `ActionSet`），而不是一个大 PR——每个阶段本来就是独立的评审单元。
-
 | 阶段 | 内容 | 状态 |
 |---|---|---|
 | **1** | 归属搬迁：Feishu 渲染器进 `platform/feishu`；Weixin QR 客户端去重；`telegram_keyboard.go` → `action_menu.go` | ✅ 已落地 |

--- a/imbot/core/behavior_test.go
+++ b/imbot/core/behavior_test.go
@@ -1,0 +1,45 @@
+package core
+
+import "testing"
+
+// TestPlatformBehaviorPairingDefaults pins which platforms enforce TOFU pairing
+// when the operator has expressed no preference. Getting this wrong in the
+// permissive direction means anyone holding a leaked bot token gets full DM
+// command access, so the table is worth an explicit test.
+func TestPlatformBehaviorPairingDefaults(t *testing.T) {
+	tokenDM := []Platform{PlatformTelegram, PlatformDiscord, PlatformSlack}
+	for _, p := range tokenDM {
+		if !GetPlatformBehavior(p).RequiresPairingByDefault {
+			t.Errorf("%s hands out DM access to any token holder and must default to pairing", p)
+		}
+	}
+
+	others := []Platform{PlatformFeishu, PlatformLark, PlatformDingTalk, PlatformWecom, PlatformWeixin, PlatformTingly}
+	for _, p := range others {
+		if GetPlatformBehavior(p).RequiresPairingByDefault {
+			t.Errorf("%s authenticates through the platform itself; pairing should not be forced", p)
+		}
+	}
+}
+
+func TestPlatformBehaviorVerbose(t *testing.T) {
+	// Weixin ties each outbound message to a single inbound reply context, so
+	// a running commentary of intermediate messages cannot be delivered.
+	if !GetPlatformBehavior(PlatformWeixin).SuppressVerbose {
+		t.Error("weixin cannot carry intermediate progress messages")
+	}
+	for _, p := range []Platform{PlatformTelegram, PlatformFeishu, PlatformTingly} {
+		if GetPlatformBehavior(p).SuppressVerbose {
+			t.Errorf("%s supports intermediate messages", p)
+		}
+	}
+}
+
+// TestPlatformBehaviorUnknownIsConservative covers the property that makes the
+// zero value safe: an unknown platform must not accidentally opt into anything.
+func TestPlatformBehaviorUnknownIsConservative(t *testing.T) {
+	b := GetPlatformBehavior(Platform("some-future-platform"))
+	if b.RequiresPairingByDefault || b.SuppressVerbose {
+		t.Errorf("unknown platform got non-zero behavior: %+v", b)
+	}
+}

--- a/imbot/core/platforms.go
+++ b/imbot/core/platforms.go
@@ -24,6 +24,41 @@ type PlatformDescriptor struct {
 	// Reactions maps semantic reaction tokens to platform-specific emoji/keys.
 	// nil means ResolveReaction falls back to the token string itself.
 	Reactions map[ReactionToken]string
+	// Behavior holds the product-level defaults a platform implies. These used
+	// to be switch statements scattered across the consuming packages, which
+	// meant adding a platform required finding every one of them.
+	Behavior PlatformBehavior
+}
+
+// PlatformBehavior captures the product-level defaults that follow from a
+// platform's nature rather than from operator configuration.
+//
+// Everything here has a safe zero value, so a platform with no entry behaves
+// like the conservative default rather than silently misbehaving.
+type PlatformBehavior struct {
+	// RequiresPairingByDefault marks platforms where possession of the bot
+	// token alone grants full DM command access, so a TOFU pairing handshake
+	// is enforced unless the operator explicitly opts out.
+	RequiresPairingByDefault bool
+
+	// SuppressVerbose marks platforms that cannot carry a running commentary
+	// of intermediate progress messages — typically because each outbound
+	// message is tied to a single inbound reply context, so follow-ups either
+	// fail or arrive detached.
+	//
+	// Phrased as "suppress" rather than "supports" so the zero value means
+	// "verbose is fine", which is true of every platform but the exceptions.
+	SuppressVerbose bool
+}
+
+// GetPlatformBehavior returns the product-level defaults for a platform. An
+// unknown platform gets the zero value, which is the conservative choice for
+// every field.
+func GetPlatformBehavior(platform Platform) PlatformBehavior {
+	if d, ok := platformByID[platform]; ok {
+		return d.Behavior
+	}
+	return PlatformBehavior{}
 }
 
 // platformDescriptors is the canonical, ordered list of known platforms.
@@ -42,6 +77,7 @@ var platformDescriptors = []PlatformDescriptor{
 	},
 	{
 		ID:          PlatformTelegram,
+		Behavior:    PlatformBehavior{RequiresPairingByDefault: true},
 		DisplayName: "Telegram",
 		Capabilities: &PlatformCapabilities{
 			ChatTypes:  []ChatType{ChatTypeDirect, ChatTypeGroup, ChatTypeChannel, ChatTypeThread},
@@ -54,6 +90,7 @@ var platformDescriptors = []PlatformDescriptor{
 	},
 	{
 		ID:          PlatformDiscord,
+		Behavior:    PlatformBehavior{RequiresPairingByDefault: true},
 		DisplayName: "Discord",
 		Capabilities: &PlatformCapabilities{
 			ChatTypes:  []ChatType{ChatTypeDirect, ChatTypeGroup, ChatTypeChannel, ChatTypeThread},
@@ -66,6 +103,7 @@ var platformDescriptors = []PlatformDescriptor{
 	},
 	{
 		ID:          PlatformSlack,
+		Behavior:    PlatformBehavior{RequiresPairingByDefault: true},
 		DisplayName: "Slack",
 		Capabilities: &PlatformCapabilities{
 			ChatTypes:  []ChatType{ChatTypeDirect, ChatTypeGroup, ChatTypeChannel, ChatTypeThread},
@@ -156,6 +194,7 @@ var platformDescriptors = []PlatformDescriptor{
 		// Weixin has no explicit capabilities entry and intentionally falls
 		// back to the conservative default (see GetPlatformCapabilities).
 		ID:          PlatformWeixin,
+		Behavior:    PlatformBehavior{SuppressVerbose: true},
 		DisplayName: "Weixin",
 	},
 	{

--- a/imbot/core/restate.go
+++ b/imbot/core/restate.go
@@ -1,0 +1,75 @@
+package core
+
+import "context"
+
+// Restating a message means replacing its presentation: new body, different
+// controls, or no controls at all. It is the counterpart to sending — the way
+// a bot says "this message and its buttons are stale now".
+//
+// The interface deliberately expresses the *intent*, not the mechanism. How a
+// platform achieves it is its own business: Telegram edits the message in
+// place, Feishu patches the card, another platform might post a replacement
+// and strip the old controls. Callers that ask for "edit this message" would
+// be encoding one platform's mechanism into the contract, which is how
+// AsTelegramBot ended up gating this capability on a concrete type and leaving
+// every other platform with stale, re-clickable keyboards.
+//
+// Platforms that cannot do it at all simply do not implement the interface;
+// AsRestater then reports false and the caller behaves as before.
+
+// MessageRef identifies a previously sent message.
+type MessageRef struct {
+	ChatID    string
+	MessageID string
+}
+
+// IsZero reports whether the reference is unusable.
+func (r MessageRef) IsZero() bool {
+	return r.ChatID == "" || r.MessageID == ""
+}
+
+// RestateOptions describes the new presentation of a message.
+type RestateOptions struct {
+	// Text is the new body. Empty means "leave the body as it is" — used when
+	// the point of the call is only to take the controls away.
+	Text string
+	// Actions are the new controls. Nil removes them all, which is the common
+	// case: a menu that has been used should not be usable twice.
+	Actions *ActionSet
+	// ParseMode applies to Text when it is set.
+	ParseMode ParseMode
+}
+
+// MessageRestater is implemented by platforms that can replace an already-sent
+// message's presentation.
+type MessageRestater interface {
+	Restate(ctx context.Context, ref MessageRef, opts RestateOptions) error
+}
+
+// AsRestater reports whether a bot can restate messages.
+//
+// Note this is an *interface* assertion, unlike the AsTelegramBot it replaces,
+// which asserted a concrete *telegram.Bot and so could never be satisfied by
+// any other platform however capable.
+func AsRestater(bot Bot) (MessageRestater, bool) {
+	r, ok := bot.(MessageRestater)
+	return r, ok
+}
+
+// RestateOrIgnore restates a message when the platform supports it, and does
+// nothing otherwise. Most call sites want exactly this: taking a used menu
+// down is best-effort, and failing to do so must never break the flow that
+// followed the button press.
+//
+// It returns whether the restate was both supported and successful, which
+// callers use to decide whether to fall back to sending a new message.
+func RestateOrIgnore(ctx context.Context, bot Bot, ref MessageRef, opts RestateOptions) bool {
+	if ref.IsZero() {
+		return false
+	}
+	restater, ok := AsRestater(bot)
+	if !ok {
+		return false
+	}
+	return restater.Restate(ctx, ref, opts) == nil
+}

--- a/imbot/core/types.go
+++ b/imbot/core/types.go
@@ -51,9 +51,12 @@ const (
 	ErrMessageTooLong    ErrorCode = "MESSAGE_TOO_LONG"
 	ErrInvalidTarget     ErrorCode = "INVALID_TARGET"
 	ErrMediaNotSupported ErrorCode = "MEDIA_NOT_SUPPORTED"
-	ErrPlatformError     ErrorCode = "PLATFORM_ERROR"
-	ErrTimeout           ErrorCode = "TIMEOUT"
-	ErrUnknown           ErrorCode = "UNKNOWN"
+	// ErrNotSupported marks an operation this platform cannot perform at all,
+	// as opposed to one that failed. Callers treat it as "capability absent".
+	ErrNotSupported  ErrorCode = "NOT_SUPPORTED"
+	ErrPlatformError ErrorCode = "PLATFORM_ERROR"
+	ErrTimeout       ErrorCode = "TIMEOUT"
+	ErrUnknown       ErrorCode = "UNKNOWN"
 )
 
 // Sender represents the message sender

--- a/imbot/imbot.go
+++ b/imbot/imbot.go
@@ -2,10 +2,13 @@
 package imbot
 
 import (
+	"context"
+
 	"github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot/command"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 	"github.com/tingly-dev/tingly-box/imbot/interaction"
+	platformreg "github.com/tingly-dev/tingly-box/imbot/platform"
 	"github.com/tingly-dev/tingly-box/imbot/platform/feishu"
 	"github.com/tingly-dev/tingly-box/imbot/platform/telegram"
 )
@@ -475,4 +478,49 @@ const (
 // NewActionSet creates an empty action set.
 func NewActionSet() *core.ActionSet {
 	return core.NewActionSet()
+}
+
+// Message restating — replacing an already-sent message's presentation.
+//
+// This replaces the AsTelegramBot + RemoveMessageKeyboard / EditMessageWithKeyboard
+// pattern, which gated the capability on a *concrete* type assertion and so
+// could never be satisfied by Feishu or tingly however capable they were —
+// leaving their users with stale, re-clickable keyboards.
+type (
+	// MessageRef identifies a previously sent message.
+	MessageRef = core.MessageRef
+	// RestateOptions describes a message's new presentation.
+	RestateOptions = core.RestateOptions
+	// MessageRestater is implemented by platforms that can restate messages.
+	MessageRestater = core.MessageRestater
+)
+
+// AsRestater reports whether a bot can restate messages. Unlike AsTelegramBot
+// this is an interface assertion, so any capable platform satisfies it.
+func AsRestater(bot Bot) (core.MessageRestater, bool) {
+	return core.AsRestater(bot)
+}
+
+// RestateOrIgnore restates a message where supported and does nothing
+// otherwise, reporting whether it succeeded. Taking a used menu down is
+// best-effort: it must never break the flow that followed the button press.
+func RestateOrIgnore(ctx context.Context, bot Bot, ref core.MessageRef, opts core.RestateOptions) bool {
+	return core.RestateOrIgnore(ctx, bot, ref, opts)
+}
+
+// GetPlatformBehavior returns the product-level defaults a platform implies
+// (pairing enforcement, verbose suppression). Consumers query this instead of
+// switching on platform names, so adding a platform is a table edit.
+func GetPlatformBehavior(platform Platform) core.PlatformBehavior {
+	return core.GetPlatformBehavior(platform)
+}
+
+// PlatformBehavior re-exports the platform behavior record.
+type PlatformBehavior = core.PlatformBehavior
+
+// SetupCommandMenu installs a command registry into the platform's native
+// command menu (Telegram's menu button, Feishu/Lark quick actions). Platforms
+// without one are a no-op, so callers do not branch on platform.
+func SetupCommandMenu(bot Bot, platform Platform, reg *CommandRegistry) error {
+	return platformreg.SetupCommandMenu(bot, platform, reg)
 }

--- a/imbot/platform.go
+++ b/imbot/platform.go
@@ -9,6 +9,41 @@ type PlatformAuthConfig struct {
 	DisplayName string      `json:"display_name"` // Human-readable platform name
 	Category    string      `json:"category"`     // "im", "enterprise", "business"
 	Fields      []FieldSpec `json:"fields"`       // Required/optional auth fields
+
+	// Auth describes how the stored auth map becomes a core.AuthConfig.
+	//
+	// Deliberately separate from Fields: Fields is the settings-UI form, this
+	// is the wire mapping. They usually overlap, but not always — Weixin's
+	// credentials arrive from the QR flow and have no form fields at all, so
+	// deriving the wire mapping from Fields would leave Weixin bots unable to
+	// authenticate.
+	Auth AuthMapping `json:"-"`
+}
+
+// AuthMapping says which auth-map keys feed which core.AuthConfig fields, and
+// which of them a bot cannot start without.
+//
+// This exists so that adding a platform is a table edit rather than a hunt for
+// every switch statement over platform names. Lark is the cautionary tale: it
+// was present in this table but missing from two hand-written switches in the
+// bot manager, so Lark bots were rejected as having no valid credentials and,
+// had they got past that, would have been handed a token-type auth config that
+// the Feishu client rejects.
+type AuthMapping struct {
+	// Type is the core.AuthConfig type: token, oauth, qr, none.
+	Type string
+	// TokenKey and friends name the auth-map key feeding each AuthConfig field.
+	// An empty name means the field is not used by this platform.
+	TokenKey        string
+	ClientIDKey     string
+	ClientSecretKey string
+	AccountIDKey    string
+	AuthDirKey      string
+	// OptionKeys are auth-map entries forwarded verbatim into Config.Options
+	// rather than into AuthConfig.
+	OptionKeys []string
+	// RequiredKeys must all be present and non-empty before a bot may start.
+	RequiredKeys []string
 }
 
 // FieldSpec defines a single auth field
@@ -25,6 +60,7 @@ type FieldSpec struct {
 var PlatformConfigs = map[string]PlatformAuthConfig{
 	"telegram": {
 		Platform: "telegram",
+		Auth:     AuthMapping{Type: "token", TokenKey: "token", RequiredKeys: []string{"token"}},
 		AuthType: "token",
 		Category: "im",
 		Fields: []FieldSpec{
@@ -40,6 +76,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"slack": {
 		Platform: "slack",
+		Auth:     AuthMapping{Type: "token", TokenKey: "token", RequiredKeys: []string{"token"}},
 		AuthType: "token",
 		Category: "im",
 		Fields: []FieldSpec{
@@ -55,6 +92,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"discord": {
 		Platform: "discord",
+		Auth:     AuthMapping{Type: "token", TokenKey: "token", RequiredKeys: []string{"token"}},
 		AuthType: "token",
 		Category: "im",
 		Fields: []FieldSpec{
@@ -70,6 +108,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"dingtalk": {
 		Platform: "dingtalk",
+		Auth:     AuthMapping{Type: "oauth", ClientIDKey: "clientId", ClientSecretKey: "clientSecret", RequiredKeys: []string{"clientId", "clientSecret"}},
 		AuthType: "oauth",
 		Category: "enterprise",
 		Fields: []FieldSpec{
@@ -93,6 +132,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"feishu": {
 		Platform: "feishu",
+		Auth:     AuthMapping{Type: "oauth", ClientIDKey: "clientId", ClientSecretKey: "clientSecret", RequiredKeys: []string{"clientId", "clientSecret"}},
 		AuthType: "oauth",
 		Category: "enterprise",
 		Fields: []FieldSpec{
@@ -116,6 +156,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"lark": {
 		Platform: "lark",
+		Auth:     AuthMapping{Type: "oauth", ClientIDKey: "clientId", ClientSecretKey: "clientSecret", RequiredKeys: []string{"clientId", "clientSecret"}},
 		AuthType: "oauth",
 		Category: "enterprise",
 		Fields: []FieldSpec{
@@ -139,6 +180,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"whatsapp": {
 		Platform: "whatsapp",
+		Auth:     AuthMapping{Type: "token", TokenKey: "token", AccountIDKey: "phoneNumberId", RequiredKeys: []string{"token"}},
 		AuthType: "token",
 		Category: "business",
 		Fields: []FieldSpec{
@@ -162,12 +204,14 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"weixin": {
 		Platform: "weixin",
+		Auth:     AuthMapping{Type: "qr", TokenKey: "token", AccountIDKey: "bot_id", AuthDirKey: "user_id", OptionKeys: []string{"user_id", "base_url"}, RequiredKeys: []string{"token", "bot_id"}},
 		AuthType: "qr",
 		Category: "enterprise",
 		Fields:   []FieldSpec{}, // No fields - credentials set via QR flow
 	},
 	"wecom": {
 		Platform: "wecom",
+		Auth:     AuthMapping{Type: "oauth", ClientIDKey: "clientId", ClientSecretKey: "clientSecret", RequiredKeys: []string{"clientId", "clientSecret"}},
 		AuthType: "oauth",
 		Category: "enterprise",
 		Fields: []FieldSpec{
@@ -191,6 +235,7 @@ var PlatformConfigs = map[string]PlatformAuthConfig{
 	},
 	"tingly": {
 		Platform: "tingly",
+		Auth:     AuthMapping{Type: "none", TokenKey: "token"},
 		AuthType: "none",
 		Category: "im",
 		Fields:   []FieldSpec{}, // No required credentials
@@ -254,4 +299,68 @@ var AuthTypeLabels = map[string]string{
 	"oauth": "OAuth",
 	"qr":    "QR Code",
 	"basic": "Basic Auth",
+}
+
+// defaultAuthMapping is used for platforms with no entry in PlatformConfigs.
+// Historically that meant "assume a bot token", which is the least surprising
+// guess for a new IM platform.
+var defaultAuthMapping = AuthMapping{Type: "token", TokenKey: "token", RequiredKeys: []string{"token"}}
+
+// AuthMappingFor returns a platform's auth mapping, falling back to the
+// token-based default for unknown platforms.
+func AuthMappingFor(platform string) AuthMapping {
+	if cfg, ok := PlatformConfigs[platform]; ok && cfg.Auth.Type != "" {
+		return cfg.Auth
+	}
+	return defaultAuthMapping
+}
+
+// BuildAuthConfig converts a bot's stored auth map into a core.AuthConfig.
+func BuildAuthConfig(platform string, auth map[string]string) AuthConfig {
+	m := AuthMappingFor(platform)
+	pick := func(key string) string {
+		if key == "" {
+			return ""
+		}
+		return auth[key]
+	}
+	return AuthConfig{
+		Type:         m.Type,
+		Token:        pick(m.TokenKey),
+		ClientID:     pick(m.ClientIDKey),
+		ClientSecret: pick(m.ClientSecretKey),
+		AccountID:    pick(m.AccountIDKey),
+		AuthDir:      pick(m.AuthDirKey),
+	}
+}
+
+// MissingAuthKeys lists the required auth keys a bot has not been given. An
+// empty result means the bot has everything it needs to attempt a connection.
+func MissingAuthKeys(platform string, auth map[string]string) []string {
+	var missing []string
+	for _, key := range AuthMappingFor(platform).RequiredKeys {
+		if auth[key] == "" {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+// AuthOptions returns the auth-map entries a platform expects in Config.Options
+// rather than in AuthConfig (Weixin's user_id / base_url).
+func AuthOptions(platform string, auth map[string]string) map[string]interface{} {
+	keys := AuthMappingFor(platform).OptionKeys
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make(map[string]interface{}, len(keys))
+	for _, key := range keys {
+		if v, ok := auth[key]; ok && v != "" {
+			out[key] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/imbot/platform/feishu/action_render.go
+++ b/imbot/platform/feishu/action_render.go
@@ -166,3 +166,57 @@ func actionSetFromMap(m map[string]interface{}) *core.ActionSet {
 	}
 	return set
 }
+
+// Restate implements core.MessageRestater.
+//
+// Feishu patches the card in place (PATCH /im/v1/messages/:id), which updates
+// what the user already sees without pushing a new notification — the property
+// that makes "take the used menu down" safe to do here rather than by posting a
+// replacement message.
+//
+// Patching only applies to interactive (card) messages. Every message this
+// package sends with actions is a card, and markdown text is also sent as a
+// card, so the common cases are covered; a plain-text message cannot be
+// patched and the API reports that as an error, which callers treat as
+// best-effort.
+//
+// One case Feishu cannot serve: a patch replaces the whole card content, so
+// there is no way to drop the buttons while leaving the body alone. Callers
+// asking for that (RestateOptions with no Text) get an error rather than a
+// card whose body has been blanked — losing the user's message would be worse
+// than leaving a stale menu up.
+func (b *Bot) Restate(ctx context.Context, ref core.MessageRef, opts core.RestateOptions) error {
+	if ref.IsZero() {
+		return core.NewInvalidTargetError(core.Platform(b.domain), ref.MessageID, "empty message reference")
+	}
+	if opts.Text == "" {
+		return core.NewBotError(core.ErrNotSupported,
+			"feishu cannot change a card's controls without also rewriting its body; supply RestateOptions.Text",
+			false)
+	}
+	if b.client == nil || b.client.Im == nil {
+		return fmt.Errorf("bot client is nil")
+	}
+
+	card := buildActionCard(opts.Text, opts.Actions)
+	cardJSON, err := card.String()
+	if err != nil {
+		return fmt.Errorf("failed to serialize card: %w", err)
+	}
+
+	resp, err := b.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
+		MessageId(ref.MessageID).
+		Body(larkim.NewPatchMessageReqBodyBuilder().
+			Content(cardJSON).
+			Build()).
+		Build())
+	if err != nil {
+		return core.WrapError(err, core.Platform(b.domain), core.ErrPlatformError)
+	}
+	if resp.Code != 0 {
+		return core.NewBotError(core.ErrPlatformError, fmt.Sprintf("patch card failed: %s", resp.Msg), false)
+	}
+
+	b.UpdateLastActivity()
+	return nil
+}

--- a/imbot/platform/feishu/action_render_test.go
+++ b/imbot/platform/feishu/action_render_test.go
@@ -1,6 +1,7 @@
 package feishu
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -114,5 +115,35 @@ func TestActionSetFromLegacyMarkup(t *testing.T) {
 	// rather than silently shipping a button-less card.
 	if !actionSetFromLegacyMarkup(struct{ Nope bool }{}).IsEmpty() {
 		t.Error("expected an unknown markup shape to decode to nothing")
+	}
+}
+
+// TestRestateRefusesBodylessRequest pins a contract Feishu cannot satisfy.
+//
+// core.RestateOptions documents empty Text as "leave the body alone", which is
+// what the three "take the used menu down" call sites ask for. A Feishu card
+// patch replaces the whole content, so honouring that request literally would
+// blank out the user's message — strictly worse than leaving a stale menu up.
+// The platform reports the capability as absent instead, and RestateOrIgnore
+// turns that into a no-op.
+func TestRestateRefusesBodylessRequest(t *testing.T) {
+	bot := &Bot{domain: DomainFeishu}
+	err := bot.Restate(context.Background(),
+		core.MessageRef{ChatID: "oc_x", MessageID: "om_x"},
+		core.RestateOptions{})
+
+	if err == nil {
+		t.Fatal("expected a bodyless restate to be refused, not to blank the card")
+	}
+	if code := core.GetErrorCode(err); code != core.ErrNotSupported {
+		t.Errorf("error code = %q, want %q so callers can tell absence from failure",
+			code, core.ErrNotSupported)
+	}
+}
+
+func TestRestateRejectsZeroRef(t *testing.T) {
+	bot := &Bot{domain: DomainFeishu}
+	if err := bot.Restate(context.Background(), core.MessageRef{}, core.RestateOptions{Text: "x"}); err == nil {
+		t.Error("expected an empty message reference to be rejected")
 	}
 }

--- a/imbot/platform/menu_setup.go
+++ b/imbot/platform/menu_setup.go
@@ -1,0 +1,33 @@
+package platform
+
+import (
+	"github.com/tingly-dev/tingly-box/imbot/command"
+	"github.com/tingly-dev/tingly-box/imbot/core"
+	"github.com/tingly-dev/tingly-box/imbot/platform/feishu"
+	"github.com/tingly-dev/tingly-box/imbot/platform/telegram"
+)
+
+// commandMenuSetup maps a platform to its native command-menu installer.
+//
+// This lives beside the bot-creator registry because it is the same kind of
+// fact: what a platform can do and how to reach it. It used to be a switch in
+// internal/remote_control's bot manager, which meant the consumer had to
+// import platform packages and be edited whenever a platform gained a menu.
+//
+// A platform with no entry simply has no native command menu — that is a
+// normal outcome, not an error.
+var commandMenuSetup = map[core.Platform]func(core.Bot, *command.CommandRegistry) error{
+	core.PlatformTelegram: telegram.SetupMenuButton,
+	core.PlatformFeishu:   feishu.SetupQuickActions,
+	core.PlatformLark:     feishu.SetupQuickActions,
+}
+
+// SetupCommandMenu installs the command registry into the platform's native
+// menu. Platforms without one are a no-op, so callers do not need to ask first.
+func SetupCommandMenu(bot core.Bot, platform core.Platform, reg *command.CommandRegistry) error {
+	setup, ok := commandMenuSetup[platform]
+	if !ok {
+		return nil
+	}
+	return setup(bot, reg)
+}

--- a/imbot/platform/telegram/action_render.go
+++ b/imbot/platform/telegram/action_render.go
@@ -1,6 +1,8 @@
 package telegram
 
 import (
+	"context"
+
 	"github.com/go-telegram/bot/models"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 	"github.com/tingly-dev/tingly-box/imbot/interaction"
@@ -127,4 +129,31 @@ func buildButton(action core.Action) (models.InlineKeyboardButton, bool) {
 		return models.InlineKeyboardButton{}, false
 	}
 	return btn, true
+}
+
+// Restate implements core.MessageRestater.
+//
+// Telegram edits in place: the body via editMessageText when new text is
+// given, and the controls via editMessageReplyMarkup — an empty keyboard being
+// how Telegram expresses "no controls".
+func (b *Bot) Restate(ctx context.Context, ref core.MessageRef, opts core.RestateOptions) error {
+	if ref.IsZero() {
+		return core.NewInvalidTargetError(core.PlatformTelegram, ref.MessageID, "empty message reference")
+	}
+
+	var markup *models.InlineKeyboardMarkup
+	if !opts.Actions.IsEmpty() {
+		kb := BuildInlineKeyboard(opts.Actions)
+		markup = &kb
+	}
+
+	if opts.Text == "" {
+		// Controls-only change. An empty inline keyboard clears the buttons.
+		if markup == nil {
+			markup = &models.InlineKeyboardMarkup{InlineKeyboard: [][]models.InlineKeyboardButton{}}
+		}
+		return b.editReplyMarkup(ctx, ref.ChatID, ref.MessageID, markup)
+	}
+
+	return b.editMessageText(ctx, ref.ChatID, ref.MessageID, opts.Text, markup)
 }

--- a/imbot/platform/telegram/telegram.go
+++ b/imbot/platform/telegram/telegram.go
@@ -298,33 +298,36 @@ func (b *Bot) EditMessage(ctx context.Context, messageID string, text string) er
 
 // EditMessageWithKeyboard edits a message with text and inline keyboard
 func (b *Bot) EditMessageWithKeyboard(ctx interface{}, chatID string, messageID string, text string, keyboard *models.InlineKeyboardMarkup) error {
+	// The ctx parameter is a historical any-typed placeholder that was never
+	// used; the bot's own context is what drives the call. Kept for the
+	// existing interface — new code goes through Restate.
+	return b.editMessageText(b.ctx, chatID, messageID, text, keyboard)
+}
+
+// editMessageText replaces a message's body and inline keyboard. A nil
+// keyboard removes the controls, which is how Telegram's editMessageText
+// behaves when no reply markup is supplied.
+func (b *Bot) editMessageText(ctx context.Context, chatID string, messageID string, text string, keyboard *models.InlineKeyboardMarkup) error {
 	if err := b.EnsureReady(); err != nil {
 		return err
 	}
 
-	// Parse chat ID
 	chatIDInt, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		return core.NewInvalidTargetError(core.PlatformTelegram, chatID, "invalid chat ID")
 	}
-
-	// Parse message ID
 	msgIDInt, err := strconv.Atoi(messageID)
 	if err != nil {
 		return core.NewInvalidTargetError(core.PlatformTelegram, messageID, "invalid message ID")
 	}
 
-	params := &tgbot.EditMessageTextParams{
-		ChatID:    chatIDInt,
-		MessageID: msgIDInt,
-		Text:      escapeMarkdownV2(text),   // Apply MarkdownV2 escaping
-		ParseMode: models.ParseModeMarkdown, // Use this for MarkdownV2
-	}
-
-	// Set keyboard if provided
-	params.ReplyMarkup = keyboard
-
-	_, err = b.api.EditMessageText(b.ctx, params)
+	_, err = b.api.EditMessageText(ctx, &tgbot.EditMessageTextParams{
+		ChatID:      chatIDInt,
+		MessageID:   msgIDInt,
+		Text:        escapeMarkdownV2(text),   // Apply MarkdownV2 escaping
+		ParseMode:   models.ParseModeMarkdown, // Use this for MarkdownV2
+		ReplyMarkup: keyboard,
+	})
 	if err != nil {
 		return core.WrapError(err, core.PlatformTelegram, core.ErrPlatformError)
 	}
@@ -335,32 +338,32 @@ func (b *Bot) EditMessageWithKeyboard(ctx interface{}, chatID string, messageID 
 
 // RemoveMessageKeyboard removes the inline keyboard from a message
 func (b *Bot) RemoveMessageKeyboard(ctx interface{}, chatID string, messageID string) error {
+	// An empty inline keyboard is how Telegram expresses "no controls".
+	return b.editReplyMarkup(b.ctx, chatID, messageID, &models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{},
+	})
+}
+
+// editReplyMarkup swaps a message's inline keyboard without touching its body.
+func (b *Bot) editReplyMarkup(ctx context.Context, chatID string, messageID string, markup *models.InlineKeyboardMarkup) error {
 	if err := b.EnsureReady(); err != nil {
 		return err
 	}
 
-	// Parse chat ID
 	chatIDInt, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		return core.NewInvalidTargetError(core.PlatformTelegram, chatID, "invalid chat ID")
 	}
-
-	// Parse message ID
 	msgIDInt, err := strconv.Atoi(messageID)
 	if err != nil {
 		return core.NewInvalidTargetError(core.PlatformTelegram, messageID, "invalid message ID")
 	}
 
-	// Create edit config with empty inline keyboard to remove existing keyboard
-	params := &tgbot.EditMessageReplyMarkupParams{
-		ChatID:    chatIDInt,
-		MessageID: msgIDInt,
-		ReplyMarkup: &models.InlineKeyboardMarkup{
-			InlineKeyboard: [][]models.InlineKeyboardButton{},
-		},
-	}
-
-	_, err = b.api.EditMessageReplyMarkup(b.ctx, params)
+	_, err = b.api.EditMessageReplyMarkup(ctx, &tgbot.EditMessageReplyMarkupParams{
+		ChatID:      chatIDInt,
+		MessageID:   msgIDInt,
+		ReplyMarkup: markup,
+	})
 	if err != nil {
 		return core.WrapError(err, core.PlatformTelegram, core.ErrPlatformError)
 	}

--- a/imbot/platform/tingly/restate_test.go
+++ b/imbot/platform/tingly/restate_test.go
@@ -1,0 +1,77 @@
+package tingly
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+// TestRestateTakesMenuDown covers the capability that AsTelegramBot used to
+// gate behind a concrete type assertion. tingly implementing it is what lets
+// the "used menus are taken down" behaviour be asserted on a platform other
+// than Telegram at all.
+func TestRestateTakesMenuDown(t *testing.T) {
+	bot, tr := newReadyBot(t)
+
+	sent, err := bot.SendMessage(context.Background(), "chat-1", &core.SendMessageOptions{
+		Text:    "pick one",
+		Actions: core.NewActionSet().AddRow(core.Action{Label: "Yes", CallbackData: "yes"}),
+	})
+	require.NoError(t, err)
+
+	ref := core.MessageRef{ChatID: "chat-1", MessageID: sent.MessageID}
+	require.True(t, core.RestateOrIgnore(context.Background(), bot, ref, core.RestateOptions{}))
+
+	events := tr.EventsForChat("chat-1")
+	require.Len(t, events, 2)
+	assert.Equal(t, EventRestate, events[1].Kind)
+	assert.Equal(t, sent.MessageID, events[1].MessageID)
+	assert.Nil(t, events[1].Keyboard, "nil actions must clear the controls")
+	assert.Empty(t, events[1].Text, "empty text leaves the body alone")
+}
+
+func TestRestateReplacesTextAndActions(t *testing.T) {
+	bot, tr := newReadyBot(t)
+
+	sent, err := bot.SendText(context.Background(), "chat-1", "page 1")
+	require.NoError(t, err)
+
+	ref := core.MessageRef{ChatID: "chat-1", MessageID: sent.MessageID}
+	opts := core.RestateOptions{
+		Text:    "page 2",
+		Actions: core.NewActionSet().AddRow(core.Action{Label: "Next", CallbackData: "next"}),
+	}
+	require.True(t, core.RestateOrIgnore(context.Background(), bot, ref, opts))
+
+	events := tr.EventsForChat("chat-1")
+	require.Len(t, events, 2)
+	assert.Equal(t, "page 2", events[1].Text)
+	require.NotNil(t, events[1].Keyboard)
+	assert.Equal(t, "Next", events[1].Keyboard.Rows[0][0].Label)
+}
+
+// TestRestateOrIgnoreOnUnsupportedPlatform pins the contract that keeps call
+// sites simple: restating is best-effort and must never break the flow that
+// followed the button press.
+func TestRestateOrIgnoreOnUnsupportedPlatform(t *testing.T) {
+	bot, _ := newReadyBot(t)
+
+	// A zero reference is not usable and must be reported as such rather than
+	// attempted.
+	assert.False(t, core.RestateOrIgnore(context.Background(), bot, core.MessageRef{}, core.RestateOptions{}))
+	assert.False(t, core.RestateOrIgnore(context.Background(), bot,
+		core.MessageRef{ChatID: "chat-1"}, core.RestateOptions{}))
+
+	// A bot that does not implement the capability reports false without panicking.
+	var plain core.Bot = notARestater{}
+	_, ok := core.AsRestater(plain)
+	assert.False(t, ok)
+	assert.False(t, core.RestateOrIgnore(context.Background(), plain,
+		core.MessageRef{ChatID: "c", MessageID: "m"}, core.RestateOptions{}))
+}
+
+// notARestater is a core.Bot that deliberately lacks the Restate method.
+type notARestater struct{ core.Bot }

--- a/imbot/platform/tingly/tingly.go
+++ b/imbot/platform/tingly/tingly.go
@@ -123,3 +123,19 @@ func (b *Bot) DeleteMessage(ctx context.Context, messageID string) error {
 func (b *Bot) PlatformInfo() *core.PlatformInfo {
 	return core.NewPlatformInfoFor(core.PlatformTingly)
 }
+
+// Restate implements core.MessageRestater.
+//
+// tingly is the in-process E2E harness, so it implements the capability purely
+// to make restate paths observable in tests — without it, every assertion
+// about "the used menu is taken down" would only ever exercise Telegram.
+func (b *Bot) Restate(ctx context.Context, ref core.MessageRef, opts core.RestateOptions) error {
+	if err := b.EnsureReady(); err != nil {
+		return err
+	}
+	if ref.IsZero() {
+		return core.NewInvalidTargetError(core.PlatformTingly, ref.MessageID, "empty message reference")
+	}
+	b.UpdateLastActivity()
+	return b.transport.Restate(ctx, ref, opts)
+}

--- a/imbot/platform/tingly/transport.go
+++ b/imbot/platform/tingly/transport.go
@@ -25,6 +25,8 @@ const (
 	EventDelete EventKind = "delete"
 	EventReact  EventKind = "react"
 	EventMedia  EventKind = "media"
+	// EventRestate is a message-presentation replacement (see core.MessageRestater).
+	EventRestate EventKind = "restate"
 )
 
 // Event records a single outbound action issued by the bot.
@@ -50,9 +52,8 @@ type Event struct {
 	Raw *core.SendMessageOptions
 }
 
-// Keyboard is a decoded inline keyboard. It accepts both
-// imbot.InlineKeyboardMarkup and the Telegram models.InlineKeyboardMarkup —
-// see DecodeReplyMarkup in adapter.go.
+// Keyboard is a decoded inline keyboard, built from the neutral
+// core.ActionSet an outbound message carries — see decodeActions in adapter.go.
 type Keyboard struct {
 	Rows [][]Button
 }
@@ -82,6 +83,9 @@ type Transport interface {
 
 	// Edit records a message edit.
 	Edit(ctx context.Context, messageID, text string) error
+
+	// Restate records a message-presentation replacement.
+	Restate(ctx context.Context, ref core.MessageRef, opts core.RestateOptions) error
 
 	// Delete records a message delete.
 	Delete(ctx context.Context, messageID string) error
@@ -230,6 +234,22 @@ func (t *InProcessTransport) Edit(ctx context.Context, messageID, text string) e
 		ChatID:    chatID,
 		MessageID: messageID,
 		Text:      text,
+	})
+	return nil
+}
+
+// Restate records a restate (message-presentation replacement) event so tests
+// can assert that a used menu was taken down on a non-Telegram platform.
+func (t *InProcessTransport) Restate(ctx context.Context, ref core.MessageRef, opts core.RestateOptions) error {
+	if t.closed.Load() {
+		return core.NewBotError(core.ErrConnectionFailed, "tingly transport closed", false)
+	}
+	t.record(Event{
+		Kind:      EventRestate,
+		ChatID:    ref.ChatID,
+		MessageID: ref.MessageID,
+		Text:      opts.Text,
+		Keyboard:  convertActionSet(opts.Actions),
 	})
 	return nil
 }

--- a/imbot/platform_auth_test.go
+++ b/imbot/platform_auth_test.go
@@ -1,0 +1,155 @@
+package imbot
+
+import "testing"
+
+// TestBuildAuthConfigLark is the regression test for a defect the table
+// replaced: "lark" was present in PlatformConfigs but missing from both
+// hand-written switches in the bot manager, so Lark bots were rejected as
+// having no valid credentials, and would have been handed a token-type auth
+// config that the Feishu client rejects even if they had got past that.
+func TestBuildAuthConfigLark(t *testing.T) {
+	auth := map[string]string{"clientId": "cli_x", "clientSecret": "sec"}
+
+	cfg := BuildAuthConfig("lark", auth)
+	if cfg.Type != "oauth" {
+		t.Errorf("Type = %q, want oauth — the Feishu client rejects anything else", cfg.Type)
+	}
+	if cfg.ClientID != "cli_x" || cfg.ClientSecret != "sec" {
+		t.Errorf("credentials not mapped: %+v", cfg)
+	}
+	if missing := MissingAuthKeys("lark", auth); len(missing) != 0 {
+		t.Errorf("a fully configured Lark bot reports missing keys: %v", missing)
+	}
+}
+
+func TestBuildAuthConfigPerPlatform(t *testing.T) {
+	tests := []struct {
+		platform string
+		auth     map[string]string
+		wantType string
+		check    func(*testing.T, AuthConfig)
+	}{
+		{
+			platform: "telegram",
+			auth:     map[string]string{"token": "t"},
+			wantType: "token",
+			check: func(t *testing.T, c AuthConfig) {
+				if c.Token != "t" {
+					t.Errorf("Token = %q", c.Token)
+				}
+			},
+		},
+		{
+			platform: "feishu",
+			auth:     map[string]string{"clientId": "id", "clientSecret": "sec"},
+			wantType: "oauth",
+			check: func(t *testing.T, c AuthConfig) {
+				if c.ClientID != "id" || c.ClientSecret != "sec" {
+					t.Errorf("oauth fields not mapped: %+v", c)
+				}
+			},
+		},
+		{
+			platform: "whatsapp",
+			auth:     map[string]string{"token": "t", "phoneNumberId": "p"},
+			wantType: "token",
+			check: func(t *testing.T, c AuthConfig) {
+				if c.AccountID != "p" {
+					t.Errorf("AccountID = %q, want the phone number id", c.AccountID)
+				}
+			},
+		},
+		{
+			platform: "weixin",
+			auth:     map[string]string{"token": "t", "bot_id": "b", "user_id": "u", "base_url": "https://x"},
+			wantType: "qr",
+			check: func(t *testing.T, c AuthConfig) {
+				if c.AccountID != "b" {
+					t.Errorf("AccountID = %q, want bot_id", c.AccountID)
+				}
+				if c.AuthDir != "u" {
+					t.Errorf("AuthDir = %q, want user_id — Weixin reuses this field", c.AuthDir)
+				}
+			},
+		},
+		{
+			platform: "tingly",
+			auth:     map[string]string{},
+			wantType: "none",
+			check:    func(t *testing.T, c AuthConfig) {},
+		},
+		{
+			// A platform with no table entry falls back to a bot token, which
+			// is the least surprising guess for a new IM platform.
+			platform: "some-future-platform",
+			auth:     map[string]string{"token": "t"},
+			wantType: "token",
+			check: func(t *testing.T, c AuthConfig) {
+				if c.Token != "t" {
+					t.Errorf("Token = %q", c.Token)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			cfg := BuildAuthConfig(tt.platform, tt.auth)
+			if cfg.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", cfg.Type, tt.wantType)
+			}
+			tt.check(t, cfg)
+			if missing := MissingAuthKeys(tt.platform, tt.auth); len(missing) != 0 {
+				t.Errorf("unexpected missing keys: %v", missing)
+			}
+		})
+	}
+}
+
+// TestMissingAuthKeysNamesThem covers the operator-facing half: a bot that
+// cannot start should say which credential it lacks, not just "no valid
+// credentials".
+func TestMissingAuthKeysNamesThem(t *testing.T) {
+	missing := MissingAuthKeys("feishu", map[string]string{"clientId": "id"})
+	if len(missing) != 1 || missing[0] != "clientSecret" {
+		t.Errorf("missing = %v, want [clientSecret]", missing)
+	}
+
+	if missing := MissingAuthKeys("tingly", nil); len(missing) != 0 {
+		t.Errorf("tingly needs no credentials, got %v", missing)
+	}
+}
+
+// TestAuthOptionsWeixin covers credentials that travel as connection options
+// rather than as auth fields.
+func TestAuthOptionsWeixin(t *testing.T) {
+	opts := AuthOptions("weixin", map[string]string{
+		"token": "t", "bot_id": "b", "user_id": "u", "base_url": "https://x",
+	})
+	if opts["user_id"] != "u" || opts["base_url"] != "https://x" {
+		t.Errorf("weixin options = %v", opts)
+	}
+	if _, leaked := opts["token"]; leaked {
+		t.Error("token belongs in AuthConfig, not in connection options")
+	}
+
+	if opts := AuthOptions("telegram", map[string]string{"token": "t"}); opts != nil {
+		t.Errorf("telegram has no option-carried credentials, got %v", opts)
+	}
+}
+
+// TestAuthMappingCoversEveryConfiguredPlatform guards the table against the
+// exact drift that broke Lark: an entry that describes a form but never says
+// how those fields reach the client.
+func TestAuthMappingCoversEveryConfiguredPlatform(t *testing.T) {
+	for id, cfg := range PlatformConfigs {
+		if cfg.Auth.Type == "" {
+			t.Errorf("platform %q has no auth mapping", id)
+			continue
+		}
+		if cfg.Auth.Type != cfg.AuthType {
+			t.Errorf("platform %q: auth mapping type %q disagrees with form AuthType %q",
+				id, cfg.Auth.Type, cfg.AuthType)
+		}
+	}
+}

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -276,10 +276,9 @@ func (h *BotHandler) handleResumePick(hCtx HandlerContext, sessionID string, msg
 	// Strip the keyboard from the original listing message so the user can't
 	// double-tap into a stale state. Best-effort; ignore failures.
 	if msgID, _ := msg.Metadata["message_id"].(string); msgID != "" {
-		if tgBot, ok := imbot.AsTelegramBot(hCtx.Bot); ok {
-			if err := tgBot.RemoveMessageKeyboard(context.Background(), hCtx.ChatID, msgID); err != nil {
-				logrus.WithError(err).Debug("Failed to remove resume keyboard")
-			}
+		ref := imbot.MessageRef{ChatID: hCtx.ChatID, MessageID: msgID}
+		if !imbot.RestateOrIgnore(context.Background(), hCtx.Bot, ref, imbot.RestateOptions{}) {
+			logrus.WithField("messageID", msgID).Debug("Could not remove resume keyboard")
 		}
 	}
 
@@ -292,9 +291,8 @@ func (h *BotHandler) handleResumePick(hCtx HandlerContext, sessionID string, msg
 // No state to clean up — armed state only flips on `pick`.
 func (h *BotHandler) handleResumeCancel(hCtx HandlerContext, msg imbot.Message) {
 	if msgID, _ := msg.Metadata["message_id"].(string); msgID != "" {
-		if tgBot, ok := imbot.AsTelegramBot(hCtx.Bot); ok {
-			_ = tgBot.RemoveMessageKeyboard(context.Background(), hCtx.ChatID, msgID)
-		}
+		ref := imbot.MessageRef{ChatID: hCtx.ChatID, MessageID: msgID}
+		_ = imbot.RestateOrIgnore(context.Background(), hCtx.Bot, ref, imbot.RestateOptions{})
 	}
 	h.SendText(hCtx, "Resume cancelled.")
 }

--- a/internal/remote_control/bot/chat_store.go
+++ b/internal/remote_control/bot/chat_store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/imbot"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/jsonstore"
 )
@@ -83,15 +84,14 @@ func (b BotSetting) IsRequirePairing() bool {
 }
 
 // PlatformDefaultsRequirePairing reports whether a bot on the given platform
-// has TOFU pairing enforced when RequirePairing is unset (nil). Telegram,
-// Discord and Slack expose full DM command access to anyone who knows the
-// bot token, so they default to enforced.
+// has TOFU pairing enforced when RequirePairing is unset (nil).
+//
+// The answer comes from imbot's platform descriptor table rather than a switch
+// here: which platforms hand out full DM command access to anyone holding the
+// bot token is a fact about the platform, and it belongs next to the rest of
+// each platform's intrinsic metadata.
 func PlatformDefaultsRequirePairing(platform string) bool {
-	switch platform {
-	case "telegram", "discord", "slack":
-		return true
-	}
-	return false
+	return imbot.GetPlatformBehavior(imbot.Platform(platform)).RequiresPairingByDefault
 }
 
 // Chat represents all state associated with a chat (direct or group)

--- a/internal/remote_control/bot/feature/telegram_dir_browser.go
+++ b/internal/remote_control/bot/feature/telegram_dir_browser.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/imbot"
-	imbottelegram "github.com/tingly-dev/tingly-box/imbot/platform/telegram"
 )
 
 const (
@@ -380,22 +379,19 @@ func SendDirectoryBrowser(ctx context.Context, bot imbot.Bot, browser *Directory
 		return "", err
 	}
 
-	// Try to cast bot to TelegramBot for editing.
-	//
-	// TODO(phase-3): this is the last place that still needs a Telegram
-	// payload, because in-place message editing has not been lifted to a
-	// capability interface yet. Seam 4 (MessageRestater) replaces it, at which
-	// point Feishu and tingly get editing too.
-	tgBot, ok := imbot.AsTelegramBot(bot)
-	if ok && editMessageID != "" && state.MessageID != "" {
-		// Edit existing message
-		tgKeyboard := imbottelegram.BuildInlineKeyboard(kb.BuildActions())
-		if err := tgBot.EditMessageWithKeyboard(ctx, chatID, editMessageID, text, &tgKeyboard); err != nil {
-			logrus.WithError(err).Warn("Failed to edit message, sending new one")
-			// Fall through to send new message
-		} else {
+	// Restate the existing browser message in place when the platform can do
+	// it, so paging does not spam the chat with a new message per step.
+	if editMessageID != "" && state.MessageID != "" {
+		ref := imbot.MessageRef{ChatID: chatID, MessageID: editMessageID}
+		opts := imbot.RestateOptions{
+			Text:      text,
+			Actions:   kb.BuildActions(),
+			ParseMode: imbot.ParseModeMarkdown,
+		}
+		if imbot.RestateOrIgnore(ctx, bot, ref, opts) {
 			return editMessageID, nil
 		}
+		logrus.Debug("Could not restate directory browser message, sending a new one")
 	}
 
 	// Send new message with the action set; each platform renders it itself.

--- a/internal/remote_control/bot/handler_constructor.go
+++ b/internal/remote_control/bot/handler_constructor.go
@@ -177,7 +177,3 @@ func NewBotHandler(
 
 	return handler
 }
-
-// GetVerbose returns the current verbose mode setting for a chat
-// Checks chat store first, then bot setting default
-// Returns false for platforms that don't support verbose mode (e.g., Weixin)

--- a/internal/remote_control/bot/handler_verbose.go
+++ b/internal/remote_control/bot/handler_verbose.go
@@ -1,12 +1,20 @@
 package bot
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/imbot"
+)
 
 func (h *BotHandler) GetVerbose(chatID string) bool {
-	// Check if platform supports verbose mode
-	//if !SupportsVerboseMode(h.botSetting.Platform) {
-	//	return false
-	//}
+	// Some platforms cannot carry a running commentary of intermediate
+	// messages — Weixin ties each outbound message to one inbound reply
+	// context, so follow-ups either fail or arrive detached. The check used to
+	// be commented out here with no table to consult; it now reads imbot's
+	// platform descriptor and applies regardless of the operator's setting,
+	// because it is a platform limit rather than a preference.
+	if imbot.GetPlatformBehavior(imbot.Platform(h.botSetting.Platform)).SuppressVerbose {
+		return false
+	}
 
 	// Try to get verbose from chat store
 	if h.chatStore != nil {

--- a/internal/remote_control/bot/manager.go
+++ b/internal/remote_control/bot/manager.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/imbot"
-	imbotfeishu "github.com/tingly-dev/tingly-box/imbot/platform/feishu"
-	imbottelegram "github.com/tingly-dev/tingly-box/imbot/platform/telegram"
 	"github.com/tingly-dev/tingly-box/remote/audit"
 	"github.com/tingly-dev/tingly-box/remote/channel"
 	"github.com/tingly-dev/tingly-box/remote/channel/imchannel"
@@ -57,14 +56,11 @@ func runBotWithSettings(ctx context.Context, setting BotSetting, dataPath string
 		options["proxy"] = setting.ProxyURL
 	}
 
-	// Add Weixin-specific options
-	if setting.Platform == "weixin" {
-		if userID, ok := setting.Auth["user_id"]; ok {
-			options["user_id"] = userID
-		}
-		if baseURL, ok := setting.Auth["base_url"]; ok {
-			options["base_url"] = baseURL
-		}
+	// Some platforms carry extra credentials as connection options rather than
+	// as auth fields (Weixin's user_id / base_url). Which ones is a fact in
+	// imbot's platform table.
+	for k, v := range imbot.AuthOptions(setting.Platform, setting.Auth) {
+		options[k] = v
 	}
 	err = manager.AddBot(&imbot.Config{
 		UUID:     setting.UUID,
@@ -165,17 +161,9 @@ func runBotWithSettings(ctx context.Context, setting BotSetting, dataPath string
 		}
 
 		if commandRegistry != nil {
-			var err error
-			switch platform {
-			case imbot.PlatformTelegram:
-				err = imbottelegram.SetupMenuButton(bot, commandRegistry)
-			case imbot.PlatformFeishu, imbot.PlatformLark:
-				err = imbotfeishu.SetupQuickActions(bot, commandRegistry)
-			default:
-				// Other platforms don't support menu configuration
-				err = nil
-			}
-
+			// Platforms without a native command menu are a no-op inside
+			// SetupCommandMenu, so there is nothing to branch on here.
+			err := imbot.SetupCommandMenu(bot, platform, commandRegistry)
 			if err != nil {
 				// Log warning but don't fail startup
 				logrus.WithError(err).WithField("platform", setting.Platform).Warn("Failed to setup menu button")
@@ -192,48 +180,15 @@ func runBotWithSettings(ctx context.Context, setting BotSetting, dataPath string
 	return nil
 }
 
-// buildAuthConfig creates auth config based on platform
+// buildAuthConfig creates the platform auth config from a bot's stored auth
+// map, driven by imbot's platform table rather than a switch here.
+//
+// The switch this replaces omitted "lark" in both this function and the
+// credential check below, so Lark bots were rejected for having no valid
+// credentials — and would have been handed a token-type config the Feishu
+// client rejects even if they had got that far.
 func buildAuthConfig(setting BotSetting) imbot.AuthConfig {
-	platform := setting.Platform
-	auth := setting.Auth
-
-	switch platform {
-	case "telegram", "discord", "slack":
-		return imbot.AuthConfig{
-			Type:  "token",
-			Token: auth["token"],
-		}
-	case "dingtalk", "feishu", "wecom":
-		return imbot.AuthConfig{
-			Type:         "oauth",
-			ClientID:     auth["clientId"],
-			ClientSecret: auth["clientSecret"],
-		}
-	case "whatsapp":
-		return imbot.AuthConfig{
-			Type:      "token",
-			Token:     auth["token"],
-			AccountID: auth["phoneNumberId"],
-		}
-	case "weixin":
-		return imbot.AuthConfig{
-			Type:      "qr",
-			Token:     auth["token"],
-			AccountID: auth["bot_id"],
-			AuthDir:   auth["user_id"], // Store user_id in AuthDir for Weixin
-		}
-	case "tingly":
-		// Tingly is tokenless.
-		return imbot.AuthConfig{
-			Type:  "none",
-			Token: auth["token"], // optional shared secret, may be empty
-		}
-	default:
-		return imbot.AuthConfig{
-			Type:  "token",
-			Token: auth["token"],
-		}
-	}
+	return imbot.BuildAuthConfig(setting.Platform, setting.Auth)
 }
 
 // getProjectPathForGroup retrieves the project path bound to a group chat.
@@ -357,7 +312,7 @@ func (m *Manager) Start(parentCtx context.Context, uuid string) error {
 
 	// Handle both bot.Settings and db.Settings types
 	// Determine the type and extract common fields
-	var platform, token string
+	var platform string
 	var auth map[string]string
 	var name string
 	var record db.Settings
@@ -395,31 +350,17 @@ func (m *Manager) Start(parentCtx context.Context, uuid string) error {
 		return fmt.Errorf("unknown platform: %s", platform)
 	}
 
-	token = auth["token"]
-
-	// Validate auth credentials based on platform
-	hasValidAuth := false
-	switch platform {
-	case "dingtalk", "feishu", "wecom":
-		// OAuth platforms require clientId and clientSecret
-		hasValidAuth = auth["clientId"] != "" && auth["clientSecret"] != ""
-	case "weixin":
-		// Weixin QR requires token, bot_id, user_id, base_url
-		hasValidAuth = auth["token"] != "" && auth["bot_id"] != ""
-	case "whatsapp":
-		// WhatsApp requires token, phoneNumberId is optional
-		hasValidAuth = token != ""
-	case "tingly":
-		// Tingly does not require credentials.
-		hasValidAuth = true
-	default:
-		// Token-based platforms (telegram, discord, slack, etc.)
-		hasValidAuth = token != ""
-	}
-
-	if !hasValidAuth {
-		logrus.WithField("uuid", uuid).WithField("platform", platform).Warn("Bot has no valid auth credentials, not starting")
-		return fmt.Errorf("bot has no valid auth credentials for platform: %s", platform)
+	// Which credentials a platform needs is a fact in imbot's platform table,
+	// not a switch here. Naming the missing keys also turns an opaque "no valid
+	// credentials" into something an operator can act on.
+	if missing := imbot.MissingAuthKeys(platform, auth); len(missing) > 0 {
+		logrus.WithFields(logrus.Fields{
+			"uuid":     uuid,
+			"platform": platform,
+			"missing":  strings.Join(missing, ", "),
+		}).Warn("Bot is missing required credentials, not starting")
+		return fmt.Errorf("bot for platform %s is missing required credentials: %s",
+			platform, strings.Join(missing, ", "))
 	}
 
 	// Mount gate: a bot is a resource that only runs when it has an active

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -284,30 +284,24 @@ func (h *BotHandler) removeActionKeyboard(bot imbot.Bot, chatID string) {
 		return
 	}
 
-	// Try to cast to TelegramBot and remove the keyboard
-	if tgBot, ok := imbot.AsTelegramBot(bot); ok {
-		if err := tgBot.RemoveMessageKeyboard(context.Background(), chatID, msgID); err != nil {
-			logrus.WithError(err).WithField("chatID", chatID).WithField("messageID", msgID).Debug("Failed to remove action keyboard")
-		} else {
-			// Successfully removed, clear the tracking
-			h.actionMenuMessageIDMu.Lock()
-			delete(h.actionMenuMessageID, chatID)
-			h.actionMenuMessageIDMu.Unlock()
-		}
+	// Take the menu down wherever the platform supports it. Nil actions mean
+	// "no controls"; empty text leaves the message body alone.
+	ref := imbot.MessageRef{ChatID: chatID, MessageID: msgID}
+	if imbot.RestateOrIgnore(context.Background(), bot, ref, imbot.RestateOptions{}) {
+		h.actionMenuMessageIDMu.Lock()
+		delete(h.actionMenuMessageID, chatID)
+		h.actionMenuMessageIDMu.Unlock()
+	} else {
+		logrus.WithField("chatID", chatID).WithField("messageID", msgID).Debug("Could not remove action keyboard")
 	}
 }
 
-// editDirectoryBrowserMessage edits the directory browser message to show status and remove keyboard
+// editDirectoryBrowserMessage restates the directory browser message: new
+// status text, no controls.
 func editDirectoryBrowserMessage(ctx context.Context, bot imbot.Bot, chatID string, msgID string, text string) {
-	if tgBot, ok := imbot.AsTelegramBot(bot); ok {
-		// Remove the keyboard first
-		if err := tgBot.RemoveMessageKeyboard(ctx, chatID, msgID); err != nil {
-			logrus.WithError(err).WithField("chatID", chatID).WithField("messageID", msgID).Debug("Failed to remove directory browser keyboard")
-		} else {
-			// Successfully removed keyboard, now edit the text
-			if err := tgBot.EditMessageWithKeyboard(ctx, chatID, msgID, text, nil); err != nil {
-				logrus.WithError(err).WithField("chatID", chatID).WithField("messageID", msgID).Debug("Failed to edit directory browser text")
-			}
-		}
+	ref := imbot.MessageRef{ChatID: chatID, MessageID: msgID}
+	if !imbot.RestateOrIgnore(ctx, bot, ref, imbot.RestateOptions{Text: text}) {
+		logrus.WithField("chatID", chatID).WithField("messageID", msgID).
+			Debug("Could not restate directory browser message")
 	}
 }

--- a/remote/channel/imchannel/imprompter.go
+++ b/remote/channel/imchannel/imprompter.go
@@ -533,11 +533,12 @@ func (p *IMPrompter) editPromptToResult(bot imbot.Bot, chatID, messageID string,
 		resultText += "\n\n❌ *Denied*"
 	}
 
-	// Edit message to remove keyboard and show result
-	if tgBot, ok := imbot.AsTelegramBot(bot); ok {
-		_ = tgBot.EditMessageWithKeyboard(context.Background(), chatID, messageID, resultText, nil)
-	} else {
-		// Fallback: send a new message with the result
+	// Restate the prompt to its outcome: new text, controls gone. Platforms
+	// that cannot restate get a fresh message instead, so the user always sees
+	// the result either way.
+	ref := imbot.MessageRef{ChatID: chatID, MessageID: messageID}
+	opts := imbot.RestateOptions{Text: resultText, ParseMode: imbot.ParseModeMarkdown}
+	if !imbot.RestateOrIgnore(context.Background(), bot, ref, opts) {
 		_, _ = bot.SendMessage(context.Background(), chatID, &imbot.SendMessageOptions{
 			Text:      resultText,
 			ParseMode: imbot.ParseModeMarkdown,
@@ -550,9 +551,9 @@ func (p *IMPrompter) editPromptToTimeout(bot imbot.Bot, chatID, messageID string
 	resultText := p.buildPromptText(req, true) // supportsKeyboard doesn't matter for timeout
 	resultText += "\n\n⏰ *Timed Out*"
 
-	if tgBot, ok := imbot.AsTelegramBot(bot); ok {
-		_ = tgBot.EditMessageWithKeyboard(context.Background(), chatID, messageID, resultText, nil)
-	}
+	ref := imbot.MessageRef{ChatID: chatID, MessageID: messageID}
+	_ = imbot.RestateOrIgnore(context.Background(), bot, ref,
+		imbot.RestateOptions{Text: resultText, ParseMode: imbot.ParseModeMarkdown})
 }
 
 // cleanup removes a pending request and its response channel


### PR DESCRIPTION
**Stack 3 of 3, last one.** Based on `main`.

1. ~~#1434 — ownership moves~~ ✅ merged
2. ~~#1435 — neutral outbound actions~~ ✅ merged
3. **this PR** — capability table and message restating

## Capability table

`core.PlatformDescriptor` gains a `Behavior` record (`RequiresPairingByDefault`, `SuppressVerbose`), and `platform.go` gains an `AuthMapping` describing how a stored auth map becomes an `AuthConfig`. Six switch statements in the bot manager and chat store now read those tables. `internal/remote_control/bot/manager.go` no longer contains any platform literal.

**Two things stayed deliberately separate:**

- **Menu installation cannot live in `core`** — `command` imports `core`, so a `func(Bot, *CommandRegistry)` field would cycle. It went to `imbot/platform/menu_setup.go` alongside the bot-creator registry: data in the descriptor table, behaviour dispatch in the platform registry.
- **`AuthMapping` is not derived from `FieldSpec`.** `FieldSpec` describes the settings-UI form; this is the wire mapping. Weixin's credentials come from the QR flow and have no form fields at all, so deriving one from the other would leave Weixin bots unable to authenticate.

## Defect fixed: Lark bots could not start

Both switches in the bot manager omitted `"lark"` while `PlatformConfigs` had an entry for it. Two independent failures from one cause:

1. the credential check fell to the default branch and demanded a token the Lark form never collects → "no valid auth credentials, not starting";
2. `buildAuthConfig` would have handed the Feishu client a token-type config it rejects.

A table with a hand-maintained switch beside it. `TestAuthMappingCoversEveryConfiguredPlatform` now fails if a future platform is added to the table without a wire mapping.

## Message restating

`core.MessageRestater` expresses the intent — "this message and its buttons are stale, replace them" — rather than the mechanism. Telegram edits in place; Feishu patches the card via `PATCH /im/v1/messages/:id`, which updates what the user already sees without a new notification; tingly records the event so the behaviour is assertable off Telegram.

7 call sites move from `AsTelegramBot` — a *concrete* type assertion that Feishu and tingly could never satisfy, which is why used menus stayed clickable everywhere but Telegram — to `RestateOrIgnore`, a no-op where unsupported so taking a menu down can never break the flow that followed the button press. `AsTelegramBot` is now used only for `ResolveChatID` in `/join`, a declared Telegram-only product feature.

## Known limits and behaviour changes

**Weixin no longer sends intermediate progress messages.** Each outbound message is tied to one inbound reply context, so a running commentary cannot be delivered. The check existed but had been commented out with its doc comment left behind; this restores the documented intent rather than introducing a new policy. If commenting it out was deliberate, this is the line to push back on.

**The Feishu keyboard fix is partial.** `RestateOptions` documents empty `Text` as "leave the body alone", which is what the three take-the-menu-down call sites ask for. Telegram honours it via `editMessageReplyMarkup`; Feishu cannot, because a card patch replaces the whole content — honouring it literally would blank out the user's message. Feishu reports `ErrNotSupported` and `RestateOrIgnore` turns that into a no-op. Losing the body is worse than leaving a stale menu.

**Telegram's edit paths now take a real context.** Both previously ran on the bot's own context, so cancellation never propagated.

**Not verified against a live Feishu bot** — no credentials in this environment. The button and patch behaviour is derived from the SDK and the type switch and is deterministic, but "what the user actually sees" deserves a real-bot confirmation before release.

## What comes next

`Action.Payload` replacing `CallbackData` is the next step and touches the callback protocol, so it gets its own PR. Telegram's 64-byte `callback_data` limit has already leaked into the application architecture — the directory browser navigates by index and snapshots `BindFlowState.Dirs` purely to fit it, a constraint Feishu does not have — and the limit itself is documented in a comment but never validated, so `bind:create:<path>` fails the whole send for paths over 52 bytes.

Reply-context forwarding, the `menu` package, and removal of the deprecated metadata path follow after that. The compat path cannot go first: imbot's own interaction handler and the `menu` adapters still produce `replyMarkup`.

## Verification

Rebased onto current `main` (`b203cb8`, after #1437). 24 files, +860 −192 — all under `imbot/`, `internal/remote_control/`, `remote/channel/` and `.design/`.

Build and `go vet` clean with and without `-tags e2e`; **98 packages pass, 0 failures** (whole repo, not just the touched subtrees).

New tests cover the Lark auth mapping, per-platform auth wiring, named missing-credential reporting, the pairing and verbose defaults (getting pairing wrong in the permissive direction hands DM command access to anyone holding a leaked token, so it is pinned explicitly), restating on a non-Telegram platform, and Feishu's refusal to honour a bodyless restate.

### Correction

An earlier revision of this branch accidentally reverted 11 files from #1432 (`frontend/` config modals and `internal/server/{config,module/configapply}`, −465 lines). Cause: the branch was assembled with `git checkout <old-branch> -- .`, which copies the whole tree from a branch based on a commit that predated #1432, and the check used to verify it compared against that same old branch — so it confirmed the copy succeeded rather than that nothing else was harmed. Fixed by restoring those files from `main`; the scope check above now runs against `main` and asserts no path outside the four intended subtrees appears in the diff. #1434 and #1435 were assembled from explicit file lists and were never affected — verified against `main`.