### PR TITLE
feat(dashboard): surface response performance percentiles

### DIFF
--- a/.design/dashboard.md
+++ b/.design/dashboard.md
@@ -36,7 +36,7 @@ Three global filters apply to the stat cards, chart, request view, activity heat
 The main analysis pane has three modes:
 
 - **Summary** — stacked token trend.
-- **By Request** — request sample, breakdown charts, and request table; only available for `today` and `yesterday`.
+- **By Request** — paginated request table for concrete diagnosis; only available for `today` and `yesterday`.
 - **Activity** — fixed 365-day heatmap.
 
 If a stale `requests` selection survives a route change into a daily range, `effectiveViewMode` renders Summary instead.
@@ -102,13 +102,14 @@ Vocabulary is deliberate:
 
 ## API contract
 
-Three gzip-compressed JSON endpoints live under `/api/v1/usage/`:
+Four gzip-compressed JSON endpoints live under `/api/v1/usage/`:
 
 | Endpoint | Main consumers | Important parameters |
 |---|---|---|
 | `/stats` | Dashboard cards/model table; Team user/model tables | `group_by=model\|provider\|scenario\|rule\|user\|daily\|hourly`, time bounds, provider/model/scenario/rule/user/status filters, sort, limit ≤ 1000 |
 | `/timeseries` | Dashboard Summary and Activity | `interval=minute\|hour\|day\|week`, time bounds, provider/model/scenario/user filters |
 | `/records` | Dashboard By Request | time bounds, provider/model/scenario/user/status filters, `limit` ≤ 1000, `offset` |
+| `/performance` | Dashboard Summary | time bounds and provider/model/scenario/user filters; successful requests only |
 
 The stats response is `{ meta, data }`; `data` contains additive counts plus derived rates. The records response uses `meta: { total, limit, offset }` for the real filtered range.
 
@@ -122,7 +123,8 @@ Usage Dashboard:
 
 - `/stats`, `group_by=model`, `limit=1000`.
 - `/timeseries`, with minute or day interval.
-- `/records`, initially limited to the most recent 500.
+- `/records`, initially limited to the most recent 500 when By Request is opened.
+- `/performance`, for the complete filtered range while Summary is visible.
 - `getProviders` and `listAPITokens` for filter metadata.
 
 Team Usage:
@@ -137,7 +139,7 @@ The Team table intentionally starts from registered tokens, then left-joins usag
 
 The frontend transport uses the generated OpenAPI client, while dashboard view components keep small local interfaces (`AggregatedStat`, `TimeSeriesData`, `UsageRecord`) for rendering.
 
-The runtime handlers accept `user_id` for `/timeseries` and `/records`, and the frontend sends it. At the time of writing, those two query parameters are not declared in `TimeSeriesQuery` / `UsageRecordsQuery` and their Swagger route configuration, so `api.ts` uses a cast around the generated query type. If the usage API contract is touched, add the missing Swagger query definitions and run `task codegen`; do not hand-edit `openapi.json` or `frontend/src/client/schema.d.ts`.
+The runtime handlers and Swagger contract accept `user_id` consistently for `/timeseries`, `/records`, and `/performance`. Contract changes start from the backend model and route configuration, followed by `task codegen`; do not hand-edit `openapi.json` or `frontend/src/client/schema.d.ts`.
 
 ## Backend query and aggregation path
 
@@ -218,6 +220,16 @@ Cards show:
 
 The stack order is Cache Read → Input → Output. Cache Write is carried in each data point for tooltips but is never rendered as a fourth series.
 
+Response Performance also lives in Summary because it describes the selected range as a whole rather than an individual request. It comes from `/performance` and excludes failed requests. When the viewport can preserve a readable chart (1280px and wider), it shares one analysis row with the token trend: Response Performance acts as a compact fixed-width index (320px) on the left, while the trend receives the remaining width on the right. Narrower screens stack the two cards in that same order. This keeps percentile summary and time-series detail at the same information level without dedicating a separate full row to either one:
+
+- **TTFT** — P10/P50/P90/P95/P99 over streamed requests with a first content token.
+- **TPS** — per-request output throughput, derived as `(output_tokens - 1) / ((latency_ms - ttft_ms) / 1000)`, the inverse of TPOT. The first token belongs to TTFT, so N output tokens contain N−1 decode intervals. The API returns P10/P50/P90/P95/P99; the UI emphasizes P10 through P95 and intentionally hides TPS P99. This is not aggregate server throughput across concurrent requests.
+- **Latency** — P10/P50/P90/P95/P99 over successful requests with a positive latency.
+
+Percentile rows descend top-to-bottom as P99 → P95 → P90 → P50 → P10; metric columns run left-to-right as TTFT → TPS → Latency. This transposed matrix keeps the performance card narrow while preserving globally aligned comparisons. The backend calculates all five percentiles for every metric, but the frontend intentionally hides TPS P99 because the fastest 1% is easily dominated by short-request timing artifacts and has little operational value; TPS P95 remains the stable upper-tail reference. TTFT and Latency retain P99. All values have equal visual weight and use the same type scale. TPS values omit a repeated unit because the metric name already defines it.
+
+The frontend treats absent or non-finite percentile fields as unavailable (`—`) so a rolling upgrade against an older backend schema does not crash the dashboard while P95 is being introduced.
+
 ### By Request
 
 The dashboard first loads the most recent 500 records plus `meta.total`.
@@ -225,7 +237,7 @@ The dashboard first loads the most recent 500 records plus `meta.total`.
 - If `total ≤ 500`, status filtering and pagination remain client-side.
 - If `total > 500`, the table switches to server paging and pushes status, limit, and offset into SQL.
 
-The charts always describe the 500-record sample. When the range is larger, a caption explicitly says that the charts reflect the most recent N of M requests.
+By Request intentionally contains only the paginated request table. Token Breakdown was removed because its input/output/cache totals duplicate the stat cards, summary trend, and request columns. The request table exposes derived TPS per row for concrete diagnosis.
 
 The page resets request pagination when filters or the range start change, but not when auto-refresh only advances the range end.
 

--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -364,6 +364,15 @@ func (sr *streamRecorder) Finish(model string, usage *protocol.TokenUsage)
 
 `MetricsData`：`InputTokens / OutputTokens / LatencyMs / TTFTMs / CacheHit / TPS`。
 
+TPS 只对有首内容 token 时间的流式请求成立，口径是首 token 之后的 decode speed，也就是 TPOT 的倒数：
+
+```text
+TPS = (output_tokens - 1) / (completion_time - first_token_time)
+    = (output_tokens - 1) * 1000 / (latency_ms - ttft_ms)
+```
+
+首 token 已计入 TTFT，因此 N 个输出 token 只有 N−1 个 decode interval。非流式请求、`output_tokens <= 1`、缺少首 token 时间，或 `latency_ms <= ttft_ms` 时 TPS 为 0，不进入 Dashboard TPS 分位数。Dashboard 展示的是逐请求 TPS 的分布，不是并发请求叠加后的服务总吞吐。
+
 ### 5.2 `trackUsageFromContext(c, inputTokens, outputTokens, err)` —— 旧式 2-int 入口
 
 只有 input/output 的简化路径（cache/reasoning/system 会丢）。新代码尽量用 §5.1。

--- a/frontend/src/components/dashboard/PerformanceSummary.tsx
+++ b/frontend/src/components/dashboard/PerformanceSummary.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+import { Box, CircularProgress, Paper, Typography } from '@mui/material';
+import api from '@/services/api';
+
+interface MetricPercentiles {
+    sample_count: number;
+    p10?: number;
+    p50?: number;
+    p90?: number;
+    p95?: number;
+    p99?: number;
+}
+
+interface PerformanceSummaryData {
+    ttft: MetricPercentiles;
+    tps: MetricPercentiles;
+    completion: MetricPercentiles;
+}
+
+export interface PerformanceQueryParams {
+    start_time: string;
+    end_time: string;
+    provider: string;
+    model: string;
+    user: string;
+}
+
+const fmtLatency = (ms: number) => {
+    if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${ms}ms`;
+};
+
+type PercentileKey = 'p99' | 'p95' | 'p90' | 'p50' | 'p10';
+
+const PERCENTILES: Array<{ key: PercentileKey; label: string }> = [
+    { key: 'p99', label: 'P99' },
+    { key: 'p95', label: 'P95' },
+    { key: 'p90', label: 'P90' },
+    { key: 'p50', label: 'P50' },
+    { key: 'p10', label: 'P10' },
+];
+
+function formatMetricValue(metric: MetricPercentiles | undefined, kind: 'latency' | 'tps', percentile: PercentileKey) {
+    if (!metric?.sample_count) return '—';
+    if (kind === 'tps' && percentile === 'p99') return '—';
+    const value = metric[percentile];
+    if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+    return kind === 'tps'
+        ? value.toFixed(1)
+        : fmtLatency(Math.round(value));
+}
+
+export default function PerformanceSummary({ queryParams }: { queryParams: PerformanceQueryParams | null }) {
+    const [data, setData] = useState<PerformanceSummaryData | null>(null);
+    const [loading, setLoading] = useState(false);
+    const requestSeq = useRef(0);
+
+    useEffect(() => {
+        if (!queryParams) return;
+        const seq = ++requestSeq.current;
+        setLoading(true);
+        setData(null);
+        (async () => {
+            try {
+                const filters: Record<string, string> = {
+                    start_time: queryParams.start_time,
+                    end_time: queryParams.end_time,
+                };
+                if (queryParams.provider !== 'all') filters.provider = queryParams.provider;
+                if (queryParams.model !== 'all') filters.model = queryParams.model;
+                if (queryParams.user !== 'all') filters.user_id = queryParams.user;
+                const result = await api.getUsagePerformance(filters);
+                if (seq === requestSeq.current && result?.ttft) setData(result);
+            } catch (error) {
+                console.error('Failed to load performance summary:', error);
+            } finally {
+                if (seq === requestSeq.current) setLoading(false);
+            }
+        })();
+    }, [queryParams]);
+
+    const metrics = [
+        { key: 'ttft', title: 'TTFT', metric: data?.ttft, kind: 'latency' as const },
+        { key: 'tps', title: 'TPS', metric: data?.tps, kind: 'tps' as const },
+        { key: 'latency', title: 'Latency', metric: data?.completion, kind: 'latency' as const },
+    ];
+
+    return (
+        <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, backgroundColor: 'background.paper', boxShadow: 'none', overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+            <Box sx={{ px: 2.25, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Typography sx={{ fontWeight: 600, fontSize: '0.875rem' }}>Response Performance</Typography>
+                {loading && <CircularProgress size={18} />}
+            </Box>
+            <Box sx={{ px: 2.25, pb: 1, display: 'grid', gridTemplateColumns: '52px repeat(3, minmax(0, 1fr))', columnGap: 1 }}>
+                <Box />
+                {metrics.map(({ key, title, metric }) => (
+                    <Box key={key} sx={{ minWidth: 0 }}>
+                        <Typography sx={{ fontWeight: 600, fontSize: '0.76rem' }}>{title}</Typography>
+                        <Typography sx={{ color: 'text.disabled', fontSize: '0.6rem', mt: 0.2 }}>
+                            n={metric?.sample_count.toLocaleString() ?? 0}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', '& > * + *': { borderTop: '1px solid', borderColor: 'divider' } }}>
+                {PERCENTILES.map(({ key, label }) => (
+                    <Box key={key} sx={{ px: 2.25, py: 1.25, minWidth: 0, flex: 1, display: 'grid', gridTemplateColumns: '52px repeat(3, minmax(0, 1fr))', alignItems: 'center', columnGap: 1 }}>
+                        <Typography sx={{ color: 'text.secondary', fontSize: '0.68rem', fontWeight: 600 }}>{label}</Typography>
+                        {metrics.map((metric) => {
+                            const value = formatMetricValue(metric.metric, metric.kind, key);
+                            return (
+                                <Typography key={metric.key} sx={{ color: value === '—' ? 'text.disabled' : 'text.primary', fontWeight: 650, fontSize: '0.86rem', whiteSpace: 'nowrap' }}>
+                                    {value}
+                                </Typography>
+                            );
+                        })}
+                    </Box>
+                ))}
+            </Box>
+        </Paper>
+    );
+}

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -17,20 +17,8 @@ import {
     CircularProgress,
     useTheme,
 } from '@mui/material';
-import {
-    PieChart,
-    Pie,
-    Cell,
-    BarChart,
-    Bar,
-    XAxis,
-    YAxis,
-    CartesianGrid,
-    Tooltip as ReTooltip,
-    ResponsiveContainer,
-} from 'recharts';
 import { WaveSine as StreamIcon } from '@/components/icons';
-import { getThemeChartStyles, TOKEN_COLORS, formatNumber, hasCacheWrites } from './chartStyles';
+import { TOKEN_COLORS, formatNumber, hasCacheWrites } from './chartStyles';
 import api from '@/services/api';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -54,22 +42,14 @@ export interface UsageRecord {
     error_code?: string;
     latency_ms: number;
     ttft_ms?: number;
+    tokens_per_second?: number;
     streamed: boolean;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const SUCCESS_COLOR = '#10B981';
-const ERROR_COLOR  = '#EF4444';
-
-const LATENCY_BUCKETS = [
-    { label: '<0.2s',   min: 0,    max: 200  },
-    { label: '0.2-0.5', min: 200,  max: 500  },
-    { label: '0.5-1s',  min: 500,  max: 1000 },
-    { label: '1-2s',    min: 1000, max: 2000 },
-    { label: '2-5s',    min: 2000, max: 5000 },
-    { label: '>5s',     min: 5000, max: Infinity },
-];
+const ERROR_COLOR = '#EF4444';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -80,192 +60,22 @@ const fmtLatency = (ms: number) => {
     return `${ms}ms`;
 };
 
+const getTokensPerSecond = (record: UsageRecord) => {
+    if (!record.streamed) return 0;
+    if ((record.tokens_per_second ?? 0) > 0) return record.tokens_per_second!;
+    const decodeMs = record.latency_ms - (record.ttft_ms ?? 0);
+    if (record.output_tokens <= 1 || (record.ttft_ms ?? 0) <= 0 || decodeMs <= 0) return 0;
+    return (record.output_tokens - 1) * 1000 / decodeMs;
+};
+
+const getTPSFormula = (record: UsageRecord) => {
+    const decodeMs = record.latency_ms - (record.ttft_ms ?? 0);
+    if (getTokensPerSecond(record) <= 0) return '';
+    return `${record.output_tokens - 1} decode intervals / ${decodeMs}ms after TTFT`;
+};
+
 const fmtTime = (ts: string) =>
     new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-
-// ─── Token Donut ─────────────────────────────────────────────────────────────
-
-function DonutTooltip({ active, payload }: any) {
-    const theme = useTheme();
-    if (!active || !payload?.length) return null;
-    const d = payload[0].payload;
-    return (
-        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.25, boxShadow: theme.shadows[4] }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: d.color, flexShrink: 0 }} />
-                <Typography sx={{ fontSize: '0.75rem', fontWeight: 600 }}>{d.name}</Typography>
-            </Box>
-            <Typography sx={{ fontSize: '0.72rem', color: 'text.secondary', mt: 0.25 }}>
-                {fmtTokens(d.value)} ({d.pct}%)
-            </Typography>
-        </Box>
-    );
-}
-
-function TokenDonut({ records }: { records: UsageRecord[] }) {
-    const totalInput  = records.reduce((s, r) => s + r.input_tokens, 0);
-    const totalOutput = records.reduce((s, r) => s + r.output_tokens, 0);
-    const totalCache  = records.reduce((s, r) => s + r.cache_read_tokens, 0);
-    // Cache writes live INSIDE input_tokens, so they must not become a fourth
-    // slice — that would inflate the total by counting them twice. They annotate
-    // the Input slice instead.
-    const totalCacheWrite = records.reduce((s, r) => s + (r.cache_write_tokens || 0), 0);
-    const total = totalInput + totalOutput + totalCache;
-
-    const pieData = [
-        { name: 'Input',  value: totalInput,  color: TOKEN_COLORS.input.main,  pct: total > 0 ? ((totalInput  / total) * 100).toFixed(1) : '0',
-          note: totalCacheWrite > 0 ? `incl. ${fmtTokens(totalCacheWrite)} written` : '' },
-        { name: 'Output', value: totalOutput, color: TOKEN_COLORS.output.main, pct: total > 0 ? ((totalOutput / total) * 100).toFixed(1) : '0', note: '' },
-        { name: 'Cache Read', value: totalCache, color: TOKEN_COLORS.cache.main, pct: total > 0 ? ((totalCache / total) * 100).toFixed(1) : '0', note: '' },
-    ].filter(d => d.value > 0);
-
-    return (
-        <Paper elevation={0} sx={{ p: 2.5, border: '1px solid', borderColor: 'divider', borderRadius: 2, backgroundColor: 'background.paper', boxShadow: 'none' }}>
-            <Typography sx={{ fontWeight: 600, fontSize: '0.875rem', mb: 2 }}>Token Breakdown</Typography>
-            {total === 0 ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 140 }}>
-                    <Typography variant="caption" sx={{
-                        color: "text.disabled"
-                    }}>No data</Typography>
-                </Box>
-            ) : (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5 }}>
-                    {/* Donut */}
-                    <Box sx={{ position: 'relative', flexShrink: 0, width: 140, height: 140 }}>
-                        <PieChart width={140} height={140}>
-                            <Pie data={pieData} cx={70} cy={70} innerRadius={42} outerRadius={62} dataKey="value" paddingAngle={2} isAnimationActive={false}>
-                                {pieData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
-                            </Pie>
-                            <ReTooltip content={<DonutTooltip />} />
-                        </PieChart>
-                        {/* Center label */}
-                        <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', textAlign: 'center', pointerEvents: 'none' }}>
-                            <Typography sx={{ fontSize: '0.82rem', fontWeight: 700, lineHeight: 1.2 }}>
-                                {fmtTokens(total)}
-                            </Typography>
-                            <Typography sx={{ fontSize: '0.58rem', color: 'text.secondary', lineHeight: 1.2 }}>
-                                total
-                            </Typography>
-                        </Box>
-                    </Box>
-
-                    {/* Legend */}
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, minWidth: 0 }}>
-                        {pieData.map(d => (
-                            <Box key={d.name} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: d.color, flexShrink: 0 }} />
-                                <Box sx={{ minWidth: 0 }}>
-                                    <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', lineHeight: 1.2 }}>{d.name}</Typography>
-                                    <Typography sx={{ fontSize: '0.78rem', fontWeight: 600, lineHeight: 1.3 }}>
-                                        {fmtTokens(d.value)}
-                                        <Typography component="span" sx={{ fontSize: '0.65rem', color: 'text.secondary', ml: 0.5 }}>
-                                            {d.pct}%
-                                        </Typography>
-                                    </Typography>
-                                    {d.note && (
-                                        <Typography sx={{ fontSize: '0.62rem', color: 'text.secondary', lineHeight: 1.2 }}>
-                                            {d.note}
-                                        </Typography>
-                                    )}
-                                </Box>
-                            </Box>
-                        ))}
-                        <Box sx={{ mt: 0.5, pt: 0.75, borderTop: '1px solid', borderColor: 'divider' }}>
-                            <Typography sx={{ fontSize: '0.68rem', color: 'text.secondary' }}>
-                                {records.length} requests
-                            </Typography>
-                        </Box>
-                    </Box>
-                </Box>
-            )}
-        </Paper>
-    );
-}
-
-// ─── Latency Histogram ────────────────────────────────────────────────────────
-
-function HistoTooltip({ active, payload, label }: any) {
-    const theme = useTheme();
-    if (!active || !payload?.length) return null;
-    const success = payload.find((p: any) => p.dataKey === 'success')?.value ?? 0;
-    const error   = payload.find((p: any) => p.dataKey === 'error')?.value   ?? 0;
-    return (
-        <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.25, boxShadow: theme.shadows[4] }}>
-            <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, mb: 0.5 }}>{label}</Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-                <Typography sx={{ fontSize: '0.7rem', color: SUCCESS_COLOR }}>Success: {success}</Typography>
-                {error > 0 && <Typography sx={{ fontSize: '0.7rem', color: ERROR_COLOR }}>Error: {error}</Typography>}
-                <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', fontWeight: 600 }}>Total: {success + error}</Typography>
-            </Box>
-        </Box>
-    );
-}
-
-function LatencyHistogram({ records }: { records: UsageRecord[] }) {
-    const theme = useTheme();
-    const chartStyles = getThemeChartStyles(theme);
-    const [metric, setMetric] = useState<'latency' | 'ttft'>('latency');
-
-    const getValue = (r: UsageRecord) => metric === 'latency' ? r.latency_ms : (r.ttft_ms ?? 0);
-    // TTFT is only meaningful for streamed requests
-    const pool = metric === 'ttft' ? records.filter(r => r.streamed && (r.ttft_ms ?? 0) > 0) : records;
-
-    const histData = LATENCY_BUCKETS.map(b => ({
-        label: b.label,
-        success: pool.filter(r => getValue(r) >= b.min && getValue(r) < b.max && r.status === 'success').length,
-        error:   pool.filter(r => getValue(r) >= b.min && getValue(r) < b.max && r.status !== 'success').length,
-    }));
-
-    const hasData = pool.length > 0;
-
-    return (
-        <Paper elevation={0} sx={{ p: 2.5, border: '1px solid', borderColor: 'divider', borderRadius: 2, backgroundColor: 'background.paper', boxShadow: 'none' }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                <Typography sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
-                    {metric === 'latency' ? 'Latency' : 'TTFT'} Distribution
-                </Typography>
-                <ToggleButtonGroup
-                    value={metric} exclusive size="small"
-                    onChange={(_, v) => v && setMetric(v)}
-                    sx={{ '& .MuiToggleButton-root': { px: 1.25, py: 0.25, fontSize: '0.7rem', textTransform: 'none' } }}
-                >
-                    <ToggleButton value="latency">Latency</ToggleButton>
-                    <ToggleButton value="ttft">TTFT</ToggleButton>
-                </ToggleButtonGroup>
-            </Box>
-            {!hasData ? (
-                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: 140, gap: 0.5 }}>
-                    <Typography variant="caption" sx={{
-                        color: "text.disabled"
-                    }}>
-                        {metric === 'ttft' ? 'No TTFT data — backend field not yet exposed' : 'No data'}
-                    </Typography>
-                </Box>
-            ) : (
-                <ResponsiveContainer width="100%" height={140}>
-                    <BarChart data={histData} margin={{ top: 0, right: 4, bottom: 0, left: -20 }} barCategoryGap="20%">
-                        <CartesianGrid strokeDasharray="3 3" stroke={chartStyles.chart.grid} strokeOpacity={0.6} vertical={false} />
-                        <XAxis
-                            dataKey="label"
-                            tick={{ fontSize: 10, fill: theme.palette.text.secondary }}
-                            tickLine={false}
-                            axisLine={{ stroke: chartStyles.chart.axis }}
-                        />
-                        <YAxis
-                            tick={{ fontSize: 10, fill: theme.palette.text.secondary }}
-                            tickLine={false}
-                            axisLine={false}
-                            allowDecimals={false}
-                        />
-                        <ReTooltip content={<HistoTooltip />} cursor={{ fill: theme.palette.action.hover }} />
-                        <Bar dataKey="success" stackId="a" fill={SUCCESS_COLOR} fillOpacity={0.75} isAnimationActive={false} radius={[0, 0, 0, 0]} />
-                        <Bar dataKey="error"   stackId="a" fill={ERROR_COLOR}   fillOpacity={0.85} isAnimationActive={false} radius={[3, 3, 0, 0]} />
-                    </BarChart>
-                </ResponsiveContainer>
-            )}
-        </Paper>
-    );
-}
 
 // ─── Request Table ────────────────────────────────────────────────────────────
 
@@ -330,6 +140,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                             <TableCell align="right">Output</TableCell>
                             <TableCell align="right">Latency</TableCell>
                             <TableCell align="right">TTFT</TableCell>
+                            <TableCell align="right">TPS</TableCell>
                             <TableCell align="center">Status</TableCell>
                             <TableCell align="center">Stream</TableCell>
                         </TableRow>
@@ -337,7 +148,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                     <TableBody>
                         {records.length === 0 && !loading ? (
                             <TableRow>
-                                <TableCell colSpan={10} align="center" sx={{ py: 5 }}>
+                                <TableCell colSpan={11 + (showCacheWrite ? 1 : 0)} align="center" sx={{ py: 5 }}>
                                     <Typography variant="body2" sx={{
                                         color: "text.secondary"
                                     }}>No requests found</Typography>
@@ -430,6 +241,15 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                                     </Typography>
                                 </TableCell>
 
+                                {/* Per-request output TPS after TTFT */}
+                                <TableCell align="right">
+                                    <Tooltip title={getTPSFormula(r)} placement="top">
+                                        <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: getTokensPerSecond(r) > 0 ? 'text.primary' : 'text.disabled', cursor: getTokensPerSecond(r) > 0 ? 'help' : 'default' }}>
+                                            {getTokensPerSecond(r) > 0 ? getTokensPerSecond(r).toFixed(1) : '-'}
+                                        </Typography>
+                                    </Tooltip>
+                                </TableCell>
+
                                 {/* Status */}
                                 <TableCell align="center">
                                     {r.status === 'success' ? (
@@ -482,8 +302,8 @@ export interface RecordsQueryParams {
 }
 
 interface RequestsViewProps {
-    /** Most recent records in range (capped sample) — feeds the charts, and
-     *  the table too when it covers the whole range. */
+    /** Most recent records in range (capped sample) — feeds the table directly
+     *  when it covers the whole range. */
     records: UsageRecord[];
     loading: boolean;
     /** Real total in range from the server; records may be capped below it. */
@@ -561,20 +381,7 @@ export default function RequestsView({ records, loading, totalCount, queryParams
     const tableLoading = sampleComplete ? loading && records.length === 0 : serverLoading;
 
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {/* Charts row */}
-            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-                <TokenDonut records={records} />
-                <LatencyHistogram records={records} />
-            </Box>
-            {!sampleComplete && totalCount != null && (
-                <Typography variant="caption" sx={{ color: 'text.secondary', mt: -1.5 }}>
-                    Charts reflect the most recent {records.length.toLocaleString()} of{' '}
-                    {totalCount.toLocaleString()} requests; the table below pages through all of them.
-                </Typography>
-            )}
-
-            {/* Table */}
+        <Box>
             <RequestTable
                 records={tableRecords}
                 total={tableTotal}

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -9,6 +9,8 @@ export { default as DashboardHeatmapSection } from './DashboardHeatmapSection';
 export { default as AgentQuickNav } from './AgentQuickNav';
 export { default as RequestsView } from './RequestsView';
 export type { UsageRecord } from './RequestsView';
+export { default as PerformanceSummary } from './PerformanceSummary';
+export type { PerformanceQueryParams } from './PerformanceSummary';
 export {
     UsageMetricHeaderCells,
     UsageMetricValueCells,

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2514,6 +2514,7 @@ export const handlers = [
                 : m.model.includes('mini') ? 200 + Math.random() * 600
                 : 600 + Math.random() * 1800
             )
+            const ttft = (m.streamed && !isError) ? Math.round(latency * (0.05 + Math.random() * 0.15)) : 0
             const ts = new Date(dayStart.getTime() + Math.random() * (now - dayStart.getTime()))
             return {
                 id: i + 1,
@@ -2530,7 +2531,10 @@ export const handlers = [
                 status: isError ? 'error' : 'success',
                 error_code: isError ? 'rate_limit_exceeded' : '',
                 latency_ms: latency,
-                ttft_ms: (m.streamed && !isError) ? Math.round(latency * (0.05 + Math.random() * 0.15)) : 0,
+                ttft_ms: ttft,
+                tokens_per_second: (m.streamed && !isError && output > 1)
+                    ? (output - 1) * 1000 / (latency - ttft)
+                    : 0,
                 streamed: m.streamed && !isError,
             }
         }).sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
@@ -2544,6 +2548,12 @@ export const handlers = [
             data: page,
         })
     }),
+
+    http.get('/api/v1/usage/performance', () => HttpResponse.json({
+        ttft: { sample_count: 842, p10: 118, p50: 386, p90: 1120, p95: 1860, p99: 3480 },
+        tps: { sample_count: 817, p10: 31.4, p50: 52.8, p90: 83.6, p95: 94.8, p99: 104.2 },
+        completion: { sample_count: 910, p10: 2350, p50: 8400, p90: 22100, p95: 35400, p99: 61200 },
+    })),
 
     // ============================================
     // ImBot Settings API (v1)

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -18,7 +18,7 @@ import {
     Divider,
 } from '@mui/material';
 import { Refresh as RefreshIcon, Outbound as CallMadeIcon, ErrorOutline as ErrorOutlineIcon, Token as PaidIcon, Stream as StreamIcon, Autorenew as CachedIcon, FilterOff } from '@/components/icons';
-import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView, DashboardHeatmapSection, formatNumber, getTotalTokens, getCacheHitRate, getCacheHitRateColor, formatCacheBreakdown, getErrorRateColor } from '@/components/dashboard';
+import { StatCard, DailyTokenHistoryChart, HourlyTokenHistoryChart, ServiceStatsTable, AgentQuickNav, RequestsView, PerformanceSummary, DashboardHeatmapSection, formatNumber, getTotalTokens, getCacheHitRate, getCacheHitRateColor, formatCacheBreakdown, getErrorRateColor } from '@/components/dashboard';
 import type { TimeSeriesData, AggregatedStat, UsageRecord } from '@/components/dashboard';
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import PageHeader from '@/components/PageHeader';
@@ -735,11 +735,28 @@ export default function DashboardPage() {
                             refreshKey={heatmapRefresh}
                         />
                     ) : effectiveViewMode === 'summary' ? (
-                        timeRange === 'today' || timeRange === 'yesterday' ? (
-                            <HourlyTokenHistoryChart data={timeSeries} />
-                        ) : (
-                            <DailyTokenHistoryChart data={timeSeries} />
-                        )
+                        <Box
+                            sx={{
+                                display: 'grid',
+                                gridTemplateColumns: 'minmax(0, 1fr)',
+                                '@media (min-width: 1280px)': {
+                                    gridTemplateColumns: '320px minmax(0, 1fr)',
+                                },
+                                gap: 2,
+                                alignItems: 'stretch',
+                            }}
+                        >
+                            <Box sx={{ minWidth: 0, display: 'flex' }}>
+                                <PerformanceSummary queryParams={recordsParams} />
+                            </Box>
+                            <Box sx={{ minWidth: 0, display: 'flex' }}>
+                                {timeRange === 'today' || timeRange === 'yesterday' ? (
+                                    <HourlyTokenHistoryChart data={timeSeries} />
+                                ) : (
+                                    <DailyTokenHistoryChart data={timeSeries} />
+                                )}
+                            </Box>
+                        </Box>
                     ) : (
                         <RequestsView
                             records={records}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -962,6 +962,36 @@ export const api = {
         }
     },
 
+    getUsagePerformance: async (params: {
+        start_time?: string;
+        end_time?: string;
+        provider?: string;
+        model?: string;
+        scenario?: string;
+        user_id?: string;
+    } = {}): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await client.GET('/api/v1/usage/performance', {
+                headers,
+                params: {
+                    query: {
+                        start_time: params.start_time,
+                        end_time: params.end_time,
+                        provider: params.provider,
+                        model: params.model,
+                        scenario: params.scenario,
+                        user_id: params.user_id,
+                    }
+                }
+            });
+            return response.data;
+        } catch (error: any) {
+            return {success: false, error: error.message};
+        }
+    },
+
     // ============================================
     // OAuth API
     // ============================================

--- a/internal/data/db/usage_daily_test.go
+++ b/internal/data/db/usage_daily_test.go
@@ -360,6 +360,60 @@ func TestGetRecordsTotalWithoutFullCount(t *testing.T) {
 	}
 }
 
+func TestGetPerformanceSummary(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+	now := time.Now()
+
+	records := []UsageRecord{
+		{ProviderUUID: "prov-a", ProviderName: "A", Model: "m", Scenario: "default", UserID: "admin", Timestamp: now.Add(-3 * time.Minute), OutputTokens: 10, Status: "success", Streamed: true, TTFTMs: 100, LatencyMs: 1000}, // 10 TPS
+		{ProviderUUID: "prov-a", ProviderName: "A", Model: "m", Scenario: "default", UserID: "admin", Timestamp: now.Add(-2 * time.Minute), OutputTokens: 17, Status: "success", Streamed: true, TTFTMs: 200, LatencyMs: 1000}, // 20 TPS
+		{ProviderUUID: "prov-a", ProviderName: "A", Model: "m", Scenario: "default", UserID: "admin", Timestamp: now.Add(-time.Minute), OutputTokens: 100, Status: "error", Streamed: true, TTFTMs: 900, LatencyMs: 10000},     // excluded
+		{ProviderUUID: "prov-b", ProviderName: "B", Model: "m", Scenario: "default", UserID: "admin", Timestamp: now, OutputTokens: 30, Status: "success", Streamed: false, LatencyMs: 300},                                    // completion only
+	}
+	for i := range records {
+		if err := store.RecordUsage(&records[i]); err != nil {
+			t.Fatalf("RecordUsage failed: %v", err)
+		}
+	}
+
+	summary, err := store.GetPerformanceSummary(now.Add(-time.Hour), now.Add(time.Minute), map[string]string{"provider_uuid": "prov-a"})
+	if err != nil {
+		t.Fatalf("GetPerformanceSummary failed: %v", err)
+	}
+	if summary.TTFT.SampleCount != 2 || summary.TTFT.P50 != 150 {
+		t.Fatalf("TTFT summary = %+v, want count=2 p50=150", summary.TTFT)
+	}
+	if summary.TPS.SampleCount != 2 || summary.TPS.P50 != 15 || summary.TPS.P95 != 19.5 {
+		t.Fatalf("TPS summary = %+v, want count=2 p50=15 p95=19.5", summary.TPS)
+	}
+	if summary.Completion.SampleCount != 2 || summary.Completion.P50 != 1000 {
+		t.Fatalf("completion summary = %+v, want count=2 p50=1000", summary.Completion)
+	}
+}
+
+func TestTokensPerSecondRejectsInvalidIntervals(t *testing.T) {
+	// Mirrors the dashboard case: 33 output tokens have 32 decode intervals
+	// between TTFT=2.8s and latency=3.0s, yielding 160 TPS.
+	if got := TokensPerSecond(33, 3000, 2800); got != 160 {
+		t.Fatalf("TokensPerSecond = %v, want 160", got)
+	}
+	for _, got := range []float64{
+		TokensPerSecond(0, 1200, 200),
+		TokensPerSecond(1, 1200, 200),
+		TokensPerSecond(50, 1200, 0),
+		TokensPerSecond(50, 200, 200),
+	} {
+		if got != 0 {
+			t.Fatalf("invalid TokensPerSecond = %v, want 0", got)
+		}
+	}
+}
+
 // TestUpgradeAddingSummedColumnKeepsAggregates covers the real upgrade path
 // for cache_write_tokens. usage_daily and usage_records gain the column in the
 // same migration, so every pre-upgrade record contributes 0 and AutoMigrate's

--- a/internal/data/db/usage_record.go
+++ b/internal/data/db/usage_record.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -124,6 +125,26 @@ type UsageStore struct {
 	// lock (WAL mode supports concurrent readers), so dashboard queries do
 	// not serialize behind proxy usage writes or each other.
 	mu sync.RWMutex
+}
+
+// PerformanceMetricSummary describes the typical and tail values for one
+// request-performance metric. P10 is primarily useful for TPS, where lower is
+// worse; latency-style metrics use P50/P90/P99.
+type PerformanceMetricSummary struct {
+	SampleCount int64
+	P10         float64
+	P50         float64
+	P90         float64
+	P95         float64
+	P99         float64
+}
+
+// PerformanceSummary separates the three questions users ask about a streamed
+// response: when it started, how quickly it generated, and when it completed.
+type PerformanceSummary struct {
+	TTFT       PerformanceMetricSummary
+	TPS        PerformanceMetricSummary
+	Completion PerformanceMetricSummary
 }
 
 // NewUsageStore creates or loads a usage store using SQLite database.
@@ -629,6 +650,102 @@ func (us *UsageStore) GetRecords(startTime, endTime time.Time, filters map[strin
 	}
 
 	return records, total, nil
+}
+
+// TokensPerSecond derives per-request output TPS from persisted timing fields.
+// The first token is accounted for by TTFT, leaving N-1 decode intervals from
+// the first output token to the last.
+func TokensPerSecond(outputTokens, latencyMs, ttftMs int) float64 {
+	decodeMs := latencyMs - ttftMs
+	if outputTokens <= 1 || ttftMs <= 0 || decodeMs <= 0 {
+		return 0
+	}
+	return float64(outputTokens-1) * 1000 / float64(decodeMs)
+}
+
+// GetPerformanceSummary calculates percentiles across the complete filtered
+// range. Only successful requests participate: failures and cancellations have
+// different completion semantics and would distort the user-experience view.
+func (us *UsageStore) GetPerformanceSummary(startTime, endTime time.Time, filters map[string]string) (PerformanceSummary, error) {
+	us.mu.RLock()
+	defer us.mu.RUnlock()
+
+	query := us.db.Model(&UsageRecord{}).
+		Select("latency_ms", "ttft_ms", "output_tokens", "streamed").
+		Where("status = ?", "success")
+	if !startTime.IsZero() {
+		query = query.Where("timestamp >= ?", startTime)
+	}
+	if !endTime.IsZero() {
+		query = query.Where("timestamp <= ?", endTime)
+	}
+	for key, value := range filters {
+		query = query.Where(key+" = ?", value)
+	}
+
+	var records []UsageRecord
+	if err := query.Find(&records).Error; err != nil {
+		return PerformanceSummary{}, err
+	}
+
+	completion := make([]float64, 0, len(records))
+	ttft := make([]float64, 0, len(records))
+	tps := make([]float64, 0, len(records))
+	for _, record := range records {
+		if record.LatencyMs > 0 {
+			completion = append(completion, float64(record.LatencyMs))
+		}
+		if !record.Streamed {
+			continue
+		}
+		if record.TTFTMs > 0 {
+			ttft = append(ttft, float64(record.TTFTMs))
+		}
+		if speed := TokensPerSecond(record.OutputTokens, record.LatencyMs, record.TTFTMs); speed > 0 {
+			tps = append(tps, speed)
+		}
+	}
+
+	return PerformanceSummary{
+		TTFT:       summarizePerformanceMetric(ttft),
+		TPS:        summarizePerformanceMetric(tps),
+		Completion: summarizePerformanceMetric(completion),
+	}, nil
+}
+
+func summarizePerformanceMetric(values []float64) PerformanceMetricSummary {
+	if len(values) == 0 {
+		return PerformanceMetricSummary{}
+	}
+	sort.Float64s(values)
+	return PerformanceMetricSummary{
+		SampleCount: int64(len(values)),
+		P10:         percentileFloat(values, 0.10),
+		P50:         percentileFloat(values, 0.50),
+		P90:         percentileFloat(values, 0.90),
+		P95:         percentileFloat(values, 0.95),
+		P99:         percentileFloat(values, 0.99),
+	}
+}
+
+func percentileFloat(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	index := p * float64(len(sorted)-1)
+	lower := int(index)
+	upper := lower + 1
+	if upper >= len(sorted) {
+		return sorted[lower]
+	}
+	fraction := index - float64(lower)
+	return sorted[lower] + fraction*(sorted[upper]-sorted[lower])
 }
 
 // GetRecordsAfterID returns usage records with id greater than lastID.

--- a/internal/loadbalance/load_balancing.go
+++ b/internal/loadbalance/load_balancing.go
@@ -74,7 +74,7 @@ type ServiceStats struct {
 	P99LatencyMs      float64   `json:"p99_latency_ms"`      // 99th percentile latency
 	LastLatencyUpdate time.Time `json:"last_latency_update"` // When latency was last updated
 
-	// Token speed tracking fields (tokens per second)
+	// Per-request output TPS tracking fields (decode speed after TTFT)
 	SpeedSamples    []float64 `json:"-"`                 // Rolling window of token speed samples
 	AvgTokenSpeed   float64   `json:"avg_token_speed"`   // Average tokens per second
 	LastSpeedUpdate time.Time `json:"last_speed_update"` // When speed was last updated
@@ -301,7 +301,7 @@ func (ss *ServiceStats) GetLatencyStats() (avg, p50, p95, p99 float64, sampleCou
 	return ss.AvgLatencyMs, ss.P50LatencyMs, ss.P95LatencyMs, ss.P99LatencyMs, len(ss.LatencySamples)
 }
 
-// RecordTokenSpeed records a token speed sample (tokens per second)
+// RecordTokenSpeed records a per-request output TPS sample after TTFT
 func (ss *ServiceStats) RecordTokenSpeed(speedTps float64, maxSamples int) {
 	ss.mutex.Lock()
 	defer ss.mutex.Unlock()
@@ -324,7 +324,7 @@ func (ss *ServiceStats) RecordTokenSpeed(speedTps float64, maxSamples int) {
 	ss.LastSpeedUpdate = time.Now()
 }
 
-// recalculateSpeedStats recalculates token speed statistics
+// recalculateSpeedStats recalculates per-request output TPS statistics
 // Must be called with mutex held
 func (ss *ServiceStats) recalculateSpeedStats() {
 	if len(ss.SpeedSamples) == 0 {

--- a/internal/server/module/usage/handler.go
+++ b/internal/server/module/usage/handler.go
@@ -204,6 +204,10 @@ func (h *Handler) GetRecords(c *gin.Context) {
 	// Convert db.UsageRecord to usage.UsageRecordResponse
 	data := make([]UsageRecordResponse, len(records))
 	for i, r := range records {
+		tokensPerSecond := 0.0
+		if r.Streamed {
+			tokensPerSecond = db.TokensPerSecond(r.OutputTokens, r.LatencyMs, r.TTFTMs)
+		}
 		data[i] = UsageRecordResponse{
 			ID:               r.ID,
 			ProviderUUID:     r.ProviderUUID,
@@ -223,6 +227,7 @@ func (h *Handler) GetRecords(c *gin.Context) {
 			ErrorCode:        r.ErrorCode,
 			LatencyMs:        r.LatencyMs,
 			TTFTMs:           r.TTFTMs,
+			TokensPerSecond:  tokensPerSecond,
 			Streamed:         r.Streamed,
 		}
 	}
@@ -237,6 +242,52 @@ func (h *Handler) GetRecords(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// GetPerformanceSummary returns percentiles over the complete selected range.
+func (h *Handler) GetPerformanceSummary(c *gin.Context) {
+	if h.usageStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Usage store not available"})
+		return
+	}
+
+	startTime := parseTimeQuery(c, "start_time", time.Now().Add(-1*time.Hour))
+	endTime := parseTimeQuery(c, "end_time", time.Now())
+	filters := make(map[string]string)
+	if provider := c.Query("provider"); provider != "" {
+		filters["provider_uuid"] = provider
+	}
+	if model := c.Query("model"); model != "" {
+		filters["model"] = model
+	}
+	if scenario := c.Query("scenario"); scenario != "" {
+		filters["scenario"] = scenario
+	}
+	if userID := c.Query("user_id"); userID != "" {
+		filters["user_id"] = userID
+	}
+
+	summary, err := h.usageStore.GetPerformanceSummary(startTime, endTime, filters)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	metric := func(value db.PerformanceMetricSummary) PerformanceMetricSummary {
+		return PerformanceMetricSummary{
+			SampleCount: value.SampleCount,
+			P10:         value.P10,
+			P50:         value.P50,
+			P90:         value.P90,
+			P95:         value.P95,
+			P99:         value.P99,
+		}
+	}
+	c.JSON(http.StatusOK, PerformanceSummaryResponse{
+		TTFT:       metric(summary.TTFT),
+		TPS:        metric(summary.TPS),
+		Completion: metric(summary.Completion),
+	})
 }
 
 // DeleteOldRecords deletes usage records older than the specified date

--- a/internal/server/module/usage/routes.go
+++ b/internal/server/module/usage/routes.go
@@ -144,6 +144,12 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 			Required:    false,
 			Description: "Filter by scenario",
 		}),
+		swagger.WithQueryConfig("user_id", swagger.QueryParamConfig{
+			Name:        "user_id",
+			Type:        "string",
+			Required:    false,
+			Description: "Filter by user ID",
+		}),
 		swagger.WithResponseModel(TimeSeriesResponse{}),
 		swagger.WithErrorResponses(
 			swagger.ErrorResponseConfig{Code: 503, Message: "Usage store not available"},
@@ -191,6 +197,12 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 			Required:    false,
 			Description: "Filter by status",
 		}),
+		swagger.WithQueryConfig("user_id", swagger.QueryParamConfig{
+			Name:        "user_id",
+			Type:        "string",
+			Required:    false,
+			Description: "Filter by user ID",
+		}),
 		swagger.WithQueryConfig("limit", swagger.QueryParamConfig{
 			Name:        "limit",
 			Type:        "integer",
@@ -209,6 +221,35 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 			Minimum:     intPtr(0),
 		}),
 		swagger.WithResponseModel(UsageRecordsResponse{}),
+		swagger.WithErrorResponses(
+			swagger.ErrorResponseConfig{Code: 503, Message: "Usage store not available"},
+		),
+	)
+
+	// GET /api/v1/usage/performance - Get response-performance percentiles
+	router.GET("/usage/performance", handler.GetPerformanceSummary,
+		swagger.WithMiddleware(middleware.Gzip()),
+		swagger.WithTags("usage"),
+		swagger.WithDescription("Returns TTFT, per-request output TPS, and latency percentiles over successful requests"),
+		swagger.WithQueryConfig("start_time", swagger.QueryParamConfig{
+			Name: "start_time", Type: "string", Description: "ISO 8601 start time",
+		}),
+		swagger.WithQueryConfig("end_time", swagger.QueryParamConfig{
+			Name: "end_time", Type: "string", Description: "ISO 8601 end time",
+		}),
+		swagger.WithQueryConfig("provider", swagger.QueryParamConfig{
+			Name: "provider", Type: "string", Description: "Filter by provider UUID",
+		}),
+		swagger.WithQueryConfig("model", swagger.QueryParamConfig{
+			Name: "model", Type: "string", Description: "Filter by model name",
+		}),
+		swagger.WithQueryConfig("scenario", swagger.QueryParamConfig{
+			Name: "scenario", Type: "string", Description: "Filter by scenario",
+		}),
+		swagger.WithQueryConfig("user_id", swagger.QueryParamConfig{
+			Name: "user_id", Type: "string", Description: "Filter by user ID",
+		}),
+		swagger.WithResponseModel(PerformanceSummaryResponse{}),
 		swagger.WithErrorResponses(
 			swagger.ErrorResponseConfig{Code: 503, Message: "Usage store not available"},
 		),

--- a/internal/server/module/usage/types.go
+++ b/internal/server/module/usage/types.go
@@ -65,6 +65,7 @@ type TimeSeriesQuery struct {
 	Provider  string `json:"provider" form:"provider" description:"Filter by provider UUID"`
 	Model     string `json:"model" form:"model" description:"Filter by model name"`
 	Scenario  string `json:"scenario" form:"scenario" description:"Filter by scenario"`
+	UserID    string `json:"user_id" form:"user_id" description:"Filter by user ID"`
 }
 
 // TimeSeriesData represents a single time bucket in time series data
@@ -100,6 +101,7 @@ type UsageRecordsQuery struct {
 	Provider  string `json:"provider" form:"provider" description:"Filter by provider UUID"`
 	Model     string `json:"model" form:"model" description:"Filter by model name"`
 	Scenario  string `json:"scenario" form:"scenario" description:"Filter by scenario"`
+	UserID    string `json:"user_id" form:"user_id" description:"Filter by user ID"`
 	Status    string `json:"status" form:"status" description:"Filter by status"`
 	Limit     int    `json:"limit" form:"limit" description:"Max results (max 1000)" example:"50"`
 	Offset    int    `json:"offset" form:"offset" description:"Pagination offset" example:"0"`
@@ -107,25 +109,26 @@ type UsageRecordsQuery struct {
 
 // UsageRecordResponse represents a single usage record
 type UsageRecordResponse struct {
-	ID               uint   `json:"id" example:"1"`
-	ProviderUUID     string `json:"provider_uuid" example:"uuid-123"`
-	ProviderName     string `json:"provider_name" example:"openai"`
-	Model            string `json:"model" example:"gpt-4"`
-	Scenario         string `json:"scenario" example:"openai"`
-	RuleUUID         string `json:"rule_uuid,omitempty" example:"rule-uuid"`
-	UserID           string `json:"user_id,omitempty" example:"usr_123"`
-	RequestModel     string `json:"request_model,omitempty" example:"gpt-4"`
-	Timestamp        string `json:"timestamp" example:"2025-01-10T12:00:00Z"`
-	InputTokens      int    `json:"input_tokens" example:"1000"`
-	OutputTokens     int    `json:"output_tokens" example:"500"`
-	TotalTokens      int    `json:"total_tokens" example:"1500"`
-	CacheReadTokens  int    `json:"cache_read_tokens" example:"2000"`
-	CacheWriteTokens int    `json:"cache_write_tokens" example:"300"`
-	Status           string `json:"status" example:"success"`
-	ErrorCode        string `json:"error_code,omitempty"`
-	LatencyMs        int    `json:"latency_ms" example:"1200"`
-	TTFTMs           int    `json:"ttft_ms" example:"180"`
-	Streamed         bool   `json:"streamed" example:"true"`
+	ID               uint    `json:"id" example:"1"`
+	ProviderUUID     string  `json:"provider_uuid" example:"uuid-123"`
+	ProviderName     string  `json:"provider_name" example:"openai"`
+	Model            string  `json:"model" example:"gpt-4"`
+	Scenario         string  `json:"scenario" example:"openai"`
+	RuleUUID         string  `json:"rule_uuid,omitempty" example:"rule-uuid"`
+	UserID           string  `json:"user_id,omitempty" example:"usr_123"`
+	RequestModel     string  `json:"request_model,omitempty" example:"gpt-4"`
+	Timestamp        string  `json:"timestamp" example:"2025-01-10T12:00:00Z"`
+	InputTokens      int     `json:"input_tokens" example:"1000"`
+	OutputTokens     int     `json:"output_tokens" example:"500"`
+	TotalTokens      int     `json:"total_tokens" example:"1500"`
+	CacheReadTokens  int     `json:"cache_read_tokens" example:"2000"`
+	CacheWriteTokens int     `json:"cache_write_tokens" example:"300"`
+	Status           string  `json:"status" example:"success"`
+	ErrorCode        string  `json:"error_code,omitempty"`
+	LatencyMs        int     `json:"latency_ms" example:"1200"`
+	TTFTMs           int     `json:"ttft_ms" example:"180"`
+	TokensPerSecond  float64 `json:"tokens_per_second" example:"52.4"`
+	Streamed         bool    `json:"streamed" example:"true"`
 }
 
 // UsageRecordsResponse represents the response for usage records
@@ -139,6 +142,25 @@ type UsageRecordsMeta struct {
 	Total  int `json:"total" example:"1000"`
 	Limit  int `json:"limit" example:"50"`
 	Offset int `json:"offset" example:"0"`
+}
+
+// PerformanceMetricSummary contains percentiles and the number of valid
+// samples used. P10 is meaningful for TPS; P90/P99 describe latency tails.
+type PerformanceMetricSummary struct {
+	SampleCount int64   `json:"sample_count" example:"842"`
+	P10         float64 `json:"p10" example:"31.2"`
+	P50         float64 `json:"p50" example:"52.4"`
+	P90         float64 `json:"p90" example:"88.1"`
+	P95         float64 `json:"p95" example:"96.7"`
+	P99         float64 `json:"p99" example:"110.5"`
+}
+
+// PerformanceSummaryResponse summarizes response start, per-request output
+// throughput, and latency over the complete filtered range.
+type PerformanceSummaryResponse struct {
+	TTFT       PerformanceMetricSummary `json:"ttft"`
+	TPS        PerformanceMetricSummary `json:"tps"`
+	Completion PerformanceMetricSummary `json:"completion"`
 }
 
 // DeleteOldRecordsRequest represents the request to delete old usage records

--- a/internal/server/tracking_context.go
+++ b/internal/server/tracking_context.go
@@ -164,11 +164,11 @@ func GetCacheHit(c *gin.Context) (bool, bool) {
 	return false, false
 }
 
-// CalculateTPS calculates Tokens Per Second (generation speed) for streaming requests.
+// CalculateTPS calculates Tokens Per Second for streaming requests.
 // For non-streaming requests or when TTFT is not available, returns 0.
 //
-// TPS is calculated as: outputTokens / (currentTime - firstTokenTime)
-// This measures the actual token generation speed after the first token was received.
+// TPS is the inverse of time per output token (TPOT):
+// (outputTokens - 1) / (currentTime - firstTokenTime).
 //
 // Parameters:
 //   - c: Gin context containing timing information
@@ -183,25 +183,22 @@ func CalculateTPS(c *gin.Context, outputTokens int, streamed bool) float64 {
 		return 0
 	}
 
-	// Need output tokens to calculate
-	if outputTokens <= 0 {
+	// At least two tokens are required to form one decode interval.
+	if outputTokens <= 1 {
 		return 0
 	}
 
-	// Get first token time - required for accurate TPS calculation
 	firstTokenTime, hasFirstToken := GetFirstTokenTime(c)
 	if !hasFirstToken {
-		return 0 // Cannot calculate TPS without knowing when first token arrived
+		return 0
 	}
 
-	// Calculate duration from first token to now (in seconds)
 	duration := time.Since(firstTokenTime).Seconds()
 	if duration <= 0 {
 		return 0 // Invalid duration
 	}
 
-	// TPS = tokens / seconds
-	return float64(outputTokens) / duration
+	return float64(outputTokens-1) / duration
 }
 
 // DetectCacheHit determines if a request was served from cache based on TokenUsage.

--- a/internal/server/tracking_context_test.go
+++ b/internal/server/tracking_context_test.go
@@ -134,14 +134,14 @@ func TestExtractScenarioFromPath(t *testing.T) {
 func TestCalculateTPS_Streaming(t *testing.T) {
 	c := &gin.Context{}
 
-	// Set up context: streaming request with first token time 500ms ago
+	// Set up context: first output token arrived 500ms ago.
 	c.Set(ContextKeyStreamed, true)
 	c.Set(ContextKeyFirstTokenTime, time.Now().Add(-500*time.Millisecond))
 
 	// Calculate TPS with 100 output tokens
 	tps := CalculateTPS(c, 100, true)
 
-	// Expected: 100 tokens / 0.5 seconds = 200 TPS
+	// Expected: 99 decode intervals / 0.5 seconds = 198 TPS
 	// Allow tolerance for execution time (180-220)
 	assert.GreaterOrEqual(t, tps, 180.0)
 	assert.LessOrEqual(t, tps, 220.0)
@@ -158,14 +158,14 @@ func TestCalculateTPS_NonStreaming(t *testing.T) {
 	assert.Equal(t, 0.0, tps)
 }
 
-// TestCalculateTPS_NoFirstToken tests TPS calculation without first token time
+// TestCalculateTPS_NoFirstToken tests TPS calculation without TTFT timing.
 func TestCalculateTPS_NoFirstToken(t *testing.T) {
 	c := &gin.Context{}
 
-	// Streaming but no first token time set
+	// Streaming but no first-token time set.
 	tps := CalculateTPS(c, 100, true)
 
-	// Should return 0 when first token time is not available
+	// Should return 0 when decode duration is not available.
 	assert.Equal(t, 0.0, tps)
 }
 

--- a/internal/server/usage_tracking.go
+++ b/internal/server/usage_tracking.go
@@ -26,7 +26,7 @@ type MetricsData struct {
 	LatencyMs    int64   // Total request latency in milliseconds
 	TTFTMs       int64   // Time To First Token in milliseconds (0 if not available/applicable)
 	CacheHit     bool    // Whether this request hit the cache
-	TPS          float64 // Tokens Per Second - generation speed (0 for non-streaming requests)
+	TPS          float64 // Per-request output TPS after TTFT (0 when unavailable)
 }
 
 // GetUserIDFromContext extracts the user ID from gin context.

--- a/internal/typ/tactics.go
+++ b/internal/typ/tactics.go
@@ -197,7 +197,7 @@ func (rt *RandomTactic) GetType() loadbalance.TacticType {
 	return loadbalance.TacticRandom
 }
 
-// SpeedBasedTactic implements load balancing based on token generation speed
+// SpeedBasedTactic implements load balancing based on output TPS
 type SpeedBasedTactic struct {
 	MinSamplesRequired int     // Minimum samples before making decisions
 	SpeedThresholdTps  float64 // Minimum acceptable tokens per second
@@ -222,7 +222,7 @@ func NewSpeedBasedTactic(minSamplesRequired int, speedThresholdTps float64, samp
 	}
 }
 
-// SelectService selects service based on token generation speed
+// SelectService selects service based on output TPS
 func (st *SpeedBasedTactic) SelectService(rule *Rule) *loadbalance.Service {
 	// Get active services
 	activeServices := rule.GetActiveServices()

--- a/openapi.json
+++ b/openapi.json
@@ -5714,6 +5714,94 @@
         }
       }
     },
+    "/api/v1/usage/performance": {
+      "get": {
+        "tags": [
+          "usage"
+        ],
+        "summary": "Returns TTFT, per-request output TPS, and latency percentiles over successful requests",
+        "description": "Returns TTFT, per-request output TPS, and latency percentiles over successful requests",
+        "operationId": "apiV1UsagePerformanceGet",
+        "parameters": [
+          {
+            "name": "start_time",
+            "in": "query",
+            "description": "ISO 8601 start time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_time",
+            "in": "query",
+            "description": "ISO 8601 end time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Filter by provider UUID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "description": "Filter by model name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scenario",
+            "in": "query",
+            "description": "Filter by scenario",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Filter by user ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PerformanceSummaryResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Usage store not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/usage/records": {
       "get": {
         "tags": [
@@ -5772,6 +5860,15 @@
             "name": "status",
             "in": "query",
             "description": "Filter by status",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Filter by user ID",
             "required": false,
             "schema": {
               "type": "string"
@@ -6113,6 +6210,15 @@
             "name": "scenario",
             "in": "query",
             "description": "Filter by scenario",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Filter by user ID",
             "required": false,
             "schema": {
               "type": "string"
@@ -11339,6 +11445,74 @@
           "active"
         ]
       },
+      "PerformanceMetricSummary": {
+        "type": "object",
+        "properties": {
+          "p10": {
+            "type": "number",
+            "format": "double",
+            "description": "Field p10",
+            "example": 31.2
+          },
+          "p50": {
+            "type": "number",
+            "format": "double",
+            "description": "Field p50",
+            "example": 52.4
+          },
+          "p90": {
+            "type": "number",
+            "format": "double",
+            "description": "Field p90",
+            "example": 88.1
+          },
+          "p95": {
+            "type": "number",
+            "format": "double",
+            "description": "Field p95",
+            "example": 96.7
+          },
+          "p99": {
+            "type": "number",
+            "format": "double",
+            "description": "Field p99",
+            "example": 110.5
+          },
+          "sample_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field sample_count",
+            "example": 842
+          }
+        },
+        "required": [
+          "sample_count",
+          "p10",
+          "p50",
+          "p90",
+          "p95",
+          "p99"
+        ]
+      },
+      "PerformanceSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "completion": {
+            "$ref": "#/components/schemas/PerformanceMetricSummary"
+          },
+          "tps": {
+            "$ref": "#/components/schemas/PerformanceMetricSummary"
+          },
+          "ttft": {
+            "$ref": "#/components/schemas/PerformanceMetricSummary"
+          }
+        },
+        "required": [
+          "ttft",
+          "tps",
+          "completion"
+        ]
+      },
       "Permission": {
         "type": "object",
         "properties": {
@@ -14596,6 +14770,12 @@
             "description": "Field timestamp",
             "example": "2025-01-10T12:00:00Z"
           },
+          "tokens_per_second": {
+            "type": "number",
+            "format": "double",
+            "description": "Field tokens_per_second",
+            "example": 52.4
+          },
           "total_tokens": {
             "type": "integer",
             "format": "int64",
@@ -14629,6 +14809,7 @@
           "status",
           "latency_ms",
           "ttft_ms",
+          "tokens_per_second",
           "streamed"
         ]
       },


### PR DESCRIPTION
## Summary

Replace low-signal request distribution charts with a compact response-performance summary. Users can now compare TTFT, TPS, and end-to-end latency percentiles alongside the token usage trend for the complete filtered range

<img width="2398" height="962" alt="image" src="https://github.com/user-attachments/assets/1a3a3fba-eb57-4b2c-a188-84f839339154" />


## Key Changes

- **Performance visibility**: Show TTFT, TPS, and Latency as an aligned percentile matrix covering P99, P95, P90, P50, and P10. TPS P99 remains available from the API but is intentionally hidden because the fastest 1% has limited operational value.

- **Summary workflow**: Place the compact 320px performance matrix beside the token usage curve on wide screens and stack both sections responsively on narrower screens.

- **Request diagnosis**: Expose per-request TPS in the request table with its decode-interval calculation, while removing the repetitive Token Breakdown and latency distribution charts.

- **Metric semantics**: Calculate generation TPS from decode intervals after TTFT, using `(output_tokens - 1) / (latency - TTFT)`, and exclude failed or invalid samples from performance percentiles.

- **Filtered-range analysis**: Add a performance endpoint supporting time range, provider, model, scenario, and identity filters so percentiles describe the complete selected range rather than the latest request page.

- **Rolling compatibility**: Treat missing or non-finite percentile fields as unavailable, preventing an older backend without P95 from crashing the Dashboard during rolling upgrades.

- **API contract**: Publish request TPS and performance percentile models, including P95, through the generated OpenAPI schema.

## Testing

- `go test ./internal/data/db ./internal/server/module/usage ./internal/server ./internal/loadbalance ./internal/typ -count=1`
- Frontend Oxlint
- Frontend production build
- `git diff --check`
- Visual verification at desktop and mobile widths with no runtime errors or horizontal overflow