### PR TITLE
feat(oauth): claude_org_id rule flag for per-rule organization control

### DIFF
--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -71,6 +71,7 @@ export interface RuleFlags {
     claudeCodeCompat?: boolean;
     cleanHeader?: boolean;
     context1m?: boolean;
+    claudeOrgId?: string;
 }
 
 export interface RuleFlagsApi {
@@ -88,6 +89,7 @@ export interface RuleFlagsApi {
     claude_code_compat?: boolean;
     clean_header?: boolean;
     context_1m?: boolean;
+    claude_org_id?: string;
 }
 
 export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref';

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -35,7 +35,11 @@ type ClaudeClient struct {
 // NewClaudeClient creates a new Claude client wrapper.
 // It builds an Anthropic SDK client with Claude Code specific headers and middleware,
 // then wraps it in an AnthropicClient for delegation.
-func NewClaudeClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*ClaudeClient, error) {
+//
+// ctx is the inbound request context: the pool constructs a client per request,
+// so per-request hints resolved here (the claude_org_id rule flag via
+// typ.GetClaudeOrgID) are correctly scoped to the request being served.
+func NewClaudeClient(ctx context.Context, provider *typ.Provider, model string, sessionID typ.SessionID) (*ClaudeClient, error) {
 	logrus.Debug("creating claude-client")
 
 	// Handle API base URL - Anthropic SDK expects base without /v1
@@ -54,7 +58,7 @@ func NewClaudeClient(provider *typ.Provider, model string, sessionID typ.Session
 	isOAuthToken := IsClaudeOAuthToken(provider.GetAccessToken())
 
 	// Apply Claude Code specific headers
-	options = applyClaudeCodeHeaders(options, provider, sessionID.Value, isOAuthToken)
+	options = applyClaudeCodeHeaders(options, provider, sessionID.Value, isOAuthToken, typ.GetClaudeOrgID(ctx))
 
 	// Add beta query parameter
 	options = append(options, anthropicOption.WithQuery("beta", "true"))
@@ -79,7 +83,9 @@ func NewClaudeClient(provider *typ.Provider, model string, sessionID typ.Session
 }
 
 // applyClaudeCodeHeaders applies Claude Code specific headers via SDK options.
-func applyClaudeCodeHeaders(options []anthropicOption.RequestOption, provider *typ.Provider, sessionID string, isOAuthToken bool) []anthropicOption.RequestOption {
+// orgOverride, when non-empty, replaces the login-time organization as the
+// anthropic-organization-id value (the claude_org_id rule flag).
+func applyClaudeCodeHeaders(options []anthropicOption.RequestOption, provider *typ.Provider, sessionID string, isOAuthToken bool, orgOverride string) []anthropicOption.RequestOption {
 	// Build beta header with all required flags
 	baseBetas := anthropicBeta
 
@@ -117,10 +123,22 @@ func applyClaudeCodeHeaders(options []anthropicOption.RequestOption, provider *t
 		anthropicOption.WithHeader("x-stainless-timeout", stainlessTimeout),
 	)
 
-	// Attribute the request to the organization the OAuth token was issued for.
-	// Without this, Anthropic falls back to the token's default context, which
-	// breaks org-bound entitlements (e.g. Cyber Verification).
-	if orgID := provider.OAuthDetail.GetExtraFieldString("organization_id"); orgID != "" {
+	// Organization attribution is opt-in via the claude_org_id rule flag:
+	// unset (empty) attaches no organization header — the classic default;
+	// "auto" attributes the request to the organization the OAuth token was
+	// issued for (login-time capture), which org-bound entitlements (e.g.
+	// Cyber Verification) rely on; any other value attributes the request to
+	// that organization instead.
+	var orgID string
+	switch orgOverride {
+	case "":
+		// default: no organization header
+	case typ.ClaudeOrgIDAuto:
+		orgID = provider.OAuthDetail.GetExtraFieldString("organization_id")
+	default:
+		orgID = orgOverride
+	}
+	if orgID != "" {
 		options = append(options, anthropicOption.WithHeader("anthropic-organization-id", orgID))
 	}
 

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -64,7 +64,7 @@ func TestNewClaudeClient_OAuthToken(t *testing.T) {
 	provider := newOAuthProvider()
 	sessionID := typ.SessionID{Value: "test-session-123"}
 
-	c, err := NewClaudeClient(provider, "claude-sonnet-4-6", sessionID)
+	c, err := NewClaudeClient(context.Background(), provider, "claude-sonnet-4-6", sessionID)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.NotNil(t, c.AnthropicClient)
@@ -74,7 +74,7 @@ func TestNewClaudeClient_APIKey(t *testing.T) {
 	provider := newAPIKeyProvider()
 	sessionID := typ.SessionID{Value: "test-session-456"}
 
-	c, err := NewClaudeClient(provider, "claude-opus-4-6", sessionID)
+	c, err := NewClaudeClient(context.Background(), provider, "claude-opus-4-6", sessionID)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
@@ -88,7 +88,7 @@ func TestNewClaudeClient_StripV1FromBase(t *testing.T) {
 		Token:    "sk-ant-api-test",
 	}
 	sessionID := typ.SessionID{Value: "sess"}
-	c, err := NewClaudeClient(provider, "", sessionID)
+	c, err := NewClaudeClient(context.Background(), provider, "", sessionID)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
@@ -99,7 +99,7 @@ func TestNewClaudeClient_StripV1FromBase(t *testing.T) {
 
 func TestClaudeClient_ListModels_ReturnsError(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	models, err := c.ListModels(context.Background())
@@ -222,7 +222,7 @@ func TestRestoreBetaToolNamesInMessage(t *testing.T) {
 
 func TestGuard_DisablesThinkingWhenUnset(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	// Build a valid metadata user_id (JSON format)
@@ -242,7 +242,7 @@ func TestGuard_DisablesThinkingWhenUnset(t *testing.T) {
 
 func TestGuard_PreservesExistingThinking(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -270,7 +270,7 @@ func TestGuard_PreservesExistingThinking(t *testing.T) {
 
 func TestGuardBeta_DisablesThinkingWhenUnset(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -288,7 +288,7 @@ func TestGuardBeta_DisablesThinkingWhenUnset(t *testing.T) {
 
 func TestGuardBeta_PreservesExistingThinking(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -311,7 +311,7 @@ func TestGuardBeta_PreservesExistingThinking(t *testing.T) {
 
 func TestGuardBeta_StripsClearThinkingEditWhenThinkingDisabled(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -337,7 +337,7 @@ func TestGuardBeta_StripsClearThinkingEditWhenThinkingDisabled(t *testing.T) {
 
 func TestGuardBeta_KeepsClearThinkingEditWhenThinkingEnabled(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -363,7 +363,7 @@ func TestGuardBeta_KeepsClearThinkingEditWhenThinkingEnabled(t *testing.T) {
 
 func TestGuardBeta_KeepsClearThinkingEditWhenEffortSet(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -389,7 +389,7 @@ func TestGuardBeta_KeepsClearThinkingEditWhenEffortSet(t *testing.T) {
 
 func TestGuardBeta_StripsClearThinkingWhenDisabledOverridesEffort(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -413,7 +413,7 @@ func TestGuardBeta_StripsClearThinkingWhenDisabledOverridesEffort(t *testing.T) 
 
 func TestGuard_DoesNotDisableThinkingWhenEffortSet(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -436,7 +436,7 @@ func TestGuard_DoesNotDisableThinkingWhenEffortSet(t *testing.T) {
 
 func TestGuard_RemapsToolNames(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
@@ -457,7 +457,7 @@ func TestGuard_RemapsToolNames(t *testing.T) {
 
 func TestGuardBeta_RemapsToolNames(t *testing.T) {
 	provider := newOAuthProvider()
-	c, err := NewClaudeClient(provider, "", typ.SessionID{Value: "s"})
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
 
 	userID := `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`

--- a/internal/client/claude_org_id_test.go
+++ b/internal/client/claude_org_id_test.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestClaudeClient_ClaudeOrgID drives the full ClaudeClient path
+// (NewClaudeClient → Guard → SDK → HTTP) against a capturing server and pins
+// the claude_org_id semantics: unset attaches no organization header (classic
+// behavior — the login-time capture is opt-in), "auto" attributes to the
+// organization captured at OAuth login, and any other value attributes to
+// that organization. The flag is resolved from the request context at
+// construction (the pool builds a client per request); Guard-built clients
+// inherit it via the base client's Options.
+func TestClaudeClient_ClaudeOrgID(t *testing.T) {
+	const loginOrg = "11111111-2222-3333-4444-555555555555"
+	const customOrg = "99999999-8888-7777-6666-555555555555"
+
+	var gotOrg string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOrg = r.Header.Get("anthropic-organization-id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6",` +
+			`"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn",` +
+			`"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	newProvider := func() *typ.Provider {
+		return &typ.Provider{
+			Name:     "test-claude-org",
+			APIBase:  srv.URL,
+			AuthType: ai.AuthTypeOAuth,
+			OAuthDetail: &ai.OAuthDetail{
+				AccessToken: "sk-ant-oat01-testtoken",
+				ExtraFields: map[string]interface{}{"organization_id": loginOrg},
+			},
+		}
+	}
+
+	newReq := func() *anthropic.MessageNewParams {
+		return &anthropic.MessageNewParams{
+			Model:     "claude-sonnet-4-6",
+			MaxTokens: 16,
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
+			},
+			Metadata: anthropic.MetadataParam{
+				UserID: param.NewOpt(`{"device_id":"d","account_uuid":"a","session_id":"sess-1"}`),
+			},
+		}
+	}
+
+	send := func(t *testing.T, ctx context.Context, provider *typ.Provider) {
+		t.Helper()
+		c, err := NewClaudeClient(ctx, provider, "claude-sonnet-4-6", typ.SessionID{Value: "s"})
+		require.NoError(t, err)
+		_, err = c.MessagesNew(ctx, newReq())
+		require.NoError(t, err)
+	}
+
+	t.Run("default sends no org header even when login org is known", func(t *testing.T) {
+		send(t, context.Background(), newProvider())
+		assert.Empty(t, gotOrg)
+	})
+
+	t.Run("auto sends the login-time org", func(t *testing.T) {
+		ctx := typ.WithClaudeOrgID(context.Background(), typ.ClaudeOrgIDAuto)
+		send(t, ctx, newProvider())
+		assert.Equal(t, loginOrg, gotOrg)
+	})
+
+	t.Run("auto with no login-time org sends no header", func(t *testing.T) {
+		ctx := typ.WithClaudeOrgID(context.Background(), typ.ClaudeOrgIDAuto)
+		p := newProvider()
+		p.OAuthDetail.ExtraFields = nil
+		send(t, ctx, p)
+		assert.Empty(t, gotOrg)
+	})
+
+	t.Run("custom value replaces the login-time org", func(t *testing.T) {
+		ctx := typ.WithClaudeOrgID(context.Background(), customOrg)
+		send(t, ctx, newProvider())
+		assert.Equal(t, customOrg, gotOrg)
+	})
+}

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -134,7 +134,7 @@ func (p *ClientPool) GetAnthropicClient(ctx context.Context, provider *typ.Provi
 
 	// Check if this is a Claude Code OAuth provider
 	if provider.AuthType == typ.AuthTypeOAuth && provider.OAuthDetail != nil && provider.OAuthDetail.GetIssuer() == ai.IssuerClaudeCode {
-		client, err = NewClaudeClient(provider, model, sessionID)
+		client, err = NewClaudeClient(ctx, provider, model, sessionID)
 		if err != nil {
 			logrus.WithContext(ctx).Errorf("Failed to create Claude client for provider %s: %v", provider.Name, err)
 			return nil

--- a/internal/client/timeout_test.go
+++ b/internal/client/timeout_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -107,7 +108,7 @@ func TestClaudeClient_TimeoutValidation(t *testing.T) {
 			}
 
 			// Test that Claude Code client creation succeeds with timeout handling
-			client, err := NewClaudeClient(provider, "claude-3-5-sonnet-20241022", typ.SessionID{})
+			client, err := NewClaudeClient(context.Background(), provider, "claude-3-5-sonnet-20241022", typ.SessionID{})
 			if err != nil {
 				t.Fatalf("NewClaudeClient() should not fail with timeout %d: %v", tt.providerTimeout, err)
 			}

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -460,6 +460,84 @@ func ruleFlagCases() []flagCase {
 			}
 		}},
 
+		// ── claude_org_id ────────────────────────────────────────────────────
+		// Asserted on the real Claude OAuth path (pool → NewClaudeClient). The
+		// flag is tri-state: unset sends no anthropic-organization-id header
+		// (classic default — the login-time capture is opt-in), "auto" sends
+		// the organization captured in OAuthDetail.ExtraFields, and a custom
+		// value sends exactly that. All three states are driven through rules
+		// on the same provider below.
+		{key: "claude_org_id", run: func(t flagTB, env *TestEnv) {
+			s := flagScenario()
+			env.virtual.RegisterScenario(s)
+			const providerName = "flag-orgid-claude"
+			const loginOrg = "11111111-2222-3333-4444-555555555555"
+			const orgID = "99999999-8888-7777-6666-555555555555"
+			_ = env.appConfig.AddProvider(&typ.Provider{
+				UUID:     providerName,
+				Name:     providerName,
+				APIBase:  env.virtual.URL(),
+				APIStyle: protocol.APIStyleAnthropic,
+				AuthType: ai.AuthTypeOAuth,
+				OAuthDetail: &ai.OAuthDetail{
+					Issuer:      ai.IssuerClaudeCode,
+					AccessToken: "sk-ant-oat01-virtual",
+					ExtraFields: map[string]interface{}{"organization_id": loginOrg},
+				},
+				Enabled: true,
+				Timeout: int64(constant.DefaultRequestTimeout),
+			})
+
+			providerModel := "virtual-model-" + s.Name
+			addRule := func(reqModel, flagValue string) {
+				rule := newHarnessRule(reqModel, typ.ScenarioClaudeCode, reqModel, providerModel,
+					harnessService(providerName, providerModel))
+				rule.Flags = typ.RuleFlags{ClaudeOrgID: flagValue}
+				_ = env.appConfig.GetGlobalConfig().AddRequestConfig(rule)
+			}
+			addRule("pv-flag-orgid-default", "")
+			addRule("pv-flag-orgid-auto", typ.ClaudeOrgIDAuto)
+			addRule("pv-flag-orgid", orgID)
+
+			send := func(reqModel string) *CapturedRequest {
+				// Claude Code always sends metadata.user_id; ClaudeClient's
+				// Guard requires it, so mirror the real client here.
+				_, body := flagBaseRequest(protocol.TypeAnthropicV1, reqModel, false)
+				var m map[string]any
+				if err := json.Unmarshal(body, &m); err != nil {
+					t.Fatalf("unmarshal base request: %v", err)
+				}
+				m["metadata"] = map[string]any{
+					"user_id": `{"device_id":"d","account_uuid":"a","session_id":"flag-orgid-session"}`,
+				}
+				body = mustMarshal(m)
+
+				res, err := env.dispatch(protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta, s.Name,
+					"/tingly/claude_code/v1/messages", body, nil, false)
+				if err != nil {
+					t.Fatalf("dispatch: %v", err)
+				}
+				if res.HTTPStatus != 200 {
+					t.Fatalf("request failed: status=%d body=%s", res.HTTPStatus, truncate(string(res.RawBody), 300))
+				}
+				up := env.virtual.LastRequest(EndpointAnthropic)
+				if up == nil {
+					t.Fatal("no upstream request captured")
+				}
+				return up
+			}
+
+			if got := send("pv-flag-orgid-default").Headers.Get("anthropic-organization-id"); got != "" {
+				t.Errorf("unset flag must send no anthropic-organization-id upstream; got %q", got)
+			}
+			if got := send("pv-flag-orgid-auto").Headers.Get("anthropic-organization-id"); got != loginOrg {
+				t.Errorf("auto did not send the login-time organization upstream; got %q, want %q", got, loginOrg)
+			}
+			if got := send("pv-flag-orgid").Headers.Get("anthropic-organization-id"); got != orgID {
+				t.Errorf("custom value did not reach anthropic-organization-id upstream; got %q, want %q", got, orgID)
+			}
+		}},
+
 		// ── context_1m ───────────────────────────────────────────────────────
 		// Asserted on the real claude_code path: (1) a [1m]-suffixed incoming
 		// model still routes to its bare-named rule (suffix-normalized

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -173,18 +173,17 @@ func ResolveRuleFlagsWithScenario(
 	// Messages methods read it and add the context-1m beta per request.
 	applyContext1M(c, flags)
 
-	// Attach the anthropic-organization-id override the same way: the outbound
-	// Anthropic client/transport reads it per request and sends it instead of
-	// the provider's login-time organization.
+	// Attach the claude_org_id hint the same way: NewClaudeClient reads it per
+	// request and decides whether/what anthropic-organization-id to send.
 	applyClaudeOrgID(c, flags)
 
 	return flags
 }
 
-// applyClaudeOrgID attaches the claude_org_id override to the request context
-// so the outbound Anthropic client (generic and Claude Code OAuth) sends it as
-// the anthropic-organization-id header. No-op when the flag is empty, so the
-// provider's login-time organization stays in effect.
+// applyClaudeOrgID attaches the claude_org_id flag to the request context so
+// NewClaudeClient can resolve it when composing the anthropic-organization-id
+// header. No-op when the flag is empty, so no organization header is sent —
+// organization attribution is opt-in (see typ.RuleFlags.ClaudeOrgID).
 func applyClaudeOrgID(c *gin.Context, flags typ.RuleFlags) {
 	if flags.ClaudeOrgID == "" || c == nil || c.Request == nil {
 		return

--- a/internal/server/rule_flags.go
+++ b/internal/server/rule_flags.go
@@ -173,7 +173,23 @@ func ResolveRuleFlagsWithScenario(
 	// Messages methods read it and add the context-1m beta per request.
 	applyContext1M(c, flags)
 
+	// Attach the anthropic-organization-id override the same way: the outbound
+	// Anthropic client/transport reads it per request and sends it instead of
+	// the provider's login-time organization.
+	applyClaudeOrgID(c, flags)
+
 	return flags
+}
+
+// applyClaudeOrgID attaches the claude_org_id override to the request context
+// so the outbound Anthropic client (generic and Claude Code OAuth) sends it as
+// the anthropic-organization-id header. No-op when the flag is empty, so the
+// provider's login-time organization stays in effect.
+func applyClaudeOrgID(c *gin.Context, flags typ.RuleFlags) {
+	if flags.ClaudeOrgID == "" || c == nil || c.Request == nil {
+		return
+	}
+	c.Request = c.Request.WithContext(typ.WithClaudeOrgID(c.Request.Context(), flags.ClaudeOrgID))
 }
 
 // applyContext1M attaches the 1M-context hint to the request context so the

--- a/internal/server/rule_flags_test.go
+++ b/internal/server/rule_flags_test.go
@@ -591,3 +591,34 @@ func TestResolveRuleFlagsWithScenario_CleanHeaderSuppressedForClaudeOAuth(t *tes
 		t.Error("CleanHeader should be preserved when provider is nil")
 	}
 }
+
+func TestApplyClaudeOrgID(t *testing.T) {
+	t.Run("attaches override to request context", func(t *testing.T) {
+		c := newGinContext(t)
+		applyClaudeOrgID(c, typ.RuleFlags{ClaudeOrgID: "org-uuid"})
+		if got := typ.GetClaudeOrgID(c.Request.Context()); got != "org-uuid" {
+			t.Errorf("claude org id in ctx = %q, want %q", got, "org-uuid")
+		}
+	})
+
+	t.Run("empty flag is a no-op", func(t *testing.T) {
+		c := newGinContext(t)
+		applyClaudeOrgID(c, typ.RuleFlags{})
+		if got := typ.GetClaudeOrgID(c.Request.Context()); got != "" {
+			t.Errorf("claude org id in ctx = %q, want empty", got)
+		}
+	})
+}
+
+func TestResolveRuleFlagsWithScenario_ClaudeOrgIDReachesContext(t *testing.T) {
+	c := newGinContext(t)
+	rule := &typ.Rule{Flags: typ.RuleFlags{ClaudeOrgID: "org-uuid"}}
+	got := ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, &typ.ScenarioConfig{},
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+	if got.ClaudeOrgID != "org-uuid" {
+		t.Errorf("ClaudeOrgID = %q, want %q", got.ClaudeOrgID, "org-uuid")
+	}
+	if ctxVal := typ.GetClaudeOrgID(c.Request.Context()); ctxVal != "org-uuid" {
+		t.Errorf("claude org id in ctx = %q, want %q", ctxVal, "org-uuid")
+	}
+}

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -222,6 +222,18 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:    FlagCategoryApp,
 		},
 		{
+			Key:         "claude_org_id",
+			Label:       "Claude organization ID",
+			Description: "Control the anthropic-organization-id header sent to Anthropic for this rule (Claude OAuth providers). Leave empty (default) to attach no organization header — the classic behavior, so existing setups are unaffected. Choose \"Login organization\" to attribute requests to the organization captured at OAuth login (org-bound entitlements such as Cyber Verification need this), or enter an organization UUID to attribute requests to that specific organization.",
+			Type:        FlagTypeString,
+			Category:    FlagCategoryRequestAnthropic,
+			Placeholder: "e.g. 12345678-1234-1234-1234-123456789012",
+			Suggestions: []FlagOption{
+				// Sentinel preset — see typ.ClaudeOrgIDAuto.
+				{Label: "Login organization (from OAuth)", Value: ClaudeOrgIDAuto},
+			},
+		},
+		{
 			Key:         "context_1m",
 			Label:       "1M Context Window",
 			Description: "Enable Anthropic's 1M token context window for supported models (Sonnet 4.6+, Opus 4.6+). Injects the context-1m-2025-08-07 beta flag into the upstream anthropic-beta header; the model name sent to the provider is unchanged. Only enable for models that support the 1M context window.",

--- a/internal/typ/id.go
+++ b/internal/typ/id.go
@@ -193,6 +193,40 @@ func GetClientUserAgent(ctx context.Context) string {
 // client, whose Beta/Messages methods add the context-1m beta flag per request.
 const Context1MKey contextKey = "context_1m"
 
+// ClaudeOrgIDKey carries the rule-level claude_org_id override down to the
+// outbound Anthropic client/transport, which sends it as the
+// anthropic-organization-id header instead of the provider's login-time
+// organization.
+const ClaudeOrgIDKey contextKey = "claude_org_id"
+
+// ClaudeOrgIDAuto is the sentinel claude_org_id value that attaches the
+// organization captured at OAuth login
+// (OAuthDetail.ExtraFields["organization_id"]) as anthropic-organization-id.
+// Sending the organization is opt-in: an unset (empty) flag attaches no
+// organization header at all, preserving the classic behavior.
+const ClaudeOrgIDAuto = "auto"
+
+// WithClaudeOrgID attaches the anthropic-organization-id override that the
+// outbound Anthropic client reads at request time. Empty values are not
+// attached (no override).
+func WithClaudeOrgID(ctx context.Context, orgID string) context.Context {
+	if orgID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ClaudeOrgIDKey, orgID)
+}
+
+// GetClaudeOrgID returns the per-request organization-id override, or "" if none.
+func GetClaudeOrgID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if orgID, ok := ctx.Value(ClaudeOrgIDKey).(string); ok {
+		return orgID
+	}
+	return ""
+}
+
 // WithContext1M marks the request as wanting Anthropic's 1M context window.
 func WithContext1M(ctx context.Context) context.Context {
 	return context.WithValue(ctx, Context1MKey, true)

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -256,6 +256,14 @@ type RuleFlags struct {
 	// anthropic-beta header. The model name sent to Anthropic is unchanged —
 	// only the beta header changes behavior.
 	Context1M bool `json:"context_1m,omitempty" yaml:"context_1m,omitempty"`
+
+	// ClaudeOrgID overrides the anthropic-organization-id header sent upstream.
+	// By default the Claude OAuth client attributes requests to the organization
+	// captured at login (OAuthDetail.ExtraFields["organization_id"]), which is
+	// immutable. This flag lets a rule attribute its requests to a different
+	// Anthropic organization on demand (e.g. org-bound entitlements). Empty
+	// means no override — the provider's login-time organization is used.
+	ClaudeOrgID string `json:"claude_org_id,omitempty" yaml:"claude_org_id,omitempty"`
 }
 
 // VisionProxyService identifies the upstream used to describe images for the

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -257,12 +257,13 @@ type RuleFlags struct {
 	// only the beta header changes behavior.
 	Context1M bool `json:"context_1m,omitempty" yaml:"context_1m,omitempty"`
 
-	// ClaudeOrgID overrides the anthropic-organization-id header sent upstream.
-	// By default the Claude OAuth client attributes requests to the organization
-	// captured at login (OAuthDetail.ExtraFields["organization_id"]), which is
-	// immutable. This flag lets a rule attribute its requests to a different
-	// Anthropic organization on demand (e.g. org-bound entitlements). Empty
-	// means no override — the provider's login-time organization is used.
+	// ClaudeOrgID controls the anthropic-organization-id header sent upstream
+	// for Claude OAuth providers. Organization attribution is opt-in: empty
+	// (default) sends no organization header at all. "auto"
+	// (typ.ClaudeOrgIDAuto) sends the organization captured at OAuth login
+	// (OAuthDetail.ExtraFields["organization_id"]), which org-bound
+	// entitlements (e.g. Cyber Verification) rely on. Any other value sends
+	// that organization id verbatim.
 	ClaudeOrgID string `json:"claude_org_id,omitempty" yaml:"claude_org_id,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1462, which started forwarding the OAuth login organization as `anthropic-organization-id` on every Claude OAuth request — a behavior change for all existing setups, and the value is immutable after login. This makes organization attribution an explicit, per-rule choice via a new `claude_org_id` rule flag:

- **unset (empty, default)** — send no organization header, restoring the classic pre-#1462 behavior
- **`auto`** — send the organization captured at OAuth login (needed for org-bound entitlements like Cyber Verification)
- **any other value** — send that organization id verbatim

## Key Changes

- `typ.RuleFlags.ClaudeOrgID` + registry entry (`request_anthropic` category, `Login organization` quick-pick via the `typ.ClaudeOrgIDAuto` sentinel) — registry-driven catalog, no dedicated frontend work needed.
- `ResolveRuleFlagsWithScenario` attaches the flag to the request context, following the existing `context_1m` / `custom_user_agent` hint pattern.
- `NewClaudeClient` resolves the flag when composing `anthropic-organization-id` (constructed per request, so it's correctly request-scoped). Generic Anthropic path is untouched — this is Claude OAuth specific.
- `claudeOrgId` / `claude_org_id` typings in `RoutingGraphTypes.ts`.

## Compatibility Notes

- **Default behavior changes vs #1462**: with the flag unset, Claude OAuth requests no longer carry `anthropic-organization-id`. Rules that need login-org attribution must set `auto`.

## Testing

- Gateway-level `claude_org_id` case on the real Claude OAuth path (pool → `NewClaudeClient`) pins all three states against the captured upstream request.
- `TestClaudeClient_ClaudeOrgID` drives `NewClaudeClient → Guard → SDK → HTTP` against a capturing server across the same matrix.
- `go test ./internal/typ/... ./internal/client/... ./internal/server/ ./internal/protocoltest/` and `go vet ./internal/...` pass.

## Notes

- `openapi.json` intentionally not regenerated — a regen currently pulls in ~500 lines of unrelated drift and breaks the frontend quota typecheck. Needs a separate `task codegen` pass; the flag works without it since rule flags round-trip through `typ.RuleFlags` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UeeNs35PANEu6PpnmyfNM