### PR TITLE
refactor(ui, guiding): Improve routing/tier guide dialogs: reading order, layout polish, EN/ZH copy

### DIFF
--- a/frontend/src/components/nodes/ActionAddNode.tsx
+++ b/frontend/src/components/nodes/ActionAddNode.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import NodeTooltip from './NodeTooltip';
 import { getRouteGraphBorderColor, graphNodeBaseHoverStyles, graphNodeHoverStyles, nodeSpotlightSx, SMALL_NODE_STYLES } from './styles';
 
@@ -81,13 +82,14 @@ export const ActionAddNode: React.FC<AddProviderNodeProps> = ({
     active,
     warning = false,
     onAdd,
-    tooltip = 'Add model',
+    tooltip,
 }) => {
+    const { t } = useTranslation();
     // Pulse when guidance (Quick Start → "Select a Model") points the user here.
     const spotlight = useAddModelSpotlight(active);
 
     return (
-        <NodeTooltip title={tooltip} placement="top">
+        <NodeTooltip title={tooltip ?? t('rule.nodes.addModel', { defaultValue: 'Add model' })} placement="top">
             <StyledAddProviderNode
                 active={active}
                 warning={warning}
@@ -103,7 +105,7 @@ export const ActionAddNode: React.FC<AddProviderNodeProps> = ({
                         fontSize: '0.6rem',
                         lineHeight: 1.1
                     }}>
-                    Add model
+                    {t('rule.nodes.addModel', { defaultValue: 'Add model' })}
                 </Typography>
             </StyledAddProviderNode>
         </NodeTooltip>

--- a/frontend/src/components/tier/EntryGuideDialog.tsx
+++ b/frontend/src/components/tier/EntryGuideDialog.tsx
@@ -204,6 +204,35 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                         py: { xs: 2, sm: 3 },
                         px: { xs: 2, sm: 3 },
                     }}>
+                        {/* Explanation Text */}
+                        <Box sx={{ mb: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
+                            <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
+                                {t(currentStep.content, { defaultValue: currentStep.content })}
+                            </Typography>
+
+                            {/* Annotations */}
+                            {currentStep.annotations && currentStep.annotations.length > 0 && (
+                                <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {currentStep.annotations.map((annotation, idx) => (
+                                        <Paper
+                                            key={idx}
+                                            variant="outlined"
+                                            sx={{
+                                                p: 1.5,
+                                                bgcolor: 'action.hover',
+                                                borderRadius: 1,
+                                                flex: '1 1 45%',
+                                            }}
+                                        >
+                                            <Typography variant="caption" color="primary" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+                                                {t(annotation.text, { defaultValue: annotation.text })}
+                                            </Typography>
+                                        </Paper>
+                                    ))}
+                                </Box>
+                            )}
+                        </Box>
+
                         {/* Static Graph Diagram */}
                         <Box sx={{
                             bgcolor: 'background.default',
@@ -243,35 +272,6 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                             }}>
                                 💡 {t('rule.routing.guide.hoverHint', { defaultValue: 'Action buttons shown - try hovering over nodes!' })}
                             </Box>
-                        </Box>
-
-                        {/* Explanation Text */}
-                        <Box sx={{ mt: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
-                            <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
-                                {t(currentStep.content, { defaultValue: currentStep.content })}
-                            </Typography>
-
-                            {/* Annotations */}
-                            {currentStep.annotations && currentStep.annotations.length > 0 && (
-                                <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                                    {currentStep.annotations.map((annotation, idx) => (
-                                        <Paper
-                                            key={idx}
-                                            variant="outlined"
-                                            sx={{
-                                                p: 1.5,
-                                                bgcolor: 'action.hover',
-                                                borderRadius: 1,
-                                                flex: '1 1 45%',
-                                            }}
-                                        >
-                                            <Typography variant="caption" color="primary" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
-                                                {t(annotation.text, { defaultValue: annotation.text })}
-                                            </Typography>
-                                        </Paper>
-                                    ))}
-                                </Box>
-                            )}
                         </Box>
                     </Box>
                 </Box>

--- a/frontend/src/components/tier/EntryGuideDialog.tsx
+++ b/frontend/src/components/tier/EntryGuideDialog.tsx
@@ -159,17 +159,21 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                 <CloseIcon />
             </IconButton>
             <DialogContent id="entry-guide-dialog-description" dividers sx={{ p: 0 }}>
-                <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%', gap: 2 }}>
-                    {/* Left side: Vertical Stepper */}
+                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, height: '100%' }}>
+                    {/* Left side: step navigation rail */}
                     <Box sx={{
-                        width: { xs: '100%', sm: 220 },
+                        width: { xs: '100%', sm: 240 },
                         py: { xs: 2, sm: 3 },
-                        px: { xs: 2, sm: 1 },
+                        px: { xs: 2, sm: 3 },
                         display: 'flex',
                         flexDirection: { xs: 'row', sm: 'column' },
-                        alignItems: { xs: 'center', sm: 'flex-start' },
+                        alignItems: { xs: 'center', sm: 'stretch' },
                         overflowX: { xs: 'auto', sm: 'visible' },
                         flexShrink: 0,
+                        bgcolor: 'background.default',
+                        borderRight: { xs: 'none', sm: '1px solid' },
+                        borderBottom: { xs: '1px solid', sm: 'none' },
+                        borderColor: { xs: 'divider', sm: 'divider' },
                     }}>
                         <Stepper
                             activeStep={safeActiveStep}
@@ -202,10 +206,10 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                         flexDirection: 'column',
                         minWidth: 0,
                         py: { xs: 2, sm: 3 },
-                        px: { xs: 2, sm: 3 },
+                        px: { xs: 2, sm: 4 },
                     }}>
                         {/* Explanation Text */}
-                        <Box sx={{ mb: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
+                        <Box sx={{ mb: 2.5 }}>
                             <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
                                 {t(currentStep.content, { defaultValue: currentStep.content })}
                             </Typography>

--- a/frontend/src/components/tier/EntryGuideDialog.tsx
+++ b/frontend/src/components/tier/EntryGuideDialog.tsx
@@ -274,7 +274,7 @@ export const EntryGuideDialog: React.FC<EntryGuideDialogProps> = ({
                                 fontSize: '0.75rem',
                                 opacity: 0.8,
                             }}>
-                                💡 {t('rule.routing.guide.hoverHint', { defaultValue: 'Action buttons shown - try hovering over nodes!' })}
+                                💡 {t('rule.routing.guide.hoverHint', { defaultValue: 'Hover over a node in the diagram to see its actions' })}
                             </Box>
                         </Box>
                     </Box>

--- a/frontend/src/components/tier/StaticGraphViewer.tsx
+++ b/frontend/src/components/tier/StaticGraphViewer.tsx
@@ -1,5 +1,6 @@
 import { Box, type SxProps } from '@mui/material';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { UnifiedRoutingGraph } from '@/components/UnifiedRoutingGraph';
 import type { ConfigRecord } from '@/components/RoutingGraphTypes';
 import type { Provider } from '@/types/provider';
@@ -25,8 +26,26 @@ export const StaticGraphViewer: React.FC<StaticGraphViewerProps> = ({
     sx,
     ...props
 }) => {
+    const { t } = useTranslation();
     const diagramData = TIER_DIAGRAM_DATA[scenario];
-    if (!diagramData) {
+
+    // The demo records carry English descriptions as authoring defaults; look
+    // them up per scenario so the diagrams read localized like the rest of
+    // the guide (falling back to the authored English text).
+    const record = React.useMemo<ConfigRecord | undefined>(() => {
+        if (!diagramData) return undefined;
+        const base = diagramData.record;
+        return {
+            ...base,
+            description: t(`rule.guideDiagrams.${scenario}.description`, { defaultValue: base.description }),
+            smartRouting: base.smartRouting?.map((rule, i) => ({
+                ...rule,
+                description: t(`rule.guideDiagrams.${scenario}.smart.${i}`, { defaultValue: rule.description }),
+            })),
+        };
+    }, [diagramData, scenario, t]);
+
+    if (!diagramData || !record) {
         return (
             <Box sx={{ textAlign: 'center', color: 'text.secondary', ...sx }} {...props}>
                 Diagram not found: {scenario}
@@ -35,7 +54,6 @@ export const StaticGraphViewer: React.FC<StaticGraphViewerProps> = ({
     }
 
     const {
-        record,
         providers,
         active = true,
     } = diagramData;

--- a/frontend/src/components/tier/TierGuideDialog.tsx
+++ b/frontend/src/components/tier/TierGuideDialog.tsx
@@ -186,6 +186,35 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                         py: { xs: 2, sm: 3 },
                         px: { xs: 2, sm: 3 },
                     }}>
+                        {/* Explanation Text */}
+                        <Box sx={{ mb: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
+                            <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
+                                {t(currentStep.content, { defaultValue: currentStep.content })}
+                            </Typography>
+
+                            {/* Annotations */}
+                            {currentStep.annotations && currentStep.annotations.length > 0 && (
+                                <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {currentStep.annotations.map((annotation, idx) => (
+                                        <Paper
+                                            key={idx}
+                                            variant="outlined"
+                                            sx={{
+                                                p: 1.5,
+                                                bgcolor: 'action.hover',
+                                                borderRadius: 1,
+                                                flex: '1 1 45%',
+                                            }}
+                                        >
+                                            <Typography variant="caption" color="primary" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+                                                {t(annotation.text, { defaultValue: annotation.text })}
+                                            </Typography>
+                                        </Paper>
+                                    ))}
+                                </Box>
+                            )}
+                        </Box>
+
                         {/* Static Graph Diagram */}
                         <Box sx={{
                             bgcolor: 'background.default',
@@ -222,35 +251,6 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                             }}>
                                 💡 {t('rule.tier.guide.hoverHint', { defaultValue: 'Action buttons shown - try hovering over nodes!' })}
                             </Box>
-                        </Box>
-
-                        {/* Explanation Text */}
-                        <Box sx={{ mt: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
-                            <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
-                                {t(currentStep.content, { defaultValue: currentStep.content })}
-                            </Typography>
-
-                            {/* Annotations */}
-                            {currentStep.annotations && currentStep.annotations.length > 0 && (
-                                <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                                    {currentStep.annotations.map((annotation, idx) => (
-                                        <Paper
-                                            key={idx}
-                                            variant="outlined"
-                                            sx={{
-                                                p: 1.5,
-                                                bgcolor: 'action.hover',
-                                                borderRadius: 1,
-                                                flex: '1 1 45%',
-                                            }}
-                                        >
-                                            <Typography variant="caption" color="primary" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
-                                                {t(annotation.text, { defaultValue: annotation.text })}
-                                            </Typography>
-                                        </Paper>
-                                    ))}
-                                </Box>
-                            )}
                         </Box>
                     </Box>
                 </Box>

--- a/frontend/src/components/tier/TierGuideDialog.tsx
+++ b/frontend/src/components/tier/TierGuideDialog.tsx
@@ -253,7 +253,7 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                                 fontSize: '0.75rem',
                                 opacity: 0.8,
                             }}>
-                                💡 {t('rule.tier.guide.hoverHint', { defaultValue: 'Action buttons shown - try hovering over nodes!' })}
+                                💡 {t('rule.tier.guide.hoverHint', { defaultValue: 'Hover over a node in the diagram to see its actions' })}
                             </Box>
                         </Box>
                     </Box>

--- a/frontend/src/components/tier/TierGuideDialog.tsx
+++ b/frontend/src/components/tier/TierGuideDialog.tsx
@@ -141,17 +141,21 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                 <CloseIcon />
             </IconButton>
             <DialogContent id="tier-guide-dialog-description" dividers sx={{ p: 0 }}>
-                <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%', gap: 2 }}>
-                    {/* Left side: Vertical Stepper */}
+                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, height: '100%' }}>
+                    {/* Left side: step navigation rail */}
                     <Box sx={{
-                        width: { xs: '100%', sm: 220 },
+                        width: { xs: '100%', sm: 240 },
                         py: { xs: 2, sm: 3 },
-                        px: { xs: 2, sm: 1 },
+                        px: { xs: 2, sm: 3 },
                         display: 'flex',
                         flexDirection: { xs: 'row', sm: 'column' },
-                        alignItems: { xs: 'center', sm: 'flex-start' },
+                        alignItems: { xs: 'center', sm: 'stretch' },
                         overflowX: { xs: 'auto', sm: 'visible' },
                         flexShrink: 0,
+                        bgcolor: 'background.default',
+                        borderRight: { xs: 'none', sm: '1px solid' },
+                        borderBottom: { xs: '1px solid', sm: 'none' },
+                        borderColor: { xs: 'divider', sm: 'divider' },
                     }}>
                         <Stepper
                             activeStep={activeStep}
@@ -184,10 +188,10 @@ export const TierGuideDialog: React.FC<TierGuideDialogProps> = ({
                         flexDirection: 'column',
                         minWidth: 0,
                         py: { xs: 2, sm: 3 },
-                        px: { xs: 2, sm: 3 },
+                        px: { xs: 2, sm: 4 },
                     }}>
                         {/* Explanation Text */}
-                        <Box sx={{ mb: 2, p: { xs: 2, sm: 3 }, bgcolor: 'background.default', borderRadius: 1 }}>
+                        <Box sx={{ mb: 2.5 }}>
                             <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
                                 {t(currentStep.content, { defaultValue: currentStep.content })}
                             </Typography>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -464,7 +464,7 @@ export default {
         "close": "Close",
         "firstRunHint": "💡 You just added your second provider. Configure tiers to set up primary and fallback routing!",
         "dontShowAgain": "Don't show this again",
-        "hoverHint": "Action buttons shown - try hovering over nodes!",
+        "hoverHint": "Hover over a node in the diagram to see its actions",
         "steps": {
           "1": {
             "title": "What is a Tier?",
@@ -526,12 +526,12 @@ export default {
         "next": "Next",
         "gotIt": "Got it!",
         "close": "Close",
-        "hoverHint": "Action buttons shown - try hovering over nodes!",
+        "hoverHint": "Hover over a node in the diagram to see its actions",
         "toolbarLabel": "Page toolbar",
         "clickHere": "Click here",
         "steps": {
           "connectAI": {
-            "title": "1. Connect an AI provider",
+            "title": "Connect an AI provider",
             "content": "Routing needs at least one AI service to forward to. Use Connect AI in the page toolbar to add a provider — paste an API key, sign in with OAuth, or point at a self-hosted server. Until you do, a rule has nothing to route to.",
             "annotation": {
               "toolbar": "Connect AI lives in the page toolbar",
@@ -539,7 +539,7 @@ export default {
             }
           },
           "addModel": {
-            "title": "2. Add your first model",
+            "title": "Add your first model",
             "content": "Each rule maps a request model to one or more models. In an empty rule, click ＋ Add model to pick a connected provider and a model. Need a separate rule for a different request model? Use New Rule in the toolbar.",
             "annotation": {
               "addModel": "＋ Add model — pick provider + model",
@@ -547,7 +547,7 @@ export default {
             }
           },
           "editModel": {
-            "title": "3. Change or remove a model",
+            "title": "Change or remove a model",
             "content": "Click any model card to edit it — swap to a different model, switch the provider, or move it to another tier. Hover the card to reveal its actions; the trash icon removes it from the rule.",
             "annotation": {
               "click": "Click a card to edit / swap the model",
@@ -555,7 +555,7 @@ export default {
             }
           },
           "loadBalance": {
-            "title": "4. Load balancing within a tier",
+            "title": "Load balancing within a tier",
             "content": "When several models share the same tier (T0), incoming traffic is spread evenly across them. This balances load and prevents any single model from being overwhelmed.",
             "annotation": {
               "sameTier": "Same tier = load balanced",
@@ -563,7 +563,7 @@ export default {
             }
           },
           "tierFallback": {
-            "title": "5. Tier-based fallback chain",
+            "title": "Tier-based fallback chain",
             "content": "Lower tiers are tried first: T0 is primary, and if every T0 model fails, traffic cascades to T1, then T2, and so on. Use the up/down actions on a card to move it between tiers and build a failover chain.",
             "annotation": {
               "primary": "T0 — primary (tried first)",
@@ -596,6 +596,31 @@ export default {
             }
           }
         }
+      }
+    },
+    "nodes": {
+      "addModel": "Add model"
+    },
+    "guideDiagrams": {
+      "empty": { "description": "Example rule" },
+      "single-provider": { "description": "Single provider rule" },
+      "two-providers-same-tier": { "description": "Load balancing example" },
+      "two-providers-different-tiers": { "description": "Primary and fallback example" },
+      "three-tiers": { "description": "Multi-tier fallback example" },
+      "runtime-failover": { "description": "Failover scenario" },
+      "direct-single": { "description": "Direct routing with single provider" },
+      "direct-multiple-tiers": { "description": "Direct routing with multiple tiers" },
+      "smart-basic": {
+        "description": "Smart routing with basic conditions",
+        "smart": { "0": "Route Claude requests to Anthropic" }
+      },
+      "smart-conditions": {
+        "description": "Smart routing with multiple conditions",
+        "smart": { "0": "Route Claude requests to Anthropic", "1": "Route large token requests to Azure" }
+      },
+      "smart-complex": {
+        "description": "Smart routing with complex conditions",
+        "smart": { "0": "Route Claude requests to Anthropic", "1": "Route large token requests to Azure", "2": "Route @@@ds commands to DeepSeek" }
       }
     },
     "menu": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -466,7 +466,7 @@ export default {
         "close": "关闭",
         "firstRunHint": "💡 您刚刚添加了第二个提供商。配置层级以设置主备路由！",
         "dontShowAgain": "不再显示",
-        "hoverHint": "操作按钮已显示 - 尝试悬停节点查看！",
+        "hoverHint": "悬停示意图中的节点可查看操作按钮",
         "steps": {
           "1": {
             "title": "什么是层级？",
@@ -528,61 +528,61 @@ export default {
         "next": "下一步",
         "gotIt": "明白了！",
         "close": "关闭",
-        "hoverHint": "操作按钮已显示 - 尝试悬停节点查看！",
+        "hoverHint": "悬停示意图中的节点可查看操作按钮",
         "toolbarLabel": "页面工具栏",
         "clickHere": "点这里",
         "steps": {
           "connectAI": {
-            "title": "1. 连接一个 AI 提供商",
-            "content": "路由需要至少一个可转发的 AI 服务。点击页面工具栏的「Connect AI」添加提供商——粘贴 API 密钥、用 OAuth 登录，或指向自托管服务器。在此之前，规则没有可路由的目标。",
+            "title": "连接 AI 提供商",
+            "content": "路由至少需要一个可转发的 AI 服务。点击页面工具栏的「连接 AI」添加提供商——可粘贴 API 密钥、通过 OAuth 登录，或指向自托管服务器。在此之前，规则没有可路由的目标。",
             "annotation": {
-              "toolbar": "Connect AI 在页面工具栏",
+              "toolbar": "「连接 AI」在页面工具栏中",
               "empty": "空规则还没有模型"
             }
           },
           "addModel": {
-            "title": "2. 添加第一个模型",
-            "content": "每条规则把一个请求模型映射到一个或多个模型。在空规则里点击「＋ 添加模型」，选择已连接的提供商和模型。需要为另一个请求模型单独建一条规则？用工具栏的「New Rule」。",
+            "title": "添加第一个模型",
+            "content": "每条规则将一个请求模型映射到一个或多个模型。在空规则中点击「＋ 添加模型」，选择已连接的提供商和模型。需要为其他请求模型单独建规则？使用工具栏的「新建规则」。",
             "annotation": {
-              "addModel": "＋ 添加模型——选提供商 + 模型",
-              "newRule": "New Rule 新增一条请求模型映射"
+              "addModel": "「＋ 添加模型」——选择提供商和模型",
+              "newRule": "「新建规则」新增一条请求模型映射"
             }
           },
           "editModel": {
-            "title": "3. 更换或移除模型",
-            "content": "点击任意模型卡片即可编辑——换成别的模型、切换提供商，或移动到其他层级。悬停卡片会显示操作按钮；垃圾桶图标可把它从规则中移除。",
+            "title": "更换或移除模型",
+            "content": "点击任意模型卡片即可编辑——换成其他模型、切换提供商，或移动到其他层级。悬停卡片会显示操作按钮；点击垃圾桶图标可将其从规则中移除。",
             "annotation": {
-              "click": "点击卡片编辑 / 换模型",
-              "remove": "悬停 → 垃圾桶图标移除"
+              "click": "点击卡片编辑或更换模型",
+              "remove": "悬停后点垃圾桶图标移除"
             }
           },
           "loadBalance": {
-            "title": "4. 层级内负载均衡",
-            "content": "当多个模型处于同一层级（T0）时，传入流量会在它们之间均匀分配，从而平衡负载、避免任何单个模型过载。",
+            "title": "层级内负载均衡",
+            "content": "当多个模型处于同一层级（如 T0）时，传入流量会在它们之间均匀分配，从而平衡负载、避免单个模型过载。",
             "annotation": {
               "sameTier": "同一层级 = 负载均衡",
-              "services": "多个模型共享流量"
+              "services": "多个模型分摊流量"
             }
           },
           "tierFallback": {
-            "title": "5. 基于层级的故障转移链",
-            "content": "层级越低越先尝试：T0 是主选，若所有 T0 模型都失败，流量会级联到 T1，再到 T2，依此类推。用卡片上的上/下操作在层级间移动它，搭建故障转移链。",
+            "title": "层级故障转移链",
+            "content": "层级编号越小越先尝试：T0 是首选；当 T0 的所有模型都失败时，流量会依次级联到 T1、T2……使用卡片上的 ↑/↓ 按钮在层级间移动模型，即可搭建故障转移链。",
             "annotation": {
               "primary": "T0 — 主模型（首先尝试）",
-              "fallback": "T1 — 备选模型（T0 失败时使用）"
+              "fallback": "T1 — 备选模型（T0 失败时启用）"
             }
           },
           "smartIntro": {
             "title": "什么是智能路由？",
-            "content": "智能路由让你定义自定义条件来控制哪个模型处理每个请求。可按模型名称、令牌数量、用户组或任意请求参数路由——精细控制，无需管理复杂的层级配置。",
+            "content": "智能路由让您通过自定义条件控制每个请求由哪个模型处理。可按模型名称、令牌数量、用户组或任意请求参数路由——无需管理复杂的层级配置即可实现精细控制。",
             "annotation": {
-              "smartButton": "用入口开关切换到 Smart",
+              "smartButton": "通过入口的模式开关切换到智能路由",
               "conditional": "基于规则的条件路由"
             }
           },
           "smartConditions": {
             "title": "智能路由条件",
-            "content": "每个智能规则都有一个决定何时生效的条件——例如模型名称「包含 claude」，或令牌数量「大于 4000」用于大上下文。规则自上而下评估，第一个匹配的获胜。",
+            "content": "每条智能规则都有一个决定其何时生效的条件——例如模型名称「包含 claude」，或令牌数量「大于 4000」（用于大上下文）。规则自上而下依次匹配，命中的第一条生效。",
             "annotation": {
               "modelBased": "按模型名称路由",
               "tokenBased": "按令牌数量路由"
@@ -590,14 +590,39 @@ export default {
           },
           "smartAdvanced": {
             "title": "高级智能路由",
-            "content": "把多个智能规则叠加成更丰富的策略：Claude 请求走一条路、大上下文走另一条、高级用户走第三条。不匹配任何规则的请求会落到默认服务。",
+            "content": "将多条智能规则组合成更丰富的策略：Claude 请求走一条路径、大上下文走另一条、高级用户走第三条。未命中任何规则的请求会落入默认服务。",
             "annotation": {
-              "defaultRoute": "不匹配请求的默认路由",
+              "defaultRoute": "未命中请求的默认路由",
               "claudeRoute": "Claude 模型的路由",
               "largeContext": "大上下文窗口的路由"
             }
           }
         }
+      }
+    },
+    "nodes": {
+      "addModel": "添加模型"
+    },
+    "guideDiagrams": {
+      "empty": { "description": "示例规则" },
+      "single-provider": { "description": "单提供商规则" },
+      "two-providers-same-tier": { "description": "负载均衡示例" },
+      "two-providers-different-tiers": { "description": "主备路由示例" },
+      "three-tiers": { "description": "多层级故障转移示例" },
+      "runtime-failover": { "description": "故障转移场景" },
+      "direct-single": { "description": "单提供商直接路由" },
+      "direct-multiple-tiers": { "description": "多层级直接路由" },
+      "smart-basic": {
+        "description": "基础条件智能路由",
+        "smart": { "0": "将 Claude 请求路由到 Anthropic" }
+      },
+      "smart-conditions": {
+        "description": "多条件智能路由",
+        "smart": { "0": "将 Claude 请求路由到 Anthropic", "1": "将大令牌请求路由到 Azure" }
+      },
+      "smart-complex": {
+        "description": "复杂条件智能路由",
+        "smart": { "0": "将 Claude 请求路由到 Anthropic", "1": "将大令牌请求路由到 Azure", "2": "将 @@@ds 命令路由到 DeepSeek" }
       }
     },
     "menu": {


### PR DESCRIPTION
## Summary

Three rounds of improvements to the routing guide dialogs (`EntryGuideDialog` for Direct/Smart routing, `TierGuideDialog` for tiers):

### Reading order
Each step showed the diagram first with the explanation below it, which reads backwards for a guide. Steps now lead with the explanation text, followed by the diagram.

### Layout polish
- The step list sat almost flush against the dialog's left edge (8px padding, misaligned with the 24px title inset). The stepper column is now a proper navigation rail: padding aligned with the title, subtle background fill, and a divider separating it from the content area (border-bottom on mobile where it flows horizontally).
- Dropped the gray box around the explanation text — plain text on the dialog surface leaves the diagram card as the single framed element, reducing visual noise.

### EN/ZH copy
- Removed the "1. 2. 3." prefixes from step titles — the stepper rail already numbers the steps, so titles were double-numbered.
- Chinese guide text referred to toolbar buttons by their English names ("Connect AI", "New Rule") while the zh UI renders 「连接 AI」/「新建规则」 — instructions now match the actual buttons.
- Localized diagram mock data: the hard-coded "Add model" node label now goes through `rule.nodes.addModel`, and demo rule / smart-rule descriptions resolve through `rule.guideDiagrams.*` per scenario (falling back to the authored English).
- Rewrote the hover hint into a plain tip in both languages, smoothed awkward zh phrasing (第一个匹配的获胜 → 命中的第一条生效, etc.), and unified pronouns to 您.

## Screenshots

Verified via headless-Chrome screenshots in mock mode, in both English and Chinese: text-above-diagram order, sidebar rail alignment, and zh diagrams now showing 「连接 AI」/「新建规则」/「添加模型」/「示例规则」consistent with the guide copy.

## Testing

- `tsc --noEmit`: no errors in the touched files (remaining errors are pre-existing, from the generated client schema not present in this environment).
- Visual verification of guide steps in both locales via the ui-preview flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD6Ma4mZdBCSp4ePrTMpu3