### PR TITLE
refactor(protocol/assembler): add StreamAssembler surface + OpenAI responses assembler

### DIFF
--- a/internal/protocol/assembler/openai_responses_assembler.go
+++ b/internal/protocol/assembler/openai_responses_assembler.go
@@ -205,6 +205,9 @@ func (a *ResponsesAssembler) Accumulate(event responses.ResponseStreamEventUnion
 	case "response.failed":
 		a.status = "failed"
 		a.finished = true
+		if responseHasPayload(&event.Response) {
+			a.response = &event.Response
+		}
 		return true
 
 	case "response.incomplete":
@@ -374,7 +377,15 @@ func responseHasPayload(resp *responses.Response) bool {
 	if resp == nil {
 		return false
 	}
-	return resp.ID != "" || len(resp.Output) > 0 || resp.Usage.InputTokens != 0 || resp.Usage.OutputTokens != 0 || resp.Usage.TotalTokens != 0
+	return resp.ID != "" ||
+		resp.Status != "" ||
+		resp.Model != "" ||
+		resp.Error.Code != "" ||
+		resp.Error.Message != "" ||
+		len(resp.Output) > 0 ||
+		resp.Usage.InputTokens != 0 ||
+		resp.Usage.OutputTokens != 0 ||
+		resp.Usage.TotalTokens != 0
 }
 
 func (a *ResponsesAssembler) ensureResponseHasAccumulatedOutput(resp *responses.Response) {

--- a/internal/protocol/assembler/stream_assembler.go
+++ b/internal/protocol/assembler/stream_assembler.go
@@ -1,0 +1,219 @@
+package assembler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// StreamAssembler is the protocol-owned common surface for reconstructing one
+// complete response from native stream events. It accepts SDK events, Wire
+// DTOs, or json.RawMessage values; protocol-specific handling remains here
+// rather than in observers such as Recording.
+type StreamAssembler interface {
+	Add(value any) error
+	Finish() (any, error)
+	Terminal() bool
+	TerminalError() error
+}
+
+// NewStreamAssembler adapts the existing protocol assemblers to one common
+// interface. Protocol conversion is intentionally out of scope: the caller
+// must select the protocol already spoken at its observation boundary.
+func NewStreamAssembler(api protocol.APIType) (StreamAssembler, error) {
+	return newStreamAssembler(api, 1)
+}
+
+// NewStreamAssemblerForRequest configures protocol-specific expectations from
+// the provider-bound request. Today this is used for OpenAI Chat's n choices.
+func NewStreamAssemblerForRequest(api protocol.APIType, request any) (StreamAssembler, error) {
+	return newStreamAssembler(api, OpenAIChatChoiceCount(request))
+}
+
+func newStreamAssembler(api protocol.APIType, expectedChatChoices int) (StreamAssembler, error) {
+	switch api {
+	case protocol.TypeAnthropicV1:
+		return &anthropicV1StreamAssembler{inner: NewAnthropicSDKAssembler()}, nil
+	case protocol.TypeAnthropicBeta:
+		return &anthropicBetaStreamAssembler{inner: NewAnthropicBetaSDKAssembler()}, nil
+	case protocol.TypeOpenAIChat:
+		return &openAIChatStreamAssembler{
+			inner:           NewOpenAIStreamAssembler(),
+			expectedChoices: expectedChatChoices,
+		}, nil
+	case protocol.TypeOpenAIResponses:
+		return &openAIResponsesStreamAssembler{inner: NewResponsesAssembler()}, nil
+	default:
+		return nil, fmt.Errorf("stream assembler: unsupported protocol %q", api)
+	}
+}
+
+// OpenAIChatChoiceCount returns the request's expected number of choices,
+// defaulting invalid, omitted, or non-Chat values to one.
+func OpenAIChatChoiceCount(request any) int {
+	chatRequest, ok := request.(*openai.ChatCompletionNewParams)
+	if !ok || chatRequest == nil {
+		return 1
+	}
+	choices := chatRequest.N.Or(1)
+	if choices < 1 {
+		return 1
+	}
+	maxInt := int(^uint(0) >> 1)
+	if uint64(choices) > uint64(maxInt) {
+		return maxInt
+	}
+	return int(choices)
+}
+
+type anthropicV1StreamAssembler struct {
+	inner    *AnthropicSDKAssembler
+	started  bool
+	terminal bool
+}
+
+func (a *anthropicV1StreamAssembler) Add(value any) error {
+	raw, err := streamEventJSON(value)
+	if err != nil {
+		return err
+	}
+	var event anthropic.MessageStreamEventUnion
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return fmt.Errorf("decode Anthropic V1 stream event: %w", err)
+	}
+	if err := a.inner.Accumulate(event); err != nil {
+		return err
+	}
+	if event.Type == "message_start" {
+		a.started = true
+	}
+	if event.Type == "message_stop" && a.started {
+		a.terminal = true
+	}
+	return nil
+}
+
+func (a *anthropicV1StreamAssembler) Terminal() bool     { return a.terminal }
+func (*anthropicV1StreamAssembler) TerminalError() error { return nil }
+
+func (a *anthropicV1StreamAssembler) Finish() (any, error) {
+	return a.inner.Finish(), nil
+}
+
+type anthropicBetaStreamAssembler struct {
+	inner    *AnthropicBetaSDKAssembler
+	started  bool
+	terminal bool
+}
+
+func (a *anthropicBetaStreamAssembler) Add(value any) error {
+	raw, err := streamEventJSON(value)
+	if err != nil {
+		return err
+	}
+	var event anthropic.BetaRawMessageStreamEventUnion
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return fmt.Errorf("decode Anthropic Beta stream event: %w", err)
+	}
+	if err := a.inner.Accumulate(event); err != nil {
+		return err
+	}
+	if event.Type == "message_start" {
+		a.started = true
+	}
+	if event.Type == "message_stop" && a.started {
+		a.terminal = true
+	}
+	return nil
+}
+
+func (a *anthropicBetaStreamAssembler) Terminal() bool     { return a.terminal }
+func (*anthropicBetaStreamAssembler) TerminalError() error { return nil }
+
+func (a *anthropicBetaStreamAssembler) Finish() (any, error) {
+	return a.inner.Finish(), nil
+}
+
+type openAIChatStreamAssembler struct {
+	inner           *OpenAIChatStreamAssembler
+	expectedChoices int
+	finishedChoices map[int64]struct{}
+}
+
+func (a *openAIChatStreamAssembler) Add(value any) error {
+	raw, err := streamEventJSON(value)
+	if err != nil {
+		return err
+	}
+	var event openai.ChatCompletionChunk
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return fmt.Errorf("decode OpenAI Chat stream event: %w", err)
+	}
+	if !a.inner.AddChunk(event) {
+		return fmt.Errorf("accumulate OpenAI Chat stream chunk %q", event.ID)
+	}
+	for _, choice := range event.Choices {
+		if choice.FinishReason != "" && choice.Index >= 0 && choice.Index < int64(a.expectedChoices) {
+			if a.finishedChoices == nil {
+				a.finishedChoices = make(map[int64]struct{})
+			}
+			a.finishedChoices[choice.Index] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (a *openAIChatStreamAssembler) Terminal() bool {
+	return len(a.finishedChoices) >= a.expectedChoices
+}
+func (*openAIChatStreamAssembler) TerminalError() error { return nil }
+
+func (a *openAIChatStreamAssembler) Finish() (any, error) {
+	return a.inner.Finish(), nil
+}
+
+type openAIResponsesStreamAssembler struct {
+	inner       *ResponsesAssembler
+	terminalErr error
+}
+
+func (a *openAIResponsesStreamAssembler) Add(value any) error {
+	raw, err := streamEventJSON(value)
+	if err != nil {
+		return err
+	}
+	var event responses.ResponseStreamEventUnion
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return fmt.Errorf("decode OpenAI Responses stream event: %w", err)
+	}
+	a.inner.Accumulate(event)
+	switch event.Type {
+	case "response.failed", "error":
+		a.terminalErr = fmt.Errorf("OpenAI Responses stream ended with %s", event.Type)
+	}
+	return nil
+}
+
+func (a *openAIResponsesStreamAssembler) Finish() (any, error) {
+	return a.inner.Finish(), nil
+}
+
+func (a *openAIResponsesStreamAssembler) Terminal() bool       { return a.inner.IsFinished() }
+func (a *openAIResponsesStreamAssembler) TerminalError() error { return a.terminalErr }
+
+func streamEventJSON(value any) ([]byte, error) {
+	if value == nil {
+		return nil, errors.New("stream event is nil")
+	}
+
+	raw, err := protocol.SnapshotJSON(value)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot stream event %T: %w", value, err)
+	}
+	return raw, nil
+}

--- a/internal/protocol/assembler/stream_assembler_test.go
+++ b/internal/protocol/assembler/stream_assembler_test.go
@@ -1,0 +1,260 @@
+package assembler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	protocolstream "github.com/tingly-dev/tingly-box/internal/protocol/stream"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
+)
+
+func TestNewStreamAssemblerRejectsUnsupportedProtocol(t *testing.T) {
+	assembler, err := NewStreamAssembler("")
+	require.Nil(t, assembler)
+	require.ErrorContains(t, err, "unsupported protocol")
+
+	assembler, err = NewStreamAssembler(protocol.TypeGoogle)
+	require.Nil(t, assembler)
+	require.ErrorContains(t, err, "google")
+}
+
+func TestCommonStreamAssemblerAnthropicV1(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeAnthropicV1)
+	require.NoError(t, err)
+
+	require.NoError(t, assembler.Add(anthropic.MessageStreamEventUnion{
+		Type: "message_start",
+		Message: anthropic.Message{
+			ID:    "msg-v1",
+			Type:  "message",
+			Role:  "assistant",
+			Model: "claude-v1",
+		},
+	}))
+
+	result, err := assembler.Finish()
+	require.NoError(t, err)
+	message, ok := result.(*anthropic.Message)
+	require.True(t, ok)
+	require.Equal(t, "msg-v1", string(message.ID))
+}
+
+func TestCommonStreamAssemblerAnthropicBetaFromJSON(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeAnthropicBeta)
+	require.NoError(t, err)
+
+	event := json.RawMessage(`{
+		"type":"message_start",
+		"message":{
+			"id":"msg-beta",
+			"type":"message",
+			"role":"assistant",
+			"content":[],
+			"model":"claude-beta",
+			"stop_reason":null,
+			"stop_sequence":null,
+			"usage":{"input_tokens":1,"output_tokens":0}
+		}
+	}`)
+	require.NoError(t, assembler.Add(event))
+
+	result, err := assembler.Finish()
+	require.NoError(t, err)
+	message, ok := result.(*anthropic.BetaMessage)
+	require.True(t, ok)
+	require.Equal(t, "msg-beta", string(message.ID))
+}
+
+func TestCommonStreamAssemblerAnthropicBetaFromConvertedEvent(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeAnthropicBeta)
+	require.NoError(t, err)
+
+	event := protocolstream.AnthropicEvent{
+		Type: "message_start",
+		Data: map[string]any{
+			"type": "message_start",
+			"message": map[string]any{
+				"id": "msg-converted-beta", "type": "message", "role": "assistant",
+				"content": []any{}, "model": "claude-beta", "stop_reason": nil, "stop_sequence": nil,
+				"usage": map[string]any{"input_tokens": 1, "output_tokens": 0},
+			},
+		},
+	}
+	require.NoError(t, assembler.Add(event))
+
+	result, err := assembler.Finish()
+	require.NoError(t, err)
+	message, ok := result.(*anthropic.BetaMessage)
+	require.True(t, ok)
+	require.Equal(t, "msg-converted-beta", string(message.ID))
+}
+
+func TestCommonStreamAssemblerOpenAIChatAcceptsWireDTO(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeOpenAIChat)
+	require.NoError(t, err)
+
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{
+		ID:      "chat-1",
+		Object:  "chat.completion.chunk",
+		Created: 1,
+		Model:   "public-model",
+		Choices: []wire.ChatStreamChoice{{
+			Index: 0,
+			Delta: wire.ChatStreamDelta{Role: "assistant", Content: "hello "},
+		}},
+	}))
+	stop := "stop"
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{
+		ID:     "chat-1",
+		Object: "chat.completion.chunk",
+		Model:  "public-model",
+		Choices: []wire.ChatStreamChoice{{
+			Index:        0,
+			Delta:        wire.ChatStreamDelta{Content: "world"},
+			FinishReason: &stop,
+		}},
+	}))
+
+	result, err := assembler.Finish()
+	require.NoError(t, err)
+	completion, ok := result.(*openai.ChatCompletion)
+	require.True(t, ok)
+	require.Equal(t, "chat-1", completion.ID)
+	require.Equal(t, "public-model", completion.Model)
+	require.Equal(t, "hello world", completion.Choices[0].Message.Content)
+	require.True(t, assembler.Terminal())
+}
+
+func TestCommonStreamAssemblerOpenAIChatRejectsMismatchedIDs(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeOpenAIChat)
+	require.NoError(t, err)
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{ID: "chat-a", Object: "chat.completion.chunk"}))
+	require.Error(t, assembler.Add(wire.ChatStreamChunk{ID: "chat-b", Object: "chat.completion.chunk"}))
+}
+
+func TestCommonStreamAssemblerOpenAIChatWaitsForEveryChoice(t *testing.T) {
+	request := &openai.ChatCompletionNewParams{N: param.NewOpt(int64(2))}
+	assembler, err := NewStreamAssemblerForRequest(protocol.TypeOpenAIChat, request)
+	require.NoError(t, err)
+	stop := "stop"
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{
+		ID: "chat-multi", Object: "chat.completion.chunk",
+		Choices: []wire.ChatStreamChoice{{
+			Index: 0, FinishReason: &stop,
+		}},
+	}))
+	require.False(t, assembler.Terminal())
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{
+		ID: "chat-multi", Object: "chat.completion.chunk",
+		Choices: []wire.ChatStreamChoice{{Index: 2, FinishReason: &stop}, {Index: 3, FinishReason: &stop}},
+	}))
+	require.False(t, assembler.Terminal(), "out-of-range choice indexes must not complete the stream")
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{
+		ID: "chat-multi", Object: "chat.completion.chunk",
+		Choices: []wire.ChatStreamChoice{{
+			Index: 1, FinishReason: &stop,
+		}},
+	}))
+	require.True(t, assembler.Terminal())
+}
+
+func TestCommonStreamAssemblerOpenAIChatDoesNotPreallocateUntrustedN(t *testing.T) {
+	request := &openai.ChatCompletionNewParams{N: param.NewOpt(int64(^uint64(0) >> 1))}
+	assembler, err := NewStreamAssemblerForRequest(protocol.TypeOpenAIChat, request)
+	require.NoError(t, err)
+	stop := "stop"
+	require.NoError(t, assembler.Add(wire.ChatStreamChunk{
+		ID: "chat-large-n", Object: "chat.completion.chunk",
+		Choices: []wire.ChatStreamChoice{{Index: 0, FinishReason: &stop}},
+	}))
+	require.False(t, assembler.Terminal())
+}
+
+func TestCommonStreamAssemblerAnthropicRequiresMessageStart(t *testing.T) {
+	for _, api := range []protocol.APIType{protocol.TypeAnthropicV1, protocol.TypeAnthropicBeta} {
+		t.Run(string(api), func(t *testing.T) {
+			assembler, err := NewStreamAssembler(api)
+			require.NoError(t, err)
+			require.NoError(t, assembler.Add(json.RawMessage(`{"type":"message_stop"}`)))
+			require.False(t, assembler.Terminal())
+		})
+	}
+}
+
+func TestCommonStreamAssemblerOpenAIResponsesAcceptsWireDTO(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeOpenAIResponses)
+	require.NoError(t, err)
+
+	require.NoError(t, assembler.Add(wire.ResponsesCreatedEvent{
+		Type: "response.created",
+		Response: wire.ResponsesWireResponse{
+			ID:     "resp-1",
+			Object: "response",
+			Status: "in_progress",
+			Model:  "public-model",
+		},
+	}))
+	require.NoError(t, assembler.Add(wire.ResponsesOutputTextDeltaEvent{
+		Type:         "response.output_text.delta",
+		OutputIndex:  0,
+		ContentIndex: 0,
+		Delta:        "hello responses",
+	}))
+	require.NoError(t, assembler.Add(wire.ResponsesCompletedEvent{
+		Type: "response.completed",
+		Response: wire.ResponsesWireResponse{
+			ID:     "resp-1",
+			Object: "response",
+			Status: "completed",
+			Model:  "public-model",
+			Output: []wire.ResponsesOutputItemWire{},
+		},
+	}))
+
+	result, err := assembler.Finish()
+	require.NoError(t, err)
+	response, ok := result.(*responses.Response)
+	require.True(t, ok)
+	require.Equal(t, "resp-1", response.ID)
+	require.Equal(t, responses.ResponsesModel("public-model"), response.Model)
+	require.Equal(t, "hello responses", response.OutputText())
+}
+
+func TestCommonStreamAssemblerRejectsInvalidEvent(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeOpenAIChat)
+	require.NoError(t, err)
+	require.ErrorContains(t, assembler.Add([]byte(`not-json`)), "not valid JSON")
+	require.ErrorContains(t, assembler.Add(nil), "nil")
+}
+
+func TestCommonStreamAssemblerRejectsTypedNilEvent(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeOpenAIChat)
+	require.NoError(t, err)
+	var event *openai.ChatCompletionChunk
+	require.NotPanics(t, func() {
+		require.ErrorContains(t, assembler.Add(event), "nil")
+	})
+}
+
+func TestCommonStreamAssemblerPreservesResponsesFailedPayload(t *testing.T) {
+	assembler, err := NewStreamAssembler(protocol.TypeOpenAIResponses)
+	require.NoError(t, err)
+	require.NoError(t, assembler.Add(json.RawMessage(
+		`{"type":"response.failed","sequence_number":1,"response":{"id":"resp-failed","object":"response","status":"failed","model":"provider-model","output":[],"error":{"code":"server_error","message":"provider failed"}}}`,
+	)))
+	require.True(t, assembler.Terminal())
+	require.ErrorContains(t, assembler.TerminalError(), "response.failed")
+
+	result, err := assembler.Finish()
+	require.NoError(t, err)
+	response, ok := result.(*responses.Response)
+	require.True(t, ok)
+	require.Equal(t, "resp-failed", response.ID)
+	require.Equal(t, responses.ResponseStatusFailed, response.Status)
+}

--- a/internal/protocol/json_snapshot.go
+++ b/internal/protocol/json_snapshot.go
@@ -1,0 +1,50 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// SnapshotJSON returns an owned JSON snapshot of one protocol value. SDK
+// values may expose RawJSON to preserve fields unknown to their typed DTOs;
+// typed nils are rejected before calling that method.
+func SnapshotJSON(value any) ([]byte, error) {
+	if isNilJSONValue(value) {
+		return nil, fmt.Errorf("protocol JSON value %T is nil", value)
+	}
+
+	var raw []byte
+	switch typed := value.(type) {
+	case json.RawMessage:
+		raw = typed
+	case []byte:
+		raw = typed
+	case interface{ RawJSON() string }:
+		raw = []byte(typed.RawJSON())
+	}
+	if len(raw) == 0 {
+		var err error
+		raw, err = json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("protocol JSON value %T is not valid JSON", value)
+	}
+	return append([]byte(nil), raw...), nil
+}
+
+func isNilJSONValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
- assembler/stream_assembler: a protocol-owned common surface for reconstructing one complete response from native stream events (SDK events, Wire DTOs, or json.RawMessage). Moves reconstruction logic out of observers (e.g. Recording) into the protocol layer where it belongs. Adds stream_assembler_test.go covering the reconstruction paths.
- assembler/openai_responses_assembler: OpenAI Responses event assembly adjustments for the new surface.