### PR TITLE
refactor: extract pkg/envsubst as shared ${VAR}/$VAR expansion primitive

### DIFF
--- a/internal/mcp/runtime/env_refs.go
+++ b/internal/mcp/runtime/env_refs.go
@@ -3,15 +3,12 @@ package runtime
 import (
 	"os"
 	"reflect"
-	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/tingly-dev/tingly-box/internal/typ"
+	"github.com/tingly-dev/tingly-box/pkg/envsubst"
 )
-
-var envRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
 // EnvRefIssue describes a missing environment reference in MCP runtime config.
 type EnvRefIssue struct {
@@ -151,37 +148,28 @@ func walkExpandValue(v reflect.Value, path, sourceID string, sourceEnv map[strin
 }
 
 func expandStringEnvRefs(input string, sourceEnv map[string]string, allowProcessEnv bool) (string, []string) {
-	if input == "" || !strings.Contains(input, "${") {
+	if input == "" || !strings.ContainsRune(input, '$') {
 		return input, nil
 	}
-	missing := make(map[string]struct{})
-	expanded := envRefPattern.ReplaceAllStringFunc(input, func(match string) string {
-		sub := envRefPattern.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		name := sub[1]
-		if val, ok := sourceEnv[name]; ok && val != "" {
-			// Avoid self-referential expansion loops like FOO=${FOO}.
-			if val != match {
-				return val
-			}
+	// Lookup closure preserving MCP's resolution order:
+	//  1. sourceEnv[name], when set, non-empty, and not a self-reference
+	//     (e.g. FOO=${FOO} would otherwise expand to itself);
+	//  2. the process environment, when allowProcessEnv;
+	//  3. otherwise unset — envsubst leaves the literal and reports it missing.
+	lookup := func(name string) (string, bool) {
+		if val, ok := sourceEnv[name]; ok && val != "" && !isSelfRef(val, name) {
+			return val, true
 		}
 		if allowProcessEnv {
-			if val, ok := os.LookupEnv(name); ok {
-				return val
-			}
+			return os.LookupEnv(name)
 		}
-		missing[name] = struct{}{}
-		return match
-	})
-	if len(missing) == 0 {
-		return expanded, nil
+		return "", false
 	}
-	out := make([]string, 0, len(missing))
-	for name := range missing {
-		out = append(out, name)
-	}
-	sort.Strings(out)
-	return expanded, out
+	return envsubst.Expand(input, lookup)
+}
+
+// isSelfRef reports whether val is a ${name}/$name reference to name itself
+// (e.g. name="FOO", val="${FOO}"), which must not be expanded to avoid a loop.
+func isSelfRef(val, name string) bool {
+	return val == "${"+name+"}" || val == "$"+name
 }

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -1,0 +1,132 @@
+// Package envsubst expands ${VAR} and $VAR references in strings against a
+// caller-supplied lookup. It mirrors the syntax of [os.Expand] (both braced
+// ${VAR} and bare $VAR forms, with VAR = [A-Za-z_][A-Za-z0-9_]*), but differs
+// from the standard library in two ways that callers in this repo rely on:
+//
+//   - An unset variable (lookup returns ok=false) is left as the literal
+//     reference (${"${VAR}"} or $VAR) rather than replaced with the empty
+//     string. This lets callers surface "VAR was not set" instead of silently
+//     substituting nothing.
+//   - Expand returns the sorted list of variable names that were unset, so the
+//     caller can report them. (os.Expand's mapper has no ok return and thus
+//     cannot distinguish "empty value" from "unset".)
+//
+// Use ExpandOS for the common case of resolving against [os.LookupEnv] with no
+// interest in the unset list.
+package envsubst
+
+import (
+	"os"
+	"sort"
+	"strings"
+)
+
+// Expand replaces ${VAR} and $VAR references in s using lookup to resolve each
+// name. A name that lookup reports as unset (ok=false) is left as the original
+// literal reference and is included in the returned missing slice (sorted,
+// de-duplicated). The expanded string and the missing list are returned.
+//
+// lookup mirrors os.LookupEnv's contract: returning (value, true) substitutes
+// value (which may itself be empty); returning (_, false) marks the name unset.
+func Expand(s string, lookup func(name string) (string, bool)) (string, []string) {
+	if !strings.ContainsRune(s, '$') {
+		return s, nil
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	missing := map[string]struct{}{}
+
+	for i := 0; i < len(s); {
+		if s[i] != '$' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		// s[i] == '$': try to read a reference starting here.
+		ref, name, rest := readRef(s, i)
+		if ref == "" {
+			// Not a reference (e.g. "$5", "$" at end-of-string, "${1abc}").
+			// Emit the '$' literally and continue from the next byte.
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		if v, ok := lookup(name); ok {
+			b.WriteString(v)
+		} else {
+			b.WriteString(ref) // leave literal
+			missing[name] = struct{}{}
+		}
+		i = rest
+	}
+
+	var miss []string
+	if len(missing) > 0 {
+		miss = make([]string, 0, len(missing))
+		for name := range missing {
+			miss = append(miss, name)
+		}
+		sort.Strings(miss)
+	}
+	return b.String(), miss
+}
+
+// ExpandOS is a convenience wrapper around Expand that resolves references
+// against the process environment ([os.LookupEnv]) and returns only the
+// expanded string. Unset variables are left as their literal reference.
+func ExpandOS(s string) string {
+	out, _ := Expand(s, os.LookupEnv)
+	return out
+}
+
+// readRef attempts to read a ${VAR} or $VAR reference beginning at s[i] (which
+// must be '$'). Returns:
+//   - ref:  the full original reference text (e.g. "${FOO}", "$FOO"), or "" if
+//           the bytes at s[i] are not a valid reference;
+//   - name: the extracted variable name (e.g. "FOO");
+//   - rest: the index just past the reference (where to continue scanning).
+//
+// VAR must match [A-Za-z_][A-Za-z0-9_]*. For the braced form the closing '}' is
+// required and the name must be non-empty; otherwise the '$' is treated as a
+// literal and readRef returns ("", "", i).
+func readRef(s string, i int) (ref, name string, rest int) {
+	// s[i] == '$'. Caller guarantees len(s) > i.
+	if i+1 >= len(s) {
+		return "", "", i + 1
+	}
+	if s[i+1] == '{' {
+		// Braced form: ${NAME}. NAME must start with a letter/underscore.
+		j := i + 2
+		start := j
+		if j >= len(s) || !isNameStart(s[j]) {
+			// "${" with no valid name start — not a reference.
+			return "", "", i + 1
+		}
+		for j < len(s) && isNameByte(s[j]) {
+			j++
+		}
+		if j >= len(s) || s[j] != '}' {
+			// No closing brace — not a reference.
+			return "", "", i + 1
+		}
+		return s[i : j+1], s[start:j], j + 1
+	}
+	// Bare form: $NAME
+	if !isNameStart(s[i+1]) {
+		return "", "", i + 1
+	}
+	j := i + 1
+	start := j
+	for j < len(s) && isNameByte(s[j]) {
+		j++
+	}
+	return s[i:j], s[start:j], j
+}
+
+func isNameStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isNameByte(c byte) bool {
+	return isNameStart(c) || (c >= '0' && c <= '9')
+}

--- a/pkg/envsubst/envsubst_test.go
+++ b/pkg/envsubst/envsubst_test.go
@@ -1,0 +1,113 @@
+package envsubst
+
+import (
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	// lookup that knows FOO and BAR, nothing else.
+	lookup := func(name string) (string, bool) {
+		switch name {
+		case "FOO":
+			return "foo-val", true
+		case "BAR":
+			return "bar-val", true
+		case "EMPTY":
+			return "", true // set, but empty
+		}
+		return "", false
+	}
+
+	cases := []struct {
+		name        string
+		in          string
+		want        string
+		wantMissing []string
+	}{
+		{"braced", "${FOO}", "foo-val", nil},
+		{"bare", "$FOO", "foo-val", nil},
+		{"embedded braced", "pre-${FOO}-post", "pre-foo-val-post", nil},
+		{"embedded bare", "x=$FOO end", "x=foo-val end", nil},
+		{"multiple", "${FOO}@$BAR", "foo-val@bar-val", nil},
+		{"adjacent", "${FOO}${BAR}", "foo-valbar-val", nil},
+		{"ref plus literal suffix (url style)", "${FOO}/v1/", "foo-val/v1/", nil},
+
+		// unset: leave literal + report missing
+		{"unset braced", "${NOPE}", "${NOPE}", []string{"NOPE"}},
+		{"unset bare", "$NOPE", "$NOPE", []string{"NOPE"}},
+		{"mixed set and unset", "${FOO}-${NOPE}", "foo-val-${NOPE}", []string{"NOPE"}},
+		{"two distinct unset", "${A}-${B}", "${A}-${B}", []string{"A", "B"}},
+		{"same unset twice deduped", "${A}-${A}", "${A}-${A}", []string{"A"}},
+
+		// set-but-empty is NOT unset: substitutes empty, not in missing
+		{"set empty substituted", "[${EMPTY}]", "[]", nil},
+
+		// non-references: '$' emitted literally
+		{"no dollar", "plain", "plain", nil},
+		{"dollar digit", "cost $5 and $10", "cost $5 and $10", nil},
+		{"bare dollar at end", "trailing$", "trailing$", nil},
+		{"bare dollar alone", "$", "$", nil},
+		{"braced invalid name", "${1abc}", "${1abc}", nil}, // name can't start with digit
+		{"braced no close", "${FOO", "${FOO", nil},
+		{"underscore name", "$_FOO_BAR", "$_FOO_BAR", []string{"_FOO_BAR"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, gotMissing := Expand(c.in, lookup)
+			if got != c.want {
+				t.Fatalf("Expand(%q) = %q, want %q", c.in, got, c.want)
+			}
+			if !eqSlice(gotMissing, c.wantMissing) {
+				t.Fatalf("missing: got %v, want %v", gotMissing, c.wantMissing)
+			}
+		})
+	}
+}
+
+func TestExpandNoDollarShortCircuits(t *testing.T) {
+	called := false
+	lookup := func(string) (string, bool) { called = true; return "", false }
+	got, missing := Expand("no refs here", lookup)
+	if got != "no refs here" {
+		t.Fatalf("got %q", got)
+	}
+	if missing != nil {
+		t.Fatalf("want nil missing, got %v", missing)
+	}
+	if called {
+		t.Fatal("lookup should not be called when string has no '$'")
+	}
+}
+
+func TestExpandOS(t *testing.T) {
+	t.Setenv("ENVSUBST_TEST_VAR", "os-val")
+	t.Setenv("ENVSUBST_TEST_EMPTY", "")
+
+	got := ExpandOS("${ENVSUBST_TEST_VAR}/$ENVSUBST_TEST_VAR")
+	want := "os-val/os-val"
+	if got != want {
+		t.Fatalf("ExpandOS = %q, want %q", got, want)
+	}
+
+	// set-but-empty substitutes empty.
+	if got, want := ExpandOS("[${ENVSUBST_TEST_EMPTY}]"), "[]"; got != want {
+		t.Fatalf("empty var: got %q want %q", got, want)
+	}
+
+	// unset left literal (no panic, no empty substitution).
+	if got, want := ExpandOS("${ENVSUBST_TEST_UNSET}"), "${ENVSUBST_TEST_UNSET}"; got != want {
+		t.Fatalf("unset: got %q want %q", got, want)
+	}
+}
+
+func eqSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

The `${VAR}`/`$VAR` reference-expansion logic existed in two near-duplicate implementations — `internal/protocoltest` and `internal/mcp/runtime` — both carrying the same regex loop plus sorted-missing collection. This extracts one source of truth in `pkg/envsubst` and migrates the MCP runtime path onto it, so the syntax lives in exactly one place.

## Key Changes

- **Shared `pkg/envsubst.Expand` primitive**: Mirrors `os.Expand` syntax (braced `${VAR}` and bare `$VAR`), but unlike the standard library it (a) leaves an unset variable as the literal reference rather than substituting `""`, and (b) returns the sorted, de-duplicated list of unset names so callers can report them. Both behaviors are what the existing call sites depend on.
- **MCP runtime migrated**: `expandStringEnvRefs` becomes a thin wrapper over `envsubst.Expand` with a lookup closure that preserves MCP's exact resolution order (source-local env first, then process env when allowed). Drops the package-local regex and `regexp`/`sort` imports.

## Notes

- **Behavior change (intentional, low risk)**: MCP source string fields now also expand bare `$VAR`, not just `${VAR}`. `${VAR}` was always the documented form, the self-referential guard (`FOO=${FOO}`) is preserved, and nothing in the env_refs tests asserted braced-only matching — but flag it if any MCP source relied on literal `$`-prefixed tokens.