### PR TITLE
fix(oauth): forward anthropic-organization-id on Claude Code OAuth requests

### DIFF
--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -76,7 +76,8 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 	if provider.AuthType == typ.AuthTypeOAuth {
 		if provider.OAuthDetail != nil && provider.OAuthDetail.Issuer == ai.IssuerClaudeCode {
 			transport = &claudeRoundTripper{
-				RoundTripper: createSessionBoundTransport(provider, sessionID),
+				RoundTripper:   createSessionBoundTransport(provider, sessionID),
+				organizationID: provider.OAuthDetail.GetExtraFieldString("organization_id"),
 			}
 			logrus.Infof("Using session-bound transport for OAuth issuer: %s, session: %s",
 				provider.OAuthDetail.GetIssuer(), sessionID.Value)

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -117,6 +117,13 @@ func applyClaudeCodeHeaders(options []anthropicOption.RequestOption, provider *t
 		anthropicOption.WithHeader("x-stainless-timeout", stainlessTimeout),
 	)
 
+	// Attribute the request to the organization the OAuth token was issued for.
+	// Without this, Anthropic falls back to the token's default context, which
+	// breaks org-bound entitlements (e.g. Cyber Verification).
+	if orgID := provider.OAuthDetail.GetExtraFieldString("organization_id"); orgID != "" {
+		options = append(options, anthropicOption.WithHeader("anthropic-organization-id", orgID))
+	}
+
 	return options
 }
 

--- a/internal/client/claude_round_tripper.go
+++ b/internal/client/claude_round_tripper.go
@@ -399,6 +399,13 @@ func mergeBetaFlags(required []string, upstream []string, requiredOAuth string) 
 // - Manages conditional Authorization vs x-api-key header
 type claudeRoundTripper struct {
 	http.RoundTripper
+
+	// organizationID is the Anthropic organization the OAuth token belongs to,
+	// captured at login into OAuthDetail.ExtraFields["organization_id"]. It must
+	// be re-attached here as anthropic-organization-id: the header cleanup in
+	// applyClaudeCodeHeaders strips every anthropic-* header, so a value set via
+	// SDK options would not survive.
+	organizationID string
 }
 
 func (t *claudeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -573,6 +580,13 @@ func (t *claudeRoundTripper) applyClaudeCodeHeaders(req *http.Request, isOAuthTo
 		"x-stainless-arch":                          stainlessArch(),
 		"x-stainless-os":                            stainlessOS(),
 		"x-stainless-timeout":                       stainlessTimeout,
+	}
+
+	// Attribute the request to the organization the OAuth token was issued for.
+	// Without this, Anthropic falls back to the token's default context, which
+	// breaks org-bound entitlements (e.g. Cyber Verification).
+	if t.organizationID != "" {
+		headers["anthropic-organization-id"] = t.organizationID
 	}
 
 	for k, v := range headers {

--- a/internal/client/claude_round_tripper_test.go
+++ b/internal/client/claude_round_tripper_test.go
@@ -26,6 +26,30 @@ func TestClaudeSDKHeaders(t *testing.T) {
 	assert.Equal(t, "600", stainlessTimeout)
 }
 
+func TestApplyClaudeCodeHeadersOrganizationID(t *testing.T) {
+	newReq := func() *http.Request {
+		req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+		assert.NoError(t, err)
+		req.Header.Set("X-Api-Key", "sk-ant-oat01-test")
+		return req
+	}
+
+	t.Run("forwards org id captured at OAuth login", func(t *testing.T) {
+		rt := &claudeRoundTripper{organizationID: "11111111-2222-3333-4444-555555555555"}
+		req := newReq()
+		rt.applyClaudeCodeHeaders(req, true, "claude-sonnet-4-6", "")
+		assert.Equal(t, "11111111-2222-3333-4444-555555555555", req.Header.Get("anthropic-organization-id"))
+	})
+
+	t.Run("no header when org id unknown, upstream value stripped", func(t *testing.T) {
+		rt := &claudeRoundTripper{}
+		req := newReq()
+		req.Header.Set("Anthropic-Organization-Id", "stale-upstream-value")
+		rt.applyClaudeCodeHeaders(req, true, "claude-sonnet-4-6", "")
+		assert.Empty(t, req.Header.Get("anthropic-organization-id"))
+	})
+}
+
 func TestAnthropicBetaFlags(t *testing.T) {
 	for _, flag := range []string{
 		"claude-code-20250219",


### PR DESCRIPTION
## Problem

When a Claude Code OAuth provider is used, requests forwarded to Anthropic never carry the organization identity, so Anthropic attributes them to the token's **default/personal context** instead of the organization the token was issued for. Any entitlement bound to a specific organization (e.g. the Cyber Verification Program) silently stops applying, and requests get rejected by org-level safeguards even though the account is verified.

Root cause: the org id was **write-only**.

- At OAuth login, `populateAnthropicMetadata` (`ai/oauth/manager.go`) extracts `organization_id` from Anthropic's token response and persists it into `OAuthDetail.ExtraFields`.
- At request time, `claudeRoundTripper.applyClaudeCodeHeaders` (`internal/client/claude_round_tripper.go`) deletes **every** `anthropic-*` header and rebuilds a fixed header table — which did not include `anthropic-organization-id`. Nothing in the codebase ever read the stored `organization_id` back.

So the value was captured and stored on login, then dropped on every outgoing request.

## Fix

Read `organization_id` from `OAuthDetail.ExtraFields` and attach it as the `anthropic-organization-id` header on both Claude Code OAuth request paths:

1. **`claudeRoundTripper` path** (`internal/client/anthropic.go` + `claude_round_tripper.go`): the round tripper gains an `organizationID` field, populated at construction from the provider. It is added to the rebuilt header table inside `applyClaudeCodeHeaders` — it *must* live there rather than in SDK options, because the header cleanup strips all `anthropic-*` headers before the table is applied.
2. **`ClaudeClient` SDK-options path** (`internal/client/claude_client.go`): the package-level `applyClaudeCodeHeaders` appends the same header via `anthropicOption.WithHeader`.

The header is only set when a non-empty `organization_id` exists, so:
- API-key providers and non-ClaudeCode OAuth issuers are untouched.
- Older stored OAuth providers without the metadata behave exactly as before.
- A stale upstream-supplied `anthropic-organization-id` is still stripped by the cleanup and not resurrected.

This mirrors the existing precedent in `codex_client.go`, which forwards `account_id` from ExtraFields as `X-ChatGPT-Account-ID`.

## Testing

- New unit test `TestApplyClaudeCodeHeadersOrganizationID` covers both cases: the header is forwarded when the org id is present, and absent (including stripping a stale upstream value) when it is not.
- `go test ./internal/client/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
