### PR TITLE
bugfix(observability): report resolved dual-provider upstream

### DIFF
--- a/internal/constant/tracking_ctx.go
+++ b/internal/constant/tracking_ctx.go
@@ -1,9 +1,22 @@
 package constant
 
-// Gin context key constants for per-request tracking metadata.
-// Defined here so that server/, routing/, and middleware/ sub-packages
-// can all reference the same values without import cycles.
+// Gin context key constants for per-request metadata. Defined here so that
+// server/, routing/, middleware/, and protocol/ sub-packages can share the
+// writer/reader contract without import cycles or duplicated string literals.
 const (
+	// Authentication metadata.
+	CtxKeyUserID                    = "user_id"                     // string
+	CtxKeyEnterpriseUserID          = "enterprise_user_id"          // string
+	CtxKeyEnterpriseDepartmentID    = "enterprise_department_id"    // string
+	CtxKeyEnterpriseKeyPrefix       = "enterprise_key_prefix"       // string
+	CtxKeyEnterpriseUserTier        = "enterprise_user_tier"        // string
+	CtxKeyEnterpriseContextJTI      = "enterprise_context_jti"      // string
+	CtxKeyEnterpriseContextVerified = "enterprise_context_verified" // bool
+	CtxKeyRemoteClientID            = "client_id"                   // string
+	CtxKeyRemoteClaims              = "claims"                      // *auth.Claims
+	CtxKeyRequestID                 = "request_id"                  // string
+
+	// Request tracking metadata.
 	CtxKeyRule           = "tracking_rule"             // *typ.Rule
 	CtxKeyProvider       = "tracking_provider"         // *typ.Provider
 	CtxKeyModel          = "tracking_model"            // string (actual model used)
@@ -17,4 +30,11 @@ const (
 	CtxKeyAffinityKey    = "tracking_affinity_key"     // string (scoped affinity store key: session + matched smart partition)
 	CtxKeyLBServiceID    = "tracking_lb_service_id"    // string (selected upstream, e.g. "provider-uuid:model")
 	CtxKeyLBTactic       = "tracking_lb_tactic"        // string (tactic name, e.g. "random")
+
+	// Protocol recording metadata.
+	CtxKeyProtocolRecorder    = "protocol_recorder"     // *recording.ProtocolRecorder
+	CtxKeyStreamEventRecorder = "stream_event_recorder" // protocol/stream.StreamEventRecorder
+
+	// Guardrail runtime metadata.
+	CtxKeyCredentialMaskState = "guardrails_credential_mask_state" // *guardrails/core.CredentialMaskState
 )

--- a/internal/guardrails/core/credential_alias.go
+++ b/internal/guardrails/core/credential_alias.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 )
 
-// CredentialMaskStateContextKey is the shared gin-context key used to carry
-// request-scoped alias mappings from request masking to stream/tool restoration.
-const CredentialMaskStateContextKey = "guardrails_credential_mask_state"
-
 // CredentialMaskState tracks the credential substitutions observed in one request flow.
 type CredentialMaskState struct {
 	AliasToReal map[string]string `json:"alias_to_real,omitempty"`

--- a/internal/guardrails/core/model.go
+++ b/internal/guardrails/core/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 )
 
 // Verdict is the overall decision from a policy or engine.
@@ -150,7 +151,7 @@ func (i Input) CredentialMaskState() *CredentialMaskState {
 		return i.State.CredentialMask
 	}
 	if i.Runtime.Context != nil {
-		if value, ok := i.Runtime.Context.Get(CredentialMaskStateContextKey); ok {
+		if value, ok := i.Runtime.Context.Get(constant.CtxKeyCredentialMaskState); ok {
 			if state, ok := value.(*CredentialMaskState); ok {
 				return state
 			}

--- a/internal/protocol/stream/anthropic_helper.go
+++ b/internal/protocol/stream/anthropic_helper.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
@@ -143,7 +144,7 @@ func sendAnthropicStreamEvent(c *gin.Context, eventType string, eventData any, f
 	c.SSEvent(eventType, string(eventJSON))
 	flusher.Flush()
 
-	if recorder, exists := c.Get("stream_event_recorder"); exists {
+	if recorder, exists := c.Get(constant.CtxKeyStreamEventRecorder); exists {
 		if r, ok := recorder.(StreamEventRecorder); ok {
 			if m, ok := eventData.(map[string]interface{}); ok {
 				r.RecordRawMapEvent(eventType, m)

--- a/internal/remote_control/config/config.go
+++ b/internal/remote_control/config/config.go
@@ -289,8 +289,8 @@ func AuthMiddleware(cfg *Config) gin.HandlerFunc {
 				normalized = normalized[7:]
 			}
 			if cfg.UserToken != "" && normalized == cfg.UserToken {
-				c.Set("client_id", "user")
-				c.Set("claims", &auth.Claims{ClientID: "user"})
+				c.Set(constant.CtxKeyRemoteClientID, "user")
+				c.Set(constant.CtxKeyRemoteClaims, &auth.Claims{ClientID: "user"})
 				c.Next()
 				return
 			}
@@ -306,8 +306,8 @@ func AuthMiddleware(cfg *Config) gin.HandlerFunc {
 		}
 
 		// Store claims in context
-		c.Set("client_id", claims.ClientID)
-		c.Set("claims", claims)
+		c.Set(constant.CtxKeyRemoteClientID, claims.ClientID)
+		c.Set(constant.CtxKeyRemoteClaims, claims)
 
 		logrus.Debugf("Authenticated request from client: %s", claims.ClientID)
 

--- a/internal/server/anthropic_count_tokens.go
+++ b/internal/server/anthropic_count_tokens.go
@@ -99,9 +99,8 @@ func (ph *ProtocolHandler) anthropicCountTokens(c *gin.Context, provider *typ.Pr
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleAnthropic)
-
-	c.Set("provider", provider.UUID)
-	c.Set("model", model)
+	c.Set(ContextKeyProvider, provider)
+	c.Set(ContextKeyModel, model)
 
 	apiStyle := provider.APIStyle
 	wrapper := ph.deps.ClientPool.GetAnthropicClient(context.Background(), provider, model)

--- a/internal/server/anthropic_message.go
+++ b/internal/server/anthropic_message.go
@@ -225,15 +225,12 @@ func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.A
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleAnthropic)
+	c.Set(ContextKeyProvider, provider)
 	if provider.Timeout <= 0 {
 		provider.Timeout = constant.DefaultRequestTimeout
 	}
 
 	req.Model = anthropic.Model(requestModel)
-
-	// Set provider UUID in context (Service.Provider uses UUID, not name)
-	c.Set("provider", provider.UUID)
-	c.Set("model", requestModel)
 
 	// Build and run server-side pre-transform chain (scenario-driven flags)
 	maxAllowed := ph.deps.TemplateManager.GetMaxTokensForModelByProvider(provider, requestModel)
@@ -351,15 +348,12 @@ func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleAnthropic)
+	c.Set(ContextKeyProvider, provider)
 	if provider.Timeout <= 0 {
 		provider.Timeout = constant.DefaultRequestTimeout
 	}
 
 	req.Model = anthropic.Model(requestModel)
-
-	// Set provider UUID in context (Service.Provider uses UUID, not name)
-	c.Set("provider", provider.UUID)
-	c.Set("model", requestModel)
 
 	// Build and run server-side pre-transform chain (scenario-driven flags)
 	maxAllowed := ph.deps.TemplateManager.GetMaxTokensForModelByProvider(provider, requestModel)

--- a/internal/server/failover_logging_test.go
+++ b/internal/server/failover_logging_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	internalobs "github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
@@ -268,7 +269,7 @@ func TestFailoverRecordsBreakerFailureIndependentlyOfRecorder(t *testing.T) {
 					if err != nil {
 						t.Fatalf("NewProtocolRecorder: %v", err)
 					}
-					c.Set(recording.RecorderContextKey, protocolRecorder)
+					c.Set(constant.CtxKeyProtocolRecorder, protocolRecorder)
 				}
 
 				attempt := func(provider *typ.Provider, model string) {

--- a/internal/server/guardrails_runtime_ai.go
+++ b/internal/server/guardrails_runtime_ai.go
@@ -4,6 +4,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/guardrails"
 	guardrailsadapter "github.com/tingly-dev/tingly-box/internal/guardrails/adapter"
 	guardrailscore "github.com/tingly-dev/tingly-box/internal/guardrails/core"
@@ -61,13 +62,13 @@ func EnsureGuardrailsCredentialMaskState(c *gin.Context) *guardrailscore.Credent
 	if c == nil {
 		return nil
 	}
-	if existing, ok := c.Get(guardrailscore.CredentialMaskStateContextKey); ok {
+	if existing, ok := c.Get(constant.CtxKeyCredentialMaskState); ok {
 		if state, ok := existing.(*guardrailscore.CredentialMaskState); ok && state != nil {
 			return state
 		}
 	}
 	state := guardrailscore.NewCredentialMaskState()
-	c.Set(guardrailscore.CredentialMaskStateContextKey, state)
+	c.Set(constant.CtxKeyCredentialMaskState, state)
 	return state
 }
 

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/pkg/auth"
@@ -278,10 +279,9 @@ func (am *AuthMiddleware) UserAuthMiddleware() gin.HandlerFunc {
 			// Direct token comparison
 			if token == configToken || strings.TrimPrefix(token, "Bearer ") == configToken {
 				// Token matches the one in global config, allow access
-				c.Set("client_id", "user_authenticated")
 				// For UI user authentication, set user_id to default admin
 				// This matches the migrated user_id in usage_records
-				c.Set("user_id", db.DefaultAdminUserID)
+				c.Set(constant.CtxKeyUserID, db.DefaultAdminUserID)
 				c.Next()
 				return
 			}
@@ -328,10 +328,7 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 				tokenRecord, validateErr := am.apiTokenStore.ValidateToken(token)
 				if validateErr == nil && tokenRecord != nil {
 					// Token is valid and enabled
-					c.Set("user_id", tokenRecord.UserID)
-					c.Set("token_id", tokenRecord.TokenID)
-					c.Set("client_id", "model_authenticated")
-					c.Set("auth_method", "api_token")
+					c.Set(constant.CtxKeyUserID, tokenRecord.UserID)
 
 					// Update last used asynchronously
 					go am.apiTokenStore.UpdateLastUsed(tokenRecord.TokenID)
@@ -358,11 +355,9 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 
 		// Direct token comparison
 		if token == configToken || xApiKey == configToken {
-			c.Set("client_id", "model_authenticated")
-			c.Set("auth_method", "global_token")
 			// Set UserID to default admin for usage tracking consistency
 			// This matches the migrated user_id values in usage_records
-			c.Set("user_id", db.DefaultAdminUserID)
+			c.Set(constant.CtxKeyUserID, db.DefaultAdminUserID)
 			contextJWT := strings.TrimSpace(c.GetHeader("X-TBE-Context-JWT"))
 			if contextJWT != "" {
 				claims, verifyErr := verifyEnterpriseContextJWT(cfg, contextJWT)
@@ -371,12 +366,12 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 					return
 				}
 				if claims != nil {
-					c.Set("enterprise_user_id", claims.UserID)
-					c.Set("enterprise_department_id", claims.DepartmentID)
-					c.Set("enterprise_key_prefix", claims.KeyPrefix)
-					c.Set("enterprise_user_tier", claims.Tier)
-					c.Set("enterprise_context_jti", claims.JTI)
-					c.Set("enterprise_context_verified", true)
+					c.Set(constant.CtxKeyEnterpriseUserID, claims.UserID)
+					c.Set(constant.CtxKeyEnterpriseDepartmentID, claims.DepartmentID)
+					c.Set(constant.CtxKeyEnterpriseKeyPrefix, claims.KeyPrefix)
+					c.Set(constant.CtxKeyEnterpriseUserTier, claims.Tier)
+					c.Set(constant.CtxKeyEnterpriseContextJTI, claims.JTI)
+					c.Set(constant.CtxKeyEnterpriseContextVerified, true)
 				}
 			}
 			c.Next()

--- a/internal/server/middleware/auth_context_jwt_test.go
+++ b/internal/server/middleware/auth_context_jwt_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 )
 
@@ -33,9 +34,9 @@ func newModelAuthTestRouter(t *testing.T) (*gin.Engine, *config.Config, string) 
 	am := NewAuthMiddleware(cfg, nil, nil, nil)
 	r.POST("/v1/chat/completions", am.ModelAuthMiddleware(), func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"enterprise_user_id":       c.GetString("enterprise_user_id"),
-			"enterprise_department_id": c.GetString("enterprise_department_id"),
-			"verified":                 c.GetBool("enterprise_context_verified"),
+			"enterprise_user_id":       c.GetString(constant.CtxKeyEnterpriseUserID),
+			"enterprise_department_id": c.GetString(constant.CtxKeyEnterpriseDepartmentID),
+			"verified":                 c.GetBool(constant.CtxKeyEnterpriseContextVerified),
 		})
 	})
 	return r, cfg, secret

--- a/internal/server/middleware/multi_mode_memory_log.go
+++ b/internal/server/middleware/multi_mode_memory_log.go
@@ -14,11 +14,6 @@ import (
 	"github.com/tingly-dev/tingly-box/pkg/obs"
 )
 
-// GinRequestIDKey is the gin context key under which the per-request
-// correlation id is stored. Handlers and later stages read it via
-// c.GetString(GinRequestIDKey) to tie their logs to the request.
-const GinRequestIDKey = "request_id"
-
 // MultiModeMemoryLogMiddleware is the HTTP access log for the whole request
 // chain. It records one structured entry per request — method, path, status,
 // latency, error, and (for AI routes) routing metadata — correlated across
@@ -78,9 +73,9 @@ func (m *MultiModeMemoryLogMiddleware) Middleware() gin.HandlerFunc {
 			requestID = uuid.NewString()
 		}
 		// Store on gin context so Gin middleware/handlers that hold *gin.Context
-		// can read it via c.GetString(GinRequestIDKey) — e.g. the access log
+		// can read it via CtxKeyRequestID — e.g. the access log
 		// fields below and stage_smart_routing's emitTrace.
-		c.Set(GinRequestIDKey, requestID)
+		c.Set(constant.CtxKeyRequestID, requestID)
 
 		// Also carry the id on the Go request context so code that only has
 		// context.Context (protocol converters, upstream client calls) can log

--- a/internal/server/module/imbot/handler_pairing.go
+++ b/internal/server/module/imbot/handler_pairing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/remote_control/bot"
 )
@@ -25,7 +26,7 @@ func resolveRequirePairing(s db.Settings) bool {
 // bot.NewLogAuditor), so the imbot.pair.* action family stays consistent
 // whether the event came from a chat command or the web UI.
 func logPairAudit(c *gin.Context, action, uuid, message string) {
-	bot.NewLogAuditor().Info(action, c.GetString("user_id"), c.ClientIP(), message, map[string]interface{}{
+	bot.NewLogAuditor().Info(action, c.GetString(constant.CtxKeyUserID), c.ClientIP(), message, map[string]interface{}{
 		"bot_uuid": uuid,
 		"by":       "web",
 	})

--- a/internal/server/openai_chat.go
+++ b/internal/server/openai_chat.go
@@ -187,6 +187,7 @@ func (ph *ProtocolHandler) runOpenAIChatAttempt(c *gin.Context, req *protocol.Op
 	// Resolve dual endpoint: when the provider has an OpenAI-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
+	c.Set(ContextKeyProvider, provider)
 	if provider.Timeout <= 0 {
 		provider.Timeout = constant.DefaultRequestTimeout
 	}

--- a/internal/server/openai_responses.go
+++ b/internal/server/openai_responses.go
@@ -193,6 +193,7 @@ func (ph *ProtocolHandler) runOpenAIResponsesAttempt(c *gin.Context, req *protoc
 	// Resolve dual endpoint: when the provider has an OpenAI-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
+	c.Set(ContextKeyProvider, provider)
 	if provider.Timeout <= 0 {
 		provider.Timeout = constant.DefaultRequestTimeout
 	}

--- a/internal/server/protocol_handler.go
+++ b/internal/server/protocol_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/data"
 	"github.com/tingly-dev/tingly-box/internal/guardrails"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -205,7 +206,7 @@ func (ph *ProtocolHandler) applyVisionProxy(c *gin.Context, scenarioType typ.Rul
 // isEnterpriseContextPresent reports whether the request carries an
 // enterprise-runtime identity (already authorized upstream by TBE).
 func isEnterpriseContextPresent(c *gin.Context) bool {
-	return strings.TrimSpace(c.GetString("enterprise_user_id")) != ""
+	return strings.TrimSpace(c.GetString(constant.CtxKeyEnterpriseUserID)) != ""
 }
 
 // resolveSessionID returns the session identifier for the current request as
@@ -296,6 +297,6 @@ func (ph *ProtocolHandler) EnsureProtocolRecorder(c *gin.Context, scenario strin
 		return nil
 	}
 	rec.BindProvider(provider, model, mode)
-	c.Set(recording.RecorderContextKey, rec)
+	c.Set(constant.CtxKeyProtocolRecorder, rec)
 	return rec
 }

--- a/internal/server/recording/hook.go
+++ b/internal/server/recording/hook.go
@@ -6,14 +6,11 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/assembler"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
-
-// streamRecorderContextKey is the gin context key under which the active
-// streamRecorder is published for protocol-layer code to feed events into.
-const streamRecorderContextKey = "stream_event_recorder"
 
 // StreamRecorder couples a ProtocolRecorder with a stream assembler so that
 // raw SSE events emitted during protocol conversion are mirrored into both
@@ -149,7 +146,7 @@ func (sr *StreamRecorder) SetupStreamRecorderInContext(c *gin.Context) {
 	if sr == nil {
 		return
 	}
-	c.Set(streamRecorderContextKey, sr)
+	c.Set(constant.CtxKeyStreamEventRecorder, sr)
 }
 
 // AttachRecorderHooks wires a ProtocolRecorder into a native Anthropic stream

--- a/internal/server/recording/recorder.go
+++ b/internal/server/recording/recorder.go
@@ -10,14 +10,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/obs"
-	"github.com/tingly-dev/tingly-box/internal/server/middleware"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
-
-// RecorderContextKey is the gin context key under which the active
-// ProtocolRecorder is stored so later handler stages can reuse it.
-const RecorderContextKey = "protocol_recorder"
 
 // ProtocolRecorder captures a single client→tingly-box→provider cycle.
 //
@@ -108,7 +104,7 @@ func GetRecorderFromContext(c *gin.Context) (*ProtocolRecorder, bool) {
 }
 
 func getRecorderFromContext(c *gin.Context) (*ProtocolRecorder, bool) {
-	v, exists := c.Get(RecorderContextKey)
+	v, exists := c.Get(constant.CtxKeyProtocolRecorder)
 	if !exists {
 		return nil, false
 	}
@@ -313,7 +309,7 @@ func (sr *ProtocolRecorder) release() {
 // runs outside an HTTP request.
 func (sr *ProtocolRecorder) resolveRequestID() string {
 	if sr.c != nil {
-		if id := sr.c.GetString(middleware.GinRequestIDKey); id != "" {
+		if id := sr.c.GetString(constant.CtxKeyRequestID); id != "" {
 			return id
 		}
 	}
@@ -349,12 +345,6 @@ func (sr *ProtocolRecorder) synthesizeFinalResponse() *obs.RecordResponse {
 		bodyJSON["_stream_chunks"] = len(sr.streamChunks)
 		bodyJSON["_note"] = "assembled response unavailable"
 		logrus.Debugf("obs: ProtocolRecorder fallback response, chunks=%d", len(sr.streamChunks))
-	} else if sr.c != nil {
-		if responseBody, exists := sr.c.Get("response_body"); exists {
-			if b, ok := responseBody.([]byte); ok {
-				_ = json.Unmarshal(b, &bodyJSON)
-			}
-		}
 	}
 
 	resp := &obs.RecordResponse{

--- a/internal/server/routing/simple.go
+++ b/internal/server/routing/simple.go
@@ -75,9 +75,6 @@ func (s *SimpleSelector) SelectService(
 	// this, not the bare session, or they'll miss partition-scoped pins.
 	c.Set(constant.CtxKeyAffinityKey, AffinitySessionKey(ctx.SessionID.String(), result.MatchedSmartRuleIndex))
 
-	// Store result metadata for observability
-	c.Set("routing_source", result.Source)
-
 	// Store LB trajectory: which upstream was selected and via which tactic.
 	// SourceSmartRouting and SourceAffinity bypass the normal LB tactic, so
 	// label them explicitly; otherwise use the rule's configured tactic name.

--- a/internal/server/routing/stage_smart_routing.go
+++ b/internal/server/routing/stage_smart_routing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -108,7 +109,7 @@ func (s *SmartRoutingStage) emitTrace(
 	}
 	if ctx.GinContext != nil {
 		fields["client_ip"] = ctx.GinContext.ClientIP()
-		fields["request_id"] = ctx.GinContext.GetString("request_id")
+		fields["request_id"] = ctx.GinContext.GetString(constant.CtxKeyRequestID)
 	}
 
 	if s.multiLogger != nil {

--- a/internal/server/usage_tracking.go
+++ b/internal/server/usage_tracking.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/data/db"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -33,11 +34,11 @@ type MetricsData struct {
 // This ensures that JWT API token authentication takes precedence for user tracking.
 func GetUserIDFromContext(c *gin.Context) string {
 	// First, try user_id from JWT API token authentication or global auth
-	if userID := c.GetString("user_id"); userID != "" {
+	if userID := c.GetString(constant.CtxKeyUserID); userID != "" {
 		return userID
 	}
 	// Fall back to enterprise_user_id from enterprise context JWT
-	if enterpriseUserID := c.GetString("enterprise_user_id"); enterpriseUserID != "" {
+	if enterpriseUserID := c.GetString(constant.CtxKeyEnterpriseUserID); enterpriseUserID != "" {
 		return enterpriseUserID
 	}
 	return ""
@@ -115,7 +116,7 @@ func (s *Server) trackUsageFromContext(c *gin.Context, inputTokens, outputTokens
 	// 2. Record to OTel (primary path for metrics)
 	if s.tokenTracker != nil {
 		userTier := ""
-		if strings.TrimSpace(c.GetString("enterprise_user_id")) != "" {
+		if strings.TrimSpace(c.GetString(constant.CtxKeyEnterpriseUserID)) != "" {
 			userTier = "enterprise"
 		}
 		// Metric attributes must stay low-cardinality: pass the bounded error
@@ -144,13 +145,13 @@ func (s *Server) trackUsageFromContext(c *gin.Context, inputTokens, outputTokens
 	s.reportHealthStatus(provider, model, err, errorCode)
 
 	// 5. Enterprise key-level 429 alerting hook (best-effort).
-	if err != nil && isRateLimitError(err) && strings.TrimSpace(c.GetString("enterprise_user_id")) != "" {
+	if err != nil && isRateLimitError(err) && strings.TrimSpace(c.GetString(constant.CtxKeyEnterpriseUserID)) != "" {
 		_ = reportEnterpriseRateLimitEvent(
 			c.Request.Context(),
-			c.GetString("enterprise_key_prefix"),
+			c.GetString(constant.CtxKeyEnterpriseKeyPrefix),
 			provider.UUID,
 			scenario,
-			c.GetString("enterprise_user_id"),
+			c.GetString(constant.CtxKeyEnterpriseUserID),
 		)
 	}
 }
@@ -259,13 +260,13 @@ func (s *Server) trackUsageWithTokenUsage(c *gin.Context, usage *protocol.TokenU
 	s.reportHealthStatus(provider, model, err, errorCode)
 
 	// 5. Enterprise key-level 429 alerting hook (best-effort).
-	if err != nil && isRateLimitError(err) && strings.TrimSpace(c.GetString("enterprise_user_id")) != "" {
+	if err != nil && isRateLimitError(err) && strings.TrimSpace(c.GetString(constant.CtxKeyEnterpriseUserID)) != "" {
 		_ = reportEnterpriseRateLimitEvent(
 			c.Request.Context(),
-			c.GetString("enterprise_key_prefix"),
+			c.GetString(constant.CtxKeyEnterpriseKeyPrefix),
 			provider.UUID,
 			scenario,
-			c.GetString("enterprise_user_id"),
+			c.GetString(constant.CtxKeyEnterpriseUserID),
 		)
 	}
 }
@@ -463,17 +464,6 @@ func (s *Server) updateServiceStats(rule *typ.Rule, provider *typ.Provider, mode
 			}
 			return
 		}
-	}
-}
-
-// TrackUsage implements the UsageTracker interface.
-// It extracts the gin.Context from the provided context and calls trackUsageFromContext.
-// The gin.Context should be stored in the context with the key "gin_context".
-func (s *Server) TrackUsage(ctx context.Context, inputTokens, outputTokens int, err error) {
-	// Try to get gin.Context from the context
-	// This is set when creating HandleContext
-	if c, ok := ctx.Value("gin_context").(*gin.Context); ok {
-		s.trackUsageFromContext(c, inputTokens, outputTokens, err)
 	}
 }
 

--- a/internal/server/usage_tracking_test.go
+++ b/internal/server/usage_tracking_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -156,9 +157,8 @@ func TestTrackUsageFromContext_ReportsEnterpriseRateLimit(t *testing.T) {
 	rule := &typ.Rule{UUID: "r1"}
 	provider := &typ.Provider{UUID: "p1", Name: "provider-1"}
 	SetTrackingContext(c, rule, provider, "tingly/cc", "tingly/cc", false)
-	c.Set("client_id", "enterprise_access_token")
-	c.Set("enterprise_key_prefix", "sk-tbe-12345678")
-	c.Set("enterprise_user_id", "u1")
+	c.Set(constant.CtxKeyEnterpriseKeyPrefix, "sk-tbe-12345678")
+	c.Set(constant.CtxKeyEnterpriseUserID, "u1")
 
 	s := &Server{}
 	s.trackUsageFromContext(c, 0, 0, errors.New("upstream returned 429 rate limit"))


### PR DESCRIPTION
## Summary

Dual providers could route requests to the correct OpenAI or Anthropic endpoint while access logs continued reporting metadata from the legacy primary endpoint. This aligns request observability with the resolved upstream and consolidates Gin context keys into one shared contract.

## Key Changes

- **Dual-protocol observability**: Refresh the active provider metadata after resolving OpenAI and Anthropic endpoints, so access logs report the upstream that actually handled the request.
- **Context contract**: Centralize authentication, tracking, request correlation, recording, guardrail, and remote-control context keys so producers and consumers cannot drift through duplicated string literals.
- **Metadata lifecycle**: Remove context values and fallback paths that no longer have active consumers, reducing misleading or stale request state.

## Testing

- Verified middleware, recording, routing, protocol stream, guardrail, remote-control, and targeted server tests.
- Verified formatting with `git diff --check`.

## Notes

- The branch is one commit behind `origin/main`; the missing commit only contains unrelated UI table hover changes. The PR patch itself contains only the dual-provider observability and context-key changes.