### PR TITLE
refactor(imbot) 2b: button identity is a payload, not Telegram's wire format

### DIFF
--- a/.design/imbot-platform-seams.md
+++ b/.design/imbot-platform-seams.md
@@ -109,7 +109,12 @@ func SwitchInlineButton(label, query string) core.Action
 `ActionSet` 保留**行结构**——布局有意义（目录浏览器依赖它），没有行概念的平台可以
 自己 flatten。
 
-兼容期：`Metadata["replyMarkup"]` 保留一个版本，读到时打 deprecation 日志。
+**按钮身份是 `core.Payload`（有序 segment），不是 `callback_data`**（2b 落地）。
+编码是平台自己的事：Feishu 放进 button value 的 JSON 数组，Telegram 能塞进 64 字节
+就 join，塞不下就寄存换短 token。见 §5。
+
+兼容期：`Action.CallbackData` 与 `Metadata["replyMarkup"]` 各保留一个版本，读到时
+打 deprecation 日志。
 
 ### Seam 2 — 回复上下文由 imbot 自己记 ⏳ 计划中
 
@@ -233,10 +238,34 @@ Telegram 在**每一列**都是最紧的。它的约束已经泄漏成全平台�
   **52 字节**就会被 Telegram 拒（`BUTTON_DATA_INVALID`），整条消息发不出去。
 
 **结论：按钮身份不能是 `callback_data`** —— 那是把 Telegram 的传输编码当成了按钮
-的身份。目标形态是 `Action.Payload map[string]any`，由 imbot 负责投递：Feishu 直接
-进 button value；Telegram 先试编码进 64 字节，放不下就存短 token（随消息生命周期
-回收），`callback_data` 只带 `tok:<n>`。届时索引导航、`Dirs` 快照、NUL 编码三样
-全部可删。
+的身份。已落地形态是 `core.Payload`（**有序 segment**，`imbot/core/payload.go`），
+由平台负责投递：Feishu 直接进 button value 的 JSON 数组；Telegram 能 join 进 64
+字节就照旧 join（**线上字节不变**，老键盘继续可用），放不下、含 `:`、或撞上保留前缀
+就寄存进 per-bot vault，`callback_data` 只带 `@<n>`。索引导航、`Dirs` 快照、NUL
+编码三样已全部删除。
+
+#### 为什么是 segment 而不是 `map[string]any`
+
+原计划写的是 `map[string]any`。实现时改为有序 segment，理由：
+
+1. **全仓的 dispatch 都是位置式的**（`parts[0]` / `parts[1]`…）。segment 与之一一
+   对应，迁移是机械的、可逐行 review 的；而这是整个计划里**唯一碰回调协议**的一步，
+   改错的表现是"按钮点了没反应"——最不该在这一步引入大面积重写。
+2. **名字会是发明出来的，不是发现出来的**。今天的数据本来就是位置式的
+   （`action:sub:arg`），套一层 key 只是给它编名字。
+3. 两种形态下"编码归平台管"这条关键性质都成立——而那才是这条 seam 的目的。
+
+`Payload` 只有 `Name()` / `Arg(i)` 两个读取器，且**越界返回 `""`**：老版本渲染的
+按钮 segment 更少时，读到的是"缺数据"而不是 panic。
+
+#### token 寄存的边界
+
+vault 是**进程内、有上限（4096 条）的 FIFO**。回调载荷描述的是"某个会话里某条消息
+上的某个控件"，其寿命不该长过产生它的流程本身——而本仓每个这类流程本来就把状态放
+内存里并带超时。上限保证长跑的 bot 不会把这张表撑大。
+
+token 解析不到时（bot 重启，或被挤出），**明确告诉用户按钮已失效**，而不是把这次
+点击吞掉。旧行为下"点了没反应"和"bot 坏了"在用户端是同一件事。
 
 另外两件必须显式建模的：
 
@@ -253,7 +282,7 @@ Telegram 在**每一列**都是最紧的。它的约束已经泄漏成全平台�
 |---|---|---|
 | **1** | 归属搬迁：Feishu 渲染器进 `platform/feishu`；Weixin QR 客户端去重；`telegram_keyboard.go` → `action_menu.go` | ✅ 已落地 |
 | **2a** | Seam 1 上半：`Actions` 进类型系统、13 个调用点迁移、Tier 3 逃生舱 | ✅ 已落地 |
-| **2b** | Seam 1 下半：按钮身份换 `Payload`、Telegram token 降级、补 64 字节校验、删索引导航与 NUL 编码 | ⏳ **独立 PR** |
+| **2b** | Seam 1 下半：按钮身份换 `Payload`、Telegram token 降级、补 64 字节校验、删索引导航与 NUL 编码；顺带把 Feishu 卡片回调接上 | ✅ 已落地 |
 | **3** | Seam 3 + Seam 4：能力表、`MessageRestater` | ✅ 已落地 |
 | **4** | Seam 2（回复上下文自动化）+ `FileResolver` | ⏳ |
 | **5** | `menu` 包归位：让它建立在新 seam 之上 / 降级 / 删除，三选一 | ⏳ |
@@ -261,6 +290,11 @@ Telegram 在**每一列**都是最紧的。它的约束已经泄漏成全平台�
 
 **2a / 2b 拆分的理由**：2b 是唯一触碰**回调协议**的一步，改错就是"按钮点了没反应"。
 拆开让 2a 的用户价值（Feishu 按钮可见）不被 2b 的风险绑架。
+
+**2b 里为什么还带了 Feishu 卡片回调**：做 2b 时才发现 2a 的修复只到一半——按钮渲染
+出来了，但**点击根本没有入站路径**（§7.6）。而 2b 改的正是 button value 的形状；
+没有消费方，这个形状就无从验证。两者是同一条回路的两端，分开做等于把一端焊死在
+不可验证的状态。
 
 **Phase 5 刻意排在 seam 之后**：先让新 seam 的形状被真实使用验证过，再决定 `menu`
 该不该活，而不是反过来。
@@ -301,6 +335,9 @@ Clear / CD / Project、目录浏览、`/resume` 选择器对 Feishu 用户全部
 > 仍待真机验证：本仓无 Feishu 凭据，类型开关的推导是确定的，但"用户实际看到什么"
 > 应由真机确认背书。
 
+**这条修复只到一半，另一半见 §7.6**：按钮渲染出来了，但当时没有任何入站路径接收
+点击。写"已修"时没查回路的另一端，是这次调研里最该记下的教训。
+
 ### 7.2 非 Telegram 平台键盘撤不掉（Seam 4 已修）
 
 `AsTelegramBot` 是**具体类型断言**（`bot.(*telegram.Bot)`），Feishu/tingly 永远走
@@ -340,6 +377,52 @@ verbose mode (e.g., Weixin)"）。说的和做的不一致——这是没有能�
 事实来源的价值——`TestAuthMappingCoversEveryConfiguredPlatform` 现在会在下一次
 漏填时直接失败。
 
+### 7.6 Feishu 卡片按钮**点了没有任何入站**（2b 已修）
+
+2a 修好了"按钮渲染不出来"，但只修了一半。Feishu 的 bot 只订阅了消息事件：
+
+```go
+dispatcher.NewEventDispatcher("", "").
+    OnP2MessageReceiveV1(b.handleP2MessageReceiveV1)   // 仅此一条
+```
+
+`HandleCardAction` 是个直接返回 `not implemented` 的桩，而全应用的回调分发都挂在
+`Metadata["is_callback"]` 上——只有 Telegram 和 tingly 会设。所以 Feishu 用户点下
+按钮的结果是：转圈，然后什么都没有。
+
+**这比没有按钮更糟**。没有按钮是"功能缺失"，有按钮点了不动是"这 bot 坏了"。
+
+现已注册 `OnP2CardActionTrigger`，把卡片回调归一化成 `core.Message`（带 `Payload`）
+后走与其它平台完全相同的分发路径。
+
+> 待真机验证：本仓无 Feishu 凭据。SDK v3.9.7 的 WS 客户端把 `MessageTypeCard` 直接
+> 丢弃，但 `card.action.trigger` 是走 `MessageTypeEvent` 经 `EventDispatcher.Do`
+> 分发的（`Do` 会先查 `callbackType2CallbackHandler`）——推导如此，仍需真机背书。
+> 最坏情况是事件不到达，行为与今天一致，不构成回退。
+
+### 7.7 `getReceiveIdType` 的前缀匹配全是死分支（2b 已修）
+
+```go
+prefix := targetID[:4]        // 4 字符
+switch prefix {
+case "ou_":  ...              // 3 字符，永远不等
+case "oc_":  ...              // 永远不等
+}
+```
+
+四字符切片不可能等于三字符常量，所以 `oc_` / `ou_` 两个分支**不可达**，除了字面
+`cli_` 之外的一切目标都落到 default → `open_id`。而且映射本身也是反的：`oc_` 是
+会话（chat_id），`ou_` 是用户（open_id），原码写成了互换。
+
+之所以在 2b 里修：卡片回调的回复目标就是 `oc_` 开头的 chat_id，不修则 §7.6 接上了
+入站也回不出去。已补 `TestGetReceiveIdType`。
+
+### 7.8 `bind:create` 建完目录就沉默（2b 已修）
+
+`telegram_callback.go` 的 `case "create"` 只做了 `os.MkdirAll`，成功之后既不绑定也
+不回话，直接 fallthrough 出 switch。用户点"✅ Create"，目录在磁盘上出现了，聊天里
+一个字都没有——无从判断绑定是否发生。现已补上 `completeBind` + 清理浏览状态。
+
 ## 8. 归属与命名规则
 
 **两类平台专有代码，性质不同，去处不同：**
@@ -371,8 +454,14 @@ import cycles with imbot/platform packages"——不成立，它只需要 `inter
 4. `handler_verbose.go` 的能力判定恢复启用。（Seam 3 ✅）
 5. 在 imbot 新增一个假想平台，`remote_control` **零改动**即可跑通
    `manager_channel_test.go` 的 notify 全链路。
-6. 回调载荷的长度约束不再泄漏到调用方：`grep -rn "64" imbot/interaction/` 只在
-   Telegram 平台包内出现。（2b）
+6. 回调载荷的长度约束不再泄漏到调用方：64 字节作为**生效的约束**只存在于
+   `imbot/platform/telegram/callback_codec.go`；`interaction` 与
+   `internal/remote_control` 里仅剩解释历史的注释。（2b ✅）
+7. `internal/remote_control` 与 `remote/channel` 里不再有 `FormatCallbackData` /
+   `CallbackButton` / `FormatDirPath` 调用——按钮一律用 `ActionButton` /
+   `NewPayload` 声明 segment。（2b ✅）
+8. Feishu 卡片按钮点击有入站路径，且与其它平台走同一套 dispatch。（2b ✅，
+   待真机验证）
 
 ## 10. 测试
 
@@ -391,6 +480,18 @@ import cycles with imbot/platform packages"——不成立，它只需要 `inter
   交给任何持有泄漏 token 的人，值得显式钉住）、verbose 抑制、未知平台取零值。
 - `imbot/platform/tingly/restate_test.go` — 撤菜单、换文本+控件、
   以及不支持平台/空引用时 `RestateOrIgnore` 安静返回 false。
+- `imbot/core/payload_test.go` — 越界读取返回 `""` 而非 panic（老版本按钮 segment
+  更少）、`HasSeparator`、`EffectivePayload` 的兼容优先级、`IsLink` 必须把 payload
+  算进去（算错就把控件渲染成纯链接，回调永不触发）。
+- `imbot/platform/telegram/callback_codec_test.go` — **线上字节不变**（短载荷仍是
+  `bind:up`，老键盘不失效）、超长载荷编码后必定 ≤64（§5 那条会整条消息发不出去的
+  缺陷）、含 `:` 的路径往返且不产生 NUL、保留前缀不被误认成 token、失效 token 可被
+  区分、FIFO 逐出。
+- `imbot/platform/feishu/card_callback_test.go` — button value 携带 segment 往返、
+  含 `:` 的路径、legacy 扁平串仍可解、JSON 化后的 `[]interface{}` 形状，以及
+  `getReceiveIdType` 的前缀映射（§7.7）。
+- `internal/remote_control/bot/feature/dir_browser_test.go` — 目录按钮携带**路径**
+  而非索引、含 `:` 的目录名可导航、create 确认按钮携带原始路径。
 - `imbot/platform/tingly/tingly_test.go` — 新契约（`Actions`）与兼容期
   （legacy metadata）各一。原 `TestBot_SendWithTelegramKeyboard` 已删除：它断言的
   双形状解码正是本次消灭的耦合。

--- a/imbot/core/action.go
+++ b/imbot/core/action.go
@@ -71,12 +71,15 @@ type Action struct {
 	ID string
 	// Label is the user-visible button text.
 	Label string
-	// CallbackData is the opaque payload echoed back when the action fires.
+	// Payload is what comes back when the action fires: ordered segments, with
+	// each platform free to deliver them however it can. See payload.go.
+	Payload Payload
+	// CallbackData is the flat colon-joined form of Payload.
 	//
-	// TODO(phase-2b): this is Telegram's wire format leaking into the neutral
-	// model — it forces a 64-byte budget on every platform, including those
-	// with no such limit. It is scheduled to become an arbitrary Payload with
-	// per-platform delivery.
+	// Deprecated: this is Telegram's wire encoding, not an identity — see the
+	// Payload doc comment for what that cost. Producers inside imbot's own
+	// interaction and menu packages still build it, so renderers accept it and
+	// parse it into segments. New code sets Payload.
 	CallbackData string
 	// URL is the link opened by ActionOpenURL / ActionOpenMiniApp.
 	URL string
@@ -100,10 +103,21 @@ func (a Action) ExtFor(platform Platform) (any, bool) {
 	return v, ok
 }
 
+// EffectivePayload returns the action's payload, parsing the deprecated
+// CallbackData when that is all the producer supplied. Renderers call this
+// rather than reading either field directly, so the compatibility path lives
+// in one place and disappears in one edit.
+func (a Action) EffectivePayload() Payload {
+	if len(a.Payload) > 0 {
+		return a.Payload
+	}
+	return PayloadFromCallbackData(a.CallbackData)
+}
+
 // IsLink reports whether the action should be rendered as a link rather than
 // as a callback control.
 func (a Action) IsLink() bool {
-	return a.URL != "" && (a.Kind == ActionOpenURL || a.CallbackData == "")
+	return a.URL != "" && (a.Kind == ActionOpenURL || a.EffectivePayload().IsEmpty())
 }
 
 // ActionSet is a laid-out group of message-scoped actions. Rows are preserved

--- a/imbot/core/message.go
+++ b/imbot/core/message.go
@@ -20,6 +20,21 @@ type Message struct {
 	ChatType      ChatType               `json:"chatType"`
 	ThreadContext *ThreadContext         `json:"threadContext,omitempty"`
 	Metadata      map[string]interface{} `json:"metadata,omitempty"`
+	// Payload carries the segments of the action the user activated, for
+	// messages that are button presses rather than typed input. Empty for
+	// ordinary messages. Platforms fill it in their inbound adapter, which is
+	// where the platform's own encoding stops being visible.
+	Payload Payload `json:"payload,omitempty"`
+}
+
+// IsCallback reports whether this message is an action firing rather than
+// user-typed content.
+func (m *Message) IsCallback() bool {
+	if !m.Payload.IsEmpty() {
+		return true
+	}
+	isCallback, _ := m.Metadata["is_callback"].(bool)
+	return isCallback
 }
 
 // TextContent represents text message content

--- a/imbot/core/message_builder.go
+++ b/imbot/core/message_builder.go
@@ -133,6 +133,16 @@ func (b *MessageBuilder) WithMetadataMap(metadata map[string]interface{}) *Messa
 	return b
 }
 
+// WithPayload marks the message as an action firing and records the segments
+// it carries. It also sets the legacy is_callback / callback_data metadata so
+// consumers that have not migrated keep working.
+func (b *MessageBuilder) WithPayload(payload Payload) *MessageBuilder {
+	b.msg.Payload = payload
+	return b.
+		WithMetadata("is_callback", true).
+		WithMetadata("callback_data", payload.FlatCallbackData())
+}
+
 // WithRawMetadata adds raw platform data to metadata under a namespaced key
 func (b *MessageBuilder) WithRawMetadata(key string, value interface{}) *MessageBuilder {
 	return b.WithMetadata(string(b.platform)+":"+key, value)

--- a/imbot/core/payload.go
+++ b/imbot/core/payload.go
@@ -1,0 +1,101 @@
+package core
+
+import "strings"
+
+// Payload is a button's identity: the ordered segments a platform hands back
+// when the user taps it.
+//
+// It exists because the previous identity — Telegram's callback_data — was a
+// transport encoding, not an identity. That encoding is a colon-joined string
+// capped at 64 bytes, and treating it as the neutral model leaked Telegram's
+// budget into every platform and into the application's own data model:
+//
+//   - Any payload above 64 bytes made Telegram reject the entire message, not
+//     just the button. Nothing validated it, so a long project path took the
+//     whole reply down with a BUTTON_DATA_INVALID the user never saw.
+//   - Because ":" was the separator, a path containing ":" had to be escaped;
+//     the escape used a NUL byte, which is invalid inside the JSON that Feishu
+//     button values are made of.
+//   - The directory browser could not fit a path at all, so it sent array
+//     indices and kept a server-side snapshot to resolve them — a whole
+//     state machine that existed only to satisfy Telegram, on every platform.
+//
+// With identity separated from encoding, each platform delivers segments its
+// own way: Feishu puts them in the button's JSON value, Telegram joins them
+// when they fit and swaps in a short token when they do not.
+//
+// # Why segments rather than a map
+//
+// Every dispatch site in this repository is positional — "bind", "dir", path.
+// Segments model that exactly, so the change stays mechanical in the one step
+// that must not break: a mis-migrated button is a button that silently does
+// nothing. A map[string]any would buy named fields, but the names would be
+// invented rather than discovered, and it would rewrite every producer and
+// consumer at once. Encoding stays platform business either way, which is the
+// property that actually matters here.
+type Payload []string
+
+// NewPayload builds a payload from its segments.
+func NewPayload(segments ...string) Payload {
+	return Payload(segments)
+}
+
+// Name returns the first segment, which by convention names the action's
+// namespace ("bind", "perm", "project"). It is "" for an empty payload, so
+// callers can switch on it without a length check.
+func (p Payload) Name() string {
+	return p.Arg(0)
+}
+
+// Arg returns segment i, or "" when it is absent. Bounds-safe by design: a
+// stale button from an older release carrying fewer segments should read as
+// missing data, not panic the receiving handler.
+func (p Payload) Arg(i int) string {
+	if i < 0 || i >= len(p) {
+		return ""
+	}
+	return p[i]
+}
+
+// IsEmpty reports whether the payload carries nothing.
+func (p Payload) IsEmpty() bool {
+	return len(p) == 0
+}
+
+// legacySeparator is the character the flat callback_data encoding joins on.
+// It is Telegram's convention, inherited by every platform that copied the
+// shape; it is defined here only so the compatibility helpers below agree.
+const legacySeparator = ":"
+
+// FlatCallbackData renders the payload in the historical colon-joined form.
+//
+// This is a compatibility shim for surfaces that still speak the flat string —
+// the interaction and menu packages, and the callback_data metadata key that
+// existing consumers read. It is lossy whenever a segment contains ":", which
+// is exactly why it is not how payloads travel any more. Platforms encoding
+// for the wire must handle that case rather than call this.
+func (p Payload) FlatCallbackData() string {
+	return strings.Join(p, legacySeparator)
+}
+
+// HasSeparator reports whether any segment contains the legacy separator, in
+// which case the flat encoding cannot round-trip and the platform must deliver
+// the segments some other way.
+func (p Payload) HasSeparator() bool {
+	for _, seg := range p {
+		if strings.Contains(seg, legacySeparator) {
+			return true
+		}
+	}
+	return false
+}
+
+// PayloadFromCallbackData parses the historical flat encoding back into
+// segments. Used on inbound paths that still receive a flat string, and to
+// interpret Action.CallbackData from producers that have not migrated.
+func PayloadFromCallbackData(data string) Payload {
+	if data == "" {
+		return nil
+	}
+	return Payload(strings.Split(data, legacySeparator))
+}

--- a/imbot/core/payload_test.go
+++ b/imbot/core/payload_test.go
@@ -1,0 +1,64 @@
+package core
+
+import "testing"
+
+// TestPayloadAccessorsAreBoundsSafe: a stale button from an older release may
+// carry fewer segments than the handler expects. Reading past the end must
+// look like missing data, not panic the receiving handler.
+func TestPayloadAccessorsAreBoundsSafe(t *testing.T) {
+	var empty Payload
+	if empty.Name() != "" || empty.Arg(3) != "" || !empty.IsEmpty() {
+		t.Error("empty payload should read as blanks")
+	}
+
+	p := NewPayload("bind", "dir")
+	if p.Name() != "bind" || p.Arg(1) != "dir" {
+		t.Errorf("unexpected segments: %v", p)
+	}
+	if p.Arg(2) != "" || p.Arg(-1) != "" {
+		t.Error("out-of-range reads should be empty")
+	}
+}
+
+func TestHasSeparator(t *testing.T) {
+	if NewPayload("bind", "dir", "/tmp/x").HasSeparator() {
+		t.Error("no segment contains a colon")
+	}
+	if !NewPayload("bind", "dir", "/mnt/c:/x").HasSeparator() {
+		t.Error("the colon should be detected")
+	}
+}
+
+// TestEffectivePayloadPrefersSegments checks the compatibility rule: producers
+// that still set only CallbackData keep working, and a producer that sets both
+// is read from the segments.
+func TestEffectivePayloadPrefersSegments(t *testing.T) {
+	legacy := Action{CallbackData: "perm:deny:req-1"}
+	if got := legacy.EffectivePayload(); got.Name() != "perm" || got.Arg(2) != "req-1" {
+		t.Errorf("legacy action decoded to %v", got)
+	}
+
+	both := Action{Payload: NewPayload("a", "b"), CallbackData: "x:y"}
+	if got := both.EffectivePayload(); got.Name() != "a" {
+		t.Errorf("segments should win, got %v", got)
+	}
+
+	if !(Action{}).EffectivePayload().IsEmpty() {
+		t.Error("an action with neither should read as empty")
+	}
+}
+
+// TestIsLinkConsidersPayload: a URL button with no payload is a link, but one
+// carrying a payload is a control that happens to have a URL. Getting this
+// wrong renders the button as a plain link and the callback never fires.
+func TestIsLinkConsidersPayload(t *testing.T) {
+	if !(Action{URL: "https://example.test"}).IsLink() {
+		t.Error("a bare URL action is a link")
+	}
+	if (Action{URL: "https://example.test", Payload: NewPayload("go")}).IsLink() {
+		t.Error("an action carrying a payload is not a plain link")
+	}
+	if !(Action{URL: "https://example.test", Payload: NewPayload("go"), Kind: ActionOpenURL}).IsLink() {
+		t.Error("an explicit open_url action is a link regardless")
+	}
+}

--- a/imbot/imbot.go
+++ b/imbot/imbot.go
@@ -101,6 +101,7 @@ type (
 	ConnectionDetails = core.ConnectionDetails
 
 	// Keyboard types
+	Payload              = core.Payload
 	InlineKeyboardButton = interaction.InlineKeyboardButton
 	InlineKeyboardMarkup = interaction.InlineKeyboardMarkup
 	KeyboardBuilder      = interaction.KeyboardBuilder
@@ -289,7 +290,19 @@ func NewKeyboardBuilder() *interaction.KeyboardBuilder {
 	return interaction.NewKeyboardBuilder()
 }
 
-// CallbackButton creates a callback button
+// NewPayload builds a button payload from its segments.
+func NewPayload(segments ...string) core.Payload {
+	return core.NewPayload(segments...)
+}
+
+// ActionButton creates a button carrying the given payload segments.
+func ActionButton(text string, segments ...string) interaction.InlineKeyboardButton {
+	return interaction.ActionButton(text, segments...)
+}
+
+// CallbackButton creates a callback button from a pre-joined string.
+//
+// Deprecated: use ActionButton.
 func CallbackButton(text, callbackData string) interaction.InlineKeyboardButton {
 	return interaction.CallbackButton(text, callbackData)
 }
@@ -302,16 +315,6 @@ func FormatCallbackData(action string, data ...string) string {
 // ParseCallbackData parses a callback data string into parts
 func ParseCallbackData(data string) []string {
 	return interaction.ParseCallbackData(data)
-}
-
-// FormatDirPath formats a directory path for callback data (handles colons in paths)
-func FormatDirPath(path string) string {
-	return interaction.FormatDirPath(path)
-}
-
-// ParseDirPath parses a directory path from callback data
-func ParseDirPath(encoded string) string {
-	return interaction.ParseDirPath(encoded)
 }
 
 // FormatDirButton formats a directory name for a button

--- a/imbot/interaction/keyboard.go
+++ b/imbot/interaction/keyboard.go
@@ -9,7 +9,14 @@ import (
 
 // InlineKeyboardButton represents a button in an inline keyboard
 type InlineKeyboardButton struct {
-	Text         string `json:"text"`
+	Text string `json:"text"`
+	// Payload is what the button sends back. Prefer it over CallbackData: it
+	// is not bound to any platform's wire encoding, so a segment may be as
+	// long as it needs to be and may contain any character.
+	Payload core.Payload `json:"payload,omitempty"`
+	// CallbackData is the flat colon-joined form.
+	//
+	// Deprecated: use Payload. See imbot/core/payload.go.
 	CallbackData string `json:"callback_data,omitempty"`
 	URL          string `json:"url,omitempty"`
 }
@@ -46,7 +53,20 @@ func (b *KeyboardBuilder) AddButton(button InlineKeyboardButton) *KeyboardBuilde
 	return b
 }
 
-// CallbackButton creates a callback button
+// ActionButton creates a button that sends back the given payload segments.
+// This is the form to use: the segments stay segments all the way to the
+// platform, which is what lets a button carry a full filesystem path.
+func ActionButton(text string, segments ...string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:    text,
+		Payload: core.NewPayload(segments...),
+	}
+}
+
+// CallbackButton creates a callback button from a pre-joined string.
+//
+// Deprecated: use ActionButton. Joining the segments yourself reintroduces
+// the separator collision and the 64-byte budget this seam removed.
 func CallbackButton(text, callbackData string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:         text,
@@ -137,17 +157,12 @@ func FormatCallbackData(action string, data ...string) string {
 	return strings.Join(parts, ":")
 }
 
-// FormatDirPath formats a directory path for callback data (handles colons in paths)
-func FormatDirPath(path string) string {
-	// Replace problematic characters for callback data
-	// Telegram callback data max length is 64 bytes
-	return strings.ReplaceAll(path, ":", "\x00")
-}
-
-// ParseDirPath parses a directory path from callback data
-func ParseDirPath(encoded string) string {
-	return strings.ReplaceAll(encoded, "\x00", ":")
-}
+// FormatDirPath and ParseDirPath used to live here: they swapped ":" for a NUL
+// byte so a path could survive the colon-joined callback encoding. Both are
+// gone. A path now travels as its own payload segment, so there is no
+// separator to collide with — and the NUL they produced was invalid inside the
+// JSON that Feishu button values are made of, which made the escape a bug on
+// every platform except the one it was written for.
 
 // TruncateText truncates text to maxLen with ellipsis
 func TruncateText(text string, maxLen int) string {
@@ -178,6 +193,7 @@ func (m InlineKeyboardMarkup) ToActionSet() *core.ActionSet {
 		for _, btn := range row {
 			actions = append(actions, core.Action{
 				Label:        btn.Text,
+				Payload:      btn.Payload,
 				CallbackData: btn.CallbackData,
 				URL:          btn.URL,
 			})

--- a/imbot/interaction/keyboard.go
+++ b/imbot/interaction/keyboard.go
@@ -114,28 +114,9 @@ func (b *KeyboardBuilder) ButtonCount() int {
 	return count
 }
 
-// CallbackDataBuilder helps build structured callback data strings
-type CallbackDataBuilder struct {
-	parts []string
-}
-
-// NewCallbackData creates a new callback data builder
-func NewCallbackData(action string) *CallbackDataBuilder {
-	return &CallbackDataBuilder{
-		parts: []string{action},
-	}
-}
-
-// Add adds a data part to the callback
-func (b *CallbackDataBuilder) Add(data string) *CallbackDataBuilder {
-	b.parts = append(b.parts, data)
-	return b
-}
-
-// Build returns the callback data string
-func (b *CallbackDataBuilder) Build() string {
-	return strings.Join(b.parts, ":")
-}
+// CallbackDataBuilder is gone: it built the flat colon-joined string that
+// core.Payload replaces, and nothing had used it. Build segments with
+// ActionButton or core.NewPayload instead.
 
 // ParseCallbackData parses a callback data string into parts
 func ParseCallbackData(data string) []string {

--- a/imbot/platform/feishu/action_render.go
+++ b/imbot/platform/feishu/action_render.go
@@ -105,18 +105,57 @@ func buildActionButton(action core.Action) (larkcard.MessageCardActionElement, b
 			MultiUrl(larkcard.NewMessageCardURL().Url(action.URL)), true
 	}
 
-	if action.CallbackData == "" {
+	payload := action.EffectivePayload()
+	if payload.IsEmpty() {
 		// Nothing to send back and nowhere to go.
 		return nil, false
 	}
 
+	// A Feishu button value is arbitrary JSON, so the payload's segments go in
+	// as segments — no length budget, no separator to escape. The flat form is
+	// carried alongside only for consumers still reading callback_data.
 	return larkcard.NewMessageCardEmbedButton().
 		Text(larkcard.NewMessageCardPlainText().Content(action.Label)).
 		Type(larkcard.MessageCardButtonTypeDefault).
 		Value(map[string]interface{}{
-			"callback": action.CallbackData,
-			"actionId": action.ID,
+			payloadValueKey: []string(payload),
+			"callback":      payload.FlatCallbackData(),
+			"actionId":      action.ID,
 		}), true
+}
+
+// payloadValueKey is where a button's payload segments live inside the Feishu
+// button value object.
+const payloadValueKey = "payload"
+
+// payloadFromButtonValue reads the segments back out of an inbound card action
+// value, accepting the flat callback string from buttons rendered by earlier
+// releases.
+// Values that have been through the wire arrive as []interface{}; values read
+// back before serialisation are still []string. Both are accepted so a test
+// exercises the same decoder production does.
+func payloadFromButtonValue(value map[string]interface{}) core.Payload {
+	switch raw := value[payloadValueKey].(type) {
+	case []string:
+		return core.Payload(raw)
+	case []interface{}:
+		segments := make(core.Payload, 0, len(raw))
+		for _, item := range raw {
+			s, ok := item.(string)
+			if !ok {
+				return nil
+			}
+			segments = append(segments, s)
+		}
+		return segments
+	}
+	// A button rendered before payload segments existed carries only the
+	// joined string. It cannot represent a segment containing ":", but no
+	// such button was expressible then either.
+	if flat, ok := value["callback"].(string); ok {
+		return core.PayloadFromCallbackData(flat)
+	}
+	return nil
 }
 
 // actionSetFromLegacyMarkup accepts the shapes that used to be pushed through

--- a/imbot/platform/feishu/action_render.go
+++ b/imbot/platform/feishu/action_render.go
@@ -143,6 +143,9 @@ func payloadFromButtonValue(value map[string]interface{}) core.Payload {
 		for _, item := range raw {
 			s, ok := item.(string)
 			if !ok {
+				// A malformed array is not something to half-decode: a payload
+				// missing a segment dispatches to the wrong handler rather
+				// than to none.
 				return nil
 			}
 			segments = append(segments, s)

--- a/imbot/platform/feishu/bot_sdk.go
+++ b/imbot/platform/feishu/bot_sdk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
@@ -25,33 +26,36 @@ const (
 	DomainLark   Domain = "lark"
 )
 
-// getReceiveIdType determines the receive_id_type based on the target ID format
-// - "user_id": for user's user_id (global across apps, for P2P/direct chat)
-// - "open_id": for user's open_id (app-specific, for P2P/direct chat)
-// - "chat_id": for group/chat IDs
+// getReceiveIdType picks the receive_id_type that matches a target ID.
 //
-// Feishu/Lark ID patterns:
-// - ou_xxxxxx: user's user_id (global, preferred for cross-app messaging)
-// - oc_xxxxxx: user's open_id (app-specific)
-// - cli_xxxxxx: group chat ID
+// Feishu writes the kind of an ID into its prefix:
+//   - oc_xxxxxx: a conversation (chat_id) — group or one-to-one
+//   - ou_xxxxxx: a user as this app sees them (open_id)
+//   - on_xxxxxx: a user as the app developer sees them (union_id)
+//   - anything with "@": an email address
+//   - no prefix: a tenant-assigned user_id
 //
-// The most reliable approach is to check ID prefix.
+// The previous version had the user and chat prefixes swapped, and compared
+// them against a four-character slice so neither could match in the first
+// place; every target was therefore sent as an open_id.
 func getReceiveIdType(targetID string) string {
-	if len(targetID) < 4 {
-		return "open_id"
-	}
-
-	prefix := targetID[:4]
-	switch prefix {
-	case "cli_":
-		return "chat_id"
-	case "ou_":
-		return "user_id" // Global user_id for cross-app messaging
-	case "oc_":
-		return "open_id" // App-specific open_id
+	// Feishu identifies the receiver by an ID whose kind is written into its
+	// prefix. Matching that prefix has to be a prefix test: the previous
+	// version compared targetID[:4] against three-character constants, so the
+	// "oc_" and "ou_" cases could never match and every target — including
+	// chat IDs — was sent as an open_id.
+	switch {
+	case strings.HasPrefix(targetID, "oc_"):
+		return "chat_id" // conversation, group or one-to-one
+	case strings.HasPrefix(targetID, "ou_"):
+		return "open_id" // user, scoped to this app
+	case strings.HasPrefix(targetID, "on_"):
+		return "union_id" // user, scoped to the app developer
+	case strings.Contains(targetID, "@"):
+		return "email"
 	default:
-		// Default to open_id for backward compatibility
-		return "open_id"
+		// A tenant-assigned user_id has no prefix to key off.
+		return "user_id"
 	}
 }
 
@@ -153,7 +157,8 @@ func (b *Bot) StartReceiving(ctx context.Context) error {
 	// Create event handler that converts Lark events to core.Message
 	// OnP2MessageReceiveV1 handles both v1.0 and v2.0 message receive events
 	eventHandler := dispatcher.NewEventDispatcher("", "").
-		OnP2MessageReceiveV1(b.handleP2MessageReceiveV1)
+		OnP2MessageReceiveV1(b.handleP2MessageReceiveV1).
+		OnP2CardActionTrigger(b.handleCardActionTrigger)
 
 	// Determine base URL for WebSocket
 	wsDomain := lark.FeishuBaseUrl

--- a/imbot/platform/feishu/card_callback.go
+++ b/imbot/platform/feishu/card_callback.go
@@ -1,0 +1,71 @@
+package feishu
+
+import (
+	"context"
+	"time"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+	"github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+// Card button presses arrive as their own callback event, separate from the
+// message stream. Until this file existed the bot subscribed only to message
+// receipt, so every card button it rendered was inert: the click produced a
+// spinner on the user's side and nothing at all on ours.
+//
+// That is worse than having no buttons. Phase 2a fixed Feishu cards rendering
+// without buttons; a button that renders and then does nothing looks to the
+// user like a broken bot rather than a missing feature.
+
+// handleCardActionTrigger converts a card button press into a core.Message and
+// emits it on the same channel as ordinary messages, so consumers dispatch
+// callbacks identically on every platform.
+//
+// The returned response is what Feishu shows the user immediately. Returning
+// nil leaves the card as it is, which is right here: the handler downstream
+// decides whether to restate the card, and guessing a toast would pre-empt it.
+func (b *Bot) handleCardActionTrigger(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+	if event == nil || event.Event == nil || event.Event.Action == nil {
+		return nil, nil
+	}
+
+	payload := payloadFromButtonValue(event.Event.Action.Value)
+	if payload.IsEmpty() {
+		b.Logger().Debug("Card action carried no recognisable payload: %v", event.Event.Action.Value)
+		return nil, nil
+	}
+
+	var chatID, messageID string
+	if event.Event.Context != nil {
+		chatID = event.Event.Context.OpenChatID
+		messageID = event.Event.Context.OpenMessageID
+	}
+
+	senderID := ""
+	if op := event.Event.Operator; op != nil {
+		// Prefer the tenant-global user_id when the app is scoped to see it,
+		// matching what convertLarkMessageToCore does for ordinary messages so
+		// a chat's sender identity does not change between the two paths.
+		if op.UserID != nil && *op.UserID != "" {
+			senderID = *op.UserID
+		} else {
+			senderID = op.OpenID
+		}
+	}
+
+	msg := core.NewMessageBuilder(core.Platform(b.domain)).
+		WithID(messageID).
+		WithTimestamp(time.Now().Unix()).
+		WithSender(senderID, "", "").
+		WithRecipient(chatID, string(core.ChatTypeDirect), "").
+		WithTextContent("", nil).
+		WithPayload(payload).
+		WithMetadata("callback_query_id", messageID).
+		WithMetadata("message_id", messageID).
+		WithMetadata("original_chat_id", chatID).
+		Build()
+
+	b.EmitMessage(*msg)
+	b.UpdateLastActivity()
+	return nil, nil
+}

--- a/imbot/platform/feishu/card_callback.go
+++ b/imbot/platform/feishu/card_callback.go
@@ -21,24 +21,40 @@ import (
 // emits it on the same channel as ordinary messages, so consumers dispatch
 // callbacks identically on every platform.
 //
-// The returned response is what Feishu shows the user immediately. Returning
-// nil leaves the card as it is, which is right here: the handler downstream
-// decides whether to restate the card, and guessing a toast would pre-empt it.
+// The returned response is what Feishu shows the user immediately. An empty
+// response means "leave the card alone", which is right here: the handler
+// downstream decides whether to restate the card, and guessing a toast would
+// pre-empt it.
+//
+// It must be an empty value rather than a nil pointer. The SDK returns this
+// through an interface{} and tests it against nil, so a typed nil pointer
+// still reads as non-nil and gets marshalled — sending Feishu a literal
+// "null" body instead of no body at all.
 func (b *Bot) handleCardActionTrigger(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+	noReply := &callback.CardActionTriggerResponse{}
+
 	if event == nil || event.Event == nil || event.Event.Action == nil {
-		return nil, nil
+		return noReply, nil
 	}
 
 	payload := payloadFromButtonValue(event.Event.Action.Value)
 	if payload.IsEmpty() {
 		b.Logger().Debug("Card action carried no recognisable payload: %v", event.Event.Action.Value)
-		return nil, nil
+		return noReply, nil
 	}
 
 	var chatID, messageID string
 	if event.Event.Context != nil {
 		chatID = event.Event.Context.OpenChatID
 		messageID = event.Event.Context.OpenMessageID
+	}
+	if chatID == "" {
+		// Without a chat there is nowhere to reply. Emitting anyway would be
+		// worse than dropping: the message builder substitutes "unknown" for a
+		// missing recipient, and the handler would then address a chat that
+		// does not exist.
+		b.Logger().Warn("Card action arrived without a chat ID, dropping: %v", payload)
+		return noReply, nil
 	}
 
 	senderID := ""
@@ -67,5 +83,5 @@ func (b *Bot) handleCardActionTrigger(ctx context.Context, event *callback.CardA
 
 	b.EmitMessage(*msg)
 	b.UpdateLastActivity()
-	return nil, nil
+	return noReply, nil
 }

--- a/imbot/platform/feishu/card_callback_test.go
+++ b/imbot/platform/feishu/card_callback_test.go
@@ -1,9 +1,11 @@
 package feishu
 
 import (
+	"context"
 	"testing"
 
 	larkcard "github.com/larksuite/oapi-sdk-go/v3/card"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	"github.com/tingly-dev/tingly-box/imbot/core"
 )
 
@@ -90,5 +92,64 @@ func TestGetReceiveIdType(t *testing.T) {
 		if got := getReceiveIdType(target); got != want {
 			t.Errorf("getReceiveIdType(%q) = %q, want %q", target, got, want)
 		}
+	}
+}
+
+// TestCardActionResponseIsNeverATypedNil guards a trap in how the SDK returns
+// this handler's result. It passes the value out through an interface{} and
+// tests it against nil; a nil *CardActionTriggerResponse still reads as
+// non-nil there and gets marshalled, so Feishu would receive a literal "null"
+// body rather than no body. Every return path must carry a real value.
+func TestCardActionResponseIsNeverATypedNil(t *testing.T) {
+	b := &Bot{BaseBot: core.NewBaseBot(&core.Config{Platform: core.PlatformFeishu}), domain: DomainFeishu}
+
+	for name, event := range map[string]*callback.CardActionTriggerEvent{
+		"nil event":     nil,
+		"nil inner":     {},
+		"empty payload": {Event: &callback.CardActionTriggerRequest{Action: &callback.CallBackAction{Value: map[string]interface{}{}}}},
+		"no chat": {Event: &callback.CardActionTriggerRequest{
+			Action: &callback.CallBackAction{Value: map[string]interface{}{"callback": "bind:up"}},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := b.handleCardActionTrigger(context.Background(), event)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp == nil {
+				t.Fatal("returned a nil pointer; the SDK marshals that as \"null\"")
+			}
+			// Mirror the SDK: the value crosses an interface{} boundary.
+			var asAny interface{} = resp
+			if asAny == nil {
+				t.Fatal("unreachable, but documents what the SDK checks")
+			}
+		})
+	}
+}
+
+// TestCardActionWithoutChatIsDropped: the message builder substitutes
+// "unknown" for a missing recipient, so emitting would address a chat that
+// does not exist rather than failing visibly.
+func TestCardActionWithoutChatIsDropped(t *testing.T) {
+	b := &Bot{BaseBot: core.NewBaseBot(&core.Config{Platform: core.PlatformFeishu}), domain: DomainFeishu}
+
+	received := make(chan core.Message, 1)
+	b.OnMessage(func(m core.Message) {
+		received <- m
+	})
+
+	_, err := b.handleCardActionTrigger(context.Background(), &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Action: &callback.CallBackAction{Value: map[string]interface{}{"callback": "bind:up"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case m := <-received:
+		t.Fatalf("a chat-less card action was emitted: recipient=%q", m.Recipient.ID)
+	default:
 	}
 }

--- a/imbot/platform/feishu/card_callback_test.go
+++ b/imbot/platform/feishu/card_callback_test.go
@@ -1,0 +1,94 @@
+package feishu
+
+import (
+	"testing"
+
+	larkcard "github.com/larksuite/oapi-sdk-go/v3/card"
+	"github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+// buttonValue renders one action and digs out the value object Feishu will
+// hand back when the button is tapped.
+func buttonValue(t *testing.T, action core.Action) map[string]interface{} {
+	t.Helper()
+	el, ok := buildActionButton(action)
+	if !ok {
+		t.Fatal("action was not rendered as a button")
+	}
+	btn, ok := el.(*larkcard.MessageCardEmbedButton)
+	if !ok {
+		t.Fatalf("unexpected button type %T", el)
+	}
+	return btn.Value_
+}
+
+// TestButtonValueCarriesSegments: a Feishu button value is arbitrary JSON, so
+// the payload goes in as segments and nothing needs truncating or escaping.
+// This is the half of the seam Telegram cannot have.
+func TestButtonValueCarriesSegments(t *testing.T) {
+	longPath := "/home/somebody/projects/an-organisation/a-long-repository-name/nested"
+	value := buttonValue(t, core.Action{
+		Label:   "Create",
+		Payload: core.NewPayload("bind", "create", longPath),
+	})
+
+	got := payloadFromButtonValue(value)
+	if got.Name() != "bind" || got.Arg(1) != "create" || got.Arg(2) != longPath {
+		t.Fatalf("round trip = %v", got)
+	}
+}
+
+// TestButtonValueRoundTripsSeparator: the segment survives a colon, which the
+// old NUL escape could not express inside JSON at all.
+func TestButtonValueRoundTripsSeparator(t *testing.T) {
+	weird := "/mnt/c:/Users/someone"
+	value := buttonValue(t, core.Action{
+		Label:   "Go",
+		Payload: core.NewPayload("bind", "dir", weird),
+	})
+	if got := payloadFromButtonValue(value).Arg(2); got != weird {
+		t.Errorf("path = %q, want %q", got, weird)
+	}
+}
+
+// TestButtonValueAcceptsLegacyFlatCallback keeps buttons rendered by an
+// earlier release working after an upgrade: their value objects carry only the
+// joined string.
+func TestButtonValueAcceptsLegacyFlatCallback(t *testing.T) {
+	got := payloadFromButtonValue(map[string]interface{}{"callback": "perm:deny:req-1"})
+	if got.Name() != "perm" || got.Arg(2) != "req-1" {
+		t.Fatalf("legacy value did not decode: %v", got)
+	}
+}
+
+// TestButtonValueDecodesJSONRoundTrip covers the shape the SDK actually
+// delivers: the value has been through JSON, so the segment array arrives as
+// []interface{} rather than []string.
+func TestButtonValueDecodesJSONRoundTrip(t *testing.T) {
+	got := payloadFromButtonValue(map[string]interface{}{
+		payloadValueKey: []interface{}{"bind", "dir", "/tmp/x"},
+	})
+	if got.Arg(2) != "/tmp/x" {
+		t.Fatalf("decoded = %v", got)
+	}
+}
+
+// TestGetReceiveIdType covers the mapping that decides how a reply is
+// addressed. The previous version compared a four-character slice against
+// three-character prefixes, so the chat and user cases were unreachable and
+// every target was sent as an open_id — including the chat IDs a card
+// callback replies to.
+func TestGetReceiveIdType(t *testing.T) {
+	cases := map[string]string{
+		"oc_a1b2c3":         "chat_id",
+		"ou_a1b2c3":         "open_id",
+		"on_a1b2c3":         "union_id",
+		"someone@corp.test": "email",
+		"7f3d9a2b":          "user_id",
+	}
+	for target, want := range cases {
+		if got := getReceiveIdType(target); got != want {
+			t.Errorf("getReceiveIdType(%q) = %q, want %q", target, got, want)
+		}
+	}
+}

--- a/imbot/platform/telegram/action_render.go
+++ b/imbot/platform/telegram/action_render.go
@@ -56,7 +56,7 @@ func SwitchInlineButton(label, query string) core.Action {
 // deprecated Metadata["replyMarkup"] convention.
 func (b *Bot) resolveReplyMarkup(opts *core.SendMessageOptions) *models.InlineKeyboardMarkup {
 	if !opts.Actions.IsEmpty() {
-		markup := BuildInlineKeyboard(opts.Actions)
+		markup := b.BuildInlineKeyboard(opts.Actions)
 		return &markup
 	}
 
@@ -77,7 +77,7 @@ func (b *Bot) resolveReplyMarkup(opts *core.SendMessageOptions) *models.InlineKe
 	case *models.InlineKeyboardMarkup:
 		return m
 	case interaction.InlineKeyboardMarkup:
-		markup := BuildInlineKeyboard(m.ToActionSet())
+		markup := b.BuildInlineKeyboard(m.ToActionSet())
 		return &markup
 	}
 	return nil
@@ -86,12 +86,16 @@ func (b *Bot) resolveReplyMarkup(opts *core.SendMessageOptions) *models.InlineKe
 // BuildInlineKeyboard renders a neutral action set as a Telegram inline
 // keyboard. Actions this platform cannot express are dropped here rather than
 // at the call site — that is the whole point of the seam.
-func BuildInlineKeyboard(set *core.ActionSet) models.InlineKeyboardMarkup {
+//
+// It is a bot method because encoding a payload into callback_data may need to
+// park it in that bot's vault; the wire form of a button is bot-scoped state,
+// not a pure function of the action.
+func (b *Bot) BuildInlineKeyboard(set *core.ActionSet) models.InlineKeyboardMarkup {
 	var rows [][]models.InlineKeyboardButton
 	for _, row := range set.Rows {
 		var buttons []models.InlineKeyboardButton
 		for _, action := range row {
-			if btn, ok := buildButton(action); ok {
+			if btn, ok := b.buildButton(action); ok {
 				buttons = append(buttons, btn)
 			}
 		}
@@ -102,7 +106,7 @@ func BuildInlineKeyboard(set *core.ActionSet) models.InlineKeyboardMarkup {
 	return models.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
-func buildButton(action core.Action) (models.InlineKeyboardButton, bool) {
+func (b *Bot) buildButton(action core.Action) (models.InlineKeyboardButton, bool) {
 	btn := models.InlineKeyboardButton{Text: action.Label}
 
 	// Tier 3 first: a Telegram-specific shape wins over the neutral fields.
@@ -119,9 +123,9 @@ func buildButton(action core.Action) (models.InlineKeyboardButton, bool) {
 		}
 	}
 
-	switch {
-	case action.CallbackData != "":
-		btn.CallbackData = action.CallbackData
+	switch payload := action.EffectivePayload(); {
+	case !payload.IsEmpty():
+		btn.CallbackData = b.callbacks.encodeCallbackData(payload)
 	case action.URL != "":
 		btn.URL = action.URL
 	default:
@@ -143,7 +147,7 @@ func (b *Bot) Restate(ctx context.Context, ref core.MessageRef, opts core.Restat
 
 	var markup *models.InlineKeyboardMarkup
 	if !opts.Actions.IsEmpty() {
-		kb := BuildInlineKeyboard(opts.Actions)
+		kb := b.BuildInlineKeyboard(opts.Actions)
 		markup = &kb
 	}
 

--- a/imbot/platform/telegram/action_render_test.go
+++ b/imbot/platform/telegram/action_render_test.go
@@ -7,12 +7,18 @@ import (
 	"github.com/tingly-dev/tingly-box/imbot/interaction"
 )
 
+// testBot is the minimum Bot needed to render a keyboard: a callback vault.
+// Rendering is bot-scoped because encoding a payload may park it.
+func testBot() *Bot {
+	return &Bot{callbacks: newCallbackVault()}
+}
+
 func TestBuildInlineKeyboardPreservesRows(t *testing.T) {
 	set := core.NewActionSet().
 		AddRow(core.Action{Label: "A", CallbackData: "a"}, core.Action{Label: "B", CallbackData: "b"}).
 		AddRow(core.Action{Label: "C", CallbackData: "c"})
 
-	kb := BuildInlineKeyboard(set)
+	kb := testBot().BuildInlineKeyboard(set)
 	if len(kb.InlineKeyboard) != 2 {
 		t.Fatalf("rows = %d, want 2", len(kb.InlineKeyboard))
 	}
@@ -25,7 +31,7 @@ func TestBuildInlineKeyboardPreservesRows(t *testing.T) {
 }
 
 func TestBuildInlineKeyboardURLAction(t *testing.T) {
-	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(
+	kb := testBot().BuildInlineKeyboard(core.NewActionSet().AddRow(
 		core.Action{Label: "Docs", URL: "https://example.test", Kind: core.ActionOpenURL},
 	))
 	if got := kb.InlineKeyboard[0][0].URL; got != "https://example.test" {
@@ -37,7 +43,7 @@ func TestBuildInlineKeyboardURLAction(t *testing.T) {
 // with neither callback data nor a URL, which Telegram rejects outright — and
 // a rejected button fails the whole send, not just the button.
 func TestBuildInlineKeyboardDropsUnsendableAction(t *testing.T) {
-	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(core.Action{Label: "orphan"}))
+	kb := testBot().BuildInlineKeyboard(core.NewActionSet().AddRow(core.Action{Label: "orphan"}))
 	if len(kb.InlineKeyboard) != 0 {
 		t.Errorf("expected the unsendable action to be dropped, got %v", kb.InlineKeyboard)
 	}
@@ -56,7 +62,7 @@ func TestWebAppButton(t *testing.T) {
 		t.Error("the neutral URL must be set so the fallback has something to use")
 	}
 
-	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(action))
+	kb := testBot().BuildInlineKeyboard(core.NewActionSet().AddRow(action))
 	btn := kb.InlineKeyboard[0][0]
 	if btn.WebApp == nil {
 		t.Fatal("expected a web_app button on Telegram")
@@ -70,7 +76,7 @@ func TestWebAppButton(t *testing.T) {
 }
 
 func TestSwitchInlineButton(t *testing.T) {
-	kb := BuildInlineKeyboard(core.NewActionSet().AddRow(SwitchInlineButton("Share", "query")))
+	kb := testBot().BuildInlineKeyboard(core.NewActionSet().AddRow(SwitchInlineButton("Share", "query")))
 	btn := kb.InlineKeyboard[0][0]
 	if btn.SwitchInlineQuery == nil || *btn.SwitchInlineQuery != "query" {
 		t.Errorf("expected switch_inline_query to be set, got %+v", btn)
@@ -82,7 +88,7 @@ func TestKeyboardToActionSetRoundTrip(t *testing.T) {
 		AddRow(interaction.CallbackButton("Yes", "yes"), interaction.CallbackButton("No", "no")).
 		AddRow(interaction.URLButton("Docs", "https://example.test"))
 
-	out := BuildInlineKeyboard(kb.BuildActions())
+	out := testBot().BuildInlineKeyboard(kb.BuildActions())
 	if len(out.InlineKeyboard) != 2 {
 		t.Fatalf("rows = %d, want 2", len(out.InlineKeyboard))
 	}

--- a/imbot/platform/telegram/callback_codec.go
+++ b/imbot/platform/telegram/callback_codec.go
@@ -1,0 +1,127 @@
+package telegram
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+// Telegram's callback_data is at most 64 bytes, and the limit is enforced on
+// the whole outbound message: one oversized button and sendMessage fails with
+// BUTTON_DATA_INVALID, so the user sees no message at all rather than a
+// message with one button missing. That made it the single most damaging
+// platform constraint in the system, and nothing in the codebase checked it.
+//
+// This file makes the limit unreachable. A payload that fits the flat encoding
+// travels as before — same wire bytes, so buttons rendered by older releases
+// still resolve. A payload that does not fit is parked in a per-bot vault and
+// the button carries a short token instead.
+//
+// The vault is deliberately in-memory and bounded. Callback payloads describe
+// a control on a specific message in a specific conversation; they are worth
+// no more durability than the flow that produced them, and every such flow in
+// this repository already keeps its state in memory with a timeout. What the
+// bound buys is the guarantee that a long-lived bot cannot grow this map
+// forever.
+
+const (
+	// telegramCallbackDataLimit is Telegram's hard cap on callback_data, in
+	// bytes.
+	telegramCallbackDataLimit = 64
+
+	// tokenPrefix marks a callback_data that is a vault reference rather than
+	// an encoded payload. "@" is reserved: no application payload may begin
+	// with it, which encodeCallbackData enforces by tokenizing any payload
+	// that does.
+	tokenPrefix = "@"
+
+	// vaultCapacity is how many parked payloads a bot keeps. Each entry is a
+	// handful of short strings, so this costs little; it is sized to be far
+	// beyond the number of buttons a conversation realistically leaves live.
+	vaultCapacity = 4096
+)
+
+// expiredButtonNotice is shown when a token no longer resolves — the bot has
+// restarted, or the button is older than vaultCapacity payloads. Saying so is
+// the point: the previous behaviour for an unresolvable button was silence,
+// which reads to the user as a broken bot.
+const expiredButtonNotice = "This button is no longer active. Send the command again."
+
+// callbackVault parks payloads that cannot be encoded into callback_data and
+// hands out short tokens that can.
+type callbackVault struct {
+	mu       sync.Mutex
+	entries  map[string]core.Payload
+	order    []string // insertion order, for eviction
+	next     uint64
+	capacity int
+}
+
+func newCallbackVault() *callbackVault {
+	return &callbackVault{
+		entries:  make(map[string]core.Payload),
+		capacity: vaultCapacity,
+	}
+}
+
+// park stores a payload and returns the token that stands for it.
+func (v *callbackVault) park(payload core.Payload) string {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	v.next++
+	token := tokenPrefix + strconv.FormatUint(v.next, 36)
+
+	stored := make(core.Payload, len(payload))
+	copy(stored, payload)
+	v.entries[token] = stored
+	v.order = append(v.order, token)
+
+	if len(v.order) > v.capacity {
+		evict := v.order[0]
+		v.order = v.order[1:]
+		delete(v.entries, evict)
+	}
+	return token
+}
+
+// resolve returns the payload a token stands for.
+func (v *callbackVault) resolve(token string) (core.Payload, bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	payload, ok := v.entries[token]
+	return payload, ok
+}
+
+// encodeCallbackData renders a payload as callback_data, parking it when the
+// flat encoding will not do. The result is always within Telegram's limit.
+//
+// Three things force a token: a segment containing the ":" separator (the flat
+// encoding cannot round-trip it — this is what the old NUL-escaping worked
+// around, at the cost of producing bytes that are invalid inside Feishu's JSON
+// button values), an encoding over the byte limit, and a payload that would
+// collide with the reserved token prefix.
+func (v *callbackVault) encodeCallbackData(payload core.Payload) string {
+	if payload.IsEmpty() {
+		return ""
+	}
+	flat := payload.FlatCallbackData()
+	if !payload.HasSeparator() &&
+		len(flat) <= telegramCallbackDataLimit &&
+		!strings.HasPrefix(flat, tokenPrefix) {
+		return flat
+	}
+	return v.park(payload)
+}
+
+// decodeCallbackData turns inbound callback_data back into segments. The
+// second result is false only for a token that no longer resolves; plain data
+// always decodes, including data produced before this encoding existed.
+func (v *callbackVault) decodeCallbackData(data string) (core.Payload, bool) {
+	if strings.HasPrefix(data, tokenPrefix) {
+		return v.resolve(data)
+	}
+	return core.PayloadFromCallbackData(data), true
+}

--- a/imbot/platform/telegram/callback_codec_test.go
+++ b/imbot/platform/telegram/callback_codec_test.go
@@ -1,0 +1,135 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/imbot/core"
+)
+
+// TestShortPayloadKeepsFlatEncoding pins the wire format for payloads that
+// fit. Buttons rendered by earlier releases carry exactly these bytes, so
+// changing this would strand every keyboard already sitting in a chat.
+func TestShortPayloadKeepsFlatEncoding(t *testing.T) {
+	v := newCallbackVault()
+	got := v.encodeCallbackData(core.NewPayload("bind", "up"))
+	if got != "bind:up" {
+		t.Fatalf("encoded = %q, want bind:up", got)
+	}
+	back, ok := v.decodeCallbackData(got)
+	if !ok || back.Name() != "bind" || back.Arg(1) != "up" {
+		t.Fatalf("round trip = %v (ok=%v)", back, ok)
+	}
+}
+
+// TestOversizePayloadStaysWithinTelegramLimit is the defect this seam exists
+// to close. A bind confirmation carries an absolute path; the old encoding put
+// it straight into callback_data, so any path over 52 bytes pushed the button
+// past Telegram's cap and sendMessage failed for the whole message — the user
+// saw nothing at all, with no error anywhere that named the cause.
+func TestOversizePayloadStaysWithinTelegramLimit(t *testing.T) {
+	v := newCallbackVault()
+	longPath := "/home/somebody/projects/an-organisation/a-fairly-long-repository-name/nested/deeper"
+	payload := core.NewPayload("bind", "create", longPath)
+
+	if len(payload.FlatCallbackData()) <= telegramCallbackDataLimit {
+		t.Fatalf("test fixture is not actually oversized (%d bytes)", len(payload.FlatCallbackData()))
+	}
+
+	encoded := v.encodeCallbackData(payload)
+	if len(encoded) > telegramCallbackDataLimit {
+		t.Fatalf("encoded to %d bytes, over Telegram's %d limit: %q",
+			len(encoded), telegramCallbackDataLimit, encoded)
+	}
+
+	back, ok := v.decodeCallbackData(encoded)
+	if !ok {
+		t.Fatal("token did not resolve")
+	}
+	if back.Arg(2) != longPath {
+		t.Errorf("path = %q, want %q", back.Arg(2), longPath)
+	}
+}
+
+// TestPayloadWithSeparatorRoundTrips covers what FormatDirPath used to work
+// around by substituting a NUL byte — a substitution that produced bytes no
+// JSON string can hold, so it broke the platforms whose button values are
+// JSON. Segments carry the colon intact instead.
+func TestPayloadWithSeparatorRoundTrips(t *testing.T) {
+	v := newCallbackVault()
+	weird := "/mnt/c:/Users/someone/project"
+	encoded := v.encodeCallbackData(core.NewPayload("bind", "dir", weird))
+
+	back, ok := v.decodeCallbackData(encoded)
+	if !ok {
+		t.Fatal("did not resolve")
+	}
+	if back.Arg(2) != weird {
+		t.Errorf("path = %q, want %q", back.Arg(2), weird)
+	}
+	if strings.Contains(encoded, "\x00") {
+		t.Error("encoding must not emit NUL bytes")
+	}
+}
+
+// TestReservedPrefixIsNotConfusedForAToken guards the one ambiguity the token
+// scheme introduces: an application payload whose first segment starts with
+// the reserved marker must not be handed back as a token lookup.
+func TestReservedPrefixIsNotConfusedForAToken(t *testing.T) {
+	v := newCallbackVault()
+	payload := core.NewPayload(tokenPrefix+"mention", "reply")
+
+	encoded := v.encodeCallbackData(payload)
+	back, ok := v.decodeCallbackData(encoded)
+	if !ok {
+		t.Fatal("did not resolve")
+	}
+	if back.Name() != tokenPrefix+"mention" || back.Arg(1) != "reply" {
+		t.Errorf("round trip lost the payload: %v", back)
+	}
+}
+
+// TestUnresolvableTokenIsReportedNotSilent: an evicted or post-restart token
+// must be distinguishable from valid data, so the bot can say the button is
+// dead rather than absorb the tap.
+func TestUnresolvableTokenIsReportedNotSilent(t *testing.T) {
+	v := newCallbackVault()
+	if _, ok := v.decodeCallbackData(tokenPrefix + "zzzz"); ok {
+		t.Error("an unknown token must not resolve")
+	}
+	// Plain data from before this encoding existed still decodes.
+	if _, ok := v.decodeCallbackData("perm:deny:req-1"); !ok {
+		t.Error("legacy flat callback data must still decode")
+	}
+}
+
+func TestVaultEvictsOldestBeyondCapacity(t *testing.T) {
+	v := newCallbackVault()
+	v.capacity = 3
+
+	tokens := make([]string, 0, 4)
+	for _, name := range []string{"a", "b", "c", "d"} {
+		tokens = append(tokens, v.park(core.NewPayload(name)))
+	}
+
+	if _, ok := v.resolve(tokens[0]); ok {
+		t.Error("the oldest entry should have been evicted")
+	}
+	for _, tok := range tokens[1:] {
+		if _, ok := v.resolve(tok); !ok {
+			t.Errorf("token %q should still resolve", tok)
+		}
+	}
+}
+
+// TestBuildInlineKeyboardEncodesPayload checks the renderer goes through the
+// codec rather than reading a pre-joined string off the action.
+func TestBuildInlineKeyboardEncodesPayload(t *testing.T) {
+	b := testBot()
+	kb := b.BuildInlineKeyboard(core.NewActionSet().AddRow(
+		core.Action{Label: "Up", Payload: core.NewPayload("bind", "up")},
+	))
+	if got := kb.InlineKeyboard[0][0].CallbackData; got != "bind:up" {
+		t.Errorf("callback data = %q, want bind:up", got)
+	}
+}

--- a/imbot/platform/telegram/telegram.go
+++ b/imbot/platform/telegram/telegram.go
@@ -29,6 +29,9 @@ type Bot struct {
 	wg           sync.WaitGroup
 	mu           sync.RWMutex
 	messageIDMap map[string]int // chatID -> last message ID
+	// callbacks encodes outbound action payloads into callback_data and
+	// resolves them again on the way back. See callback_codec.go.
+	callbacks *callbackVault
 }
 
 type MenuButtonType string
@@ -109,6 +112,7 @@ func NewTelegramBot(config *core.Config) (*Bot, error) {
 		BaseBot:      core.NewBaseBot(config),
 		api:          api,
 		messageIDMap: make(map[string]int),
+		callbacks:    newCallbackVault(),
 	}
 
 	return bot, nil
@@ -176,17 +180,42 @@ func (b *Bot) handleCallbackQueryUpdate(ctx context.Context, api *tgbot.Bot, upd
 	query := update.CallbackQuery
 	b.Logger().Debug("Received callback query from %d: %s", query.From.ID, query.Data)
 
+	// Resolve the wire encoding back into payload segments before anyone
+	// downstream sees it. A token that no longer resolves is reported to the
+	// user rather than emitted as a message nothing will match: an inert
+	// button is indistinguishable from a broken bot.
+	payload, ok := b.callbacks.decodeCallbackData(query.Data)
+	if !ok {
+		b.Logger().Debug("Callback token %s no longer resolves", query.Data)
+		b.answerCallbackQuery(query.ID, expiredButtonNotice)
+		return
+	}
+
 	coreMessage, err := b.adapter.AdaptCallback(b.ctx, query)
 	if err != nil {
 		b.Logger().Error("Failed to adapt callback: %v", err)
 		return
 	}
+	coreMessage.Payload = payload
+	// Consumers still reading the flat form get the resolved payload, not the
+	// token that stood in for it on the wire.
+	if coreMessage.Metadata != nil {
+		coreMessage.Metadata["callback_data"] = payload.FlatCallbackData()
+	}
 
 	b.EmitMessage(*coreMessage)
 
 	// Answer the callback query to remove loading state
+	b.answerCallbackQuery(query.ID, "")
+}
+
+// answerCallbackQuery clears the button's loading spinner, optionally showing
+// the user a notice. Telegram requires this within roughly 15 seconds or the
+// button spins on the client.
+func (b *Bot) answerCallbackQuery(queryID, text string) {
 	_, _ = b.api.AnswerCallbackQuery(b.ctx, &tgbot.AnswerCallbackQueryParams{
-		CallbackQueryID: query.ID,
+		CallbackQueryID: queryID,
+		Text:            text,
 	})
 }
 

--- a/imbot/platform/tingly/adapter.go
+++ b/imbot/platform/tingly/adapter.go
@@ -50,8 +50,11 @@ func convertActionSet(set *core.ActionSet) *Keyboard {
 		buttons := make([]Button, 0, len(row))
 		for _, a := range row {
 			buttons = append(buttons, Button{
-				Label:        a.Label,
-				CallbackData: a.CallbackData,
+				Label: a.Label,
+				// The harness mirrors Telegram's flat encoding so tests read
+				// the same strings production does. Unlike Telegram it has no
+				// size limit, so no token fallback is needed here.
+				CallbackData: a.EffectivePayload().FlatCallbackData(),
 				URL:          a.URL,
 			})
 		}
@@ -94,6 +97,7 @@ func NewIncomingCallback(messageID, chatID string, sender core.Sender, callbackD
 		},
 		Content:  core.NewTextContent(""),
 		ChatType: chatType,
+		Payload:  core.PayloadFromCallbackData(callbackData),
 		Metadata: map[string]interface{}{
 			"is_callback":       true,
 			"callback_data":     callbackData,

--- a/internal/remote_control/bot/bot_command.go
+++ b/internal/remote_control/bot/bot_command.go
@@ -194,13 +194,13 @@ func buildProjectKeyboard(currentPath string, projectPaths []string) imbot.Inlin
 			marker = " ✓"
 		}
 		rows = append(rows, []imbot.InlineKeyboardButton{{
-			Text:         fmt.Sprintf("%d. 📁 %s%s", i+1, filepath.Base(path), marker),
-			CallbackData: imbot.FormatCallbackData("project", "switch", path),
+			Text:    fmt.Sprintf("%d. 📁 %s%s", i+1, filepath.Base(path), marker),
+			Payload: imbot.NewPayload("project", "switch", path),
 		}})
 	}
 	rows = append(rows, []imbot.InlineKeyboardButton{{
-		Text:         "📁 Bind New Project",
-		CallbackData: imbot.FormatCallbackData("action", "bind"),
+		Text:    "📁 Bind New Project",
+		Payload: imbot.NewPayload("action", "bind"),
 	}})
 	return imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
 }

--- a/internal/remote_control/bot/command.go
+++ b/internal/remote_control/bot/command.go
@@ -805,8 +805,8 @@ func buildResumeKeyboard(sessions []ResumableSession) imbot.InlineKeyboardMarkup
 	for i, s := range sessions {
 		label := fmt.Sprintf("#%d · %s · %s", i+1, formatRelativeTime(latestTime(s)), formatTurns(s.NumTurns))
 		current = append(current, imbot.InlineKeyboardButton{
-			Text:         label,
-			CallbackData: imbot.FormatCallbackData("resume", "pick", s.SessionID),
+			Text:    label,
+			Payload: imbot.NewPayload("resume", "pick", s.SessionID),
 		})
 		if len(current) == cols {
 			rows = append(rows, current)
@@ -817,8 +817,8 @@ func buildResumeKeyboard(sessions []ResumableSession) imbot.InlineKeyboardMarkup
 		rows = append(rows, current)
 	}
 	rows = append(rows, []imbot.InlineKeyboardButton{{
-		Text:         "Cancel",
-		CallbackData: imbot.FormatCallbackData("resume", "cancel"),
+		Text:    "Cancel",
+		Payload: imbot.NewPayload("resume", "cancel"),
 	}})
 	return imbot.InlineKeyboardMarkup{InlineKeyboard: rows}
 }

--- a/internal/remote_control/bot/feature/action_menu.go
+++ b/internal/remote_control/bot/feature/action_menu.go
@@ -15,42 +15,46 @@ import (
 	"github.com/tingly-dev/tingly-box/imbot"
 )
 
-// BindFlowState represents the state of an ongoing bind flow
+// BindFlowState represents the state of an ongoing bind flow.
+//
+// It used to also cache the directory listing, because a button could not
+// carry a path: Telegram's 64-byte callback_data forced the browser to send
+// array indices and resolve them here. Payload segments carry the path itself
+// now, so the snapshot — and the class of bug where a stale index resolved
+// against a re-listed directory — is gone.
 type BindFlowState struct {
 	ChatID       string
 	CurrentPath  string
 	Page         int
-	TotalDirs    int
 	PageSize     int
 	MessageID    string // Message ID to edit
 	ExpiresAt    time.Time
-	WaitingInput bool     // Waiting for custom path input
-	PromptMsgID  string   // Prompt message ID for cleanup
-	Dirs         []string // Current directory list (for navigation by index)
+	WaitingInput bool   // Waiting for custom path input
+	PromptMsgID  string // Prompt message ID for cleanup
 }
 
 // BuildActionKeyboard builds the inline keyboard for actions (Clear/Bind)
 func BuildActionKeyboard() *imbot.KeyboardBuilder {
 	return imbot.NewKeyboardBuilder().
 		AddRow(
-			imbot.CallbackButton("🗑 Clear", imbot.FormatCallbackData("action", "clear")),
-			imbot.CallbackButton("📁 CD", imbot.FormatCallbackData("action", "bind")),
-			imbot.CallbackButton("🔧 Project", imbot.FormatCallbackData("action", "project")),
+			imbot.ActionButton("🗑 Clear", "action", "clear"),
+			imbot.ActionButton("📁 CD", "action", "bind"),
+			imbot.ActionButton("🔧 Project", "action", "project"),
 		)
 }
 
 // BuildCancelKeyboard builds a simple cancel keyboard
 func BuildCancelKeyboard() *imbot.KeyboardBuilder {
 	return imbot.NewKeyboardBuilder().
-		AddRow(imbot.CallbackButton("❌ Cancel", imbot.FormatCallbackData("bind", "cancel")))
+		AddRow(imbot.ActionButton("❌ Cancel", "bind", "cancel"))
 }
 
 // BuildCreateConfirmKeyboard builds the confirmation keyboard for creating a directory
 func BuildCreateConfirmKeyboard(path string) (*imbot.KeyboardBuilder, string) {
 	kb := imbot.NewKeyboardBuilder().
 		AddRow(
-			imbot.CallbackButton("✅ Create", imbot.FormatCallbackData("bind", "create", imbot.FormatDirPath(path))),
-			imbot.CallbackButton("❌ Cancel", imbot.FormatCallbackData("bind", "cancel")),
+			imbot.ActionButton("✅ Create", "bind", "create", path),
+			imbot.ActionButton("❌ Cancel", "bind", "cancel"),
 		)
 
 	text := fmt.Sprintf("📁 *The path doesn't exist. Create it?*\n\n`%s`", path)
@@ -61,10 +65,10 @@ func BuildCreateConfirmKeyboard(path string) (*imbot.KeyboardBuilder, string) {
 func BuildBindConfirmKeyboard() *imbot.KeyboardBuilder {
 	return imbot.NewKeyboardBuilder().
 		AddRow(
-			imbot.CallbackButton("✓ Confirm", imbot.FormatCallbackData("bind", "confirm")),
-			imbot.CallbackButton("✏️ Change", imbot.FormatCallbackData("bind", "custom")),
+			imbot.ActionButton("✓ Confirm", "bind", "confirm"),
+			imbot.ActionButton("✏️ Change", "bind", "custom"),
 		).
 		AddRow(
-			imbot.CallbackButton("❌ Cancel", imbot.FormatCallbackData("bind", "cancel")),
+			imbot.ActionButton("❌ Cancel", "bind", "cancel"),
 		)
 }

--- a/internal/remote_control/bot/feature/dir_browser_test.go
+++ b/internal/remote_control/bot/feature/dir_browser_test.go
@@ -1,0 +1,112 @@
+package feature
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/imbot"
+)
+
+// TestDirectoryButtonsCarryPaths pins the change that let the snapshot go:
+// each directory button names the path it navigates to, rather than an index
+// into a listing the server had to remember.
+func TestDirectoryButtonsCarryPaths(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"alpha", "beta"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	b := NewDirectoryBrowser()
+	if _, err := b.StartAt("chat-1", root); err != nil {
+		t.Fatal(err)
+	}
+
+	_, kb, _, err := b.BuildKeyboard("chat-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dirPayloads []imbot.Payload
+	for _, row := range kb.Build().InlineKeyboard {
+		for _, btn := range row {
+			if btn.Payload.Name() == "bind" && btn.Payload.Arg(1) == "dir" {
+				dirPayloads = append(dirPayloads, btn.Payload)
+			}
+		}
+	}
+
+	if len(dirPayloads) != 2 {
+		t.Fatalf("expected 2 directory buttons, got %d", len(dirPayloads))
+	}
+	for _, p := range dirPayloads {
+		target := p.Arg(2)
+		if !filepath.IsAbs(target) {
+			t.Errorf("button carries %q, want an absolute path", target)
+		}
+		if info, err := os.Stat(target); err != nil || !info.IsDir() {
+			t.Errorf("button target %q is not a directory", target)
+		}
+	}
+}
+
+// TestNavigateAcceptsPathWithSeparator is what the NUL escape existed to fake.
+// A directory whose name contains ":" is legal on Linux, and it now travels
+// through a button unchanged.
+func TestNavigateAcceptsPathWithSeparator(t *testing.T) {
+	root := t.TempDir()
+	odd := filepath.Join(root, "release:2026")
+	if err := os.Mkdir(odd, 0o755); err != nil {
+		t.Skipf("filesystem rejects ':' in names: %v", err)
+	}
+
+	b := NewDirectoryBrowser()
+	if _, err := b.StartAt("chat-1", root); err != nil {
+		t.Fatal(err)
+	}
+	_, kb, _, err := b.BuildKeyboard("chat-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var target string
+	for _, row := range kb.Build().InlineKeyboard {
+		for _, btn := range row {
+			if btn.Payload.Name() == "bind" && btn.Payload.Arg(1) == "dir" {
+				target = btn.Payload.Arg(2)
+			}
+		}
+	}
+	if !strings.Contains(target, ":") {
+		t.Fatalf("expected the colon to survive into the button, got %q", target)
+	}
+	if err := b.Navigate("chat-1", target); err != nil {
+		t.Fatalf("navigating to %q failed: %v", target, err)
+	}
+	if got := b.GetCurrentPath("chat-1"); got != odd {
+		t.Errorf("current path = %q, want %q", got, odd)
+	}
+}
+
+// TestBuildCreateConfirmCarriesRawPath guards the flow that used to break
+// outright: a long path made the confirmation button exceed Telegram's
+// callback_data limit, which rejected the entire message.
+func TestBuildCreateConfirmCarriesRawPath(t *testing.T) {
+	path := "/home/somebody/projects/an-organisation/a-fairly-long-repository-name"
+	kb, _ := BuildCreateConfirmKeyboard(path)
+
+	for _, row := range kb.Build().InlineKeyboard {
+		for _, btn := range row {
+			if btn.Payload.Arg(1) == "create" {
+				if got := btn.Payload.Arg(2); got != path {
+					t.Errorf("payload path = %q, want %q", got, path)
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("no create button was rendered")
+}

--- a/internal/remote_control/bot/feature/telegram_dir_browser.go
+++ b/internal/remote_control/bot/feature/telegram_dir_browser.go
@@ -127,23 +127,6 @@ func (b *DirectoryBrowser) Navigate(chatID string, path string) error {
 	return nil
 }
 
-// NavigateByIndex navigates to a subdirectory by index (stored in state.Dirs)
-func (b *DirectoryBrowser) NavigateByIndex(chatID string, index int) error {
-	b.mu.RLock()
-	state, ok := b.states[chatID]
-	b.mu.RUnlock()
-
-	if !ok {
-		return fmt.Errorf("no active bind flow")
-	}
-
-	if index < 0 || index >= len(state.Dirs) {
-		return fmt.Errorf("invalid directory index: %d", index)
-	}
-
-	return b.Navigate(chatID, state.Dirs[index])
-}
-
 // NavigateUp navigates to the parent directory
 func (b *DirectoryBrowser) NavigateUp(chatID string) error {
 	b.mu.RLock()
@@ -253,10 +236,6 @@ func (b *DirectoryBrowser) BuildKeyboard(chatID string) (*BindFlowState, *imbot.
 		return nil, nil, "", err
 	}
 
-	// Store dirs for navigation by index
-	state.Dirs = dirs
-	state.TotalDirs = len(dirs)
-
 	// Calculate pagination
 	totalPages := (len(dirs) + state.PageSize - 1) / state.PageSize
 	if totalPages == 0 {
@@ -272,12 +251,14 @@ func (b *DirectoryBrowser) BuildKeyboard(chatID string) (*BindFlowState, *imbot.
 	// Build keyboard
 	kb := imbot.NewKeyboardBuilder()
 
-	// Directory buttons (use index instead of path to avoid 64-byte limit)
+	// Directory buttons carry the path they navigate to. They used to carry
+	// the index of the path in a server-side snapshot, purely because a path
+	// does not fit in Telegram's callback_data — which meant a listing that
+	// changed under the user navigated somewhere they did not pick.
 	for i := startIdx; i < endIdx; i++ {
 		dirName := filepath.Base(dirs[i])
 		buttonText := imbot.FormatDirButton(dirName, 20)
-		callbackData := imbot.FormatCallbackData("bind", "dir", fmt.Sprintf("%d", i))
-		kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
+		kb.AddRow(imbot.ActionButton(buttonText, "bind", "dir", dirs[i]))
 	}
 
 	// Navigation row
@@ -285,15 +266,15 @@ func (b *DirectoryBrowser) BuildKeyboard(chatID string) (*BindFlowState, *imbot.
 
 	// Parent directory button
 	if hasParent(state.CurrentPath) {
-		navButtons = append(navButtons, imbot.CallbackButton("📁 ..", imbot.FormatCallbackData("bind", "up")))
+		navButtons = append(navButtons, imbot.ActionButton("📁 ..", "bind", "up"))
 	}
 
 	// Pagination buttons
 	if state.Page > 0 {
-		navButtons = append(navButtons, imbot.CallbackButton("◀ Prev", imbot.FormatCallbackData("bind", "prev")))
+		navButtons = append(navButtons, imbot.ActionButton("◀ Prev", "bind", "prev"))
 	}
 	if state.Page < totalPages-1 && len(dirs) > endIdx {
-		navButtons = append(navButtons, imbot.CallbackButton("Next ▶", imbot.FormatCallbackData("bind", "next")))
+		navButtons = append(navButtons, imbot.ActionButton("Next ▶", "bind", "next"))
 	}
 
 	if len(navButtons) > 0 {
@@ -302,12 +283,12 @@ func (b *DirectoryBrowser) BuildKeyboard(chatID string) (*BindFlowState, *imbot.
 
 	// Select current directory button and custom path button
 	kb.AddRow(
-		imbot.CallbackButton("✓ Select This", imbot.FormatCallbackData("bind", "select")),
-		imbot.CallbackButton("✏️ Custom", imbot.FormatCallbackData("bind", "custom")),
+		imbot.ActionButton("✓ Select This", "bind", "select"),
+		imbot.ActionButton("✏️ Custom", "bind", "custom"),
 	)
 
 	// Cancel button
-	kb.AddRow(imbot.CallbackButton("❌ Cancel", imbot.FormatCallbackData("bind", "cancel")))
+	kb.AddRow(imbot.ActionButton("❌ Cancel", "bind", "cancel"))
 
 	// Build message text
 	shortPath := state.CurrentPath

--- a/internal/remote_control/bot/handler_message.go
+++ b/internal/remote_control/bot/handler_message.go
@@ -34,7 +34,8 @@ func (h *BotHandler) HandleMessage(msg imbot.Message, platform imbot.Platform, b
 		return
 	}
 
-	// OLD: Check if this is a legacy callback query (for backward compatibility)
+	// An action firing (a button press) dispatches on its payload, not on
+	// message text.
 	if msg.IsCallback() {
 		h.handleCallbackQuery(bot, chatID, msg)
 		return

--- a/internal/remote_control/bot/handler_message.go
+++ b/internal/remote_control/bot/handler_message.go
@@ -35,7 +35,7 @@ func (h *BotHandler) HandleMessage(msg imbot.Message, platform imbot.Platform, b
 	}
 
 	// OLD: Check if this is a legacy callback query (for backward compatibility)
-	if isCallback, _ := msg.Metadata["is_callback"].(bool); isCallback {
+	if msg.IsCallback() {
 		h.handleCallbackQuery(bot, chatID, msg)
 		return
 	}

--- a/internal/remote_control/bot/prompt_reply.go
+++ b/internal/remote_control/bot/prompt_reply.go
@@ -36,13 +36,11 @@ func promptReplyRouter(mgr *imbot.Manager, prompter *imchannel.IMPrompter) OnMes
 			_, _ = bot.SendMessage(context.Background(), chatID, opts)
 		}
 
-		if isCallback, _ := msg.Metadata["is_callback"].(bool); isCallback {
-			callbackData, _ := msg.Metadata["callback_data"].(string)
-			parts := imbot.ParseCallbackData(callbackData)
-			if len(parts) == 0 || parts[0] != "perm" {
+		if msg.IsCallback() {
+			if msg.Payload.Name() != "perm" {
 				return false
 			}
-			return handlePromptCallback(prompter, send, msg.Sender.ID, parts, true)
+			return handlePromptCallback(prompter, send, msg.Sender.ID, msg.Payload, true)
 		}
 
 		if !msg.IsTextContent() {
@@ -65,22 +63,21 @@ func promptReplyRouter(mgr *imbot.Manager, prompter *imchannel.IMPrompter) OnMes
 // remote-agent BotHandler keeps its own delegating paths for the standalone
 // (host-less) mode used by the CLI and the test harness.
 
-// handlePromptCallback routes one parsed "perm" callback (parts[0] == "perm")
-// to the prompter's pending request. send delivers user-facing feedback to the
-// originating chat.
+// handlePromptCallback routes one "perm" callback payload (segment 0 ==
+// "perm") to the prompter's pending request. send delivers user-facing
+// feedback to the originating chat.
 //
 // claimUnknown controls who answers for an expired/foreign request ID: the
 // terminal consumer (remote agent) passes true and tells the user the request
 // expired; a first-in-line consumer (channel) passes false so the callback
 // falls through to the next consumer, which may own the request.
-func handlePromptCallback(prompter *imchannel.IMPrompter, send func(string), senderID string, parts []string, claimUnknown bool) bool {
-	if len(parts) < 3 {
-		logrus.WithField("parts", parts).Warn("Invalid permission callback data")
+func handlePromptCallback(prompter *imchannel.IMPrompter, send func(string), senderID string, payload imbot.Payload, claimUnknown bool) bool {
+	subAction := payload.Arg(1)
+	requestID := payload.Arg(2)
+	if subAction == "" || requestID == "" {
+		logrus.WithField("payload", payload).Warn("Invalid permission callback data")
 		return claimUnknown
 	}
-
-	subAction := parts[1]
-	requestID := parts[2]
 
 	// Check if the request exists
 	pendingReq, exists := prompter.GetPendingRequest(requestID)
@@ -102,13 +99,13 @@ func handlePromptCallback(prompter *imchannel.IMPrompter, send func(string), sen
 
 	case "option":
 		// Handle multi-option selection (e.g., AskUserQuestion)
-		// Callback data format: perm:option:reqID:qIdx:optIdx
-		if len(parts) < 5 {
-			logrus.WithField("parts", parts).Warn("Invalid option callback data")
+		// Payload segments: perm, option, reqID, qIdx, optIdx
+		qIdxStr := payload.Arg(3)
+		optIdxStr := payload.Arg(4)
+		if qIdxStr == "" || optIdxStr == "" {
+			logrus.WithField("payload", payload).Warn("Invalid option callback data")
 			return true
 		}
-		qIdxStr := parts[3]
-		optIdxStr := parts[4]
 
 		// Resolve question text and option label from the pending request
 		var questionText, optionLabel string
@@ -129,7 +126,7 @@ func handlePromptCallback(prompter *imchannel.IMPrompter, send func(string), sen
 			}
 		}
 		if questionText == "" || optionLabel == "" {
-			logrus.WithField("parts", parts).Warn("Could not resolve question or option from callback data")
+			logrus.WithField("payload", payload).Warn("Could not resolve question or option from callback data")
 			send("⚠️ Failed to process selection.")
 			return true
 		}

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -12,13 +12,12 @@ import (
 
 // handleCallbackQuery handles callback queries from inline keyboards
 func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot.Message) {
-	callbackData, _ := msg.Metadata["callback_data"].(string)
-	if callbackData == "" {
-		return
-	}
-
-	parts := imbot.ParseCallbackData(callbackData)
-	if len(parts) == 0 {
+	// The payload arrives as segments, already decoded by the platform. What
+	// those segments looked like on the wire — a colon-joined string, a token
+	// standing in for an oversized one, a JSON array in a card button value —
+	// is the platform's business, not this dispatcher's.
+	payload := msg.Payload
+	if payload.IsEmpty() {
 		return
 	}
 
@@ -31,18 +30,16 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 		Platform:  msg.Platform,
 	}
 
-	action := parts[0]
-
-	switch action {
+	switch payload.Name() {
 	case "perm":
 		// Handle permission request response
-		h.handlePermissionCallback(hCtx, parts)
+		h.handlePermissionCallback(hCtx, payload)
 
 	case "action":
-		if len(parts) < 2 {
+		subAction := payload.Arg(1)
+		if subAction == "" {
 			return
 		}
-		subAction := parts[1]
 		switch subAction {
 		case "clear":
 			// Remove the action keyboard before handling
@@ -66,27 +63,24 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 		// Remove the action keyboard before handling
 		h.removeActionKeyboard(bot, chatID)
 		// Start interactive bind
-		if len(parts) < 3 {
-			return
-		}
-		subAction := parts[1]
-		switch subAction {
-		case "switch":
-			projectID := parts[2]
-			h.handleProjectSwitch(hCtx, projectID)
+		if payload.Arg(1) == "switch" {
+			if projectID := payload.Arg(2); projectID != "" {
+				h.handleProjectSwitch(hCtx, projectID)
+			}
 		}
 
 	case "resume":
-		if len(parts) < 2 {
+		subAction := payload.Arg(1)
+		if subAction == "" {
 			return
 		}
-		subAction := parts[1]
 		switch subAction {
 		case "pick":
-			if len(parts) < 3 {
+			sessionID := payload.Arg(2)
+			if sessionID == "" {
 				return
 			}
-			h.handleResumePick(hCtx, parts[2], msg)
+			h.handleResumePick(hCtx, sessionID, msg)
 		case "cancel":
 			h.handleResumeCancel(hCtx, msg)
 		}
@@ -95,27 +89,22 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 		// Remove the action keyboard before handling
 		h.removeActionKeyboard(bot, chatID)
 		// Start interactive bind
-		if len(parts) < 2 {
+		subAction := payload.Arg(1)
+		if subAction == "" {
 			return
 		}
-		subAction := parts[1]
 		switch subAction {
 		case "confirm":
 			// Confirm bind to current directory
 			h.handleBindConfirm(hCtx)
 
 		case "dir":
-			// Navigate to directory by index
-			if len(parts) < 3 {
+			// Navigate to the directory the button names.
+			target := payload.Arg(2)
+			if target == "" {
 				return
 			}
-			indexStr := parts[2]
-			var index int
-			if _, err := fmt.Sscanf(indexStr, "%d", &index); err != nil {
-				logrus.WithError(err).Warn("Failed to parse directory index")
-				return
-			}
-			if err := h.directoryBrowser.NavigateByIndex(chatID, index); err != nil {
+			if err := h.directoryBrowser.Navigate(chatID, target); err != nil {
 				logrus.WithError(err).Warn("Failed to navigate directory")
 				return
 			}
@@ -184,18 +173,22 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 			h.handleCustomPathPrompt(hCtx)
 
 		case "create":
-			// Create directory and bind (path from custom input, encoded)
-			if len(parts) < 3 {
+			// Create the directory the confirmation button carries and bind it.
+			path := payload.Arg(2)
+			if path == "" {
 				return
 			}
-			encodedPath := parts[2]
-			path := imbot.ParseDirPath(encodedPath)
-			// Create the directory
 			if err := os.MkdirAll(path, 0755); err != nil {
 				logrus.WithError(err).Error("Failed to create directory")
 				h.SendText(hCtx, fmt.Sprintf("Failed to create directory: %v", err))
 				return
 			}
+			// Creating the directory was only half of what the button offered.
+			// Without this the flow ended in silence: the directory appeared
+			// on disk and the chat said nothing, so the user had no way to
+			// tell whether the bind had happened.
+			h.completeBind(hCtx, path)
+			h.directoryBrowser.Clear(chatID)
 
 		case "cancel":
 			h.directoryBrowser.Clear(chatID)
@@ -252,8 +245,8 @@ func (h *BotHandler) handleCustomPathPrompt(hCtx HandlerContext) {
 // Only reachable in standalone (host-less) mode: the managed path's host
 // router claims "perm" callbacks first. Mechanics shared via prompt_reply.go;
 // as the terminal handler it claims unknown request IDs and reports expired.
-func (h *BotHandler) handlePermissionCallback(hCtx HandlerContext, parts []string) {
-	handlePromptCallback(h.imPrompter, func(text string) { h.SendText(hCtx, text) }, hCtx.SenderID, parts, true)
+func (h *BotHandler) handlePermissionCallback(hCtx HandlerContext, payload imbot.Payload) {
+	handlePromptCallback(h.imPrompter, func(text string) { h.SendText(hCtx, text) }, hCtx.SenderID, payload, true)
 }
 
 // handleCreateConfirm sends a confirmation prompt for creating a directory

--- a/internal/remote_control/bot/telegram_callback.go
+++ b/internal/remote_control/bot/telegram_callback.go
@@ -42,27 +42,20 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 		}
 		switch subAction {
 		case "clear":
-			// Remove the action keyboard before handling
+			// The menu is consumed by the tap; take it down before acting so a
+			// second tap cannot race the first.
 			h.removeActionKeyboard(bot, chatID)
 			h.handleClearCommand(hCtx)
 		case "bind":
-			// Remove the action keyboard before handling
 			h.removeActionKeyboard(bot, chatID)
-			// Start interactive bind
-			// Start interactive bind
 			h.handleBindInteractive(hCtx)
 		case "project":
-			// Remove the action keyboard before handling
 			h.removeActionKeyboard(bot, chatID)
-			// Start interactive bind
-			// Start interactive bind
 			h.handleBotProjectCommand(hCtx)
 		}
 
 	case "project":
-		// Remove the action keyboard before handling
 		h.removeActionKeyboard(bot, chatID)
-		// Start interactive bind
 		if payload.Arg(1) == "switch" {
 			if projectID := payload.Arg(2); projectID != "" {
 				h.handleProjectSwitch(hCtx, projectID)
@@ -98,56 +91,15 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 			// Confirm bind to current directory
 			h.handleBindConfirm(hCtx)
 
-		case "dir":
-			// Navigate to the directory the button names.
-			target := payload.Arg(2)
-			if target == "" {
+		case "dir", "up", "prev", "next":
+			// Every browser move is "mutate the flow state, then redraw in
+			// place". Keeping that one shape here means a new move cannot
+			// forget the redraw.
+			if err := h.moveDirectoryBrowser(chatID, subAction, payload.Arg(2)); err != nil {
+				logrus.WithError(err).WithField("move", subAction).Warn("Directory browser move failed")
 				return
 			}
-			if err := h.directoryBrowser.Navigate(chatID, target); err != nil {
-				logrus.WithError(err).Warn("Failed to navigate directory")
-				return
-			}
-			// Get message ID from metadata for editing
-			msgID, _ := msg.Metadata["message_id"].(string)
-			if msgID == "" {
-				msgID = msg.ID
-			}
-			_, _ = feature.SendDirectoryBrowser(h.ctx, bot, h.directoryBrowser, chatID, msgID)
-
-		case "up":
-			// Navigate to parent directory
-			if err := h.directoryBrowser.NavigateUp(chatID); err != nil {
-				logrus.WithError(err).Warn("Failed to navigate up")
-				return
-			}
-			msgID, _ := msg.Metadata["message_id"].(string)
-			if msgID == "" {
-				msgID = msg.ID
-			}
-			_, _ = feature.SendDirectoryBrowser(h.ctx, bot, h.directoryBrowser, chatID, msgID)
-
-		case "prev":
-			if err := h.directoryBrowser.PrevPage(chatID); err != nil {
-				logrus.WithError(err).Warn("Failed to go to previous page")
-				return
-			}
-			msgID, _ := msg.Metadata["message_id"].(string)
-			if msgID == "" {
-				msgID = msg.ID
-			}
-			_, _ = feature.SendDirectoryBrowser(h.ctx, bot, h.directoryBrowser, chatID, msgID)
-
-		case "next":
-			if err := h.directoryBrowser.NextPage(chatID); err != nil {
-				logrus.WithError(err).Warn("Failed to go to next page")
-				return
-			}
-			msgID, _ := msg.Metadata["message_id"].(string)
-			if msgID == "" {
-				msgID = msg.ID
-			}
-			_, _ = feature.SendDirectoryBrowser(h.ctx, bot, h.directoryBrowser, chatID, msgID)
+			_, _ = feature.SendDirectoryBrowser(h.ctx, bot, h.directoryBrowser, chatID, browserMessageID(msg))
 
 		case "select":
 			// Select current directory (path is in state)
@@ -189,18 +141,46 @@ func (h *BotHandler) handleCallbackQuery(bot imbot.Bot, chatID string, msg imbot
 			// tell whether the bind had happened.
 			h.completeBind(hCtx, path)
 			h.directoryBrowser.Clear(chatID)
+			// Take the confirmation down, as the select path does, so the
+			// button cannot be tapped a second time against cleared state.
+			editDirectoryBrowserMessage(h.ctx, bot, chatID, browserMessageID(msg),
+				fmt.Sprintf("✅ Created and bound: `%s`", path))
 
 		case "cancel":
 			h.directoryBrowser.Clear(chatID)
-			// Get message ID from metadata for editing
-			msgID, _ := msg.Metadata["message_id"].(string)
-			if msgID == "" {
-				msgID = msg.ID
-			}
-			// Edit message to show cancel and remove keyboard
-			editDirectoryBrowserMessage(h.ctx, bot, chatID, msgID, "❌ Bind cancelled.")
+			editDirectoryBrowserMessage(h.ctx, bot, chatID, browserMessageID(msg), "❌ Bind cancelled.")
 			h.SendText(hCtx, "Bind cancelled.")
 		}
+	}
+}
+
+// browserMessageID returns the message the browser keyboard is attached to,
+// falling back to the callback's own message when the platform did not supply
+// one separately.
+func browserMessageID(msg imbot.Message) string {
+	if id, _ := msg.Metadata["message_id"].(string); id != "" {
+		return id
+	}
+	return msg.ID
+}
+
+// moveDirectoryBrowser applies one navigation step to the bind flow. target is
+// only read by the "dir" move.
+func (h *BotHandler) moveDirectoryBrowser(chatID, move, target string) error {
+	switch move {
+	case "dir":
+		if target == "" {
+			return fmt.Errorf("no directory given")
+		}
+		return h.directoryBrowser.Navigate(chatID, target)
+	case "up":
+		return h.directoryBrowser.NavigateUp(chatID)
+	case "prev":
+		return h.directoryBrowser.PrevPage(chatID)
+	case "next":
+		return h.directoryBrowser.NextPage(chatID)
+	default:
+		return fmt.Errorf("unknown move %q", move)
 	}
 }
 

--- a/remote/channel/imchannel/imprompter.go
+++ b/remote/channel/imchannel/imprompter.go
@@ -431,8 +431,7 @@ func (p *IMPrompter) buildDefaultKeyboard(requestID string) imbot.InlineKeyboard
 
 	for _, opt := range ask.PermissionOptions {
 		buttonText := opt.Icon + " " + opt.Label
-		callbackData := imbot.FormatCallbackData("perm", opt.Action, requestID)
-		kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
+		kb.AddRow(imbot.ActionButton(buttonText, "perm", opt.Action, requestID))
 	}
 
 	return kb.Build()
@@ -457,20 +456,19 @@ func (p *IMPrompter) buildAskUserQuestionKeyboard(req ask.Request) imbot.InlineK
 		// Add a label row for the question if there are multiple questions
 		if len(questions) > 1 {
 			questionText, _ := question["question"].(string)
-			kb.AddRow(imbot.CallbackButton(fmt.Sprintf("Q%d: %s", qIdx+1, questionText), imbot.FormatCallbackData("perm", "noop", req.ID)))
+			kb.AddRow(imbot.ActionButton(fmt.Sprintf("Q%d: %s", qIdx+1, questionText), "perm", "noop", req.ID))
 		}
 		for optIdx, option := range options {
 			label, _ := option["label"].(string)
 			if label != "" {
 				buttonText := fmt.Sprintf("%d. %s", optIdx+1, label)
-				callbackData := imbot.FormatCallbackData("perm", "option", req.ID, fmt.Sprintf("%d", qIdx), fmt.Sprintf("%d", optIdx))
-				kb.AddRow(imbot.CallbackButton(buttonText, callbackData))
+				kb.AddRow(imbot.ActionButton(buttonText, "perm", "option", req.ID, fmt.Sprintf("%d", qIdx), fmt.Sprintf("%d", optIdx)))
 			}
 		}
 	}
 
 	// Add cancel button
-	kb.AddRow(imbot.CallbackButton("❌ Cancel", imbot.FormatCallbackData("perm", "deny", req.ID)))
+	kb.AddRow(imbot.ActionButton("❌ Cancel", "perm", "deny", req.ID))
 
 	return kb.Build()
 }

--- a/remote/channel/imchannel/imprompter_test.go
+++ b/remote/channel/imchannel/imprompter_test.go
@@ -74,14 +74,14 @@ func Test_AskUserQuestionKeyboard_AcceptsHeterogeneousShapes(t *testing.T) {
 
 			kb := p.buildAskUserQuestionKeyboard(req)
 
-			// Walk the rendered buttons and assert two perm:option callbacks
+			// Walk the rendered buttons and assert two perm:option payloads
 			// exist, one per declared option.
 			labels := []string{}
 			callbacks := []string{}
 			for _, row := range kb.InlineKeyboard {
 				for _, b := range row {
 					labels = append(labels, b.Text)
-					callbacks = append(callbacks, b.CallbackData)
+					callbacks = append(callbacks, b.Payload.FlatCallbackData())
 				}
 			}
 


### PR DESCRIPTION
Phase 2b of `.design/imbot-platform-seams.md` — the one step that touches the callback protocol, which is why it was split out from #1435.

## The problem

Buttons were identified by `callback_data`: a colon-joined string capped at 64 bytes. That is Telegram's transport encoding. Treating it as the neutral identity leaked Telegram's budget into every platform and into the application's own data model.

Three consequences, all live on `main`:

- **A payload over 64 bytes made Telegram reject the whole message**, not just the button. `bind:create:<path>` overflows at 52 bytes of path, so binding a deep project produced no reply at all — no error surfaced anywhere that named the cause. Nothing validated the limit.
- **`:` being the separator** meant a path containing `:` had to be escaped, and `FormatDirPath` substituted a NUL byte — invalid inside the JSON that Feishu button values are made of.
- **A path did not fit at all**, so the directory browser sent array indices and kept a server-side `BindFlowState.Dirs` snapshot to resolve them. Every platform paid for Telegram's limit, and a listing that changed under the user navigated somewhere they had not picked.

## The change

`core.Payload` makes identity **ordered segments** and leaves encoding to the platform:

| | encoding |
|---|---|
| Feishu | segments go into the button's JSON value — no budget, no separator to escape |
| Telegram | joined when they fit (**same wire bytes**, so keyboards already sitting in chats keep working); oversized, colon-bearing, or prefix-colliding payloads are parked in a bounded per-bot vault and the button carries a short token |

A token that no longer resolves (bot restart, or evicted past the 4096-entry cap) tells the user the button is dead rather than absorbing the tap. Under the old behaviour "clicked and nothing happened" and "the bot is broken" were the same thing to the user.

Index navigation, `BindFlowState.Dirs`/`TotalDirs`, and `FormatDirPath`/`ParseDirPath` are deleted.

### Deviation from the design record

The doc sketched `Payload map[string]any`; this lands ordered segments instead. Rationale is written into §5: every dispatch site in the repo is positional, so segments map one-to-one and the migration stays mechanical — and this is the one step whose failure mode is a button that silently does nothing. A map buys named fields, but the names would be invented rather than discovered.

`Arg(i)` returns `""` out of range rather than panicking, because a button rendered by an older release carries fewer segments.

## Also fixed — found while wiring the round trip

- **§7.6 Feishu card buttons had no inbound path at all.** The bot subscribed only to `OnP2MessageReceiveV1`, `HandleCardAction` was a stub returning `not implemented`, and the whole app-level dispatch keys off `Metadata["is_callback"]`, which only Telegram and tingly set. Phase 2a made Feishu buttons *visible* but *inert* — worse than absent, since a button that does nothing reads as a broken bot. Registers `OnP2CardActionTrigger` and normalises the callback onto the same dispatch path as every other platform. §7.1 in the design record has been corrected: it claimed the defect was fixed without checking the other end of the loop.
- **§7.7 `getReceiveIdType` compared `targetID[:4]` against three-character prefixes**, so the `oc_` and `ou_` branches were unreachable and every target was addressed as an `open_id`; the mapping was also inverted (`oc_` is a chat, `ou_` a user). Verified against sample IDs before changing. A card callback replies to an `oc_` chat ID, so this blocked the fix above.
- **§7.8 `bind:create` created the directory and then returned** without binding or replying — the directory appeared on disk and the chat said nothing.

## Verification

- `go build ./...` clean
- `go vet -tags e2e ./...` clean (`imbot/tests/` is behind a build tag and does not compile under plain `go test ./...`)
- **99 packages pass, 0 failures**
- scope check run against `origin/main`: no paths outside `imbot/`, `internal/remote_control/`, `remote/channel/`, `.design/`; `frontend/` and `internal/server/` diff empty

New tests cover what the change claims: wire bytes unchanged for short payloads, oversized payloads always ≤64, colon-bearing paths round-trip without NUL, reserved prefix not mistaken for a token, expired tokens distinguishable, FIFO eviction, Feishu button-value round trip in both pre- and post-JSON shapes, `getReceiveIdType` prefix mapping, and directory buttons carrying paths rather than indices.

## Needs real-bot verification

This repo has no Feishu credentials. SDK v3.9.7's WebSocket client drops `MessageTypeCard`, but `card.action.trigger` is delivered as `MessageTypeEvent` and `EventDispatcher.Do` checks the callback-handler table first — the derivation is sound but wants confirmation on a live bot. Worst case the event never arrives and behaviour matches today, so this is not a regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbXSY3DYEhpre9hrVQagkt