### PR TITLE
refactor(protocol): centralize usage→wire conversion and type the nonstream converters

### DIFF
--- a/internal/protocol/nonstream/anthropic.go
+++ b/internal/protocol/nonstream/anthropic.go
@@ -13,9 +13,15 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
-// HandleAnthropicBetaToOpenAIResponse converts an Anthropic BetaMessage to the
-// OpenAI Chat Completions wire format.
+// HandleAnthropicBetaToOpenAIResponse preserves the legacy conversion entry
+// point while delegating to the transport-neutral value converter.
 func HandleAnthropicBetaToOpenAIResponse(bm *anthropic.BetaMessage, responseModel string) wire.ChatCompletionWire {
+	return ConvertAnthropicBetaToOpenAIChat(bm, responseModel)
+}
+
+// ConvertAnthropicBetaToOpenAIChat converts an Anthropic Beta message to the
+// transport-neutral OpenAI Chat Completions wire value.
+func ConvertAnthropicBetaToOpenAIChat(bm *anthropic.BetaMessage, responseModel string) wire.ChatCompletionWire {
 	var toolCalls []wire.ChatCompletionToolCallWire
 	var textContent string
 	var thinking string
@@ -57,20 +63,7 @@ func HandleAnthropicBetaToOpenAIResponse(bm *anthropic.BetaMessage, responseMode
 	}
 
 	// OpenAI wire: prompt_tokens = total (uncached + cache_read + cache_creation).
-	promptTokens := bm.Usage.InputTokens +
-		bm.Usage.CacheReadInputTokens +
-		bm.Usage.CacheCreationInputTokens
-	usage := wire.ChatCompletionUsageWire{
-		PromptTokens:     promptTokens,
-		CompletionTokens: bm.Usage.OutputTokens,
-		TotalTokens:      promptTokens + bm.Usage.OutputTokens,
-	}
-	if bm.Usage.CacheReadInputTokens > 0 || bm.Usage.CacheCreationInputTokens > 0 {
-		usage.PromptTokensDetails = &wire.ChatCompletionPromptDetailsWire{
-			CachedTokens:     bm.Usage.CacheReadInputTokens,
-			CacheWriteTokens: bm.Usage.CacheCreationInputTokens,
-		}
-	}
+	usage := usage.ToChatUsageWire(usage.FromAnthropicBetaMessage(bm.Usage))
 
 	return wire.ChatCompletionWire{
 		ID:      bm.ID,

--- a/internal/protocol/nonstream/nonstream_test.go
+++ b/internal/protocol/nonstream/nonstream_test.go
@@ -111,6 +111,29 @@ func TestHandleAnthropicToOpenAI(t *testing.T) {
 	}
 }
 
+func TestConvertAnthropicBetaToOpenAIChatMatchesLegacyEntry(t *testing.T) {
+	message := &anthropic.BetaMessage{
+		ID:   "msg_transport_neutral",
+		Role: "assistant",
+		Content: []anthropic.BetaContentBlockUnion{
+			{Type: "text", Text: "parallel path"},
+		},
+		StopReason: "end_turn",
+		Usage: anthropic.BetaUsage{
+			InputTokens:  4,
+			OutputTokens: 2,
+		},
+	}
+
+	pure := ConvertAnthropicBetaToOpenAIChat(message, "client-visible-model")
+	legacy := HandleAnthropicBetaToOpenAIResponse(message, "client-visible-model")
+	// Created is intentionally generated at conversion time; normalize it when
+	// comparing two sequential calls to the same pure implementation.
+	pure.Created = 0
+	legacy.Created = 0
+	assert.Equal(t, pure, legacy)
+}
+
 func TestHandleOpenAIToAnthropic(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -3,7 +3,6 @@ package nonstream
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/google/uuid"
@@ -29,8 +28,37 @@ func anthropicUsageWire(u *protocol.TokenUsage) wire.AnthropicUsageWire {
 }
 
 func HandleOpenAIChatToAnthropic(chat *openai.ChatCompletion, model string) *anthropic.BetaMessage {
-	wire := wire.AnthropicMsgWire{
-		ID:           fmt.Sprintf("msg_%d", time.Now().Unix()),
+	value, err := marshalOpenAIChatToAnthropic(chat, model)
+	if err != nil {
+		return &anthropic.BetaMessage{}
+	}
+	var msg anthropic.BetaMessage
+	if err := json.Unmarshal(value, &msg); err != nil {
+		return &anthropic.BetaMessage{}
+	}
+	return &msg
+}
+
+// ConvertOpenAIChatToAnthropicV1 converts an OpenAI Chat completion to a typed
+// Anthropic v1 response without writing it to an HTTP transport.
+func ConvertOpenAIChatToAnthropicV1(chat *openai.ChatCompletion, model string) (*anthropic.Message, error) {
+	value, err := marshalOpenAIChatToAnthropic(chat, model)
+	if err != nil {
+		return nil, err
+	}
+	var msg anthropic.Message
+	if err := json.Unmarshal(value, &msg); err != nil {
+		return nil, fmt.Errorf("decode Anthropic v1 response: %w", err)
+	}
+	return &msg, nil
+}
+
+func marshalOpenAIChatToAnthropic(chat *openai.ChatCompletion, model string) ([]byte, error) {
+	if chat == nil {
+		return nil, fmt.Errorf("convert OpenAI Chat response to Anthropic: response is nil")
+	}
+	result := wire.AnthropicMsgWire{
+		ID:           "msg_" + uuid.NewString(),
 		Type:         "message",
 		Role:         "assistant",
 		Content:      []interface{}{},
@@ -43,7 +71,7 @@ func HandleOpenAIChatToAnthropic(chat *openai.ChatCompletion, model string) *ant
 	// Preserve server_tool_use from ExtraFields if present
 	if chat.JSON.ExtraFields != nil {
 		if serverToolUse, exists := chat.JSON.ExtraFields["server_tool_use"]; exists && serverToolUse.Valid() {
-			wire.ServerToolUse = json.RawMessage(serverToolUse.Raw())
+			result.ServerToolUse = json.RawMessage(serverToolUse.Raw())
 		}
 	}
 
@@ -68,22 +96,38 @@ func HandleOpenAIChatToAnthropic(chat *openai.ChatCompletion, model string) *ant
 			contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
 		}
 		if choice.FinishReason == "tool_calls" {
-			wire.StopReason = "tool_use"
+			result.StopReason = "tool_use"
+		} else if choice.FinishReason == "length" {
+			result.StopReason = "max_tokens"
 		}
 		break
 	}
-	wire.Content = contentBlocks
+	result.Content = contentBlocks
 
-	jsonBytes, _ := json.Marshal(wire)
-	var msg anthropic.BetaMessage
-	json.Unmarshal(jsonBytes, &msg)
-	return &msg
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode Anthropic response: %w", err)
+	}
+	return jsonBytes, nil
 }
 
 // HandleOpenAIChatToAnthropicBeta converts OpenAI response to Anthropic beta format
 func HandleOpenAIChatToAnthropicBeta(chat *openai.ChatCompletion, model string) anthropic.BetaMessage {
-	wire := wire.AnthropicMsgWire{
-		ID:           fmt.Sprintf("msg_%d", time.Now().Unix()),
+	msg, err := ConvertOpenAIChatToAnthropicBeta(chat, model)
+	if err != nil {
+		return anthropic.BetaMessage{}
+	}
+	return *msg
+}
+
+// ConvertOpenAIChatToAnthropicBeta converts an OpenAI Chat completion to a
+// typed Anthropic beta response without writing it to an HTTP transport.
+func ConvertOpenAIChatToAnthropicBeta(chat *openai.ChatCompletion, model string) (*anthropic.BetaMessage, error) {
+	if chat == nil {
+		return nil, fmt.Errorf("convert OpenAI Chat response to Anthropic beta: response is nil")
+	}
+	result := wire.AnthropicMsgWire{
+		ID:           "msg_" + uuid.NewString(),
 		Type:         "message",
 		Role:         "assistant",
 		Content:      []interface{}{},
@@ -95,7 +139,7 @@ func HandleOpenAIChatToAnthropicBeta(chat *openai.ChatCompletion, model string) 
 
 	if chat.JSON.ExtraFields != nil {
 		if serverToolUse, exists := chat.JSON.ExtraFields["server_tool_use"]; exists && serverToolUse.Valid() {
-			wire.ServerToolUse = json.RawMessage(serverToolUse.Raw())
+			result.ServerToolUse = json.RawMessage(serverToolUse.Raw())
 		}
 	}
 
@@ -120,16 +164,23 @@ func HandleOpenAIChatToAnthropicBeta(chat *openai.ChatCompletion, model string) 
 			contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(toolCall.ID, input, toolCall.Function.Name))
 		}
 		if choice.FinishReason == "tool_calls" {
-			wire.StopReason = string(anthropic.BetaStopReasonToolUse)
+			result.StopReason = string(anthropic.BetaStopReasonToolUse)
+		} else if choice.FinishReason == "length" {
+			result.StopReason = string(anthropic.BetaStopReasonMaxTokens)
 		}
 		break
 	}
-	wire.Content = contentBlocks
+	result.Content = contentBlocks
 
-	jsonBytes, _ := json.Marshal(wire)
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode Anthropic beta response: %w", err)
+	}
 	var msg anthropic.BetaMessage
-	json.Unmarshal(jsonBytes, &msg)
-	return msg
+	if err := json.Unmarshal(jsonBytes, &msg); err != nil {
+		return nil, fmt.Errorf("decode Anthropic beta response: %w", err)
+	}
+	return &msg, nil
 }
 
 // HandleResponsesToAnthropicBeta converts OpenAI Responses API response to Anthropic beta format
@@ -159,7 +210,7 @@ func HandleResponsesToAnthropicBeta(rs *responses.Response, model string) anthro
 			if err := json.Unmarshal([]byte(argsStr), &arguments); err != nil {
 				arguments = make(map[string]interface{})
 			}
-			contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(output.ID, arguments, output.Name))
+			contentBlocks = append(contentBlocks, anthropic.NewBetaToolUseBlock(responsesToolCallID(output), arguments, output.Name))
 			wire.StopReason = string(anthropic.BetaStopReasonToolUse)
 		}
 	}
@@ -169,6 +220,13 @@ func HandleResponsesToAnthropicBeta(rs *responses.Response, model string) anthro
 			if content.Type == "reasoning_text" && content.Text != "" {
 				contentBlocks = append(contentBlocks, anthropic.NewBetaThinkingBlock("thinking-"+uuid.New().String()[0:6], content.Text))
 			}
+		}
+	}
+	if rs.Status == "incomplete" {
+		if rs.IncompleteDetails.Reason == "content_filter" {
+			wire.StopReason = string(anthropic.BetaStopReasonRefusal)
+		} else {
+			wire.StopReason = string(anthropic.BetaStopReasonMaxTokens)
 		}
 	}
 
@@ -216,7 +274,7 @@ func HandleResponsesToAnthropicV1(rs *responses.Response, model string) anthropi
 			if err := json.Unmarshal([]byte(argsStr), &arguments); err != nil {
 				arguments = make(map[string]interface{})
 			}
-			contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(output.ID, arguments, output.Name))
+			contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(responsesToolCallID(output), arguments, output.Name))
 			wire.StopReason = "tool_use"
 		}
 	}
@@ -226,6 +284,13 @@ func HandleResponsesToAnthropicV1(rs *responses.Response, model string) anthropi
 			if content.Type == "reasoning_text" && content.Text != "" {
 				contentBlocks = append(contentBlocks, anthropic.NewThinkingBlock("thinking-"+uuid.New().String()[0:6], content.Text))
 			}
+		}
+	}
+	if rs.Status == "incomplete" {
+		if rs.IncompleteDetails.Reason == "content_filter" {
+			wire.StopReason = "refusal"
+		} else {
+			wire.StopReason = "max_tokens"
 		}
 	}
 
@@ -244,6 +309,13 @@ func HandleResponsesToAnthropicV1(rs *responses.Response, model string) anthropi
 	var msg anthropic.Message
 	json.Unmarshal(jsonBytes, &msg)
 	return msg
+}
+
+func responsesToolCallID(output responses.ResponseOutputItemUnion) string {
+	if output.CallID != "" {
+		return output.CallID
+	}
+	return output.ID
 }
 
 // resolveResponsesArguments extracts the arguments string from a Responses API output item.

--- a/internal/protocol/nonstream/openai_to_anthropic_semantics_test.go
+++ b/internal/protocol/nonstream/openai_to_anthropic_semantics_test.go
@@ -1,0 +1,73 @@
+package nonstream
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesToAnthropicUsesCallID(t *testing.T) {
+	var response responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id":"resp_tool","object":"response","status":"completed","model":"provider-model",
+		"output":[{"id":"fc_item","call_id":"call_weather","type":"function_call","name":"get_weather","arguments":"{\"city\":\"Paris\"}","status":"completed"}],
+		"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}
+	}`), &response))
+
+	beta := HandleResponsesToAnthropicBeta(&response, "public-model")
+	require.Len(t, beta.Content, 1)
+	assert.Equal(t, "tool_use", beta.Content[0].Type)
+	assert.Equal(t, "call_weather", beta.Content[0].ID)
+
+	v1 := HandleResponsesToAnthropicV1(&response, "public-model")
+	require.Len(t, v1.Content, 1)
+	assert.Equal(t, "tool_use", v1.Content[0].Type)
+	assert.Equal(t, "call_weather", v1.Content[0].ID)
+}
+
+func TestCompleteConversionsPreserveTruncation(t *testing.T) {
+	chat := &openai.ChatCompletion{
+		ID: "chatcmpl-length",
+		Choices: []openai.ChatCompletionChoice{{
+			FinishReason: "length",
+			Message:      openai.ChatCompletionMessage{Role: "assistant", Content: "partial"},
+		}},
+	}
+	v1, err := ConvertOpenAIChatToAnthropicV1(chat, "public-model")
+	require.NoError(t, err)
+	assert.Equal(t, "max_tokens", string(v1.StopReason))
+	beta, err := ConvertOpenAIChatToAnthropicBeta(chat, "public-model")
+	require.NoError(t, err)
+	assert.Equal(t, "max_tokens", string(beta.StopReason))
+
+	var response responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id":"resp_incomplete","object":"response","status":"incomplete","model":"provider-model",
+		"incomplete_details":{"reason":"max_output_tokens"},
+		"output":[{"id":"msg_1","type":"message","role":"assistant","status":"incomplete","content":[{"type":"output_text","text":"partial","annotations":[]}]}],
+		"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}
+	}`), &response))
+	responsesV1 := HandleResponsesToAnthropicV1(&response, "public-model")
+	assert.Equal(t, "max_tokens", string(responsesV1.StopReason))
+	responsesBeta := HandleResponsesToAnthropicBeta(&response, "public-model")
+	assert.Equal(t, "max_tokens", string(responsesBeta.StopReason))
+}
+
+func TestChatToAnthropicSyntheticIDsAreUnique(t *testing.T) {
+	chat := &openai.ChatCompletion{
+		ID: "chatcmpl-source",
+		Choices: []openai.ChatCompletionChoice{{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Role: "assistant", Content: "hello"},
+		}},
+	}
+	first, err := ConvertOpenAIChatToAnthropicV1(chat, "public-model")
+	require.NoError(t, err)
+	second, err := ConvertOpenAIChatToAnthropicV1(chat, "public-model")
+	require.NoError(t, err)
+	assert.NotEqual(t, first.ID, second.ID)
+}

--- a/internal/protocol/nonstream/openai_to_chat.go
+++ b/internal/protocol/nonstream/openai_to_chat.go
@@ -8,51 +8,67 @@ import (
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	usageconv "github.com/tingly-dev/tingly-box/internal/protocol/usage"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
 type responsesToChatNonStreamState struct {
 	content   strings.Builder
 	refusal   strings.Builder
-	toolCalls []map[string]any
+	toolCalls []wire.ChatCompletionToolCallWire
 }
 
 // HandleResponsesToOpenAIChat writes a Responses API response as OpenAI Chat format.
 // Corresponds to stream.HandleResponsesToOpenAIChatStream.
 func HandleResponsesToOpenAIChat(hc *protocol.HandleContext, rs *responses.Response) (map[string]any, *protocol.TokenUsage, error) {
-	state := buildResponsesToChatNonStreamState(rs)
-	message := state.message()
-
-	choices := []map[string]any{
-		{
-			"index":         0,
-			"message":       message,
-			"finish_reason": mapResponsesFinishReason(rs, len(state.toolCalls) > 0),
-		},
-	}
-
-	// The canonical type owns the Chat usage shape; only total_tokens differs,
-	// preferring the value upstream actually reported when it sent one.
-	normalizedUsage := usageconv.FromOpenAIResponses(rs.Usage)
-	usage := normalizedUsage.ToOpenAIChatUsageMap()
-	if reported := int(rs.Usage.TotalTokens); reported != 0 {
-		usage["total_tokens"] = reported
-	}
-
-	chatResp := map[string]any{
-		"id":      rs.ID,
-		"object":  "chat.completion",
-		"created": int64(rs.CreatedAt),
-		"model":   hc.ResponseModel,
-		"choices": choices,
-		"usage":   usage,
-	}
+	chatResp := BuildOpenAIChatPayloadFromResponses(rs, hc.ResponseModel)
 	hc.GinContext.JSON(http.StatusOK, chatResp)
 	return chatResp, usageconv.FromOpenAIResponses(rs.Usage), nil
 }
 
+// BuildOpenAIChatPayloadFromResponses converts a complete Responses result to
+// the minimal Chat Completions wire shape without writing an HTTP response.
+func BuildOpenAIChatPayloadFromResponses(rs *responses.Response, responseModel string) map[string]any {
+	return ConvertResponsesToOpenAIChat(rs, responseModel).ToMap()
+}
+
+// ConvertResponsesToOpenAIChat builds the typed Chat Completions wire
+// contract without coupling protocol conversion to HTTP or generic maps.
+func ConvertResponsesToOpenAIChat(rs *responses.Response, responseModel string) wire.ChatCompletionWire {
+	state := buildResponsesToChatNonStreamState(rs)
+	message := wire.ChatCompletionMessageWire{
+		Role:      "assistant",
+		Content:   state.content.String(),
+		Refusal:   state.refusal.String(),
+		ToolCalls: state.toolCalls,
+	}
+
+	// The canonical wire type owns the Chat usage shape; only total_tokens is
+	// overridden with the value the upstream Responses API actually reported
+	// (per .design/stream-usage-tracking.md §"wire usage map" — cover one key,
+	// do not fork the constructor). Falls back to the computed value when the
+	// upstream did not report one.
+	usage := usageconv.ToChatUsageWire(usageconv.FromOpenAIResponses(rs.Usage))
+	if reported := rs.Usage.TotalTokens; reported != 0 {
+		usage.TotalTokens = reported
+	}
+
+	return wire.ChatCompletionWire{
+		ID:      rs.ID,
+		Object:  "chat.completion",
+		Created: int64(rs.CreatedAt),
+		Model:   responseModel,
+		Choices: []wire.ChatCompletionChoiceWire{{
+			Index:        0,
+			Message:      message,
+			FinishReason: mapResponsesFinishReason(rs, len(state.toolCalls) > 0),
+		}},
+		Usage: usage,
+	}
+}
+
 func buildResponsesToChatNonStreamState(rs *responses.Response) *responsesToChatNonStreamState {
 	state := &responsesToChatNonStreamState{
-		toolCalls: make([]map[string]any, 0),
+		toolCalls: make([]wire.ChatCompletionToolCallWire, 0),
 	}
 	if rs == nil {
 		return state
@@ -70,39 +86,18 @@ func buildResponsesToChatNonStreamState(rs *responses.Response) *responsesToChat
 				}
 			}
 		case "function_call", "custom_tool_call", "mcp_call":
-			state.toolCalls = append(state.toolCalls, map[string]any{
-				"id":   firstNonEmpty(output.CallID, output.ID),
-				"type": "function",
-				"function": map[string]any{
-					"name":      output.Name,
-					"arguments": output.Arguments.OfString,
+			state.toolCalls = append(state.toolCalls, wire.ChatCompletionToolCallWire{
+				ID:   firstNonEmpty(output.CallID, output.ID),
+				Type: "function",
+				Function: wire.ChatCompletionFunctionWire{
+					Name:      output.Name,
+					Arguments: output.Arguments.OfString,
 				},
 			})
 		}
 	}
 
 	return state
-}
-
-func (s *responsesToChatNonStreamState) message() map[string]any {
-	message := map[string]any{
-		"role": "assistant",
-	}
-	if s == nil {
-		return message
-	}
-
-	if content := s.content.String(); content != "" {
-		message["content"] = content
-	}
-	if refusal := s.refusal.String(); refusal != "" {
-		message["refusal"] = refusal
-	}
-	if len(s.toolCalls) > 0 {
-		message["tool_calls"] = s.toolCalls
-	}
-
-	return message
 }
 
 func mapResponsesFinishReason(rs *responses.Response, hasToolCalls bool) string {

--- a/internal/protocol/nonstream/openai_to_chat_test.go
+++ b/internal/protocol/nonstream/openai_to_chat_test.go
@@ -51,9 +51,9 @@ func TestOpenAIResponsesToChatToolCalls(t *testing.T) {
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	result, _, err := HandleResponsesToOpenAIChat(protocol.NewHandleContext(c, "proxy-model"), &resp)
 	require.NoError(t, err)
-	choices := result["choices"].([]map[string]any)
+	choices := asJSONMapSlice(t, result["choices"])
 	message := choices[0]["message"].(map[string]any)
-	toolCalls := message["tool_calls"].([]map[string]any)
+	toolCalls := asJSONMapSlice(t, message["tool_calls"])
 
 	assert.Equal(t, "tool_calls", choices[0]["finish_reason"])
 	assert.Equal(t, "assistant", message["role"])
@@ -112,8 +112,48 @@ func TestOpenAIResponsesToChatIncompleteReasons(t *testing.T) {
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
 			result, _, err := HandleResponsesToOpenAIChat(protocol.NewHandleContext(c, "proxy-model"), &resp)
 			require.NoError(t, err)
-			choices := result["choices"].([]map[string]any)
+			choices := asJSONMapSlice(t, result["choices"])
 			assert.Equal(t, tt.expectedStop, choices[0]["finish_reason"])
 		})
 	}
+}
+
+func TestConvertResponsesToOpenAIChatPreservesTypedExtensions(t *testing.T) {
+	raw := []byte(`{
+		"id":"resp_extensions","created_at":1710000000,"model":"gpt-4.1",
+		"object":"response","status":"completed",
+		"output":[{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"refusal","refusal":"cannot comply"}]}],
+		"usage":{"input_tokens":12,"output_tokens":7,"total_tokens":19,"input_tokens_details":{"cached_tokens":4},"output_tokens_details":{"reasoning_tokens":3}}
+	}`)
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal(raw, &resp))
+
+	converted := ConvertResponsesToOpenAIChat(&resp, "public-model")
+	require.Len(t, converted.Choices, 1)
+	assert.Equal(t, "cannot comply", converted.Choices[0].Message.Refusal)
+	require.NotNil(t, converted.Usage.PromptTokensDetails)
+	assert.EqualValues(t, 4, converted.Usage.PromptTokensDetails.CachedTokens)
+	require.NotNil(t, converted.Usage.CompletionTokensDetails)
+	assert.EqualValues(t, 3, converted.Usage.CompletionTokensDetails.ReasoningTokens)
+
+	payload := converted.ToMap()
+	choices := asJSONMapSlice(t, payload["choices"])
+	message := choices[0]["message"].(map[string]any)
+	assert.Equal(t, "cannot comply", message["refusal"])
+	usage := payload["usage"].(map[string]any)
+	assert.EqualValues(t, 3, usage["completion_tokens_details"].(map[string]any)["reasoning_tokens"])
+}
+
+func asJSONMapSlice(t *testing.T, value any) []map[string]any {
+	t.Helper()
+	items, ok := value.([]any)
+	require.Truef(t, ok, "expected JSON array, got %T", value)
+
+	result := make([]map[string]any, len(items))
+	for i, item := range items {
+		mapped, ok := item.(map[string]any)
+		require.Truef(t, ok, "expected JSON object at index %d, got %T", i, item)
+		result[i] = mapped
+	}
+	return result
 }

--- a/internal/protocol/nonstream/openai_to_responses.go
+++ b/internal/protocol/nonstream/openai_to_responses.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/usage"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
 // HandleOpenAIChatToResponses writes an OpenAI Chat response as Responses API format.
@@ -29,6 +30,12 @@ func HandleAnthropicBetaToResponses(hc *protocol.HandleContext, resp *anthropic.
 
 // BuildResponsesPayloadFromChat converts a Chat completion response to Responses API format.
 func BuildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, actualModel string) map[string]any {
+	return ConvertChatToResponsesWire(resp, responseModel, actualModel).ToMap()
+}
+
+// ConvertChatToResponsesWire builds the typed Responses API output contract
+// without routing protocol conversion through generic maps or JSON decoding.
+func ConvertChatToResponsesWire(resp *openai.ChatCompletion, responseModel, actualModel string) wire.ResponsesWireResponse {
 	model := responseModel
 	if model == "" {
 		model = actualModel
@@ -41,135 +48,161 @@ func BuildResponsesPayloadFromChat(resp *openai.ChatCompletion, responseModel, a
 		finishReason = string(resp.Choices[0].FinishReason)
 	}
 
-	status, incompleteDetails := chatFinishReasonToResponsesStatus(finishReason)
+	status, incompleteReason := chatFinishReasonToResponsesStatus(finishReason)
 	itemStatus := status
 
-	output := []map[string]any{}
+	output := []wire.ResponsesOutputItemWire{}
 	if messageContent != "" {
-		output = append(output, map[string]any{
+		output = append(output, wire.ResponsesOutputItemWire{
 			// The real Responses API always assigns output items an id;
 			// strict clients (AI SDK zod) require it.
-			"id":     "msg_" + resp.ID,
-			"type":   "message",
-			"role":   "assistant",
-			"status": itemStatus,
-			"content": []map[string]any{
+			ID:     "msg_" + resp.ID,
+			Type:   "message",
+			Role:   "assistant",
+			Status: itemStatus,
+			Content: []wire.ResponsesContentPartWire{
 				// The real Responses API always includes annotations on
 				// output_text; strict clients (AI SDK zod) require it.
-				{"type": "output_text", "text": messageContent, "annotations": []any{}},
+				{Type: "output_text", Text: messageContent, Annotations: []any{}},
 			},
 		})
+	}
+	if len(resp.Choices) > 0 {
+		for _, toolCall := range resp.Choices[0].Message.ToolCalls {
+			arguments := toolCall.Function.Arguments
+			output = append(output, wire.ResponsesOutputItemWire{
+				ID:        toolCall.ID,
+				CallID:    toolCall.ID,
+				Type:      "function_call",
+				Name:      toolCall.Function.Name,
+				Arguments: &arguments,
+				Status:    itemStatus,
+			})
+		}
 	}
 
 	// The canonical type owns the Responses usage shape, including the cache
 	// read/write and reasoning detail a client would otherwise read as zeros.
-	usageMap := usage.FromOpenAIChatCompletion(resp.Usage).ToOpenAIResponsesUsageMap()
+	usageWire := usage.ToResponsesUsageWire(usage.FromOpenAIChatCompletion(resp.Usage))
 
-	result := map[string]any{
-		"id":         resp.ID,
-		"object":     "response",
-		"created_at": time.Now().Unix(),
-		"model":      model,
-		"status":     status,
-		"output":     output,
-		"usage":      usageMap,
+	result := wire.ResponsesWireResponse{
+		ID:        resp.ID,
+		Object:    "response",
+		CreatedAt: time.Now().Unix(),
+		Model:     model,
+		Status:    status,
+		Output:    output,
+		Usage:     usageWire,
 	}
-	if incompleteDetails != nil {
-		result["incomplete_details"] = incompleteDetails
+	if incompleteReason != "" {
+		result.IncompleteDetails = &wire.ResponsesIncompleteDetailsWire{
+			Reason: incompleteReason,
+		}
 	}
 	return result
 }
 
-func chatFinishReasonToResponsesStatus(finishReason string) (string, map[string]any) {
+func chatFinishReasonToResponsesStatus(finishReason string) (status, incompleteReason string) {
 	switch finishReason {
 	case "length":
-		return "incomplete", map[string]any{"reason": "max_output_tokens"}
+		return "incomplete", "max_output_tokens"
 	case "content_filter":
-		return "incomplete", map[string]any{"reason": "content_filter"}
+		return "incomplete", "content_filter"
 	default:
-		return "completed", nil
+		return "completed", ""
 	}
 }
 
 // BuildResponsesPayloadFromAnthropicBeta converts an Anthropic Beta message response to Responses API format.
 func BuildResponsesPayloadFromAnthropicBeta(resp *anthropic.BetaMessage, responseModel, actualModel string) map[string]any {
+	return ConvertAnthropicBetaToResponsesWire(resp, responseModel, actualModel).ToMap()
+}
+
+// ConvertAnthropicBetaToResponsesWire builds the typed Responses API output
+// contract without coupling the Bridge to transport or SDK JSON internals.
+func ConvertAnthropicBetaToResponsesWire(resp *anthropic.BetaMessage, responseModel, actualModel string) wire.ResponsesWireResponse {
 	model := responseModel
 	if model == "" {
 		model = actualModel
 	}
 
-	status, incompleteDetails := anthropicStopReasonToResponsesStatus(string(resp.StopReason))
+	status, incompleteReason := anthropicStopReasonToResponsesStatus(string(resp.StopReason))
 
-	output := []map[string]any{}
-	outputIndex := 0
+	output := []wire.ResponsesOutputItemWire{}
 
-	var textParts []map[string]any
+	var textParts []wire.ResponsesContentPartWire
 	for _, block := range resp.Content {
-		switch block.Type {
-		case "text":
+		if block.Type == "text" {
 			if block.Text == "" {
 				continue
 			}
-			textParts = append(textParts, map[string]any{
-				"type":        "output_text",
-				"text":        block.Text,
-				"annotations": []any{},
+			textParts = append(textParts, wire.ResponsesContentPartWire{
+				Type:        "output_text",
+				Text:        block.Text,
+				Annotations: []any{},
 			})
-		case "tool_use":
-			argsJSON := "{}"
-			if block.Input != nil {
-				if raw, err := json.Marshal(block.Input); err == nil {
-					argsJSON = string(raw)
-				}
-			}
-			output = append(output, map[string]any{
-				"type":         "function_call",
-				"id":           block.ID,
-				"name":         block.Name,
-				"arguments":    argsJSON,
-				"output_index": outputIndex,
-			})
-			outputIndex++
 		}
 	}
 
 	if len(textParts) > 0 {
-		msgItem := map[string]any{
-			"id":      "msg_" + resp.ID,
-			"type":    "message",
-			"role":    "assistant",
-			"status":  status,
-			"content": textParts,
+		msgItem := wire.ResponsesOutputItemWire{
+			ID:      "msg_" + resp.ID,
+			Type:    "message",
+			Role:    "assistant",
+			Status:  status,
+			Content: textParts,
 		}
-		output = append([]map[string]any{msgItem}, output...)
+		output = append(output, msgItem)
+	}
+
+	for _, block := range resp.Content {
+		if block.Type != "tool_use" {
+			continue
+		}
+		argsJSON := "{}"
+		if block.Input != nil {
+			if raw, err := json.Marshal(block.Input); err == nil {
+				argsJSON = string(raw)
+			}
+		}
+		output = append(output, wire.ResponsesOutputItemWire{
+			Type:      "function_call",
+			ID:        block.ID,
+			CallID:    block.ID,
+			Name:      block.Name,
+			Arguments: &argsJSON,
+			Status:    status,
+		})
 	}
 
 	// Responses-API input_tokens is the TOTAL prompt cost, so normalizing the
 	// Anthropic usage folds cache_creation into it and reports cache_read
 	// separately — Anthropic cache_creation lands in the cache_write_tokens slot,
 	// both being the premium-rate write portion of the prompt total.
-	usageMap := usage.FromAnthropicBetaMessage(resp.Usage).ToOpenAIResponsesUsageMap()
+	usageWire := usage.ToResponsesUsageWire(usage.FromAnthropicBetaMessage(resp.Usage))
 
-	result := map[string]any{
-		"id":         resp.ID,
-		"object":     "response",
-		"created_at": time.Now().Unix(),
-		"model":      model,
-		"status":     status,
-		"output":     output,
-		"usage":      usageMap,
+	result := wire.ResponsesWireResponse{
+		ID:        resp.ID,
+		Object:    "response",
+		CreatedAt: time.Now().Unix(),
+		Model:     model,
+		Status:    status,
+		Output:    output,
+		Usage:     usageWire,
 	}
-	if incompleteDetails != nil {
-		result["incomplete_details"] = incompleteDetails
+	if incompleteReason != "" {
+		result.IncompleteDetails = &wire.ResponsesIncompleteDetailsWire{
+			Reason: incompleteReason,
+		}
 	}
 	return result
 }
 
-func anthropicStopReasonToResponsesStatus(stopReason string) (string, map[string]any) {
+func anthropicStopReasonToResponsesStatus(stopReason string) (status, incompleteReason string) {
 	switch stopReason {
 	case "max_tokens":
-		return "incomplete", map[string]any{"reason": "max_output_tokens"}
+		return "incomplete", "max_output_tokens"
 	default:
-		return "completed", nil
+		return "completed", ""
 	}
 }

--- a/internal/protocol/nonstream/openai_usage_test.go
+++ b/internal/protocol/nonstream/openai_usage_test.go
@@ -1,10 +1,13 @@
 package nonstream
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +35,10 @@ func TestBuildResponsesPayloadFromChat_UsageDetails(t *testing.T) {
 	}
 
 	payload := BuildResponsesPayloadFromChat(resp, "gpt-x", "gpt-x")
+	typed := ConvertChatToResponsesWire(resp, "gpt-x", "gpt-x")
+	require.NotNil(t, typed.Usage)
+	assert.EqualValues(t, 30, typed.Usage.InputTokensDetails.CachedTokens)
+	assert.EqualValues(t, 12, typed.Usage.OutputTokensDetails.ReasoningTokens)
 	usage, _ := payload["usage"].(map[string]any)
 	require.NotNil(t, usage)
 
@@ -45,6 +52,83 @@ func TestBuildResponsesPayloadFromChat_UsageDetails(t *testing.T) {
 	outDetails, _ := usage["output_tokens_details"].(map[string]any)
 	require.NotNil(t, outDetails, "output_tokens_details must carry reasoning_tokens")
 	assert.EqualValues(t, 12, outDetails["reasoning_tokens"])
+}
+
+func TestConvertAnthropicBetaToResponsesWireToolCall(t *testing.T) {
+	resp := &anthropic.BetaMessage{
+		ID:   "msg_tool",
+		Role: "assistant",
+		Type: "message",
+		Content: []anthropic.BetaContentBlockUnion{
+			{Type: "text", Text: "checking"},
+			{
+				Type: "tool_use", ID: "call_1", Name: "lookup",
+				Input: json.RawMessage(`{"query":"typed wire"}`),
+			},
+		},
+		StopReason: "tool_use",
+	}
+
+	converted := ConvertAnthropicBetaToResponsesWire(resp, "public-model", "provider-model")
+	require.Len(t, converted.Output, 2)
+	assert.Equal(t, "message", converted.Output[0].Type)
+	item := converted.Output[1]
+	assert.Equal(t, "function_call", item.Type)
+	assert.Equal(t, "completed", item.Status)
+	assert.Equal(t, "call_1", item.CallID)
+	require.NotNil(t, item.Arguments)
+	assert.Contains(t, *item.Arguments, "typed wire")
+
+	encoded, err := json.Marshal(converted)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(encoded), `"arguments":"{\"query\":\"typed wire\"}"`), string(encoded))
+	assert.NotContains(t, string(encoded), `"output_index"`)
+}
+
+func TestConvertChatToResponsesWirePreservesToolCalls(t *testing.T) {
+	resp := &openai.ChatCompletion{
+		ID: "chatcmpl_tool",
+		Choices: []openai.ChatCompletionChoice{{
+			FinishReason: "tool_calls",
+			Message: openai.ChatCompletionMessage{ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
+				ID:   "call_chat_1",
+				Type: "function",
+				Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+					Name: "lookup", Arguments: `{"query":"typed wire"}`,
+				},
+			}}},
+		}},
+	}
+
+	converted := ConvertChatToResponsesWire(resp, "public-model", "provider-model")
+	require.Len(t, converted.Output, 1)
+	item := converted.Output[0]
+	assert.Equal(t, "function_call", item.Type)
+	assert.Equal(t, "call_chat_1", item.ID)
+	assert.Equal(t, "call_chat_1", item.CallID)
+	assert.Equal(t, "lookup", item.Name)
+	require.NotNil(t, item.Arguments)
+	assert.JSONEq(t, `{"query":"typed wire"}`, *item.Arguments)
+}
+
+func TestResponsesToAnthropicUsesCallIDForToolResultRoundTrip(t *testing.T) {
+	resp := &responses.Response{
+		ID: "resp_tool",
+		Output: []responses.ResponseOutputItemUnion{{
+			ID: "fc_item_1", Type: "function_call", CallID: "call_provider_1", Name: "lookup",
+			Arguments: responses.ResponseOutputItemUnionArguments{OfString: `{"query":"round trip"}`},
+		}},
+	}
+
+	beta := HandleResponsesToAnthropicBeta(resp, "public-model")
+	require.Len(t, beta.Content, 1)
+	assert.Equal(t, "tool_use", beta.Content[0].Type)
+	assert.Equal(t, "call_provider_1", beta.Content[0].ID)
+
+	v1 := HandleResponsesToAnthropicV1(resp, "public-model")
+	require.Len(t, v1.Content, 1)
+	assert.Equal(t, "tool_use", v1.Content[0].Type)
+	assert.Equal(t, "call_provider_1", v1.Content[0].ID)
 }
 
 // TestBuildResponsesPayloadFromAnthropicBeta_UsageDetails verifies that the
@@ -69,6 +153,10 @@ func TestBuildResponsesPayloadFromAnthropicBeta_UsageDetails(t *testing.T) {
 	}
 
 	payload := BuildResponsesPayloadFromAnthropicBeta(resp, "claude-x", "claude-x")
+	typed := ConvertAnthropicBetaToResponsesWire(resp, "claude-x", "claude-x")
+	require.NotNil(t, typed.Usage)
+	assert.EqualValues(t, 66, typed.Usage.InputTokens)
+	assert.EqualValues(t, 11, typed.Usage.InputTokensDetails.CachedTokens)
 	usage, _ := payload["usage"].(map[string]any)
 	require.NotNil(t, usage)
 

--- a/internal/protocol/request/anthropic_v1_to_beta.go
+++ b/internal/protocol/request/anthropic_v1_to_beta.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/sirupsen/logrus"
@@ -17,24 +18,32 @@ import (
 // tool_result content and image data; the round-trip has no such gaps and
 // needs no updates when the SDK adds new block types.
 //
-// Returns nil (rather than erroring) if req is nil or the round-trip fails,
-// so callers doing best-effort context extraction (smart-routing) degrade
-// gracefully instead of panicking.
+// This compatibility wrapper keeps the historical nil-on-failure behavior for
+// context-extraction callers. Protocol boundaries that need an actionable
+// error should use ConvertAnthropicV1ToBetaRequestWithError.
 func ConvertAnthropicV1ToBetaRequest(req *anthropic.MessageNewParams) *anthropic.BetaMessageNewParams {
-	if req == nil {
-		return nil
-	}
-
-	b, err := json.Marshal(req)
+	converted, err := ConvertAnthropicV1ToBetaRequestWithError(req)
 	if err != nil {
-		logrus.WithError(err).Warn("ConvertAnthropicV1ToBetaRequest: marshal v1 request failed")
+		logrus.WithError(err).Warn("ConvertAnthropicV1ToBetaRequest: wire conversion failed")
 		return nil
+	}
+	return converted
+}
+
+// ConvertAnthropicV1ToBetaRequestWithError performs the same wire conversion
+// and reports malformed or non-JSON parameter values to the caller.
+func ConvertAnthropicV1ToBetaRequestWithError(req *anthropic.MessageNewParams) (*anthropic.BetaMessageNewParams, error) {
+	if req == nil {
+		return nil, nil
 	}
 
-	var beta anthropic.BetaMessageNewParams
-	if err := json.Unmarshal(b, &beta); err != nil {
-		logrus.WithError(err).Warn("ConvertAnthropicV1ToBetaRequest: unmarshal into beta shape failed")
-		return nil
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Anthropic v1 request: %w", err)
 	}
-	return &beta
+	var beta anthropic.BetaMessageNewParams
+	if err := json.Unmarshal(data, &beta); err != nil {
+		return nil, fmt.Errorf("unmarshal Anthropic v1 request as Beta: %w", err)
+	}
+	return &beta, nil
 }

--- a/internal/protocol/request/anthropic_v1_to_beta_test.go
+++ b/internal/protocol/request/anthropic_v1_to_beta_test.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -129,4 +131,71 @@ func TestConvertAnthropicV1ToBetaRequest_ModelAndThinking(t *testing.T) {
 
 func TestConvertAnthropicV1ToBetaRequest_Nil(t *testing.T) {
 	assert.Nil(t, ConvertAnthropicV1ToBetaRequest(nil))
+}
+
+func TestConvertAnthropicV1ToBetaRequestPreservesWireSubset(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet",
+		"max_tokens":1024,
+		"metadata":{"user_id":"user-1"},
+		"system":[{"type":"text","text":"system","cache_control":{"type":"ephemeral"}}],
+		"messages":[
+			{"role":"user","content":[
+				{"type":"text","text":"look"},
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}
+			]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"tool-1","name":"lookup","input":{"city":"Paris"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":[{"type":"text","text":"sunny"}]}]}
+		],
+		"tools":[{"name":"lookup","description":"weather lookup","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],
+		"tool_choice":{"type":"tool","name":"lookup","disable_parallel_tool_use":true},
+		"stop_sequences":["done"],
+		"temperature":0.2,
+		"top_k":20,
+		"top_p":0.8,
+		"thinking":{"type":"enabled","budget_tokens":256}
+	}`)
+
+	var v1 anthropic.MessageNewParams
+	if err := json.Unmarshal(raw, &v1); err != nil {
+		t.Fatalf("decode v1 request: %v", err)
+	}
+	beta, err := ConvertAnthropicV1ToBetaRequestWithError(&v1)
+	if err != nil {
+		t.Fatalf("ConvertAnthropicV1ToBetaRequestWithError() error = %v", err)
+	}
+
+	want := decodeJSONObject(t, mustMarshalJSON(t, &v1))
+	got := decodeJSONObject(t, mustMarshalJSON(t, beta))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Beta wire request differs from v1 subset\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestConvertAnthropicV1ToBetaRequestNil(t *testing.T) {
+	if got := ConvertAnthropicV1ToBetaRequest(nil); got != nil {
+		t.Fatalf("ConvertAnthropicV1ToBetaRequest(nil) = %#v, want nil", got)
+	}
+	got, err := ConvertAnthropicV1ToBetaRequestWithError(nil)
+	if err != nil || got != nil {
+		t.Fatalf("ConvertAnthropicV1ToBetaRequestWithError(nil) = %#v, %v", got, err)
+	}
+}
+
+func mustMarshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%T): %v", value, err)
+	}
+	return data
+}
+
+func decodeJSONObject(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("decode JSON object: %v", err)
+	}
+	return value
 }

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -76,19 +76,3 @@ func sendResponsesErrorEvent(c *gin.Context, message string, errorType string, _
 	}
 	OpenAIResponsesEvent(c, errorEvent.EventType(), errorEvent)
 }
-
-func responsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
-	totalInput := int64(u.InputTokens + u.CacheReadTokens)
-	return &wire.ResponsesUsageWire{
-		InputTokens:  totalInput,
-		OutputTokens: int64(u.OutputTokens),
-		TotalTokens:  totalInput + int64(u.OutputTokens),
-		InputTokensDetails: wire.ResponsesInputTokensDetailsWire{
-			CachedTokens:     int64(u.CacheReadTokens),
-			CacheWriteTokens: int64(u.CacheWriteTokens),
-		},
-		OutputTokensDetails: wire.ResponsesOutputTokensDetailsWire{
-			ReasoningTokens: int64(u.ReasoningTokens),
-		},
-	}
-}

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
@@ -336,7 +336,8 @@ func (c *anthropicBetaToResponsesConverter) emitCompletionEvents() {
 		CreatedAt:   c.createdAt,
 		CompletedAt: c.createdAt,
 		Output:      output,
-		Usage:       responsesUsageWire(u),
+		Usage:       usagepkg.ToResponsesUsageWire(u),
+		Model:       c.responseModel,
 	}
 
 	if isIncomplete {

--- a/internal/protocol/stream/anthropic_to_openai_converter.go
+++ b/internal/protocol/stream/anthropic_to_openai_converter.go
@@ -199,7 +199,7 @@ func (c *anthropicToOpenAIConverter) processEvent(event *anthropic.BetaRawMessag
 		}
 		chunk := c.newChunk(wire.ChatStreamDelta{}, &finishReason)
 		if !c.disableStreamUsage && c.acc.HasUsage() {
-			chunk.Usage = chatStreamUsageWire(c.acc.Result())
+			chunk.Usage = usagepkg.ToChatStreamUsageWire(c.acc.Result())
 		}
 		c.pending = append(c.pending, chunk)
 		c.done = true
@@ -221,28 +221,4 @@ func (c *anthropicToOpenAIConverter) newChunk(delta wire.ChatStreamDelta, finish
 			{Index: 0, Delta: delta, FinishReason: finishReason},
 		},
 	}
-}
-
-// chatStreamUsageWire converts normalized TokenUsage into the Chat Completions
-// stream usage wire shape. Same semantics as usagepkg.ChatUsage: prompt_tokens
-// is the TOTAL (uncached + cached + written), cached_tokens and
-// cache_write_tokens reported, disjoint subsets. Anthropic's
-// cache_creation_input_tokens lands in cache_write_tokens.
-func chatStreamUsageWire(u *protocol.TokenUsage) *wire.ChatStreamUsage {
-	totalInput := u.InputTokens + u.CacheReadTokens
-	su := &wire.ChatStreamUsage{
-		PromptTokens:     int64(totalInput),
-		CompletionTokens: int64(u.OutputTokens),
-		TotalTokens:      int64(totalInput + u.OutputTokens),
-	}
-	if u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
-		su.PromptTokensDetails = &wire.ChatStreamPromptTokenDetails{
-			CachedTokens:     int64(u.CacheReadTokens),
-			CacheWriteTokens: int64(u.CacheWriteTokens),
-		}
-	}
-	if u.ReasoningTokens > 0 {
-		su.CompletionTokensDetails = &wire.ChatStreamOutputTokenDetails{ReasoningTokens: int64(u.ReasoningTokens)}
-	}
-	return su
 }

--- a/internal/protocol/stream/openai_chat_to_responses_converter.go
+++ b/internal/protocol/stream/openai_chat_to_responses_converter.go
@@ -355,7 +355,7 @@ func (c *chatToResponsesConverter) wireResponse(status string, output []wire.Res
 		CreatedAt: c.createdAt,
 		Status:    status,
 		Output:    output,
-		Usage:     responsesUsageWire(c.Usage()),
+		Usage:     protocolusage.ToResponsesUsageWire(c.Usage()),
 		Model:     c.responseModel,
 	}
 }

--- a/internal/protocol/stream/openai_responses_to_chat_converter.go
+++ b/internal/protocol/stream/openai_responses_to_chat_converter.go
@@ -181,6 +181,10 @@ func (c *responsesToChatConverter) processEvent(evt *responses.ResponseStreamEve
 		// response.completed so the terminal chunk preserves output + usage
 		// rather than falling through to the post-loop usage=0 fallback.
 		c.usage = protocolusage.FromOpenAIResponses(evt.Response.Usage)
+		// Override total_tokens with the value the upstream Responses stream
+		// actually reported (per .design/stream-usage-tracking.md — cover one
+		// key, do not fork the constructor), falling back to the computed
+		// input+cacheRead+output when the upstream did not report one.
 		if evt.Response.Usage.TotalTokens != 0 {
 			c.totalTokens = evt.Response.Usage.TotalTokens
 		} else {
@@ -287,12 +291,11 @@ func (c *responsesToChatConverter) toolCallDeltaChunk(index int, delta string) w
 func (c *responsesToChatConverter) finalChunk(finishReason string) wire.ChatStreamChunk {
 	chunk := c.newChunk(wire.ChatStreamDelta{}, &finishReason)
 	if !c.disableUsage {
-		// Same wire shape as the Anthropic→Chat path; only total_tokens differs,
-		// preferring the total the upstream Responses stream already reported.
-		usage := chatStreamUsageWire(c.Usage())
-		if c.totalTokens != 0 {
-			usage.TotalTokens = c.totalTokens
-		}
+		// Same wire shape as the Anthropic→Chat path; only total_tokens is
+		// overridden with the total the upstream Responses stream already
+		// reported (captured into c.totalTokens), per the cover-one-key rule.
+		usage := protocolusage.ToChatStreamUsageWire(c.Usage())
+		usage.TotalTokens = c.totalTokens
 		chunk.Usage = usage
 	}
 	return chunk

--- a/internal/protocol/usage/wire.go
+++ b/internal/protocol/usage/wire.go
@@ -1,0 +1,96 @@
+package usage
+
+import (
+	protocol "github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
+)
+
+// TokenUsage → wire output constructors.
+//
+// The canonical *protocol.TokenUsage is the single source of truth for token
+// accounting; these functions are the ONLY place that turns it into a wire
+// usage shape. Every handler/stream converter calls them instead of rebuilding
+// the prompt-total + cache-detail + reasoning-detail logic inline.
+//
+// Shared semantics (mirrors protocol.TokenUsage docs):
+//   - prompt/input tokens on the wire = TOTAL = uncached + cache_read +
+//     cache_write (InputTokens already folds writes in, so only read hits are
+//     added back via PromptTotalTokens).
+//   - cached_tokens and cache_write_tokens are reported as disjoint subsets.
+//   - cache_write_tokens / details blocks are omitted when there is nothing to
+//     report — an absent value means "channel does not report it", which is
+//     distinct from an explicit zero.
+//
+// (Exception: ResponsesInputTokensDetailsWire keeps cached_tokens/reasoning
+// always-present per its own doc — see that struct.)
+
+// ToChatStreamUsageWire converts normalized TokenUsage into the Chat Completions
+// stream usage wire shape.
+func ToChatStreamUsageWire(u *protocol.TokenUsage) *wire.ChatStreamUsage {
+	if u == nil {
+		return nil
+	}
+	totalInput := int64(u.PromptTotalTokens())
+	built := &wire.ChatStreamUsage{
+		PromptTokens:     totalInput,
+		CompletionTokens: int64(u.OutputTokens),
+		TotalTokens:      totalInput + int64(u.OutputTokens),
+	}
+	if u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
+		built.PromptTokensDetails = &wire.ChatStreamPromptTokenDetails{
+			CachedTokens:     int64(u.CacheReadTokens),
+			CacheWriteTokens: int64(u.CacheWriteTokens),
+		}
+	}
+	if u.ReasoningTokens > 0 {
+		built.CompletionTokensDetails = &wire.ChatStreamOutputTokenDetails{ReasoningTokens: int64(u.ReasoningTokens)}
+	}
+	return built
+}
+
+// ToChatUsageWire converts normalized TokenUsage into the non-streaming Chat
+// Completions usage wire shape.
+func ToChatUsageWire(u *protocol.TokenUsage) wire.ChatCompletionUsageWire {
+	if u == nil {
+		return wire.ChatCompletionUsageWire{}
+	}
+	totalInput := int64(u.PromptTotalTokens())
+	built := wire.ChatCompletionUsageWire{
+		PromptTokens:     totalInput,
+		CompletionTokens: int64(u.OutputTokens),
+		TotalTokens:      totalInput + int64(u.OutputTokens),
+	}
+	if u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
+		built.PromptTokensDetails = &wire.ChatCompletionPromptDetailsWire{
+			CachedTokens:     int64(u.CacheReadTokens),
+			CacheWriteTokens: int64(u.CacheWriteTokens),
+		}
+	}
+	if u.ReasoningTokens > 0 {
+		built.CompletionTokensDetails = &wire.ChatCompletionOutputDetailsWire{
+			ReasoningTokens: int64(u.ReasoningTokens),
+		}
+	}
+	return built
+}
+
+// ToResponsesUsageWire converts normalized TokenUsage into the Responses API
+// usage wire shape.
+func ToResponsesUsageWire(u *protocol.TokenUsage) *wire.ResponsesUsageWire {
+	if u == nil {
+		return nil
+	}
+	inputTokens := int64(u.PromptTotalTokens())
+	return &wire.ResponsesUsageWire{
+		InputTokens:  inputTokens,
+		OutputTokens: int64(u.OutputTokens),
+		TotalTokens:  inputTokens + int64(u.OutputTokens),
+		InputTokensDetails: wire.ResponsesInputTokensDetailsWire{
+			CachedTokens:     int64(u.CacheReadTokens),
+			CacheWriteTokens: int64(u.CacheWriteTokens),
+		},
+		OutputTokensDetails: wire.ResponsesOutputTokensDetailsWire{
+			ReasoningTokens: int64(u.ReasoningTokens),
+		},
+	}
+}

--- a/internal/protocol/wire/openai_chat.go
+++ b/internal/protocol/wire/openai_chat.go
@@ -73,35 +73,36 @@ type ChatStreamError struct {
 
 // ChatCompletionWire is the OpenAI Chat Completions response wire format.
 type ChatCompletionWire struct {
-	ID      string                    `json:"id"`
-	Object  string                    `json:"object"`
-	Created int64                     `json:"created"`
-	Model   string                    `json:"model"`
+	ID      string                     `json:"id"`
+	Object  string                     `json:"object"`
+	Created int64                      `json:"created"`
+	Model   string                     `json:"model"`
 	Choices []ChatCompletionChoiceWire `json:"choices"`
-	Usage   ChatCompletionUsageWire   `json:"usage"`
+	Usage   ChatCompletionUsageWire    `json:"usage"`
 }
 
 // ToMap serializes to a generic map for callers that apply runtime transforms.
-func (r ChatCompletionWire) ToMap() map[string]interface{} {
+func (r ChatCompletionWire) ToMap() map[string]any {
 	raw, _ := json.Marshal(r)
-	var m map[string]interface{}
+	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
 	return m
 }
 
 // ChatCompletionChoiceWire is a single choice in the OpenAI Chat Completions response.
 type ChatCompletionChoiceWire struct {
-	Index        int                      `json:"index"`
+	Index        int                       `json:"index"`
 	Message      ChatCompletionMessageWire `json:"message"`
-	FinishReason string                   `json:"finish_reason"`
+	FinishReason string                    `json:"finish_reason"`
 }
 
 // ChatCompletionMessageWire is the message inside a choice.
 type ChatCompletionMessageWire struct {
-	Role             string                      `json:"role"`
-	Content          string                      `json:"content,omitempty"`
+	Role             string                       `json:"role"`
+	Content          string                       `json:"content,omitempty"`
+	Refusal          string                       `json:"refusal,omitempty"`
 	ToolCalls        []ChatCompletionToolCallWire `json:"tool_calls,omitempty"`
-	ReasoningContent string                      `json:"reasoning_content,omitempty"`
+	ReasoningContent string                       `json:"reasoning_content,omitempty"`
 }
 
 // ChatCompletionToolCallWire is a single tool call inside a message.
@@ -121,10 +122,11 @@ type ChatCompletionFunctionWire struct {
 // prompt_tokens = TOTAL (uncached + cached + written); cached_tokens and
 // cache_write_tokens are reported, disjoint subsets of it.
 type ChatCompletionUsageWire struct {
-	PromptTokens        int64                            `json:"prompt_tokens"`
-	CompletionTokens    int64                            `json:"completion_tokens"`
-	TotalTokens         int64                            `json:"total_tokens"`
-	PromptTokensDetails *ChatCompletionPromptDetailsWire `json:"prompt_tokens_details,omitempty"`
+	PromptTokens            int64                            `json:"prompt_tokens"`
+	CompletionTokens        int64                            `json:"completion_tokens"`
+	TotalTokens             int64                            `json:"total_tokens"`
+	PromptTokensDetails     *ChatCompletionPromptDetailsWire `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *ChatCompletionOutputDetailsWire `json:"completion_tokens_details,omitempty"`
 }
 
 // ChatCompletionPromptDetailsWire breaks down prompt token categories.
@@ -132,4 +134,9 @@ type ChatCompletionUsageWire struct {
 type ChatCompletionPromptDetailsWire struct {
 	CachedTokens     int64 `json:"cached_tokens"`
 	CacheWriteTokens int64 `json:"cache_write_tokens,omitempty"`
+}
+
+// ChatCompletionOutputDetailsWire breaks down completion token categories.
+type ChatCompletionOutputDetailsWire struct {
+	ReasoningTokens int64 `json:"reasoning_tokens"`
 }

--- a/internal/protocol/wire/openai_responses.go
+++ b/internal/protocol/wire/openai_responses.go
@@ -26,8 +26,8 @@ func (e ResponsesFunctionCallArgumentsDeltaEvent) EventType() string { return e.
 func (e ResponsesFunctionCallArgumentsDoneEvent) EventType() string  { return e.Type }
 
 type ResponsesStreamErrorEvent struct {
-	Type           string                  `json:"type"`
-	SequenceNumber int64                   `json:"sequence_number"`
+	Type           string                   `json:"type"`
+	SequenceNumber int64                    `json:"sequence_number"`
 	Error          ResponsesStreamErrorBody `json:"error"`
 }
 
@@ -37,26 +37,26 @@ type ResponsesStreamErrorBody struct {
 }
 
 type ResponsesCreatedEvent struct {
-	Type           string               `json:"type"`
-	SequenceNumber int64                `json:"sequence_number"`
+	Type           string                `json:"type"`
+	SequenceNumber int64                 `json:"sequence_number"`
 	Response       ResponsesWireResponse `json:"response"`
 }
 
 type ResponsesInProgressEvent struct {
-	Type           string               `json:"type"`
-	SequenceNumber int64                `json:"sequence_number"`
+	Type           string                `json:"type"`
+	SequenceNumber int64                 `json:"sequence_number"`
 	Response       ResponsesWireResponse `json:"response"`
 }
 
 type ResponsesCompletedEvent struct {
-	Type           string               `json:"type"`
-	SequenceNumber int64                `json:"sequence_number"`
+	Type           string                `json:"type"`
+	SequenceNumber int64                 `json:"sequence_number"`
 	Response       ResponsesWireResponse `json:"response"`
 }
 
 type ResponsesIncompleteEvent struct {
-	Type           string               `json:"type"`
-	SequenceNumber int64                `json:"sequence_number"`
+	Type           string                `json:"type"`
+	SequenceNumber int64                 `json:"sequence_number"`
 	Response       ResponsesWireResponse `json:"response"`
 }
 
@@ -72,16 +72,26 @@ type ResponsesWireResponse struct {
 	IncompleteDetails *ResponsesIncompleteDetailsWire `json:"incomplete_details,omitempty"`
 }
 
+// ToMap converts the typed response contract to the legacy map surface used by
+// existing non-stream handlers. Stage Bridges should pass the typed value.
+// ToMap serializes to a generic map for callers that apply runtime transforms.
+func (r ResponsesWireResponse) ToMap() map[string]any {
+	raw, _ := json.Marshal(r)
+	var m map[string]any
+	_ = json.Unmarshal(raw, &m)
+	return m
+}
+
 type ResponsesIncompleteDetailsWire struct {
 	Reason string `json:"reason"`
 }
 
 type ResponsesUsageWire struct {
-	InputTokens         int64                           `json:"input_tokens"`
-	OutputTokens        int64                           `json:"output_tokens"`
-	TotalTokens         int64                           `json:"total_tokens"`
-	InputTokensDetails  ResponsesInputTokensDetailsWire  `json:"input_tokens_details,omitempty"`
-	OutputTokensDetails ResponsesOutputTokensDetailsWire `json:"output_tokens_details,omitempty"`
+	InputTokens         int64                            `json:"input_tokens"`
+	InputTokensDetails  ResponsesInputTokensDetailsWire  `json:"input_tokens_details"`
+	OutputTokens        int64                            `json:"output_tokens"`
+	OutputTokensDetails ResponsesOutputTokensDetailsWire `json:"output_tokens_details"`
+	TotalTokens         int64                            `json:"total_tokens"`
 }
 
 // Codex CLI's ResponseCompleted decoder requires cached_tokens and
@@ -94,8 +104,8 @@ type ResponsesUsageWire struct {
 // an absent value is meaningful — it says the channel never reported writes
 // (e.g. Azure, which does not surface them at all).
 type ResponsesInputTokensDetailsWire struct {
-	CachedTokens     int64 `json:"cached_tokens"`
 	CacheWriteTokens int64 `json:"cache_write_tokens,omitempty"`
+	CachedTokens     int64 `json:"cached_tokens"`
 }
 
 type ResponsesOutputTokensDetailsWire struct {
@@ -103,28 +113,28 @@ type ResponsesOutputTokensDetailsWire struct {
 }
 
 type ResponsesOutputItemAddedEvent struct {
-	Type           string                 `json:"type"`
-	SequenceNumber int64                  `json:"sequence_number"`
-	OutputIndex    int                    `json:"output_index"`
+	Type           string                  `json:"type"`
+	SequenceNumber int64                   `json:"sequence_number"`
+	OutputIndex    int                     `json:"output_index"`
 	Item           ResponsesOutputItemWire `json:"item"`
 }
 
 type ResponsesOutputItemDoneEvent struct {
-	Type           string                 `json:"type"`
-	SequenceNumber int64                  `json:"sequence_number"`
-	OutputIndex    int                    `json:"output_index"`
+	Type           string                  `json:"type"`
+	SequenceNumber int64                   `json:"sequence_number"`
+	OutputIndex    int                     `json:"output_index"`
 	Item           ResponsesOutputItemWire `json:"item"`
 }
 
 type ResponsesOutputItemWire struct {
-	ID        string                    `json:"id"`
-	Type      string                    `json:"type"`
-	Role      string                    `json:"role,omitempty"`
-	Status    string                    `json:"status"`
+	ID        string                     `json:"id"`
+	Type      string                     `json:"type"`
+	Role      string                     `json:"role,omitempty"`
+	Status    string                     `json:"status,omitempty"`
 	Content   []ResponsesContentPartWire `json:"content,omitempty"`
-	CallID    string                    `json:"call_id,omitempty"`
-	Name      string                    `json:"name,omitempty"`
-	Arguments *string                   `json:"arguments,omitempty"`
+	CallID    string                     `json:"call_id,omitempty"`
+	Name      string                     `json:"name,omitempty"`
+	Arguments *string                    `json:"arguments,omitempty"`
 }
 
 type ResponsesContentPartWire struct {
@@ -157,20 +167,20 @@ func (p ResponsesContentPartWire) MarshalJSON() ([]byte, error) {
 }
 
 type ResponsesContentPartAddedEvent struct {
-	Type           string                  `json:"type"`
-	SequenceNumber int64                   `json:"sequence_number"`
-	ItemID         string                  `json:"item_id"`
-	OutputIndex    int                     `json:"output_index"`
-	ContentIndex   int                     `json:"content_index"`
+	Type           string                   `json:"type"`
+	SequenceNumber int64                    `json:"sequence_number"`
+	ItemID         string                   `json:"item_id"`
+	OutputIndex    int                      `json:"output_index"`
+	ContentIndex   int                      `json:"content_index"`
 	Part           ResponsesContentPartWire `json:"part"`
 }
 
 type ResponsesContentPartDoneEvent struct {
-	Type           string                  `json:"type"`
-	SequenceNumber int64                   `json:"sequence_number"`
-	ItemID         string                  `json:"item_id"`
-	OutputIndex    int                     `json:"output_index"`
-	ContentIndex   int                     `json:"content_index"`
+	Type           string                   `json:"type"`
+	SequenceNumber int64                    `json:"sequence_number"`
+	ItemID         string                   `json:"item_id"`
+	OutputIndex    int                      `json:"output_index"`
+	ContentIndex   int                      `json:"content_index"`
 	Part           ResponsesContentPartWire `json:"part"`
 }
 


### PR DESCRIPTION
## Summary

Token-usage accounting was rebuilt inline across handlers and drifted (the stream Chat and Responses paths computed input totals differently), and nonstream converters emitted hand-rolled `map[string]any` payloads. This lifts both into one shared contract with typed wire structs and fixes the gaps the duplication hid.

## Key Changes

- **Single usage→wire contract**: New `internal/protocol/usage/wire.go` is now the only path from `*TokenUsage` to any wire usage shape; every converter calls it instead of re-deriving cache/reasoning/prompt-total semantics.
- **Typed nonstream converters**: Chat / Anthropic v1+beta / Responses conversions return typed `wire.*Wire` via transport-neutral `Convert*` entry points; legacy `Handle*` HTTP wrappers stay as thin shims.
- **Responses tool-call ID fidelity**: `Responses→Anthropic` now emits upstream `call_id` as the tool-use `id`, fixing broken multi-turn tool-result correlation.
- **Truncation stop-reason parity**: OpenAI `length` and Responses `incomplete` now map to Anthropic `max_tokens` (and `content_filter` → `refusal`) across v1 and beta.
- **Actionable errors + stable IDs**: Conversion errors propagate instead of silently yielding zero values; synthetic Anthropic IDs use UUID instead of a same-second-colliding timestamp.
