### PR TITLE
feat(dashboard): split cache read vs write in usage views

### DIFF
--- a/.design/dashboard.md
+++ b/.design/dashboard.md
@@ -40,6 +40,12 @@ server-side equality filter matches the UI's Success/Error toggle 1:1.
 Time bounds are sent as local ISO strings with timezone offset
 (`toLocalISOString`) because the backend stores local time.
 
+The dashboard components declare these response shapes as **local
+interfaces**, not types generated from `openapi.json`. That is why
+`cache_write_tokens` could ship ahead of a codegen run — `openapi.json`
+currently lags the Go models by that one field. Anything that does consume
+the generated SDK needs `task codegen` first.
+
 ## Backend query path
 
 - **`usage_daily` pre-aggregation** (`internal/data/db/usage_daily.go`): one
@@ -102,6 +108,9 @@ Usage" side panel used to sit next to the chart; it was removed as a
 near-duplicate of the "Usage by Model" table below — both read the same
 `group_by=model` stats — so the table is now the sole per-model view.)
 
+Three stacked series: **Cache Read**, **Input**, **Output**. Cache *writes*
+are deliberately not a fourth series — see the cache read/write section below.
+
 ### By Request (`RequestsView.tsx`)
 
 The page always fetches a **sample**: the most recent 500 records for the
@@ -144,6 +153,37 @@ Layout facts that keep the grid stable:
   `transform` to cells**: transformed bounds of edge cells extend the
   scrollable overflow of the `overflowX: auto` container, making the scrollbar
   flicker and the grid jump under the cursor.
+
+## Cache reads vs cache writes
+
+Caching is two costs, not one. Reads are the discount; writes are billed at a
+premium (Anthropic `cache_creation`, OpenAI `cache_write_tokens` since
+gpt-5.6). The API exposes both: `cache_input_tokens` is reads only,
+`cache_write_tokens` is writes.
+
+**`cache_write_tokens` is a SUBSET of `total_input_tokens`, never an addend.**
+This is the one thing to get right here — the backend folds the write cost
+into input on purpose (see `.design/stream-usage-tracking.md` §2). So cache
+writes must never become a fourth stacked series, a fourth donut slice, or a
+term in any total; doing so double counts the same tokens and inflates every
+figure on the page.
+
+They surface as annotations on the Input figure instead:
+
+- Chart tooltip: `Input Tokens: 12,570 (incl. 1,508 written)`
+- Token Breakdown donut: `incl. 107K written` under the Input legend entry
+- Cache Hit Rate card subtitle: `40M read · 4.8M written`
+- Own column (`Cache Write`) in Usage by Model and the By Request table
+
+Vocabulary: every previously-"Cache" label is now **Cache Read**, so the word
+means one thing. The write column and the "written" annotations render only
+when there is a non-zero write in the data (`hasCacheWrites`) — pre-gpt-5.6
+models and Azure never report writes, so an always-on column would be a
+permanent wall of zeros. `formatCacheBreakdown` in `chartStyles.ts` owns that
+decision for the stat cards.
+
+The Cache Hit Rate formula is unchanged: `read / (read + input)`. Since input
+already contains the writes, a write correctly counts as a miss.
 
 ## Invariants / gotchas
 

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -30,7 +30,7 @@ import {
     ResponsiveContainer,
 } from 'recharts';
 import { WaveSine as StreamIcon } from '@/components/icons';
-import { getThemeChartStyles, TOKEN_COLORS, formatNumber } from './chartStyles';
+import { getThemeChartStyles, TOKEN_COLORS, formatNumber, hasCacheWrites } from './chartStyles';
 import api from '@/services/api';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -49,6 +49,7 @@ export interface UsageRecord {
     output_tokens: number;
     total_tokens: number;
     cache_input_tokens: number;
+    cache_write_tokens?: number;
     status: string;
     error_code?: string;
     latency_ms: number;
@@ -105,12 +106,17 @@ function TokenDonut({ records }: { records: UsageRecord[] }) {
     const totalInput  = records.reduce((s, r) => s + r.input_tokens, 0);
     const totalOutput = records.reduce((s, r) => s + r.output_tokens, 0);
     const totalCache  = records.reduce((s, r) => s + r.cache_input_tokens, 0);
+    // Cache writes live INSIDE input_tokens, so they must not become a fourth
+    // slice — that would inflate the total by counting them twice. They annotate
+    // the Input slice instead.
+    const totalCacheWrite = records.reduce((s, r) => s + (r.cache_write_tokens || 0), 0);
     const total = totalInput + totalOutput + totalCache;
 
     const pieData = [
-        { name: 'Input',  value: totalInput,  color: TOKEN_COLORS.input.main,  pct: total > 0 ? ((totalInput  / total) * 100).toFixed(1) : '0' },
-        { name: 'Output', value: totalOutput, color: TOKEN_COLORS.output.main, pct: total > 0 ? ((totalOutput / total) * 100).toFixed(1) : '0' },
-        { name: 'Cache',  value: totalCache,  color: TOKEN_COLORS.cache.main,  pct: total > 0 ? ((totalCache  / total) * 100).toFixed(1) : '0' },
+        { name: 'Input',  value: totalInput,  color: TOKEN_COLORS.input.main,  pct: total > 0 ? ((totalInput  / total) * 100).toFixed(1) : '0',
+          note: totalCacheWrite > 0 ? `incl. ${fmtTokens(totalCacheWrite)} written` : '' },
+        { name: 'Output', value: totalOutput, color: TOKEN_COLORS.output.main, pct: total > 0 ? ((totalOutput / total) * 100).toFixed(1) : '0', note: '' },
+        { name: 'Cache Read', value: totalCache, color: TOKEN_COLORS.cache.main, pct: total > 0 ? ((totalCache / total) * 100).toFixed(1) : '0', note: '' },
     ].filter(d => d.value > 0);
 
     return (
@@ -156,6 +162,11 @@ function TokenDonut({ records }: { records: UsageRecord[] }) {
                                             {d.pct}%
                                         </Typography>
                                     </Typography>
+                                    {d.note && (
+                                        <Typography sx={{ fontSize: '0.62rem', color: 'text.secondary', lineHeight: 1.2 }}>
+                                            {d.note}
+                                        </Typography>
+                                    )}
                                 </Box>
                             </Box>
                         ))}
@@ -278,6 +289,7 @@ interface TableSectionProps {
 
 function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading, onStatusFilterChange, onPageChange, onRowsPerPageChange }: TableSectionProps) {
     const theme = useTheme();
+    const showCacheWrite = hasCacheWrites(records);
 
     return (
         <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden', backgroundColor: 'background.paper', boxShadow: 'none', width: '100%', minWidth: 0 }}>
@@ -312,7 +324,8 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                             <TableCell>Time</TableCell>
                             <TableCell>Model</TableCell>
                             <TableCell>Scenario</TableCell>
-                            <TableCell align="right" sx={{ minWidth: 96 }}>Cache</TableCell>
+                            <TableCell align="right" sx={{ minWidth: 96 }}>Cache Read</TableCell>
+                            {showCacheWrite && <TableCell align="right">Cache Write</TableCell>}
                             <TableCell align="right">Input</TableCell>
                             <TableCell align="right">Output</TableCell>
                             <TableCell align="right">Latency</TableCell>
@@ -384,6 +397,14 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                                         );
                                     })()}
                                 </TableCell>
+
+                                {showCacheWrite && (
+                                    <TableCell align="right">
+                                        <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: (r.cache_write_tokens || 0) > 0 ? 'text.primary' : 'text.disabled' }}>
+                                            {(r.cache_write_tokens || 0) > 0 ? fmtTokens(r.cache_write_tokens || 0) : '-'}
+                                        </Typography>
+                                    </TableCell>
+                                )}
                                 <TableCell align="right">
                                     <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.input.main }}>
                                         {fmtTokens(r.input_tokens)}

--- a/frontend/src/components/dashboard/ServiceStatsTable.tsx
+++ b/frontend/src/components/dashboard/ServiceStatsTable.tsx
@@ -13,7 +13,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { useState } from 'react';
-import { formatNumber } from './chartStyles';
+import { formatNumber, hasCacheWrites } from './chartStyles';
 
 export interface AggregatedStat {
     key: string;
@@ -27,6 +27,7 @@ export interface AggregatedStat {
     total_input_tokens: number;
     total_output_tokens: number;
     cache_input_tokens?: number;
+    cache_write_tokens?: number;
     avg_latency_ms?: number;
     error_count?: number;
     error_rate?: number;
@@ -38,6 +39,7 @@ interface ServiceStatsTableProps {
 }
 
 export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
+    const showCacheWrite = hasCacheWrites(stats);
     const theme = useTheme();
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -120,8 +122,13 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
                                 Requests
                             </TableCell>
                             <TableCell align="right" sx={{ fontWeight: 600 }}>
-                                Cache Tokens
+                                Cache Read
                             </TableCell>
+                            {showCacheWrite && (
+                                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                                    Cache Write
+                                </TableCell>
+                            )}
                             <TableCell align="right" sx={{ fontWeight: 600 }}>
                                 Cache Hit
                             </TableCell>
@@ -216,6 +223,9 @@ export default function ServiceStatsTable({ stats }: ServiceStatsTableProps) {
                                         </TableCell>
                                         <TableCell align="right">{formatRequests(stat.request_count)}</TableCell>
                                         <TableCell align="right">{formatTokens(stat.cache_input_tokens || 0)}</TableCell>
+                                        {showCacheWrite && (
+                                            <TableCell align="right">{formatTokens(stat.cache_write_tokens || 0)}</TableCell>
+                                        )}
                                         <TableCell align="right">
                                             <Typography
                                                 variant="body2"

--- a/frontend/src/components/dashboard/TokenHistoryChart/DailyChart.tsx
+++ b/frontend/src/components/dashboard/TokenHistoryChart/DailyChart.tsx
@@ -67,7 +67,7 @@ export function DailyTokenHistoryChart({ data }: DailyTokenHistoryChartProps) {
                 <>
                     <Box sx={{ display: 'flex', justifyContent: 'center', gap: 3, mb: 2 }}>
                         <LegendItem
-                            label="Cache"
+                            label="Cache Read"
                             color={chartStyles.token.cache.main}
                             visible={visibleSeries.cache}
                             onToggle={() => toggleSeries('cache')}
@@ -133,7 +133,7 @@ export function DailyTokenHistoryChart({ data }: DailyTokenHistoryChartProps) {
                             />
                             <Bar
                                 dataKey="cacheTokens"
-                                name="Cache Tokens"
+                                name="Cache Read"
                                 stackId="tokens"
                                 hide={!visibleSeries.cache}
                                 stroke={chartStyles.token.cache.main}

--- a/frontend/src/components/dashboard/TokenHistoryChart/HourlyChart.tsx
+++ b/frontend/src/components/dashboard/TokenHistoryChart/HourlyChart.tsx
@@ -39,7 +39,7 @@ export function HourlyTokenHistoryChart({data}: HourlyTokenHistoryChartProps) {
                 <>
                     <Box sx={{display: 'flex', justifyContent: 'center', gap: 3, mb: 2}}>
                         <LegendItem
-                            label="Cache"
+                            label="Cache Read"
                             color={chartStyles.token.cache.main}
                             visible={visibleSeries.cache}
                             onToggle={() => toggleSeries('cache')}
@@ -101,7 +101,7 @@ export function HourlyTokenHistoryChart({data}: HourlyTokenHistoryChartProps) {
                             <Area
                                 type="monotone"
                                 dataKey="cacheTokens"
-                                name="Cache Tokens"
+                                name="Cache Read"
                                 stackId="1"
                                 stroke={chartStyles.token.cache.main}
                                 strokeWidth={1}

--- a/frontend/src/components/dashboard/TokenHistoryChart/components.tsx
+++ b/frontend/src/components/dashboard/TokenHistoryChart/components.tsx
@@ -49,7 +49,7 @@ export function LegendItem({ label, color, visible, onToggle }: LegendItemProps)
     );
 }
 
-const SERIES_ORDER = ['Cache Tokens', 'Input Tokens', 'Output Tokens'];
+const SERIES_ORDER = ['Cache Read', 'Input Tokens', 'Output Tokens'];
 
 export function CustomTooltip({ active, payload }: any) {
     const theme = useTheme();
@@ -107,6 +107,14 @@ export function CustomTooltip({ active, payload }: any) {
                     </Box>
                     <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.primary' }}>
                         {entry.value.toLocaleString()}
+                        {/* Cache writes are part of the input tokens already plotted,
+                            so they annotate the Input row instead of getting their own
+                            series — a fourth stacked band would count them twice. */}
+                        {entry.name === 'Input Tokens' && data.cacheWriteTokens > 0 && (
+                            <Box component="span" sx={{ fontWeight: 400, color: 'text.secondary', ml: 0.5 }}>
+                                (incl. {data.cacheWriteTokens.toLocaleString()} written)
+                            </Box>
+                        )}
                     </Typography>
                 </Box>
             ))}

--- a/frontend/src/components/dashboard/TokenHistoryChart/types.ts
+++ b/frontend/src/components/dashboard/TokenHistoryChart/types.ts
@@ -7,6 +7,7 @@ export interface TimeSeriesData {
     input_tokens: number;
     output_tokens: number;
     cache_input_tokens?: number;
+    cache_write_tokens?: number;
     error_count?: number;
     avg_latency_ms?: number;
 }
@@ -18,6 +19,9 @@ export interface ChartDataPoint {
     inputTokens: number;
     outputTokens: number;
     cacheTokens: number;
+    // Cache writes are a SUBSET of inputTokens, never a fourth stacked series —
+    // charting them separately would double count the same tokens.
+    cacheWriteTokens: number;
     cacheRatio: number;
 }
 

--- a/frontend/src/components/dashboard/TokenHistoryChart/utils.ts
+++ b/frontend/src/components/dashboard/TokenHistoryChart/utils.ts
@@ -71,6 +71,7 @@ export const formatChartData = (data: TimeSeriesData[], isDayMode: boolean): Cha
             inputTokens: item.input_tokens,
             outputTokens: item.output_tokens,
             cacheTokens: cache,
+            cacheWriteTokens: item.cache_write_tokens || 0,
             cacheRatio,
         };
     });
@@ -99,6 +100,7 @@ export const aggregateTo5MinBuckets = (data: TimeSeriesData[]): TimeSeriesData[]
         input_tokens: number;
         output_tokens: number;
         cache_input_tokens: number;
+        cache_write_tokens: number;
         request_count: number;
         error_count: number;
         total_latency_weight: number;
@@ -128,6 +130,7 @@ export const aggregateTo5MinBuckets = (data: TimeSeriesData[]): TimeSeriesData[]
             existing.input_tokens += item.input_tokens || 0;
             existing.output_tokens += item.output_tokens || 0;
             existing.cache_input_tokens += item.cache_input_tokens || 0;
+            existing.cache_write_tokens += item.cache_write_tokens || 0;
             existing.request_count += requestCount;
             existing.error_count += item.error_count || 0;
             existing.total_latency_weight += latency * requestCount;
@@ -137,6 +140,7 @@ export const aggregateTo5MinBuckets = (data: TimeSeriesData[]): TimeSeriesData[]
                 input_tokens: item.input_tokens || 0,
                 output_tokens: item.output_tokens || 0,
                 cache_input_tokens: item.cache_input_tokens || 0,
+                cache_write_tokens: item.cache_write_tokens || 0,
                 request_count: requestCount,
                 error_count: item.error_count || 0,
                 total_latency_weight: latency * requestCount,
@@ -152,6 +156,7 @@ export const aggregateTo5MinBuckets = (data: TimeSeriesData[]): TimeSeriesData[]
             input_tokens: bucket.input_tokens,
             output_tokens: bucket.output_tokens,
             cache_input_tokens: bucket.cache_input_tokens,
+            cache_write_tokens: bucket.cache_write_tokens,
             request_count: bucket.request_count,
             error_count: bucket.error_count,
             avg_latency_ms: bucket.request_count > 0

--- a/frontend/src/components/dashboard/cacheBreakdown.test.ts
+++ b/frontend/src/components/dashboard/cacheBreakdown.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { formatCacheBreakdown, getCacheHitRate } from './chartStyles';
+
+const fmt = (n: number) => n.toLocaleString();
+
+describe('formatCacheBreakdown', () => {
+    it('omits the write half when the channel reports no writes', () => {
+        // Pre-gpt-5.6 models and Azure never surface cache writes, so a "0 written"
+        // suffix would be permanent noise rather than information.
+        expect(formatCacheBreakdown(1200, 0, fmt)).toBe('1,200 read');
+    });
+
+    it('shows reads and writes side by side once writes exist', () => {
+        expect(formatCacheBreakdown(1200, 340, fmt)).toBe('1,200 read · 340 written');
+    });
+
+    it('still reports writes when nothing was read from cache', () => {
+        // First request against a fresh prefix: everything is written, nothing hit.
+        expect(formatCacheBreakdown(0, 512, fmt)).toBe('0 read · 512 written');
+    });
+});
+
+describe('getCacheHitRate', () => {
+    it('excludes cache writes from the denominator by construction', () => {
+        // inputTokens already contains the write portion — the hit rate is
+        // read / (read + input), so writes correctly count as a miss, not a hit.
+        expect(getCacheHitRate(800, 200)).toBeCloseTo(80);
+    });
+
+    it('returns 0 rather than NaN with no traffic', () => {
+        expect(getCacheHitRate(0, 0)).toBe(0);
+    });
+});

--- a/frontend/src/components/dashboard/chartStyles.ts
+++ b/frontend/src/components/dashboard/chartStyles.ts
@@ -153,6 +153,25 @@ export const getTotalTokens = (stat: {
 export const getCacheHitRate = (cacheTokens: number, inputTokens: number): number =>
     (cacheTokens + inputTokens) > 0 ? (cacheTokens / (cacheTokens + inputTokens)) * 100 : 0;
 
+// Formats the read/write breakdown shown under a cache stat. Cache writes are
+// only reported by gpt-5.6+ and Anthropic; on every other channel the count is
+// permanently zero, so the write half is omitted rather than shown as noise.
+export const formatCacheBreakdown = (
+    cacheReadTokens: number,
+    cacheWriteTokens: number,
+    format: (n: number) => string,
+): string =>
+    cacheWriteTokens > 0
+        ? `${format(cacheReadTokens)} read \u00b7 ${format(cacheWriteTokens)} written`
+        : `${format(cacheReadTokens)} read`;
+
+// Whether any row carries a cache write, i.e. whether the write dimension is
+// worth showing at all. Owns the "omit when there is nothing to attribute"
+// policy for the tables, the same way formatCacheBreakdown owns it for the
+// stat cards — keep both readings of that policy in this one file.
+export const hasCacheWrites = (rows: { cache_write_tokens?: number }[]): boolean =>
+    rows.some((r) => (r.cache_write_tokens ?? 0) > 0);
+
 // Health-gauge color for a Cache Hit Rate stat card (higher is better).
 export const getCacheHitRateColor = (percent: number): 'success' | 'warning' | 'error' =>
     percent >= 50 ? 'success' : percent >= 20 ? 'warning' : 'error';

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -15,6 +15,8 @@ export {
     getTotalTokens,
     getCacheHitRate,
     getCacheHitRateColor,
+    formatCacheBreakdown,
+    hasCacheWrites,
     getErrorRateColor,
 } from './chartStyles';
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1078,7 +1078,7 @@ export default {
       "joined": "Added {{value}}",
       "input": "Input",
       "output": "Output",
-      "cache": "Cache",
+      "cacheRead": "Cache Read",
       "allModels": "All models",
       "modelMix": "Where their tokens went",
       "noUsers": "No users match your search.",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1078,7 +1078,7 @@ export default {
       "joined": "添加于 {{value}}",
       "input": "输入",
       "output": "输出",
-      "cache": "缓存",
+      "cacheRead": "缓存读取",
       "allModels": "全部模型",
       "modelMix": "Token 用在了哪里",
       "noUsers": "没有匹配的用户。",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2117,11 +2117,11 @@ export const handlers = [
         const groupBy = url.searchParams.get('group_by')
         const userID = url.searchParams.get('user_id')
         const userUsage = [
-            { key: 'admin', user_id: 'admin', request_count: 2310, total_tokens: 11200000, total_input_tokens: 6180000, total_output_tokens: 4220000, cache_input_tokens: 800000, error_count: 9, error_rate: 0.0039 },
-            { key: 'user-platform', user_id: 'user-platform', request_count: 1884, total_tokens: 8460000, total_input_tokens: 4620000, total_output_tokens: 3140000, cache_input_tokens: 700000, error_count: 13, error_rate: 0.0069 },
-            { key: 'user-design', user_id: 'user-design', request_count: 1256, total_tokens: 5790000, total_input_tokens: 3110000, total_output_tokens: 2260000, cache_input_tokens: 420000, error_count: 4, error_rate: 0.0032 },
-            { key: 'user-mobile', user_id: 'user-mobile', request_count: 934, total_tokens: 3680000, total_input_tokens: 2180000, total_output_tokens: 1420000, cache_input_tokens: 80000, error_count: 19, error_rate: 0.0203 },
-            { key: 'user-support', user_id: 'user-support', request_count: 226, total_tokens: 930000, total_input_tokens: 540000, total_output_tokens: 370000, cache_input_tokens: 20000, error_count: 1, error_rate: 0.0044 },
+            { key: 'admin', user_id: 'admin', request_count: 2310, total_tokens: 11200000, total_input_tokens: 6180000, total_output_tokens: 4220000, cache_input_tokens: 800000, cache_write_tokens: 96000, error_count: 9, error_rate: 0.0039 },
+            { key: 'user-platform', user_id: 'user-platform', request_count: 1884, total_tokens: 8460000, total_input_tokens: 4620000, total_output_tokens: 3140000, cache_input_tokens: 700000, cache_write_tokens: 84000, error_count: 13, error_rate: 0.0069 },
+            { key: 'user-design', user_id: 'user-design', request_count: 1256, total_tokens: 5790000, total_input_tokens: 3110000, total_output_tokens: 2260000, cache_input_tokens: 420000, cache_write_tokens: 50400, error_count: 4, error_rate: 0.0032 },
+            { key: 'user-mobile', user_id: 'user-mobile', request_count: 934, total_tokens: 3680000, total_input_tokens: 2180000, total_output_tokens: 1420000, cache_input_tokens: 80000, cache_write_tokens: 9600, error_count: 19, error_rate: 0.0203 },
+            { key: 'user-support', user_id: 'user-support', request_count: 226, total_tokens: 930000, total_input_tokens: 540000, total_output_tokens: 370000, cache_input_tokens: 20000, cache_write_tokens: 2400, error_count: 1, error_rate: 0.0044 },
         ]
         if (groupBy === 'user') {
             return HttpResponse.json({ success: true, data: userUsage })
@@ -2145,6 +2145,7 @@ export const handlers = [
                     total_input_tokens: scale(1140000),
                     total_output_tokens: scale(920000),
                     cache_input_tokens: scale(23860000),
+                    cache_write_tokens: scale(2863200),
                     avg_latency_ms: 1240,
                     error_count: scale(12),
                     error_rate: 0.65,
@@ -2161,6 +2162,7 @@ export const handlers = [
                     total_input_tokens: scale(620000),
                     total_output_tokens: scale(380000),
                     cache_input_tokens: scale(7180000),
+                    cache_write_tokens: scale(861600),
                     avg_latency_ms: 2100,
                     error_count: scale(3),
                     error_rate: 0.71,
@@ -2177,6 +2179,7 @@ export const handlers = [
                     total_input_tokens: scale(890000),
                     total_output_tokens: scale(520000),
                     cache_input_tokens: scale(5310000),
+                    cache_write_tokens: scale(637200),
                     avg_latency_ms: 980,
                     error_count: scale(8),
                     error_rate: 0.85,
@@ -2193,6 +2196,7 @@ export const handlers = [
                     total_input_tokens: scale(390000),
                     total_output_tokens: scale(410000),
                     cache_input_tokens: scale(3510000),
+                    cache_write_tokens: scale(421200),
                     avg_latency_ms: 420,
                     error_count: scale(5),
                     error_rate: 0.23,
@@ -2209,6 +2213,7 @@ export const handlers = [
                     total_input_tokens: scale(1050000),
                     total_output_tokens: scale(120000),
                     cache_input_tokens: scale(180000),
+                    cache_write_tokens: scale(21600),
                     avg_latency_ms: 3200,
                     error_count: scale(2),
                     error_rate: 0.64,
@@ -2268,6 +2273,8 @@ export const handlers = [
                     input_tokens: input,
                     output_tokens: output,
                     cache_input_tokens: cache,
+                    // Writes are a slice of the uncached input, never on top of it.
+                    cache_write_tokens: Math.round(input * 0.12),
                     total_tokens: input + output + cache,
                     error_count: Math.round(Math.random() * 3),
                     avg_latency_ms: Math.round(900 + Math.random() * 600),
@@ -2344,6 +2351,7 @@ export const handlers = [
                 output_tokens: output,
                 total_tokens: input + output + cache,
                 cache_input_tokens: cache,
+                cache_write_tokens: Math.round(input * 0.12),
                 status: isError ? 'error' : 'success',
                 error_code: isError ? 'rate_limit_exceeded' : '',
                 latency_ms: latency,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -18,7 +18,7 @@ import {
     Divider,
 } from '@mui/material';
 import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon, Token as PaidIcon, Stream as StreamIcon, Autorenew as CachedIcon, FilterOff } from '@/components/icons';
-import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView, DashboardHeatmapSection, formatNumber, getTotalTokens, getCacheHitRate, getCacheHitRateColor, getErrorRateColor } from '@/components/dashboard';
+import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView, DashboardHeatmapSection, formatNumber, getTotalTokens, getCacheHitRate, getCacheHitRateColor, formatCacheBreakdown, getErrorRateColor } from '@/components/dashboard';
 import type { TimeSeriesData, AggregatedStat, UsageRecord } from '@/components/dashboard';
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import PageHeader from '@/components/PageHeader';
@@ -374,6 +374,10 @@ export default function DashboardPage() {
     const totalInputTokens = stats.reduce((sum, s) => sum + (s.total_input_tokens || 0), 0);
     const totalOutputTokens = stats.reduce((sum, s) => sum + (s.total_output_tokens || 0), 0);
     const totalCacheTokens = stats.reduce((sum, s) => sum + (s.cache_input_tokens || 0), 0);
+    // Cache writes are already inside total_input_tokens (they are billed at a
+    // premium but are still this prompt's input), so they are reported next to
+    // the read hits rather than added to any total.
+    const totalCacheWriteTokens = stats.reduce((sum, s) => sum + (s.cache_write_tokens || 0), 0);
     const totalTokens = totalInputTokens + totalOutputTokens + totalCacheTokens;
 
     // Calculate error rate
@@ -672,7 +676,7 @@ export default function DashboardPage() {
                         <StatCard
                             title="Cache Hit Rate"
                             value={`${cacheHitRate.toFixed(1)}%`}
-                            subtitle={`${formatNumber(totalCacheTokens)} cached`}
+                            subtitle={formatCacheBreakdown(totalCacheTokens, totalCacheWriteTokens, formatNumber)}
                             icon={<CachedIcon />}
                             color={getCacheHitRateColor(cacheHitRate)}
                         />

--- a/frontend/src/pages/UserUsagePage.tsx
+++ b/frontend/src/pages/UserUsagePage.tsx
@@ -50,6 +50,7 @@ import {
     getTotalTokens,
     getCacheHitRate,
     getCacheHitRateColor,
+    formatCacheBreakdown,
     getErrorRateColor,
 } from '@/components/dashboard';
 import type { AggregatedStat } from '@/components/dashboard';
@@ -75,6 +76,7 @@ interface UserUsageRow extends APITokenInfo {
     total_input_tokens: number;
     total_output_tokens: number;
     cache_input_tokens: number;
+    cache_write_tokens: number;
     error_count: number;
     error_rate: number;
 }
@@ -265,6 +267,7 @@ export default function UserUsagePage() {
                 total_input_tokens: stat?.total_input_tokens || 0,
                 total_output_tokens: stat?.total_output_tokens || 0,
                 cache_input_tokens: stat?.cache_input_tokens || 0,
+                cache_write_tokens: stat?.cache_write_tokens || 0,
                 error_count: stat?.error_count || 0,
                 error_rate: stat?.error_rate || 0,
             };
@@ -332,12 +335,13 @@ export default function UserUsagePage() {
                 acc.tokens += row.total_tokens;
                 acc.inputTokens += row.total_input_tokens;
                 acc.cacheTokens += row.cache_input_tokens;
+                acc.cacheWriteTokens += row.cache_write_tokens;
                 acc.requests += row.request_count;
                 acc.errors += row.error_count;
                 if (row.request_count > 0) acc.activeUsers += 1;
                 return acc;
             },
-            { tokens: 0, inputTokens: 0, cacheTokens: 0, requests: 0, errors: 0, activeUsers: 0 },
+            { tokens: 0, inputTokens: 0, cacheTokens: 0, cacheWriteTokens: 0, requests: 0, errors: 0, activeUsers: 0 },
         );
         return {
             ...totals,
@@ -348,6 +352,7 @@ export default function UserUsagePage() {
     const {
         tokens: totalTokens,
         cacheTokens: totalCacheTokens,
+        cacheWriteTokens: totalCacheWriteTokens,
         requests: totalRequests,
         errors: totalErrors,
         activeUsers,
@@ -382,10 +387,9 @@ export default function UserUsagePage() {
         {
             label: t('dashboard.userUsage.cacheHitRate', { defaultValue: 'Cache hit rate' }),
             value: `${cacheHitRate.toFixed(1)}%`,
-            hint: t('dashboard.userUsage.cached', {
-                value: formatNumber(totalCacheTokens),
-                defaultValue: `${formatNumber(totalCacheTokens)} cached`,
-            }),
+            // Already a fully composed string; wrapping it in t() would be an
+            // identity call against a key that does not exist.
+            hint: formatCacheBreakdown(totalCacheTokens, totalCacheWriteTokens, formatNumber),
             icon: <CachedIcon />,
             color: getCacheHitRateColor(cacheHitRate),
         },
@@ -803,7 +807,7 @@ export default function UserUsagePage() {
                                     {[
                                         { label: t('dashboard.userUsage.input', { defaultValue: 'Input' }), value: selectedUser.total_input_tokens, color: TOKEN_COLORS.input.main },
                                         { label: t('dashboard.userUsage.output', { defaultValue: 'Output' }), value: selectedUser.total_output_tokens, color: TOKEN_COLORS.output.main },
-                                        { label: t('dashboard.userUsage.cache', { defaultValue: 'Cache' }), value: selectedUser.cache_input_tokens, color: TOKEN_COLORS.cache.main },
+                                        { label: t('dashboard.userUsage.cacheRead', { defaultValue: 'Cache Read' }), value: selectedUser.cache_input_tokens, color: TOKEN_COLORS.cache.main },
                                     ].map(({ label, value, color }) => (
                                         <Grid
                                             key={label}


### PR DESCRIPTION
Folded into #1453 — the frontend half is 16 files and splitting it only bought an extra review round. The commit is carried over unchanged (`e7db5ee`).