### PR TITLE
refactor(protocol/stream): bidirectional stream converter improvements + review hardening

### DIFF
--- a/internal/protocol/stream/anthropic_beta_to_openai_responses.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses.go
@@ -28,7 +28,7 @@ func HandleAnthropicBetaToOpenAIResponsesStream(
 		}
 	}()
 
-	conv := newAnthropicBetaToResponsesConverter(stream, responseModel)
+	conv := NewAnthropicBetaToOpenAIResponsesConverter(stream, responseModel)
 
 	usage, err := RunConverter(hc, conv, responsesSSEWriter(c))
 

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +11,11 @@ import (
 	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
+
+// errAnthropicStreamTruncated reports an upstream Anthropic stream that ended
+// (with no transport error) before delivering message_stop. Shared by every
+// converter that consumes an AnthropicBetaStream so callers can errors.Is it.
+var errAnthropicStreamTruncated = errors.New("anthropic stream ended without message_stop")
 
 // anthropicBetaToResponsesConverter converts an Anthropic Beta stream into
 // a sequence of Responses API wire events. It implements StreamConverter.
@@ -91,7 +97,7 @@ func (c *anthropicBetaToResponsesConverter) Next() (interface{}, bool, error) {
 				return nil, false, err
 			}
 			if !c.finished {
-				return nil, false, fmt.Errorf("anthropic stream ended without message_stop")
+				return nil, false, errAnthropicStreamTruncated
 			}
 			return nil, true, nil
 		}
@@ -166,7 +172,7 @@ func (c *anthropicBetaToResponsesConverter) emitContentBlockStart(event *anthrop
 	currentOutputIndex := c.outputIndex
 
 	if blockType == "text" {
-		itemID := fmt.Sprintf("item_%d_%d", c.createdAt, index)
+		itemID := fmt.Sprintf("msg_%d_%d", c.createdAt, index)
 		c.pendingTextBlocks[index] = &pendingResponseTextBlock{
 			itemID:      itemID,
 			outputIndex: currentOutputIndex,

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_converter.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
@@ -15,50 +14,68 @@ import (
 // anthropicBetaToResponsesConverter converts an Anthropic Beta stream into
 // a sequence of Responses API wire events. It implements StreamConverter.
 type anthropicBetaToResponsesConverter struct {
-	stream        *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion]
+	stream        AnthropicBetaStream
 	responseModel string
 	acc           *usagepkg.AnthropicAccumulator
 
 	// state (formerly responsesConverterState)
-	responseID       string
-	itemID           string
-	outputIndex      int
-	accumulatedText  string
-	finished         bool
-	pendingToolCalls map[int]*pendingResponseToolCall
-	hasSentCreated   bool
-	sequenceNumber   int
-	createdAt        int64
-	currentBlockType string
-	stopReason       string
+	responseID        string
+	outputIndex       int
+	finished          bool
+	pendingTextBlocks map[int]*pendingResponseTextBlock
+	pendingToolCalls  map[int]*pendingResponseToolCall
+	hasSentCreated    bool
+	sequenceNumber    int
+	createdAt         int64
+	stopReason        string
 
 	// internal event queue
 	pending []wire.ResponsesEvent
 }
 
+// pendingResponseTextBlock tracks one Anthropic text content block as one
+// Responses message output item. Anthropic may interleave multiple text and
+// tool-use blocks, so text state cannot be shared across the whole response.
+type pendingResponseTextBlock struct {
+	itemID      string
+	outputIndex int
+	text        strings.Builder
+}
+
 // pendingResponseToolCall tracks a tool call being assembled from Anthropic stream chunks
 type pendingResponseToolCall struct {
-	itemID    string
-	name      string
-	arguments strings.Builder
+	itemID      string
+	name        string
+	outputIndex int
+	arguments   strings.Builder
 }
 
 // newAnthropicBetaToResponsesConverter creates a converter that reads from an
 // Anthropic Beta stream and yields Responses API wire events.
 func newAnthropicBetaToResponsesConverter(
-	stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion],
+	stream AnthropicBetaStream,
 	responseModel string,
 ) *anthropicBetaToResponsesConverter {
 	ts := time.Now().Unix()
 	return &anthropicBetaToResponsesConverter{
-		stream:           stream,
-		responseModel:    responseModel,
-		acc:              usagepkg.NewAnthropicAccumulator(),
-		responseID:       fmt.Sprintf("resp_%d", ts),
-		itemID:           fmt.Sprintf("item_%d", ts),
-		pendingToolCalls: make(map[int]*pendingResponseToolCall),
-		createdAt:        ts,
+		stream:            stream,
+		responseModel:     responseModel,
+		acc:               usagepkg.NewAnthropicAccumulator(),
+		responseID:        fmt.Sprintf("resp_%d", ts),
+		pendingTextBlocks: make(map[int]*pendingResponseTextBlock),
+		pendingToolCalls:  make(map[int]*pendingResponseToolCall),
+		createdAt:         ts,
 	}
+}
+
+// NewAnthropicBetaToOpenAIResponsesConverter creates a transport-neutral
+// converter. HTTP/SSE framing and stream close ownership remain with the
+// caller, so the same converter can serve legacy handlers and Stage Bridges.
+func NewAnthropicBetaToOpenAIResponsesConverter(
+	stream AnthropicBetaStream,
+	responseModel string,
+) StreamConverter {
+	return newAnthropicBetaToResponsesConverter(stream, responseModel)
 }
 
 func (c *anthropicBetaToResponsesConverter) Next() (interface{}, bool, error) {
@@ -144,17 +161,22 @@ func (c *anthropicBetaToResponsesConverter) emitMessageStart() {
 }
 
 func (c *anthropicBetaToResponsesConverter) emitContentBlockStart(event *anthropic.BetaRawMessageStreamEventUnion) {
-	index := event.Index
+	index := int(event.Index)
 	blockType := event.ContentBlock.Type
-	c.currentBlockType = blockType
+	currentOutputIndex := c.outputIndex
 
 	if blockType == "text" {
+		itemID := fmt.Sprintf("item_%d_%d", c.createdAt, index)
+		c.pendingTextBlocks[index] = &pendingResponseTextBlock{
+			itemID:      itemID,
+			outputIndex: currentOutputIndex,
+		}
 		c.pending = append(c.pending, wire.ResponsesOutputItemAddedEvent{
 			Type:           "response.output_item.added",
 			SequenceNumber: int64(c.nextSeq()),
-			OutputIndex:    c.outputIndex,
+			OutputIndex:    currentOutputIndex,
 			Item: wire.ResponsesOutputItemWire{
-				ID:      c.itemID,
+				ID:      itemID,
 				Type:    "message",
 				Status:  "in_progress",
 				Role:    "assistant",
@@ -164,21 +186,22 @@ func (c *anthropicBetaToResponsesConverter) emitContentBlockStart(event *anthrop
 		c.pending = append(c.pending, wire.ResponsesContentPartAddedEvent{
 			Type:           "response.content_part.added",
 			SequenceNumber: int64(c.nextSeq()),
-			ItemID:         c.itemID,
-			OutputIndex:    c.outputIndex,
+			ItemID:         itemID,
+			OutputIndex:    currentOutputIndex,
 			ContentIndex:   0,
 			Part:           wire.ResponsesContentPartWire{Type: "output_text", Text: ""},
 		})
+		c.outputIndex++
 	} else if blockType == "tool_use" {
 		toolID := event.ContentBlock.ID
 		toolName := event.ContentBlock.Name
-		c.pendingToolCalls[int(index)] = &pendingResponseToolCall{itemID: toolID, name: toolName}
+		c.pendingToolCalls[index] = &pendingResponseToolCall{itemID: toolID, name: toolName, outputIndex: currentOutputIndex}
 
 		arguments := ""
 		c.pending = append(c.pending, wire.ResponsesOutputItemAddedEvent{
 			Type:           "response.output_item.added",
 			SequenceNumber: int64(c.nextSeq()),
-			OutputIndex:    c.outputIndex,
+			OutputIndex:    currentOutputIndex,
 			Item: wire.ResponsesOutputItemWire{
 				Type:      "function_call",
 				ID:        toolID,
@@ -194,28 +217,32 @@ func (c *anthropicBetaToResponsesConverter) emitContentBlockStart(event *anthrop
 
 func (c *anthropicBetaToResponsesConverter) emitContentBlockDelta(event *anthropic.BetaRawMessageStreamEventUnion) {
 	deltaType := event.Delta.Type
-	index := event.Index
+	index := int(event.Index)
 
 	if deltaType == "text_delta" {
-		text := event.Delta.Text
-		c.accumulatedText += text
+		block, exists := c.pendingTextBlocks[index]
+		if !exists {
+			return
+		}
+		delta := event.Delta.Text
+		block.text.WriteString(delta)
 		c.pending = append(c.pending, wire.ResponsesOutputTextDeltaEvent{
 			Type:           "response.output_text.delta",
-			Delta:          text,
-			ItemID:         c.itemID,
-			OutputIndex:    c.outputIndex,
+			Delta:          delta,
+			ItemID:         block.itemID,
+			OutputIndex:    block.outputIndex,
 			ContentIndex:   0,
 			SequenceNumber: int64(c.nextSeq()),
 		})
 	} else if deltaType == "input_json_delta" {
-		if pending, exists := c.pendingToolCalls[int(index)]; exists {
+		if pending, exists := c.pendingToolCalls[index]; exists {
 			argsDelta := event.Delta.PartialJSON
 			pending.arguments.WriteString(argsDelta)
 			c.pending = append(c.pending, wire.ResponsesFunctionCallArgumentsDeltaEvent{
 				Type:           "response.function_call_arguments.delta",
 				Delta:          argsDelta,
 				ItemID:         pending.itemID,
-				OutputIndex:    c.outputIndex,
+				OutputIndex:    pending.outputIndex,
 				SequenceNumber: int64(c.nextSeq()),
 			})
 		}
@@ -223,68 +250,66 @@ func (c *anthropicBetaToResponsesConverter) emitContentBlockDelta(event *anthrop
 }
 
 func (c *anthropicBetaToResponsesConverter) emitContentBlockStop(event *anthropic.BetaRawMessageStreamEventUnion) {
-	index := event.Index
-	blockType := c.currentBlockType
+	index := int(event.Index)
 
-	if blockType == "text" {
+	if block, exists := c.pendingTextBlocks[index]; exists {
+		text := block.text.String()
 		c.pending = append(c.pending,
 			wire.ResponsesOutputTextDoneEvent{
 				Type:           "response.output_text.done",
-				ItemID:         c.itemID,
-				OutputIndex:    c.outputIndex,
+				ItemID:         block.itemID,
+				OutputIndex:    block.outputIndex,
 				ContentIndex:   0,
-				Text:           c.accumulatedText,
+				Text:           text,
 				SequenceNumber: int64(c.nextSeq()),
 			},
 			wire.ResponsesContentPartDoneEvent{
 				Type:           "response.content_part.done",
 				SequenceNumber: int64(c.nextSeq()),
-				ItemID:         c.itemID,
-				OutputIndex:    c.outputIndex,
+				ItemID:         block.itemID,
+				OutputIndex:    block.outputIndex,
 				ContentIndex:   0,
-				Part:           wire.ResponsesContentPartWire{Type: "output_text", Text: c.accumulatedText},
+				Part:           wire.ResponsesContentPartWire{Type: "output_text", Text: text},
 			},
 			wire.ResponsesOutputItemDoneEvent{
 				Type:           "response.output_item.done",
 				SequenceNumber: int64(c.nextSeq()),
-				OutputIndex:    c.outputIndex,
+				OutputIndex:    block.outputIndex,
 				Item: wire.ResponsesOutputItemWire{
-					ID:     c.itemID,
+					ID:     block.itemID,
 					Type:   "message",
 					Status: "completed",
 					Role:   "assistant",
 					Content: []wire.ResponsesContentPartWire{
-						{Type: "output_text", Text: c.accumulatedText},
+						{Type: "output_text", Text: text},
 					},
 				},
 			},
 		)
-	} else if blockType == "tool_use" {
-		if pending, exists := c.pendingToolCalls[int(index)]; exists {
-			argumentsStr := pending.arguments.String()
-			c.pending = append(c.pending,
-				wire.ResponsesFunctionCallArgumentsDoneEvent{
-					Type:           "response.function_call_arguments.done",
-					ItemID:         pending.itemID,
-					OutputIndex:    c.outputIndex,
-					Arguments:      argumentsStr,
-					SequenceNumber: int64(c.nextSeq()),
+	} else if pending, exists := c.pendingToolCalls[index]; exists {
+		argumentsStr := pending.arguments.String()
+		c.pending = append(c.pending,
+			wire.ResponsesFunctionCallArgumentsDoneEvent{
+				Type:           "response.function_call_arguments.done",
+				ItemID:         pending.itemID,
+				OutputIndex:    pending.outputIndex,
+				Arguments:      argumentsStr,
+				SequenceNumber: int64(c.nextSeq()),
+			},
+			wire.ResponsesOutputItemDoneEvent{
+				Type:           "response.output_item.done",
+				SequenceNumber: int64(c.nextSeq()),
+				OutputIndex:    pending.outputIndex,
+				Item: wire.ResponsesOutputItemWire{
+					Type:      "function_call",
+					ID:        pending.itemID,
+					CallID:    pending.itemID,
+					Name:      pending.name,
+					Arguments: &argumentsStr,
+					Status:    "completed",
 				},
-				wire.ResponsesOutputItemDoneEvent{
-					Type:           "response.output_item.done",
-					SequenceNumber: int64(c.nextSeq()),
-					OutputIndex:    c.outputIndex,
-					Item: wire.ResponsesOutputItemWire{
-						Type:      "function_call",
-						ID:        pending.itemID,
-						CallID:    pending.itemID,
-						Name:      pending.name,
-						Arguments: &argumentsStr,
-						Status:    "completed",
-					},
-				},
-			)
-		}
+			},
+		)
 	}
 }
 
@@ -305,28 +330,28 @@ func (c *anthropicBetaToResponsesConverter) emitCompletionEvents() {
 		itemStatus = "incomplete"
 	}
 
-	var output []wire.ResponsesOutputItemWire
-	if c.accumulatedText != "" {
-		output = append(output, wire.ResponsesOutputItemWire{
-			ID:     c.itemID,
+	output := make([]wire.ResponsesOutputItemWire, c.outputIndex)
+	for _, block := range c.pendingTextBlocks {
+		output[block.outputIndex] = wire.ResponsesOutputItemWire{
+			ID:     block.itemID,
 			Type:   "message",
 			Status: itemStatus,
 			Role:   "assistant",
 			Content: []wire.ResponsesContentPartWire{
-				{Type: "output_text", Text: c.accumulatedText},
+				{Type: "output_text", Text: block.text.String()},
 			},
-		})
+		}
 	}
 	for _, pending := range c.pendingToolCalls {
 		argumentsStr := pending.arguments.String()
-		output = append(output, wire.ResponsesOutputItemWire{
+		output[pending.outputIndex] = wire.ResponsesOutputItemWire{
 			Type:      "function_call",
 			ID:        pending.itemID,
 			CallID:    pending.itemID,
 			Name:      pending.name,
 			Arguments: &argumentsStr,
-			Status:    "completed",
-		})
+			Status:    itemStatus,
+		}
 	}
 
 	u := c.acc.Result()

--- a/internal/protocol/stream/anthropic_beta_to_openai_responses_golden_test.go
+++ b/internal/protocol/stream/anthropic_beta_to_openai_responses_golden_test.go
@@ -12,40 +12,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
 
-// seqOfFull extracts the SequenceNumber from any Responses API event type emitted
-// by the anthropicBetaToResponsesConverter, including ContentPart events that
-// seqOf in the ChatToResponses golden test does not cover.
-func seqOfFull(t *testing.T, e wire.ResponsesEvent) int64 {
-	t.Helper()
-	switch v := e.(type) {
-	case wire.ResponsesCreatedEvent:
-		return v.SequenceNumber
-	case wire.ResponsesInProgressEvent:
-		return v.SequenceNumber
-	case wire.ResponsesOutputItemAddedEvent:
-		return v.SequenceNumber
-	case wire.ResponsesContentPartAddedEvent:
-		return v.SequenceNumber
-	case wire.ResponsesOutputTextDeltaEvent:
-		return v.SequenceNumber
-	case wire.ResponsesFunctionCallArgumentsDeltaEvent:
-		return v.SequenceNumber
-	case wire.ResponsesOutputTextDoneEvent:
-		return v.SequenceNumber
-	case wire.ResponsesContentPartDoneEvent:
-		return v.SequenceNumber
-	case wire.ResponsesOutputItemDoneEvent:
-		return v.SequenceNumber
-	case wire.ResponsesFunctionCallArgumentsDoneEvent:
-		return v.SequenceNumber
-	case wire.ResponsesCompletedEvent:
-		return v.SequenceNumber
-	default:
-		t.Fatalf("unexpected event type %T", e)
-		return 0
-	}
-}
-
 // TestAnthropicBetaToResponsesConverter_GoldenSequence is a hermetic regression
 // oracle for the anthropicBetaToResponsesConverter. It feeds a realistic Anthropic
 // Beta stream (text block + tool call assembled across two delta chunks, then
@@ -158,7 +124,7 @@ func TestAnthropicBetaToResponsesConverter_GoldenSequence(t *testing.T) {
 
 	// 2. Sequence numbers start at 0 and increment by 1 (no gaps/dupes).
 	for i, e := range got {
-		assert.Equal(t, int64(i), seqOfFull(t, e), "sequence number at position %d", i)
+		assert.Equal(t, int64(i), seqOf(t, e), "sequence number at position %d", i)
 	}
 
 	// 3. Spot-check key payloads.
@@ -167,15 +133,125 @@ func TestAnthropicBetaToResponsesConverter_GoldenSequence(t *testing.T) {
 
 	textDone := got[6].(wire.ResponsesOutputTextDoneEvent)
 	assert.Equal(t, "Hello, World!", textDone.Text)
+	assert.Equal(t, 0, textDone.OutputIndex)
+	assert.Equal(t, 0, got[2].(wire.ResponsesOutputItemAddedEvent).OutputIndex)
+	assert.Equal(t, 0, got[3].(wire.ResponsesContentPartAddedEvent).OutputIndex)
 
 	argsDone := got[12].(wire.ResponsesFunctionCallArgumentsDoneEvent)
 	assert.Equal(t, `{"city":"Paris"}`, argsDone.Arguments)
+	assert.Equal(t, 1, got[9].(wire.ResponsesOutputItemAddedEvent).OutputIndex)
+	assert.Equal(t, 1, got[10].(wire.ResponsesFunctionCallArgumentsDeltaEvent).OutputIndex)
+	assert.Equal(t, 1, got[11].(wire.ResponsesFunctionCallArgumentsDeltaEvent).OutputIndex)
+	assert.Equal(t, 1, argsDone.OutputIndex)
+	assert.Equal(t, 1, got[13].(wire.ResponsesOutputItemDoneEvent).OutputIndex)
 
 	completed := got[14].(wire.ResponsesCompletedEvent)
 	assert.Equal(t, "completed", completed.Response.Status)
+	assert.Equal(t, "claude-3-5-sonnet-20241022", completed.Response.Model)
+	require.Len(t, completed.Response.Output, 2)
+	assert.Equal(t, "message", completed.Response.Output[0].Type)
+	assert.Equal(t, "function_call", completed.Response.Output[1].Type)
 
 	// 4. Usage reflects upstream message_start (input) + message_delta (output).
 	usage := conv.Usage()
 	assert.Equal(t, 10, usage.InputTokens)
 	assert.Equal(t, 5, usage.OutputTokens)
+}
+
+func TestAnthropicBetaToResponsesConverter_PreservesInterleavedTextBlocks(t *testing.T) {
+	marshal := func(v map[string]any) string {
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	events := []string{
+		marshal(map[string]any{
+			"type": "message_start",
+			"message": map[string]any{
+				"id": "msg_interleaved", "type": "message", "role": "assistant",
+				"content": []any{}, "model": "claude-test",
+				"stop_reason": nil, "stop_sequence": nil,
+				"usage": map[string]any{"input_tokens": 3, "output_tokens": 0},
+			},
+		}),
+		marshal(map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		}),
+		marshal(map[string]any{
+			"type": "content_block_delta", "index": 0,
+			"delta": map[string]any{"type": "text_delta", "text": "before"},
+		}),
+		marshal(map[string]any{"type": "content_block_stop", "index": 0}),
+		marshal(map[string]any{
+			"type": "content_block_start", "index": 1,
+			"content_block": map[string]any{
+				"type": "tool_use", "id": "tool_interleaved", "name": "lookup",
+				"input": map[string]any{},
+			},
+		}),
+		marshal(map[string]any{
+			"type": "content_block_delta", "index": 1,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": `{}`},
+		}),
+		marshal(map[string]any{"type": "content_block_stop", "index": 1}),
+		marshal(map[string]any{
+			"type": "content_block_start", "index": 2,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		}),
+		marshal(map[string]any{
+			"type": "content_block_delta", "index": 2,
+			"delta": map[string]any{"type": "text_delta", "text": "after"},
+		}),
+		marshal(map[string]any{"type": "content_block_stop", "index": 2}),
+		marshal(map[string]any{
+			"type":  "message_delta",
+			"delta": map[string]any{"stop_reason": "tool_use", "stop_sequence": nil},
+			"usage": map[string]any{"output_tokens": 4},
+		}),
+		marshal(map[string]any{"type": "message_stop"}),
+	}
+
+	stream := anthropicstream.NewStream[anthropic.BetaRawMessageStreamEventUnion](
+		newFakeAnthropicDecoder(events), nil,
+	)
+	conv := newAnthropicBetaToResponsesConverter(stream, "claude-test")
+
+	var added []wire.ResponsesOutputItemAddedEvent
+	var done []wire.ResponsesOutputItemDoneEvent
+	var completed wire.ResponsesCompletedEvent
+	for {
+		event, finished, err := conv.Next()
+		require.NoError(t, err)
+		if finished {
+			break
+		}
+		switch typed := event.(type) {
+		case wire.ResponsesOutputItemAddedEvent:
+			added = append(added, typed)
+		case wire.ResponsesOutputItemDoneEvent:
+			done = append(done, typed)
+		case wire.ResponsesCompletedEvent:
+			completed = typed
+		}
+	}
+
+	require.Len(t, added, 3)
+	require.Len(t, done, 3)
+	for index := range added {
+		assert.Equal(t, index, added[index].OutputIndex)
+		assert.Equal(t, index, done[index].OutputIndex)
+		assert.Equal(t, added[index].Item.ID, done[index].Item.ID)
+	}
+	assert.NotEqual(t, added[0].Item.ID, added[2].Item.ID)
+
+	require.Len(t, completed.Response.Output, 3)
+	assert.Equal(t, "message", completed.Response.Output[0].Type)
+	assert.Equal(t, "before", completed.Response.Output[0].Content[0].Text)
+	assert.Equal(t, "function_call", completed.Response.Output[1].Type)
+	assert.Equal(t, "message", completed.Response.Output[2].Type)
+	assert.Equal(t, "after", completed.Response.Output[2].Content[0].Text)
+	assert.Equal(t, added[0].Item.ID, completed.Response.Output[0].ID)
+	assert.Equal(t, added[2].Item.ID, completed.Response.Output[2].ID)
 }

--- a/internal/protocol/stream/anthropic_to_openai_converter.go
+++ b/internal/protocol/stream/anthropic_to_openai_converter.go
@@ -6,12 +6,20 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	usagepkg "github.com/tingly-dev/tingly-box/internal/protocol/usage"
 	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
 )
+
+// AnthropicBetaStream is the transport-neutral iterator surface consumed by
+// the Anthropic Beta to OpenAI Chat stream converter. The Anthropic SDK stream
+// and dormant Stage adapters both implement this contract.
+type AnthropicBetaStream interface {
+	Next() bool
+	Current() anthropic.BetaRawMessageStreamEventUnion
+	Err() error
+}
 
 // anthropicToOpenAIConverter is a stateful iterator that reads Anthropic Beta stream
 // events and emits OpenAI Chat Completion wire chunks.
@@ -21,7 +29,7 @@ import (
 // values ("role":"", "finish_reason":"", zero usage on every chunk), which
 // strict clients reject.
 type anthropicToOpenAIConverter struct {
-	stream             *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion]
+	stream             AnthropicBetaStream
 	responseModel      string
 	disableStreamUsage bool
 	hooks              *AnthropicToOpenAIMCPHooks
@@ -46,7 +54,7 @@ type anthropicToOpenAIConverter struct {
 }
 
 func newAnthropicToOpenAIConverter(
-	stream *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion],
+	stream AnthropicBetaStream,
 	responseModel string,
 	disableStreamUsage bool,
 	hooks *AnthropicToOpenAIMCPHooks,
@@ -60,6 +68,17 @@ func newAnthropicToOpenAIConverter(
 		created:            time.Now().Unix(),
 		acc:                usagepkg.NewAnthropicAccumulator(),
 	}
+}
+
+// NewAnthropicBetaToOpenAIChatConverter creates a hook-free, transport-neutral
+// converter. HTTP/SSE framing, MCP hooks, and stream close ownership remain
+// with the caller.
+func NewAnthropicBetaToOpenAIChatConverter(
+	stream AnthropicBetaStream,
+	responseModel string,
+	disableStreamUsage bool,
+) StreamConverter {
+	return newAnthropicToOpenAIConverter(stream, responseModel, disableStreamUsage, nil)
 }
 
 func (c *anthropicToOpenAIConverter) Next() (interface{}, bool, error) {

--- a/internal/protocol/stream/anthropic_to_openai_converter.go
+++ b/internal/protocol/stream/anthropic_to_openai_converter.go
@@ -99,7 +99,7 @@ func (c *anthropicToOpenAIConverter) Next() (interface{}, bool, error) {
 				return nil, false, err
 			}
 			if c.started && !c.done {
-				return nil, false, fmt.Errorf("anthropic stream ended without message_stop")
+				return nil, false, errAnthropicStreamTruncated
 			}
 			return nil, true, nil
 		}

--- a/internal/protocol/stream/anthropic_to_openai_converter_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_converter_test.go
@@ -1,0 +1,99 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol/wire"
+)
+
+func TestNewAnthropicBetaToOpenAIChatConverter(t *testing.T) {
+	stream := &anthropicBetaSliceStream{events: anthropicBetaEvents(t,
+		map[string]any{
+			"type": "message_start",
+			"message": map[string]any{
+				"id": "msg_parallel", "type": "message", "role": "assistant",
+				"content": []any{}, "model": "provider-model",
+				"usage": map[string]any{"input_tokens": 4, "output_tokens": 0},
+			},
+		},
+		map[string]any{"type": "content_block_start", "index": 0, "content_block": map[string]any{"type": "text", "text": ""}},
+		map[string]any{"type": "content_block_delta", "index": 0, "delta": map[string]any{"type": "text_delta", "text": "parallel path"}},
+		map[string]any{"type": "content_block_stop", "index": 0},
+		map[string]any{"type": "message_delta", "delta": map[string]any{"stop_reason": "end_turn"}, "usage": map[string]any{"output_tokens": 2}},
+		map[string]any{"type": "message_stop"},
+	)}
+	converter := NewAnthropicBetaToOpenAIChatConverter(stream, "client-visible-model", false)
+
+	var chunks []wire.ChatStreamChunk
+	for {
+		event, done, err := converter.Next()
+		require.NoError(t, err)
+		if done {
+			break
+		}
+		chunk, ok := event.(wire.ChatStreamChunk)
+		require.Truef(t, ok, "event type = %T", event)
+		chunks = append(chunks, chunk)
+	}
+
+	require.Len(t, chunks, 3)
+	assert.Equal(t, "assistant", chunks[0].Choices[0].Delta.Role)
+	assert.Equal(t, "parallel path", chunks[1].Choices[0].Delta.Content)
+	require.NotNil(t, chunks[2].Choices[0].FinishReason)
+	assert.Equal(t, "stop", *chunks[2].Choices[0].FinishReason)
+	require.NotNil(t, chunks[2].Usage)
+	assert.EqualValues(t, 4, chunks[2].Usage.PromptTokens)
+	assert.EqualValues(t, 2, chunks[2].Usage.CompletionTokens)
+	require.NotNil(t, converter.Usage())
+	assert.Equal(t, 4, converter.Usage().InputTokens)
+	assert.Equal(t, 2, converter.Usage().OutputTokens)
+}
+
+func TestNewAnthropicBetaToOpenAIChatConverterPropagatesIteratorError(t *testing.T) {
+	want := errors.New("upstream failed before an event")
+	converter := NewAnthropicBetaToOpenAIChatConverter(&anthropicBetaSliceStream{err: want}, "model", false)
+
+	event, done, err := converter.Next()
+	assert.Nil(t, event)
+	assert.False(t, done)
+	assert.ErrorIs(t, err, want)
+}
+
+type anthropicBetaSliceStream struct {
+	events []anthropic.BetaRawMessageStreamEventUnion
+	index  int
+	err    error
+}
+
+func (s *anthropicBetaSliceStream) Next() bool {
+	if s.index >= len(s.events) {
+		return false
+	}
+	s.index++
+	return true
+}
+
+func (s *anthropicBetaSliceStream) Current() anthropic.BetaRawMessageStreamEventUnion {
+	return s.events[s.index-1]
+}
+
+func (s *anthropicBetaSliceStream) Err() error { return s.err }
+
+func anthropicBetaEvents(t *testing.T, bodies ...map[string]any) []anthropic.BetaRawMessageStreamEventUnion {
+	t.Helper()
+	events := make([]anthropic.BetaRawMessageStreamEventUnion, 0, len(bodies))
+	for _, body := range bodies {
+		raw, err := json.Marshal(body)
+		require.NoError(t, err)
+		var event anthropic.BetaRawMessageStreamEventUnion
+		require.NoError(t, json.Unmarshal(raw, &event))
+		events = append(events, event)
+	}
+	return events
+}

--- a/internal/protocol/stream/openai_chat_to_responses_converter.go
+++ b/internal/protocol/stream/openai_chat_to_responses_converter.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/openai/openai-go/v3"
-	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	protocolusage "github.com/tingly-dev/tingly-box/internal/protocol/usage"
@@ -17,7 +16,7 @@ import (
 // chatToResponsesConverter converts an OpenAI Chat Completions stream into
 // a sequence of Responses API events. It implements StreamConverter.
 type chatToResponsesConverter struct {
-	stream        *openaistream.Stream[openai.ChatCompletionChunk]
+	stream        OpenAIChatStream
 	responseModel string
 
 	// internal state
@@ -26,6 +25,7 @@ type chatToResponsesConverter struct {
 	sequenceNumber    int64
 	outputIndex       int
 	textItemID        string
+	textOutputIndex   int
 	hasTextItem       bool
 	pendingToolCalls  map[int]*pendingToolCallResponse
 	accumulatedText   strings.Builder
@@ -51,13 +51,14 @@ type pendingToolCallResponse struct {
 
 // NewChatToResponsesConverter creates a converter that reads from an OpenAI
 // Chat Completions stream and yields Responses API wire events.
-func NewChatToResponsesConverter(stream *openaistream.Stream[openai.ChatCompletionChunk], responseModel string) *chatToResponsesConverter {
+func NewChatToResponsesConverter(stream OpenAIChatStream, responseModel string) *chatToResponsesConverter {
 	return &chatToResponsesConverter{
 		stream:           stream,
 		responseModel:    responseModel,
 		responseID:       fmt.Sprintf("resp_%d", time.Now().Unix()),
 		createdAt:        time.Now().Unix(),
 		textItemID:       fmt.Sprintf("msg_%d", time.Now().UnixNano()),
+		textOutputIndex:  -1,
 		usage:            protocol.ZeroTokenUsage(),
 		pendingToolCalls: make(map[int]*pendingToolCallResponse),
 	}
@@ -127,6 +128,8 @@ func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChun
 	// Handle content delta
 	if choice.Delta.Content != "" {
 		if !c.hasTextItem {
+			c.textOutputIndex = c.outputIndex
+			c.outputIndex++
 			c.emitTextItemAdded()
 			c.hasTextItem = true
 		}
@@ -135,7 +138,7 @@ func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChun
 			Type:           "response.output_text.delta",
 			SequenceNumber: c.nextSeq(),
 			ItemID:         c.textItemID,
-			OutputIndex:    0,
+			OutputIndex:    c.textOutputIndex,
 			ContentIndex:   0,
 			Delta:          choice.Delta.Content,
 			Logprobs:       []interface{}{},
@@ -152,10 +155,6 @@ func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChun
 				itemID = truncateToolCallID(toolCall.ID)
 			}
 
-			// Reserve OutputIndex 0 for the text message item; tool calls start at 1.
-			if c.outputIndex == 0 {
-				c.outputIndex = 1
-			}
 			toolOutputIndex := c.outputIndex
 			c.outputIndex++
 
@@ -235,15 +234,27 @@ func (c *chatToResponsesConverter) emitCompletionEvents() {
 			Type:           "response.output_text.done",
 			SequenceNumber: c.nextSeq(),
 			ItemID:         c.textItemID,
-			OutputIndex:    0,
+			OutputIndex:    c.textOutputIndex,
 			ContentIndex:   0,
 			Text:           text,
 			Logprobs:       []interface{}{},
 		})
+		c.pending = append(c.pending, wire.ResponsesContentPartDoneEvent{
+			Type:           "response.content_part.done",
+			SequenceNumber: c.nextSeq(),
+			OutputIndex:    c.textOutputIndex,
+			ItemID:         c.textItemID,
+			ContentIndex:   0,
+			Part: wire.ResponsesContentPartWire{
+				Type:        "output_text",
+				Text:        text,
+				Annotations: []interface{}{},
+			},
+		})
 		c.pending = append(c.pending, wire.ResponsesOutputItemDoneEvent{
 			Type:           "response.output_item.done",
 			SequenceNumber: c.nextSeq(),
-			OutputIndex:    0,
+			OutputIndex:    c.textOutputIndex,
 			Item:           newResponsesMessageItem(c.textItemID, "completed", text),
 		})
 	}
@@ -283,9 +294,9 @@ func (c *chatToResponsesConverter) emitCompletionEvents() {
 		itemStatus = "incomplete"
 	}
 
-	var output []wire.ResponsesOutputItemWire
+	output := make([]wire.ResponsesOutputItemWire, c.outputIndex)
 	if c.accumulatedText.Len() > 0 {
-		output = append(output, newResponsesMessageItem(c.textItemID, itemStatus, c.accumulatedText.String()))
+		output[c.textOutputIndex] = newResponsesMessageItem(c.textItemID, itemStatus, c.accumulatedText.String())
 	}
 	for _, idx := range sortedIndexes {
 		ptc := c.pendingToolCalls[idx]
@@ -293,7 +304,7 @@ func (c *chatToResponsesConverter) emitCompletionEvents() {
 		if callID == "" {
 			callID = ptc.itemID
 		}
-		output = append(output, newResponsesFunctionCallItem(ptc.itemID, callID, ptc.name, ptc.arguments.String(), itemStatus))
+		output[ptc.outputIdx] = newResponsesFunctionCallItem(ptc.itemID, callID, ptc.name, ptc.arguments.String(), itemStatus)
 	}
 
 	if isIncomplete {
@@ -328,14 +339,22 @@ func chatFinishReasonToIncomplete(finishReason string) (bool, string) {
 }
 
 func (c *chatToResponsesConverter) emitTextItemAdded() {
-	if c.outputIndex == 0 {
-		c.outputIndex = 1
-	}
 	c.pending = append(c.pending, wire.ResponsesOutputItemAddedEvent{
 		Type:           "response.output_item.added",
 		SequenceNumber: c.nextSeq(),
-		OutputIndex:    0,
+		OutputIndex:    c.textOutputIndex,
 		Item:           newResponsesMessageItem(c.textItemID, "in_progress", ""),
+	})
+	c.pending = append(c.pending, wire.ResponsesContentPartAddedEvent{
+		Type:           "response.content_part.added",
+		SequenceNumber: c.nextSeq(),
+		ItemID:         c.textItemID,
+		OutputIndex:    c.textOutputIndex,
+		ContentIndex:   0,
+		Part: wire.ResponsesContentPartWire{
+			Type:        "output_text",
+			Annotations: []interface{}{},
+		},
 	})
 }
 

--- a/internal/protocol/stream/openai_chat_to_responses_converter.go
+++ b/internal/protocol/stream/openai_chat_to_responses_converter.go
@@ -102,15 +102,8 @@ func (c *chatToResponsesConverter) Usage() *protocol.TokenUsage {
 // processChunk handles a single upstream ChatCompletionChunk and appends
 // zero or more Responses API events to c.pending.
 func (c *chatToResponsesConverter) processChunk(chunk *openai.ChatCompletionChunk) {
-	// Emit response.created on first chunk
-	if !c.hasSentCreated {
-		c.pending = append(c.pending, wire.ResponsesCreatedEvent{
-			Type:           "response.created",
-			SequenceNumber: c.nextSeq(),
-			Response:       c.wireResponse("in_progress", nil),
-		})
-		c.hasSentCreated = true
-	}
+	// Emit response.created / response.in_progress on first chunk
+	c.emitCreated()
 
 	// Track usage
 	if chunkHasUsage(chunk.Usage) {
@@ -215,14 +208,7 @@ func (c *chatToResponsesConverter) emitCompletionEvents() {
 	}
 	c.completedSent = true
 
-	if !c.hasSentCreated {
-		c.pending = append(c.pending, wire.ResponsesCreatedEvent{
-			Type:           "response.created",
-			SequenceNumber: c.nextSeq(),
-			Response:       c.wireResponse("in_progress", nil),
-		})
-		c.hasSentCreated = true
-	}
+	c.emitCreated()
 
 	if c.finishReason == "" {
 		c.finishReason = "stop"
@@ -295,7 +281,7 @@ func (c *chatToResponsesConverter) emitCompletionEvents() {
 	}
 
 	output := make([]wire.ResponsesOutputItemWire, c.outputIndex)
-	if c.accumulatedText.Len() > 0 {
+	if c.hasTextItem {
 		output[c.textOutputIndex] = newResponsesMessageItem(c.textItemID, itemStatus, c.accumulatedText.String())
 	}
 	for _, idx := range sortedIndexes {
@@ -336,6 +322,26 @@ func chatFinishReasonToIncomplete(finishReason string) (bool, string) {
 	default:
 		return false, ""
 	}
+}
+
+// emitCreated appends response.created + response.in_progress once. The real
+// Responses API opens every stream with both events, and strict clients (and
+// the sibling Anthropic-to-Responses converter) expect the pair.
+func (c *chatToResponsesConverter) emitCreated() {
+	if c.hasSentCreated {
+		return
+	}
+	c.hasSentCreated = true
+	c.pending = append(c.pending, wire.ResponsesCreatedEvent{
+		Type:           "response.created",
+		SequenceNumber: c.nextSeq(),
+		Response:       c.wireResponse("in_progress", nil),
+	})
+	c.pending = append(c.pending, wire.ResponsesInProgressEvent{
+		Type:           "response.in_progress",
+		SequenceNumber: c.nextSeq(),
+		Response:       c.wireResponse("in_progress", nil),
+	})
 }
 
 func (c *chatToResponsesConverter) emitTextItemAdded() {

--- a/internal/protocol/stream/openai_chat_to_responses_golden_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_golden_test.go
@@ -110,16 +110,18 @@ func TestChatToResponsesConverter_GoldenSequence(t *testing.T) {
 	// 1. Exact ordered event sequence — the heart of the oracle.
 	want := []string{
 		"response.created",
-		"response.output_item.added",             // text item (index 0)
+		"response.output_item.added", // text item (index 0)
+		"response.content_part.added",
 		"response.output_text.delta",             // "Hello"
 		"response.output_text.delta",             // ", World!"
 		"response.output_item.added",             // function call (index 1)
 		"response.function_call_arguments.delta", // {"city":
 		"response.function_call_arguments.delta", // "Paris"}
 		"response.output_text.done",              // text done before tool done
-		"response.output_item.done",              // text message item
-		"response.function_call_arguments.done",  // full arguments
-		"response.output_item.done",              // function call item
+		"response.content_part.done",
+		"response.output_item.done",             // text message item
+		"response.function_call_arguments.done", // full arguments
+		"response.output_item.done",             // function call item
 		"response.completed",
 	}
 	gotTypes := make([]string, len(got))
@@ -134,17 +136,17 @@ func TestChatToResponsesConverter_GoldenSequence(t *testing.T) {
 	}
 
 	// 3. Spot-check key payloads.
-	assert.Equal(t, "Hello", got[2].(wire.ResponsesOutputTextDeltaEvent).Delta)
-	assert.Equal(t, ", World!", got[3].(wire.ResponsesOutputTextDeltaEvent).Delta)
+	assert.Equal(t, "Hello", got[3].(wire.ResponsesOutputTextDeltaEvent).Delta)
+	assert.Equal(t, ", World!", got[4].(wire.ResponsesOutputTextDeltaEvent).Delta)
 
-	textDone := got[7].(wire.ResponsesOutputTextDoneEvent)
+	textDone := got[8].(wire.ResponsesOutputTextDoneEvent)
 	assert.Equal(t, "Hello, World!", textDone.Text)
 
-	argsDone := got[9].(wire.ResponsesFunctionCallArgumentsDoneEvent)
+	argsDone := got[11].(wire.ResponsesFunctionCallArgumentsDoneEvent)
 	assert.Equal(t, "get_weather", argsDone.Name)
 	assert.Equal(t, `{"city":"Paris"}`, argsDone.Arguments)
 
-	completed := got[11].(wire.ResponsesCompletedEvent)
+	completed := got[13].(wire.ResponsesCompletedEvent)
 	assert.Equal(t, "completed", completed.Response.Status)
 	require.Len(t, completed.Response.Output, 2, "final output carries text + tool-call items")
 
@@ -161,7 +163,11 @@ func seqOf(t *testing.T, e wire.ResponsesEvent) int64 {
 	switch v := e.(type) {
 	case wire.ResponsesCreatedEvent:
 		return v.SequenceNumber
+	case wire.ResponsesInProgressEvent:
+		return v.SequenceNumber
 	case wire.ResponsesOutputItemAddedEvent:
+		return v.SequenceNumber
+	case wire.ResponsesContentPartAddedEvent:
 		return v.SequenceNumber
 	case wire.ResponsesOutputTextDeltaEvent:
 		return v.SequenceNumber
@@ -169,11 +175,15 @@ func seqOf(t *testing.T, e wire.ResponsesEvent) int64 {
 		return v.SequenceNumber
 	case wire.ResponsesOutputTextDoneEvent:
 		return v.SequenceNumber
+	case wire.ResponsesContentPartDoneEvent:
+		return v.SequenceNumber
 	case wire.ResponsesOutputItemDoneEvent:
 		return v.SequenceNumber
 	case wire.ResponsesFunctionCallArgumentsDoneEvent:
 		return v.SequenceNumber
 	case wire.ResponsesCompletedEvent:
+		return v.SequenceNumber
+	case wire.ResponsesIncompleteEvent:
 		return v.SequenceNumber
 	default:
 		t.Fatalf("unexpected event type %T", e)

--- a/internal/protocol/stream/openai_chat_to_responses_golden_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_golden_test.go
@@ -110,6 +110,7 @@ func TestChatToResponsesConverter_GoldenSequence(t *testing.T) {
 	// 1. Exact ordered event sequence — the heart of the oracle.
 	want := []string{
 		"response.created",
+		"response.in_progress",
 		"response.output_item.added", // text item (index 0)
 		"response.content_part.added",
 		"response.output_text.delta",             // "Hello"
@@ -136,17 +137,17 @@ func TestChatToResponsesConverter_GoldenSequence(t *testing.T) {
 	}
 
 	// 3. Spot-check key payloads.
-	assert.Equal(t, "Hello", got[3].(wire.ResponsesOutputTextDeltaEvent).Delta)
-	assert.Equal(t, ", World!", got[4].(wire.ResponsesOutputTextDeltaEvent).Delta)
+	assert.Equal(t, "Hello", got[4].(wire.ResponsesOutputTextDeltaEvent).Delta)
+	assert.Equal(t, ", World!", got[5].(wire.ResponsesOutputTextDeltaEvent).Delta)
 
-	textDone := got[8].(wire.ResponsesOutputTextDoneEvent)
+	textDone := got[9].(wire.ResponsesOutputTextDoneEvent)
 	assert.Equal(t, "Hello, World!", textDone.Text)
 
-	argsDone := got[11].(wire.ResponsesFunctionCallArgumentsDoneEvent)
+	argsDone := got[12].(wire.ResponsesFunctionCallArgumentsDoneEvent)
 	assert.Equal(t, "get_weather", argsDone.Name)
 	assert.Equal(t, `{"city":"Paris"}`, argsDone.Arguments)
 
-	completed := got[13].(wire.ResponsesCompletedEvent)
+	completed := got[14].(wire.ResponsesCompletedEvent)
 	assert.Equal(t, "completed", completed.Response.Status)
 	require.Len(t, completed.Response.Output, 2, "final output carries text + tool-call items")
 

--- a/internal/protocol/stream/openai_chat_to_responses_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_test.go
@@ -201,13 +201,14 @@ func TestChatToResponsesConverter_TextDelta(t *testing.T) {
 		},
 	})
 
-	// Should emit: response.created, output_item.added, output_text.delta
-	require.Len(t, conv.pending, 3)
+	// Should emit the complete Responses text lifecycle before the delta.
+	require.Len(t, conv.pending, 4)
 	assert.Equal(t, "response.created", conv.pending[0].(wire.ResponsesCreatedEvent).Type)
 	assert.Equal(t, "response.output_item.added", conv.pending[1].(wire.ResponsesOutputItemAddedEvent).Type)
-	assert.Equal(t, "response.output_text.delta", conv.pending[2].(wire.ResponsesOutputTextDeltaEvent).Type)
+	assert.Equal(t, "response.content_part.added", conv.pending[2].(wire.ResponsesContentPartAddedEvent).Type)
+	assert.Equal(t, "response.output_text.delta", conv.pending[3].(wire.ResponsesOutputTextDeltaEvent).Type)
 
-	delta := conv.pending[2].(wire.ResponsesOutputTextDeltaEvent)
+	delta := conv.pending[3].(wire.ResponsesOutputTextDeltaEvent)
 	assert.Equal(t, "Hello, World!", delta.Delta)
 }
 
@@ -239,6 +240,42 @@ func TestChatToResponsesConverter_ToolCall(t *testing.T) {
 	argsDelta := conv.pending[1].(wire.ResponsesFunctionCallArgumentsDeltaEvent)
 	assert.Equal(t, "response.function_call_arguments.delta", argsDelta.Type)
 	assert.Equal(t, `{"loc`, argsDelta.Delta)
+}
+
+func TestChatToResponsesConverter_ToolOnlyUsesFirstOutputIndex(t *testing.T) {
+	conv := NewChatToResponsesConverter(nil, "gpt-4o-mini")
+	conv.hasSentCreated = true
+
+	conv.processChunk(&openai.ChatCompletionChunk{Choices: []openai.ChatCompletionChunkChoice{{
+		Delta: openai.ChatCompletionChunkChoiceDelta{ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
+			Index: 0,
+			ID:    "call_123",
+			Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+				Name: "get_weather", Arguments: `{"city":"Paris"}`,
+			},
+		}}},
+	}}})
+	conv.processChunk(&openai.ChatCompletionChunk{Choices: []openai.ChatCompletionChunkChoice{{
+		FinishReason: "tool_calls",
+	}}})
+
+	added := conv.pending[0].(wire.ResponsesOutputItemAddedEvent)
+	assert.Equal(t, 0, added.OutputIndex)
+
+	var done wire.ResponsesOutputItemDoneEvent
+	var completed wire.ResponsesCompletedEvent
+	for _, event := range conv.pending {
+		switch event := event.(type) {
+		case wire.ResponsesOutputItemDoneEvent:
+			done = event
+		case wire.ResponsesCompletedEvent:
+			completed = event
+		}
+	}
+	assert.Equal(t, 0, done.OutputIndex)
+	require.Len(t, completed.Response.Output, 1)
+	assert.Equal(t, "function_call", completed.Response.Output[0].Type)
+	assert.Equal(t, "call_123", completed.Response.Output[0].CallID)
 }
 
 // TestChatToResponsesConverter_CompletedEvent tests usage propagation

--- a/internal/protocol/stream/openai_chat_to_responses_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_test.go
@@ -202,13 +202,14 @@ func TestChatToResponsesConverter_TextDelta(t *testing.T) {
 	})
 
 	// Should emit the complete Responses text lifecycle before the delta.
-	require.Len(t, conv.pending, 4)
+	require.Len(t, conv.pending, 5)
 	assert.Equal(t, "response.created", conv.pending[0].(wire.ResponsesCreatedEvent).Type)
-	assert.Equal(t, "response.output_item.added", conv.pending[1].(wire.ResponsesOutputItemAddedEvent).Type)
-	assert.Equal(t, "response.content_part.added", conv.pending[2].(wire.ResponsesContentPartAddedEvent).Type)
-	assert.Equal(t, "response.output_text.delta", conv.pending[3].(wire.ResponsesOutputTextDeltaEvent).Type)
+	assert.Equal(t, "response.in_progress", conv.pending[1].(wire.ResponsesInProgressEvent).Type)
+	assert.Equal(t, "response.output_item.added", conv.pending[2].(wire.ResponsesOutputItemAddedEvent).Type)
+	assert.Equal(t, "response.content_part.added", conv.pending[3].(wire.ResponsesContentPartAddedEvent).Type)
+	assert.Equal(t, "response.output_text.delta", conv.pending[4].(wire.ResponsesOutputTextDeltaEvent).Type)
 
-	delta := conv.pending[3].(wire.ResponsesOutputTextDeltaEvent)
+	delta := conv.pending[4].(wire.ResponsesOutputTextDeltaEvent)
 	assert.Equal(t, "Hello, World!", delta.Delta)
 }
 

--- a/internal/protocol/stream/openai_responses_to_anthropic_assembly_test.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_assembly_test.go
@@ -105,7 +105,9 @@ func TestHandleResponsesToAnthropicV1Assembly_Golden(t *testing.T) {
 
 	toolBlock := content[1].(map[string]any)
 	assert.Equal(t, "tool_use", toolBlock["type"])
-	assert.Equal(t, "fc_1", toolBlock["id"])
+	// Anthropic tool_result correlation uses Responses call_id, while the
+	// response item id remains an internal stream assembly identifier.
+	assert.Equal(t, "call_1", toolBlock["id"])
 	assert.Equal(t, "get_weather", toolBlock["name"])
 	assert.Equal(t, map[string]any{"city": "Paris"}, toolBlock["input"])
 

--- a/internal/protocol/stream/openai_responses_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_converter.go
@@ -57,6 +57,17 @@ func newResponsesToAnthropicConverter(ctx context.Context, stream ResponsesStrea
 	}
 }
 
+// NewOpenAIResponsesToAnthropicConverter creates a transport-neutral
+// Responses-to-Anthropic converter. The caller owns stream closure and wire
+// framing; emitted values can be normalized with AsAnthropicEvent.
+func NewOpenAIResponsesToAnthropicConverter(
+	ctx context.Context,
+	stream ResponsesStreamIter,
+	responseModel string,
+) StreamConverter {
+	return newResponsesToAnthropicConverter(ctx, stream, responseModel)
+}
+
 func (r *responsesToAnthropicConverter) Next() (interface{}, bool, error) {
 	if !r.messageStartSent {
 		r.emitMessageStart()
@@ -323,7 +334,11 @@ func (r *responsesToAnthropicConverter) processEvent(currentEvent responses.Resp
 			r.emitContentBlockDelta(r.state.textBlockIndex, anthropicTextDelta(textDelta.Delta))
 		case "function_call", "custom_tool_call", "mcp_call":
 			itemID := itemAdded.Item.ID
-			truncatedID := truncateToolCallID(itemID)
+			callID := itemAdded.Item.CallID
+			if callID == "" {
+				callID = itemID
+			}
+			truncatedID := truncateToolCallID(callID)
 			blockIndex := r.state.nextBlockIndex
 			r.state.nextBlockIndex++
 
@@ -537,7 +552,11 @@ func (r *responsesToAnthropicConverter) finalize(resp *responses.Response, stopR
 			continue
 		}
 
-		truncatedID := truncateToolCallID(itemID)
+		callID := outputItem.CallID
+		if callID == "" {
+			callID = itemID
+		}
+		truncatedID := truncateToolCallID(callID)
 		blockIndex := r.state.nextBlockIndex
 		r.state.nextBlockIndex++
 

--- a/internal/protocol/stream/openai_responses_to_anthropic_golden_test.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_golden_test.go
@@ -120,6 +120,7 @@ func TestResponsesToAnthropicConverter_GoldenSequence(t *testing.T) {
 	toolBlockStart := eventDataAsMap(t, got[5].data)
 	toolBlock := toolBlockStart["content_block"].(map[string]interface{})
 	assert.Equal(t, "tool_use", toolBlock["type"])
+	assert.Equal(t, "call_1", toolBlock["id"], "Anthropic tool_result must reference the Responses call_id")
 	assert.Equal(t, "get_weather", toolBlock["name"])
 
 	// args delta

--- a/internal/protocol/stream/openai_responses_to_chat_converter.go
+++ b/internal/protocol/stream/openai_responses_to_chat_converter.go
@@ -57,6 +57,16 @@ func newResponsesToChatConverter(stream ResponsesStreamIter, responseModel strin
 	}
 }
 
+// NewOpenAIResponsesToChatConverter creates a transport-neutral Responses to
+// Chat stream converter. The caller owns stream closure and SSE framing.
+func NewOpenAIResponsesToChatConverter(
+	stream ResponsesStreamIter,
+	responseModel string,
+	disableUsage bool,
+) StreamConverter {
+	return newResponsesToChatConverter(stream, responseModel, disableUsage)
+}
+
 func (c *responsesToChatConverter) Next() (interface{}, bool, error) {
 	// Drain buffered events first
 	if len(c.pending) > 0 {

--- a/internal/protocol/stream/openai_to_anthropic.go
+++ b/internal/protocol/stream/openai_to_anthropic.go
@@ -99,6 +99,12 @@ type OpenAIToAnthropicMCPHooks struct {
 
 var ErrMCPStreamContinue = errors.New("mcp stream should continue")
 
+// NewOpenAIChatToAnthropicV1Converter creates the transport-free V1 stream
+// state machine. The caller owns driving and closing the supplied stream.
+func NewOpenAIChatToAnthropicV1Converter(stream OpenAIChatStream, responseModel string, req *openai.ChatCompletionNewParams) StreamConverter {
+	return newOpenAIToAnthropicConverter(stream, responseModel, req, nil, mapOpenAIFinishReasonToAnthropic)
+}
+
 // HandleOpenAIToAnthropicStreamResponse processes OpenAI streaming events and converts them to Anthropic format.
 // Returns UsageStat containing token usage information for tracking.
 func HandleOpenAIToAnthropicStreamResponse(hc *protocol.HandleContext, req *openai.ChatCompletionNewParams, stream *openaistream.Stream[openai.ChatCompletionChunk], responseModel string) (*protocol.TokenUsage, error) {

--- a/internal/protocol/stream/openai_to_anthropic_beta.go
+++ b/internal/protocol/stream/openai_to_anthropic_beta.go
@@ -13,6 +13,12 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
+// NewOpenAIChatToAnthropicBetaConverter creates the transport-free beta stream
+// state machine. The caller owns driving and closing the supplied stream.
+func NewOpenAIChatToAnthropicBetaConverter(stream OpenAIChatStream, responseModel string, req *openai.ChatCompletionNewParams) StreamConverter {
+	return newOpenAIToAnthropicConverter(stream, responseModel, req, nil, mapOpenAIFinishReasonToAnthropicBeta)
+}
+
 // HandleOpenAIToAnthropicBetaStream processes OpenAI streaming events and converts them to Anthropic beta format.
 // Returns UsageStat containing token usage information for tracking.
 func HandleOpenAIToAnthropicBetaStream(hc *protocol.HandleContext, req *openai.ChatCompletionNewParams, stream *openaistream.Stream[openai.ChatCompletionChunk], responseModel string) (*protocol.TokenUsage, error) {

--- a/internal/protocol/stream/openai_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_to_anthropic_converter.go
@@ -132,12 +132,19 @@ func (c *openAIToAnthropicConverter) Next() (interface{}, bool, error) {
 
 	for {
 		if !c.stream.Next() {
-			if err := c.stream.Err(); err != nil {
-				return nil, false, err
-			}
+			streamErr := c.stream.Err()
 			if c.finishSeen && c.hookErr == nil {
-				// Upstream finished normally.
+				// Upstream delivered finish_reason, so the turn is semantically
+				// complete. The SDK keeps reading past [DONE] to physical EOF,
+				// where a provider that tears the connection down without a
+				// clean close surfaces a scanner error; treating that as fatal
+				// would discard a fully delivered response. Salvage it.
+				if streamErr != nil {
+					logrus.WithError(streamErr).Warn("openai stream errored after finish_reason; salvaging completed response")
+				}
 				c.emitTerminalEvents()
+			} else if streamErr != nil {
+				return nil, false, streamErr
 			} else if c.messageStarted && c.hookErr == nil {
 				// Upstream cut mid-stream after content started: surface an
 				// honest error event rather than fabricating a clean end_turn.

--- a/internal/protocol/stream/openai_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_to_anthropic_converter.go
@@ -1,13 +1,13 @@
 package stream
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
-	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -23,10 +23,48 @@ type anthropicStreamEvent struct {
 	data      any
 }
 
+// AnthropicEvent is the transport-neutral view of an Anthropic stream event.
+// HTTP writers may keep using the internal representation; protocol stages use
+// this exported value to carry event name and data without taking over SSE
+// framing.
+type AnthropicEvent struct {
+	Type string
+	Data any
+}
+
+// RawJSON returns the protocol payload rather than the transport wrapper.
+// Protocol-owned assemblers use this to reconstruct converted streams without
+// mistaking the Type/Data carrier itself for an Anthropic wire event.
+func (e AnthropicEvent) RawJSON() string {
+	raw, err := json.Marshal(e.Data)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// AsAnthropicEvent exposes an event emitted by an Anthropic stream converter.
+func AsAnthropicEvent(event any) (AnthropicEvent, bool) {
+	value, ok := event.(anthropicStreamEvent)
+	if !ok {
+		return AnthropicEvent{}, false
+	}
+	return AnthropicEvent{Type: value.eventType, Data: value.data}, true
+}
+
+// OpenAIChatStream is the minimum iterator surface required by the Chat to
+// Anthropic state machine. The OpenAI SDK stream and stage stream adapters both
+// implement it.
+type OpenAIChatStream interface {
+	Next() bool
+	Current() openai.ChatCompletionChunk
+	Err() error
+}
+
 // openAIToAnthropicConverter is a stateful iterator that reads OpenAI Chat Completion
 // chunks and emits Anthropic SSE events (map-based).
 type openAIToAnthropicConverter struct {
-	stream          *openaistream.Stream[openai.ChatCompletionChunk]
+	stream          OpenAIChatStream
 	responseModel   string
 	req             *openai.ChatCompletionNewParams
 	hooks           *OpenAIToAnthropicMCPHooks
@@ -47,7 +85,7 @@ type openAIToAnthropicConverter struct {
 }
 
 func newOpenAIToAnthropicConverter(
-	stream *openaistream.Stream[openai.ChatCompletionChunk],
+	stream OpenAIChatStream,
 	responseModel string,
 	req *openai.ChatCompletionNewParams,
 	hooks *OpenAIToAnthropicMCPHooks,
@@ -94,6 +132,9 @@ func (c *openAIToAnthropicConverter) Next() (interface{}, bool, error) {
 
 	for {
 		if !c.stream.Next() {
+			if err := c.stream.Err(); err != nil {
+				return nil, false, err
+			}
 			if c.finishSeen && c.hookErr == nil {
 				// Upstream finished normally.
 				c.emitTerminalEvents()

--- a/internal/protocol/stream/openai_to_anthropic_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_test.go
@@ -59,6 +59,97 @@ func TestOpenAIChatToAnthropicConvertersPropagateIteratorError(t *testing.T) {
 	}
 }
 
+// openAIChatSliceStream replays fixed chunks, then reports err from Err() once
+// exhausted — simulating a provider whose connection teardown is dirty.
+type openAIChatSliceStream struct {
+	chunks []openai.ChatCompletionChunk
+	index  int
+	err    error
+}
+
+func (s *openAIChatSliceStream) Next() bool {
+	if s.index >= len(s.chunks) {
+		return false
+	}
+	s.index++
+	return true
+}
+
+func (s *openAIChatSliceStream) Current() openai.ChatCompletionChunk {
+	return s.chunks[s.index-1]
+}
+
+func (s *openAIChatSliceStream) Err() error { return s.err }
+
+func openAIChatChunks(t *testing.T, bodies ...string) []openai.ChatCompletionChunk {
+	t.Helper()
+	chunks := make([]openai.ChatCompletionChunk, 0, len(bodies))
+	for _, body := range bodies {
+		var chunk openai.ChatCompletionChunk
+		require.NoError(t, json.Unmarshal([]byte(body), &chunk))
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+// TestOpenAIChatToAnthropicSalvagesDirtyTeardownAfterFinish pins the salvage
+// semantics: once finish_reason arrived the turn is semantically complete, so a
+// scanner error surfaced while draining to physical EOF (a provider closing
+// without a clean shutdown) must not discard the response — the client still
+// gets message_delta + message_stop and no error.
+func TestOpenAIChatToAnthropicSalvagesDirtyTeardownAfterFinish(t *testing.T) {
+	stream := &openAIChatSliceStream{
+		chunks: openAIChatChunks(t,
+			`{"choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`,
+			`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		),
+		err: errors.New("unexpected EOF"),
+	}
+	converter := NewOpenAIChatToAnthropicV1Converter(stream, "model", nil)
+
+	var types []string
+	for {
+		event, done, err := converter.Next()
+		require.NoError(t, err, "dirty teardown after finish_reason must be salvaged, not surfaced")
+		if done {
+			break
+		}
+		typed, ok := AsAnthropicEvent(event)
+		require.Truef(t, ok, "event type = %T", event)
+		types = append(types, typed.Type)
+	}
+
+	require.GreaterOrEqual(t, len(types), 2)
+	assert.Equal(t, "message_start", types[0])
+	assert.Equal(t, "message_delta", types[len(types)-2])
+	assert.Equal(t, "message_stop", types[len(types)-1])
+}
+
+// TestOpenAIChatToAnthropicPropagatesMidStreamError pins the complementary
+// case: the same teardown error before finish_reason is a genuine truncation
+// and must surface as an error instead of fabricating a clean ending.
+func TestOpenAIChatToAnthropicPropagatesMidStreamError(t *testing.T) {
+	want := errors.New("connection reset by peer")
+	stream := &openAIChatSliceStream{
+		chunks: openAIChatChunks(t,
+			`{"choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"}}]}`,
+		),
+		err: want,
+	}
+	converter := NewOpenAIChatToAnthropicV1Converter(stream, "model", nil)
+
+	for {
+		event, done, err := converter.Next()
+		if err != nil {
+			assert.ErrorIs(t, err, want)
+			return
+		}
+		require.False(t, done, "mid-stream teardown error must surface, got clean end")
+		_, ok := AsAnthropicEvent(event)
+		require.Truef(t, ok, "event type = %T", event)
+	}
+}
+
 type closeNotifyRecorder struct {
 	*httptest.ResponseRecorder
 }

--- a/internal/protocol/stream/openai_to_anthropic_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,6 +27,37 @@ func (f *fakeOpenAIDecoder) Event() openaistream.Event { return openaistream.Eve
 func (f *fakeOpenAIDecoder) Next() bool                { return false }
 func (f *fakeOpenAIDecoder) Close() error              { return nil }
 func (f *fakeOpenAIDecoder) Err() error                { return nil }
+
+type failingOpenAIChatStream struct {
+	err error
+}
+
+func (s *failingOpenAIChatStream) Next() bool { return false }
+func (s *failingOpenAIChatStream) Current() openai.ChatCompletionChunk {
+	return openai.ChatCompletionChunk{}
+}
+func (s *failingOpenAIChatStream) Err() error { return s.err }
+
+func TestOpenAIChatToAnthropicConvertersPropagateIteratorError(t *testing.T) {
+	want := errors.New("upstream iterator failed")
+	constructors := map[string]func(OpenAIChatStream) StreamConverter{
+		"v1": func(stream OpenAIChatStream) StreamConverter {
+			return NewOpenAIChatToAnthropicV1Converter(stream, "model", nil)
+		},
+		"beta": func(stream OpenAIChatStream) StreamConverter {
+			return NewOpenAIChatToAnthropicBetaConverter(stream, "model", nil)
+		},
+	}
+
+	for name, newConverter := range constructors {
+		t.Run(name, func(t *testing.T) {
+			event, done, err := newConverter(&failingOpenAIChatStream{err: want}).Next()
+			assert.Nil(t, event)
+			assert.False(t, done)
+			assert.ErrorIs(t, err, want)
+		})
+	}
+}
 
 type closeNotifyRecorder struct {
 	*httptest.ResponseRecorder


### PR DESCRIPTION
## Summary

The streaming converters carried per-response state where the wire protocols demand per-block state, and coupled the conversion state machines to SDK HTTP stream types. The result: interleaved Anthropic content blocks merged into one Responses item, every event claimed `output_index` 0 while the final `output` array had multiple elements, tool calls correlated by internal item id instead of the `call_id` clients must echo back, and upstream transport errors were either masked as clean endings or (after the first fix) discarded fully-delivered responses on dirty connection teardown. This makes each conversion direction wire-faithful, testable without HTTP plumbing, and honest about upstream failures.

## Key Changes

- **Transport-neutral converter surface**: `AnthropicBetaStream` / `OpenAIChatStream` iterator interfaces + exported constructors decouple the state machines from SDK SSE types; converters now test hermetically and are reusable by the upcoming stage bridges.
- **Per-block state in Anthropic→Responses**: each content block gets its own item ID (`msg_` convention) and a real, contiguous `output_index` that matches the final `output` array — interleaved text/tool blocks no longer collapse into one item, pinned by an interleaving regression test.
- **Responses lifecycle fidelity in Chat→Responses**: emits the full `response.created` / `response.in_progress` opening pair and the `content_part.added`/`done` text lifecycle that the real API always sends and strict clients (AI SDK zod) require; `output_index` follows arrival order, so tool-only responses start at 0.
- **Tool-call correlation via `call_id`**: Responses→Anthropic emits upstream `call_id` as `tool_use.id` (item-id fallback), closing the round-trip with the request-direction converters — the id a client echoes in `tool_result.tool_use_id` now lands back in `function_call`/`function_call_output.call_id` matching provider state.
- **Honest stream-error semantics**: `stream.Err()` propagates instead of masquerading as clean EOF — but once `finish_reason` arrived the turn is semantically complete, so scanner noise from a dirty connection teardown (the SDK drains past `[DONE]` to physical EOF) is logged and the completed response salvaged, not discarded.
- **Golden + semantic tests per direction**: exact event-sequence oracles for both Responses-producing paths, plus regression tests for iterator-error propagation, dirty-teardown salvage, and mid-stream truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L77zfUUwcwv2cvWrdpDxQL