### PR TITLE
bugfix(protocol): preserve prompt cache across protocol hops

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -579,7 +579,8 @@ by the matrix's fixed request. `cache_controls.go` uses the same raw-request and
 provider-capture approach as `content_shapes`, across two path classes:
 
 - **single-hop**: every pair in `DefaultPairs()` (A→B);
-- **ABA**: every case in `DefaultIdempotentCases()` (A→B→A).
+- **ABA**: every case in `DefaultIdempotentCases()` plus Anthropic Beta
+  variants (A→B→A).
 
 ABA cases reuse `setupChainHopRoute`: the A→B provider points back at the
 gateway's B endpoint, so the same request genuinely re-enters the HTTP gateway
@@ -591,7 +592,10 @@ For every path and stream mode, the suite sends:
 1. a cached request with two stable-prefix markers and verifies both markers
    plus OpenAI explicit mode at the final provider;
 2. the matching no-cache request and verifies that no marker or explicit mode
-   was synthesized.
+   was synthesized;
+3. an automatic-cache request and verifies Anthropic's top-level
+   `cache_control` ↔ OpenAI's `prompt_cache_options.mode="implicit"` through
+   both the JSON re-entry boundary and the final provider request.
 
 Run it with:
 

--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -595,10 +595,11 @@ cost_input = (prompt_tokens − cached_tokens − cache_write_tokens) × input_r
 协议转换必须保留缓存语义：
 
 - Chat ↔ Responses 双向复制 `prompt_cache_key`、`prompt_cache_options`、`prompt_cache_retention`，并逐 content block 映射 `prompt_cache_breakpoint`。
+- Anthropic 请求顶层的 automatic `cache_control` ↔ OpenAI `prompt_cache_options.mode = "implicit"`；automatic 与显式断点并存时保留 `implicit` 模式和各 content breakpoint。
 - Anthropic Messages 的 `cache_control` 与 Chat / Responses 的显式 content breakpoint 双向映射；有断点时设置 OpenAI `prompt_cache_options.mode = "explicit"`。
 - Responses 的 `instructions` 是纯字符串，不能承载断点；带 cache 的 Anthropic system block 或 Chat system content 必须转换为 `role = "system"` 的 input item，不能塞进 `instructions`。
 - OpenAI 不允许在 tool definition 上挂 breakpoint。Anthropic tool definition 上的 `cache_control` 转换时推进到 tools 后第一个可缓存 content block，使缓存前缀仍包含完整 tools，不能直接丢弃。
-- Anthropic `5m` / `1h` 与 OpenAI 当前 `30m` TTL 不同，跨协议只保证 breakpoint 语义，不伪造等价 TTL。
+- Anthropic `5m` / `1h` 与 OpenAI 当前 `30m` TTL 不同，跨协议只保证 automatic/breakpoint 语义，不伪造等价 TTL；A→O→A 会恢复 `cache_control`，但 TTL 回落为 Anthropic 默认 `5m`。
 
 ### 12.3 通道差异
 

--- a/internal/protocol/request/anthropic_beta_to_openai.go
+++ b/internal/protocol/request/anthropic_beta_to_openai.go
@@ -78,10 +78,10 @@ func betaImageBlockToOpenAIURL(img *anthropic.BetaImageBlockParam) string {
 // convertAnthropicBetaAssistantMessageToOpenAI converts Anthropic beta assistant message to OpenAI format
 // Note: thinking content is preserved in "x_thinking" field for provider-specific transforms
 func convertAnthropicBetaAssistantMessageToOpenAI(msg anthropic.BetaMessageParam) openai.ChatCompletionMessageParamUnion {
-	return convertAnthropicViewAssistantToOpenAI(viewAnthropicBetaMessage(msg).Blocks)
+	return convertAnthropicViewAssistantToOpenAI(viewAnthropicBetaMessage(msg).Content)
 }
 
 // convertAnthropicBetaUserMessageToOpenAI converts Anthropic beta user message to OpenAI format
 func convertAnthropicBetaUserMessageToOpenAI(msg anthropic.BetaMessageParam) []openai.ChatCompletionMessageParamUnion {
-	return convertAnthropicViewUserToOpenAI(viewAnthropicBetaMessage(msg).Blocks)
+	return convertAnthropicViewUserToOpenAI(viewAnthropicBetaMessage(msg).Content)
 }

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -83,8 +83,13 @@ func ConvertAnthropicBetaToResponsesRequest(anthropicReq *anthropic.BetaMessageN
 	hasRepresentableCacheControl := hasSystemCacheControl || anthropicBetaMessagesHaveRepresentableCacheControl(anthropicReq.Messages)
 	hasFallbackCacheControl := anthropicBetaToolsHaveCacheControl(anthropicReq.Tools) ||
 		anthropicBetaMessagesHaveToolUseCacheControl(anthropicReq.Messages)
-	if hasRepresentableCacheControl || hasFallbackCacheControl {
-		params.PromptCacheOptions.Mode = "explicit"
+	hasAutomaticCacheControl := !param.IsOmitted(anthropicReq.CacheControl)
+	if hasAutomaticCacheControl || hasRepresentableCacheControl || hasFallbackCacheControl {
+		if hasAutomaticCacheControl {
+			params.PromptCacheOptions.Mode = "implicit"
+		} else {
+			params.PromptCacheOptions.Mode = "explicit"
+		}
 		if !hasRepresentableCacheControl && hasFallbackCacheControl {
 			applyFirstResponsesCacheBreakpoint(params)
 		}

--- a/internal/protocol/request/anthropic_v1_to_openai.go
+++ b/internal/protocol/request/anthropic_v1_to_openai.go
@@ -23,7 +23,7 @@ func ConvertAnthropicToOpenAIRequest(anthropicReq *anthropic.MessageNewParams, c
 
 // ConvertAnthropicToolsToOpenAI converts Anthropic tools to OpenAI format
 func ConvertAnthropicToolsToOpenAI(tools []anthropic.ToolUnionParam) []openai.ChatCompletionToolUnionParam {
-	return convertAnthropicToolViewsToOpenAI(viewAnthropicV1Tools(tools))
+	return convertAnthropicToolViewsToOpenAI(tools)
 }
 
 func convertAnthropicInputSchemaToOpenAIParameters(properties any, required []string) shared.FunctionParameters {
@@ -70,7 +70,10 @@ func ConvertAnthropicToolsToOpenAIWithTransformedSchema(tools []anthropic.ToolUn
 
 // ConvertAnthropicToolChoiceToOpenAI converts Anthropic tool_choice to OpenAI format
 func ConvertAnthropicToolChoiceToOpenAI(tc *anthropic.ToolChoiceUnionParam) openai.ChatCompletionToolChoiceOptionUnionParam {
-	return convertAnthropicToolChoiceViewToOpenAI(viewAnthropicV1ToolChoice(tc))
+	if tc == nil {
+		return convertAnthropicToolChoiceViewToOpenAI(anthropic.ToolChoiceUnionParam{})
+	}
+	return convertAnthropicToolChoiceViewToOpenAI(*tc)
 }
 
 // convertToolResultContent extracts the content from a tool result block
@@ -128,7 +131,7 @@ func ConvertTextBlocksToString(blocks []anthropic.TextBlockParam) string {
 // This handles both text content and tool_use blocks
 // Note: thinking content is preserved in "x_thinking" field for provider-specific transforms
 func convertAnthropicAssistantMessageToOpenAI(msg anthropic.MessageParam) openai.ChatCompletionMessageParamUnion {
-	return convertAnthropicViewAssistantToOpenAI(viewAnthropicV1Message(msg).Blocks)
+	return convertAnthropicViewAssistantToOpenAI(msg.Content)
 }
 
 // convertAnthropicUserMessageToOpenAI converts Anthropic user message to OpenAI format
@@ -136,5 +139,5 @@ func convertAnthropicAssistantMessageToOpenAI(msg anthropic.MessageParam) openai
 // tool_result blocks in Anthropic become separate role="tool" messages in OpenAI
 // Returns a slice of messages because tool results become separate messages
 func convertAnthropicUserMessageToOpenAI(msg anthropic.MessageParam) []openai.ChatCompletionMessageParamUnion {
-	return convertAnthropicViewUserToOpenAI(viewAnthropicV1Message(msg).Blocks)
+	return convertAnthropicViewUserToOpenAI(msg.Content)
 }

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -78,8 +78,13 @@ func ConvertAnthropicV1ToResponsesRequest(anthropicReq *anthropic.MessageNewPara
 	hasRepresentableCacheControl := hasSystemCacheControl || anthropicV1MessagesHaveRepresentableCacheControl(anthropicReq.Messages)
 	hasFallbackCacheControl := anthropicV1ToolsHaveCacheControl(anthropicReq.Tools) ||
 		anthropicV1MessagesHaveToolUseCacheControl(anthropicReq.Messages)
-	if hasRepresentableCacheControl || hasFallbackCacheControl {
-		params.PromptCacheOptions.Mode = "explicit"
+	hasAutomaticCacheControl := !param.IsOmitted(anthropicReq.CacheControl)
+	if hasAutomaticCacheControl || hasRepresentableCacheControl || hasFallbackCacheControl {
+		if hasAutomaticCacheControl {
+			params.PromptCacheOptions.Mode = "implicit"
+		} else {
+			params.PromptCacheOptions.Mode = "explicit"
+		}
 		if !hasRepresentableCacheControl && hasFallbackCacheControl {
 			applyFirstResponsesCacheBreakpoint(params)
 		}

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -15,102 +15,26 @@ import (
 )
 
 // This file holds the shared core of the Anthropic→OpenAI and
-// Anthropic→Google request converters. The Anthropic v1 and Beta SDK types
-// are structurally identical but nominally distinct, which historically led
-// to fully duplicated converter pairs (one per type). Instead of duplicating
-// the conversion logic, each variant is adapted into the normalized views
-// below by a thin, mechanical field-copy adapter, and a single core performs
-// the actual conversion.
+// Anthropic→Google request converters. The overlapping Anthropic v1 and Beta
+// SDK fields are structurally equivalent but nominally distinct, which
+// historically led to fully duplicated converter pairs (one per type).
+// Instead, the Beta adapter maps supported fields into canonical v1 SDK types,
+// and a single core performs the actual conversion.
 
-// anthropicBlockKind enumerates the content block variants the converters
-// care about.
-type anthropicBlockKind int
-
-const (
-	blockViewSkip anthropicBlockKind = iota
-	blockViewText
-	blockViewThinking
-	blockViewRedactedThinking
-	blockViewToolUse
-	blockViewToolResult
-	blockViewImage
-)
-
-// anthropicBlockView is a normalized view of a v1/beta content block.
-type anthropicBlockView struct {
-	Kind anthropicBlockKind
-
-	// Text carries the text for blockViewText and the thinking text for
-	// blockViewThinking.
-	Text string
-
-	// tool_use fields
-	ToolID    string
-	ToolName  string
-	ToolInput any
-
-	// tool_result fields
-	ToolResultID   string
-	ToolResultText string
-
-	// image fields: base64 sources set MediaType+Data, URL sources set URL.
-	ImageMediaType string
-	ImageData      string
-	ImageURL       string
-
-	// CacheControl marks the end of a reusable prompt prefix. OpenAI Chat has
-	// the same concept under prompt_cache_breakpoint.
-	CacheControl anthropic.CacheControlEphemeralParam
-}
-
-// anthropicMessageView is a normalized view of a v1/beta message.
-type anthropicMessageView struct {
-	Role   string
-	Blocks []anthropicBlockView
-}
-
-// anthropicToolView is a normalized view of a v1/beta tool definition.
-type anthropicToolView struct {
-	Name         string
-	Description  string
-	CacheControl anthropic.CacheControlEphemeralParam
-	// InputSchema is the full schema param value (marshalled for Google).
-	InputSchema any
-	// Properties/Required are the schema fields (used for OpenAI parameters).
-	Properties    any
-	Required      []string
-	HasProperties bool
-}
-
-// anthropicToolChoiceView is a normalized view of a v1/beta tool_choice.
-type anthropicToolChoiceView struct {
-	HasAuto  bool
-	HasAny   bool
-	HasTool  bool
-	ToolName string
-}
-
-// anthropicRequestView is a normalized view of a full v1/beta request.
+// anthropicRequestView is the canonical Anthropic request subset consumed by
+// the shared OpenAI and Google converters. Its fields deliberately use the v1
+// SDK types and nesting; Beta adapters bridge nominally distinct SDK types into
+// this shape without inventing a parallel request model.
 type anthropicRequestView struct {
-	Model        string
+	Model        anthropic.Model
 	MaxTokens    int64
 	CacheControl anthropic.CacheControlEphemeralParam
 	System       []anthropic.TextBlockParam
-	Messages     []anthropicMessageView
-	Tools        []anthropicToolView
-	HasTools     bool
-	ToolChoice   anthropicToolChoiceView
-	// ThinkingEnabled reflects Thinking.OfEnabled/OfAdaptive or the
-	// model-level IsThinkingEnabled* check.
-	ThinkingEnabled bool
-	OutputEffort    string
-}
-
-func viewAnthropicV1CacheControl(control *anthropic.CacheControlEphemeralParam) anthropic.CacheControlEphemeralParam {
-	if control == nil || anthropicparam.IsOmitted(*control) {
-		return anthropic.CacheControlEphemeralParam{}
-	}
-	return *control
+	Messages     []anthropic.MessageParam
+	Tools        []anthropic.ToolUnionParam
+	ToolChoice   anthropic.ToolChoiceUnionParam
+	Thinking     anthropic.ThinkingConfigParamUnion
+	OutputConfig anthropic.OutputConfigParam
 }
 
 func viewAnthropicBetaCacheControl(control *anthropic.BetaCacheControlEphemeralParam) anthropic.CacheControlEphemeralParam {
@@ -127,202 +51,174 @@ func hasAnthropicCacheControl(control anthropic.CacheControlEphemeralParam) bool
 	return !anthropicparam.IsOmitted(control)
 }
 
-// ───────────────────────── v1 adapters ─────────────────────────
-
-func viewAnthropicV1Block(block anthropic.ContentBlockParamUnion) anthropicBlockView {
-	cacheControl := block.GetCacheControl()
-	cache := viewAnthropicV1CacheControl(cacheControl)
-	switch {
-	case block.OfText != nil:
-		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: cache}
-	case block.OfThinking != nil:
-		return anthropicBlockView{Kind: blockViewThinking, Text: block.OfThinking.Thinking}
-	case block.OfRedactedThinking != nil:
-		return anthropicBlockView{Kind: blockViewRedactedThinking}
-	case block.OfToolUse != nil:
-		return anthropicBlockView{
-			Kind:         blockViewToolUse,
-			ToolID:       block.OfToolUse.ID,
-			ToolName:     block.OfToolUse.Name,
-			ToolInput:    block.OfToolUse.Input,
-			CacheControl: cache,
-		}
-	case block.OfToolResult != nil:
-		return anthropicBlockView{
-			Kind:           blockViewToolResult,
-			ToolResultID:   block.OfToolResult.ToolUseID,
-			ToolResultText: convertToolResultContent(block.OfToolResult.Content),
-			CacheControl:   cache,
-		}
-	case block.OfImage != nil:
-		v := anthropicBlockView{Kind: blockViewImage, CacheControl: cache}
-		if block.OfImage.Source.OfBase64 != nil {
-			v.ImageMediaType = string(block.OfImage.Source.OfBase64.MediaType)
-			v.ImageData = block.OfImage.Source.OfBase64.Data
-		} else if block.OfImage.Source.OfURL != nil {
-			v.ImageURL = block.OfImage.Source.OfURL.URL
-		}
-		return v
-	}
-	return anthropicBlockView{Kind: blockViewSkip}
-}
-
-func viewAnthropicV1Message(msg anthropic.MessageParam) anthropicMessageView {
-	blocks := make([]anthropicBlockView, 0, len(msg.Content))
-	for _, block := range msg.Content {
-		blocks = append(blocks, viewAnthropicV1Block(block))
-	}
-	return anthropicMessageView{Role: string(msg.Role), Blocks: blocks}
-}
-
-func viewAnthropicV1Tools(tools []anthropic.ToolUnionParam) []anthropicToolView {
-	if len(tools) == 0 {
-		return nil
-	}
-	out := make([]anthropicToolView, 0, len(tools))
-	for _, t := range tools {
-		tool := t.OfTool
-		if tool == nil {
-			continue
-		}
-		out = append(out, anthropicToolView{
-			Name:          tool.Name,
-			Description:   tool.Description.Value,
-			InputSchema:   tool.InputSchema,
-			Properties:    tool.InputSchema.Properties,
-			Required:      tool.InputSchema.Required,
-			HasProperties: tool.InputSchema.Properties != nil,
-			CacheControl:  viewAnthropicV1CacheControl(&tool.CacheControl),
-		})
-	}
-	return out
-}
-
-func viewAnthropicV1ToolChoice(tc *anthropic.ToolChoiceUnionParam) anthropicToolChoiceView {
-	v := anthropicToolChoiceView{
-		HasAuto: tc.OfAuto != nil,
-		HasAny:  tc.OfAny != nil,
-		HasTool: tc.OfTool != nil,
-	}
-	if tc.OfTool != nil {
-		v.ToolName = tc.OfTool.Name
-	}
-	return v
-}
-
 func viewAnthropicV1Request(req *anthropic.MessageNewParams) anthropicRequestView {
-	view := anthropicRequestView{
-		Model:           string(req.Model),
-		MaxTokens:       req.MaxTokens,
-		CacheControl:    viewAnthropicV1CacheControl(&req.CacheControl),
-		HasTools:        len(req.Tools) > 0,
-		Tools:           viewAnthropicV1Tools(req.Tools),
-		ToolChoice:      viewAnthropicV1ToolChoice(&req.ToolChoice),
-		ThinkingEnabled: req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabled(req),
-		OutputEffort:    string(req.OutputConfig.Effort),
+	return anthropicRequestView{
+		Model:        req.Model,
+		MaxTokens:    req.MaxTokens,
+		CacheControl: req.CacheControl,
+		System:       req.System,
+		Messages:     req.Messages,
+		Tools:        req.Tools,
+		ToolChoice:   req.ToolChoice,
+		Thinking:     req.Thinking,
+		OutputConfig: req.OutputConfig,
 	}
-	for _, sys := range req.System {
-		view.System = append(view.System, sys)
-	}
-	for _, msg := range req.Messages {
-		view.Messages = append(view.Messages, viewAnthropicV1Message(msg))
-	}
-	return view
 }
 
 // ───────────────────────── beta adapters ─────────────────────────
 
-func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropicBlockView {
-	cacheControl := block.GetCacheControl()
-	cache := viewAnthropicBetaCacheControl(cacheControl)
+func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropic.ContentBlockParamUnion {
 	switch {
 	case block.OfText != nil:
-		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: cache}
+		return anthropic.ContentBlockParamUnion{OfText: &anthropic.TextBlockParam{
+			Text:         block.OfText.Text,
+			CacheControl: viewAnthropicBetaCacheControl(&block.OfText.CacheControl),
+		}}
 	case block.OfThinking != nil:
-		return anthropicBlockView{Kind: blockViewThinking, Text: block.OfThinking.Thinking}
+		return anthropic.ContentBlockParamUnion{OfThinking: &anthropic.ThinkingBlockParam{
+			Thinking:  block.OfThinking.Thinking,
+			Signature: block.OfThinking.Signature,
+		}}
 	case block.OfRedactedThinking != nil:
-		return anthropicBlockView{Kind: blockViewRedactedThinking}
+		return anthropic.ContentBlockParamUnion{OfRedactedThinking: &anthropic.RedactedThinkingBlockParam{
+			Data: block.OfRedactedThinking.Data,
+		}}
 	case block.OfToolUse != nil:
-		return anthropicBlockView{
-			Kind:         blockViewToolUse,
-			ToolID:       block.OfToolUse.ID,
-			ToolName:     block.OfToolUse.Name,
-			ToolInput:    block.OfToolUse.Input,
-			CacheControl: cache,
-		}
+		return anthropic.ContentBlockParamUnion{OfToolUse: &anthropic.ToolUseBlockParam{
+			ID:           block.OfToolUse.ID,
+			Name:         block.OfToolUse.Name,
+			Input:        block.OfToolUse.Input,
+			CacheControl: viewAnthropicBetaCacheControl(&block.OfToolUse.CacheControl),
+		}}
 	case block.OfToolResult != nil:
-		return anthropicBlockView{
-			Kind:           blockViewToolResult,
-			ToolResultID:   block.OfToolResult.ToolUseID,
-			ToolResultText: convertBetaToolResultContent(block.OfToolResult.Content),
-			CacheControl:   cache,
-		}
+		return anthropic.ContentBlockParamUnion{OfToolResult: &anthropic.ToolResultBlockParam{
+			ToolUseID:    block.OfToolResult.ToolUseID,
+			IsError:      block.OfToolResult.IsError,
+			CacheControl: viewAnthropicBetaCacheControl(&block.OfToolResult.CacheControl),
+			Content: []anthropic.ToolResultBlockParamContentUnion{{
+				OfText: &anthropic.TextBlockParam{Text: convertBetaToolResultContent(block.OfToolResult.Content)},
+			}},
+		}}
 	case block.OfImage != nil:
-		v := anthropicBlockView{Kind: blockViewImage, CacheControl: cache}
-		if block.OfImage.Source.OfBase64 != nil {
-			v.ImageMediaType = string(block.OfImage.Source.OfBase64.MediaType)
-			v.ImageData = block.OfImage.Source.OfBase64.Data
-		} else if block.OfImage.Source.OfURL != nil {
-			v.ImageURL = block.OfImage.Source.OfURL.URL
+		image := &anthropic.ImageBlockParam{
+			CacheControl: viewAnthropicBetaCacheControl(&block.OfImage.CacheControl),
 		}
-		return v
+		if block.OfImage.Source.OfBase64 != nil {
+			image.Source.OfBase64 = &anthropic.Base64ImageSourceParam{
+				Data:      block.OfImage.Source.OfBase64.Data,
+				MediaType: anthropic.Base64ImageSourceMediaType(block.OfImage.Source.OfBase64.MediaType),
+			}
+		} else if block.OfImage.Source.OfURL != nil {
+			image.Source.OfURL = &anthropic.URLImageSourceParam{
+				URL: block.OfImage.Source.OfURL.URL,
+			}
+		}
+		return anthropic.ContentBlockParamUnion{OfImage: image}
 	}
-	return anthropicBlockView{Kind: blockViewSkip}
+	return anthropic.ContentBlockParamUnion{}
 }
 
-func viewAnthropicBetaMessage(msg anthropic.BetaMessageParam) anthropicMessageView {
-	blocks := make([]anthropicBlockView, 0, len(msg.Content))
+func viewAnthropicBetaMessage(msg anthropic.BetaMessageParam) anthropic.MessageParam {
+	blocks := make([]anthropic.ContentBlockParamUnion, 0, len(msg.Content))
 	for _, block := range msg.Content {
 		blocks = append(blocks, viewAnthropicBetaBlock(block))
 	}
-	return anthropicMessageView{Role: string(msg.Role), Blocks: blocks}
+	return anthropic.MessageParam{
+		Role:    anthropic.MessageParamRole(msg.Role),
+		Content: blocks,
+	}
 }
 
-func viewAnthropicBetaTools(tools []anthropic.BetaToolUnionParam) []anthropicToolView {
+func viewAnthropicBetaTools(tools []anthropic.BetaToolUnionParam) []anthropic.ToolUnionParam {
 	if len(tools) == 0 {
 		return nil
 	}
-	out := make([]anthropicToolView, 0, len(tools))
+	out := make([]anthropic.ToolUnionParam, 0, len(tools))
 	for _, t := range tools {
 		tool := t.OfTool
 		if tool == nil {
+			out = append(out, anthropic.ToolUnionParam{})
 			continue
 		}
-		out = append(out, anthropicToolView{
-			Name:          tool.Name,
-			Description:   tool.Description.Value,
-			InputSchema:   tool.InputSchema,
-			Properties:    tool.InputSchema.Properties,
-			Required:      tool.InputSchema.Required,
-			HasProperties: tool.InputSchema.Properties != nil,
-			CacheControl:  viewAnthropicBetaCacheControl(&tool.CacheControl),
-		})
+		out = append(out, anthropic.ToolUnionParam{OfTool: &anthropic.ToolParam{
+			Name:                tool.Name,
+			Description:         tool.Description,
+			InputSchema:         viewAnthropicBetaToolInputSchema(tool.InputSchema),
+			CacheControl:        viewAnthropicBetaCacheControl(&tool.CacheControl),
+			EagerInputStreaming: tool.EagerInputStreaming,
+			DeferLoading:        tool.DeferLoading,
+			Strict:              tool.Strict,
+			Type:                anthropic.ToolType(tool.Type),
+			AllowedCallers:      tool.AllowedCallers,
+			InputExamples:       tool.InputExamples,
+		}})
 	}
 	return out
 }
 
-func viewAnthropicBetaToolChoice(tc *anthropic.BetaToolChoiceUnionParam) anthropicToolChoiceView {
-	v := anthropicToolChoiceView{
-		HasAuto: tc.OfAuto != nil,
-		HasAny:  tc.OfAny != nil,
-		HasTool: tc.OfTool != nil,
+func viewAnthropicBetaToolInputSchema(schema anthropic.BetaToolInputSchemaParam) anthropic.ToolInputSchemaParam {
+	return anthropic.ToolInputSchemaParam{
+		Type:        schema.Type,
+		Properties:  schema.Properties,
+		Required:    schema.Required,
+		ExtraFields: schema.ExtraFields,
 	}
-	if tc.OfTool != nil {
-		v.ToolName = tc.OfTool.Name
+}
+
+func viewAnthropicBetaToolChoice(tc *anthropic.BetaToolChoiceUnionParam) anthropic.ToolChoiceUnionParam {
+	if tc == nil {
+		return anthropic.ToolChoiceUnionParam{}
 	}
-	return v
+	switch {
+	case tc.OfAuto != nil:
+		return anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{
+			DisableParallelToolUse: tc.OfAuto.DisableParallelToolUse,
+		}}
+	case tc.OfAny != nil:
+		return anthropic.ToolChoiceUnionParam{OfAny: &anthropic.ToolChoiceAnyParam{
+			DisableParallelToolUse: tc.OfAny.DisableParallelToolUse,
+		}}
+	case tc.OfTool != nil:
+		return anthropic.ToolChoiceUnionParam{OfTool: &anthropic.ToolChoiceToolParam{
+			Name:                   tc.OfTool.Name,
+			DisableParallelToolUse: tc.OfTool.DisableParallelToolUse,
+		}}
+	case tc.OfNone != nil:
+		none := anthropic.NewToolChoiceNoneParam()
+		return anthropic.ToolChoiceUnionParam{OfNone: &none}
+	}
+	return anthropic.ToolChoiceUnionParam{}
+}
+
+func viewAnthropicBetaThinking(thinking anthropic.BetaThinkingConfigParamUnion) anthropic.ThinkingConfigParamUnion {
+	switch {
+	case thinking.OfEnabled != nil:
+		return anthropic.ThinkingConfigParamUnion{OfEnabled: &anthropic.ThinkingConfigEnabledParam{
+			BudgetTokens: thinking.OfEnabled.BudgetTokens,
+			Display:      anthropic.ThinkingConfigEnabledDisplay(thinking.OfEnabled.Display),
+		}}
+	case thinking.OfDisabled != nil:
+		disabled := anthropic.NewThinkingConfigDisabledParam()
+		return anthropic.ThinkingConfigParamUnion{OfDisabled: &disabled}
+	case thinking.OfAdaptive != nil:
+		return anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{
+			Display: anthropic.ThinkingConfigAdaptiveDisplay(thinking.OfAdaptive.Display),
+		}}
+	}
+	return anthropic.ThinkingConfigParamUnion{}
 }
 
 func viewAnthropicBetaRequest(req *anthropic.BetaMessageNewParams) anthropicRequestView {
 	view := anthropicRequestView{
-		Model:           string(req.Model),
-		MaxTokens:       req.MaxTokens,
-		CacheControl:    viewAnthropicBetaCacheControl(&req.CacheControl),
-		HasTools:        len(req.Tools) > 0,
-		Tools:           viewAnthropicBetaTools(req.Tools),
-		ToolChoice:      viewAnthropicBetaToolChoice(&req.ToolChoice),
-		ThinkingEnabled: req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabledBeta(req),
-		OutputEffort:    string(req.OutputConfig.Effort),
+		Model:        req.Model,
+		MaxTokens:    req.MaxTokens,
+		CacheControl: viewAnthropicBetaCacheControl(&req.CacheControl),
+		Tools:        viewAnthropicBetaTools(req.Tools),
+		ToolChoice:   viewAnthropicBetaToolChoice(&req.ToolChoice),
+		Thinking:     viewAnthropicBetaThinking(req.Thinking),
+		OutputConfig: anthropic.OutputConfigParam{
+			Effort: anthropic.OutputConfigEffort(req.OutputConfig.Effort),
+		},
 	}
 	for _, sys := range req.System {
 		view.System = append(view.System, anthropic.TextBlockParam{
@@ -351,12 +247,12 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 	// Convert messages
 	for _, msg := range view.Messages {
 		switch msg.Role {
-		case "user":
+		case anthropic.MessageParamRoleUser:
 			// User messages may contain tool_result blocks - need special handling
-			openaiReq.Messages = append(openaiReq.Messages, convertAnthropicViewUserToOpenAI(msg.Blocks)...)
-		case "assistant":
+			openaiReq.Messages = append(openaiReq.Messages, convertAnthropicViewUserToOpenAI(msg.Content)...)
+		case anthropic.MessageParamRoleAssistant:
 			// Convert assistant message with potential tool_use blocks
-			openaiReq.Messages = append(openaiReq.Messages, convertAnthropicViewAssistantToOpenAI(msg.Blocks))
+			openaiReq.Messages = append(openaiReq.Messages, convertAnthropicViewAssistantToOpenAI(msg.Content))
 		}
 	}
 
@@ -386,7 +282,7 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 	}
 
 	// Convert tools from Anthropic format to OpenAI format
-	if view.HasTools {
+	if len(view.Tools) > 0 {
 		openaiReq.Tools = convertAnthropicToolViewsToOpenAI(view.Tools)
 		// Convert tool choice
 		openaiReq.ToolChoice = convertAnthropicToolChoiceViewToOpenAI(view.ToolChoice)
@@ -413,12 +309,12 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 		HasThinking:     false,
 		ReasoningEffort: "medium", // Default to "medium" for OpenAI-compatible APIs
 	}
-	if view.ThinkingEnabled {
+	if view.Thinking.OfEnabled != nil || view.Thinking.OfAdaptive != nil || messagesHaveThinking(view.Messages) {
 		config.HasThinking = true
 		config.ReasoningEffort = "medium"
 	}
-	if view.OutputEffort != "" {
-		config.ReasoningEffort = shared.ReasoningEffort(view.OutputEffort)
+	if view.OutputConfig.Effort != "" {
+		config.ReasoningEffort = shared.ReasoningEffort(view.OutputConfig.Effort)
 	}
 
 	// Only set stream_options for streaming requests (per OpenAI API spec)
@@ -431,7 +327,7 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 // convertAnthropicViewAssistantToOpenAI converts an assistant message's
 // blocks to a single OpenAI assistant message. Thinking content is preserved
 // in the "x_thinking" extra field for provider-specific transforms.
-func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.ChatCompletionMessageParamUnion {
+func convertAnthropicViewAssistantToOpenAI(blocks []anthropic.ContentBlockParamUnion) openai.ChatCompletionMessageParamUnion {
 	preserveTextParts := blocksHaveCacheControl(blocks)
 	var textContent strings.Builder
 	var textParts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
@@ -439,34 +335,34 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 	var thinking string
 
 	for _, block := range blocks {
-		switch block.Kind {
-		case blockViewText:
+		switch {
+		case block.OfText != nil:
 			if preserveTextParts {
-				part := openAITextPart(block.Text, hasAnthropicCacheControl(block.CacheControl))
+				part := openAITextPart(block.OfText.Text, hasAnthropicCacheControl(block.OfText.CacheControl))
 				textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
 					OfText: &part,
 				})
 			} else {
-				textContent.WriteString(block.Text)
+				textContent.WriteString(block.OfText.Text)
 			}
-		case blockViewToolUse:
+		case block.OfToolUse != nil:
 			// Convert tool_use block to OpenAI tool_call format;
 			// marshal input to a JSON string for OpenAI
 			var args string
-			if argsBytes, err := json.Marshal(block.ToolInput); err == nil {
+			if argsBytes, err := json.Marshal(block.OfToolUse.Input); err == nil {
 				args = string(argsBytes)
 			}
 			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
 				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-					ID: block.ToolID,
+					ID: block.OfToolUse.ID,
 					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-						Name:      block.ToolName,
+						Name:      block.OfToolUse.Name,
 						Arguments: args,
 					},
 				},
 			})
-		case blockViewThinking:
-			thinking = block.Text
+		case block.OfThinking != nil:
+			thinking = block.OfThinking.Thinking
 		}
 	}
 
@@ -491,43 +387,44 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 // convertAnthropicViewUserToOpenAI converts a user message's blocks to OpenAI
 // messages. tool_result blocks become separate role="tool" messages, image
 // blocks turn the message into a multimodal content-part array.
-func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.ChatCompletionMessageParamUnion {
+func convertAnthropicViewUserToOpenAI(blocks []anthropic.ContentBlockParamUnion) []openai.ChatCompletionMessageParamUnion {
 	var result []openai.ChatCompletionMessageParamUnion
 	var hasToolResult, hasImage, hasCache bool
 
 	for _, block := range blocks {
-		switch block.Kind {
-		case blockViewToolResult:
+		switch {
+		case block.OfToolResult != nil:
 			hasToolResult = true
-		case blockViewImage:
+		case block.OfImage != nil:
 			hasImage = true
 		}
-		hasCache = hasCache || hasAnthropicCacheControl(block.CacheControl)
+		hasCache = hasCache || blockHasCacheControl(block)
 	}
 
 	switch {
 	case hasToolResult:
 		// When there are tool_result blocks, we need to create separate messages
-		var textBlocks []anthropicBlockView
+		var textBlocks []anthropic.ContentBlockParamUnion
 		for _, block := range blocks {
-			switch block.Kind {
-			case blockViewText:
+			switch {
+			case block.OfText != nil:
 				textBlocks = append(textBlocks, block)
-			case blockViewToolResult:
+			case block.OfToolResult != nil:
 				// Convert tool_result to OpenAI role="tool" message.
 				// Truncate tool_call_id to meet OpenAI's 40 character limit.
-				if hasAnthropicCacheControl(block.CacheControl) {
-					part := openAITextPart(block.ToolResultText, true)
+				resultText := convertToolResultContent(block.OfToolResult.Content)
+				if hasAnthropicCacheControl(block.OfToolResult.CacheControl) {
+					part := openAITextPart(resultText, true)
 					result = append(result, openai.ChatCompletionMessageParamUnion{
 						OfTool: &openai.ChatCompletionToolMessageParam{
-							ToolCallID: truncateToolCallID(block.ToolResultID),
+							ToolCallID: truncateToolCallID(block.OfToolResult.ToolUseID),
 							Content: openai.ChatCompletionToolMessageParamContentUnion{
 								OfArrayOfContentParts: []openai.ChatCompletionContentPartTextParam{part},
 							},
 						},
 					})
 				} else {
-					result = append(result, openai.ToolMessage(block.ToolResultText, truncateToolCallID(block.ToolResultID)))
+					result = append(result, openai.ToolMessage(resultText, truncateToolCallID(block.OfToolResult.ToolUseID)))
 				}
 			}
 		}
@@ -539,19 +436,19 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		// Multimodal user message: emit an array of text + image_url content parts
 		parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(blocks))
 		for _, block := range blocks {
-			switch block.Kind {
-			case blockViewText:
-				part := openAITextPart(block.Text, hasAnthropicCacheControl(block.CacheControl))
+			switch {
+			case block.OfText != nil:
+				part := openAITextPart(block.OfText.Text, hasAnthropicCacheControl(block.OfText.CacheControl))
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
-			case blockViewImage:
-				url := imageViewToOpenAIURL(block)
+			case block.OfImage != nil:
+				url := anthropicImageToOpenAIURL(block.OfImage)
 				if url == "" {
 					continue
 				}
 				imagePart := openai.ChatCompletionContentPartImageParam{
 					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
 				}
-				if hasAnthropicCacheControl(block.CacheControl) {
+				if hasAnthropicCacheControl(block.OfImage.CacheControl) {
 					imagePart.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
 				}
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imagePart})
@@ -564,8 +461,8 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		// Simple text-only user message
 		var textContent strings.Builder
 		for _, block := range blocks {
-			if block.Kind == blockViewText {
-				textContent.WriteString(block.Text)
+			if block.OfText != nil {
+				textContent.WriteString(block.OfText.Text)
 			}
 		}
 		if textContent.Len() > 0 {
@@ -593,11 +490,27 @@ func systemBlocksHaveCacheControl(blocks []anthropic.TextBlockParam) bool {
 	return false
 }
 
-func blocksHaveCacheControl(blocks []anthropicBlockView) bool {
+func blockHasCacheControl(block anthropic.ContentBlockParamUnion) bool {
+	control := block.GetCacheControl()
+	return control != nil && hasAnthropicCacheControl(*control)
+}
+
+func blocksHaveCacheControl(blocks []anthropic.ContentBlockParamUnion) bool {
 	for _, block := range blocks {
-		if hasAnthropicCacheControl(block.CacheControl) &&
-			(block.Kind == blockViewText || block.Kind == blockViewImage || block.Kind == blockViewToolResult) {
+		if blockHasCacheControl(block) &&
+			(block.OfText != nil || block.OfImage != nil || block.OfToolResult != nil) {
 			return true
+		}
+	}
+	return false
+}
+
+func messagesHaveThinking(messages []anthropic.MessageParam) bool {
+	for _, message := range messages {
+		for _, block := range message.Content {
+			if block.OfThinking != nil {
+				return true
+			}
 		}
 	}
 	return false
@@ -608,7 +521,7 @@ func viewHasRepresentableCacheControl(view anthropicRequestView) bool {
 		return true
 	}
 	for _, message := range view.Messages {
-		if blocksHaveCacheControl(message.Blocks) {
+		if blocksHaveCacheControl(message.Content) {
 			return true
 		}
 	}
@@ -617,7 +530,7 @@ func viewHasRepresentableCacheControl(view anthropicRequestView) bool {
 
 func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 	for _, tool := range view.Tools {
-		if hasAnthropicCacheControl(tool.CacheControl) {
+		if tool.OfTool != nil && hasAnthropicCacheControl(tool.OfTool.CacheControl) {
 			return true
 		}
 	}
@@ -626,8 +539,8 @@ func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 
 func viewHasToolUseCacheControl(view anthropicRequestView) bool {
 	for _, message := range view.Messages {
-		for _, block := range message.Blocks {
-			if block.Kind == blockViewToolUse && hasAnthropicCacheControl(block.CacheControl) {
+		for _, block := range message.Content {
+			if block.OfToolUse != nil && hasAnthropicCacheControl(block.OfToolUse.CacheControl) {
 				return true
 			}
 		}
@@ -674,34 +587,41 @@ func applyFirstOpenAICacheBreakpoint(req *openai.ChatCompletionNewParams) {
 	}
 }
 
-// imageViewToOpenAIURL renders an image block view as the URL string OpenAI's
+// anthropicImageToOpenAIURL renders an Anthropic image block as the URL string OpenAI's
 // image_url content part expects. Base64 sources become a data: URL; URL
 // sources are passed through. Returns "" for unsupported sources.
-func imageViewToOpenAIURL(block anthropicBlockView) string {
-	if block.ImageData != "" {
-		return "data:" + block.ImageMediaType + ";base64," + block.ImageData
+func anthropicImageToOpenAIURL(image *anthropic.ImageBlockParam) string {
+	if image.Source.OfBase64 != nil {
+		return "data:" + string(image.Source.OfBase64.MediaType) + ";base64," + image.Source.OfBase64.Data
 	}
-	return block.ImageURL
+	if image.Source.OfURL != nil {
+		return image.Source.OfURL.URL
+	}
+	return ""
 }
 
 // convertAnthropicToolViewsToOpenAI converts normalized tool definitions to
 // OpenAI function tools.
-func convertAnthropicToolViewsToOpenAI(tools []anthropicToolView) []openai.ChatCompletionToolUnionParam {
+func convertAnthropicToolViewsToOpenAI(tools []anthropic.ToolUnionParam) []openai.ChatCompletionToolUnionParam {
 	// nil means the request declared no tools at all; a non-nil empty view
 	// slice (tools declared, none convertible — e.g. only server tools)
 	// must keep producing "tools": [] on the wire, exactly as before.
-	if tools == nil {
+	if len(tools) == 0 {
 		return nil
 	}
 
 	out := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
-	for _, tool := range tools {
+	for _, union := range tools {
+		tool := union.OfTool
+		if tool == nil {
+			continue
+		}
 		// Convert Anthropic input schema to OpenAI function parameters
-		parameters := convertAnthropicInputSchemaToOpenAIParameters(tool.Properties, tool.Required)
+		parameters := convertAnthropicInputSchemaToOpenAIParameters(tool.InputSchema.Properties, tool.InputSchema.Required)
 
 		out = append(out, openai.ChatCompletionFunctionTool(shared.FunctionDefinitionParam{
 			Name:        tool.Name,
-			Description: param.Opt[string]{Value: tool.Description},
+			Description: param.Opt[string]{Value: tool.Description.Value},
 			Parameters:  parameters,
 		}))
 	}
@@ -711,11 +631,11 @@ func convertAnthropicToolViewsToOpenAI(tools []anthropicToolView) []openai.ChatC
 // convertAnthropicToolChoiceViewToOpenAI converts a normalized tool_choice to
 // OpenAI format. Anthropic's "any" (required) maps to auto, as OpenAI has no
 // direct equivalent.
-func convertAnthropicToolChoiceViewToOpenAI(tc anthropicToolChoiceView) openai.ChatCompletionToolChoiceOptionUnionParam {
-	if tc.HasTool {
+func convertAnthropicToolChoiceViewToOpenAI(tc anthropic.ToolChoiceUnionParam) openai.ChatCompletionToolChoiceOptionUnionParam {
+	if tc.OfTool != nil {
 		return openai.ToolChoiceOptionFunctionToolChoice(
 			openai.ChatCompletionNamedToolChoiceFunctionParam{
-				Name: tc.ToolName,
+				Name: tc.OfTool.Name,
 			},
 		)
 	}
@@ -757,7 +677,7 @@ func convertAnthropicViewToGoogleRequest(view anthropicRequestView) (string, []*
 	}
 
 	// Convert tools from Anthropic format to Google format
-	if view.HasTools {
+	if len(view.Tools) > 0 {
 		config.Tools = []*genai.Tool{
 			{
 				FunctionDeclarations: convertAnthropicToolViewsToGoogle(view.Tools),
@@ -766,57 +686,58 @@ func convertAnthropicViewToGoogleRequest(view anthropicRequestView) (string, []*
 	}
 
 	// Convert tool choice
-	if view.ToolChoice.HasAuto || view.ToolChoice.HasTool || view.ToolChoice.HasAny {
+	if view.ToolChoice.OfAuto != nil || view.ToolChoice.OfTool != nil || view.ToolChoice.OfAny != nil {
 		config.ToolConfig = convertAnthropicToolChoiceViewToGoogle(view.ToolChoice)
 	}
 
-	return view.Model, contents, config
+	return string(view.Model), contents, config
 }
 
 // convertAnthropicViewMessageToGoogle converts one normalized message to a
 // Google content. Returns nil when the message produces no parts or has an
 // unsupported role.
-func convertAnthropicViewMessageToGoogle(msg anthropicMessageView) *genai.Content {
+func convertAnthropicViewMessageToGoogle(msg anthropic.MessageParam) *genai.Content {
 	switch msg.Role {
-	case "user":
+	case anthropic.MessageParamRoleUser:
 		content := &genai.Content{
 			Role:  "user",
 			Parts: []*genai.Part{},
 		}
-		for _, block := range msg.Blocks {
-			switch block.Kind {
-			case blockViewText:
-				content.Parts = append(content.Parts, genai.NewPartFromText(block.Text))
-			case blockViewImage:
+		for _, block := range msg.Content {
+			switch {
+			case block.OfText != nil:
+				content.Parts = append(content.Parts, genai.NewPartFromText(block.OfText.Text))
+			case block.OfImage != nil:
 				// For Google API, images need to be passed as inline data with MIME type
-				if block.ImageData != "" {
+				if block.OfImage.Source.OfBase64 != nil {
 					content.Parts = append(content.Parts, &genai.Part{
 						InlineData: &genai.Blob{
-							MIMEType: block.ImageMediaType,
-							Data:     []byte(block.ImageData),
+							MIMEType: string(block.OfImage.Source.OfBase64.MediaType),
+							Data:     []byte(block.OfImage.Source.OfBase64.Data),
 						},
 					})
-				} else if block.ImageURL != "" {
+				} else if block.OfImage.Source.OfURL != nil {
 					// For URL images, we'd need to fetch them first
 					// For now, skip or handle as text reference
-					content.Parts = append(content.Parts, genai.NewPartFromText("[Image: "+block.ImageURL+"]"))
+					content.Parts = append(content.Parts, genai.NewPartFromText("[Image: "+block.OfImage.Source.OfURL.URL+"]"))
 				}
-			case blockViewToolResult:
+			case block.OfToolResult != nil:
 				// Convert tool_result to function_response.
 				// FunctionResponse.Name should be the tool_use ID for Google API.
 				// Try to parse as JSON first; if it fails, wrap as plain text output.
+				resultText := convertToolResultContent(block.OfToolResult.Content)
 				var response map[string]any
-				if err := json.Unmarshal([]byte(block.ToolResultText), &response); err != nil {
+				if err := json.Unmarshal([]byte(resultText), &response); err != nil {
 					// Not valid JSON, wrap in "output" key
-					response = map[string]any{"output": block.ToolResultText}
+					response = map[string]any{"output": resultText}
 				}
 				content.Parts = append(content.Parts, &genai.Part{
 					FunctionResponse: &genai.FunctionResponse{
-						Name:     block.ToolResultID, // Use tool_use ID as Name
+						Name:     block.OfToolResult.ToolUseID, // Use tool_use ID as Name
 						Response: response,
 					},
 				})
-			case blockViewThinking, blockViewRedactedThinking:
+			case block.OfThinking != nil, block.OfRedactedThinking != nil:
 				// Skip thinking blocks - Google API doesn't support them
 			}
 		}
@@ -825,29 +746,29 @@ func convertAnthropicViewMessageToGoogle(msg anthropicMessageView) *genai.Conten
 		}
 		return content
 
-	case "assistant":
+	case anthropic.MessageParamRoleAssistant:
 		content := &genai.Content{
 			Role:  "model",
 			Parts: []*genai.Part{},
 		}
-		for _, block := range msg.Blocks {
-			switch block.Kind {
-			case blockViewText:
-				content.Parts = append(content.Parts, genai.NewPartFromText(block.Text))
-			case blockViewToolUse:
+		for _, block := range msg.Content {
+			switch {
+			case block.OfText != nil:
+				content.Parts = append(content.Parts, genai.NewPartFromText(block.OfText.Text))
+			case block.OfToolUse != nil:
 				// Convert tool_use to function_call
 				var argsInput map[string]interface{}
-				if inputBytes, ok := block.ToolInput.([]byte); ok {
+				if inputBytes, ok := block.OfToolUse.Input.([]byte); ok {
 					_ = json.Unmarshal(inputBytes, &argsInput)
 				}
 				content.Parts = append(content.Parts, &genai.Part{
 					FunctionCall: &genai.FunctionCall{
-						ID:   block.ToolID,
-						Name: block.ToolName,
+						ID:   block.OfToolUse.ID,
+						Name: block.OfToolUse.Name,
 						Args: argsInput,
 					},
 				})
-			case blockViewThinking, blockViewRedactedThinking:
+			case block.OfThinking != nil, block.OfRedactedThinking != nil:
 				// Skip thinking blocks - Google API doesn't support them
 			}
 		}
@@ -861,18 +782,22 @@ func convertAnthropicViewMessageToGoogle(msg anthropicMessageView) *genai.Conten
 
 // convertAnthropicToolViewsToGoogle converts normalized tool definitions to
 // Google function declarations.
-func convertAnthropicToolViewsToGoogle(tools []anthropicToolView) []*genai.FunctionDeclaration {
+func convertAnthropicToolViewsToGoogle(tools []anthropic.ToolUnionParam) []*genai.FunctionDeclaration {
 	// nil means no tools declared; non-nil empty keeps the previous
 	// empty-declarations shape for requests whose tools were all filtered.
-	if tools == nil {
+	if len(tools) == 0 {
 		return nil
 	}
 
 	out := make([]*genai.FunctionDeclaration, 0, len(tools))
-	for _, tool := range tools {
+	for _, union := range tools {
+		tool := union.OfTool
+		if tool == nil {
+			continue
+		}
 		// Convert Anthropic input schema to Google parameters
 		var parameters *genai.Schema
-		if tool.HasProperties {
+		if tool.InputSchema.Properties != nil {
 			if schemaBytes, err := json.Marshal(tool.InputSchema); err == nil {
 				_ = json.Unmarshal(schemaBytes, &parameters)
 				// Normalize schema types from lowercase (JSON Schema) to uppercase (Google format)
@@ -882,7 +807,7 @@ func convertAnthropicToolViewsToGoogle(tools []anthropicToolView) []*genai.Funct
 
 		out = append(out, &genai.FunctionDeclaration{
 			Name:        tool.Name,
-			Description: tool.Description,
+			Description: tool.Description.Value,
 			Parameters:  parameters,
 		})
 	}
@@ -891,19 +816,19 @@ func convertAnthropicToolViewsToGoogle(tools []anthropicToolView) []*genai.Funct
 
 // convertAnthropicToolChoiceViewToGoogle converts a normalized tool_choice to
 // a Google tool config.
-func convertAnthropicToolChoiceViewToGoogle(tc anthropicToolChoiceView) *genai.ToolConfig {
+func convertAnthropicToolChoiceViewToGoogle(tc anthropic.ToolChoiceUnionParam) *genai.ToolConfig {
 	config := &genai.ToolConfig{
 		FunctionCallingConfig: &genai.FunctionCallingConfig{},
 	}
 
-	if tc.HasAuto {
+	if tc.OfAuto != nil {
 		config.FunctionCallingConfig.Mode = genai.FunctionCallingConfigModeAuto
 	}
-	if tc.HasTool {
+	if tc.OfTool != nil {
 		config.FunctionCallingConfig.Mode = genai.FunctionCallingConfigModeAny
-		config.FunctionCallingConfig.AllowedFunctionNames = []string{tc.ToolName}
+		config.FunctionCallingConfig.AllowedFunctionNames = []string{tc.OfTool.Name}
 	}
-	if tc.HasAny {
+	if tc.OfAny != nil {
 		config.FunctionCallingConfig.Mode = genai.FunctionCallingConfigModeAny
 	}
 

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -36,15 +36,6 @@ const (
 	blockViewImage
 )
 
-// cacheControlView retains the Anthropic cache metadata even when the target
-// protocol cannot express all of it. In particular, OpenAI currently has only
-// a 30m request-level TTL, so Anthropic's 5m/1h value must not be silently
-// rewritten as an allegedly equivalent OpenAI value.
-type cacheControlView struct {
-	Present bool
-	TTL     string
-}
-
 // anthropicBlockView is a normalized view of a v1/beta content block.
 type anthropicBlockView struct {
 	Kind anthropicBlockKind
@@ -69,7 +60,7 @@ type anthropicBlockView struct {
 
 	// CacheControl marks the end of a reusable prompt prefix. OpenAI Chat has
 	// the same concept under prompt_cache_breakpoint.
-	CacheControl cacheControlView
+	CacheControl anthropic.CacheControlEphemeralParam
 }
 
 // anthropicMessageView is a normalized view of a v1/beta message.
@@ -82,7 +73,7 @@ type anthropicMessageView struct {
 type anthropicToolView struct {
 	Name         string
 	Description  string
-	CacheControl cacheControlView
+	CacheControl anthropic.CacheControlEphemeralParam
 	// InputSchema is the full schema param value (marshalled for Google).
 	InputSchema any
 	// Properties/Required are the schema fields (used for OpenAI parameters).
@@ -101,38 +92,39 @@ type anthropicToolChoiceView struct {
 
 // anthropicRequestView is a normalized view of a full v1/beta request.
 type anthropicRequestView struct {
-	Model     string
-	MaxTokens int64
-	// AutomaticCacheControl represents Anthropic's request-level
-	// cache_control. OpenAI expresses the same moving last-block behavior with
-	// prompt_cache_options.mode="implicit".
-	AutomaticCacheControl cacheControlView
-	// SystemTexts holds one entry per system text block; the OpenAI core
-	// joins them without separators, the Google core joins with "\n".
-	SystemTexts         []string
-	SystemCacheControls []cacheControlView
-	Messages            []anthropicMessageView
-	Tools               []anthropicToolView
-	HasTools            bool
-	ToolChoice          anthropicToolChoiceView
+	Model        string
+	MaxTokens    int64
+	CacheControl anthropic.CacheControlEphemeralParam
+	System       []anthropic.TextBlockParam
+	Messages     []anthropicMessageView
+	Tools        []anthropicToolView
+	HasTools     bool
+	ToolChoice   anthropicToolChoiceView
 	// ThinkingEnabled reflects Thinking.OfEnabled/OfAdaptive or the
 	// model-level IsThinkingEnabled* check.
 	ThinkingEnabled bool
 	OutputEffort    string
 }
 
-func viewAnthropicV1CacheControl(control *anthropic.CacheControlEphemeralParam) cacheControlView {
+func viewAnthropicV1CacheControl(control *anthropic.CacheControlEphemeralParam) anthropic.CacheControlEphemeralParam {
 	if control == nil || anthropicparam.IsOmitted(*control) {
-		return cacheControlView{}
+		return anthropic.CacheControlEphemeralParam{}
 	}
-	return cacheControlView{Present: true, TTL: string(control.TTL)}
+	return *control
 }
 
-func viewAnthropicBetaCacheControl(control *anthropic.BetaCacheControlEphemeralParam) cacheControlView {
+func viewAnthropicBetaCacheControl(control *anthropic.BetaCacheControlEphemeralParam) anthropic.CacheControlEphemeralParam {
 	if control == nil || anthropicparam.IsOmitted(*control) {
-		return cacheControlView{}
+		return anthropic.CacheControlEphemeralParam{}
 	}
-	return cacheControlView{Present: true, TTL: string(control.TTL)}
+	return anthropic.CacheControlEphemeralParam{
+		Type: control.Type,
+		TTL:  anthropic.CacheControlEphemeralTTL(control.TTL),
+	}
+}
+
+func hasAnthropicCacheControl(control anthropic.CacheControlEphemeralParam) bool {
+	return !anthropicparam.IsOmitted(control)
 }
 
 // ───────────────────────── v1 adapters ─────────────────────────
@@ -220,18 +212,17 @@ func viewAnthropicV1ToolChoice(tc *anthropic.ToolChoiceUnionParam) anthropicTool
 
 func viewAnthropicV1Request(req *anthropic.MessageNewParams) anthropicRequestView {
 	view := anthropicRequestView{
-		Model:                 string(req.Model),
-		MaxTokens:             req.MaxTokens,
-		AutomaticCacheControl: viewAnthropicV1CacheControl(&req.CacheControl),
-		HasTools:              len(req.Tools) > 0,
-		Tools:                 viewAnthropicV1Tools(req.Tools),
-		ToolChoice:            viewAnthropicV1ToolChoice(&req.ToolChoice),
-		ThinkingEnabled:       req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabled(req),
-		OutputEffort:          string(req.OutputConfig.Effort),
+		Model:           string(req.Model),
+		MaxTokens:       req.MaxTokens,
+		CacheControl:    viewAnthropicV1CacheControl(&req.CacheControl),
+		HasTools:        len(req.Tools) > 0,
+		Tools:           viewAnthropicV1Tools(req.Tools),
+		ToolChoice:      viewAnthropicV1ToolChoice(&req.ToolChoice),
+		ThinkingEnabled: req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabled(req),
+		OutputEffort:    string(req.OutputConfig.Effort),
 	}
 	for _, sys := range req.System {
-		view.SystemTexts = append(view.SystemTexts, sys.Text)
-		view.SystemCacheControls = append(view.SystemCacheControls, viewAnthropicV1CacheControl(&sys.CacheControl))
+		view.System = append(view.System, sys)
 	}
 	for _, msg := range req.Messages {
 		view.Messages = append(view.Messages, viewAnthropicV1Message(msg))
@@ -324,18 +315,20 @@ func viewAnthropicBetaToolChoice(tc *anthropic.BetaToolChoiceUnionParam) anthrop
 
 func viewAnthropicBetaRequest(req *anthropic.BetaMessageNewParams) anthropicRequestView {
 	view := anthropicRequestView{
-		Model:                 string(req.Model),
-		MaxTokens:             req.MaxTokens,
-		AutomaticCacheControl: viewAnthropicBetaCacheControl(&req.CacheControl),
-		HasTools:              len(req.Tools) > 0,
-		Tools:                 viewAnthropicBetaTools(req.Tools),
-		ToolChoice:            viewAnthropicBetaToolChoice(&req.ToolChoice),
-		ThinkingEnabled:       req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabledBeta(req),
-		OutputEffort:          string(req.OutputConfig.Effort),
+		Model:           string(req.Model),
+		MaxTokens:       req.MaxTokens,
+		CacheControl:    viewAnthropicBetaCacheControl(&req.CacheControl),
+		HasTools:        len(req.Tools) > 0,
+		Tools:           viewAnthropicBetaTools(req.Tools),
+		ToolChoice:      viewAnthropicBetaToolChoice(&req.ToolChoice),
+		ThinkingEnabled: req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabledBeta(req),
+		OutputEffort:    string(req.OutputConfig.Effort),
 	}
 	for _, sys := range req.System {
-		view.SystemTexts = append(view.SystemTexts, sys.Text)
-		view.SystemCacheControls = append(view.SystemCacheControls, viewAnthropicBetaCacheControl(&sys.CacheControl))
+		view.System = append(view.System, anthropic.TextBlockParam{
+			Text:         sys.Text,
+			CacheControl: viewAnthropicBetaCacheControl(&sys.CacheControl),
+		})
 	}
 	for _, msg := range req.Messages {
 		view.Messages = append(view.Messages, viewAnthropicBetaMessage(msg))
@@ -369,20 +362,24 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 
 	// Convert system messages. Keep block boundaries when cache controls are
 	// present so their exact prompt prefix survives A→O→A gateway chaining.
-	if len(view.SystemTexts) > 0 {
+	if len(view.System) > 0 {
 		var systemMsg openai.ChatCompletionMessageParamUnion
-		if hasCacheControl(view.SystemCacheControls) {
-			parts := make([]openai.ChatCompletionContentPartTextParam, 0, len(view.SystemTexts))
-			for i, text := range view.SystemTexts {
-				part := openai.ChatCompletionContentPartTextParam{Text: text}
-				if i < len(view.SystemCacheControls) && view.SystemCacheControls[i].Present {
+		if systemBlocksHaveCacheControl(view.System) {
+			parts := make([]openai.ChatCompletionContentPartTextParam, 0, len(view.System))
+			for _, system := range view.System {
+				part := openai.ChatCompletionContentPartTextParam{Text: system.Text}
+				if hasAnthropicCacheControl(system.CacheControl) {
 					part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
 				}
 				parts = append(parts, part)
 			}
 			systemMsg = openai.SystemMessage(parts)
 		} else {
-			systemMsg = openai.SystemMessage(strings.Join(view.SystemTexts, ""))
+			var systemText strings.Builder
+			for _, system := range view.System {
+				systemText.WriteString(system.Text)
+			}
+			systemMsg = openai.SystemMessage(systemText.String())
 		}
 		// Add system message at the beginning
 		openaiReq.Messages = append([]openai.ChatCompletionMessageParamUnion{systemMsg}, openaiReq.Messages...)
@@ -397,8 +394,8 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 
 	hasRepresentableCacheControl := viewHasRepresentableCacheControl(view)
 	hasFallbackCacheControl := viewHasToolDefinitionCacheControl(view) || viewHasToolUseCacheControl(view)
-	if view.AutomaticCacheControl.Present || hasRepresentableCacheControl || hasFallbackCacheControl {
-		if view.AutomaticCacheControl.Present {
+	if hasAnthropicCacheControl(view.CacheControl) || hasRepresentableCacheControl || hasFallbackCacheControl {
+		if hasAnthropicCacheControl(view.CacheControl) {
 			openaiReq.PromptCacheOptions.Mode = "implicit"
 		} else {
 			openaiReq.PromptCacheOptions.Mode = "explicit"
@@ -445,7 +442,7 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 		switch block.Kind {
 		case blockViewText:
 			if preserveTextParts {
-				part := openAITextPart(block.Text, block.CacheControl.Present)
+				part := openAITextPart(block.Text, hasAnthropicCacheControl(block.CacheControl))
 				textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
 					OfText: &part,
 				})
@@ -505,7 +502,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		case blockViewImage:
 			hasImage = true
 		}
-		hasCache = hasCache || block.CacheControl.Present
+		hasCache = hasCache || hasAnthropicCacheControl(block.CacheControl)
 	}
 
 	switch {
@@ -519,7 +516,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 			case blockViewToolResult:
 				// Convert tool_result to OpenAI role="tool" message.
 				// Truncate tool_call_id to meet OpenAI's 40 character limit.
-				if block.CacheControl.Present {
+				if hasAnthropicCacheControl(block.CacheControl) {
 					part := openAITextPart(block.ToolResultText, true)
 					result = append(result, openai.ChatCompletionMessageParamUnion{
 						OfTool: &openai.ChatCompletionToolMessageParam{
@@ -544,7 +541,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		for _, block := range blocks {
 			switch block.Kind {
 			case blockViewText:
-				part := openAITextPart(block.Text, block.CacheControl.Present)
+				part := openAITextPart(block.Text, hasAnthropicCacheControl(block.CacheControl))
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
 			case blockViewImage:
 				url := imageViewToOpenAIURL(block)
@@ -554,7 +551,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 				imagePart := openai.ChatCompletionContentPartImageParam{
 					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
 				}
-				if block.CacheControl.Present {
+				if hasAnthropicCacheControl(block.CacheControl) {
 					imagePart.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
 				}
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imagePart})
@@ -587,9 +584,9 @@ func openAITextPart(text string, cacheControl bool) openai.ChatCompletionContent
 	return part
 }
 
-func hasCacheControl(values []cacheControlView) bool {
-	for _, value := range values {
-		if value.Present {
+func systemBlocksHaveCacheControl(blocks []anthropic.TextBlockParam) bool {
+	for _, block := range blocks {
+		if hasAnthropicCacheControl(block.CacheControl) {
 			return true
 		}
 	}
@@ -598,7 +595,7 @@ func hasCacheControl(values []cacheControlView) bool {
 
 func blocksHaveCacheControl(blocks []anthropicBlockView) bool {
 	for _, block := range blocks {
-		if block.CacheControl.Present &&
+		if hasAnthropicCacheControl(block.CacheControl) &&
 			(block.Kind == blockViewText || block.Kind == blockViewImage || block.Kind == blockViewToolResult) {
 			return true
 		}
@@ -607,7 +604,7 @@ func blocksHaveCacheControl(blocks []anthropicBlockView) bool {
 }
 
 func viewHasRepresentableCacheControl(view anthropicRequestView) bool {
-	if hasCacheControl(view.SystemCacheControls) {
+	if systemBlocksHaveCacheControl(view.System) {
 		return true
 	}
 	for _, message := range view.Messages {
@@ -620,7 +617,7 @@ func viewHasRepresentableCacheControl(view anthropicRequestView) bool {
 
 func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 	for _, tool := range view.Tools {
-		if tool.CacheControl.Present {
+		if hasAnthropicCacheControl(tool.CacheControl) {
 			return true
 		}
 	}
@@ -630,7 +627,7 @@ func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 func viewHasToolUseCacheControl(view anthropicRequestView) bool {
 	for _, message := range view.Messages {
 		for _, block := range message.Blocks {
-			if block.Kind == blockViewToolUse && block.CacheControl.Present {
+			if block.Kind == blockViewToolUse && hasAnthropicCacheControl(block.CacheControl) {
 				return true
 			}
 		}
@@ -740,10 +737,10 @@ func convertAnthropicViewToGoogleRequest(view anthropicRequestView) (string, []*
 	config.MaxOutputTokens = int32(view.MaxTokens)
 
 	// Convert system message (joined with newlines)
-	if len(view.SystemTexts) > 0 {
+	if len(view.System) > 0 {
 		var systemText strings.Builder
-		for _, text := range view.SystemTexts {
-			systemText.WriteString(text)
+		for _, system := range view.System {
+			systemText.WriteString(system.Text)
 			systemText.WriteString("\n")
 		}
 		config.SystemInstruction = &genai.Content{

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -36,6 +36,15 @@ const (
 	blockViewImage
 )
 
+// cacheControlView retains the Anthropic cache metadata even when the target
+// protocol cannot express all of it. In particular, OpenAI currently has only
+// a 30m request-level TTL, so Anthropic's 5m/1h value must not be silently
+// rewritten as an allegedly equivalent OpenAI value.
+type cacheControlView struct {
+	Present bool
+	TTL     string
+}
+
 // anthropicBlockView is a normalized view of a v1/beta content block.
 type anthropicBlockView struct {
 	Kind anthropicBlockKind
@@ -60,7 +69,7 @@ type anthropicBlockView struct {
 
 	// CacheControl marks the end of a reusable prompt prefix. OpenAI Chat has
 	// the same concept under prompt_cache_breakpoint.
-	CacheControl bool
+	CacheControl cacheControlView
 }
 
 // anthropicMessageView is a normalized view of a v1/beta message.
@@ -73,7 +82,7 @@ type anthropicMessageView struct {
 type anthropicToolView struct {
 	Name         string
 	Description  string
-	CacheControl bool
+	CacheControl cacheControlView
 	// InputSchema is the full schema param value (marshalled for Google).
 	InputSchema any
 	// Properties/Required are the schema fields (used for OpenAI parameters).
@@ -94,10 +103,14 @@ type anthropicToolChoiceView struct {
 type anthropicRequestView struct {
 	Model     string
 	MaxTokens int64
+	// AutomaticCacheControl represents Anthropic's request-level
+	// cache_control. OpenAI expresses the same moving last-block behavior with
+	// prompt_cache_options.mode="implicit".
+	AutomaticCacheControl cacheControlView
 	// SystemTexts holds one entry per system text block; the OpenAI core
 	// joins them without separators, the Google core joins with "\n".
 	SystemTexts         []string
-	SystemCacheControls []bool
+	SystemCacheControls []cacheControlView
 	Messages            []anthropicMessageView
 	Tools               []anthropicToolView
 	HasTools            bool
@@ -108,14 +121,28 @@ type anthropicRequestView struct {
 	OutputEffort    string
 }
 
+func viewAnthropicV1CacheControl(control *anthropic.CacheControlEphemeralParam) cacheControlView {
+	if control == nil || anthropicparam.IsOmitted(*control) {
+		return cacheControlView{}
+	}
+	return cacheControlView{Present: true, TTL: string(control.TTL)}
+}
+
+func viewAnthropicBetaCacheControl(control *anthropic.BetaCacheControlEphemeralParam) cacheControlView {
+	if control == nil || anthropicparam.IsOmitted(*control) {
+		return cacheControlView{}
+	}
+	return cacheControlView{Present: true, TTL: string(control.TTL)}
+}
+
 // ───────────────────────── v1 adapters ─────────────────────────
 
 func viewAnthropicV1Block(block anthropic.ContentBlockParamUnion) anthropicBlockView {
 	cacheControl := block.GetCacheControl()
-	hasCacheControl := cacheControl != nil && !anthropicparam.IsOmitted(*cacheControl)
+	cache := viewAnthropicV1CacheControl(cacheControl)
 	switch {
 	case block.OfText != nil:
-		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: hasCacheControl}
+		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: cache}
 	case block.OfThinking != nil:
 		return anthropicBlockView{Kind: blockViewThinking, Text: block.OfThinking.Thinking}
 	case block.OfRedactedThinking != nil:
@@ -126,17 +153,17 @@ func viewAnthropicV1Block(block anthropic.ContentBlockParamUnion) anthropicBlock
 			ToolID:       block.OfToolUse.ID,
 			ToolName:     block.OfToolUse.Name,
 			ToolInput:    block.OfToolUse.Input,
-			CacheControl: hasCacheControl,
+			CacheControl: cache,
 		}
 	case block.OfToolResult != nil:
 		return anthropicBlockView{
 			Kind:           blockViewToolResult,
 			ToolResultID:   block.OfToolResult.ToolUseID,
 			ToolResultText: convertToolResultContent(block.OfToolResult.Content),
-			CacheControl:   hasCacheControl,
+			CacheControl:   cache,
 		}
 	case block.OfImage != nil:
-		v := anthropicBlockView{Kind: blockViewImage, CacheControl: hasCacheControl}
+		v := anthropicBlockView{Kind: blockViewImage, CacheControl: cache}
 		if block.OfImage.Source.OfBase64 != nil {
 			v.ImageMediaType = string(block.OfImage.Source.OfBase64.MediaType)
 			v.ImageData = block.OfImage.Source.OfBase64.Data
@@ -173,7 +200,7 @@ func viewAnthropicV1Tools(tools []anthropic.ToolUnionParam) []anthropicToolView 
 			Properties:    tool.InputSchema.Properties,
 			Required:      tool.InputSchema.Required,
 			HasProperties: tool.InputSchema.Properties != nil,
-			CacheControl:  !anthropicparam.IsOmitted(tool.CacheControl),
+			CacheControl:  viewAnthropicV1CacheControl(&tool.CacheControl),
 		})
 	}
 	return out
@@ -193,17 +220,18 @@ func viewAnthropicV1ToolChoice(tc *anthropic.ToolChoiceUnionParam) anthropicTool
 
 func viewAnthropicV1Request(req *anthropic.MessageNewParams) anthropicRequestView {
 	view := anthropicRequestView{
-		Model:           string(req.Model),
-		MaxTokens:       req.MaxTokens,
-		HasTools:        len(req.Tools) > 0,
-		Tools:           viewAnthropicV1Tools(req.Tools),
-		ToolChoice:      viewAnthropicV1ToolChoice(&req.ToolChoice),
-		ThinkingEnabled: req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabled(req),
-		OutputEffort:    string(req.OutputConfig.Effort),
+		Model:                 string(req.Model),
+		MaxTokens:             req.MaxTokens,
+		AutomaticCacheControl: viewAnthropicV1CacheControl(&req.CacheControl),
+		HasTools:              len(req.Tools) > 0,
+		Tools:                 viewAnthropicV1Tools(req.Tools),
+		ToolChoice:            viewAnthropicV1ToolChoice(&req.ToolChoice),
+		ThinkingEnabled:       req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabled(req),
+		OutputEffort:          string(req.OutputConfig.Effort),
 	}
 	for _, sys := range req.System {
 		view.SystemTexts = append(view.SystemTexts, sys.Text)
-		view.SystemCacheControls = append(view.SystemCacheControls, !anthropicparam.IsOmitted(sys.CacheControl))
+		view.SystemCacheControls = append(view.SystemCacheControls, viewAnthropicV1CacheControl(&sys.CacheControl))
 	}
 	for _, msg := range req.Messages {
 		view.Messages = append(view.Messages, viewAnthropicV1Message(msg))
@@ -215,10 +243,10 @@ func viewAnthropicV1Request(req *anthropic.MessageNewParams) anthropicRequestVie
 
 func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropicBlockView {
 	cacheControl := block.GetCacheControl()
-	hasCacheControl := cacheControl != nil && !anthropicparam.IsOmitted(*cacheControl)
+	cache := viewAnthropicBetaCacheControl(cacheControl)
 	switch {
 	case block.OfText != nil:
-		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: hasCacheControl}
+		return anthropicBlockView{Kind: blockViewText, Text: block.OfText.Text, CacheControl: cache}
 	case block.OfThinking != nil:
 		return anthropicBlockView{Kind: blockViewThinking, Text: block.OfThinking.Thinking}
 	case block.OfRedactedThinking != nil:
@@ -229,17 +257,17 @@ func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropi
 			ToolID:       block.OfToolUse.ID,
 			ToolName:     block.OfToolUse.Name,
 			ToolInput:    block.OfToolUse.Input,
-			CacheControl: hasCacheControl,
+			CacheControl: cache,
 		}
 	case block.OfToolResult != nil:
 		return anthropicBlockView{
 			Kind:           blockViewToolResult,
 			ToolResultID:   block.OfToolResult.ToolUseID,
 			ToolResultText: convertBetaToolResultContent(block.OfToolResult.Content),
-			CacheControl:   hasCacheControl,
+			CacheControl:   cache,
 		}
 	case block.OfImage != nil:
-		v := anthropicBlockView{Kind: blockViewImage, CacheControl: hasCacheControl}
+		v := anthropicBlockView{Kind: blockViewImage, CacheControl: cache}
 		if block.OfImage.Source.OfBase64 != nil {
 			v.ImageMediaType = string(block.OfImage.Source.OfBase64.MediaType)
 			v.ImageData = block.OfImage.Source.OfBase64.Data
@@ -276,7 +304,7 @@ func viewAnthropicBetaTools(tools []anthropic.BetaToolUnionParam) []anthropicToo
 			Properties:    tool.InputSchema.Properties,
 			Required:      tool.InputSchema.Required,
 			HasProperties: tool.InputSchema.Properties != nil,
-			CacheControl:  !anthropicparam.IsOmitted(tool.CacheControl),
+			CacheControl:  viewAnthropicBetaCacheControl(&tool.CacheControl),
 		})
 	}
 	return out
@@ -296,17 +324,18 @@ func viewAnthropicBetaToolChoice(tc *anthropic.BetaToolChoiceUnionParam) anthrop
 
 func viewAnthropicBetaRequest(req *anthropic.BetaMessageNewParams) anthropicRequestView {
 	view := anthropicRequestView{
-		Model:           string(req.Model),
-		MaxTokens:       req.MaxTokens,
-		HasTools:        len(req.Tools) > 0,
-		Tools:           viewAnthropicBetaTools(req.Tools),
-		ToolChoice:      viewAnthropicBetaToolChoice(&req.ToolChoice),
-		ThinkingEnabled: req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabledBeta(req),
-		OutputEffort:    string(req.OutputConfig.Effort),
+		Model:                 string(req.Model),
+		MaxTokens:             req.MaxTokens,
+		AutomaticCacheControl: viewAnthropicBetaCacheControl(&req.CacheControl),
+		HasTools:              len(req.Tools) > 0,
+		Tools:                 viewAnthropicBetaTools(req.Tools),
+		ToolChoice:            viewAnthropicBetaToolChoice(&req.ToolChoice),
+		ThinkingEnabled:       req.Thinking.OfEnabled != nil || req.Thinking.OfAdaptive != nil || IsThinkingEnabledBeta(req),
+		OutputEffort:          string(req.OutputConfig.Effort),
 	}
 	for _, sys := range req.System {
 		view.SystemTexts = append(view.SystemTexts, sys.Text)
-		view.SystemCacheControls = append(view.SystemCacheControls, !anthropicparam.IsOmitted(sys.CacheControl))
+		view.SystemCacheControls = append(view.SystemCacheControls, viewAnthropicBetaCacheControl(&sys.CacheControl))
 	}
 	for _, msg := range req.Messages {
 		view.Messages = append(view.Messages, viewAnthropicBetaMessage(msg))
@@ -346,7 +375,7 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 			parts := make([]openai.ChatCompletionContentPartTextParam, 0, len(view.SystemTexts))
 			for i, text := range view.SystemTexts {
 				part := openai.ChatCompletionContentPartTextParam{Text: text}
-				if i < len(view.SystemCacheControls) && view.SystemCacheControls[i] {
+				if i < len(view.SystemCacheControls) && view.SystemCacheControls[i].Present {
 					part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
 				}
 				parts = append(parts, part)
@@ -368,8 +397,12 @@ func convertAnthropicViewToOpenAIRequest(view anthropicRequestView, isStreaming 
 
 	hasRepresentableCacheControl := viewHasRepresentableCacheControl(view)
 	hasFallbackCacheControl := viewHasToolDefinitionCacheControl(view) || viewHasToolUseCacheControl(view)
-	if hasRepresentableCacheControl || hasFallbackCacheControl {
-		openaiReq.PromptCacheOptions.Mode = "explicit"
+	if view.AutomaticCacheControl.Present || hasRepresentableCacheControl || hasFallbackCacheControl {
+		if view.AutomaticCacheControl.Present {
+			openaiReq.PromptCacheOptions.Mode = "implicit"
+		} else {
+			openaiReq.PromptCacheOptions.Mode = "explicit"
+		}
 		if !hasRepresentableCacheControl && hasFallbackCacheControl {
 			// OpenAI cannot put a breakpoint on a tool definition or tool call.
 			// Advance that boundary to the first cacheable content block, which
@@ -412,7 +445,7 @@ func convertAnthropicViewAssistantToOpenAI(blocks []anthropicBlockView) openai.C
 		switch block.Kind {
 		case blockViewText:
 			if preserveTextParts {
-				part := openAITextPart(block.Text, block.CacheControl)
+				part := openAITextPart(block.Text, block.CacheControl.Present)
 				textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
 					OfText: &part,
 				})
@@ -472,7 +505,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		case blockViewImage:
 			hasImage = true
 		}
-		hasCache = hasCache || block.CacheControl
+		hasCache = hasCache || block.CacheControl.Present
 	}
 
 	switch {
@@ -486,7 +519,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 			case blockViewToolResult:
 				// Convert tool_result to OpenAI role="tool" message.
 				// Truncate tool_call_id to meet OpenAI's 40 character limit.
-				if block.CacheControl {
+				if block.CacheControl.Present {
 					part := openAITextPart(block.ToolResultText, true)
 					result = append(result, openai.ChatCompletionMessageParamUnion{
 						OfTool: &openai.ChatCompletionToolMessageParam{
@@ -511,7 +544,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 		for _, block := range blocks {
 			switch block.Kind {
 			case blockViewText:
-				part := openAITextPart(block.Text, block.CacheControl)
+				part := openAITextPart(block.Text, block.CacheControl.Present)
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
 			case blockViewImage:
 				url := imageViewToOpenAIURL(block)
@@ -521,7 +554,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropicBlockView) []openai.Chat
 				imagePart := openai.ChatCompletionContentPartImageParam{
 					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
 				}
-				if block.CacheControl {
+				if block.CacheControl.Present {
 					imagePart.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
 				}
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imagePart})
@@ -554,9 +587,9 @@ func openAITextPart(text string, cacheControl bool) openai.ChatCompletionContent
 	return part
 }
 
-func hasCacheControl(values []bool) bool {
+func hasCacheControl(values []cacheControlView) bool {
 	for _, value := range values {
-		if value {
+		if value.Present {
 			return true
 		}
 	}
@@ -565,7 +598,7 @@ func hasCacheControl(values []bool) bool {
 
 func blocksHaveCacheControl(blocks []anthropicBlockView) bool {
 	for _, block := range blocks {
-		if block.CacheControl &&
+		if block.CacheControl.Present &&
 			(block.Kind == blockViewText || block.Kind == blockViewImage || block.Kind == blockViewToolResult) {
 			return true
 		}
@@ -587,7 +620,7 @@ func viewHasRepresentableCacheControl(view anthropicRequestView) bool {
 
 func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 	for _, tool := range view.Tools {
-		if tool.CacheControl {
+		if tool.CacheControl.Present {
 			return true
 		}
 	}
@@ -597,7 +630,7 @@ func viewHasToolDefinitionCacheControl(view anthropicRequestView) bool {
 func viewHasToolUseCacheControl(view anthropicRequestView) bool {
 	for _, message := range view.Messages {
 		for _, block := range message.Blocks {
-			if block.Kind == blockViewToolUse && block.CacheControl {
+			if block.Kind == blockViewToolUse && block.CacheControl.Present {
 				return true
 			}
 		}

--- a/internal/protocol/request/any_to_google.go
+++ b/internal/protocol/request/any_to_google.go
@@ -279,11 +279,14 @@ func ConvertAnthropicToGoogleRequest(anthropicReq *anthropic.MessageNewParams, d
 }
 
 func ConvertAnthropicToGoogleTools(tools []anthropic.ToolUnionParam) []*genai.FunctionDeclaration {
-	return convertAnthropicToolViewsToGoogle(viewAnthropicV1Tools(tools))
+	return convertAnthropicToolViewsToGoogle(tools)
 }
 
 func ConvertAnthropicToGoogleToolChoice(tc *anthropic.ToolChoiceUnionParam) *genai.ToolConfig {
-	return convertAnthropicToolChoiceViewToGoogle(viewAnthropicV1ToolChoice(tc))
+	if tc == nil {
+		return convertAnthropicToolChoiceViewToGoogle(anthropic.ToolChoiceUnionParam{})
+	}
+	return convertAnthropicToolChoiceViewToGoogle(*tc)
 }
 
 // ConvertAnthropicBetaToGoogleRequest converts Anthropic beta request to

--- a/internal/protocol/request/cache_control_roundtrip_test.go
+++ b/internal/protocol/request/cache_control_roundtrip_test.go
@@ -140,8 +140,8 @@ func TestAnthropicCacheControlTTLDegradesExplicitlyAcrossOpenAI(t *testing.T) {
 		},
 	}
 	view := viewAnthropicV1Request(in)
-	require.True(t, view.AutomaticCacheControl.Present)
-	require.Equal(t, "1h", view.AutomaticCacheControl.TTL)
+	require.False(t, anthropicparam.IsOmitted(view.CacheControl))
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, view.CacheControl.TTL)
 
 	chat, _ := ConvertAnthropicToOpenAIRequest(in, true, false, false)
 	require.Equal(t, "implicit", chat.PromptCacheOptions.Mode)
@@ -152,6 +152,76 @@ func TestAnthropicCacheControlTTLDegradesExplicitlyAcrossOpenAI(t *testing.T) {
 	require.False(t, anthropicparam.IsOmitted(out.CacheControl))
 	require.Empty(t, out.CacheControl.TTL,
 		"cross-family round trip preserves automatic caching but Anthropic 1h has no OpenAI equivalent")
+}
+
+func TestAnthropicViewPreservesSDKCacheControlShape(t *testing.T) {
+	cache1h := anthropic.CacheControlEphemeralParam{
+		Type: "ephemeral",
+		TTL:  anthropic.CacheControlEphemeralTTLTTL1h,
+	}
+	cache5m := anthropic.CacheControlEphemeralParam{
+		Type: "ephemeral",
+		TTL:  anthropic.CacheControlEphemeralTTLTTL5m,
+	}
+	user := anthropic.NewTextBlock("stable conversation prefix")
+	user.OfText.CacheControl = cache1h
+	in := &anthropic.MessageNewParams{
+		Model:        "claude-test",
+		MaxTokens:    256,
+		CacheControl: cache1h,
+		System: []anthropic.TextBlockParam{{
+			Text:         "stable system prompt",
+			CacheControl: cache5m,
+		}},
+		Messages: []anthropic.MessageParam{anthropic.NewUserMessage(user)},
+		Tools: []anthropic.ToolUnionParam{{
+			OfTool: &anthropic.ToolParam{
+				Name:         "lookup",
+				InputSchema:  anthropic.ToolInputSchemaParam{Type: "object"},
+				CacheControl: cache1h,
+			},
+		}},
+	}
+
+	view := viewAnthropicV1Request(in)
+	require.Equal(t, cache1h.TTL, view.CacheControl.TTL)
+	require.Equal(t, cache5m.TTL, view.System[0].CacheControl.TTL)
+	require.Equal(t, cache1h.TTL, view.Messages[0].Blocks[0].CacheControl.TTL)
+	require.Equal(t, cache1h.TTL, view.Tools[0].CacheControl.TTL)
+
+	betaCache1h := anthropic.BetaCacheControlEphemeralParam{
+		Type: "ephemeral",
+		TTL:  anthropic.BetaCacheControlEphemeralTTLTTL1h,
+	}
+	betaCache5m := anthropic.BetaCacheControlEphemeralParam{
+		Type: "ephemeral",
+		TTL:  anthropic.BetaCacheControlEphemeralTTLTTL5m,
+	}
+	betaUser := anthropic.NewBetaTextBlock("stable conversation prefix")
+	betaUser.OfText.CacheControl = betaCache1h
+	betaIn := &anthropic.BetaMessageNewParams{
+		Model:        "claude-test",
+		MaxTokens:    256,
+		CacheControl: betaCache1h,
+		System: []anthropic.BetaTextBlockParam{{
+			Text:         "stable system prompt",
+			CacheControl: betaCache5m,
+		}},
+		Messages: []anthropic.BetaMessageParam{anthropic.NewBetaUserMessage(betaUser)},
+		Tools: []anthropic.BetaToolUnionParam{{
+			OfTool: &anthropic.BetaToolParam{
+				Name:         "lookup",
+				InputSchema:  anthropic.BetaToolInputSchemaParam{Type: "object"},
+				CacheControl: betaCache1h,
+			},
+		}},
+	}
+
+	betaView := viewAnthropicBetaRequest(betaIn)
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.CacheControl.TTL)
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL5m, betaView.System[0].CacheControl.TTL)
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.Messages[0].Blocks[0].CacheControl.TTL)
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.Tools[0].CacheControl.TTL)
 }
 
 func TestAnthropicToolCacheControlAdvancesToOpenAICacheableContent(t *testing.T) {

--- a/internal/protocol/request/cache_control_roundtrip_test.go
+++ b/internal/protocol/request/cache_control_roundtrip_test.go
@@ -186,8 +186,8 @@ func TestAnthropicViewPreservesSDKCacheControlShape(t *testing.T) {
 	view := viewAnthropicV1Request(in)
 	require.Equal(t, cache1h.TTL, view.CacheControl.TTL)
 	require.Equal(t, cache5m.TTL, view.System[0].CacheControl.TTL)
-	require.Equal(t, cache1h.TTL, view.Messages[0].Blocks[0].CacheControl.TTL)
-	require.Equal(t, cache1h.TTL, view.Tools[0].CacheControl.TTL)
+	require.Equal(t, cache1h.TTL, view.Messages[0].Content[0].OfText.CacheControl.TTL)
+	require.Equal(t, cache1h.TTL, view.Tools[0].OfTool.CacheControl.TTL)
 
 	betaCache1h := anthropic.BetaCacheControlEphemeralParam{
 		Type: "ephemeral",
@@ -220,8 +220,80 @@ func TestAnthropicViewPreservesSDKCacheControlShape(t *testing.T) {
 	betaView := viewAnthropicBetaRequest(betaIn)
 	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.CacheControl.TTL)
 	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL5m, betaView.System[0].CacheControl.TTL)
-	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.Messages[0].Blocks[0].CacheControl.TTL)
-	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.Tools[0].CacheControl.TTL)
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.Messages[0].Content[0].OfText.CacheControl.TTL)
+	require.Equal(t, anthropic.CacheControlEphemeralTTLTTL1h, betaView.Tools[0].OfTool.CacheControl.TTL)
+}
+
+func TestAnthropicViewUsesSDKCanonicalShape(t *testing.T) {
+	t.Run("v1 fields pass through without flattening", func(t *testing.T) {
+		text := anthropic.NewTextBlock("hello")
+		tool := anthropic.ToolUnionParamOfTool(
+			anthropic.ToolInputSchemaParam{Type: "object", Properties: map[string]any{"q": map[string]any{"type": "string"}}},
+			"lookup",
+		)
+		toolChoice := anthropic.ToolChoiceParamOfTool("lookup")
+		thinking := anthropic.ThinkingConfigParamOfEnabled(2048)
+		in := &anthropic.MessageNewParams{
+			Model:        "claude-test",
+			MaxTokens:    256,
+			Messages:     []anthropic.MessageParam{anthropic.NewUserMessage(text)},
+			Tools:        []anthropic.ToolUnionParam{tool},
+			ToolChoice:   toolChoice,
+			Thinking:     thinking,
+			OutputConfig: anthropic.OutputConfigParam{Effort: anthropic.OutputConfigEffortHigh},
+		}
+
+		view := viewAnthropicV1Request(in)
+		require.Same(t, in.Messages[0].Content[0].OfText, view.Messages[0].Content[0].OfText)
+		require.Same(t, in.Tools[0].OfTool, view.Tools[0].OfTool)
+		require.Same(t, in.ToolChoice.OfTool, view.ToolChoice.OfTool)
+		require.Same(t, in.Thinking.OfEnabled, view.Thinking.OfEnabled)
+		require.Equal(t, in.OutputConfig.Effort, view.OutputConfig.Effort)
+	})
+
+	t.Run("beta fields bridge into v1 SDK unions", func(t *testing.T) {
+		image := anthropic.NewBetaImageBlock(anthropic.BetaBase64ImageSourceParam{
+			Data:      "aGVsbG8=",
+			MediaType: anthropic.BetaBase64ImageSourceMediaTypeImagePNG,
+		})
+		thinkingBlock := anthropic.NewBetaThinkingBlock("signature", "reasoning")
+		tool := anthropic.BetaToolUnionParamOfTool(
+			anthropic.BetaToolInputSchemaParam{
+				Type:       "object",
+				Properties: map[string]any{"q": map[string]any{"type": "string"}},
+				Required:   []string{"q"},
+			},
+			"lookup",
+		)
+		toolChoice := anthropic.BetaToolChoiceParamOfTool("lookup")
+		toolChoice.OfTool.DisableParallelToolUse = anthropic.Bool(true)
+		thinking := anthropic.BetaThinkingConfigParamOfEnabled(2048)
+		thinking.OfEnabled.Display = anthropic.BetaThinkingConfigEnabledDisplayOmitted
+		in := &anthropic.BetaMessageNewParams{
+			Model:     "claude-test",
+			MaxTokens: 256,
+			Messages: []anthropic.BetaMessageParam{{
+				Role:    anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{image, thinkingBlock},
+			}},
+			Tools:        []anthropic.BetaToolUnionParam{tool},
+			ToolChoice:   toolChoice,
+			Thinking:     thinking,
+			OutputConfig: anthropic.BetaOutputConfigParam{Effort: anthropic.BetaOutputConfigEffortHigh},
+		}
+
+		view := viewAnthropicBetaRequest(in)
+		require.NotNil(t, view.Messages[0].Content[0].OfImage)
+		require.Equal(t, "aGVsbG8=", view.Messages[0].Content[0].OfImage.Source.OfBase64.Data)
+		require.Equal(t, "signature", view.Messages[0].Content[1].OfThinking.Signature)
+		require.NotNil(t, view.Tools[0].OfTool)
+		require.Equal(t, []string{"q"}, view.Tools[0].OfTool.InputSchema.Required)
+		require.Equal(t, "lookup", view.ToolChoice.OfTool.Name)
+		require.True(t, view.ToolChoice.OfTool.DisableParallelToolUse.Value)
+		require.EqualValues(t, 2048, view.Thinking.OfEnabled.BudgetTokens)
+		require.Equal(t, anthropic.ThinkingConfigEnabledDisplayOmitted, view.Thinking.OfEnabled.Display)
+		require.Equal(t, anthropic.OutputConfigEffortHigh, view.OutputConfig.Effort)
+	})
 }
 
 func TestAnthropicToolCacheControlAdvancesToOpenAICacheableContent(t *testing.T) {

--- a/internal/protocol/request/cache_control_roundtrip_test.go
+++ b/internal/protocol/request/cache_control_roundtrip_test.go
@@ -56,6 +56,104 @@ func TestAnthropicOpenAIAnthropicPreservesCacheControl(t *testing.T) {
 	require.False(t, anthropicparam.IsOmitted(out.Messages[0].Content[0].OfText.CacheControl))
 }
 
+func TestAnthropicAutomaticCacheControlRoundTripsThroughOpenAIWire(t *testing.T) {
+	t.Run("chat", func(t *testing.T) {
+		in := &anthropic.MessageNewParams{
+			Model:        "claude-test",
+			MaxTokens:    256,
+			CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			System:       []anthropic.TextBlockParam{{Text: "stable system prompt"}},
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(anthropic.NewTextBlock("growing conversation")),
+			},
+		}
+
+		chat, _ := ConvertAnthropicToOpenAIRequest(in, true, false, false)
+		require.Equal(t, "implicit", chat.PromptCacheOptions.Mode)
+
+		wire, err := json.Marshal(chat)
+		require.NoError(t, err)
+		require.Contains(t, string(wire), `"prompt_cache_options":{"mode":"implicit"}`)
+
+		var reparsed openai.ChatCompletionNewParams
+		require.NoError(t, json.Unmarshal(wire, &reparsed))
+		out := ConvertOpenAIToAnthropicRequest(&reparsed, 4096)
+		require.False(t, anthropicparam.IsOmitted(out.CacheControl))
+	})
+
+	t.Run("responses", func(t *testing.T) {
+		in := &anthropic.MessageNewParams{
+			Model:        "claude-test",
+			MaxTokens:    256,
+			CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			System:       []anthropic.TextBlockParam{{Text: "stable system prompt"}},
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(anthropic.NewTextBlock("growing conversation")),
+			},
+		}
+
+		responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+		require.Equal(t, "implicit", responsesReq.PromptCacheOptions.Mode)
+
+		wire, err := json.Marshal(responsesReq)
+		require.NoError(t, err)
+		require.Contains(t, string(wire), `"prompt_cache_options":{"mode":"implicit"}`)
+
+		var reparsed responses.ResponseNewParams
+		require.NoError(t, json.Unmarshal(wire, &reparsed))
+		out := ConvertOpenAIResponsesToAnthropicBetaRequest(reparsed, 4096)
+		require.False(t, anthropicparam.IsOmitted(out.CacheControl))
+	})
+}
+
+func TestAnthropicAutomaticAndExplicitCacheControlsCoexist(t *testing.T) {
+	user := anthropic.NewTextBlock("stable conversation prefix")
+	user.OfText.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	in := &anthropic.MessageNewParams{
+		Model:        "claude-test",
+		MaxTokens:    256,
+		CacheControl: anthropic.NewCacheControlEphemeralParam(),
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(user),
+		},
+	}
+	chat, _ := ConvertAnthropicToOpenAIRequest(in, true, false, false)
+	require.Equal(t, "implicit", chat.PromptCacheOptions.Mode)
+	require.False(t, openaiparam.IsOmitted(
+		chat.Messages[0].OfUser.Content.OfArrayOfContentParts[0].OfText.PromptCacheBreakpoint))
+
+	responsesReq := ConvertAnthropicV1ToResponsesRequest(in)
+	require.Equal(t, "implicit", responsesReq.PromptCacheOptions.Mode)
+	requireResponsesTextBreakpoint(t, responsesReq.Input.OfInputItemList[0], "user")
+}
+
+func TestAnthropicCacheControlTTLDegradesExplicitlyAcrossOpenAI(t *testing.T) {
+	in := &anthropic.MessageNewParams{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		CacheControl: anthropic.CacheControlEphemeralParam{
+			Type: "ephemeral",
+			TTL:  anthropic.CacheControlEphemeralTTLTTL1h,
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("growing conversation")),
+		},
+	}
+	view := viewAnthropicV1Request(in)
+	require.True(t, view.AutomaticCacheControl.Present)
+	require.Equal(t, "1h", view.AutomaticCacheControl.TTL)
+
+	chat, _ := ConvertAnthropicToOpenAIRequest(in, true, false, false)
+	require.Equal(t, "implicit", chat.PromptCacheOptions.Mode)
+	require.Empty(t, chat.PromptCacheOptions.Ttl,
+		"Anthropic 1h must not be mistranslated as OpenAI's only supported 30m TTL")
+
+	out := ConvertOpenAIToAnthropicRequest(chat, 4096)
+	require.False(t, anthropicparam.IsOmitted(out.CacheControl))
+	require.Empty(t, out.CacheControl.TTL,
+		"cross-family round trip preserves automatic caching but Anthropic 1h has no OpenAI equivalent")
+}
+
 func TestAnthropicToolCacheControlAdvancesToOpenAICacheableContent(t *testing.T) {
 	in := &anthropic.MessageNewParams{
 		Model:     "claude-test",

--- a/internal/protocol/request/openai_responses_to_anthropic.go
+++ b/internal/protocol/request/openai_responses_to_anthropic.go
@@ -23,6 +23,9 @@ func ConvertOpenAIResponsesToAnthropicBetaRequest(
 	defaultMaxTokens int64,
 ) *anthropic.BetaMessageNewParams {
 	anthropicParams := &anthropic.BetaMessageNewParams{}
+	if params.PromptCacheOptions.Mode == "implicit" {
+		anthropicParams.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+	}
 
 	// Convert model
 	if params.Model != "" {

--- a/internal/protocol/request/openai_to_anthropic.go
+++ b/internal/protocol/request/openai_to_anthropic.go
@@ -136,6 +136,9 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 		Messages:  messages,
 		MaxTokens: maxTokens,
 	}
+	if req.PromptCacheOptions.Mode == "implicit" {
+		params.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+	}
 
 	// Add system blocks if any. Array-form OpenAI content keeps standard
 	// prompt_cache_breakpoint markers from an earlier Anthropic hop.

--- a/internal/protocoltest/cache_controls.go
+++ b/internal/protocoltest/cache_controls.go
@@ -30,6 +30,25 @@ func cacheControlScenario() Scenario {
 	return s
 }
 
+func cacheControlIdempotentCases() []IdempotentCase {
+	cases := append([]IdempotentCase(nil), DefaultIdempotentCases()...)
+	cases = append(cases,
+		IdempotentCase{
+			Name:     "anthropic_beta_via_openai_chat",
+			Source:   protocol.TypeAnthropicBeta,
+			Mid:      protocol.TypeOpenAIChat,
+			Baseline: protocol.TypeAnthropicBeta,
+		},
+		IdempotentCase{
+			Name:     "anthropic_beta_via_openai_responses",
+			Source:   protocol.TypeAnthropicBeta,
+			Mid:      protocol.TypeOpenAIResponses,
+			Baseline: protocol.TypeAnthropicBeta,
+		},
+	)
+	return cases
+}
+
 // cacheControlBody returns the same stable system + user prefix in each source
 // protocol. cached controls both markers and OpenAI's explicit cache mode.
 func cacheControlBody(source protocol.APIType, model string, streaming, cached bool) map[string]any {
@@ -94,6 +113,23 @@ func cacheControlBody(source protocol.APIType, model string, streaming, cached b
 	panic(fmt.Sprintf("unsupported cache-control source protocol %s", source))
 }
 
+// automaticCacheControlBody exercises the request-level/implicit cache mode:
+// Anthropic names it top-level cache_control, while OpenAI names it
+// prompt_cache_options.mode="implicit". Unlike cacheControlBody, it contains
+// no explicit content breakpoint.
+func automaticCacheControlBody(source protocol.APIType, model string, streaming bool) map[string]any {
+	body := cacheControlBody(source, model, streaming, false)
+	switch source {
+	case protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta:
+		body["cache_control"] = map[string]any{"type": "ephemeral"}
+	case protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses:
+		body["prompt_cache_options"] = map[string]any{"mode": "implicit"}
+	default:
+		panic(fmt.Sprintf("unsupported automatic cache-control source protocol %s", source))
+	}
+	return body
+}
+
 func cacheControlEndpoint(target protocol.APIType) EndpointKind {
 	switch target {
 	case protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta:
@@ -115,6 +151,17 @@ func sendCacheControlBody(t flagTB, env *TestEnv, source, target protocol.APITyp
 	if err != nil {
 		t.Fatalf("dispatch %s -> %s (cached=%v, streaming=%v): %v",
 			source, target, cached, streaming, err)
+	}
+}
+
+func sendAutomaticCacheControlBody(t flagTB, env *TestEnv, source, target protocol.APIType, scenarioName, model string, streaming bool) {
+	t.Helper()
+	path, _ := buildRequest(source, model, streaming)
+	_, err := env.dispatch(source, target, scenarioName, path,
+		mustMarshal(automaticCacheControlBody(source, model, streaming)), nil, streaming)
+	if err != nil {
+		t.Fatalf("dispatch automatic cache %s -> %s (streaming=%v): %v",
+			source, target, streaming, err)
 	}
 }
 
@@ -215,6 +262,50 @@ func assertCapturedCacheState(t flagTB, env *TestEnv, target protocol.APIType, c
 	}
 }
 
+func assertCapturedAutomaticCacheState(t flagTB, env *TestEnv, target protocol.APIType, label string) {
+	t.Helper()
+	endpoint := cacheControlEndpoint(target)
+	if endpoint == "" {
+		t.Fatalf("%s: unsupported target protocol %s", label, target)
+	}
+	captured := env.virtual.LastRequest(endpoint)
+	if captured == nil {
+		t.Fatalf("%s: final provider received no %s request", label, endpoint)
+	}
+	body := captured.JSON()
+
+	if endpoint == EndpointAnthropic {
+		raw, ok := body["cache_control"]
+		if !ok {
+			t.Errorf("%s: final Anthropic body has no top-level cache_control; body=%s",
+				label, truncate(string(captured.Body), 1200))
+			return
+		}
+		control, _ := raw.(map[string]any)
+		if got, _ := control["type"].(string); got != "ephemeral" {
+			t.Errorf("%s: final cache_control.type = %q, want ephemeral; body=%s",
+				label, got, truncate(string(captured.Body), 1200))
+		}
+		// Automatic caching must not invent explicit content breakpoints.
+		delete(body, "cache_control")
+		if explicit := countCacheMarkers(t, body, "cache_control", "type", "ephemeral"); explicit != 0 {
+			t.Errorf("%s: final Anthropic body contains %d explicit cache marker(s); body=%s",
+				label, explicit, truncate(string(captured.Body), 1200))
+		}
+		return
+	}
+
+	options, _ := body["prompt_cache_options"].(map[string]any)
+	if got, _ := options["mode"].(string); got != "implicit" {
+		t.Errorf("%s: final prompt_cache_options.mode = %q, want implicit; body=%s",
+			label, got, truncate(string(captured.Body), 1200))
+	}
+	if explicit := countCacheMarkers(t, body, "prompt_cache_breakpoint", "mode", "explicit"); explicit != 0 {
+		t.Errorf("%s: final OpenAI body contains %d explicit cache marker(s); body=%s",
+			label, explicit, truncate(string(captured.Body), 1200))
+	}
+}
+
 func runSingleCacheControlCase(t flagTB, env *TestEnv, pair ProtocolPair, streaming bool) {
 	t.Helper()
 	s := cacheControlScenario()
@@ -230,6 +321,10 @@ func runSingleCacheControlCase(t flagTB, env *TestEnv, pair ProtocolPair, stream
 		sendCacheControlBody(t, env, pair.Source, pair.Target, s.Name, model, streaming, cached)
 		assertCapturedCacheState(t, env, pair.Target, cached, label)
 	}
+	label := fmt.Sprintf("single/%s→%s/automatic/%s",
+		pair.Source, pair.Target, streamMode(streaming))
+	sendAutomaticCacheControlBody(t, env, pair.Source, pair.Target, s.Name, model, streaming)
+	assertCapturedAutomaticCacheState(t, env, pair.Target, label)
 }
 
 func runABACacheControlCase(t flagTB, env *TestEnv, ic IdempotentCase, streaming bool) {
@@ -254,6 +349,10 @@ func runABACacheControlCase(t flagTB, env *TestEnv, ic IdempotentCase, streaming
 		sendCacheControlBody(t, env, ic.Source, ic.Mid, s.Name, headModel, streaming, cached)
 		assertCapturedCacheState(t, env, ic.Baseline, cached, label)
 	}
+	label := fmt.Sprintf("aba/%s→%s→%s/automatic/%s",
+		ic.Source, ic.Mid, ic.Baseline, streamMode(streaming))
+	sendAutomaticCacheControlBody(t, env, ic.Source, ic.Mid, s.Name, headModel, streaming)
+	assertCapturedAutomaticCacheState(t, env, ic.Baseline, label)
 }
 
 func cacheStateName(cached bool) string {
@@ -290,7 +389,7 @@ func (m *Matrix) ExecuteAllCacheControls() []TestResult {
 		}
 	}
 
-	for _, ic := range DefaultIdempotentCases() {
+	for _, ic := range cacheControlIdempotentCases() {
 		for _, streaming := range m.Streaming {
 			ic := ic
 			streaming := streaming


### PR DESCRIPTION
## Summary

Anthropic automatic cache control was lost when requests crossed an OpenAI protocol boundary and returned through an A→O→A path. Preserve automatic and explicit caching semantics across Chat and Responses conversions while keeping the shared conversion model aligned with the upstream Anthropic SDK structures.

## Key Changes

- **Automatic cache continuity**: Map Anthropic top-level `cache_control` to OpenAI `prompt_cache_options.mode="implicit"` and restore it when converting back to Anthropic.
- **Mixed cache strategies**: Preserve implicit automatic caching alongside explicit content breakpoints instead of allowing one strategy to overwrite the other.
- **SDK-aligned conversion boundary**: Replace flattened custom request, content, tool, tool-choice, thinking, output, and cache representations with canonical Anthropic SDK unions and nested fields.
- **Beta compatibility**: Bridge supported Anthropic Beta SDK structures explicitly into canonical v1 SDK types without introducing a parallel protocol model.
- **Gateway regression coverage**: Exercise actual JSON re-entry across A→O→A paths for Anthropic v1 and Beta, Chat and Responses, streaming and non-streaming requests.
- **Cache safety checks**: Verify automatic caching does not synthesize explicit breakpoints and no-cache requests remain cache-free.

## Compatibility Notes

- **TTL behavior**: Anthropic `5m` and `1h` TTL values have no exact OpenAI equivalent because OpenAI exposes `30m`. Cross-protocol conversion preserves automatic cache semantics without inventing a TTL; returning to Anthropic uses its default `5m` behavior.
- **Existing explicit caching**: Existing system, message, and fallback breakpoint behavior remains supported.

## Testing

- `go test ./internal/protocol/... ./internal/protocoltest ./cli/harness -count=1`
- `go vet ./internal/protocol/request ./internal/protocoltest ./cli/harness`
- `git diff --check origin/main..HEAD`