### PR TITLE
bugfix(protocol): preserve prompt cache across conversions

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -13,6 +13,10 @@
 > §10.1. The matrix itself always sends the same fixed single-turn prompt and
 > only varies the mocked *response* shape, so it cannot catch bugs in how
 > unusual *request* shapes are forwarded upstream.
+>
+> Related: prompt-cache request metadata is covered by `cache_controls.go` —
+> see §10.2. It validates cache/no-cache over every single hop and every ABA
+> idempotent chain.
 
 ---
 
@@ -98,8 +102,8 @@ Assertions + SemanticEquivalence checks
 
 ### Section drivers (`section.go`)
 
-Every section (single-hop, transitive, idempotent, flags, content_shapes)
-contributes only its combos and per-combo execution; the env-per-scenario
+Every section (single-hop, transitive, idempotent, flags, content_shapes,
+cache_controls) contributes only its combos and per-combo execution; the env-per-scenario
 lifecycle, setup-failure fan-out, and `testing.T` scaffolding live once in
 `internal/protocoltest/section.go`:
 
@@ -107,14 +111,15 @@ lifecycle, setup-failure fan-out, and `testing.T` scaffolding live once in
 |--------|---------|---------|
 | `Matrix.executePerScenario(skip, combosFor)` | `ExecuteAll` / `ExecuteAllTransitive` / `ExecuteAllIdempotent` | CLI-side: one env per scenario, scenarios run concurrently (§3.1), combos within a scenario run sequentially against the shared env |
 | `Matrix.runPerScenario(t, skip, run)` | `RunTransitive` / `RunIdempotent` | `testing.T` counterpart: one env per scenario subtest, `t.Parallel()` scenarios, combos sequential |
-| `Matrix.runRecorderCases(cases)` | `ExecuteAllFlags` / `ExecuteAllContentShapes` | CLI-side: one env per case, cases run concurrently (§3.1) |
-| `runRecorderCase(name, scenario, run)` | `runRecorderCases` | Runs one `flagTB`-style case body under the recording shim (`flagRecorder`), returns its `TestResult` |
+| `Matrix.runRecorderCases(cases)` | `ExecuteAllFlags` / `ExecuteAllContentShapes` / `ExecuteAllCacheControls` | CLI-side: one env per case, cases run concurrently (§3.1) |
+| `runRecorderCase(case)` | `runRecorderCases` | Runs one `flagTB`-style case body under the recording shim (`flagRecorder`), returns its `TestResult` |
 | `setupFailureResult(base, err)` | `executeScenarioCombos` / `runRecorderCase` | Shared "env failed to boot" `TestResult` construction |
 
 A `scenarioCombo` is `{meta TestResult, run func(*TestEnv) TestResult}` — the
 `meta` doubles as the setup-failure result when the scenario's env cannot be
-created. A `recorderCase` is the equivalent for the flags/content_shapes
-suites: `{name, scenario string, run func(flagTB, *TestEnv)}`. (Single-hop
+created. A `recorderCase` is the equivalent for the
+flags/content_shapes/cache_controls suites: it carries result metadata plus
+`run func(flagTB, *TestEnv)`. (Single-hop
 `Matrix.Run(t)` keeps its own deeper subtest nesting —
 `scenario/source/target/mode` with one env per leaf — because its test-name
 contract and per-leaf parallelism differ from the per-scenario sections.)
@@ -208,22 +213,23 @@ go test -tags e2e ./internal/protocoltest/... -run TestContentShapes
 executor (`ExecuteAll*`) so the CLI can run it directly — including idempotence
 and the rule-flag suite, which would otherwise be go-test-only.
 
-| `--mode` | single (A→B) | transitive (A→B→C) | idempotent (`g(f(A))==A`) | flags (per-rule) | content_shapes (§10.1) |
-|----------|:---:|:---:|:---:|:---:|:---:|
-| `default` *(no flag)* | ✅ | — | ✅ | — | — |
-| `all` | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `single` | ✅ | — | — | — | — |
-| `transitive` | — | ✅ | — | — | — |
-| `idempotent` | — | — | ✅ | — | — |
-| `flags` | — | — | — | ✅ | — |
-| `content_shapes` | — | — | — | — | ✅ |
+| `--mode` | single (A→B) | transitive (A→B→C) | idempotent (`g(f(A))==A`) | flags (per-rule) | content_shapes (§10.1) | cache_controls (§10.2) |
+|----------|:---:|:---:|:---:|:---:|:---:|:---:|
+| `default` *(no flag)* | ✅ | — | ✅ | — | — | — |
+| `all` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `single` | ✅ | — | — | — | — | — |
+| `transitive` | — | ✅ | — | — | — | — |
+| `idempotent` | — | — | ✅ | — | — | — |
+| `flags` | — | — | — | ✅ | — | — |
+| `content_shapes` | — | — | — | — | ✅ | — |
+| `cache_controls` | — | — | — | — | — | ✅ |
 
 This mode → section mapping is declared in one place: the `matrixSections`
 registry in `cli/harness/matrix.go`. Each entry names the section, lists the
-`--mode` values that include it, marks whether it is http-only (`flags` /
-`content_shapes` drive raw requests directly), and points at its
-`ExecuteAll*` executor. Adding a section = one registry entry + extending the
-`--mode` enum (see §8 for why this replaced a hand-maintained if-chain).
+`--mode` values that include it, marks whether it is http-only (`flags`,
+`content_shapes`, and `cache_controls` drive raw requests directly), and points
+at its `ExecuteAll*` executor. Adding a section = one registry entry + extending
+the `--mode` enum (see §8 for why this replaced a hand-maintained if-chain).
 
 ```bash
 # Default: single-hop + idempotent round-trips. Two-hop and flags are OFF by
@@ -240,6 +246,7 @@ go run ./cli/harness matrix --mode=transitive
 go run ./cli/harness matrix --mode=idempotent
 go run ./cli/harness matrix --mode=flags     # per-rule flag behavior
 go run ./cli/harness matrix --mode=content_shapes  # request content-shape regression
+go run ./cli/harness matrix --mode=cache_controls  # single-hop + ABA cache/no-cache
 
 # Filter by scenario / source / target
 go run ./cli/harness matrix --scenario text --source anthropic_v1
@@ -254,6 +261,11 @@ The `flags` section is documented in detail in
 
 The `content_shapes` section is documented in §10.1 below; `ExecuteAllContentShapes`
 reports one `TestResult` per case (`Name: "content_shapes/<case name>"`).
+
+The `cache_controls` section is documented in §10.2 below;
+`ExecuteAllCacheControls` reports one result per protocol path and stream mode.
+Each result verifies both the positive cache request and the negative no-cache
+request against the final provider capture.
 
 Other CLI flags (`--batch`, `--record-dir`, `--mcp`, `-v`) are documented in
 [`cli/harness/README.md`](../cli/harness/README.md); `--batch` and
@@ -559,3 +571,31 @@ under both `*testing.T` (`TestContentShapes`) and the CLI
 See `contentShapeCases()` in `content_shapes.go` for current coverage. Extend
 that list, not the matrix's `Scenario`/`buildRequest`, when a future bug is
 "the gateway dropped an unusual request shape while forwarding it."
+
+### 10.2 Prompt-cache request suite (`cache_controls.go`)
+
+Prompt-cache metadata is also request-shaped and therefore cannot be exercised
+by the matrix's fixed request. `cache_controls.go` uses the same raw-request and
+provider-capture approach as `content_shapes`, across two path classes:
+
+- **single-hop**: every pair in `DefaultPairs()` (A→B);
+- **ABA**: every case in `DefaultIdempotentCases()` (A→B→A).
+
+ABA cases reuse `setupChainHopRoute`: the A→B provider points back at the
+gateway's B endpoint, so the same request genuinely re-enters the HTTP gateway
+and executes B→A before reaching `VirtualServer`. This is distinct from the
+`transitive` section, whose two hops are separate requests.
+
+For every path and stream mode, the suite sends:
+
+1. a cached request with two stable-prefix markers and verifies both markers
+   plus OpenAI explicit mode at the final provider;
+2. the matching no-cache request and verifies that no marker or explicit mode
+   was synthesized.
+
+Run it with:
+
+```bash
+go test ./internal/protocoltest -run TestCacheControls -count=1
+go run ./cli/harness matrix --mode=cache_controls
+```

--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -579,7 +579,7 @@ cost_input = (prompt_tokens − cached_tokens − cache_write_tokens) × input_r
 
 `cached_tokens` 与 `cache_write_tokens` 都是 `prompt_tokens` 的子集且**互不重叠**。OpenAI 文档没有一句话明说这点，但 `prompt_tokens_details` 的定义就是「prompt 的拆分」；社区曾上报 `cached + write > prompt_tokens` 的账单，OpenAI 确认是 bug 并退款。**如果上游真的发来 `cached + write > prompt`，那是上游 bug，不要跟着算。**
 
-### 12.2 请求侧参数（当前为透传，无本地语义）
+### 12.2 请求侧参数与跨协议转换
 
 | 参数 | 状态 | 说明 |
 |---|---|---|
@@ -591,6 +591,14 @@ cost_input = (prompt_tokens − cached_tokens − cache_write_tokens) × input_r
 `prompt_cache_breakpoint` 的可挂载位置：Chat 是 `text` / `image_url` / `input_audio` / `file` 四种 content part（**不含 tools 定义**）；Responses 是 `input_text` / `input_image` / `input_file`。`implicit` 模式下 1 个隐式 + 最新 3 个显式断点，`explicit` 模式下无隐式 + 最新 4 个显式（无显式断点 = 完全不走缓存）。前缀仍需 ≥1024 token 才可缓存。
 
 > ⚠️ 5.6+ 的 `ttl` 只有 `30m`，比老模型的 `24h` 短——长会话代理的缓存命中率会下降，路由策略若依赖长缓存需要重新评估。
+
+协议转换必须保留缓存语义：
+
+- Chat ↔ Responses 双向复制 `prompt_cache_key`、`prompt_cache_options`、`prompt_cache_retention`，并逐 content block 映射 `prompt_cache_breakpoint`。
+- Anthropic Messages 的 `cache_control` 与 Chat / Responses 的显式 content breakpoint 双向映射；有断点时设置 OpenAI `prompt_cache_options.mode = "explicit"`。
+- Responses 的 `instructions` 是纯字符串，不能承载断点；带 cache 的 Anthropic system block 或 Chat system content 必须转换为 `role = "system"` 的 input item，不能塞进 `instructions`。
+- OpenAI 不允许在 tool definition 上挂 breakpoint。Anthropic tool definition 上的 `cache_control` 转换时推进到 tools 后第一个可缓存 content block，使缓存前缀仍包含完整 tools，不能直接丢弃。
+- Anthropic `5m` / `1h` 与 OpenAI 当前 `30m` TTL 不同，跨协议只保证 breakpoint 语义，不伪造等价 TTL。
 
 ### 12.3 通道差异
 

--- a/cli/harness/matrix.go
+++ b/cli/harness/matrix.go
@@ -26,7 +26,7 @@ type MatrixCmd struct {
 	Targets    []string `kong:"name='target',sep=',',help='Filter by target protocol (can repeat or comma-separate)'"`
 	Streaming  bool     `kong:"name='streaming',help='Run only streaming tests'"`
 	NonStream  bool     `kong:"name='non-streaming',help='Run only non-streaming tests'"`
-	Mode       string   `kong:"name='mode',default='default',enum='default,all,single,transitive,idempotent,flags,content_shapes',help='Section selection: default (single + idempotent round-trip; two-hop OFF), all (single + transitive + idempotent + flags + content_shapes), single (A→B only), transitive (A→B→C only), idempotent (round-trip g(f(A))==A only), flags (per-rule flag behavior only), content_shapes (request content-shape regression only)'"`
+	Mode       string   `kong:"name='mode',default='default',enum='default,all,single,transitive,idempotent,flags,content_shapes,cache_controls',help='Section selection: default (single + idempotent round-trip; two-hop OFF), all (every section), single (A→B only), transitive (A→B→C only), idempotent (round-trip g(f(A))==A only), flags (per-rule flag behavior only), content_shapes (request content-shape regression only), cache_controls (single-hop + ABA cache/no-cache requests)'"`
 	Client     string   `kong:"name='client',default='http',enum='http,gosdk,python,node,aisdk',help='Client driver: http (raw JSON over net/http, default), gosdk (official anthropic-sdk-go / openai-go), python (real Python SDKs via subprocess driver), node (real Node SDKs via subprocess driver), aisdk (AI SDK by Vercel via subprocess driver)'"`
 	JsonOutput bool     `kong:"name='json',help='Output results as JSON'"`
 	Verbose    int      `kong:"name='verbose',short='v',type='counter',help='Verbose output (repeat for more detail)'"`
@@ -54,6 +54,7 @@ var matrixSections = []matrixSection{
 	{name: "idempotent", modes: []string{"default", "all", "idempotent"}, exec: (*protocoltest.Matrix).ExecuteAllIdempotent},
 	{name: "flags", modes: []string{"all", "flags"}, httpOnly: true, exec: (*protocoltest.Matrix).ExecuteAllFlags},
 	{name: "content_shapes", modes: []string{"all", "content_shapes"}, httpOnly: true, exec: (*protocoltest.Matrix).ExecuteAllContentShapes},
+	{name: "cache_controls", modes: []string{"all", "cache_controls"}, httpOnly: true, exec: (*protocoltest.Matrix).ExecuteAllCacheControls},
 }
 
 // Help returns extended help text shown by `harness matrix --help`.
@@ -77,6 +78,9 @@ func (*MatrixCmd) Help() string {
 
   # Run only request content-shape regression tests
   harness matrix --mode=content_shapes
+
+  # Run single-hop + ABA prompt-cache request tests
+  harness matrix --mode=cache_controls
 
   # Run only single-hop (A→B) tests
   harness matrix --mode=single

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
 )
@@ -13,15 +14,32 @@ import (
 func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageNewParams) *responses.ResponseNewParams {
 	params := &responses.ResponseNewParams{}
 	params.Model = shared.ResponsesModel(anthropicReq.Model)
+	hasSystemCacheControl := false
 
 	// Convert system messages to Instructions (system/developer role)
 	if len(anthropicReq.System) > 0 {
-		params.Instructions = ParamOpt(ConvertBetaTextBlocksToString(anthropicReq.System))
+		for _, block := range anthropicReq.System {
+			hasSystemCacheControl = hasSystemCacheControl || !param.IsOmitted(block.CacheControl)
+		}
+		if !hasSystemCacheControl {
+			params.Instructions = ParamOpt(ConvertBetaTextBlocksToString(anthropicReq.System))
+		}
 	}
 
 	// Convert messages to Response API Input items
 	// Build conversation as a list of input items
 	var inputItems []responses.ResponseInputItemUnionParam
+	if hasSystemCacheControl {
+		content := make(responses.ResponseInputMessageContentListParam, 0, len(anthropicReq.System))
+		for _, block := range anthropicReq.System {
+			part := &responses.ResponseInputTextParam{Text: block.Text}
+			if !param.IsOmitted(block.CacheControl) {
+				part.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+			}
+			content = append(content, responses.ResponseInputContentUnionParam{OfInputText: part})
+		}
+		inputItems = append(inputItems, responseMessageWithContent("system", content))
+	}
 
 	for _, msg := range anthropicReq.Messages {
 		if string(msg.Role) == "user" {
@@ -62,6 +80,15 @@ func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageN
 		params.ToolChoice = ConvertAnthropicBetaToolChoiceToResponses(&anthropicReq.ToolChoice)
 	}
 
+	hasRepresentableCacheControl := hasSystemCacheControl || anthropicBetaMessagesHaveRepresentableCacheControl(anthropicReq.Messages)
+	hasToolCacheControl := anthropicBetaToolsHaveCacheControl(anthropicReq.Tools)
+	if hasRepresentableCacheControl || hasToolCacheControl {
+		params.PromptCacheOptions.Mode = "explicit"
+		if !hasRepresentableCacheControl && hasToolCacheControl {
+			applyFirstResponsesCacheBreakpoint(params)
+		}
+	}
+
 	//// Convert stop sequences
 	//if len(anthropicReq.StopSequences) > 0 {
 	//	// Responses API uses Stop as a union type
@@ -76,13 +103,16 @@ func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageN
 func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
 
-	var hasToolResult, hasImage bool
+	var hasToolResult, hasImage, hasCacheControl bool
 	for _, block := range msg.Content {
 		if block.OfToolResult != nil {
 			hasToolResult = true
 		}
 		if block.OfImage != nil {
 			hasImage = true
+		}
+		if cacheControl := block.GetCacheControl(); cacheControl != nil {
+			hasCacheControl = hasCacheControl || !param.IsOmitted(*cacheControl)
 		}
 	}
 
@@ -91,11 +121,22 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 		for _, block := range msg.Content {
 			if block.OfToolResult != nil {
 				// Convert tool_result to Responses API function call output
+				output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
+				content := convertBetaToolResultContent(block.OfToolResult.Content)
+				if !param.IsOmitted(block.OfToolResult.CacheControl) {
+					text := &responses.ResponseInputTextContentParam{
+						Text:                  content,
+						PromptCacheBreakpoint: responses.NewResponseInputTextContentPromptCacheBreakpointParam(),
+					}
+					output.OfResponseFunctionCallOutputItemArray = responses.ResponseFunctionCallOutputItemListParam{
+						{OfInputText: text},
+					}
+				} else {
+					output.OfString = ParamOpt(content)
+				}
 				outputItem := responses.ResponseInputItemFunctionCallOutputParam{
 					CallID: block.OfToolResult.ToolUseID,
-					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
-						OfString: ParamOpt(convertBetaToolResultContent(block.OfToolResult.Content)),
-					},
+					Output: output,
 					Status: "completed",
 				}
 				items = append(items, responses.ResponseInputItemUnionParam{
@@ -103,37 +144,51 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 				})
 			} else if block.OfText != nil && block.OfText.Text != "" {
 				// Text content alongside tool results
+				content := responses.EasyInputMessageContentUnionParam{OfString: ParamOpt(block.OfText.Text)}
+				if !param.IsOmitted(block.OfText.CacheControl) {
+					text := &responses.ResponseInputTextParam{
+						Text:                  block.OfText.Text,
+						PromptCacheBreakpoint: responses.NewResponseInputTextPromptCacheBreakpointParam(),
+					}
+					content = responses.EasyInputMessageContentUnionParam{
+						OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+							{OfInputText: text},
+						},
+					}
+				}
 				messageItem := responses.EasyInputMessageParam{
-					Type: responses.EasyInputMessageTypeMessage,
-					Role: responses.EasyInputMessageRole("user"),
-					Content: responses.EasyInputMessageContentUnionParam{
-						OfString: ParamOpt(block.OfText.Text),
-					},
+					Type:    responses.EasyInputMessageTypeMessage,
+					Role:    responses.EasyInputMessageRole("user"),
+					Content: content,
 				}
 				items = append(items, responses.ResponseInputItemUnionParam{
 					OfMessage: &messageItem,
 				})
 			}
 		}
-	} else if hasImage {
+	} else if hasImage || hasCacheControl {
 		// Multimodal user message: emit input_text + input_image content parts
 		contentList := make(responses.ResponseInputMessageContentListParam, 0, len(msg.Content))
 		for _, block := range msg.Content {
 			switch {
 			case block.OfText != nil:
+				text := &responses.ResponseInputTextParam{Text: block.OfText.Text}
+				if !param.IsOmitted(block.OfText.CacheControl) {
+					text.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+				}
 				contentList = append(contentList, responses.ResponseInputContentUnionParam{
-					OfInputText: &responses.ResponseInputTextParam{Text: block.OfText.Text},
+					OfInputText: text,
 				})
 			case block.OfImage != nil:
 				url := betaImageBlockToOpenAIURL(block.OfImage)
 				if url == "" {
 					continue
 				}
-				contentList = append(contentList, responses.ResponseInputContentUnionParam{
-					OfInputImage: &responses.ResponseInputImageParam{
-						ImageURL: ParamOpt(url),
-					},
-				})
+				image := &responses.ResponseInputImageParam{ImageURL: ParamOpt(url)}
+				if !param.IsOmitted(block.OfImage.CacheControl) {
+					image.PromptCacheBreakpoint = responses.NewResponseInputImagePromptCacheBreakpointParam()
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{OfInputImage: image})
 			}
 		}
 		if len(contentList) > 0 {
@@ -173,11 +228,13 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 func convertBetaAssistantMessageToResponsesInput(msg anthropic.BetaMessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
 	var textContent string
+	var textBlocks []anthropic.BetaTextBlockParam
 
 	// Process content blocks
 	for _, block := range msg.Content {
 		if block.OfText != nil {
 			textContent += block.OfText.Text
+			textBlocks = append(textBlocks, *block.OfText)
 		}
 	}
 
@@ -200,12 +257,25 @@ func convertBetaAssistantMessageToResponsesInput(msg anthropic.BetaMessageParam)
 
 	// Add text content as a separate message if present
 	if textContent != "" {
+		content := responses.EasyInputMessageContentUnionParam{OfString: ParamOpt(textContent)}
+		for _, block := range textBlocks {
+			if !param.IsOmitted(block.CacheControl) {
+				parts := make(responses.ResponseInputMessageContentListParam, 0, len(textBlocks))
+				for _, textBlock := range textBlocks {
+					part := &responses.ResponseInputTextParam{Text: textBlock.Text}
+					if !param.IsOmitted(textBlock.CacheControl) {
+						part.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+					}
+					parts = append(parts, responses.ResponseInputContentUnionParam{OfInputText: part})
+				}
+				content = responses.EasyInputMessageContentUnionParam{OfInputItemContentList: parts}
+				break
+			}
+		}
 		messageItem := responses.EasyInputMessageParam{
-			Type: responses.EasyInputMessageTypeMessage,
-			Role: responses.EasyInputMessageRole("assistant"),
-			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: ParamOpt(textContent),
-			},
+			Type:    responses.EasyInputMessageTypeMessage,
+			Role:    responses.EasyInputMessageRole("assistant"),
+			Content: content,
 		}
 		items = append(items, responses.ResponseInputItemUnionParam{
 			OfMessage: &messageItem,
@@ -214,6 +284,31 @@ func convertBetaAssistantMessageToResponsesInput(msg anthropic.BetaMessageParam)
 
 	// An assistant message with no text and no tool_use blocks is empty — skip it.
 	return items
+}
+
+func anthropicBetaMessagesHaveRepresentableCacheControl(messages []anthropic.BetaMessageParam) bool {
+	for _, message := range messages {
+		for _, block := range message.Content {
+			cacheControl := block.GetCacheControl()
+			if cacheControl == nil || param.IsOmitted(*cacheControl) {
+				continue
+			}
+			if block.OfText != nil || block.OfImage != nil || block.OfToolResult != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anthropicBetaToolsHaveCacheControl(tools []anthropic.BetaToolUnionParam) bool {
+	for _, tool := range tools {
+		cacheControl := tool.GetCacheControl()
+		if cacheControl != nil && !param.IsOmitted(*cacheControl) {
+			return true
+		}
+	}
+	return false
 }
 
 // ConvertAnthropicBetaToolsToResponses converts Anthropic beta tools to Responses API format

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -81,10 +81,11 @@ func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageN
 	}
 
 	hasRepresentableCacheControl := hasSystemCacheControl || anthropicBetaMessagesHaveRepresentableCacheControl(anthropicReq.Messages)
-	hasToolCacheControl := anthropicBetaToolsHaveCacheControl(anthropicReq.Tools)
-	if hasRepresentableCacheControl || hasToolCacheControl {
+	hasFallbackCacheControl := anthropicBetaToolsHaveCacheControl(anthropicReq.Tools) ||
+		anthropicBetaMessagesHaveToolUseCacheControl(anthropicReq.Messages)
+	if hasRepresentableCacheControl || hasFallbackCacheControl {
 		params.PromptCacheOptions.Mode = "explicit"
-		if !hasRepresentableCacheControl && hasToolCacheControl {
+		if !hasRepresentableCacheControl && hasFallbackCacheControl {
 			applyFirstResponsesCacheBreakpoint(params)
 		}
 	}
@@ -294,6 +295,17 @@ func anthropicBetaMessagesHaveRepresentableCacheControl(messages []anthropic.Bet
 				continue
 			}
 			if block.OfText != nil || block.OfImage != nil || block.OfToolResult != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anthropicBetaMessagesHaveToolUseCacheControl(messages []anthropic.BetaMessageParam) bool {
+	for _, message := range messages {
+		for _, block := range message.Content {
+			if block.OfToolUse != nil && !param.IsOmitted(block.OfToolUse.CacheControl) {
 				return true
 			}
 		}

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -76,10 +76,11 @@ func ConvertAnthropicV1ToResponsesRequest(anthropicReq *anthropic.MessageNewPara
 	}
 
 	hasRepresentableCacheControl := hasSystemCacheControl || anthropicV1MessagesHaveRepresentableCacheControl(anthropicReq.Messages)
-	hasToolCacheControl := anthropicV1ToolsHaveCacheControl(anthropicReq.Tools)
-	if hasRepresentableCacheControl || hasToolCacheControl {
+	hasFallbackCacheControl := anthropicV1ToolsHaveCacheControl(anthropicReq.Tools) ||
+		anthropicV1MessagesHaveToolUseCacheControl(anthropicReq.Messages)
+	if hasRepresentableCacheControl || hasFallbackCacheControl {
 		params.PromptCacheOptions.Mode = "explicit"
-		if !hasRepresentableCacheControl && hasToolCacheControl {
+		if !hasRepresentableCacheControl && hasFallbackCacheControl {
 			applyFirstResponsesCacheBreakpoint(params)
 		}
 	}
@@ -304,6 +305,17 @@ func anthropicV1MessagesHaveRepresentableCacheControl(messages []anthropic.Messa
 				continue
 			}
 			if block.OfText != nil || block.OfImage != nil || block.OfToolResult != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anthropicV1MessagesHaveToolUseCacheControl(messages []anthropic.MessageParam) bool {
+	for _, message := range messages {
+		for _, block := range message.Content {
+			if block.OfToolUse != nil && !param.IsOmitted(block.OfToolUse.CacheControl) {
 				return true
 			}
 		}

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -14,23 +14,39 @@ import (
 func ConvertAnthropicV1ToResponsesRequest(anthropicReq *anthropic.MessageNewParams) *responses.ResponseNewParams {
 	params := &responses.ResponseNewParams{}
 	params.Model = shared.ResponsesModel(anthropicReq.Model)
+	hasSystemCacheControl := false
 
 	// Convert system messages to Instructions (system role in v1)
 	// In v1, system messages are passed via the System param
 	if len(anthropicReq.System) > 0 {
+		for _, block := range anthropicReq.System {
+			hasSystemCacheControl = hasSystemCacheControl || !param.IsOmitted(block.CacheControl)
+		}
 		// Join system text blocks into a single instruction string
 		var instructionsStr string
 		for _, block := range anthropicReq.System {
 			instructionsStr += block.Text
 		}
-		if instructionsStr != "" {
+		if instructionsStr != "" && !hasSystemCacheControl {
 			params.Instructions = param.NewOpt(instructionsStr)
 		}
 	}
 
 	// Convert messages to Input items (Responses API format)
 	// Always set Input field, even if empty, as Responses API requires it
-	inputItems := convertV1MessagesToResponsesInput(anthropicReq.Messages)
+	var inputItems responses.ResponseInputParam
+	if hasSystemCacheControl {
+		content := make(responses.ResponseInputMessageContentListParam, 0, len(anthropicReq.System))
+		for _, block := range anthropicReq.System {
+			part := &responses.ResponseInputTextParam{Text: block.Text}
+			if !param.IsOmitted(block.CacheControl) {
+				part.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+			}
+			content = append(content, responses.ResponseInputContentUnionParam{OfInputText: part})
+		}
+		inputItems = append(inputItems, responseMessageWithContent("system", content))
+	}
+	inputItems = append(inputItems, convertV1MessagesToResponsesInput(anthropicReq.Messages)...)
 	params.Input = responses.ResponseNewParamsInputUnion{
 		OfInputItemList: responses.ResponseInputParam(inputItems),
 	}
@@ -59,6 +75,15 @@ func ConvertAnthropicV1ToResponsesRequest(anthropicReq *anthropic.MessageNewPara
 		params.ToolChoice = ConvertAnthropicV1ToolChoiceToResponses(&anthropicReq.ToolChoice)
 	}
 
+	hasRepresentableCacheControl := hasSystemCacheControl || anthropicV1MessagesHaveRepresentableCacheControl(anthropicReq.Messages)
+	hasToolCacheControl := anthropicV1ToolsHaveCacheControl(anthropicReq.Tools)
+	if hasRepresentableCacheControl || hasToolCacheControl {
+		params.PromptCacheOptions.Mode = "explicit"
+		if !hasRepresentableCacheControl && hasToolCacheControl {
+			applyFirstResponsesCacheBreakpoint(params)
+		}
+	}
+
 	return params
 }
 
@@ -83,13 +108,16 @@ func convertV1MessagesToResponsesInput(messages []anthropic.MessageParam) respon
 func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
 
-	var hasToolResult, hasImage bool
+	var hasToolResult, hasImage, hasCacheControl bool
 	for _, block := range msg.Content {
 		if block.OfToolResult != nil {
 			hasToolResult = true
 		}
 		if block.OfImage != nil {
 			hasImage = true
+		}
+		if cacheControl := block.GetCacheControl(); cacheControl != nil {
+			hasCacheControl = hasCacheControl || !param.IsOmitted(*cacheControl)
 		}
 	}
 
@@ -98,11 +126,22 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 		for _, block := range msg.Content {
 			if block.OfToolResult != nil {
 				// Convert tool_result to function_call_output
+				output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
+				content := convertV1ToolResultContentToString(block.OfToolResult.Content)
+				if !param.IsOmitted(block.OfToolResult.CacheControl) {
+					text := &responses.ResponseInputTextContentParam{
+						Text:                  content,
+						PromptCacheBreakpoint: responses.NewResponseInputTextContentPromptCacheBreakpointParam(),
+					}
+					output.OfResponseFunctionCallOutputItemArray = responses.ResponseFunctionCallOutputItemListParam{
+						{OfInputText: text},
+					}
+				} else {
+					output.OfString = param.NewOpt(content)
+				}
 				outputItem := responses.ResponseInputItemFunctionCallOutputParam{
 					CallID: block.OfToolResult.ToolUseID,
-					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
-						OfString: param.NewOpt(convertV1ToolResultContentToString(block.OfToolResult.Content)),
-					},
+					Output: output,
 					Status: "completed",
 				}
 				items = append(items, responses.ResponseInputItemUnionParam{
@@ -110,12 +149,24 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 				})
 			} else if block.OfText != nil {
 				// Text content alongside tool results
+				content := responses.EasyInputMessageContentUnionParam{
+					OfString: param.NewOpt(block.OfText.Text),
+				}
+				if !param.IsOmitted(block.OfText.CacheControl) {
+					text := &responses.ResponseInputTextParam{
+						Text:                  block.OfText.Text,
+						PromptCacheBreakpoint: responses.NewResponseInputTextPromptCacheBreakpointParam(),
+					}
+					content = responses.EasyInputMessageContentUnionParam{
+						OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+							{OfInputText: text},
+						},
+					}
+				}
 				messageItem := responses.EasyInputMessageParam{
-					Type: responses.EasyInputMessageTypeMessage,
-					Role: responses.EasyInputMessageRole("user"),
-					Content: responses.EasyInputMessageContentUnionParam{
-						OfString: param.NewOpt(block.OfText.Text),
-					},
+					Type:    responses.EasyInputMessageTypeMessage,
+					Role:    responses.EasyInputMessageRole("user"),
+					Content: content,
 				}
 				items = append(items, responses.ResponseInputItemUnionParam{
 					OfMessage: &messageItem,
@@ -125,25 +176,29 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 		return items
 	}
 
-	if hasImage {
+	if hasImage || hasCacheControl {
 		// Multimodal user message: emit input_text + input_image content parts
 		contentList := make(responses.ResponseInputMessageContentListParam, 0, len(msg.Content))
 		for _, block := range msg.Content {
 			switch {
 			case block.OfText != nil:
+				text := &responses.ResponseInputTextParam{Text: block.OfText.Text}
+				if !param.IsOmitted(block.OfText.CacheControl) {
+					text.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+				}
 				contentList = append(contentList, responses.ResponseInputContentUnionParam{
-					OfInputText: &responses.ResponseInputTextParam{Text: block.OfText.Text},
+					OfInputText: text,
 				})
 			case block.OfImage != nil:
 				url := imageBlockToOpenAIURL(block.OfImage)
 				if url == "" {
 					continue
 				}
-				contentList = append(contentList, responses.ResponseInputContentUnionParam{
-					OfInputImage: &responses.ResponseInputImageParam{
-						ImageURL: param.NewOpt(url),
-					},
-				})
+				image := &responses.ResponseInputImageParam{ImageURL: param.NewOpt(url)}
+				if !param.IsOmitted(block.OfImage.CacheControl) {
+					image.PromptCacheBreakpoint = responses.NewResponseInputImagePromptCacheBreakpointParam()
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{OfInputImage: image})
 			}
 		}
 		if len(contentList) > 0 {
@@ -183,11 +238,13 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 func convertV1AssistantMessageToResponsesInput(msg anthropic.MessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
 	var textContent string
+	var textBlocks []anthropic.TextBlockParam
 
 	// Process content blocks to collect text and find tool_use blocks
 	for _, block := range msg.Content {
 		if block.OfText != nil {
 			textContent += block.OfText.Text
+			textBlocks = append(textBlocks, *block.OfText)
 		}
 	}
 
@@ -210,12 +267,25 @@ func convertV1AssistantMessageToResponsesInput(msg anthropic.MessageParam) []res
 
 	// Add text content as a separate message if present
 	if textContent != "" {
+		content := responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt(textContent)}
+		for _, block := range textBlocks {
+			if !param.IsOmitted(block.CacheControl) {
+				parts := make(responses.ResponseInputMessageContentListParam, 0, len(textBlocks))
+				for _, textBlock := range textBlocks {
+					part := &responses.ResponseInputTextParam{Text: textBlock.Text}
+					if !param.IsOmitted(textBlock.CacheControl) {
+						part.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+					}
+					parts = append(parts, responses.ResponseInputContentUnionParam{OfInputText: part})
+				}
+				content = responses.EasyInputMessageContentUnionParam{OfInputItemContentList: parts}
+				break
+			}
+		}
 		messageItem := responses.EasyInputMessageParam{
-			Type: responses.EasyInputMessageTypeMessage,
-			Role: responses.EasyInputMessageRole("assistant"),
-			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(textContent),
-			},
+			Type:    responses.EasyInputMessageTypeMessage,
+			Role:    responses.EasyInputMessageRole("assistant"),
+			Content: content,
 		}
 		items = append(items, responses.ResponseInputItemUnionParam{
 			OfMessage: &messageItem,
@@ -224,6 +294,31 @@ func convertV1AssistantMessageToResponsesInput(msg anthropic.MessageParam) []res
 
 	// An assistant message with no text and no tool_use blocks is empty — skip it.
 	return items
+}
+
+func anthropicV1MessagesHaveRepresentableCacheControl(messages []anthropic.MessageParam) bool {
+	for _, message := range messages {
+		for _, block := range message.Content {
+			cacheControl := block.GetCacheControl()
+			if cacheControl == nil || param.IsOmitted(*cacheControl) {
+				continue
+			}
+			if block.OfText != nil || block.OfImage != nil || block.OfToolResult != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anthropicV1ToolsHaveCacheControl(tools []anthropic.ToolUnionParam) bool {
+	for _, tool := range tools {
+		cacheControl := tool.GetCacheControl()
+		if cacheControl != nil && !param.IsOmitted(*cacheControl) {
+			return true
+		}
+	}
+	return false
 }
 
 // convertV1ContentBlocksToString converts v1 content blocks to string

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -403,6 +403,7 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 // blocks to a single OpenAI assistant message. Thinking content is preserved
 // in the "x_thinking" extra field for provider-specific transforms.
 func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.ChatCompletionMessageParamUnion {
+	preserveTextParts := blocksHaveCacheControl(blocks)
 	var textContent strings.Builder
 	var textParts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
 	var toolCalls []openai.ChatCompletionMessageToolCallUnionParam
@@ -411,11 +412,14 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 	for _, block := range blocks {
 		switch block.Kind {
 		case blockViewText:
-			textContent.WriteString(block.Text)
-			part := openAITextPart(block.Text, block.CacheControl)
-			textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
-				OfText: &part,
-			})
+			if preserveTextParts {
+				part := openAITextPart(block.Text, block.CacheControl)
+				textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+					OfText: &part,
+				})
+			} else {
+				textContent.WriteString(block.Text)
+			}
 		case blockViewToolUse:
 			// Convert tool_use block to OpenAI tool_call format;
 			// marshal input to a JSON string for OpenAI
@@ -441,7 +445,7 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 	assistant := &openai.ChatCompletionAssistantMessageParam{
 		ToolCalls: toolCalls,
 	}
-	if blocksHaveCacheControl(blocks) {
+	if preserveTextParts {
 		assistant.Content.OfArrayOfContentParts = textParts
 	} else {
 		assistant.Content.OfString = openai.Opt(textContent.String())

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	anthropicparam "github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/shared"
@@ -56,6 +57,10 @@ type anthropicBlockView struct {
 	ImageMediaType string
 	ImageData      string
 	ImageURL       string
+
+	// CacheControl marks the end of a reusable prompt prefix. OpenAI Chat has
+	// the same concept under prompt_cache_breakpoint.
+	CacheControl bool
 }
 
 // anthropicMessageView is a normalized view of a v1/beta message.
@@ -66,8 +71,9 @@ type anthropicMessageView struct {
 
 // anthropicToolView is a normalized view of a v1/beta tool definition.
 type anthropicToolView struct {
-	Name        string
-	Description string
+	Name         string
+	Description  string
+	CacheControl bool
 	// InputSchema is the full schema param value (marshalled for Google).
 	InputSchema any
 	// Properties/Required are the schema fields (used for OpenAI parameters).
@@ -90,11 +96,12 @@ type anthropicRequestView struct {
 	MaxTokens int64
 	// SystemTexts holds one entry per system text block; the OpenAI core
 	// joins them without separators, the Google core joins with "\n".
-	SystemTexts []string
-	Messages    []anthropicMessageView
-	Tools       []anthropicToolView
-	HasTools    bool
-	ToolChoice  anthropicToolChoiceView
+	SystemTexts         []string
+	SystemCacheControls []bool
+	Messages            []anthropicMessageView
+	Tools               []anthropicToolView
+	HasTools            bool
+	ToolChoice          anthropicToolChoiceView
 	// ThinkingEnabled reflects Thinking.OfEnabled/OfAdaptive or the
 	// model-level IsThinkingEnabled* check.
 	ThinkingEnabled bool
@@ -104,28 +111,32 @@ type anthropicRequestView struct {
 // ───────────────────────── v1 adapters ─────────────────────────
 
 func viewAnthropicV1Block(block anthropic.ContentBlockParamUnion) anthropicBlockView {
+	cacheControl := block.GetCacheControl()
+	hasCacheControl := cacheControl != nil && !anthropicparam.IsOmitted(*cacheControl)
 	switch {
 	case block.OfText != nil:
-		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text}
+		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: hasCacheControl}
 	case block.OfThinking != nil:
 		return anthropicBlockView{Kind: blockViewThinking, Text: block.OfThinking.Thinking}
 	case block.OfRedactedThinking != nil:
 		return anthropicBlockView{Kind: blockViewRedactedThinking}
 	case block.OfToolUse != nil:
 		return anthropicBlockView{
-			Kind:      blockViewToolUse,
-			ToolID:    block.OfToolUse.ID,
-			ToolName:  block.OfToolUse.Name,
-			ToolInput: block.OfToolUse.Input,
+			Kind:         blockViewToolUse,
+			ToolID:       block.OfToolUse.ID,
+			ToolName:     block.OfToolUse.Name,
+			ToolInput:    block.OfToolUse.Input,
+			CacheControl: hasCacheControl,
 		}
 	case block.OfToolResult != nil:
 		return anthropicBlockView{
 			Kind:           blockViewToolResult,
 			ToolResultID:   block.OfToolResult.ToolUseID,
 			ToolResultText: convertToolResultContent(block.OfToolResult.Content),
+			CacheControl:   hasCacheControl,
 		}
 	case block.OfImage != nil:
-		v := anthropicBlockView{Kind: blockViewImage}
+		v := anthropicBlockView{Kind: blockViewImage, CacheControl: hasCacheControl}
 		if block.OfImage.Source.OfBase64 != nil {
 			v.ImageMediaType = string(block.OfImage.Source.OfBase64.MediaType)
 			v.ImageData = block.OfImage.Source.OfBase64.Data
@@ -162,6 +173,7 @@ func viewAnthropicV1Tools(tools []anthropic.ToolUnionParam) []anthropicToolView 
 			Properties:    tool.InputSchema.Properties,
 			Required:      tool.InputSchema.Required,
 			HasProperties: tool.InputSchema.Properties != nil,
+			CacheControl:  !anthropicparam.IsOmitted(tool.CacheControl),
 		})
 	}
 	return out
@@ -191,6 +203,7 @@ func viewAnthropicV1Request(req *anthropic.MessageNewParams) anthropicRequestVie
 	}
 	for _, sys := range req.System {
 		view.SystemTexts = append(view.SystemTexts, sys.Text)
+		view.SystemCacheControls = append(view.SystemCacheControls, !anthropicparam.IsOmitted(sys.CacheControl))
 	}
 	for _, msg := range req.Messages {
 		view.Messages = append(view.Messages, viewAnthropicV1Message(msg))
@@ -201,28 +214,32 @@ func viewAnthropicV1Request(req *anthropic.MessageNewParams) anthropicRequestVie
 // ───────────────────────── beta adapters ─────────────────────────
 
 func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropicBlockView {
+	cacheControl := block.GetCacheControl()
+	hasCacheControl := cacheControl != nil && !anthropicparam.IsOmitted(*cacheControl)
 	switch {
 	case block.OfText != nil:
-		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text}
+		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: hasCacheControl}
 	case block.OfThinking != nil:
 		return anthropicBlockView{Kind: blockViewThinking, Text: block.OfThinking.Thinking}
 	case block.OfRedactedThinking != nil:
 		return anthropicBlockView{Kind: blockViewRedactedThinking}
 	case block.OfToolUse != nil:
 		return anthropicBlockView{
-			Kind:      blockViewToolUse,
-			ToolID:    block.OfToolUse.ID,
-			ToolName:  block.OfToolUse.Name,
-			ToolInput: block.OfToolUse.Input,
+			Kind:         blockViewToolUse,
+			ToolID:       block.OfToolUse.ID,
+			ToolName:     block.OfToolUse.Name,
+			ToolInput:    block.OfToolUse.Input,
+			CacheControl: hasCacheControl,
 		}
 	case block.OfToolResult != nil:
 		return anthropicBlockView{
 			Kind:           blockViewToolResult,
 			ToolResultID:   block.OfToolResult.ToolUseID,
 			ToolResultText: convertBetaToolResultContent(block.OfToolResult.Content),
+			CacheControl:   hasCacheControl,
 		}
 	case block.OfImage != nil:
-		v := anthropicBlockView{Kind: blockViewImage}
+		v := anthropicBlockView{Kind: blockViewImage, CacheControl: hasCacheControl}
 		if block.OfImage.Source.OfBase64 != nil {
 			v.ImageMediaType = string(block.OfImage.Source.OfBase64.MediaType)
 			v.ImageData = block.OfImage.Source.OfBase64.Data
@@ -259,6 +276,7 @@ func viewAnthropicBetaTools(tools []anthropic.BetaToolUnionParam) []anthropicToo
 			Properties:    tool.InputSchema.Properties,
 			Required:      tool.InputSchema.Required,
 			HasProperties: tool.InputSchema.Properties != nil,
+			CacheControl:  !anthropicparam.IsOmitted(tool.CacheControl),
 		})
 	}
 	return out
@@ -288,6 +306,7 @@ func viewAnthropicBetaRequest(req *anthropic.BetaMessageNewParams) anthropicRequ
 	}
 	for _, sys := range req.System {
 		view.SystemTexts = append(view.SystemTexts, sys.Text)
+		view.SystemCacheControls = append(view.SystemCacheControls, !anthropicparam.IsOmitted(sys.CacheControl))
 	}
 	for _, msg := range req.Messages {
 		view.Messages = append(view.Messages, viewAnthropicBetaMessage(msg))
@@ -319,9 +338,23 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 		}
 	}
 
-	// Convert system message (joined without separators)
+	// Convert system messages. Keep block boundaries when cache controls are
+	// present so their exact prompt prefix survives A→O→A gateway chaining.
 	if len(view.SystemTexts) > 0 {
-		systemMsg := openai.SystemMessage(strings.Join(view.SystemTexts, ""))
+		var systemMsg openai.ChatCompletionMessageParamUnion
+		if hasCacheControl(view.SystemCacheControls) {
+			parts := make([]openai.ChatCompletionContentPartTextParam, 0, len(view.SystemTexts))
+			for i, text := range view.SystemTexts {
+				part := openai.ChatCompletionContentPartTextParam{Text: text}
+				if i < len(view.SystemCacheControls) && view.SystemCacheControls[i] {
+					part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+				}
+				parts = append(parts, part)
+			}
+			systemMsg = openai.SystemMessage(parts)
+		} else {
+			systemMsg = openai.SystemMessage(strings.Join(view.SystemTexts, ""))
+		}
 		// Add system message at the beginning
 		openaiReq.Messages = append([]openai.ChatCompletionMessageParamUnion{systemMsg}, openaiReq.Messages...)
 	}
@@ -331,6 +364,19 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 		openaiReq.Tools = convertAnthropicToolViewsToOpenAI(view.Tools)
 		// Convert tool choice
 		openaiReq.ToolChoice = convertAnthropicToolChoiceViewToOpenAI(view.ToolChoice)
+	}
+
+	hasRepresentableCacheControl := viewHasRepresentableCacheControl(view)
+	hasToolDefinitionCacheControl := viewHasToolDefinitionCacheControl(view)
+	if hasRepresentableCacheControl || hasToolDefinitionCacheControl {
+		openaiReq.PromptCacheOptions.Mode = "explicit"
+		if !hasRepresentableCacheControl && hasToolDefinitionCacheControl {
+			// OpenAI cannot put a breakpoint on a tool definition.
+			// Advance that boundary to the first cacheable content block, which
+			// still includes the tools prefix and avoids dropping caching
+			// entirely when gateways are chained.
+			applyFirstOpenAICacheBreakpoint(openaiReq)
+		}
 	}
 
 	// thinking
@@ -358,6 +404,7 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 // in the "x_thinking" extra field for provider-specific transforms.
 func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.ChatCompletionMessageParamUnion {
 	var textContent strings.Builder
+	var textParts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
 	var toolCalls []openai.ChatCompletionMessageToolCallUnionParam
 	var thinking string
 
@@ -365,6 +412,10 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 		switch block.Kind {
 		case blockViewText:
 			textContent.WriteString(block.Text)
+			part := openAITextPart(block.Text, block.CacheControl)
+			textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+				OfText: &part,
+			})
 		case blockViewToolUse:
 			// Convert tool_use block to OpenAI tool_call format;
 			// marshal input to a JSON string for OpenAI
@@ -390,7 +441,11 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 	assistant := &openai.ChatCompletionAssistantMessageParam{
 		ToolCalls: toolCalls,
 	}
-	assistant.Content.OfString = openai.Opt(textContent.String())
+	if blocksHaveCacheControl(blocks) {
+		assistant.Content.OfArrayOfContentParts = textParts
+	} else {
+		assistant.Content.OfString = openai.Opt(textContent.String())
+	}
 
 	// Preserve x_thinking in ExtraFields for provider transforms (e.g., DeepSeek/Moonshot)
 	// Must set on OfAssistant (variant level), not on union level, because
@@ -405,7 +460,7 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 // blocks turn the message into a multimodal content-part array.
 func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.ChatCompletionMessageParamUnion {
 	var result []openai.ChatCompletionMessageParamUnion
-	var hasToolResult, hasImage bool
+	var hasToolResult, hasImage, hasCache bool
 
 	for _, block := range blocks {
 		switch block.Kind {
@@ -414,39 +469,59 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		case blockViewImage:
 			hasImage = true
 		}
+		hasCache = hasCache || block.CacheControl
 	}
 
 	switch {
 	case hasToolResult:
 		// When there are tool_result blocks, we need to create separate messages
-		var textContent strings.Builder
+		var textBlocks []anthropicBlockView
 		for _, block := range blocks {
 			switch block.Kind {
 			case blockViewText:
-				textContent.WriteString(block.Text)
+				textBlocks = append(textBlocks, block)
 			case blockViewToolResult:
 				// Convert tool_result to OpenAI role="tool" message.
 				// Truncate tool_call_id to meet OpenAI's 40 character limit.
-				result = append(result, openai.ToolMessage(block.ToolResultText, truncateToolCallID(block.ToolResultID)))
+				if block.CacheControl {
+					part := openAITextPart(block.ToolResultText, true)
+					result = append(result, openai.ChatCompletionMessageParamUnion{
+						OfTool: &openai.ChatCompletionToolMessageParam{
+							ToolCallID: truncateToolCallID(block.ToolResultID),
+							Content: openai.ChatCompletionToolMessageParamContentUnion{
+								OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{part},
+							},
+						},
+					})
+				} else {
+					result = append(result, openai.ToolMessage(block.ToolResultText, truncateToolCallID(block.ToolResultID)))
+				}
 			}
 		}
 		// If there was text content alongside tool results, add it as a user message
-		if textContent.Len() > 0 {
-			result = append(result, openai.UserMessage(textContent.String()))
+		if len(textBlocks) > 0 {
+			result = append(result, convertAnthropicViewUserToOpenAI(textBlocks)...)
 		}
-	case hasImage:
+	case hasImage || hasCache:
 		// Multimodal user message: emit an array of text + image_url content parts
 		parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(blocks))
 		for _, block := range blocks {
 			switch block.Kind {
 			case blockViewText:
-				parts = append(parts, openai.TextContentPart(block.Text))
+				part := openAITextPart(block.Text, block.CacheControl)
+				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
 			case blockViewImage:
 				url := imageViewToOpenAIURL(block)
 				if url == "" {
 					continue
 				}
-				parts = append(parts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{URL: url}))
+				imagePart := openai.ChatCompletionContentPartImageParam{
+					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
+				}
+				if block.CacheControl {
+					imagePart.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
+				}
+				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imagePart})
 			}
 		}
 		if len(parts) > 0 {
@@ -466,6 +541,93 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 	}
 
 	return result
+}
+
+func openAITextPart(text string, cacheControl bool) openai.ChatCompletionContentPartTextParam {
+	part := openai.ChatCompletionContentPartTextParam{Text: text}
+	if cacheControl {
+		part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+	}
+	return part
+}
+
+func hasCacheControl(values []bool) bool {
+	for _, value := range values {
+		if value {
+			return true
+		}
+	}
+	return false
+}
+
+func blocksHaveCacheControl(blocks []anthropicBlockView) bool {
+	for _, block := range blocks {
+		if block.CacheControl &&
+			(block.Kind == blockViewText || block.Kind == blockViewImage || block.Kind == blockViewToolResult) {
+			return true
+		}
+	}
+	return false
+}
+
+func viewHasRepresentableCacheControl(view anthropicRequestView) bool {
+	if hasCacheControl(view.SystemCacheControls) {
+		return true
+	}
+	for _, message := range view.Messages {
+		if blocksHaveCacheControl(message.Blocks) {
+			return true
+		}
+	}
+	return false
+}
+
+func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
+	for _, tool := range view.Tools {
+		if tool.CacheControl {
+			return true
+		}
+	}
+	return false
+}
+
+func applyFirstOpenAICacheBreakpoint(req *openai.ChatCompletionNewParams) {
+	for i := range req.Messages {
+		msg := &req.Messages[i]
+		switch {
+		case msg.OfSystem != nil:
+			if text := msg.OfSystem.Content.OfString.Value; text != "" {
+				msg.OfSystem.Content.OfString = param.Opt[string]{}
+				msg.OfSystem.Content.OfArrayOfContentParts = []openai.ChatCompletionContentPartTextParam{
+					openAITextPart(text, true),
+				}
+				return
+			}
+			if len(msg.OfSystem.Content.OfArrayOfContentParts) > 0 {
+				msg.OfSystem.Content.OfArrayOfContentParts[0].PromptCacheBreakpoint =
+					openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+				return
+			}
+		case msg.OfUser != nil:
+			if text := msg.OfUser.Content.OfString.Value; text != "" {
+				msg.OfUser.Content.OfString = param.Opt[string]{}
+				part := openAITextPart(text, true)
+				msg.OfUser.Content.OfArrayOfContentParts = []openai.ChatCompletionContentPartUnionParam{{OfText: &part}}
+				return
+			}
+			for j := range msg.OfUser.Content.OfArrayOfContentParts {
+				part := &msg.OfUser.Content.OfArrayOfContentParts[j]
+				if part.OfText != nil {
+					part.OfText.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+					return
+				}
+				if part.OfImageURL != nil {
+					part.OfImageURL.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
+					return
+				}
+			}
+		}
+	}
 }
 
 // imageViewToOpenAIURL renders an image block view as the URL string OpenAI's

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -367,14 +367,13 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 	}
 
 	hasRepresentableCacheControl := viewHasRepresentableCacheControl(view)
-	hasToolDefinitionCacheControl := viewHasToolDefinitionCacheControl(view)
-	if hasRepresentableCacheControl || hasToolDefinitionCacheControl {
+	hasFallbackCacheControl := viewHasToolDefinitionCacheControl(view) || viewHasToolUseCacheControl(view)
+	if hasRepresentableCacheControl || hasFallbackCacheControl {
 		openaiReq.PromptCacheOptions.Mode = "explicit"
-		if !hasRepresentableCacheControl && hasToolDefinitionCacheControl {
-			// OpenAI cannot put a breakpoint on a tool definition.
+		if !hasRepresentableCacheControl && hasFallbackCacheControl {
+			// OpenAI cannot put a breakpoint on a tool definition or tool call.
 			// Advance that boundary to the first cacheable content block, which
-			// still includes the tools prefix and avoids dropping caching
-			// entirely when gateways are chained.
+			// avoids dropping caching entirely when gateways are chained.
 			applyFirstOpenAICacheBreakpoint(openaiReq)
 		}
 	}
@@ -590,6 +589,17 @@ func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 	for _, tool := range view.Tools {
 		if tool.CacheControl {
 			return true
+		}
+	}
+	return false
+}
+
+func viewHasToolUseCacheControl(view anthropicRequestView) bool {
+	for _, message := range view.Messages {
+		for _, block := range message.Blocks {
+			if block.Kind == blockViewToolUse && block.CacheControl {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/protocol/request/cache_control.go
+++ b/internal/protocol/request/cache_control.go
@@ -5,10 +5,9 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
-// applyFirstResponsesCacheBreakpoint carries an Anthropic tool-definition
-// cache boundary into Responses. Responses cannot attach a breakpoint directly
-// to a tool definition, so the boundary advances to the first content block;
-// the cached prefix still includes all tool definitions.
+// applyFirstResponsesCacheBreakpoint carries an Anthropic cache boundary that
+// Responses cannot attach directly (for example, on a tool definition or tool
+// call). The boundary advances to the first cacheable content block.
 func applyFirstResponsesCacheBreakpoint(req *responses.ResponseNewParams) {
 	if req.Instructions.Valid() && req.Instructions.Value != "" {
 		text := &responses.ResponseInputTextParam{

--- a/internal/protocol/request/cache_control.go
+++ b/internal/protocol/request/cache_control.go
@@ -1,0 +1,54 @@
+package request
+
+import (
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// applyFirstResponsesCacheBreakpoint carries an Anthropic tool-definition
+// cache boundary into Responses. Responses cannot attach a breakpoint directly
+// to a tool definition, so the boundary advances to the first content block;
+// the cached prefix still includes all tool definitions.
+func applyFirstResponsesCacheBreakpoint(req *responses.ResponseNewParams) {
+	if req.Instructions.Valid() && req.Instructions.Value != "" {
+		text := &responses.ResponseInputTextParam{
+			Text:                  req.Instructions.Value,
+			PromptCacheBreakpoint: responses.NewResponseInputTextPromptCacheBreakpointParam(),
+		}
+		req.Instructions = param.Opt[string]{}
+		system := responseMessageWithContent("system", responses.ResponseInputMessageContentListParam{
+			{OfInputText: text},
+		})
+		req.Input.OfInputItemList = append(responses.ResponseInputParam{system}, req.Input.OfInputItemList...)
+		return
+	}
+
+	for i := range req.Input.OfInputItemList {
+		item := &req.Input.OfInputItemList[i]
+		if item.OfMessage != nil {
+			content := &item.OfMessage.Content
+			if content.OfString.Valid() && content.OfString.Value != "" {
+				text := &responses.ResponseInputTextParam{
+					Text:                  content.OfString.Value,
+					PromptCacheBreakpoint: responses.NewResponseInputTextPromptCacheBreakpointParam(),
+				}
+				content.OfString = param.Opt[string]{}
+				content.OfInputItemContentList = responses.ResponseInputMessageContentListParam{
+					{OfInputText: text},
+				}
+				return
+			}
+			for j := range content.OfInputItemContentList {
+				part := &content.OfInputItemContentList[j]
+				if part.OfInputText != nil {
+					part.OfInputText.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+					return
+				}
+				if part.OfInputImage != nil {
+					part.OfInputImage.PromptCacheBreakpoint = responses.NewResponseInputImagePromptCacheBreakpointParam()
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/protocol/request/cache_control_family_test.go
+++ b/internal/protocol/request/cache_control_family_test.go
@@ -154,6 +154,53 @@ func TestCacheControlProtocolFamilyToolFallbackPrefersSystemPrefix(t *testing.T)
 	require.True(t, responsesReq.Input.OfInputItemList[1].OfMessage.Content.OfString.Valid())
 }
 
+func TestCacheControlProtocolFamilyToolUseFallbackPrefersSystemPrefix(t *testing.T) {
+	toolUse := anthropic.NewToolUseBlock("call_1", map[string]any{"query": "weather"}, "lookup")
+	toolUse.OfToolUse.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 128,
+		System:    []anthropic.TextBlockParam{{Text: "stable system"}},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewAssistantMessage(toolUse),
+		},
+	}
+
+	chat, _ := ConvertAnthropicToOpenAIRequest(in, true, false, false)
+	require.Equal(t, "explicit", chat.PromptCacheOptions.Mode)
+	require.Len(t, chat.Messages[0].OfSystem.Content.OfArrayOfContentParts, 1)
+	require.False(t, openaiparam.IsOmitted(
+		chat.Messages[0].OfSystem.Content.OfArrayOfContentParts[0].PromptCacheBreakpoint))
+
+	responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+	require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+	require.False(t, responsesReq.Instructions.Valid())
+	require.Len(t, responsesReq.Input.OfInputItemList, 2)
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[0], "system")
+	require.NotNil(t, responsesReq.Input.OfInputItemList[1].OfFunctionCall)
+
+	betaToolUse := anthropic.NewBetaToolUseBlock("call_1", map[string]any{"query": "weather"}, "lookup")
+	betaToolUse.OfToolUse.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+	betaIn := &anthropic.BetaMessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 128,
+		System:    []anthropic.BetaTextBlockParam{{Text: "stable system"}},
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role:    anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{betaToolUse},
+			},
+		},
+	}
+
+	betaResponsesReq := ConvertAnthropicBetaToResponsesRequest(betaIn)
+	require.Equal(t, "explicit", betaResponsesReq.PromptCacheOptions.Mode)
+	require.False(t, betaResponsesReq.Instructions.Valid())
+	require.Len(t, betaResponsesReq.Input.OfInputItemList, 2)
+	requireResponsesTextBreakpoint(t, betaResponsesReq.Input.OfInputItemList[0], "system")
+	require.NotNil(t, betaResponsesReq.Input.OfInputItemList[1].OfFunctionCall)
+}
+
 func requireAnthropicFamilyBoundaries(t *testing.T, out *anthropic.BetaMessageNewParams) {
 	t.Helper()
 	require.Len(t, out.System, 2)

--- a/internal/protocol/request/cache_control_family_test.go
+++ b/internal/protocol/request/cache_control_family_test.go
@@ -1,0 +1,208 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicparam "github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/openai/openai-go/v3"
+	openaiparam "github.com/openai/openai-go/v3/packages/param"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheControlProtocolFamilyPreservesMultiblockBoundaries(t *testing.T) {
+	userText := anthropic.NewTextBlock("user text")
+	userImage := anthropic.NewImageBlock(anthropic.URLImageSourceParam{
+		URL: "https://example.com/image.png",
+	})
+	userImage.OfImage.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	assistantText := anthropic.NewTextBlock("assistant text")
+	assistantText.OfText.CacheControl = anthropic.NewCacheControlEphemeralParam()
+
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: []anthropic.TextBlockParam{
+			{Text: "system part one"},
+			{
+				Text:         "system part two",
+				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(userText, userImage),
+			anthropic.NewAssistantMessage(assistantText),
+		},
+	}
+
+	t.Run("messages chat messages", func(t *testing.T) {
+		chat, _ := ConvertAnthropicToOpenAIRequest(in, true, true, false)
+		require.Equal(t, "explicit", chat.PromptCacheOptions.Mode)
+		require.Len(t, chat.Messages, 3)
+
+		systemParts := chat.Messages[0].OfSystem.Content.OfArrayOfContentParts
+		require.Len(t, systemParts, 2)
+		require.True(t, openaiparam.IsOmitted(systemParts[0].PromptCacheBreakpoint))
+		require.False(t, openaiparam.IsOmitted(systemParts[1].PromptCacheBreakpoint))
+
+		userParts := chat.Messages[1].OfUser.Content.OfArrayOfContentParts
+		require.Len(t, userParts, 2)
+		require.NotNil(t, userParts[0].OfText)
+		require.True(t, openaiparam.IsOmitted(userParts[0].OfText.PromptCacheBreakpoint))
+		require.NotNil(t, userParts[1].OfImageURL)
+		require.False(t, openaiparam.IsOmitted(userParts[1].OfImageURL.PromptCacheBreakpoint))
+
+		assistantParts := chat.Messages[2].OfAssistant.Content.OfArrayOfContentParts
+		require.Len(t, assistantParts, 1)
+		require.False(t, openaiparam.IsOmitted(assistantParts[0].OfText.PromptCacheBreakpoint))
+
+		out := ConvertOpenAIToAnthropicRequest(chat, 4096)
+		requireAnthropicFamilyBoundaries(t, out)
+	})
+
+	t.Run("messages responses messages", func(t *testing.T) {
+		responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+		require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+		require.Len(t, responsesReq.Input.OfInputItemList, 3)
+
+		system := responsesReq.Input.OfInputItemList[0].OfMessage
+		require.NotNil(t, system)
+		require.Len(t, system.Content.OfInputItemContentList, 2)
+		require.True(t, openaiparam.IsOmitted(
+			system.Content.OfInputItemContentList[0].OfInputText.PromptCacheBreakpoint))
+		require.False(t, openaiparam.IsOmitted(
+			system.Content.OfInputItemContentList[1].OfInputText.PromptCacheBreakpoint))
+
+		user := responsesReq.Input.OfInputItemList[1].OfMessage
+		require.NotNil(t, user)
+		require.Len(t, user.Content.OfInputItemContentList, 2)
+		require.True(t, openaiparam.IsOmitted(
+			user.Content.OfInputItemContentList[0].OfInputText.PromptCacheBreakpoint))
+		require.False(t, openaiparam.IsOmitted(
+			user.Content.OfInputItemContentList[1].OfInputImage.PromptCacheBreakpoint))
+
+		assistant := responsesReq.Input.OfInputItemList[2].OfMessage
+		require.NotNil(t, assistant)
+		require.Len(t, assistant.Content.OfInputItemContentList, 1)
+		require.False(t, openaiparam.IsOmitted(
+			assistant.Content.OfInputItemContentList[0].OfInputText.PromptCacheBreakpoint))
+
+		out := ConvertOpenAIResponsesToAnthropicBetaRequest(*responsesReq, 4096)
+		requireAnthropicFamilyBoundaries(t, out)
+	})
+}
+
+func TestCacheControlProtocolFamilyDoesNotSynthesizeBreakpoints(t *testing.T) {
+	anthropicReq := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 128,
+		System:    []anthropic.TextBlockParam{{Text: "system"}},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("hello")),
+		},
+	}
+
+	chat, _ := ConvertAnthropicToOpenAIRequest(anthropicReq, true, false, false)
+	require.Empty(t, chat.PromptCacheOptions.Mode)
+	require.True(t, chat.Messages[0].OfSystem.Content.OfString.Valid())
+	require.True(t, chat.Messages[1].OfUser.Content.OfString.Valid())
+
+	responsesReq := ConvertAnthropicV1ToResponsesRequest(anthropicReq)
+	require.Empty(t, responsesReq.PromptCacheOptions.Mode)
+	require.True(t, responsesReq.Instructions.Valid())
+	require.Len(t, responsesReq.Input.OfInputItemList, 1)
+	require.True(t, responsesReq.Input.OfInputItemList[0].OfMessage.Content.OfString.Valid())
+
+	chatAgain := ConvertOpenAIResponsesToChat(responsesReq, 4096)
+	require.Empty(t, chatAgain.PromptCacheOptions.Mode)
+	require.True(t, chatAgain.Messages[0].OfSystem.Content.OfString.Valid())
+	require.True(t, chatAgain.Messages[1].OfUser.Content.OfString.Valid())
+}
+
+func TestCacheControlProtocolFamilyToolFallbackPrefersSystemPrefix(t *testing.T) {
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 128,
+		System:    []anthropic.TextBlockParam{{Text: "stable system"}},
+		Tools: []anthropic.ToolUnionParam{{
+			OfTool: &anthropic.ToolParam{
+				Name: "lookup",
+				InputSchema: anthropic.ToolInputSchemaParam{
+					Type:       "object",
+					Properties: map[string]any{},
+				},
+				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			},
+		}},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("dynamic user input")),
+		},
+	}
+
+	chat, _ := ConvertAnthropicToOpenAIRequest(in, true, false, false)
+	require.Equal(t, "explicit", chat.PromptCacheOptions.Mode)
+	require.Len(t, chat.Messages[0].OfSystem.Content.OfArrayOfContentParts, 1)
+	require.False(t, openaiparam.IsOmitted(
+		chat.Messages[0].OfSystem.Content.OfArrayOfContentParts[0].PromptCacheBreakpoint))
+	require.True(t, chat.Messages[1].OfUser.Content.OfString.Valid())
+
+	responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+	require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+	require.False(t, responsesReq.Instructions.Valid())
+	require.Len(t, responsesReq.Input.OfInputItemList, 2)
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[0], "system")
+	require.True(t, responsesReq.Input.OfInputItemList[1].OfMessage.Content.OfString.Valid())
+}
+
+func requireAnthropicFamilyBoundaries(t *testing.T, out *anthropic.BetaMessageNewParams) {
+	t.Helper()
+	require.Len(t, out.System, 2)
+	require.True(t, anthropicparam.IsOmitted(out.System[0].CacheControl))
+	require.False(t, anthropicparam.IsOmitted(out.System[1].CacheControl))
+	require.Len(t, out.Messages, 2)
+
+	user := out.Messages[0]
+	require.Len(t, user.Content, 2)
+	require.NotNil(t, user.Content[0].OfText)
+	require.True(t, anthropicparam.IsOmitted(user.Content[0].OfText.CacheControl))
+	require.NotNil(t, user.Content[1].OfImage)
+	require.False(t, anthropicparam.IsOmitted(user.Content[1].OfImage.CacheControl))
+
+	assistant := out.Messages[1]
+	require.Len(t, assistant.Content, 1)
+	require.NotNil(t, assistant.Content[0].OfText)
+	require.False(t, anthropicparam.IsOmitted(assistant.Content[0].OfText.CacheControl))
+}
+
+func TestCacheControlProtocolFamilyChatResponsesKeepsMultipleBreakpoints(t *testing.T) {
+	first := openai.ChatCompletionContentPartTextParam{
+		Text:                  "first",
+		PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+	}
+	second := openai.ChatCompletionContentPartTextParam{
+		Text:                  "second",
+		PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+	}
+	in := &openai.ChatCompletionNewParams{
+		Model: "gpt-test",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+				{OfText: &first},
+				{OfText: &second},
+			}),
+		},
+		PromptCacheOptions: openai.ChatCompletionNewParamsPromptCacheOptions{Mode: "explicit"},
+	}
+
+	responsesReq := ConvertChatToOpenAIResponses(in, 4096)
+	content := responsesReq.Input.OfInputItemList[0].OfMessage.Content.OfInputItemContentList
+	require.Len(t, content, 2)
+	require.False(t, openaiparam.IsOmitted(content[0].OfInputText.PromptCacheBreakpoint))
+	require.False(t, openaiparam.IsOmitted(content[1].OfInputText.PromptCacheBreakpoint))
+
+	out := ConvertOpenAIResponsesToChat(responsesReq, 4096)
+	parts := out.Messages[0].OfUser.Content.OfArrayOfContentParts
+	require.Len(t, parts, 2)
+	require.False(t, openaiparam.IsOmitted(parts[0].OfText.PromptCacheBreakpoint))
+	require.False(t, openaiparam.IsOmitted(parts[1].OfText.PromptCacheBreakpoint))
+}

--- a/internal/protocol/request/cache_control_roundtrip_test.go
+++ b/internal/protocol/request/cache_control_roundtrip_test.go
@@ -1,0 +1,259 @@
+package request
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicparam "github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/openai/openai-go/v3"
+	openaiparam "github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicOpenAIAnthropicPreservesCacheControl(t *testing.T) {
+	userBlock := anthropic.NewTextBlock("stable conversation prefix")
+	userBlock.OfText.CacheControl = anthropic.NewCacheControlEphemeralParam()
+
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: []anthropic.TextBlockParam{
+			{
+				Text:         "stable system prompt",
+				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(userBlock),
+		},
+	}
+
+	openAIReq, _ := ConvertAnthropicToOpenAIRequest(in, true, true, false)
+	require.Equal(t, "explicit", openAIReq.PromptCacheOptions.Mode)
+	require.Len(t, openAIReq.Messages, 2)
+
+	systemParts := openAIReq.Messages[0].OfSystem.Content.OfArrayOfContentParts
+	require.Len(t, systemParts, 1)
+	require.False(t, openaiparam.IsOmitted(systemParts[0].PromptCacheBreakpoint))
+
+	userParts := openAIReq.Messages[1].OfUser.Content.OfArrayOfContentParts
+	require.Len(t, userParts, 1)
+	require.NotNil(t, userParts[0].OfText)
+	require.False(t, openaiparam.IsOmitted(userParts[0].OfText.PromptCacheBreakpoint))
+
+	wire, err := json.Marshal(openAIReq)
+	require.NoError(t, err)
+	require.Contains(t, string(wire), `"prompt_cache_breakpoint":{"mode":"explicit"}`)
+
+	out := ConvertOpenAIToAnthropicRequest(openAIReq, 4096)
+	require.Len(t, out.System, 1)
+	require.False(t, anthropicparam.IsOmitted(out.System[0].CacheControl))
+	require.Len(t, out.Messages, 1)
+	require.Len(t, out.Messages[0].Content, 1)
+	require.NotNil(t, out.Messages[0].Content[0].OfText)
+	require.False(t, anthropicparam.IsOmitted(out.Messages[0].Content[0].OfText.CacheControl))
+}
+
+func TestAnthropicToolCacheControlAdvancesToOpenAICacheableContent(t *testing.T) {
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Tools: []anthropic.ToolUnionParam{{
+			OfTool: &anthropic.ToolParam{
+				Name: "lookup",
+				InputSchema: anthropic.ToolInputSchemaParam{
+					Type:       "object",
+					Properties: map[string]any{},
+				},
+				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			},
+		}},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("look this up")),
+		},
+	}
+
+	openAIReq, _ := ConvertAnthropicToOpenAIRequest(in, true, true, false)
+	require.Equal(t, "explicit", openAIReq.PromptCacheOptions.Mode)
+	require.Len(t, openAIReq.Messages, 1)
+
+	// OpenAI does not support breakpoints on tool definitions, so the boundary
+	// advances to the first content block after the tools prefix.
+	userParts := openAIReq.Messages[0].OfUser.Content.OfArrayOfContentParts
+	require.Len(t, userParts, 1)
+	require.NotNil(t, userParts[0].OfText)
+	require.False(t, openaiparam.IsOmitted(userParts[0].OfText.PromptCacheBreakpoint))
+
+	out := ConvertOpenAIToAnthropicRequest(openAIReq, 4096)
+	require.Len(t, out.Messages, 1)
+	require.Len(t, out.Messages[0].Content, 1)
+	require.False(t, anthropicparam.IsOmitted(out.Messages[0].Content[0].OfText.CacheControl))
+}
+
+func TestAnthropicResponsesAnthropicPreservesCacheControl(t *testing.T) {
+	userBlock := anthropic.NewTextBlock("stable conversation prefix")
+	userBlock.OfText.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: []anthropic.TextBlockParam{{
+			Text:         "stable system prompt",
+			CacheControl: anthropic.NewCacheControlEphemeralParam(),
+		}},
+		Messages: []anthropic.MessageParam{anthropic.NewUserMessage(userBlock)},
+	}
+
+	responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+	require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+	require.False(t, responsesReq.Instructions.Valid())
+	require.Len(t, responsesReq.Input.OfInputItemList, 2)
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[0], "system")
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[1], "user")
+
+	out := ConvertOpenAIResponsesToAnthropicBetaRequest(*responsesReq, 4096)
+	require.Len(t, out.System, 1)
+	require.False(t, anthropicparam.IsOmitted(out.System[0].CacheControl))
+	require.Len(t, out.Messages, 1)
+	require.False(t, anthropicparam.IsOmitted(out.Messages[0].Content[0].OfText.CacheControl))
+
+	betaIn := ConvertAnthropicV1ToBetaRequest(in)
+	require.NotNil(t, betaIn)
+	betaResponsesReq := ConvertAnthropicBetaToResponsesRequest(betaIn)
+	require.Equal(t, "explicit", betaResponsesReq.PromptCacheOptions.Mode)
+	require.Len(t, betaResponsesReq.Input.OfInputItemList, 2)
+	requireResponsesTextBreakpoint(t, betaResponsesReq.Input.OfInputItemList[0], "system")
+	requireResponsesTextBreakpoint(t, betaResponsesReq.Input.OfInputItemList[1], "user")
+}
+
+func TestAnthropicResponsesPreservesToolCacheControls(t *testing.T) {
+	t.Run("tool definition advances to first content", func(t *testing.T) {
+		in := &anthropic.MessageNewParams{
+			Model:     "claude-test",
+			MaxTokens: 256,
+			Tools: []anthropic.ToolUnionParam{{
+				OfTool: &anthropic.ToolParam{
+					Name: "lookup",
+					InputSchema: anthropic.ToolInputSchemaParam{
+						Type:       "object",
+						Properties: map[string]any{},
+					},
+					CacheControl: anthropic.NewCacheControlEphemeralParam(),
+				},
+			}},
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(anthropic.NewTextBlock("look this up")),
+			},
+		}
+
+		responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+		require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+		require.Len(t, responsesReq.Input.OfInputItemList, 1)
+		requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[0], "user")
+	})
+
+	t.Run("tool result round trip", func(t *testing.T) {
+		toolResult := anthropic.NewToolResultBlock("call_1", "stable tool output", false)
+		toolResult.OfToolResult.CacheControl = anthropic.NewCacheControlEphemeralParam()
+		in := &anthropic.MessageNewParams{
+			Model:     "claude-test",
+			MaxTokens: 256,
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(toolResult),
+			},
+		}
+
+		responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+		require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+		require.Len(t, responsesReq.Input.OfInputItemList, 1)
+		output := responsesReq.Input.OfInputItemList[0].OfFunctionCallOutput
+		require.NotNil(t, output)
+		require.Len(t, output.Output.OfResponseFunctionCallOutputItemArray, 1)
+		require.False(t, openaiparam.IsOmitted(
+			output.Output.OfResponseFunctionCallOutputItemArray[0].OfInputText.PromptCacheBreakpoint))
+
+		out := ConvertOpenAIResponsesToAnthropicBetaRequest(*responsesReq, 4096)
+		require.Len(t, out.Messages, 1)
+		require.NotNil(t, out.Messages[0].Content[0].OfToolResult)
+		require.False(t, anthropicparam.IsOmitted(out.Messages[0].Content[0].OfToolResult.CacheControl))
+	})
+}
+
+func TestChatResponsesChatPreservesCacheControlsAndOptions(t *testing.T) {
+	systemPart := openai.ChatCompletionContentPartTextParam{
+		Text:                  "stable system prompt",
+		PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+	}
+	userPart := openai.ChatCompletionContentPartTextParam{
+		Text:                  "stable conversation prefix",
+		PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+	}
+	toolPart := openai.ChatCompletionContentPartTextParam{
+		Text:                  "stable tool output",
+		PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+	}
+	in := &openai.ChatCompletionNewParams{
+		Model: "gpt-test",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage([]openai.ChatCompletionContentPartTextParam{systemPart}),
+			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{{OfText: &userPart}}),
+			{
+				OfTool: &openai.ChatCompletionToolMessageParam{
+					ToolCallID: "call_1",
+					Content: openai.ChatCompletionToolMessageParamContentUnion{
+						OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{toolPart},
+					},
+				},
+			},
+		},
+		PromptCacheKey: openai.Opt("stable-key"),
+		PromptCacheOptions: openai.ChatCompletionNewParamsPromptCacheOptions{
+			Mode: "explicit",
+			Ttl:  "30m",
+		},
+		PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
+	}
+
+	responsesReq := ConvertChatToOpenAIResponses(in, 4096)
+	require.Equal(t, "stable-key", responsesReq.PromptCacheKey.Value)
+	require.Equal(t, "explicit", responsesReq.PromptCacheOptions.Mode)
+	require.Equal(t, "30m", responsesReq.PromptCacheOptions.Ttl)
+	require.Equal(t, responses.ResponseNewParamsPromptCacheRetention24h, responsesReq.PromptCacheRetention)
+	require.False(t, responsesReq.Instructions.Valid())
+	require.Len(t, responsesReq.Input.OfInputItemList, 3)
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[0], "system")
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[1], "user")
+	toolOutput := responsesReq.Input.OfInputItemList[2].OfFunctionCallOutput
+	require.NotNil(t, toolOutput)
+	require.Len(t, toolOutput.Output.OfResponseFunctionCallOutputItemArray, 1)
+	require.False(t, openaiparam.IsOmitted(
+		toolOutput.Output.OfResponseFunctionCallOutputItemArray[0].OfInputText.PromptCacheBreakpoint))
+
+	out := ConvertOpenAIResponsesToChat(responsesReq, 4096)
+	require.Equal(t, "stable-key", out.PromptCacheKey.Value)
+	require.Equal(t, "explicit", out.PromptCacheOptions.Mode)
+	require.Equal(t, "30m", out.PromptCacheOptions.Ttl)
+	require.Equal(t, openai.ChatCompletionNewParamsPromptCacheRetention24h, out.PromptCacheRetention)
+	require.Len(t, out.Messages, 3)
+	require.False(t, openaiparam.IsOmitted(
+		out.Messages[0].OfSystem.Content.OfArrayOfContentParts[0].PromptCacheBreakpoint))
+	require.False(t, openaiparam.IsOmitted(
+		out.Messages[1].OfUser.Content.OfArrayOfContentParts[0].OfText.PromptCacheBreakpoint))
+	require.False(t, openaiparam.IsOmitted(
+		out.Messages[2].OfTool.Content.OfArrayOfContentParts[0].PromptCacheBreakpoint))
+}
+
+func requireResponsesTextBreakpoint(
+	t *testing.T,
+	item responses.ResponseInputItemUnionParam,
+	role string,
+) {
+	t.Helper()
+	require.NotNil(t, item.OfMessage)
+	require.Equal(t, role, string(item.OfMessage.Role))
+	require.Len(t, item.OfMessage.Content.OfInputItemContentList, 1)
+	require.NotNil(t, item.OfMessage.Content.OfInputItemContentList[0].OfInputText)
+	require.False(t, openaiparam.IsOmitted(
+		item.OfMessage.Content.OfInputItemContentList[0].OfInputText.PromptCacheBreakpoint))
+}

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -53,6 +53,13 @@ func ConvertChatToOpenAIResponses(params *openai.ChatCompletionNewParams, defaul
 	for _, msg := range params.Messages {
 		switch {
 		case !param.IsOmitted(msg.OfSystem):
+			if chatTextPartsHaveCacheBreakpoint(msg.OfSystem.Content.OfArrayOfContentParts) {
+				// Responses' instructions field is a plain string and cannot
+				// carry an explicit cache boundary. Keep this as a system input
+				// item so the breakpoint remains attached to its content.
+				otherMessages = append(otherMessages, msg)
+				continue
+			}
 			// Extract system message content (string or array-of-text form)
 			sysMsg := msg.OfSystem
 			if !param.IsOmitted(sysMsg.Content.OfString) && sysMsg.Content.OfString.Value != "" {
@@ -111,6 +118,13 @@ func ConvertChatToOpenAIResponses(params *openai.ChatCompletionNewParams, defaul
 		}
 	}
 
+	result.PromptCacheKey = params.PromptCacheKey
+	result.PromptCacheOptions = responses.ResponseNewParamsPromptCacheOptions{
+		Mode: params.PromptCacheOptions.Mode,
+		Ttl:  params.PromptCacheOptions.Ttl,
+	}
+	result.PromptCacheRetention = responses.ResponseNewParamsPromptCacheRetention(params.PromptCacheRetention)
+
 	return result
 }
 
@@ -120,6 +134,9 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 
 	for _, msg := range messages {
 		switch {
+		case !param.IsOmitted(msg.OfSystem):
+			result = append(result, convertChatSystemMessageToResponses(msg.OfSystem)...)
+
 		case !param.IsOmitted(msg.OfUser):
 			result = append(result, convertChatUserMessageToResponses(msg.OfUser)...)
 
@@ -152,6 +169,17 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 	return result
 }
 
+func convertChatSystemMessageToResponses(systemMsg *openai.ChatCompletionSystemMessageParam) []responses.ResponseInputItemUnionParam {
+	if systemMsg.Content.OfString.Valid() && systemMsg.Content.OfString.Value != "" {
+		return []responses.ResponseInputItemUnionParam{responseMessageWithString("system", systemMsg.Content.OfString.Value)}
+	}
+	content := responseContentFromChatTextParts(systemMsg.Content.OfArrayOfContentParts)
+	if len(content) == 0 {
+		return nil
+	}
+	return []responses.ResponseInputItemUnionParam{responseMessageWithContent("system", content)}
+}
+
 // convertChatUserMessageToResponses converts a Chat user message to Responses format.
 // Returns nil if the message has no usable content.
 func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessageParam) []responses.ResponseInputItemUnionParam {
@@ -173,19 +201,23 @@ func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessage
 		for _, part := range userMsg.Content.OfArrayOfContentParts {
 			switch {
 			case part.OfText != nil:
+				inputText := &responses.ResponseInputTextParam{Text: part.OfText.Text}
+				if hasOpenAITextCacheBreakpoint(*part.OfText) {
+					inputText.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+				}
 				contentList = append(contentList, responses.ResponseInputContentUnionParam{
-					OfInputText: &responses.ResponseInputTextParam{Text: part.OfText.Text},
+					OfInputText: inputText,
 				})
 			case part.OfImageURL != nil:
 				url := part.OfImageURL.ImageURL.URL
 				if url == "" {
 					continue
 				}
-				contentList = append(contentList, responses.ResponseInputContentUnionParam{
-					OfInputImage: &responses.ResponseInputImageParam{
-						ImageURL: param.NewOpt(url),
-					},
-				})
+				inputImage := &responses.ResponseInputImageParam{ImageURL: param.NewOpt(url)}
+				if !param.IsOmitted(part.OfImageURL.PromptCacheBreakpoint) {
+					inputImage.PromptCacheBreakpoint = responses.NewResponseInputImagePromptCacheBreakpointParam()
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{OfInputImage: inputImage})
 			}
 		}
 		if len(contentList) > 0 {
@@ -208,40 +240,102 @@ func convertChatUserMessageToResponses(userMsg *openai.ChatCompletionUserMessage
 // convertChatAssistantMessageToResponses converts a Chat assistant message to Responses format.
 // Returns nil if the message has no usable text content.
 func convertChatAssistantMessageToResponses(assistantMsg *openai.ChatCompletionAssistantMessageParam) []responses.ResponseInputItemUnionParam {
-	content := assistantMsg.Content.OfString.Value
-	if content == "" {
-		content = joinAssistantTextContentParts(assistantMsg.Content.OfArrayOfContentParts)
+	if content := assistantMsg.Content.OfString.Value; content != "" {
+		return []responses.ResponseInputItemUnionParam{responseMessageWithString("assistant", content)}
 	}
-	if content == "" {
+	var parts []openai.ChatCompletionContentPartTextParam
+	for _, part := range assistantMsg.Content.OfArrayOfContentParts {
+		if part.OfText != nil {
+			parts = append(parts, *part.OfText)
+		}
+	}
+	if !chatTextPartsHaveCacheBreakpoint(parts) {
+		content := joinTextContentParts(parts)
+		if content == "" {
+			return nil
+		}
+		return []responses.ResponseInputItemUnionParam{responseMessageWithString("assistant", content)}
+	}
+	content := responseContentFromChatTextParts(parts)
+	if len(content) == 0 {
 		return nil
 	}
-
-	return []responses.ResponseInputItemUnionParam{{
-		OfMessage: &responses.EasyInputMessageParam{
-			Type: responses.EasyInputMessageTypeMessage,
-			Role: responses.EasyInputMessageRole("assistant"),
-			Content: responses.EasyInputMessageContentUnionParam{
-				OfString: param.NewOpt(content),
-			},
-		},
-	}}
+	return []responses.ResponseInputItemUnionParam{responseMessageWithContent("assistant", content)}
 }
 
 // convertChatToolMessageToResponses converts a Chat tool message to Responses function_call_output format.
 func convertChatToolMessageToResponses(toolMsg *openai.ChatCompletionToolMessageParam) responses.ResponseInputItemUnionParam {
 	content := toolMsg.Content.OfString.Value
-	if content == "" {
-		content = joinTextContentParts(toolMsg.Content.OfArrayOfContentParts)
+	output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
+	if content != "" {
+		output.OfString = param.NewOpt(content)
+	} else if !chatTextPartsHaveCacheBreakpoint(toolMsg.Content.OfArrayOfContentParts) {
+		output.OfString = param.NewOpt(joinTextContentParts(toolMsg.Content.OfArrayOfContentParts))
+	} else {
+		items := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(toolMsg.Content.OfArrayOfContentParts))
+		for _, part := range toolMsg.Content.OfArrayOfContentParts {
+			if part.Text == "" {
+				continue
+			}
+			item := &responses.ResponseInputTextContentParam{Text: part.Text}
+			if hasOpenAITextCacheBreakpoint(part) {
+				item.PromptCacheBreakpoint = responses.NewResponseInputTextContentPromptCacheBreakpointParam()
+			}
+			items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{OfInputText: item})
+		}
+		if len(items) > 0 {
+			output.OfResponseFunctionCallOutputItemArray = items
+		} else {
+			output.OfString = param.NewOpt("")
+		}
 	}
 
 	return responses.ResponseInputItemUnionParam{
 		OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
 			CallID: toolMsg.ToolCallID,
-			Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
-				OfString: param.NewOpt(content),
-			},
+			Output: output,
 		},
 	}
+}
+
+func responseContentFromChatTextParts(parts []openai.ChatCompletionContentPartTextParam) responses.ResponseInputMessageContentListParam {
+	content := make(responses.ResponseInputMessageContentListParam, 0, len(parts))
+	for _, part := range parts {
+		if part.Text == "" {
+			continue
+		}
+		item := &responses.ResponseInputTextParam{Text: part.Text}
+		if hasOpenAITextCacheBreakpoint(part) {
+			item.PromptCacheBreakpoint = responses.NewResponseInputTextPromptCacheBreakpointParam()
+		}
+		content = append(content, responses.ResponseInputContentUnionParam{OfInputText: item})
+	}
+	return content
+}
+
+func responseMessageWithString(role, content string) responses.ResponseInputItemUnionParam {
+	return responses.ResponseInputItemUnionParam{OfMessage: &responses.EasyInputMessageParam{
+		Type:    responses.EasyInputMessageTypeMessage,
+		Role:    responses.EasyInputMessageRole(role),
+		Content: responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt(content)},
+	}}
+}
+
+func responseMessageWithContent(role string, content responses.ResponseInputMessageContentListParam) responses.ResponseInputItemUnionParam {
+	return responses.ResponseInputItemUnionParam{OfMessage: &responses.EasyInputMessageParam{
+		Type:    responses.EasyInputMessageTypeMessage,
+		Role:    responses.EasyInputMessageRole(role),
+		Content: responses.EasyInputMessageContentUnionParam{OfInputItemContentList: content},
+	}}
+}
+
+func chatTextPartsHaveCacheBreakpoint(parts []openai.ChatCompletionContentPartTextParam) bool {
+	for _, part := range parts {
+		if hasOpenAITextCacheBreakpoint(part) {
+			return true
+		}
+	}
+	return false
 }
 
 // ConvertChatToolsToResponsesTools converts Chat Completion tools to Responses API tools.

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -27,18 +27,6 @@ func joinTextContentParts(parts []openai.ChatCompletionContentPartTextParam) str
 	return strings.Join(texts, "\n")
 }
 
-// joinAssistantTextContentParts concatenates the text fields of assistant array
-// content parts into a single newline-separated string, ignoring refusal parts.
-func joinAssistantTextContentParts(parts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion) string {
-	textParts := make([]openai.ChatCompletionContentPartTextParam, 0, len(parts))
-	for _, part := range parts {
-		if part.OfText != nil {
-			textParts = append(textParts, *part.OfText)
-		}
-	}
-	return joinTextContentParts(textParts)
-}
-
 // ConvertChatToOpenAIResponses converts OpenAI Chat Completions params to Responses API format.
 // This enables using Chat Completions format with Responses API providers.
 func ConvertChatToOpenAIResponses(params *openai.ChatCompletionNewParams, defaultMaxTokens int64) *responses.ResponseNewParams {

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -36,15 +36,23 @@ func ConvertChatToOpenAIResponses(params *openai.ChatCompletionNewParams, defaul
 
 	var systemParts []string
 	var otherMessages []openai.ChatCompletionMessageParamUnion
+	preserveSystemMessages := false
+	for _, msg := range params.Messages {
+		if msg.OfSystem != nil &&
+			chatTextPartsHaveCacheBreakpoint(msg.OfSystem.Content.OfArrayOfContentParts) {
+			preserveSystemMessages = true
+			break
+		}
+	}
 
 	// Separate system messages from other messages
 	for _, msg := range params.Messages {
 		switch {
 		case !param.IsOmitted(msg.OfSystem):
-			if chatTextPartsHaveCacheBreakpoint(msg.OfSystem.Content.OfArrayOfContentParts) {
+			if preserveSystemMessages {
 				// Responses' instructions field is a plain string and cannot
-				// carry an explicit cache boundary. Keep this as a system input
-				// item so the breakpoint remains attached to its content.
+				// carry explicit cache boundaries. Keep every system message
+				// in input so their order and breakpoints remain intact.
 				otherMessages = append(otherMessages, msg)
 				continue
 			}
@@ -130,6 +138,7 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 
 		case !param.IsOmitted(msg.OfAssistant):
 			assistantMsg := msg.OfAssistant
+			result = append(result, convertChatAssistantMessageToResponses(assistantMsg)...)
 			// Check if assistant has tool calls
 			if len(assistantMsg.ToolCalls) > 0 {
 				// Convert each tool call to function_call item
@@ -145,8 +154,6 @@ func ConvertChatMessagesToResponsesInput(messages []openai.ChatCompletionMessage
 						})
 					}
 				}
-			} else {
-				result = append(result, convertChatAssistantMessageToResponses(assistantMsg)...)
 			}
 
 		case !param.IsOmitted(msg.OfTool):

--- a/internal/protocol/request/openai_chat_to_openai_responses_test.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses_test.go
@@ -55,6 +55,32 @@ func TestConvertChatToOpenAIResponses(t *testing.T) {
 		assert.Len(t, result.Input.OfInputItemList, 1)
 	})
 
+	t.Run("mixed cached system messages preserve order", func(t *testing.T) {
+		cached := openai.ChatCompletionContentPartTextParam{
+			Text:                  "cached first",
+			PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+		}
+		params := &openai.ChatCompletionNewParams{
+			Model: openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.SystemMessage([]openai.ChatCompletionContentPartTextParam{cached}),
+				openai.SystemMessage("uncached second"),
+				openai.UserMessage("question"),
+			},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		require.False(t, result.Instructions.Valid())
+		require.Len(t, result.Input.OfInputItemList, 3)
+		require.Equal(t, "system", string(result.Input.OfInputItemList[0].OfMessage.Role))
+		require.Equal(t, "cached first",
+			result.Input.OfInputItemList[0].OfMessage.Content.OfInputItemContentList[0].OfInputText.Text)
+		require.Equal(t, "system", string(result.Input.OfInputItemList[1].OfMessage.Role))
+		require.Equal(t, "uncached second", result.Input.OfInputItemList[1].OfMessage.Content.OfString.Value)
+		require.Equal(t, "user", string(result.Input.OfInputItemList[2].OfMessage.Role))
+	})
+
 	t.Run("assistant message with text", func(t *testing.T) {
 		params := &openai.ChatCompletionNewParams{
 			Model:    openai.ChatModel("gpt-4"),
@@ -125,6 +151,34 @@ func TestConvertChatToOpenAIResponses(t *testing.T) {
 		assert.Equal(t, "call_123", fnCall.CallID)
 		assert.Equal(t, "get_weather", fnCall.Name)
 		assert.Equal(t, `{"location":"NYC"}`, fnCall.Arguments)
+	})
+
+	t.Run("assistant text and cache breakpoint survive beside tool call", func(t *testing.T) {
+		text := openai.ChatCompletionContentPartTextParam{
+			Text:                  "Calling the weather tool.",
+			PromptCacheBreakpoint: openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam(),
+		}
+		assistant := createAssistantWithToolCallsMessage()
+		assistant.OfAssistant.Content.OfString = param.Opt[string]{}
+		assistant.OfAssistant.Content.OfArrayOfContentParts = []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+			{OfText: &text},
+		}
+		params := &openai.ChatCompletionNewParams{
+			Model:    openai.ChatModel("gpt-4"),
+			Messages: []openai.ChatCompletionMessageParamUnion{assistant},
+		}
+
+		result := ConvertChatToOpenAIResponses(params, 4096)
+
+		require.Len(t, result.Input.OfInputItemList, 2)
+		message := result.Input.OfInputItemList[0].OfMessage
+		require.NotNil(t, message)
+		require.Equal(t, "assistant", string(message.Role))
+		require.Len(t, message.Content.OfInputItemContentList, 1)
+		require.Equal(t, "Calling the weather tool.", message.Content.OfInputItemContentList[0].OfInputText.Text)
+		require.False(t, param.IsOmitted(
+			message.Content.OfInputItemContentList[0].OfInputText.PromptCacheBreakpoint))
+		require.NotNil(t, result.Input.OfInputItemList[1].OfFunctionCall)
 	})
 
 	t.Run("tool result conversion", func(t *testing.T) {

--- a/internal/protocol/request/openai_responses_to_anthropic.go
+++ b/internal/protocol/request/openai_responses_to_anthropic.go
@@ -41,6 +41,8 @@ func ConvertOpenAIResponsesToAnthropicBetaRequest(
 
 	// Convert input to messages
 	if !param.IsOmitted(params.Input.OfInputItemList) {
+		anthropicParams.System = append(anthropicParams.System,
+			convertResponsesSystemInputToAnthropicBeta(params.Input.OfInputItemList)...)
 		messages := convertResponsesInputToAnthropicBetaMessages(params.Input.OfInputItemList)
 		if len(messages) > 0 {
 			anthropicParams.Messages = messages
@@ -82,6 +84,37 @@ func ConvertOpenAIResponsesToAnthropicBetaRequest(
 	}
 
 	return anthropicParams
+}
+
+func convertResponsesSystemInputToAnthropicBeta(inputItems responses.ResponseInputParam) []anthropic.BetaTextBlockParam {
+	var system []anthropic.BetaTextBlockParam
+	for _, item := range inputItems {
+		if item.OfMessage == nil {
+			continue
+		}
+		msg := item.OfMessage
+		role := string(msg.Role)
+		if role != "system" && role != "developer" {
+			continue
+		}
+		if msg.Content.OfString.Valid() {
+			if msg.Content.OfString.Value != "" {
+				system = append(system, anthropic.BetaTextBlockParam{Text: msg.Content.OfString.Value})
+			}
+			continue
+		}
+		for _, content := range msg.Content.OfInputItemContentList {
+			if content.OfInputText == nil || content.OfInputText.Text == "" {
+				continue
+			}
+			block := anthropic.BetaTextBlockParam{Text: content.OfInputText.Text}
+			if !param.IsOmitted(content.OfInputText.PromptCacheBreakpoint) {
+				block.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+			}
+			system = append(system, block)
+		}
+	}
+	return system
 }
 
 // convertResponsesInputToAnthropicBetaMessages converts Responses API input items to Anthropic Beta messages
@@ -129,7 +162,11 @@ func convertResponsesUserMessageToAnthropicBeta(msg *responses.EasyInputMessageP
 		for _, contentItem := range msg.Content.OfInputItemContentList {
 			switch {
 			case !param.IsOmitted(contentItem.OfInputText):
-				blocks = append(blocks, anthropic.NewBetaTextBlock(contentItem.OfInputText.Text))
+				block := anthropic.NewBetaTextBlock(contentItem.OfInputText.Text)
+				if !param.IsOmitted(contentItem.OfInputText.PromptCacheBreakpoint) {
+					block.OfText.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+				}
+				blocks = append(blocks, block)
 			case !param.IsOmitted(contentItem.OfInputImage):
 				img := contentItem.OfInputImage
 				if !img.ImageURL.Valid() {
@@ -137,6 +174,9 @@ func convertResponsesUserMessageToAnthropicBeta(msg *responses.EasyInputMessageP
 					continue
 				}
 				if block, ok := openAIImageURLToAnthropicBetaBlock(img.ImageURL.Value); ok {
+					if !param.IsOmitted(img.PromptCacheBreakpoint) {
+						block.OfImage.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+					}
 					blocks = append(blocks, block)
 				}
 			default:
@@ -167,7 +207,11 @@ func convertResponsesAssistantMessageToAnthropicBeta(msg *responses.EasyInputMes
 		var blocks []anthropic.BetaContentBlockParamUnion
 		for _, contentItem := range msg.Content.OfInputItemContentList {
 			if !param.IsOmitted(contentItem.OfInputText) {
-				blocks = append(blocks, anthropic.NewBetaTextBlock(contentItem.OfInputText.Text))
+				block := anthropic.NewBetaTextBlock(contentItem.OfInputText.Text)
+				if !param.IsOmitted(contentItem.OfInputText.PromptCacheBreakpoint) {
+					block.OfText.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+				}
+				blocks = append(blocks, block)
 			} else {
 				// Log unsupported content types
 				logrus.Warnf("Unsupported content type in Responses API beta user message, skipping. Content types available: %v", contentItem)
@@ -211,14 +255,25 @@ func convertResponsesFunctionCallToAnthropicBeta(call *responses.ResponseFunctio
 func convertResponsesFunctionCallOutputToAnthropicBeta(output *responses.ResponseInputItemFunctionCallOutputParam) anthropic.BetaMessageParam {
 	// Extract output content
 	var outputStr string
+	hasCacheControl := false
 	if !param.IsOmitted(output.Output.OfString) {
 		outputStr = output.Output.OfString.Value
+	} else {
+		for _, item := range output.Output.OfResponseFunctionCallOutputItemArray {
+			if item.OfInputText == nil {
+				continue
+			}
+			outputStr += item.OfInputText.Text
+			hasCacheControl = hasCacheControl || !param.IsOmitted(item.OfInputText.PromptCacheBreakpoint)
+		}
 	}
 
 	// Create user message with tool_result block
-	return anthropic.NewBetaUserMessage(
-		anthropic.NewBetaToolResultBlock(output.CallID, outputStr, false),
-	)
+	block := anthropic.NewBetaToolResultBlock(output.CallID, outputStr, false)
+	if hasCacheControl {
+		block.OfToolResult.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+	}
+	return anthropic.NewBetaUserMessage(block)
 }
 
 // ConvertResponsesToolsToAnthropicBeta converts Responses API tools to Anthropic Beta tools

--- a/internal/protocol/request/openai_responses_to_chat.go
+++ b/internal/protocol/request/openai_responses_to_chat.go
@@ -247,6 +247,13 @@ func createMessageFromResponsesContent(role string, content responses.ResponseIn
 		}
 		return openai.SystemMessage(parts), true
 
+	case "developer":
+		parts := responseTextContentToChatTextParts(content)
+		if len(parts) == 0 {
+			return openai.ChatCompletionMessageParamUnion{}, false
+		}
+		return openai.DeveloperMessage(parts), true
+
 	case "assistant":
 		textParts := responseTextContentToChatTextParts(content)
 		if len(textParts) == 0 {

--- a/internal/protocol/request/openai_responses_to_chat.go
+++ b/internal/protocol/request/openai_responses_to_chat.go
@@ -59,6 +59,13 @@ func ConvertOpenAIResponsesToChat(params *responses.ResponseNewParams, defaultMa
 		result.ToolChoice = ConvertResponsesToolChoiceToChat(params.ToolChoice)
 	}
 
+	result.PromptCacheKey = params.PromptCacheKey
+	result.PromptCacheOptions = openai.ChatCompletionNewParamsPromptCacheOptions{
+		Mode: params.PromptCacheOptions.Mode,
+		Ttl:  params.PromptCacheOptions.Ttl,
+	}
+	result.PromptCacheRetention = openai.ChatCompletionNewParamsPromptCacheRetention(params.PromptCacheRetention)
+
 	return result
 }
 
@@ -121,64 +128,14 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 				content := msg.Content.OfString.Value
 				messages = append(messages, createMessage(role, content))
 			} else if !param.IsOmitted(msg.Content.OfInputItemContentList) {
-				// Array content. If any input_image is present, preserve the
-				// multipart shape for OpenAI Chat Completions so vision input
-				// survives the conversion. Otherwise concatenate text items.
-				var hasImage bool
-				for _, contentItem := range msg.Content.OfInputItemContentList {
-					if !param.IsOmitted(contentItem.OfInputImage) {
-						hasImage = true
-						break
-					}
-				}
-
-				if hasImage && strings.EqualFold(role, "user") {
-					parts := make([]map[string]interface{}, 0, len(msg.Content.OfInputItemContentList))
-					for _, contentItem := range msg.Content.OfInputItemContentList {
-						switch {
-						case !param.IsOmitted(contentItem.OfInputText):
-							parts = append(parts, map[string]interface{}{
-								"type": "text",
-								"text": contentItem.OfInputText.Text,
-							})
-						case !param.IsOmitted(contentItem.OfInputImage):
-							img := contentItem.OfInputImage
-							if !img.ImageURL.Valid() || img.ImageURL.Value == "" {
-								continue
-							}
-							parts = append(parts, map[string]interface{}{
-								"type":      "image_url",
-								"image_url": map[string]interface{}{"url": img.ImageURL.Value},
-							})
-						}
-					}
-					if len(parts) > 0 {
-						msgMap := map[string]interface{}{
-							"role":    "user",
-							"content": parts,
-						}
-						msgBytes, _ := json.Marshal(msgMap)
-						var userMsg openai.ChatCompletionMessageParamUnion
-						_ = json.Unmarshal(msgBytes, &userMsg)
-						messages = append(messages, userMsg)
-					}
-					continue
-				}
-
-				var contentStr string
-				for _, contentItem := range msg.Content.OfInputItemContentList {
-					if !param.IsOmitted(contentItem.OfInputText) {
-						contentStr += contentItem.OfInputText.Text
-					}
-				}
-				if contentStr != "" {
-					messages = append(messages, createMessage(role, contentStr))
+				if converted, ok := createMessageFromResponsesContent(role, msg.Content.OfInputItemContentList); ok {
+					messages = append(messages, converted)
 				}
 			}
 			continue
 		}
 
-			// Accumulate consecutive function_call items into a single assistant message.
+		// Accumulate consecutive function_call items into a single assistant message.
 		// Flushed on the next message boundary or first function_call_output.
 		if !param.IsOmitted(item.OfFunctionCall) {
 			fnCall := item.OfFunctionCall
@@ -199,22 +156,34 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 			output := item.OfFunctionCallOutput
 
 			// Extract output content
-			var content string
 			if !param.IsOmitted(output.Output.OfString) {
-				content = output.Output.OfString.Value
+				messages = append(messages, openai.ToolMessage(output.Output.OfString.Value, output.CallID))
+				continue
 			}
-
-			// Create tool message
-			toolMsg := map[string]interface{}{
-				"role":         "tool",
-				"tool_call_id": output.CallID,
-				"content":      content,
+			parts := make([]openai.ChatCompletionContentPartTextParam, 0,
+				len(output.Output.OfResponseFunctionCallOutputItemArray))
+			for _, item := range output.Output.OfResponseFunctionCallOutputItemArray {
+				if item.OfInputText == nil || item.OfInputText.Text == "" {
+					continue
+				}
+				part := openai.ChatCompletionContentPartTextParam{Text: item.OfInputText.Text}
+				if !param.IsOmitted(item.OfInputText.PromptCacheBreakpoint) {
+					part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+				}
+				parts = append(parts, part)
 			}
-
-			msgBytes, _ := json.Marshal(toolMsg)
-			var result openai.ChatCompletionMessageParamUnion
-			_ = json.Unmarshal(msgBytes, &result)
-			messages = append(messages, result)
+			if len(parts) > 0 {
+				messages = append(messages, openai.ChatCompletionMessageParamUnion{
+					OfTool: &openai.ChatCompletionToolMessageParam{
+						ToolCallID: output.CallID,
+						Content: openai.ChatCompletionToolMessageParamContentUnion{
+							OfArrayOfContentParts: parts,
+						},
+					},
+				})
+			} else {
+				messages = append(messages, openai.ToolMessage("", output.CallID))
+			}
 		}
 	}
 
@@ -222,6 +191,96 @@ func ConvertResponsesInputToMessages(items responses.ResponseInputParam) []opena
 	flushCalls(pendingCalls)
 
 	return messages
+}
+
+func createMessageFromResponsesContent(role string, content responses.ResponseInputMessageContentListParam) (openai.ChatCompletionMessageParamUnion, bool) {
+	var text string
+	var hasImage, hasCacheBreakpoint bool
+	for _, item := range content {
+		switch {
+		case item.OfInputText != nil:
+			text += item.OfInputText.Text
+			hasCacheBreakpoint = hasCacheBreakpoint || !param.IsOmitted(item.OfInputText.PromptCacheBreakpoint)
+		case item.OfInputImage != nil:
+			hasImage = true
+			hasCacheBreakpoint = hasCacheBreakpoint || !param.IsOmitted(item.OfInputImage.PromptCacheBreakpoint)
+		}
+	}
+
+	if !hasImage && !hasCacheBreakpoint {
+		if text == "" {
+			return openai.ChatCompletionMessageParamUnion{}, false
+		}
+		return createMessage(role, text), true
+	}
+
+	switch strings.ToLower(role) {
+	case "user":
+		parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(content))
+		for _, item := range content {
+			switch {
+			case item.OfInputText != nil:
+				part := openai.ChatCompletionContentPartTextParam{Text: item.OfInputText.Text}
+				if !param.IsOmitted(item.OfInputText.PromptCacheBreakpoint) {
+					part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+				}
+				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
+			case item.OfInputImage != nil && item.OfInputImage.ImageURL.Valid():
+				part := openai.ChatCompletionContentPartImageParam{
+					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: item.OfInputImage.ImageURL.Value},
+				}
+				if !param.IsOmitted(item.OfInputImage.PromptCacheBreakpoint) {
+					part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
+				}
+				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &part})
+			}
+		}
+		if len(parts) == 0 {
+			return openai.ChatCompletionMessageParamUnion{}, false
+		}
+		return openai.UserMessage(parts), true
+
+	case "system":
+		parts := responseTextContentToChatTextParts(content)
+		if len(parts) == 0 {
+			return openai.ChatCompletionMessageParamUnion{}, false
+		}
+		return openai.SystemMessage(parts), true
+
+	case "assistant":
+		textParts := responseTextContentToChatTextParts(content)
+		if len(textParts) == 0 {
+			return openai.ChatCompletionMessageParamUnion{}, false
+		}
+		parts := make([]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion, 0, len(textParts))
+		for i := range textParts {
+			part := textParts[i]
+			parts = append(parts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{OfText: &part})
+		}
+		return openai.ChatCompletionMessageParamUnion{
+			OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfArrayOfContentParts: parts,
+				},
+			},
+		}, true
+	}
+	return openai.ChatCompletionMessageParamUnion{}, false
+}
+
+func responseTextContentToChatTextParts(content responses.ResponseInputMessageContentListParam) []openai.ChatCompletionContentPartTextParam {
+	parts := make([]openai.ChatCompletionContentPartTextParam, 0, len(content))
+	for _, item := range content {
+		if item.OfInputText == nil || item.OfInputText.Text == "" {
+			continue
+		}
+		part := openai.ChatCompletionContentPartTextParam{Text: item.OfInputText.Text}
+		if !param.IsOmitted(item.OfInputText.PromptCacheBreakpoint) {
+			part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+		}
+		parts = append(parts, part)
+	}
+	return parts
 }
 
 // createMessage creates a ChatCompletionMessageParamUnion based on role and content.

--- a/internal/protocol/request/openai_responses_to_chat_test.go
+++ b/internal/protocol/request/openai_responses_to_chat_test.go
@@ -406,6 +406,36 @@ func TestConvertResponsesInputToMessages(t *testing.T) {
 		assert.Equal(t, "user", getMessageRole(t, messages[0]))
 		assert.Equal(t, "Hello, world!", getMessageContent(t, messages[0]))
 	})
+
+	t.Run("cached developer content preserves role", func(t *testing.T) {
+		input := responses.ResponseInputParam{
+			{
+				OfMessage: &responses.EasyInputMessageParam{
+					Type: responses.EasyInputMessageTypeMessage,
+					Role: responses.EasyInputMessageRole("developer"),
+					Content: responses.EasyInputMessageContentUnionParam{
+						OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+							{
+								OfInputText: &responses.ResponseInputTextParam{
+									Text:                  "developer instruction",
+									PromptCacheBreakpoint: responses.NewResponseInputTextPromptCacheBreakpointParam(),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		messages := ConvertResponsesInputToMessages(input)
+
+		require.Len(t, messages, 1)
+		require.NotNil(t, messages[0].OfDeveloper)
+		require.Len(t, messages[0].OfDeveloper.Content.OfArrayOfContentParts, 1)
+		part := messages[0].OfDeveloper.Content.OfArrayOfContentParts[0]
+		require.Equal(t, "developer instruction", part.Text)
+		require.False(t, param.IsOmitted(part.PromptCacheBreakpoint))
+	})
 }
 
 func TestConvertResponsesToolsToChatTools(t *testing.T) {

--- a/internal/protocol/request/openai_to_anthropic.go
+++ b/internal/protocol/request/openai_to_anthropic.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
+	openaiparam "github.com/openai/openai-go/v3/packages/param"
 )
 
 // ConvertOpenAIToAnthropicRequest converts OpenAI ChatCompletionNewParams to Anthropic SDK format
 func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaultMaxTokens int64) *anthropic.BetaMessageNewParams {
 	messages := make([]anthropic.BetaMessageParam, 0, len(req.Messages))
-	var systemParts []string
+	var systemBlocks []anthropic.BetaTextBlockParam
 
 	for _, msg := range req.Messages {
 		// Read the typed union fields directly — no JSON round-trip needed.
@@ -18,9 +19,14 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 		case msg.OfSystem != nil:
 			// System message → params.System (string or array-of-text form)
 			if content := msg.OfSystem.Content.OfString.Value; content != "" {
-				systemParts = append(systemParts, content)
-			} else if text := joinTextContentParts(msg.OfSystem.Content.OfArrayOfContentParts); text != "" {
-				systemParts = append(systemParts, text)
+				systemBlocks = append(systemBlocks, anthropic.BetaTextBlockParam{Text: content})
+			} else {
+				for _, part := range msg.OfSystem.Content.OfArrayOfContentParts {
+					if part.Text == "" {
+						continue
+					}
+					systemBlocks = append(systemBlocks, betaTextBlockFromOpenAI(part))
+				}
 			}
 
 		case msg.OfUser != nil:
@@ -36,10 +42,17 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 					switch {
 					case part.OfText != nil:
 						if part.OfText.Text != "" {
-							blocks = append(blocks, anthropic.NewBetaTextBlock(part.OfText.Text))
+							block := anthropic.NewBetaTextBlock(part.OfText.Text)
+							if hasOpenAITextCacheBreakpoint(*part.OfText) {
+								block.OfText.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+							}
+							blocks = append(blocks, block)
 						}
 					case part.OfImageURL != nil:
 						if block, ok := openAIImageURLToAnthropicBetaBlock(part.OfImageURL.ImageURL.URL); ok {
+							if !openaiparam.IsOmitted(part.OfImageURL.PromptCacheBreakpoint) {
+								block.OfImage.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+							}
 							blocks = append(blocks, block)
 						}
 					}
@@ -57,8 +70,17 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			// Add text content if present (string or array-of-text form)
 			if content := msg.OfAssistant.Content.OfString.Value; content != "" {
 				blocks = append(blocks, anthropic.NewBetaTextBlock(content))
-			} else if text := joinAssistantTextContentParts(msg.OfAssistant.Content.OfArrayOfContentParts); text != "" {
-				blocks = append(blocks, anthropic.NewBetaTextBlock(text))
+			} else {
+				for _, part := range msg.OfAssistant.Content.OfArrayOfContentParts {
+					if part.OfText == nil || part.OfText.Text == "" {
+						continue
+					}
+					block := anthropic.NewBetaTextBlock(part.OfText.Text)
+					if hasOpenAITextCacheBreakpoint(*part.OfText) {
+						block.OfText.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+					}
+					blocks = append(blocks, block)
+				}
 			}
 
 			// Convert tool calls to tool_use blocks
@@ -87,12 +109,18 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 			// Tool result message → tool_result block (must be USER role).
 			// Content may be a plain string or an array of text blocks.
 			content := msg.OfTool.Content.OfString.Value
+			hasCacheControl := false
 			if content == "" {
 				content = joinTextContentParts(msg.OfTool.Content.OfArrayOfContentParts)
+				for _, part := range msg.OfTool.Content.OfArrayOfContentParts {
+					hasCacheControl = hasCacheControl || hasOpenAITextCacheBreakpoint(part)
+				}
 			}
-			blocks := []anthropic.BetaContentBlockParamUnion{
-				anthropic.NewBetaToolResultBlock(msg.OfTool.ToolCallID, content, false),
+			block := anthropic.NewBetaToolResultBlock(msg.OfTool.ToolCallID, content, false)
+			if hasCacheControl {
+				block.OfToolResult.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
 			}
+			blocks := []anthropic.BetaContentBlockParamUnion{block}
 			messages = append(messages, anthropic.NewBetaUserMessage(blocks...))
 		}
 	}
@@ -109,12 +137,10 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 		MaxTokens: maxTokens,
 	}
 
-	// Add system parts if any
-	if len(systemParts) > 0 {
-		params.System = make([]anthropic.BetaTextBlockParam, len(systemParts))
-		for i, part := range systemParts {
-			params.System[i] = anthropic.BetaTextBlockParam{Text: part}
-		}
+	// Add system blocks if any. Array-form OpenAI content keeps standard
+	// prompt_cache_breakpoint markers from an earlier Anthropic hop.
+	if len(systemBlocks) > 0 {
+		params.System = systemBlocks
 	}
 
 	// Convert tools from OpenAI format to Anthropic format
@@ -126,6 +152,18 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 	}
 
 	return params
+}
+
+func hasOpenAITextCacheBreakpoint(part openai.ChatCompletionContentPartTextParam) bool {
+	return !openaiparam.IsOmitted(part.PromptCacheBreakpoint)
+}
+
+func betaTextBlockFromOpenAI(part openai.ChatCompletionContentPartTextParam) anthropic.BetaTextBlockParam {
+	block := anthropic.BetaTextBlockParam{Text: part.Text}
+	if hasOpenAITextCacheBreakpoint(part) {
+		block.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+	}
+	return block
 }
 
 // openAIImageURLToAnthropicBetaBlock turns an OpenAI image_url.url string into

--- a/internal/protocoltest/cache_controls.go
+++ b/internal/protocoltest/cache_controls.go
@@ -1,0 +1,312 @@
+package protocoltest
+
+import (
+	"fmt"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// cache_controls is the request-side prompt-cache regression section shared by
+// go test and `harness matrix --mode=cache_controls`.
+//
+// The normal scenario matrix deliberately sends one fixed plain-text request,
+// so it cannot prove that cache markers survive conversion. These cases send
+// bespoke cache/no-cache requests through the real gateway and inspect the
+// request captured by the final VirtualServer provider.
+//
+// Two path classes are covered:
+//
+//   - single: every supported A -> B pair in Matrix.Pairs;
+//   - ABA: every idempotent A -> B -> A path, using setupChainHopRoute so the
+//     first conversion re-enters the gateway through B's real HTTP endpoint.
+
+const cacheControlExpectedMarkers = 2
+
+func cacheControlScenario() Scenario {
+	s := TextScenario()
+	s.Name = "cache_controls"
+	s.Description = "Shared fixture for request-side prompt-cache conversion checks"
+	s.Assertions = nil
+	return s
+}
+
+// cacheControlBody returns the same stable system + user prefix in each source
+// protocol. cached controls both markers and OpenAI's explicit cache mode.
+func cacheControlBody(source protocol.APIType, model string, streaming, cached bool) map[string]any {
+	cacheControl := map[string]any{"type": "ephemeral"}
+	breakpoint := map[string]any{"mode": "explicit"}
+
+	switch source {
+	case protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta:
+		system := map[string]any{"type": "text", "text": "stable system prefix"}
+		user := map[string]any{"type": "text", "text": "stable conversation prefix"}
+		if cached {
+			system["cache_control"] = cacheControl
+			user["cache_control"] = cacheControl
+		}
+		return map[string]any{
+			"model":      model,
+			"max_tokens": 64,
+			"stream":     streaming,
+			"system":     []map[string]any{system},
+			"messages": []map[string]any{{
+				"role":    "user",
+				"content": []map[string]any{user},
+			}},
+		}
+
+	case protocol.TypeOpenAIChat:
+		system := map[string]any{"type": "text", "text": "stable system prefix"}
+		user := map[string]any{"type": "text", "text": "stable conversation prefix"}
+		body := map[string]any{
+			"model":  model,
+			"stream": streaming,
+			"messages": []map[string]any{
+				{"role": "system", "content": []map[string]any{system}},
+				{"role": "user", "content": []map[string]any{user}},
+			},
+		}
+		if cached {
+			system["prompt_cache_breakpoint"] = breakpoint
+			user["prompt_cache_breakpoint"] = breakpoint
+			body["prompt_cache_options"] = map[string]any{"mode": "explicit"}
+		}
+		return body
+
+	case protocol.TypeOpenAIResponses:
+		system := map[string]any{"type": "input_text", "text": "stable system prefix"}
+		user := map[string]any{"type": "input_text", "text": "stable conversation prefix"}
+		body := map[string]any{
+			"model":  model,
+			"stream": streaming,
+			"input": []map[string]any{
+				{"type": "message", "role": "system", "content": []map[string]any{system}},
+				{"type": "message", "role": "user", "content": []map[string]any{user}},
+			},
+		}
+		if cached {
+			system["prompt_cache_breakpoint"] = breakpoint
+			user["prompt_cache_breakpoint"] = breakpoint
+			body["prompt_cache_options"] = map[string]any{"mode": "explicit"}
+		}
+		return body
+	}
+	panic(fmt.Sprintf("unsupported cache-control source protocol %s", source))
+}
+
+func cacheControlEndpoint(target protocol.APIType) EndpointKind {
+	switch target {
+	case protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta:
+		return EndpointAnthropic
+	case protocol.TypeOpenAIChat:
+		return EndpointChat
+	case protocol.TypeOpenAIResponses:
+		return EndpointResponses
+	default:
+		return ""
+	}
+}
+
+func sendCacheControlBody(t flagTB, env *TestEnv, source, target protocol.APIType, scenarioName, model string, streaming, cached bool) {
+	t.Helper()
+	path, _ := buildRequest(source, model, streaming)
+	_, err := env.dispatch(source, target, scenarioName, path,
+		mustMarshal(cacheControlBody(source, model, streaming, cached)), nil, streaming)
+	if err != nil {
+		t.Fatalf("dispatch %s -> %s (cached=%v, streaming=%v): %v",
+			source, target, cached, streaming, err)
+	}
+}
+
+// countCacheMarkers recursively counts markerKey and validates every marker's
+// protocol-specific discriminator. Invalid marker values are reported as
+// errors but still counted, keeping missing-vs-malformed diagnostics separate.
+func countCacheMarkers(t flagTB, value any, markerKey, discriminator, wantValue string) int {
+	t.Helper()
+	count := 0
+	var walk func(any)
+	walk = func(v any) {
+		switch node := v.(type) {
+		case map[string]any:
+			for key, child := range node {
+				if key == markerKey {
+					count++
+					marker, ok := child.(map[string]any)
+					if !ok {
+						t.Errorf("%s marker is %T, want object", markerKey, child)
+					} else if got, _ := marker[discriminator].(string); got != wantValue {
+						t.Errorf("%s.%s = %q, want %q", markerKey, discriminator, got, wantValue)
+					}
+				}
+				walk(child)
+			}
+		case []any:
+			for _, child := range node {
+				walk(child)
+			}
+		}
+	}
+	walk(value)
+	return count
+}
+
+func assertCapturedCacheState(t flagTB, env *TestEnv, target protocol.APIType, cached bool, label string) {
+	t.Helper()
+	endpoint := cacheControlEndpoint(target)
+	if endpoint == "" {
+		t.Fatalf("%s: unsupported target protocol %s", label, target)
+	}
+
+	captured := env.virtual.LastRequest(endpoint)
+	if captured == nil {
+		t.Fatalf("%s: final provider received no %s request", label, endpoint)
+	}
+	body := captured.JSON()
+
+	markerKey := "prompt_cache_breakpoint"
+	discriminator := "mode"
+	wantValue := "explicit"
+	if endpoint == EndpointAnthropic {
+		markerKey = "cache_control"
+		discriminator = "type"
+		wantValue = "ephemeral"
+	}
+
+	gotMarkers := countCacheMarkers(t, body, markerKey, discriminator, wantValue)
+	wantMarkers := 0
+	if cached {
+		wantMarkers = cacheControlExpectedMarkers
+	}
+	if gotMarkers != wantMarkers {
+		t.Errorf("%s: final %s marker count = %d, want %d; body=%s",
+			label, markerKey, gotMarkers, wantMarkers, truncate(string(captured.Body), 1200))
+	}
+
+	unexpectedKey := "cache_control"
+	unexpectedDiscriminator := "type"
+	unexpectedValue := "ephemeral"
+	if endpoint == EndpointAnthropic {
+		unexpectedKey = "prompt_cache_breakpoint"
+		unexpectedDiscriminator = "mode"
+		unexpectedValue = "explicit"
+	}
+	if unexpected := countCacheMarkers(t, body, unexpectedKey, unexpectedDiscriminator, unexpectedValue); unexpected != 0 {
+		t.Errorf("%s: final provider body contains %d non-native %s marker(s); body=%s",
+			label, unexpected, unexpectedKey, truncate(string(captured.Body), 1200))
+	}
+
+	if endpoint == EndpointAnthropic {
+		return
+	}
+	rawOptions, hasOptions := body["prompt_cache_options"]
+	if hasOptions != cached {
+		t.Errorf("%s: final prompt_cache_options presence = %v, want %v; body=%s",
+			label, hasOptions, cached, truncate(string(captured.Body), 1200))
+	}
+	options, _ := rawOptions.(map[string]any)
+	mode, _ := options["mode"].(string)
+	wantMode := ""
+	if cached {
+		wantMode = "explicit"
+	}
+	if mode != wantMode {
+		t.Errorf("%s: final prompt_cache_options.mode = %q, want %q; body=%s",
+			label, mode, wantMode, truncate(string(captured.Body), 1200))
+	}
+}
+
+func runSingleCacheControlCase(t flagTB, env *TestEnv, pair ProtocolPair, streaming bool) {
+	t.Helper()
+	s := cacheControlScenario()
+	env.SetupRoute(pair.Source, pair.Target, s)
+	model := env.findRouteModel(pair.Source, pair.Target, s.Name)
+	if model == "" {
+		t.Fatalf("single %s -> %s: route model not configured", pair.Source, pair.Target)
+	}
+
+	for _, cached := range []bool{true, false} {
+		label := fmt.Sprintf("single/%s→%s/%s/%s",
+			pair.Source, pair.Target, cacheStateName(cached), streamMode(streaming))
+		sendCacheControlBody(t, env, pair.Source, pair.Target, s.Name, model, streaming, cached)
+		assertCapturedCacheState(t, env, pair.Target, cached, label)
+	}
+}
+
+func runABACacheControlCase(t flagTB, env *TestEnv, ic IdempotentCase, streaming bool) {
+	t.Helper()
+	s := cacheControlScenario()
+
+	// Tail: B -> A through the final VirtualServer provider.
+	env.SetupRoute(ic.Mid, ic.Baseline, s)
+	tailModel := env.findRouteModel(ic.Mid, ic.Baseline, s.Name)
+	if tailModel == "" {
+		t.Fatalf("ABA %s -> %s -> %s: tail route model not configured",
+			ic.Source, ic.Mid, ic.Baseline)
+	}
+
+	// Head: A -> B and re-enter this gateway carrying tailModel.
+	headModel := fmt.Sprintf("cache-aba-%s", ic.Name)
+	env.setupChainHopRoute(ic.Source, ic.Mid, s, headModel, tailModel)
+
+	for _, cached := range []bool{true, false} {
+		label := fmt.Sprintf("aba/%s→%s→%s/%s/%s",
+			ic.Source, ic.Mid, ic.Baseline, cacheStateName(cached), streamMode(streaming))
+		sendCacheControlBody(t, env, ic.Source, ic.Mid, s.Name, headModel, streaming, cached)
+		assertCapturedCacheState(t, env, ic.Baseline, cached, label)
+	}
+}
+
+func cacheStateName(cached bool) string {
+	if cached {
+		return "cache"
+	}
+	return "no_cache"
+}
+
+// ExecuteAllCacheControls runs single-hop and ABA prompt-cache request checks.
+// Each result validates both the positive cache case and the negative no-cache
+// case. Name formats:
+//
+//   - cache_controls/single/A→B/{stream|nonstream}
+//   - cache_controls/aba/A→B→A/{stream|nonstream}
+func (m *Matrix) ExecuteAllCacheControls() []TestResult {
+	var cases []recorderCase
+	for _, pair := range m.Pairs {
+		for _, streaming := range m.Streaming {
+			pair := pair
+			streaming := streaming
+			name := fmt.Sprintf("cache_controls/single/%s→%s/%s",
+				pair.Source, pair.Target, streamMode(streaming))
+			cases = append(cases, recorderCase{
+				name:      name,
+				scenario:  "cache_controls/single",
+				source:    pair.Source,
+				target:    pair.Target,
+				streaming: streaming,
+				run: func(t flagTB, env *TestEnv) {
+					runSingleCacheControlCase(t, env, pair, streaming)
+				},
+			})
+		}
+	}
+
+	for _, ic := range DefaultIdempotentCases() {
+		for _, streaming := range m.Streaming {
+			ic := ic
+			streaming := streaming
+			name := fmt.Sprintf("cache_controls/aba/%s→%s→%s/%s",
+				ic.Source, ic.Mid, ic.Baseline, streamMode(streaming))
+			cases = append(cases, recorderCase{
+				name:      name,
+				scenario:  "cache_controls/aba",
+				source:    ic.Source,
+				target:    ic.Mid,
+				streaming: streaming,
+				run: func(t flagTB, env *TestEnv) {
+					runABACacheControlCase(t, env, ic, streaming)
+				},
+			})
+		}
+	}
+	return m.runRecorderCases(cases)
+}

--- a/internal/protocoltest/cache_controls_test.go
+++ b/internal/protocoltest/cache_controls_test.go
@@ -1,0 +1,35 @@
+package protocoltest
+
+import "testing"
+
+// TestCacheControls drives every direct and ABA cache/no-cache request through
+// the real gateway. The case implementation is shared with
+// `harness matrix --mode=cache_controls`.
+func TestCacheControls(t *testing.T) {
+	m := DefaultMatrix()
+	for _, pair := range m.Pairs {
+		pair := pair
+		for _, streaming := range m.Streaming {
+			streaming := streaming
+			t.Run("single/"+pair.String()+"/"+streamMode(streaming), func(t *testing.T) {
+				t.Parallel()
+				env := NewTestEnv(t)
+				defer env.Close()
+				runSingleCacheControlCase(t, env, pair, streaming)
+			})
+		}
+	}
+
+	for _, ic := range DefaultIdempotentCases() {
+		ic := ic
+		for _, streaming := range m.Streaming {
+			streaming := streaming
+			t.Run("aba/"+ic.Name+"/"+streamMode(streaming), func(t *testing.T) {
+				t.Parallel()
+				env := NewTestEnv(t)
+				defer env.Close()
+				runABACacheControlCase(t, env, ic, streaming)
+			})
+		}
+	}
+}

--- a/internal/protocoltest/section.go
+++ b/internal/protocoltest/section.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"golang.org/x/sync/errgroup"
 )
 
-// This file holds the shared drivers behind the matrix's sections
-// (single-hop, transitive, idempotent, flags, content_shapes). Each section
+// This file holds the shared drivers behind the matrix's sections (single-hop,
+// transitive, idempotent, flags, content_shapes, cache_controls). Each section
 // contributes only its combos and per-combo execution; the env-per-scenario
-// lifecycle, setup-failure fan-out, parallelism, and testing.T scaffolding
-// live here once.
+// lifecycle, setup-failure fan-out, parallelism, and testing.T scaffolding live
+// here once.
 
 // scenarioCombo is one runnable cell within a per-scenario section: the
 // TestResult metadata that identifies it plus the function that executes it
@@ -149,13 +150,16 @@ func (m *Matrix) runPerScenario(t *testing.T, skipScenario func(Scenario) bool, 
 	}
 }
 
-// recorderCase is one flagTB-style case body (flags, content_shapes): a
-// section-prefixed result name, the short case name shown in the CLI table's
-// Scenario column, and the case body itself.
+// recorderCase is one flagTB-style case body (flags, content_shapes,
+// cache_controls): a section-prefixed result name, CLI result metadata, and the
+// case body itself.
 type recorderCase struct {
-	name     string
-	scenario string
-	run      func(flagTB, *TestEnv)
+	name      string
+	scenario  string
+	source    protocol.APIType
+	target    protocol.APIType
+	streaming bool
+	run       func(flagTB, *TestEnv)
 }
 
 // runRecorderCases executes recorder cases with bounded parallelism — each
@@ -164,15 +168,21 @@ type recorderCase struct {
 func (m *Matrix) runRecorderCases(cases []recorderCase) []TestResult {
 	results := make([]TestResult, len(cases))
 	runIndexed(len(cases), m.sectionParallelism(), func(i int) {
-		results[i] = runRecorderCase(cases[i].name, cases[i].scenario, cases[i].run)
+		results[i] = runRecorderCase(cases[i])
 	})
 	return results
 }
 
 // runRecorderCase executes one flagTB-style case body against a fresh env,
 // converting recorded failures into a CLI TestResult.
-func runRecorderCase(name, scenario string, run func(flagTB, *TestEnv)) TestResult {
-	res := TestResult{Name: name, Scenario: scenario}
+func runRecorderCase(c recorderCase) TestResult {
+	res := TestResult{
+		Name:      c.name,
+		Scenario:  c.scenario,
+		Source:    c.source,
+		Target:    c.target,
+		Streaming: c.streaming,
+	}
 	start := time.Now()
 
 	env, err := NewTestEnvForCLI()
@@ -191,7 +201,7 @@ func runRecorderCase(name, scenario string, run func(flagTB, *TestEnv)) TestResu
 				panic(r)
 			}
 		}()
-		run(rec, env)
+		c.run(rec, env)
 	}()
 
 	res.Errors = rec.errs


### PR DESCRIPTION
## Summary

Preserve prompt-cache semantics when requests cross Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses protocols. This prevents nested and ABA gateway conversions from silently dropping cache boundaries and leaving cache usage at zero.

## Key Changes

- **Cross-protocol cache continuity**: Preserve request cache keys, options, retention, and content-level breakpoints across Chat, Responses, Anthropic V1, and Anthropic Beta conversions.

- **Conversation fidelity**: Keep mixed cached system messages in their original order, retain assistant text alongside tool calls, and preserve cached developer messages.

- **Tool cache boundaries**: Carry Anthropic tool-definition and `tool_use` cache controls through OpenAI-compatible protocols using a deterministic content-boundary fallback when the target cannot represent the original marker directly.

- **Negative cache guarantees**: Ensure conversions do not synthesize cache markers or explicit cache mode for requests that did not enable caching.

- **Single-hop and ABA coverage**: Add a `cache_controls` matrix mode covering every supported direct protocol pair and real A→B→A gateway re-entry path in streaming and non-streaming modes.

- **Typed conversion safety**: Replace cache-sensitive JSON round trips with typed SDK conversions and simplify duplicate content construction.

## Testing

- `go test ./internal/protocol/... ./internal/protocoltest ./cli/harness -count=1`
- `go vet ./internal/protocol/request ./cli/harness`
- `go run ./cli/harness matrix --mode=cache_controls`
  - 36 passed
  - 0 failed
  - 0 skipped

## Notes

- The branch contains four focused commits separating protocol fixes, matrix coverage, simplification, and CR follow-up fixes.
- The local CR concluded with all findings resolved.