### PR TITLE
bugfix: Make provider mutation hooks synchronous

### DIFF
--- a/internal/server/config/provider.go
+++ b/internal/server/config/provider.go
@@ -219,6 +219,13 @@ func (c *Config) RegisterProviderDeleteHook(hook ProviderDeleteHook) {
 }
 
 // notifyProviderUpdate notifies all registered hooks about a provider create/update change.
+//
+// Hooks run synchronously (with panic isolation): they are cheap in-memory
+// invalidations (transport pool cleanup), and running them inline guarantees
+// that by the time the mutating call returns, the next outbound request builds
+// its connection from the updated provider. The previous async (goroutine)
+// dispatch left a window where a request issued right after the update could
+// still reuse a transport configured from the pre-update provider.
 func (c *Config) notifyProviderUpdate(provider *typ.Provider) {
 	c.hookMu.RLock()
 	hooks := make([]ProviderUpdateHook, len(c.providerUpdateHooks))
@@ -226,8 +233,7 @@ func (c *Config) notifyProviderUpdate(provider *typ.Provider) {
 	c.hookMu.RUnlock()
 
 	for _, hook := range hooks {
-		// Call hook in goroutine to avoid blocking the update operation
-		go func(h ProviderUpdateHook) {
+		func(h ProviderUpdateHook) {
 			defer func() {
 				if r := recover(); r != nil {
 					logrus.Errorf("Provider update hook panic: %v", r)
@@ -238,7 +244,8 @@ func (c *Config) notifyProviderUpdate(provider *typ.Provider) {
 	}
 }
 
-// notifyProviderDelete notifies all registered hooks about a provider deletion
+// notifyProviderDelete notifies all registered hooks about a provider deletion.
+// Synchronous for the same reason as notifyProviderUpdate.
 func (c *Config) notifyProviderDelete(uuid string) {
 	c.hookMu.RLock()
 	hooks := make([]ProviderDeleteHook, len(c.providerDeleteHooks))
@@ -246,7 +253,7 @@ func (c *Config) notifyProviderDelete(uuid string) {
 	c.hookMu.RUnlock()
 
 	for _, hook := range hooks {
-		go func(h ProviderDeleteHook) {
+		func(h ProviderDeleteHook) {
 			defer func() {
 				if r := recover(); r != nil {
 					logrus.Errorf("Provider delete hook panic: %v", r)

--- a/internal/server/config/provider_hooks_test.go
+++ b/internal/server/config/provider_hooks_test.go
@@ -48,6 +48,42 @@ func TestAddProviderNotifiesUpdateHooks(t *testing.T) {
 	}
 }
 
+// TestProviderMutationHooksAreSynchronous locks in the contract that hook
+// side effects are visible the moment the mutating call returns — no
+// goroutine window during which a request could still use stale caches.
+func TestProviderMutationHooksAreSynchronous(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()), WithDisableMigration(), WithDisableBuiltIn())
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	var updates []string
+	cfg.RegisterProviderUpdateHook(providerUpdateHookFunc(func(p *typ.Provider) {
+		updates = append(updates, p.UUID)
+	}))
+
+	provider := &typ.Provider{
+		UUID:    "provider-sync-hook",
+		Name:    "provider sync hook",
+		APIBase: "https://example.com/v1",
+		Token:   "sk-test",
+	}
+	if err := cfg.AddProvider(provider); err != nil {
+		t.Fatalf("AddProvider error: %v", err)
+	}
+	if len(updates) != 1 {
+		t.Fatalf("update hook not invoked synchronously on AddProvider: %v", updates)
+	}
+
+	provider.Token = "sk-rotated"
+	if err := cfg.UpdateProvider(provider.UUID, provider); err != nil {
+		t.Fatalf("UpdateProvider error: %v", err)
+	}
+	if len(updates) != 2 {
+		t.Fatalf("update hook not invoked synchronously on UpdateProvider: %v", updates)
+	}
+}
+
 func TestAddProviderInvalidatesRegisteredClientPool(t *testing.T) {
 	transportPool := client.GetGlobalTransportPool()
 	transportPool.Clear()


### PR DESCRIPTION
## Summary
Changes provider update and delete hooks from asynchronous (goroutine-based) to synchronous execution to eliminate a race condition window where requests could use stale cached transports after a provider mutation.

## Changes
- **Removed goroutine dispatch** in `notifyProviderUpdate()` and `notifyProviderDelete()`: hooks now execute inline with panic isolation instead of spawning goroutines
- **Updated documentation**: added detailed comments explaining why synchronous execution is necessary — hook side effects (transport pool invalidation) must be visible immediately when the mutating call returns
- **Added test coverage**: `TestProviderMutationHooksAreSynchronous` verifies that hooks fire synchronously on both `AddProvider` and `UpdateProvider` operations

## Implementation Details
The previous async approach left a window where a request issued immediately after a provider update could still reuse a transport configured from the pre-update provider state. By running hooks synchronously (with panic recovery to prevent one hook from blocking others), we guarantee that by the time `AddProvider` or `UpdateProvider` returns, the next outbound request will build its connection from the updated provider configuration.

Hooks remain cheap in-memory operations (transport pool cleanup), so the synchronous overhead is negligible and the correctness guarantee is worth the trade-off.

https://claude.ai/code/session_01R8ph3SK7ZNzzshRGX7YU6X