### PR TITLE
bugfix: ReferenceError - settingsPath is not defined in Claude code config generator (Windows + Unix)

### DIFF
--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -90,7 +90,7 @@ if (fs.existsSync(targetPath)) {
     try { existing = JSON.parse(content); } catch (e) {}
 }
 
-const merged = settingsPath.includes("settings.json")
+const merged = targetPath.includes("settings.json")
     ? { ...existing, ...config }
     : { ...existing, ...config };
 


### PR DESCRIPTION
## What

`generateNodeScript()` in `ClaudeCodeConfigModal.tsx` references an undefined variable `settingsPath` in the merge branch. Because that function is shared, this breaks **every** generated setup script — the Windows (PowerShell) tab and the Unix (Linux/macOS) tab, for both `settings.json` and `.claude.json` — with a `ReferenceError` at line 41 and nothing being written.

```ts
// Before
const merged = settingsPath.includes("settings.json")   // undefined -> ReferenceError
    ? { ...existing, ...config }
    : { ...existing, ...config };

// After
const merged = targetPath.includes("settings.json")     // correct variable
    ? { ...existing, ...config }
    : { ...existing, ...config };
```

## Why
The generator already resolves the real path into a local `targetPath` (`path.join(homeDir, settingsPath)`); the merge guard just used the wrong identifier. `settingsPath` does not exist in that scope. The two branches are identical, so `targetPath.includes(...)` preserves behavior while being correct.

## Verification
Confirmed by running the generated script with real Node.js v20 on Linux:
- **Before**: `ReferenceError: settingsPath is not defined`, exit 1.
- **After**: writes and merges into `~/.claude/settings.json` (`{...existing, ...config}` keeps old keys, overrides new ones), exit 0.

Also verified on Windows: the PowerShell variant no longer crashes and writes the config.

## Test
- Manual tab → Windows tab (settings.json and .claude.json) → run in PowerShell → no ReferenceError; config merged and written.
- Manual tab → Linux/macOS tab → run the generated `node -e '...'` script in bash → no ReferenceError; config merged and written.
- JSON template tabs unchanged.

Fixes #1509