### PR TITLE
fix(ui): make API-style badges opaque so node text doesn't bleed through

### DIFF
--- a/frontend/src/components/ApiStyleBadge.tsx
+++ b/frontend/src/components/ApiStyleBadge.tsx
@@ -2,6 +2,19 @@ import {Box, useTheme, alpha} from '@mui/material';
 import type {SxProps, Theme} from '@mui/material';
 import { EMPTY_SX } from '@/constants/defaults';
 
+// Parse a #RRGGBB (or #RGB) hex string into an {r,g,b} triple. Returns null for
+// anything else (css color names, rgb() strings) so callers can fall back safely.
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+    let h = hex.trim();
+    if (!h.startsWith('#')) return null;
+    h = h.slice(1);
+    if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+    if (h.length !== 6) return null;
+    const num = parseInt(h, 16);
+    if (Number.isNaN(num)) return null;
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+};
+
 interface ApiStyleBadgeProps {
     apiStyle: string;
     compact?: boolean;
@@ -20,35 +33,40 @@ export const ApiStyleBadge = ({apiStyle, sx = EMPTY_SX, compact = false, minimal
         return null; // Don't show badge for unknown styles
     }
 
-    // Use theme colors for better consistency
-    const getBadgeStyles = () => {
-        if (isOpenAI) {
-            return {
-                backgroundColor: alpha(theme.palette.info.main, 0.1),
-                color: theme.palette.info.main,
-                borderColor: alpha(theme.palette.info.main, 0.3),
-            };
-        } else if (isAnthropic) {
-            // Warm orange, between red and terracotta
-            return {
-                backgroundColor: alpha('#E07A5F', 0.12),
-                color: '#E07A5F',
-                borderColor: alpha('#E07A5F', 0.4),
-            };
-        } else if (isGoogle) {
-            // Google blue
-            return {
-                backgroundColor: alpha('#4285F4', 0.1),
-                color: '#4285F4',
-                borderColor: alpha('#4285F4', 0.3),
-            };
-        }
-        return {
-            backgroundColor: alpha(theme.palette.grey[500], 0.1),
-            color: theme.palette.text.secondary,
-            borderColor: alpha(theme.palette.grey[500], 0.3),
-        };
+    // The badge floats over the service node's own text (provider name), so its
+    // background must be FULLY OPAQUE — any alpha lets that text bleed through.
+    // We blend the brand tint onto the theme's paper color directly, producing a
+    // solid color per mode rather than a transparent wash. Mirrors ActionButtonsBox,
+    // which layers a solid paper backing for the same reason (see nodes/styles.tsx).
+    const paper = theme.palette.background.paper;
+    const isDark = theme.palette.mode === 'dark';
+
+    // Composite a translucent tint over an opaque paper base → one opaque color.
+    const blend = (tint: string, tintAlpha: number) => {
+        const t = hexToRgb(tint);
+        const p = hexToRgb(paper);
+        if (!t || !p) return paper;
+        const a = tintAlpha;
+        const r = Math.round(t.r * a + p.r * (1 - a));
+        const g = Math.round(t.g * a + p.g * (1 - a));
+        const b = Math.round(t.b * a + p.b * (1 - a));
+        return `rgb(${r}, ${g}, ${b})`;
     };
+
+    const tints = {
+        openai: { tint: theme.palette.info.main, fill: isDark ? 0.22 : 0.14, border: alpha(theme.palette.info.main, 0.4) },
+        anthropic: { tint: '#E07A5F', fill: isDark ? 0.26 : 0.16, border: alpha('#E07A5F', 0.5) },
+        google: { tint: '#4285F4', fill: isDark ? 0.22 : 0.14, border: alpha('#4285F4', 0.4) },
+        fallback: { tint: theme.palette.grey[500], fill: isDark ? 0.22 : 0.14, border: alpha(theme.palette.grey[500], 0.4) },
+    } as const;
+    const key = isOpenAI ? 'openai' : isAnthropic ? 'anthropic' : isGoogle ? 'google' : 'fallback';
+    const t = tints[key];
+
+    const getBadgeStyles = () => ({
+        backgroundColor: blend(t.tint, t.fill), // opaque — no bleed-through
+        color: t.tint,
+        borderColor: t.border,
+    });
 
     const label = isOpenAI ? 'OpenAI' : isAnthropic ? 'Anthropic' : 'Google';
     const letter = isOpenAI ? 'O' : isAnthropic ? 'A' : 'G';
@@ -100,8 +118,8 @@ export const ApiStyleBadge = ({apiStyle, sx = EMPTY_SX, compact = false, minimal
                     duration: theme.transitions.duration.shorter,
                 }),
                 '&:hover': {
-                    backgroundColor: alpha(badgeStyles.color, 0.15),
-                    borderColor: alpha(badgeStyles.color, 0.5),
+                    backgroundColor: blend(t.tint, isDark ? 0.32 : 0.22),
+                    borderColor: alpha(t.tint, 0.6),
                 },
                 ...sx,
             }}

--- a/frontend/src/components/ApiStyleBadge.tsx
+++ b/frontend/src/components/ApiStyleBadge.tsx
@@ -1,19 +1,7 @@
-import {Box, useTheme, alpha} from '@mui/material';
+import {Box, useTheme} from '@mui/material';
+import {alpha, decomposeColor} from '@mui/material/styles';
 import type {SxProps, Theme} from '@mui/material';
 import { EMPTY_SX } from '@/constants/defaults';
-
-// Parse a #RRGGBB (or #RGB) hex string into an {r,g,b} triple. Returns null for
-// anything else (css color names, rgb() strings) so callers can fall back safely.
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-    let h = hex.trim();
-    if (!h.startsWith('#')) return null;
-    h = h.slice(1);
-    if (h.length === 3) h = h.split('').map((c) => c + c).join('');
-    if (h.length !== 6) return null;
-    const num = parseInt(h, 16);
-    if (Number.isNaN(num)) return null;
-    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
-};
 
 interface ApiStyleBadgeProps {
     apiStyle: string;
@@ -21,6 +9,31 @@ interface ApiStyleBadgeProps {
     minimal?: boolean;
     sx?: SxProps<Theme>;
 }
+
+type Rgb = { r: number; g: number; b: number };
+
+// Resolve any CSS color MUI understands (hex / rgb() / rgba() / hsl() / names)
+// into an opaque {r,g,b} triple. rgba() alpha is pre-composited over opaque
+// white so the result is always fully opaque — this is what makes the badge
+// background solid even when the theme's paper is itself translucent (e.g. the
+// sunlit theme uses rgba(255,255,255,0.75) paper).
+const toOpaqueRgb = (color: string): Rgb | null => {
+    const c = decomposeColor(color);
+    const [r, g, b, a = 1] = c.values as number[];
+    if ([r, g, b].some((n) => !Number.isFinite(n))) return null;
+    const alphaV = Number.isFinite(a) ? a : 1;
+    // Composite onto white if there's an alpha channel.
+    const over = (n: number) => Math.round(n * alphaV + 255 * (1 - alphaV));
+    return { r: over(r), g: over(g), b: over(b) };
+};
+
+// Composite a translucent tint over an opaque paper base → one opaque color.
+const blend = (tint: string, tintAlpha: number, paperRgb: Rgb): string => {
+    const t = toOpaqueRgb(tint);
+    if (!t) return `rgb(${paperRgb.r}, ${paperRgb.g}, ${paperRgb.b})`;
+    const mix = (n: number, p: number) => Math.round(n * tintAlpha + p * (1 - tintAlpha));
+    return `rgb(${mix(t.r, paperRgb.r)}, ${mix(t.g, paperRgb.g)}, ${mix(t.b, paperRgb.b)})`;
+};
 
 // Helper function to render API style badge with icon and colored background
 export const ApiStyleBadge = ({apiStyle, sx = EMPTY_SX, compact = false, minimal = false}: ApiStyleBadgeProps) => {
@@ -33,44 +46,26 @@ export const ApiStyleBadge = ({apiStyle, sx = EMPTY_SX, compact = false, minimal
         return null; // Don't show badge for unknown styles
     }
 
-    // The badge floats over the service node's own text (provider name), so its
-    // background must be FULLY OPAQUE — any alpha lets that text bleed through.
-    // We blend the brand tint onto the theme's paper color directly, producing a
-    // solid color per mode rather than a transparent wash. Mirrors ActionButtonsBox,
-    // which layers a solid paper backing for the same reason (see nodes/styles.tsx).
-    const paper = theme.palette.background.paper;
+    // The badge floats (position:absolute) over the service node's own text
+    // (provider name), so its background must be FULLY OPAQUE — any alpha lets
+    // that text bleed through. We composite each brand tint onto the theme's
+    // paper color to produce a solid color per mode rather than a transparent
+    // wash. Mirrors the solid-paper backing used by ActionButtonsBox.
     const isDark = theme.palette.mode === 'dark';
+    const paperRgb = toOpaqueRgb(theme.palette.background.paper) ?? { r: 255, g: 255, b: 255 };
 
-    // Composite a translucent tint over an opaque paper base → one opaque color.
-    const blend = (tint: string, tintAlpha: number) => {
-        const t = hexToRgb(tint);
-        const p = hexToRgb(paper);
-        if (!t || !p) return paper;
-        const a = tintAlpha;
-        const r = Math.round(t.r * a + p.r * (1 - a));
-        const g = Math.round(t.g * a + p.g * (1 - a));
-        const b = Math.round(t.b * a + p.b * (1 - a));
-        return `rgb(${r}, ${g}, ${b})`;
-    };
-
-    const tints = {
-        openai: { tint: theme.palette.info.main, fill: isDark ? 0.22 : 0.14, border: alpha(theme.palette.info.main, 0.4) },
-        anthropic: { tint: '#E07A5F', fill: isDark ? 0.26 : 0.16, border: alpha('#E07A5F', 0.5) },
-        google: { tint: '#4285F4', fill: isDark ? 0.22 : 0.14, border: alpha('#4285F4', 0.4) },
-        fallback: { tint: theme.palette.grey[500], fill: isDark ? 0.22 : 0.14, border: alpha(theme.palette.grey[500], 0.4) },
+    // One table per provider: identity + brand color + tint strength.
+    // fill is the resting tint opacity over paper; hoverFill is the stronger
+    // hover opacity. Dark mode gets a higher fill so tints stay visible on dark paper.
+    const providers = {
+        openai:    { label: 'OpenAI',    letter: 'O', tint: theme.palette.info.main, fill: isDark ? 0.22 : 0.14, hoverFill: isDark ? 0.32 : 0.22, border: alpha(theme.palette.info.main, 0.4) },
+        anthropic: { label: 'Anthropic', letter: 'A', tint: '#E07A5F',               fill: isDark ? 0.26 : 0.16, hoverFill: isDark ? 0.36 : 0.26, border: alpha('#E07A5F', 0.5) },
+        google:    { label: 'Google',    letter: 'G', tint: '#4285F4',               fill: isDark ? 0.22 : 0.14, hoverFill: isDark ? 0.32 : 0.22, border: alpha('#4285F4', 0.4) },
     } as const;
-    const key = isOpenAI ? 'openai' : isAnthropic ? 'anthropic' : isGoogle ? 'google' : 'fallback';
-    const t = tints[key];
+    const p = isOpenAI ? providers.openai : isAnthropic ? providers.anthropic : providers.google;
 
-    const getBadgeStyles = () => ({
-        backgroundColor: blend(t.tint, t.fill), // opaque — no bleed-through
-        color: t.tint,
-        borderColor: t.border,
-    });
-
-    const label = isOpenAI ? 'OpenAI' : isAnthropic ? 'Anthropic' : 'Google';
-    const letter = isOpenAI ? 'O' : isAnthropic ? 'A' : 'G';
-    const badgeStyles = getBadgeStyles();
+    const backgroundColor = blend(p.tint, p.fill, paperRgb); // opaque — no bleed-through
+    const hoverBackgroundColor = blend(p.tint, p.hoverFill, paperRgb);
 
     if (minimal) {
         return (
@@ -86,13 +81,13 @@ export const ApiStyleBadge = ({apiStyle, sx = EMPTY_SX, compact = false, minimal
                     fontSize: '9px',
                     fontWeight: 700,
                     lineHeight: 1,
-                    border: `1px solid ${badgeStyles.borderColor}`,
-                    backgroundColor: badgeStyles.backgroundColor,
-                    color: badgeStyles.color,
+                    border: `1px solid ${p.border}`,
+                    backgroundColor,
+                    color: p.tint,
                     ...sx,
                 }}
             >
-                {letter}
+                {p.letter}
             </Box>
         );
     }
@@ -111,20 +106,20 @@ export const ApiStyleBadge = ({apiStyle, sx = EMPTY_SX, compact = false, minimal
                 fontWeight: 600,
                 height: compact ? '16px' : '20px',
                 minWidth: compact ? 'unset' : '76px',
-                border: `1px solid ${badgeStyles.borderColor}`,
-                backgroundColor: badgeStyles.backgroundColor,
-                color: badgeStyles.color,
+                border: `1px solid ${p.border}`,
+                backgroundColor,
+                color: p.tint,
                 transition: theme.transitions.create(['background-color', 'color', 'border-color'], {
                     duration: theme.transitions.duration.shorter,
                 }),
                 '&:hover': {
-                    backgroundColor: blend(t.tint, isDark ? 0.32 : 0.22),
-                    borderColor: alpha(t.tint, 0.6),
+                    backgroundColor: hoverBackgroundColor,
+                    borderColor: alpha(p.tint, 0.6),
                 },
                 ...sx,
             }}
         >
-            {compact ? (<span>{label}</span>) : (<span>{label} Style</span>)}
+            {compact ? (<span>{p.label}</span>) : (<span>{p.label} Style</span>)}
         </Box>
     );
 };


### PR DESCRIPTION
## Summary

Small OpenAI, Anthropic, and Google-style badges on routing-graph service nodes previously used semi-transparent backgrounds (`alpha(color, 0.1)`). Since the badges are positioned absolutely over the node’s own provider name text, that text showed through the badge—making it look muddy and hard to read. This change makes every badge background fully opaque across all themes (light, dark, and sunlit) while preserving the brand tint.

## Key Changes

- **Readability over service nodes**: Badge backgrounds are now composited onto the theme’s paper color to produce a single opaque `rgb()` per theme. The provider name behind a badge no longer bleeds through. The brand-tint fill is retained (and adjusted per light/dark theme) so the badges remain instantly recognizable as OpenAI, Anthropic, or Google.
- **Theme robustness (including sunlit)**: The paper color is resolved using MUI’s `decomposeColor`, which handles `hex`, `rgb()`, `rgba()`, `hsl()`, and color names. Any alpha channel is pre-composited onto opaque white. This is crucial because the **sunlit** theme uses a translucent `rgba(255, 255, 255, 0.75)` background for paper—a naive hex-only parser would fall back to that translucent value and silently reintroduce the bug. The hover state also follows the same opaque-blend path, eliminating any translucency flicker.
- **Maintainability**: The per-provider dispatch for `label`, `letter`, `tint`, and `fill` (previously three nearly identical ternary chains) has been consolidated into a single lookup table. The redundant `getBadgeStyles` wrapper has been removed.

## Testing

- `tsc --noEmit` passes cleanly for the changed file.
- Examined the rendered badge `backgroundColor` via the mock dev server in light, dark, and sunlit themes. All returned fully opaque `rgb()` (no alpha channel) in every theme—for example, sunlit OpenAI: `rgb(220, 245, 249)`, sunlit Anthropic: `rgb(250, 234, 229)`.
- Visual screenshots confirm solid backgrounds with no text bleed-through.