### PR TITLE
fix(notify): auth-gate hook path, add route write-path, run codegen

### DIFF
--- a/.design/bot-arch.md
+++ b/.design/bot-arch.md
@@ -441,16 +441,41 @@ defaults to `true`) so the platform selector is live; Remote keeps opening
 it locked to whichever platform tab is active, exactly as before. `?add=1`
 on `/bots/overview` still deep-links into the create flow.
 
-**Notify's write-path gap.** `notifyConsumer.Mounted` is implicit — at
-least one outbound scenario binding (`claude_code`, …) present and not
-disabled (§4) — not a stored boolean like `remote_agent`. There is no
-existing UI or API for creating/editing those route rows (they're
-currently CLI/config-only), so `NotifyPage` reads real status
-(`isNotifyMounted` / `notifyRoutes` in `types/bot.ts`, parsed client-side
-from the same `scenarios` JSON the backend already returns) but the
-"attach a route" action is a disabled placeholder. Making that real needs
-a backend endpoint + swagger definition for outbound route CRUD — not done
-in this pass; do that before promising notify configuration in-product.
+**Notify's write-path gap — closed 2026-07-28.** `notifyConsumer.Mounted` is
+implicit — at least one outbound scenario binding (`claude_code`, …) present
+and not disabled (§4) — not a stored boolean like `remote_agent`. There was no
+UI or API for creating/editing those route rows (CLI/config-only), so
+`NotifyPage` could read real status (`isNotifyMounted` / `notifyRoutes` in
+`types/bot.ts`) but not act on it.
+
+Rather than a new route family, the write path reuses the existing
+`PUT/POST /api/v1/imbot-settings/:uuid` `remote_agent`-mount-toggle machinery
+(`internal/server/module/imbot`), since it's the same shape of problem — flip
+a row in the bot's `Scenarios` JSON, cascade `Enabled` if the result is
+active — one field on `CreateRequest`/`UpdateRequest`:
+
+```
+"notify_route": {
+  "chat_id": "dm:ops",           // required unless remove:true
+  "name": "claude_code",         // optional — the only real plugin today
+  "events": ["Stop"],            // optional — empty = all events
+  "enabled": true,               // optional — nil on create = on
+  "on_timeout": "deny",          // optional — claudecode.PermissionPolicy
+  "total_budget_seconds": 120,   // optional
+  "remove": false                // true → delete the route instead
+}
+```
+
+`remote/binding` gained the general-purpose primitives this needed —
+`UpsertBinding` / `RemoveBinding` (raw-row read-modify-write, preserving
+every other row's unknown fields verbatim, same technique as
+`SetScenarioEnabled`) and `ListOutboundBindings` (typed read of every
+non-`remote_agent` row) — so the write path and `notifyRoutes()`'s read path
+share one source of truth. `internal/server/module/imbot.applyNotifyRoute`
+is the thin HTTP-facing wrapper both `CreateSettings` and `UpdateSettings`
+call; activating a route cascades `Enabled = true` exactly like the
+`remote_agent` toggle does, so "attach a route" alone is enough to bring a
+notify-only bot up — no separate "and now enable the bot" step.
 
 **Old per-platform Bots pages (`/bots/telegram`, `/bots/weixin`, …) stay
 live but out of nav** — same "hidden, not removed" precedent as before,

--- a/.design/bot-interaction-api.md
+++ b/.design/bot-interaction-api.md
@@ -1,6 +1,6 @@
 # Bot Interaction Interface — auth + open two-kind API (notify / interactive)
 
-> Status: **spec** · Date: 2026-07-25
+> Status: **PR1 + PR2 shipped** · Date: 2026-07-25 (PR2 auth follow-up: 2026-07-28)
 > Builds on: [`.design/bot-arch.md`](bot-arch.md) (resource → channel → consumers),
 > [`.design/security.md`](security.md) (random default tokens, no silent fallback).
 > Scope: the *inbound* HTTP surface that lets external callers drive a bot's
@@ -327,9 +327,31 @@ modes behind one entrypoint — exactly the picker we're avoiding.
 
 1. **PR 1 (this spec):** `/api/v1/bots/*` general API, registered on the
    existing `apiV1` group (inheriting `getUserAuthMiddleware`). Claude Code
-   path untouched → zero behavior change for existing users.
+   path untouched → zero behavior change for existing users. ✅ shipped.
 2. **PR 2:** gate `/tingly/:scenario/*` behind `getUserAuthMiddleware()`; update
    the Claude Code hook helper to send the token. Document the requirement.
+   ✅ shipped 2026-07-28: `notifymodule.RegisterRoutes` now takes an
+   `authMW gin.HandlerFunc` param (`internal/server/module/notify/routes.go`),
+   wired to `s.getUserAuthMiddleware()` in `server_control.go`. Both hook
+   scripts (`internal/script/tingly-notify.sh`, `tingly-im-hook.sh`) read a new
+   `TINGLY_HOOK_TOKEN` env var and send it as `Authorization: Bearer …`;
+   `ApplyNotifyHooks`/`ApplyImHooks` (`internal/server/config/apply_config.go`)
+   now take a `token string` param and merge `TINGLY_HOOK_TOKEN` into
+   `settings.json`'s `env` block via `mergeHookToken`, the same block Claude
+   Code already merges into every hook subprocess's environment.
+   **Caveat found while shipping this:** those two `Apply*Hooks` functions —
+   and `InstallNotifyScript`/`InstallIMHookScript`, which write the scripts
+   themselves to `~/.claude/` — have had **zero callers** anywhere in the
+   product (no HTTP endpoint, no CLI command, no frontend button) since they
+   were introduced; today the only way to actually get either hook installed
+   is to hand-copy the JSON snippet in the script's header comment into
+   `settings.json`. That's a pre-existing, separate gap from the auth hole
+   this PR closes — auth now works for whoever *has* installed a hook, but
+   nothing in the product currently helps an operator install one. Left
+   unfixed here pending a decision on where that trigger should live (a CLI
+   command, since these scripts always run on the same machine as the
+   Claude Code process, vs. a UI toggle in the existing "connect Claude Code"
+   flow next to `InstallStatusLine`).
 
 No third step is committed. A scoped per-bot token for third-party integrations
 is **not** pre-built; if it is ever needed it arrives as its own proposal, and

--- a/frontend/src/components/notify/BotNotifyGroup.tsx
+++ b/frontend/src/components/notify/BotNotifyGroup.tsx
@@ -1,7 +1,7 @@
-import {ContentCopy as CopyIcon, Edit as CustomIcon, Close as CloseIcon, Code as CodeIcon, Refresh as RefreshIcon} from '@/components/icons';
+import {ContentCopy as CopyIcon, Edit as CustomIcon, Close as CloseIcon, Code as CodeIcon, Refresh as RefreshIcon, Bell as BellIcon} from '@/components/icons';
 import {api} from '@/services/api';
 import {notify} from '@/utils/notify';
-import {isPairingRequired} from '@/types/bot';
+import {isPairingRequired, claudeCodeRoute} from '@/types/bot';
 import type {BotChat, BotSettings} from '@/types/bot';
 import {fontMono} from '@/theme/fonts';
 import NotifyTestDialog from '@/components/notify/NotifyTestDialog';
@@ -41,6 +41,10 @@ export interface BotNotifyGroupProps {
     bot: BotSettings;
     onToggle: (uuid: string) => void;
     isToggling?: boolean;
+    // Called after a route mutation succeeds, with the bot's fresh scenarios
+    // JSON, so the parent page's bot list stays in sync (mirrors onToggle's
+    // "patch just this bot" pattern rather than a full re-fetch).
+    onRouteChange?: (uuid: string, scenarios: string) => void;
 }
 
 // Em-dash placeholder for empty status/project/updated meta — shared styling.
@@ -109,7 +113,7 @@ const ProbeResultLine: React.FC<{result: ChatProbeResult; onDismiss: () => void}
 
 
 
-const BotNotifyGroup: React.FC<BotNotifyGroupProps> = ({bot, onToggle, isToggling}) => {
+const BotNotifyGroup: React.FC<BotNotifyGroupProps> = ({bot, onToggle, isToggling, onRouteChange}) => {
     const {t} = useTranslation();
     const enabled = bot.enabled ?? true;
 
@@ -117,6 +121,12 @@ const BotNotifyGroup: React.FC<BotNotifyGroupProps> = ({bot, onToggle, isTogglin
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [testChatID, setTestChatID] = useState<string | null>(null);
+    // Chat ID currently mid-route-mutation, so only that row's button shows a
+    // spinner (routing is a single-flight action — one route per bot today).
+    const [routingChatID, setRoutingChatID] = useState<string | null>(null);
+
+    const route = claudeCodeRoute(bot.scenarios);
+    const routedChatID = route?.enabled !== false ? route?.chat_id : undefined;
 
     const loadChats = useCallback(async () => {
         if (!bot.uuid) return;
@@ -152,6 +162,30 @@ const BotNotifyGroup: React.FC<BotNotifyGroupProps> = ({bot, onToggle, isTogglin
 
     const openTest = useCallback((chatID: string) => setTestChatID(chatID), []);
     const closeTest = useCallback(() => setTestChatID(null), []);
+
+    // Route Claude Code's /tingly/claude_code/notify hook to this chat (or
+    // stop routing there). One route per bot today — claude_code is the only
+    // scenario plugin registered — so "route here" on a different chat moves
+    // it rather than adding a second route. See .design/bot-arch.md §10.
+    const handleSetRoute = useCallback(async (chatID: string) => {
+        if (!bot.uuid) return;
+        setRoutingChatID(chatID);
+        const isCurrentlyRouted = routedChatID === chatID;
+        const result = isCurrentlyRouted
+            ? await api.setNotifyRoute(bot.uuid, {remove: true})
+            : await api.setNotifyRoute(bot.uuid, {chat_id: chatID});
+        setRoutingChatID(null);
+        if (result.error) {
+            notify.error(result.error);
+            return;
+        }
+        if (typeof result.settings?.scenarios === 'string') {
+            onRouteChange?.(bot.uuid, result.settings.scenarios);
+        }
+        notify.success(isCurrentlyRouted
+            ? t('notify.group.routeRemoved', {defaultValue: 'Claude Code notifications no longer route here'})
+            : t('notify.group.routeSet', {defaultValue: 'Claude Code notifications now route to this chat'}));
+    }, [bot.uuid, routedChatID, onRouteChange, t]);
 
     // The capability probe runner — owns firing notify/confirm against a chat
     // and the per-(chat,capability) results. Lives at the group level so a
@@ -301,6 +335,41 @@ const BotNotifyGroup: React.FC<BotNotifyGroupProps> = ({bot, onToggle, isTogglin
                                             </Typography>
                                         )}
                                         <Box sx={{flexGrow: 1}} />
+                                        {/* Claude Code hook route — "routed here" chip on whichever
+                                            chat currently gets /tingly/claude_code/notify traffic, a
+                                            one-click button to route it here otherwise. One route per
+                                            bot today (claude_code is the only scenario plugin), so
+                                            picking a different chat moves it. See bot-arch.md §10. */}
+                                        {routedChatID === chat.chat_id ? (
+                                            <Tooltip title={t('notify.group.routedHint', {defaultValue: 'Claude Code notifications route here — click to stop'})}>
+                                                <Chip
+                                                    icon={<BellIcon fontSize="small" />}
+                                                    label={t('notify.group.routed', {defaultValue: 'Routed'})}
+                                                    size="small"
+                                                    color="primary"
+                                                    variant="outlined"
+                                                    onClick={() => handleSetRoute(chat.chat_id)}
+                                                    onDelete={() => handleSetRoute(chat.chat_id)}
+                                                    deleteIcon={routingChatID === chat.chat_id ? <CircularProgress size={12} /> : <CloseIcon fontSize="small" />}
+                                                    disabled={routingChatID !== null}
+                                                />
+                                            </Tooltip>
+                                        ) : (
+                                            <Tooltip title={t('notify.group.routeHint', {defaultValue: 'Route Claude Code hook notifications to this chat'})}>
+                                                <span>
+                                                    <Button
+                                                        size="small"
+                                                        variant="text"
+                                                        startIcon={routingChatID === chat.chat_id ? <CircularProgress size={14} /> : <BellIcon fontSize="small" />}
+                                                        onClick={() => handleSetRoute(chat.chat_id)}
+                                                        disabled={routingChatID !== null}
+                                                        sx={{textTransform: 'none'}}
+                                                    >
+                                                        {t('notify.group.route', {defaultValue: 'Route here'})}
+                                                    </Button>
+                                                </span>
+                                            </Tooltip>
+                                        )}
                                         <Tooltip title={t('notify.group.copyChatId', {defaultValue: 'Copy Chat ID'})}>
                                             <IconButton size="small" onClick={() => handleCopy(chat.chat_id)}>
                                                 <CopyIcon fontSize="small" />

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2443,6 +2443,10 @@ export const handlers = [
                     smartguide_provider: 'mock-provider-anthropic',
                     smartguide_model: 'claude-sonnet-5',
                     chat_id_lock: '123456789',
+                    // Notify route already active on the first mock chat, so the IM
+                    // Notify page shows both states: a "Routed" chip here and a
+                    // "Route here" button on the sibling chat.
+                    scenarios: JSON.stringify([{ name: 'claude_code', chat_id: 'telegram:123456789', enabled: true }]),
                     created_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
                     auth: { token: 'mock-bot-token-****' },
                 },
@@ -2561,9 +2565,21 @@ export const handlers = [
         return HttpResponse.json({ status: 'answered', decision: { selected: 'allow' } })
     }),
 
+    // Mirrors the real SettingsResponse{success, settings} shape (not a flat
+    // echo) so notify_route round-trips through settings.scenarios the same
+    // way the real PUT /imbot-settings/:uuid does — BotNotifyGroup's "Route
+    // here" action reads result.settings.scenarios to flip the chip.
     http.put('/api/v1/imbot-settings/:uuid', async ({ params, request }) => {
         const body = await request.json() as any
-        return HttpResponse.json({ success: true, uuid: params.uuid, ...body })
+        const uuid = params.uuid as string
+        let scenarios = ''
+        if (body.notify_route) {
+            const nr = body.notify_route
+            scenarios = nr.remove ? '[]' : JSON.stringify([
+                { name: nr.name || 'claude_code', chat_id: nr.chat_id, enabled: nr.enabled !== false },
+            ])
+        }
+        return HttpResponse.json({ success: true, settings: { uuid, ...body, scenarios } })
     }),
 
     http.post('/api/v1/imbot-settings', async ({ request }) => {

--- a/frontend/src/pages/notify/NotifyPage.tsx
+++ b/frontend/src/pages/notify/NotifyPage.tsx
@@ -58,6 +58,12 @@ const NotifyPage = () => {
         void toggle(uuid, enabled);
     }, [toggle]);
 
+    // Patch just the mutated bot's scenarios after a route change (create/
+    // move/remove) — same "patch, don't re-fetch" shape as toggle above.
+    const handleRouteChange = useCallback((uuid: string, scenarios: string) => {
+        setBots((prev) => prev.map((b) => (b.uuid === uuid ? {...b, scenarios} : b)));
+    }, []);
+
     return (
         <PageLayout loading={loading}>
             {/* Usage guide — embedded education (ux-principles #8). Collapsed by
@@ -89,6 +95,7 @@ const NotifyPage = () => {
                                 bot={bot}
                                 onToggle={(uuid) => handleToggle(uuid, !(bot.enabled ?? true))}
                                 isToggling={isToggling(bot.uuid!)}
+                                onRouteChange={handleRouteChange}
                             />
                         ))}
                     </Stack>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
 
 import TinglyService from "@/bindings";
 import type {components} from '@/client';
-import type {BotChat} from '@/types/bot';
+import type {BotChat, BotSettings} from '@/types/bot';
 import {getApiBaseUrl} from '../utils/protocol';
 import {
     controlApi,
@@ -1518,55 +1518,57 @@ export const api = {
     },
 
     // List the chats a bot can reach (GET /api/v1/bots/:bot/chats).
-    // Placeholder until codegen regenerates the client SDK for the new
-    // bot-interaction endpoint — calls the raw path directly.
     listBotChats: async (botUUID: string): Promise<{chats?: BotChat[]; running?: boolean; error?: string}> => {
         try {
-            const base = await getApiBaseUrl();
+            const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await fetch(`${base}/api/v1/bots/${encodeURIComponent(botUUID)}/chats`, {
-                headers: {...headers, 'Content-Type': 'application/json'},
+            const response = await client.GET('/api/v1/bots/{bot}/chats', {
+                headers,
+                params: {path: {bot: botUUID}},
             });
-            if (!response.ok) {
-                return {error: `failed to list chats (${response.status})`};
+            if (response.error) {
+                return {error: `failed to list chats (${response.response.status})`};
             }
-            return await response.json();
+            return {chats: response.data?.chats, running: response.data?.running};
         } catch (error: any) {
             return {error: error.message};
         }
     },
 
     // Send a one-way notification to a running bot's chat
-    // (POST /api/v1/bots/:bot/notify). Placeholder until codegen regenerates
-    // the client SDK — calls the raw path directly. Field names mirror the
-    // backend notifyRequest: chat_id + body required, title/level optional.
+    // (POST /api/v1/bots/:bot/notify). Field names mirror the backend
+    // notifyRequest: chat_id + body required, title/level optional.
     notifyBot: async (
         botUUID: string,
         body: {chat_id: string; title?: string; body: string; level?: string},
     ): Promise<{ok?: boolean; error?: string}> => {
         try {
-            const base = await getApiBaseUrl();
+            const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await fetch(`${base}/api/v1/bots/${encodeURIComponent(botUUID)}/notify`, {
-                method: 'POST',
-                headers: {...headers, 'Content-Type': 'application/json'},
-                body: JSON.stringify(body),
+            const response = await client.POST('/api/v1/bots/{bot}/notify', {
+                headers,
+                params: {path: {bot: botUUID}},
+                body,
             });
-            if (!response.ok) {
-                const data = await response.json().catch(() => null);
-                return {error: data?.error || `notify failed (${response.status})`};
+            if (response.error) {
+                const data = response.error as {error?: string} | undefined;
+                return {error: data?.error || `notify failed (${response.response.status})`};
             }
-            return await response.json();
+            return {ok: response.data?.ok};
         } catch (error: any) {
             return {error: error.message};
         }
     },
 
     // Start an interactive prompt on a running bot's chat
-    // (POST /api/v1/bots/:bot/interact). Placeholder until codegen regenerates
-    // the client SDK. Returns request_id + wait_url + expires_at, or {error}.
-    // Field names mirror backend interactRequest: chat_id/kind/title required,
-    // options required for confirm/choose, timeout_seconds optional (≤30m).
+    // (POST /api/v1/bots/:bot/interact). Returns request_id + wait_url +
+    // expires_at, or {error}. Field names mirror backend interactRequest:
+    // chat_id/kind/title required, options required for confirm/choose,
+    // timeout_seconds optional (≤30m). The endpoint actually responds 202
+    // (not 200 — see bot_routes.go's WithDescription note on this codegen
+    // tool's generic-200 limitation), which openapi-fetch treats as an
+    // "error" status even though the body is the normal success shape —
+    // BotInteractResponse either way, so we read whichever bucket has it.
     interactBot: async (
         botUUID: string,
         body: {
@@ -1579,50 +1581,63 @@ export const api = {
         },
     ): Promise<{request_id?: string; wait_url?: string; expires_at?: string; error?: string}> => {
         try {
-            const base = await getApiBaseUrl();
+            const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await fetch(`${base}/api/v1/bots/${encodeURIComponent(botUUID)}/interact`, {
-                method: 'POST',
-                headers: {...headers, 'Content-Type': 'application/json'},
-                body: JSON.stringify(body),
+            const response = await client.POST('/api/v1/bots/{bot}/interact', {
+                headers,
+                params: {path: {bot: botUUID}},
+                body,
             });
-            if (!response.ok) {
-                const data = await response.json().catch(() => null);
-                return {error: data?.error || `interact failed (${response.status})`};
+            if (response.response.status === 202) {
+                const data = (response.data ?? response.error) as
+                    | {request_id?: string; wait_url?: string; expires_at?: string}
+                    | undefined;
+                return {request_id: data?.request_id, wait_url: data?.wait_url, expires_at: data?.expires_at};
             }
-            return await response.json();
+            const data = response.error as {error?: string} | undefined;
+            return {error: data?.error || `interact failed (${response.response.status})`};
         } catch (error: any) {
             return {error: error.message};
         }
     },
 
     // Long-poll for the reply to an interactive prompt
-    // (GET /api/v1/bots/:bot/interact/:request_id?timeout=Ns). Placeholder
-    // until codegen. Returns a normalized status:
+    // (GET /api/v1/bots/:bot/interact/:request_id?timeout=Ns). Returns a
+    // normalized status:
     //   'answered' | 'cancelled' (200, carries decision)
     //   'timeout' | 'error'     (410, carries decision/reason)
     //   'pending'               (504 — caller retries)
     //   'expired'               (404)
     //   'unavailable'           (503)
-    // Transport failures fold into {error} (mirrors runProbe.ts).
+    // Transport failures fold into {error} (mirrors runProbe.ts). Branches
+    // on the raw HTTP status (openapi-fetch only knows 200 as "success" per
+    // this codegen tool's limitation — see bot_routes.go) rather than
+    // response.data/.error, since 410/answered-vs-timeout both carry the
+    // same BotWaitResponse body shape.
     waitBotInteract: async (
         botUUID: string,
         requestID: string,
         timeoutMs = 45000,
     ): Promise<{status?: string; decision?: Record<string, unknown>; reason?: string; error?: string}> => {
         try {
-            const base = await getApiBaseUrl();
+            const client = await getClient();
             const headers = await getAuthHeaders();
-            const response = await fetch(
-                `${base}/api/v1/bots/${encodeURIComponent(botUUID)}/interact/${encodeURIComponent(requestID)}?timeout=${Math.floor(timeoutMs / 1000)}s`,
-                {headers: {...headers, 'Content-Type': 'application/json'}},
-            );
-            const data = await response.json().catch(() => null);
-            if (response.status === 504) return {status: 'pending'};
-            if (response.status === 404) return {status: 'expired'};
-            if (response.status === 503) return {status: 'unavailable'};
-            if (!response.ok) {
-                return {error: data?.error || `wait failed (${response.status})`};
+            const response = await client.GET('/api/v1/bots/{bot}/interact/{request_id}', {
+                headers,
+                params: {
+                    path: {bot: botUUID, request_id: requestID},
+                    query: {timeout: `${Math.floor(timeoutMs / 1000)}s`},
+                },
+            });
+            const status = response.response.status;
+            if (status === 504) return {status: 'pending'};
+            if (status === 404) return {status: 'expired'};
+            if (status === 503) return {status: 'unavailable'};
+            const data = (response.data ?? response.error) as
+                | {status?: string; decision?: Record<string, unknown>; reason?: string; error?: string}
+                | undefined;
+            if (status !== 200 && status !== 410) {
+                return {error: data?.error || `wait failed (${status})`};
             }
             // 200 (answered/cancelled) or 410 (timeout/error) carry a status body.
             return {
@@ -1693,6 +1708,15 @@ export const api = {
         smartguide_provider?: string;
         smartguide_model?: string;
         remote_agent?: boolean;
+        notify_route?: {
+            name?: string;
+            chat_id?: string;
+            events?: string[];
+            enabled?: boolean;
+            on_timeout?: string;
+            total_budget_seconds?: number;
+            remove?: boolean;
+        };
     }): Promise<any> => {
         try {
             const client = await getClient();
@@ -1709,6 +1733,18 @@ export const api = {
             }
             return {success: false, error: error.message};
         }
+    },
+
+    // Create, edit, or remove a bot's outbound notify route — the chat a
+    // Claude Code hook notification/prompt delivers through (see
+    // .design/bot-arch.md §10, internal/server/module/imbot.NotifyRouteRequest).
+    // Thin wrapper over updateImBotSetting so BotNotifyGroup's per-chat "route
+    // notifications here" action doesn't need to know the settings PUT shape.
+    setNotifyRoute: async (
+        uuid: string,
+        route: {chat_id: string; enabled?: boolean; on_timeout?: string; total_budget_seconds?: number} | {remove: true},
+    ): Promise<{success?: boolean; settings?: BotSettings; error?: string}> => {
+        return api.updateImBotSetting(uuid, {notify_route: route});
     },
 
     deleteImBotSetting: async (uuid: string): Promise<any> => {

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -156,10 +156,17 @@ export function isRemoteAgentMounted(scenarios?: string): boolean {
     }
 }
 
+// CLAUDE_CODE_ROUTE is the only outbound scenario plugin registered today
+// (remote/scenario/builtin/claudecode) — the route a Claude Code hook
+// notification/prompt delivers through. Mirrors the backend's default in
+// applyNotifyRoute (internal/server/module/imbot).
+export const CLAUDE_CODE_ROUTE = 'claude_code';
+
 // A route row in a bot's scenarios JSON: a real outbound scenario binding
-// (e.g. "claude_code") rather than the "remote_agent" mount row. Read-only
-// mirror of the Go struct in remote/binding — there is no write path for
-// these from the frontend yet (see NotifyPage).
+// (e.g. "claude_code") rather than the "remote_agent" mount row. Mirrors the
+// Go struct in remote/binding. Written via api.setNotifyRoute
+// (POST/PUT .../imbot-settings/:uuid with a notify_route field — see
+// internal/server/module/imbot.NotifyRouteRequest).
 export interface NotifyRoute {
     name: string;
     chat_id?: string;
@@ -199,6 +206,14 @@ export function notifyRoutes(scenarios?: string): NotifyRoute[] {
 // remote_agent, notify fails CLOSED — no bindings means not mounted.
 export function isNotifyMounted(scenarios?: string): boolean {
     return notifyRoutes(scenarios).some((r) => r.enabled !== false);
+}
+
+// claudeCodeRoute returns the bot's "claude_code" route (chat_id + active
+// state), if one exists. Since claude_code is the only outbound scenario
+// plugin registered today, a bot has at most one real route — this is what
+// BotNotifyGroup checks per chat row to show "routed here" / offer to route.
+export function claudeCodeRoute(scenarios?: string): NotifyRoute | undefined {
+    return notifyRoutes(scenarios).find((r) => r.name === CLAUDE_CODE_ROUTE);
 }
 
 // countBotsByPlatform tallies active/total bots per platform — feeds the

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
-	github.com/larksuite/oapi-sdk-go/v3 v3.9.7
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/modelcontextprotocol/go-sdk v1.6.1
@@ -132,6 +131,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/larksuite/oapi-sdk-go/v3 v3.9.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/internal/script/tingly-im-hook.sh
+++ b/internal/script/tingly-im-hook.sh
@@ -11,6 +11,7 @@
 #
 # Usage (from Claude Code settings.json hooks):
 #   {
+#     "env": { "TINGLY_HOOK_TOKEN": "<your tingly-box user token>" },
 #     "hooks": {
 #       "PreToolUse": [{
 #         "matcher": "",
@@ -22,6 +23,13 @@
 #       }]
 #     }
 #   }
+#
+# TINGLY_HOOK_TOKEN is the same user token used to sign into the tingly-box
+# web UI (Settings > user token) — /tingly/:scenario/{notify,wait} requires
+# it. Without it the server responds 401 to the initial POST, which this
+# script treats like any other unexpected error: log and let Claude proceed
+# unblocked (see the case statement below) rather than hang a tool call on a
+# misconfigured token.
 
 set -u
 
@@ -31,6 +39,12 @@ TINGLY_API_URL="${TINGLY_API_URL:-http://localhost:12580}"
 TINGLY_SCENARIO="${TINGLY_SCENARIO:-claude_code}"
 TINGLY_HOOK_POLL_SECONDS="${TINGLY_HOOK_POLL_SECONDS:-45}"
 TINGLY_HOOK_TOTAL_BUDGET_SECONDS="${TINGLY_HOOK_TOTAL_BUDGET_SECONDS:-300}"
+TINGLY_HOOK_TOKEN="${TINGLY_HOOK_TOKEN:-}"
+
+AUTH_HEADER=()
+if [ -n "$TINGLY_HOOK_TOKEN" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer ${TINGLY_HOOK_TOKEN}")
+fi
 
 # json_field <key> < json   -> echoes the string value of the top-level
 # key (or empty if missing). Avoids a hard jq dependency.
@@ -64,6 +78,7 @@ printf '%s' "$CC_INPUT" >"$POST_BODY"
 RESP=$(curl -sS -o - -w '\n%{http_code}' \
   -X POST \
   -H 'Content-Type: application/json' \
+  "${AUTH_HEADER[@]}" \
   --data-binary "@$POST_BODY" \
   "${TINGLY_API_URL}/tingly/${TINGLY_SCENARIO}/notify" 2>/dev/null) || {
   # Network failure: do not block Claude.
@@ -80,6 +95,12 @@ case "$HTTP_CODE" in
     ;;
   200)
     # Push delivered (no IM binding configured); continue without blocking.
+    exit 0
+    ;;
+  401)
+    # Missing/invalid TINGLY_HOOK_TOKEN; a clear message beats a generic
+    # "HTTP 401" for anyone diagnosing why prompts stopped arriving.
+    printf 'tingly-im-hook: 401 unauthorized — set TINGLY_HOOK_TOKEN in settings.json env to your tingly-box user token\n' >&2
     exit 0
     ;;
   404)

--- a/internal/script/tingly-notify.sh
+++ b/internal/script/tingly-notify.sh
@@ -13,6 +13,7 @@
 #
 # Usage (from Claude Code settings.json hooks):
 #   {
+#     "env": { "TINGLY_HOOK_TOKEN": "<your tingly-box user token>" },
 #     "hooks": {
 #       "Stop": [{
 #         "matcher": "",
@@ -24,6 +25,10 @@
 #       }]
 #     }
 #   }
+#
+# TINGLY_HOOK_TOKEN is the same user token used to sign into the tingly-box
+# web UI (Settings > user token) — /tingly/:scenario/notify requires it.
+# Without it the server responds 401 and this script exits quietly.
 
 set -u
 
@@ -31,12 +36,19 @@ CC_INPUT=$(cat)
 
 TINGLY_API_URL="${TINGLY_API_URL:-http://localhost:12580}"
 TINGLY_SCENARIO="${TINGLY_SCENARIO:-claude_code}"
+TINGLY_HOOK_TOKEN="${TINGLY_HOOK_TOKEN:-}"
+
+AUTH_HEADER=()
+if [ -n "$TINGLY_HOOK_TOKEN" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer ${TINGLY_HOOK_TOKEN}")
+fi
 
 # Forward the full Claude Code hook input to Tingly Box.
 # This is fire-and-forget: we don't care about the response.
 # The server will deliver desktop notification or forward to IM if configured.
 echo "$CC_INPUT" | curl -s -X POST \
   -H "Content-Type: application/json" \
+  "${AUTH_HEADER[@]}" \
   -d @- \
   "${TINGLY_API_URL}/tingly/${TINGLY_SCENARIO}/notify" 2>/dev/null || true
 

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -570,6 +570,32 @@ func writeManagedFileIfChanged(path string, content []byte, perm os.FileMode) (b
 	return created, nil
 }
 
+// HookTokenEnvVar is the settings.json `env` key the notify/im hook scripts
+// read their bearer token from (internal/script/tingly-notify.sh,
+// tingly-im-hook.sh). /tingly/:scenario/* requires the operator's user token
+// like every other control-plane surface (see .design/bot-interaction-api.md
+// §3.6) — the scripts run locally as Claude Code hook subprocesses, so
+// settings.json's `env` block (which Claude Code merges into every hook's
+// environment) is how they receive it without a separate distribution step.
+const HookTokenEnvVar = "TINGLY_HOOK_TOKEN"
+
+// mergeHookToken writes token into existingConfig["env"][HookTokenEnvVar],
+// preserving any other env entries already present. token == "" is a no-op
+// (leaves existing env, if any, untouched) so callers that don't have a
+// token yet (or intentionally run without auth) don't clobber a
+// hand-configured value.
+func mergeHookToken(existingConfig map[string]interface{}, token string) {
+	if token == "" {
+		return
+	}
+	env, ok := existingConfig["env"].(map[string]interface{})
+	if !ok {
+		env = make(map[string]interface{})
+	}
+	env[HookTokenEnvVar] = token
+	existingConfig["env"] = env
+}
+
 // NotifyHookEntries defines the Claude Code hooks to install for PUSH-ONLY notifications.
 // This includes Stop events and completion-type notifications.
 // For interactive approval hooks (PreToolUse, permission notifications), use ImHookEntries instead.
@@ -607,10 +633,13 @@ func ImHookEntries() map[string]interface{} {
 	}
 }
 
-// ApplyNotifyHooks installs the notify script and merges notification hooks into settings.json.
-// This is independent of the agent apply flow — it can be called standalone.
-// Existing hooks with different matchers are preserved.
-func ApplyNotifyHooks() (*ApplyResult, error) {
+// ApplyNotifyHooks installs the notify script and merges notification hooks
+// into settings.json. This is independent of the agent apply flow — it can
+// be called standalone. Existing hooks with different matchers are
+// preserved. token is the operator's user token, written to the settings
+// `env` block (see HookTokenEnvVar) so the script can authenticate against
+// /tingly/:scenario/notify; pass "" to skip (e.g. no token configured yet).
+func ApplyNotifyHooks(token string) (*ApplyResult, error) {
 	_, _, err := InstallNotifyScript()
 	if err != nil {
 		return nil, fmt.Errorf("failed to install notify script: %w", err)
@@ -666,6 +695,7 @@ func ApplyNotifyHooks() (*ApplyResult, error) {
 		existingHooks[event] = merged
 	}
 	existingConfig["hooks"] = existingHooks
+	mergeHookToken(existingConfig, token)
 
 	// Write
 	output, err := json.MarshalIndent(existingConfig, "", "  ")
@@ -685,10 +715,12 @@ func ApplyNotifyHooks() (*ApplyResult, error) {
 	return result, nil
 }
 
-// ApplyImHooks installs the IM hook script (interactive approval) and merges IM hooks into settings.json.
-// This is independent of the agent apply flow — it can be called standalone.
-// Existing hooks with different matchers are preserved.
-func ApplyImHooks() (*ApplyResult, error) {
+// ApplyImHooks installs the IM hook script (interactive approval) and merges
+// IM hooks into settings.json. This is independent of the agent apply flow —
+// it can be called standalone. Existing hooks with different matchers are
+// preserved. token is the operator's user token, written to the settings
+// `env` block (see HookTokenEnvVar); pass "" to skip.
+func ApplyImHooks(token string) (*ApplyResult, error) {
 	_, _, err := InstallIMHookScript()
 	if err != nil {
 		return nil, fmt.Errorf("failed to install IM hook script: %w", err)
@@ -744,6 +776,7 @@ func ApplyImHooks() (*ApplyResult, error) {
 		existingHooks[event] = merged
 	}
 	existingConfig["hooks"] = existingHooks
+	mergeHookToken(existingConfig, token)
 
 	// Write
 	output, err := json.MarshalIndent(existingConfig, "", "  ")

--- a/internal/server/config/apply_config_notify_hooks_test.go
+++ b/internal/server/config/apply_config_notify_hooks_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempHome points os.UserHomeDir() (via $HOME) at a fresh temp dir with
+// a .claude directory already created, restoring the original HOME on
+// cleanup. Mirrors the pattern used by TestApplyClaudeSettings_NewFile.
+func withTempHome(t *testing.T) (home, claudeDir string) {
+	t.Helper()
+	home = t.TempDir()
+	original := os.Getenv("HOME")
+	os.Setenv("HOME", home)
+	t.Cleanup(func() { os.Setenv("HOME", original) })
+
+	claudeDir = filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("failed to create .claude dir: %v", err)
+	}
+	return home, claudeDir
+}
+
+func readSettings(t *testing.T, claudeDir string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	return settings
+}
+
+func TestMergeHookToken(t *testing.T) {
+	t.Run("empty token is a no-op", func(t *testing.T) {
+		cfg := map[string]interface{}{"env": map[string]interface{}{"FOO": "bar"}}
+		mergeHookToken(cfg, "")
+		env := cfg["env"].(map[string]interface{})
+		if _, ok := env[HookTokenEnvVar]; ok {
+			t.Fatalf("expected no %s written for empty token, env = %v", HookTokenEnvVar, env)
+		}
+		if env["FOO"] != "bar" {
+			t.Fatalf("expected existing env entries preserved, got %v", env)
+		}
+	})
+
+	t.Run("writes token into a fresh env block", func(t *testing.T) {
+		cfg := map[string]interface{}{}
+		mergeHookToken(cfg, "tb-user-abc123")
+		env, ok := cfg["env"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected env block to be created, got %v", cfg)
+		}
+		if env[HookTokenEnvVar] != "tb-user-abc123" {
+			t.Fatalf("token = %v, want tb-user-abc123", env[HookTokenEnvVar])
+		}
+	})
+
+	t.Run("preserves unrelated env entries", func(t *testing.T) {
+		cfg := map[string]interface{}{"env": map[string]interface{}{"ANTHROPIC_MODEL": "tingly/cc"}}
+		mergeHookToken(cfg, "tb-user-abc123")
+		env := cfg["env"].(map[string]interface{})
+		if env["ANTHROPIC_MODEL"] != "tingly/cc" {
+			t.Fatalf("expected ANTHROPIC_MODEL preserved, got %v", env)
+		}
+		if env[HookTokenEnvVar] != "tb-user-abc123" {
+			t.Fatalf("token = %v, want tb-user-abc123", env[HookTokenEnvVar])
+		}
+	})
+}
+
+func TestApplyNotifyHooks(t *testing.T) {
+	_, claudeDir := withTempHome(t)
+
+	result, err := ApplyNotifyHooks("tb-user-abc123")
+	if err != nil {
+		t.Fatalf("ApplyNotifyHooks failed: %v", err)
+	}
+	if !result.Success || !result.Created {
+		t.Fatalf("expected a successful new-file result, got %+v", result)
+	}
+
+	if _, err := os.Stat(filepath.Join(claudeDir, "tingly-notify.sh")); err != nil {
+		t.Fatalf("expected notify script installed: %v", err)
+	}
+
+	settings := readSettings(t, claudeDir)
+	env, ok := settings["env"].(map[string]interface{})
+	if !ok || env[HookTokenEnvVar] != "tb-user-abc123" {
+		t.Fatalf("expected %s in settings env, got %v", HookTokenEnvVar, settings["env"])
+	}
+
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected hooks block, got %v", settings)
+	}
+	if _, ok := hooks["Stop"]; !ok {
+		t.Fatalf("expected Stop hook entry, got %v", hooks)
+	}
+}
+
+func TestApplyImHooks(t *testing.T) {
+	_, claudeDir := withTempHome(t)
+
+	result, err := ApplyImHooks("tb-user-abc123")
+	if err != nil {
+		t.Fatalf("ApplyImHooks failed: %v", err)
+	}
+	if !result.Success || !result.Created {
+		t.Fatalf("expected a successful new-file result, got %+v", result)
+	}
+
+	settings := readSettings(t, claudeDir)
+	env, ok := settings["env"].(map[string]interface{})
+	if !ok || env[HookTokenEnvVar] != "tb-user-abc123" {
+		t.Fatalf("expected %s in settings env, got %v", HookTokenEnvVar, settings["env"])
+	}
+
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected hooks block, got %v", settings)
+	}
+	if _, ok := hooks["PreToolUse"]; !ok {
+		t.Fatalf("expected PreToolUse hook entry, got %v", hooks)
+	}
+}
+
+// TestApplyNotifyThenImHooks verifies the two independent install flows
+// compose: running both against the same settings.json keeps both hook sets
+// and the token survives both merges.
+func TestApplyNotifyThenImHooks(t *testing.T) {
+	_, claudeDir := withTempHome(t)
+
+	if _, err := ApplyNotifyHooks("tb-user-abc123"); err != nil {
+		t.Fatalf("ApplyNotifyHooks failed: %v", err)
+	}
+	if _, err := ApplyImHooks("tb-user-abc123"); err != nil {
+		t.Fatalf("ApplyImHooks failed: %v", err)
+	}
+
+	settings := readSettings(t, claudeDir)
+	hooks := settings["hooks"].(map[string]interface{})
+	if _, ok := hooks["Stop"]; !ok {
+		t.Fatalf("expected notify's Stop hook to survive the im-hook merge, got %v", hooks)
+	}
+	if _, ok := hooks["PreToolUse"]; !ok {
+		t.Fatalf("expected im-hook's PreToolUse hook, got %v", hooks)
+	}
+	env := settings["env"].(map[string]interface{})
+	if env[HookTokenEnvVar] != "tb-user-abc123" {
+		t.Fatalf("token = %v, want tb-user-abc123", env[HookTokenEnvVar])
+	}
+}
+
+func TestApplyNotifyHooks_EmptyTokenLeavesEnvUntouched(t *testing.T) {
+	_, claudeDir := withTempHome(t)
+
+	if _, err := ApplyNotifyHooks(""); err != nil {
+		t.Fatalf("ApplyNotifyHooks failed: %v", err)
+	}
+
+	settings := readSettings(t, claudeDir)
+	if env, ok := settings["env"]; ok {
+		if m, ok := env.(map[string]interface{}); ok {
+			if _, has := m[HookTokenEnvVar]; has {
+				t.Fatalf("expected no %s written for empty token, env = %v", HookTokenEnvVar, m)
+			}
+		}
+	}
+}

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -184,6 +184,21 @@ func (h *Handler) CreateSettings(c *gin.Context) {
 		}
 	}
 
+	// Attach a notify route at birth, e.g. creating a notify-only bot
+	// (remote_agent off + an active route) in one call. Same cascade as
+	// RemoteAgent: an active route with no live bot is useless.
+	if req.NotifyRoute != nil {
+		updated, err := applyNotifyRoute(settings.Scenarios, req.NotifyRoute)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid notify route", "details": err.Error()})
+			return
+		}
+		settings.Scenarios = updated
+		if notifyRouteActivates(req.NotifyRoute) {
+			settings.Enabled = true
+		}
+	}
+
 	created, err := h.store.CreateSettings(settings)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -355,6 +370,20 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		}
 		settings.Scenarios = updated
 		if *req.RemoteAgent {
+			settings.Enabled = true
+		}
+	}
+
+	// Attach/edit/remove the outbound notify route (bot-arch.md §10's
+	// write-path gap). Same cascade as RemoteAgent when activating a route.
+	if req.NotifyRoute != nil {
+		updated, err := applyNotifyRoute(settings.Scenarios, req.NotifyRoute)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid notify route", "details": err.Error()})
+			return
+		}
+		settings.Scenarios = updated
+		if notifyRouteActivates(req.NotifyRoute) {
 			settings.Enabled = true
 		}
 	}
@@ -604,6 +633,50 @@ func normalizeAllowlist(values []string) []string {
 		out = append(out, entry)
 	}
 	return out
+}
+
+// applyNotifyRoute upserts or removes a bot's outbound notify route on
+// scenariosJSON per req — the write path bot-arch.md §10 flagged as missing.
+// name defaults to "claude_code" (the only registered scenario plugin today)
+// when req.Name is empty. Shared by CreateSettings and UpdateSettings so
+// "attach a route" works the same at both call sites.
+func applyNotifyRoute(scenariosJSON string, req *NotifyRouteRequest) (string, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = "claude_code"
+	}
+
+	if req.Remove {
+		return binding.RemoveBinding(scenariosJSON, name)
+	}
+
+	chatID := strings.TrimSpace(req.ChatID)
+	if chatID == "" {
+		return scenariosJSON, fmt.Errorf("chat_id is required to create or update a notify route")
+	}
+
+	options := map[string]any{}
+	if req.OnTimeout != "" {
+		options["on_timeout"] = req.OnTimeout
+	}
+	if req.TotalBudgetSeconds != nil {
+		options["total_budget_seconds"] = *req.TotalBudgetSeconds
+	}
+
+	return binding.UpsertBinding(scenariosJSON, binding.Binding{
+		Name:    name,
+		ChatID:  chatID,
+		Events:  req.Events,
+		Enabled: req.Enabled,
+		Options: options,
+	})
+}
+
+// notifyRouteActivates reports whether req results in an active (mounted)
+// route, i.e. whether the bot's Enabled flag should cascade on — mirrors the
+// RemoteAgent cascade ("a mount with no live bot is useless").
+func notifyRouteActivates(req *NotifyRouteRequest) bool {
+	return !req.Remove && (req.Enabled == nil || *req.Enabled)
 }
 
 // SetChannelRegistry wires the remote channel registry through to the

--- a/internal/server/module/imbot/notify_route_test.go
+++ b/internal/server/module/imbot/notify_route_test.go
@@ -1,0 +1,113 @@
+package imbot
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/remote/binding"
+)
+
+func boolPtr(b bool) *bool { return &b }
+func intPtr(i int) *int    { return &i }
+
+func TestApplyNotifyRoute_CreateDefaultsNameToClaudeCode(t *testing.T) {
+	out, err := applyNotifyRoute("", &NotifyRouteRequest{ChatID: "dm:ops"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	routes, err := binding.ListOutboundBindings(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 || routes[0].Name != "claude_code" || routes[0].ChatID != "dm:ops" {
+		t.Fatalf("unexpected routes: %+v", routes)
+	}
+}
+
+func TestApplyNotifyRoute_RequiresChatIDUnlessRemoving(t *testing.T) {
+	if _, err := applyNotifyRoute("", &NotifyRouteRequest{}); err == nil {
+		t.Fatal("expected error for missing chat_id")
+	}
+	// Removing doesn't need a chat_id.
+	if _, err := applyNotifyRoute("", &NotifyRouteRequest{Remove: true}); err != nil {
+		t.Fatalf("remove should not require chat_id: %v", err)
+	}
+}
+
+func TestApplyNotifyRoute_OptionsMapToPermissionPolicy(t *testing.T) {
+	out, err := applyNotifyRoute("", &NotifyRouteRequest{
+		ChatID:             "dm:ops",
+		OnTimeout:          "deny",
+		TotalBudgetSeconds: intPtr(120),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	routes, err := binding.ListOutboundBindings(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %+v", routes)
+	}
+	if routes[0].Options["on_timeout"] != "deny" {
+		t.Fatalf("on_timeout lost: %+v", routes[0].Options)
+	}
+	// Round-tripped through JSON, a number decodes into interface{} as
+	// float64, not int — that's the existing binding.Options contract
+	// (claudecode.readPolicy already handles both shapes), not a bug here.
+	if routes[0].Options["total_budget_seconds"] != float64(120) {
+		t.Fatalf("total_budget_seconds lost: %+v", routes[0].Options)
+	}
+}
+
+func TestApplyNotifyRoute_RemovePreservesOtherBindings(t *testing.T) {
+	base := `[{"name":"remote_agent","enabled":true},{"name":"claude_code","chat_id":"dm:ops"}]`
+	out, err := applyNotifyRoute(base, &NotifyRouteRequest{Remove: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.ScenarioMounted(out, binding.RemoteAgentScenario) {
+		t.Fatalf("expected remote_agent to survive route removal, got %q", out)
+	}
+	routes, err := binding.ListOutboundBindings(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("expected the route removed, got %+v", routes)
+	}
+}
+
+func TestApplyNotifyRoute_CustomName(t *testing.T) {
+	out, err := applyNotifyRoute("", &NotifyRouteRequest{Name: "claude_code_staging", ChatID: "dm:staging"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	routes, err := binding.ListOutboundBindings(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 || routes[0].Name != "claude_code_staging" {
+		t.Fatalf("unexpected routes: %+v", routes)
+	}
+}
+
+func TestNotifyRouteActivates(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *NotifyRouteRequest
+		want bool
+	}{
+		{"create with nil Enabled activates", &NotifyRouteRequest{ChatID: "c1"}, true},
+		{"explicit enabled=true activates", &NotifyRouteRequest{ChatID: "c1", Enabled: boolPtr(true)}, true},
+		{"explicit enabled=false does not activate", &NotifyRouteRequest{ChatID: "c1", Enabled: boolPtr(false)}, false},
+		{"remove never activates", &NotifyRouteRequest{Remove: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := notifyRouteActivates(tc.req); got != tc.want {
+				t.Fatalf("notifyRouteActivates() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/module/imbot/types.go
+++ b/internal/server/module/imbot/types.go
@@ -43,6 +43,10 @@ type CreateRequest struct {
 	// control Claude Code / SmartGuide from chat. nil → default (mounted). When
 	// set true it also enables the bot (a mount with no live bot is useless).
 	RemoteAgent *bool `json:"remote_agent,omitempty"`
+	// NotifyRoute attaches an outbound notify route at creation, e.g. to
+	// create a notify-only bot (RemoteAgent: false + an active route) in one
+	// call. nil → no route. See NotifyRouteRequest.
+	NotifyRoute *NotifyRouteRequest `json:"notify_route,omitempty"`
 }
 
 // UpdateRequest represents the request to update ImBot settings
@@ -66,6 +70,41 @@ type UpdateRequest struct {
 	// setting it false leaves Enabled as-is but the bot stops if it was the only
 	// active mount.
 	RemoteAgent *bool `json:"remote_agent,omitempty"`
+	// NotifyRoute creates/edits/removes the bot's outbound notify route.
+	// nil → unchanged. See NotifyRouteRequest.
+	NotifyRoute *NotifyRouteRequest `json:"notify_route,omitempty"`
+}
+
+// NotifyRouteRequest creates, edits, or removes the bot's outbound "notify"
+// route — the write path bot-arch.md §10 called out as missing (until now
+// these were CLI/config-only). "claude_code" is the only scenario plugin
+// registered today (remote/scenario/builtin/claudecode), so Name defaults to
+// it rather than exposing a picker with a single option (ux-principles #6 —
+// smart defaults over toggles).
+//
+// OnTimeout/TotalBudgetSeconds are typed fields (not a free-form options map)
+// so the swagger schema documents the two settings an operator actually sets
+// — they map onto claudecode.PermissionPolicy's on_timeout/
+// total_budget_seconds, stored in the binding's Options.
+type NotifyRouteRequest struct {
+	// Name defaults to "claude_code" when empty.
+	Name string `json:"name,omitempty"`
+	// ChatID is required unless Remove is true. Discover it via
+	// GET /api/v1/bots/{bot}/chats.
+	ChatID string `json:"chat_id,omitempty"`
+	// Events restricts which hook events route here; empty = all events.
+	Events []string `json:"events,omitempty"`
+	// Enabled is the route's own on/off switch, independent of ChatID —
+	// nil on create means "on"; nil on an existing route leaves it as-is.
+	Enabled *bool `json:"enabled,omitempty"`
+	// OnTimeout is claude_code's PermissionPolicy.OnTimeout ("deny" | "allow").
+	OnTimeout string `json:"on_timeout,omitempty"`
+	// TotalBudgetSeconds is claude_code's PermissionPolicy.TotalBudgetSeconds;
+	// nil keeps the plugin's own default.
+	TotalBudgetSeconds *int `json:"total_budget_seconds,omitempty"`
+	// Remove deletes the route instead of creating/updating it. When true,
+	// only Name is read.
+	Remove bool `json:"remove,omitempty"`
 }
 
 // PairingCodeResponse represents the response for pairing-code reveal/rotate.

--- a/internal/server/module/notify/bot_routes.go
+++ b/internal/server/module/notify/bot_routes.go
@@ -48,6 +48,31 @@ type BotChatsResponse struct {
 	Running bool             `json:"running" example:"true"`
 }
 
+// BotNotifyResponse is the swagger model for the 200 body of
+// POST /bots/:bot/notify.
+type BotNotifyResponse struct {
+	OK bool `json:"ok" example:"true"`
+}
+
+// BotInteractResponse is the swagger model for the 202 body of
+// POST /bots/:bot/interact.
+type BotInteractResponse struct {
+	RequestID string `json:"request_id" example:"a1b2c3d4e5f6"`
+	WaitURL   string `json:"wait_url" example:"/api/v1/bots/<bot>/interact/a1b2c3d4e5f6"`
+	ExpiresAt string `json:"expires_at" example:"2026-07-25T12:05:00Z"`
+}
+
+// BotWaitResponse is the swagger model for the body of
+// GET /bots/:bot/interact/:request_id, shared across its 200/410 outcomes —
+// status distinguishes them ("answered"/"cancelled" vs "timeout"/"error").
+// See handler.go's respondResult for the exact mapping (shared with the
+// Claude Code /wait endpoint).
+type BotWaitResponse struct {
+	Status   string         `json:"status" example:"answered"`
+	Decision map[string]any `json:"decision,omitempty"`
+	Reason   string         `json:"reason,omitempty" example:"context deadline exceeded"`
+}
+
 // RegisterBotRoutes registers the general bot interaction API on a control-
 // plane route group (the existing apiV1 group, which already applies
 // getUserAuthMiddleware). Routes:
@@ -65,6 +90,7 @@ func RegisterBotRoutes(router *swagger.RouteGroup, handler *BotAPIHandler) {
 		swagger.WithDescription("Deliver a one-way notification to a running bot's chat. Requires the operator user token."),
 		swagger.WithPathParam("bot", "string", "Target bot UUID"),
 		swagger.WithRequestModel(BotNotifyRequest{}),
+		swagger.WithResponseModel(BotNotifyResponse{}),
 		swagger.WithErrorResponses(
 			swagger.ErrorResponseConfig{Code: 400, Message: "Invalid request body"},
 			swagger.ErrorResponseConfig{Code: 404, Message: "Bot not running"},
@@ -74,9 +100,10 @@ func RegisterBotRoutes(router *swagger.RouteGroup, handler *BotAPIHandler) {
 
 	router.POST("/bots/:bot/interact", handler.Interact,
 		swagger.WithTags("bot-interaction"),
-		swagger.WithDescription("Start an interactive prompt on a running bot's chat and return a request_id to long-poll for the reply."),
+		swagger.WithDescription("Start an interactive prompt on a running bot's chat and return a request_id to long-poll for the reply. Responds 202, not 200 (the schema's documented 200 is this tool's generic success code — the handler actually returns 202)."),
 		swagger.WithPathParam("bot", "string", "Target bot UUID"),
 		swagger.WithRequestModel(BotInteractRequest{}),
+		swagger.WithResponseModel(BotInteractResponse{}),
 		swagger.WithErrorResponses(
 			swagger.ErrorResponseConfig{Code: 400, Message: "Invalid request body or kind"},
 			swagger.ErrorResponseConfig{Code: 404, Message: "Bot not running"},
@@ -86,9 +113,11 @@ func RegisterBotRoutes(router *swagger.RouteGroup, handler *BotAPIHandler) {
 
 	router.GET("/bots/:bot/interact/:request_id", handler.Wait,
 		swagger.WithTags("bot-interaction"),
-		swagger.WithDescription("Long-poll for the reply to an interactive prompt started by POST /bots/:bot/interact."),
+		swagger.WithDescription("Long-poll for the reply to an interactive prompt started by POST /bots/:bot/interact. Status mapping: 200 answered/cancelled, 410 timeout/error, 504 pending (retry), 404 expired."),
 		swagger.WithPathParam("bot", "string", "Target bot UUID"),
 		swagger.WithPathParam("request_id", "string", "Interaction request id from the interact response"),
+		swagger.WithQuery("timeout", "string", "Long-poll budget, e.g. \"45s\" (default 45s, capped at 50s)"),
+		swagger.WithResponseModel(BotWaitResponse{}),
 		swagger.WithErrorResponses(
 			swagger.ErrorResponseConfig{Code: 404, Message: "Request expired"},
 			swagger.ErrorResponseConfig{Code: 503, Message: "Interaction registry unavailable"},

--- a/internal/server/module/notify/handler_test.go
+++ b/internal/server/module/notify/handler_test.go
@@ -99,7 +99,11 @@ func TestNotifyAndWait_PreToolUseAllow(t *testing.T) {
 	handler := NewHandlerWithRouting(scenarios, results, runtime)
 
 	router := gin.New()
-	RegisterRoutes(router, handler)
+	// A no-op passthrough middleware: these tests exercise Notify/Wait
+	// dispatch behavior, not auth (that's TestRegisterRoutes_AppliesAuthMiddleware
+	// below and the production wiring in server_control.go, which passes the
+	// real getUserAuthMiddleware()).
+	RegisterRoutes(router, handler, func(c *gin.Context) { c.Next() })
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
@@ -182,7 +186,11 @@ func TestWaitUnknownIDReturns404(t *testing.T) {
 	results := interaction.New[interaction.Result](time.Second)
 	handler := NewHandlerWithRouting(scenario.NewRegistry(), results, nil)
 	router := gin.New()
-	RegisterRoutes(router, handler)
+	// A no-op passthrough middleware: these tests exercise Notify/Wait
+	// dispatch behavior, not auth (that's TestRegisterRoutes_AppliesAuthMiddleware
+	// below and the production wiring in server_control.go, which passes the
+	// real getUserAuthMiddleware()).
+	RegisterRoutes(router, handler, func(c *gin.Context) { c.Next() })
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
@@ -203,7 +211,11 @@ func TestNotifyPushFallsBackToDesktopWhenUnregistered(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	handler := NewHandler() // no routing
 	router := gin.New()
-	RegisterRoutes(router, handler)
+	// A no-op passthrough middleware: these tests exercise Notify/Wait
+	// dispatch behavior, not auth (that's TestRegisterRoutes_AppliesAuthMiddleware
+	// below and the production wiring in server_control.go, which passes the
+	// real getUserAuthMiddleware()).
+	RegisterRoutes(router, handler, func(c *gin.Context) { c.Next() })
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
@@ -248,7 +260,11 @@ func TestNotifyAndWait_AutoChannelHeadless(t *testing.T) {
 	handler := NewHandlerWithRouting(scenarios, results, runtime)
 
 	router := gin.New()
-	RegisterRoutes(router, handler)
+	// A no-op passthrough middleware: these tests exercise Notify/Wait
+	// dispatch behavior, not auth (that's TestRegisterRoutes_AppliesAuthMiddleware
+	// below and the production wiring in server_control.go, which passes the
+	// real getUserAuthMiddleware()).
+	RegisterRoutes(router, handler, func(c *gin.Context) { c.Next() })
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
@@ -293,5 +309,62 @@ func TestNotifyAndWait_AutoChannelHeadless(t *testing.T) {
 	hso, _ := dec["hookSpecificOutput"].(map[string]interface{})
 	if hso["permissionDecision"] != "allow" {
 		t.Fatalf("expected allow from auto-policy, got %v", hso["permissionDecision"])
+	}
+}
+
+// TestRegisterRoutes_AppliesAuthMiddleware verifies /tingly/:scenario/* is
+// actually gated by whatever middleware RegisterRoutes is given — the fix
+// for the previously-unauthenticated hook path (see
+// .design/bot-interaction-api.md §3.6/§5). Production wires the real
+// getUserAuthMiddleware(); here a stand-in bearer-token check is enough to
+// confirm the group applies it to both routes.
+func TestRegisterRoutes_AppliesAuthMiddleware(t *testing.T) {
+	const validToken = "tb-user-test-token"
+	requireBearer := func(c *gin.Context) {
+		if c.GetHeader("Authorization") != "Bearer "+validToken {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+
+	handler := NewHandler() // fallback-only handler; desktop notify never invoked in this test
+	router := gin.New()
+	RegisterRoutes(router, handler, requireBearer)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	body := strings.NewReader(`{"hook_event_name":"Stop"}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tingly/claude_code/notify", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a token, got %d", resp.StatusCode)
+	}
+
+	req2, _ := http.NewRequest(http.MethodGet, srv.URL+"/tingly/claude_code/wait/some-id", nil)
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a token on /wait, got %d", resp2.StatusCode)
+	}
+
+	req3, _ := http.NewRequest(http.MethodPost, srv.URL+"/tingly/claude_code/notify", strings.NewReader(`{"hook_event_name":"Stop"}`))
+	req3.Header.Set("Content-Type", "application/json")
+	req3.Header.Set("Authorization", "Bearer "+validToken)
+	resp3, err := http.DefaultClient.Do(req3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 with a valid token, got %d", resp3.StatusCode)
 	}
 }

--- a/internal/server/module/notify/routes.go
+++ b/internal/server/module/notify/routes.go
@@ -2,9 +2,15 @@ package notify
 
 import "github.com/gin-gonic/gin"
 
-// RegisterRoutes registers notification hook routes
-func RegisterRoutes(engine *gin.Engine, handler *Handler) {
-	ccGroup := engine.Group("/tingly/:scenario")
+// RegisterRoutes registers notification hook routes behind the given auth
+// middleware. This is the Claude Code hook path — the same operator user
+// token as the web UI / control-plane API (see .design/bot-interaction-api.md
+// §3.1, §3.6). authMW must not be nil in production; passing gin.HandlerFunc
+// wraps every scenario, so callers that genuinely want it open (e.g. a
+// stock/offline setup with no user token configured yet) must say so
+// explicitly by passing a no-op middleware rather than omitting one.
+func RegisterRoutes(engine *gin.Engine, handler *Handler, authMW gin.HandlerFunc) {
+	ccGroup := engine.Group("/tingly/:scenario", authMW)
 	ccGroup.POST("/notify", handler.Notify)
 	ccGroup.GET("/wait/:request_id", handler.Wait)
 }

--- a/internal/server/server_control.go
+++ b/internal/server/server_control.go
@@ -140,7 +140,12 @@ func (s *Server) UseUIEndpoints(ctx context.Context) {
 	} else {
 		notifyHandler = notifymodule.NewHandler()
 	}
-	notifymodule.RegisterRoutes(s.engine, notifyHandler)
+	// The Claude Code hook path reuses the operator's own user token — the
+	// same credential the web UI and /api/v1/bots/* already require — closing
+	// the gap where anyone who could reach the port could push notifications
+	// or fire interactive prompts into an operator's chats. See
+	// .design/bot-interaction-api.md §3.6/§5.
+	notifymodule.RegisterRoutes(s.engine, notifyHandler, s.getUserAuthMiddleware())
 
 	// Create route manager
 	manager := swagger.NewRouteManager(s.engine)

--- a/internal/server/swagger.go
+++ b/internal/server/swagger.go
@@ -61,9 +61,11 @@ func registerAllAPIRoutes(engine *gin.Engine, manager *swagger.RouteManager, s *
 	statusHandler := statusline.NewHandler(cfg, nil, quotaMgr, nil)
 	statusline.RegisterRoutes(engine, statusHandler)
 
-	// Claude Code notification hook endpoint (no auth required)
+	// Claude Code notification hook endpoint — gated the same as the running
+	// server (s.getUserAuthMiddleware()) so the generated OpenAPI doc reflects
+	// reality.
 	notifyHandler := notifymodule.NewHandler()
-	notifymodule.RegisterRoutes(engine, notifyHandler)
+	notifymodule.RegisterRoutes(engine, notifyHandler, s.getUserAuthMiddleware())
 
 	// Web API endpoints (uses the same method as the running server)
 	s.UseWebAPIEndpoints(manager)

--- a/openapi.json
+++ b/openapi.json
@@ -151,6 +151,268 @@
         }
       }
     },
+    "/api/v1/bots/{bot}/chats": {
+      "get": {
+        "tags": [
+          "bot-interaction"
+        ],
+        "summary": "List the chats a running bot can reach. Use the returned chat_id as the chat_id field in POST /bots/:bot/notify and /interact. A bot that isn't running returns an empty list with running:false rather than an error.",
+        "description": "List the chats a running bot can reach. Use the returned chat_id as the chat_id field in POST /bots/:bot/notify and /interact. A bot that isn't running returns an empty list with running:false rather than an error.",
+        "operationId": "apiV1BotsBotChatsGet",
+        "parameters": [
+          {
+            "name": "bot",
+            "in": "path",
+            "description": "Target bot UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotChatsResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Chat listing unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/bots/{bot}/interact": {
+      "post": {
+        "tags": [
+          "bot-interaction"
+        ],
+        "summary": "Start an interactive prompt on a running bot's chat and return a request_id to long-poll for the reply. Responds 202, not 200 (the schema's documented 200 is this tool's generic success code — the handler actually returns 202).",
+        "description": "Start an interactive prompt on a running bot's chat and return a request_id to long-poll for the reply. Responds 202, not 200 (the schema's documented 200 is this tool's generic success code — the handler actually returns 202).",
+        "operationId": "apiV1BotsBotInteractPost",
+        "parameters": [
+          {
+            "name": "bot",
+            "in": "path",
+            "description": "Target bot UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotInteractRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotInteractResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or kind",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bot not running",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Interaction registry unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/bots/{bot}/interact/{request_id}": {
+      "get": {
+        "tags": [
+          "bot-interaction"
+        ],
+        "summary": "Long-poll for the reply to an interactive prompt started by POST /bots/:bot/interact. Status mapping: 200 answered/cancelled, 410 timeout/error, 504 pending (retry), 404 expired.",
+        "description": "Long-poll for the reply to an interactive prompt started by POST /bots/:bot/interact. Status mapping: 200 answered/cancelled, 410 timeout/error, 504 pending (retry), 404 expired.",
+        "operationId": "apiV1BotsBotInteractRequest_idGet",
+        "parameters": [
+          {
+            "name": "bot",
+            "in": "path",
+            "description": "Target bot UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "path",
+            "description": "Interaction request id from the interact response",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Long-poll budget, e.g. \"45s\" (default 45s, capped at 50s)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotWaitResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Request expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Interaction registry unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/bots/{bot}/notify": {
+      "post": {
+        "tags": [
+          "bot-interaction"
+        ],
+        "summary": "Deliver a one-way notification to a running bot's chat. Requires the operator user token.",
+        "description": "Deliver a one-way notification to a running bot's chat. Requires the operator user token.",
+        "operationId": "apiV1BotsBotNotifyPost",
+        "parameters": [
+          {
+            "name": "bot",
+            "in": "path",
+            "description": "Target bot UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotNotifyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotNotifyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bot not running",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Delivery failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/codex/import/openai": {
       "post": {
         "tags": [
@@ -329,6 +591,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ClaudeConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/codex": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get the currently applied Codex preferences",
+        "description": "Get the currently applied Codex preferences",
+        "operationId": "apiV1ConfigCodexGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodexConfigResponse"
                 }
               }
             }
@@ -6094,6 +6378,222 @@
           "data"
         ]
       },
+      "BotChatSummary": {
+        "type": "object",
+        "properties": {
+          "chat_id": {
+            "type": "string",
+            "description": "Field chat_id",
+            "example": "telegram:123456789"
+          },
+          "is_paired": {
+            "type": "boolean",
+            "description": "Field is_paired",
+            "example": true
+          },
+          "is_whitelisted": {
+            "type": "boolean",
+            "description": "Field is_whitelisted",
+            "example": false
+          },
+          "platform": {
+            "type": "string",
+            "description": "Field platform",
+            "example": "telegram"
+          },
+          "project_path": {
+            "type": "string",
+            "description": "Field project_path",
+            "example": "/home/user/proj"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Field updated_at",
+            "example": "2026-07-25T12:00:00Z"
+          }
+        },
+        "required": [
+          "chat_id"
+        ]
+      },
+      "BotChatsResponse": {
+        "type": "object",
+        "properties": {
+          "chats": {
+            "type": "array",
+            "description": "Field chats",
+            "items": {
+              "$ref": "#/components/schemas/BotChatSummary"
+            }
+          },
+          "running": {
+            "type": "boolean",
+            "description": "Field running",
+            "example": true
+          }
+        },
+        "required": [
+          "chats",
+          "running"
+        ]
+      },
+      "BotInteractOption": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Field label",
+            "example": "Yes"
+          },
+          "style": {
+            "type": "string",
+            "description": "Field style",
+            "example": "primary"
+          },
+          "value": {
+            "type": "string",
+            "description": "Field value",
+            "example": "yes"
+          }
+        },
+        "required": [
+          "value",
+          "label"
+        ]
+      },
+      "BotInteractRequest": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Field body",
+            "example": "commit a1b2c3"
+          },
+          "chat_id": {
+            "type": "string",
+            "description": "Field chat_id",
+            "example": "dm:ops"
+          },
+          "kind": {
+            "type": "string",
+            "description": "Field kind",
+            "example": "confirm"
+          },
+          "options": {
+            "type": "array",
+            "description": "Field options",
+            "items": {
+              "$ref": "#/components/schemas/BotInteractOption"
+            }
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field timeout_seconds",
+            "example": 120
+          },
+          "title": {
+            "type": "string",
+            "description": "Field title",
+            "example": "Deploy to prod?"
+          }
+        },
+        "required": [
+          "chat_id",
+          "kind",
+          "title"
+        ]
+      },
+      "BotInteractResponse": {
+        "type": "object",
+        "properties": {
+          "expires_at": {
+            "type": "string",
+            "description": "Field expires_at",
+            "example": "2026-07-25T12:05:00Z"
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Field request_id",
+            "example": "a1b2c3d4e5f6"
+          },
+          "wait_url": {
+            "type": "string",
+            "description": "Field wait_url",
+            "example": "/api/v1/bots/\u003cbot\u003e/interact/a1b2c3d4e5f6"
+          }
+        },
+        "required": [
+          "request_id",
+          "wait_url",
+          "expires_at"
+        ]
+      },
+      "BotNotifyRequest": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Field body",
+            "example": "main branch is red"
+          },
+          "chat_id": {
+            "type": "string",
+            "description": "Field chat_id",
+            "example": "dm:ops"
+          },
+          "level": {
+            "type": "string",
+            "description": "Field level",
+            "example": "info"
+          },
+          "title": {
+            "type": "string",
+            "description": "Field title",
+            "example": "Build #412 failed"
+          }
+        },
+        "required": [
+          "chat_id",
+          "body"
+        ]
+      },
+      "BotNotifyResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "description": "Field ok",
+            "example": true
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "BotWaitResponse": {
+        "type": "object",
+        "properties": {
+          "decision": {
+            "type": "object",
+            "description": "Field decision",
+            "additionalProperties": {}
+          },
+          "reason": {
+            "type": "string",
+            "description": "Field reason",
+            "example": "context deadline exceeded"
+          },
+          "status": {
+            "type": "string",
+            "description": "Field status",
+            "example": "answered"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
       "ClaudeCodePrefs": {
         "type": "object",
         "properties": {
@@ -6300,6 +6800,32 @@
           "configToml",
           "authJson",
           "models"
+        ]
+      },
+      "CodexConfigResponse": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean",
+            "description": "Field exists"
+          },
+          "preferences": {
+            "$ref": "#/components/schemas/CodexPrefs"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          },
+          "writeCatalog": {
+            "type": "boolean",
+            "description": "Field writeCatalog"
+          }
+        },
+        "required": [
+          "success",
+          "exists",
+          "preferences",
+          "writeCatalog"
         ]
       },
       "CodexPrefs": {
@@ -6589,9 +7115,9 @@
               "type": "string"
             }
           },
-          "chat_id": {
+          "chat_id_lock": {
             "type": "string",
-            "description": "Field chat_id"
+            "description": "Field chat_id_lock"
           },
           "default_agent": {
             "type": "string",
@@ -6608,6 +7134,9 @@
           "name": {
             "type": "string",
             "description": "Field name"
+          },
+          "notify_route": {
+            "$ref": "#/components/schemas/NotifyRouteRequest"
           },
           "platform": {
             "type": "string",
@@ -8655,6 +9184,43 @@
           "total",
           "requests"
         ]
+      },
+      "NotifyRouteRequest": {
+        "type": "object",
+        "properties": {
+          "chat_id": {
+            "type": "string",
+            "description": "Field chat_id"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Field enabled"
+          },
+          "events": {
+            "type": "array",
+            "description": "Field events",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          },
+          "on_timeout": {
+            "type": "string",
+            "description": "Field on_timeout"
+          },
+          "remove": {
+            "type": "boolean",
+            "description": "Field remove"
+          },
+          "total_budget_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field total_budget_seconds"
+          }
+        }
       },
       "OAuthAuthorizeRequest": {
         "type": "object",
@@ -10931,9 +11497,9 @@
               "type": "string"
             }
           },
-          "chat_id": {
+          "chat_id_lock": {
             "type": "string",
-            "description": "Field chat_id"
+            "description": "Field chat_id_lock"
           },
           "created_at": {
             "type": "string",
@@ -11899,9 +12465,9 @@
               "type": "string"
             }
           },
-          "chat_id": {
+          "chat_id_lock": {
             "type": "string",
-            "description": "Field chat_id"
+            "description": "Field chat_id_lock"
           },
           "default_agent": {
             "type": "string",
@@ -11918,6 +12484,9 @@
           "name": {
             "type": "string",
             "description": "Field name"
+          },
+          "notify_route": {
+            "$ref": "#/components/schemas/NotifyRouteRequest"
           },
           "platform": {
             "type": "string",
@@ -13391,6 +13960,10 @@
     {
       "name": "auth",
       "description": "Operations related to auth"
+    },
+    {
+      "name": "bot-interaction",
+      "description": "Operations related to bot-interaction"
     },
     {
       "name": "codex",

--- a/remote/binding/binding.go
+++ b/remote/binding/binding.go
@@ -193,6 +193,153 @@ func SetScenarioEnabled(scenariosJSON, name string, enabled bool) (string, error
 	return string(out), nil
 }
 
+// UpsertBinding inserts or replaces (by Name) an outbound route in
+// scenariosJSON, preserving every other row — other routes and the
+// remote_agent mount row — verbatim. This is the write path bot-arch.md §10
+// flagged as missing: until this existed, creating/editing a route (e.g. the
+// "claude_code" route the notify purpose delivers through) was CLI/config-only.
+//
+// b.Enabled == nil is written as "mounted" by omission (ScenarioMounted /
+// OutboundScenarioMounted already treat an absent enabled key as on), so a
+// freshly created route is active without the caller needing to spell out
+// enabled:true.
+func UpsertBinding(scenariosJSON string, b Binding) (string, error) {
+	if b.Name == "" {
+		return scenariosJSON, fmt.Errorf("binding name is required")
+	}
+	rows, err := parseRawRows(scenariosJSON)
+	if err != nil {
+		return scenariosJSON, err
+	}
+
+	row, err := bindingToRow(b)
+	if err != nil {
+		return scenariosJSON, err
+	}
+
+	found := false
+	for i, r := range rows {
+		if rowName(r) == b.Name {
+			rows[i] = row
+			found = true
+			break
+		}
+	}
+	if !found {
+		rows = append(rows, row)
+	}
+
+	return marshalRows(rows)
+}
+
+// RemoveBinding deletes the binding with the given name from scenariosJSON,
+// if present. A no-op (returns scenariosJSON's equivalent parse, nil error)
+// when no binding with that name exists.
+func RemoveBinding(scenariosJSON, name string) (string, error) {
+	rows, err := parseRawRows(scenariosJSON)
+	if err != nil {
+		return scenariosJSON, err
+	}
+
+	kept := rows[:0]
+	for _, r := range rows {
+		if rowName(r) == name {
+			continue
+		}
+		kept = append(kept, r)
+	}
+
+	return marshalRows(kept)
+}
+
+// ListOutboundBindings returns every outbound route in scenariosJSON — every
+// row except the remote_agent mount switch — as typed Bindings. Read-only
+// counterpart to UpsertBinding/RemoveBinding.
+func ListOutboundBindings(scenariosJSON string) ([]Binding, error) {
+	all, err := parse(scenariosJSON)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Binding, 0, len(all))
+	for _, b := range all {
+		if b.Name == "" || b.Name == RemoteAgentScenario {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// parseRawRows parses scenariosJSON into the raw row representation
+// UpsertBinding/RemoveBinding/SetScenarioEnabled operate on, so unknown
+// fields on rows the caller isn't touching survive round-tripping.
+func parseRawRows(scenariosJSON string) ([]map[string]json.RawMessage, error) {
+	var rows []map[string]json.RawMessage
+	if trimmed := strings.TrimSpace(scenariosJSON); trimmed != "" {
+		if err := json.Unmarshal([]byte(trimmed), &rows); err != nil {
+			return nil, fmt.Errorf("parse scenarios: %w", err)
+		}
+	}
+	return rows, nil
+}
+
+func marshalRows(rows []map[string]json.RawMessage) (string, error) {
+	out, err := json.Marshal(rows)
+	if err != nil {
+		return "", fmt.Errorf("marshal scenarios: %w", err)
+	}
+	return string(out), nil
+}
+
+func rowName(row map[string]json.RawMessage) string {
+	var n string
+	if raw, ok := row["name"]; ok {
+		_ = json.Unmarshal(raw, &n)
+	}
+	return n
+}
+
+// bindingToRow renders a typed Binding back into the raw row shape, flattening
+// Options into top-level keys (the inverse of parse's Options-collection).
+func bindingToRow(b Binding) (map[string]json.RawMessage, error) {
+	row := map[string]json.RawMessage{}
+	nameRaw, err := json.Marshal(b.Name)
+	if err != nil {
+		return nil, fmt.Errorf("marshal name: %w", err)
+	}
+	row["name"] = nameRaw
+
+	if b.ChatID != "" {
+		v, err := json.Marshal(b.ChatID)
+		if err != nil {
+			return nil, fmt.Errorf("marshal chat_id: %w", err)
+		}
+		row["chat_id"] = v
+	}
+	if len(b.Events) > 0 {
+		v, err := json.Marshal(b.Events)
+		if err != nil {
+			return nil, fmt.Errorf("marshal events: %w", err)
+		}
+		row["events"] = v
+	}
+	if b.Enabled != nil {
+		v, err := json.Marshal(*b.Enabled)
+		if err != nil {
+			return nil, fmt.Errorf("marshal enabled: %w", err)
+		}
+		row["enabled"] = v
+	}
+	for k, val := range b.Options {
+		v, err := json.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("marshal option %q: %w", k, err)
+		}
+		row[k] = v
+	}
+	return row, nil
+}
+
 // rawBinding mirrors Binding but uses a free-form map[string]json.RawMessage
 // so we can keep all unknown fields in Options.
 type rawBinding map[string]json.RawMessage

--- a/remote/binding/routes_test.go
+++ b/remote/binding/routes_test.go
@@ -1,0 +1,177 @@
+package binding
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestUpsertBindingCreatesRoute(t *testing.T) {
+	out, err := UpsertBinding("", Binding{Name: "claude_code", ChatID: "dm:ops"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parse(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "claude_code" || got[0].ChatID != "dm:ops" {
+		t.Fatalf("unexpected bindings: %+v", got)
+	}
+	// A freshly created route with Enabled == nil must read back as mounted
+	// (absence-is-on for the row itself; OutboundScenarioMounted requires the
+	// row be present at all, which it now is).
+	if !OutboundScenarioMounted(out) {
+		t.Fatalf("expected route to be mounted, got %q", out)
+	}
+}
+
+func TestUpsertBindingReplacesByName(t *testing.T) {
+	base := `[{"name":"remote_agent","enabled":true},{"name":"claude_code","chat_id":"old","events":["Stop"]}]`
+
+	out, err := UpsertBinding(base, Binding{
+		Name:    "claude_code",
+		ChatID:  "new",
+		Enabled: boolPtr(false),
+		Options: map[string]any{"on_timeout": "deny", "total_budget_seconds": 120},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parse(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows (remote_agent preserved + updated claude_code), got %+v", got)
+	}
+
+	var sawRA, sawCC bool
+	for _, b := range got {
+		switch b.Name {
+		case RemoteAgentScenario:
+			sawRA = true
+			if b.Enabled == nil || !*b.Enabled {
+				t.Fatalf("remote_agent row must survive untouched: %+v", b)
+			}
+		case "claude_code":
+			sawCC = true
+			if b.ChatID != "new" {
+				t.Fatalf("chat_id not replaced: %+v", b)
+			}
+			if b.Enabled == nil || *b.Enabled {
+				t.Fatalf("expected enabled=false, got %+v", b.Enabled)
+			}
+			if b.Options["on_timeout"] != "deny" {
+				t.Fatalf("options lost: %+v", b.Options)
+			}
+			// Old "events" field must be gone — UpsertBinding replaces the
+			// whole row rather than merging field by field.
+			if len(b.Events) != 0 {
+				t.Fatalf("expected events cleared by full replace, got %+v", b.Events)
+			}
+		}
+	}
+	if !sawRA || !sawCC {
+		t.Fatalf("expected both rows present, got %+v", got)
+	}
+
+	// The disabled route must not count as mounted.
+	if OutboundScenarioMounted(out) {
+		t.Fatalf("expected not mounted after disabling the only route, got %q", out)
+	}
+}
+
+func TestUpsertBindingRequiresName(t *testing.T) {
+	if _, err := UpsertBinding("", Binding{ChatID: "dm:ops"}); err == nil {
+		t.Fatal("expected error for empty binding name")
+	}
+}
+
+func TestRemoveBinding(t *testing.T) {
+	base := `[{"name":"remote_agent","enabled":true},{"name":"claude_code","chat_id":"c1"}]`
+
+	out, err := RemoveBinding(base, "claude_code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := parse(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != RemoteAgentScenario {
+		t.Fatalf("expected only remote_agent to remain, got %+v", got)
+	}
+	if OutboundScenarioMounted(out) {
+		t.Fatalf("expected not mounted with no outbound routes, got %q", out)
+	}
+
+	// Removing a name that isn't present is a no-op, not an error.
+	out2, err := RemoveBinding(out, "does_not_exist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, err := parse(out2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got2) != 1 {
+		t.Fatalf("expected removing an absent name to be a no-op, got %+v", got2)
+	}
+}
+
+func TestListOutboundBindings(t *testing.T) {
+	base := `[{"name":"remote_agent","enabled":false},{"name":"claude_code","chat_id":"c1"},{"name":"claude_code_staging","chat_id":"c2","enabled":false}]`
+
+	routes, err := ListOutboundBindings(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 outbound routes (remote_agent excluded), got %+v", routes)
+	}
+	names := map[string]bool{}
+	for _, r := range routes {
+		names[r.Name] = true
+	}
+	if !names["claude_code"] || !names["claude_code_staging"] {
+		t.Fatalf("expected both outbound routes listed, got %+v", routes)
+	}
+}
+
+func TestListOutboundBindingsEmpty(t *testing.T) {
+	routes, err := ListOutboundBindings("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("expected no routes for empty scenarios, got %+v", routes)
+	}
+}
+
+func TestUpsertThenRemoveRoundTrip(t *testing.T) {
+	out, err := UpsertBinding("", Binding{Name: "claude_code", ChatID: "dm:ops", Events: []string{"Stop", "PreToolUse"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err = UpsertBinding(out, Binding{Name: "remote_agent", Enabled: boolPtr(true)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err = RemoveBinding(out, "claude_code")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routes, err := ListOutboundBindings(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("expected claude_code removed, got %+v", routes)
+	}
+	if !ScenarioMounted(out, RemoteAgentScenario) {
+		t.Fatalf("expected remote_agent to survive the claude_code removal")
+	}
+}


### PR DESCRIPTION
## Why

Asked to re-audit `module/imbot` + `module/notify` after the recent remote/bot/imbot refactors (#1443/#1444/#1447/#1448), since notify was suspected to have regressed. The startup-race bug found during that audit was pulled out into its own PR (#1451); this PR covers the rest: two gaps the earlier redesign had explicitly deferred, plus codegen.

## What

**1. `/tingly/:scenario/{notify,wait}` was unauthenticated** (`internal/server/module/notify/routes.go`, `internal/script/tingly-{notify,im-hook}.sh`, `internal/server/config/apply_config.go`)

Flagged in `.design/bot-interaction-api.md` as the PR1 follow-up that never shipped. `RegisterRoutes` now takes an auth middleware (wired to the real `getUserAuthMiddleware()`); both Claude Code hook scripts read a new `TINGLY_HOOK_TOKEN` env var and send it as a bearer token; `ApplyNotifyHooks`/`ApplyImHooks` merge that token into `settings.json`'s `env` block for whoever installs the hooks. (Separate, pre-existing finding surfaced while shipping this: those install functions have had zero callers anywhere in the product since they were introduced — no CLI, no UI. Documented in the design doc rather than fixed here, since "should this be a CLI command or a UI toggle" is a product decision, not a bug fix.)

**2. Outbound notify route write-path** (`remote/binding/binding.go`, `internal/server/module/imbot/{types,handler}.go`, frontend `BotNotifyGroup.tsx`/`NotifyPage.tsx`/`types/bot.ts`)

`.design/bot-arch.md` §10's "write-path gap": there was no way to create/edit a bot's outbound scenario route short of hand-editing the settings store. Reuses the existing `remote_agent`-mount-toggle shape rather than a new route family — a `notify_route` field on `CreateRequest`/`UpdateRequest`, backed by two new general-purpose primitives in `remote/binding` (`UpsertBinding`/`RemoveBinding`, raw-row read-modify-write preserving unrelated rows verbatim; `ListOutboundBindings` for the typed read side). Activating a route cascades `Enabled` the same way `remote_agent` already does, so a notify-only bot comes up from one call. Frontend: each reachable chat row in `BotNotifyGroup` now shows a "Routed" chip (one-click to stop) or a "Route here" button, reusing the chat list already fetched for the capability probes — no separate chat_id form.

**3. Codegen**

Ran `task codegen` now that the API surface settled: `openapi.json` picks up `/api/v1/bots/*` and `notify_route`; `frontend/src/services/api.ts`'s four bot-interaction placeholder functions are rewritten against the generated, typed client. Added response models + the missing `timeout` query param to `bot_routes.go` so the generated types describe response bodies instead of `Record<string, never>`.

`pkg/notify` is untouched by this PR.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/... ./remote/... ./pkg/notify/...` — all pass, including new tests for the binding primitives (`remote/binding/routes_test.go`), the notify-route handler logic (`internal/server/module/imbot/notify_route_test.go`), the hook-token merge (`internal/server/config/apply_config_notify_hooks_test.go`), and the auth gate (`TestRegisterRoutes_AppliesAuthMiddleware` in `internal/server/module/notify/handler_test.go`)
- [x] `pnpm typecheck`, `pnpm lint` clean on frontend
- [x] Manually verified the hook scripts' auth header against a local HTTP server (token sent when set, omitted when not, clean 401 diagnostic)
- [x] Verified the route write-path interactively in mock mode — clicking flips the "Routed" chip/"Route here" button and a toast confirms, both directions

## Design docs updated

- `.design/bot-arch.md` — §10 write-path gap marked closed with the shipped shape
- `.design/bot-interaction-api.md` — PR2 (auth) marked shipped, with the newly-discovered unwired-installer gap documented as a separate open item
