### PR TITLE
feat(notify): turn the IM Notify page into a bot control surface

### DIFF
--- a/frontend/src/components/bot/BotChatsButton.tsx
+++ b/frontend/src/components/bot/BotChatsButton.tsx
@@ -1,0 +1,183 @@
+import {Message as MessageIcon, ContentCopy as CopyIcon} from '@/components/icons';
+import type {BotChat} from '@/types/bot';
+import {api} from '@/services/api';
+import {notify} from '@/utils/notify';
+import {
+    Box,
+    CircularProgress,
+    IconButton,
+    List,
+    ListItem,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import Popover from '@mui/material/Popover';
+import {useCallback, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+
+// BotChatsButton surfaces the chat ids a bot can reach, so an operator can
+// copy the channel-native chat_id that POST /api/v1/bots/:bot/{notify,interact}
+// requires in its request body. Without this the value is undiscoverable from
+// the UI (see ux-principles #5 — show the concrete value; #11 — hand over the
+// artifact for the next action). Loads lazily on first open via the
+// /bots/:bot/chats endpoint.
+interface BotChatsButtonProps {
+    botUUID: string;
+    // platform + pairingRequired tailor the empty-chats hint: a bot that
+    // enforces TOFU pairing registers a chat only after the user pairs first,
+    // so the hint points there instead of just "send a message".
+    platform?: string;
+    pairingRequired?: boolean;
+    disabled?: boolean;
+}
+
+const BotChatsButton: React.FC<BotChatsButtonProps> = ({botUUID, platform, pairingRequired, disabled}) => {
+    const {t} = useTranslation();
+    const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+    const [tooltipOpen, setTooltipOpen] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [chats, setChats] = useState<BotChat[]>([]);
+    const [running, setRunning] = useState<boolean | null>(null); // null = not loaded yet
+    const [error, setError] = useState<string | null>(null);
+
+    const handleOpen = useCallback(async (e: React.MouseEvent<HTMLElement>) => {
+        // Close the tooltip the moment the popover opens, otherwise its hover
+        // text lingers over the open popover.
+        setTooltipOpen(false);
+        setAnchor(e.currentTarget);
+        if (running !== null || error) return; // already loaded this session
+        setLoading(true);
+        setError(null);
+        const result = await api.listBotChats(botUUID);
+        setLoading(false);
+        if (result.error) {
+            setError(result.error);
+        } else {
+            setChats(result.chats ?? []);
+            setRunning(result.running ?? true);
+        }
+    }, [botUUID, running, error]);
+
+    const handleClose = useCallback(() => setAnchor(null), []);
+
+    const handleCopy = useCallback(async (chatID: string) => {
+        try {
+            await navigator.clipboard.writeText(chatID);
+            notify.success(t('bots.table.chatIdCopied', {defaultValue: 'Chat ID copied'}));
+        } catch {
+            notify.error(t('bots.table.chatIdCopyFailed', {defaultValue: 'Copy failed — check clipboard permissions'}));
+        }
+    }, [t]);
+
+    const open = Boolean(anchor);
+
+    return (
+        <>
+            <Popover
+                open={open}
+                anchorEl={anchor}
+                onClose={handleClose}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
+                transformOrigin={{vertical: 'top', horizontal: 'left'}}
+                slotProps={{paper: {sx: {minWidth: 280, maxWidth: 380, mt: 0.5}}}}
+            >
+                <Box sx={{p: 1.5}}>
+                    <Typography variant="caption" sx={{color: 'text.secondary', fontWeight: 600}}>
+                        {t('bots.table.chatsTitle', {defaultValue: 'Reachable chats — copy the Chat ID for notify/interact'})}
+                    </Typography>
+                    {loading && (
+                        <Box sx={{display: 'flex', justifyContent: 'center', py: 2}}>
+                            <CircularProgress size={20}/>
+                        </Box>
+                    )}
+                    {!loading && error && (
+                        <Typography variant="body2" sx={{color: 'error.main', py: 1}}>{error}</Typography>
+                    )}
+                    {!loading && !error && chats.length === 0 && (
+                        // Empty state names the mechanism that registers a chat
+                        // (not just "no chats") and points to the next action.
+                        // A bot that isn't running has no reachable chats at
+                        // all, so the message points to starting it rather
+                        // than sending a message into the void.
+                        // ux-principles #11: hand over the next action, not a notice.
+                        <Box sx={{py: 1}}>
+                            <Typography variant="body2" sx={{color: 'text.disabled'}}>
+                                {running === false
+                                    ? t('bots.table.notRunning', {
+                                        defaultValue: 'This bot isn’t running. Start it, then send it a message on {{platform}} — its Chat ID appears here.',
+                                        platform: platform || t('bots.table.itsPlatform', {defaultValue: 'its platform'}),
+                                    })
+                                    : pairingRequired
+                                        ? t('bots.table.noChatsPairFirst', {
+                                            defaultValue: 'No chats yet. Pair this bot (see Pairing), then send it a message on {{platform}} — its Chat ID appears here.',
+                                            platform: platform || t('bots.table.itsPlatform', {defaultValue: 'its platform'}),
+                                        })
+                                        : t('bots.table.noChats', {
+                                            defaultValue: 'No chats yet. Send any message to this bot on {{platform}} and its Chat ID will appear here.',
+                                            platform: platform || t('bots.table.itsPlatform', {defaultValue: 'its platform'}),
+                                        })}
+                            </Typography>
+                        </Box>
+                    )}
+                    {!loading && !error && chats.length > 0 && (
+                        <List dense disablePadding sx={{mt: 0.5}}>
+                            {chats.map((chat) => (
+                                <ListItem key={chat.chat_id} disableGutters sx={{py: 0.25}}>
+                                    <Stack direction="row" spacing={0.5} sx={{alignItems: 'center', width: '100%', minWidth: 0}}>
+                                        <IconButton
+                                            size="small"
+                                            onClick={() => handleCopy(chat.chat_id)}
+                                            sx={{p: 0.25, flexShrink: 0}}
+                                            aria-label={t('bots.table.copyChatId', {defaultValue: 'Copy Chat ID'})}
+                                        >
+                                            <CopyIcon fontSize="inherit"/>
+                                        </IconButton>
+                                        <Typography
+                                            variant="caption"
+                                            component="span"
+                                            sx={{
+                                                fontFamily: 'monospace',
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                                minWidth: 0,
+                                                flex: 1,
+                                            }}
+                                        >
+                                            {chat.chat_id}
+                                        </Typography>
+                                        {chat.is_paired && (
+                                            <Typography variant="caption" sx={{color: 'success.main', flexShrink: 0}}>
+                                                {t('bots.table.paired', {defaultValue: 'paired'})}
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                </ListItem>
+                            ))}
+                        </List>
+                    )}
+                </Box>
+            </Popover>
+            <Tooltip
+                title={t('bots.table.showChats', {defaultValue: 'Show reachable chats (copy Chat ID)'})}
+                open={tooltipOpen && !open}
+                onOpen={() => setTooltipOpen(true)}
+                onClose={() => setTooltipOpen(false)}
+                leaveDelay={0}
+            >
+                <IconButton
+                    size="small"
+                    color="primary"
+                    onClick={handleOpen}
+                    disabled={disabled}
+                    aria-label={t('bots.table.showChats', {defaultValue: 'Show reachable chats'})}
+                >
+                    <MessageIcon fontSize="small"/>
+                </IconButton>
+            </Tooltip>
+        </>
+    );
+};
+
+export default BotChatsButton;

--- a/frontend/src/components/bot/BotTable.tsx
+++ b/frontend/src/components/bot/BotTable.tsx
@@ -1,6 +1,7 @@
 import {ContentCopy as CopyIcon, Delete as DeleteIcon, Edit as EditIcon, RestartAlt as RestartIcon} from '@/components/icons';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import PairingCodePanel from './PairingCodePanel';
+import BotChatsButton from './BotChatsButton';
 import {isRemoteAgentMounted, isNotifyMounted, isPairingRequired} from '@/types/bot';
 import type {BotSettings} from '@/types/bot';
 import {notify} from '@/utils/notify';
@@ -166,7 +167,7 @@ const BotTable: React.FC<BotTableProps> = ({
                                         (:bot), copyable. Icon + text on one row (mirrors ApiKeyTable's
                                         API Key cell); UUID truncates with the full value in the tooltip.
                                         Labeled "Bot UUID" (not "Bot ID") to split the name collision with
-                                        a chat's own id — ux-principles #3. */}
+                                        the Chat ID surfaced by BotChatsButton — ux-principles #3. */}
                                     <TableCell>
                                         <Stack direction="row" spacing={0.5} sx={{alignItems: 'center'}}>
                                             <Tooltip title={t('bots.table.copyUuid', {defaultValue: 'Copy Bot UUID'})}>
@@ -239,6 +240,19 @@ const BotTable: React.FC<BotTableProps> = ({
                                     {/* Actions */}
                                     <TableCell align="right">
                                         <Stack direction="row" spacing={0.5} sx={{alignItems: 'center', justifyContent: 'flex-end'}}>
+                                            {/* Reachable chats — surfaces the chat_id the notify/interact API
+                                                needs in its body, copyable. Kept in Actions (rather than its
+                                                own column) because it is reference data the operator copies
+                                                on demand, not a per-row status; the fixed column budget is
+                                                tuned for the always-visible columns. The button owns its own
+                                                tooltip so it can dismiss it when the popover opens (a
+                                                wrapping Tooltip here leaves its hover text lingering). */}
+                                            <BotChatsButton
+                                                botUUID={bot.uuid!}
+                                                platform={bot.platform}
+                                                pairingRequired={pairingNeeded}
+                                                disabled={toggling || restarting}
+                                            />
                                             <Tooltip title={isActive
                                                 ? t('remoteControl.card.restartBot', {defaultValue: 'Restart Bot'})
                                                 : t('remoteControl.card.enableToRestart', {defaultValue: 'Enable bot to restart'})}>

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -131,6 +131,7 @@ import {
     IconTools,
     IconServer,
     IconMessageReport,
+    IconMessage,
     IconWaveSine,
     IconCircleFilled,
     IconWorldDownload,
@@ -323,6 +324,7 @@ export const CloudDownload = tablerMui(IconWorldDownload);
 
 // --- Communication -----------------------------------------------------------
 export const MessageReport = tablerMui(IconMessageReport);
+export const Message = tablerMui(IconMessage);
 
 // --- Calendar / schedule -----------------------------------------------------
 export const EventNote = tablerMui(IconCalendarClock);

--- a/frontend/src/components/notify/BotNotifyGroup.tsx
+++ b/frontend/src/components/notify/BotNotifyGroup.tsx
@@ -1,0 +1,386 @@
+import {ContentCopy as CopyIcon, Edit as CustomIcon, Close as CloseIcon, Code as CodeIcon, Refresh as RefreshIcon} from '@/components/icons';
+import {api} from '@/services/api';
+import {notify} from '@/utils/notify';
+import {isPairingRequired} from '@/types/bot';
+import type {BotChat, BotSettings} from '@/types/bot';
+import {fontMono} from '@/theme/fonts';
+import NotifyTestDialog from '@/components/notify/NotifyTestDialog';
+import {CHAT_CAPABILITIES} from '@/components/notify/chatCapabilities';
+import useChatProbe, {type ChatCapability, type ChatProbeResult} from '@/components/notify/useChatProbe';
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    Collapse,
+    IconButton,
+    Stack,
+    Switch,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import {useCallback, useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+
+// BotNotifyGroup is one bot's panel on the IM Notify page: a header (name +
+// platform + the enabled switch that governs whether this bot can be driven)
+// over an ALWAYS-EXPANDED list of the chats it can reach. Each chat row is a
+// CAPABILITY PROBE BENCH — a row of one-click buttons (Notify / Confirm active,
+// Choose / Ask gated, Custom → free-form dialog) that exercise each chat
+// capability end-to-end and show a probe-style verdict inline, exactly as the
+// model-routing probe does for providers (see components/probe/). This answers
+// the operator's real question — "do my bot's chat capabilities actually work?"
+// — not "can I compose one custom message?" (ux-principles #1/#5/#11).
+//
+// The chats are fetched eagerly when the bot is enabled, not behind a button.
+// A disabled bot has no channel in the registry, so /chats would answer an
+// empty list with running:false — we skip the round trip entirely and render
+// the disabled body instead.
+export interface BotNotifyGroupProps {
+    bot: BotSettings;
+    onToggle: (uuid: string) => void;
+    isToggling?: boolean;
+}
+
+// Em-dash placeholder for empty status/project/updated meta — shared styling.
+const Dash: React.FC = () => (
+    <Typography variant="body2" sx={{color: 'text.secondary'}}>—</Typography>
+);
+
+// formatLatency mirrors probe/runProbe.ts: "850ms" / "1.2s".
+const formatLatency = (ms: number): string => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`);
+
+// One-glance verdict label + severity for a probe result, mirroring the probe
+// feature's StatusBar mapping of outcome → label.
+const verdict = (r: ChatProbeResult): {label: string; severity: 'success' | 'error' | 'warning' | 'info'} => {
+    switch (r.status) {
+        case 'delivered': return {label: `Delivered · ${formatLatency(r.latencyMs)}`, severity: 'success'};
+        case 'answered': return {label: `Answered: ${String(r.decision?.selected ?? '?')} · ${formatLatency(r.latencyMs)}`, severity: 'success'};
+        case 'cancelled': return {label: `Cancelled · ${formatLatency(r.latencyMs)}`, severity: 'warning'};
+        case 'timed-out': return {label: `Timed out · ${formatLatency(r.latencyMs)}`, severity: 'warning'};
+        case 'expired': return {label: `Expired · ${formatLatency(r.latencyMs)}`, severity: 'warning'};
+        default: return {label: r.error ? `Failed: ${r.error}` : 'Failed', severity: 'error'};
+    }
+};
+
+// ProbeResultLine is the inline verdict for one capability probe — an outlined
+// Alert (mirroring probe's StatusBar) with the capability, the one-glance
+// outcome, and a collapsible Raw JSON. Dismissible so the row stays clean.
+const ProbeResultLine: React.FC<{result: ChatProbeResult; onDismiss: () => void}> = ({result, onDismiss}) => {
+    const {t} = useTranslation();
+    const [showRaw, setShowRaw] = useState(false);
+    const v = verdict(result);
+    return (
+        <Alert
+            severity={v.severity}
+            variant="outlined"
+            icon={false}
+            sx={{py: 0.5, borderRadius: 1, '& .MuiAlert-message': {width: '100%'}}}
+        >
+            <Box sx={{display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap'}}>
+                <Chip label={result.capability} size="small" sx={{textTransform: 'capitalize', fontWeight: 600}} />
+                <Typography variant="body2" sx={{fontWeight: 600, color: v.severity === 'success' ? 'success.main' : v.severity === 'error' ? 'error.main' : 'warning.main'}}>
+                    {v.label}
+                </Typography>
+                {result.reason && (
+                    <Typography variant="caption" sx={{color: 'text.secondary'}}>{result.reason}</Typography>
+                )}
+                <Box sx={{flexGrow: 1}} />
+                <Tooltip title={t('notify.probe.showRaw', {defaultValue: 'Show raw payload'})}>
+                    <IconButton size="small" onClick={() => setShowRaw((s) => !s)}>
+                        <CodeIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title={t('common.dismiss', {defaultValue: 'Dismiss'})}>
+                    <IconButton size="small" onClick={onDismiss}>
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+            </Box>
+            <Collapse in={showRaw}>
+                <Box sx={{mt: 1, p: 1, bgcolor: 'action.hover', borderRadius: 1, fontFamily: fontMono, fontSize: '0.75rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all'}}>
+                    {JSON.stringify(result.raw ?? result, null, 2)}
+                </Box>
+            </Collapse>
+        </Alert>
+    );
+};
+
+
+
+const BotNotifyGroup: React.FC<BotNotifyGroupProps> = ({bot, onToggle, isToggling}) => {
+    const {t} = useTranslation();
+    const enabled = bot.enabled ?? true;
+
+    const [chats, setChats] = useState<BotChat[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [testChatID, setTestChatID] = useState<string | null>(null);
+
+    const loadChats = useCallback(async () => {
+        if (!bot.uuid) return;
+        setLoading(true);
+        setError(null);
+        const result = await api.listBotChats(bot.uuid);
+        setLoading(false);
+        if (result.error) {
+            setError(result.error);
+        } else {
+            setChats(result.chats ?? []);
+        }
+    }, [bot.uuid]);
+
+    // Eager-load only when the bot is enabled (a stopped bot has no reachable
+    // chats). Re-fetch on enable transitions so toggling on surfaces fresh chats.
+    useEffect(() => {
+        if (enabled) loadChats();
+        else {
+            setChats([]);
+            setError(null);
+        }
+    }, [enabled, loadChats]);
+
+    const handleCopy = useCallback(async (chatID: string) => {
+        try {
+            await navigator.clipboard.writeText(chatID);
+            notify.success(t('notify.chat.copied', {defaultValue: 'Chat ID copied'}));
+        } catch {
+            notify.error(t('notify.chat.copyFailed', {defaultValue: 'Copy failed — check clipboard permissions'}));
+        }
+    }, [t]);
+
+    const openTest = useCallback((chatID: string) => setTestChatID(chatID), []);
+    const closeTest = useCallback(() => setTestChatID(null), []);
+
+    // The capability probe runner — owns firing notify/confirm against a chat
+    // and the per-(chat,capability) results. Lives at the group level so a
+    // result persists across re-renders of the chat list.
+    const probe = useChatProbe();
+    const handleProbe = useCallback((chatID: string, capability: ChatCapability) => {
+        if (!bot.uuid) return;
+        void probe.run(bot.uuid, chatID, capability);
+    }, [bot.uuid, probe]);
+
+    return (
+        <Box
+            sx={{
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1.5,
+                overflow: 'hidden',
+            }}
+        >
+            {/* Header: name + platform + enabled switch (the on/off for driving
+                this bot) + chat count. The switch is the bot's existing enabled
+                flag — surfaced here because "can I use this bot to notify?" is
+                exactly the question this page answers. */}
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    px: 2,
+                    py: 1.25,
+                    bgcolor: 'action.hover',
+                    flexWrap: 'wrap',
+                }}
+            >
+                {/* Fixed-width name column so every group's name chip aligns
+                    across rows — name length varies, but the column shouldn't. */}
+                <Tooltip title={bot.name || bot.platform}>
+                    <Typography noWrap variant="body2" sx={{fontWeight: 600, flexShrink: 0, width: {xs: 96, sm: 150}}}>
+                        {bot.name || bot.platform}
+                    </Typography>
+                </Tooltip>
+                <Chip label={bot.platform} size="small" />
+                <Box sx={{flexGrow: 1}} />
+                {enabled && (
+                    <Typography variant="body2" sx={{color: 'text.secondary'}}>
+                        {chats.length > 0
+                            ? t('notify.group.chatCount', {defaultValue: '{{count}} reachable chat(s)', count: chats.length})
+                            : t('notify.group.noChats', {defaultValue: 'No reachable chats'})}
+                    </Typography>
+                )}
+                {enabled && (
+                    // Manual refresh: a chat only registers after the bot
+                    // actually receives a message on its channel, so the first
+                    // view is expected to be stale until the operator re-pulls.
+                    <Tooltip title={t('notify.group.refresh', {defaultValue: 'Refresh reachable chats'})}>
+                        <IconButton
+                            size="small"
+                            onClick={loadChats}
+                            disabled={loading || isToggling}
+                            aria-label={t('notify.group.refresh', {defaultValue: 'Refresh reachable chats'})}
+                        >
+                            {loading ? <CircularProgress size={16}/> : <RefreshIcon fontSize="small"/>}
+                        </IconButton>
+                    </Tooltip>
+                )}
+                <Tooltip title={enabled
+                    ? t('notify.group.disableHint', {defaultValue: 'Disable this bot'})
+                    : t('notify.group.enableHint', {defaultValue: 'Enable this bot to send notifications'})}>
+                    {/* The switch is wired to the same toggle the Bots table uses
+                        (POST /imbot-settings/:uuid/toggle) — it starts/stops the
+                        bot's channel, which is what governs whether notify can
+                        reach it. A disabled-bot row shows why chats are absent. */}
+                    <Stack
+                        direction="row"
+                        spacing={0.75}
+                        sx={{alignItems: 'center', cursor: isToggling ? 'wait' : 'pointer'}}
+                    >
+                        <Switch
+                            size="small"
+                            color="success"
+                            checked={enabled}
+                            disabled={isToggling}
+                            onChange={() => onToggle(bot.uuid!)}
+                        />
+                        {isToggling ? (
+                            <CircularProgress size={14} />
+                        ) : (
+                            <Typography variant="body2" sx={{color: enabled ? 'success.main' : 'text.secondary', fontWeight: 600}}>
+                                {enabled ? t('common.on', {defaultValue: 'On'}) : t('common.off', {defaultValue: 'Off'})}
+                            </Typography>
+                        )}
+                    </Stack>
+                </Tooltip>
+            </Box>
+
+            {/* Body: the reachable chats, always expanded (no extra click). */}
+            <Box sx={{px: {xs: 1, sm: 2}, py: 1.5}}>
+                {!enabled ? (
+                    <Typography variant="body2" sx={{color: 'text.disabled', py: 1}}>
+                        {t('notify.group.disabledBody', {defaultValue: 'Bot is off — enable it to see and send to its reachable chats.'})}
+                    </Typography>
+                ) : loading ? (
+                    <Box sx={{display: 'flex', justifyContent: 'center', py: 2}}>
+                        <CircularProgress size={20} />
+                    </Box>
+                ) : error ? (
+                    <Typography variant="body2" sx={{color: 'error.main', py: 1}}>{error}</Typography>
+                ) : chats.length === 0 ? (
+                    <Typography variant="body2" sx={{color: 'text.disabled', py: 1}}>
+                        {isPairingRequired(bot)
+                            ? t('notify.group.emptyPairFirst', {defaultValue: 'No chats yet. Pair this bot, then send it a message on {{platform}} — its Chat ID appears here.', platform: bot.platform || 'its platform'})
+                            : t('notify.group.empty', {defaultValue: 'No chats yet. Send any message to this bot on {{platform}} and its Chat ID appears here.', platform: bot.platform || 'its platform'})}
+                    </Typography>
+                ) : (
+                    <Stack spacing={1}>
+                        {chats.map((chat) => {
+                            const running = (cap: ChatCapability) => probe.isRunning(chat.chat_id, cap);
+                            const anyRunning = running('notify') || running('confirm');
+                            return (
+                                <Box
+                                    key={chat.chat_id}
+                                    sx={{
+                                        border: '1px solid',
+                                        borderColor: 'divider',
+                                        borderRadius: 1,
+                                        p: 1.25,
+                                    }}
+                                >
+                                    {/* Chat identity + meta row */}
+                                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap'}}>
+                                        <Typography variant="body2" component="span" sx={{fontFamily: fontMono, color: 'text.primary', fontWeight: 600}}>
+                                            {chat.chat_id}
+                                        </Typography>
+                                        {chat.is_paired ? (
+                                            <Chip label={t('notify.group.paired', {defaultValue: 'paired'})} size="small" color="success" variant="outlined" />
+                                        ) : <Dash/>}
+                                        {chat.project_path && (
+                                            <Tooltip title={chat.project_path}>
+                                                <Typography variant="caption" component="span" noWrap sx={{color: 'text.secondary', maxWidth: 220}}>
+                                                    {chat.project_path}
+                                                </Typography>
+                                            </Tooltip>
+                                        )}
+                                        {chat.updated_at && (
+                                            <Typography variant="caption" sx={{color: 'text.disabled'}}>
+                                                {new Date(chat.updated_at).toLocaleString()}
+                                            </Typography>
+                                        )}
+                                        <Box sx={{flexGrow: 1}} />
+                                        <Tooltip title={t('notify.group.copyChatId', {defaultValue: 'Copy Chat ID'})}>
+                                            <IconButton size="small" onClick={() => handleCopy(chat.chat_id)}>
+                                                <CopyIcon fontSize="small" />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </Box>
+
+                                    {/* Capability probe controls + inline verdict.
+                                        Mirrors the probe feature: one-click trigger
+                                        per capability, result renders inline. */}
+                                    <Box sx={{display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap', mt: 1}}>
+                                        {CHAT_CAPABILITIES.map((cap) => {
+                                            // `gated` is chatCapabilities' own answer to "is this
+                                            // capability wired end-to-end yet?" — read it rather
+                                            // than re-listing the runnable ones here, so the two
+                                            // can't drift apart.
+                                            const active = !cap.gated;
+                                            const isRunning = active && running(cap.capability as ChatCapability);
+                                            const result = active ? probe.getResult(chat.chat_id, cap.capability as ChatCapability) : undefined;
+                                            const v = result ? verdict(result) : null;
+                                            return (
+                                                <Tooltip key={cap.capability} title={cap.hint}>
+                                                    <span>
+                                                        <Button
+                                                            size="small"
+                                                            variant="outlined"
+                                                            color={v?.severity === 'success' ? 'success' : v?.severity === 'error' ? 'error' : v?.severity === 'warning' ? 'warning' : 'primary'}
+                                                            disabled={!active || isRunning || anyRunning}
+                                                            onClick={() => active && handleProbe(chat.chat_id, cap.capability as ChatCapability)}
+                                                            startIcon={isRunning ? <CircularProgress size={14} color="inherit" /> : cap.icon}
+                                                            sx={{textTransform: 'none'}}
+                                                        >
+                                                            {cap.label}
+                                                        </Button>
+                                                    </span>
+                                                </Tooltip>
+                                            );
+                                        })}
+                                        {/* Custom → free-form editor (the escape hatch). */}
+                                        <Tooltip title={t('notify.group.customHint', {defaultValue: 'Compose a custom message (free-form)'})}>
+                                            <Button
+                                                size="small"
+                                                variant="text"
+                                                color="primary"
+                                                startIcon={<CustomIcon fontSize="small" />}
+                                                onClick={() => openTest(chat.chat_id)}
+                                                sx={{textTransform: 'none'}}
+                                            >
+                                                {t('notify.group.custom', {defaultValue: 'Custom'})}
+                                            </Button>
+                                        </Tooltip>
+                                    </Box>
+
+                                    {/* Inline probe results (one per active capability that has run). */}
+                                    {(probe.getResult(chat.chat_id, 'notify') || probe.getResult(chat.chat_id, 'confirm')) && (
+                                        <Stack spacing={0.75} sx={{mt: 1}}>
+                                            {(['notify', 'confirm'] as const).map((cap) => {
+                                                const r = probe.getResult(chat.chat_id, cap);
+                                                if (!r) return null;
+                                                return <ProbeResultLine key={cap} result={r} onDismiss={() => probe.clear(chat.chat_id, cap)} />;
+                                            })}
+                                        </Stack>
+                                    )}
+                                </Box>
+                            );
+                        })}
+                    </Stack>
+                )}
+            </Box>
+
+            <NotifyTestDialog
+                open={testChatID !== null}
+                botUUID={bot.uuid!}
+                botName={bot.name || bot.platform}
+                chats={chats}
+                initialChatID={testChatID ?? undefined}
+                onClose={closeTest}
+            />
+        </Box>
+    );
+};
+
+export default BotNotifyGroup;

--- a/frontend/src/components/notify/NotifyGuide.tsx
+++ b/frontend/src/components/notify/NotifyGuide.tsx
@@ -1,0 +1,90 @@
+import CodeBlock from '@/components/CodeBlock';
+import {getDisplayOrigin} from '@/utils/protocol';
+import {Box, Stack, Typography} from '@mui/material';
+import {useTranslation} from 'react-i18next';
+
+// NotifyGuide is the body of the IM Notify usage guide — it teaches an operator
+// how to drive a bot's chat via the authenticated bot-interaction API, embedded
+// in the product (ux-principles #8). It is organized around the three questions
+// an integrator actually asks (ux-principles #1):
+//
+//   1. Who can call this, and how do I authenticate?
+//   2. What exactly do I send?  (concrete curl + JSON — principle #5)
+//   3. Where do I get the chat_id the body requires?
+//
+// Auth reuses the operator's existing user token — no new credential — so the
+// guide says so plainly rather than inventing a "notify token" story (see
+// .design/bot-interaction-api.md §3.1). The base URL is the operator's own
+// origin so the curl is copy-pasteable as-is (principle #11 — hand over the
+// artifact for the next action).
+const NotifyGuide: React.FC = () => {
+    const {t} = useTranslation();
+    const origin = getDisplayOrigin();
+
+    // Concrete, copy-pasteable curl. <BOT_UUID> and <CHAT_ID> are left as
+    // placeholders the operator fills from the table below + the per-bot chats
+    // list — the guide points there explicitly in section 3.
+    const curl = `curl -X POST ${origin}/api/v1/bots/<BOT_UUID>/notify \\
+  -H "Authorization: Bearer <USER_TOKEN>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "chat_id": "<CHAT_ID>",
+    "title": "Build #412 failed",
+    "body": "main branch is red",
+    "level": "warn"
+  }'`;
+
+    const jsonBody = `{
+  "chat_id": "<CHAT_ID>",   // required — the channel-native conversation id
+  "title": "Build #412 failed",  // optional
+  "body": "main branch is red",  // required
+  "level": "info"                // optional: info | warn | error
+}`;
+
+    return (
+        <Stack spacing={2.5}>
+            {/* 1. Who can call this / auth */}
+            <Box>
+                <Typography variant="subtitle2" sx={{fontWeight: 600, mb: 0.5}}>
+                    {t('notify.guide.auth.title', {defaultValue: '1. Authenticate with your user token'})}
+                </Typography>
+                <Typography variant="body2" sx={{color: 'text.secondary'}}>
+                    {t('notify.guide.auth.body', {
+                        defaultValue: 'Any integration can drive a bot’s chat. Auth reuses your existing operator user token (the same one this web UI uses) as a Bearer header — no new credential to mint. Interactive prompts (/interact) and one-way notifications (/notify) are separate URLs, so the request shape is the mode.',
+                    })}
+                </Typography>
+            </Box>
+
+            {/* 2. What to send */}
+            <Box>
+                <Typography variant="subtitle2" sx={{fontWeight: 600, mb: 0.5}}>
+                    {t('notify.guide.send.title', {defaultValue: '2. Send a one-way notification'})}
+                </Typography>
+                <Typography variant="body2" sx={{color: 'text.secondary', mb: 1}}>
+                    {t('notify.guide.send.body', {
+                        defaultValue: 'POST to /api/v1/bots/{bot}/notify with the bot UUID in the path. A 200 means delivered.',
+                    })}
+                </Typography>
+                <CodeBlock code={curl} language="bash"/>
+                <Typography variant="caption" sx={{color: 'text.secondary', mt: 1, display: 'block'}}>
+                    {t('notify.guide.send.json', {defaultValue: 'Request body:'})}
+                </Typography>
+                <CodeBlock code={jsonBody} language="json"/>
+            </Box>
+
+            {/* 3. Where to get chat_id */}
+            <Box>
+                <Typography variant="subtitle2" sx={{fontWeight: 600, mb: 0.5}}>
+                    {t('notify.guide.chatid.title', {defaultValue: '3. Get the chat_id from the list below'})}
+                </Typography>
+                <Typography variant="body2" sx={{color: 'text.secondary'}}>
+                    {t('notify.guide.chatid.body', {
+                        defaultValue: 'Each bot row shows the chats it can reach — open it and copy the Chat ID. A chat appears here only after a user has messaged the bot (on Telegram/Discord/Slack, pair it first). Or send a test message right from the row to verify the link end-to-end.',
+                    })}
+                </Typography>
+            </Box>
+        </Stack>
+    );
+};
+
+export default NotifyGuide;

--- a/frontend/src/components/notify/NotifyTestDialog.tsx
+++ b/frontend/src/components/notify/NotifyTestDialog.tsx
@@ -1,0 +1,186 @@
+import {Send as SendIcon} from '@/components/icons';
+import {api} from '@/services/api';
+import {notify} from '@/utils/notify';
+import {fontMono} from '@/theme/fonts';
+import type {BotChat} from '@/types/bot';
+import {
+    Autocomplete,
+    Button,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+import {useCallback, useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+
+// NotifyTestDialog lets an operator send a one-way test notification to a
+// running bot's chat — the concrete payoff of the notify usage guide. It drives
+// POST /api/v1/bots/:bot/notify (api.notifyBot) end-to-end so the link is
+// verifiable from the UI. One-way only; interact (request→reply) is out of scope
+// for this pass.
+//
+// The chat_id picker is the live, channel-native id /notify needs (concept (b),
+// not the chat_id_lock inbound restriction and not the scenarios route target).
+// It's an Autocomplete over the chats the parent already loaded — one input that
+// both picks from the list and accepts a pasted id when no chat is registered
+// yet. See .design/bot-interaction-api.md and ux-principles #5/#11.
+export interface NotifyTestDialogProps {
+    open: boolean;
+    botUUID: string;
+    botName?: string;
+    /** The bot's reachable chats — owned by the parent (BotNotifyGroup), so the
+     *  dialog doesn't re-fetch what's already loaded one level up. */
+    chats: BotChat[];
+    /** Pre-fill the chat_id (e.g. when opened from a specific chat row). */
+    initialChatID?: string;
+    onClose: () => void;
+}
+
+const LEVELS = ['info', 'warn', 'error'] as const;
+type Level = (typeof LEVELS)[number];
+
+const NotifyTestDialog: React.FC<NotifyTestDialogProps> = ({open, botUUID, botName, chats, initialChatID, onClose}) => {
+    const {t} = useTranslation();
+
+    const [chatID, setChatID] = useState('');
+    const [title, setTitle] = useState('');
+    const [body, setBody] = useState('');
+    const [level, setLevel] = useState<Level>('info');
+    const [sending, setSending] = useState(false);
+
+    // Reset the form each time the dialog opens. The chat list is owned by the
+    // parent, so there's no fetch here.
+    useEffect(() => {
+        if (!open) return;
+        setChatID(initialChatID ?? '');
+        setTitle('');
+        setBody('');
+        setLevel('info');
+    }, [open, initialChatID]);
+
+    const canSend = chatID.trim() !== '' && body.trim() !== '' && !sending;
+
+    const handleSend = useCallback(async () => {
+        setSending(true);
+        const result = await api.notifyBot(botUUID, {
+            chat_id: chatID.trim(),
+            title: title.trim() || undefined,
+            body: body.trim(),
+            level,
+        });
+        setSending(false);
+        if (result.error) {
+            notify.error(t('notify.test.sendFailed', {defaultValue: 'Send failed: {{error}}', error: result.error}));
+            return;
+        }
+        notify.success(t('notify.test.sent', {defaultValue: 'Notification sent'}));
+        onClose();
+    }, [botUUID, chatID, title, body, level, onClose, t]);
+
+    return (
+        <Dialog open={open} onClose={sending ? undefined : onClose} fullWidth maxWidth="sm">
+            <DialogTitle>
+                {t('notify.test.title', {defaultValue: 'Send a test notification'})}
+                {botName ? ` — ${botName}` : ''}
+            </DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{mt: 0.5}}>
+                    {/* One chat_id control: pick from the list OR paste a value
+                        when no chat is registered yet (freeSolo). Avoids the
+                        two-controls-one-value trap. */}
+                    <Autocomplete
+                        size="small"
+                        freeSolo
+                        options={chats}
+                        getOptionLabel={(c) => (typeof c === 'string' ? c : c.chat_id)}
+                        value={chats.find((c) => c.chat_id === chatID) ?? (chatID ? chatID : null)}
+                        onChange={(_e, value) => setChatID(typeof value === 'string' ? value : (value?.chat_id ?? ''))}
+                        onInputChange={(_e, value) => setChatID(value)}
+                        renderOption={(props, option) => {
+                            const chat = typeof option === 'string' ? {chat_id: option} : option;
+                            return (
+                                <li {...props} key={chat.chat_id}>
+                                    <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
+                                        <Typography component="span" sx={{fontFamily: fontMono}}>
+                                            {chat.chat_id}
+                                        </Typography>
+                                        {chat.is_paired && (
+                                            <Typography component="span" variant="caption" sx={{color: 'success.main'}}>
+                                                {t('notify.test.paired', {defaultValue: 'paired'})}
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                </li>
+                            );
+                        }}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label={t('notify.test.chatId', {defaultValue: 'Chat ID'})}
+                                placeholder={chats.length === 0
+                                    ? t('notify.test.chatIdPlaceholder', {defaultValue: 'No chats yet — paste a Chat ID'})
+                                    : ''}
+                            />
+                        )}
+                    />
+                    <TextField
+                        size="small"
+                        fullWidth
+                        label={t('notify.test.titleField', {defaultValue: 'Title (optional)'})}
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        disabled={sending}
+                    />
+                    <TextField
+                        size="small"
+                        fullWidth
+                        multiline
+                        minRows={3}
+                        label={t('notify.test.bodyField', {defaultValue: 'Body'})}
+                        value={body}
+                        onChange={(e) => setBody(e.target.value)}
+                        disabled={sending}
+                        required
+                    />
+                    <FormControl size="small" fullWidth disabled={sending}>
+                        <InputLabel>{t('notify.test.level', {defaultValue: 'Level'})}</InputLabel>
+                        <Select
+                            value={level}
+                            label={t('notify.test.level', {defaultValue: 'Level'})}
+                            onChange={(e) => setLevel(e.target.value as Level)}
+                        >
+                            {LEVELS.map((l) => (
+                                <MenuItem key={l} value={l}>{l}</MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                </Stack>
+            </DialogContent>
+            <DialogActions sx={{px: 3, pb: 2}}>
+                <Button onClick={onClose} disabled={sending}>
+                    {t('common.cancel', {defaultValue: 'Cancel'})}
+                </Button>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleSend}
+                    disabled={!canSend}
+                    startIcon={sending ? undefined : <SendIcon/>}
+                >
+                    {sending ? <CircularProgress size={16} color="inherit"/> : t('notify.test.send', {defaultValue: 'Send'})}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default NotifyTestDialog;

--- a/frontend/src/components/notify/chatCapabilities.tsx
+++ b/frontend/src/components/notify/chatCapabilities.tsx
@@ -1,0 +1,52 @@
+import {Bell as NotifyIcon, CheckCircle as ConfirmIcon, ListAlt as ChooseIcon, Message as AskIcon} from '@/components/icons';
+import type {ChatCapability} from './useChatProbe';
+
+// chatCapabilities is the single source of truth for the per-chat capability
+// probe row — what buttons render, in what order, their labels, and which are
+// gated. The probe feature is mode-driven via a ToggleButtonGroup
+// (ProbeDialog.tsx); chat has more capabilities, so this is the preset array
+// the probe lacks. See the IM Notify probe plan.
+//
+// `gated` capabilities are shown disabled with an experimental tooltip: their
+// backend option/free-text threading into the IM keyboard is incomplete
+// (imchannel.ToAskRequest doesn't copy ix.Options), so we don't expose them
+// until that's fixed — no point wiring a trigger that can't render its prompt.
+
+export interface ChatCapabilityDef {
+    capability: ChatCapability | 'choose' | 'ask';
+    label: string;
+    icon: React.ReactNode;
+    /** Disabled with an "experimental" tooltip — backend path incomplete. */
+    gated?: boolean;
+    /** One-line hint for the button tooltip. */
+    hint: string;
+}
+
+export const CHAT_CAPABILITIES: ChatCapabilityDef[] = [
+    {
+        capability: 'notify',
+        label: 'Notify',
+        icon: <NotifyIcon fontSize="small" />,
+        hint: 'Send a one-way test notification and verify delivery',
+    },
+    {
+        capability: 'confirm',
+        label: 'Confirm',
+        icon: <ConfirmIcon fontSize="small" />,
+        hint: 'Send an Allow/Deny prompt and wait for the reply',
+    },
+    {
+        capability: 'choose',
+        label: 'Choose',
+        icon: <ChooseIcon fontSize="small" />,
+        gated: true,
+        hint: 'Multi-option prompt (experimental — backend option rendering incomplete)',
+    },
+    {
+        capability: 'ask',
+        label: 'Ask',
+        icon: <AskIcon fontSize="small" />,
+        gated: true,
+        hint: 'Free-text question (experimental — backend text capture incomplete)',
+    },
+];

--- a/frontend/src/components/notify/useChatProbe.ts
+++ b/frontend/src/components/notify/useChatProbe.ts
@@ -1,0 +1,155 @@
+import {api} from '@/services/api';
+import {useCallback, useState} from 'react';
+
+// useChatProbe is the chat-capability probe runner. For a given (bot, chat),
+// it fires one capability (notify / confirm) end-to-end and normalizes the
+// outcome into a single ChatProbeResult — so the UI only renders one shape,
+// mirroring how the probe feature folds everything into one ProbeResult envelope
+// (see components/probe/runProbe.ts).
+//
+// - notify  → api.notifyBot; success = delivered (200 {ok:true}).
+// - confirm → api.interactBot then long-polls api.waitBotInteract, retrying on
+//   `pending` (504) until the prompt is answered/cancelled/timed out/expired.
+//   success = answered; decision.selected ∈ {allow, deny}.
+//
+// choose/ask share the confirm runner shape but are gated at the button layer
+// (their backend option/free-text threading into the IM keyboard is incomplete),
+// so this hook doesn't expose them yet.
+
+export type ChatCapability = 'notify' | 'confirm';
+
+export interface ChatProbeResult {
+    capability: ChatCapability;
+    /** true only for a clean success: notify delivered, or confirm answered. */
+    success: boolean;
+    /** One-glance status label: delivered | answered | cancelled | timed-out | expired | failed. */
+    status: 'delivered' | 'answered' | 'cancelled' | 'timed-out' | 'expired' | 'failed';
+    latencyMs: number;
+    /** The reply decision (confirm: {selected:'allow'|'deny'}), if any. */
+    decision?: Record<string, unknown>;
+    /** Error/reason text on non-success. */
+    error?: string;
+    /** Backend reason (e.g. why a prompt timed out), if any. */
+    reason?: string;
+    /** Raw payload for the "Raw JSON" collapsible. */
+    raw?: unknown;
+}
+
+type ResultMap = Record<string, ChatProbeResult | undefined>;
+
+const key = (chatID: string, capability: ChatCapability) => `${chatID}:${capability}`;
+
+// Confirm long-poll budget: keep polling until the prompt resolves or expires.
+// Each wait call is ~45s (server max 50s); cap the whole thing so it can't run
+// forever if something goes wrong.
+const CONFIRM_TOTAL_BUDGET_MS = 6 * 60 * 1000;
+const WAIT_TIMEOUT_MS = 45_000;
+
+export interface UseChatProbeResult {
+    results: ResultMap;
+    running: Record<string, boolean>;
+    run: (botUUID: string, chatID: string, capability: ChatCapability) => Promise<void>;
+    isRunning: (chatID: string, capability: ChatCapability) => boolean;
+    getResult: (chatID: string, capability: ChatCapability) => ChatProbeResult | undefined;
+    clear: (chatID: string, capability: ChatCapability) => void;
+}
+
+export function useChatProbe(): UseChatProbeResult {
+    const [results, setResults] = useState<ResultMap>({});
+    const [running, setRunning] = useState<Record<string, boolean>>({});
+
+    const setResult = useCallback((k: string, r: ChatProbeResult) => {
+        setResults((prev) => ({...prev, [k]: r}));
+    }, []);
+    const setRun = useCallback((k: string, v: boolean) => {
+        setRunning((prev) => ({...prev, [k]: v}));
+    }, []);
+
+    const runNotify = useCallback(async (botUUID: string, chatID: string, started: number): Promise<ChatProbeResult> => {
+        const result = await api.notifyBot(botUUID, {
+            chat_id: chatID,
+            title: 'Test notification',
+            body: 'Sent from the IM Notify probe — this verifies one-way delivery to this chat.',
+            level: 'info',
+        });
+        const latencyMs = Date.now() - started;
+        if (result.error) {
+            return {capability: 'notify', success: false, status: 'failed', latencyMs, error: result.error, raw: result};
+        }
+        return {capability: 'notify', success: true, status: 'delivered', latencyMs, raw: result};
+    }, []);
+
+    const runConfirm = useCallback(async (botUUID: string, chatID: string, started: number): Promise<ChatProbeResult> => {
+        const start = await api.interactBot(botUUID, {
+            chat_id: chatID,
+            kind: 'confirm',
+            title: 'Test: approve?',
+            body: 'This verifies the bot\'s interactive prompt works. Tap Allow or Deny.',
+            // confirm requires ≥1 option (handler validates len>0 before the
+            // channel renders). The channel's permission path renders
+            // Allow/Deny/Always-Allow regardless, and returns decision.selected
+            // ∈ {allow, deny, always} — so send those values.
+            options: [
+                {value: 'allow', label: 'Allow', style: 'primary'},
+                {value: 'deny', label: 'Deny', style: 'danger'},
+            ],
+            timeout_seconds: 120,
+        });
+        if (start.error || !start.request_id) {
+            return {capability: 'confirm', success: false, status: 'failed', latencyMs: Date.now() - started, error: start.error || 'no request_id', raw: start};
+        }
+
+        // Long-poll loop: retry on pending until resolved/expired/budget hit.
+        const deadline = started + CONFIRM_TOTAL_BUDGET_MS;
+        let last: {status?: string; decision?: Record<string, unknown>; reason?: string; error?: string} = {status: 'pending'};
+        while (Date.now() < deadline) {
+            last = await api.waitBotInteract(botUUID, start.request_id, WAIT_TIMEOUT_MS);
+            if (last.error) {
+                return {capability: 'confirm', success: false, status: 'failed', latencyMs: Date.now() - started, error: last.error, raw: {start, ...last}};
+            }
+            if (last.status === 'answered') {
+                return {capability: 'confirm', success: true, status: 'answered', latencyMs: Date.now() - started, decision: last.decision, raw: {start, ...last}};
+            }
+            if (last.status === 'cancelled') {
+                return {capability: 'confirm', success: false, status: 'cancelled', latencyMs: Date.now() - started, decision: last.decision, raw: {start, ...last}};
+            }
+            if (last.status === 'timeout' || last.status === 'error') {
+                return {capability: 'confirm', success: false, status: 'timed-out', latencyMs: Date.now() - started, decision: last.decision, reason: last.reason, raw: {start, ...last}};
+            }
+            if (last.status === 'expired' || last.status === 'unavailable') {
+                return {capability: 'confirm', success: false, status: 'expired', latencyMs: Date.now() - started, raw: {start, ...last}};
+            }
+            // status === 'pending' → loop and long-poll again
+        }
+        return {capability: 'confirm', success: false, status: 'timed-out', latencyMs: Date.now() - started, raw: {start, ...last}};
+    }, []);
+
+    const run = useCallback(async (botUUID: string, chatID: string, capability: ChatCapability) => {
+        const k = key(chatID, capability);
+        setRun(k, true);
+        const started = Date.now();
+        try {
+            const r = capability === 'notify'
+                ? await runNotify(botUUID, chatID, started)
+                : await runConfirm(botUUID, chatID, started);
+            setResult(k, r);
+        } finally {
+            setRun(k, false);
+        }
+    }, [runNotify, runConfirm, setRun, setResult]);
+
+    const isRunning = useCallback((chatID: string, capability: ChatCapability) => Boolean(running[key(chatID, capability)]), [running]);
+    const getResult = useCallback((chatID: string, capability: ChatCapability) => results[key(chatID, capability)], [results]);
+    const clear = useCallback((chatID: string, capability: ChatCapability) => {
+        const k = key(chatID, capability);
+        setResults((prev) => {
+            const next = {...prev};
+            delete next[k];
+            return next;
+        });
+    }, []);
+
+    return {results, running, run, isRunning, getResult, clear};
+}
+
+export default useChatProbe;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2519,6 +2519,48 @@ export const handlers = [
         })
     }),
 
+    // Bot interaction API — GET /bots/:bot/chats and POST /bots/:bot/notify.
+    // Mirrors internal/server/module/notify/bot_api.go. Returns a couple of
+    // sample chats so the chat_id picker + copy is exercisable in mock mode.
+    http.get('/api/v1/bots/:bot/chats', () => {
+        return HttpResponse.json({
+            chats: [
+                { chat_id: 'telegram:123456789', platform: 'telegram', is_paired: true, updated_at: new Date().toISOString() },
+                { chat_id: 'telegram:987654321', platform: 'telegram', is_paired: false, updated_at: new Date().toISOString() },
+            ],
+        })
+    }),
+
+    http.post('/api/v1/bots/:bot/notify', async ({ request }) => {
+        const body = await request.json().catch(() => null) as any
+        if (!body || !body.chat_id || !body.body) {
+            return HttpResponse.json({ error: 'chat_id and body are required' }, { status: 400 })
+        }
+        return HttpResponse.json({ ok: true })
+    }),
+
+    // Bot interact API — POST /bots/:bot/interact + GET .../interact/:id.
+    // Mirrors internal/server/module/notify/bot_api.go. The wait handler
+    // answers on the first poll so the confirm probe resolves immediately in
+    // mock mode (real backend long-polls).
+    http.post('/api/v1/bots/:bot/interact', async ({ params, request }) => {
+        const body = await request.json().catch(() => null) as any
+        if (!body || !body.chat_id || !body.kind || !body.title) {
+            return HttpResponse.json({ error: 'chat_id, kind, and title are required' }, { status: 400 })
+        }
+        const request_id = 'mock-req-' + Math.random().toString(36).slice(2, 10)
+        return HttpResponse.json({
+            request_id,
+            wait_url: `/api/v1/bots/${params.bot}/interact/${request_id}`,
+            expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+        }, { status: 202 })
+    }),
+
+    http.get('/api/v1/bots/:bot/interact/:request_id', () => {
+        // Immediately answered with "allow" so the confirm probe succeeds.
+        return HttpResponse.json({ status: 'answered', decision: { selected: 'allow' } })
+    }),
+
     http.put('/api/v1/imbot-settings/:uuid', async ({ params, request }) => {
         const body = await request.json() as any
         return HttpResponse.json({ success: true, uuid: params.uuid, ...body })

--- a/frontend/src/pages/notify/NotifyPage.tsx
+++ b/frontend/src/pages/notify/NotifyPage.tsx
@@ -1,20 +1,27 @@
 import EmptyState from '@/components/EmptyState';
 import { PageLayout } from '@/components/PageLayout';
 import UnifiedCard from '@/components/UnifiedCard';
+import CollapsibleGuide from '@/components/remote-control/CollapsibleGuide';
+import NotifyGuide from '@/components/notify/NotifyGuide';
+import BotNotifyGroup from '@/components/notify/BotNotifyGroup';
+import { useBotToggle } from '@/hooks/useBotToggle';
 import { api } from '@/services/api';
-import { isNotifyMounted, notifyRoutes } from '@/types/bot';
 import type { BotSettings } from '@/types/bot';
-import { Box, Chip, CircularProgress, Stack, Tooltip, Typography } from '@mui/material';
+import { Stack } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-// NotifyPage is the Notify purpose — the twin of Remote, but lighter: notify
-// has no bot-config knobs of its own (see consumer_notify.go), it's mounted
-// implicitly by whichever outbound scenario routes (claude_code, ...) point
-// at a bot. That routing has no frontend surface yet, so this page is
-// read-only for now: it shows the real mount status and routes derived from
-// each bot's scenarios JSON, but attaching a NEW route needs a backend API +
-// swagger definition this pass didn't add (see .design/bot-arch.md §10).
+// NotifyPage opens up the authenticated bot-interaction API: it teaches how to
+// call it (top guide) and, per bot, shows the chats that bot can reach as an
+// always-expanded table — each chat row carries the concrete chat_id that
+// POST /api/v1/bots/:bot/notify needs in its body, with copy + send-test inline
+// (no extra click to reach the work surface). The bot's enabled switch is the
+// on/off for whether it can be driven.
+//
+// This page is no longer about "which scenario routes point at this bot" (that
+// was the old read-only framing, surfaced as a misleading "No routes" chip) —
+// it answers the operator's actual question: "what can I send to, right now?"
+// See .design/bot-interaction-api.md and ux-principles #1/#5/#11.
 const NotifyPage = () => {
     const { t } = useTranslation();
     const [bots, setBots] = useState<BotSettings[]>([]);
@@ -38,80 +45,52 @@ const NotifyPage = () => {
         loadBots();
     }, [loadBots]);
 
+    // Toggle is the shared control-plane action (POST /imbot-settings/:uuid/
+    // toggle): it starts/stops the bot's channel, which governs whether notify
+    // can reach it. On success we patch only the toggled bot in state rather
+    // than re-fetching the whole list, so sibling panels aren't churned. The
+    // hook owns the toast + in-flight UUID and is shared with the Bots pages.
+    const {toggle, isToggling} = useBotToggle({
+        onDone: (uuid) => setBots((prev) => prev.map((b) => (b.uuid === uuid ? {...b, enabled: !b.enabled} : b))),
+    });
+
+    const handleToggle = useCallback((uuid: string, enabled: boolean) => {
+        void toggle(uuid, enabled);
+    }, [toggle]);
+
     return (
-        <PageLayout loading={false}>
+        <PageLayout loading={loading}>
+            {/* Usage guide — embedded education (ux-principles #8). Collapsed by
+                default so the bots + chats (the work surface) are the visual
+                anchor; the guide is one click away whenever needed. */}
+            <CollapsibleGuide
+                platformName={t('notify.title', { defaultValue: 'IM Notify' })}
+                platformGuide={<NotifyGuide />}
+            />
             <UnifiedCard
                 title={t('notify.title', { defaultValue: 'IM Notify' })}
                 subtitle={t('notify.subtitle', {
-                    defaultValue: 'Which of your bots deliver scenario notifications and interactive prompts to chat.',
+                    defaultValue: 'Send one-way notifications to any chat your bots can reach.',
                 })}
                 size="full"
                 sx={{ mb: 2 }}
                 titleHeadingLevel={1}
             >
-                {loading ? (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                        <CircularProgress />
-                    </Box>
-                ) : bots.length === 0 ? (
+                {bots.length === 0 ? (
                     <EmptyState
                         title={t('notify.emptyTitle', { defaultValue: 'No bots connected yet' })}
-                        description={t('notify.emptyDescription', { defaultValue: 'Connect a bot on the Bots page first, then come back here to see what it notifies.' })}
+                        description={t('notify.emptyDescription', { defaultValue: 'Connect a bot on the Bots page first, then come back here to send it notifications.' })}
                     />
                 ) : (
-                    <Stack spacing={1}>
-                        {bots.map((bot) => {
-                            const mounted = isNotifyMounted(bot.scenarios);
-                            const routes = notifyRoutes(bot.scenarios);
-                            return (
-                                <Box
-                                    key={bot.uuid}
-                                    sx={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        flexWrap: 'wrap',
-                                        gap: 1.5,
-                                        px: 2,
-                                        py: 1.5,
-                                        border: '1px solid',
-                                        borderColor: 'divider',
-                                        borderRadius: 1.5,
-                                    }}
-                                >
-                                    {/* Fixed-width name column so the chips
-                                        align across rows — same as BotCard. */}
-                                    <Tooltip title={bot.name || bot.platform}>
-                                        <Typography noWrap variant="body2" sx={{ fontWeight: 600, flexShrink: 0, width: { xs: 96, sm: 150 } }}>
-                                            {bot.name || bot.platform}
-                                        </Typography>
-                                    </Tooltip>
-                                    <Chip label={bot.platform} size="small" />
-                                    <Chip
-                                        label={mounted
-                                            ? t('notify.mounted', { defaultValue: 'Notifying' })
-                                            : t('notify.notMounted', { defaultValue: 'No routes' })}
-                                        size="small"
-                                        variant={mounted ? 'filled' : 'outlined'}
-                                        color={mounted ? 'primary' : 'default'}
-                                    />
-                                    {routes.length > 0 && (
-                                        <Typography variant="caption" sx={{ color: 'text.secondary', fontFamily: 'monospace' }}>
-                                            {routes.map((r) => r.name).join(', ')}
-                                        </Typography>
-                                    )}
-                                    <Box sx={{ flexGrow: 1 }} />
-                                    <Tooltip title={t('notify.attachComingSoonHint', { defaultValue: 'Attaching a route from here is not wired up yet — routes are currently configured per scenario.' })}>
-                                        <span>
-                                            <Chip
-                                                label={t('notify.attachComingSoon', { defaultValue: '+ Attach a route (soon)' })}
-                                                size="small"
-                                                disabled
-                                            />
-                                        </span>
-                                    </Tooltip>
-                                </Box>
-                            );
-                        })}
+                    <Stack spacing={1.5}>
+                        {bots.map((bot) => (
+                            <BotNotifyGroup
+                                key={bot.uuid}
+                                bot={bot}
+                                onToggle={(uuid) => handleToggle(uuid, !(bot.enabled ?? true))}
+                                isToggling={isToggling(bot.uuid!)}
+                            />
+                        ))}
                     </Stack>
                 )}
             </UnifiedCard>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,6 +2,7 @@
 
 import TinglyService from "@/bindings";
 import type {components} from '@/client';
+import type {BotChat} from '@/types/bot';
 import {getApiBaseUrl} from '../utils/protocol';
 import {
     controlApi,
@@ -1513,6 +1514,124 @@ export const api = {
             return response.data;
         } catch (error: any) {
             return {success: false, error: error.message};
+        }
+    },
+
+    // List the chats a bot can reach (GET /api/v1/bots/:bot/chats).
+    // Placeholder until codegen regenerates the client SDK for the new
+    // bot-interaction endpoint — calls the raw path directly.
+    listBotChats: async (botUUID: string): Promise<{chats?: BotChat[]; running?: boolean; error?: string}> => {
+        try {
+            const base = await getApiBaseUrl();
+            const headers = await getAuthHeaders();
+            const response = await fetch(`${base}/api/v1/bots/${encodeURIComponent(botUUID)}/chats`, {
+                headers: {...headers, 'Content-Type': 'application/json'},
+            });
+            if (!response.ok) {
+                return {error: `failed to list chats (${response.status})`};
+            }
+            return await response.json();
+        } catch (error: any) {
+            return {error: error.message};
+        }
+    },
+
+    // Send a one-way notification to a running bot's chat
+    // (POST /api/v1/bots/:bot/notify). Placeholder until codegen regenerates
+    // the client SDK — calls the raw path directly. Field names mirror the
+    // backend notifyRequest: chat_id + body required, title/level optional.
+    notifyBot: async (
+        botUUID: string,
+        body: {chat_id: string; title?: string; body: string; level?: string},
+    ): Promise<{ok?: boolean; error?: string}> => {
+        try {
+            const base = await getApiBaseUrl();
+            const headers = await getAuthHeaders();
+            const response = await fetch(`${base}/api/v1/bots/${encodeURIComponent(botUUID)}/notify`, {
+                method: 'POST',
+                headers: {...headers, 'Content-Type': 'application/json'},
+                body: JSON.stringify(body),
+            });
+            if (!response.ok) {
+                const data = await response.json().catch(() => null);
+                return {error: data?.error || `notify failed (${response.status})`};
+            }
+            return await response.json();
+        } catch (error: any) {
+            return {error: error.message};
+        }
+    },
+
+    // Start an interactive prompt on a running bot's chat
+    // (POST /api/v1/bots/:bot/interact). Placeholder until codegen regenerates
+    // the client SDK. Returns request_id + wait_url + expires_at, or {error}.
+    // Field names mirror backend interactRequest: chat_id/kind/title required,
+    // options required for confirm/choose, timeout_seconds optional (≤30m).
+    interactBot: async (
+        botUUID: string,
+        body: {
+            chat_id: string;
+            kind: 'confirm' | 'choose' | 'ask';
+            title: string;
+            body?: string;
+            options?: Array<{value: string; label: string; style?: string}>;
+            timeout_seconds?: number;
+        },
+    ): Promise<{request_id?: string; wait_url?: string; expires_at?: string; error?: string}> => {
+        try {
+            const base = await getApiBaseUrl();
+            const headers = await getAuthHeaders();
+            const response = await fetch(`${base}/api/v1/bots/${encodeURIComponent(botUUID)}/interact`, {
+                method: 'POST',
+                headers: {...headers, 'Content-Type': 'application/json'},
+                body: JSON.stringify(body),
+            });
+            if (!response.ok) {
+                const data = await response.json().catch(() => null);
+                return {error: data?.error || `interact failed (${response.status})`};
+            }
+            return await response.json();
+        } catch (error: any) {
+            return {error: error.message};
+        }
+    },
+
+    // Long-poll for the reply to an interactive prompt
+    // (GET /api/v1/bots/:bot/interact/:request_id?timeout=Ns). Placeholder
+    // until codegen. Returns a normalized status:
+    //   'answered' | 'cancelled' (200, carries decision)
+    //   'timeout' | 'error'     (410, carries decision/reason)
+    //   'pending'               (504 — caller retries)
+    //   'expired'               (404)
+    //   'unavailable'           (503)
+    // Transport failures fold into {error} (mirrors runProbe.ts).
+    waitBotInteract: async (
+        botUUID: string,
+        requestID: string,
+        timeoutMs = 45000,
+    ): Promise<{status?: string; decision?: Record<string, unknown>; reason?: string; error?: string}> => {
+        try {
+            const base = await getApiBaseUrl();
+            const headers = await getAuthHeaders();
+            const response = await fetch(
+                `${base}/api/v1/bots/${encodeURIComponent(botUUID)}/interact/${encodeURIComponent(requestID)}?timeout=${Math.floor(timeoutMs / 1000)}s`,
+                {headers: {...headers, 'Content-Type': 'application/json'}},
+            );
+            const data = await response.json().catch(() => null);
+            if (response.status === 504) return {status: 'pending'};
+            if (response.status === 404) return {status: 'expired'};
+            if (response.status === 503) return {status: 'unavailable'};
+            if (!response.ok) {
+                return {error: data?.error || `wait failed (${response.status})`};
+            }
+            // 200 (answered/cancelled) or 410 (timeout/error) carry a status body.
+            return {
+                status: data?.status,
+                decision: data?.decision,
+                reason: data?.reason,
+            };
+        } catch (error: any) {
+            return {error: error.message};
         }
     },
 

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -130,7 +130,9 @@ const PLATFORM_DEFAULT_REQUIRE_PAIRING: Record<string, boolean> = {
 };
 
 // isPairingRequired reports whether a bot enforces TOFU pairing — either via an
-// explicit require_pairing flag, or the platform default.
+// explicit require_pairing flag, or the platform default. Used by BotTable and
+// PairingCodePanel, and by BotChatsButton to tailor the empty-chats hint (a
+// bot that requires pairing registers a chat only after the user pairs first).
 export function isPairingRequired(bot?: {require_pairing?: boolean; platform?: string} | null): boolean {
     if (typeof bot?.require_pairing === 'boolean') {
         return bot.require_pairing;
@@ -163,6 +165,19 @@ export interface NotifyRoute {
     chat_id?: string;
     events?: string[];
     enabled?: boolean;
+}
+
+// A chat a bot can reach, as returned by GET /api/v1/bots/:bot/chats. The
+// chat_id is the channel-native conversation identifier the notify/interact
+// API requires in its request body — surfacing it here (and in BotTable) is
+// what makes those endpoints usable from the UI. Placeholder until codegen.
+export interface BotChat {
+    chat_id: string;
+    platform?: string;
+    is_paired?: boolean;
+    is_whitelisted?: boolean;
+    project_path?: string;
+    updated_at?: string;
 }
 
 // notifyRoutes extracts a bot's outbound scenario bindings (every scenarios


### PR DESCRIPTION
## Why

The IM Notify page answered a question nobody asks — *"which scenario routes point at this bot?"* — and answered it read-only, with a `No routes` chip that read as broken and a disabled `+ Attach a route (soon)` affordance.

The question an operator actually has is: **"what can I send to, right now, and does it work?"** (ux-principles #1).

## What the page is now

Each bot is a panel over an **always-expanded** list of the chats it can reach — no extra click to get to the work surface. Every chat row carries:

- The concrete **`chat_id`**, monospaced and copyable — the literal value `/notify` and `/interact` need in their body (ux-principles #5, #11).
- Pairing state, bound project, last-activity — the context that tells you *which* chat this is.
- A **capability probe bench**: one-click `Notify` and `Confirm` buttons that drive the real endpoints end-to-end and render the verdict inline — latency, decision, collapsible raw payload — mirroring how the model-routing probe reports for providers (ux-principles #7: diagnostics traverse the real path).

`Choose` and `Ask` render **disabled with an explanatory tooltip**: their option/free-text threading into the IM keyboard is incomplete (`imchannel.ToAskRequest` doesn't copy `ix.Options`), and a trigger that cannot render its prompt is worse than a visibly gated one. `Custom` opens a free-form composer as the escape hatch.

A **collapsed guide** above the list teaches the API in place (ux-principles #8): auth, a copy-pasteable `curl` against the operator's own origin, the request body, and where the `chat_id` comes from.

The bot's **enabled switch** sits in the panel header, because "can this bot be driven at all" is the same question the page answers. It shares `useBotToggle` with the Bots pages.

The **bots table** gains the same chats popover in its Actions cell, so the `chat_id` is reachable from the resource view without navigating here first.

## Bug fixed along the way

`NotifyPage` passed the bot's **pre-toggle** state to `useBotToggle`, so disabling a bot toasted "Bot enabled" and vice versa. It now passes the state being moved to, matching how the bots table calls it.

## Codegen

`services/api.ts` carries hand-written wrappers for `/chats`, `/notify`, `/interact` and the interact long-poll. These are **placeholders until `task codegen` regenerates the client SDK** for the new endpoints, per the frontend convention in `CLAUDE.md`. Mock handlers mirror the backend so the whole surface is exercisable in mock mode offline.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` — 34 passed
- `pnpm lint` — no new warnings