### PR TITLE
fix(imbot): close startup race that could leave a bot channel-less

### DIFF
--- a/.design/bot-arch.md
+++ b/.design/bot-arch.md
@@ -502,7 +502,11 @@ siblings above. Legacy `/remote-control/*` redirects to `/remote-agent/*`.
   notify "randomly" stopped working. Fixed by passing `channelRegistry`
   into `NewBotManager`/`imbot.NewHandler` and wiring it before
   `go bm.periodicBotSync(ctx)` is spawned, so there is no window in which a
-  bot can start without it.
+  bot can start without it. The now-redundant `SetChannelRegistry` setters on
+  `imbot.Handler`/`imbot.BotManager` were removed rather than left as
+  dead code — keeping them around would read as "this is still how you wire
+  it," inviting a future caller to reintroduce the exact race by calling one
+  after construction.
 
 ## 12. Tests
 

--- a/.design/bot-arch.md
+++ b/.design/bot-arch.md
@@ -486,6 +486,23 @@ siblings above. Legacy `/remote-control/*` redirects to `/remote-agent/*`.
   as before the split, when one prompter served everything.
 - A bot with remote_agent mounted but no routes registers a channel nothing
   routes to; harmless, and it keeps "channel comes with running" simple.
+- **Wire the channel registry at construction, not with a post-hoc setter.**
+  `internal/server/module/imbot.NewBotManager` used to accept the registry
+  only via a later `SetChannelRegistry` call from `server_control.go`, after
+  `NewHandler` had already returned. But construction also spawns
+  `periodicBotSync`'s background goroutine, which runs an *immediate* sync
+  that `Start()`s every already-enabled bot right away (bots enabled while
+  the server was down). If that goroutine reached a given bot's `Start()`
+  before the main goroutine's later `SetChannelRegistry` call landed, that
+  bot came up fully connected but with no channel registered — silently
+  unreachable from `/tingly/:scenario/notify` and `/api/v1/bots/:bot/*` for
+  its entire run, since `Sync` never restarts an already-running bot. Purely
+  an initialization-order race (no data race — both sides take the same
+  mutex), so it did not reproduce every boot, which made it look like
+  notify "randomly" stopped working. Fixed by passing `channelRegistry`
+  into `NewBotManager`/`imbot.NewHandler` and wiring it before
+  `go bm.periodicBotSync(ctx)` is spawned, so there is no window in which a
+  bot can start without it.
 
 ## 12. Tests
 

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -28,7 +28,6 @@ type LifecycleController interface {
 	RestartBotByUUID(ctx context.Context, uuid string) error
 	Sync(ctx context.Context) error
 	Shutdown()
-	SetChannelRegistry(reg *channel.Registry)
 }
 
 // Handler handles ImBot settings HTTP requests
@@ -607,16 +606,6 @@ func normalizeAllowlist(values []string) []string {
 		out = append(out, entry)
 	}
 	return out
-}
-
-// SetChannelRegistry wires the remote channel registry through to the
-// underlying bot manager. Used by the server during route registration so
-// each running bot exposes itself as a remote.channel.Channel.
-func (h *Handler) SetChannelRegistry(reg *channel.Registry) {
-	if h.botMgr == nil {
-		return
-	}
-	h.botMgr.SetChannelRegistry(reg)
 }
 
 // ChatStore returns the chat store shared by every running bot. It is owned

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -40,10 +40,13 @@ type Handler struct {
 	feishuRegHandler *FeishuRegHandler     // Feishu/Lark one-click registration handler
 }
 
-// NewHandler creates a new ImBot settings handler
-func NewHandler(ctx context.Context, cfg *config.Config) (*Handler, error) {
+// NewHandler creates a new ImBot settings handler. channelRegistry is passed
+// straight through to NewBotManager — see its doc comment for why this must
+// happen at construction time rather than via a later SetChannelRegistry
+// call.
+func NewHandler(ctx context.Context, cfg *config.Config, channelRegistry *channel.Registry) (*Handler, error) {
 	sm := cfg.StoreManager()
-	botMgr, err := NewBotManager(ctx, cfg)
+	botMgr, err := NewBotManager(ctx, cfg, channelRegistry)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/module/imbot/manager.go
+++ b/internal/server/module/imbot/manager.go
@@ -43,11 +43,18 @@ type BotStatus struct {
 }
 
 // NewBotManager creates a new BotManager with all required dependencies.
-// If a channel registry is supplied via SetChannelRegistry before bots
-// are started, each running bot exposes itself as a remote.channel.Channel
-// so Claude Code hooks routed to /tingly/:scenario/notify can drive
-// that bot's chat through the scenario plugin layer.
-func NewBotManager(ctx context.Context, cfg *config.Config) (*BotManager, error) {
+// channelRegistry is wired into the internal bot.Manager before the
+// background sync loop starts (see below) so every bot it brings up —
+// including bots enabled before the server started — registers itself as a
+// remote.channel.Channel. Passing it here rather than through a later
+// SetChannelRegistry call closes a startup race: periodicBotSync's initial
+// sync runs in its own goroutine immediately after construction, and used to
+// be able to Start() bots before a subsequent SetChannelRegistry call landed,
+// permanently starting them with no channel (Claude Code hooks and the bot
+// interaction API would then find "bot not running" for a bot that was, in
+// fact, running). channelRegistry may be nil (e.g. swagger doc generation,
+// which never drives real chats).
+func NewBotManager(ctx context.Context, cfg *config.Config, channelRegistry *channel.Registry) (*BotManager, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -101,6 +108,9 @@ func NewBotManager(ctx context.Context, cfg *config.Config) (*BotManager, error)
 	// Create internal bot manager
 	internalMgr := bot.NewManager(store, notifyConsumer, remoteAgentConsumer)
 	internalMgr.SetChatStore(chatStore)
+	// Wire the channel registry BEFORE periodicBotSync's goroutine gets a
+	// chance to Start() any bot — see the constructor doc comment.
+	internalMgr.SetChannelRegistry(channelRegistry)
 
 	bm := &BotManager{
 		manager:      internalMgr,

--- a/internal/server/module/imbot/manager.go
+++ b/internal/server/module/imbot/manager.go
@@ -397,16 +397,6 @@ func (bm *BotManager) GetStore() *db.ImBotSettingsStore {
 	return bm.store
 }
 
-// SetChannelRegistry passes the remote channel registry through to the
-// underlying bot manager so each running bot registers an imbot-backed
-// Channel reachable from the notify scenario plugins.
-func (bm *BotManager) SetChannelRegistry(reg *channel.Registry) {
-	if bm == nil || bm.manager == nil {
-		return
-	}
-	bm.manager.SetChannelRegistry(reg)
-}
-
 // GetTBClient returns the TBClient for SmartGuide model configuration.
 func (bm *BotManager) GetTBClient() tbclient.TBClient {
 	if bm == nil {

--- a/internal/server/server_control.go
+++ b/internal/server/server_control.go
@@ -181,20 +181,22 @@ func (s *Server) UseUIEndpoints(ctx context.Context) {
 		usagemodule.RegisterRoutes(apiV1, usageHandler)
 	}
 
-	// ImBot settings API routes - register from imbotsettings module
-	imbotHandler, err := imbot.NewHandler(ctx, s.config)
+	// ImBot settings API routes - register from imbotsettings module.
+	// s.channelRegistry is passed in at construction (not wired later via
+	// SetChannelRegistry) so every bot NewHandler brings up — including bots
+	// enabled before the server started, which the background sync starts
+	// immediately on its own goroutine — registers itself as a
+	// remote.channel.Channel reachable from /tingly/:scenario and
+	// /api/v1/bots/:bot/*. Passing it after the fact left a startup race
+	// where such a bot could finish starting before the registry landed and
+	// would then never expose a channel until manually restarted.
+	imbotHandler, err := imbot.NewHandler(ctx, s.config, s.channelRegistry)
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to create imbotsettings handler, imbot settings APIs will not be available")
 	} else {
 		imbot.RegisterRoutes(apiV1, imbotHandler)
 		// Store handler reference for shutdown
 		s.imbotSettingsHandler = imbotHandler
-		// Wire the channel registry so each running bot exposes itself
-		// as a remote.channel.Channel reachable from /tingly/:scenario
-		// scenario plugins.
-		if s.channelRegistry != nil {
-			imbotHandler.SetChannelRegistry(s.channelRegistry)
-		}
 	}
 
 	// Bot interaction API — the general, caller-facing surface for driving a

--- a/internal/server/swagger.go
+++ b/internal/server/swagger.go
@@ -90,9 +90,12 @@ func registerAllAPIRoutes(engine *gin.Engine, manager *swagger.RouteManager, s *
 		usagemodule.RegisterRoutes(apiV1, usageHandler)
 	}
 
-	// ImBot settings API routes - register from imbotsettings module
+	// ImBot settings API routes - register from imbotsettings module. No
+	// channel registry here — this path only generates OpenAPI docs and
+	// never drives real chats (see the bot-interaction API registration
+	// below, which mirrors server_control.go's nil-channel handler).
 	ctx := context.Background()
-	imbotHandler, err := imbot.NewHandler(ctx, cfg)
+	imbotHandler, err := imbot.NewHandler(ctx, cfg, nil)
 	if err != nil {
 		fmt.Printf("Failed to create imbotsettings handler: %v\n", err)
 	} else {


### PR DESCRIPTION
## Why

Auditing `module/imbot`/`module/notify` after the recent remote/bot/imbot refactors (#1443/#1444/#1447/#1448) surfaced a real, intermittent bug.

## What

`internal/server/module/imbot.NewBotManager` spawns `periodicBotSync`'s background goroutine — which immediately `Start()`s every already-enabled bot — as part of construction. `server_control.go` created the `channel.Registry` first, but only wired it into the bot manager *after* `imbot.NewHandler()` returned, via a separate `SetChannelRegistry` call:

```go
s.channelRegistry = channel.NewRegistry()
...
imbotHandler, err := imbot.NewHandler(ctx, s.config)   // spawns the sync goroutine here
...
imbotHandler.SetChannelRegistry(s.channelRegistry)      // ...but this lands after NewHandler returns
```

If the background goroutine's initial `Sync()` reached a given bot's `Start()` before that `SetChannelRegistry` call landed, the bot came up fully connected to its IM platform but with **no channel registered** — `/tingly/:scenario/notify` and `/api/v1/bots/:bot/*` would report "bot not running" for a bot that, in fact, was. `Sync()` never restarts an already-running bot, so this state persisted for the bot's entire run, until it was manually stopped/restarted.

This is a pure initialization-order race (both sides take the same mutex, so `go test -race` doesn't catch it) — whether it triggers depends on goroutine scheduling, SQLite read latency, and how many bots are configured. That's why it presented as "notify randomly stops working" rather than a consistent failure.

**Fix:** pass `channelRegistry` into `NewBotManager`/`imbot.NewHandler` at construction time, wired before the sync goroutine is spawned, so there is no window in which a bot can start without it. `internal/server/swagger.go`'s OpenAPI-doc-generation path (which never drives real chats) passes `nil`, matching its previous behavior.

**Follow-up simplification:** `Handler.SetChannelRegistry`, `BotManager.SetChannelRegistry`, and the matching `LifecycleController` interface method had zero callers left once the registry moved to a constructor argument. Removed rather than left as dead code — keeping a setter that looks like "the way to wire this" is an invitation for someone to call it after construction and reintroduce the exact race this PR fixes.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/server/module/imbot/... ./internal/server/... ./internal/remote_control/bot/...` — all pass
- [x] Design note added to `.design/bot-arch.md` §11 documenting the hazard, the fix, and why the dead setters were removed rather than kept around
