### PR TITLE
fix(mcpserver): emit one message envelope across a multi-round tool loop

### DIFF
--- a/internal/mcpserver/anthropic_beta_adapter.go
+++ b/internal/mcpserver/anthropic_beta_adapter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
 
-	"github.com/tingly-dev/tingly-box/internal/mcp/runtime"
 	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 )
 
@@ -47,20 +46,12 @@ func (a *AnthropicBetaAdapter) ExtractTools(response any) ([]Tool, error) {
 	return tools, nil
 }
 
+// IsVirtualTool delegates to the package-level classifier so every adapter
+// answers the same question the same way. It used to be copied per adapter,
+// which meant a new class of server-executed tool had to be remembered in
+// four places.
 func (a *AnthropicBetaAdapter) IsVirtualTool(tool Tool, registry *coretool.VirtualToolRegistry) bool {
-	sourceID, toolName, ok := runtime.ParseNormalizedToolName(tool.Name())
-	if !ok {
-		return false
-	}
-	if sourceID == "advisor" || (sourceID == "builtin" && toolName == "advisor") {
-		return true
-	}
-	if registry == nil {
-		return false
-	}
-
-	_, exists := registry.Get(toolName)
-	return exists
+	return IsVirtualTool(tool.Name(), registry)
 }
 
 func (a *AnthropicBetaAdapter) SplitVirtualExternal(

--- a/internal/mcpserver/anthropic_v1_adapter.go
+++ b/internal/mcpserver/anthropic_v1_adapter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
 
-	"github.com/tingly-dev/tingly-box/internal/mcp/runtime"
 	coretool "github.com/tingly-dev/tingly-box/internal/tool"
 )
 
@@ -47,20 +46,12 @@ func (a *AnthropicV1Adapter) ExtractTools(response any) ([]Tool, error) {
 	return tools, nil
 }
 
+// IsVirtualTool delegates to the package-level classifier so every adapter
+// answers the same question the same way. It used to be copied per adapter,
+// which meant a new class of server-executed tool had to be remembered in
+// four places.
 func (a *AnthropicV1Adapter) IsVirtualTool(tool Tool, registry *coretool.VirtualToolRegistry) bool {
-	sourceID, toolName, ok := runtime.ParseNormalizedToolName(tool.Name())
-	if !ok {
-		return false
-	}
-	if sourceID == "advisor" || (sourceID == "builtin" && toolName == "advisor") {
-		return true
-	}
-	if registry == nil {
-		return false
-	}
-
-	_, exists := registry.Get(toolName)
-	return exists
+	return IsVirtualTool(tool.Name(), registry)
 }
 
 func (a *AnthropicV1Adapter) SplitVirtualExternal(

--- a/internal/mcpserver/generic_stream_interceptor.go
+++ b/internal/mcpserver/generic_stream_interceptor.go
@@ -41,6 +41,13 @@ type GenericStreamInterceptor struct {
 	totalOutputTokens int64
 	totalCacheTokens  int64
 
+	// sentMessageStart records that the client has already been given the
+	// message envelope. The loop may run several upstream rounds, but the
+	// client asked for ONE completion — that a tool round happened inside is
+	// exactly what the loop exists to hide. Every round after the first
+	// therefore drops its own message_start.
+	sentMessageStart bool
+
 	// Mutable request for multi-round loop
 	currentReq any
 
@@ -418,6 +425,11 @@ func (i *GenericStreamInterceptor) routeEvent(event any, eventType EventType) er
 	case EventText:
 		if isAnthropicMessageStartEvent(event) {
 			i.seenMessageStart = true
+			// One envelope per client request; see sentMessageStart.
+			if i.sentMessageStart {
+				return nil
+			}
+			i.sentMessageStart = true
 		}
 		if isAnthropicContentBlockStartEvent(event) {
 			i.seenContentBlockStart = true
@@ -803,52 +815,48 @@ func extractContentBlockIndex(event any) (int, bool) {
 	}
 }
 
-func isAnthropicMessageStartEvent(event any) bool {
+// The three predicates below must recognise BOTH Anthropic stream unions.
+//
+// They used to match only the Beta union, which made every one of them return
+// false on the v1 path — so the interceptor's envelope bookkeeping
+// (seenMessageStart, seenContentBlockStart/Stop, and the duplicate-envelope
+// suppression built on them) was silently inert for v1 targets, and the
+// truncation check in consumeRound could never fire there either. Nothing
+// failed loudly; the client just received a second message_start.
+//
+// anthropicEventKind normalises an event of either union to its wire type
+// name, so a single string comparison covers both.
+func anthropicEventKind(event any) string {
 	switch e := event.(type) {
+	case anthropic.MessageStreamEventUnion:
+		return e.Type
+	case *anthropic.MessageStreamEventUnion:
+		if e == nil {
+			return ""
+		}
+		return e.Type
 	case anthropic.BetaRawMessageStreamEventUnion:
-		_, ok := e.AsAny().(anthropic.BetaRawMessageStartEvent)
-		return ok
+		return e.Type
 	case *anthropic.BetaRawMessageStreamEventUnion:
 		if e == nil {
-			return false
+			return ""
 		}
-		_, ok := e.AsAny().(anthropic.BetaRawMessageStartEvent)
-		return ok
+		return e.Type
 	default:
-		return false
+		return ""
 	}
+}
+
+func isAnthropicMessageStartEvent(event any) bool {
+	return anthropicEventKind(event) == "message_start"
 }
 
 func isAnthropicContentBlockStartEvent(event any) bool {
-	switch e := event.(type) {
-	case anthropic.BetaRawMessageStreamEventUnion:
-		_, ok := e.AsAny().(anthropic.BetaRawContentBlockStartEvent)
-		return ok
-	case *anthropic.BetaRawMessageStreamEventUnion:
-		if e == nil {
-			return false
-		}
-		_, ok := e.AsAny().(anthropic.BetaRawContentBlockStartEvent)
-		return ok
-	default:
-		return false
-	}
+	return anthropicEventKind(event) == "content_block_start"
 }
 
 func isAnthropicContentBlockStopEvent(event any) bool {
-	switch e := event.(type) {
-	case anthropic.BetaRawMessageStreamEventUnion:
-		_, ok := e.AsAny().(anthropic.BetaRawContentBlockStopEvent)
-		return ok
-	case *anthropic.BetaRawMessageStreamEventUnion:
-		if e == nil {
-			return false
-		}
-		_, ok := e.AsAny().(anthropic.BetaRawContentBlockStopEvent)
-		return ok
-	default:
-		return false
-	}
+	return anthropicEventKind(event) == "content_block_stop"
 }
 
 func extractAnthropicStopReason(event any) string {

--- a/internal/mcpserver/openai_chat_adapter.go
+++ b/internal/mcpserver/openai_chat_adapter.go
@@ -47,20 +47,12 @@ func (o *OpenAIChatAdapter) ExtractTools(response any) ([]Tool, error) {
 	return tools, nil
 }
 
+// IsVirtualTool delegates to the package-level classifier so every adapter
+// answers the same question the same way. It used to be copied per adapter,
+// which meant a new class of server-executed tool had to be remembered in
+// four places.
 func (o *OpenAIChatAdapter) IsVirtualTool(tool Tool, registry *coretool.VirtualToolRegistry) bool {
-	sourceID, toolName, ok := runtime.ParseNormalizedToolName(tool.Name())
-	if !ok {
-		return false
-	}
-	if sourceID == "advisor" || (sourceID == "builtin" && toolName == "advisor") {
-		return true
-	}
-	if registry == nil {
-		return false
-	}
-
-	_, exists := registry.Get(toolName)
-	return exists
+	return IsVirtualTool(tool.Name(), registry)
 }
 
 func (o *OpenAIChatAdapter) SplitVirtualExternal(

--- a/internal/mcpserver/stream_rounds_test.go
+++ b/internal/mcpserver/stream_rounds_test.go
@@ -1,0 +1,341 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/gin-gonic/gin"
+
+	coretool "github.com/tingly-dev/tingly-box/internal/tool"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+//
+// A two-round Anthropic stream: the model asks for a server-executed tool,
+// the interceptor answers it in-process, and the model then produces text.
+// That is the shape of every tool-loop round trip, so the client-visible event
+// sequence it yields is the contract worth pinning.
+
+// A server-executed tool name. advisor is the built-in one every classifier
+// already recognises, so the harness needs no registry setup.
+const roundsToolName = "tingly_box_mcp__advisor__advisor"
+
+func anthropicEvents(t *testing.T, raws ...string) []anthropic.BetaRawMessageStreamEventUnion {
+	t.Helper()
+	out := make([]anthropic.BetaRawMessageStreamEventUnion, 0, len(raws))
+	for _, raw := range raws {
+		var e anthropic.BetaRawMessageStreamEventUnion
+		if err := json.Unmarshal([]byte(raw), &e); err != nil {
+			t.Fatalf("unmarshal event %s: %v", raw, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func toolRoundEvents(t *testing.T) []anthropic.BetaRawMessageStreamEventUnion {
+	return anthropicEvents(t,
+		`{"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"downstream","stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"`+roundsToolName+`","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"go\"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	)
+}
+
+func textRoundEvents(t *testing.T) []anthropic.BetaRawMessageStreamEventUnion {
+	return anthropicEvents(t,
+		`{"type":"message_start","message":{"id":"m2","type":"message","role":"assistant","content":[],"model":"downstream","stop_reason":null,"usage":{"input_tokens":20,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done."}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`,
+		`{"type":"message_stop"}`,
+	)
+}
+
+// ── Doubles ─────────────────────────────────────────────────────────────────
+
+type sliceStream struct {
+	events []anthropic.BetaRawMessageStreamEventUnion
+	idx    int
+}
+
+func (s *sliceStream) Next() bool    { s.idx++; return s.idx <= len(s.events) }
+func (s *sliceStream) Current() any  { return s.events[s.idx-1] }
+func (s *sliceStream) Err() error    { return nil }
+func (s *sliceStream) Close() error  { return nil }
+
+type roundsForwarder struct {
+	rounds [][]anthropic.BetaRawMessageStreamEventUnion
+	calls  int
+}
+
+func (f *roundsForwarder) ForwardStream(_ context.Context, _ any, _ string, _ any) (StreamHandle, error) {
+	events := f.rounds[min(f.calls, len(f.rounds)-1)]
+	f.calls++
+	return &sliceStream{events: events}, nil
+}
+
+func (f *roundsForwarder) ForwardNonStream(context.Context, any, string, any) (any, error) {
+	return nil, nil
+}
+
+// noopServerOps satisfies the usage-reporting dependency; the interceptor
+// dereferences it unconditionally at the end of Run.
+type noopServerOps struct{}
+
+func (noopServerOps) TrackUsage(*gin.Context, int, int, int) {}
+func (noopServerOps) CallMCPTool(context.Context, string, string, []map[string]any) (string, error) {
+	return "", nil
+}
+func (noopServerOps) GetRecorder() ProtocolRecorder { return nil }
+
+type cannedExecutor struct{ text string }
+
+func (e cannedExecutor) ExecuteToolWithContext(ctx context.Context, tool Tool, _ []map[string]any) (context.Context, ToolExecutionResult, error) {
+	return ctx, ToolExecutionResult{ToolUseID: tool.ID(), Contents: coretool.TextToolResult(e.text).Contents}, nil
+}
+func (e cannedExecutor) ExecuteTool(ctx context.Context, tool Tool, m []map[string]any) (ToolExecutionResult, error) {
+	_, r, err := e.ExecuteToolWithContext(ctx, tool, m)
+	return r, err
+}
+func (e cannedExecutor) ExecuteTools(ctx context.Context, tools []Tool, m []map[string]any) ([]ToolExecutionResult, error) {
+	out := make([]ToolExecutionResult, 0, len(tools))
+	for _, tool := range tools {
+		r, _ := e.ExecuteTool(ctx, tool, m)
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// sseEventNames returns the `event:` names in order, as a client would read them.
+func sseEventNames(body string) []string {
+	var names []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "event: ") {
+			names = append(names, strings.TrimPrefix(line, "event: "))
+		}
+	}
+	return names
+}
+
+func countName(names []string, want string) int {
+	n := 0
+	for _, name := range names {
+		if name == want {
+			n++
+		}
+	}
+	return n
+}
+
+func runTwoRoundStream(t *testing.T) string {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	interceptor := NewGenericStreamInterceptor(
+		c, noopServerOps{}, &typ.Provider{UUID: "p"}, nil, coretool.NewVirtualToolRegistry(), nil,
+		NewAnthropicBetaAdapter(),
+		&roundsForwarder{rounds: [][]anthropic.BetaRawMessageStreamEventUnion{
+			toolRoundEvents(t), textRoundEvents(t),
+		}},
+		cannedExecutor{text: "tool output"},
+		InterceptorConfig{MaxRounds: 3},
+	)
+	if err := interceptor.Run(&anthropic.BetaMessageNewParams{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return rec.Body.String()
+}
+
+// A multi-round loop must still produce ONE well-formed message. The client
+// asked for a single completion; that a tool round happened inside is exactly
+// what the loop is supposed to hide.
+func TestStreamInterceptor_MultiRoundEmitsOneMessageEnvelope(t *testing.T) {
+	body := runTwoRoundStream(t)
+	names := sseEventNames(body)
+
+	if got := countName(names, "message_start"); got != 1 {
+		t.Errorf("message_start emitted %d times, want 1 — a second envelope makes the stream malformed; events=%v", got, names)
+	}
+	if got := countName(names, "message_stop"); got != 1 {
+		t.Errorf("message_stop emitted %d times, want 1; events=%v", got, names)
+	}
+	if got := countName(names, "message_delta"); got != 1 {
+		t.Errorf("message_delta emitted %d times, want 1; events=%v", got, names)
+	}
+	if names[0] != "message_start" {
+		t.Errorf("stream must open with message_start, got %q; events=%v", names[0], names)
+	}
+	if names[len(names)-1] != "message_stop" {
+		t.Errorf("stream must close with message_stop, got %q; events=%v", names[len(names)-1], names)
+	}
+}
+
+// The terminal stop_reason must describe how the message actually ended, not
+// how an intermediate tool round ended. A client that reads "tool_use" looks
+// for a tool_use block it will never find — the loop consumed it.
+func TestStreamInterceptor_FinalStopReasonComesFromTheLastRound(t *testing.T) {
+	body := runTwoRoundStream(t)
+
+	if strings.Contains(body, `"stop_reason":"tool_use"`) {
+		t.Errorf("terminal stop_reason leaked the tool round's value; body=%s", body)
+	}
+	if !strings.Contains(body, `"stop_reason":"end_turn"`) {
+		t.Errorf("terminal stop_reason should be the final round's end_turn; body=%s", body)
+	}
+}
+
+// The tool call itself must never reach the client.
+func TestStreamInterceptor_VirtualToolCallIsNotVisibleToTheClient(t *testing.T) {
+	body := runTwoRoundStream(t)
+	if strings.Contains(body, roundsToolName) {
+		t.Errorf("server-executed tool call leaked to the client; body=%s", body)
+	}
+	if !strings.Contains(body, "Done.") {
+		t.Errorf("final answer missing; body=%s", body)
+	}
+}
+
+// The real-world variant that first surfaced this: some upstreams (the
+// in-process vmodel among them) close a round without a stop_reason. The
+// terminal event must still not describe the tool round — the client would
+// look for a tool_use block the loop already consumed.
+func TestStreamInterceptor_FinalRoundWithoutStopReasonDoesNotReuseTheToolRound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	textNoStopReason := anthropicEvents(t,
+		`{"type":"message_start","message":{"id":"m2","type":"message","role":"assistant","content":[],"model":"downstream","stop_reason":null,"usage":{"input_tokens":20,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done."}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":null,"stop_sequence":null},"usage":{"output_tokens":7}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	interceptor := NewGenericStreamInterceptor(
+		c, noopServerOps{}, &typ.Provider{UUID: "p"}, nil, coretool.NewVirtualToolRegistry(), nil,
+		NewAnthropicBetaAdapter(),
+		&roundsForwarder{rounds: [][]anthropic.BetaRawMessageStreamEventUnion{
+			toolRoundEvents(t), textNoStopReason,
+		}},
+		cannedExecutor{text: "tool output"},
+		InterceptorConfig{MaxRounds: 3},
+	)
+	if err := interceptor.Run(&anthropic.BetaMessageNewParams{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body := rec.Body.String()
+
+	if strings.Contains(body, `"stop_reason":"tool_use"`) {
+		t.Errorf("terminal stop_reason reused the tool round's value; body=%s", body)
+	}
+	names := sseEventNames(body)
+	if got := countName(names, "message_start"); got != 1 {
+		t.Errorf("message_start emitted %d times, want 1; events=%v", got, names)
+	}
+	if names[len(names)-1] != "message_stop" {
+		t.Errorf("stream must close with message_stop; events=%v", names)
+	}
+}
+
+// The same contract on the v1 union. Both are live: which one a request gets
+// depends on the target the rule resolves to, and the interceptor's envelope
+// bookkeeping used to recognise only the Beta shape — so v1 clients received a
+// second message_start while every Beta-based test stayed green.
+func TestStreamInterceptor_V1UnionAlsoEmitsOneMessageEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	v1Events := func(raws ...string) []anthropic.MessageStreamEventUnion {
+		out := make([]anthropic.MessageStreamEventUnion, 0, len(raws))
+		for _, raw := range raws {
+			var e anthropic.MessageStreamEventUnion
+			if err := json.Unmarshal([]byte(raw), &e); err != nil {
+				t.Fatalf("unmarshal %s: %v", raw, err)
+			}
+			out = append(out, e)
+		}
+		return out
+	}
+
+	toolRound := v1Events(
+		`{"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"downstream","stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"`+roundsToolName+`","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"go\"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	)
+	textRound := v1Events(
+		`{"type":"message_start","message":{"id":"m2","type":"message","role":"assistant","content":[],"model":"downstream","stop_reason":null,"usage":{"input_tokens":20,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done."}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	interceptor := NewGenericStreamInterceptor(
+		c, noopServerOps{}, &typ.Provider{UUID: "p"}, nil, coretool.NewVirtualToolRegistry(), nil,
+		NewAnthropicV1Adapter(),
+		&v1RoundsForwarder{rounds: [][]anthropic.MessageStreamEventUnion{toolRound, textRound}},
+		cannedExecutor{text: "tool output"},
+		InterceptorConfig{MaxRounds: 3},
+	)
+	if err := interceptor.Run(&anthropic.MessageNewParams{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body := rec.Body.String()
+	names := sseEventNames(body)
+	if got := countName(names, "message_start"); got != 1 {
+		t.Errorf("message_start emitted %d times, want 1; events=%v", got, names)
+	}
+	if strings.Contains(body, roundsToolName) {
+		t.Errorf("server-executed tool call leaked to the client; body=%s", body)
+	}
+	if strings.Contains(body, `"stop_reason":"tool_use"`) {
+		t.Errorf("terminal stop_reason leaked the tool round's value; body=%s", body)
+	}
+}
+
+type v1SliceStream struct {
+	events []anthropic.MessageStreamEventUnion
+	idx    int
+}
+
+func (s *v1SliceStream) Next() bool   { s.idx++; return s.idx <= len(s.events) }
+func (s *v1SliceStream) Current() any { return s.events[s.idx-1] }
+func (s *v1SliceStream) Err() error   { return nil }
+func (s *v1SliceStream) Close() error { return nil }
+
+type v1RoundsForwarder struct {
+	rounds [][]anthropic.MessageStreamEventUnion
+	calls  int
+}
+
+func (f *v1RoundsForwarder) ForwardStream(context.Context, any, string, any) (StreamHandle, error) {
+	events := f.rounds[min(f.calls, len(f.rounds)-1)]
+	f.calls++
+	return &v1SliceStream{events: events}, nil
+}
+
+func (f *v1RoundsForwarder) ForwardNonStream(context.Context, any, string, any) (any, error) {
+	return nil, nil
+}


### PR DESCRIPTION
A multi-round server-side tool loop sends the client a **second `message_start`**. The loop runs several upstream rounds, but the client asked for one completion — hiding the tool round is the whole point — and two envelopes make the stream malformed for any strict Anthropic consumer.

This affects the MCP tool loop as it ships today (advisor and any virtual tool). It was found while building an unrelated feature on top of the same loop, and is split out here so it can be reviewed on its own.

## Root cause

Narrower than the symptom suggests. `isAnthropicMessageStartEvent` and its `content_block_start` / `content_block_stop` siblings matched **only the Beta stream union**:

```go
case anthropic.BetaRawMessageStreamEventUnion: ...
case *anthropic.BetaRawMessageStreamEventUnion: ...
default: return false
```

On a **v1** target every one of them returns `false`, so the interceptor's whole envelope bookkeeping (`seenMessageStart`, `seenContentBlockStart/Stop`) was silently inert there — including the truncation check in `consumeRound`, which could never fire on v1. Nothing failed loudly; the client just got an extra `message_start`.

The predicates now compare the wire type name, which covers both unions, and a cross-round `sentMessageStart` drops every envelope after the first.

## Also in here

The three format adapters each carried **their own copy** of `IsVirtualTool`, identical to the package-level one — four copies of the same logic, so any new class of server-executed tool has to be remembered in four places. They now delegate to the shared classifier. (This is how the bug above was first noticed: a change to the shared function had no effect.)

## Verification

New two-round interceptor harness (`stream_rounds_test.go`): tool round → in-process execution → text round, asserting the **client-visible SSE sequence** on **both unions** — one envelope, no leaked tool call, terminal `stop_reason` from the last round.

The both-unions part is the point: a Beta-only test passes against the broken code, which is exactly how this survived.

```
go build ./... && go test ./internal/...   # green
```

## Reviewer notes

- No behavior change when the loop runs a single round — the suppression only engages from the second round on.
- `stream_rounds_test.go` uses the built-in `advisor` tool name, so it needs no registry setup.
- Known, **not** addressed here: in an end-to-end run the terminal `stop_reason` can still report the tool round's `tool_use`. That reproduces on **both** streaming and non-streaming, so it is not this interceptor — it sits further down, in the loop's response assembly or the v1 conversion. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puminmg5qPmsaDvrsXxMdG