### PR TITLE
fix(protocol): group parallel tool calls in responses->anthropic conversion

### DIFF
--- a/internal/protocol/request/openai_responses_to_anthropic.go
+++ b/internal/protocol/request/openai_responses_to_anthropic.go
@@ -120,36 +120,63 @@ func convertResponsesSystemInputToAnthropicBeta(inputItems responses.ResponseInp
 	return system
 }
 
-// convertResponsesInputToAnthropicBetaMessages converts Responses API input items to Anthropic Beta messages
+// convertResponsesInputToAnthropicBetaMessages converts Responses API input items to Anthropic Beta messages.
+//
+// The Responses API models a tool round-trip as consecutive function_call items
+// (the assistant's turn) followed by consecutive function_call_output items.
+// Anthropic requires every tool_use block to be answered by its tool_result in
+// the very next message, so parallel calls are folded into a single assistant
+// message (all tool_use) and a single user message (all tool_result); otherwise
+// back-to-back tool_use messages get rejected upstream with "tool_use ids were
+// found without tool_result blocks immediately after".
 func convertResponsesInputToAnthropicBetaMessages(inputItems responses.ResponseInputParam) []anthropic.BetaMessageParam {
 	var messages []anthropic.BetaMessageParam
 
 	for _, item := range inputItems {
-		// Handle message items
-		if !param.IsOmitted(item.OfMessage) {
+		switch {
+		case !param.IsOmitted(item.OfMessage):
 			msg := item.OfMessage
-			if string(msg.Role) == "user" {
+			switch string(msg.Role) {
+			case "user":
 				messages = append(messages, convertResponsesUserMessageToAnthropicBeta(msg))
-			} else if string(msg.Role) == "assistant" {
-				messages = append(messages, convertResponsesAssistantMessageToAnthropicBeta(msg))
+			case "assistant":
+				converted := convertResponsesAssistantMessageToAnthropicBeta(msg)
+				// Codex emits a blank message item for tool-only turns; drop it.
+				converted.Content = dropEmptyTextBlocks(converted.Content)
+				if len(converted.Content) > 0 {
+					messages = append(messages, converted)
+				}
 			}
-			continue
-		}
-
-		// Handle function call items (tool_use)
-		if !param.IsOmitted(item.OfFunctionCall) {
-			messages = append(messages, convertResponsesFunctionCallToAnthropicBeta(item.OfFunctionCall))
-			continue
-		}
-
-		// Handle function call output items (tool_result)
-		if !param.IsOmitted(item.OfFunctionCallOutput) {
-			messages = append(messages, convertResponsesFunctionCallOutputToAnthropicBeta(item.OfFunctionCallOutput))
-			continue
+		case !param.IsOmitted(item.OfFunctionCall):
+			appendBetaMessage(&messages, convertResponsesFunctionCallToAnthropicBeta(item.OfFunctionCall))
+		case !param.IsOmitted(item.OfFunctionCallOutput):
+			appendBetaMessage(&messages, convertResponsesFunctionCallOutputToAnthropicBeta(item.OfFunctionCallOutput))
 		}
 	}
 
 	return messages
+}
+
+// appendBetaMessage merges consecutive same-role messages into one, so parallel
+// tool calls and their results each collapse into a single assistant/user message.
+func appendBetaMessage(messages *[]anthropic.BetaMessageParam, msg anthropic.BetaMessageParam) {
+	if n := len(*messages); n > 0 && (*messages)[n-1].Role == msg.Role {
+		(*messages)[n-1].Content = append((*messages)[n-1].Content, msg.Content...)
+		return
+	}
+	*messages = append(*messages, msg)
+}
+
+// dropEmptyTextBlocks removes empty text blocks, which carry no content.
+func dropEmptyTextBlocks(blocks []anthropic.BetaContentBlockParamUnion) []anthropic.BetaContentBlockParamUnion {
+	out := blocks[:0:0]
+	for _, b := range blocks {
+		if b.OfText != nil && b.OfText.Text == "" {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
 }
 
 // convertResponsesUserMessageToAnthropicBeta converts Responses API user message to Anthropic Beta format

--- a/internal/protocol/request/openai_responses_to_anthropic_test.go
+++ b/internal/protocol/request/openai_responses_to_anthropic_test.go
@@ -136,6 +136,118 @@ func TestConvertOpenAIResponsesToAnthropicBetaRequest_FunctionCall(t *testing.T)
 	}
 }
 
+func TestConvertOpenAIResponsesToAnthropicBetaRequest_ParallelToolCalls(t *testing.T) {
+	// Regression: codex re-sends parallel tool calls as consecutive function_call
+	// items followed by consecutive function_call_output items; they must fold
+	// into one assistant message and one user message so every tool_use is
+	// answered by its tool_result in the very next message. Before the fix the
+	// output was back-to-back assistant tool_use messages, rejected upstream.
+	params := responses.ResponseNewParams{
+		Model: "cc",
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: responses.ResponseInputParam{
+				{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role:    responses.EasyInputMessageRole("user"),
+						Content: responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt("do two things")},
+					},
+				},
+				{
+					OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+						CallID: "call_00_AAAA", Name: "exec", Arguments: `{"cmd":"echo hello"}`,
+					},
+				},
+				{
+					OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+						CallID: "call_00_BBBB", Name: "exec", Arguments: `{"cmd":"ls"}`,
+					},
+				},
+				{
+					OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+						CallID: "call_00_AAAA",
+						Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: param.NewOpt("hello")},
+					},
+				},
+				{
+					OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+						CallID: "call_00_BBBB",
+						Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: param.NewOpt("AGENTS.md\nCLAUDE.md")},
+					},
+				},
+			},
+		},
+	}
+
+	result := ConvertOpenAIResponsesToAnthropicBetaRequest(params, 4096)
+
+	// user, assistant[tool_use A, tool_use B], user[tool_result A, tool_result B]
+	if len(result.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(result.Messages))
+	}
+	assistant := result.Messages[1]
+	if string(assistant.Role) != "assistant" || len(assistant.Content) != 2 ||
+		assistant.Content[0].OfToolUse == nil || assistant.Content[1].OfToolUse == nil {
+		t.Fatalf("expected messages[1] to hold 2 tool_use blocks, got %v", assistant)
+	}
+	user := result.Messages[2]
+	if string(user.Role) != "user" || len(user.Content) != 2 ||
+		user.Content[0].OfToolResult == nil || user.Content[1].OfToolResult == nil {
+		t.Fatalf("expected messages[2] to hold 2 tool_result blocks, got %v", user)
+	}
+}
+
+func TestConvertOpenAIResponsesToAnthropicBetaRequest_SequentialToolCalls(t *testing.T) {
+	// Sequential calls (call → result, then call → result) must stay separate:
+	// each assistant tool_use message is followed by its own user tool_result.
+	params := responses.ResponseNewParams{
+		Model: "cc",
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: responses.ResponseInputParam{
+				{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role:    responses.EasyInputMessageRole("user"),
+						Content: responses.EasyInputMessageContentUnionParam{OfString: param.NewOpt("run tools one at a time")},
+					},
+				},
+				{
+					OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+						CallID: "call_00_AAAA", Name: "exec", Arguments: `{"cmd":"echo hello"}`,
+					},
+				},
+				{
+					OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+						CallID: "call_00_AAAA",
+						Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: param.NewOpt("hello")},
+					},
+				},
+				{
+					OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+						CallID: "call_00_BBBB", Name: "exec", Arguments: `{"cmd":"ls"}`,
+					},
+				},
+				{
+					OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+						CallID: "call_00_BBBB",
+						Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: param.NewOpt("AGENTS.md\nCLAUDE.md")},
+					},
+				},
+			},
+		},
+	}
+
+	result := ConvertOpenAIResponsesToAnthropicBetaRequest(params, 4096)
+
+	// user, assistant[tool_use A], user[tool_result A], assistant[tool_use B], user[tool_result B]
+	if len(result.Messages) != 5 {
+		t.Fatalf("expected 5 messages for sequential calls, got %d", len(result.Messages))
+	}
+	for _, i := range []int{1, 3} {
+		if string(result.Messages[i].Role) != "assistant" || len(result.Messages[i].Content) != 1 {
+			t.Fatalf("expected messages[%d] to be a single assistant tool_use, got %v", i, result.Messages[i])
+		}
+	}
+}
+
 func TestConvertResponsesToolChoiceToAnthropicBeta(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Responses API models a tool round-trip as consecutive function_call items followed by consecutive function_call_output items. The converter emitted each as its own message, so parallel tool calls produced back-to-back assistant tool_use messages lacking their tool_result in the next message. Anthropic requires every tool_use to be answered in the very next message, so strict Anthropic-compatible endpoints (e.g. DeepSeek) rejected the request. 

Fold consecutive function_call items into one assistant message and consecutive function_call_output items into one user message; drop codex blank message item for tool-only turns.