### PR TITLE
fix(protocol): use fc-prefixed item IDs for Responses function calls

### DIFF
--- a/internal/protocol/stream/openai_chat_to_responses_converter.go
+++ b/internal/protocol/stream/openai_chat_to_responses_converter.go
@@ -143,10 +143,15 @@ func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChun
 		openaiIndex := int(toolCall.Index)
 
 		if _, exists := c.pendingToolCalls[openaiIndex]; !exists {
+			// A Responses function-call item has two distinct identifiers:
+			//   - id: the Responses output item ID (must use the fc_ prefix)
+			//   - call_id: the correlation ID used by function_call_output
+			//
+			// Chat Completions exposes only tool_call.id (normally call_...).
+			// Preserve it as call_id, but never reuse it as the Responses item ID:
+			// Codex persists output item IDs and a later native Responses request
+			// rejects an item whose id starts with call_ instead of fc_.
 			itemID := fmt.Sprintf("fc_%d_%d", time.Now().Unix(), openaiIndex)
-			if toolCall.ID != "" {
-				itemID = truncateToolCallID(toolCall.ID)
-			}
 
 			toolOutputIndex := c.outputIndex
 			c.outputIndex++

--- a/internal/protocol/stream/openai_chat_to_responses_golden_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_golden_test.go
@@ -147,6 +147,17 @@ func TestChatToResponsesConverter_GoldenSequence(t *testing.T) {
 	assert.Equal(t, "get_weather", argsDone.Name)
 	assert.Equal(t, `{"city":"Paris"}`, argsDone.Arguments)
 
+	// Responses item IDs and tool-call correlation IDs are different fields.
+	// The Chat tool call ID remains call_id, while the synthesized item ID must
+	// be fc_-prefixed so Codex can replay it to a native Responses provider.
+	fnAdded := got[6].(wire.ResponsesOutputItemAddedEvent)
+	assert.True(t, strings.HasPrefix(fnAdded.Item.ID, "fc_"))
+	assert.NotEqual(t, "call_1", fnAdded.Item.ID)
+	assert.Equal(t, "call_1", fnAdded.Item.CallID)
+	assert.Equal(t, fnAdded.Item.ID, got[7].(wire.ResponsesFunctionCallArgumentsDeltaEvent).ItemID)
+	assert.Equal(t, fnAdded.Item.ID, got[8].(wire.ResponsesFunctionCallArgumentsDeltaEvent).ItemID)
+	assert.Equal(t, fnAdded.Item.ID, argsDone.ItemID)
+
 	completed := got[14].(wire.ResponsesCompletedEvent)
 	assert.Equal(t, "completed", completed.Response.Status)
 	require.Len(t, completed.Response.Output, 2, "final output carries text + tool-call items")


### PR DESCRIPTION
## Summary
Chat Completions exposes one tool-call ID (`call_...`), while Responses uses separate fields for the function-call item ID (`id`, `fc_...`) and the tool-call correlation ID (`call_id`). The converter replaced the generated `fc_...` item ID with `call_...`, so native Responses endpoints rejected the item when conversation history was replayed.

This change keeps `fc_...` as the item `id`, preserves `call_...` as `call_id`, and adds regression coverage for argument-event `item_id` references.

## Log

```
base_url="https://chatgpt.com/backend-api", returning HTTP 400: Invalid 'input[67].id': 'call_...'. Expected an ID that begins with 'fc'.
```

## Tests

```text
go test ./internal/protocol/stream -count=1
go test ./internal/protocol/request ./internal/protocol/nonstream -count=1
```
