### PR TITLE
bugfix(codex): support Claude Code cached prompts

### DIFF
--- a/internal/client/codex_round_tripper.go
+++ b/internal/client/codex_round_tripper.go
@@ -141,6 +141,12 @@ func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
 	bodyStr, _ = sjson.Delete(bodyStr, "temperature")
 	bodyStr, _ = sjson.Delete(bodyStr, "top_p")
 
+	// The standard Responses API exposes explicit prompt-cache controls, but
+	// ChatGPT's Codex endpoint rejects them. Keep prompt_cache_key (supported by
+	// Codex for affinity) while removing the unsupported policy and per-content
+	// breakpoint fields at this provider boundary.
+	bodyStr = sanitizeCodexPromptCacheJSON(bodyStr)
+
 	// Final gate: ChatGPT backend rejects items with empty or non-conforming id.
 	// The SDK-level sanitizer only covers a subset of input item variants, so
 	// scrub the marshaled JSON to catch every variant the SDK may emit.
@@ -149,6 +155,14 @@ func (t *codexRoundTripper) filterField(body []byte) ([]byte, error) {
 	// Drop message items whose content serialized as "" — Codex treats empty
 	// string content as a missing required parameter.
 	bodyStr = sanitizeCodexEmptyContentJSON(bodyStr)
+
+	// ChatGPT's Codex backend rejects role="system" input messages. Responses
+	// requests normally carry system text in `instructions`, but protocol
+	// conversion must use an input message when the source system block has an
+	// explicit cache breakpoint. Lift that text back into `instructions` at this
+	// provider boundary; standard Responses providers keep the richer cache
+	// representation unchanged.
+	bodyStr = normalizeCodexSystemMessagesJSON(bodyStr)
 
 	return []byte(bodyStr), nil
 }
@@ -214,6 +228,87 @@ func sanitizeCodexEmptyContentJSON(bodyStr string) string {
 		if updated, err := sjson.Delete(bodyStr, path); err == nil {
 			bodyStr = updated
 		}
+	}
+	return bodyStr
+}
+
+// sanitizeCodexPromptCacheJSON removes standard Responses cache-control fields
+// that the ChatGPT Codex backend does not accept. Content breakpoints can occur
+// on message content and function-call output content.
+func sanitizeCodexPromptCacheJSON(bodyStr string) string {
+	bodyStr, _ = sjson.Delete(bodyStr, "prompt_cache_options")
+	bodyStr, _ = sjson.Delete(bodyStr, "prompt_cache_retention")
+
+	input := gjson.Get(bodyStr, "input")
+	if !input.IsArray() {
+		return bodyStr
+	}
+	for i, item := range input.Array() {
+		for _, field := range []string{"content", "output"} {
+			parts := item.Get(field)
+			if !parts.IsArray() {
+				continue
+			}
+			for j, part := range parts.Array() {
+				if !part.Get("prompt_cache_breakpoint").Exists() {
+					continue
+				}
+				path := fmt.Sprintf("input.%d.%s.%d.prompt_cache_breakpoint", i, field, j)
+				bodyStr, _ = sjson.Delete(bodyStr, path)
+			}
+		}
+	}
+	return bodyStr
+}
+
+// normalizeCodexSystemMessagesJSON moves system-role input messages into the
+// top-level instructions field. The ChatGPT Codex endpoint does not accept
+// system messages in `input`, while the standard Responses API uses that shape
+// to attach prompt-cache breakpoints to system content.
+func normalizeCodexSystemMessagesJSON(bodyStr string) string {
+	input := gjson.Get(bodyStr, "input")
+	if !input.IsArray() {
+		return bodyStr
+	}
+
+	var systemTexts []string
+	var systemIndexes []int
+	for i, item := range input.Array() {
+		if item.Get("type").String() != "message" || item.Get("role").String() != "system" {
+			continue
+		}
+		systemIndexes = append(systemIndexes, i)
+		content := item.Get("content")
+		if content.Type == gjson.String {
+			if text := strings.TrimSpace(content.String()); text != "" {
+				systemTexts = append(systemTexts, text)
+			}
+			continue
+		}
+		if !content.IsArray() {
+			continue
+		}
+		for _, part := range content.Array() {
+			if text := strings.TrimSpace(part.Get("text").String()); text != "" {
+				systemTexts = append(systemTexts, text)
+			}
+		}
+	}
+
+	if len(systemIndexes) == 0 {
+		return bodyStr
+	}
+
+	if existing := strings.TrimSpace(gjson.Get(bodyStr, "instructions").String()); existing != "" {
+		systemTexts = append([]string{existing}, systemTexts...)
+	}
+	if len(systemTexts) > 0 {
+		bodyStr, _ = sjson.Set(bodyStr, "instructions", strings.Join(systemTexts, "\n\n"))
+	}
+
+	// Delete in reverse so earlier indexes remain stable.
+	for i := len(systemIndexes) - 1; i >= 0; i-- {
+		bodyStr, _ = sjson.Delete(bodyStr, fmt.Sprintf("input.%d", systemIndexes[i]))
 	}
 	return bodyStr
 }

--- a/internal/client/codex_round_tripper_test.go
+++ b/internal/client/codex_round_tripper_test.go
@@ -155,6 +155,69 @@ func TestSanitizeCodexEmptyContentJSON_HighIndex(t *testing.T) {
 	assert.Len(t, input, 1012, "empty-content message at high index must be dropped")
 }
 
+func TestNormalizeCodexSystemMessagesJSON(t *testing.T) {
+	t.Run("lifts cached system input into instructions", func(t *testing.T) {
+		body := `{
+			"model":"gpt-5.6-sol",
+			"input":[
+				{"type":"message","role":"system","content":[{"type":"input_text","text":"You are Claude Code.","prompt_cache_breakpoint":{"type":"ephemeral"}}]},
+				{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}
+			]
+		}`
+
+		out := normalizeCodexSystemMessagesJSON(body)
+		assert.Equal(t, "You are Claude Code.", gjson.Get(out, "instructions").String())
+		input := gjson.Get(out, "input").Array()
+		require.Len(t, input, 1)
+		assert.Equal(t, "user", input[0].Get("role").String())
+	})
+
+	t.Run("preserves existing instructions and system order", func(t *testing.T) {
+		body := `{
+			"instructions":"existing",
+			"input":[
+				{"type":"message","role":"system","content":"first"},
+				{"type":"message","role":"user","content":"hello"},
+				{"type":"message","role":"system","content":[{"type":"input_text","text":"second"}]}
+			]
+		}`
+
+		out := normalizeCodexSystemMessagesJSON(body)
+		assert.Equal(t, "existing\n\nfirst\n\nsecond", gjson.Get(out, "instructions").String())
+		assert.Len(t, gjson.Get(out, "input").Array(), 1)
+	})
+
+	t.Run("leaves requests without system input untouched", func(t *testing.T) {
+		body := `{"instructions":"existing","input":[{"type":"message","role":"user","content":"hello"}]}`
+		assert.Equal(t, body, normalizeCodexSystemMessagesJSON(body))
+	})
+}
+
+func TestCodexFilterFieldLiftsSystemMessages(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"prompt_cache_key":"session-1",
+		"prompt_cache_options":{"mode":"explicit"},
+		"prompt_cache_retention":"24h",
+		"input":[
+			{"type":"message","role":"system","content":[{"type":"input_text","text":"system prompt","prompt_cache_breakpoint":{"type":"ephemeral"}}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hello","prompt_cache_breakpoint":{"type":"ephemeral"}}]},
+			{"type":"function_call_output","call_id":"call-1","output":[{"type":"input_text","text":"result","prompt_cache_breakpoint":{"type":"ephemeral"}}]}
+		]
+	}`)
+
+	out, err := (&codexRoundTripper{}).filterField(body)
+	require.NoError(t, err)
+	assert.Equal(t, "system prompt", gjson.GetBytes(out, "instructions").String())
+	assert.False(t, gjson.GetBytes(out, `input.#(role=="system")`).Exists())
+	assert.Equal(t, "user", gjson.GetBytes(out, "input.0.role").String())
+	assert.False(t, gjson.GetBytes(out, "prompt_cache_options").Exists())
+	assert.False(t, gjson.GetBytes(out, "prompt_cache_retention").Exists())
+	assert.Equal(t, "session-1", gjson.GetBytes(out, "prompt_cache_key").String())
+	assert.False(t, gjson.GetBytes(out, "input.0.content.0.prompt_cache_breakpoint").Exists())
+	assert.False(t, gjson.GetBytes(out, "input.1.output.0.prompt_cache_breakpoint").Exists())
+}
+
 func TestCodexInputItemIDRequired(t *testing.T) {
 	required := []string{
 		"reasoning", "code_interpreter_call", "computer_call", "file_search_call",


### PR DESCRIPTION
## Summary

Fix Claude Code requests routed through the ChatGPT Codex backend failing with HTTP 400 due to unsupported system messages and explicit prompt-cache parameters.

Help to fix #1489 which is mentioned in #1457.

## Key Changes

- **System prompt compatibility**: Lift system-role input content into top-level `instructions`, preserving prompt behavior while satisfying the ChatGPT Codex request contract.
- **Cache compatibility boundary**: Remove unsupported `prompt_cache_options`, `prompt_cache_retention`, and content breakpoints only at the Codex transport boundary, while retaining `prompt_cache_key`.
- **Provider isolation**: Preserve full cache-control conversion for standard Responses providers that support explicit cache semantics.
- **Regression protection**: Cover cached system prompts, user content, tool outputs, instruction merging, and cache-key preservation.

## Testing

- `go test ./internal/client -count=1`

## Notes

- Explicit Claude Code cache breakpoints cannot be forwarded to the ChatGPT Codex backend; its native caching can still use `prompt_cache_key`.